### PR TITLE
add `--cpu-prof-interval` flag

### DIFF
--- a/src/bun.js.zig
+++ b/src/bun.js.zig
@@ -285,7 +285,9 @@ pub const Run = struct {
                 .dir = cpu_prof_opts.dir,
                 .md_format = cpu_prof_opts.md_format,
                 .json_format = cpu_prof_opts.json_format,
+                .interval = cpu_prof_opts.interval,
             };
+            CPUProfiler.setSamplingInterval(cpu_prof_opts.interval);
             CPUProfiler.startCPUProfiler(vm.jsc_vm);
             bun.analytics.Features.cpu_profile += 1;
         }

--- a/src/bun.js/bindings/BunCPUProfiler.cpp
+++ b/src/bun.js/bindings/BunCPUProfiler.cpp
@@ -19,6 +19,7 @@
 
 extern "C" void Bun__startCPUProfiler(JSC::VM* vm);
 extern "C" void Bun__stopCPUProfiler(JSC::VM* vm, BunString* outJSON, BunString* outText);
+extern "C" void Bun__setSamplingInterval(int intervalMicroseconds);
 
 void Bun__setSamplingInterval(int intervalMicroseconds)
 {

--- a/src/bun.js/bindings/BunCPUProfiler.cpp
+++ b/src/bun.js/bindings/BunCPUProfiler.cpp
@@ -20,6 +20,11 @@
 extern "C" void Bun__startCPUProfiler(JSC::VM* vm);
 extern "C" void Bun__stopCPUProfiler(JSC::VM* vm, BunString* outJSON, BunString* outText);
 
+void Bun__setSamplingInterval(int intervalMicroseconds)
+{
+    Bun::setSamplingInterval(intervalMicroseconds);
+}
+
 namespace Bun {
 
 // Store the profiling start time in microseconds since Unix epoch

--- a/src/bun.js/bindings/BunCPUProfiler.zig
+++ b/src/bun.js/bindings/BunCPUProfiler.zig
@@ -12,7 +12,7 @@ extern fn Bun__stopCPUProfiler(vm: *jsc.VM, outJSON: ?*bun.String, outText: ?*bu
 extern fn Bun__setSamplingInterval(intervalMicroseconds: c_int) void;
 
 pub fn setSamplingInterval(interval: u32) void {
-    Bun__setSamplingInterval(@as(c_int, @truncate(interval)));
+    Bun__setSamplingInterval(@intCast(interval));
 }
 
 pub fn startCPUProfiler(vm: *jsc.VM) void {

--- a/src/bun.js/bindings/BunCPUProfiler.zig
+++ b/src/bun.js/bindings/BunCPUProfiler.zig
@@ -3,11 +3,17 @@ pub const CPUProfilerConfig = struct {
     dir: []const u8,
     md_format: bool = false,
     json_format: bool = false,
+    interval: u32 = 1000,
 };
 
 // C++ function declarations
 extern fn Bun__startCPUProfiler(vm: *jsc.VM) void;
 extern fn Bun__stopCPUProfiler(vm: *jsc.VM, outJSON: ?*bun.String, outText: ?*bun.String) void;
+extern fn Bun__setSamplingInterval(intervalMicroseconds: c_int) void;
+
+pub fn setSamplingInterval(interval: u32) void {
+    Bun__setSamplingInterval(@as(c_int, @truncate(interval)));
+}
 
 pub fn startCPUProfiler(vm: *jsc.VM) void {
     Bun__startCPUProfiler(vm);

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -392,6 +392,7 @@ pub const Command = struct {
             enabled: bool = false,
             name: []const u8 = "",
             dir: []const u8 = "",
+            interval: u32 = 1000,
             md_format: bool = false,
             json_format: bool = false,
         } = .{},

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -91,6 +91,7 @@ pub const runtime_params_ = [_]ParamType{
     clap.parseParam("--cpu-prof-name <STR>             Specify the name of the CPU profile file") catch unreachable,
     clap.parseParam("--cpu-prof-dir <STR>              Specify the directory where the CPU profile will be saved") catch unreachable,
     clap.parseParam("--cpu-prof-md                     Output CPU profile in markdown format (grep-friendly, designed for LLM analysis)") catch unreachable,
+    clap.parseParam("--cpu-prof-interval <STR>         Specify the sampling interval in microseconds for CPU profiling (default: 1000)") catch unreachable,
     clap.parseParam("--heap-prof                       Generate V8 heap snapshot on exit (.heapsnapshot)") catch unreachable,
     clap.parseParam("--heap-prof-name <STR>            Specify the name of the heap profile file") catch unreachable,
     clap.parseParam("--heap-prof-dir <STR>             Specify the directory where the heap profile will be saved") catch unreachable,
@@ -864,6 +865,9 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
             ctx.runtime_options.cpu_prof.md_format = cpu_prof_md_flag;
             // json_format is true if --cpu-prof is passed (regardless of --cpu-prof-md)
             ctx.runtime_options.cpu_prof.json_format = cpu_prof_flag;
+            if (args.option("--cpu-prof-interval")) |interval_str| {
+                ctx.runtime_options.cpu_prof.interval = std.fmt.parseInt(u32, interval_str, 10) catch 1000;
+            }
         } else {
             // Warn if --cpu-prof-name or --cpu-prof-dir is used without a profiler flag
             if (args.option("--cpu-prof-name")) |_| {
@@ -871,6 +875,9 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
             }
             if (args.option("--cpu-prof-dir")) |_| {
                 Output.warn("--cpu-prof-dir requires --cpu-prof or --cpu-prof-md to be enabled", .{});
+            }
+            if (args.option("--cpu-prof-interval")) |_| {
+                Output.warn("--cpu-prof-interval requires --cpu-prof or --cpu-prof-md to be enabled", .{});
             }
         }
 


### PR DESCRIPTION
Adds `--cpu-prof-interval` to configure the CPU profiler sampling interval in microseconds (default: 1000), matching Node.js's `--cpu-prof-interval` flag.

```sh
bun --cpu-prof --cpu-prof-interval 500 index.js
```

- Parsed as `u32`, truncated to `c_int` when passed to JSC's `SamplingProfiler::setTimingInterval`
- Invalid values silently fall back to the default (1000μs)
- Warns if used without `--cpu-prof` or `--cpu-prof-md`