### PR TITLE
fix(fs): properly handle file: URL strings in fs.watch and fs.watchFile

### DIFF
--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -44,6 +44,12 @@ class FSWatcher extends EventEmitter {
   constructor(path, options, listener) {
     super();
 
+    if (path instanceof URL) {
+      path = Bun.fileURLToPath(path);
+    } else if (typeof path === "string" && path.startsWith("file:")) {
+      path = Bun.fileURLToPath(path);
+    }
+
     if (typeof options === "function") {
       listener = options;
       options = {};
@@ -646,6 +652,7 @@ const statWatchers = new Map();
 function getValidatedPath(p: any) {
   if (p instanceof URL) return Bun.fileURLToPath(p as URL);
   if (typeof p !== "string") throw $ERR_INVALID_ARG_TYPE("path", "string or URL", p);
+  if (p.startsWith("file:")) return Bun.fileURLToPath(p);
   return require("node:path").resolve(p);
 }
 function watchFile(filename, options, listener) {

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -16,6 +16,9 @@ beforeEach(() => {
   testDir = tempDirWithFiles("watch", {
     "watch.txt": "hello",
     [encodingFileName]: "hello",
+    "space dir": {
+      "space file.txt": "hello",
+    },
   });
 });
 
@@ -123,6 +126,35 @@ describe("fs.watchFile", () => {
     await Bun.sleep(100);
     fs.unwatchFile(file);
     expect(called).toBe(false);
+  });
+
+  test("should work with file: URL string containing percent-encoded spaces", async () => {
+    const { pathToFileURL } = require("bun");
+    const filepath = path.join(testDir, "space dir", "space file.txt");
+    const fileUrl = pathToFileURL(filepath).href; // e.g. file:///tmp/.../space%20dir/space%20file.txt
+    expect(fileUrl).toContain("%20");
+
+    let { promise, resolve } = Promise.withResolvers<void>();
+    let entries: any = [];
+    fs.watchFile(fileUrl, { interval: 50 }, (curr, prev) => {
+      entries.push([curr, prev]);
+      resolve();
+      resolve = () => {};
+    });
+    let increment = 0;
+    const interval = repeat(() => {
+      increment++;
+      fs.writeFileSync(filepath, "hello" + increment);
+    });
+    await promise;
+    clearInterval(interval);
+
+    fs.unwatchFile(fileUrl);
+
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries[0][0].size).toBeGreaterThan(5);
+    expect(entries[0][1].size).toBe(5);
+    expect(entries[0][0].mtimeMs).toBeGreaterThan(entries[0][1].mtimeMs);
   });
 
   test("StatWatcherScheduler stress test (1000 watchers with random times)", async () => {

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from "bun";
 import { isWindows, tempDirWithFiles } from "harness";
 import fs from "node:fs";
 import path from "path";
@@ -129,7 +130,6 @@ describe("fs.watchFile", () => {
   });
 
   test("should work with file: URL string containing percent-encoded spaces", async () => {
-    const { pathToFileURL } = require("bun");
     const filepath = path.join(testDir, "space dir", "space file.txt");
     const fileUrl = pathToFileURL(filepath).href; // e.g. file:///tmp/.../space%20dir/space%20file.txt
     expect(fileUrl).toContain("%20");


### PR DESCRIPTION
## Summary
- Convert `file:` URL strings to filesystem paths via `Bun.fileURLToPath()` in the JS layer for both `fs.watch` and `fs.watchFile`/`fs.unwatchFile`
- Handles percent-decoding (e.g. `%20` → space) and proper URL parsing, which the previous naive `slice[6..]` stripping in Zig could not do
- Zig-level `file://` stripping is left unchanged; the JS layer now resolves file URLs before they reach native code

## Test plan
- [x] New test: `fs.watch` with `file:` URL string containing `%20`-encoded spaces
- [x] New test: `fs.watchFile` with `file:` URL string containing `%20`-encoded spaces
- [x] Both tests fail with `USE_SYSTEM_BUN=1` and pass with `bun bd test`
- [x] Existing `fs.watch` "should work with url" test (URL object) still passes
- [x] Full `fs.watchFile` suite passes (6 pass, 1 skip, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)