### PR TITLE
fix(completions): undefined variable leading to bash completion errors

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -56,8 +56,7 @@ _read_scripts_in_package_json() {
     # when a script is passed as an option, do not show other scripts as part of the completion anymore
     local re_prev_script="(^| )${prev}($| )";
     [[
-        ( "${COMPREPLY[*]}" =~ ${re_prev_script} && -n "${COMP_WORDS[2]}" ) || \
-            ( "${COMPREPLY[*]}" =~ ${re_comp_word_script} )
+        ( "${COMPREPLY[*]}" =~ ${re_prev_script} && -n "${COMP_WORDS[2]}" )
     ]] && {
         local re_script=$(echo ${package_json_compreply[@]} | sed 's/[^ ]*/(&)/g');
         local new_reply=$(echo "${COMPREPLY[@]}" | sed -E "s/$re_script//");


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/oven-sh/bun/issues/24847

Not sure what the original intent of this undefined variable was but I'd rather have a working version than try to fully fix that functionality

### How did you verify your code works?

Edited the currently installed completions script from my bun install with identical changes
