### PR TITLE
fix(build-jsc): enable REMOTE_INSPECTOR for macOS release builds

### DIFF
--- a/scripts/build-jsc.ts
+++ b/scripts/build-jsc.ts
@@ -129,6 +129,7 @@ const getCommonFlags = (config: BuildConfig) => {
       "-DBUN_FAST_TLS=ON",
       "-DPTHREAD_JIT_PERMISSIONS_API=1",
       "-DUSE_PTHREAD_JIT_PERMISSIONS_API=ON",
+      "-DENABLE_REMOTE_INSPECTOR=ON",
     );
   } else if (IS_LINUX) {
     flags.push(
@@ -172,7 +173,6 @@ const getBuildFlags = (config: BuildConfig) => {
         "-DCMAKE_BUILD_TYPE=Debug",
         "-DENABLE_BUN_SKIP_FAILING_ASSERTIONS=ON",
         "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
-        "-DENABLE_REMOTE_INSPECTOR=ON",
         "-DUSE_VISIBILITY_ATTRIBUTE=1",
       );
 


### PR DESCRIPTION
### What does this PR do?

  Move `-DENABLE_REMOTE_INSPECTOR=ON` from the debug-only flags to the
  macOS common flags so it applies to all build configurations (debug,
  release, lto). This was already the case for Linux and Windows.

  Without this, `build:release:local` fails because BunDebugger.cpp and
  InspectorLifecycleAgent.cpp unconditionally use JSC inspector APIs that
  are only available when REMOTE_INSPECTOR is enabled.

### How did you verify your code works?

Build locally
