### PR TITLE
fix(transpiler): legacy TS decorator parameter no longer shadows imported binding

### DIFF
--- a/test/regression/issue/17036.test.ts
+++ b/test/regression/issue/17036.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/17036
+// Legacy TypeScript decorator parameter with the same name as an imported
+// variable should not shadow the import in the decorator expression.
+test("legacy TS decorator parameter does not shadow import", async () => {
+  using dir = tempDir("issue-17036", {
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        experimentalDecorators: true,
+      },
+    }),
+    "token.ts": `export const X = "hello";`,
+    "inject.ts": `export function Inject(token: any): ParameterDecorator {
+  return (target, propertyKey, parameterIndex) => {};
+}`,
+    // Parameter name X shadows the imported X, but the decorator expression
+    // @Inject(X) should still refer to the imported X.
+    "index.ts": `import { Inject } from "./inject.ts";
+import { X } from "./token.ts";
+
+class ExampleClass {
+  constructor(
+    @Inject(X) X: string
+  ) {}
+}
+
+console.log("OK");`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "index.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("OK\n");
+  expect(stderr).not.toContain("ReferenceError");
+  expect(exitCode).toBe(0);
+});
+
+test("legacy TS decorator parameter - multiple params with shadowing", async () => {
+  using dir = tempDir("issue-17036-multi", {
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        experimentalDecorators: true,
+      },
+    }),
+    "tokens.ts": `export const A = "tokenA";
+export const B = "tokenB";`,
+    "inject.ts": `export function Inject(token: any): ParameterDecorator {
+  return (target, propertyKey, parameterIndex) => {};
+}`,
+    "index.ts": `import { Inject } from "./inject.ts";
+import { A, B } from "./tokens.ts";
+
+class ExampleClass {
+  constructor(
+    @Inject(A) A: string,
+    @Inject(B) B: string
+  ) {}
+}
+
+console.log("OK");`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "index.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("OK\n");
+  expect(stderr).not.toContain("ReferenceError");
+  expect(exitCode).toBe(0);
+});
+
+test("legacy TS decorator parameter - non-shadowing still works", async () => {
+  using dir = tempDir("issue-17036-noshadow", {
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        experimentalDecorators: true,
+      },
+    }),
+    "token.ts": `export const X = "hello";`,
+    "inject.ts": `export function Inject(token: any): ParameterDecorator {
+  return (target, propertyKey, parameterIndex) => {};
+}`,
+    // Parameter name differs from import name - should still work
+    "index.ts": `import { Inject } from "./inject.ts";
+import { X } from "./token.ts";
+
+class ExampleClass {
+  constructor(
+    @Inject(X) myParam: string
+  ) {}
+}
+
+console.log("OK");`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "index.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("OK\n");
+  expect(stderr).not.toContain("ReferenceError");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- When a constructor parameter has the same name as an imported variable used in a legacy TypeScript decorator expression (e.g., `@Inject(X) X: string`), the transpiler incorrectly dropped the import for `X`, causing a `ReferenceError` at runtime
- The root cause was that parameter decorator expressions were visited inside the `function_args` scope, which already contained the parameter binding from the parse pass, so `findSymbol("X")` found the parameter instead of the import
- The fix visits decorator expressions in the parent (enclosing) scope, matching the runtime semantics where decorator calls are hoisted outside the function

Closes #17036

## Test plan

- [x] New regression test `test/regression/issue/17036.test.ts` with 3 cases:
  - Single parameter shadowing import (`@Inject(X) X: string`)
  - Multiple parameters each shadowing their imports
  - Non-shadowing case still works correctly
- [x] Tests fail with system bun (`USE_SYSTEM_BUN=1`) and pass with debug build
- [x] All existing decorator test suites pass (22 legacy, 5 metadata, 27 ES decorator tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)