### PR TITLE
Fix null pointer crash in Bun.$ lazy property callback

### DIFF
--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -317,7 +317,7 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
 #if BUN_DEBUG
     if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
 #endif
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
 
@@ -329,7 +329,7 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
 #if BUN_DEBUG
     if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
 #endif
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));
 }
@@ -364,20 +364,20 @@ static JSValue constructBunShell(VM& vm, JSObject* bunObject)
     args.append(createShellInterpreterFunction);
     args.append(createParsedShellScript);
     JSC::JSValue shell = JSC::call(globalObject, createShellFn, args, "BunShell"_s);
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
 
     if (!shell.isObject()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Internal error: BunShell constructor did not return an object"_s);
-        return {};
+        return jsUndefined();
     }
 
     auto* bunShell = shell.getObject();
 
     auto ShellError = bunShell->get(globalObject, JSC::Identifier::fromString(vm, "ShellError"_s));
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
     if (!ShellError.isObject()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Internal error: BunShell.ShellError is not an object"_s);
-        return {};
+        return jsUndefined();
     }
 
     bunShell->putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "braces"_s), 1, Generated::BunObject::jsBraces, ImplementationVisibility::Public, NoIntrinsic, JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | 0);

--- a/test/js/bun/shell/shell-stackoverflow-crash.test.ts
+++ b/test/js/bun/shell/shell-stackoverflow-crash.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("accessing Bun.$ after stack overflow does not crash", async () => {

--- a/test/js/bun/shell/shell-stackoverflow-crash.test.ts
+++ b/test/js/bun/shell/shell-stackoverflow-crash.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("accessing Bun.$ after stack overflow does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      function F8() {
+          if (!new.target) { throw 'must be called with new'; }
+          const v14 = this?.constructor;
+          try { new v14(); } catch (e) {}
+          Bun.$;
+      }
+      new F8();
+      console.log("OK");
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("OK\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fix null pointer dereference crash when accessing `Bun.$` (or `Bun.sql`/`Bun.SQL`/`Bun.postgres`) after a stack overflow
- `PropertyCallback` handlers returned empty `JSValue{}` on exception. An empty JSValue (all bits zero) passes `isCell()` but `asCell()` returns null, crashing in `reifyStaticProperty` → `putDirect` → `isGetterSetterSlow`
- Return `jsUndefined()` instead of `{}` on error paths so the value is a valid non-cell JSValue while the pending exception still propagates correctly

## Crash reproduction
```js
function F8() {
    if (!new.target) { throw 'must be called with new'; }
    const v14 = this?.constructor;
    try { new v14(); } catch (e) {}
    Bun.$;
}
new F8();
```

The recursive `new v14()` causes a stack overflow. After it's caught, accessing `Bun.$` triggers the lazy property callback `constructBunShell`, which calls `JSC::call()`. This fails due to the stack overflow state, and `RETURN_IF_EXCEPTION(scope, {})` returns empty `JSValue{}`. The caller `reifyStaticProperty` passes this to `putDirect`, which calls `isGetterSetter()` on the null cell → crash.

## Test plan
- [x] Reproduced crash with debug binary before fix
- [x] Verified crash no longer occurs after fix (5 consecutive runs)
- [x] Added regression test that fails with system bun and passes with fix
- [x] `bun bd test test/js/bun/shell/shell-stackoverflow-crash.test.ts` passes

https://claude.ai/code/session_01KjaS2DyQweyZeuB2ELKnTv