### PR TITLE
fix(install): exclude optional peers resolved against dev deps in --prod

### DIFF
--- a/test/regression/issue/26837.test.ts
+++ b/test/regression/issue/26837.test.ts
@@ -1,0 +1,45 @@
+// https://github.com/oven-sh/bun/issues/26837
+// Test that `bun install --production` does not install optional peer
+// dependencies that are also listed as devDependencies. When a production
+// dependency (e.g. @prisma/client) has an optional peer (e.g. typescript),
+// and that same package appears in the root devDependencies, `--production`
+// should NOT install it.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("--production should not install optional peers that match devDependencies", async () => {
+  using dir = tempDir("issue-26837", {
+    "package.json": JSON.stringify({
+      name: "test-issue-26837",
+      dependencies: {
+        "@prisma/client": "^6.3.1",
+      },
+      devDependencies: {
+        typescript: "^5.7.3",
+      },
+    }),
+  });
+
+  // Run bun install --production
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", "--production"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // typescript should NOT be installed since it's a devDependency
+  // and we're installing with --production
+  const output = stdout + stderr;
+  expect(output).not.toContain("error:");
+
+  // Check that typescript is not in node_modules
+  const typescriptExists = await Bun.file(`${dir}/node_modules/typescript/package.json`).exists();
+  expect(typescriptExists).toBe(false);
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fixes `bun install --production` incorrectly installing optional peer dependencies that match root `devDependencies`
- When `@prisma/client` has `typescript` as an optional peer, and `typescript` is in `devDependencies`, running `bun i --prod` would incorrectly install `typescript`
- The fix adds a check in the filter phase: when an optional peer from a non-root package matches a root dev dependency and `--prod` is active, filter it out

## How it works

During the `.resolvable` tree-building phase, optional peers get resolved against any matching dependency in the tree, including dev deps. In the subsequent `.filter` phase, the root dev dependency is correctly filtered out, but the optional peer retains its resolved package ID and passes through because `remote_package_features.peer_dependencies` is always `true`.

The fix checks in `isFilteredDependencyOrWorkspace`: if the dependency is an optional peer, the parent is a non-root remote package, and `dev_dependencies` are disabled (`--prod`), scan the root package's dependencies for a dev dep with the same name hash. If found, filter the optional peer out.

Closes #26837

## Test plan

- [x] Added regression test `test/regression/issue/26837.test.ts` that verifies `typescript` is not installed when running `--production` with `@prisma/client` as a prod dep and `typescript` as a dev dep
- [x] Verified test fails with system bun (before fix) and passes with debug build (after fix)
- [x] Ran existing `bun-install.test.ts` suite — no regressions (163 pass, pre-existing timeout failures only)
- [x] Ran `test-dev-peer-dependency-priority.test.ts` — no regressions (3/4 pass, 1 pre-existing timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)