### PR TITLE
perf(markdown): cache tag strings in React renderer

### DIFF
--- a/bench/snippets/markdown.mjs
+++ b/bench/snippets/markdown.mjs
@@ -105,6 +105,10 @@ summary(() => {
     bench(`small (${small.length} chars) - Bun.markdown.render`, () => {
       return Bun.markdown.render(small, renderCallbacks);
     });
+
+    bench(`small (${small.length} chars) - Bun.markdown.react`, () => {
+      return Bun.markdown.react(small);
+    });
   }
 
   bench(`small (${small.length} chars) - marked`, () => {
@@ -125,6 +129,10 @@ summary(() => {
     bench(`medium (${medium.length} chars) - Bun.markdown.render`, () => {
       return Bun.markdown.render(medium, renderCallbacks);
     });
+
+    bench(`medium (${medium.length} chars) - Bun.markdown.react`, () => {
+      return Bun.markdown.react(medium);
+    });
   }
 
   bench(`medium (${medium.length} chars) - marked`, () => {
@@ -144,6 +152,10 @@ summary(() => {
 
     bench(`large (${large.length} chars) - Bun.markdown.render`, () => {
       return Bun.markdown.render(large, renderCallbacks);
+    });
+
+    bench(`large (${large.length} chars) - Bun.markdown.react`, () => {
+      return Bun.markdown.react(large);
     });
   }
 

--- a/src/bun.js/api/MarkdownObject.zig
+++ b/src/bun.js/api/MarkdownObject.zig
@@ -464,8 +464,8 @@ const ParseRenderer = struct {
         const entry = self.#stack.pop().?;
         const g = self.#globalObject;
 
-        // Determine HTML tag name
-        const type_str: []const u8 = blockTypeName(block_type, entry.data);
+        // Determine HTML tag index for cached string
+        const tag_index = getBlockTypeTag(block_type, entry.data);
 
         // For headings, compute slug before counting props
         const slug: ?[]const u8 = if (block_type == .h) self.#heading_tracker.leaveHeading(bun.default_allocator) else null;
@@ -496,7 +496,7 @@ const ParseRenderer = struct {
 
         // Build React element — use component override as type if set
         const component = self.getBlockComponent(block_type, entry.data);
-        const type_val: JSValue = if (component != .zero) component else try bun.String.createUTF8ForJS(g, type_str);
+        const type_val: JSValue = if (component != .zero) component else getCachedTagString(g, tag_index);
 
         const props = JSValue.createEmptyObject(g, props_count);
         self.#marked_args.append(props);
@@ -572,7 +572,7 @@ const ParseRenderer = struct {
         const entry = self.#stack.pop().?;
         const g = self.#globalObject;
 
-        const type_str: []const u8 = spanTypeName(span_type);
+        const tag_index = getSpanTypeTag(span_type);
 
         // Count props fields: always children (or alt for img) + metadata
         var props_count: usize = 1; // children (or alt for img)
@@ -592,7 +592,7 @@ const ParseRenderer = struct {
 
         // Build React element: { $$typeof, type, key, ref, props }
         const component = self.getSpanComponent(span_type);
-        const type_val: JSValue = if (component != .zero) component else try bun.String.createUTF8ForJS(g, type_str);
+        const type_val: JSValue = if (component != .zero) component else getCachedTagString(g, tag_index);
 
         const props = JSValue.createEmptyObject(g, props_count);
         self.#marked_args.append(props);
@@ -675,7 +675,7 @@ const ParseRenderer = struct {
         switch (text_type) {
             .br => {
                 const br_component = self.#components.br;
-                const br_type: JSValue = if (br_component != .zero) br_component else try bun.String.createUTF8ForJS(g, "br");
+                const br_type: JSValue = if (br_component != .zero) br_component else getCachedTagString(g, .br);
                 const empty_props = JSValue.createEmptyObject(g, 0);
                 self.#marked_args.append(empty_props);
                 const obj = self.createElement(br_type, empty_props);
@@ -704,53 +704,6 @@ const ParseRenderer = struct {
                 try parent.children.push(g, str);
             },
         }
-    }
-
-    // ========================================
-    // Type name mappings
-    // ========================================
-
-    fn blockTypeName(block_type: md.BlockType, data: u32) []const u8 {
-        return switch (block_type) {
-            .h => switch (data) {
-                1 => "h1",
-                2 => "h2",
-                3 => "h3",
-                4 => "h4",
-                5 => "h5",
-                else => "h6",
-            },
-            .p => "p",
-            .quote => "blockquote",
-            .ul => "ul",
-            .ol => "ol",
-            .li => "li",
-            .code => "pre",
-            .hr => "hr",
-            .html => "html",
-            .table => "table",
-            .thead => "thead",
-            .tbody => "tbody",
-            .tr => "tr",
-            .th => "th",
-            .td => "td",
-            .doc => "div",
-        };
-    }
-
-    fn spanTypeName(span_type: md.SpanType) []const u8 {
-        return switch (span_type) {
-            .em => "em",
-            .strong => "strong",
-            .a => "a",
-            .img => "img",
-            .code => "code",
-            .del => "del",
-            .latexmath => "math",
-            .latexmath_display => "math",
-            .wikilink => "a",
-            .u => "u",
-        };
     }
 };
 
@@ -1133,3 +1086,86 @@ const md = bun.md;
 const jsc = bun.jsc;
 const JSValue = jsc.JSValue;
 const ZigString = jsc.ZigString;
+
+// Cached tag string indices - must match BunMarkdownTagStrings.h
+const TagIndex = enum(u8) {
+    h1 = 0,
+    h2 = 1,
+    h3 = 2,
+    h4 = 3,
+    h5 = 4,
+    h6 = 5,
+    p = 6,
+    blockquote = 7,
+    ul = 8,
+    ol = 9,
+    li = 10,
+    pre = 11,
+    hr = 12,
+    html = 13,
+    table = 14,
+    thead = 15,
+    tbody = 16,
+    tr = 17,
+    th = 18,
+    td = 19,
+    div = 20,
+    em = 21,
+    strong = 22,
+    a = 23,
+    img = 24,
+    code = 25,
+    del = 26,
+    math = 27,
+    u = 28,
+    br = 29,
+};
+
+extern fn BunMarkdownTagStrings__getTagString(*jsc.JSGlobalObject, u8) JSValue;
+
+fn getCachedTagString(globalObject: *jsc.JSGlobalObject, tag: TagIndex) JSValue {
+    return BunMarkdownTagStrings__getTagString(globalObject, @intFromEnum(tag));
+}
+
+fn getBlockTypeTag(block_type: md.BlockType, data: u32) TagIndex {
+    return switch (block_type) {
+        .h => switch (data) {
+            1 => .h1,
+            2 => .h2,
+            3 => .h3,
+            4 => .h4,
+            5 => .h5,
+            else => .h6,
+        },
+        .p => .p,
+        .quote => .blockquote,
+        .ul => .ul,
+        .ol => .ol,
+        .li => .li,
+        .code => .pre,
+        .hr => .hr,
+        .html => .html,
+        .table => .table,
+        .thead => .thead,
+        .tbody => .tbody,
+        .tr => .tr,
+        .th => .th,
+        .td => .td,
+        .doc => .div,
+    };
+}
+
+fn getSpanTypeTag(span_type: md.SpanType) TagIndex {
+    return switch (span_type) {
+        .em => .em,
+        .strong => .strong,
+        .a => .a,
+        .img => .img,
+        .code => .code,
+        .del => .del,
+        .latexmath => .math,
+        .latexmath_display => .math,
+        .wikilink => .a,
+        .u => .u,
+    };
+}

--- a/src/bun.js/api/MarkdownObject.zig
+++ b/src/bun.js/api/MarkdownObject.zig
@@ -1078,15 +1078,6 @@ fn extractLanguage(src_text: []const u8, info_beg: u32) []const u8 {
     return "";
 }
 
-const std = @import("std");
-
-const bun = @import("bun");
-const md = bun.md;
-
-const jsc = bun.jsc;
-const JSValue = jsc.JSValue;
-const ZigString = jsc.ZigString;
-
 // Cached tag string indices - must match BunMarkdownTagStrings.h
 const TagIndex = enum(u8) {
     h1 = 0,
@@ -1169,3 +1160,12 @@ fn getSpanTypeTag(span_type: md.SpanType) TagIndex {
         .u => .u,
     };
 }
+
+const std = @import("std");
+
+const bun = @import("bun");
+const md = bun.md;
+
+const jsc = bun.jsc;
+const JSValue = jsc.JSValue;
+const ZigString = jsc.ZigString;

--- a/src/bun.js/bindings/BunMarkdownTagStrings.cpp
+++ b/src/bun.js/bindings/BunMarkdownTagStrings.cpp
@@ -11,10 +11,10 @@
 namespace Bun {
 using namespace JSC;
 
-#define MARKDOWN_TAG_STRINGS_LAZY_PROPERTY_DEFINITION(name, str, idx) \
-    this->m_strings[idx].initLater( \
+#define MARKDOWN_TAG_STRINGS_LAZY_PROPERTY_DEFINITION(name, str, idx)              \
+    this->m_strings[idx].initLater(                                                \
         [](const JSC::LazyProperty<JSGlobalObject, JSString>::Initializer& init) { \
-            init.set(jsOwnedString(init.vm, str)); \
+            init.set(jsOwnedString(init.vm, str));                                 \
         });
 
 #define MARKDOWN_TAG_STRINGS_LAZY_PROPERTY_VISITOR(name, str, idx) \
@@ -47,9 +47,10 @@ extern "C" JSC::EncodedJSValue BunMarkdownTagStrings__getTagString(Zig::GlobalOb
     // Use a switch to call the appropriate accessor
     switch (tagIndex) {
 #define MARKDOWN_TAG_STRINGS_CASE(name, str, idx) \
-    case idx: return JSC::JSValue::encode(tagStrings.name##String(globalObject));
+    case idx:                                     \
+        return JSC::JSValue::encode(tagStrings.name##String(globalObject));
 
-    MARKDOWN_TAG_STRINGS_EACH_NAME(MARKDOWN_TAG_STRINGS_CASE)
+        MARKDOWN_TAG_STRINGS_EACH_NAME(MARKDOWN_TAG_STRINGS_CASE)
 
 #undef MARKDOWN_TAG_STRINGS_CASE
     default:

--- a/src/bun.js/bindings/BunMarkdownTagStrings.cpp
+++ b/src/bun.js/bindings/BunMarkdownTagStrings.cpp
@@ -1,0 +1,58 @@
+#include "root.h"
+#include "BunMarkdownTagStrings.h"
+#include <JavaScriptCore/JSString.h>
+#include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/LazyProperty.h>
+#include <JavaScriptCore/LazyPropertyInlines.h>
+#include "ZigGlobalObject.h"
+#include <JavaScriptCore/SlotVisitorInlines.h>
+#include <JavaScriptCore/VMTrapsInlines.h>
+
+namespace Bun {
+using namespace JSC;
+
+#define MARKDOWN_TAG_STRINGS_LAZY_PROPERTY_DEFINITION(name, str, idx) \
+    this->m_strings[idx].initLater( \
+        [](const JSC::LazyProperty<JSGlobalObject, JSString>::Initializer& init) { \
+            init.set(jsOwnedString(init.vm, str)); \
+        });
+
+#define MARKDOWN_TAG_STRINGS_LAZY_PROPERTY_VISITOR(name, str, idx) \
+    this->m_strings[idx].visit(visitor);
+
+void MarkdownTagStrings::initialize()
+{
+    MARKDOWN_TAG_STRINGS_EACH_NAME(MARKDOWN_TAG_STRINGS_LAZY_PROPERTY_DEFINITION)
+}
+
+template<typename Visitor>
+void MarkdownTagStrings::visit(Visitor& visitor)
+{
+    MARKDOWN_TAG_STRINGS_EACH_NAME(MARKDOWN_TAG_STRINGS_LAZY_PROPERTY_VISITOR)
+}
+
+template void MarkdownTagStrings::visit(JSC::AbstractSlotVisitor&);
+template void MarkdownTagStrings::visit(JSC::SlotVisitor&);
+
+} // namespace Bun
+
+// C API for Zig bindings
+extern "C" JSC::EncodedJSValue BunMarkdownTagStrings__getTagString(Zig::GlobalObject* globalObject, uint8_t tagIndex)
+{
+    if (tagIndex >= MARKDOWN_TAG_STRINGS_COUNT)
+        return JSC::JSValue::encode(JSC::jsUndefined());
+
+    auto& tagStrings = globalObject->markdownTagStrings();
+
+    // Use a switch to call the appropriate accessor
+    switch (tagIndex) {
+#define MARKDOWN_TAG_STRINGS_CASE(name, str, idx) \
+    case idx: return JSC::JSValue::encode(tagStrings.name##String(globalObject));
+
+    MARKDOWN_TAG_STRINGS_EACH_NAME(MARKDOWN_TAG_STRINGS_CASE)
+
+#undef MARKDOWN_TAG_STRINGS_CASE
+    default:
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+}

--- a/src/bun.js/bindings/BunMarkdownTagStrings.h
+++ b/src/bun.js/bindings/BunMarkdownTagStrings.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <JavaScriptCore/JSString.h>
+#include <JavaScriptCore/LazyProperty.h>
+
+// Markdown HTML tag names cached as JSStrings
+// These are commonly reused when rendering markdown to React elements
+
+// clang-format off
+#define MARKDOWN_TAG_STRINGS_EACH_NAME(macro) \
+    macro(h1, "h1"_s, 0) \
+    macro(h2, "h2"_s, 1) \
+    macro(h3, "h3"_s, 2) \
+    macro(h4, "h4"_s, 3) \
+    macro(h5, "h5"_s, 4) \
+    macro(h6, "h6"_s, 5) \
+    macro(p, "p"_s, 6) \
+    macro(blockquote, "blockquote"_s, 7) \
+    macro(ul, "ul"_s, 8) \
+    macro(ol, "ol"_s, 9) \
+    macro(li, "li"_s, 10) \
+    macro(pre, "pre"_s, 11) \
+    macro(hr, "hr"_s, 12) \
+    macro(html, "html"_s, 13) \
+    macro(table, "table"_s, 14) \
+    macro(thead, "thead"_s, 15) \
+    macro(tbody, "tbody"_s, 16) \
+    macro(tr, "tr"_s, 17) \
+    macro(th, "th"_s, 18) \
+    macro(td, "td"_s, 19) \
+    macro(div, "div"_s, 20) \
+    macro(em, "em"_s, 21) \
+    macro(strong, "strong"_s, 22) \
+    macro(a, "a"_s, 23) \
+    macro(img, "img"_s, 24) \
+    macro(code, "code"_s, 25) \
+    macro(del, "del"_s, 26) \
+    macro(math, "math"_s, 27) \
+    macro(u, "u"_s, 28) \
+    macro(br, "br"_s, 29)
+// clang-format on
+
+#define MARKDOWN_TAG_STRINGS_COUNT 30
+
+namespace Bun {
+
+using namespace JSC;
+
+class MarkdownTagStrings {
+public:
+#define MARKDOWN_TAG_STRINGS_ACCESSOR_DEFINITION(name, str, idx) \
+    JSC::JSString* name##String(JSC::JSGlobalObject* globalObject) \
+    { \
+        return m_strings[idx].getInitializedOnMainThread(globalObject); \
+    }
+
+    MARKDOWN_TAG_STRINGS_EACH_NAME(MARKDOWN_TAG_STRINGS_ACCESSOR_DEFINITION)
+
+#undef MARKDOWN_TAG_STRINGS_ACCESSOR_DEFINITION
+
+    void initialize();
+
+    template<typename Visitor>
+    void visit(Visitor& visitor);
+
+private:
+    JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSString> m_strings[MARKDOWN_TAG_STRINGS_COUNT];
+};
+
+} // namespace Bun

--- a/src/bun.js/bindings/BunMarkdownTagStrings.h
+++ b/src/bun.js/bindings/BunMarkdownTagStrings.h
@@ -48,9 +48,9 @@ using namespace JSC;
 
 class MarkdownTagStrings {
 public:
-#define MARKDOWN_TAG_STRINGS_ACCESSOR_DEFINITION(name, str, idx) \
-    JSC::JSString* name##String(JSC::JSGlobalObject* globalObject) \
-    { \
+#define MARKDOWN_TAG_STRINGS_ACCESSOR_DEFINITION(name, str, idx)        \
+    JSC::JSString* name##String(JSC::JSGlobalObject* globalObject)      \
+    {                                                                   \
         return m_strings[idx].getInitializedOnMainThread(globalObject); \
     }
 

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -1699,6 +1699,7 @@ void GlobalObject::finishCreation(VM& vm)
     m_commonStrings.initialize();
     m_http2CommonStrings.initialize();
     m_bakeAdditions.initialize();
+    m_markdownTagStrings.initialize();
 
     Bun::addNodeModuleConstructorProperties(vm, this);
     m_JSNodeHTTPServerSocketStructure.initLater(

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -58,6 +58,7 @@ struct node_module;
 #include "headers-handwritten.h"
 #include "BunCommonStrings.h"
 #include "BunHttp2CommonStrings.h"
+#include "BunMarkdownTagStrings.h"
 #include "BunGlobalScope.h"
 #include <js_native_api.h>
 #include <node_api.h>
@@ -526,6 +527,7 @@ public:
     V(private, std::unique_ptr<WebCore::DOMConstructors>, m_constructors)                                    \
     V(private, Bun::CommonStrings, m_commonStrings)                                                          \
     V(private, Bun::Http2CommonStrings, m_http2CommonStrings)                                                \
+    V(private, Bun::MarkdownTagStrings, m_markdownTagStrings)                                                \
                                                                                                              \
     /* JSC's hashtable code-generator tries to access these properties, so we make them public. */           \
     /* However, we'd like it better if they could be protected. */                                           \
@@ -716,6 +718,7 @@ public:
 
     Bun::CommonStrings& commonStrings() { return m_commonStrings; }
     Bun::Http2CommonStrings& http2CommonStrings() { return m_http2CommonStrings; }
+    Bun::MarkdownTagStrings& markdownTagStrings() { return m_markdownTagStrings; }
 #include "ZigGeneratedClasses+lazyStructureHeader.h"
 
     void finishCreation(JSC::VM&);


### PR DESCRIPTION
## Summary

Cache frequently-used HTML tag strings (div, p, h1-h6, etc.) in `GlobalObject` using `LazyProperty<JSGlobalObject, JSString>` instead of creating new JSStrings on every React element creation in `Bun.markdown.react()`.

## Changes

- Added `BunMarkdownTagStrings.h/.cpp` with 30 cached tag strings
- Modified `MarkdownObject.zig` to use cached strings via C API
- Integrated with `ZigGlobalObject` for proper GC visiting

## Benchmark Results

All benchmarks performed on Apple M4 Max with release builds.

### mitata Benchmark (Bun.markdown.react)

| Size | Main | Feature | Improvement |
|------|------|---------|-------------|
| small (121 chars) | 3.20 µs | 2.30 µs | **28% faster** |
| medium (1039 chars) | 15.09 µs | 14.02 µs | **7% faster** |
| large (20780 chars) | 288.48 µs | 267.14 µs | **7.4% faster** |

### Heap Profile

| Metric | Main | Feature | Improvement |
|--------|------|---------|-------------|
| Heap size | 500.7 KB | 469.7 KB | **6% reduction** |
| Object count | 12,000 | 10,315 | **14% reduction** |
| String count | 4,248 | 2,563 | **40% reduction** |
| String size | 97.1 KB | 65.8 KB | **32% reduction** |

### HTTP Request Benchmark (ab -n 10000 -c 20)

| Metric | Main | Feature | Improvement |
|--------|------|---------|-------------|
| Requests/sec | 7,710 | 8,174 | **6% faster** |
| Time/request | 2.59 ms | 2.45 ms | **5% faster** |
| p99 latency | 6 ms | 3 ms | **50% improvement** |

## Technical Details

The optimization uses JSC's `LazyProperty` pattern (similar to `BunCommonStrings` and `BunHttp2CommonStrings`) to lazily initialize and cache tag strings on first use. This avoids repeated `bun.String.createUTF8ForJS` calls which allocate new JSStrings for the same tag names on every markdown element.