### PR TITLE
fix(windows): use cmd.exe to invoke `start` for opening URLs

### DIFF
--- a/src/js/internal/html.ts
+++ b/src/js/internal/html.ts
@@ -383,7 +383,9 @@ yourself with Bun.serve().
             // TODO: copy the AppleScript from create-react-app or Vite.
             Bun.spawn(["open", url]).exited.catch(() => {});
           } else if (process.platform === "win32") {
-            Bun.spawn(["start", url]).exited.catch(() => {});
+            // "start" is a cmd.exe built-in command, not an executable.
+            // The empty string argument is the window title (required for URLs with special characters).
+            Bun.spawn(["cmd.exe", "/c", "start", "", url]).exited.catch(() => {});
           } else {
             Bun.spawn(["xdg-open", url]).exited.catch(() => {});
           }


### PR DESCRIPTION
## Summary

- Fixes the "o + Enter" shortcut in the HTML dev server on Windows
- Fixes `openURL()` in `src/open.zig` for Windows

On Windows, `start` is a cmd.exe built-in command, not an executable. Attempting to spawn it directly causes "Executable not found" errors:

```
error: Executable not found in $PATH: "start"
  path: "start",
 errno: -4058,
  code: "ENOENT"
```

The fix invokes `cmd.exe /c start "" <url>` instead of `start <url>`. The empty string argument is the window title, which is required when the URL contains special characters.

## Test plan

- [x] Verified the code compiles on Linux
- [ ] Test on Windows: run `bun test.html` and press `o + Enter` to open browser

Fixes #26231

🤖 Generated with [Claude Code](https://claude.ai/code)