### PR TITLE
fix(readline): use symbol key for _refreshLine in tab completer

### DIFF
--- a/src/js/node/readline.ts
+++ b/src/js/node/readline.ts
@@ -1534,7 +1534,7 @@ var _Interface = class Interface extends InterfaceConstructor {
         prefix +
         StringPrototypeSlice.$call(this.line, this.cursor, this.line.length);
       this.cursor = this.cursor - completeOn.length + prefix.length;
-      this._refreshLine();
+      this[kRefreshLine]();
       return;
     }
 

--- a/test/regression/issue/26411.test.ts
+++ b/test/regression/issue/26411.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/26411
+// Tab completion with node:readline/promises threw
+// "TypeError: this._refreshLine is not a function"
+test("tab completion works with node:readline/promises", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+import readline from "node:readline/promises";
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  terminal: true,
+  completer: (line) => [["FOO", "FOOBAR"], line]
+});
+rl.line = "foo";
+rl.cursor = 3;
+setTimeout(() => {
+  rl.close();
+  console.log("OK");
+  process.exit(0);
+}, 100);
+rl.write("", { name: "tab" });
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("this._refreshLine is not a function");
+  expect(stdout).toContain("OK");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fixed TypeError "this._refreshLine is not a function" when using tab completion with `node:readline/promises`
- Changed `this._refreshLine()` to `this[kRefreshLine]()` in the tab completer method for consistency with the rest of the codebase

## Root Cause
The `[kTabCompleter]` method was calling `this._refreshLine()` which only exists on the `Interface` class (`node:readline`), not on `PromisesInterface` (`node:readline/promises`). This caused a TypeError when using tab completion with the promises API.

## Test plan
- [ ] Run `bun bd test test/regression/issue/26411.test.ts` to verify the fix
- [ ] Test tab completion manually with `node:readline/promises`

Fixes #26411

🤖 Generated with [Claude Code](https://claude.com/claude-code)