### PR TITLE
fix(transpiler): treat eval sources as ESM to prevent "use strict" from triggering CJS heuristic

### DIFF
--- a/src/bun.js/ModuleLoader.zig
+++ b/src/bun.js/ModuleLoader.zig
@@ -934,6 +934,9 @@ pub export fn Bun__transpileFile(
     }
 
     const module_type: options.ModuleType = brk: {
+        // Eval sources (-e flag) are always ESM
+        if (jsc_vm.module_loader.eval_source != null)
+            break :brk .esm;
         const ext = lr.path.name.ext;
         // regular expression /.[cm][jt]s$/
         if (ext.len == ".cjs".len) {

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1562,7 +1562,12 @@ pub fn fetchWithoutOnLoadPlugins(
     const lr = options.getLoaderAndVirtualSource(specifier_clone.slice(), jsc_vm, &virtual_source_to_use, &blob_to_deinit, null) catch {
         return error.ModuleNotFound;
     };
-    const module_type: options.ModuleType = if (lr.package_json) |pkg| pkg.module_type else .unknown;
+    const module_type: options.ModuleType = if (jsc_vm.module_loader.eval_source != null)
+        .esm
+    else if (lr.package_json) |pkg|
+        pkg.module_type
+    else
+        .unknown;
 
     // .print_source, which is used by exceptions avoids duplicating the entire source code
     // but that means we have to be careful of the lifetime of the source code

--- a/test/regression/issue/012655.test.ts
+++ b/test/regression/issue/012655.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/12655
+// "use strict" in -e eval mode should not cause the code to be treated as
+// sloppy-mode CommonJS. Eval sources are always ESM (strict mode).
+
+test('eval with "use strict" should still be strict mode', async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", '"use strict"; let body = 1; body["test"] = "test"; console.log(body);'],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("");
+  expect(stderr).toContain("TypeError");
+  expect(exitCode).not.toBe(0);
+});
+
+test("eval without use strict should be strict mode (ESM)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", 'let body = 1; body["test"] = "test"; console.log(body);'],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("");
+  expect(stderr).toContain("TypeError");
+  expect(exitCode).not.toBe(0);
+});
+
+test("eval with use strict still runs valid code correctly", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", '"use strict"; console.log(1 + 2);'],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("3\n");
+  expect(exitCode).toBe(0);
+});
+
+test("all primitive types throw TypeError on property assignment in eval", async () => {
+  const code = `
+    const primitives = [1, "hello", true, Symbol("x"), 42n];
+    for (const p of primitives) {
+      try { p.x = 1; console.log("BUG: " + typeof p); } catch(e) { console.log("OK: " + typeof p); }
+    }
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("OK: number\nOK: string\nOK: boolean\nOK: symbol\nOK: bigint\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fixes `bun -e '"use strict"; ...'` incorrectly running in sloppy mode instead of strict mode
- The parser's module type heuristic treated `"use strict"` as a signal for CommonJS (since it's redundant in ESM), but eval sources should always be ESM
- Sets `module_type = .esm` for eval sources in both `Bun__transpileFile` (synchronous path) and `fetchWithoutOnLoadPlugins` (asynchronous path)

Closes #12655

## Test plan

- [x] `bun -e '"use strict"; let body = 1; body["test"] = "test";'` now correctly throws TypeError (strict mode)
- [x] `bun -e 'let body = 1; body["test"] = "test";'` still correctly throws TypeError (ESM is strict)
- [x] `.cjs` files without `"use strict"` still silently ignore primitive property assignment (sloppy mode)
- [x] `.cjs` files with `"use strict"` still throw TypeError (strict mode)
- [x] All primitive types (number, string, boolean, symbol, bigint) throw correctly
- [x] Existing eval tests pass (`test/cli/run/run-eval.test.ts` - 29 tests)
- [x] Existing `"use strict"` CJS transpiler tests pass
- [x] Regression test fails with system bun, passes with fixed build

🤖 Generated with [Claude Code](https://claude.com/claude-code)