### PR TITLE
test(sql): add DELETE with WHERE IN helper tests

### DIFF
--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1507,6 +1507,68 @@ describe("SQL helpers", () => {
     expect(result[0].param1).toBe("value1");
     expect(result[0].param2).toBe("value2");
   });
+
+  test("DELETE with WHERE IN helper", async () => {
+    const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+    await sql`CREATE TEMPORARY TABLE ${sql(random_name)} (id int, name text, age int)`;
+    const users = [
+      { id: 1, name: "John", age: 30 },
+      { id: 2, name: "Jane", age: 25 },
+      { id: 3, name: "Bob", age: 35 },
+    ];
+    await sql`INSERT INTO ${sql(random_name)} ${sql(users)}`;
+
+    // Verify initial state
+    const before = await sql`SELECT * FROM ${sql(random_name)} ORDER BY id`;
+    expect(before.length).toBe(3);
+
+    // DELETE with array of values
+    await sql`DELETE FROM ${sql(random_name)} WHERE id IN ${sql([1, 2])}`;
+
+    const after = await sql`SELECT * FROM ${sql(random_name)}`;
+    expect(after.length).toBe(1);
+    expect(after[0].id).toBe(3);
+    expect(after[0].name).toBe("Bob");
+  });
+
+  test("DELETE with WHERE IN using objects", async () => {
+    const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+    await sql`CREATE TEMPORARY TABLE ${sql(random_name)} (id int, name text, age int)`;
+    const users = [
+      { id: 1, name: "John", age: 30 },
+      { id: 2, name: "Jane", age: 25 },
+      { id: 3, name: "Bob", age: 35 },
+    ];
+    await sql`INSERT INTO ${sql(random_name)} ${sql(users)}`;
+
+    // DELETE with objects and column name
+    const toDelete = [{ id: 1 }, { id: 3 }];
+    await sql`DELETE FROM ${sql(random_name)} WHERE id IN ${sql(toDelete, "id")}`;
+
+    const after = await sql`SELECT * FROM ${sql(random_name)}`;
+    expect(after.length).toBe(1);
+    expect(after[0].id).toBe(2);
+    expect(after[0].name).toBe("Jane");
+  });
+
+  test("DELETE with WHERE NOT IN helper", async () => {
+    const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+    await sql`CREATE TEMPORARY TABLE ${sql(random_name)} (id int, name text, age int)`;
+    const users = [
+      { id: 1, name: "John", age: 30 },
+      { id: 2, name: "Jane", age: 25 },
+      { id: 3, name: "Bob", age: 35 },
+    ];
+    await sql`INSERT INTO ${sql(random_name)} ${sql(users)}`;
+
+    // DELETE with NOT IN
+    await sql`DELETE FROM ${sql(random_name)} WHERE id NOT IN ${sql([2])}`;
+
+    const after = await sql`SELECT * FROM ${sql(random_name)}`;
+    expect(after.length).toBe(1);
+    expect(after[0].id).toBe(2);
+    expect(after[0].name).toBe("Jane");
+  });
 });
 
 describe("Helper argument validation", () => {


### PR DESCRIPTION
## Summary

Closes #26146

This PR adds tests to verify that DELETE statements work correctly with the `sql()` helper for WHERE IN clauses. 

**Important finding:** The functionality requested in #26146 already works! The user was trying to use `sql.array()` which is designed for PostgreSQL array column types (like `TEXT[]`, `INTEGER[]`), not for WHERE IN expansion.

The correct ways to delete multiple rows by ID:

```ts
// Using sql() helper (works with SQLite, PostgreSQL, MySQL)
await sql`DELETE FROM users WHERE id IN ${sql([1, 2, 3])}`;

// Using sql() with objects
await sql`DELETE FROM users WHERE id IN ${sql([{id: 1}, {id: 2}], "id")}`;

// PostgreSQL-specific: using sql.array with ANY()
await sql`DELETE FROM users WHERE id = ANY(${sql.array([1, 2, 3], "int")})`;
```

## Tests Added

- DELETE with WHERE IN using array of values (SQLite + PostgreSQL)
- DELETE with WHERE IN using objects and column name (SQLite + PostgreSQL)
- DELETE with WHERE NOT IN (SQLite + PostgreSQL)
- DELETE with WHERE id = ANY using sql.array (PostgreSQL only)

## Test plan

- [x] All new SQLite tests pass with `bun bd test test/js/sql/sqlite-sql.test.ts -t "DELETE with WHERE"`
- [ ] PostgreSQL tests require Docker (manual CI verification needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)