### PR TITLE
fix(child_process): remove self-referencing cycle in execSync/execFileSync errors

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1016,6 +1016,9 @@ function checkExecSyncError(ret, args, cmd?) {
   if (ret.error) {
     err = ret.error;
     ObjectAssign(err, ret);
+    // ObjectAssign copies ret.error onto err, but err IS ret.error,
+    // creating a self-referencing cycle (err.error === err). Remove it.
+    delete err.error;
   } else if (ret.status !== 0) {
     let msg = "Command failed: ";
     msg += cmd || ArrayPrototypeJoin.$call(args, " ");

--- a/test/regression/issue/26844.test.ts
+++ b/test/regression/issue/26844.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { execFileSync, execSync } from "child_process";
+
+test("execFileSync error should not have self-referencing cycle", () => {
+  try {
+    execFileSync("nonexistent_binary_xyz_123");
+    expect.unreachable();
+  } catch (err: any) {
+    // err.error should not be the same object as err (self-referencing cycle)
+    expect(err.error).not.toBe(err);
+    // JSON.stringify should not throw due to cyclic structure
+    expect(() => JSON.stringify(err)).not.toThrow();
+  }
+});
+
+test("execSync error should not have self-referencing cycle", () => {
+  try {
+    execSync("nonexistent_binary_xyz_123");
+    expect.unreachable();
+  } catch (err: any) {
+    expect(err.error).not.toBe(err);
+    expect(() => JSON.stringify(err)).not.toThrow();
+  }
+});


### PR DESCRIPTION
## Summary
- Fix `checkExecSyncError` creating a self-referencing cycle where `err.error === err`, which causes `JSON.stringify(err)` to throw
- After `ObjectAssign(err, ret)` copies all properties from `ret` onto `err` (which IS `ret.error`), delete `err.error` to break the cycle
- Add regression tests for both `execFileSync` and `execSync`

Closes #26844

## Test plan
- [x] `USE_SYSTEM_BUN=1 bun test test/regression/issue/26844.test.ts` fails (confirms bug exists in system bun)
- [x] `bun bd test test/regression/issue/26844.test.ts` passes (confirms fix works)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)