### PR TITLE
fix(printer): avoid double backslash in regex with escaped non-ASCII

### DIFF
--- a/test/regression/issue/26785.test.ts
+++ b/test/regression/issue/26785.test.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/26785
+// Bun's regex printer was incorrectly handling backslash-escaped non-ASCII
+// characters in regex literals. When a non-ASCII character is preceded by a
+// backslash, the printer converts the character to `\uXXXX` format but was
+// adding another backslash, resulting in `\\uXXXX` which breaks regex semantics.
+
+test("regex with backslash-escaped non-ASCII character matches correctly", async () => {
+  using dir = tempDir("issue-26785", {
+    "test.js": `
+const R = /[\\⁄]/;  // backslash + U+2044 (fraction slash)
+const testString = '³⁄₅₂ cup of stuff';
+const match = testString.match(R);
+
+// Should match the fraction slash character, not the letter 'u'
+console.log(JSON.stringify({
+  source: R.source,
+  match: match ? match[0] : null,
+  index: match ? match.index : null
+}));
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const result = JSON.parse(stdout.trim());
+
+  // The source should have \u2044 (one backslash), not \\u2044 (two backslashes)
+  expect(result.source).toBe("[\\u2044]");
+  // Should match the fraction slash character at index 1, not 'u' from 'cup'
+  expect(result.match).toBe("⁄");
+  expect(result.index).toBe(1);
+  expect(exitCode).toBe(0);
+});
+
+test("complex regex with backslash-escaped non-ASCII matches fractions", async () => {
+  using dir = tempDir("issue-26785-complex", {
+    "test.js": `
+// Original regex from the issue
+const R = /[½⅓⅔¼¾⅕⅖⅗⅘⅙⅚⅐⅛⅜⅝⅞⅑⅒]|([⁰¹²³⁴⁵⁶⁷⁸⁹]+|[₀₁₂₃₄₅₆₇₈₉]+|[0-9]+)([\\/\\⁄])([⁰¹²³⁴⁵⁶⁷⁸⁹]+|[₀₁₂₃₄₅₆₇₈₉]+|[0-9]+)/;
+const m = '³⁄₅₂ cup of stuff'.match(R);
+console.log(JSON.stringify(m));
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const result = JSON.parse(stdout.trim());
+
+  // Should match the fraction "³⁄₅₂"
+  expect(result).not.toBeNull();
+  expect(result[0]).toBe("³⁄₅₂");
+  expect(result[1]).toBe("³");
+  expect(result[2]).toBe("⁄");
+  expect(result[3]).toBe("₅₂");
+  expect(exitCode).toBe(0);
+});
+
+test("regex with non-ASCII character without preceding backslash works", async () => {
+  using dir = tempDir("issue-26785-no-backslash", {
+    "test.js": `
+// Non-ASCII character without a preceding backslash should still work
+const R = /[⁄]/;
+const testString = '³⁄₅₂ cup of stuff';
+const match = testString.match(R);
+console.log(JSON.stringify({
+  match: match ? match[0] : null,
+  index: match ? match.index : null
+}));
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const result = JSON.parse(stdout.trim());
+
+  // Should still match the fraction slash character
+  expect(result.match).toBe("⁄");
+  expect(result.index).toBe(1);
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/26785.test.ts
+++ b/test/regression/issue/26785.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe } from "harness";
 
 // https://github.com/oven-sh/bun/issues/26785
 // Bun's regex printer was incorrectly handling backslash-escaped non-ASCII
@@ -8,8 +8,11 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // adding another backslash, resulting in `\\uXXXX` which breaks regex semantics.
 
 test("regex with backslash-escaped non-ASCII character matches correctly", async () => {
-  using dir = tempDir("issue-26785", {
-    "test.js": `
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
 const R = /[\\⁄]/;  // backslash + U+2044 (fraction slash)
 const testString = '³⁄₅₂ cup of stuff';
 const match = testString.match(R);
@@ -21,11 +24,7 @@ console.log(JSON.stringify({
   index: match ? match.index : null
 }));
 `,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test.js"],
-    cwd: String(dir),
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
@@ -44,18 +43,17 @@ console.log(JSON.stringify({
 });
 
 test("complex regex with backslash-escaped non-ASCII matches fractions", async () => {
-  using dir = tempDir("issue-26785-complex", {
-    "test.js": `
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
 // Original regex from the issue
 const R = /[½⅓⅔¼¾⅕⅖⅗⅘⅙⅚⅐⅛⅜⅝⅞⅑⅒]|([⁰¹²³⁴⁵⁶⁷⁸⁹]+|[₀₁₂₃₄₅₆₇₈₉]+|[0-9]+)([\\/\\⁄])([⁰¹²³⁴⁵⁶⁷⁸⁹]+|[₀₁₂₃₄₅₆₇₈₉]+|[0-9]+)/;
 const m = '³⁄₅₂ cup of stuff'.match(R);
 console.log(JSON.stringify(m));
 `,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test.js"],
-    cwd: String(dir),
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
@@ -75,8 +73,11 @@ console.log(JSON.stringify(m));
 });
 
 test("regex with non-ASCII character without preceding backslash works", async () => {
-  using dir = tempDir("issue-26785-no-backslash", {
-    "test.js": `
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
 // Non-ASCII character without a preceding backslash should still work
 const R = /[⁄]/;
 const testString = '³⁄₅₂ cup of stuff';
@@ -86,11 +87,7 @@ console.log(JSON.stringify({
   index: match ? match.index : null
 }));
 `,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test.js"],
-    cwd: String(dir),
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",


### PR DESCRIPTION
## Summary

- Fixes regex printing of backslash-escaped non-ASCII characters
- Tracks whether previous character was a backslash to avoid doubling backslashes when generating unicode escape sequences

## Problem

When the regex printer encounters a non-ASCII character that was preceded by a backslash escape, it was incorrectly adding another backslash before the unicode escape sequence, resulting in `\\uXXXX` instead of `\uXXXX`.

For example:
```js
const R = /[\⁄]/;  // backslash + U+2044 (fraction slash)
```

Was being printed as `/[\\u2044]/`, which changes the regex semantics:
- **Expected**: matches the fraction slash character (⁄)
- **Actual (bug)**: matches `\`, `u`, `2`, `0`, `4`, `4` as separate characters

This caused the regex from the issue to fail matching fractions:
```js
const R = /[½⅓⅔¼¾⅕⅖⅗⅘⅙⅚⅐⅛⅜⅝⅞⅑⅒]|([⁰¹²³⁴⁵⁶⁷⁸⁹]+|[₀₁₂₃₄₅₆₇₈₉]+|[0-9]+)([\/\⁄])([⁰¹²³⁴⁵⁶⁷⁸⁹]+|[₀₁₂₃₄₅₆₇₈₉]+|[0-9]+)/;
'³⁄₅₂ cup of stuff'.match(R);
// Expected: ["³⁄₅₂", "³", "⁄", "₅₂"]
// Actual: null
```

## Solution

Track whether the previous character was a backslash when iterating through the regex literal. When generating unicode escape sequences for non-ASCII characters, omit the leading backslash if the previous character was already a backslash (which was escaping the non-ASCII character).

## Test plan

- Added regression test in `test/regression/issue/26785.test.ts`
- Test verifies the regex source is correctly printed
- Test verifies the regex matches the expected characters

Closes #26785

🤖 Generated with [Claude Code](https://claude.com/claude-code)