### PR TITLE
feat(test): add Symbol.dispose support to mock/spyOn

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -2179,6 +2179,7 @@ declare module "bun:test" {
       mockResolvedValueOnce(value: ResolveType<T>): this;
       mockRejectedValue(value: RejectType<T>): this;
       mockRejectedValueOnce(value: RejectType<T>): this;
+      [Symbol.dispose](): void;
     }
 
     // export type MockMetadata<T, MetadataType = MockMetadataType> = {

--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -988,6 +988,10 @@ void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* g
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 
     this->putDirect(vm, Identifier::fromString(vm, "_isMockFunction"_s), jsBoolean(true), 0);
+
+    // Support `using spy = spyOn(...)` — auto-restores when leaving scope.
+    JSValue restoreFn = this->getDirect(vm, Identifier::fromString(vm, "mockRestore"_s));
+    this->putDirect(vm, vm.propertyNames->disposeSymbol, restoreFn, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsMockFunctionGetMockImplementation, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))

--- a/test/js/bun/test/mock-disposable.test.ts
+++ b/test/js/bun/test/mock-disposable.test.ts
@@ -1,0 +1,35 @@
+import { expect, mock, spyOn, test } from "bun:test";
+
+test("spyOn returns a disposable that calls mockRestore", () => {
+  const obj = { method: () => "original" };
+
+  {
+    using spy = spyOn(obj, "method").mockReturnValue("mocked");
+    expect(obj.method()).toBe("mocked");
+    expect(spy).toHaveBeenCalledTimes(1);
+  }
+
+  expect(obj.method()).toBe("original");
+});
+
+test("mock() returns a disposable that calls mockRestore", () => {
+  const fn = mock(() => "original");
+
+  expect(fn[Symbol.dispose]).toBeFunction();
+  fn[Symbol.dispose]();
+});
+
+test("using with spyOn auto-restores prototype methods", () => {
+  class Greeter {
+    greet() {
+      return "hello";
+    }
+  }
+
+  {
+    using spy = spyOn(Greeter.prototype, "greet").mockReturnValue("hola");
+    expect(new Greeter().greet()).toBe("hola");
+  }
+
+  expect(new Greeter().greet()).toBe("hello");
+});

--- a/test/js/bun/test/mock-disposable.test.ts
+++ b/test/js/bun/test/mock-disposable.test.ts
@@ -15,8 +15,11 @@ test("spyOn returns a disposable that calls mockRestore", () => {
 test("mock() returns a disposable that calls mockRestore", () => {
   const fn = mock(() => "original");
 
+  fn();
+  expect(fn).toHaveBeenCalledTimes(1);
   expect(fn[Symbol.dispose]).toBeFunction();
   fn[Symbol.dispose]();
+  expect(fn).toHaveBeenCalledTimes(0);
 });
 
 test("using with spyOn auto-restores prototype methods", () => {


### PR DESCRIPTION
## Summary

- Add `[Symbol.dispose]` to mock function prototype, aliased to `mockRestore`
- Enables `using spy = spyOn(obj, "method")` to auto-restore when leaving scope
- Works for both `spyOn()` and `mock()`

Addresses #6040 — gives users a clean way to scope spy lifetimes instead of manually calling `mockRestore()` or relying on `afterEach`.

### Example

```ts
import { spyOn, expect, test } from "bun:test";

test("auto-restores spy", () => {
  const obj = { method: () => "original" };

  {
    using spy = spyOn(obj, "method").mockReturnValue("mocked");
    expect(obj.method()).toBe("mocked");
  }

  // automatically restored
  expect(obj.method()).toBe("original");
});
```

## Test plan

- `bun bd test test/js/bun/test/mock-disposable.test.ts` — 3 tests pass
- Verified tests fail with `USE_SYSTEM_BUN=1`