### PR TITLE
fix(Response): initialize #url field to prevent crash on Windows

### DIFF
--- a/src/bun.js/webcore/Response.zig
+++ b/src/bun.js/webcore/Response.zig
@@ -668,6 +668,7 @@ pub fn constructError(
             .#body = Body{
                 .value = .{ .Empty = {} },
             },
+            .#url = bun.String.empty,
         },
     );
 
@@ -751,6 +752,7 @@ pub fn constructor(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame, j
     var response = bun.new(Response, Response{
         .#body = body,
         .#init = _init,
+        .#url = bun.String.empty,
         .#js_ref = .initWeak(js_this),
     });
 


### PR DESCRIPTION
## Summary
- Fix crash on Windows when constructing Response objects
- The `#url` field was not initialized in `Response.constructor()` and `Response.constructError()`, leaving garbage memory
- When `calculateEstimatedByteSize()` called `byteSlice()` on the uninitialized `String`, it caused a "switch on corrupt value" panic

## Stack trace from crash report
```
panic: switch on corrupt value

string.zig:663: byteSlice
Response.zig:101: calculateEstimatedByteSize
ZigGeneratedClasses.zig:17038: ResponseClass__construct
```

## Test plan
- [x] Existing Response tests pass (`bun bd test test/js/web/fetch/response.test.ts`)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)