### PR TITLE
fix(shell): handle unrecognized errno in cd instead of hanging

### DIFF
--- a/src/shell/builtin/cd.zig
+++ b/src/shell/builtin/cd.zig
@@ -87,7 +87,16 @@ fn handleChangeCwdErr(this: *Cd, err: Syscall.Error, new_cwd_: []const u8) Yield
 
             return this.writeStderrNonBlocking("not a directory: {s}\n", .{new_cwd_});
         },
-        else => return .failed,
+        else => {
+            const message: []const u8 = brk: {
+                if (err.getErrorCodeTagName()) |entry| {
+                    _, const sys_errno = entry;
+                    if (Syscall.coreutils_error_map.get(sys_errno)) |msg| break :brk msg;
+                }
+                break :brk "unknown error";
+            };
+            return this.writeStderrNonBlocking("{s}: {s}\n", .{ new_cwd_, message });
+        },
     }
 }
 

--- a/test/js/bun/shell/shell-builtin-hang.test.ts
+++ b/test/js/bun/shell/shell-builtin-hang.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix } from "harness";
+
+// Regression test: cd with a path component exceeding NAME_MAX (255 bytes)
+// triggers ENAMETOOLONG from openat(). The handleChangeCwdErr function
+// had `else => return .failed` which means "JS error was thrown" but
+// no error was actually thrown, causing the shell to hang indefinitely.
+
+describe.if(isPosix)("cd with path exceeding NAME_MAX should not hang", () => {
+  test("cd returns error for path component > 255 chars", async () => {
+    const longComponent = Buffer.alloc(256, "A").toString();
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import { $ } from "bun";
+        $.throws(false);
+        const r = await $\`cd ${longComponent}\`;
+        console.log("exitCode:" + r.exitCode);
+        `,
+      ],
+      env: { ...bunEnv, longComponent },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("exitCode:1");
+    expect(stderr).toContain("File name too long");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix `cd` hanging when encountering unrecognized errno values (e.g. ENAMETOOLONG for path components > 255 bytes)
- The `handleChangeCwdErr` function's `else` branch returned `.failed` (meaning "JS error was thrown") but no error was actually thrown, causing the shell trampoline to terminate without completing the command
- Now looks up a human-readable error message via `coreutils_error_map` and writes it to stderr, matching the behavior of the NOTDIR/NOENT cases

## Test plan

- [x] Added regression test that confirms `cd` with 256-char path component returns exit code 1 with "File name too long" error
- [x] Test times out (hangs) without the fix, passes with the fix
- [x] Existing shell tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)