### PR TITLE
fix: correct PrismaLibSql typo in prisma.mdx

### DIFF
--- a/docs/guides/ecosystem/prisma.mdx
+++ b/docs/guides/ecosystem/prisma.mdx
@@ -102,9 +102,9 @@ mode: center
 
     	```ts prisma/db.ts icon="/icons/typescript.svg"
     	import { PrismaClient } from "./generated/client";
-    	import { PrismaLibSQL } from "@prisma/adapter-libsql";
+    	import { PrismaLibSql } from "@prisma/adapter-libsql";
 
-    	const adapter = new PrismaLibSQL({ url: process.env.DATABASE_URL || "" });
+    	const adapter = new PrismaLibSql({ url: process.env.DATABASE_URL || "" });
     	export const prisma = new PrismaClient({ adapter });
     	```
     </Step>


### PR DESCRIPTION
Fixes issue #25491 - Changed PrismaLibSQL to PrismaLibSql to match the actual export name from @prisma/adapter-libsql package.