### PR TITLE
fix(http): preserve original header name casing in Node.js HTTP server

### DIFF
--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -538,7 +538,8 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
 
     for (const auto& header : internalHeaders.commonHeaders()) {
 
-        const auto& name = WebCore::httpHeaderNameString(header.key);
+        // Use the original name if it was preserved, otherwise use the default header name string
+        const auto& name = header.originalName.isEmpty() ? WebCore::httpHeaderNameString(header.key) : StringView(header.originalName);
         const auto& value = header.value;
 
         // We have to tell uWS not to automatically insert a TransferEncoding or Date header.
@@ -930,7 +931,8 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPSetHeader, (JSGlobalObject * globalObject, CallFr
                     RETURN_IF_EXCEPTION(scope, {});
                     auto value = item.toWTFString(globalObject);
                     RETURN_IF_EXCEPTION(scope, {});
-                    impl->set(name, value);
+                    // Use setPreservingOriginalName to preserve the original header name casing
+                    impl->setPreservingOriginalName(name, value);
                     RETURN_IF_EXCEPTION(scope, {});
                 }
                 for (unsigned i = 1; i < length; ++i) {
@@ -947,7 +949,8 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPSetHeader, (JSGlobalObject * globalObject, CallFr
 
             auto value = valueValue.toWTFString(globalObject);
             RETURN_IF_EXCEPTION(scope, {});
-            impl->set(name, value);
+            // Use setPreservingOriginalName to preserve the original header name casing
+            impl->setPreservingOriginalName(name, value);
             RETURN_IF_EXCEPTION(scope, {});
             return JSValue::encode(jsUndefined());
         }

--- a/src/bun.js/bindings/webcore/FetchHeaders.h
+++ b/src/bun.js/bindings/webcore/FetchHeaders.h
@@ -64,6 +64,7 @@ public:
     ExceptionOr<bool> has(const StringView) const;
     ExceptionOr<void> set(const String& name, const String& value);
     ExceptionOr<void> set(const HTTPHeaderName name, const String& value);
+    ExceptionOr<void> setPreservingOriginalName(const String& name, const String& value);
 
     ExceptionOr<void> fill(const Init&);
     ExceptionOr<void> fill(const FetchHeaders&);

--- a/test/regression/issue/15578.test.ts
+++ b/test/regression/issue/15578.test.ts
@@ -1,0 +1,158 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/15578
+// Node.js HTTP server should preserve the original casing of header names
+// when using res.setHeader()
+
+test("res.setHeader preserves original header name casing", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import { createServer } from 'node:http';
+      import { connect } from 'node:net';
+
+      const http = createServer((req, res) => {
+        res.setHeader('location', 'http://test.com');
+        res.setHeader('content-type', 'text/plain');
+        res.setHeader('X-Custom-Header', 'custom-value');
+        res.setHeader('X-UPPERCASE', 'value1');
+        res.setHeader('x-lowercase', 'value2');
+        res.end('test');
+      });
+
+      http.listen(0, () => {
+        const port = http.address().port;
+
+        // Use raw socket to see actual header casing
+        const client = connect(port, 'localhost', () => {
+          client.write('GET / HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n');
+        });
+
+        client.on('data', (data) => {
+          const response = data.toString();
+          console.log(response);
+          client.end();
+          http.close();
+        });
+      });
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+
+  // Check that lowercase headers are preserved as lowercase
+  expect(stdout).toContain("location: http://test.com");
+  expect(stdout).toContain("content-type: text/plain");
+
+  // Check that the original casing is preserved
+  expect(stdout).toContain("X-Custom-Header: custom-value");
+  expect(stdout).toContain("X-UPPERCASE: value1");
+  expect(stdout).toContain("x-lowercase: value2");
+
+  // Make sure title-case versions are NOT present
+  expect(stdout).not.toContain("Location:");
+  expect(stdout).not.toContain("Content-Type:");
+});
+
+test("res.setHeader with array values preserves header name casing", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import { createServer } from 'node:http';
+      import { connect } from 'node:net';
+
+      const http = createServer((req, res) => {
+        // Set a header with multiple values (array)
+        res.setHeader('x-multi-value', ['value1', 'value2']);
+        res.end('test');
+      });
+
+      http.listen(0, () => {
+        const port = http.address().port;
+
+        const client = connect(port, 'localhost', () => {
+          client.write('GET / HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n');
+        });
+
+        client.on('data', (data) => {
+          const response = data.toString();
+          console.log(response);
+          client.end();
+          http.close();
+        });
+      });
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+
+  // x-multi-value should appear with original lowercase casing
+  expect(stdout).toContain("x-multi-value:");
+});
+
+test("writeHead preserves header name casing", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import { createServer } from 'node:http';
+      import { connect } from 'node:net';
+
+      const http = createServer((req, res) => {
+        res.writeHead(302, {
+          'location': '/redirect',
+          'cache-control': 'no-cache'
+        });
+        res.end();
+      });
+
+      http.listen(0, () => {
+        const port = http.address().port;
+
+        const client = connect(port, 'localhost', () => {
+          client.write('GET / HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n');
+        });
+
+        client.on('data', (data) => {
+          const response = data.toString();
+          console.log(response);
+          client.end();
+          http.close();
+        });
+      });
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+
+  // Headers passed to writeHead should preserve their casing
+  expect(stdout).toContain("location: /redirect");
+  expect(stdout).toContain("cache-control: no-cache");
+});


### PR DESCRIPTION
## Summary

- Fixes header casing issue where `res.setHeader('location', ...)` would send `Location` instead of `location`
- Adds `originalName` field to `CommonHeader` struct to store the original header name casing
- Uses `setPreservingOriginalName` method in the Node.js HTTP binding to preserve original casing
- Falls back to default casing when original name is not set (for Web Fetch API compatibility)

## Test plan

- [x] Added regression test `test/regression/issue/15578.test.ts`
- [x] Test passes with `bun bd test`
- [x] Test fails with `USE_SYSTEM_BUN=1` (verifying it tests the bug)
- [x] Verified fix matches Node.js behavior for lowercase and mixed-case headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)