### PR TITLE
fix(bundler): allow reserved words as property names in --define values

### DIFF
--- a/src/defines.zig
+++ b/src/defines.zig
@@ -155,12 +155,14 @@ pub const DefineData = struct {
         // check for nested identifiers
         var valueSplitter = std.mem.splitScalar(u8, value_str, '.');
         var isIdent = true;
+        var isFirstPart = true;
 
         while (valueSplitter.next()) |part| {
-            if (!js_lexer.isIdentifier(part) or js_lexer.Keywords.has(part)) {
+            if (!js_lexer.isIdentifier(part) or (isFirstPart and js_lexer.Keywords.has(part))) {
                 isIdent = false;
                 break;
             }
+            isFirstPart = false;
         }
 
         if (isIdent) {

--- a/test/regression/issue/21200.test.ts
+++ b/test/regression/issue/21200.test.ts
@@ -7,19 +7,8 @@ describe("bundler", () => {
   itBundled("regression/21200/DefineReservedWordProperty", {
     files: {
       "entry.js": /* js */ `
-        if (VAR1 !== 42) throw 'fail: VAR1=' + VAR1;
-        if (VAR2 !== 42) throw 'fail: VAR2=' + VAR2;
-        if (VAR3 !== 42) throw 'fail: VAR3=' + VAR3;
-        if (VAR4 !== 42) throw 'fail: VAR4=' + VAR4;
-        if (VAR5 !== 42) throw 'fail: VAR5=' + VAR5;
-        if (VAR6 !== 42) throw 'fail: VAR6=' + VAR6;
-      `,
-      "entry2.js": /* js */ `
         globalThis.x = { "import": 1, "export": 2, "class": 3, "function": 4, "var": 5, "default": 6 };
         globalThis.a = { b: { c: { "import": 7 } } };
-        require("./entry3.js");
-      `,
-      "entry3.js": /* js */ `
         if (VAR1 !== 1) throw 'fail: VAR1=' + VAR1;
         if (VAR2 !== 2) throw 'fail: VAR2=' + VAR2;
         if (VAR3 !== 3) throw 'fail: VAR3=' + VAR3;
@@ -29,7 +18,6 @@ describe("bundler", () => {
         if (VAR7 !== 7) throw 'fail: VAR7=' + VAR7;
       `,
     },
-    entryPoints: ["entry2.js"],
     define: {
       VAR1: "x.import",
       VAR2: "x.export",

--- a/test/regression/issue/21200.test.ts
+++ b/test/regression/issue/21200.test.ts
@@ -1,0 +1,44 @@
+import { describe } from "bun:test";
+import { itBundled } from "../../bundler/expectBundled";
+
+describe("bundler", () => {
+  // https://github.com/oven-sh/bun/issues/21200
+  // --define with reserved word property names should produce property access, not string literals
+  itBundled("regression/21200/DefineReservedWordProperty", {
+    files: {
+      "entry.js": /* js */ `
+        if (VAR1 !== 42) throw 'fail: VAR1=' + VAR1;
+        if (VAR2 !== 42) throw 'fail: VAR2=' + VAR2;
+        if (VAR3 !== 42) throw 'fail: VAR3=' + VAR3;
+        if (VAR4 !== 42) throw 'fail: VAR4=' + VAR4;
+        if (VAR5 !== 42) throw 'fail: VAR5=' + VAR5;
+        if (VAR6 !== 42) throw 'fail: VAR6=' + VAR6;
+      `,
+      "entry2.js": /* js */ `
+        globalThis.x = { "import": 1, "export": 2, "class": 3, "function": 4, "var": 5, "default": 6 };
+        globalThis.a = { b: { c: { "import": 7 } } };
+        require("./entry3.js");
+      `,
+      "entry3.js": /* js */ `
+        if (VAR1 !== 1) throw 'fail: VAR1=' + VAR1;
+        if (VAR2 !== 2) throw 'fail: VAR2=' + VAR2;
+        if (VAR3 !== 3) throw 'fail: VAR3=' + VAR3;
+        if (VAR4 !== 4) throw 'fail: VAR4=' + VAR4;
+        if (VAR5 !== 5) throw 'fail: VAR5=' + VAR5;
+        if (VAR6 !== 6) throw 'fail: VAR6=' + VAR6;
+        if (VAR7 !== 7) throw 'fail: VAR7=' + VAR7;
+      `,
+    },
+    entryPoints: ["entry2.js"],
+    define: {
+      VAR1: "x.import",
+      VAR2: "x.export",
+      VAR3: "x.class",
+      VAR4: "x.function",
+      VAR5: "x.var",
+      VAR6: "x.default",
+      VAR7: "a.b.c.import",
+    },
+    run: true,
+  });
+});


### PR DESCRIPTION
## Summary

- Fixed `--define` treating values like `x.import` as string literals instead of property access expressions
- The keyword check in `DefineData.parse()` now only applies to the first part of a dotted path, since reserved words are valid property names in JavaScript (e.g. `x.import`, `a.b.c.default`)

Closes #21200

## Test plan

- [x] Added regression test `test/regression/issue/21200.test.ts` covering `import`, `export`, `class`, `function`, `var`, `default` as property names, plus deep chains like `a.b.c.import`
- [x] Verified test fails with system bun (`USE_SYSTEM_BUN=1`) and passes with debug build
- [x] Verified standalone keywords (e.g. `--define "VAR=import"`) are still correctly treated as string literals

🤖 Generated with [Claude Code](https://claude.com/claude-code)