### PR TITLE
fix(transpiler): hoist directives above JSX imports and preserve during minification

### DIFF
--- a/src/ast/visit.zig
+++ b/src/ast/visit.zig
@@ -1192,8 +1192,11 @@ pub fn Visit(
                 switch (stmt.data) {
                     .s_empty => continue,
 
-                    // skip directives for now
-                    .s_directive => continue,
+                    // Directives like "use client" / "use server" must be preserved.
+                    .s_directive => {
+                        output.append(stmt) catch unreachable;
+                        continue;
+                    },
 
                     .s_local => |local| {
                         // Merge adjacent local statements

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -6044,8 +6044,24 @@ pub fn printAst(
         }
     }
 
+    // Hoist directive prologue ("use client", "use server", etc.) before
+    // all other statements so that auto-generated imports (e.g. JSX runtime)
+    // don't push directives out of the prologue position.
+    // https://github.com/oven-sh/bun/issues/6854
     for (tree.parts.slice()) |part| {
         for (part.stmts) |stmt| {
+            if (stmt.data != .s_directive) continue;
+            try printer.printStmt(stmt, PrinterType.TopLevel.init(.yes));
+            if (printer.writer.getError()) {} else |err| {
+                return err;
+            }
+            printer.printSemicolonIfNeeded();
+        }
+    }
+
+    for (tree.parts.slice()) |part| {
+        for (part.stmts) |stmt| {
+            if (stmt.data == .s_directive) continue;
             try printer.printStmt(stmt, PrinterType.TopLevel.init(.yes));
             if (printer.writer.getError()) {} else |err| {
                 return err;
@@ -6308,8 +6324,24 @@ pub fn printCommonJS(
     printer.binary_expression_stack = std.array_list.Managed(PrinterType.BinaryExpressionVisitor).init(bin_stack_heap.get());
     defer printer.binary_expression_stack.clearAndFree();
 
+    // Hoist directive prologue ("use client", "use server", etc.) before
+    // all other statements so that auto-generated imports (e.g. JSX runtime)
+    // don't push directives out of the prologue position.
+    // https://github.com/oven-sh/bun/issues/6854
     for (tree.parts.slice()) |part| {
         for (part.stmts) |stmt| {
+            if (stmt.data != .s_directive) continue;
+            try printer.printStmt(stmt, PrinterType.TopLevel.init(.yes));
+            if (printer.writer.getError()) {} else |err| {
+                return err;
+            }
+            printer.printSemicolonIfNeeded();
+        }
+    }
+
+    for (tree.parts.slice()) |part| {
+        for (part.stmts) |stmt| {
+            if (stmt.data == .s_directive) continue;
             try printer.printStmt(stmt, PrinterType.TopLevel.init(.yes));
             if (printer.writer.getError()) {} else |err| {
                 return err;

--- a/test/regression/issue/6854.test.ts
+++ b/test/regression/issue/6854.test.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/6854
+// "use client" / "use server" directives must be hoisted above auto-generated
+// imports (e.g. JSX runtime) and must be preserved during minification.
+
+test('"use client" appears before JSX runtime import in --no-bundle', async () => {
+  using dir = tempDir("issue-6854", {
+    "input.jsx": `"use client";\nexport function Button() { return <div>Click</div>; }`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--no-bundle", "input.jsx"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toStartWith('"use client";\n');
+  expect(exitCode).toBe(0);
+});
+
+test('"use server" appears before JSX runtime import in --no-bundle', async () => {
+  using dir = tempDir("issue-6854", {
+    "input.jsx": `"use server";\nexport function action() { return <div/>; }`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--no-bundle", "input.jsx"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toStartWith('"use server";\n');
+  expect(exitCode).toBe(0);
+});
+
+test('"use client" preserved with --minify', async () => {
+  using dir = tempDir("issue-6854", {
+    "input.js": `"use client";\nexport function Component() { return "hello"; }`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--no-bundle", "--minify", "input.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toStartWith('"use client";');
+  expect(exitCode).toBe(0);
+});
+
+test('"use client" preserved with --minify and JSX', async () => {
+  using dir = tempDir("issue-6854", {
+    "input.jsx": `"use client";\nexport function Button() { return <div>Click</div>; }`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--no-bundle", "--minify", "input.jsx"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toStartWith('"use client";');
+  expect(exitCode).toBe(0);
+});
+
+test('"use server" preserved with --minify', async () => {
+  using dir = tempDir("issue-6854", {
+    "input.js": `"use server";\nexport async function submitForm(data) { return data; }`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--no-bundle", "--minify", "input.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toStartWith('"use server";');
+  expect(exitCode).toBe(0);
+});
+
+test("directive without JSX still works in --no-bundle", async () => {
+  using dir = tempDir("issue-6854", {
+    "input.js": `"use client";\nexport function Component() { return "hello"; }`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--no-bundle", "input.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toStartWith('"use client";\n');
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

Fixes #6854

- **Hoist directive prologue in no-bundle mode**: `"use client"` and `"use server"` directives are now printed before all other statements (including auto-generated JSX runtime imports) in both the ESM and CommonJS no-bundle print paths (`js_printer.zig`).
- **Preserve directives during minify-syntax**: The minify-syntax pass in `visit.zig` was explicitly skipping (`continue`) all `s_directive` statements, causing them to be dropped from the output. Changed to preserve them.

### Before

```js
// bun build --no-bundle input.jsx
import { jsxDEV } from "react/jsx-dev-runtime";
"use client";  // ← directive pushed below import
export function Button() { ... }

// bun build --no-bundle --minify input.jsx
import{jsxDEV as i}from"react/jsx-dev-runtime";export function Button(){...}
// ← "use client" completely gone
```

### After

```js
// bun build --no-bundle input.jsx
"use client";
import { jsxDEV } from "react/jsx-dev-runtime";
export function Button() { ... }

// bun build --no-bundle --minify input.jsx
"use client";import{jsxDEV as i}from"react/jsx-dev-runtime";export function Button(){...}
```

## Test plan

- [x] Added regression test `test/regression/issue/6854.test.ts` with 6 test cases
- [x] Tests fail with `USE_SYSTEM_BUN=1` (5 of 6 fail, confirming the bugs existed)
- [x] Tests pass with `bun bd test`
- [x] Existing transpiler directive tests still pass
- [x] Existing bundler banner tests still pass
- [x] Existing DCE tests still pass (73 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)