### PR TITLE
chore: update mimalloc to latest dev3

### DIFF
--- a/cmake/targets/BuildMimalloc.cmake
+++ b/cmake/targets/BuildMimalloc.cmake
@@ -4,7 +4,7 @@ register_repository(
   REPOSITORY
     oven-sh/mimalloc
   COMMIT
-    989115cefb6915baa13788cb8252d83aac5330ad
+    ffa38ab8ac914f9eb7af75c1f8ad457643dc14f2
 )
 
 set(MIMALLOC_CMAKE_ARGS


### PR DESCRIPTION
## Summary
- Updates oven-sh/mimalloc bun-dev3 branch to latest upstream microsoft/mimalloc dev3 (ffa38ab8)
- Merged 12 new commits from upstream

### Key upstream changes included:
- fix re-initialization of threads on macOS
- add lock for sub-pagemap allocations
- fix peak commit stat
- fix use of continue in bitmap find_and_clear (fixes rare case of not finding space while it exists)

## Test plan
- [ ] CI passes
- [ ] Memory allocation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)