### PR TITLE
Remove dead data URL check in fetch implementation

### DIFF
--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -372,19 +372,6 @@ fn fetchImpl(
     }
     url_proxy_buffer = url.href;
 
-    if (url_str.hasPrefixComptime("data:")) {
-        var url_slice = url_str.toUTF8WithoutRef(allocator);
-        defer url_slice.deinit();
-
-        var data_url = DataURL.parseWithoutCheck(url_slice.slice()) catch {
-            const err = globalThis.createError("failed to fetch the data URL", .{});
-            return JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, err);
-        };
-        data_url.url = url_str;
-
-        return dataURLResponse(data_url, globalThis, allocator);
-    }
-
     // **Start with the harmless ones.**
 
     // "method"


### PR DESCRIPTION
## Summary
- Remove unreachable dead code that checked for data URLs in `fetchImpl()`
- Data URLs are already handled earlier in the function via the `dispatch_request` block which processes `.data` scheme URLs
- This redundant check at lines 375-387 could never be reached

## Test plan
- [ ] Verify existing fetch tests pass with `bun bd test test/js/web/fetch/`
- [ ] Confirm data URL fetching still works correctly (handled by earlier code path)

## Changelog
<!-- CHANGELOG:START -->
<!-- No user-facing changes - internal code cleanup only -->
<!-- CHANGELOG:END -->

🤖 Generated with [Claude Code](https://claude.com/claude-code) (100% 12-shotted by claude-opus-4-5)