### PR TITLE
fix(shell): don't set UV_PROCESS_WINDOWS_HIDE for shell spawns

### DIFF
--- a/src/shell/subproc.zig
+++ b/src/shell/subproc.zig
@@ -810,7 +810,7 @@ pub const ShellSubprocess = struct {
             },
 
             .windows = if (Environment.isWindows) bun.spawn.WindowsSpawnOptions.WindowsOptions{
-                .hide_window = true,
+                .hide_window = false,
                 .loop = event_loop,
             },
         };


### PR DESCRIPTION
## Summary

- Fixes Windows conhost console fonts changing to raster fonts when using shell `$` to spawn PowerShell

## What was the problem?

When using the shell `$` function to spawn processes on Windows in conhost, the console fonts were being changed to raster fonts after execution. This was caused by always setting `hide_window = true` for shell spawns, which translates to the `UV_PROCESS_WINDOWS_HIDE` flag.

This flag affects how Windows creates child process windows, and when interactive programs like PowerShell exit, the conhost console resets its display properties including fonts to defaults (raster fonts).

**Note**: `Bun.spawn()` doesn't have this issue because it defaults `windowsHide` to `false`.

## The fix

Changed `hide_window` from `true` to `false` for shell spawns in `src/shell/subproc.zig`, matching the default behavior of `Bun.spawn()`.

## Test plan

- [x] Build passes
- [ ] Manual verification on Windows with cmd in conhost running PowerShell via `$\`powershell\``

Fixes #26558

🤖 Generated with [Claude Code](https://claude.com/claude-code)