### PR TITLE
fix(windows): prevent panic on unknown Win32 error codes from RtlNtStatusToDosError

### DIFF
--- a/src/windows.zig
+++ b/src/windows.zig
@@ -4190,22 +4190,6 @@ pub fn GetEnvironmentVariableW(lpName: LPWSTR, lpBuffer: [*]u16, nSize: DWORD) G
 
 pub const env = @import("./windows/env.zig");
 
-const builtin = @import("builtin");
-const std = @import("std");
-
-const bun = @import("bun");
-const Environment = bun.Environment;
-const Output = bun.Output;
-const c = bun.c;
-
-const Maybe = bun.sys.Maybe;
-const SystemErrno = bun.sys.SystemErrno;
-const log = bun.sys.syslog;
-
-const w = std.os.windows;
-const win32 = windows;
-const windows = std.os.windows;
-
 test "Win32Error.fromNTStatus handles unknown error codes" {
     // Regression test for https://github.com/oven-sh/bun/issues/26756
     // RtlNtStatusToDosError can return Win32 error codes that are not defined
@@ -4226,3 +4210,19 @@ test "Win32Error.fromNTStatus handles unknown error codes" {
     // Verify toSystemErrno returns null for unknown codes (as expected)
     try std.testing.expectEqual(@as(?SystemErrno, null), unknown_code.toSystemErrno());
 }
+
+const builtin = @import("builtin");
+const std = @import("std");
+
+const bun = @import("bun");
+const Environment = bun.Environment;
+const Output = bun.Output;
+const c = bun.c;
+
+const Maybe = bun.sys.Maybe;
+const SystemErrno = bun.sys.SystemErrno;
+const log = bun.sys.syslog;
+
+const w = std.os.windows;
+const win32 = windows;
+const windows = std.os.windows;


### PR DESCRIPTION
## Summary

- Fix crash on Windows with "invalid enum value" panic during module resolution
- Change `RtlNtStatusToDosError` extern to return `u32` instead of `Win32Error` enum directly
- Use `@enumFromInt` to properly convert the value, allowing the non-exhaustive enum's `_` catch-all to handle unknown codes

## Root Cause

When `RtlNtStatusToDosError` returns a Win32 error code not defined in Bun's `Win32Error` enum, Zig's runtime panics with "invalid enum value". This happens because the extern function was declared to return `Win32Error` directly.

## Test plan

- [x] Verified cross-platform compilation with `bun run zig:check-all`
- [x] Verified debug build compiles with `bun bd`
- [x] Added unit test for unknown error code handling

Fixes #26756

🤖 Generated with [Claude Code](https://claude.com/claude-code)