### PR TITLE
fix(shell): pass literal pattern when glob matches no files

### DIFF
--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -640,11 +640,11 @@ booga"
   });
 
   describe("glob expansion", () => {
-    // Issue #8403: https://github.com/oven-sh/bun/issues/8403
-    TestBuilder.command`ls *.sdfljsfsdf`
-      .exitCode(1)
-      .stderr("bun: no matches found: *.sdfljsfsdf\n")
-      .runAsTest("No matches should fail");
+    // When a glob pattern matches no files, the literal pattern is passed to the command (bash-like behavior)
+    TestBuilder.command`echo *.sdfljsfsdf`
+      .exitCode(0)
+      .stdout("*.sdfljsfsdf\n")
+      .runAsTest("No matches passes literal pattern to command");
 
     TestBuilder.command`FOO=*.lolwut; echo $FOO`
       .stdout("*.lolwut\n")

--- a/test/regression/issue/26317.test.ts
+++ b/test/regression/issue/26317.test.ts
@@ -1,0 +1,43 @@
+// Regression test for https://github.com/oven-sh/bun/issues/26317
+// Bun's shell should pass literal glob patterns to commands when no files match,
+// instead of failing with "no matches found" (bash-like behavior vs zsh failglob)
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("bun run --shell=bun with unmatched glob should not error", async () => {
+  // Create a temp directory with no dist folder
+  using dir = tempDir("issue-26317", {
+    "package.json": JSON.stringify({
+      scripts: {
+        // This script uses a glob pattern that won't match any files
+        clean: "echo dist/*",
+      },
+    }),
+  });
+
+  // Run the script using bun's shell
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "--shell=bun", "clean"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The literal pattern should be passed to echo, not cause a "no matches found" error
+  expect(stdout.trim()).toBe("dist/*");
+  expect(stderr).not.toContain("no matches found");
+  expect(exitCode).toBe(0);
+});
+
+test("bun shell glob with no matches passes literal pattern", async () => {
+  const { stdout, stderr, exitCode } = await Bun.$`echo nonexistent/*.xyz`.quiet();
+
+  // When no files match, the literal pattern should be passed to the command
+  expect(stdout.toString().trim()).toBe("nonexistent/*.xyz");
+  expect(stderr.toString()).not.toContain("no matches found");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- When a glob pattern doesn't match any files, pass the literal pattern to the command instead of erroring with "no matches found"
- This matches bash's default behavior (vs zsh's failglob)
- Scripts like `rimraf dist/*` now work when `dist` directory doesn't exist

## Test plan

- [x] Added regression test for issue #26317
- [x] Updated existing glob expansion test to expect new behavior
- [x] Verified fix passes with `bun bd test`
- [x] Verified tests fail with `USE_SYSTEM_BUN=1` (before fix)

Fixes #26317

🤖 Generated with [Claude Code](https://claude.com/claude-code)