### PR TITLE
fix(socket): null deref in Listener.getsockname with non-object argument

### DIFF
--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -850,7 +850,8 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
         return .js_undefined;
     }
 
-    const out = callFrame.argumentsAsArray(1)[0];
+    const arg = callFrame.argumentsAsArray(1)[0];
+    const out = if (arg.isObject()) arg else JSValue.createEmptyObject(globalThis, 3);
     const socket = this.listener.uws;
 
     var buf: [64]u8 = [_]u8{0} ** 64;
@@ -872,7 +873,7 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
     out.put(globalThis, bun.String.static("family"), family_js);
     out.put(globalThis, bun.String.static("address"), address_js);
     out.put(globalThis, bun.String.static("port"), port_js);
-    return .js_undefined;
+    return out;
 }
 
 pub fn jsAddServerName(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {

--- a/test/js/bun/net/listener-getsockname.test.ts
+++ b/test/js/bun/net/listener-getsockname.test.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "bun:test";
+
+test("Listener.getsockname with non-object argument does not crash", () => {
+  const listener = Bun.listen({
+    hostname: "localhost",
+    port: 0,
+    socket: {
+      data() {},
+    },
+  });
+  try {
+    // Calling getsockname with a non-object argument should not crash
+    const result = (listener as any).getsockname(13);
+    expect(result).toBeObject();
+    expect(result.family).toMatch(/^IPv[46]$/);
+    expect(result.address).toBeString();
+    expect(typeof result.port).toBe("number");
+  } finally {
+    listener.stop(true);
+  }
+});
+
+test("Listener.getsockname with no arguments does not crash", () => {
+  const listener = Bun.listen({
+    hostname: "localhost",
+    port: 0,
+    socket: {
+      data() {},
+    },
+  });
+  try {
+    // Calling getsockname with no arguments should not crash
+    const result = (listener as any).getsockname();
+    expect(result).toBeObject();
+    expect(result.family).toMatch(/^IPv[46]$/);
+    expect(result.address).toBeString();
+    expect(typeof result.port).toBe("number");
+  } finally {
+    listener.stop(true);
+  }
+});
+
+test("Listener.getsockname with object argument still works", () => {
+  const listener = Bun.listen({
+    hostname: "localhost",
+    port: 0,
+    socket: {
+      data() {},
+    },
+  });
+  try {
+    const obj: any = {};
+    const result = (listener as any).getsockname(obj);
+    // When passed an object, it should populate that same object
+    expect(obj.family).toMatch(/^IPv[46]$/);
+    expect(obj.address).toBeString();
+    expect(typeof obj.port).toBe("number");
+    // And the return value should be the same object
+    expect(result).toBe(obj);
+  } finally {
+    listener.stop(true);
+  }
+});

--- a/test/js/bun/net/listener-getsockname.test.ts
+++ b/test/js/bun/net/listener-getsockname.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("Listener.getsockname with non-object argument does not crash", () => {
   const listener = Bun.listen({


### PR DESCRIPTION
## Summary
- `Listener.getsockname()` crashed with a null pointer dereference when called with a non-object argument (or no arguments), because it unconditionally passed the first argument to `JSValue.put()` which calls `getObject()` on the value — returning null for non-objects.
- The fix checks whether the argument is an object; if not, it creates a fresh empty object. The populated object is now also returned instead of `undefined`.

## Crash reproduction
```js
function f6(a7, a8) { return Uint32Array; }
const v9 = { data: f6 };
const listener = Bun.listen({ hostname: "localhost", port: 0, socket: v9 });
listener.getsockname(13); // crashes: null deref in BunString.cpp:942
```

## Test plan
- [x] Added test for `getsockname` with non-object argument
- [x] Added test for `getsockname` with no arguments
- [x] Added test for `getsockname` with object argument (existing behavior preserved)
- [x] Verified crash reproduces with original binary
- [x] Verified fix resolves the crash