### PR TITLE
fix(fs): Dirent.isFIFO() incorrectly returns true for unknown type

### DIFF
--- a/src/bun.js/bindings/NodeDirent.cpp
+++ b/src/bun.js/bindings/NodeDirent.cpp
@@ -277,7 +277,7 @@ JSC_DEFINE_HOST_FUNCTION(jsDirentProtoFuncIsFIFO, (JSC::JSGlobalObject * globalO
     int32_t type = getType(vm, callFrame->thisValue(), defaultGlobalObject(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
 
-    return JSValue::encode(jsBoolean(type == static_cast<int32_t>(DirEntType::NamedPipe) || type == static_cast<int32_t>(DirEntType::EventPort)));
+    return JSValue::encode(jsBoolean(type == static_cast<int32_t>(DirEntType::NamedPipe)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsDirentProtoFuncIsFile, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/test/regression/issue/24129.test.ts
+++ b/test/regression/issue/24129.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+
+// Test for GitHub issue #24129
+// When a filesystem returns DT_UNKNOWN (like sshfs, NFS, or other remote/virtual filesystems),
+// fs.Dirent.isFIFO() was incorrectly returning true because the EventPort type (value 0)
+// was being checked in isFIFO(), and Unknown also maps to 0.
+
+test("Dirent with unknown type should return false for all type checks", () => {
+  const UV_DIRENT_UNKNOWN = fs.constants.UV_DIRENT_UNKNOWN;
+  expect(UV_DIRENT_UNKNOWN).toBe(0);
+
+  // Create a Dirent with unknown type (simulates what happens on sshfs/NFS mounts)
+  const dirent = new fs.Dirent("test-file", UV_DIRENT_UNKNOWN);
+
+  // All type checks should return false for unknown type
+  expect(dirent.isFile()).toBe(false);
+  expect(dirent.isDirectory()).toBe(false);
+  expect(dirent.isSymbolicLink()).toBe(false);
+  expect(dirent.isSocket()).toBe(false);
+  expect(dirent.isBlockDevice()).toBe(false);
+  expect(dirent.isCharacterDevice()).toBe(false);
+
+  // This is the bug fix - isFIFO() should return false for unknown type
+  // Previously it returned true because EventPort (0) was checked
+  expect(dirent.isFIFO()).toBe(false);
+});
+
+test("Dirent.isFIFO() should only return true for actual FIFO/named pipe", () => {
+  const UV_DIRENT_FIFO = fs.constants.UV_DIRENT_FIFO;
+  expect(UV_DIRENT_FIFO).toBe(4);
+
+  // Create a Dirent with FIFO type
+  const fifoDirent = new fs.Dirent("test-fifo", UV_DIRENT_FIFO);
+  expect(fifoDirent.isFIFO()).toBe(true);
+
+  // Verify other type checks return false
+  expect(fifoDirent.isFile()).toBe(false);
+  expect(fifoDirent.isDirectory()).toBe(false);
+});


### PR DESCRIPTION
## Summary
- Fix `fs.Dirent.isFIFO()` incorrectly returning `true` for unknown file types (e.g., on sshfs/NFS mounts)
- Remove the `EventPort` check from `isFIFO()` since `EventPort = 0 = Unknown`
- Add regression test for the fix

Fixes #24129

## Root Cause
In `NodeDirent.cpp`, the `isFIFO()` method was checking:
```cpp
type == static_cast<int32_t>(DirEntType::NamedPipe) || type == static_cast<int32_t>(DirEntType::EventPort)
```

Since `EventPort = 0` and `Unknown = 0` (they share the same enum value), any file with unknown type (returned by filesystems like sshfs, NFS, etc. that don't populate `d_type`) would incorrectly trigger `isFIFO() === true`.

## Test plan
- [x] Regression test: `bun bd test test/regression/issue/24129.test.ts`
- [x] Existing Dirent tests: `bun bd test test/js/node/fs/fs.test.ts -t "Dirent"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)