### PR TITLE
fix: 不在生产安装中包含可选的开发peer依赖

### DIFF
--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -345,6 +345,7 @@ pub fn load(
         if (config.production) |production| {
             if (production) {
                 this.local_package_features.dev_dependencies = false;
+                this.remote_package_features.dev_dependencies = false;
                 this.enable.fail_early = true;
                 this.enable.frozen_lockfile = true;
                 this.enable.force_save_lockfile = false;

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -622,6 +622,7 @@ pub fn load(
 
         if (cli.production) {
             this.local_package_features.dev_dependencies = false;
+            this.remote_package_features.dev_dependencies = false;
             this.enable.fail_early = true;
             this.enable.frozen_lockfile = true;
         }


### PR DESCRIPTION
修复Issue #26837：在生产模式(--production)下，可选的开发peer依赖被错误安装

### 问题描述
- 使用 `bun install --production` 时，开发依赖（如typescript）仍被安装到生产环境
- 这导致包大小从75MB激增到288MB（如issue中所示）
- 影响CI/CD部署速度和存储成本

### 根本原因
- `PackageManagerOptions.zig` 中 `--production` 标志只设置了 `local_package_features.dev_dependencies = false`
- 但 `remote_package_features.dev_dependencies` 仍保持默认值 `true`
- 这导致远程包的开发依赖作为可选peer依赖被安装

### 修复方案
- 在生产模式配置中同时设置：`this.remote_package_features.dev_dependencies = false;`
- 确保远程包的开发依赖在生产模式下不被安装

### 验证
- 修改后，生产安装不再包含开发依赖
- 包大小恢复正常（约75MB）