### PR TITLE
fix(shell): prevent heap buffer overflow in brace expansion with 256+ elements

### DIFF
--- a/src/shell/braces.zig
+++ b/src/shell/braces.zig
@@ -380,7 +380,7 @@ pub const Parser = struct {
 };
 
 pub fn calculateExpandedAmount(tokens: []const Token) u32 {
-    var nested_brace_stack = bun.SmallList(u8, MAX_NESTED_BRACES){};
+    var nested_brace_stack = bun.SmallList(u16, MAX_NESTED_BRACES){};
     defer nested_brace_stack.deinit(bun.default_allocator);
     var variant_count: u32 = 0;
     var prev_comma: bool = false;

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -54,4 +54,20 @@ describe("$.braces", () => {
     const result = $.braces(`lol {😂,🫵,🤣}`);
     expect(result).toEqual(["lol 😂", "lol 🫵", "lol 🤣"]);
   });
+
+  test("257 elements does not crash (u8 overflow regression)", () => {
+    // Regression test: calculateExpandedAmount used a u8 counter that would
+    // wrap at 256 elements, causing a heap buffer overflow in release builds.
+    const elements = Array.from({ length: 257 }, (_, i) => String(i)).join(",");
+    const result = $.braces(`{${elements}}`);
+    expect(result.length).toBe(257);
+    expect(result[0]).toBe("0");
+    expect(result[256]).toBe("256");
+  });
+
+  test("256 elements does not crash", () => {
+    const elements = Array.from({ length: 256 }, (_, i) => String(i)).join(",");
+    const result = $.braces(`{${elements}}`);
+    expect(result.length).toBe(256);
+  });
 });


### PR DESCRIPTION
## Summary

- Fix integer overflow in `calculateExpandedAmount` where a `u8` counter wraps at 256 elements, causing a heap buffer overflow in release builds
- Change `SmallList(u8, MAX_NESTED_BRACES)` to `SmallList(u16, MAX_NESTED_BRACES)` to match the `u16` width already used in `buildExpansionTable`
- Add regression tests for 256 and 257 element brace expansions

## Details

The `calculateExpandedAmount` function in `src/shell/braces.zig` used a `SmallList(u8, ...)` to count alternatives per brace group. When a brace expression like `{a,b,c,...}` contains 256+ comma-separated elements, the `u8` counter silently wraps to 0 in ReleaseFast builds (panics in debug builds). This causes the caller in `Expansion.zig` to allocate an undersized buffer, and the subsequent `expand()` call (which uses `u16` counters internally via `buildExpansionTable`) writes past the buffer boundary.

The fix is a one-character change: `u8` → `u16`, making the counter consistent with `buildExpansionTable`.

**Reproduction**: `$.braces("{0,1,2,...,256}")` with 257 elements crashes the process.

## Test plan

- [x] Verify crash with 257 elements before fix (confirmed: segfault in release, panic in debug)
- [x] Verify fix resolves the crash (`bun bd test test/js/bun/shell/brace.test.ts` — 9 tests pass)
- [x] Verify test fails with system bun (`USE_SYSTEM_BUN=1` — crashes as expected)
- [x] Existing brace expansion tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)