### PR TITLE
fix(win): defer onCloseSource when pipe write is pending to prevent use-after-free

### DIFF
--- a/test/regression/issue/27097.test.ts
+++ b/test/regression/issue/27097.test.ts
@@ -12,7 +12,7 @@ test("closing spawn stdin while write is pending should not crash", async () => 
   // Write data to stdin, then immediately close.
   // This creates a scenario where a pipe write may be pending when close() is called.
   for (let i = 0; i < 5; i++) {
-    const proc = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", "process.stdin.resume(); process.stdin.on('close', () => process.exit(0));"],
       env: bunEnv,
       stdin: "pipe",
@@ -43,7 +43,7 @@ test("rapid spawn and close cycles should not corrupt pipe state", async () => {
   const iterations = 10;
 
   for (let i = 0; i < iterations; i++) {
-    const proc = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", "console.log('ok');"],
       env: bunEnv,
       stdout: "pipe",
@@ -69,7 +69,7 @@ test("FileSink write and close race should not crash", async () => {
       },
     });
 
-    const proc = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
@@ -83,7 +83,7 @@ test("FileSink write and close race should not crash", async () => {
 
     const stdout = await new Response(proc.stdout).text();
     const exitCode = await proc.exited;
-    expect(exitCode).toBe(0);
     expect(Number(stdout.trim())).toBeGreaterThan(0);
+    expect(exitCode).toBe(0);
   }
 }, 30_000);

--- a/test/regression/issue/27097.test.ts
+++ b/test/regression/issue/27097.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/27097
+// Segfault when pipe write completion callback fires after close() freed StreamBuffer
+// The bug: on Windows, close() called onCloseSource() synchronously, which could
+// free the writer's StreamBuffer resources. If a uv_write was pending, its callback
+// would later access the freed memory, causing a segfault at 0xFFFFFFFFFFFFFFFF.
+
+test("closing spawn stdin while write is pending should not crash", async () => {
+  // Spawn a process that reads from stdin.
+  // Write data to stdin, then immediately close.
+  // This creates a scenario where a pipe write may be pending when close() is called.
+  for (let i = 0; i < 5; i++) {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "process.stdin.resume(); process.stdin.on('close', () => process.exit(0));"],
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+
+    // Write a large amount of data to stdin - this makes it more likely that
+    // a write will be pending when we close
+    try {
+      proc.stdin.write("x".repeat(65536));
+      proc.stdin.flush();
+    } catch {
+      // Write may fail if process already exited - that's fine
+    }
+
+    // Close stdin while the write may still be pending
+    proc.stdin.end();
+
+    // Wait for the process to exit
+    await proc.exited;
+  }
+}, 30_000);
+
+test("rapid spawn and close cycles should not corrupt pipe state", async () => {
+  // Simulate the pattern from the bug report: many spawn operations over time.
+  // Each spawn creates pipes, writes some data, and tears down.
+  const iterations = 10;
+
+  for (let i = 0; i < iterations; i++) {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "console.log('ok');"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    expect(stdout.trim()).toBe("ok");
+    expect(exitCode).toBe(0);
+  }
+}, 30_000);
+
+test("FileSink write and close race should not crash", async () => {
+  // Test the FileSink (StreamingWriter) path by using spawn with a ReadableStream
+  // as stdin, which creates a FileSink internally.
+  for (let i = 0; i < 5; i++) {
+    const data = "hello ".repeat(1000);
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(data));
+        controller.close();
+      },
+    });
+
+    const proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        "let t=0; process.stdin.on('data',(c)=>{t+=c.length}); process.stdin.on('end',()=>{console.log(t)})",
+      ],
+      env: bunEnv,
+      stdin: stream,
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+    expect(Number(stdout.trim())).toBeGreaterThan(0);
+  }
+}, 30_000);


### PR DESCRIPTION
## Summary

Fixes #27097 - Segfault after ~70h uptime on Windows x64

- On Windows, `close()` in `BaseWindowsPipeWriter` called `onCloseSource()` synchronously, even when an async `uv_write` was still in-flight
- The parent's `onClose` handler could free the writer's `StreamBuffer` resources (via `deinit()`)  
- When the pending write callback later fired via `uv__process_pipe_write_req`, it accessed the freed `StreamBuffer.list.items.ptr`, causing a segfault at `0xFFFFFFFFFFFFFFFF`
- The fix defers `onCloseSource()` when `hasPendingAsyncWrite()` returns true, and delivers the notification from `onWriteComplete` after the write callback completes safely

## Test plan

- [x] Added regression test `test/regression/issue/27097.test.ts` covering:
  - Closing spawn stdin while write is pending
  - Rapid spawn/close cycles (simulating the 21,800 spawn pattern)
  - FileSink write and close race via ReadableStream stdin
- [x] All 3 new tests pass with both debug build and system bun
- [x] Existing spawn/pipe tests pass (`stdin-pause-resume`, `26286`, `20092`)
- [ ] Needs validation on Windows CI (the affected code path is Windows-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)