### PR TITLE
fix(compile): use remaining buffer in standalone POSIX write loop

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -935,7 +935,7 @@ pub const StandaloneModuleGraph = struct {
 
                 var remain = bytes;
                 while (remain.len > 0) {
-                    switch (Syscall.write(cloned_executable_fd, bytes)) {
+                    switch (Syscall.write(cloned_executable_fd, remain)) {
                         .result => |written| remain = remain[written..],
                         .err => |err| {
                             Output.prettyErrorln("<r><red>error<r><d>:<r> failed to write to temporary file\n{f}", .{err});


### PR DESCRIPTION
## What does this PR do?

Fixes the write loop in `StandaloneModuleGraph.inject()` for POSIX targets (the `else` branch handling ELF/Linux standalone binaries) to pass `remain` instead of `bytes` to `Syscall.write()`.

## Problem

The write loop that appends the bundled module graph to the end of the executable uses a standard partial-write retry pattern, but passes the full `bytes` buffer on every iteration instead of the remaining portion:

```zig
var remain = bytes;
while (remain.len > 0) {
    switch (Syscall.write(cloned_executable_fd, bytes)) {   // bug: should be 'remain'
        .result => |written| remain = remain[written..],
        ...
    }
}
```

If a partial write occurs, the next iteration re-writes from the start of the buffer instead of continuing where it left off, corrupting the output binary. The analogous read loop elsewhere in the same file already correctly uses `remain`.

## Fix

One-character change: `bytes` → `remain` in the `Syscall.write()` call.

## How did you verify your code works?

- `bun bd` compiles successfully
- `bun bd test test/bundler/bun-build-compile.test.ts` — 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)