### PR TITLE
fix(proxy): respect NO_PROXY for explicit proxy options in fetch and ws

### DIFF
--- a/src/bun.js/bindings/webcore/WebSocket.cpp
+++ b/src/bun.js/bindings/webcore/WebSocket.cpp
@@ -83,6 +83,7 @@
 namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSocket);
 extern "C" int Bun__getTLSRejectUnauthorizedValue();
+extern "C" bool Bun__isNoProxy(const char* hostname, size_t hostname_len, const char* host, size_t host_len);
 
 static ErrorEvent::Init createErrorEventInit(WebSocket& webSocket, const String& reason, JSC::JSGlobalObject* globalObject)
 {
@@ -573,6 +574,19 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
 
     // Determine connection type based on proxy usage and TLS requirements
     bool hasProxy = proxyConfig.has_value();
+
+    // Check NO_PROXY even for explicitly-provided proxies
+    if (hasProxy) {
+        auto hostStr = m_url.host().toString();
+        auto hostWithPort = hostName(m_url, is_secure);
+        auto hostUtf8 = hostStr.utf8();
+        auto hostWithPortUtf8 = hostWithPort.utf8();
+        if (Bun__isNoProxy(hostUtf8.data(), hostUtf8.length(), hostWithPortUtf8.data(), hostWithPortUtf8.length())) {
+            proxyConfig = std::nullopt;
+            hasProxy = false;
+        }
+    }
+
     bool proxyIsHTTPS = hasProxy && proxyConfig->isHTTPS;
 
     // Connection type determines what kind of socket we use:

--- a/src/bun.js/virtual_machine_exports.zig
+++ b/src/bun.js/virtual_machine_exports.zig
@@ -158,6 +158,13 @@ export fn Bun__getTLSRejectUnauthorizedValue() i32 {
     return if (jsc.VirtualMachine.get().getTLSRejectUnauthorized()) 1 else 0;
 }
 
+export fn Bun__isNoProxy(hostname_ptr: [*]const u8, hostname_len: usize, host_ptr: [*]const u8, host_len: usize) bool {
+    const vm = jsc.VirtualMachine.get();
+    const hostname: ?[]const u8 = if (hostname_len > 0) hostname_ptr[0..hostname_len] else null;
+    const host: ?[]const u8 = if (host_len > 0) host_ptr[0..host_len] else null;
+    return vm.transpiler.env.isNoProxy(hostname, host);
+}
+
 export fn Bun__setVerboseFetchValue(value: i32) void {
     VirtualMachine.get().default_verbose_fetch = if (value == 1) .headers else if (value == 2) .curl else .none;
 }

--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -1036,9 +1036,16 @@ pub const FetchTasklet = struct {
         var proxy: ?ZigURL = null;
         if (fetch_options.proxy) |proxy_opt| {
             if (!proxy_opt.isEmpty()) { //if is empty just ignore proxy
-                proxy = fetch_options.proxy orelse jsc_vm.transpiler.env.getHttpProxyFor(fetch_options.url);
+                // Check NO_PROXY even for explicitly-provided proxies
+                if (!jsc_vm.transpiler.env.isNoProxy(fetch_options.url.hostname, fetch_options.url.host)) {
+                    proxy = proxy_opt;
+                }
+            } else {
+                // if empty just use the default proxy resolution
+                proxy = jsc_vm.transpiler.env.getHttpProxyFor(fetch_options.url);
             }
         } else {
+            // no proxy provided, use default proxy resolution
             proxy = jsc_vm.transpiler.env.getHttpProxyFor(fetch_options.url);
         }
 

--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -1040,10 +1040,8 @@ pub const FetchTasklet = struct {
                 if (!jsc_vm.transpiler.env.isNoProxy(fetch_options.url.hostname, fetch_options.url.host)) {
                     proxy = proxy_opt;
                 }
-            } else {
-                // if empty just use the default proxy resolution
-                proxy = jsc_vm.transpiler.env.getHttpProxyFor(fetch_options.url);
             }
+            // else: proxy: "" means explicitly no proxy (direct connection)
         } else {
             // no proxy provided, use default proxy resolution
             proxy = jsc_vm.transpiler.env.getHttpProxyFor(fetch_options.url);

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -250,8 +250,14 @@ pub const Loader = struct {
                     }
                 }
             } else {
-                // Entry is hostname/IPv6 only, match against hostname (suffix match)
-                if (strings.endsWith(hn, no_proxy_entry)) {
+                // Entry is hostname/IPv6 only, match exact or dot-boundary suffix (case-insensitive)
+                const entry_len = no_proxy_entry.len;
+                if (hn.len == entry_len) {
+                    if (strings.eqlCaseInsensitiveASCII(hn, no_proxy_entry, true)) return true;
+                } else if (hn.len > entry_len and
+                    hn[hn.len - entry_len - 1] == '.' and
+                    strings.eqlCaseInsensitiveASCII(hn[hn.len - entry_len ..], no_proxy_entry, true))
+                {
                     return true;
                 }
             }

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -860,7 +860,7 @@ describe("proxy object format with headers", () => {
   });
 });
 
-describe("NO_PROXY with explicit proxy option", () => {
+describe.concurrent("NO_PROXY with explicit proxy option", () => {
   // These tests use subprocess spawning because NO_PROXY is read from the
   // process environment at startup. A dead proxy that immediately closes
   // connections is used so that if NO_PROXY doesn't work, the fetch fails

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { tls as tlsCert } from "harness";
+import { bunEnv, bunExe, tls as tlsCert } from "harness";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { once } from "node:events";
 import net from "node:net";
@@ -857,5 +857,65 @@ describe("proxy object format with headers", () => {
     // The request should succeed (without proxy, since URL object is ignored)
     expect(response.ok).toBe(true);
     expect(response.status).toBe(200);
+  });
+});
+
+describe("NO_PROXY with explicit proxy option", () => {
+  // These tests use subprocess spawning because NO_PROXY is read from the
+  // process environment at startup. A dead proxy (port 1) is used so that
+  // if NO_PROXY doesn't work, the fetch fails with a connection error.
+
+  test("NO_PROXY bypasses explicit proxy for fetch", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const resp = await fetch("http://localhost:${httpServer.port}", { proxy: "http://127.0.0.1:1" }); console.log(resp.status);`,
+      ],
+      env: { ...bunEnv, NO_PROXY: "localhost" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) console.error("stderr:", stderr);
+    expect(stdout.trim()).toBe("200");
+    expect(exitCode).toBe(0);
+  });
+
+  test("NO_PROXY with port bypasses explicit proxy for fetch", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const resp = await fetch("http://localhost:${httpServer.port}", { proxy: "http://127.0.0.1:1" }); console.log(resp.status);`,
+      ],
+      env: { ...bunEnv, NO_PROXY: `localhost:${httpServer.port}` },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) console.error("stderr:", stderr);
+    expect(stdout.trim()).toBe("200");
+    expect(exitCode).toBe(0);
+  });
+
+  test("NO_PROXY non-match does not bypass explicit proxy", async () => {
+    // NO_PROXY doesn't match, so fetch should try the dead proxy and fail
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `try { await fetch("http://localhost:${httpServer.port}", { proxy: "http://127.0.0.1:1" }); process.exit(1); } catch { process.exit(0); }`,
+      ],
+      env: { ...bunEnv, NO_PROXY: "other.com" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const exitCode = await proc.exited;
+    // exit(0) means fetch threw (proxy connection failed), proving proxy was used
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -659,7 +659,7 @@ describe("ws module with HttpsProxyAgent", () => {
   });
 });
 
-describe("WebSocket NO_PROXY bypass", () => {
+describe.concurrent("WebSocket NO_PROXY bypass", () => {
   test("NO_PROXY matching hostname bypasses explicit proxy for ws://", async () => {
     // authProxy requires credentials; if NO_PROXY works, the WebSocket bypasses
     // the proxy and connects directly. If NO_PROXY doesn't work, the proxy


### PR DESCRIPTION
### What does this PR do?

Extract NO_PROXY checking logic from getHttpProxyFor into a reusable isNoProxy method on the env Loader. This allows both fetch() and WebSocket to check NO_PROXY even when a proxy is explicitly provided via the proxy option (not just via http_proxy env var).

Changes:
- env_loader.zig: Extract isNoProxy() from getHttpProxyFor()
- FetchTasklet.zig: Check isNoProxy() before using explicit proxy
- WebSocket.cpp: Check Bun__isNoProxy() before using explicit proxy
- virtual_machine_exports.zig: Export Bun__isNoProxy for C++ access
- Add NO_PROXY tests for both fetch and WebSocket proxy paths

### How did you verify your code works?
Tests