### PR TITLE
fix: change 'banner' header in bundler docs page to code format

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1150,7 +1150,7 @@ A map of file extensions to built-in loader names. This can be used to quickly c
   </Tab>
 </Tabs>
 
-### banner
+### `banner`
 
 A banner to be added to the final bundle, this can be a directive like `"use client"` for react or a comment block such as a license for the code.
 


### PR DESCRIPTION
### What does this PR do?

Updated header formatting for 'banner' section. 'banner' is a reserved word in mintlify, so the header does not render without this fix. See https://www.mintlify.com/docs/components/banner

### How did you verify your code works?

Tested with `npx mint dev`.