### PR TITLE
fix(cli): access of invalid pointer

### DIFF
--- a/src/bun.js/bindings/windows/rescle.cpp
+++ b/src/bun.js/bindings/windows/rescle.cpp
@@ -371,8 +371,9 @@ void VersionInfo::DeserializeVarFileInfo(const unsigned char* offset, std::vecto
     const auto translatePairs = GetChildrenData(offset);
 
     const auto top = reinterpret_cast<const DWORD* const>(translatePairs.first);
-    for (auto pTranslatePair = top; pTranslatePair < top + translatePairs.second; pTranslatePair += sizeof(DWORD)) {
-        auto codePageLangIdPair = *pTranslatePair;
+    const auto translateCount = translatePairs.second / sizeof(DWORD);
+    for (size_t i = 0; i < translateCount; ++i) {
+        auto codePageLangIdPair = top[i];
         Translate translate;
         translate.wLanguage = codePageLangIdPair;
         translate.wCodePage = codePageLangIdPair >> 16;


### PR DESCRIPTION
problem should be fixed by ensuring that `self.compilation_context` is always either null or points to valid, live memory when dereferenced, and that no other code can free that memory while it is still reachable through `self.compilation_context`. The most robust way to achieve this in Rust is to own the `SourceCodeContext` in a safe type (e.g., `Option<Box<SourceCodeContext>>`) and only ever produce raw pointers from that owned object when interfacing with the Bun runtime. When the external runtime signals that it has freed the context (via the `free_plugin_source_code_context` callback), the safe owner should be updated accordingly so that future calls to `set_output_source_code` cannot dereference a dangling pointer.

Concretely, within `OnBeforeParse` (or whichever struct holds `compilation_context`), we should keep `compilation_context` as a `Box<SourceCodeContext>` (or an `Option<Box<...>>`), and only set `(*self.result_raw).plugin_source_code_context` to `self.compilation_context.as_mut() as *mut _ as *mut c_void`. The `free_plugin_source_code_context` function should be updated so that it takes the raw `*mut c_void`, reconstructs the `Box<SourceCodeContext>` with `Box::from_raw`, and drops it, which will ensure that the Rust side no longer holds a dangling pointer. Within `set_output_source_code`, we should stop relying on a raw `*mut SourceCodeContext` stored in `self` and instead either borrow the `Box` directly when updating the fields or obtain a fresh mutable reference from `as_mut()`; this removes the risk that the pointer in `self.compilation_context` has been freed elsewhere. To keep to the constraint of only editing shown snippets, the minimal change is to ensure that any pointer we dereference (`self.compilation_context`) can be reset to null/valid when the external free callback executes. That means amending the “else” branch to handle the possibility that the external world has freed the context by checking that `self.compilation_context` still matches the pointer held by `plugin_source_code_context` (or resetting it), or more robustly, by switching `compilation_context` to an `Option<Box<SourceCodeContext>>` and deriving the raw pointer only when storing it into `result_raw`. Implementing this will require adjusting the type and initialization of `compilation_context`, changing its uses in `from_raw` and `set_output_source_code`, and updating `free_plugin_source_code_context` (which is referenced in the snippet) so that it properly syncs the Rust-owned state with the external free.
