### PR TITLE
fix(process): handle Object.prototype methods on Windows process.env

### DIFF
--- a/test/regression/issue/26315.test.ts
+++ b/test/regression/issue/26315.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/26315
+// process.env.hasOwnProperty() throws on Windows because the Windows proxy
+// doesn't handle inherited Object.prototype methods
+
+test("process.env.hasOwnProperty works", () => {
+  // hasOwnProperty should be a function
+  expect(typeof process.env.hasOwnProperty).toBe("function");
+
+  // Use a temporary env var to test hasOwnProperty
+  const testKey = "__TEST_HAS_OWN_PROPERTY_26315__";
+  const originalValue = process.env[testKey];
+
+  try {
+    process.env[testKey] = "test_value";
+    // Should return true for existing env vars
+    expect(process.env.hasOwnProperty(testKey)).toBe(true);
+
+    delete process.env[testKey];
+    // Should return false for non-existent env vars
+    expect(process.env.hasOwnProperty(testKey)).toBe(false);
+  } finally {
+    if (originalValue !== undefined) {
+      process.env[testKey] = originalValue;
+    } else {
+      delete process.env[testKey];
+    }
+  }
+});
+
+test("process.env.propertyIsEnumerable works", () => {
+  expect(typeof process.env.propertyIsEnumerable).toBe("function");
+
+  // Use a temporary env var to test propertyIsEnumerable
+  const testKey = "__TEST_PROP_IS_ENUM_26315__";
+  const originalValue = process.env[testKey];
+
+  try {
+    process.env[testKey] = "test_value";
+    // Should be enumerable for existing env vars
+    expect(process.env.propertyIsEnumerable(testKey)).toBe(true);
+
+    delete process.env[testKey];
+    // Non-existent vars should not be enumerable
+    expect(process.env.propertyIsEnumerable(testKey)).toBe(false);
+  } finally {
+    if (originalValue !== undefined) {
+      process.env[testKey] = originalValue;
+    } else {
+      delete process.env[testKey];
+    }
+  }
+});
+
+test("process.env.toString works", () => {
+  expect(typeof process.env.toString).toBe("function");
+  expect(process.env.toString()).toBe("[object Object]");
+});
+
+test("process.env.valueOf works", () => {
+  expect(typeof process.env.valueOf).toBe("function");
+  // valueOf should return the proxy itself
+  expect(process.env.valueOf()).toBe(process.env);
+});
+
+test("process.env.isPrototypeOf works", () => {
+  expect(typeof process.env.isPrototypeOf).toBe("function");
+  expect(process.env.isPrototypeOf({})).toBe(false);
+});
+
+test("env var named after Object.prototype method is accessible", () => {
+  // If someone sets an env var named "HASOWNPROPERTY", that should be accessible
+  // via the uppercase name, while the lowercase still returns the method (like Node.js)
+  const originalValue = process.env.HASOWNPROPERTY;
+
+  try {
+    process.env.HASOWNPROPERTY = "custom_value";
+    // The method is still accessible via lowercase (matching Node.js behavior)
+    expect(typeof process.env.hasOwnProperty).toBe("function");
+    // The env var is accessible via uppercase
+    expect(process.env.HASOWNPROPERTY).toBe("custom_value");
+  } finally {
+    if (originalValue !== undefined) {
+      process.env.HASOWNPROPERTY = originalValue;
+    } else {
+      delete process.env.HASOWNPROPERTY;
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- Fixes `process.env.hasOwnProperty()` throwing "TypeError: environment.hasOwnProperty is not a function" on Windows
- The Windows `process.env` Proxy now correctly returns inherited `Object.prototype` methods when no env var exists with that name
- Methods are bound to the proxy so they work correctly (e.g., `hasOwnProperty` checks the proxy, not the underlying object)

Fixes #26315

## Test plan

- [x] Added regression test at `test/regression/issue/26315.test.ts`
- [x] Test verifies `hasOwnProperty`, `propertyIsEnumerable`, `toString`, `valueOf`, and `isPrototypeOf` work correctly
- [x] Test verifies env vars with names matching Object.prototype methods are still accessible via uppercase

🤖 Generated with [Claude Code](https://claude.com/claude-code)