### PR TITLE
fix(udp): prevent socket from dying on Windows ICMP port unreachable

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1231,6 +1231,18 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
         return LIBUS_SOCKET_ERROR;
     }
 
+#ifdef _WIN32
+    /* Disable WSAECONNRESET errors from ICMP "Port Unreachable" messages.
+     * Without this, sending to a closed port causes subsequent recv calls to fail,
+     * which would close the entire UDP socket. This matches Node.js/libuv behavior. */
+    {
+        BOOL bNewBehavior = FALSE;
+        DWORD dwBytesReturned = 0;
+        WSAIoctl(listenFd, SIO_UDP_CONNRESET, &bNewBehavior, sizeof(bNewBehavior),
+                 NULL, 0, &dwBytesReturned, NULL, NULL);
+    }
+#endif
+
     if (port != 0) {
         /* Should this also go for UDP? */
         int enabled = 1;

--- a/test/regression/issue/26166.test.ts
+++ b/test/regression/issue/26166.test.ts
@@ -1,0 +1,59 @@
+import { udpSocket } from "bun";
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/26166
+// On Windows, ICMP "Port Unreachable" messages cause WSAECONNRESET errors which
+// would close the UDP socket entirely. This test verifies the socket stays alive.
+test("UDP socket survives sending to unreachable port", async () => {
+  let receivedCount = 0;
+  const receivedData: string[] = [];
+  const { resolve, reject, promise } = Promise.withResolvers<void>();
+
+  // Create a server socket
+  const server = await udpSocket({
+    socket: {
+      data(socket, data, port, address) {
+        receivedCount++;
+        receivedData.push(new TextDecoder().decode(data));
+        if (receivedCount === 2) {
+          resolve();
+        }
+      },
+    },
+  });
+
+  // Create a client
+  const client = await udpSocket({});
+
+  // Send first message to the server
+  client.send(Buffer.from("message1"), server.port, "127.0.0.1");
+
+  // Wait a bit for message to be received
+  await Bun.sleep(50);
+
+  // Now send to an unreachable port (a port that's definitely not listening)
+  // This would trigger an ICMP Port Unreachable on Windows
+  const unreachablePort = 59999;
+  server.send(Buffer.from("this will fail"), unreachablePort, "127.0.0.1");
+
+  // Wait a bit for the ICMP error to potentially be processed
+  await Bun.sleep(100);
+
+  // Send second message - this should still work if the socket survived
+  client.send(Buffer.from("message2"), server.port, "127.0.0.1");
+
+  // Wait for messages with timeout
+  const timeout = setTimeout(() => reject(new Error("Timeout waiting for messages")), 2000);
+
+  try {
+    await promise;
+    clearTimeout(timeout);
+  } finally {
+    server.close();
+    client.close();
+  }
+
+  expect(receivedCount).toBe(2);
+  expect(receivedData).toContain("message1");
+  expect(receivedData).toContain("message2");
+});


### PR DESCRIPTION
## Summary

Fixes #26166

- Added `SIO_UDP_CONNRESET` socket option on Windows to prevent UDP sockets from being closed when receiving ICMP "Port Unreachable" messages
- Added regression test verifying UDP socket survives after sending to an unreachable port

On Windows, when a UDP socket sends a packet to an unreachable port (e.g., when a client disconnects before the server can respond), the Windows TCP/IP stack receives an ICMP "Port Unreachable" message. By default, Windows forwards this as `WSAECONNRESET` (error code 10054) to subsequent `recv` calls, causing Bun's UDP socket to close completely.

This fix disables that behavior using `WSAIoctl(socket, SIO_UDP_CONNRESET, FALSE, ...)`, matching Node.js/libuv behavior.

## Test plan

- [x] Added regression test `test/regression/issue/26166.test.ts`
- [x] All existing UDP tests pass (`bun bd test test/js/bun/udp/udp_socket.test.ts`)
- [ ] Test on actual Windows machine (this is a Windows-specific fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)