### PR TITLE
fix: add null pointer guards to WebSocket functions

### DIFF
--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1122,7 +1122,7 @@ extern "C"
                                    const char **dest)
   {
     if (!ws) {
-      *dest = nullptr;
+      if (dest) *dest = nullptr;
       return 0;
     }
     if (ssl)
@@ -1145,7 +1145,7 @@ extern "C"
                                            const char **dest)
   {
     if (!ws) {
-      *dest = nullptr;
+      if (dest) *dest = nullptr;
       return 0;
     }
     if (ssl)

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -818,6 +818,7 @@ extern "C"
 
   void *uws_ws_get_user_data(int ssl, uws_websocket_t *ws)
   {
+    if (!ws) return nullptr;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -831,6 +832,7 @@ extern "C"
 
   void uws_ws_close(int ssl, uws_websocket_t *ws)
   {
+    if (!ws) return;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -848,6 +850,7 @@ extern "C"
   uws_sendstatus_t uws_ws_send(int ssl, uws_websocket_t *ws, const char *message,
                                size_t length, uws_opcode_t opcode)
   {
+    if (!ws) return (uws_sendstatus_t)uWS::SendStatus::DROPPED;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -866,6 +869,7 @@ extern "C"
                                             uws_opcode_t opcode, bool compress,
                                             bool fin)
   {
+    if (!ws) return (uws_sendstatus_t)uWS::SendStatus::DROPPED;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -889,6 +893,7 @@ extern "C"
                                         const char *message, size_t length,
                                         bool compress)
   {
+    if (!ws) return (uws_sendstatus_t)uWS::SendStatus::DROPPED;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -905,6 +910,7 @@ extern "C"
                                               const char *message, size_t length,
                                               bool compress)
   {
+    if (!ws) return (uws_sendstatus_t)uWS::SendStatus::DROPPED;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -922,6 +928,7 @@ extern "C"
                                          const char *message, size_t length,
                                          uws_opcode_t opcode, bool compress)
   {
+    if (!ws) return (uws_sendstatus_t)uWS::SendStatus::DROPPED;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -940,6 +947,7 @@ extern "C"
                                              const char *message, size_t length,
                                              bool compress)
   {
+    if (!ws) return (uws_sendstatus_t)uWS::SendStatus::DROPPED;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -956,6 +964,7 @@ extern "C"
   void uws_ws_end(int ssl, uws_websocket_t *ws, int code, const char *message,
                   size_t length)
   {
+    if (!ws) return;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -973,6 +982,7 @@ extern "C"
   void uws_ws_cork(int ssl, uws_websocket_t *ws, void (*handler)(void *user_data),
                    void *user_data)
   {
+    if (!ws) return;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -992,6 +1002,7 @@ extern "C"
   bool uws_ws_subscribe(int ssl, uws_websocket_t *ws, const char *topic,
                         size_t length)
   {
+    if (!ws) return false;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -1005,6 +1016,7 @@ extern "C"
   bool uws_ws_unsubscribe(int ssl, uws_websocket_t *ws, const char *topic,
                           size_t length)
   {
+    if (!ws) return false;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -1019,6 +1031,7 @@ extern "C"
   bool uws_ws_is_subscribed(int ssl, uws_websocket_t *ws, const char *topic,
                             size_t length)
   {
+    if (!ws) return false;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -1034,6 +1047,7 @@ extern "C"
                                               void *user_data),
                              void *user_data)
   {
+    if (!ws) return;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -1055,6 +1069,7 @@ extern "C"
                       size_t topic_length, const char *message,
                       size_t message_length)
   {
+    if (!ws) return false;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -1073,6 +1088,7 @@ extern "C"
                                    const char *message, size_t message_length,
                                    uws_opcode_t opcode, bool compress)
   {
+    if (!ws) return false;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -1090,6 +1106,7 @@ extern "C"
 
   size_t uws_ws_get_buffered_amount(int ssl, uws_websocket_t *ws)
   {
+    if (!ws) return 0;
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -1104,6 +1121,10 @@ extern "C"
   size_t uws_ws_get_remote_address(int ssl, uws_websocket_t *ws,
                                    const char **dest)
   {
+    if (!ws) {
+      *dest = nullptr;
+      return 0;
+    }
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -1123,6 +1144,10 @@ extern "C"
   size_t uws_ws_get_remote_address_as_text(int ssl, uws_websocket_t *ws,
                                            const char **dest)
   {
+    if (!ws) {
+      *dest = nullptr;
+      return 0;
+    }
     if (ssl)
     {
       TLSWebSocket *uws =
@@ -1857,6 +1882,7 @@ __attribute__((callback (corker, ctx)))
   }
 
   size_t uws_ws_memory_cost(int ssl, uws_websocket_t *ws) {
+    if (!ws) return 0;
     if (ssl) {
       return ((TLSWebSocket*)ws)->memoryCost();
     } else {


### PR DESCRIPTION
When a WebSocket connection is closed during a race condition (e.g - when broadcast events fire after a client has disconnected), the 
ws
 pointer passed to C++ functions can be null. Previously, this would cause an immediate segmentation fault at address 0x0.

This patch adds null pointer guards to all WebSocket-related functions in 
libuwsockets.cpp
. When a null pointer is detected, functions now return safe default values (DROPPED status for sends, 
false
 for boolean operations, 0 for size operations) instead of crashing.

Fixes #25944