### PR TITLE
fix(s3): reject CRLF characters in header values to prevent header injection

### DIFF
--- a/src/s3/credentials.zig
+++ b/src/s3/credentials.zig
@@ -221,7 +221,11 @@ pub const S3Credentials = struct {
                             defer str.deref();
                             if (str.tag != .Empty and str.tag != .Dead) {
                                 new_credentials._contentDispositionSlice = str.toUTF8(bun.default_allocator);
-                                new_credentials.content_disposition = new_credentials._contentDispositionSlice.?.slice();
+                                const slice = new_credentials._contentDispositionSlice.?.slice();
+                                if (containsNewlineOrCR(slice)) {
+                                    return globalObject.throwInvalidArguments("contentDisposition must not contain newline characters (CR/LF)", .{});
+                                }
+                                new_credentials.content_disposition = slice;
                             }
                         } else {
                             return globalObject.throwInvalidArgumentTypeValue("contentDisposition", "string", js_value);
@@ -236,7 +240,11 @@ pub const S3Credentials = struct {
                             defer str.deref();
                             if (str.tag != .Empty and str.tag != .Dead) {
                                 new_credentials._contentTypeSlice = str.toUTF8(bun.default_allocator);
-                                new_credentials.content_type = new_credentials._contentTypeSlice.?.slice();
+                                const slice = new_credentials._contentTypeSlice.?.slice();
+                                if (containsNewlineOrCR(slice)) {
+                                    return globalObject.throwInvalidArguments("type must not contain newline characters (CR/LF)", .{});
+                                }
+                                new_credentials.content_type = slice;
                             }
                         } else {
                             return globalObject.throwInvalidArgumentTypeValue("type", "string", js_value);
@@ -251,7 +259,11 @@ pub const S3Credentials = struct {
                             defer str.deref();
                             if (str.tag != .Empty and str.tag != .Dead) {
                                 new_credentials._contentEncodingSlice = str.toUTF8(bun.default_allocator);
-                                new_credentials.content_encoding = new_credentials._contentEncodingSlice.?.slice();
+                                const slice = new_credentials._contentEncodingSlice.?.slice();
+                                if (containsNewlineOrCR(slice)) {
+                                    return globalObject.throwInvalidArguments("contentEncoding must not contain newline characters (CR/LF)", .{});
+                                }
+                                new_credentials.content_encoding = slice;
                             }
                         } else {
                             return globalObject.throwInvalidArgumentTypeValue("contentEncoding", "string", js_value);
@@ -1149,6 +1161,12 @@ const CanonicalRequest = struct {
         };
     }
 };
+
+/// Returns true if the given slice contains any CR (\r) or LF (\n) characters,
+/// which would allow HTTP header injection if used in a header value.
+fn containsNewlineOrCR(value: []const u8) bool {
+    return std.mem.indexOfAny(u8, value, "\r\n") != null;
+}
 
 const std = @import("std");
 const ACL = @import("./acl.zig").ACL;

--- a/test/regression/issue/s3-header-injection.test.ts
+++ b/test/regression/issue/s3-header-injection.test.ts
@@ -1,0 +1,148 @@
+import { S3Client } from "bun";
+import { describe, expect, test } from "bun:test";
+
+// Test that CRLF characters in S3 options are rejected to prevent header injection.
+// See: HTTP Header Injection via S3 Content-Disposition Value
+
+describe("S3 header injection prevention", () => {
+  test("contentDisposition with CRLF should throw", () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("OK", { status: 200 });
+      },
+    });
+
+    const client = new S3Client({
+      accessKeyId: "test-key",
+      secretAccessKey: "test-secret",
+      endpoint: server.url.href,
+      bucket: "test-bucket",
+    });
+
+    expect(() =>
+      client.write("test-file.txt", "Hello", {
+        contentDisposition: 'attachment; filename="evil"\r\nX-Injected: value',
+      }),
+    ).toThrow(/CR\/LF/);
+  });
+
+  test("contentEncoding with CRLF should throw", () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("OK", { status: 200 });
+      },
+    });
+
+    const client = new S3Client({
+      accessKeyId: "test-key",
+      secretAccessKey: "test-secret",
+      endpoint: server.url.href,
+      bucket: "test-bucket",
+    });
+
+    expect(() =>
+      client.write("test-file.txt", "Hello", {
+        contentEncoding: "gzip\r\nX-Injected: value",
+      }),
+    ).toThrow(/CR\/LF/);
+  });
+
+  test("type (content-type) with CRLF should throw", () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("OK", { status: 200 });
+      },
+    });
+
+    const client = new S3Client({
+      accessKeyId: "test-key",
+      secretAccessKey: "test-secret",
+      endpoint: server.url.href,
+      bucket: "test-bucket",
+    });
+
+    expect(() =>
+      client.write("test-file.txt", "Hello", {
+        type: "text/plain\r\nX-Injected: value",
+      }),
+    ).toThrow(/CR\/LF/);
+  });
+
+  test("contentDisposition with only CR should throw", () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("OK", { status: 200 });
+      },
+    });
+
+    const client = new S3Client({
+      accessKeyId: "test-key",
+      secretAccessKey: "test-secret",
+      endpoint: server.url.href,
+      bucket: "test-bucket",
+    });
+
+    expect(() =>
+      client.write("test-file.txt", "Hello", {
+        contentDisposition: "attachment\rinjected",
+      }),
+    ).toThrow(/CR\/LF/);
+  });
+
+  test("contentDisposition with only LF should throw", () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("OK", { status: 200 });
+      },
+    });
+
+    const client = new S3Client({
+      accessKeyId: "test-key",
+      secretAccessKey: "test-secret",
+      endpoint: server.url.href,
+      bucket: "test-bucket",
+    });
+
+    expect(() =>
+      client.write("test-file.txt", "Hello", {
+        contentDisposition: "attachment\ninjected",
+      }),
+    ).toThrow(/CR\/LF/);
+  });
+
+  test("valid contentDisposition without CRLF should not throw", async () => {
+    const { promise: requestReceived, resolve: onRequestReceived } = Promise.withResolvers<Headers>();
+
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        onRequestReceived(req.headers);
+        return new Response("OK", { status: 200 });
+      },
+    });
+
+    const client = new S3Client({
+      accessKeyId: "test-key",
+      secretAccessKey: "test-secret",
+      endpoint: server.url.href,
+      bucket: "test-bucket",
+    });
+
+    // Valid content-disposition values should not throw synchronously.
+    // The write may eventually fail because the mock server doesn't speak S3 protocol,
+    // but the option parsing should succeed and a request should be initiated.
+    expect(() =>
+      client.write("test-file.txt", "Hello", {
+        contentDisposition: 'attachment; filename="report.pdf"',
+      }),
+    ).not.toThrow();
+
+    const receivedHeaders = await requestReceived;
+    expect(receivedHeaders.get("content-disposition")).toBe('attachment; filename="report.pdf"');
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes HTTP header injection vulnerability in S3 client where user-controlled options (`contentDisposition`, `contentEncoding`, `type`) were passed to HTTP headers without CRLF validation
- Adds input validation at the JS-to-Zig boundary in `src/s3/credentials.zig` that throws a `TypeError` if `\r` or `\n` characters are detected
- An attacker could previously inject arbitrary headers (e.g. `X-Amz-Security-Token`) by embedding `\r\n` in these string fields

## Test plan

- [x] Added `test/regression/issue/s3-header-injection.test.ts` with 6 tests:
  - CRLF in `contentDisposition` throws
  - CRLF in `contentEncoding` throws
  - CRLF in `type` (content-type) throws
  - Lone CR in `contentDisposition` throws
  - Lone LF in `contentDisposition` throws
  - Valid `contentDisposition` without CRLF still works correctly
- [x] Tests fail with `USE_SYSTEM_BUN=1` (confirming vulnerability exists in current release)
- [x] Tests pass with `bun bd test` (confirming fix works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)