### PR TITLE
fix(parser): downgrade const reassignment in dead code from error to warning

### DIFF
--- a/test/regression/issue/13992.test.ts
+++ b/test/regression/issue/13992.test.ts
@@ -1,0 +1,131 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/13992
+// Bun was too aggressive with const reassignment errors in dead/unreachable code.
+// Per the ECMAScript specification, reassignment to a const binding is a runtime
+// TypeError, not a syntax error. Programs with unreachable const assignments should
+// still run.
+
+test("const reassignment after return (unreachable code)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+function b(){
+    return;
+    obj = 2;
+}
+const obj = 1;
+b();
+console.log(obj);
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("1");
+  expect(exitCode).toBe(0);
+});
+
+test("const reassignment inside if(false) (dead code)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+function b() {
+   if (false) {
+    obj = 2;
+   }
+}
+const obj = 1;
+b();
+console.log(obj);
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("1");
+  expect(exitCode).toBe(0);
+});
+
+test("const reassignment in never-called function", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+"use strict";
+function a() {
+  obj = 2;
+}
+const obj = 1;
+console.log(obj);
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("1");
+  expect(exitCode).toBe(0);
+});
+
+test("const reassignment inside with statement resolves to property", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const obj = { obj: 2 };
+with (obj) {
+    obj = 10;
+};
+console.log(JSON.stringify(obj));
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe('{"obj":10}');
+  expect(exitCode).toBe(0);
+});
+
+test("actual const reassignment still throws at runtime", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const obj = Math.random();
+obj = 2;
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("TypeError");
+  expect(exitCode).not.toBe(0);
+});


### PR DESCRIPTION
## Summary

Fixes #13992.

Per the ECMAScript specification, reassignment to a `const` binding is a **runtime** `TypeError`, not a syntax error. Bun was incorrectly treating all `const` reassignment as a parse-time error, which prevented valid programs from running when the offending assignment was in unreachable/dead code.

- **Downgrade const reassignment from error to warning** when not bundling and the const value is not inlined (matching esbuild's behavior)
- **Skip the const assignment check inside `with` statements** where the identifier may resolve to a property of the `with` object at runtime rather than the outer `const` binding

The error is preserved for the bundler case (where `const` may be converted to `var`) and for inlined constants (where removing the assignment would produce invalid code).

### Cases fixed:

| Snippet | Description | Before | After |
|---------|-------------|--------|-------|
| `function b(){ return; obj = 2; } const obj = 1; b();` | Unreachable code after `return` | Error | Runs OK |
| `function b(){ if(false){ obj = 2; } } const obj = 1; b();` | Dead code in `if(false)` | Error | Runs OK |
| `function a(){ obj = 2; } const obj = 1;` | Never-called function | Error | Runs OK |
| `const obj = {obj:2}; with(obj){ obj=10; }` | `with` statement resolves to property | Error | Runs OK, prints `{obj:10}` |

## Test plan

- [x] New regression tests in `test/regression/issue/13992.test.ts` covering all 4 snippets from the issue plus a test that actual const reassignment still throws at runtime
- [x] Tests fail with `USE_SYSTEM_BUN=1` (pre-fix) and pass with `bun bd test` (post-fix)
- [x] Existing bundler tests (`ForbidConstAssignWhenBundling`, `ConstValueInliningAssign`) still pass
- [x] Transpiler tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)