### PR TITLE
fix(jsx): respect NODE_ENV=production for JSX transform selection

### DIFF
--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -242,8 +242,9 @@ pub const BuildCommand = struct {
         this_transpiler.resolver.opts = this_transpiler.options;
         this_transpiler.resolver.env_loader = this_transpiler.env;
 
-        // Allow tsconfig.json overriding, but always set it to false if --production is passed.
-        if (ctx.bundler_options.production) {
+        // Allow tsconfig.json overriding, but always set it to false if --production is passed
+        // or NODE_ENV=production is set.
+        if (ctx.bundler_options.production or this_transpiler.options.force_node_env == .production) {
             this_transpiler.options.jsx.development = false;
             this_transpiler.resolver.opts.jsx.development = false;
         }

--- a/src/options.zig
+++ b/src/options.zig
@@ -1241,7 +1241,7 @@ pub const JSX = struct {
         .{ "classic", RuntimeDevelopmentPair{ .runtime = .classic, .development = null } },
         .{ "automatic", RuntimeDevelopmentPair{ .runtime = .automatic, .development = true } },
         .{ "react", RuntimeDevelopmentPair{ .runtime = .classic, .development = null } },
-        .{ "react-jsx", RuntimeDevelopmentPair{ .runtime = .automatic, .development = true } },
+        .{ "react-jsx", RuntimeDevelopmentPair{ .runtime = .automatic, .development = false } },
         .{ "react-jsxdev", RuntimeDevelopmentPair{ .runtime = .automatic, .development = true } },
     });
 

--- a/src/transpiler.zig
+++ b/src/transpiler.zig
@@ -567,6 +567,8 @@ pub const Transpiler = struct {
         } else if (is_production) {
             this.options.setProduction(true);
             this.resolver.opts.setProduction(true);
+            this.options.force_node_env = .production;
+            this.resolver.opts.force_node_env = .production;
         }
     }
 

--- a/test/regression/issue/23959.test.ts
+++ b/test/regression/issue/23959.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/23959
+// Bun.build always assumes "react-jsxdev" even when "react-jsx" should be used
+describe("NODE_ENV=production should use production JSX transform", () => {
+  test("bun build --no-bundle with NODE_ENV=production uses jsx instead of jsxDEV", async () => {
+    using dir = tempDir("issue-23959", {
+      "input.tsx": `console.log(<div>Hello</div>);`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "input.tsx"],
+      cwd: String(dir),
+      env: { ...bunEnv, NODE_ENV: "production" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+
+    // Should use production jsx runtime, not development jsxDEV
+    expect(stdout).toContain("/jsx-runtime");
+    expect(stdout).not.toContain("/jsx-dev-runtime");
+    expect(stdout).not.toContain("jsxDEV");
+    expect(await proc.exited).toBe(0);
+  });
+
+  test("bun build --no-bundle with --production uses jsx instead of jsxDEV", async () => {
+    using dir = tempDir("issue-23959-flag", {
+      "input.tsx": `console.log(<div>Hello</div>);`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "--production", "input.tsx"],
+      cwd: String(dir),
+      env: { ...bunEnv },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+
+    // Should use production jsx runtime
+    expect(stdout).toContain("/jsx-runtime");
+    expect(stdout).not.toContain("/jsx-dev-runtime");
+    expect(stdout).not.toContain("jsxDEV");
+    expect(await proc.exited).toBe(0);
+  });
+
+  test("bun build --no-bundle with NODE_ENV=production and tsconfig react-jsx uses jsx", async () => {
+    using dir = tempDir("issue-23959-tsconfig", {
+      "input.tsx": `console.log(<div>Hello</div>);`,
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          jsx: "react-jsx",
+          jsxImportSource: "react",
+        },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "input.tsx"],
+      cwd: String(dir),
+      env: { ...bunEnv, NODE_ENV: "production" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+
+    // Should use production jsx runtime
+    expect(stdout).toContain("/jsx-runtime");
+    expect(stdout).not.toContain("/jsx-dev-runtime");
+    expect(stdout).not.toContain("jsxDEV");
+    expect(await proc.exited).toBe(0);
+  });
+
+  test("bun build --no-bundle with NODE_ENV=development uses jsxDEV", async () => {
+    using dir = tempDir("issue-23959-dev", {
+      "input.tsx": `console.log(<div>Hello</div>);`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "input.tsx"],
+      cwd: String(dir),
+      env: { ...bunEnv, NODE_ENV: "development" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+
+    // Should use development jsxDEV runtime
+    expect(stdout).toContain("jsxDEV");
+    expect(stdout).toContain("/jsx-dev-runtime");
+    expect(await proc.exited).toBe(0);
+  });
+
+  test("bun build (bundled) with NODE_ENV=production uses production jsx", async () => {
+    using dir = tempDir("issue-23959-bundled", {
+      "input.tsx": `
+        import { jsx } from "react/jsx-runtime";
+        console.log(jsx("div", { children: "Hello" }));
+      `,
+      "node_modules/react/jsx-runtime.js": `
+        export function jsx(type, props, key) {
+          return { type, props, key, runtime: "production" };
+        }
+      `,
+      "node_modules/react/jsx-dev-runtime.js": `
+        export function jsxDEV(type, props, key) {
+          return { type, props, key, runtime: "development" };
+        }
+      `,
+      "node_modules/react/package.json": JSON.stringify({ name: "react", version: "19.0.0" }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          jsx: "react-jsx",
+          jsxImportSource: "react",
+        },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "input.tsx"],
+      cwd: String(dir),
+      env: { ...bunEnv, NODE_ENV: "production" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+
+    // Bundled output should use production jsx, not jsxDEV
+    expect(stdout).not.toContain("jsxDEV");
+    expect(stdout).not.toContain("jsx_dev_runtime");
+    expect(await proc.exited).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #23959. `bun build` was always using development JSX transforms (`jsxDEV` from `react/jsx-dev-runtime`) even when `NODE_ENV=production` was set.

Three interacting bugs caused this:

- **`RuntimeMap` regression in `src/options.zig`**: The `"react-jsx"` tsconfig option was mapped to `.development = true` instead of `.development = false`. This is a regression of the fix in PR #17013.
- **Missing `force_node_env` in `src/transpiler.zig`**: When `NODE_ENV=production` was detected in `configureDefines`, it set production mode but did **not** set `force_node_env = .production`, unlike the `NODE_ENV=development` path which correctly sets `force_node_env = .development`.
- **Incomplete override in `src/cli/build_command.zig`**: The post-tsconfig JSX development override only applied when the `--production` CLI flag was passed, not when `NODE_ENV=production` was set via environment.

## Test plan

- [x] New regression test `test/regression/issue/23959.test.ts` with 5 cases:
  - `NODE_ENV=production` with `--no-bundle` uses `jsx`/`jsx-runtime`
  - `--production` flag with `--no-bundle` uses `jsx`/`jsx-runtime`
  - `NODE_ENV=production` with tsconfig `react-jsx` uses `jsx`/`jsx-runtime`
  - `NODE_ENV=development` uses `jsxDEV`/`jsx-dev-runtime`
  - Bundled build with `NODE_ENV=production` and mock react uses production jsx
- [x] Test fails with `USE_SYSTEM_BUN=1` (system bun v1.3.9)
- [x] Test passes with `bun bd test`
- [x] Existing `test/bundler/bundler_jsx.test.ts` passes (27 pass, 0 fail)
- [x] Existing `test/bundler/transpiler/jsx-production.test.ts` passes (32 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)