### PR TITLE
fix(ffi): correct integer boundary encoding for uint32 and int64 values

### DIFF
--- a/src/bun.js/api/FFI.h
+++ b/src/bun.js/api/FFI.h
@@ -89,7 +89,7 @@ BUN_FFI_IMPORT extern struct NapiEnv Bun__thisFFIModuleNapiEnv;
 #define TagValueNull             (OtherTag)
 #define NotCellMask  (int64_t)(NumberTag | OtherTag)
 
-#define MAX_INT32 2147483648
+#define MAX_INT32 2147483647
 #define MAX_INT52 9007199254740991
 
 // If all bits in the mask are set, this indicates an integer number,
@@ -174,6 +174,7 @@ static EncodedJSValue PTR_TO_JSVALUE(void* ptr) __attribute__((__always_inline__
 
 static void* JSVALUE_TO_PTR(EncodedJSValue val) __attribute__((__always_inline__));
 static int32_t JSVALUE_TO_INT32(EncodedJSValue val) __attribute__((__always_inline__));
+static uint32_t JSVALUE_TO_UINT32(EncodedJSValue val) __attribute__((__always_inline__));
 static float JSVALUE_TO_FLOAT(EncodedJSValue val) __attribute__((__always_inline__));
 static double JSVALUE_TO_DOUBLE(EncodedJSValue val) __attribute__((__always_inline__));
 static bool JSVALUE_TO_BOOL(EncodedJSValue val) __attribute__((__always_inline__));
@@ -260,6 +261,16 @@ static int32_t JSVALUE_TO_INT32(EncodedJSValue val) {
   return val.asInt64;
 }
 
+static uint32_t JSVALUE_TO_UINT32(EncodedJSValue val) {
+  if (JSVALUE_IS_INT32(val)) {
+    return (uint32_t)JSVALUE_TO_INT32(val);
+  }
+  if (JSVALUE_IS_NUMBER(val)) {
+    return (uint32_t)JSVALUE_TO_DOUBLE(val);
+  }
+  return 0;
+}
+
 static EncodedJSValue INT32_TO_JSVALUE(int32_t val) {
    EncodedJSValue res;
    res.asInt64 = NumberTag | (uint32_t)val;
@@ -306,7 +317,7 @@ static bool JSVALUE_TO_BOOL(EncodedJSValue val) {
 
 static uint64_t JSVALUE_TO_UINT64(EncodedJSValue value) {
   if (JSVALUE_IS_INT32(value)) {
-    return (uint64_t)JSVALUE_TO_INT32(value);
+    return (uint64_t)(uint32_t)JSVALUE_TO_INT32(value);
   }
 
   if (JSVALUE_IS_NUMBER(value)) {
@@ -332,11 +343,11 @@ static int64_t JSVALUE_TO_INT64(EncodedJSValue value) {
 }
 
 static EncodedJSValue UINT64_TO_JSVALUE(void* jsGlobalObject, uint64_t val) {
-  if (val < MAX_INT32) {
+  if (val <= MAX_INT32) {
     return INT32_TO_JSVALUE((int32_t)val);
   }
 
-  if (val < MAX_INT52) {
+  if (val <= MAX_INT52) {
     return DOUBLE_TO_JSVALUE((double)val);
   }
 

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -2032,7 +2032,8 @@ pub const FFI = struct {
         /// Types that we can directly pass through as an `int64_t`
         pub fn needsACastInC(this: ABIType) bool {
             return switch (this) {
-                .char, .int8_t, .uint8_t, .int16_t, .uint16_t, .int32_t, .uint32_t => false,
+                .char, .int8_t, .uint8_t, .int16_t, .uint16_t, .int32_t => false,
+                .uint32_t => true,
                 else => true,
             };
         }
@@ -2143,11 +2144,17 @@ pub const FFI = struct {
                             try writer.writeAll("(bool)");
                         try writer.writeAll("JSVALUE_TO_BOOL(");
                     },
-                    .char, .int8_t, .uint8_t, .int16_t, .uint16_t, .int32_t, .uint32_t => {
+                    .char, .int8_t, .uint8_t, .int16_t, .uint16_t, .int32_t => {
                         if (self.exact)
                             try writer.print("({s})", .{bun.asByteSlice(@tagName(self.tag))});
 
                         try writer.writeAll("JSVALUE_TO_INT32(");
+                    },
+                    .uint32_t => {
+                        if (self.exact)
+                            try writer.writeAll("(uint32_t)");
+
+                        try writer.writeAll("JSVALUE_TO_UINT32(");
                     },
                     .i64_fast, .int64_t => {
                         if (self.exact)
@@ -2297,10 +2304,8 @@ pub const FFI = struct {
                 .uint8_t => "uint8_t",
                 .int16_t => "int16_t",
                 .uint16_t => "uint16_t",
-                // see the comment in ffi.ts about why `uint32_t` acts as `int32_t`
-                .int32_t,
-                .uint32_t,
-                => "int32_t",
+                .int32_t => "int32_t",
+                .uint32_t => "uint32_t",
                 .i64_fast, .int64_t => "int64_t",
                 .u64_fast, .uint64_t => "uint64_t",
                 .double => "double",

--- a/test/js/bun/ffi/ffi-int-boundary.test.ts
+++ b/test/js/bun/ffi/ffi-int-boundary.test.ts
@@ -1,0 +1,107 @@
+import { cc } from "bun:ffi";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { isASAN, tempDirWithFiles } from "harness";
+import path from "path";
+
+// TinyCC's setjmp/longjmp error handling conflicts with ASan.
+describe.skipIf(isASAN)("FFI integer boundary values", () => {
+  const source = /* c */ `
+    #include <stdint.h>
+
+    // 2147483648 is INT32_MAX + 1 (0x80000000)
+    uint32_t returns_uint32_boundary(void) {
+      return 2147483648u;
+    }
+
+    // INT32_MAX = 2147483647
+    uint32_t returns_uint32_max_int32(void) {
+      return 2147483647u;
+    }
+
+    // UINT32_MAX
+    uint32_t returns_uint32_max(void) {
+      return 4294967295u;
+    }
+
+    // Return value that's exactly at the boundary for int64 fast path
+    int64_t returns_int64_boundary_pos(void) {
+      return 2147483648ll;
+    }
+
+    int64_t returns_int64_boundary_neg(void) {
+      return -2147483649ll;
+    }
+
+    // Identity functions for round-tripping
+    uint32_t identity_u32(uint32_t val) {
+      return val;
+    }
+  `;
+
+  let dir: string;
+
+  beforeAll(() => {
+    dir = tempDirWithFiles("bun-ffi-int-boundary", {
+      "boundary.c": source,
+    });
+  });
+
+  describe("uint32 boundary at INT32_MAX+1", () => {
+    let lib: any;
+
+    beforeAll(() => {
+      lib = cc({
+        source: path.join(dir, "boundary.c"),
+        symbols: {
+          returns_uint32_boundary: { args: [], returns: "uint32_t" },
+          returns_uint32_max_int32: { args: [], returns: "uint32_t" },
+          returns_uint32_max: { args: [], returns: "uint32_t" },
+          returns_int64_boundary_pos: { args: [], returns: "i64_fast" },
+          returns_int64_boundary_neg: { args: [], returns: "i64_fast" },
+          identity_u32: { args: ["uint32_t"], returns: "uint32_t" },
+        },
+      });
+    });
+
+    afterAll(() => {
+      lib?.close();
+    });
+
+    it("uint32 value 2147483648 should not become negative", () => {
+      // This is the core bug: 2147483648 (0x80000000) was being routed through
+      // the int32 encoding path, causing sign corruption to -2147483648
+      const result = lib.symbols.returns_uint32_boundary();
+      expect(result).toBe(2147483648);
+      expect(result).toBeGreaterThan(0);
+    });
+
+    it("uint32 value 2147483647 (INT32_MAX) should work correctly", () => {
+      const result = lib.symbols.returns_uint32_max_int32();
+      expect(result).toBe(2147483647);
+    });
+
+    it("uint32 value 4294967295 (UINT32_MAX) should work correctly", () => {
+      const result = lib.symbols.returns_uint32_max();
+      expect(result).toBe(4294967295);
+    });
+
+    it("int64_fast value 2147483648 should not become negative", () => {
+      // INT64_TO_JSVALUE was casting 2147483648 to int32_t causing UB/sign corruption
+      const result = lib.symbols.returns_int64_boundary_pos();
+      expect(result).toBe(2147483648);
+      expect(result).toBeGreaterThan(0);
+    });
+
+    it("int64_fast value -2147483649 should be correctly negative", () => {
+      const result = lib.symbols.returns_int64_boundary_neg();
+      expect(result).toBe(-2147483649);
+      expect(result).toBeLessThan(-2147483648);
+    });
+
+    it("round-trip uint32 value 2147483648 through identity function", () => {
+      const result = lib.symbols.identity_u32(2147483648);
+      expect(result).toBe(2147483648);
+      expect(result).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fix sign corruption where FFI functions returning `uint32_t` value `2147483648` (0x80000000) produce `-2147483648` in JavaScript
- Fix round-trip of `uint32_t` values > `INT32_MAX` through FFI function arguments (was receiving `0` in C)
- Fix `JSVALUE_TO_UINT64` sign-extension where passing `-1` from JS produced `0xFFFFFFFFFFFFFFFF` as uint64

### Root causes

1. `MAX_INT32` was defined as `2147483648` (INT32_MAX + 1) instead of `2147483647` (INT32_MAX), causing the boundary value to be routed through the int32 encoding path where it overflows
2. The C code generator used `JSVALUE_TO_INT32` for `uint32_t` arguments, which only handles int32-tagged JSValues. When JS passes `2147483648` (a double in JSC), the int32 extraction returns garbage. Added `JSVALUE_TO_UINT32` that handles both int32-tagged and double-encoded JSValues
3. `JSVALUE_TO_UINT64` cast int32 directly to uint64, causing sign-extension of negative values

## Test plan

- [x] New test `test/js/bun/ffi/ffi-int-boundary.test.ts` covers:
  - `uint32_t` return value at boundary (2147483648)
  - `uint32_t` return of INT32_MAX (2147483647)  
  - `uint32_t` return of UINT32_MAX (4294967295)
  - `i64_fast` return at +/- boundary values
  - Round-trip of uint32 boundary value through identity function
- [x] Test fails with system bun (`USE_SYSTEM_BUN=1`), passes with `bun bd test`
- [x] All existing FFI tests pass (`ffi.test.js`, `cc.test.ts`, `ffi-error-messages.test.ts`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)