### PR TITLE
fix(bundler): fix bundling of multiple entrypoints that include CSS file that inlines an asset

### DIFF
--- a/test/bundler/bundler_regressions.test.ts
+++ b/test/bundler/bundler_regressions.test.ts
@@ -295,4 +295,19 @@ describe("bundler", () => {
     run: true,
     capture: ["1 /* Value */", "1 /* Value */", "1 /* Value */"],
   });
+
+  // https://github.com/oven-sh/bun/issues/20278
+  itBundled("regression/EntryPointsWithCSSInlinedAssets#20278", {
+    files: {
+      "/style.css": /* css */ `
+        select {
+          background-image: url("./icon.svg");
+        }
+      `,
+      "/icon.svg": `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="m6 9 6 6 6-6"/></svg>`,
+    },
+    entryPoints: ["/style.css", "/icon.svg"],
+    outputPaths: ["/out/style.css", "/out/icon.js"],
+    outdir: "/out",
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/oven-sh/bun/issues/20278

**Fix 1**
Out of bounds access in `computeChunks.zig`. Happened because entry point bit indexes were used directly as JS chunk indexes. But CSS-inlined assets have no JS chunk, so the size of JS chunks array wasn't equal to entry bits array.

Fixed by adding an array that stores actual JS chunk index for each entry bit. CSS-only entries map to `null` and are skipped.

**Fix 2**
After fix 1, a second crash happened: `additional_files.len > 0` assertion failure in `bundle_v2.zig`. During `findReachableFiles`, there's an optimization that clears `additional_files` for file-loader assets only referenced inline in CSS. But when the asset is also an entry point, the linker still needs `additional_files` to emit the output chunk. 

Fixed by checking if a file is not an entry point

### How did you verify your code works?
Added a regression test