### PR TITLE
fix(test): show empty string keys in object diffs

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5138,7 +5138,7 @@ restart:
 
             RETURN_IF_EXCEPTION(scope, void());
             for (auto& property : properties) {
-                if (property.isEmpty() || property.isNull()) [[unlikely]]
+                if (property.isNull()) [[unlikely]]
                     continue;
 
                 // ignore constructor
@@ -5168,9 +5168,6 @@ restart:
                 visitedProperties.append(property);
 
                 ZigString key = toZigString(property.isSymbol() && !property.isPrivateName() ? property.impl() : property.string());
-
-                if (key.len == 0)
-                    continue;
 
                 JSC::JSValue propertyValue = jsUndefined();
 
@@ -5312,7 +5309,7 @@ extern "C" [[ZIG_EXPORT(nothrow)]] bool JSC__isBigIntInInt64Range(JSC::EncodedJS
     auto clientData = WebCore::clientData(vm);
 
     for (auto property : vector) {
-        if (property.isEmpty() || property.isNull()) [[unlikely]]
+        if (property.isNull()) [[unlikely]]
             continue;
 
         // ignore constructor

--- a/test/regression/issue/18028.test.ts
+++ b/test/regression/issue/18028.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/18028
+// Object diff in bun test should display empty string keys correctly.
+
+test("toStrictEqual diff shows empty string keys", () => {
+  expect({
+    val: { "": "value" },
+  }).toStrictEqual({
+    val: { "": "value" },
+  });
+});
+
+test("toEqual diff shows empty string keys", () => {
+  expect({ "": "hello" }).toEqual({ "": "hello" });
+});
+
+test("empty string key with various value types", () => {
+  expect({ "": 0 }).toEqual({ "": 0 });
+  expect({ "": null }).toEqual({ "": null });
+  expect({ "": "" }).toEqual({ "": "" });
+  expect({ "": false }).toEqual({ "": false });
+  expect({ "": undefined }).toEqual({ "": undefined });
+});
+
+test("empty string key mixed with other keys", () => {
+  expect({ foo: "bar", "": "value" }).toEqual({ foo: "bar", "": "value" });
+});
+
+test("toStrictEqual fails and shows diff with empty string key", async () => {
+  using dir = tempDir("issue-18028", {
+    "test.test.ts": `
+import { test, expect } from "bun:test";
+test("diff", () => {
+  expect({ val: {} }).toStrictEqual({ val: { "": "value" } });
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "test.test.ts"],
+    cwd: String(dir),
+    env: { ...bunEnv, FORCE_COLOR: "0" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  // The diff section should show non-zero changed lines
+  expect(stderr).toContain("- Expected  - 3");
+  expect(stderr).toContain("+ Received  + 1");
+  // The diff should include the empty string key
+  expect(stderr).toContain('"": "value"');
+  expect(exitCode).toBe(1);
+});
+
+test("console.log shows empty string keys", () => {
+  const result = Bun.spawnSync({
+    cmd: [bunExe(), "-e", 'console.log({ "": "value", foo: "bar" })'],
+    env: { ...bunEnv, NO_COLOR: "1" },
+  });
+
+  const stdout = result.stdout.toString();
+  expect(stdout).toContain('"": "value"');
+});


### PR DESCRIPTION
## Summary

- Fix `bun test` object diffs silently dropping properties with empty string keys (`""`)
- Fix `console.log` also dropping empty string keys when formatting objects
- `Identifier::isEmpty()` was returning `true` for both null identifiers and empty string identifiers, causing `forEachPropertyOrdered` and `forEachPropertyImpl` to skip `""` keys entirely

## Root Cause

In `src/bun.js/bindings/bindings.cpp`, two property iteration functions used `property.isEmpty()` to skip invalid identifiers. However, `WTF::String::isEmpty()` returns `true` for zero-length strings (like `""`), not just null strings. This meant legitimate empty string property keys were silently dropped during object formatting.

The fix replaces `property.isEmpty()` with `property.isNull()` to only skip null identifiers, and removes a redundant `key.len == 0` check.

## Test plan

- [x] Added regression test `test/regression/issue/18028.test.ts` with 6 test cases
- [x] Verified test passes with `bun bd test`
- [x] Verified subprocess diff test fails with `USE_SYSTEM_BUN=1` (unfixed bun)

Closes #18028

🤖 Generated with [Claude Code](https://claude.com/claude-code)