### PR TITLE
fix(worker_threads): receiveMessageOnPort now handles falsy message values

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -120,11 +120,11 @@ let resourceLimits = {};
 let workerData = _workerData;
 let threadId = _threadId;
 function receiveMessageOnPort(port: MessagePort) {
-  let res = _receiveMessageOnPort(port);
-  if (!res) return undefined;
-  return {
-    message: res,
-  };
+  // Native function now returns { message: value } when there IS a message,
+  // or undefined when the queue is empty.
+  // This correctly handles falsy message values like undefined, null, 0, false, "".
+  // https://github.com/oven-sh/bun/issues/26501
+  return _receiveMessageOnPort(port);
 }
 
 // TODO: parent port emulation is not complete


### PR DESCRIPTION
## Summary
- Fix for #26501 - `receiveMessageOnPort` unexpectedly drops messages with falsy values
- Previously, the JS wrapper checked `if (!res)` to detect "no message", which incorrectly treated falsy message values (undefined, null, 0, false, '') as empty queue
- The fix moves the wrapping logic to the native C++ code which uses `std::optional` to properly distinguish "no message" from "message with falsy value"

## Changes
- **MessagePort.cpp**: Native `tryTakeMessage` now returns `{ message: value }` when there IS a message
- **worker_threads.ts**: Simplified to just return the native result
- **worker_threads.test.ts**: Added test for falsy message values

## Test plan
- [x] Added test case that sends all falsy values (undefined, null, 0, false, '') plus truthy values
- [x] Test fails with system bun (confirming bug exists)
- [x] Test verifies all messages are received correctly

Before fix:
```
expected: [ undefined, null, 0, 1, false, true, "", "hello world" ]
actual: [ 1, true, "hello world" ]
```

After fix:
```
expected: [ undefined, null, 0, 1, false, true, "", "hello world" ]
actual: [ undefined, null, 0, 1, false, true, "", "hello world" ]
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)