### PR TITLE
fix(install): hoist workspace dependencies to root node_modules by default

### DIFF
--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -573,16 +573,18 @@ pub fn installIsolatedPackages(
                     } else {
                         // transitive dependencies (also direct dependencies of workspaces!)
                         const dep_name = dependencies[new_entry_dep_id].name.slice(string_buf);
-                        if (manager.options.public_hoist_pattern) |public_hoist_pattern| {
-                            if (public_hoist_pattern.isMatch(dep_name)) {
-                                const hoist_entry = try public_hoisted.getOrPut(dep_name);
-                                if (!hoist_entry.found_existing) {
-                                    try entry_dependencies[0].insert(
-                                        lockfile.allocator,
-                                        .{ .entry_id = new_entry_id, .dep_id = new_entry_dep_id },
-                                        &ctx,
-                                    );
-                                }
+                        const should_public_hoist = if (manager.options.public_hoist_pattern) |public_hoist_pattern|
+                            public_hoist_pattern.isMatch(dep_name)
+                        else
+                            true; // default: hoist all (like pnpm's default publicHoistPattern: ['*'])
+                        if (should_public_hoist) {
+                            const hoist_entry = try public_hoisted.getOrPut(dep_name);
+                            if (!hoist_entry.found_existing) {
+                                try entry_dependencies[0].insert(
+                                    lockfile.allocator,
+                                    .{ .entry_id = new_entry_id, .dep_id = new_entry_dep_id },
+                                    &ctx,
+                                );
                             }
                         }
                     }

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -102,9 +102,20 @@ describe("basic", () => {
 
     await runBunInstall(bunEnv, packageDir);
 
-    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([".bun", "two-range-deps"]);
+    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([
+      ".bun",
+      "@types",
+      "no-deps",
+      "two-range-deps",
+    ]);
     expect(readlinkSync(join(packageDir, "node_modules", "two-range-deps"))).toBe(
       join(".bun", "two-range-deps@1.0.0", "node_modules", "two-range-deps"),
+    );
+    expect(readlinkSync(join(packageDir, "node_modules", "no-deps"))).toBe(
+      join(".bun", "no-deps@1.1.0", "node_modules", "no-deps"),
+    );
+    expect(readlinkSync(join(packageDir, "node_modules", "@types", "is-number"))).toBe(
+      join("..", ".bun", "@types+is-number@2.0.0", "node_modules", "@types", "is-number"),
     );
     expect(readlinkSync(join(packageDir, "node_modules", ".bun", "node_modules", "two-range-deps"))).toBe(
       join("..", "two-range-deps@1.0.0", "node_modules", "two-range-deps"),
@@ -388,7 +399,14 @@ describe("isolated workspaces", () => {
 
     expect(existsSync(join(packageDir, "node_modules", "pkg-1"))).toBeFalse();
     expect(readlinkSync(join(packageDir, "pkg-1", "node_modules", "pkg-2"))).toBe(join("..", "..", "pkg-2"));
-    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([".bun", "no-deps"]);
+    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([
+      ".bun",
+      "@types",
+      "a-dep",
+      "a-dep-b",
+      "b-dep-a",
+      "no-deps",
+    ]);
     expect(readlinkSync(join(packageDir, "node_modules", "no-deps"))).toBe(
       join(".bun", "no-deps@1.0.0", "node_modules", "no-deps"),
     );
@@ -585,7 +603,12 @@ describe("optional peers", () => {
       });
       expect(await exited).toBe(0);
 
-      expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([".bun", "one-dep", "one-one-dep"]);
+      expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([
+        ".bun",
+        "no-deps",
+        "one-dep",
+        "one-one-dep",
+      ]);
       expect(await readdirSorted(join(packageDir, "node_modules/.bun"))).toEqual([
         "no-deps@1.0.1",
         "node_modules",
@@ -802,7 +825,7 @@ describe("existing node_modules, missing node_modules/.bun", () => {
         readdirSorted(join(packageDir, "packages", "pkg1", "node_modules")),
         readdirSorted(join(packageDir, "packages", "pkg2", "node_modules")),
       ]),
-    ).toEqual([[".bun", expect.stringContaining(".old_modules-"), "no-deps"], ["no-deps"], ["a-dep"]]);
+    ).toEqual([[".bun", expect.stringContaining(".old_modules-"), "a-dep", "no-deps"], ["no-deps"], ["a-dep"]]);
 
     // another install will not reset the node_modules
 
@@ -813,7 +836,7 @@ describe("existing node_modules, missing node_modules/.bun", () => {
         await rm(join(packageDir, "node_modules", entry), { recursive: true, force: true });
       }
     }
-    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([".bun", "no-deps"]);
+    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([".bun", "a-dep", "no-deps"]);
 
     // add things to workspace node_modules. these will go undetected
     await Promise.all([
@@ -838,7 +861,7 @@ describe("existing node_modules, missing node_modules/.bun", () => {
         readdirSorted(join(packageDir, "packages", "pkg2", "node_modules")),
       ]),
     ).toEqual([
-      [".bun", "no-deps"],
+      [".bun", "a-dep", "no-deps"],
       ["no-deps", "oops1"],
       ["a-dep", "oops2"],
     ]);
@@ -992,8 +1015,11 @@ test("many transitive dependencies", async () => {
     "1-peer-dep-a",
     "alias-loop-1",
     "alias-loop-2",
+    "alias1",
+    "alias2",
     "basic-1",
     "is-number",
+    "no-deps",
   ]);
   expect(readlinkSync(join(packageDir, "node_modules", "alias-loop-1"))).toBe(
     join(".bun", "alias-loop-1@1.0.0", "node_modules", "alias-loop-1"),
@@ -1057,7 +1083,7 @@ test("dependency names are preserved", async () => {
 
   await runBunInstall(bunEnv, packageDir);
 
-  expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([".bun", "alias-loop-1"]);
+  expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([".bun", "alias-loop-1", "alias1", "alias2"]);
   expect(readlinkSync(join(packageDir, "node_modules", "alias-loop-1"))).toBe(
     join(".bun", "alias-loop-1@1.0.0", "node_modules", "alias-loop-1"),
   );

--- a/test/regression/issue/27110.test.ts
+++ b/test/regression/issue/27110.test.ts
@@ -1,0 +1,114 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { readlinkSync } from "fs";
+import { VerdaccioRegistry, bunEnv, readdirSorted, runBunInstall } from "harness";
+import { join } from "path";
+
+// Regression test for https://github.com/oven-sh/bun/issues/27110
+// Workspace dependencies should be hoisted to root node_modules by default
+// in isolated mode (auto linker with workspaces).
+
+const registry = new VerdaccioRegistry();
+
+beforeAll(async () => {
+  await registry.start();
+});
+
+afterAll(() => {
+  registry.stop();
+});
+
+test("isolated linker hoists workspace dependencies to root node_modules by default", async () => {
+  const { packageDir } = await registry.createTestDir({
+    bunfigOpts: { linker: "isolated" },
+    files: {
+      "package.json": JSON.stringify({
+        name: "workspace-root",
+        private: true,
+        workspaces: ["packages/*"],
+      }),
+      "packages/app/package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: {
+          "no-deps": "1.0.0",
+        },
+      }),
+    },
+  });
+
+  await runBunInstall(bunEnv, packageDir);
+
+  // Root node_modules should contain the hoisted dependency
+  const rootNodeModules = await readdirSorted(join(packageDir, "node_modules"));
+  expect(rootNodeModules).toContain(".bun");
+  expect(rootNodeModules).toContain("app");
+  expect(rootNodeModules).toContain("no-deps");
+
+  // The hoisted dependency should be a symlink into the .bun store
+  expect(readlinkSync(join(packageDir, "node_modules", "no-deps"))).toBe(
+    join(".bun", "no-deps@1.0.0", "node_modules", "no-deps"),
+  );
+
+  // Workspace package should also have its dependency symlinked
+  const appNodeModules = await readdirSorted(join(packageDir, "packages", "app", "node_modules"));
+  expect(appNodeModules).toContain("no-deps");
+});
+
+test("isolated linker hoists transitive workspace dependencies to root node_modules by default", async () => {
+  const { packageDir } = await registry.createTestDir({
+    bunfigOpts: { linker: "isolated" },
+    files: {
+      "package.json": JSON.stringify({
+        name: "workspace-root",
+        private: true,
+        workspaces: ["packages/*"],
+      }),
+      "packages/app/package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: {
+          "a-dep": "1.0.1",
+        },
+      }),
+    },
+  });
+
+  await runBunInstall(bunEnv, packageDir);
+
+  // Root node_modules should contain both the direct and transitive dependencies
+  const rootNodeModules = await readdirSorted(join(packageDir, "node_modules"));
+  expect(rootNodeModules).toContain(".bun");
+  expect(rootNodeModules).toContain("app");
+  expect(rootNodeModules).toContain("a-dep");
+  // a-dep depends on no-deps, which should also be hoisted
+  expect(rootNodeModules).toContain("no-deps");
+});
+
+test("isolated linker respects publicHoistPattern when set", async () => {
+  const { packageDir } = await registry.createTestDir({
+    bunfigOpts: { linker: "isolated", publicHoistPattern: "no-deps" },
+    files: {
+      "package.json": JSON.stringify({
+        name: "workspace-root",
+        private: true,
+        workspaces: ["packages/*"],
+      }),
+      "packages/app/package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: {
+          "a-dep": "1.0.1",
+        },
+      }),
+    },
+  });
+
+  await runBunInstall(bunEnv, packageDir);
+
+  // Only no-deps should be hoisted (matches pattern), not a-dep
+  const rootNodeModules = await readdirSorted(join(packageDir, "node_modules"));
+  expect(rootNodeModules).toContain(".bun");
+  expect(rootNodeModules).toContain("app");
+  expect(rootNodeModules).toContain("no-deps");
+  expect(rootNodeModules).not.toContain("a-dep");
+});


### PR DESCRIPTION
## Summary

Fixes #27110

When using the isolated linker (auto-selected for workspace monorepos), dependencies of workspace packages were not being symlinked into the root `node_modules/` directory. This caused:

- `require()` resolution to fail from the root directory
- Tools like Metro bundler, Babel, and Expo CLI to fail with `MODULE_NOT_FOUND`
- A confusing experience where `bun install` reports success but packages are inaccessible

**Root cause:** In `src/install/isolated_install.zig`, the public hoisting logic (which controls what appears in root `node_modules/`) was gated behind `public_hoist_pattern`, which defaults to `null`. When null, **no** transitive or workspace dependencies were hoisted to root — only direct dependencies of the root package.json.

**Fix:** When `publicHoistPattern` is not explicitly configured, default to hoisting all dependencies to root `node_modules/` (equivalent to `publicHoistPattern: ['*']`). This matches how `hoistPattern` already defaults to hoisting everything for the hidden store (`node_modules/.bun/node_modules/`). Users can still restrict hoisting by setting `publicHoistPattern` explicitly in bunfig.toml or .npmrc.

- Changed the default behavior in `isolated_install.zig` (2-line logic change)
- Updated existing test expectations in `isolated-install.test.ts` to reflect new default hoisting
- Added regression test in `test/regression/issue/27110.test.ts`

## Test plan

- [x] Verified the reproduction case from #27110 now works (root `node_modules/` contains hoisted symlinks)
- [x] Verified `require.resolve()` works from root directory after `bun install`
- [x] Added regression test covering: default hoisting, transitive hoisting, and explicit `publicHoistPattern` override
- [x] Updated existing test expectations in `isolated-install.test.ts` to match new default behavior
- [ ] CI should validate all install tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)