### PR TITLE
fix: support JS ReadableStream in HTMLRewriter.transform()

### DIFF
--- a/test/regression/issue/14216.test.ts
+++ b/test/regression/issue/14216.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/14216
+// HTMLRewriter should work with JavaScript-created ReadableStreams
+
+test("HTMLRewriter.transform() works with a JS ReadableStream", async () => {
+  const inputStream = new ReadableStream({
+    start(controller) {
+      controller.enqueue("<html><body>Hello world</body></html>");
+      controller.close();
+    },
+  });
+
+  const rw = new HTMLRewriter();
+  rw.on("body", {
+    element(element) {
+      element.setAttribute("class", "modified");
+    },
+  });
+
+  const response = rw.transform(new Response(inputStream));
+  const text = await response.text();
+  expect(text).toBe('<html><body class="modified">Hello world</body></html>');
+});
+
+test("HTMLRewriter.transform() works with a JS ReadableStream and onEndTag", async () => {
+  const inputStream = new ReadableStream({
+    start(controller) {
+      controller.enqueue("<html><body>Hello world</body></html>");
+      controller.close();
+    },
+  });
+
+  const rw = new HTMLRewriter();
+  rw.on("body", {
+    element(element) {
+      element.onEndTag(end => {
+        end.before("<span>injected</span>", { html: true });
+      });
+    },
+  });
+
+  const response = rw.transform(new Response(inputStream));
+  const text = await response.text();
+  expect(text).toBe("<html><body>Hello world<span>injected</span></body></html>");
+});
+
+test("HTMLRewriter.transform() works with a multi-chunk JS ReadableStream", async () => {
+  const inputStream = new ReadableStream({
+    start(controller) {
+      controller.enqueue("<html><body>");
+      controller.enqueue("Hello ");
+      controller.enqueue("world");
+      controller.enqueue("</body></html>");
+      controller.close();
+    },
+  });
+
+  const rw = new HTMLRewriter();
+  rw.on("body", {
+    element(element) {
+      element.setAttribute("class", "modified");
+    },
+  });
+
+  const response = rw.transform(new Response(inputStream));
+  const text = await response.text();
+  expect(text).toBe('<html><body class="modified">Hello world</body></html>');
+});
+
+test("HTMLRewriter.transform() works with a binary-chunk JS ReadableStream", async () => {
+  const encoder = new TextEncoder();
+  const inputStream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode("<html><body>Binary</body></html>"));
+      controller.close();
+    },
+  });
+
+  const rw = new HTMLRewriter();
+  const response = rw.transform(new Response(inputStream));
+  const text = await response.text();
+  expect(text).toBe("<html><body>Binary</body></html>");
+});
+
+test("HTMLRewriter.transform() works with an async pull-based JS ReadableStream", async () => {
+  const inputStream = new ReadableStream({
+    async pull(controller) {
+      controller.enqueue("<html><body>Async</body></html>");
+      controller.close();
+    },
+  });
+
+  const rw = new HTMLRewriter();
+  const response = rw.transform(new Response(inputStream));
+  const text = await response.text();
+  expect(text).toBe("<html><body>Async</body></html>");
+});
+
+test("HTMLRewriter.transform() works with an empty JS ReadableStream", async () => {
+  const inputStream = new ReadableStream({
+    start(controller) {
+      controller.close();
+    },
+  });
+
+  const rw = new HTMLRewriter();
+  const response = rw.transform(new Response(inputStream));
+  const text = await response.text();
+  expect(text).toBe("");
+});


### PR DESCRIPTION
## Summary

- Fix `HTMLRewriter.transform()` throwing `ERR_STREAM_CANNOT_PIPE` when the `Response` body is a JavaScript-created `ReadableStream`
- Replace the broken `createJSSink` approach (which used `ArrayBufferSink` pipe that lost data on `end()`) with `readableStreamToArrayBuffer` which properly buffers the stream through the JS runtime
- Also pass the resolved promise value through `handleResolveStream` so ArrayBuffer results can be extracted

## Test plan

- [x] Added regression tests in `test/regression/issue/14216.test.ts`
  - Single-chunk string ReadableStream
  - Multi-chunk string ReadableStream  
  - Binary chunk (Uint8Array) ReadableStream
  - Async pull-based ReadableStream
  - Empty ReadableStream
  - ReadableStream with `onEndTag` element handler
- [x] Verified all 6 new tests fail with `USE_SYSTEM_BUN=1` and pass with debug build
- [x] Verified all existing HTMLRewriter tests pass (0 regressions)

Closes #14216

🤖 Generated with [Claude Code](https://claude.com/claude-code)