### PR TITLE
fix(sql): flush MySQL queries after transaction completion

### DIFF
--- a/src/sql/mysql/js/JSMySQLConnection.zig
+++ b/src/sql/mysql/js/JSMySQLConnection.zig
@@ -155,6 +155,10 @@ pub fn enqueueRequest(this: *@This(), item: *JSMySQLQuery) void {
     this.#connection.enqueueRequest(item);
     this.resetConnectionTimeout();
     this.registerAutoFlusher();
+    // Ensure the connection keeps the event loop alive while a query is pending.
+    // Without this, the process may exit before the response arrives if the
+    // connection was previously idle (poll_ref unrefed).
+    this.updateReferenceType();
 }
 
 pub fn close(this: *@This()) void {

--- a/test/regression/issue/27102.test.ts
+++ b/test/regression/issue/27102.test.ts
@@ -1,0 +1,82 @@
+import { SQL, randomUUIDv7 } from "bun";
+import { beforeEach, expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+// https://github.com/oven-sh/bun/issues/27102
+// After a sql.begin() transaction completes, subsequent queries would silently
+// fail because data was queued but never flushed to the socket.
+describeWithContainer(
+  "mysql",
+  {
+    image: "mysql_plain",
+  },
+  container => {
+    const getOptions = (): Bun.SQL.Options => ({
+      url: `mysql://root@${container.host}:${container.port}/bun_sql_test`,
+      max: 1,
+    });
+
+    beforeEach(async () => {
+      await container.ready;
+    });
+
+    test("queries work after transaction completes", async () => {
+      await using sql = new SQL(getOptions());
+
+      // Initial query works fine
+      const [before] = await sql`SELECT 1 as ok`;
+      expect(before.ok).toBe(1);
+
+      // Transaction completes successfully
+      await sql.begin(async sql => {
+        await sql`SELECT 1`;
+      });
+
+      // This query should work but previously caused silent process exit
+      const [after] = await sql`SELECT 2 as ok`;
+      expect(after.ok).toBe(2);
+    });
+
+    test("queries work after transaction with table operations", async () => {
+      await using sql = new SQL(getOptions());
+      const table = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
+
+      await sql`CREATE TEMPORARY TABLE ${sql(table)} (id int, val text)`;
+
+      // Transaction with actual work
+      await sql.begin(async tx => {
+        await tx`INSERT INTO ${sql(table)} VALUES (1, 'hello')`;
+        await tx`INSERT INTO ${sql(table)} VALUES (2, 'world')`;
+      });
+
+      // Post-transaction queries must still work
+      const rows = await sql`SELECT * FROM ${sql(table)} ORDER BY id`;
+      expect(rows.length).toBe(2);
+      expect(rows[0].val).toBe("hello");
+      expect(rows[1].val).toBe("world");
+
+      // And another transaction should also work
+      await sql.begin(async tx => {
+        await tx`INSERT INTO ${sql(table)} VALUES (3, 'again')`;
+      });
+
+      const rows2 = await sql`SELECT * FROM ${sql(table)} ORDER BY id`;
+      expect(rows2.length).toBe(3);
+    });
+
+    test("multiple sequential transactions work", async () => {
+      await using sql = new SQL(getOptions());
+
+      for (let i = 0; i < 5; i++) {
+        await sql.begin(async tx => {
+          const [row] = await tx`SELECT ${i} as val`;
+          expect(row.val).toBe(i);
+        });
+
+        // Query after each transaction
+        const [row] = await sql`SELECT ${i + 100} as val`;
+        expect(row.val).toBe(i + 100);
+      }
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Fixes #27102

After a MySQL transaction completes (`sql.begin()` → BEGIN/COMMIT), subsequent queries silently fail — either the process exits with code 0 or `MySQLError: Connection closed` is thrown. This happens because:

- `queue.advance()` sets up the next query in the request queue but does **not** call `flushData()` to actually send the bytes over the socket
- The auto-flusher may not be registered in time (the event loop can exit before `registerAutoFlusher()` runs), so query data sits unsent in the write buffer
- On previously-idle connections, the poll ref is unset, so the event loop has nothing keeping it alive while waiting for the MySQL server's response

**Changes:**

- **`MySQLConnection.zig`**: Replace `queue.advance(connection)` with `flushQueue()` in 4 locations (after auth OK, after caching_sha2 auth success, after prepared statement completion, and after prepared statement error). `flushQueue()` both advances the queue AND flushes data to the socket.
- **`JSMySQLConnection.zig`**: Call `updateReferenceType()` in `enqueueRequest` so the connection keeps the event loop alive while a query is in flight on a previously-idle connection.

## Test plan

- [x] `bun bd` compiles successfully
- [ ] `bun bd test test/regression/issue/27102.test.ts` — regression test for queries after transactions (requires Docker/MySQL)
- [ ] `bun bd test test/js/sql/sql-mysql.transactions.test.ts` — existing transaction tests still pass
- [ ] `bun bd test test/js/sql/sql-mysql.test.ts` — full MySQL test suite still passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)