### PR TITLE
fix(bundler): convert backslashes in path.pretty on Windows

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -689,7 +689,9 @@ pub const BundleV2 = struct {
         if (path.pretty.ptr == path.text.ptr) {
             // TODO: outbase
             const rel = bun.path.relativePlatform(transpiler.fs.top_level_dir, path.text, .loose, false);
-            path.pretty = bun.handleOom(this.allocator().dupe(u8, rel));
+            const pretty = bun.handleOom(this.allocator().dupe(u8, rel));
+            bun.path.platformToPosixInPlace(u8, pretty);
+            path.pretty = pretty;
         }
         path.assertPrettyIsValid();
 

--- a/test/regression/issue/026798.test.ts
+++ b/test/regression/issue/026798.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+// Test for https://github.com/oven-sh/bun/issues/26798
+// Bun.build crashes on Windows when a plugin's onResolve returns null,
+// falling back to the standard resolver, and the resulting path.pretty
+// contains Windows backslashes.
+test("Bun.build with plugin onResolve returning null should not crash", async () => {
+  const dir = tempDirWithFiles("onresolve-null-test", {
+    "src/index.ts": `import { foo } from "./foo"; console.log(foo);`,
+    "src/foo.ts": `export const foo = "hello";`,
+    "build.ts": `
+const result = await Bun.build({
+  entrypoints: ["./src/index.ts"],
+  plugins: [
+    {
+      name: "null-returner",
+      setup(build) {
+        // Return null to trigger fallback to standard resolver
+        build.onResolve({ filter: /.*/ }, (args) => {
+          return null;
+        });
+      },
+    },
+  ],
+});
+
+if (!result.success) {
+  console.error("Build failed:", result.logs);
+  process.exit(1);
+}
+console.log("Build succeeded");
+`,
+  });
+
+  const { stdout, stderr, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), "run", "build.ts"],
+    cwd: dir,
+    env: bunEnv,
+  });
+
+  const stderrText = stderr.toString();
+  const stdoutText = stdout.toString();
+
+  // Should not crash with "panic" or "assertion failed"
+  expect(stderrText).not.toContain("panic");
+  expect(stderrText).not.toContain("Assertion failed");
+  expect(stderrText).not.toContain("assertPrettyIsValid");
+
+  expect(stdoutText).toContain("Build succeeded");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/026798.test.ts
+++ b/test/regression/issue/026798.test.ts
@@ -33,20 +33,16 @@ console.log("Build succeeded");
 `,
   });
 
-  const { stdout, stderr, exitCode } = Bun.spawnSync({
+  await using proc = Bun.spawn({
     cmd: [bunExe(), "run", "build.ts"],
     cwd: dir,
     env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
   });
 
-  const stderrText = stderr.toString();
-  const stdoutText = stdout.toString();
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
-  // Should not crash with "panic" or "assertion failed"
-  expect(stderrText).not.toContain("panic");
-  expect(stderrText).not.toContain("Assertion failed");
-  expect(stderrText).not.toContain("assertPrettyIsValid");
-
-  expect(stdoutText).toContain("Build succeeded");
+  expect(stdout).toContain("Build succeeded");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Summary

Fixes #26798

- Convert Windows backslashes to POSIX forward slashes in `path.pretty` when setting it from `relativePlatform()` result
- On Windows, `relativePlatform()` with `always_copy = false` can return paths with backslashes when paths have different roots (different drives or UNC paths). This violates the invariant that `path.pretty` must only contain forward slashes, causing `assertPrettyIsValid()` to panic.

## Test plan

- [x] Added regression test at `test/regression/issue/026798.test.ts` that verifies `Bun.build` with a plugin returning null from `onResolve` works without crashing
- The fix uses `platformToPosixInPlace()` which is a no-op on non-Windows platforms, so this is safe on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)