### PR TITLE
fix(types): Add missing string/object types for the metafile bundler option

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2753,7 +2753,13 @@ declare module "bun" {
      * which can be used for bundle analysis, visualization, or integration with
      * other tools.
      *
-     * When `true`, the metafile JSON string is included in the {@link BuildOutput.metafile} property.
+     * - If set to one of: `true`, a string, or an object, the metafile data is populated into
+     *   the {@link BuildOutput.metafile} property.
+     *    - If set to a string containing a path (relative to {@link BuildConfig.outdir}), a
+     *      JSON metafile will additionally be written to that location.
+     *    - If set to an object, paths to write JSON and/or markdown formats can be
+     *      individually set (relative to {@link BuildConfig.outdir}), and the respective
+     *      metafiles will be written to those locations for any formats that were defined.
      *
      * @default false
      *
@@ -2762,21 +2768,66 @@ declare module "bun" {
      * const result = await Bun.build({
      *   entrypoints: ['./src/index.ts'],
      *   outdir: './dist',
+     *   // Enable population of the metafile property in the result object
      *   metafile: true,
      * });
-     *
-     * // Write metafile to disk for analysis
+     * 
      * if (result.metafile) {
-     *   await Bun.write('./dist/meta.json', result.metafile);
+     *   // Analyze inputs
+     *   for (const [path, meta] of Object.entries(result.metafile.inputs)) {
+     *     console.log(`${path}: ${meta.bytes} bytes`);
+     *   }
+     * 
+     *   // Analyze outputs
+     *   for (const [path, meta] of Object.entries(result.metafile.outputs)) {
+     *     console.log(`${path}: ${meta.bytes} bytes`);
+     *   }
+
+     *   // Save for external analysis tools
+     *   await Bun.write('./dist/meta.json', JSON.stringify(result.metafile));
      * }
      *
-     * // Parse and analyze the metafile
-     * const meta = JSON.parse(result.metafile!);
-     * console.log('Input files:', Object.keys(meta.inputs));
-     * console.log('Output files:', Object.keys(meta.outputs));
+     * ```
+     *
+     * @example
+     * ```ts
+     * const result = await Bun.build({
+     *   entrypoints: ['./src/index.ts'],
+     *   outdir: './dist',
+     *   // Write metafile in JSON format to ./dist/meta.json
+     *   metafile: './meta.json',
+     * });
+     *
+     * // `metafile` property is also populated
+     * console.log(result.metafile)
+     *
+     * ```
+     *
+     * @example
+     * ```ts
+     * const result = await Bun.build({
+     *   entrypoints: ['./src/index.ts'],
+     *   outdir: './dist',
+     *   metafile: {
+     *     // Write metafile in JSON format to ./dist/meta.json
+     *     json: 'meta.json',
+     *     // Write metafile in markdown format to ./dist/meta.md
+     *     markdown: 'meta.md',
+     *   }
+     * });
+     *
+     * // `metafile` property is also populated
+     * console.log(result.metafile)
+     *
      * ```
      */
-    metafile?: boolean;
+    metafile?:
+      | boolean
+      | string
+      | {
+          json?: string;
+          markdown?: string;
+        };
 
     outdir?: string;
 
@@ -3408,7 +3459,7 @@ declare module "bun" {
     /**
      * Metadata about the build including inputs, outputs, and their relationships.
      *
-     * Only present when {@link BuildConfig.metafile} is `true`.
+     * Only present when {@link BuildConfig.metafile} is enabled (`true`, string, or object).
      *
      * The metafile contains detailed information about:
      * - **inputs**: All source files that were bundled, their byte sizes, imports, and format


### PR DESCRIPTION
### What does this PR do?

https://github.com/oven-sh/bun/pull/26441 added new capabilities to the `metafile` build option, which were then documented in https://github.com/oven-sh/bun/commit/4feede90f549ec8743243685ca25ce6c88e53e53.

However, the TypeScript types for these capabilities (specifically, the new string/object values) are missing. This adds them.

Additionally to this the existing `@example` was outdated (referenced that `BuildOutput.metafile` was a JSON string, which is no longer correct -- its a deserialised object).

### How did you verify your code works?
Point replacement of existing declaration file with my new one, and subsequent consumption of it to verify new option values correctly type check.
