### PR TITLE
fix(console): print blank line when console methods called with no args

### DIFF
--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -91,6 +91,7 @@ using namespace JSC;
     macro(cwd) \
     macro(data) \
     macro(dataView) \
+    macro(debug) \
     macro(decode) \
     macro(delimiter) \
     macro(dest) \
@@ -105,6 +106,7 @@ using namespace JSC;
     macro(encoding) \
     macro(end) \
     macro(errno) \
+    macro(error) \
     macro(errorSteps) \
     macro(evaluateCommonJSModule) \
     macro(evaluated) \
@@ -139,6 +141,7 @@ using namespace JSC;
     macro(httpOnly) \
     macro(ignoreBOM) \
     macro(importer) \
+    macro(info) \
     macro(inFlightCloseRequest) \
     macro(inFlightWriteRequest) \
     macro(inherits) \
@@ -159,6 +162,7 @@ using namespace JSC;
     macro(lineText) \
     macro(loadEsmIntoCjs) \
     macro(localStreams) \
+    macro(log) \
     macro(main) \
     macro(makeAbortError) \
     macro(makeDOMException) \
@@ -273,6 +277,7 @@ using namespace JSC;
     macro(version) \
     macro(versions) \
     macro(view) \
+    macro(warn) \
     macro(warning) \
     macro(writable) \
     macro(write) \

--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -1,3 +1,48 @@
+// Wrappers for console methods to handle zero-argument calls.
+// JSC's ConsoleClient skips calling messageWithTypeAndLevel when there are no arguments,
+// but Node.js prints an empty line in that case. These wrappers ensure we pass an empty
+// string when called with no arguments, so our messageWithTypeAndLevel is invoked.
+
+export function log(this: Console) {
+  const nativeLog = $getByIdDirectPrivate(this, "log");
+  if ($argumentCount() === 0) {
+    return nativeLog.$call(this, "");
+  }
+  return nativeLog.$apply(this, arguments);
+}
+
+export function warn(this: Console) {
+  const nativeWarn = $getByIdDirectPrivate(this, "warn");
+  if ($argumentCount() === 0) {
+    return nativeWarn.$call(this, "");
+  }
+  return nativeWarn.$apply(this, arguments);
+}
+
+export function error(this: Console) {
+  const nativeError = $getByIdDirectPrivate(this, "error");
+  if ($argumentCount() === 0) {
+    return nativeError.$call(this, "");
+  }
+  return nativeError.$apply(this, arguments);
+}
+
+export function info(this: Console) {
+  const nativeInfo = $getByIdDirectPrivate(this, "info");
+  if ($argumentCount() === 0) {
+    return nativeInfo.$call(this, "");
+  }
+  return nativeInfo.$apply(this, arguments);
+}
+
+export function debug(this: Console) {
+  const nativeDebug = $getByIdDirectPrivate(this, "debug");
+  if ($argumentCount() === 0) {
+    return nativeDebug.$call(this, "");
+  }
+  return nativeDebug.$apply(this, arguments);
+}
+
 $overriddenName = "[Symbol.asyncIterator]";
 export function asyncIterator(this: Console) {
   var stream = Bun.stdin.stream();

--- a/test/regression/issue/26151.test.ts
+++ b/test/regression/issue/26151.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Test for https://github.com/oven-sh/bun/issues/26151
+// console.log() with zero arguments should print an empty line, matching Node.js behavior
+
+describe("console methods with zero arguments print empty line", () => {
+  test("console.log()", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.log("foo"); console.log(); console.log("bar");`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("foo\n\nbar\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("console.info()", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.info("foo"); console.info(); console.info("bar");`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("foo\n\nbar\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("console.debug()", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.debug("foo"); console.debug(); console.debug("bar");`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("foo\n\nbar\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("console.warn()", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.warn("foo"); console.warn(); console.warn("bar");`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("");
+    expect(stderr).toBe("foo\n\nbar\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("console.error()", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.error("foo"); console.error(); console.error("bar");`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("");
+    expect(stderr).toBe("foo\n\nbar\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("console methods with arguments still work normally", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.log("hello", "world"); console.log(123); console.log({ foo: "bar" });`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("hello world");
+    expect(stdout).toContain("123");
+    expect(stdout).toContain("foo");
+    expect(stdout).toContain("bar");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `console.log()`, `console.warn()`, `console.error()`, `console.info()`, and `console.debug()` to print a blank line when called with no arguments, matching Node.js behavior

## Test plan
- Added regression test in `test/regression/issue/26151.test.ts`
- Verified test fails with `USE_SYSTEM_BUN=1` and passes with debug build

Closes #26151

🤖 Generated with [Claude Code](https://claude.ai/code)