### PR TITLE
fix(docs): update `runtime/markdown` page Callout component

### DIFF
--- a/docs/runtime/markdown.mdx
+++ b/docs/runtime/markdown.mdx
@@ -3,9 +3,9 @@ title: Markdown
 description: Parse and render Markdown with Bun's built-in Markdown API, supporting GFM extensions and custom rendering callbacks
 ---
 
-{% callout type="note" %}
+<Callout type="note">
 **Unstable API** — This API is under active development and may change in future versions of Bun.
-{% /callout %}
+</Callout>
 
 Bun includes a fast, built-in Markdown parser written in Zig. It supports GitHub Flavored Markdown (GFM) extensions and provides three APIs:
 


### PR DESCRIPTION
### What does this PR do?
Fix #26727 
fix the Page Not Found bug 
### How did you verify your code works?
I run the development server:
```bash
mint dev
```

<img width="1287" height="823" alt="Markdown" src="https://github.com/user-attachments/assets/555716b4-1aee-46bd-b066-1e00986b3923" />
