### PR TITLE
fix: proper 3-step teardown in HTTPContext.deinit()

### DIFF
--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -79,7 +79,12 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
         }
 
         pub fn deinit(this: *@This()) void {
-            this.us_socket_context.deinit(ssl);
+            // Replace callbacks with no-ops first to avoid UAF when closing sockets.
+            this.us_socket_context.cleanCallbacks(ssl);
+            // Close any remaining sockets in the context.
+            this.us_socket_context.close(ssl);
+            // Free the uSockets context synchronously.
+            this.us_socket_context.free(ssl);
             bun.default_allocator.destroy(this);
         }
 

--- a/test/js/bun/http/tls-deinit-fixture.js
+++ b/test/js/bun/http/tls-deinit-fixture.js
@@ -1,0 +1,36 @@
+// Fixture for testing HTTPContext.deinit() with live keepalive sockets.
+// When the process exits, HTTPContext is torn down. If sockets are still in
+// the keepalive pool, the old single-call deinit() could fire callbacks on
+// partially-freed memory (UAF). The 3-step fix (cleanCallbacks → close → free)
+// prevents this. If the bug is present, this will crash/segfault.
+
+const cert = process.env.TLS_CERT;
+const key = process.env.TLS_KEY;
+
+if (!cert || !key) {
+  throw new Error("TLS_CERT and TLS_KEY env vars required");
+}
+
+using server = Bun.serve({
+  port: 0,
+  tls: { cert, key },
+  hostname: "127.0.0.1",
+  fetch() {
+    return new Response("ok");
+  },
+});
+
+const url = `https://127.0.0.1:${server.port}`;
+
+// Make requests with keepalive enabled so sockets stay pooled after completion.
+for (let i = 0; i < 10; i++) {
+  const res = await fetch(url, {
+    tls: { rejectUnauthorized: false },
+    keepalive: true,
+  });
+  await res.text();
+}
+
+// Exit immediately while keepalive sockets are still pooled.
+// This triggers HTTPContext.deinit() with live sockets.
+console.log("OK");

--- a/test/js/bun/http/tls-deinit.test.ts
+++ b/test/js/bun/http/tls-deinit.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tls as validTls } from "harness";
+import { join } from "node:path";
+
+describe("HTTPContext.deinit with live keepalive sockets", () => {
+  test("process exits cleanly when keepalive sockets are pooled", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "tls-deinit-fixture.js")],
+      env: {
+        ...bunEnv,
+        TLS_CERT: validTls.cert,
+        TLS_KEY: validTls.key,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim()).toBe("OK");
+    if (exitCode !== 0) {
+      console.error(stderr);
+    }
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Replace single `us_socket_context.deinit()` call with proper 3-step teardown:

1. `cleanCallbacks()` — replace callbacks with no-ops to avoid UAF
2. `close()` — close remaining sockets
3. `free()` — free the uSockets context

Split from #27385.