### PR TITLE
fix(napi): tie external buffer finalizer to ArrayBuffer lifecycle

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -2044,19 +2044,13 @@ extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
         NAPI_RETURN_SUCCESS(env);
     }
 
-    auto arrayBuffer = ArrayBuffer::createFromBytes({ reinterpret_cast<const uint8_t*>(data), length }, createSharedTask<void(void*)>([](void*) {
-        // do nothing
+    auto arrayBuffer = ArrayBuffer::createFromBytes({ reinterpret_cast<const uint8_t*>(data), length }, createSharedTask<void(void*)>([envRef = WTF::Ref<NapiEnv>(*env), finalize_hint, finalize_cb](void* p) {
+        NAPI_LOG("external buffer finalizer");
+        envRef->doFinalizer(finalize_cb, p, finalize_hint);
     }));
 
     auto* buffer = JSC::JSUint8Array::create(globalObject, subclassStructure, WTF::move(arrayBuffer), 0, length);
     NAPI_RETURN_IF_EXCEPTION(env);
-
-    // setup finalizer after creating the array. if it throws callers of napi_create_external_buffer are expected
-    // to free input
-    vm.heap.addFinalizer(buffer, [env = WTF::Ref<NapiEnv>(*env), finalize_cb, data, finalize_hint](JSCell* cell) -> void {
-        NAPI_LOG("external buffer finalizer");
-        env->doFinalizer(finalize_cb, data, finalize_hint);
-    });
 
     *result = toNapi(buffer, globalObject);
     NAPI_RETURN_SUCCESS(env);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -282,6 +282,14 @@ describe.concurrent("napi", () => {
       expect(result).toContain("PASS: napi_is_detached_arraybuffer returns true for empty buffer's arraybuffer");
       expect(result).not.toContain("FAIL");
     });
+
+    // https://github.com/oven-sh/bun/issues/26446
+    it("calls finalizer when buffer is garbage collected", async () => {
+      const result = await checkSameOutput("test_issue_26446", []);
+      expect(result).toContain("PASS: napi_create_external_buffer created buffer with correct data");
+      expect(result).toContain("PASS: Buffer data is correct after creation");
+      expect(result).not.toContain("FAIL");
+    });
   });
 
   describe("napi_async_work", () => {


### PR DESCRIPTION
## Summary

- Fixes a race condition in `napi_create_external_buffer` where the finalizer was added separately via `vm.heap.addFinalizer`, allowing native code to free/reuse the underlying memory while JavaScript still held a reference to the ArrayBuffer
- Ties the finalizer directly to the ArrayBuffer via `createFromBytes`, matching the pattern used in `napi_create_external_arraybuffer`
- This prevents data corruption at 16KB boundaries when using NAPI-based libraries like `impit`

Fixes #26446

## Test plan

- [x] Added C++ test `test_napi_external_buffer_finalizer` to verify buffer creation and data integrity
- [x] Added JavaScript test `test_issue_26446` to verify buffer lifecycle and finalizer behavior
- [x] All existing `napi_create_external_buffer` tests pass
- [x] Existing `resvg` third-party test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)