### PR TITLE
fix(stripANSI): handle SIMD false positives for non-ANSI control chars

### DIFF
--- a/src/bun.js/bindings/stripANSI.cpp
+++ b/src/bun.js/bindings/stripANSI.cpp
@@ -42,6 +42,13 @@ static std::optional<WTF::String> stripANSI(const std::span<const Char> input)
         // Append everything before the escape sequence
         result.append(std::span { start, escPos });
         const auto newPos = ANSI::consumeANSI(escPos, end);
+        if (newPos == escPos) {
+            // No ANSI found
+            result.append(std::span { escPos, escPos + 1 });
+            start = escPos + 1;
+            continue;
+        }
+
         ASSERT(newPos > start);
         ASSERT(newPos <= end);
         foundANSI = true;

--- a/test/regression/issue/27014.test.ts
+++ b/test/regression/issue/27014.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/27014
+test("Bun.stripANSI does not hang on non-ANSI control characters", () => {
+  const s = "\u0016zo\u00BAd\u0019\u00E8\u00E0\u0013?\u00C1+\u0014d\u00D3\u00E9";
+  const result = Bun.stripANSI(s);
+  expect(result).toBe(s);
+});


### PR DESCRIPTION
The SIMD fast path in `findEscapeCharacter` matches bytes in `0x10-0x1F` and `0x90-0x9F`, but `consumeANSI` only handles actual ANSI escape introducers (`0x1b`, `0x9b`, `0x9d`, `0x90`, `0x98`, `0x9e`, `0x9f`). For non-ANSI bytes like `0x16` (SYN), `consumeANSI` returns the same pointer it received, causing an infinite loop in release builds and an assertion failure in debug builds.

When a SIMD false positive is detected (`consumeANSI` returns the same pointer), the byte is preserved in the output and scanning advances past it.

Fixes #27014