### PR TITLE
fix(libarchive): use normalized path in mkdiratZ to prevent directory traversal

### DIFF
--- a/src/libarchive/libarchive.zig
+++ b/src/libarchive/libarchive.zig
@@ -460,13 +460,13 @@ pub const Archiver = struct {
                             if (comptime Environment.isWindows) {
                                 try bun.MakePath.makePath(u16, dir, path);
                             } else {
-                                std.posix.mkdiratZ(dir_fd, pathname, @intCast(mode)) catch |err| {
+                                std.posix.mkdiratZ(dir_fd, path, @intCast(mode)) catch |err| {
                                     // It's possible for some tarballs to return a directory twice, with and
                                     // without `./` in the beginning. So if it already exists, continue to the
                                     // next entry.
                                     if (err == error.PathAlreadyExists or err == error.NotDir) continue;
                                     bun.makePath(dir, std.fs.path.dirname(path_slice) orelse return err) catch {};
-                                    std.posix.mkdiratZ(dir_fd, pathname, 0o777) catch {};
+                                    std.posix.mkdiratZ(dir_fd, path, 0o777) catch {};
                                 };
                             }
                         },


### PR DESCRIPTION
## Summary

- Fix path traversal vulnerability in tarball directory extraction on POSIX systems where `mkdiratZ` used the un-normalized `pathname` (raw from tarball) instead of the normalized `path` variable, allowing `../` components to escape the extraction root via kernel path resolution
- The Windows directory creation, symlink creation, and file creation code paths already correctly used the normalized path — only the two POSIX `mkdiratZ` calls were affected (lines 463 and 469)
- `bun install` is not affected because npm mode skips directory entries; affected callers include `bun create`, GitHub tarball extraction, and `compile_target`

## Test plan

- [x] Added regression test that crafts a tarball with `safe_dir/../../escaped_dir/` directory entry and verifies it cannot create directories outside the extraction root
- [x] Verified test **fails** with system bun (vulnerable) and **passes** with debug build (fixed)
- [x] Full `archive.test.ts` suite passes (99/99 tests)
- [x] `symlink-path-traversal.test.ts` continues to pass (3/3 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)