### PR TITLE
fix(http): add authorized property and own socket to HTTPS client responses

### DIFF
--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -130,7 +130,22 @@ function IncomingMessage(socket) {
 
     Readable.$call(this, streamOptions);
 
-    this[fakeSocketSymbol] = socket;
+    if (socket) {
+      // Node.js assigns `this.socket = socket` directly, so it's an own data
+      // property. Define it explicitly here (instead of going through the
+      // prototype getter/setter, which stores it on fakeSocketSymbol) so that
+      // response.hasOwnProperty('socket') is true — postman-request and
+      // similar libraries rely on this for SSL verification, reading
+      // response.socket.authorized / .encrypted off the real TLS socket.
+      Object.defineProperty(this, "socket", {
+        value: socket,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    } else {
+      this[fakeSocketSymbol] = socket;
+    }
 
     this.httpVersionMajor = null;
     this.httpVersionMinor = null;

--- a/test/regression/issue/23452.test.ts
+++ b/test/regression/issue/23452.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import http from "node:http";
+import https from "node:https";
+import { join } from "node:path";
+
+const fixturesDir = join(import.meta.dirname, "..", "fixtures");
+const cert = readFileSync(join(fixturesDir, "cert.pem"), "utf8");
+const key = readFileSync(join(fixturesDir, "cert.key"), "utf8");
+
+test("HTTPS response has socket as own property with authorized=true", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    tls: { cert, key },
+    fetch() {
+      return new Response("OK");
+    },
+  });
+
+  // Read the socket synchronously in the response handler, the way
+  // postman-request and similar libraries do for SSL verification. The socket
+  // is detached from the response once the body ends (keep-alive returns it to
+  // the pool), so capture what we need before draining the response.
+  const result = await new Promise<{ hasOwnSocket: boolean; encrypted: unknown; authorized: unknown }>(
+    (resolve, reject) => {
+      const req = https.get(`https://localhost:${server.port}/`, { ca: cert, rejectUnauthorized: true }, res => {
+        resolve({
+          hasOwnSocket: Object.prototype.hasOwnProperty.call(res, "socket"),
+          encrypted: res.socket.encrypted,
+          authorized: res.socket.authorized,
+        });
+        res.resume();
+      });
+      req.on("error", reject);
+    },
+  );
+
+  expect(result).toEqual({ hasOwnSocket: true, encrypted: true, authorized: true });
+});
+
+test("HTTPS response reports authorized=false for an unverified certificate", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    tls: { cert, key },
+    fetch() {
+      return new Response("OK");
+    },
+  });
+
+  // Without the matching CA and with rejectUnauthorized: false, the connection
+  // succeeds but the self-signed certificate is not trusted. `authorized` must
+  // reflect the real TLS handshake result (false), not a hardcoded `true`.
+  const result = await new Promise<{ hasOwnSocket: boolean; encrypted: unknown; authorized: unknown }>(
+    (resolve, reject) => {
+      const req = https.get(`https://localhost:${server.port}/`, { rejectUnauthorized: false }, res => {
+        resolve({
+          hasOwnSocket: Object.prototype.hasOwnProperty.call(res, "socket"),
+          encrypted: res.socket.encrypted,
+          authorized: res.socket.authorized,
+        });
+        res.resume();
+      });
+      req.on("error", reject);
+    },
+  );
+
+  expect(result).toEqual({ hasOwnSocket: true, encrypted: true, authorized: false });
+});
+
+test("HTTP response socket has no encrypted/authorized properties", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response("OK");
+    },
+  });
+
+  const result = await new Promise<{ hasOwnSocket: boolean; encrypted: unknown; authorized: unknown }>(
+    (resolve, reject) => {
+      const req = http.get(`http://localhost:${server.port}/`, res => {
+        resolve({
+          hasOwnSocket: Object.prototype.hasOwnProperty.call(res, "socket"),
+          encrypted: res.socket.encrypted,
+          authorized: res.socket.authorized,
+        });
+        res.resume();
+      });
+      req.on("error", reject);
+    },
+  );
+
+  expect(result).toEqual({ hasOwnSocket: true, encrypted: undefined, authorized: undefined });
+});


### PR DESCRIPTION
### What does this PR do?

 - Fix `response.socket.authorized` being `undefined` for HTTPS client responses made via `node:http`/`node:https`
 - Fix `response.hasOwnProperty('socket')` returning `false` (was a prototype getter instead of an own property like Node.js)

### How did you verify your code works?

- Tests added: `test/regression/issue/23452.test.ts` - these fail with the current version of Bun, but work with the changes in this branch
- And then I also manually validated the change in a project that uses `postman-request` with HTTPS, and it works without issue now.

Closes #23452 
