### PR TITLE
fix(publish) Support split npmrc auth for publish

### DIFF
--- a/src/cli/publish_command.zig
+++ b/src/cli/publish_command.zig
@@ -535,7 +535,7 @@ pub const PublishCommand = struct {
         const registry = ctx.manager.scopeForPackageName(ctx.package_name);
 
         // Check for authentication: token, OR auth/user (username:password), OR URL-embedded credentials
-        if (registry.token.len == 0 and (registry.auth.len == 0 or registry.user.len == 0) and (registry.url.password.len == 0 or registry.url.username.len == 0)) {
+        if (registry.token.len == 0 and registry.auth.len == 0 and registry.user.len == 0 and (registry.url.password.len == 0 or registry.url.username.len == 0)) {
             return error.NeedAuth;
         }
 

--- a/src/cli/publish_command.zig
+++ b/src/cli/publish_command.zig
@@ -534,7 +534,7 @@ pub const PublishCommand = struct {
     ) PublishError!void {
         const registry = ctx.manager.scopeForPackageName(ctx.package_name);
 
-        if (registry.token.len == 0 and (registry.url.password.len == 0 or registry.url.username.len == 0)) {
+        if (registry.token.len == 0 and registry.auth.len == 0 and registry.user.len == 0 and (registry.url.password.len == 0 or registry.url.username.len == 0)) {
             return error.NeedAuth;
         }
 

--- a/src/cli/publish_command.zig
+++ b/src/cli/publish_command.zig
@@ -534,7 +534,8 @@ pub const PublishCommand = struct {
     ) PublishError!void {
         const registry = ctx.manager.scopeForPackageName(ctx.package_name);
 
-        if (registry.token.len == 0 and registry.auth.len == 0 and registry.user.len == 0 and (registry.url.password.len == 0 or registry.url.username.len == 0)) {
+        // Check for authentication: token, OR auth/user (username:password), OR URL-embedded credentials
+        if (registry.token.len == 0 and (registry.auth.len == 0 or registry.user.len == 0) and (registry.url.password.len == 0 or registry.url.username.len == 0)) {
             return error.NeedAuth;
         }
 

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -967,3 +967,93 @@ describe("--tolerate-republish", async () => {
     expect(err).not.toContain("error:");
   });
 });
+
+describe("split npmrc authentication", () => {
+  const authFormats = [
+    {
+      name: "split username and password",
+      scope: null,
+      packageName: "split-username-password-test",
+      async createNpmrc(registry: VerdaccioRegistry) {
+        const username = "testuser";
+        const password = "testpass123";
+        await registry.generateUser(username, password);
+
+        return `registry=http://localhost:${registry.port}/
+//localhost:${registry.port}/:username=${username}
+//localhost:${registry.port}/:_password=${Buffer.from(password).toString("base64")}
+//localhost:${registry.port}/:email=${username}@example.com
+`;
+      },
+    },
+    {
+      name: "split username and password with scoped registry",
+      scope: "@scoped",
+      packageName: "@scoped/split-scoped-test",
+      async createNpmrc(registry: VerdaccioRegistry) {
+        const username = "scopeduser";
+        const password = "scopedpass456";
+        await registry.generateUser(username, password);
+
+        return `@scoped:registry=http://localhost:${registry.port}/
+//localhost:${registry.port}/:username=${username}
+//localhost:${registry.port}/:_password=${Buffer.from(password).toString("base64")}
+//localhost:${registry.port}/:email=${username}@example.com
+`;
+      },
+    },
+    {
+      name: "split _authToken",
+      scope: null,
+      packageName: "split-authtoken-test",
+      async createNpmrc(registry: VerdaccioRegistry) {
+        const token = await registry.generateUser("tokenuser", "tokenpass");
+
+        return `registry=http://localhost:${registry.port}/
+//localhost:${registry.port}/:_authToken=${token}
+`;
+      },
+    },
+    {
+      name: "split _authToken with scoped registry",
+      scope: "@scoped",
+      packageName: "@scoped/split-token-test",
+      async createNpmrc(registry: VerdaccioRegistry) {
+        const token = await registry.generateUser("scopedtokenuser", "scopedtokenpass");
+
+        return `@scoped:registry=http://localhost:${registry.port}/
+//localhost:${registry.port}/:_authToken=${token}
+`;
+      },
+    },
+  ];
+
+  for (const format of authFormats) {
+    test(`should authenticate with ${format.name}`, async () => {
+      const { packageDir, packageJson } = await registry.createTestDir();
+      const npmrcContent = await format.createNpmrc(registry);
+
+      const pkgJson = {
+        name: format.packageName,
+        version: "1.0.0",
+      };
+
+      const cleanupPath = format.scope
+        ? join(registry.packagesPath, format.scope, format.packageName.split('/')[1])
+        : join(registry.packagesPath, format.packageName);
+
+      await Promise.all([
+        rm(cleanupPath, { recursive: true, force: true }),
+        write(join(packageDir, ".npmrc"), npmrcContent),
+        write(packageJson, JSON.stringify(pkgJson)),
+      ]);
+
+      const { out, err, exitCode } = await publish(env, packageDir);
+
+      expect(exitCode).toBe(0);
+      expect(out).toContain(`+ ${format.packageName}@1.0.0`);
+      expect(err).not.toContain("missing authentication");
+    });
+  }
+});
+

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1039,7 +1039,7 @@ describe("split npmrc authentication", () => {
       };
 
       const cleanupPath = format.scope
-        ? join(registry.packagesPath, format.scope, format.packageName.split('/')[1])
+        ? join(registry.packagesPath, format.scope, format.packageName.split("/")[1])
         : join(registry.packagesPath, format.packageName);
 
       await Promise.all([
@@ -1050,10 +1050,9 @@ describe("split npmrc authentication", () => {
 
       const { out, err, exitCode } = await publish(env, packageDir);
 
-      expect(exitCode).toBe(0);
       expect(out).toContain(`+ ${format.packageName}@1.0.0`);
       expect(err).not.toContain("missing authentication");
+      expect(exitCode).toBe(0);
     });
   }
 });
-


### PR DESCRIPTION
### What does this PR do?

Fixes `bun publish` failing with "error: missing authentication" despite valid `.npmrc` credentials, while `bun install` and `npm publish` both work fine with the same configuration. Updates the auth check to accept the `registry.auth` and `registry.user` combination that gets set.

This specifically affects split username/password authentication like:
```npmrc
//registry.example.com/:username=myuser
//registry.example.com/:_password=base64encodedpass
```

#### Related Issues
- #24124
- #18670

### How did you verify your code works?

New auth tests in `test/cli/install/bun-publish.test.ts`, four new tests verify different `.npmrc` authentication formats:
  - Split username/password with default registry (**fails on current release**)
  - Split username/password with scoped registry (**fails on current release**)
  - Split `_authToken` with default registry (already worked, but expanded coverage)
  - Split `_authToken` with scoped registry (already worked, but expanded coverage)

Manual testing with debug release:

Tested publishing to a private JFrog Artifactory registry using split username/password in `.npmrc`:
```npmrc
@scope:registry=https://registry.example.com/npm/
//registry.example.com/npm/:username=myuser
//registry.example.com/npm/:_password=mysecurebase64encodedpass
```

Before fix: ❌ `error: missing authentication`
After fix:    ✅ `   + @scope/abcefg@0.1.0-rc.0` 
