### PR TITLE
fix: add ENABLE_BASELINE support for ARM64 to fix crash on older CPUs

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -24,9 +24,19 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm|ARM|arm64|ARM64|aarch64|AARCH64")
   elseif(WIN32)
     # Windows ARM64: use /clang: prefix for clang-cl, skip for MSVC cl.exe subprojects
     # These flags are only understood by clang-cl, not MSVC cl.exe
-    register_compiler_flags(/clang:-march=armv8-a+crc /clang:-mtune=ampere1)
+    if(ENABLE_BASELINE)
+      # Baseline: ARMv8.0-A compatible, use outline atomics for LSE compatibility
+      register_compiler_flags(/clang:-march=armv8-a+crc /clang:-moutline-atomics)
+    else()
+      register_compiler_flags(/clang:-march=armv8-a+crc /clang:-mtune=ampere1)
+    endif()
   else()
-    register_compiler_flags(-march=armv8-a+crc -mtune=ampere1)
+    if(ENABLE_BASELINE)
+      # Baseline: ARMv8.0-A compatible, use outline atomics for LSE compatibility
+      register_compiler_flags(-march=armv8-a+crc -moutline-atomics)
+    else()
+      register_compiler_flags(-march=armv8-a+crc -mtune=ampere1)
+    endif()
   endif()
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|X86_64|x64|X64|amd64|AMD64")
   if(ENABLE_BASELINE)

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -99,6 +99,8 @@ endif()
 
 if(ARCH STREQUAL "x64")
   optionx(ENABLE_BASELINE BOOL "If baseline features should be used for older CPUs (e.g. disables AVX, AVX2)" DEFAULT OFF)
+elseif(ARCH STREQUAL "aarch64")
+  optionx(ENABLE_BASELINE BOOL "If baseline features should be used for older ARM64 CPUs (e.g. ARMv8.0-A without LSE)" DEFAULT OFF)
 endif()
 
 # Disabling logs by default for tests yields faster builds

--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -84,6 +84,10 @@ if(LINUX AND ABI STREQUAL "musl")
   set(WEBKIT_SUFFIX "-musl")
 endif()
 
+if(ENABLE_BASELINE)
+  set(WEBKIT_SUFFIX "${WEBKIT_SUFFIX}-baseline")
+endif()
+
 if(DEBUG)
   set(WEBKIT_SUFFIX "${WEBKIT_SUFFIX}-debug")
 elseif(ENABLE_LTO)


### PR DESCRIPTION
## Summary

- Adds `ENABLE_BASELINE` option for ARM64 architecture (similar to existing x64 baseline support)
- Uses `-moutline-atomics` flag for ARM64 baseline builds to generate runtime-detected atomic implementations
- Adds `-baseline` suffix for ARM64 WebKit downloads

Fixes #26556

## Problem

Bun 1.3.7 crashes with "Illegal instruction" on older ARM64 CPUs (ARMv8.0-A without LSE support) such as:
- Cortex-A53 (Raspberry Pi 3/4, Amlogic S905X)
- Exynos 9611
- AWS a1 instances

The crash occurs because WebKit's `pas_lock.h` uses GCC atomic builtins that compile to inline LSE instructions (casa, ldaddl, swpa) when built on ARMv8.1+ CI runners. These instructions don't exist on ARMv8.0-A CPUs.

## Solution

The `-moutline-atomics` flag generates code that performs runtime CPU feature detection and uses the appropriate atomic implementation (LSE on newer CPUs, LL/SC on older CPUs).

**Note:** This fix requires building and publishing baseline ARM64 WebKit builds with `-moutline-atomics` for the full fix to work. The Bun build system changes here enable downloading those baseline builds once available.

## Test plan

- [x] Code compiles successfully (CMake configuration tested)
- [ ] Once baseline ARM64 WebKit is published: Test on Raspberry Pi 4 or AWS a1 instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)