### PR TITLE
fix(install): skip missing patch files for packages not in dependency graph

### DIFF
--- a/test/regression/issue/26969.test.ts
+++ b/test/regression/issue/26969.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/26969
+// bun install should not fail when patchedDependencies references a patch file
+// that doesn't exist, as long as the patched package is not in the dependency graph.
+test("bun install succeeds when patchedDependencies patch file is missing but package is not in dependency graph", async () => {
+  using dir = tempDir("issue-26969", {
+    "package.json": JSON.stringify({
+      name: "repro-26969",
+      private: true,
+      patchedDependencies: {
+        "next-auth@5.0.0": "patches/next-auth@5.0.0.patch",
+      },
+    }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Should not error about missing patch file
+  expect(stderr).not.toContain("Couldn't find patch file");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- `bun install` no longer errors when `patchedDependencies` references a patch file that doesn't exist on disk, as long as the patched package is not part of the resolved dependency graph
- This fixes pruned monorepo contexts (e.g. `turbo prune --docker`) where the root `package.json` may reference patches for packages only used by other workspaces
- If the patched package IS in the dependency graph and the patch file is missing, the error is still properly reported

## How it works

During install, Bun pre-calculates patch file hashes for all entries in `patchedDependencies` as an optimization. Previously, if a patch file didn't exist, this pre-calculation would immediately error — even if the package wasn't needed.

The fix makes the pre-calculation phase tolerant of missing patch files:
1. **`calcHash` in `patch_install.zig`**: When a patch file is not found (`ENOENT`) during a pre-calculation task, silently returns `null` instead of logging an error
2. **`runFromMainThreadCalcHash` in `patch_install.zig`**: When a pre-calculation returns no hash, gracefully returns instead of crashing
3. **`cleanWithLogger` in `lockfile.zig`**: Skips patched dependency entries with null hashes (unreferenced packages) when writing the cleaned lockfile

If the patched package IS later encountered during dependency resolution, `determinePreinstallState` will trigger a new (non-pre) hash calculation that properly reports the missing file error.

## Test plan
- [x] New regression test `test/regression/issue/26969.test.ts` verifies `bun install` succeeds when patch file is missing but package is not in dependency graph
- [x] Verified the test fails with the unpatched system bun (`USE_SYSTEM_BUN=1`)
- [x] Verified `bun install` still errors when the patched package IS in the dependency graph but the patch file is missing
- [x] All 26 existing `bun-patch.test.ts` tests pass
- [x] 16/17 existing `bun-install-patch.test.ts` tests pass (1 pre-existing timeout in debug build)

Closes #26969

🤖 Generated with [Claude Code](https://claude.com/claude-code)