### PR TITLE
fix(timers): ensure all ready timers fire before setImmediate callbacks

### DIFF
--- a/test/regression/issue/26508.test.ts
+++ b/test/regression/issue/26508.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/26508
+// When multiple setTimeout timers are ready to fire at the same time, Bun should
+// execute all ready timer callbacks before any setImmediate callbacks that were
+// scheduled by those timer callbacks. This matches Node.js behavior.
+test("setImmediate scheduled by timer should run after all ready timers fire", async () => {
+  // Run multiple times to catch the intermittent nature of the bug
+  for (let i = 0; i < 20; i++) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          let immediateRan = false;
+          let t2Ran = false;
+
+          const t1 = setTimeout(() => {
+            setImmediate(() => {
+              immediateRan = true;
+              // Check after both timer and immediate have run
+              if (!t2Ran) {
+                console.log("FAIL: immediate ran before t2");
+                process.exit(1);
+              }
+            });
+          });
+
+          const t2 = setTimeout(() => {
+            t2Ran = true;
+            if (immediateRan) {
+              console.log("FAIL: immediate ran before second timeout");
+              process.exit(1);
+            }
+          });
+
+          // Force both timers to be scheduled at the same millisecond
+          // by setting them to have the same _idleStart value
+          t2._idleStart = t1._idleStart;
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+
+    if (exitCode !== 0) {
+      console.error(`Iteration ${i} failed:`);
+      console.error("stdout:", stdout);
+      console.error("stderr:", stderr);
+    }
+    expect(exitCode).toBe(0);
+  }
+}, 60000); // 60 second timeout for spawning 20 subprocesses


### PR DESCRIPTION
## Summary
- Fixed an intermittent bug where `setImmediate` callbacks scheduled by a timer callback could run before other timer callbacks that were ready to fire at the same time
- The bug occurred because the timer readiness check used full nanosecond precision, while the timer heap ordering uses millisecond-truncated precision for JavaScript timers
- The fix aligns the timer readiness check with the heap ordering to ensure all timers scheduled for the same millisecond fire together

## Test plan
- Added regression test in `test/regression/issue/26508.test.ts`
- Verified with the original reproduction script that the bug no longer occurs
- `bun bd test test/regression/issue/26508.test.ts` passes

Fixes #26508

🤖 Generated with [Claude Code](https://claude.com/claude-code)