### PR TITLE
fix: allow worker `onerror` / `preventDefault()` to prevent worker termination

### DIFF
--- a/test/regression/issue/16424-worker-no-handler.ts
+++ b/test/regression/issue/16424-worker-no-handler.ts
@@ -1,0 +1,4 @@
+// Worker that does NOT handle errors — should terminate
+setTimeout(() => {
+  throw new Error("unhandled test error");
+}, 50);

--- a/test/regression/issue/16424-worker-prevent-default.ts
+++ b/test/regression/issue/16424-worker-prevent-default.ts
@@ -1,0 +1,14 @@
+// Worker that handles errors via addEventListener + preventDefault()
+self.addEventListener("error", e => {
+  e.preventDefault();
+});
+
+postMessage("before-error");
+
+setTimeout(() => {
+  throw new Error("test error");
+}, 50);
+
+setTimeout(() => {
+  postMessage("after-error");
+}, 200);

--- a/test/regression/issue/16424.test.ts
+++ b/test/regression/issue/16424.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/16424
+// Worker should continue running after an error is handled by self.onerror / preventDefault()
+
+test("worker continues running when error event calls preventDefault()", async () => {
+  const worker = new Worker(new URL("./16424-worker-prevent-default.ts", import.meta.url).href);
+
+  try {
+    const messages: string[] = [];
+    const done = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("Timed out waiting for worker messages")), 5000);
+      worker.onmessage = e => {
+        messages.push(e.data);
+        if (e.data === "after-error") {
+          clearTimeout(timeout);
+          resolve();
+        }
+      };
+      worker.onerror = () => {
+        clearTimeout(timeout);
+        reject(new Error("Error propagated to parent (should have been handled inside worker)"));
+      };
+    });
+
+    await done;
+    expect(messages).toContain("before-error");
+    expect(messages).toContain("after-error");
+  } finally {
+    worker.terminate();
+  }
+});
+
+test("worker terminates when error event is NOT handled", async () => {
+  const worker = new Worker(new URL("./16424-worker-no-handler.ts", import.meta.url).href);
+
+  const closed = await new Promise<boolean>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Timed out")), 5000);
+    worker.addEventListener("error", () => {
+      // Error propagated to parent — expected
+    });
+    worker.addEventListener("close", () => {
+      clearTimeout(timeout);
+      resolve(true);
+    });
+  });
+
+  expect(closed).toBe(true);
+});


### PR DESCRIPTION
## Summary

- **Make worker ErrorEvent cancelable** so `preventDefault()` can mark the error as handled
- **Check `defaultPrevented`** after dispatching the error event inside the worker, and only terminate the worker / propagate to parent if the error was NOT handled
- **Undo `unhandled_error_counter` increment** when error is handled, so the worker event loop stays alive

Previously, Bun unconditionally terminated the worker on any uncaught exception, ignoring `self.onerror` handlers and `preventDefault()` calls on the error event. Per the [HTML spec for runtime script errors in workers](https://html.spec.whatwg.org/multipage/workers.html#runtime-script-errors-2), if the error event is canceled, the worker should continue running.

Closes #16424

## Test plan

- [x] New regression test `test/regression/issue/16424.test.ts` verifies:
  - Worker continues running after error is handled via `addEventListener('error', e => e.preventDefault())`
  - Worker terminates when error is NOT handled (no `preventDefault()`)
- [x] Test fails on system bun (v1.3.9), passes on debug build with fix
- [x] Manual verification with standalone script confirms worker stays alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)