### PR TITLE
fix(bundler): place standalone HTML scripts in <head> to preserve execution order

### DIFF
--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -28,7 +28,9 @@ describe("compile --target=browser", () => {
     expect(html).toContain("<style>");
     expect(html).toContain("color: red");
     expect(html).toContain("</style>");
-    expect(html).toContain('<script type="module">');
+    // Standalone HTML uses classic <script> (not type="module") in <head>
+    // to ensure synchronous execution before inline body scripts
+    expect(html).toContain("<script>");
     expect(html).toContain('console.log("hello")');
     expect(html).toContain("</script>");
     // Should NOT have external references
@@ -36,7 +38,7 @@ describe("compile --target=browser", () => {
     expect(html).not.toContain('href="');
   });
 
-  test("uses type=module on inline scripts", async () => {
+  test("uses classic script (not type=module) for inline scripts", async () => {
     using dir = tempDir("compile-browser-module", {
       "index.html": `<!DOCTYPE html><html><body><script src="./app.js"></script></body></html>`,
       "app.js": `console.log("module");`,
@@ -50,8 +52,9 @@ describe("compile --target=browser", () => {
 
     expect(result.success).toBe(true);
     const html = await result.outputs[0].text();
-    expect(html).toContain('<script type="module">');
-    expect(html).not.toMatch(/<script>(?!<)/);
+    // Standalone HTML uses classic <script> to preserve execution order
+    expect(html).toContain("<script>");
+    expect(html).not.toContain('<script type="module">');
   });
 
   test("top-level await works with inline scripts", async () => {
@@ -69,7 +72,7 @@ console.log(data);`,
 
     expect(result.success).toBe(true);
     const html = await result.outputs[0].text();
-    expect(html).toContain('<script type="module">');
+    expect(html).toContain("<script>");
     expect(html).toContain("await");
   });
 
@@ -185,7 +188,7 @@ export const APP_VERSION = "1.0.0";`,
     expect(html).toContain("[LOG]");
     // Single output, no external refs
     expect(html).not.toContain('src="');
-    expect(html).toContain('<script type="module">');
+    expect(html).toContain("<script>");
   });
 
   test("CSS imported from JS and via link tag (deduplicated)", async () => {
@@ -288,7 +291,7 @@ body { color: blue; }`,
     const html = await Bun.file(`${outdir}/index.html`).text();
     expect(html).toContain("<style>");
     expect(html).toContain("font-weight: bold");
-    expect(html).toContain('<script type="module">');
+    expect(html).toContain("<script>");
     expect(html).toContain('console.log("outdir test")');
   });
 
@@ -454,7 +457,7 @@ body { color: blue; }`,
     const html = await Bun.file(`${outdir}/index.html`).text();
     expect(html).toContain("<style>");
     expect(html).toContain("font-weight: bold");
-    expect(html).toContain('<script type="module">');
+    expect(html).toContain("<script>");
     expect(html).toContain('console.log("cli test")');
 
     expect(stderr).toBe("");
@@ -484,7 +487,7 @@ body { color: blue; }`,
     expect(html).toContain("<style>");
     expect(html).toContain("color: green");
     // JS should also be inlined (this was the bug - JS was dropped in fallback path)
-    expect(html).toContain('<script type="module">');
+    expect(html).toContain("<script>");
     expect(html).toContain('console.log("malformed html")');
   });
 
@@ -513,7 +516,7 @@ console.log(message);`,
     const html = await result.outputs[0].text();
     expect(html).toContain("<style>");
     expect(html).toContain("</style>");
-    expect(html).toContain('<script type="module">');
+    expect(html).toContain("<script>");
     expect(html).toContain("</script>");
   });
 });

--- a/test/regression/issue/27113.test.ts
+++ b/test/regression/issue/27113.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/27113
+// Standalone HTML: <head> script must execute before inline <body> scripts
+test("standalone HTML head script executes before inline body scripts", async () => {
+  using dir = tempDir("issue-27113", {
+    "setup.js": `window.greeting = "Hello from setup.js";`,
+    "index.html": `<!doctype html>
+<html>
+  <head>
+    <script src="./setup.js"></script>
+  </head>
+  <body>
+    <pre id="out"></pre>
+    <script>
+      document.getElementById("out").textContent =
+        "greeting: " + window.greeting;
+    </script>
+  </body>
+</html>`,
+  });
+
+  const result = await Bun.build({
+    entrypoints: [`${dir}/index.html`],
+    compile: true,
+    target: "browser",
+  });
+
+  expect(result.success).toBe(true);
+  expect(result.outputs.length).toBe(1);
+
+  const html = await result.outputs[0].text();
+
+  // The bundled script should be in <head>, not before </body>
+  const headEnd = html.indexOf("</head>");
+  const bodyStart = html.indexOf("<body>");
+  const scriptStart = html.indexOf("<script>");
+  expect(headEnd).toBeGreaterThan(-1);
+  expect(bodyStart).toBeGreaterThan(-1);
+  expect(scriptStart).toBeGreaterThan(-1);
+
+  // The inlined script containing setup.js must appear BEFORE </head>
+  expect(scriptStart).toBeLessThan(headEnd);
+
+  // The script must NOT use type="module" (which would defer execution)
+  expect(html).not.toContain('<script type="module">');
+
+  // The setup code should be present
+  expect(html).toContain('window.greeting = "Hello from setup.js"');
+});


### PR DESCRIPTION
## Summary

- Fix standalone HTML mode (`--compile --target=browser`) placing bundled JS as `<script type="module">` before `</body>`, which broke execution order with existing inline body scripts
- Move bundled JS into `<head>` as a classic `<script>` (not `type="module"`) so it executes synchronously before inline body scripts, preserving the original script execution order
- Remove the now-unnecessary `addBodyTags()` function and associated body script injection paths

Fixes #27113

## Test plan

- [x] Added regression test `test/regression/issue/27113.test.ts` that verifies head scripts appear before `</head>` and don't use `type="module"`
- [x] Updated existing standalone HTML tests in `test/bundler/standalone.test.ts` to reflect the change from `<script type="module">` to classic `<script>`
- [x] All 18 standalone tests pass (`bun bd test test/bundler/standalone.test.ts`)
- [x] Regression test passes (`bun bd test test/regression/issue/27113.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)