### PR TITLE
fix(publish): skip auth check for `--dry-run`

### DIFF
--- a/src/cli/publish_command.zig
+++ b/src/cli/publish_command.zig
@@ -534,6 +534,21 @@ pub const PublishCommand = struct {
     ) PublishError!void {
         const registry = ctx.manager.scopeForPackageName(ctx.package_name);
 
+        // continues from `printSummary`
+        Output.pretty(
+            \\<b><blue>Tag<r>: {s}
+            \\<b><blue>Access<r>: {s}
+            \\<b><blue>Registry<r>: {s}
+            \\
+        , .{
+            if (ctx.manager.options.publish_config.tag.len > 0) ctx.manager.options.publish_config.tag else "latest",
+            if (ctx.manager.options.publish_config.access) |access| @tagName(access) else "default",
+            registry.url.href,
+        });
+
+        // dry-run stops here, no auth or network requests needed
+        if (ctx.manager.options.dry_run) return;
+
         if (registry.token.len == 0 and (registry.url.password.len == 0 or registry.url.username.len == 0)) {
             return error.NeedAuth;
         }
@@ -553,21 +568,6 @@ pub const PublishCommand = struct {
                 return;
             }
         }
-
-        // continues from `printSummary`
-        Output.pretty(
-            \\<b><blue>Tag<r>: {s}
-            \\<b><blue>Access<r>: {s}
-            \\<b><blue>Registry<r>: {s}
-            \\
-        , .{
-            if (ctx.manager.options.publish_config.tag.len > 0) ctx.manager.options.publish_config.tag else "latest",
-            if (ctx.manager.options.publish_config.access) |access| @tagName(access) else "default",
-            registry.url.href,
-        });
-
-        // dry-run stops here
-        if (ctx.manager.options.dry_run) return;
 
         const publish_req_body = try constructPublishRequestBody(directory_publish, ctx);
 

--- a/test/regression/issue/17428.test.ts
+++ b/test/regression/issue/17428.test.ts
@@ -27,3 +27,26 @@ test("bun publish --dry-run works without authentication", async () => {
   expect(stdout).toContain("(dry-run)");
   expect(exitCode).toBe(0);
 });
+
+test("bun publish without --dry-run fails without authentication", async () => {
+  using dir = tempDir("publish-no-auth", {
+    "package.json": JSON.stringify({
+      name: "no-auth-test",
+      version: "1.0.0",
+    }),
+    "index.js": "module.exports = {};",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "publish"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("missing authentication");
+  expect(exitCode).not.toBe(0);
+});

--- a/test/regression/issue/17428.test.ts
+++ b/test/regression/issue/17428.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/17428
+// `bun publish --dry-run` should not require authentication
+test("bun publish --dry-run works without authentication", async () => {
+  using dir = tempDir("publish-dry-run-no-auth", {
+    "package.json": JSON.stringify({
+      name: "dry-run-no-auth-test",
+      version: "1.0.0",
+    }),
+    "index.js": "module.exports = {};",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "publish", "--dry-run"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("missing authentication");
+  expect(stdout).toContain("dry-run-no-auth-test");
+  expect(stdout).toContain("(dry-run)");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Move the dry-run early return before the authentication check in `publish()` so that `bun publish --dry-run` completes without requiring credentials
- The summary info (Tag, Access, Registry) is still printed during dry-run before returning

Closes #17428

## Test plan
- [x] Added regression test `test/regression/issue/17428.test.ts` that runs `bun publish --dry-run` without any auth configuration
- [x] Verified test **fails** with system bun (reproduces the bug)
- [x] Verified test **passes** with debug build (confirms the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)