### PR TITLE
fix(test): invoke JS-level then() for lazy promise subclasses in expect().rejects/resolves

### DIFF
--- a/src/test_runner/expect.zig
+++ b/src/test_runner/expect.zig
@@ -170,6 +170,29 @@ pub const Expect = struct {
         return processPromise(this.custom_label, this.flags, globalThis, value, matcher_name, matcher_params, false);
     }
 
+    /// Some Promise subclasses are lazy — they only start their underlying
+    /// work when `.then()` is called (e.g. Bun Shell's `ShellPromise`).
+    /// `waitForPromise()` watches the internal promise state directly without
+    /// going through `.then()`, so such promises would never settle and
+    /// `expect()` would hang forever. This helper calls the user-visible
+    /// `.then()` method (with no handlers) to trigger any lazy initialization,
+    /// matching the observable behavior of `await value`.
+    fn triggerLazyPromise(globalThis: *JSGlobalObject, value: JSValue, promise: jsc.AnyPromise) bun.JSError!void {
+        if (promise.status() != .pending) return;
+        if (!value.isObject()) return;
+        const then_fn = try value.get(globalThis, "then") orelse return;
+        if (!then_fn.isCallable()) return;
+
+        const then_result = try then_fn.call(globalThis, value, &.{});
+        // `.then()` with no handlers returns a promise that follows the
+        // original. Mark it as handled so a rejection doesn't surface as an
+        // unhandled rejection warning — the original promise is what we
+        // actually observe below.
+        if (then_result.asAnyPromise()) |returned_promise| {
+            returned_promise.setHandled(globalThis.vm());
+        }
+    }
+
     /// Processes the async flags (resolves/rejects), waiting for the async value if needed.
     /// If no flags, returns the original value
     /// If either flag is set, waits for the result, and returns either it as a JSValue, or null if the expectation failed (in which case if silent is false, also throws a js exception)
@@ -179,6 +202,8 @@ pub const Expect = struct {
                 if (value.asAnyPromise()) |promise| {
                     const vm = globalThis.vm();
                     promise.setHandled(vm);
+
+                    try triggerLazyPromise(globalThis, value, promise);
 
                     globalThis.bunVM().waitForPromise(promise);
 
@@ -576,6 +601,7 @@ pub const Expect = struct {
         }
 
         if (return_value.asAnyPromise()) |promise| {
+            try triggerLazyPromise(globalThis, return_value, promise);
             vm.waitForPromise(promise);
             scope.apply(vm);
             switch (promise.unwrap(globalThis.vm(), .mark_handled)) {
@@ -1049,6 +1075,8 @@ pub const Expect = struct {
         if (result.asAnyPromise()) |promise| {
             const vm = globalThis.vm();
             promise.setHandled(vm);
+
+            try triggerLazyPromise(globalThis, result, promise);
 
             globalThis.bunVM().waitForPromise(promise);
 

--- a/test/regression/issue/14670.test.ts
+++ b/test/regression/issue/14670.test.ts
@@ -1,0 +1,115 @@
+// https://github.com/oven-sh/bun/issues/14670
+//
+// `expect($`...`).rejects.toThrow()` hung forever because ShellPromise is a
+// lazy Promise subclass — it only starts the shell when `.then()` is called.
+// `expect().resolves` / `.rejects` waited on the internal promise state
+// directly without calling `.then()`, so the shell never ran and the promise
+// never settled.
+//
+// These tests spawn a subprocess with a timeout so that unfixed builds fail
+// cleanly instead of hanging the test runner.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+async function runTest(source: string) {
+  using dir = tempDir("issue-14670", {
+    "fixture.test.ts": source,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "fixture.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 20_000,
+  });
+
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  return { stderr, exitCode, signalCode: proc.signalCode };
+}
+
+test("expect($`...`).rejects.toThrow() does not hang", async () => {
+  const { stderr, exitCode, signalCode } = await runTest(`
+    import { expect, test } from "bun:test";
+    import { $ } from "bun";
+
+    test("shell rejects", async () => {
+      await expect($\`definitely-not-a-real-command-14670\`.quiet()).rejects.toThrow();
+    });
+  `);
+
+  expect(stderr).toContain("1 pass");
+  expect(stderr).toContain("0 fail");
+  expect(signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+}, 30_000);
+
+test("expect($`...`).resolves does not hang", async () => {
+  const { stderr, exitCode, signalCode } = await runTest(`
+    import { expect, test } from "bun:test";
+    import { $ } from "bun";
+
+    test("shell resolves", async () => {
+      await expect($\`echo hi\`.quiet()).resolves.toHaveProperty("exitCode", 0);
+    });
+  `);
+
+  expect(stderr).toContain("1 pass");
+  expect(stderr).toContain("0 fail");
+  expect(signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+}, 30_000);
+
+test("expect(() => $`...`).toThrow() does not hang", async () => {
+  const { stderr, exitCode, signalCode } = await runTest(`
+    import { expect, test } from "bun:test";
+    import { $ } from "bun";
+
+    test("shell fn toThrow", async () => {
+      expect(() => $\`definitely-not-a-real-command-14670\`.quiet()).toThrow();
+    });
+  `);
+
+  expect(stderr).toContain("1 pass");
+  expect(stderr).toContain("0 fail");
+  expect(signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+}, 30_000);
+
+test("expect(lazyPromiseSubclass).rejects does not hang", async () => {
+  // Same bug without Bun Shell: any Promise subclass whose work is kicked
+  // off in an overridden `.then()` would hang `expect().resolves/.rejects`.
+  const { stderr, exitCode, signalCode } = await runTest(`
+    import { expect, test } from "bun:test";
+
+    class LazyReject extends Promise<never> {
+      #started = false;
+      #reject!: (e: unknown) => void;
+      constructor() {
+        let rej!: (e: unknown) => void;
+        super((_, r) => { rej = r; });
+        this.#reject = rej;
+      }
+      then(onfulfilled, onrejected) {
+        if (!this.#started) {
+          this.#started = true;
+          setImmediate(() => this.#reject(new Error("boom")));
+        }
+        return super.then(onfulfilled, onrejected);
+      }
+      static get [Symbol.species]() { return Promise; }
+    }
+
+    test("lazy rejects", async () => {
+      await expect(new LazyReject()).rejects.toThrow("boom");
+    });
+  `);
+
+  expect(stderr).toContain("1 pass");
+  expect(stderr).toContain("0 fail");
+  expect(signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+}, 30_000);


### PR DESCRIPTION
## Reproduction

```ts
import { expect, test } from "bun:test";
import { $ } from "bun";

test("", async () => {
  expect($`bad-command`).rejects.toThrow();
});
```

`bun test` hangs forever (never exits).

## Root cause

`ShellPromise` is a *lazy* Promise subclass — it only starts the shell interpreter when `.then()` is called:

```ts
then(onfulfilled, onrejected) {
  this.#run();  // <-- shell starts here
  return super.then(onfulfilled, onrejected);
}
```

`expect().resolves` / `.rejects` extracts the internal `JSPromise` via `asAnyPromise()` and blocks on it with `waitForPromise()`, which watches the internal promise state directly **without ever calling `.then()`**. So `#run()` never fires, the shell never runs, the promise never settles, and `waitForPromise()` spins forever.

The same hang occurs with `expect(() => $`...`).toThrow()` (the function-returning-a-promise path), and with any user-defined Promise subclass that defers work to `.then()`.

## Fix

Before `waitForPromise()`, if the promise is still pending, call the user-visible `.then()` on the original value — with no handlers — to trigger any lazy initialization. This matches what `await value` does observably. The returned promise is marked handled so a rejection there doesn't surface as an unhandled-rejection warning (we observe the original promise, not the chained one).

Applied at all three `waitForPromise()` sites in `expect.zig`:
- `processPromise` — `.resolves` / `.rejects`
- `getValueAsToThrow` — `expect(fn).toThrow()` where `fn` returns a promise
- `executeCustomMatcher` — async custom matchers

## Verification

```
git stash push -- src/  && bun bd test test/regression/issue/14670.test.ts  → 4 fail (subprocess hangs, killed by timeout)
git stash pop           && bun bd test test/regression/issue/14670.test.ts  → 4 pass
```

The regression test spawns a subprocess with a 20s timeout so unfixed builds fail cleanly instead of hanging the test runner. It covers `.rejects.toThrow()`, `.resolves`, `expect(() => $`...`).toThrow()`, and a shell-free lazy Promise subclass.

Closes #14670
