### PR TITLE
fix(http): key keepalive pool on SSL context for custom TLS in fetch()

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -73,7 +73,7 @@ pub fn checkServerIdentity(
                     };
 
                     // we inform the user that the cert is invalid
-                    client.progressUpdate(is_ssl, if (is_ssl) &http_thread.https_context else &http_thread.http_context, socket);
+                    client.progressUpdate(is_ssl, if (is_ssl) client.getSslCtx() else &http_thread.http_context, socket);
                     // continue until we are aborted or not
                     return true;
                 } else {
@@ -217,7 +217,7 @@ pub fn onClose(
     if (client.state.flags.is_redirect_pending) {
         // if the connection is closed and we are pending redirect just do the redirect
         // in this case we will re-connect or go to a different socket if needed
-        client.doRedirect(is_ssl, if (is_ssl) &http_thread.https_context else &http_thread.http_context, socket);
+        client.doRedirect(is_ssl, if (is_ssl) client.getSslCtx() else &http_thread.http_context, socket);
         return;
     }
     if (in_progress) {
@@ -226,7 +226,7 @@ pub fn onClose(
                 .CHUNKED_IN_TRAILERS_LINE_HEAD, .CHUNKED_IN_TRAILERS_LINE_MIDDLE => {
                     // ignore failure if we are in the middle of trailer headers, since we processed all the chunks and trailers are ignored
                     client.state.flags.received_last_chunk = true;
-                    client.progressUpdate(comptime is_ssl, if (is_ssl) &http_thread.https_context else &http_thread.http_context, socket);
+                    client.progressUpdate(comptime is_ssl, if (is_ssl) client.getSslCtx() else &http_thread.http_context, socket);
                     return;
                 },
                 // here we are in the middle of a chunk so ECONNRESET is expected
@@ -235,7 +235,7 @@ pub fn onClose(
         } else if (client.state.content_length == null and client.state.response_stage == .body) {
             // no content length informed so we are done here
             client.state.flags.received_last_chunk = true;
-            client.progressUpdate(comptime is_ssl, if (is_ssl) &http_thread.https_context else &http_thread.http_context, socket);
+            client.progressUpdate(comptime is_ssl, if (is_ssl) client.getSslCtx() else &http_thread.http_context, socket);
             return;
         }
     }
@@ -481,6 +481,9 @@ flags: Flags = Flags{},
 
 state: InternalState = .{},
 tls_props: ?*SSLConfig = null,
+/// Points to the custom SSL context this client uses (from custom_ssl_context_map).
+/// null means use the default https_context. Set by HTTPThread.connect().
+custom_ssl_ctx: ?*NewHTTPContext(true) = null,
 result_callback: HTTPClientResult.Callback = undefined,
 
 /// Some HTTP servers (such as npm) report Last-Modified times but ignore If-Modified-Since.
@@ -533,6 +536,11 @@ pub fn isKeepAlivePossible(this: *HTTPClient) bool {
         if (this.state.flags.allow_keepalive and !this.flags.disable_keepalive) return true;
     }
     return false;
+}
+
+/// Returns the SSL context for this client (custom or default).
+pub inline fn getSslCtx(this: *HTTPClient) *NewHTTPContext(true) {
+    return this.custom_ssl_ctx orelse &http_thread.https_context;
 }
 
 // lowercase hash header names so that we can be sure
@@ -942,7 +950,7 @@ fn printResponse(response: picohttp.Response) void {
 pub fn onPreconnect(this: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket) void {
     log("onPreconnect({})", .{this.url});
     this.unregisterAbortTracker();
-    const ctx = if (comptime is_ssl) &http_thread.https_context else &http_thread.http_context;
+    const ctx = if (comptime is_ssl) this.getSslCtx() else &http_thread.http_context;
     ctx.releaseSocket(
         socket,
         this.flags.did_have_handshaking_error and !this.flags.reject_unauthorized,
@@ -1220,7 +1228,7 @@ pub fn onWritable(this: *HTTPClient, comptime is_first_call: bool, comptime is_s
                     this.state.request_stage = .body;
                     if (this.flags.is_streaming_request_body) {
                         // lets signal to start streaming the body
-                        this.progressUpdate(is_ssl, if (is_ssl) &http_thread.https_context else &http_thread.http_context, socket);
+                        this.progressUpdate(is_ssl, if (is_ssl) this.getSslCtx() else &http_thread.http_context, socket);
                     }
                 }
                 return;
@@ -1233,7 +1241,7 @@ pub fn onWritable(this: *HTTPClient, comptime is_first_call: bool, comptime is_s
                     this.state.request_stage = .body;
                     if (this.flags.is_streaming_request_body) {
                         // lets signal to start streaming the body
-                        this.progressUpdate(is_ssl, if (is_ssl) &http_thread.https_context else &http_thread.http_context, socket);
+                        this.progressUpdate(is_ssl, if (is_ssl) this.getSslCtx() else &http_thread.http_context, socket);
                     }
                 }
                 assert(
@@ -1388,7 +1396,7 @@ pub fn onWritable(this: *HTTPClient, comptime is_first_call: bool, comptime is_s
                     this.state.request_stage = .proxy_body;
                     if (this.flags.is_streaming_request_body) {
                         // lets signal to start streaming the body
-                        this.progressUpdate(is_ssl, if (is_ssl) &http_thread.https_context else &http_thread.http_context, socket);
+                        this.progressUpdate(is_ssl, if (is_ssl) this.getSslCtx() else &http_thread.http_context, socket);
                     }
                     assert(this.state.request_body.len > 0);
 
@@ -1779,7 +1787,7 @@ pub fn drainResponseBody(this: *HTTPClient, comptime is_ssl: bool, socket: NewHT
         return;
     }
 
-    this.sendProgressUpdateWithoutStageCheck(is_ssl, http_thread.context(is_ssl), socket);
+    this.sendProgressUpdateWithoutStageCheck(is_ssl, if (is_ssl) this.getSslCtx() else &http_thread.http_context, socket);
 }
 
 fn sendProgressUpdateWithoutStageCheck(this: *HTTPClient, comptime is_ssl: bool, ctx: *NewHTTPContext(is_ssl), socket: NewHTTPContext(is_ssl).HTTPSocket) void {

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -312,7 +312,14 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     unreachable;
                 } else {
                     log("PooledSocket not claimed by any context pool", .{});
-                    terminateSocket(pooled.http_socket);
+                    // Cannot call terminateSocket here: it goes through
+                    // markSocketAsDead → markTaggedSocketAsDead which reads the
+                    // still-PooledSocket tag and re-enters addMemoryBackToPool,
+                    // causing infinite recursion. Mark dead and close directly.
+                    if (pooled.http_socket.ext(**anyopaque)) |ctx| {
+                        ctx.* = bun.cast(**anyopaque, ActiveSocket.init(dead_socket).ptr());
+                    }
+                    pooled.http_socket.close(.failure);
                 }
             }
 

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -299,7 +299,20 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             }
 
             fn addMemoryBackToPool(pooled: *PooledSocket) void {
-                assert(context().pending_sockets.put(pooled));
+                // Check the default context first (most common case).
+                if (context().pending_sockets.put(pooled)) return;
+                // Check custom SSL contexts — the pooled socket may belong
+                // to a custom context's HiveArray.
+                if (comptime ssl) {
+                    for (bun.http.HTTPThread.customSslContextValues()) |custom_ctx| {
+                        if (custom_ctx.pending_sockets.put(pooled)) return;
+                    }
+                }
+                if (comptime bun.Environment.allow_assert) {
+                    unreachable;
+                } else {
+                    log("PooledSocket not claimed by any context pool", .{});
+                }
             }
 
             pub fn onData(
@@ -312,7 +325,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     return client.onData(
                         comptime ssl,
                         buf,
-                        if (comptime ssl) &bun.http.http_thread.https_context else &bun.http.http_thread.http_context,
+                        if (comptime ssl) client.getSslCtx() else &bun.http.http_thread.http_context,
                         socket,
                     );
                 } else if (tagged.is(PooledSocket)) {
@@ -421,7 +434,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                         continue;
                     }
 
-                    assert(context().pending_sockets.put(socket));
+                    assert(this.pending_sockets.put(socket));
                     log("+ Keep-Alive reuse {s}:{d}", .{ hostname, port });
                     return http_socket;
                 }

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -312,6 +312,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     unreachable;
                 } else {
                     log("PooledSocket not claimed by any context pool", .{});
+                    terminateSocket(pooled.http_socket);
                 }
             }
 

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -250,6 +250,7 @@ pub fn connect(this: *@This(), client: *HTTPClient, comptime is_ssl: bool) !NewH
             }
             // we need the config so dont free it
             var custom_context = try bun.default_allocator.create(NewHTTPContext(is_ssl));
+            custom_context.pending_sockets = NewHTTPContext(is_ssl).PooledSocketHiveAllocator.init();
             custom_context.initWithClientConfig(client) catch |err| {
                 client.tls_props = null;
 

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -235,10 +235,16 @@ pub fn connect(this: *@This(), client: *HTTPClient, comptime is_ssl: bool) !NewH
                         bun.default_allocator.destroy(requested_config);
                     }
                     client.tls_props = other_config;
+                    const matched_ctx = custom_ssl_context_map.get(other_config).?;
+                    client.custom_ssl_ctx = matched_ctx;
                     if (client.http_proxy) |url| {
-                        return try custom_ssl_context_map.get(other_config).?.connect(client, url.hostname, url.getPortAuto());
+                        // https://github.com/oven-sh/bun/issues/11343
+                        if (url.protocol.len == 0 or strings.eqlComptime(url.protocol, "https") or strings.eqlComptime(url.protocol, "http")) {
+                            return try this.context(is_ssl).connect(client, url.hostname, url.getPortAuto());
+                        }
+                        return error.UnsupportedProxyProtocol;
                     } else {
-                        return try custom_ssl_context_map.get(other_config).?.connect(client, client.url.hostname, client.url.getPortAuto());
+                        return try matched_ctx.connect(client, client.url.hostname, client.url.getPortAuto());
                     }
                 }
             }
@@ -259,10 +265,8 @@ pub fn connect(this: *@This(), client: *HTTPClient, comptime is_ssl: bool) !NewH
                     error.LoadCAFile => error.FailedToOpenSocket,
                 };
             };
-            try custom_ssl_context_map.put(requested_config, custom_context);
-            // We might deinit the socket context, so we disable keepalive to make sure we don't
-            // free it while in use.
-            client.flags.disable_keepalive = true;
+            bun.handleOom(custom_ssl_context_map.put(requested_config, custom_context));
+            client.custom_ssl_ctx = custom_context;
             if (client.http_proxy) |url| {
                 // https://github.com/oven-sh/bun/issues/11343
                 if (url.protocol.len == 0 or strings.eqlComptime(url.protocol, "https") or strings.eqlComptime(url.protocol, "http")) {
@@ -287,6 +291,15 @@ pub fn connect(this: *@This(), client: *HTTPClient, comptime is_ssl: bool) !NewH
 
 pub fn context(this: *@This(), comptime is_ssl: bool) *NewHTTPContext(is_ssl) {
     return if (is_ssl) &this.https_context else &this.http_context;
+}
+
+/// Returns a borrowed slice of custom SSL context pointers from the internal
+/// hash map storage. The caller must not mutate `custom_ssl_context_map`
+/// (e.g. via `connect()` adding a new entry) while iterating the result.
+/// This is safe because map mutations and pool returns happen in distinct
+/// phases of the event loop.
+pub fn customSslContextValues() []*NewHTTPContext(true) {
+    return custom_ssl_context_map.values();
 }
 
 fn drainQueuedShutdowns(this: *@This()) void {

--- a/test/js/bun/http/tls-keepalive.test.ts
+++ b/test/js/bun/http/tls-keepalive.test.ts
@@ -1,0 +1,79 @@
+import { test, expect, describe } from "bun:test";
+import { tls as validTls, invalidTls } from "harness";
+
+describe("TLS keepalive with custom SSL contexts", () => {
+  test("multiple requests with same custom TLS config reuse connections", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      tls: validTls,
+      fetch() {
+        return new Response("ok");
+      },
+    });
+
+    const url = `https://localhost:${server.port}/`;
+    const results: string[] = [];
+
+    for (let i = 0; i < 5; i++) {
+      const res = await fetch(url, {
+        tls: { ca: validTls.cert },
+      });
+      results.push(await res.text());
+    }
+
+    expect(results).toEqual(["ok", "ok", "ok", "ok", "ok"]);
+  });
+
+  test("different TLS configs for same hostname do not cross-contaminate", async () => {
+    // This test verifies that the keepalive pool is keyed by SSL context,
+    // not just by host:port. The first fetch with a valid CA should pool its
+    // connection; the second fetch with a different (invalid) CA must NOT
+    // reuse that pooled connection and should fail TLS verification.
+    await using server = Bun.serve({
+      port: 0,
+      tls: validTls,
+      fetch() {
+        return new Response("ok");
+      },
+    });
+
+    const url = `https://localhost:${server.port}/`;
+
+    // First request with valid CA should succeed and pool the connection
+    const res1 = await fetch(url, {
+      tls: { ca: validTls.cert },
+    });
+    expect(await res1.text()).toBe("ok");
+
+    // Second request with invalid/wrong CA must fail —
+    // it should NOT reuse the first connection's TLS session
+    try {
+      await fetch(url, {
+        tls: { ca: invalidTls.cert },
+      });
+      // If we get here, the connection was incorrectly reused
+      expect().fail("Expected fetch with wrong CA to fail, but it succeeded");
+    } catch (e: any) {
+      expect(e.code).toBe("UNABLE_TO_VERIFY_LEAF_SIGNATURE");
+    }
+  });
+
+  test("many sequential requests with custom TLS return correct responses", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      tls: validTls,
+      fetch() {
+        return new Response("ok");
+      },
+    });
+
+    const url = `https://localhost:${server.port}/`;
+
+    for (let i = 0; i < 50; i++) {
+      const res = await fetch(url, {
+        tls: { ca: validTls.cert },
+      });
+      expect(await res.text()).toBe("ok");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the keepalive pool routing for custom TLS contexts in `fetch()`. Previously, all HTTP client callbacks hardcoded the default `https_context`, so sockets from custom TLS configurations were released into the wrong keepalive pool — causing either a memory leak (when keepalive was disabled as a workaround) or a security vulnerability (when keepalive was naively enabled, allowing different SSL configs for the same hostname to share connections).

**Root cause:** The `ctx` parameter flowing through all 9 HTTP client callback sites in `http.zig` plus handlers in `HTTPContext.zig` always pointed to the default `https_context`, never to custom contexts created via `custom_ssl_context_map`.

## Changes

- **`src/http.zig`**: Added `custom_ssl_ctx` field and `getSslCtx()` helper to `HTTPClient`. Fixed all 9 call sites (`checkServerIdentity`, `onClose`, `onPreconnect`, `onWritable`, `drainResponseBody`) to use `getSslCtx()` instead of hardcoding `&http_thread.https_context`.

- **`src/http/HTTPThread.zig`**: Set `client.custom_ssl_ctx` during `connect()` in both the existing-context-match path and new-context-creation path. Added `customSslContextValues()` to expose custom context values.

- **`src/http/HTTPContext.zig`**: Fixed `addMemoryBackToPool` to check the default pool first, then iterate custom SSL contexts using `HiveArray.put()`'s pointer-range check to find the owning pool. Fixed `onData` to use `client.getSslCtx()`. Fixed `existingSocket` to use `this.pending_sockets` directly.

- **`test/js/bun/http/tls-keepalive.test.ts`**: New tests verifying keepalive works with custom TLS, different TLS configs don't cross-contaminate, and stress testing pool correctness.

## Test plan

- [ ] `bun bd test test/js/bun/http/tls-keepalive.test.ts` — new tests pass
- [ ] `bun bd test test/js/web/fetch/fetch.tls.test.ts` — existing TLS tests still pass