### PR TITLE
fix(ci): fix invalid YAML in update-root-certs workflow

### DIFF
--- a/.github/workflows/update-root-certs.yml
+++ b/.github/workflows/update-root-certs.yml
@@ -78,6 +78,6 @@ jobs:
           branch: certs/update-root-certs
           base: main
           delete-branch: true
-          labels:
-            - "automation"
-            - "root-certs"
+          labels: |
+            automation
+            root-certs


### PR DESCRIPTION
`labels` in `update-root-certs.yml` used a YAML sequence (`- "automation"`) but `peter-evans/create-pull-request` expects a string (comma or newline-delimited). GitHub Actions rejects the sequence with `A sequence was not expected` on every push to any branch.

switched to a pipe-delimited string per the [action's docs](https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#action-inputs).

one file changed, no logic changes.