### PR TITLE
fix(tls): use correct variable in setVerifyMode

### DIFF
--- a/src/bun.js/api/bun/socket/tls_socket_functions.zig
+++ b/src/bun.js/api/bun/socket/tls_socket_functions.zig
@@ -556,7 +556,7 @@ pub fn setVerifyMode(this: *This, globalObject: *jsc.JSGlobalObject, callframe: 
     }
 
     const request_cert = request_cert_js.toBoolean();
-    const reject_unauthorized = request_cert_js.toBoolean();
+    const reject_unauthorized = reject_unauthorized_js.toBoolean();
     var verify_mode: c_int = BoringSSL.SSL_VERIFY_NONE;
     if (this.isServer()) {
         if (request_cert) {


### PR DESCRIPTION
## Summary
- Fix typo in `setVerifyMode` where `reject_unauthorized` was incorrectly reading from `request_cert_js` instead of `reject_unauthorized_js`

## Test plan
- Existing TLS renegotiation tests pass
- Code inspection shows the fix is correct (simple variable name typo)

🤖 Generated with [Claude Code](https://claude.ai/code)