### PR TITLE
fix(test): make mock.restore() restore modules mocked with mock.module()

### DIFF
--- a/src/bun.js/bindings/BunPlugin.h
+++ b/src/bun.js/bindings/BunPlugin.h
@@ -76,6 +76,7 @@ public:
         bool hasVirtualModules() const { return virtualModules != nullptr; }
 
         void addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mock);
+        void restoreModuleMocks(JSC::JSGlobalObject* globalObject);
 
         std::optional<String> resolveVirtualModule(const String& path, const String& from);
 

--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -1461,7 +1461,9 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSetSystemTime, (JSC::JSGlobalObject * globalO
 
 BUN_DEFINE_HOST_FUNCTION(JSMock__jsRestoreAllMocks, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
-    JSMock__resetSpies(jsCast<Zig::GlobalObject*>(globalObject));
+    auto* zigGlobalObject = jsCast<Zig::GlobalObject*>(globalObject);
+    JSMock__resetSpies(zigGlobalObject);
+    zigGlobalObject->onLoadPlugins.restoreModuleMocks(globalObject);
     return JSValue::encode(jsUndefined());
 }
 

--- a/test/js/bun/test/mock/mock-module-restore.test.ts
+++ b/test/js/bun/test/mock/mock-module-restore.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, mock, spyOn, test } from "bun:test";
+import { fn, variable } from "./mock-module-fixture";
+import * as spyFixture from "./spymodule-fixture";
+
+describe("mock.module restore", () => {
+  test("mock.restore() restores ESM module exports to original values", () => {
+    expect(fn()).toBe(42);
+    expect(variable).toBe(7);
+
+    mock.module("./mock-module-fixture", () => ({
+      fn: () => 999,
+      variable: 100,
+    }));
+
+    expect(fn()).toBe(999);
+    expect(variable).toBe(100);
+
+    mock.restore();
+
+    expect(fn()).toBe(42);
+    expect(variable).toBe(7);
+  });
+
+  test("re-mocking after restore works", () => {
+    expect(fn()).toBe(42);
+    expect(variable).toBe(7);
+
+    mock.module("./mock-module-fixture", () => ({
+      fn: () => 555,
+      variable: 55,
+    }));
+
+    expect(fn()).toBe(555);
+    expect(variable).toBe(55);
+
+    mock.restore();
+
+    expect(fn()).toBe(42);
+    expect(variable).toBe(7);
+  });
+
+  test("multiple re-mocks then restore goes back to true originals", () => {
+    expect(fn()).toBe(42);
+    expect(variable).toBe(7);
+
+    mock.module("./mock-module-fixture", () => ({
+      fn: () => 1,
+      variable: 1,
+    }));
+    expect(fn()).toBe(1);
+
+    mock.module("./mock-module-fixture", () => ({
+      fn: () => 2,
+      variable: 2,
+    }));
+    expect(fn()).toBe(2);
+
+    mock.module("./mock-module-fixture", () => ({
+      fn: () => 3,
+      variable: 3,
+    }));
+    expect(fn()).toBe(3);
+
+    mock.restore();
+
+    expect(fn()).toBe(42);
+    expect(variable).toBe(7);
+  });
+
+  test("mock.restore() also restores spyOn alongside mock.module", () => {
+    const originalSpy = spyFixture.iSpy;
+
+    spyOn(spyFixture, "iSpy");
+    expect(spyFixture.iSpy).not.toBe(originalSpy);
+
+    mock.module("./mock-module-fixture", () => ({
+      fn: () => 777,
+    }));
+    expect(fn()).toBe(777);
+
+    mock.restore();
+
+    expect(spyFixture.iSpy).toBe(originalSpy);
+    expect(fn()).toBe(42);
+  });
+
+  test("mock.restore() restores builtin modules", async () => {
+    const origReadFile = (await import("node:fs/promises")).readFile;
+
+    mock.module("fs/promises", () => ({
+      readFile: () => Promise.resolve("mocked-content"),
+    }));
+
+    const { readFile } = await import("node:fs/promises");
+    expect(await readFile("anything")).toBe("mocked-content");
+
+    mock.restore();
+
+    const { readFile: restored } = await import("node:fs/promises");
+    expect(restored).toBe(origReadFile);
+  });
+});


### PR DESCRIPTION
## Summary

`mock.restore()` now correctly restores modules mocked with `mock.module()`, fixing a long-standing issue where `mock.restore()` only reset function spies (`spyOn`) but had no effect on module mocks.

## Problem

`mock.restore()` called `JSMock__resetSpies()` which only handled `spyOn` function spies. It never touched the `virtualModules` map or reversed `overrideExportValue` patches on ESM namespace objects. This meant module mocks persisted across tests even after calling `mock.restore()`.

## Solution

Added snapshot/restore logic to `JSModuleMock`:

- **Snapshot**: Before patching ESM exports via `overrideExportValue`, save original values into a plain JSObject stored as a `WriteBarrier` on the existing GC-managed `JSModuleMock` (same pattern as `spyOn`'s `spyOriginal`)
- **Restore**: On `mock.restore()`, iterate `virtualModules`, restore original export values via `overrideExportValue`, and clear mock entries
- **Re-mock safety**: Preserve true originals across re-mocks of the same specifier so restore always goes back to the real module

### Key discovery

`JSModuleNamespaceObject::getOwnPropertyNames()` returns 0 exports for Bun's synthetic namespace objects because `m_names` is empty. The fix uses the mock result object's property names to determine which exports to snapshot from the namespace.

## Changes

- `src/bun.js/bindings/BunPlugin.cpp` — Added `WriteBarrier` fields to `JSModuleMock`, snapshot logic before ESM/CJS patching, `restoreModuleMocks()` method
- `src/bun.js/bindings/BunPlugin.h` — Added `restoreModuleMocks` declaration
- `src/bun.js/bindings/JSMockFunction.cpp` — Wired `restoreModuleMocks` into `JSMock__jsRestoreAllMocks`
- `test/js/bun/test/mock/mock-module-restore.test.ts` — New tests

## Tests

5 new tests covering:
1. Basic ESM restore (mock → restore → originals)
2. Re-mocking after restore
3. Multiple re-mocks then restore (preserves true originals)
4. Combined `spyOn` + `mock.module` restore
5. Builtin module restore (`fs/promises`)

All existing mock-module tests continue to pass (9 pass, 1 todo, 0 fail).

Closes #7823