### PR TITLE
feat: implement EventSource (Server-Sent Events) API

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -937,8 +937,8 @@ JSC_DEFINE_CUSTOM_SETTER(EventSource_setter,
     JSValue value = JSValue::decode(encodedValue);
     auto* globalObject = jsCast<Zig::GlobalObject*>(lexicalGlobalObject);
 
-    // Replace the accessor with a plain data property
-    globalObject->putDirect(vm, Identifier::fromString(vm, "EventSource"_s), value, 0);
+    // Replace the accessor with a plain data property, preserving DontEnum
+    globalObject->putDirect(vm, Identifier::fromString(vm, "EventSource"_s), value, static_cast<unsigned>(PropertyAttribute::DontEnum));
     return true;
 }
 

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -928,6 +928,20 @@ JSC_DEFINE_CUSTOM_GETTER(EventSource_getter,
     return JSC::JSValue::encode(globalObject->m_eventSourceConstructor.get(globalObject));
 }
 
+// EventSource constructor setter - allows globalThis.EventSource to be reassigned
+JSC_DEFINE_CUSTOM_SETTER(EventSource_setter,
+    (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue,
+        JSC::EncodedJSValue encodedValue, JSC::PropertyName property))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    JSValue value = JSValue::decode(encodedValue);
+    auto* globalObject = jsCast<Zig::GlobalObject*>(lexicalGlobalObject);
+
+    // Replace the accessor with a plain data property
+    globalObject->putDirect(vm, Identifier::fromString(vm, "EventSource"_s), value, 0);
+    return true;
+}
+
 JSC_DEFINE_CUSTOM_GETTER(globalOnMessage,
     (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue,
         JSC::PropertyName))
@@ -2816,8 +2830,8 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "onmessage"_s), JSC::CustomGetterSetter::create(vm, globalOnMessage, setGlobalOnMessage), 0);
     putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "onerror"_s), JSC::CustomGetterSetter::create(vm, globalOnError, setGlobalOnError), 0);
 
-    // EventSource - loaded from undici module lazily
-    putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "EventSource"_s), JSC::CustomGetterSetter::create(vm, EventSource_getter, nullptr), PropertyAttribute::DontEnum | PropertyAttribute::CustomValue);
+    // EventSource - loaded from undici module lazily, can be reassigned
+    putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "EventSource"_s), JSC::CustomGetterSetter::create(vm, EventSource_getter, EventSource_setter), PropertyAttribute::DontEnum | PropertyAttribute::CustomValue);
 
     // ----- Extensions to Built-in objects -----
 

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2336,8 +2336,8 @@ void GlobalObject::finishCreation(VM& vm)
             }
         }
 
-        // Fallback: create a function that throws when called
-        init.set(JSC::JSFunction::create(vm, globalObject, 0, "EventSource"_s, eventSourceNotAvailable, ImplementationVisibility::Public));
+        // Fallback: create a function that throws when called (length 1 per Web API spec)
+        init.set(JSC::JSFunction::create(vm, globalObject, 1, "EventSource"_s, eventSourceNotAvailable, ImplementationVisibility::Public));
     });
 
     m_JSFileSinkClassStructure.initLater(

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -635,8 +635,8 @@ public:
     V(public, LazyPropertyOfGlobalObject<Symbol>, m_nodeVMDontContextify)                                    \
     V(public, LazyPropertyOfGlobalObject<Symbol>, m_nodeVMUseMainContextDefaultLoader)                       \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcSerializeFunction)                                \
-    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcParseHandleFunction)                             \
-    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_eventSourceConstructor)    /* EventSource from undici module */
+    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcParseHandleFunction)                              \
+    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_eventSourceConstructor) /* EventSource from undici module */
 
 #define DECLARE_GLOBALOBJECT_GC_MEMBER(visibility, T, name) \
     visibility:                                             \

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -636,7 +636,7 @@ public:
     V(public, LazyPropertyOfGlobalObject<Symbol>, m_nodeVMUseMainContextDefaultLoader)                       \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcSerializeFunction)                                \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcParseHandleFunction)                             \
-    V(public, LazyPropertyOfGlobalObject<JSObject>, m_eventSourceConstructor)    /* EventSource from undici module */
+    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_eventSourceConstructor)    /* EventSource from undici module */
 
 #define DECLARE_GLOBALOBJECT_GC_MEMBER(visibility, T, name) \
     visibility:                                             \

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -635,7 +635,8 @@ public:
     V(public, LazyPropertyOfGlobalObject<Symbol>, m_nodeVMDontContextify)                                    \
     V(public, LazyPropertyOfGlobalObject<Symbol>, m_nodeVMUseMainContextDefaultLoader)                       \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcSerializeFunction)                                \
-    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcParseHandleFunction)
+    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcParseHandleFunction)                             \
+    V(public, LazyPropertyOfGlobalObject<JSObject>, m_eventSourceConstructor)    /* EventSource from undici module */
 
 #define DECLARE_GLOBALOBJECT_GC_MEMBER(visibility, T, name) \
     visibility:                                             \

--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -435,12 +435,17 @@ class EventSource extends EventTarget {
   }
 
   set onopen(value) {
-    if (this.#onopen) {
-      this.removeEventListener("open", this.#onopen);
+    const oldHandler = this.#onopen;
+    // Only store functions, treat non-callables as null
+    const newHandler = typeof value === "function" ? value : null;
+    this.#onopen = newHandler;
+    // Remove old handler if it was a function
+    if (typeof oldHandler === "function") {
+      this.removeEventListener("open", oldHandler);
     }
-    this.#onopen = value;
-    if (value) {
-      this.addEventListener("open", value);
+    // Add new handler if it's a function
+    if (typeof newHandler === "function") {
+      this.addEventListener("open", newHandler);
     }
   }
 
@@ -449,12 +454,17 @@ class EventSource extends EventTarget {
   }
 
   set onmessage(value) {
-    if (this.#onmessage) {
-      this.removeEventListener("message", this.#onmessage);
+    const oldHandler = this.#onmessage;
+    // Only store functions, treat non-callables as null
+    const newHandler = typeof value === "function" ? value : null;
+    this.#onmessage = newHandler;
+    // Remove old handler if it was a function
+    if (typeof oldHandler === "function") {
+      this.removeEventListener("message", oldHandler);
     }
-    this.#onmessage = value;
-    if (value) {
-      this.addEventListener("message", value);
+    // Add new handler if it's a function
+    if (typeof newHandler === "function") {
+      this.addEventListener("message", newHandler);
     }
   }
 
@@ -463,12 +473,17 @@ class EventSource extends EventTarget {
   }
 
   set onerror(value) {
-    if (this.#onerror) {
-      this.removeEventListener("error", this.#onerror);
+    const oldHandler = this.#onerror;
+    // Only store functions, treat non-callables as null
+    const newHandler = typeof value === "function" ? value : null;
+    this.#onerror = newHandler;
+    // Remove old handler if it was a function
+    if (typeof oldHandler === "function") {
+      this.removeEventListener("error", oldHandler);
     }
-    this.#onerror = value;
-    if (value) {
-      this.addEventListener("error", value);
+    // Add new handler if it's a function
+    if (typeof newHandler === "function") {
+      this.addEventListener("error", newHandler);
     }
   }
 

--- a/test/regression/issue/3319.test.ts
+++ b/test/regression/issue/3319.test.ts
@@ -49,279 +49,243 @@ describe("EventSource", () => {
       es.close();
     });
 
-    it(
-      "should transition to OPEN state when connected",
-      async () => {
-        using server = Bun.serve({
-          port: 0,
-          fetch() {
-            return new Response(
-              new ReadableStream({
-                start(controller) {
-                  controller.enqueue(new TextEncoder().encode("data: test\n\n"));
-                },
-              }),
-              { headers: { "Content-Type": "text/event-stream" } },
-            );
-          },
-        });
+    it("should transition to OPEN state when connected", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode("data: test\n\n"));
+              },
+            }),
+            { headers: { "Content-Type": "text/event-stream" } },
+          );
+        },
+      });
 
-        const es = new EventSource(`http://localhost:${server.port}`);
-        const { promise, resolve, reject } = Promise.withResolvers<void>();
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
 
-        es.onopen = () => {
-          expect(es.readyState).toBe(EventSource.OPEN);
-          es.close();
-          resolve();
-        };
+      es.onopen = () => {
+        expect(es.readyState).toBe(EventSource.OPEN);
+        es.close();
+        resolve();
+      };
 
-        es.onerror = () => {
-          es.close();
-          reject(new Error("Connection error"));
-        };
+      es.onerror = () => {
+        es.close();
+        reject(new Error("Connection error"));
+      };
 
-        await promise;
-      },
-      { timeout: 5000 },
-    );
+      await promise;
+    });
 
-    it(
-      "should transition to CLOSED state when close() is called",
-      async () => {
-        using server = Bun.serve({
-          port: 0,
-          fetch() {
-            return new Response(
-              new ReadableStream({
-                start(controller) {
-                  controller.enqueue(new TextEncoder().encode("data: test\n\n"));
-                },
-              }),
-              { headers: { "Content-Type": "text/event-stream" } },
-            );
-          },
-        });
+    it("should transition to CLOSED state when close() is called", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode("data: test\n\n"));
+              },
+            }),
+            { headers: { "Content-Type": "text/event-stream" } },
+          );
+        },
+      });
 
-        const es = new EventSource(`http://localhost:${server.port}`);
-        const { promise, resolve, reject } = Promise.withResolvers<void>();
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
 
-        es.onopen = () => {
-          es.close();
-          expect(es.readyState).toBe(EventSource.CLOSED);
-          resolve();
-        };
+      es.onopen = () => {
+        es.close();
+        expect(es.readyState).toBe(EventSource.CLOSED);
+        resolve();
+      };
 
-        es.onerror = () => {
-          es.close();
-          reject(new Error("Connection error"));
-        };
+      es.onerror = () => {
+        es.close();
+        reject(new Error("Connection error"));
+      };
 
-        await promise;
-      },
-      { timeout: 5000 },
-    );
+      await promise;
+    });
   });
 
   describe("message events", () => {
-    it(
-      "should receive simple message events",
-      async () => {
-        using server = Bun.serve({
-          port: 0,
-          fetch() {
-            return new Response("data: Hello, World!\n\n", {
-              headers: { "Content-Type": "text/event-stream" },
-            });
-          },
-        });
+    it("should receive simple message events", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("data: Hello, World!\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
 
-        const es = new EventSource(`http://localhost:${server.port}`);
-        const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
 
-        es.onmessage = e => {
-          es.close();
-          resolve(e);
-        };
+      es.onmessage = e => {
+        es.close();
+        resolve(e);
+      };
 
-        es.onerror = () => {
-          es.close();
-          reject(new Error("Connection error"));
-        };
+      es.onerror = () => {
+        es.close();
+        reject(new Error("Connection error"));
+      };
 
-        const event = await promise;
-        expect(event.data).toBe("Hello, World!");
-      },
-      { timeout: 5000 },
-    );
+      const event = await promise;
+      expect(event.data).toBe("Hello, World!");
+    });
 
-    it(
-      "should handle multi-line data",
-      async () => {
-        using server = Bun.serve({
-          port: 0,
-          fetch() {
-            return new Response("data: Line 1\ndata: Line 2\ndata: Line 3\n\n", {
-              headers: { "Content-Type": "text/event-stream" },
-            });
-          },
-        });
+    it("should handle multi-line data", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("data: Line 1\ndata: Line 2\ndata: Line 3\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
 
-        const es = new EventSource(`http://localhost:${server.port}`);
-        const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
 
-        es.onmessage = e => {
-          es.close();
-          resolve(e);
-        };
+      es.onmessage = e => {
+        es.close();
+        resolve(e);
+      };
 
-        es.onerror = () => {
-          es.close();
-          reject(new Error("Connection error"));
-        };
+      es.onerror = () => {
+        es.close();
+        reject(new Error("Connection error"));
+      };
 
-        const event = await promise;
-        expect(event.data).toBe("Line 1\nLine 2\nLine 3");
-      },
-      { timeout: 5000 },
-    );
+      const event = await promise;
+      expect(event.data).toBe("Line 1\nLine 2\nLine 3");
+    });
 
-    it(
-      "should handle custom event types",
-      async () => {
-        using server = Bun.serve({
-          port: 0,
-          fetch() {
-            return new Response("event: custom\ndata: Custom Event Data\n\n", {
-              headers: { "Content-Type": "text/event-stream" },
-            });
-          },
-        });
+    it("should handle custom event types", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("event: custom\ndata: Custom Event Data\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
 
-        const es = new EventSource(`http://localhost:${server.port}`);
-        const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
 
-        es.addEventListener("custom", (e: Event) => {
-          es.close();
-          resolve(e as MessageEvent);
-        });
+      es.addEventListener("custom", (e: Event) => {
+        es.close();
+        resolve(e as MessageEvent);
+      });
 
-        es.onerror = () => {
-          es.close();
-          reject(new Error("Connection error"));
-        };
+      es.onerror = () => {
+        es.close();
+        reject(new Error("Connection error"));
+      };
 
-        const event = await promise;
-        expect(event.data).toBe("Custom Event Data");
-      },
-      { timeout: 5000 },
-    );
+      const event = await promise;
+      expect(event.data).toBe("Custom Event Data");
+    });
 
-    it(
-      "should track lastEventId",
-      async () => {
-        using server = Bun.serve({
-          port: 0,
-          fetch() {
-            return new Response("id: 123\ndata: test\n\n", {
-              headers: { "Content-Type": "text/event-stream" },
-            });
-          },
-        });
+    it("should track lastEventId", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("id: 123\ndata: test\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
 
-        const es = new EventSource(`http://localhost:${server.port}`);
-        const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
 
-        es.onmessage = e => {
-          es.close();
-          resolve(e);
-        };
+      es.onmessage = e => {
+        es.close();
+        resolve(e);
+      };
 
-        es.onerror = () => {
-          es.close();
-          reject(new Error("Connection error"));
-        };
+      es.onerror = () => {
+        es.close();
+        reject(new Error("Connection error"));
+      };
 
-        const event = await promise;
-        expect(event.lastEventId).toBe("123");
-      },
-      { timeout: 5000 },
-    );
+      const event = await promise;
+      expect(event.lastEventId).toBe("123");
+    });
   });
 
   describe("error handling", () => {
-    it(
-      "should fire error event for wrong MIME type",
-      async () => {
-        using server = Bun.serve({
-          port: 0,
-          fetch() {
-            return new Response("data: test\n\n", {
-              headers: { "Content-Type": "text/plain" },
-            });
-          },
-        });
+    it("should fire error event for wrong MIME type", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("data: test\n\n", {
+            headers: { "Content-Type": "text/plain" },
+          });
+        },
+      });
 
-        const es = new EventSource(`http://localhost:${server.port}`);
-        const { promise, resolve } = Promise.withResolvers<Event>();
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve } = Promise.withResolvers<Event>();
 
-        es.onerror = e => {
-          es.close();
-          resolve(e);
-        };
+      es.onerror = e => {
+        es.close();
+        resolve(e);
+      };
 
-        await promise;
-        expect(es.readyState).toBe(EventSource.CLOSED);
-      },
-      { timeout: 5000 },
-    );
+      await promise;
+      expect(es.readyState).toBe(EventSource.CLOSED);
+    });
 
-    it(
-      "should fire error event for HTTP errors",
-      async () => {
-        using server = Bun.serve({
-          port: 0,
-          fetch() {
-            return new Response("Not Found", { status: 404 });
-          },
-        });
+    it("should fire error event for HTTP errors", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("Not Found", { status: 404 });
+        },
+      });
 
-        const es = new EventSource(`http://localhost:${server.port}`);
-        const { promise, resolve } = Promise.withResolvers<Event>();
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve } = Promise.withResolvers<Event>();
 
-        es.onerror = e => {
-          es.close();
-          resolve(e);
-        };
+      es.onerror = e => {
+        es.close();
+        resolve(e);
+      };
 
-        await promise;
-        expect(es.readyState).toBe(EventSource.CLOSED);
-      },
-      { timeout: 5000 },
-    );
+      await promise;
+      expect(es.readyState).toBe(EventSource.CLOSED);
+    });
 
-    it(
-      "should close connection on HTTP 204",
-      async () => {
-        using server = Bun.serve({
-          port: 0,
-          fetch() {
-            return new Response(null, { status: 204 });
-          },
-        });
+    it("should close connection on HTTP 204", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response(null, { status: 204 });
+        },
+      });
 
-        const es = new EventSource(`http://localhost:${server.port}`);
-        const { promise, resolve } = Promise.withResolvers<Event>();
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve } = Promise.withResolvers<Event>();
 
-        es.onerror = e => {
-          es.close();
-          resolve(e);
-        };
+      es.onerror = e => {
+        es.close();
+        resolve(e);
+      };
 
-        await promise;
-        expect(es.readyState).toBe(EventSource.CLOSED);
-      },
-      { timeout: 5000 },
-    );
+      await promise;
+      expect(es.readyState).toBe(EventSource.CLOSED);
+    });
   });
 
   describe("properties", () => {
@@ -370,148 +334,210 @@ describe("EventSource", () => {
       expect(es.withCredentials).toBe(true);
       es.close();
     });
+
+    it("should have non-enumerable instance getters for state constants", () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("data: test\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`);
+      // Instance should have getters that delegate to static values
+      expect(es.CONNECTING).toBe(0);
+      expect(es.OPEN).toBe(1);
+      expect(es.CLOSED).toBe(2);
+      // They should not be own enumerable properties
+      expect(Object.keys(es)).not.toContain("CONNECTING");
+      expect(Object.keys(es)).not.toContain("OPEN");
+      expect(Object.keys(es)).not.toContain("CLOSED");
+      es.close();
+    });
   });
 
   describe("comments and ignored lines", () => {
-    it(
-      "should ignore comment lines starting with colon",
-      async () => {
-        using server = Bun.serve({
-          port: 0,
-          fetch() {
-            return new Response(":this is a comment\ndata: actual data\n\n", {
-              headers: { "Content-Type": "text/event-stream" },
-            });
-          },
-        });
+    it("should ignore comment lines starting with colon", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response(":this is a comment\ndata: actual data\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
 
-        const es = new EventSource(`http://localhost:${server.port}`);
-        const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
 
-        es.onmessage = e => {
-          es.close();
-          resolve(e);
-        };
+      es.onmessage = e => {
+        es.close();
+        resolve(e);
+      };
 
-        es.onerror = () => {
-          es.close();
-          reject(new Error("Connection error"));
-        };
+      es.onerror = () => {
+        es.close();
+        reject(new Error("Connection error"));
+      };
 
-        const event = await promise;
-        expect(event.data).toBe("actual data");
-      },
-      { timeout: 5000 },
-    );
+      const event = await promise;
+      expect(event.data).toBe("actual data");
+    });
   });
 
   describe("retry field", () => {
-    it(
-      "should accept valid retry field values",
-      async () => {
-        // Note: We can't directly test the internal reconnection time,
-        // but we verify the connection works with a retry field
-        using server = Bun.serve({
-          port: 0,
-          fetch() {
-            return new Response("retry: 1000\ndata: test\n\n", {
-              headers: { "Content-Type": "text/event-stream" },
-            });
-          },
-        });
+    it("should accept valid retry field values", async () => {
+      // Note: We can't directly test the internal reconnection time,
+      // but we verify the connection works with a retry field
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("retry: 1000\ndata: test\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
 
-        const es = new EventSource(`http://localhost:${server.port}`);
-        const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
 
-        es.onmessage = e => {
-          es.close();
-          resolve(e);
-        };
+      es.onmessage = e => {
+        es.close();
+        resolve(e);
+      };
 
-        es.onerror = () => {
-          es.close();
-          reject(new Error("Connection error"));
-        };
+      es.onerror = () => {
+        es.close();
+        reject(new Error("Connection error"));
+      };
 
-        const event = await promise;
-        expect(event.data).toBe("test");
-      },
-      { timeout: 5000 },
-    );
+      const event = await promise;
+      expect(event.data).toBe("test");
+    });
   });
 
   describe("multiple messages", () => {
-    it(
-      "should receive multiple messages in sequence",
-      async () => {
-        using server = Bun.serve({
-          port: 0,
-          fetch() {
-            return new Response("data: first\n\ndata: second\n\ndata: third\n\n", {
-              headers: { "Content-Type": "text/event-stream" },
-            });
-          },
-        });
+    it("should receive multiple messages in sequence", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("data: first\n\ndata: second\n\ndata: third\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
 
-        const es = new EventSource(`http://localhost:${server.port}`);
-        const messages: string[] = [];
-        const { promise, resolve, reject } = Promise.withResolvers<void>();
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const messages: string[] = [];
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
 
-        es.onmessage = e => {
-          messages.push(e.data);
-          if (messages.length >= 3) {
-            es.close();
-            resolve();
-          }
-        };
-
-        es.onerror = () => {
+      es.onmessage = e => {
+        messages.push(e.data);
+        if (messages.length >= 3) {
           es.close();
-          // On stream end, error fires before reconnect attempt
-          if (messages.length >= 3) {
-            resolve();
-          } else {
-            reject(new Error("Connection error"));
-          }
-        };
+          resolve();
+        }
+      };
 
-        await promise;
-        expect(messages).toEqual(["first", "second", "third"]);
-      },
-      { timeout: 5000 },
-    );
+      es.onerror = () => {
+        es.close();
+        // On stream end, error fires before reconnect attempt
+        if (messages.length >= 3) {
+          resolve();
+        } else {
+          reject(new Error("Connection error"));
+        }
+      };
+
+      await promise;
+      expect(messages).toEqual(["first", "second", "third"]);
+    });
   });
 
   describe("CRLF handling", () => {
-    it(
-      "should handle CRLF line endings",
-      async () => {
-        using server = Bun.serve({
-          port: 0,
-          fetch() {
-            return new Response("data: test\r\n\r\n", {
-              headers: { "Content-Type": "text/event-stream" },
-            });
-          },
-        });
+    it("should handle CRLF line endings", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("data: test\r\n\r\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
 
-        const es = new EventSource(`http://localhost:${server.port}`);
-        const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
 
-        es.onmessage = e => {
-          es.close();
-          resolve(e);
-        };
+      es.onmessage = e => {
+        es.close();
+        resolve(e);
+      };
 
-        es.onerror = () => {
-          es.close();
-          reject(new Error("Connection error"));
-        };
+      es.onerror = () => {
+        es.close();
+        reject(new Error("Connection error"));
+      };
 
-        const event = await promise;
-        expect(event.data).toBe("test");
-      },
-      { timeout: 5000 },
-    );
+      const event = await promise;
+      expect(event.data).toBe("test");
+    });
+  });
+
+  describe("Content-Type handling", () => {
+    it("should accept Content-Type with parameters", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("data: test\n\n", {
+            headers: { "Content-Type": "text/event-stream; charset=utf-8" },
+          });
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+
+      es.onmessage = e => {
+        es.close();
+        resolve(e);
+      };
+
+      es.onerror = () => {
+        es.close();
+        reject(new Error("Connection error"));
+      };
+
+      const event = await promise;
+      expect(event.data).toBe("test");
+    });
+
+    it("should accept Content-Type case-insensitively", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("data: test\n\n", {
+            headers: { "Content-Type": "TEXT/EVENT-STREAM" },
+          });
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+
+      es.onmessage = e => {
+        es.close();
+        resolve(e);
+      };
+
+      es.onerror = () => {
+        es.close();
+        reject(new Error("Connection error"));
+      };
+
+      const event = await promise;
+      expect(event.data).toBe("test");
+    });
   });
 });

--- a/test/regression/issue/3319.test.ts
+++ b/test/regression/issue/3319.test.ts
@@ -1,0 +1,477 @@
+import { describe, expect, it } from "bun:test";
+
+// Test for https://github.com/oven-sh/bun/issues/3319
+// EventSource (Server-Sent Events) implementation
+
+describe("EventSource", () => {
+  it("should be defined globally", () => {
+    expect(typeof EventSource).toBe("function");
+    expect(EventSource.CONNECTING).toBe(0);
+    expect(EventSource.OPEN).toBe(1);
+    expect(EventSource.CLOSED).toBe(2);
+  });
+
+  it("should have correct prototype chain", () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("data: test\n\n", {
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      },
+    });
+
+    const es = new EventSource(`http://localhost:${server.port}`);
+    expect(es instanceof EventTarget).toBe(true);
+    expect(EventSource.prototype).toBeDefined();
+    es.close();
+  });
+
+  describe("connection lifecycle", () => {
+    it("should start in CONNECTING state", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode("data: test\n\n"));
+                // Don't close to keep stream open
+              },
+            }),
+            { headers: { "Content-Type": "text/event-stream" } },
+          );
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`);
+      expect(es.readyState).toBe(EventSource.CONNECTING);
+      es.close();
+    });
+
+    it("should transition to OPEN state when connected", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode("data: test\n\n"));
+              },
+            }),
+            { headers: { "Content-Type": "text/event-stream" } },
+          );
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve } = Promise.withResolvers<void>();
+
+      es.onopen = () => {
+        expect(es.readyState).toBe(EventSource.OPEN);
+        es.close();
+        resolve();
+      };
+
+      es.onerror = () => {
+        es.close();
+        resolve();
+      };
+
+      await promise;
+    });
+
+    it("should transition to CLOSED state when close() is called", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode("data: test\n\n"));
+              },
+            }),
+            { headers: { "Content-Type": "text/event-stream" } },
+          );
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve } = Promise.withResolvers<void>();
+
+      es.onopen = () => {
+        es.close();
+        expect(es.readyState).toBe(EventSource.CLOSED);
+        resolve();
+      };
+
+      es.onerror = () => {
+        es.close();
+        resolve();
+      };
+
+      await promise;
+    });
+  });
+
+  describe("message events", () => {
+    it("should receive simple message events", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("data: Hello, World!\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+
+      const timeout = setTimeout(() => {
+        es.close();
+        reject(new Error("Timeout waiting for message"));
+      }, 5000);
+
+      es.onmessage = e => {
+        clearTimeout(timeout);
+        es.close();
+        resolve(e);
+      };
+
+      es.onerror = () => {
+        clearTimeout(timeout);
+        es.close();
+        reject(new Error("Connection error"));
+      };
+
+      const event = await promise;
+      expect(event.data).toBe("Hello, World!");
+    });
+
+    it("should handle multi-line data", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("data: Line 1\ndata: Line 2\ndata: Line 3\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+
+      const timeout = setTimeout(() => {
+        es.close();
+        reject(new Error("Timeout waiting for message"));
+      }, 5000);
+
+      es.onmessage = e => {
+        clearTimeout(timeout);
+        es.close();
+        resolve(e);
+      };
+
+      es.onerror = () => {
+        clearTimeout(timeout);
+        es.close();
+        reject(new Error("Connection error"));
+      };
+
+      const event = await promise;
+      expect(event.data).toBe("Line 1\nLine 2\nLine 3");
+    });
+
+    it("should handle custom event types", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("event: custom\ndata: Custom Event Data\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+
+      const timeout = setTimeout(() => {
+        es.close();
+        reject(new Error("Timeout waiting for message"));
+      }, 5000);
+
+      es.addEventListener("custom", (e: Event) => {
+        clearTimeout(timeout);
+        es.close();
+        resolve(e as MessageEvent);
+      });
+
+      es.onerror = () => {
+        clearTimeout(timeout);
+        es.close();
+        reject(new Error("Connection error"));
+      };
+
+      const event = await promise;
+      expect(event.data).toBe("Custom Event Data");
+    });
+
+    it("should track lastEventId", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("id: 123\ndata: test\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+
+      const timeout = setTimeout(() => {
+        es.close();
+        reject(new Error("Timeout waiting for message"));
+      }, 5000);
+
+      es.onmessage = e => {
+        clearTimeout(timeout);
+        es.close();
+        resolve(e);
+      };
+
+      es.onerror = () => {
+        clearTimeout(timeout);
+        es.close();
+        reject(new Error("Connection error"));
+      };
+
+      const event = await promise;
+      expect(event.lastEventId).toBe("123");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should fire error event for wrong MIME type", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("data: test\n\n", {
+            headers: { "Content-Type": "text/plain" },
+          });
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<Event>();
+
+      const timeout = setTimeout(() => {
+        es.close();
+        reject(new Error("Timeout waiting for error"));
+      }, 5000);
+
+      es.onerror = e => {
+        clearTimeout(timeout);
+        es.close();
+        resolve(e);
+      };
+
+      await promise;
+      expect(es.readyState).toBe(EventSource.CLOSED);
+    });
+
+    it("should fire error event for HTTP errors", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("Not Found", { status: 404 });
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<Event>();
+
+      const timeout = setTimeout(() => {
+        es.close();
+        reject(new Error("Timeout waiting for error"));
+      }, 5000);
+
+      es.onerror = e => {
+        clearTimeout(timeout);
+        es.close();
+        resolve(e);
+      };
+
+      await promise;
+      expect(es.readyState).toBe(EventSource.CLOSED);
+    });
+  });
+
+  describe("properties", () => {
+    it("should have correct url property", () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("data: test\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
+
+      const url = `http://localhost:${server.port}/path?query=value`;
+      const es = new EventSource(url);
+      expect(es.url).toBe(url);
+      es.close();
+    });
+
+    it("should default withCredentials to false", () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("data: test\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`);
+      expect(es.withCredentials).toBe(false);
+      es.close();
+    });
+
+    it("should respect withCredentials option", () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("data: test\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`, { withCredentials: true });
+      expect(es.withCredentials).toBe(true);
+      es.close();
+    });
+  });
+
+  describe("comments and ignored lines", () => {
+    it("should ignore comment lines starting with colon", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response(":this is a comment\ndata: actual data\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+
+      const timeout = setTimeout(() => {
+        es.close();
+        reject(new Error("Timeout waiting for message"));
+      }, 5000);
+
+      es.onmessage = e => {
+        clearTimeout(timeout);
+        es.close();
+        resolve(e);
+      };
+
+      es.onerror = () => {
+        clearTimeout(timeout);
+        es.close();
+        reject(new Error("Connection error"));
+      };
+
+      const event = await promise;
+      expect(event.data).toBe("actual data");
+    });
+  });
+
+  describe("retry field", () => {
+    it("should accept valid retry field values", async () => {
+      // Note: We can't directly test the internal reconnection time,
+      // but we verify the connection works with a retry field
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("retry: 1000\ndata: test\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+
+      const timeout = setTimeout(() => {
+        es.close();
+        reject(new Error("Timeout waiting for message"));
+      }, 5000);
+
+      es.onmessage = e => {
+        clearTimeout(timeout);
+        es.close();
+        resolve(e);
+      };
+
+      es.onerror = () => {
+        clearTimeout(timeout);
+        es.close();
+        reject(new Error("Connection error"));
+      };
+
+      const event = await promise;
+      expect(event.data).toBe("test");
+    });
+  });
+
+  describe("multiple messages", () => {
+    it("should receive multiple messages in sequence", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("data: first\n\ndata: second\n\ndata: third\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      });
+
+      const es = new EventSource(`http://localhost:${server.port}`);
+      const messages: string[] = [];
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+      const timeout = setTimeout(() => {
+        es.close();
+        reject(new Error("Timeout waiting for messages"));
+      }, 5000);
+
+      es.onmessage = e => {
+        messages.push(e.data);
+        if (messages.length >= 3) {
+          clearTimeout(timeout);
+          es.close();
+          resolve();
+        }
+      };
+
+      es.onerror = () => {
+        clearTimeout(timeout);
+        es.close();
+        // On stream end, error fires before reconnect attempt
+        if (messages.length >= 3) {
+          resolve();
+        } else {
+          reject(new Error("Connection error"));
+        }
+      };
+
+      await promise;
+      expect(messages).toEqual(["first", "second", "third"]);
+    });
+  });
+});

--- a/test/regression/issue/3319.test.ts
+++ b/test/regression/issue/3319.test.ts
@@ -546,12 +546,14 @@ describe("EventSource", () => {
       const original = EventSource;
       const fake = function FakeEventSource() {};
 
-      // Reassign should work
-      (globalThis as any).EventSource = fake;
-      expect(EventSource).toBe(fake);
-
-      // Restore
-      (globalThis as any).EventSource = original;
+      try {
+        // Reassign should work
+        (globalThis as any).EventSource = fake;
+        expect(EventSource).toBe(fake);
+      } finally {
+        // Always restore original to avoid leaking mutated global
+        (globalThis as any).EventSource = original;
+      }
       expect(EventSource).toBe(original);
     });
   });


### PR DESCRIPTION
## Summary
- Implements the `EventSource` API (Server-Sent Events) as defined by the WHATWG HTML spec
- Uses fetch-based streaming for proper cookie/credential handling
- Properly extends EventTarget for addEventListener/removeEventListener/dispatchEvent
- Supports all SSE features: custom events, lastEventId, retry/reconnection
- Exposed as a global like in browsers/Node.js

This was previously removed from Bun because the original implementation didn't work properly (it used raw TCP connections instead of HTTP).

## Test plan
- [x] Added comprehensive test suite in `test/regression/issue/3319.test.ts`
- [x] Tests cover: constructor, readyState transitions, message events, multi-line data, custom events, lastEventId, error handling, URL property, withCredentials, comments, retry field, multiple messages

Fixes #3319

🤖 Generated with [Claude Code](https://claude.ai/code)