### PR TITLE
fix(standalone): remove incorrect @alignCast on sourcemap bytes

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -336,7 +336,7 @@ pub const StandaloneModuleGraph = struct {
                     .contents = sliceToZ(raw_bytes, module.contents),
                     .sourcemap = if (module.sourcemap.length > 0)
                         .{ .serialized = .{
-                            .bytes = @alignCast(sliceTo(raw_bytes, module.sourcemap)),
+                            .bytes = sliceTo(raw_bytes, module.sourcemap),
                         } }
                     else
                         .none,
@@ -588,7 +588,7 @@ pub const StandaloneModuleGraph = struct {
 
         if (comptime Environment.isDebug) {
             // An expensive sanity check:
-            var graph = try fromBytes(allocator, @alignCast(output_bytes), offsets);
+            var graph = try fromBytes(allocator, output_bytes, offsets);
             defer {
                 graph.files.unlockPointers();
                 graph.files.deinit();

--- a/test/regression/issue/27383.test.ts
+++ b/test/regression/issue/27383.test.ts
@@ -56,7 +56,6 @@ try { fn(); } catch (e) {
   // The stack trace should contain original file names (sourcemap worked)
   expect(stdout).toMatch(/error from (a|bb|ccc|ddddd)/);
 
-  // Should not crash (exit code 0, no panic in stderr)
-  expect(stderr).not.toContain("panic");
+  // Should not crash
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/27383.test.ts
+++ b/test/regression/issue/27383.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test";
+import { bunEnv, tempDir } from "harness";
+import { join } from "path";
+
+// Regression test for https://github.com/oven-sh/bun/issues/27383
+// Standalone executables with inline sourcemaps could crash with
+// "panic: incorrect alignment" on Windows ARM64 (ReleaseSafe builds)
+// because @alignCast promoted the alignment of sourcemap byte slices
+// inside the LazySourceMap union from 1 to 8, but serialized sourcemap
+// data in standalone binaries can be at any offset.
+
+test("standalone compile with inline sourcemap does not crash from alignment", async () => {
+  // Use files with varying name lengths to increase the chance of
+  // non-8-byte-aligned sourcemap offsets in the standalone binary.
+  using dir = tempDir("issue-27383", {
+    "a.js": `export function a() { throw new Error("error from a"); }`,
+    "bb.js": `export function bb() { throw new Error("error from bb"); }`,
+    "ccc.js": `export function ccc() { throw new Error("error from ccc"); }`,
+    "ddddd.js": `export function ddddd() { throw new Error("error from ddddd"); }`,
+    "entry.js": `
+import { a } from "./a.js";
+import { bb } from "./bb.js";
+import { ccc } from "./ccc.js";
+import { ddddd } from "./ddddd.js";
+
+const fns = [a, bb, ccc, ddddd];
+const fn = fns[Math.floor(Math.random() * fns.length)];
+try { fn(); } catch (e) {
+  // Accessing the stack triggers sourcemap parsing
+  console.log(e.stack);
+}
+`,
+  });
+
+  const result = await Bun.build({
+    entrypoints: [join(String(dir), "entry.js")],
+    compile: true,
+    sourcemap: "inline",
+  });
+
+  expect(result.success).toBe(true);
+  expect(result.outputs.length).toBe(1);
+
+  const executablePath = result.outputs[0].path;
+
+  await using proc = Bun.spawn({
+    cmd: [executablePath],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The stack trace should contain original file names (sourcemap worked)
+  expect(stdout).toMatch(/error from (a|bb|ccc|ddddd)/);
+
+  // Should not crash (exit code 0, no panic in stderr)
+  expect(stderr).not.toContain("panic");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Remove unnecessary `@alignCast()` on sourcemap byte slices in `StandaloneModuleGraph.zig` that caused `panic: incorrect alignment` on Windows ARM64 ReleaseSafe builds
- The `LazySourceMap` union's payload alignment (8 bytes from the `*SourceMap.ParsedSourceMap` pointer variant) caused `@alignCast` to promote the sourcemap `[]const u8` slice alignment from 1 to 8, but serialized sourcemap data in standalone binaries can be at any offset
- Add regression test that compiles a standalone with inline sourcemaps using files with varying name lengths

Closes #27383

## Test plan

- [x] `bun bd test test/regression/issue/27383.test.ts` passes
- [x] `bun bd test test/bundler/bun-build-compile-sourcemap.test.ts` passes (existing tests unaffected)
- [ ] CI passes on Windows ARM64 (where the bug manifests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)