### PR TITLE
fix(nix): disable fortify hardening for debug builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -131,6 +131,7 @@
           stdenv = pkgs.clangStdenv;
         }) {
           inherit packages;
+          hardeningDisable = [ "fortify" ];
 
           shellHook = ''
             # Set up build environment


### PR DESCRIPTION
### What does this PR do?

NixOS enables security hardening flags by default in `mkShell` / `devShells` e.g.  `_FORTIFY_SOURCE=2`. This flag adds runtime buffer overflow checks but requires compiler optimization (`-O1` or higher) to work, since it needs to inline functions to insert checks.
Debug builds use `-O0` (no optimization), which causes this compilation error:
`error: _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror,-W#warnings]`

This patch is a standard Nix way to disable this specific flag while keeping other hardening features intact. It doesn't affect release builds since it's scoped to `devShells`.

### How did you verify your code works?

`bun bd test` successfully runs test cases.      
