### PR TITLE
feat(cli): add pnpm-compatible fuzzy scope matching for `--filter`

### DIFF
--- a/src/cli/filter_arg.zig
+++ b/src/cli/filter_arg.zig
@@ -209,7 +209,7 @@ pub const FilterSet = struct {
             if (filter.kind == .name and filter.fuzzy_scope_eligible) {
                 if (matchesScopedPackage(name, filter.pattern)) {
                     // Track this as a candidate for fuzzy matching
-                    self.fuzzy_scope_candidates.put(name, {}) catch {};
+                    self.fuzzy_scope_candidates.put(name, {}) catch |err| bun.handleOom(err);
                     self.fuzzy_scope_initialized = true;
                 }
             }

--- a/src/cli/filter_arg.zig
+++ b/src/cli/filter_arg.zig
@@ -184,9 +184,7 @@ pub const FilterSet = struct {
             }
         }
         self.allocator.free(self.filters);
-        if (self.fuzzy_scope_initialized) {
-            self.fuzzy_scope_candidates.deinit();
-        }
+        self.fuzzy_scope_candidates.deinit();
     }
 
     pub fn matchesPath(self: *const FilterSet, path: []const u8) bool {


### PR DESCRIPTION
### What does this PR do?

Added pnpm-compatible fuzzy scope matching for the `--filter` flag in `bun run`. When filtering by package name without a scope, Bun will now match scoped packages if no unscoped package with that name exists. (Issue #25512)

Following pnpm's documented behavior at https://pnpm.io/filtering:
"Specifying the scope of the package is optional, so --filter=core will pick @babel/core if core is not found. However, if the workspace has multiple packages with the same name (for instance, @babel/core and @types/core), then filtering without scope will pick nothing."

This patch implements:
Direct match takes priority: If `--filter=core` matches an unscoped package core, only that package is selected
Fuzzy matching as fallback: If no direct match exists, try matching `@*/core` against scoped packages
Ambiguity handling: If multiple scoped packages match (e.g., `@babel/core` and `@types/core`), no packages are selected (error)

### How did you verify your code works?

Added 5 new test cases in `test/cli/run/filter-workspace.test.ts` under `fuzzy scope matching`:
- matches scoped package by unscoped name when unique
- does not match when there's an unscoped package with same name
- does not match when multiple scoped packages match
- still matches when filter starts with @
- glob patterns work with scoped packages

All existing tests continue to pass. 