### PR TITLE
fix: change 'banner' heading to code format

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -623,7 +623,6 @@ Inlines environment variables matching the given prefix (the part before the `*`
     await Bun.build({
       entrypoints: ['./index.tsx'],
       outdir: './out',
-
       // Inline all env vars that start with "ACME_PUBLIC_"
       env: "ACME_PUBLIC_*",
     })

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -623,7 +623,7 @@ Inlines environment variables matching the given prefix (the part before the `*`
     await Bun.build({
       entrypoints: ['./index.tsx'],
       outdir: './out',
-      
+
       // Inline all env vars that start with "ACME_PUBLIC_"
       env: "ACME_PUBLIC_*",
     })
@@ -1150,7 +1150,7 @@ A map of file extensions to built-in loader names. This can be used to quickly c
   </Tab>
 </Tabs>
 
-### banner
+### `banner`
 
 A banner to be added to the final bundle, this can be a directive like `"use client"` for react or a comment block such as a license for the code.
 


### PR DESCRIPTION
### What does this PR do?

Updated header formatting for 'banner' section. 'banner' is a reserved word in mintlify, so the header does not render without this fix. See https://www.mintlify.com/docs/components/banner

Fixes #26062 

### How did you verify your code works?

Tested with `npx mint dev`.
