### PR TITLE
fix(HTMLRewriter): support transforming Responses from ReadableStreams

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3588,6 +3588,10 @@ GlobalObject::PromiseFunctions GlobalObject::promiseHandlerID(Zig::FFIFunction h
         return GlobalObject::PromiseFunctions::Bun__FileSink__onResolveStream;
     } else if (handler == Bun__FileSink__onRejectStream) {
         return GlobalObject::PromiseFunctions::Bun__FileSink__onRejectStream;
+    } else if (handler == Bun__BodyValueBufferer__onResolveStreamToArrayBuffer) {
+        return GlobalObject::PromiseFunctions::Bun__BodyValueBufferer__onResolveStreamToArrayBuffer;
+    } else if (handler == Bun__BodyValueBufferer__onRejectStreamToArrayBuffer) {
+        return GlobalObject::PromiseFunctions::Bun__BodyValueBufferer__onRejectStreamToArrayBuffer;
     } else {
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -389,8 +389,10 @@ public:
         Bun__FileStreamWrapper__onResolveRequestStream,
         Bun__FileSink__onResolveStream,
         Bun__FileSink__onRejectStream,
+        Bun__BodyValueBufferer__onResolveStreamToArrayBuffer,
+        Bun__BodyValueBufferer__onRejectStreamToArrayBuffer,
     };
-    static constexpr size_t promiseFunctionsSize = 36;
+    static constexpr size_t promiseFunctionsSize = 38;
 
     static PromiseFunctions promiseHandlerID(SYSV_ABI EncodedJSValue (*handler)(JSC::JSGlobalObject* arg0, JSC::CallFrame* arg1));
 

--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -741,6 +741,8 @@ BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugTLS__onResolveStream);
 
 BUN_DECLARE_HOST_FUNCTION(Bun__BodyValueBufferer__onRejectStream);
 BUN_DECLARE_HOST_FUNCTION(Bun__BodyValueBufferer__onResolveStream);
+BUN_DECLARE_HOST_FUNCTION(Bun__BodyValueBufferer__onResolveStreamToArrayBuffer);
+BUN_DECLARE_HOST_FUNCTION(Bun__BodyValueBufferer__onRejectStreamToArrayBuffer);
 
 #endif
 

--- a/test/regression/issue/11758.test.ts
+++ b/test/regression/issue/11758.test.ts
@@ -1,0 +1,131 @@
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/11758
+// HTMLRewriter should be able to transform Responses created from ReadableStreams
+
+test("HTMLRewriter transforms Response from ReadableStream", async () => {
+  const rewriter = new HTMLRewriter();
+  rewriter.on("b", {
+    element(element) {
+      element.before("<h1>", { html: true });
+      element.after("</h1>", { html: true });
+      element.removeAndKeepContent();
+    },
+  });
+
+  const response = rewriter.transform(
+    new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("<b>hello world</b>"));
+          controller.close();
+        },
+      }),
+      { headers: { "content-type": "text/html" } },
+    ),
+  );
+
+  const text = await response.text();
+  expect(text).toBe("<h1>hello world</h1>");
+});
+
+test("HTMLRewriter transforms Response from ReadableStream with multiple chunks", async () => {
+  const rewriter = new HTMLRewriter();
+  rewriter.on("p", {
+    element(element) {
+      element.setAttribute("class", "modified");
+    },
+  });
+
+  const response = rewriter.transform(
+    new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("<p>chunk one</p>"));
+          controller.enqueue(new TextEncoder().encode("<p>chunk two</p>"));
+          controller.close();
+        },
+      }),
+      { headers: { "content-type": "text/html" } },
+    ),
+  );
+
+  const text = await response.text();
+  expect(text).toBe('<p class="modified">chunk one</p><p class="modified">chunk two</p>');
+});
+
+test("HTMLRewriter transforms Response from async ReadableStream", async () => {
+  const rewriter = new HTMLRewriter();
+  rewriter.on("span", {
+    element(element) {
+      element.setInnerContent("replaced");
+    },
+  });
+
+  const response = rewriter.transform(
+    new Response(
+      new ReadableStream({
+        async start(controller) {
+          controller.enqueue(new TextEncoder().encode("<div><span>original</span></div>"));
+          controller.close();
+        },
+      }),
+      { headers: { "content-type": "text/html" } },
+    ),
+  );
+
+  const text = await response.text();
+  expect(text).toBe("<div><span>replaced</span></div>");
+});
+
+test("HTMLRewriter transforms Response from ReadableStream with pull", async () => {
+  const rewriter = new HTMLRewriter();
+  rewriter.on("em", {
+    element(element) {
+      element.tagName = "strong";
+    },
+  });
+
+  let pullCount = 0;
+  const response = rewriter.transform(
+    new Response(
+      new ReadableStream({
+        pull(controller) {
+          if (pullCount === 0) {
+            controller.enqueue(new TextEncoder().encode("<em>emphasis</em>"));
+            pullCount++;
+          } else {
+            controller.close();
+          }
+        },
+      }),
+      { headers: { "content-type": "text/html" } },
+    ),
+  );
+
+  const text = await response.text();
+  expect(text).toBe("<strong>emphasis</strong>");
+});
+
+test("HTMLRewriter handles empty ReadableStream", async () => {
+  const rewriter = new HTMLRewriter();
+  rewriter.on("b", {
+    element(element) {
+      element.remove();
+    },
+  });
+
+  const response = rewriter.transform(
+    new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+      { headers: { "content-type": "text/html" } },
+    ),
+  );
+
+  const text = await response.text();
+  expect(text).toBe("");
+});


### PR DESCRIPTION
## Summary

- Fix `HTMLRewriter.transform()` failing with `ERR_STREAM_CANNOT_PIPE` when the Response body is a user-constructed `ReadableStream`
- Add `bufferJSReadableStream()` to consume JavaScript/Direct ReadableStreams via `readableStreamToArrayBuffer()`, then deliver the buffered bytes to HTMLRewriter for processing

Closes #11758

## Root Cause

In `Body.zig`'s `BodyValueBufferer`, the `bufferLockedBodyValue` function returned `error.UnsupportedStreamType` for `.JavaScript` and `.Direct` stream types (with a comment "this is broken right now"). This meant any Response created from `new ReadableStream({...})` could not be transformed by HTMLRewriter.

## Fix

Instead of the broken `createJSSink` approach that was commented out, the fix uses the existing `readableStreamToArrayBuffer()` JavaScript-level API to consume the stream. This API already works correctly for `Response.text()` and similar methods. The resolved ArrayBuffer bytes are then delivered to `onFinishedBuffering` to proceed with HTML rewriting.

## Test plan

- [x] New regression test `test/regression/issue/11758.test.ts` with 5 test cases:
  - Basic ReadableStream transform
  - Multiple chunks
  - Async ReadableStream
  - Pull-based ReadableStream
  - Empty ReadableStream
- [x] All existing HTMLRewriter tests pass (`html-rewriter.test.js`, `html-rewriter-doctype.test.ts`, `htmlrewriter-additional-bugs.test.ts`)
- [x] Tests fail with system bun (`USE_SYSTEM_BUN=1`) and pass with debug build

🤖 Generated with [Claude Code](https://claude.com/claude-code)