### PR TITLE
Add debian community repository

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -87,7 +87,14 @@ Bun ships as a single, dependency-free executable. You can install it via script
       The packages in this section provide binary installs for Bun but are not official packages within the associated distributions. These packages are maintained by community members and as such a higher level of caution should be taken when installing them.
     </Warning>
 
-    Debian and Ubuntu, visit the [debian.griffo.io](https://debian.griffo.io).
+    For Debian and Ubuntu, add the community APT repository and install:
+
+    ```bash APT icon="terminal"
+    curl -sS https://debian.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc | sudo gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/debian.griffo.io.gpg
+    echo "deb https://debian.griffo.io/apt $(lsb_release -sc 2>/dev/null) main" | sudo tee /etc/apt/sources.list.d/debian.griffo.io.list
+    sudo apt update && sudo apt install bun
+    ```
+    For more details, visit [debian.griffo.io](https://debian.griffo.io).
 
   </Tab>
 </Tabs>

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -81,6 +81,15 @@ Bun ships as a single, dependency-free executable. You can install it via script
     ```
 
   </Tab>
+
+  <Tab title="Community Packages">
+    <Warning>
+      The packages in this section provide binary installs for Bun but are not official packages within the associated distributions. These packages are maintained by community members and as such a higher level of caution should be taken when installing them.
+    </Warning>
+
+    Debian and Ubuntu, visit the [debian.griffo.io](https://debian.griffo.io).
+
+  </Tab>
 </Tabs>
 
 To check that Bun was installed successfully, open a new terminal window and run:
@@ -360,6 +369,7 @@ To remove Bun from your system:
       scoop uninstall bun
       ```
     	</CodeGroup>
+
     </Tab>
 
 </Tabs>


### PR DESCRIPTION
### What does this PR do?

Adds to the docs a section for community maintained packages

Added Debian and ubuntu repos, which I have been hosting for some time now.
Package indexes can be found as an example
https://debian.griffo.io/apt/dists/trixie/main/binary-amd64/Packages

You can see zed is one of the most downloaded package this month so far
<img width="809" height="647" alt="image" src="https://github.com/user-attachments/assets/3dcb225d-15d1-4314-a0af-4518f58cf207" />
