### PR TITLE
fix(run): resolve preload config context

### DIFF
--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -133,19 +133,30 @@ pub const Bunfig = struct {
                 errdefer preloads.deinit();
                 while (array.next()) |item| {
                     try this.expectString(item);
-                    if (item.data.e_string.len() > 0)
-                        preloads.appendAssumeCapacity(try item.data.e_string.string(allocator));
+                    if (item.data.e_string.len() > 0) {
+                        const specifier = try item.data.e_string.string(allocator);
+                        preloads.appendAssumeCapacity(try this.resolvePreloadSpecifier(allocator, specifier));
+                    }
                 }
                 this.ctx.preloads = preloads.items;
             } else if (expr.data == .e_string) {
                 if (expr.data.e_string.len() > 0) {
                     var preloads = try allocator.alloc(string, 1);
-                    preloads[0] = try expr.data.e_string.string(allocator);
+                    preloads[0] = try this.resolvePreloadSpecifier(allocator, try expr.data.e_string.string(allocator));
                     this.ctx.preloads = preloads;
                 }
             } else if (expr.data != .e_null) {
                 try this.addError(expr.loc, "Expected preload to be an array");
             }
+        }
+
+        fn resolvePreloadSpecifier(this: *Parser, allocator: std.mem.Allocator, specifier: string) !string {
+            if (std.fs.path.isAbsolute(specifier) or resolver.isPackagePath(specifier)) {
+                return specifier;
+            }
+
+            const source_dir = std.fs.path.dirname(this.source.path.text) orelse return specifier;
+            return try allocator.dupe(u8, resolve_path.joinAbsString(source_dir, &[_]string{specifier}, .auto));
         }
 
         fn loadEnvConfig(this: *Parser, expr: js_ast.Expr) !void {
@@ -1251,6 +1262,7 @@ const string = []const u8;
 
 const options = @import("./options.zig");
 const resolver = @import("./resolver/resolver.zig");
+const resolve_path = @import("./resolver/resolve_path.zig");
 const std = @import("std");
 const Command = @import("./cli.zig").Command;
 const PackageJSON = @import("./resolver/package_json.zig").PackageJSON;

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -339,13 +339,17 @@ pub fn loadConfig(allocator: std.mem.Allocator, user_config_path_: ?string, ctx:
     var config_path_: []const u8 = user_config_path_ orelse "";
 
     var auto_loaded: bool = false;
+    const first_positional = if (ctx.positionals.len > 0) ctx.positionals[0] else "";
+    const first_positional_is_absolute = first_positional.len > 0 and std.fs.path.isAbsolute(first_positional);
     if (config_path_.len == 0 and (user_config_path_ != null or
         Command.Tag.always_loads_config.get(cmd) or
         (cmd == .AutoCommand and
             // "bun"
             (ctx.positionals.len == 0 or
                 // "bun file.js"
-                ctx.positionals.len > 0 and options.defaultLoaders.has(std.fs.path.extension(ctx.positionals[0]))))))
+                ctx.positionals.len > 0 and
+                    options.defaultLoaders.has(std.fs.path.extension(first_positional)) and
+                    !first_positional_is_absolute))))
     {
         config_path_ = "bunfig.toml";
         auto_loaded = true;

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1364,7 +1364,24 @@ pub const RunCommand = struct {
         }
 
         if (!ctx.debug.loaded_bunfig) {
-            bun.cli.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", ctx, .RunCommand) catch {};
+            if (std.fs.path.isAbsolute(target_name)) {
+                const loader = options.defaultLoaders.get(std.fs.path.extension(target_name));
+                if (loader != null and loader.?.canBeRunByBun()) {
+                    var config_path_buf: bun.PathBuffer = undefined;
+                    const entry_dir = std.fs.path.dirname(target_name) orelse target_name;
+                    const entry_config_path = resolve_path.joinAbsStringBufZ(
+                        entry_dir,
+                        &config_path_buf,
+                        &[_]string{"bunfig.toml"},
+                        .auto,
+                    );
+                    bun.cli.Arguments.loadConfigPath(ctx.allocator, true, entry_config_path, ctx, .RunCommand) catch {};
+                } else {
+                    bun.cli.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", ctx, .RunCommand) catch {};
+                }
+            } else {
+                bun.cli.Arguments.loadConfigPath(ctx.allocator, true, "bunfig.toml", ctx, .RunCommand) catch {};
+            }
         }
 
         // try fast run (check if the file exists and is not a folder, then run it)

--- a/test/cli/run/preload-test.test.js
+++ b/test/cli/run/preload-test.test.js
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
 import { mkdirSync, realpathSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import { tmpdir } from "os";
 import { join } from "path";
 const preloadModule = `
@@ -209,5 +209,75 @@ plugin({
       expect(stdout.toString()).toBe("");
       expect(exitCode).toBe(1);
     }
+  });
+
+  test("does not apply cwd bunfig preload when running absolute entrypoint", () => {
+    const root = tempDirWithFiles("bun-preload-cross-repo", {
+      "repo-a": {
+        "bunfig.toml": `preload = ["./src/config/opentelemetry.ts"]`,
+        src: {
+          config: {
+            "opentelemetry.ts": `throw new Error("PRELOAD_FROM_A");`,
+          },
+        },
+      },
+      "repo-b": {
+        "index.ts": `console.log("ENTRY_FROM_B");`,
+      },
+    });
+
+    const repoA = join(root, "repo-a");
+    const entryInRepoB = join(root, "repo-b", "index.ts");
+    const { stdout, stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), entryInRepoB, "help"],
+      cwd: repoA,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(stdout.toString()).toContain("ENTRY_FROM_B");
+    expect(stderr.toString()).not.toContain("PRELOAD_FROM_A");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--config resolves relative preload from config directory", () => {
+    const root = tempDirWithFiles("bun-preload-config-base", {
+      "repo-a": {
+        "bunfig.toml": `preload = ["./src/config/opentelemetry.ts"]`,
+        src: {
+          config: {
+            "opentelemetry.ts": `throw new Error("PRELOAD_FROM_A");`,
+          },
+        },
+      },
+      "repo-b": {
+        "bunfig.toml": `preload = ["./src/config/opentelemetry.ts"]`,
+        src: {
+          config: {
+            "opentelemetry.ts": `console.log("PRELOAD_FROM_B");`,
+          },
+        },
+        "index.ts": `console.log("ENTRY_FROM_B");`,
+      },
+    });
+
+    const repoA = join(root, "repo-a");
+    const repoB = join(root, "repo-b");
+    const configInRepoB = join(repoB, "bunfig.toml");
+    const entryInRepoB = join(repoB, "index.ts");
+
+    const { stdout, stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), "--config", configInRepoB, entryInRepoB, "help"],
+      cwd: repoA,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(stdout.toString()).toContain("PRELOAD_FROM_B");
+    expect(stdout.toString()).toContain("ENTRY_FROM_B");
+    expect(stderr.toString()).not.toContain("PRELOAD_FROM_A");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- avoid auto-loading cwd bunfig for `bun /absolute/path/to/file` so cross-repo entrypoints do not inherit unrelated preload side-effects
- in run command fallback config loading, resolve auto bunfig from the absolute entrypoint directory when running a runnable absolute file
- resolve relative `preload` entries from the bunfig file directory, which makes `--config` behavior consistent
- add regression coverage in `test/cli/run/preload-test.test.js` for cross-repo absolute entrypoints and `--config` preload base directory

## Repro
- from repo A with `bunfig.toml` preload, run `bun /abs/path/to/repo-b/index.ts help`
- before: preload from repo A executes and can fail unrelated runs
- after: repo A preload is not applied to repo B absolute entrypoint

## Testing
- `USE_SYSTEM_BUN=1 bun test test/cli/run/preload-test.test.js` (fails on new regression tests, reproduces bug)
- `bun bd test test/cli/run/preload-test.test.js` (blocked in this environment: CMake cannot find Ninja)
