### PR TITLE
Update example `bun pm cache` commands so they work as described.

### DIFF
--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -185,13 +185,13 @@ bun pm hash-print
 To print the path to Bun's global module cache:
 
 ```bash terminal icon="terminal"
-bun pm cache
+bun pm cache --global
 ```
 
 To clear Bun's global module cache:
 
 ```bash terminal icon="terminal"
-bun pm cache rm
+bun pm cache rm --global
 ```
 
 ## migrate


### PR DESCRIPTION
The docs refer to the global cache. But as noted in https://github.com/oven-sh/bun/issues/26427 , these commands cannot be run outside a project unless the `--global` flag is passed. So this change adds the flag.
