### PR TITLE
fix(socket): handle missing argument in Listener.getsockname()

### DIFF
--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -850,7 +850,9 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
         return .js_undefined;
     }
 
-    const out = callFrame.argumentsAsArray(1)[0];
+    const arg = callFrame.argumentsAsArray(1)[0];
+    const have_out = arg.isObject();
+    const out = if (have_out) arg else JSValue.createEmptyObject(globalThis, 3);
     const socket = this.listener.uws;
 
     var buf: [64]u8 = [_]u8{0} ** 64;
@@ -872,7 +874,9 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
     out.put(globalThis, bun.String.static("family"), family_js);
     out.put(globalThis, bun.String.static("address"), address_js);
     out.put(globalThis, bun.String.static("port"), port_js);
-    return .js_undefined;
+    // When called with an object argument (internal node:net usage), return
+    // undefined to indicate success. Otherwise return the newly created object.
+    return if (have_out) .js_undefined else out;
 }
 
 pub fn jsAddServerName(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {

--- a/test/js/bun/net/tcp-server.test.ts
+++ b/test/js/bun/net/tcp-server.test.ts
@@ -295,6 +295,43 @@ describe("tcp socket binaryType", () => {
   }
 });
 
+it("getsockname without arguments should not crash", () => {
+  using server = Bun.listen({
+    socket: {
+      open() {},
+      close() {},
+      data() {},
+    },
+    port: 0,
+    hostname: "127.0.0.1",
+  });
+
+  const result = server.getsockname();
+  expect(result).toBeObject();
+  expect(result.family).toBe("IPv4");
+  expect(result.address).toBe("127.0.0.1");
+  expect(result.port).toBe(server.port);
+});
+
+it("getsockname with object argument populates the object", () => {
+  using server = Bun.listen({
+    socket: {
+      open() {},
+      close() {},
+      data() {},
+    },
+    port: 0,
+    hostname: "127.0.0.1",
+  });
+
+  const out: Record<string, any> = {};
+  const result = server.getsockname(out);
+  expect(result).toBeUndefined();
+  expect(out.family).toBe("IPv4");
+  expect(out.address).toBe("127.0.0.1");
+  expect(out.port).toBe(server.port);
+});
+
 it("should not leak memory", async () => {
   // assert we don't leak the sockets
   // we expect 1 or 2 because that's the prototype / structure


### PR DESCRIPTION
## Summary

- Fix null pointer dereference in `Listener.getsockname()` when called without an object argument
- When `getsockname()` is called without arguments, it now creates and returns a new object with the socket address info
- When called with an object argument (internal `node:net` usage), existing behavior is preserved (object is populated, `undefined` is returned)

## Root Cause

`Listener.getsockname()` unconditionally took the first argument from the call frame and called `.put()` on it. When no argument was provided, this was `undefined`, which caused `JSC__JSValue__putBunString` in C++ to call `getObject()` returning null, then dereference it.

## Reproduction

```js
const listener = Bun.listen({ hostname: "localhost", port: 0, socket: { data(a) { return a; } } });
listener.getsockname(); // crash: null pointer dereference in BunString.cpp:942
listener.stop();
```

## Test plan

- [x] Verified the crash reproduces with the debug ASAN binary before the fix
- [x] Verified the crash no longer reproduces after the fix
- [x] Added test for `getsockname()` without arguments (returns object with family/address/port)
- [x] Added test for `getsockname(out)` with object argument (populates object, returns undefined)
- [x] Verified the new test fails on the system bun (crashes) and passes with the debug build