### PR TITLE
fix: preserve non-ASCII characters in tagged template literal raw strings

### DIFF
--- a/src/bun.js/ModuleLoader.zig
+++ b/src/bun.js/ModuleLoader.zig
@@ -570,7 +570,10 @@ pub fn transpileSourceCode(
                 .allocator = null,
                 .source_code = brk: {
                     const written = printer.ctx.getWritten();
-                    const result = cache.output_code orelse bun.String.cloneLatin1(written);
+                    const result = cache.output_code orelse if (bun.strings.firstNonASCII(written) != null)
+                        bun.String.cloneUTF8(written)
+                    else
+                        bun.String.cloneLatin1(written);
 
                     if (written.len > 1024 * 1024 * 2 or jsc_vm.smol) {
                         printer.ctx.buffer.deinit();

--- a/src/bun.js/RuntimeTranspilerStore.zig
+++ b/src/bun.js/RuntimeTranspilerStore.zig
@@ -577,7 +577,10 @@ pub const RuntimeTranspilerStore = struct {
             const source_code = brk: {
                 const written = printer.ctx.getWritten();
 
-                const result = cache.output_code orelse bun.String.cloneLatin1(written);
+                const result = cache.output_code orelse if (bun.strings.firstNonASCII(written) != null)
+                    bun.String.cloneUTF8(written)
+                else
+                    bun.String.cloneLatin1(written);
 
                 if (written.len > 1024 * 1024 * 2 or vm.smol) {
                     printer.ctx.buffer.deinit();

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -1963,62 +1963,11 @@ fn NewPrinter(
         }
 
         fn printRawTemplateLiteral(p: *Printer, bytes: []const u8) void {
-            if (comptime is_json or !ascii_only) {
-                p.print(bytes);
-                return;
-            }
-
-            // Translate any non-ASCII to unicode escape sequences
-            // Note that this does not correctly handle malformed template literal strings
-            // template literal strings can contain invalid unicode code points
-            // and pretty much anything else
-            //
-            // we use WTF-8 here, but that's still not good enough.
-            //
-            var ascii_start: usize = 0;
-            var is_ascii = false;
-            var iter = CodepointIterator.init(bytes);
-            var cursor = CodepointIterator.Cursor{};
-
-            while (iter.next(&cursor)) {
-                switch (cursor.c) {
-                    // unlike other versions, we only want to mutate > 0x7F
-                    0...last_ascii => {
-                        if (!is_ascii) {
-                            ascii_start = cursor.i;
-                            is_ascii = true;
-                        }
-                    },
-                    else => {
-                        if (is_ascii) {
-                            p.print(bytes[ascii_start..cursor.i]);
-                            is_ascii = false;
-                        }
-
-                        switch (cursor.c) {
-                            0...0xFFFF => {
-                                p.print([_]u8{
-                                    '\\',
-                                    'u',
-                                    hex_chars[cursor.c >> 12],
-                                    hex_chars[(cursor.c >> 8) & 15],
-                                    hex_chars[(cursor.c >> 4) & 15],
-                                    hex_chars[cursor.c & 15],
-                                });
-                            },
-                            else => {
-                                p.print("\\u{");
-                                p.fmt("{x}", .{cursor.c}) catch unreachable;
-                                p.print("}");
-                            },
-                        }
-                    },
-                }
-            }
-
-            if (is_ascii) {
-                p.print(bytes[ascii_start..]);
-            }
+            // Per the ECMAScript specification, the .raw property of tagged
+            // templates must contain the exact source text. Non-ASCII characters
+            // must never be escaped here, even when ascii_only is true, because
+            // doing so would change the string value that the tag function receives.
+            p.print(bytes);
         }
 
         pub fn printExpr(p: *Printer, expr: Expr, level: Level, in_flags: ExprFlag.Set) void {

--- a/test/regression/issue/018859.test.ts
+++ b/test/regression/issue/018859.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("tagged template literals preserve non-ASCII in .raw", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `function tag(strings) { return strings.raw[0]; } console.log(tag\`Привет, Мир\`);`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("Привет, Мир");
+  expect(exitCode).toBe(0);
+});
+
+test("shell $ preserves non-ASCII characters", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `import {$} from "bun"; await $\`echo "Hello world: Привет, Мир"\`;`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("Hello world: Привет, Мир");
+  expect(exitCode).toBe(0);
+});
+
+test("tagged template literals preserve CJK characters in .raw", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `function tag(strings) { return strings.raw[0]; } console.log(tag\`你好世界\`);`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("你好世界");
+  expect(exitCode).toBe(0);
+});
+
+test("tagged template literals preserve emoji in .raw", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `function tag(strings) { return strings.raw[0]; } console.log(tag\`Hello 🌍\`);`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("Hello 🌍");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fixed `printRawTemplateLiteral` in the JS printer to stop escaping non-ASCII characters to `\uXXXX` sequences in raw template strings. Per the ECMAScript spec, the `.raw` property must contain the exact source text.
- When the transpiler output contains non-ASCII bytes (from raw template content), the source is now passed to JSC as UTF-8 instead of Latin-1 so multi-byte sequences decode to correct Unicode codepoints.
- This fixes `Bun.$` shell tag and all other tagged template literals incorrectly converting Unicode text like `Привет` to `\u041F\u0440\u0438\u0432\u0435\u0442`.

Closes #18859

## Test plan
- [x] Added regression test `test/regression/issue/018859.test.ts` with 4 test cases:
  - Tagged template with Cyrillic characters in `.raw`
  - Bun shell `$` with Cyrillic characters
  - Tagged template with CJK characters
  - Tagged template with emoji (4-byte UTF-8)
- [x] Verified all tests pass with `bun bd test`
- [x] Verified all tests fail with `USE_SYSTEM_BUN=1` (pre-fix behavior)
- [x] Verified regular string literals, untagged templates, and `String.raw` still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)