### PR TITLE
fix(stripANSI): avoid perf cliff on control-heavy input

### DIFF
--- a/test/regression/issue/27014.test.ts
+++ b/test/regression/issue/27014.test.ts
@@ -6,3 +6,9 @@ test("Bun.stripANSI does not hang on non-ANSI control characters", () => {
   const result = Bun.stripANSI(s);
   expect(result).toBe(s);
 });
+
+test("Bun.stripANSI does not hang on large control-heavy strings", () => {
+  const s = "\x1c".repeat(200_000);
+  const result = Bun.stripANSI(s);
+  expect(result).toBe(s);
+});

--- a/test/regression/issue/27014.test.ts
+++ b/test/regression/issue/27014.test.ts
@@ -8,7 +8,7 @@ test("Bun.stripANSI does not hang on non-ANSI control characters", () => {
 });
 
 test("Bun.stripANSI does not hang on large control-heavy strings", () => {
-  const s = "\x1c".repeat(200_000);
+  const s = Buffer.alloc(200_000, 0x1c).toString();
   const result = Bun.stripANSI(s);
   expect(result).toBe(s);
 });


### PR DESCRIPTION
Bun.stripANSI() can get extremely slow on control-heavy input that is not actually ANSI (for example U+001C repeated), pegging CPU.

This validates SIMD candidates in findEscapeCharacter() and keeps scanning the current SIMD chunk on false positives, so we stay linear on inputs like "\x1c".repeat(n).

Adds a regression test for "\x1c".repeat(200_000).

Tests:
- ./build/debug/bun-debug test test/regression/issue/27014.test.ts
- ./build/debug/bun-debug test test/js/bun/util/stripANSI.test.ts