### PR TITLE
Add workflow to close stale robobun PRs older than 90 days

### DIFF
--- a/.github/workflows/close-stale-robobun-prs.yml
+++ b/.github/workflows/close-stale-robobun-prs.yml
@@ -1,0 +1,30 @@
+name: Close stale robobun PRs
+on:
+  schedule:
+    - cron: "30 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  close-stale-robobun-prs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Close stale robobun PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          ninety_days_ago=$(date -u -d '90 days ago' +%Y-%m-%dT%H:%M:%SZ)
+
+          gh pr list \
+            --author robobun \
+            --state open \
+            --json number,updatedAt \
+            --limit 200 \
+            --jq ".[] | select(.updatedAt < \"$ninety_days_ago\") | .number" |
+          while read -r pr_number; do
+            echo "Closing PR #$pr_number (last updated before $ninety_days_ago)"
+            gh pr close "$pr_number" --comment "Closing this PR because it has been inactive for more than 90 days."
+          done


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that runs daily at 12:30 AM UTC
- Finds all open PRs authored by `robobun` that haven't been updated in over 90 days
- Closes them with a comment explaining the reason

## Test plan
- [ ] Verify the workflow runs successfully via `workflow_dispatch` manual trigger
- [ ] Confirm it correctly identifies PRs older than 90 days
- [ ] Confirm it leaves recent PRs untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)