### PR TITLE
fix(transpiler): fold const enum members that reference const variables

### DIFF
--- a/src/ast/P.zig
+++ b/src/ast/P.zig
@@ -1119,7 +1119,7 @@ pub fn NewParser_(
         pub fn handleIdentifier(noalias p: *P, loc: logger.Loc, ident: E.Identifier, original_name: ?string, opts: IdentifierOpts) Expr {
             const ref = ident.ref;
 
-            if (p.options.features.inlining) {
+            if (p.options.features.inlining or p.should_fold_typescript_constant_expressions) {
                 if (p.const_values.get(ref)) |replacement| {
                     p.ignoreUsage(ref);
                     return replacement;

--- a/src/ast/visit.zig
+++ b/src/ast/visit.zig
@@ -797,6 +797,28 @@ pub fn Visit(
                 var preprocessed_enums: std.ArrayListUnmanaged([]Stmt) = .{};
                 defer preprocessed_enums.deinit(p.allocator);
                 if (p.scopes_in_order_for_enum.count() > 0) {
+                    // Pre-populate const_values for simple const declarations that
+                    // appear before enums. This allows const enum members to reference
+                    // const variables with constant initializers, matching TypeScript
+                    // behavior. Without this, the enum preprocessing (which runs before
+                    // the main statement visiting loop) would not see these values.
+                    for (stmts.items) |*stmt| {
+                        if (stmt.data == .s_local) {
+                            const local = stmt.data.s_local;
+                            if (local.kind == .k_const) {
+                                for (local.decls.slice()) |decl| {
+                                    if (decl.binding.data == .b_identifier) {
+                                        if (decl.value) |val| {
+                                            if (val.data.canBeConstValue()) {
+                                                p.const_values.put(p.allocator, decl.binding.data.b_identifier.ref, val) catch unreachable;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     var found: usize = 0;
                     for (stmts.items) |*stmt| {
                         if (stmt.data == .s_enum) {

--- a/test/regression/issue/19581.test.ts
+++ b/test/regression/issue/19581.test.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("const enum members can reference const variables with constant initializers", async () => {
+  using dir = tempDir("19581", {
+    "index.ts": `
+      const enum First {
+        A = 1,
+        B = 2,
+        C = 3,
+      }
+
+      const multiplier = 5;
+
+      const enum Second {
+        D = First.A * multiplier,
+        E = First.B * multiplier,
+        F = First.C * multiplier,
+      }
+
+      console.log(Second.D, Second.E, Second.F, Second.E + Second.F);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--no-bundle", String(dir) + "/index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The const enum values should be fully folded to numeric literals.
+  // Second.D = First.A * multiplier = 1 * 5 = 5
+  // Second.E = First.B * multiplier = 2 * 5 = 10
+  // Second.F = First.C * multiplier = 3 * 5 = 15
+  expect(stdout).toContain("5 /* D */");
+  expect(stdout).toContain("10 /* E */");
+  expect(stdout).toContain("15 /* F */");
+  // The multiplier variable should not appear in the enum output
+  expect(stdout).not.toContain("* multiplier");
+  expect(exitCode).toBe(0);
+});
+
+test("const enum with const variable folds completely with --minify", async () => {
+  using dir = tempDir("19581-minify", {
+    "index.ts": `
+      const enum First { A = 1, B = 2, C = 3 }
+      const multiplier = 5;
+      const enum Second {
+        D = First.A * multiplier,
+        E = First.B * multiplier,
+        F = First.C * multiplier,
+      }
+      console.log(Second.E + Second.F);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--minify", String(dir) + "/index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // With minification, 10 + 15 should fold to 25
+  expect(stdout.trim()).toBe("console.log(25);");
+  expect(exitCode).toBe(0);
+});
+
+test("const enum folding with simple const variable", async () => {
+  using dir = tempDir("19581-simple", {
+    "index.ts": `
+      const base = 10;
+      const enum MyEnum {
+        A = base,
+        B = base + 1,
+        C = base * 2,
+      }
+      console.log(MyEnum.A, MyEnum.B, MyEnum.C);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--no-bundle", String(dir) + "/index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("10 /* A */");
+  expect(stdout).toContain("11 /* B */");
+  expect(stdout).toContain("20 /* C */");
+  // The enum values should be folded, not left as "base" or "base + 1"
+  expect(stdout).not.toContain("= base");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fixes `const enum` members not being constant-folded when they reference `const` variables with constant initializers (e.g., `const x = 5`)
- Pre-populates `const_values` for simple const declarations before the enum preprocessing pass runs, in both the tree-shaking and non-tree-shaking code paths
- Also checks `should_fold_typescript_constant_expressions` in `handleIdentifier` so that `const_values` are used during enum folding even without the global `inlining` feature flag

Before: `const multiplier = 5; const enum E { A = 1 * multiplier }` → kept `multiplier` as a runtime reference
After: correctly folds to `const enum E { A = 5 }`, matching TypeScript behavior

Closes #19581

## Test plan

- [x] New regression tests in `test/regression/issue/19581.test.ts` that verify:
  - Enum members referencing const variables are folded in `--no-bundle` mode
  - Full folding works with `--minify` (e.g., `console.log(25)`)
  - Simple const variable references in enum values are folded
- [x] All tests fail with `USE_SYSTEM_BUN=1` (confirming the bug)
- [x] All tests pass with `bun bd test`
- [x] Existing `test/bundler/esbuild/ts.test.ts` tests pass (57/57)
- [x] Existing `test/bundler/esbuild/default.test.ts` tests pass (150/150)

🤖 Generated with [Claude Code](https://claude.com/claude-code)