### PR TITLE
perf(path): use pre-built Structure for path.parse() result objects

### DIFF
--- a/bench/snippets/path-parse.mjs
+++ b/bench/snippets/path-parse.mjs
@@ -1,0 +1,18 @@
+import { posix, win32 } from "path";
+import { bench, run } from "../runner.mjs";
+
+const paths = ["/home/user/dir/file.txt", "/home/user/dir/", "file.txt", "/root", ""];
+
+paths.forEach(p => {
+  bench(`posix.parse(${JSON.stringify(p)})`, () => {
+    globalThis.abc = posix.parse(p);
+  });
+});
+
+paths.forEach(p => {
+  bench(`win32.parse(${JSON.stringify(p)})`, () => {
+    globalThis.abc = win32.parse(p);
+  });
+});
+
+await run();

--- a/src/bun.js/bindings/Path.cpp
+++ b/src/bun.js/bindings/Path.cpp
@@ -114,6 +114,25 @@ static JSC::JSObject* createPath(JSGlobalObject* globalThis, bool isWindows)
 
 } // namespace Zig
 
+extern "C" JSC::EncodedJSValue PathParsedObject__create(
+    JSC::JSGlobalObject* globalObject,
+    JSC::EncodedJSValue root,
+    JSC::EncodedJSValue dir,
+    JSC::EncodedJSValue base,
+    JSC::EncodedJSValue ext,
+    JSC::EncodedJSValue name)
+{
+    auto* global = JSC::jsCast<Zig::GlobalObject*>(globalObject);
+    auto& vm = JSC::getVM(globalObject);
+    JSC::JSObject* result = JSC::constructEmptyObject(vm, global->pathParsedObjectStructure());
+    result->putDirectOffset(vm, 0, JSC::JSValue::decode(root));
+    result->putDirectOffset(vm, 1, JSC::JSValue::decode(dir));
+    result->putDirectOffset(vm, 2, JSC::JSValue::decode(base));
+    result->putDirectOffset(vm, 3, JSC::JSValue::decode(ext));
+    result->putDirectOffset(vm, 4, JSC::JSValue::decode(name));
+    return JSC::JSValue::encode(result);
+}
+
 namespace Bun {
 
 JSC::JSValue createNodePathBinding(Zig::GlobalObject* globalObject)

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2067,6 +2067,30 @@ void GlobalObject::finishCreation(VM& vm)
             init.set(structure);
         });
 
+    this->m_pathParsedObjectStructure.initLater(
+        [](const Initializer<Structure>& init) {
+            // { root, dir, base, ext, name } — path.parse() result
+            Structure* structure = init.owner->structureCache().emptyObjectStructureForPrototype(
+                init.owner, init.owner->objectPrototype(), 5);
+            PropertyOffset offset;
+            structure = Structure::addPropertyTransition(init.vm, structure,
+                Identifier::fromString(init.vm, "root"_s), 0, offset);
+            RELEASE_ASSERT(offset == 0);
+            structure = Structure::addPropertyTransition(init.vm, structure,
+                Identifier::fromString(init.vm, "dir"_s), 0, offset);
+            RELEASE_ASSERT(offset == 1);
+            structure = Structure::addPropertyTransition(init.vm, structure,
+                Identifier::fromString(init.vm, "base"_s), 0, offset);
+            RELEASE_ASSERT(offset == 2);
+            structure = Structure::addPropertyTransition(init.vm, structure,
+                Identifier::fromString(init.vm, "ext"_s), 0, offset);
+            RELEASE_ASSERT(offset == 3);
+            structure = Structure::addPropertyTransition(init.vm, structure,
+                init.vm.propertyNames->name, 0, offset);
+            RELEASE_ASSERT(offset == 4);
+            init.set(structure);
+        });
+
     this->m_pendingVirtualModuleResultStructure.initLater(
         [](const Initializer<Structure>& init) {
             init.set(Bun::PendingVirtualModuleResult::createStructure(init.vm, init.owner, init.owner->objectPrototype()));

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -567,6 +567,7 @@ public:
     V(public, LazyClassStructure, m_JSHTTPParserClassStructure)                                              \
                                                                                                              \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_jsonlParseResultStructure)                           \
+    V(private, LazyPropertyOfGlobalObject<Structure>, m_pathParsedObjectStructure)                          \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_pendingVirtualModuleResultStructure)                 \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_performMicrotaskFunction)                           \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_nativeMicrotaskTrampoline)                          \
@@ -702,6 +703,7 @@ public:
     void reload();
 
     JSC::Structure* jsonlParseResultStructure() { return m_jsonlParseResultStructure.get(this); }
+    JSC::Structure* pathParsedObjectStructure() { return m_pathParsedObjectStructure.get(this); }
     JSC::Structure* pendingVirtualModuleResultStructure() { return m_pendingVirtualModuleResultStructure.get(this); }
 
     // We need to know if the napi module registered itself or we registered it.

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -567,7 +567,7 @@ public:
     V(public, LazyClassStructure, m_JSHTTPParserClassStructure)                                              \
                                                                                                              \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_jsonlParseResultStructure)                           \
-    V(private, LazyPropertyOfGlobalObject<Structure>, m_pathParsedObjectStructure)                          \
+    V(private, LazyPropertyOfGlobalObject<Structure>, m_pathParsedObjectStructure)                           \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_pendingVirtualModuleResultStructure)                 \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_performMicrotaskFunction)                           \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_nativeMicrotaskTrampoline)                          \

--- a/src/bun.js/node/path.zig
+++ b/src/bun.js/node/path.zig
@@ -71,13 +71,12 @@ fn PathParsed(comptime T: type) type {
         name: []const T = "",
 
         pub fn toJSObject(this: @This(), globalObject: *jsc.JSGlobalObject) bun.JSError!jsc.JSValue {
-            var jsObject = jsc.JSValue.createEmptyObject(globalObject, 5);
-            jsObject.put(globalObject, jsc.ZigString.static("root"), try bun.String.createUTF8ForJS(globalObject, this.root));
-            jsObject.put(globalObject, jsc.ZigString.static("dir"), try bun.String.createUTF8ForJS(globalObject, this.dir));
-            jsObject.put(globalObject, jsc.ZigString.static("base"), try bun.String.createUTF8ForJS(globalObject, this.base));
-            jsObject.put(globalObject, jsc.ZigString.static("ext"), try bun.String.createUTF8ForJS(globalObject, this.ext));
-            jsObject.put(globalObject, jsc.ZigString.static("name"), try bun.String.createUTF8ForJS(globalObject, this.name));
-            return jsObject;
+            const root = try bun.String.createUTF8ForJS(globalObject, this.root);
+            const dir = try bun.String.createUTF8ForJS(globalObject, this.dir);
+            const base = try bun.String.createUTF8ForJS(globalObject, this.base);
+            const ext = try bun.String.createUTF8ForJS(globalObject, this.ext);
+            const name_val = try bun.String.createUTF8ForJS(globalObject, this.name);
+            return PathParsedObject__create(globalObject, root, dir, base, ext, name_val);
         }
     };
 }
@@ -2748,6 +2747,14 @@ pub fn resolveJS_T(comptime T: type, globalObject: *jsc.JSGlobalObject, allocato
 }
 
 extern "c" fn Process__getCachedCwd(*jsc.JSGlobalObject) jsc.JSValue;
+extern "c" fn PathParsedObject__create(
+    *jsc.JSGlobalObject,
+    jsc.JSValue,
+    jsc.JSValue,
+    jsc.JSValue,
+    jsc.JSValue,
+    jsc.JSValue,
+) jsc.JSValue;
 
 pub fn resolve(globalObject: *jsc.JSGlobalObject, isWindows: bool, args_ptr: [*]jsc.JSValue, args_len: u16) bun.JSError!jsc.JSValue {
     var arena = bun.ArenaAllocator.init(bun.default_allocator);


### PR DESCRIPTION
## Summary

Optimize `path.parse()` by caching a pre-built JSC Structure for the result object. Instead of creating a new empty object and performing 5 `putDirect` calls (each triggering a Structure transition), we now use `constructEmptyObject` with the cached Structure and write values directly via `putDirectOffset`.

## What changed

- **`ZigGlobalObject.h/cpp`**: Added `m_pathParsedObjectStructure` as a `LazyPropertyOfGlobalObject<Structure>` with fixed property offsets for `{root, dir, base, ext, name}`.
- **`Path.cpp`**: Added `PathParsedObject__create` extern "C" factory function that constructs the object using the pre-built Structure and `putDirectOffset`.
- **`path.zig`**: Replaced `toJSObject()` implementation to call the C++ factory function instead of `createEmptyObject` + 5x `.put()`.
- **`bench/snippets/path-parse.mjs`**: Added benchmark for `path.parse()`.

This follows the same pattern used by `JSSocketAddressDTO` and `m_jsonlParseResultStructure`.

## Benchmark results (Apple M4 Max)

| Benchmark | Before (1.3.9) | After | Speedup |
|---|---|---|---|
| `posix.parse("/home/user/dir/file.txt")` | 266.71 ns | 119.62 ns | **2.23x** |
| `posix.parse("/home/user/dir/")` | 239.10 ns | 91.46 ns | **2.61x** |
| `posix.parse("file.txt")` | 232.55 ns | 89.20 ns | **2.61x** |
| `posix.parse("/root")` | 246.75 ns | 92.68 ns | **2.66x** |
| `posix.parse("")` | 152.19 ns | 20.72 ns | **7.34x** |
| `win32.parse("/home/user/dir/file.txt")` | 260.08 ns | 118.12 ns | **2.20x** |
| `win32.parse("/home/user/dir/")` | 234.35 ns | 93.47 ns | **2.51x** |
| `win32.parse("file.txt")` | 224.19 ns | 80.56 ns | **2.78x** |
| `win32.parse("/root")` | 241.20 ns | 88.23 ns | **2.73x** |
| `win32.parse("")` | 160.39 ns | 24.20 ns | **6.63x** |

**~2.2x–2.8x faster** for typical paths, **~7x faster** for empty strings.

## GC Safety

- `LazyPropertyOfGlobalObject<Structure>` is automatically visited via `FOR_EACH_GLOBALOBJECT_GC_MEMBER`.
- JSValues created by `createUTF8ForJS` are protected by JSC's conservative stack scanning during the factory function call.

## Test

All 116 existing path tests pass (`bun bd test test/js/node/path/`).