### PR TITLE
move tickImmediateTasks into us_loop_run_bun_tick

### DIFF
--- a/test/js/web/timers/setImmediate-event-loop.test.ts
+++ b/test/js/web/timers/setImmediate-event-loop.test.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("setImmediate runs before setTimeout(0)", async () => {
+  const order: string[] = [];
+
+  await new Promise<void>(resolve => {
+    setTimeout(() => {
+      order.push("timeout");
+      resolve();
+    }, 0);
+
+    setImmediate(() => {
+      order.push("immediate");
+    });
+  });
+
+  expect(order).toEqual(["immediate", "timeout"]);
+});
+
+test("nested setImmediate callbacks run on separate ticks", async () => {
+  const order: string[] = [];
+
+  await new Promise<void>(resolve => {
+    setImmediate(() => {
+      order.push("first");
+      setImmediate(() => {
+        order.push("third");
+        resolve();
+      });
+    });
+    setImmediate(() => {
+      order.push("second");
+    });
+  });
+
+  expect(order).toEqual(["first", "second", "third"]);
+});
+
+test("setImmediate microtasks drain between callbacks", async () => {
+  const order: string[] = [];
+
+  await new Promise<void>(resolve => {
+    setImmediate(() => {
+      order.push("immediate1");
+      Promise.resolve().then(() => order.push("microtask-from-immediate1"));
+    });
+    setImmediate(() => {
+      order.push("immediate2");
+      Promise.resolve().then(() => {
+        order.push("microtask-from-immediate2");
+        resolve();
+      });
+    });
+  });
+
+  // Microtask from immediate1 should drain before immediate2 runs
+  // (each runImmediateTask calls exitMaybeDrainMicrotasks)
+  expect(order).toEqual(["immediate1", "microtask-from-immediate1", "immediate2", "microtask-from-immediate2"]);
+});
+
+test("setImmediate works with active I/O", async () => {
+  const server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Promise<Response>(resolve => {
+        setImmediate(() => {
+          resolve(new Response("from-immediate"));
+        });
+      });
+    },
+  });
+
+  try {
+    const resp = await fetch(`http://localhost:${server.port}/`);
+    expect(await resp.text()).toBe("from-immediate");
+  } finally {
+    server.stop(true);
+  }
+});
+
+test("many setImmediate callbacks execute correctly", async () => {
+  const count = 1000;
+  let executed = 0;
+
+  await new Promise<void>(resolve => {
+    for (let i = 0; i < count; i++) {
+      setImmediate(() => {
+        executed++;
+        if (executed === count) {
+          resolve();
+        }
+      });
+    }
+  });
+
+  expect(executed).toBe(count);
+});
+
+test("setImmediate works when spawned as subprocess", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      let count = 0;
+      function tick() {
+        count++;
+        if (count < 5) {
+          setImmediate(tick);
+        } else {
+          console.log("done:" + count);
+        }
+      }
+      setImmediate(tick);
+    `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("done:5");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Move `setImmediate` callback execution (`tickImmediateTasks`) from the Zig event loop layer (`autoTick`/`autoTickActive`) into the C poll function (`us_loop_run_bun_tick`) via a new `Bun__tickImmediateTasks` exported callback
- The callback runs at the top of `us_loop_run_bun_tick`, before the `num_polls == 0` early return, ensuring immediates still fire even with no registered file descriptors
- When more immediate tasks are pending after execution, the callback forces a zero timeout on the subsequent `epoll_pwait2`/`kevent64` syscall, replacing the previous `wakeup()` approach
- Windows continues to call `tickImmediateTasks` directly from Zig since it uses a different poll backend (libuv)

## Test plan

- [x] All existing `setImmediate` tests pass (`test/js/web/timers/setImmediate.test.js`, `test/js/web/timers/setImmediate2.test.ts`, `test/js/node/timers/node-timers.test.ts`)
- [x] All existing web timer tests show identical pass/fail counts vs main
- [x] New test suite (`test/js/web/timers/setImmediate-event-loop.test.ts`) covering:
  - setImmediate ordering vs setTimeout(0)
  - Nested setImmediate across ticks
  - Microtask draining between immediate callbacks
  - setImmediate with active HTTP server I/O
  - Bulk setImmediate execution (1000 callbacks)
  - Subprocess setImmediate behavior
- [x] Manual verification of setImmediate with HTTP server integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)