### PR TITLE
fix(node:http): fall back to 'request' event when no 'upgrade' listener exists

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -602,14 +602,25 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           http_res.end();
           socket.destroy();
         } else if (is_upgrade) {
-          server.emit("upgrade", http_req, socket, kEmptyBuffer);
-          if (!socket._httpMessage) {
+          if (server.listenerCount("upgrade") > 0) {
+            server.emit("upgrade", http_req, socket, kEmptyBuffer);
+            if (!socket._httpMessage) {
+              if (canUseInternalAssignSocket) {
+                // ~10% performance improvement in JavaScriptCore due to avoiding .once("close", ...) and removing a listener
+                assignSocketInternal(http_res, socket);
+              } else {
+                http_res.assignSocket(socket);
+              }
+            }
+          } else {
+            // Node.js compatibility: when no 'upgrade' listener exists,
+            // fall back to emitting 'request' (see nodejs/node docs for http.Server 'upgrade' event)
             if (canUseInternalAssignSocket) {
-              // ~10% performance improvement in JavaScriptCore due to avoiding .once("close", ...) and removing a listener
               assignSocketInternal(http_res, socket);
             } else {
               http_res.assignSocket(socket);
             }
+            server.emit("request", http_req, http_res);
           }
         } else if (http_req.headers.expect !== undefined) {
           if (http_req.headers.expect === "100-continue") {

--- a/test/regression/issue/26924.test.ts
+++ b/test/regression/issue/26924.test.ts
@@ -1,0 +1,62 @@
+import { expect, test, describe } from "bun:test";
+import http from "node:http";
+
+// https://github.com/oven-sh/bun/issues/26924
+// node:http server should fall back to emitting 'request' when an upgrade
+// request arrives but no 'upgrade' event listener is registered.
+
+describe("node:http upgrade fallback to request", () => {
+  test("emits 'request' when no 'upgrade' listener exists", async () => {
+    const { promise: gotRequest, resolve: resolveRequest } = Promise.withResolvers<http.IncomingMessage>();
+
+    const server = http.createServer((req, res) => {
+      resolveRequest(req);
+      res.writeHead(200);
+      res.end("ok");
+    });
+
+    try {
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const port = (server.address() as { port: number }).port;
+
+      // Send a WebSocket upgrade request — server has no 'upgrade' listener,
+      // so Node.js should fall back to emitting 'request'
+      const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+
+      const req = await gotRequest;
+      expect(req.headers.upgrade).toBe("websocket");
+
+      ws.close();
+    } finally {
+      server.close();
+    }
+  });
+
+  test("emits 'upgrade' when listener exists", async () => {
+    const { promise: gotUpgrade, resolve: resolveUpgrade } = Promise.withResolvers<http.IncomingMessage>();
+
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+
+    server.on("upgrade", (req, socket) => {
+      resolveUpgrade(req);
+      socket.end();
+    });
+
+    try {
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const port = (server.address() as { port: number }).port;
+
+      const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+
+      const req = await gotUpgrade;
+      expect(req.headers.upgrade).toBe("websocket");
+
+      ws.close();
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
Closes #26924

## Problem

When a `node:http` server receives an HTTP upgrade request (e.g. WebSocket) but has **no `'upgrade'` event listener**, Node.js falls back to emitting a `'request'` event instead. This allows the server to handle it as a regular HTTP request.

Bun was unconditionally emitting `'upgrade'` regardless of whether any listener was registered, causing the request to be silently dropped.

**Node.js behavior:**
```
[Server] received a request.         ← upgrade fallback to 'request' ✓
```

**Bun behavior (before fix):**
```
                                     ← request silently dropped ✗
```

## Fix

Added a `server.listenerCount("upgrade")` check in `_http_server.ts` before emitting the `'upgrade'` event. When no listener exists, the server now falls back to emitting `'request'` — consistent with how `'connect'` (line 534) and `'checkContinue'` (line 616) are already handled in the same function.

```typescript
} else if (is_upgrade) {
  if (server.listenerCount("upgrade") > 0) {
    server.emit("upgrade", http_req, socket, kEmptyBuffer);
    // ...
  } else {
    // Fall back to 'request' — Node.js compatibility
    assignSocket(http_res, socket);
    server.emit("request", http_req, http_res);
  }
```

## Test

Added regression test in `test/regression/issue/26924.test.ts` that:
1. Verifies upgrade requests fall back to `'request'` when no `'upgrade'` listener exists
2. Verifies upgrade requests still emit `'upgrade'` when a listener is registered

Verified with system Bun 1.3.9:
- Test 1 **times out** (bug confirmed — request is dropped)
- Test 2 **passes** (existing upgrade behavior works)

Verified with Node.js 22.21.1:
- Both tests pass (correct fallback behavior)