### PR TITLE
fix(install): expand tilde (~) in cache directory paths from config files

### DIFF
--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -696,7 +696,7 @@ pub const Bunfig = struct {
                             }
 
                             if (cache.asString(allocator)) |value| {
-                                install.cache_directory = value;
+                                install.cache_directory = try bun.strings.expandTilde(allocator, value);
                                 break :load;
                             }
 
@@ -715,7 +715,7 @@ pub const Bunfig = struct {
 
                                 if (cache.get("dir")) |directory| {
                                     if (directory.asString(allocator)) |value| {
-                                        install.cache_directory = value;
+                                        install.cache_directory = try bun.strings.expandTilde(allocator, value);
                                     }
                                 }
                             }

--- a/src/ini.zig
+++ b/src/ini.zig
@@ -999,7 +999,7 @@ pub fn loadNpmrc(
 
     if (out.asProperty("cache")) |query| {
         if (query.expr.asUtf8StringLiteral()) |str| {
-            install.cache_directory = try allocator.dupe(u8, str);
+            install.cache_directory = try bun.strings.expandTilde(allocator, str);
         } else if (query.expr.asBool()) |b| {
             install.disable_cache = !b;
         }

--- a/test/regression/issue/26715.test.ts
+++ b/test/regression/issue/26715.test.ts
@@ -109,8 +109,9 @@ describe("tilde expansion in cache paths", () => {
       "package.json": JSON.stringify({ name: "foo", version: "1.0.0" }),
     });
     const absoluteCachePath = join(testDir, "absolute-cache-dir");
-    // Write bunfig.toml with the absolute path
-    await Bun.write(join(testDir, "bunfig.toml"), `[install]\ncache = "${absoluteCachePath.replace(/\\/g, "/")}"`);
+    // Write bunfig.toml with forward slashes (works on all platforms)
+    const configPath = absoluteCachePath.replace(/\\/g, "/");
+    await Bun.write(join(testDir, "bunfig.toml"), `[install]\ncache = "${configPath}"`);
 
     const testEnv = { ...bunEnv };
     delete testEnv.BUN_INSTALL_CACHE_DIR;
@@ -127,7 +128,8 @@ describe("tilde expansion in cache paths", () => {
     const err = stderrForInstall(await proc.stderr.text());
 
     expect(err).toBeEmpty();
-    expect(out).toBe(absoluteCachePath);
+    // Normalize both paths to forward slashes for comparison
+    expect(out.replace(/\\/g, "/")).toBe(configPath);
 
     expect(await proc.exited).toBe(0);
   });

--- a/test/regression/issue/26715.test.ts
+++ b/test/regression/issue/26715.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import { rm } from "fs/promises";
+import { bunExe, bunEnv as env, stderrForInstall, tempDirWithFiles } from "harness";
+import { join } from "path";
+
+// https://github.com/oven-sh/bun/issues/26715
+// Bun should expand ~ (tilde) to the home directory in cache paths from .npmrc and bunfig.toml
+
+describe("tilde expansion in cache paths", () => {
+  test(".npmrc cache path expands tilde to home directory", async () => {
+    const testDir = tempDirWithFiles("tilde-npmrc-", {
+      ".npmrc": "cache=~/.bun-test-cache-dir",
+      "package.json": JSON.stringify({ name: "foo", version: "1.0.0" }),
+    });
+
+    // Remove any bunfig.toml that might override the .npmrc setting
+    await rm(join(testDir, "bunfig.toml"), { force: true });
+
+    const originalCacheDir = env.BUN_INSTALL_CACHE_DIR;
+    delete env.BUN_INSTALL_CACHE_DIR;
+
+    try {
+      const { stdout, stderr, exited } = Bun.spawn({
+        cmd: [bunExe(), "pm", "cache"],
+        cwd: testDir,
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const out = (await stdout.text()).trim();
+      const err = stderrForInstall(await stderr.text());
+
+      expect(err).toBeEmpty();
+      // Should NOT contain literal "~" - it should be expanded to the home directory
+      expect(out).not.toContain("/~/");
+      expect(out).not.toStartWith("~");
+      // Should contain the home directory path
+      const homeDir = process.env.HOME || process.env.USERPROFILE;
+      expect(out).toStartWith(homeDir!);
+      expect(out).toEndWith(".bun-test-cache-dir");
+
+      expect(await exited).toBe(0);
+    } finally {
+      env.BUN_INSTALL_CACHE_DIR = originalCacheDir;
+    }
+  });
+
+  test("bunfig.toml cache string expands tilde to home directory", async () => {
+    const testDir = tempDirWithFiles("tilde-bunfig-str-", {
+      "bunfig.toml": '[install]\ncache = "~/.bun-test-cache-dir"',
+      "package.json": JSON.stringify({ name: "foo", version: "1.0.0" }),
+    });
+
+    const originalCacheDir = env.BUN_INSTALL_CACHE_DIR;
+    delete env.BUN_INSTALL_CACHE_DIR;
+
+    try {
+      const { stdout, stderr, exited } = Bun.spawn({
+        cmd: [bunExe(), "pm", "cache"],
+        cwd: testDir,
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const out = (await stdout.text()).trim();
+      const err = stderrForInstall(await stderr.text());
+
+      expect(err).toBeEmpty();
+      expect(out).not.toContain("/~/");
+      expect(out).not.toStartWith("~");
+      const homeDir = process.env.HOME || process.env.USERPROFILE;
+      expect(out).toStartWith(homeDir!);
+      expect(out).toEndWith(".bun-test-cache-dir");
+
+      expect(await exited).toBe(0);
+    } finally {
+      env.BUN_INSTALL_CACHE_DIR = originalCacheDir;
+    }
+  });
+
+  test("bunfig.toml cache.dir expands tilde to home directory", async () => {
+    const testDir = tempDirWithFiles("tilde-bunfig-dir-", {
+      "bunfig.toml": '[install.cache]\ndir = "~/.bun-test-cache-dir"',
+      "package.json": JSON.stringify({ name: "foo", version: "1.0.0" }),
+    });
+
+    const originalCacheDir = env.BUN_INSTALL_CACHE_DIR;
+    delete env.BUN_INSTALL_CACHE_DIR;
+
+    try {
+      const { stdout, stderr, exited } = Bun.spawn({
+        cmd: [bunExe(), "pm", "cache"],
+        cwd: testDir,
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const out = (await stdout.text()).trim();
+      const err = stderrForInstall(await stderr.text());
+
+      expect(err).toBeEmpty();
+      expect(out).not.toContain("/~/");
+      expect(out).not.toStartWith("~");
+      const homeDir = process.env.HOME || process.env.USERPROFILE;
+      expect(out).toStartWith(homeDir!);
+      expect(out).toEndWith(".bun-test-cache-dir");
+
+      expect(await exited).toBe(0);
+    } finally {
+      env.BUN_INSTALL_CACHE_DIR = originalCacheDir;
+    }
+  });
+
+  test("paths without tilde are not affected", async () => {
+    const testDir = tempDirWithFiles("no-tilde-", {
+      "bunfig.toml": '[install]\ncache = "/tmp/absolute-cache-dir"',
+      "package.json": JSON.stringify({ name: "foo", version: "1.0.0" }),
+    });
+
+    const originalCacheDir = env.BUN_INSTALL_CACHE_DIR;
+    delete env.BUN_INSTALL_CACHE_DIR;
+
+    try {
+      const { stdout, stderr, exited } = Bun.spawn({
+        cmd: [bunExe(), "pm", "cache"],
+        cwd: testDir,
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const out = (await stdout.text()).trim();
+      const err = stderrForInstall(await stderr.text());
+
+      expect(err).toBeEmpty();
+      expect(out).toBe("/tmp/absolute-cache-dir");
+
+      expect(await exited).toBe(0);
+    } finally {
+      env.BUN_INSTALL_CACHE_DIR = originalCacheDir;
+    }
+  });
+
+  test("~username paths are not expanded (only ~ is expanded)", async () => {
+    // ~username syntax (for other users' home dirs) should not be expanded
+    // as it would require looking up user info
+    const testDir = tempDirWithFiles("tilde-user-", {
+      "bunfig.toml": '[install]\ncache = "~otheruser/cache"',
+      "package.json": JSON.stringify({ name: "foo", version: "1.0.0" }),
+    });
+
+    const originalCacheDir = env.BUN_INSTALL_CACHE_DIR;
+    delete env.BUN_INSTALL_CACHE_DIR;
+
+    try {
+      const { stdout, stderr, exited } = Bun.spawn({
+        cmd: [bunExe(), "pm", "cache"],
+        cwd: testDir,
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const out = (await stdout.text()).trim();
+      const err = stderrForInstall(await stderr.text());
+
+      expect(err).toBeEmpty();
+      // Should still contain ~otheruser since we don't expand that form
+      expect(out).toContain("~otheruser");
+
+      expect(await exited).toBe(0);
+    } finally {
+      env.BUN_INSTALL_CACHE_DIR = originalCacheDir;
+    }
+  });
+});

--- a/test/regression/issue/26715.test.ts
+++ b/test/regression/issue/26715.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { rm } from "fs/promises";
-import { bunExe, bunEnv as env, stderrForInstall, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, stderrForInstall, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 // https://github.com/oven-sh/bun/issues/26715
@@ -16,34 +16,31 @@ describe("tilde expansion in cache paths", () => {
     // Remove any bunfig.toml that might override the .npmrc setting
     await rm(join(testDir, "bunfig.toml"), { force: true });
 
-    const originalCacheDir = env.BUN_INSTALL_CACHE_DIR;
-    delete env.BUN_INSTALL_CACHE_DIR;
+    // Clone env to avoid mutating shared object
+    const testEnv = { ...bunEnv };
+    delete testEnv.BUN_INSTALL_CACHE_DIR;
 
-    try {
-      const { stdout, stderr, exited } = Bun.spawn({
-        cmd: [bunExe(), "pm", "cache"],
-        cwd: testDir,
-        env,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pm", "cache"],
+      cwd: testDir,
+      env: testEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-      const out = (await stdout.text()).trim();
-      const err = stderrForInstall(await stderr.text());
+    const out = (await proc.stdout.text()).trim();
+    const err = stderrForInstall(await proc.stderr.text());
 
-      expect(err).toBeEmpty();
-      // Should NOT contain literal "~" - it should be expanded to the home directory
-      expect(out).not.toContain("/~/");
-      expect(out).not.toStartWith("~");
-      // Should contain the home directory path
-      const homeDir = process.env.HOME || process.env.USERPROFILE;
-      expect(out).toStartWith(homeDir!);
-      expect(out).toEndWith(".bun-test-cache-dir");
+    expect(err).toBeEmpty();
+    // Should NOT contain literal "~" - it should be expanded to the home directory
+    expect(out).not.toContain("/~/");
+    expect(out).not.toStartWith("~");
+    // Should contain the home directory path
+    const homeDir = process.env.HOME || process.env.USERPROFILE;
+    expect(out).toStartWith(homeDir!);
+    expect(out).toEndWith(".bun-test-cache-dir");
 
-      expect(await exited).toBe(0);
-    } finally {
-      env.BUN_INSTALL_CACHE_DIR = originalCacheDir;
-    }
+    expect(await proc.exited).toBe(0);
   });
 
   test("bunfig.toml cache string expands tilde to home directory", async () => {
@@ -52,32 +49,28 @@ describe("tilde expansion in cache paths", () => {
       "package.json": JSON.stringify({ name: "foo", version: "1.0.0" }),
     });
 
-    const originalCacheDir = env.BUN_INSTALL_CACHE_DIR;
-    delete env.BUN_INSTALL_CACHE_DIR;
+    const testEnv = { ...bunEnv };
+    delete testEnv.BUN_INSTALL_CACHE_DIR;
 
-    try {
-      const { stdout, stderr, exited } = Bun.spawn({
-        cmd: [bunExe(), "pm", "cache"],
-        cwd: testDir,
-        env,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pm", "cache"],
+      cwd: testDir,
+      env: testEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-      const out = (await stdout.text()).trim();
-      const err = stderrForInstall(await stderr.text());
+    const out = (await proc.stdout.text()).trim();
+    const err = stderrForInstall(await proc.stderr.text());
 
-      expect(err).toBeEmpty();
-      expect(out).not.toContain("/~/");
-      expect(out).not.toStartWith("~");
-      const homeDir = process.env.HOME || process.env.USERPROFILE;
-      expect(out).toStartWith(homeDir!);
-      expect(out).toEndWith(".bun-test-cache-dir");
+    expect(err).toBeEmpty();
+    expect(out).not.toContain("/~/");
+    expect(out).not.toStartWith("~");
+    const homeDir = process.env.HOME || process.env.USERPROFILE;
+    expect(out).toStartWith(homeDir!);
+    expect(out).toEndWith(".bun-test-cache-dir");
 
-      expect(await exited).toBe(0);
-    } finally {
-      env.BUN_INSTALL_CACHE_DIR = originalCacheDir;
-    }
+    expect(await proc.exited).toBe(0);
   });
 
   test("bunfig.toml cache.dir expands tilde to home directory", async () => {
@@ -86,32 +79,28 @@ describe("tilde expansion in cache paths", () => {
       "package.json": JSON.stringify({ name: "foo", version: "1.0.0" }),
     });
 
-    const originalCacheDir = env.BUN_INSTALL_CACHE_DIR;
-    delete env.BUN_INSTALL_CACHE_DIR;
+    const testEnv = { ...bunEnv };
+    delete testEnv.BUN_INSTALL_CACHE_DIR;
 
-    try {
-      const { stdout, stderr, exited } = Bun.spawn({
-        cmd: [bunExe(), "pm", "cache"],
-        cwd: testDir,
-        env,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pm", "cache"],
+      cwd: testDir,
+      env: testEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-      const out = (await stdout.text()).trim();
-      const err = stderrForInstall(await stderr.text());
+    const out = (await proc.stdout.text()).trim();
+    const err = stderrForInstall(await proc.stderr.text());
 
-      expect(err).toBeEmpty();
-      expect(out).not.toContain("/~/");
-      expect(out).not.toStartWith("~");
-      const homeDir = process.env.HOME || process.env.USERPROFILE;
-      expect(out).toStartWith(homeDir!);
-      expect(out).toEndWith(".bun-test-cache-dir");
+    expect(err).toBeEmpty();
+    expect(out).not.toContain("/~/");
+    expect(out).not.toStartWith("~");
+    const homeDir = process.env.HOME || process.env.USERPROFILE;
+    expect(out).toStartWith(homeDir!);
+    expect(out).toEndWith(".bun-test-cache-dir");
 
-      expect(await exited).toBe(0);
-    } finally {
-      env.BUN_INSTALL_CACHE_DIR = originalCacheDir;
-    }
+    expect(await proc.exited).toBe(0);
   });
 
   test("paths without tilde are not affected", async () => {
@@ -120,28 +109,24 @@ describe("tilde expansion in cache paths", () => {
       "package.json": JSON.stringify({ name: "foo", version: "1.0.0" }),
     });
 
-    const originalCacheDir = env.BUN_INSTALL_CACHE_DIR;
-    delete env.BUN_INSTALL_CACHE_DIR;
+    const testEnv = { ...bunEnv };
+    delete testEnv.BUN_INSTALL_CACHE_DIR;
 
-    try {
-      const { stdout, stderr, exited } = Bun.spawn({
-        cmd: [bunExe(), "pm", "cache"],
-        cwd: testDir,
-        env,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pm", "cache"],
+      cwd: testDir,
+      env: testEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-      const out = (await stdout.text()).trim();
-      const err = stderrForInstall(await stderr.text());
+    const out = (await proc.stdout.text()).trim();
+    const err = stderrForInstall(await proc.stderr.text());
 
-      expect(err).toBeEmpty();
-      expect(out).toBe("/tmp/absolute-cache-dir");
+    expect(err).toBeEmpty();
+    expect(out).toBe("/tmp/absolute-cache-dir");
 
-      expect(await exited).toBe(0);
-    } finally {
-      env.BUN_INSTALL_CACHE_DIR = originalCacheDir;
-    }
+    expect(await proc.exited).toBe(0);
   });
 
   test("~username paths are not expanded (only ~ is expanded)", async () => {
@@ -152,28 +137,24 @@ describe("tilde expansion in cache paths", () => {
       "package.json": JSON.stringify({ name: "foo", version: "1.0.0" }),
     });
 
-    const originalCacheDir = env.BUN_INSTALL_CACHE_DIR;
-    delete env.BUN_INSTALL_CACHE_DIR;
+    const testEnv = { ...bunEnv };
+    delete testEnv.BUN_INSTALL_CACHE_DIR;
 
-    try {
-      const { stdout, stderr, exited } = Bun.spawn({
-        cmd: [bunExe(), "pm", "cache"],
-        cwd: testDir,
-        env,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pm", "cache"],
+      cwd: testDir,
+      env: testEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-      const out = (await stdout.text()).trim();
-      const err = stderrForInstall(await stderr.text());
+    const out = (await proc.stdout.text()).trim();
+    const err = stderrForInstall(await proc.stderr.text());
 
-      expect(err).toBeEmpty();
-      // Should still contain ~otheruser since we don't expand that form
-      expect(out).toContain("~otheruser");
+    expect(err).toBeEmpty();
+    // Should still contain ~otheruser since we don't expand that form
+    expect(out).toContain("~otheruser");
 
-      expect(await exited).toBe(0);
-    } finally {
-      env.BUN_INSTALL_CACHE_DIR = originalCacheDir;
-    }
+    expect(await proc.exited).toBe(0);
   });
 });

--- a/test/regression/issue/26715.test.ts
+++ b/test/regression/issue/26715.test.ts
@@ -104,10 +104,13 @@ describe("tilde expansion in cache paths", () => {
   });
 
   test("paths without tilde are not affected", async () => {
+    // Use a platform-independent absolute path within the test directory
     const testDir = tempDirWithFiles("no-tilde-", {
-      "bunfig.toml": '[install]\ncache = "/tmp/absolute-cache-dir"',
       "package.json": JSON.stringify({ name: "foo", version: "1.0.0" }),
     });
+    const absoluteCachePath = join(testDir, "absolute-cache-dir");
+    // Write bunfig.toml with the absolute path
+    await Bun.write(join(testDir, "bunfig.toml"), `[install]\ncache = "${absoluteCachePath.replace(/\\/g, "/")}"`);
 
     const testEnv = { ...bunEnv };
     delete testEnv.BUN_INSTALL_CACHE_DIR;
@@ -124,7 +127,7 @@ describe("tilde expansion in cache paths", () => {
     const err = stderrForInstall(await proc.stderr.text());
 
     expect(err).toBeEmpty();
-    expect(out).toBe("/tmp/absolute-cache-dir");
+    expect(out).toBe(absoluteCachePath);
 
     expect(await proc.exited).toBe(0);
   });


### PR DESCRIPTION
## Summary

- Fixes tilde (`~`) expansion in cache paths from `.npmrc` and `bunfig.toml` configuration files
- Adds `strings.expandTilde` utility function for path tilde expansion
- Applies expansion when parsing `cache` option in `.npmrc` and `cache`/`cache.dir` in `bunfig.toml`

## Test plan

- Added regression test `test/regression/issue/26715.test.ts` that verifies:
  - `.npmrc` `cache=~/.path` expands correctly
  - `bunfig.toml` `cache = "~/.path"` expands correctly  
  - `bunfig.toml` `cache.dir = "~/.path"` expands correctly
  - Absolute paths without tilde are unchanged
  - `~username` paths (other users) are not expanded (matches shell behavior)

Closes #26715

🤖 Generated with [Claude Code](https://claude.com/claude-code)