### PR TITLE
fix: release ReadableStream Strong ref on fetch body cancel

### DIFF
--- a/src/bun.js/webcore/Body.zig
+++ b/src/bun.js/webcore/Body.zig
@@ -75,6 +75,7 @@ pub const PendingValue = struct {
     onStartBuffering: ?*const fn (ctx: *anyopaque) void = null,
     onStartStreaming: ?*const fn (ctx: *anyopaque) jsc.WebCore.DrainResult = null,
     onReadableStreamAvailable: ?*const fn (ctx: *anyopaque, globalThis: *jsc.JSGlobalObject, readable: jsc.WebCore.ReadableStream) void = null,
+    onStreamCancelled: ?*const fn (ctx: ?*anyopaque) void = null,
     size_hint: Blob.SizeType = 0,
 
     deinit: bool = false,
@@ -494,6 +495,13 @@ pub const Value = union(Tag) {
                     .context = undefined,
                     .globalThis = globalThis,
                 });
+
+                if (locked.onStreamCancelled) |onCancelled| {
+                    if (locked.task) |task| {
+                        reader.cancel_handler = onCancelled;
+                        reader.cancel_ctx = task;
+                    }
+                }
 
                 reader.context.setup();
 

--- a/src/bun.js/webcore/ReadableStream.zig
+++ b/src/bun.js/webcore/ReadableStream.zig
@@ -442,6 +442,8 @@ pub fn NewSource(
         close_handler: ?*const fn (?*anyopaque) void = null,
         close_ctx: ?*anyopaque = null,
         close_jsvalue: jsc.Strong.Optional = .empty,
+        cancel_handler: ?*const fn (?*anyopaque) void = null,
+        cancel_ctx: ?*anyopaque = null,
         globalThis: *JSGlobalObject = undefined,
         this_jsvalue: jsc.JSValue = .zero,
         is_closed: bool = false,
@@ -493,6 +495,10 @@ pub fn NewSource(
 
             this.cancelled = true;
             onCancel(&this.context);
+            if (this.cancel_handler) |handler| {
+                this.cancel_handler = null;
+                handler(this.cancel_ctx);
+            }
         }
 
         pub fn onClose(this: *This) void {

--- a/test/js/web/fetch/fetch-stream-cancel-leak.test.ts
+++ b/test/js/web/fetch/fetch-stream-cancel-leak.test.ts
@@ -1,0 +1,140 @@
+import { heapStats } from "bun:jsc";
+import { expect, test } from "bun:test";
+
+// Test that ReadableStream objects from cancelled fetch responses are properly GC'd.
+//
+// When a streaming HTTP response body is cancelled mid-stream, FetchTasklet's
+// readable_stream_ref (a Strong GC root) is not released because:
+//   1. ByteStream.onCancel() doesn't notify the FetchTasklet
+//   2. The HTTP connection stays open, so has_more never becomes false
+//   3. Bun__FetchResponse_finalize sees the Strong ref and skips cleanup
+//
+// This creates a circular dependency where the Strong ref prevents GC,
+// and the GC finalizer skips cleanup because the Strong ref exists.
+
+test("ReadableStream from fetch should be GC'd after reader.cancel()", async () => {
+  // Use a raw TCP server to avoid server-side JS ReadableStream objects
+  // that would add noise to objectTypeCounts.
+  // The server sends one HTTP chunk immediately, then keeps the connection open.
+  using server = Bun.listen({
+    port: 0,
+    hostname: "127.0.0.1",
+    socket: {
+      data(socket) {
+        socket.write(
+          "HTTP/1.1 200 OK\r\n" +
+            "Transfer-Encoding: chunked\r\n" +
+            "Connection: keep-alive\r\n" +
+            "\r\n" +
+            "400\r\n" +
+            Buffer.alloc(0x400, "x").toString() +
+            "\r\n",
+        );
+        // Don't send terminal chunk "0\r\n\r\n" — keep connection open
+      },
+      open() {},
+      close() {},
+      error() {},
+    },
+  });
+
+  const url = `http://127.0.0.1:${server.port}/`;
+  const N = 30;
+
+  // Warmup: ensure JIT, lazy init, and connection pool are warmed up
+  for (let i = 0; i < 5; i++) {
+    const response = await fetch(url);
+    const reader = response.body!.getReader();
+    await reader.read();
+    await reader.cancel();
+  }
+
+  Bun.gc(true);
+  await Bun.sleep(10);
+  Bun.gc(true);
+
+  const baseline = heapStats().objectTypeCounts.ReadableStream ?? 0;
+
+  // Main test: fetch, read one chunk, cancel, repeat N times
+  for (let i = 0; i < N; i++) {
+    const response = await fetch(url);
+    const reader = response.body!.getReader();
+    await reader.read();
+    await reader.cancel();
+  }
+
+  // Allow finalizers to run, then GC aggressively
+  Bun.gc(true);
+  await Bun.sleep(50);
+  Bun.gc(true);
+  await Bun.sleep(50);
+  Bun.gc(true);
+
+  const after = heapStats().objectTypeCounts.ReadableStream ?? 0;
+  const leaked = after - baseline;
+
+  // With the bug: leaked ≈ N (each cancelled stream's Strong ref prevents GC)
+  // When fixed: leaked should be near 0 (Strong ref released on cancel)
+  expect(leaked).toBeLessThanOrEqual(5);
+});
+
+test("ReadableStream from fetch should be GC'd after body.cancel()", async () => {
+  using server = Bun.listen({
+    port: 0,
+    hostname: "127.0.0.1",
+    socket: {
+      data(socket) {
+        socket.write(
+          "HTTP/1.1 200 OK\r\n" +
+            "Transfer-Encoding: chunked\r\n" +
+            "Connection: keep-alive\r\n" +
+            "\r\n" +
+            "400\r\n" +
+            Buffer.alloc(0x400, "x").toString() +
+            "\r\n",
+        );
+      },
+      open() {},
+      close() {},
+      error() {},
+    },
+  });
+
+  const url = `http://127.0.0.1:${server.port}/`;
+  const N = 30;
+
+  // Warmup
+  for (let i = 0; i < 5; i++) {
+    const response = await fetch(url);
+    const reader = response.body!.getReader();
+    await reader.read();
+    reader.releaseLock();
+    await response.body!.cancel();
+  }
+
+  Bun.gc(true);
+  await Bun.sleep(10);
+  Bun.gc(true);
+
+  const baseline = heapStats().objectTypeCounts.ReadableStream ?? 0;
+
+  // Main test: fetch, read, releaseLock, cancel body directly
+  for (let i = 0; i < N; i++) {
+    const response = await fetch(url);
+    const reader = response.body!.getReader();
+    await reader.read();
+    reader.releaseLock();
+    await response.body!.cancel();
+  }
+
+  Bun.gc(true);
+  await Bun.sleep(50);
+  Bun.gc(true);
+  await Bun.sleep(50);
+  Bun.gc(true);
+
+  const after = heapStats().objectTypeCounts.ReadableStream ?? 0;
+  const leaked = after - baseline;
+
+  expect(leaked).toBeLessThanOrEqual(5);
+});


### PR DESCRIPTION
## Summary

When a streaming HTTP response body is cancelled via `reader.cancel()` or `body.cancel()`, `FetchTasklet.readable_stream_ref` (a `ReadableStream.Strong` GC root) was never released. This caused ReadableStream objects, associated Promises, and Uint8Array buffers to be retained indefinitely — leaking ~260KB per cancelled streaming request.

## Root Cause

`ByteStream.onCancel()` cleaned up its own state (`done = true`, buffer freed, pending promise resolved) but **did not notify the FetchTasklet**. The Strong ref was only released when:
- `has_more` became `false` (HTTP response fully received) — but the server may keep the connection open
- `Bun__FetchResponse_finalize` — but this checks `readable_stream_ref.held.has()` and **skips cleanup when the Strong ref is set** (line 958)

This created a circular dependency: the Strong ref prevented GC, and the finalizer skipped cleanup because the Strong ref existed.

## Fix

Add a `cancel_handler` callback to `NewSource` (`ReadableStream.zig`) that propagates cancel events to the data producer. `FetchTasklet` registers this callback via `Body.PendingValue.onStreamCancelled`. When the stream is cancelled, the handler calls `ignoreRemainingResponseBody()` to release the Strong ref, stop processing further HTTP data, and unref the event loop.

To prevent use-after-free when `FetchTasklet` is freed before `cancel()` is called (e.g., HTTP response completes normally, then user cancels the orphaned stream), `clearStreamCancelHandler()` nulls the `cancel_handler` on the `ByteStream.Source` at all 3 sites where `readable_stream_ref` is released.

## Test

Added `test/js/web/fetch/fetch-stream-cancel-leak.test.ts` — uses a raw TCP server (`Bun.listen`) that sends one HTTP chunk then keeps the connection open. Client fetches 30 times, reads one chunk, cancels, then asserts `heapStats().objectTypeCounts.ReadableStream` does not accumulate. Before the fix, all 30 ReadableStreams leaked; after the fix, 0 leak.