### PR TITLE
fix(cmake): download baseline WebKit for x64 baseline builds

### DIFF
--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -9,9 +9,6 @@ if(NOT WEBKIT_VERSION)
   set(WEBKIT_VERSION 8af7958ff0e2a4787569edf64641a1ae7cfe074a)
 endif()
 
-# Use preview build URL for Windows ARM64 until the fix is merged to main
-set(WEBKIT_PREVIEW_PR 140)
-
 string(SUBSTRING ${WEBKIT_VERSION} 0 16 WEBKIT_VERSION_PREFIX)
 string(SUBSTRING ${WEBKIT_VERSION} 0 8 WEBKIT_VERSION_SHORT)
 
@@ -207,6 +204,12 @@ endif()
 
 if(LINUX AND ABI STREQUAL "musl")
   set(WEBKIT_SUFFIX "-musl")
+endif()
+
+# Baseline builds target older CPUs without AVX/AVX2 (e.g. Nehalem).
+# They require a WebKit library also compiled without AVX/AVX2 instructions.
+if(ENABLE_BASELINE AND WEBKIT_ARCH STREQUAL "amd64")
+  set(WEBKIT_SUFFIX "${WEBKIT_SUFFIX}-baseline")
 endif()
 
 if(DEBUG)


### PR DESCRIPTION
## Summary

- Adds `-baseline` suffix to WebKit download URL when `ENABLE_BASELINE` is set for x64 builds, so baseline Bun links against a WebKit compiled without AVX/AVX2 instructions
- Removes unused `WEBKIT_PREVIEW_PR` variable (WebKit PR #140 was already merged)

## Root cause

When `ENABLE_BASELINE` is set, Bun's own code is compiled with `-march=nehalem` (SSE4.2 only, no AVX). However, `SetupWebKit.cmake` was downloading the regular WebKit tarball (`bun-webkit-linux-amd64.tar.gz`) which is compiled with AVX/AVX2 support. When baseline Bun called into WebKit/JSC on a non-AVX CPU, it hit AVX instructions and crashed with SIGILL (exit code 132).

## Fix

The suffix computation now includes a check for `ENABLE_BASELINE`:

```cmake
if(ENABLE_BASELINE AND WEBKIT_ARCH STREQUAL "amd64")
  set(WEBKIT_SUFFIX "${WEBKIT_SUFFIX}-baseline")
endif()
```

This produces the correct artifact names matching [oven-sh/WebKit PR #137](https://github.com/oven-sh/WebKit/pull/137):
- `bun-webkit-linux-amd64-baseline.tar.gz`
- `bun-webkit-linux-amd64-baseline-lto.tar.gz`
- `bun-webkit-linux-amd64-musl-baseline.tar.gz`
- `bun-webkit-linux-amd64-musl-baseline-lto.tar.gz`

## Dependencies

This fix requires [oven-sh/WebKit PR #137](https://github.com/oven-sh/WebKit/pull/137) to be merged first so that the baseline WebKit artifacts exist in releases. Until then, baseline CI builds will fail to download WebKit (which is the desired behavior - it's better to fail loudly at build time than to silently link AVX-enabled WebKit into a baseline binary).

## Test plan

- [ ] Verify suffix computation produces correct download URLs for all combinations (baseline, baseline+musl, baseline+lto, baseline+musl+lto)
- [ ] After oven-sh/WebKit PR #137 is merged: verify baseline x64 build downloads and links against the correct WebKit
- [ ] After oven-sh/WebKit PR #137 is merged: verify baseline Bun runs without SIGILL on non-AVX CPUs

Closes #27006

🤖 Generated with [Claude Code](https://claude.com/claude-code)