### PR TITLE
fix(socket): handle non-object argument in Listener.getsockname

### DIFF
--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -850,7 +850,8 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
         return .js_undefined;
     }
 
-    const out = callFrame.argumentsAsArray(1)[0];
+    const arg = callFrame.argumentsAsArray(1)[0];
+    const out = if (arg.isObject()) arg else JSValue.createEmptyObject(globalThis, 3);
     const socket = this.listener.uws;
 
     var buf: [64]u8 = [_]u8{0} ** 64;


### PR DESCRIPTION
## Summary
- Fix null pointer dereference in `Listener.getsockname()` when called with a non-object argument
- `getsockname()` unconditionally called `.put()` on its first argument, assuming it was an object. When a non-object (e.g. an integer) was passed, `JSC::JSValue::decode(encodedTarget).getObject()` in `JSC__JSValue__putBunString` returned null, causing a null pointer dereference at `BunString.cpp:942`
- The fix creates a new empty object when the argument is not an object, so the function always has a valid target for the property writes

## Crash reproduction
```js
function f6(a7, a8) { return a7; }
const v9 = { data: f6 };
const v11 = Bun.listen({ hostname: "localhost", port: 0, socket: v9 });
v11.getsockname(1); // null pointer deref in BunString.cpp:942
v11.stop(true);
```

## Test plan
- [x] Verified the crash reproduces with the original debug binary
- [x] Verified the crash is fixed with the patched debug binary
- [x] Verified with both minimal and full fuzzer reproduction cases