### PR TITLE
fix: abort HTTP connection when response body stream is cancelled

### DIFF
--- a/src/bun.js/webcore/ByteStream.zig
+++ b/src/bun.js/webcore/ByteStream.zig
@@ -356,6 +356,9 @@ pub fn onCancel(this: *@This()) void {
         action.reject(global, .{ .AbortReason = .UserAbort }) catch {}; // TODO: properly propagate exception upwards
         this.buffer_action = null;
     }
+
+    // Note: cancel propagation to the HTTP connection is handled by the
+    // Source.cancel() method via cancel_handler, not here.
 }
 
 pub fn memoryCost(this: *const @This()) usize {

--- a/src/bun.js/webcore/ReadableStream.zig
+++ b/src/bun.js/webcore/ReadableStream.zig
@@ -442,6 +442,8 @@ pub fn NewSource(
         close_handler: ?*const fn (?*anyopaque) void = null,
         close_ctx: ?*anyopaque = null,
         close_jsvalue: jsc.Strong.Optional = .empty,
+        cancel_handler: ?*const fn (?*anyopaque) void = null,
+        cancel_ctx: ?*anyopaque = null,
         globalThis: *JSGlobalObject = undefined,
         this_jsvalue: jsc.JSValue = .zero,
         is_closed: bool = false,
@@ -493,6 +495,11 @@ pub fn NewSource(
 
             this.cancelled = true;
             onCancel(&this.context);
+
+            if (this.cancel_handler) |handler| {
+                this.cancel_handler = null;
+                handler(this.cancel_ctx);
+            }
         }
 
         pub fn onClose(this: *This) void {

--- a/test/regression/issue/17048.test.ts
+++ b/test/regression/issue/17048.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/17048
+// Breaking from a `for await` loop over a response body should abort
+// the underlying HTTP connection and allow the process to exit promptly.
+test("breaking from for-await over response.body exits promptly", async () => {
+  // Start a server that streams data slowly over ~3 seconds
+  using server = Bun.serve({
+    port: 0,
+    async fetch() {
+      const stream = new ReadableStream({
+        async start(controller) {
+          controller.enqueue(new TextEncoder().encode("hello "));
+          for (let i = 0; i < 3; i++) {
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            controller.enqueue(new TextEncoder().encode("world "));
+          }
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        headers: { "Content-Type": "text/plain" },
+      });
+    },
+  });
+
+  // The client breaks after the first chunk, then the process should exit
+  // naturally without waiting for the full stream.
+  const script = `
+    const response = await fetch("http://localhost:${server.port}");
+    for await (const chunk of response.body) {
+      break;
+    }
+  `;
+
+  const start = Date.now();
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [exitCode, stderr] = await Promise.all([proc.exited, proc.stderr.text()]);
+  const elapsed = Date.now() - start;
+
+  if (exitCode !== 0) {
+    console.error("stderr:", stderr);
+  }
+
+  // The process should exit well within 2 seconds.
+  // Before the fix, it would wait ~3+ seconds for the slow stream to finish.
+  expect(elapsed).toBeLessThan(2000);
+  expect(exitCode).toBe(0);
+}, 10_000);


### PR DESCRIPTION
## Summary
- Fixes #17048: Breaking from a `for await` loop over a `response.body` stream now properly aborts the underlying HTTP connection, allowing the process to exit immediately instead of waiting for the full response to be received.

## Changes
- Added `cancel_handler`/`cancel_ctx` fields to `ReadableStream.NewSource` — a dedicated callback invoked when the stream source is cancelled (distinct from the existing `close_handler` which gets overwritten by JS-side `onClose` bindings)
- `FetchTasklet.onReadableStreamAvailable` now registers a cancel handler that calls `abortTask()` to schedule HTTP connection shutdown
- Cancel handler is cleared on natural stream completion and error paths to avoid aborting connections that finish normally

## Root cause
When `break` is called in a `for await (const chunk of response.body)` loop, the async iterator's `finally` block calls `stream.cancel()`, which propagates through to `ByteStream.onCancel()`. However, there was no mechanism to propagate this cancellation back to the `FetchTasklet`/`HTTPClient` to abort the underlying socket connection. The HTTP client would continue reading data from the server until the response completed naturally.

## Test plan
- [x] Added regression test `test/regression/issue/17048.test.ts` that spawns a slow streaming server and verifies the child process exits within 2 seconds after breaking from the stream loop
- [x] Verified test fails with system bun (3032ms elapsed) and passes with fix (~800ms elapsed)
- [x] Verified fetch stream tests pass (timeouts in full suite run are pre-existing debug build issues)
- [x] Verified normal full-body reads (`response.text()`, complete stream consumption) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)