### PR TITLE
fix(bundler): tree-shake per-entrypoint when multiple entrypoints share a module

### DIFF
--- a/src/bundler/LinkerGraph.zig
+++ b/src/bundler/LinkerGraph.zig
@@ -11,6 +11,13 @@ allocator: std.mem.Allocator,
 
 code_splitting: bool = false,
 
+/// Per-entry-point part liveness tracking for tree-shaking with multiple
+/// entry points. Indexed as [source_index][part_index], each AutoBitSet
+/// tracks which entry points make the part live. This enables per-entry-point
+/// tree-shaking so that shared modules only include exports actually used by
+/// each specific entry point's chunk.
+part_entry_bits: [][]AutoBitSet = &[_][]AutoBitSet{},
+
 // This is an alias from Graph
 // it is not a clone!
 ast: MultiArrayList(JSAst) = .{},

--- a/test/regression/issue/011476.test.ts
+++ b/test/regression/issue/011476.test.ts
@@ -1,0 +1,187 @@
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/11476
+// Tree-shaking with multiple entrypoints doesn't work properly.
+// When bundling multiple entrypoints that share a common module, the bundler
+// includes the union of all used exports from the shared module in every output
+// file, instead of only the exports actually used by each specific entrypoint.
+
+test("tree-shaking with multiple entrypoints only includes used exports per chunk", async () => {
+  using dir = tempDir("issue-11476", {
+    "package.ts": `
+export function entrypoint1Function() { console.log("entrypoint1Function called"); }
+export function entrypoint2Function() { console.log("entrypoint2Function called"); }
+export function unusedByBoth() { console.log("unusedByBoth called"); }
+`,
+    "entrypoint1.ts": `
+import { entrypoint1Function } from "./package";
+entrypoint1Function();
+`,
+    "entrypoint2.ts": `
+import { entrypoint2Function } from "./package";
+entrypoint2Function();
+`,
+  });
+
+  const result = await Bun.build({
+    entrypoints: [`${dir}/entrypoint1.ts`, `${dir}/entrypoint2.ts`],
+    outdir: `${dir}/dist`,
+  });
+
+  expect(result.success).toBe(true);
+  expect(result.outputs.length).toBe(2);
+
+  const output1 = await result.outputs[0].text();
+  const output2 = await result.outputs[1].text();
+
+  // entrypoint1 should only contain entrypoint1Function
+  expect(output1).toContain("entrypoint1Function");
+  expect(output1).not.toContain("entrypoint2Function");
+  expect(output1).not.toContain("unusedByBoth");
+
+  // entrypoint2 should only contain entrypoint2Function
+  expect(output2).toContain("entrypoint2Function");
+  expect(output2).not.toContain("entrypoint1Function");
+  expect(output2).not.toContain("unusedByBoth");
+});
+
+test("tree-shaking with multiple entrypoints and overlapping imports", async () => {
+  using dir = tempDir("issue-11476-overlap", {
+    "shared.ts": `
+export function sharedFunc() { console.log("shared"); }
+export function onlyInOne() { console.log("onlyInOne"); }
+export function onlyInTwo() { console.log("onlyInTwo"); }
+export function inBoth() { console.log("inBoth"); }
+export function unused() { console.log("unused"); }
+`,
+    "ep1.ts": `
+import { sharedFunc, onlyInOne, inBoth } from "./shared";
+sharedFunc();
+onlyInOne();
+inBoth();
+`,
+    "ep2.ts": `
+import { sharedFunc, onlyInTwo, inBoth } from "./shared";
+sharedFunc();
+onlyInTwo();
+inBoth();
+`,
+  });
+
+  const result = await Bun.build({
+    entrypoints: [`${dir}/ep1.ts`, `${dir}/ep2.ts`],
+    outdir: `${dir}/dist`,
+  });
+
+  expect(result.success).toBe(true);
+  expect(result.outputs.length).toBe(2);
+
+  const output1 = await result.outputs[0].text();
+  const output2 = await result.outputs[1].text();
+
+  // ep1 should have sharedFunc, onlyInOne, and inBoth but NOT onlyInTwo or unused
+  expect(output1).toContain("sharedFunc");
+  expect(output1).toContain("onlyInOne");
+  expect(output1).toContain("inBoth");
+  expect(output1).not.toContain("onlyInTwo");
+  expect(output1).not.toContain("unused");
+
+  // ep2 should have sharedFunc, onlyInTwo, and inBoth but NOT onlyInOne or unused
+  expect(output2).toContain("sharedFunc");
+  expect(output2).toContain("onlyInTwo");
+  expect(output2).toContain("inBoth");
+  expect(output2).not.toContain("onlyInOne");
+  expect(output2).not.toContain("unused");
+});
+
+test("tree-shaking with 3 entrypoints sharing a module", async () => {
+  using dir = tempDir("issue-11476-three", {
+    "shared.ts": `
+export function funcA() { console.log("A"); }
+export function funcB() { console.log("B"); }
+export function funcC() { console.log("C"); }
+export function unused() { console.log("unused"); }
+`,
+    "ep1.ts": `
+import { funcA } from "./shared";
+funcA();
+`,
+    "ep2.ts": `
+import { funcB } from "./shared";
+funcB();
+`,
+    "ep3.ts": `
+import { funcA, funcC } from "./shared";
+funcA();
+funcC();
+`,
+  });
+
+  const result = await Bun.build({
+    entrypoints: [`${dir}/ep1.ts`, `${dir}/ep2.ts`, `${dir}/ep3.ts`],
+    outdir: `${dir}/dist`,
+  });
+
+  expect(result.success).toBe(true);
+  expect(result.outputs.length).toBe(3);
+
+  const output1 = await result.outputs[0].text();
+  const output2 = await result.outputs[1].text();
+  const output3 = await result.outputs[2].text();
+
+  // ep1 should only have funcA
+  expect(output1).toContain("funcA");
+  expect(output1).not.toContain("funcB");
+  expect(output1).not.toContain("funcC");
+  expect(output1).not.toContain("unused");
+
+  // ep2 should only have funcB
+  expect(output2).toContain("funcB");
+  expect(output2).not.toContain("funcA");
+  expect(output2).not.toContain("funcC");
+  expect(output2).not.toContain("unused");
+
+  // ep3 should have funcA and funcC
+  expect(output3).toContain("funcA");
+  expect(output3).toContain("funcC");
+  expect(output3).not.toContain("funcB");
+  expect(output3).not.toContain("unused");
+});
+
+test("tree-shaking with multiple entrypoints and --minify", async () => {
+  using dir = tempDir("issue-11476-minify", {
+    "package.ts": `
+export function entrypoint1Function() { console.log("entrypoint1Function called"); }
+export function entrypoint2Function() { console.log("entrypoint2Function called"); }
+`,
+    "entrypoint1.ts": `
+import { entrypoint1Function } from "./package";
+entrypoint1Function();
+`,
+    "entrypoint2.ts": `
+import { entrypoint2Function } from "./package";
+entrypoint2Function();
+`,
+  });
+
+  const result = await Bun.build({
+    entrypoints: [`${dir}/entrypoint1.ts`, `${dir}/entrypoint2.ts`],
+    outdir: `${dir}/dist`,
+    minify: true,
+  });
+
+  expect(result.success).toBe(true);
+  expect(result.outputs.length).toBe(2);
+
+  const output1 = await result.outputs[0].text();
+  const output2 = await result.outputs[1].text();
+
+  // Even when minified, entrypoint1 should not contain entrypoint2's string
+  expect(output1).toContain("entrypoint1Function called");
+  expect(output1).not.toContain("entrypoint2Function called");
+
+  // And vice versa
+  expect(output2).toContain("entrypoint2Function called");
+  expect(output2).not.toContain("entrypoint1Function called");
+});


### PR DESCRIPTION
## Summary

- Fixes tree-shaking with multiple entrypoints so that shared modules only include exports actually used by each specific entrypoint's chunk, rather than the union of all exports used by any entrypoint
- Adds per-entry-point part liveness tracking (`part_entry_bits`) during the tree-shaking phase
- When only a single entrypoint is used, the behavior is unchanged (zero overhead)

## Root Cause

The tree-shaking phase tracked part liveness with a single global `is_live: bool` per part. When entry point A used `foo` and entry point B used `bar` from a shared module, both parts got `is_live = true`, causing both to appear in both output files.

**Before (bug):**
```
entrypoint1.js → includes entrypoint1Function AND entrypoint2Function
entrypoint2.js → includes entrypoint1Function AND entrypoint2Function
```

**After (fix):**
```
entrypoint1.js → includes only entrypoint1Function
entrypoint2.js → includes only entrypoint2Function
```

## Implementation

1. **`LinkerGraph.zig`**: Added `part_entry_bits: [][]AutoBitSet` field to track which entry points make each part live
2. **`LinkerContext.zig`**: 
   - Initialize `part_entry_bits` in `treeShakingAndCodeSplitting` (only when multiple entry points exist)
   - Modified `markFileLiveForTreeShaking` and `markPartLiveForTreeShaking` to accept and propagate `entry_point_id`, setting the corresponding bit in `part_entry_bits`
   - The early-return optimization now checks per-entry-point bits instead of just the global `is_live` flag
3. **`findAllImportedPartsInJSOrder.zig`**: Added `isPartLiveForChunk` helper that checks if a part is live for any entry point belonging to the current chunk, replacing the simple `part.is_live` check

## Test plan

- [x] New regression tests in `test/regression/issue/011476.test.ts` (4 test cases)
  - Basic 2-entrypoint tree-shaking
  - Overlapping imports (some exports shared, some unique)
  - 3-entrypoint tree-shaking
  - Tree-shaking with `--minify`
- [x] Tests fail with `USE_SYSTEM_BUN=1` (confirms they catch the bug)
- [x] Tests pass with `bun bd test` (confirms the fix works)
- [x] Existing bundler test suites pass:
  - `bundler_splitting.test.ts` (10 pass)
  - `bundler_compile_splitting.test.ts` (3 pass)
  - `bundler_promiseall_deadcode.test.ts` (3 pass)
  - `bun-build-api.test.ts` (35 pass)
  - `esbuild/dce.test.ts` (73 pass)
  - `esbuild/splitting.test.ts` (22 pass)
  - `esbuild/default.test.ts` (150 pass)

Closes #11476

🤖 Generated with [Claude Code](https://claude.com/claude-code)