### PR TITLE
feat(test): add `advanceTimers` option to `jest.useFakeTimers()`

### DIFF
--- a/src/bun.js/test/timers/FakeTimers.zig
+++ b/src/bun.js/test/timers/FakeTimers.zig
@@ -5,6 +5,17 @@
 /// - count (cannot be implemented efficiently with TimerHeap)
 timers: TimerHeap = .{ .context = {} },
 
+/// Auto-advance timer that runs in real time and periodically advances fake time.
+/// When advanceTimers option is enabled, this timer fires every N milliseconds of real time
+/// and advances the fake clock by the same amount.
+auto_advance_timer: bun.api.Timer.EventLoopTimer = .{
+    .tag = .FakeTimersAutoAdvance,
+    .next = .epoch,
+},
+/// The interval in milliseconds for auto-advancing timers.
+/// 0 means auto-advance is disabled.
+auto_advance_interval_ms: u32 = 0,
+
 pub var current_time: struct {
     const min_timespec = bun.timespec{ .sec = std.math.minInt(i64), .nsec = std.math.minInt(i64) };
     /// starts at 0. offset in milliseconds.
@@ -63,11 +74,12 @@ pub fn isActive(this: *FakeTimers) bool {
 
     return this.#active;
 }
-fn activate(this: *FakeTimers, js_now: f64, globalObject: *jsc.JSGlobalObject) void {
+fn activate(this: *FakeTimers, js_now: f64, globalObject: *jsc.JSGlobalObject, auto_advance_ms: u32) void {
     this.assertValid(.locked);
     defer this.assertValid(.locked);
 
     this.#active = true;
+    this.auto_advance_interval_ms = auto_advance_ms;
     current_time.set(globalObject, .{ .offset = &.epoch, .js = js_now });
 }
 fn deactivate(this: *FakeTimers, globalObject: *jsc.JSGlobalObject) void {
@@ -75,6 +87,7 @@ fn deactivate(this: *FakeTimers, globalObject: *jsc.JSGlobalObject) void {
     defer this.assertValid(.locked);
 
     this.clear();
+    this.stopAutoAdvanceTimer(globalObject);
     current_time.clear(globalObject);
     this.#active = false;
 }
@@ -96,7 +109,9 @@ fn executeNext(this: *FakeTimers, globalObject: *jsc.JSGlobalObject) bool {
     const next = blk: {
         timers.lock.lock();
         defer timers.lock.unlock();
-        break :blk this.timers.deleteMin() orelse return false;
+        const timer = this.timers.deleteMin() orelse return false;
+        timer.in_heap = .none;
+        break :blk timer;
     };
 
     this.fire(globalObject, next);
@@ -130,6 +145,7 @@ fn executeUntil(this: *FakeTimers, globalObject: *jsc.JSGlobalObject, until: bun
             const peek = this.timers.peek() orelse break;
             if (peek.next.greater(&until)) break;
             bun.assert(this.timers.deleteMin() == peek);
+            peek.in_heap = .none;
             break :blk peek;
         };
         this.fire(globalObject, next);
@@ -154,6 +170,81 @@ fn executeAllTimers(this: *FakeTimers, globalObject: *jsc.JSGlobalObject) void {
     defer this.assertValid(.unlocked);
 
     while (this.executeNext(globalObject)) {}
+}
+
+// ===
+// Auto-advance timer
+// ===
+
+/// Called when the auto-advance timer fires (in real time).
+/// This advances fake time by the configured interval and fires any timers that are ready.
+pub fn onAutoAdvanceTimer(this: *FakeTimers, vm: *jsc.VirtualMachine) void {
+    this.assertValid(.unlocked);
+    defer this.assertValid(.unlocked);
+
+    const interval_ms = this.auto_advance_interval_ms;
+    if (interval_ms == 0) return;
+
+    const globalObject = vm.global;
+    const timers = &vm.timer;
+
+    // Check if fake timers are still active
+    {
+        timers.lock.lock();
+        defer timers.lock.unlock();
+        if (!this.isActive()) return;
+    }
+
+    // Get current fake time and advance it
+    const current = current_time.getTimespecNow() orelse return;
+    const target = current.addMs(interval_ms);
+
+    // Execute all timers up to the target time.
+    // Note: This may trigger JavaScript callbacks that could call useRealTimers(),
+    // so we need to check isActive() again after this returns.
+    this.executeUntil(globalObject, target);
+
+    // Re-check if fake timers are still active after executing timers.
+    // JavaScript code in timer callbacks may have called useRealTimers().
+    {
+        timers.lock.lock();
+        defer timers.lock.unlock();
+        if (!this.isActive()) return;
+    }
+
+    current_time.set(globalObject, .{ .offset = &target });
+
+    // Reschedule ourselves using real time
+    this.scheduleAutoAdvanceTimer(vm);
+}
+
+/// Schedule the auto-advance timer to fire after the configured interval (in real time).
+fn scheduleAutoAdvanceTimer(this: *FakeTimers, vm: *jsc.VirtualMachine) void {
+    const interval_ms = this.auto_advance_interval_ms;
+    if (interval_ms == 0) return;
+
+    const now = bun.timespec.now(.force_real_time);
+    this.auto_advance_timer.next = now.addMs(interval_ms);
+    this.auto_advance_timer.state = .PENDING;
+
+    // Insert into the regular timer heap (not the fake heap) using real time.
+    // The FakeTimersAutoAdvance tag has allowFakeTimers() == false so it goes
+    // into the regular heap.
+    vm.timer.insert(&this.auto_advance_timer);
+}
+
+/// Stop the auto-advance timer. Must be called with timers.lock held.
+fn stopAutoAdvanceTimer(this: *FakeTimers, globalObject: *jsc.JSGlobalObject) void {
+    const vm = globalObject.bunVM();
+    this.auto_advance_interval_ms = 0;
+    // Remove the timer from its heap based on where it's stored
+    switch (this.auto_advance_timer.in_heap) {
+        .regular => vm.timer.timers.remove(&this.auto_advance_timer),
+        .fake => this.timers.remove(&this.auto_advance_timer),
+        .none => {}, // Timer is not in any heap (already fired or not yet started)
+    }
+    this.auto_advance_timer.in_heap = .none;
+    this.auto_advance_timer.state = .CANCELLED;
 }
 
 // ===
@@ -197,6 +288,7 @@ fn useFakeTimers(globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) b
     const this = &timers.fake_timers;
 
     var js_now = bun.cpp.JSMock__getCurrentUnixTimeMs();
+    var auto_advance_ms: u32 = 0;
 
     // Check if options object was provided
     const args = callframe.argumentsAsArray(1);
@@ -216,12 +308,37 @@ fn useFakeTimers(globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) b
                 return globalObject.throwInvalidArguments("'now' must be a number or Date", .{});
             }
         }
+
+        // Check if 'advanceTimers' field is provided
+        // advanceTimers: true means advance by 20ms every 20ms (Jest default)
+        // advanceTimers: <number> means advance by that many ms every that many ms
+        if (!config.advanceTimers.isUndefined()) {
+            if (config.advanceTimers.isBoolean()) {
+                if (config.advanceTimers.toBoolean()) {
+                    // Default to 20ms like Jest
+                    auto_advance_ms = 20;
+                }
+            } else if (config.advanceTimers.isNumber()) {
+                const advance_num = config.advanceTimers.asNumber();
+                if (advance_num < 1 or advance_num > std.math.maxInt(u32)) {
+                    return globalObject.throwInvalidArguments("'advanceTimers' must be a positive number", .{});
+                }
+                auto_advance_ms = @intFromFloat(advance_num);
+            } else {
+                return globalObject.throwInvalidArguments("'advanceTimers' must be a boolean or number", .{});
+            }
+        }
     }
 
     {
         timers.lock.lock();
         defer timers.lock.unlock();
-        this.activate(js_now, globalObject);
+        this.activate(js_now, globalObject, auto_advance_ms);
+    }
+
+    // Start auto-advance timer if enabled (must be done outside the lock)
+    if (auto_advance_ms > 0) {
+        this.scheduleAutoAdvanceTimer(vm);
     }
 
     // Set setTimeout.clock = true to signal that fake timers are enabled.

--- a/src/bun.js/test/timers/FakeTimers.zig
+++ b/src/bun.js/test/timers/FakeTimers.zig
@@ -241,6 +241,9 @@ fn scheduleAutoAdvanceTimer(this: *FakeTimers, vm: *jsc.VirtualMachine) void {
 
 /// Stop the auto-advance timer. Must be called with timers.lock held.
 fn stopAutoAdvanceTimer(this: *FakeTimers, globalObject: *jsc.JSGlobalObject) void {
+    this.assertValid(.locked);
+    defer this.assertValid(.locked);
+
     const vm = globalObject.bunVM();
     this.#auto_advance_interval_ms = 0;
     // Remove the timer from its heap based on where it's stored

--- a/src/bun.js/test/timers/FakeTimers.zig
+++ b/src/bun.js/test/timers/FakeTimers.zig
@@ -229,6 +229,9 @@ fn scheduleAutoAdvanceTimer(this: *FakeTimers, vm: *jsc.VirtualMachine) void {
     const interval_ms = this.#auto_advance_interval_ms;
     if (interval_ms == 0) return;
 
+    // Prevent double-insertion if timer is already scheduled
+    if (this.#auto_advance_timer.in_heap != .none) return;
+
     const now = bun.timespec.now(.force_real_time);
     this.#auto_advance_timer.next = now.addMs(interval_ms);
     this.#auto_advance_timer.state = .PENDING;

--- a/src/bun.js/test/timers/FakeTimersConfig.bindv2.ts
+++ b/src/bun.js/test/timers/FakeTimersConfig.bindv2.ts
@@ -11,5 +11,9 @@ export const FakeTimersConfig = b.dictionary(
       type: b.RawAny,
       internalName: "now",
     },
+    advanceTimers: {
+      type: b.RawAny,
+      internalName: "advanceTimers",
+    },
   },
 );

--- a/test/regression/issue/26037.test.ts
+++ b/test/regression/issue/26037.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, it, jest } from "bun:test";
+
+describe("GitHub issue #26037: useFakeTimers with advanceTimers option", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("advanceTimers: true auto-advances timers (default 20ms)", async () => {
+    jest.useFakeTimers({ advanceTimers: true });
+
+    let timerFired = false;
+    setTimeout(() => {
+      timerFired = true;
+    }, 10);
+
+    // Wait for the auto-advance timer to fire using setImmediate loop
+    for (let i = 0; i < 100 && !timerFired; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+
+    expect(timerFired).toBe(true);
+  });
+
+  it("advanceTimers: <number> auto-advances timers by that amount", async () => {
+    jest.useFakeTimers({ advanceTimers: 10 });
+
+    const values: number[] = [];
+    setTimeout(() => values.push(1), 5);
+    setTimeout(() => values.push(2), 15);
+    setTimeout(() => values.push(3), 25);
+
+    // Wait for auto-advance timers to fire multiple times
+    for (let i = 0; i < 100 && values.length < 3; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+
+    expect(values).toEqual([1, 2, 3]);
+  });
+
+  it("advanceTimers: false does not auto-advance timers", async () => {
+    jest.useFakeTimers({ advanceTimers: false });
+
+    let timerFired = false;
+    setTimeout(() => {
+      timerFired = true;
+    }, 10);
+
+    // Run setImmediate a few times to ensure no auto-advance happens
+    for (let i = 0; i < 10; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+
+    expect(timerFired).toBe(false);
+
+    // Now manually advance to verify the timer works
+    jest.advanceTimersByTime(10);
+    expect(timerFired).toBe(true);
+  });
+
+  it("without advanceTimers option, timers do not auto-advance (default behavior)", async () => {
+    jest.useFakeTimers();
+
+    let timerFired = false;
+    setTimeout(() => {
+      timerFired = true;
+    }, 10);
+
+    // Run setImmediate a few times to ensure no auto-advance happens
+    for (let i = 0; i < 10; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+
+    expect(timerFired).toBe(false);
+
+    // Now manually advance to verify the timer works
+    jest.advanceTimersByTime(10);
+    expect(timerFired).toBe(true);
+  });
+
+  it("useRealTimers stops auto-advancing", async () => {
+    jest.useFakeTimers({ advanceTimers: true });
+
+    let count = 0;
+    const intervalId = setInterval(() => {
+      count++;
+    }, 10);
+
+    // Let some timers fire via auto-advance
+    for (let i = 0; i < 50 && count === 0; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    const countAfterAutoAdvance = count;
+    expect(countAfterAutoAdvance).toBeGreaterThan(0);
+
+    // Clear the interval before switching timers
+    clearInterval(intervalId);
+
+    // Switch to real timers - should stop auto-advancing
+    jest.useRealTimers();
+
+    // Re-enable fake timers without auto-advance
+    jest.useFakeTimers();
+
+    let newTimer = false;
+    setTimeout(() => {
+      newTimer = true;
+    }, 10);
+
+    // Run setImmediate - without advanceTimers, the timer should NOT fire
+    for (let i = 0; i < 10; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+
+    // New timer should NOT have fired because we didn't enable advanceTimers
+    expect(newTimer).toBe(false);
+  });
+
+  it("advanceTimers works with setInterval", async () => {
+    jest.useFakeTimers({ advanceTimers: 5 });
+
+    const values: number[] = [];
+    setInterval(() => values.push(values.length + 1), 10);
+
+    // Wait for multiple interval fires
+    for (let i = 0; i < 100 && values.length < 4; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+
+    // Should have fired multiple times
+    expect(values.length).toBeGreaterThan(3);
+  });
+
+  it("advanceTimers combined with now option", async () => {
+    const startTime = 1000000;
+    jest.useFakeTimers({ now: startTime, advanceTimers: 10 });
+
+    expect(Date.now()).toBe(startTime);
+
+    // Let time advance via auto-advance
+    for (let i = 0; i < 50; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+
+    // Time should have advanced
+    expect(Date.now()).toBeGreaterThan(startTime);
+  });
+
+  it("timers work correctly after useRealTimers is called during auto-advance", async () => {
+    // This tests the race condition where useRealTimers() is called during
+    // the auto-advance timer's execution (while it's firing fake timers).
+    jest.useFakeTimers({ advanceTimers: 20 });
+
+    // Wait using the auto-advance feature
+    await new Promise(resolve => setTimeout(resolve, 30));
+
+    // Switch back to real timers
+    jest.useRealTimers();
+
+    // Now a new setTimeout should work correctly with real time
+    let timerFired = false;
+    setTimeout(() => {
+      timerFired = true;
+    }, 10);
+
+    // Wait with real time
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(timerFired).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `advanceTimers` option to `jest.useFakeTimers()` for automatic timer advancement
- `advanceTimers: true` advances fake time by 20ms every 20ms of real time (matching Jest's default behavior)
- `advanceTimers: <number>` advances fake time by that number of milliseconds
- Enables compatibility with @testing-library/user-event and similar libraries that wait for timers during interactions

## Implementation Details
Uses a real-time `EventLoopTimer` with a new `FakeTimersAutoAdvance` tag that:
- Runs on real time (not affected by fake timers)
- Periodically advances the fake clock and fires any ready fake timers
- Properly handles race conditions when `useRealTimers()` is called during timer callbacks

## Test plan
- [ ] New regression tests in `test/regression/issue/26037.test.ts` covering:
  - `advanceTimers: true` auto-advances timers
  - `advanceTimers: <number>` advances by specified amount
  - `advanceTimers: false` does not auto-advance
  - Default behavior (no advanceTimers option) remains unchanged
  - `useRealTimers()` properly stops auto-advancing
  - Works with `setInterval`
  - Works combined with `now` option
  - Handles race condition when `useRealTimers()` called during auto-advance
- [ ] Existing fake timer tests pass (`test/js/bun/test/fake-timers/fake-timers.test.ts`)

Fixes #26037

🤖 Generated with [Claude Code](https://claude.com/claude-code)