### PR TITLE
fix(valkey): enforce max nesting depth in RESP parser to prevent stack overflow

### DIFF
--- a/test/regression/issue/5928.test.ts
+++ b/test/regression/issue/5928.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Test for security issue: ValkeyReader.readValue() unbounded recursion
+// A malicious Redis/Valkey server can send deeply nested RESP structures
+// that exhaust the call stack and crash the Bun process via stack overflow.
+
+test("valkey RESP parser should reject deeply nested responses", async () => {
+  // Create a malicious server that sends deeply nested RESP arrays
+  // Each "*1\r\n" is a RESP array of length 1, nesting into the next level
+  const nestingDepth = 100_000;
+
+  using server = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open(socket) {
+        // Do nothing on open - wait for data
+      },
+      data(socket, data) {
+        const request = Buffer.from(data).toString();
+
+        // Respond to HELLO (RESP3 protocol negotiation) with a simple OK
+        if (request.includes("HELLO")) {
+          socket.write("+OK\r\n");
+          return;
+        }
+
+        // For any other command (e.g., GET), send a deeply nested RESP array
+        // *1\r\n repeated nestingDepth times, then a leaf value
+        let response = "";
+        for (let i = 0; i < nestingDepth; i++) {
+          response += "*1\r\n";
+        }
+        response += "$3\r\nfoo\r\n";
+        socket.write(response);
+      },
+      close() {},
+      error(socket, err) {},
+    },
+  });
+
+  const port = server.port;
+
+  // Use a subprocess so a crash doesn't take down the test runner
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const client = new Bun.RedisClient("redis://127.0.0.1:${port}");
+      try {
+        const result = await client.send("GET", ["test"]);
+        // If we get here without crashing, the parser handled it
+        console.log("RESULT:" + JSON.stringify(result));
+      } catch (e) {
+        console.log("ERROR:" + e.message);
+      } finally {
+        client.close();
+      }
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The process should NOT crash (exit code 0 or a handled error)
+  // Before the fix: process crashes with stack overflow (signal 11/SIGSEGV or similar)
+  // After the fix: parser returns an error about nesting depth exceeded
+  if (exitCode !== 0) {
+    console.log("stdout:", stdout);
+    console.log("stderr:", stderr);
+    console.log("exitCode:", exitCode);
+  }
+  expect(stdout).toContain("ERROR:");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Adds a maximum nesting depth limit (64) to the Valkey RESP protocol parser's `readValue()` function to prevent stack overflow from maliciously crafted deeply-nested responses
- Adds a `NestingTooDeep` error to `RedisError` that surfaces as `REDIS_INVALID_RESPONSE` to JS callers
- The depth check applies to all recursive RESP types: Array, Map, Set, Attribute, and Push

## Details

The `ValkeyReader.readValue()` function was recursive with no depth limit. A malicious Redis/Valkey server could send deeply nested RESP structures (e.g., `*1\r\n` repeated 100,000 times) to exhaust the call stack with a single small response (~few hundred KB of wire data), causing a SIGSEGV that terminates the entire Bun process.

The fix introduces a private `readValueDepth()` helper that tracks the current recursion depth. When depth reaches 64, the parser returns `error.NestingTooDeep` instead of recursing further. The public `readValue()` API is unchanged — it simply calls `readValueDepth()` with an initial depth of 0.

A depth limit of 64 is far beyond any legitimate Redis/Valkey use case while preventing stack exhaustion.

## Test plan

- [x] Added regression test (`test/regression/issue/5928.test.ts`) that spins up a mock malicious server sending 100,000 levels of nested RESP arrays
- [x] Verified the test **crashes with SIGSEGV (exit code 139)** on unpatched `bun` (`USE_SYSTEM_BUN=1`)
- [x] Verified the test **passes** (graceful error, exit code 0) with `bun bd test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)