### PR TITLE
fix(cmake): disable bmalloc/libpas on Windows to fix crash

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -1265,7 +1265,6 @@ if(WIN32)
     target_link_libraries(${bun} PRIVATE
       ${WEBKIT_LIB_PATH}/WTF.lib
       ${WEBKIT_LIB_PATH}/JavaScriptCore.lib
-      ${WEBKIT_LIB_PATH}/bmalloc.lib
       ${WEBKIT_LIB_PATH}/sicudtd.lib
       ${WEBKIT_LIB_PATH}/sicuind.lib
       ${WEBKIT_LIB_PATH}/sicuucd.lib
@@ -1274,7 +1273,6 @@ if(WIN32)
     target_link_libraries(${bun} PRIVATE
       ${WEBKIT_LIB_PATH}/WTF.lib
       ${WEBKIT_LIB_PATH}/JavaScriptCore.lib
-      ${WEBKIT_LIB_PATH}/bmalloc.lib
       ${WEBKIT_LIB_PATH}/sicudt.lib
       ${WEBKIT_LIB_PATH}/sicuin.lib
       ${WEBKIT_LIB_PATH}/sicuuc.lib


### PR DESCRIPTION
## What does this PR do?

Removes `bmalloc.lib` from Windows link targets (both Debug and Release) in `cmake/targets/BuildBun.cmake`.

bmalloc/libpas was originally disabled on Windows in PR #20931 due to `pas_assertion_failed` assertion crashes. It was inadvertently re-enabled in PR #26381 (WebKit update), causing crashes on Windows starting with Bun 1.3.9. This restores the intended behavior.

This is a re-submission of the fix from PR #26983, which was closed due to unrelated CI failures.

Fixes #26985
Fixes #26982

## How did you verify your code works?

This is a Windows-specific CMake change (removing a library from link targets). Verified by:
- Confirming `bmalloc.lib` is removed from both DEBUG and non-DEBUG Windows link paths
- Confirming non-Windows linking (libbmalloc.a with conditional check) is unchanged
- This matches the fix previously validated in PR #20931 which originally disabled bmalloc on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)