### PR TITLE
fix: remove unsafe ObjectInitializationScope from fromEntries

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -3026,22 +3026,20 @@ JSC::EncodedJSValue JSC__JSValue__fromEntries(JSC::JSGlobalObject* globalObject,
         return JSC::JSValue::encode(JSC::constructEmptyObject(globalObject));
     }
 
-    JSC::JSObject* object = nullptr;
-    {
-        JSC::ObjectInitializationScope initializationScope(vm);
-        object = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), std::min(static_cast<unsigned int>(initialCapacity), JSFinalObject::maxInlineCapacity));
+    JSC::JSObject* object = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), std::min(static_cast<unsigned int>(initialCapacity), JSFinalObject::maxInlineCapacity));
 
-        if (!clone) {
-            for (size_t i = 0; i < initialCapacity; ++i) {
-                object->putDirect(
-                    vm, JSC::PropertyName(JSC::Identifier::fromString(vm, Zig::toString(keys[i]))),
-                    Zig::toJSStringGC(values[i], globalObject), 0);
-            }
-        } else {
-            for (size_t i = 0; i < initialCapacity; ++i) {
-                object->putDirect(vm, JSC::PropertyName(Zig::toIdentifier(keys[i], globalObject)),
-                    Zig::toJSStringGC(values[i], globalObject), 0);
-            }
+    if (!clone) {
+        for (size_t i = 0; i < initialCapacity; ++i) {
+            object->putDirect(
+                vm, JSC::PropertyName(JSC::Identifier::fromString(vm, Zig::toString(keys[i]))),
+                Zig::toJSStringGC(values[i], globalObject), 0);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
+    } else {
+        for (size_t i = 0; i < initialCapacity; ++i) {
+            object->putDirect(vm, JSC::PropertyName(Zig::toIdentifier(keys[i], globalObject)),
+                Zig::toJSStringGC(values[i], globalObject), 0);
+            RETURN_IF_EXCEPTION(scope, {});
         }
     }
 


### PR DESCRIPTION
## Summary

Speculative fix for [BUN-1K54](https://bun-p9.sentry.io/issues/7260165386/) — a segfault in `JSC__JSValue__fromEntries` with 238 occurrences on Windows x86_64 (Bun 1.3.9).

## Problem

`JSC__JSValue__fromEntries` wraps its property insertion loop inside a `JSC::ObjectInitializationScope`. This scope is designed for fast, allocation-free object initialization using `putDirectOffset`. However, the code uses `putDirect` (which can trigger structure transitions) along with `toJSStringGC` and `toIdentifier` (which allocate on the GC heap).

In **debug builds**, `ObjectInitializationScope` includes `AssertNoGC` and `DisallowVMEntry` guards that would catch this misuse immediately. In **release builds**, the scope is essentially a no-op (only emits a `mutatorFence` on destruction), so GC can silently trigger during the loop. When this happens, the GC may encounter partially-initialized object slots containing garbage values, leading to a segfault.

## Fix

- Remove the `ObjectInitializationScope` block, since `putDirect` with allocating helpers is incompatible with its contract.
- Add `RETURN_IF_EXCEPTION` checks inside each loop iteration to properly propagate exceptions (e.g., OOM during string allocation).

## Test

Added a regression test that creates a `FileSystemRouter` with 128 routes and accesses `router.routes` under GC pressure. Verified via temporary `fprintf` logging that the test exercises the modified `JSC__JSValue__fromEntries` code path with `initialCapacity=128, clone=true`.

Note: The original crash is a GC timing issue that cannot be deterministically reproduced in a test. This test validates correctness of the code path rather than reproducing the specific crash.