### PR TITLE
fix(socket): handle non-object argument in Listener.getsockname

### DIFF
--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -850,7 +850,8 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
         return .js_undefined;
     }
 
-    const out = callFrame.argumentsAsArray(1)[0];
+    const arg = callFrame.argumentsAsArray(1)[0];
+    const out = if (arg.isObject()) arg else JSValue.createEmptyObject(globalThis, 3);
     const socket = this.listener.uws;
 
     var buf: [64]u8 = [_]u8{0} ** 64;
@@ -872,7 +873,7 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
     out.put(globalThis, bun.String.static("family"), family_js);
     out.put(globalThis, bun.String.static("address"), address_js);
     out.put(globalThis, bun.String.static("port"), port_js);
-    return .js_undefined;
+    return out;
 }
 
 pub fn jsAddServerName(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {

--- a/test/js/bun/net/tcp-server.test.ts
+++ b/test/js/bun/net/tcp-server.test.ts
@@ -295,6 +295,38 @@ describe("tcp socket binaryType", () => {
   }
 });
 
+it("getsockname should not crash when called without an object argument", () => {
+  using server = listen({
+    socket: {
+      open() {},
+      close() {},
+      data() {},
+    },
+    hostname: "localhost",
+    port: 0,
+  });
+
+  // Calling with no arguments should return a new object
+  const result = server.getsockname();
+  expect(result).toBeObject();
+  expect(["IPv4", "IPv6"]).toContain(result.family);
+  expect(result.address).toBeDefined();
+  expect(typeof result.port).toBe("number");
+
+  // Calling with a non-object argument should return a new object
+  const result2 = server.getsockname(42 as any);
+  expect(result2).toBeObject();
+  expect(["IPv4", "IPv6"]).toContain(result2.family);
+
+  // Calling with an object should populate it
+  const obj = {} as any;
+  const result3 = server.getsockname(obj);
+  expect(result3).toBe(obj);
+  expect(["IPv4", "IPv6"]).toContain(obj.family);
+  expect(obj.address).toBeDefined();
+  expect(typeof obj.port).toBe("number");
+});
+
 it("should not leak memory", async () => {
   // assert we don't leak the sockets
   // we expect 1 or 2 because that's the prototype / structure


### PR DESCRIPTION
## Summary
- Fix null pointer dereference crash in `Listener.getsockname()` when called without arguments or with a non-object argument
- `getsockname()` assumed its first argument was always an object and called `.put()` on it unconditionally, but `JSC__JSValue__putBunString` would crash when `getObject()` returns null for non-object values
- Now creates a new empty object when the argument is not an object, and returns the result object

## Crash reproduction
```js
const listener = Bun.listen({
  hostname: "localhost", port: 0,
  socket: { data(a, b) { return a; } }
});
listener.getsockname(536870887); // crash: null deref in BunString.cpp:942
listener.stop();
```

Crash: `BunString.cpp:942: runtime error: member call on null pointer of type 'JSC::JSObject'`

## Test plan
- [x] Added test in `test/js/bun/net/tcp-server.test.ts` covering: no arguments, non-object argument, and object argument cases
- [x] Verified test crashes on unpatched bun (`USE_SYSTEM_BUN=1`) and passes with the fix (`bun bd test`)