### PR TITLE
fix: call cancel callback on "direct" ReadableStream cancel

### DIFF
--- a/test/regression/issue/18315.test.ts
+++ b/test/regression/issue/18315.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test";
+
+test("cancel callback of 'direct' readable stream is called (lazy, never read)", async () => {
+  let cancelled = false;
+  let cancelReason: unknown;
+  const sourceStream = new ReadableStream({
+    type: "direct",
+    pull() {},
+    cancel(reason) {
+      cancelled = true;
+      cancelReason = reason;
+    },
+  });
+
+  const reason = new Error("test cancel");
+  await sourceStream.cancel(reason);
+
+  expect(cancelled).toBe(true);
+  expect(cancelReason).toBe(reason);
+});
+
+test("cancel callback of 'direct' readable stream is called (after reading)", async () => {
+  let cancelled = false;
+  let cancelReason: unknown;
+  const sourceStream = new ReadableStream({
+    type: "direct",
+    async pull(controller) {
+      controller.write("hello");
+      controller.flush();
+      // Keep the stream open so it can be cancelled
+      await new Promise(() => {});
+    },
+    cancel(reason) {
+      cancelled = true;
+      cancelReason = reason;
+    },
+  });
+
+  const reader = sourceStream.getReader();
+  // Read one chunk to trigger controller initialization
+  const chunk = await reader.read();
+  expect(chunk.done).toBe(false);
+
+  const reason = new Error("test cancel");
+  await reader.cancel(reason);
+
+  expect(cancelled).toBe(true);
+  expect(cancelReason).toBe(reason);
+});
+
+test("cancel callback of 'direct' readable stream works with async cancel", async () => {
+  let cancelled = false;
+  const sourceStream = new ReadableStream({
+    type: "direct",
+    pull() {},
+    async cancel() {
+      await Bun.sleep(1);
+      cancelled = true;
+    },
+  });
+
+  await sourceStream.cancel();
+
+  expect(cancelled).toBe(true);
+});
+
+test("cancel callback of 'direct' readable stream without cancel callback doesn't throw", async () => {
+  const sourceStream = new ReadableStream({
+    type: "direct",
+    pull() {},
+  });
+
+  // Should not throw
+  await sourceStream.cancel();
+});


### PR DESCRIPTION
## Summary
- When a `type: "direct"` ReadableStream's `.cancel()` method was called, the user-provided `cancel` callback was never invoked
- Fixed two distinct failure paths: lazy streams (controller never created) and initialized streams (controller missing `$cancel` property)
- Added `onCancelDirectStream` handler and wired it into both direct stream controller types

## Test plan
- [x] Added regression tests in `test/regression/issue/18315.test.ts` covering:
  - Cancel callback invoked on lazy direct stream (never read from)
  - Cancel callback invoked on initialized direct stream (after reading)
  - Async cancel callbacks complete before `.cancel()` resolves
  - Streams without cancel callbacks don't throw
- [x] Verified tests fail with `USE_SYSTEM_BUN=1` (3/4 fail) and pass with `bun bd test` (4/4 pass)
- [x] Existing stream tests pass (`streams.test.js`, `serve-direct-readable-stream.test.ts`)

Closes #18315

🤖 Generated with [Claude Code](https://claude.com/claude-code)