### PR TITLE
fix(cmake): disable bmalloc/libpas on Windows to fix crash

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -1265,7 +1265,6 @@ if(WIN32)
     target_link_libraries(${bun} PRIVATE
       ${WEBKIT_LIB_PATH}/WTF.lib
       ${WEBKIT_LIB_PATH}/JavaScriptCore.lib
-      ${WEBKIT_LIB_PATH}/bmalloc.lib
       ${WEBKIT_LIB_PATH}/sicudtd.lib
       ${WEBKIT_LIB_PATH}/sicuind.lib
       ${WEBKIT_LIB_PATH}/sicuucd.lib
@@ -1274,7 +1273,6 @@ if(WIN32)
     target_link_libraries(${bun} PRIVATE
       ${WEBKIT_LIB_PATH}/WTF.lib
       ${WEBKIT_LIB_PATH}/JavaScriptCore.lib
-      ${WEBKIT_LIB_PATH}/bmalloc.lib
       ${WEBKIT_LIB_PATH}/sicudt.lib
       ${WEBKIT_LIB_PATH}/sicuin.lib
       ${WEBKIT_LIB_PATH}/sicuuc.lib


### PR DESCRIPTION
## Summary

- Remove `bmalloc.lib` from Windows link targets (both DEBUG and RELEASE) in `cmake/targets/BuildBun.cmake`
- libpas/bmalloc was disabled on Windows in PR #20931 due to stability issues (`pas_assertion_failed` crashes after extended runtime), but was inadvertently re-enabled in PR #26381 ("Update WebKit") without fixing the underlying issues
- This restores the intended behavior and fixes the crash reported in #26982

## Background

The crash manifests as `pas_assertion_failed` in bmalloc's segregated allocator after extended runtime with many allocations (e.g., thousands of `fetch()` calls over ~73 minutes). The same class of crashes was previously documented in #21192, #24576, and #20505.

The non-Windows build already has a conditional guard for bmalloc linking:
```cmake
if(WEBKIT_LOCAL OR NOT APPLE OR EXISTS ${WEBKIT_LIB_PATH}/libbmalloc.a)
    target_link_libraries(${bun} PRIVATE ${WEBKIT_LIB_PATH}/libbmalloc.a)
endif()
```

This PR simply removes the unconditional `bmalloc.lib` linking on Windows that was re-introduced.

## Test plan

- [ ] Windows CI builds successfully without bmalloc.lib
- [ ] Long-running fetch workloads on Windows no longer crash with `pas_assertion_failed`

Fixes #26982

🤖 Generated with [Claude Code](https://claude.com/claude-code)