### PR TITLE
fix(Bun.write): create file for empty Response when createPath is false

### DIFF
--- a/test/regression/issue/06827.test.ts
+++ b/test/regression/issue/06827.test.ts
@@ -6,7 +6,7 @@ import path from "path";
 describe("issue #6827 - Bun.write from empty Response doesn't create any file", () => {
   test("Bun.write with empty Response creates file", async () => {
     using dir = tempDir("issue-6827", {});
-    const filePath = path.join(String(dir), "ok.txt");
+    const filePath = path.join(dir, "ok.txt");
 
     // Should create an empty file
     const bytesWritten = await Bun.write(filePath, new Response(""));

--- a/test/regression/issue/06827.test.ts
+++ b/test/regression/issue/06827.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import fs from "fs";
+import { tempDir } from "harness";
+import path from "path";
+
+describe("issue #6827 - Bun.write from empty Response doesn't create any file", () => {
+  test("Bun.write with empty Response creates file", async () => {
+    using dir = tempDir("issue-6827", {});
+    const filePath = path.join(String(dir), "ok.txt");
+
+    // Should create an empty file
+    const bytesWritten = await Bun.write(filePath, new Response(""));
+
+    expect(bytesWritten).toBe(0);
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(await Bun.file(filePath).text()).toBe("");
+  });
+
+  test("Bun.write with empty Blob creates file", async () => {
+    using dir = tempDir("issue-6827-blob", {});
+    const filePath = path.join(String(dir), "ok.txt");
+
+    // Should create an empty file
+    const bytesWritten = await Bun.write(filePath, new Blob([]));
+
+    expect(bytesWritten).toBe(0);
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(await Bun.file(filePath).text()).toBe("");
+  });
+
+  test("Bun.write with empty Response truncates existing file", async () => {
+    using dir = tempDir("issue-6827-truncate", {});
+    const filePath = path.join(String(dir), "existing.txt");
+
+    // First write some content
+    await Bun.write(filePath, "hello world");
+    expect(await Bun.file(filePath).text()).toBe("hello world");
+
+    // Now write empty Response - should truncate
+    const bytesWritten = await Bun.write(filePath, new Response(""));
+
+    expect(bytesWritten).toBe(0);
+    expect(await Bun.file(filePath).text()).toBe("");
+  });
+
+  test("Bun.write with empty string still works (baseline)", async () => {
+    using dir = tempDir("issue-6827-baseline", {});
+    const filePath = path.join(String(dir), "ok.txt");
+
+    // This should work (and already does)
+    const bytesWritten = await Bun.write(filePath, "");
+
+    expect(bytesWritten).toBe(0);
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(await Bun.file(filePath).text()).toBe("");
+  });
+
+  test("Bun.write with empty Response and createPath: false should still create the file (not the dir)", async () => {
+    using dir = tempDir("issue-6827-createpath", {});
+    const filePath = path.join(String(dir), "newfile.txt");
+
+    // createPath: false should only prevent creating parent directories, not the file itself
+    const bytesWritten = await Bun.write(filePath, new Response(""), { createPath: false });
+
+    expect(bytesWritten).toBe(0);
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(await Bun.file(filePath).text()).toBe("");
+  });
+
+  test("Bun.write with empty Response and createPath: false should error when parent dir missing", async () => {
+    using dir = tempDir("issue-6827-nodir", {});
+    const filePath = path.join(String(dir), "nonexistent", "subdir", "file.txt");
+
+    // Should fail because parent directory doesn't exist and createPath is false
+    await expect(Bun.write(filePath, new Response(""), { createPath: false })).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #6827

When writing empty content (e.g., `new Response("")`), the `truncate` syscall fails with `ENOENT` if the file doesn't exist. Previously, this would error out when `createPath: false` even if the parent directory existed.

Now we attempt to create the file with `open(O_WRONLY | O_CREAT | O_TRUNC)` before checking `mkdirp_if_not_exists`, correctly separating file creation from parent directory creation.

- `createPath: false` now only prevents creating missing **parent directories**, not the file itself
- Added `O_WRONLY` flag to open calls for consistency with the rest of the codebase

## Test plan

- Added regression test at `test/regression/issue/06827.test.ts` covering:
  - Empty Response creates file
  - Empty Blob creates file
  - Empty Response truncates existing file
  - Empty string baseline (already worked)
  - `createPath: false` still creates file when parent exists
  - `createPath: false` errors when parent dir missing
- Ran full `bun-write.test.js` suite (30/30 pass)