### PR TITLE
fix: print blank line for empty console args

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2789,6 +2789,52 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     RETURN_IF_EXCEPTION(scope, );
     consoleObject->putDirectBuiltinFunction(vm, this, vm.propertyNames->asyncIteratorSymbol, consoleObjectAsyncIteratorCodeGenerator(vm), PropertyAttribute::Builtin | 0);
     consoleObject->putDirectBuiltinFunction(vm, this, clientData->builtinNames().writePublicName(), consoleObjectWriteCodeGenerator(vm), PropertyAttribute::Builtin | 0);
+    {
+        auto logName = Identifier::fromString(vm, "log"_s);
+        auto logNativeName = Identifier::fromString(vm, "__bunNativeLog"_s);
+        JSValue originalLog = consoleObject->get(this, logName);
+        RETURN_IF_EXCEPTION(scope, );
+        if (!originalLog.isUndefined()) {
+            consoleObject->putDirect(vm, logNativeName, originalLog, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+            consoleObject->putDirectBuiltinFunction(vm, this, logName, consoleObjectLogCodeGenerator(vm), PropertyAttribute::Builtin | 0);
+        }
+
+        auto infoName = Identifier::fromString(vm, "info"_s);
+        auto infoNativeName = Identifier::fromString(vm, "__bunNativeInfo"_s);
+        JSValue originalInfo = consoleObject->get(this, infoName);
+        RETURN_IF_EXCEPTION(scope, );
+        if (!originalInfo.isUndefined()) {
+            consoleObject->putDirect(vm, infoNativeName, originalInfo, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+            consoleObject->putDirectBuiltinFunction(vm, this, infoName, consoleObjectInfoCodeGenerator(vm), PropertyAttribute::Builtin | 0);
+        }
+
+        auto debugName = Identifier::fromString(vm, "debug"_s);
+        auto debugNativeName = Identifier::fromString(vm, "__bunNativeDebug"_s);
+        JSValue originalDebug = consoleObject->get(this, debugName);
+        RETURN_IF_EXCEPTION(scope, );
+        if (!originalDebug.isUndefined()) {
+            consoleObject->putDirect(vm, debugNativeName, originalDebug, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+            consoleObject->putDirectBuiltinFunction(vm, this, debugName, consoleObjectDebugCodeGenerator(vm), PropertyAttribute::Builtin | 0);
+        }
+
+        auto warnName = Identifier::fromString(vm, "warn"_s);
+        auto warnNativeName = Identifier::fromString(vm, "__bunNativeWarn"_s);
+        JSValue originalWarn = consoleObject->get(this, warnName);
+        RETURN_IF_EXCEPTION(scope, );
+        if (!originalWarn.isUndefined()) {
+            consoleObject->putDirect(vm, warnNativeName, originalWarn, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+            consoleObject->putDirectBuiltinFunction(vm, this, warnName, consoleObjectWarnCodeGenerator(vm), PropertyAttribute::Builtin | 0);
+        }
+
+        auto errorName = Identifier::fromString(vm, "error"_s);
+        auto errorNativeName = Identifier::fromString(vm, "__bunNativeError"_s);
+        JSValue originalError = consoleObject->get(this, errorName);
+        RETURN_IF_EXCEPTION(scope, );
+        if (!originalError.isUndefined()) {
+            consoleObject->putDirect(vm, errorNativeName, originalError, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+            consoleObject->putDirectBuiltinFunction(vm, this, errorName, consoleObjectErrorCodeGenerator(vm), PropertyAttribute::Builtin | 0);
+        }
+    }
     consoleObject->putDirectCustomAccessor(vm, Identifier::fromString(vm, "Console"_s), CustomGetterSetter::create(vm, getConsoleConstructor, nullptr), PropertyAttribute::CustomValue | 0);
     consoleObject->putDirectCustomAccessor(vm, Identifier::fromString(vm, "_stdout"_s), CustomGetterSetter::create(vm, getConsoleStdout, nullptr), PropertyAttribute::DontEnum | PropertyAttribute::CustomValue | 0);
     consoleObject->putDirectCustomAccessor(vm, Identifier::fromString(vm, "_stderr"_s), CustomGetterSetter::create(vm, getConsoleStderr, nullptr), PropertyAttribute::DontEnum | PropertyAttribute::CustomValue | 0);

--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -134,6 +134,56 @@ export function write(this: Console, input) {
   return wrote;
 }
 
+export function log(this: Console) {
+  const receiver = (this as any)?.__bunNativeLog ? this : globalThis.console;
+  const nativeLog = (receiver as any).__bunNativeLog;
+  const count = $argumentCount();
+  if (count === 0) {
+    return nativeLog.$call(receiver, "");
+  }
+  return nativeLog.$apply(receiver, arguments);
+}
+
+export function info(this: Console) {
+  const receiver = (this as any)?.__bunNativeInfo ? this : globalThis.console;
+  const nativeInfo = (receiver as any).__bunNativeInfo;
+  const count = $argumentCount();
+  if (count === 0) {
+    return nativeInfo.$call(receiver, "");
+  }
+  return nativeInfo.$apply(receiver, arguments);
+}
+
+export function debug(this: Console) {
+  const receiver = (this as any)?.__bunNativeDebug ? this : globalThis.console;
+  const nativeDebug = (receiver as any).__bunNativeDebug;
+  const count = $argumentCount();
+  if (count === 0) {
+    return nativeDebug.$call(receiver, "");
+  }
+  return nativeDebug.$apply(receiver, arguments);
+}
+
+export function warn(this: Console) {
+  const receiver = (this as any)?.__bunNativeWarn ? this : globalThis.console;
+  const nativeWarn = (receiver as any).__bunNativeWarn;
+  const count = $argumentCount();
+  if (count === 0) {
+    return nativeWarn.$call(receiver, "");
+  }
+  return nativeWarn.$apply(receiver, arguments);
+}
+
+export function error(this: Console) {
+  const receiver = (this as any)?.__bunNativeError ? this : globalThis.console;
+  const nativeError = (receiver as any).__bunNativeError;
+  const count = $argumentCount();
+  if (count === 0) {
+    return nativeError.$call(receiver, "");
+  }
+  return nativeError.$apply(receiver, arguments);
+}
+
 // This is the `console.Console` constructor. It is mostly copied from Node.
 // https://github.com/nodejs/node/blob/d2c7c367741bdcb6f7f77f55ce95a745f0b29fef/lib/internal/console/constructor.js
 // Some parts are copied from imported files and inlined here. Not too much of a performance issue

--- a/test/regression/issue/26151.test.ts
+++ b/test/regression/issue/26151.test.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { join } from "path";
+
+function runConsoleScript(name: string, code: string) {
+  const dir = tempDirWithFiles(name, {
+    "index.js": code,
+  });
+  const result = Bun.spawnSync([bunExe(), join(dir, "index.js")], {
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  return result;
+}
+
+const cases = [
+  {
+    name: "console.log",
+    dir: "console-log-empty",
+    code: `console.log("foo"); console.log(); console.log("bar");`,
+    stdout: "foo\n\nbar\n",
+    stderr: "",
+  },
+  {
+    name: "console.info",
+    dir: "console-info-empty",
+    code: `console.info("foo"); console.info(); console.info("bar");`,
+    stdout: "foo\n\nbar\n",
+    stderr: "",
+  },
+  {
+    name: "console.debug",
+    dir: "console-debug-empty",
+    code: `console.debug("foo"); console.debug(); console.debug("bar");`,
+    stdout: "foo\n\nbar\n",
+    stderr: "",
+  },
+  {
+    name: "console.warn",
+    dir: "console-warn-empty",
+    code: `console.warn("foo"); console.warn(); console.warn("bar");`,
+    stdout: "",
+    stderr: "foo\n\nbar\n",
+  },
+  {
+    name: "console.error",
+    dir: "console-error-empty",
+    code: `console.error("foo"); console.error(); console.error("bar");`,
+    stdout: "",
+    stderr: "foo\n\nbar\n",
+  },
+];
+
+for (const { name, dir, code, stdout, stderr } of cases) {
+  test(`${name}() with no args prints a blank line`, () => {
+    const result = runConsoleScript(dir, code);
+    expect(result.stdout.toString("utf8")).toBe(stdout);
+    expect(result.stderr.toString("utf8")).toBe(stderr);
+    expect(result.exitCode).toBe(0);
+  });
+}


### PR DESCRIPTION
Issue: https://github.com/oven-sh/bun/issues/26151

Summary
- Preserve blank-line output for console.* with zero arguments by routing through native console methods.
- Protect __bunNative* hooks from deletion and add regression coverage across log/info/debug/warn/error.

Motivation
- console.* without args should still emit a newline; current behavior drops the blank line.
- Extra guard prevents accidental removal of native hooks and keeps wrappers reliable.

Validation
- build\\debug\\bun-debug.exe test test\\regression\\issue\\26151.test.ts