### PR TITLE
fix(shell): builtin `rm` returns wrong exit code in quiet mode

### DIFF
--- a/src/shell/builtin/rm.zig
+++ b/src/shell/builtin/rm.zig
@@ -289,7 +289,7 @@ pub noinline fn next(this: *Rm) Yield {
     }
 
     switch (this.state) {
-        .done => return this.bltn().done(0),
+        .done => return this.bltn().done(this.state.done.exit_code),
         .err => return this.bltn().done(this.state.err),
         else => unreachable,
     }
@@ -430,7 +430,7 @@ pub fn onShellRmTaskDone(this: *Rm, task: *ShellRmTask) void {
     if (tasks_done >= this.state.exec.total_tasks and
         exec.getOutputCount(.output_done) >= exec.getOutputCount(.output_count))
     {
-        this.state = .{ .done = .{ .exit_code = if (exec.err) |theerr| theerr.errno else 0 } };
+        this.state = .{ .done = .{ .exit_code = if (exec.err != null) 1 else 0 } };
         this.next().run();
     }
 }

--- a/test/regression/issue/18161.test.ts
+++ b/test/regression/issue/18161.test.ts
@@ -1,0 +1,46 @@
+import { $ } from "bun";
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+
+describe("shell .quiet() should preserve exit codes", () => {
+  test("builtin rm with .quiet() throws on failure", async () => {
+    using dir = tempDir("issue-18161", {});
+    try {
+      await $`rm ${dir}/nonexistent-file.txt`.quiet();
+      expect.unreachable();
+    } catch (e: any) {
+      expect(e.exitCode).not.toBe(0);
+    }
+  });
+
+  test("builtin rm with .nothrow().quiet() returns non-zero exit code", async () => {
+    using dir = tempDir("issue-18161", {});
+    const result = await $`rm ${dir}/nonexistent-file.txt`.nothrow().quiet();
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test("builtin rm with .text() throws on failure", async () => {
+    using dir = tempDir("issue-18161", {});
+    try {
+      await $`rm ${dir}/nonexistent-file.txt`.text();
+      expect.unreachable();
+    } catch (e: any) {
+      expect(e.exitCode).not.toBe(0);
+    }
+  });
+
+  test("builtin rm with .quiet() returns 0 on success", async () => {
+    using dir = tempDir("issue-18161", {
+      "existing-file.txt": "hello",
+    });
+    const result = await $`rm ${dir}/existing-file.txt`.nothrow().quiet();
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("builtin rm exit code matches between quiet and non-quiet", async () => {
+    using dir = tempDir("issue-18161", {});
+    const nonQuiet = await $`rm ${dir}/nonexistent-file.txt`.nothrow();
+    const quiet = await $`rm ${dir}/nonexistent-file.txt`.nothrow().quiet();
+    expect(quiet.exitCode).toBe(nonQuiet.exitCode);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixed builtin `rm` returning exit code 0 instead of 1 when a file doesn't exist and `.quiet()` or `.text()` is used
- The `next()` function had a hardcoded `done(0)` that ignored the stored exit code, only affecting the quiet/pipe code path
- Also fixed `onShellRmTaskDone` to use POSIX-conventional exit code 1 instead of raw errno values

Closes #18161

## Test plan

- [x] New regression test `test/regression/issue/18161.test.ts` covering:
  - `.quiet()` throws on `rm` failure
  - `.nothrow().quiet()` returns non-zero exit code
  - `.text()` throws on `rm` failure  
  - `.quiet()` returns 0 on successful `rm`
  - Exit code matches between quiet and non-quiet modes
- [x] Verified test fails with `USE_SYSTEM_BUN=1` (2 of 5 tests fail)
- [x] Verified test passes with `bun bd test`
- [x] Existing `throw.test.ts` tests pass
- [x] Existing `bunshell.test.ts` tests have no new failures (4 pre-existing quiet subprocess timeout failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)