### PR TITLE
fix(debugger): use crypto.randomUUID() for WebSocket auth token

### DIFF
--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -591,7 +591,7 @@ function parseUrl(input: string): URL {
 }
 
 function randomId() {
-  return Math.random().toString(36).slice(2);
+  return crypto.randomUUID();
 }
 
 const { enableANSIColors } = Bun;

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -9,7 +9,7 @@ import { InspectorSession, JUnitReporter, connect } from "./junit-reporter";
 import { SocketFramer } from "./socket-framer";
 let inspectee: Subprocess;
 const anyPort = expect.stringMatching(/^\d+$/);
-const anyPathname = expect.stringMatching(/^\/[a-z0-9]+$/);
+const anyPathname = expect.stringMatching(/^\/[a-f0-9-]+$/);
 
 /**
  * Get a function that creates a random `.sock` file in the specified temporary directory.


### PR DESCRIPTION
## Summary
- Replace `Math.random().toString(36).slice(2)` with `crypto.randomUUID()` for generating the debugger WebSocket path token in `src/js/internal/debugger.ts`
- `Math.random()` is not cryptographically secure — a local attacker (or DNS rebinding attack) could predict the token and connect to the debugger WebSocket to execute arbitrary code via Chrome DevTools Protocol
- This is the same class of vulnerability as Node.js [CVE-2018-7160](https://nvd.nist.gov/vuln/detail/CVE-2018-7160), which Node.js fixed by switching to `crypto.randomUUID()`
- Updated the `anyPathname` regex in `test/cli/inspect/inspect.test.ts` to match UUID format

## Test plan
- [x] Verified `bun bd` builds successfully
- [x] Verified debugger output now shows UUID token: `ws://localhost:37733/d724df93-7bb3-4f50-b0a5-dd135e2020e1`
- [x] Verified existing inspector tests pass (`test/js/node/inspector/inspector.test.ts` — 5/5 pass)
- [x] Verified unix socket inspect tests pass (`test/cli/inspect/inspect.test.ts` unix tests — 4/4 pass)
- [x] Confirmed websocket test failures in `test/cli/inspect/inspect.test.ts` are pre-existing and unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)