### PR TITLE
perf(buffer): move Buffer.slice/subarray to native C++ with int32 fast path

### DIFF
--- a/bench/snippets/buffer-slice.mjs
+++ b/bench/snippets/buffer-slice.mjs
@@ -1,0 +1,38 @@
+// @runtime bun,node
+import { bench, group, run } from "../runner.mjs";
+
+const small = Buffer.alloc(64, 0x42);
+const medium = Buffer.alloc(1024, 0x42);
+const large = Buffer.alloc(1024 * 1024, 0x42);
+
+group("slice - no args", () => {
+  bench("Buffer(64).slice()", () => small.slice());
+  bench("Buffer(1024).slice()", () => medium.slice());
+  bench("Buffer(1M).slice()", () => large.slice());
+});
+
+group("slice - one int arg", () => {
+  bench("Buffer(64).slice(10)", () => small.slice(10));
+  bench("Buffer(1024).slice(10)", () => medium.slice(10));
+  bench("Buffer(1M).slice(1024)", () => large.slice(1024));
+});
+
+group("slice - two int args", () => {
+  bench("Buffer(64).slice(10, 50)", () => small.slice(10, 50));
+  bench("Buffer(1024).slice(10, 100)", () => medium.slice(10, 100));
+  bench("Buffer(1M).slice(1024, 4096)", () => large.slice(1024, 4096));
+});
+
+group("slice - negative args", () => {
+  bench("Buffer(64).slice(-10)", () => small.slice(-10));
+  bench("Buffer(1024).slice(-100, -10)", () => medium.slice(-100, -10));
+  bench("Buffer(1M).slice(-4096, -1024)", () => large.slice(-4096, -1024));
+});
+
+group("subarray - two int args", () => {
+  bench("Buffer(64).subarray(10, 50)", () => small.subarray(10, 50));
+  bench("Buffer(1024).subarray(10, 100)", () => medium.subarray(10, 100));
+  bench("Buffer(1M).subarray(1024, 4096)", () => large.subarray(1024, 4096));
+});
+
+await run();

--- a/src/js/builtins/JSBufferPrototype.ts
+++ b/src/js/builtins/JSBufferPrototype.ts
@@ -664,28 +664,6 @@ export function toJSON(this: BufferExt) {
   return { type, data };
 }
 
-export function slice(this: BufferExt, start, end) {
-  var { buffer, byteOffset, byteLength } = this;
-
-  function adjustOffset(offset, length) {
-    // Use Math.trunc() to convert offset to an integer value that can be larger
-    // than an Int32. Hence, don't use offset | 0 or similar techniques.
-    offset = Math.trunc(offset);
-    if (offset === 0 || offset !== offset) {
-      return 0;
-    } else if (offset < 0) {
-      offset += length;
-      return offset > 0 ? offset : 0;
-    } else {
-      return offset < length ? offset : length;
-    }
-  }
-
-  var start_ = adjustOffset(start, byteLength);
-  var end_ = end !== undefined ? adjustOffset(end, byteLength) : byteLength;
-  return new $Buffer(buffer, byteOffset + start_, end_ > start_ ? end_ - start_ : 0);
-}
-
 $getter;
 export function parent(this: BufferExt) {
   return $isObject(this) && this instanceof $Buffer ? this.buffer : undefined;

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -887,6 +887,49 @@ for (let withOverridenBufferWrite of [false, true]) {
         expect(f[1]).toBe(0x6f);
       });
 
+      it("slice() with fractional offsets truncates toward zero", () => {
+        const buf = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+        // -0.1 should truncate to 0, not -1
+        const a = buf.slice(-0.1);
+        expect(a.length).toBe(10);
+        expect(a[0]).toBe(0);
+
+        // -1.9 should truncate to -1, not -2
+        const b = buf.slice(-1.9);
+        expect(b.length).toBe(1);
+        expect(b[0]).toBe(9);
+
+        // 1.9 should truncate to 1
+        const c = buf.slice(1.9, 4.1);
+        expect(c.length).toBe(3);
+        expect(c[0]).toBe(1);
+        expect(c[1]).toBe(2);
+        expect(c[2]).toBe(3);
+
+        // NaN should be treated as 0
+        const d = buf.slice(NaN, NaN);
+        expect(d.length).toBe(0);
+
+        const e = buf.slice(NaN);
+        expect(e.length).toBe(10);
+      });
+
+      it("slice() on detached buffer throws TypeError", () => {
+        const ab = new ArrayBuffer(10);
+        const buf = Buffer.from(ab);
+        // Detach the ArrayBuffer by transferring it
+        structuredClone(ab, { transfer: [ab] });
+        expect(() => buf.slice(0, 5)).toThrow(TypeError);
+      });
+
+      it("subarray() on detached buffer throws TypeError", () => {
+        const ab = new ArrayBuffer(10);
+        const buf = Buffer.from(ab);
+        structuredClone(ab, { transfer: [ab] });
+        expect(() => buf.subarray(0, 5)).toThrow(TypeError);
+      });
+
       function forEachUnicode(label, test) {
         ["ucs2", "ucs-2", "utf16le", "utf-16le"].forEach(encoding =>
           it(`${label} (${encoding})`, test.bind(null, encoding)),


### PR DESCRIPTION
## Summary

Move `Buffer.slice()` / `Buffer.subarray()` from a JS builtin to a native C++ implementation, eliminating the `adjustOffset` closure allocation and JS→C++ constructor overhead on every call. Additionally, add an int32 fast path that skips `toNumber()` (which can invoke `valueOf`/`Symbol.toPrimitive`) when arguments are already int32—the common case for calls like `buf.slice(0, 10)`.

## Changes

- **`src/bun.js/bindings/JSBuffer.cpp`**: Add `jsBufferPrototypeFunction_sliceBody` with `adjustSliceOffsetInt32` / `adjustSliceOffsetDouble` helpers. Update prototype hash table entries from `BuiltinGeneratorType` to `NativeFunctionType` for both `slice` and `subarray`.
- **`src/js/builtins/JSBufferPrototype.ts`**: Remove the JS `slice` function (was lines 667–687).
- **`bench/snippets/buffer-slice.mjs`**: Add mitata benchmark.

## Benchmark (Apple M4 Max)

| Benchmark | Before (v1.3.8) | After | Speedup |
|---|---|---|---|
| `Buffer(64).slice()` | 27.19 ns | **14.56 ns** | **1.87x** |
| `Buffer(1024).slice()` | 27.84 ns | **14.62 ns** | **1.90x** |
| `Buffer(1M).slice()` | 29.20 ns | **14.89 ns** | **1.96x** |
| `Buffer(64).slice(10)` | 30.26 ns | **16.01 ns** | **1.89x** |
| `Buffer(1024).slice(10, 100)` | 30.92 ns | **18.32 ns** | **1.69x** |
| `Buffer(1024).slice(-100, -10)` | 28.82 ns | **17.37 ns** | **1.66x** |
| `Buffer(1024).subarray(10, 100)` | 28.67 ns | **16.32 ns** | **1.76x** |

**~1.7–1.9x faster** across all cases. All 449 buffer tests pass.