### PR TITLE
fix(transpiler): implement Annex B.3.3 sloppy mode block function hoisting

### DIFF
--- a/test/regression/issue/23633.test.ts
+++ b/test/regression/issue/23633.test.ts
@@ -1,0 +1,158 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/23633
+// Block-scoped function declarations in sloppy mode (.cjs) should follow
+// ECMAScript Annex B.3.3 semantics: the function should be assigned to the
+// outer var-scoped binding at the point of the declaration.
+
+test("Annex B.3.3: block-scoped function overwrites outer binding in sloppy mode", async () => {
+  // This is the exact reproduction from the issue.
+  using dir = tempDir("issue-23633", {
+    "test.cjs": `
+function foo() {
+  console.log('foo');
+}
+foo();
+{
+  function foo() {
+    console.log('bar');
+  }
+  foo();
+}
+foo();
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Before the fix, the last call printed "foo" instead of "bar"
+  expect(stdout.trim()).toBe("foo\nbar\nbar");
+  expect(exitCode).toBe(0);
+});
+
+test("Annex B.3.3: block-scoped function inside a function scope", async () => {
+  using dir = tempDir("issue-23633-fn-scope", {
+    "test.cjs": `
+function test1() {
+  function foo() { return 'outer'; }
+  console.log(foo());
+  {
+    function foo() { return 'inner'; }
+    console.log(foo());
+  }
+  console.log(foo());
+}
+test1();
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("outer\ninner\ninner");
+  expect(exitCode).toBe(0);
+});
+
+test("Annex B.3.3: block-scoped function hoisted from block to enclosing scope", async () => {
+  using dir = tempDir("issue-23633-nested", {
+    "test.cjs": `
+{
+  function f() { return 'block'; }
+  console.log(f());
+}
+console.log(f());
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("block\nblock");
+  expect(exitCode).toBe(0);
+});
+
+test("Annex B.3.3: strict mode (ESM) does NOT leak block-scoped functions", async () => {
+  using dir = tempDir("issue-23633-esm", {
+    "test.mjs": `
+export {};
+function foo() { return 'outer'; }
+console.log(foo());
+{
+  function foo() { return 'inner'; }
+  console.log(foo());
+}
+console.log(foo());
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("outer\ninner\nouter");
+  expect(exitCode).toBe(0);
+});
+
+test("Annex B.3.3: transpiled output is correct for sloppy mode", async () => {
+  // Verify that `bun build --no-bundle` produces correct Annex B output
+  using dir = tempDir("issue-23633-build", {
+    "test.cjs": `
+function foo() {
+  console.log('foo');
+}
+foo();
+{
+  function foo() {
+    console.log('bar');
+  }
+  foo();
+}
+foo();
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--no-bundle", "test.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The transpiled output should contain a var assignment from the block function
+  // to the outer scope (the key Annex B.3.3 behavior)
+  expect(stdout).toContain("var foo");
+  expect(stdout).toContain("foo =");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fix block-scoped function declarations in sloppy mode (.cjs) to follow ECMAScript Annex B.3.3 semantics
- Remove `willUseRenamer()` guard that prevented Annex B lowering in non-bundle/non-minify mode
- Rename block-scoped symbols with unique suffix (`foo_1$`) when no renamer is active to avoid name collisions
- Add regression tests covering sloppy mode, function scope, nested blocks, and ESM strict mode

Fixes #23633

## Details

In sloppy mode, a function declaration inside a block should:
1. Create a block-scoped binding (like `let`) for the function within the block
2. Also assign the function value to the outer `var`-scoped binding at the point of the declaration

Before this fix, `bun build --no-bundle foo.cjs` produced:
```js
function foo() { console.log("foo"); }
foo();
{
  let foo = function() { console.log("bar"); };
  foo();
}
foo(); // prints "foo" (WRONG - should print "bar")
```

After this fix:
```js
function foo() { console.log("foo"); }
foo();
{
  let foo_1$ = function() { console.log("bar"); };
  foo = foo_1$;  // assigns to outer var scope
  foo_1$();
}
foo(); // prints "bar" (CORRECT)
var foo;
```

## Test plan

- [x] `bun bd test test/regression/issue/23633.test.ts` — 5/5 pass
- [x] `USE_SYSTEM_BUN=1 bun test test/regression/issue/23633.test.ts` — 4/5 fail (confirms tests catch the bug)
- [x] `bun bd test test/bundler/transpiler/` — no regressions (351 pass, pre-existing failures only)
- [x] Verified output matches Node.js for the original reproduction case

🤖 Generated with [Claude Code](https://claude.com/claude-code)