### PR TITLE
fix(windows): classify junctions as directories in dir_iterator to fix `rm -rf` crash

### DIFF
--- a/src/shell/builtin/rm.zig
+++ b/src/shell/builtin/rm.zig
@@ -1095,6 +1095,13 @@ pub const ShellRmTask = struct {
                     bun.sys.E.ISDIR => {
                         return Handler.onIsDir(vtable, parent_dir_task, path, is_absolute, buf);
                     },
+                    // On Windows, trying to delete a directory-like entry (e.g. a
+                    // junction/mount point) with FILE_NON_DIRECTORY_FILE returns
+                    // STATUS_NOT_A_DIRECTORY which maps to ENOTDIR. Treat it the
+                    // same as EISDIR.
+                    bun.sys.E.NOTDIR => {
+                        return Handler.onIsDir(vtable, parent_dir_task, path, is_absolute, buf);
+                    },
                     // This might happen if the file is actually a directory
                     bun.sys.E.PERM => {
                         switch (builtin.os.tag) {

--- a/test/regression/issue/27233.test.ts
+++ b/test/regression/issue/27233.test.ts
@@ -1,0 +1,32 @@
+import { $ } from "bun";
+import { expect, test } from "bun:test";
+import { isWindows, tempDir } from "harness";
+import { existsSync, mkdirSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
+
+// https://github.com/oven-sh/bun/issues/27233
+// On Windows, `rm -rf` panics with "invalid enum value" when encountering a
+// JUNCTION inside a directory. Junctions are directory reparse points
+// (IO_REPARSE_TAG_MOUNT_POINT) that were incorrectly classified as symlinks,
+// causing DeleteFileBun to be called with FILE_NON_DIRECTORY_FILE.
+test.if(isWindows)("rm -rf removes directory containing a junction", async () => {
+  using dir = tempDir("rm-junction");
+  const target = join(String(dir), "target");
+  const container = join(String(dir), "container");
+  const junction = join(container, "J");
+
+  mkdirSync(target);
+  mkdirSync(container);
+  // 'junction' type creates a Windows JUNCTION (IO_REPARSE_TAG_MOUNT_POINT)
+  symlinkSync(target, junction, "junction");
+
+  expect(existsSync(junction)).toBeTrue();
+
+  const { exitCode, stderr } = await $`rm -rf ${container}`;
+
+  expect(stderr.toString()).toBe("");
+  expect(exitCode).toBe(0);
+  expect(existsSync(container)).toBeFalse();
+  // The junction target should still exist (rm should remove the junction, not the target)
+  expect(existsSync(target)).toBeTrue();
+});


### PR DESCRIPTION
## Summary

Fixes #27233 - `rm -rf` panics with "invalid enum value" when encountering a Windows JUNCTION inside a directory.

- **Root cause**: Windows JUNCTIONs (`mklink /J`) have both `FILE_ATTRIBUTE_DIRECTORY` and `FILE_ATTRIBUTE_REPARSE_POINT` set. The directory iterator classified all reparse points as `sym_link`, so junctions were treated as files. `DeleteFileBun` was called with `FILE_NON_DIRECTORY_FILE`, Windows returned `STATUS_NOT_A_DIRECTORY`, and the unhandled errno caused a panic.
- **Fix**: Switch from `FileDirectoryInformation` to `FileBothDirectoryInformation` in the Windows directory iterator. The `EaSize` field of `FILE_BOTH_DIR_INFORMATION` contains the reparse tag when `FILE_ATTRIBUTE_REPARSE_POINT` is set. Junctions (`IO_REPARSE_TAG_MOUNT_POINT`) are now correctly classified as directories.
- **Safety net**: Added `ENOTDIR` handling in `rm.zig`'s `removeEntryFile` to treat it the same as `EISDIR`, preventing panics if this class of error occurs through other code paths.

## Test plan

- [x] Added Windows-only regression test `test/regression/issue/27233.test.ts`
- [x] Verified existing `rm.test.ts` tests still pass (3/3 relevant tests pass; 1 pre-existing unrelated failure)
- [x] Verified `zig:check-all` passes (61/61 platform builds succeed)
- [ ] Windows CI will validate the junction-specific regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)