### PR TITLE
shell: only treat digit as fd-prefix redirect at word boundary

### DIFF
--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -2734,6 +2734,7 @@ pub fn NewLexer(comptime encoding: StringEncoding) type {
                                 .BraceEnd,
                                 .CmdSubstEnd,
                                 .Asterisk,
+                                .DoubleAsterisk,
                                 => break :escaped,
                                 else => {},
                             };
@@ -3082,6 +3083,7 @@ pub fn NewLexer(comptime encoding: StringEncoding) type {
                         return flags;
                     },
                     '<' => {
+                        _ = self.eat();
                         dir = .in;
                         const is_double = self.eat_simple_redirect_operator(dir);
                         if (is_double) flags.append = true;

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -2961,6 +2961,7 @@ pub fn NewLexer(comptime encoding: StringEncoding) type {
                     .BraceEnd,
                     .CmdSubstEnd,
                     .Asterisk,
+                    .DoubleAsterisk,
                     => true,
 
                     .Pipe,
@@ -2969,7 +2970,6 @@ pub fn NewLexer(comptime encoding: StringEncoding) type {
                     .DoubleAmpersand,
                     .Redirect,
                     .Dollar,
-                    .DoubleAsterisk,
                     .Eq,
                     .Semicolon,
                     .Newline,

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -2716,6 +2716,27 @@ pub fn NewLexer(comptime encoding: StringEncoding) type {
                             comptime for ('0'..'9') |c| assertSpecialChar(c);
 
                             if (self.chars.state != .Normal) break :escaped;
+                            // POSIX: a digit is only an fd-prefix for a redirect (e.g. `2>`)
+                            // when it begins a new word. If we're already accumulating a
+                            // word (e.g. `abc1>file`) or the preceding token is part of the
+                            // same compound word (e.g. `"abc"1>file`, `$(cmd)1>file`), the
+                            // digit is literal text and the `>`/`<` that follows is handled
+                            // by its own operator case.
+                            if (self.word_start != self.j) break :escaped;
+                            if (self.last_tok_tag()) |tag| switch (tag) {
+                                .Var,
+                                .VarArgv,
+                                .Text,
+                                .SingleQuotedText,
+                                .DoubleQuotedText,
+                                .BraceBegin,
+                                .Comma,
+                                .BraceEnd,
+                                .CmdSubstEnd,
+                                .Asterisk,
+                                => break :escaped,
+                                else => {},
+                            };
                             const snapshot = self.make_snapshot();
                             if (self.eat_redirect(input)) |redirect| {
                                 try self.break_word(true);

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1135,6 +1135,16 @@ describe("deno_task", () => {
   describe("redirects", async function igodf() {
     TestBuilder.command`echo 5 6 7 > test.txt`.fileEquals("test.txt", "5 6 7\n").runAsTest("basic redirect");
 
+    // A trailing digit on a word adjacent to `>` must stay part of the word;
+    // it is not an fd-prefix. `echo abc1>test.txt` should write "abc1\n".
+    TestBuilder.command`echo abc1>test.txt`
+      .fileEquals("test.txt", "abc1\n")
+      .runAsTest("digit at end of word is not an fd prefix");
+
+    TestBuilder.command`echo test100>test.txt`
+      .fileEquals("test.txt", "test100\n")
+      .runAsTest("multi-digit tail is not an fd prefix");
+
     TestBuilder.command`echo 1 2 3 && echo 1 > test.txt`
       .stdout("1 2 3\n")
       .fileEquals("test.txt", "1\n")

--- a/test/js/bun/shell/lex.test.ts
+++ b/test/js/bun/shell/lex.test.ts
@@ -451,6 +451,37 @@ describe("lex shell", () => {
     expect(JSON.parse(result)).toEqual(expected);
   });
 
+  test("op_redirect fd-prefixed stdin `<`", () => {
+    // `N<file` is a single `<` redirect — append must be false.
+    expect(JSON.parse(lex`cmd1 0< file.txt`)).toEqual([
+      { "Text": "cmd1" },
+      { "Delimit": {} },
+      { "Redirect": redirect({ stdin: true }) },
+      { "Text": "file.txt" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+    expect(JSON.parse(lex`cat 0<input.txt`)).toEqual([
+      { "Text": "cat" },
+      { "Delimit": {} },
+      { "Redirect": redirect({ stdin: true }) },
+      { "Text": "input.txt" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+
+    // `N<<file` is the doubled form (single Redirect token, append=true),
+    // not two separate Redirect tokens.
+    expect(JSON.parse(lex`cmd1 0<< file.txt`)).toEqual([
+      { "Text": "cmd1" },
+      { "Delimit": {} },
+      { "Redirect": redirect({ stdin: true, append: true }) },
+      { "Text": "file.txt" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+  });
+
   test("op_redirect digit at end of word is not an fd prefix", () => {
     // `abc1>file` must lex as the word `abc1` followed by `>` (stdout redirect),
     // not `abc` followed by `1>`.
@@ -498,6 +529,32 @@ describe("lex shell", () => {
       { "Text": "foo" },
       { "Delimit": {} },
       { "CmdSubstEnd": {} },
+      { "Text": "2" },
+      { "Delimit": {} },
+      { "Redirect": redirect({ stdout: true }) },
+      { "Text": "file" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+
+    // Digit following a glob is part of the same compound word.
+    expect(JSON.parse(lex`echo *2>file`)).toEqual([
+      { "Text": "echo" },
+      { "Delimit": {} },
+      { "Asterisk": {} },
+      { "Text": "2" },
+      { "Delimit": {} },
+      { "Redirect": redirect({ stdout: true }) },
+      { "Text": "file" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+
+    // Same for `**`.
+    expect(JSON.parse(lex`echo **2>file`)).toEqual([
+      { "Text": "echo" },
+      { "Delimit": {} },
+      { "DoubleAsterisk": {} },
       { "Text": "2" },
       { "Delimit": {} },
       { "Redirect": redirect({ stdout: true }) },

--- a/test/js/bun/shell/lex.test.ts
+++ b/test/js/bun/shell/lex.test.ts
@@ -563,6 +563,18 @@ describe("lex shell", () => {
       { "Eof": {} },
     ]);
 
+    // But with a space, the digit is a new word and stays an fd prefix.
+    expect(JSON.parse(lex`echo ** 2>file`)).toEqual([
+      { "Text": "echo" },
+      { "Delimit": {} },
+      { "DoubleAsterisk": {} },
+      { "Delimit": {} },
+      { "Redirect": redirect({ stderr: true }) },
+      { "Text": "file" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+
     // A digit that *does* begin a word (preceded by whitespace) is still an fd prefix.
     expect(JSON.parse(lex`echo abc 2>file`)).toEqual([
       { "Text": "echo" },

--- a/test/js/bun/shell/lex.test.ts
+++ b/test/js/bun/shell/lex.test.ts
@@ -451,6 +451,95 @@ describe("lex shell", () => {
     expect(JSON.parse(result)).toEqual(expected);
   });
 
+  test("op_redirect digit at end of word is not an fd prefix", () => {
+    // `abc1>file` must lex as the word `abc1` followed by `>` (stdout redirect),
+    // not `abc` followed by `1>`.
+    expect(JSON.parse(lex`echo abc1>file`)).toEqual([
+      { "Text": "echo" },
+      { "Delimit": {} },
+      { "Text": "abc1" },
+      { "Delimit": {} },
+      { "Redirect": redirect({ stdout: true }) },
+      { "Text": "file" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+
+    // `test100>out` must not split off the trailing `0` as `0>`.
+    expect(JSON.parse(lex`echo test100>out`)).toEqual([
+      { "Text": "echo" },
+      { "Delimit": {} },
+      { "Text": "test100" },
+      { "Delimit": {} },
+      { "Redirect": redirect({ stdout: true }) },
+      { "Text": "out" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+
+    // Digit following a quoted fragment is part of the same compound word.
+    expect(JSON.parse(lex`echo "abc"1>file`)).toEqual([
+      { "Text": "echo" },
+      { "Delimit": {} },
+      { "DoubleQuotedText": "abc" },
+      { "Text": "1" },
+      { "Delimit": {} },
+      { "Redirect": redirect({ stdout: true }) },
+      { "Text": "file" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+
+    // Digit following a command substitution is part of the same compound word.
+    expect(JSON.parse(lex`echo $(foo)2>file`)).toEqual([
+      { "Text": "echo" },
+      { "Delimit": {} },
+      { "CmdSubstBegin": {} },
+      { "Text": "foo" },
+      { "Delimit": {} },
+      { "CmdSubstEnd": {} },
+      { "Text": "2" },
+      { "Delimit": {} },
+      { "Redirect": redirect({ stdout: true }) },
+      { "Text": "file" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+
+    // A digit that *does* begin a word (preceded by whitespace) is still an fd prefix.
+    expect(JSON.parse(lex`echo abc 2>file`)).toEqual([
+      { "Text": "echo" },
+      { "Delimit": {} },
+      { "Text": "abc" },
+      { "Delimit": {} },
+      { "Redirect": redirect({ stderr: true }) },
+      { "Text": "file" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+
+    // A digit at the start of input is still an fd prefix.
+    expect(JSON.parse(lex`2>file`)).toEqual([
+      { "Redirect": redirect({ stderr: true }) },
+      { "Text": "file" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+
+    // A digit immediately after an operator (no intervening word) is still an fd prefix.
+    expect(JSON.parse(lex`echo foo;2>file`)).toEqual([
+      { "Text": "echo" },
+      { "Delimit": {} },
+      { "Text": "foo" },
+      { "Delimit": {} },
+      { "Semicolon": {} },
+      { "Redirect": redirect({ stderr: true }) },
+      { "Text": "file" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ]);
+  });
+
   test("obj_ref", () => {
     const expected = [
       {

--- a/test/regression/issue/12602.test.ts
+++ b/test/regression/issue/12602.test.ts
@@ -1,0 +1,52 @@
+import { $ } from "bun";
+import { expect, test } from "bun:test";
+import { isWindows, tempDir } from "harness";
+
+// GH-12602: Shell incorrectly strips trailing digits from command names
+// when followed by a redirect operator. e.g. `./script1<file` was parsed
+// as `./script` with `1<file` (fd redirect), instead of `./script1` with
+// `<file` (stdin redirect).
+test.skipIf(isWindows)("command name ending in digit followed by redirect is not treated as fd redirect", async () => {
+  using dir = tempDir("12602", {
+    "script1": "#!/bin/sh\necho Hello from script1",
+    "input.txt": "some input",
+  });
+
+  // Make script1 executable
+  const chmodRes = await $`chmod +x ${dir}/script1`.quiet();
+  expect(chmodRes.exitCode).toBe(0);
+
+  // ./script1<input.txt — the "1" must stay part of the command name
+  const result = await $`cd ${dir} && ./script1<input.txt`.quiet();
+  expect(result.text()).toBe("Hello from script1\n");
+  expect(result.exitCode).toBe(0);
+
+  // Redirect from a missing file should fail (the command name must still be correct)
+  const bad = await $`cd ${dir} && ./script1<missing.txt`.quiet().nothrow();
+  expect(bad.exitCode).not.toBe(0);
+});
+
+test.skipIf(isWindows)("command name ending in '2' followed by redirect is not treated as fd redirect", async () => {
+  using dir = tempDir("12602-2", {
+    "script2": "#!/bin/sh\necho Hello from script2",
+    "input.txt": "some input",
+  });
+
+  const chmodRes = await $`chmod +x ${dir}/script2`.quiet();
+  expect(chmodRes.exitCode).toBe(0);
+
+  const result = await $`cd ${dir} && ./script2<input.txt`.quiet();
+  expect(result.text()).toBe("Hello from script2\n");
+  expect(result.exitCode).toBe(0);
+});
+
+test.skipIf(isWindows)("standalone digit redirect still works", async () => {
+  using dir = tempDir("12602-fd", {
+    "input.txt": "hello from file",
+  });
+
+  // `cat 0<input.txt` — 0 is NOT part of a word, so it should be treated as fd redirect
+  const result = await $`cd ${dir} && cat 0<input.txt`.quiet();
+  expect(result.text()).toBe("hello from file");
+  expect(result.exitCode).toBe(0);
+});

--- a/test/regression/issue/12602.test.ts
+++ b/test/regression/issue/12602.test.ts
@@ -40,7 +40,7 @@ test.skipIf(isWindows)("command name ending in '2' followed by redirect is not t
   expect(result.exitCode).toBe(0);
 });
 
-test.skipIf(isWindows)("standalone digit redirect still works", async () => {
+test("standalone digit redirect still works", async () => {
   using dir = tempDir("12602-fd", {
     "input.txt": "hello from file",
   });


### PR DESCRIPTION
## What does this PR do?

Fixes the shell lexer treating a digit at the end of a word as an fd-prefix when followed by `>` / `<`.

### Repro

```sh
$`echo abc1>file`       # wrote "abc\n" — lexed as `echo abc` + `1>file`
$`echo test100>out`     # wrote nothing — lexed as `echo test10` + `0>out` (stdin redirect)
$`echo "abc"1>file`     # wrote "abc\n" — lexed as `echo "abc"` + `1>file`
$`./script1<input`      # ran `./script` with `1<input`
```

POSIX only recognizes an IO number when the digits form their own word. bash writes `abc1\n`, `test100\n`, `abc1\n`, and runs `./script1` respectively.

### Root cause

In the `'0'...'9'` arm of the lexer (`src/shell/shell.zig`), `eat_redirect()` was attempted unconditionally whenever a digit appeared in Normal state, then `break_word()` was called *after* the redirect was accepted — silently splitting the trailing digit off whatever word preceded it.

### Fix

Before entering the fd-redirect path, require that the digit begins a new word:

1. `self.word_start == self.j` — no text currently being accumulated, **and**
2. the preceding token (if any) is not a word-continuation token (`Text`, `Var`, `SingleQuotedText`, `DoubleQuotedText`, `CmdSubstEnd`, `Asterisk`, brace tokens) — same classification `break_word_impl` already uses.

Digits that genuinely begin a word — after whitespace (`echo 2>file`), at start of input (`2>file`), or after an operator (`echo foo;2>file`) — still parse as fd prefixes.

### How did you verify your code works?

* `USE_SYSTEM_BUN=1 bun test test/js/bun/shell/lex.test.ts -t "op_redirect digit"` → **fail**
* `bun bd test test/js/bun/shell/lex.test.ts` → 30/30 pass
* `bun bd test test/js/bun/shell/parse.test.ts` → 17/17 pass
* `bun bd test test/js/bun/shell/file-io.test.ts` → 25/25 pass
* `bun bd test test/js/bun/shell/bunshell.test.ts -t redirect` → 28/28 pass
* `bun bd test test/regression/issue/12602.test.ts` → 3/3 pass

Closes #12602
