### PR TITLE
TestContext not passed to hooks in node:test

### DIFF
--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -380,7 +380,6 @@ function createHook(arg0: unknown, arg1: unknown, context?: TestContext) {
   const runHook = (done: (error?: unknown) => void) => {
     let result: unknown;
     try {
-      // Passar o contexto se disponível, caso contrário chamar sem argumentos
       result = context ? fn(context) : fn();
     } catch (error) {
       done(error);

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -115,25 +115,25 @@ class TestContext {
   }
 
   before(arg0: unknown, arg1: unknown) {
-    const { fn } = createHook(arg0, arg1);
+    const { fn } = createHook(arg0, arg1, this);
     const { beforeAll } = bunTest();
     beforeAll(fn);
   }
 
   after(arg0: unknown, arg1: unknown) {
-    const { fn } = createHook(arg0, arg1);
+    const { fn } = createHook(arg0, arg1, this);
     const { afterAll } = bunTest();
     afterAll(fn);
   }
 
   beforeEach(arg0: unknown, arg1: unknown) {
-    const { fn } = createHook(arg0, arg1);
+    const { fn } = createHook(arg0, arg1, this);
     const { beforeEach } = bunTest();
     beforeEach(fn);
   }
 
   afterEach(arg0: unknown, arg1: unknown) {
-    const { fn } = createHook(arg0, arg1);
+    const { fn } = createHook(arg0, arg1, this);
     const { afterEach } = bunTest();
     afterEach(fn);
   }
@@ -374,13 +374,14 @@ function parseHookOptions(arg0: unknown, arg1: unknown) {
   return { fn, options };
 }
 
-function createHook(arg0: unknown, arg1: unknown) {
+function createHook(arg0: unknown, arg1: unknown, context?: TestContext) {
   const { fn, options } = parseHookOptions(arg0, arg1);
 
   const runHook = (done: (error?: unknown) => void) => {
     let result: unknown;
     try {
-      result = fn();
+      // Passar o contexto se disponível, caso contrário chamar sem argumentos
+      result = context ? fn(context) : fn();
     } catch (error) {
       done(error);
       return;
@@ -396,7 +397,7 @@ function createHook(arg0: unknown, arg1: unknown) {
 }
 
 type TestFn = (ctx: TestContext) => unknown | Promise<unknown>;
-type HookFn = () => unknown | Promise<unknown>;
+type HookFn = (ctx?: TestContext) => unknown | Promise<unknown>;
 
 type TestOptions = {
   concurrency?: number | boolean | null;


### PR DESCRIPTION
This PR fixes https://github.com/oven-sh/bun/issues/26170

## What does this PR do?

This PR fixes a bug where `TestContext` was not being passed to hook functions when using `t.after()`, `t.afterEach()`, `t.before()`, and `t.beforeEach()` in the `node:test` module.

### The Problem

When registering hooks via `TestContext` methods (e.g., `t.after((ctx) => ctx.diagnostic(...))`), the hook function was not receiving the `TestContext` as a parameter, causing `TypeError: undefined is not an object (evaluating 't.diagnostic')` errors.

### The Solution

The fix modifies the `createHook()` function to accept an optional `TestContext` parameter and pass it to the hook function when available. The changes include:

1. **Updated hook methods** to pass `this` (the `TestContext` instance) to `createHook()`:
   - `TestContext.before()` 
   - `TestContext.after()`
   - `TestContext.beforeEach()`
   - `TestContext.afterEach()`

2. **Modified `createHook()` function** to accept an optional `context?: TestContext` parameter and pass it to the hook function when calling it.

3. **Updated type definition** for `HookFn` to accept an optional `TestContext` parameter: `(ctx?: TestContext) => unknown | Promise<unknown>`

4. **Maintained backward compatibility** - hooks that don't expect a context parameter continue to work as before.

### Example

**Before (broken):**
```typescript
test('example test', async (t) => {
  t.after((t) => {
    t.diagnostic(`finished running ${t.name}`); // TypeError: t is undefined
  });
});
```

**After (fixed):**
```typescript
test('example test', async (t) => {
  t.after((t) => {
    t.diagnostic(`finished running ${t.name}`); // Works correctly!
  });
});
```

## How did you verify your code works?

1. **Created comprehensive tests** in `execution-test/test-context-hooks.test.ts` that verify:
   - `after()` hook receives `TestContext` correctly
   - `afterEach()` hook receives `TestContext` correctly
   - Original bug case from issue report now works
   - Backward compatibility (hooks without context parameter still work)
   - Context properties are accessible in hooks
   - Multiple hooks with context work correctly
   - Async hooks with context work correctly
   - Context verification in various scenarios

2. **Verified the original bug is fixed:**
   ```bash
   bun bd test ./execution-test/test.test.ts
   ```
   The test that previously failed with `TypeError: undefined is not an object (evaluating 't.diagnostic')` now passes successfully.

3. **Ran all new tests:**
   ```bash
   bun bd test ./execution-test/test-context-hooks.test.ts
   ```
   All 8 tests pass, confirming that:
   - `TestContext` is correctly passed to hooks
   - All context properties (name, filePath, signal, assert) are accessible
   - Backward compatibility is maintained
   - Async hooks work correctly

4. **Tested with the original issue reproduction case:**
   ```typescript
   import { test } from 'node:test';
   
   test('example test', async (t) => {
     t.after((t) => t.diagnostic(`finished running ${t.name}`));
     console.log('Hello World');
   });
   ```
   This now works correctly, printing both "Hello World" and "finished running example test" as expected.

## Changes Made

- `src/js/node/test.ts`:
  - Modified `TestContext.before()`, `after()`, `beforeEach()`, and `afterEach()` to pass `this` to `createHook()`
  - Updated `createHook()` function signature to accept optional `context?: TestContext` parameter
  - Modified hook execution to pass context when available: `result = context ? fn(context) : fn()`
  - Updated `HookFn` type to accept optional `TestContext` parameter

## Related Issue
https://github.com/oven-sh/bun/issues/26170
