### PR TITLE
fix(http): add missing header validation in appendHeader

### DIFF
--- a/src/js/node/_http_outgoing.ts
+++ b/src/js/node/_http_outgoing.ts
@@ -202,7 +202,11 @@ const OutgoingMessagePrototype = {
   _closed: false,
   _headerNames: undefined,
   appendHeader(name, value) {
-    validateString(name, "name");
+    if ((this._header !== undefined && this._header !== null) || this[headerStateSymbol] === NodeHTTPHeaderState.sent) {
+      throw $ERR_HTTP_HEADERS_SENT("append");
+    }
+    validateHeaderName(name);
+    validateHeaderValue(name, value);
     var headers = (this[headersSymbol] ??= new Headers());
     headers.append(name, value);
     return this;


### PR DESCRIPTION
## Summary
- `appendHeader` was only calling `validateString(name, "name")`, bypassing `validateHeaderName` (RFC 7230 HTTP token compliance) and `validateHeaderValue` (invalid character/CRLF/undefined checks) that `setHeader` properly uses
- Added `validateHeaderName(name)` and `validateHeaderValue(name, value)` calls to match `setHeader` and Node.js behavior
- Added missing headers-already-sent check (`ERR_HTTP_HEADERS_SENT`) consistent with `setHeader`

## Test plan
- [x] Added test `appendHeader validates header name and value like setHeader` that verifies:
  - Invalid header names (spaces, parens, empty, colon) throw `ERR_INVALID_HTTP_TOKEN`
  - Undefined values throw `ERR_HTTP_INVALID_HEADER_VALUE`
  - CRLF injection in values throws `ERR_INVALID_CHAR`
  - Null bytes in values throw `ERR_INVALID_CHAR`
  - Valid headers still work correctly
- [x] Added test `appendHeader throws after headers sent` that verifies `ERR_HTTP_HEADERS_SENT` after `write()`
- [x] Tests fail with `USE_SYSTEM_BUN=1` and pass with `bun bd test`
- [x] Existing `node-http.test.ts` suite passes (75/77, 1 skip, 1 pre-existing flaky proxy test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)