### PR TITLE
fix(sql): recognize PGUSERNAME environment variable

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -692,7 +692,8 @@ function parseOptions(
       break;
     }
     case "postgres": {
-      username ||= options.username || options.user || env.PG_USER || env.PGUSER || env.USER || "postgres";
+      username ||=
+        options.username || options.user || env.PGUSERNAME || env.PG_USER || env.PGUSER || env.USER || "postgres";
       break;
     }
   }

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -25,7 +25,7 @@ describe("SQL adapter environment variable precedence", () => {
     'MARIADB_URL', 'MARIADBURL',
     'TLS_MARIADB_DATABASE_URL',
     'SQLITE_URL', 'SQLITEURL',
-    'PGHOST', 'PGUSER', 'PGPASSWORD', 'PGDATABASE', 'PGPORT',
+    'PGHOST', 'PGUSER', 'PGUSERNAME', 'PGPASSWORD', 'PGDATABASE', 'PGPORT',
     'MYSQL_HOST', 'MYSQL_USER', 'MYSQL_PASSWORD', 'MYSQL_DATABASE', 'MYSQL_PORT'
   ];
 
@@ -140,6 +140,30 @@ describe("SQL adapter environment variable precedence", () => {
     });
 
     expect(options.options.username).toBe("postgres-user");
+  });
+
+  test("PGUSERNAME should take precedence over PGUSER (issue #26684)", () => {
+    process.env.USER = "generic-user";
+    process.env.PGUSER = "pguser-fallback";
+    process.env.PGUSERNAME = "pgusername-primary";
+
+    const options = new SQL({
+      adapter: "postgres",
+    });
+
+    expect(options.options.username).toBe("pgusername-primary");
+  });
+
+  test("PGUSER should work when PGUSERNAME is not set", () => {
+    process.env.USER = "generic-user";
+    process.env.PGUSER = "pguser-value";
+    // PGUSERNAME is not set
+
+    const options = new SQL({
+      adapter: "postgres",
+    });
+
+    expect(options.options.username).toBe("pguser-value");
   });
 
   test("should infer mysql adapter from MYSQL_URL env var", () => {


### PR DESCRIPTION
## Summary
- Add `PGUSERNAME` to the PostgreSQL username resolution logic
- This matches the documented behavior at https://bun.sh/docs/runtime/sql#postgresql-environment-variables
- The code previously only checked for `PG_USER` and `PGUSER`, but the docs list `PGUSERNAME` as the primary environment variable

## Test plan
- [x] Added tests for `PGUSERNAME` taking precedence over `PGUSER`
- [x] Added test verifying `PGUSER` still works when `PGUSERNAME` is not set
- [x] All 40 tests in `test/js/sql/adapter-env-var-precedence.test.ts` pass

Fixes #26684

🤖 Generated with [Claude Code](https://claude.com/claude-code)