### PR TITLE
fix(run): validate NODE env path exists before using it

### DIFF
--- a/test/regression/issue/26207.test.ts
+++ b/test/regression/issue/26207.test.ts
@@ -1,0 +1,122 @@
+// https://github.com/oven-sh/bun/issues/26207
+// bun run --filter and --workspaces should fall back to bun's node symlink
+// when NODE env var points to a non-existent path
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+test("bun run --workspaces creates node symlink when NODE env points to non-existent path", async () => {
+  const dir = tempDirWithFiles("workspaces-node-fallback", {
+    "package.json": JSON.stringify({
+      name: "root",
+      workspaces: ["packages/*"],
+    }),
+    "packages/a/package.json": JSON.stringify({
+      name: "a",
+      scripts: {
+        test: "node -e \"console.log('node works')\"",
+      },
+    }),
+  });
+
+  // Set NODE to a non-existent path and remove system node from PATH
+  const env = {
+    ...bunEnv,
+    NODE: "/nonexistent/path/to/node",
+    PATH: "/usr/bin", // PATH without node
+  };
+
+  const proc = Bun.spawn({
+    cmd: [bunExe(), "run", "--workspaces", "test"],
+    env,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Should succeed because bun creates a symlink to its own node
+  expect(stdout).toContain("node works");
+  expect(exitCode).toBe(0);
+});
+
+test("bun run --filter creates node symlink when NODE env points to non-existent path", async () => {
+  const dir = tempDirWithFiles("filter-node-fallback", {
+    "package.json": JSON.stringify({
+      name: "root",
+      workspaces: ["packages/*"],
+    }),
+    "packages/a/package.json": JSON.stringify({
+      name: "a",
+      scripts: {
+        test: "node -e \"console.log('node works from filter')\"",
+      },
+    }),
+  });
+
+  // Set NODE to a non-existent path and remove system node from PATH
+  const env = {
+    ...bunEnv,
+    NODE: "/nonexistent/path/to/node",
+    PATH: "/usr/bin", // PATH without node
+  };
+
+  const proc = Bun.spawn({
+    cmd: [bunExe(), "run", "--filter", "*", "test"],
+    env,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Should succeed because bun creates a symlink to its own node
+  expect(stdout).toContain("node works from filter");
+  expect(exitCode).toBe(0);
+});
+
+test("bun run --workspaces runs scripts that have #!/usr/bin/env node shebang", async () => {
+  const dir = tempDirWithFiles("workspaces-shebang", {
+    "package.json": JSON.stringify({
+      name: "root",
+      workspaces: ["packages/*"],
+    }),
+    "packages/a/package.json": JSON.stringify({
+      name: "a",
+      scripts: {
+        build: "./build.js",
+      },
+    }),
+    // Create an executable script with node shebang
+    "packages/a/build.js": "#!/usr/bin/env node\nconsole.log('build script ran');",
+  });
+
+  // Make the script executable
+  const { execSync } = await import("child_process");
+  execSync(`chmod +x "${dir}/packages/a/build.js"`);
+
+  // Remove system node from PATH, and clear NODE/npm_node_execpath to avoid
+  // interfering with bun's node symlink creation
+  const env = {
+    ...bunEnv,
+    NODE: undefined,
+    npm_node_execpath: undefined,
+    PATH: "/usr/bin", // PATH without node
+  };
+
+  const proc = Bun.spawn({
+    cmd: [bunExe(), "run", "--workspaces", "build"],
+    env,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Should succeed because bun creates a symlink to its own node
+  expect(stdout).toContain("build script ran");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fixes `bun run --filter` and `bun run --workspaces` failing when `NODE` env var points to a non-existent file
- The `getNodePath` function now validates that the `NODE` or `npm_node_execpath` env var points to an executable file before using it
- If the env var path doesn't exist, falls back to searching PATH for node, then creates bun's node symlink if no system node is found

## Test plan
- [x] Added regression test for issue #26207
- [x] Verified existing workspaces and filter tests still pass
- [x] Verified `bun run --workspaces` works when NODE env is invalid
- [x] Verified `bun run --filter` works when NODE env is invalid
- [x] Verified scripts with `#!/usr/bin/env node` shebang work correctly

Fixes #26207

🤖 Generated with [Claude Code](https://claude.ai/code)