### PR TITLE
fix(transpiler): preserve non-ASCII chars in tagged template raw strings

### DIFF
--- a/src/bun.js/ModuleLoader.zig
+++ b/src/bun.js/ModuleLoader.zig
@@ -570,7 +570,7 @@ pub fn transpileSourceCode(
                 .allocator = null,
                 .source_code = brk: {
                     const written = printer.ctx.getWritten();
-                    const result = cache.output_code orelse bun.String.cloneLatin1(written);
+                    const result = cache.output_code orelse bun.String.cloneUTF8(written);
 
                     if (written.len > 1024 * 1024 * 2 or jsc_vm.smol) {
                         printer.ctx.buffer.deinit();

--- a/src/bun.js/RuntimeTranspilerStore.zig
+++ b/src/bun.js/RuntimeTranspilerStore.zig
@@ -577,7 +577,7 @@ pub const RuntimeTranspilerStore = struct {
             const source_code = brk: {
                 const written = printer.ctx.getWritten();
 
-                const result = cache.output_code orelse bun.String.cloneLatin1(written);
+                const result = cache.output_code orelse bun.String.cloneUTF8(written);
 
                 if (written.len > 1024 * 1024 * 2 or vm.smol) {
                     printer.ctx.buffer.deinit();

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -1963,62 +1963,10 @@ fn NewPrinter(
         }
 
         fn printRawTemplateLiteral(p: *Printer, bytes: []const u8) void {
-            if (comptime is_json or !ascii_only) {
-                p.print(bytes);
-                return;
-            }
-
-            // Translate any non-ASCII to unicode escape sequences
-            // Note that this does not correctly handle malformed template literal strings
-            // template literal strings can contain invalid unicode code points
-            // and pretty much anything else
-            //
-            // we use WTF-8 here, but that's still not good enough.
-            //
-            var ascii_start: usize = 0;
-            var is_ascii = false;
-            var iter = CodepointIterator.init(bytes);
-            var cursor = CodepointIterator.Cursor{};
-
-            while (iter.next(&cursor)) {
-                switch (cursor.c) {
-                    // unlike other versions, we only want to mutate > 0x7F
-                    0...last_ascii => {
-                        if (!is_ascii) {
-                            ascii_start = cursor.i;
-                            is_ascii = true;
-                        }
-                    },
-                    else => {
-                        if (is_ascii) {
-                            p.print(bytes[ascii_start..cursor.i]);
-                            is_ascii = false;
-                        }
-
-                        switch (cursor.c) {
-                            0...0xFFFF => {
-                                p.print([_]u8{
-                                    '\\',
-                                    'u',
-                                    hex_chars[cursor.c >> 12],
-                                    hex_chars[(cursor.c >> 8) & 15],
-                                    hex_chars[(cursor.c >> 4) & 15],
-                                    hex_chars[cursor.c & 15],
-                                });
-                            },
-                            else => {
-                                p.print("\\u{");
-                                p.fmt("{x}", .{cursor.c}) catch unreachable;
-                                p.print("}");
-                            },
-                        }
-                    },
-                }
-            }
-
-            if (is_ascii) {
-                p.print(bytes[ascii_start..]);
-            }
+            // Raw template literals must preserve the exact source text including
+            // non-ASCII characters. Escaping non-ASCII to \uXXXX would change the
+            // semantics of tagged template .raw strings (issue #15492).
+            p.print(bytes);
         }
 
         pub fn printExpr(p: *Printer, expr: Expr, level: Level, in_flags: ExprFlag.Set) void {

--- a/test/regression/issue/15492.test.ts
+++ b/test/regression/issue/15492.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/15492
+// Tagged template literal .raw strings should preserve non-ASCII Unicode
+// characters instead of escaping them to \uXXXX sequences.
+test("tagged template raw strings preserve non-ASCII characters", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `(function (s) {
+  console.log(JSON.stringify(s.raw[0]));
+  console.log(JSON.stringify(s[0]));
+})\`\uFEFFtest\`;
+
+console.log(JSON.stringify(\`\uFEFFtest\`));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const lines = stdout.trim().split("\n");
+  // All three should be identical: raw, cooked, and regular template
+  // The BOM character should be preserved as-is in raw strings, not escaped to \uFEFF
+  const expected = JSON.stringify("\uFEFFtest");
+  expect(lines[0]).toBe(expected); // raw
+  expect(lines[1]).toBe(expected); // cooked
+  expect(lines[2]).toBe(expected); // regular template
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fixed tagged template literal `.raw` strings incorrectly escaping non-ASCII Unicode characters (e.g., U+FEFF BOM) to `\uXXXX` sequences, which changed the semantics of the raw string
- The printer's `printRawTemplateLiteral()` now preserves raw UTF-8 source bytes instead of escaping non-ASCII characters
- Module loaders (`ModuleLoader.zig`, `RuntimeTranspilerStore.zig`) now use `cloneUTF8()` instead of `cloneLatin1()` so multi-byte UTF-8 characters in transpiler output are correctly decoded by JSC rather than being misinterpreted as individual Latin-1 bytes

For ASCII-only output (the common case with `ascii_only` mode), `cloneUTF8` falls back to the same Latin-1 code path, so there is no performance regression.

Closes #15492

## Test plan

- [x] Added regression test in `test/regression/issue/15492.test.ts` that verifies tagged template `.raw[0]` preserves actual BOM character
- [x] Test fails with `USE_SYSTEM_BUN=1` (reproduces the bug)
- [x] Test passes with `bun bd test` (fix works)
- [x] Template literal transpiler tests pass (108 pass, 0 fail)
- [x] Bundler edge case tests pass (99 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)