### PR TITLE
fix(crypto): encrypt serialized CryptoKey material with per-process AES key

### DIFF
--- a/src/bun.js/bindings/ScriptExecutionContext.cpp
+++ b/src/bun.js/bindings/ScriptExecutionContext.cpp
@@ -9,6 +9,10 @@
 #include "EventLoopTask.h"
 #include "BunBroadcastChannelRegistry.h"
 #include <wtf/LazyRef.h>
+
+#if ENABLE(WEB_CRYPTO)
+#include "SerializedCryptoKeyWrap.h"
+#endif
 extern "C" void Bun__startLoop(us_loop_t* loop);
 
 namespace WebCore {
@@ -395,5 +399,23 @@ extern "C" JSC::JSGlobalObject* ScriptExecutionContextIdentifier__getGlobalObjec
     if (!context) return nullptr;
     return context->globalObject();
 }
+
+#if ENABLE(WEB_CRYPTO)
+bool ScriptExecutionContext::wrapCryptoKey(const Vector<uint8_t>& key, Vector<uint8_t>& wrappedKey)
+{
+    auto masterKey = defaultWebCryptoMasterKey();
+    if (!masterKey)
+        return false;
+    return wrapSerializedCryptoKey(*masterKey, key, wrappedKey);
+}
+
+bool ScriptExecutionContext::unwrapCryptoKey(const Vector<uint8_t>& wrappedKey, Vector<uint8_t>& key)
+{
+    auto masterKey = defaultWebCryptoMasterKey();
+    if (!masterKey)
+        return false;
+    return unwrapSerializedCryptoKey(*masterKey, wrappedKey, key);
+}
+#endif
 
 } // namespace WebCore

--- a/src/bun.js/bindings/ScriptExecutionContext.h
+++ b/src/bun.js/bindings/ScriptExecutionContext.h
@@ -94,15 +94,11 @@ public:
     // }
 
 #if ENABLE(WEB_CRYPTO)
-    // These two methods are used when CryptoKeys are serialized into IndexedDB. As a side effect, it is also
-    // used for things that utilize the same structure clone algorithm, for example, message passing between
-    // worker and document.
-
-    // For now these will return false. In the future, we will want to implement these similar to how WorkerGlobalScope.cpp does.
-    // virtual bool wrapCryptoKey(const Vector<uint8_t>& key, Vector<uint8_t>& wrappedKey) = 0;
-    // virtual bool unwrapCryptoKey(const Vector<uint8_t>& wrappedKey, Vector<uint8_t>& key) = 0;
-    bool wrapCryptoKey(const Vector<uint8_t>& key, Vector<uint8_t>& wrappedKey) { return false; }
-    bool unwrapCryptoKey(const Vector<uint8_t>& wrappedKey, Vector<uint8_t>& key) { return false; }
+    // These two methods are used when CryptoKeys are serialized via the structured clone algorithm,
+    // including structuredClone(), postMessage to workers, and IndexedDB storage.
+    // They wrap/unwrap the serialized key material using a per-process AES master key.
+    bool wrapCryptoKey(const Vector<uint8_t>& key, Vector<uint8_t>& wrappedKey);
+    bool unwrapCryptoKey(const Vector<uint8_t>& wrappedKey, Vector<uint8_t>& key);
 #endif
 
     WEBCORE_EXPORT static bool postTaskTo(ScriptExecutionContextIdentifier identifier, Function<void(ScriptExecutionContext&)>&& task);

--- a/test/js/web/crypto/cryptokey-serialization.test.ts
+++ b/test/js/web/crypto/cryptokey-serialization.test.ts
@@ -1,0 +1,113 @@
+import { deserialize, serialize } from "bun:jsc";
+import { describe, expect, test } from "bun:test";
+
+describe("CryptoKey serialization", () => {
+  test("structuredClone preserves AES-GCM key", async () => {
+    const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, ["encrypt", "decrypt"]);
+    const cloned = structuredClone(key);
+
+    const original = new Uint8Array(await crypto.subtle.exportKey("raw", key));
+    const clonedExport = new Uint8Array(await crypto.subtle.exportKey("raw", cloned));
+
+    expect(Buffer.from(clonedExport)).toEqual(Buffer.from(original));
+  });
+
+  test("structuredClone preserves HMAC key", async () => {
+    const key = await crypto.subtle.generateKey({ name: "HMAC", hash: "SHA-256" }, true, ["sign", "verify"]);
+    const cloned = structuredClone(key);
+
+    const original = new Uint8Array(await crypto.subtle.exportKey("raw", key));
+    const clonedExport = new Uint8Array(await crypto.subtle.exportKey("raw", cloned));
+
+    expect(Buffer.from(clonedExport)).toEqual(Buffer.from(original));
+  });
+
+  test("structuredClone preserves RSA-OAEP key pair", async () => {
+    const keyPair = await crypto.subtle.generateKey(
+      { name: "RSA-OAEP", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
+      true,
+      ["encrypt", "decrypt"],
+    );
+
+    const clonedPrivate = structuredClone(keyPair.privateKey);
+    const clonedPublic = structuredClone(keyPair.publicKey);
+
+    const origPrivate = new Uint8Array(await crypto.subtle.exportKey("pkcs8", keyPair.privateKey));
+    const clonedPrivateExport = new Uint8Array(await crypto.subtle.exportKey("pkcs8", clonedPrivate));
+
+    const origPublic = new Uint8Array(await crypto.subtle.exportKey("spki", keyPair.publicKey));
+    const clonedPublicExport = new Uint8Array(await crypto.subtle.exportKey("spki", clonedPublic));
+
+    expect(Buffer.from(clonedPrivateExport)).toEqual(Buffer.from(origPrivate));
+    expect(Buffer.from(clonedPublicExport)).toEqual(Buffer.from(origPublic));
+  });
+
+  test("structuredClone preserves ECDSA key pair", async () => {
+    const keyPair = await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, ["sign", "verify"]);
+
+    const clonedPrivate = structuredClone(keyPair.privateKey);
+    const origPrivate = new Uint8Array(await crypto.subtle.exportKey("pkcs8", keyPair.privateKey));
+    const clonedPrivateExport = new Uint8Array(await crypto.subtle.exportKey("pkcs8", clonedPrivate));
+
+    expect(Buffer.from(clonedPrivateExport)).toEqual(Buffer.from(origPrivate));
+  });
+
+  test("structuredClone preserves non-extractable key usages and algorithm", async () => {
+    const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 128 }, false, ["encrypt"]);
+    const cloned = structuredClone(key);
+
+    expect(cloned.extractable).toBe(false);
+    expect(cloned.algorithm.name).toBe("AES-GCM");
+    expect((cloned.algorithm as AesKeyAlgorithm).length).toBe(128);
+    expect(cloned.usages).toEqual(["encrypt"]);
+  });
+
+  test("bun:jsc serialize/deserialize round-trips AES key", async () => {
+    const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, ["encrypt", "decrypt"]);
+    const serialized = serialize(key);
+    const deserialized = deserialize(serialized) as CryptoKey;
+
+    const original = new Uint8Array(await crypto.subtle.exportKey("raw", key));
+    const restored = new Uint8Array(await crypto.subtle.exportKey("raw", deserialized));
+
+    expect(Buffer.from(restored)).toEqual(Buffer.from(original));
+  });
+
+  test("serialized CryptoKey data is wrapped (raw key bytes not present in serialized form)", async () => {
+    const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, ["encrypt", "decrypt"]);
+
+    const rawKeyBytes = new Uint8Array(await crypto.subtle.exportKey("raw", key));
+    const rawHex = Buffer.from(rawKeyBytes).toString("hex");
+
+    const serialized = serialize(key);
+    const serializedHex = Buffer.from(serialized).toString("hex");
+
+    // The raw key bytes should NOT appear verbatim in the serialized data
+    // because the wrapping function encrypts them with a per-process master key.
+    expect(serializedHex.includes(rawHex)).toBe(false);
+  });
+
+  test("cloned key can be used for encrypt/decrypt", async () => {
+    const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, ["encrypt", "decrypt"]);
+    const cloned = structuredClone(key);
+
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const plaintext = new TextEncoder().encode("Hello, World!");
+
+    const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, plaintext);
+    const decrypted = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, cloned, ciphertext);
+
+    expect(new Uint8Array(decrypted)).toEqual(plaintext);
+  });
+
+  test("cloned HMAC key can be used for sign/verify", async () => {
+    const key = await crypto.subtle.generateKey({ name: "HMAC", hash: "SHA-256" }, true, ["sign", "verify"]);
+    const cloned = structuredClone(key);
+
+    const data = new TextEncoder().encode("test data");
+    const signature = await crypto.subtle.sign("HMAC", key, data);
+    const valid = await crypto.subtle.verify("HMAC", cloned, signature, data);
+
+    expect(valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Implement actual AES key wrapping (RFC 5649) for serialized CryptoKey material, replacing the no-op wrap/unwrap functions inherited from WebKit's OpenSSL port
- Generate a per-process 256-bit random master key via `RAND_bytes` and use `AES_wrap_key_padded`/`AES_unwrap_key_padded` to encrypt/decrypt key material during structured clone serialization
- Enable the previously commented-out `wrapCryptoKey`/`unwrapCryptoKey` calls in `SerializedScriptValue.cpp` and wire them through `ScriptExecutionContext`

## Background

The `wrapSerializedCryptoKey` and `unwrapSerializedCryptoKey` functions in `SerializedCryptoKeyWrapOpenSSL.cpp` were no-ops that simply copied raw key bytes unchanged (inherited from WebKit bug [#173883](https://bugs.webkit.org/show_bug.cgi?id=173883)). This meant when `CryptoKey` objects were serialized via `structuredClone()` or `postMessage()`, the private key material was stored in plaintext in the serialized buffer, potentially exposable through logs, crash dumps, or accidental persistence.

## Changes

| File | Change |
|------|--------|
| `SerializedCryptoKeyWrapOpenSSL.cpp` | Implement `defaultWebCryptoMasterKey()` with per-process 256-bit random key; implement `wrapSerializedCryptoKey`/`unwrapSerializedCryptoKey` using RFC 5649 padded AES key wrap |
| `ScriptExecutionContext.h/.cpp` | Wire `wrapCryptoKey`/`unwrapCryptoKey` methods to call through to the wrap functions with the master key |
| `SerializedScriptValue.cpp` | Enable wrapping on serialization and unwrapping on deserialization (previously commented out) |

## Test plan

- [x] New test: `test/js/web/crypto/cryptokey-serialization.test.ts` (9 tests)
  - AES-GCM, HMAC, RSA-OAEP, ECDSA keys survive `structuredClone()` round-trip
  - Non-extractable key preserves usages and algorithm
  - `bun:jsc` `serialize`/`deserialize` round-trip works
  - **Raw key bytes do NOT appear in serialized form** (the key security assertion)
  - Cloned keys function correctly for encrypt/decrypt and sign/verify
- [x] Verified the security test **fails on system Bun** (raw bytes present) and **passes with fix** (raw bytes encrypted)
- [x] All existing structured-clone tests pass (118 tests)
- [x] All existing web-crypto tests pass (6 tests)
- [x] All structuredClone-classes tests pass (57 tests)
- [x] All structured-clone blob/file tests pass (24 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)