### PR TITLE
fix(cli): `bun --bun init` no longer creates folder named "init"

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -303,7 +303,7 @@ pub var pretend_to_be_node = false;
 pub var is_bunx_exe = false;
 
 /// Index in argv where the command was found by `which()`
-pub var command_arg_index: usize = 1;
+var command_arg_index: usize = 1;
 
 pub const Command = struct {
     pub fn get() Context {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -302,6 +302,9 @@ pub var pretend_to_be_node = false;
 /// This is set `true` during `Command.which()` if argv0 is "bunx"
 pub var is_bunx_exe = false;
 
+/// Index in argv where the command was found by `which()`
+pub var command_arg_index: usize = 1;
+
 pub const Command = struct {
     pub fn get() Context {
         return global_cli_ctx;
@@ -562,6 +565,8 @@ pub const Command = struct {
             next_arg = ((args_iter.next()) orelse return .AutoCommand);
         }
 
+        command_arg_index = args_iter.i - 1;
+
         const first_arg_name = next_arg;
         const RootCommandMatcher = strings.ExactSizeMatcher(12);
 
@@ -749,7 +754,7 @@ pub const Command = struct {
             .DiscordCommand => return try DiscordCommand.exec(allocator),
             .HelpCommand => return try HelpCommand.exec(allocator),
             .ReservedCommand => return try ReservedCommand.exec(allocator),
-            .InitCommand => return try InitCommand.exec(allocator, bun.argv[@min(2, bun.argv.len)..]),
+            .InitCommand => return try InitCommand.exec(allocator, bun.argv[@min(command_arg_index + 1, bun.argv.len)..]),
             .InfoCommand => {
                 try @"bun info"(allocator, log);
                 return;


### PR DESCRIPTION
Track command position in argv to correctly slice arguments for `InitCommand`.

### What does this PR do?

Running `bun --bun init -y` would create a folder called `init/` instead of initializing in the current directory.

The problem was that `which()` correctly skipped `--bun` to find the command, but we always sliced arguments from index 2

So `"init"` got passed to `InitCommand` as the folder name.

Fixed by tracking where the command was actually found in `argv`

### How did you verify your code works?

```bash
# before: created `init/` folder
bun --bun init -y && ls  # init/

# after: initialized in current directory
bun --bun init -y && ls  # package.json, index.ts, ...
```

Existing init tests pass.