### PR TITLE
Add Encore Cloud deployment guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -306,6 +306,7 @@
               "/guides/deployment/vercel",
               "/guides/deployment/railway",
               "/guides/deployment/render",
+              "/guides/deployment/encore",
               "/guides/deployment/aws-lambda",
               "/guides/deployment/digital-ocean",
               "/guides/deployment/google-cloud-run"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -362,6 +362,7 @@
               "/guides/ecosystem/drizzle",
               "/guides/ecosystem/gel",
               "/guides/ecosystem/elysia",
+              "/guides/ecosystem/encore",
               "/guides/ecosystem/express",
               "/guides/ecosystem/hono",
               "/guides/ecosystem/mongoose",

--- a/docs/guides/deployment/encore.mdx
+++ b/docs/guides/deployment/encore.mdx
@@ -1,0 +1,202 @@
+---
+title: Deploy a Bun application on Encore Cloud
+description: Deploy Bun applications to Encore Cloud with automatic infrastructure provisioning, built-in observability, and zero DevOps configuration.
+sidebarTitle: Deploy on Encore Cloud
+mode: center
+---
+
+[Encore Cloud](https://encore.cloud) is a development platform that automatically provisions infrastructure for your backend applications. Deploy to Encore's free cloud hosting, or connect your own AWS/GCP account for production workloads.
+
+This guide walks through deploying a Bun application with Encore Cloud.
+
+<Note>Bun support in Encore is currently experimental. Enable it by adding `"experiments": ["bun-runtime"]` to your `encore.app` file.</Note>
+
+---
+
+**Prerequisites**:
+
+- An [Encore account](https://app.encore.dev)
+- Encore CLI installed
+
+---
+
+## Step 1: Install Encore CLI
+
+```bash terminal icon="terminal"
+# macOS
+brew install encoredev/tap/encore
+
+# Linux
+curl -L https://encore.dev/install.sh | bash
+
+# Windows
+iwr https://encore.dev/install.ps1 | iex
+```
+
+---
+
+## Step 2: Create your app
+
+Create a new Encore app:
+
+```bash terminal icon="terminal"
+encore app create my-app --example=ts/hello-world
+cd my-app
+```
+
+---
+
+## Step 3: Enable Bun runtime
+
+Add the Bun experiment to your `encore.app` file:
+
+```json encore.app icon="file-json"
+{
+  "id": "my-app",
+  "experiments": ["bun-runtime"]
+}
+```
+
+---
+
+## Step 4: Define your API
+
+Create a service with an API endpoint:
+
+```ts hello/hello.ts icon="/icons/typescript.svg"
+import { api } from "encore.dev/api";
+
+export const world = api(
+  { expose: true, method: "GET", path: "/hello/:name" },
+  async ({ name }: { name: string }) => {
+    return { message: `Hello, ${name}!` };
+  }
+);
+```
+
+---
+
+## Step 5: Run locally
+
+Start the local development server:
+
+```bash terminal icon="terminal"
+encore run
+```
+
+Open [localhost:4000/hello/world](http://localhost:4000/hello/world) to see your API.
+
+The local dashboard at [localhost:9400](http://localhost:9400) shows traces, logs, and auto-generated API docs.
+
+---
+
+## Step 6: Deploy
+
+Deploy to Encore Cloud:
+
+```bash terminal icon="terminal"
+git add -A .
+git commit -m "Initial commit"
+git push encore
+```
+
+By default, your app deploys to Encore Cloud's free hosting. For production workloads, connect your AWS or GCP account in the Encore dashboard and Encore provisions infrastructure there instead.
+
+---
+
+## Infrastructure primitives
+
+Encore provides type-safe infrastructure primitives. You write the same code for all environments, and Encore provisions the appropriate services depending on where you deploy.
+
+### Databases
+
+```ts icon="/icons/typescript.svg"
+import { SQLDatabase } from "encore.dev/storage/sqldb";
+
+const db = new SQLDatabase("mydb", { migrations: "./migrations" });
+```
+
+| Local  | Encore Cloud (free) | AWS        | GCP       |
+| ------ | ------------------- | ---------- | --------- |
+| Docker | Managed Postgres    | Amazon RDS | Cloud SQL |
+
+### Pub/Sub
+
+```ts icon="/icons/typescript.svg"
+import { Topic, Subscription } from "encore.dev/pubsub";
+
+const signups = new Topic<SignupEvent>("signups");
+
+const _ = new Subscription(signups, "send-welcome", {
+  handler: sendWelcomeEmail,
+});
+```
+
+| Local     | Encore Cloud (free) | AWS       | GCP         |
+| --------- | ------------------- | --------- | ----------- |
+| In-memory | GCP Pub/Sub         | SNS + SQS | GCP Pub/Sub |
+
+### Object storage
+
+```ts icon="/icons/typescript.svg"
+import { Bucket } from "encore.dev/storage/objects";
+
+const uploads = new Bucket("uploads", { versioned: false });
+```
+
+| Local      | Encore Cloud (free) | AWS             | GCP             |
+| ---------- | ------------------- | --------------- | --------------- |
+| Local disk | Managed             | S3 + CloudFront | GCS + Cloud CDN |
+
+### Caches
+
+```ts icon="/icons/typescript.svg"
+import { CacheCluster } from "encore.dev/storage/cache";
+
+const cluster = new CacheCluster("my-cache", { evictionPolicy: "allkeys-lru" });
+```
+
+| Local     | Encore Cloud (free) | AWS         | GCP         |
+| --------- | ------------------- | ----------- | ----------- |
+| In-memory | In-memory           | ElastiCache | Memorystore |
+
+### Cron jobs
+
+```ts icon="/icons/typescript.svg"
+import { Cron } from "encore.dev/cron";
+
+const _ = new Cron("daily-cleanup", {
+  title: "Daily cleanup",
+  schedule: "0 0 * * *",
+  endpoint: cleanup,
+});
+```
+
+| Local    | Encore Cloud (free) | AWS     | GCP     |
+| -------- | ------------------- | ------- | ------- |
+| Disabled | Managed             | Managed | Managed |
+
+### Secrets
+
+```bash terminal icon="terminal"
+encore secret set --type prod MySecretKey
+```
+
+```ts icon="/icons/typescript.svg"
+import { secret } from "encore.dev/config";
+
+const mySecret = secret("MySecretKey");
+```
+
+| Local         | Encore Cloud (free) | AWS             | GCP            |
+| ------------- | ------------------- | --------------- | -------------- |
+| .secrets file | Managed             | Secrets Manager | Secret Manager |
+
+---
+
+## Learn more
+
+- [Encore Cloud](https://encore.cloud)
+- [Encore Documentation](https://encore.dev/docs)
+- [Encore Templates](https://encore.dev/templates)
+- [Encore Discord](https://encore.dev/discord)

--- a/docs/guides/deployment/encore.mdx
+++ b/docs/guides/deployment/encore.mdx
@@ -116,9 +116,9 @@ import { SQLDatabase } from "encore.dev/storage/sqldb";
 const db = new SQLDatabase("mydb", { migrations: "./migrations" });
 ```
 
-| Local  | Encore Cloud (free) | AWS        | GCP       |
-| ------ | ------------------- | ---------- | --------- |
-| Docker | Managed Postgres    | Amazon RDS | Cloud SQL |
+| Local  | AWS        | GCP       |
+| ------ | ---------- | --------- |
+| Docker | Amazon RDS | Cloud SQL |
 
 ### Pub/Sub
 
@@ -132,9 +132,9 @@ const _ = new Subscription(signups, "send-welcome", {
 });
 ```
 
-| Local     | Encore Cloud (free) | AWS       | GCP         |
-| --------- | ------------------- | --------- | ----------- |
-| In-memory | GCP Pub/Sub         | SNS + SQS | GCP Pub/Sub |
+| Local     | AWS       | GCP         |
+| --------- | --------- | ----------- |
+| In-memory | SNS + SQS | GCP Pub/Sub |
 
 ### Object storage
 
@@ -144,9 +144,9 @@ import { Bucket } from "encore.dev/storage/objects";
 const uploads = new Bucket("uploads", { versioned: false });
 ```
 
-| Local      | Encore Cloud (free) | AWS             | GCP             |
-| ---------- | ------------------- | --------------- | --------------- |
-| Local disk | Managed             | S3 + CloudFront | GCS + Cloud CDN |
+| Local      | AWS             | GCP             |
+| ---------- | --------------- | --------------- |
+| Local disk | S3 + CloudFront | GCS + Cloud CDN |
 
 ### Caches
 
@@ -156,9 +156,9 @@ import { CacheCluster } from "encore.dev/storage/cache";
 const cluster = new CacheCluster("my-cache", { evictionPolicy: "allkeys-lru" });
 ```
 
-| Local     | Encore Cloud (free) | AWS         | GCP         |
-| --------- | ------------------- | ----------- | ----------- |
-| In-memory | In-memory           | ElastiCache | Memorystore |
+| Local     | AWS         | GCP         |
+| --------- | ----------- | ----------- |
+| In-memory | ElastiCache | Memorystore |
 
 ### Cron jobs
 
@@ -172,9 +172,9 @@ const _ = new Cron("daily-cleanup", {
 });
 ```
 
-| Local    | Encore Cloud (free) | AWS     | GCP     |
-| -------- | ------------------- | ------- | ------- |
-| Disabled | Managed             | Managed | Managed |
+| Local    | AWS     | GCP     |
+| -------- | ------- | ------- |
+| Disabled | Managed | Managed |
 
 ### Secrets
 
@@ -188,9 +188,9 @@ import { secret } from "encore.dev/config";
 const mySecret = secret("MySecretKey");
 ```
 
-| Local         | Encore Cloud (free) | AWS             | GCP            |
-| ------------- | ------------------- | --------------- | -------------- |
-| .secrets file | Managed             | Secrets Manager | Secret Manager |
+| Local         | AWS             | GCP            |
+| ------------- | --------------- | -------------- |
+| .secrets file | Secrets Manager | Secret Manager |
 
 ---
 

--- a/docs/guides/ecosystem/encore.mdx
+++ b/docs/guides/ecosystem/encore.mdx
@@ -1,0 +1,53 @@
+---
+title: Build a backend using Encore and Bun
+sidebarTitle: Encore with Bun
+mode: center
+---
+
+[Encore](https://encore.dev) is an open source backend framework for TypeScript with built-in infrastructure and observability.
+
+<Note>Bun support in Encore is experimental. Enable it by adding `"experiments": ["bun-runtime"]` to your `encore.app` file.</Note>
+
+```ts hello/hello.ts icon="/icons/typescript.svg"
+import { api } from "encore.dev/api";
+
+export const world = api(
+  { expose: true, method: "GET", path: "/hello/:name" },
+  async ({ name }: { name: string }) => {
+    return { message: `Hello, ${name}!` };
+  }
+);
+```
+
+---
+
+Install the Encore CLI and create a new app:
+
+```bash terminal icon="terminal"
+brew install encoredev/tap/encore
+encore app create my-app --example=ts/hello-world
+cd my-app
+```
+
+---
+
+Enable Bun in `encore.app`:
+
+```json encore.app icon="file-json"
+{
+  "id": "my-app",
+  "experiments": ["bun-runtime"]
+}
+```
+
+---
+
+Run locally and open [localhost:4000](http://localhost:4000):
+
+```bash terminal icon="terminal"
+encore run
+```
+
+---
+
+Refer to [Encore's documentation](https://encore.dev/docs) for more, or see the [deployment guide](/docs/guides/deployment/encore) for deploying to Encore Cloud.


### PR DESCRIPTION
Adds a deployment guide for Encore Cloud under guides/deployment.

Covers:
- CLI installation
- Project setup with experimental Bun runtime flag
- Local development
- Deployment to Encore Cloud (free tier) or own AWS/GCP
- Infrastructure primitives (databases, pub/sub, object storage, caches, cron, secrets) with mapping tables showing what each provisions across environments