### PR TITLE
fix(http): refcount SSLConfig + TLS keepalive for custom configs (mTLS)

### DIFF
--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -275,8 +275,7 @@ fn fetchImpl(
 
         if (ssl_config) |conf| {
             ssl_config = null;
-            conf.deinit();
-            bun.default_allocator.destroy(conf);
+            conf.deref();
         }
     }
 
@@ -468,7 +467,8 @@ fn fetchImpl(
                         }) |config| {
                             const ssl_config_object = bun.handleOom(bun.default_allocator.create(SSLConfig));
                             ssl_config_object.* = config;
-                            break :extract_ssl_config ssl_config_object;
+                            // Intern via GlobalRegistry for deduplication and pointer equality
+                            break :extract_ssl_config SSLConfig.GlobalRegistry.intern(ssl_config_object);
                         }
                     }
                 }

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -8,6 +8,11 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             port: u16 = 0,
             /// If you set `rejectUnauthorized` to `false`, the connection fails to verify,
             did_have_handshaking_error_while_reject_unauthorized_is_false: bool = false,
+            /// The interned SSLConfig this socket was created with (null = default context).
+            /// Holds a ref while the socket is in the keepalive pool.
+            ssl_config: ?*SSLConfig = null,
+            /// The context that owns this pooled socket's memory (for returning to correct pool).
+            owner: *Context,
         };
 
         pub fn markTaggedSocketAsDead(socket: HTTPSocket, tagged: ActiveSocket) void {
@@ -79,7 +84,30 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
         }
 
         pub fn deinit(this: *@This()) void {
-            this.us_socket_context.deinit(ssl);
+            // Replace callbacks with no-ops first to avoid UAF when closing sockets.
+            this.us_socket_context.cleanCallbacks(ssl);
+
+            // Drain pooled keepalive sockets: deref their ssl_config and force-close.
+            // Must force-close (code != 0) because SSL clean shutdown (code=0) requires a
+            // shutdown handshake with the peer, which won't complete during eviction.
+            // Without force-close, the socket stays linked and the context refcount never
+            // reaches 0, leaking the SSL_CTX.
+            if (comptime ssl) {
+                var iter = this.pending_sockets.used.iterator(.{ .kind = .set });
+                while (iter.next()) |idx| {
+                    const pooled = this.pending_sockets.at(@intCast(idx));
+                    if (pooled.ssl_config) |config| {
+                        config.deref();
+                        pooled.ssl_config = null;
+                    }
+                    pooled.http_socket.close(.failure);
+                }
+            }
+
+            // Close any remaining sockets in the context (should be none after draining pool).
+            this.us_socket_context.close(ssl);
+            // Free the uSockets context synchronously.
+            this.us_socket_context.free(ssl);
             bun.default_allocator.destroy(this);
         }
 
@@ -161,7 +189,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
         /// If `did_have_handshaking_error_while_reject_unauthorized_is_false`
         /// is set, then we can only reuse the socket for HTTP Keep Alive if
         /// `reject_unauthorized` is set to `false`.
-        pub fn releaseSocket(this: *@This(), socket: HTTPSocket, did_have_handshaking_error_while_reject_unauthorized_is_false: bool, hostname: []const u8, port: u16) void {
+        pub fn releaseSocket(this: *@This(), socket: HTTPSocket, did_have_handshaking_error_while_reject_unauthorized_is_false: bool, hostname: []const u8, port: u16, ssl_config: ?*SSLConfig) void {
             // log("releaseSocket(0x{f})", .{bun.fmt.hexIntUpper(@intFromPtr(socket.socket))});
 
             if (comptime Environment.allow_assert) {
@@ -186,6 +214,12 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     @memcpy(pending.hostname_buf[0..hostname.len], hostname);
                     pending.hostname_len = @as(u8, @truncate(hostname.len));
                     pending.port = port;
+                    pending.owner = this;
+                    // Hold a ref on ssl_config while it's in the keepalive pool
+                    pending.ssl_config = ssl_config;
+                    if (ssl_config) |config| {
+                        config.ref();
+                    }
 
                     log("Keep-Alive release {s}:{d}", .{
                         hostname,
@@ -299,7 +333,12 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             }
 
             fn addMemoryBackToPool(pooled: *PooledSocket) void {
-                assert(context().pending_sockets.put(pooled));
+                // Release the ssl_config ref held by this pooled socket
+                if (pooled.ssl_config) |config| {
+                    config.deref();
+                    pooled.ssl_config = null;
+                }
+                assert(pooled.owner.pending_sockets.put(pooled));
             }
 
             pub fn onData(
@@ -312,7 +351,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     return client.onData(
                         comptime ssl,
                         buf,
-                        if (comptime ssl) &bun.http.http_thread.https_context else &bun.http.http_thread.http_context,
+                        client.getSslCtx(ssl),
                         socket,
                     );
                 } else if (tagged.is(PooledSocket)) {
@@ -392,7 +431,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             }
         };
 
-        fn existingSocket(this: *@This(), reject_unauthorized: bool, hostname: []const u8, port: u16) ?HTTPSocket {
+        fn existingSocket(this: *@This(), reject_unauthorized: bool, hostname: []const u8, port: u16, ssl_config: ?*SSLConfig) ?HTTPSocket {
             if (hostname.len > MAX_KEEPALIVE_HOSTNAME)
                 return null;
 
@@ -401,6 +440,11 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             while (iter.next()) |pending_socket_index| {
                 var socket = this.pending_sockets.at(@as(u16, @intCast(pending_socket_index)));
                 if (socket.port != port) {
+                    continue;
+                }
+
+                // Match ssl_config by pointer equality (interned configs)
+                if (socket.ssl_config != ssl_config) {
                     continue;
                 }
 
@@ -421,7 +465,12 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                         continue;
                     }
 
-                    assert(context().pending_sockets.put(socket));
+                    // Release the pooled socket's ssl_config ref (caller has its own ref)
+                    if (socket.ssl_config) |config| {
+                        config.deref();
+                        socket.ssl_config = null;
+                    }
+                    assert(this.pending_sockets.put(socket));
                     log("+ Keep-Alive reuse {s}:{d}", .{ hostname, port });
                     return http_socket;
                 }
@@ -452,7 +501,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             client.connected_url.hostname = hostname;
 
             if (client.isKeepAlivePossible()) {
-                if (this.existingSocket(client.flags.reject_unauthorized, hostname, port)) |sock| {
+                if (this.existingSocket(client.flags.reject_unauthorized, hostname, port, client.tls_props)) |sock| {
                     if (sock.ext(**anyopaque)) |ctx| {
                         ctx.* = bun.cast(**anyopaque, ActiveSocket.init(client).ptr());
                     }
@@ -499,6 +548,7 @@ const assert = bun.assert;
 const strings = bun.strings;
 const uws = bun.uws;
 const BoringSSL = bun.BoringSSL.c;
+const SSLConfig = bun.api.server.ServerConfig.SSLConfig;
 
 const HTTPClient = bun.http;
 const InitError = HTTPClient.InitError;

--- a/test/js/bun/http/tls-keepalive-leak-fixture.js
+++ b/test/js/bun/http/tls-keepalive-leak-fixture.js
@@ -1,0 +1,74 @@
+// Fixture for TLS keepalive memory leak detection.
+// Spawned as a subprocess with --smol for clean memory measurement.
+//
+// Usage: bun --smol tls-keepalive-leak-fixture.js
+// Env: TLS_CERT, TLS_KEY - PEM cert/key for the server
+//      NUM_REQUESTS - number of requests to make (default 50000)
+//      MODE - "same" (same TLS config) or "distinct" (unique configs)
+
+const cert = process.env.TLS_CERT;
+const key = process.env.TLS_KEY;
+const numRequests = parseInt(process.env.NUM_REQUESTS || "50000", 10);
+const mode = process.env.MODE || "same";
+
+if (!cert || !key) {
+  throw new Error("TLS_CERT and TLS_KEY env vars required");
+}
+
+using server = Bun.serve({
+  port: 0,
+  tls: { cert, key },
+  hostname: "127.0.0.1",
+  fetch() {
+    return new Response("ok");
+  },
+});
+
+const url = `https://127.0.0.1:${server.port}`;
+
+// Warmup
+for (let i = 0; i < 20_000; i++) {
+  await fetch(url, {
+    tls: { ca: cert, rejectUnauthorized: false },
+    keepalive: true,
+  });
+}
+Bun.gc(true);
+const baselineRss = process.memoryUsage.rss();
+
+const requests = [];
+if (mode === "same") {
+  // All requests use the same TLS config — tests SSLConfig dedup
+  const tlsOpts = { ca: cert, rejectUnauthorized: false };
+
+  for (let i = 0; i < numRequests; i++) {
+    await fetch(url, { tls: tlsOpts, keepalive: true });
+  }
+} else if (mode === "distinct") {
+  // Each request uses a unique TLS config — tests cache eviction
+  for (let i = 0; i < numRequests; i++) {
+    await fetch(url, {
+      tls: { ca: cert, rejectUnauthorized: false, serverName: `host-${i}.example.com` },
+      keepalive: true,
+    });
+  }
+}
+
+// Allow the HTTP thread to process deferred SSL context frees
+await Bun.sleep(100);
+Bun.gc(true);
+await Bun.sleep(100);
+Bun.gc(true);
+const finalRss = process.memoryUsage.rss();
+const growthMB = (finalRss - baselineRss) / (1024 * 1024);
+
+// Output as JSON for the parent test to parse
+console.log(
+  JSON.stringify({
+    baselineRss,
+    finalRss,
+    growthMB: Math.round(growthMB * 100) / 100,
+    numRequests,
+    mode,
+  }),
+);

--- a/test/js/bun/http/tls-keepalive.test.ts
+++ b/test/js/bun/http/tls-keepalive.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, tls as validTls, isASAN } from "harness";
+import { bunEnv, bunExe, isASAN, tls as validTls } from "harness";
 import { join } from "node:path";
 
 setDefaultTimeout(30_000);

--- a/test/js/bun/http/tls-keepalive.test.ts
+++ b/test/js/bun/http/tls-keepalive.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, tls as validTls, isASAN } from "harness";
+import { join } from "node:path";
+
+setDefaultTimeout(30_000);
+
+describe("TLS keepalive for custom SSL configs", () => {
+  test("keepalive reuses connections with same TLS config", async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls: validTls,
+      hostname: "127.0.0.1",
+      fetch(req, server) {
+        const ip = server.requestIP(req);
+        return new Response(String(ip?.port ?? 0));
+      },
+    });
+
+    const url = `https://127.0.0.1:${server.port}`;
+    const tlsOpts = { ca: validTls.cert, rejectUnauthorized: false };
+
+    // Make sequential requests with keepalive enabled.
+    // With our fix: connections reuse → same client port.
+    // Without fix: disable_keepalive=true → new connection each time → different ports.
+    const ports: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const res = await fetch(url, { tls: tlsOpts, keepalive: true });
+      ports.push(parseInt(await res.text(), 10));
+    }
+
+    const uniquePorts = new Set(ports);
+    // Keepalive working: at most 2 unique ports (allowing one reconnect)
+    expect(uniquePorts.size).toBeLessThanOrEqual(2);
+  });
+
+  test("different TLS configs use separate connections", async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls: validTls,
+      hostname: "127.0.0.1",
+      fetch(req, server) {
+        const ip = server.requestIP(req);
+        return new Response(String(ip?.port ?? 0));
+      },
+    });
+
+    const url = `https://127.0.0.1:${server.port}`;
+
+    // Two configs that differ (serverName makes them different SSLConfigs)
+    const tlsA = { ca: validTls.cert, rejectUnauthorized: false };
+    const tlsB = { ca: validTls.cert, rejectUnauthorized: false, serverName: "127.0.0.1" };
+
+    const resA = await fetch(url, { tls: tlsA, keepalive: true });
+    const portA = parseInt(await resA.text(), 10);
+
+    const resB = await fetch(url, { tls: tlsB, keepalive: true });
+    const portB = parseInt(await resB.text(), 10);
+
+    // Different SSL configs must not share keepalive connections
+    expect(portA).not.toBe(portB);
+  });
+
+  test("stress test - many sequential requests reuse connections", async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls: validTls,
+      hostname: "127.0.0.1",
+      fetch(req, server) {
+        const ip = server.requestIP(req);
+        return new Response(String(ip?.port ?? 0));
+      },
+    });
+
+    const url = `https://127.0.0.1:${server.port}`;
+    const tlsOpts = { ca: validTls.cert, rejectUnauthorized: false };
+
+    const ports: number[] = [];
+    for (let i = 0; i < 50; i++) {
+      const res = await fetch(url, { tls: tlsOpts, keepalive: true });
+      ports.push(parseInt(await res.text(), 10));
+    }
+
+    const uniquePorts = new Set(ports);
+    // 50 requests through keepalive should use very few connections
+    expect(uniquePorts.size).toBeLessThanOrEqual(3);
+  });
+
+  test("keepalive disabled creates new connections each time", async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls: validTls,
+      hostname: "127.0.0.1",
+      fetch(req, server) {
+        const ip = server.requestIP(req);
+        return new Response(String(ip?.port ?? 0));
+      },
+    });
+
+    const url = `https://127.0.0.1:${server.port}`;
+    const tlsOpts = { ca: validTls.cert, rejectUnauthorized: false };
+
+    // With keepalive explicitly disabled, each request should open a new connection
+    const ports: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      const res = await fetch(url, { tls: tlsOpts, keepalive: false });
+      ports.push(parseInt(await res.text(), 10));
+    }
+
+    const uniquePorts = new Set(ports);
+    // Every request should use a different connection → different port
+    expect(uniquePorts.size).toBe(5);
+  });
+});
+
+describe.skipIf(isASAN)("TLS custom config memory leak detection", () => {
+  test("repeated fetches with same custom TLS config do not leak memory", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", join(import.meta.dir, "tls-keepalive-leak-fixture.js")],
+      env: {
+        ...bunEnv,
+        TLS_CERT: validTls.cert,
+        TLS_KEY: validTls.key,
+        NUM_REQUESTS: "100000",
+        MODE: "same",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    if (exitCode !== 0) {
+      console.error(stderr);
+    }
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout.trim());
+    console.log(`Same config: ${result.numRequests} requests, growth: ${result.growthMB} MB`);
+
+    expect(result.growthMB).toBeLessThan(10);
+  });
+
+  test("many distinct TLS configs stay bounded by cache eviction", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", join(import.meta.dir, "tls-keepalive-leak-fixture.js")],
+      env: {
+        ...bunEnv,
+        TLS_CERT: validTls.cert,
+        TLS_KEY: validTls.key,
+        NUM_REQUESTS: "200",
+        MODE: "distinct",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    if (exitCode !== 0) {
+      console.error(stderr);
+    }
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout.trim());
+    console.log(`Distinct configs: ${result.numRequests} configs, growth: ${result.growthMB} MB`);
+
+    expect(result.growthMB).toBeLessThan(75);
+  });
+});

--- a/test/regression/issue/27358.test.ts
+++ b/test/regression/issue/27358.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { tls as validTls } from "harness";
+
+describe("mTLS SSLConfig keepalive (#27358)", () => {
+  test("fetch with custom TLS reuses keepalive connections", async () => {
+    // Track client ports to detect connection reuse
+    const clientPorts: number[] = [];
+
+    using server = Bun.serve({
+      port: 0,
+      tls: validTls,
+      hostname: "127.0.0.1",
+      fetch(req, server) {
+        const ip = server.requestIP(req);
+        return new Response(String(ip?.port ?? 0));
+      },
+    });
+
+    const url = `https://127.0.0.1:${server.port}`;
+    const tlsOpts = { ca: validTls.cert, rejectUnauthorized: false };
+
+    // Make sequential requests with keepalive enabled.
+    // With our fix: keepalive works for custom TLS, connections are reused → same port.
+    // With old code: disable_keepalive=true, every request opens a new TCP connection → different ports.
+    const numRequests = 6;
+    for (let i = 0; i < numRequests; i++) {
+      const res = await fetch(url, { tls: tlsOpts, keepalive: true });
+      const port = parseInt(await res.text(), 10);
+      clientPorts.push(port);
+    }
+
+    // Count unique client ports.
+    const uniquePorts = new Set(clientPorts);
+
+    // With keepalive working: sequential requests reuse the connection,
+    // so we expect significantly fewer unique ports than requests.
+    // The first request establishes a connection, subsequent ones reuse it.
+    // Allow for at most 2 unique ports (in case of a one-time reconnect).
+    expect(uniquePorts.size).toBeLessThanOrEqual(2);
+  });
+
+  test("different custom TLS configs do NOT share keepalive connections", async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls: validTls,
+      hostname: "127.0.0.1",
+      fetch(req, server) {
+        const ip = server.requestIP(req);
+        return new Response(String(ip?.port ?? 0));
+      },
+    });
+
+    const url = `https://127.0.0.1:${server.port}`;
+
+    // Config A - just CA
+    const tlsA = { ca: validTls.cert, rejectUnauthorized: false };
+    // Config B - CA + explicit serverName (makes it a different SSLConfig)
+    const tlsB = { ca: validTls.cert, rejectUnauthorized: false, serverName: "127.0.0.1" };
+
+    // Request with config A
+    const resA = await fetch(url, { tls: tlsA, keepalive: true });
+    const portA = parseInt(await resA.text(), 10);
+
+    // Request with config B — must open a new connection (different SSL context)
+    const resB = await fetch(url, { tls: tlsB, keepalive: true });
+    const portB = parseInt(await resB.text(), 10);
+
+    // Different configs → different connections → different ports
+    expect(portA).not.toBe(portB);
+  });
+});


### PR DESCRIPTION
Add reference counting to SSLConfig via GlobalRegistry interning, enable keepalive for custom TLS configs (mTLS), and add proper SSL context caching with TTL/LRU eviction.

### Changes
- **SSLConfig** — RC mixin, GlobalRegistry, contentHash, destroy, intern
- **fetch.zig** — Use `deref()` instead of manual deinit+destroy, intern via GlobalRegistry
- **http.zig** — `custom_ssl_ctx` field, `getSslCtx()` helper, callback sites use `getSslCtx()`
- **HTTPThread.zig** — `SslContextCacheEntry` with timestamps, TTL/LRU eviction
- **HTTPContext.zig** — `PooledSocket.ssl_config` + `owner` fields, ref/deref in releaseSocket/existingSocket/addMemoryBackToPool, proper deinit teardown

### Tests
- `test/js/bun/http/tls-keepalive.test.ts` — keepalive reuse, isolation, memory leak tests
- `test/regression/issue/27358.test.ts` — regression test for mTLS keepalive

Split from #27385.