### PR TITLE
fix(resolver): skip case-insensitive false matches during extension probing

### DIFF
--- a/test/regression/issue/22686.test.ts
+++ b/test/regression/issue/22686.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/22686
+// When a directory has files that differ only in case and extension
+// (e.g. todos.ts and Todos.tsx), extensionless imports should resolve
+// to the correct file based on case-sensitive stem matching.
+test("extensionless import resolves correct file when similar names differ by case", async () => {
+  using dir = tempDir("issue-22686", {
+    "src/todos.ts": `export const todos = ["todo1", "todo2"];`,
+    "src/Todos.tsx": `export function Todos() { return "Todos Component"; }`,
+    "src/index.tsx": `
+import { todos } from "./todos";
+import { Todos } from "./Todos";
+console.log(JSON.stringify(todos));
+console.log(Todos());
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "src/index.tsx"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe('["todo1","todo2"]\nTodos Component\n');
+  expect(exitCode).toBe(0);
+});
+
+test("bundler resolves correct file when similar names differ by case", async () => {
+  using dir = tempDir("issue-22686-bundler", {
+    "src/todos.ts": `export const todos = ["todo1", "todo2"];`,
+    "src/Todos.tsx": `export function Todos() { return "Todos Component"; }`,
+    "src/index.tsx": `
+import { todos } from "./todos";
+import { Todos } from "./Todos";
+console.log(JSON.stringify(todos));
+console.log(Todos());
+`,
+  });
+
+  // First, bundle
+  await using buildProc = Bun.spawn({
+    cmd: [bunExe(), "build", "src/index.tsx", "--outdir=dist"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [buildStdout, buildStderr, buildExitCode] = await Promise.all([
+    buildProc.stdout.text(),
+    buildProc.stderr.text(),
+    buildProc.exited,
+  ]);
+
+  expect(buildStderr).toBe("");
+  expect(buildExitCode).toBe(0);
+
+  // Then run the bundled output
+  await using runProc = Bun.spawn({
+    cmd: [bunExe(), "run", "dist/index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [runStdout, runStderr, runExitCode] = await Promise.all([
+    runProc.stdout.text(),
+    runProc.stderr.text(),
+    runProc.exited,
+  ]);
+
+  expect(runStderr).toBe("");
+  expect(runStdout).toBe('["todo1","todo2"]\nTodos Component\n');
+  expect(runExitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

Fixes #22686

When a directory contains files that differ only in case and extension (e.g. `todos.ts` and `Todos.tsx`), importing the lowercase one without an explicit extension (`import { todos } from "./todos"`) fails with ENOENT because the resolver's case-insensitive directory lookup incorrectly matches `Todos.tsx` before trying the correct `.ts` extension.

**Root cause**: The resolver's `loadExtension` function appends candidate extensions to the import stem and looks them up in a case-insensitive directory entry map. When probing `todos` + `.tsx` → `todos.tsx`, the case-insensitive lookup finds `Todos.tsx` (a different file) and returns it as a match, preventing the correct `todos.ts` from ever being tried.

**Two fixes**:
- **Skip false matches**: When the case-insensitive lookup finds a file with a different stem (e.g. `Todos` vs `todos`), skip it and continue trying other extensions
- **Fix path caching**: `loadExtension` was caching the absolute path using the query string (`todos.tsx`) instead of the entry's actual base name (`Todos.tsx`), producing nonexistent paths on case-sensitive filesystems (Linux)

## Test plan

- [x] Added regression test in `test/regression/issue/22686.test.ts`
- [x] Test verifies both runtime and bundler resolve correctly with case-differing `.ts`/`.tsx` files
- [x] Test fails with `USE_SYSTEM_BUN=1` (reproduces the ENOENT error)
- [x] Test passes with `bun bd test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)