### PR TITLE
fix: support Blob and BunFile inputs in HTMLRewriter.transform()

### DIFF
--- a/test/regression/issue/17259.test.ts
+++ b/test/regression/issue/17259.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+
+test("HTMLRewriter.transform supports Blob input", () => {
+  const html = '<div class="hello">Hello</div><script src="/main.js"></script>';
+  const blob = new Blob([html], { type: "text/html" });
+
+  const tags: string[] = [];
+  const result = new HTMLRewriter()
+    .on("*", {
+      element(element) {
+        tags.push(element.tagName);
+      },
+    })
+    .transform(blob);
+
+  expect(result).toBeInstanceOf(Blob);
+  expect(tags).toEqual(["div", "script"]);
+});
+
+test("HTMLRewriter.transform supports Blob input and modifies content", async () => {
+  const html = '<div class="old">content</div>';
+  const blob = new Blob([html], { type: "text/html" });
+
+  const result = new HTMLRewriter()
+    .on("div", {
+      element(element) {
+        element.setAttribute("class", "new");
+      },
+    })
+    .transform(blob);
+
+  expect(result).toBeInstanceOf(Blob);
+  const text = await result.text();
+  expect(text).toBe('<div class="new">content</div>');
+});
+
+test("HTMLRewriter.transform supports Bun.file() input", async () => {
+  using dir = tempDir("html-rewriter-bunfile", {
+    "index.html": '<h1>Hello</h1><p class="old">World</p>',
+  });
+
+  const file = Bun.file(`${dir}/index.html`);
+
+  const result = new HTMLRewriter()
+    .on("p", {
+      element(element) {
+        element.setAttribute("class", "new");
+      },
+    })
+    .transform(file);
+
+  // BunFile requires async I/O, so transform returns a Response
+  expect(result).toBeInstanceOf(Response);
+  const text = await result.text();
+  expect(text).toBe('<h1>Hello</h1><p class="new">World</p>');
+});
+
+test("HTMLRewriter.transform Blob with element handler reading attributes", () => {
+  const html = '<script src="/app.js"></script><script src="/vendor.js"></script>';
+  const blob = new Blob([html]);
+
+  const srcs: string[] = [];
+  new HTMLRewriter()
+    .on("script", {
+      element(element) {
+        const src = element.getAttribute("src");
+        if (src) srcs.push(src);
+      },
+    })
+    .transform(blob);
+
+  expect(srcs).toEqual(["/app.js", "/vendor.js"]);
+});


### PR DESCRIPTION
## Summary
- `HTMLRewriter.transform()` now accepts `Blob` and `Bun.file()` (BunFile) inputs, matching the documented API and type definitions
- In-memory `Blob` inputs return a transformed `Blob`
- File-backed `Blob` inputs (`Bun.file()`) return a `Response` (since they require async I/O through the `ValueBufferer` path)
- Updated error message from `"Expected Response or Body"` to `"Expected Response, Blob, String, or ArrayBuffer"`

Closes #17259

## Test plan
- [x] New regression tests in `test/regression/issue/17259.test.ts` covering:
  - Basic Blob input with element handler
  - Blob input with content modification (setAttribute)
  - BunFile input with content modification
  - Blob input reading element attributes
- [x] Tests fail with `USE_SYSTEM_BUN=1` (confirms fix)
- [x] Tests pass with `bun bd test`
- [x] Existing HTMLRewriter tests pass (41/41 in `test/js/workerd/html-rewriter.test.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)