### PR TITLE
fix(resolver): resolve tsconfig paths with .js extension pattern correctly

### DIFF
--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -3089,7 +3089,6 @@ pub const Resolver = struct {
                 var parts = [_]string{
                     prefix,
                     if (matched_text_with_suffix_len > 0) std.mem.trimLeft(u8, matched_text_with_suffix[0..matched_text_with_suffix_len], "/") else "",
-                    std.mem.trimLeft(u8, longest_match.suffix, "/"),
                 };
                 const absolute_original_path = r.fs.absBuf(
                     &parts,

--- a/test/regression/issue/26193.test.ts
+++ b/test/regression/issue/26193.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/26193
+// tsconfig paths with .js extension pattern were not resolved correctly
+test("tsconfig paths with .js extension pattern resolves correctly", async () => {
+  using dir = tempDir("issue-26193", {
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        paths: {
+          "@src/*.js": ["./src/*.ts"],
+        },
+      },
+    }),
+    "src/lib.ts": `export const greeting = "Hello";`,
+    "main.ts": `import { greeting } from "@src/lib.js";
+console.log(greeting);`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "main.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("Hello");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test("tsconfig paths with complex extension patterns", async () => {
+  using dir = tempDir("issue-26193-complex", {
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        paths: {
+          "@utils/*.js": ["./utils/*.ts"],
+          "@components/*.jsx": ["./components/*.tsx"],
+        },
+      },
+    }),
+    "utils/helper.ts": `export const helper = () => "helper";`,
+    "components/Button.tsx": `export const Button = () => "Button";`,
+    "main.ts": `import { helper } from "@utils/helper.js";
+import { Button } from "@components/Button.jsx";
+console.log(helper(), Button());`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "main.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("helper Button");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fixed tsconfig paths with `.js` extension patterns (e.g., `@src/*.js` -> `./src/*.ts`) not resolving correctly
- The resolver was incorrectly appending the pattern suffix (`.js`) to the resolved path, causing paths like `./src/lib.ts/.js` instead of `./src/lib.ts`
- The fix removes the erroneous append of `longest_match.suffix` since `matched_text_with_suffix` already contains the complete suffix from the target path

## Test plan

- [x] Added regression test in `test/regression/issue/26193.test.ts`
- [x] Verified test fails with system bun (without fix)
- [x] Verified test passes with debug build (with fix)
- [x] Existing tsconfig tests pass (`test/bundler/esbuild/tsconfig.test.ts`, `test/cli/run/tsconfig-override.test.ts`, `test/bundler/bundler_compile_autoload.test.ts`)

Fixes #26193

🤖 Generated with [Claude Code](https://claude.com/claude-code)