### PR TITLE
fix: implement `getConnections` and `connections` on `http.Server`

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -286,6 +286,25 @@ Server.prototype.unref = function () {
   return this;
 };
 
+Server.prototype.getConnections = function (callback) {
+  if (typeof callback !== "function") {
+    return this;
+  }
+  const server = this[serverSymbol];
+  // If server is not running, return 0 connections (matching net.Server behavior)
+  callback(null, server ? server.pendingRequests : 0);
+  return this;
+};
+
+Object.defineProperty(Server.prototype, "connections", {
+  get() {
+    const server = this[serverSymbol];
+    return server ? server.pendingRequests : 0;
+  },
+  configurable: true,
+  enumerable: true,
+});
+
 Server.prototype.closeAllConnections = function () {
   const server = this[serverSymbol];
   if (!server) {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2,7 +2,7 @@
 const EventEmitter: typeof import("node:events").EventEmitter = require("node:events");
 const { Duplex, Stream } = require("node:stream");
 const { _checkInvalidHeaderChar: checkInvalidHeaderChar } = require("node:_http_common");
-const { validateObject, validateLinkHeaderValue, validateBoolean, validateInteger } = require("internal/validators");
+const { validateObject, validateLinkHeaderValue, validateBoolean, validateInteger, validateFunction } = require("internal/validators");
 const { ConnResetException } = require("internal/shared");
 
 const { isPrimary } = require("internal/cluster/isPrimary");
@@ -286,18 +286,16 @@ Server.prototype.unref = function () {
   return this;
 };
 
-Server.prototype.getConnections = function (callback) {
-  if (typeof callback !== "function") {
-    return this;
-  }
+Server.prototype.getConnections = function (this: Server, callback) {
+  validateFunction(callback, "callback");
   const server = this[serverSymbol];
   // If server is not running, return 0 connections (matching net.Server behavior)
-  callback(null, server ? server.pendingRequests : 0);
+  process.nextTick(callback, null, server ? server.pendingRequests : 0);
   return this;
 };
 
 Object.defineProperty(Server.prototype, "connections", {
-  get() {
+  get(this: Server) {
     const server = this[serverSymbol];
     return server ? server.pendingRequests : 0;
   },

--- a/test/regression/issue/04459.test.ts
+++ b/test/regression/issue/04459.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-test("http.Server.getConnections returns connection count", async () => {
+test.concurrent("http.Server.getConnections returns connection count", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -42,7 +42,7 @@ server.listen(0, () => {
   expect(exitCode).toBe(0);
 });
 
-test("http.Server.connections property is available", async () => {
+test.concurrent("http.Server.connections property is available", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -81,7 +81,7 @@ server.listen(0, () => {
   expect(exitCode).toBe(0);
 });
 
-test("http.Server.getConnections returns 0 when server is not listening", async () => {
+test.concurrent("http.Server.getConnections returns 0 when server is not listening", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/regression/issue/04459.test.ts
+++ b/test/regression/issue/04459.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("http.Server.getConnections returns connection count", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const http = require("node:http");
+
+const server = http.createServer((req, res) => {
+  server.getConnections((err, count) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: err, count: count }));
+  });
+});
+
+server.listen(0, () => {
+  const port = server.address().port;
+  fetch("http://localhost:" + port)
+    .then(r => r.json())
+    .then(data => {
+      console.log(JSON.stringify(data));
+      server.close();
+    });
+});
+`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout.trim());
+  expect(result.error).toBeNull();
+  expect(result.count).toBeGreaterThanOrEqual(0);
+  expect(typeof result.count).toBe("number");
+  expect(exitCode).toBe(0);
+});
+
+test("http.Server.connections property is available", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const http = require("node:http");
+
+const server = http.createServer((req, res) => {
+  const count = server.connections;
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ count: count, type: typeof count }));
+});
+
+server.listen(0, () => {
+  const port = server.address().port;
+  fetch("http://localhost:" + port)
+    .then(r => r.json())
+    .then(data => {
+      console.log(JSON.stringify(data));
+      server.close();
+    });
+});
+`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout.trim());
+  expect(result.type).toBe("number");
+  expect(result.count).toBeGreaterThanOrEqual(0);
+  expect(exitCode).toBe(0);
+});
+
+test("http.Server.getConnections returns 0 when server is not listening", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const http = require("node:http");
+
+const server = http.createServer();
+server.getConnections((err, count) => {
+  console.log(JSON.stringify({ error: err, count: count }));
+});
+`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout.trim());
+  expect(result.error).toBeNull();
+  expect(result.count).toBe(0);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Adds `getConnections(callback)` method and `connections` property to `http.Server.prototype`
- `http.Server` extends `EventEmitter` directly (not `net.Server`), so these `net.Server` methods were missing
- Uses the underlying `Bun.serve()` server's `pendingRequests` to report active connection count

Closes #4459

## Test plan
- [x] Added regression test `test/regression/issue/04459.test.ts` with 3 test cases:
  - `getConnections` returns connection count during a request
  - `connections` property is available and returns a number
  - `getConnections` returns 0 when server is not listening
- [x] All tests pass with `bun bd test`
- [x] All tests fail with `USE_SYSTEM_BUN=1` (confirming the bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)