### PR TITLE
perf(structuredClone): remove unnecessary zero-fill for Int32 and Double array fast paths

### DIFF
--- a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
@@ -5954,16 +5954,14 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
                     auto* data = array->butterfly()->contiguous().data();
                     if (!containsHole(data, length)) {
                         size_t byteSize = sizeof(JSValue) * length;
-                        Vector<uint8_t> buffer(byteSize, 0);
-                        memcpy(buffer.mutableSpan().data(), data, byteSize);
+                        Vector<uint8_t> buffer(std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(data), byteSize });
                         return SerializedScriptValue::createInt32ArrayFastPath(WTF::move(buffer), length);
                     }
                 } else {
                     auto* data = array->butterfly()->contiguousDouble().data();
                     if (!containsHole(data, length)) {
                         size_t byteSize = sizeof(double) * length;
-                        Vector<uint8_t> buffer(byteSize, 0);
-                        memcpy(buffer.mutableSpan().data(), data, byteSize);
+                        Vector<uint8_t> buffer(std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(data), byteSize });
                         return SerializedScriptValue::createDoubleArrayFastPath(WTF::move(buffer), length);
                     }
                 }


### PR DESCRIPTION
## What

Replace two-step `Vector<uint8_t>` zero-initialization + `memcpy` with direct `std::span` copy construction in the `structuredClone` Int32 and Double array fast paths.

## Why

The previous code allocated a zero-filled buffer and then immediately overwrote it with `memcpy`. By constructing the `Vector` directly from a `std::span`, we eliminate the redundant zero-fill and reduce the operation to a single copy.

### Before
```cpp
Vector<uint8_t> buffer(byteSize, 0);
memcpy(buffer.mutableSpan().data(), data, byteSize);
```

### After
```cpp
Vector<uint8_t> buffer(std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(data), byteSize });
```

## Test

`bun bd test test/js/web/structured-clone-fastpath.test.ts` — 91/92 pass (1 pre-existing flaky memory test unrelated to this change).