### PR TITLE
fix(transpiler): preserve "use strict" directives in function bodies

### DIFF
--- a/src/ast/visit.zig
+++ b/src/ast/visit.zig
@@ -1192,8 +1192,12 @@ pub fn Visit(
                 switch (stmt.data) {
                     .s_empty => continue,
 
-                    // skip directives for now
-                    .s_directive => continue,
+                    // Preserve directives (e.g. "use strict") as they have
+                    // semantic meaning and must not be removed.
+                    .s_directive => {
+                        output.append(stmt) catch unreachable;
+                        continue;
+                    },
 
                     .s_local => |local| {
                         // Merge adjacent local statements

--- a/test/regression/issue/19490.test.ts
+++ b/test/regression/issue/19490.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("use strict in function body is preserved in CJS transpilation", async () => {
+  using dir = tempDir("issue-19490", {
+    "strict_module.js": `
+;(function(root, factory) {
+  if (typeof exports === "object") {
+    module.exports = factory();
+  }
+}(this, function() {
+  "use strict";
+  var fn = function() { return typeof this; };
+  return { fn: fn };
+}));
+`,
+    "test.js": `
+var mod = require("./strict_module.js");
+var result = mod.fn.apply("hello");
+console.log(result);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "test.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // In strict mode, `this` is not boxed, so typeof this === "string"
+  // In sloppy mode, `this` is boxed to String object, so typeof this === "object"
+  expect(stdout.trim()).toBe("string");
+  expect(exitCode).toBe(0);
+});
+
+test("json-logic-js style UMD with use strict works correctly", async () => {
+  using dir = tempDir("issue-19490-umd", {
+    "logic.js": `
+;(function(root, factory) {
+  if (typeof exports === "object") {
+    module.exports = factory();
+  }
+}(this, function() {
+  "use strict";
+
+  var arrayUnique = function(array) {
+    var a = [];
+    for (var i = 0, l = array.length; i < l; i++) {
+      if (a.indexOf(array[i]) === -1) {
+        a.push(array[i]);
+      }
+    }
+    return a;
+  };
+
+  var operations = {
+    "some": function(data, values) {
+      var dominated = values[0];
+      var rule = values[1];
+
+      for (var i = 0; i < dominated.length; i++) {
+        // In strict mode, apply with a string keeps this as a string
+        // In sloppy mode, it gets boxed to a String object
+        if (applyRule.apply(dominated[i], [rule])) {
+          return true;
+        }
+      }
+      return false;
+    }
+  };
+
+  function applyRule(rule) {
+    if (typeof rule === "object" && rule !== null && "===" in rule) {
+      var args = rule["==="];
+      var left = args[0];
+      var right = args[1];
+      // When left is { var: "" }, resolve to \`this\`
+      if (typeof left === "object" && "var" in left && left["var"] === "") {
+        left = this;
+      }
+      return left === right;
+    }
+    return false;
+  }
+
+  return {
+    apply: function(rules) {
+      if (typeof rules === "object" && rules !== null && "some" in rules) {
+        return operations["some"](null, rules["some"]);
+      }
+      return null;
+    }
+  };
+}));
+`,
+    "test.js": `
+var logic = require("./logic.js");
+var result = logic.apply({
+  some: [
+    ["hello", "world"],
+    { "===": [{ var: "" }, "hello"] }
+  ]
+});
+console.log(result);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "test.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("true");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fixes the CJS transpiler stripping `"use strict"` directives from function bodies, causing functions that should execute in strict mode to run in sloppy mode instead
- This broke libraries like `json-logic-js` that use UMD patterns with `"use strict"` inside factory functions, because `this` was boxed to a String object instead of staying a primitive
- Two root causes fixed:
  1. **Parser** (`parse.zig`): The directive prologue parser unconditionally skipped `"use strict"` and only restored it for the module scope. Now function-level `"use strict"` is converted to `S.Directive` nodes that survive through the AST pipeline.
  2. **Visit pass** (`visit.zig`): The `joinWithComma` optimization (when `minify_syntax` + `dead_code_elimination` are enabled) unconditionally removed all `S.Directive` nodes. Now it preserves them since they have semantic meaning.

Closes #19490

## Test plan

- [x] New regression test `test/regression/issue/19490.test.ts` with two cases:
  - Simple function-body `"use strict"` with `Function.prototype.apply` on a primitive
  - json-logic-js style UMD pattern with `"use strict"` in factory function
- [x] Test passes with `bun bd test` and fails with `USE_SYSTEM_BUN=1`
- [x] Existing strict mode tests pass (`test/bundler/transpiler/preserve-use-strict-cjs.test.ts`)
- [x] Existing transpiler tests pass (`test/js/bun/transpiler/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)