### PR TITLE
fix(napi): return napi_function for AsyncContextFrame in napi_typeof

### DIFF
--- a/src/bun.js/bindings/AsyncContextFrame.cpp
+++ b/src/bun.js/bindings/AsyncContextFrame.cpp
@@ -43,6 +43,11 @@ JSValue AsyncContextFrame::withAsyncContextIfNeeded(JSGlobalObject* globalObject
         return callback;
     }
 
+    // If already wrapped in an AsyncContextFrame, return as-is to avoid double-wrapping.
+    if (jsDynamicCast<AsyncContextFrame*>(callback)) {
+        return callback;
+    }
+
     // Construct a low-overhead wrapper
     auto& vm = JSC::getVM(globalObject);
     return AsyncContextFrame::create(

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -2427,6 +2427,11 @@ extern "C" napi_status napi_typeof(napi_env env, napi_value val,
                 return napi_clear_last_error(env);
             }
 
+            if (JSC::jsDynamicCast<AsyncContextFrame*>(value)) {
+                *result = napi_function;
+                return napi_clear_last_error(env);
+            }
+
             *result = napi_object;
             return napi_clear_last_error(env);
 

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -677,7 +677,7 @@ pub export fn napi_make_callback(env_: napi_env, _: *anyopaque, recv_: napi_valu
         return envIsNull();
     };
     const recv, const func = .{ recv_.get(), func_.get() };
-    if (func.isEmptyOrUndefinedOrNull() or !func.isCallable()) {
+    if (func.isEmptyOrUndefinedOrNull() or (!func.isCallable() and !func.isAsyncContextFrame())) {
         return env.setLastError(.function_expected);
     }
 
@@ -1762,7 +1762,7 @@ pub export fn napi_create_threadsafe_function(
     };
     const func = func_.get();
 
-    if (call_js_cb == null and (func.isEmptyOrUndefinedOrNull() or !func.isCallable())) {
+    if (call_js_cb == null and (func.isEmptyOrUndefinedOrNull() or (!func.isCallable() and !func.isAsyncContextFrame()))) {
         return env.setLastError(.function_expected);
     }
 


### PR DESCRIPTION
## Summary
- `napi_typeof` was returning `napi_object` for `AsyncContextFrame` values, which are internally callable JSObjects
- Native addons that check callback types (e.g. encore.dev's runtime) would fail with `expect Function, got: Object` and panic
- Added a `jsDynamicCast<AsyncContextFrame*>` check before the final `napi_object` fallback to correctly report these values as `napi_function`

Closes #25933

## Test plan
- [x] Verify encore.dev + supertokens reproduction from the issue no longer panics
- [ ] Existing napi tests continue to pass

Generated with [Claude Code](https://claude.com/claude-code)