### PR TITLE
fix(shell): support `-e` and `-E` flags in builtin `echo`

### DIFF
--- a/src/shell/builtin/echo.zig
+++ b/src/shell/builtin/echo.zig
@@ -12,27 +12,79 @@ state: union(enum) {
 
 pub fn start(this: *Echo) Yield {
     var args = this.bltn().argsSlice();
-    const no_newline = args.len >= 1 and std.mem.eql(u8, bun.sliceTo(args[0], 0), "-n");
 
-    args = args[if (no_newline) 1 else 0..];
+    // Parse flags: echo accepts -n, -e, -E in any combination.
+    // Flag parsing stops at the first arg that doesn't start with '-'
+    // or contains an invalid flag character.
+    var no_newline = false;
+    var escape_sequences = false;
+    var flags_done = false;
+    var args_start: usize = 0;
+
+    for (args) |arg| {
+        if (flags_done) break;
+        const flag = std.mem.span(arg);
+        if (flag.len < 2 or flag[0] != '-') {
+            flags_done = true;
+            break;
+        }
+        // Validate all characters are valid echo flags
+        var valid = true;
+        for (flag[1..]) |c| {
+            switch (c) {
+                'n', 'e', 'E' => {},
+                else => {
+                    valid = false;
+                    break;
+                },
+            }
+        }
+        if (!valid) {
+            flags_done = true;
+            break;
+        }
+        // Apply flags (last -e/-E wins)
+        for (flag[1..]) |c| {
+            switch (c) {
+                'n' => no_newline = true,
+                'e' => escape_sequences = true,
+                'E' => escape_sequences = false,
+                else => unreachable,
+            }
+        }
+        args_start += 1;
+    }
+
+    args = args[args_start..];
     const args_len = args.len;
     var has_leading_newline: bool = false;
+    var stop_output = false;
 
     // TODO: Should flush buffer after it gets to a certain size
     for (args, 0..) |arg, i| {
+        if (stop_output) break;
         const thearg = std.mem.span(arg);
-        if (i < args_len - 1) {
-            bun.handleOom(this.output.appendSlice(thearg));
-            bun.handleOom(this.output.append(' '));
+        const is_last = i == args_len - 1;
+
+        if (escape_sequences) {
+            stop_output = appendWithEscapes(&this.output, thearg);
         } else {
-            if (thearg.len > 0 and thearg[thearg.len - 1] == '\n') {
-                has_leading_newline = true;
+            if (is_last) {
+                if (thearg.len > 0 and thearg[thearg.len - 1] == '\n') {
+                    has_leading_newline = true;
+                }
+                bun.handleOom(this.output.appendSlice(bun.strings.trimSubsequentLeadingChars(thearg, '\n')));
+            } else {
+                bun.handleOom(this.output.appendSlice(thearg));
             }
-            bun.handleOom(this.output.appendSlice(bun.strings.trimSubsequentLeadingChars(thearg, '\n')));
+        }
+
+        if (!stop_output and !is_last) {
+            bun.handleOom(this.output.append(' '));
         }
     }
 
-    if (!has_leading_newline and !no_newline) bun.handleOom(this.output.append('\n'));
+    if (!stop_output and !has_leading_newline and !no_newline) bun.handleOom(this.output.append('\n'));
 
     if (this.bltn().stdout.needsIO()) |safeguard| {
         this.state = .waiting;
@@ -41,6 +93,109 @@ pub fn start(this: *Echo) Yield {
     _ = this.bltn().writeNoIO(.stdout, this.output.items[0..]);
     this.state = .done;
     return this.bltn().done(0);
+}
+
+/// Appends `input` to `output`, interpreting backslash escape sequences.
+/// Returns true if a \c escape was encountered (meaning stop all output).
+fn appendWithEscapes(output: *std.array_list.Managed(u8), input: []const u8) bool {
+    var i: usize = 0;
+    while (i < input.len) {
+        if (input[i] == '\\' and i + 1 < input.len) {
+            switch (input[i + 1]) {
+                '\\' => {
+                    bun.handleOom(output.append('\\'));
+                    i += 2;
+                },
+                'a' => {
+                    bun.handleOom(output.append('\x07'));
+                    i += 2;
+                },
+                'b' => {
+                    bun.handleOom(output.append('\x08'));
+                    i += 2;
+                },
+                'c' => {
+                    // \c: produce no further output
+                    return true;
+                },
+                'e', 'E' => {
+                    bun.handleOom(output.append('\x1b'));
+                    i += 2;
+                },
+                'f' => {
+                    bun.handleOom(output.append('\x0c'));
+                    i += 2;
+                },
+                'n' => {
+                    bun.handleOom(output.append('\n'));
+                    i += 2;
+                },
+                'r' => {
+                    bun.handleOom(output.append('\r'));
+                    i += 2;
+                },
+                't' => {
+                    bun.handleOom(output.append('\t'));
+                    i += 2;
+                },
+                'v' => {
+                    bun.handleOom(output.append('\x0b'));
+                    i += 2;
+                },
+                '0' => {
+                    // \0nnn: octal value (up to 3 octal digits)
+                    i += 2; // skip \0
+                    var val: u8 = 0;
+                    var digits: usize = 0;
+                    while (digits < 3 and i < input.len and input[i] >= '0' and input[i] <= '7') {
+                        val = val *% 8 +% (input[i] - '0');
+                        i += 1;
+                        digits += 1;
+                    }
+                    bun.handleOom(output.append(val));
+                },
+                'x' => {
+                    // \xHH: hex value (up to 2 hex digits)
+                    i += 2; // skip \x
+                    var val: u8 = 0;
+                    var digits: usize = 0;
+                    while (digits < 2 and i < input.len) {
+                        const hex_val = hexDigitValue(input[i]);
+                        if (hex_val) |hv| {
+                            val = val *% 16 +% hv;
+                            i += 1;
+                            digits += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    if (digits > 0) {
+                        bun.handleOom(output.append(val));
+                    } else {
+                        // No valid hex digits: output \x literally
+                        bun.handleOom(output.appendSlice("\\x"));
+                    }
+                },
+                else => {
+                    // Unknown escape: output backslash and the character as-is
+                    bun.handleOom(output.append('\\'));
+                    bun.handleOom(output.append(input[i + 1]));
+                    i += 2;
+                },
+            }
+        } else {
+            bun.handleOom(output.append(input[i]));
+            i += 1;
+        }
+    }
+    return false;
+}
+
+fn hexDigitValue(c: u8) ?u8 {
+    if (c >= '0' and c <= '9') return c - '0';
+    if (c >= 'a' and c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' and c <= 'F') return c - 'A' + 10;
+    return null;
 }
 
 pub fn onIOWriterChunk(this: *Echo, _: usize, e: ?jsc.SystemError) Yield {

--- a/test/js/bun/shell/commands/echo.test.ts
+++ b/test/js/bun/shell/commands/echo.test.ts
@@ -61,11 +61,7 @@ describe("echo error handling", async () => {
 });
 
 describe("echo special cases", async () => {
-  TestBuilder.command`echo -n -n hello`
-    .exitCode(0)
-    .stdout("-n hello")
-    .stderr("")
-    .runAsTest("-n flag with -n as argument");
+  TestBuilder.command`echo -n -n hello`.exitCode(0).stdout("hello").stderr("").runAsTest("-n flag with -n as argument");
 
   TestBuilder.command`echo -- -n hello`
     .exitCode(0)

--- a/test/regression/issue/17405.test.ts
+++ b/test/regression/issue/17405.test.ts
@@ -1,0 +1,117 @@
+import { $ } from "bun";
+import { describe, expect, test } from "bun:test";
+
+describe("echo -e flag support", () => {
+  test("echo -e does not output -e as literal text", async () => {
+    const result = await $`echo -e hello`.text();
+    expect(result).toBe("hello\n");
+  });
+
+  test("echo -e interprets backslash-n", async () => {
+    const result = await $`echo -e ${"hello\\nworld"}`.text();
+    expect(result).toBe("hello\nworld\n");
+  });
+
+  test("echo -e interprets backslash-t", async () => {
+    const result = await $`echo -e ${"hello\\tworld"}`.text();
+    expect(result).toBe("hello\tworld\n");
+  });
+
+  test("echo -e interprets backslash-backslash", async () => {
+    const result = await $`echo -e ${"hello\\\\world"}`.text();
+    expect(result).toBe("hello\\world\n");
+  });
+
+  test("echo -e interprets \\a (bell)", async () => {
+    const result = await $`echo -e ${"\\a"}`.text();
+    expect(result).toBe("\x07\n");
+  });
+
+  test("echo -e interprets \\b (backspace)", async () => {
+    const result = await $`echo -e ${"a\\bb"}`.text();
+    expect(result).toBe("a\bb\n");
+  });
+
+  test("echo -e interprets \\r (carriage return)", async () => {
+    const result = await $`echo -e ${"hello\\rworld"}`.text();
+    expect(result).toBe("hello\rworld\n");
+  });
+
+  test("echo -e interprets \\f (form feed)", async () => {
+    const result = await $`echo -e ${"\\f"}`.text();
+    expect(result).toBe("\f\n");
+  });
+
+  test("echo -e interprets \\v (vertical tab)", async () => {
+    const result = await $`echo -e ${"\\v"}`.text();
+    expect(result).toBe("\v\n");
+  });
+
+  test("echo -e interprets \\0nnn (octal)", async () => {
+    // \0101 = 'A' (65 decimal)
+    const result = await $`echo -e ${"\\0101"}`.text();
+    expect(result).toBe("A\n");
+  });
+
+  test("echo -e interprets \\xHH (hex)", async () => {
+    // \x41 = 'A'
+    const result = await $`echo -e ${"\\x41\\x42\\x43"}`.text();
+    expect(result).toBe("ABC\n");
+  });
+
+  test("echo -e \\c stops output", async () => {
+    const result = await $`echo -e ${"hello\\cworld"}`.text();
+    expect(result).toBe("hello");
+  });
+
+  test("echo -e with \\e (escape character)", async () => {
+    const result = await $`echo -e ${"\\e"}`.text();
+    expect(result).toBe("\x1b\n");
+  });
+
+  test("echo -E disables escape interpretation", async () => {
+    const result = await $`echo -E ${"hello\\nworld"}`.text();
+    expect(result).toBe("hello\\nworld\n");
+  });
+
+  test("echo -eE (last wins: -E disables)", async () => {
+    const result = await $`echo -eE ${"hello\\tworld"}`.text();
+    expect(result).toBe("hello\\tworld\n");
+  });
+
+  test("echo -Ee (last wins: -e enables)", async () => {
+    const result = await $`echo -Ee ${"hello\\tworld"}`.text();
+    expect(result).toBe("hello\tworld\n");
+  });
+
+  test("echo -ne (no newline + escapes)", async () => {
+    const result = await $`echo -ne ${"hello\\tworld"}`.text();
+    expect(result).toBe("hello\tworld");
+  });
+
+  test("echo -en (same as -ne)", async () => {
+    const result = await $`echo -en ${"hello\\tworld"}`.text();
+    expect(result).toBe("hello\tworld");
+  });
+
+  test("echo -n still works (no newline)", async () => {
+    const result = await $`echo -n hello`.text();
+    expect(result).toBe("hello");
+  });
+
+  test("echo with invalid flag outputs literally", async () => {
+    const result = await $`echo -x hello`.text();
+    expect(result).toBe("-x hello\n");
+  });
+
+  test("echo -e piped to cat (original issue scenario)", async () => {
+    const pw = "mypassword";
+    const result = await $`echo -e ${pw} | cat`.text();
+    expect(result).toBe("mypassword\n");
+  });
+
+  test("echo without -e still works normally", async () => {
+    const result = await $`echo hello world`.text();
+    expect(result).toBe("hello world\n");
+  });
+});


### PR DESCRIPTION
## Summary

- Bun's builtin `echo` only supported the `-n` flag. The `-e` flag (and `-E`) were treated as literal text, causing `echo -e password` to output `-e password` instead of `password`. This broke common patterns like `echo -e $password | sudo -S ...`.
- Added full `-e` (enable backslash escapes) and `-E` (disable backslash escapes) flag support, matching bash behavior including combined flags like `-ne`, `-en`, `-eE`, `-Ee`.
- Supported escape sequences: `\\`, `\a`, `\b`, `\c`, `\e`/`\E`, `\f`, `\n`, `\r`, `\t`, `\v`, `\0nnn` (octal), `\xHH` (hex).

Closes #17405

## Test plan

- [x] Added 22 tests in `test/regression/issue/17405.test.ts` covering all escape sequences, flag combinations, and the original issue scenario
- [x] Verified tests fail with system bun (19/22 fail) and pass with debug build (22/22 pass)
- [x] Verified existing shell tests (`bunshell.test.ts`) still pass — all 27 echo-related tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)