### PR TITLE
fix: don't invoke user-defined prototype methods in primordials makeSafe

### DIFF
--- a/test/regression/issue/18890.test.ts
+++ b/test/regression/issue/18890.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/18890
+// Adding functions to Set/Map/WeakSet/WeakMap prototypes before import('fs')
+// should not cause those functions to be invoked by Bun's internal primordials.
+
+test("import('fs') does not invoke user-defined Set.prototype methods", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "Set.prototype.hi = function () { throw 'hi' }; await import('fs')"],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("error: hi");
+  expect(exitCode).toBe(0);
+});
+
+test("import('fs') does not invoke user-defined Map.prototype methods", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "Map.prototype.hi = function () { throw 'hi' }; await import('fs')"],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("error: hi");
+  expect(exitCode).toBe(0);
+});
+
+test("static import with prototype pollution does not throw", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "Set.prototype.hi = function () { throw 'hi' }; require('fs'); import fs from 'fs'"],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("error: hi");
+  expect(exitCode).toBe(0);
+});
+
+test("fs module works correctly after prototype pollution", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      "Set.prototype.hi = function () { throw 'hi' }; const fs = await import('fs'); console.log(typeof fs.readFileSync)",
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("function");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fixes `import('fs')` (and other dynamic imports) invoking user-defined zero-argument functions on `Set.prototype`, `Map.prototype`, etc.
- The `makeSafe` function in `primordials.js` was dynamically probing all own keys of `Set.prototype`/`Map.prototype` by **calling** every zero-arg function to check if it returns an iterator. When user code added functions to these prototypes before the lazy primordials initialization, those functions were invoked unexpectedly.
- Fix: hardcode the known iterator-returning method names (`entries`, `keys`, `values`, `Symbol.iterator`) instead of dynamically probing all prototype methods.

Closes #18890

## Test plan
- [x] Added regression test in `test/regression/issue/18890.test.ts`
- [x] Verified tests fail with system Bun (4/4 fail) and pass with debug build (4/4 pass)
- [x] Tested all reproduction cases from the issue:
  - `Set.prototype.hi = function () { throw 'hi' }; await import('fs')` — no longer throws
  - `Map.prototype.hi = function () { throw 'hi' }; await import('fs')` — no longer throws
  - Static import + require + prototype override — no longer throws
  - `fs` module functionality works correctly after prototype pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)