### PR TITLE
fix(vm): prevent sandbox's `globalThis` property from shadowing VM builtins

### DIFF
--- a/src/bun.js/bindings/NodeVM.cpp
+++ b/src/bun.js/bindings/NodeVM.cpp
@@ -919,10 +919,20 @@ bool NodeVMGlobalObject::getOwnPropertySlot(JSObject* cell, JSGlobalObject* glob
 
     bool notContextified = thisObject->isNotContextified();
 
-    if (notContextified && propertyName.uid()->utf8() == "globalThis") [[unlikely]] {
+    if (propertyName.uid()->utf8() == "globalThis") [[unlikely]] {
+        // When code inside a VM context accesses `globalThis`, we must return the VM's
+        // global object (which has JSC builtins like eval, parseInt, etc.) rather than
+        // letting the lookup fall through to the sandbox's own `globalThis` property.
+        // Without this, if the sandbox has `globalThis = sandbox` (as happy-dom does),
+        // the sandbox's own `globalThis` would shadow the VM global, causing builtins
+        // to appear undefined. See: https://github.com/oven-sh/bun/issues/16363
         slot.disableCaching();
         slot.setThisValue(thisObject);
-        slot.setValue(thisObject, slot.attributes(), thisObject->specialSandbox());
+        if (notContextified) {
+            slot.setValue(thisObject, slot.attributes(), thisObject->specialSandbox());
+        } else {
+            slot.setValue(thisObject, slot.attributes(), thisObject);
+        }
         return true;
     }
 

--- a/test/regression/issue/16363.test.ts
+++ b/test/regression/issue/16363.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test";
+import VM from "vm";
+
+// https://github.com/oven-sh/bun/issues/16363
+// When a sandbox has `globalThis = sandbox` (as happy-dom does), builtins like
+// eval, parseInt, Array, etc. should still be accessible via `globalThis.eval`
+// inside the VM context.
+
+test("globalThis.eval is available when sandbox has globalThis = sandbox", () => {
+  const sandbox = {} as Record<string, unknown>;
+  sandbox.globalThis = sandbox;
+  VM.createContext(sandbox);
+
+  const result = new VM.Script("typeof globalThis.eval").runInContext(sandbox);
+  expect(result).toBe("function");
+});
+
+test("globalThis builtins are not shadowed by sandbox's globalThis property", () => {
+  const sandbox = {} as Record<string, unknown>;
+  sandbox.globalThis = sandbox;
+  VM.createContext(sandbox);
+
+  const result = JSON.parse(
+    new VM.Script(`
+    JSON.stringify({
+      typeofEval: typeof globalThis.eval,
+      typeofParseInt: typeof globalThis.parseInt,
+      typeofArray: typeof globalThis.Array,
+      typeofObject: typeof globalThis.Object,
+      typeofMath: typeof globalThis.Math,
+      typeofJSON: typeof globalThis.JSON,
+    })
+  `).runInContext(sandbox),
+  );
+
+  expect(result.typeofEval).toBe("function");
+  expect(result.typeofParseInt).toBe("function");
+  expect(result.typeofArray).toBe("function");
+  expect(result.typeofObject).toBe("function");
+  expect(result.typeofMath).toBe("object");
+  expect(result.typeofJSON).toBe("object");
+});
+
+test("globalThis works normally without sandbox.globalThis property", () => {
+  const sandbox = {} as Record<string, unknown>;
+  VM.createContext(sandbox);
+
+  const result = new VM.Script("typeof globalThis.eval").runInContext(sandbox);
+  expect(result).toBe("function");
+});


### PR DESCRIPTION
## Summary

- Fix `node:vm` contexts where sandbox has `globalThis = sandbox` (as happy-dom's `BrowserWindow` does) causing all JSC builtins (`eval`, `parseInt`, `Array`, `Object`, `Math`, `JSON`, etc.) to be `undefined` when accessed via `globalThis`
- Intercept `globalThis` lookups in `NodeVMGlobalObject::getOwnPropertySlot` for contextified objects, returning the VM's global object which properly delegates to both the sandbox and JSC builtins
- Previously, the `globalThis` intercept only applied to the `notContextified` path

## Root Cause

When `VM.createContext(sandbox)` is called with a sandbox that has `sandbox.globalThis = sandbox`, code running inside the VM context that accesses `globalThis.eval` would:

1. Look up `globalThis` on `NodeVMGlobalObject`
2. Fall through to `contextifiedObject->getPropertySlot()` which finds the sandbox's own `globalThis` property
3. Return the sandbox object itself (which doesn't have builtins like `eval`)
4. Result in `globalThis.eval` being `undefined`

The fix ensures `globalThis` always resolves to the VM's `NodeVMGlobalObject` (which inherits JSC builtins and proxies to the sandbox), regardless of whether the sandbox has its own `globalThis` property.

## Test plan

- [x] New regression test `test/regression/issue/16363.test.ts` passes with `bun bd test`
- [x] New regression test fails with `USE_SYSTEM_BUN=1` (confirms bug exists in released versions)
- [x] Existing VM test suite (`test/js/node/vm/vm.test.ts`) passes with 198/198 tests, 0 failures

Closes #16363

🤖 Generated with [Claude Code](https://claude.com/claude-code)