### PR TITLE
fix: support BYOB readers on native ReadableStreams

### DIFF
--- a/test/regression/issue/12908.test.ts
+++ b/test/regression/issue/12908.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/12908
+// BYOB reader on native ReadableStreams (req.body, fetch().body, Blob.stream(), Bun.file().stream())
+// threw "ReadableStreamBYOBReader needs a ReadableByteStreamController"
+
+test("req.body supports BYOB reader in Bun.serve", async () => {
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const reader = req.body!.getReader({ mode: "byob" });
+      const chunks: Uint8Array[] = [];
+      while (true) {
+        const { done, value } = await reader.read(new Uint8Array(1024));
+        if (done) break;
+        chunks.push(value);
+      }
+      reader.releaseLock();
+      const total = chunks.reduce((sum, c) => sum + c.byteLength, 0);
+      return new Response(`OK:${total}`);
+    },
+  });
+
+  const body = "hello world";
+  const resp = await fetch(`http://localhost:${server.port}/`, {
+    method: "POST",
+    body,
+  });
+  expect(resp.status).toBe(200);
+  expect(await resp.text()).toBe(`OK:${body.length}`);
+});
+
+test("fetch() response body supports BYOB reader", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response("hello from server");
+    },
+  });
+
+  const resp = await fetch(`http://localhost:${server.port}/`);
+  const reader = resp.body!.getReader({ mode: "byob" });
+  const chunks: Uint8Array[] = [];
+  while (true) {
+    const { done, value } = await reader.read(new Uint8Array(1024));
+    if (done) break;
+    chunks.push(value);
+  }
+  reader.releaseLock();
+  const text = new TextDecoder().decode(Buffer.concat(chunks));
+  expect(text).toBe("hello from server");
+});
+
+test("Blob.stream() supports BYOB reader", async () => {
+  const blob = new Blob(["hello blob data"]);
+  const stream = blob.stream();
+  const reader = stream.getReader({ mode: "byob" });
+  const chunks: Uint8Array[] = [];
+  while (true) {
+    const { done, value } = await reader.read(new Uint8Array(1024));
+    if (done) break;
+    chunks.push(value);
+  }
+  reader.releaseLock();
+  const text = new TextDecoder().decode(Buffer.concat(chunks));
+  expect(text).toBe("hello blob data");
+});
+
+test("Bun.file().stream() supports BYOB reader", async () => {
+  // Write a temp file
+  const path = require("path").join(require("os").tmpdir(), `byob-test-${Date.now()}.txt`);
+  const content = "hello file data";
+  await Bun.write(path, content);
+  try {
+    const stream = Bun.file(path).stream();
+    const reader = stream.getReader({ mode: "byob" });
+    const chunks: Uint8Array[] = [];
+    while (true) {
+      const { done, value } = await reader.read(new Uint8Array(1024));
+      if (done) break;
+      chunks.push(value);
+    }
+    reader.releaseLock();
+    const text = new TextDecoder().decode(Buffer.concat(chunks));
+    expect(text).toBe(content);
+  } finally {
+    require("fs").unlinkSync(path);
+  }
+});
+
+test("default reader still works on native streams after getReader fix", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response("default reader test");
+    },
+  });
+
+  const resp = await fetch(`http://localhost:${server.port}/`);
+  const reader = resp.body!.getReader();
+  const chunks: Uint8Array[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  reader.releaseLock();
+  const text = new TextDecoder().decode(Buffer.concat(chunks));
+  expect(text).toBe("default reader test");
+});


### PR DESCRIPTION
## Summary

Fixes #12908.

- Native `ReadableStream`s (`req.body`, `fetch().body`, `Blob.stream()`, `Bun.file().stream()`) threw `TypeError: ReadableStreamBYOBReader needs a ReadableByteStreamController` when calling `getReader({ mode: 'byob' })`
- Fixed lazy stream initialization to trigger for BYOB reader path (was only triggered for default readers)
- When a BYOB reader is requested, the underlying source now gets `type: "bytes"` so a `ReadableByteStreamController` is created instead of `ReadableStreamDefaultController`. This is only done for BYOB readers to preserve performance for the default reader path (avoids `pendingPullIntos` overhead)
- Fixed `readableStreamClose()` to resolve pending `readIntoRequests` for BYOB readers on stream close (was only handling default reader `readRequests`)
- Fixed `readableStreamReaderGenericRelease()` to look up the underlying source from either `underlyingSource` or `underlyingByteSource` when calling `$resume`

## Test plan

- [x] New regression test in `test/regression/issue/12908.test.ts` covering all native stream types with BYOB readers
- [x] Verified test fails with `USE_SYSTEM_BUN=1` (4 of 5 tests fail)
- [x] Verified test passes with `bun bd test`
- [x] Existing `test/js/web/streams/streams.test.js` suite passes (68/68)
- [x] Node.js BYOB compatibility tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)