### PR TITLE
feat(node:process): implement process.initgroups

### DIFF
--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -602,17 +602,26 @@ describe.concurrent(() => {
       expect(process.getgroups()).toBeInstanceOf(Array);
       expect(process.getgroups().length).toBeGreaterThan(0);
     });
+    it("process.initgroups is a function", () => {
+      expect(typeof process.initgroups).toBe("function");
+    });
+    it("process.initgroups throws with invalid user type", () => {
+      expect(() => process.initgroups(123, 0)).toThrow();
+    });
+    it("process.initgroups throws with unknown user", () => {
+      expect(() => process.initgroups("nonexistent_user_12345", 0)).toThrow();
+    });
     it("process.getuid", () => {
       expect(typeof process.getuid()).toBe("number");
     });
   } else {
-    it("process.getegid, process.geteuid, process.getgid, process.getgroups, process.getuid, process.getuid are not implemented on Windows", () => {
+    it("POSIX-only process functions are not implemented on Windows", () => {
       expect(process.getegid).toBeUndefined();
       expect(process.geteuid).toBeUndefined();
       expect(process.getgid).toBeUndefined();
       expect(process.getgroups).toBeUndefined();
       expect(process.getuid).toBeUndefined();
-      expect(process.getuid).toBeUndefined();
+      expect(process.initgroups).toBeUndefined();
     });
   }
 


### PR DESCRIPTION
## Summary

Implements the `process.initgroups(user, extraGroup)` function for Node.js compatibility.

- Takes a username string as the first argument
- Takes an extra group (number or group name string) as the second argument
- Validates the user exists before calling `initgroups`
- Throws appropriate errors for invalid arguments:
  - `ERR_INVALID_ARG_TYPE` if user is not a string
  - `ERR_UNKNOWN_CREDENTIAL` if user doesn't exist
  - `ERR_UNKNOWN_CREDENTIAL` if group doesn't exist (when passed as string)
- Only available on non-Windows platforms (consistent with Node.js behavior)

Closes #23891

## Test Plan

- Added tests verifying:
  - `process.initgroups` is a function
  - Throws with invalid user type (number instead of string)
  - Throws with unknown user
  - Is undefined on Windows

## AI Disclosure

This PR was written primarily by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)