### PR TITLE
feat: support CPU profiling via environment variables

### DIFF
--- a/src/bun.js.zig
+++ b/src/bun.js.zig
@@ -281,8 +281,8 @@ pub const Run = struct {
             const cpu_prof_opts = this.ctx.runtime_options.cpu_prof;
 
             vm.cpu_profiler_config = CPUProfiler.CPUProfilerConfig{
-                .name = if (cpu_prof_opts.name.len > 0) cpu_prof_opts.name else bun.env_var.BUN_CPU_PROFILE_NAME.get() orelse "",
-                .dir = if (cpu_prof_opts.dir.len > 0) cpu_prof_opts.dir else bun.env_var.BUN_CPU_PROFILE_DIR.get() orelse "",
+                .name = cpu_prof_opts.name orelse bun.env_var.BUN_CPU_PROFILE_NAME.get() orelse "",
+                .dir = cpu_prof_opts.dir orelse bun.env_var.BUN_CPU_PROFILE_DIR.get() orelse "",
             };
             CPUProfiler.startCPUProfiler(vm.jsc_vm);
             bun.analytics.Features.cpu_profile += 1;

--- a/src/bun.js.zig
+++ b/src/bun.js.zig
@@ -277,12 +277,12 @@ pub const Run = struct {
         vm.onUnhandledRejection = &onUnhandledRejectionBeforeClose;
 
         // Start CPU profiler if enabled
-        if (this.ctx.runtime_options.cpu_prof.enabled) {
+        if (this.ctx.runtime_options.cpu_prof.enabled or bun.env_var.BUN_CPU_PROFILE.get()) {
             const cpu_prof_opts = this.ctx.runtime_options.cpu_prof;
 
             vm.cpu_profiler_config = CPUProfiler.CPUProfilerConfig{
-                .name = cpu_prof_opts.name,
-                .dir = cpu_prof_opts.dir,
+                .name = if (cpu_prof_opts.name.len > 0) cpu_prof_opts.name else bun.env_var.BUN_CPU_PROFILE_NAME.get() orelse "",
+                .dir = if (cpu_prof_opts.dir.len > 0) cpu_prof_opts.dir else bun.env_var.BUN_CPU_PROFILE_DIR.get() orelse "",
             };
             CPUProfiler.startCPUProfiler(vm.jsc_vm);
             bun.analytics.Features.cpu_profile += 1;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -390,8 +390,8 @@ pub const Command = struct {
         console_depth: ?u16 = null,
         cpu_prof: struct {
             enabled: bool = false,
-            name: []const u8 = "",
-            dir: []const u8 = "",
+            name: ?[]const u8 = null,
+            dir: ?[]const u8 = null,
         } = .{},
     };
 

--- a/src/env_var.zig
+++ b/src/env_var.zig
@@ -37,6 +37,9 @@ pub const BUN_CONFIG_DISABLE_ioctl_ficlonerange = New(kind.boolean, "BUN_CONFIG_
 ///
 /// It's unclear why this was done.
 pub const BUN_CONFIG_DNS_TIME_TO_LIVE_SECONDS = New(kind.unsigned, "BUN_CONFIG_DNS_TIME_TO_LIVE_SECONDS", .{ .default = 30 });
+pub const BUN_CPU_PROFILE = New(kind.boolean, "BUN_CPU_PROFILE", .{ .default = false });
+pub const BUN_CPU_PROFILE_DIR = New(kind.string, "BUN_CPU_PROFILE_DIR", .{});
+pub const BUN_CPU_PROFILE_NAME = New(kind.string, "BUN_CPU_PROFILE_NAME", .{});
 pub const BUN_CRASH_REPORT_URL = New(kind.string, "BUN_CRASH_REPORT_URL", .{});
 pub const BUN_DEBUG = New(kind.string, "BUN_DEBUG", .{});
 pub const BUN_DEBUG_ALL = New(kind.boolean, "BUN_DEBUG_ALL", .{});


### PR DESCRIPTION
Adds environment variable support for enabling CPU profiling without CLI flags:

- `BUN_CPU_PROFILE=1` — enables the CPU profiler
- `BUN_CPU_PROFILE_DIR=<path>` — sets the output directory for the profile
- `BUN_CPU_PROFILE_NAME=<name>` — sets the profile file name

These are used as fallbacks when the corresponding `--cpu-prof` CLI options are not provided. This is useful for profiling in contexts where modifying the command line isn't practical (e.g. scripts invoked by other tools).