### PR TITLE
ci: fix update workflows creating duplicate PRs

### DIFF
--- a/.github/workflows/update-cares.yml
+++ b/.github/workflows/update-cares.yml
@@ -88,7 +88,7 @@ jobs:
           commit-message: "deps: update c-ares to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update c-ares to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true
-          branch: deps/update-cares-${{ github.run_number }}
+          branch: deps/update-cares
           body: |
             ## What does this PR do?
 

--- a/.github/workflows/update-hdrhistogram.yml
+++ b/.github/workflows/update-hdrhistogram.yml
@@ -91,7 +91,7 @@ jobs:
           commit-message: "deps: update hdrhistogram to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update hdrhistogram to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true
-          branch: deps/update-hdrhistogram-${{ github.run_number }}
+          branch: deps/update-hdrhistogram
           body: |
             ## What does this PR do?
 

--- a/.github/workflows/update-highway.yml
+++ b/.github/workflows/update-highway.yml
@@ -107,7 +107,7 @@ jobs:
           commit-message: "deps: update highway to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update highway to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true
-          branch: deps/update-highway-${{ github.run_number }}
+          branch: deps/update-highway
           body: |
             ## What does this PR do?
 

--- a/.github/workflows/update-libarchive.yml
+++ b/.github/workflows/update-libarchive.yml
@@ -88,7 +88,7 @@ jobs:
           commit-message: "deps: update libarchive to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update libarchive to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true
-          branch: deps/update-libarchive-${{ github.run_number }}
+          branch: deps/update-libarchive
           body: |
             ## What does this PR do?
 

--- a/.github/workflows/update-libdeflate.yml
+++ b/.github/workflows/update-libdeflate.yml
@@ -88,7 +88,7 @@ jobs:
           commit-message: "deps: update libdeflate to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update libdeflate to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true
-          branch: deps/update-libdeflate-${{ github.run_number }}
+          branch: deps/update-libdeflate
           body: |
             ## What does this PR do?
 

--- a/.github/workflows/update-lolhtml.yml
+++ b/.github/workflows/update-lolhtml.yml
@@ -100,7 +100,7 @@ jobs:
           commit-message: "deps: update lolhtml to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update lolhtml to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true
-          branch: deps/update-lolhtml-${{ github.run_number }}
+          branch: deps/update-lolhtml
           body: |
             ## What does this PR do?
 

--- a/.github/workflows/update-lshpack.yml
+++ b/.github/workflows/update-lshpack.yml
@@ -105,7 +105,7 @@ jobs:
           commit-message: "deps: update lshpack to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update lshpack to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true
-          branch: deps/update-lshpack-${{ github.run_number }}
+          branch: deps/update-lshpack
           body: |
             ## What does this PR do?
 

--- a/.github/workflows/update-root-certs.yml
+++ b/.github/workflows/update-root-certs.yml
@@ -74,7 +74,7 @@ jobs:
             ```
             ${{ env.changed_files }}
             ```
-          branch: certs/update-root-certs-${{ github.run_number }}
+          branch: certs/update-root-certs
           base: main
           delete-branch: true
           labels:

--- a/.github/workflows/update-sqlite3.yml
+++ b/.github/workflows/update-sqlite3.yml
@@ -83,7 +83,7 @@ jobs:
           commit-message: "deps: update sqlite to ${{ steps.check-version.outputs.latest }}"
           title: "deps: update sqlite to ${{ steps.check-version.outputs.latest }}"
           delete-branch: true
-          branch: deps/update-sqlite-${{ steps.check-version.outputs.latest }}
+          branch: deps/update-sqlite
           body: |
             ## What does this PR do?
 

--- a/.github/workflows/update-vendor.yml
+++ b/.github/workflows/update-vendor.yml
@@ -68,7 +68,7 @@ jobs:
           commit-message: "deps: update ${{ matrix.package }} to ${{ steps.check-version.outputs.latest }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update ${{ matrix.package }} to ${{ steps.check-version.outputs.latest }}"
           delete-branch: true
-          branch: deps/update-${{ matrix.package }}-${{ github.run_number }}
+          branch: deps/update-${{ matrix.package }}
           body: |
             ## What does this PR do?
 

--- a/.github/workflows/update-zstd.yml
+++ b/.github/workflows/update-zstd.yml
@@ -88,7 +88,7 @@ jobs:
           commit-message: "deps: update zstd to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update zstd to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true
-          branch: deps/update-zstd-${{ github.run_number }}
+          branch: deps/update-zstd
           body: |
             ## What does this PR do?
 


### PR DESCRIPTION
## Summary
- Fixed all `update-*.yml` workflows that were creating duplicate PRs every week

## Problem
The update workflows (libarchive, zstd, cares, etc.) were using `${{ github.run_number }}` in the branch name, e.g.:
```yaml
branch: deps/update-libarchive-${{ github.run_number }}
```

This caused a new unique branch to be created on every workflow run, so the `peter-evans/create-pull-request` action couldn't detect existing PRs and would create duplicates.

**Evidence:** There are currently 8+ open duplicate PRs for libarchive alone:
- #26432 deps: update libarchive to v3.8.5 (deps/update-libarchive-56)
- #26209 deps: update libarchive to v3.8.5 (deps/update-libarchive-55)
- #25955 deps: update libarchive to v3.8.5 (deps/update-libarchive-54)
- etc.

## Solution
Changed all workflows to use static branch names, e.g.:
```yaml
branch: deps/update-libarchive
```

This allows the action to:
1. Detect if an existing branch/PR already exists
2. Update the existing PR with new changes instead of creating a new one
3. Properly use `delete-branch: true` when the PR is merged

## Files Changed
- `.github/workflows/update-cares.yml`
- `.github/workflows/update-hdrhistogram.yml`
- `.github/workflows/update-highway.yml`
- `.github/workflows/update-libarchive.yml`
- `.github/workflows/update-libdeflate.yml`
- `.github/workflows/update-lolhtml.yml`
- `.github/workflows/update-lshpack.yml`
- `.github/workflows/update-root-certs.yml`
- `.github/workflows/update-sqlite3.yml`
- `.github/workflows/update-vendor.yml`
- `.github/workflows/update-zstd.yml`

## Test plan
- [x] Verified the change is syntactically correct
- [ ] Wait for next scheduled run of any workflow to verify it updates existing PR instead of creating a new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)