### PR TITLE
fix(node-fetch): extract TLS options from agent for mTLS support (#19754)

### DIFF
--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -169,6 +169,68 @@ async function fetch(
       init = { ...init, body: Readable.toWeb(readable) };
     }
   }
+  if (init) {
+    let agent = (init as any).agent;
+    if (agent) {
+      if ($isCallable(agent)) {
+        const parsedUrl = new URL(typeof url === "string" ? url : url instanceof URL ? url.href : url.url);
+        agent = agent.$call(undefined, parsedUrl);
+      }
+      if ($isObject(agent)) {
+        const connectOpts = agent.connectOpts;
+        const agentOpts = agent.options;
+        const opts =
+          $isObject(connectOpts) && $isObject(agentOpts)
+            ? { __proto__: null, ...connectOpts, ...agentOpts }
+            : $isObject(agentOpts)
+              ? agentOpts
+              : connectOpts;
+        if ($isObject(opts)) {
+          const tls: any = {};
+          let hasTls = false;
+          if (opts.rejectUnauthorized !== undefined) {
+            tls.rejectUnauthorized = opts.rejectUnauthorized;
+            hasTls = true;
+          }
+          if (opts.ca !== undefined) {
+            tls.ca = opts.ca;
+            hasTls = true;
+          }
+          if (opts.cert !== undefined) {
+            tls.cert = opts.cert;
+            hasTls = true;
+          }
+          if (opts.key !== undefined) {
+            tls.key = opts.key;
+            hasTls = true;
+          }
+          if (opts.passphrase !== undefined) {
+            tls.passphrase = opts.passphrase;
+            hasTls = true;
+          }
+          if (opts.pfx !== undefined) {
+            tls.pfx = opts.pfx;
+            hasTls = true;
+          }
+          if (opts.servername !== undefined) {
+            tls.serverName = opts.servername;
+            hasTls = true;
+          }
+          if (opts.ciphers !== undefined) {
+            tls.ciphers = opts.ciphers;
+            hasTls = true;
+          }
+          if (opts.secureOptions !== undefined) {
+            tls.secureOptions = opts.secureOptions;
+            hasTls = true;
+          }
+          if (hasTls && !(init as any).tls) {
+            init = { ...init, tls } as any;
+          }
+        }
+      }
+    }
+  }
   const response = await nativeFetch.$call(undefined, url, init);
   Object.setPrototypeOf(response, ResponsePrototype);
   return response;

--- a/test/regression/issue/19754.test.ts
+++ b/test/regression/issue/19754.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import https from "node:https";
+import { join } from "path";
+
+const fixturesDir = join(import.meta.dir, "..", "..", "js", "node", "http", "fixtures");
+
+const cert = readFileSync(join(fixturesDir, "cert.pem"), "utf8");
+const key = readFileSync(join(fixturesDir, "cert.key"), "utf8");
+
+describe("GitHub issue #19754: node-fetch with https.Agent TLS options", () => {
+  test("node-fetch rejects self-signed cert without ca", async () => {
+    using server = Bun.serve({
+      tls: { cert, key },
+      port: 0,
+      fetch() {
+        return new Response("OK");
+      },
+    });
+
+    const nodeFetch = require("node-fetch");
+    await expect(nodeFetch(`https://localhost:${server.port}/`)).rejects.toThrow();
+  });
+
+  test("node-fetch extracts TLS options from agent", async () => {
+    using server = Bun.serve({
+      tls: { cert, key },
+      port: 0,
+      fetch() {
+        return new Response("OK");
+      },
+    });
+
+    const nodeFetch = require("node-fetch");
+    const agent = new https.Agent({
+      ca: cert,
+      rejectUnauthorized: true,
+    });
+
+    const response = await nodeFetch(`https://localhost:${server.port}/`, { agent });
+    expect(await response.text()).toBe("OK");
+    agent.destroy();
+  });
+
+  test("node-fetch extracts TLS options from agent function", async () => {
+    using server = Bun.serve({
+      tls: { cert, key },
+      port: 0,
+      fetch() {
+        return new Response("OK");
+      },
+    });
+
+    const nodeFetch = require("node-fetch");
+    const agent = new https.Agent({
+      ca: cert,
+      rejectUnauthorized: true,
+    });
+
+    const response = await nodeFetch(`https://localhost:${server.port}/`, {
+      agent: (_url: URL) => agent,
+    });
+    expect(await response.text()).toBe("OK");
+    agent.destroy();
+  });
+
+  test("node-fetch extracts TLS options from agent.connectOpts", async () => {
+    using server = Bun.serve({
+      tls: { cert, key },
+      port: 0,
+      fetch() {
+        return new Response("OK");
+      },
+    });
+
+    const nodeFetch = require("node-fetch");
+    const agent = { connectOpts: { ca: cert, rejectUnauthorized: true } };
+
+    const response = await nodeFetch(`https://localhost:${server.port}/`, { agent });
+    expect(await response.text()).toBe("OK");
+  });
+
+  test("node-fetch does not override explicit tls option with agent", async () => {
+    using server = Bun.serve({
+      tls: { cert, key },
+      port: 0,
+      fetch() {
+        return new Response("OK");
+      },
+    });
+
+    const nodeFetch = require("node-fetch");
+    const agent = new https.Agent({
+      rejectUnauthorized: true,
+    });
+
+    const response = await nodeFetch(`https://localhost:${server.port}/`, {
+      agent,
+      tls: { ca: cert, rejectUnauthorized: true },
+    });
+    expect(await response.text()).toBe("OK");
+    agent.destroy();
+  });
+});


### PR DESCRIPTION
Fixes #19754 

### What does this PR do?

Extracts TLS options (ca, cert, key, passphrase, pfx, rejectUnauthorized, servername, ciphers, secureOptions) from the agent property passed to node-fetch and forwards them as the tls option to Bun's native fetch. This fixes compatibility with libraries like `@kubernetes/client-node` that pass client certificates via an https.Agent for mTLS authentication.

Supports both agent.options (standard https.Agent) and agent.connectOpts (used by https-proxy-agent), with options taking priority when both are present. Also supports the agent function form `(agent: (url) => new https.Agent(...))` and does not override an explicitly provided tls option.

### How did you verify your code works?

Added regression test (test/regression/issue/19754.test.ts) covering:
- Self-signed cert rejected without ca (negative case)
- TLS options extracted from `https.Agent` object
- TLS options extracted from agent callback function
- TLS options extracted from `agent.connectOpts`
- Explicit tls option is not overridden by agent options