### PR TITLE
fix(bundler): enable `tsconfig` option in Bun.build() API

### DIFF
--- a/test/regression/issue/26793.test.ts
+++ b/test/regression/issue/26793.test.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/26793
+// Bun.build() API tsconfig option does not work - path aliases are not resolved
+
+test("Bun.build() tsconfig option should resolve path aliases", async () => {
+  using dir = tempDir("issue-26793", {
+    "src/index.ts": `import { sum } from "@/utils";\nexport { sum };\n`,
+    "src/utils.ts": `export function sum(a: number, b: number) { return a + b; }\n`,
+    "tsconfig.custom.json": JSON.stringify({
+      compilerOptions: {
+        baseUrl: ".",
+        paths: {
+          "@/*": ["./src/*"],
+        },
+      },
+    }),
+  });
+
+  const result = await Bun.build({
+    entrypoints: [`${dir}/src/index.ts`],
+    outdir: `${dir}/dist`,
+    tsconfig: `${dir}/tsconfig.custom.json`,
+  });
+
+  expect(result.success).toBe(true);
+  expect(result.outputs.length).toBe(1);
+
+  const output = await result.outputs[0].text();
+  // The bundled output should contain the sum function
+  expect(output).toContain("sum");
+});
+
+test("Bun.build() tsconfig option should work with relative path in tsconfig", async () => {
+  using dir = tempDir("issue-26793-relative", {
+    "src/index.ts": `import { multiply } from "@lib/math";\nexport { multiply };\n`,
+    "lib/math.ts": `export function multiply(a: number, b: number) { return a * b; }\n`,
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        baseUrl: ".",
+        paths: {
+          "@lib/*": ["./lib/*"],
+        },
+      },
+    }),
+  });
+
+  // Test that tsconfig with relative paths inside it (baseUrl, paths) works correctly
+  const result = await Bun.build({
+    entrypoints: [`${dir}/src/index.ts`],
+    outdir: `${dir}/dist`,
+    tsconfig: `${dir}/tsconfig.json`,
+  });
+
+  expect(result.success).toBe(true);
+  expect(result.outputs.length).toBe(1);
+
+  const output = await result.outputs[0].text();
+  expect(output).toContain("multiply");
+});
+
+test("Bun.build() without tsconfig option should not resolve custom aliases", async () => {
+  using dir = tempDir("issue-26793-no-tsconfig", {
+    "src/index.ts": `import { divide } from "@custom/math";\nexport { divide };\n`,
+    "custom/math.ts": `export function divide(a: number, b: number) { return a / b; }\n`,
+    // No tsconfig at root, custom tsconfig is not passed
+    "other/tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        baseUrl: ".",
+        paths: {
+          "@custom/*": ["./custom/*"],
+        },
+      },
+    }),
+  });
+
+  const result = await Bun.build({
+    entrypoints: [`${dir}/src/index.ts`],
+    outdir: `${dir}/dist`,
+    // No tsconfig option - should fail to resolve the alias
+    throw: false, // Don't throw, just return success=false
+  });
+
+  // Without the tsconfig option, the path alias should not be resolved
+  expect(result.success).toBe(false);
+  expect(result.logs.some(log => log.message?.includes("@custom/math"))).toBe(true);
+});


### PR DESCRIPTION
## Summary
- Fixes the `tsconfig` option in `Bun.build()` API which was not working
- Path aliases defined in custom tsconfig files are now properly resolved
- Added regression test for the fix

## Details
The `tsconfig` option in `Bun.build()` was defined in TypeScript types but never actually implemented. This PR:

1. Parses the `tsconfig` property from the JavaScript config object in `JSBundler.zig`
2. Passes `tsconfig_override` to `TransformOptions` during `Transpiler.init`
3. Explicitly loads and attaches the tsconfig to the directory cache

The root cause was that the bundler's resolver shares a global directory cache with the main process. When a build script loads, the main process populates the cache without the tsconfig_override, and subsequent bundler operations use cached entries lacking tsconfig information.

## Test plan
- [x] Added regression test `test/regression/issue/26793.test.ts`
- [x] Verified the fix works with the reproduction case from the issue
- [x] Verified the test fails with the system bun (USE_SYSTEM_BUN=1)
- [x] Verified the test passes with the debug build

Fixes #26793

🤖 Generated with [Claude Code](https://claude.com/claude-code)