### PR TITLE
fix: use BoringSSL for std.crypto random seed to support older Linux kernels

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1,6 +1,10 @@
 pub const panic = _bun.crash_handler.panic;
 pub const std_options = std.Options{
     .enable_segfault_handler = false,
+    // Use BoringSSL's RAND_bytes instead of the default getrandom() syscall.
+    // BoringSSL falls back to /dev/urandom on older kernels (< 3.17) where
+    // the getrandom syscall doesn't exist, avoiding a panic on ENOSYS.
+    .cryptoRandomSeed = _bun.csprng,
 };
 
 pub const io_mode = .blocking;

--- a/src/main_test.zig
+++ b/src/main_test.zig
@@ -7,6 +7,7 @@ const Environment = bun.Environment;
 pub const panic = recover.panic;
 pub const std_options = std.Options{
     .enable_segfault_handler = false,
+    .cryptoRandomSeed = bun.csprng,
 };
 
 pub const io_mode = .blocking;


### PR DESCRIPTION
## Summary

- Override Zig's default `cryptoRandomSeed` in `std_options` to use BoringSSL's `RAND_bytes` (via `bun.csprng`) instead of the `getrandom()` syscall
- On Linux kernels < 3.17 (e.g. Synology NAS with kernel 3.10), the `getrandom` syscall doesn't exist and returns `ENOSYS`, causing Zig's stdlib to panic with `"getrandom() failed to provide entropy"`
- BoringSSL already handles this gracefully by falling back to `/dev/urandom`

## Details

Bun already uses BoringSSL's `RAND_bytes` for all its own cryptographic random needs (`bun.csprng`). However, Zig's standard library `std.crypto.random` uses a separate code path that calls the `getrandom` syscall directly, with no fallback for `ENOSYS`. 

Zig's `std.Options` struct provides a `cryptoRandomSeed` override for exactly this purpose. This PR sets it to `bun.csprng` in both `src/main.zig` and `src/main_test.zig`.

## Test plan

- [x] `bun bd` compiles successfully
- [x] `crypto.getRandomValues()`, `crypto.randomUUID()`, and `require("crypto").randomFillSync()` all work correctly
- Cannot write a meaningful automated regression test since reproducing requires a Linux kernel < 3.17

Closes #27279

🤖 Generated with [Claude Code](https://claude.com/claude-code)