### PR TITLE
Upgrade WebKit to 5b194ac887f2

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -911,7 +911,12 @@ if(WIN32)
 endif()
 
 if(USE_MIMALLOC_AS_DEFAULT_ALLOCATOR)
-  target_compile_definitions(${bun} PRIVATE USE_MIMALLOC=1)
+  # When building with WEBKIT_LOCAL, don't define USE_MIMALLOC here since it's
+  # already defined in WebKit's cmakeconfig.h (as either 0 or 1 depending on
+  # how WebKit was built). This avoids macro redefinition errors.
+  if(NOT WEBKIT_LOCAL)
+    target_compile_definitions(${bun} PRIVATE USE_MIMALLOC=1)
+  endif()
 endif()
 
 target_compile_definitions(${bun} PRIVATE

--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -2,7 +2,7 @@ option(WEBKIT_VERSION "The version of WebKit to use")
 option(WEBKIT_LOCAL "If a local version of WebKit should be used instead of downloading")
 
 if(NOT WEBKIT_VERSION)
-  set(WEBKIT_VERSION 5ae5f07f29059c183a8db2eef2c9aabd474ec73c)
+  set(WEBKIT_VERSION 5b194ac887f29e2a222e2b3fd97e1378ba4f0298)
 endif()
 
 string(SUBSTRING ${WEBKIT_VERSION} 0 16 WEBKIT_VERSION_PREFIX)
@@ -34,7 +34,9 @@ if(WEBKIT_LOCAL)
       ${WEBKIT_PATH}/bmalloc/Headers
       ${WEBKIT_PATH}/WTF/Headers
       ${WEBKIT_PATH}/JavaScriptCore/PrivateHeaders/JavaScriptCore
-      ${WEBKIT_PATH}/JavaScriptCore/DerivedSources/inspector
+      # Note: DerivedSources/inspector is NOT included here because all inspector
+      # headers are already in PrivateHeaders/JavaScriptCore. Including both paths
+      # causes "redefinition" errors since the same headers exist in both locations.
     )
   endif()
 

--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -2,7 +2,7 @@ option(WEBKIT_VERSION "The version of WebKit to use")
 option(WEBKIT_LOCAL "If a local version of WebKit should be used instead of downloading")
 
 if(NOT WEBKIT_VERSION)
-  set(WEBKIT_VERSION 5b194ac887f29e2a222e2b3fd97e1378ba4f0298)
+  set(WEBKIT_VERSION c8e4b57dd997f535040d45c08b8057bad43bfabd)
 endif()
 
 string(SUBSTRING ${WEBKIT_VERSION} 0 16 WEBKIT_VERSION_PREFIX)


### PR DESCRIPTION
## Summary
- Upgrade WebKit to latest upstream (5b194ac887f29e2a222e2b3fd97e1378ba4f0298)
- Fix build issues for local WebKit builds

## WebKit Changes Summary

### Notable Changes
- **bmalloc -> mimalloc migration**: Major allocator change in upstream (disabled for Bun since we use our own mimalloc)
- **B3 compiler**: Removed linear scan register allocator (greedy allocator is now the only option)
- **2.6x faster `[...set]` spread** optimization by Sosuke Suzuki (Bun)
- **2.5x faster `Array.prototype.slice` on ScopedArguments** by Sosuke Suzuki (Bun)
- **String constant folding**: `String.fromCharCode` and `String.prototype.codePointAt` now constant-folded in DFG/FTL

### Bug Fixes Included
- `RegExp.prototype[Symbol.split]` incorrectly used fast path when `limit` is not a number
- `TypedArray.prototype.subarray` calculated `beginByteOffset` incorrectly
- WASM debugger: Fixed deadlock during thread suspension
- DFG: Fixed ValueRep reduction preserving speculation checks

### Build Changes (this PR)
- Removed `DerivedSources/inspector` from include paths (headers already in `PrivateHeaders/JavaScriptCore`)
- Don't define `USE_MIMALLOC` when building with `WEBKIT_LOCAL` (avoids macro redefinition)
- WebKit's `build.ts` updated to disable `USE_MIMALLOC` (Bun uses its own mimalloc)

## Test plan
- [x] Built WebKit with `bun build.ts debug`
- [x] Built Bun with `bun run build:local`
- [x] Verified basic functionality (`bun-debug --print '42'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)