### PR TITLE
fix(bake): prevent stale_files bitset out-of-bounds panic during bundling

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -2021,7 +2021,7 @@ fn generateClientBundle(dev: *DevServer, route_bundle: *RouteBundle) bun.OOM![]u
     if (dev.framework.react_fast_refresh) |rfr| brk: {
         const rfr_index = dev.client_graph.getFileIndex(rfr.import_source) orelse
             break :brk;
-        if (!dev.client_graph.stale_files.isSet(rfr_index.get())) {
+        if (!dev.client_graph.stale_files.isSetAllowOutOfBound(rfr_index.get(), true)) {
             try dev.client_graph.traceImports(rfr_index, &gts, .find_client_modules);
             react_fast_refresh_id = rfr.import_source;
         }
@@ -3082,7 +3082,7 @@ pub fn isFileCached(dev: *DevServer, path: []const u8, side: bake.Graph) ?CacheE
             };
             const index = g.bundled_files.getIndex(path) orelse
                 return null; // non-existent files are considered stale
-            if (!g.stale_files.isSet(index)) {
+            if (!g.stale_files.isSetAllowOutOfBound(index, true)) {
                 return .{ .kind = g.getFileByIndex(.init(@intCast(index))).fileKind() };
             }
             return null;
@@ -3106,8 +3106,8 @@ fn appendOpaqueEntryPoint(
 
     const file_index = fromOpaqueFileId(side, file);
     if (switch (side) {
-        .server => dev.server_graph.stale_files.isSet(file_index.get()),
-        .client => dev.client_graph.stale_files.isSet(file_index.get()),
+        .server => dev.server_graph.stale_files.isSetAllowOutOfBound(file_index.get(), true),
+        .client => dev.client_graph.stale_files.isSetAllowOutOfBound(file_index.get(), true),
     }) {
         try entry_points.appendJs(alloc, file_names[file_index.get()], side.graph());
     }

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -417,3 +417,42 @@ devTest("commonjs forms", {
     await c.expectMessage({ field: "6" });
   },
 });
+
+// Regression test for https://github.com/oven-sh/bun/issues/27356
+// CJS module with many sub-files caused stale_files bitset out-of-bounds panic
+// because receiveChunk() added files during bundling before ensureStaleBitCapacity()
+// was called to resize the bitset.
+devTest("cjs module with many sub-requires does not crash", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import result from "./lib/index.js";
+      console.log(result);
+    `,
+    "lib/index.js": `
+      const a = require("./mod1.js");
+      const b = require("./mod2.js");
+      const c = require("./mod3.js");
+      const d = require("./mod4.js");
+      const e = require("./mod5.js");
+      const f = require("./mod6.js");
+      const g = require("./mod7.js");
+      const h = require("./mod8.js");
+      module.exports = a + b + c + d + e + f + g + h;
+    `,
+    "lib/mod1.js": `module.exports = 1;`,
+    "lib/mod2.js": `module.exports = 2;`,
+    "lib/mod3.js": `module.exports = 3;`,
+    "lib/mod4.js": `module.exports = 4;`,
+    "lib/mod5.js": `module.exports = 5;`,
+    "lib/mod6.js": `module.exports = 6;`,
+    "lib/mod7.js": `module.exports = 7;`,
+    "lib/mod8.js": `module.exports = 8;`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage(36);
+  },
+});


### PR DESCRIPTION
## Summary

- Replace `stale_files.isSet()` with `stale_files.isSetAllowOutOfBound()` at three call sites in `DevServer.zig` where the bitset could be accessed before being resized to match newly added files
- Newly discovered files during bundling (via `receiveChunk()`) get indices that exceed the `stale_files` bitset capacity until `ensureStaleBitCapacity()` is called after bundling completes
- Out-of-bounds indices are treated as stale (uncached), which is semantically correct for files that haven't been through a full bundle cycle

## Root Cause

During bundling, `receiveChunk()` adds new files to `bundled_files`, increasing valid file indices. Meanwhile, `isFileCached()` and `appendOpaqueEntryPoint()` look up paths in `bundled_files` and check `stale_files.isSet(index)` — but `ensureStaleBitCapacity()` hasn't resized the bitset yet. On Windows (ReleaseSafe builds where assertions are enabled), this causes a panic. On Linux/macOS (ReleaseFast), the assertion is stripped and it silently reads out-of-bounds memory.

The fix follows the existing pattern at line 3726 which already uses `isSetAllowOutOfBound()` for the same bitset.

## Test plan

- [x] Added regression test: CJS module with 8+ sub-requires verifying dev server doesn't crash
- [x] All existing `test/bake/dev/bundle.test.ts` tests pass (13/13)

Closes #27356

🤖 Generated with [Claude Code](https://claude.com/claude-code)