### PR TITLE
fix(io): prevent segfault from libuv pipe EOF callback after reader cleanup

### DIFF
--- a/test/regression/issue/26832.test.ts
+++ b/test/regression/issue/26832.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/26832
+// Segfault when libuv delivers pipe EOF callbacks after the reader is cleaned up.
+// The crash occurs when spawning many subprocesses and closing them rapidly,
+// causing a race between pipe close and pending EOF callbacks.
+test("rapid subprocess spawn and close does not crash", async () => {
+  const iterations = 50;
+  const promises: Promise<void>[] = [];
+
+  for (let i = 0; i < iterations; i++) {
+    promises.push(
+      (async () => {
+        const proc = Bun.spawn({
+          cmd: [bunExe(), "-e", "process.stdout.write('x'); process.exit(0)"],
+          stdout: "pipe",
+          stderr: "pipe",
+          env: bunEnv,
+        });
+
+        // Read and immediately discard - the key is rapid open/close cycles
+        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+        expect(exitCode).toBe(0);
+      })(),
+    );
+  }
+
+  await Promise.all(promises);
+});


### PR DESCRIPTION
## Summary

- Fix Windows segfault (`SIGSEGV` at `0xFFFFFFFFFFFFFFFF`) caused by libuv delivering pipe EOF callbacks after `WindowsBufferedReader` has been cleaned up
- Set `pipe.data`/`tty.data` to `null` in `closeImpl` instead of self-referencing pointer, and add null guards in `onStreamAlloc` and `onStreamRead`
- Simplify `onPipeClose`/`onTTYClose` to use the handle parameter directly (it's already the correct type)

## Root Cause

When `closeImpl` closes a pipe, it previously set `pipe.data = pipe` (self-referencing for the close callback) and then called `pipe.close()`. However, libuv may still have pending read callbacks (e.g. EOF notifications) queued. When these fire, `onStreamRead` would cast the now-invalid `stream.data` to `*WindowsBufferedReader`, dereferencing garbage memory and crashing.

## Fix

1. **`closeImpl`**: Set `pipe.data = null` / `tty.data = null` instead of self-referencing
2. **`onStreamAlloc`**: Use `handle.data orelse return` instead of unconditional `bun.cast`
3. **`onStreamRead`**: Use `stream.data orelse return` instead of unconditional `bun.cast`
4. **`onPipeClose`/`onTTYClose`**: Use `handle` parameter directly since it's already the correct `*uv.Pipe`/`*uv.uv_tty_t` type — no need to read from `handle.data`

Closes #26832
Duplicate of #26574

## Test plan

- [x] Added regression test (`test/regression/issue/26832.test.ts`) that spawns 50 concurrent subprocesses with piped stdout
- [x] Debug build compiles successfully
- [x] Regression test passes with `bun bd test`
- [ ] CI passes on Windows (where the race condition manifests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)