### PR TITLE
fix(parser): reject optional chaining in assignment targets

### DIFF
--- a/src/ast/parseSuffix.zig
+++ b/src/ast/parseSuffix.zig
@@ -944,6 +944,5 @@ const T = js_lexer.T;
 const js_parser = bun.js_parser;
 const DeferredErrors = js_parser.DeferredErrors;
 const JSXTransformType = js_parser.JSXTransformType;
-const SideEffects = js_parser.SideEffects;
 const TypeScript = js_parser.TypeScript;
 const options = js_parser.options;

--- a/src/ast/parseSuffix.zig
+++ b/src/ast/parseSuffix.zig
@@ -97,15 +97,7 @@ pub fn ParseSuffix(
         }
         fn t_question_dot(p: *P, level: Level, optional_chain: *?OptionalChain, left: *Expr) anyerror!Continuation {
             try p.lexer.next();
-            var optional_start: ?OptionalChain = OptionalChain.start;
-
-            // Remove unnecessary optional chains
-            if (p.options.features.minify_syntax) {
-                const result = SideEffects.toNullOrUndefined(p, left.data);
-                if (result.ok and !result.value) {
-                    optional_start = null;
-                }
-            }
+            const optional_start: ?OptionalChain = OptionalChain.start;
 
             switch (p.lexer.token) {
                 .t_open_bracket => {

--- a/src/ast/visitExpr.zig
+++ b/src/ast/visitExpr.zig
@@ -550,6 +550,27 @@ pub fn VisitExpr(
                 });
                 e_.target = target_visited;
 
+                // Remove unnecessary optional chains
+                if (p.options.features.minify_syntax) {
+                    if (e_.optional_chain == .start) {
+                        const result = SideEffects.toNullOrUndefined(p, e_.target.data);
+                        if (result.ok and !result.value) {
+                            e_.optional_chain = null;
+                        }
+                    } else if (e_.optional_chain == .continuation) {
+                        // Strip orphaned continuations whose target's chain was already removed
+                        const target_chain = switch (e_.target.data) {
+                            .e_dot => |dot| dot.optional_chain,
+                            .e_index => |idx| idx.optional_chain,
+                            .e_call => |call| call.optional_chain,
+                            else => null,
+                        };
+                        if (target_chain == null) {
+                            e_.optional_chain = null;
+                        }
+                    }
+                }
+
                 switch (e_.index.data) {
                     .e_private_identifier => |_private| {
                         var private = _private;
@@ -877,6 +898,27 @@ pub fn VisitExpr(
                     .property_access_for_method_call_maybe_should_replace_with_undefined = in.property_access_for_method_call_maybe_should_replace_with_undefined,
                 });
 
+                // Remove unnecessary optional chains
+                if (p.options.features.minify_syntax) {
+                    if (e_.optional_chain == .start) {
+                        const result = SideEffects.toNullOrUndefined(p, e_.target.data);
+                        if (result.ok and !result.value) {
+                            e_.optional_chain = null;
+                        }
+                    } else if (e_.optional_chain == .continuation) {
+                        // Strip orphaned continuations whose target's chain was already removed
+                        const target_chain = switch (e_.target.data) {
+                            .e_dot => |dot| dot.optional_chain,
+                            .e_index => |idx| idx.optional_chain,
+                            .e_call => |call| call.optional_chain,
+                            else => null,
+                        };
+                        if (target_chain == null) {
+                            e_.optional_chain = null;
+                        }
+                    }
+                }
+
                 // 'require.resolve' -> .e_require_resolve_call_target
                 if (e_.target.data == .e_require_call_target and
                     strings.eqlComptime(e_.name, "resolve"))
@@ -1197,6 +1239,27 @@ pub fn VisitExpr(
                     .has_chain_parent = e_.optional_chain == .continuation,
                     .property_access_for_method_call_maybe_should_replace_with_undefined = true,
                 });
+
+                // Remove unnecessary optional chains
+                if (p.options.features.minify_syntax) {
+                    if (e_.optional_chain == .start) {
+                        const result = SideEffects.toNullOrUndefined(p, e_.target.data);
+                        if (result.ok and !result.value) {
+                            e_.optional_chain = null;
+                        }
+                    } else if (e_.optional_chain == .continuation) {
+                        // Strip orphaned continuations whose target's chain was already removed
+                        const target_chain = switch (e_.target.data) {
+                            .e_dot => |dot| dot.optional_chain,
+                            .e_index => |idx| idx.optional_chain,
+                            .e_call => |call| call.optional_chain,
+                            else => null,
+                        };
+                        if (target_chain == null) {
+                            e_.optional_chain = null;
+                        }
+                    }
+                }
 
                 // Copy the call side effect flag over if this is a known target
                 switch (e_.target.data) {

--- a/test/regression/issue/15848.test.ts
+++ b/test/regression/issue/15848.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/15848
+// Optional chaining in assignment target should be a SyntaxError
+
+test("optional chaining dot access in for-of assignment target", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `for ([{set y(val){console.log("accessed")}}?.y = 0] of [[]]);`],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("Invalid assignment target");
+  expect(stdout).not.toContain("accessed");
+  expect(exitCode).not.toBe(0);
+});
+
+test("optional chaining bracket access in assignment", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `({})?.["x"] = 1`],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("Invalid assignment target");
+  expect(exitCode).not.toBe(0);
+});
+
+test("array literal optional chaining in assignment", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `[1]?.x = 0`],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("Invalid assignment target");
+  expect(exitCode).not.toBe(0);
+});
+
+test("class expression optional chaining in assignment", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `(class {})?.x = 0`],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("Invalid assignment target");
+  expect(exitCode).not.toBe(0);
+});
+
+test("function expression optional chaining in assignment", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `(function(){})?.x = 0`],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("Invalid assignment target");
+  expect(exitCode).not.toBe(0);
+});
+
+test("valid optional chaining is not affected", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const obj = { a: { b: 1 } };
+      console.log(obj?.a?.b);
+      console.log({}?.x);
+      console.log([1]?.length);
+    `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("1");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fixes a bug where `{}?.y = 0` and similar expressions with optional chaining on the left-hand side of an assignment were silently accepted instead of throwing a SyntaxError
- The parser's `minify_syntax` optimization was stripping the optional chain (`?.` → `.`) during parsing, before the visitor's `isValidAssignmentTarget` check could see it
- Moved the optional chain removal optimization from the parse phase (`parseSuffix.zig`) to the visit phase (`visitExpr.zig`), so the assignment target check runs first

## Test plan
- [x] Added regression test `test/regression/issue/15848.test.ts` covering all affected patterns
- [x] Verified test fails with `USE_SYSTEM_BUN=1` (confirms the bug exists in released Bun)
- [x] Verified test passes with `bun bd test` (confirms the fix works)
- [x] Verified valid optional chaining (`obj?.a?.b`, `{}?.x`, `[1]?.length`) is unaffected
- [x] Verified the minification optimization still works for non-assignment targets (`{}?.x` → `{}.x`)
- [x] All existing transpiler tests pass (108 pass, 0 fail)

Closes #15848

🤖 Generated with [Claude Code](https://claude.com/claude-code)