### PR TITLE
fix(cli): support `node --run` when bun pretends to be node

### DIFF
--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -101,4 +101,39 @@ describe("fake node cli", () => {
     const temp = tempDirWithFiles("fake-node", {});
     expect(() => fakeNodeRun(temp, [])).toThrow();
   });
+
+  describe("node --run", () => {
+    test("runs a package.json script", () => {
+      const temp = tempDirWithFiles("fake-node", {
+        "package.json": JSON.stringify({
+          scripts: {
+            echo_test: "echo pass",
+          },
+        }),
+      });
+      expect(fakeNodeRun(temp, ["--run", "echo_test"]).stdout).toBe("pass");
+    });
+
+    test("runs pre/post scripts", () => {
+      const temp = tempDirWithFiles("fake-node", {
+        "package.json": JSON.stringify({
+          scripts: {
+            premyscript: "echo pre",
+            myscript: "echo main",
+            postmyscript: "echo post",
+          },
+        }),
+      });
+      expect(fakeNodeRun(temp, ["--run", "myscript"]).stdout).toBe("pre\nmain\npost");
+    });
+
+    test("errors on missing script", () => {
+      const temp = tempDirWithFiles("fake-node", {
+        "package.json": JSON.stringify({
+          scripts: {},
+        }),
+      });
+      expect(() => fakeNodeRun(temp, ["--run", "nonexistent"])).toThrow();
+    });
+  });
 });

--- a/test/regression/issue/27074.test.ts
+++ b/test/regression/issue/27074.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "../../harness";
+
+// https://github.com/oven-sh/bun/issues/27074
+// `bun run --bun build` fails when a pre-script uses `node --run`
+test("bun run --bun works with node --run in lifecycle scripts", () => {
+  const temp = tempDirWithFiles("issue-27074", {
+    "package.json": JSON.stringify({
+      scripts: {
+        echo_test: "echo echo_test_ran",
+        prebuild: "node --run echo_test",
+        build: "echo build_ran",
+      },
+    }),
+  });
+
+  const result = Bun.spawnSync({
+    cmd: [bunExe(), "run", "--bun", "build"],
+    cwd: temp,
+    env: bunEnv,
+  });
+
+  const stdout = result.stdout.toString("utf8").trim();
+  const stderr = result.stderr.toString("utf8").trim();
+
+  expect(stdout).toContain("echo_test_ran");
+  expect(stdout).toContain("build_ran");
+  expect(result.exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- When `bun run --bun` is used, child processes invoking `node` actually run bun via a symlink. Node.js v22+ supports `node --run <script>` to run package.json scripts, but bun's fake node mode silently ignored the `--run` flag and tried to execute the script name as a file path, causing `Module not found` errors.
- Detect `--run` in the raw argv within `execAsIfNode()` and delegate to `RunCommand.exec()` which already handles package.json script resolution including pre/post lifecycle scripts.

Closes #27074

## Test plan
- [x] Added tests in `test/cli/run/as-node.test.ts` for `node --run` (runs script, runs pre/post scripts, errors on missing script)
- [x] Added regression test in `test/regression/issue/27074.test.ts` for the exact reproduction from the issue
- [x] Verified new tests fail with system bun (`USE_SYSTEM_BUN=1`) and pass with debug build
- [x] All existing as-node tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)