### PR TITLE
fix(http): preserve explicit Content-Length header with streaming request body

### DIFF
--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -1154,6 +1154,14 @@ pub const FetchTasklet = struct {
         }
     }
 
+    /// Whether the request body should skip chunked transfer encoding framing.
+    /// True for upgraded connections (e.g. WebSocket) or when the user explicitly
+    /// set Content-Length without setting Transfer-Encoding.
+    fn skipChunkedFraming(this: *const FetchTasklet) bool {
+        return this.upgraded_connection or
+            (this.request_headers.get("content-length") != null and this.request_headers.get("transfer-encoding") == null);
+    }
+
     pub fn writeRequestData(this: *FetchTasklet, data: []const u8) ResumableSinkBackpressure {
         log("writeRequestData {}", .{data.len});
         if (this.signal) |signal| {
@@ -1175,9 +1183,7 @@ pub const FetchTasklet = struct {
         // dont have backpressure so we will schedule the data to be written
         // if we have backpressure the onWritable will drain the buffer
         needs_schedule = stream_buffer.isEmpty();
-        if (this.upgraded_connection or
-            (this.request_headers.get("content-length") != null and this.request_headers.get("transfer-encoding") == null))
-        {
+        if (this.skipChunkedFraming()) {
             bun.handleOom(stream_buffer.write(data));
         } else {
             //16 is the max size of a hex number size that represents 64 bits + 2 for the \r\n
@@ -1211,10 +1217,8 @@ pub const FetchTasklet = struct {
             }
             this.abortTask();
         } else {
-            if (!this.upgraded_connection and
-                !(this.request_headers.get("content-length") != null and this.request_headers.get("transfer-encoding") == null))
-            {
-                // Not an upgraded connection and not using explicit Content-Length, send the terminating chunk
+            if (!this.skipChunkedFraming()) {
+                // Using chunked transfer encoding, send the terminating chunk
                 const thread_safe_stream_buffer = this.request_body_streaming_buffer orelse return;
                 const stream_buffer = thread_safe_stream_buffer.acquire();
                 defer thread_safe_stream_buffer.release();

--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -1175,7 +1175,9 @@ pub const FetchTasklet = struct {
         // dont have backpressure so we will schedule the data to be written
         // if we have backpressure the onWritable will drain the buffer
         needs_schedule = stream_buffer.isEmpty();
-        if (this.upgraded_connection) {
+        const skip_chunked_framing = this.upgraded_connection or
+            (if (this.http) |h| h.client.flags.is_streaming_request_body_with_content_length else false);
+        if (skip_chunked_framing) {
             bun.handleOom(stream_buffer.write(data));
         } else {
             //16 is the max size of a hex number size that represents 64 bits + 2 for the \r\n
@@ -1209,15 +1211,16 @@ pub const FetchTasklet = struct {
             }
             this.abortTask();
         } else {
-            if (!this.upgraded_connection) {
-                // If is not upgraded we need to send the terminating chunk
+            const skip_chunked_framing = this.upgraded_connection or
+                (if (this.http) |h| h.client.flags.is_streaming_request_body_with_content_length else false);
+            if (!skip_chunked_framing) {
+                // If not upgraded and not using explicit Content-Length, send the terminating chunk
                 const thread_safe_stream_buffer = this.request_body_streaming_buffer orelse return;
                 const stream_buffer = thread_safe_stream_buffer.acquire();
                 defer thread_safe_stream_buffer.release();
                 bun.handleOom(stream_buffer.write(http.end_of_chunked_http1_1_encoding_response_body));
             }
             if (this.http) |http_| {
-                // just tell to write the end of the chunked encoding aka 0\r\n\r\n
                 http.http_thread.scheduleRequestWrite(http_, .end);
             }
         }

--- a/src/http.zig
+++ b/src/http.zig
@@ -616,6 +616,9 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
     var add_transfer_encoding = true;
     var original_content_length: ?string = null;
 
+    // Reset on each request (buildRequest is also called on redirects).
+    this.flags.is_streaming_request_body_with_content_length = false;
+
     for (header_names, 0..) |head, i| {
         const name = this.headerStr(head);
         // Hash it as lowercase
@@ -721,14 +724,20 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
     if (body_len > 0 or this.method.hasRequestBody()) {
         if (this.flags.is_streaming_request_body) {
             if (original_content_length) |content_length| {
-                // User explicitly set Content-Length; preserve it instead of using chunked encoding.
-                // This matches Node.js behavior where an explicit Content-Length is always honored.
-                request_headers_buf[header_count] = .{
-                    .name = content_length_header_name,
-                    .value = content_length,
-                };
-                header_count += 1;
-                this.flags.is_streaming_request_body_with_content_length = true;
+                if (add_transfer_encoding) {
+                    // User explicitly set Content-Length and did not set Transfer-Encoding;
+                    // preserve Content-Length instead of using chunked encoding.
+                    // This matches Node.js behavior where an explicit Content-Length is always honored.
+                    request_headers_buf[header_count] = .{
+                        .name = content_length_header_name,
+                        .value = content_length,
+                    };
+                    header_count += 1;
+                    this.flags.is_streaming_request_body_with_content_length = true;
+                }
+                // If !add_transfer_encoding, the user explicitly set Transfer-Encoding,
+                // which was already added to request_headers_buf. We respect that and
+                // do not add Content-Length (they are mutually exclusive per HTTP/1.1).
             } else if (add_transfer_encoding and this.flags.upgrade_state == .none) {
                 request_headers_buf[header_count] = chunked_encoded_header;
                 header_count += 1;

--- a/src/http.zig
+++ b/src/http.zig
@@ -457,10 +457,9 @@ pub const Flags = packed struct(u16) {
     reject_unauthorized: bool = true,
     is_preconnect_only: bool = false,
     is_streaming_request_body: bool = false,
-    is_streaming_request_body_with_content_length: bool = false,
     defer_fail_until_connecting_is_complete: bool = false,
     upgrade_state: HTTPUpgradeState = .none,
-    _padding: u2 = 0,
+    _padding: u3 = 0,
 };
 
 // TODO: reduce the size of this struct
@@ -616,9 +615,6 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
     var add_transfer_encoding = true;
     var original_content_length: ?string = null;
 
-    // Reset on each request (buildRequest is also called on redirects).
-    this.flags.is_streaming_request_body_with_content_length = false;
-
     for (header_names, 0..) |head, i| {
         const name = this.headerStr(head);
         // Hash it as lowercase
@@ -733,7 +729,6 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
                         .value = content_length,
                     };
                     header_count += 1;
-                    this.flags.is_streaming_request_body_with_content_length = true;
                 }
                 // If !add_transfer_encoding, the user explicitly set Transfer-Encoding,
                 // which was already added to request_headers_buf. We respect that and

--- a/test/regression/issue/27061.test.ts
+++ b/test/regression/issue/27061.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, test } from "bun:test";
+import http from "node:http";
+
+// Regression test for https://github.com/oven-sh/bun/issues/27061
+// When http.ClientRequest.write() is called more than once (streaming data in chunks),
+// Bun was stripping the explicitly-set Content-Length header and switching to
+// Transfer-Encoding: chunked. Node.js preserves Content-Length in all cases.
+
+describe("node:http ClientRequest preserves explicit Content-Length", () => {
+  test("with multiple req.write() calls", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<{
+      contentLength: string | undefined;
+      transferEncoding: string | undefined;
+      bodyLength: number;
+    }>();
+
+    const server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        resolve({
+          contentLength: req.headers["content-length"],
+          transferEncoding: req.headers["transfer-encoding"],
+          bodyLength: Buffer.concat(chunks).length,
+        });
+        res.writeHead(200);
+        res.end("ok");
+      });
+    });
+
+    await new Promise<void>(res => server.listen(0, "127.0.0.1", res));
+    const port = (server.address() as any).port;
+
+    try {
+      const chunk1 = Buffer.alloc(100, "a");
+      const chunk2 = Buffer.alloc(100, "b");
+      const totalLength = chunk1.length + chunk2.length;
+
+      const req = http.request({
+        hostname: "127.0.0.1",
+        port,
+        method: "POST",
+        headers: {
+          "Content-Length": totalLength.toString(),
+        },
+      });
+
+      await new Promise<void>((res, rej) => {
+        req.on("error", rej);
+        req.on("response", () => res());
+        req.write(chunk1);
+        req.write(chunk2);
+        req.end();
+      });
+
+      const result = await promise;
+      expect(result.contentLength).toBe("200");
+      expect(result.transferEncoding).toBeUndefined();
+      expect(result.bodyLength).toBe(200);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("with req.write() + req.end(data)", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<{
+      contentLength: string | undefined;
+      transferEncoding: string | undefined;
+      bodyLength: number;
+    }>();
+
+    const server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        resolve({
+          contentLength: req.headers["content-length"],
+          transferEncoding: req.headers["transfer-encoding"],
+          bodyLength: Buffer.concat(chunks).length,
+        });
+        res.writeHead(200);
+        res.end("ok");
+      });
+    });
+
+    await new Promise<void>(res => server.listen(0, "127.0.0.1", res));
+    const port = (server.address() as any).port;
+
+    try {
+      const chunk1 = Buffer.alloc(100, "a");
+      const chunk2 = Buffer.alloc(100, "b");
+      const totalLength = chunk1.length + chunk2.length;
+
+      const req = http.request({
+        hostname: "127.0.0.1",
+        port,
+        method: "POST",
+        headers: {
+          "Content-Length": totalLength.toString(),
+        },
+      });
+
+      await new Promise<void>((res, rej) => {
+        req.on("error", rej);
+        req.on("response", () => res());
+        req.write(chunk1);
+        req.end(chunk2);
+      });
+
+      const result = await promise;
+      expect(result.contentLength).toBe("200");
+      expect(result.transferEncoding).toBeUndefined();
+      expect(result.bodyLength).toBe(200);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("with three req.write() calls", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<{
+      contentLength: string | undefined;
+      transferEncoding: string | undefined;
+      bodyLength: number;
+    }>();
+
+    const server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        resolve({
+          contentLength: req.headers["content-length"],
+          transferEncoding: req.headers["transfer-encoding"],
+          bodyLength: Buffer.concat(chunks).length,
+        });
+        res.writeHead(200);
+        res.end("ok");
+      });
+    });
+
+    await new Promise<void>(res => server.listen(0, "127.0.0.1", res));
+    const port = (server.address() as any).port;
+
+    try {
+      const chunk1 = Buffer.alloc(100, "a");
+      const chunk2 = Buffer.alloc(100, "b");
+      const chunk3 = Buffer.alloc(100, "c");
+      const totalLength = chunk1.length + chunk2.length + chunk3.length;
+
+      const req = http.request({
+        hostname: "127.0.0.1",
+        port,
+        method: "POST",
+        headers: {
+          "Content-Length": totalLength.toString(),
+        },
+      });
+
+      await new Promise<void>((res, rej) => {
+        req.on("error", rej);
+        req.on("response", () => res());
+        req.write(chunk1);
+        req.write(chunk2);
+        req.write(chunk3);
+        req.end();
+      });
+
+      const result = await promise;
+      expect(result.contentLength).toBe("300");
+      expect(result.transferEncoding).toBeUndefined();
+      expect(result.bodyLength).toBe(300);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("single req.write() still works", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<{
+      contentLength: string | undefined;
+      transferEncoding: string | undefined;
+      bodyLength: number;
+    }>();
+
+    const server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        resolve({
+          contentLength: req.headers["content-length"],
+          transferEncoding: req.headers["transfer-encoding"],
+          bodyLength: Buffer.concat(chunks).length,
+        });
+        res.writeHead(200);
+        res.end("ok");
+      });
+    });
+
+    await new Promise<void>(res => server.listen(0, "127.0.0.1", res));
+    const port = (server.address() as any).port;
+
+    try {
+      const data = Buffer.alloc(200, "x");
+
+      const req = http.request({
+        hostname: "127.0.0.1",
+        port,
+        method: "POST",
+        headers: {
+          "Content-Length": data.length.toString(),
+        },
+      });
+
+      await new Promise<void>((res, rej) => {
+        req.on("error", rej);
+        req.on("response", () => res());
+        req.write(data);
+        req.end();
+      });
+
+      const result = await promise;
+      expect(result.contentLength).toBe("200");
+      expect(result.transferEncoding).toBeUndefined();
+      expect(result.bodyLength).toBe(200);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("without explicit Content-Length still uses chunked encoding", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<{
+      contentLength: string | undefined;
+      transferEncoding: string | undefined;
+      bodyLength: number;
+    }>();
+
+    const server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        resolve({
+          contentLength: req.headers["content-length"],
+          transferEncoding: req.headers["transfer-encoding"],
+          bodyLength: Buffer.concat(chunks).length,
+        });
+        res.writeHead(200);
+        res.end("ok");
+      });
+    });
+
+    await new Promise<void>(res => server.listen(0, "127.0.0.1", res));
+    const port = (server.address() as any).port;
+
+    try {
+      const chunk1 = Buffer.alloc(100, "a");
+      const chunk2 = Buffer.alloc(100, "b");
+
+      const req = http.request({
+        hostname: "127.0.0.1",
+        port,
+        method: "POST",
+        // No Content-Length header
+      });
+
+      await new Promise<void>((res, rej) => {
+        req.on("error", rej);
+        req.on("response", () => res());
+        req.write(chunk1);
+        req.write(chunk2);
+        req.end();
+      });
+
+      const result = await promise;
+      // Without explicit Content-Length, chunked encoding should be used
+      expect(result.transferEncoding).toBe("chunked");
+      expect(result.bodyLength).toBe(200);
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- When `http.ClientRequest.write()` was called more than once (streaming data in chunks), Bun was stripping the explicitly-set `Content-Length` header and switching to `Transfer-Encoding: chunked`. Node.js preserves `Content-Length` in all cases when it's explicitly set by the user.
- This caused real-world failures (e.g. Vercel CLI file uploads) where large binary files streamed via multiple `write()` calls had their Content-Length stripped, causing server-side "invalid file size" errors.
- The fix preserves the user's explicit `Content-Length` for streaming request bodies and skips chunked transfer encoding framing when `Content-Length` is set.

Closes #27061
Closes #26976

## Changes

- **`src/http.zig`**: When a streaming request body has an explicit `Content-Length` header set by the user, use that instead of adding `Transfer-Encoding: chunked`. Added `is_streaming_request_body_with_content_length` flag to track this.
- **`src/bun.js/webcore/fetch/FetchTasklet.zig`**: Skip chunked transfer encoding framing (`writeRequestData`) and the chunked terminator (`writeEndRequest`) when the request has an explicit `Content-Length`.
- **`test/regression/issue/27061.test.ts`**: Regression test covering multiple write patterns (2x write, write+end(data), 3x write) plus validation that chunked encoding is still used when no `Content-Length` is set.

## Test plan

- [x] New regression test passes with `bun bd test test/regression/issue/27061.test.ts`
- [x] Test fails with `USE_SYSTEM_BUN=1` (confirms the bug exists in current release)
- [x] Existing `test/js/node/http/` tests pass (no regressions)
- [x] Fetch file upload tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)