### PR TITLE
Make GC release access skip interval configurable

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -7,6 +7,7 @@ const VirtualMachine = @This();
 
 export var has_bun_garbage_collector_flag_enabled = false;
 pub export var isBunTest: bool = false;
+pub export var Bun__defaultRemainingRunsUntilSkipReleaseAccess: c_int = 10;
 
 // TODO: evaluate if this has any measurable performance impact.
 pub var synthetic_allocation_limit: usize = std.math.maxInt(u32);

--- a/src/bun.js/bindings/BunJSCEventLoop.cpp
+++ b/src/bun.js/bindings/BunJSCEventLoop.cpp
@@ -4,6 +4,8 @@
 #include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/Heap.h>
 
+extern "C" int Bun__defaultRemainingRunsUntilSkipReleaseAccess;
+
 extern "C" void Bun__JSC_onBeforeWait(JSC::VM* _Nonnull vm)
 {
     ASSERT(vm);
@@ -46,7 +48,7 @@ extern "C" void Bun__JSC_onBeforeWait(JSC::VM* _Nonnull vm)
         // finalizers that might've been waiting to be run is a good idea.
         // But if you haven't, like if the process is just waiting on I/O
         // then don't bother.
-        static constexpr int defaultRemainingRunsUntilSkipReleaseAccess = 10;
+        const int defaultRemainingRunsUntilSkipReleaseAccess = Bun__defaultRemainingRunsUntilSkipReleaseAccess;
 
         static thread_local int remainingRunsUntilSkipReleaseAccess = 0;
 

--- a/src/bun.js/event_loop/GarbageCollectionController.zig
+++ b/src/bun.js/event_loop/GarbageCollectionController.zig
@@ -52,6 +52,14 @@ pub fn init(this: *GarbageCollectionController, vm: *VirtualMachine) void {
     }
     this.gc_timer_interval = gc_timer_interval;
 
+    if (vm.transpiler.env.get("BUN_GC_RUNS_UNTIL_SKIP_RELEASE_ACCESS")) |val| {
+        if (std.fmt.parseInt(c_int, val, 10)) |parsed| {
+            if (parsed >= 0) {
+                VirtualMachine.Bun__defaultRemainingRunsUntilSkipReleaseAccess = parsed;
+            }
+        } else |_| {}
+    }
+
     this.disabled = vm.transpiler.env.has("BUN_GC_TIMER_DISABLE");
 
     if (!this.disabled)


### PR DESCRIPTION
## Summary
- Make `defaultRemainingRunsUntilSkipReleaseAccess` configurable at runtime instead of a compile-time constant
- Add `BUN_GC_RUNS_UNTIL_SKIP_RELEASE_ACCESS` environment variable to control how many idle event loop iterations pass before skipping JSC heap `releaseAccess` calls in `onBeforeWait`
- Default remains 10, matching the previous hardcoded value

## Test plan
- [ ] Verify default behavior is unchanged (no env var set, value is 10)
- [ ] Verify `BUN_GC_RUNS_UNTIL_SKIP_RELEASE_ACCESS=0` causes release access to be skipped every iteration
- [ ] Verify `BUN_GC_RUNS_UNTIL_SKIP_RELEASE_ACCESS=100` delays skipping for 100 idle iterations
- [ ] Verify negative values are ignored (default is preserved)
- [ ] Verify non-numeric values are ignored (default is preserved)

## Changelog
<!-- CHANGELOG:START -->
<!-- CHANGELOG:END -->

🤖 Generated with [Claude Code](https://claude.com/claude-code) (0% 3-shotted by claude)