### PR TITLE
fix: fix spelling errors in test files

### DIFF
--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -136,7 +136,7 @@ it("bun add --only-missing should not install existing package", async () => {
     }),
   );
 
-  // First time: install succesfully.
+  // First time: install successfully.
   const { stdout, stderr, exited } = spawn({
     cmd: [bunExe(), "add", "--only-missing", "bar"],
     cwd: package_dir,

--- a/test/cli/install/hosted-git-info/cases.ts
+++ b/test/cli/install/hosted-git-info/cases.ts
@@ -8,7 +8,7 @@
  *   - https://github.com/npm/hosted-git-info/blob/main/test/file.js
  *   - https://github.com/npm/hosted-git-info/blob/main/test/parse-url.js
  */
-// This is a valid git branch name that contains other occurences of the characters we check
+// This is a valid git branch name that contains other occurrences of the characters we check
 // for to determine the committish in order to test that we parse those correctly
 const committishDefaults = { committish: "lk/br@nch.t#st:^1.0.0-pre.4" };
 

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -185,7 +185,7 @@ for (const { name, connect } of tests) {
       expect(await res.text()).toBe("<h1>HELLO</h1>");
     });
 
-    it("should have peer certificate when using self asign certificate", async () => {
+    it("should have peer certificate when using self-signed certificate", async () => {
       using server = Bun.serve({
         tls: {
           cert: COMMON_CERT.cert,

--- a/test/js/web/fetch/abort-signal-leak.test.ts
+++ b/test/js/web/fetch/abort-signal-leak.test.ts
@@ -19,6 +19,6 @@ test("'abort' event on req.signal should not cause AbortSignal to never be GCed"
   await testReqSignalAbortEvent();
 });
 
-test("'abort' event hadnler on req.signal that never is called should not prevent AbortSignal from being GCed", async () => {
+test("'abort' event handler on req.signal that never is called should not prevent AbortSignal from being GCed", async () => {
   await testReqSignalAbortEventNeverResolves();
 });


### PR DESCRIPTION
## Summary
- Fix `hadnler` -> `handler` in `test/js/web/fetch/abort-signal-leak.test.ts`
- Fix `self asign` -> `self-signed` in `test/js/node/tls/node-tls-connect.test.ts`
- Fix `succesfully` -> `successfully` in `test/cli/install/bun-add.test.ts`
- Fix `occurences` -> `occurrences` in `test/cli/install/hosted-git-info/cases.ts`