### PR TITLE
feat(test): add --retry flag and emit separate testcase entries for retries in JUnit XML

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -20,12 +20,7 @@
           "completionType": "javascript_files"
         }
       ],
-      "examples": [
-        "bun run ./index.js",
-        "bun run ./index.tsx",
-        "bun run dev",
-        "bun run lint"
-      ],
+      "examples": ["bun run ./index.js", "bun run ./index.tsx", "bun run dev", "bun run lint"],
       "usage": "Usage: bun run [flags] <file or script>",
       "documentationUrl": "https://bun.com/docs/cli/run",
       "dynamicCompletions": {
@@ -58,6 +53,14 @@
         {
           "name": "rerun-each",
           "description": "Re-run each test file <NUMBER> times, helps catch certain bugs",
+          "hasValue": true,
+          "valueType": "val",
+          "required": false,
+          "multiple": false
+        },
+        {
+          "name": "retry",
+          "description": "Default retry count for all tests, overridden by per-test { retry: N }",
           "hasValue": true,
           "valueType": "val",
           "required": false,
@@ -152,11 +155,7 @@
           "completionType": "test_files"
         }
       ],
-      "examples": [
-        "bun test",
-        "bun test foo bar",
-        "bun test --test-name-pattern baz"
-      ],
+      "examples": ["bun test", "bun test foo bar", "bun test --test-name-pattern baz"],
       "usage": "Usage: bun test [flags] [<patterns>]",
       "documentationUrl": "https://bun.com/docs/cli/test",
       "dynamicCompletions": {
@@ -199,9 +198,7 @@
       "examples": [],
       "usage": "Usage: bunx [flags] <package><@version> [flags and arguments for the package]",
       "dynamicCompletions": {},
-      "aliases": [
-        "bunx"
-      ]
+      "aliases": ["bunx"]
     },
     "repl": {
       "name": "repl",
@@ -232,10 +229,7 @@
           "completionType": "script"
         }
       ],
-      "examples": [
-        "bun exec \"echo hi\"",
-        "bun exec \"echo \\\"hey friends\\\"!\""
-      ],
+      "examples": ["bun exec \"echo hi\"", "bun exec \"echo \\\"hey friends\\\"!\""],
       "usage": "Usage: bun exec <script>",
       "dynamicCompletions": {}
     },
@@ -545,14 +539,9 @@
           "type": "string"
         }
       ],
-      "examples": [
-        "bun install",
-        "bun install --production"
-      ],
+      "examples": ["bun install", "bun install --production"],
       "usage": "Usage: bun install [flags] <name>@<version>",
-      "aliases": [
-        "i"
-      ],
+      "aliases": ["i"],
       "documentationUrl": "https://bun.com/docs/cli/install.",
       "dynamicCompletions": {}
     },
@@ -864,9 +853,7 @@
         "bun add --peer esbuild"
       ],
       "usage": "Usage: bun add [flags] <package><@version>",
-      "aliases": [
-        "a"
-      ],
+      "aliases": ["a"],
       "documentationUrl": "https://bun.com/docs/cli/add.",
       "dynamicCompletions": {
         "packages": true
@@ -1126,13 +1113,9 @@
           "completionType": "installed_package"
         }
       ],
-      "examples": [
-        "bun remove ts-node"
-      ],
+      "examples": ["bun remove ts-node"],
       "usage": "Usage: bun remove [flags] [<packages>]",
-      "aliases": [
-        "rm"
-      ],
+      "aliases": ["rm"],
       "documentationUrl": "https://bun.com/docs/cli/remove.",
       "dynamicCompletions": {
         "packages": true
@@ -1422,12 +1405,7 @@
           "type": "string"
         }
       ],
-      "examples": [
-        "bun update",
-        "bun update --latest",
-        "bun update -i",
-        "bun update zod jquery@3"
-      ],
+      "examples": ["bun update", "bun update --latest", "bun update -i", "bun update zod jquery@3"],
       "usage": "Usage: bun update [flags] <name>@<version>",
       "documentationUrl": "https://bun.com/docs/cli/update.",
       "dynamicCompletions": {}
@@ -1452,10 +1430,7 @@
           "type": "string"
         }
       ],
-      "examples": [
-        "bun audit",
-        "bun audit --json"
-      ],
+      "examples": ["bun audit", "bun audit --json"],
       "usage": "Usage: bun audit [flags]",
       "documentationUrl": "https://bun.com/docs/install/audit.",
       "dynamicCompletions": {}
@@ -1997,10 +1972,7 @@
           "completionType": "package"
         }
       ],
-      "examples": [
-        "bun link",
-        "bun link <package>"
-      ],
+      "examples": ["bun link", "bun link <package>"],
       "usage": "Usage: bun link [flags] [<packages>]",
       "documentationUrl": "https://bun.com/docs/cli/link.",
       "dynamicCompletions": {}
@@ -2252,9 +2224,7 @@
           "type": "string"
         }
       ],
-      "examples": [
-        "bun unlink"
-      ],
+      "examples": ["bun unlink"],
       "usage": "Usage: bun unlink [flags]",
       "documentationUrl": "https://bun.com/docs/cli/unlink.",
       "dynamicCompletions": {}
@@ -3248,11 +3218,7 @@
           "completionType": "package"
         }
       ],
-      "examples": [
-        "bun info react",
-        "bun info react@18.0.0",
-        "bun info react version --json"
-      ],
+      "examples": ["bun info react", "bun info react@18.0.0", "bun info react version --json"],
       "usage": "Usage: bun info [flags] <package>[@<version>]",
       "documentationUrl": "https://bun.com/docs/cli/info.",
       "dynamicCompletions": {}
@@ -3603,12 +3569,7 @@
           "type": "string"
         }
       ],
-      "examples": [
-        "bun init",
-        "bun init --yes",
-        "bun init --react",
-        "bun init --react=tailwind my-app"
-      ],
+      "examples": ["bun init", "bun init --yes", "bun init --react", "bun init --react=tailwind my-app"],
       "usage": "Usage: bun init [flags] [<folder>]",
       "dynamicCompletions": {}
     },
@@ -3621,9 +3582,7 @@
       "usage": "Usage:",
       "documentationUrl": "https://bun.com/docs/cli/bun-create",
       "dynamicCompletions": {},
-      "aliases": [
-        "c"
-      ]
+      "aliases": ["c"]
     },
     "upgrade": {
       "name": "upgrade",
@@ -3637,10 +3596,7 @@
           "type": "string"
         }
       ],
-      "examples": [
-        "bun upgrade",
-        "bun upgrade --stable"
-      ],
+      "examples": ["bun upgrade", "bun upgrade --stable"],
       "usage": "Usage: bun upgrade [flags]",
       "documentationUrl": "https://bun.com/docs/installation#upgrading",
       "dynamicCompletions": {}
@@ -3743,9 +3699,7 @@
       "description": "Configure auto-install behavior. One of \"auto\" (default, auto-installs when no node_modules), \"fallback\" (missing packages only), \"force\" (always).",
       "hasValue": true,
       "valueType": "val",
-      "choices": [
-        "auto"
-      ],
+      "choices": ["auto"],
       "required": false,
       "multiple": false
     },
@@ -3827,12 +3781,7 @@
       "description": "Set the default order of DNS lookup results. Valid orders: verbatim (default), ipv4first, ipv6first",
       "hasValue": true,
       "valueType": "val",
-      "choices": [
-        "verbatim",
-        "(default)",
-        "ipv4first",
-        "ipv6first"
-      ],
+      "choices": ["verbatim", "(default)", "ipv4first", "ipv6first"],
       "required": false,
       "multiple": false
     },
@@ -3898,9 +3847,7 @@
       "description": "One of \"strict\", \"throw\", \"warn\", \"none\", or \"warn-with-error-code\"",
       "hasValue": true,
       "valueType": "val",
-      "choices": [
-        "strict"
-      ],
+      "choices": ["strict"],
       "required": false,
       "multiple": false
     },

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -665,6 +665,7 @@ _bun_test_completion() {
         '--timeout[Set the per-test timeout in milliseconds, default is 5000.]:timeout' \
         '--update-snapshots[Update snapshot files]' \
         '--rerun-each[Re-run each test file <NUMBER> times, helps catch certain bugs]:rerun' \
+        '--retry[Default retry count for all tests]:retry' \
         '--todo[Include tests that are marked with "test.todo()"]' \
         '--coverage[Generate a coverage profile]' \
         '--bail[Exit the test suite after <NUMBER> failures. If you do not specify a number, it defaults to 1.]:bail' \

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -298,6 +298,17 @@ This is useful for catching flaky tests or non-deterministic behavior. Each test
 
 The `--rerun-each` CLI flag will override this setting when specified.
 
+### `test.retry`
+
+Default retry count for all tests. Failed tests will be retried up to this many times. Per-test `{ retry: N }` overrides this value. Default `0` (no retries).
+
+```toml title="bunfig.toml" icon="settings"
+[test]
+retry = 3
+```
+
+The `--retry` CLI flag will override this setting when specified.
+
 ### `test.concurrentTestGlob`
 
 Specify a glob pattern to automatically run matching test files with concurrent test execution enabled. Test files matching this pattern will behave as if the `--concurrent` flag was passed, running all tests within those files concurrently.

--- a/docs/snippets/cli/test.mdx
+++ b/docs/snippets/cli/test.mdx
@@ -15,7 +15,8 @@ bun test <patterns>
 </ParamField>
 
 <ParamField path="--retry" type="number">
-  Default retry count for all tests. Failed tests will be retried up to <code>NUMBER</code> times. Overridden by per-test <code>{`{ retry: N }`}</code>
+  Default retry count for all tests. Failed tests will be retried up to <code>NUMBER</code> times. Overridden by
+  per-test <code>{`{ retry: N }`}</code>
 </ParamField>
 
 <ParamField path="--concurrent" type="boolean">

--- a/docs/snippets/cli/test.mdx
+++ b/docs/snippets/cli/test.mdx
@@ -14,6 +14,10 @@ bun test <patterns>
   Re-run each test file <code>NUMBER</code> times, helps catch certain bugs
 </ParamField>
 
+<ParamField path="--retry" type="number">
+  Default retry count for all tests. Failed tests will be retried up to <code>NUMBER</code> times. Overridden by per-test <code>{`{ retry: N }`}</code>
+</ParamField>
+
 <ParamField path="--concurrent" type="boolean">
   Treat all tests as <code>test.concurrent()</code> tests
 </ParamField>

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -222,6 +222,17 @@ randomize = true
 seed = 2444615283
 ```
 
+#### retry
+
+Default retry count for all tests. Failed tests will be retried up to this many times. Per-test `{ retry: N }` overrides this value. Default `0` (no retries).
+
+```toml title="bunfig.toml" icon="settings"
+[test]
+retry = 3
+```
+
+The `--retry` CLI flag will override this setting when specified.
+
 #### rerunEach
 
 Re-run each test file multiple times to identify flaky tests:

--- a/docs/test/index.mdx
+++ b/docs/test/index.mdx
@@ -201,6 +201,31 @@ test.failing.each([1, 2, 3])("chained qualifiers %d", input => {
 });
 ```
 
+## Retry failed tests
+
+Use the `--retry` flag to automatically retry failed tests up to a given number of times. If a test fails and then passes on a subsequent attempt, it is reported as passing.
+
+```sh terminal icon="terminal"
+bun test --retry 3
+```
+
+Per-test `{ retry: N }` overrides the global `--retry` value:
+
+```ts
+// Uses the global --retry value
+test("uses global retry", () => { /* ... */ });
+
+// Overrides --retry with its own value
+test("custom retry", { retry: 1 }, () => { /* ... */ });
+```
+
+You can also set this in `bunfig.toml`:
+
+```toml title="bunfig.toml" icon="settings"
+[test]
+retry = 3
+```
+
 ## Rerun tests
 
 Use the `--rerun-each` flag to run each test multiple times. This is useful for detecting flaky or non-deterministic test failures.

--- a/docs/test/index.mdx
+++ b/docs/test/index.mdx
@@ -213,10 +213,14 @@ Per-test `{ retry: N }` overrides the global `--retry` value:
 
 ```ts
 // Uses the global --retry value
-test("uses global retry", () => { /* ... */ });
+test("uses global retry", () => {
+  /* ... */
+});
 
 // Overrides --retry with its own value
-test("custom retry", { retry: 1 }, () => { /* ... */ });
+test("custom retry", { retry: 1 }, () => {
+  /* ... */
+});
 ```
 
 You can also set this in `bunfig.toml`:

--- a/src/bun.js/test/Execution.zig
+++ b/src/bun.js/test/Execution.zig
@@ -78,6 +78,8 @@ pub const ExecutionSequence = struct {
     test_entry: ?*ExecutionEntry,
     remaining_repeat_count: u32,
     remaining_retry_count: u32,
+    flaky_attempt_count: u32 = 0,
+    flaky_attempts_buf: [MAX_FLAKY_ATTEMPTS]FlakyAttempt = undefined,
     result: Result = .pending,
     executing: bool = false,
     started_at: bun.timespec = .epoch,
@@ -104,6 +106,38 @@ pub const ExecutionSequence = struct {
             .remaining_repeat_count = cfg.repeat_count,
             .remaining_retry_count = cfg.retry_count,
         };
+    }
+
+    pub const MAX_FLAKY_ATTEMPTS: usize = 16;
+
+    pub const FlakyAttempt = struct {
+        result: Result,
+        elapsed_ns: u64,
+
+        pub fn failureType(this: FlakyAttempt) []const u8 {
+            return switch (this.result) {
+                .fail_because_timeout, .fail_because_timeout_with_done_callback,
+                .fail_because_hook_timeout, .fail_because_hook_timeout_with_done_callback,
+                => "TimeoutError",
+                else => "AssertionError",
+            };
+        }
+
+        pub fn failureMessage(this: FlakyAttempt) ?[]const u8 {
+            return switch (this.result) {
+                .fail_because_timeout, .fail_because_timeout_with_done_callback => "test timed out",
+                .fail_because_hook_timeout, .fail_because_hook_timeout_with_done_callback => "hook timed out",
+                .fail_because_failing_test_passed => "test marked with .failing() did not throw",
+                .fail_because_todo_passed => "TODO passed",
+                .fail_because_expected_has_assertions => "expected to have assertions, but none were run",
+                .fail_because_expected_assertion_count => "expected more assertions",
+                else => null,
+            };
+        }
+    };
+
+    pub fn flakyAttempts(this: *const ExecutionSequence) []const FlakyAttempt {
+        return this.flaky_attempts_buf[0..this.flaky_attempt_count];
     }
 
     fn entryMode(this: ExecutionSequence) bun_test.ScopeMode {
@@ -480,6 +514,14 @@ fn advanceSequence(this: *Execution, sequence: *ExecutionSequence, group: *Concu
 
         // Handle retry logic: if test failed and we have retries remaining, retry it
         if (test_failed and sequence.remaining_retry_count > 0) {
+            if (sequence.flaky_attempt_count < ExecutionSequence.MAX_FLAKY_ATTEMPTS) {
+                const elapsed_ns = if (sequence.started_at.eql(&.epoch)) 0 else sequence.started_at.sinceNow(.force_real_time);
+                sequence.flaky_attempts_buf[sequence.flaky_attempt_count] = .{
+                    .result = sequence.result,
+                    .elapsed_ns = elapsed_ns,
+                };
+                sequence.flaky_attempt_count += 1;
+            }
             sequence.remaining_retry_count -= 1;
             this.resetSequence(sequence);
             return;
@@ -604,13 +646,17 @@ pub fn resetSequence(this: *Execution, sequence: *ExecutionSequence) void {
         }
     }
 
-    // Preserve the current remaining_repeat_count and remaining_retry_count
+    // Preserve retry/repeat counts and flaky attempt history across reset
+    const saved_flaky_attempt_count = sequence.flaky_attempt_count;
+    const saved_flaky_attempts_buf = sequence.flaky_attempts_buf;
     sequence.* = .init(.{
         .first_entry = sequence.first_entry,
         .test_entry = sequence.test_entry,
         .retry_count = sequence.remaining_retry_count,
         .repeat_count = sequence.remaining_repeat_count,
     });
+    sequence.flaky_attempt_count = saved_flaky_attempt_count;
+    sequence.flaky_attempts_buf = saved_flaky_attempts_buf;
     _ = this;
 }
 

--- a/src/bun.js/test/Execution.zig
+++ b/src/bun.js/test/Execution.zig
@@ -79,7 +79,7 @@ pub const ExecutionSequence = struct {
     remaining_repeat_count: u32,
     remaining_retry_count: u32,
     flaky_attempt_count: usize = 0,
-    flaky_attempts_buf: [MAX_FLAKY_ATTEMPTS]FlakyAttempt = undefined,
+    flaky_attempts_buf: [MAX_FLAKY_ATTEMPTS]FlakyAttempt = std.mem.zeroes([MAX_FLAKY_ATTEMPTS]FlakyAttempt),
     result: Result = .pending,
     executing: bool = false,
     started_at: bun.timespec = .epoch,

--- a/src/bun.js/test/Execution.zig
+++ b/src/bun.js/test/Execution.zig
@@ -113,29 +113,6 @@ pub const ExecutionSequence = struct {
     pub const FlakyAttempt = struct {
         result: Result,
         elapsed_ns: u64,
-
-        pub fn failureType(this: FlakyAttempt) []const u8 {
-            return switch (this.result) {
-                .fail_because_timeout,
-                .fail_because_timeout_with_done_callback,
-                .fail_because_hook_timeout,
-                .fail_because_hook_timeout_with_done_callback,
-                => "TimeoutError",
-                else => "AssertionError",
-            };
-        }
-
-        pub fn failureMessage(this: FlakyAttempt) ?[]const u8 {
-            return switch (this.result) {
-                .fail_because_timeout, .fail_because_timeout_with_done_callback => "test timed out",
-                .fail_because_hook_timeout, .fail_because_hook_timeout_with_done_callback => "hook timed out",
-                .fail_because_failing_test_passed => "test marked with .failing() did not throw",
-                .fail_because_todo_passed => "TODO passed",
-                .fail_because_expected_has_assertions => "expected to have assertions, but none were run",
-                .fail_because_expected_assertion_count => "expected more assertions",
-                else => null,
-            };
-        }
     };
 
     pub fn flakyAttempts(this: *const ExecutionSequence) []const FlakyAttempt {

--- a/src/bun.js/test/Execution.zig
+++ b/src/bun.js/test/Execution.zig
@@ -78,7 +78,7 @@ pub const ExecutionSequence = struct {
     test_entry: ?*ExecutionEntry,
     remaining_repeat_count: u32,
     remaining_retry_count: u32,
-    flaky_attempt_count: u32 = 0,
+    flaky_attempt_count: usize = 0,
     flaky_attempts_buf: [MAX_FLAKY_ATTEMPTS]FlakyAttempt = undefined,
     result: Result = .pending,
     executing: bool = false,
@@ -116,8 +116,10 @@ pub const ExecutionSequence = struct {
 
         pub fn failureType(this: FlakyAttempt) []const u8 {
             return switch (this.result) {
-                .fail_because_timeout, .fail_because_timeout_with_done_callback,
-                .fail_because_hook_timeout, .fail_because_hook_timeout_with_done_callback,
+                .fail_because_timeout,
+                .fail_because_timeout_with_done_callback,
+                .fail_because_hook_timeout,
+                .fail_because_hook_timeout_with_done_callback,
                 => "TimeoutError",
                 else => "AssertionError",
             };

--- a/src/bun.js/test/ScopeFunctions.zig
+++ b/src/bun.js/test/ScopeFunctions.zig
@@ -409,6 +409,9 @@ pub fn parseArguments(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame
             result.options.retry = runner.test_options.retry;
         }
     }
+    if ((result.options.retry orelse 0) != 0 and result.options.repeats != 0) {
+        return globalThis.throwPretty("{f}(): Cannot set both retry and repeats", .{signature});
+    }
 
     const default_timeout_ms: ?u32 = if (bun.jsc.Jest.Jest.runner) |runner| if (runner.default_timeout_ms != 0) runner.default_timeout_ms else null else null;
     const override_timeout_ms: ?u32 = if (bun.jsc.Jest.Jest.runner) |runner| if (runner.default_timeout_override != std.math.maxInt(u32)) runner.default_timeout_override else null else null;

--- a/src/bun.js/test/ScopeFunctions.zig
+++ b/src/bun.js/test/ScopeFunctions.zig
@@ -404,6 +404,12 @@ pub fn parseArguments(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame
 
     result.description = if (description.isUndefinedOrNull()) null else try getDescription(gpa, globalThis, description, signature);
 
+    if (result.options.retry == 0) {
+        if (bun.jsc.Jest.Jest.runner) |runner| {
+            result.options.retry = runner.test_options.retry;
+        }
+    }
+
     const default_timeout_ms: ?u32 = if (bun.jsc.Jest.Jest.runner) |runner| if (runner.default_timeout_ms != 0) runner.default_timeout_ms else null else null;
     const override_timeout_ms: ?u32 = if (bun.jsc.Jest.Jest.runner) |runner| if (runner.default_timeout_override != std.math.maxInt(u32)) runner.default_timeout_override else null else null;
     const timeout_option_ms: ?u32 = if (timeout_option) |timeout| std.math.lossyCast(u32, timeout) else null;

--- a/src/bun.js/test/ScopeFunctions.zig
+++ b/src/bun.js/test/ScopeFunctions.zig
@@ -249,7 +249,7 @@ fn enqueueDescribeOrTestCallback(this: *ScopeFunctions, bunTest: *bun_test.BunTe
             _ = try bunTest.collection.active_scope.appendTest(bunTest.gpa, description, if (matches_filter) callback else null, .{
                 .has_done_parameter = has_done_parameter,
                 .timeout = options.timeout,
-                .retry_count = options.retry,
+                .retry_count = options.retry orelse 0,
                 .repeat_count = options.repeats,
             }, base, .collection);
         },
@@ -295,7 +295,7 @@ const ParseArgumentsResult = struct {
 };
 const ParseArgumentsOptions = struct {
     timeout: u32 = 0,
-    retry: u32 = 0,
+    retry: ?u32 = null,
     repeats: u32 = 0,
 };
 pub const CallbackMode = enum { require, allow };
@@ -391,7 +391,7 @@ pub fn parseArguments(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame
             if (!repeats.isNumber()) {
                 return globalThis.throwPretty("{f}() expects repeats to be a number", .{signature});
             }
-            if (result.options.retry != 0) {
+            if (result.options.retry != null and result.options.retry.? != 0) {
                 return globalThis.throwPretty("{f}(): Cannot set both retry and repeats", .{signature});
             }
             result.options.repeats = std.math.lossyCast(u32, repeats.asNumber());
@@ -404,7 +404,7 @@ pub fn parseArguments(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame
 
     result.description = if (description.isUndefinedOrNull()) null else try getDescription(gpa, globalThis, description, signature);
 
-    if (result.options.retry == 0) {
+    if (result.options.retry == null) {
         if (bun.jsc.Jest.Jest.runner) |runner| {
             result.options.retry = runner.test_options.retry;
         }

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -402,6 +402,11 @@ pub const Bunfig = struct {
                         this.ctx.test_options.repeat_count = expr.data.e_number.toU32();
                     }
 
+                    if (test_.get("retry")) |expr| {
+                        try this.expect(expr, .e_number);
+                        this.ctx.test_options.retry = expr.data.e_number.toU32();
+                    }
+
                     if (test_.get("concurrentTestGlob")) |expr| {
                         switch (expr.data) {
                             .e_string => |str| {

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -399,6 +399,10 @@ pub const Bunfig = struct {
 
                     if (test_.get("rerunEach")) |expr| {
                         try this.expect(expr, .e_number);
+                        if (this.ctx.test_options.retry != 0) {
+                            try this.addError(expr.loc, "\"rerunEach\" cannot be used with \"retry\"");
+                            return;
+                        }
                         this.ctx.test_options.repeat_count = expr.data.e_number.toU32();
                     }
 

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -404,6 +404,10 @@ pub const Bunfig = struct {
 
                     if (test_.get("retry")) |expr| {
                         try this.expect(expr, .e_number);
+                        if (this.ctx.test_options.repeat_count != 0) {
+                            try this.addError(expr.loc, "\"retry\" cannot be used with \"rerunEach\"");
+                            return;
+                        }
                         this.ctx.test_options.retry = expr.data.e_number.toU32();
                     }
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -341,6 +341,7 @@ pub const Command = struct {
         default_timeout_ms: u32 = 5 * std.time.ms_per_s,
         update_snapshots: bool = false,
         repeat_count: u32 = 0,
+        retry: u32 = 0,
         run_todo: bool = false,
         only: bool = false,
         pass_with_no_tests: bool = false,

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -576,6 +576,10 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                 };
             }
         }
+        if (ctx.test_options.retry != 0 and ctx.test_options.repeat_count != 0) {
+            Output.prettyErrorln("<r><red>error<r>: --retry cannot be used with --rerun-each", .{});
+            Global.exit(1);
+        }
         if (args.option("--test-name-pattern")) |namePattern| {
             ctx.test_options.test_filter_pattern = namePattern;
             const regex = RegularExpression.init(bun.String.fromBytes(namePattern), RegularExpression.Flags.none) catch {

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -220,6 +220,7 @@ pub const test_only_params = [_]ParamType{
     clap.parseParam("--timeout <NUMBER>               Set the per-test timeout in milliseconds, default is 5000.") catch unreachable,
     clap.parseParam("-u, --update-snapshots           Update snapshot files") catch unreachable,
     clap.parseParam("--rerun-each <NUMBER>            Re-run each test file <NUMBER> times, helps catch certain bugs") catch unreachable,
+    clap.parseParam("--retry <NUMBER>                 Default retry count for all tests, overridden by per-test { retry: N }") catch unreachable,
     clap.parseParam("--todo                           Include tests that are marked with \"test.todo()\"") catch unreachable,
     clap.parseParam("--only                           Run only tests that are marked with \"test.only()\" or \"describe.only()\"") catch unreachable,
     clap.parseParam("--pass-with-no-tests             Exit with code 0 when no tests are found") catch unreachable,
@@ -563,6 +564,14 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
             if (repeat_count.len > 0) {
                 ctx.test_options.repeat_count = std.fmt.parseInt(u32, repeat_count, 10) catch |e| {
                     Output.prettyErrorln("<r><red>error<r>: --rerun-each expects a number: {s}", .{@errorName(e)});
+                    Global.exit(1);
+                };
+            }
+        }
+        if (args.option("--retry")) |retry_count| {
+            if (retry_count.len > 0) {
+                ctx.test_options.retry = std.fmt.parseInt(u32, retry_count, 10) catch |e| {
+                    Output.prettyErrorln("<r><red>error<r>: --retry expects a number: {s}", .{@errorName(e)});
                     Global.exit(1);
                 };
             }

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -378,6 +378,7 @@ pub const JunitReporter = struct {
         assertions: u32,
         elapsed_ns: u64,
         line_number: u32,
+        flaky_attempts: []const bun.jsc.Jest.bun_test.Execution.ExecutionSequence.FlakyAttempt,
     ) !void {
         const elapsed_ns_f64: f64 = @floatFromInt(elapsed_ns);
         const elapsed_ms = elapsed_ns_f64 / std.time.ns_per_ms;
@@ -413,7 +414,29 @@ pub const JunitReporter = struct {
 
         switch (status) {
             .pass => {
-                try this.contents.appendSlice(bun.default_allocator, " />\n");
+                if (flaky_attempts.len > 0) {
+                    try this.contents.appendSlice(bun.default_allocator, ">\n");
+                    for (flaky_attempts) |attempt| {
+                        const attempt_ns_f64: f64 = @floatFromInt(attempt.elapsed_ns);
+                        const attempt_seconds = attempt_ns_f64 / std.time.ns_per_s;
+                        try this.contents.appendSlice(bun.default_allocator, indent);
+                        if (attempt.failureMessage()) |message| {
+                            try this.contents.writer(bun.default_allocator).print(
+                                "  <flakyFailure message=\"{s}\" type=\"{s}\" time=\"{f}\" />\n",
+                                .{ message, attempt.failureType(), bun.fmt.trimmedPrecision(attempt_seconds, 6) },
+                            );
+                        } else {
+                            try this.contents.writer(bun.default_allocator).print(
+                                "  <flakyFailure type=\"{s}\" time=\"{f}\" />\n",
+                                .{ attempt.failureType(), bun.fmt.trimmedPrecision(attempt_seconds, 6) },
+                            );
+                        }
+                    }
+                    try this.contents.appendSlice(bun.default_allocator, indent);
+                    try this.contents.appendSlice(bun.default_allocator, "</testcase>\n");
+                } else {
+                    try this.contents.appendSlice(bun.default_allocator, " />\n");
+                }
             },
             .fail => {
                 if (this.suite_stack.items.len > 0) {
@@ -854,7 +877,7 @@ pub const CommandLineReporter = struct {
                         }
                     }
 
-                    bun.handleOom(junit.writeTestCase(status, filename, display_label, concatenated_describe_scopes.items, assertions, elapsed_ns, line_number));
+                    bun.handleOom(junit.writeTestCase(status, filename, display_label, concatenated_describe_scopes.items, assertions, elapsed_ns, line_number, sequence.flakyAttempts()));
                 }
             }
         }

--- a/test/cli/test/retry-flag.test.ts
+++ b/test/cli/test/retry-flag.test.ts
@@ -64,6 +64,225 @@ test("per-test { retry } overrides --retry", async () => {
   expect(exitCode).not.toBe(0);
 });
 
+test("--retry works with describe blocks and beforeEach/afterEach hooks", async () => {
+  using dir = tempDir("retry-hooks", {
+    "hooks.test.ts": `
+      import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+      let hookLog: string[] = [];
+      let attempt = 0;
+
+      describe("suite with hooks", () => {
+        beforeEach(() => {
+          hookLog.push("before");
+        });
+
+        afterEach(() => {
+          hookLog.push("after");
+        });
+
+        test("flaky with hooks", () => {
+          attempt++;
+          hookLog.push("test:" + attempt);
+          if (attempt < 3) throw new Error("fail attempt " + attempt);
+          // On passing attempt, verify hooks ran each time
+          expect(hookLog).toEqual([
+            "before", "test:1", "after",
+            "before", "test:2", "after",
+            "before", "test:3",
+          ]);
+        });
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--retry", "3", "hooks.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("flaky with hooks");
+  expect(exitCode).toBe(0);
+});
+
+test("--retry with multiple tests where only some need retries", async () => {
+  using dir = tempDir("retry-multi", {
+    "multi.test.ts": `
+      import { test, expect } from "bun:test";
+      let flakyCount = 0;
+
+      test("always passes", () => {
+        expect(1 + 1).toBe(2);
+      });
+
+      test("flaky test", () => {
+        flakyCount++;
+        if (flakyCount < 2) throw new Error("fail");
+        expect(true).toBe(true);
+      });
+
+      test("always fails", () => {
+        throw new Error("permanent failure");
+      });
+
+      test("another passing test", () => {
+        expect("hello").toBe("hello");
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--retry", "3", "multi.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // "always fails" should still fail after all retries
+  expect(exitCode).not.toBe(0);
+  // Both passing tests and the flaky test should show as passing
+  expect(stderr).toContain("always passes");
+  expect(stderr).toContain("flaky test");
+  expect(stderr).toContain("always fails");
+  expect(stderr).toContain("another passing test");
+});
+
+test("--retry with async tests", async () => {
+  using dir = tempDir("retry-async", {
+    "async.test.ts": `
+      import { test, expect } from "bun:test";
+      let count = 0;
+
+      test("async flaky test", async () => {
+        count++;
+        await Bun.sleep(1);
+        if (count < 3) throw new Error("async fail attempt " + count);
+        expect(true).toBe(true);
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--retry", "3", "async.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("async flaky test");
+  expect(stderr).toContain("attempt 3");
+  expect(exitCode).toBe(0);
+});
+
+test("--retry with nested describe blocks", async () => {
+  using dir = tempDir("retry-nested", {
+    "nested.test.ts": `
+      import { test, expect, describe, beforeEach } from "bun:test";
+      let outerSetup = 0;
+      let innerSetup = 0;
+      let attempt = 0;
+
+      describe("outer", () => {
+        beforeEach(() => { outerSetup++; });
+
+        describe("inner", () => {
+          beforeEach(() => { innerSetup++; });
+
+          test("deeply nested flaky", () => {
+            attempt++;
+            if (attempt < 2) throw new Error("fail");
+            // Both outer and inner beforeEach should have run for each attempt
+            expect(outerSetup).toBe(2);
+            expect(innerSetup).toBe(2);
+          });
+        });
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--retry", "3", "nested.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("deeply nested flaky");
+  expect(exitCode).toBe(0);
+});
+
+test("--retry past MAX_FLAKY_ATTEMPTS (16) still retries correctly", async () => {
+  using dir = tempDir("retry-max", {
+    "max.test.ts": `
+      import { test, expect } from "bun:test";
+      let count = 0;
+
+      // Fails 19 times, passes on attempt 20 -- well past the 16-entry buffer
+      test("fails many times", { retry: 20 }, () => {
+        count++;
+        if (count < 20) throw new Error("fail attempt " + count);
+        expect(true).toBe(true);
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "max.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("fails many times");
+  expect(exitCode).toBe(0);
+});
+
+test("--retry with test.skip and test.todo does not retry them", async () => {
+  using dir = tempDir("retry-skip-todo", {
+    "skip-todo.test.ts": `
+      import { test, expect } from "bun:test";
+
+      test.skip("skipped test", () => {
+        throw new Error("should not run");
+      });
+
+      test.todo("todo test");
+
+      let count = 0;
+      test("normal flaky", () => {
+        count++;
+        if (count < 2) throw new Error("fail");
+        expect(true).toBe(true);
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--retry", "3", "skip-todo.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("normal flaky");
+  expect(stderr).toContain("skipped test");
+  expect(stderr).toContain("todo test");
+  expect(exitCode).toBe(0);
+});
+
 test("bunfig.toml retry works equivalently", async () => {
   using dir = tempDir("retry-bunfig", {
     "bunfig.toml": `

--- a/test/cli/test/retry-flag.test.ts
+++ b/test/cli/test/retry-flag.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("--retry retries failed tests", async () => {
+  using dir = tempDir("retry-flag", {
+    "flaky.test.ts": `
+      import { test, expect } from "bun:test";
+      let count = 0;
+      test("flaky test", () => {
+        count++;
+        if (count < 3) throw new Error("fail attempt " + count);
+        expect(true).toBe(true);
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--retry", "3", "flaky.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("flaky test");
+  expect(stderr).toContain("attempt 3");
+  expect(exitCode).toBe(0);
+});
+
+test("per-test { retry } overrides --retry", async () => {
+  using dir = tempDir("retry-override", {
+    "override.test.ts": `
+      import { test, expect } from "bun:test";
+      let countA = 0;
+      let countB = 0;
+
+      // Per-test retry=1 overrides --retry 5. Fails twice, so retry=1 not enough.
+      test("limited retry", { retry: 1 }, () => {
+        countA++;
+        if (countA < 3) throw new Error("fail attempt " + countA);
+      });
+
+      // Uses global --retry 5 default, fails once then passes.
+      test("default retry", () => {
+        countB++;
+        if (countB < 2) throw new Error("fail attempt " + countB);
+        expect(true).toBe(true);
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--retry", "5", "override.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("limited retry");
+  expect(stderr).toContain("default retry");
+  expect(exitCode).not.toBe(0);
+});
+
+test("bunfig.toml retry works equivalently", async () => {
+  using dir = tempDir("retry-bunfig", {
+    "bunfig.toml": `
+[test]
+retry = 3
+`,
+    "flaky.test.ts": `
+      import { test, expect } from "bun:test";
+      let count = 0;
+      test("flaky via bunfig", () => {
+        count++;
+        if (count < 3) throw new Error("fail attempt " + count);
+        expect(true).toBe(true);
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "flaky.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("flaky via bunfig");
+  expect(stderr).toContain("attempt 3");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -344,7 +344,6 @@ describe("junit reporter", () => {
     });
     await proc.exited;
 
-    expect(proc.exitCode).toBe(0);
     const xmlContent = await file(junitPath).text();
 
     // The flaky test should have flakyFailure elements (2 failures before passing on attempt 3)
@@ -373,6 +372,8 @@ describe("junit reporter", () => {
 
     expect(result.testsuites.$.failures).toBe("0");
     expect(result.testsuites.$.tests).toBe("2");
+
+    expect(proc.exitCode).toBe(0);
   });
 });
 

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -336,7 +336,7 @@ describe("junit reporter", () => {
     });
 
     const junitPath = `${tmpDir}/junit.xml`;
-    const proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
+    await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
       cwd: tmpDir,
       env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
       stdout: "pipe",


### PR DESCRIPTION
#### (Copies commits from #26447)

## Summary
- Add a global `--retry <N>` flag to `bun test` that sets a default retry count for all tests (overridable by per-test `{ retry: N }`). Also configurable via `[test] retry = N` in bunfig.toml.
- When a test passes after one or more retries, the JUnit XML reporter emits a separate `<testcase>` entry for each failed attempt (with `<failure>`), followed by the final passing `<testcase>`. This gives flaky test detection tools per-attempt timing and result data using standard JUnit XML that all CI systems can parse.

## Test plan
- `bun bd test test/js/junit-reporter/junit.test.js` — verifies separate `<testcase>` entries appear in JUnit XML for tests that pass after retry
- `bun bd test test/cli/test/retry-flag.test.ts` — verifies the `--retry` CLI flag applies a default retry count to all tests

## Changelog
<!-- CHANGELOG:START -->
- Added `--retry <N>` flag to `bun test` to set a default retry count for all tests
- Added `[test] retry` option to bunfig.toml
- JUnit XML reporter now emits separate `<testcase>` entries for each retry attempt, providing CI visibility into flaky tests
<!-- CHANGELOG:END -->