### PR TITLE
fix(misctools): missing error handling and FileName printing

### DIFF
--- a/misctools/ntquery.cpp
+++ b/misctools/ntquery.cpp
@@ -54,6 +54,10 @@ int main_using_file_directory_information(int argc, char *argv[]) {
   // open the current working directory using NT API
   HANDLE hFile = CreateFile(argv[1], GENERIC_READ, FILE_SHARE_READ, NULL,
                             OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+  if (hFile == INVALID_HANDLE_VALUE) {
+    printf("Error opening directory: %lu\n", GetLastError());
+    return 1;
+  }
 
   // use NtQueryDirectoryFile
   char buffer[64096];
@@ -69,7 +73,7 @@ int main_using_file_directory_information(int argc, char *argv[]) {
 
   PFILE_DIRECTORY_INFORMATION pDirInfo = (PFILE_DIRECTORY_INFORMATION)buffer;
   while (TRUE) {
-    printf("%S\n", pDirInfo->FileName);
+    printf("%.*S\n", pDirInfo->FileNameLength / sizeof(WCHAR), pDirInfo->FileName);
     if (pDirInfo->NextEntryOffset == 0) {
       // if no more entries, continue to next query directory call
       status = NtQueryDirectoryFile(
@@ -116,7 +120,10 @@ int main_using_file_both_information(int argc, char *argv[]) {
   // open the current working directory using NT API
   HANDLE hFile = CreateFile(argv[1], GENERIC_READ, FILE_SHARE_READ, NULL,
                             OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
-
+  if (hFile == INVALID_HANDLE_VALUE) {
+    printf("Error opening directory: %lu\n", GetLastError());
+    return 1;
+  }
   // use NtQueryDirectoryFile
   char buffer[64096];
 
@@ -131,7 +138,7 @@ int main_using_file_both_information(int argc, char *argv[]) {
 
   PFILE_BOTH_DIR_INFORMATION pDirInfo = (PFILE_BOTH_DIR_INFORMATION)buffer;
   while (TRUE) {
-    printf("%S\n", pDirInfo->FileName);
+    printf("%.*S\n", pDirInfo->FileNameLength / sizeof(WCHAR), pDirInfo->FileName);
     if (pDirInfo->NextEntryOffset == 0) {
       // if no more entries, continue to next query directory call
       status = NtQueryDirectoryFile(
@@ -166,6 +173,10 @@ int main_using_findfirstfile_ex(int argc, char *argv[]) {
   // open the current working directory using NT API
   HANDLE hFile = CreateFile(argv[1], GENERIC_READ, FILE_SHARE_READ, NULL,
                             OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+	if (hFile == INVALID_HANDLE_VALUE) {
+		printf("Error opening directory: %lu\n", GetLastError());
+		return 1;
+	}
 
   char buffer[64096];
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes two bugs in `misctools/ntquery.cpp`:

1. **Adds missing `CreateFile` error handling** - All three functions now check if `CreateFile` returns `INVALID_HANDLE_VALUE` before using the handle. Without this check, the code would pass an invalid handle to subsequent functions, causing cryptic errors instead of clear error messages.

2. **Fixes `FileName` printing bug** - The `FileName` field in `FILE_DIRECTORY_INFORMATION` and `FILE_BOTH_DIR_INFORMATION` structures is not null-terminated. The original code used `printf("%S\n", pDirInfo->FileName)` which expects a null-terminated string, causing garbage characters to be printed after filenames. Now uses `printf("%.*S\n", pDirInfo->FileNameLength / sizeof(WCHAR), pDirInfo->FileName)` to print exactly the correct number of characters.

### How did you verify your code works?

The changes are error handling additions and correctness fixes that don't alter the core logic:
- The `CreateFile` checks only trigger when file opening already fails, providing better error messages
- The `FileName` printing fix uses the length field that's already present in the structure, ensuring correct output
- Both changes follow standard Windows API practices for handling these data types

While I haven't compiled and tested on Windows, the fixes are straightforward corrections that align with Microsoft's documentation for these APIs.