### PR TITLE
Use ReleaseFast instead of ReleaseSafe for Windows builds

### DIFF
--- a/cmake/tools/SetupZig.cmake
+++ b/cmake/tools/SetupZig.cmake
@@ -39,12 +39,6 @@ else()
   unsupported(CMAKE_BUILD_TYPE)
 endif()
 
-# Since Bun 1.1, Windows has been built using ReleaseSafe.
-# This is because it caught more crashes, but we can reconsider this in the future
-if(WIN32 AND DEFAULT_ZIG_OPTIMIZE STREQUAL "ReleaseFast")
-  set(DEFAULT_ZIG_OPTIMIZE "ReleaseSafe")
-endif()
-
 optionx(ZIG_OPTIMIZE "ReleaseFast|ReleaseSafe|ReleaseSmall|Debug" "The Zig optimize level to use" DEFAULT ${DEFAULT_ZIG_OPTIMIZE})
 
 # To use LLVM bitcode from Zig, more work needs to be done. Currently, an install of

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, tmpdirSync } from "harness";
 import { join } from "node:path";
 import tls from "node:tls";
 
@@ -263,7 +263,7 @@ describe.concurrent("fetch-tls", () => {
     });
     const start = performance.now();
     const TIMEOUT = 200;
-    const THRESHOLD = 150;
+    const THRESHOLD = 150 * (isASAN ? 2 : 1); // ASAN can be very slow, so we need to increase the threshold for it
 
     try {
       await fetch(server.url, {


### PR DESCRIPTION
## Summary
- Remove the Windows-specific override in `cmake/tools/SetupZig.cmake` that forced `ReleaseSafe` on Windows release builds since Bun 1.1
- Windows release builds will now use `ReleaseFast` like macOS and Linux, which disables Zig safety checks (bounds checking, overflow detection, etc.) in favor of maximum performance

## Test plan
- [ ] Verify Windows CI builds succeed with `ReleaseFast`
- [ ] Run the Windows test suite to check for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)