### PR TITLE
fix(fetch): remove vm.log.level coupling from verbose fetch logging

### DIFF
--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -219,10 +219,12 @@ fn fetchImpl(
     var disable_timeout = false;
     var disable_keepalive = false;
     var disable_decompression = false;
-    var verbose: http.HTTPVerboseLevel = if (vm.log.level.atLeast(.debug)) .headers else .none;
-    if (verbose == .none) {
-        verbose = vm.getVerboseFetch();
-    }
+    // Only enable verbose fetch logging via explicit opt-in:
+    // 1. BUN_CONFIG_VERBOSE_FETCH environment variable
+    // 2. explicit `verbose: true` or `verbose: "curl"` option in fetch options
+    // Note: We no longer check vm.log.level here, as that's for compiler/transpiler
+    // logging and shouldn't affect runtime fetch verbosity.
+    var verbose: http.HTTPVerboseLevel = vm.getVerboseFetch();
 
     var proxy: ?ZigURL = null;
     var redirect_type: FetchRedirect = FetchRedirect.follow;

--- a/test/regression/issue/26724.test.ts
+++ b/test/regression/issue/26724.test.ts
@@ -1,9 +1,23 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// Issue #26724: verbose [fetch] logging appears in bun test without BUN_CONFIG_VERBOSE_FETCH set
+//
+// The root cause was that fetch.zig checked vm.log.level.atLeast(.debug) before checking
+// the BUN_CONFIG_VERBOSE_FETCH environment variable. This caused verbose logging to be
+// enabled whenever the VM's log level was debug or lower, regardless of user preference.
+//
+// The fix ensures verbose fetch logging is ONLY enabled via explicit opt-in:
+// 1. BUN_CONFIG_VERBOSE_FETCH environment variable
+// 2. explicit `verbose: true` or `verbose: "curl"` option in fetch options
+//
+// Note: The original bug manifested specifically with testcontainers/dockerode patterns
+// which couldn't be easily reproduced without Docker. These tests validate the core
+// behavior that verbose logging respects the environment variable.
 
 describe("issue #26724: verbose fetch logging should not be enabled by default", () => {
   test("fetch should not output verbose logs without BUN_CONFIG_VERBOSE_FETCH", async () => {
-    // Start a local test server
     using server = Bun.serve({
       port: 0,
       fetch() {
@@ -19,7 +33,7 @@ describe("issue #26724: verbose fetch logging should not be enabled by default",
       cmd: [bunExe(), "-e", script],
       env: {
         ...bunEnv,
-        BUN_CONFIG_VERBOSE_FETCH: undefined, // Explicitly ensure it's not set
+        BUN_CONFIG_VERBOSE_FETCH: undefined,
       },
       stdout: "pipe",
       stderr: "pipe",
@@ -27,7 +41,6 @@ describe("issue #26724: verbose fetch logging should not be enabled by default",
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // Should not contain verbose fetch output (> or [fetch])
     expect(stderr).not.toContain("[fetch]");
     expect(stderr).not.toContain("> HTTP/1.1");
     expect(stdout).toContain("status: 200");
@@ -35,7 +48,6 @@ describe("issue #26724: verbose fetch logging should not be enabled by default",
   });
 
   test("fetch should output verbose logs when BUN_CONFIG_VERBOSE_FETCH=1", async () => {
-    // Start a local test server
     using server = Bun.serve({
       port: 0,
       fetch() {
@@ -59,16 +71,17 @@ describe("issue #26724: verbose fetch logging should not be enabled by default",
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // Should contain verbose fetch output
     expect(stderr + stdout).toContain("> HTTP/1.1");
     expect(stdout).toContain("status: 200");
     expect(exitCode).toBe(0);
   });
 
-  test("node:http requests should not output verbose logs without BUN_CONFIG_VERBOSE_FETCH", async () => {
-    // Start a local test server
+  test("node:http requests over unix socket should not output verbose logs without BUN_CONFIG_VERBOSE_FETCH", async () => {
+    using dir = tempDir("issue-26724-unix", {});
+    const socketPath = join(String(dir), "test.sock");
+
     using server = Bun.serve({
-      port: 0,
+      unix: socketPath,
       fetch() {
         return new Response(JSON.stringify({ status: "ok" }), {
           headers: { "Content-Type": "application/json" },
@@ -76,9 +89,14 @@ describe("issue #26724: verbose fetch logging should not be enabled by default",
       },
     });
 
+    // Use node:http with socketPath - this is the pattern used by dockerode/testcontainers
     const script = `
       import http from 'node:http';
-      const options = { hostname: 'localhost', port: ${server.port}, path: '/get', method: 'GET' };
+      const options = {
+        socketPath: ${JSON.stringify(socketPath)},
+        path: '/info',
+        method: 'GET',
+      };
       const req = http.request(options, (res) => {
         let data = '';
         res.on('data', (chunk) => { data += chunk; });
@@ -92,7 +110,7 @@ describe("issue #26724: verbose fetch logging should not be enabled by default",
       cmd: [bunExe(), "-e", script],
       env: {
         ...bunEnv,
-        BUN_CONFIG_VERBOSE_FETCH: undefined, // Explicitly ensure it's not set
+        BUN_CONFIG_VERBOSE_FETCH: undefined,
       },
       stdout: "pipe",
       stderr: "pipe",
@@ -100,7 +118,6 @@ describe("issue #26724: verbose fetch logging should not be enabled by default",
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // Should not contain verbose fetch output (> or [fetch])
     expect(stderr).not.toContain("[fetch]");
     expect(stderr).not.toContain("> HTTP/1.1");
     expect(stdout).toContain("status: 200");
@@ -108,7 +125,6 @@ describe("issue #26724: verbose fetch logging should not be enabled by default",
   });
 
   test("bun test should not output verbose fetch logs without BUN_CONFIG_VERBOSE_FETCH", async () => {
-    // Start a local test server
     using server = Bun.serve({
       port: 0,
       fetch() {
@@ -118,7 +134,6 @@ describe("issue #26724: verbose fetch logging should not be enabled by default",
       },
     });
 
-    // This test requires a file since bun test needs a test file to run
     using dir = tempDir("issue-26724-buntest", {
       "fetch.test.ts": `
         import { test, expect } from "bun:test";
@@ -136,7 +151,7 @@ describe("issue #26724: verbose fetch logging should not be enabled by default",
       cmd: [bunExe(), "test", "fetch.test.ts"],
       env: {
         ...bunEnv,
-        BUN_CONFIG_VERBOSE_FETCH: undefined, // Explicitly ensure it's not set
+        BUN_CONFIG_VERBOSE_FETCH: undefined,
         TEST_SERVER_URL: `http://localhost:${server.port}/get`,
       },
       cwd: String(dir),
@@ -146,7 +161,6 @@ describe("issue #26724: verbose fetch logging should not be enabled by default",
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // Should not contain verbose fetch output (> or [fetch])
     const output = stdout + stderr;
     expect(output).not.toContain("[fetch]");
     expect(output).not.toContain("> HTTP/1.1");

--- a/test/regression/issue/26724.test.ts
+++ b/test/regression/issue/26724.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("issue #26724: verbose fetch logging should not be enabled by default", () => {
+  test("fetch should not output verbose logs without BUN_CONFIG_VERBOSE_FETCH", async () => {
+    using dir = tempDir("issue-26724", {
+      "test.ts": `
+        const response = await fetch("https://httpbin.org/get");
+        console.log("status:", response.status);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "test.ts"],
+      env: {
+        ...bunEnv,
+        BUN_CONFIG_VERBOSE_FETCH: undefined, // Explicitly ensure it's not set
+      },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Should not contain verbose fetch output (> or [fetch])
+    expect(stderr).not.toContain("[fetch]");
+    expect(stderr).not.toContain("> HTTP/1.1");
+    expect(stdout).toContain("status: 200");
+    expect(exitCode).toBe(0);
+  });
+
+  test("fetch should output verbose logs when BUN_CONFIG_VERBOSE_FETCH=1", async () => {
+    using dir = tempDir("issue-26724-verbose", {
+      "test.ts": `
+        const response = await fetch("https://httpbin.org/get");
+        console.log("status:", response.status);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "test.ts"],
+      env: {
+        ...bunEnv,
+        BUN_CONFIG_VERBOSE_FETCH: "1",
+      },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Should contain verbose fetch output
+    expect(stderr + stdout).toContain("> HTTP/1.1");
+    expect(stdout).toContain("status: 200");
+    expect(exitCode).toBe(0);
+  });
+
+  test("node:http requests should not output verbose logs without BUN_CONFIG_VERBOSE_FETCH", async () => {
+    using dir = tempDir("issue-26724-nodehttp", {
+      "test.ts": `
+        import http from 'node:http';
+
+        const options = {
+          hostname: 'httpbin.org',
+          port: 80,
+          path: '/get',
+          method: 'GET',
+        };
+
+        const req = http.request(options, (res) => {
+          let data = '';
+          res.on('data', (chunk) => { data += chunk; });
+          res.on('end', () => {
+            console.log('status:', res.statusCode);
+          });
+        });
+
+        req.on('error', (err) => {
+          console.error('error:', err.message);
+        });
+
+        req.end();
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "test.ts"],
+      env: {
+        ...bunEnv,
+        BUN_CONFIG_VERBOSE_FETCH: undefined, // Explicitly ensure it's not set
+      },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Should not contain verbose fetch output (> or [fetch])
+    expect(stderr).not.toContain("[fetch]");
+    expect(stderr).not.toContain("> HTTP/1.1");
+    expect(stdout).toContain("status: 200");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun test should not output verbose fetch logs without BUN_CONFIG_VERBOSE_FETCH", async () => {
+    using dir = tempDir("issue-26724-buntest", {
+      "fetch.test.ts": `
+        import { test, expect } from "bun:test";
+
+        test("fetch works", async () => {
+          const response = await fetch("https://httpbin.org/get");
+          expect(response.status).toBe(200);
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "fetch.test.ts"],
+      env: {
+        ...bunEnv,
+        BUN_CONFIG_VERBOSE_FETCH: undefined, // Explicitly ensure it's not set
+      },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Should not contain verbose fetch output (> or [fetch])
+    const output = stdout + stderr;
+    expect(output).not.toContain("[fetch]");
+    expect(output).not.toContain("> HTTP/1.1");
+    expect(output).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Removes the coupling between `vm.log.level` and verbose fetch logging
- Verbose fetch logging is now only enabled via explicit opt-in:
  1. `BUN_CONFIG_VERBOSE_FETCH` environment variable
  2. Explicit `verbose: true` or `verbose: "curl"` option in fetch options

## Test plan

- [ ] Verify no verbose fetch logs appear without `BUN_CONFIG_VERBOSE_FETCH`
- [ ] Verify `BUN_CONFIG_VERBOSE_FETCH=1` still enables verbose logging
- [ ] Verify `fetch(..., { verbose: true })` still works
- [ ] Run regression test: `bun test test/regression/issue/26724.test.ts`

Fixes #26724

🤖 Generated with [Claude Code](https://claude.com/claude-code)