### PR TITLE
fix(jsc): AsyncDisposableStack.use() with sync @@dispose fallback

### DIFF
--- a/test/regression/issue/024277.test.ts
+++ b/test/regression/issue/024277.test.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/24277
+// AsyncDisposableStack.use() should accept objects with only @@dispose (sync),
+// falling back from @@asyncDispose per the TC39 spec.
+
+test("AsyncDisposableStack.use() with sync @@dispose falls back correctly", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      await using scope = new AsyncDisposableStack();
+
+      scope.use({
+        async [Symbol.asyncDispose]() {
+          console.log("async dispose");
+        },
+      });
+
+      scope.use({
+        [Symbol.dispose]() {
+          console.log("sync dispose");
+        },
+      });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  // Resources are disposed in LIFO order (stack)
+  expect(stdout).toBe("sync dispose\nasync dispose\n");
+  expect(exitCode).toBe(0);
+});
+
+test("await using with sync @@dispose falls back correctly", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      async function main() {
+        const log = [];
+        {
+          await using a = {
+            async [Symbol.asyncDispose]() {
+              log.push("async");
+            },
+          };
+          await using b = {
+            [Symbol.dispose]() {
+              log.push("sync");
+            },
+          };
+        }
+        console.log(log.join(","));
+      }
+      await main();
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  // LIFO order: b disposed first (sync), then a (async)
+  expect(stdout).toBe("sync,async\n");
+  expect(exitCode).toBe(0);
+});
+
+test("AsyncDisposableStack.use() throws when neither @@asyncDispose nor @@dispose is present", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      try {
+        await using scope = new AsyncDisposableStack();
+        scope.use({});
+        console.log("ERROR: should have thrown");
+      } catch (e) {
+        console.log("caught: " + (e instanceof TypeError));
+      }
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("caught: true\n");
+  expect(exitCode).toBe(0);
+});
+
+test("AsyncDisposableStack.use() with @@asyncDispose still works", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      await using scope = new AsyncDisposableStack();
+      scope.use({
+        async [Symbol.asyncDispose]() {
+          console.log("async only");
+        },
+      });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("async only\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

Fixes #24277

- Add regression test for `AsyncDisposableStack.prototype.use()` throwing `TypeError: @@asyncDispose must be callable` when passed an object with only `Symbol.dispose` (not `Symbol.asyncDispose`)
- The actual fix is in the WebKit/JSC fork: oven-sh/WebKit#162

### Root cause

The `getAsyncDisposableMethod` JSC builtin function had two bugs:
1. It checked `!isCallable(method)` **before** `isUndefinedOrNull(method)`, causing a TypeError when `@@asyncDispose` was `undefined` instead of falling through to the undefined check
2. It was missing the **fallback to `@@dispose`** entirely — per the TC39 spec (`GetDisposeMethod` with hint `async-dispose`), if `@@asyncDispose` is not present, the runtime should fall back to `@@dispose` and wrap it in a Promise adapter

Additionally, `AsyncDisposableStackPrototype.use()` was using `@getDisposableStackInternalField` (sync) instead of `@getAsyncDisposableStackInternalField` (async).

### What this PR adds

A regression test that validates:
- `AsyncDisposableStack.use()` with sync `@@dispose` falls back correctly  
- `await using` with sync `@@dispose` works correctly
- Objects with neither `@@asyncDispose` nor `@@dispose` still throw TypeError
- Objects with `@@asyncDispose` continue to work as before

### WebKit dependency

This PR depends on the WebKit fix in oven-sh/WebKit#162 being merged and a new WebKit release being created with the updated commit hash in `cmake/tools/SetupWebKit.cmake`.

## Test plan

- [x] Test fails with system bun (confirms the bug exists)
- [x] Test passes with debug build using patched local WebKit (`WEBKIT_LOCAL=ON`)
- [x] Original reproduction case from issue works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)