### PR TITLE
fix: release ReadableStream Strong ref on S3 download stream cancel

### DIFF
--- a/test/js/bun/s3/s3-stream-cancel-leak.test.ts
+++ b/test/js/bun/s3/s3-stream-cancel-leak.test.ts
@@ -1,0 +1,89 @@
+import { S3Client } from "bun";
+import { heapStats } from "bun:jsc";
+import { expect, test } from "bun:test";
+
+// Test that ReadableStream objects from cancelled S3 download streams are properly GC'd.
+//
+// When a streaming S3 download body is cancelled mid-stream, S3DownloadStreamWrapper's
+// readable_stream_ref (a Strong GC root) is not released because:
+//   1. ByteStream.onCancel() doesn't notify the S3DownloadStreamWrapper
+//   2. The S3 download continues in the background, so has_more never becomes false
+//   3. The Strong ref prevents GC of the ReadableStream
+//
+// This is the same pattern as the FetchTasklet stream cancel leak.
+
+test("ReadableStream from S3 stream() should be GC'd after reader.cancel()", async () => {
+  // Use a raw TCP server to mock an S3 GET response.
+  // The server sends one HTTP chunk immediately, then keeps the connection open
+  // to simulate a large file download in progress.
+  using server = Bun.listen({
+    port: 0,
+    hostname: "127.0.0.1",
+    socket: {
+      data(socket) {
+        // Respond to any incoming request with a chunked 200 OK
+        socket.write(
+          "HTTP/1.1 200 OK\r\n" +
+            "Transfer-Encoding: chunked\r\n" +
+            "Connection: keep-alive\r\n" +
+            "Content-Type: application/octet-stream\r\n" +
+            "\r\n" +
+            "400\r\n" +
+            Buffer.alloc(0x400, "x").toString() +
+            "\r\n",
+        );
+        // Don't send terminal chunk "0\r\n\r\n" — keep connection open
+      },
+      open() {},
+      close() {},
+      error() {},
+    },
+  });
+
+  const s3 = new S3Client({
+    accessKeyId: "test",
+    secretAccessKey: "test",
+    endpoint: `http://127.0.0.1:${server.port}`,
+    bucket: "test",
+  });
+
+  const N = 30;
+
+  // Warmup: ensure JIT, lazy init, and connection pool are warmed up
+  for (let i = 0; i < 5; i++) {
+    const file = s3.file(`warmup-${i}.bin`);
+    const stream = file.stream();
+    const reader = stream.getReader();
+    await reader.read();
+    await reader.cancel();
+  }
+
+  Bun.gc(true);
+  await Bun.sleep(10);
+  Bun.gc(true);
+
+  const baseline = heapStats().objectTypeCounts.ReadableStream ?? 0;
+
+  // Main test: stream, read one chunk, cancel, repeat N times
+  for (let i = 0; i < N; i++) {
+    const file = s3.file(`test-${i}.bin`);
+    const stream = file.stream();
+    const reader = stream.getReader();
+    await reader.read();
+    await reader.cancel();
+  }
+
+  // Allow finalizers to run, then GC aggressively
+  Bun.gc(true);
+  await Bun.sleep(50);
+  Bun.gc(true);
+  await Bun.sleep(50);
+  Bun.gc(true);
+
+  const after = heapStats().objectTypeCounts.ReadableStream ?? 0;
+  const leaked = after - baseline;
+
+  // With the bug: leaked ≈ N (each cancelled stream's Strong ref prevents GC)
+  // When fixed: leaked should be near 0 (Strong ref released on cancel)
+  expect(leaked).toBeLessThanOrEqual(5);
+});


### PR DESCRIPTION
## Summary

Same issue as #27191 (FetchTasklet), but in `S3DownloadStreamWrapper` (`src/s3/client.zig`).

When a streaming S3 download body is cancelled via `reader.cancel()`, `S3DownloadStreamWrapper.readable_stream_ref` (a `ReadableStream.Strong` GC root) was never released. The S3 download continued in the background, and the Strong ref prevented GC of the ReadableStream — leaking memory until the download eventually completed.

## Root Cause

`ByteStream.onCancel()` cleaned up its own state but **did not notify the `S3DownloadStreamWrapper`**. The wrapper only called `deinit()` (which releases the Strong ref) when `has_more == false` — i.e., when the S3 download fully completed. If the user cancelled the stream mid-download, the Strong ref was held until the entire file finished downloading in the background.

This is the exact same pattern that was fixed for `FetchTasklet` in #27191.

## Fix

- Register a `cancel_handler` on the `ByteStream.Source` that releases `readable_stream_ref` when the stream is cancelled. The download callback will see `readable_stream_ref.get()` return `null` and skip data delivery until the download finishes and `deinit()` cleans up the remaining resources.
- Add `clearStreamCancelHandler()` in `deinit()` to null the `cancel_handler`/`cancel_ctx` on the `ByteStream.Source`, preventing use-after-free when the wrapper is freed before `cancel()` is called (e.g., download completes normally).

## Test

Added `test/js/bun/s3/s3-stream-cancel-leak.test.ts` — uses a raw TCP server (`Bun.listen`) that mocks an S3 GET response: sends one HTTP chunk then keeps the connection open. Client streams 30 times via `s3.file().stream()`, reads one chunk, cancels, then asserts `heapStats().objectTypeCounts.ReadableStream` does not accumulate. Before the fix, all 30 ReadableStreams leaked; after the fix, 0 leak.