### PR TITLE
fix(shell,io): fix use-after-free in shell interpreter and pipe reader on Windows

### DIFF
--- a/test/regression/issue/26832.test.ts
+++ b/test/regression/issue/26832.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/26832
+// Segfault when libuv delivers pipe EOF callbacks after the reader is cleaned up.
+// The crash occurs when spawning many subprocesses and closing them rapidly,
+// causing a race between pipe close and pending EOF callbacks.
+test("rapid subprocess spawn and close does not crash", async () => {
+  const iterations = 50;
+  const promises: Promise<void>[] = [];
+
+  for (let i = 0; i < iterations; i++) {
+    promises.push(
+      (async () => {
+        const proc = Bun.spawn({
+          cmd: [bunExe(), "-e", "process.stdout.write('x'); process.exit(0)"],
+          stdout: "pipe",
+          stderr: "pipe",
+          env: bunEnv,
+        });
+
+        // Read and immediately discard - the key is rapid open/close cycles
+        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+        expect(exitCode).toBe(0);
+      })(),
+    );
+  }
+
+  await Promise.all(promises);
+});

--- a/test/regression/issue/26847.test.ts
+++ b/test/regression/issue/26847.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Issue #26847: Segfault in shell interpreter GC finalization
+// When setupIOBeforeRun() fails in the JS path, the interpreter was freed
+// immediately via deinitFromExec(). When GC later ran deinitFromFinalizer(),
+// it accessed already-freed memory, causing a segfault.
+//
+// The exact error path (dup() failure) is hard to trigger from JS, but this
+// test exercises the shell interpreter + GC interaction to verify there are
+// no lifetime issues when many shell interpreters are created and collected.
+test("shell interpreter GC finalization does not crash", async () => {
+  const code = `
+    // Create many shell interpreters and let them be collected by GC.
+    // This stresses the GC finalization path of ShellInterpreter objects.
+    for (let i = 0; i < 100; i++) {
+      // Create shell promises but don't await them, so they get GC'd
+      Bun.$\`echo \${i}\`.quiet();
+    }
+    // Force garbage collection to finalize the shell interpreter objects.
+    Bun.gc(true);
+    await Bun.sleep(10);
+    Bun.gc(true);
+
+    // Also test the normal path: run and await shell commands, then GC
+    for (let i = 0; i < 10; i++) {
+      await Bun.$\`echo \${i}\`.quiet();
+    }
+    Bun.gc(true);
+    Bun.gc(true);
+
+    console.log("OK");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("OK");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- **Shell interpreter error path**: When `setupIOBeforeRun()` fails in `runFromJS()`, the interpreter was freed immediately via `#deinitFromExec()` → `allocator.destroy(this)`. Since the interpreter is a GC-managed object, the GC finalizer later accessed freed memory causing a segfault in `uv__queue_insert_tail`. Fix: clean up runtime resources only via `#derefRootShellAndIOIfNeeded(true)` and `keep_alive.disable()`, letting the GC finalizer handle destruction.
- **Pipe reader EOF callbacks**: `closeImpl()` set `pipe.data`/`tty.data` to self-referencing pointers, but pending libuv `onStreamRead`/`onStreamAlloc` callbacks would cast the stale pointer to `WindowsBufferedReader`, causing a segfault. Fix: set `pipe.data`/`tty.data` to null during close and add null guards (`orelse return`) in the callbacks. The `onPipeClose`/`onTTYClose` handlers now destroy the handle directly instead of casting from the data pointer.

Closes #26856

## Test plan
- [x] `bun bd test test/regression/issue/26847.test.ts` — shell interpreter GC finalization stress test
- [x] `bun bd test test/regression/issue/26832.test.ts` — rapid subprocess spawn/close race condition test
- [ ] Windows CI passes (the primary platform where the segfault occurs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)