### PR TITLE
fix(process): support running Bun inside macOS App Sandbox

### DIFF
--- a/test/js/bun/test-macos-app-sandbox.test.ts
+++ b/test/js/bun/test-macos-app-sandbox.test.ts
@@ -84,11 +84,7 @@ describe.skipIf(!isMacOS)("macOS App Sandbox", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout.trim()).toBe("hello sandbox");
     expect(exitCode).toBe(0);
@@ -106,11 +102,7 @@ describe.skipIf(!isMacOS)("macOS App Sandbox", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout.trim()).toContain("Library/Containers/dev.bun.test.bun_sandboxed");
     expect(exitCode).toBe(0);

--- a/test/js/bun/test-macos-app-sandbox.test.ts
+++ b/test/js/bun/test-macos-app-sandbox.test.ts
@@ -1,32 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { copyFileSync } from "fs";
+import { copyFileSync, rmSync } from "fs";
+import { homedir } from "os";
 import { bunEnv, bunExe, isMacOS, tempDir } from "harness";
 import { join } from "path";
-
-const infoPlist = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>CFBundleExecutable</key>
-	<string>bun</string>
-	<key>CFBundleIdentifier</key>
-	<string>dev.bun.test.bun_sandboxed</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>bun_sandboxed</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
-	<key>CFBundleSupportedPlatforms</key>
-	<array>
-		<string>MacOSX</string>
-	</array>
-	<key>CFBundleVersion</key>
-	<string>1</string>
-</dict>
-</plist>`;
 
 const entitlementsPlist = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -45,12 +21,39 @@ const entitlementsPlist = `<?xml version="1.0" encoding="UTF-8"?>
 </dict>
 </plist>`;
 
-async function createSandboxedApp(prefix: string) {
+function makeInfoPlist(bundleId: string) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>bun</string>
+	<key>CFBundleIdentifier</key>
+	<string>${bundleId}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>bun_sandboxed</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>`;
+}
+
+async function createSandboxedApp(prefix: string, bundleId: string) {
   const dir = tempDir(prefix, {
     "entitlements.plist": entitlementsPlist,
     "bun_sandboxed.app": {
       "Contents": {
-        "Info.plist": infoPlist,
+        "Info.plist": makeInfoPlist(bundleId),
         "MacOS": {},
       },
     },
@@ -65,46 +68,60 @@ async function createSandboxedApp(prefix: string) {
   await using codesign = Bun.spawn({
     cmd: ["/usr/bin/codesign", "--entitlements", entitlementsPath, "--force", "-s", "-", appBundlePath],
     env: bunEnv,
-    stderr: "pipe",
+    stdout: "pipe",
+    stderr: "inherit",
   });
   expect(await codesign.exited).toBe(0);
 
-  return { dir, bunPath };
+  return { dir, bunPath, bundleId, containerPath: join(homedir(), "Library", "Containers", bundleId) };
 }
 
 // Modeled after Node.js's test/parallel/test-macos-app-sandbox.js
 describe.skipIf(!isMacOS)("macOS App Sandbox", () => {
   test.concurrent("bun can execute JavaScript inside the app sandbox", async () => {
-    const { dir, bunPath } = await createSandboxedApp("macos-sandbox-test");
+    const { dir, bunPath, containerPath } = await createSandboxedApp("macos-sandbox-test", "dev.bun.test.sandbox_exec");
     using _dir = dir;
 
-    await using proc = Bun.spawn({
-      cmd: [bunPath, "-e", "console.log('hello sandbox')"],
-      env: bunEnv,
-      stderr: "pipe",
-    });
+    try {
+      await using proc = Bun.spawn({
+        cmd: [bunPath, "-e", "console.log('hello sandbox')"],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "inherit",
+      });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
-    expect(stdout.trim()).toBe("hello sandbox");
-    expect(exitCode).toBe(0);
+      expect(stdout.trim()).toBe("hello sandbox");
+      expect(exitCode).toBe(0);
+    } finally {
+      rmSync(containerPath, { recursive: true, force: true });
+    }
   });
 
   test.concurrent("sandboxed bun runs inside the sandbox container", async () => {
-    const { dir, bunPath } = await createSandboxedApp("macos-sandbox-test-container");
+    const { dir, bunPath, bundleId, containerPath } = await createSandboxedApp(
+      "macos-sandbox-test-container",
+      "dev.bun.test.sandbox_container",
+    );
     using _dir = dir;
 
-    // When running inside a macOS App Sandbox, os.homedir() should return
-    // the sandbox container path, not the real home directory.
-    await using proc = Bun.spawn({
-      cmd: [bunPath, "-e", "console.log(require('os').homedir())"],
-      env: bunEnv,
-      stderr: "pipe",
-    });
+    try {
+      // When running inside a macOS App Sandbox, os.homedir() should return
+      // the sandbox container path, not the real home directory.
+      await using proc = Bun.spawn({
+        cmd: [bunPath, "-e", "console.log(require('os').homedir())"],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "inherit",
+      });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
-    expect(stdout.trim()).toContain("Library/Containers/dev.bun.test.bun_sandboxed");
-    expect(exitCode).toBe(0);
+      expect(stdout.trim()).toContain(`Library/Containers/${bundleId}`);
+      expect(exitCode).toBe(0);
+    } finally {
+      rmSync(containerPath, { recursive: true, force: true });
+    }
   });
 });

--- a/test/js/bun/test-macos-app-sandbox.test.ts
+++ b/test/js/bun/test-macos-app-sandbox.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+import { copyFileSync, mkdirSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+const isMacOS = process.platform === "darwin";
+
+// Modeled after Node.js's test/parallel/test-macos-app-sandbox.js
+describe.skipIf(!isMacOS)("macOS App Sandbox", () => {
+  test("bun can execute JavaScript inside the app sandbox", () => {
+    using dir = tempDir("macos-sandbox-test");
+
+    const appBundlePath = join(String(dir), "bun_sandboxed.app");
+    const contentsPath = join(appBundlePath, "Contents");
+    const macOSPath = join(contentsPath, "MacOS");
+    const bunPath = join(macOSPath, "bun");
+
+    // Create app bundle structure:
+    // bun_sandboxed.app/
+    // └── Contents
+    //     ├── Info.plist
+    //     └── MacOS
+    //         └── bun
+    mkdirSync(appBundlePath);
+    mkdirSync(contentsPath);
+    mkdirSync(macOSPath);
+
+    writeFileSync(
+      join(contentsPath, "Info.plist"),
+      `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>bun</string>
+	<key>CFBundleIdentifier</key>
+	<string>dev.bun.test.bun_sandboxed</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>bun_sandboxed</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>`,
+    );
+
+    const entitlementsPath = join(String(dir), "entitlements.plist");
+    writeFileSync(
+      entitlementsPath,
+      `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-executable-page-protection</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>`,
+    );
+
+    // Copy the bun binary into the app bundle
+    copyFileSync(bunExe(), bunPath);
+
+    // Sign the app bundle with sandbox entitlements
+    const codesignResult = Bun.spawnSync({
+      cmd: ["/usr/bin/codesign", "--entitlements", entitlementsPath, "--force", "-s", "-", appBundlePath],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    expect(codesignResult.exitCode).toBe(0);
+
+    // Run bun inside the sandbox
+    const result = Bun.spawnSync({
+      cmd: [bunPath, "-e", "console.log('hello sandbox')"],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const stdout = result.stdout.toString().trim();
+    const stderr = result.stderr.toString();
+
+    // Assert stdout before exit code for better error messages
+    expect(stdout).toBe("hello sandbox");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("sandboxed bun cannot read the home directory", () => {
+    using dir = tempDir("macos-sandbox-test-homedir");
+
+    const appBundlePath = join(String(dir), "bun_sandboxed.app");
+    const contentsPath = join(appBundlePath, "Contents");
+    const macOSPath = join(contentsPath, "MacOS");
+    const bunPath = join(macOSPath, "bun");
+
+    mkdirSync(appBundlePath);
+    mkdirSync(contentsPath);
+    mkdirSync(macOSPath);
+
+    writeFileSync(
+      join(contentsPath, "Info.plist"),
+      `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>bun</string>
+	<key>CFBundleIdentifier</key>
+	<string>dev.bun.test.bun_sandboxed</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>bun_sandboxed</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>`,
+    );
+
+    const entitlementsPath = join(String(dir), "entitlements.plist");
+    writeFileSync(
+      entitlementsPath,
+      `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-executable-page-protection</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>`,
+    );
+
+    copyFileSync(bunExe(), bunPath);
+
+    const codesignResult = Bun.spawnSync({
+      cmd: ["/usr/bin/codesign", "--entitlements", entitlementsPath, "--force", "-s", "-", appBundlePath],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    expect(codesignResult.exitCode).toBe(0);
+
+    // Sandboxed app should not be able to read the home directory.
+    // Print a marker first to confirm the process started successfully
+    // before the sandboxed filesystem access fails.
+    const homedir = Bun.env.HOME ?? "/Users";
+    const result = Bun.spawnSync({
+      cmd: [
+        bunPath,
+        "-e",
+        `process.stdout.write("SANDBOX_START\\n"); require('fs').readdirSync(${JSON.stringify(homedir)})`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const stdout = result.stdout.toString();
+    expect(stdout).toContain("SANDBOX_START");
+    expect(result.exitCode).not.toBe(0);
+  });
+});

--- a/test/js/bun/test-macos-app-sandbox.test.ts
+++ b/test/js/bun/test-macos-app-sandbox.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { copyFileSync, rmSync } from "fs";
-import { homedir } from "os";
 import { bunEnv, bunExe, isMacOS, tempDir } from "harness";
+import { homedir } from "os";
 import { join } from "path";
 
 const entitlementsPlist = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary

Fixes two issues in `bun_initialize_process()` that prevent Bun from running inside a macOS App Sandbox (`com.apple.security.app-sandbox`):

- **TTY state capture fix**: Move `bun_stdio_tty[fd] = 1` inside the `tcgetattr` success check. In the macOS App Sandbox, `tcgetattr` fails with `EPERM` even though `isatty()` returns true. Previously the TTY flag was set unconditionally, causing `bun_restore_stdio()` to call `tcsetattr` with uninitialized termios state at exit. This is the same class of bug Node.js fixed in [nodejs/node#33944](https://github.com/nodejs/node/pull/33944).

- **`dup2` return value bug**: `dup2(oldfd, newfd)` returns `newfd` on success (not 0), so the check `err != 0` incorrectly triggered `abort()` for stdout/stderr (fd 1 and 2). Changed to `err < 0` and replaced `abort()` with a graceful fallback. Also handles `open("/dev/null")` failure gracefully for restricted environments.

Closes #15661

## Test plan

- [x] Build succeeds (`bun bd`)
- [x] Existing TTY tests pass (`tty.test.ts`, `nodettywrap.test.ts`)
- [x] New `test-macos-app-sandbox.test.ts` correctly skips on non-macOS
- [ ] On macOS: new test creates app bundle, signs with sandbox entitlements, runs `bun -e` inside sandbox, verifies exit code 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)