### PR TITLE
Fix websocket proxy ping crash

### DIFF
--- a/src/http/websocket_client.zig
+++ b/src/http/websocket_client.zig
@@ -138,6 +138,10 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
             // Set to null FIRST to prevent re-entrancy (shutdown can trigger callbacks)
             if (this.proxy_tunnel) |tunnel| {
                 this.proxy_tunnel = null;
+                // Detach the websocket from the tunnel before shutdown so the
+                // tunnel's onClose callback doesn't dispatch a spurious 1006
+                // after we've already handled a clean close.
+                tunnel.clearConnectedWebSocket();
                 tunnel.shutdown();
                 tunnel.deref();
             }

--- a/src/http/websocket_client/WebSocketProxyTunnel.zig
+++ b/src/http/websocket_client/WebSocketProxyTunnel.zig
@@ -253,6 +253,13 @@ pub fn setConnectedWebSocket(this: *WebSocketProxyTunnel, ws: *WebSocketClient) 
     this.#upgrade_client = .{ .none = {} };
 }
 
+/// Clear the connected WebSocket reference. Called before tunnel shutdown during
+/// a clean close so the tunnel's onClose callback doesn't dispatch a spurious
+/// abrupt close (1006) after the WebSocket has already sent a clean close frame.
+pub fn clearConnectedWebSocket(this: *WebSocketProxyTunnel) void {
+    this.#connected_websocket = null;
+}
+
 /// SSLWrapper callback: Called with encrypted data to send to network
 fn writeEncrypted(this: *WebSocketProxyTunnel, encrypted_data: []const u8) void {
     log("writeEncrypted: {} bytes", .{encrypted_data.len});

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -353,105 +353,6 @@ describe("WebSocket through HTTP CONNECT proxy", () => {
     await promise;
     gc();
   });
-
-  test("server-initiated ping is ponged correctly through proxy", async () => {
-    // Regression test: sendPong was checking socket.isClosed() on the detached
-    // socket instead of using hasTCP(), causing an immediate 1006 close when
-    // the server sent a Ping frame through a CONNECT proxy tunnel.
-    //
-    // Uses a raw TCP server to send WebSocket ping frames directly, ensuring
-    // the client's sendPong codepath is exercised through the CONNECT tunnel.
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
-
-    let handshakeBuffer = new Uint8Array(0);
-    let handshakeComplete = false;
-
-    const rawServer = Bun.listen({
-      socket: {
-        data(socket, data) {
-          if (handshakeComplete) return; // ignore client frames after handshake
-
-          // Accumulate handshake data
-          const newBuf = new Uint8Array(handshakeBuffer.length + data.byteLength);
-          newBuf.set(handshakeBuffer);
-          newBuf.set(new Uint8Array(data), handshakeBuffer.length);
-          handshakeBuffer = newBuf;
-
-          const str = new TextDecoder().decode(handshakeBuffer);
-          const endOfHeaders = str.indexOf("\r\n\r\n");
-          if (endOfHeaders === -1) return;
-
-          // Complete the WebSocket handshake
-          const keyMatch = /Sec-WebSocket-Key:\s*(.*)\r\n/i.exec(str);
-          if (!keyMatch) {
-            socket.end();
-            reject(new Error("Missing Sec-WebSocket-Key"));
-            return;
-          }
-
-          const hasher = new Bun.CryptoHasher("sha1");
-          hasher.update(keyMatch[1].trim());
-          hasher.update("258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
-          const accept = hasher.digest("base64");
-
-          socket.write(
-            "HTTP/1.1 101 Switching Protocols\r\n" +
-              "Upgrade: websocket\r\n" +
-              "Connection: Upgrade\r\n" +
-              `Sec-WebSocket-Accept: ${accept}\r\n` +
-              "\r\n",
-          );
-          socket.flush();
-          handshakeComplete = true;
-
-          // Send a ping frame (opcode 0x89, FIN=1, no payload)
-          socket.write(new Uint8Array([0x89, 0x00]));
-          socket.flush();
-
-          // Then send a text frame "survived" — if the client receives this,
-          // the connection was not killed by the ping.
-          const payload = new TextEncoder().encode("survived");
-          const textFrame = new Uint8Array(2 + payload.length);
-          textFrame[0] = 0x81; // FIN + Text opcode
-          textFrame[1] = payload.length;
-          textFrame.set(payload, 2);
-          socket.write(textFrame);
-          socket.flush();
-        },
-      },
-      hostname: "127.0.0.1",
-      port: 0,
-    });
-
-    try {
-      const ws = new WebSocket(`ws://127.0.0.1:${rawServer.port}`, {
-        proxy: `http://127.0.0.1:${proxyPort}`,
-      });
-
-      ws.onmessage = event => {
-        if (String(event.data) === "survived") {
-          ws.close(1000);
-        }
-      };
-
-      ws.onclose = event => {
-        if (event.code === 1000) {
-          resolve();
-        } else {
-          reject(new Error(`Unexpected close code: ${event.code}`));
-        }
-      };
-
-      ws.onerror = event => {
-        reject(event);
-      };
-
-      await promise;
-    } finally {
-      rawServer.stop(true);
-    }
-    gc();
-  });
 });
 
 describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
@@ -495,6 +396,71 @@ describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
     const messages = await promise;
     expect(messages).toContain("connected");
     expect(messages).toContain("hello via tls tunnel");
+    gc();
+  });
+
+  test("server-initiated ping survives through TLS tunnel proxy", async () => {
+    // Regression test: sendPong checked socket.isClosed() on the detached tcp
+    // field instead of using hasTCP(). For wss:// through HTTP proxy, the
+    // WebSocket uses initWithTunnel which sets tcp = detached (all I/O goes
+    // through proxy_tunnel). Detached sockets return true for isClosed(), so
+    // sendPong would immediately dispatch a 1006 close instead of sending the
+    // pong through the tunnel.
+    using pingServer = Bun.serve({
+      port: 0,
+      tls: {
+        key: tlsCerts.key,
+        cert: tlsCerts.cert,
+      },
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("Expected WebSocket", { status: 400 });
+      },
+      websocket: {
+        message(ws, message) {
+          if (String(message) === "ready") {
+            // Send a ping after the client confirms it's connected.
+            // On the buggy code path, this triggers sendPong on the detached
+            // socket → dispatchAbruptClose → 1006.
+            ws.ping();
+            // Follow up with a text message. If the client receives this,
+            // the connection survived the ping/pong exchange.
+            ws.send("after-ping");
+          }
+        },
+      },
+    });
+
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+    const ws = new WebSocket(`wss://127.0.0.1:${pingServer.port}`, {
+      proxy: `http://127.0.0.1:${proxyPort}`,
+      tls: { rejectUnauthorized: false },
+    });
+
+    ws.onopen = () => {
+      ws.send("ready");
+    };
+
+    ws.onmessage = event => {
+      if (String(event.data) === "after-ping") {
+        ws.close(1000);
+      }
+    };
+
+    ws.onclose = event => {
+      if (event.code === 1000) {
+        resolve();
+      } else {
+        reject(new Error(`Unexpected close code: ${event.code}`));
+      }
+    };
+
+    ws.onerror = event => {
+      reject(event);
+    };
+
+    await promise;
     gc();
   });
 });


### PR DESCRIPTION
### What does this PR do?

The `sendPong` fix alone wasn't sufficient. The bug only manifests with **wss:// through HTTP proxy** (not ws://), because only that path uses `initWithTunnel` with a detached socket.

**Two bugs were found and fixed:**

1. **`sendPong`/`sendCloseWithBody` socket checks** (`src/http/websocket_client.zig`): Replaced `socket.isClosed() or socket.isShutdown()` with `!this.hasTCP()` as originally proposed. Also guarded `shutdownRead()` against detached sockets.

2. **Spurious 1006 during clean close** (`src/http/websocket_client.zig` + `WebSocketProxyTunnel.zig`): When `sendCloseWithBody` calls `clearData()`, it shuts down the proxy tunnel. The tunnel's `onClose` callback was calling `ws.fail(ErrorCode.ended)` which dispatched a 1006 abrupt close, overriding the clean 1000 close already in progress. Fixed by adding `tunnel.clearConnectedWebSocket()` before `tunnel.shutdown()` so the callback is a no-op.

### How did you verify your code works?

- `USE_SYSTEM_BUN=1`: Fails with `Unexpected close code: 1006`
- `bun bd test`: Passes with clean 1000 close
- Full proxy test suite: 25 pass, 4 skip, 0 fail
- Related fragmented/close tests: all passing
