### PR TITLE
fix(shell): prevent use-after-free in runFromJS error path

### DIFF
--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -1154,7 +1154,7 @@ pub const Interpreter = struct {
         _ = callframe; // autofix
 
         if (this.setupIOBeforeRun().asErr()) |e| {
-            defer this.#deinitFromExec();
+            this.#derefRootShellAndIOIfNeeded(true);
             const shellerr = bun.shell.ShellErr.newSys(e);
             return try throwShellErr(&shellerr, .{ .js = globalThis.bunVM().event_loop });
         }

--- a/test/regression/issue/26907.test.ts
+++ b/test/regression/issue/26907.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for #26907: use-after-free in shell interpreter's runFromJS error path.
+// When setupIOBeforeRun() fails (e.g., stdout handle is invalid on Windows), the interpreter
+// must NOT call allocator.destroy(this) directly, since the GC finalizer will later try to
+// access the freed memory. Instead, it should clean up runtime resources via
+// derefRootShellAndIOIfNeeded and let the GC handle destruction.
+//
+// The bug is most reliably triggered on Windows where stdout can be unavailable,
+// causing setupIOBeforeRun() -> dup(stdout) to fail. On Linux, dup rarely fails.
+test("shell interpreter does not crash on GC after shell error", async () => {
+  // Run many shell commands and force GC to stress the interpreter lifecycle.
+  // On Windows with the bug, this would segfault during GC sweep when the
+  // finalizer accesses already-freed interpreter memory.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      async function main() {
+        const promises = [];
+        for (let i = 0; i < 50; i++) {
+          promises.push(Bun.$\`echo hello\`.quiet().catch(() => {}));
+        }
+        await Promise.all(promises);
+        // Force GC multiple times to trigger finalizers
+        Bun.gc(true);
+        Bun.gc(true);
+        process.stderr.write("OK\\n");
+      }
+      main();
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [_stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("OK");
+  expect(exitCode).toBe(0);
+});
+
+test("shell interpreter handles closed stdout without crashing", async () => {
+  // Close stdout before running shell commands to trigger setupIOBeforeRun failure.
+  // On Windows this reliably triggers the error path; on Linux dup may still succeed.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const fs = require("fs");
+      fs.closeSync(1);
+      async function main() {
+        try {
+          await Bun.$\`echo hello\`;
+        } catch (e) {
+          // Error is expected when stdout is unavailable
+        }
+        // Force GC to trigger finalizer - this would segfault before the fix on Windows
+        Bun.gc(true);
+        Bun.gc(true);
+        process.stderr.write("OK\\n");
+      }
+      main();
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [_stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("OK");
+  // Process must not segfault (exit code 139 on Linux, non-zero on Windows)
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fix use-after-free in the shell interpreter's `runFromJS` error path when `setupIOBeforeRun()` fails (e.g., stdout handle is invalid on Windows)
- Replace `#deinitFromExec()` (which immediately frees the GC-managed interpreter) with `#derefRootShellAndIOIfNeeded(true)` (which cleans up runtime resources and lets the GC finalizer handle destruction)
- Add regression tests for shell interpreter lifecycle under GC pressure and with closed stdout

## Root Cause

In `runFromJS`, when `setupIOBeforeRun()` fails, `#deinitFromExec()` calls `allocator.destroy(this)` which frees the interpreter struct immediately. However, the interpreter is wrapped in a GC-managed `JSShellInterpreter`, so the GC finalizer later calls `deinitFromFinalizer()` on already-freed memory, causing a segfault.

The fix uses `#derefRootShellAndIOIfNeeded(true)` which:
1. Cleans up runtime resources (IO, shell env)
2. Sets `cleanup_state = .runtime_cleaned` so the GC finalizer knows what's already been cleaned
3. Lets the GC finalizer handle the actual struct destruction via `deinitFromFinalizer()`

## Test plan

- [x] `bun bd test test/regression/issue/26907.test.ts` passes
- [ ] CI passes on Windows (where the bug is most reliably triggered)

Closes #26907

🤖 Generated with [Claude Code](https://claude.com/claude-code)