### PR TITLE
fix: use baseline WebKit builds for CPUs without AVX support

### DIFF
--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -79,6 +79,12 @@ if(ENABLE_ASAN)
   set(WEBKIT_SUFFIX "${WEBKIT_SUFFIX}-asan")
 endif()
 
+# Baseline builds require a WebKit compiled without AVX instructions (nehalem target).
+# This only applies to x86_64 builds, as ARM builds don't have this issue.
+if(ENABLE_BASELINE AND CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64|x64|AMD64")
+  set(WEBKIT_SUFFIX "${WEBKIT_SUFFIX}-baseline")
+endif()
+
 setx(WEBKIT_NAME bun-webkit-${WEBKIT_OS}-${WEBKIT_ARCH}${WEBKIT_SUFFIX})
 set(WEBKIT_FILENAME ${WEBKIT_NAME}.tar.gz)
 setx(WEBKIT_DOWNLOAD_URL https://github.com/oven-sh/WebKit/releases/download/autobuild-${WEBKIT_VERSION}/${WEBKIT_FILENAME})


### PR DESCRIPTION
## Summary

- Add `-baseline` suffix to WebKit download URL when `ENABLE_BASELINE` is set on x86_64 builds
- This ensures baseline Bun downloads a WebKit built without AVX instructions (`-march=nehalem` instead of `-march=haswell`)

## Problem

The baseline build of Bun is compiled with `-march=nehalem` (no AVX), but was downloading a WebKit library compiled with `-march=haswell` (includes AVX2). When running on CPUs without AVX support (like older Intel CPUs or some VMs), the WebKit code executed AVX instructions, triggering a SIGILL (illegal instruction) crash:

```
Bun v1.3.6 (d530ed99) Windows x64 (baseline)
CPU: sse42
Features: ... no_avx2 no_avx ...
CPU lacks AVX support. Please consider upgrading to a newer CPU.
panic(main thread): Illegal instruction at address 0x7FF7F28A80FC
```

## Test plan

- [x] Verified CMake logic is correct with unit tests
- [ ] WebKit CI needs to produce baseline variants (`bun-webkit-*-baseline.tar.gz`) built with `-march=nehalem`

> **Note**: This PR prepares the Bun side of the fix. A corresponding change to the WebKit CI (oven-sh/WebKit) is required to produce the baseline WebKit builds.

Fixes #26353

🤖 Generated with [Claude Code](https://claude.com/claude-code)