### PR TITLE
fix(spawn): prevent integer overflow in getArgv with large array length

### DIFF
--- a/test/js/bun/spawn/spawn-large-array-length.test.ts
+++ b/test/js/bun/spawn/spawn-large-array-length.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+describe("spawn with spoofed array length", () => {
+  test("Bun.spawnSync throws on array with length near u32 max", () => {
+    const arr = ["echo", "hello"];
+    Object.defineProperty(arr, "length", { value: 4294967295 });
+    expect(() => {
+      Bun.spawnSync(arr);
+    }).toThrow(/cmd array is too large/);
+  });
+
+  test("Bun.spawn throws on array with length near u32 max", () => {
+    const arr = ["echo", "hello"];
+    Object.defineProperty(arr, "length", { value: 4294967295 });
+    expect(() => {
+      Bun.spawn(arr);
+    }).toThrow(/cmd array is too large/);
+  });
+
+  test("Bun.spawnSync still works with normal arrays", () => {
+    const result = Bun.spawnSync(["echo", "hello"]);
+    expect(result.stdout.toString().trim()).toBe("hello");
+    expect(result.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Crash
Integer overflow panic in `getArgv` when `Bun.spawn`/`Bun.spawnSync` receives an array with `.length` near u32 max (e.g. 4294967295).

## Reproduction
```js
const arr = ["echo", "hello"];
Object.defineProperty(arr, "length", { value: 4294967295 });
Bun.spawnSync(arr);
```

## Root Cause
`JSArrayIterator.len` is a `u32` derived from the JS array's `.length` property. In `getArgv`, the expression `cmds_array.len + 2` (for argv0 + null terminator) overflows `u32` arithmetic when `len` is close to `u32` max. This causes a panic in debug builds and a segfault in release builds. Additionally, the validation checks (`isEmptyOrUndefinedOrNull` and `len == 0`) were placed after the overflowing `initCapacity` call, so they couldn't prevent the crash.

## Fix
- Move validation checks before the `initCapacity` call
- Add a length check rejecting arrays with length > `u32 max - 2`
- Widen `cmds_array.len` to `usize` before adding 2 to prevent overflow
- Use `try argv.append()` instead of `appendAssumeCapacity` for safety

## Verification
- Reproduction no longer crashes (throws clean "cmd array is too large" error)
- Normal `Bun.spawn`/`Bun.spawnSync` usage unaffected
- Added regression test at `test/js/bun/spawn/spawn-large-array-length.test.ts`