### PR TITLE
fix(fs): throw catchable error for large files in readFileSync instead of crashing

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -10,7 +10,8 @@ pub export var isBunTest: bool = false;
 
 // TODO: evaluate if this has any measurable performance impact.
 pub var synthetic_allocation_limit: usize = std.math.maxInt(u32);
-pub var string_allocation_limit: usize = std.math.maxInt(u32);
+/// WebKit's String::MaxLength is std::numeric_limits<int32_t>::max() = 2^31-1
+pub var string_allocation_limit: usize = std.math.maxInt(i32);
 
 comptime {
     _ = Bun__remapStackFramePositions;

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -517,7 +517,10 @@ pub fn loadExtraEnvAndSourceCodePrinter(this: *VirtualMachine) void {
         if (map.get("BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT")) |value| {
             if (std.fmt.parseInt(usize, value, 10)) |limit| {
                 synthetic_allocation_limit = limit;
-                string_allocation_limit = limit;
+                // Clamp string_allocation_limit to WebKit's String::MaxLength (2^31-1)
+                // to prevent reintroducing the crash with large string allocations
+                const webkit_max: usize = std.math.maxInt(i32);
+                string_allocation_limit = @min(limit, webkit_max);
             } else |_| {
                 Output.panic("BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT must be a positive integer", .{});
             }

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -4819,20 +4819,30 @@ pub const NodeFS = struct {
     }
 
     fn shouldThrowOutOfMemoryEarlyForJavaScript(encoding: Encoding, size: usize, syscall: Syscall.Tag) ?Syscall.Error {
-        // Strings & typed arrays max out at 4.7 GB.
-        // But, it's **string length**
-        // So you can load an 8 GB hex string, for example, it should be fine.
-        const adjusted_size = switch (encoding) {
-            .utf16le, .ucs2, .utf8 => size / 4 -| 1,
-            .hex => size / 2 -| 1,
-            .base64, .base64url => size / 3 -| 1,
-            .ascii, .latin1, .buffer => size,
+        // The encoding specifies how to ENCODE the raw bytes into a JavaScript string.
+        // We need to estimate the output string length in characters.
+        // WebKit's String::MaxLength is 2^31-1 characters (~2 billion).
+        const output_size, const limit = switch (encoding) {
+            // UTF-16le/UCS-2: 2 bytes per character
+            .utf16le, .ucs2 => .{ size / 2, jsc.VirtualMachine.string_allocation_limit },
+            // UTF-8: For valid UTF-8, output length <= input bytes (ASCII is 1:1,
+            // multi-byte sequences produce fewer UTF-16 code units than bytes)
+            .utf8 => .{ size, jsc.VirtualMachine.string_allocation_limit },
+            // Hex: Each byte produces 2 hex characters
+            .hex => .{ size *| 2, jsc.VirtualMachine.string_allocation_limit },
+            // Base64: ~4 characters per 3 bytes
+            .base64, .base64url => .{ (size *| 4) / 3 +| 1, jsc.VirtualMachine.string_allocation_limit },
+            // ASCII/Latin1: 1 byte = 1 character
+            .ascii, .latin1 => .{ size, jsc.VirtualMachine.string_allocation_limit },
+            // Buffer: Returns a typed array, not a string - check against typed array limit
+            .buffer => .{ size, jsc.VirtualMachine.synthetic_allocation_limit },
         };
 
         if (
-        // Typed arrays in JavaScript are limited to 4.7 GB.
-        adjusted_size > jsc.VirtualMachine.synthetic_allocation_limit or
-            // If they do not have enough memory to open the file and they're on Linux, let's throw an error instead of dealing with the OOM killer.
+        // Check against the appropriate JavaScript limit (string or typed array)
+        output_size > limit or
+            // If they do not have enough memory to open the file and they're on Linux,
+            // let's throw an error instead of dealing with the OOM killer.
             (Environment.isLinux and size >= bun.getTotalMemorySize()))
         {
             return Syscall.Error.fromCode(.NOMEM, syscall);
@@ -5054,6 +5064,12 @@ pub const NodeFS = struct {
             };
 
             if (did_succeed) {
+                // Check size limit even for small files read in one go
+                if (args.limit_size_for_javascript) {
+                    if (shouldThrowOutOfMemoryEarlyForJavaScript(args.encoding, total, .read)) |err| {
+                        return .{ .err = err.withPathLike(args.path) };
+                    }
+                }
                 switch (args.encoding) {
                     .buffer => {
                         if (comptime flavor == .sync and string_type == .default) {

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -4830,8 +4830,8 @@ pub const NodeFS = struct {
             .utf8 => .{ size, jsc.VirtualMachine.string_allocation_limit },
             // Hex: Each byte produces 2 hex characters
             .hex => .{ size *| 2, jsc.VirtualMachine.string_allocation_limit },
-            // Base64: ~4 characters per 3 bytes
-            .base64, .base64url => .{ (size *| 4) / 3 +| 1, jsc.VirtualMachine.string_allocation_limit },
+            // Base64: ceil(size / 3) * 4 characters (every 3 bytes produce 4 chars, with padding)
+            .base64, .base64url => .{ ((size +| 2) / 3) *| 4, jsc.VirtualMachine.string_allocation_limit },
             // ASCII/Latin1: 1 byte = 1 character
             .ascii, .latin1 => .{ size, jsc.VirtualMachine.string_allocation_limit },
             // Buffer: Returns a typed array, not a string - check against typed array limit

--- a/test/regression/issue/26323.test.ts
+++ b/test/regression/issue/26323.test.ts
@@ -159,10 +159,9 @@ try {
     expect(exitCode).toBe(0);
   });
 
-  test("should allow reading files as buffer even when larger than string limit", async () => {
+  test("should allow reading files as buffer within the limit", async () => {
     // When reading as buffer (no encoding), the synthetic_allocation_limit is used
-    // which is the same as string_allocation_limit when set via env var
-    // But buffer reading is checked against synthetic_allocation_limit
+    // This test verifies that buffers within the limit can still be read
     using dir = tempDir("readfile-buffer-limit", {
       "data.bin": "x".repeat(500),
     });

--- a/test/regression/issue/26323.test.ts
+++ b/test/regression/issue/26323.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("fs.readFileSync", () => {
+  test("should throw catchable error for files exceeding string length limit with utf-8 encoding", async () => {
+    // Create a file that exceeds the lowered string limit
+    // We set BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT to 1000 bytes
+    // and create a 2000 byte file, which should exceed the limit
+    using dir = tempDir("readfile-string-limit", {
+      "large.txt": "x".repeat(2000),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+const fs = require("fs");
+try {
+  const content = fs.readFileSync("large.txt", "utf-8");
+  console.log("ERROR: Should have thrown but got content length:", content.length);
+  process.exit(1);
+} catch (error) {
+  console.log("Caught error:", error.code);
+  process.exit(0);
+}
+`,
+      ],
+      env: {
+        ...bunEnv,
+        // BUN_GARBAGE_COLLECTOR_LEVEL must be set for BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT to be processed
+        BUN_GARBAGE_COLLECTOR_LEVEL: "0",
+        BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT: "1000",
+      },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Should exit cleanly with code 0 (caught the error)
+    expect(stdout).toContain("Caught error: ENOMEM");
+    expect(exitCode).toBe(0);
+  });
+
+  test("should throw catchable error for files exceeding string length limit with ascii encoding", async () => {
+    using dir = tempDir("readfile-string-limit-ascii", {
+      "large.txt": "x".repeat(2000),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+const fs = require("fs");
+try {
+  const content = fs.readFileSync("large.txt", "ascii");
+  console.log("ERROR: Should have thrown but got content length:", content.length);
+  process.exit(1);
+} catch (error) {
+  console.log("Caught error:", error.code);
+  process.exit(0);
+}
+`,
+      ],
+      env: {
+        ...bunEnv,
+        // BUN_GARBAGE_COLLECTOR_LEVEL must be set for BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT to be processed
+        BUN_GARBAGE_COLLECTOR_LEVEL: "0",
+        BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT: "1000",
+      },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("Caught error: ENOMEM");
+    expect(exitCode).toBe(0);
+  });
+
+  test("should throw catchable error for hex encoding when output exceeds limit", async () => {
+    // Hex encoding doubles the size: 600 bytes -> 1200 chars > 1000 limit
+    using dir = tempDir("readfile-string-limit-hex", {
+      "data.bin": "x".repeat(600),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+const fs = require("fs");
+try {
+  const content = fs.readFileSync("data.bin", "hex");
+  console.log("ERROR: Should have thrown but got content length:", content.length);
+  process.exit(1);
+} catch (error) {
+  console.log("Caught error:", error.code);
+  process.exit(0);
+}
+`,
+      ],
+      env: {
+        ...bunEnv,
+        // BUN_GARBAGE_COLLECTOR_LEVEL must be set for BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT to be processed
+        BUN_GARBAGE_COLLECTOR_LEVEL: "0",
+        BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT: "1000",
+      },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("Caught error: ENOMEM");
+    expect(exitCode).toBe(0);
+  });
+
+  test("should allow reading files within the limit", async () => {
+    using dir = tempDir("readfile-within-limit", {
+      "small.txt": "x".repeat(500),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+const fs = require("fs");
+try {
+  const content = fs.readFileSync("small.txt", "utf-8");
+  console.log("Success: read", content.length, "chars");
+  process.exit(0);
+} catch (error) {
+  console.log("ERROR: Unexpected error:", error.code);
+  process.exit(1);
+}
+`,
+      ],
+      env: {
+        ...bunEnv,
+        // BUN_GARBAGE_COLLECTOR_LEVEL must be set for BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT to be processed
+        BUN_GARBAGE_COLLECTOR_LEVEL: "0",
+        BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT: "1000",
+      },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("Success: read 500 chars");
+    expect(exitCode).toBe(0);
+  });
+
+  test("should allow reading files as buffer even when larger than string limit", async () => {
+    // When reading as buffer (no encoding), the synthetic_allocation_limit is used
+    // which is the same as string_allocation_limit when set via env var
+    // But buffer reading is checked against synthetic_allocation_limit
+    using dir = tempDir("readfile-buffer-limit", {
+      "data.bin": "x".repeat(500),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+const fs = require("fs");
+try {
+  const content = fs.readFileSync("data.bin");
+  console.log("Success: read", content.length, "bytes as buffer");
+  process.exit(0);
+} catch (error) {
+  console.log("ERROR: Unexpected error:", error.code);
+  process.exit(1);
+}
+`,
+      ],
+      env: {
+        ...bunEnv,
+        // BUN_GARBAGE_COLLECTOR_LEVEL must be set for BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT to be processed
+        BUN_GARBAGE_COLLECTOR_LEVEL: "0",
+        BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT: "1000",
+      },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("Success: read 500 bytes as buffer");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/regression/issue/26323.test.ts
+++ b/test/regression/issue/26323.test.ts
@@ -7,7 +7,7 @@ describe("fs.readFileSync", () => {
     // We set BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT to 1000 bytes
     // and create a 2000 byte file, which should exceed the limit
     using dir = tempDir("readfile-string-limit", {
-      "large.txt": "x".repeat(2000),
+      "large.txt": Buffer.alloc(2000, "x").toString(),
     });
 
     await using proc = Bun.spawn({
@@ -46,7 +46,7 @@ try {
 
   test("should throw catchable error for files exceeding string length limit with ascii encoding", async () => {
     using dir = tempDir("readfile-string-limit-ascii", {
-      "large.txt": "x".repeat(2000),
+      "large.txt": Buffer.alloc(2000, "x").toString(),
     });
 
     await using proc = Bun.spawn({
@@ -85,7 +85,7 @@ try {
   test("should throw catchable error for hex encoding when output exceeds limit", async () => {
     // Hex encoding doubles the size: 600 bytes -> 1200 chars > 1000 limit
     using dir = tempDir("readfile-string-limit-hex", {
-      "data.bin": "x".repeat(600),
+      "data.bin": Buffer.alloc(600, "x").toString(),
     });
 
     await using proc = Bun.spawn({
@@ -123,7 +123,7 @@ try {
 
   test("should allow reading files within the limit", async () => {
     using dir = tempDir("readfile-within-limit", {
-      "small.txt": "x".repeat(500),
+      "small.txt": Buffer.alloc(500, "x").toString(),
     });
 
     await using proc = Bun.spawn({
@@ -163,7 +163,7 @@ try {
     // When reading as buffer (no encoding), the synthetic_allocation_limit is used
     // This test verifies that buffers within the limit can still be read
     using dir = tempDir("readfile-buffer-limit", {
-      "data.bin": "x".repeat(500),
+      "data.bin": Buffer.alloc(500, "x").toString(),
     });
 
     await using proc = Bun.spawn({


### PR DESCRIPTION
## Summary
- Fixed `fs.readFileSync` crashing with SIGTRAP (exit code 133) when reading files larger than ~2GB with string-producing encodings like "utf-8"
- Now throws a catchable `ENOMEM` error like Node.js does (`Error: Cannot create a string longer than 0x1fffffe8 characters`)
- Corrected the output size estimation logic in `shouldThrowOutOfMemoryEarlyForJavaScript` which was backwards
- Set `string_allocation_limit` to match WebKit's `String::MaxLength` (~2GB)

## Test plan
- [x] Added regression test in `test/regression/issue/26323.test.ts`
- [x] Verified test fails with `USE_SYSTEM_BUN=1` and passes with `bun bd test`
- [x] Manual testing with 2.5GB file shows error is now catchable

Fixes #26323

🤖 Generated with [Claude Code](https://claude.com/claude-code)