### PR TITLE
fix(http): don't enter tunnel mode for proxy-style absolute URLs in request line

### DIFF
--- a/docs/runtime/markdown.mdx
+++ b/docs/runtime/markdown.mdx
@@ -4,7 +4,7 @@ description: Parse and render Markdown with Bun's built-in Markdown API, support
 ---
 
 <Callout type="note">
-**Unstable API** — This API is under active development and may change in future versions of Bun.
+  **Unstable API** — This API is under active development and may change in future versions of Bun.
 </Callout>
 
 Bun includes a fast, built-in Markdown parser written in Zig. It supports GitHub Flavored Markdown (GFM) extensions and provides three APIs:

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -566,8 +566,10 @@ namespace uWS
 
 
             bool isHTTPMethod = (__builtin_expect(data[1] == '/', 1));
-            bool isConnect = !isHTTPMethod && (isHTTPorHTTPSPrefixForProxies(data + 1, end) == 1 || ((data - start) == 7 && memcmp(start, "CONNECT", 7) == 0));
-            if (isHTTPMethod || isConnect) [[likely]] {
+            bool isConnect = !isHTTPMethod && ((data - start) == 7 && memcmp(start, "CONNECT", 7) == 0);
+            /* Also accept proxy-style absolute URLs (http://... or https://...) as valid request targets */
+            bool isProxyStyleURL = !isHTTPMethod && !isConnect && data[0] == 32 && isHTTPorHTTPSPrefixForProxies(data + 1, end) == 1;
+            if (isHTTPMethod || isConnect || isProxyStyleURL) [[likely]] {
                 header.key = {start, (size_t) (data - start)};
                 data++;
                 if(!isValidMethod(header.key, useStrictMethodValidation)) {

--- a/test/js/node/http/node-http-proxy-url.node.mts
+++ b/test/js/node/http/node-http-proxy-url.node.mts
@@ -1,0 +1,158 @@
+/**
+ * All tests in this file should also run in Node.js.
+ *
+ * Do not add any tests that only run in Bun.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { createServer, request as httpRequest } from "node:http";
+import type { AddressInfo } from "node:net";
+
+// Helper to make a request and get the response
+function makeRequest(port: number, path: string): Promise<{ statusCode: number; body: string; url: string }> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`Request to ${path} timed out after 5000ms`)), 5000);
+    const req = httpRequest({ host: "127.0.0.1", port, path, method: "GET" }, res => {
+      let body = "";
+      res.on("data", chunk => {
+        body += chunk;
+      });
+      res.on("end", () => {
+        clearTimeout(timeout);
+        resolve({ statusCode: res.statusCode!, body, url: path });
+      });
+    });
+    req.on("error", err => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+    req.end();
+  });
+}
+
+function listenOnRandomPort(server: ReturnType<typeof createServer>): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as AddressInfo;
+      resolve(addr.port);
+    });
+  });
+}
+
+describe("HTTP server with proxy-style absolute URLs", () => {
+  test("sequential GET requests with absolute URL paths don't hang", async () => {
+    const server = createServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end(req.url);
+    });
+
+    const port = await listenOnRandomPort(server);
+
+    try {
+      // Make 3 sequential requests with proxy-style absolute URLs
+      // Before the fix, request 2 would hang because the parser entered tunnel mode
+      const r1 = await makeRequest(port, "http://example.com/test1");
+      assert.strictEqual(r1.statusCode, 200);
+      assert.ok(r1.body.includes("example.com"), `Expected body to contain "example.com", got: ${r1.body}`);
+      assert.ok(r1.body.includes("/test1"), `Expected body to contain "/test1", got: ${r1.body}`);
+
+      const r2 = await makeRequest(port, "http://example.com/test2");
+      assert.strictEqual(r2.statusCode, 200);
+      assert.ok(r2.body.includes("example.com"), `Expected body to contain "example.com", got: ${r2.body}`);
+      assert.ok(r2.body.includes("/test2"), `Expected body to contain "/test2", got: ${r2.body}`);
+
+      const r3 = await makeRequest(port, "http://other.com/test3");
+      assert.strictEqual(r3.statusCode, 200);
+      assert.ok(r3.body.includes("other.com"), `Expected body to contain "other.com", got: ${r3.body}`);
+      assert.ok(r3.body.includes("/test3"), `Expected body to contain "/test3", got: ${r3.body}`);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("sequential POST requests with absolute URL paths don't hang", async () => {
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", chunk => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end(`${req.method} ${req.url} body=${body}`);
+      });
+    });
+
+    const port = await listenOnRandomPort(server);
+
+    try {
+      for (let i = 1; i <= 3; i++) {
+        const result = await new Promise<{ statusCode: number; body: string }>((resolve, reject) => {
+          const timeout = setTimeout(() => reject(new Error(`POST request ${i} timed out`)), 5000);
+          const req = httpRequest(
+            {
+              host: "127.0.0.1",
+              port,
+              path: `http://example.com/post${i}`,
+              method: "POST",
+              headers: { "Content-Type": "text/plain" },
+            },
+            res => {
+              let body = "";
+              res.on("data", chunk => {
+                body += chunk;
+              });
+              res.on("end", () => {
+                clearTimeout(timeout);
+                resolve({ statusCode: res.statusCode!, body });
+              });
+            },
+          );
+          req.on("error", err => {
+            clearTimeout(timeout);
+            reject(err);
+          });
+          req.write(`data${i}`);
+          req.end();
+        });
+        assert.strictEqual(result.statusCode, 200);
+        assert.ok(result.body.includes(`/post${i}`), `Expected body to contain "/post${i}", got: ${result.body}`);
+        assert.ok(result.body.includes(`body=data${i}`), `Expected body to contain "body=data${i}", got: ${result.body}`);
+      }
+    } finally {
+      server.close();
+    }
+  });
+
+  test("mixed normal and proxy-style URLs work sequentially", async () => {
+    const server = createServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end(req.url);
+    });
+
+    const port = await listenOnRandomPort(server);
+
+    try {
+      // Mix of normal and proxy-style URLs
+      const r1 = await makeRequest(port, "/normal1");
+      assert.strictEqual(r1.statusCode, 200);
+      assert.ok(r1.body.includes("/normal1"), `Expected body to contain "/normal1", got: ${r1.body}`);
+
+      const r2 = await makeRequest(port, "http://example.com/proxy1");
+      assert.strictEqual(r2.statusCode, 200);
+      assert.ok(r2.body.includes("example.com"), `Expected body to contain "example.com", got: ${r2.body}`);
+      assert.ok(r2.body.includes("/proxy1"), `Expected body to contain "/proxy1", got: ${r2.body}`);
+
+      const r3 = await makeRequest(port, "/normal2");
+      assert.strictEqual(r3.statusCode, 200);
+      assert.ok(r3.body.includes("/normal2"), `Expected body to contain "/normal2", got: ${r3.body}`);
+
+      const r4 = await makeRequest(port, "http://other.com/proxy2");
+      assert.strictEqual(r4.statusCode, 200);
+      assert.ok(r4.body.includes("other.com"), `Expected body to contain "other.com", got: ${r4.body}`);
+      assert.ok(r4.body.includes("/proxy2"), `Expected body to contain "/proxy2", got: ${r4.body}`);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/test/js/node/http/node-http-proxy-url.node.mts
+++ b/test/js/node/http/node-http-proxy-url.node.mts
@@ -6,27 +6,28 @@
 
 import { describe, test } from "node:test";
 import assert from "node:assert";
-import { createServer, request as httpRequest } from "node:http";
+import { Agent, createServer, request as httpRequest } from "node:http";
 import type { AddressInfo } from "node:net";
 
-// Helper to make a request and get the response
-function makeRequest(port: number, path: string): Promise<{ statusCode: number; body: string; url: string }> {
+// Helper to make a request and get the response.
+// Uses a shared agent so that all requests go through the same TCP connection,
+// which is critical for actually testing the keep-alive / proxy-URL bug.
+function makeRequest(
+  port: number,
+  path: string,
+  agent: Agent,
+): Promise<{ statusCode: number; body: string; url: string }> {
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error(`Request to ${path} timed out after 5000ms`)), 5000);
-    const req = httpRequest({ host: "127.0.0.1", port, path, method: "GET" }, res => {
+    const req = httpRequest({ host: "127.0.0.1", port, path, method: "GET", agent }, res => {
       let body = "";
       res.on("data", chunk => {
         body += chunk;
       });
       res.on("end", () => {
-        clearTimeout(timeout);
         resolve({ statusCode: res.statusCode!, body, url: path });
       });
     });
-    req.on("error", err => {
-      clearTimeout(timeout);
-      reject(err);
-    });
+    req.on("error", reject);
     req.end();
   });
 }
@@ -41,7 +42,8 @@ function listenOnRandomPort(server: ReturnType<typeof createServer>): Promise<nu
 }
 
 describe("HTTP server with proxy-style absolute URLs", () => {
-  test("sequential GET requests with absolute URL paths don't hang", async () => {
+  test("sequential GET requests with absolute URL paths don't hang", { timeout: 5000 }, async () => {
+    const agent = new Agent({ keepAlive: true, maxSockets: 1 });
     const server = createServer((req, res) => {
       res.writeHead(200, { "Content-Type": "text/plain" });
       res.end(req.url);
@@ -52,26 +54,28 @@ describe("HTTP server with proxy-style absolute URLs", () => {
     try {
       // Make 3 sequential requests with proxy-style absolute URLs
       // Before the fix, request 2 would hang because the parser entered tunnel mode
-      const r1 = await makeRequest(port, "http://example.com/test1");
+      const r1 = await makeRequest(port, "http://example.com/test1", agent);
       assert.strictEqual(r1.statusCode, 200);
       assert.ok(r1.body.includes("example.com"), `Expected body to contain "example.com", got: ${r1.body}`);
       assert.ok(r1.body.includes("/test1"), `Expected body to contain "/test1", got: ${r1.body}`);
 
-      const r2 = await makeRequest(port, "http://example.com/test2");
+      const r2 = await makeRequest(port, "http://example.com/test2", agent);
       assert.strictEqual(r2.statusCode, 200);
       assert.ok(r2.body.includes("example.com"), `Expected body to contain "example.com", got: ${r2.body}`);
       assert.ok(r2.body.includes("/test2"), `Expected body to contain "/test2", got: ${r2.body}`);
 
-      const r3 = await makeRequest(port, "http://other.com/test3");
+      const r3 = await makeRequest(port, "http://other.com/test3", agent);
       assert.strictEqual(r3.statusCode, 200);
       assert.ok(r3.body.includes("other.com"), `Expected body to contain "other.com", got: ${r3.body}`);
       assert.ok(r3.body.includes("/test3"), `Expected body to contain "/test3", got: ${r3.body}`);
     } finally {
+      agent.destroy();
       server.close();
     }
   });
 
-  test("sequential POST requests with absolute URL paths don't hang", async () => {
+  test("sequential POST requests with absolute URL paths don't hang", { timeout: 5000 }, async () => {
+    const agent = new Agent({ keepAlive: true, maxSockets: 1 });
     const server = createServer((req, res) => {
       let body = "";
       req.on("data", chunk => {
@@ -88,7 +92,6 @@ describe("HTTP server with proxy-style absolute URLs", () => {
     try {
       for (let i = 1; i <= 3; i++) {
         const result = await new Promise<{ statusCode: number; body: string }>((resolve, reject) => {
-          const timeout = setTimeout(() => reject(new Error(`POST request ${i} timed out`)), 5000);
           const req = httpRequest(
             {
               host: "127.0.0.1",
@@ -96,6 +99,7 @@ describe("HTTP server with proxy-style absolute URLs", () => {
               path: `http://example.com/post${i}`,
               method: "POST",
               headers: { "Content-Type": "text/plain" },
+              agent,
             },
             res => {
               let body = "";
@@ -103,15 +107,11 @@ describe("HTTP server with proxy-style absolute URLs", () => {
                 body += chunk;
               });
               res.on("end", () => {
-                clearTimeout(timeout);
                 resolve({ statusCode: res.statusCode!, body });
               });
             },
           );
-          req.on("error", err => {
-            clearTimeout(timeout);
-            reject(err);
-          });
+          req.on("error", reject);
           req.write(`data${i}`);
           req.end();
         });
@@ -120,11 +120,13 @@ describe("HTTP server with proxy-style absolute URLs", () => {
         assert.ok(result.body.includes(`body=data${i}`), `Expected body to contain "body=data${i}", got: ${result.body}`);
       }
     } finally {
+      agent.destroy();
       server.close();
     }
   });
 
-  test("mixed normal and proxy-style URLs work sequentially", async () => {
+  test("mixed normal and proxy-style URLs work sequentially", { timeout: 5000 }, async () => {
+    const agent = new Agent({ keepAlive: true, maxSockets: 1 });
     const server = createServer((req, res) => {
       res.writeHead(200, { "Content-Type": "text/plain" });
       res.end(req.url);
@@ -134,24 +136,25 @@ describe("HTTP server with proxy-style absolute URLs", () => {
 
     try {
       // Mix of normal and proxy-style URLs
-      const r1 = await makeRequest(port, "/normal1");
+      const r1 = await makeRequest(port, "/normal1", agent);
       assert.strictEqual(r1.statusCode, 200);
       assert.ok(r1.body.includes("/normal1"), `Expected body to contain "/normal1", got: ${r1.body}`);
 
-      const r2 = await makeRequest(port, "http://example.com/proxy1");
+      const r2 = await makeRequest(port, "http://example.com/proxy1", agent);
       assert.strictEqual(r2.statusCode, 200);
       assert.ok(r2.body.includes("example.com"), `Expected body to contain "example.com", got: ${r2.body}`);
       assert.ok(r2.body.includes("/proxy1"), `Expected body to contain "/proxy1", got: ${r2.body}`);
 
-      const r3 = await makeRequest(port, "/normal2");
+      const r3 = await makeRequest(port, "/normal2", agent);
       assert.strictEqual(r3.statusCode, 200);
       assert.ok(r3.body.includes("/normal2"), `Expected body to contain "/normal2", got: ${r3.body}`);
 
-      const r4 = await makeRequest(port, "http://other.com/proxy2");
+      const r4 = await makeRequest(port, "http://other.com/proxy2", agent);
       assert.strictEqual(r4.statusCode, 200);
       assert.ok(r4.body.includes("other.com"), `Expected body to contain "other.com", got: ${r4.body}`);
       assert.ok(r4.body.includes("/proxy2"), `Expected body to contain "/proxy2", got: ${r4.body}`);
     } finally {
+      agent.destroy();
       server.close();
     }
   });

--- a/test/js/node/http/node-http-proxy-url.node.mts
+++ b/test/js/node/http/node-http-proxy-url.node.mts
@@ -42,7 +42,7 @@ function listenOnRandomPort(server: ReturnType<typeof createServer>): Promise<nu
 }
 
 describe("HTTP server with proxy-style absolute URLs", () => {
-  test("sequential GET requests with absolute URL paths don't hang", { timeout: 5000 }, async () => {
+  test("sequential GET requests with absolute URL paths don't hang", async () => {
     const agent = new Agent({ keepAlive: true, maxSockets: 1 });
     const server = createServer((req, res) => {
       res.writeHead(200, { "Content-Type": "text/plain" });
@@ -74,7 +74,7 @@ describe("HTTP server with proxy-style absolute URLs", () => {
     }
   });
 
-  test("sequential POST requests with absolute URL paths don't hang", { timeout: 5000 }, async () => {
+  test("sequential POST requests with absolute URL paths don't hang", async () => {
     const agent = new Agent({ keepAlive: true, maxSockets: 1 });
     const server = createServer((req, res) => {
       let body = "";
@@ -125,7 +125,7 @@ describe("HTTP server with proxy-style absolute URLs", () => {
     }
   });
 
-  test("mixed normal and proxy-style URLs work sequentially", { timeout: 5000 }, async () => {
+  test("mixed normal and proxy-style URLs work sequentially", async () => {
     const agent = new Agent({ keepAlive: true, maxSockets: 1 });
     const server = createServer((req, res) => {
       res.writeHead(200, { "Content-Type": "text/plain" });

--- a/test/js/node/http/node-http-proxy-url.test.ts
+++ b/test/js/node/http/node-http-proxy-url.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 describe("HTTP server with proxy-style absolute URLs", () => {
   test("tests should run on node.js", async () => {
-    const process = Bun.spawn({
+    await using process = Bun.spawn({
       cmd: [nodeExe(), "--test", join(import.meta.dir, "node-http-proxy-url.node.mts")],
       stdout: "inherit",
       stderr: "inherit",
@@ -14,7 +14,7 @@ describe("HTTP server with proxy-style absolute URLs", () => {
     expect(await process.exited).toBe(0);
   });
   test("tests should run on bun", async () => {
-    const process = Bun.spawn({
+    await using process = Bun.spawn({
       cmd: [bunExe(), "test", join(import.meta.dir, "node-http-proxy-url.node.mts")],
       stdout: "inherit",
       stderr: "inherit",

--- a/test/js/node/http/node-http-proxy-url.test.ts
+++ b/test/js/node/http/node-http-proxy-url.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, nodeExe } from "harness";
+import { join } from "node:path";
+
+describe("HTTP server with proxy-style absolute URLs", () => {
+  test("tests should run on node.js", async () => {
+    const process = Bun.spawn({
+      cmd: [nodeExe(), "--test", join(import.meta.dir, "node-http-proxy-url.node.mts")],
+      stdout: "inherit",
+      stderr: "inherit",
+      stdin: "ignore",
+      env: bunEnv,
+    });
+    expect(await process.exited).toBe(0);
+  });
+  test("tests should run on bun", async () => {
+    const process = Bun.spawn({
+      cmd: [bunExe(), "test", join(import.meta.dir, "node-http-proxy-url.node.mts")],
+      stdout: "inherit",
+      stderr: "inherit",
+      stdin: "ignore",
+      env: bunEnv,
+    });
+    expect(await process.exited).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a bug where sequential HTTP requests with proxy-style absolute URLs (e.g. `GET http://example.com/path HTTP/1.1`) hang on the 2nd+ request when using keep-alive connections.

## Root Cause

In `packages/bun-uws/src/HttpParser.h`, the parser was treating proxy-style absolute URLs identically to `CONNECT` method requests — setting `isConnectRequest = true` and entering tunnel mode. This flag was never reset between requests on the same keep-alive connection, so the 2nd+ request was swallowed as raw tunnel data instead of being parsed as HTTP.

## Fix

3-line change in `HttpParser.h:569`:
- **`isConnect`**: Now only matches actual `CONNECT` method requests (removed `isHTTPorHTTPSPrefixForProxies` from the condition)
- **`isProxyStyleURL`**: New variable that detects `http://`/`https://` prefixes and accepts them as valid request targets — without triggering tunnel mode

## Who was affected

- Any Bun HTTP server (`Bun.serve()` or `node:http createServer`) receiving proxy-style requests on keep-alive connections
- HTTP proxy servers built with Bun could only handle one request per connection
- Bun's own HTTP client making sequential requests through an HTTP proxy backed by a Bun server

## Test

Added `test/js/node/http/node-http-proxy-url.test.ts` with 3 test cases:
1. Sequential GET requests with absolute URL paths
2. Sequential POST requests with absolute URL paths
3. Mixed normal and proxy-style URLs

Tests run under both Node.js and Bun for compatibility verification.

- ❌ Fails with system bun (2/3 tests timeout on 2nd request)
- ✅ Passes with debug build (3/3 tests pass)