### PR TITLE
fix(windows): move -ExecutionPolicy Bypass before -c in uninstall command

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -344,7 +344,7 @@ To remove Bun from your system:
 
     <Tab title="Windows">
     	```powershell PowerShell icon="windows"
-    powershell -c ~\.bun\uninstall.ps1
+    powershell -ExecutionPolicy Bypass -c ~\.bun\uninstall.ps1
     ```
     </Tab>
 

--- a/src/cli/install.ps1
+++ b/src/cli/install.ps1
@@ -287,7 +287,7 @@ function Install-Bun {
       New-ItemProperty -Path $RegistryKey -Name "DisplayName" -Value "Bun" -PropertyType String -Force | Out-Null
       New-ItemProperty -Path $RegistryKey -Name "InstallLocation" -Value "${BunRoot}" -PropertyType String -Force | Out-Null
       New-ItemProperty -Path $RegistryKey -Name "DisplayIcon" -Value $BunBin\bun.exe -PropertyType String -Force | Out-Null
-      New-ItemProperty -Path $RegistryKey -Name "UninstallString" -Value "powershell -c `"& `'$BunRoot\uninstall.ps1`' -PauseOnError`" -ExecutionPolicy Bypass" -PropertyType String -Force | Out-Null
+      New-ItemProperty -Path $RegistryKey -Name "UninstallString" -Value "powershell -ExecutionPolicy Bypass -c `"& `'$BunRoot\uninstall.ps1`' -PauseOnError`"" -PropertyType String -Force | Out-Null
     } catch {
       if ($rootKey -ne $null) {
         Remove-Item -Path $RegistryKey -Force


### PR DESCRIPTION
## Summary
- Fixes the position of `-ExecutionPolicy Bypass` in the Windows registry `UninstallString` so it comes **before** `-c`, where PowerShell actually recognizes it as an option
- Adds `-ExecutionPolicy Bypass` to the documented Windows uninstall command in `docs/installation.mdx`

## Problem
PowerShell requires options like `-ExecutionPolicy Bypass` to appear **before** the `-c` (command) argument. The registry entry had it placed **after** the command text:

```
powershell -c "& 'path\uninstall.ps1' -PauseOnError" -ExecutionPolicy Bypass
```

This caused uninstall to fail with `PSSecurityException` / `UnauthorizedAccess` on Windows systems with `Restricted` or `AllSigned` execution policies — which is common on fresh Windows installations.

## Fix
Moved the flag to the correct position:

```
powershell -ExecutionPolicy Bypass -c "& 'path\uninstall.ps1' -PauseOnError"
```

This matches the pattern already used elsewhere in the codebase (`src/crash_handler.zig`, `BinLinkingShim.zig`, `BuildBun.cmake`).

## Test plan
- [ ] Verify on a Windows machine with `Restricted` execution policy that uninstalling via "Add or Remove Programs" works
- [ ] Verify `powershell -ExecutionPolicy Bypass -c ~\.bun\uninstall.ps1` works from the command line

Closes #27399

🤖 Generated with [Claude Code](https://claude.com/claude-code)