### PR TITLE
feat: add bun:git module with libgit2 integration

### DIFF
--- a/cmake/Sources.json
+++ b/cmake/Sources.json
@@ -46,6 +46,7 @@
       "src/io/*.cpp",
       "src/bun.js/modules/*.cpp",
       "src/bun.js/bindings/*.cpp",
+      "src/bun.js/bindings/git/*.cpp",
       "src/bun.js/bindings/webcore/*.cpp",
       "src/bun.js/bindings/sqlite/*.cpp",
       "src/bun.js/bindings/webcrypto/*.cpp",

--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -54,6 +54,7 @@ set(BUN_DEPENDENCIES
   Cares
   Highway
   LibDeflate
+  Libgit2
   LolHtml
   Lshpack
   Mimalloc
@@ -1322,7 +1323,7 @@ list(TRANSFORM BUN_DEPENDENCIES TOLOWER OUTPUT_VARIABLE BUN_TARGETS)
 add_custom_target(dependencies DEPENDS ${BUN_TARGETS})
 
 if(APPLE)
-  target_link_libraries(${bun} PRIVATE icucore resolv)
+  target_link_libraries(${bun} PRIVATE icucore resolv iconv)
   target_compile_definitions(${bun} PRIVATE U_DISABLE_RENAMING=1)
 endif()
 

--- a/cmake/targets/BuildLibgit2.cmake
+++ b/cmake/targets/BuildLibgit2.cmake
@@ -1,0 +1,40 @@
+register_repository(
+  NAME
+    libgit2
+  REPOSITORY
+    libgit2/libgit2
+  TAG
+    v1.9.0
+)
+
+register_cmake_command(
+  TARGET
+    libgit2
+  TARGETS
+    libgit2package
+  ARGS
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+    -DBUILD_SHARED_LIBS=OFF
+    -DBUILD_TESTS=OFF
+    -DBUILD_CLI=OFF
+    -DBUILD_EXAMPLES=OFF
+    -DBUILD_FUZZERS=OFF
+    # Network disabled - local operations only
+    -DUSE_HTTPS=OFF
+    -DUSE_SSH=OFF
+    # Use bundled dependencies to avoid symbol conflicts with Bun's libraries
+    -DUSE_BUNDLED_ZLIB=ON
+    -DUSE_HTTP_PARSER=builtin
+    -DREGEX_BACKEND=builtin
+    -DUSE_SHA1=CollisionDetection
+    # Enable threading
+    -DUSE_THREADS=ON
+    # Disable authentication features (not needed for local operations)
+    -DUSE_GSSAPI=OFF
+  LIB_PATH
+    .
+  LIBRARIES
+    git2
+  INCLUDES
+    include
+)

--- a/packages/bun-types/git.d.ts
+++ b/packages/bun-types/git.d.ts
@@ -1,0 +1,190 @@
+/**
+ * Fast Git operations for Bun.js powered by libgit2.
+ *
+ * This module provides read-only Git repository operations.
+ * Network operations (HTTPS/SSH) are not supported - local operations only.
+ *
+ * @example
+ * ```ts
+ * import { Repository } from 'bun:git';
+ *
+ * const repo = Repository.open('.');
+ * const head = repo.head();
+ * console.log(`HEAD: ${head.id} - ${head.summary}`);
+ * console.log(`Author: ${head.author.name} <${head.author.email}>`);
+ * ```
+ *
+ * @module bun:git
+ */
+declare module "bun:git" {
+  /**
+   * Represents a Git signature (author or committer information).
+   */
+  export interface Signature {
+    /**
+     * The name of the person.
+     * @example "John Doe"
+     */
+    readonly name: string;
+
+    /**
+     * The email address of the person.
+     * @example "john@example.com"
+     */
+    readonly email: string;
+
+    /**
+     * Unix timestamp of when the signature was created.
+     * @example 1704067200
+     */
+    readonly time: number;
+  }
+
+  /**
+   * Represents a Git commit object.
+   *
+   * A commit contains information about a snapshot of the repository,
+   * including the author, committer, message, and parent commits.
+   *
+   * @example
+   * ```ts
+   * const head = repo.head();
+   * console.log(head.id);       // "abc123..."
+   * console.log(head.message);  // "feat: add new feature\n\nDetailed description..."
+   * console.log(head.summary);  // "feat: add new feature"
+   * ```
+   */
+  export class Commit {
+    /**
+     * The full 40-character hexadecimal SHA-1 hash of the commit.
+     * @example "a1b2c3d4e5f6..."
+     */
+    readonly id: string;
+
+    /**
+     * The full commit message, including the body.
+     * @example "feat: add new feature\n\nThis commit adds..."
+     */
+    readonly message: string;
+
+    /**
+     * The first line of the commit message (the summary/title).
+     * Does not include any trailing newline.
+     * @example "feat: add new feature"
+     */
+    readonly summary: string;
+
+    /**
+     * The author of the commit (who wrote the changes).
+     */
+    readonly author: Signature;
+
+    /**
+     * The committer of the commit (who committed the changes).
+     * This may differ from the author in cases like cherry-picks or rebases.
+     */
+    readonly committer: Signature;
+
+    /**
+     * Unix timestamp of when the commit was created.
+     * This is the committer's timestamp.
+     * @example 1704067200
+     */
+    readonly time: number;
+  }
+
+  /**
+   * Represents a Git repository.
+   *
+   * Use {@link Repository.open} to open an existing repository.
+   *
+   * @example
+   * ```ts
+   * import { Repository } from 'bun:git';
+   *
+   * // Open the repository at the current directory
+   * const repo = Repository.open('.');
+   *
+   * // Get repository info
+   * console.log('Path:', repo.path);        // "/path/to/repo/.git/"
+   * console.log('Workdir:', repo.workdir);  // "/path/to/repo/"
+   * console.log('Is bare:', repo.isBare);   // false
+   *
+   * // Get the HEAD commit
+   * const head = repo.head();
+   * console.log('HEAD:', head.id.slice(0, 7), head.summary);
+   * ```
+   */
+  export class Repository {
+    /**
+     * Opens an existing Git repository.
+     *
+     * The path can point to either a working directory or a bare repository.
+     * If the path points to a working directory, the `.git` directory will be located automatically.
+     *
+     * @param path Path to the repository (working directory or .git directory)
+     * @returns A Repository instance
+     * @throws Error if the path is not a valid Git repository
+     *
+     * @example
+     * ```ts
+     * // Open by working directory
+     * const repo = Repository.open('/path/to/project');
+     *
+     * // Open by .git directory
+     * const repo2 = Repository.open('/path/to/project/.git');
+     *
+     * // Open current directory
+     * const repo3 = Repository.open('.');
+     * ```
+     */
+    static open(path: string): Repository;
+
+    /**
+     * Gets the commit that HEAD currently points to.
+     *
+     * @returns The commit that HEAD references
+     * @throws Error if HEAD is unborn (new repository with no commits)
+     *
+     * @example
+     * ```ts
+     * const head = repo.head();
+     * console.log(`Current commit: ${head.summary}`);
+     * console.log(`Author: ${head.author.name}`);
+     * ```
+     */
+    head(): Commit;
+
+    /**
+     * The path to the `.git` directory.
+     * Always ends with a trailing slash.
+     *
+     * @example "/Users/me/project/.git/"
+     */
+    readonly path: string;
+
+    /**
+     * The path to the working directory.
+     * Returns `null` for bare repositories.
+     * When present, always ends with a trailing slash.
+     *
+     * @example "/Users/me/project/"
+     */
+    readonly workdir: string | null;
+
+    /**
+     * Whether this is a bare repository.
+     * Bare repositories have no working directory.
+     *
+     * @example
+     * ```ts
+     * if (repo.isBare) {
+     *   console.log('This is a bare repository');
+     * }
+     * ```
+     */
+    readonly isBare: boolean;
+  }
+
+  export default Repository;
+}

--- a/packages/bun-types/git.d.ts
+++ b/packages/bun-types/git.d.ts
@@ -41,6 +41,283 @@ declare module "bun:git" {
   }
 
   /**
+   * Status flags for working directory entries.
+   * These are bit flags that can be combined with bitwise OR.
+   *
+   * @example
+   * ```ts
+   * import { Status } from 'bun:git';
+   *
+   * const entries = repo.getStatus();
+   * for (const entry of entries) {
+   *   if (entry.status & Status.WT_MODIFIED) {
+   *     console.log('Modified in workdir:', entry.path);
+   *   }
+   *   if (entry.status & Status.INDEX_NEW) {
+   *     console.log('New in index:', entry.path);
+   *   }
+   * }
+   * ```
+   */
+  export const Status: {
+    /** Entry is current and unchanged */
+    readonly CURRENT: 0;
+    /** Entry is new in the index */
+    readonly INDEX_NEW: 1;
+    /** Entry is modified in the index */
+    readonly INDEX_MODIFIED: 2;
+    /** Entry is deleted in the index */
+    readonly INDEX_DELETED: 4;
+    /** Entry is renamed in the index */
+    readonly INDEX_RENAMED: 8;
+    /** Entry type changed in the index */
+    readonly INDEX_TYPECHANGE: 16;
+    /** Entry is new in the working tree */
+    readonly WT_NEW: 128;
+    /** Entry is modified in the working tree */
+    readonly WT_MODIFIED: 256;
+    /** Entry is deleted in the working tree */
+    readonly WT_DELETED: 512;
+    /** Entry type changed in the working tree */
+    readonly WT_TYPECHANGE: 1024;
+    /** Entry is renamed in the working tree */
+    readonly WT_RENAMED: 2048;
+    /** Entry is ignored */
+    readonly IGNORED: 16384;
+    /** Entry is conflicted */
+    readonly CONFLICTED: 32768;
+  };
+
+  /**
+   * Delta types for diff entries.
+   *
+   * @example
+   * ```ts
+   * import { DeltaType } from 'bun:git';
+   *
+   * const diff = repo.diff();
+   * for (const file of diff.files) {
+   *   if (file.status === DeltaType.ADDED) {
+   *     console.log('Added:', file.newPath);
+   *   }
+   * }
+   * ```
+   */
+  export const DeltaType: {
+    /** No changes */
+    readonly UNMODIFIED: 0;
+    /** Entry does not exist in old version */
+    readonly ADDED: 1;
+    /** Entry does not exist in new version */
+    readonly DELETED: 2;
+    /** Entry content changed between old and new */
+    readonly MODIFIED: 3;
+    /** Entry was renamed between old and new */
+    readonly RENAMED: 4;
+    /** Entry was copied from another old entry */
+    readonly COPIED: 5;
+    /** Entry is ignored item in workdir */
+    readonly IGNORED: 6;
+    /** Entry is untracked item in workdir */
+    readonly UNTRACKED: 7;
+    /** Entry type changed between old and new */
+    readonly TYPECHANGE: 8;
+    /** Entry is unreadable */
+    readonly CONFLICTED: 10;
+  };
+
+  /**
+   * Options for getting repository status.
+   */
+  export interface StatusOptions {
+    /**
+     * Include untracked files in the status.
+     * @default true
+     */
+    includeUntracked?: boolean;
+
+    /**
+     * Include ignored files in the status.
+     * @default false
+     */
+    includeIgnored?: boolean;
+
+    /**
+     * Recurse into untracked directories.
+     * @default true
+     */
+    recurseUntrackedDirs?: boolean;
+
+    /**
+     * Detect renamed files.
+     * @default false
+     */
+    detectRenames?: boolean;
+  }
+
+  /**
+   * Represents a status entry for a file in the working directory.
+   */
+  export class StatusEntry {
+    /**
+     * The path of the file relative to the repository root.
+     */
+    readonly path: string;
+
+    /**
+     * Status flags (combination of Status values).
+     */
+    readonly status: number;
+
+    /**
+     * Check if the entry is new (untracked or staged as new).
+     */
+    isNew(): boolean;
+
+    /**
+     * Check if the entry is modified.
+     */
+    isModified(): boolean;
+
+    /**
+     * Check if the entry is deleted.
+     */
+    isDeleted(): boolean;
+
+    /**
+     * Check if the entry is renamed.
+     */
+    isRenamed(): boolean;
+
+    /**
+     * Check if the entry is ignored.
+     */
+    isIgnored(): boolean;
+
+    /**
+     * Check if the entry has changes staged in the index.
+     */
+    inIndex(): boolean;
+
+    /**
+     * Check if the entry has changes in the working tree.
+     */
+    inWorkingTree(): boolean;
+  }
+
+  /**
+   * Represents an entry in the Git index.
+   */
+  export interface IndexEntry {
+    /**
+     * The path of the file relative to the repository root.
+     */
+    readonly path: string;
+
+    /**
+     * The file mode (e.g., 0o100644 for regular files).
+     */
+    readonly mode: number;
+
+    /**
+     * The blob OID (SHA-1 hash) of the file content.
+     */
+    readonly oid: string;
+
+    /**
+     * The stage number (0 for normal, 1-3 for conflict stages).
+     */
+    readonly stage: number;
+
+    /**
+     * The file size in bytes.
+     */
+    readonly size: number;
+  }
+
+  /**
+   * Options for getting diff information.
+   */
+  export interface DiffOptions {
+    /**
+     * If true, compare HEAD to index (staged changes).
+     * If false, compare HEAD to working directory.
+     * @default false
+     */
+    cached?: boolean;
+  }
+
+  /**
+   * Represents a changed file in a diff.
+   */
+  export interface DiffFile {
+    /**
+     * The type of change (see DeltaType).
+     */
+    readonly status: number;
+
+    /**
+     * The old path (null for added files).
+     */
+    readonly oldPath: string | null;
+
+    /**
+     * The new path.
+     */
+    readonly newPath: string;
+
+    /**
+     * Similarity percentage for renamed/copied files (0-100).
+     */
+    readonly similarity?: number;
+  }
+
+  /**
+   * Result of a diff operation.
+   */
+  export interface DiffResult {
+    /**
+     * List of changed files.
+     */
+    readonly files: DiffFile[];
+
+    /**
+     * Statistics about the diff.
+     */
+    readonly stats: {
+      /** Number of files changed */
+      readonly filesChanged: number;
+      /** Total lines inserted */
+      readonly insertions: number;
+      /** Total lines deleted */
+      readonly deletions: number;
+    };
+  }
+
+  /**
+   * Options for getting commit history.
+   */
+  export interface LogOptions {
+    /**
+     * Starting point for history traversal.
+     * @default "HEAD"
+     */
+    from?: string;
+
+    /**
+     * Range specification (e.g., "origin/main..HEAD").
+     * If provided, `from` is ignored.
+     */
+    range?: string;
+
+    /**
+     * Maximum number of commits to return.
+     * @default unlimited
+     */
+    limit?: number;
+  }
+
+  /**
    * Represents a Git commit object.
    *
    * A commit contains information about a snapshot of the repository,
@@ -184,6 +461,181 @@ declare module "bun:git" {
      * ```
      */
     readonly isBare: boolean;
+
+    /**
+     * Gets the working directory status.
+     *
+     * Returns an array of status entries for all changed files in the
+     * working directory and index.
+     *
+     * @param options Options to control which files are included
+     * @returns Array of status entries
+     *
+     * @example
+     * ```ts
+     * import { Repository, Status } from 'bun:git';
+     *
+     * const repo = Repository.open('.');
+     * const status = repo.getStatus();
+     *
+     * for (const entry of status) {
+     *   if (entry.isModified()) {
+     *     console.log('Modified:', entry.path);
+     *   }
+     *   if (entry.isNew()) {
+     *     console.log('New:', entry.path);
+     *   }
+     * }
+     * ```
+     */
+    getStatus(options?: StatusOptions): StatusEntry[];
+
+    /**
+     * Resolves a revision specification to a commit OID.
+     *
+     * Supports standard Git revision syntax including:
+     * - Branch names: "main", "feature/foo"
+     * - Tag names: "v1.0.0"
+     * - SHA prefixes: "abc123"
+     * - Special refs: "HEAD", "HEAD~1", "HEAD^2"
+     * - Upstream: "@{u}", "main@{u}"
+     *
+     * @param spec The revision specification to resolve
+     * @returns The 40-character hex OID
+     * @throws Error if the spec cannot be resolved
+     *
+     * @example
+     * ```ts
+     * const headOid = repo.revParse('HEAD');
+     * const parentOid = repo.revParse('HEAD~1');
+     * const branchOid = repo.revParse('main');
+     * ```
+     */
+    revParse(spec: string): string;
+
+    /**
+     * Gets the name of the current branch.
+     *
+     * @returns The branch name, or null if HEAD is detached or unborn
+     *
+     * @example
+     * ```ts
+     * const branch = repo.getCurrentBranch();
+     * if (branch) {
+     *   console.log('On branch:', branch);
+     * } else {
+     *   console.log('HEAD is detached');
+     * }
+     * ```
+     */
+    getCurrentBranch(): string | null;
+
+    /**
+     * Gets the ahead/behind counts between two commits.
+     *
+     * This is useful for comparing a local branch to its upstream.
+     *
+     * @param local The local ref (default: "HEAD")
+     * @param upstream The upstream ref (default: "@{u}")
+     * @returns Object with ahead and behind counts
+     *
+     * @example
+     * ```ts
+     * const { ahead, behind } = repo.aheadBehind();
+     * console.log(`${ahead} ahead, ${behind} behind`);
+     *
+     * // Compare specific refs
+     * const { ahead, behind } = repo.aheadBehind('feature', 'origin/main');
+     * ```
+     */
+    aheadBehind(local?: string, upstream?: string): { ahead: number; behind: number };
+
+    /**
+     * Gets the list of files tracked in the index.
+     *
+     * @returns Array of index entries
+     *
+     * @example
+     * ```ts
+     * const files = repo.listFiles();
+     * console.log(`Tracking ${files.length} files`);
+     *
+     * for (const file of files) {
+     *   console.log(`${file.path} (mode: ${file.mode.toString(8)})`);
+     * }
+     * ```
+     */
+    listFiles(): IndexEntry[];
+
+    /**
+     * Gets diff information between HEAD and working directory or index.
+     *
+     * @param options Options to control the diff behavior
+     * @returns Diff result with file list and statistics
+     *
+     * @example
+     * ```ts
+     * import { Repository, DeltaType } from 'bun:git';
+     *
+     * const repo = Repository.open('.');
+     *
+     * // Unstaged changes (HEAD vs workdir)
+     * const diff = repo.diff();
+     * console.log(`${diff.stats.filesChanged} files changed`);
+     * console.log(`+${diff.stats.insertions} -${diff.stats.deletions}`);
+     *
+     * // Staged changes (HEAD vs index)
+     * const staged = repo.diff({ cached: true });
+     *
+     * for (const file of diff.files) {
+     *   if (file.status === DeltaType.MODIFIED) {
+     *     console.log('Modified:', file.newPath);
+     *   }
+     * }
+     * ```
+     */
+    diff(options?: DiffOptions): DiffResult;
+
+    /**
+     * Counts the number of commits in a range.
+     *
+     * @param range Optional range specification (e.g., "origin/main..HEAD")
+     * @returns Number of commits
+     *
+     * @example
+     * ```ts
+     * // Total commits
+     * const total = repo.countCommits();
+     *
+     * // Commits since origin/main
+     * const since = repo.countCommits('origin/main..HEAD');
+     * ```
+     */
+    countCommits(range?: string): number;
+
+    /**
+     * Gets the commit history.
+     *
+     * @param options Options to control the log behavior
+     * @returns Array of commits
+     *
+     * @example
+     * ```ts
+     * // Last 10 commits
+     * const commits = repo.log({ limit: 10 });
+     *
+     * for (const commit of commits) {
+     *   console.log(`${commit.id.slice(0, 7)} ${commit.summary}`);
+     * }
+     *
+     * // Commits in a range
+     * const range = repo.log({ range: 'origin/main..HEAD' });
+     *
+     * // Commits from a specific ref
+     * const fromTag = repo.log({ from: 'v1.0.0', limit: 5 });
+     * ```
+     */
+    log(options?: LogOptions): Commit[];
   }
 
   export default Repository;

--- a/packages/bun-types/index.d.ts
+++ b/packages/bun-types/index.d.ts
@@ -14,6 +14,7 @@
 /// <reference path="./html-rewriter.d.ts" />
 /// <reference path="./jsc.d.ts" />
 /// <reference path="./sqlite.d.ts" />
+/// <reference path="./git.d.ts" />
 /// <reference path="./test.d.ts" />
 /// <reference path="./wasm.d.ts" />
 /// <reference path="./overrides.d.ts" />

--- a/src/bun.js/HardcodedModule.zig
+++ b/src/bun.js/HardcodedModule.zig
@@ -10,6 +10,7 @@ pub const HardcodedModule = enum {
     @"bun:test",
     @"bun:wrap",
     @"bun:sqlite",
+    @"bun:git",
     @"node:assert",
     @"node:assert/strict",
     @"node:async_hooks",
@@ -98,6 +99,7 @@ pub const HardcodedModule = enum {
         .{ "bun:main", .@"bun:main" },
         .{ "bun:test", .@"bun:test" },
         .{ "bun:sqlite", .@"bun:sqlite" },
+        .{ "bun:git", .@"bun:git" },
         .{ "bun:wrap", .@"bun:wrap" },
         .{ "bun:internal-for-testing", .@"bun:internal-for-testing" },
         // Node.js
@@ -366,6 +368,7 @@ pub const HardcodedModule = enum {
             .{ "bun:ffi", .{ .path = "bun:ffi" } },
             .{ "bun:jsc", .{ .path = "bun:jsc" } },
             .{ "bun:sqlite", .{ .path = "bun:sqlite" } },
+            .{ "bun:git", .{ .path = "bun:git" } },
             .{ "bun:wrap", .{ .path = "bun:wrap" } },
             .{ "bun:internal-for-testing", .{ .path = "bun:internal-for-testing" } },
             .{ "ffi", .{ .path = "bun:ffi" } },

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -125,6 +125,7 @@
 #include "JSSocketAddressDTO.h"
 #include "JSReactElement.h"
 #include "JSSQLStatement.h"
+#include "git/JSGit.h"
 #include "JSStringDecoder.h"
 #include "JSTextEncoder.h"
 #include "JSTextEncoderStream.h"
@@ -1866,6 +1867,16 @@ void GlobalObject::finishCreation(VM& vm)
     m_JSSQLStatementStructure.initLater(
         [](const Initializer<Structure>& init) {
             init.set(WebCore::createJSSQLStatementStructure(init.owner));
+        });
+
+    m_JSGitRepositoryStructure.initLater(
+        [](const Initializer<Structure>& init) {
+            init.set(WebCore::createJSGitRepositoryStructure(init.owner));
+        });
+
+    m_JSGitCommitStructure.initLater(
+        [](const Initializer<Structure>& init) {
+            init.set(WebCore::createJSGitCommitStructure(init.owner));
         });
 
     m_V8GlobalInternals.initLater(

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -316,6 +316,9 @@ public:
 
     Structure* JSSQLStatementStructure() const { return m_JSSQLStatementStructure.getInitializedOnMainThread(this); }
 
+    Structure* JSGitRepositoryStructure() const { return m_JSGitRepositoryStructure.getInitializedOnMainThread(this); }
+    Structure* JSGitCommitStructure() const { return m_JSGitCommitStructure.getInitializedOnMainThread(this); }
+
     v8::shim::GlobalInternals* V8GlobalInternals() const { return m_V8GlobalInternals.getInitializedOnMainThread(this); }
 
     Bun::BakeAdditionsToGlobalObject& bakeAdditions() { return m_bakeAdditions; }
@@ -620,6 +623,8 @@ public:
     V(private, LazyPropertyOfGlobalObject<Structure>, m_NapiTypeTagStructure)                                \
                                                                                                              \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSSQLStatementStructure)                             \
+    V(private, LazyPropertyOfGlobalObject<Structure>, m_JSGitRepositoryStructure)                            \
+    V(private, LazyPropertyOfGlobalObject<Structure>, m_JSGitCommitStructure)                                \
     V(private, LazyPropertyOfGlobalObject<v8::shim::GlobalInternals>, m_V8GlobalInternals)                   \
                                                                                                              \
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_bunObject)                                             \

--- a/src/bun.js/bindings/git/JSGit.cpp
+++ b/src/bun.js/bindings/git/JSGit.cpp
@@ -290,7 +290,10 @@ JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryGetStatus, (JSC::JSGlobalObject * lexica
 
     size_t count = git_status_list_entrycount(statusList);
     JSC::JSArray* result = JSC::constructEmptyArray(lexicalGlobalObject, nullptr, count);
-    RETURN_IF_EXCEPTION(scope, {});
+    if (scope.exception()) [[unlikely]] {
+        git_status_list_free(statusList);
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
 
     for (size_t i = 0; i < count; i++) {
         const git_status_entry* entry = git_status_byindex(statusList, i);
@@ -322,7 +325,10 @@ JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryGetStatus, (JSC::JSGlobalObject * lexica
             JSC::jsNumber(static_cast<int>(entry->status)));
 
         result->putDirectIndex(lexicalGlobalObject, i, entryObj);
-        RETURN_IF_EXCEPTION(scope, {});
+        if (scope.exception()) [[unlikely]] {
+            git_status_list_free(statusList);
+            return JSC::JSValue::encode(JSC::jsUndefined());
+        }
     }
 
     git_status_list_free(statusList);
@@ -556,7 +562,10 @@ JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryListFiles, (JSC::JSGlobalObject * lexica
 
     size_t count = git_index_entrycount(index);
     JSC::JSArray* result = JSC::constructEmptyArray(lexicalGlobalObject, nullptr, count);
-    RETURN_IF_EXCEPTION(scope, {});
+    if (scope.exception()) [[unlikely]] {
+        git_index_free(index);
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
 
     for (size_t i = 0; i < count; i++) {
         const git_index_entry* entry = git_index_get_byindex(index, i);
@@ -583,7 +592,10 @@ JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryListFiles, (JSC::JSGlobalObject * lexica
             JSC::jsNumber(static_cast<double>(entry->file_size)));
 
         result->putDirectIndex(lexicalGlobalObject, i, entryObj);
-        RETURN_IF_EXCEPTION(scope, {});
+        if (scope.exception()) [[unlikely]] {
+            git_index_free(index);
+            return JSC::JSValue::encode(JSC::jsUndefined());
+        }
     }
 
     git_index_free(index);
@@ -683,7 +695,10 @@ JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryDiff, (JSC::JSGlobalObject * lexicalGlob
     // Get file list
     size_t numDeltas = git_diff_num_deltas(diff);
     JSC::JSArray* files = JSC::constructEmptyArray(lexicalGlobalObject, nullptr, numDeltas);
-    RETURN_IF_EXCEPTION(scope, {});
+    if (scope.exception()) [[unlikely]] {
+        git_diff_free(diff);
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
 
     for (size_t i = 0; i < numDeltas; i++) {
         const git_diff_delta* delta = git_diff_get_delta(diff, i);
@@ -715,7 +730,10 @@ JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryDiff, (JSC::JSGlobalObject * lexicalGlob
         }
 
         files->putDirectIndex(lexicalGlobalObject, i, fileObj);
-        RETURN_IF_EXCEPTION(scope, {});
+        if (scope.exception()) [[unlikely]] {
+            git_diff_free(diff);
+            return JSC::JSValue::encode(JSC::jsUndefined());
+        }
     }
 
     git_diff_free(diff);

--- a/src/bun.js/bindings/git/JSGit.cpp
+++ b/src/bun.js/bindings/git/JSGit.cpp
@@ -792,7 +792,10 @@ JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryCountCommits, (JSC::JSGlobalObject * lex
         }
 
         WTF::String rangeString = rangeValue.toWTFString(lexicalGlobalObject);
-        RETURN_IF_EXCEPTION(scope, {});
+        if (scope.exception()) [[unlikely]] {
+            git_revwalk_free(walk);
+            return JSC::JSValue::encode(JSC::jsUndefined());
+        }
         WTF::CString rangeCString = rangeString.utf8();
 
         error = git_revwalk_push_range(walk, rangeCString.data());

--- a/src/bun.js/bindings/git/JSGit.cpp
+++ b/src/bun.js/bindings/git/JSGit.cpp
@@ -223,11 +223,725 @@ JSC_DEFINE_CUSTOM_GETTER(jsGitRepositoryIsBare, (JSC::JSGlobalObject * lexicalGl
     return JSC::JSValue::encode(JSC::jsBoolean(git_repository_is_bare(repo)));
 }
 
+// ============================================================================
+// getStatus - Get working directory status
+// ============================================================================
+
+JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryGetStatus, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitRepository* thisObject = JSC::jsDynamicCast<JSGitRepository*>(callFrame->thisValue());
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Repository object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_repository* repo = thisObject->repository();
+    if (!repo) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Repository has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    // Parse options
+    git_status_options opts = GIT_STATUS_OPTIONS_INIT;
+    opts.show = GIT_STATUS_SHOW_INDEX_AND_WORKDIR;
+    opts.flags = GIT_STATUS_OPT_INCLUDE_UNTRACKED | GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS;
+
+    if (callFrame->argumentCount() > 0) {
+        JSC::JSValue optionsValue = callFrame->argument(0);
+        if (optionsValue.isObject()) {
+            JSC::JSObject* options = optionsValue.toObject(lexicalGlobalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+
+            JSC::JSValue includeUntracked = options->get(lexicalGlobalObject, JSC::Identifier::fromString(vm, "includeUntracked"_s));
+            RETURN_IF_EXCEPTION(scope, {});
+            if (!includeUntracked.isUndefined() && !includeUntracked.toBoolean(lexicalGlobalObject)) {
+                opts.flags &= ~GIT_STATUS_OPT_INCLUDE_UNTRACKED;
+            }
+
+            JSC::JSValue includeIgnored = options->get(lexicalGlobalObject, JSC::Identifier::fromString(vm, "includeIgnored"_s));
+            RETURN_IF_EXCEPTION(scope, {});
+            if (!includeIgnored.isUndefined() && includeIgnored.toBoolean(lexicalGlobalObject)) {
+                opts.flags |= GIT_STATUS_OPT_INCLUDE_IGNORED;
+            }
+
+            JSC::JSValue recurseUntrackedDirs = options->get(lexicalGlobalObject, JSC::Identifier::fromString(vm, "recurseUntrackedDirs"_s));
+            RETURN_IF_EXCEPTION(scope, {});
+            if (!recurseUntrackedDirs.isUndefined() && !recurseUntrackedDirs.toBoolean(lexicalGlobalObject)) {
+                opts.flags &= ~GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS;
+            }
+
+            JSC::JSValue detectRenames = options->get(lexicalGlobalObject, JSC::Identifier::fromString(vm, "detectRenames"_s));
+            RETURN_IF_EXCEPTION(scope, {});
+            if (!detectRenames.isUndefined() && detectRenames.toBoolean(lexicalGlobalObject)) {
+                opts.flags |= GIT_STATUS_OPT_RENAMES_HEAD_TO_INDEX | GIT_STATUS_OPT_RENAMES_INDEX_TO_WORKDIR;
+            }
+        }
+    }
+
+    git_status_list* statusList = nullptr;
+    int error = git_status_list_new(&statusList, repo, &opts);
+    if (error < 0) {
+        throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to get status"));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    size_t count = git_status_list_entrycount(statusList);
+    JSC::JSArray* result = JSC::constructEmptyArray(lexicalGlobalObject, nullptr, count);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    for (size_t i = 0; i < count; i++) {
+        const git_status_entry* entry = git_status_byindex(statusList, i);
+        if (!entry)
+            continue;
+
+        JSC::JSObject* entryObj = JSC::constructEmptyObject(lexicalGlobalObject);
+
+        // Get the path (from either index or workdir)
+        const char* path = nullptr;
+        if (entry->head_to_index && entry->head_to_index->new_file.path) {
+            path = entry->head_to_index->new_file.path;
+        } else if (entry->index_to_workdir && entry->index_to_workdir->new_file.path) {
+            path = entry->index_to_workdir->new_file.path;
+        } else if (entry->head_to_index && entry->head_to_index->old_file.path) {
+            path = entry->head_to_index->old_file.path;
+        } else if (entry->index_to_workdir && entry->index_to_workdir->old_file.path) {
+            path = entry->index_to_workdir->old_file.path;
+        }
+
+        if (path) {
+            entryObj->putDirect(vm, JSC::Identifier::fromString(vm, "path"_s),
+                JSC::jsString(vm, WTF::String::fromUTF8(path)));
+        } else {
+            entryObj->putDirect(vm, JSC::Identifier::fromString(vm, "path"_s), JSC::jsEmptyString(vm));
+        }
+
+        entryObj->putDirect(vm, JSC::Identifier::fromString(vm, "status"_s),
+            JSC::jsNumber(static_cast<int>(entry->status)));
+
+        result->putDirectIndex(lexicalGlobalObject, i, entryObj);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    git_status_list_free(statusList);
+    return JSC::JSValue::encode(result);
+}
+
+// ============================================================================
+// revParse - Resolve a revision spec to an OID
+// ============================================================================
+
+JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryRevParse, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitRepository* thisObject = JSC::jsDynamicCast<JSGitRepository*>(callFrame->thisValue());
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Repository object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_repository* repo = thisObject->repository();
+    if (!repo) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Repository has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    if (callFrame->argumentCount() < 1) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "revParse requires a spec argument"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    JSC::JSValue specValue = callFrame->argument(0);
+    if (!specValue.isString()) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Spec must be a string"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    WTF::String specString = specValue.toWTFString(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    WTF::CString specCString = specString.utf8();
+
+    git_object* obj = nullptr;
+    int error = git_revparse_single(&obj, repo, specCString.data());
+    if (error < 0) {
+        throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to parse revision spec"));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    const git_oid* oid = git_object_id(obj);
+    char oidStr[GIT_OID_SHA1_HEXSIZE + 1];
+    git_oid_tostr(oidStr, sizeof(oidStr), oid);
+
+    git_object_free(obj);
+    return JSC::JSValue::encode(JSC::jsString(vm, WTF::String::fromUTF8(oidStr)));
+}
+
+// ============================================================================
+// getCurrentBranch - Get the name of the current branch
+// ============================================================================
+
+JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryGetCurrentBranch, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitRepository* thisObject = JSC::jsDynamicCast<JSGitRepository*>(callFrame->thisValue());
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Repository object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_repository* repo = thisObject->repository();
+    if (!repo) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Repository has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_reference* headRef = nullptr;
+    int error = git_repository_head(&headRef, repo);
+
+    // GIT_EUNBORNBRANCH means HEAD points to a branch that doesn't exist yet
+    if (error == GIT_EUNBORNBRANCH || error == GIT_ENOTFOUND) {
+        return JSC::JSValue::encode(JSC::jsNull());
+    }
+
+    if (error < 0) {
+        throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to get HEAD"));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    // Check if HEAD is detached
+    if (git_repository_head_detached(repo)) {
+        git_reference_free(headRef);
+        return JSC::JSValue::encode(JSC::jsNull());
+    }
+
+    // Get the branch name (strip refs/heads/ prefix)
+    const char* branchName = git_reference_shorthand(headRef);
+    JSC::JSValue result = JSC::jsString(vm, WTF::String::fromUTF8(branchName));
+
+    git_reference_free(headRef);
+    return JSC::JSValue::encode(result);
+}
+
+// ============================================================================
+// aheadBehind - Get ahead/behind counts between two commits
+// ============================================================================
+
+JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryAheadBehind, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitRepository* thisObject = JSC::jsDynamicCast<JSGitRepository*>(callFrame->thisValue());
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Repository object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_repository* repo = thisObject->repository();
+    if (!repo) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Repository has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    // Default to HEAD and @{u} (upstream)
+    WTF::CString localSpec = WTF::String("HEAD"_s).utf8();
+    WTF::CString upstreamSpec;
+
+    // Parse arguments
+    if (callFrame->argumentCount() > 0 && !callFrame->argument(0).isUndefinedOrNull()) {
+        JSC::JSValue localValue = callFrame->argument(0);
+        if (!localValue.isString()) {
+            throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Local must be a string"_s));
+            return JSC::JSValue::encode(JSC::jsUndefined());
+        }
+        WTF::String localString = localValue.toWTFString(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        localSpec = localString.utf8();
+    }
+
+    if (callFrame->argumentCount() > 1 && !callFrame->argument(1).isUndefinedOrNull()) {
+        JSC::JSValue upstreamValue = callFrame->argument(1);
+        if (!upstreamValue.isString()) {
+            throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Upstream must be a string"_s));
+            return JSC::JSValue::encode(JSC::jsUndefined());
+        }
+        WTF::String upstreamString = upstreamValue.toWTFString(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        upstreamSpec = upstreamString.utf8();
+    }
+
+    // Get the local OID
+    git_object* localObj = nullptr;
+    int error = git_revparse_single(&localObj, repo, localSpec.data());
+    if (error < 0) {
+        throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to resolve local ref"));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+    git_oid localOid = *git_object_id(localObj);
+    git_object_free(localObj);
+
+    // Get the upstream OID
+    git_oid upstreamOid;
+    if (upstreamSpec.length() == 0) {
+        // Try to get upstream from @{u}
+        git_object* upstreamObj = nullptr;
+        error = git_revparse_single(&upstreamObj, repo, "@{u}");
+        if (error < 0) {
+            // No upstream configured, return 0 for both
+            JSC::JSObject* result = JSC::constructEmptyObject(lexicalGlobalObject);
+            result->putDirect(vm, JSC::Identifier::fromString(vm, "ahead"_s), JSC::jsNumber(0));
+            result->putDirect(vm, JSC::Identifier::fromString(vm, "behind"_s), JSC::jsNumber(0));
+            return JSC::JSValue::encode(result);
+        }
+        upstreamOid = *git_object_id(upstreamObj);
+        git_object_free(upstreamObj);
+    } else {
+        git_object* upstreamObj = nullptr;
+        error = git_revparse_single(&upstreamObj, repo, upstreamSpec.data());
+        if (error < 0) {
+            throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to resolve upstream ref"));
+            return JSC::JSValue::encode(JSC::jsUndefined());
+        }
+        upstreamOid = *git_object_id(upstreamObj);
+        git_object_free(upstreamObj);
+    }
+
+    size_t ahead = 0, behind = 0;
+    error = git_graph_ahead_behind(&ahead, &behind, repo, &localOid, &upstreamOid);
+    if (error < 0) {
+        throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to compute ahead/behind"));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    JSC::JSObject* result = JSC::constructEmptyObject(lexicalGlobalObject);
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "ahead"_s), JSC::jsNumber(static_cast<double>(ahead)));
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "behind"_s), JSC::jsNumber(static_cast<double>(behind)));
+
+    return JSC::JSValue::encode(result);
+}
+
+// ============================================================================
+// listFiles - Get list of files in the index
+// ============================================================================
+
+JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryListFiles, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitRepository* thisObject = JSC::jsDynamicCast<JSGitRepository*>(callFrame->thisValue());
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Repository object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_repository* repo = thisObject->repository();
+    if (!repo) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Repository has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_index* index = nullptr;
+    int error = git_repository_index(&index, repo);
+    if (error < 0) {
+        throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to get repository index"));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    size_t count = git_index_entrycount(index);
+    JSC::JSArray* result = JSC::constructEmptyArray(lexicalGlobalObject, nullptr, count);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    for (size_t i = 0; i < count; i++) {
+        const git_index_entry* entry = git_index_get_byindex(index, i);
+        if (!entry)
+            continue;
+
+        JSC::JSObject* entryObj = JSC::constructEmptyObject(lexicalGlobalObject);
+
+        entryObj->putDirect(vm, JSC::Identifier::fromString(vm, "path"_s),
+            JSC::jsString(vm, WTF::String::fromUTF8(entry->path)));
+
+        entryObj->putDirect(vm, JSC::Identifier::fromString(vm, "mode"_s),
+            JSC::jsNumber(static_cast<int>(entry->mode)));
+
+        char oidStr[GIT_OID_SHA1_HEXSIZE + 1];
+        git_oid_tostr(oidStr, sizeof(oidStr), &entry->id);
+        entryObj->putDirect(vm, JSC::Identifier::fromString(vm, "oid"_s),
+            JSC::jsString(vm, WTF::String::fromUTF8(oidStr)));
+
+        entryObj->putDirect(vm, JSC::Identifier::fromString(vm, "stage"_s),
+            JSC::jsNumber(GIT_INDEX_ENTRY_STAGE(entry)));
+
+        entryObj->putDirect(vm, JSC::Identifier::fromString(vm, "size"_s),
+            JSC::jsNumber(static_cast<double>(entry->file_size)));
+
+        result->putDirectIndex(lexicalGlobalObject, i, entryObj);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    git_index_free(index);
+    return JSC::JSValue::encode(result);
+}
+
+// ============================================================================
+// diff - Get diff information
+// ============================================================================
+
+JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryDiff, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitRepository* thisObject = JSC::jsDynamicCast<JSGitRepository*>(callFrame->thisValue());
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Repository object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_repository* repo = thisObject->repository();
+    if (!repo) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Repository has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    bool cached = false;
+
+    // Parse options
+    if (callFrame->argumentCount() > 0) {
+        JSC::JSValue optionsValue = callFrame->argument(0);
+        if (optionsValue.isObject()) {
+            JSC::JSObject* options = optionsValue.toObject(lexicalGlobalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+
+            JSC::JSValue cachedValue = options->get(lexicalGlobalObject, JSC::Identifier::fromString(vm, "cached"_s));
+            RETURN_IF_EXCEPTION(scope, {});
+            if (!cachedValue.isUndefined()) {
+                cached = cachedValue.toBoolean(lexicalGlobalObject);
+            }
+        }
+    }
+
+    // Get HEAD tree
+    git_reference* headRef = nullptr;
+    git_commit* headCommit = nullptr;
+    git_tree* headTree = nullptr;
+
+    int error = git_repository_head(&headRef, repo);
+    if (error == 0) {
+        const git_oid* oid = git_reference_target(headRef);
+        if (oid) {
+            error = git_commit_lookup(&headCommit, repo, oid);
+            if (error == 0) {
+                error = git_commit_tree(&headTree, headCommit);
+            }
+        }
+        git_reference_free(headRef);
+    }
+
+    git_diff* diff = nullptr;
+    git_diff_options diffOpts = GIT_DIFF_OPTIONS_INIT;
+
+    if (cached) {
+        // HEAD vs index
+        error = git_diff_tree_to_index(&diff, repo, headTree, nullptr, &diffOpts);
+    } else {
+        // HEAD vs workdir (with index)
+        error = git_diff_tree_to_workdir_with_index(&diff, repo, headTree, &diffOpts);
+    }
+
+    if (headTree)
+        git_tree_free(headTree);
+    if (headCommit)
+        git_commit_free(headCommit);
+
+    if (error < 0) {
+        throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to create diff"));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    // Get stats
+    git_diff_stats* stats = nullptr;
+    error = git_diff_get_stats(&stats, diff);
+    if (error < 0) {
+        git_diff_free(diff);
+        throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to get diff stats"));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    size_t filesChanged = git_diff_stats_files_changed(stats);
+    size_t insertions = git_diff_stats_insertions(stats);
+    size_t deletions = git_diff_stats_deletions(stats);
+    git_diff_stats_free(stats);
+
+    // Get file list
+    size_t numDeltas = git_diff_num_deltas(diff);
+    JSC::JSArray* files = JSC::constructEmptyArray(lexicalGlobalObject, nullptr, numDeltas);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    for (size_t i = 0; i < numDeltas; i++) {
+        const git_diff_delta* delta = git_diff_get_delta(diff, i);
+        if (!delta)
+            continue;
+
+        JSC::JSObject* fileObj = JSC::constructEmptyObject(lexicalGlobalObject);
+
+        fileObj->putDirect(vm, JSC::Identifier::fromString(vm, "status"_s),
+            JSC::jsNumber(static_cast<int>(delta->status)));
+
+        if (delta->old_file.path) {
+            fileObj->putDirect(vm, JSC::Identifier::fromString(vm, "oldPath"_s),
+                JSC::jsString(vm, WTF::String::fromUTF8(delta->old_file.path)));
+        } else {
+            fileObj->putDirect(vm, JSC::Identifier::fromString(vm, "oldPath"_s), JSC::jsNull());
+        }
+
+        if (delta->new_file.path) {
+            fileObj->putDirect(vm, JSC::Identifier::fromString(vm, "newPath"_s),
+                JSC::jsString(vm, WTF::String::fromUTF8(delta->new_file.path)));
+        } else {
+            fileObj->putDirect(vm, JSC::Identifier::fromString(vm, "newPath"_s), JSC::jsNull());
+        }
+
+        if (delta->similarity > 0) {
+            fileObj->putDirect(vm, JSC::Identifier::fromString(vm, "similarity"_s),
+                JSC::jsNumber(static_cast<int>(delta->similarity)));
+        }
+
+        files->putDirectIndex(lexicalGlobalObject, i, fileObj);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    git_diff_free(diff);
+
+    // Build result object
+    JSC::JSObject* result = JSC::constructEmptyObject(lexicalGlobalObject);
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "files"_s), files);
+
+    JSC::JSObject* statsObj = JSC::constructEmptyObject(lexicalGlobalObject);
+    statsObj->putDirect(vm, JSC::Identifier::fromString(vm, "filesChanged"_s),
+        JSC::jsNumber(static_cast<double>(filesChanged)));
+    statsObj->putDirect(vm, JSC::Identifier::fromString(vm, "insertions"_s),
+        JSC::jsNumber(static_cast<double>(insertions)));
+    statsObj->putDirect(vm, JSC::Identifier::fromString(vm, "deletions"_s),
+        JSC::jsNumber(static_cast<double>(deletions)));
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "stats"_s), statsObj);
+
+    return JSC::JSValue::encode(result);
+}
+
+// ============================================================================
+// countCommits - Count commits in a range
+// ============================================================================
+
+JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryCountCommits, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitRepository* thisObject = JSC::jsDynamicCast<JSGitRepository*>(callFrame->thisValue());
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Repository object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_repository* repo = thisObject->repository();
+    if (!repo) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Repository has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_revwalk* walk = nullptr;
+    int error = git_revwalk_new(&walk, repo);
+    if (error < 0) {
+        throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to create revwalk"));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    // Parse range argument
+    if (callFrame->argumentCount() > 0 && !callFrame->argument(0).isUndefinedOrNull()) {
+        JSC::JSValue rangeValue = callFrame->argument(0);
+        if (!rangeValue.isString()) {
+            git_revwalk_free(walk);
+            throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Range must be a string"_s));
+            return JSC::JSValue::encode(JSC::jsUndefined());
+        }
+
+        WTF::String rangeString = rangeValue.toWTFString(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        WTF::CString rangeCString = rangeString.utf8();
+
+        error = git_revwalk_push_range(walk, rangeCString.data());
+        if (error < 0) {
+            git_revwalk_free(walk);
+            throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to set range"));
+            return JSC::JSValue::encode(JSC::jsUndefined());
+        }
+    } else {
+        // Default to HEAD
+        error = git_revwalk_push_head(walk);
+        if (error < 0) {
+            git_revwalk_free(walk);
+            throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to push HEAD"));
+            return JSC::JSValue::encode(JSC::jsUndefined());
+        }
+    }
+
+    git_revwalk_sorting(walk, GIT_SORT_TIME);
+
+    git_oid oid;
+    size_t count = 0;
+    while (git_revwalk_next(&oid, walk) == 0) {
+        count++;
+    }
+
+    git_revwalk_free(walk);
+    return JSC::JSValue::encode(JSC::jsNumber(static_cast<double>(count)));
+}
+
+// ============================================================================
+// log - Get commit history
+// ============================================================================
+
+JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryLog, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitRepository* thisObject = JSC::jsDynamicCast<JSGitRepository*>(callFrame->thisValue());
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Repository object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_repository* repo = thisObject->repository();
+    if (!repo) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Repository has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    // Parse options
+    WTF::CString fromSpec = WTF::String("HEAD"_s).utf8();
+    WTF::CString rangeSpec;
+    int limit = -1; // -1 means no limit
+
+    if (callFrame->argumentCount() > 0) {
+        JSC::JSValue optionsValue = callFrame->argument(0);
+        if (optionsValue.isObject()) {
+            JSC::JSObject* options = optionsValue.toObject(lexicalGlobalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+
+            JSC::JSValue fromValue = options->get(lexicalGlobalObject, JSC::Identifier::fromString(vm, "from"_s));
+            RETURN_IF_EXCEPTION(scope, {});
+            if (!fromValue.isUndefined() && fromValue.isString()) {
+                WTF::String fromString = fromValue.toWTFString(lexicalGlobalObject);
+                RETURN_IF_EXCEPTION(scope, {});
+                fromSpec = fromString.utf8();
+            }
+
+            JSC::JSValue rangeValue = options->get(lexicalGlobalObject, JSC::Identifier::fromString(vm, "range"_s));
+            RETURN_IF_EXCEPTION(scope, {});
+            if (!rangeValue.isUndefined() && rangeValue.isString()) {
+                WTF::String rangeString = rangeValue.toWTFString(lexicalGlobalObject);
+                RETURN_IF_EXCEPTION(scope, {});
+                rangeSpec = rangeString.utf8();
+            }
+
+            JSC::JSValue limitValue = options->get(lexicalGlobalObject, JSC::Identifier::fromString(vm, "limit"_s));
+            RETURN_IF_EXCEPTION(scope, {});
+            if (!limitValue.isUndefined() && limitValue.isNumber()) {
+                limit = limitValue.toInt32(lexicalGlobalObject);
+                RETURN_IF_EXCEPTION(scope, {});
+            }
+        }
+    }
+
+    git_revwalk* walk = nullptr;
+    int error = git_revwalk_new(&walk, repo);
+    if (error < 0) {
+        throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to create revwalk"));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    if (rangeSpec.length() > 0) {
+        error = git_revwalk_push_range(walk, rangeSpec.data());
+    } else {
+        git_object* fromObj = nullptr;
+        error = git_revparse_single(&fromObj, repo, fromSpec.data());
+        if (error == 0) {
+            error = git_revwalk_push(walk, git_object_id(fromObj));
+            git_object_free(fromObj);
+        }
+    }
+
+    if (error < 0) {
+        git_revwalk_free(walk);
+        throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to set revwalk range"));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_revwalk_sorting(walk, GIT_SORT_TIME);
+
+    auto* globalObject = JSC::jsDynamicCast<Zig::GlobalObject*>(lexicalGlobalObject);
+    if (!globalObject) {
+        git_revwalk_free(walk);
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Invalid global object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    JSC::Structure* commitStructure = globalObject->JSGitCommitStructure();
+
+    // Collect commits
+    Vector<JSC::Strong<JSC::JSObject>> commits;
+    git_oid oid;
+    int count = 0;
+    while (git_revwalk_next(&oid, walk) == 0) {
+        if (limit >= 0 && count >= limit)
+            break;
+
+        git_commit* commit = nullptr;
+        error = git_commit_lookup(&commit, repo, &oid);
+        if (error < 0)
+            continue;
+
+        JSGitCommit* jsCommit = JSGitCommit::create(vm, commitStructure, commit);
+        commits.append(JSC::Strong<JSC::JSObject>(vm, jsCommit));
+        count++;
+    }
+
+    git_revwalk_free(walk);
+
+    // Create result array
+    JSC::JSArray* result = JSC::constructEmptyArray(lexicalGlobalObject, nullptr, commits.size());
+    RETURN_IF_EXCEPTION(scope, {});
+
+    for (size_t i = 0; i < commits.size(); i++) {
+        result->putDirectIndex(lexicalGlobalObject, i, commits[i].get());
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    return JSC::JSValue::encode(result);
+}
+
 static const HashTableValue JSGitRepositoryPrototypeTableValues[] = {
     { "head"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsGitRepositoryHead, 0 } },
     { "path"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsGitRepositoryGetPath, 0 } },
     { "workdir"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsGitRepositoryGetWorkdir, 0 } },
     { "isBare"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsGitRepositoryIsBare, 0 } },
+    { "getStatus"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsGitRepositoryGetStatus, 1 } },
+    { "revParse"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsGitRepositoryRevParse, 1 } },
+    { "getCurrentBranch"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsGitRepositoryGetCurrentBranch, 0 } },
+    { "aheadBehind"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsGitRepositoryAheadBehind, 2 } },
+    { "listFiles"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsGitRepositoryListFiles, 0 } },
+    { "diff"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsGitRepositoryDiff, 1 } },
+    { "countCommits"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsGitRepositoryCountCommits, 1 } },
+    { "log"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsGitRepositoryLog, 1 } },
 };
 
 class JSGitRepositoryPrototype final : public JSC::JSNonFinalObject {

--- a/src/bun.js/bindings/git/JSGit.cpp
+++ b/src/bun.js/bindings/git/JSGit.cpp
@@ -1,0 +1,570 @@
+/*
+ * Copyright (C) 2024 Oven-sh
+ */
+
+#include "root.h"
+
+#include "JavaScriptCore/Error.h"
+#include "JavaScriptCore/Structure.h"
+#include "JavaScriptCore/ThrowScope.h"
+#include "JavaScriptCore/ExceptionScope.h"
+#include "JavaScriptCore/JSType.h"
+
+#include "JSGit.h"
+#include <JavaScriptCore/JSObjectInlines.h>
+#include <JavaScriptCore/FunctionPrototype.h>
+#include <JavaScriptCore/HeapAnalyzer.h>
+#include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
+#include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/ObjectConstructor.h>
+#include <JavaScriptCore/SubspaceInlines.h>
+#include <JavaScriptCore/ObjectPrototype.h>
+#include "BunBuiltinNames.h"
+#include "BunString.h"
+
+#include <git2.h>
+#include <mutex>
+
+namespace WebCore {
+
+// Lazy initialization of libgit2
+static std::once_flag s_libgit2InitFlag;
+
+static void ensureLibgit2Initialized()
+{
+    std::call_once(s_libgit2InitFlag, []() {
+        git_libgit2_init();
+    });
+}
+
+// Helper to create error from libgit2 error
+static JSC::JSValue createGitError(JSC::JSGlobalObject* globalObject, const char* message)
+{
+    const git_error* err = git_error_last();
+    WTF::String errorMessage;
+    if (err && err->message) {
+        errorMessage = WTF::String::fromUTF8(err->message);
+    } else if (message) {
+        errorMessage = WTF::String::fromUTF8(message);
+    } else {
+        errorMessage = "Unknown git error"_s;
+    }
+    return JSC::createError(globalObject, errorMessage);
+}
+
+// ============================================================================
+// JSGitRepository Implementation
+// ============================================================================
+
+JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryOpen, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ensureLibgit2Initialized();
+
+    if (callFrame->argumentCount() < 1) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Repository.open requires a path argument"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    JSC::JSValue pathValue = callFrame->argument(0);
+    if (!pathValue.isString()) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Path must be a string"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    WTF::String pathString = pathValue.toWTFString(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    WTF::CString pathCString = pathString.utf8();
+
+    git_repository* repo = nullptr;
+    int error = git_repository_open(&repo, pathCString.data());
+
+    if (error < 0) {
+        throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to open repository"));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    auto* globalObject = JSC::jsDynamicCast<Zig::GlobalObject*>(lexicalGlobalObject);
+    if (!globalObject) {
+        git_repository_free(repo);
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Invalid global object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    JSC::Structure* structure = globalObject->JSGitRepositoryStructure();
+    JSGitRepository* jsRepo = JSGitRepository::create(vm, structure, repo);
+
+    return JSC::JSValue::encode(jsRepo);
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsGitRepositoryGetPath, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitRepository* thisObject = JSC::jsDynamicCast<JSGitRepository*>(JSC::JSValue::decode(thisValue));
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Repository object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_repository* repo = thisObject->repository();
+    if (!repo) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Repository has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    const char* path = git_repository_path(repo);
+    if (!path) {
+        return JSC::JSValue::encode(JSC::jsNull());
+    }
+
+    return JSC::JSValue::encode(JSC::jsString(vm, WTF::String::fromUTF8(path)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsGitRepositoryGetWorkdir, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitRepository* thisObject = JSC::jsDynamicCast<JSGitRepository*>(JSC::JSValue::decode(thisValue));
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Repository object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_repository* repo = thisObject->repository();
+    if (!repo) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Repository has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    const char* workdir = git_repository_workdir(repo);
+    if (!workdir) {
+        return JSC::JSValue::encode(JSC::jsNull());
+    }
+
+    return JSC::JSValue::encode(JSC::jsString(vm, WTF::String::fromUTF8(workdir)));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsGitRepositoryHead, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitRepository* thisObject = JSC::jsDynamicCast<JSGitRepository*>(callFrame->thisValue());
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Repository object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_repository* repo = thisObject->repository();
+    if (!repo) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Repository has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_reference* headRef = nullptr;
+    int error = git_repository_head(&headRef, repo);
+    if (error < 0) {
+        throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to get HEAD"));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    const git_oid* oid = git_reference_target(headRef);
+    if (!oid) {
+        git_reference_free(headRef);
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "HEAD is not a direct reference"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_commit* commit = nullptr;
+    error = git_commit_lookup(&commit, repo, oid);
+    git_reference_free(headRef);
+
+    if (error < 0) {
+        throwException(lexicalGlobalObject, scope, createGitError(lexicalGlobalObject, "Failed to lookup HEAD commit"));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    auto* globalObject = JSC::jsDynamicCast<Zig::GlobalObject*>(lexicalGlobalObject);
+    if (!globalObject) {
+        git_commit_free(commit);
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Invalid global object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    JSC::Structure* structure = globalObject->JSGitCommitStructure();
+    JSGitCommit* jsCommit = JSGitCommit::create(vm, structure, commit);
+
+    return JSC::JSValue::encode(jsCommit);
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsGitRepositoryIsBare, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitRepository* thisObject = JSC::jsDynamicCast<JSGitRepository*>(JSC::JSValue::decode(thisValue));
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Repository object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_repository* repo = thisObject->repository();
+    if (!repo) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Repository has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    return JSC::JSValue::encode(JSC::jsBoolean(git_repository_is_bare(repo)));
+}
+
+static const HashTableValue JSGitRepositoryPrototypeTableValues[] = {
+    { "head"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsGitRepositoryHead, 0 } },
+    { "path"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsGitRepositoryGetPath, 0 } },
+    { "workdir"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsGitRepositoryGetWorkdir, 0 } },
+    { "isBare"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsGitRepositoryIsBare, 0 } },
+};
+
+class JSGitRepositoryPrototype final : public JSC::JSNonFinalObject {
+public:
+    using Base = JSC::JSNonFinalObject;
+
+    static JSGitRepositoryPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure)
+    {
+        JSGitRepositoryPrototype* ptr = new (NotNull, JSC::allocateCell<JSGitRepositoryPrototype>(vm)) JSGitRepositoryPrototype(vm, globalObject, structure);
+        ptr->finishCreation(vm, globalObject);
+        return ptr;
+    }
+
+    DECLARE_INFO;
+
+    template<typename CellType, JSC::SubspaceAccess>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSGitRepositoryPrototype, Base);
+        return &vm.plainObjectSpace();
+    }
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+    {
+        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
+    }
+
+private:
+    JSGitRepositoryPrototype(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+
+    void finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+    {
+        Base::finishCreation(vm);
+        reifyStaticProperties(vm, JSGitRepositoryPrototype::info(), JSGitRepositoryPrototypeTableValues, *this);
+    }
+};
+
+const ClassInfo JSGitRepositoryPrototype::s_info = { "Repository"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSGitRepositoryPrototype) };
+const ClassInfo JSGitRepository::s_info = { "Repository"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSGitRepository) };
+
+JSGitRepository* JSGitRepository::create(JSC::VM& vm, JSC::Structure* structure, git_repository* repo)
+{
+    JSGitRepository* ptr = new (NotNull, JSC::allocateCell<JSGitRepository>(vm)) JSGitRepository(vm, structure, repo);
+    ptr->finishCreation(vm);
+    return ptr;
+}
+
+void JSGitRepository::finishCreation(JSC::VM& vm)
+{
+    Base::finishCreation(vm);
+}
+
+void JSGitRepository::destroy(JSC::JSCell* cell)
+{
+    JSGitRepository* thisObject = static_cast<JSGitRepository*>(cell);
+    if (thisObject->m_repo) {
+        git_repository_free(thisObject->m_repo);
+        thisObject->m_repo = nullptr;
+    }
+    thisObject->~JSGitRepository();
+}
+
+JSC::Structure* createJSGitRepositoryStructure(JSC::JSGlobalObject* globalObject)
+{
+    JSC::Structure* prototypeStructure = JSGitRepositoryPrototype::createStructure(globalObject->vm(), globalObject, globalObject->objectPrototype());
+    prototypeStructure->setMayBePrototype(true);
+    JSGitRepositoryPrototype* prototype = JSGitRepositoryPrototype::create(globalObject->vm(), globalObject, prototypeStructure);
+    return JSGitRepository::createStructure(globalObject->vm(), globalObject, prototype);
+}
+
+// ============================================================================
+// JSGitCommit Implementation
+// ============================================================================
+
+JSC_DEFINE_CUSTOM_GETTER(jsGitCommitGetId, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitCommit* thisObject = JSC::jsDynamicCast<JSGitCommit*>(JSC::JSValue::decode(thisValue));
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Commit object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_commit* commit = thisObject->commit();
+    if (!commit) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Commit has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    const git_oid* oid = git_commit_id(commit);
+    char oidStr[GIT_OID_SHA1_HEXSIZE + 1];
+    git_oid_tostr(oidStr, sizeof(oidStr), oid);
+
+    return JSC::JSValue::encode(JSC::jsString(vm, WTF::String::fromUTF8(oidStr)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsGitCommitGetMessage, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitCommit* thisObject = JSC::jsDynamicCast<JSGitCommit*>(JSC::JSValue::decode(thisValue));
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Commit object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_commit* commit = thisObject->commit();
+    if (!commit) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Commit has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    const char* message = git_commit_message(commit);
+    if (!message) {
+        return JSC::JSValue::encode(JSC::jsEmptyString(vm));
+    }
+
+    return JSC::JSValue::encode(JSC::jsString(vm, WTF::String::fromUTF8(message)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsGitCommitGetSummary, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitCommit* thisObject = JSC::jsDynamicCast<JSGitCommit*>(JSC::JSValue::decode(thisValue));
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Commit object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_commit* commit = thisObject->commit();
+    if (!commit) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Commit has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    const char* summary = git_commit_summary(commit);
+    if (!summary) {
+        return JSC::JSValue::encode(JSC::jsEmptyString(vm));
+    }
+
+    return JSC::JSValue::encode(JSC::jsString(vm, WTF::String::fromUTF8(summary)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsGitCommitGetAuthor, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitCommit* thisObject = JSC::jsDynamicCast<JSGitCommit*>(JSC::JSValue::decode(thisValue));
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Commit object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_commit* commit = thisObject->commit();
+    if (!commit) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Commit has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    const git_signature* author = git_commit_author(commit);
+    if (!author) {
+        return JSC::JSValue::encode(JSC::jsNull());
+    }
+
+    JSC::JSObject* obj = JSC::constructEmptyObject(lexicalGlobalObject);
+    obj->putDirect(vm, JSC::Identifier::fromString(vm, "name"_s),
+        JSC::jsString(vm, WTF::String::fromUTF8(author->name ? author->name : "")));
+    obj->putDirect(vm, JSC::Identifier::fromString(vm, "email"_s),
+        JSC::jsString(vm, WTF::String::fromUTF8(author->email ? author->email : "")));
+    obj->putDirect(vm, JSC::Identifier::fromString(vm, "time"_s),
+        JSC::jsNumber(static_cast<double>(author->when.time) * 1000.0)); // Convert to milliseconds for JS Date
+
+    return JSC::JSValue::encode(obj);
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsGitCommitGetCommitter, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitCommit* thisObject = JSC::jsDynamicCast<JSGitCommit*>(JSC::JSValue::decode(thisValue));
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Commit object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_commit* commit = thisObject->commit();
+    if (!commit) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Commit has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    const git_signature* committer = git_commit_committer(commit);
+    if (!committer) {
+        return JSC::JSValue::encode(JSC::jsNull());
+    }
+
+    JSC::JSObject* obj = JSC::constructEmptyObject(lexicalGlobalObject);
+    obj->putDirect(vm, JSC::Identifier::fromString(vm, "name"_s),
+        JSC::jsString(vm, WTF::String::fromUTF8(committer->name ? committer->name : "")));
+    obj->putDirect(vm, JSC::Identifier::fromString(vm, "email"_s),
+        JSC::jsString(vm, WTF::String::fromUTF8(committer->email ? committer->email : "")));
+    obj->putDirect(vm, JSC::Identifier::fromString(vm, "time"_s),
+        JSC::jsNumber(static_cast<double>(committer->when.time) * 1000.0));
+
+    return JSC::JSValue::encode(obj);
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsGitCommitGetTime, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSGitCommit* thisObject = JSC::jsDynamicCast<JSGitCommit*>(JSC::JSValue::decode(thisValue));
+    if (!thisObject) {
+        throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected Commit object"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_commit* commit = thisObject->commit();
+    if (!commit) {
+        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Commit has been freed"_s));
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+
+    git_time_t time = git_commit_time(commit);
+    return JSC::JSValue::encode(JSC::jsNumber(static_cast<double>(time)));
+}
+
+static const HashTableValue JSGitCommitPrototypeTableValues[] = {
+    { "id"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsGitCommitGetId, 0 } },
+    { "message"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsGitCommitGetMessage, 0 } },
+    { "summary"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsGitCommitGetSummary, 0 } },
+    { "author"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsGitCommitGetAuthor, 0 } },
+    { "committer"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsGitCommitGetCommitter, 0 } },
+    { "time"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsGitCommitGetTime, 0 } },
+};
+
+class JSGitCommitPrototype final : public JSC::JSNonFinalObject {
+public:
+    using Base = JSC::JSNonFinalObject;
+
+    static JSGitCommitPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure)
+    {
+        JSGitCommitPrototype* ptr = new (NotNull, JSC::allocateCell<JSGitCommitPrototype>(vm)) JSGitCommitPrototype(vm, globalObject, structure);
+        ptr->finishCreation(vm, globalObject);
+        return ptr;
+    }
+
+    DECLARE_INFO;
+
+    template<typename CellType, JSC::SubspaceAccess>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSGitCommitPrototype, Base);
+        return &vm.plainObjectSpace();
+    }
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+    {
+        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
+    }
+
+private:
+    JSGitCommitPrototype(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+
+    void finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+    {
+        Base::finishCreation(vm);
+        reifyStaticProperties(vm, JSGitCommitPrototype::info(), JSGitCommitPrototypeTableValues, *this);
+    }
+};
+
+const ClassInfo JSGitCommitPrototype::s_info = { "Commit"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSGitCommitPrototype) };
+const ClassInfo JSGitCommit::s_info = { "Commit"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSGitCommit) };
+
+JSGitCommit* JSGitCommit::create(JSC::VM& vm, JSC::Structure* structure, git_commit* commit)
+{
+    JSGitCommit* ptr = new (NotNull, JSC::allocateCell<JSGitCommit>(vm)) JSGitCommit(vm, structure, commit);
+    ptr->finishCreation(vm);
+    return ptr;
+}
+
+void JSGitCommit::finishCreation(JSC::VM& vm)
+{
+    Base::finishCreation(vm);
+}
+
+void JSGitCommit::destroy(JSC::JSCell* cell)
+{
+    JSGitCommit* thisObject = static_cast<JSGitCommit*>(cell);
+    if (thisObject->m_commit) {
+        git_commit_free(thisObject->m_commit);
+        thisObject->m_commit = nullptr;
+    }
+    thisObject->~JSGitCommit();
+}
+
+JSC::Structure* createJSGitCommitStructure(JSC::JSGlobalObject* globalObject)
+{
+    JSC::Structure* prototypeStructure = JSGitCommitPrototype::createStructure(globalObject->vm(), globalObject, globalObject->objectPrototype());
+    prototypeStructure->setMayBePrototype(true);
+    JSGitCommitPrototype* prototype = JSGitCommitPrototype::create(globalObject->vm(), globalObject, prototypeStructure);
+    return JSGitCommit::createStructure(globalObject->vm(), globalObject, prototype);
+}
+
+// ============================================================================
+// Module Creation (called from $cpp in git.ts)
+// ============================================================================
+
+JSC::JSValue createJSGitModule(Zig::GlobalObject* globalObject)
+{
+    JSC::VM& vm = globalObject->vm();
+
+    // Create the module object with Repository.open as a static method
+    JSC::JSObject* module = JSC::constructEmptyObject(globalObject);
+
+    // Add Repository class/namespace with static methods
+    JSC::JSObject* repositoryObj = JSC::constructEmptyObject(globalObject);
+    repositoryObj->putDirect(vm, JSC::Identifier::fromString(vm, "open"_s),
+        JSC::JSFunction::create(vm, globalObject, 1, "open"_s, jsGitRepositoryOpen, ImplementationVisibility::Public));
+
+    module->putDirect(vm, JSC::Identifier::fromString(vm, "Repository"_s), repositoryObj);
+
+    return module;
+}
+
+} // namespace WebCore

--- a/src/bun.js/bindings/git/JSGit.h
+++ b/src/bun.js/bindings/git/JSGit.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2024 Oven-sh
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "root.h"
+#include "ZigGlobalObject.h"
+
+#include <JavaScriptCore/JSFunction.h>
+#include <JavaScriptCore/JSDestructibleObject.h>
+#include <JavaScriptCore/VM.h>
+
+#include "headers-handwritten.h"
+#include "BunClientData.h"
+#include <JavaScriptCore/CallFrame.h>
+
+// Forward declarations for libgit2 types
+typedef struct git_repository git_repository;
+typedef struct git_commit git_commit;
+typedef struct git_oid git_oid;
+
+namespace WebCore {
+
+// Forward declarations
+class JSGitRepository;
+class JSGitCommit;
+class JSGitOid;
+
+// JSGitRepository - Wraps git_repository*
+class JSGitRepository final : public JSC::JSDestructibleObject {
+public:
+    using Base = JSC::JSDestructibleObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    static JSGitRepository* create(JSC::VM& vm, JSC::Structure* structure, git_repository* repo);
+    static void destroy(JSC::JSCell* cell);
+
+    DECLARE_INFO;
+
+    template<typename CellType, JSC::SubspaceAccess mode>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        return WebCore::subspaceForImpl<JSGitRepository, WebCore::UseCustomHeapCellType::No>(
+            vm,
+            [](auto& spaces) { return spaces.m_clientSubspaceForJSGitRepository.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSGitRepository = std::forward<decltype(space)>(space); },
+            [](auto& spaces) { return spaces.m_subspaceForJSGitRepository.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSGitRepository = std::forward<decltype(space)>(space); });
+    }
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+    {
+        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
+    }
+
+    git_repository* repository() const { return m_repo; }
+
+private:
+    JSGitRepository(JSC::VM& vm, JSC::Structure* structure, git_repository* repo)
+        : Base(vm, structure)
+        , m_repo(repo)
+    {
+    }
+
+    void finishCreation(JSC::VM& vm);
+
+    git_repository* m_repo { nullptr };
+};
+
+// JSGitCommit - Wraps git_commit*
+class JSGitCommit final : public JSC::JSDestructibleObject {
+public:
+    using Base = JSC::JSDestructibleObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    static JSGitCommit* create(JSC::VM& vm, JSC::Structure* structure, git_commit* commit);
+    static void destroy(JSC::JSCell* cell);
+
+    DECLARE_INFO;
+
+    template<typename CellType, JSC::SubspaceAccess mode>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        return WebCore::subspaceForImpl<JSGitCommit, WebCore::UseCustomHeapCellType::No>(
+            vm,
+            [](auto& spaces) { return spaces.m_clientSubspaceForJSGitCommit.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSGitCommit = std::forward<decltype(space)>(space); },
+            [](auto& spaces) { return spaces.m_subspaceForJSGitCommit.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSGitCommit = std::forward<decltype(space)>(space); });
+    }
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+    {
+        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
+    }
+
+    git_commit* commit() const { return m_commit; }
+
+private:
+    JSGitCommit(JSC::VM& vm, JSC::Structure* structure, git_commit* commit)
+        : Base(vm, structure)
+        , m_commit(commit)
+    {
+    }
+
+    void finishCreation(JSC::VM& vm);
+
+    git_commit* m_commit { nullptr };
+};
+
+// Structure creation functions
+JSC::Structure* createJSGitRepositoryStructure(JSC::JSGlobalObject* globalObject);
+JSC::Structure* createJSGitCommitStructure(JSC::JSGlobalObject* globalObject);
+
+// Module creation function (called from $cpp)
+JSC::JSValue createJSGitModule(Zig::GlobalObject* globalObject);
+
+} // namespace WebCore

--- a/src/bun.js/bindings/webcore/DOMClientIsoSubspaces.h
+++ b/src/bun.js/bindings/webcore/DOMClientIsoSubspaces.h
@@ -24,6 +24,8 @@ public:
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForNapiPrototype;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSSQLStatement;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSSQLStatementConstructor;
+    std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSGitRepository;
+    std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSGitCommit;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSSinkConstructor;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSSinkController;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSSink;

--- a/src/bun.js/bindings/webcore/DOMIsoSubspaces.h
+++ b/src/bun.js/bindings/webcore/DOMIsoSubspaces.h
@@ -24,6 +24,8 @@ public:
     std::unique_ptr<IsoSubspace> m_subspaceForNapiPrototype;
     std::unique_ptr<IsoSubspace> m_subspaceForJSSQLStatement;
     std::unique_ptr<IsoSubspace> m_subspaceForJSSQLStatementConstructor;
+    std::unique_ptr<IsoSubspace> m_subspaceForJSGitRepository;
+    std::unique_ptr<IsoSubspace> m_subspaceForJSGitCommit;
     std::unique_ptr<IsoSubspace> m_subspaceForJSSinkConstructor;
     std::unique_ptr<IsoSubspace> m_subspaceForJSSinkController;
     std::unique_ptr<IsoSubspace> m_subspaceForJSSink;

--- a/src/js/bun/git.ts
+++ b/src/js/bun/git.ts
@@ -12,14 +12,131 @@ interface Signature {
   time: number; // Unix timestamp in milliseconds
 }
 
-interface StatusEntry {
+interface StatusOptions {
+  includeUntracked?: boolean;
+  includeIgnored?: boolean;
+  recurseUntrackedDirs?: boolean;
+  detectRenames?: boolean;
+}
+
+interface InternalStatusEntry {
   path: string;
-  status: string;
+  status: number;
+}
+
+interface IndexEntry {
+  path: string;
+  mode: number;
+  oid: string;
+  stage: number;
+  size: number;
+}
+
+interface DiffOptions {
+  cached?: boolean;
+}
+
+interface DiffFile {
+  status: number;
+  oldPath: string | null;
+  newPath: string;
+  similarity?: number;
+}
+
+interface DiffResult {
+  files: DiffFile[];
+  stats: {
+    filesChanged: number;
+    insertions: number;
+    deletions: number;
+  };
 }
 
 interface LogOptions {
   from?: string;
+  range?: string;
   limit?: number;
+}
+
+// Status constants (nodegit compatible)
+const Status = {
+  CURRENT: 0,
+  INDEX_NEW: 1,
+  INDEX_MODIFIED: 2,
+  INDEX_DELETED: 4,
+  INDEX_RENAMED: 8,
+  INDEX_TYPECHANGE: 16,
+  WT_NEW: 128,
+  WT_MODIFIED: 256,
+  WT_DELETED: 512,
+  WT_TYPECHANGE: 1024,
+  WT_RENAMED: 2048,
+  IGNORED: 16384,
+  CONFLICTED: 32768,
+};
+
+// DeltaType constants (nodegit compatible)
+const DeltaType = {
+  UNMODIFIED: 0,
+  ADDED: 1,
+  DELETED: 2,
+  MODIFIED: 3,
+  RENAMED: 4,
+  COPIED: 5,
+  IGNORED: 6,
+  UNTRACKED: 7,
+  TYPECHANGE: 8,
+  CONFLICTED: 10,
+};
+
+class StatusEntry {
+  path: string;
+  status: number;
+
+  constructor(entry: InternalStatusEntry) {
+    this.path = entry.path;
+    this.status = entry.status;
+  }
+
+  isNew(): boolean {
+    return (this.status & (Status.INDEX_NEW | Status.WT_NEW)) !== 0;
+  }
+
+  isModified(): boolean {
+    return (this.status & (Status.INDEX_MODIFIED | Status.WT_MODIFIED)) !== 0;
+  }
+
+  isDeleted(): boolean {
+    return (this.status & (Status.INDEX_DELETED | Status.WT_DELETED)) !== 0;
+  }
+
+  isRenamed(): boolean {
+    return (this.status & (Status.INDEX_RENAMED | Status.WT_RENAMED)) !== 0;
+  }
+
+  isIgnored(): boolean {
+    return (this.status & Status.IGNORED) !== 0;
+  }
+
+  inIndex(): boolean {
+    return (
+      (this.status &
+        (Status.INDEX_NEW |
+          Status.INDEX_MODIFIED |
+          Status.INDEX_DELETED |
+          Status.INDEX_RENAMED |
+          Status.INDEX_TYPECHANGE)) !==
+      0
+    );
+  }
+
+  inWorkingTree(): boolean {
+    return (
+      (this.status &
+        (Status.WT_NEW | Status.WT_MODIFIED | Status.WT_DELETED | Status.WT_TYPECHANGE | Status.WT_RENAMED)) !==
+      0
+    );
+  }
 }
 
 class Repository {
@@ -67,6 +184,64 @@ class Repository {
    */
   get isBare(): boolean {
     return this.#repo.isBare;
+  }
+
+  /**
+   * Get the working directory status (nodegit compatible)
+   */
+  getStatus(options?: StatusOptions): StatusEntry[] {
+    const entries = this.#repo.getStatus(options);
+    return entries.map((e: InternalStatusEntry) => new StatusEntry(e));
+  }
+
+  /**
+   * Resolve a revision spec to an OID
+   */
+  revParse(spec: string): string {
+    return this.#repo.revParse(spec);
+  }
+
+  /**
+   * Get the name of the current branch (null if detached HEAD or no commits)
+   */
+  getCurrentBranch(): string | null {
+    return this.#repo.getCurrentBranch();
+  }
+
+  /**
+   * Get ahead/behind counts between two commits
+   */
+  aheadBehind(local?: string, upstream?: string): { ahead: number; behind: number } {
+    return this.#repo.aheadBehind(local, upstream);
+  }
+
+  /**
+   * Get list of files in the index
+   */
+  listFiles(): IndexEntry[] {
+    return this.#repo.listFiles();
+  }
+
+  /**
+   * Get diff information
+   */
+  diff(options?: DiffOptions): DiffResult {
+    return this.#repo.diff(options);
+  }
+
+  /**
+   * Count commits in a range
+   */
+  countCommits(range?: string): number {
+    return this.#repo.countCommits(range);
+  }
+
+  /**
+   * Get commit history
+   */
+  log(options?: LogOptions): Commit[] {
+    const commits = this.#repo.log(options);
+    return commits.map((c: any) => new Commit(c));
   }
 }
 
@@ -124,5 +299,8 @@ export default {
   __esModule: true,
   Repository,
   Commit,
+  StatusEntry,
+  Status,
+  DeltaType,
   default: Repository,
 };

--- a/src/js/bun/git.ts
+++ b/src/js/bun/git.ts
@@ -1,0 +1,128 @@
+// Hardcoded module "bun:git"
+
+let Git: any;
+
+function initializeGit() {
+  Git = $cpp("git/JSGit.cpp", "createJSGitModule");
+}
+
+interface Signature {
+  name: string;
+  email: string;
+  time: number; // Unix timestamp in milliseconds
+}
+
+interface StatusEntry {
+  path: string;
+  status: string;
+}
+
+interface LogOptions {
+  from?: string;
+  limit?: number;
+}
+
+class Repository {
+  #repo: any;
+
+  constructor(repo: any) {
+    this.#repo = repo;
+  }
+
+  /**
+   * Open an existing Git repository
+   */
+  static open(path: string): Repository {
+    if (!Git) {
+      initializeGit();
+    }
+    const repo = Git.Repository.open(path);
+    return new Repository(repo);
+  }
+
+  /**
+   * Get the HEAD commit
+   */
+  head(): Commit {
+    const commit = this.#repo.head();
+    return new Commit(commit);
+  }
+
+  /**
+   * Get the .git directory path
+   */
+  get path(): string {
+    return this.#repo.path;
+  }
+
+  /**
+   * Get the working directory path (null for bare repositories)
+   */
+  get workdir(): string | null {
+    return this.#repo.workdir;
+  }
+
+  /**
+   * Check if this is a bare repository
+   */
+  get isBare(): boolean {
+    return this.#repo.isBare;
+  }
+}
+
+class Commit {
+  #commit: any;
+
+  constructor(commit: any) {
+    this.#commit = commit;
+  }
+
+  /**
+   * Get the commit OID (SHA-1 hash)
+   */
+  get id(): string {
+    return this.#commit.id;
+  }
+
+  /**
+   * Get the full commit message
+   */
+  get message(): string {
+    return this.#commit.message;
+  }
+
+  /**
+   * Get the first line of the commit message
+   */
+  get summary(): string {
+    return this.#commit.summary;
+  }
+
+  /**
+   * Get the author signature
+   */
+  get author(): Signature {
+    return this.#commit.author;
+  }
+
+  /**
+   * Get the committer signature
+   */
+  get committer(): Signature {
+    return this.#commit.committer;
+  }
+
+  /**
+   * Get the commit time as Unix timestamp (seconds since epoch)
+   */
+  get time(): number {
+    return this.#commit.time;
+  }
+}
+
+export default {
+  __esModule: true,
+  Repository,
+  Commit,
+  default: Repository,
+};

--- a/test/js/bun/git/repository.test.ts
+++ b/test/js/bun/git/repository.test.ts
@@ -1,4 +1,4 @@
-import { Commit, Repository } from "bun:git";
+import { Commit, DeltaType, Repository, Status, StatusEntry } from "bun:git";
 import { describe, expect, test } from "bun:test";
 
 describe("bun:git", () => {
@@ -104,6 +104,283 @@ describe("bun:git", () => {
       expect(head.time).toBeGreaterThan(0);
       // Should be a reasonable Unix timestamp (after 2020)
       expect(head.time).toBeGreaterThan(1577836800);
+    });
+  });
+
+  describe("getStatus", () => {
+    test("getStatus returns an array of StatusEntry", () => {
+      const repo = Repository.open(".");
+      const status = repo.getStatus();
+
+      expect(Array.isArray(status)).toBe(true);
+      // Each entry should have path and status
+      for (const entry of status) {
+        expect(entry).toBeInstanceOf(StatusEntry);
+        expect(typeof entry.path).toBe("string");
+        expect(typeof entry.status).toBe("number");
+      }
+    });
+
+    test("StatusEntry has helper methods", () => {
+      const repo = Repository.open(".");
+      const status = repo.getStatus();
+
+      // Test that helper methods exist and return booleans
+      for (const entry of status) {
+        expect(typeof entry.isNew()).toBe("boolean");
+        expect(typeof entry.isModified()).toBe("boolean");
+        expect(typeof entry.isDeleted()).toBe("boolean");
+        expect(typeof entry.isRenamed()).toBe("boolean");
+        expect(typeof entry.isIgnored()).toBe("boolean");
+        expect(typeof entry.inIndex()).toBe("boolean");
+        expect(typeof entry.inWorkingTree()).toBe("boolean");
+      }
+    });
+
+    test("getStatus with includeUntracked option", () => {
+      const repo = Repository.open(".");
+
+      const withUntracked = repo.getStatus({ includeUntracked: true });
+      const withoutUntracked = repo.getStatus({ includeUntracked: false });
+
+      // Both should be arrays
+      expect(Array.isArray(withUntracked)).toBe(true);
+      expect(Array.isArray(withoutUntracked)).toBe(true);
+    });
+
+    test("Status constants are defined", () => {
+      expect(Status.CURRENT).toBe(0);
+      expect(Status.INDEX_NEW).toBe(1);
+      expect(Status.INDEX_MODIFIED).toBe(2);
+      expect(Status.INDEX_DELETED).toBe(4);
+      expect(Status.INDEX_RENAMED).toBe(8);
+      expect(Status.WT_NEW).toBe(128);
+      expect(Status.WT_MODIFIED).toBe(256);
+      expect(Status.WT_DELETED).toBe(512);
+      expect(Status.IGNORED).toBe(16384);
+      expect(Status.CONFLICTED).toBe(32768);
+    });
+  });
+
+  describe("revParse", () => {
+    test("revParse resolves HEAD", () => {
+      const repo = Repository.open(".");
+      const oid = repo.revParse("HEAD");
+
+      expect(typeof oid).toBe("string");
+      expect(oid).toMatch(/^[0-9a-f]{40}$/);
+    });
+
+    test("revParse resolves HEAD~1", () => {
+      const repo = Repository.open(".");
+      const head = repo.revParse("HEAD");
+      const parent = repo.revParse("HEAD~1");
+
+      expect(typeof parent).toBe("string");
+      expect(parent).toMatch(/^[0-9a-f]{40}$/);
+      // Parent should be different from HEAD
+      expect(parent).not.toBe(head);
+    });
+
+    test("revParse throws for invalid spec", () => {
+      const repo = Repository.open(".");
+
+      expect(() => repo.revParse("invalid-ref-that-does-not-exist")).toThrow();
+    });
+  });
+
+  describe("getCurrentBranch", () => {
+    test("getCurrentBranch returns a string or null", () => {
+      const repo = Repository.open(".");
+      const branch = repo.getCurrentBranch();
+
+      // It's either a string (branch name) or null (detached HEAD)
+      if (branch !== null) {
+        expect(typeof branch).toBe("string");
+        expect(branch.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("aheadBehind", () => {
+    test("aheadBehind returns ahead and behind counts", () => {
+      const repo = Repository.open(".");
+
+      // This may return {ahead: 0, behind: 0} if no upstream is set
+      const result = repo.aheadBehind();
+
+      expect(typeof result).toBe("object");
+      expect(typeof result.ahead).toBe("number");
+      expect(typeof result.behind).toBe("number");
+      expect(result.ahead).toBeGreaterThanOrEqual(0);
+      expect(result.behind).toBeGreaterThanOrEqual(0);
+    });
+
+    test("aheadBehind with explicit refs", () => {
+      const repo = Repository.open(".");
+
+      // Compare HEAD~5 to HEAD
+      const result = repo.aheadBehind("HEAD", "HEAD~5");
+
+      expect(typeof result.ahead).toBe("number");
+      expect(typeof result.behind).toBe("number");
+      // HEAD should be 5 ahead of HEAD~5
+      expect(result.ahead).toBe(5);
+      expect(result.behind).toBe(0);
+    });
+  });
+
+  describe("listFiles", () => {
+    test("listFiles returns an array of IndexEntry", () => {
+      const repo = Repository.open(".");
+      const files = repo.listFiles();
+
+      expect(Array.isArray(files)).toBe(true);
+      expect(files.length).toBeGreaterThan(0);
+
+      // Check structure of entries
+      for (const entry of files.slice(0, 5)) {
+        expect(typeof entry.path).toBe("string");
+        expect(typeof entry.mode).toBe("number");
+        expect(typeof entry.oid).toBe("string");
+        expect(entry.oid).toMatch(/^[0-9a-f]{40}$/);
+        expect(typeof entry.stage).toBe("number");
+        expect(typeof entry.size).toBe("number");
+      }
+    });
+
+    test("listFiles includes package.json", () => {
+      const repo = Repository.open(".");
+      const files = repo.listFiles();
+
+      const packageJson = files.find(f => f.path === "package.json");
+      expect(packageJson).toBeDefined();
+      expect(packageJson!.path).toBe("package.json");
+    });
+  });
+
+  describe("diff", () => {
+    test("diff returns DiffResult", () => {
+      const repo = Repository.open(".");
+      const diff = repo.diff();
+
+      expect(typeof diff).toBe("object");
+      expect(Array.isArray(diff.files)).toBe(true);
+      expect(typeof diff.stats).toBe("object");
+      expect(typeof diff.stats.filesChanged).toBe("number");
+      expect(typeof diff.stats.insertions).toBe("number");
+      expect(typeof diff.stats.deletions).toBe("number");
+    });
+
+    test("diff with cached option", () => {
+      const repo = Repository.open(".");
+
+      const workdir = repo.diff({ cached: false });
+      const cached = repo.diff({ cached: true });
+
+      // Both should return valid DiffResult
+      expect(typeof workdir.stats.filesChanged).toBe("number");
+      expect(typeof cached.stats.filesChanged).toBe("number");
+    });
+
+    test("diff files have correct structure", () => {
+      const repo = Repository.open(".");
+      const diff = repo.diff();
+
+      for (const file of diff.files) {
+        expect(typeof file.status).toBe("number");
+        // newPath should always be present
+        expect(typeof file.newPath).toBe("string");
+        // oldPath can be string or null
+        expect(file.oldPath === null || typeof file.oldPath === "string").toBe(true);
+      }
+    });
+
+    test("DeltaType constants are defined", () => {
+      expect(DeltaType.UNMODIFIED).toBe(0);
+      expect(DeltaType.ADDED).toBe(1);
+      expect(DeltaType.DELETED).toBe(2);
+      expect(DeltaType.MODIFIED).toBe(3);
+      expect(DeltaType.RENAMED).toBe(4);
+      expect(DeltaType.COPIED).toBe(5);
+      expect(DeltaType.IGNORED).toBe(6);
+      expect(DeltaType.UNTRACKED).toBe(7);
+      expect(DeltaType.TYPECHANGE).toBe(8);
+      expect(DeltaType.CONFLICTED).toBe(10);
+    });
+  });
+
+  describe("countCommits", () => {
+    test("countCommits returns a positive number", () => {
+      const repo = Repository.open(".");
+      const count = repo.countCommits();
+
+      expect(typeof count).toBe("number");
+      expect(count).toBeGreaterThan(0);
+    });
+
+    test("countCommits with range", () => {
+      const repo = Repository.open(".");
+
+      // Count commits between HEAD~10 and HEAD
+      const count = repo.countCommits("HEAD~10..HEAD");
+
+      expect(typeof count).toBe("number");
+      expect(count).toBe(10);
+    });
+  });
+
+  describe("log", () => {
+    test("log returns an array of Commit objects", () => {
+      const repo = Repository.open(".");
+      const commits = repo.log({ limit: 5 });
+
+      expect(Array.isArray(commits)).toBe(true);
+      expect(commits.length).toBe(5);
+
+      for (const commit of commits) {
+        expect(commit).toBeInstanceOf(Commit);
+        expect(commit.id).toMatch(/^[0-9a-f]{40}$/);
+        expect(typeof commit.summary).toBe("string");
+      }
+    });
+
+    test("log with limit option", () => {
+      const repo = Repository.open(".");
+
+      const ten = repo.log({ limit: 10 });
+      const five = repo.log({ limit: 5 });
+
+      expect(ten.length).toBe(10);
+      expect(five.length).toBe(5);
+    });
+
+    test("log with range option", () => {
+      const repo = Repository.open(".");
+
+      const commits = repo.log({ range: "HEAD~5..HEAD" });
+
+      expect(commits.length).toBe(5);
+    });
+
+    test("log with from option", () => {
+      const repo = Repository.open(".");
+      const head = repo.head();
+
+      const commits = repo.log({ from: "HEAD", limit: 1 });
+
+      expect(commits.length).toBe(1);
+      expect(commits[0].id).toBe(head.id);
+    });
+
+    test("log returns commits in chronological order (newest first)", () => {
+      const repo = Repository.open(".");
+      const commits = repo.log({ limit: 5 });
+
+      // Verify commits are sorted by time (newest first)
+      for (let i = 1; i < commits.length; i++) {
+        expect(commits[i - 1].time).toBeGreaterThanOrEqual(commits[i].time);
+      }
     });
   });
 });

--- a/test/js/bun/git/repository.test.ts
+++ b/test/js/bun/git/repository.test.ts
@@ -1,0 +1,109 @@
+import { Commit, Repository } from "bun:git";
+import { describe, expect, test } from "bun:test";
+
+describe("bun:git", () => {
+  describe("Repository", () => {
+    test("Repository.open opens the current repository", () => {
+      // Open the Bun repository itself
+      const repo = Repository.open(".");
+
+      expect(repo).toBeInstanceOf(Repository);
+      expect(typeof repo.path).toBe("string");
+      expect(repo.path).toContain(".git");
+    });
+
+    test("Repository.path returns the .git directory path", () => {
+      const repo = Repository.open(".");
+
+      expect(repo.path).toEndWith(".git/");
+    });
+
+    test("Repository.workdir returns the working directory path", () => {
+      const repo = Repository.open(".");
+
+      expect(repo.workdir).not.toBeNull();
+      expect(typeof repo.workdir).toBe("string");
+    });
+
+    test("Repository.isBare returns false for normal repositories", () => {
+      const repo = Repository.open(".");
+
+      expect(repo.isBare).toBe(false);
+    });
+
+    test("Repository.open throws for non-existent path", () => {
+      expect(() => Repository.open("/nonexistent/path")).toThrow();
+    });
+
+    test("Repository.open throws for non-repository path", () => {
+      expect(() => Repository.open("/tmp")).toThrow();
+    });
+  });
+
+  describe("Commit", () => {
+    test("Repository.head() returns a Commit object", () => {
+      const repo = Repository.open(".");
+      const head = repo.head();
+
+      expect(head).toBeInstanceOf(Commit);
+    });
+
+    test("Commit.id returns a 40-character hex string", () => {
+      const repo = Repository.open(".");
+      const head = repo.head();
+
+      expect(typeof head.id).toBe("string");
+      expect(head.id).toMatch(/^[0-9a-f]{40}$/);
+    });
+
+    test("Commit.message returns the commit message", () => {
+      const repo = Repository.open(".");
+      const head = repo.head();
+
+      expect(typeof head.message).toBe("string");
+      expect(head.message.length).toBeGreaterThan(0);
+    });
+
+    test("Commit.summary returns the first line of the message", () => {
+      const repo = Repository.open(".");
+      const head = repo.head();
+
+      expect(typeof head.summary).toBe("string");
+      expect(head.summary.length).toBeGreaterThan(0);
+      // Summary should not contain newlines
+      expect(head.summary).not.toContain("\n");
+    });
+
+    test("Commit.author returns a Signature object", () => {
+      const repo = Repository.open(".");
+      const head = repo.head();
+      const author = head.author;
+
+      expect(typeof author).toBe("object");
+      expect(typeof author.name).toBe("string");
+      expect(typeof author.email).toBe("string");
+      expect(typeof author.time).toBe("number");
+    });
+
+    test("Commit.committer returns a Signature object", () => {
+      const repo = Repository.open(".");
+      const head = repo.head();
+      const committer = head.committer;
+
+      expect(typeof committer).toBe("object");
+      expect(typeof committer.name).toBe("string");
+      expect(typeof committer.email).toBe("string");
+      expect(typeof committer.time).toBe("number");
+    });
+
+    test("Commit.time returns a Unix timestamp", () => {
+      const repo = Repository.open(".");
+      const head = repo.head();
+
+      expect(typeof head.time).toBe("number");
+      expect(head.time).toBeGreaterThan(0);
+      // Should be a reasonable Unix timestamp (after 2020)
+      expect(head.time).toBeGreaterThan(1577836800);
+    });
+  });
+});

--- a/test/js/bun/git/repository.test.ts
+++ b/test/js/bun/git/repository.test.ts
@@ -1,5 +1,8 @@
 import { Commit, DeltaType, Repository, Status, StatusEntry } from "bun:git";
 import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 describe("bun:git", () => {
   describe("Repository", () => {
@@ -37,6 +40,13 @@ describe("bun:git", () => {
 
     test("Repository.open throws for non-repository path", () => {
       expect(() => Repository.open("/tmp")).toThrow();
+    });
+
+    test("Repository.open works with .git directory path", () => {
+      const repo = Repository.open("./.git");
+
+      expect(repo).toBeInstanceOf(Repository);
+      expect(repo.path).toEndWith(".git/");
     });
   });
 
@@ -148,17 +158,66 @@ describe("bun:git", () => {
       expect(Array.isArray(withoutUntracked)).toBe(true);
     });
 
+    test("getStatus with all options", () => {
+      const repo = Repository.open(".");
+
+      // Should not throw with various option combinations
+      expect(() =>
+        repo.getStatus({
+          includeUntracked: true,
+          includeIgnored: false,
+          recurseUntrackedDirs: true,
+          detectRenames: false,
+        }),
+      ).not.toThrow();
+
+      expect(() =>
+        repo.getStatus({
+          includeUntracked: false,
+          includeIgnored: true,
+          recurseUntrackedDirs: false,
+          detectRenames: true,
+        }),
+      ).not.toThrow();
+    });
+
     test("Status constants are defined", () => {
       expect(Status.CURRENT).toBe(0);
       expect(Status.INDEX_NEW).toBe(1);
       expect(Status.INDEX_MODIFIED).toBe(2);
       expect(Status.INDEX_DELETED).toBe(4);
       expect(Status.INDEX_RENAMED).toBe(8);
+      expect(Status.INDEX_TYPECHANGE).toBe(16);
       expect(Status.WT_NEW).toBe(128);
       expect(Status.WT_MODIFIED).toBe(256);
       expect(Status.WT_DELETED).toBe(512);
+      expect(Status.WT_TYPECHANGE).toBe(1024);
+      expect(Status.WT_RENAMED).toBe(2048);
       expect(Status.IGNORED).toBe(16384);
       expect(Status.CONFLICTED).toBe(32768);
+    });
+
+    test("StatusEntry helper methods work correctly with status flags", () => {
+      // Create a StatusEntry-like object manually to test helpers
+      const entry = new StatusEntry({ path: "test.txt", status: Status.WT_NEW });
+      expect(entry.isNew()).toBe(true);
+      expect(entry.isModified()).toBe(false);
+      expect(entry.inWorkingTree()).toBe(true);
+      expect(entry.inIndex()).toBe(false);
+
+      const modifiedEntry = new StatusEntry({ path: "test.txt", status: Status.INDEX_MODIFIED });
+      expect(modifiedEntry.isModified()).toBe(true);
+      expect(modifiedEntry.isNew()).toBe(false);
+      expect(modifiedEntry.inIndex()).toBe(true);
+
+      const deletedEntry = new StatusEntry({ path: "test.txt", status: Status.WT_DELETED });
+      expect(deletedEntry.isDeleted()).toBe(true);
+
+      const renamedEntry = new StatusEntry({ path: "test.txt", status: Status.INDEX_RENAMED });
+      expect(renamedEntry.isRenamed()).toBe(true);
+
+      const ignoredEntry = new StatusEntry({ path: "test.txt", status: Status.IGNORED });
+      expect(ignoredEntry.isIgnored()).toBe(true);
     });
   });
 
@@ -182,10 +241,60 @@ describe("bun:git", () => {
       expect(parent).not.toBe(head);
     });
 
+    test("revParse resolves HEAD^", () => {
+      const repo = Repository.open(".");
+      const parent1 = repo.revParse("HEAD~1");
+      const parent2 = repo.revParse("HEAD^");
+
+      // HEAD^ and HEAD~1 should be the same for non-merge commits
+      expect(parent1).toBe(parent2);
+    });
+
+    test("revParse resolves HEAD~n for various n", () => {
+      const repo = Repository.open(".");
+
+      const head = repo.revParse("HEAD");
+      const parent1 = repo.revParse("HEAD~1");
+      const parent2 = repo.revParse("HEAD~2");
+      const parent5 = repo.revParse("HEAD~5");
+
+      // All should be different and valid
+      expect(head).not.toBe(parent1);
+      expect(parent1).not.toBe(parent2);
+      expect(parent2).not.toBe(parent5);
+
+      // All should be valid OIDs
+      expect(parent5).toMatch(/^[0-9a-f]{40}$/);
+    });
+
+    test("revParse resolves short SHA", () => {
+      const repo = Repository.open(".");
+      const head = repo.head();
+      const shortSha = head.id.slice(0, 7);
+
+      const resolved = repo.revParse(shortSha);
+      expect(resolved).toBe(head.id);
+    });
+
     test("revParse throws for invalid spec", () => {
       const repo = Repository.open(".");
 
       expect(() => repo.revParse("invalid-ref-that-does-not-exist")).toThrow();
+    });
+
+    test("revParse throws for empty string", () => {
+      const repo = Repository.open(".");
+
+      expect(() => repo.revParse("")).toThrow();
+    });
+
+    test("revParse result matches head().id for HEAD", () => {
+      const repo = Repository.open(".");
+
+      const headFromRevParse = repo.revParse("HEAD");
+      const headFromHead = repo.head().id;
+
+      expect(headFromRevParse).toBe(headFromHead);
     });
   });
 
@@ -198,6 +307,8 @@ describe("bun:git", () => {
       if (branch !== null) {
         expect(typeof branch).toBe("string");
         expect(branch.length).toBeGreaterThan(0);
+        // Branch name should not contain refs/heads/ prefix
+        expect(branch).not.toContain("refs/heads/");
       }
     });
   });
@@ -228,6 +339,37 @@ describe("bun:git", () => {
       expect(result.ahead).toBe(5);
       expect(result.behind).toBe(0);
     });
+
+    test("aheadBehind with same ref returns 0/0", () => {
+      const repo = Repository.open(".");
+
+      const result = repo.aheadBehind("HEAD", "HEAD");
+
+      expect(result.ahead).toBe(0);
+      expect(result.behind).toBe(0);
+    });
+
+    test("aheadBehind is symmetric", () => {
+      const repo = Repository.open(".");
+
+      const result1 = repo.aheadBehind("HEAD", "HEAD~3");
+      const result2 = repo.aheadBehind("HEAD~3", "HEAD");
+
+      expect(result1.ahead).toBe(result2.behind);
+      expect(result1.behind).toBe(result2.ahead);
+    });
+
+    test("aheadBehind throws for invalid local ref", () => {
+      const repo = Repository.open(".");
+
+      expect(() => repo.aheadBehind("invalid-ref-xxx", "HEAD")).toThrow();
+    });
+
+    test("aheadBehind throws for invalid upstream ref", () => {
+      const repo = Repository.open(".");
+
+      expect(() => repo.aheadBehind("HEAD", "invalid-ref-xxx")).toThrow();
+    });
   });
 
   describe("listFiles", () => {
@@ -256,6 +398,37 @@ describe("bun:git", () => {
       const packageJson = files.find(f => f.path === "package.json");
       expect(packageJson).toBeDefined();
       expect(packageJson!.path).toBe("package.json");
+    });
+
+    test("listFiles entries have stage 0 for non-conflicted files", () => {
+      const repo = Repository.open(".");
+      const files = repo.listFiles();
+
+      // In a normal repository, all files should have stage 0
+      for (const entry of files) {
+        expect(entry.stage).toBe(0);
+      }
+    });
+
+    test("listFiles file modes are valid", () => {
+      const repo = Repository.open(".");
+      const files = repo.listFiles();
+
+      // Common file modes: 0o100644 (regular), 0o100755 (executable), 0o120000 (symlink)
+      const validModes = [0o100644, 0o100755, 0o120000, 0o040000, 0o160000];
+
+      for (const entry of files.slice(0, 100)) {
+        expect(validModes).toContain(entry.mode);
+      }
+    });
+
+    test("listFiles returns files in consistent order", () => {
+      const repo = Repository.open(".");
+      const files1 = repo.listFiles();
+      const files2 = repo.listFiles();
+
+      // Same order on repeated calls
+      expect(files1.map(f => f.path)).toEqual(files2.map(f => f.path));
     });
   });
 
@@ -296,6 +469,22 @@ describe("bun:git", () => {
       }
     });
 
+    test("diff stats are non-negative", () => {
+      const repo = Repository.open(".");
+      const diff = repo.diff();
+
+      expect(diff.stats.filesChanged).toBeGreaterThanOrEqual(0);
+      expect(diff.stats.insertions).toBeGreaterThanOrEqual(0);
+      expect(diff.stats.deletions).toBeGreaterThanOrEqual(0);
+    });
+
+    test("diff filesChanged matches files array length", () => {
+      const repo = Repository.open(".");
+      const diff = repo.diff();
+
+      expect(diff.stats.filesChanged).toBe(diff.files.length);
+    });
+
     test("DeltaType constants are defined", () => {
       expect(DeltaType.UNMODIFIED).toBe(0);
       expect(DeltaType.ADDED).toBe(1);
@@ -328,6 +517,30 @@ describe("bun:git", () => {
       expect(typeof count).toBe("number");
       expect(count).toBe(10);
     });
+
+    test("countCommits with various ranges", () => {
+      const repo = Repository.open(".");
+
+      expect(repo.countCommits("HEAD~1..HEAD")).toBe(1);
+      expect(repo.countCommits("HEAD~5..HEAD")).toBe(5);
+      expect(repo.countCommits("HEAD~20..HEAD")).toBe(20);
+    });
+
+    test("countCommits with empty range returns 0", () => {
+      const repo = Repository.open(".");
+
+      // HEAD..HEAD should be 0 commits
+      const count = repo.countCommits("HEAD..HEAD");
+
+      expect(count).toBe(0);
+    });
+
+    test("countCommits throws for invalid range", () => {
+      const repo = Repository.open(".");
+
+      expect(() => repo.countCommits("invalid-ref..HEAD")).toThrow();
+      expect(() => repo.countCommits("HEAD..invalid-ref")).toThrow();
+    });
   });
 
   describe("log", () => {
@@ -355,6 +568,15 @@ describe("bun:git", () => {
       expect(five.length).toBe(5);
     });
 
+    test("log with limit=1", () => {
+      const repo = Repository.open(".");
+
+      const commits = repo.log({ limit: 1 });
+
+      expect(commits.length).toBe(1);
+      expect(commits[0].id).toBe(repo.head().id);
+    });
+
     test("log with range option", () => {
       const repo = Repository.open(".");
 
@@ -373,6 +595,16 @@ describe("bun:git", () => {
       expect(commits[0].id).toBe(head.id);
     });
 
+    test("log with from option using commit SHA", () => {
+      const repo = Repository.open(".");
+      const parent = repo.revParse("HEAD~2");
+
+      const commits = repo.log({ from: parent, limit: 1 });
+
+      expect(commits.length).toBe(1);
+      expect(commits[0].id).toBe(parent);
+    });
+
     test("log returns commits in chronological order (newest first)", () => {
       const repo = Repository.open(".");
       const commits = repo.log({ limit: 5 });
@@ -381,6 +613,303 @@ describe("bun:git", () => {
       for (let i = 1; i < commits.length; i++) {
         expect(commits[i - 1].time).toBeGreaterThanOrEqual(commits[i].time);
       }
+    });
+
+    test("log without limit returns all commits up to HEAD", () => {
+      const repo = Repository.open(".");
+
+      const allCommits = repo.log({});
+      const countedCommits = repo.countCommits();
+
+      expect(allCommits.length).toBe(countedCommits);
+    });
+
+    test("log range matches countCommits", () => {
+      const repo = Repository.open(".");
+
+      const commits = repo.log({ range: "HEAD~7..HEAD" });
+      const count = repo.countCommits("HEAD~7..HEAD");
+
+      expect(commits.length).toBe(count);
+      expect(commits.length).toBe(7);
+    });
+
+    test("log throws for invalid from ref", () => {
+      const repo = Repository.open(".");
+
+      expect(() => repo.log({ from: "invalid-ref-xxx" })).toThrow();
+    });
+
+    test("log throws for invalid range", () => {
+      const repo = Repository.open(".");
+
+      expect(() => repo.log({ range: "invalid..HEAD" })).toThrow();
+    });
+
+    test("log commit properties are accessible", () => {
+      const repo = Repository.open(".");
+      const commits = repo.log({ limit: 3 });
+
+      for (const commit of commits) {
+        // All properties should be accessible without throwing
+        expect(commit.id).toMatch(/^[0-9a-f]{40}$/);
+        expect(typeof commit.message).toBe("string");
+        expect(typeof commit.summary).toBe("string");
+        expect(typeof commit.time).toBe("number");
+        expect(typeof commit.author.name).toBe("string");
+        expect(typeof commit.author.email).toBe("string");
+        expect(typeof commit.committer.name).toBe("string");
+        expect(typeof commit.committer.email).toBe("string");
+      }
+    });
+  });
+
+  describe("temporary repository tests", () => {
+    test("getStatus detects new untracked file", async () => {
+      using dir = tempDir("git-status-test", {});
+      const dirPath = String(dir);
+
+      // Initialize a git repository
+      await Bun.$`git init ${dirPath}`.quiet();
+      await Bun.$`git -C ${dirPath} config user.email "test@test.com"`.quiet();
+      await Bun.$`git -C ${dirPath} config user.name "Test"`.quiet();
+
+      // Create initial commit
+      writeFileSync(join(dirPath, "initial.txt"), "initial content");
+      await Bun.$`git -C ${dirPath} add .`.quiet();
+      await Bun.$`git -C ${dirPath} commit -m "initial"`.quiet();
+
+      // Create an untracked file
+      writeFileSync(join(dirPath, "untracked.txt"), "untracked content");
+
+      const repo = Repository.open(dirPath);
+      const status = repo.getStatus();
+
+      expect(status.length).toBe(1);
+      expect(status[0].path).toBe("untracked.txt");
+      expect(status[0].status & Status.WT_NEW).toBeTruthy();
+      expect(status[0].isNew()).toBe(true);
+    });
+
+    test("getStatus detects modified file", async () => {
+      using dir = tempDir("git-status-modified-test", {});
+      const dirPath = String(dir);
+
+      await Bun.$`git init ${dirPath}`.quiet();
+      await Bun.$`git -C ${dirPath} config user.email "test@test.com"`.quiet();
+      await Bun.$`git -C ${dirPath} config user.name "Test"`.quiet();
+
+      writeFileSync(join(dirPath, "file.txt"), "original content");
+      await Bun.$`git -C ${dirPath} add .`.quiet();
+      await Bun.$`git -C ${dirPath} commit -m "initial"`.quiet();
+
+      // Modify the file
+      writeFileSync(join(dirPath, "file.txt"), "modified content");
+
+      const repo = Repository.open(dirPath);
+      const status = repo.getStatus();
+
+      expect(status.length).toBe(1);
+      expect(status[0].path).toBe("file.txt");
+      expect(status[0].status & Status.WT_MODIFIED).toBeTruthy();
+      expect(status[0].isModified()).toBe(true);
+    });
+
+    test("getStatus detects staged file", async () => {
+      using dir = tempDir("git-status-staged-test", {});
+      const dirPath = String(dir);
+
+      await Bun.$`git init ${dirPath}`.quiet();
+      await Bun.$`git -C ${dirPath} config user.email "test@test.com"`.quiet();
+      await Bun.$`git -C ${dirPath} config user.name "Test"`.quiet();
+
+      writeFileSync(join(dirPath, "file.txt"), "original content");
+      await Bun.$`git -C ${dirPath} add .`.quiet();
+      await Bun.$`git -C ${dirPath} commit -m "initial"`.quiet();
+
+      // Modify and stage
+      writeFileSync(join(dirPath, "file.txt"), "modified content");
+      await Bun.$`git -C ${dirPath} add file.txt`.quiet();
+
+      const repo = Repository.open(dirPath);
+      const status = repo.getStatus();
+
+      expect(status.length).toBe(1);
+      expect(status[0].path).toBe("file.txt");
+      expect(status[0].status & Status.INDEX_MODIFIED).toBeTruthy();
+      expect(status[0].inIndex()).toBe(true);
+    });
+
+    test("getStatus detects deleted file", async () => {
+      using dir = tempDir("git-status-deleted-test", {});
+      const dirPath = String(dir);
+
+      await Bun.$`git init ${dirPath}`.quiet();
+      await Bun.$`git -C ${dirPath} config user.email "test@test.com"`.quiet();
+      await Bun.$`git -C ${dirPath} config user.name "Test"`.quiet();
+
+      writeFileSync(join(dirPath, "file.txt"), "content");
+      await Bun.$`git -C ${dirPath} add .`.quiet();
+      await Bun.$`git -C ${dirPath} commit -m "initial"`.quiet();
+
+      // Delete the file
+      unlinkSync(join(dirPath, "file.txt"));
+
+      const repo = Repository.open(dirPath);
+      const status = repo.getStatus();
+
+      expect(status.length).toBe(1);
+      expect(status[0].path).toBe("file.txt");
+      expect(status[0].status & Status.WT_DELETED).toBeTruthy();
+      expect(status[0].isDeleted()).toBe(true);
+    });
+
+    test("diff detects changes in temp repo", async () => {
+      using dir = tempDir("git-diff-test", {});
+      const dirPath = String(dir);
+
+      await Bun.$`git init ${dirPath}`.quiet();
+      await Bun.$`git -C ${dirPath} config user.email "test@test.com"`.quiet();
+      await Bun.$`git -C ${dirPath} config user.name "Test"`.quiet();
+
+      writeFileSync(join(dirPath, "file.txt"), "line1\nline2\nline3\n");
+      await Bun.$`git -C ${dirPath} add .`.quiet();
+      await Bun.$`git -C ${dirPath} commit -m "initial"`.quiet();
+
+      // Modify the file
+      writeFileSync(join(dirPath, "file.txt"), "line1\nmodified\nline3\nnewline\n");
+
+      const repo = Repository.open(dirPath);
+      const diff = repo.diff();
+
+      expect(diff.files.length).toBe(1);
+      expect(diff.files[0].newPath).toBe("file.txt");
+      expect(diff.files[0].status).toBe(DeltaType.MODIFIED);
+      expect(diff.stats.filesChanged).toBe(1);
+      expect(diff.stats.insertions).toBeGreaterThan(0);
+      expect(diff.stats.deletions).toBeGreaterThan(0);
+    });
+
+    test("diff cached shows staged changes", async () => {
+      using dir = tempDir("git-diff-cached-test", {});
+      const dirPath = String(dir);
+
+      await Bun.$`git init ${dirPath}`.quiet();
+      await Bun.$`git -C ${dirPath} config user.email "test@test.com"`.quiet();
+      await Bun.$`git -C ${dirPath} config user.name "Test"`.quiet();
+
+      writeFileSync(join(dirPath, "file.txt"), "original\n");
+      await Bun.$`git -C ${dirPath} add .`.quiet();
+      await Bun.$`git -C ${dirPath} commit -m "initial"`.quiet();
+
+      // Modify and stage
+      writeFileSync(join(dirPath, "file.txt"), "modified\n");
+      await Bun.$`git -C ${dirPath} add file.txt`.quiet();
+
+      const repo = Repository.open(dirPath);
+      const cachedDiff = repo.diff({ cached: true });
+
+      // Staged changes should show the modification
+      expect(cachedDiff.files.length).toBe(1);
+      expect(cachedDiff.files[0].status).toBe(DeltaType.MODIFIED);
+    });
+
+    test("listFiles in new repo", async () => {
+      using dir = tempDir("git-listfiles-test", {});
+      const dirPath = String(dir);
+
+      await Bun.$`git init ${dirPath}`.quiet();
+      await Bun.$`git -C ${dirPath} config user.email "test@test.com"`.quiet();
+      await Bun.$`git -C ${dirPath} config user.name "Test"`.quiet();
+
+      writeFileSync(join(dirPath, "a.txt"), "a");
+      writeFileSync(join(dirPath, "b.txt"), "b");
+      writeFileSync(join(dirPath, "c.txt"), "c");
+      await Bun.$`git -C ${dirPath} add .`.quiet();
+      await Bun.$`git -C ${dirPath} commit -m "initial"`.quiet();
+
+      const repo = Repository.open(dirPath);
+      const files = repo.listFiles();
+
+      expect(files.length).toBe(3);
+      expect(files.map(f => f.path).sort()).toEqual(["a.txt", "b.txt", "c.txt"]);
+    });
+
+    test("log and countCommits in new repo", async () => {
+      using dir = tempDir("git-log-test", {});
+      const dirPath = String(dir);
+
+      await Bun.$`git init ${dirPath}`.quiet();
+      await Bun.$`git -C ${dirPath} config user.email "test@test.com"`.quiet();
+      await Bun.$`git -C ${dirPath} config user.name "Test"`.quiet();
+
+      // Create 3 commits
+      writeFileSync(join(dirPath, "file.txt"), "1");
+      await Bun.$`git -C ${dirPath} add .`.quiet();
+      await Bun.$`git -C ${dirPath} commit -m "first commit"`.quiet();
+
+      writeFileSync(join(dirPath, "file.txt"), "2");
+      await Bun.$`git -C ${dirPath} add .`.quiet();
+      await Bun.$`git -C ${dirPath} commit -m "second commit"`.quiet();
+
+      writeFileSync(join(dirPath, "file.txt"), "3");
+      await Bun.$`git -C ${dirPath} add .`.quiet();
+      await Bun.$`git -C ${dirPath} commit -m "third commit"`.quiet();
+
+      const repo = Repository.open(dirPath);
+
+      expect(repo.countCommits()).toBe(3);
+
+      const commits = repo.log({});
+      expect(commits.length).toBe(3);
+
+      // Verify all commit messages are present (order may vary due to same timestamp)
+      const summaries = commits.map(c => c.summary).sort();
+      expect(summaries).toEqual(["first commit", "second commit", "third commit"]);
+    });
+
+    test("getCurrentBranch returns main/master in new repo", async () => {
+      using dir = tempDir("git-branch-test", {});
+      const dirPath = String(dir);
+
+      await Bun.$`git init ${dirPath}`.quiet();
+      await Bun.$`git -C ${dirPath} config user.email "test@test.com"`.quiet();
+      await Bun.$`git -C ${dirPath} config user.name "Test"`.quiet();
+
+      writeFileSync(join(dirPath, "file.txt"), "content");
+      await Bun.$`git -C ${dirPath} add .`.quiet();
+      await Bun.$`git -C ${dirPath} commit -m "initial"`.quiet();
+
+      const repo = Repository.open(dirPath);
+      const branch = repo.getCurrentBranch();
+
+      // Default branch could be "main" or "master" depending on git config
+      expect(branch === "main" || branch === "master").toBe(true);
+    });
+
+    test("getCurrentBranch returns null for detached HEAD", async () => {
+      using dir = tempDir("git-detached-test", {});
+      const dirPath = String(dir);
+
+      await Bun.$`git init ${dirPath}`.quiet();
+      await Bun.$`git -C ${dirPath} config user.email "test@test.com"`.quiet();
+      await Bun.$`git -C ${dirPath} config user.name "Test"`.quiet();
+
+      writeFileSync(join(dirPath, "file.txt"), "1");
+      await Bun.$`git -C ${dirPath} add .`.quiet();
+      await Bun.$`git -C ${dirPath} commit -m "first"`.quiet();
+
+      writeFileSync(join(dirPath, "file.txt"), "2");
+      await Bun.$`git -C ${dirPath} add .`.quiet();
+      await Bun.$`git -C ${dirPath} commit -m "second"`.quiet();
+
+      // Detach HEAD
+      await Bun.$`git -C ${dirPath} checkout HEAD~1`.quiet();
+
+      const repo = Repository.open(dirPath);
+      const branch = repo.getCurrentBranch();
+
+      expect(branch).toBeNull();
     });
   });
 });


### PR DESCRIPTION
This PR adds a new `bun:git` module that provides fast, synchronous Git operations powered by [libgit2](https://libgit2.org/). The module is designed for read-only repository inspection, making it ideal for build tools, CI scripts, and development utilities.

## Motivation

Many JavaScript tools need to interact with Git repositories (checking status, reading commit history, detecting branches, etc.). Currently, developers must either:
- Shell out to `git` CLI (slow, requires parsing text output)
- Use libraries like `nodegit` or `isomorphic-git` (large dependencies, often async-only)

`bun:git` provides a fast, built-in alternative with a simple synchronous API.

## API Overview

```typescript
import { Repository, Status, DeltaType } from 'bun:git';

const repo = Repository.open('.');

// Get current state
console.log('Branch:', repo.getCurrentBranch());
console.log('HEAD:', repo.head().summary);

// Check status
for (const entry of repo.getStatus()) {
  if (entry.status & Status.WT_MODIFIED) {
    console.log('Modified:', entry.path);
  }
}

// Get recent commits
for (const commit of repo.log({ limit: 10 })) {
  console.log(`${commit.id.slice(0, 7)} ${commit.summary}`);
}

// Diff information
const diff = repo.diff();
console.log(`${diff.stats.filesChanged} files, +${diff.stats.insertions} -${diff.stats.deletions}`);
```

## Architecture

- **JavaScript layer** (`src/js/bun/git.ts`): Thin wrappers exposing `Repository`, `Commit`, `StatusEntry` classes
- **C++ bindings** (`src/bun.js/bindings/git/JSGit.cpp`): JSC bindings to libgit2
- **libgit2** (`vendor/libgit2`): v1.9.0, compiled as a static library

All operations are synchronous. Resources are cleaned up via normal GC.

## Current Limitations

- **Read-only**: No write operations (commit, stage, checkout)
- **Local only**: No network operations (clone, fetch, push)
- **No submodules/worktrees**
- **No blob content retrieval** (`git show HEAD:<file>`)
- **No git config reading**
- **File-level diff only** (no line-level hunks)

## Future Plans

- More read operations (blob content, config, blame, merge-base)
- Some write operations (stage, commit, reset)