### PR TITLE
fix(test): mock.module() should work with static imports of mocked modules

### DIFF
--- a/src/ast/Ast.zig
+++ b/src/ast/Ast.zig
@@ -71,6 +71,11 @@ has_commonjs_export_names: bool = false,
 has_import_meta: bool = false,
 import_meta_ref: Ref = Ref.None,
 
+/// Specifiers from mock.module("specifier", fn) calls detected during parsing
+/// in test mode. Used to register placeholder virtual modules before the module
+/// graph is built, preventing link errors for mocked modules.
+mock_module_specifiers: bun.StringArrayHashMapUnmanaged(void) = .{},
+
 pub const CommonJSNamedExport = struct {
     loc_ref: LocRef,
     needs_decl: bool = true,

--- a/src/ast/P.zig
+++ b/src/ast/P.zig
@@ -304,6 +304,11 @@ pub fn NewParser_(
 
         jest: Jest = .{},
 
+        /// When inject_jest_globals is enabled, this collects specifiers from
+        /// mock.module("specifier", fn) calls, so that placeholder virtual modules
+        /// can be registered before the module graph is built.
+        mock_module_specifiers: bun.StringArrayHashMapUnmanaged(void) = .{},
+
         // Imports (both ES6 and CommonJS) are tracked at the top level
         import_records: ImportRecordList,
         import_records_for_current_part: List(u32) = .{},
@@ -6616,6 +6621,7 @@ pub fn NewParser_(
                 .ts_enums = try p.computeTsEnumsMap(allocator),
                 .import_meta_ref = p.import_meta_ref,
 
+                .mock_module_specifiers = p.mock_module_specifiers,
                 .symbols = js_ast.Symbol.List.moveFromList(&p.symbols),
                 .parts = bun.BabyList(js_ast.Part).moveFromList(parts),
                 .import_records = ImportRecord.List.moveFromList(&p.import_records),

--- a/src/bun.js/RuntimeTranspilerStore.zig
+++ b/src/bun.js/RuntimeTranspilerStore.zig
@@ -574,6 +574,11 @@ pub const RuntimeTranspilerStore = struct {
                 dumpSource(this.vm, specifier, &printer);
             }
 
+            // Register placeholder virtual modules for mock.module() targets.
+            if (parse_result.ast.mock_module_specifiers.count() > 0) {
+                @import("./ModuleLoader.zig").registerPendingMockModules(vm, &parse_result, path);
+            }
+
             const source_code = brk: {
                 const written = printer.ctx.getWritten();
 

--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -944,6 +944,7 @@ pub const Jest = struct {
     xit: Ref = Ref.None,
     xtest: Ref = Ref.None,
     xdescribe: Ref = Ref.None,
+    mock: Ref = Ref.None,
 };
 
 // Doing this seems to yield a 1% performance improvement parsing larger files

--- a/test/regression/issue/18358-fixture-missing-export.ts
+++ b/test/regression/issue/18358-fixture-missing-export.ts
@@ -1,0 +1,4 @@
+// This module intentionally does NOT export 'myExportedFunction'.
+// The test verifies that mock.module() prevents the real module from
+// being loaded, so the missing export doesn't cause a link error.
+export const someOtherExport = "real-value";

--- a/test/regression/issue/18358.test.ts
+++ b/test/regression/issue/18358.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, mock } from "bun:test";
+
+// Register mock BEFORE the static import (which gets hoisted by ESM).
+// The mock.module() call should be detected during transpilation and
+// a placeholder virtual module registered so that the static import
+// doesn't fail during module linking.
+mock.module("./18358-fixture-missing-export.ts", () => ({
+  myExportedFunction: (fn: any) => ({
+    getClient: fn,
+    query: () => ({ data: { test: "test" }, loading: false, error: undefined }),
+  }),
+}));
+
+import { myExportedFunction } from "./18358-fixture-missing-export.ts";
+
+describe("issue #18358", () => {
+  it("mock.module should intercept module loading before ESM link phase", () => {
+    expect(typeof myExportedFunction).toBe("function");
+    const result = myExportedFunction(() => "client");
+    expect(result.getClient()).toBe("client");
+    expect(result.query()).toEqual({
+      data: { test: "test" },
+      loading: false,
+      error: undefined,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes `mock.module()` failing when the mocked module is also statically imported in the same test file
- Detects top-level `mock.module("specifier", fn)` calls during parsing and pre-registers placeholder virtual modules with the expected export names before the ESM module graph is built
- This prevents JSC's linker from throwing `SyntaxError: Export named 'X' not found` when the real module doesn't have the expected exports

## Problem
When a test file uses `mock.module()` alongside a static import of the same module:
```ts
mock.module("@apollo/experimental-nextjs-app-support", () => ({
    registerApolloClient: () => ({...}),
}));
import { registerApolloClient } from "@apollo/experimental-nextjs-app-support";
```
ESM import hoisting causes the static import to be resolved and linked **before** `mock.module()` executes. If the real module doesn't export `registerApolloClient`, JSC's linker throws a `SyntaxError`.

## Solution
During transpilation, the parser now detects top-level `mock.module("specifier", callback)` calls and records the specifier strings. After transpilation but before the module graph is built, placeholder virtual modules are registered with the expected export names (derived from the file's static imports of the same specifier). When JSC's module loader encounters these specifiers, it finds the placeholder instead of the real module. Later, when `mock.module()` actually executes, it replaces the placeholder with the real mock via `overrideExportValue`.

## Test plan
- [x] New regression test `test/regression/issue/18358.test.ts` passes with debug build
- [x] New test fails with system bun (verifying it tests the right thing)
- [x] Existing `test/js/bun/test/mock/mock-module.test.ts` tests all pass (no regressions)

Closes #18358

🤖 Generated with [Claude Code](https://claude.com/claude-code)