### PR TITLE
fix(fetch): respect `dispatcher` option from undici for TLS settings

### DIFF
--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -263,7 +263,18 @@ class MockAgent {
 function mockErrors() {}
 
 class Dispatcher extends EventEmitter {}
-class Agent extends Dispatcher {}
+class Agent extends Dispatcher {
+  #options;
+
+  constructor(options = {}) {
+    super();
+    this.#options = options;
+  }
+
+  get options() {
+    return this.#options;
+  }
+}
 class Pool extends Dispatcher {
   request() {}
 }

--- a/test/regression/issue/24376.test.ts
+++ b/test/regression/issue/24376.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "bun:test";
+import { expiredTls } from "harness";
+import { Agent } from "undici";
+
+// Test for issue #24376: fetch doesn't respect dispatcher option from undici
+// The dispatcher option should allow setting TLS options like rejectUnauthorized
+// via undici's Agent class.
+
+describe("fetch with undici dispatcher", () => {
+  it("should respect rejectUnauthorized: false from dispatcher", async () => {
+    // Create a server with an expired/self-signed certificate
+    using server = Bun.serve({
+      port: 0,
+      tls: expiredTls,
+      fetch() {
+        return new Response("Hello World");
+      },
+    });
+
+    // Create an undici Agent with rejectUnauthorized: false
+    const agent = new Agent({
+      connect: {
+        rejectUnauthorized: false,
+      },
+    });
+
+    // This should succeed because the agent has rejectUnauthorized: false
+    const response = await fetch(`https://localhost:${server.port}`, {
+      dispatcher: agent,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("Hello World");
+  });
+
+  it("should fail with self-signed cert when dispatcher has rejectUnauthorized: true", async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls: expiredTls,
+      fetch() {
+        return new Response("Hello World");
+      },
+    });
+
+    const agent = new Agent({
+      connect: {
+        rejectUnauthorized: true,
+      },
+    });
+
+    // This should fail because the certificate is invalid and rejectUnauthorized is true
+    expect(
+      fetch(`https://localhost:${server.port}`, {
+        dispatcher: agent,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("should fail with self-signed cert when no dispatcher is provided", async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls: expiredTls,
+      fetch() {
+        return new Response("Hello World");
+      },
+    });
+
+    // This should fail because the certificate is invalid and no TLS options are provided
+    expect(fetch(`https://localhost:${server.port}`)).rejects.toThrow();
+  });
+
+  it("tls option should take precedence over dispatcher", async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls: expiredTls,
+      fetch() {
+        return new Response("Hello World");
+      },
+    });
+
+    // Agent says reject, but tls option says don't reject
+    const agent = new Agent({
+      connect: {
+        rejectUnauthorized: true,
+      },
+    });
+
+    // tls option should override dispatcher
+    const response = await fetch(`https://localhost:${server.port}`, {
+      dispatcher: agent,
+      tls: {
+        rejectUnauthorized: false,
+      },
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("Agent stores and exposes options", () => {
+    const options = {
+      connect: {
+        rejectUnauthorized: false,
+        timeout: 5000,
+      },
+    };
+
+    const agent = new Agent(options);
+    expect(agent.options).toEqual(options);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes `fetch()` to respect the `dispatcher` option from undici for TLS configuration
- Updates the stubbed undici `Agent` class to store constructor options

When using undici's `Agent` class with `fetch()`, the TLS configuration (such as `rejectUnauthorized: false`) was not being applied. For example:

```typescript
import { Agent } from 'undici';

const agent = new Agent({
  connect: {
    rejectUnauthorized: false,
  },
});

// This now works!
const response = await fetch('https://self-signed.badssl.com/', {
  dispatcher: agent,
});
```

## Changes

1. **`src/js/thirdparty/undici.js`**: Updated the stubbed `Agent` class to store constructor options and expose them via an `options` getter

2. **`src/bun.js/webcore/fetch.zig`**: Added dispatcher option parsing in fetch to extract `connect.rejectUnauthorized` from the agent's options. The `tls` option takes precedence over `dispatcher` settings when both are provided.

## Test plan

- [x] Added regression test `test/regression/issue/24376.test.ts`
- [x] Verified test fails with system bun (`USE_SYSTEM_BUN=1`)
- [x] Verified test passes with debug build (`bun bd test`)
- [x] Ran existing fetch TLS tests to ensure no regressions

Fixes #24376

🤖 Generated with [Claude Code](https://claude.com/claude-code)