### PR TITLE
docs(bundler): rename banner heading to avoid hidden id

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1150,7 +1150,7 @@ A map of file extensions to built-in loader names. This can be used to quickly c
   </Tab>
 </Tabs>
 
-### banner
+### banner directive
 
 A banner to be added to the final bundle, this can be a directive like `"use client"` for react or a comment block such as a license for the code.
 


### PR DESCRIPTION
### What does this PR do?
Rename the “banner” section to “banner directive” so the auto-generated heading id is no longer banner (which gets hidden).
<img width="1083" height="898" alt="image" src="https://github.com/user-attachments/assets/f55a746e-730b-47b5-81ff-f5cb0e1197ac" />
<img width="816" height="96" alt="image" src="https://github.com/user-attachments/assets/38c9a76f-86a3-4ba1-acad-7b55d0ae06e0" />



### How did you verify your code works?
Verified locally by `bunx --bun mint dev`

Fixes #26062
