### PR TITLE
fix: send well-known HTTP headers in lowercase instead of title-case

### DIFF
--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -538,7 +538,7 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
 
     for (const auto& header : internalHeaders.commonHeaders()) {
 
-        const auto& name = WebCore::httpHeaderNameString(header.key);
+        const auto& name = WTF::httpHeaderNameStringImpl(header.key);
         const auto& value = header.value;
 
         // We have to tell uWS not to automatically insert a TransferEncoding or Date header.

--- a/test/regression/issue/15578.test.ts
+++ b/test/regression/issue/15578.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "bun:test";
+
+// Regression test for https://github.com/oven-sh/bun/issues/15578
+// Well-known HTTP headers should be sent lowercase (matching Node.js behavior),
+// not title-cased.
+
+test("node:http server sends well-known headers in lowercase", async () => {
+  const { createServer } = await import("node:http");
+
+  const server = createServer((req, res) => {
+    res.setHeader("location", "http://test.com");
+    res.setHeader("content-type", "text/plain");
+    res.setHeader("cache-control", "no-cache");
+    res.setHeader("x-custom-header", "custom-value");
+    res.end("ok");
+  });
+
+  server.listen(0);
+  const port = (server.address() as any).port;
+
+  try {
+    const response = await fetch(`http://localhost:${port}/`);
+    const text = await response.text();
+    expect(text).toBe("ok");
+
+    // Verify well-known headers are lowercase by inspecting raw headers
+    // response.headers normalizes casing, so we need to check the raw response
+    // Using a raw TCP connection to inspect actual header casing
+    const { connect } = await import("node:net");
+
+    const rawResponse = await new Promise<string>((resolve, reject) => {
+      const client = connect(port, "127.0.0.1", () => {
+        client.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+      });
+      let data = "";
+      client.on("data", chunk => {
+        data += chunk.toString();
+      });
+      client.on("end", () => {
+        resolve(data);
+      });
+      client.on("error", reject);
+    });
+
+    // The raw HTTP response should contain lowercase header names
+    expect(rawResponse).toContain("location: http://test.com");
+    expect(rawResponse).toContain("content-type: text/plain");
+    expect(rawResponse).toContain("cache-control: no-cache");
+    expect(rawResponse).toContain("x-custom-header: custom-value");
+
+    // Should NOT contain title-cased versions
+    expect(rawResponse).not.toContain("Location:");
+    expect(rawResponse).not.toContain("Content-Type:");
+    expect(rawResponse).not.toContain("Cache-Control:");
+  } finally {
+    server.close();
+  }
+});
+
+test("Bun.serve sends well-known headers in lowercase", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      return new Response("ok", {
+        headers: {
+          "location": "http://test.com",
+          "content-type": "text/plain",
+          "cache-control": "no-cache",
+          "x-custom-header": "custom-value",
+        },
+      });
+    },
+  });
+
+  const { connect } = await import("node:net");
+
+  const rawResponse = await new Promise<string>((resolve, reject) => {
+    const client = connect(server.port, "127.0.0.1", () => {
+      client.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    });
+    let data = "";
+    client.on("data", chunk => {
+      data += chunk.toString();
+    });
+    client.on("end", () => {
+      resolve(data);
+    });
+    client.on("error", reject);
+  });
+
+  // The raw HTTP response should contain lowercase header names
+  expect(rawResponse).toContain("location: http://test.com");
+  expect(rawResponse).toContain("content-type: text/plain");
+  expect(rawResponse).toContain("cache-control: no-cache");
+  expect(rawResponse).toContain("x-custom-header: custom-value");
+
+  // Should NOT contain title-cased versions
+  expect(rawResponse).not.toContain("Location:");
+  expect(rawResponse).not.toContain("Content-Type:");
+  expect(rawResponse).not.toContain("Cache-Control:");
+});


### PR DESCRIPTION
## Summary
- Well-known HTTP headers (e.g., `content-type`, `location`, `cache-control`) were being sent with title-case names (`Content-Type`, `Location`, `Cache-Control`) in HTTP responses from both `node:http` and `Bun.serve()`.
- Changed `writeFetchHeadersToUWSResponse` in `NodeHTTP.cpp` to use `httpHeaderNameStringImpl` (lowercase) instead of `httpHeaderNameString` (title-case) when writing common header names. This is a one-line fix.
- This matches Node.js behavior and is more compatible with HTTP/2, which requires lowercase header field names per RFC 7540.

Closes #15578

## Test plan
- [x] Added regression test `test/regression/issue/15578.test.ts` that verifies raw HTTP responses contain lowercase header names for both `node:http` and `Bun.serve()`
- [x] Verified test fails with system bun (`USE_SYSTEM_BUN=1`) and passes with debug build
- [x] Ran existing test suites (`bun-serve-headers`, `bun-serve-file`, `bun-serve-date`, `node-http`, `node-http-transfer-encoding`, `bun-serve-static`) — all pass (pre-existing failures are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)