### PR TITLE
fix(build): download baseline WebKit for x64 baseline builds

### DIFF
--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -209,6 +209,10 @@ if(LINUX AND ABI STREQUAL "musl")
   set(WEBKIT_SUFFIX "-musl")
 endif()
 
+if(ENABLE_BASELINE AND WEBKIT_ARCH STREQUAL "amd64")
+  set(WEBKIT_SUFFIX "${WEBKIT_SUFFIX}-baseline")
+endif()
+
 if(DEBUG)
   set(WEBKIT_SUFFIX "${WEBKIT_SUFFIX}-debug")
 elseif(ENABLE_LTO)


### PR DESCRIPTION
## Summary

- When `ENABLE_BASELINE=ON` is set for x86_64 builds, append `-baseline` to the WebKit download URL suffix in `SetupWebKit.cmake`
- Without this fix, baseline Bun links against a WebKit library compiled with AVX/AVX2 instructions, causing `SIGILL` crashes on CPUs without AVX support
- The baseline suffix placement matches the naming convention from oven-sh/WebKit#137 which produces the corresponding baseline WebKit artifacts

## Context

The `ENABLE_BASELINE` flag correctly sets `-march=nehalem` for Bun's own code (`CompilerFlags.cmake:32`) and marks the binary as baseline (`BuildBun.cmake:690`), but the WebKit download URL was missing the baseline distinction. This meant baseline Bun was linking against a WebKit built with `-march=haswell` (AVX2), causing illegal instruction crashes on pre-AVX CPUs.

**Note:** This fix depends on [oven-sh/WebKit#137](https://github.com/oven-sh/WebKit/pull/137) being merged to produce the baseline WebKit build artifacts. Until that PR is merged, baseline builds will get a clear download error at build time instead of silently producing a binary that crashes at runtime.

Closes #27090
Also related to #26353, #26635, #26872, #27006

## Test plan

- [x] Verified the suffix produces correct download URLs:
  - `bun-webkit-linux-amd64-baseline-lto.tar.gz` (Linux glibc LTO)
  - `bun-webkit-linux-amd64-baseline.tar.gz` (Linux glibc)
  - `bun-webkit-linux-amd64-musl-baseline-lto.tar.gz` (Linux musl LTO)
  - `bun-webkit-linux-amd64-musl-baseline.tar.gz` (Linux musl)
- [x] Verified non-baseline builds are unaffected (suffix only added when both `ENABLE_BASELINE` and `amd64` arch)
- [x] Verified ARM64 builds are unaffected (baseline is x86_64-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)