### PR TITLE
parser: preserve TDZ for const declared in switch case

### DIFF
--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1606,8 +1606,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // Ignore declarations if the scope is shadowed by a direct "eval" call.
             // The eval'd code may indirectly reference this symbol and the actual
             // use count may be greater than 1.
+            //
+            // Ignore declarations inside a switch case body: every case in a switch
+            // shares one lexical scope but we visit one case at a time, so
+            // `use_count_estimate` for a decl in case 0 has not yet seen references
+            // from later cases and may spuriously read as 1 — inlining then would
+            // delete the decl out from under those later references (issue #30932).
             // SAFETY: current_scope is a valid arena ptr for the parse.
-            if p.current_scope != p.module_scope && !p.current_scope().contains_direct_eval {
+            if kind != StmtsKind::SwitchStmt
+                && p.current_scope != p.module_scope
+                && !p.current_scope().contains_direct_eval
+            {
                 // Keep inlining variables until a failure or until there are none left.
                 // That handles cases like this:
                 //

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2153,6 +2153,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         {
             p.push_scope_for_visit_pass(js_ast::scope::Kind::Block, data.body_loc)
                 .expect("unreachable");
+            // Every case body shares one lexical scope but is entered conditionally,
+            // so a `const` declared in one case does not dominate references to that
+            // name in other cases. Disable the const-local-prefix inlining for the
+            // entire switch body — otherwise `case 'a': console.log(X)` could be
+            // rewritten to use the value from `case '*': const X = 2;` above it and
+            // silently bypass the TDZ error the spec requires (issue #30932).
+            p.cur_scope().is_after_const_local_prefix = true;
             let old_is_inside_switch = p.fn_or_arrow_data_visit.is_inside_switch;
             p.fn_or_arrow_data_visit.is_inside_switch = true;
             let cases = data.cases.slice_mut();
@@ -2164,7 +2171,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     //                 p.warnAboutTypeofAndString(s.Test, *c.Value)
                 }
                 let mut _stmts = stmts_to_list(p.arena, cases[i].body);
-                p.visit_stmts(&mut _stmts, StmtsKind::None)
+                p.visit_stmts(&mut _stmts, StmtsKind::SwitchStmt)
                     .expect("unreachable");
                 cases[i].body = list_to_stmts(_stmts);
             }

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -209,3 +209,97 @@ test("math.pow", () => {
   expect(foo2(20.4) + "").toEqual("0.22140372138502384");
   expect(20.4 ** -0.5 + "").toEqual("0.22140372138502384");
 });
+
+// https://github.com/oven-sh/bun/issues/30932
+describe("switch-case const does not leak across cases", () => {
+  test("literal-initialized const is not inlined into sibling case", () => {
+    // Pre-fix, Bun's const-prefix inliner treated `const CONSTANT = 2` in
+    // `case "*"` as an inlineable value and replaced `CONSTANT` in `case "a"`
+    // with `2`, so the second case returned "a=2". Per the spec the inner
+    // `const CONSTANT` hoists into the switch's lexical scope and shadows
+    // anything outside, so a reference from a sibling case that runs before
+    // the declaration must throw a TDZ ReferenceError.
+    function test(action) {
+      switch (action) {
+        case "*":
+          const CONSTANT = 2;
+          return "matched " + CONSTANT;
+        case "a":
+          return "a=" + CONSTANT;
+      }
+    }
+    expect(() => test("a")).toThrow(ReferenceError);
+    expect(test("*")).toBe("matched 2");
+  });
+
+  test("non-foldable const is not substituted out of sibling case", () => {
+    // Pre-fix, the single-use-substitution pass saw `use_count_estimate == 1`
+    // for `const X = Math.random()` while visiting `case "*"` (the reference
+    // in `case "a"` had not been visited yet), inlined the `Math.random()`
+    // call into the case "*" return, and deleted the declaration — leaving
+    // `case "a"` with a dangling reference that would throw
+    // `X is not defined` instead of a TDZ error.
+    function test(action) {
+      switch (action) {
+        case "*":
+          const X = Math.random();
+          return "* " + X;
+        case "a":
+          return "a " + X;
+      }
+    }
+    expect(() => test("a")).toThrow(
+      expect.objectContaining({
+        name: "ReferenceError",
+        message: expect.stringContaining("before initialization"),
+      }),
+    );
+  });
+
+  test("outer const is shadowed by inner const, not leaked through", () => {
+    // Matches the shape of the reported repro: an outer `CONSTANT = 1` is
+    // shadowed by a switch-scoped `const CONSTANT = 2`. Bun used to resolve
+    // the `case "a"` reference to the inlined `2`; Node and the spec require
+    // a TDZ ReferenceError because the inner binding hoists over the entire
+    // switch body.
+    const CONSTANT = 1;
+    function test(action) {
+      switch (action) {
+        case "*":
+          const CONSTANT = 2;
+          return "* " + CONSTANT;
+        case "a":
+          return "a " + CONSTANT;
+      }
+      return "outer=" + CONSTANT;
+    }
+    expect(() => test("a")).toThrow(ReferenceError);
+    expect(test("*")).toBe("* 2");
+    // Outside the switch body the outer `CONSTANT` is still visible.
+    expect(test("other")).toBe("outer=1");
+  });
+
+  test("declaration + use in the same case still works", () => {
+    function test() {
+      switch ("a") {
+        case "a": {
+          const X = 42;
+          return X;
+        }
+      }
+    }
+    expect(test()).toBe(42);
+  });
+
+  test("fall-through from declaring case still initializes binding", () => {
+    function test() {
+      switch ("a") {
+        case "a":
+          const X = 100;
+        case "b":
+          return "X=" + X;
+      }
+    }
+    expect(test()).toBe("X=100");
+  });
+});


### PR DESCRIPTION
## Summary

Every case in a switch statement shares one lexical scope but each case is entered conditionally, so a `const` declared in one case does not dominate references to that name in sibling cases. The transpiler was performing two separate inlining passes that both ignored this and silently bypassed the TDZ `ReferenceError` the spec requires.

## Repro

From #30932:

```js
'use strict';
const CONSTANT = 1;
const ACTION = 'a';

+function test() {
  switch (ACTION) {
    case '*':
      const CONSTANT = 2;
      break;
    case 'a':
      console.log('CONSTANT=' + CONSTANT);
  }
}();
```

| | Before | After | Node |
|---|---|---|---|
| output | `CONSTANT=2` | `ReferenceError: Cannot access 'CONSTANT' before initialization` | `ReferenceError: Cannot access 'CONSTANT' before initialization` |

## Root cause

Two optimizations in the visit pass were firing across switch case boundaries:

1. **const-local-prefix inlining** (`const_values`) — a leading run of `const X = literal` in a scope is recorded and every reference to `X` later in that scope is replaced with the literal. Because all switch cases share one block scope, `const CONSTANT = 2` in `case '*'` was treated as part of the prefix for the whole switch body, and `CONSTANT` in `case 'a'` was rewritten to `2`.

2. **single-use substitution** — `visit_stmts` walks a block's output and, if a `const X = expr` decl is immediately followed by its only use, inlines `expr` into the use and deletes the decl. It runs once per case body, but `use_count_estimate` is global: while visiting `case '*'` the counter has only seen `case '*'`s references, so `const X = Math.random()` followed by `return X` reads as single-use and gets inlined — and the decl is deleted out from under `case 'a'`s reference, throwing `X is not defined` instead of a TDZ error.

## Fix

- In `s_switch`, mark the switch body scope as `is_after_const_local_prefix = true` so no `const` inside any case is added to `const_values`.
- Pass `StmtsKind::SwitchStmt` when visiting each case body, and skip the single-use substitution in `visit_stmts` when `kind == SwitchStmt`.

Both `const`/`let` declarations that are declared + used **within the same case** remain unaffected (they aren't across-case references), and nested block scopes inside a case (`case 'a': { const X = 1; ... }`) are untouched — they still get their own scope and both optimizations apply as before.

## Tests

`test/bundler/transpiler/runtime-transpiler.test.ts` gains five cases covering:
- The literal-initialized const from the report (prefix-inlining bug).
- A non-foldable const (single-use-substitution bug).
- The shadowed-outer variant.
- Same-case declare+use (must still work).
- Fall-through from the declaring case (must still work).

Gate: `bun bd test test/bundler/transpiler/runtime-transpiler.test.ts` passes with the fix; the three TDZ-expecting tests fail without it.

Closes #30932
Closes #18477