### PR TITLE
Fix null pointer crash in Listener.getsockname() without arguments

### DIFF
--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -850,7 +850,9 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
         return .js_undefined;
     }
 
-    const out = callFrame.argumentsAsArray(1)[0];
+    const arg = callFrame.argumentsAsArray(1)[0];
+    const has_out = arg.isObject();
+    const out = if (has_out) arg else JSValue.createEmptyObject(globalThis, 3);
     const socket = this.listener.uws;
 
     var buf: [64]u8 = [_]u8{0} ** 64;
@@ -872,7 +874,7 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
     out.put(globalThis, bun.String.static("family"), family_js);
     out.put(globalThis, bun.String.static("address"), address_js);
     out.put(globalThis, bun.String.static("port"), port_js);
-    return .js_undefined;
+    return if (has_out) .js_undefined else out;
 }
 
 pub fn jsAddServerName(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {

--- a/test/js/bun/net/tcp-server.test.ts
+++ b/test/js/bun/net/tcp-server.test.ts
@@ -57,6 +57,46 @@ it("remoteAddress works", async () => {
   await prom;
 });
 
+it("getsockname without arguments should not crash", () => {
+  using server = Bun.listen({
+    socket: {
+      open() {},
+      close() {},
+      data() {},
+    },
+    port: 0,
+    hostname: "127.0.0.1",
+  });
+
+  const result = server.getsockname();
+  expect(result).toEqual({
+    family: "IPv4",
+    address: "127.0.0.1",
+    port: server.port,
+  });
+});
+
+it("getsockname with an out object populates it", () => {
+  using server = Bun.listen({
+    socket: {
+      open() {},
+      close() {},
+      data() {},
+    },
+    port: 0,
+    hostname: "127.0.0.1",
+  });
+
+  const out: Record<string, unknown> = {};
+  const result = server.getsockname(out);
+  expect(result).toBeUndefined();
+  expect(out).toEqual({
+    family: "IPv4",
+    address: "127.0.0.1",
+    port: server.port,
+  });
+});
+
 it("should not allow invalid tls option", () => {
   [1, "string", Symbol("symbol")].forEach(value => {
     expect(() => {


### PR DESCRIPTION
## Summary
- Fixed a null pointer dereference crash in `Listener.getsockname()` when called without an out-object argument
- When no argument is passed, the function now creates and returns a new object with `{family, address, port}` instead of crashing
- When an out-object is passed, the existing behavior is preserved (populate in-place, return `undefined`)

## Root Cause
`Listener.getsockname()` unconditionally called `.getObject()` on the first argument. When called without arguments (e.g. `Bun.listen(...).getsockname()`), the argument defaults to `undefined`, and `getObject()` returns null. This null pointer was then passed to `putDirect()` in `BunString.cpp:942`, causing a crash.

## Reproduction
```js
function f3(a4, a5) {
    return f3;
}
const v6 = { data: f3 };
Bun.listen({ hostname: "localhost", port: 0, socket: v6 }).getsockname();
```

## Test plan
- [x] Added test for `getsockname()` without arguments — returns `{family, address, port}` object
- [x] Added test for `getsockname(out)` with an out-object — populates it in-place and returns `undefined`
- [x] Verified crash no longer reproduces with debug ASAN binary

https://claude.ai/code/session_01PxYrYFseM3UutPg2C5AKM8