### PR TITLE
fix(sql): correct MySQL unix socket error message

### DIFF
--- a/src/sql/mysql/js/JSMySQLConnection.zig
+++ b/src/sql/mysql/js/JSMySQLConnection.zig
@@ -464,7 +464,7 @@ pub fn createInstance(globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFra
             ptr.#connection.setSocket(.{
                 .SocketTCP = uws.SocketTCP.connectUnixAnon(path, ctx, ptr, false) catch |err| {
                     ptr.deref();
-                    return globalObject.throwError(err, "failed to connect to postgresql");
+                    return globalObject.throwError(err, "failed to connect to mysql");
                 },
             });
         } else {

--- a/test/regression/issue/26648.test.ts
+++ b/test/regression/issue/26648.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("MySQL unix socket error message should not say 'postgresql'", async () => {
+  using dir = tempDir("mysql-socket-test", {
+    "test.ts": `
+import { join } from "path";
+// Create a regular file (not a socket) to trigger the connection error
+const fakeSockPath = join(import.meta.dirname, "fake.sock");
+await Bun.write(fakeSockPath, "");
+
+const conn = new Bun.SQL({
+  adapter: 'mysql',
+  path: fakeSockPath,
+  username: 'root',
+  database: 'test'
+});
+
+try {
+  await conn\`select 1\`;
+} catch(e) {
+  console.log(e.message);
+}
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const output = stdout + stderr;
+  expect(output).not.toContain("postgresql");
+  expect(output).toContain("mysql");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fixes incorrect error message when connecting to MySQL via unix socket
- Changed "failed to connect to postgresql" to "failed to connect to mysql"

Fixes #26648

## Test plan
- [x] Added regression test `test/regression/issue/26648.test.ts`
- [x] Verified test fails with system Bun (has the bug)
- [x] Verified test passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)