### PR TITLE
fix(bake): respect --no-clear-screen in DevServer HMR

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -2845,7 +2845,7 @@ pub fn finalizeBundle(
 
     if (dev.bundling_failures.count() == 0) {
         if (current_bundle.had_reload_event) {
-            const clear_terminal = !debug.isVisible();
+            const clear_terminal = !debug.isVisible() and !dev.vm.transpiler.env.hasSetNoClearTerminalOnReload(false);
             if (clear_terminal) {
                 Output.disableBuffering();
                 Output.resetTerminalAll();


### PR DESCRIPTION
## Summary

- Fix `--no-clear-screen` and `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD` not working with `Bun.serve` when `hmr: true`

The DevServer was only checking `debug.isVisible()` to decide whether to clear the terminal during HMR reloads, ignoring the user's preference set via the CLI flag or environment variable.

## Test plan

- [x] Build succeeds
- [x] Existing hot reload tests pass (`test/bake/dev/hot.test.ts`)
- [x] Manual verification: terminal is not cleared when `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD=1` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)