### PR TITLE
refactor: hoist pre-computed slices into isFilteredDependencyOrWorkspace args

### DIFF
--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -18,6 +18,7 @@ pub fn installIsolatedPackages(
         const pkg_dependency_slices = pkgs.items(.dependencies);
         const pkg_resolutions = pkgs.items(.resolution);
         const pkg_names = pkgs.items(.name);
+        const pkg_metas = pkgs.items(.meta);
 
         const resolutions = lockfile.buffers.resolutions.items;
         const dependencies = lockfile.buffers.dependencies.items;
@@ -222,7 +223,12 @@ pub fn installIsolatedPackages(
                         workspace_filters,
                         install_root_dependencies,
                         manager,
-                        lockfile,
+                        pkg_names,
+                        pkg_metas,
+                        pkg_resolutions,
+                        resolutions,
+                        dependencies,
+                        string_buf,
                     )) {
                         continue;
                     }


### PR DESCRIPTION
## Summary
- Refactored `isFilteredDependencyOrWorkspace` to receive pre-computed slices (`pkg_names`, `pkg_metas`, `pkg_resolutions`, `buf_resolutions`, `buf_dependencies`, `string_bytes`) as arguments instead of computing them from the lockfile on every call
- Updated both callers: `installIsolatedPackages` in `isolated_install.zig` and `processSubtree` in `Tree.zig`
- Avoids redundant `.slice()` / `.items()` calls inside the hot `next_node` loop

## Test plan
- [x] `bun bd` compiles successfully
- [ ] Existing install tests pass (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)