### PR TITLE
fix(gc): reduce idle CPU by transitioning GC timer to slow mode faster

### DIFF
--- a/src/bun.js/event_loop/GarbageCollectionController.zig
+++ b/src/bun.js/event_loop/GarbageCollectionController.zig
@@ -96,7 +96,7 @@ pub fn onGCTimer(timer: *uws.Timer) callconv(.c) void {
 //    - Slow: GC runs every 30 seconds
 //
 // When the heap size is increasing, we always switch to fast mode
-// When the heap size has been the same or less for 30 seconds, we switch to slow mode
+// When the heap size has been the same for 5 consecutive ticks, we switch to slow mode
 pub fn updateGCRepeatTimer(this: *GarbageCollectionController, comptime setting: @Type(.enum_literal)) void {
     if (setting == .fast and !this.gc_repeating_timer_fast) {
         this.gc_repeating_timer_fast = true;
@@ -116,7 +116,7 @@ pub fn onGCRepeatingTimer(timer: *uws.Timer) callconv(.c) void {
     this.gc_last_heap_size_on_repeating_timer = this.gc_last_heap_size;
     if (prev_heap_size == this.gc_last_heap_size_on_repeating_timer) {
         this.heap_size_didnt_change_for_repeating_timer_ticks_count +|= 1;
-        if (this.heap_size_didnt_change_for_repeating_timer_ticks_count >= 30) {
+        if (this.heap_size_didnt_change_for_repeating_timer_ticks_count >= 5) {
             // make the timer interval longer
             this.updateGCRepeatTimer(.slow);
         }


### PR DESCRIPTION
## Summary

- Reduce the GC repeating timer's slow-mode transition threshold from 30 ticks to 5 ticks, so Bun reaches idle state ~6x faster (5s vs 30s of stable heap required)
- This addresses excessive idle CPU usage reported when applications have large module registries with active timers

## Root Cause

Bun's GC controller uses a repeating timer that fires every 1 second in "fast mode" to check if garbage collection is needed. It only transitions to "slow mode" (30-second interval) after the heap size has been stable for 30 consecutive ticks — meaning 30 seconds of constant event loop wakeups even when the process is completely idle.

Each timer tick creates an epoll/kqueue wakeup (via timerfd on Linux), calls `collectAsync()`, and reads heap statistics. While each individual wakeup is lightweight, the cumulative effect is measurable: the original reporter observed 2-10% CPU with 11k modules loaded, compared to ~0% in Node.js. The `pidstat` output showed CPU activity in 28 out of 28 sampled seconds (constant wakeups) vs Node.js's 1 out of 28.

## Fix

Reduce the threshold from 30 to 5 consecutive stable-heap ticks before transitioning to slow mode. After 5 seconds of stable heap, there's sufficient evidence the process is idle and doesn't need frequent GC checks. The timer still switches back to fast mode immediately when heap growth is detected, preserving GC responsiveness during active allocation.

## Test plan

- [x] Debug build compiles successfully
- [x] Manual verification: with 11k modules + timers, the GC timer transitions to slow mode within ~5 seconds instead of ~30 seconds
- [ ] CI passes — this is a minimal, safe change to a single threshold constant

Closes #27365

🤖 Generated with [Claude Code](https://claude.com/claude-code)