### PR TITLE
fix(socket): handle non-object argument in Listener.getsockname()

### DIFF
--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -850,7 +850,8 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
         return .js_undefined;
     }
 
-    const out = callFrame.argumentsAsArray(1)[0];
+    const arg = callFrame.argumentsAsArray(1)[0];
+    const out = if (arg.isObject()) arg else JSValue.createEmptyObject(globalThis, 3);
     const socket = this.listener.uws;
 
     var buf: [64]u8 = [_]u8{0} ** 64;
@@ -872,7 +873,7 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
     out.put(globalThis, bun.String.static("family"), family_js);
     out.put(globalThis, bun.String.static("address"), address_js);
     out.put(globalThis, bun.String.static("port"), port_js);
-    return .js_undefined;
+    return out;
 }
 
 pub fn jsAddServerName(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {

--- a/test/js/bun/socket/listener-getsockname-no-args.test.ts
+++ b/test/js/bun/socket/listener-getsockname-no-args.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "bun:test";
+
+test("Listener.getsockname() works without arguments", () => {
+  const listener = Bun.listen({
+    hostname: "localhost",
+    port: 0,
+    socket: {
+      data() {},
+    },
+  });
+
+  try {
+    // Calling getsockname() without arguments should return an object
+    // with family, address, and port properties (not crash).
+    const result = listener.getsockname();
+    expect(result).toBeObject();
+    expect(result.family).toMatch(/^IPv[46]$/);
+    expect(result.address).toBeString();
+    expect(result.port).toBeNumber();
+
+    // Calling with an object argument should still work (existing behavior).
+    const obj: Record<string, unknown> = {};
+    listener.getsockname(obj);
+    expect(obj.family).toMatch(/^IPv[46]$/);
+    expect(obj.address).toBeString();
+    expect(obj.port).toBeNumber();
+
+    // Calling with a non-object argument should return a new object (not crash).
+    const result2 = listener.getsockname(42 as any);
+    expect(result2).toBeObject();
+    expect(result2.family).toMatch(/^IPv[46]$/);
+  } finally {
+    listener.stop();
+  }
+});

--- a/test/js/bun/socket/listener-getsockname-no-args.test.ts
+++ b/test/js/bun/socket/listener-getsockname-no-args.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("Listener.getsockname() works without arguments", () => {
   const listener = Bun.listen({


### PR DESCRIPTION
## Summary
- Fix null pointer dereference in `Listener.getsockname()` when called without arguments or with a non-object argument.
- The function unconditionally called `.put()` on the first call frame argument, which invokes `getObject()` in C++ and returns null for non-object values (e.g., `undefined`), causing a crash at `BunString.cpp:942`.
- When the argument is not an object, create a new empty JS object and return it, matching the common Node.js pattern where address info functions return an object.

## Crash reproduction
```js
const listener = Bun.listen({ hostname: "localhost", port: 0, socket: { data() {} } });
listener.getsockname(); // crash: null pointer dereference
```

## Test plan
- [x] Verified crash reproduces with debug-fuzz ASAN binary before fix
- [x] Verified crash no longer occurs after fix
- [x] Added test `test/js/bun/socket/listener-getsockname-no-args.test.ts` covering no-arg, object-arg, and non-object-arg cases
- [x] Verified test fails with system bun (`USE_SYSTEM_BUN=1`) and passes with debug build (`bun bd test`)

https://claude.ai/code/session_01UEQc8JbWybcPVLpCLoFMhB