### PR TITLE
fix(cli): make --compile imply --production as documented

### DIFF
--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -915,7 +915,8 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
         ctx.bundler_options.transform_only = args.flag("--no-bundle");
         ctx.bundler_options.bytecode = args.flag("--bytecode");
 
-        const production = args.flag("--production");
+        const compile = args.flag("--compile");
+        const production = args.flag("--production") or compile;
 
         if (args.flag("--app")) {
             if (!bun.FeatureFlags.bake()) {
@@ -1043,7 +1044,7 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
             }
         }
 
-        if (args.flag("--compile")) {
+        if (compile) {
             ctx.bundler_options.compile = true;
             ctx.bundler_options.inline_entrypoint_import_meta_main = true;
         }
@@ -1436,7 +1437,7 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
             Global.exit(1);
         }
 
-        if (args.flag("--production")) {
+        if (args.flag("--production") or ctx.bundler_options.compile) {
             const any_html = for (opts.entry_points) |entry_point| {
                 if (strings.hasSuffixComptime(entry_point, ".html")) {
                     break true;

--- a/test/regression/issue/26373.test.ts
+++ b/test/regression/issue/26373.test.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Test that --compile implies --production (minification enabled)
+// https://github.com/oven-sh/bun/issues/26373
+
+test("--compile implies --production and enables minification", async () => {
+  using dir = tempDir("issue-26373", {
+    // Use code with long variable names that will be minified in production mode
+    "index.ts": `
+const myVeryLongVariableName = "hello";
+const anotherLongVariableName = "world";
+console.log(myVeryLongVariableName, anotherLongVariableName);
+`,
+  });
+
+  // Build without flags (no minification, larger bundle)
+  await using noMinifyProc = Bun.spawn({
+    cmd: [bunExe(), "build", "--outfile", "no-minify.js", "./index.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [, noMinifyStderr, noMinifyExitCode] = await Promise.all([
+    noMinifyProc.stdout.text(),
+    noMinifyProc.stderr.text(),
+    noMinifyProc.exited,
+  ]);
+
+  expect(noMinifyStderr).toBe("");
+  expect(noMinifyExitCode).toBe(0);
+
+  // Build with --production (minification enabled, smaller bundle)
+  await using productionProc = Bun.spawn({
+    cmd: [bunExe(), "build", "--production", "--outfile", "production.js", "./index.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [, productionStderr, productionExitCode] = await Promise.all([
+    productionProc.stdout.text(),
+    productionProc.stderr.text(),
+    productionProc.exited,
+  ]);
+
+  expect(productionStderr).toBe("");
+  expect(productionExitCode).toBe(0);
+
+  // Read the bundle files
+  const noMinifyContent = await Bun.file(`${dir}/no-minify.js`).text();
+  const productionContent = await Bun.file(`${dir}/production.js`).text();
+
+  // Non-minified should contain the original long variable names
+  expect(noMinifyContent).toContain("myVeryLongVariableName");
+  expect(noMinifyContent).toContain("anotherLongVariableName");
+
+  // Production (minified) should NOT contain the original long variable names
+  expect(productionContent).not.toContain("myVeryLongVariableName");
+  expect(productionContent).not.toContain("anotherLongVariableName");
+
+  // Build with --compile only (should imply --production, including minification)
+  // The output should show "minify" step
+  await using compileProc = Bun.spawn({
+    cmd: [bunExe(), "build", "--compile", "--outfile", "compiled", "./index.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [compileStdout, compileStderr, compileExitCode] = await Promise.all([
+    compileProc.stdout.text(),
+    compileProc.stderr.text(),
+    compileProc.exited,
+  ]);
+
+  expect(compileStderr).toBe("");
+  expect(compileExitCode).toBe(0);
+
+  // The stdout should contain "minify" indicating minification was performed
+  // This is the key assertion that proves --compile implies --production
+  expect(compileStdout).toContain("minify");
+
+  // The compiled executable should run correctly
+  await using runCompiled = Bun.spawn({
+    cmd: [`${dir}/compiled`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [compiledOutput, compiledStderr, runExitCode] = await Promise.all([
+    runCompiled.stdout.text(),
+    runCompiled.stderr.text(),
+    runCompiled.exited,
+  ]);
+
+  expect(compiledStderr).toBe("");
+  expect(compiledOutput).toBe("hello world\n");
+  expect(runExitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Makes `--compile` flag actually imply `--production` as documented in the help text
- Enables minification (minify_syntax, minify_whitespace, minify_identifiers) when using `--compile`
- Sets `bundler_options.production = true` when using `--compile`

## Test plan
- Added regression test `test/regression/issue/26373.test.ts` that verifies:
  - `--compile` produces "minify" output (indicating minification is enabled)
  - Compiled executables run correctly
  - Test fails with current bun and passes with this fix

Fixes #26373

🤖 Generated with [Claude Code](https://claude.ai/code)