### PR TITLE
fix(bundler): write external sourcemap .map files for `bun build --compile`

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -2179,15 +2179,55 @@ pub const BundleV2 = struct {
                 output_file.is_executable = true;
             }
 
+            // Write external sourcemap files next to the compiled executable and
+            // keep them in the output array. Destroy all other non-entry-point files.
+            const sourcemap_outfile = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{s}.map", .{full_outfile_path}));
+            var kept: usize = 0;
             for (output_files.items, 0..) |*current, i| {
-                if (i != entry_point_index) {
+                if (i == entry_point_index) {
+                    output_files.items[kept] = current.*;
+                    kept += 1;
+                } else if (result == .success and current.output_kind == .sourcemap and current.value == .buffer) {
+                    const sourcemap_bytes = current.value.buffer.bytes;
+                    if (sourcemap_bytes.len > 0) {
+                        // Write the sourcemap file to disk next to the executable
+                        var pathbuf: bun.PathBuffer = undefined;
+                        const sourcemap_basename = std.fs.path.basename(sourcemap_outfile);
+                        const write_path = if (Environment.isWindows) sourcemap_outfile else sourcemap_basename;
+                        switch (bun.jsc.Node.fs.NodeFS.writeFileWithPathBuffer(
+                            &pathbuf,
+                            .{
+                                .data = .{ .buffer = .{
+                                    .buffer = .{
+                                        .ptr = @constCast(sourcemap_bytes.ptr),
+                                        .len = @as(u32, @truncate(sourcemap_bytes.len)),
+                                        .byte_len = @as(u32, @truncate(sourcemap_bytes.len)),
+                                    },
+                                } },
+                                .encoding = .buffer,
+                                .dirfd = .fromStdDir(root_dir),
+                                .file = .{ .path = .{
+                                    .string = bun.PathString.init(write_path),
+                                } },
+                            },
+                        )) {
+                            .err => {
+                                current.deinit();
+                            },
+                            .result => {
+                                current.dest_path = sourcemap_outfile;
+                                output_files.items[kept] = current.*;
+                                kept += 1;
+                            },
+                        }
+                    } else {
+                        current.deinit();
+                    }
+                } else {
                     current.deinit();
                 }
             }
-
-            const entry_point_output_file = output_files.swapRemove(entry_point_index);
-            output_files.items.len = 1;
-            output_files.items[0] = entry_point_output_file;
+            output_files.items.len = kept;
 
             return result;
         }

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -2193,9 +2193,9 @@ pub const BundleV2 = struct {
                         // Derive the .map filename from the sourcemap's own dest_path,
                         // placed in the same directory as the compiled executable.
                         const map_basename = if (current.dest_path.len > 0)
-                            std.fs.path.basename(current.dest_path)
+                            bun.path.basename(current.dest_path)
                         else
-                            std.fs.path.basename(bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{s}.map", .{full_outfile_path})));
+                            bun.path.basename(bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{s}.map", .{full_outfile_path})));
 
                         const sourcemap_full_path = if (dirname.len == 0 or strings.eqlComptime(dirname, "."))
                             bun.handleOom(bun.default_allocator.dupe(u8, map_basename))

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -2181,7 +2181,7 @@ pub const BundleV2 = struct {
 
             // Write external sourcemap files next to the compiled executable and
             // keep them in the output array. Destroy all other non-entry-point files.
-            const sourcemap_outfile = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{s}.map", .{full_outfile_path}));
+            // With --splitting, there can be multiple sourcemap files (one per chunk).
             var kept: usize = 0;
             for (output_files.items, 0..) |*current, i| {
                 if (i == entry_point_index) {
@@ -2190,10 +2190,21 @@ pub const BundleV2 = struct {
                 } else if (result == .success and current.output_kind == .sourcemap and current.value == .buffer) {
                     const sourcemap_bytes = current.value.buffer.bytes;
                     if (sourcemap_bytes.len > 0) {
+                        // Derive the .map filename from the sourcemap's own dest_path,
+                        // placed in the same directory as the compiled executable.
+                        const map_basename = if (current.dest_path.len > 0)
+                            std.fs.path.basename(current.dest_path)
+                        else
+                            std.fs.path.basename(bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{s}.map", .{full_outfile_path})));
+
+                        const sourcemap_full_path = if (dirname.len == 0 or strings.eqlComptime(dirname, "."))
+                            bun.handleOom(bun.default_allocator.dupe(u8, map_basename))
+                        else
+                            bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{s}{c}{s}", .{ dirname, std.fs.path.sep, map_basename }));
+
                         // Write the sourcemap file to disk next to the executable
                         var pathbuf: bun.PathBuffer = undefined;
-                        const sourcemap_basename = std.fs.path.basename(sourcemap_outfile);
-                        const write_path = if (Environment.isWindows) sourcemap_outfile else sourcemap_basename;
+                        const write_path = if (Environment.isWindows) sourcemap_full_path else map_basename;
                         switch (bun.jsc.Node.fs.NodeFS.writeFileWithPathBuffer(
                             &pathbuf,
                             .{
@@ -2215,7 +2226,7 @@ pub const BundleV2 = struct {
                                 current.deinit();
                             },
                             .result => {
-                                current.dest_path = sourcemap_outfile;
+                                current.dest_path = sourcemap_full_path;
                                 output_files.items[kept] = current.*;
                                 kept += 1;
                             },

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -2222,7 +2222,8 @@ pub const BundleV2 = struct {
                                 } },
                             },
                         )) {
-                            .err => {
+                            .err => |err| {
+                                bun.Output.err(err, "failed to write sourcemap file '{s}'", .{write_path});
                                 current.deinit();
                             },
                             .result => {

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -549,7 +549,6 @@ pub const BuildCommand = struct {
                 // Write external sourcemap files next to the compiled executable.
                 // With --splitting, there can be multiple .map files (one per chunk).
                 if (this_transpiler.options.source_map == .external) {
-                    const outfile_dirname = std.fs.path.dirname(outfile) orelse "";
                     for (output_files) |f| {
                         if (f.output_kind == .sourcemap and f.value == .buffer) {
                             const sourcemap_bytes = f.value.buffer.bytes;
@@ -567,11 +566,9 @@ pub const BuildCommand = struct {
                                     try std.fmt.allocPrint(allocator, "{s}.map", .{exe_base});
                             };
 
-                            const map_path = if (outfile_dirname.len == 0)
-                                map_basename
-                            else
-                                try std.fmt.allocPrint(allocator, "{s}{c}{s}", .{ outfile_dirname, std.fs.path.sep, map_basename });
-
+                            // root_dir already points to the outfile's parent directory,
+                            // so use map_basename (not a path with directory components)
+                            // to avoid writing to a doubled directory path.
                             var pathbuf: bun.PathBuffer = undefined;
                             switch (bun.jsc.Node.fs.NodeFS.writeFileWithPathBuffer(
                                 &pathbuf,
@@ -586,12 +583,12 @@ pub const BuildCommand = struct {
                                     .encoding = .buffer,
                                     .dirfd = .fromStdDir(root_dir),
                                     .file = .{ .path = .{
-                                        .string = bun.PathString.init(map_path),
+                                        .string = bun.PathString.init(map_basename),
                                     } },
                                 },
                             )) {
                                 .err => |err| {
-                                    Output.err(err, "failed to write sourcemap file '{s}'", .{map_path});
+                                    Output.err(err, "failed to write sourcemap file '{s}'", .{map_basename});
                                     had_err = true;
                                 },
                                 .result => {},

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -557,9 +557,9 @@ pub const BuildCommand = struct {
                             // Use the sourcemap's own dest_path basename if available,
                             // otherwise fall back to {outfile}.map
                             const map_basename = if (f.dest_path.len > 0)
-                                std.fs.path.basename(f.dest_path)
+                                bun.path.basename(f.dest_path)
                             else brk: {
-                                const exe_base = std.fs.path.basename(outfile);
+                                const exe_base = bun.path.basename(outfile);
                                 break :brk if (compile_target.os == .windows and !strings.hasSuffixComptime(exe_base, ".exe"))
                                     try std.fmt.allocPrint(allocator, "{s}.exe.map", .{exe_base})
                                 else

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -546,17 +546,31 @@ pub const BuildCommand = struct {
                     Global.exit(1);
                 }
 
-                // Write external sourcemap files next to the compiled executable
+                // Write external sourcemap files next to the compiled executable.
+                // With --splitting, there can be multiple .map files (one per chunk).
                 if (this_transpiler.options.source_map == .external) {
+                    const outfile_dirname = std.fs.path.dirname(outfile) orelse "";
                     for (output_files) |f| {
                         if (f.output_kind == .sourcemap and f.value == .buffer) {
                             const sourcemap_bytes = f.value.buffer.bytes;
                             if (sourcemap_bytes.len == 0) continue;
 
-                            const outfile_with_ext = if (compile_target.os == .windows and !strings.hasSuffixComptime(outfile, ".exe"))
-                                try std.fmt.allocPrint(allocator, "{s}.exe.map", .{outfile})
+                            // Use the sourcemap's own dest_path basename if available,
+                            // otherwise fall back to {outfile}.map
+                            const map_basename = if (f.dest_path.len > 0)
+                                std.fs.path.basename(f.dest_path)
+                            else brk: {
+                                const exe_base = std.fs.path.basename(outfile);
+                                break :brk if (compile_target.os == .windows and !strings.hasSuffixComptime(exe_base, ".exe"))
+                                    try std.fmt.allocPrint(allocator, "{s}.exe.map", .{exe_base})
+                                else
+                                    try std.fmt.allocPrint(allocator, "{s}.map", .{exe_base});
+                            };
+
+                            const map_path = if (outfile_dirname.len == 0)
+                                map_basename
                             else
-                                try std.fmt.allocPrint(allocator, "{s}.map", .{outfile});
+                                try std.fmt.allocPrint(allocator, "{s}{c}{s}", .{ outfile_dirname, std.fs.path.sep, map_basename });
 
                             var pathbuf: bun.PathBuffer = undefined;
                             switch (bun.jsc.Node.fs.NodeFS.writeFileWithPathBuffer(
@@ -572,12 +586,12 @@ pub const BuildCommand = struct {
                                     .encoding = .buffer,
                                     .dirfd = .fromStdDir(root_dir),
                                     .file = .{ .path = .{
-                                        .string = bun.PathString.init(outfile_with_ext),
+                                        .string = bun.PathString.init(map_path),
                                     } },
                                 },
                             )) {
                                 .err => |err| {
-                                    Output.err(err, "failed to write sourcemap file '{s}'", .{outfile_with_ext});
+                                    Output.err(err, "failed to write sourcemap file '{s}'", .{map_path});
                                     had_err = true;
                                 },
                                 .result => {},

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -546,6 +546,46 @@ pub const BuildCommand = struct {
                     Global.exit(1);
                 }
 
+                // Write external sourcemap files next to the compiled executable
+                if (this_transpiler.options.source_map == .external) {
+                    for (output_files) |f| {
+                        if (f.output_kind == .sourcemap and f.value == .buffer) {
+                            const sourcemap_bytes = f.value.buffer.bytes;
+                            if (sourcemap_bytes.len == 0) continue;
+
+                            const outfile_with_ext = if (compile_target.os == .windows and !strings.hasSuffixComptime(outfile, ".exe"))
+                                try std.fmt.allocPrint(allocator, "{s}.exe.map", .{outfile})
+                            else
+                                try std.fmt.allocPrint(allocator, "{s}.map", .{outfile});
+
+                            var pathbuf: bun.PathBuffer = undefined;
+                            switch (bun.jsc.Node.fs.NodeFS.writeFileWithPathBuffer(
+                                &pathbuf,
+                                .{
+                                    .data = .{ .buffer = .{
+                                        .buffer = .{
+                                            .ptr = @constCast(sourcemap_bytes.ptr),
+                                            .len = @as(u32, @truncate(sourcemap_bytes.len)),
+                                            .byte_len = @as(u32, @truncate(sourcemap_bytes.len)),
+                                        },
+                                    } },
+                                    .encoding = .buffer,
+                                    .dirfd = .fromStdDir(root_dir),
+                                    .file = .{ .path = .{
+                                        .string = bun.PathString.init(outfile_with_ext),
+                                    } },
+                                },
+                            )) {
+                                .err => |err| {
+                                    Output.err(err, "failed to write sourcemap file '{s}'", .{outfile_with_ext});
+                                    had_err = true;
+                                },
+                                .result => {},
+                            }
+                        }
+                    }
+                }
+
                 const compiled_elapsed = @divTrunc(@as(i64, @truncate(std.time.nanoTimestamp() - bundled_end)), @as(i64, std.time.ns_per_ms));
                 const compiled_elapsed_digit_count: isize = switch (compiled_elapsed) {
                     0...9 => 3,

--- a/test/bundler/bun-build-compile-sourcemap.test.ts
+++ b/test/bundler/bun-build-compile-sourcemap.test.ts
@@ -173,9 +173,10 @@ export function greet() {
     const executablePath = executableOutput.path;
     expect(await Bun.file(executablePath).exists()).toBe(true);
 
-    // With splitting, there should be multiple sourcemap outputs
+    // With splitting and a dynamic import, there should be at least 2 sourcemaps
+    // (one for the entry chunk, one for the lazy-loaded chunk)
     const sourcemapOutputs = result.outputs.filter((o: any) => o.kind === "sourcemap");
-    expect(sourcemapOutputs.length).toBeGreaterThanOrEqual(1);
+    expect(sourcemapOutputs.length).toBeGreaterThanOrEqual(2);
 
     // Each sourcemap should be a valid .map file on disk
     const mapPaths = new Set<string>();

--- a/test/bundler/bun-build-compile-sourcemap.test.ts
+++ b/test/bundler/bun-build-compile-sourcemap.test.ts
@@ -147,6 +147,67 @@ main();`,
     expect(sourcemapOutputs.length).toBe(0);
   });
 
+  test("compile with splitting and external sourcemap writes multiple .map files", async () => {
+    using dir = tempDir("build-compile-sourcemap-splitting", {
+      "entry.js": `
+const mod = await import("./lazy.js");
+mod.greet();
+`,
+      "lazy.js": `
+export function greet() {
+  console.log("hello from lazy module");
+}
+`,
+    });
+
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "entry.js")],
+      compile: true,
+      splitting: true,
+      sourcemap: "external",
+    });
+
+    expect(result.success).toBe(true);
+
+    const executableOutput = result.outputs.find((o: any) => o.kind === "entry-point")!;
+    const executablePath = executableOutput.path;
+    expect(await Bun.file(executablePath).exists()).toBe(true);
+
+    // With splitting, there should be multiple sourcemap outputs
+    const sourcemapOutputs = result.outputs.filter((o: any) => o.kind === "sourcemap");
+    expect(sourcemapOutputs.length).toBeGreaterThanOrEqual(1);
+
+    // Each sourcemap should be a valid .map file on disk
+    const mapPaths = new Set<string>();
+    for (const sm of sourcemapOutputs) {
+      expect(sm.path).toEndWith(".map");
+      expect(await Bun.file(sm.path).exists()).toBe(true);
+
+      // Each map file should have a unique path (no overwrites)
+      expect(mapPaths.has(sm.path)).toBe(false);
+      mapPaths.add(sm.path);
+
+      // Validate the sourcemap is valid JSON
+      const mapContent = JSON.parse(await Bun.file(sm.path).text());
+      expect(mapContent.version).toBe(3);
+      expect(mapContent.mappings).toBeString();
+    }
+
+    // Run the compiled executable to ensure it works
+    await using proc = Bun.spawn({
+      cmd: [executablePath],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("hello from lazy module");
+    expect(exitCode).toBe(0);
+  });
+
   test("compile with multiple source files", async () => {
     using dir = tempDir("build-compile-sourcemap-multiple-files", {
       "utils.js": `export function utilError() {

--- a/test/bundler/bun-build-compile-sourcemap.test.ts
+++ b/test/bundler/bun-build-compile-sourcemap.test.ts
@@ -26,9 +26,9 @@ main();`,
     });
 
     expect(result.success).toBe(true);
-    expect(result.outputs.length).toBe(1);
 
-    const executablePath = result.outputs[0].path;
+    const executableOutput = result.outputs.find((o: any) => o.kind === "entry-point")!;
+    const executablePath = executableOutput.path;
     expect(await Bun.file(executablePath).exists()).toBe(true);
 
     // Run the compiled executable and capture the error
@@ -92,6 +92,59 @@ main();`,
 
     // Verify it failed (the error was thrown)
     expect(exitCode).not.toBe(0);
+  });
+
+  test("compile with sourcemap: external writes .map file to disk", async () => {
+    using dir = tempDir("build-compile-sourcemap-external-file", helperFiles);
+
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "app.js")],
+      compile: true,
+      sourcemap: "external",
+    });
+
+    expect(result.success).toBe(true);
+
+    const executableOutput = result.outputs.find((o: any) => o.kind === "entry-point")!;
+    const executablePath = executableOutput.path;
+    expect(await Bun.file(executablePath).exists()).toBe(true);
+
+    // The sourcemap output should appear in build result outputs
+    const sourcemapOutputs = result.outputs.filter((o: any) => o.kind === "sourcemap");
+    expect(sourcemapOutputs.length).toBe(1);
+
+    // The .map file should exist next to the executable
+    const mapPath = sourcemapOutputs[0].path;
+    expect(mapPath).toEndWith(".map");
+    expect(await Bun.file(mapPath).exists()).toBe(true);
+
+    // Validate the sourcemap is valid JSON with expected fields
+    const mapContent = JSON.parse(await Bun.file(mapPath).text());
+    expect(mapContent.version).toBe(3);
+    expect(mapContent.sources).toBeArray();
+    expect(mapContent.sources.length).toBeGreaterThan(0);
+    expect(mapContent.mappings).toBeString();
+  });
+
+  test("compile without sourcemap does not write .map file", async () => {
+    using dir = tempDir("build-compile-no-sourcemap-file", {
+      "nosourcemap_entry.js": helperFiles["app.js"],
+      "helper.js": helperFiles["helper.js"],
+    });
+
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "nosourcemap_entry.js")],
+      compile: true,
+    });
+
+    expect(result.success).toBe(true);
+
+    const executablePath = result.outputs[0].path;
+    // No .map file should exist next to the executable
+    expect(await Bun.file(`${executablePath}.map`).exists()).toBe(false);
+    // No sourcemap outputs should be in the result
+    const sourcemapOutputs = result.outputs.filter((o: any) => o.kind === "sourcemap");
+    expect(sourcemapOutputs.length).toBe(0);
   });
 
   test("compile with multiple source files", async () => {

--- a/test/bundler/bun-build-compile-sourcemap.test.ts
+++ b/test/bundler/bun-build-compile-sourcemap.test.ts
@@ -139,7 +139,8 @@ main();`,
 
     expect(result.success).toBe(true);
 
-    const executablePath = result.outputs[0].path;
+    const executableOutput = result.outputs.find((o: any) => o.kind === "entry-point")!;
+    const executablePath = executableOutput.path;
     // No .map file should exist next to the executable
     expect(await Bun.file(`${executablePath}.map`).exists()).toBe(false);
     // No sourcemap outputs should be in the result
@@ -233,7 +234,6 @@ export function greet() {
 
     const [_stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).not.toContain("error");
     expect(exitCode).toBe(0);
 
     // The executable should be at subdir/myapp
@@ -249,9 +249,8 @@ export function greet() {
     expect(mapContent.version).toBe(3);
     expect(mapContent.mappings).toBeString();
 
-    // The doubled path (subdir/subdir/) should NOT exist
-    const doubledSubdir = join(String(dir), "subdir", "subdir");
-    expect(await Bun.file(doubledSubdir).exists()).toBe(false);
+    // Verify no .map was written into the doubled path subdir/subdir/
+    expect(await Bun.file(join(String(dir), "subdir", "subdir", "myapp.map")).exists()).toBe(false);
   });
 
   test("compile with multiple source files", async () => {

--- a/test/bundler/bun-build-compile-sourcemap.test.ts
+++ b/test/bundler/bun-build-compile-sourcemap.test.ts
@@ -234,6 +234,7 @@ export function greet() {
 
     const [_stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
 
     // The executable should be at subdir/myapp

--- a/test/bundler/bun-build-compile-sourcemap.test.ts
+++ b/test/bundler/bun-build-compile-sourcemap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 describe("Bun.build compile with sourcemap", () => {
@@ -207,6 +207,51 @@ export function greet() {
 
     expect(stdout).toContain("hello from lazy module");
     expect(exitCode).toBe(0);
+  });
+
+  test("compile with --outfile subdir/myapp writes .map next to executable", async () => {
+    using dir = tempDir("build-compile-sourcemap-outfile-subdir", helperFiles);
+
+    const subdirPath = join(String(dir), "subdir");
+
+    // Use CLI: bun build --compile --outfile subdir/myapp --sourcemap=external
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "build",
+        "--compile",
+        join(String(dir), "app.js"),
+        "--outfile",
+        join(subdirPath, "myapp"),
+        "--sourcemap=external",
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [_stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("error");
+    expect(exitCode).toBe(0);
+
+    // The executable should be at subdir/myapp
+    expect(await Bun.file(join(subdirPath, "myapp")).exists()).toBe(true);
+
+    // The .map file should be in subdir/ (next to the executable)
+    const glob = new Bun.Glob("*.map");
+    const mapFiles = Array.from(glob.scanSync({ cwd: subdirPath }));
+    expect(mapFiles.length).toBe(1);
+
+    // Validate the sourcemap is valid JSON
+    const mapContent = JSON.parse(await Bun.file(join(subdirPath, mapFiles[0])).text());
+    expect(mapContent.version).toBe(3);
+    expect(mapContent.mappings).toBeString();
+
+    // The doubled path (subdir/subdir/) should NOT exist
+    const doubledSubdir = join(String(dir), "subdir", "subdir");
+    expect(await Bun.file(doubledSubdir).exists()).toBe(false);
   });
 
   test("compile with multiple source files", async () => {

--- a/test/bundler/bun-build-compile-sourcemap.test.ts
+++ b/test/bundler/bun-build-compile-sourcemap.test.ts
@@ -214,6 +214,7 @@ export function greet() {
     using dir = tempDir("build-compile-sourcemap-outfile-subdir", helperFiles);
 
     const subdirPath = join(String(dir), "subdir");
+    const exeSuffix = process.platform === "win32" ? ".exe" : "";
 
     // Use CLI: bun build --compile --outfile subdir/myapp --sourcemap=external
     await using proc = Bun.spawn({
@@ -237,8 +238,8 @@ export function greet() {
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
 
-    // The executable should be at subdir/myapp
-    expect(await Bun.file(join(subdirPath, "myapp")).exists()).toBe(true);
+    // The executable should be at subdir/myapp (with .exe on Windows)
+    expect(await Bun.file(join(subdirPath, `myapp${exeSuffix}`)).exists()).toBe(true);
 
     // The .map file should be in subdir/ (next to the executable)
     const glob = new Bun.Glob("*.map");


### PR DESCRIPTION
## Summary
- When using `bun build --compile --sourcemap=external`, the `.map` files were embedded in the executable but never written to disk. This fix writes them next to the compiled executable.
- With `--splitting` enabled, multiple chunks each produce their own sourcemap. Previously all would overwrite a single `{outfile}.map`; now each `.map` file preserves its chunk-specific name (e.g., `chunk-XXXXX.js.map`).
- Fixes both the JavaScript API (`Bun.build`) and CLI (`bun build`) code paths.

## Test plan
- [x] `bun bd test test/bundler/bun-build-compile-sourcemap.test.ts` — all 8 tests pass
- [x] New test: `compile with sourcemap: external writes .map file to disk` — verifies a single `.map` file is written and contains valid sourcemap JSON
- [x] New test: `compile without sourcemap does not write .map file` — verifies no `.map` file appears without the flag
- [x] New test: `compile with splitting and external sourcemap writes multiple .map files` — verifies each chunk gets its own uniquely-named `.map` file on disk
- [x] Verified new tests fail with `USE_SYSTEM_BUN=1` (confirming they test the fix, not pre-existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)