### PR TITLE
Update installation URLs for Bun

### DIFF
--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -310,7 +310,7 @@ pub const UpgradeCommand = struct {
     const profile_exe_subpath = Version.profile_folder_name ++ std.fs.path.sep_str ++ "bun-profile" ++ exe_suffix;
 
     const manual_upgrade_command = switch (Environment.os) {
-        .linux, .mac => "curl -fsSL https://bun.com/install | bash",
+        .linux, .mac => "curl -fsSL https://bun.sh/install | bash",
         .windows => "powershell -c 'irm bun.sh/install.ps1|iex'",
         else => "(TODO: Install script for " ++ Environment.os.displayString() ++ ")",
     };
@@ -862,7 +862,7 @@ pub const UpgradeCommand = struct {
                     \\
                     \\What's new in Bun v{s}:
                     \\
-                    \\    <cyan>https://bun.com/blog/release-notes/{s}<r>
+                    \\    <cyan>https://bun.sh/blog/release-notes/{s}<r>
                     \\
                     \\Report any bugs:
                     \\


### PR DESCRIPTION
### What does this PR do?

When updating my local Bun install, the link to view the release notes pointed to bun.com, which failed to resolve. This pull request updates that update message to use bun.com. In practice, the URL is changed like this:

```diff
-https://bun.com/blog/release-notes/bun-v1.3.9
+https://bun.sh/blog/release-notes/bun-v1.3.9
```

![screenshot of output](https://github.com/user-attachments/assets/740bb0e7-e9a7-449d-b7e3-c7f6d626b088)

When searching, I also found that it had referenced the old domain in a setup command. This command differs from the one [shown officially on the website](https://bun.sh/). I went ahead and updated from bun.com to bun.sh.

### How did you verify your code works?

I tested the URL to make sure it works when updating the command output. I also did a test run of the manual upgrade command and confirmed that the old one failed, while the new one succeeded:

```
➜  ~ curl -fsSL https://bun.com/install | bash
curl: (35) Recv failure: Connection reset by peer
➜  ~ curl -fsSL https://bun.sh/install | bash
######################################################################## 100.0%
bun was installed successfully to ~/.bun/bin/bun 
Run 'bun --help' to get started
➜  ~ 
```

When testing the commands with a VPN, bun.com started resolving again (it was DNS), but the differing domains could still confuse newcomers trying to decide which domain is genuine.