### PR TITLE
fix: fix spelling errors in codegen, scripts, and tests

### DIFF
--- a/scripts/label-issue.ts
+++ b/scripts/label-issue.ts
@@ -286,7 +286,7 @@ const labels = [
   },
   {
     name: "wintercg",
-    description: "Web-interoperable Runtimes Community Group compatiblity",
+    description: "Web-interoperable Runtimes Community Group compatibility",
   },
 ];
 

--- a/src/codegen/cppbind.ts
+++ b/src/codegen/cppbind.ts
@@ -553,7 +553,7 @@ async function processFile(parser: CppParser, file: string, allFunctions: CppFn[
 
       queryFoundLines.add(lineInfo.get(zigExportAttr.from).line);
 
-      // disabled because lezer parses (extern "C") seperately to the function definition / block
+      // disabled because lezer parses (extern "C") separately to the function definition / block
       /* const linkage = closest(fnNode, "LinkageSpecification");
       const linkageString = linkage?.getChild("String");
       if (!linkage || !linkageString || text(linkageString, ctx) !== '"C"') {

--- a/test/js/bun/yaml/yaml-test-suite.test.ts
+++ b/test/js/bun/yaml/yaml-test-suite.test.ts
@@ -6024,7 +6024,7 @@ test("yaml-test-suite/X4QW", () => {
 });
 
 test("yaml-test-suite/X8DW", () => {
-  // Explicit key and value seperated by comment
+  // Explicit key and value separated by comment
   const input: string = `---
 ? key
 # comment


### PR DESCRIPTION
## Summary
- Fix `seperately` -> `separately` in `src/codegen/cppbind.ts`
- Fix `compatiblity` -> `compatibility` in `scripts/label-issue.ts`
- Fix `seperated` -> `separated` in `test/js/bun/yaml/yaml-test-suite.test.ts`