### PR TITLE
fix(test): write JUnit reporter outfile when --bail triggers early exit

### DIFF
--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -945,6 +945,7 @@ pub const CommandLineReporter = struct {
                     this.printSummary();
                     Output.prettyError("\nBailed out after {d} failure{s}<r>\n", .{ this.jest.bail, if (this.jest.bail == 1) "" else "s" });
                     Output.flush();
+                    this.writeJUnitReportIfNeeded();
                     Global.exit(1);
                 }
             },
@@ -965,6 +966,20 @@ pub const CommandLineReporter = struct {
         });
 
         Output.printStartEnd(bun.start_time, std.time.nanoTimestamp());
+    }
+
+    /// Writes the JUnit reporter output file if a JUnit reporter is active and
+    /// an outfile path was configured. This must be called before any early exit
+    /// (e.g. bail) so that the report is not lost.
+    pub fn writeJUnitReportIfNeeded(this: *CommandLineReporter) void {
+        if (this.reporters.junit) |junit| {
+            if (this.jest.test_options.reporter_outfile) |outfile| {
+                if (junit.current_file.len > 0) {
+                    junit.endTestSuite() catch {};
+                }
+                junit.writeToFile(outfile) catch {};
+            }
+        }
     }
 
     pub fn generateCodeCoverage(this: *CommandLineReporter, vm: *jsc.VirtualMachine, opts: *TestCommand.CodeCoverageOptions, comptime reporters: TestCommand.Reporters, comptime enable_ansi_colors: bool) !void {
@@ -1769,12 +1784,7 @@ pub const TestCommand = struct {
         Output.prettyError("\n", .{});
         Output.flush();
 
-        if (reporter.reporters.junit) |junit| {
-            if (junit.current_file.len > 0) {
-                junit.endTestSuite() catch {};
-            }
-            junit.writeToFile(ctx.test_options.reporter_outfile.?) catch {};
-        }
+        reporter.writeJUnitReportIfNeeded();
 
         if (vm.hot_reload == .watch) {
             vm.runWithAPILock(jsc.VirtualMachine, vm, runEventLoopForWatch);
@@ -1917,6 +1927,7 @@ pub const TestCommand = struct {
                     if (reporter.jest.bail == reporter.summary().fail) {
                         reporter.printSummary();
                         Output.prettyError("\nBailed out after {d} failure{s}<r>\n", .{ reporter.jest.bail, if (reporter.jest.bail == 1) "" else "s" });
+                        reporter.writeJUnitReportIfNeeded();
 
                         vm.exit_handler.exit_code = 1;
                         vm.is_shutting_down = true;

--- a/test/regression/issue/26851.test.ts
+++ b/test/regression/issue/26851.test.ts
@@ -20,7 +20,7 @@ test("--bail writes JUnit reporter outfile", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const exitCode = await proc.exited;
 
   // The test should fail and bail
   expect(exitCode).not.toBe(0);
@@ -58,7 +58,7 @@ test("--bail writes JUnit reporter outfile with multiple files", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const exitCode = await proc.exited;
 
   // The test should fail and bail
   expect(exitCode).not.toBe(0);
@@ -71,6 +71,7 @@ test("--bail writes JUnit reporter outfile with multiple files", async () => {
   expect(xml).toContain("<?xml");
   expect(xml).toContain("<testsuites");
   expect(xml).toContain("</testsuites>");
-  // The passing test from the first file should be recorded
+  // Both the passing and failing tests should be recorded
   expect(xml).toContain("passing test");
+  expect(xml).toContain("another failing test");
 });

--- a/test/regression/issue/26851.test.ts
+++ b/test/regression/issue/26851.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+test("--bail writes JUnit reporter outfile", async () => {
+  using dir = tempDir("bail-junit", {
+    "fail.test.ts": `
+      import { test, expect } from "bun:test";
+      test("failing test", () => { expect(1).toBe(2); });
+    `,
+  });
+
+  const outfile = join(String(dir), "results.xml");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--bail", "--reporter=junit", `--reporter-outfile=${outfile}`, "fail.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The test should fail and bail
+  expect(exitCode).not.toBe(0);
+
+  // The JUnit report file should still be written despite bail
+  const file = Bun.file(outfile);
+  expect(await file.exists()).toBe(true);
+
+  const xml = await file.text();
+  expect(xml).toContain("<?xml");
+  expect(xml).toContain("<testsuites");
+  expect(xml).toContain("</testsuites>");
+  expect(xml).toContain("failing test");
+});
+
+test("--bail writes JUnit reporter outfile with multiple files", async () => {
+  using dir = tempDir("bail-junit-multi", {
+    "a_pass.test.ts": `
+      import { test, expect } from "bun:test";
+      test("passing test", () => { expect(1).toBe(1); });
+    `,
+    "b_fail.test.ts": `
+      import { test, expect } from "bun:test";
+      test("another failing test", () => { expect(1).toBe(2); });
+    `,
+  });
+
+  const outfile = join(String(dir), "results.xml");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--bail", "--reporter=junit", `--reporter-outfile=${outfile}`],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The test should fail and bail
+  expect(exitCode).not.toBe(0);
+
+  // The JUnit report file should still be written despite bail
+  const file = Bun.file(outfile);
+  expect(await file.exists()).toBe(true);
+
+  const xml = await file.text();
+  expect(xml).toContain("<?xml");
+  expect(xml).toContain("<testsuites");
+  expect(xml).toContain("</testsuites>");
+  // The passing test from the first file should be recorded
+  expect(xml).toContain("passing test");
+});


### PR DESCRIPTION
## Summary
- When `--bail` caused an early exit after a test failure, the JUnit reporter output file (`--reporter-outfile`) was never written because `Global.exit()` was called before the normal completion path
- Extracted the JUnit write logic into a `writeJUnitReportIfNeeded()` method on `CommandLineReporter` and call it in both bail exit paths (test failure and unhandled rejection) as well as the normal completion path

Closes #26851

## Test plan
- [x] Added regression test `test/regression/issue/26851.test.ts` with two cases:
  - Single failing test file with `--bail` produces JUnit XML output
  - Multiple test files where bail triggers on second file still writes the report
- [x] Verified test fails with system bun (`USE_SYSTEM_BUN=1`)
- [x] Verified test passes with `bun bd test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)