### PR TITLE
fix(transpiler): preserve emoji in tagged template literals

### DIFF
--- a/src/bun.js/ModuleLoader.zig
+++ b/src/bun.js/ModuleLoader.zig
@@ -387,7 +387,10 @@ pub fn transpileSourceCode(
                 const bytecode_slice = parse_result.already_bundled.bytecodeSlice();
                 return ResolvedSource{
                     .allocator = null,
-                    .source_code = bun.String.cloneLatin1(source.contents),
+                    .source_code = if (bun.strings.isAllASCII(source.contents))
+                        bun.String.cloneLatin1(source.contents)
+                    else
+                        bun.String.cloneUTF8(source.contents),
                     .specifier = input_specifier,
                     .source_url = input_specifier.createIfDifferent(path.text),
                     .already_bundled = true,
@@ -570,7 +573,10 @@ pub fn transpileSourceCode(
                 .allocator = null,
                 .source_code = brk: {
                     const written = printer.ctx.getWritten();
-                    const result = cache.output_code orelse bun.String.cloneLatin1(written);
+                    const result = cache.output_code orelse if (bun.strings.isAllASCII(written))
+                        bun.String.cloneLatin1(written)
+                    else
+                        bun.String.cloneUTF8(written);
 
                     if (written.len > 1024 * 1024 * 2 or jsc_vm.smol) {
                         printer.ctx.buffer.deinit();

--- a/test/regression/issue/16763.test.ts
+++ b/test/regression/issue/16763.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/16763
+// Tagged template literals with emoji (non-BMP Unicode) were being incorrectly
+// escaped to \u{...} sequences by the printer when ascii_only was true. This
+// corrupted the .raw property that tag functions receive, since the raw value
+// would contain the literal escape characters instead of the original emoji.
+test("tagged template literals preserve emoji after bundling", async () => {
+  using dir = tempDir("issue-16763", {
+    "index.ts": `
+import { $ } from "bun";
+const result = await $\`echo 👋\`.text();
+console.log(result.trim());
+`,
+  });
+
+  const result = await Bun.build({
+    entrypoints: [`${dir}/index.ts`],
+    outdir: `${dir}/dist`,
+    target: "bun",
+  });
+
+  expect(result.success).toBe(true);
+  expect(result.outputs.length).toBe(1);
+
+  const output = await result.outputs[0].text();
+  // The bundled output must NOT contain \u{1f44b} escape sequences
+  expect(output).not.toContain("\\u{1f44b}");
+  // It must contain the actual emoji character
+  expect(output).toContain("👋");
+
+  // Verify the bundled output runs correctly
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), `${dir}/dist/index.js`],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("👋");
+  expect(exitCode).toBe(0);
+});
+
+test("String.raw preserves emoji after bundling", async () => {
+  using dir = tempDir("issue-16763-string-raw", {
+    "index.ts": `console.log(String.raw\`👋🌍\`);`,
+  });
+
+  const result = await Bun.build({
+    entrypoints: [`${dir}/index.ts`],
+    outdir: `${dir}/dist`,
+    target: "bun",
+  });
+
+  expect(result.success).toBe(true);
+
+  const output = await result.outputs[0].text();
+  expect(output).toContain("👋🌍");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), `${dir}/dist/index.js`],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("👋🌍");
+  expect(exitCode).toBe(0);
+});
+
+test("tagged template with emoji and interpolation preserves raw values after bundling", async () => {
+  using dir = tempDir("issue-16763-interp", {
+    "index.ts": 'function tag(strings) {\n  return strings.raw.join("|");\n}\nconsole.log(tag`🐰${"x"}🌍`);\n',
+  });
+
+  const result = await Bun.build({
+    entrypoints: [`${dir}/index.ts`],
+    outdir: `${dir}/dist`,
+    target: "bun",
+  });
+
+  expect(result.success).toBe(true);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), `${dir}/dist/index.js`],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("🐰|🌍");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fixed the transpiler/printer escaping non-ASCII characters (emoji) in tagged template literals to `\u{...}` sequences, which corrupted the `.raw` property that tag functions receive
- Fixed the module loader to use UTF-8 encoding when transpiler output contains non-ASCII bytes, ensuring JSC correctly interprets multi-byte characters

Closes #16763

## Root Cause

The printer's `printRawTemplateLiteral` function was converting non-ASCII characters to `\u{...}` escape sequences when `ascii_only` was true (always the case for `--target=bun`). This is incorrect for tagged template literals because:

1. Tag functions (like `String.raw`, Bun's `$` shell) receive the source text via `strings.raw`
2. `\u{1f44b}` in source text means the raw value is the 9-character string `\u{1f44b}`, not the emoji `👋`
3. So escaping `👋` → `\u{1f44b}` changes the program's semantics

Additionally, the module loader was using `cloneLatin1` to create JSC strings from transpiler output, which treats each byte as a Latin-1 character. Multi-byte UTF-8 sequences (like emoji) would be misinterpreted.

## Changes

**`src/js_printer.zig`**: `printRawTemplateLiteral` now outputs raw bytes directly instead of escaping non-ASCII characters. This matches esbuild's behavior, which also prints tagged template raw content verbatim regardless of the `ascii_only` setting.

**`src/bun.js/ModuleLoader.zig`**: Both the transpiler output path and the already-bundled path now check if the output contains non-ASCII bytes. If so, `cloneUTF8` is used instead of `cloneLatin1`, ensuring JSC correctly decodes multi-byte UTF-8 sequences. For ASCII-only content (the common case), the fast `cloneLatin1` path is still used.

## Test plan

- [x] Added regression test `test/regression/issue/16763.test.ts` with 3 test cases:
  - Tagged template with emoji after bundling (`bun $\`echo 👋\``)
  - `String.raw` preserves emoji after bundling
  - Tagged template with emoji and interpolation
- [x] All 3 tests fail with system bun (`USE_SYSTEM_BUN=1`) and pass with debug build
- [x] Existing `template-literal.test.ts` still passes
- [x] All transpiler tests pass (351/351, excluding pre-existing JSX timeout issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)