### PR TITLE
fix(bundler): prevent stale file descriptor errors on repeated Bun.build calls

### DIFF
--- a/test/regression/issue/09517.test.ts
+++ b/test/regression/issue/09517.test.ts
@@ -1,0 +1,71 @@
+// https://github.com/oven-sh/bun/issues/9517
+// Repeated Bun.build calls with FileSystemRouter and absolute path imports
+// would fail with "Unseekable reading file" due to stale cached file descriptors.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+test("Bun.build does not fail on repeated calls with FileSystemRouter present", async () => {
+  using dir = tempDir("issue-9517", {
+    "pages/index.js": `export default function Page() { return "Hello"; }`,
+  });
+
+  const dirPath = String(dir);
+  const absPagePath = join(dirPath, "pages/index.js");
+
+  // Create an entry file that imports from an absolute path
+  await Bun.write(
+    join(dirPath, "pages/_entry.js"),
+    `import PageComponent from "${absPagePath}";\nconsole.log(PageComponent());\n`,
+  );
+
+  // Script that creates a FileSystemRouter (which populates the
+  // resolver's FD cache) and then runs Bun.build multiple times.
+  await Bun.write(
+    join(dirPath, "runner.js"),
+    `
+const router = new Bun.FileSystemRouter({
+  style: "nextjs",
+  dir: "./pages",
+});
+
+const results = [];
+for (let i = 0; i < 10; i++) {
+  const result = await Bun.build({
+    entrypoints: ['./pages/_entry.js'],
+  });
+  results.push({
+    success: result.success,
+    errors: result.success ? [] : result.logs.map(l => l.message),
+  });
+}
+console.log(JSON.stringify(results));
+`,
+  );
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "runner.js"],
+    env: bunEnv,
+    cwd: dirPath,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  if (stdout.trim().length === 0) {
+    throw new Error(`Subprocess produced no stdout. stderr: ${stderr}`);
+  }
+
+  const results = JSON.parse(stdout.trim());
+
+  // All 10 builds should succeed
+  for (let i = 0; i < results.length; i++) {
+    if (!results[i].success) {
+      throw new Error(`Build #${i} failed: ${JSON.stringify(results[i].errors)}`);
+    }
+    expect(results[i].success).toBe(true);
+  }
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

Fixes #9517

When `FileSystemRouter` and `Bun.build` are used together, subsequent build calls fail with "Unseekable reading file" errors. The root cause is a **stale file descriptor (FD) ownership bug**: the bundler's `ParseTask` closes FDs after parsing each file, but the resolver's entry cache still holds references to those closed FDs. On the next `Bun.build` call, the resolver returns the stale FDs, causing `seekTo(0)` to fail.

### Changes

**`src/cache.zig`** — Two functions fixed: `readFileShared` and `readFileWithAllocator`
- Don't return cached FDs to callers — prevents `ParseTask` from closing FDs owned by the resolver's entry cache
- If `seekTo(0)` fails on a cached FD (stale/closed), fall back to opening the file fresh instead of propagating the error
- Handle `EBADF` from `openatA` when the directory FD is stale, falling back to absolute path open

**`src/fs.zig`** — `readDirectoryWithIterator`
- Don't cache directory FDs when `needToCloseFiles()` is true — the handle will be closed by the defer block, making the cached FD stale

### Reproduction

```js
const router = new Bun.FileSystemRouter({ style: "nextjs", dir: "./pages" });

// First build succeeds, all subsequent builds fail with:
// "Unseekable reading file: .../pages/index.js"
for (let i = 0; i < 10; i++) {
  const result = await Bun.build({ entrypoints: ['./pages/_entry.js'] });
  console.log(result.success); // true, false, false, false, ...
}
```

## Test plan

- [x] Added regression test `test/regression/issue/09517.test.ts`
- [x] Test passes with `bun bd test test/regression/issue/09517.test.ts`
- [x] Test fails with `USE_SYSTEM_BUN=1 bun test test/regression/issue/09517.test.ts` (confirms the bug existed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)