### PR TITLE
fix: match Node.js fetch error format with TypeError and .cause

### DIFF
--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -708,6 +708,8 @@ pub const FetchTasklet = struct {
             return .{ .AbortReason = reason };
         }
 
+        const globalThis = this.global_this;
+
         // some times we don't have metadata so we also check http.url
         const path = if (this.metadata) |metadata|
             bun.String.cloneUTF8(metadata.url)
@@ -716,16 +718,28 @@ pub const FetchTasklet = struct {
         else
             bun.String.empty;
 
+        const hostname_str = if (this.http) |http_|
+            bun.String.cloneUTF8(http_.url.hostname)
+        else
+            bun.String.empty;
+
         const fetch_error = jsc.SystemError{
             .code = bun.String.static(switch (this.result.fail.?) {
                 error.ConnectionClosed => "ECONNRESET",
+                error.ConnectionRefused => "ECONNREFUSED",
+                error.DNSLookupFailed => "ENOTFOUND",
                 else => |e| @errorName(e),
             }),
             .message = switch (this.result.fail.?) {
                 error.ConnectionClosed => bun.String.static("The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()"),
+                error.DNSLookupFailed => bun.String.createFormat("getaddrinfo ENOTFOUND {f}", .{
+                    hostname_str,
+                }) catch |err| bun.handleOom(err),
                 error.FailedToOpenSocket => bun.String.static("Was there a typo in the url or port?"),
                 error.TooManyRedirects => bun.String.static("The response redirected too many times. For more information, pass `verbose: true` in the second argument to fetch()"),
-                error.ConnectionRefused => bun.String.static("Unable to connect. Is the computer able to access the url?"),
+                error.ConnectionRefused => bun.String.createFormat("connect ECONNREFUSED {f}", .{
+                    path,
+                }) catch |err| bun.handleOom(err),
                 error.RedirectURLInvalid => bun.String.static("Redirect URL in Location header is invalid."),
 
                 error.UNABLE_TO_GET_ISSUER_CERT => bun.String.static("unable to get issuer certificate"),
@@ -800,10 +814,32 @@ pub const FetchTasklet = struct {
                     path,
                 }) catch |err| bun.handleOom(err),
             },
+            .syscall = switch (this.result.fail.?) {
+                error.DNSLookupFailed => bun.String.static("getaddrinfo"),
+                error.ConnectionRefused => bun.String.static("connect"),
+                else => bun.String.empty,
+            },
+            .hostname = hostname_str,
             .path = path,
         };
 
-        return .{ .SystemError = fetch_error };
+        // Create the inner cause error from SystemError
+        const cause_js = fetch_error.toErrorInstance(globalThis);
+
+        // Wrap in a TypeError with message "fetch failed" to match Node.js behavior
+        const outer_error = globalThis.createTypeErrorInstance("fetch failed", .{});
+        outer_error.put(globalThis, "cause", cause_js);
+
+        // Also set .code on the outer error for backward compatibility with existing Bun code
+        const code_str = switch (this.result.fail.?) {
+            error.ConnectionClosed => bun.String.static("ECONNRESET"),
+            error.ConnectionRefused => bun.String.static("ECONNREFUSED"),
+            error.DNSLookupFailed => bun.String.static("ENOTFOUND"),
+            else => |e| bun.String.static(@errorName(e)),
+        };
+        outer_error.put(globalThis, "code", code_str.toJS(globalThis) catch .js_undefined);
+
+        return .{ .JSValue = .create(outer_error, globalThis) };
     }
 
     pub fn onReadableStreamAvailable(ctx: *anyopaque, globalThis: *jsc.JSGlobalObject, readable: jsc.WebCore.ReadableStream) void {

--- a/src/http.zig
+++ b/src/http.zig
@@ -265,9 +265,16 @@ pub fn onTimeout(
 }
 pub fn onConnectError(
     client: *HTTPClient,
+    errno: c_int,
 ) void {
-    log("onConnectError  {s}\n", .{client.url.href});
-    client.fail(error.ConnectionRefused);
+    log("onConnectError  {s} errno={d}\n", .{ client.url.href, errno });
+    // Negative errno values indicate EAI (DNS) errors from getaddrinfo.
+    // Positive values are system errno codes (e.g. ECONNREFUSED).
+    if (errno < 0) {
+        client.fail(error.DNSLookupFailed);
+    } else {
+        client.fail(error.ConnectionRefused);
+    }
 }
 
 pub inline fn getAllocator() std.mem.Allocator {

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -361,12 +361,12 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             pub fn onConnectError(
                 ptr: *anyopaque,
                 socket: HTTPSocket,
-                _: c_int,
+                code: c_int,
             ) void {
                 const tagged = getTagged(ptr);
                 markTaggedSocketAsDead(socket, tagged);
                 if (tagged.get(HTTPClient)) |client| {
-                    client.onConnectError();
+                    client.onConnectError(code);
                 }
                 // us_connecting_socket_close is always called internally by uSockets
             }

--- a/test/js/bun/test/parallel/test-http-should-error-with-faulty-args.ts
+++ b/test/js/bun/test/parallel/test-http-should-error-with-faulty-args.ts
@@ -29,6 +29,11 @@ try {
   await res.text();
   expect(true).toBe("unreacheable");
 } catch (err) {
+  // fetch errors are now TypeError with "fetch failed" message and .cause (Node.js compat)
+  expect(err).toBeInstanceOf(TypeError);
+  expect(err.message).toBe("fetch failed");
   expect(err.code).toBe("FailedToOpenSocket");
-  expect(err.message).toBe("Was there a typo in the url or port?");
+  expect(err.cause).toBeDefined();
+  expect(err.cause.code).toBe("FailedToOpenSocket");
+  expect(err.cause.message).toBe("Was there a typo in the url or port?");
 }

--- a/test/regression/issue/20486.test.ts
+++ b/test/regression/issue/20486.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "bun:test";
+
+// GitHub Issue #20486: Native fetch incompatibilities with NodeJS error format and codes
+// Fetch errors should be TypeError with "fetch failed" message and a .cause property
+// containing the detailed error information, matching Node.js behavior.
+
+test("fetch DNS failure returns TypeError with ENOTFOUND cause", async () => {
+  try {
+    await fetch("http://non-existing-domain-ever.com/");
+    expect.unreachable();
+  } catch (e: any) {
+    // Outer error should be a TypeError with message "fetch failed"
+    expect(e).toBeInstanceOf(TypeError);
+    expect(e.message).toBe("fetch failed");
+
+    // Should have a .cause property
+    expect(e.cause).toBeDefined();
+    expect(e.cause).toBeInstanceOf(Error);
+
+    // Cause should have ENOTFOUND code and getaddrinfo syscall
+    expect(e.cause.code).toBe("ENOTFOUND");
+    expect(e.cause.syscall).toBe("getaddrinfo");
+    expect(e.cause.hostname).toBe("non-existing-domain-ever.com");
+  }
+}, 30_000);
+
+test("fetch connection refused returns TypeError with ECONNREFUSED cause", async () => {
+  try {
+    await fetch("http://localhost:19999/");
+    expect.unreachable();
+  } catch (e: any) {
+    // Outer error should be a TypeError with message "fetch failed"
+    expect(e).toBeInstanceOf(TypeError);
+    expect(e.message).toBe("fetch failed");
+
+    // Should have a .cause property
+    expect(e.cause).toBeDefined();
+    expect(e.cause).toBeInstanceOf(Error);
+
+    // Cause should have ECONNREFUSED code and connect syscall
+    expect(e.cause.code).toBe("ECONNREFUSED");
+    expect(e.cause.syscall).toBe("connect");
+  }
+});
+
+test("fetch invalid URL returns TypeError with ERR_INVALID_URL cause", async () => {
+  try {
+    await fetch("invalid-url");
+    expect.unreachable();
+  } catch (e: any) {
+    // Outer error should be a TypeError
+    expect(e).toBeInstanceOf(TypeError);
+    expect(e.message).toBe("Failed to parse URL from invalid-url");
+
+    // Should have a .cause property that is also a TypeError
+    expect(e.cause).toBeDefined();
+    expect(e.cause).toBeInstanceOf(TypeError);
+
+    // Cause should have ERR_INVALID_URL code and input property
+    expect(e.cause.code).toBe("ERR_INVALID_URL");
+    expect(e.cause.input).toBe("invalid-url");
+  }
+});
+
+test("fetch invalid protocol returns TypeError with cause", async () => {
+  try {
+    await fetch("ftp://example.com");
+    expect.unreachable();
+  } catch (e: any) {
+    // Outer error should be a TypeError with "fetch failed" message
+    expect(e).toBeInstanceOf(TypeError);
+    expect(e.message).toBe("fetch failed");
+
+    // Should have a .cause property
+    expect(e.cause).toBeDefined();
+    expect(e.cause).toBeInstanceOf(Error);
+    expect(e.cause.message).toBe("unknown scheme");
+  }
+});
+
+test("fetch DNS failure is distinguishable from connection refused", async () => {
+  // DNS failure
+  let dnsError: any;
+  try {
+    await fetch("http://non-existing-domain-ever.com/");
+  } catch (e: any) {
+    dnsError = e;
+  }
+
+  // Connection refused
+  let connError: any;
+  try {
+    await fetch("http://localhost:19999/");
+  } catch (e: any) {
+    connError = e;
+  }
+
+  // Both should be TypeErrors with "fetch failed" message
+  expect(dnsError).toBeInstanceOf(TypeError);
+  expect(connError).toBeInstanceOf(TypeError);
+  expect(dnsError.message).toBe("fetch failed");
+  expect(connError.message).toBe("fetch failed");
+
+  // But their causes should have different error codes
+  expect(dnsError.cause.code).toBe("ENOTFOUND");
+  expect(connError.cause.code).toBe("ECONNREFUSED");
+
+  // And different syscalls
+  expect(dnsError.cause.syscall).toBe("getaddrinfo");
+  expect(connError.cause.syscall).toBe("connect");
+}, 30_000);


### PR DESCRIPTION
## Summary

Fixes #20486 - Bun's `fetch()` error format now matches Node.js behavior:

- **Network errors are now `TypeError`** with message `"fetch failed"` and a `.cause` property containing the detailed error (per fetch spec 12.3)
- **DNS failures use `ENOTFOUND`** code with `getaddrinfo` syscall (previously indistinguishable from connection refused)
- **Connection refused uses `ECONNREFUSED`** code with `connect` syscall (previously generic `ConnectionRefused`)
- **Invalid URL** wraps cause `TypeError` with `ERR_INVALID_URL` code and `input` property
- **Invalid protocol** wraps cause `Error` with `"unknown scheme"` message
- **Backward-compatible** `.code` property preserved on outer error for existing Bun code

### Changes

- `packages/bun-usockets/src/context.c`: Propagate DNS error codes and socket errors through `c->error` field
- `src/http/HTTPContext.zig`: Pass errno from `onConnectError` callback
- `src/http.zig`: Use errno to distinguish DNS failures (`error.DNSLookupFailed`) from connection refused
- `src/deps/uws/socket.zig`: Check C errno after sync connect failure to detect cached DNS errors
- `src/bun.js/webcore/fetch/FetchTasklet.zig`: Create `TypeError("fetch failed")` with `.cause` containing `SystemError`
- `src/bun.js/webcore/fetch.zig`: Wrap invalid URL/protocol errors with `.cause`

## Test plan

- [x] `bun bd test test/regression/issue/20486.test.ts` - 5 new tests pass
- [x] `USE_SYSTEM_BUN=1 bun test test/regression/issue/20486.test.ts` - all 5 fail (validates tests)
- [x] `bun bd test test/js/web/fetch/fetch-args.test.ts` - 47 existing tests pass
- [x] `bun bd test test/js/bun/http/serve.test.ts -t "abruptly stop"` - backward compat tests pass
- [x] `bun bd test ./test/js/bun/test/parallel/test-http-should-error-with-faulty-args.ts` - updated test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)