### PR TITLE
feat(s3): add response override options for presigned URLs

### DIFF
--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -393,6 +393,72 @@ declare module "bun" {
      *     });
      */
     method?: "GET" | "POST" | "PUT" | "DELETE" | "HEAD";
+
+    /**
+     * Sets the Cache-Control header of the response when the presigned URL is accessed.
+     *
+     * @example
+     *     const url = file.presign({
+     *       expiresIn: 3600,
+     *       responseCacheControl: "max-age=3600, public"
+     *     });
+     */
+    responseCacheControl?: string;
+
+    /**
+     * Sets the Content-Disposition header of the response when the presigned URL is accessed.
+     *
+     * @example
+     *     const url = file.presign({
+     *       expiresIn: 3600,
+     *       responseContentDisposition: "attachment; filename=\"report.pdf\""
+     *     });
+     */
+    responseContentDisposition?: string;
+
+    /**
+     * Sets the Content-Encoding header of the response when the presigned URL is accessed.
+     *
+     * @example
+     *     const url = file.presign({
+     *       expiresIn: 3600,
+     *       responseContentEncoding: "gzip"
+     *     });
+     */
+    responseContentEncoding?: string;
+
+    /**
+     * Sets the Content-Language header of the response when the presigned URL is accessed.
+     *
+     * @example
+     *     const url = file.presign({
+     *       expiresIn: 3600,
+     *       responseContentLanguage: "en-US"
+     *     });
+     */
+    responseContentLanguage?: string;
+
+    /**
+     * Sets the Content-Type header of the response when the presigned URL is accessed.
+     *
+     * @example
+     *     const url = file.presign({
+     *       expiresIn: 3600,
+     *       responseContentType: "application/pdf"
+     *     });
+     */
+    responseContentType?: string;
+
+    /**
+     * Sets the Expires header of the response when the presigned URL is accessed.
+     *
+     * @example
+     *     const url = file.presign({
+     *       expiresIn: 3600,
+     *       responseExpires: "Wed, 21 Oct 2025 07:28:00 GMT"
+     *     });
+     */
+    responseExpires?: string;
   }
 
   interface S3Stats {

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -505,6 +505,12 @@ pub fn getPresignUrlFrom(this: *Blob, globalThis: *jsc.JSGlobalObject, extra_opt
         .request_payer = credentialsWithOptions.request_payer,
         .content_disposition = credentialsWithOptions.content_disposition,
         .content_type = credentialsWithOptions.content_type,
+        .response_cache_control = credentialsWithOptions.response_cache_control,
+        .response_content_disposition = credentialsWithOptions.response_content_disposition,
+        .response_content_encoding = credentialsWithOptions.response_content_encoding,
+        .response_content_language = credentialsWithOptions.response_content_language,
+        .response_content_type = credentialsWithOptions.response_content_type,
+        .response_expires = credentialsWithOptions.response_expires,
     }, false, .{ .expires = expires }) catch |sign_err| {
         return S3.throwSignError(sign_err, globalThis);
     };

--- a/test/regression/issue/18016.test.ts
+++ b/test/regression/issue/18016.test.ts
@@ -1,0 +1,149 @@
+import { S3Client } from "bun";
+import { describe, expect, test } from "bun:test";
+
+describe("S3 presign response override options (#18016)", () => {
+  const s3 = new S3Client({
+    accessKeyId: "test-key",
+    secretAccessKey: "test-secret",
+    endpoint: "https://s3.example.com",
+    bucket: "test-bucket",
+  });
+
+  test("presign should support responseCacheControl option", () => {
+    const url = s3.presign("test-file.txt", {
+      expiresIn: 300,
+      responseCacheControl: "max-age=3600, public",
+    });
+
+    const urlObj = new URL(url);
+
+    // Verify response-cache-control parameter is present
+    expect(urlObj.searchParams.get("response-cache-control")).toBe("max-age=3600, public");
+  });
+
+  test("presign should support responseContentDisposition option", () => {
+    const url = s3.presign("test-file.txt", {
+      expiresIn: 300,
+      responseContentDisposition: 'attachment; filename="report.pdf"',
+    });
+
+    const urlObj = new URL(url);
+
+    // Verify response-content-disposition parameter is present
+    expect(urlObj.searchParams.get("response-content-disposition")).toBe('attachment; filename="report.pdf"');
+  });
+
+  test("presign should support responseContentEncoding option", () => {
+    const url = s3.presign("test-file.txt", {
+      expiresIn: 300,
+      responseContentEncoding: "gzip",
+    });
+
+    const urlObj = new URL(url);
+
+    // Verify response-content-encoding parameter is present
+    expect(urlObj.searchParams.get("response-content-encoding")).toBe("gzip");
+  });
+
+  test("presign should support responseContentLanguage option", () => {
+    const url = s3.presign("test-file.txt", {
+      expiresIn: 300,
+      responseContentLanguage: "en-US",
+    });
+
+    const urlObj = new URL(url);
+
+    // Verify response-content-language parameter is present
+    expect(urlObj.searchParams.get("response-content-language")).toBe("en-US");
+  });
+
+  test("presign should support responseContentType option", () => {
+    const url = s3.presign("test-file.txt", {
+      expiresIn: 300,
+      responseContentType: "application/pdf",
+    });
+
+    const urlObj = new URL(url);
+
+    // Verify response-content-type parameter is present
+    expect(urlObj.searchParams.get("response-content-type")).toBe("application/pdf");
+  });
+
+  test("presign should support responseExpires option", () => {
+    const url = s3.presign("test-file.txt", {
+      expiresIn: 300,
+      responseExpires: "Wed, 21 Oct 2025 07:28:00 GMT",
+    });
+
+    const urlObj = new URL(url);
+
+    // Verify response-expires parameter is present
+    expect(urlObj.searchParams.get("response-expires")).toBe("Wed, 21 Oct 2025 07:28:00 GMT");
+  });
+
+  test("presign should support multiple response override options", () => {
+    const url = s3.presign("test-file.txt", {
+      expiresIn: 300,
+      responseCacheControl: "max-age=3600",
+      responseContentDisposition: 'inline; filename="doc.pdf"',
+      responseContentType: "application/pdf",
+    });
+
+    const urlObj = new URL(url);
+    const params = Array.from(urlObj.searchParams.keys());
+
+    // Verify all parameters are present and in alphabetical order
+    expect(params).toContain("response-cache-control");
+    expect(params).toContain("response-content-disposition");
+    expect(params).toContain("response-content-type");
+
+    // Verify values
+    expect(urlObj.searchParams.get("response-cache-control")).toBe("max-age=3600");
+    expect(urlObj.searchParams.get("response-content-disposition")).toBe('inline; filename="doc.pdf"');
+    expect(urlObj.searchParams.get("response-content-type")).toBe("application/pdf");
+
+    // Verify alphabetical order
+    const expected = params.slice().sort();
+    expect(params).toEqual(expected);
+  });
+
+  test("presign should prefer responseContentType over type for response override", () => {
+    const url = s3.presign("test-file.txt", {
+      expiresIn: 300,
+      type: "text/plain",
+      responseContentType: "application/json",
+    });
+
+    const urlObj = new URL(url);
+
+    // responseContentType should take precedence
+    expect(urlObj.searchParams.get("response-content-type")).toBe("application/json");
+  });
+
+  test("presign should prefer responseContentDisposition over contentDisposition for response override", () => {
+    const url = s3.presign("test-file.txt", {
+      expiresIn: 300,
+      contentDisposition: "inline",
+      responseContentDisposition: "attachment",
+    });
+
+    const urlObj = new URL(url);
+
+    // responseContentDisposition should take precedence
+    expect(urlObj.searchParams.get("response-content-disposition")).toBe("attachment");
+  });
+
+  test("S3File presign method should support response override options", () => {
+    const file = s3.file("test-file.txt");
+    const url = file.presign({
+      expiresIn: 300,
+      responseCacheControl: "no-cache",
+      responseContentType: "image/png",
+    });
+
+    const urlObj = new URL(url);
+
+    expect(urlObj.searchParams.get("response-cache-control")).toBe("no-cache");
+    expect(urlObj.searchParams.get("response-content-type")).toBe("image/png");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds support for S3 presigned URL response override parameters
- Fixes #18016

AWS S3 presigned URLs support several response override query parameters that allow customizing response headers when the URL is accessed. This PR adds support for these options:

- `responseCacheControl` - Sets `response-cache-control` query parameter
- `responseContentDisposition` - Sets `response-content-disposition` query parameter
- `responseContentEncoding` - Sets `response-content-encoding` query parameter
- `responseContentLanguage` - Sets `response-content-language` query parameter
- `responseContentType` - Sets `response-content-type` query parameter
- `responseExpires` - Sets `response-expires` query parameter

### Example Usage

```js
import { s3 } from "bun";

const file = s3("my-bucket/my-key");
const url = file.presign({
    expiresIn: 3600,
    responseCacheControl: "max-age=3600, public",
    responseContentDisposition: 'attachment; filename="report.pdf"',
    responseContentType: "application/pdf",
});
```

This matches the AWS SDK's `GetObjectCommand` options:
```js
// AWS SDK equivalent
const command = new GetObjectCommand({
    Bucket: bucket,
    Key: key,
    ResponseCacheControl: "max-age=3600, public",
    ResponseContentDisposition: 'attachment; filename="report.pdf"',
    ResponseContentType: "application/pdf",
});
const url = await getSignedUrl(client, command, { expiresIn: 3600 });
```

## Test plan

- Added test file `test/regression/issue/18016.test.ts` with tests for all new options
- Test verifies query parameters are correctly encoded in presigned URLs
- Test verifies parameters maintain alphabetical order for AWS SigV4 compliance
- Test verifies backwards compatibility with existing `type` and `contentDisposition` options

🤖 Generated with [Claude Code](https://claude.com/claude-code)