### PR TITLE
fix(s3): correct typo in S3ListObjectsResponse checksumAlgorithm property

### DIFF
--- a/src/s3/list_objects.zig
+++ b/src/s3/list_objects.zig
@@ -126,7 +126,7 @@ pub const S3ListObjectsV2Result = struct {
                 }
 
                 if (item.checksum_algorithme) |checksum_algorithme| {
-                    objectInfo.put(globalObject, jsc.ZigString.static("checksumAlgorithme"), try bun.String.createUTF8ForJS(globalObject, checksum_algorithme));
+                    objectInfo.put(globalObject, jsc.ZigString.static("checksumAlgorithm"), try bun.String.createUTF8ForJS(globalObject, checksum_algorithme));
                 }
 
                 if (item.checksum_type) |checksum_type| {


### PR DESCRIPTION
## Summary

Fixes a typo in `src/s3/list_objects.zig` where the JS property key was set to `"checksumAlgorithme"` (with a trailing `e`) instead of `"checksumAlgorithm"`.

The TypeScript type in `packages/bun-types/s3.d.ts` correctly declares this as `checksumAlgorithm`, but the runtime code exposed `checksumAlgorithme`, making the property inaccessible via the documented name.

Fixes #19142