### PR TITLE
fix(process): implement `getActiveResourcesInfo` to return actual active resources

### DIFF
--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -699,7 +699,7 @@ describe.concurrent(() => {
     });
   }
 
-  const arrayStubs = ["getActiveResourcesInfo", "_getActiveRequests", "_getActiveHandles"];
+  const arrayStubs = ["_getActiveRequests", "_getActiveHandles"];
 
   for (const stub of arrayStubs) {
     it(`process.${stub}`, () => {

--- a/test/regression/issue/24538.test.ts
+++ b/test/regression/issue/24538.test.ts
@@ -1,0 +1,153 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/24538
+// process.getActiveResourcesInfo() was always returning [], causing Expo to hang
+
+test("process.getActiveResourcesInfo returns array", () => {
+  const result = process.getActiveResourcesInfo();
+  expect(result).toBeInstanceOf(Array);
+});
+
+test("process.getActiveResourcesInfo reports active setTimeout", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const t = setTimeout(() => {}, 100000);
+const resources = process.getActiveResourcesInfo();
+console.log(JSON.stringify(resources));
+clearTimeout(t);
+`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const resources = JSON.parse(stdout.trim());
+  expect(resources).toContain("Timeout");
+  expect(exitCode).toBe(0);
+});
+
+test("process.getActiveResourcesInfo reports active setInterval", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const iv = setInterval(() => {}, 100000);
+const resources = process.getActiveResourcesInfo();
+console.log(JSON.stringify(resources));
+clearInterval(iv);
+`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const resources = JSON.parse(stdout.trim());
+  expect(resources).toContain("Timeout");
+  expect(exitCode).toBe(0);
+});
+
+test("process.getActiveResourcesInfo reports active TCP server", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const net = require('net');
+const server = net.createServer();
+server.listen(0, () => {
+  const resources = process.getActiveResourcesInfo();
+  console.log(JSON.stringify(resources));
+  server.close();
+});
+`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const resources = JSON.parse(stdout.trim());
+  expect(resources.length).toBeGreaterThan(0);
+  expect(exitCode).toBe(0);
+});
+
+test("process.getActiveResourcesInfo returns empty array with no resources", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const resources = process.getActiveResourcesInfo();
+console.log(JSON.stringify(resources));
+`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const resources = JSON.parse(stdout.trim());
+  expect(resources).toEqual([]);
+  expect(exitCode).toBe(0);
+});
+
+test("process.getActiveResourcesInfo reports multiple timers", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const t1 = setTimeout(() => {}, 100000);
+const t2 = setTimeout(() => {}, 100000);
+const t3 = setTimeout(() => {}, 100000);
+const resources = process.getActiveResourcesInfo();
+console.log(JSON.stringify(resources));
+clearTimeout(t1);
+clearTimeout(t2);
+clearTimeout(t3);
+`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const resources = JSON.parse(stdout.trim());
+  const timeoutCount = resources.filter((r: string) => r === "Timeout").length;
+  expect(timeoutCount).toBe(3);
+  expect(exitCode).toBe(0);
+});
+
+test("process.getActiveResourcesInfo reports Immediate for setImmediate", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+setImmediate(() => {});
+const resources = process.getActiveResourcesInfo();
+console.log(JSON.stringify(resources));
+`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const resources = JSON.parse(stdout.trim());
+  expect(resources).toContain("Immediate");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Implements `process.getActiveResourcesInfo()` to return actual active resources instead of always returning `[]`
- Reports `"Timeout"` for each active `setTimeout`/`setInterval` timer (matching Node.js naming)
- Reports `"Immediate"` for each active `setImmediate` callback
- Reports `"TCPSocketWrap"` for other active poll handles (TCP, pipes, servers, etc.)
- Fixes Expo CLI hanging when running under Bun, because Expo uses this API to detect blocking resources and force-exit

Closes #24538

## How it works

The implementation adds a Zig function (`getActiveResourceCounts`) that reads the event loop's active resource counters:
- `vm.timer.active_timer_count` for ref'd setTimeout/setInterval timers
- `vm.timer.immediate_ref_count` for ref'd setImmediate callbacks
- `loop.active` minus the timer/immediate group refs for other active poll handles (TCP sockets, pipes, servers, etc.)

The C++ side (`Process_getActiveResourcesInfo`) calls this function and builds a JS array with the appropriate type strings.

## Test plan

- [x] New regression test `test/regression/issue/24538.test.ts` with 7 test cases
- [x] Verifies `getActiveResourcesInfo` returns `[]` when no resources active
- [x] Verifies `"Timeout"` is reported for setTimeout/setInterval
- [x] Verifies `"Immediate"` is reported for setImmediate
- [x] Verifies TCP server is detected as active resource
- [x] Verifies multiple timers produce multiple entries
- [x] Existing process tests pass
- [x] Test fails with `USE_SYSTEM_BUN=1` (old stub behavior)


🤖 Generated with [Claude Code](https://claude.com/claude-code)