### PR TITLE
fix(bundler): fix out-of-bounds access in DynamicBitSetUnmanaged.bytes()

### DIFF
--- a/src/collections/bit_set.zig
+++ b/src/collections/bit_set.zig
@@ -880,7 +880,7 @@ pub const DynamicBitSetUnmanaged = struct {
     }
 
     pub fn bytes(self: Self) []const u8 {
-        return std.mem.sliceAsBytes(self.masks[0 .. numMasks(self.bit_length) + 1]);
+        return std.mem.sliceAsBytes(self.masks[0..numMasks(self.bit_length)]);
     }
 
     /// Returns the total number of set bits in this bit set.


### PR DESCRIPTION
## Summary

Fixes an index out-of-bounds panic that occurs during bundler code splitting on Windows.

- The `bytes()` function in `DynamicBitSetUnmanaged` was accessing `masks[0..numMasks(bit_length) + 1]`, reading one element past the allocated array
- When the bit set has exactly one mask (bit_length <= 64), this causes a panic: "index out of bounds: index 1, len 1"
- The bug manifests when sorting chunk deduplication keys derived from `AutoBitSet.bytes()`

The fix simply removes the erroneous `+ 1` from the slice bounds.

## Test plan

- [x] `bun bd test test/bundler/bundler_splitting.test.ts` - passes
- [x] `bun bd test test/bundler/esbuild/splitting.test.ts` - passes
- [x] `bun bd test test/bundler/bundler_regressions.test.ts` - passes
- [x] `bun bd test test/bundler/bundler_edgecase.test.ts` - passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)