### PR TITLE
fix(dns): update c-ares to fix Windows DNS SRV resolution regression

### DIFF
--- a/cmake/targets/BuildCares.cmake
+++ b/cmake/targets/BuildCares.cmake
@@ -4,7 +4,7 @@ register_repository(
   REPOSITORY
     c-ares/c-ares
   COMMIT
-    3ac47ee46edd8ea40370222f91613fc16c434853
+    e29bca8b113d4c5bbf2996f3e94fccbc298a4503
 )
 
 register_cmake_command(

--- a/test/regression/issue/27180.test.ts
+++ b/test/regression/issue/27180.test.ts
@@ -1,0 +1,16 @@
+// https://github.com/oven-sh/bun/issues/27180
+// c-ares v1.34.6 introduced a regression on Windows where DNS SRV queries fail
+// with ECONNREFUSED due to a bug in wide string handling in the Windows registry
+// reading code (size == 1 instead of size == sizeof(WCHAR)).
+import { expect, test } from "bun:test";
+import dns from "node:dns";
+
+test("dns.resolveSrv resolves SRV records", async () => {
+  const results = await dns.promises.resolveSrv("_imaps._tcp.gmail.com");
+  expect(Array.isArray(results)).toBe(true);
+  expect(results.length).toBeGreaterThan(0);
+  expect(results[0]).toHaveProperty("name");
+  expect(results[0]).toHaveProperty("port");
+  expect(results[0]).toHaveProperty("priority");
+  expect(results[0]).toHaveProperty("weight");
+});


### PR DESCRIPTION
## Summary

- Updates c-ares from v1.34.6 (`3ac47ee`) to include upstream fix `e29bca8` ([c-ares/c-ares#1064](https://github.com/c-ares/c-ares/pull/1064)) which corrects a Windows DNS registry reading bug
- c-ares v1.34.6 changed Windows registry reading to use wide strings but checked for empty string size using `size == 1` instead of `size == sizeof(WCHAR)`, corrupting the DNS server list and causing SRV queries to fail with `ECONNREFUSED`
- Adds regression test for DNS SRV resolution

Fixes #27180
Fixes #25718
Fixes #26467

## Test plan

- [x] `bun bd test test/regression/issue/27180.test.ts` passes on Linux
- [ ] Verify DNS SRV resolution works on Windows (the affected platform)
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)