### PR TITLE
fix(compile): enable package.json loading by default in compiled executables

### DIFF
--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -276,7 +276,7 @@ pub const JSBundler = struct {
             autoload_dotenv: bool = true,
             autoload_bunfig: bool = true,
             autoload_tsconfig: bool = false,
-            autoload_package_json: bool = false,
+            autoload_package_json: bool = true,
 
             pub fn fromJS(globalThis: *jsc.JSGlobalObject, config: jsc.JSValue, allocator: std.mem.Allocator, compile_target: ?CompileTarget) JSError!?CompileOptions {
                 var this = CompileOptions{

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -477,7 +477,7 @@ pub const Command = struct {
             compile_autoload_dotenv: bool = true,
             compile_autoload_bunfig: bool = true,
             compile_autoload_tsconfig: bool = false,
-            compile_autoload_package_json: bool = false,
+            compile_autoload_package_json: bool = true,
             compile_executable_path: ?[]const u8 = null,
             windows: options.WindowsOptions = .{},
         };

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -564,6 +564,54 @@ describe("bundler", () => {
     },
     compile: true,
   });
+  // https://github.com/oven-sh/bun/issues/27058
+  itBundled("compile/DynamicRequireWithPackageJsonMain", {
+    files: {
+      "/entry.tsx": /* tsx */ `
+        const req = (x) => require(x);
+        const result = req('pkg-with-main');
+        console.log(JSON.stringify(result));
+      `,
+      "/node_modules/pkg-with-main/package.json": JSON.stringify({ name: "pkg-with-main", main: "lib/index.js" }),
+      "/node_modules/pkg-with-main/lib/index.js": "throw new Error('Must be runtime import.')",
+    },
+    runtimeFiles: {
+      "/node_modules/pkg-with-main/package.json": JSON.stringify({ name: "pkg-with-main", main: "lib/index.js" }),
+      "/node_modules/pkg-with-main/lib/index.js": `module.exports = { hello: "world" };`,
+    },
+    run: {
+      stdout: '{"hello":"world"}',
+      setCwd: true,
+    },
+    compile: true,
+  });
+  // https://github.com/oven-sh/bun/issues/27058
+  itBundled("compile/DynamicRequireWithPackageJsonExports", {
+    files: {
+      "/entry.tsx": /* tsx */ `
+        const req = (x) => require(x);
+        const result = req('pkg-with-exports');
+        console.log(JSON.stringify(result));
+      `,
+      "/node_modules/pkg-with-exports/package.json": JSON.stringify({
+        name: "pkg-with-exports",
+        exports: { ".": "./src/entry.js" },
+      }),
+      "/node_modules/pkg-with-exports/src/entry.js": "throw new Error('Must be runtime import.')",
+    },
+    runtimeFiles: {
+      "/node_modules/pkg-with-exports/package.json": JSON.stringify({
+        name: "pkg-with-exports",
+        exports: { ".": "./src/entry.js" },
+      }),
+      "/node_modules/pkg-with-exports/src/entry.js": `module.exports = { status: "ok" };`,
+    },
+    run: {
+      stdout: '{"status":"ok"}',
+      setCwd: true,
+    },
+    compile: true,
+  });
   // see comment in `usePackageManager` for why this is a test
   itBundled("compile/NoAutoInstall", {
     files: {


### PR DESCRIPTION
## Summary

- Fix compiled executables (`bun build --compile`) being unable to resolve external modules that use `main`, `exports`, or `module` fields in their `package.json`
- This was a regression from #25340 which introduced `--compile-autoload-package-json` defaulting to `false`
- Change the default to `true` in both CLI and JS API (`Bun.build`) paths

Closes #27058

## Root Cause

PR #25340 added `compile_autoload_package_json` defaulting to `false`. This propagated through:

1. `src/cli.zig` → `compile_autoload_package_json: bool = false`
2. `src/cli/build_command.zig` → `disable_autoload_package_json = !false` → `true`
3. `src/bun.js.zig` → `load_package_json = !true` → `false`
4. `src/resolver/resolver.zig` → skips reading `package.json` files from disk entirely

This broke the vast majority of npm packages loaded dynamically at runtime from compiled executables, since nearly all packages use `main` or `exports` in their `package.json`.

## Test plan

- [x] Added `compile/DynamicRequireWithPackageJsonMain` test - verifies runtime require of a package with `main` field in `package.json`
- [x] Added `compile/DynamicRequireWithPackageJsonExports` test - verifies runtime require of a package with `exports` field in `package.json`
- [x] Both tests fail with `USE_SYSTEM_BUN=1` (confirming the regression) and pass with the fix
- [x] Full `bundler_compile.test.ts` suite passes (55/56, the 1 pre-existing failure is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)