### PR TITLE
fix(css): prevent style rule deduplication across `@property` boundaries

### DIFF
--- a/src/css/rules/rules.zig
+++ b/src/css/rules/rules.zig
@@ -452,6 +452,14 @@ pub fn CssRuleList(comptime AtRule: type) type {
                 }
 
                 bun.handleOom(rules.append(context.allocator, rule.*));
+                moved_rule = true;
+
+                // Non-style rules (e.g. @property, @keyframes) act as a barrier for
+                // style rule deduplication. We cannot safely merge identical style rules
+                // across such boundaries because the intervening at-rule may affect how
+                // the declarations are interpreted (e.g. @property defines a custom
+                // property that a :root rule above may set differently than one below).
+                style_rules.clearRetainingCapacity();
             }
 
             // MISSING SHIT HERE

--- a/test/regression/issue/27117.test.ts
+++ b/test/regression/issue/27117.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("CSS bundler should not drop :root rule before @property", async () => {
+  using dir = tempDir("css-property-root-dedup", {
+    "input.css": `:root {
+  --bar: 1;
+}
+
+@property --foo {
+  syntax: "<number>";
+  inherits: true;
+  initial-value: 0;
+}
+
+:root {
+  --baz: 2;
+}
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "input.css", "--outdir", "out"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const output = await Bun.file(`${dir}/out/input.css`).text();
+
+  // Both :root blocks must be preserved — they cannot be merged across the @property boundary
+  expect(output).toContain("--bar: 1");
+  expect(output).toContain("--baz: 2");
+  expect(output).toContain("@property --foo");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fixes the CSS bundler incorrectly removing a `:root` selector when it appears before an `@property` at-rule and another `:root` exists after it
- The deduplication logic in `CssRuleList.minify()` was merging style rules across non-style rule boundaries (like `@property`), which changes CSS semantics
- Clears the `style_rules` deduplication map when a non-style rule is appended, preventing merges across these boundaries

## Test plan

- [x] Added regression test in `test/regression/issue/27117.test.ts`
- [x] Verified test fails with system bun (`USE_SYSTEM_BUN=1`) — reproduces the bug
- [x] Verified test passes with debug build (`bun bd test`)
- [x] Verified adjacent `:root` rules (without intervening at-rules) are still correctly merged
- [x] All existing CSS bundler tests pass (`test/bundler/esbuild/css.test.ts` — 53 tests)
- [x] All CSS modules tests pass (`test/bundler/css/css-modules.test.ts` — 3 tests)

Closes #27117

🤖 Generated with [Claude Code](https://claude.com/claude-code)