### PR TITLE
fix(listen): handle missing argument in Listener.getsockname()

### DIFF
--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -850,7 +850,8 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
         return .js_undefined;
     }
 
-    const out = callFrame.argumentsAsArray(1)[0];
+    const arg = callFrame.argumentsAsArray(1)[0];
+    const out = if (arg.isObject()) arg else JSValue.createEmptyObject(globalThis, 3);
     const socket = this.listener.uws;
 
     var buf: [64]u8 = [_]u8{0} ** 64;
@@ -872,7 +873,7 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
     out.put(globalThis, bun.String.static("family"), family_js);
     out.put(globalThis, bun.String.static("address"), address_js);
     out.put(globalThis, bun.String.static("port"), port_js);
-    return .js_undefined;
+    return out;
 }
 
 pub fn jsAddServerName(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {

--- a/test/js/bun/http/bun-listen-connect-args.test.ts
+++ b/test/js/bun/http/bun-listen-connect-args.test.ts
@@ -11,11 +11,13 @@ describe("getsockname", () => {
       },
     });
     const result = server.getsockname();
-    expect(result).toEqual(expect.objectContaining({
-      family: expect.any(String),
-      address: expect.any(String),
-      port: expect.any(Number),
-    }));
+    expect(result).toEqual(
+      expect.objectContaining({
+        family: expect.any(String),
+        address: expect.any(String),
+        port: expect.any(Number),
+      }),
+    );
     server.stop(true);
   });
 

--- a/test/js/bun/http/bun-listen-connect-args.test.ts
+++ b/test/js/bun/http/bun-listen-connect-args.test.ts
@@ -1,5 +1,40 @@
-import { describe, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { cwdScope, isWindows, rmScope, tempDirWithFiles } from "harness";
+
+describe("getsockname", () => {
+  test("called without arguments does not crash", () => {
+    using server = Bun.listen({
+      hostname: "localhost",
+      port: 0,
+      socket: {
+        data() {},
+      },
+    });
+    const result = server.getsockname();
+    expect(result).toEqual(expect.objectContaining({
+      family: expect.any(String),
+      address: expect.any(String),
+      port: expect.any(Number),
+    }));
+    server.stop(true);
+  });
+
+  test("called with an object argument populates it", () => {
+    using server = Bun.listen({
+      hostname: "localhost",
+      port: 0,
+      socket: {
+        data() {},
+      },
+    });
+    const out: Record<string, unknown> = {};
+    server.getsockname(out);
+    expect(out.family).toBeString();
+    expect(out.address).toBeString();
+    expect(out.port).toBeNumber();
+    server.stop(true);
+  });
+});
 
 describe.if(!isWindows)("unix socket", () => {
   test("valid", () => {


### PR DESCRIPTION
## Summary

- Fix null pointer dereference in `Listener.getsockname()` when called without arguments
- When no object argument is provided, create and return a new object instead of crashing

## Root Cause

`Listener.getsockname()` expected its first argument to be an object to populate with `family`, `address`, and `port` properties. When called without arguments (e.g. `listener.getsockname()`), the argument defaults to `undefined`. Calling `.put()` on `undefined` leads to `JSC::JSValue::decode().getObject()` returning null in `JSC__JSValue__putBunString` (`BunString.cpp:942`), causing a null pointer dereference.

## Fix

Check if the argument is an object. If not, create a new empty JS object with capacity for the 3 properties. Return the (possibly new) object so callers without an argument still get the result.

## Reproduction

```js
delete globalThis.Loader;
Bun.generateHeapSnapshot = console.profile = console.profileEnd = process.abort = () => {};
function f3(a4, a5) {
    return a4;
}
const v6 = { data: f3 };
Bun.listen({ hostname: "localhost", port: 0, socket: v6 }).getsockname();
Bun.gc(true);
```

## Test plan

- [x] Added test for `getsockname()` called without arguments — verifies it returns a valid address object
- [x] Added test for `getsockname(out)` called with an object argument — verifies existing behavior still works
- [x] Verified crash reproduces with unfixed binary and is resolved with the fix