### PR TITLE
feat(test): add `include` option for custom test file patterns

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -353,6 +353,9 @@ pub const Command = struct {
         test_filter_pattern: ?[]const u8 = null,
         test_filter_regex: ?*RegularExpression = null,
         max_concurrency: u32 = 20,
+        /// Custom glob patterns for test file discovery (e.g., ["**/*.unit.ts", "**/*.int.ts"])
+        /// When set, overrides the default patterns (.test., _test_, .spec., _spec_)
+        include: ?[]const []const u8 = null,
 
         reporters: struct {
             dots: bool = false,

--- a/src/cli/test/Scanner.zig
+++ b/src/cli/test/Scanner.zig
@@ -7,7 +7,7 @@ exclusion_names: []const []const u8 = &.{},
 filter_names: []const []const u8 = &.{},
 /// Custom glob patterns for test file discovery (e.g., ["**/*.unit.ts", "**/*.int.ts"])
 /// When set, overrides the default suffix patterns (.test., _test_, .spec., _spec_)
-include_patterns: ?[]const []const u8 = null,
+#include_patterns: ?[]const []const u8 = null,
 dirs_to_scan: Fifo,
 /// Paths to test files found while scanning.
 test_files: std.ArrayListUnmanaged(bun.PathString),
@@ -127,15 +127,15 @@ pub const test_name_suffixes = [_][]const u8{
     "_spec",
 };
 
-pub fn couldBeTestFile(this: *Scanner, name: []const u8, comptime needs_test_suffix: bool) bool {
+pub fn couldBeTestFile(this: *Scanner, name: []const u8, rel_path: []const u8, comptime needs_test_suffix: bool) bool {
     const extname = std.fs.path.extension(name);
     if (extname.len == 0 or !this.options.loader(extname).isJavaScriptLike()) return false;
     if (comptime !needs_test_suffix) return true;
 
-    // If custom include patterns are set, use glob matching instead of default suffixes
-    if (this.include_patterns) |patterns| {
+    // If custom include patterns are set, use glob matching with relative path
+    if (this.#include_patterns) |patterns| {
         for (patterns) |pattern| {
-            if (bun.glob.match(pattern, name).matches()) return true;
+            if (bun.glob.match(pattern, rel_path).matches()) return true;
         }
         return false;
     }
@@ -170,7 +170,7 @@ pub fn doesPathMatchFilter(this: *Scanner, name: []const u8) bool {
 }
 
 pub fn isTestFile(this: *Scanner, name: []const u8) bool {
-    return this.couldBeTestFile(name, false) and this.doesPathMatchFilter(name);
+    return this.couldBeTestFile(name, name, false) and this.doesPathMatchFilter(name);
 }
 
 pub fn next(this: *Scanner, entry: *FileSystem.Entry, fd: bun.StoredFileDescriptorType) void {
@@ -202,13 +202,15 @@ pub fn next(this: *Scanner, entry: *FileSystem.Entry, fd: bun.StoredFileDescript
             if (!entry.abs_path.isEmpty()) return;
 
             this.search_count += 1;
-            if (!this.couldBeTestFile(name, true)) return;
 
+            // Compute paths for test file check (needed for include pattern glob matching)
             const parts = &[_][]const u8{ entry.dir, entry.base() };
             const path = this.fs.absBuf(parts, &this.open_dir_buf);
+            const rel_path = bun.path.relative(this.fs.top_level_dir, path);
+
+            if (!this.couldBeTestFile(name, rel_path, true)) return;
 
             if (!this.doesAbsolutePathMatchFilter(path)) {
-                const rel_path = bun.path.relative(this.fs.top_level_dir, path);
                 if (!this.doesPathMatchFilter(rel_path)) return;
             }
 

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1447,7 +1447,7 @@ pub const TestCommand = struct {
 
         var scanner = bun.handleOom(Scanner.init(ctx.allocator, &vm.transpiler, ctx.positionals.len));
         defer scanner.deinit();
-        scanner.include_patterns = ctx.test_options.include;
+        scanner.#include_patterns = ctx.test_options.include;
         const has_relative_path = for (ctx.positionals) |arg| {
             if (std.fs.path.isAbsolute(arg) or
                 strings.startsWith(arg, "./") or

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1447,6 +1447,7 @@ pub const TestCommand = struct {
 
         var scanner = bun.handleOom(Scanner.init(ctx.allocator, &vm.transpiler, ctx.positionals.len));
         defer scanner.deinit();
+        scanner.include_patterns = ctx.test_options.include;
         const has_relative_path = for (ctx.positionals) |arg| {
             if (std.fs.path.isAbsolute(arg) or
                 strings.startsWith(arg, "./") or
@@ -1585,20 +1586,35 @@ pub const TestCommand = struct {
         if (test_files.len == 0) {
             failed_to_find_any_tests = true;
 
+            const has_custom_include = ctx.test_options.include != null;
+
             // "bun test" - positionals[0] == "test"
             // Therefore positionals starts at [1].
             if (ctx.positionals.len < 2) {
                 if (Output.isAIAgent()) {
                     // Be very clear to ai.
-                    Output.errGeneric("0 test files matching **{{.test,.spec,_test_,_spec_}}.{{js,ts,jsx,tsx}} in --cwd={f}", .{bun.fmt.quote(bun.fs.FileSystem.instance.top_level_dir)});
+                    if (has_custom_include) {
+                        Output.errGeneric("0 test files matching custom include patterns in --cwd={f}", .{bun.fmt.quote(bun.fs.FileSystem.instance.top_level_dir)});
+                    } else {
+                        Output.errGeneric("0 test files matching **{{.test,.spec,_test_,_spec_}}.{{js,ts,jsx,tsx}} in --cwd={f}", .{bun.fmt.quote(bun.fs.FileSystem.instance.top_level_dir)});
+                    }
                 } else {
                     // Be friendlier to humans.
-                    Output.prettyErrorln(
-                        \\<yellow>No tests found!<r>
-                        \\
-                        \\Tests need ".test", "_test_", ".spec" or "_spec_" in the filename <d>(ex: "MyApp.test.ts")<r>
-                        \\
-                    , .{});
+                    if (has_custom_include) {
+                        Output.prettyErrorln(
+                            \\<yellow>No tests found!<r>
+                            \\
+                            \\No files matched the custom include patterns in bunfig.toml
+                            \\
+                        , .{});
+                    } else {
+                        Output.prettyErrorln(
+                            \\<yellow>No tests found!<r>
+                            \\
+                            \\Tests need ".test", "_test_", ".spec" or "_spec_" in the filename <d>(ex: "MyApp.test.ts")<r>
+                            \\
+                        , .{});
+                    }
                 }
             } else {
                 if (Output.isAIAgent()) {
@@ -1624,11 +1640,19 @@ pub const TestCommand = struct {
                     Output.printStartEnd(ctx.start_time, std.time.nanoTimestamp());
                 }
 
-                Output.prettyErrorln(
-                    \\
-                    \\
-                    \\<blue>note<r><d>:<r> Tests need ".test", "_test_", ".spec" or "_spec_" in the filename <d>(ex: "MyApp.test.ts")<r>
-                , .{});
+                if (has_custom_include) {
+                    Output.prettyErrorln(
+                        \\
+                        \\
+                        \\<blue>note<r><d>:<r> Using custom include patterns from bunfig.toml
+                    , .{});
+                } else {
+                    Output.prettyErrorln(
+                        \\
+                        \\
+                        \\<blue>note<r><d>:<r> Tests need ".test", "_test_", ".spec" or "_spec_" in the filename <d>(ex: "MyApp.test.ts")<r>
+                    , .{});
+                }
 
                 // print a helpful note
                 if (has_file_like) |i| {

--- a/test/cli/test-include-patterns.test.ts
+++ b/test/cli/test-include-patterns.test.ts
@@ -1,0 +1,269 @@
+import { describe, test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe.concurrent("test.include configuration", () => {
+  test("custom include pattern matches files", async () => {
+    using dir = tempDir("test-include-basic", {
+      "bunfig.toml": `
+[test]
+include = ["**/*.unit.ts"]
+`,
+      "math.unit.ts": `
+import { test, expect } from "bun:test";
+test("addition", () => {
+  expect(1 + 1).toBe(2);
+});
+`,
+      // This file should NOT be found (doesn't match pattern)
+      "helper.ts": `
+export const add = (a: number, b: number) => a + b;
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    const output = stdout + stderr;
+    expect(output).toContain("1 pass");
+    expect(output).toContain("math.unit.ts");
+    expect(exitCode).toBe(0);
+  });
+
+  test("multiple include patterns work", async () => {
+    using dir = tempDir("test-include-multi", {
+      "bunfig.toml": `
+[test]
+include = ["**/*.unit.ts", "**/*.int.ts"]
+`,
+      "math.unit.ts": `
+import { test, expect } from "bun:test";
+test("unit test", () => {
+  expect(true).toBe(true);
+});
+`,
+      "api.int.ts": `
+import { test, expect } from "bun:test";
+test("integration test", () => {
+  expect(true).toBe(true);
+});
+`,
+      // This file should NOT be found
+      "math.test.ts": `
+import { test, expect } from "bun:test";
+test("should not run", () => {
+  expect(true).toBe(false);
+});
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    const output = stdout + stderr;
+    expect(output).toContain("2 pass");
+    expect(output).toContain("math.unit.ts");
+    expect(output).toContain("api.int.ts");
+    // Should NOT contain math.test.ts since custom patterns override defaults
+    expect(output).not.toContain("math.test.ts");
+    expect(exitCode).toBe(0);
+  });
+
+  test("single include pattern as string works", async () => {
+    using dir = tempDir("test-include-string", {
+      "bunfig.toml": `
+[test]
+include = "**/*.e2e.ts"
+`,
+      "login.e2e.ts": `
+import { test, expect } from "bun:test";
+test("e2e test", () => {
+  expect(true).toBe(true);
+});
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    const output = stdout + stderr;
+    expect(output).toContain("1 pass");
+    expect(output).toContain("login.e2e.ts");
+    expect(exitCode).toBe(0);
+  });
+
+  test("empty include pattern produces error", async () => {
+    using dir = tempDir("test-include-empty", {
+      "bunfig.toml": `
+[test]
+include = ""
+`,
+      "test.test.ts": `
+import { test, expect } from "bun:test";
+test("dummy", () => {});
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    const output = stdout + stderr;
+    expect(output).toContain("empty");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("empty include array produces error", async () => {
+    using dir = tempDir("test-include-empty-array", {
+      "bunfig.toml": `
+[test]
+include = []
+`,
+      "test.test.ts": `
+import { test, expect } from "bun:test";
+test("dummy", () => {});
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    const output = stdout + stderr;
+    expect(output).toContain("empty");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("include pattern in subdirectory", async () => {
+    using dir = tempDir("test-include-subdir", {
+      "bunfig.toml": `
+[test]
+include = ["tests/**/*.spec.ts"]
+`,
+      "tests/unit/math.spec.ts": `
+import { test, expect } from "bun:test";
+test("math spec", () => {
+  expect(2 + 2).toBe(4);
+});
+`,
+      "tests/integration/api.spec.ts": `
+import { test, expect } from "bun:test";
+test("api spec", () => {
+  expect(true).toBe(true);
+});
+`,
+      // This should NOT be found (not in tests/ directory)
+      "src/helper.spec.ts": `
+import { test, expect } from "bun:test";
+test("should not run", () => {
+  expect(true).toBe(false);
+});
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    const output = stdout + stderr;
+    expect(output).toContain("2 pass");
+    expect(output).toContain("math.spec.ts");
+    expect(output).toContain("api.spec.ts");
+    expect(output).not.toContain("helper.spec.ts");
+    expect(exitCode).toBe(0);
+  });
+
+  test("no tests found message with custom include", async () => {
+    using dir = tempDir("test-include-no-match", {
+      "bunfig.toml": `
+[test]
+include = ["**/*.nonexistent.ts"]
+`,
+      "math.test.ts": `
+import { test, expect } from "bun:test";
+test("dummy", () => {});
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    const output = stdout + stderr;
+    expect(output).toContain("No tests found");
+    expect(output).toContain("custom include patterns");
+    expect(exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new `include` option to the `[test]` section of bunfig.toml that allows users to customize which files are discovered as test files.

This enables use cases like:
- Separating unit tests (`*.unit.ts`) from integration tests (`*.int.ts`)
- Using custom naming conventions (`*.e2e.ts`, `*.itest.ts`)
- Restricting tests to specific directories (e.g., `tests/**/*.spec.ts`)

**Example bunfig.toml:**
```toml
[test]
include = ["**/*.unit.ts", "**/*.int.ts"]
```

When `include` is set, it overrides the default patterns (`.test.`, `_test_`, `.spec.`, `_spec_`).

## Implementation

- Added `include` field to `TestOptions` struct in `cli.zig`
- Added parsing for `include` in `bunfig.zig` (supports both string and array of strings)
- Modified `Scanner.zig` to use glob matching when custom patterns are configured
- Updated error messages in `test_command.zig` to be aware of custom include patterns
- Added comprehensive tests in `test/cli/test-include-patterns.test.ts`

## Test plan

- [x] Single include pattern matches files
- [x] Multiple include patterns work together
- [x] Single string pattern (not array) works
- [x] Empty pattern produces error
- [x] Empty array produces error
- [x] Patterns with directory prefixes work (`tests/**/*.spec.ts`)
- [x] Error message shows "custom include patterns" when configured

Closes #3440

🤖 Generated with [Claude Code](https://claude.com/claude-code)