### PR TITLE
fix(stringWidth): correct width for Thai/Lao spacing vowels

### DIFF
--- a/docs/runtime/markdown.mdx
+++ b/docs/runtime/markdown.mdx
@@ -4,7 +4,7 @@ description: Parse and render Markdown with Bun's built-in Markdown API, support
 ---
 
 <Callout type="note">
-**Unstable API** — This API is under active development and may change in future versions of Bun.
+  **Unstable API** — This API is under active development and may change in future versions of Bun.
 </Callout>
 
 Bun includes a fast, built-in Markdown parser written in Zig. It supports GitHub Flavored Markdown (GFM) extensions and provides three APIs:

--- a/src/string/immutable/visible.zig
+++ b/src/string/immutable/visible.zig
@@ -70,11 +70,13 @@ pub fn isZeroWidthCodepointType(comptime T: type, cp: T) bool {
     }
 
     // Thai combining marks
-    if ((cp >= 0xe31 and cp <= 0xe3a) or (cp >= 0xe47 and cp <= 0xe4e))
+    // Note: U+0E32 (SARA AA) and U+0E33 (SARA AM) are Grapheme_Base (spacing vowels), not combining
+    if (cp == 0xe31 or (cp >= 0xe34 and cp <= 0xe3a) or (cp >= 0xe47 and cp <= 0xe4e))
         return true;
 
     // Lao combining marks
-    if ((cp >= 0xeb1 and cp <= 0xebc) or (cp >= 0xec8 and cp <= 0xecd))
+    // Note: U+0EB2 and U+0EB3 are spacing vowels like Thai, not combining
+    if (cp == 0xeb1 or (cp >= 0xeb4 and cp <= 0xebc) or (cp >= 0xec8 and cp <= 0xecd))
         return true;
 
     // Combining Diacritical Marks Extended

--- a/test/js/bun/util/stringWidth.test.ts
+++ b/test/js/bun/util/stringWidth.test.ts
@@ -485,6 +485,28 @@ describe("stringWidth extended", () => {
       expect(Bun.stringWidth("ก็")).toBe(1); // With maitaikhu
       expect(Bun.stringWidth("ปฏัก")).toBe(3); // ป + ฏ + ั (combining) + ก = 3 visible
     });
+
+    test("Thai spacing vowels (SARA AA and SARA AM)", () => {
+      // U+0E32 (SARA AA) and U+0E33 (SARA AM) are spacing vowels, not combining marks
+      expect(Bun.stringWidth("\u0E32")).toBe(1); // SARA AA alone
+      expect(Bun.stringWidth("\u0E33")).toBe(1); // SARA AM alone
+      expect(Bun.stringWidth("ก\u0E32")).toBe(2); // ก + SARA AA
+      expect(Bun.stringWidth("ก\u0E33")).toBe(2); // กำ (KO KAI + SARA AM)
+      expect(Bun.stringWidth("คำ")).toBe(2); // Common Thai word
+      expect(Bun.stringWidth("ทำ")).toBe(2); // Common Thai word
+      // True combining marks should still be zero-width
+      expect(Bun.stringWidth("\u0E31")).toBe(0); // MAI HAN-AKAT (combining)
+      expect(Bun.stringWidth("ก\u0E31")).toBe(1); // กั
+    });
+
+    test("Lao spacing vowels", () => {
+      // U+0EB2 and U+0EB3 are spacing vowels in Lao, similar to Thai
+      expect(Bun.stringWidth("\u0EB2")).toBe(1); // LAO VOWEL SIGN AA
+      expect(Bun.stringWidth("\u0EB3")).toBe(1); // LAO VOWEL SIGN AM
+      expect(Bun.stringWidth("ກ\u0EB2")).toBe(2); // KO + AA
+      // True combining marks should still be zero-width
+      expect(Bun.stringWidth("\u0EB1")).toBe(0); // MAI KAN (combining)
+    });
   });
 
   describe("non-ASCII in escape sequences and Indic script handling", () => {


### PR DESCRIPTION
## Summary

`Bun.stringWidth` was incorrectly treating Thai SARA AA (U+0E32), SARA AM (U+0E33), and their Lao equivalents (U+0EB2, U+0EB3) as zero-width characters.

## Root Cause

In `src/string/immutable/visible.zig`, the range check for Thai/Lao combining marks was too broad:
- Thai: `0xe31 <= cp <= 0xe3a` included U+0E32 and U+0E33
- Lao: `0xeb1 <= cp <= 0xebc` included U+0EB2 and U+0EB3

According to Unicode (UCD Grapheme_Break property), these are **spacing vowels** (Grapheme_Base), not combining marks.

## Changes

- **`src/string/immutable/visible.zig`**: Exclude U+0E32, U+0E33, U+0EB2, U+0EB3 from zero-width ranges
- **`test/js/bun/util/stringWidth.test.ts`**: Add tests for Thai and Lao spacing vowels

## Before/After

| Character | Before | After |
|-----------|--------|-------|
| `\u0E32` (SARA AA) | 0 | 1 |
| `\u0E33` (SARA AM) | 0 | 1 |
| `คำ` (common Thai word) | 1 | 2 |
| `\u0EB2` (Lao AA) | 0 | 1 |
| `\u0EB3` (Lao AM) | 0 | 1 |
