### PR TITLE
fix(shell): prevent integer overflow in brace expansion variant counting

### DIFF
--- a/src/shell/braces.zig
+++ b/src/shell/braces.zig
@@ -59,7 +59,7 @@ pub fn expand(
     out: []std.array_list.Managed(u8),
     contains_nested: bool,
 ) ExpandError!void {
-    var out_key_counter: u16 = 1;
+    var out_key_counter: u32 = 1;
     if (!contains_nested) {
         var expansions_table = try buildExpansionTableAlloc(allocator, tokens);
 
@@ -74,8 +74,8 @@ pub fn expand(
 fn expandNested(
     root: *AST.Group,
     out: []std.array_list.Managed(u8),
-    out_key: u16,
-    out_key_counter: *u16,
+    out_key: u32,
+    out_key_counter: *u32,
     start: u32,
 ) ExpandError!void {
     if (root.atoms == .single) {
@@ -157,8 +157,8 @@ fn expandFlat(
     tokens: []const Token,
     expansion_table: []const ExpansionVariant,
     out: []std.array_list.Managed(u8),
-    out_key: u16,
-    out_key_counter: *u16,
+    out_key: u32,
+    out_key_counter: *u32,
     depth_: u8,
     start: usize,
     end: usize,

--- a/src/shell/braces.zig
+++ b/src/shell/braces.zig
@@ -380,7 +380,9 @@ pub const Parser = struct {
 };
 
 pub fn calculateExpandedAmount(tokens: []const Token) u32 {
-    var nested_brace_stack = bun.SmallList(u8, MAX_NESTED_BRACES){};
+    // Use u32 per nesting level to avoid overflow when a single brace group
+    // has more than 255 comma-separated items.
+    var nested_brace_stack = bun.SmallList(u32, MAX_NESTED_BRACES){};
     defer nested_brace_stack.deinit(bun.default_allocator);
     var variant_count: u32 = 0;
     var prev_comma: bool = false;
@@ -405,7 +407,7 @@ pub fn calculateExpandedAmount(tokens: []const Token) u32 {
                 } else if (variant_count == 0) {
                     variant_count = variants;
                 } else {
-                    variant_count *= variants;
+                    variant_count = std.math.mul(u32, variant_count, variants) catch std.math.maxInt(u32);
                 }
             },
             else => {},

--- a/test/js/bun/shell/shell-brace-overflow.test.ts
+++ b/test/js/bun/shell/shell-brace-overflow.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix } from "harness";
+
+// Regression test: brace expansion with 256+ items used a u8 counter for
+// variant counting, which overflowed and caused a segfault on release builds
+// or integer overflow panic on debug builds.
+
+describe.if(isPosix)("brace expansion should handle large item counts", () => {
+  test("256 items in a brace group does not crash", async () => {
+    // Generate {x0,x1,x2,...,x255} - 256 items overflows u8
+    const items = Array.from({ length: 256 }, (_, i) => `x${i}`).join(",");
+    const cmd = `echo {${items}}`;
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import { $ } from "bun";
+        $.throws(false);
+        const r = await $\`${cmd}\`;
+        const words = r.stdout.toString().trim().split(" ");
+        console.log("count:" + words.length);
+        console.log("first:" + words[0]);
+        console.log("last:" + words[words.length - 1]);
+        console.log("exitCode:" + r.exitCode);
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("count:256");
+    expect(stdout).toContain("first:x0");
+    expect(stdout).toContain("last:x255");
+    expect(stdout).toContain("exitCode:0");
+    expect(exitCode).toBe(0);
+  });
+
+  test("500 items in a brace group does not crash", async () => {
+    const items = Array.from({ length: 500 }, (_, i) => `y${i}`).join(",");
+    const cmd = `echo {${items}}`;
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import { $ } from "bun";
+        $.throws(false);
+        const r = await $\`${cmd}\`;
+        const words = r.stdout.toString().trim().split(" ");
+        console.log("count:" + words.length);
+        console.log("exitCode:" + r.exitCode);
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("count:500");
+    expect(stdout).toContain("exitCode:0");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/shell/shell-brace-overflow.test.ts
+++ b/test/js/bun/shell/shell-brace-overflow.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isPosix } from "harness";
 
-// Regression test: brace expansion with 256+ items used a u8 counter for
-// variant counting, which overflowed and caused a segfault on release builds
-// or integer overflow panic on debug builds.
+// Regression tests for brace expansion integer overflows:
+// 1. u8 variant counter overflowed at 256 items in a single brace group
+// 2. u16 out_key_counter overflowed at 65536 total cartesian product expansions
 
 describe.if(isPosix)("brace expansion should handle large item counts", () => {
-  test("256 items in a brace group does not crash", async () => {
+  test.concurrent("256 items in a brace group does not crash", async () => {
     // Generate {x0,x1,x2,...,x255} - 256 items overflows u8
     const items = Array.from({ length: 256 }, (_, i) => `x${i}`).join(",");
     const cmd = `echo {${items}}`;
@@ -40,7 +40,7 @@ describe.if(isPosix)("brace expansion should handle large item counts", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("500 items in a brace group does not crash", async () => {
+  test.concurrent("500 items in a brace group does not crash", async () => {
     const items = Array.from({ length: 500 }, (_, i) => `y${i}`).join(",");
     const cmd = `echo {${items}}`;
 
@@ -68,4 +68,32 @@ describe.if(isPosix)("brace expansion should handle large item counts", () => {
     expect(stdout).toContain("exitCode:0");
     expect(exitCode).toBe(0);
   });
+
+  test("cartesian product exceeding 65535 does not crash", async () => {
+    // {a,b} repeated 16 times = 2^16 = 65536 expansions, which overflows u16
+    // Use ${{raw:...}} to pass brace expression without shell interpolation
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import { $ } from "bun";
+        $.throws(false);
+        const r = await $\`echo $\{{ raw: "{a,b}".repeat(16) }}\`;
+        const words = r.stdout.toString().trim().split(" ");
+        console.log("count:" + words.length);
+        console.log("exitCode:" + r.exitCode);
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("count:65536");
+    expect(stdout).toContain("exitCode:0");
+    expect(exitCode).toBe(0);
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

- Fix crash when brace expansion has 256+ comma-separated items (e.g. `{x0,x1,...,x255}`)
- The variant counter per nesting level was `u8`, overflowing at 256 items: integer overflow panic on debug builds, segfault on release builds
- Changed to `u32` and added checked multiplication for cross-group variant count

**Repro:** `echo {x0,x1,x2,...,x255}` with 256 items crashes with segfault (release) or integer overflow panic (debug)

## Test plan

- [x] Added test with 256 items (exact overflow boundary) - verifies all 256 items expand correctly
- [x] Added test with 500 items - verifies larger counts work
- [x] Tests crash without fix (integer overflow panic / timeout), pass with fix
- [x] Existing brace expansion tests (`brace.test.ts`) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)