### PR TITLE
fix(build): restore baseline WebKit suffix for x64 builds

### DIFF
--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -87,6 +87,11 @@ if(LINUX AND ABI STREQUAL "musl")
   set(WEBKIT_SUFFIX "-musl")
 endif()
 
+# Baseline builds require a WebKit compiled without AVX instructions
+if(ENABLE_BASELINE AND WEBKIT_ARCH STREQUAL "amd64")
+  set(WEBKIT_SUFFIX "${WEBKIT_SUFFIX}-baseline")
+endif()
+
 if(DEBUG)
   set(WEBKIT_SUFFIX "${WEBKIT_SUFFIX}-debug")
 elseif(ENABLE_LTO)


### PR DESCRIPTION
## Summary

- Re-applies the baseline WebKit suffix fix that was accidentally reverted
- Fixes illegal instruction (SIGILL) crashes on baseline x64 CPUs and in Docker QEMU emulation

Fixes #26635

## Root Cause

The fix from #26071 was accidentally reverted in commit b268004715 ("Upgrade WebKit to d5bd162d9ab2") on Jan 15. Without this fix, baseline x64 builds download the standard WebKit library compiled with `-march=haswell`, which includes AVX/AVX2 instructions that crash on older CPUs or under QEMU emulation.

## Change

Restores the `-baseline` suffix for WebKit downloads when `ENABLE_BASELINE` is set on x86_64, ensuring baseline builds use a WebKit library compiled without AVX instructions.

## Test plan

- [x] Verify the WebKit download URL includes `-baseline` suffix for baseline x64 builds
- [ ] CI QEMU verification step should pass (uses `scripts/verify-baseline-cpu.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)