### PR TITLE
perf(clone): add structuredClone/postMessage fast path for TypedArray

### DIFF
--- a/bench/snippets/structuredClone-typedarray.mjs
+++ b/bench/snippets/structuredClone-typedarray.mjs
@@ -1,0 +1,68 @@
+import { bench, group, run, summary } from "../runner.mjs";
+
+// === TypedArray structuredClone benchmarks ===
+
+// Uint8Array at various sizes
+var uint8_64 = new Uint8Array(64);
+var uint8_1K = new Uint8Array(1024);
+var uint8_64K = new Uint8Array(64 * 1024);
+var uint8_1M = new Uint8Array(1024 * 1024);
+
+// Fill with non-zero data to be realistic
+for (var i = 0; i < uint8_64.length; i++) uint8_64[i] = i & 0xff;
+for (var i = 0; i < uint8_1K.length; i++) uint8_1K[i] = i & 0xff;
+for (var i = 0; i < uint8_64K.length; i++) uint8_64K[i] = i & 0xff;
+for (var i = 0; i < uint8_1M.length; i++) uint8_1M[i] = i & 0xff;
+
+// Other typed array types (1KB each)
+var int8_1K = new Int8Array(1024);
+var uint16_1K = new Uint16Array(512); // 1KB
+var int32_1K = new Int32Array(256); // 1KB
+var float32_1K = new Float32Array(256); // 1KB
+var float64_1K = new Float64Array(128); // 1KB
+var bigint64_1K = new BigInt64Array(128); // 1KB
+
+for (var i = 0; i < int8_1K.length; i++) int8_1K[i] = (i % 256) - 128;
+for (var i = 0; i < uint16_1K.length; i++) uint16_1K[i] = i;
+for (var i = 0; i < int32_1K.length; i++) int32_1K[i] = i * 1000;
+for (var i = 0; i < float32_1K.length; i++) float32_1K[i] = i * 0.1;
+for (var i = 0; i < float64_1K.length; i++) float64_1K[i] = i * 0.1;
+for (var i = 0; i < bigint64_1K.length; i++) bigint64_1K[i] = BigInt(i);
+
+// Slice view (byteOffset != 0) — should fall back to slow path
+var sliceBuf = new ArrayBuffer(2048);
+var uint8_slice = new Uint8Array(sliceBuf, 512, 512);
+
+summary(() => {
+  group("Uint8Array by size", () => {
+    bench("Uint8Array 64B", () => structuredClone(uint8_64));
+    bench("Uint8Array 1KB", () => structuredClone(uint8_1K));
+    bench("Uint8Array 64KB", () => structuredClone(uint8_64K));
+    bench("Uint8Array 1MB", () => structuredClone(uint8_1M));
+  });
+});
+
+summary(() => {
+  group("TypedArray types (1KB each)", () => {
+    bench("Int8Array", () => structuredClone(int8_1K));
+    bench("Uint8Array", () => structuredClone(uint8_1K));
+    bench("Uint16Array", () => structuredClone(uint16_1K));
+    bench("Int32Array", () => structuredClone(int32_1K));
+    bench("Float32Array", () => structuredClone(float32_1K));
+    bench("Float64Array", () => structuredClone(float64_1K));
+    bench("BigInt64Array", () => structuredClone(bigint64_1K));
+  });
+});
+
+// Pre-create for fair comparison
+var uint8_whole = new Uint8Array(512);
+for (var i = 0; i < 512; i++) uint8_whole[i] = i & 0xff;
+
+summary(() => {
+  group("fast path vs slow path (512B)", () => {
+    bench("Uint8Array whole (fast path)", () => structuredClone(uint8_whole));
+    bench("Uint8Array slice (slow path)", () => structuredClone(uint8_slice));
+  });
+});
+
+await run();

--- a/bench/snippets/structuredClone.mjs
+++ b/bench/snippets/structuredClone.mjs
@@ -59,4 +59,15 @@ var objectsMedium = Array.from({ length: 100 }, (_, i) => ({ id: i, name: `item-
 bench("structuredClone([10 objects])", () => structuredClone(objectsSmall));
 bench("structuredClone([100 objects])", () => structuredClone(objectsMedium));
 
+// TypedArray fast path targets
+var uint8Small = new Uint8Array(64);
+var uint8Medium = new Uint8Array(1024);
+var uint8Large = new Uint8Array(1024 * 1024);
+var float64Medium = new Float64Array(128);
+
+bench("structuredClone(Uint8Array 64B)", () => structuredClone(uint8Small));
+bench("structuredClone(Uint8Array 1KB)", () => structuredClone(uint8Medium));
+bench("structuredClone(Uint8Array 1MB)", () => structuredClone(uint8Large));
+bench("structuredClone(Float64Array 1KB)", () => structuredClone(float64Medium));
+
 await run();

--- a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
@@ -389,19 +389,32 @@ static unsigned typedArrayElementSize(ArrayBufferViewSubtag tag)
 static ArrayBufferViewSubtag subtagForTypedArrayType(TypedArrayType type)
 {
     switch (type) {
-    case TypeInt8: return Int8ArrayTag;
-    case TypeUint8: return Uint8ArrayTag;
-    case TypeUint8Clamped: return Uint8ClampedArrayTag;
-    case TypeInt16: return Int16ArrayTag;
-    case TypeUint16: return Uint16ArrayTag;
-    case TypeInt32: return Int32ArrayTag;
-    case TypeUint32: return Uint32ArrayTag;
-    case TypeFloat16: return Float16ArrayTag;
-    case TypeFloat32: return Float32ArrayTag;
-    case TypeFloat64: return Float64ArrayTag;
-    case TypeBigInt64: return BigInt64ArrayTag;
-    case TypeBigUint64: return BigUint64ArrayTag;
-    default: return DataViewTag;
+    case TypeInt8:
+        return Int8ArrayTag;
+    case TypeUint8:
+        return Uint8ArrayTag;
+    case TypeUint8Clamped:
+        return Uint8ClampedArrayTag;
+    case TypeInt16:
+        return Int16ArrayTag;
+    case TypeUint16:
+        return Uint16ArrayTag;
+    case TypeInt32:
+        return Int32ArrayTag;
+    case TypeUint32:
+        return Uint32ArrayTag;
+    case TypeFloat16:
+        return Float16ArrayTag;
+    case TypeFloat32:
+        return Float32ArrayTag;
+    case TypeFloat64:
+        return Float64ArrayTag;
+    case TypeBigInt64:
+        return BigInt64ArrayTag;
+    case TypeBigUint64:
+        return BigUint64ArrayTag;
+    default:
+        return DataViewTag;
     }
 }
 

--- a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
@@ -5967,6 +5967,7 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
                     // byteOffset == 0 (whole-buffer view), no named properties.
                     if (!view->isDetached()
                         && !view->isOutOfBounds()
+                        && !view->isShared()
                         && !view->isResizableOrGrowableShared()
                         && view->byteOffset() == 0
                         && structure->maxOffset() == invalidOffset) {

--- a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
@@ -5963,27 +5963,21 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
                 if (isTypedView(jsType)) {
                     auto* view = jsCast<JSArrayBufferView*>(object);
                     size_t byteLength = view->byteLength();
-                    // Fast path conditions: not detached, not out of bounds, not shared,
-                    // not resizable/growable, byteOffset == 0, covers entire backing buffer,
-                    // no named properties.
-                    // For FastTypedArray/OversizeTypedArray (hasArrayBuffer()==false), the view
-                    // owns the data directly and always covers it entirely.
-                    // For WastefulTypedArray (hasArrayBuffer()==true), we must verify the view
-                    // covers the full ArrayBuffer; partial views (e.g. new Uint8Array(buf, 0, 8)
-                    // over a 16-byte buffer) must fall through to the slow path which preserves
-                    // the full backing buffer and byteOffset/byteLength.
-                    // possiblySharedBuffer() is safe here: hasArrayBuffer()==true means
-                    // WastefulTypedArray, which just returns existingBufferInButterfly()
-                    // without triggering slowDownAndWasteMemory().
-                    bool coversFullBuffer = !view->hasArrayBuffer()
-                        || view->byteLength() == view->possiblySharedBuffer()->byteLength();
                     if (!view->isDetached()
                         && !view->isOutOfBounds()
                         && !view->isShared()
                         && !view->isResizableOrGrowableShared()
                         && view->byteOffset() == 0
-                        && coversFullBuffer
-                        && structure->maxOffset() == invalidOffset) {
+                        && structure->maxOffset() == invalidOffset
+                        // For WastefulTypedArray (hasArrayBuffer()==true), verify the view
+                        // covers the full ArrayBuffer; partial views (e.g. new Uint8Array(buf, 0, 8)
+                        // over a 16-byte buffer) must fall through to the slow path.
+                        // possiblySharedBuffer() is safe after isDetached()/isShared() checks:
+                        // WastefulTypedArray just returns existingBufferInButterfly() without
+                        // triggering slowDownAndWasteMemory(). Must be evaluated AFTER isDetached()
+                        // to avoid null deref on detached buffers.
+                        && (!view->hasArrayBuffer()
+                            || view->byteLength() == view->possiblySharedBuffer()->byteLength())) {
                         auto taType = typedArrayType(jsType);
                         auto subtag = subtagForTypedArrayType(taType);
                         auto* data = static_cast<const uint8_t*>(view->vector());

--- a/src/bun.js/bindings/webcore/SerializedScriptValue.h
+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.h
@@ -87,6 +87,7 @@ enum class FastPath : uint8_t {
     Int32Array,
     DoubleArray,
     DenseArray,
+    TypedArray,
 };
 
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
@@ -147,6 +148,9 @@ public:
 
     // Fast path for postMessage with dense arrays containing simple objects
     static Ref<SerializedScriptValue> createDenseArrayFastPath(WTF::FixedVector<DenseArrayElement>&& elements);
+
+    // Fast path for postMessage with TypedArray (Uint8Array, Float64Array, etc.)
+    static Ref<SerializedScriptValue> createTypedArrayFastPath(Vector<uint8_t>&& data, uint8_t subtag);
 
     static Ref<SerializedScriptValue> nullValue();
 
@@ -255,6 +259,8 @@ private:
     SerializedScriptValue(Vector<uint8_t>&& butterflyData, uint32_t length, FastPath fastPath);
     // Constructor for DenseArray fast path
     explicit SerializedScriptValue(WTF::FixedVector<DenseArrayElement>&& denseElements);
+    // Constructor for TypedArray fast path
+    SerializedScriptValue(Vector<uint8_t>&& data, uint8_t subtag);
 
     size_t computeMemoryCost() const;
 
@@ -294,6 +300,9 @@ private:
 
     // DenseArray fast path: array of primitives/strings/simple objects
     FixedVector<DenseArrayElement> m_denseArrayElements {};
+
+    // TypedArray fast path: subtag identifying the TypedArray type (ArrayBufferViewSubtag)
+    uint8_t m_typedArraySubtag { 0 };
 };
 
 template<class Encoder>

--- a/test/js/web/structured-clone-fastpath.test.ts
+++ b/test/js/web/structured-clone-fastpath.test.ts
@@ -883,4 +883,183 @@ describe("Structured Clone Fast Path", () => {
     port1.close();
     port2.close();
   });
+
+  // === TypedArray fast path tests ===
+
+  const typedArrayCtors = [
+    { name: "Uint8Array", ctor: Uint8Array, values: [0, 1, 127, 255] },
+    { name: "Int8Array", ctor: Int8Array, values: [-128, -1, 0, 1, 127] },
+    { name: "Uint8ClampedArray", ctor: Uint8ClampedArray, values: [0, 1, 127, 255] },
+    { name: "Uint16Array", ctor: Uint16Array, values: [0, 1, 256, 65535] },
+    { name: "Int16Array", ctor: Int16Array, values: [-32768, -1, 0, 1, 32767] },
+    { name: "Uint32Array", ctor: Uint32Array, values: [0, 1, 65536, 4294967295] },
+    { name: "Int32Array", ctor: Int32Array, values: [-2147483648, -1, 0, 1, 2147483647] },
+    { name: "Float32Array", ctor: Float32Array, values: [0, 1.5, -1.5, 3.4028234663852886e38] },
+    { name: "Float64Array", ctor: Float64Array, values: [0, 1.5, -1.5, Number.MAX_VALUE, Number.MIN_VALUE] },
+  ] as const;
+
+  for (const { name, ctor, values } of typedArrayCtors) {
+    test(`structuredClone(${name}) basic values`, () => {
+      const input = new ctor(values as any);
+      const cloned = structuredClone(input);
+      expect(cloned).toBeInstanceOf(ctor);
+      expect(cloned).toEqual(input);
+      expect(cloned.buffer).not.toBe(input.buffer);
+    });
+  }
+
+  test("structuredClone(BigInt64Array) basic values", () => {
+    const input = new BigInt64Array([-9223372036854775808n, -1n, 0n, 1n, 9223372036854775807n]);
+    const cloned = structuredClone(input);
+    expect(cloned).toBeInstanceOf(BigInt64Array);
+    expect(cloned).toEqual(input);
+    expect(cloned.buffer).not.toBe(input.buffer);
+  });
+
+  test("structuredClone(BigUint64Array) basic values", () => {
+    const input = new BigUint64Array([0n, 1n, 18446744073709551615n]);
+    const cloned = structuredClone(input);
+    expect(cloned).toBeInstanceOf(BigUint64Array);
+    expect(cloned).toEqual(input);
+    expect(cloned.buffer).not.toBe(input.buffer);
+  });
+
+  test("structuredClone(Float16Array) basic values", () => {
+    const input = new Float16Array([0, 1.5, -1.5, 65504]);
+    const cloned = structuredClone(input);
+    expect(cloned).toBeInstanceOf(Float16Array);
+    expect(cloned).toEqual(input);
+    expect(cloned.buffer).not.toBe(input.buffer);
+  });
+
+  test("structuredClone empty TypedArray", () => {
+    const input = new Uint8Array(0);
+    const cloned = structuredClone(input);
+    expect(cloned).toBeInstanceOf(Uint8Array);
+    expect(cloned.length).toBe(0);
+    expect(cloned.byteLength).toBe(0);
+  });
+
+  test("structuredClone large TypedArray (1MB)", () => {
+    const input = new Uint8Array(1024 * 1024);
+    for (let i = 0; i < input.length; i++) input[i] = i & 0xff;
+    const cloned = structuredClone(input);
+    expect(cloned).toBeInstanceOf(Uint8Array);
+    expect(cloned.length).toBe(input.length);
+    expect(cloned).toEqual(input);
+    expect(cloned.buffer).not.toBe(input.buffer);
+  });
+
+  test("structuredClone Float64Array with special values", () => {
+    const input = new Float64Array([NaN, Infinity, -Infinity, -0, 0]);
+    const cloned = structuredClone(input);
+    expect(cloned).toBeInstanceOf(Float64Array);
+    expect(cloned[0]).toBeNaN();
+    expect(cloned[1]).toBe(Infinity);
+    expect(cloned[2]).toBe(-Infinity);
+    expect(Object.is(cloned[3], -0)).toBe(true);
+    expect(cloned[4]).toBe(0);
+  });
+
+  test("structuredClone Float32Array with special values", () => {
+    const input = new Float32Array([NaN, Infinity, -Infinity, -0]);
+    const cloned = structuredClone(input);
+    expect(cloned).toBeInstanceOf(Float32Array);
+    expect(cloned[0]).toBeNaN();
+    expect(cloned[1]).toBe(Infinity);
+    expect(cloned[2]).toBe(-Infinity);
+    expect(Object.is(cloned[3], -0)).toBe(true);
+  });
+
+  test("structuredClone TypedArray creates independent copy", () => {
+    const input = new Uint8Array([1, 2, 3, 4, 5]);
+    const cloned = structuredClone(input);
+    cloned[0] = 255;
+    expect(input[0]).toBe(1);
+    input[1] = 200;
+    expect(cloned[1]).toBe(2);
+  });
+
+  test("structuredClone DataView falls back to slow path but works correctly", () => {
+    const buf = new ArrayBuffer(8);
+    const view = new DataView(buf);
+    view.setFloat64(0, 3.14);
+    const cloned = structuredClone(view);
+    expect(cloned).toBeInstanceOf(DataView);
+    expect(cloned.getFloat64(0)).toBe(3.14);
+    expect(cloned.buffer).not.toBe(buf);
+  });
+
+  test("structuredClone TypedArray slice view falls back to slow path", () => {
+    const buf = new ArrayBuffer(16);
+    new Uint8Array(buf).set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    const sliceView = new Uint8Array(buf, 4, 4);
+    const cloned = structuredClone(sliceView);
+    expect(cloned).toBeInstanceOf(Uint8Array);
+    expect(cloned).toEqual(new Uint8Array([4, 5, 6, 7]));
+    // structuredClone clones the full backing ArrayBuffer, preserving byteOffset
+    expect(cloned.byteOffset).toBe(4);
+    expect(cloned.buffer.byteLength).toBe(16);
+  });
+
+  test("structuredClone TypedArray with named properties falls back to slow path", () => {
+    const input = new Uint8Array([1, 2, 3]) as any;
+    input.customProp = "hello";
+    // Named properties on TypedArray are not cloneable via structuredClone,
+    // the slow path handles this correctly (ignores them)
+    const cloned = structuredClone(input);
+    expect(cloned).toBeInstanceOf(Uint8Array);
+    expect(cloned).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  test("structuredClone detached TypedArray throws DataCloneError", () => {
+    const buf = new ArrayBuffer(8);
+    const input = new Uint8Array(buf);
+    // Detach the buffer by transferring it
+    structuredClone(buf, { transfer: [buf] });
+    expect(() => structuredClone(input)).toThrow();
+  });
+
+  test("postMessage TypedArray via MessageChannel", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const input = new Uint8Array([10, 20, 30, 40, 50]);
+    const { promise, resolve } = Promise.withResolvers();
+    port2.onmessage = (e: MessageEvent) => resolve(e.data);
+    port1.postMessage(input);
+    const result = await promise;
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result).toEqual(input);
+    port1.close();
+    port2.close();
+  });
+
+  test("postMessage Float64Array via MessageChannel", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const input = new Float64Array([1.1, 2.2, 3.3, NaN, Infinity]);
+    const { promise, resolve } = Promise.withResolvers();
+    port2.onmessage = (e: MessageEvent) => resolve(e.data);
+    port1.postMessage(input);
+    const result = await promise;
+    expect(result).toBeInstanceOf(Float64Array);
+    expect(result[0]).toBe(1.1);
+    expect(result[1]).toBe(2.2);
+    expect(result[2]).toBe(3.3);
+    expect(result[3]).toBeNaN();
+    expect(result[4]).toBe(Infinity);
+    port1.close();
+    port2.close();
+  });
+
+  test("postMessage BigInt64Array via MessageChannel", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const input = new BigInt64Array([0n, -1n, 9223372036854775807n]);
+    const { promise, resolve } = Promise.withResolvers();
+    port2.onmessage = (e: MessageEvent) => resolve(e.data);
+    port1.postMessage(input);
+    const result = await promise;
+    expect(result).toBeInstanceOf(BigInt64Array);
+    expect(result).toEqual(input);
+    port1.close();
+    port2.close();
+  });
 });


### PR DESCRIPTION
## Summary

Adds an in-memory fast path for `structuredClone` / `postMessage` that completely skips the `CloneSerializer` / `CloneDeserializer` byte-buffer serialization pipeline when the input is a **TypedArray** (`Uint8Array`, `Float64Array`, `BigInt64Array`, etc.).

This builds on the existing fast path infrastructure (String, SimpleObject, SimpleArray, Int32Array/DoubleArray butterfly memcpy, DenseArray) to cover another extremely common pattern — cloning binary data via TypedArrays.

## How it works

### Serialization
When a TypedArray meets the fast path conditions, the raw backing data is copied directly from `view->vector()` into a `Vector<uint8_t>` using a single `memcpy`. The `ArrayBufferViewSubtag` (which TypedArray type) is stored alongside. This avoids:
- The entire `CloneSerializer` state machine initialization
- Tag writing and byte-buffer formatting
- Calling `possiblySharedBuffer()`, which triggers `slowDownAndWasteMemory()` for `FastTypedArray`/`OversizeTypedArray` modes (creating a backing `ArrayBuffer` that did not previously exist)

The TypedArray type is determined via `isTypedView(jsType)` + `typedArrayType(jsType)` → `subtagForTypedArrayType()` — an O(1) lookup from the JSC `Structure` type info, avoiding the chain of `inherits<>` checks used by the slow path.

### Deserialization
Creates an `ArrayBuffer` via `ArrayBuffer::tryCreate(span)` (Gigacage allocation + memcpy), computes the element count from `byteLength / elementSize`, and constructs the appropriate TypedArray view with `wrappedAs()`.

### Fast path conditions (all must be true)

| Condition | Rationale |
|-----------|-----------|
| Not detached | Detached buffers → DataCloneError (handled by slow path) |
| Not out of bounds | OOB → DataCloneError |
| Not resizable/growable shared | Requires `ResizableArrayBufferTag` handling |
| `byteOffset == 0` | Whole-buffer views only; slice views fall through to slow path |
| No named properties | `structure->maxOffset() == invalidOffset` |
| Not DataView | DataView excluded (uncommon, different semantics) |

## Benchmarks

Apple M4 Max, release build vs system Bun v1.3.9:

### TypedArray by size (Uint8Array)

| Size | Bun v1.3.9 | This PR | Speedup |
|------|-----------|---------|---------|
| 64B | 273 ns | **104 ns** | **2.6x** |
| 1KB | 322 ns | **163 ns** | **2.0x** |
| 64KB | 2.53 µs | 2.26 µs | 1.1x |
| 1MB | 28.6 µs | 27.7 µs | ~1.0x |

### All TypedArray types (1KB each)

| Type | Bun v1.3.9 | This PR | Speedup |
|------|-----------|---------|---------|
| Int8Array | 343 ns | **163 ns** | **2.1x** |
| Uint8Array | 339 ns | **170 ns** | **2.0x** |
| Uint16Array | 324 ns | **167 ns** | **1.9x** |
| Int32Array | 347 ns | **169 ns** | **2.0x** |
| Float32Array | 349 ns | **171 ns** | **2.0x** |
| Float64Array | 345 ns | **170 ns** | **2.0x** |
| BigInt64Array | 343 ns | **173 ns** | **2.0x** |

### Fast path vs slow path (512B, same data)

| Path | Bun v1.3.9 | This PR |
|------|-----------|---------|
| Whole view (fast path) | 305 ns | **134 ns** |
| Slice view (slow path) | 370 ns | 382 ns |
| **Ratio** | 1.21x | **2.84x** |

As expected, the speedup is most significant for small-to-medium TypedArrays (≤4KB) where serializer/deserializer overhead dominates. For large arrays (64KB+), `memcpy` dominates and the difference narrows.

## Test coverage

22 new tests covering:
- **All 12 TypedArray types**: Uint8Array, Int8Array, Uint8ClampedArray, Uint16Array, Int16Array, Uint32Array, Int32Array, Float32Array, Float64Array, Float16Array, BigInt64Array, BigUint64Array
- **Edge cases**: empty TypedArray, large (1MB), special float values (NaN, Infinity, -Infinity, -0)
- **Independence**: mutations to clone do not affect source and vice versa
- **Fallback correctness**: DataView, slice views (byteOffset ≠ 0), named properties, detached buffers
- **postMessage**: Uint8Array, Float64Array, BigInt64Array via MessageChannel

## Changed files

- `src/bun.js/bindings/webcore/SerializedScriptValue.h` — `FastPath::TypedArray`, constructor, factory, `m_typedArraySubtag` field
- `src/bun.js/bindings/webcore/SerializedScriptValue.cpp` — `subtagForTypedArrayType()`, serialize detection, constructor, deserialize switch, `computeMemoryCost`
- `test/js/web/structured-clone-fastpath.test.ts` — 22 new tests
- `bench/snippets/structuredClone.mjs` — TypedArray benchmarks
- `bench/snippets/structuredClone-typedarray.mjs` — Dedicated TypedArray benchmark suite