### PR TITLE
fix(fetch): guard enqueueTaskConcurrent against VM shutdown race

### DIFF
--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -78,6 +78,11 @@ pub const FetchTasklet = struct {
         bun.debugAssert(count > 0);
 
         if (count == 1) {
+            if (this.javascript_vm.isShuttingDown()) {
+                this.deinit() catch |err| switch (err) {};
+                return;
+            }
+
             // this is really unlikely to happen, but can happen
             // lets make sure that we always call deinit from main thread
 
@@ -1155,6 +1160,8 @@ pub const FetchTasklet = struct {
 
     /// This is ALWAYS called from the http thread and we cannot touch the buffer here because is locked
     pub fn onWriteRequestDataDrain(this: *FetchTasklet) void {
+        if (this.javascript_vm.isShuttingDown()) return;
+
         // ref until the main thread callback is called
         this.ref();
         this.javascript_vm.eventLoop().enqueueTaskConcurrent(jsc.ConcurrentTask.fromCallback(this, FetchTasklet.resumeRequestDataStream));
@@ -1383,6 +1390,8 @@ pub const FetchTasklet = struct {
                 return;
             }
         }
+        // will deinit when done with the http client (when is_done = true)
+        if (task.javascript_vm.isShuttingDown()) return;
 
         task.javascript_vm.eventLoop().enqueueTaskConcurrent(task.concurrent_task.from(task, .manual_deinit));
     }


### PR DESCRIPTION
Add `isShuttingDown()` checks in FetchTasklet before calling `enqueueTaskConcurrent` to prevent use-after-free when the VM is tearing down.

Guards added at 3 sites:
1. `derefFromThread()` — when refcount reaches 1
2. `onWriteRequestDataDrain()` — before ref + enqueue
3. Completion callback — before final enqueue

Split from #27385.