### PR TITLE
fix(sqlite): finalize transaction statements on `close()` to prevent "database is locked"

### DIFF
--- a/test/regression/issue/14709.test.ts
+++ b/test/regression/issue/14709.test.ts
@@ -1,0 +1,51 @@
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+
+test("db.close(true) works after db.transaction()", () => {
+  const db = new Database(":memory:");
+  db.transaction(() => {})();
+  expect(() => db.close(true)).not.toThrow();
+});
+
+test("db.close(true) works after db.transaction() with actual work", () => {
+  const db = new Database(":memory:");
+  db.run("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)");
+  const insert = db.transaction((items: string[]) => {
+    const stmt = db.query("INSERT INTO test (value) VALUES (?)");
+    for (const item of items) {
+      stmt.run(item);
+    }
+  });
+  insert(["a", "b", "c"]);
+  expect(db.query("SELECT COUNT(*) as count FROM test").get()).toEqual({ count: 3 });
+  expect(() => db.close(true)).not.toThrow();
+});
+
+test("using declaration works with db.transaction()", () => {
+  using db = new Database(":memory:");
+  db.transaction(() => {})();
+  // Symbol.dispose calls close(true), should not throw
+});
+
+test("db.close(true) works after multiple transaction types", () => {
+  const db = new Database(":memory:");
+  db.transaction(() => {})();
+  db.transaction(() => {}).deferred();
+  db.transaction(() => {}).immediate();
+  db.transaction(() => {}).exclusive();
+  expect(() => db.close(true)).not.toThrow();
+});
+
+test("db.close(true) works after nested transactions", () => {
+  const db = new Database(":memory:");
+  db.run("CREATE TABLE test (id INTEGER PRIMARY KEY)");
+  const outer = db.transaction(() => {
+    db.run("INSERT INTO test (id) VALUES (1)");
+    const inner = db.transaction(() => {
+      db.run("INSERT INTO test (id) VALUES (2)");
+    });
+    inner();
+  });
+  outer();
+  expect(() => db.close(true)).not.toThrow();
+});


### PR DESCRIPTION
## Summary

- Fixes `db.close(true)` throwing "database is locked" after using `db.transaction()`
- The `getController` function creates prepared statements via `db.prepare()` which bypasses the query cache, so they were never finalized during `close()`
- `close()` now explicitly finalizes any cached transaction controller statements before calling `sqlite3_close()`

Fixes #14709

## Test plan

- [x] New regression tests in `test/regression/issue/14709.test.ts` covering:
  - Basic `close(true)` after `transaction()`
  - `close(true)` after transaction with actual work
  - `using` declaration (calls `close(true)` via `Symbol.dispose`)
  - Multiple transaction types (deferred, immediate, exclusive)
  - Nested transactions
- [x] All new tests fail with system bun (`USE_SYSTEM_BUN=1`) and pass with debug build
- [x] Existing SQLite test suite (`test/js/bun/sqlite/sqlite.test.js`) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)