### PR TITLE
fix(install): don't apply minimum-release-age to transitive dependencies

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -725,7 +725,15 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
                                         if (version.tag == .npm and version.value.npm.version.isExact()) {
                                             if (loaded_manifest.?.findByVersion(version.value.npm.version.head.head.range.left.version)) |find_result| {
                                                 if (this.options.minimum_release_age_ms) |min_age_ms| {
-                                                    if (!loaded_manifest.?.shouldExcludeFromAgeFilter(this.options.minimum_release_age_excludes) and Npm.PackageManifest.isPackageVersionTooRecent(find_result.package, min_age_ms)) {
+                                                    // Only apply minimum-release-age to workspace dependencies
+                                                    // (direct deps of any workspace package.json).
+                                                    // Transitive dependencies should not be filtered, as they are
+                                                    // pinned by their parent package and filtering them would break
+                                                    // the dependency tree (see #27004).
+                                                    if (this.lockfile.isWorkspaceDependency(id) and
+                                                        !loaded_manifest.?.shouldExcludeFromAgeFilter(this.options.minimum_release_age_excludes) and
+                                                        Npm.PackageManifest.isPackageVersionTooRecent(find_result.package, min_age_ms))
+                                                    {
                                                         const package_name = this.lockfile.str(&name);
                                                         const min_age_seconds = min_age_ms / std.time.ms_per_s;
                                                         this.log.addErrorFmt(null, logger.Loc.Empty, this.allocator, "Version \"{s}@{f}\" was published within minimum release age of {d} seconds", .{ package_name, find_result.version.fmt(this.lockfile.buffers.string_bytes.items), min_age_seconds }) catch {};
@@ -1625,9 +1633,19 @@ fn getOrPutResolvedPackage(
                 this.options.minimum_release_age_ms != null,
             ) orelse return null; // manifest might still be downloading. This feels unreliable.
 
+            // Only apply minimum-release-age to workspace dependencies
+            // (direct deps of any workspace package.json).
+            // Transitive dependencies should not be filtered, as they are pinned
+            // by their parent package and filtering them would break the
+            // dependency tree (see #27004).
+            const effective_min_age_ms: ?f64 = if (this.lockfile.isWorkspaceDependency(dependency_id))
+                this.options.minimum_release_age_ms
+            else
+                null;
+
             const version_result: Npm.PackageManifest.FindVersionResult = switch (version.tag) {
-                .dist_tag => manifest.findByDistTagWithFilter(this.lockfile.str(&version.value.dist_tag.tag), this.options.minimum_release_age_ms, this.options.minimum_release_age_excludes),
-                .npm => manifest.findBestVersionWithFilter(version.value.npm.version, this.lockfile.buffers.string_bytes.items, this.options.minimum_release_age_ms, this.options.minimum_release_age_excludes),
+                .dist_tag => manifest.findByDistTagWithFilter(this.lockfile.str(&version.value.dist_tag.tag), effective_min_age_ms, this.options.minimum_release_age_excludes),
+                .npm => manifest.findBestVersionWithFilter(version.value.npm.version, this.lockfile.buffers.string_bytes.items, effective_min_age_ms, this.options.minimum_release_age_excludes),
                 else => unreachable,
             };
 


### PR DESCRIPTION
## Summary

- Fixed `minimum-release-age` incorrectly filtering transitive dependencies, causing install failures when a parent package pins an exact version of a child that was published too recently
- The age filter is now only applied to workspace dependencies (direct deps declared in any workspace `package.json`), not to transitive dependencies resolved from the registry

## Root Cause

When `minimum-release-age` is configured (e.g. via `bunfig.toml` or `--minimum-release-age`), the filter was applied uniformly to **all** dependencies including transitive ones. This meant that if `@types/bun@1.3.9` depended on exactly `bun-types@1.3.9`, and `bun-types@1.3.9` was published within the minimum release age window, the install would fail — even though the user only declared `@types/bun` as a direct dependency.

The fix uses `isWorkspaceDependency()` to check if a dependency is declared in any workspace's `package.json` before applying the age filter. Two code paths were fixed:

1. **Cached exact version path** (`PackageManagerEnqueue.zig:725`): When a cached exact version is found in the manifest cache
2. **Version resolution path** (`PackageManagerEnqueue.zig:1633`): When resolving versions via `findByDistTagWithFilter`/`findBestVersionWithFilter`

## Test plan

- [x] New test: "exact-pinned transitive dependencies that are too recent should not be filtered (#27004)" — uses a mock registry with `parent-package@1.0.0` (10 days old) depending on `recent-child-package@1.0.0` (1 day old, exact pin), verifies install succeeds with 5-day minimum-release-age
- [x] Verified new test fails with system bun (`USE_SYSTEM_BUN=1`) and passes with debug build
- [x] All 49 existing minimum-release-age tests pass (including monorepo tests)

Fixes #27004

🤖 Generated with [Claude Code](https://claude.com/claude-code)