### PR TITLE
fix(transpiler): respect trimUnusedImports in scanImports/scan

### DIFF
--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -874,6 +874,7 @@ pub fn scan(this: *JSTranspiler, globalThis: *jsc.JSGlobalObject, callframe: *js
     const named_imports_value = try namedImportsToJS(
         globalThis,
         parse_result.ast.import_records.slice(),
+        this.config.trim_unused_imports orelse false,
     );
 
     const named_exports_value = try namedExportsToJS(
@@ -1060,20 +1061,30 @@ fn namedExportsToJS(global: *JSGlobalObject, named_exports: *JSAst.Ast.NamedExpo
     return bun.String.toJSArray(global, names);
 }
 
-fn namedImportsToJS(global: *JSGlobalObject, import_records: []const ImportRecord) bun.JSError!jsc.JSValue {
+fn namedImportsToJS(global: *JSGlobalObject, import_records: []const ImportRecord, trim_unused_imports: bool) bun.JSError!jsc.JSValue {
     const path_label = jsc.ZigString.static("path");
     const kind_label = jsc.ZigString.static("kind");
 
-    const array = try jsc.JSValue.createEmptyArray(global, import_records.len);
+    var count: u32 = 0;
+    for (import_records) |record| {
+        if (record.flags.is_internal) continue;
+        if (trim_unused_imports and record.flags.is_unused) continue;
+        count += 1;
+    }
+
+    const array = try jsc.JSValue.createEmptyArray(global, count);
     array.ensureStillAlive();
 
-    for (import_records, 0..) |record, i| {
+    var i: u32 = 0;
+    for (import_records) |record| {
         if (record.flags.is_internal) continue;
+        if (trim_unused_imports and record.flags.is_unused) continue;
 
         array.ensureStillAlive();
         const path = jsc.ZigString.init(record.path.text).toJS(global);
         const kind = jsc.ZigString.init(record.kind.label()).toJS(global);
-        try array.putIndex(global, @as(u32, @truncate(i)), try jsc.JSValue.createObject2(global, path_label, kind_label, path, kind));
+        try array.putIndex(global, i, try jsc.JSValue.createObject2(global, path_label, kind_label, path, kind));
+        i += 1;
     }
 
     return array;
@@ -1165,6 +1176,7 @@ pub fn scanImports(this: *JSTranspiler, globalThis: *jsc.JSGlobalObject, callfra
     const named_imports_value = try namedImportsToJS(
         globalThis,
         this.scan_pass_result.import_records.items,
+        this.config.trim_unused_imports orelse false,
     );
     return named_imports_value;
 }

--- a/test/regression/issue/13251.test.ts
+++ b/test/regression/issue/13251.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test";
+
+test("scanImports respects trimUnusedImports", () => {
+  const transpiler = new Bun.Transpiler({
+    trimUnusedImports: true,
+    loader: "tsx",
+  });
+
+  // Unused named import should be trimmed
+  expect(transpiler.scanImports(`import { Component } from "./Component";`)).toEqual([]);
+
+  // Unused default import should be trimmed
+  expect(transpiler.scanImports(`import Foo from "./Foo";`)).toEqual([]);
+
+  // Unused namespace import should be trimmed
+  expect(transpiler.scanImports(`import * as Utils from "./Utils";`)).toEqual([]);
+
+  // Used named import should be kept
+  expect(transpiler.scanImports(`import { Component } from "./Component"; console.log(Component);`)).toEqual([
+    { path: "./Component", kind: "import-statement" },
+  ]);
+
+  // Bare/side-effect import should always be kept
+  expect(transpiler.scanImports(`import "./side-effect";`)).toEqual([
+    { path: "./side-effect", kind: "import-statement" },
+  ]);
+
+  // Type-only import should always be trimmed
+  expect(transpiler.scanImports(`import type { Foo } from "./Foo";`)).toEqual([]);
+});
+
+test("scan respects trimUnusedImports", () => {
+  const transpiler = new Bun.Transpiler({
+    trimUnusedImports: true,
+    loader: "tsx",
+  });
+
+  // Unused named import should be trimmed from scan result
+  const unusedResult = transpiler.scan(`import { Component } from "./Component";`);
+  expect(unusedResult.imports).toEqual([]);
+
+  // Used named import should be kept in scan result
+  const usedResult = transpiler.scan(`import { Component } from "./Component"; console.log(Component);`);
+  expect(usedResult.imports).toEqual([{ path: "./Component", kind: "import-statement" }]);
+
+  // Bare/side-effect import should always be kept
+  const sideEffectResult = transpiler.scan(`import "./side-effect";`);
+  expect(sideEffectResult.imports).toEqual([{ path: "./side-effect", kind: "import-statement" }]);
+});
+
+test("scanImports returns all imports when trimUnusedImports is false", () => {
+  const transpiler = new Bun.Transpiler({
+    trimUnusedImports: false,
+    loader: "tsx",
+  });
+
+  // Unused named import should NOT be trimmed when option is false
+  expect(transpiler.scanImports(`import { Component } from "./Component";`)).toEqual([
+    { path: "./Component", kind: "import-statement" },
+  ]);
+});
+
+test("scan returns all imports when trimUnusedImports is false", () => {
+  const transpiler = new Bun.Transpiler({
+    trimUnusedImports: false,
+    loader: "tsx",
+  });
+
+  const result = transpiler.scan(`import { Component } from "./Component";`);
+  expect(result.imports).toEqual([{ path: "./Component", kind: "import-statement" }]);
+});


### PR DESCRIPTION
## Summary
- `trimUnusedImports` was ignored by `Bun.Transpiler.scanImports()` and `Bun.Transpiler.scan()`, only working for `transformSync()`
- The `namedImportsToJS` helper now checks the `is_unused` flag on import records when `trimUnusedImports` is enabled
- Also fixes a pre-existing array sizing bug where skipped records left holes/undefined entries in the result array

Closes #13251

## Test plan
- [x] Added regression test `test/regression/issue/13251.test.ts` covering:
  - `scanImports()` with `trimUnusedImports: true` — unused named, default, and namespace imports are trimmed
  - `scan()` with `trimUnusedImports: true` — unused imports are trimmed from the result
  - Used imports, bare/side-effect imports, and type-only imports behave correctly
  - `trimUnusedImports: false` preserves all imports (no regression)
- [x] Test fails with system Bun (`USE_SYSTEM_BUN=1`) and passes with debug build (`bun bd test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)