### PR TITLE
fix(http): fix setHeaders throwing ERR_HTTP_HEADERS_SENT on new requests

### DIFF
--- a/src/js/node/_http_outgoing.ts
+++ b/src/js/node/_http_outgoing.ts
@@ -271,7 +271,7 @@ const OutgoingMessagePrototype = {
     return this;
   },
   setHeaders(headers) {
-    if (this._header || this[headerStateSymbol] !== NodeHTTPHeaderState.none) {
+    if ((this._header !== undefined && this._header !== null) || this[headerStateSymbol] == NodeHTTPHeaderState.sent) {
       throw $ERR_HTTP_HEADERS_SENT("set");
     }
 

--- a/src/js/node/_http_outgoing.ts
+++ b/src/js/node/_http_outgoing.ts
@@ -271,7 +271,7 @@ const OutgoingMessagePrototype = {
     return this;
   },
   setHeaders(headers) {
-    if ((this._header != null) || this[headerStateSymbol] == NodeHTTPHeaderState.sent) {
+    if ((this._header != null) || this[headerStateSymbol] === NodeHTTPHeaderState.sent) {
       throw $ERR_HTTP_HEADERS_SENT("set");
     }
 

--- a/src/js/node/_http_outgoing.ts
+++ b/src/js/node/_http_outgoing.ts
@@ -271,7 +271,7 @@ const OutgoingMessagePrototype = {
     return this;
   },
   setHeaders(headers) {
-    if ((this._header !== undefined && this._header !== null) || this[headerStateSymbol] == NodeHTTPHeaderState.sent) {
+    if ((this._header != null) || this[headerStateSymbol] == NodeHTTPHeaderState.sent) {
       throw $ERR_HTTP_HEADERS_SENT("set");
     }
 

--- a/test/regression/issue/27049.test.ts
+++ b/test/regression/issue/27049.test.ts
@@ -68,18 +68,22 @@ test("ServerResponse.setHeaders should not throw before headers are sent", async
     res.end("ok");
   });
 
-  server.listen(0, () => {
-    const port = (server.address() as any).port;
-    const req = http.request(`http://localhost:${port}/test`, res => {
-      resolve(res.headers["x-custom"] as string);
-      server.close();
+  try {
+    server.listen(0, () => {
+      const port = (server.address() as any).port;
+      try {
+        const req = http.request(`http://localhost:${port}/test`, res => {
+          resolve(res.headers["x-custom"] as string);
+        });
+        req.on("error", reject);
+        req.end();
+      } catch (e) {
+        reject(e);
+      }
     });
-    req.on("error", e => {
-      server.close();
-      reject(e);
-    });
-    req.end();
-  });
 
-  expect(await promise).toBe("server-value");
+    expect(await promise).toBe("server-value");
+  } finally {
+    server.close();
+  }
 });

--- a/test/regression/issue/27049.test.ts
+++ b/test/regression/issue/27049.test.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "bun:test";
+import http from "node:http";
+
+test("ClientRequest.setHeaders should not throw ERR_HTTP_HEADERS_SENT on new request", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      return new Response(req.headers.get("x-test") ?? "missing");
+    },
+  });
+
+  const { resolve, reject, promise } = Promise.withResolvers<string>();
+
+  const req = http.request(`http://localhost:${server.port}/test`, { method: "GET" }, res => {
+    let data = "";
+    res.on("data", (chunk: Buffer) => {
+      data += chunk.toString();
+    });
+    res.on("end", () => resolve(data));
+  });
+
+  req.on("error", reject);
+
+  // This should not throw - headers haven't been sent yet
+  req.setHeaders(new Headers({ "x-test": "value" }));
+
+  req.end();
+
+  const body = await promise;
+  expect(body).toBe("value");
+});
+
+test("ClientRequest.setHeaders works with Map", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      return new Response(req.headers.get("x-map-test") ?? "missing");
+    },
+  });
+
+  const { resolve, reject, promise } = Promise.withResolvers<string>();
+
+  const req = http.request(`http://localhost:${server.port}/test`, { method: "GET" }, res => {
+    let data = "";
+    res.on("data", (chunk: Buffer) => {
+      data += chunk.toString();
+    });
+    res.on("end", () => resolve(data));
+  });
+
+  req.on("error", reject);
+
+  req.setHeaders(new Map([["x-map-test", "map-value"]]));
+
+  req.end();
+
+  const body = await promise;
+  expect(body).toBe("map-value");
+});
+
+test("ServerResponse.setHeaders should not throw before headers are sent", async () => {
+  const { resolve, reject, promise } = Promise.withResolvers<string>();
+
+  const server = http.createServer((req, res) => {
+    // This should not throw - headers haven't been sent yet
+    res.setHeaders(new Headers({ "x-custom": "server-value" }));
+    res.writeHead(200);
+    res.end("ok");
+  });
+
+  server.listen(0, () => {
+    const port = (server.address() as any).port;
+    const req = http.request(`http://localhost:${port}/test`, res => {
+      resolve(res.headers["x-custom"] as string);
+      server.close();
+    });
+    req.on("error", e => {
+      server.close();
+      reject(e);
+    });
+    req.end();
+  });
+
+  expect(await promise).toBe("server-value");
+});


### PR DESCRIPTION
## Summary

- Fix `OutgoingMessage.setHeaders()` incorrectly throwing `ERR_HTTP_HEADERS_SENT` on brand new `ClientRequest` instances
- The guard condition `this[headerStateSymbol] !== NodeHTTPHeaderState.none` failed when `headerStateSymbol` was `undefined` (since `ClientRequest` doesn't call the `OutgoingMessage` constructor), and was also stricter than Node.js which only checks `this._header`
- Align the check with the working `setHeader()` (singular) method: only throw when `_header` is set or `headerStateSymbol` equals `sent`

Closes #27049

## Test plan
- [x] New regression test `test/regression/issue/27049.test.ts` covers:
  - `ClientRequest.setHeaders()` with `Headers` object
  - `ClientRequest.setHeaders()` with `Map`
  - `ServerResponse.setHeaders()` before headers are sent
- [x] Test fails with system bun (`USE_SYSTEM_BUN=1`)
- [x] Test passes with debug build (`bun bd test`)
- [x] Existing header-related tests in `node-http.test.ts` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)