### PR TITLE
fix: enable BYOB reader support for Blob.stream(), Response.body, and File.stream()

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2762,6 +2762,7 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
 
     putDirectBuiltinFunction(vm, this, builtinNames.createFIFOPrivateName(), streamInternalsCreateFIFOCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectBuiltinFunction(vm, this, builtinNames.createEmptyReadableStreamPrivateName(), readableStreamCreateEmptyReadableStreamCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    putDirectBuiltinFunction(vm, this, builtinNames.createEmptyByteReadableStreamPrivateName(), readableStreamCreateEmptyByteReadableStreamCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectBuiltinFunction(vm, this, builtinNames.createUsedReadableStreamPrivateName(), readableStreamCreateUsedReadableStreamCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectBuiltinFunction(vm, this, builtinNames.createNativeReadableStreamPrivateName(), readableStreamCreateNativeReadableStreamCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectBuiltinFunction(vm, this, builtinNames.requireESMPrivateName(), commonJSRequireESMCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -2987,6 +2987,17 @@ JSC::EncodedJSValue JSC__JSModuleLoader__evaluate(JSC::JSGlobalObject* globalObj
     return JSValue::encode(emptyStream);
 }
 
+[[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue ReadableStream__emptyByte(Zig::GlobalObject* globalObject)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto clientData = WebCore::clientData(vm);
+    auto* function = globalObject->getDirect(vm, clientData->builtinNames().createEmptyByteReadableStreamPrivateName()).getObject();
+    JSValue emptyStream = JSC::call(globalObject, function, JSC::ArgList(), "ReadableStream.create"_s);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(emptyStream);
+}
+
 [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue ReadableStream__used(Zig::GlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/bun.js/webcore/ReadableStream.zig
+++ b/src/bun.js/webcore/ReadableStream.zig
@@ -299,7 +299,7 @@ pub fn fromOwnedSlice(globalThis: *JSGlobalObject, bytes: []u8, recommended_chun
 pub fn fromBlobCopyRef(globalThis: *JSGlobalObject, blob: *const Blob, recommended_chunk_size: Blob.SizeType) bun.JSError!jsc.JSValue {
     jsc.markBinding(@src());
     var store = blob.store orelse {
-        return ReadableStream.empty(globalThis);
+        return ReadableStream.emptyByte(globalThis);
     };
     switch (store.data) {
         .bytes => {
@@ -392,6 +392,11 @@ pub fn fromPipe(
 pub fn empty(globalThis: *JSGlobalObject) bun.JSError!jsc.JSValue {
     jsc.markBinding(@src());
     return bun.cpp.ReadableStream__empty(globalThis);
+}
+
+pub fn emptyByte(globalThis: *JSGlobalObject) bun.JSError!jsc.JSValue {
+    jsc.markBinding(@src());
+    return bun.cpp.ReadableStream__emptyByte(globalThis);
 }
 
 pub fn used(globalThis: *JSGlobalObject) bun.JSError!jsc.JSValue {

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -79,6 +79,7 @@ using namespace JSC;
     macro(controller) \
     macro(cork) \
     macro(createCommonJSModule) \
+    macro(createEmptyByteReadableStream) \
     macro(createEmptyReadableStream) \
     macro(createFIFO) \
     macro(createInternalModuleById) \

--- a/test/regression/issue/16402.test.ts
+++ b/test/regression/issue/16402.test.ts
@@ -1,0 +1,166 @@
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+
+// Issue #16402: Blob.stream(), Response.body, and File.stream() should return
+// byte streams (ReadableByteStreamController) per the W3C File API and Fetch
+// specs, enabling BYOB reader support.
+
+test("Blob.stream() supports BYOB reader", async () => {
+  const blob = new Blob(["hello world"]);
+  const stream = blob.stream();
+  const reader = stream.getReader({ mode: "byob" });
+
+  let buf = new Uint8Array(64);
+  const result = await reader.read(buf);
+  expect(result.done).toBe(false);
+  expect(new TextDecoder().decode(result.value)).toBe("hello world");
+
+  // Read again to get done signal
+  buf = new Uint8Array(64);
+  const result2 = await reader.read(buf);
+  expect(result2.done).toBe(true);
+  expect(result2.value!.byteLength).toBe(0);
+
+  reader.releaseLock();
+});
+
+test("Blob.stream() still works with default reader", async () => {
+  const blob = new Blob(["hello default"]);
+  const stream = blob.stream();
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+
+  const combined = new Uint8Array(chunks.reduce((a, c) => a + c.length, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.length;
+  }
+  expect(new TextDecoder().decode(combined)).toBe("hello default");
+});
+
+test("Response.body supports BYOB reader", async () => {
+  const response = new Response("hello response");
+  const reader = response.body!.getReader({ mode: "byob" });
+
+  let buf = new Uint8Array(64);
+  const result = await reader.read(buf);
+  expect(result.done).toBe(false);
+  expect(new TextDecoder().decode(result.value)).toBe("hello response");
+
+  reader.releaseLock();
+});
+
+test("Response.body still works with default reader", async () => {
+  const response = new Response("hello response default");
+  const reader = response.body!.getReader();
+  const chunks: Uint8Array[] = [];
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+
+  const combined = new Uint8Array(chunks.reduce((a, c) => a + c.length, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.length;
+  }
+  expect(new TextDecoder().decode(combined)).toBe("hello response default");
+});
+
+test("empty Blob.stream() supports BYOB reader", async () => {
+  const blob = new Blob([]);
+  const stream = blob.stream();
+  const reader = stream.getReader({ mode: "byob" });
+
+  const buf = new Uint8Array(64);
+  const result = await reader.read(buf);
+  expect(result.done).toBe(true);
+
+  reader.releaseLock();
+});
+
+test("Bun.file().stream() supports BYOB reader", async () => {
+  using dir = tempDir("byob-test", {
+    "test.txt": "hello from file",
+  });
+
+  const file = Bun.file(`${dir}/test.txt`);
+  const stream = file.stream();
+  const reader = stream.getReader({ mode: "byob" });
+
+  let buf = new Uint8Array(64);
+  const result = await reader.read(buf);
+  expect(result.done).toBe(false);
+  expect(new TextDecoder().decode(result.value)).toBe("hello from file");
+
+  reader.releaseLock();
+});
+
+test("large Blob.stream() with BYOB reader reads all data", async () => {
+  const data = new Uint8Array(1024 * 1024); // 1MB
+  data.fill(42);
+  const blob = new Blob([data]);
+  const stream = blob.stream();
+  const reader = stream.getReader({ mode: "byob" });
+
+  let total = 0;
+  while (true) {
+    let buf = new Uint8Array(65536);
+    const { done, value } = await reader.read(buf);
+    if (done) break;
+    total += value.byteLength;
+    // Verify the data is correct
+    for (let i = 0; i < value.byteLength; i++) {
+      if (value[i] !== 42) {
+        expect(value[i]).toBe(42); // will fail with helpful message
+        return;
+      }
+    }
+  }
+  expect(total).toBe(1024 * 1024);
+});
+
+test("Blob.stream() BYOB reader works with music-metadata pattern", async () => {
+  // This is the pattern used by strtok3/music-metadata that was failing
+  const blob = new Blob([new Uint8Array([0x49, 0x44, 0x33, 0x04, 0x00])]);
+  const stream = blob.stream();
+
+  // First try BYOB reader (the preferred path in strtok3)
+  const reader = stream.getReader({ mode: "byob" });
+  const buf = new Uint8Array(5);
+  const result = await reader.read(buf);
+
+  expect(result.done).toBe(false);
+  expect(result.value).toBeInstanceOf(Uint8Array);
+  expect(result.value!.byteLength).toBe(5);
+  expect(Array.from(result.value!)).toEqual([0x49, 0x44, 0x33, 0x04, 0x00]);
+});
+
+test("fetch Response.body supports BYOB reader", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response("byob fetch test");
+    },
+  });
+
+  const response = await fetch(server.url);
+  const reader = response.body!.getReader({ mode: "byob" });
+
+  let buf = new Uint8Array(64);
+  const result = await reader.read(buf);
+  expect(result.done).toBe(false);
+  expect(new TextDecoder().decode(result.value)).toBe("byob fetch test");
+
+  reader.releaseLock();
+});


### PR DESCRIPTION
## Summary

- Fixes `Blob.stream()`, `Response.body`, and `File.stream()` to return byte streams (`ReadableByteStreamController`) as required by the W3C File API and Fetch specs
- Enables BYOB (Bring Your Own Buffer) reader support: `stream.getReader({ mode: "byob" })` now works
- Previously, these streams used `ReadableStreamDefaultController`, which caused `TypeError: ReadableStreamBYOBReader needs a ReadableByteStreamController`

### Key changes

1. **`NativeReadableStreamSource` now uses `type: "bytes"`** to create a `ReadableByteStreamController`. The `autoAllocateChunkSize` is kept as a private field (`#chunkSize`) rather than a public property so the controller doesn't create `pendingPullInto` descriptors, which were incompatible with the push-based native stream model.

2. **`readableStreamClose` handles BYOB readers** — pending `readIntoRequests` are now properly fulfilled with `{ done: true }` when the stream closes, preventing hangs on the final read.

3. **`readableStreamReaderGenericRelease` handles byte controllers** — the `$resume` call now checks both `underlyingSource` and `underlyingByteSource` to avoid crashes on `releaseLock()`.

4. **Lazy initialization is triggered for BYOB readers** — `getReader({ mode: "byob" })` now triggers the deferred `start()` call, same as default readers.

5. **Empty blob streams** use a dedicated `createEmptyByteReadableStream` to return a proper byte stream.

Closes #16402

## Test plan

- [x] New regression test: `test/regression/issue/16402.test.ts` (9 tests covering Blob, Response, File, empty blob, large blob, BYOB pattern from music-metadata, and fetch)
- [x] Existing tests pass: `direct-readable-stream.test.tsx` (229 pass), `readablestream-helpers.test.ts` (30 pass), `blob.test.ts` (9 pass), `body-stream.test.ts` (4883 pass), `streams.test.js` (66 pass, 2 pre-existing failures unrelated to this change)
- [x] Verified test fails on system bun v1.3.9 and passes on debug build

🤖 Generated with [Claude Code](https://claude.com/claude-code)