### PR TITLE
fix(shell): prevent use-after-free in runFromJS error path

### DIFF
--- a/test/regression/issue/26847.test.ts
+++ b/test/regression/issue/26847.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Issue #26847: Segfault in shell interpreter GC finalization
+// When setupIOBeforeRun() fails in the JS path, the interpreter was freed
+// immediately via deinitFromExec(). When GC later ran deinitFromFinalizer(),
+// it accessed already-freed memory, causing a segfault.
+//
+// The exact error path (dup() failure) is hard to trigger from JS, but this
+// test exercises the shell interpreter + GC interaction to verify there are
+// no lifetime issues when many shell interpreters are created and collected.
+test("shell interpreter GC finalization does not crash", async () => {
+  const code = `
+    // Create many shell interpreters and let them be collected by GC.
+    // This stresses the GC finalization path of ShellInterpreter objects.
+    for (let i = 0; i < 100; i++) {
+      // Create shell promises but don't await them, so they get GC'd
+      Bun.$\`echo \${i}\`.quiet();
+    }
+    // Force garbage collection to finalize the shell interpreter objects.
+    Bun.gc(true);
+    await Bun.sleep(10);
+    Bun.gc(true);
+
+    // Also test the normal path: run and await shell commands, then GC
+    for (let i = 0; i < 10; i++) {
+      await Bun.$\`echo \${i}\`.quiet();
+    }
+    Bun.gc(true);
+    Bun.gc(true);
+
+    console.log("OK");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("OK");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fix use-after-free in shell interpreter when `setupIOBeforeRun()` fails in the JS code path
- Replace `#deinitFromExec()` with `#derefRootShellAndIOIfNeeded(true)` to let GC handle deallocation
- Add regression test exercising shell interpreter GC finalization

## Problem

When `setupIOBeforeRun()` fails inside `runFromJS()`, the error path called `#deinitFromExec()` which immediately frees the interpreter via `allocator.destroy(this)`. Since the interpreter is a GC-managed JavaScript object, the GC finalizer (`deinitFromFinalizer()`) would later try to access the already-freed memory, causing a segfault.

**Crash sequence:**
1. `runFromJS()` → `setupIOBeforeRun()` fails (e.g., `dup(stdout)` returns EBADF)
2. `#deinitFromExec()` calls `allocator.destroy(this)` — interpreter memory is freed
3. GC runs → `deinitFromFinalizer()` accesses freed memory → **segfault**

## Fix

Replace `#deinitFromExec()` with `#derefRootShellAndIOIfNeeded(true)` which:
- Cleans up IO resources and shell environment (same as the normal `finish()` path)
- Sets `cleanup_state = .runtime_cleaned` so the GC finalizer knows what's left to do
- Disables `keep_alive` since no work will be started
- Leaves the actual object deallocation to `deinitFromFinalizer()`, which is the correct owner for GC-managed objects

This is consistent with how `finish()` (line 1215) handles cleanup and follows the same pattern established by prior fixes (#26626, #26277).

## Test plan

- [x] `bun bd test test/regression/issue/26847.test.ts` passes
- [ ] CI passes on all platforms

Closes #26847

🤖 Generated with [Claude Code](https://claude.com/claude-code)