### PR TITLE
fix(shell): fix unicode cursor tracking causing __bunstr_N leak in output

### DIFF
--- a/test/regression/issue/17244.test.ts
+++ b/test/regression/issue/17244.test.ts
@@ -1,0 +1,43 @@
+import { $ } from "bun";
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/17244
+// Shell template literals leaked __bunstr_N when the first interpolated value
+// contained a space and a subsequent value contained a multi-byte UTF-8 character.
+
+test("shell interpolation with space and multi-byte UTF-8", async () => {
+  const a = " ";
+  const b = "Í";
+
+  const result = await $`echo ${a} ${b}`.text();
+  expect(result.trim()).toBe("Í");
+  expect(result).not.toContain("__bunstr");
+});
+
+test("shell interpolation with trailing-space string and 2-byte UTF-8", async () => {
+  const a = "a ";
+  const b = "Í";
+
+  const result = await $`echo ${a} ${b}`.text();
+  // "a " (with trailing space preserved) + " " (template separator) + "Í"
+  expect(result.trim()).toBe("a  Í");
+  expect(result).not.toContain("__bunstr");
+});
+
+test("shell interpolation with space and 3-byte UTF-8", async () => {
+  const a = " ";
+  const b = "€";
+
+  const result = await $`echo ${a} ${b}`.text();
+  expect(result.trim()).toBe("€");
+  expect(result).not.toContain("__bunstr");
+});
+
+test("shell interpolation with embedded space and multi-byte UTF-8", async () => {
+  const a = "a b";
+  const b = "Í";
+
+  const result = await $`echo ${a} ${b}`.text();
+  expect(result.trim()).toBe("a b Í");
+  expect(result).not.toContain("__bunstr");
+});


### PR DESCRIPTION
## Summary
- Fixed `srcBytesAtCursor()` and `cursorPos()` in the shell lexer's unicode path (`ShellCharIter(.wtf8)`) to use `self.src.cursor.i` instead of `self.src.iter.i`, which was permanently stuck at 0
- Fixed `bumpCursorAscii()` to properly decode the codepoint at the new cursor position instead of storing the last digit character, which caused the wrong character to be returned on the next read

## Root Cause
When the shell template literal source contained multi-byte UTF-8 characters (e.g., `Í`, `€`), the `LexerUnicode` path was used. In this path, `srcBytesAtCursor()` and `cursorPos()` referenced `self.src.iter.i` — the `CodepointIterator`'s internal field that is never modified (the `next()` method takes `*const Iterator`). This meant:

1. `srcBytesAtCursor()` always returned bytes from position 0 (the start of the source)
2. `looksLikeJSStringRef()` checked for `__bunstr_` at position 0 instead of the current cursor position, failing to match
3. The `\x08__bunstr_N` reference was passed through as literal text into the shell output

This only occurred when **both** conditions were met:
- An interpolated value contained a space (triggering `needsEscapeBunstr` → stored as `__bunstr_N` ref)
- A subsequent value contained multi-byte UTF-8 (triggering `LexerUnicode` instead of `LexerAscii`)

Closes #17244

## Test plan
- [x] Added regression tests in `test/regression/issue/17244.test.ts`
- [x] Verified tests fail with `USE_SYSTEM_BUN=1` (system bun 1.3.9)
- [x] Verified tests pass with `bun bd test`
- [x] Ran existing shell tests (`bunshell.test.ts`, `bunshell-default.test.ts`, `bunshell-instance.test.ts`) — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)