### PR TITLE
fix(http): align DeadSocket to prevent crash on Windows ARM64 stable builds

### DIFF
--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -480,7 +480,9 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
 
 const DeadSocket = struct {
     garbage: u8 = 0,
-    pub var dead_socket: DeadSocket = .{};
+    /// Must be aligned to `@alignOf(usize)` so that tagged pointer values
+    /// embedding this address pass the `@alignCast` in `bun.cast`.
+    pub var dead_socket: DeadSocket align(@alignOf(usize)) = .{};
 };
 
 var dead_socket = &DeadSocket.dead_socket;


### PR DESCRIPTION
## Summary

- `DeadSocket` only contains a `u8` field (alignment 1), so the linker could place `DeadSocket.dead_socket` at a non-8-byte-aligned address
- When `markTaggedSocketAsDead` creates a tagged pointer embedding this address and passes it through `bun.cast(**anyopaque, ...)`, the `@alignCast` panics with "incorrect alignment" because the bottom bits of the tagged value come from the unaligned address
- Fix: add `align(@alignOf(usize))` to the `dead_socket` variable declaration

This only manifested on stable (non-canary) Windows ARM64 builds because the binary layout differs when `ci_assert` is false, shifting the static variable to a non-aligned address. Canary builds happened to place it at an aligned address by coincidence.

## Test plan

- [x] Verified `fetch('https://example.com')` no longer crashes on Windows ARM64 stable build (ENABLE_CANARY=OFF)
- [x] Verified 5 sequential HTTPS fetches complete successfully
- [x] Verified the fix is a single-line change with no behavioral side effects