### PR TITLE
fix(resolver): use POSIX separators for package names on Windows

### DIFF
--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -1761,7 +1761,8 @@ pub const ESModule = struct {
                             return Resolution{ .path = result, .status = .PackageResolve, .debug = .{ .token = target.first_token } };
                         } else {
                             const parts2 = [_]string{ str, subpath };
-                            const result = resolve_path.joinStringBuf(&resolve_target_buf2, parts2, .auto);
+                            // Use POSIX separators for package names (Node.js spec requirement)
+                            const result = resolve_path.joinStringBuf(&resolve_target_buf2, parts2, .posix);
                             if (r.debug_logs) |log| {
                                 log.addNoteFmt("Resolved \".{s}\" to \".{s}\"", .{ str, result });
                             }


### PR DESCRIPTION
### What does this PR do?
Fixes package name resolution in subpath imports on Windows by using POSIX path separators (`/`) instead of Windows separators (`\`).

#### Related issues
#26069 

### What is the issue?
On Windows, when resolving subpath imports that redirect to scoped packages (e.g., `#resolver` → `@myproject/resolver`), the resolver incorrectly uses backslashes (`\`) as path separators, converting `@myproject/resolver` to `@myproject\resolver`.
This causes:
- Package name not recognized
- `exports` field ignored
- Wrong module type resolved (CJS instead of ESM)

Package names must always use forward slashes per Node.js specification, regardless of platform.

### How did you verify your code works?
1. Clone [subpath import test project](https://github.com/craftingmod/bun-subpath-import-slash)
```bash
git clone https://github.com/craftingmod/bun-subpath-import-slash.git
cd bun-subpath-import-slash
bun install
```
2. Run test
```bash
bun run test:bun
```
3. Check output
```
 4 pass
 0 fail
 4 expect() calls
Ran 4 tests across 1 file. [218.00ms]
```


### Platform
- [x] Windows
- [ ] macOS
- [ ] Linux

This fix only affects Windows builds. Other platforms already use POSIX separators.
