### PR TITLE
fix(windows): remove incorrect @alignCast in standalone sourcemap deserialization

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -336,7 +336,7 @@ pub const StandaloneModuleGraph = struct {
                     .contents = sliceToZ(raw_bytes, module.contents),
                     .sourcemap = if (module.sourcemap.length > 0)
                         .{ .serialized = .{
-                            .bytes = @alignCast(sliceTo(raw_bytes, module.sourcemap)),
+                            .bytes = sliceTo(raw_bytes, module.sourcemap),
                         } }
                     else
                         .none,
@@ -588,7 +588,7 @@ pub const StandaloneModuleGraph = struct {
 
         if (comptime Environment.isDebug) {
             // An expensive sanity check:
-            var graph = try fromBytes(allocator, @alignCast(output_bytes), offsets);
+            var graph = try fromBytes(allocator, output_bytes, offsets);
             defer {
                 graph.files.unlockPointers();
                 graph.files.deinit();

--- a/test/regression/issue/27276.test.ts
+++ b/test/regression/issue/27276.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { bunEnv, tempDir } from "harness";
+import { join } from "path";
+
+// Regression test for https://github.com/oven-sh/bun/issues/27276
+// Standalone compile with sourcemaps panicked on Windows due to an
+// incorrect @alignCast when deserializing the embedded module graph.
+// The sourcemap slice could be at a non-8-byte-aligned offset, but
+// the LazySourceMap union inflated the required alignment to 8 because
+// it also holds a pointer variant.
+test("standalone compile with sourcemap does not panic on misaligned sourcemap data", async () => {
+  // Use multiple files with varying name lengths to increase the
+  // chance that the serialized sourcemap offset is not 8-byte aligned.
+  using dir = tempDir("issue-27276", {
+    "index.js": `
+import { a } from "./a.js";
+import { bc } from "./bc.js";
+import { def } from "./def.js";
+a();
+bc();
+def();
+`,
+    "a.js": `export function a() { return 1; }`,
+    "bc.js": `export function bc() { return 2; }`,
+    "def.js": `export function def() { return 3; }`,
+  });
+
+  const result = await Bun.build({
+    entrypoints: [join(String(dir), "index.js")],
+    outdir: String(dir),
+    compile: true,
+    sourcemap: "inline",
+  });
+
+  expect(result.success).toBe(true);
+  expect(result.outputs.length).toBe(1);
+
+  const executablePath = result.outputs[0].path;
+
+  await using proc = Bun.spawn({
+    cmd: [executablePath],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

Fixes #27276.

- Removed an incorrect `@alignCast` when deserializing sourcemap data in `StandaloneModuleGraph.fromBytes()` that panicked on Windows (ReleaseSafe) when the sourcemap slice was at a non-8-byte-aligned offset
- Removed a redundant `@alignCast` in the debug-only sanity check in `toBytes()`

### Root cause

The `LazySourceMap` union has a `parsed: *SourceMap.ParsedSourceMap` variant (pointer alignment 8), which inflates the union's payload alignment to 8. The `@alignCast` on the `serialized` variant's `bytes: []const u8` was promoting the slice pointer alignment to 8, but the sourcemap data in the standalone binary can be at any offset. On Windows (built with `ReleaseSafe`), this triggers a runtime panic. On Linux/macOS (`ReleaseFast`), this is silent undefined behavior.

## Test plan

- [x] Existing sourcemap compile tests pass (`bun-build-compile-sourcemap.test.ts` — 5/5)
- [x] New regression test passes (`test/regression/issue/27276.test.ts`)
- [x] Debug build compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)