### PR TITLE
fix(bundler): honor `env: 'disable'` for NODE_ENV and BUN_ENV

### DIFF
--- a/src/options.zig
+++ b/src/options.zig
@@ -1483,7 +1483,7 @@ pub fn definesFromTransformOptions(
         );
     }
 
-    if (behavior != .load_all_without_inlining) {
+    if (behavior != .load_all_without_inlining and behavior != .disable) {
         const quoted_node_env: string = brk: {
             if (NODE_ENV) |node_env| {
                 if (node_env.len > 0) {

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -65,6 +65,24 @@ for (let backend of ["api", "cli"] as const) {
       },
     });
 
+    // Test disable mode - NODE_ENV is also not inlined (regression #22820)
+    itBundled("env/disable-node-env", {
+      env: {
+        NODE_ENV: "production",
+      },
+      backend: backend,
+      dotenv: "disable",
+      files: {
+        "/a.js": `
+        console.log(process.env.NODE_ENV);
+        console.log(process.env.NODE_ENV !== "production");
+      `,
+      },
+      run: {
+        stdout: "undefined\ntrue\n",
+      },
+    });
+
     // TODO: make this work as expected with process.env isntead of relying on the initial env vars.
     // Test pattern matching - only vars with prefix are inlined
     if (backend === "cli")

--- a/test/regression/issue/22820.test.ts
+++ b/test/regression/issue/22820.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/22820
+// Bun.build with env: 'disable' should not inline process.env.NODE_ENV
+test("Bun.build env: 'disable' does not inline NODE_ENV", async () => {
+  using dir = tempDir("issue-22820", {
+    "program.ts": `
+console.log(process.env.NODE_ENV);
+console.log(process.env.SOMETHING_ELSE);
+console.log(process.env.NODE_ENV !== "production");
+console.log(process.env.SOMETHING_ELSE !== "production");
+`,
+    "build.ts": `
+const result = await Bun.build({
+  entrypoints: ['./program.ts'],
+  outdir: './dist',
+  target: 'bun',
+  env: 'disable',
+});
+if (!result.success) {
+  console.error(result.logs);
+  process.exit(1);
+}
+`,
+  });
+
+  // Run the build
+  await using buildProc = Bun.spawn({
+    cmd: [bunExe(), "build.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [buildStdout, buildStderr, buildExit] = await Promise.all([
+    buildProc.stdout.text(),
+    buildProc.stderr.text(),
+    buildProc.exited,
+  ]);
+
+  expect(buildStderr).toBe("");
+  expect(buildExit).toBe(0);
+
+  // Read the bundled output and verify NODE_ENV is NOT inlined
+  const output = await Bun.file(`${dir}/dist/program.js`).text();
+  // process.env.NODE_ENV should appear twice (not replaced with a string literal)
+  expect(output.match(/process\.env\.NODE_ENV/g)?.length).toBe(2);
+  expect(output).toContain("process.env.SOMETHING_ELSE");
+  // "development" should NOT appear — that was the buggy inlined value
+  expect(output).not.toContain('"development"');
+  // The comparison should NOT be constant-folded to `true`
+  expect(output).not.toMatch(/console\.log\(true\)/);
+});


### PR DESCRIPTION
## Summary
- When `env: 'disable'` was set in `Bun.build` options, `process.env.NODE_ENV` and `process.env.BUN_ENV` were still being inlined as compile-time defines (e.g., replaced with `"development"`) and comparisons like `process.env.NODE_ENV !== "production"` were constant-folded to `true`.
- The condition in `definesFromTransformOptions` (`src/options.zig:1486`) only excluded `.load_all_without_inlining` but not `.disable`, so the `NODE_ENV`/`BUN_ENV` define injection block ran even when env was disabled.
- Fixed by adding `and behavior != .disable` to the condition.

Closes #22820

## Test plan
- [x] Added regression test `test/regression/issue/22820.test.ts` that builds with `env: 'disable'` and verifies `process.env.NODE_ENV` is not inlined
- [x] Added `env/disable-node-env` test case to `test/bundler/bundler_env.test.ts`
- [x] Verified test fails with system bun (`USE_SYSTEM_BUN=1`) and passes with debug build (`bun bd test`)
- [x] All existing `bundler_env.test.ts` tests pass (9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)