### PR TITLE
fix(socket): handle missing argument in Listener.getsockname()

### DIFF
--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -850,7 +850,9 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
         return .js_undefined;
     }
 
-    const out = callFrame.argumentsAsArray(1)[0];
+    const arg = callFrame.argumentsAsArray(1)[0];
+    const caller_provided_object = arg.isObject();
+    const out = if (caller_provided_object) arg else JSValue.createEmptyObject(globalThis, 3);
     const socket = this.listener.uws;
 
     var buf: [64]u8 = [_]u8{0} ** 64;
@@ -872,7 +874,10 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
     out.put(globalThis, bun.String.static("family"), family_js);
     out.put(globalThis, bun.String.static("address"), address_js);
     out.put(globalThis, bun.String.static("port"), port_js);
-    return .js_undefined;
+    // Internal callers (net.ts) pass an object and use the return value as an error code,
+    // so return undefined (falsy = no error) when an object was provided. When called
+    // without an argument, return the newly created object directly.
+    return if (caller_provided_object) .js_undefined else out;
 }
 
 pub fn jsAddServerName(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {

--- a/test/js/bun/net/listener-getsockname.test.ts
+++ b/test/js/bun/net/listener-getsockname.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("Listener.getsockname() works without arguments", () => {
   using listener = Bun.listen({

--- a/test/js/bun/net/listener-getsockname.test.ts
+++ b/test/js/bun/net/listener-getsockname.test.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "bun:test";
+
+test("Listener.getsockname() works without arguments", () => {
+  using listener = Bun.listen({
+    hostname: "localhost",
+    port: 0,
+    socket: {
+      data() {},
+    },
+  });
+
+  const result = listener.getsockname();
+  expect(result).toEqual({
+    family: expect.stringMatching(/^IPv[46]$/),
+    address: expect.any(String),
+    port: expect.any(Number),
+  });
+  expect(result.port).toBeGreaterThan(0);
+});
+
+test("Listener.getsockname() works with an object argument", () => {
+  using listener = Bun.listen({
+    hostname: "localhost",
+    port: 0,
+    socket: {
+      data() {},
+    },
+  });
+
+  const out: Record<string, unknown> = {};
+  const err = listener.getsockname(out);
+  expect(err).toBeUndefined();
+  expect(out).toEqual({
+    family: expect.stringMatching(/^IPv[46]$/),
+    address: expect.any(String),
+    port: expect.any(Number),
+  });
+  expect(out.port).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary

- Fix null pointer dereference in `Listener.getsockname()` when called without an object argument
- `getsockname()` unconditionally used its first argument as an output object, but when called without arguments (e.g. `listener.getsockname()`), the value is `undefined` and `getObject()` returns null, causing a crash in `BunString.cpp:942`
- When no object argument is provided, create a new empty object, populate it, and return it directly

## Reproduction

```js
function f3(a4, a5) {
    return a5;
}
const v6 = { data: f3 };
Bun.listen({ hostname: "localhost", port: 0, socket: v6 }).getsockname();
Bun.gc(true);
```

Crash output:
```
../../src/bun.js/bindings/BunString.cpp:942:13: runtime error: member call on null pointer of type 'JSC::JSObject'
```

## Test plan

- [x] Added `test/js/bun/net/listener-getsockname.test.ts` with tests for both the no-argument and object-argument code paths
- [x] Verified crash is reproduced on current release and fixed with this change
- [x] Verified internal callers (net.ts) still work correctly — when an object is passed, it returns `undefined` (falsy = no error)