### PR TITLE
fix(fetch): custom Host header no longer causes ConnectionRefused

### DIFF
--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -915,13 +915,6 @@ fn fetchImpl(
         }
 
         if (fetch_headers) |headers_| {
-            if (headers_.fastGet(bun.webcore.FetchHeaders.HTTPHeaderName.Host)) |_hostname| {
-                if (hostname) |host| {
-                    hostname = null;
-                    allocator.free(host);
-                }
-                hostname = bun.handleOom(_hostname.toOwnedSliceZ(allocator));
-            }
             if (url.isS3()) {
                 if (headers_.fastGet(bun.webcore.FetchHeaders.HTTPHeaderName.Range)) |_range| {
                     if (range) |range_| {

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -282,7 +282,8 @@ pub fn connect(this: *@This(), client: *HTTPClient, comptime is_ssl: bool) !NewH
             return error.UnsupportedProxyProtocol;
         }
     }
-    return try this.context(is_ssl).connect(client, client.url.hostname, client.url.getPortAuto());
+    const target_hostname = client.hostname orelse client.url.hostname;
+    return try this.context(is_ssl).connect(client, target_hostname, client.url.getPortAuto());
 }
 
 pub fn context(this: *@This(), comptime is_ssl: bool) *NewHTTPContext(is_ssl) {


### PR DESCRIPTION
## Summary

- Fixed `fetch()` with custom Host header different from URL causing ConnectionRefused
- Bug: Bun incorrectly used Host header value for connection target instead of URL's host
- `fetch("https://example.com", { headers: { host: "whatever" } })` now works correctly

## Root Cause

In `fetch.zig`, the Host header was being extracted and stored in the `hostname` field, which was then used for the connection target. This caused the HTTP client to try connecting to the wrong host.

## Changes

1. **src/bun.js/webcore/fetch.zig**: Removed incorrect Host header extraction that overrode connection hostname
2. **src/http/HTTPThread.zig**: Updated to prefer explicit hostname override, falling back to URL hostname
3. **test/js/web/fetch/fetch.test.ts**: Added regression test

## Test plan

- [x] Added regression test for custom Host header with fetch
- [x] Test verifies connection goes to URL's host while custom Host header is sent
- [ ] CI tests pass

Fixes #26579

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>