### PR TITLE
fix(cli): error when using --bytecode with cross-compilation

### DIFF
--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -995,6 +995,12 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                             Output.errGeneric("Unsupported compile target: {f}\n", .{ctx.bundler_options.compile_target});
                             Global.exit(1);
                         }
+                        // Bytecode is not portable across different platforms/architectures/libcs
+                        // because JSC bytecode format depends on the specific build configuration.
+                        if (ctx.bundler_options.bytecode and !ctx.bundler_options.compile_target.isDefault()) {
+                            Output.errGeneric("--bytecode is not supported with cross-compilation. The target platform ({f}) differs from the host platform.", .{ctx.bundler_options.compile_target});
+                            Global.exit(1);
+                        }
                         opts.target = .bun;
                         break :brk;
                     }

--- a/test/regression/issue/24144.test.ts
+++ b/test/regression/issue/24144.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, isMusl, tempDir } from "harness";
+
+// Issue #24144: Using --bytecode with --target bun-linux-x64-musl causes a segfault
+// because bytecode is not portable across different platforms/architectures/libcs.
+// The fix is to error out at build time when --bytecode is combined with cross-compilation.
+describe("issue #24144: bytecode with cross-compilation", () => {
+  test("--bytecode with cross-compilation target should error", async () => {
+    using dir = tempDir("issue-24144", {
+      "index.ts": `console.log("Hello, world!");`,
+    });
+
+    // Use a cross-compilation target that differs from current platform
+    // We pick a musl target if we're on glibc, or glibc target if we're on musl
+    const crossTarget = isLinux
+      ? isMusl
+        ? "bun-linux-x64" // glibc target if we're on musl
+        : "bun-linux-x64-musl" // musl target if we're on glibc
+      : "bun-linux-x64-musl"; // any linux target if we're not on linux
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", "--bytecode", `--target=${crossTarget}`, "index.ts", "--outfile=server"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("--bytecode is not supported with cross-compilation");
+    expect(exitCode).toBe(1);
+  });
+
+  test("--bytecode without cross-compilation should work", async () => {
+    using dir = tempDir("issue-24144-same-platform", {
+      "index.ts": `console.log("Hello, world!");`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", "--bytecode", "index.ts", "--outfile=server"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Should succeed without the cross-compilation error
+    expect(stderr).not.toContain("--bytecode is not supported with cross-compilation");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix for #24144: Using `--bytecode` with `--target bun-linux-x64-musl` (or any cross-compilation target) now produces a clear error at build time instead of silently creating a binary that segfaults on the target platform
- JSC bytecode is not portable across different platforms/architectures/libcs because the bytecode format depends on the specific build configuration

## Test plan
- Added regression test `test/regression/issue/24144.test.ts`
- Test verifies that `--bytecode` with cross-compilation target produces an error
- Test verifies that `--bytecode` without cross-compilation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)