### PR TITLE
fix(lockfile): handle BrokenPipe gracefully when printing lockfile

### DIFF
--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1150,7 +1150,11 @@ pub const Printer = struct {
         }
 
         const writer = Output.writerBuffered();
-        try printWithLockfile(allocator, lockfile, format, @TypeOf(writer), writer);
+        printWithLockfile(allocator, lockfile, format, @TypeOf(writer), writer) catch |err| switch (err) {
+            error.OutOfMemory => bun.outOfMemory(),
+            error.BrokenPipe, error.WriteFailed => return,
+            else => |e| return e,
+        };
         Output.flush();
     }
 

--- a/test/regression/issue/05828.test.ts
+++ b/test/regression/issue/05828.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix } from "harness";
+import { join } from "path";
+
+// https://github.com/oven-sh/bun/issues/5828
+test.if(isPosix)("bun bun.lockb handles BrokenPipe gracefully", async () => {
+  // Use an existing lockfile that has enough content to trigger the BrokenPipe
+  // The sharp integration test has a lockfile with many dependencies
+  const lockfilePath = join(import.meta.dir, "../../integration/sharp/bun.lockb");
+
+  // Simulate piping to a command that closes stdin immediately (like `true`)
+  // This tests that `bun bun.lockb` doesn't crash with BrokenPipe error
+  await using proc = Bun.spawn({
+    cmd: ["sh", "-c", `${bunExe()} ${lockfilePath} | true`],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Should exit cleanly (0) instead of crashing with BrokenPipe error
+  // The stderr should NOT contain "BrokenPipe" or "WriteFailed" error
+  expect(stderr).not.toContain("BrokenPipe");
+  expect(stderr).not.toContain("WriteFailed");
+  expect(stderr).not.toContain("error");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fixes `bun bun.lockb | head` showing an internal error message instead of exiting silently

## Test plan
- Added regression test in `test/regression/issue/05828.test.ts`
- Verified the test fails with the current release version
- Verified the test passes with the fix

Fixes #5828

🤖 Generated with [Claude Code](https://claude.com/claude-code)