### PR TITLE
feat: upgrade Node.js target to v25.3.0

### DIFF
--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -160,10 +160,10 @@ endif()
 optionx(REVISION STRING "The git revision of the build" DEFAULT ${DEFAULT_REVISION})
 
 # Used in process.version, process.versions.node, napi, and elsewhere
-setx(NODEJS_VERSION "24.3.0")
+setx(NODEJS_VERSION "25.3.0")
 
 # Used in process.versions.modules and compared while loading V8 modules
-setx(NODEJS_ABI_VERSION "137")
+setx(NODEJS_ABI_VERSION "141")
 
 if(APPLE)
   set(DEFAULT_STATIC_SQLITE OFF)

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -240,7 +240,7 @@ function Install-Git {
 }
 
 function Install-NodeJs {
-  Install-Package nodejs -Command node -Version "24.3.0"
+  Install-Package nodejs -Command node -Version "25.3.0"
 }
 
 function Install-Bun {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -779,7 +779,7 @@ install_common_software() {
 }
 
 nodejs_version_exact() {
-	print "24.3.0"
+	print "25.3.0"
 }
 
 nodejs_version() {

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -230,11 +230,11 @@ static JSValue constructVersions(VM& vm, JSObject* processObject)
 
     // Use commit hash for zstd (semantic version extraction not working yet)
     object->putDirect(vm, JSC::Identifier::fromString(vm, "zstd"_s), JSC::jsOwnedString(vm, ASCIILiteral::fromLiteralUnsafe(BUN_VERSION_ZSTD_HASH)), 0);
-    object->putDirect(vm, JSC::Identifier::fromString(vm, "v8"_s), JSValue(JSC::jsOwnedString(vm, String("13.6.233.10-node.18"_s))), 0);
+    object->putDirect(vm, JSC::Identifier::fromString(vm, "v8"_s), JSValue(JSC::jsOwnedString(vm, String("14.1.146.11-node.18"_s))), 0);
 #if OS(WINDOWS)
     object->putDirect(vm, JSC::Identifier::fromString(vm, "uv"_s), JSValue(JSC::jsOwnedString(vm, String::fromLatin1(uv_version_string()))), 0);
 #else
-    object->putDirect(vm, JSC::Identifier::fromString(vm, "uv"_s), JSValue(JSC::jsOwnedString(vm, String("1.48.0"_s))), 0);
+    object->putDirect(vm, JSC::Identifier::fromString(vm, "uv"_s), JSValue(JSC::jsOwnedString(vm, String("1.51.0"_s))), 0);
 #endif
     object->putDirect(vm, JSC::Identifier::fromString(vm, "napi"_s), JSValue(JSC::jsOwnedString(vm, String("10"_s))), 0);
 

--- a/src/bun.js/bindings/v8/V8Isolate.h
+++ b/src/bun.js/bindings/v8/V8Isolate.h
@@ -17,12 +17,12 @@ class GlobalInternals;
 // they need to have the correct layout.
 class Isolate final {
 public:
-    // v8-internal.h:775
-    static constexpr int kUndefinedValueRootIndex = 4;
-    static constexpr int kTheHoleValueRootIndex = 5;
-    static constexpr int kNullValueRootIndex = 6;
-    static constexpr int kTrueValueRootIndex = 7;
-    static constexpr int kFalseValueRootIndex = 8;
+    // v8-internal.h:1057
+    static constexpr int kUndefinedValueRootIndex = 0;
+    static constexpr int kTheHoleValueRootIndex = 1;
+    static constexpr int kNullValueRootIndex = 2;
+    static constexpr int kTrueValueRootIndex = 3;
+    static constexpr int kFalseValueRootIndex = 4;
 
     Isolate(shim::GlobalInternals* globalInternals);
 
@@ -50,9 +50,9 @@ public:
     shim::GlobalInternals* m_globalInternals;
     Zig::GlobalObject* m_globalObject;
 
-    uintptr_t m_padding[78];
+    uintptr_t m_padding[79];
 
-    std::array<TaggedPointer, 9> m_roots;
+    std::array<TaggedPointer, 6> m_roots;
 };
 
 } // namespace v8

--- a/test/v8/v8.test.ts
+++ b/test/v8/v8.test.ts
@@ -21,7 +21,7 @@ enum BuildMode {
 delete bunEnv.CC;
 delete bunEnv.CXX;
 
-// Node.js 24.3.0 requires C++20
+// Node.js 25.3.0 requires C++20
 bunEnv.CXXFLAGS ??= "";
 if (process.platform == "darwin") {
   bunEnv.CXXFLAGS += " -std=gnu++20";


### PR DESCRIPTION
## Summary

Upgrade Bun's self-reported Node.js version from v24.3.0 to v25.3.0.

### Changes
- Update `NODEJS_VERSION` to `25.3.0`
- Update `NODEJS_ABI_VERSION` to `141` (NODE_MODULE_VERSION)
- Update V8 version to `14.1.146.11` (from `13.6.233.10`)
- Update libuv version to `1.51.0` (from `1.48.0`)
- Update V8 Isolate root indices to match V8 14.1:
  - `kUndefinedValueRootIndex`: 4 → 0
  - `kTheHoleValueRootIndex`: 5 → 1
  - `kNullValueRootIndex`: 6 → 2
  - `kTrueValueRootIndex`: 7 → 3
  - `kFalseValueRootIndex`: 8 → 4
- Update V8 Isolate padding from 78 to 79 elements (`kIsolateRootsOffset`: 640 → 648)
- Update `m_roots` array size from 9 to 6 elements

N-API version remains at 10 (still the latest).

### Files Modified
- `cmake/Options.cmake` - Version numbers
- `scripts/bootstrap.sh` - Node.js version for bootstrap
- `scripts/bootstrap.ps1` - Node.js version for Windows bootstrap
- `src/bun.js/bindings/BunProcess.cpp` - V8 and libuv version strings
- `src/bun.js/bindings/v8/V8Isolate.h` - V8 API compatibility updates
- `test/v8/v8.test.ts` - Comment update

## Test plan

- [x] Build succeeds: `bun bd`
- [x] `process.version` returns `v25.3.0`
- [x] `process.versions.v8` returns `14.1.146.11-node.18`
- [x] `process.config.variables.node_module_version` returns `141`
- [x] N-API tests build and run (80 pass)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)