### PR TITLE
fix(bundler): don't reject server configs with a stop() method

### DIFF
--- a/src/bundler/entry_points.zig
+++ b/src/bundler/entry_points.zig
@@ -167,7 +167,10 @@ pub const ServerEntryPoint = struct {
                     \\var hmrSymbol = Symbol("BunServerHMR");
                     \\var entryNamespace = start;
                     \\function isServerConfig(def) {{
-                    \\   return def && def !== globalThis && (typeof def.fetch === 'function' || def.app != undefined) && typeof def.stop !== 'function';
+                    \\   if (!def || def === globalThis) return false;
+                    \\   if (typeof def.fetch !== 'function' && def.app == undefined) return false;
+                    \\   if (typeof def.stop === 'function' && typeof def.hostname === 'string' && typeof def.port === 'number') return false;
+                    \\   return true;
                     \\}}
                     \\if (typeof entryNamespace?.then === 'function') {{
                     \\   entryNamespace = entryNamespace.then((entryNamespace) => {{
@@ -206,7 +209,10 @@ pub const ServerEntryPoint = struct {
                 \\import * as start from "{f}";
                 \\var entryNamespace = start;
                 \\function isServerConfig(def) {{
-                \\   return def && def !== globalThis && (typeof def.fetch === 'function' || def.app != undefined) && typeof def.stop !== 'function';
+                \\   if (!def || def === globalThis) return false;
+                \\   if (typeof def.fetch !== 'function' && def.app == undefined) return false;
+                \\   if (typeof def.stop === 'function' && typeof def.hostname === 'string' && typeof def.port === 'number') return false;
+                \\   return true;
                 \\}}
                 \\if (typeof entryNamespace?.then === 'function') {{
                 \\   entryNamespace = entryNamespace.then((entryNamespace) => {{


### PR DESCRIPTION
## What does this PR do?

Fixes `export default` HTTP server detection rejecting any object that has a `stop()` method, even when it's a valid server config (not a running server).

## How did you verify your code works?

Reproduction from #26747:

```js
export default {
  port: 8080,
  fetch(req) { return new Response("hello"); },
  stop() { console.log("cleanup"); },
};
```

Before: Bun does not start the server (silently skipped because `typeof def.stop !== 'function'` fails).
After: Bun starts the server correctly.

## Root Cause

`isServerConfig()` in `src/bundler/entry_points.zig` used:

```js
typeof def.stop !== 'function'
```

This was intended to prevent double-serving when `export default Bun.serve({...})` returns a running `Server` instance (which has a `stop()` method). But it's too broad — it rejects **any** object with `stop()`, including Elysia apps and plain config objects.

## Fix

Replace the broad `stop` check with precise running-server detection. A running `Bun.Server` instance uniquely has `stop` (function) + `hostname` (string) + `port` (number). A config object or framework app won't have `hostname` as a string or `port` as a number before being served.

```js
// Before: rejects anything with stop()
typeof def.stop !== 'function'

// After: only rejects running Bun.Server instances
!(typeof def.stop === 'function' && typeof def.hostname === 'string' && typeof def.port === 'number')
```

Both instances of `isServerConfig` (HMR and standard modes) are updated.

Fixes https://github.com/oven-sh/bun/issues/26747

Made with [Cursor](https://cursor.com)