### PR TITLE
fix(bundler): handle interface imports in decorator metadata

### DIFF
--- a/src/ast/P.zig
+++ b/src/ast/P.zig
@@ -5255,6 +5255,14 @@ pub fn NewParser_(
                 .m_identifier => |ref| {
                     p.recordUsage(ref);
                     if (p.is_import_item.contains(ref)) {
+                        // Mark as generated so linker doesn't error on missing exports.
+                        // This is common for TypeScript interfaces/types used in decorator
+                        // metadata which don't exist at runtime.
+                        // See: https://github.com/oven-sh/bun/issues/8439
+                        const symbol = &p.symbols.items[ref.innerIndex()];
+                        if (symbol.import_item_status == .none) {
+                            symbol.import_item_status = .generated;
+                        }
                         return p.maybeDefinedHelper(p.newExpr(
                             E.ImportIdentifier{
                                 .ref = ref,


### PR DESCRIPTION
## Summary

When TypeScript interfaces are imported without `import type` and used in decorator metadata, the bundler errors with "No matching export" because interfaces don't exist at runtime.

**Root cause:** When decorator metadata references an imported type (interface), Bun emits an `E.ImportIdentifier` that creates a direct binding. The linker errors because type-only exports don't exist at runtime.

**Fix:** Mark import identifiers used in decorator metadata as `.generated`. This tells the linker to gracefully fall back to `undefined` (which `maybeDefinedHelper` converts to `Object`) instead of erroring. This is the same pattern already used for namespace property access (e.g., `ns.TypeOnlyExport`) which already worked correctly.

## Test case

```typescript
// types.ts
export interface Config {
  apiUrl: string;
}

// service.ts  
import { Config } from "./types";  // Note: NOT "import type"

function Injectable() {
  return (target: any) => {};
}

@Injectable()
class Service {
  constructor(config: Config) {}  // Was: "No matching export" error
}
```

## Changes

- `src/ast/P.zig`: Mark decorator metadata imports as `.generated` (8 lines)
- `test/bundler/bundler_decorator_metadata.test.ts`: Add 2 test cases for the fix

Fixes #8439

---

🤖 Generated with [Claude Code](https://claude.ai/code)