### PR TITLE
fix(fuzzilli): prevent segfault in FUZZILLI_PRINT when REPRL fd is closed

### DIFF
--- a/src/bun.js/bindings/FuzzilliREPRL.cpp
+++ b/src/bun.js/bindings/FuzzilliREPRL.cpp
@@ -144,11 +144,10 @@ static JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES functionFuzzilli(JSC::JSGlob
             WTF::String output = arg1.toWTFString(globalObject);
             RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
 
-            // Cache the FILE* for the REPRL data-write fd to avoid repeated
-            // fdopen calls and the associated resource leak. If the fd is not
-            // open (e.g. running standalone outside the REPRL loop), fdopen
-            // returns NULL and we silently skip the write.
-            static FILE* f = fdopen(REPRL_DWFD, "w");
+            static FILE* f = nullptr;
+            if (!f) {
+                f = fdopen(REPRL_DWFD, "w");
+            }
             if (f) {
                 fprintf(f, "%s\n", output.utf8().data());
                 fflush(f);

--- a/src/bun.js/bindings/FuzzilliREPRL.cpp
+++ b/src/bun.js/bindings/FuzzilliREPRL.cpp
@@ -144,9 +144,15 @@ static JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES functionFuzzilli(JSC::JSGlob
             WTF::String output = arg1.toWTFString(globalObject);
             RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
 
-            FILE* f = fdopen(REPRL_DWFD, "w");
-            fprintf(f, "%s\n", output.utf8().data());
-            fflush(f);
+            // Cache the FILE* for the REPRL data-write fd to avoid repeated
+            // fdopen calls and the associated resource leak. If the fd is not
+            // open (e.g. running standalone outside the REPRL loop), fdopen
+            // returns NULL and we silently skip the write.
+            static FILE* f = fdopen(REPRL_DWFD, "w");
+            if (f) {
+                fprintf(f, "%s\n", output.utf8().data());
+                fflush(f);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix segfault when `fuzzilli('FUZZILLI_PRINT', ...)` is called outside the REPRL loop (i.e. when running the fuzzilli debug binary standalone)
- The crash was caused by `fdopen(103, "w")` returning NULL when fd 103 isn't open, followed by `fprintf(NULL, ...)` which segfaults
- Made the `FILE*` static to cache it across calls (also fixing a resource leak from repeated `fdopen` calls) and added a NULL check

## Crash reproduction
Minimal:
```js
// When running with the fuzzilli-enabled debug binary:
fuzzilli('FUZZILLI_PRINT', 'test message');
```

## Test plan
- [x] Verified original binary crashes 100% of the time with the reproduction case
- [x] Verified fixed binary has 0 crashes in 30 runs with the same reproduction case

https://claude.ai/code/session_01TbAGeP6aQsSbnL57YGQXV8