### PR TITLE
fix(bindgen): hoist WTF::String temps to dispatch scope to prevent use-after-free

### DIFF
--- a/src/bun.js/api/BunObject.bind.ts
+++ b/src/bun.js/api/BunObject.bind.ts
@@ -21,16 +21,3 @@ export const gc = fn({
   },
   ret: t.usize,
 });
-
-export const StringWidthOptions = t.dictionary({
-  countAnsiEscapeCodes: t.boolean.default(false),
-  ambiguousIsNarrow: t.boolean.default(true),
-});
-
-export const stringWidth = fn({
-  args: {
-    str: t.DOMString.default(""),
-    opts: StringWidthOptions.default({}),
-  },
-  ret: t.usize,
-});

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -34,6 +34,7 @@ pub const BunObject = struct {
     pub const sha = toJSCallback(host_fn.wrapStaticMethod(Crypto.SHA512_256, "hash_", true));
     pub const shellEscape = toJSCallback(Bun.shellEscape);
     pub const shrink = toJSCallback(Bun.shrink);
+    pub const stringWidth = toJSCallback(Bun.stringWidth);
     pub const sleepSync = toJSCallback(Bun.sleepSync);
     pub const spawn = toJSCallback(host_fn.wrapStaticMethod(api.Subprocess, "spawn", false));
     pub const spawnSync = toJSCallback(host_fn.wrapStaticMethod(api.Subprocess, "spawnSync", false));
@@ -179,6 +180,7 @@ pub const BunObject = struct {
         @export(&BunObject.sha, .{ .name = callbackName("sha") });
         @export(&BunObject.shellEscape, .{ .name = callbackName("shellEscape") });
         @export(&BunObject.shrink, .{ .name = callbackName("shrink") });
+        @export(&BunObject.stringWidth, .{ .name = callbackName("stringWidth") });
         @export(&BunObject.sleepSync, .{ .name = callbackName("sleepSync") });
         @export(&BunObject.spawn, .{ .name = callbackName("spawn") });
         @export(&BunObject.spawnSync, .{ .name = callbackName("spawnSync") });
@@ -1382,14 +1384,8 @@ pub fn getUnsafe(globalThis: *jsc.JSGlobalObject, _: *jsc.JSObject) jsc.JSValue 
     return UnsafeObject.create(globalThis);
 }
 
-pub fn stringWidth(str: bun.String, opts: gen.StringWidthOptions) usize {
-    if (str.length() == 0)
-        return 0;
-
-    if (opts.count_ansi_escape_codes)
-        return str.visibleWidth(!opts.ambiguous_is_narrow);
-
-    return str.visibleWidthExcludeANSIColors(!opts.ambiguous_is_narrow);
+pub fn stringWidth(globalObject: *jsc.JSGlobalObject, callFrame: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+    return bun.String.jsGetStringWidth(globalObject, callFrame);
 }
 
 /// EnvironmentVariables is runtime defined.

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -995,7 +995,7 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
     stderr                                         BunObject_lazyPropCb_wrap_stderr                                    DontDelete|PropertyCallback
     stdin                                          BunObject_lazyPropCb_wrap_stdin                                     DontDelete|PropertyCallback
     stdout                                         BunObject_lazyPropCb_wrap_stdout                                    DontDelete|PropertyCallback
-    stringWidth                                    Generated::BunObject::jsStringWidth                                 DontDelete|Function 2
+    stringWidth                                    BunObject_callback_stringWidth                                      DontDelete|Function 2
     stripANSI                                      jsFunctionBunStripANSI                                              DontDelete|Function 1
     wrapAnsi                                       jsFunctionBunWrapAnsi                                               DontDelete|Function 3
     Terminal                                       BunObject_lazyPropCb_wrap_Terminal                                  DontDelete|PropertyCallback


### PR DESCRIPTION
## Summary

Fixes a use-after-free in bindgen v1 generated C++ bindings that causes `"switch on corrupt value"` panics in `String.deref` on Windows. This is a top crash (500+ reports across v1.3.3–v1.3.9), predominantly affecting standalone executables.

## Root Cause

`Bun::toString(WTF::String&)` copies the raw `StringImpl*` pointer **without adding a reference**. For optional string arguments with defaults and dictionary string fields, the generated code declares `WTF::String` inside an `if` block, but the resulting `BunString` outlives it:

```cpp
BunString argStr;
if (!arg.isUndefinedOrNull()) {
    WTF::String wtfString_0 = WebCore::convert<IDLDOMString>(...);
    argStr = Bun::toString(wtfString_0);  // copies pointer, no ref
}  // ← wtfString_0 destroyed here, drops ref → StringImpl may be freed
// argStr now holds a dangling pointer to freed memory
```

When the freed memory is reused, `String.deref()` reads garbage for the tag field → `"switch on corrupt value"` panic.

### Why it was Windows-only / elevated recently

- The mimalloc v3 update (shipped in v1.3.7/v1.3.8) changed heap reuse patterns on Windows, causing freed memory to be overwritten more aggressively — turning a latent UAF into a frequent crash
- The mimalloc v3 revert in v1.3.9 reduced crash frequency back to baseline but did not fix the underlying bug
- A [previous fix](https://github.com/oven-sh/bun/pull/26717) was reverted due to unrelated CI failures

## Fix

Hoist all `WTF::String` temporaries to the same scope as the Zig dispatch call, so they stay alive until the `BunString` values are consumed:

1. **Function string arguments**: `WTF::String` is declared at the top of the generated function, before any `if` blocks for optional arguments
2. **Dictionary string fields**: The `convert*` function accepts `WTF::String&` references owned by the caller, so the string data outlives the `convert*` function and remains valid through the dispatch call

This approach is exception-safe — `WTF::String` destructors handle cleanup automatically on all exit paths (normal return, `RETURN_IF_EXCEPTION`, etc.) with no leaked refs.

### Difference from the previous fix

The [previous fix](https://github.com/oven-sh/bun/pull/26717) hoisted `WTF::String` for function arguments but kept dictionary field temps **inside** the `convert*` function. This left dictionary string fields as use-after-return — `result->encoding` would be a dangling pointer after `convert*` returned. This fix correctly passes `WTF::String&` refs from the dispatch scope through to the `convert*` function.

### Affected call sites

Only 2 call sites have the vulnerable pattern (`DOMString` + `.default(...)`):
- `Bun.stringWidth()` — `str: t.DOMString.default("")`  
- `os.userInfo()` — `encoding: t.DOMString.default("")` in `UserInfoOptions` dictionary

Note: bindgen v2 is not affected — it uses `releaseImpl().leakRef()` which transfers ownership correctly.