### PR TITLE
fix(timers): cache scheduling time to prevent setTimeout/setImmediate interleaving

### DIFF
--- a/src/bun.js/api/Timer/TimerObjectInternals.zig
+++ b/src/bun.js/api/Timer/TimerObjectInternals.zig
@@ -402,7 +402,9 @@ pub fn reschedule(this: *TimerObjectInternals, timer: JSValue, vm: *VirtualMachi
     // https://github.com/nodejs/node/blob/a7cbb904745591c9a9d047a364c2c188e5470047/lib/internal/timers.js#L612
     if (!this.shouldRescheduleTimer(repeat, idle_timeout)) return;
 
-    const now = timespec.now(.allow_mocked_time);
+    // Use cached time so that multiple timers scheduled in the same event loop
+    // tick get the same base time (matching Node.js's uv_update_time behavior).
+    const now = vm.timer.getCachedNow();
     const scheduled_time = now.addMs(this.interval);
     const was_active = this.eventLoopTimer().state == .ACTIVE;
     if (was_active) {

--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -394,6 +394,13 @@ pub fn autoTick(this: *EventLoop) void {
         }
     }
 
+    // Invalidate the cached timer scheduling time so that timers created
+    // during this tick get a fresh base time. This ensures timers scheduled
+    // in the same JS execution context share the same base time (like
+    // Node.js's uv_update_time), preventing two setTimeout(fn, 1) calls
+    // from getting different expiry times due to microsecond differences.
+    ctx.timer.invalidateCachedNow();
+
     if (Environment.isPosix) {
         ctx.timer.drainTimers(ctx);
     }
@@ -466,6 +473,8 @@ pub fn autoTickActive(this: *EventLoop) void {
     } else {
         loop.tickWithoutIdle();
     }
+
+    ctx.timer.invalidateCachedNow();
 
     if (Environment.isPosix) {
         ctx.timer.drainTimers(ctx);

--- a/test/regression/issue/26508.test.ts
+++ b/test/regression/issue/26508.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/26508
+// setImmediate callbacks should not interleave between setTimeout callbacks
+// that expire at the same logical time. Node.js runs all expired timers
+// before processing immediates (check phase).
+test("setImmediate should not run between two expired setTimeout callbacks", async () => {
+  // Run the test multiple times since the original bug was timing-dependent
+  // (~10-20% failure rate per run on debug builds).
+  for (let i = 0; i < 50; i++) {
+    const result = await new Promise<boolean>(resolve => {
+      let immediateRan = false;
+      const t1 = setTimeout(() => {
+        setImmediate(() => {
+          immediateRan = true;
+        });
+      });
+
+      const t2 = setTimeout(() => {
+        resolve(immediateRan);
+      });
+
+      t2._idleStart = t1._idleStart;
+    });
+    expect(result).toBe(false);
+  }
+});


### PR DESCRIPTION
## Summary

- Adds a cached time mechanism to the timer system (similar to Node.js's `uv_update_time`) that ensures all timers scheduled within the same event loop tick share the same base time
- When multiple `setTimeout(fn, delay)` calls were made in the same tick, each independently called `timespec.now()`, giving them slightly different expiry times (~microseconds apart), causing them to fire in separate event loop iterations
- The cache is invalidated after the event loop wakes from I/O polling (`tickWithTimeout`), so each new tick gets a fresh timestamp

Closes #26508

## Test plan
- [x] New regression test `test/regression/issue/26508.test.ts` that runs 50 iterations of the reproduction case
- [x] All existing timer tests pass (`node-timers.test.ts`, `test-timers.test.ts`, `timers.promises.test.ts`)
- [x] Manual verification with debug build (previously ~10-20% failure rate, now 0%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)