### PR TITLE
fix(bundler): don't inline NODE_ENV/BUN_ENV when env is "disable"

### DIFF
--- a/src/options.zig
+++ b/src/options.zig
@@ -1483,7 +1483,7 @@ pub fn definesFromTransformOptions(
         );
     }
 
-    if (behavior != .load_all_without_inlining) {
+    if (behavior != .load_all_without_inlining and behavior != .disable) {
         const quoted_node_env: string = brk: {
             if (NODE_ENV) |node_env| {
                 if (node_env.len > 0) {

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -65,6 +65,25 @@ for (let backend of ["api", "cli"] as const) {
       },
     });
 
+    // Test disable mode also prevents NODE_ENV and BUN_ENV from being inlined (#20183)
+    itBundled("env/disable-node-env", {
+      backend: backend,
+      dotenv: "disable",
+      files: {
+        "/a.js": `
+        console.log(process.env.NODE_ENV);
+        console.log(process.env.BUN_ENV);
+      `,
+      },
+      run: {
+        env: {
+          NODE_ENV: "production",
+          BUN_ENV: "production",
+        },
+        stdout: "production\nproduction\n",
+      },
+    });
+
     // TODO: make this work as expected with process.env isntead of relying on the initial env vars.
     // Test pattern matching - only vars with prefix are inlined
     if (backend === "cli")


### PR DESCRIPTION
## Summary
- `Bun.build({ env: "disable" })` was still inlining `process.env.NODE_ENV` and `process.env.BUN_ENV` to their build-time values, despite `env: "disable"` being intended to prevent **all** environment variable inlining.
- The root cause was in `src/options.zig`: the NODE_ENV/BUN_ENV define block only checked for `load_all_without_inlining` behavior, not `disable`. Added `disable` to the guard condition.
- Added a test that verifies NODE_ENV and BUN_ENV are read from the runtime environment (not inlined) when `env: "disable"` is set.

Closes #20183

## Test plan
- [x] `bun bd test test/bundler/bundler_env.test.ts` — all 9 tests pass (including new `env/disable-node-env`)
- [x] `USE_SYSTEM_BUN=1 bun test test/bundler/bundler_env.test.ts` — new test correctly fails on unfixed bun (NODE_ENV/BUN_ENV are inlined as build-time values instead of reading from runtime env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)