### PR TITLE
perf(minify): skip renaming symbols with zero use count

### DIFF
--- a/src/renamer.zig
+++ b/src/renamer.zig
@@ -272,13 +272,14 @@ pub const MinifyRenamer = struct {
             var slots = this.slots.getPtr(ns);
             sorted.clearRetainingCapacity();
             try sorted.ensureUnusedCapacity(slots.items.len);
-            sorted.items.len = slots.items.len;
 
-            for (sorted.items, slots.items, 0..) |*elem, slot, i| {
-                elem.* = SlotAndCount{
+            for (slots.items, 0..) |slot, i| {
+                // Skip symbols with zero use count - they're never used and don't need a minified name
+                if (slot.count == 0) continue;
+                sorted.appendAssumeCapacity(SlotAndCount{
                     .slot = @as(u32, @intCast(i)),
                     .count = slot.count,
-                };
+                });
             }
             std.sort.pdq(SlotAndCount, sorted.items, {}, SlotAndCount.lessThan);
 


### PR DESCRIPTION
## Summary
- Filter out zero-count slots before sorting in MinifyRenamer, avoiding unnecessary sorting and iteration

These slots represent declared symbols in nested scopes that were tree-shaken away. By filtering them out before sorting, we avoid unnecessary name generation work.

Ported from oxc: https://github.com/oxc-project/oxc/pull/18183

## Test plan
- Added `minify/SkipUnusedSymbolSlots` test that verifies the optimization works when nested scopes are tree-shaken
- Existing bundler minify tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)