### PR TITLE
fix(socket): handle non-object argument in Listener.getsockname

### DIFF
--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -850,7 +850,8 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
         return .js_undefined;
     }
 
-    const out = callFrame.argumentsAsArray(1)[0];
+    const arg = callFrame.argumentsAsArray(1)[0];
+    const out = if (arg.isObject()) arg else JSValue.createEmptyObject(globalThis, 3);
     const socket = this.listener.uws;
 
     var buf: [64]u8 = [_]u8{0} ** 64;


### PR DESCRIPTION
## Summary
- Fix null pointer dereference in `Listener.getsockname` when called with a non-object argument
- `getsockname` assumed its first argument was always an object and called `.put()` on it directly. When a non-object value (e.g. a number) or no argument is passed, `JSValue.getObject()` returns null, causing a null pointer dereference in `JSC__JSValue__putBunString` (`BunString.cpp:942`)
- The fix checks if the argument is an object and falls back to creating a new empty object if it is not

## Crash reproduction
```js
function f10(a11, a12) { return a11; }
const v13 = { data: f10 };
const listener = Bun.listen({ hostname: "localhost", port: 0, socket: v13 });
listener.getsockname(536870887);
```

```
../../src/bun.js/bindings/BunString.cpp:942:13: runtime error: member call on null pointer of type 'JSC::JSObject'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../../src/bun.js/bindings/BunString.cpp:942:13
```

## Test plan
- [x] Verified the crash reproduces with the debug ASAN binary before the fix
- [x] Verified the crash no longer reproduces after the fix
- [x] Verified normal `getsockname({})` usage still works correctly
- [x] Verified edge cases (no arguments, null, number) no longer crash

https://claude.ai/code/session_014JfaCgPkfj9uHH3HWoQZu9