### PR TITLE
fix(diagnostics_channel): retain channels with active subscribers

### DIFF
--- a/test/regression/issue/26536.test.ts
+++ b/test/regression/issue/26536.test.ts
@@ -1,0 +1,125 @@
+// Test for https://github.com/oven-sh/bun/issues/26536
+// diagnostics_channel subscribers should persist across preload and app scripts
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("diagnostics_channel subscribers persist from preload to main script", async () => {
+  // Create temp directory with test files
+  using dir = tempDir("issue-26536", {
+    "preload.mjs": `
+import dc from 'node:diagnostics_channel';
+
+const channel = dc.channel('test.channel.26536');
+channel.subscribe((msg) => {
+  console.log("HOOK CALLED:", JSON.stringify(msg));
+});
+console.log("[preload] hasSubscribers:", channel.hasSubscribers);
+`,
+    "app.mjs": `
+import dc from 'node:diagnostics_channel';
+
+const channel = dc.channel('test.channel.26536');
+console.log("[app] hasSubscribers:", channel.hasSubscribers);
+
+// Publish a message - should trigger the subscriber from preload
+channel.publish({ test: true });
+`,
+  });
+
+  // Run with preload
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--preload", "./preload.mjs", "./app.mjs"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toContain("[preload] hasSubscribers: true");
+  expect(stdout).toContain("[app] hasSubscribers: true");
+  expect(stdout).toContain('HOOK CALLED: {"test":true}');
+  expect(exitCode).toBe(0);
+});
+
+test("diagnostics_channel subscribers persist with CJS preload", async () => {
+  // Create temp directory with test files
+  using dir = tempDir("issue-26536-cjs", {
+    "preload.cjs": `
+const dc = require('node:diagnostics_channel');
+
+const channel = dc.channel('test.channel.26536.cjs');
+channel.subscribe((msg) => {
+  console.log("HOOK CALLED:", JSON.stringify(msg));
+});
+console.log("[preload] hasSubscribers:", channel.hasSubscribers);
+`,
+    "app.mjs": `
+import dc from 'node:diagnostics_channel';
+
+const channel = dc.channel('test.channel.26536.cjs');
+console.log("[app] hasSubscribers:", channel.hasSubscribers);
+
+// Publish a message - should trigger the subscriber from preload
+channel.publish({ fromApp: "hello" });
+`,
+  });
+
+  // Run with CJS preload
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--preload", "./preload.cjs", "./app.mjs"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toContain("[preload] hasSubscribers: true");
+  expect(stdout).toContain("[app] hasSubscribers: true");
+  expect(stdout).toContain('HOOK CALLED: {"fromApp":"hello"}');
+  expect(exitCode).toBe(0);
+});
+
+test("diagnostics_channel channel() returns same instance", async () => {
+  // Create temp directory with test files
+  using dir = tempDir("issue-26536-same-instance", {
+    "preload.mjs": `
+import dc from 'node:diagnostics_channel';
+
+const channel = dc.channel('test.channel.26536.same');
+channel.subscribe(() => {});
+
+// Store reference on globalThis
+globalThis.__testChannel = channel;
+console.log("[preload] stored channel");
+`,
+    "app.mjs": `
+import dc from 'node:diagnostics_channel';
+
+const channel = dc.channel('test.channel.26536.same');
+console.log("[app] same channel:", channel === globalThis.__testChannel);
+`,
+  });
+
+  // Run with preload
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--preload", "./preload.mjs", "./app.mjs"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toContain("[preload] stored channel");
+  expect(stdout).toContain("[app] same channel: true");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fixed `node:diagnostics_channel` channels being garbage collected even when they have active subscribers
- This was causing OpenTelemetry instrumentation to fail for frameworks like Fastify and Express when subscribers were registered in preload scripts

## Root Cause

The `WeakReference` class in `diagnostics_channel.ts` extended `WeakRef` but only tracked a reference count without actually preventing garbage collection. When channels had active subscribers, they could still be GC'd because there was no strong reference keeping them alive.

## Fix

Aligned the `WeakReference` implementation with Node.js by maintaining a strong reference when `refCount > 0`:
- When `incRef()` is called and refCount transitions from 0 to 1, store a strong reference
- When `decRef()` returns refCount to 0, clear the strong reference to allow GC

This matches the behavior in [Node.js's internal util.js](https://github.com/nodejs/node/blob/fb47afc335ef78a8cef7eac52b8ee7f045300696/lib/internal/util.js#L888-L919).

## Test plan

- [x] Added regression test that verifies subscribers persist from preload to main script
- [x] Test covers both ESM and CJS preload scripts
- [x] Existing `diagnostics_channel.test.ts` tests pass
- [x] Verified test fails with system Bun (v1.3.7) and passes with debug build

Fixes #26536

🤖 Generated with [Claude Code](https://claude.ai/code)