### PR TITLE
fix(serve): don't set default content-type for BufferSource response bodies

### DIFF
--- a/test/regression/issue/21193.test.ts
+++ b/test/regression/issue/21193.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/21193
+// Per the Fetch spec, BufferSource bodies (ArrayBuffer, TypedArray, DataView)
+// should not have a default Content-Type header.
+test("Response with Uint8Array body should not have content-type in Bun.serve", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(new TextEncoder().encode("hello"));
+    },
+  });
+
+  const res = await fetch(server.url);
+  expect(res.headers.get("content-type")).toBeNull();
+  expect(await res.text()).toBe("hello");
+});
+
+test("Response with ArrayBuffer body should not have content-type in Bun.serve", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(new ArrayBuffer(8));
+    },
+  });
+
+  const res = await fetch(server.url);
+  expect(res.headers.get("content-type")).toBeNull();
+  expect(res.headers.get("content-length")).toBe("8");
+});
+
+test("Response with DataView body should not have content-type in Bun.serve", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(new DataView(new ArrayBuffer(4)));
+    },
+  });
+
+  const res = await fetch(server.url);
+  expect(res.headers.get("content-type")).toBeNull();
+  expect(res.headers.get("content-length")).toBe("4");
+});
+
+test("Response with string body should still have text/plain content-type", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response("hello");
+    },
+  });
+
+  const res = await fetch(server.url);
+  expect(res.headers.get("content-type")).toBe("text/plain;charset=utf-8");
+  expect(await res.text()).toBe("hello");
+});
+
+test("Response with Blob body should have blob content-type", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(new Blob(["hello"], { type: "text/html" }));
+    },
+  });
+
+  const res = await fetch(server.url);
+  expect(res.headers.get("content-type")).toBe("text/html;charset=utf-8");
+  expect(await res.text()).toBe("hello");
+});
+
+test("Response with explicit content-type header and Uint8Array body should keep it", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(new TextEncoder().encode("hello"), {
+        headers: { "content-type": "text/plain" },
+      });
+    },
+  });
+
+  const res = await fetch(server.url);
+  expect(res.headers.get("content-type")).toBe("text/plain");
+  expect(await res.text()).toBe("hello");
+});


### PR DESCRIPTION
## Summary

- Per the Fetch spec, `BufferSource` bodies (`ArrayBuffer`, `TypedArray`, `DataView`) should not have a default `Content-Type` header set when used as a `Response` body
- Previously, `Bun.serve()` was injecting `content-type: application/octet-stream` for these bodies because `getContentType` checked `blob.contentType().len > 0`, which always returned `true` for `InternalBlob` (it defaults to `MimeType.other`)
- Changed to use `blob.hasContentTypeFromUser()` so only user-specified content types are applied, matching the Fetch spec behavior

Closes #21193

## Test plan

- [x] Added regression test `test/regression/issue/21193.test.ts` covering:
  - `Uint8Array` body → no content-type header
  - `ArrayBuffer` body → no content-type header
  - `DataView` body → no content-type header
  - String body → still gets `text/plain;charset=utf-8`
  - Blob body with explicit type → preserves user-specified type
  - Explicit `content-type` header with `Uint8Array` body → preserves user header
- [x] Test fails on system Bun (`USE_SYSTEM_BUN=1`), passes on debug build
- [x] Existing `serve.test.ts` tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)