### PR TITLE
fix(install): use hash map for O(1) lookups in dependency hoisting

### DIFF
--- a/test/regression/issue/27033.test.ts
+++ b/test/regression/issue/27033.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Regression test for #27033: `bun install` had exponential slowdown with workspace
+// configurations containing many packages with overlapping transitive dependencies.
+// The root cause was O(n) linear scans in hoistDependency() for each dependency being
+// hoisted, resulting in O(n^2) behavior when many deps are hoisted to the root tree.
+test("workspace install with many overlapping workspace dependencies does not hang", async () => {
+  // Create a workspace with many workspace packages that cross-reference each other.
+  // This exercises the hoisting code path that was O(n^2) before the fix.
+  // With 30 workspace packages each depending on all others, this creates ~900
+  // dependency edges that all need to be hoisted.
+  const numPackages = 30;
+  const files: Record<string, string> = {};
+
+  for (let i = 0; i < numPackages; i++) {
+    const deps: Record<string, string> = {};
+    // Each package depends on all other packages
+    for (let j = 0; j < numPackages; j++) {
+      if (i !== j) {
+        deps[`pkg-${j}`] = "workspace:*";
+      }
+    }
+    files[`packages/pkg-${i}/package.json`] = JSON.stringify({
+      name: `pkg-${i}`,
+      version: "1.0.0",
+      dependencies: deps,
+    });
+  }
+
+  using dir = tempDir("issue-27033", {
+    "package.json": JSON.stringify({
+      name: "workspace-root",
+      private: true,
+      workspaces: ["packages/*"],
+    }),
+    ...files,
+  });
+
+  // Before the fix, this would hang or take >60s with many overlapping deps.
+  // After the fix, it should complete in a few seconds.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("panic:");
+  expect(stderr).not.toContain("error:");
+  expect(stdout).toContain("31 packages");
+  expect(exitCode).toBe(0);
+}, 30_000);


### PR DESCRIPTION
## Summary

- Replace O(n) linear scan in `hoistDependency()` with O(1) hash map lookup per tree node
- Add per-tree `NameHashMap` (PackageNameHash → DependencyID) maintained alongside dependency lists
- Fixes exponential slowdown in workspace installs with many overlapping transitive dependencies

## Root Cause

The `hoistDependency` function in `Tree.zig` linearly scanned all dependencies placed in each tree to find a matching `name_hash`. For each dependency being hoisted, this scan walked up the tree hierarchy, scanning at every level. In workspace configurations with many overlapping transitive dependencies (e.g., 20+ `@tamagui/*` packages sharing hundreds of common transitive deps), the root tree accumulated hundreds of dependencies, making each subsequent lookup O(n). Combined with the recursive tree walk, this produced O(n²) overall behavior.

This caused `bun install` to hang indefinitely (>120s) in workspace setups that completed in ~4.5s as flat projects.

## Fix

Added a `NameHashMap` (`std.AutoHashMapUnmanaged(PackageNameHash, DependencyID)`) to each tree node in the builder. The map is updated whenever a dependency is placed (`.placement`) or replaced (`.resolve_replace`). The linear scan in `hoistDependency` is replaced with a single hash map lookup, reducing the per-dependency hoisting cost from O(n) to O(1).

## Test plan

- [x] Added regression test `test/regression/issue/27033.test.ts` - workspace with 30 cross-referencing packages
- [x] Existing workspace tests pass (50/50 non-Verdaccio tests)
- [x] Debug build compiles successfully
- [x] `bun bd test test/regression/issue/27033.test.ts` passes

Closes #27033

🤖 Generated with [Claude Code](https://claude.com/claude-code)