### PR TITLE
feat(ci): bake build dependencies into CI images

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -136,7 +136,64 @@ set -efu
 export BUILDKITE_BUILD_CHECKOUT_PATH=/var/lib/buildkite-agent/build
 EOF
 
-RUN chmod 744 /var/lib/buildkite-agent/hooks/environment
+# Checkout hook - uses git fetch instead of clone when repo exists
+RUN cat <<'EOF' > /var/lib/buildkite-agent/hooks/checkout
+#!/bin/sh
+set -efu
+
+CHECKOUT_PATH="${BUILDKITE_BUILD_CHECKOUT_PATH}"
+COMMIT="${BUILDKITE_COMMIT}"
+REPO="${BUILDKITE_REPO}"
+
+echo "--- :git: Checkout"
+
+if [ -d "${CHECKOUT_PATH}/.git" ]; then
+    echo "Repository exists, using git fetch..."
+    cd "${CHECKOUT_PATH}"
+    git fetch --depth=1 origin "${COMMIT}" || git fetch origin "${COMMIT}"
+    git reset --hard
+    git clean -fdx -e 'build/' -e 'vendor/zig/'
+    git checkout -f "${COMMIT}"
+else
+    echo "Repository does not exist, cloning..."
+    git clone --depth=1 "${REPO}" "${CHECKOUT_PATH}"
+    cd "${CHECKOUT_PATH}"
+    git fetch --depth=1 origin "${COMMIT}" || git fetch origin "${COMMIT}"
+    git checkout -f "${COMMIT}"
+fi
+
+echo "Checked out ${COMMIT}"
+EOF
+
+# Pre-command hook - removes node_modules before each build
+RUN cat <<'EOF' > /var/lib/buildkite-agent/hooks/pre-command
+#!/bin/sh
+set -eu
+
+CHECKOUT_PATH="${BUILDKITE_BUILD_CHECKOUT_PATH}"
+
+if [ -d "${CHECKOUT_PATH}/node_modules" ]; then
+    echo "Removing existing node_modules..."
+    rm -rf "${CHECKOUT_PATH}/node_modules"
+fi
+EOF
+
+RUN chmod 755 /var/lib/buildkite-agent/hooks/environment \
+    && chmod 755 /var/lib/buildkite-agent/hooks/checkout \
+    && chmod 755 /var/lib/buildkite-agent/hooks/pre-command
+
+# Clone Bun repository and pre-download dependencies
+# This avoids downloading dependencies during each CI build
+RUN git clone --depth=1 https://github.com/oven-sh/bun.git /var/lib/buildkite-agent/build
+
+WORKDIR /var/lib/buildkite-agent/build
+
+# Install dependencies and run cmake configure to download build dependencies
+RUN bun install --frozen-lockfile && \
+    mkdir -p build/release && \
+    cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=Release -DCI=ON && \
+    rm -rf build/release/CMakeFiles build/release/CMakeCache.txt build/release/cmake_install.cmake && \
+    rm -rf node_modules
 
 COPY  ../*/agent.mjs /var/bun/scripts/
 

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -182,20 +182,14 @@ RUN chmod 755 /var/lib/buildkite-agent/hooks/environment \
     && chmod 755 /var/lib/buildkite-agent/hooks/checkout \
     && chmod 755 /var/lib/buildkite-agent/hooks/pre-command
 
-# Clone Bun repository and pre-download dependencies
+# Pre-download the bake-dependencies script and run it
+# The script handles: cloning repo, installing deps, running cmake, downloading build deps
 # This avoids downloading dependencies during each CI build
-RUN git clone --depth=1 https://github.com/oven-sh/bun.git /var/lib/buildkite-agent/build
+RUN curl -fsSL https://raw.githubusercontent.com/oven-sh/bun/main/scripts/bake-dependencies.sh -o /tmp/bake-dependencies.sh && \
+    BUN_REPO_PATH=/var/lib/buildkite-agent/build sh /tmp/bake-dependencies.sh && \
+    rm /tmp/bake-dependencies.sh
 
 WORKDIR /var/lib/buildkite-agent/build
-
-# Install dependencies, generate source lists, and run cmake configure to download build dependencies
-# Keep cmake/ninja files so subsequent builds can skip already-downloaded dependencies
-RUN bun install --frozen-lockfile && \
-    bun run scripts/glob-sources.mjs && \
-    mkdir -p build/release && \
-    cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=Release -DCI=ON && \
-    cmake --build build/release --target clone-zig clone-boringssl clone-mimalloc clone-zstd clone-lolhtml clone-cares clone-libdeflate clone-libarchive clone-tinycc clone-zlib clone-lshpack clone-brotli clone-highway clone-hdrhistogram clone-picohttpparser || true && \
-    rm -rf node_modules
 
 COPY  ../*/agent.mjs /var/bun/scripts/
 

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -152,7 +152,7 @@ if [ -d "${CHECKOUT_PATH}/.git" ]; then
     cd "${CHECKOUT_PATH}"
     git fetch --depth=1 origin "${COMMIT}" || git fetch origin "${COMMIT}"
     git reset --hard
-    git clean -fdx -e 'build/' -e 'vendor/zig/'
+    git clean -fdx -e 'build/' -e 'vendor/'
     git checkout -f "${COMMIT}"
 else
     echo "Repository does not exist, cloning..."
@@ -188,11 +188,13 @@ RUN git clone --depth=1 https://github.com/oven-sh/bun.git /var/lib/buildkite-ag
 
 WORKDIR /var/lib/buildkite-agent/build
 
-# Install dependencies and run cmake configure to download build dependencies
+# Install dependencies, generate source lists, and run cmake configure to download build dependencies
 RUN bun install --frozen-lockfile && \
+    bun run scripts/glob-sources.mjs && \
     mkdir -p build/release && \
     cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=Release -DCI=ON && \
-    rm -rf build/release/CMakeFiles build/release/CMakeCache.txt build/release/cmake_install.cmake && \
+    cmake --build build/release --target clone-zig clone-boringssl clone-mimalloc clone-zstd clone-lolhtml clone-cares clone-libdeflate clone-libarchive clone-tinycc clone-zlib clone-lshpack clone-brotli clone-highway clone-hdrhistogram clone-picohttpparser || true && \
+    rm -rf build/release/CMakeFiles build/release/CMakeCache.txt build/release/cmake_install.cmake build/release/build.ninja build/release/compile_commands.json && \
     rm -rf node_modules
 
 COPY  ../*/agent.mjs /var/bun/scripts/

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -189,12 +189,12 @@ RUN git clone --depth=1 https://github.com/oven-sh/bun.git /var/lib/buildkite-ag
 WORKDIR /var/lib/buildkite-agent/build
 
 # Install dependencies, generate source lists, and run cmake configure to download build dependencies
+# Keep cmake/ninja files so subsequent builds can skip already-downloaded dependencies
 RUN bun install --frozen-lockfile && \
     bun run scripts/glob-sources.mjs && \
     mkdir -p build/release && \
     cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=Release -DCI=ON && \
     cmake --build build/release --target clone-zig clone-boringssl clone-mimalloc clone-zstd clone-lolhtml clone-cares clone-libdeflate clone-libarchive clone-tinycc clone-zlib clone-lshpack clone-brotli clone-highway clone-hdrhistogram clone-picohttpparser || true && \
-    rm -rf build/release/CMakeFiles build/release/CMakeCache.txt build/release/cmake_install.cmake build/release/build.ninja build/release/compile_commands.json && \
     rm -rf node_modules
 
 COPY  ../*/agent.mjs /var/bun/scripts/

--- a/.github/workflows/ci-images.yml
+++ b/.github/workflows/ci-images.yml
@@ -1,0 +1,106 @@
+name: Rebuild CI Images
+
+on:
+  schedule:
+    # Run daily at 4 AM UTC
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: 'Platforms to rebuild (comma-separated, or "all")'
+        required: false
+        default: "all"
+        type: string
+
+jobs:
+  # Determine which platforms to build
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      platforms: ${{ steps.set-matrix.outputs.platforms }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: set-matrix
+        run: |
+          if [ "${{ github.event.inputs.platforms }}" = "all" ] || [ -z "${{ github.event.inputs.platforms }}" ]; then
+            # All platforms used in CI
+            echo 'platforms=["linux-x64-debian-12","linux-x64-amazonlinux-2023","linux-x64-alpine-3.22","linux-aarch64-debian-12","linux-aarch64-amazonlinux-2023","linux-aarch64-alpine-3.22"]' >> $GITHUB_OUTPUT
+          else
+            # Convert comma-separated to JSON array
+            platforms=$(echo '${{ github.event.inputs.platforms }}' | jq -R -s -c 'split(",") | map(gsub("^\\s+|\\s+$";""))')
+            echo "platforms=$platforms" >> $GITHUB_OUTPUT
+          fi
+
+  rebuild:
+    needs: matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJson(needs.matrix.outputs.platforms) }}
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Parse platform
+        id: parse
+        run: |
+          platform="${{ matrix.platform }}"
+          # Parse platform string like "linux-x64-debian-12" or "linux-aarch64-alpine-3.22"
+          os=$(echo "$platform" | cut -d'-' -f1)
+          arch=$(echo "$platform" | cut -d'-' -f2)
+          distro=$(echo "$platform" | cut -d'-' -f3)
+          release=$(echo "$platform" | cut -d'-' -f4)
+
+          echo "os=$os" >> $GITHUB_OUTPUT
+          echo "arch=$arch" >> $GITHUB_OUTPUT
+          echo "distro=$distro" >> $GITHUB_OUTPUT
+          echo "release=$release" >> $GITHUB_OUTPUT
+
+      - name: Get bootstrap version
+        id: version
+        run: |
+          version=$(grep -E '^# Version: [0-9]+' scripts/bootstrap.sh | grep -oE '[0-9]+')
+          echo "version=v${version}" >> $GITHUB_OUTPUT
+          echo "Bootstrap version: v${version}"
+
+      - name: Rebuild and publish image
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          OS: ${{ steps.parse.outputs.os }}
+          ARCH: ${{ steps.parse.outputs.arch }}
+          DISTRO: ${{ steps.parse.outputs.distro }}
+          RELEASE: ${{ steps.parse.outputs.release }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          echo "Rebuilding CI image for $PLATFORM (version $VERSION)"
+
+          # Build and publish the image
+          # This will create/overwrite the AMI with name like "linux-x64-debian-12-v27"
+          bun run scripts/machine.mjs \
+            --os "$OS" \
+            --arch "$ARCH" \
+            --distro "$DISTRO" \
+            --release "$RELEASE" \
+            --ci \
+            publish-image
+
+      - name: Summary
+        run: |
+          echo "## Rebuilt CI Image" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Platform:** ${{ matrix.platform }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Date:** $(date -u +%Y-%m-%d)" >> $GITHUB_STEP_SUMMARY

--- a/scripts/bake-dependencies.sh
+++ b/scripts/bake-dependencies.sh
@@ -60,13 +60,13 @@ ABI="$(detect_abi)"
 
 # Default paths - these should match what the buildkite agent uses
 BUN_REPO_PATH="${BUN_REPO_PATH:-/var/lib/buildkite-agent/build}"
-BUILD_TYPE="${BUILD_TYPE:-release}"
+BUILD_DIR="${BUILD_DIR:-release}"
 
 print "=== Bun Dependency Baking Script ==="
 print "Architecture: $ARCH"
 print "ABI: ${ABI:-glibc}"
 print "Repository path: $BUN_REPO_PATH"
-print "Build type: $BUILD_TYPE"
+print "Build directory: $BUILD_DIR"
 
 # Clone the Bun repository if it doesn't exist
 if [ ! -d "$BUN_REPO_PATH/.git" ]; then
@@ -90,7 +90,7 @@ print "Generating cmake source lists..."
 bun run scripts/glob-sources.mjs
 
 # Set up build directory
-BUILD_PATH="$BUN_REPO_PATH/build/$BUILD_TYPE"
+BUILD_PATH="$BUN_REPO_PATH/build/$BUILD_DIR"
 CACHE_PATH="$BUILD_PATH/cache"
 mkdir -p "$BUILD_PATH" "$CACHE_PATH"
 

--- a/scripts/bake-dependencies.sh
+++ b/scripts/bake-dependencies.sh
@@ -1,0 +1,158 @@
+#!/bin/sh
+# Version: 1
+#
+# This script pre-downloads all build dependencies into the image.
+# It should be run during AMI baking to avoid downloading dependencies
+# during each CI build.
+#
+# Dependencies downloaded:
+# - Zig compiler
+# - WebKit (JavaScriptCore)
+# - BoringSSL
+# - And other cmake-managed dependencies
+
+set -eu
+
+print() {
+    echo "$@"
+}
+
+error() {
+    print "error: $@" >&2
+    exit 1
+}
+
+# Detect architecture
+detect_arch() {
+    arch="$(uname -m)"
+    case "$arch" in
+    x86_64 | x64 | amd64)
+        echo "x64"
+        ;;
+    aarch64 | arm64)
+        echo "aarch64"
+        ;;
+    *)
+        error "Unsupported architecture: $arch"
+        ;;
+    esac
+}
+
+# Detect ABI (glibc vs musl)
+detect_abi() {
+    if [ -f "/etc/alpine-release" ]; then
+        echo "musl"
+    else
+        ldd_output="$(ldd --version 2>&1 || true)"
+        case "$ldd_output" in
+        *musl*)
+            echo "musl"
+            ;;
+        *)
+            echo ""
+            ;;
+        esac
+    fi
+}
+
+ARCH="$(detect_arch)"
+ABI="$(detect_abi)"
+
+# Default paths - these should match what the buildkite agent uses
+BUN_REPO_PATH="${BUN_REPO_PATH:-/var/lib/buildkite-agent/build}"
+BUILD_TYPE="${BUILD_TYPE:-release}"
+
+print "=== Bun Dependency Baking Script ==="
+print "Architecture: $ARCH"
+print "ABI: ${ABI:-glibc}"
+print "Repository path: $BUN_REPO_PATH"
+print "Build type: $BUILD_TYPE"
+
+# Clone the Bun repository if it doesn't exist
+if [ ! -d "$BUN_REPO_PATH/.git" ]; then
+    print "Cloning Bun repository..."
+    git clone --depth=1 https://github.com/oven-sh/bun.git "$BUN_REPO_PATH"
+else
+    print "Bun repository already exists, updating..."
+    cd "$BUN_REPO_PATH"
+    git fetch --depth=1 origin main
+    git checkout FETCH_HEAD
+fi
+
+cd "$BUN_REPO_PATH"
+
+# Install npm dependencies (will be cleaned later, but needed for codegen)
+print "Installing npm dependencies..."
+bun install --frozen-lockfile
+
+# Set up build directory
+BUILD_PATH="$BUN_REPO_PATH/build/$BUILD_TYPE"
+CACHE_PATH="$BUILD_PATH/cache"
+mkdir -p "$BUILD_PATH" "$CACHE_PATH"
+
+print "Build path: $BUILD_PATH"
+print "Cache path: $CACHE_PATH"
+
+# Run cmake configure to download all dependencies
+# This will download: Zig, WebKit, BoringSSL, and all other dependencies
+print "Running CMake configure to download dependencies..."
+
+CMAKE_ARGS="-S $BUN_REPO_PATH -B $BUILD_PATH"
+CMAKE_ARGS="$CMAKE_ARGS -G Ninja"
+CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release"
+CMAKE_ARGS="$CMAKE_ARGS -DCI=ON"
+
+if [ -n "$ABI" ]; then
+    CMAKE_ARGS="$CMAKE_ARGS -DABI=$ABI"
+fi
+
+# Run cmake configure - this downloads all dependencies
+cmake $CMAKE_ARGS
+
+# Also download debug WebKit variant for debug builds
+print "Downloading debug WebKit variant..."
+cmake $CMAKE_ARGS -DCMAKE_BUILD_TYPE=Debug -B "$BUN_REPO_PATH/build/debug" || true
+
+# Clean up build artifacts but keep downloaded dependencies
+print "Cleaning up build artifacts..."
+rm -rf "$BUILD_PATH/CMakeFiles" "$BUILD_PATH/CMakeCache.txt" "$BUILD_PATH/cmake_install.cmake"
+rm -rf "$BUN_REPO_PATH/build/debug/CMakeFiles" "$BUN_REPO_PATH/build/debug/CMakeCache.txt" 2>/dev/null || true
+
+# Remove node_modules - will be reinstalled during actual builds
+print "Removing node_modules..."
+rm -rf "$BUN_REPO_PATH/node_modules"
+
+# List what was downloaded
+print ""
+print "=== Downloaded Dependencies ==="
+if [ -d "$BUN_REPO_PATH/vendor/zig" ]; then
+    print "✓ Zig compiler: $(ls -la "$BUN_REPO_PATH/vendor/zig/zig" 2>/dev/null | awk '{print $5}' || echo 'present')"
+fi
+if [ -d "$CACHE_PATH/webkit-"* ] 2>/dev/null; then
+    print "✓ WebKit: $(du -sh "$CACHE_PATH"/webkit-* 2>/dev/null | head -1 || echo 'present')"
+fi
+if [ -d "$BUILD_PATH/boringssl" ]; then
+    print "✓ BoringSSL: present"
+fi
+if [ -d "$BUILD_PATH/mimalloc" ]; then
+    print "✓ mimalloc: present"
+fi
+if [ -d "$BUILD_PATH/zstd" ]; then
+    print "✓ zstd: present"
+fi
+if [ -d "$BUILD_PATH/lol-html" ]; then
+    print "✓ lol-html: present"
+fi
+
+# Calculate total size
+TOTAL_SIZE="$(du -sh "$BUN_REPO_PATH" 2>/dev/null | cut -f1 || echo 'unknown')"
+print ""
+print "Total repository size: $TOTAL_SIZE"
+
+print ""
+print "=== Dependency baking complete ==="
+print "The following will happen during CI builds:"
+print "  1. git fetch origin <commit> (instead of full clone)"
+print "  2. git checkout <commit>"
+print "  3. rm -rf node_modules && bun install"
+print "  4. Build will use pre-downloaded dependencies"

--- a/scripts/bake-dependencies.sh
+++ b/scripts/bake-dependencies.sh
@@ -18,7 +18,7 @@ print() {
 }
 
 error() {
-    print "error: $@" >&2
+    printf 'error: %s\n' "$*" >&2
     exit 1
 }
 
@@ -103,13 +103,13 @@ print "Running CMake configure to download dependencies..."
 
 # Run cmake configure - this downloads WebKit
 if [ -n "$ABI" ]; then
-    cmake -S "$BUN_REPO_PATH" -B "$BUILD_PATH" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCI=ON -DABI="$ABI"
+    if ! cmake -S "$BUN_REPO_PATH" -B "$BUILD_PATH" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCI=ON -DABI="$ABI"; then
+        error "CMake configure failed for release build"
+    fi
 else
-    cmake -S "$BUN_REPO_PATH" -B "$BUILD_PATH" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCI=ON
-fi
-
-if [ $? -ne 0 ]; then
-    error "CMake configure failed for release build"
+    if ! cmake -S "$BUN_REPO_PATH" -B "$BUILD_PATH" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCI=ON; then
+        error "CMake configure failed for release build"
+    fi
 fi
 
 # Run cmake build for clone targets only - this downloads Zig, BoringSSL, etc.
@@ -124,13 +124,13 @@ fi
 # Also download debug WebKit variant for debug builds
 print "Downloading debug WebKit variant..."
 if [ -n "$ABI" ]; then
-    cmake -S "$BUN_REPO_PATH" -B "$BUN_REPO_PATH/build/debug" -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCI=ON -DABI="$ABI"
+    if ! cmake -S "$BUN_REPO_PATH" -B "$BUN_REPO_PATH/build/debug" -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCI=ON -DABI="$ABI"; then
+        error "CMake configure failed for debug build"
+    fi
 else
-    cmake -S "$BUN_REPO_PATH" -B "$BUN_REPO_PATH/build/debug" -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCI=ON
-fi
-
-if [ $? -ne 0 ]; then
-    error "CMake configure failed for debug build"
+    if ! cmake -S "$BUN_REPO_PATH" -B "$BUN_REPO_PATH/build/debug" -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCI=ON; then
+        error "CMake configure failed for debug build"
+    fi
 fi
 
 # Keep cmake/ninja files so subsequent builds don't re-download dependencies

--- a/scripts/bake-dependencies.sh
+++ b/scripts/bake-dependencies.sh
@@ -122,10 +122,9 @@ cmake --build "$BUILD_PATH" --target clone-zig clone-boringssl clone-mimalloc cl
 print "Downloading debug WebKit variant..."
 cmake $CMAKE_ARGS -DCMAKE_BUILD_TYPE=Debug -B "$BUN_REPO_PATH/build/debug" || true
 
-# Clean up build artifacts but keep downloaded dependencies
-print "Cleaning up build artifacts..."
-rm -rf "$BUILD_PATH/CMakeFiles" "$BUILD_PATH/CMakeCache.txt" "$BUILD_PATH/cmake_install.cmake" "$BUILD_PATH/build.ninja" "$BUILD_PATH/compile_commands.json" "$BUILD_PATH/.ninja_deps" "$BUILD_PATH/.ninja_log"
-rm -rf "$BUN_REPO_PATH/build/debug/CMakeFiles" "$BUN_REPO_PATH/build/debug/CMakeCache.txt" "$BUN_REPO_PATH/build/debug/build.ninja" 2>/dev/null || true
+# Keep cmake/ninja files so subsequent builds don't re-download dependencies
+# The ninja build system tracks what's been built - removing these files causes re-downloads
+print "Keeping build system files for caching..."
 
 # Remove node_modules - will be reinstalled during actual builds
 print "Removing node_modules..."

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1485,7 +1485,7 @@ if [ -d "${CHECKOUT_PATH}/.git" ]; then
 
     # Clean up any local changes
     git reset --hard
-    git clean -fdx -e 'build/' -e 'vendor/zig/'
+    git clean -fdx -e 'build/' -e 'vendor/'
 
     # Checkout the commit
     git checkout -f "${COMMIT}"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Version: 26
+# Version: 27
 
 # A script that installs the dependencies needed to build and test Bun.
 # This should work on macOS and Linux with a POSIX shell.
@@ -1455,13 +1455,69 @@ create_buildkite_user() {
 	# reasons.
 	local hook_dir=${home}/hooks
 	mkdir -p -m 755 "${hook_dir}"
+
+	# Environment hook - sets checkout path
 	cat << EOF > "${hook_dir}/environment"
 #!/bin/sh
 set -efu
 
 export BUILDKITE_BUILD_CHECKOUT_PATH=${home}/build
 EOF
+
+	# Checkout hook - uses git fetch instead of clone when repo exists
+	# This works with the pre-baked repository from bake-dependencies.sh
+	cat << 'CHECKOUT_EOF' > "${hook_dir}/checkout"
+#!/bin/sh
+set -efu
+
+CHECKOUT_PATH="${BUILDKITE_BUILD_CHECKOUT_PATH}"
+COMMIT="${BUILDKITE_COMMIT}"
+REPO="${BUILDKITE_REPO}"
+
+echo "--- :git: Checkout"
+
+if [ -d "${CHECKOUT_PATH}/.git" ]; then
+    echo "Repository exists, using git fetch..."
+    cd "${CHECKOUT_PATH}"
+
+    # Fetch the specific commit
+    git fetch --depth=1 origin "${COMMIT}" || git fetch origin "${COMMIT}"
+
+    # Clean up any local changes
+    git reset --hard
+    git clean -fdx -e 'build/' -e 'vendor/zig/'
+
+    # Checkout the commit
+    git checkout -f "${COMMIT}"
+else
+    echo "Repository does not exist, cloning..."
+    git clone --depth=1 "${REPO}" "${CHECKOUT_PATH}"
+    cd "${CHECKOUT_PATH}"
+    git fetch --depth=1 origin "${COMMIT}" || git fetch origin "${COMMIT}"
+    git checkout -f "${COMMIT}"
+fi
+
+echo "Checked out ${COMMIT}"
+CHECKOUT_EOF
+
+	# Pre-command hook - removes node_modules before bun install
+	cat << 'PRECOMMAND_EOF' > "${hook_dir}/pre-command"
+#!/bin/sh
+set -eu
+
+CHECKOUT_PATH="${BUILDKITE_BUILD_CHECKOUT_PATH}"
+
+# Remove node_modules before each build to ensure clean state
+# Dependencies are re-installed via bun install
+if [ -d "${CHECKOUT_PATH}/node_modules" ]; then
+    echo "Removing existing node_modules..."
+    rm -rf "${CHECKOUT_PATH}/node_modules"
+fi
+PRECOMMAND_EOF
+
 	execute_sudo chmod +x "${hook_dir}/environment"
+	execute_sudo chmod +x "${hook_dir}/checkout"
+	execute_sudo chmod +x "${hook_dir}/pre-command"
 	execute_sudo chown -R "$user:$group" "$hook_dir"
 
 	set +ef -"$opts"
@@ -1669,6 +1725,24 @@ ensure_no_tmpfs() {
 	execute_sudo systemctl mask tmp.mount
 }
 
+bake_bun_dependencies() {
+	if ! [ "$ci" = "1" ]; then
+		return
+	fi
+
+	print "Baking Bun dependencies into image..."
+
+	# The bake script will clone Bun and download all build dependencies
+	# This includes: Zig, WebKit, BoringSSL, mimalloc, zstd, etc.
+	bake_script="$(dirname "$0")/bake-dependencies.sh"
+	if [ -f "$bake_script" ]; then
+		# Run as buildkite-agent user so files have correct ownership
+		execute_as_user "BUN_REPO_PATH=/var/lib/buildkite-agent/build sh $bake_script"
+	else
+		print "Warning: bake-dependencies.sh not found, skipping dependency baking"
+	fi
+}
+
 main() {
 	check_features "$@"
 	check_operating_system
@@ -1685,6 +1759,7 @@ main() {
 	if [ "${BUN_NO_CORE_DUMP:-0}" != "1" ]; then
 		configure_core_dumps
 	fi
+	bake_bun_dependencies
 	clean_system
 	ensure_no_tmpfs
 }


### PR DESCRIPTION
## Summary

- Pre-clone Bun repository into CI images
- Pre-download all build dependencies (Zig, WebKit, BoringSSL, mimalloc, zstd, lol-html, c-ares, etc.)
- Add buildkite hooks to use `git fetch` + `git checkout` instead of full clone
- Preserve downloaded dependencies with `git clean -fdx -e 'build/' -e 'vendor/'`
- Add GitHub Actions workflow to automatically rebuild CI images daily
- Fix AMI replacement to ensure no gap where image is unavailable

## Changes

1. **`scripts/bake-dependencies.sh`** (new) - Script to download all build dependencies during image baking
2. **`scripts/bootstrap.sh`** (v26→v27) - Added bake function and buildkite hooks
3. **`.buildkite/Dockerfile`** - Added hooks and dependency pre-download steps
4. **`.github/workflows/ci-images.yml`** (new) - Daily workflow to rebuild CI images
5. **`scripts/machine.mjs`** - Fix AMI replacement to create-then-deregister (no downtime)

## Test plan

- [ ] Verify bake-dependencies.sh downloads all dependencies correctly
- [ ] Verify CI builds use pre-downloaded dependencies (no "Downloading..." messages)
- [ ] Verify daily image rebuild workflow creates valid AMIs
- [ ] Verify AMI replacement has no gap where image is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)