### PR TITLE
fix(net): guard against undefined socket.data in SocketHandlers2 handlers

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -482,6 +482,7 @@ const ServerHandlers: SocketHandler<NetSocket> = {
 const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_handle"]>["data"]> = {
   open(socket) {
     $debug("Bun.Socket open");
+    if (socket.data === undefined) return;
     let { self, req } = socket.data;
     socket[owner_symbol] = self;
     $debug("self[kupgraded]", String(self[kupgraded]));
@@ -504,12 +505,14 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
   },
   data(socket, buffer) {
     $debug("Bun.Socket data");
+    if (socket.data === undefined) return;
     const { self } = socket.data;
     self.bytesRead += buffer.length;
     if (!self.push(buffer)) socket.pause();
   },
   drain(socket) {
     $debug("Bun.Socket drain");
+    if (socket.data === undefined) return;
     const { self } = socket.data;
     const callback = self[kwriteCallback];
     self.connecting = false;
@@ -527,6 +530,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
   },
   end(socket) {
     $debug("Bun.Socket end");
+    if (socket.data === undefined) return;
     const { self } = socket.data;
     if (self[kended]) return;
     self[kended] = true;
@@ -536,6 +540,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
   },
   close(socket, err) {
     $debug("Bun.Socket close");
+    if (socket.data === undefined) return;
     let { self } = socket.data;
     if (err) $debug(err);
     if (self[kclosed]) return;
@@ -548,6 +553,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
   },
   handshake(socket, success, verifyError) {
     $debug("Bun.Socket handshake");
+    if (socket.data === undefined) return;
     const { self } = socket.data;
     if (!success && verifyError?.code === "ECONNRESET") {
       // will be handled in onConnectEnd
@@ -599,11 +605,13 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
   },
   timeout(socket) {
     $debug("Bun.Socket timeout");
+    if (socket.data === undefined) return;
     const { self } = socket.data;
     self.emit("timeout", self);
   },
   connectError(socket, error) {
     $debug("Bun.Socket connectError");
+    if (socket.data === undefined) return;
     let { self, req } = socket.data;
     socket[owner_symbol] = self;
     req!.oncomplete(error.errno, self._handle, req, true, true);

--- a/test/regression/issue/21226.test.ts
+++ b/test/regression/issue/21226.test.ts
@@ -1,0 +1,184 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tls } from "harness";
+import { createConnection, createServer } from "node:net";
+import { createServer as createTlsServer, connect as tlsConnect } from "node:tls";
+
+// Regression test for https://github.com/oven-sh/bun/issues/21226
+// SocketHandlers2 (client-side socket handlers) crashed with
+// "TypeError: Right side of assignment cannot be destructured"
+// when socket.data was undefined during drain/close/etc callbacks.
+
+test("net client socket does not crash when rapidly connecting and disconnecting (issue #21226)", async () => {
+  // Create a simple TCP server
+  const server = createServer(socket => {
+    socket.on("data", data => {
+      socket.write(data);
+    });
+  });
+
+  await new Promise<void>(resolve => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const port = (server.address() as any).port;
+
+  try {
+    // Rapidly create and destroy many connections to exercise SocketHandlers2 code paths
+    // This tries to trigger the race condition where socket.data could be undefined
+    const iterations = 50;
+    const promises: Promise<void>[] = [];
+
+    for (let i = 0; i < iterations; i++) {
+      promises.push(
+        new Promise<void>((resolve, reject) => {
+          const client = createConnection(port, "127.0.0.1", () => {
+            client.write("test data " + i);
+          });
+
+          client.on("data", () => {
+            // Immediately destroy after receiving data
+            client.destroy();
+          });
+
+          client.on("close", () => {
+            resolve();
+          });
+
+          client.on("error", err => {
+            // Connection reset errors are acceptable
+            if ((err as any).code === "ECONNRESET" || (err as any).code === "EPIPE") {
+              resolve();
+            } else {
+              reject(err);
+            }
+          });
+        }),
+      );
+    }
+
+    await Promise.all(promises);
+  } finally {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+});
+
+test("tls client socket does not crash when rapidly connecting and disconnecting (issue #21226)", async () => {
+  // Create a TLS server (the original issue was triggered with TLS connections)
+  const server = createTlsServer(
+    {
+      cert: tls.cert,
+      key: tls.key,
+      ca: tls.ca,
+    },
+    socket => {
+      socket.on("data", data => {
+        socket.write(data);
+      });
+    },
+  );
+
+  await new Promise<void>(resolve => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const port = (server.address() as any).port;
+
+  try {
+    // Rapidly create and destroy many TLS connections
+    const iterations = 50;
+    const promises: Promise<void>[] = [];
+
+    for (let i = 0; i < iterations; i++) {
+      promises.push(
+        new Promise<void>((resolve, reject) => {
+          const client = tlsConnect(
+            {
+              port,
+              host: "127.0.0.1",
+              rejectUnauthorized: false,
+            },
+            () => {
+              client.write("test data " + i);
+            },
+          );
+
+          client.on("data", () => {
+            client.destroy();
+          });
+
+          client.on("close", () => {
+            resolve();
+          });
+
+          client.on("error", err => {
+            if ((err as any).code === "ECONNRESET" || (err as any).code === "EPIPE") {
+              resolve();
+            } else {
+              reject(err);
+            }
+          });
+        }),
+      );
+    }
+
+    await Promise.all(promises);
+  } finally {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+});
+
+// Direct test: verify the fix by spawning a subprocess that exercises the
+// SocketHandlers2 drain handler under conditions where socket.data might be undefined
+test("net.connect drain handler does not throw when socket.data is undefined (issue #21226)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const net = require("node:net");
+      const server = net.createServer(socket => {
+        // Write a lot of data to trigger drain on the client
+        for (let i = 0; i < 100; i++) {
+          socket.write("x".repeat(1024));
+        }
+        socket.end();
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const port = server.address().port;
+        // Create many concurrent connections
+        let completed = 0;
+        const total = 20;
+        for (let i = 0; i < total; i++) {
+          const client = net.createConnection(port, "127.0.0.1", () => {
+            client.write("hello");
+          });
+          client.on("data", () => {
+            client.destroy();
+          });
+          client.on("close", () => {
+            completed++;
+            if (completed === total) {
+              server.close();
+              process.exit(0);
+            }
+          });
+          client.on("error", () => {
+            completed++;
+            if (completed === total) {
+              server.close();
+              process.exit(0);
+            }
+          });
+        }
+      });
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const exitCode = await proc.exited;
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Add `if (socket.data === undefined) return;` guards to all handlers in `SocketHandlers2` (client-side socket handlers in `node:net`) that were missing them
- The `error` handler already had this guard, but `open`, `data`, `drain`, `end`, `close`, `handshake`, `timeout`, and `connectError` did not
- This prevents a `TypeError: Right side of assignment cannot be destructured` crash when `socket.data` is undefined during rapid connection/disconnection cycles (e.g., with neo4j-driver over TLS)

## Root Cause

`SocketHandlers2` in `src/js/node/net.ts` is used for client-side sockets created via `Socket.prototype.connect()`. All handlers destructure `socket.data` (e.g., `const { self } = socket.data`), but `socket.data` can be `undefined` if the socket's data property hasn't been set yet or was cleared during teardown. The Zig-level `getData()` returns `js_undefined` by default.

The server-side `SocketHandlers` already had proper guards (`if (!self) return;`), and even the `error` handler in `SocketHandlers2` had the guard — confirming the developers were aware of this possibility. This PR adds the missing guards to all remaining handlers.

## Test plan

- [x] Added regression test in `test/regression/issue/21226.test.ts`
- [x] Tests exercise TCP and TLS rapid connect/disconnect scenarios
- [x] Verified existing `test/js/node/net/node-net.test.ts` tests still pass (pre-existing failures are unrelated)

Closes #21226

🤖 Generated with [Claude Code](https://claude.com/claude-code)