### PR TITLE
fix(blob): read file-backed blobs when constructing Blob from multiple parts

### DIFF
--- a/test/regression/issue/27071.test.ts
+++ b/test/regression/issue/27071.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+
+test("new Blob([Bun.file(), buffer]) includes file contents", async () => {
+  using dir = tempDir("blob-file-concat", {
+    "testfile.txt": "HELLO_FROM_FILE",
+  });
+
+  const file = Bun.file(`${dir}/testfile.txt`);
+  const buffer = Buffer.from("BUFFER_DATA");
+
+  // file + buffer
+  const r1 = await new Blob([file, buffer]).text();
+  expect(r1).toBe("HELLO_FROM_FILEBUFFER_DATA");
+
+  // buffer + file
+  const r2 = await new Blob([buffer, file]).text();
+  expect(r2).toBe("BUFFER_DATAHELLO_FROM_FILE");
+
+  // file + file
+  const r3 = await new Blob([file, file]).text();
+  expect(r3).toBe("HELLO_FROM_FILEHELLO_FROM_FILE");
+
+  // single file still works
+  const r4 = await new Blob([file]).text();
+  expect(r4).toBe("HELLO_FROM_FILE");
+
+  // size should be correct
+  expect(new Blob([file, buffer]).size).toBe(26);
+  expect(new Blob([buffer, file]).size).toBe(26);
+  expect(new Blob([file, file]).size).toBe(30);
+});
+
+test("new Blob([Bun.file(), string]) includes file contents", async () => {
+  using dir = tempDir("blob-file-string", {
+    "testfile.txt": "FILE_CONTENT",
+  });
+
+  const file = Bun.file(`${dir}/testfile.txt`);
+
+  const r1 = await new Blob([file, "STRING_DATA"]).text();
+  expect(r1).toBe("FILE_CONTENTSTRING_DATA");
+
+  const r2 = await new Blob(["STRING_DATA", file]).text();
+  expect(r2).toBe("STRING_DATAFILE_CONTENT");
+});
+
+test("new Blob([Bun.file(), Uint8Array]) includes file contents", async () => {
+  using dir = tempDir("blob-file-uint8", {
+    "testfile.txt": "FILE_DATA",
+  });
+
+  const file = Bun.file(`${dir}/testfile.txt`);
+  const uint8 = new Uint8Array([65, 66, 67]); // "ABC"
+
+  const r1 = await new Blob([file, uint8]).text();
+  expect(r1).toBe("FILE_DATAABC");
+
+  const r2 = await new Blob([uint8, file]).text();
+  expect(r2).toBe("ABCFILE_DATA");
+});
+
+test("new Blob([Bun.file(), Blob]) includes file contents", async () => {
+  using dir = tempDir("blob-file-blob", {
+    "testfile.txt": "FILE_DATA",
+  });
+
+  const file = Bun.file(`${dir}/testfile.txt`);
+  const otherBlob = new Blob(["BLOB_DATA"]);
+
+  const r1 = await new Blob([file, otherBlob]).text();
+  expect(r1).toBe("FILE_DATABLOB_DATA");
+
+  const r2 = await new Blob([otherBlob, file]).text();
+  expect(r2).toBe("BLOB_DATAFILE_DATA");
+});


### PR DESCRIPTION
## Summary
- When a `Bun.file()` blob was combined with other parts in `new Blob([...])`, its contents were silently dropped because `sharedView()` returns empty for file-backed blobs whose data hasn't been read into memory yet.
- Now synchronously reads file contents when file-backed blobs appear as parts in the Blob constructor, using the same `NodeFS.readFile` sync pattern already used by `FormDataContext`.

Closes #27071

## Test plan
- [x] Added regression test `test/regression/issue/27071.test.ts` covering:
  - `new Blob([file, buffer])` — file contents + buffer
  - `new Blob([buffer, file])` — buffer + file contents
  - `new Blob([file, file])` — two file-backed blobs
  - `new Blob([file])` — single file (still works)
  - `.size` correctness for composite blobs
  - Combinations with strings, Uint8Array, and in-memory Blobs
- [x] Verified test fails on unpatched Bun (`USE_SYSTEM_BUN=1`)
- [x] Verified test passes on debug build (`bun bd test`)
- [x] Existing blob tests pass (blob.test.ts, blob-cow.test.ts, blob-write.test.ts, bun-file.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)