### PR TITLE
fix(shell): prevent use-after-free in builtin OutputTask callbacks inside $()

### DIFF
--- a/src/shell/builtin/cp.zig
+++ b/src/shell/builtin/cp.zig
@@ -266,8 +266,8 @@ pub const ShellCpOutputTask = OutputTask(Cp, .{
 
 const ShellCpOutputTaskVTable = struct {
     pub fn writeErr(this: *Cp, childptr: anytype, errbuf: []const u8) ?Yield {
+        this.state.exec.output_waiting += 1;
         if (this.bltn().stderr.needsIO()) |safeguard| {
-            this.state.exec.output_waiting += 1;
             return this.bltn().stderr.enqueue(childptr, errbuf, safeguard);
         }
         _ = this.bltn().writeNoIO(.stderr, errbuf);
@@ -279,8 +279,8 @@ const ShellCpOutputTaskVTable = struct {
     }
 
     pub fn writeOut(this: *Cp, childptr: anytype, output: *OutputSrc) ?Yield {
+        this.state.exec.output_waiting += 1;
         if (this.bltn().stdout.needsIO()) |safeguard| {
-            this.state.exec.output_waiting += 1;
             return this.bltn().stdout.enqueue(childptr, output.slice(), safeguard);
         }
         _ = this.bltn().writeNoIO(.stdout, output.slice());

--- a/src/shell/builtin/ls.zig
+++ b/src/shell/builtin/ls.zig
@@ -175,8 +175,8 @@ pub const ShellLsOutputTask = OutputTask(Ls, .{
 const ShellLsOutputTaskVTable = struct {
     pub fn writeErr(this: *Ls, childptr: anytype, errbuf: []const u8) ?Yield {
         log("ShellLsOutputTaskVTable.writeErr(0x{x}, {s})", .{ @intFromPtr(this), errbuf });
+        this.state.exec.output_waiting += 1;
         if (this.bltn().stderr.needsIO()) |safeguard| {
-            this.state.exec.output_waiting += 1;
             return this.bltn().stderr.enqueue(childptr, errbuf, safeguard);
         }
         _ = this.bltn().writeNoIO(.stderr, errbuf);
@@ -190,8 +190,8 @@ const ShellLsOutputTaskVTable = struct {
 
     pub fn writeOut(this: *Ls, childptr: anytype, output: *OutputSrc) ?Yield {
         log("ShellLsOutputTaskVTable.writeOut(0x{x}, {s})", .{ @intFromPtr(this), output.slice() });
+        this.state.exec.output_waiting += 1;
         if (this.bltn().stdout.needsIO()) |safeguard| {
-            this.state.exec.output_waiting += 1;
             return this.bltn().stdout.enqueue(childptr, output.slice(), safeguard);
         }
         log("ShellLsOutputTaskVTable.writeOut(0x{x}, {s}) no IO", .{ @intFromPtr(this), output.slice() });

--- a/src/shell/builtin/mkdir.zig
+++ b/src/shell/builtin/mkdir.zig
@@ -129,8 +129,8 @@ pub const ShellMkdirOutputTask = OutputTask(Mkdir, .{
 
 const ShellMkdirOutputTaskVTable = struct {
     pub fn writeErr(this: *Mkdir, childptr: anytype, errbuf: []const u8) ?Yield {
+        this.state.exec.output_waiting += 1;
         if (this.bltn().stderr.needsIO()) |safeguard| {
-            this.state.exec.output_waiting += 1;
             return this.bltn().stderr.enqueue(childptr, errbuf, safeguard);
         }
         _ = this.bltn().writeNoIO(.stderr, errbuf);
@@ -142,8 +142,8 @@ const ShellMkdirOutputTaskVTable = struct {
     }
 
     pub fn writeOut(this: *Mkdir, childptr: anytype, output: *OutputSrc) ?Yield {
+        this.state.exec.output_waiting += 1;
         if (this.bltn().stdout.needsIO()) |safeguard| {
-            this.state.exec.output_waiting += 1;
             const slice = output.slice();
             log("THE SLICE: {d} {s}", .{ slice.len, slice });
             return this.bltn().stdout.enqueue(childptr, slice, safeguard);

--- a/src/shell/builtin/touch.zig
+++ b/src/shell/builtin/touch.zig
@@ -132,8 +132,8 @@ pub const ShellTouchOutputTask = OutputTask(Touch, .{
 
 const ShellTouchOutputTaskVTable = struct {
     pub fn writeErr(this: *Touch, childptr: anytype, errbuf: []const u8) ?Yield {
+        this.state.exec.output_waiting += 1;
         if (this.bltn().stderr.needsIO()) |safeguard| {
-            this.state.exec.output_waiting += 1;
             return this.bltn().stderr.enqueue(childptr, errbuf, safeguard);
         }
         _ = this.bltn().writeNoIO(.stderr, errbuf);
@@ -145,8 +145,8 @@ const ShellTouchOutputTaskVTable = struct {
     }
 
     pub fn writeOut(this: *Touch, childptr: anytype, output: *OutputSrc) ?Yield {
+        this.state.exec.output_waiting += 1;
         if (this.bltn().stdout.needsIO()) |safeguard| {
-            this.state.exec.output_waiting += 1;
             const slice = output.slice();
             log("THE SLICE: {d} {s}", .{ slice.len, slice });
             return this.bltn().stdout.enqueue(childptr, slice, safeguard);

--- a/test/js/bun/shell/shell-cmdsub-crash.test.ts
+++ b/test/js/bun/shell/shell-cmdsub-crash.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for use-after-poison in builtin OutputTask callbacks
+// inside command substitution $().
+//
+// The bug: output_waiting was only incremented for async writes but
+// output_done was always incremented, so when stdout is sync (.pipe
+// in cmdsub) the counter check `output_done >= output_waiting` fires
+// prematurely, calling done() and freeing the builtin while IOWriter
+// callbacks are still pending.
+//
+// Repro requires many ls tasks with errors — `ls /tmp/*` on a system
+// with many /tmp entries and some permission-denied dirs reliably
+// triggers the ASAN use-after-poison.
+
+describe("builtins in command substitution with errors should not crash", () => {
+  test("ls /tmp/* in command substitution", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import { $ } from "bun";
+        $.throws(false);
+        await $\`echo $(ls /tmp/*)\`;
+        console.log("done");
+      `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("done");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes use-after-free (ASAN use-after-poison) when shell builtins (`ls`, `touch`, `mkdir`, `cp`) run inside command substitution `$(...)` and encounter errors (e.g., permission denied)
- The `output_waiting` and `output_done` counters in the builtin exec state went out of sync because `output_waiting` was only incremented for async IO operations, while `output_done` was always incremented
- In command substitution, stdout is `.pipe` (sync) and stderr is `.fd` (async), so a single OutputTask completing both writes could satisfy the done condition while another OutputTask's async stderr write was still pending in the IOWriter

The fix moves `output_waiting += 1` before the `needsIO()` check in all four affected builtins so it's always incremented, matching `output_done`.

## Test plan

- [x] `echo $(ls /tmp/*)` — no ASAN errors (previously crashed with use-after-poison)
- [x] `echo $(touch /root/a /root/b ...)` — no ASAN errors
- [x] `echo $(mkdir /root/a /root/b ...)` — no ASAN errors
- [x] `ls /nonexistent` — still reports error and exits with code 1
- [x] `echo $(ls /tmp)` — still captures output correctly
- [x] Existing shell test suite: 292 pass, 52 fail (pre-existing), 83 todo — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)