### PR TITLE
fix(bundler): hoist CJS export clauses out of control flow

### DIFF
--- a/src/ast/P.zig
+++ b/src/ast/P.zig
@@ -233,6 +233,21 @@ pub fn NewParser_(
         had_commonjs_named_exports_this_visit: bool = false,
         commonjs_replacement_stmts: StmtNodeList = &.{},
 
+        /// Tracks nesting depth inside control flow constructs (if/else, while,
+        /// do-while). Used to detect when CJS export assignments like
+        /// `exports.x = value` appear inside control flow, where emitting an
+        /// `export {}` clause inline would produce invalid JavaScript (export
+        /// declarations must be at the top level). The `var` declaration is
+        /// still emitted inline (since var is hoisted), but the export clause
+        /// is deferred to be appended at the part's top level.
+        control_flow_nesting_depth: u32 = 0,
+
+        /// Export clauses deferred from inside control flow. When a CJS export
+        /// assignment is found inside an if/while/do-while body that doesn't
+        /// push a new scope, we can't emit `export { $x as x }` inline. These
+        /// are collected here and appended at the end of `appendPart`.
+        deferred_commonjs_export_stmts: List(Stmt) = .{},
+
         parse_pass_symbol_uses: ParsePassSymbolUsageType = undefined,
 
         /// Used by commonjs_at_runtime
@@ -3610,6 +3625,15 @@ pub fn NewParser_(
                     }
                 }
                 p.relocated_top_level_vars.clearRetainingCapacity();
+            }
+
+            // Append any export clauses that were deferred from inside control
+            // flow (e.g. `if (cond) exports.x = "y"`). The var declarations
+            // were emitted inline (since var is hoisted), but export clauses
+            // must be at the module top level.
+            if (p.deferred_commonjs_export_stmts.items.len > 0) {
+                try partStmts.appendSlice(p.deferred_commonjs_export_stmts.items);
+                p.deferred_commonjs_export_stmts.clearRetainingCapacity();
             }
 
             if (partStmts.items.len > 0) {

--- a/src/ast/visit.zig
+++ b/src/ast/visit.zig
@@ -474,9 +474,11 @@ pub fn Visit(
         pub fn visitLoopBody(noalias p: *P, stmt: StmtNodeIndex) StmtNodeIndex {
             const old_is_inside_loop = p.fn_or_arrow_data_visit.is_inside_loop;
             p.fn_or_arrow_data_visit.is_inside_loop = true;
+            p.control_flow_nesting_depth += 1;
             p.loop_body = stmt.data;
             const res = p.visitSingleStmt(stmt, .loop_body);
             p.fn_or_arrow_data_visit.is_inside_loop = old_is_inside_loop;
+            p.control_flow_nesting_depth -= 1;
             return res;
         }
 

--- a/src/ast/visitStmt.zig
+++ b/src/ast/visitStmt.zig
@@ -874,26 +874,40 @@ pub fn VisitStmt(
                                                 .loc = last.loc_ref.loc,
                                             },
                                         };
-                                        stmts.appendSlice(
-                                            &[_]Stmt{
-                                                p.s(
-                                                    S.Local{
-                                                        .kind = .k_var,
-                                                        .is_export = false,
-                                                        .was_commonjs_export = true,
-                                                        .decls = G.Decl.List.fromOwnedSlice(decls),
-                                                    },
-                                                    stmt.loc,
-                                                ),
-                                                p.s(
-                                                    S.ExportClause{
-                                                        .items = clause_items,
-                                                        .is_single_line = true,
-                                                    },
-                                                    stmt.loc,
-                                                ),
+                                        const export_clause_stmt = p.s(
+                                            S.ExportClause{
+                                                .items = clause_items,
+                                                .is_single_line = true,
                                             },
+                                            stmt.loc,
+                                        );
+
+                                        // Always emit the var declaration inline (var is
+                                        // hoisted in JS so this is valid even inside
+                                        // control flow). But the export clause must be at
+                                        // the module top level — defer it when we're
+                                        // inside control flow (e.g. braceless if/else or
+                                        // while body that doesn't push a new scope).
+                                        stmts.append(
+                                            p.s(
+                                                S.Local{
+                                                    .kind = .k_var,
+                                                    .is_export = false,
+                                                    .was_commonjs_export = true,
+                                                    .decls = G.Decl.List.fromOwnedSlice(decls),
+                                                },
+                                                stmt.loc,
+                                            ),
                                         ) catch unreachable;
+
+                                        if (p.control_flow_nesting_depth > 0) {
+                                            p.deferred_commonjs_export_stmts.append(
+                                                p.allocator,
+                                                export_clause_stmt,
+                                            ) catch unreachable;
+                                        } else {
+                                            stmts.append(export_clause_stmt) catch unreachable;
+                                        }
 
                                         return;
                                     }
@@ -1024,6 +1038,9 @@ pub fn VisitStmt(
                 if (p.options.features.minify_syntax) {
                     data.test_ = SideEffects.simplifyBoolean(p, data.test_);
                 }
+
+                p.control_flow_nesting_depth += 1;
+                defer p.control_flow_nesting_depth -= 1;
 
                 const effects = SideEffects.toBoolean(p, data.test_.data);
                 if (effects.ok and !effects.value) {

--- a/src/ast/visitStmt.zig
+++ b/src/ast/visitStmt.zig
@@ -913,7 +913,22 @@ pub fn VisitStmt(
                                     }
                                 }
                             } else if (p.commonjs_replacement_stmts.len > 0) {
-                                if (stmts.items.len == 0) {
+                                if (p.control_flow_nesting_depth > 0) {
+                                    // Inside control flow, var declarations can be
+                                    // emitted inline (var is hoisted), but export
+                                    // clauses must be deferred to the module top level.
+                                    for (p.commonjs_replacement_stmts) |replacement_stmt| {
+                                        if (replacement_stmt.data == .s_export_clause) {
+                                            p.deferred_commonjs_export_stmts.append(
+                                                p.allocator,
+                                                replacement_stmt,
+                                            ) catch unreachable;
+                                        } else {
+                                            stmts.append(replacement_stmt) catch unreachable;
+                                        }
+                                    }
+                                    p.commonjs_replacement_stmts.len = 0;
+                                } else if (stmts.items.len == 0) {
                                     stmts.items = p.commonjs_replacement_stmts;
                                     stmts.capacity = p.commonjs_replacement_stmts.len;
                                     p.commonjs_replacement_stmts.len = 0;

--- a/test/regression/issue/11032.test.ts
+++ b/test/regression/issue/11032.test.ts
@@ -69,6 +69,7 @@ describe("issue #11032: CJS exports inside control flow", () => {
       proc.stderr.text(),
       proc.exited,
     ]);
+    expect(buildStderr).toBe("");
     expect(buildExitCode).toBe(0);
 
     // Write the bundled output and run it
@@ -113,6 +114,7 @@ describe("issue #11032: CJS exports inside control flow", () => {
       proc.stderr.text(),
       proc.exited,
     ]);
+    expect(buildStderr).toBe("");
     expect(buildExitCode).toBe(0);
 
     expect(buildOutput).not.toContain("tagSymbol");
@@ -161,6 +163,7 @@ describe("issue #11032: CJS exports inside control flow", () => {
       proc.stderr.text(),
       proc.exited,
     ]);
+    expect(buildStderr).toBe("");
     expect(buildExitCode).toBe(0);
 
     expect(buildOutput).not.toContain("tagSymbol");
@@ -207,6 +210,7 @@ describe("issue #11032: CJS exports inside control flow", () => {
       proc.stderr.text(),
       proc.exited,
     ]);
+    expect(buildStderr).toBe("");
     expect(buildExitCode).toBe(0);
 
     expect(buildOutput).not.toContain("tagSymbol");
@@ -253,6 +257,7 @@ describe("issue #11032: CJS exports inside control flow", () => {
       proc.stderr.text(),
       proc.exited,
     ]);
+    expect(buildStderr).toBe("");
     expect(buildExitCode).toBe(0);
 
     expect(buildOutput).not.toContain("tagSymbol");
@@ -299,6 +304,7 @@ describe("issue #11032: CJS exports inside control flow", () => {
       proc.stderr.text(),
       proc.exited,
     ]);
+    expect(buildStderr).toBe("");
     expect(buildExitCode).toBe(0);
 
     using runDir = tempDir("issue-11032-toplevel-exec", {

--- a/test/regression/issue/11032.test.ts
+++ b/test/regression/issue/11032.test.ts
@@ -183,6 +183,98 @@ describe("issue #11032: CJS exports inside control flow", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("module.exports object inside braceless if produces valid output", async () => {
+    using dir = tempDir("issue-11032-modexp-if", {
+      "mod.js": `
+        var condition = true;
+        if (condition) module.exports = { x: "a", y: "b" };
+      `,
+      "entry.js": `
+        import { x, y } from "./mod.js";
+        console.log(x, y);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--target", "bun", path.join(String(dir), "entry.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [buildOutput, buildStderr, buildExitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(buildExitCode).toBe(0);
+
+    expect(buildOutput).not.toContain("tagSymbol");
+    expect(buildOutput).not.toContain("__INVALID__REF__");
+
+    using runDir = tempDir("issue-11032-modexp-if-exec", {
+      "bundle.js": buildOutput,
+    });
+
+    await using run = Bun.spawn({
+      cmd: [bunExe(), path.join(String(runDir), "bundle.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+
+    expect(stdout.trim()).toBe("a b");
+    expect(exitCode).toBe(0);
+  });
+
+  test("module.exports object inside while loop produces valid output", async () => {
+    using dir = tempDir("issue-11032-modexp-while", {
+      "mod.js": `
+        var i = 0;
+        while (i < 1) { module.exports = { x: "loop-obj" }; i++; }
+      `,
+      "entry.js": `
+        import { x } from "./mod.js";
+        console.log(x);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--target", "bun", path.join(String(dir), "entry.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [buildOutput, buildStderr, buildExitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(buildExitCode).toBe(0);
+
+    expect(buildOutput).not.toContain("tagSymbol");
+    expect(buildOutput).not.toContain("__INVALID__REF__");
+
+    using runDir = tempDir("issue-11032-modexp-while-exec", {
+      "bundle.js": buildOutput,
+    });
+
+    await using run = Bun.spawn({
+      cmd: [bunExe(), path.join(String(runDir), "bundle.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+
+    expect(stdout.trim()).toBe("loop-obj");
+    expect(exitCode).toBe(0);
+  });
+
   test("top-level CJS exports still work correctly", async () => {
     using dir = tempDir("issue-11032-toplevel", {
       "mod.js": `

--- a/test/regression/issue/11032.test.ts
+++ b/test/regression/issue/11032.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "path";
+
+// Regression test for https://github.com/oven-sh/bun/issues/11032
+// CJS exports inside control flow (if/else, while) produced invalid JS:
+// - `export {}` clauses nested inside if-bodies (must be top-level)
+// - references to undefined `tagSymbol` sentinel
+describe("issue #11032: CJS exports inside control flow", () => {
+  test("exports inside braceless if/else produces valid output", async () => {
+    using dir = tempDir("issue-11032-if", {
+      "mod.js": `
+        var condition = true;
+        if (condition) exports.x = "yes"; else exports.x = "no";
+      `,
+      "entry.js": `
+        import { x } from "./mod.js";
+        export { x };
+      `,
+    });
+
+    const result = await Bun.build({
+      entrypoints: [path.join(String(dir), "entry.js")],
+      target: "browser",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBeGreaterThan(0);
+
+    const output = await result.outputs[0].text();
+
+    // The output must not contain invalid nested export clauses or sentinel references
+    expect(output).not.toContain("tagSymbol");
+    expect(output).not.toContain("__INVALID__REF__");
+
+    // Verify the export clause is not nested inside an if-statement body.
+    // A valid export clause should appear at the top level, not inside control flow.
+    const lines = output.split("\n");
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("export")) {
+        // Export lines should not be indented (i.e., not nested inside control flow)
+        expect(line).toBe(trimmed);
+      }
+    }
+  });
+
+  test("exports inside braceless if/else runs correctly", async () => {
+    using dir = tempDir("issue-11032-if-run", {
+      "mod.js": `
+        var condition = true;
+        if (condition) exports.x = "yes"; else exports.x = "no";
+      `,
+      "entry.js": `
+        import { x } from "./mod.js";
+        console.log(x);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--target", "bun", path.join(String(dir), "entry.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [buildOutput, buildStderr, buildExitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(buildExitCode).toBe(0);
+
+    // Write the bundled output and run it
+    using runDir = tempDir("issue-11032-if-run-exec", {
+      "bundle.js": buildOutput,
+    });
+
+    await using run = Bun.spawn({
+      cmd: [bunExe(), path.join(String(runDir), "bundle.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+
+    expect(stdout.trim()).toBe("yes");
+    expect(exitCode).toBe(0);
+  });
+
+  test("exports inside while loop produces valid output", async () => {
+    using dir = tempDir("issue-11032-while", {
+      "mod.js": `
+        var i = 0;
+        while (i < 1) { exports.x = "from-loop"; i++; }
+      `,
+      "entry.js": `
+        import { x } from "./mod.js";
+        console.log(x);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--target", "bun", path.join(String(dir), "entry.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [buildOutput, buildStderr, buildExitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(buildExitCode).toBe(0);
+
+    expect(buildOutput).not.toContain("tagSymbol");
+    expect(buildOutput).not.toContain("__INVALID__REF__");
+
+    using runDir = tempDir("issue-11032-while-exec", {
+      "bundle.js": buildOutput,
+    });
+
+    await using run = Bun.spawn({
+      cmd: [bunExe(), path.join(String(runDir), "bundle.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+
+    expect(stdout.trim()).toBe("from-loop");
+    expect(exitCode).toBe(0);
+  });
+
+  test("exports inside braced if block produces valid output", async () => {
+    using dir = tempDir("issue-11032-braced", {
+      "mod.js": `
+        var condition = true;
+        if (condition) {
+          exports.x = "braced";
+        }
+      `,
+      "entry.js": `
+        import { x } from "./mod.js";
+        console.log(x);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--target", "bun", path.join(String(dir), "entry.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [buildOutput, buildStderr, buildExitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(buildExitCode).toBe(0);
+
+    expect(buildOutput).not.toContain("tagSymbol");
+    expect(buildOutput).not.toContain("__INVALID__REF__");
+
+    using runDir = tempDir("issue-11032-braced-exec", {
+      "bundle.js": buildOutput,
+    });
+
+    await using run = Bun.spawn({
+      cmd: [bunExe(), path.join(String(runDir), "bundle.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+
+    expect(stdout.trim()).toBe("braced");
+    expect(exitCode).toBe(0);
+  });
+
+  test("top-level CJS exports still work correctly", async () => {
+    using dir = tempDir("issue-11032-toplevel", {
+      "mod.js": `
+        exports.x = "top-level";
+        exports.y = 42;
+      `,
+      "entry.js": `
+        import { x, y } from "./mod.js";
+        console.log(x, y);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--target", "bun", path.join(String(dir), "entry.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [buildOutput, buildStderr, buildExitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(buildExitCode).toBe(0);
+
+    using runDir = tempDir("issue-11032-toplevel-exec", {
+      "bundle.js": buildOutput,
+    });
+
+    await using run = Bun.spawn({
+      cmd: [bunExe(), path.join(String(runDir), "bundle.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+
+    expect(stdout.trim()).toBe("top-level 42");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- When CJS exports (`exports.x = value`) appear inside control flow (braceless if/else, while, do-while), the bundler was emitting `export { $x as x }` inline inside the if-body — producing invalid JS since export declarations must be at the top level. This also caused `__INVALID__REF__` sentinel references in the output.
- Instead of deoptimizing to the full CJS wrapper (losing static ESM analysis benefits), this fix hoists the export clause to the module's top level while keeping the `var` declaration inline (since `var` is hoisted in JavaScript).
- Tracks control flow nesting depth in the parser and defers export clauses when inside control flow, appending them at the part level in `appendPart`.

Closes #11032
Supersedes #27255 (which took the deoptimization approach)

## Test plan

- [x] New regression tests in `test/regression/issue/11032.test.ts` covering:
  - CJS exports inside braceless if/else produces valid output (no `__INVALID__REF__`, no nested exports)
  - CJS exports inside braceless if/else runs correctly (outputs `"yes"`)
  - CJS exports inside while loop produces valid output and runs correctly
  - CJS exports inside braced if block produces valid output and runs correctly
  - Top-level CJS exports still work correctly (regression check)
- [x] Tests fail with `USE_SYSTEM_BUN=1` (confirming bug exists in current release)
- [x] Tests pass with `bun bd test` (confirming fix works)
- [x] Existing bundler CJS-to-ESM tests pass (`test/bundler/bundler_cjs2esm.test.ts` — 16/16)
- [x] Existing bundler CJS tests pass (`test/bundler/bundler_cjs.test.ts` — 23/23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)