### PR TITLE
fix(parser): support Flow's `import typeof` and `export typeof` syntax

### DIFF
--- a/test/regression/issue/16945.test.ts
+++ b/test/regression/issue/16945.test.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/16945
+// Flow's `import typeof` syntax should be stripped during transpilation,
+// analogous to TypeScript's `import type`.
+
+test("import typeof default from module", async () => {
+  using dir = tempDir("16945", {
+    "flow_module.js": `
+import typeof ActionSheetIOS from './action_sheet';
+export default function hello() { return "hello"; }
+`,
+    "action_sheet.js": `export default class ActionSheetIOS {}`,
+    "index.js": `import hello from './flow_module'; console.log(hello());`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("hello");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test("import typeof with named imports", async () => {
+  using dir = tempDir("16945", {
+    "flow_module.js": `
+import typeof { Foo, Bar } from './types';
+export default function hello() { return "named"; }
+`,
+    "types.js": `export class Foo {} export class Bar {}`,
+    "index.js": `import hello from './flow_module'; console.log(hello());`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("named");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test("import typeof with namespace import", async () => {
+  using dir = tempDir("16945", {
+    "flow_module.js": `
+import typeof * as Types from './types';
+export default function hello() { return "namespace"; }
+`,
+    "types.js": `export class Foo {}`,
+    "index.js": `import hello from './flow_module'; console.log(hello());`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("namespace");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test("export typeof is stripped", async () => {
+  using dir = tempDir("16945", {
+    "flow_module.js": `
+export typeof { Foo } from './types';
+export default function hello() { return "export-typeof"; }
+`,
+    "types.js": `export class Foo {}`,
+    "index.js": `import hello from './flow_module'; console.log(hello());`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("export-typeof");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test("bun build --no-bundle strips import typeof", async () => {
+  using dir = tempDir("16945", {
+    "flow_module.js": `
+import typeof ActionSheetIOS from './action_sheet';
+export default function hello() { return "hello"; }
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--no-bundle", `${dir}/flow_module.js`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The import typeof should be stripped, so it shouldn't appear in output
+  expect(stdout).not.toContain("typeof");
+  expect(stdout).toContain("hello");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Add parser support for Flow's `import typeof` syntax (`import typeof Foo from 'bar'`, `import typeof * as Foo from 'bar'`, `import typeof { Foo } from 'bar'`)
- Add parser support for Flow's `export typeof` syntax (`export typeof { Foo } from 'bar'`)
- These type-only imports/exports are stripped during transpilation, analogous to TypeScript's `import type`

Closes #16945

## Test plan
- [x] Added regression tests in `test/regression/issue/16945.test.ts` covering all variants
- [x] Tests pass with debug build (`bun bd test test/regression/issue/16945.test.ts`)
- [x] Tests fail with system bun (`USE_SYSTEM_BUN=1 bun test test/regression/issue/16945.test.ts`)
- [x] Verified original reproduction case from the issue works

🤖 Generated with [Claude Code](https://claude.com/claude-code)