### PR TITLE
fix(worker_threads): receiveMessageOnPort handles falsy values

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -121,7 +121,7 @@ let workerData = _workerData;
 let threadId = _threadId;
 function receiveMessageOnPort(port: MessagePort) {
   let res = _receiveMessageOnPort(port);
-  if (!res) return undefined;
+  if (res === undefined) return undefined;
   return {
     message: res,
   };

--- a/test/regression/issue/26501.test.ts
+++ b/test/regression/issue/26501.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { MessageChannel, receiveMessageOnPort } from "node:worker_threads";
+
+test("receiveMessageOnPort handles falsy values correctly", () => {
+  const { port1, port2 } = new MessageChannel();
+
+  const values = [0, 1, false, true, "", "hello world", null];
+  for (const value of values) {
+    port1.postMessage(value);
+  }
+
+  const received: unknown[] = [];
+  for (let i = 0; i < values.length; i++) {
+    const result = receiveMessageOnPort(port2);
+    if (result !== undefined) {
+      received.push(result.message);
+    }
+  }
+
+  expect(received).toEqual(values);
+
+  // Extra call should return undefined (no more messages)
+  expect(receiveMessageOnPort(port2)).toBeUndefined();
+});


### PR DESCRIPTION
## Summary
- Fixed `receiveMessageOnPort` dropping messages with falsy values (`0`, `false`, `''`, `null`)
- Changed condition from `if (!res)` to `if (res === undefined)` to correctly distinguish "no message" from "falsy message"

## Test plan
- [x] Added regression test `test/regression/issue/26501.test.ts`
- [x] Verified test fails with system bun (`USE_SYSTEM_BUN=1`)
- [x] Verified test passes with debug build (`bun bd test`)

Fixes #26501

🤖 Generated with [Claude Code](https://claude.com/claude-code)