### PR TITLE
fix(undici): add Dispatcher close() and destroy() methods

### DIFF
--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -263,8 +263,12 @@ class MockAgent {
 function mockErrors() {}
 
 class Dispatcher extends EventEmitter {
-  async close() {}
-  async destroy() {}
+  async close() {
+    return null;
+  }
+  async destroy() {
+    return null;
+  }
 }
 class Agent extends Dispatcher {}
 class Pool extends Dispatcher {

--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -262,7 +262,10 @@ class MockAgent {
 
 function mockErrors() {}
 
-class Dispatcher extends EventEmitter {}
+class Dispatcher extends EventEmitter {
+  async close() {}
+  async destroy() {}
+}
 class Agent extends Dispatcher {}
 class Pool extends Dispatcher {
   request() {}

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -171,16 +171,20 @@ describe("undici", () => {
       expect(result).toBe(null);
     });
 
-    it("Pool should have close() and destroy() methods", () => {
+    it("Pool should have close() and destroy() methods", async () => {
       const pool = new Pool();
       expect(typeof pool.close).toBe("function");
       expect(typeof pool.destroy).toBe("function");
+      expect(await pool.close()).toBe(null);
+      expect(await pool.destroy()).toBe(null);
     });
 
-    it("Client should have close() and destroy() methods", () => {
+    it("Client should have close() and destroy() methods", async () => {
       const client = new Client();
       expect(typeof client.close).toBe("function");
       expect(typeof client.destroy).toBe("function");
+      expect(await client.close()).toBe(null);
+      expect(await client.destroy()).toBe(null);
     });
   });
 });

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { request } from "undici";
+import { Agent, Client, Pool, request } from "undici";
 
 import { createServer } from "../../../http-test-server";
 
@@ -158,30 +158,26 @@ describe("undici", () => {
 
   describe("Dispatcher", () => {
     it("Agent should have close() method that returns a promise", async () => {
-      const { Agent } = await import("undici");
       const agent = new Agent();
       expect(typeof agent.close).toBe("function");
       const result = await agent.close();
-      expect(result).toBe(undefined);
+      expect(result).toBe(null);
     });
 
     it("Agent should have destroy() method that returns a promise", async () => {
-      const { Agent } = await import("undici");
       const agent = new Agent();
       expect(typeof agent.destroy).toBe("function");
       const result = await agent.destroy();
-      expect(result).toBe(undefined);
+      expect(result).toBe(null);
     });
 
-    it("Pool should have close() and destroy() methods", async () => {
-      const { Pool } = await import("undici");
+    it("Pool should have close() and destroy() methods", () => {
       const pool = new Pool();
       expect(typeof pool.close).toBe("function");
       expect(typeof pool.destroy).toBe("function");
     });
 
-    it("Client should have close() and destroy() methods", async () => {
-      const { Client } = await import("undici");
+    it("Client should have close() and destroy() methods", () => {
       const client = new Client();
       expect(typeof client.close).toBe("function");
       expect(typeof client.destroy).toBe("function");

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -155,4 +155,36 @@ describe("undici", () => {
     //   expect(json.form.foo).toBe("bar");
     // });
   });
+
+  describe("Dispatcher", () => {
+    it("Agent should have close() method that returns a promise", async () => {
+      const { Agent } = await import("undici");
+      const agent = new Agent();
+      expect(typeof agent.close).toBe("function");
+      const result = await agent.close();
+      expect(result).toBe(undefined);
+    });
+
+    it("Agent should have destroy() method that returns a promise", async () => {
+      const { Agent } = await import("undici");
+      const agent = new Agent();
+      expect(typeof agent.destroy).toBe("function");
+      const result = await agent.destroy();
+      expect(result).toBe(undefined);
+    });
+
+    it("Pool should have close() and destroy() methods", async () => {
+      const { Pool } = await import("undici");
+      const pool = new Pool();
+      expect(typeof pool.close).toBe("function");
+      expect(typeof pool.destroy).toBe("function");
+    });
+
+    it("Client should have close() and destroy() methods", async () => {
+      const { Client } = await import("undici");
+      const client = new Client();
+      expect(typeof client.close).toBe("function");
+      expect(typeof client.destroy).toBe("function");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `close()` and `destroy()` async methods to the `Dispatcher` class in Bun's undici polyfill
- These methods are inherited by `Agent`, `Pool`, `Client`, and other Dispatcher subclasses
- Followed existed stub pattern in `src/js/thirdparty/undici.js` found in `Pool` / `Client`

## Test plan
- Added tests verifying `Agent`, `Pool`, and `Client` have working `close()` and `destroy()` methods
- `bun bd test test/js/first_party/undici/undici.test.ts` passes

Fixes #14498