### PR TITLE
fix(s3): reject CRLF characters in S3 header value options

### DIFF
--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -2681,6 +2681,9 @@ pub fn getWriter(
                         return globalThis.throwInvalidArgumentType("write", "options.contentDisposition", "string");
                     }
                     content_disposition_str = try content_disposition.toSlice(globalThis, bun.default_allocator);
+                    if (!bun.S3.S3Credentials.isValidHTTPHeaderValue(content_disposition_str.?.slice())) {
+                        return globalThis.throwInvalidArgumentType("write", "options.contentDisposition", "a valid HTTP header value (cannot contain \\r, \\n, or null bytes)");
+                    }
                 }
                 var content_encoding_str: ?ZigString.Slice = null;
                 defer if (content_encoding_str) |ce| ce.deinit();
@@ -2689,6 +2692,9 @@ pub fn getWriter(
                         return globalThis.throwInvalidArgumentType("write", "options.contentEncoding", "string");
                     }
                     content_encoding_str = try content_encoding.toSlice(globalThis, bun.default_allocator);
+                    if (!bun.S3.S3Credentials.isValidHTTPHeaderValue(content_encoding_str.?.slice())) {
+                        return globalThis.throwInvalidArgumentType("write", "options.contentEncoding", "a valid HTTP header value (cannot contain \\r, \\n, or null bytes)");
+                    }
                 }
                 var credentialsWithOptions = try s3.getCredentialsWithOptions(options, globalThis);
                 defer credentialsWithOptions.deinit();

--- a/test/js/bun/s3/s3-crlf-injection.test.ts
+++ b/test/js/bun/s3/s3-crlf-injection.test.ts
@@ -1,0 +1,210 @@
+import { S3Client } from "bun";
+import { describe, expect, it } from "bun:test";
+
+// Test that S3 header values reject CRLF characters to prevent HTTP header injection.
+// This validates the fix for header injection via contentDisposition, type, and contentEncoding.
+
+describe("S3 - CRLF Header Injection Prevention", () => {
+  const baseOptions = {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+    endpoint: "http://127.0.0.1:1234",
+    bucket: "test",
+  };
+
+  describe("contentDisposition", () => {
+    it("should reject CRLF", () => {
+      expect(() => {
+        new S3Client({
+          ...baseOptions,
+          contentDisposition: "attachment\r\nX-Injected: true",
+        });
+      }).toThrow(/contentDisposition/);
+    });
+
+    it("should reject lone CR", () => {
+      expect(() => {
+        new S3Client({
+          ...baseOptions,
+          contentDisposition: "attachment\rX-Injected: true",
+        });
+      }).toThrow(/contentDisposition/);
+    });
+
+    it("should reject lone LF", () => {
+      expect(() => {
+        new S3Client({
+          ...baseOptions,
+          contentDisposition: "attachment\nX-Injected: true",
+        });
+      }).toThrow(/contentDisposition/);
+    });
+
+    it("should reject null bytes", () => {
+      expect(() => {
+        new S3Client({
+          ...baseOptions,
+          contentDisposition: "attachment\x00injected",
+        });
+      }).toThrow(/contentDisposition/);
+    });
+
+    it("should allow valid values", () => {
+      expect(() => {
+        new S3Client({
+          ...baseOptions,
+          contentDisposition: 'attachment; filename="report.pdf"',
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe("type (content-type)", () => {
+    it("should reject CRLF", () => {
+      expect(() => {
+        new S3Client({
+          ...baseOptions,
+          type: "text/plain\r\nX-Injected: true",
+        });
+      }).toThrow(/type/);
+    });
+
+    it("should reject lone LF", () => {
+      expect(() => {
+        new S3Client({
+          ...baseOptions,
+          type: "text/plain\nX-Injected: true",
+        });
+      }).toThrow(/type/);
+    });
+
+    it("should allow valid values", () => {
+      expect(() => {
+        new S3Client({
+          ...baseOptions,
+          type: "application/octet-stream",
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe("contentEncoding", () => {
+    it("should reject CRLF", () => {
+      expect(() => {
+        new S3Client({
+          ...baseOptions,
+          contentEncoding: "gzip\r\nX-Injected: true",
+        });
+      }).toThrow(/contentEncoding/);
+    });
+
+    it("should reject lone LF", () => {
+      expect(() => {
+        new S3Client({
+          ...baseOptions,
+          contentEncoding: "gzip\nX-Injected: true",
+        });
+      }).toThrow(/contentEncoding/);
+    });
+
+    it("should allow valid values", () => {
+      expect(() => {
+        new S3Client({
+          ...baseOptions,
+          contentEncoding: "gzip",
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe("per-file options", () => {
+    it("should reject CRLF in contentDisposition on file()", () => {
+      const client = new S3Client(baseOptions);
+      expect(() => {
+        client.file("test-key", {
+          contentDisposition: "attachment\r\nX-Injected: true",
+        });
+      }).toThrow(/contentDisposition/);
+    });
+
+    it("should reject CRLF in type on file()", () => {
+      const client = new S3Client(baseOptions);
+      expect(() => {
+        client.file("test-key", {
+          type: "text/plain\r\nX-Injected: true",
+        });
+      }).toThrow(/type/);
+    });
+
+    it("should reject CRLF in contentEncoding on file()", () => {
+      const client = new S3Client(baseOptions);
+      expect(() => {
+        client.file("test-key", {
+          contentEncoding: "gzip\r\nX-Injected: true",
+        });
+      }).toThrow(/contentEncoding/);
+    });
+  });
+
+  describe("write() options path", () => {
+    it("should reject CRLF in contentDisposition on write()", async () => {
+      const client = new S3Client(baseOptions);
+      const file = client.file("test-key");
+      expect(file.write("data", { contentDisposition: "attachment\r\nX-Injected: true" })).rejects.toThrow(
+        /contentDisposition/,
+      );
+    });
+
+    it("should reject CRLF in contentEncoding on write()", async () => {
+      const client = new S3Client(baseOptions);
+      const file = client.file("test-key");
+      expect(file.write("data", { contentEncoding: "gzip\r\nX-Injected: true" })).rejects.toThrow(/contentEncoding/);
+    });
+  });
+
+  it("CRLF in contentDisposition should not reach the wire", async () => {
+    const requests: string[] = [];
+    const server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        data(socket, data) {
+          requests.push(data.toString());
+          socket.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+          socket.end();
+        },
+        open() {},
+        close() {},
+        error() {},
+      },
+    });
+
+    try {
+      const client = new S3Client({
+        accessKeyId: "test",
+        secretAccessKey: "testsecret1234567890123456789012",
+        endpoint: `http://127.0.0.1:${server.port}`,
+        bucket: "test",
+      });
+
+      const file = client.file("test-key");
+      try {
+        await file.write("test-data", {
+          contentDisposition: "attachment; filename=report.pdf\r\nX-Injected: true",
+        });
+      } catch {
+        // Expected to throw
+      }
+
+      // Give a moment for any request to arrive
+      await Bun.sleep(200);
+
+      // Verify no injected header made it to the wire
+      for (const req of requests) {
+        expect(req).not.toContain("X-Injected");
+      }
+    } finally {
+      server.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Validate `contentDisposition`, `type` (content-type), and `contentEncoding` S3 options for carriage return (`\r`), line feed (`\n`), and null bytes (`\0`) to prevent HTTP header injection (CRLF injection) in S3 API requests
- These values were previously converted from JS strings to raw bytes and placed directly into HTTP headers without any CRLF sanitization, bypassing the `FetchHeaders` validation layer which properly rejects such characters
- The fix adds validation at all entry points: `S3Client` constructor options, per-file options via `client.file()`, and inline options on `.write()`

## Test plan

- [x] New test file `test/js/bun/s3/s3-crlf-injection.test.ts` with 17 tests covering:
  - CRLF, lone CR, lone LF, and null byte rejection for `contentDisposition`, `type`, and `contentEncoding`
  - Per-file options path (`client.file("key", { contentDisposition: ... })`)
  - Write options path (`file.write("data", { contentDisposition: ... })`)
  - Wire-level verification that injected headers never reach the TCP connection
  - Valid values still accepted without error
- [x] Tests pass with `bun bd test`
- [x] Tests fail with `USE_SYSTEM_BUN=1` (confirming the vulnerability exists without the fix)
- [x] Existing S3 tests (`s3-requester-pays`, `s3-storage-class`, `s3-list-objects`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)