### PR TITLE
fix(sqlite): use libsqlite3.so as default library path on Linux

### DIFF
--- a/src/bun.js/bindings/sqlite/lazy_sqlite3.h
+++ b/src/bun.js/bindings/sqlite/lazy_sqlite3.h
@@ -215,7 +215,7 @@ static const char* sqlite3_lib_path = "sqlite3.dll";
 #elif OS(DARWIN)
 static const char* sqlite3_lib_path = "libsqlite3.dylib";
 #else
-static const char* sqlite3_lib_path = "sqlite3";
+static const char* sqlite3_lib_path = "libsqlite3.so";
 #endif
 
 static HMODULE sqlite3_handle = nullptr;


### PR DESCRIPTION
### What does this PR do?
This PR changes the default SQLite shared library filename from `sqlite3` to `libsqlite3.so` for Linux and other non-Windows/Darwin platforms, when build with `-DUSE_STATIC_SQLITE=OFF`.

### How did you verify your code works?
Without the change when running `bun -e 'import { Database } from "bun:sqlite"; new Database(":memory:"); console.log("OK")'` I get the error:
```
1 | import { Database } from "bun:sqlite"; new Database(":memory:"); console.log("OK")
                                           ^
error: sqlite3: cannot open shared object file: No such file or directory
      at new Database (bun:sqlite:260:28)
      at /tmp/[eval]:1:40
      at loadAndEvaluateModule (2:1)

Bun v1.3.5-canary.1+fa5a5bbe5 (Linux x64)
```

See here: https://gitlab.archlinux.org/archlinux/packaging/packages/bun/-/issues/2

With the change it works as expected:
```
$ bun -e 'import { Database } from "bun:sqlite"; new Database(":memory:"); console.log("OK")'
OK
```