### PR TITLE
fix: increase robobun PR query limit from 200 to 1000

### DIFF
--- a/.github/workflows/close-stale-robobun-prs.yml
+++ b/.github/workflows/close-stale-robobun-prs.yml
@@ -22,7 +22,7 @@ jobs:
             --author robobun \
             --state open \
             --json number,updatedAt \
-            --limit 200 \
+            --limit 1000 \
             --jq ".[] | select(.updatedAt < \"$ninety_days_ago\") | .number" |
           while read -r pr_number; do
             echo "Closing PR #$pr_number (last updated before $ninety_days_ago)"


### PR DESCRIPTION
## Summary
- There are 500+ open robobun PRs, many dating back to August 2025
- The previous limit of 200 caused the workflow to miss the oldest (stalest) PRs
- Increases the `--limit` to 1000 so all stale PRs get closed

## Test plan
- [ ] Merge and trigger via workflow_dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)