### PR TITLE
fix(fs): correct off-by-one in file:// URL prefix stripping

### DIFF
--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -509,7 +509,7 @@ pub const StatWatcher = struct {
         defer bun.path_buffer_pool.put(buf);
         var slice = args.path.slice();
         if (bun.strings.startsWith(slice, "file://")) {
-            slice = slice[6..];
+            slice = slice["file://".len..];
         }
 
         var parts = [_]string{slice};

--- a/src/bun.js/node/node_fs_watcher.zig
+++ b/src/bun.js/node/node_fs_watcher.zig
@@ -634,7 +634,7 @@ pub const FSWatcher = struct {
             defer bun.path_buffer_pool.put(buf);
             var slice = args.path.slice();
             if (bun.strings.startsWith(slice, "file://")) {
-                slice = slice[6..];
+                slice = slice["file://".len..];
             }
 
             const cwd = switch (bun.sys.getcwd(buf)) {


### PR DESCRIPTION
## What does this PR do?

Fixes an off-by-one error when stripping the `file://` prefix from paths in `fs.watch` and `fs.watchFile`.

## How did you verify your code works?

`"file://"` is 7 characters, but the code used `slice[6..]`, leaving a stray `/` at the start of the resulting path. This causes incorrect path resolution when watching files via `file://` URLs.

```zig
// Before (wrong — strips 6 chars from a 7-char prefix):
slice = slice[6..];

// After (correct — uses compile-time length):
slice = slice["file://".len..];
```

## Files changed

- `src/bun.js/node/node_fs_watcher.zig` — line 637
- `src/bun.js/node/node_fs_stat_watcher.zig` — line 512

Both instances replaced the hardcoded `6` with `"file://".len` for correctness and self-documentation.

Refs: https://github.com/oven-sh/bun/issues/26770

Made with [Cursor](https://cursor.com)