### PR TITLE
Reduce CI test output by using dots reporter

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1314,7 +1314,7 @@ async function spawnBunTest(execPath, testPath, opts = { cwd }) {
   const isReallyTest = isTestStrict(testPath) || absPath.includes("vendor");
   const args = opts["args"] ?? [];
 
-  const testArgs = ["test", ...args, `--timeout=${perTestTimeout}`];
+  const testArgs = ["test", ...args, `--timeout=${perTestTimeout}`, "--reporter=dots"];
 
   // This will be set if a JUnit file is generated
   let junitFilePath = null;


### PR DESCRIPTION
## Summary
- Adds `--reporter=dots` to `bun test` invocations in `scripts/runner.node.mjs` to reduce CI log output volume
- The dots reporter prints a single character per test (`.` for pass, `X` for fail) instead of full test names
- When JUnit reporting is also enabled, both reporters stack correctly — dots goes to stdout, JUnit writes to file

## Test plan
- [ ] Verify CI builds run with dots reporter and produce smaller logs
- [ ] Verify JUnit reports are still generated correctly when `--junit` is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)