### PR TITLE
fix(fs): throw early for strings exceeding WebKit's 2GB limit

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -10,7 +10,10 @@ pub export var isBunTest: bool = false;
 
 // TODO: evaluate if this has any measurable performance impact.
 pub var synthetic_allocation_limit: usize = std.math.maxInt(u32);
-pub var string_allocation_limit: usize = std.math.maxInt(u32);
+/// Max WTFStringImpl/JSString length, matches `WTF::String::MaxLength` / `JSString::MaxLength`.
+/// This ensures readFileSync and other APIs that return strings will throw early
+/// instead of allowing WebKit to silently truncate strings larger than ~2GB.
+pub var string_allocation_limit: usize = std.math.maxInt(i32);
 
 comptime {
     _ = Bun__remapStackFramePositions;

--- a/test/regression/issue/2570.test.ts
+++ b/test/regression/issue/2570.test.ts
@@ -1,0 +1,29 @@
+import { constants, kMaxLength, kStringMaxLength } from "buffer";
+import { expect, test } from "bun:test";
+
+// Issue #2570: JSON.parse silently truncates strings larger than ~2GB
+// Root cause: Mismatch between Bun's string allocation limit and WebKit's String::MaxLength
+//
+// The fix ensures that readFileSync with string encodings (utf8, ascii, etc.)
+// checks against WebKit's String::MaxLength (~2GB) instead of the higher
+// typed array limit (~4GB). This prevents silent string truncation that
+// caused confusing "JSON Parse error: Unexpected EOF" errors.
+
+test("kStringMaxLength matches WebKit's String::MaxLength (2^31 - 1)", () => {
+  // WebKit's String::MaxLength is std::numeric_limits<int32_t>::max()
+  const maxInt32 = Math.pow(2, 31) - 1;
+  expect(kStringMaxLength).toBe(maxInt32);
+  expect(constants.MAX_STRING_LENGTH).toBe(maxInt32);
+});
+
+test("buffer encoding has higher limit than string encoding", () => {
+  // Buffer encoding uses synthetic_allocation_limit (~4.7GB)
+  // String encoding uses string_allocation_limit (~2.15GB)
+
+  // kMaxLength is for buffers/typed arrays
+  // kStringMaxLength is for strings
+  expect(kMaxLength).toBeGreaterThan(kStringMaxLength);
+
+  // kStringMaxLength should be 2^31 - 1 (maxInt32)
+  expect(kStringMaxLength).toBe(2147483647);
+});


### PR DESCRIPTION
## Summary
- Fixes `readFileSync` with string encodings to throw ENOMEM early for files > ~2GB
- Prevents silent string truncation that caused confusing "JSON Parse error: Unexpected EOF"

## Test plan
- Added regression test verifying `kStringMaxLength` matches WebKit's limit (2^31 - 1)
- Ran fs tests to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)