### PR TITLE
docs: amend env file instructions and command line usage for set-env.mdx

### DIFF
--- a/docs/guides/runtime/set-env.mdx
+++ b/docs/guides/runtime/set-env.mdx
@@ -15,7 +15,7 @@ process.env.API_TOKEN; // => "secret"
 
 Set these variables in a `.env` file.
 
-Bun reads the following files automatically (listed in order of increasing precedence).
+Bun reads the following files in the current working directory automatically (listed in order of increasing precedence).
 
 - `.env`
 - `.env.production`, `.env.development`, `.env.test` (depending on value of `NODE_ENV`)
@@ -24,6 +24,11 @@ Bun reads the following files automatically (listed in order of increasing prece
 ```ini .env icon="settings"
 FOO=hello
 BAR=world
+```
+
+To read an env file from any other file system path, you must use `--env-file`. 
+```sh
+bun --env-file=../.env index.ts 
 ```
 
 ---
@@ -45,6 +50,8 @@ $env:FOO="helloworld"; bun run dev
 ```
 
 </CodeGroup>
+
+Variables from the command line override .env
 
 ---
 


### PR DESCRIPTION
Clarified the description of how Bun reads env files and added information on using --env-file to specify a different path.

### What does this PR do?

just docs

### How did you verify your code works?

markdown parser still parses :D