### PR TITLE
fix(install): silently ignore missing literal workspace paths

### DIFF
--- a/src/install/lockfile/Package/WorkspaceMap.zig
+++ b/src/install/lockfile/Package/WorkspaceMap.zig
@@ -153,15 +153,7 @@ pub fn processNamesArray(
         ) catch |err| {
             bun.handleErrorReturnTrace(err, @errorReturnTrace());
             switch (err) {
-                error.EISNOTDIR, error.EISDIR, error.EACCESS, error.EPERM, error.ENOENT, error.FileNotFound => {
-                    log.addErrorFmt(
-                        source,
-                        item.loc,
-                        allocator,
-                        "Workspace not found \"{s}\"",
-                        .{input_path},
-                    ) catch {};
-                },
+                error.EISNOTDIR, error.EISDIR, error.EACCESS, error.EPERM, error.ENOENT, error.FileNotFound => {},
                 error.MissingPackageName => {
                     log.addErrorFmt(
                         source,

--- a/test/cli/install/bad-workspace.test.ts
+++ b/test/cli/install/bad-workspace.test.ts
@@ -34,9 +34,9 @@ test("bad workspace path", () => {
   });
   const text = stderr!.toString();
 
-  expect(text).toContain('Workspace not found "i-dont-exist"');
-
-  expect(exitCode).toBe(1);
+  // Missing workspace paths are silently ignored, matching npm behavior
+  expect(text).not.toContain('Workspace not found "i-dont-exist"');
+  expect(exitCode).toBe(0);
 });
 
 test("workspace with ./ should not crash", () => {

--- a/test/regression/issue/26970.test.ts
+++ b/test/regression/issue/26970.test.ts
@@ -1,0 +1,114 @@
+import { spawnSync } from "bun";
+import { beforeAll, beforeEach, expect, setDefaultTimeout, test } from "bun:test";
+import { writeFileSync } from "fs";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
+
+let cwd: string;
+
+beforeAll(() => {
+  setDefaultTimeout(1000 * 60 * 5);
+});
+
+beforeEach(() => {
+  cwd = tmpdirSync();
+});
+
+test("missing literal workspace path should not error", () => {
+  writeFileSync(
+    `${cwd}/package.json`,
+    JSON.stringify(
+      {
+        name: "test",
+        workspaces: ["terraform"],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const { stderr, exitCode } = spawnSync({
+    cmd: [bunExe(), "install"],
+    cwd,
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const text = stderr!.toString();
+
+  expect(text).not.toContain("Workspace not found");
+  expect(exitCode).toBe(0);
+});
+
+test("missing glob workspace pattern should not error", () => {
+  writeFileSync(
+    `${cwd}/package.json`,
+    JSON.stringify(
+      {
+        name: "test",
+        workspaces: ["terraform*"],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const { stderr, exitCode } = spawnSync({
+    cmd: [bunExe(), "install"],
+    cwd,
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const text = stderr!.toString();
+
+  expect(text).not.toContain("Workspace not found");
+  expect(exitCode).toBe(0);
+});
+
+test("literal and glob missing workspaces behave the same", () => {
+  // Test literal path
+  writeFileSync(
+    `${cwd}/package.json`,
+    JSON.stringify(
+      {
+        name: "test",
+        workspaces: ["nonexistent"],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const literalResult = spawnSync({
+    cmd: [bunExe(), "install"],
+    cwd,
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  // Test glob pattern
+  writeFileSync(
+    `${cwd}/package.json`,
+    JSON.stringify(
+      {
+        name: "test",
+        workspaces: ["nonexistent*"],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const globResult = spawnSync({
+    cmd: [bunExe(), "install"],
+    cwd,
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  // Both should succeed with exit code 0
+  expect(literalResult.exitCode).toBe(0);
+  expect(globResult.exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fixed inconsistency where `bun install` errored on missing literal workspace paths (e.g. `"terraform"`) but silently succeeded for glob patterns that matched nothing (e.g. `"terraform*"`)
- Now both cases silently skip, matching npm's behavior

## Changes
- `src/install/lockfile/Package/WorkspaceMap.zig`: Removed error logging for `ENOENT`/`FileNotFound` on literal workspace paths — the error handler now silently continues (same as the glob code path)
- `test/cli/install/bad-workspace.test.ts`: Updated existing test to expect silent success instead of error
- `test/regression/issue/26970.test.ts`: Added regression tests verifying both literal and glob missing workspaces behave identically

## Test plan
- [x] Verified regression test **fails** with `USE_SYSTEM_BUN=1` (reproduces the bug)
- [x] Verified regression test **passes** with `bun bd test` (fix works)
- [x] Verified existing `bad-workspace.test.ts` passes with updated expectations
- [x] All 6 tests pass across both test files

Closes #26970

🤖 Generated with [Claude Code](https://claude.com/claude-code)