### PR TITLE
fix(test): use "Received value" instead of "Expected value" in error messages

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -554,7 +554,7 @@ pub const Expect = struct {
                 return .{ value, return_value_from_function };
             }
 
-            return globalThis.throw("Expected value must be a function", .{});
+            return globalThis.throw("Received value must be a function", .{});
         }
 
         var return_value: JSValue = .zero;
@@ -2002,7 +2002,7 @@ pub const mock = struct {
         if (!returns.jsType().isArray()) {
             var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
             defer formatter.deinit();
-            return globalThis.throw("Expected value must be a mock function: {f}", .{value.toFmt(&formatter)});
+            return globalThis.throw("Received value must be a mock function: {f}", .{value.toFmt(&formatter)});
         }
 
         return try returns.arrayIterator(globalThis);
@@ -2015,7 +2015,7 @@ pub const mock = struct {
         }
         var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
-        return globalThis.throw("Expected value must be a mock function with returns: {f}", .{value.toFmt(&formatter)});
+        return globalThis.throw("Received value must be a mock function with returns: {f}", .{value.toFmt(&formatter)});
     }
     pub fn jestMockReturnObject_value(globalThis: *JSGlobalObject, value: bun.jsc.JSValue) bun.JSError!JSValue {
         return (try value.get(globalThis, "value")) orelse .js_undefined;

--- a/src/bun.js/test/expect/toContainKey.zig
+++ b/src/bun.js/test/expect/toContainKey.zig
@@ -22,7 +22,7 @@ pub fn toContainKey(
 
     const not = this.flags.not;
     if (!value.isObject()) {
-        return globalThis.throwInvalidArguments("Expected value must be an object\nReceived: {f}", .{value.toFmt(&formatter)});
+        return globalThis.throwInvalidArguments("Received value must be an object\nReceived: {f}", .{value.toFmt(&formatter)});
     }
 
     var pass = try value.hasOwnPropertyValue(globalThis, expected);

--- a/src/bun.js/test/expect/toHaveBeenCalled.zig
+++ b/src/bun.js/test/expect/toHaveBeenCalled.zig
@@ -15,7 +15,7 @@ pub fn toHaveBeenCalled(this: *Expect, globalThis: *JSGlobalObject, callframe: *
     if (!calls.jsType().isArray()) {
         var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
-        return globalThis.throw("Expected value must be a mock function: {f}", .{value.toFmt(&formatter)});
+        return globalThis.throw("Received value must be a mock function: {f}", .{value.toFmt(&formatter)});
     }
 
     const calls_length = try calls.getLength(globalThis);

--- a/src/bun.js/test/expect/toHaveBeenCalledOnce.zig
+++ b/src/bun.js/test/expect/toHaveBeenCalledOnce.zig
@@ -11,7 +11,7 @@ pub fn toHaveBeenCalledOnce(this: *Expect, globalThis: *JSGlobalObject, callfram
     if (!calls.jsType().isArray()) {
         var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
-        return globalThis.throw("Expected value must be a mock function: {f}", .{value.toFmt(&formatter)});
+        return globalThis.throw("Received value must be a mock function: {f}", .{value.toFmt(&formatter)});
     }
 
     const calls_length = try calls.getLength(globalThis);

--- a/src/bun.js/test/expect/toHaveBeenCalledTimes.zig
+++ b/src/bun.js/test/expect/toHaveBeenCalledTimes.zig
@@ -13,7 +13,7 @@ pub fn toHaveBeenCalledTimes(this: *Expect, globalThis: *JSGlobalObject, callfra
     if (!calls.jsType().isArray()) {
         var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
-        return globalThis.throw("Expected value must be a mock function: {f}", .{value.toFmt(&formatter)});
+        return globalThis.throw("Received value must be a mock function: {f}", .{value.toFmt(&formatter)});
     }
 
     if (arguments.len < 1 or !arguments[0].isUInt32AsAnyInt()) {

--- a/src/bun.js/test/expect/toHaveBeenLastCalledWith.zig
+++ b/src/bun.js/test/expect/toHaveBeenLastCalledWith.zig
@@ -26,7 +26,7 @@ pub fn toHaveBeenLastCalledWith(this: *Expect, globalThis: *JSGlobalObject, call
         if (!lastCallValue.jsType().isArray()) {
             var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
             defer formatter.deinit();
-            return globalThis.throw("Expected value must be a mock function with calls: {f}", .{value.toFmt(&formatter)});
+            return globalThis.throw("Received value must be a mock function with calls: {f}", .{value.toFmt(&formatter)});
         }
 
         if (try lastCallValue.getLength(globalThis) != arguments.len) {

--- a/src/bun.js/test/expect/toHaveLastReturnedWith.zig
+++ b/src/bun.js/test/expect/toHaveLastReturnedWith.zig
@@ -13,7 +13,7 @@ pub fn toHaveLastReturnedWith(this: *Expect, globalThis: *JSGlobalObject, callfr
     if (!returns.jsType().isArray()) {
         var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
-        return globalThis.throw("Expected value must be a mock function: {f}", .{value.toFmt(&formatter)});
+        return globalThis.throw("Received value must be a mock function: {f}", .{value.toFmt(&formatter)});
     }
 
     const calls_count = @as(u32, @intCast(try returns.getLength(globalThis)));

--- a/src/bun.js/test/expect/toHaveNthReturnedWith.zig
+++ b/src/bun.js/test/expect/toHaveNthReturnedWith.zig
@@ -21,7 +21,7 @@ pub fn toHaveNthReturnedWith(this: *Expect, globalThis: *JSGlobalObject, callfra
     if (!returns.jsType().isArray()) {
         var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
-        return globalThis.throw("Expected value must be a mock function: {f}", .{value.toFmt(&formatter)});
+        return globalThis.throw("Received value must be a mock function: {f}", .{value.toFmt(&formatter)});
     }
 
     const calls_count = @as(u32, @intCast(try returns.getLength(globalThis)));

--- a/src/bun.js/test/expect/toHaveReturnedWith.zig
+++ b/src/bun.js/test/expect/toHaveReturnedWith.zig
@@ -13,7 +13,7 @@ pub fn toHaveReturnedWith(this: *Expect, globalThis: *JSGlobalObject, callframe:
     if (!returns.jsType().isArray()) {
         var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };
         defer formatter.deinit();
-        return globalThis.throw("Expected value must be a mock function: {f}", .{value.toFmt(&formatter)});
+        return globalThis.throw("Received value must be a mock function: {f}", .{value.toFmt(&formatter)});
     }
 
     const calls_count = @as(u32, @intCast(try returns.getLength(globalThis)));

--- a/test/regression/issue/26996.test.ts
+++ b/test/regression/issue/26996.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/26996
+// Error messages should say "Received value" (the value passed to expect()),
+// not "Expected value" (which refers to the matcher argument in testing terminology).
+
+test("toThrow on non-function says 'Received value'", () => {
+  try {
+    expect(123).toThrow(Error);
+    throw new Error("should not reach here");
+  } catch (e: any) {
+    expect(e.message).toBe("Received value must be a function");
+  }
+});
+
+test("toHaveBeenCalled on non-mock says 'Received value'", () => {
+  try {
+    expect(123).toHaveBeenCalled();
+    throw new Error("should not reach here");
+  } catch (e: any) {
+    expect(e.message).toContain("Received value must be a mock function");
+  }
+});
+
+test("toHaveBeenCalledTimes on non-mock says 'Received value'", () => {
+  try {
+    expect(123).toHaveBeenCalledTimes(1);
+    throw new Error("should not reach here");
+  } catch (e: any) {
+    expect(e.message).toContain("Received value must be a mock function");
+  }
+});
+
+test("toContainKey on non-object says 'Received value'", () => {
+  try {
+    expect(123).toContainKey("foo");
+    throw new Error("should not reach here");
+  } catch (e: any) {
+    expect(e.message).toContain("Received value must be an object");
+  }
+});


### PR DESCRIPTION
## Summary

- Change error messages in `expect()` matchers to say "Received value must be..." instead of "Expected value must be..." when referring to the value passed to `expect()`, matching Jest's behavior
- Fixed 11 occurrences across `expect.zig` and 8 matcher files (`toThrow`, `toHaveBeenCalled`, `toHaveBeenCalledOnce`, `toHaveBeenCalledTimes`, `toHaveNthReturnedWith`, `toHaveReturnedWith`, `toHaveLastReturnedWith`, `toHaveBeenLastCalledWith`, `toContainKey`)
- Correctly left "Expected value" wording in matchers that validate the **matcher argument** (e.g., `toBeInstanceOf`, `toBeCloseTo`, `toMatch`, `toHaveLength`, `toThrow`'s expected type check)

Closes #26996

## Test plan

- [x] Added regression test `test/regression/issue/26996.test.ts` covering `toThrow`, `toHaveBeenCalled`, `toHaveBeenCalledTimes`, and `toContainKey`
- [x] Verified test fails with `USE_SYSTEM_BUN=1` (old "Expected value" messages)
- [x] Verified test passes with `bun bd test` (new "Received value" messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)