### PR TITLE
fix(install): match npmrc auth tokens by both host and path

### DIFF
--- a/src/ini.zig
+++ b/src/ini.zig
@@ -1306,7 +1306,9 @@ pub fn loadNpmrc(
         for (configs.items) |conf_item| {
             const conf_item_url = bun.URL.parse(conf_item.registry_url);
 
-            if (std.mem.eql(u8, bun.strings.withoutTrailingSlash(default_registry_url.host), bun.strings.withoutTrailingSlash(conf_item_url.host))) {
+            if (std.mem.eql(u8, bun.strings.withoutTrailingSlash(default_registry_url.host), bun.strings.withoutTrailingSlash(conf_item_url.host)) and
+                std.mem.eql(u8, bun.strings.withoutTrailingSlash(default_registry_url.pathname), bun.strings.withoutTrailingSlash(conf_item_url.pathname)))
+            {
                 // Apply config to default registry
                 const v: *bun.schema.api.NpmRegistry = brk: {
                     if (install.default_registry) |*r| break :brk r;
@@ -1343,7 +1345,9 @@ pub fn loadNpmrc(
             for (registry_map.scopes.keys(), registry_map.scopes.values()) |*k, *v| {
                 const url = url_map.get(k.*) orelse unreachable;
 
-                if (std.mem.eql(u8, bun.strings.withoutTrailingSlash(url.host), bun.strings.withoutTrailingSlash(conf_item_url.host))) {
+                if (std.mem.eql(u8, bun.strings.withoutTrailingSlash(url.host), bun.strings.withoutTrailingSlash(conf_item_url.host)) and
+                    std.mem.eql(u8, bun.strings.withoutTrailingSlash(url.pathname), bun.strings.withoutTrailingSlash(conf_item_url.pathname)))
+                {
                     if (conf_item_url.hostname.len > 0) {
                         if (!std.mem.eql(u8, bun.strings.withoutTrailingSlash(url.hostname), bun.strings.withoutTrailingSlash(conf_item_url.hostname))) {
                             continue;


### PR DESCRIPTION
## Summary

- Fixes `.npmrc` auth token matching to consider both host **and** pathname when matching tokens to registries
- Previously, when multiple auth tokens existed for the same host but different paths, the last token would incorrectly be used for all registries
- Now, `//somehost.com/org1/npm/registry/:_authToken=jwt1` correctly only applies to registry URLs with path `/org1/npm/registry/`

## Test plan

- [x] Added unit tests that verify correct token is matched for same-host different-path scenarios
- [x] Verified tests fail with system Bun (pre-fix) and pass with debug build (post-fix)
- [x] Ran existing npmrc tests to ensure no regression

Fixes #26350

🤖 Generated with [Claude Code](https://claude.com/claude-code)