### PR TITLE
perf(structuredClone): add fast path for root-level dense arrays

### DIFF
--- a/bench/snippets/structuredClone.mjs
+++ b/bench/snippets/structuredClone.mjs
@@ -33,7 +33,23 @@ var testArray = [
 
 import { bench, run } from "../runner.mjs";
 
-bench("structuredClone(array)", () => structuredClone(testArray));
+bench("structuredClone(nested array)", () => structuredClone(testArray));
 bench("structuredClone(123)", () => structuredClone(123));
 bench("structuredClone({a: 123})", () => structuredClone({ a: 123 }));
+
+// Array fast path targets
+var numbersSmall = Array.from({ length: 10 }, (_, i) => i);
+var numbersMedium = Array.from({ length: 100 }, (_, i) => i);
+var numbersLarge = Array.from({ length: 1000 }, (_, i) => i);
+var stringsSmall = Array.from({ length: 10 }, (_, i) => `item-${i}`);
+var stringsMedium = Array.from({ length: 100 }, (_, i) => `item-${i}`);
+var mixed = [1, "hello", true, null, undefined, 3.14, "world", false, 42, "test"];
+
+bench("structuredClone([10 numbers])", () => structuredClone(numbersSmall));
+bench("structuredClone([100 numbers])", () => structuredClone(numbersMedium));
+bench("structuredClone([1000 numbers])", () => structuredClone(numbersLarge));
+bench("structuredClone([10 strings])", () => structuredClone(stringsSmall));
+bench("structuredClone([100 strings])", () => structuredClone(stringsMedium));
+bench("structuredClone([10 mixed])", () => structuredClone(mixed));
+
 await run();

--- a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
@@ -5675,8 +5675,8 @@ size_t SerializedScriptValue::computeMemoryCost() const
         cost += m_simpleArrayElements.byteSize();
         for (const auto& elem : m_simpleArrayElements) {
             std::visit(WTF::makeVisitor(
-                [&](JSC::JSValue) { /* already included in byteSize() */ },
-                [&](const String& s) { cost += s.sizeInBytes(); }),
+                           [&](JSC::JSValue) { /* already included in byteSize() */ },
+                           [&](const String& s) { cost += s.sizeInBytes(); }),
                 elem);
         }
         break;
@@ -5952,10 +5952,16 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
 
                 for (unsigned i = 0; i < length; i++) {
                     JSValue elem = data[i].get();
-                    if (!elem) { ok = false; break; }
+                    if (!elem) {
+                        ok = false;
+                        break;
+                    }
 
                     if (elem.isCell()) {
-                        if (!elem.isString()) { ok = false; break; }
+                        if (!elem.isString()) {
+                            ok = false;
+                            break;
+                        }
                         auto* str = asString(elem);
                         String strValue = str->value(&lexicalGlobalObject);
                         RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });

--- a/src/bun.js/bindings/webcore/SerializedScriptValue.h
+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.h
@@ -270,6 +270,8 @@ private:
     size_t m_memoryCost { 0 };
 
     FixedVector<SimpleInMemoryPropertyTableEntry> m_simpleInMemoryPropertyTable {};
+    // m_simpleArrayElements and m_arrayButterflyData/m_arrayLength are used exclusively:
+    // SimpleArray uses m_simpleArrayElements; Int32Array/DoubleArray use m_arrayButterflyData + m_arrayLength.
     FixedVector<SimpleCloneableValue> m_simpleArrayElements {};
 
     // Int32Array / DoubleArray fast path: raw butterfly data

--- a/test/js/web/structured-clone-fastpath.test.ts
+++ b/test/js/web/structured-clone-fastpath.test.ts
@@ -90,6 +90,55 @@ describe("Structured Clone Fast Path", () => {
     expect(delta).toBeLessThan(1024 * 1024);
   });
 
+  // === Array fast path tests ===
+
+  test("structuredClone should work with empty array", () => {
+    expect(structuredClone([])).toEqual([]);
+  });
+
+  test("structuredClone should work with array of numbers", () => {
+    const input = [1, 2, 3, 4, 5];
+    expect(structuredClone(input)).toEqual(input);
+  });
+
+  test("structuredClone should work with array of strings", () => {
+    const input = ["hello", "world", ""];
+    expect(structuredClone(input)).toEqual(input);
+  });
+
+  test("structuredClone should work with array of mixed primitives", () => {
+    const input = [1, "hello", true, false, null, undefined, 3.14];
+    const cloned = structuredClone(input);
+    expect(cloned).toEqual(input);
+  });
+
+  test("structuredClone should work with array of special numbers", () => {
+    const cloned = structuredClone([-0, NaN, Infinity, -Infinity]);
+    expect(Object.is(cloned[0], -0)).toBe(true);
+    expect(cloned[1]).toBeNaN();
+    expect(cloned[2]).toBe(Infinity);
+    expect(cloned[3]).toBe(-Infinity);
+  });
+
+  test("structuredClone should work with large array of numbers", () => {
+    const input = Array.from({ length: 10000 }, (_, i) => i);
+    expect(structuredClone(input)).toEqual(input);
+  });
+
+  test("structuredClone should fallback for arrays with nested objects", () => {
+    const input = [{ a: 1 }, { b: 2 }];
+    expect(structuredClone(input)).toEqual(input);
+  });
+
+  test("structuredClone should fallback for arrays with holes", () => {
+    const input = [1, , 3]; // sparse
+    const cloned = structuredClone(input);
+    // structured clone spec: holes become undefined
+    expect(cloned[0]).toBe(1);
+    expect(cloned[1]).toBe(undefined);
+    expect(cloned[2]).toBe(3);
+  });
+
   test("structuredClone on object with simple properties can exceed JSFinalObject::maxInlineCapacity", () => {
     let largeValue = {};
     for (let i = 0; i < 100; i++) {

--- a/test/js/web/structured-clone-fastpath.test.ts
+++ b/test/js/web/structured-clone-fastpath.test.ts
@@ -139,6 +139,39 @@ describe("Structured Clone Fast Path", () => {
     expect(cloned[2]).toBe(3);
   });
 
+  test("structuredClone should work with array of doubles", () => {
+    const input = [1.5, 2.7, 3.14, 0.1 + 0.2];
+    const cloned = structuredClone(input);
+    expect(cloned).toEqual(input);
+  });
+
+  test("structuredClone creates independent copy of array", () => {
+    const input = [1, 2, 3];
+    const cloned = structuredClone(input);
+    cloned[0] = 999;
+    expect(input[0]).toBe(1);
+  });
+
+  test("structuredClone should preserve named properties on arrays", () => {
+    const input: any = [1, 2, 3];
+    input.foo = "bar";
+    const cloned = structuredClone(input);
+    expect(cloned.foo).toBe("bar");
+    expect(Array.from(cloned)).toEqual([1, 2, 3]);
+  });
+
+  test("postMessage should work with array fast path", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const input = [1, 2, 3, "hello", true];
+    const { promise, resolve } = Promise.withResolvers();
+    port2.onmessage = (e: MessageEvent) => resolve(e.data);
+    port1.postMessage(input);
+    const result = await promise;
+    expect(result).toEqual(input);
+    port1.close();
+    port2.close();
+  });
+
   test("structuredClone on object with simple properties can exceed JSFinalObject::maxInlineCapacity", () => {
     let largeValue = {};
     for (let i = 0; i < 100; i++) {

--- a/test/js/web/structured-clone-fastpath.test.ts
+++ b/test/js/web/structured-clone-fastpath.test.ts
@@ -172,6 +172,191 @@ describe("Structured Clone Fast Path", () => {
     port2.close();
   });
 
+  // === Edge case tests ===
+
+  test("structuredClone of frozen array should produce a non-frozen clone", () => {
+    const input = Object.freeze([1, 2, 3]);
+    const cloned = structuredClone(input);
+    expect(cloned).toEqual([1, 2, 3]);
+    expect(Object.isFrozen(cloned)).toBe(false);
+    cloned[0] = 999;
+    expect(cloned[0]).toBe(999);
+  });
+
+  test("structuredClone of sealed array should produce a non-sealed clone", () => {
+    const input = Object.seal([1, 2, 3]);
+    const cloned = structuredClone(input);
+    expect(cloned).toEqual([1, 2, 3]);
+    expect(Object.isSealed(cloned)).toBe(false);
+    cloned.push(4);
+    expect(cloned).toEqual([1, 2, 3, 4]);
+  });
+
+  test("structuredClone of array with deleted element (hole via delete)", () => {
+    const input = [1, 2, 3];
+    delete (input as any)[1];
+    const cloned = structuredClone(input);
+    expect(cloned[0]).toBe(1);
+    expect(cloned[1]).toBe(undefined);
+    expect(cloned[2]).toBe(3);
+    expect(1 in cloned).toBe(false); // holes remain holes after structuredClone
+  });
+
+  test("structuredClone of array with length > actual elements", () => {
+    const input = [1, 2, 3];
+    input.length = 6;
+    const cloned = structuredClone(input);
+    expect(cloned.length).toBe(6);
+    expect(cloned[0]).toBe(1);
+    expect(cloned[1]).toBe(2);
+    expect(cloned[2]).toBe(3);
+    expect(cloned[3]).toBe(undefined);
+  });
+
+  test("structuredClone of single element arrays", () => {
+    expect(structuredClone([42])).toEqual([42]);
+    expect(structuredClone([3.14])).toEqual([3.14]);
+    expect(structuredClone(["hello"])).toEqual(["hello"]);
+    expect(structuredClone([true])).toEqual([true]);
+    expect(structuredClone([null])).toEqual([null]);
+  });
+
+  test("structuredClone of array with named properties on Int32 array", () => {
+    const input: any = [1, 2, 3]; // Int32 indexing
+    input.name = "test";
+    input.count = 42;
+    const cloned = structuredClone(input);
+    expect(cloned.name).toBe("test");
+    expect(cloned.count).toBe(42);
+    expect(Array.from(cloned)).toEqual([1, 2, 3]);
+  });
+
+  test("structuredClone of array with named properties on Double array", () => {
+    const input: any = [1.1, 2.2, 3.3]; // Double indexing
+    input.label = "doubles";
+    const cloned = structuredClone(input);
+    expect(cloned.label).toBe("doubles");
+    expect(Array.from(cloned)).toEqual([1.1, 2.2, 3.3]);
+  });
+
+  test("structuredClone of array that transitions Int32 to Double", () => {
+    const input = [1, 2, 3]; // starts as Int32
+    input.push(4.5); // transitions to Double
+    const cloned = structuredClone(input);
+    expect(cloned).toEqual([1, 2, 3, 4.5]);
+  });
+
+  test("structuredClone of array with modified prototype", () => {
+    const input = [1, 2, 3];
+    Object.setPrototypeOf(input, {
+      customMethod() {
+        return 42;
+      },
+    });
+    const cloned = structuredClone(input);
+    // Clone should have standard Array prototype, not the custom one
+    expect(Array.from(cloned)).toEqual([1, 2, 3]);
+    expect(cloned).toBeInstanceOf(Array);
+    expect((cloned as any).customMethod).toBeUndefined();
+  });
+
+  test("structuredClone of array with prototype indexed properties and holes", () => {
+    const proto = Object.create(Array.prototype);
+    proto[1] = "from proto";
+    const input = new Array(3);
+    Object.setPrototypeOf(input, proto);
+    input[0] = "a";
+    input[2] = "c";
+    // structuredClone only copies own properties; prototype values are not included
+    const cloned = structuredClone(input);
+    expect(cloned[0]).toBe("a");
+    expect(1 in cloned).toBe(false); // hole, not "from proto"
+    expect(cloned[2]).toBe("c");
+    expect(cloned).toBeInstanceOf(Array);
+  });
+
+  test("postMessage with Int32 array via MessageChannel", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const input = [10, 20, 30, 40, 50];
+    const { promise, resolve } = Promise.withResolvers();
+    port2.onmessage = (e: MessageEvent) => resolve(e.data);
+    port1.postMessage(input);
+    const result = await promise;
+    expect(result).toEqual(input);
+    port1.close();
+    port2.close();
+  });
+
+  test("postMessage with Double array via MessageChannel", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const input = [1.1, 2.2, 3.3];
+    const { promise, resolve } = Promise.withResolvers();
+    port2.onmessage = (e: MessageEvent) => resolve(e.data);
+    port1.postMessage(input);
+    const result = await promise;
+    expect(result).toEqual(input);
+    port1.close();
+    port2.close();
+  });
+
+  test("structuredClone of array multiple times produces independent copies", () => {
+    const input = [1, 2, 3];
+    const clones = Array.from({ length: 10 }, () => structuredClone(input));
+    clones[0][0] = 999;
+    clones[5][1] = 888;
+    // All other clones and the original should be unaffected
+    expect(input).toEqual([1, 2, 3]);
+    for (let i = 1; i < 10; i++) {
+      if (i === 5) {
+        expect(clones[i]).toEqual([1, 888, 3]);
+      } else {
+        expect(clones[i]).toEqual([1, 2, 3]);
+      }
+    }
+  });
+
+  test("structuredClone of Array subclass loses subclass identity", () => {
+    class MyArray extends Array {
+      customProp = "hello";
+      sum() {
+        return this.reduce((a: number, b: number) => a + b, 0);
+      }
+    }
+    const input = new MyArray(1, 2, 3);
+    input.customProp = "world";
+    const cloned = structuredClone(input);
+    // structuredClone spec: result is a plain Array, not a subclass
+    expect(Array.from(cloned)).toEqual([1, 2, 3]);
+    expect(cloned).toBeInstanceOf(Array);
+    expect((cloned as any).sum).toBeUndefined();
+  });
+
+  test("structuredClone of array with only undefined values", () => {
+    const input = [undefined, undefined, undefined];
+    const cloned = structuredClone(input);
+    expect(cloned).toEqual([undefined, undefined, undefined]);
+    expect(cloned.length).toBe(3);
+    // Ensure they are actual values, not holes
+    expect(0 in cloned).toBe(true);
+    expect(1 in cloned).toBe(true);
+    expect(2 in cloned).toBe(true);
+  });
+
+  test("structuredClone of array with only null values", () => {
+    const input = [null, null, null];
+    const cloned = structuredClone(input);
+    expect(cloned).toEqual([null, null, null]);
+  });
+
+  test("structuredClone of dense double array preserves -0 and NaN", () => {
+    const input = [-0, NaN, -0, NaN];
+    const cloned = structuredClone(input);
+    expect(Object.is(cloned[0], -0)).toBe(true);
+    expect(cloned[1]).toBeNaN();
+    expect(Object.is(cloned[2], -0)).toBe(true);
+    expect(cloned[3]).toBeNaN();
+  });
+
   test("structuredClone on object with simple properties can exceed JSFinalObject::maxInlineCapacity", () => {
     let largeValue = {};
     for (let i = 0; i < 100; i++) {


### PR DESCRIPTION
## Summary

Add a fast path for `structuredClone` and `postMessage` when the root value is a dense array of primitives or strings. This bypasses the full `CloneSerializer`/`CloneDeserializer` machinery by keeping data in native C++ structures instead of serializing to a byte stream.

**Important:** This optimization only applies when the root value passed to `structuredClone()` / `postMessage()` is an array. Nested arrays within objects still go through the normal serialization path.

## Implementation

Three tiers of array fast paths, checked in order:

| Tier | Indexing Type | Strategy | Applies When |
|------|--------------|----------|--------------|
| **Tier 1** | `ArrayWithInt32` | `memcpy` butterfly data | Dense int32 array, no holes, no named properties |
| **Tier 2** | `ArrayWithDouble` | `memcpy` butterfly data | Dense double array, no holes, no named properties |
| **Tier 3** | `ArrayWithContiguous` | Copy elements into `FixedVector<variant<JSValue, String>>` | Dense array of primitives/strings, no holes, no named properties |

All tiers fall through to the normal serialization path when:
- The array has holes that must forward to the prototype
- The array has named properties (e.g., `arr.foo = "bar"`) — checked via `structure->maxOffset() != invalidOffset`
- Elements contain non-primitive, non-string values (objects, arrays, etc.)
- The context requires wire-format serialization (storage, cross-process transfer)

### Deserialization

- **Tier 1/2:** Allocate a new `Butterfly` via `vm.auxiliarySpace()`, `memcpy` data back, create array with `JSArray::createWithButterfly()`. Falls back to normal deserialization if `isHavingABadTime` (forced ArrayStorage mode).
- **Tier 3:** Pre-convert elements to `JSValue` (including `jsString()` allocation), then use `JSArray::tryCreateUninitializedRestricted()` + `initializeIndex()`.

## Benchmarks

Apple M4 Max, comparing system Bun 1.3.8 vs this branch (release build):

| Benchmark | Before | After | Speedup |
|-----------|--------|-------|---------|
| `structuredClone([10 numbers])` | 308.71 ns | 40.38 ns | **7.6x** |
| `structuredClone([100 numbers])` | 1.62 µs | 86.87 ns | **18.7x** |
| `structuredClone([1000 numbers])` | 13.79 µs | 544.56 ns | **25.3x** |
| `structuredClone([10 strings])` | 642.38 ns | 307.38 ns | **2.1x** |
| `structuredClone([100 strings])` | 5.67 µs | 2.57 µs | **2.2x** |
| `structuredClone([10 mixed])` | 446.32 ns | 198.35 ns | **2.3x** |
| `structuredClone(nested array)` | 1.84 µs | 1.79 µs | 1.0x (not eligible) |
| `structuredClone({a: 123})` | 95.98 ns | 100.07 ns | 1.0x (no regression) |

Int32 arrays see the largest gains (up to 25x) since they use a direct `memcpy` of butterfly memory. String/mixed arrays see ~2x improvement. No performance regression on non-eligible inputs.

## Bug Fix

Also fixes a correctness bug where arrays with named properties (e.g., `arr.foo = "bar"`) would lose those properties when going through the array fast path. Added a `structure->maxOffset() != invalidOffset` guard to fall back to normal serialization for such arrays.

Fixed a minor double-counting issue in `computeMemoryCost` where `JSValue` elements in `SimpleArray` were counted both by `byteSize()` and individually.

## Test Plan

38 tests in `test/js/web/structured-clone-fastpath.test.ts` covering:

- Basic array types: empty, numbers, strings, mixed primitives, special numbers (`-0`, `NaN`, `Infinity`)
- Large arrays (10,000 elements)
- Tier 2: double arrays, Int32→Double transition
- Deep clone independence verification
- Named properties on Int32, Double, and Contiguous arrays
- `postMessage` via `MessageChannel` for Int32, Double, and mixed arrays
- Edge cases: frozen/sealed arrays, deleted elements (holes), `length` extension, single-element arrays
- Prototype modification (custom prototype, indexed prototype properties with holes)
- `Array` subclass identity loss (per spec)
- `undefined`-only and `null`-only arrays
- Multiple independent clones from the same source
