### PR TITLE
fix(fs): handle '.' path normalization on Windows

### DIFF
--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -650,6 +650,10 @@ pub const PathLike = union(enum) {
                 return strings.toKernel32Path(@alignCast(std.mem.bytesAsSlice(u16, buf)), normal);
             }
             const normal = path_handler.normalizeStringBuf(s, b, true, .windows, false);
+            // Handle the case where normalizing "." results in an empty string
+            if (normal.len == 0) {
+                return strings.toKernel32Path(@alignCast(std.mem.bytesAsSlice(u16, buf)), ".");
+            }
             return strings.toKernel32Path(@alignCast(std.mem.bytesAsSlice(u16, buf)), normal);
         }
 

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -649,11 +649,11 @@ pub const PathLike = union(enum) {
                 const normal = path_handler.normalizeBuf(resolve, b, .windows);
                 return strings.toKernel32Path(@alignCast(std.mem.bytesAsSlice(u16, buf)), normal);
             }
-            const normal = path_handler.normalizeStringBuf(s, b, true, .windows, false);
-            // Handle the case where normalizing "." results in an empty string
-            if (normal.len == 0) {
+            // Handle "." specially since normalizeStringBuf strips it to an empty string
+            if (s.len == 1 and s[0] == '.') {
                 return strings.toKernel32Path(@alignCast(std.mem.bytesAsSlice(u16, buf)), ".");
             }
+            const normal = path_handler.normalizeStringBuf(s, b, true, .windows, false);
             return strings.toKernel32Path(@alignCast(std.mem.bytesAsSlice(u16, buf)), normal);
         }
 

--- a/test/regression/issue/26631.test.ts
+++ b/test/regression/issue/26631.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test";
+import { existsSync, statSync } from "node:fs";
+import { exists, stat } from "node:fs/promises";
+
+// https://github.com/oven-sh/bun/issues/26631
+// Path resolution fails for current directory '.' on Windows
+
+test("existsSync('.') should return true", () => {
+  expect(existsSync(".")).toBe(true);
+});
+
+test("exists('.') should return true", async () => {
+  expect(await exists(".")).toBe(true);
+});
+
+test("statSync('.') should return directory stats", () => {
+  const stats = statSync(".");
+  expect(stats.isDirectory()).toBe(true);
+});
+
+test("stat('.') should return directory stats", async () => {
+  const stats = await stat(".");
+  expect(stats.isDirectory()).toBe(true);
+});
+
+test("existsSync('..') should return true", () => {
+  expect(existsSync("..")).toBe(true);
+});
+
+test("exists('..') should return true", async () => {
+  expect(await exists("..")).toBe(true);
+});
+
+test("statSync('..') should return directory stats", () => {
+  const stats = statSync("..");
+  expect(stats.isDirectory()).toBe(true);
+});
+
+test("stat('..') should return directory stats", async () => {
+  const stats = await stat("..");
+  expect(stats.isDirectory()).toBe(true);
+});


### PR DESCRIPTION
## Summary
- Fix path normalization for "." on Windows where `normalizeStringBuf` was incorrectly stripping it to an empty string
- This caused `existsSync('.')`, `statSync('.')`, and other fs operations to fail on Windows

## Test plan
- Added regression test `test/regression/issue/26631.test.ts` that tests `existsSync`, `exists`, `statSync`, and `stat` for both `.` and `..` paths
- All tests pass locally with `bun bd test test/regression/issue/26631.test.ts`
- Verified code compiles on all platforms with `bun run zig:check-all`

Fixes #26631

🤖 Generated with [Claude Code](https://claude.com/claude-code)