### PR TITLE
fix(run): replace `node --run` with `bun run` in package.json scripts

### DIFF
--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -159,6 +159,13 @@ pub const RunCommand = struct {
                             continue;
                         }
 
+                        if (strings.hasPrefixComptime(script[start..], "node --run ")) {
+                            try copy_script.appendSlice(BUN_RUN ++ " ");
+                            entry_i += "node --run ".len;
+                            delimiter = 0;
+                            continue;
+                        }
+
                         if (strings.hasPrefixComptime(script[start..], "npx ")) {
                             try copy_script.appendSlice(BUN_BIN_NAME ++ " x ");
                             entry_i += "npx ".len;

--- a/test/regression/issue/27074.test.ts
+++ b/test/regression/issue/27074.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+// https://github.com/oven-sh/bun/issues/27074
+// node --run <script> (Node.js v22+) should be replaced with bun run <script>
+// when using --bun flag
+
+test("bun run --bun translates 'node --run' to 'bun run'", async () => {
+  const dir = tempDirWithFiles("issue-27074", {
+    "package.json": JSON.stringify({
+      scripts: {
+        greet: 'echo "hello from greet"',
+        dev: "node --run greet",
+      },
+    }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "--bun", "dev"],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("hello from greet");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Adds `node --run <script>` → `bun run <script>` replacement in `replacePackageManagerRun`, matching the existing pattern for `npm run`, `pnpm run`, `yarn run`, etc.
- Node.js v22+ added `node --run` as a built-in way to run package.json scripts. When `--bun` is used, Bun replaces `node` with itself via PATH symlink, but doesn't understand `--run` — it tries to find a **file** with the script name, causing `Module not found` errors.

Fixes #27074

## Test plan

- [ ] New test `test/regression/issue/27074.test.ts` — creates a package.json with `"dev": "node --run greet"` and verifies `bun run --bun dev` succeeds
- [ ] CI validates the change across platforms