### PR TITLE
fix(types): align ArrayBuffer.resize and Promise.withResolvers with ES spec

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1060,7 +1060,7 @@ interface ArrayBuffer {
   /**
    * Resize an ArrayBuffer in-place.
    */
-  resize(byteLength: number): ArrayBuffer;
+  resize(newByteLength?: number): void;
 
   /**
    * Returns a section of an ArrayBuffer.
@@ -1072,7 +1072,7 @@ interface SharedArrayBuffer {
   /**
    * Grow the SharedArrayBuffer in-place.
    */
-  grow(size: number): SharedArrayBuffer;
+  grow(newByteLength?: number): void;
 }
 
 interface ArrayConstructor {
@@ -1405,7 +1405,7 @@ interface PromiseConstructor {
    */
   withResolvers<T>(): {
     promise: Promise<T>;
-    resolve: (value?: T | PromiseLike<T>) => void;
+    resolve: (value: T | PromiseLike<T>) => void;
     reject: (reason?: any) => void;
   };
 

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -513,6 +513,74 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  describe("core-js type compatibility", () => {
+    // See: https://github.com/oven-sh/bun/issues/26868
+    // @core-js/types (non-pure) augments global PromiseConstructor, which is
+    // what triggers the TS2430 conflict fixed in #26868. It also declares
+    // DOM interfaces for iterable-dom-collections that are empty without
+    // lib.dom.d.ts.
+    const coreJsDOMInterfaces = [
+      "Attr",
+      "CSSRule",
+      "CSSValue",
+      "ClientRect",
+      "DOMPoint",
+      "DOMRect",
+      "DataTransferItem",
+      "Element",
+      "HTMLOptionElement",
+      "MimeType",
+      "Node",
+      "PaintRequest",
+      "SVGLength",
+      "SVGNumber",
+      "SVGPathSeg",
+      "SVGTransform",
+      "SourceBuffer",
+      "StyleSheet",
+      "TextTrack",
+      "TextTrackCue",
+      "Touch",
+    ] as const;
+
+    typeTest("no conflicts with @core-js/types", {
+      packages: ["@core-js/types@4.0.0-alpha.1"],
+      options: {
+        // bun-types provides all type declarations without TypeScript's
+        // standard lib. Using lib: [] ensures we test bun-types' own
+        // signatures without TypeScript's lib.es2024 masking bugs via
+        // duplicate overloads.
+        lib: [],
+      },
+      files: {
+        "core-js-compat.ts": `
+          /// <reference types="@core-js/types" />
+
+          // Verify usage works with both bun-types and core-js-types loaded
+          const buf = new ArrayBuffer(1024, { maxByteLength: 2048 });
+          buf.resize(2048);
+
+          const { promise, resolve, reject } = Promise.withResolvers<string>();
+          resolve("hello");
+        `,
+      },
+      emptyInterfaces: new Set([...expectedEmptyInterfacesWhenNoDOM, ...coreJsDOMInterfaces]),
+      diagnostics: diagnostics => {
+        // Keep diagnostics from the test file, bun-types, or interface
+        // merge conflicts (2430). Exclude internal core-js issues like
+        // circular self-references.
+        const relevantDiagnostics = diagnostics.filter(
+          d =>
+            d.line === null ||
+            d.line.startsWith("core-js-compat.ts") ||
+            d.line?.includes("bun-types") ||
+            d.code === 2430,
+        );
+        expect(relevantDiagnostics).toEqual([]);
+      },
+    });
+  });
+
   describe("lib configuration", () => {
     typeTest("checks with no lib at all", {
       options: {

--- a/test/integration/bun-types/fixture/array-buffer.ts
+++ b/test/integration/bun-types/fixture/array-buffer.ts
@@ -13,3 +13,15 @@ const buf = new SharedArrayBuffer(1024);
 buf.grow(2048);
 
 expectType(buffer[Symbol.toStringTag]).extends<string>();
+
+// SharedArrayBuffer.grow() returns void per ES spec, parameter is optional
+expectType(buf.grow(2048)).is<void>();
+expectType(buf.grow()).is<void>();
+
+// ArrayBuffer.resize() returns void per ES spec, parameter is optional
+expectType(buffer.resize(2048)).is<void>();
+expectType(buffer.resize()).is<void>();
+
+// Promise.withResolvers().resolve has a required parameter
+const { resolve } = Promise.withResolvers<string>();
+expectType(resolve).is<(value: string | PromiseLike<string>) => void>();


### PR DESCRIPTION
## Summary

Fixes two incorrect type signatures in `packages/bun-types/globals.d.ts` that deviate from the ECMAScript spec and TypeScript's standard library types, causing type conflicts with libraries like [core-js](https://github.com/zloirock/core-js) that also declare these types.

### 1. `ArrayBuffer.resize()` return type

```diff
- resize(byteLength: number): ArrayBuffer;
+ resize(newByteLength?: number): void;
```

Per the [ECMAScript spec](https://tc39.es/ecma262/#sec-arraybuffer.prototype.resize), `resize()` returns `undefined`. The parameter is also now optional, matching TypeScript's `lib.es2024.arraybuffer.d.ts`.

### 2. `Promise.withResolvers().resolve` parameter optionality

```diff
- resolve: (value?: T | PromiseLike<T>) => void;
+ resolve: (value: T | PromiseLike<T>) => void;
```

The `value` parameter should be **required**, matching TypeScript's `lib.es2024.promise.d.ts`. Making it optional caused `(value?: T | PromiseLike<T> | undefined) => void` to be incompatible with `(value: T | PromiseLike<T>) => void`, producing TS2430 errors when core-js types extend `PromiseConstructor`.

### 3. Tests

- **`array-buffer.ts` fixture**: `expectType` assertions verify `ArrayBuffer.resize()` returns `void` and `Promise.withResolvers().resolve` has a required parameter.
- **core-js compatibility test**: Installs `@core-js/types@4.0.0-alpha.1` from npm and verifies no type conflicts when both bun-types and core-js types are loaded.

## Test plan

- [x] `USE_SYSTEM_BUN=1 bun test test/integration/bun-types/bun-types.test.ts` — 12/12 pass

Closes #26868