### PR TITLE
fix(types): add missing `contentEncoding` to S3Options type definition

### DIFF
--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -300,6 +300,25 @@ declare module "bun" {
     contentDisposition?: string | undefined;
 
     /**
+     * The Content-Encoding header value.
+     * Specifies what content encodings have been applied to the object,
+     * for example to indicate that it has been compressed.
+     *
+     * @example
+     *    // Setting gzip encoding
+     *     const file = s3.file("data.json.gz", {
+     *       contentEncoding: "gzip"
+     *     });
+     *
+     * @example
+     *    // Setting encoding when writing
+     *     await s3.write("data.json.gz", compressedData, {
+     *       contentEncoding: "gzip"
+     *     });
+     */
+    contentEncoding?: string | undefined;
+
+    /**
      * By default, Amazon S3 uses the STANDARD Storage Class to store newly created objects.
      *
      * @example


### PR DESCRIPTION
## Summary
- Adds the missing `contentEncoding` property to the `S3Options` TypeScript type definition in `packages/bun-types/s3.d.ts`
- The runtime support for `contentEncoding` was added in PR #26149 but the type definitions were not updated, causing TypeScript errors and missing IDE autocompletion

Closes #27328

## Test plan
- [x] Verify `contentEncoding` appears in `S3Options` interface alongside `contentDisposition`
- [x] Existing runtime tests in `test/js/bun/s3/s3.test.ts` already cover the runtime behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)