### PR TITLE
fix(webcore): close reader when sliced Bun.file stream reaches max_size

### DIFF
--- a/src/runtime/webcore/FileReader.zig
+++ b/src/runtime/webcore/FileReader.zig
@@ -320,14 +320,23 @@ pub fn onReadChunk(this: *@This(), init_buf: []const u8, state: bun.io.ReadState
 
     if (buf.len > 0) {
         if (this.max_size) |max_size| {
-            if (this.total_readed >= max_size) return false;
+            if (this.total_readed >= max_size) {
+                // We already delivered `max_size` bytes on a previous chunk.
+                // Close the reader so `isDone()` becomes true; otherwise
+                // `onPull` will return `.pending` forever for non-pollable
+                // regular files.
+                close = true;
+                return false;
+            }
             const len = @min(max_size - this.total_readed, buf.len);
             if (buf.len > len) {
                 buf = buf[0..len];
             }
             this.total_readed += len;
 
-            if (buf.len == 0) {
+            if (this.total_readed >= max_size) {
+                // This chunk satisfies the slice; treat it as the final one
+                // and close the reader after delivering it.
                 close = true;
                 hasMore = false;
             }
@@ -391,7 +400,7 @@ pub fn onReadChunk(this: *@This(), init_buf: []const u8, state: bun.io.ReadState
             return false;
         }
 
-        const was_done = this.reader.isDone();
+        const was_done = this.reader.isDone() or close;
 
         if (this.pending_view.len >= buf.len) {
             @memcpy(this.pending_view[0..buf.len], buf);
@@ -411,7 +420,7 @@ pub fn onReadChunk(this: *@This(), init_buf: []const u8, state: bun.io.ReadState
         }
 
         if (bun.isSliceInBuffer(buf, reader_buffer.allocatedSlice())) {
-            if (this.reader.isDone()) {
+            if (was_done) {
                 bun.assert_eql(buf.ptr, reader_buffer.items.ptr);
                 var buffer = reader_buffer.moveToUnmanaged();
                 buffer.shrinkRetainingCapacity(buf.len);
@@ -424,7 +433,7 @@ pub fn onReadChunk(this: *@This(), init_buf: []const u8, state: bun.io.ReadState
         }
 
         if (!bun.isSliceInBuffer(buf, this.buffered.allocatedSlice())) {
-            this.pending.result = if (this.reader.isDone())
+            this.pending.result = if (was_done)
                 .{ .temporary_and_done = .fromBorrowedSliceDangerous(buf) }
             else
                 .{ .temporary = .fromBorrowedSliceDangerous(buf) };
@@ -436,7 +445,7 @@ pub fn onReadChunk(this: *@This(), init_buf: []const u8, state: bun.io.ReadState
         this.buffered = .{};
         buffered.shrinkRetainingCapacity(buf.len);
 
-        this.pending.result = if (this.reader.isDone())
+        this.pending.result = if (was_done)
             .{ .owned_and_done = .moveFromList(&buffered) }
         else
             .{ .owned = .moveFromList(&buffered) };
@@ -447,6 +456,11 @@ pub fn onReadChunk(this: *@This(), init_buf: []const u8, state: bun.io.ReadState
             reader_buffer.clearRetainingCapacity();
         }
     }
+
+    // When `close` is set we've just scheduled `this.reader.close()` via the
+    // defer above; returning true here would let the low-level read loop
+    // issue another read against the now-closed fd.
+    if (close) return false;
 
     // For pipes, we have to keep pulling or the other process will block.
     return this.read_inside_on_pull != .temporary and

--- a/test/regression/issue/18192.test.ts
+++ b/test/regression/issue/18192.test.ts
@@ -1,0 +1,86 @@
+// https://github.com/oven-sh/bun/issues/18192
+// Bun.file(path).slice(...).stream() would hang forever when the underlying
+// file was larger than 640 KiB, because FileReader.onReadChunk() stopped
+// asking for more data once max_size was reached but never closed the
+// underlying reader — leaving isDone() == false and the next onPull()
+// parked on a pending promise that nothing would ever resolve (regular
+// files are not pollable).
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe.concurrent("#18192 Bun.file().slice().stream() on large files", () => {
+  for (const fileSize of [512 * 1024, 640 * 1024, 640 * 1024 + 1, 768 * 1024, 2 * 1024 * 1024]) {
+    test(`slice(0, 1) on a ${fileSize}-byte file does not hang`, async () => {
+      using dir = tempDir("issue-18192", {
+        "run.js": `
+          import { writeFileSync } from "fs";
+          writeFileSync("data", Buffer.alloc(${fileSize}, 0x41));
+          const text = await Bun.readableStreamToText(Bun.file("data").slice(0, 1).stream());
+          console.log(JSON.stringify({ len: text.length, first: text }));
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe(JSON.stringify({ len: 1, first: "A" }));
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  test("slice(start, end) on a large file yields the correct bytes", async () => {
+    using dir = tempDir("issue-18192", {
+      "run.js": `
+        import { writeFileSync } from "fs";
+        const size = 1024 * 1024;
+        const buf = Buffer.alloc(size);
+        for (let i = 0; i < size; i++) buf[i] = i % 256;
+        writeFileSync("data", buf);
+
+        for (const [start, end] of [[0, 1], [5, 10], [300_000, 300_005], [0, 300_000], [700_000, 700_001]]) {
+          const chunks = [];
+          for await (const chunk of Bun.file("data").slice(start, end).stream()) {
+            chunks.push(chunk);
+          }
+          const got = Buffer.concat(chunks);
+          const want = buf.subarray(start, end);
+          if (!got.equals(want)) {
+            console.log("FAIL", start, end, "got", got.length, "bytes, want", want.length);
+            process.exit(1);
+          }
+        }
+        console.log("OK");
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/regression/issue/18192.test.ts
+++ b/test/regression/issue/18192.test.ts
@@ -28,11 +28,7 @@ describe.concurrent("#18192 Bun.file().slice().stream() on large files", () => {
         stderr: "pipe",
       });
 
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stderr).toBe("");
       expect(stdout.trim()).toBe(JSON.stringify({ len: 1, first: "A" }));
@@ -73,11 +69,7 @@ describe.concurrent("#18192 Bun.file().slice().stream() on large files", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).toBe("");
     expect(stdout.trim()).toBe("OK");


### PR DESCRIPTION
## What

`Bun.file(path).slice(start, end).stream()` hangs forever when the underlying file is larger than 640 KiB.

```js
import { writeFileSync } from "fs";
writeFileSync("zeroes", Buffer.alloc(768 * 1024));
await Bun.readableStreamToText(Bun.file("zeroes").slice(0, 1).stream()); // never resolves
```

Fixes #18192

## Why

`FileReader.onReadChunk()` tracks `max_size` for sliced file blobs. When `total_readed >= max_size` it returned `false` to stop the low-level read loop, but never closed the underlying `BufferedReader`. That leaves `reader.isDone() == false`, so the next `onPull()` returns `.pending` — and since regular files are not pollable, nothing ever resolves that pending promise.

The separate `if (buf.len == 0)` check meant to close the reader was dead code: at that point `buf` has been truncated to `@min(max_size - total_readed, buf.len)` where both operands are `>= 1`.

The 640 KiB threshold comes from `PipeReader`'s 256 KiB `pipeReadBuffer` and its 128 KiB flush cutoff: the second `onPull` starts reading at offset 512 KiB, and if more than 128 KiB remain before EOF, `onReadChunk` is called with `.progress` (hitting the broken early return) instead of reaching the EOF path that would mark the reader done.

## How

In `FileReader.onReadChunk()`:

- Set `close = true` on the `total_readed >= max_size` early return so the deferred `reader.close()` actually runs.
- Replace the dead `buf.len == 0` check with `total_readed >= max_size` so the chunk that satisfies the slice is delivered as the final one (`close = true; hasMore = false`).
- Fold `close` into `was_done` so the async/pending path (Windows file reads, pipes) delivers `*_and_done` and returns `false` instead of continuing to read from a closed fd.
- Return `false` at the end of the function when `close` is set, so the synchronous POSIX read loop does not issue another `pread` against the now-closed fd.

As a side effect the reader now stops after the first chunk that satisfies `max_size` instead of reading (and discarding) the rest of the file.

## Verification

- `bun bd test test/regression/issue/18192.test.ts` → 6 pass
- `USE_SYSTEM_BUN=1 bun test test/regression/issue/18192.test.ts` → 4 fail (hang on every file > 640 KiB)
- `bun bd test test/js/web/fetch/blob.test.ts test/js/bun/util/bun-file-fd-read.test.ts` → all pass
- `bun run zig:check-all` → all targets compile
