### PR TITLE
chore(deps): update BoringSSL fork to latest upstream

### DIFF
--- a/cmake/targets/BuildBoringSSL.cmake
+++ b/cmake/targets/BuildBoringSSL.cmake
@@ -4,7 +4,7 @@ register_repository(
   REPOSITORY
     oven-sh/boringssl
   COMMIT
-    f66315648ab12ea32ceab86b3b4562799c2cb65a
+    4f4f5ef8ebc6e23cbf393428f0ab1b526773f7ac
 )
 
 register_cmake_command(

--- a/cmake/targets/BuildBoringSSL.cmake
+++ b/cmake/targets/BuildBoringSSL.cmake
@@ -4,7 +4,7 @@ register_repository(
   REPOSITORY
     oven-sh/boringssl
   COMMIT
-    6832787f8739d0c4d7ab7e9c2e81c9c47f5e6c5a
+    f66315648ab12ea32ceab86b3b4562799c2cb65a
 )
 
 register_cmake_command(

--- a/cmake/targets/BuildBoringSSL.cmake
+++ b/cmake/targets/BuildBoringSSL.cmake
@@ -4,7 +4,7 @@ register_repository(
   REPOSITORY
     oven-sh/boringssl
   COMMIT
-    f1ffd9e83d4f5c28a9c70d73f9a4e6fcf310062f
+    6832787f8739d0c4d7ab7e9c2e81c9c47f5e6c5a
 )
 
 register_cmake_command(

--- a/src/bun.js/bindings/ncrypto.cpp
+++ b/src/bun.js/bindings/ncrypto.cpp
@@ -1901,7 +1901,7 @@ DataPointer DHPointer::stateless(const EVPKeyPointer& ourKey,
 // ============================================================================
 // KDF
 
-const EVP_MD* getDigestByName(const WTF::StringView name, bool ignoreSHA512_224)
+const EVP_MD* getDigestByName(const WTF::StringView name)
 {
     // Historically, "dss1" and "DSS1" were DSA aliases for SHA-1
     // exposed through the public API.
@@ -1955,9 +1955,6 @@ const EVP_MD* getDigestByName(const WTF::StringView name, bool ignoreSHA512_224)
                     return EVP_sha512();
                 }
                 if (WTF::equalIgnoringASCIICase(moreBits, "/224"_s)) {
-                    if (ignoreSHA512_224) {
-                        return nullptr;
-                    }
                     return EVP_sha512_224();
                 }
                 if (WTF::equalIgnoringASCIICase(moreBits, "/256"_s)) {
@@ -1977,10 +1974,6 @@ const EVP_MD* getDigestByName(const WTF::StringView name, bool ignoreSHA512_224)
         if (WTF::equalIgnoringASCIICase(remain, "128"_s)) {
             return EVP_sha1();
         }
-    }
-
-    if (ignoreSHA512_224 && WTF::equalIgnoringASCIICase(name, "sha512-224"_s)) {
-        return nullptr;
     }
 
     // if (name == "ripemd160WithRSA"_s || name == "RSA-RIPEMD160"_s) {

--- a/src/bun.js/bindings/ncrypto.h
+++ b/src/bun.js/bindings/ncrypto.h
@@ -1575,7 +1575,7 @@ Buffer<char> ExportChallenge(const char* input, size_t length);
 // ============================================================================
 // KDF
 
-const EVP_MD* getDigestByName(const WTF::StringView name, bool ignoreSHA512_224 = false);
+const EVP_MD* getDigestByName(const WTF::StringView name);
 const EVP_CIPHER* getCipherByName(const WTF::StringView name);
 
 // Verify that the specified HKDF output length is valid for the given digest.

--- a/src/bun.js/bindings/node/crypto/JSHash.cpp
+++ b/src/bun.js/bindings/node/crypto/JSHash.cpp
@@ -251,15 +251,7 @@ JSC_DEFINE_HOST_FUNCTION(jsHashProtoFuncDigest, (JSC::JSGlobalObject * lexicalGl
 
     // Only compute the digest if it hasn't been cached yet
     if (!hash->m_digest && len > 0) {
-
-        const EVP_MD* md = hash->m_ctx.getDigest();
-        uint32_t bufLen = len;
-        if (md == EVP_sha512_224()) {
-            // SHA-512/224 expects buffer length of length % 8. can be truncated afterwards
-            bufLen = SHA512_224_DIGEST_BUFFER_LENGTH;
-        }
-
-        auto data = hash->m_ctx.digestFinal(bufLen);
+        auto data = hash->m_ctx.digestFinal(len);
         if (!data) {
             throwCryptoError(lexicalGlobalObject, scope, ERR_get_error(), "Failed to finalize digest"_s);
             return {};
@@ -325,7 +317,7 @@ JSC_DEFINE_HOST_FUNCTION(constructHash, (JSC::JSGlobalObject * globalObject, JSC
         WTF::String algorithm = algorithmOrHashInstanceValue.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
 
-        md = ncrypto::getDigestByName(algorithm, true);
+        md = ncrypto::getDigestByName(algorithm);
         if (!md) {
             zigHasher = ExternZigHash::getByName(zigGlobalObject, algorithm);
         }


### PR DESCRIPTION
## Summary

Updates the BoringSSL fork to the latest upstream (337 commits since last update) with bug fixes for Node.js crypto compatibility.

### Upstream BoringSSL Changes (337 commits)

| Category | Count |
|----------|-------|
| API Changes (including namespacing) | 42 |
| Code Cleanup/Refactoring | 35 |
| Testing/CI | 32 |
| Build System (Bazel, CMake) | 27 |
| Bug Fixes | 25 |
| Post-Quantum Cryptography | 14 |
| TLS/SSL Changes | 12 |
| Rust Bindings/Wrappers | 9 |
| Performance Improvements | 8 |
| Documentation | 8 |

#### Highlights

**Post-Quantum Cryptography**
- ML-DSA (Module-Lattice Digital Signature Algorithm): Full EVP integration, Wycheproof tests, external mu verification
- SLH-DSA: Implementation of pure SLH-DSA-SHAKE-256f
- Merkle Tree Certificates: New support for verifying signatureless MTCs

**Major API Changes**
- New `CRYPTO_IOVEC` based AEAD APIs for zero-copy I/O across all ciphers
- Massive namespacing effort moving internal symbols into `bssl` namespace
- `bssl::Span` modernization to match `std::span` behavior

**TLS/SSL**
- Added `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256` support
- HMAC on SHA-384 for TLS 1.3
- Improved Lucky 13 mitigation

**Build System**
- Bazel 8.x and 9.0.0 compatibility
- CI upgrades: Ubuntu 24.04, Android NDK r29

---

### Bun-specific Patches (in oven-sh/boringssl)

1. **Fix SHA512-224 EVP final buffer size** (`digests.cc.inc`)
   - `BCM_sha512_224_final` writes 32 bytes but `EVP_MD.md_size` is 28 bytes
   - Now uses a temp buffer to avoid buffer overwrite

2. **Fix `EVP_do_all_sorted` to return only lowercase names** (`evp_do_all.cc`)
   - `EVP_CIPHER_do_all_sorted` and `EVP_MD_do_all_sorted` now return only lowercase names
   - Matches Node.js behavior for `crypto.getCiphers()` and `crypto.getHashes()`

---

### Changes in Bun

- Updated BoringSSL commit hash to `4f4f5ef8ebc6e23cbf393428f0ab1b526773f7ac`
- Removed `ignoreSHA512_224` parameter from `ncrypto::getDigestByName()` to enable SHA512-224 support
- Removed special SHA512-224 buffer handling in `JSHash.cpp` (no longer needed after BoringSSL fix)

## Test plan
- [x] `crypto.createHash('sha512-224')` works correctly
- [x] `crypto.getHashes()` returns lowercase names (md4, md5, sha1, sha256, etc.)
- [x] `crypto.getCiphers()` returns lowercase names (aes-128-cbc, aes-256-gcm, etc.)
- [x] `test/regression/issue/crypto-names.test.ts` passes
- [x] All CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)