### PR TITLE
fix(windows): chunk large buffers in preadv/pwritev to avoid integer overflow

### DIFF
--- a/src/sys_uv.zig
+++ b/src/sys_uv.zig
@@ -572,8 +572,9 @@ pub fn write(fd: FileDescriptor, buf: []const u8) Maybe(usize) {
 
 pub const Tag = @import("./sys.zig").Tag;
 
-const bun = @import("bun");
 const std = @import("std");
+
+const bun = @import("bun");
 const Environment = bun.Environment;
 const FileDescriptor = bun.FileDescriptor;
 const Maybe = bun.sys.Maybe;

--- a/src/sys_uv.zig
+++ b/src/sys_uv.zig
@@ -284,38 +284,79 @@ pub fn closeAllowingStdoutAndStderr(fd: FileDescriptor) ?bun.sys.Error {
     return fd.closeAllowingStandardIo(@returnAddress());
 }
 
+/// Maximum number of iovec buffers that can be passed to uv_fs_read/uv_fs_write.
+/// libuv uses c_uint for nbufs, so we must not exceed its maximum value.
+const max_iovec_count: usize = std.math.maxInt(c_uint);
+
+/// Maximum size of a single buffer in uv_buf_t.
+/// libuv uses ULONG (u32) for the buffer length on Windows.
+const max_buf_len: usize = std.math.maxInt(u32);
+
 pub fn preadv(fd: FileDescriptor, bufs: []const bun.PlatformIOVec, position: i64) Maybe(usize) {
     const uv_fd = fd.uv();
     comptime bun.assert(bun.PlatformIOVec == uv.uv_buf_t);
 
     const debug_timer = bun.Output.DebugTimer.start();
 
-    var req: uv.fs_t = uv.fs_t.uninitialized;
-    defer req.deinit();
+    var total_read: usize = 0;
+    var remaining_bufs = bufs;
+    var current_position = position;
 
-    const rc = uv.uv_fs_read(
-        uv.Loop.get(),
-        &req,
-        uv_fd,
-        bufs.ptr,
-        @intCast(bufs.len),
-        position,
-        null,
-    );
+    while (remaining_bufs.len > 0) {
+        const chunk_len = @min(remaining_bufs.len, max_iovec_count);
+        const chunk_bufs = remaining_bufs[0..chunk_len];
 
-    if (Environment.isDebug) {
-        var total_bytes: usize = 0;
-        for (bufs) |buf| {
-            total_bytes += buf.len;
+        var req: uv.fs_t = uv.fs_t.uninitialized;
+        defer req.deinit();
+
+        const rc = uv.uv_fs_read(
+            uv.Loop.get(),
+            &req,
+            uv_fd,
+            chunk_bufs.ptr,
+            @intCast(chunk_len),
+            current_position,
+            null,
+        );
+
+        if (Environment.isDebug) {
+            var chunk_bytes: usize = 0;
+            for (chunk_bufs) |buf| {
+                chunk_bytes += buf.len;
+            }
+            log("uv read({}, {d} total bytes) = {d} ({f})", .{ uv_fd, chunk_bytes, rc.int(), debug_timer });
         }
-        log("uv read({}, {d} total bytes) = {d} ({f})", .{ uv_fd, total_bytes, rc.int(), debug_timer });
+
+        if (rc.errno()) |errno| {
+            return .{ .err = .{ .errno = errno, .fd = fd, .syscall = .read } };
+        }
+
+        const bytes_read: usize = @intCast(rc.int());
+        total_read += bytes_read;
+
+        // If we read less than requested, we're done (EOF or partial read)
+        if (bytes_read == 0) {
+            break;
+        }
+
+        // Check if this chunk was fully read by comparing bytes read to chunk capacity
+        var chunk_capacity: usize = 0;
+        for (chunk_bufs) |buf| {
+            chunk_capacity += buf.len;
+        }
+        if (bytes_read < chunk_capacity) {
+            break;
+        }
+
+        remaining_bufs = remaining_bufs[chunk_len..];
+
+        // Update position for the next chunk (if position tracking is enabled)
+        if (current_position >= 0) {
+            current_position += @intCast(bytes_read);
+        }
     }
 
-    if (rc.errno()) |errno| {
-        return .{ .err = .{ .errno = errno, .fd = fd, .syscall = .read } };
-    } else {
-        return .{ .result = @as(usize, @intCast(rc.int())) };
-    }
+    return .{ .result = total_read };
 }
 
 pub fn pwritev(fd: FileDescriptor, bufs: []const bun.PlatformIOVecConst, position: i64) Maybe(usize) {
@@ -324,65 +365,215 @@ pub fn pwritev(fd: FileDescriptor, bufs: []const bun.PlatformIOVecConst, positio
 
     const debug_timer = bun.Output.DebugTimer.start();
 
-    var req: uv.fs_t = uv.fs_t.uninitialized;
-    defer req.deinit();
+    var total_written: usize = 0;
+    var remaining_bufs = bufs;
+    var current_position = position;
 
-    const rc = uv.uv_fs_write(
-        uv.Loop.get(),
-        &req,
-        uv_fd,
-        bufs.ptr,
-        @intCast(bufs.len),
-        position,
-        null,
-    );
+    while (remaining_bufs.len > 0) {
+        const chunk_len = @min(remaining_bufs.len, max_iovec_count);
+        const chunk_bufs = remaining_bufs[0..chunk_len];
 
-    if (Environment.isDebug) {
-        var total_bytes: usize = 0;
-        for (bufs) |buf| {
-            total_bytes += buf.len;
+        var req: uv.fs_t = uv.fs_t.uninitialized;
+        defer req.deinit();
+
+        const rc = uv.uv_fs_write(
+            uv.Loop.get(),
+            &req,
+            uv_fd,
+            chunk_bufs.ptr,
+            @intCast(chunk_len),
+            current_position,
+            null,
+        );
+
+        if (Environment.isDebug) {
+            var chunk_bytes: usize = 0;
+            for (chunk_bufs) |buf| {
+                chunk_bytes += buf.len;
+            }
+            log("uv write({}, {d} total bytes) = {d} ({f})", .{ uv_fd, chunk_bytes, rc.int(), debug_timer });
         }
-        log("uv write({}, {d} total bytes) = {d} ({f})", .{ uv_fd, total_bytes, rc.int(), debug_timer });
+
+        if (rc.errno()) |errno| {
+            return .{ .err = .{ .errno = errno, .fd = fd, .syscall = .write } };
+        }
+
+        const bytes_written: usize = @intCast(rc.int());
+        total_written += bytes_written;
+
+        // If we wrote less than requested, we're done (partial write)
+        if (bytes_written == 0) {
+            break;
+        }
+
+        // Check if this chunk was fully written by comparing bytes written to chunk capacity
+        var chunk_capacity: usize = 0;
+        for (chunk_bufs) |buf| {
+            chunk_capacity += buf.len;
+        }
+        if (bytes_written < chunk_capacity) {
+            break;
+        }
+
+        remaining_bufs = remaining_bufs[chunk_len..];
+
+        // Update position for the next chunk (if position tracking is enabled)
+        if (current_position >= 0) {
+            current_position += @intCast(bytes_written);
+        }
     }
 
-    if (rc.errno()) |errno| {
-        return .{ .err = .{ .errno = errno, .fd = fd, .syscall = .write } };
-    } else {
-        return .{ .result = @as(usize, @intCast(rc.int())) };
-    }
+    return .{ .result = total_written };
 }
 
 pub inline fn readv(fd: FileDescriptor, bufs: []bun.PlatformIOVec) Maybe(usize) {
     return preadv(fd, bufs, -1);
 }
 
-pub inline fn pread(fd: FileDescriptor, buf: []u8, position: i64) Maybe(usize) {
-    var bufs: [1]bun.PlatformIOVec = .{bun.platformIOVecCreate(buf)};
-    return preadv(fd, &bufs, position);
+pub fn pread(fd: FileDescriptor, buf: []u8, position: i64) Maybe(usize) {
+    // If buffer fits in a single uv_buf_t, use the simple path
+    if (buf.len <= max_buf_len) {
+        var bufs: [1]bun.PlatformIOVec = .{bun.platformIOVecCreate(buf)};
+        return preadv(fd, &bufs, position);
+    }
+
+    // Buffer is too large, need to chunk it
+    var total_read: usize = 0;
+    var remaining = buf;
+    var current_position = position;
+
+    while (remaining.len > 0) {
+        const chunk_len = @min(remaining.len, max_buf_len);
+        var bufs: [1]bun.PlatformIOVec = .{bun.platformIOVecCreate(remaining[0..chunk_len])};
+
+        switch (preadv(fd, &bufs, current_position)) {
+            .err => |err| return .{ .err = err },
+            .result => |bytes_read| {
+                total_read += bytes_read;
+
+                if (bytes_read == 0 or bytes_read < chunk_len) {
+                    break;
+                }
+
+                remaining = remaining[chunk_len..];
+                if (current_position >= 0) {
+                    current_position += @intCast(bytes_read);
+                }
+            },
+        }
+    }
+
+    return .{ .result = total_read };
 }
 
-pub inline fn read(fd: FileDescriptor, buf: []u8) Maybe(usize) {
-    var bufs: [1]bun.PlatformIOVec = .{bun.platformIOVecCreate(buf)};
-    return readv(fd, &bufs);
+pub fn read(fd: FileDescriptor, buf: []u8) Maybe(usize) {
+    // If buffer fits in a single uv_buf_t, use the simple path
+    if (buf.len <= max_buf_len) {
+        var bufs: [1]bun.PlatformIOVec = .{bun.platformIOVecCreate(buf)};
+        return readv(fd, &bufs);
+    }
+
+    // Buffer is too large, need to chunk it
+    var total_read: usize = 0;
+    var remaining = buf;
+
+    while (remaining.len > 0) {
+        const chunk_len = @min(remaining.len, max_buf_len);
+        var bufs: [1]bun.PlatformIOVec = .{bun.platformIOVecCreate(remaining[0..chunk_len])};
+
+        switch (readv(fd, &bufs)) {
+            .err => |err| return .{ .err = err },
+            .result => |bytes_read| {
+                total_read += bytes_read;
+
+                if (bytes_read == 0 or bytes_read < chunk_len) {
+                    break;
+                }
+
+                remaining = remaining[chunk_len..];
+            },
+        }
+    }
+
+    return .{ .result = total_read };
 }
 
 pub inline fn writev(fd: FileDescriptor, bufs: []bun.PlatformIOVec) Maybe(usize) {
     return pwritev(fd, bufs, -1);
 }
 
-pub inline fn pwrite(fd: FileDescriptor, buf: []const u8, position: i64) Maybe(usize) {
-    var bufs: [1]bun.PlatformIOVec = .{bun.platformIOVecCreate(buf)};
-    return pwritev(fd, &bufs, position);
+pub fn pwrite(fd: FileDescriptor, buf: []const u8, position: i64) Maybe(usize) {
+    // If buffer fits in a single uv_buf_t, use the simple path
+    if (buf.len <= max_buf_len) {
+        var bufs: [1]bun.PlatformIOVecConst = .{bun.platformIOVecConstCreate(buf)};
+        return pwritev(fd, &bufs, position);
+    }
+
+    // Buffer is too large, need to chunk it
+    var total_written: usize = 0;
+    var remaining = buf;
+    var current_position = position;
+
+    while (remaining.len > 0) {
+        const chunk_len = @min(remaining.len, max_buf_len);
+        var bufs: [1]bun.PlatformIOVecConst = .{bun.platformIOVecConstCreate(remaining[0..chunk_len])};
+
+        switch (pwritev(fd, &bufs, current_position)) {
+            .err => |err| return .{ .err = err },
+            .result => |bytes_written| {
+                total_written += bytes_written;
+
+                if (bytes_written == 0 or bytes_written < chunk_len) {
+                    break;
+                }
+
+                remaining = remaining[chunk_len..];
+                if (current_position >= 0) {
+                    current_position += @intCast(bytes_written);
+                }
+            },
+        }
+    }
+
+    return .{ .result = total_written };
 }
 
-pub inline fn write(fd: FileDescriptor, buf: []const u8) Maybe(usize) {
-    var bufs: [1]bun.PlatformIOVec = .{bun.platformIOVecCreate(buf)};
-    return writev(fd, &bufs);
+pub fn write(fd: FileDescriptor, buf: []const u8) Maybe(usize) {
+    // If buffer fits in a single uv_buf_t, use the simple path
+    if (buf.len <= max_buf_len) {
+        var bufs: [1]bun.PlatformIOVecConst = .{bun.platformIOVecConstCreate(buf)};
+        return writev(fd, &bufs);
+    }
+
+    // Buffer is too large, need to chunk it
+    var total_written: usize = 0;
+    var remaining = buf;
+
+    while (remaining.len > 0) {
+        const chunk_len = @min(remaining.len, max_buf_len);
+        var bufs: [1]bun.PlatformIOVecConst = .{bun.platformIOVecConstCreate(remaining[0..chunk_len])};
+
+        switch (writev(fd, &bufs)) {
+            .err => |err| return .{ .err = err },
+            .result => |bytes_written| {
+                total_written += bytes_written;
+
+                if (bytes_written == 0 or bytes_written < chunk_len) {
+                    break;
+                }
+
+                remaining = remaining[chunk_len..];
+            },
+        }
+    }
+
+    return .{ .result = total_written };
 }
 
 pub const Tag = @import("./sys.zig").Tag;
 
 const bun = @import("bun");
+const std = @import("std");
 const Environment = bun.Environment;
 const FileDescriptor = bun.FileDescriptor;
 const Maybe = bun.sys.Maybe;


### PR DESCRIPTION
## Summary
- Fix panic "integer does not fit in destination type" when reading/writing large files on Windows
- Add chunking for iovec arrays that exceed `c_uint` max entries
- Add chunking for individual buffers that exceed 4GB (`u32` max)

The libuv functions `uv_fs_read` and `uv_fs_write` have two size limitations:
1. `nbufs` parameter is `c_uint` (32-bit), limiting the number of iovec entries
2. `uv_buf_t.len` is `ULONG` (u32 on Windows), limiting individual buffer sizes to 4GB

This change processes large operations in chunks, accumulating results and updating file positions between chunks.

## Test plan
- [x] Verified `bun run zig:check-all` passes on all platforms
- [x] Verified `bun bd` builds successfully
- [x] Verified basic file read/write operations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)