### PR TITLE
fix(bundler): prevent NODE_ENV inlining when env is "disable" via JS API

### DIFF
--- a/src/options.zig
+++ b/src/options.zig
@@ -1483,7 +1483,7 @@ pub fn definesFromTransformOptions(
         );
     }
 
-    if (behavior != .load_all_without_inlining) {
+    if (behavior != .load_all_without_inlining and behavior != .disable) {
         const quoted_node_env: string = brk: {
             if (NODE_ENV) |node_env| {
                 if (node_env.len > 0) {

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -65,6 +65,23 @@ for (let backend of ["api", "cli"] as const) {
       },
     });
 
+    // #19508 - env: "disable" should also prevent NODE_ENV from being inlined
+    itBundled("env/disable-node-env", {
+      backend: backend,
+      dotenv: "disable",
+      files: {
+        "/a.js": `console.log(process.env.NODE_ENV);`,
+      },
+      onAfterBundle(api) {
+        const content = api.readFile("/out.js");
+        if (!content.includes("process.env.NODE_ENV")) {
+          throw new Error(
+            "process.env.NODE_ENV was inlined but should have been preserved with env: 'disable'. Output:\n" + content,
+          );
+        }
+      },
+    });
+
     // TODO: make this work as expected with process.env isntead of relying on the initial env vars.
     // Test pattern matching - only vars with prefix are inlined
     if (backend === "cli")


### PR DESCRIPTION
## Summary
- When using `Bun.build({ env: "disable" })`, `process.env.NODE_ENV` was still being inlined to its current value (e.g. `"development"`), while the CLI `bun build --env=disable` correctly preserved it.
- The root cause: the JS API mapped `"disable"` to the `.disable` enum value, but `definesFromTransformOptions` in `src/options.zig` only checked for `.load_all_without_inlining` when deciding whether to skip NODE_ENV inlining. Added `.disable` to that guard condition.

Fixes #19508

## Test plan
- [x] Added `env/disable-node-env` test in `test/bundler/bundler_env.test.ts` that runs for both `api` and `cli` backends
- [x] Test verifies `process.env.NODE_ENV` is preserved (not inlined) when `env: "disable"` is set
- [x] Test fails on system bun (`USE_SYSTEM_BUN=1`) and passes on debug build (`bun bd test`)
- [x] All existing bundler env tests continue to pass (9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)