### PR TITLE
Route Windows CI jobs to Azure VM sizes

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -102,6 +102,19 @@ function getTargetLabel(target) {
 /**
  * @type {Platform[]}
  */
+// Azure VM sizes — single source of truth for both ci.mjs and azure.mjs
+const azureVmSize = {
+  "windows-aarch64": "Standard_D4ps_v6", // 4 vCPU, 16 GiB, Cobalt 100
+  "windows-x64": "Standard_D8ds_v6", // 8 vCPU, 32 GiB
+};
+
+function getAzureVmSize(os, arch) {
+  return azureVmSize[`${os}-${arch}`];
+}
+
+/**
+ * @type {Platform[]}
+ */
 const buildPlatforms = [
   { os: "darwin", arch: "aarch64", release: "14" },
   { os: "darwin", arch: "x64", release: "14" },
@@ -114,8 +127,7 @@ const buildPlatforms = [
   { os: "linux", arch: "x64", abi: "musl", baseline: true, distro: "alpine", release: "3.23" },
   { os: "windows", arch: "x64", release: "2019" },
   { os: "windows", arch: "x64", baseline: true, release: "2019" },
-  // TODO: Re-enable when Windows ARM64 VS component installation is resolved on Buildkite runners
-  // { os: "windows", arch: "aarch64", release: "2019" },
+  { os: "windows", arch: "aarch64", release: "11" },
 ];
 
 /**
@@ -138,8 +150,7 @@ const testPlatforms = [
   { os: "linux", arch: "x64", abi: "musl", baseline: true, distro: "alpine", release: "3.23", tier: "latest" },
   { os: "windows", arch: "x64", release: "2019", tier: "oldest" },
   { os: "windows", arch: "x64", release: "2019", baseline: true, tier: "oldest" },
-  // TODO: Enable when Windows ARM64 CI runners are ready
-  // { os: "windows", arch: "aarch64", release: "2019", tier: "oldest" },
+  { os: "windows", arch: "aarch64", release: "11", tier: "latest" },
 ];
 
 /**
@@ -304,15 +315,8 @@ function getCppAgent(platform, options) {
     };
   }
 
-  // Cross-compile Windows ARM64 from x64 runners
-  if (os === "windows" && arch === "aarch64") {
-    return getEc2Agent({ ...platform, arch: "x64" }, options, {
-      instanceType: "c7i.4xlarge",
-    });
-  }
-
   return getEc2Agent(platform, options, {
-    instanceType: arch === "aarch64" ? "c8g.4xlarge" : "c7i.4xlarge",
+    instanceType: os === "windows" ? getAzureVmSize(os, arch) : arch === "aarch64" ? "c8g.4xlarge" : "c7i.4xlarge",
   });
 }
 
@@ -333,10 +337,8 @@ function getLinkBunAgent(platform, options) {
   }
 
   if (os === "windows") {
-    // Cross-compile Windows ARM64 from x64 runners
-    const agentPlatform = arch === "aarch64" ? { ...platform, arch: "x64" } : platform;
-    return getEc2Agent(agentPlatform, options, {
-      instanceType: "r7i.large",
+    return getEc2Agent(platform, options, {
+      instanceType: getAzureVmSize(os, arch),
     });
   }
 
@@ -363,7 +365,16 @@ function getZigPlatform() {
  * @param {PipelineOptions} options
  * @returns {Agent}
  */
-function getZigAgent(_platform, options) {
+function getZigAgent(platform, options) {
+  const { os, arch } = platform;
+
+  // Windows Zig builds on Azure runners
+  if (os === "windows") {
+    return getEc2Agent(platform, options, {
+      instanceType: getAzureVmSize(os, arch),
+    });
+  }
+
   return getEc2Agent(getZigPlatform(), options, {
     instanceType: "r8g.large",
   });
@@ -388,7 +399,7 @@ function getTestAgent(platform, options) {
   // TODO: delete this block when we upgrade to mimalloc v3
   if (os === "windows") {
     return getEc2Agent(platform, options, {
-      instanceType: "c7i.2xlarge",
+      instanceType: getAzureVmSize(os, arch),
       cpuCount: 2,
       threadsPerCore: 1,
     });
@@ -466,24 +477,12 @@ function getBuildCommand(target, options, label) {
 }
 
 /**
- * Get extra flags needed when cross-compiling Windows ARM64 from x64.
- * Applied to C++ and link steps (not Zig, which has its own toolchain handling).
- */
-function getWindowsArm64CrossFlags(target) {
-  if (target.os === "windows" && target.arch === "aarch64") {
-    return " --toolchain windows-aarch64";
-  }
-  return "";
-}
-
-/**
  * @param {Platform} platform
  * @param {PipelineOptions} options
  * @returns {Step}
  */
 function getBuildCppStep(platform, options) {
   const command = getBuildCommand(platform, options);
-  const crossFlags = getWindowsArm64CrossFlags(platform);
 
   return {
     key: `${getTargetKey(platform)}-build-cpp`,
@@ -498,7 +497,7 @@ function getBuildCppStep(platform, options) {
     // We used to build the C++ dependencies and bun in separate steps.
     // However, as long as the zig build takes longer than both sequentially,
     // it's cheaper to run them in the same step. Can be revisited in the future.
-    command: [`${command}${crossFlags} --target bun`, `${command}${crossFlags} --target dependencies`],
+    command: [`${command} --target bun`, `${command} --target dependencies`],
   };
 }
 
@@ -524,7 +523,10 @@ function getBuildToolchain(target) {
  * @returns {Step}
  */
 function getBuildZigStep(platform, options) {
+  const { os, arch } = platform;
   const toolchain = getBuildToolchain(platform);
+  // Native Windows ARM64 builds don't need a cross-compilation toolchain
+  const toolchainArg = os === "windows" && arch === "aarch64" ? "" : ` --toolchain ${toolchain}`;
   return {
     key: `${getTargetKey(platform)}-build-zig`,
     retry: getRetry(),
@@ -532,7 +534,7 @@ function getBuildZigStep(platform, options) {
     agents: getZigAgent(platform, options),
     cancel_on_build_failing: isMergeQueue(),
     env: getBuildEnv(platform, options),
-    command: `${getBuildCommand(platform, options)} --target bun-zig --toolchain ${toolchain}`,
+    command: `${getBuildCommand(platform, options)} --target bun-zig${toolchainArg}`,
     timeout_in_minutes: 35,
   };
 }
@@ -555,7 +557,7 @@ function getLinkBunStep(platform, options) {
       ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=0",
       ...getBuildEnv(platform, options),
     },
-    command: `${getBuildCommand(platform, options, "build-bun")}${getWindowsArm64CrossFlags(platform)} --target bun`,
+    command: `${getBuildCommand(platform, options, "build-bun")} --target bun`,
   };
 }
 
@@ -739,6 +741,7 @@ function getBuildImageStep(platform, options) {
   const { publishImages } = options;
   const action = publishImages ? "publish-image" : "create-image";
 
+  const cloud = os === "windows" ? "azure" : "aws";
   const command = [
     "node",
     "./scripts/machine.mjs",
@@ -747,7 +750,7 @@ function getBuildImageStep(platform, options) {
     `--arch=${arch}`,
     distro && `--distro=${distro}`,
     `--release=${release}`,
-    "--cloud=aws",
+    `--cloud=${cloud}`,
     "--ci",
     "--authorized-org=oven-sh",
   ];
@@ -1201,8 +1204,6 @@ async function getPipeline(options = {}) {
     buildImages || publishImages
       ? [...buildPlatforms, ...testPlatforms]
           .filter(({ os }) => os !== "darwin")
-          // Windows ARM64 cross-compiles from x64 runners, no separate image needed
-          .filter(({ os, arch }) => !(os === "windows" && arch === "aarch64"))
           .map(platform => [getImageKey(platform), platform])
       : [],
   );


### PR DESCRIPTION
Routes all Windows CI jobs to use Azure VM sizes instead of AWS instance types.

**Changes:**
- Add `azureVmSize` object as single source of truth for Azure VM sizes
- All Windows agent functions (`getCppAgent`, `getLinkBunAgent`, `getZigAgent`, `getTestAgent`) use `getAzureVmSize()` for Windows
- Enable Windows ARM64 in build and test platforms (native builds, no cross-compilation)
- Use `--cloud=azure` for Windows build-image steps

Fixes the `c7i.4xlarge is not a valid Azure VM size` error when robobun creates Azure VMs.