### PR TITLE
perf(watcher): batch kevent registrations (65% fewer syscalls on average)

### DIFF
--- a/src/watcher/KEventWatcher.zig
+++ b/src/watcher/KEventWatcher.zig
@@ -6,6 +6,8 @@ pub const EventListIndex = u32;
 eventlist_index: EventListIndex = 0,
 
 fd: bun.FD.Optional = .none,
+pending_kevents_buf: [256]KEvent = undefined,
+pending_kevents_len: u16 = 0,
 
 const changelist_count = 128;
 


### PR DESCRIPTION
### What does this PR do?

Batches kqueue event registrations in the file watcher on macOS. Previously, addFileDescriptorToKQueueWithoutChecks made a separate kevent() syscall for every file registered. Now it appends to a 256-entry buffer and flushes them all in one kevent() call. When watching 500 files, this reduces 500 syscalls to 2.

Also deduplicates `appendDirectoryAssumeCapacity`, which had a copy-pasted `kevent` registration block identical to `addFileDescriptorToKQueueWithoutChecks` — it now calls the shared function.

### How did you verify your code works?
A few ways (on Mac)!

First, I wanted to isolate and test that this would move the needle. In C, I wrote a test below.
Results (used `cc`, compiled with `-O2` flag):
| FD Count | Single (avg) | Batched (avg) | Speedup | ns/fd (single) | ns/fd (batched) |
|---|---|---|---|---|---|
| 10 | 4.4 µs | 1.6 µs | **63%** | 436 | 160 |
| 50 | 19.2 µs | 5.9 µs | **69%** | 384 | 118 |
| 100 | 35.0 µs | 11.5 µs | **67%** | 350 | 115 |
| 500 | 182.2 µs | 62.9 µs | **65%** | 364 | 126 |
| 1,000 | 362.0 µs | 118.6 µs | **67%** | 362 | 119 |
| 5,000 | 1,843.2 µs | 637.4 µs | **65%** | 369 | 127 |

Then, after integrating this into bun:

- All existing watcher tests pass: `watch.test.ts`, `watcher-trace.test.ts`, `hot/watch.test.ts`, `hot/watch-many-dirs.test.ts` (129 directories)
- Wrote a custom stress test (didn't know if it'd be appropriate to push this) that watches 300 files across 30 directories (exceeding the 256-entry buffer to exercise the auto-flush path), verifies file change detection and reload after modification. Ran 3 consecutive times with no flakiness.

C raw test below:
```
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>
#include <sys/event.h>
#include <sys/time.h>

static double now_us(void) {
  struct timeval tv;
  gettimeofday(&tv, NULL);
  return tv.tv_sec * 1e6 + tv.tv_usec;
}

// Pattern 1: Register events one at a time (what callers typically do)
static double bench_kevent_single(int kq, int *fds, int nfds) {
  struct kevent ev;
  double t0 = now_us();
  for (int i = 0; i < nfds; i++) {
    EV_SET(&ev, fds[i], EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);
    if (kevent(kq, &ev, 1, NULL, 0, NULL) < 0) {
      perror("kevent single");
      return -1;
    }
  }
  double t1 = now_us();
  return t1 - t0;
}

// Pattern 2: Register all events in one batched call
static double bench_kevent_batched(int kq, int *fds, int nfds) {
  struct kevent *evs = malloc(sizeof(struct kevent) * nfds);
  for (int i = 0; i < nfds; i++) {
    EV_SET(&evs[i], fds[i], EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);
  }

  double t0 = now_us();
  int rc = kevent(kq, evs, nfds, NULL, 0, NULL);
  double t1 = now_us();

  if (rc < 0) perror("kevent batched");
  free(evs);
  return t1 - t0;
}

// Deregister all events (cleanup between tests)
static void deregister_all(int kq, int *fds, int nfds) {
  struct kevent *evs = malloc(sizeof(struct kevent) * nfds);
  for (int i = 0; i < nfds; i++) {
    EV_SET(&evs[i], fds[i], EVFILT_READ, EV_DELETE, 0, 0, NULL);
  }
  kevent(kq, evs, nfds, NULL, 0, NULL);
  free(evs);
}

int main(void) {
  printf("=== kevent() Single vs Batched Registration ===\n\n");

  int test_sizes[] = { 10, 50, 100, 500, 1000, 5000 };
  int ntests = sizeof(test_sizes) / sizeof(test_sizes[0]);
  int iterations = 50;

  for (int t = 0; t < ntests; t++) {
    int nfds = test_sizes[t];
    printf("--- %d file descriptors, %d iterations ---\n", nfds, iterations);

    // Create pipes to get real FDs
    int *read_fds = malloc(sizeof(int) * nfds);
    int *write_fds = malloc(sizeof(int) * nfds);
    for (int i = 0; i < nfds; i++) {
      int pipefd[2];
      if (pipe(pipefd) < 0) { perror("pipe"); return 1; }
      read_fds[i] = pipefd[0];
      write_fds[i] = pipefd[1];
    }

    double sum_single = 0, sum_batched = 0;
    double min_single = 1e18, min_batched = 1e18;

    for (int i = 0; i < iterations; i++) {
      int kq1 = kqueue();
      double ts = bench_kevent_single(kq1, read_fds, nfds);
      close(kq1);
      sum_single += ts;
      if (ts < min_single) min_single = ts;

      int kq2 = kqueue();
      double tb = bench_kevent_batched(kq2, read_fds, nfds);
      close(kq2);
      sum_batched += tb;
      if (tb < min_batched) min_batched = tb;
    }

    double avg_s = sum_single / iterations;
    double avg_b = sum_batched / iterations;
    double speedup = (avg_s - avg_b) / avg_s * 100.0;

    printf("  Single:  avg=%8.1f µs  min=%8.1f µs  (%.0f ns/fd)\n",
      avg_s, min_single, avg_s * 1000.0 / nfds);
    printf("  Batched: avg=%8.1f µs  min=%8.1f µs  (%.0f ns/fd)\n",
      avg_b, min_batched, avg_b * 1000.0 / nfds);
    printf("  Speedup: %.1f%% (avg)  %.1f%% (min)\n\n",
      speedup, (min_single - min_batched) / min_single * 100.0);

    // Cleanup
    for (int i = 0; i < nfds; i++) {
      close(read_fds[i]);
      close(write_fds[i]);
    }
    free(read_fds);
    free(write_fds);
  }

  printf("Done.\n");
  return 0;
}
```

Test below:
```
import { spawn } from "bun";
import { describe, expect, test } from "bun:test";
import { bunEnv, bunExe, forEachLine, isASAN, isCI, isMacOS, tempDirWithFiles } from "harness";
import { mkdirSync, writeFileSync } from "node:fs";
import { join } from "node:path";
// This stress test exercises kevent batching on macOS by registering
// many files with the watcher. The pending_kevents buffer is 256 entries,
// so using >256 files ensures the auto-flush path is exercised.
describe.skipIf(!isMacOS)("--watch with many files", () => {
    test.skipIf(isCI && isASAN)(
        "handles 300+ files across many directories",
        async () => {
            const dirCount = 30;
            const filesPerDir = 10; // 300 files total, exceeds 256-entry kevent buffer
            const files: Record<string, string> = {
                "entry.js": "// placeholder",
            };
            // Generate directory structure
            for (let d = 0; d < dirCount; d++) {
                const dirName = `dir${d.toString().padStart(3, "0")}`;
                for (let f = 0; f < filesPerDir; f++) {
                    const fileName = `mod${f}.js`;
                    files[`${dirName}/${fileName}`] = `export const v = ${d * filesPerDir + f};`;
                }
            }
            const tmpdir = tempDirWithFiles("watch-many-files", files);
            // Create entry that imports all modules
            const imports: string[] = [];
            for (let d = 0; d < dirCount; d++) {
                const dirName = `dir${d.toString().padStart(3, "0")}`;
                for (let f = 0; f < filesPerDir; f++) {
                    imports.push(`import './${dirName}/mod${f}.js';`);
                }
            }
            writeFileSync(
                join(tmpdir, "entry.js"),
                `${imports.join("\n")}\nconsole.log('loaded', ${dirCount * filesPerDir}, 'files');\n`,
            );
            await using proc = spawn({
                cmd: [bunExe(), "--watch", "entry.js"],
                cwd: tmpdir,
                env: bunEnv,
                stdout: "pipe",
                stderr: "inherit",
            });
            const iter = forEachLine(proc.stdout);
            // Wait for initial load
            const { value: line } = await iter.next();
            expect(line).toContain(`loaded ${dirCount * filesPerDir} files`);
            // Modify a file in the middle to trigger a reload
            const targetDir = `dir${Math.floor(dirCount / 2).toString().padStart(3, "0")}`;
            const targetFile = join(tmpdir, targetDir, "mod0.js");
            writeFileSync(targetFile, `export const v = 'modified';`);
            const { value: reloadLine } = await iter.next();
            expect(reloadLine).toContain(`loaded ${dirCount * filesPerDir} files`);
            proc.kill();
        },
        30000,
    );
    test.skipIf(isCI && isASAN)(
        "handles simultaneous modifications to files in different directories",
        async () => {
            const dirCount = 20;
            const filesPerDir = 5; // 100 files
            const files: Record<string, string> = {
                "entry.js": "// placeholder",
            };
            for (let d = 0; d < dirCount; d++) {
                const dirName = `pkg${d}`;
                for (let f = 0; f < filesPerDir; f++) {
                    files[`${dirName}/f${f}.js`] = `export const x = ${d * filesPerDir + f};`;
                }
            }
            const tmpdir = tempDirWithFiles("watch-simultaneous", files);
            const imports = [];
            for (let d = 0; d < dirCount; d++) {
                for (let f = 0; f < filesPerDir; f++) {
                    imports.push(`import './pkg${d}/f${f}.js';`);
                }
            }
            writeFileSync(
                join(tmpdir, "entry.js"),
                `${imports.join("\n")}\nconsole.log('ready', ${dirCount * filesPerDir});\n`,
            );
            await using proc = spawn({
                cmd: [bunExe(), "--watch", "entry.js"],
                cwd: tmpdir,
                env: bunEnv,
                stdout: "pipe",
                stderr: "inherit",
            });
            const iter = forEachLine(proc.stdout);
            const { value: line } = await iter.next();
            expect(line).toContain(`ready ${dirCount * filesPerDir}`);
            // Modify files across multiple directories simultaneously
            const writes = [];
            for (let d = 0; d < 10; d++) {
                writes.push(
                    Bun.write(
                        join(tmpdir, `pkg${d}`, "f0.js"),
                        `export const x = 'updated_${d}';`,
                    ),
                );
            }
            await Promise.all(writes);
            const { value: reloadLine } = await iter.next();
            expect(reloadLine).toContain(`ready ${dirCount * filesPerDir}`);
            proc.kill();
        },
        30000,
    );
});
```
