### PR TITLE
fix(bundler): preserve data-* attributes on script and link tags in HTML bundler

### DIFF
--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.zig
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.zig
@@ -290,7 +290,7 @@ fn collectDataAttributes(element: *const lol.Element, allocator: std.mem.Allocat
         const name_slice = attr_name.slice();
 
         // Check if attribute name starts with "data-"
-        if (name_slice.len >= 5 and std.mem.eql(u8, name_slice[0..5], "data-")) {
+        if (std.mem.startsWith(u8, name_slice, "data-")) {
             const attr_value = attr.value();
             defer attr_value.deinit();
             const value_slice = attr_value.slice();
@@ -309,6 +309,8 @@ fn collectDataAttributes(element: *const lol.Element, allocator: std.mem.Allocat
                 switch (c) {
                     '"' => result.appendSlice("&quot;") catch bun.outOfMemory(),
                     '&' => result.appendSlice("&amp;") catch bun.outOfMemory(),
+                    '<' => result.appendSlice("&lt;") catch bun.outOfMemory(),
+                    '>' => result.appendSlice("&gt;") catch bun.outOfMemory(),
                     else => result.append(c) catch bun.outOfMemory(),
                 }
             }

--- a/test/regression/issue/26216.test.ts
+++ b/test/regression/issue/26216.test.ts
@@ -1,0 +1,138 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("bun build preserves data-* attributes on script tags", async () => {
+  using dir = tempDir("issue-26216", {
+    "index.html": `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <script type="module" src="./app.js" data-inline data-custom="value"></script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>`,
+    "app.js": `console.log("hello");`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./index.html", "--outdir=out"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(0);
+
+  const outputHtml = await Bun.file(`${dir}/out/index.html`).text();
+
+  // Check that data-* attributes are preserved on the bundled script tag
+  expect(outputHtml).toContain('data-inline=""');
+  expect(outputHtml).toContain('data-custom="value"');
+});
+
+test("bun build preserves data-* attributes on link tags", async () => {
+  using dir = tempDir("issue-26216-link", {
+    "index.html": `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <link href="./style.css" rel="stylesheet" data-theme="dark" data-priority="high">
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>`,
+    "style.css": `body { color: red; }`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./index.html", "--outdir=out"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(0);
+
+  const outputHtml = await Bun.file(`${dir}/out/index.html`).text();
+
+  // Check that data-* attributes are preserved on the bundled link tag
+  expect(outputHtml).toContain('data-theme="dark"');
+  expect(outputHtml).toContain('data-priority="high"');
+});
+
+test("bun build preserves data-* attributes with special characters", async () => {
+  using dir = tempDir("issue-26216-special", {
+    "index.html": `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <script type="module" src="./app.js" data-config='{"key":"value"}'></script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>`,
+    "app.js": `console.log("hello");`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./index.html", "--outdir=out"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(0);
+
+  const outputHtml = await Bun.file(`${dir}/out/index.html`).text();
+
+  // Check that data-* attributes with special characters are preserved (quotes get escaped)
+  expect(outputHtml).toContain("data-config=");
+});
+
+test("bun build uses data-* attributes from first bundled element when merging multiple scripts", async () => {
+  using dir = tempDir("issue-26216-merge", {
+    "index.html": `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <script type="module" src="./app1.js" data-first="true"></script>
+  <script type="module" src="./app2.js" data-second="true"></script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>`,
+    "app1.js": `console.log("app1");`,
+    "app2.js": `console.log("app2");`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./index.html", "--outdir=out"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(0);
+
+  const outputHtml = await Bun.file(`${dir}/out/index.html`).text();
+
+  // The first bundled script's data-* attributes should be used
+  expect(outputHtml).toContain('data-first="true"');
+});

--- a/test/regression/issue/26216.test.ts
+++ b/test/regression/issue/26216.test.ts
@@ -26,13 +26,13 @@ test("bun build preserves data-* attributes on script tags", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(exitCode).toBe(0);
-
   const outputHtml = await Bun.file(`${dir}/out/index.html`).text();
 
   // Check that data-* attributes are preserved on the bundled script tag
   expect(outputHtml).toContain('data-inline=""');
   expect(outputHtml).toContain('data-custom="value"');
+
+  expect(exitCode).toBe(0);
 });
 
 test("bun build preserves data-* attributes on link tags", async () => {
@@ -60,13 +60,13 @@ test("bun build preserves data-* attributes on link tags", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(exitCode).toBe(0);
-
   const outputHtml = await Bun.file(`${dir}/out/index.html`).text();
 
   // Check that data-* attributes are preserved on the bundled link tag
   expect(outputHtml).toContain('data-theme="dark"');
   expect(outputHtml).toContain('data-priority="high"');
+
+  expect(exitCode).toBe(0);
 });
 
 test("bun build preserves data-* attributes with special characters", async () => {
@@ -94,12 +94,13 @@ test("bun build preserves data-* attributes with special characters", async () =
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(exitCode).toBe(0);
-
   const outputHtml = await Bun.file(`${dir}/out/index.html`).text();
 
   // Check that data-* attributes with special characters are preserved (quotes get escaped)
-  expect(outputHtml).toContain("data-config=");
+  // The original single-quoted JSON value gets converted to double quotes with escaped inner quotes
+  expect(outputHtml).toContain('data-config="{&quot;key&quot;:&quot;value&quot;}"');
+
+  expect(exitCode).toBe(0);
 });
 
 test("bun build uses data-* attributes from first bundled element when merging multiple scripts", async () => {
@@ -129,10 +130,12 @@ test("bun build uses data-* attributes from first bundled element when merging m
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(exitCode).toBe(0);
-
   const outputHtml = await Bun.file(`${dir}/out/index.html`).text();
 
   // The first bundled script's data-* attributes should be used
   expect(outputHtml).toContain('data-first="true"');
+  // The second script's attributes should NOT be included
+  expect(outputHtml).not.toContain('data-second="true"');
+
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Summary

- Fixes a bug where `bun build` was stripping `data-*` attributes from `<script>` and `<link>` tags when bundling HTML files
- Captures `data-*` attributes from the first bundled element of each type (JS/CSS) and includes them on the injected bundled tags

## Root Cause

When processing `<script src="...">` and `<link href="...">` tags that reference JavaScript or CSS files, the bundler calls `element.remove()` to remove the original tag. Later, new tags are injected to reference the bundled files, but these new tags weren't carrying over custom attributes from the original elements.

## Solution

1. Added fields to track `data-*` attributes for JS and CSS elements
2. Before removing a script/link element, capture its `data-*` attributes (from the first bundled element of each type)
3. Include those attributes when generating the injected tags in the output HTML

## Test plan

- [x] Added tests in `test/regression/issue/26216.test.ts`
- [x] Tests verify `data-*` attributes are preserved on both script and link tags
- [x] Tests verify proper handling of attributes with special characters
- [x] Tests verify first element's attributes are used when multiple elements are bundled together
- [x] Verified tests fail with `USE_SYSTEM_BUN=1` (without fix) and pass with `bun bd test` (with fix)

Fixes #26216

🤖 Generated with [Claude Code](https://claude.ai/code)