### PR TITLE
fix: worker parentPort.on("message") not firing with top-level await

### DIFF
--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -495,14 +495,14 @@ fn spin(this: *WebWorker) void {
             this.exitAndDeinit();
             return;
         }
-    } else {
+    } else if (promise.status() == .fulfilled) {
         _ = promise.result();
     }
+    // If promise is still pending (top-level await), that's OK — the main
+    // event loop below will continue to tick until it settles.
 
     this.flushLogs();
     log("[{d}] event loop start", .{this.execution_context_id});
-    // TODO(@190n) call dispatchOnline earlier (basically as soon as spin() starts, before
-    // we start running JS)
     WebWorker__dispatchOnline(this.cpp_worker, vm.global);
     WebWorker__fireEarlyMessages(this.cpp_worker, vm.global);
     this.setStatus(.running);

--- a/test/regression/issue/15408.test.ts
+++ b/test/regression/issue/15408.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/15408
+// parentPort.on("message") never fires when the worker module uses top-level await.
+test("parentPort.on('message') works with top-level await in worker", async () => {
+  using dir = tempDir("issue-15408", {
+    "main.js": `
+      import { Worker } from "node:worker_threads";
+      const worker = new Worker("./worker.js", {});
+      worker.postMessage("hello");
+      worker.on("message", (msg) => {
+        console.log(msg);
+        worker.terminate();
+      });
+    `,
+    "worker.js": `
+      import { parentPort } from "node:worker_threads";
+
+      parentPort.on("message", (msg) => {
+        parentPort.postMessage("received message");
+      });
+
+      // Top-level await - the worker should still receive messages
+      // while this TLA is pending.
+      while (true) {
+        await new Promise((r) => setImmediate(r));
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("received message");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fixes `parentPort.on("message")` callbacks never firing when a worker module uses top-level `await`
- Changes `loadEntryPointForWebWorker` to not block waiting for the module promise to settle, allowing `dispatchOnline`/`fireEarlyMessages` to run even when TLA is pending
- The main event loop naturally handles both TLA promise resolution and message dispatching

## Root Cause

When a worker module uses top-level `await`, `loadEntryPointForWebWorker()` called `waitForPromiseWithTermination()` which blocks until the module promise settles. For modules with infinite TLA loops (e.g. `while (true) { await new Promise(r => setImmediate(r)); }`), the promise never settles, so `dispatchOnline()` and `fireEarlyMessages()` were never reached. Messages from the parent were queued in `m_pendingTasks` but never dispatched.

## Fix

`loadEntryPointForWebWorker` now runs a single event loop `tick()` instead of blocking until the promise settles. This executes all synchronous module code (including `parentPort.on("message", ...)` listener registration) before returning. The caller (`spin()`) then proceeds to call `dispatchOnline`/`fireEarlyMessages` and enters the main event loop, which handles both the pending TLA promise and message dispatching concurrently.

## Test plan

- [x] New regression test: `test/regression/issue/15408.test.ts`
- [x] Verified test fails with system bun (`USE_SYSTEM_BUN=1`) — times out
- [x] Verified test passes with debug build (`bun bd test`)
- [x] Verified existing `test/js/node/worker_threads/` tests show no new failures

Closes #15408

🤖 Generated with [Claude Code](https://claude.com/claude-code)