### PR TITLE
fix: sort fs.readdir entries

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -1193,7 +1193,7 @@ pub const AsyncReaddirRecursiveTask = struct {
         // Sort the final result list to match Node.js behavior
         switch (this.args.tag()) {
             inline else => |tag| {
-                sortReaddirEntries(@TypeOf(@field(this.result_list, @tagName(tag)).items[0]), @field(this.result_list, @tagName(tag)).items);
+                NodeFS.sortReaddirEntries(@TypeOf(@field(this.result_list, @tagName(tag)).items[0]), @field(this.result_list, @tagName(tag)).items);
             },
         }
 
@@ -4448,7 +4448,7 @@ pub const NodeFS = struct {
         };
     }
 
-    fn sortReaddirEntries(comptime ExpectedType: type, entries: []ExpectedType) void {
+    pub fn sortReaddirEntries(comptime ExpectedType: type, entries: []ExpectedType) void {
         std.mem.sort(ExpectedType, entries, {}, struct {
             fn lessThan(_: void, a: ExpectedType, b: ExpectedType) bool {
                 const a_slice = switch (ExpectedType) {

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -1193,7 +1193,10 @@ pub const AsyncReaddirRecursiveTask = struct {
         // Sort the final result list to match Node.js behavior
         switch (this.args.tag()) {
             inline else => |tag| {
-                NodeFS.sortReaddirEntries(@TypeOf(@field(this.result_list, @tagName(tag)).items[0]), @field(this.result_list, @tagName(tag)).items);
+                var results = &@field(this.result_list, @tagName(tag));
+                if (results.items.len > 0) {
+                    NodeFS.sortReaddirEntries(@TypeOf(results.items[0]), results.items);
+                }
             },
         }
 
@@ -3481,8 +3484,6 @@ pub const NodeFS = struct {
                 }
             }
         }
-
-        sortReaddirEntries(ExpectedType, entries.items);
         return .success;
     }
 

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -3482,6 +3482,7 @@ pub const NodeFS = struct {
             }
         }
 
+        sortReaddirEntries(ExpectedType, entries.items);
         return .success;
     }
 

--- a/test/js/node/fs/readdir-sorted.test.ts
+++ b/test/js/node/fs/readdir-sorted.test.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import fs from "node:fs";
+import path from "node:path";
+
+test("fs.readdir returns sorted entries", async () => {
+  using dir = tempDir("readdir-sorted", {
+    "a": "",
+    "b": "",
+    "c": "",
+    "0": "",
+    "1": "",
+    "2": "",
+  });
+
+  const entries = fs.readdirSync(String(dir));
+  expect(entries).toEqual(["0", "1", "2", "a", "b", "c"]);
+});
+
+test("fs.readdir async returns sorted entries", async () => {
+  using dir = tempDir("readdir-sorted-async", {
+    "a": "",
+    "b": "",
+    "c": "",
+    "0": "",
+    "1": "",
+    "2": "",
+  });
+
+  const entries = await fs.promises.readdir(String(dir));
+  expect(entries).toEqual(["0", "1", "2", "a", "b", "c"]);
+});
+
+test("fs.readdir with buffer encoding returns sorted entries", async () => {
+  using dir = tempDir("readdir-sorted-buffer", {
+    "a": "",
+    "b": "",
+    "c": "",
+    "0": "",
+    "1": "",
+    "2": "",
+  });
+
+  const entries = fs.readdirSync(String(dir), { encoding: "buffer" });
+  const names = entries.map(buf => buf.toString());
+  expect(names).toEqual(["0", "1", "2", "a", "b", "c"]);
+});
+
+test("fs.readdir with withFileTypes returns sorted entries", async () => {
+  using dir = tempDir("readdir-sorted-dirent", {
+    "a": "",
+    "b": "",
+    "c": "",
+    "0": "",
+    "1": "",
+    "2": "",
+  });
+
+  const entries = fs.readdirSync(String(dir), { withFileTypes: true });
+  const names = entries.map(dirent => dirent.name);
+  expect(names).toEqual(["0", "1", "2", "a", "b", "c"]);
+});
+
+test("fs.readdir recursive returns sorted entries", async () => {
+  using dir = tempDir("readdir-sorted-recursive", {
+    "a": "",
+    "b": "",
+    "c": "",
+    "subdir/d": "",
+    "subdir/e": "",
+    "subdir/0": "",
+  });
+
+  const entries = fs.readdirSync(String(dir), { recursive: true });
+  // Sort expectations for recursive: all entries should be sorted
+  expect(entries.sort()).toEqual(entries);
+});
+
+test("fs.readdir with mixed case returns sorted entries", async () => {
+  using dir = tempDir("readdir-sorted-mixed", {
+    "Apple": "",
+    "banana": "",
+    "Cherry": "",
+    "1file": "",
+    "2file": "",
+  });
+
+  const entries = fs.readdirSync(String(dir));
+  // Sort should be case-sensitive lexicographic
+  expect(entries).toEqual(["1file", "2file", "Apple", "Cherry", "banana"]);
+});

--- a/test/js/node/fs/readdir-sorted.test.ts
+++ b/test/js/node/fs/readdir-sorted.test.ts
@@ -1,7 +1,6 @@
-import { test, expect } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
 import fs from "node:fs";
-import path from "node:path";
 
 test("fs.readdir returns sorted entries", async () => {
   using dir = tempDir("readdir-sorted", {

--- a/test/js/node/fs/readdir-sorted.test.ts
+++ b/test/js/node/fs/readdir-sorted.test.ts
@@ -73,7 +73,8 @@ test("fs.readdir recursive returns sorted entries", async () => {
 
   const entries = fs.readdirSync(String(dir), { recursive: true });
   // Sort expectations for recursive: all entries should be sorted
-  expect(entries.sort()).toEqual(entries);
+  const sortedEntries = entries.slice().sort();
+  expect(entries).toEqual(sortedEntries);
 });
 
 test("fs.readdir with mixed case returns sorted entries", async () => {

--- a/test/regression/issue/25734.test.ts
+++ b/test/regression/issue/25734.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { tempDir } from "harness";
 import fs from "node:fs";
 
-test("fs.readdir returns sorted entries", async () => {
+test("fs.readdir returns sorted entries", () => {
   using dir = tempDir("readdir-sorted", {
     "a": "",
     "b": "",
@@ -30,7 +30,7 @@ test("fs.readdir async returns sorted entries", async () => {
   expect(entries).toEqual(["0", "1", "2", "a", "b", "c"]);
 });
 
-test("fs.readdir with buffer encoding returns sorted entries", async () => {
+test("fs.readdir with buffer encoding returns sorted entries", () => {
   using dir = tempDir("readdir-sorted-buffer", {
     "a": "",
     "b": "",
@@ -45,7 +45,7 @@ test("fs.readdir with buffer encoding returns sorted entries", async () => {
   expect(names).toEqual(["0", "1", "2", "a", "b", "c"]);
 });
 
-test("fs.readdir with withFileTypes returns sorted entries", async () => {
+test("fs.readdir with withFileTypes returns sorted entries", () => {
   using dir = tempDir("readdir-sorted-dirent", {
     "a": "",
     "b": "",
@@ -60,7 +60,7 @@ test("fs.readdir with withFileTypes returns sorted entries", async () => {
   expect(names).toEqual(["0", "1", "2", "a", "b", "c"]);
 });
 
-test("fs.readdir recursive returns sorted entries", async () => {
+test("fs.readdir recursive returns sorted entries", () => {
   using dir = tempDir("readdir-sorted-recursive", {
     "a": "",
     "b": "",
@@ -76,7 +76,7 @@ test("fs.readdir recursive returns sorted entries", async () => {
   expect(entries).toEqual(sortedEntries);
 });
 
-test("fs.readdir with mixed case returns sorted entries", async () => {
+test("fs.readdir with mixed case returns sorted entries", () => {
   using dir = tempDir("readdir-sorted-mixed", {
     "Apple": "",
     "banana": "",


### PR DESCRIPTION
### What does this PR do?

Sorts the output of fs.readdir

Fixes  #25734 

### How did you verify your code works?

Added a test
