### PR TITLE
fix(cmake): use BUILDKITE_BUILD_NUMBER to avoid 302 redirect

### DIFF
--- a/cmake/tools/SetupBuildkite.cmake
+++ b/cmake/tools/SetupBuildkite.cmake
@@ -6,7 +6,8 @@ endif()
 
 optionx(BUILDKITE_ORGANIZATION_SLUG STRING "The organization slug to use on Buildkite" DEFAULT "bun")
 optionx(BUILDKITE_PIPELINE_SLUG STRING "The pipeline slug to use on Buildkite" DEFAULT "bun")
-optionx(BUILDKITE_BUILD_ID STRING "The build ID to use on Buildkite")
+optionx(BUILDKITE_BUILD_ID STRING "The build ID (UUID) to use on Buildkite")
+optionx(BUILDKITE_BUILD_NUMBER STRING "The build number to use on Buildkite")
 optionx(BUILDKITE_GROUP_ID STRING "The group ID to use on Buildkite")
 
 if(ENABLE_BASELINE)
@@ -32,7 +33,13 @@ if(NOT BUILDKITE_BUILD_ID)
   return()
 endif()
 
-setx(BUILDKITE_BUILD_URL https://buildkite.com/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_ID})
+# Use BUILDKITE_BUILD_NUMBER for the URL if available, as the UUID format causes a 302 redirect
+# that CMake's file(DOWNLOAD) doesn't follow, resulting in empty response.
+if(BUILDKITE_BUILD_NUMBER)
+  setx(BUILDKITE_BUILD_URL https://buildkite.com/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER})
+else()
+  setx(BUILDKITE_BUILD_URL https://buildkite.com/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_ID})
+endif()
 setx(BUILDKITE_BUILD_PATH ${BUILDKITE_BUILDS_PATH}/builds/${BUILDKITE_BUILD_ID})
 
 file(


### PR DESCRIPTION
## What does this PR do?

Fixes CMake "No jobs found" error during the build-bun step in CI by using `BUILDKITE_BUILD_NUMBER` instead of `BUILDKITE_BUILD_ID` (UUID) for the Buildkite API URL.

### Problem

When `BUN_LINK_ONLY=ON`, `SetupBuildkite.cmake` fetches build info from the Buildkite API to download artifacts from earlier build steps (build-cpp, build-zig).

The `BUILDKITE_BUILD_ID` environment variable contains a UUID (e.g., `019bee3e-da45-4e9f-b4d8-4bdb5aeac0ac`). When this UUID is used in the URL, Buildkite returns a **302 redirect** to the numeric build number URL (e.g., `/builds/35708`).

CMake's `file(DOWNLOAD)` command **does not follow HTTP redirects**, so the downloaded file is empty. Parsing the empty JSON yields 0 jobs, triggering the fatal error:

```
CMake Error at cmake/tools/SetupBuildkite.cmake:67 (message):
  No jobs found:
  https://buildkite.com/bun/bun/builds/019bee3e-da45-4e9f-b4d8-4bdb5aeac0ac
```

### Solution

Prefer `BUILDKITE_BUILD_NUMBER` (numeric, e.g., `35708`) when available, which doesn't redirect. This environment variable is automatically set by Buildkite.

## How did you verify your code works?

- Verified UUID URL returns 302: `curl -sS -w '%{http_code}' "https://buildkite.com/bun/bun/builds/019bee3e-da45-4e9f-b4d8-4bdb5aeac0ac"` → `302`
- Verified numeric URL returns 200 with JSON: `curl -sS -H "Accept: application/json" "https://buildkite.com/bun/bun/builds/35708"` → valid JSON with jobs array

🤖 Generated with [Claude Code](https://claude.com/claude-code)