### PR TITLE
fix: apply default signal disposition when no JS listeners are registered

### DIFF
--- a/test/js/node/process/process-on.test.ts
+++ b/test/js/node/process/process-on.test.ts
@@ -105,12 +105,10 @@ describe("signal default disposition", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode, signalCode] = await Promise.all([
-      child.stdout.text(),
-      child.stderr.text(),
-      child.exited,
-      child.signalCode,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
+
+    // Read signalCode after the process has exited (it's a synchronous property)
+    const signalCode = child.signalCode;
 
     // Process should be terminated by SIGHUP (exit code null, signal SIGHUP)
     // or exit with 128 + 1 = 129
@@ -138,12 +136,9 @@ describe("signal default disposition", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode, signalCode] = await Promise.all([
-      child.stdout.text(),
-      child.stderr.text(),
-      child.exited,
-      child.signalCode,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
+
+    const signalCode = child.signalCode;
 
     if (signalCode) {
       expect(signalCode).toBe("SIGTERM");
@@ -203,12 +198,9 @@ describe("signal default disposition", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode, signalCode] = await Promise.all([
-      child.stdout.text(),
-      child.stderr.text(),
-      child.exited,
-      child.signalCode,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
+
+    const signalCode = child.signalCode;
 
     // After removing all listeners, SIGHUP should use default disposition
     if (signalCode) {

--- a/test/js/node/process/process-on.test.ts
+++ b/test/js/node/process/process-on.test.ts
@@ -84,3 +84,137 @@ describe("process.on", () => {
     expect(result2.exitCode).toBe(0);
   });
 });
+
+describe("signal default disposition", () => {
+  it("SIGHUP terminates process when no JS listeners are registered", async () => {
+    await using child = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        // Keep the process alive without registering any signal listeners
+        setInterval(() => {}, 60000);
+        // Give the event loop a moment to settle, then send SIGHUP to self
+        setTimeout(() => {
+          process.kill(process.pid, "SIGHUP");
+        }, 50);
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode, signalCode] = await Promise.all([
+      child.stdout.text(),
+      child.stderr.text(),
+      child.exited,
+      child.signalCode,
+    ]);
+
+    // Process should be terminated by SIGHUP (exit code null, signal SIGHUP)
+    // or exit with 128 + 1 = 129
+    if (signalCode) {
+      expect(signalCode).toBe("SIGHUP");
+    } else {
+      expect(exitCode).toBe(128 + 1);
+    }
+  });
+
+  it("SIGTERM terminates process when no JS listeners are registered", async () => {
+    await using child = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        setInterval(() => {}, 60000);
+        setTimeout(() => {
+          process.kill(process.pid, "SIGTERM");
+        }, 50);
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode, signalCode] = await Promise.all([
+      child.stdout.text(),
+      child.stderr.text(),
+      child.exited,
+      child.signalCode,
+    ]);
+
+    if (signalCode) {
+      expect(signalCode).toBe("SIGTERM");
+    } else {
+      expect(exitCode).toBe(128 + 15);
+    }
+  });
+
+  it("signal with JS listener does NOT terminate process", async () => {
+    await using child = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        let handled = false;
+        process.on("SIGUSR1", () => {
+          handled = true;
+          process.exit(0);
+        });
+        setTimeout(() => {
+          process.kill(process.pid, "SIGUSR1");
+        }, 50);
+        setTimeout(() => {
+          // Fallback exit if signal handler didn't fire
+          process.exit(1);
+        }, 5000);
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const exitCode = await child.exited;
+    expect(exitCode).toBe(0);
+  });
+
+  it("removing all listeners restores default disposition", async () => {
+    await using child = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        // Add then remove listener
+        const handler = () => {};
+        process.on("SIGHUP", handler);
+        process.removeListener("SIGHUP", handler);
+
+        setInterval(() => {}, 60000);
+        setTimeout(() => {
+          process.kill(process.pid, "SIGHUP");
+        }, 50);
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode, signalCode] = await Promise.all([
+      child.stdout.text(),
+      child.stderr.text(),
+      child.exited,
+      child.signalCode,
+    ]);
+
+    // After removing all listeners, SIGHUP should use default disposition
+    if (signalCode) {
+      expect(signalCode).toBe("SIGHUP");
+    } else {
+      expect(exitCode).toBe(128 + 1);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

When a signal (e.g. `SIGHUP` from terminal death) is delivered to Bun's event loop via `Bun__onSignalForJS` and no JavaScript listeners are registered via `process.on()`, the signal is **silently swallowed**. This causes processes to become orphaned zombies that consume memory indefinitely.

**Node.js behavior**: when no listener exists for a signal, the default OS disposition takes effect (terminate for `SIGHUP`/`SIGTERM`/`SIGINT`). Bun should match this.

## The Bug

In `BunProcess.cpp`, `Bun__onSignalForJS()` unconditionally calls `emitForBindings()` on the process object. When `listenerCount` is 0, `emitForBindings()` does nothing and the function returns — the signal is consumed without effect.

**Signal flow that triggers this**:
1. Bun installs native signal handlers via `sigaction()` in several places (`onDidChangeListeners`, `Bun__registerSignalsForForwarding` during `spawnSync`, etc.)
2. Signal arrives → native handler (`forwardSignal` / `Bun__onPosixSignal`) enqueues to ring buffer
3. Event loop drains ring buffer → calls `Bun__onSignalForJS`
4. **If no JS `process.on()` listener exists**: `emitForBindings()` is a no-op → signal vanishes

## The Fix

Check `listenerCount` in `Bun__onSignalForJS`. If zero listeners exist, restore `SIG_DFL` via `sigaction()` and re-raise the signal so the OS terminates the process with the correct exit code (`128 + signo`). This matches Node.js's `SignalExit()` pattern in [`node.cc`](https://github.com/nodejs/node/blob/4e9877f73d8a94d89f65974365c672f66dc070c6/src/node.cc#L184-L187).

## Reproduction

1. Run any Bun application in a terminal (e.g. tmux pane)
2. Kill the terminal (e.g. `tmux kill-pane`)
3. The Bun process receives `SIGHUP` from the kernel but continues running as an orphan (`PPID=1`)
4. The process consumes memory indefinitely with no terminal attached

**Real-world impact**: On my system, 14 orphaned `opencode` (Bun-based TUI) processes accumulated to **66 GB of RAM** from repeated terminal session closures.

## Notes

- Bun's REPL already works around this with an explicit `process.on("SIGHUP", () => process.exit())` in `src/js/internal/html.ts:363` — this fix makes the workaround unnecessary for all Bun applications
- The `#if !OS(WINDOWS)` guard ensures no behavioral change on Windows where `sigaction`/`raise` aren't available
- Gated behind `listenerCount == 0` so existing programs with explicit signal handlers are unaffected

Refs: #1505, #7422