### PR TITLE
fix(bundler): emit valid JS for unused dynamic imports

### DIFF
--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -1708,13 +1708,19 @@ fn NewPrinter(
                 }
 
                 // Internal "require()" or "import()"
+                const has_side_effects = meta.wrapper_ref.isValid() or
+                    meta.exports_ref.isValid() or
+                    meta.was_unwrapped_require or
+                    p.options.input_files_for_dev_server != null;
                 if (record.kind == .dynamic) {
                     p.printSpaceBeforeIdentifier();
                     p.print("Promise.resolve()");
 
-                    level = p.printDotThenPrefix();
+                    if (has_side_effects) {
+                        level = p.printDotThenPrefix();
+                    }
                 }
-                defer if (record.kind == .dynamic) p.printDotThenSuffix();
+                defer if (record.kind == .dynamic and has_side_effects) p.printDotThenSuffix();
 
                 // Make sure the comma operator is properly wrapped
                 const wrap_comma_operator = meta.exports_ref.isValid() and

--- a/test/regression/issue/24709.test.ts
+++ b/test/regression/issue/24709.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+
+test("bun build produces valid JS for unused dynamic imports", async () => {
+  using dir = tempDir("issue-24709", {
+    "void-import.ts": `
+export function main() {
+    void import("./dep.ts");
+}
+`,
+    "bare-import.ts": `
+export function main() {
+    import("./dep.ts");
+}
+`,
+    "dep.ts": `export const x = 1;`,
+  });
+
+  const transpiler = new Bun.Transpiler();
+
+  // Test void import("...")
+  {
+    const result = await Bun.build({
+      entrypoints: [`${dir}/void-import.ts`],
+    });
+
+    expect(result.success).toBe(true);
+    const output = await result.outputs[0].text();
+
+    // The output must not contain an empty arrow function body like "() => )"
+    expect(output).not.toContain("() => )");
+
+    // Validate the output is syntactically valid JS by scanning it
+    expect(() => transpiler.scanImports(output)).not.toThrow();
+  }
+
+  // Test bare import("...")
+  {
+    const result = await Bun.build({
+      entrypoints: [`${dir}/bare-import.ts`],
+    });
+
+    expect(result.success).toBe(true);
+    const output = await result.outputs[0].text();
+
+    expect(output).not.toContain("() => )");
+    expect(() => transpiler.scanImports(output)).not.toThrow();
+  }
+});


### PR DESCRIPTION
## Summary

- Fixes `bun build` producing syntactically invalid JavaScript (`Promise.resolve().then(() => )`) for unused dynamic imports like `void import("./dep.ts")` or bare `import("./dep.ts")` expression statements
- When `exports_ref` is cleared for unused results but the `.then(() => ...)` wrapper was still emitted, the arrow function body was empty. Now skips the `.then()` wrapper entirely when there's nothing to execute inside the callback, producing just `Promise.resolve()`
- The bug only affected cases where the import result was unused — `const x = import(...)`, `await import(...)`, and `.then()` chains were already correct

Closes #24709

## Test plan

- [x] Added regression test in `test/regression/issue/24709.test.ts` that validates both `void import()` and bare `import()` statement cases
- [x] Verified test fails with system bun (reproduces the bug) and passes with debug build (fix works)
- [x] Verified used dynamic imports (`const m = await import(...)`) still produce correct `.then(() => exports)` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)