### PR TITLE
fix(bundler): use absolute paths for assets in compile mode

### DIFF
--- a/src/bundler/Chunk.zig
+++ b/src/bundler/Chunk.zig
@@ -240,9 +240,12 @@ pub const Chunk = struct {
                                     .none => unreachable,
                                 };
 
+                                // If the path is absolute (starts with `/`), use it directly without computing relative path.
+                                // This preserves absolute paths for compile mode where assets should be served from root.
+                                const is_absolute_path = strings.startsWithChar(file_path, '/');
                                 const cheap_normalizer = cheapPrefixNormalizer(
                                     import_prefix,
-                                    if (from_chunk_dir.len == 0 or force_absolute_path)
+                                    if (from_chunk_dir.len == 0 or force_absolute_path or is_absolute_path)
                                         file_path
                                     else
                                         bun.path.relativePlatformBuf(relative_platform_buf, from_chunk_dir, file_path, .posix, false),
@@ -332,12 +335,16 @@ pub const Chunk = struct {
 
                                 // normalize windows paths to '/'
                                 bun.path.platformToPosixInPlace(u8, @constCast(file_path));
+                                // If the path is absolute (starts with `/`), use it directly without computing relative path.
+                                // This preserves absolute paths for compile mode where assets should be served from root.
+                                const is_absolute_path = strings.startsWithChar(file_path, '/');
+                                const used_file_path = if (from_chunk_dir.len == 0 or force_absolute_path or is_absolute_path)
+                                    file_path
+                                else
+                                    bun.path.relativePlatformBuf(relative_platform_buf, from_chunk_dir, file_path, .posix, false);
                                 const cheap_normalizer = cheapPrefixNormalizer(
                                     import_prefix,
-                                    if (from_chunk_dir.len == 0 or force_absolute_path)
-                                        file_path
-                                    else
-                                        bun.path.relativePlatformBuf(relative_platform_buf, from_chunk_dir, file_path, .posix, false),
+                                    used_file_path,
                                 );
 
                                 if (cheap_normalizer[0].len > 0) {

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -206,9 +206,12 @@ pub const BundleV2 = struct {
 
         // We need to make sure it has [hash] in the names so we don't get conflicts.
         if (this_transpiler.options.compile) {
-            client_transpiler.options.asset_naming = bun.options.PathTemplate.asset.data;
-            client_transpiler.options.chunk_naming = bun.options.PathTemplate.chunk.data;
-            client_transpiler.options.entry_naming = "./[name]-[hash].[ext]";
+            // Use absolute paths (starting with `/`) so that assets are correctly
+            // resolved from any route, not just the root. Relative paths like
+            // `./style.css` would resolve to `/about/style.css` on the `/about` route.
+            client_transpiler.options.asset_naming = "/[name]-[hash].[ext]";
+            client_transpiler.options.chunk_naming = "/[name]-[hash].[ext]";
+            client_transpiler.options.entry_naming = "/[name]-[hash].[ext]";
 
             // Avoid setting a public path for --compile since all the assets
             // will be served relative to the server root.
@@ -4509,6 +4512,11 @@ pub const ContentHasher = struct {
 // this is just being nice
 pub fn cheapPrefixNormalizer(prefix: []const u8, suffix: []const u8) [2]string {
     if (prefix.len == 0) {
+        // If path is absolute (starts with /), don't add ./ prefix.
+        // This preserves absolute paths for compile mode where assets should be served from root.
+        if (strings.startsWithChar(suffix, '/')) {
+            return .{ "", suffix };
+        }
         const suffix_no_slash = bun.strings.removeLeadingDotSlash(suffix);
         return .{
             if (strings.hasPrefixComptime(suffix_no_slash, "../")) "" else "./",

--- a/test/regression/issue/24180.test.ts
+++ b/test/regression/issue/24180.test.ts
@@ -64,11 +64,14 @@ export default {
 
   expect(buildStderr).not.toContain("error");
   expect(buildExitCode).toBe(0);
-  expect(fs.existsSync(outfile)).toBe(true);
+
+  // On Windows, the compiler may append ".exe" to the output file
+  const exePath = fs.existsSync(outfile) ? outfile : outfile + ".exe";
+  expect(fs.existsSync(exePath)).toBe(true);
 
   // Run the compiled executable with await using for automatic cleanup
   await using serverProc = Bun.spawn({
-    cmd: [outfile],
+    cmd: [exePath],
     cwd: dir,
     env: bunEnv,
     stdout: "pipe",

--- a/test/regression/issue/24180.test.ts
+++ b/test/regression/issue/24180.test.ts
@@ -98,7 +98,9 @@ export default {
   }
   reader.releaseLock();
 
-  expect(port).not.toBeNull();
+  if (port === null) {
+    throw new Error(`Failed to detect server port from stderr output:\n${stderrOutput}`);
+  }
 
   // Fetch the HTML from the root route
   const rootUrl = `http://localhost:${port}/`;

--- a/test/regression/issue/24180.test.ts
+++ b/test/regression/issue/24180.test.ts
@@ -98,7 +98,9 @@ export default {
   expect(port).not.toBeNull();
 
   // Fetch the HTML from the root route
-  const res = await fetch(`http://localhost:${port}/`);
+  const rootUrl = `http://localhost:${port}/`;
+  const res = await fetch(rootUrl);
+  expect(res.status).toBe(200);
   const html = await res.text();
 
   // Check that the CSS and JS paths are absolute, not relative

--- a/test/regression/issue/24180.test.ts
+++ b/test/regression/issue/24180.test.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "bun:test";
+import fs from "fs";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import path from "path";
+
+// https://github.com/oven-sh/bun/issues/24180
+// When building fullstack apps with --compile, asset paths in HTML should be
+// absolute (starting with `/`) not relative (starting with `./`). Relative paths
+// cause 404 errors when navigating to routes other than `/`.
+test("fullstack compile uses absolute asset paths in generated HTML", async () => {
+  const dir = tempDirWithFiles("24180", {
+    "index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <script type="module" src="./client.ts"></script>
+    <div id="app">Hello</div>
+  </body>
+</html>
+`,
+    "styles.css": `
+body {
+  background: red;
+}
+`,
+    "client.ts": `
+console.log("loaded");
+`,
+    "server.ts": `
+import html from "./index.html";
+
+export default {
+  port: 0,
+  static: {
+    "/": html,
+    "/about": html,
+  },
+  fetch(req) {
+    return new Response("Not found", { status: 404 });
+  },
+};
+`,
+  });
+
+  const outfile = path.join(dir, "myapp");
+
+  // Build the fullstack app with --compile
+  const buildProc = Bun.spawn({
+    cmd: [bunExe(), "build", "--compile", "./server.ts", "--outfile", outfile],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [buildStdout, buildStderr, buildExitCode] = await Promise.all([
+    new Response(buildProc.stdout).text(),
+    new Response(buildProc.stderr).text(),
+    buildProc.exited,
+  ]);
+
+  expect(buildStderr).not.toContain("error");
+  expect(buildExitCode).toBe(0);
+  expect(fs.existsSync(outfile)).toBe(true);
+
+  // Run the compiled executable
+  const serverProc = Bun.spawn({
+    cmd: [outfile],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // Wait for the server to start and capture the port
+  const reader = serverProc.stdout.getReader();
+  let output = "";
+  let port: number | null = null;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    output += new TextDecoder().decode(value);
+    const match = output.match(/localhost:(\d+)/);
+    if (match) {
+      port = parseInt(match[1], 10);
+      break;
+    }
+  }
+
+  expect(port).not.toBeNull();
+
+  try {
+    // Fetch the HTML from the root route
+    const res = await fetch(`http://localhost:${port}/`);
+    const html = await res.text();
+
+    // Check that the CSS and JS paths are absolute, not relative
+    // They should start with `/` not `./`
+    const cssMatch = html.match(/href="([^"]+\.css)"/);
+    const jsMatch = html.match(/src="([^"]+\.js)"/);
+
+    expect(cssMatch).not.toBeNull();
+    expect(jsMatch).not.toBeNull();
+
+    const cssPath = cssMatch![1];
+    const jsPath = jsMatch![1];
+
+    // Verify paths are absolute (start with /)
+    expect(cssPath.startsWith("/")).toBe(true);
+    expect(jsPath.startsWith("/")).toBe(true);
+
+    // Verify paths don't use relative notation
+    expect(cssPath.startsWith("./")).toBe(false);
+    expect(jsPath.startsWith("./")).toBe(false);
+
+    // Also verify the assets are actually accessible
+    const cssRes = await fetch(`http://localhost:${port}${cssPath}`);
+    expect(cssRes.status).toBe(200);
+    const cssContent = await cssRes.text();
+    expect(cssContent).toContain("background");
+
+    const jsRes = await fetch(`http://localhost:${port}${jsPath}`);
+    expect(jsRes.status).toBe(200);
+    const jsContent = await jsRes.text();
+    expect(jsContent).toContain("loaded");
+  } finally {
+    serverProc.kill();
+    await serverProc.exited;
+  }
+});

--- a/test/regression/issue/24180.test.ts
+++ b/test/regression/issue/24180.test.ts
@@ -81,6 +81,7 @@ export default {
   // Read stderr to get the dynamically assigned port
   // The server outputs something like "Started development server: http://localhost:PORT"
   const reader = serverProc.stderr.getReader();
+  const decoder = new TextDecoder();
   let stderrOutput = "";
   let port: number | null = null;
 
@@ -88,7 +89,7 @@ export default {
   while (Date.now() < deadline) {
     const { done, value } = await reader.read();
     if (done) break;
-    stderrOutput += new TextDecoder().decode(value);
+    stderrOutput += decoder.decode(value, { stream: true });
     // Match various host formats: localhost:PORT, 127.0.0.1:PORT, [::1]:PORT, http://host:PORT
     const match = stderrOutput.match(/(?:https?:\/\/)?(?:\[[^\]]+\]|[\w.-]+):(\d+)/);
     if (match) {


### PR DESCRIPTION
## Summary
- Fixes #24180 - CSS/JS resources fail to load on routes other than root in fullstack compiled apps
- When building fullstack apps with `--compile`, asset paths in HTML were relative (starting with `./`) which caused 404 errors when navigating to routes other than `/`
- For example, `/about` would try to load `/about/style.css` instead of `/style.css`

## Changes
1. Sets asset/chunk/entry naming templates to use `/` prefix for client transpiler in compile mode (`src/bundler/bundle_v2.zig`)
2. Preserves absolute paths in `cheapPrefixNormalizer` instead of prepending `./` (`src/bundler/bundle_v2.zig`)
3. Skips relative path calculation when paths start with `/` (`src/bundler/Chunk.zig`)

## Test plan
- [x] Added regression test `test/regression/issue/24180.test.ts`
- [x] Test verifies paths start with `/` not `./`
- [x] Test verifies assets are accessible from the server
- [x] Verified test fails with system bun (without fix) and passes with debug build (with fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)