### PR TITLE
fix(macros): detect circular references and report clear error

### DIFF
--- a/test/regression/issue/22552.test.ts
+++ b/test/regression/issue/22552.test.ts
@@ -1,0 +1,138 @@
+// https://github.com/oven-sh/bun/issues/22552
+// Macros that return objects with circular references should produce a clear error message
+// instead of crashing with a segmentation fault.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("macro with direct circular reference should error gracefully - issue #22552", async () => {
+  using dir = tempDir("22552-circular-direct", {
+    "circular.ts": `
+export function getCircularData(): any {
+  const obj: any = { name: "test" };
+  obj.self = obj;  // Direct circular reference
+  return obj;
+}
+`,
+    "main.ts": `
+import { getCircularData } from "./circular.ts" with { type: "macro" };
+const data = getCircularData();
+console.log(data);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./main.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // Should fail with a clear error message, not crash
+  expect(stderr).toContain("circular reference");
+  expect(exitCode).toBe(1);
+});
+
+test("macro with indirect circular reference should error gracefully - issue #22552", async () => {
+  using dir = tempDir("22552-circular-indirect", {
+    "circular.ts": `
+export function getIndirectCircular(): any {
+  const a: any = { name: "a" };
+  const b: any = { name: "b" };
+  a.ref = b;
+  b.ref = a;  // Indirect circular reference
+  return a;
+}
+`,
+    "main.ts": `
+import { getIndirectCircular } from "./circular.ts" with { type: "macro" };
+const data = getIndirectCircular();
+console.log(data);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./main.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // Should fail with a clear error message, not crash
+  expect(stderr).toContain("circular reference");
+  expect(exitCode).toBe(1);
+});
+
+test("macro with circular array reference should error gracefully - issue #22552", async () => {
+  using dir = tempDir("22552-circular-array", {
+    "circular.ts": `
+export function getCircularArray(): any {
+  const arr: any[] = [1, 2, 3];
+  arr.push(arr);  // Array contains itself
+  return arr;
+}
+`,
+    "main.ts": `
+import { getCircularArray } from "./circular.ts" with { type: "macro" };
+const data = getCircularArray();
+console.log(data);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./main.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // Should fail with a clear error message, not crash
+  expect(stderr).toContain("circular reference");
+  expect(exitCode).toBe(1);
+});
+
+test("macro with non-circular nested objects should work fine - issue #22552", async () => {
+  using dir = tempDir("22552-non-circular", {
+    "data.ts": `
+export function getNestedData(): any {
+  return {
+    level1: {
+      level2: {
+        level3: {
+          value: "deep"
+        }
+      }
+    }
+  };
+}
+`,
+    "main.ts": `
+import { getNestedData } from "./data.ts" with { type: "macro" };
+const data = getNestedData();
+console.log(data.level1.level2.level3.value);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./main.ts", "--outdir", "./out"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // Non-circular structures should work fine
+  expect(stderr).not.toContain("error");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fix crash when macro returns object with circular reference
- Add clear error message instead of segfault
- Add regression tests for circular reference detection

Fixes #22552

## Root Cause
When a macro returned an object with a circular reference, Bun would crash with a segmentation fault. This happened because:

1. During JavaScript-to-AST conversion, the code would create placeholder AST nodes
2. For circular references, the placeholder (with empty properties) would be returned
3. Later AST traversal would infinitely recurse trying to visit the circular nodes

## Solution
Use a sentinel value (`Expr.empty` with `e_missing` data) to mark objects being processed:
- Before processing an object/array, store the sentinel in the visited map
- When encountering a value already being processed (sentinel detected), emit a clear error
- Move expression creation to after all children are processed, then store the final result

This prevents circular AST nodes from being created and provides a helpful error message.

## Test plan
- [x] Added regression tests for direct circular references (`obj.self = obj`)
- [x] Added tests for indirect circular references (`a.ref = b; b.ref = a`)  
- [x] Added tests for circular arrays
- [x] Verified non-circular nested objects still work
- [x] Existing macro tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)