### PR TITLE
Add a note about `import.meta.hot` available only on clientside

### DIFF
--- a/docs/bundler/hot-reloading.mdx
+++ b/docs/bundler/hot-reloading.mdx
@@ -9,6 +9,8 @@ Hot Module Replacement (HMR) allows you to update modules in a running applicati
 
 ## `import.meta.hot` API Reference
 
+<Note>`import.meta.hot` is only available on clientside.</Note>
+
 Bun implements a client-side HMR API modeled after [Vite's `import.meta.hot` API](https://vite.dev/guide/api-hmr). It can be checked for with `if (import.meta.hot)`, tree-shaking it in production.
 
 ```ts title="index.ts" icon="/icons/typescript.svg"


### PR DESCRIPTION
I have multiple time over last last few months tried to use `import.meta` on serverside to clean up some resources only to remember that it only works on clientside. This note should make it more clear.
