### PR TITLE
fix(bundler): allow `define` to replace optional chaining expressions

### DIFF
--- a/src/ast/P.zig
+++ b/src/ast/P.zig
@@ -5455,10 +5455,6 @@ pub fn NewParser_(
             switch (expr.data) {
                 .e_dot => |ex| {
                     if (parts.len > 1) {
-                        if (ex.optional_chain != null) {
-                            return false;
-                        }
-
                         // Intermediates must be dot expressions
                         const last = parts.len - 1;
                         const is_tail_match = strings.eql(parts[last], ex.name);
@@ -5474,10 +5470,6 @@ pub fn NewParser_(
                 // the intent is to handle people using this form instead of E.Dot. So we really only want to do this if the accessor can also be an identifier
                 .e_index => |index| {
                     if (parts.len > 1 and index.index.data == .e_string and index.index.data.e_string.isUTF8()) {
-                        if (index.optional_chain != null) {
-                            return false;
-                        }
-
                         const last = parts.len - 1;
                         const is_tail_match = strings.eql(parts[last], index.index.data.e_string.slice(p.allocator));
                         return is_tail_match and p.isDotDefineMatch(index.target, parts[0..last]);

--- a/test/regression/issue/07106.test.ts
+++ b/test/regression/issue/07106.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+test("define should work with optional chaining expressions", async () => {
+  using dir = tempDir("issue-7106", {
+    "input.js": `console.log(process.env.NODE_ENV);
+console.log(process.env?.NODE_ENV);
+console.log(process?.env?.NODE_ENV);
+console.log(process?.env.NODE_ENV);`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "build",
+      "--transform",
+      "--define",
+      'process.env.NODE_ENV="production"',
+      join(String(dir), "input.js"),
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+
+  // All optional chaining variants should be replaced by the define value
+  expect(stdout).toContain('"production"');
+  expect(stdout).not.toContain("process.env?.NODE_ENV");
+  expect(stdout).not.toContain("process?.env?.NODE_ENV");
+  expect(stdout).not.toContain("process?.env.NODE_ENV");
+  expect(exitCode).toBe(0);
+});
+
+test("define should work with bracket notation and optional chaining", async () => {
+  using dir = tempDir("issue-7106-2", {
+    "input.js": `console.log(a.b.c);
+console.log(a?.b.c);
+console.log(a.b?.c);
+console.log(a?.b?.c);`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--transform", "--define", 'a.b.c="replaced"', join(String(dir), "input.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  // All variants should be replaced
+  expect(stdout).not.toContain("a.b.c");
+  expect(stdout).not.toContain("a?.b.c");
+  expect(stdout).not.toContain("a.b?.c");
+  expect(stdout).not.toContain("a?.b?.c");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fixes `define` not substituting expressions that use optional chaining (`?.`), e.g. `process.env?.NODE_ENV`, `process?.env?.NODE_ENV`
- Removes the `optional_chain != null` early-return in `isDotDefineMatch` for both `.e_dot` and `.e_index` cases, matching esbuild's behavior where define matching is purely structural

## Before
```bash
$ bun build --transform --define 'process.env.NODE_ENV="production"' input.js
console.log("production");
console.log(process.env?.NODE_ENV);     // NOT replaced
console.log(process?.env?.NODE_ENV);    // NOT replaced
console.log(process?.env.NODE_ENV);     // NOT replaced
```

## After
```bash
$ bun build --transform --define 'process.env.NODE_ENV="production"' input.js
console.log("production");
console.log("production");
console.log("production");
console.log("production");
```

## Test plan
- [x] New regression test `test/regression/issue/07106.test.ts` verifies all optional chaining variants are replaced
- [x] Test fails with system bun (`USE_SYSTEM_BUN=1`) and passes with debug build
- [x] Existing `Define*` tests in `test/bundler/esbuild/extra.test.ts` pass (9 pass, 3 todo)
- [x] Existing `Define*` tests in `test/bundler/esbuild/default.test.ts` pass (2 pass, 2 todo)
- [x] Existing `ExportsConditions*` tests in `test/bundler/bundler_bun.test.ts` pass (4 pass)

Closes #7106

🤖 Generated with [Claude Code](https://claude.com/claude-code)