### PR TITLE
fix(streams): pipeTo now responds to AbortSignal

### DIFF
--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -258,6 +258,9 @@ export function readableStreamPipeToWritableStream(
 
   if (signal !== undefined) {
     const algorithm = reason => {
+      // Resolve the pending read promise to unblock any pending read operation.
+      // This allows the shutdown to proceed without waiting for the read to complete.
+      pipeState.pendingReadPromiseCapability.resolve.$call(undefined, false);
       $pipeToShutdownWithAction(
         pipeState,
         () => {

--- a/test/regression/issue/26392.test.ts
+++ b/test/regression/issue/26392.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert";
+import { test } from "node:test";
+
+// https://github.com/oven-sh/bun/issues/26392
+// ReadableStream.prototype.pipeTo does not respond to AbortSignal
+test("pipeTo responds to AbortSignal", async () => {
+  const abortController = new AbortController();
+  let cancelCalled = false;
+  let abortCalled = false;
+
+  // Promise that resolves when the pipe has started (first write received)
+  const { promise: pipeStartedPromise, resolve: pipeStarted } = Promise.withResolvers<void>();
+
+  const pipePromise = new ReadableStream({
+    start(controller) {
+      // Keep the stream open - don't close it
+      controller.enqueue("data");
+    },
+    cancel(reason) {
+      cancelCalled = true;
+      assert(reason instanceof DOMException);
+      assert.strictEqual(reason.name, "AbortError");
+    },
+  }).pipeTo(
+    new WritableStream({
+      write() {
+        // Signal that the pipe has started processing data
+        pipeStarted();
+      },
+      abort(reason) {
+        abortCalled = true;
+        assert(reason instanceof DOMException);
+        assert.strictEqual(reason.name, "AbortError");
+      },
+    }),
+    { signal: abortController.signal },
+  );
+
+  // Wait for the pipe to actually start processing
+  await pipeStartedPromise;
+
+  // Abort the signal
+  abortController.abort();
+
+  // The promise should reject with an AbortError
+  await assert.rejects(pipePromise, (err: Error) => {
+    assert(err instanceof DOMException);
+    assert.strictEqual(err.name, "AbortError");
+    return true;
+  });
+
+  // Both cancel and abort should have been called
+  assert.strictEqual(cancelCalled, true);
+  assert.strictEqual(abortCalled, true);
+});
+
+test("pipeTo with already aborted signal", async () => {
+  const abortController = new AbortController();
+  abortController.abort();
+
+  let cancelCalled = false;
+  let abortCalled = false;
+
+  const pipePromise = new ReadableStream({
+    start(controller) {
+      controller.enqueue("data");
+    },
+    cancel() {
+      cancelCalled = true;
+    },
+  }).pipeTo(
+    new WritableStream({
+      abort() {
+        abortCalled = true;
+      },
+    }),
+    { signal: abortController.signal },
+  );
+
+  await assert.rejects(pipePromise, (err: Error) => {
+    assert(err instanceof DOMException);
+    assert.strictEqual(err.name, "AbortError");
+    return true;
+  });
+
+  assert.strictEqual(cancelCalled, true);
+  assert.strictEqual(abortCalled, true);
+});
+
+test("pipeTo with preventCancel respects AbortSignal", async () => {
+  const abortController = new AbortController();
+  let cancelCalled = false;
+  let abortCalled = false;
+
+  // Promise that resolves when the pipe has started (first write received)
+  const { promise: pipeStartedPromise, resolve: pipeStarted } = Promise.withResolvers<void>();
+
+  const pipePromise = new ReadableStream({
+    start(controller) {
+      controller.enqueue("data");
+    },
+    cancel() {
+      cancelCalled = true;
+    },
+  }).pipeTo(
+    new WritableStream({
+      write() {
+        pipeStarted();
+      },
+      abort() {
+        abortCalled = true;
+      },
+    }),
+    { signal: abortController.signal, preventCancel: true },
+  );
+
+  await pipeStartedPromise;
+  abortController.abort();
+
+  await assert.rejects(pipePromise, (err: Error) => {
+    assert(err instanceof DOMException);
+    assert.strictEqual(err.name, "AbortError");
+    return true;
+  });
+
+  // cancel should NOT be called because preventCancel is true
+  assert.strictEqual(cancelCalled, false);
+  assert.strictEqual(abortCalled, true);
+});
+
+test("pipeTo with preventAbort respects AbortSignal", async () => {
+  const abortController = new AbortController();
+  let cancelCalled = false;
+  let abortCalled = false;
+
+  // Promise that resolves when the pipe has started (first write received)
+  const { promise: pipeStartedPromise, resolve: pipeStarted } = Promise.withResolvers<void>();
+
+  const pipePromise = new ReadableStream({
+    start(controller) {
+      controller.enqueue("data");
+    },
+    cancel() {
+      cancelCalled = true;
+    },
+  }).pipeTo(
+    new WritableStream({
+      write() {
+        pipeStarted();
+      },
+      abort() {
+        abortCalled = true;
+      },
+    }),
+    { signal: abortController.signal, preventAbort: true },
+  );
+
+  await pipeStartedPromise;
+  abortController.abort();
+
+  await assert.rejects(pipePromise, (err: Error) => {
+    assert(err instanceof DOMException);
+    assert.strictEqual(err.name, "AbortError");
+    return true;
+  });
+
+  assert.strictEqual(cancelCalled, true);
+  // abort should NOT be called because preventAbort is true
+  assert.strictEqual(abortCalled, false);
+});

--- a/test/regression/issue/26392.test.ts
+++ b/test/regression/issue/26392.test.ts
@@ -2,18 +2,17 @@ import assert from "node:assert";
 import { test } from "node:test";
 
 // https://github.com/oven-sh/bun/issues/26392
-// ReadableStream.prototype.pipeTo does not respond to AbortSignal
+// ReadableStream.prototype.pipeTo does not respond to AbortSignal when
+// abort() is called asynchronously (e.g. via setTimeout). The pipe hangs
+// indefinitely because the pending read promise is never resolved.
+
 test("pipeTo responds to AbortSignal", async () => {
   const abortController = new AbortController();
   let cancelCalled = false;
   let abortCalled = false;
 
-  // Promise that resolves when the pipe has started (first write received)
-  const { promise: pipeStartedPromise, resolve: pipeStarted } = Promise.withResolvers<void>();
-
   const pipePromise = new ReadableStream({
     start(controller) {
-      // Keep the stream open - don't close it
       controller.enqueue("data");
     },
     cancel(reason) {
@@ -23,10 +22,6 @@ test("pipeTo responds to AbortSignal", async () => {
     },
   }).pipeTo(
     new WritableStream({
-      write() {
-        // Signal that the pipe has started processing data
-        pipeStarted();
-      },
       abort(reason) {
         abortCalled = true;
         assert(reason instanceof DOMException);
@@ -36,20 +31,18 @@ test("pipeTo responds to AbortSignal", async () => {
     { signal: abortController.signal },
   );
 
-  // Wait for the pipe to actually start processing
-  await pipeStartedPromise;
+  // Abort asynchronously via setTimeout — this is the actual trigger for the
+  // bug. By the time the callback fires, the pipe has processed the enqueued
+  // chunk and started a new pending read that blocks forever. Without the fix,
+  // the pending read promise is never resolved, causing the pipe to hang.
+  setTimeout(() => abortController.abort());
 
-  // Abort the signal
-  abortController.abort();
-
-  // The promise should reject with an AbortError
-  await assert.rejects(pipePromise, (err: Error) => {
+  await assert.rejects(pipePromise, (err) => {
     assert(err instanceof DOMException);
     assert.strictEqual(err.name, "AbortError");
     return true;
   });
 
-  // Both cancel and abort should have been called
   assert.strictEqual(cancelCalled, true);
   assert.strictEqual(abortCalled, true);
 });
@@ -77,7 +70,7 @@ test("pipeTo with already aborted signal", async () => {
     { signal: abortController.signal },
   );
 
-  await assert.rejects(pipePromise, (err: Error) => {
+  await assert.rejects(pipePromise, (err) => {
     assert(err instanceof DOMException);
     assert.strictEqual(err.name, "AbortError");
     return true;
@@ -92,9 +85,6 @@ test("pipeTo with preventCancel respects AbortSignal", async () => {
   let cancelCalled = false;
   let abortCalled = false;
 
-  // Promise that resolves when the pipe has started (first write received)
-  const { promise: pipeStartedPromise, resolve: pipeStarted } = Promise.withResolvers<void>();
-
   const pipePromise = new ReadableStream({
     start(controller) {
       controller.enqueue("data");
@@ -104,9 +94,6 @@ test("pipeTo with preventCancel respects AbortSignal", async () => {
     },
   }).pipeTo(
     new WritableStream({
-      write() {
-        pipeStarted();
-      },
       abort() {
         abortCalled = true;
       },
@@ -114,16 +101,14 @@ test("pipeTo with preventCancel respects AbortSignal", async () => {
     { signal: abortController.signal, preventCancel: true },
   );
 
-  await pipeStartedPromise;
-  abortController.abort();
+  setTimeout(() => abortController.abort());
 
-  await assert.rejects(pipePromise, (err: Error) => {
+  await assert.rejects(pipePromise, (err) => {
     assert(err instanceof DOMException);
     assert.strictEqual(err.name, "AbortError");
     return true;
   });
 
-  // cancel should NOT be called because preventCancel is true
   assert.strictEqual(cancelCalled, false);
   assert.strictEqual(abortCalled, true);
 });
@@ -133,9 +118,6 @@ test("pipeTo with preventAbort respects AbortSignal", async () => {
   let cancelCalled = false;
   let abortCalled = false;
 
-  // Promise that resolves when the pipe has started (first write received)
-  const { promise: pipeStartedPromise, resolve: pipeStarted } = Promise.withResolvers<void>();
-
   const pipePromise = new ReadableStream({
     start(controller) {
       controller.enqueue("data");
@@ -145,9 +127,6 @@ test("pipeTo with preventAbort respects AbortSignal", async () => {
     },
   }).pipeTo(
     new WritableStream({
-      write() {
-        pipeStarted();
-      },
       abort() {
         abortCalled = true;
       },
@@ -155,16 +134,14 @@ test("pipeTo with preventAbort respects AbortSignal", async () => {
     { signal: abortController.signal, preventAbort: true },
   );
 
-  await pipeStartedPromise;
-  abortController.abort();
+  setTimeout(() => abortController.abort());
 
-  await assert.rejects(pipePromise, (err: Error) => {
+  await assert.rejects(pipePromise, (err) => {
     assert(err instanceof DOMException);
     assert.strictEqual(err.name, "AbortError");
     return true;
   });
 
   assert.strictEqual(cancelCalled, true);
-  // abort should NOT be called because preventAbort is true
   assert.strictEqual(abortCalled, false);
 });

--- a/test/regression/issue/26392.test.ts
+++ b/test/regression/issue/26392.test.ts
@@ -37,7 +37,7 @@ test("pipeTo responds to AbortSignal", async () => {
   // the pending read promise is never resolved, causing the pipe to hang.
   setTimeout(() => abortController.abort());
 
-  await assert.rejects(pipePromise, (err) => {
+  await assert.rejects(pipePromise, err => {
     assert(err instanceof DOMException);
     assert.strictEqual(err.name, "AbortError");
     return true;
@@ -70,7 +70,7 @@ test("pipeTo with already aborted signal", async () => {
     { signal: abortController.signal },
   );
 
-  await assert.rejects(pipePromise, (err) => {
+  await assert.rejects(pipePromise, err => {
     assert(err instanceof DOMException);
     assert.strictEqual(err.name, "AbortError");
     return true;
@@ -103,7 +103,7 @@ test("pipeTo with preventCancel respects AbortSignal", async () => {
 
   setTimeout(() => abortController.abort());
 
-  await assert.rejects(pipePromise, (err) => {
+  await assert.rejects(pipePromise, err => {
     assert(err instanceof DOMException);
     assert.strictEqual(err.name, "AbortError");
     return true;
@@ -136,7 +136,7 @@ test("pipeTo with preventAbort respects AbortSignal", async () => {
 
   setTimeout(() => abortController.abort());
 
-  await assert.rejects(pipePromise, (err) => {
+  await assert.rejects(pipePromise, err => {
     assert(err instanceof DOMException);
     assert.strictEqual(err.name, "AbortError");
     return true;


### PR DESCRIPTION
## Summary

- Fix `ReadableStream.prototype.pipeTo()` not responding to the `AbortSignal` parameter
- When the signal is aborted asynchronously (e.g. via `setTimeout`), the abort/cancel callbacks on the streams were not being invoked, causing the process to hang indefinitely

## Root Cause

When the abort signal fires during a `pipeTo` operation, the abort algorithm calls `pipeToShutdownWithAction`. This function waits for `pendingReadPromiseCapability.promise` to resolve before proceeding with the shutdown. However, if the ReadableStream is blocked waiting for data, the pending read promise never resolves, causing an indefinite hang.

## Fix

The fix resolves the `pendingReadPromiseCapability` before invoking `pipeToShutdownWithAction`, following the same pattern used by `pipeToErrorsMustBePropagatedForward` and `pipeToClosingMustBePropagatedForward`. This unblocks any pending read operation and allows the shutdown to proceed.

## Test plan

- [x] Regression test in `test/regression/issue/26392.test.ts` with 4 test cases
- [x] Tests use `setTimeout(() => abortController.abort())` to trigger the actual async abort bug
- [x] Tests use `node:test` + `node:assert` only — no Bun-specific APIs
- [x] Verified passing in **Node.js v24.3.0**: `node --experimental-strip-types --test` → 4/4 pass
- [x] `USE_SYSTEM_BUN=1 bun test` → 3/4 tests timeout (bug confirmed on unfixed Bun)
- [x] Tests verify abort callbacks, preventCancel, and preventAbort options

Fixes #26392

---

Verification (robobun): Lint JavaScript ✅ passed; Buildkite build #41594 in progress (pipeline passed, compilation started). Traced the hang: `pipeToShutdownWithAction` (line 450-454) waits on `pendingReadPromiseCapability.promise` when destination is writable; abort handler was the only shutdown path that calls `pipeToShutdownWithAction` with a potentially-writable destination without first resolving this promise. The other two paths that need this resolve already have it: `pipeToErrorsMustBePropagatedForward` (line 361) and `pipeToClosingMustBePropagatedForward` (line 396). The two paths that omit it (`pipeToErrorsMustBePropagatedBackward`, `pipeToClosingMustBePropagatedBackward`) are safe because their entry conditions guarantee the destination is not writable, skipping the wait branch. Tests exercise the actual async hang via `setTimeout(() => abortController.abort())`; 3/4 timeout on unfixed Bun, confirming regression coverage. No TODO/FIXME/HACK in diff. CodeRabbit reviews are style nits only. Jarred-Sumner CHANGES_REQUESTED (old tests not failing on system Bun) addressed by rewriting to async abort pattern per johngeorgewright feedback.