### PR TITLE
fix(windows): prevent use-after-free in pipe writer close with pending writes

### DIFF
--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -760,7 +760,7 @@ pub const WindowsBufferedReader = struct {
                 return Type.onReaderError(@as(*Type, @ptrCast(@alignCast(this))), err);
             }
             fn loop(this: *anyopaque) *Async.Loop {
-                return Type.loop(@as(*Type, @alignCast(@ptrCast(this))));
+                return Type.loop(@as(*Type, @ptrCast(@alignCast(this))));
             }
         };
         return .{
@@ -955,14 +955,14 @@ pub const WindowsBufferedReader = struct {
     }
 
     fn onStreamAlloc(handle: *uv.Handle, suggested_size: usize, buf: *uv.uv_buf_t) callconv(.c) void {
-        var this = bun.cast(*WindowsBufferedReader, handle.data);
+        const this: *WindowsBufferedReader = @ptrCast(@alignCast(handle.data orelse return));
         const result = this.getReadBufferWithStableMemoryAddress(suggested_size);
         buf.* = uv.uv_buf_t.init(result);
     }
 
     fn onStreamRead(handle: *uv.uv_handle_t, nread: uv.ReturnCodeI64, buf: *const uv.uv_buf_t) callconv(.c) void {
         const stream = bun.cast(*uv.uv_stream_t, handle);
-        var this = bun.cast(*WindowsBufferedReader, stream.data);
+        const this: *WindowsBufferedReader = @ptrCast(@alignCast(stream.data orelse return));
 
         const nread_int = nread.int();
 
@@ -1199,13 +1199,15 @@ pub const WindowsBufferedReader = struct {
     }
 
     fn onPipeClose(handle: *uv.Pipe) callconv(.c) void {
-        const this = bun.cast(*uv.Pipe, handle.data);
-        bun.default_allocator.destroy(this);
+        // Use the handle directly for destroy, not handle.data which may be null
+        // during cleanup races.
+        bun.default_allocator.destroy(handle);
     }
 
     fn onTTYClose(handle: *uv.uv_tty_t) callconv(.c) void {
-        const this = bun.cast(*uv.uv_tty_t, handle.data);
-        bun.default_allocator.destroy(this);
+        // Use the handle directly for destroy, not handle.data which may be null
+        // during cleanup races.
+        bun.default_allocator.destroy(handle);
     }
 
     pub fn onRead(this: *WindowsBufferedReader, amount: bun.sys.Maybe(usize), slice: []u8, hasMore: ReadState) void {

--- a/test/regression/issue/27138.test.ts
+++ b/test/regression/issue/27138.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/27138
+// "switch on corrupt value" panic on Windows during long-running sessions
+// with heavy spawn usage. Root cause: use-after-free when pipe writer's
+// close() was called while an async write was still in-flight, causing
+// onCloseSource() to fire synchronously and free resources that the
+// pending write callback would later access.
+
+test("rapid spawn/close cycles should not crash", async () => {
+  // Spawn many short-lived processes that write to stdin and immediately
+  // close. This exercises the close-while-write-pending path.
+  const iterations = 50;
+  const promises: Promise<void>[] = [];
+
+  for (let i = 0; i < iterations; i++) {
+    promises.push(
+      (async () => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", "process.stdin.resume(); setTimeout(() => process.exit(0), 10)"],
+          env: bunEnv,
+          stdin: "pipe",
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+
+        // Write data to stdin, then immediately close.
+        // This creates the race condition where close() is called
+        // while the write may still be in-flight.
+        try {
+          proc.stdin.write("hello world\n".repeat(100));
+        } catch {
+          // Write may fail if process exits first - that's fine
+        }
+        proc.stdin.end();
+
+        await proc.exited;
+      })(),
+    );
+  }
+
+  await Promise.all(promises);
+  // If we get here without crashing, the test passes.
+  expect(true).toBe(true);
+});
+
+test("concurrent spawn with stdout/stderr reading should not corrupt memory", async () => {
+  // Spawn processes that produce output and read from them concurrently.
+  // This exercises the pipe reader close path.
+  const iterations = 30;
+  const promises: Promise<void>[] = [];
+
+  for (let i = 0; i < iterations; i++) {
+    promises.push(
+      (async () => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", `console.log("x".repeat(1024)); console.error("y".repeat(1024));`],
+          env: bunEnv,
+          stdin: "ignore",
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        expect(stdout.length).toBeGreaterThan(0);
+        expect(stderr.length).toBeGreaterThan(0);
+        expect(exitCode).toBe(0);
+      })(),
+    );
+  }
+
+  await Promise.all(promises);
+});


### PR DESCRIPTION
## Summary

- Fix use-after-free crash on Windows when `close()` is called on a pipe writer while an async write (`uv_write`/`uv_fs_write`) is still in-flight
- Add null-safety guards in PipeReader stream callbacks to prevent panics during handle cleanup races
- Use handle parameter directly in pipe/tty close callbacks instead of potentially stale `handle.data`

This addresses the "switch on corrupt value" panic reported in long-running Windows sessions (like Claude Code) with heavy spawn usage. The root cause: `BaseWindowsPipeWriter.close()` called `onCloseSource()` synchronously even when an async write was pending. The parent's close handler could then free the writer's `StreamBuffer` memory, and when the pending write callback later fired, it accessed freed memory causing corruption.

### Changes

**PipeWriter.zig:**
- `BaseWindowsPipeWriter.close()`: Check `hasPendingAsyncWrite()` before calling `onCloseSource()`. When a write is in-flight, defer the notification to the write-complete callback.
- `WindowsBufferedWriter`: Add `hasPendingAsyncWrite()` method and `source == null` early-return in `onWriteComplete`/`onFsWriteComplete` to complete deferred `onCloseSource()`.
- `WindowsStreamingWriter`: Add `hasPendingAsyncWrite()` method and `source == null` early-return in `onWriteComplete`/`onFsWriteComplete`.
- `onPipeClose`/`onTTYClose`: Use handle parameter directly for `destroy()` instead of casting through `handle.data`.

**PipeReader.zig:**
- `onStreamAlloc`/`onStreamRead`: Add null guards for `handle.data`/`stream.data` to safely return when data pointer is null during cleanup.
- `onPipeClose`/`onTTYClose`: Use handle parameter directly for `destroy()`.

Fixes #27138

## Test plan

- [x] New regression test `test/regression/issue/27138.test.ts` - rapid spawn/close cycles and concurrent stdout/stderr reading
- [x] Existing spawn stdin tests pass
- [x] Existing spawn stdout tests pass
- [x] Existing child_process pipe tests pass
- [ ] Windows CI validation (the bug is Windows-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)