### PR TITLE
fix(sql): ref MySQL poll when enqueueing request on idle connection

### DIFF
--- a/src/sql/mysql/js/JSMySQLConnection.zig
+++ b/src/sql/mysql/js/JSMySQLConnection.zig
@@ -155,6 +155,7 @@ pub fn enqueueRequest(this: *@This(), item: *JSMySQLQuery) void {
     this.#connection.enqueueRequest(item);
     this.resetConnectionTimeout();
     this.registerAutoFlusher();
+    this.updateReferenceType();
 }
 
 pub fn close(this: *@This()) void {


### PR DESCRIPTION
## Summary
- Fix MySQL queries hanging after async fs operations (like `fs.promises.readdir()`) on Windows
- Add `updateReferenceType()` call in `enqueueRequest()` to properly ref the poll when new queries are added to an idle connection

## Root Cause
When a MySQL connection becomes idle, `updateReferenceType()` unrefs the `poll_ref`. However, when a new query is enqueued via `enqueueRequest()`, it was not calling `updateReferenceType()` to ref the poll again. This caused the event loop to not properly wait for MySQL socket I/O on Windows when queries were issued after async fs operations.

## Test Plan
- [x] Added regression test that verifies queries work after `fs.promises.readdir()`
- [ ] CI tests pass for MySQL container tests

Fixes #24130

🤖 Generated with [Claude Code](https://claude.ai/code)