### PR TITLE
fix(bundler): prevent stale FDs errors in Bun.build and server.reload when run with --hot or --watch

### DIFF
--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1014,7 +1014,10 @@ pub const Resolver = struct {
                     const symlink_path = query.entry.symlink(&r.fs.fs, r.store_fd);
                     if (symlink_path.len > 0) {
                         path.setRealpath(symlink_path);
-                        if (!result.file_fd.isValid()) result.file_fd = query.entry.cache.fd;
+                        // Non-owning resolvers must not borrow cached FDs (see store_fd).
+                        if (!result.file_fd.isValid() and r.store_fd) {
+                            result.file_fd = query.entry.cache.fd;
+                        }
 
                         if (r.debug_logs) |*debug| {
                             debug.addNoteFmt("Resolved symlink \"{s}\" to \"{s}\"", .{ path.text, symlink_path });
@@ -1051,7 +1054,10 @@ pub const Resolver = struct {
                             debug.addNoteFmt("Resolved symlink \"{s}\" to \"{s}\"", .{ symlink, path.text });
                         }
                         query.entry.cache.symlink = PathString.init(symlink);
-                        if (!result.file_fd.isValid() and store_fd) result.file_fd = query.entry.cache.fd;
+                        // Non-owning resolvers must not borrow cached FDs (see store_fd).
+                        if (!result.file_fd.isValid() and store_fd) {
+                            result.file_fd = query.entry.cache.fd;
+                        }
 
                         path.setRealpath(symlink);
                     }
@@ -2491,7 +2497,7 @@ pub const Resolver = struct {
                         .primary = Path.initWithNamespace(absolute_out_path, "file"),
                     },
                     .dirname_fd = entries.fd,
-                    .file_fd = entry_query.entry.cache.fd,
+                    .file_fd = if (r.store_fd) entry_query.entry.cache.fd else bun.invalid_fd,
                     .dir_info = resolved_dir_info,
                     .diff_case = entry_query.diff_case,
                     .is_node_module = true,
@@ -3841,7 +3847,7 @@ pub const Resolver = struct {
                     .path = abs_path,
                     .diff_case = query.diff_case,
                     .dirname_fd = entries.fd,
-                    .file_fd = query.entry.cache.fd,
+                    .file_fd = if (r.store_fd) query.entry.cache.fd else bun.invalid_fd,
                 };
             }
         }
@@ -3916,7 +3922,7 @@ pub const Resolver = struct {
                                 },
                                 .diff_case = query.diff_case,
                                 .dirname_fd = entries.fd,
-                                .file_fd = query.entry.cache.fd,
+                                .file_fd = if (r.store_fd) query.entry.cache.fd else bun.invalid_fd,
                             };
                         }
                     }
@@ -3969,7 +3975,7 @@ pub const Resolver = struct {
                     },
                     .diff_case = query.diff_case,
                     .dirname_fd = entries.fd,
-                    .file_fd = query.entry.cache.fd,
+                    .file_fd = if (r.store_fd) query.entry.cache.fd else bun.invalid_fd,
                 };
             }
         }

--- a/test/regression/issue/18242.test.ts
+++ b/test/regression/issue/18242.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/18242
+// NotOpenForReading for subsequent builds. Same root cause as #9517 and #26075:
+// FileSystemRouter caches FDs, BundleThread (store_fd=false) borrows and closes
+// them, subsequent builds get NotOpenForReading errors.
+
+test("Multiple Bun.build calls with FileSystemRouter entrypoints should not fail", async () => {
+  const dir = tempDirWithFiles("issue-18242", {
+    "pages/index.ts": `console.log("Hello via Bun!");`,
+    "build.ts": `import path from 'path';
+
+const PROJECT_ROOT = process.cwd();
+const PAGES_DIR = path.resolve(PROJECT_ROOT, 'pages');
+
+const srcRouter = new Bun.FileSystemRouter({
+  dir: PAGES_DIR,
+  style: 'nextjs',
+});
+
+const entrypoints = Object.values(srcRouter.routes);
+
+async function build() {
+  console.log("Starting first build...");
+  const first = await Bun.build({
+    entrypoints: entrypoints,
+    outdir: "dist/browser",
+  });
+  if (!first.success) {
+    const errors = first.logs.map(k => Bun.inspect(k)).join("\\n");
+    throw new Error("First build failed: " + errors);
+  }
+  console.log("First build complete");
+
+  console.log("Starting second build...");
+  const second = await Bun.build({
+    entrypoints: entrypoints,
+    outdir: "dist/bun",
+    target: "bun",
+  });
+  if (!second.success) {
+    const errors = second.logs.map(k => Bun.inspect(k)).join("\\n");
+    throw new Error("Second build failed: " + errors);
+  }
+  console.log("Second build complete");
+}
+
+await build();
+console.log("SUCCESS: Both builds completed");`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build.ts"],
+    cwd: dir,
+    env: bunEnv,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  // Should not have the characteristic error from #18242
+  expect(stderr).not.toContain("NotOpenForReading");
+  expect(stderr).not.toContain("Unexpected reading file");
+  expect(stderr).not.toContain("EBADF");
+
+  // Both builds should complete successfully
+  expect(stdout).toContain("First build complete");
+  expect(stdout).toContain("Second build complete");
+  expect(stdout).toContain("SUCCESS: Both builds completed");
+
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/26075.test.ts
+++ b/test/regression/issue/26075.test.ts
@@ -1,0 +1,125 @@
+import { expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, symlinkSync } from "fs";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { join } from "path";
+
+// Test for https://github.com/oven-sh/bun/issues/26075
+// server.reload() with HMR breaks bundler on second request when workspace
+// packages are resolved through directory symlinks.
+
+function setupMonorepo() {
+  const dir = tempDirWithFiles("server-reload-hmr-workspace", {
+    "packages/shared/package.json": JSON.stringify({
+      name: "@test/shared",
+      version: "1.0.0",
+      main: "index.ts",
+    }),
+    "packages/shared/index.ts": `export const APP_NAME = "Test App";
+export const VERSION = "1.0.0";`,
+    "packages/app/index.html": `<!DOCTYPE html>
+<html>
+<head><title>Test</title></head>
+<body>
+<div id="root"></div>
+<script type="module" src="./main.ts"></script>
+</body>
+</html>`,
+    "packages/app/main.ts": `import { APP_NAME, VERSION } from "@test/shared";
+document.getElementById("root")!.textContent = APP_NAME + " v" + VERSION;`,
+    "packages/app/server.ts": `import homepage from "./index.html";
+import { APP_NAME } from "@test/shared";
+import { writeFileSync } from "fs";
+
+const server = Bun.serve({
+  port: 0,
+  development: true,
+  routes: {
+    "/health": () => Response.json({ status: "starting" }),
+  },
+  fetch: () => new Response("Starting...", { status: 503 }),
+});
+
+server.reload({
+  development: { hmr: true },
+  routes: {
+    "/": homepage,
+    "/health": () => Response.json({ status: "ok", app: APP_NAME }),
+  },
+  fetch: () => new Response("Not Found", { status: 404 }),
+});
+
+writeFileSync(process.env.PORT_FILE!, String(server.port));`,
+  });
+
+  // Create workspace-style directory symlinks — the bug trigger.
+  mkdirSync(join(dir, "node_modules", "@test"), { recursive: true });
+  symlinkSync(join(dir, "packages", "shared"), join(dir, "node_modules", "@test", "shared"));
+
+  return dir;
+}
+
+async function getPortFromStartedServer(serverProc: ReturnType<typeof Bun.spawn>, portFile: string): Promise<number> {
+  const deadline = Date.now() + 5000;
+
+  while (Date.now() < deadline) {
+    // Fail fast if the server process already exited
+    const raceResult = await Promise.race([
+      serverProc.exited.then(() => "exited" as const),
+      Bun.sleep(50).then(() => "timeout" as const),
+    ]);
+    if (raceResult === "exited") {
+      const stderr = await new Response(serverProc.stderr).text();
+      const stdout = await new Response(serverProc.stdout).text();
+      throw new Error(`Server process exited early. stdout: ${stdout}, stderr: ${stderr}`);
+    }
+    if (existsSync(portFile)) {
+      const content = readFileSync(portFile, "utf8").trim();
+      const parsed = parseInt(content, 10);
+      if (!isNaN(parsed) && parsed > 0) {
+        return parsed;
+      }
+    }
+  }
+
+  const stderr = await new Response(serverProc.stderr).text();
+  const stdout = await new Response(serverProc.stdout).text();
+  throw new Error(`Server failed to start. stdout: ${stdout}, stderr: ${stderr}`);
+}
+
+for (const flag of ["--hot", "--watch"]) {
+  test(`server.reload() with html bundle and ${flag} should handle workspace packages on multiple requests`, async () => {
+    const dir = setupMonorepo();
+    const portFile = join(dir, ".port");
+
+    await using serverProc = Bun.spawn({
+      cmd: [bunExe(), flag, join(dir, "packages/app/server.ts")],
+      cwd: join(dir, "packages/app"),
+      env: { ...bunEnv, PORT_FILE: portFile },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const port = await getPortFromStartedServer(serverProc, portFile);
+    const baseUrl = `http://localhost:${port}`;
+
+    // First request — bundles the HTML route
+    const res1 = await fetch(baseUrl);
+    expect(res1.status).toBe(200);
+    const html1 = await res1.text();
+    expect(html1).toContain("<html");
+
+    // Second request — before the fix, stale FD caused EBADF here
+    const res2 = await fetch(baseUrl);
+    expect(res2.status).toBe(200);
+    const html2 = await res2.text();
+    expect(html2).toContain("<html");
+
+    // Third request — stability check
+    const res3 = await fetch(baseUrl);
+    expect(res3.status).toBe(200);
+
+    // Health endpoint — uses shared module on server side
+    const healthRes = await fetch(`${baseUrl}/health`);
+    expect(healthRes.status).toBe(200);
+    expect(await healthRes.json()).toEqual({ status: "ok", app: "Test App" });
+  });
+}

--- a/test/regression/issue/9517.test.ts
+++ b/test/regression/issue/9517.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { join } from "path";
+
+// Regression test for https://github.com/oven-sh/bun/issues/9517
+// Intermittent errors with Bun.build and Bun.FileSystemRouter when importing
+// absolute paths. Same root cause as #26075: non-owning resolvers borrow
+// cached FDs from the singleton FileSystem cache.
+
+test("FileSystemRouter + Bun.build should not cause intermittent file reading errors", async () => {
+  const dir = tempDirWithFiles("issue-9517", {
+    "pages/index.ts": `export default function home() {
+  return "Home Page";
+}`,
+    // Placeholder - will be overwritten with absolute path
+    "pages/_entry.ts": `PLACEHOLDER`,
+    "server.ts": `const router = new Bun.FileSystemRouter({
+  style: "nextjs",
+  dir: "./pages",
+});
+
+async function doBuild() {
+  const result = await Bun.build({
+    entrypoints: ['./pages/_entry.ts'],
+  });
+
+  if (!result.success) {
+    const errors = result.logs.map(k => Bun.inspect(k)).join("\\n");
+    throw new Error("Build failed: " + errors);
+  }
+
+  return result.outputs.find(k => k.kind === 'entry-point');
+}
+
+// Multiple builds to trigger the stale FD race condition.
+await doBuild();
+console.log("Build 1 success");
+
+await doBuild();
+console.log("Build 2 success");
+
+console.log("SUCCESS: All builds completed");`,
+  });
+
+  // Write the _entry.ts file with absolute path to trigger the bug
+  // (issue #9517 specifically mentions that absolute paths trigger it)
+  const indexPath = join(dir, "pages/index.ts");
+  await Bun.write(
+    join(dir, "pages/_entry.ts"),
+    `import PageComponent from "${indexPath.replace(/\\/g, "/")}";
+console.log("Loaded:", PageComponent.name);
+export { PageComponent };`,
+  );
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "server.ts"],
+    cwd: dir,
+    env: bunEnv,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  // Should not have file reading errors characteristic of the bug
+  expect(stderr).not.toContain("Unexpected reading file");
+  expect(stderr).not.toContain("NotOpenForReading");
+  expect(stderr).not.toContain("EBADF");
+  expect(stderr).not.toContain("bad file descriptor");
+
+  // All builds should succeed
+  expect(stdout).toContain("Build 1 success");
+  expect(stdout).toContain("Build 2 success");
+  expect(stdout).toContain("SUCCESS: All builds completed");
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #26075
Fixes #25551
Fixes #11123
Fixes #9517
Fixes #18242
Fixes #25373
Fixes #17607

Fixes a bug where non-owning resolvers could borrow cached file descriptors from the singleton FileSystem cache, close them via ParseTask, and leave stale FD numbers in the cache. This manifests as "Unexpected reading file", "Unseekable reading file", "NotOpenForReading", or 500 errors on subsequent builds/requests. This happens with both `--hot` and `--watch` in at least bun 1.3.9.

The bug requires `--hot`/`--watch` flag and one of these triggers:
2. A monorepo workspace w/symlinks + `server.reload()` + HMR (#26075)
3. `FileSystemRouter` + repeated `Bun.build()` calls (#9517, #25551, #11123, #18242)

> Note: Probably does not address #2538 — this seems like an unrelated docker permission issue that I was unable to replicate, and likely a mistaken link added in original robobun PR (#26087).
> Should close @robobun PRs (#26087 and #26079) which do not address the root cause

**Root Cause**

The VM resolver (`--hot`/`--watch` → `store_fd=true`) caches file descriptors in the singleton FileSystem's `DirEntry.Entry.cache.fd`. The BundleThread resolver (`store_fd=false`) shares the same singleton and was borrowing those cached FDs — despite not owning them. After the first bundle, `ParseTask` closes the FD (because `bun_watcher == null` for BundleThread), but the singleton cache still holds the now-closed FD number. On the second bundle, `seekTo(0)` fails with EBADF.

**Fix: `src/resolver/resolver.zig`** — 5 sites fixed:

The guard for reading cached FDs should check `store_fd`. `store_fd` is the resolver's declaration of FD ownership: when `true`, the resolver owns and manages cached FDs; when `false`, it must not borrow them because its `ParseTask` will close them after use, invalidating the cache for the owning resolver.

- Lines ~1017, ~2494, ~3844, ~3919, ~3972: added `r.store_fd` ownership guard (previously unguarded)

This follows Zig allocator semantics — the question isn't "are we low on FDs" (scarcity) but "does this resolver own the FDs in the cache" (ownership).

### How did you verify your code works?

- [x] `test/regression/issue/26075.test.ts` — `server.reload()` with both `--hot` and `--watch` in monorepo workspace
- [x] `test/regression/issue/9517.test.ts` — `FileSystemRouter` + repeated `Bun.build()` with absolute paths
- [x] `test/regression/issue/18242.test.ts` — Multiple `Bun.build()` with `FileSystemRouter` entrypoints
- [x] All 4 tests across 3 files: `USE_SYSTEM_BUN=1` fails, `bun bd test` passes
- [x] Tested against original repro at https://github.com/theshadow27/bun-hmr-reload-bug

🤖 Co-Authored with [Claude Code](https://claude.com/claude-code)
