### PR TITLE
fix(bunfig): handle config files with no extension

### DIFF
--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -1204,7 +1204,7 @@ pub const Bunfig = struct {
     pub fn parse(allocator: std.mem.Allocator, source: *const logger.Source, ctx: Command.Context, comptime cmd: Command.Tag) !void {
         const log_count = ctx.log.errors + ctx.log.warnings;
 
-        const expr = if (strings.eqlComptime(source.path.name.ext[1..], "toml")) TOML.parse(source, ctx.log, allocator, true) catch |err| {
+        const expr = if (strings.eqlComptime(source.path.name.extWithoutLeadingDot(), "toml")) TOML.parse(source, ctx.log, allocator, true) catch |err| {
             if (ctx.log.errors + ctx.log.warnings == log_count) {
                 try ctx.log.addErrorOpts("Failed to parse", .{
                     .source = source,

--- a/test/regression/issue/26530.test.ts
+++ b/test/regression/issue/26530.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/26530
+// Bun should not panic when given a config file path with no extension
+test("config file with no extension should not crash", async () => {
+  using dir = tempDir("issue-26530", {
+    "index.js": `console.log("ok")`,
+    // Create a config file with no extension
+    "myconfig": `{ "install": { "registry": "https://registry.npmjs.org" } }`,
+  });
+
+  // Using a config file with no extension should not cause a panic
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "--config=myconfig", "index.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Verify the script ran successfully and produced expected output
+  expect(stdout).toContain("ok");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fix panic when config file path has no extension (e.g., Windows device files like `NUL`, `CON`, `PRN`)
- Use `extWithoutLeadingDot()` instead of unsafe `ext[1..]` slice that panics on empty strings

## Test plan
- [x] Added regression test in `test/regression/issue/26530.test.ts`
- [x] Verified test passes with debug build

Fixes #26530

🤖 Generated with [Claude Code](https://claude.com/claude-code)