### PR TITLE
fix: don't silently convert unknown HTTP methods to GET in fetch()

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -86,6 +86,48 @@ static constexpr auto supportedHttpMethods = makeArray<std::string_view>(
     "UNSUBSCRIBE"
 );
 
+// Same as supportedHttpMethods but also includes the "*" (ANY) method token,
+// so that handlers registered with "*" also catch unknown/custom HTTP methods
+// that don't match any known method node in the router.
+static constexpr auto supportedHttpMethodsAndAny = makeArray<std::string_view>(
+    "ACL",
+    "BIND",
+    "CHECKOUT",
+    "CONNECT",
+    "COPY",
+    "DELETE",
+    "GET",
+    "HEAD",
+    "LINK",
+    "LOCK",
+    "M-SEARCH",
+    "MERGE",
+    "MKACTIVITY",
+    "MKCALENDAR",
+    "MKCOL",
+    "MOVE",
+    "NOTIFY",
+    "OPTIONS",
+    "PATCH",
+    "POST",
+    "PROPFIND",
+    "PROPPATCH",
+    "PURGE",
+    "PUT",
+    "QUERY",
+    "REBIND",
+    "REPORT",
+    "SEARCH",
+    "SOURCE",
+    "SUBSCRIBE",
+    "TRACE",
+    "UNBIND",
+    "UNLINK",
+    "UNLOCK",
+    "UNSUBSCRIBE",
+    "*"
+);
+
 } // namespace detail
 
 template<bool> struct HttpResponse;
@@ -586,7 +628,9 @@ public:
         std::string_view method_sv_buffer;
         // When it's NOT node:http, allow the uWS default precedence ordering.
         if (method == "*" && !httpContextData->flags.useStrictMethodValidation) {
-            methods = detail::supportedHttpMethods;
+            // Register for all known methods AND the "*" (ANY) node so that
+            // unknown/custom methods also get routed to this handler.
+            methods = detail::supportedHttpMethodsAndAny;
         } else {
             method_buffer = std::string(method);
             method_sv_buffer = std::string_view(method_buffer);

--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -1080,6 +1080,7 @@ pub const FetchTasklet = struct {
                 .reject_unauthorized = fetch_options.reject_unauthorized,
                 .verbose = fetch_options.verbose,
                 .tls_props = fetch_options.ssl_config,
+                .custom_method = fetch_options.custom_method,
             },
         );
         // enable streaming the write side
@@ -1261,6 +1262,7 @@ pub const FetchTasklet = struct {
         unix_socket_path: ZigString.Slice,
         ssl_config: ?*SSLConfig = null,
         upgraded_connection: bool = false,
+        custom_method: []const u8 = "",
     };
 
     pub fn queue(

--- a/src/http.zig
+++ b/src/http.zig
@@ -2514,7 +2514,7 @@ pub fn handleResponseMetadata(
                     // - internalResponse’s status is 301 or 302 and request’s method is `POST`
                     // - internalResponse’s status is 303 and request’s method is not `GET` or `HEAD`
                     // then:
-                    if (((status_code == 301 or status_code == 302) and (this.method == .POST or this.custom_method_len > 0)) or
+                    if (((status_code == 301 or status_code == 302) and this.method == .POST) or
                         (status_code == 303 and (this.method != .GET or this.custom_method_len > 0) and this.method != .HEAD))
                     {
                         // - Set request’s method to `GET` and request’s body to null.

--- a/src/http.zig
+++ b/src/http.zig
@@ -613,6 +613,7 @@ pub fn methodName(this: *const HTTPClient) []const u8 {
 }
 
 pub fn setCustomMethod(this: *HTTPClient, method_str: []const u8) void {
+    assert(method_str.len <= this.custom_method_buf.len);
     const len: u8 = @intCast(@min(method_str.len, this.custom_method_buf.len));
     @memcpy(this.custom_method_buf[0..len], method_str[0..len]);
     this.custom_method_len = len;
@@ -2601,7 +2602,7 @@ pub fn handleResponseMetadata(
                         }
                     }
                     this.state.flags.is_redirect_pending = true;
-                    if (this.method.hasRequestBody()) {
+                    if (this.method.hasRequestBody() or this.custom_method_len > 0) {
                         this.state.flags.resend_request_body_on_redirect = true;
                     }
                 },

--- a/src/http.zig
+++ b/src/http.zig
@@ -2513,11 +2513,12 @@ pub fn handleResponseMetadata(
                     // - internalResponse’s status is 301 or 302 and request’s method is `POST`
                     // - internalResponse’s status is 303 and request’s method is not `GET` or `HEAD`
                     // then:
-                    if (((status_code == 301 or status_code == 302) and this.method == .POST) or
-                        (status_code == 303 and this.method != .GET and this.method != .HEAD))
+                    if (((status_code == 301 or status_code == 302) and (this.method == .POST or this.custom_method_len > 0)) or
+                        (status_code == 303 and (this.method != .GET or this.custom_method_len > 0) and this.method != .HEAD))
                     {
                         // - Set request’s method to `GET` and request’s body to null.
                         this.method = .GET;
+                        this.custom_method_len = 0;
 
                         // https://github.com/oven-sh/bun/issues/6053
                         if (this.header_entries.len > 0) {

--- a/src/http/AsyncHTTP.zig
+++ b/src/http/AsyncHTTP.zig
@@ -103,7 +103,10 @@ pub const Options = struct {
     disable_decompression: ?bool = null,
     reject_unauthorized: ?bool = null,
     tls_props: ?*SSLConfig = null,
+    custom_method: []const u8 = "",
 };
+
+pub const max_custom_method_len = 24;
 
 const Preconnect = struct {
     async_http: AsyncHTTP,
@@ -189,6 +192,9 @@ pub fn init(
         .proxy_headers = options.proxy_headers,
         .redirect_type = redirect_type,
     };
+    if (options.custom_method.len > 0) {
+        this.client.setCustomMethod(options.custom_method);
+    }
     if (options.unix_socket_path) |val| {
         assert(this.client.unix_socket_path.length() == 0);
         this.client.unix_socket_path = val;

--- a/test/regression/issue/18406.test.ts
+++ b/test/regression/issue/18406.test.ts
@@ -87,11 +87,11 @@ test("Bun.serve() with fetch handler receives requests with unknown methods", as
 
 test("fetch() rejects invalid HTTP method tokens", async () => {
   // Methods with spaces should be rejected
-  expect(fetch("http://localhost:1/test", { method: "INVALID METHOD" })).rejects.toThrow();
+  await expect(fetch("http://localhost:1/test", { method: "INVALID METHOD" })).rejects.toThrow();
 
   // Empty method should be rejected
-  expect(fetch("http://localhost:1/test", { method: "" })).rejects.toThrow();
+  await expect(fetch("http://localhost:1/test", { method: "" })).rejects.toThrow();
 
   // Methods with special characters should be rejected
-  expect(fetch("http://localhost:1/test", { method: "GET\r\n" })).rejects.toThrow();
+  await expect(fetch("http://localhost:1/test", { method: "GET\r\n" })).rejects.toThrow();
 });

--- a/test/regression/issue/18406.test.ts
+++ b/test/regression/issue/18406.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/18406
+// Unknown random HTTP methods should not be silently routed to GET handlers
+
+test("fetch() with unknown method sends correct method on wire", async () => {
+  // Use a raw TCP server to verify what fetch actually sends
+  const net = require("net");
+  const receivedMethods: string[] = [];
+  const server = net.createServer((socket: any) => {
+    socket.on("data", (data: Buffer) => {
+      const line = data.toString().split("\r\n")[0];
+      const method = line.split(" ")[0];
+      receivedMethods.push(method);
+      socket.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+      socket.end();
+    });
+  });
+  await new Promise<void>(resolve => server.listen(0, resolve));
+  const port = server.address().port;
+
+  try {
+    await fetch(`http://localhost:${port}/test`, { method: "CHICKEN" });
+    await fetch(`http://localhost:${port}/test`, { method: "BUN" });
+    await fetch(`http://localhost:${port}/test`, { method: "GET" });
+    await fetch(`http://localhost:${port}/test`, { method: "POST" });
+    await fetch(`http://localhost:${port}/test`, { method: "PATCH" });
+
+    expect(receivedMethods).toEqual(["CHICKEN", "BUN", "GET", "POST", "PATCH"]);
+  } finally {
+    server.close();
+  }
+});
+
+test("Bun.serve() with routes does not route unknown methods to GET handler", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    routes: {
+      "/test": {
+        GET: () => new Response("get handler"),
+      },
+    },
+  });
+
+  // GET should work as normal
+  const getRes = await fetch(new URL("/test", server.url), { method: "GET" });
+  expect(getRes.status).toBe(200);
+  expect(await getRes.text()).toBe("get handler");
+
+  // Unknown methods should NOT be routed to the GET handler
+  const bunRes = await fetch(new URL("/test", server.url), { method: "BUN" });
+  expect(bunRes.status).not.toBe(200);
+
+  // Known but unregistered methods should return 404
+  const postRes = await fetch(new URL("/test", server.url), { method: "POST" });
+  expect(postRes.status).toBe(404);
+});
+
+test("Bun.serve() with fetch handler receives requests with unknown methods", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    routes: {
+      "/test": {
+        GET: () => new Response("get handler"),
+      },
+    },
+    fetch(req) {
+      return new Response("fetch handler", { status: 418 });
+    },
+  });
+
+  // GET should still route to the specific handler
+  const getRes = await fetch(new URL("/test", server.url), { method: "GET" });
+  expect(getRes.status).toBe(200);
+  expect(await getRes.text()).toBe("get handler");
+
+  // Unknown method should fall through to fetch handler, not GET route
+  const bunRes = await fetch(new URL("/test", server.url), { method: "BUN" });
+  expect(bunRes.status).toBe(418);
+  expect(await bunRes.text()).toBe("fetch handler");
+
+  // POST should also go to fetch handler since no POST route defined
+  const postRes = await fetch(new URL("/test", server.url), { method: "POST" });
+  expect(postRes.status).toBe(418);
+  expect(await postRes.text()).toBe("fetch handler");
+});
+
+test("fetch() rejects invalid HTTP method tokens", async () => {
+  // Methods with spaces should be rejected
+  expect(fetch("http://localhost:1/test", { method: "INVALID METHOD" })).rejects.toThrow();
+
+  // Empty method should be rejected
+  expect(fetch("http://localhost:1/test", { method: "" })).rejects.toThrow();
+
+  // Methods with special characters should be rejected
+  expect(fetch("http://localhost:1/test", { method: "GET\r\n" })).rejects.toThrow();
+});

--- a/test/regression/issue/18406.test.ts
+++ b/test/regression/issue/18406.test.ts
@@ -1,13 +1,13 @@
 import { expect, test } from "bun:test";
+import { createServer } from "net";
 
 // https://github.com/oven-sh/bun/issues/18406
 // Unknown random HTTP methods should not be silently routed to GET handlers
 
 test("fetch() with unknown method sends correct method on wire", async () => {
   // Use a raw TCP server to verify what fetch actually sends
-  const net = require("net");
   const receivedMethods: string[] = [];
-  const server = net.createServer((socket: any) => {
+  const server = createServer((socket: any) => {
     socket.on("data", (data: Buffer) => {
       const line = data.toString().split("\r\n")[0];
       const method = line.split(" ")[0];


### PR DESCRIPTION
## Summary
- **Client side**: `fetch()` now passes through custom/unknown HTTP method strings (like `"BUN"`, `"CHICKEN"`) to the wire instead of silently converting them to `"GET"`. This matches Node.js behavior and the Fetch spec (RFC 9110), which allows any valid HTTP token as a method.
- **Server side**: The uWS router's ANY (`*`) handler now also registers on the actual `*` method node, so unknown methods hitting `Bun.serve()` get routed to the catch-all/404 handler instead of causing a connection drop.

### Root Cause
`Method.fromJS()` returns `null` for unknown methods, and `fetch.zig` used `orelse .GET` to default to GET. This caused `fetch(url, {method: "BUN"})` to actually send `GET /path HTTP/1.1` on the wire, which then matched GET-specific route handlers on the server.

### Before
```
fetch(url, {method: "BUN"}) → server receives GET → 200 (GET handler response)
```

### After
```
fetch(url, {method: "BUN"}) → server receives BUN → 404 (no handler for that method)
```

Fixes #18406

## Test plan
- [x] New regression test `test/regression/issue/18406.test.ts` with 4 test cases
- [x] Verified test fails with system bun (3 of 4 tests fail)
- [x] Verified test passes with debug build (4/4 pass)
- [x] Existing `bun-serve-routes.test.ts` passes (40/40)
- [x] Existing `serve.test.ts` passes (no new failures)
- [x] Existing `fetch.test.ts` has no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)