### PR TITLE
fix(server): sanitize Content-Disposition filename to prevent header injection

### DIFF
--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -2294,22 +2294,8 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                     const basename = std.fs.path.basename(filename);
                     if (basename.len > 0) {
                         var filename_buf: [1024]u8 = undefined;
-                        // Sanitize the basename to prevent header injection (CRLF)
-                        // and quote escaping. Strip \r, \n, and replace " with '.
-                        var sanitized_buf: [1024 - 32]u8 = undefined;
-                        const max_len = @min(basename.len, sanitized_buf.len);
-                        var sanitized_len: usize = 0;
-                        for (basename[0..max_len]) |c| {
-                            if (c != '\r' and c != '\n') {
-                                sanitized_buf[sanitized_len] = if (c == '"') '\'' else c;
-                                sanitized_len += 1;
-                            }
-                        }
-                        if (sanitized_len > 0) {
-                            resp.writeHeader(
-                                "content-disposition",
-                                std.fmt.bufPrint(&filename_buf, "filename=\"{s}\"", .{sanitized_buf[0..sanitized_len]}) catch "",
-                            );
+                        if (sanitizeForContentDisposition(basename, &filename_buf)) |value| {
+                            resp.writeHeader("content-disposition", value);
                         }
                     }
                 }
@@ -2347,6 +2333,25 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
 
         fn doWriteHeaders(this: *RequestContext, headers: *WebCore.FetchHeaders) void {
             writeHeaders(headers, ssl_enabled, this.resp);
+        }
+
+        /// Sanitize a filename for use in a Content-Disposition header value.
+        /// Strips \r and \n to prevent CRLF header injection, and replaces
+        /// double quotes with single quotes to prevent breaking out of the
+        /// filename="..." parameter. Returns the formatted header value, or
+        /// null if the sanitized name is empty.
+        fn sanitizeForContentDisposition(basename: []const u8, out: *[1024]u8) ?[]const u8 {
+            var sanitized_buf: [1024 - 32]u8 = undefined;
+            const max_len = @min(basename.len, sanitized_buf.len);
+            var sanitized_len: usize = 0;
+            for (basename[0..max_len]) |c| {
+                if (c != '\r' and c != '\n') {
+                    sanitized_buf[sanitized_len] = if (c == '"') '\'' else c;
+                    sanitized_len += 1;
+                }
+            }
+            if (sanitized_len == 0) return null;
+            return std.fmt.bufPrint(out, "filename=\"{s}\"", .{sanitized_buf[0..sanitized_len]}) catch null;
         }
 
         pub fn renderBytes(this: *RequestContext) void {

--- a/test/regression/issue/26959.test.ts
+++ b/test/regression/issue/26959.test.ts
@@ -47,11 +47,10 @@ test("Content-Disposition header injection via quotes in File name", async () =>
   if (contentDisposition) {
     expect(contentDisposition).not.toContain("\r");
     expect(contentDisposition).not.toContain("\n");
-    // The inner filename value should not contain unescaped double quotes
-    const match = contentDisposition.match(/^filename="(.*)"$/);
-    if (match) {
-      expect(match[1]).not.toContain('"');
-    }
+    // The filename parameter value should not contain unescaped double quotes
+    const match = contentDisposition.match(/filename="([^"]*)"/);
+    expect(match).not.toBeNull();
+    expect(match![1]).not.toContain('"');
   }
 
   expect(body).toBe("hello");

--- a/test/regression/issue/header-injection-content-disposition.test.ts
+++ b/test/regression/issue/header-injection-content-disposition.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { tempDir } from "harness";
 
 test("Content-Disposition header injection via CRLF in File name", async () => {
   await using server = Bun.serve({
@@ -57,12 +58,10 @@ test("Content-Disposition header injection via quotes in File name", async () =>
 });
 
 test("Content-Disposition header injection via Bun.file with crafted path", async () => {
-  // Create a file with CRLF in the name on the filesystem (Linux allows this)
-  const fs = await import("fs");
-  const os = await import("os");
-  const tmpDir = fs.mkdtempSync(os.tmpdir() + "/bun-test-crlf-");
+  // Create a temp dir, then add a file with CRLF in its name (Linux allows this)
+  using dir = tempDir("crlf-filename", {});
   const maliciousFilename = "evil.bin\r\nX-Injected: true";
-  const filePath = tmpDir + "/" + maliciousFilename;
+  const filePath = `${dir}/${maliciousFilename}`;
 
   let fileCreated = false;
   try {

--- a/test/regression/issue/header-injection-content-disposition.test.ts
+++ b/test/regression/issue/header-injection-content-disposition.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "bun:test";
+
+test("Content-Disposition header injection via CRLF in File name", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    fetch() {
+      // The File name contains a CRLF sequence that could inject a header.
+      // Use application/octet-stream so autosetFilename() returns true.
+      const maliciousName = "evil.bin\r\nX-Injected: true";
+      const file = new File(["hello"], maliciousName, { type: "application/octet-stream" });
+      return new Response(file);
+    },
+  });
+
+  const response = await fetch(server.url);
+  const body = await response.text();
+
+  // The injected header must NOT appear
+  expect(response.headers.get("X-Injected")).toBeNull();
+
+  // The Content-Disposition header must not contain CRLF
+  const contentDisposition = response.headers.get("content-disposition");
+  if (contentDisposition) {
+    expect(contentDisposition).not.toContain("\r");
+    expect(contentDisposition).not.toContain("\n");
+  }
+
+  expect(body).toBe("hello");
+});
+
+test("Content-Disposition header injection via quotes in File name", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    fetch() {
+      // The File name contains quotes that could break out of filename=""
+      const maliciousName = 'evil.bin" ; malicious="true';
+      const file = new File(["hello"], maliciousName, { type: "application/octet-stream" });
+      return new Response(file);
+    },
+  });
+
+  const response = await fetch(server.url);
+  const body = await response.text();
+
+  const contentDisposition = response.headers.get("content-disposition");
+  if (contentDisposition) {
+    expect(contentDisposition).not.toContain("\r");
+    expect(contentDisposition).not.toContain("\n");
+    // The inner filename value should not contain unescaped double quotes
+    const match = contentDisposition.match(/^filename="(.*)"$/);
+    if (match) {
+      expect(match[1]).not.toContain('"');
+    }
+  }
+
+  expect(body).toBe("hello");
+});
+
+test("Content-Disposition header injection via Bun.file with crafted path", async () => {
+  // Create a file with CRLF in the name on the filesystem (Linux allows this)
+  const fs = await import("fs");
+  const os = await import("os");
+  const tmpDir = fs.mkdtempSync(os.tmpdir() + "/bun-test-crlf-");
+  const maliciousFilename = "evil.bin\r\nX-Injected: true";
+  const filePath = tmpDir + "/" + maliciousFilename;
+
+  let fileCreated = false;
+  try {
+    await Bun.write(filePath, "hello from file");
+    fileCreated = true;
+  } catch {
+    // Some filesystems may not support CRLF in filenames
+    console.log("Skipping Bun.file test - filesystem does not support CRLF in filenames");
+  }
+
+  if (fileCreated) {
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(Bun.file(filePath));
+      },
+    });
+
+    const response = await fetch(server.url);
+    const body = await response.text();
+
+    // The injected header must NOT appear
+    expect(response.headers.get("X-Injected")).toBeNull();
+
+    const contentDisposition = response.headers.get("content-disposition");
+    if (contentDisposition) {
+      expect(contentDisposition).not.toContain("\r");
+      expect(contentDisposition).not.toContain("\n");
+    }
+
+    expect(body).toBe("hello from file");
+  }
+});


### PR DESCRIPTION
## Summary

- Sanitize filenames used in auto-generated `Content-Disposition` headers to prevent HTTP header injection via CRLF sequences and quote escaping
- Strip `\r` and `\n` characters and replace `"` with `'` in the basename before interpolating into the header value
- The vulnerability allowed injecting arbitrary HTTP headers when serving files with crafted names via `Bun.file()` or `new File()` responses

## Details

When Bun's HTTP server returns a `Bun.file()` or `new File()` object as a response body, it auto-generates a `Content-Disposition` header using `std.fmt.bufPrint` with the `{s}` format specifier, which outputs bytes verbatim. On Linux, filenames can contain any byte except `/` and null, including `\r\n`. This allowed:

1. **CRLF injection**: A filename like `evil.bin\r\nX-Injected: true` would inject an `X-Injected: true` header
2. **Quote escaping**: A filename like `evil.bin" ; malicious="true` could break out of the `filename=""` value

The auto-generated header bypassed the `FetchHeaders` validation (`isValidHTTPHeaderValue`) that protects user-set headers.

## Test plan

- [x] New test: `test/regression/issue/header-injection-content-disposition.test.ts`
  - CRLF injection via `new File()` constructor name
  - Quote escaping via `new File()` constructor name
  - CRLF injection via `Bun.file()` with crafted filesystem path
- [x] Tests fail with `USE_SYSTEM_BUN=1` (vulnerability confirmed)
- [x] Tests pass with `bun bd test` (fix confirmed)
- [x] Existing `bun-serve-file.test.ts` (41 tests) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)