### PR TITLE
fix(event_loop): handle termination exceptions in handleRejectedPromises

### DIFF
--- a/src/bun.js.zig
+++ b/src/bun.js.zig
@@ -476,7 +476,7 @@ pub const Run = struct {
         }
 
         vm.onUnhandledRejection = &onUnhandledRejectionBeforeClose;
-        vm.global.handleRejectedPromises();
+        vm.global.handleRejectedPromises() catch {};
         vm.onExit();
 
         if (this.any_unhandled and !printed_sourcemap_warning_and_version) {

--- a/src/bun.js/Debugger.zig
+++ b/src/bun.js/Debugger.zig
@@ -202,7 +202,7 @@ fn start(other_vm: *VirtualMachine) void {
         Bun__startJSDebuggerThread(this.global, debugger.script_execution_context_id, &url, 0, debugger.mode == .connect);
     }
 
-    this.global.handleRejectedPromises();
+    this.global.handleRejectedPromises() catch {};
 
     if (this.log.msgs.items.len > 0) {
         this.log.print(Output.errorWriter()) catch {};

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1935,7 +1935,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
                     switch (promise.status()) {
                         .fulfilled => {
-                            globalThis.handleRejectedPromises();
+                            globalThis.handleRejectedPromises() catch {};
                             break :brk .{ .success = {} };
                         },
                         .rejected => {
@@ -1943,7 +1943,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                             break :brk .{ .rejection = promise.result(globalThis.vm()) };
                         },
                         .pending => {
-                            globalThis.handleRejectedPromises();
+                            globalThis.handleRejectedPromises() catch {};
                             if (node_http_response) |node_response| {
                                 if (node_response.flags.request_has_completed or node_response.flags.socket_closed or node_response.flags.upgraded) {
                                     strong_promise.deinit();

--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -601,8 +601,13 @@ pub const JSGlobalObject = opaque {
     }
 
     extern fn JSC__JSGlobalObject__handleRejectedPromises(*JSGlobalObject) void;
-    pub fn handleRejectedPromises(this: *JSGlobalObject) void {
-        return bun.jsc.fromJSHostCallGeneric(this, @src(), JSC__JSGlobalObject__handleRejectedPromises, .{this}) catch @panic("unreachable");
+    pub fn handleRejectedPromises(this: *JSGlobalObject) bun.JSTerminated!void {
+        var scope: jsc.CatchScope = undefined;
+        scope.init(this, @src());
+        defer scope.deinit();
+
+        JSC__JSGlobalObject__handleRejectedPromises(this);
+        try scope.assertNoExceptionExceptTermination();
     }
 
     extern fn ZigGlobalObject__readableStreamToArrayBuffer(*JSGlobalObject, JSValue) JSValue;

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -397,7 +397,7 @@ pub fn autoTick(this: *EventLoop) void {
     }
 
     ctx.onAfterEventLoop();
-    this.global.handleRejectedPromises();
+    this.global.handleRejectedPromises() catch {};
 }
 
 pub fn tickPossiblyForever(this: *EventLoop) void {
@@ -494,7 +494,7 @@ pub fn tick(this: *EventLoop) void {
     const global_vm = ctx.jsc_vm;
 
     while (true) {
-        while (this.tickWithCount(ctx) > 0) : (this.global.handleRejectedPromises()) {
+        while (this.tickWithCount(ctx) > 0) : (this.global.handleRejectedPromises() catch {}) {
             this.tickConcurrent();
         } else {
             this.drainMicrotasksWithGlobal(global, global_vm) catch return;
@@ -509,7 +509,7 @@ pub fn tick(this: *EventLoop) void {
         this.tickConcurrent();
     }
 
-    this.global.handleRejectedPromises();
+    this.global.handleRejectedPromises() catch {};
 }
 
 pub fn tickWithoutJS(this: *EventLoop) void {

--- a/src/bun.js/test/bun_test.zig
+++ b/src/bun.js/test/bun_test.zig
@@ -658,7 +658,7 @@ pub const BunTest = struct {
                         promise.setHandled();
 
             const prev_unhandled_count = vm.unhandled_error_counter;
-            globalThis.handleRejectedPromises();
+            globalThis.handleRejectedPromises() catch break;
             if (vm.unhandled_error_counter == prev_unhandled_count)
                 break;
         }

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -560,7 +560,7 @@ pub const Expect = struct {
         var return_value: JSValue = .zero;
 
         // Drain existing unhandled rejections
-        vm.global.handleRejectedPromises();
+        vm.global.handleRejectedPromises() catch {};
 
         var scope = vm.unhandledRejectionScope();
         const prev_unhandled_pending_rejection_to_capture = vm.unhandled_pending_rejection_to_capture;
@@ -569,7 +569,7 @@ pub const Expect = struct {
         return_value_from_function = value.call(globalThis, .js_undefined, &.{}) catch |err| globalThis.takeException(err);
         vm.unhandled_pending_rejection_to_capture = prev_unhandled_pending_rejection_to_capture;
 
-        vm.global.handleRejectedPromises();
+        vm.global.handleRejectedPromises() catch {};
 
         if (return_value == .zero) {
             return_value = return_value_from_function;

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1960,7 +1960,7 @@ pub const TestCommand = struct {
                     vm.eventLoop().tick();
 
                     while (prev_unhandled_count < vm.unhandled_error_counter) {
-                        vm.global.handleRejectedPromises();
+                        vm.global.handleRejectedPromises() catch break;
                         prev_unhandled_count = vm.unhandled_error_counter;
                     }
                 }
@@ -1968,7 +1968,7 @@ pub const TestCommand = struct {
                 vm.eventLoop().tickImmediateTasks(vm);
             }
 
-            vm.global.handleRejectedPromises();
+            vm.global.handleRejectedPromises() catch {};
 
             if (Output.is_github_action) {
                 Output.prettyErrorln("<r>\n::endgroup::\n", .{});


### PR DESCRIPTION
## Summary
- Fix panic when terminating workers with pending unhandled promise rejections
- Change `handleRejectedPromises` to return `bun.JSTerminated!void` and properly handle termination exceptions
- Update all callers to handle the error appropriately

## Test plan
- [x] Added test: "worker terminate with unhandled promise rejections" 
- [x] Test passes with fix, times out without fix (confirming the bug is fixed)
- [x] No new test regressions (existing failing tests were already failing before changes)

Fixes the panic reported in https://bun.report/1.3.6/Ma1d530ed9gDqgggC2zr+3CukulGmskkGmogsF+wzwiBm752Eu519E2mhB+oX__A0eNorzStKTUzOSEzKSQUAG3AEew/view

🤖 Generated with [Claude Code](https://claude.com/claude-code)