### PR TITLE
fix(domain): return values from bind(), intercept(), and run()

### DIFF
--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -37,7 +37,7 @@ domain.createDomain = domain.create = function () {
     return function () {
       var args = Array.prototype.slice.$call(arguments);
       try {
-        fn.$apply(null, args);
+        return fn.$apply(null, args);
       } catch (err) {
         emitError(err);
       }
@@ -50,7 +50,7 @@ domain.createDomain = domain.create = function () {
       } else {
         var args = Array.prototype.slice.$call(arguments, 1);
         try {
-          fn.$apply(null, args);
+          return fn.$apply(null, args);
         } catch (err) {
           emitError(err);
         }
@@ -59,11 +59,10 @@ domain.createDomain = domain.create = function () {
   };
   d.run = function (fn) {
     try {
-      fn();
+      return fn();
     } catch (err) {
       emitError(err);
     }
-    return this;
   };
   d.dispose = function () {
     this.removeAllListeners();

--- a/test/regression/issue/24287.test.ts
+++ b/test/regression/issue/24287.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "bun:test";
 
+const domain = require("domain");
+
 test("domain.bind() returns the original function's return value", () => {
-  const domain = require("domain");
   const d = domain.create();
 
   const bound = d.bind(() => 42);
@@ -9,7 +10,6 @@ test("domain.bind() returns the original function's return value", () => {
 });
 
 test("domain.bind() returns the original async function's promise", async () => {
-  const domain = require("domain");
   const d = domain.create();
 
   const bound = d.bind(async () => "hello");
@@ -19,7 +19,6 @@ test("domain.bind() returns the original async function's promise", async () => 
 });
 
 test("domain.intercept() returns the original function's return value", () => {
-  const domain = require("domain");
   const d = domain.create();
 
   const intercepted = d.intercept((...args: any[]) => args.join(","));
@@ -27,7 +26,6 @@ test("domain.intercept() returns the original function's return value", () => {
 });
 
 test("domain.intercept() returns the original async function's promise", async () => {
-  const domain = require("domain");
   const d = domain.create();
 
   const intercepted = d.intercept(async () => "world");
@@ -37,7 +35,6 @@ test("domain.intercept() returns the original async function's promise", async (
 });
 
 test("domain.run() returns the function's return value", () => {
-  const domain = require("domain");
   const d = domain.create();
 
   const result = d.run(() => 99);
@@ -45,7 +42,6 @@ test("domain.run() returns the function's return value", () => {
 });
 
 test("domain.run() returns the async function's promise", async () => {
-  const domain = require("domain");
   const d = domain.create();
 
   const result = d.run(async () => "done");

--- a/test/regression/issue/24287.test.ts
+++ b/test/regression/issue/24287.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+
+test("domain.bind() returns the original function's return value", () => {
+  const domain = require("domain");
+  const d = domain.create();
+
+  const bound = d.bind(() => 42);
+  expect(bound()).toBe(42);
+});
+
+test("domain.bind() returns the original async function's promise", async () => {
+  const domain = require("domain");
+  const d = domain.create();
+
+  const bound = d.bind(async () => "hello");
+  const result = bound();
+  expect(result).toBeInstanceOf(Promise);
+  expect(await result).toBe("hello");
+});
+
+test("domain.intercept() returns the original function's return value", () => {
+  const domain = require("domain");
+  const d = domain.create();
+
+  const intercepted = d.intercept((...args: any[]) => args.join(","));
+  expect(intercepted(null, "a", "b")).toBe("a,b");
+});
+
+test("domain.intercept() returns the original async function's promise", async () => {
+  const domain = require("domain");
+  const d = domain.create();
+
+  const intercepted = d.intercept(async () => "world");
+  const result = intercepted(null);
+  expect(result).toBeInstanceOf(Promise);
+  expect(await result).toBe("world");
+});
+
+test("domain.run() returns the function's return value", () => {
+  const domain = require("domain");
+  const d = domain.create();
+
+  const result = d.run(() => 99);
+  expect(result).toBe(99);
+});
+
+test("domain.run() returns the async function's promise", async () => {
+  const domain = require("domain");
+  const d = domain.create();
+
+  const result = d.run(async () => "done");
+  expect(result).toBeInstanceOf(Promise);
+  expect(await result).toBe("done");
+});


### PR DESCRIPTION
## Summary

- Fix `domain.bind()` to return the wrapped function's return value (was returning `undefined`)
- Fix `domain.intercept()` to return the wrapped function's return value (was returning `undefined`)
- Fix `domain.run()` to return the function's return value (was returning `this`)

## Root Cause

In `src/js/node/domain.ts`, three methods were missing `return` statements for the inner function calls. This caused all bound/intercepted/run functions to lose their return values.

This broke gulp 4.x async tasks under Bun, since gulp's `async-done` dependency uses `domain.bind(fn)` and checks the return value to detect promises. Because `bind()` swallowed the return value, async task completion was never detected, producing: *"The following tasks did not complete: ... Did you forget to signal async completion?"*

## Test plan

- [x] Regression test added (`test/regression/issue/24287.test.ts`)
- [x] Test fails with system bun (6/6 fail)
- [x] Test passes with debug build (6/6 pass)
- [ ] Verify gulp 4.x async tasks work correctly (e.g. axios build: `bun run --bun build`)

Closes #24287

🤖 Generated with [Claude Code](https://claude.com/claude-code)