### PR TITLE
fix: prevent double-fulfill when import() and require() race on same ESM module

### DIFF
--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -205,6 +205,15 @@ export function loadEsmIntoCjs(resolvedSpecifier: string) {
         (!$isPromise(fetch) ||
           ($getPromiseInternalField(fetch, $promiseFieldFlags) & $promiseStateMask) === $promiseStatePending))
     ) {
+      // If import() already started fetching this module, entry.fetch is a
+      // chained promise with a pending microtask reaction from the raw fetch
+      // promise. Clear it so $fulfillModuleSync → provideFetch → fulfillFetch
+      // creates a fresh promise instead of fulfilling the old one.
+      // https://github.com/oven-sh/bun/issues/12910
+      if (entry) {
+        entry.fetch = undefined;
+      }
+
       // force it to be no longer pending
       $fulfillModuleSync(key);
 


### PR DESCRIPTION
## Summary

Fixes a `ASSERT(status() == Status::Pending)` crash in `JSPromise::fulfillPromise` when `import()` and `require()` target the same ESM module that throws during evaluation.

**Root cause:** When `import()` starts fetching an ESM module, JSC's `requestFetch` creates `entry.fetch` as a `.then()` chained promise with a pending microtask reaction. If `require()` then loads the same module, `fetchCommonJSModuleNonBuiltin` called `provideFetch` which fulfilled that same promise directly. When the pending microtask reaction later fired, it attempted to resolve the already-fulfilled promise, crashing on the assertion.

This was exposed by #27288 which added `Loader.registry.$delete(id)` to the require() error path.

**Fix (two parts):**

- **ModuleLoader.cpp**: Extend the existing `hasAlreadyLoadedESMVersionSoWeShouldntTranspileItTwice` guard to also detect when `import()` has a fetch in progress (entry exists with a fetch promise but state is still `Fetch`). This prevents `fetchCommonJSModuleNonBuiltin` from calling `provideFetch` on that entry.
- **CommonJS.ts**: In `loadEsmIntoCjs`, clear `entry.fetch` before calling `$fulfillModuleSync`, so that `provideFetch` → `fulfillFetch` creates a fresh promise instead of fulfilling import()'s pending chained promise.

## Test plan

- [x] `test/regression/issue/12910/12910.test.ts` passes
- [x] `test/regression/issue/27287.test.ts` passes (the related regression test from #27288)
- [x] Verified crash reproduces without the fix
- [x] Verified no WebKit/JSC changes needed — this is a Bun-side misuse of `provideFetch`

Closes #12910

🤖 Generated with [Claude Code](https://claude.com/claude-code)