### PR TITLE
fix(http): prevent duplicate Transfer-Encoding header in node:http

### DIFF
--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -467,7 +467,9 @@ public:
             /* Write mark on first call to write */
             writeMark();
 
-            writeHeader("Transfer-Encoding", "chunked");
+            if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER)) {
+                writeHeader("Transfer-Encoding", "chunked");
+            }
             Super::write("\r\n", 2);
             httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
         }
@@ -489,7 +491,9 @@ public:
                 /* Write mark on first call to write */
                 writeMark();
 
-                writeHeader("Transfer-Encoding", "chunked");
+                if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER)) {
+                    writeHeader("Transfer-Encoding", "chunked");
+                }
                 Super::write("\r\n", 2);
                 httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
             }
@@ -558,7 +562,9 @@ public:
                 /* Write mark on first call to write */
                 writeMark();
 
-                writeHeader("Transfer-Encoding", "chunked");
+                if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER)) {
+                    writeHeader("Transfer-Encoding", "chunked");
+                }
                 Super::write("\r\n", 2);
                 httpResponseData->state |= HttpResponseData<SSL>::HTTP_WRITE_CALLED;
             }

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -87,6 +87,7 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
         HTTP_CONNECTION_CLOSE = 16, // used
         HTTP_WROTE_CONTENT_LENGTH_HEADER = 32, // used
         HTTP_WROTE_DATE_HEADER = 64, // used
+        HTTP_WROTE_TRANSFER_ENCODING_HEADER = 128, // used
     };
 
     /* Shared context pointer */

--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -570,6 +570,11 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
         if (header.key == WebCore::HTTPHeaderName::Date) {
             data->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_DATE_HEADER;
         }
+
+        // Prevent automatic Transfer-Encoding: chunked insertion when user provides one
+        if (header.key == WebCore::HTTPHeaderName::TransferEncoding) {
+            data->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER;
+        }
         writeResponseHeader<isSSL>(res, name, value);
     }
 
@@ -642,6 +647,7 @@ static void NodeHTTPServer__writeHead(
                 String key = propertyNames[i].string();
                 String value = headerValue.toWTFString(globalObject);
                 RETURN_IF_EXCEPTION(scope, void());
+
                 writeResponseHeader<isSSL>(response, key, value);
             }
         }


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/oven-sh/bun/issues/21201. Ran into this today during a migration from node->bun. TLDR if you set `Transfer-Encoding: chunked` via `res.writeHead()`, Bun sends the header twice because two layers independently add it:

1. `writeFetchHeadersToUWSResponse` (NodeHTTP.cpp) writes the user's headers to the response buffer
2. uWS's `HttpResponse::write()` auto-inserts `Transfer-Encoding: chunked` since no flag indicates it was already set

Added a `HTTP_WROTE_TRANSFER_ENCODING_HEADER` flag copying the pattern for `Content-Length` and `Date` deduping, checked before auto-insertion in `write()`, `flushHeaders()`, and `sendTerminatingChunk()`.

### How did you verify your code works?

Minimal repro:

```
import http from "node:http";
import net from "node:net";

http.createServer((_, res) => {
  res.writeHead(200, { "Transfer-Encoding": "chunked" });
  res.write("ok");
}).listen(0, "127.0.0.1", function () {
  const s = net.createConnection(this.address().port, "127.0.0.1", () =>
    s.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n"));
  s.on("data", (d) => {
    console.log(d.toString().split("\r\n\r\n")[0]);
    s.destroy(); this.close();
  });
});
```

Node working (showing header once)

```
$ node --version
v22.21.1

$ node /Users/mamps/code/labs/conway/tmp/bun-duplicate-te.mjs
HTTP/1.1 200 OK
Transfer-Encoding: chunked
Date: Tue, 24 Feb 2026 06:14:50 GMT
Connection: keep-alive
Keep-Alive: timeout=5
```

Bun bug (duplicate header):
```
$ bun --version
1.3.9

$ bun bun-duplicate-te.mjs
HTTP/1.1 200 OK
Transfer-Encoding: chunked
Date: Tue, 24 Feb 2026 06:13:55 GMT
Transfer-Encoding: chunked
```

Bun fixed:
```
$ ./build/debug/bun-debug --version
1.3.10-debug

$ BUN_DEBUG_QUIET_LOGS=1 ./build/debug/bun-debug /tmp/bun-duplicate-te.mjs
HTTP/1.1 200 OK
Transfer-Encoding: chunked
Date: Tue, 24 Feb 2026 06:15:53 GMT
```
