### PR TITLE
fix(windows): handle null handle.data in libuv callbacks

### DIFF
--- a/src/bun.js/node/win_watcher.zig
+++ b/src/bun.js/node/win_watcher.zig
@@ -217,8 +217,9 @@ pub const PathWatcher = struct {
 
     fn uvClosedCallback(handler: *anyopaque) callconv(.c) void {
         log("onClose", .{});
-        const event = bun.cast(*uv.uv_fs_event_t, handler);
-        const this = bun.cast(*PathWatcher, event.data);
+        const event: *uv.uv_fs_event_t = @ptrCast(@alignCast(handler));
+        // event.data may be null if the handle was already cleaned up or there was a race condition
+        const this: *PathWatcher = @ptrCast(@alignCast(event.data orelse return));
         bun.destroy(this);
     }
 

--- a/src/io/PipeWriter.zig
+++ b/src/io/PipeWriter.zig
@@ -804,12 +804,16 @@ fn BaseWindowsPipeWriter(
         }
 
         fn onPipeClose(handle: *uv.Pipe) callconv(.c) void {
-            const this = bun.cast(*uv.Pipe, handle.data);
+            // handle.data was set to point to the pipe itself before close was called
+            // If null, the handle was already cleaned up or there was a race condition
+            const this: *uv.Pipe = @ptrCast(@alignCast(handle.data orelse return));
             bun.default_allocator.destroy(this);
         }
 
         fn onTTYClose(handle: *uv.uv_tty_t) callconv(.c) void {
-            const this = bun.cast(*uv.uv_tty_t, handle.data);
+            // handle.data was set to point to the tty itself before close was called
+            // If null, the handle was already cleaned up or there was a race condition
+            const this: *uv.uv_tty_t = @ptrCast(@alignCast(handle.data orelse return));
             bun.default_allocator.destroy(this);
         }
 


### PR DESCRIPTION
## Summary

- Add null checks to Windows libuv callbacks to prevent "cast causes pointer to be null" panics
- This is a recurring Windows-specific bug (#7942, #15149, #15104, #15849, #13826) where libuv callbacks may be invoked with null `handle.data` due to race conditions during handle cleanup or event loop processing

## Changes

The following callbacks now safely handle null `handle.data`:

**PipeReader.zig:**
- `onStreamAlloc` - returns empty buffer if null
- `onStreamRead` - returns early if null
- `onPipeClose` - returns early if null
- `onTTYClose` - returns early if null

**PipeWriter.zig:**
- `onPipeClose` - returns early if null
- `onTTYClose` - returns early if null

**win_watcher.zig:**
- `uvClosedCallback` - returns early if null

## Root Cause

When the pipe/handle is being closed, the code sets `pipe.data = pipe` (self-pointer) before calling close. Due to race conditions in Windows libuv event processing, callbacks can be invoked:
1. After the handle's data pointer has been nullified
2. After the handle has been deallocated
3. During the transition period when data no longer points to the expected object

The `bun.cast()` function triggers Zig's runtime safety check when casting a null pointer, causing a panic.

## Test plan

- [x] Build succeeds (`bun bd`)
- [x] Existing spawn tests pass on Linux
- [ ] Manual testing on Windows with standalone executables (requires Windows CI)

Fixes #26574

🤖 Generated with [Claude Code](https://claude.com/claude-code)