### PR TITLE
fix(fs.watch): fix second watcher not receiving events after close

### DIFF
--- a/test/regression/issue/18919.test.ts
+++ b/test/regression/issue/18919.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/18919
+test("fs.watch works after previous watcher is closed", async () => {
+  using dir = tempDir("issue-18919", {
+    "test.txt": "A",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const fs = require('fs');
+const path = require('path');
+const file = path.join(process.cwd(), 'test.txt');
+
+const watcher_first = fs.watch(file, () => {
+  console.log('File changed');
+  watcher_first.close();
+
+  const watcher_second = fs.watch(file, () => {
+    console.log('File changed again');
+    watcher_second.close();
+  });
+
+  setTimeout(() => {
+    fs.writeFileSync(file, 'C');
+  }, 200);
+});
+
+setTimeout(() => {
+  fs.writeFileSync(file, 'B');
+}, 200);
+`,
+    ],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("File changed");
+  expect(stdout).toContain("File changed again");
+  expect(exitCode).toBe(0);
+}, 10_000);


### PR DESCRIPTION
## Summary

- Fixes `fs.watch` not receiving events when a new watcher is created for the same file after a previous watcher is closed (#18919)
- Fixes a use-after-free (ASAN: use-after-poison) in the file watcher thread when path memory was freed while still referenced by watchlist entries

### Root cause

When `fs.watch` is closed, its watchlist entry is marked for **deferred eviction** (not immediately removed). When a new `fs.watch` is created for the same file, `Watcher.addFile` finds the stale entry by hash and returns early — skipping inotify/kqueue registration for the new file descriptor. The watcher thread eventually evicts the old entry and closes its fd, leaving the new watcher with no active platform watch.

Additionally, `_decrementPathRefNoLock` freed the path string while it was still referenced by the watcher thread's watchlist entries (including parent directory entries whose `file_path` is a substring of the freed path), causing use-after-free on the watcher thread.

### Fix

1. **`Watcher.addFile`**: When an existing entry with matching hash is found and it's pending eviction, revive it by removing from the eviction list and updating in-place with the new fd, file path, and platform watch registration (`reviveEvictedEntry`).
2. **`_decrementPathRefNoLock`**: Don't free the path string — it's still referenced by the watchlist. Accept the small bounded leak (one path string per close/re-watch cycle) rather than risk memory corruption.

## Test plan

- [x] New regression test `test/regression/issue/18919.test.ts` — creates a watcher, triggers an event, closes it, creates a second watcher on the same file, and verifies the second watcher receives events
- [x] Test fails with system bun (`USE_SYSTEM_BUN=1`) — confirms the bug exists
- [x] Test passes with debug build (`bun bd test`) — confirms the fix works
- [x] No ASAN errors in debug build
- [x] Existing `test/js/node/watch/` tests pass (same pre-existing failures as before)

Fixes #18919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)