### PR TITLE
fix: use baseline WebKit for x64 baseline builds to avoid SIGILL on pre-AVX2 CPUs

### DIFF
--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -209,6 +209,12 @@ if(LINUX AND ABI STREQUAL "musl")
   set(WEBKIT_SUFFIX "-musl")
 endif()
 
+# Baseline builds (ENABLE_BASELINE) target older CPUs without AVX2 (e.g. nehalem).
+# They require a WebKit library also compiled without AVX/AVX2 instructions.
+if(ENABLE_BASELINE AND WEBKIT_ARCH STREQUAL "amd64")
+  set(WEBKIT_SUFFIX "${WEBKIT_SUFFIX}-baseline")
+endif()
+
 if(DEBUG)
   set(WEBKIT_SUFFIX "${WEBKIT_SUFFIX}-debug")
 elseif(ENABLE_LTO)


### PR DESCRIPTION
## Summary

- Add `-baseline` suffix to `WEBKIT_SUFFIX` in `SetupWebKit.cmake` when `ENABLE_BASELINE` is set for amd64 builds, so baseline builds download a WebKit library compiled without AVX/AVX2 instructions.

## Problem

The `bun-darwin-x64-baseline` (and `bun-linux-x64-baseline`) builds crash with `SIGILL` (illegal hardware instruction) on Intel CPUs without AVX2 support (e.g. Xeon E5-2450, Sandy Bridge/Ivy Bridge era).

**Root cause:** The Bun executable is correctly compiled with `-march=nehalem` (no AVX/AVX2) when `ENABLE_BASELINE=ON`, but the WebKit library download URL has no baseline suffix, so it downloads a WebKit build that contains AVX/AVX2 instructions. When these instructions execute on a pre-AVX2 CPU, the CPU raises SIGILL.

## Fix

Add baseline suffix logic to `SetupWebKit.cmake` (after the musl suffix and before the debug/lto/asan suffixes):

```cmake
if(ENABLE_BASELINE AND WEBKIT_ARCH STREQUAL "amd64")
  set(WEBKIT_SUFFIX "${WEBKIT_SUFFIX}-baseline")
endif()
```

This ensures baseline builds request `bun-webkit-*-amd64-baseline.tar.gz` instead of `bun-webkit-*-amd64.tar.gz`.

## Dependencies

This fix requires corresponding baseline WebKit builds to be published from the `oven-sh/WebKit` repository. See [oven-sh/WebKit#151](https://github.com/oven-sh/WebKit/pull/151) for the WebKit-side changes.

## Test plan

- [ ] Verify CMake configuration generates correct `WEBKIT_DOWNLOAD_URL` with `-baseline` suffix when `ENABLE_BASELINE=ON` and arch is `amd64`
- [ ] Once WebKit baseline builds are published, verify `bun-darwin-x64-baseline` runs without SIGILL on pre-AVX2 Intel CPUs
- [ ] Existing `scripts/verify-baseline-cpu.sh` CI step validates no illegal instructions via QEMU

Closes #26872

🤖 Generated with [Claude Code](https://claude.com/claude-code)