### PR TITLE
fix(http): report actual errno instead of EADDRINUSE in Bun.serve

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1752,24 +1752,20 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             if (error_instance == .zero) {
                 switch (this.config.address) {
                     .tcp => |tcp| {
-                        error_set: {
-                            if (comptime Environment.isLinux) {
-                                const rc: i32 = -1;
-                                const code = Sys.getErrno(rc);
-                                if (code == bun.sys.E.ACCES) {
-                                    error_instance = (jsc.SystemError{
-                                        .message = bun.String.init(std.fmt.bufPrint(&output_buf, "permission denied {s}:{d}", .{ tcp.hostname orelse "0.0.0.0", tcp.port }) catch "Failed to start server"),
-                                        .code = bun.String.static("EACCES"),
-                                        .syscall = bun.String.static("listen"),
-                                    }).toErrorInstance(globalThis);
-                                    break :error_set;
-                                }
-                            }
-                            error_instance = (jsc.SystemError{
-                                .message = bun.String.init(std.fmt.bufPrint(&output_buf, "Failed to start server. Is port {d} in use?", .{tcp.port}) catch "Failed to start server"),
-                                .code = bun.String.static("EADDRINUSE"),
-                                .syscall = bun.String.static("listen"),
-                            }).toErrorInstance(globalThis);
+                        const errno = Sys.getErrno(@as(i32, -1));
+                        switch (errno) {
+                            .SUCCESS, .ADDRINUSE => {
+                                error_instance = (jsc.SystemError{
+                                    .message = bun.String.init(std.fmt.bufPrint(&output_buf, "Failed to start server. Is port {d} in use?", .{tcp.port}) catch "Failed to start server"),
+                                    .code = bun.String.static("EADDRINUSE"),
+                                    .syscall = bun.String.static("listen"),
+                                }).toErrorInstance(globalThis);
+                            },
+                            else => {
+                                var sys_err = bun.sys.Error.fromCode(errno, .listen);
+                                sys_err.path = if (tcp.hostname) |h| std.mem.span(h) else "0.0.0.0";
+                                error_instance = sys_err.toJS(globalThis) catch return;
+                            },
                         }
                     },
                     .unix => |unix| {

--- a/test/regression/issue/27410.test.ts
+++ b/test/regression/issue/27410.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/27410
+// Bun.serve should report the actual errno (e.g. EADDRNOTAVAIL, EACCES, EPERM)
+// instead of always reporting EADDRINUSE when listen fails.
+
+test("Bun.serve reports EADDRNOTAVAIL instead of EADDRINUSE for non-local address", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `try {
+        Bun.serve({ port: 0, hostname: "192.0.2.1", fetch() { return new Response("ok") } });
+      } catch(e) {
+        console.log(e.code);
+      }`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("EADDRNOTAVAIL");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- When `Bun.serve` fails to bind/listen, the error handler previously only checked for `EACCES` on Linux and defaulted to `EADDRINUSE` for all other errors on all platforms
- Now reads the actual `errno` on all platforms and maps it to the correct error code (e.g. `EADDRNOTAVAIL`, `EACCES`, `EPERM`), only falling back to `EADDRINUSE` when `errno` is `SUCCESS` or actually `ADDRINUSE`

Closes #27410

## Test plan
- [x] Added regression test that binds to non-local address `192.0.2.1` and verifies `EADDRNOTAVAIL` is reported (not `EADDRINUSE`)
- [x] Test fails with `USE_SYSTEM_BUN=1` (confirms bug exists in released bun)
- [x] Test passes with `bun bd test` (confirms fix works)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/bun-1dd33a4e/bun-1dd33a4e/editor/claude%2Ffix-serve-listen-error-code?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->