### PR TITLE
fix(shell): fix use-after-free in runFromJS when setupIOBeforeRun fails

### DIFF
--- a/test/regression/issue/26894.test.ts
+++ b/test/regression/issue/26894.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/26894
+// When setupIOBeforeRun() fails (e.g., stdout dup fails), the shell interpreter
+// would free itself via #deinitFromExec, but the GC still held a reference to
+// the JS wrapper object. When the GC later finalized it, it would access freed memory.
+test("shell interpreter does not crash when stdout is closed", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const fs = require("fs");
+      // Close stdout so that the shell's dup(stdout) fails in setupIOBeforeRun
+      fs.closeSync(1);
+      try {
+        // This should throw a shell error, not segfault
+        await Bun.$\`echo hello\`;
+      } catch (e) {
+        // Expected: shell error due to failed dup of stdout
+      }
+      // Force GC to trigger finalization of the shell interpreter object.
+      // Before the fix, this would segfault due to use-after-free.
+      Bun.gc(true);
+      Bun.gc(true);
+      // Write to stderr to signal success (stdout is closed)
+      fs.writeSync(2, "OK\\n");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("OK");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fix use-after-free crash in the shell interpreter when `setupIOBeforeRun()` fails during `runFromJS` (e.g., when stdout/stderr dup fails)
- Replace `#deinitFromExec()` with `#derefRootShellAndIOIfNeeded(true)` in the error path so the GC finalizer handles the final struct deallocation instead of freeing it prematurely

## Root Cause

When `setupIOBeforeRun()` fails in the JS code path, the code called `#deinitFromExec()` which frees the interpreter struct via `allocator.destroy(this)`. However, the GC still holds a reference to the JS wrapper object and later calls `deinitFromFinalizer()` on the already-freed memory, causing a segfault.

`#deinitFromExec` is correct for standalone (non-JS) shell paths where there's no GC, but should not be used in `runFromJS` where the JS object's lifetime is managed by the GC.

## Test plan
- [x] Added regression test in `test/regression/issue/26894.test.ts` that closes stdout before running a shell command and forces GC
- [x] Existing shell tests pass (pre-existing failures in `quiet` and `leak` tests unrelated to this change)

Closes #26894

🤖 Generated with [Claude Code](https://claude.com/claude-code)