### PR TITLE
fix(test): update valkey test snapshots for Redis 8 error message format

### DIFF
--- a/test/js/valkey/reliability/error-handling.test.ts
+++ b/test/js/valkey/reliability/error-handling.test.ts
@@ -103,7 +103,7 @@ describe.skipIf(!isEnabled)("Valkey: Error Handling", () => {
       // Undefined command
       // @ts-expect-error: Testing runtime behavior with invalid types
       expect(async () => await client.send(undefined, [])).toThrowErrorMatchingInlineSnapshot(
-        `"ERR unknown command 'undefined', with args beginning with: "`,
+        `"ERR unknown command 'undefined'"`,
       );
 
       // Invalid args type
@@ -114,9 +114,7 @@ describe.skipIf(!isEnabled)("Valkey: Error Handling", () => {
 
       // Non-string command
       // @ts-expect-error: Testing runtime behavior with invalid types
-      expect(async () => await client.send(123, [])).toThrowErrorMatchingInlineSnapshot(
-        `"ERR unknown command '123', with args beginning with: "`,
-      );
+      expect(async () => await client.send(123, [])).toThrowErrorMatchingInlineSnapshot(`"ERR unknown command '123'"`);
     });
   });
 

--- a/test/js/valkey/reliability/protocol-handling.test.ts
+++ b/test/js/valkey/reliability/protocol-handling.test.ts
@@ -124,7 +124,7 @@ describe.skipIf(!isEnabled)("Valkey: Protocol Handling", () => {
       );
 
       expect(async () => await ctx.redis.send("SYNTAX-ERROR", [])).toThrowErrorMatchingInlineSnapshot(
-        `"ERR unknown command 'SYNTAX-ERROR', with args beginning with: "`,
+        `"ERR unknown command 'SYNTAX-ERROR'"`,
       );
     });
   });


### PR DESCRIPTION
## Summary
- Update inline error snapshots in valkey reliability tests to match Redis 8's changed error message format
- Redis 8 (`redis:8-alpine` in our test Docker container) no longer appends `, with args beginning with: ` when an unknown command has no arguments

## Root cause
Redis commit [`25f780b6`](https://github.com/redis/redis/commit/25f780b66243d70935ce258ecfbd9b42d6d509f7) ([PR #14690](https://github.com/redis/redis/pull/14690)) changed `commandCheckExistence()` in `src/server.c` to only append `, with args beginning with: ` when there are actual arguments (`c->argc >= 2`). Previously it was always appended, producing a dangling `, with args beginning with: ` even with zero arguments.

## Changes
- `test/js/valkey/reliability/protocol-handling.test.ts`: Updated `SYNTAX-ERROR` snapshot (no args case)
- `test/js/valkey/reliability/error-handling.test.ts`: Updated `undefined` and `123` snapshots (no args cases)

## Test plan
- [ ] Verify `protocol-handling.test.ts` passes in CI (was failing on every attempt as shown in #26869 / build #36831)
- [ ] Verify `error-handling.test.ts` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)