### PR TITLE
fix(parser): error on duplicate function declarations in strict mode block scopes

### DIFF
--- a/src/ast/Scope.zig
+++ b/src/ast/Scope.zig
@@ -137,7 +137,10 @@ pub fn canMergeSymbols(
     if (Symbol.isKindHoistedOrFunction(new) and
         Symbol.isKindHoistedOrFunction(existing) and
         (scope.kind == .entry or scope.kind == .function_body or scope.kind == .function_args or
-            (new == existing and Symbol.isKindHoisted(existing))))
+            (new == existing and Symbol.isKindHoisted(existing) and
+                // In strict mode, block-scoped function declarations behave like `let` bindings
+                // and duplicates are a SyntaxError (ES2015+ B.3.2.1, 14.1.2).
+                !(scope.strict_mode != .sloppy_mode and new == .hoisted_function))))
     {
         return .replace_with_new;
     }

--- a/test/regression/issue/14273.test.ts
+++ b/test/regression/issue/14273.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/14273
+// In strict mode, duplicate plain function declarations in a block scope
+// should be a SyntaxError (they behave like `let` bindings per ES2015+ spec).
+
+test("strict mode: duplicate function declarations in block scope is SyntaxError", async () => {
+  const cases = [
+    // Basic block scope
+    `"use strict"; { function f(){} function f(){} }`,
+    // Nested block
+    `"use strict"; { { function f(){} function f(){} } }`,
+    // Inside if
+    `"use strict"; if(true){ function f(){} function f(){} }`,
+    // Inside for
+    `"use strict"; for(;;){ function f(){} function f(){} break; }`,
+    // Inside switch case
+    `"use strict"; switch(1){ case 1: function f(){} function f(){} }`,
+    // Function body with "use strict"
+    `function outer(){ "use strict"; { function f(){} function f(){} } }`,
+  ];
+
+  for (const code of cases) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect({
+      code,
+      exitCode,
+      hasError: stderr.includes("has already been declared"),
+    }).toEqual({
+      code,
+      exitCode: 1,
+      hasError: true,
+    });
+  }
+}, 30_000);
+
+test("sloppy mode: duplicate function declarations in block scope is allowed", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `{ function f(){} function f(){} }`],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test("strict mode: duplicate async function declarations in block scope is SyntaxError", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `"use strict"; { async function f(){} async function f(){} }`],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toInclude("has already been declared");
+  expect(exitCode).toBe(1);
+});
+
+test("strict mode: duplicate generator function declarations in block scope is SyntaxError", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `"use strict"; { function* f(){} function* f(){} }`],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toInclude("has already been declared");
+  expect(exitCode).toBe(1);
+});
+
+test("strict mode: duplicate function declarations at top level is allowed", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `"use strict"; function f(){} function f(){}`],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test("strict mode: duplicate var declarations in block scope is allowed", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `"use strict"; { var x = 1; var x = 2; }`],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- In strict mode, block-scoped function declarations should behave like `let` bindings per the ECMAScript spec (B.3.2.1, 14.1.2), so duplicate plain `function` declarations in the same block scope must be a SyntaxError
- The parser's `canMergeSymbols` in `src/ast/Scope.zig` was incorrectly allowing two `hoisted_function` symbols to merge in block scopes under strict mode, because `isKindHoisted(.hoisted_function)` returned `true` without considering strict mode context
- Added a check so that in strict mode, duplicate `hoisted_function` symbols in non-top-level scopes (block, if, for, switch, nested blocks) are correctly rejected
- Sloppy mode behavior is preserved (duplicates allowed per Annex B), and top-level strict mode duplicates remain allowed

Closes #14273

## Test plan
- [x] New regression test `test/regression/issue/14273.test.ts` covering:
  - Duplicate plain function declarations in block scope under `"use strict"` (6 variants: block, nested block, if, for, switch, function body)
  - Sloppy mode allows duplicates (no regression)
  - `async function` and `function*` duplicates still caught (already worked)
  - Top-level strict mode duplicates still allowed (no regression)
  - Duplicate `var` in block scope still allowed (no regression)
- [x] `test/bundler/transpiler/preserve-use-strict-cjs.test.ts` passes
- [x] `test/bundler/transpiler/scope-mismatch-panic.test.ts` passes
- [x] `test/bundler/bundler_edgecase.test.ts` passes (99 pass, 13 todo)
- [x] `test/cli/run/syntax.test.ts` passes (592 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)