### PR TITLE
fix: fix spelling errors across multiple files

### DIFF
--- a/src/bun.js/test/expect/toHaveReturned.zig
+++ b/src/bun.js/test/expect/toHaveReturned.zig
@@ -61,8 +61,8 @@ inline fn toHaveReturnedTimesFn(this: *Expect, globalThis: *JSGlobalObject, call
             return this.throw(globalThis, signature,
                 \\
                 \\
-                \\Expected number of succesful returns: {s}<green>{d}<r>
-                \\Received number of succesful returns: {s}<red>{d}<r>
+                \\Expected number of successful returns: {s}<green>{d}<r>
+                \\Received number of successful returns: {s}<red>{d}<r>
                 \\Received number of calls:             {s}<red>{d}<r>
                 \\
             , .{ str, expected_success_count, spc, actual_success_count, spc, total_call_count });

--- a/src/js/private.d.ts
+++ b/src/js/private.d.ts
@@ -204,7 +204,7 @@ interface JSCommonJSModule {
  * Binding files are located in `src/bun.js/bindings`
  *
  * @see {@link $zig} for native zig bindings.
- * @see `src/codegen/replacements.ts` for the script that performs replacement of this funciton.
+ * @see `src/codegen/replacements.ts` for the script that performs replacement of this function.
  *
  * @param filename name of the c++ file containing the function. Do not pass a path.
  * @param symbol   The name of the binding function to call. Use `dot.notation` to access
@@ -223,7 +223,7 @@ declare function $cpp<T = any>(filename: NativeFilenameCPP, symbol: string): T;
  * Binding files are located in `src/bun.js/bindings`
  *
  * @see {@link $cpp} for native c++ bindings.
- * @see `src/codegen/replacements.ts` for the script that performs replacement of this funciton.
+ * @see `src/codegen/replacements.ts` for the script that performs replacement of this function.
  *
  * @param filename name of the zig file containing the function. Do not pass a path.
  * @param symbol   The name of the binding function. Use `dot.notation` to access

--- a/src/shell/IOWriter.zig
+++ b/src/shell/IOWriter.zig
@@ -842,7 +842,7 @@ pub fn drainBufferedData(parent: *IOWriter, buf: []const u8, max_write_size: usi
 ///       There are two areas which need to change:
 ///
 ///       1. `IOWriter.onWritePollable` calls `this.bump(child).run()` which could
-///          deinitialize the child which will deref and potentially deinitalize the
+///          deinitialize the child which will deref and potentially deinitialize the
 ///          `IOWriter`. Simple solution is to ref and defer ref the `IOWriter`
 ///
 ///       2. `PipeWriter` seems to try to use this struct after IOWriter

--- a/src/shell/states/If.zig
+++ b/src/shell/states/If.zig
@@ -101,7 +101,7 @@ pub fn next(this: *If) Yield {
                         .then => {
                             return this.parent.childDone(this, this.state.exec.last_exit_code);
                         },
-                        // if succesful, execute the elif's then branch
+                        // if successful, execute the elif's then branch
                         // otherwise, move to the next elif, or to the final else if it exists
                         .elif => {
                             if (this.state.exec.last_exit_code == 0) {

--- a/src/shell/states/Script.zig
+++ b/src/shell/states/Script.zig
@@ -97,7 +97,7 @@ pub fn deinit(this: *Script) void {
     if (!this.parent.ptr.is(Interpreter) and !this.parent.ptr.is(Subshell)) {
         // The shell state is owned by the parent when the parent is Interpreter or Subshell
         // Otherwise this Script represents a command substitution which is duped from the parent
-        // and must be deinitalized.
+        // and must be deinitialized.
         this.base.shell.deinit();
     }
 


### PR DESCRIPTION
## Summary
- Fix `succesful` -> `successful` in `toHaveReturned.zig` error messages (user-visible)
- Fix `funciton` -> `function` in `private.d.ts` JSDoc comments
- Fix `deinitalize` -> `deinitialize` in `IOWriter.zig` comment
- Fix `deinitalized` -> `deinitialized` in `Script.zig` comment
- Fix `succesful` -> `successful` in `If.zig` comment