### PR TITLE
gitignore: add .direnv dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .claude/settings.local.json
+.direnv
 .DS_Store
 .env
 .envrc


### PR DESCRIPTION
### What does this PR do?

The `.direnv` folder is created by [direnv](https://direnv.net/) when using `use flake` in `.envrc` to automatically load the Nix development shell. Since the repo already includes a flake.nix, developers on NixOS commonly use direnv (via nix-direnv) to auto-load the environment. This folder contains cached environment data and should not be committed.