### PR TITLE
fix(s3): add requestPayer support to list() method

### DIFF
--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -1284,7 +1284,10 @@ declare module "bun" {
      */
     list(
       input?: S3ListObjectsOptions | null,
-      options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint">,
+      options?: Pick<
+        S3Options,
+        "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint" | "requestPayer"
+      >,
     ): Promise<S3ListObjectsResponse>;
 
     /**
@@ -1320,7 +1323,10 @@ declare module "bun" {
      */
     static list(
       input?: S3ListObjectsOptions | null,
-      options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint">,
+      options?: Pick<
+        S3Options,
+        "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint" | "requestPayer"
+      >,
     ): Promise<S3ListObjectsResponse>;
   }
 

--- a/src/bun.js/webcore/blob/Store.zig
+++ b/src/bun.js/webcore/blob/Store.zig
@@ -427,7 +427,7 @@ pub const S3 = struct {
             .store = store, // store is needed in case of not found error
             .resolvedlistOptions = options,
             .global = globalThis,
-        }), proxy);
+        }), proxy, aws_options.request_payer);
 
         return value;
     }

--- a/src/s3/client.zig
+++ b/src/s3/client.zig
@@ -109,6 +109,7 @@ pub fn listObjects(
     callback: *const fn (S3ListObjectsResult, *anyopaque) bun.JSTerminated!void,
     callback_context: *anyopaque,
     proxy_url: ?[]const u8,
+    request_payer: bool,
 ) bun.JSTerminated!void {
     var search_params: bun.ByteList = .{};
 
@@ -177,6 +178,7 @@ pub fn listObjects(
         .path = "",
         .method = .GET,
         .search_params = search_params.slice(),
+        .request_payer = request_payer,
     }, true, null) catch |sign_err| {
         search_params.deinit(bun.default_allocator);
 

--- a/test/js/bun/s3/s3-requester-pays.test.ts
+++ b/test/js/bun/s3/s3-requester-pays.test.ts
@@ -248,4 +248,101 @@ describe("s3 - Requester Pays", () => {
 
     expect(url.searchParams.get("x-amz-request-payer")).toBeNull();
   });
+
+  it("should include x-amz-request-payer header in list() requests when requestPayer is true", async () => {
+    let reqHeaders: Headers | undefined = undefined;
+    let reqMethod: string | undefined = undefined;
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        reqHeaders = req.headers;
+        reqMethod = req.method;
+        return new Response(
+          `<?xml version="1.0" encoding="UTF-8"?><ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+          <Name>my_bucket</Name>
+          </ListBucketResult>`,
+          {
+            headers: {
+              "Content-Type": "application/xml",
+            },
+            status: 200,
+          },
+        );
+      },
+    });
+
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: server.url.href,
+      requestPayer: true,
+    });
+
+    await client.list({ prefix: "test/" });
+
+    expect(reqMethod).toBe("GET");
+    expect(reqHeaders!.get("authorization")).toInclude("x-amz-request-payer");
+    expect(reqHeaders!.get("x-amz-request-payer")).toBe("requester");
+  });
+
+  it("should NOT include x-amz-request-payer header in list() requests when requestPayer is false", async () => {
+    let reqHeaders: Headers | undefined = undefined;
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        reqHeaders = req.headers;
+        return new Response(
+          `<?xml version="1.0" encoding="UTF-8"?><ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+          <Name>my_bucket</Name>
+          </ListBucketResult>`,
+          {
+            headers: {
+              "Content-Type": "application/xml",
+            },
+            status: 200,
+          },
+        );
+      },
+    });
+
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: server.url.href,
+      requestPayer: false,
+    });
+
+    await client.list();
+
+    expect(reqHeaders!.get("authorization")).not.toInclude("x-amz-request-payer");
+    expect(reqHeaders!.get("x-amz-request-payer")).toBeNull();
+  });
+
+  it("should include x-amz-request-payer header in static list() when requestPayer is true", async () => {
+    let reqHeaders: Headers | undefined = undefined;
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        reqHeaders = req.headers;
+        return new Response(
+          `<?xml version="1.0" encoding="UTF-8"?><ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+          <Name>my_bucket</Name>
+          </ListBucketResult>`,
+          {
+            headers: {
+              "Content-Type": "application/xml",
+            },
+            status: 200,
+          },
+        );
+      },
+    });
+
+    await S3Client.list(null, {
+      ...s3Options,
+      endpoint: server.url.href,
+      requestPayer: true,
+    });
+
+    expect(reqHeaders!.get("authorization")).toInclude("x-amz-request-payer");
+    expect(reqHeaders!.get("x-amz-request-payer")).toBe("requester");
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes `S3Client.list()` not respecting the `requestPayer` option, which caused `AccessDenied` errors on Requester Pays buckets
- Added `request_payer` parameter to `listObjects()` in `src/s3/client.zig`
- Updated TypeScript types for `list()` to include `requestPayer` in the options

Fixes #26778

## Test plan
- [x] Added tests for `list()` with `requestPayer: true` (instance method)
- [x] Added tests for `list()` with `requestPayer: false` (instance method)
- [x] Added tests for `S3Client.list()` with `requestPayer: true` (static method)
- [x] Verified tests fail with system bun and pass with debug build

🤖 Generated with [Claude Code](https://claude.com/claude-code)