### PR TITLE
fix(websocket): validate Sec-WebSocket-Accept header per RFC 6455

### DIFF
--- a/src/http/websocket_client/WebSocketUpgradeClient.zig
+++ b/src/http/websocket_client/WebSocketUpgradeClient.zig
@@ -43,6 +43,10 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
         state: State = .initializing,
         subprotocols: bun.StringSet,
 
+        /// Expected Sec-WebSocket-Accept value for RFC 6455 handshake validation.
+        /// This is SHA-1(Sec-WebSocket-Key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11") base64-encoded (always 28 bytes).
+        expected_accept: [28]u8 = undefined,
+
         /// Proxy state (null when not using proxy)
         proxy: ?WebSocketProxy = null,
 
@@ -133,7 +137,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 }
             }
 
-            const body = buildRequestBody(
+            const build_result = buildRequestBody(
                 vm,
                 pathname,
                 ssl,
@@ -143,6 +147,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 extra_headers,
                 if (target_authorization) |auth| auth.slice() else null,
             ) catch return null;
+            const body = build_result.body;
 
             // Build proxy state if using proxy
             // The CONNECT request is built using local variables for proxy_authorization and proxy_headers
@@ -209,6 +214,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 .input_body_buf = if (using_proxy) connect_request else body,
                 .state = .initializing,
                 .proxy = proxy_state,
+                .expected_accept = build_result.expected_accept,
                 .subprotocols = brk: {
                     var subprotocols = bun.StringSet.init(bun.default_allocator);
                     var it = bun.http.HeaderValueIterator.init(protocol_for_subprotocols.slice());
@@ -923,7 +929,10 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 return;
             }
 
-            // TODO: check websocket_accept_header.value
+            if (!strings.eql(websocket_accept_header.value, &this.expected_accept)) {
+                this.terminate(ErrorCode.mismatch_websocket_accept_header);
+                return;
+            }
 
             const overflow_len = remain_buf.len;
             var overflow: []u8 = &.{};
@@ -1165,6 +1174,11 @@ fn buildConnectRequest(
     return buf.toOwnedSlice();
 }
 
+const BuildRequestResult = struct {
+    body: []u8,
+    expected_accept: [28]u8,
+};
+
 fn buildRequestBody(
     vm: *jsc.VirtualMachine,
     pathname: *const jsc.ZigString,
@@ -1174,7 +1188,7 @@ fn buildRequestBody(
     client_protocol: *const jsc.ZigString,
     extra_headers: NonUTF8Headers,
     target_authorization: ?[]const u8,
-) std.mem.Allocator.Error![]u8 {
+) std.mem.Allocator.Error!BuildRequestResult {
     const allocator = vm.allocator;
 
     // Check for user overrides
@@ -1221,6 +1235,17 @@ fn buildRequestBody(
         // Generate a new key if user key is invalid or not provided
         break :blk std.base64.standard.Encoder.encode(&encoded_buf, &vm.rareData().nextUUID().bytes);
     };
+
+    // Compute the expected Sec-WebSocket-Accept value per RFC 6455 Section 4.2.2:
+    // Base64(SHA-1(Sec-WebSocket-Key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+    const websocket_guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+    var sha1 = std.crypto.hash.Sha1.init(.{});
+    sha1.update(key);
+    sha1.update(websocket_guid);
+    const sha1_digest = sha1.finalResult();
+    var expected_accept: [28]u8 = undefined;
+    _ = std.base64.standard.Encoder.encode(&expected_accept, &sha1_digest);
+
     const protocol = if (user_protocol) |p| p.slice() else client_protocol.slice();
 
     const pathname_ = pathname.toSlice(allocator);
@@ -1273,7 +1298,26 @@ fn buildRequestBody(
 
     // Build request with user overrides
     if (user_host) |h| {
-        return try std.fmt.allocPrint(
+        return .{
+            .body = try std.fmt.allocPrint(
+                allocator,
+                "GET {s} HTTP/1.1\r\n" ++
+                    "Host: {f}\r\n" ++
+                    "Connection: Upgrade\r\n" ++
+                    "Upgrade: websocket\r\n" ++
+                    "Sec-WebSocket-Version: 13\r\n" ++
+                    "Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits\r\n" ++
+                    "{f}" ++
+                    "{s}" ++
+                    "\r\n",
+                .{ pathname_.slice(), h, pico_headers, extra_headers_buf.items },
+            ),
+            .expected_accept = expected_accept,
+        };
+    }
+
+    return .{
+        .body = try std.fmt.allocPrint(
             allocator,
             "GET {s} HTTP/1.1\r\n" ++
                 "Host: {f}\r\n" ++
@@ -1284,23 +1328,10 @@ fn buildRequestBody(
                 "{f}" ++
                 "{s}" ++
                 "\r\n",
-            .{ pathname_.slice(), h, pico_headers, extra_headers_buf.items },
-        );
-    }
-
-    return try std.fmt.allocPrint(
-        allocator,
-        "GET {s} HTTP/1.1\r\n" ++
-            "Host: {f}\r\n" ++
-            "Connection: Upgrade\r\n" ++
-            "Upgrade: websocket\r\n" ++
-            "Sec-WebSocket-Version: 13\r\n" ++
-            "Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits\r\n" ++
-            "{f}" ++
-            "{s}" ++
-            "\r\n",
-        .{ pathname_.slice(), host_fmt, pico_headers, extra_headers_buf.items },
-    );
+            .{ pathname_.slice(), host_fmt, pico_headers, extra_headers_buf.items },
+        ),
+        .expected_accept = expected_accept,
+    };
 }
 
 const log = Output.scoped(.WebSocketUpgradeClient, .visible);

--- a/test/js/web/websocket/websocket-accept-validation.test.ts
+++ b/test/js/web/websocket/websocket-accept-validation.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, mock } from "bun:test";
+import crypto from "node:crypto";
+import net from "node:net";
+
+describe("WebSocket Sec-WebSocket-Accept validation (RFC 6455 Section 4.1)", () => {
+  function computeAcceptKey(websocketKey: string): string {
+    return crypto
+      .createHash("sha1")
+      .update(websocketKey + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+      .digest("base64");
+  }
+
+  async function createFakeServer(
+    getAcceptKey: (clientKey: string) => string,
+  ): Promise<{ port: number; [Symbol.asyncDispose]: () => Promise<void> }> {
+    const server = net.createServer();
+    let port: number;
+
+    await new Promise<void>(resolve => {
+      server.listen(0, () => {
+        port = (server.address() as any).port;
+        resolve();
+      });
+    });
+
+    server.on("connection", socket => {
+      let requestData = "";
+
+      socket.on("data", data => {
+        requestData += data.toString();
+
+        if (requestData.includes("\r\n\r\n")) {
+          const lines = requestData.split("\r\n");
+          let websocketKey = "";
+
+          for (const line of lines) {
+            if (line.startsWith("Sec-WebSocket-Key:")) {
+              websocketKey = line.split(":")[1].trim();
+              break;
+            }
+          }
+
+          const acceptKey = getAcceptKey(websocketKey);
+
+          const response = [
+            "HTTP/1.1 101 Switching Protocols",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            `Sec-WebSocket-Accept: ${acceptKey}`,
+            "\r\n",
+          ].join("\r\n");
+
+          socket.write(response);
+        }
+      });
+    });
+
+    return {
+      port: port!,
+      [Symbol.asyncDispose]: async () => {
+        server.close();
+      },
+    };
+  }
+
+  it("should accept valid Sec-WebSocket-Accept header", async () => {
+    await using server = await createFakeServer(key => computeAcceptKey(key));
+
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const ws = new WebSocket(`ws://localhost:${server.port}`);
+
+    ws.onopen = () => resolve(undefined);
+    ws.onerror = () => reject(new Error("connection failed"));
+
+    await promise;
+    ws.close();
+  });
+
+  it("should reject invalid Sec-WebSocket-Accept header", async () => {
+    // Server returns a completely wrong accept key
+    await using server = await createFakeServer(_key => "dGhlIHNhbXBsZSBub25jZQ==");
+
+    const { promise, resolve } = Promise.withResolvers<{ code: number; reason: string }>();
+    const onopenMock = mock(() => {});
+
+    const ws = new WebSocket(`ws://localhost:${server.port}`);
+    ws.onopen = onopenMock;
+    ws.onclose = event => {
+      resolve({ code: event.code, reason: event.reason });
+    };
+
+    const result = await promise;
+    expect(onopenMock).not.toHaveBeenCalled();
+    expect(result.code).toBe(1002);
+    expect(result.reason).toBe("Mismatch websocket accept header");
+  });
+
+  it("should reject empty Sec-WebSocket-Accept value", async () => {
+    // Server returns an empty accept key
+    await using server = await createFakeServer(_key => "");
+
+    const { promise, resolve } = Promise.withResolvers<{ code: number; reason: string }>();
+    const onopenMock = mock(() => {});
+
+    const ws = new WebSocket(`ws://localhost:${server.port}`);
+    ws.onopen = onopenMock;
+    ws.onclose = event => {
+      resolve({ code: event.code, reason: event.reason });
+    };
+
+    const result = await promise;
+    expect(onopenMock).not.toHaveBeenCalled();
+    // Empty value should be caught by either the missing header check or the accept validation
+    expect(result.code).toBe(1002);
+  });
+
+  it("should reject Sec-WebSocket-Accept with wrong key computation", async () => {
+    // Server computes accept from a different key (simulating MitM)
+    await using server = await createFakeServer(_key => {
+      // Compute valid accept but for a different (attacker-chosen) key
+      return computeAcceptKey("AAAAAAAAAAAAAAAAAAAAAA==");
+    });
+
+    const { promise, resolve } = Promise.withResolvers<{ code: number; reason: string }>();
+    const onopenMock = mock(() => {});
+
+    const ws = new WebSocket(`ws://localhost:${server.port}`);
+    ws.onopen = onopenMock;
+    ws.onclose = event => {
+      resolve({ code: event.code, reason: event.reason });
+    };
+
+    const result = await promise;
+    expect(onopenMock).not.toHaveBeenCalled();
+    expect(result.code).toBe(1002);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes a security issue where the WebSocket upgrade client checked that the `Sec-WebSocket-Accept` header was **present** but never validated its **value** against the expected SHA-1 hash per RFC 6455 Section 4.1
- A MitM attacker could fake a WebSocket handshake by responding with any arbitrary `Sec-WebSocket-Accept` value, allowing them to intercept and inject WebSocket traffic
- The fix computes `Base64(SHA-1(Sec-WebSocket-Key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))` during request construction, stores it on the client struct, and validates it against the server's response during the upgrade handshake

## Changes

- Added `expected_accept: [28]u8` field to the `HTTPClient` struct to store the pre-computed expected accept value
- Modified `buildRequestBody` to return both the HTTP body and the expected accept hash via `BuildRequestResult` struct
- Replaced the `// TODO: check websocket_accept_header.value` comment with actual validation using `strings.eql`
- Uses the already-defined `ErrorCode.mismatch_websocket_accept_header` (close code 1002) on validation failure

## Test plan

- [x] New test: `test/js/web/websocket/websocket-accept-validation.test.ts` with 4 test cases:
  - Valid accept header (should connect successfully)
  - Invalid/arbitrary accept value (should reject with code 1002)
  - Empty accept value (should reject)
  - Accept computed from wrong key / MitM scenario (should reject with code 1002)
- [x] Tests fail with `USE_SYSTEM_BUN=1` (confirming vulnerability exists in current release)
- [x] Tests pass with `bun bd test` (confirming the fix works)
- [x] All existing WebSocket tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)