### PR TITLE
fix(socket): validate argument type in Listener.getsockname()

### DIFF
--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -851,6 +851,9 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
     }
 
     const out = callFrame.argumentsAsArray(1)[0];
+    if (!out.isObject()) {
+        return globalThis.throwInvalidArguments("Expected object", .{});
+    }
     const socket = this.listener.uws;
 
     var buf: [64]u8 = [_]u8{0} ** 64;


### PR DESCRIPTION
## Summary
- `Listener.getsockname()` expects an object argument to populate with socket address info (`family`, `address`, `port`), but did not validate the argument type before calling `.put()` on it.
- When called with a non-object argument (e.g. `0`), `JSValue::getObject()` returns null in `JSC__JSValue__putBunString`, causing a null pointer dereference.
- Added an `isObject()` check that throws a `TypeError` if the argument is not an object, consistent with how other socket APIs in the codebase validate their arguments.

## Reproduction
```js
const v9 = { data: function(a7, a8) { return WeakSet; } };
const v11 = Bun.listen({ hostname: "localhost", port: 0, socket: v9 });
v11.getsockname(0); // crash: null pointer dereference in BunString.cpp:942
```

## Test plan
- [x] Verified the reproduction case crashes before the fix (null pointer dereference in `BunString.cpp:942`)
- [x] Verified the reproduction case throws a proper `TypeError` after the fix
- [x] Verified normal `getsockname()` usage with an object argument still works correctly