### PR TITLE
fix(bake): add --no-bundle-page-log to silence "Bundled page in" output

### DIFF
--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -80,6 +80,7 @@ pub const runtime_params_ = [_]ParamType{
     clap.parseParam("--watch                           Automatically restart the process on file change") catch unreachable,
     clap.parseParam("--hot                             Enable auto reload in the Bun runtime, test runner, or bundler") catch unreachable,
     clap.parseParam("--no-clear-screen                 Disable clearing the terminal screen on reload when --hot or --watch is enabled") catch unreachable,
+    clap.parseParam("--no-bundle-page-log              Disable the \"Bundled page in ...\" dev-server log line for Bun.serve()") catch unreachable,
     clap.parseParam("--smol                            Use less memory, but run garbage collection more often") catch unreachable,
     clap.parseParam("-r, --preload <STR>...            Import a module before other modules are loaded") catch unreachable,
     clap.parseParam("--require <STR>...                Alias of --preload, for Node.js compatibility") catch unreachable,
@@ -712,6 +713,10 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
             if (args.flag("--no-clear-screen")) {
                 bun.DotEnv.Loader.has_no_clear_screen_cli_flag = true;
             }
+        }
+
+        if (args.flag("--no-bundle-page-log")) {
+            bun.DotEnv.Loader.has_no_bundle_page_log_cli_flag = true;
         }
 
         if (args.option("--origin")) |origin| {

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -349,6 +349,12 @@ pub const Loader = struct {
         return (has_no_clear_screen_cli_flag orelse this.getAs(bool, "BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD")) orelse default_value;
     }
 
+    pub var has_no_bundle_page_log_cli_flag: ?bool = null;
+    /// Returns whether the `BUN_CONFIG_NO_BUNDLE_PAGE_LOG` env var is set to something truthy
+    pub fn hasSetNoBundlePageLog(this: *const Loader, default_value: bool) bool {
+        return (has_no_bundle_page_log_cli_flag orelse this.getAs(bool, "BUN_CONFIG_NO_BUNDLE_PAGE_LOG")) orelse default_value;
+    }
+
     pub fn get(this: *const Loader, key: string) ?string {
         var _key = key;
         if (_key.len > 0 and _key[0] == '$') {

--- a/test/js/bun/http/bun-serve-no-bundle-page-log.test.ts
+++ b/test/js/bun/http/bun-serve-no-bundle-page-log.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+
+async function runFixture(extraArgs: string[]) {
+  using dir = tempDir("bun-serve-no-bundle-page-log", {
+    "index.html": "<!doctype html><html><body><h1>Hello</h1></body></html>",
+    "server.ts": `
+      import page from "./index.html";
+
+      using server = Bun.serve({
+        port: 0,
+        development: true,
+        static: {
+          "/": page,
+        },
+        fetch() {
+          return new Response("Not found", { status: 404 });
+        },
+      });
+
+      const response = await fetch(server.url);
+      console.log("status", response.status);
+      await response.text();
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...extraArgs, "run", join(String(dir), "server.ts")],
+    cwd: String(dir),
+    env: bunEnv,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("status 200");
+  expect(exitCode).toBe(0);
+
+  return stderr;
+}
+
+test("--no-bundle-page-log suppresses only the bundled page log line", async () => {
+  const withDefaultLogging = await runFixture([]);
+  expect(withDefaultLogging).toContain("Bundled page in");
+
+  const withFlag = await runFixture(["--no-bundle-page-log"]);
+  expect(withFlag).not.toContain("Bundled page in");
+});


### PR DESCRIPTION
### What does this PR do?

Adds a new runtime CLI flag, --no-bundle-page-log, to suppress the "Bundled page in ..." line printed by the dev server during static page bundling in Bun.serve development mode.

### How did you verify your code works?

`bun bd test test/js/bun/http/bun-serve-no-bundle-page-log.test.ts` passes, `USE_SYSTEM_BUN=1 bun test test/js/bun/http/bun-serve-no-bundle-page-log.test.ts` fails.

### Motivation

Adding an extra section here to explain why I propose it: I have a test setup where for each E2E UI test, a new instance of my server and database is spawned on a unique port and it gets torn down with the test fixture as well. This way no server in-memory start or database content can interfere between tests (as it is also per-test and in-memory). However, this results in spam in my Playwright output as the tests are running. I am using the `dot` reporter which is compact, but with these lines, I get a line from the reporter and then 150 lines of `Bundled x in y ms`, one for each E2E test. I've not found a good way to suppress this (I have a wrapper script which streams the Playwright process and ditches this line, but my coding agent likes to run the Playwright CLI directly so it doesn't work well), so I figured I'll take a stab at contributing a fix for this.