### PR TITLE
feat(install): warn when installing deprecated packages

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -1417,6 +1417,17 @@ fn getOrPutResolvedPackageWithFindResult(
     if (comptime Environment.allow_assert) bun.assert(package.meta.id != invalid_package_id);
     defer successFn(this, dependency_id, package.meta.id);
 
+    // Print deprecation warning if package is deprecated
+    if (!find_result.package.deprecated.isEmpty()) {
+        const package_name = this.lockfile.str(&name);
+        const deprecated_msg = manifest.str(&find_result.package.deprecated);
+        Output.warn("<b>{s}@{f}<r><d>:<r> {s}", .{
+            package_name,
+            find_result.version.fmt(manifest.string_buf),
+            deprecated_msg,
+        });
+    }
+
     // non-null if the package is in "patchedDependencies"
     var name_and_version_hash: ?u64 = null;
     var patchfile_hash: ?u64 = null;

--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -493,6 +493,7 @@ pub fn Package(comptime SemverIntType: type) type {
                 package.meta.os = package_version.os;
                 package.meta.integrity = package_version.integrity;
                 package.meta.setHasInstallScript(package_version.has_install_script);
+                package.meta.setIsDeprecated(!package_version.deprecated.isEmpty());
 
                 package.dependencies.off = @as(u32, @truncate(dependencies_list.items.len));
                 package.dependencies.len = total_dependencies_count;

--- a/test/regression/issue/06883.test.ts
+++ b/test/regression/issue/06883.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("issue #6883 - Bun should warn when installing deprecated packages", () => {
+  test("bun install shows deprecation warning for deprecated package", async () => {
+    using dir = tempDir("issue-6883", {
+      "package.json": JSON.stringify({
+        name: "test-deprecated",
+        dependencies: {
+          request: "2.88.2",
+        },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stderr).toContain("request@2.88.2");
+    expect(stderr).toContain("deprecated");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun install shows deprecation warnings for transitive deprecated dependencies", async () => {
+    using dir = tempDir("issue-6883-transitive", {
+      "package.json": JSON.stringify({
+        name: "test-deprecated-transitive",
+        dependencies: {
+          // request has deprecated transitive deps like har-validator and uuid@3
+          request: "2.88.2",
+        },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stderr).toContain("request@2.88.2");
+    expect(stderr).toContain("har-validator");
+    expect(stderr).toContain("uuid");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun install does not warn for non-deprecated packages", async () => {
+    using dir = tempDir("issue-6883-non-deprecated", {
+      "package.json": JSON.stringify({
+        name: "test-non-deprecated",
+        dependencies: {
+          // lodash is not deprecated
+          lodash: "^4.17.21",
+        },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stderr).not.toContain("deprecated");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #6883

Parses the `deprecated` field from npm registry responses and displays warnings during `bun install` when a package version is deprecated. This matches the behavior of npm, pnpm, and yarn.

**Example output:**
```
warn: request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warn: har-validator@5.1.5: this library is no longer supported
warn: uuid@3.4.0: Please upgrade to version 7 or higher...
```

**Changes:**
- Add `deprecated` field to `PackageVersion` struct in `npm.zig` to parse deprecation messages
- Add `is_deprecated` flag to lockfile `Meta` struct for persistence
- Print deprecation warnings when resolving new packages

## Test plan

- Added regression tests at `test/regression/issue/06883.test.ts` covering:
  - Deprecation warning shown for deprecated package (request)
  - Deprecation warnings shown for transitive deprecated dependencies
  - No warning shown for non-deprecated packages (lodash)