### PR TITLE
fix(dns): follow CNAME when resolving TXT records

### DIFF
--- a/src/bun.js/api/bun/dns.zig
+++ b/src/bun.js/api/bun/dns.zig
@@ -529,6 +529,9 @@ pub const TxtResolveInfoRequest = struct {
         var head = this.head;
         bun.default_allocator.destroy(this);
 
+        // Free c-ares TXT result after processing (similar to drainPendingHostCares)
+        defer if (result) |txt_reply| txt_reply.deinit();
+
         head.processResolve(err_, timeout, result);
     }
 };

--- a/src/bun.js/api/bun/dns.zig
+++ b/src/bun.js/api/bun/dns.zig
@@ -370,6 +370,169 @@ pub fn ResolveInfoRequest(comptime cares_type: type, comptime type_name: []const
     };
 }
 
+/// Maximum CNAME chain depth to follow (prevents infinite loops)
+const MAX_CNAME_DEPTH = 8;
+
+/// Specialized TXT resolve request that handles CNAME following.
+/// When a TXT query returns a CNAME instead of TXT records, this request
+/// automatically follows the CNAME and issues a new query for TXT records.
+pub const TxtResolveInfoRequest = struct {
+    const request_type = @This();
+    const cares_type = c_ares.struct_ares_txt_reply;
+    const type_name = "txt";
+
+    const log = Output.scoped(.TxtResolveInfoRequest, .hidden);
+
+    resolver_for_caching: ?*Resolver = null,
+    hash: u64 = 0,
+    cache: CacheConfig = CacheConfig{},
+    head: CAresLookup(cares_type, type_name),
+    tail: *CAresLookup(cares_type, type_name) = undefined,
+    cname_depth: u8 = 0,
+    /// The current name being queried (may differ from original if following CNAMEs)
+    current_name: []const u8 = "",
+
+    /// Initialize a TXT request without using pending cache coalescing.
+    /// Used for CNAME-following TXT queries which have a different request structure.
+    pub fn initNoCaching(
+        resolver: ?*Resolver,
+        name: []const u8,
+        globalThis: *jsc.JSGlobalObject,
+    ) !*@This() {
+        var request = try globalThis.allocator().create(@This());
+        var hasher = std.hash.Wyhash.init(0);
+        hasher.update(name);
+        const hash = hasher.final();
+        var poll_ref = Async.KeepAlive.init();
+        poll_ref.ref(globalThis.bunVM());
+        if (resolver) |resolver_| resolver_.ref();
+        request.* = .{
+            .resolver_for_caching = resolver,
+            .hash = hash,
+            .head = .{
+                .resolver = resolver,
+                .poll_ref = poll_ref,
+                .globalThis = globalThis,
+                .promise = jsc.JSPromise.Strong.init(globalThis),
+                .allocated = false,
+                .name = name,
+            },
+            .current_name = name,
+        };
+        request.tail = &request.head;
+        return request;
+    }
+
+    pub const CacheConfig = packed struct(u16) {
+        pending_cache: bool = false,
+        entry_cache: bool = false,
+        pos_in_pending: u5 = 0,
+        name_len: u9 = 0,
+    };
+
+    pub const PendingCacheKey = struct {
+        hash: u64,
+        len: u16,
+        lookup: *request_type = undefined,
+
+        pub fn append(this: *PendingCacheKey, cares_lookup: *CAresLookup(cares_type, type_name)) void {
+            var tail = this.lookup.tail;
+            tail.next = cares_lookup;
+            this.lookup.tail = cares_lookup;
+        }
+
+        pub fn init(name: []const u8) PendingCacheKey {
+            var hasher = std.hash.Wyhash.init(0);
+            hasher.update(name);
+            const hash = hasher.final();
+            return PendingCacheKey{
+                .hash = hash,
+                .len = @as(u16, @truncate(name.len)),
+                .lookup = undefined,
+            };
+        }
+    };
+
+    pub fn onCaresComplete(this: *@This(), err_: ?c_ares.Error, timeout: i32, result: c_ares.struct_ares_txt_reply.TxtOrCname) void {
+        switch (result) {
+            .txt => |txt_result| {
+                // Got TXT records, process normally
+                this.completeWithResult(err_, timeout, txt_result);
+            },
+            .cname => |cname_target| {
+                // Got a CNAME, follow it if we haven't exceeded the depth limit
+                defer bun.default_allocator.free(cname_target);
+
+                if (this.cname_depth >= MAX_CNAME_DEPTH) {
+                    // Too many CNAME redirects, treat as error
+                    log("CNAME depth exceeded for {s}", .{this.head.name});
+                    this.completeWithResult(c_ares.Error.ENODATA, timeout, null);
+                    return;
+                }
+
+                // Issue a follow-up query for the CNAME target
+                const resolver = this.resolver_for_caching orelse this.head.resolver orelse {
+                    // No resolver available, can't follow CNAME
+                    this.completeWithResult(c_ares.Error.ENODATA, timeout, null);
+                    return;
+                };
+
+                var channel = switch (resolver.getChannel()) {
+                    .result => |ch| ch,
+                    .err => {
+                        this.completeWithResult(c_ares.Error.ENODATA, timeout, null);
+                        return;
+                    },
+                };
+
+                // Free the previous current_name if it was allocated for CNAME following
+                if (this.cname_depth > 0) {
+                    bun.default_allocator.free(this.current_name);
+                }
+
+                // Duplicate the CNAME target for the next query
+                this.current_name = bun.default_allocator.dupe(u8, cname_target) catch {
+                    this.completeWithResult(c_ares.Error.ENOMEM, timeout, null);
+                    return;
+                };
+                this.cname_depth += 1;
+
+                log("Following CNAME: {s} -> {s} (depth: {d})", .{ this.head.name, this.current_name, this.cname_depth });
+
+                // Issue new query with the CNAME target
+                channel.resolveTxtWithCnameHandling(
+                    this.current_name,
+                    @This(),
+                    this,
+                    @This().onCaresComplete,
+                );
+            },
+            .err => {
+                // Error occurred
+                this.completeWithResult(err_, timeout, null);
+            },
+        }
+    }
+
+    fn completeWithResult(this: *@This(), err_: ?c_ares.Error, timeout: i32, result: ?*cares_type) void {
+        // Free CNAME-allocated name if applicable
+        if (this.cname_depth > 0) {
+            bun.default_allocator.free(this.current_name);
+        }
+
+        // Note: TxtResolveInfoRequest doesn't use pending cache coalescing,
+        // so we just complete the request directly without draining cache.
+        if (this.resolver_for_caching) |resolver| {
+            resolver.requestCompleted();
+        }
+
+        var head = this.head;
+        bun.default_allocator.destroy(this);
+
+        head.processResolve(err_, timeout, result);
+    }
+};
+
 pub const GetHostByAddrInfoRequest = struct {
     const request_type = @This();
 
@@ -3004,7 +3167,39 @@ pub const Resolver = struct {
         }
 
         const name = try name_str.toSliceClone(globalThis, bun.default_allocator);
-        return this.doResolveCAres(c_ares.struct_ares_txt_reply, "txt", name.slice(), globalThis);
+        return this.doResolveTxt(name.slice(), globalThis);
+    }
+
+    /// Specialized TXT resolution that handles CNAME following.
+    /// When a TXT query returns a CNAME, it automatically follows the CNAME chain
+    /// (up to MAX_CNAME_DEPTH levels) and returns the TXT records from the final target.
+    pub fn doResolveTxt(this: *Resolver, name: []const u8, globalThis: *jsc.JSGlobalObject) bun.JSError!jsc.JSValue {
+        var channel: *c_ares.Channel = switch (this.getChannel()) {
+            .result => |res| res,
+            .err => |err| {
+                return globalThis.throwValue(try err.toJSWithSyscall(globalThis, "queryTxt"));
+            },
+        };
+
+        // Note: We don't use pending cache coalescing for CNAME-following TXT queries
+        // because TxtResolveInfoRequest has a different structure than the generic
+        // ResolveInfoRequest used by the caching system. This could be optimized later.
+        var request = TxtResolveInfoRequest.initNoCaching(
+            this,
+            name,
+            globalThis,
+        ) catch |err| bun.handleOom(err);
+        const promise = request.tail.promise.value();
+
+        channel.resolveTxtWithCnameHandling(
+            name,
+            TxtResolveInfoRequest,
+            request,
+            TxtResolveInfoRequest.onCaresComplete,
+        );
+
+        this.requestSent(globalThis.bunVM());
+        return promise;
     }
 
     pub fn globalResolveAny(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {

--- a/src/deps/c_ares.zig
+++ b/src/deps/c_ares.zig
@@ -1221,7 +1221,11 @@ pub const struct_ares_txt_reply = extern struct {
     /// Caller is responsible for freeing the returned slice with bun.default_allocator.
     fn extractCnameFromBuffer(buffer: [*c]u8, buffer_length: c_int) error{OutOfMemory}!?[]u8 {
         var dnsrec: ?*ares_dns_record_t = null;
-        if (ares_dns_parse(buffer, @intCast(buffer_length), 0, &dnsrec) != ARES_SUCCESS) {
+        const parse_result = ares_dns_parse(buffer, @intCast(buffer_length), 0, &dnsrec);
+        if (parse_result == ARES_ENOMEM) {
+            return error.OutOfMemory;
+        }
+        if (parse_result != ARES_SUCCESS) {
             return null;
         }
         defer ares_dns_record_destroy(dnsrec);

--- a/src/deps/c_ares.zig
+++ b/src/deps/c_ares.zig
@@ -714,6 +714,33 @@ pub const Channel = opaque {
         ares_query(this, name_ptr, NSClass.ns_c_in, @field(NSType, field_name), cares_type.callbackWrapper(lookup_name, Type, callback), ctx);
     }
 
+    /// Resolve TXT records with CNAME following support.
+    /// When the response contains a CNAME instead of TXT records, the callback
+    /// receives a TxtOrCname.cname with the target domain name.
+    pub fn resolveTxtWithCnameHandling(
+        this: *Channel,
+        name: []const u8,
+        comptime Type: type,
+        ctx: *Type,
+        comptime callback: fn (*Type, status: ?Error, timeouts: i32, results: struct_ares_txt_reply.TxtOrCname) void,
+    ) void {
+        if (name.len >= 1023 or name.len == 0) {
+            callback(ctx, Error.EBADNAME, 0, .{ .err = .EBADNAME });
+            return;
+        }
+
+        var name_buf: [1024]u8 = undefined;
+        const name_ptr: [*:0]const u8 = brk: {
+            const len = @min(name.len, name_buf.len - 1);
+            @memcpy(name_buf[0..len], name[0..len]);
+
+            name_buf[len] = 0;
+            break :brk name_buf[0..len :0];
+        };
+
+        ares_query(this, name_ptr, NSClass.ns_c_in, NSType.ns_t_txt, struct_ares_txt_reply.callbackWrapperWithCnameHandling(Type, callback), ctx);
+    }
+
     pub fn getHostByAddr(this: *Channel, ip_addr: []const u8, comptime Type: type, ctx: *Type, comptime callback: struct_hostent.Callback(Type)) void {
         // "0000:0000:0000:0000:0000:ffff:192.168.100.228".length = 45
         const buf_size = 46;
@@ -1179,6 +1206,86 @@ pub const struct_ares_txt_reply = extern struct {
     pub fn deinit(this: *struct_ares_txt_reply) void {
         ares_free_data(this);
     }
+
+    /// Result type for TXT queries that may contain CNAME redirects
+    pub const TxtOrCname = union(enum) {
+        txt: ?*struct_ares_txt_reply,
+        cname: []const u8,
+        err: Error,
+    };
+
+    /// Extract CNAME target from a DNS response buffer.
+    /// Returns the CNAME target domain name if found, null otherwise.
+    /// The returned string points to memory owned by the dnsrec and is valid
+    /// until ares_dns_record_destroy is called.
+    fn extractCnameFromBuffer(buffer: [*c]u8, buffer_length: c_int) ?[]const u8 {
+        var dnsrec: ?*ares_dns_record_t = null;
+        if (ares_dns_parse(buffer, @intCast(buffer_length), 0, &dnsrec) != ARES_SUCCESS) {
+            return null;
+        }
+        defer ares_dns_record_destroy(dnsrec);
+
+        const rr_cnt = ares_dns_record_rr_cnt(dnsrec, .ARES_SECTION_ANSWER);
+        var i: usize = 0;
+        while (i < rr_cnt) : (i += 1) {
+            const rr = ares_dns_record_rr_get_const(dnsrec, .ARES_SECTION_ANSWER, i);
+            if (rr == null) continue;
+
+            if (ares_dns_rr_get_type(rr) == .ARES_REC_TYPE_CNAME) {
+                const cname_ptr = ares_dns_rr_get_str(rr, ARES_RR_CNAME_CNAME);
+                if (cname_ptr) |ptr| {
+                    return bun.sliceTo(ptr, 0);
+                }
+            }
+        }
+        return null;
+    }
+
+    /// Callback wrapper for TXT queries that handles CNAME following.
+    /// When a CNAME is found instead of TXT records, returns TxtOrCname.cname
+    /// so the caller can issue a follow-up query on the CNAME target.
+    pub fn callbackWrapperWithCnameHandling(
+        comptime Type: type,
+        comptime function: fn (*Type, status: ?Error, timeouts: i32, results: TxtOrCname) void,
+    ) ares_callback {
+        return &struct {
+            pub fn handleTxt(ctx: ?*anyopaque, status: c_int, timeouts: c_int, buffer: [*c]u8, buffer_length: c_int) callconv(.c) void {
+                const this = bun.cast(*Type, ctx.?);
+                if (status != ARES_SUCCESS) {
+                    function(this, Error.get(status), timeouts, .{ .err = Error.get(status).? });
+                    return;
+                }
+
+                var txt_start: [*c]struct_ares_txt_reply = undefined;
+                const result = ares_parse_txt_reply(buffer, buffer_length, &txt_start);
+
+                if (result == ARES_SUCCESS and txt_start != null) {
+                    // Got TXT records directly
+                    function(this, null, timeouts, .{ .txt = txt_start });
+                    return;
+                }
+
+                // No TXT records found, check for CNAME
+                if (extractCnameFromBuffer(buffer, buffer_length)) |cname| {
+                    // Need to copy the CNAME since the buffer will be freed
+                    const cname_copy = bun.default_allocator.dupe(u8, cname) catch {
+                        function(this, Error.ENOMEM, timeouts, .{ .err = .ENOMEM });
+                        return;
+                    };
+                    function(this, null, timeouts, .{ .cname = cname_copy });
+                    return;
+                }
+
+                // No CNAME either, return the original error
+                if (result != ARES_SUCCESS) {
+                    function(this, Error.get(result), timeouts, .{ .err = Error.get(result).? });
+                } else {
+                    // SUCCESS but null result means no TXT records
+                    function(this, Error.ENODATA, timeouts, .{ .err = .ENODATA });
+                }
+            }
+        }.handleTxt;
+    }
 };
 pub const struct_ares_txt_ext = extern struct {
     next: [*c]struct_ares_txt_ext,
@@ -1567,6 +1674,52 @@ pub extern fn ares_parse_srv_reply(abuf: [*c]const u8, alen: c_int, srv_out: [*c
 pub extern fn ares_parse_mx_reply(abuf: [*c]const u8, alen: c_int, mx_out: [*c][*c]struct_ares_mx_reply) c_int;
 pub extern fn ares_parse_txt_reply(abuf: [*c]const u8, alen: c_int, txt_out: [*c][*c]struct_ares_txt_reply) c_int;
 pub extern fn ares_parse_txt_reply_ext(abuf: [*c]const u8, alen: c_int, txt_out: [*c][*c]struct_ares_txt_ext) c_int;
+
+/// DNS record types
+pub const ares_dns_rec_type_t = enum(c_int) {
+    ARES_REC_TYPE_A = 1,
+    ARES_REC_TYPE_NS = 2,
+    ARES_REC_TYPE_CNAME = 5,
+    ARES_REC_TYPE_SOA = 6,
+    ARES_REC_TYPE_PTR = 12,
+    ARES_REC_TYPE_HINFO = 13,
+    ARES_REC_TYPE_MX = 15,
+    ARES_REC_TYPE_TXT = 16,
+    ARES_REC_TYPE_SIG = 24,
+    ARES_REC_TYPE_AAAA = 28,
+    ARES_REC_TYPE_SRV = 33,
+    ARES_REC_TYPE_NAPTR = 35,
+    ARES_REC_TYPE_OPT = 41,
+    ARES_REC_TYPE_TLSA = 52,
+    ARES_REC_TYPE_SVCB = 64,
+    ARES_REC_TYPE_HTTPS = 65,
+    ARES_REC_TYPE_ANY = 255,
+    ARES_REC_TYPE_URI = 256,
+    ARES_REC_TYPE_CAA = 257,
+    _,
+};
+
+/// DNS section types
+pub const ares_dns_section_t = enum(c_int) {
+    ARES_SECTION_ANSWER = 1,
+    ARES_SECTION_AUTHORITY = 2,
+    ARES_SECTION_ADDITIONAL = 3,
+};
+
+/// DNS RR key for CNAME record
+pub const ARES_RR_CNAME_CNAME: c_int = (@intFromEnum(ares_dns_rec_type_t.ARES_REC_TYPE_CNAME) * 100) + 1;
+
+/// Opaque DNS record types
+pub const ares_dns_record_t = opaque {};
+pub const ares_dns_rr_t = opaque {};
+
+/// DNS record parsing and access functions
+pub extern fn ares_dns_parse(buf: [*c]const u8, buf_len: usize, flags: c_uint, dnsrec: *?*ares_dns_record_t) c_int;
+pub extern fn ares_dns_record_destroy(dnsrec: ?*ares_dns_record_t) void;
+pub extern fn ares_dns_record_rr_cnt(dnsrec: ?*const ares_dns_record_t, sect: ares_dns_section_t) usize;
+pub extern fn ares_dns_record_rr_get_const(dnsrec: ?*const ares_dns_record_t, sect: ares_dns_section_t, idx: usize) ?*const ares_dns_rr_t;
+pub extern fn ares_dns_rr_get_type(rr: ?*const ares_dns_rr_t) ares_dns_rec_type_t;
+pub extern fn ares_dns_rr_get_str(rr: ?*const ares_dns_rr_t, key: c_int) ?[*:0]const u8;
 pub extern fn ares_parse_naptr_reply(abuf: [*c]const u8, alen: c_int, naptr_out: [*c][*c]struct_ares_naptr_reply) c_int;
 pub extern fn ares_parse_soa_reply(abuf: [*c]const u8, alen: c_int, soa_out: [*c][*c]struct_ares_soa_reply) c_int;
 pub extern fn ares_parse_uri_reply(abuf: [*c]const u8, alen: c_int, uri_out: [*c][*c]struct_ares_uri_reply) c_int;

--- a/test/regression/issue/26744.test.ts
+++ b/test/regression/issue/26744.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+/**
+ * Regression test for GitHub issue #26744
+ * https://github.com/oven-sh/bun/issues/26744
+ *
+ * When querying TXT records for a domain that is a CNAME, Bun should
+ * follow the CNAME chain and return the TXT records from the target domain,
+ * just like Node.js does.
+ *
+ * The issue occurs because c-ares's ares_query function returns the raw DNS
+ * response which may contain only a CNAME record (no TXT records). Bun's DNS
+ * resolver now handles this by following the CNAME chain to resolve the final
+ * TXT records.
+ */
+describe("dns.resolveTxt with CNAME domains", () => {
+  test("should follow CNAME and return TXT records", async () => {
+    const dns = require("dns/promises");
+
+    // This domain is a CNAME pointing to sendgrid.net which has TXT records
+    // Note: This test depends on external DNS infrastructure
+    const hostname = "deletemecname2.suped.com";
+
+    // Node.js successfully resolves this, so Bun should too
+    const result = await dns.resolveTxt(hostname);
+
+    // The result should be an array of TXT record arrays
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+
+    // Each TXT record is an array of strings
+    for (const txtRecord of result) {
+      expect(Array.isArray(txtRecord)).toBe(true);
+      expect(txtRecord.length).toBeGreaterThan(0);
+      for (const str of txtRecord) {
+        expect(typeof str).toBe("string");
+      }
+    }
+
+    // The target domain (sendgrid.net) should have SPF records
+    const hasSPF = result.some((record: string[]) => record.some((str: string) => str.includes("v=spf1")));
+    expect(hasSPF).toBe(true);
+  });
+
+  test("should work with Resolver class", async () => {
+    const dns = require("dns/promises");
+    const resolver = new dns.Resolver();
+
+    // Use public DNS server
+    resolver.setServers(["8.8.8.8"]);
+
+    const hostname = "deletemecname2.suped.com";
+    const result = await resolver.resolveTxt(hostname);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  test("should still work for non-CNAME domains", async () => {
+    const dns = require("dns/promises");
+
+    // google.com has TXT records directly (no CNAME)
+    const result = await dns.resolveTxt("google.com");
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/test/regression/issue/26744.test.ts
+++ b/test/regression/issue/26744.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import dns from "dns/promises";
 
 /**
  * Regression test for GitHub issue #26744
@@ -15,8 +16,6 @@ import { describe, expect, test } from "bun:test";
  */
 describe("dns.resolveTxt with CNAME domains", () => {
   test("should follow CNAME and return TXT records", async () => {
-    const dns = require("dns/promises");
-
     // This domain is a CNAME pointing to sendgrid.net which has TXT records
     // Note: This test depends on external DNS infrastructure
     const hostname = "deletemecname2.suped.com";
@@ -43,7 +42,6 @@ describe("dns.resolveTxt with CNAME domains", () => {
   });
 
   test("should work with Resolver class", async () => {
-    const dns = require("dns/promises");
     const resolver = new dns.Resolver();
 
     // Use public DNS server
@@ -57,8 +55,6 @@ describe("dns.resolveTxt with CNAME domains", () => {
   });
 
   test("should still work for non-CNAME domains", async () => {
-    const dns = require("dns/promises");
-
     // google.com has TXT records directly (no CNAME)
     const result = await dns.resolveTxt("google.com");
 


### PR DESCRIPTION
## Summary
- Fixes dns.resolveTxt() timing out when the domain is a CNAME alias
- Implements automatic CNAME chain following (up to 8 levels deep)
- Adds CNAME detection using c-ares's DNS record parsing API
- Creates specialized TxtResolveInfoRequest type for CNAME following state

## Test plan
- Added regression test in test/regression/issue/26744.test.ts
- Test verifies TXT resolution works for CNAME domains (deletemecname2.suped.com → sendgrid.net)
- Test verifies Resolver class also works with CNAME domains
- Test verifies non-CNAME domains still work correctly

## Technical details
When querying TXT records for a CNAME domain:
1. c-ares's ares_query returns a DNS response with only a CNAME record
2. ares_parse_txt_reply finds no TXT records and returns SUCCESS with null
3. Previously, this left the promise unresolved (eventual timeout)
4. Now, we detect the CNAME and issue a follow-up query on the target domain

Closes #26744

🤖 Generated with [Claude Code](https://claude.com/claude-code)