### PR TITLE
fix(node:http): emit close event on ServerResponse when socket closes

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -904,6 +904,11 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
         req.destroy();
       }
     }
+
+    // Emit "close" on the ServerResponse (httpMessage) via the close callback
+    // set in assignSocketInternal. This ensures the response's "close" event
+    // fires when the underlying socket is closed (e.g. client disconnect).
+    callCloseCallback(this);
   }
   #onCloseForDestroy(closeCallback) {
     this.#onClose();

--- a/test/regression/issue/14697.test.ts
+++ b/test/regression/issue/14697.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "bun:test";
+import { createServer } from "node:http";
+
+test("ServerResponse emits close event on client disconnect", async () => {
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  let requestClosed = false;
+  let responseClosed = false;
+
+  const server = createServer((req, res) => {
+    req.once("close", () => {
+      requestClosed = true;
+    });
+
+    res.once("close", () => {
+      responseClosed = true;
+      resolve();
+    });
+
+    // Don't end the response — wait for the client to disconnect.
+  });
+
+  server.listen(0, async () => {
+    const port = server.address()!.port;
+
+    try {
+      // Connect and immediately abort to simulate client disconnect
+      const controller = new AbortController();
+      fetch(`http://localhost:${port}`, { signal: controller.signal }).catch(() => {});
+      // Give the server a moment to receive the request before aborting
+      await Bun.sleep(50);
+      controller.abort();
+
+      // Wait for the close event on the response
+      await promise;
+
+      expect(requestClosed).toBe(true);
+      expect(responseClosed).toBe(true);
+    } finally {
+      server.close();
+    }
+  });
+
+  // Timeout safety: reject if close event never fires
+  await Promise.race([
+    promise,
+    new Promise<void>((_, rej) => setTimeout(() => rej(new Error("Timed out waiting for response close event")), 5000)),
+  ]);
+});
+
+test("ServerResponse emits close event on normal response end", async () => {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  let responseClosed = false;
+
+  const server = createServer((req, res) => {
+    res.once("close", () => {
+      responseClosed = true;
+      resolve();
+    });
+
+    res.end("hello");
+  });
+
+  server.listen(0, async () => {
+    const port = server.address()!.port;
+
+    try {
+      const resp = await fetch(`http://localhost:${port}`);
+      const text = await resp.text();
+      expect(text).toBe("hello");
+
+      await promise;
+      expect(responseClosed).toBe(true);
+    } finally {
+      server.close();
+    }
+  });
+
+  await Promise.race([
+    promise,
+    new Promise<void>((_, rej) => setTimeout(() => rej(new Error("Timed out waiting for response close event")), 5000)),
+  ]);
+});


### PR DESCRIPTION
## Summary

- Fixes `ServerResponse` not emitting the `"close"` event when the underlying socket closes (e.g. on client disconnect)
- Added `callCloseCallback(this)` at the end of `NodeHTTPServerSocket#onClose()` to invoke the close callback set in `assignSocketInternal`, which emits `"close"` on the response
- This matches Node.js behavior where both `req` and `res` emit `"close"`

Closes #14697

## Test plan

- [x] Added regression test `test/regression/issue/14697.test.ts` with two cases:
  - `ServerResponse emits close event on client disconnect` — verifies `res.once("close", ...)` fires when client aborts
  - `ServerResponse emits close event on normal response end` — verifies `res.once("close", ...)` fires after `res.end()`
- [x] Test fails with system bun (`USE_SYSTEM_BUN=1`) — times out waiting for close event
- [x] Test passes with debug build (`bun bd test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)