### PR TITLE
fix(shell): report correct illegal option character in mv command

### DIFF
--- a/src/shell/builtin/mv.zig
+++ b/src/shell/builtin/mv.zig
@@ -447,7 +447,7 @@ pub fn parseFlag(this: *Mv, flag: []const u8) union(enum) { continue_parsing, do
     if (flag[0] != '-') return .done;
 
     const small_flags = flag[1..];
-    for (small_flags) |char| {
+    for (small_flags, 0..) |char, i| {
         switch (char) {
             'f' => {
                 this.opts.force_overwrite = true;
@@ -471,7 +471,7 @@ pub fn parseFlag(this: *Mv, flag: []const u8) union(enum) { continue_parsing, do
                 this.opts.verbose_output = true;
             },
             else => {
-                return .{ .illegal_option = "-" };
+                return .{ .illegal_option = small_flags[i..][0..1] };
             },
         }
     }

--- a/test/regression/issue/26749.test.ts
+++ b/test/regression/issue/26749.test.ts
@@ -13,6 +13,7 @@ test("mv reports correct illegal option character for -T", async () => {
     const err = e as Bun.$.ShellError;
     const stderr = new TextDecoder().decode(err.stderr);
     expect(stderr).toContain("mv: illegal option -- T");
+    expect(err.exitCode).not.toBe(0);
   } finally {
     $.nothrow();
   }
@@ -27,6 +28,7 @@ test("mv reports correct illegal option character for -X", async () => {
     const err = e as Bun.$.ShellError;
     const stderr = new TextDecoder().decode(err.stderr);
     expect(stderr).toContain("mv: illegal option -- X");
+    expect(err.exitCode).not.toBe(0);
   } finally {
     $.nothrow();
   }
@@ -41,6 +43,7 @@ test("mv reports correct illegal option character when combined with valid flags
     const err = e as Bun.$.ShellError;
     const stderr = new TextDecoder().decode(err.stderr);
     expect(stderr).toContain("mv: illegal option -- X");
+    expect(err.exitCode).not.toBe(0);
   } finally {
     $.nothrow();
   }
@@ -55,6 +58,7 @@ test("mv reports correct illegal option character at end of combined flags", asy
     const err = e as Bun.$.ShellError;
     const stderr = new TextDecoder().decode(err.stderr);
     expect(stderr).toContain("mv: illegal option -- Z");
+    expect(err.exitCode).not.toBe(0);
   } finally {
     $.nothrow();
   }

--- a/test/regression/issue/26749.test.ts
+++ b/test/regression/issue/26749.test.ts
@@ -4,60 +4,22 @@ import { expect, test } from "bun:test";
 // https://github.com/oven-sh/bun/issues/26749
 // mv command should report the correct illegal option character in error messages
 
-test("mv reports correct illegal option character for -T", async () => {
-  $.throws(true);
-  try {
-    await Bun.$`mv -T ./a ./b`;
-    expect.unreachable("should have thrown");
-  } catch (e: unknown) {
-    const err = e as Bun.$.ShellError;
-    const stderr = new TextDecoder().decode(err.stderr);
-    expect(stderr).toContain("mv: illegal option -- T");
-    expect(err.exitCode).not.toBe(0);
-  } finally {
-    $.nothrow();
-  }
-});
+const cases: [string, string][] = [
+  ["-T", "T"],
+  ["-X", "X"],
+  ["-fX", "X"],
+  ["-vZ", "Z"],
+];
 
-test("mv reports correct illegal option character for -X", async () => {
+test.each(cases)("mv reports correct illegal option for %s", async (flag, expectedChar) => {
   $.throws(true);
   try {
-    await Bun.$`mv -X ./a ./b`;
+    await Bun.$`mv ${flag} ./a ./b`;
     expect.unreachable("should have thrown");
   } catch (e: unknown) {
     const err = e as Bun.$.ShellError;
     const stderr = new TextDecoder().decode(err.stderr);
-    expect(stderr).toContain("mv: illegal option -- X");
-    expect(err.exitCode).not.toBe(0);
-  } finally {
-    $.nothrow();
-  }
-});
-
-test("mv reports correct illegal option character when combined with valid flags", async () => {
-  $.throws(true);
-  try {
-    await Bun.$`mv -fX ./a ./b`;
-    expect.unreachable("should have thrown");
-  } catch (e: unknown) {
-    const err = e as Bun.$.ShellError;
-    const stderr = new TextDecoder().decode(err.stderr);
-    expect(stderr).toContain("mv: illegal option -- X");
-    expect(err.exitCode).not.toBe(0);
-  } finally {
-    $.nothrow();
-  }
-});
-
-test("mv reports correct illegal option character at end of combined flags", async () => {
-  $.throws(true);
-  try {
-    await Bun.$`mv -vZ ./a ./b`;
-    expect.unreachable("should have thrown");
-  } catch (e: unknown) {
-    const err = e as Bun.$.ShellError;
-    const stderr = new TextDecoder().decode(err.stderr);
-    expect(stderr).toContain("mv: illegal option -- Z");
+    expect(stderr).toContain(`mv: illegal option -- ${expectedChar}`);
     expect(err.exitCode).not.toBe(0);
   } finally {
     $.nothrow();

--- a/test/regression/issue/26749.test.ts
+++ b/test/regression/issue/26749.test.ts
@@ -1,0 +1,61 @@
+import { $ } from "bun";
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/26749
+// mv command should report the correct illegal option character in error messages
+
+test("mv reports correct illegal option character for -T", async () => {
+  $.throws(true);
+  try {
+    await Bun.$`mv -T ./a ./b`;
+    expect.unreachable("should have thrown");
+  } catch (e: unknown) {
+    const err = e as Bun.$.ShellError;
+    const stderr = new TextDecoder().decode(err.stderr);
+    expect(stderr).toContain("mv: illegal option -- T");
+  } finally {
+    $.nothrow();
+  }
+});
+
+test("mv reports correct illegal option character for -X", async () => {
+  $.throws(true);
+  try {
+    await Bun.$`mv -X ./a ./b`;
+    expect.unreachable("should have thrown");
+  } catch (e: unknown) {
+    const err = e as Bun.$.ShellError;
+    const stderr = new TextDecoder().decode(err.stderr);
+    expect(stderr).toContain("mv: illegal option -- X");
+  } finally {
+    $.nothrow();
+  }
+});
+
+test("mv reports correct illegal option character when combined with valid flags", async () => {
+  $.throws(true);
+  try {
+    await Bun.$`mv -fX ./a ./b`;
+    expect.unreachable("should have thrown");
+  } catch (e: unknown) {
+    const err = e as Bun.$.ShellError;
+    const stderr = new TextDecoder().decode(err.stderr);
+    expect(stderr).toContain("mv: illegal option -- X");
+  } finally {
+    $.nothrow();
+  }
+});
+
+test("mv reports correct illegal option character at end of combined flags", async () => {
+  $.throws(true);
+  try {
+    await Bun.$`mv -vZ ./a ./b`;
+    expect.unreachable("should have thrown");
+  } catch (e: unknown) {
+    const err = e as Bun.$.ShellError;
+    const stderr = new TextDecoder().decode(err.stderr);
+    expect(stderr).toContain("mv: illegal option -- Z");
+  } finally {
+    $.nothrow();
+  }
+});


### PR DESCRIPTION
## Summary

- Fixed `mv` command reporting incorrect character in illegal option error messages
- The error was showing "-" for all unrecognized flags instead of the actual flag character

**Before:** `mv -T ./a ./b` shows `mv: illegal option -- -`
**After:** `mv -T ./a ./b` shows `mv: illegal option -- T`

## Test plan
- Added regression test in `test/regression/issue/26749.test.ts`
- Tests verify correct error character for `-T`, `-X`, `-fX`, and `-vZ` flags
- Verified test fails with system Bun and passes with debug build

Fixes #26749

🤖 Generated with [Claude Code](https://claude.ai/code)