### PR TITLE
fix(types): add optional seed parameter to Bun.hash.crc32

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2154,7 +2154,7 @@ declare module "bun" {
   interface Hash {
     wyhash: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: bigint) => bigint;
     adler32: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer) => number;
-    crc32: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer) => number;
+    crc32: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: number) => number;
     cityHash32: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer) => number;
     cityHash64: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: bigint) => bigint;
     xxHash32: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: number) => number;

--- a/test/integration/bun-types/fixture/hashing.ts
+++ b/test/integration/bun-types/fixture/hashing.ts
@@ -1,1 +1,7 @@
 Bun.hash.wyhash("asdf", 1234n);
+
+// crc32 with optional seed parameter for incremental hashing
+let crc = 0;
+crc = Bun.hash.crc32(new Uint8Array([1, 2, 3]), crc);
+crc = Bun.hash.crc32(new Uint8Array([4, 5, 6]), crc);
+Bun.hash.crc32("test string", 12345);


### PR DESCRIPTION
## Summary
Adds the missing optional `seed` parameter to the TypeScript type definition for `Bun.hash.crc32`.

Fixes #26043

## Problem
`Bun.hash.crc32` supports an optional second `seed` parameter at runtime for incremental CRC32 computation, but the TypeScript types didn't include it:

```ts
let crc = 0;
crc = Bun.hash.crc32(new Uint8Array([1, 2, 3]), crc); // TS Error: Expected 1 arguments, but got 2
```

## Solution
Updated the type signature in `packages/bun-types/bun.d.ts`:
```ts
crc32: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: number) => number;
```

This matches the pattern used by other hash functions like `xxHash32` and `murmur32v3`.

## Test plan
- [x] Added type-checking test in `test/integration/bun-types/fixture/hashing.ts`

🤖 Generated with [Claude Code](https://claude.ai/code)