### PR TITLE
fix: prevent assertion crash when SharedArrayBuffer-backed views reach unsharedBuffer()

### DIFF
--- a/src/bun.js/bindings/BunIDLConvert.h
+++ b/src/bun.js/bindings/BunIDLConvert.h
@@ -189,9 +189,13 @@ template<> struct WebCore::Converter<Bun::IDLArrayBufferRef>
             return jsBuffer;
         }
         if (auto* jsView = JSC::jsDynamicCast<JSC::JSArrayBufferView*>(value)) {
+            if (jsView->isShared())
+                return std::nullopt;
             return jsView->unsharedBuffer();
         }
         if (auto* jsDataView = JSC::jsDynamicCast<JSC::JSDataView*>(value)) {
+            if (jsDataView->isShared())
+                return std::nullopt;
             return jsDataView->unsharedBuffer();
         }
         return std::nullopt;

--- a/src/bun.js/bindings/webcore/StructuredClone.cpp
+++ b/src/bun.js/bindings/webcore/StructuredClone.cpp
@@ -90,6 +90,11 @@ JSC_DEFINE_HOST_FUNCTION(structuredCloneForStream, (JSGlobalObject * globalObjec
         auto* bufferView = jsCast<JSArrayBufferView*>(value);
         ASSERT(bufferView);
 
+        if (bufferView->isShared()) {
+            throwDataCloneError(*globalObject, scope);
+            return {};
+        }
+
         auto* buffer = bufferView->unsharedBuffer();
         if (!buffer) {
             throwDataCloneError(*globalObject, scope);

--- a/test/js/web/streams/shared-array-buffer-clone.test.ts
+++ b/test/js/web/streams/shared-array-buffer-clone.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "bun:test";
+
+test("Response.clone() does not crash when body stream contains SharedArrayBuffer-backed typed array", async () => {
+  const sab = new SharedArrayBuffer(8);
+  const view = new Uint8Array(sab);
+
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(view);
+      controller.close();
+    },
+  });
+
+  const resp = new Response(stream);
+  const clone = resp.clone();
+  // Reading the cloned body triggers structuredCloneForStream on the chunk.
+  // Before the fix, this would crash with:
+  //   ASSERTION FAILED: !result || !result->isShared()
+  // Now it should throw a DataCloneError instead of crashing.
+  expect(async () => await clone.arrayBuffer()).toThrow("cloned");
+});

--- a/test/js/web/streams/shared-array-buffer-clone.test.ts
+++ b/test/js/web/streams/shared-array-buffer-clone.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("Response.clone() does not crash when body stream contains SharedArrayBuffer-backed typed array", async () => {
   const sab = new SharedArrayBuffer(8);


### PR DESCRIPTION
## Crash
Assertion failure in `JSArrayBufferView::unsharedBuffer()` when a typed array backed by a `SharedArrayBuffer` is passed through a code path that assumes unshared buffers.

## Reproduction
```js
const sab = new SharedArrayBuffer(8);
const view = new Uint8Array(sab);
const stream = new ReadableStream({
  start(controller) {
    controller.enqueue(view);
    controller.close();
  }
});
const resp = new Response(stream);
const clone = resp.clone();
await clone.arrayBuffer();
```

## Root Cause
`structuredCloneForStream` in `StructuredClone.cpp` calls `bufferView->unsharedBuffer()` without checking whether the view is backed by a `SharedArrayBuffer`. The `unsharedBuffer()` method asserts `!result || !result->isShared()`, so passing a shared-buffer-backed view triggers a crash. The same pattern exists in `BunIDLConvert.h`'s `IDLArrayBufferRef` converter, which is used by the bindgen system for APIs accepting `ArrayBuffer` arguments.

## Fix
- In `StructuredClone.cpp`: check `bufferView->isShared()` before calling `unsharedBuffer()` and throw a `DataCloneError` if shared.
- In `BunIDLConvert.h`: check `isShared()` on `JSArrayBufferView` and `JSDataView` before calling `unsharedBuffer()`, returning `std::nullopt` (conversion failure) if shared.

## Verification
- Reproduction no longer crashes (throws `DataCloneError` instead)
- Added regression test at `test/js/web/streams/shared-array-buffer-clone.test.ts`