### PR TITLE
Docs prisma datasource configuration

### DIFF
--- a/docs/guides/ecosystem/prisma-postgres.mdx
+++ b/docs/guides/ecosystem/prisma-postgres.mdx
@@ -48,7 +48,6 @@ mode: center
 
     	datasource db {
     		provider = "postgresql"
-    		url      = env("DATABASE_URL")
     	}
 
     	model User { // [!code ++]

--- a/docs/guides/ecosystem/prisma.mdx
+++ b/docs/guides/ecosystem/prisma.mdx
@@ -49,7 +49,6 @@ mode: center
 
     	  datasource db {
     	    provider = "sqlite"
-    	    url      = env("DATABASE_URL")
     	  }
 
     	  model User { // [!code ++]


### PR DESCRIPTION
### What does this PR do?

Remove DATABASE_URL from datasource configuration

### How did you verify your code works?

In Prisma ORM v7, database URLs moved from `schema.prisma` to `prisma.config.ts`

Prisma docs: https://www.prisma.io/docs/orm/reference/prisma-config-reference#overview

linked PR : https://github.com/oven-sh/bun/pull/25947
