### PR TITLE
fix(shell): non-ASCII characters in template literals (#12225)

### DIFF
--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -294,10 +294,7 @@ describe("bunshell", () => {
 
     test("escape unicode", async () => {
       const { stdout } = await $`echo \\弟\\気`;
-      // TODO: Uncomment and replace after unicode in template tags is supported
-      // expect(stdout.toString("utf8")).toEqual(`\弟\気\n`);
-      // Set this here for now, because unicode in template tags while using .raw is broken, but should be fixed
-      expect(stdout.toString("utf8")).toEqual("\\u5F1F\\u6C17\n");
+      expect(stdout.toString("utf8")).toEqual("\\弟\\気\n");
     });
 
     /**

--- a/test/regression/issue/12225.test.ts
+++ b/test/regression/issue/12225.test.ts
@@ -1,0 +1,47 @@
+import { $ } from "bun";
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/12225
+
+test("non-ASCII interpolated value with special chars needing escape", async () => {
+  const rating = "3"; // Contains digit - needs escaping via __bunstr_ ref
+  const label = "檢視"; // Non-ASCII
+
+  const result = await $`echo key=${rating} ${label}`.text();
+  expect(result.trim()).toBe("key=3 檢視");
+});
+
+test("non-ASCII static template text", async () => {
+  const result = await $`echo 檢視`.text();
+  expect(result.trim()).toBe("檢視");
+});
+
+test("non-ASCII interpolated value without special chars", async () => {
+  const label = "檢視";
+  const result = await $`echo ${label}`.text();
+  expect(result.trim()).toBe("檢視");
+});
+
+test("mixed ASCII and non-ASCII with multiple interpolations", async () => {
+  const num = "42";
+  const text = "日本語";
+  const result = await $`echo ${num} hello ${text} world`.text();
+  expect(result.trim()).toBe("42 hello 日本語 world");
+});
+
+test("supplementary plane characters in static template", async () => {
+  // U+1D573 is outside BMP, uses \u{XXXX} in raw string
+  const result = await $`echo 𝕳ello`.text();
+  expect(result.trim()).toBe("𝕳ello");
+});
+
+test("backslash-escaped unicode in template preserved", async () => {
+  // \\弟 in source means literal backslash + 弟
+  const result = await $`echo \\弟\\気`.text();
+  expect(result.trim()).toBe("\\弟\\気");
+});
+
+test("latin-1 characters in static template", async () => {
+  const result = await $`echo café`.text();
+  expect(result.trim()).toBe("café");
+});


### PR DESCRIPTION
## Summary

Fixes #12225 - Non-ASCII characters in Bun Shell template literals were broken in multiple ways.

**Four bugs fixed:**

- **Unicode lexer cursor position**: `srcBytesAtCursor()` and `cursorPos()` used `iter.i` (the iterator's decode-ahead position) instead of `cursor.i` (the actual current codepoint position). This caused `__bunstr_` string reference markers to not be found when the Unicode lexer was selected, leaking internal markers like `key=\b__bunstr_0` into shell output.

- **Unicode cursor codepoint after bump**: `bumpCursorAscii()` set the Unicode cursor's codepoint field to the last parsed digit character instead of decoding the actual codepoint at the target byte position. This caused extra characters (the substitution index digits) to leak into output.

- **Raw template string unicode escapes**: JSC's template literal `.raw` property converts non-ASCII characters to `\uXXXX` / `\u{XXXX}` escape sequences. Added `unescapeUnicodeRaw()` to convert these back to actual Unicode characters before passing to the shell parser, fixing static non-ASCII text like `` $`echo 檢視` `` producing garbled output.

- **Latin-1 double append**: `appendLatin1Impl()` appended the ASCII prefix of Latin-1 strings twice — once directly via `appendUTF8Impl`, and again via `allocateLatin1IntoUTF8WithList` which already handles the complete string including the ASCII portion. This caused strings like `café` to produce `cafecho café`.

## Test plan

- [x] New regression test `test/regression/issue/12225.test.ts` (7 test cases) — all pass with debug build, 6/7 fail with system bun
- [x] Updated existing test expectation in `bunshell.test.ts` for "escape unicode" (was testing broken behavior)
- [x] All 25 escape-related shell tests pass
- [x] Full shell test suite: 340 pass, 4 fail (pre-existing ASAN stderr warnings in debug build, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)