### PR TITLE
fix(sqlite): use correct library name on Linux

### DIFF
--- a/src/bun.js/bindings/sqlite/lazy_sqlite3.h
+++ b/src/bun.js/bindings/sqlite/lazy_sqlite3.h
@@ -215,7 +215,7 @@ static const char* sqlite3_lib_path = "sqlite3.dll";
 #elif OS(DARWIN)
 static const char* sqlite3_lib_path = "libsqlite3.dylib";
 #else
-static const char* sqlite3_lib_path = "sqlite3";
+static const char* sqlite3_lib_path = "libsqlite3.so";
 #endif
 
 static HMODULE sqlite3_handle = nullptr;

--- a/test/regression/issue/26629.test.ts
+++ b/test/regression/issue/26629.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/26629
+// bun:sqlite fails to locate the system SQLite library on Linux because
+// it searched for "sqlite3" instead of "libsqlite3.so".
+test("bun:sqlite should load the system SQLite library", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "import Database from 'bun:sqlite'; new Database(':memory:'); console.log('ok')"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fix `bun:sqlite` failing to locate the system SQLite library on Linux
- Changed the library search path from `"sqlite3"` to `"libsqlite3.so"`

On Linux, `dlopen("sqlite3", RTLD_LAZY)` fails because the library is installed as `libsqlite3.so`, not `sqlite3`. This made `bun:sqlite` unusable on Linux systems that have SQLite installed via the system package manager.

## Test plan
- [x] Added regression test `test/regression/issue/26629.test.ts`
- [x] Verified fix with `bun bd test test/regression/issue/26629.test.ts`
- [x] Manually tested SQLite operations work with the debug build

Fixes #26629

🤖 Generated with [Claude Code](https://claude.com/claude-code)