### PR TITLE
docs: fix duplicate comment

### DIFF
--- a/docs/guides/deployment/google-cloud-run.mdx
+++ b/docs/guides/deployment/google-cloud-run.mdx
@@ -119,7 +119,6 @@ FROM oven/bun:latest
 COPY package.json bun.lock ./
 
 # Install the dependencies
-# Install the dependencies
 RUN bun install --production --frozen-lockfile
 
 # Copy the rest of the application into the container


### PR DESCRIPTION
Removes duplicate comment line from docs
```diff
 # Copy the package.json and bun.lock into the container
 COPY package.json bun.lock ./
 
-# Install the dependencies
 # Install the dependencies
 RUN bun install --production --frozen-lockfile
 ```