### PR TITLE
fix(types): correct JSDoc examples for Statement.get() and Statement.all()

### DIFF
--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -610,11 +610,14 @@ declare module "bun:sqlite" {
      * ```ts
      * const stmt = db.prepare("SELECT * FROM foo WHERE bar = ?");
      *
+     * stmt.all();
+     * // => [] (no previous bindings)
+     *
      * stmt.all("baz");
      * // => [{bar: "baz"}]
      *
      * stmt.all();
-     * // => []
+     * // => [{bar: "baz"}] (uses last bound value)
      *
      * stmt.all("foo");
      * // => [{bar: "foo"}]
@@ -633,11 +636,14 @@ declare module "bun:sqlite" {
      * ```ts
      * const stmt = db.prepare("SELECT * FROM foo WHERE bar = ?");
      *
+     * stmt.get();
+     * // => null (no previous bindings)
+     *
      * stmt.get("baz");
      * // => {bar: "baz"}
      *
      * stmt.get();
-     * // => null
+     * // => {bar: "baz"} (uses last bound value)
      *
      * stmt.get("foo");
      * // => {bar: "foo"}

--- a/test/regression/issue/26622.test.ts
+++ b/test/regression/issue/26622.test.ts
@@ -1,0 +1,54 @@
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/26622
+// When parameters are omitted from .get(), .all(), etc., the statement should
+// run with the last bound values (or no parameters if there are none)
+
+test("Statement.get() uses last bound value when called without parameters", () => {
+  using db = new Database(":memory:");
+  db.run("CREATE TABLE foo (bar TEXT)");
+  db.run("INSERT INTO foo VALUES ('baz')");
+  db.run("INSERT INTO foo VALUES ('foo')");
+
+  using stmt = db.prepare("SELECT * FROM foo WHERE bar = ?");
+
+  // First call without binding returns null (no match with empty/no parameter)
+  expect(stmt.get()).toBe(null);
+
+  // Bind and get a value
+  expect(stmt.get("baz")).toEqual({ bar: "baz" });
+
+  // Call without parameters should use last bound value ("baz")
+  expect(stmt.get()).toEqual({ bar: "baz" });
+
+  // Bind a different value
+  expect(stmt.get("foo")).toEqual({ bar: "foo" });
+
+  // Call without parameters should now use "foo"
+  expect(stmt.get()).toEqual({ bar: "foo" });
+});
+
+test("Statement.all() uses last bound value when called without parameters", () => {
+  using db = new Database(":memory:");
+  db.run("CREATE TABLE foo (bar TEXT)");
+  db.run("INSERT INTO foo VALUES ('baz')");
+  db.run("INSERT INTO foo VALUES ('foo')");
+
+  using stmt = db.prepare("SELECT * FROM foo WHERE bar = ?");
+
+  // First call without binding returns empty array (no match)
+  expect(stmt.all()).toEqual([]);
+
+  // Bind and get values
+  expect(stmt.all("baz")).toEqual([{ bar: "baz" }]);
+
+  // Call without parameters should use last bound value ("baz")
+  expect(stmt.all()).toEqual([{ bar: "baz" }]);
+
+  // Bind a different value
+  expect(stmt.all("foo")).toEqual([{ bar: "foo" }]);
+
+  // Call without parameters should now use "foo"
+  expect(stmt.all()).toEqual([{ bar: "foo" }]);
+});


### PR DESCRIPTION
## Summary

- Fixes the JSDoc examples for `Statement.get()` and `Statement.all()` in `bun:sqlite`
- The examples incorrectly showed that calling these methods without parameters returns `null`/`[]`
- The actual behavior (correctly described in the prose documentation) is that last bound values are reused

## Test plan

- [x] Regression test added that verifies the documented behavior
- [x] Test passes with `bun bd test test/regression/issue/26622.test.ts`

Fixes #26622

🤖 Generated with [Claude Code](https://claude.ai/code)