### PR TITLE
fix(test): reset exit code to 0 when all tests pass

### DIFF
--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1786,6 +1786,8 @@ pub const TestCommand = struct {
             vm.exit_handler.exit_code = 1;
         } else if (reporter.jest.unhandled_errors_between_tests > 0) {
             vm.exit_handler.exit_code = 1;
+        } else {
+            vm.exit_handler.exit_code = 0;
         }
         vm.is_shutting_down = true;
         vm.runWithAPILock(jsc.VirtualMachine, vm, jsc.VirtualMachine.globalExit);

--- a/test/cli/test/process-exitcode.test.ts
+++ b/test/cli/test/process-exitcode.test.ts
@@ -1,0 +1,252 @@
+import { expect, test, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Tests for bun test exit codes per docs:
+// https://bun.com/docs/test/runtime-behavior#exit-codes
+//
+// Exit codes:
+// - 0: All tests passed, no unhandled errors
+// - 1: Test failures occurred
+// - >1: Number of unhandled errors (even if tests passed)
+//
+// Also tests that process.exitCode set inside tests does not leak into bun test's exit code.
+// The test runner should determine exit code based on test outcomes, not user-set process.exitCode.
+
+test("process.exitCode=1 at end of passing test does not affect bun test exit", async () => {
+  using dir = tempDir("exitcode-leak", {
+    "leak.test.ts": `
+import { test, expect } from "bun:test";
+
+test("passing test that sets process.exitCode=1", () => {
+  expect(true).toBe(true);
+  process.exitCode = 1; // Should not leak to bun test exit code
+});
+`,
+  });
+
+  const { exited, stdout, stderr } = Bun.spawn({
+    cmd: [bunExe(), "test", "leak.test.ts"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+    env: bunEnv,
+  });
+
+  const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+
+  expect(err).toContain("1 pass");
+  expect(err).toContain("0 fail");
+  expect(exitCode).toBe(0);
+});
+
+test("process.exitCode set to various values in passing tests does not affect exit", async () => {
+  using dir = tempDir("exitcode-various", {
+    "various.test.ts": `
+import { test, expect } from "bun:test";
+
+test("sets exitCode to 42", () => {
+  expect(1).toBe(1);
+  process.exitCode = 42;
+});
+
+test("sets exitCode to 255", () => {
+  expect(2).toBe(2);
+  process.exitCode = 255;
+});
+
+test("sets exitCode to 1", () => {
+  expect(3).toBe(3);
+  process.exitCode = 1;
+});
+`,
+  });
+
+  const { exited, stderr } = Bun.spawn({
+    cmd: [bunExe(), "test", "various.test.ts"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+    env: bunEnv,
+  });
+
+  const [err, exitCode] = await Promise.all([stderr.text(), exited]);
+
+  expect(err).toContain("3 pass");
+  expect(err).toContain("0 fail");
+  expect(exitCode).toBe(0);
+});
+
+test("afterEach setting process.exitCode does not affect bun test exit", async () => {
+  using dir = tempDir("exitcode-aftereach", {
+    "aftereach.test.ts": `
+import { test, expect, afterEach } from "bun:test";
+
+afterEach(() => {
+  process.exitCode = 1; // Cleanup setting exitCode should not leak
+});
+
+test("first test", () => {
+  expect(true).toBe(true);
+});
+
+test("second test", () => {
+  expect(true).toBe(true);
+});
+`,
+  });
+
+  const { exited, stderr } = Bun.spawn({
+    cmd: [bunExe(), "test", "aftereach.test.ts"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+    env: bunEnv,
+  });
+
+  const [err, exitCode] = await Promise.all([stderr.text(), exited]);
+
+  expect(err).toContain("2 pass");
+  expect(err).toContain("0 fail");
+  expect(exitCode).toBe(0);
+});
+
+// Positive tests: verify documented exit code behavior
+
+describe("documented exit codes", () => {
+  test("exits 0 when all tests pass", async () => {
+    using dir = tempDir("exitcode-pass", {
+      "pass.test.ts": `
+import { test, expect } from "bun:test";
+
+test("passes", () => {
+  expect(1 + 1).toBe(2);
+});
+
+test("also passes", () => {
+  expect("hello").toContain("ell");
+});
+`,
+    });
+
+    const { exited, stderr } = Bun.spawn({
+      cmd: [bunExe(), "test", "pass.test.ts"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+      env: bunEnv,
+    });
+
+    const [err, exitCode] = await Promise.all([stderr.text(), exited]);
+
+    expect(err).toContain("2 pass");
+    expect(err).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("exits 1 when test failures occur", async () => {
+    using dir = tempDir("exitcode-fail", {
+      "fail.test.ts": `
+import { test, expect } from "bun:test";
+
+test("passes", () => {
+  expect(true).toBe(true);
+});
+
+test("fails", () => {
+  expect(1).toBe(2);
+});
+`,
+    });
+
+    const { exited, stderr } = Bun.spawn({
+      cmd: [bunExe(), "test", "fail.test.ts"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+      env: bunEnv,
+    });
+
+    const [err, exitCode] = await Promise.all([stderr.text(), exited]);
+
+    expect(err).toContain("1 pass");
+    expect(err).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("exits 1 when multiple test failures occur", async () => {
+    using dir = tempDir("exitcode-multifail", {
+      "multifail.test.ts": `
+import { test, expect } from "bun:test";
+
+test("fails 1", () => {
+  expect(1).toBe(2);
+});
+
+test("fails 2", () => {
+  expect("a").toBe("b");
+});
+
+test("fails 3", () => {
+  throw new Error("oops");
+});
+`,
+    });
+
+    const { exited, stderr } = Bun.spawn({
+      cmd: [bunExe(), "test", "multifail.test.ts"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+      env: bunEnv,
+    });
+
+    const [err, exitCode] = await Promise.all([stderr.text(), exited]);
+
+    expect(err).toContain("0 pass");
+    expect(err).toContain("3 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("exits non-zero for unhandled errors between tests", async () => {
+    using dir = tempDir("exitcode-unhandled", {
+      "unhandled.test.ts": `
+import { test, expect } from "bun:test";
+
+test("test 1 passes", async () => {
+  expect(true).toBe(true);
+  // Schedule an unhandled error to fire after this test completes
+  setTimeout(() => {
+    throw new Error("Unhandled error between tests");
+  }, 10);
+});
+
+test("test 2 passes", async () => {
+  // Give time for the scheduled error to fire between tests
+  await Bun.sleep(50);
+  expect(true).toBe(true);
+});
+`,
+    });
+
+    const { exited, stderr } = Bun.spawn({
+      cmd: [bunExe(), "test", "unhandled.test.ts"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+      env: bunEnv,
+    });
+
+    const [err, exitCode] = await Promise.all([stderr.text(), exited]);
+
+    // Exit code should be > 0 due to unhandled error
+    expect(exitCode).toBeGreaterThan(0);
+    expect(err).toContain("Unhandled error");
+  });
+});

--- a/test/cli/test/process-exitcode.test.ts
+++ b/test/cli/test/process-exitcode.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // Tests for bun test exit codes per docs:

--- a/test/cli/test/process-exitcode.test.ts
+++ b/test/cli/test/process-exitcode.test.ts
@@ -25,7 +25,7 @@ test("passing test that sets process.exitCode=1", () => {
 `,
     });
 
-    const { exited, stderr } = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "leak.test.ts"],
       cwd: String(dir),
       stdout: "ignore",
@@ -34,7 +34,7 @@ test("passing test that sets process.exitCode=1", () => {
       env: bunEnv,
     });
 
-    const [err, exitCode] = await Promise.all([stderr.text(), exited]);
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
     expect(err).toContain("1 pass");
     expect(err).toContain("0 fail");
@@ -63,7 +63,7 @@ test("sets exitCode to 1", () => {
 `,
     });
 
-    const { exited, stderr } = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "various.test.ts"],
       cwd: String(dir),
       stdout: "ignore",
@@ -72,7 +72,7 @@ test("sets exitCode to 1", () => {
       env: bunEnv,
     });
 
-    const [err, exitCode] = await Promise.all([stderr.text(), exited]);
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
     expect(err).toContain("3 pass");
     expect(err).toContain("0 fail");
@@ -98,7 +98,7 @@ test("second test", () => {
 `,
     });
 
-    const { exited, stderr } = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "aftereach.test.ts"],
       cwd: String(dir),
       stdout: "ignore",
@@ -107,7 +107,7 @@ test("second test", () => {
       env: bunEnv,
     });
 
-    const [err, exitCode] = await Promise.all([stderr.text(), exited]);
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
     expect(err).toContain("2 pass");
     expect(err).toContain("0 fail");
@@ -131,7 +131,7 @@ test("also passes", () => {
 `,
     });
 
-    const { exited, stderr } = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "pass.test.ts"],
       cwd: String(dir),
       stdout: "ignore",
@@ -140,7 +140,7 @@ test("also passes", () => {
       env: bunEnv,
     });
 
-    const [err, exitCode] = await Promise.all([stderr.text(), exited]);
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
     expect(err).toContain("2 pass");
     expect(err).toContain("0 fail");
@@ -162,7 +162,7 @@ test("fails", () => {
 `,
     });
 
-    const { exited, stderr } = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "fail.test.ts"],
       cwd: String(dir),
       stdout: "ignore",
@@ -171,7 +171,7 @@ test("fails", () => {
       env: bunEnv,
     });
 
-    const [err, exitCode] = await Promise.all([stderr.text(), exited]);
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
     expect(err).toContain("1 pass");
     expect(err).toContain("1 fail");
@@ -197,7 +197,7 @@ test("fails 3", () => {
 `,
     });
 
-    const { exited, stderr } = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "multifail.test.ts"],
       cwd: String(dir),
       stdout: "ignore",
@@ -206,7 +206,7 @@ test("fails 3", () => {
       env: bunEnv,
     });
 
-    const [err, exitCode] = await Promise.all([stderr.text(), exited]);
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
     expect(err).toContain("0 pass");
     expect(err).toContain("3 fail");
@@ -232,7 +232,7 @@ test("test 2 passes", () => {
 `,
     });
 
-    const { exited, stderr } = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "unhandled.test.ts"],
       cwd: String(dir),
       stdout: "ignore",
@@ -241,7 +241,7 @@ test("test 2 passes", () => {
       env: bunEnv,
     });
 
-    const [err, exitCode] = await Promise.all([stderr.text(), exited]);
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
     // Exit code should be > 0 due to unhandled error
     expect(exitCode).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

Fix `bun test` returning exit code 1 when user code sets `process.exitCode` in tests, even when all tests pass.

## Problem

When test code sets `process.exitCode` (e.g., testing CLI utilities that use exit codes), the value leaks into `bun test`'s final exit code. This causes CI pipelines to fail despite all tests passing.

```ts
import { test, expect } from 'bun:test';

test('my cli helper', () => {
	process.exitCode = 1; // Testing error path
	expect(true).toBe(true);
});
// Result: bun test exits with code 1, even though test passed
```

This violates https://bun.sh/docs/test/runtime-behavior#exit-codes:

> "Exit code 0 - All tests passed"

## Cause

In [`src/cli/test_command.zig`](https://github.com/oven-sh/bun/pull/26435/changes#diff-abb4eeb46e18d09d7bec3ef2d0ebdcfd85e354293a85a7eabdc6e3870582ba6bL1785-R1791), the test runner only set `exit_code = 1` on failure but never reset it to 0 on success. If user code modified `process.exitCode`, that value persisted.

## Fix

Explicitly set `exit_code = 0` when all tests pass.