### PR TITLE
fix(workers): don't unref parent event loop prematurely on worker exit

### DIFF
--- a/test/regression/issue/14144.test.ts
+++ b/test/regression/issue/14144.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/14144
+// Worker messages and close events were lost when a worker called
+// process.exit() immediately after postMessage(), because the parent
+// event loop was unreffed too early in notifyNeedTermination().
+test("worker postMessage followed by process.exit delivers all messages", async () => {
+  // Run the test multiple times to catch the race condition reliably.
+  // The original bug had a ~77% failure rate on release builds.
+  for (let i = 0; i < 10; i++) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const workerBody = \`
+          self.postMessage({type: "start"});
+          self.addEventListener("message", function(event) {
+            let message = JSON.parse(event.data);
+            self.postMessage({type: "finish"});
+            process.exit();
+          });
+        \`;
+
+        const blob = new Blob([workerBody], {type: "application/javascript"});
+        const url = URL.createObjectURL(blob);
+        const workersCount = 2;
+        let finished = 0;
+        let closed = 0;
+
+        function checkDone() {
+          if (finished === workersCount && closed === workersCount) {
+            console.log("ALL_DONE");
+          }
+        }
+
+        for (let i = 0; i < workersCount; i++) {
+          const w = new Worker(url);
+          w.addEventListener("message", (event) => {
+            if (event.data.type === "finish") {
+              finished++;
+              checkDone();
+            }
+          });
+          w.addEventListener("close", () => {
+            closed++;
+            checkDone();
+          });
+          w.postMessage(JSON.stringify({}));
+        }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toInclude("ALL_DONE");
+    expect(exitCode).toBe(0);
+  }
+}, 30_000);


### PR DESCRIPTION
## Summary

- Fix race condition where worker `postMessage()` followed by `process.exit()` could cause the parent event loop to exit before processing queued messages
- Remove premature `unref` of the parent event loop in `notifyNeedTermination()` — the `deinit()` path already handles this correctly after dispatching exit/close events

## Root Cause

When a worker called `process.exit()` immediately after `postMessage()`:

1. `postMessage()` queued a message task to the parent event loop
2. `process.exit()` → `notifyNeedTermination()` unreffed the parent event loop
3. The parent event loop saw no refs remaining and exited before processing the queued message

The fix removes the early unref from `notifyNeedTermination()` and the similar one in `onUnhandledRejection()`. The parent event loop ref is properly released in `deinit()`, which runs *after* `exitAndDeinit()` has dispatched all exit/close events to the parent.

## Test plan

- [x] Added regression test (`test/regression/issue/14144.test.ts`) that spawns 2 workers which call `postMessage` then `process.exit()`, verifying all messages are received (runs 10 iterations to catch the race)
- [x] Test fails with system bun (`USE_SYSTEM_BUN=1`), passes with debug build
- [x] Existing worker tests show no new failures (4 pre-existing failures unrelated to this change)

Closes #14144

🤖 Generated with [Claude Code](https://claude.com/claude-code)