### PR TITLE
fix: default FormData Blob filename to "blob" per XHR spec

### DIFF
--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -649,7 +649,10 @@ export fn Blob__getFileNameString(this: *Blob) callconv(.c) bun.String {
         return bun.String.fromBytes(filename);
     }
 
-    return bun.String.empty;
+    // Per the XHR spec ("create an entry" algorithm), when a Blob (not a File)
+    // is appended to FormData without an explicit filename, the name should
+    // default to "blob". See: https://xhr.spec.whatwg.org/#dom-formdata-append
+    return bun.String.static("blob");
 }
 
 comptime {

--- a/test/regression/issue/21788.test.ts
+++ b/test/regression/issue/21788.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/21788
+// When a plain Blob (not a File) is appended to FormData without an explicit
+// filename, the XHR spec says the filename should default to "blob".
+// Previously Bun set it to "" (empty string).
+
+test("FormData.set with Blob defaults filename to 'blob'", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      return req.text().then(t => new Response(t));
+    },
+  });
+
+  const formData = new FormData();
+  formData.set("file", new Blob(["hello"], { type: "text/plain" }));
+
+  const res = await fetch(server.url, { method: "POST", body: formData });
+  const text = await res.text();
+
+  // The Content-Disposition header in the multipart body should contain filename="blob"
+  expect(text).toContain('filename="blob"');
+});
+
+test("FormData.append with Blob defaults filename to 'blob'", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      return req.text().then(t => new Response(t));
+    },
+  });
+
+  const formData = new FormData();
+  formData.append("file", new Blob(["hello"], { type: "text/plain" }));
+
+  const res = await fetch(server.url, { method: "POST", body: formData });
+  const text = await res.text();
+
+  expect(text).toContain('filename="blob"');
+});
+
+test("FormData.set with Blob and explicit filename uses provided name", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      return req.text().then(t => new Response(t));
+    },
+  });
+
+  const formData = new FormData();
+  formData.set("file", new Blob(["hello"], { type: "text/plain" }), "custom.txt");
+
+  const res = await fetch(server.url, { method: "POST", body: formData });
+  const text = await res.text();
+
+  expect(text).toContain('filename="custom.txt"');
+});
+
+test("FormData.set with File preserves File name", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      return req.text().then(t => new Response(t));
+    },
+  });
+
+  const formData = new FormData();
+  formData.set("file", new File(["hello"], "myfile.txt", { type: "text/plain" }));
+
+  const res = await fetch(server.url, { method: "POST", body: formData });
+  const text = await res.text();
+
+  expect(text).toContain('filename="myfile.txt"');
+});
+
+test("FormData.get returns File with name 'blob' for plain Blob", () => {
+  const formData = new FormData();
+  formData.set("file", new Blob(["hello"], { type: "text/plain" }));
+
+  const entry = formData.get("file");
+  expect(entry).toBeInstanceOf(File);
+  expect((entry as File).name).toBe("blob");
+});


### PR DESCRIPTION
## Summary
- When a plain `Blob` (not a `File`) is passed to `FormData.set()` or `FormData.append()` without an explicit filename, Bun was setting the filename to `""` (empty string) in the multipart `Content-Disposition` header
- The [XHR spec](https://xhr.spec.whatwg.org/#dom-formdata-append) requires the filename to default to `"blob"`, which matches Node.js behavior
- This caused servers that inspect the filename to determine if a file was sent to reject uploads with errors like "No file sent"

## Fix
Changed `Blob__getFileNameString` in `src/bun.js/webcore/Blob.zig` to return `"blob"` instead of an empty string when the Blob has no associated filename. This function is only called from `JSDOMFormData.cpp` for the FormData `append`/`set` code paths.

## Test plan
- [x] Added regression test `test/regression/issue/21788.test.ts` covering:
  - `FormData.set` with plain Blob defaults filename to "blob"
  - `FormData.append` with plain Blob defaults filename to "blob"
  - Explicit filename still works
  - `File` objects preserve their name
  - `FormData.get` returns a File with name "blob" for plain Blobs
- [x] Test fails with system bun (`USE_SYSTEM_BUN=1`) — confirms the bug exists
- [x] Test passes with debug build (`bun bd test`) — confirms the fix works

Closes #21788

🤖 Generated with [Claude Code](https://claude.com/claude-code)