### PR TITLE
fix(sys): remove MSG_NOSIGNAL from recvfrom flags

### DIFF
--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -462,7 +462,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                     #ifdef _WIN32
                       const int recv_flags = MSG_PUSH_IMMEDIATE;
                     #else
-                      const int recv_flags = MSG_DONTWAIT | MSG_NOSIGNAL;
+                      const int recv_flags = MSG_DONTWAIT;
                     #endif
 
                     int length;

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -2035,7 +2035,6 @@ pub fn readAll(fd: bun.FileDescriptor, buf: []u8) Maybe(usize) {
     return .{ .result = total_read };
 }
 
-const recv_flags_nonblock = c.MSG_DONTWAIT;
 const send_flags_nonblock = c.MSG_DONTWAIT | c.MSG_NOSIGNAL;
 
 pub fn recvNonBlock(fd: bun.FileDescriptor, buf: []u8) Maybe(usize) {
@@ -4360,10 +4359,12 @@ const bun = @import("bun");
 const Environment = bun.Environment;
 const FD = bun.FD;
 const MAX_PATH_BYTES = bun.MAX_PATH_BYTES;
-const c = bun.c; // translated c headers
 const jsc = bun.jsc;
 const libc_stat = bun.Stat;
 const darwin_nocancel = bun.darwin.nocancel;
+
+const c = bun.c; // translated c headers
+const recv_flags_nonblock = c.MSG_DONTWAIT;
 
 const windows = bun.windows;
 const kernel32 = bun.windows.kernel32;

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -2035,10 +2035,11 @@ pub fn readAll(fd: bun.FileDescriptor, buf: []u8) Maybe(usize) {
     return .{ .result = total_read };
 }
 
-const socket_flags_nonblock = c.MSG_DONTWAIT | c.MSG_NOSIGNAL;
+const recv_flags_nonblock = c.MSG_DONTWAIT;
+const send_flags_nonblock = c.MSG_DONTWAIT | c.MSG_NOSIGNAL;
 
 pub fn recvNonBlock(fd: bun.FileDescriptor, buf: []u8) Maybe(usize) {
-    return recv(fd, buf, socket_flags_nonblock);
+    return recv(fd, buf, recv_flags_nonblock);
 }
 
 pub fn poll(fds: []std.posix.pollfd, timeout: i32) Maybe(usize) {
@@ -2119,7 +2120,7 @@ pub fn kevent(fd: bun.FileDescriptor, changelist: []const std.c.Kevent, eventlis
 }
 
 pub fn sendNonBlock(fd: bun.FileDescriptor, buf: []const u8) Maybe(usize) {
-    return send(fd, buf, socket_flags_nonblock);
+    return send(fd, buf, send_flags_nonblock);
 }
 
 pub fn send(fd: bun.FileDescriptor, buf: []const u8, flag: u32) Maybe(usize) {

--- a/test/regression/issue/27389.test.ts
+++ b/test/regression/issue/27389.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for #27389: recvfrom() was called with MSG_NOSIGNAL which
+// is only valid for send operations. This caused EINVAL in strict environments
+// like gVisor (Google Cloud Run). The fix removes MSG_NOSIGNAL from recv flags.
+//
+// On standard Linux the kernel silently ignores the invalid flag, so we verify
+// the fix by ensuring socket recv operations complete without error.
+
+test("socket recv works without EINVAL from invalid flags", async () => {
+  // Start a simple echo server and client that exercises the recv path
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const server = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        socket: {
+          open(socket) {},
+          data(socket, data) {
+            // Echo back the data
+            socket.write(data);
+            socket.end();
+          },
+        },
+      });
+      const client = await Bun.connect({
+        hostname: "127.0.0.1",
+        port: server.port,
+        socket: {
+          open(socket) {
+            socket.write("hello");
+          },
+          data(socket, data) {
+            console.log(Buffer.from(data).toString());
+            socket.end();
+          },
+          close() {
+            server.stop(true);
+          },
+        },
+      });
+    `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("hello");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- `MSG_NOSIGNAL` is only valid for send operations (`send`, `sendto`, `sendmsg`), not receive operations (`recv`, `recvfrom`, `recvmsg`). Passing it to `recvfrom` causes `EINVAL` in strict environments like gVisor (Google Cloud Run).
- Split the shared `socket_flags_nonblock` constant into `recv_flags_nonblock` (`MSG_DONTWAIT` only) and `send_flags_nonblock` (`MSG_DONTWAIT | MSG_NOSIGNAL`).

Closes #27389

## Test plan

- [x] Added regression test `test/regression/issue/27389.test.ts` that exercises the socket recv path
- [x] Debug build passes (`bun bd test test/regression/issue/27389.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)