### PR TITLE
fix(node): add `authorized` property to `req.socket` for HTTPS servers

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -133,7 +133,11 @@ private:
                             return;
                         }
                     }
-                    httpResponseData->isAuthorized = success;
+                    // isAuthorized should be true only when both:
+                    // 1. The handshake succeeded
+                    // 2. The peer certificate was verified successfully (verify_error.error == 0)
+                    // When requestCert is false, verify_error.error will be non-zero (no peer cert)
+                    httpResponseData->isAuthorized = success && (verify_error.error == 0);
 
                     /* Any connected socket should timeout until it has a request */
                     ((HttpResponse<SSL> *) s)->resetTimeout();

--- a/src/bun.js/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
+++ b/src/bun.js/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
@@ -34,6 +34,7 @@ JSC_DECLARE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterLocalAddress);
 JSC_DECLARE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterDuplex);
 JSC_DECLARE_CUSTOM_SETTER(jsNodeHttpServerSocketSetterDuplex);
 JSC_DECLARE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterIsSecureEstablished);
+JSC_DECLARE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterAuthorized);
 
 JSC_DEFINE_CUSTOM_SETTER(noOpSetter, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue value, JSC::PropertyName propertyName))
 {
@@ -57,6 +58,7 @@ static const JSC::HashTableValue JSNodeHTTPServerSocketPrototypeTableValues[] = 
     { "write"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketWrite, 2 } },
     { "end"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), JSC::NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, jsFunctionNodeHTTPServerSocketEnd, 0 } },
     { "secureEstablished"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::ReadOnly), JSC::NoIntrinsic, { JSC::HashTableValue::GetterSetterType, jsNodeHttpServerSocketGetterIsSecureEstablished, noOpSetter } },
+    { "authorized"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::ReadOnly), JSC::NoIntrinsic, { JSC::HashTableValue::GetterSetterType, jsNodeHttpServerSocketGetterAuthorized, noOpSetter } },
 };
 
 void JSNodeHTTPServerSocketPrototype::finishCreation(JSC::VM& vm)
@@ -115,6 +117,12 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeHTTPServerSocketEnd, (JSC::JSGlobalObject
 
 // Implementation of custom getters
 JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterIsSecureEstablished, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    auto* thisObject = jsCast<JSNodeHTTPServerSocket*>(JSC::JSValue::decode(thisValue));
+    return JSValue::encode(JSC::jsBoolean(thisObject->isAuthorized()));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterAuthorized, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
     auto* thisObject = jsCast<JSNodeHTTPServerSocket*>(JSC::JSValue::decode(thisValue));
     return JSValue::encode(JSC::jsBoolean(thisObject->isAuthorized()));

--- a/src/js/internal/http/FakeSocket.ts
+++ b/src/js/internal/http/FakeSocket.ts
@@ -1,5 +1,5 @@
 const { kInternalSocketData, serverSymbol } = require("internal/http");
-const { kAutoDestroyed } = require("internal/shared");
+const { kAutoDestroyed, kHandle } = require("internal/shared");
 const { Duplex } = require("internal/stream");
 
 type FakeSocket = InstanceType<typeof FakeSocket>;
@@ -10,6 +10,7 @@ var FakeSocket = class Socket extends Duplex {
   connecting = false;
   timeout = 0;
   isServer = false;
+  authorizationError: string | undefined;
 
   #address;
   _httpMessage: any;
@@ -57,6 +58,12 @@ var FakeSocket = class Socket extends Duplex {
 
   get pending() {
     return this.connecting;
+  }
+
+  get authorized(): boolean {
+    // Try to get authorized from the underlying native handle
+    const handle = this._httpMessage?.[kHandle];
+    return handle?.authorized ?? false;
   }
 
   _read(_size) {}

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -819,6 +819,7 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   server: Server;
   _httpMessage;
   _secureEstablished = false;
+  authorizationError: string | undefined;
   #pendingCallback = null;
   constructor(server: Server, handle, encrypted) {
     super();
@@ -840,6 +841,11 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   }
   set bytesWritten(value) {
     this[kBytesWritten] = value;
+  }
+
+  get authorized(): boolean {
+    const handle = this[kHandle];
+    return handle?.authorized ?? false;
   }
 
   [kEnableStreaming](enable: boolean) {

--- a/test/regression/issue/16254.test.ts
+++ b/test/regression/issue/16254.test.ts
@@ -1,0 +1,124 @@
+// https://github.com/oven-sh/bun/issues/16254
+// req.socket.authorized should be a boolean indicating client certificate verification status
+
+import { expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import * as https from "https";
+import type { AddressInfo } from "net";
+import { join } from "path";
+
+const fixturesDir = join(import.meta.dir, "../../js/node/tls/fixtures");
+
+// ca1 is a self-signed CA certificate
+const ca1Cert = readFileSync(join(fixturesDir, "ca1-cert.pem"));
+// agent1 is signed by ca1
+const agent1Key = readFileSync(join(fixturesDir, "agent1-key.pem"));
+const agent1Cert = readFileSync(join(fixturesDir, "agent1-cert.pem"));
+
+test("req.socket.authorized should be true when client certificate is valid (mTLS)", async () => {
+  const { promise, resolve, reject } = Promise.withResolvers<{ authorized: boolean | undefined; response: string }>();
+
+  const server = https.createServer(
+    {
+      key: agent1Key,
+      cert: agent1Cert,
+      ca: ca1Cert,
+      requestCert: true,
+      rejectUnauthorized: true,
+    },
+    (req, res) => {
+      const authorized = req.socket.authorized;
+      res.writeHead(200);
+      res.end(authorized ? "Authorized" : "Not authorized");
+      resolve({ authorized, response: authorized ? "Authorized" : "Not authorized" });
+    },
+  );
+
+  server.on("error", reject);
+
+  await new Promise<void>(res => server.listen(0, res));
+
+  try {
+    const port = (server.address() as AddressInfo).port;
+
+    const req = https.request(
+      {
+        hostname: "localhost",
+        port,
+        method: "GET",
+        path: "/",
+        key: agent1Key,
+        cert: agent1Cert,
+        ca: ca1Cert,
+        rejectUnauthorized: false, // Don't reject self-signed server cert
+      },
+      res => {
+        let data = "";
+        res.on("data", chunk => (data += chunk));
+        res.on("end", () => {
+          // Response handled via promise above
+        });
+      },
+    );
+
+    req.on("error", reject);
+    req.end();
+
+    const result = await promise;
+
+    // The main assertion: authorized should be a boolean true, not undefined
+    expect(typeof result.authorized).toBe("boolean");
+    expect(result.authorized).toBe(true);
+    expect(result.response).toBe("Authorized");
+  } finally {
+    server.close();
+  }
+});
+
+test("req.socket.authorized should be defined even when requestCert is false", async () => {
+  const { promise, resolve, reject } = Promise.withResolvers<boolean | undefined>();
+
+  const server = https.createServer(
+    {
+      key: agent1Key,
+      cert: agent1Cert,
+      requestCert: false,
+      rejectUnauthorized: false,
+    },
+    (req, res) => {
+      resolve(req.socket.authorized);
+      res.writeHead(200);
+      res.end("OK");
+    },
+  );
+
+  server.on("error", reject);
+
+  await new Promise<void>(res => server.listen(0, res));
+
+  try {
+    const port = (server.address() as AddressInfo).port;
+
+    const req = https.request(
+      {
+        hostname: "localhost",
+        port,
+        method: "GET",
+        path: "/",
+        rejectUnauthorized: false,
+      },
+      () => {},
+    );
+
+    req.on("error", reject);
+    req.end();
+
+    const authorized = await promise;
+
+    // authorized should be a boolean (false when no client cert requested)
+    expect(typeof authorized).toBe("boolean");
+    expect(authorized).toBe(false);
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #16254

- Adds the `authorized` property to `req.socket` for Node.js-compatible HTTPS servers
- When using mTLS, `authorized` now correctly returns `true` when the client certificate is valid
- When no client certificate is requested/provided, `authorized` returns `false` (matching Node.js behavior)

## Test plan

- [x] Added regression test at `test/regression/issue/16254.test.ts`
- [x] Test passes with `bun bd test test/regression/issue/16254.test.ts`
- [x] Test fails with `USE_SYSTEM_BUN=1 bun test test/regression/issue/16254.test.ts` (confirming the bug exists in the current release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)