### PR TITLE
fix(init): resolve TypeScript errors in react-tailwind template build.ts

### DIFF
--- a/src/init/react-tailwind/build.ts
+++ b/src/init/react-tailwind/build.ts
@@ -82,6 +82,12 @@ function parseArgs(): Partial<Bun.BuildConfig> {
 
     if (key.includes(".")) {
       const parts = key.split(".");
+      if (parts.length > 2) {
+        console.warn(
+          `Warning: Deeply nested option "${key}" is not supported. Only single-level nesting (e.g., --minify.whitespace) is allowed.`,
+        );
+        continue;
+      }
       const parentKey = parts[0]!;
       const childKey = parts[1]!;
       const existing = config[parentKey];

--- a/src/init/react-tailwind/build.ts
+++ b/src/init/react-tailwind/build.ts
@@ -84,7 +84,10 @@ function parseArgs(): Partial<Bun.BuildConfig> {
       const parts = key.split(".");
       const parentKey = parts[0]!;
       const childKey = parts[1]!;
-      config[parentKey] = (config[parentKey] as Record<string, unknown>) || {};
+      const existing = config[parentKey];
+      if (typeof existing !== "object" || existing === null || Array.isArray(existing)) {
+        config[parentKey] = {};
+      }
       (config[parentKey] as Record<string, unknown>)[childKey] = parseValue(value);
     } else {
       config[key] = parseValue(value);

--- a/src/init/react-tailwind/build.ts
+++ b/src/init/react-tailwind/build.ts
@@ -33,7 +33,7 @@ Example:
   process.exit(0);
 }
 
-const toCamelCase = (str: string): string => str.replace(/-([a-z])/g, g => g[1].toUpperCase());
+const toCamelCase = (str: string): string => str.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
 
 const parseValue = (value: string): any => {
   if (value === "true") return true;
@@ -48,7 +48,7 @@ const parseValue = (value: string): any => {
 };
 
 function parseArgs(): Partial<Bun.BuildConfig> {
-  const config: Partial<Bun.BuildConfig> = {};
+  const config: Record<string, unknown> = {};
   const args = process.argv.slice(2);
 
   for (let i = 0; i < args.length; i++) {
@@ -81,15 +81,17 @@ function parseArgs(): Partial<Bun.BuildConfig> {
     key = toCamelCase(key);
 
     if (key.includes(".")) {
-      const [parentKey, childKey] = key.split(".");
-      config[parentKey] = config[parentKey] || {};
-      config[parentKey][childKey] = parseValue(value);
+      const parts = key.split(".");
+      const parentKey = parts[0]!;
+      const childKey = parts[1]!;
+      config[parentKey] = (config[parentKey] as Record<string, unknown>) || {};
+      (config[parentKey] as Record<string, unknown>)[childKey] = parseValue(value);
     } else {
       config[key] = parseValue(value);
     }
   }
 
-  return config;
+  return config as Partial<Bun.BuildConfig>;
 }
 
 const formatFileSize = (bytes: number): string => {

--- a/test/regression/issue/24364.test.ts
+++ b/test/regression/issue/24364.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+test("react-tailwind template passes tsc --noEmit", async () => {
+  // Read template files from source
+  const templateDir = join(import.meta.dir, "../../../src/init/react-tailwind");
+  const buildTs = readFileSync(join(templateDir, "build.ts"), "utf8");
+  const tsconfigJson = readFileSync(join(templateDir, "tsconfig.json"), "utf8");
+
+  // Create temp directory with template files
+  using dir = tempDir("issue-24364", {
+    "build.ts": buildTs,
+    "tsconfig.json": tsconfigJson,
+  });
+
+  // Install typescript and bun types
+  await using install = Bun.spawn({
+    cmd: [bunExe(), "add", "-d", "typescript", "@types/bun", "bun-plugin-tailwind"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [, , installExitCode] = await Promise.all([install.stdout.text(), install.stderr.text(), install.exited]);
+  expect(installExitCode).toBe(0);
+
+  // Run tsc --noEmit
+  await using tsc = Bun.spawn({
+    cmd: [join(String(dir), "node_modules", ".bin", "tsc"), "--noEmit"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([tsc.stdout.text(), tsc.stderr.text(), tsc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/24364.test.ts
+++ b/test/regression/issue/24364.test.ts
@@ -27,9 +27,9 @@ test("react-tailwind template passes tsc --noEmit", async () => {
   const [, , installExitCode] = await Promise.all([install.stdout.text(), install.stderr.text(), install.exited]);
   expect(installExitCode).toBe(0);
 
-  // Run tsc --noEmit
+  // Run tsc --noEmit (use bunExe() x for cross-platform compatibility)
   await using tsc = Bun.spawn({
-    cmd: [join(String(dir), "node_modules", ".bin", "tsc"), "--noEmit"],
+    cmd: [bunExe(), "x", "tsc", "--noEmit"],
     cwd: String(dir),
     env: bunEnv,
     stdout: "pipe",


### PR DESCRIPTION
## Summary
- Fixes TypeScript errors in the react-tailwind template's `build.ts` when used with the template's strict `tsconfig.json`

## Test plan
- Added regression test `test/regression/issue/24364.test.ts` that verifies TypeScript compilation passes
- Verified test fails with old template code and passes with fix

Closes #24364

🤖 Generated with [Claude Code](https://claude.com/claude-code)