### PR TITLE
fix(parser): emit SyntaxError for 'use strict' in functions with non-simple params

### DIFF
--- a/src/ast/parse.zig
+++ b/src/ast/parse.zig
@@ -1192,11 +1192,15 @@ pub fn Parse(
                                         isDirectivePrologue = true;
 
                                         if (str.eqlComptime("use strict")) {
-                                            skip = true;
                                             // Track "use strict" directives
                                             p.current_scope.strict_mode = .explicit_strict_mode;
                                             if (p.current_scope == p.module_scope)
                                                 p.module_scope_directive_loc = stmt.loc;
+                                            // Emit as .s_directive so fnBodyContainsUseStrict can
+                                            // find it and report errors for non-simple parameter lists
+                                            stmt = Stmt.alloc(S.Directive, S.Directive{
+                                                .value = str.slice(p.allocator),
+                                            }, stmt.loc);
                                         } else if (str.eqlComptime("use asm")) {
                                             skip = true;
                                             stmt.data = Prefill.Data.SEmpty;

--- a/test/regression/issue/18333.test.ts
+++ b/test/regression/issue/18333.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/18333
+// "use strict" in a function with non-simple parameters should be a SyntaxError
+// per ECMAScript spec Section 15.2.1.
+
+test("'use strict' in function with default parameter is a SyntaxError", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `function test(a = 5) { 'use strict'; }`],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("use strict");
+  expect(exitCode).not.toBe(0);
+});
+
+test("'use strict' in function with rest parameter is a SyntaxError", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `function test(...args) { 'use strict'; }`],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("use strict");
+  expect(exitCode).not.toBe(0);
+});
+
+test("'use strict' in function with destructuring parameter is a SyntaxError", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `function test({a, b}) { 'use strict'; }`],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("use strict");
+  expect(exitCode).not.toBe(0);
+});
+
+test("'use strict' in arrow function with default parameter is a SyntaxError", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `const test = (a = 1) => { 'use strict'; }`],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("use strict");
+  expect(exitCode).not.toBe(0);
+});
+
+test("'use strict' in function with array destructuring parameter is a SyntaxError", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `function test([a, b]) { 'use strict'; }`],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("use strict");
+  expect(exitCode).not.toBe(0);
+});
+
+test("'use strict' in function with simple parameters is allowed", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `function test(a, b) { 'use strict'; console.log('ok'); }`],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test("'use strict' in function with no parameters is allowed", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `function test() { 'use strict'; console.log('ok'); }`],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test("'use strict' in method with default parameter is a SyntaxError", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `({ test(a = 5) { 'use strict'; } })`],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("use strict");
+  expect(exitCode).not.toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fixes #18333: Bun was silently accepting `'use strict'` directives inside function bodies with non-simple parameters (default values, rest params, destructuring), which should be a `SyntaxError` per ECMAScript spec Section 15.2.1.
- The parser was consuming `'use strict'` and setting the strict mode flag, but skipping emission of the `.s_directive` AST node. This made `fnBodyContainsUseStrict()` always return `null`, rendering the existing validation check in `visitArgs` dead code.
- Now `'use strict'` is emitted as an `.s_directive` node (like all other directives) while still setting the scope's strict mode, allowing the existing spec compliance check to fire correctly.

## Test plan
- [x] Added regression test `test/regression/issue/18333.test.ts` with 8 test cases covering:
  - Default parameters, rest parameters, destructuring (object and array), arrow functions, methods
  - Positive cases: simple params and no params still work with `'use strict'`
- [x] Tests fail with `USE_SYSTEM_BUN=1` (6 of 8 fail) and pass with `bun bd test`
- [x] Existing parser tests pass (592 syntax tests, use-strict CJS preservation tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)