### PR TITLE
fix(node): coerce process.env values to strings like Node.js

### DIFF
--- a/test/regression/issue/26388.test.ts
+++ b/test/regression/issue/26388.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+// Issue #26388: process.env should coerce values to strings like Node.js does
+// When assigning undefined, null, numbers, or objects to process.env properties,
+// Node.js converts them to strings, but Bun was storing the actual JavaScript values.
+
+const TEST_ENV_KEYS = [
+  "TEST_UNDEFINED",
+  "TEST_JSON_UNDEFINED",
+  "TEST_NULL",
+  "TEST_NUMBER",
+  "TEST_TRUE",
+  "TEST_FALSE",
+  "TEST_OBJECT",
+  "TEST_ARRAY",
+  "TEST_STRING",
+  "TEST_EMPTY",
+  "TEST_CUSTOM_TOSTRING",
+  "TEST_SYMBOL",
+  "TEST_OVERWRITE",
+];
+
+describe("process.env string coercion", () => {
+  afterEach(() => {
+    for (const key of TEST_ENV_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  test("undefined is coerced to 'undefined' string", () => {
+    process.env.TEST_UNDEFINED = undefined as unknown as string;
+    expect(process.env.TEST_UNDEFINED).toBe("undefined");
+    expect(typeof process.env.TEST_UNDEFINED).toBe("string");
+  });
+
+  test("JSON.stringify(undefined) is coerced to 'undefined' string", () => {
+    // JSON.stringify(undefined) returns undefined (not the string "undefined")
+    // This is the exact case that breaks Vite 8 + rolldown
+    process.env.TEST_JSON_UNDEFINED = JSON.stringify(undefined) as unknown as string;
+    expect(process.env.TEST_JSON_UNDEFINED).toBe("undefined");
+    expect(typeof process.env.TEST_JSON_UNDEFINED).toBe("string");
+  });
+
+  test("null is coerced to 'null' string", () => {
+    process.env.TEST_NULL = null as unknown as string;
+    expect(process.env.TEST_NULL).toBe("null");
+    expect(typeof process.env.TEST_NULL).toBe("string");
+  });
+
+  test("number is coerced to string", () => {
+    process.env.TEST_NUMBER = 123 as unknown as string;
+    expect(process.env.TEST_NUMBER).toBe("123");
+    expect(typeof process.env.TEST_NUMBER).toBe("string");
+  });
+
+  test("boolean true is coerced to 'true' string", () => {
+    process.env.TEST_TRUE = true as unknown as string;
+    expect(process.env.TEST_TRUE).toBe("true");
+    expect(typeof process.env.TEST_TRUE).toBe("string");
+  });
+
+  test("boolean false is coerced to 'false' string", () => {
+    process.env.TEST_FALSE = false as unknown as string;
+    expect(process.env.TEST_FALSE).toBe("false");
+    expect(typeof process.env.TEST_FALSE).toBe("string");
+  });
+
+  test("object is coerced to '[object Object]' string", () => {
+    process.env.TEST_OBJECT = { foo: "bar" } as unknown as string;
+    expect(process.env.TEST_OBJECT).toBe("[object Object]");
+    expect(typeof process.env.TEST_OBJECT).toBe("string");
+  });
+
+  test("array is coerced to comma-separated string", () => {
+    process.env.TEST_ARRAY = [1, 2, 3] as unknown as string;
+    expect(process.env.TEST_ARRAY).toBe("1,2,3");
+    expect(typeof process.env.TEST_ARRAY).toBe("string");
+  });
+
+  test("string stays as string", () => {
+    process.env.TEST_STRING = "hello";
+    expect(process.env.TEST_STRING).toBe("hello");
+    expect(typeof process.env.TEST_STRING).toBe("string");
+  });
+
+  test("empty string stays as empty string", () => {
+    process.env.TEST_EMPTY = "";
+    expect(process.env.TEST_EMPTY).toBe("");
+    expect(typeof process.env.TEST_EMPTY).toBe("string");
+  });
+
+  test("object with custom toString() uses it", () => {
+    const obj = {
+      toString() {
+        return "custom-string";
+      },
+    };
+    process.env.TEST_CUSTOM_TOSTRING = obj as unknown as string;
+    expect(process.env.TEST_CUSTOM_TOSTRING).toBe("custom-string");
+    expect(typeof process.env.TEST_CUSTOM_TOSTRING).toBe("string");
+  });
+
+  test("Symbol throws TypeError", () => {
+    expect(() => {
+      process.env.TEST_SYMBOL = Symbol("test") as unknown as string;
+    }).toThrow();
+  });
+
+  test("overwriting existing env var coerces to string", () => {
+    process.env.TEST_OVERWRITE = "initial";
+    expect(process.env.TEST_OVERWRITE).toBe("initial");
+
+    process.env.TEST_OVERWRITE = 456 as unknown as string;
+    expect(process.env.TEST_OVERWRITE).toBe("456");
+    expect(typeof process.env.TEST_OVERWRITE).toBe("string");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `Proxy` wrapper for `process.env` on POSIX platforms that coerces all assigned values to strings via `'' + value`, matching Node.js behavior
- Fixes the Windows `windowsEnv` implementation to use `'' + value` instead of `String(value)` so Symbols throw `TypeError` (matching Node.js)
- Adds regression tests covering `undefined`, `null`, numbers, booleans, objects, arrays, Symbols, and custom `toString()`

| Value Assigned | Node.js `process.env.X` | Old Bun | New Bun |
|---------------|-------------------------|---------|---------| 
| `undefined` | `"undefined"` | `undefined` | `"undefined"` |
| `null` | `"null"` | `null` | `"null"` |
| `123` | `"123"` | `123` | `"123"` |
| `Symbol("test")` | throws TypeError | no-op | throws TypeError |

Fixes #26388

## Context

Node.js coerces all values assigned to `process.env` to strings. For example, `process.env.FOO = undefined` results in `process.env.FOO === "undefined"`. Bun was storing raw JavaScript values without coercion, which broke tools like Vite 8 + rolldown that pass `JSON.stringify(undefined)` (which returns JS `undefined`) through `process.env` and expect string values on the other side.

## Test plan

- [x] `bun bd test test/regression/issue/26388.test.ts` — 13/13 tests pass
- [x] `USE_SYSTEM_BUN=1 bun test test/regression/issue/26388.test.ts` — 11/13 tests fail (confirms test validity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)