### PR TITLE
fix(gc): fix three GC safety issues (speculative fix for BUN-Q81)

### DIFF
--- a/src/bun.js/bindings/JSCommonJSModule.cpp
+++ b/src/bun.js/bindings/JSCommonJSModule.cpp
@@ -1164,6 +1164,7 @@ void JSCommonJSModule::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.appendHidden(thisObject->m_dirname);
     visitor.appendHidden(thisObject->m_paths);
     visitor.appendHidden(thisObject->m_overriddenParent);
+    visitor.appendHidden(thisObject->m_overriddenCompile);
     visitor.appendHidden(thisObject->m_childrenValue);
     visitor.appendValues(thisObject->m_children.begin(), thisObject->m_children.size());
 }

--- a/src/bun.js/bindings/NodeVM.cpp
+++ b/src/bun.js/bindings/NodeVM.cpp
@@ -703,6 +703,17 @@ void NodeVMSpecialSandbox::finishCreation(VM& vm)
 
 const JSC::ClassInfo NodeVMSpecialSandbox::s_info = { "NodeVMSpecialSandbox"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(NodeVMSpecialSandbox) };
 
+template<typename Visitor>
+void NodeVMSpecialSandbox::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = jsCast<NodeVMSpecialSandbox*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+    visitor.append(thisObject->m_parentGlobal);
+}
+
+DEFINE_VISIT_CHILDREN(NodeVMSpecialSandbox);
+
 NodeVMGlobalObject::NodeVMGlobalObject(JSC::VM& vm, JSC::Structure* structure, NodeVMContextOptions contextOptions, JSValue importer)
     : Base(vm, structure, &globalObjectMethodTable())
     , m_dynamicImportCallback(vm, this, importer)

--- a/src/bun.js/bindings/NodeVM.h
+++ b/src/bun.js/bindings/NodeVM.h
@@ -85,6 +85,7 @@ public:
     static NodeVMSpecialSandbox* create(VM& vm, Structure* structure, NodeVMGlobalObject* globalObject);
 
     DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm);
     static Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype);
 

--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -2022,7 +2022,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementSetPrototypeFunction, (JSGlobalObject * l
             return {};
         }
 
-        castedThis->userPrototype.set(vm, classObject, prototype.getObject());
+        castedThis->userPrototype.set(vm, castedThis, prototype.getObject());
 
         // Force the prototypes to be re-created
         if (castedThis->version_db) {


### PR DESCRIPTION
## Speculative fix for [BUN-Q81](https://bun-p9.sentry.io/issues/BUN-Q81)

BUN-Q81 is a long-standing `SlotVisitor::drain` segfault during GC marking (150 occurrences since July 2025, across v1.1.10 through v1.3.10). A full audit of the codebase for GC safety issues found three bugs:

### 1. `JSCommonJSModule::m_overriddenCompile` not visited in `visitChildren`

`m_overriddenCompile` is a `WriteBarrier<Unknown>` that stores the overridden `module._compile` function (used by `ts-node`, `pirates`, `@swc-node/register`, etc.). It was the only WriteBarrier field in the class not visited by `visitChildrenImpl`, making it invisible to the GC. The pointed-to function could be prematurely collected, and subsequent GC marking would follow the dangling WriteBarrier pointer into freed memory.

**This is the strongest candidate for BUN-Q81.**

### 2. `JSSQLStatement::userPrototype` — wrong owner in `WriteBarrier::set()`

```cpp
// Before (wrong):
castedThis->userPrototype.set(vm, classObject, prototype.getObject());
// After (correct):
castedThis->userPrototype.set(vm, castedThis, prototype.getObject());
```

The owner parameter must be the object containing the WriteBarrier so the GC's remembered set is updated correctly. All other `.set()` calls in the same file correctly use `castedThis`.

### 3. `NodeVMSpecialSandbox` — missing `visitChildren` entirely

`NodeVMSpecialSandbox` has a `WriteBarrier<NodeVMGlobalObject> m_parentGlobal` member but had no `visitChildren` implementation. Added the standard boilerplate.