### PR TITLE
fix(http): use Transfer-Encoding: chunked when req.write() is called

### DIFF
--- a/test/regression/issue/23751.test.ts
+++ b/test/regression/issue/23751.test.ts
@@ -1,0 +1,173 @@
+import { expect, test } from "bun:test";
+import http from "node:http";
+
+// https://github.com/oven-sh/bun/issues/23751
+// When using req.write() followed by req.end(), Bun should send
+// Transfer-Encoding: chunked instead of Content-Length, matching Node.js behavior.
+
+test("http.request with req.write() uses Transfer-Encoding: chunked", async () => {
+  const { promise, resolve } = Promise.withResolvers<{
+    te: string | null;
+    cl: string | null;
+    body: string;
+  }>();
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const body = await req.text();
+      resolve({
+        te: req.headers.get("transfer-encoding"),
+        cl: req.headers.get("content-length"),
+        body,
+      });
+      return new Response("OK");
+    },
+  });
+
+  const req = http.request(
+    {
+      hostname: server.hostname,
+      port: server.port,
+      path: "/",
+      method: "POST",
+    },
+    res => {
+      res.on("data", () => {});
+      res.on("end", () => {});
+    },
+  );
+  req.write("hello");
+  req.end();
+
+  const result = await promise;
+  expect(result.te).toBe("chunked");
+  expect(result.cl).toBeNull();
+  expect(result.body).toBe("hello");
+});
+
+test("http.request with req.write() multiple chunks uses Transfer-Encoding: chunked", async () => {
+  const { promise, resolve } = Promise.withResolvers<{
+    te: string | null;
+    cl: string | null;
+    body: string;
+  }>();
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const body = await req.text();
+      resolve({
+        te: req.headers.get("transfer-encoding"),
+        cl: req.headers.get("content-length"),
+        body,
+      });
+      return new Response("OK");
+    },
+  });
+
+  const req = http.request(
+    {
+      hostname: server.hostname,
+      port: server.port,
+      path: "/",
+      method: "POST",
+    },
+    res => {
+      res.on("data", () => {});
+      res.on("end", () => {});
+    },
+  );
+  req.write("hello ");
+  req.write("world");
+  req.end();
+
+  const result = await promise;
+  expect(result.te).toBe("chunked");
+  expect(result.cl).toBeNull();
+  expect(result.body).toBe("hello world");
+});
+
+test("http.request with explicit Content-Length preserves it", async () => {
+  const { promise, resolve } = Promise.withResolvers<{
+    te: string | null;
+    cl: string | null;
+    body: string;
+  }>();
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const body = await req.text();
+      resolve({
+        te: req.headers.get("transfer-encoding"),
+        cl: req.headers.get("content-length"),
+        body,
+      });
+      return new Response("OK");
+    },
+  });
+
+  const req = http.request(
+    {
+      hostname: server.hostname,
+      port: server.port,
+      path: "/",
+      method: "POST",
+      headers: {
+        "Content-Length": "5",
+      },
+    },
+    res => {
+      res.on("data", () => {});
+      res.on("end", () => {});
+    },
+  );
+  req.write("hello");
+  req.end();
+
+  const result = await promise;
+  expect(result.cl).toBe("5");
+  expect(result.te).toBeNull();
+  expect(result.body).toBe("hello");
+});
+
+test("http.request with req.end(data) and no req.write() uses Content-Length", async () => {
+  const { promise, resolve } = Promise.withResolvers<{
+    te: string | null;
+    cl: string | null;
+    body: string;
+  }>();
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const body = await req.text();
+      resolve({
+        te: req.headers.get("transfer-encoding"),
+        cl: req.headers.get("content-length"),
+        body,
+      });
+      return new Response("OK");
+    },
+  });
+
+  const req = http.request(
+    {
+      hostname: server.hostname,
+      port: server.port,
+      path: "/",
+      method: "POST",
+    },
+    res => {
+      res.on("data", () => {});
+      res.on("end", () => {});
+    },
+  );
+  req.end("hello");
+
+  const result = await promise;
+  expect(result.cl).toBe("5");
+  expect(result.te).toBeNull();
+  expect(result.body).toBe("hello");
+});


### PR DESCRIPTION
## Summary

- When `req.write()` is used followed by `req.end()`, Bun now sends `Transfer-Encoding: chunked` instead of `Content-Length`, matching Node.js behavior
- When only `req.end(data)` is used (no prior `req.write()`), `Content-Length` is still used, also matching Node.js
- When the user explicitly sets `Content-Length`, it is preserved as-is

The fix tracks whether `req.write()` was explicitly called (vs the internal write triggered by `req.end(data)`). When explicit writes are detected without a user-set `Content-Length` header, the body chunks are wrapped in an async generator so the HTTP layer uses the streaming path with `Transfer-Encoding: chunked`.

## Test plan

- [x] Added regression test at `test/regression/issue/23751.test.ts` with 4 cases:
  - Single `req.write()` + `req.end()` → chunked
  - Multiple `req.write()` calls + `req.end()` → chunked  
  - Explicit `Content-Length` header → preserved
  - `req.end(data)` only → `Content-Length`
- [x] Test fails with `USE_SYSTEM_BUN=1` (v1.3.9) and passes with debug build
- [x] Existing `node-http.test.ts` tests still pass (77 pass, 1 pre-existing failure)

Fixes #23751

🤖 Generated with [Claude Code](https://claude.com/claude-code)