### PR TITLE
fix(docs): update TanStack Start guide to use non-deprecated CLI

### DIFF
--- a/docs/guides/ecosystem/tanstack-start.mdx
+++ b/docs/guides/ecosystem/tanstack-start.mdx
@@ -13,8 +13,10 @@ mode: center
     Use the interactive CLI to create a new TanStack Start app.
 
     ```sh terminal icon="terminal"
-    bun create @tanstack/start@latest my-tanstack-app
+    bunx @tanstack/cli create my-tanstack-app
     ```
+
+    When prompted, select `bun` as your package manager.
 
   </Step>
   <Step title="Start the dev server">

--- a/docs/guides/ecosystem/tanstack-start.mdx
+++ b/docs/guides/ecosystem/tanstack-start.mdx
@@ -16,8 +16,6 @@ mode: center
     bunx @tanstack/cli create my-tanstack-app
     ```
 
-    When prompted, select `bun` as your package manager.
-
   </Step>
   <Step title="Start the dev server">
     Change to the project directory and run the dev server with Bun.


### PR DESCRIPTION
## Summary
- Replace deprecated `bun create @tanstack/start@latest` with `bunx @tanstack/cli create` in the TanStack Start guide
- The `@tanstack/create-start` package now prints a runtime deprecation warning: *"@tanstack/create-start is deprecated. Use `tanstack create` or `npx @tanstack/cli create` instead."*

Fixes #27374

## Test plan
- [x] Verified `bunx @tanstack/cli create --help` works correctly
- [x] Verified `bunx @tanstack/create-start@latest` shows the deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)