### PR TITLE
fix(workers): prevent use-after-free when clearing message event listeners

### DIFF
--- a/src/bun.js/bindings/BunWorkerGlobalScope.cpp
+++ b/src/bun.js/bindings/BunWorkerGlobalScope.cpp
@@ -17,29 +17,37 @@ void WorkerGlobalScope::onDidChangeListenerImpl(EventTarget& self, const AtomStr
 {
     if (eventType == eventNames().messageEvent) {
         auto& global = static_cast<WorkerGlobalScope&>(self);
+        auto* context = global.scriptExecutionContext();
+
+        // During GlobalObject destruction, m_context is set to null before the
+        // ScriptExecutionContext is destroyed. In this case, we skip the event
+        // loop ref/unref since the context is being torn down anyway.
+        if (!context)
+            return;
+
         switch (kind) {
         case Add:
             if (global.m_messageEventCount == 0) {
-                global.scriptExecutionContext()->refEventLoop();
+                context->refEventLoop();
             }
             global.m_messageEventCount++;
             break;
         case Remove:
             global.m_messageEventCount--;
             if (global.m_messageEventCount == 0) {
-                global.scriptExecutionContext()->unrefEventLoop();
+                context->unrefEventLoop();
             }
             break;
         // I dont think clear in this context is ever called. If it is (search OnDidChangeListenerKind::Clear for the impl),
         // it may actually call once per event, in a way the Remove code above would suffice.
         case Clear:
             if (global.m_messageEventCount > 0) {
-                global.scriptExecutionContext()->unrefEventLoop();
+                context->unrefEventLoop();
             }
             global.m_messageEventCount = 0;
             break;
         }
     }
-};
+}
 
 }

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -824,6 +824,12 @@ GlobalObject::GlobalObject(JSC::VM& vm, JSC::Structure* structure, WebCore::Scri
 
 GlobalObject::~GlobalObject()
 {
+    // Clear the context pointer in globalEventScope before destroying the context.
+    // This prevents use-after-free when event listeners are cleaned up during
+    // globalEventScope destruction - the onDidChangeListener callback would otherwise
+    // try to access the already-freed ScriptExecutionContext.
+    globalEventScope->m_context = nullptr;
+
     if (auto* ctx = scriptExecutionContext()) {
         ctx->removeFromContextsMap();
         ctx->deref();

--- a/test/js/web/workers/worker-onmessage-null.test.ts
+++ b/test/js/web/workers/worker-onmessage-null.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Regression test for use-after-free crash when setting self.onmessage = null
+// in a worker to trigger graceful shutdown.
+
+test("setting self.onmessage = null allows worker to exit gracefully", async () => {
+  using dir = tempDir("worker-onmessage-null", {
+    "worker.js": `
+      self.onmessage = (event) => {
+        if (event.data === "ping") {
+          postMessage("pong");
+          // Clear onmessage to allow natural exit
+          self.onmessage = null;
+        }
+      };
+    `,
+    "main.js": `
+      const worker = new Worker(new URL("./worker.js", import.meta.url).href);
+
+      worker.onmessage = (event) => {
+        if (event.data === "pong") {
+          console.log("received pong");
+          // Remove the onmessage handler to allow main process to exit
+          worker.onmessage = null;
+        }
+      };
+
+      worker.onerror = (e) => {
+        console.error("Worker error:", e);
+        process.exit(1);
+      };
+
+      worker.postMessage("ping");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("received pong");
+  expect(stderr).not.toContain("error");
+  expect(stderr).not.toContain("crash");
+  expect(exitCode).toBe(0);
+});
+
+test("setting self.onmessage = null multiple times works correctly", async () => {
+  using dir = tempDir("worker-onmessage-null-multi", {
+    "worker.js": `
+      let count = 0;
+
+      self.onmessage = (event) => {
+        count++;
+        postMessage("count: " + count);
+
+        // Set and unset onmessage multiple times
+        self.onmessage = null;
+        self.onmessage = (e) => {
+          count++;
+          postMessage("count: " + count);
+          if (count >= 3) {
+            self.onmessage = null;
+          }
+        };
+      };
+    `,
+    "main.js": `
+      const worker = new Worker(new URL("./worker.js", import.meta.url).href);
+
+      const responses = [];
+      worker.onmessage = (event) => {
+        responses.push(event.data);
+        if (responses.length < 3) {
+          worker.postMessage("ping");
+        } else {
+          console.log("responses:", responses.join(", "));
+          // Remove handler to allow exit
+          worker.onmessage = null;
+        }
+      };
+
+      worker.onerror = (e) => {
+        console.error("Worker error:", e);
+        process.exit(1);
+      };
+
+      worker.postMessage("ping");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("responses: count: 1, count: 2, count: 3");
+  expect(stderr).not.toContain("error");
+  expect(stderr).not.toContain("crash");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/workers/worker-onmessage-null.test.ts
+++ b/test/js/web/workers/worker-onmessage-null.test.ts
@@ -39,6 +39,7 @@ test("setting self.onmessage = null allows worker to exit gracefully", async () 
     cmd: [bunExe(), "main.js"],
     env: bunEnv,
     cwd: String(dir),
+    stdout: "pipe",
     stderr: "pipe",
   });
 
@@ -98,6 +99,7 @@ test("setting self.onmessage = null multiple times works correctly", async () =>
     cmd: [bunExe(), "main.js"],
     env: bunEnv,
     cwd: String(dir),
+    stdout: "pipe",
     stderr: "pipe",
   });
 

--- a/test/js/web/workers/worker-onmessage-null.test.ts
+++ b/test/js/web/workers/worker-onmessage-null.test.ts
@@ -46,8 +46,6 @@ test("setting self.onmessage = null allows worker to exit gracefully", async () 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toContain("received pong");
-  expect(stderr).not.toContain("error");
-  expect(stderr).not.toContain("crash");
   expect(exitCode).toBe(0);
 });
 
@@ -106,7 +104,5 @@ test("setting self.onmessage = null multiple times works correctly", async () =>
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toContain("responses: count: 1, count: 2, count: 3");
-  expect(stderr).not.toContain("error");
-  expect(stderr).not.toContain("crash");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Summary
- Fix a use-after-free that occurs when message event listeners are removed during worker GlobalObject destruction
- The issue was that when the GlobalObject destructor runs, it derefs the ScriptExecutionContext, but the WorkerGlobalScope member is destroyed afterwards - during that destruction, event listener cleanup would try to access the now-freed ScriptExecutionContext
- The fix nulls out the context pointer before destruction and adds a null check in the callback to safely handle this case

## Test plan
- [x] Added behavioral tests in `test/js/web/workers/worker-onmessage-null.test.ts`
- [x] Tests verify setting `self.onmessage = null` allows worker to exit gracefully
- [x] Tests verify multiple set/unset cycles work correctly

**Note:** The original crash is a use-after-free that depends on memory layout and timing, making it difficult to reproduce deterministically in a test. The fix is based on code analysis of the destruction order issue. The tests verify the correct behavior of the onmessage null pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)