### PR TITLE
fix(css): strip leading @layer declarations from bundled CSS output

### DIFF
--- a/src/bundler/linker_context/prepareCssAstsForChunk.zig
+++ b/src/bundler/linker_context/prepareCssAstsForChunk.zig
@@ -154,10 +154,8 @@ fn prepareCssAstsForChunkImpl(c: *LinkerContext, chunk: *Chunk, allocator: std.m
 
                     filter: {
                         // Filter out "@charset", "@import", and leading "@layer" rules
-                        // TODO: we are doing simple version rn, only @import
                         for (ast.rules.v.items, 0..) |*rule, ruleidx| {
-                            // if ((rule.* == .import and import_records[source_index.get()].at(rule.import.import_record_idx).flags.is_internal) or rule.* == .ignored) {} else {
-                            if (rule.* == .import or rule.* == .ignored) {} else {
+                            if (rule.* == .import or rule.* == .ignored or rule.* == .layer_statement) {} else {
                                 // It's okay to do this because AST is allocated into arena
                                 const reslice = ast.rules.v.items[ruleidx..];
                                 ast.rules.v = .{

--- a/test/regression/issue/20546.test.ts
+++ b/test/regression/issue/20546.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("issue #20546 - CSS @layer declarations should be stripped from source files", () => {
+  test("separate @layer statements with @import layer()", async () => {
+    using dir = tempDir("css-layer-20546", {
+      "main.css": /* css */ `
+@layer one;
+@layer two;
+@layer three;
+
+@import url('./a.css') layer(one);
+@import url('./b.css') layer(two);
+@import url('./c.css') layer(three);
+`,
+      "a.css": /* css */ `body { margin: 0; }`,
+      "b.css": /* css */ `h1 { font-family: sans-serif; }`,
+      "c.css": /* css */ `.text-centered { text-align: center; }`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./main.css", "--outdir=out"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+
+    const outCss = await Bun.file(`${dir}/out/main.css`).text();
+
+    // @layer declarations should appear at the top (hoisted or as part of the layer blocks)
+    // @import statements should NOT appear in the output (they've been inlined)
+    expect(outCss).not.toContain("@import");
+
+    // The bare @layer declarations should not be duplicated at the bottom
+    // They should either be hoisted to the top or removed entirely since
+    // the layer blocks establish the same ordering
+    const layerOneStatements = outCss.match(/@layer one;/g);
+    const layerTwoStatements = outCss.match(/@layer two;/g);
+    const layerThreeStatements = outCss.match(/@layer three;/g);
+
+    // Each @layer declaration should appear at most once (hoisted)
+    expect((layerOneStatements ?? []).length).toBeLessThanOrEqual(1);
+    expect((layerTwoStatements ?? []).length).toBeLessThanOrEqual(1);
+    expect((layerThreeStatements ?? []).length).toBeLessThanOrEqual(1);
+
+    // The actual layer block content should be present
+    expect(outCss).toContain("margin: 0");
+    expect(outCss).toContain("font-family: sans-serif");
+    expect(outCss).toContain("text-align: center");
+
+    expect(exitCode).toBe(0);
+  });
+
+  test("comma syntax @layer statement with @import layer()", async () => {
+    using dir = tempDir("css-layer-20546-comma", {
+      "main.css": /* css */ `
+@layer one, two, three;
+
+@import url('./a.css') layer(one);
+@import url('./b.css') layer(two);
+@import url('./c.css') layer(three);
+`,
+      "a.css": /* css */ `body { margin: 0; }`,
+      "b.css": /* css */ `h1 { font-family: sans-serif; }`,
+      "c.css": /* css */ `.text-centered { text-align: center; }`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./main.css", "--outdir=out"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+
+    const outCss = await Bun.file(`${dir}/out/main.css`).text();
+
+    // @import statements should NOT appear in the output
+    expect(outCss).not.toContain("@import");
+
+    // The actual layer block content should be present
+    expect(outCss).toContain("margin: 0");
+    expect(outCss).toContain("font-family: sans-serif");
+    expect(outCss).toContain("text-align: center");
+
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- When bundling CSS with `@layer` declarations (e.g. `@layer one;`) followed by `@import` rules with `layer()`, the bundler left the bare `@layer` statements and `@import` lines in the output even though their content was already inlined into `@layer` blocks
- The fix adds `.layer_statement` to the leading-rule filter in `prepareCssAstsForChunk`, which already stripped `@import` and `.ignored` rules but missed `@layer` statement rules

Closes #20546

## Test plan
- [x] New regression test in `test/regression/issue/20546.test.ts` covers both separate `@layer` statements and comma syntax
- [x] Test fails with system bun (`USE_SYSTEM_BUN=1`) confirming the bug
- [x] Test passes with debug build (`bun bd test`)
- [x] All 53 existing CSS bundler tests pass (`test/bundler/esbuild/css.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)