### PR TITLE
fix(windows): validate GetFinalPathNameByHandleW return length to prevent buffer overflows

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -6576,7 +6576,7 @@ pub const NodeFS = struct {
                 const wbuf = bun.os_path_buffer_pool.get();
                 defer bun.os_path_buffer_pool.put(wbuf);
                 const len = bun.windows.GetFinalPathNameByHandleW(handle.cast(), wbuf, wbuf.len, 0);
-                if (len == 0) {
+                if (len == 0 or len >= wbuf.len) {
                     return ret.errnoSysP(0, .copyfile, this.osPathIntoSyncErrorBuf(dest)) orelse dst_enoent_maybe;
                 }
                 const flags = if (stat_ & windows.FILE_ATTRIBUTE_DIRECTORY != 0)

--- a/src/install/PackageInstall.zig
+++ b/src/install/PackageInstall.zig
@@ -536,9 +536,12 @@ pub const PackageInstall = struct {
         }
 
         const dest_path_length = bun.windows.GetFinalPathNameByHandleW(destbase.fd, &state.buf, state.buf.len, 0);
-        if (dest_path_length == 0) {
+        if (dest_path_length == 0 or dest_path_length >= state.buf.len) {
             const e = bun.windows.Win32Error.get();
-            const err = if (e.toSystemErrno()) |sys_err| bun.errnoToZigErr(sys_err) else error.Unexpected;
+            const err = if (dest_path_length == 0)
+                (if (e.toSystemErrno()) |sys_err| bun.errnoToZigErr(sys_err) else error.Unexpected)
+            else
+                error.NameTooLong;
             state.cached_package_dir.close();
             state.walker.deinit();
             return Result.fail(err, .opening_dest_dir, null);
@@ -560,9 +563,12 @@ pub const PackageInstall = struct {
         state.to_copy_buf = state.buf[fullpath.len..];
 
         const cache_path_length = bun.windows.GetFinalPathNameByHandleW(state.cached_package_dir.fd, &state.buf2, state.buf2.len, 0);
-        if (cache_path_length == 0) {
+        if (cache_path_length == 0 or cache_path_length >= state.buf2.len) {
             const e = bun.windows.Win32Error.get();
-            const err = if (e.toSystemErrno()) |sys_err| bun.errnoToZigErr(sys_err) else error.Unexpected;
+            const err = if (cache_path_length == 0)
+                (if (e.toSystemErrno()) |sys_err| bun.errnoToZigErr(sys_err) else error.Unexpected)
+            else
+                error.NameTooLong;
             state.cached_package_dir.close();
             state.walker.deinit();
             return Result.fail(err, .copying_files, null);
@@ -1258,10 +1264,13 @@ pub const PackageInstall = struct {
         // When we're linking on Windows, we want to avoid keeping the source directory handle open
         if (comptime Environment.isWindows) {
             var wbuf: bun.WPathBuffer = undefined;
-            const dest_path_length = bun.windows.GetFinalPathNameByHandleW(destination_dir.fd, &wbuf, dest_buf.len, 0);
-            if (dest_path_length == 0) {
+            const dest_path_length = bun.windows.GetFinalPathNameByHandleW(destination_dir.fd, &wbuf, wbuf.len, 0);
+            if (dest_path_length == 0 or dest_path_length >= wbuf.len) {
                 const e = bun.windows.Win32Error.get();
-                const err = if (e.toSystemErrno()) |sys_err| bun.errnoToZigErr(sys_err) else error.Unexpected;
+                const err = if (dest_path_length == 0)
+                    (if (e.toSystemErrno()) |sys_err| bun.errnoToZigErr(sys_err) else error.Unexpected)
+                else
+                    error.NameTooLong;
                 return Result.fail(err, .linking_dependency, null);
             }
 

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -560,9 +560,11 @@ pub const Installer = struct {
                                             0,
                                         );
 
-                                        if (src_path_len == 0) {
-                                            const e = bun.windows.Win32Error.get();
-                                            const err = e.toSystemErrno() orelse .EUNKNOWN;
+                                        if (src_path_len == 0 or src_path_len >= src_path.buf().len) {
+                                            const err: bun.sys.SystemErrno = if (src_path_len == 0)
+                                                (bun.windows.Win32Error.get().toSystemErrno() orelse .EUNKNOWN)
+                                            else
+                                                .ENAMETOOLONG;
                                             return .failure(
                                                 .{ .link_package = .{ .errno = @intFromEnum(err), .syscall = .copyfile } },
                                             );

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -3416,6 +3416,11 @@ pub fn GetFinalPathNameByHandle(
         return error.FileNotFound;
     }
 
+    if (return_length >= out_buffer.len) {
+        bun.sys.syslog("GetFinalPathNameByHandleW({*p}) = NAMETOOLONG (needed {d}, have {d})", .{ hFile, return_length, out_buffer.len });
+        return error.NameTooLong;
+    }
+
     var ret = out_buffer[0..@intCast(return_length)];
 
     bun.sys.syslog("GetFinalPathNameByHandleW({*p}) = {f}", .{ hFile, bun.fmt.utf16(ret) });


### PR DESCRIPTION
## Summary

- `GetFinalPathNameByHandleW` returns a value `>= buffer size` when the path doesn't fit, but 4 out of 5 call sites only checked for `== 0` (the error case). This could cause out-of-bounds reads/writes when Windows paths exceed the buffer capacity — e.g. deeply nested `node_modules` or `\\?\` extended paths.
- Also fixed `PackageInstall.zig:1264` passing `dest_buf.len` (a `PathBuffer` = 4096 bytes) instead of `wbuf.len` (a `WPathBuffer` = 32767 u16 elements) as the buffer size parameter to the API.

| File | Line | Issue |
|------|------|-------|
| `src/windows.zig` | 3419 | `GetFinalPathNameByHandle` wrapper missing `>= len` check |
| `src/install/PackageInstall.zig` | 538 | OOB write at `state.buf[dest_path_length]` |
| `src/install/PackageInstall.zig` | 562 | OOB slice `state.buf2[0..cache_path_length]` |
| `src/install/PackageInstall.zig` | 1261 | Wrong buffer size param + missing bounds check |
| `src/bun.js/node/node_fs.zig` | 6578 | OOB slice in symlink path resolution during `copyFile` |
| `src/install/isolated_install/Installer.zig` | 556 | `setLength` with unchecked length |

The sole correct call site (`src/sys.zig:4062`) already had the proper `>= len` check and was used as the reference pattern.

## Test plan

- [x] `bun run zig:check-windows` passes (x86_64 + aarch64, Debug + ReleaseFast)
- [ ] Windows CI passes
- [ ] Test with deeply nested `node_modules` paths on Windows (>260 chars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)