### PR TITLE
fix: embed .txt files in Bun.embeddedFiles with --compile

### DIFF
--- a/src/bundler/ParseTask.zig
+++ b/src/bundler/ParseTask.zig
@@ -372,6 +372,30 @@ fn getAST(
             return JSAst.init((try js_parser.newLazyExportAST(allocator, transpiler.options.define, opts, &temp_log, root, source, "")).?);
         },
         .text => {
+            // Set unique_key_for_additional_file so the file appears in Bun.embeddedFiles
+            // when passed as an entry point in --compile mode. The exported value is still
+            // the inline text content (not a URL) for import compatibility.
+            const content_hash = ContentHasher.run(source.contents);
+            const unique_key: []const u8 = if (transpiler.options.dev_server != null)
+                try std.fmt.allocPrint(
+                    allocator,
+                    bun.bake.DevServer.asset_prefix ++ "/{s}{s}",
+                    .{
+                        &std.fmt.bytesToHex(std.mem.asBytes(&content_hash), .lower),
+                        std.fs.path.extension(source.path.text),
+                    },
+                )
+            else
+                try std.fmt.allocPrint(
+                    allocator,
+                    "{f}A{d:0>8}",
+                    .{ bun.fmt.hexIntLower(unique_key_prefix), source.index.get() },
+                );
+            unique_key_for_additional_file.* = .{
+                .key = unique_key,
+                .content_hash = content_hash,
+            };
+            // Export the inline text content (not the URL) for import compatibility
             const root = Expr.init(E.String, E.String{
                 .data = source.contents,
             }, Logger.Loc{ .start = 0 });

--- a/src/options.zig
+++ b/src/options.zig
@@ -681,6 +681,9 @@ pub const Loader = enum(u8) {
     pub fn shouldCopyForBundling(this: Loader) bool {
         return switch (this) {
             .file,
+            .text,
+            .base64,
+            .dataurl,
             .napi,
             .sqlite,
             .sqlite_embedded,


### PR DESCRIPTION
## Summary
- Fixes `.txt` files (and other text-based files) not appearing in `Bun.embeddedFiles` when passed as entry points to `bun build --compile`
- Adds `.text`, `.base64`, and `.dataurl` loaders to `shouldCopyForBundling()`
- Sets `unique_key_for_additional_file` in the `.text` loader for proper tracking

## Test plan
- [x] Verified fix with manual test: compiled binary shows `.txt` file in `Bun.embeddedFiles`
- [x] Verified import behavior unchanged: `import x from './file.txt'` still returns text content
- [x] Added regression test in `bundler_compile.test.ts`

## Reproduction (from issue)
```bash
echo 'console.log(Bun.embeddedFiles)' > example.ts
touch foo.txt
bun build --compile --outfile example ./example.ts ./foo.txt && ./example
# Before: []
# After: [ Blob { name: "foo-xxxxx.txt" } ]
```

Fixes #26617

🤖 Generated with [Claude Code](https://claude.ai/code)