### PR TITLE
perf: optimize microtask dispatch by removing JS trampoline

### DIFF
--- a/bench/snippets/microtask-throughput.mjs
+++ b/bench/snippets/microtask-throughput.mjs
@@ -1,0 +1,108 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { bench, group, run } from "../runner.mjs";
+
+// Benchmark 1: queueMicrotask throughput
+// Tests the BunPerformMicrotaskJob handler path directly.
+// The optimization removes the JS trampoline and uses callMicrotask.
+group("queueMicrotask throughput", () => {
+  bench("queueMicrotask 1k", () => {
+    return new Promise(resolve => {
+      let remaining = 1000;
+      const tick = () => {
+        if (--remaining === 0) resolve();
+        else queueMicrotask(tick);
+      };
+      queueMicrotask(tick);
+    });
+  });
+
+  bench("queueMicrotask 10k", () => {
+    return new Promise(resolve => {
+      let remaining = 10000;
+      const tick = () => {
+        if (--remaining === 0) resolve();
+        else queueMicrotask(tick);
+      };
+      queueMicrotask(tick);
+    });
+  });
+});
+
+// Benchmark 2: Promise.resolve chain
+// Each .then() queues a microtask via the promise machinery.
+// Benefits from smaller QueuedTask (better cache locality in the Deque).
+group("Promise.resolve chain", () => {
+  bench("Promise chain 1k", () => {
+    let p = Promise.resolve();
+    for (let i = 0; i < 1000; i++) {
+      p = p.then(() => {});
+    }
+    return p;
+  });
+
+  bench("Promise chain 10k", () => {
+    let p = Promise.resolve();
+    for (let i = 0; i < 10000; i++) {
+      p = p.then(() => {});
+    }
+    return p;
+  });
+});
+
+// Benchmark 3: Promise.all (many simultaneous resolves)
+// All promises resolve at once, flooding the microtask queue.
+// Smaller QueuedTask = less memory, better cache utilization.
+group("Promise.all simultaneous", () => {
+  bench("Promise.all 1k", () => {
+    const promises = [];
+    for (let i = 0; i < 1000; i++) {
+      promises.push(Promise.resolve(i));
+    }
+    return Promise.all(promises);
+  });
+
+  bench("Promise.all 10k", () => {
+    const promises = [];
+    for (let i = 0; i < 10000; i++) {
+      promises.push(Promise.resolve(i));
+    }
+    return Promise.all(promises);
+  });
+});
+
+// Benchmark 4: queueMicrotask with AsyncLocalStorage
+// Tests the inlined async context save/restore path.
+// Previously went through performMicrotaskFunction JS trampoline.
+group("queueMicrotask + AsyncLocalStorage", () => {
+  const als = new AsyncLocalStorage();
+
+  bench("ALS.run + queueMicrotask 1k", () => {
+    return als.run({ id: 1 }, () => {
+      return new Promise(resolve => {
+        let remaining = 1000;
+        const tick = () => {
+          als.getStore(); // force context read
+          if (--remaining === 0) resolve();
+          else queueMicrotask(tick);
+        };
+        queueMicrotask(tick);
+      });
+    });
+  });
+});
+
+// Benchmark 5: async/await (each await queues microtasks)
+group("async/await chain", () => {
+  async function asyncChain(n) {
+    let sum = 0;
+    for (let i = 0; i < n; i++) {
+      sum += await Promise.resolve(i);
+    }
+    return sum;
+  }
+
+  bench("async/await 1k", () => asyncChain(1000));
+  bench("async/await 10k", () => asyncChain(10000));
+});
+
+await run();

--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -6,7 +6,7 @@ option(WEBKIT_LOCAL "If a local version of WebKit should be used instead of down
 option(WEBKIT_BUILD_TYPE "The build type for local WebKit (defaults to CMAKE_BUILD_TYPE)")
 
 if(NOT WEBKIT_VERSION)
-  set(WEBKIT_VERSION 8af7958ff0e2a4787569edf64641a1ae7cfe074a)
+  set(WEBKIT_VERSION preview-pr-160-8680a32c)
 endif()
 
 # Use preview build URL for Windows ARM64 until the fix is merged to main

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -272,7 +272,6 @@ public:
 
     JSC::JSObject* performanceObject() const { return m_performanceObject.getInitializedOnMainThread(this); }
 
-    JSC::JSFunction* performMicrotaskFunction() const { return m_performMicrotaskFunction.getInitializedOnMainThread(this); }
     JSC::JSFunction* performMicrotaskVariadicFunction() const { return m_performMicrotaskVariadicFunction.getInitializedOnMainThread(this); }
 
     JSC::Structure* utilInspectOptionsStructure() const { return m_utilInspectOptionsStructure.getInitializedOnMainThread(this); }
@@ -568,7 +567,6 @@ public:
                                                                                                              \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_jsonlParseResultStructure)                           \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_pendingVirtualModuleResultStructure)                 \
-    V(private, LazyPropertyOfGlobalObject<JSFunction>, m_performMicrotaskFunction)                           \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_nativeMicrotaskTrampoline)                          \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_performMicrotaskVariadicFunction)                   \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_utilInspectFunction)                                \

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -3538,13 +3538,11 @@ void JSC__JSPromise__rejectOnNextTickWithHandled(JSC::JSPromise* promise, JSC::J
 
         promise->internalField(JSC::JSPromise::Field::Flags).set(vm, promise, jsNumber(flags | JSC::JSPromise::isFirstResolvingFunctionCalledFlag));
         auto* globalObject = jsCast<Zig::GlobalObject*>(promise->globalObject());
-        auto microtaskFunction = globalObject->performMicrotaskFunction();
         auto rejectPromiseFunction = globalObject->rejectPromiseFunction();
 
         auto asyncContext = globalObject->m_asyncContextData.get()->getInternalField(0);
 
 #if ASSERT_ENABLED
-        ASSERT_WITH_MESSAGE(microtaskFunction, "Invalid microtask function");
         ASSERT_WITH_MESSAGE(rejectPromiseFunction, "Invalid microtask callback");
         ASSERT_WITH_MESSAGE(!value.isEmpty(), "Invalid microtask value");
 #endif
@@ -3557,7 +3555,8 @@ void JSC__JSPromise__rejectOnNextTickWithHandled(JSC::JSPromise* promise, JSC::J
             value = jsUndefined();
         }
 
-        JSC::QueuedTask task { nullptr, JSC::InternalMicrotask::BunPerformMicrotaskJob, 0, globalObject, microtaskFunction, rejectPromiseFunction, globalObject->m_asyncContextData.get()->getInternalField(0), promise, value };
+        // BunPerformMicrotaskJob: rejectPromiseFunction, asyncContext, promise, value
+        JSC::QueuedTask task { nullptr, JSC::InternalMicrotask::BunPerformMicrotaskJob, 0, globalObject, rejectPromiseFunction, globalObject->m_asyncContextData.get()->getInternalField(0), promise, value };
         globalObject->vm().queueMicrotask(WTF::move(task));
         RETURN_IF_EXCEPTION(scope, );
     }
@@ -5438,9 +5437,7 @@ extern "C" void JSC__JSGlobalObject__queueMicrotaskJob(JSC::JSGlobalObject* arg0
     if (microtaskArgs[3].isEmpty()) {
         microtaskArgs[3] = jsUndefined();
     }
-    JSC::JSFunction* microTaskFunction = globalObject->performMicrotaskFunction();
 #if ASSERT_ENABLED
-    ASSERT_WITH_MESSAGE(microTaskFunction, "Invalid microtask function");
     auto& vm = globalObject->vm();
     if (microtaskArgs[0].isCell()) {
         JSC::Integrity::auditCellFully(vm, microtaskArgs[0].asCell());
@@ -5460,7 +5457,8 @@ extern "C" void JSC__JSGlobalObject__queueMicrotaskJob(JSC::JSGlobalObject* arg0
 
 #endif
 
-    JSC::QueuedTask task { nullptr, JSC::InternalMicrotask::BunPerformMicrotaskJob, 0, globalObject, microTaskFunction, WTF::move(microtaskArgs[0]), WTF::move(microtaskArgs[1]), WTF::move(microtaskArgs[2]), WTF::move(microtaskArgs[3]) };
+    // BunPerformMicrotaskJob: job, asyncContext, arg0, arg1
+    JSC::QueuedTask task { nullptr, JSC::InternalMicrotask::BunPerformMicrotaskJob, 0, globalObject, WTF::move(microtaskArgs[0]), WTF::move(microtaskArgs[1]), WTF::move(microtaskArgs[2]), WTF::move(microtaskArgs[3]) };
     globalObject->vm().queueMicrotask(WTF::move(task));
 }
 


### PR DESCRIPTION
## Summary

Remove the `performMicrotaskFunction` JS trampoline from the microtask dispatch path. Previously, every microtask went through a JavaScript function (`jsFunctionPerformMicrotask`) that acted as a bridge between JSC's microtask queue and Bun's task handler. This change inlines that logic directly into JSC's `BunPerformMicrotaskJob` handler (via a companion WebKit change), eliminating an unnecessary JS→native round-trip on every microtask.

## Changes

### Bun side
- Remove `performMicrotaskFunction` from all `QueuedTask` construction sites (`functionQueueMicrotask`, `JSC__JSPromise__reject_`, `queueMicrotaskJob`)
- Delete `jsFunctionPerformMicrotask` (now inlined in JSC's handler)
- Remove `m_performMicrotaskFunction` `LazyProperty` and its accessor from `ZigGlobalObject`
- `sizeof(QueuedTask)` drops from 56 → 48 bytes (-14%), improving cache locality in the microtask `Deque`

### WebKit side
- Update `SetupWebKit.cmake` to point to `preview-pr-160-8680a32c` which reduces `maxMicrotaskArguments` from 5 → 4 and calls `callMicrotask` directly

### Benchmark
- Add `bench/snippets/microtask-throughput.mjs` covering queueMicrotask, Promise chains, Promise.all, AsyncLocalStorage + queueMicrotask, and async/await chains

## Benchmark Results

**CPU: Apple M4 Max (~4.23 GHz), macOS**

| Benchmark | Before (1.3.9) | After (this PR) | Speedup |
|---|---|---|---|
| queueMicrotask 1k | 40.96 µs | 17.93 µs | **2.28x** |
| queueMicrotask 10k | 409.86 µs | 169.84 µs | **2.41x** |
| Promise chain 1k | 26.12 µs | 27.48 µs | ~1.0x |
| Promise chain 10k | 257.77 µs | 265.57 µs | ~1.0x |
| Promise.all 1k | 27.47 µs | 27.65 µs | ~1.0x |
| Promise.all 10k | 266.76 µs | 269.24 µs | ~1.0x |
| ALS + queueMicrotask 1k | 42.37 µs | 20.66 µs | **2.05x** |
| async/await 1k | 19.96 µs | 18.71 µs | 1.07x |
| async/await 10k | 197.81 µs | 186.97 µs | 1.06x |

The `queueMicrotask` path (which directly exercises `BunPerformMicrotaskJob`) sees a **~2.3x speedup**. Promise-based benchmarks are unaffected as expected since they go through JSC's internal promise machinery. The `AsyncLocalStorage + queueMicrotask` combo sees a **~2x speedup** from the inlined async context save/restore.

## Companion PR

- WebKit fork: oven-sh/WebKit#160