### PR TITLE
fix: ignore SIGTTIN/SIGTTOU to prevent Bun from stopping when child takes terminal foreground

### DIFF
--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -515,6 +515,15 @@ extern "C" void bun_initialize_process()
         close(devNullFd_);
     }
 
+    // Ignore SIGTTIN and SIGTTOU to prevent Bun from being suspended when
+    // a child process (e.g. `bash -ci`) takes foreground control of the
+    // terminal via tcsetpgrp(). Without this, Bun gets stopped by the
+    // kernel when it attempts terminal I/O while in a background process
+    // group. This matches how shells handle job control.
+    // See: https://github.com/oven-sh/bun/issues/17500
+    signal(SIGTTIN, SIG_IGN);
+    signal(SIGTTOU, SIG_IGN);
+
     // Restore TTY state on exit
     if (anyTTYs) {
         struct sigaction sa;

--- a/test/regression/issue/17500.test.ts
+++ b/test/regression/issue/17500.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("Bun.spawn with bash -ci does not hang or stop the process", async () => {
+  // Spawn a bun process that runs bash -ci multiple times.
+  // Before the fix, the parent bun process could be stopped by SIGTTIN/SIGTTOU
+  // when bash -ci takes foreground control of the terminal via tcsetpgrp().
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      for (let i = 0; i < 3; i++) {
+        const child = Bun.spawn(["bash", "-ci", "echo iteration" + i], {
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([
+          new Response(child.stdout).text(),
+          new Response(child.stderr).text(),
+          child.exited,
+        ]);
+        console.log(stdout.trim());
+      }
+      console.log("done");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  let timeout = false;
+  const timer = setTimeout(() => {
+    timeout = true;
+    proc.kill();
+  }, 10000);
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  clearTimeout(timer);
+
+  expect(timeout).toBeFalse();
+  expect(stdout).toContain("iteration0");
+  expect(stdout).toContain("iteration1");
+  expect(stdout).toContain("iteration2");
+  expect(stdout).toContain("done");
+  expect(exitCode).toBe(0);
+});
+
+test("SIGTTIN and SIGTTOU signals do not stop the process", async () => {
+  // Verify that Bun ignores SIGTTIN and SIGTTOU by sending them to itself.
+  // Before the fix, these signals would use the default handler (stop the process).
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const os = require("os");
+      // Send SIGTTIN to self - should be ignored
+      process.kill(process.pid, os.constants.signals.SIGTTIN);
+      // Send SIGTTOU to self - should be ignored
+      process.kill(process.pid, os.constants.signals.SIGTTOU);
+      // If we reach here, the signals were properly ignored
+      console.log("signals ignored successfully");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  let timeout = false;
+  const timer = setTimeout(() => {
+    timeout = true;
+    proc.kill();
+  }, 5000);
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  clearTimeout(timer);
+
+  expect(timeout).toBeFalse();
+  expect(stdout.trim()).toBe("signals ignored successfully");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fixes `Bun.spawn` with `bash -ci` (interactive shell) causing Bun to be stopped/suspended
- Ignores `SIGTTIN` and `SIGTTOU` signals during process initialization, matching how shells handle job control
- Added regression test that verifies the signals are properly ignored

## Root Cause

When a child process spawned via `Bun.spawn` runs an interactive shell (e.g. `bash -ci "ffprobe ..."`), bash calls `tcsetpgrp()` to become the foreground process group. This puts Bun in a background process group. Any subsequent terminal I/O by Bun causes the kernel to send `SIGTTIN` (for reads) or `SIGTTOU` (for writes), whose default action is to **stop** the process — matching the reported symptom: `[28]+ Stopped bun main.ts`.

## Fix

Added `signal(SIGTTIN, SIG_IGN)` and `signal(SIGTTOU, SIG_IGN)` in `bun_initialize_process()`. This is the same approach that shell implementations (bash, zsh) use when managing child processes. The signals are ignored unconditionally (not just when TTYs are present) because a child can still call `tcsetpgrp()` if there's any controlling terminal for the session.

## Test plan

- [x] `bun bd test test/regression/issue/17500.test.ts` — 2/2 tests pass
- [x] `USE_SYSTEM_BUN=1 bun test test/regression/issue/17500.test.ts` — 1 test fails (confirming the test catches the bug)
- [x] Verified directly that `process.kill(process.pid, SIGTTIN)` and `process.kill(process.pid, SIGTTOU)` no longer stop the process

Closes https://github.com/oven-sh/bun/issues/17500

🤖 Generated with [Claude Code](https://claude.com/claude-code)