### PR TITLE
fix(types): add missing `bun-linux-x64-${SIMD}` compile target type

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2436,9 +2436,10 @@ declare module "bun" {
       | `bun-darwin-x64-${SIMD}`
       | `bun-linux-${Architecture}`
       | `bun-linux-${Architecture}-${Libc}`
+      | `bun-linux-x64-${SIMD}`
+      | `bun-linux-x64-${SIMD}-${Libc}`
       | "bun-windows-x64"
-      | `bun-windows-x64-${SIMD}`
-      | `bun-linux-x64-${SIMD}-${Libc}`;
+      | `bun-windows-x64-${SIMD}`;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds missing `bun-linux-x64-baseline` and `bun-linux-x64-modern` compile target types
- These targets are supported by the Bun CLI but were missing from the TypeScript type definitions

## Changes

Added `bun-linux-x64-${SIMD}` to the `CompileTarget` type union, which expands to:
- `bun-linux-x64-baseline`
- `bun-linux-x64-modern`

## Test plan

- [x] TypeScript should now accept `target: 'bun-linux-x64-modern'` without type errors

Closes #26247

🤖 Generated with [Claude Code](https://claude.com/claude-code)