### PR TITLE
fix(transpiler): don't inline const values into function bodies

### DIFF
--- a/test/regression/issue/12710.test.ts
+++ b/test/regression/issue/12710.test.ts
@@ -1,0 +1,147 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/12710
+// Const-inlining should not change the observable result of Function.prototype.toString()
+// by replacing variable references with literal values inside function bodies.
+
+test("const values are not inlined into function bodies (require + eval toString)", async () => {
+  using dir = tempDir("issue-12710", {
+    "entry.js": `
+const { log } = require("./helper");
+const hi = "hi";
+log(() => console.log(hi));
+`,
+    "helper.js": `
+export const log = (fun) => {
+  try {
+    eval("(" + fun.toString() + ")()");
+    console.log("NO_ERROR");
+  } catch (e) {
+    console.log(e.constructor.name + ": " + e.message);
+  }
+};
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The eval'd function should throw ReferenceError because `hi` is not
+  // defined in the eval scope. If const inlining replaced `hi` with `"hi"`,
+  // this would incorrectly print "hi" instead.
+  expect(stdout.trim()).toBe("ReferenceError: hi is not defined");
+  expect(exitCode).toBe(0);
+});
+
+test("const values are still inlined at the same scope level", async () => {
+  using dir = tempDir("issue-12710-same-scope", {
+    "entry.js": `
+const hi = "hi";
+console.log(hi);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("hi");
+  expect(exitCode).toBe(0);
+});
+
+test("const values declared inside function bodies are still inlined within that function", async () => {
+  using dir = tempDir("issue-12710-inner", {
+    "entry.js": `
+function foo() {
+  const x = "hello";
+  console.log(x);
+}
+foo();
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("hello");
+  expect(exitCode).toBe(0);
+});
+
+test("toString() preserves variable references in arrow functions", async () => {
+  using dir = tempDir("issue-12710-tostring", {
+    "entry.js": `
+const hi = "hi";
+const fn = () => console.log(hi);
+// The toString should contain the identifier 'hi', not the literal '"hi"'
+const str = fn.toString();
+console.log(str.includes("hi") ? "has_reference" : "no_reference");
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("has_reference");
+  expect(exitCode).toBe(0);
+});
+
+test("let variables are not inlined (unchanged behavior)", async () => {
+  using dir = tempDir("issue-12710-let", {
+    "entry.js": `
+const { log } = require("./helper");
+let hi = "hi";
+log(() => console.log(hi));
+`,
+    "helper.js": `
+export const log = (fun) => {
+  try {
+    eval("(" + fun.toString() + ")()");
+    console.log("NO_ERROR");
+  } catch (e) {
+    console.log(e.constructor.name + ": " + e.message);
+  }
+};
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("ReferenceError: hi is not defined");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fix const-inlining optimization replacing variable references with literal values inside function bodies, which changed the observable result of `Function.prototype.toString()`
- Only affects the runtime transpiler (non-bundler mode); bundler path is unchanged since users explicitly opt into minification there
- Add regression tests covering the original issue, same-scope inlining (still works), inner-function inlining (still works), toString() preservation, and let variables

## Root Cause

Bun's transpiler has a const-inlining optimization that replaces references to `const` variables with their literal values. The `const_values` map was global to the parser and did not respect function scope boundaries — so `const hi = "hi"; log(() => console.log(hi))` was transpiled to `log(() => console.log("hi"))`, changing what `Function.prototype.toString()` returns.

When the serialized function was `eval()`'d in another module, the inlined literal meant the eval succeeded when it should have thrown `ReferenceError`, since the original variable `hi` doesn't exist in the eval scope.

## Fix

Save and clear the `const_values` map when entering function/arrow bodies (in `visitFunc` and `e_arrow`), and restore it when leaving. This prevents outer-scope const values from being inlined into function bodies. Const values declared *inside* a function body are still inlined within that function.

The fix is gated on `!p.options.bundle` so the bundler path (where users explicitly opt into minification via `minifySyntax`) is unaffected.

## Test plan

- [x] `bun bd test test/regression/issue/12710.test.ts` — 5/5 pass
- [x] `USE_SYSTEM_BUN=1 bun test test/regression/issue/12710.test.ts` — 1 fail (confirms test catches the bug)
- [x] `bun bd test test/bundler/esbuild/default.test.ts` — 150 pass (was 149 before fix due to `ConstDeclRemovedIfReferencedBeforeAllUses`)
- [x] `bun bd test test/bundler/bundler_minify.test.ts` — 32 pass
- [x] `bun bd test test/bundler/bundler_string.test.ts` — 59 pass
- [x] `bun bd test test/bundler/esbuild/ts.test.ts` — 57 pass

Closes #12710

🤖 Generated with [Claude Code](https://claude.com/claude-code)