### PR TITLE
fix(transpiler): don't optimize global constructors that have been reassigned

### DIFF
--- a/src/ast/KnownGlobal.zig
+++ b/src/ast/KnownGlobal.zig
@@ -39,6 +39,11 @@ pub const KnownGlobal = enum {
         if (symbol.kind != .unbound)
             return null;
 
+        // If the global has been reassigned (e.g. `WeakMap = function() {...}`),
+        // we can't assume it still refers to the built-in constructor.
+        if (symbol.has_been_assigned_to)
+            return null;
+
         const constructor = map.get(symbol.original_name) orelse return null;
 
         return switch (constructor) {

--- a/test/regression/issue/14217.test.ts
+++ b/test/regression/issue/14217.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/14217
+// Runtime DCE incorrectly removes `new WeakMap([])` (and similar) after the
+// global constructor has been reassigned.
+
+test("reassigned WeakMap constructor is not DCE'd", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `WeakMap = function() { console.log("WeakMap called"); }; new WeakMap([]);`],
+    env: bunEnv,
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toContain("WeakMap called");
+  expect(exitCode).toBe(0);
+});
+
+test("reassigned Map constructor is not DCE'd", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `Map = function() { console.log("Map called"); }; new Map([]);`],
+    env: bunEnv,
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toContain("Map called");
+  expect(exitCode).toBe(0);
+});
+
+test("reassigned Set constructor is not DCE'd", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `Set = function() { console.log("Set called"); }; new Set([]);`],
+    env: bunEnv,
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toContain("Set called");
+  expect(exitCode).toBe(0);
+});
+
+test("reassigned Date constructor is not DCE'd", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `Date = function() { console.log("Date called"); }; new Date();`],
+    env: bunEnv,
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toContain("Date called");
+  expect(exitCode).toBe(0);
+});
+
+test("reassigned WeakSet constructor is not DCE'd", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `WeakSet = function() { console.log("WeakSet called"); }; new WeakSet([]);`],
+    env: bunEnv,
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toContain("WeakSet called");
+  expect(exitCode).toBe(0);
+});
+
+test("reassigned Error constructor preserves new.target", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `Error = function() { console.log(new.target ? "has new.target" : "no new.target"); }; new Error();`,
+    ],
+    env: bunEnv,
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toContain("has new.target");
+  expect(exitCode).toBe(0);
+});
+
+test("reassigned Array constructor is not replaced with literal", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `Array = function() { console.log("Array called"); }; new Array();`],
+    env: bunEnv,
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toContain("Array called");
+  expect(exitCode).toBe(0);
+});
+
+test("reassigned Object constructor is not replaced with literal", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `Object = function() { console.log("Object called"); }; new Object();`],
+    env: bunEnv,
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toContain("Object called");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fixed the transpiler's DCE (dead code elimination) incorrectly removing expressions like `new WeakMap([])` when the global constructor has been reassigned (e.g. `WeakMap = function() {...}`)
- The `minifyGlobalConstructor` optimization now checks `symbol.has_been_assigned_to` before assuming a global identifier still refers to its built-in constructor
- This affects all known globals: `WeakMap`, `WeakSet`, `Map`, `Set`, `Date`, `Error` (and subtypes), `Array`, `Object`, `Function`, `Headers`, `Response`, `TextEncoder`, `TextDecoder`

Closes #14217

## Test plan
- [x] Added regression tests in `test/regression/issue/14217.test.ts` covering reassigned `WeakMap`, `Map`, `Set`, `Date`, `WeakSet`, `Error`, `Array`, and `Object` constructors
- [x] Verified all 8 new tests fail with the system bun (`USE_SYSTEM_BUN=1`) and pass with the debug build (`bun bd test`)
- [x] Verified all 32 existing `test/bundler/bundler_minify.test.ts` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)