### PR TITLE
fix(spawn): prevent use-after-free in subprocess stdin cleanup

### DIFF
--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -591,7 +591,7 @@ pub fn onProcessExit(this: *Subprocess, process: *Process, status: bun.spawn.Sta
     if (this_jsvalue != .zero) {
         if (jsc.Codegen.JSSubprocess.stdinGetCached(this_jsvalue)) |existing_value| {
             if (existing_value.isCell()) {
-                if (stdin == null) {
+                if (stdin == null and !this.flags.has_stdin_destructor_called) {
                     // TODO: review this cast
                     stdin = @ptrCast(@alignCast(jsc.WebCore.FileSink.JSSink.fromJS(existing_value)));
                 }


### PR DESCRIPTION
When `onProcessExit` runs after the JSSink destructor has already freed the FileSink, the `fromJS` recovery path would read stale `m_sinkPtr` from the dead JSSink, accessing freed/reallocated memory. This could close file descriptors belonging to other subprocesses, corrupting their pipe communication.

Guard the `fromJS` recovery with `has_stdin_destructor_called` to skip it when we know the FileSink has already been freed.