### PR TITLE
test(sql): add regression test for #25552 MySQL transaction hang

### DIFF
--- a/test/regression/issue/25552.test.ts
+++ b/test/regression/issue/25552.test.ts
@@ -41,14 +41,14 @@ describeWithContainer(
       try {
         // Phase 1 - First transaction with multiple INSERTs
         await sql.begin(async tx => {
-          await tx`INSERT INTO ${sql(random_name)} (name, code) VALUES (${"Name 11"}, ${`CODE_${Math.random().toString().slice(2)}`})`;
-          await tx`INSERT INTO ${sql(random_name)} (name, code) VALUES (${"Name 12"}, ${`CODE_${Math.random().toString().slice(2)}`})`;
+          await tx`INSERT INTO ${sql(random_name)} (name, code) VALUES (${"Name 11"}, ${"CODE_11"})`;
+          await tx`INSERT INTO ${sql(random_name)} (name, code) VALUES (${"Name 12"}, ${"CODE_12"})`;
         });
 
         // Phase 2 - Second sequential transaction (this would hang before the fix)
         await sql.begin(async tx => {
-          await tx`INSERT INTO ${sql(random_name)} (name, code) VALUES (${"Name 21"}, ${`CODE_${Math.random().toString().slice(2)}`})`;
-          await tx`INSERT INTO ${sql(random_name)} (name, code) VALUES (${"Name 22"}, ${`CODE_${Math.random().toString().slice(2)}`})`;
+          await tx`INSERT INTO ${sql(random_name)} (name, code) VALUES (${"Name 21"}, ${"CODE_21"})`;
+          await tx`INSERT INTO ${sql(random_name)} (name, code) VALUES (${"Name 22"}, ${"CODE_22"})`;
         });
 
         // Verify all 4 rows were inserted
@@ -73,7 +73,7 @@ describeWithContainer(
         // Run multiple sequential transactions in a loop
         for (let i = 0; i < 5; i++) {
           await sql.begin(async tx => {
-            await tx`INSERT INTO ${sql(random_name)} (name, code) VALUES (${`Name ${i}`}, ${`CODE_${i}_${Math.random().toString().slice(2)}`})`;
+            await tx`INSERT INTO ${sql(random_name)} (name, code) VALUES (${`Name ${i}`}, ${`CODE_${i}`})`;
           });
         }
 
@@ -99,26 +99,14 @@ describeWithContainer(
       try {
         // Phase 1 - Using unsafe() as shown in the original issue
         await sql.begin(async tx => {
-          await tx.unsafe("INSERT INTO " + random_name + " (name, code) VALUES (?, ?)", [
-            "Name 11",
-            "CODE_" + Math.random().toString().slice(2),
-          ]);
-          await tx.unsafe("INSERT INTO " + random_name + " (name, code) VALUES (?, ?)", [
-            "Name 12",
-            "CODE_" + Math.random().toString().slice(2),
-          ]);
+          await tx.unsafe("INSERT INTO " + random_name + " (name, code) VALUES (?, ?)", ["Name 11", "CODE_11"]);
+          await tx.unsafe("INSERT INTO " + random_name + " (name, code) VALUES (?, ?)", ["Name 12", "CODE_12"]);
         });
 
         // Phase 2 - This would hang before the fix
         await sql.begin(async tx => {
-          await tx.unsafe("INSERT INTO " + random_name + " (name, code) VALUES (?, ?)", [
-            "Name 21",
-            "CODE_" + Math.random().toString().slice(2),
-          ]);
-          await tx.unsafe("INSERT INTO " + random_name + " (name, code) VALUES (?, ?)", [
-            "Name 22",
-            "CODE_" + Math.random().toString().slice(2),
-          ]);
+          await tx.unsafe("INSERT INTO " + random_name + " (name, code) VALUES (?, ?)", ["Name 21", "CODE_21"]);
+          await tx.unsafe("INSERT INTO " + random_name + " (name, code) VALUES (?, ?)", ["Name 22", "CODE_22"]);
         });
 
         // Verify all 4 rows were inserted

--- a/test/regression/issue/25552.test.ts
+++ b/test/regression/issue/25552.test.ts
@@ -1,0 +1,132 @@
+import { SQL, randomUUIDv7 } from "bun";
+import { beforeEach, expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/25552
+// MySQL transactions hang on Windows when attempting to start a second sequential transaction.
+// This was caused by the same issue fixed in #26030: queries added during JavaScript callbacks
+// were not properly flushed, causing the connection to wait for data that was never sent.
+
+describeWithContainer(
+  "mysql",
+  {
+    image: "mysql_plain",
+    env: {},
+    args: [],
+  },
+  container => {
+    const getOptions = () => ({
+      url: `mysql://root@${container.host}:${container.port}/bun_sql_test`,
+      max: 1,
+      bigint: true,
+    });
+
+    beforeEach(async () => {
+      await container.ready;
+    });
+
+    test("Sequential transactions with multiple INSERTs should not hang", async () => {
+      await using sql = new SQL(getOptions());
+      const random_name = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
+
+      // Create table similar to the issue reproduction
+      await sql`CREATE TABLE IF NOT EXISTS ${sql(random_name)} (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(255) NOT NULL,
+        code VARCHAR(25) NOT NULL UNIQUE,
+        created_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+      )`;
+
+      try {
+        // Phase 1 - First transaction with multiple INSERTs
+        await sql.begin(async tx => {
+          await tx`INSERT INTO ${sql(random_name)} (name, code) VALUES (${"Name 11"}, ${`CODE_${Math.random().toString().slice(2)}`})`;
+          await tx`INSERT INTO ${sql(random_name)} (name, code) VALUES (${"Name 12"}, ${`CODE_${Math.random().toString().slice(2)}`})`;
+        });
+
+        // Phase 2 - Second sequential transaction (this would hang before the fix)
+        await sql.begin(async tx => {
+          await tx`INSERT INTO ${sql(random_name)} (name, code) VALUES (${"Name 21"}, ${`CODE_${Math.random().toString().slice(2)}`})`;
+          await tx`INSERT INTO ${sql(random_name)} (name, code) VALUES (${"Name 22"}, ${`CODE_${Math.random().toString().slice(2)}`})`;
+        });
+
+        // Verify all 4 rows were inserted
+        const count = await sql`SELECT COUNT(*) as count FROM ${sql(random_name)}`;
+        expect(Number(count[0].count)).toBe(4);
+      } finally {
+        await sql`DROP TABLE IF EXISTS ${sql(random_name)}`;
+      }
+    });
+
+    test("Multiple sequential transactions in a loop should not hang", async () => {
+      await using sql = new SQL(getOptions());
+      const random_name = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
+
+      await sql`CREATE TABLE IF NOT EXISTS ${sql(random_name)} (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(255) NOT NULL,
+        code VARCHAR(25) NOT NULL UNIQUE
+      )`;
+
+      try {
+        // Run multiple sequential transactions in a loop
+        for (let i = 0; i < 5; i++) {
+          await sql.begin(async tx => {
+            await tx`INSERT INTO ${sql(random_name)} (name, code) VALUES (${`Name ${i}`}, ${`CODE_${i}_${Math.random().toString().slice(2)}`})`;
+          });
+        }
+
+        // Verify all 5 rows were inserted
+        const count = await sql`SELECT COUNT(*) as count FROM ${sql(random_name)}`;
+        expect(Number(count[0].count)).toBe(5);
+      } finally {
+        await sql`DROP TABLE IF EXISTS ${sql(random_name)}`;
+      }
+    });
+
+    test("Sequential transactions with unsafe() should not hang", async () => {
+      await using sql = new SQL(getOptions());
+      const random_name = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
+
+      // Create table similar to the issue reproduction
+      await sql`CREATE TABLE IF NOT EXISTS ${sql(random_name)} (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(255) NOT NULL,
+        code VARCHAR(25) NOT NULL UNIQUE
+      )`;
+
+      try {
+        // Phase 1 - Using unsafe() as shown in the original issue
+        await sql.begin(async tx => {
+          await tx.unsafe("INSERT INTO " + random_name + " (name, code) VALUES (?, ?)", [
+            "Name 11",
+            "CODE_" + Math.random().toString().slice(2),
+          ]);
+          await tx.unsafe("INSERT INTO " + random_name + " (name, code) VALUES (?, ?)", [
+            "Name 12",
+            "CODE_" + Math.random().toString().slice(2),
+          ]);
+        });
+
+        // Phase 2 - This would hang before the fix
+        await sql.begin(async tx => {
+          await tx.unsafe("INSERT INTO " + random_name + " (name, code) VALUES (?, ?)", [
+            "Name 21",
+            "CODE_" + Math.random().toString().slice(2),
+          ]);
+          await tx.unsafe("INSERT INTO " + random_name + " (name, code) VALUES (?, ?)", [
+            "Name 22",
+            "CODE_" + Math.random().toString().slice(2),
+          ]);
+        });
+
+        // Verify all 4 rows were inserted
+        const count = await sql`SELECT COUNT(*) as count FROM ${sql(random_name)}`;
+        expect(Number(count[0].count)).toBe(4);
+      } finally {
+        await sql`DROP TABLE IF EXISTS ${sql(random_name)}`;
+      }
+    });
+  },
+);


### PR DESCRIPTION
## Summary

- Add regression test for #25552: MySQL transactions hang on Windows when starting a second sequential transaction
- This issue was caused by the same underlying bug as #26030, which was fixed in commit a9b5f5cbd1

The test covers:
- Sequential transactions with multiple INSERTs (exact pattern from the issue)
- Multiple sequential transactions in a loop
- Sequential transactions using `unsafe()` as shown in the original issue

The root cause was that in `MySQLConnection.zig`, the `handleResultSetOK()` function's defer block was calling `queue.advance()` without flushing, causing queries added during JavaScript callbacks to not be properly sent to the server.

Closes #25552

## Test plan

- [x] Added regression test at `test/regression/issue/25552.test.ts`
- [ ] CI runs the MySQL container tests to verify the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)