### PR TITLE
fix(worker): guard message event listener tracking to worker contexts only

### DIFF
--- a/src/bun.js/bindings/BunWorkerGlobalScope.cpp
+++ b/src/bun.js/bindings/BunWorkerGlobalScope.cpp
@@ -17,6 +17,8 @@ void WorkerGlobalScope::onDidChangeListenerImpl(EventTarget& self, const AtomStr
 {
     if (eventType == eventNames().messageEvent) {
         auto& global = static_cast<WorkerGlobalScope&>(self);
+        if (!global.scriptExecutionContext()->isWorker)
+            return;
         switch (kind) {
         case Add:
             if (global.m_messageEventCount == 0) {

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -557,6 +557,7 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
             vm.ensureTerminationException();
             // Make the VM stop sooner once terminated (e.g. microtasks won't run)
             vm.forbidExecutionOnTermination();
+            globalObject->scriptExecutionContext()->isWorker = true;
         };
 
         if (auto* worker = static_cast<WebCore::Worker*>(worker_ptr)) {

--- a/test/regression/issue/24256.test.ts
+++ b/test/regression/issue/24256.test.ts
@@ -5,15 +5,13 @@ test("setting onmessage on main thread global should terminate the process", asy
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", /* js */ `globalThis.onmessage = () => {};`],
     env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
   });
 
   const exitCode = await proc.exited;
   expect(exitCode).toBe(0);
 }, 2000);
 
-test("setting onmessage inside ShadowRealm should termiante the process", async () => {
+test("setting onmessage inside ShadowRealm should terminate the process", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -24,8 +22,6 @@ test("setting onmessage inside ShadowRealm should termiante the process", async 
       `,
     ],
     env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
   });
 
   const exitCode = await proc.exited;
@@ -43,11 +39,9 @@ test("setting onmessage inside worker should keep the process alive (bun specifi
       `,
     ],
     env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
   });
 
-  const exited = await Promise.race([proc.exited.then(() => 1), Bun.sleep(300).then(() => 0)]);
+  const exited = await Promise.race([proc.exited, Bun.sleep(300).then(() => 0)]);
   expect(exited).toBe(0);
   proc.kill();
 }, 2000);

--- a/test/regression/issue/24256.test.ts
+++ b/test/regression/issue/24256.test.ts
@@ -44,4 +44,5 @@ test("setting onmessage inside worker should keep the process alive (bun specifi
   const exited = await Promise.race([proc.exited, Bun.sleep(300).then(() => 0)]);
   expect(exited).toBe(0);
   proc.kill();
+  await proc.exited;
 }, 2000);

--- a/test/regression/issue/24256.test.ts
+++ b/test/regression/issue/24256.test.ts
@@ -9,7 +9,7 @@ test("setting onmessage on main thread global should terminate the process", asy
 
   const exitCode = await proc.exited;
   expect(exitCode).toBe(0);
-}, 2000);
+});
 
 test("setting onmessage inside ShadowRealm should terminate the process", async () => {
   await using proc = Bun.spawn({
@@ -26,7 +26,7 @@ test("setting onmessage inside ShadowRealm should terminate the process", async 
 
   const exitCode = await proc.exited;
   expect(exitCode).toBe(0);
-}, 2000);
+});
 
 test("setting onmessage inside worker should keep the process alive (bun specific)", async () => {
   await using proc = Bun.spawn({
@@ -45,4 +45,4 @@ test("setting onmessage inside worker should keep the process alive (bun specifi
   expect(exited).toBe(0);
   proc.kill();
   await proc.exited;
-}, 2000);
+});


### PR DESCRIPTION
### What does this PR do?
Fixes https://github.com/oven-sh/bun/issues/24256
Fixes https://github.com/oven-sh/bun/issues/24484

Setting `onmessage` on the main thread global or inside a ShadowRealm was incorrectly incrementing the message event listener count, which prevented the process from exiting.

Also reproducible with
```js
self.addEventListener("message", () => {});
```

Fix: only track message event listeners in `WorkerGlobalScope` when the script execution context is actually a worker. Mark the context as a worker in `ZigGlobalObject` when the worker is being set up.

### How did you verify your code works?
Regression tests. They ensure that setting `onmessage` keeps the server alive in a Worker like before, but also ensures that setting it on the main thread and shadow realm (which is also on the main thread) won't prevent the server from exiting