### PR TITLE
fix(test): implement `--silent` flag for `bun test`

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -109,6 +109,11 @@ fn messageWithTypeAndLevel_(
         return;
     }
 
+    // When --silent is passed to `bun test`, suppress all console output from tests.
+    if (bun.jsc.Jest.Jest.runner != null and CLI.get().test_options.silent) {
+        return;
+    }
+
     // Lock/unlock a mutex incase two JS threads are console.log'ing at the same time
     // We do this the slightly annoying way to avoid assigning a pointer
     if (level == .Warning or level == .Error or message_type == .Assert) {

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -280,6 +280,11 @@ pub const Bunfig = struct {
                         this.ctx.test_options.coverage.enabled = expr.data.e_boolean.value;
                     }
 
+                    if (test_.get("silent")) |expr| {
+                        try this.expect(expr, .e_boolean);
+                        this.ctx.test_options.silent = expr.data.e_boolean.value;
+                    }
+
                     if (test_.get("onlyFailures")) |expr| {
                         try this.expect(expr, .e_boolean);
                         this.ctx.test_options.reporters.only_failures = expr.data.e_boolean.value;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -354,6 +354,7 @@ pub const Command = struct {
         test_filter_pattern: ?[]const u8 = null,
         test_filter_regex: ?*RegularExpression = null,
         max_concurrency: u32 = 20,
+        silent: bool = false,
 
         reporters: struct {
             dots: bool = false,

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -237,6 +237,7 @@ pub const test_only_params = [_]ParamType{
     clap.parseParam("--dots                           Enable dots reporter. Shorthand for --reporter=dots.") catch unreachable,
     clap.parseParam("--only-failures                  Only display test failures, hiding passing tests.") catch unreachable,
     clap.parseParam("--max-concurrency <NUMBER>        Maximum number of concurrent tests to execute at once. Default is 20.") catch unreachable,
+    clap.parseParam("--silent                           Prevent tests from printing messages through the console.") catch unreachable,
 };
 pub const test_params = test_only_params ++ runtime_params_ ++ transpiler_params_ ++ base_params_;
 
@@ -537,6 +538,11 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
         // Handle --only-failures flag
         if (args.flag("--only-failures")) {
             ctx.test_options.reporters.only_failures = true;
+        }
+
+        // Handle --silent flag: suppress console output from tests
+        if (args.flag("--silent")) {
+            ctx.test_options.silent = true;
         }
 
         if (args.option("--coverage-dir")) |dir| {

--- a/test/regression/issue/09558.test.ts
+++ b/test/regression/issue/09558.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("--silent suppresses console output from tests", async () => {
+  using dir = tempDir("test-silent", {
+    "silent.test.ts": `
+import { test, expect } from "bun:test";
+
+test("test with console output", () => {
+  console.log("LOG_SHOULD_BE_HIDDEN");
+  console.warn("WARN_SHOULD_BE_HIDDEN");
+  console.error("ERROR_SHOULD_BE_HIDDEN");
+  expect(1 + 1).toBe(2);
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--silent", "silent.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).not.toContain("LOG_SHOULD_BE_HIDDEN");
+  expect(stderr).not.toContain("WARN_SHOULD_BE_HIDDEN");
+  expect(stderr).not.toContain("ERROR_SHOULD_BE_HIDDEN");
+  expect(stderr).toContain("1 pass");
+  expect(exitCode).toBe(0);
+});
+
+test("without --silent, console output is visible", async () => {
+  using dir = tempDir("test-no-silent", {
+    "nosilent.test.ts": `
+import { test, expect } from "bun:test";
+
+test("test with console output", () => {
+  console.log("LOG_SHOULD_BE_VISIBLE");
+  expect(1 + 1).toBe(2);
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "nosilent.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("LOG_SHOULD_BE_VISIBLE");
+  expect(stderr).toContain("1 pass");
+  expect(exitCode).toBe(0);
+});
+
+test("--silent with bunfig.toml [test] silent = true", async () => {
+  using dir = tempDir("test-silent-bunfig", {
+    "bunfig.toml": `
+[test]
+silent = true
+`,
+    "bunfig-silent.test.ts": `
+import { test, expect } from "bun:test";
+
+test("test with console output", () => {
+  console.log("BUNFIG_LOG_HIDDEN");
+  console.warn("BUNFIG_WARN_HIDDEN");
+  expect(true).toBe(true);
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "bunfig-silent.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).not.toContain("BUNFIG_LOG_HIDDEN");
+  expect(stderr).not.toContain("BUNFIG_WARN_HIDDEN");
+  expect(stderr).toContain("1 pass");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Implement the `--silent` flag for `bun test`, which suppresses console output (`console.log`, `console.warn`, `console.error`) during test execution, matching Jest's behavior
- Support both CLI (`bun test --silent`) and config (`[test] silent = true` in `bunfig.toml`)
- Test results (pass/fail counts, test names) are still displayed — only user console output is suppressed

## Changes

- **`src/cli/Arguments.zig`**: Add `--silent` to `test_only_params` and parse it for `TestCommand`
- **`src/cli.zig`**: Add `silent: bool` field to `TestOptions`
- **`src/bunfig.zig`**: Parse `silent` in the `[test]` section of bunfig.toml
- **`src/bun.js/ConsoleObject.zig`**: Early-return from `messageWithTypeAndLevel_` when `--silent` is active and we're in the test runner, suppressing all console methods

## Test plan

- [x] `bun test --silent` suppresses `console.log`, `console.warn`, `console.error` output
- [x] Without `--silent`, console output is still visible (no regressions)
- [x] `[test] silent = true` in `bunfig.toml` works the same as the CLI flag
- [x] Test results (pass/fail summary) are still displayed with `--silent`
- [x] Regression test added: `test/regression/issue/09558.test.ts`
- [x] Test fails with system bun (USE_SYSTEM_BUN=1), passes with debug build

Closes #9558

🤖 Generated with [Claude Code](https://claude.com/claude-code)