### PR TITLE
fix(macho): only update signature size on ARM64 with codesigning enabled

### DIFF
--- a/src/bun.js/webcore/Request.zig
+++ b/src/bun.js/webcore/Request.zig
@@ -1089,8 +1089,8 @@ const string = []const u8;
 
 const Environment = @import("../../env.zig");
 const std = @import("std");
-const FetchRedirect = @import("../../http/FetchRedirect.zig").FetchRedirect;
 const FetchCacheMode = @import("../../http/FetchCacheMode.zig").FetchCacheMode;
+const FetchRedirect = @import("../../http/FetchRedirect.zig").FetchRedirect;
 const FetchRequestMode = @import("../../http/FetchRequestMode.zig").FetchRequestMode;
 const Method = @import("../../http/Method.zig").Method;
 

--- a/src/macho.zig
+++ b/src/macho.zig
@@ -183,8 +183,10 @@ pub const MachoFile = struct {
 
         // Only update offsets if the size actually changed
         if (size_diff != 0) {
-            // New signature size is the old size plus the size of the hashes for the new pages
-            sig_size = sig_size + @as(usize, @intCast(size_of_new_hashes));
+            if (self.header.cputype == macho.CPU_TYPE_ARM64 and !bun.feature_flag.BUN_NO_CODESIGN_MACHO_BINARY.get()) {
+                // New signature size is the old size plus the size of the hashes for the new pages
+                sig_size = sig_size + @as(usize, @intCast(size_of_new_hashes));
+            }
 
             // We move the offsets of the LINKEDIT segment ahead by `size_diff`
             linkedit_seg.fileoff += @as(usize, @intCast(size_diff));


### PR DESCRIPTION
The signature size adjustment was being applied unconditionally, but it should only happen when building for ARM64 and codesigning is enabled. This prevents incorrect offset calculations on non-ARM64 platforms.