### PR TITLE
fix(http2): send connection-level WINDOW_UPDATE in setLocalWindowSize

### DIFF
--- a/test/regression/issue/26915.test.ts
+++ b/test/regression/issue/26915.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test";
+import http2 from "node:http2";
+
+// Regression test for https://github.com/oven-sh/bun/issues/26915
+// setLocalWindowSize() must send a connection-level WINDOW_UPDATE frame.
+// Without this, the peer's connection-level window stays at the default
+// 65,535 bytes and streams stall when receiving larger payloads.
+test("http2 client setLocalWindowSize sends connection-level WINDOW_UPDATE", async () => {
+  const payloadSize = 256 * 1024; // 256 KB - well above the 65535 default
+  const payload = Buffer.alloc(payloadSize, "x");
+
+  const { promise: serverReady, resolve: resolveServer } = Promise.withResolvers<{
+    port: number;
+    server: http2.Http2Server;
+  }>();
+
+  const server = http2.createServer();
+  server.on("stream", stream => {
+    stream.respond({ ":status": 200 });
+    stream.end(payload);
+  });
+  server.listen(0, () => {
+    const addr = server.address();
+    if (addr && typeof addr === "object") {
+      resolveServer({ port: addr.port, server });
+    }
+  });
+
+  const { port, server: srv } = await serverReady;
+
+  try {
+    const client = http2.connect(`http://localhost:${port}`, {
+      settings: { initialWindowSize: 10 * 1024 * 1024 },
+    });
+
+    client.setLocalWindowSize(10 * 1024 * 1024);
+
+    const { promise: done, resolve: resolveDone, reject: rejectDone } = Promise.withResolvers<Buffer>();
+
+    const req = client.request({ ":path": "/" });
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => {
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      resolveDone(Buffer.concat(chunks));
+    });
+    req.on("error", rejectDone);
+    req.end();
+
+    const result = await done;
+    expect(result.length).toBe(payloadSize);
+
+    client.close();
+  } finally {
+    srv.close();
+  }
+});

--- a/test/regression/issue/26915.test.ts
+++ b/test/regression/issue/26915.test.ts
@@ -5,15 +5,10 @@ import http2 from "node:http2";
 // setLocalWindowSize() must send a connection-level WINDOW_UPDATE frame.
 // Without this, the peer's connection-level window stays at the default
 // 65,535 bytes and streams stall when receiving larger payloads.
-test("http2 client setLocalWindowSize sends connection-level WINDOW_UPDATE", async () => {
-  const payloadSize = 256 * 1024; // 256 KB - well above the 65535 default
+
+function startServer(payloadSize: number): Promise<{ port: number; server: http2.Http2Server }> {
   const payload = Buffer.alloc(payloadSize, "x");
-
-  const { promise: serverReady, resolve: resolveServer } = Promise.withResolvers<{
-    port: number;
-    server: http2.Http2Server;
-  }>();
-
+  const { promise, resolve } = Promise.withResolvers<{ port: number; server: http2.Http2Server }>();
   const server = http2.createServer();
   server.on("stream", stream => {
     stream.respond({ ":status": 200 });
@@ -22,11 +17,26 @@ test("http2 client setLocalWindowSize sends connection-level WINDOW_UPDATE", asy
   server.listen(0, () => {
     const addr = server.address();
     if (addr && typeof addr === "object") {
-      resolveServer({ port: addr.port, server });
+      resolve({ port: addr.port, server });
     }
   });
+  return promise;
+}
 
-  const { port, server: srv } = await serverReady;
+function doRequest(client: http2.ClientHttp2Session): Promise<Buffer> {
+  const { promise, resolve, reject } = Promise.withResolvers<Buffer>();
+  const req = client.request({ ":path": "/" });
+  const chunks: Buffer[] = [];
+  req.on("data", (chunk: Buffer) => chunks.push(chunk));
+  req.on("end", () => resolve(Buffer.concat(chunks)));
+  req.on("error", reject);
+  req.end();
+  return promise;
+}
+
+test("http2 client setLocalWindowSize sends connection-level WINDOW_UPDATE", async () => {
+  const payloadSize = 256 * 1024; // 256 KB - well above the 65535 default
+  const { port, server } = await startServer(payloadSize);
 
   try {
     const client = http2.connect(`http://localhost:${port}`, {
@@ -35,24 +45,29 @@ test("http2 client setLocalWindowSize sends connection-level WINDOW_UPDATE", asy
 
     client.setLocalWindowSize(10 * 1024 * 1024);
 
-    const { promise: done, resolve: resolveDone, reject: rejectDone } = Promise.withResolvers<Buffer>();
-
-    const req = client.request({ ":path": "/" });
-    const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => {
-      chunks.push(chunk);
-    });
-    req.on("end", () => {
-      resolveDone(Buffer.concat(chunks));
-    });
-    req.on("error", rejectDone);
-    req.end();
-
-    const result = await done;
+    const result = await doRequest(client);
     expect(result.length).toBe(payloadSize);
 
     client.close();
   } finally {
-    srv.close();
+    server.close();
+  }
+});
+
+test("http2 client initialWindowSize setting allows large stream payloads", async () => {
+  const payloadSize = 1024 * 1024; // 1 MB
+  const { port, server } = await startServer(payloadSize);
+
+  try {
+    const client = http2.connect(`http://localhost:${port}`, {
+      settings: { initialWindowSize: 10 * 1024 * 1024 },
+    });
+
+    const result = await doRequest(client);
+    expect(result.length).toBe(payloadSize);
+
+    client.close();
+  } finally {
+    server.close();
   }
 });

--- a/test/regression/issue/26915.test.ts
+++ b/test/regression/issue/26915.test.ts
@@ -1,5 +1,7 @@
-import { expect, test } from "bun:test";
+import assert from "node:assert";
+import { once } from "node:events";
 import http2 from "node:http2";
+import { test } from "node:test";
 
 // Regression test for https://github.com/oven-sh/bun/issues/26915
 // setLocalWindowSize() must send a connection-level WINDOW_UPDATE frame.
@@ -8,30 +10,38 @@ import http2 from "node:http2";
 
 function startServer(payloadSize: number): Promise<{ port: number; server: http2.Http2Server }> {
   const payload = Buffer.alloc(payloadSize, "x");
-  const { promise, resolve } = Promise.withResolvers<{ port: number; server: http2.Http2Server }>();
-  const server = http2.createServer();
-  server.on("stream", stream => {
-    stream.respond({ ":status": 200 });
-    stream.end(payload);
+  return new Promise(resolve => {
+    const server = http2.createServer();
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200 });
+      stream.end(payload);
+    });
+    server.listen(0, () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") {
+        resolve({ port: addr.port, server });
+      }
+    });
   });
-  server.listen(0, () => {
-    const addr = server.address();
-    if (addr && typeof addr === "object") {
-      resolve({ port: addr.port, server });
-    }
-  });
-  return promise;
 }
 
 function doRequest(client: http2.ClientHttp2Session): Promise<Buffer> {
-  const { promise, resolve, reject } = Promise.withResolvers<Buffer>();
-  const req = client.request({ ":path": "/" });
-  const chunks: Buffer[] = [];
-  req.on("data", (chunk: Buffer) => chunks.push(chunk));
-  req.on("end", () => resolve(Buffer.concat(chunks)));
-  req.on("error", reject);
-  req.end();
-  return promise;
+  return new Promise((resolve, reject) => {
+    const req = client.request({ ":path": "/" });
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function closeClient(client: http2.ClientHttp2Session): Promise<void> {
+  return new Promise(resolve => client.close(resolve));
+}
+
+function closeServer(server: http2.Http2Server): Promise<void> {
+  return new Promise(resolve => server.close(() => resolve()));
 }
 
 test("http2 client setLocalWindowSize sends connection-level WINDOW_UPDATE", async () => {
@@ -39,18 +49,20 @@ test("http2 client setLocalWindowSize sends connection-level WINDOW_UPDATE", asy
   const { port, server } = await startServer(payloadSize);
 
   try {
-    const client = http2.connect(`http://localhost:${port}`, {
+    const client = http2.connect(`http://127.0.0.1:${port}`, {
       settings: { initialWindowSize: 10 * 1024 * 1024 },
     });
 
+    // setLocalWindowSize requires the session handle to be ready
+    await once(client, "connect");
     client.setLocalWindowSize(10 * 1024 * 1024);
 
     const result = await doRequest(client);
-    expect(result.length).toBe(payloadSize);
+    assert.strictEqual(result.length, payloadSize);
 
-    client.close();
+    await closeClient(client);
   } finally {
-    server.close();
+    await closeServer(server);
   }
 });
 
@@ -59,15 +71,15 @@ test("http2 client initialWindowSize setting allows large stream payloads", asyn
   const { port, server } = await startServer(payloadSize);
 
   try {
-    const client = http2.connect(`http://localhost:${port}`, {
+    const client = http2.connect(`http://127.0.0.1:${port}`, {
       settings: { initialWindowSize: 10 * 1024 * 1024 },
     });
 
     const result = await doRequest(client);
-    expect(result.length).toBe(payloadSize);
+    assert.strictEqual(result.length, payloadSize);
 
-    client.close();
+    await closeClient(client);
   } finally {
-    server.close();
+    await closeServer(server);
   }
 });


### PR DESCRIPTION
## Summary

- `setLocalWindowSize()` updated the internal connection window size but never sent a `WINDOW_UPDATE` frame for stream 0 (connection level) to the peer
- Per RFC 9113 Section 6.9, `INITIAL_WINDOW_SIZE` only applies to stream-level windows; the connection-level window must be updated explicitly via `WINDOW_UPDATE`
- This caused HTTP/2 streams to stall after receiving 65,535 bytes (the default connection window), even when `setLocalWindowSize()` was called with a larger value

## Test plan

- [x] Added regression test `test/regression/issue/26915.test.ts` that streams 256 KB over HTTP/2 with an enlarged window
- [x] Verified test **fails** with system bun (times out at 65,535 bytes)
- [x] Verified test **passes** with debug build containing the fix

Closes #26915

🤖 Generated with [Claude Code](https://claude.com/claude-code)