### PR TITLE
fix(shell): seq crashes when called with only flags and no numeric args

### DIFF
--- a/src/shell/builtin/seq.zig
+++ b/src/shell/builtin/seq.zig
@@ -44,7 +44,7 @@ pub fn start(this: *@This()) Yield {
         break;
     }
 
-    const maybe1 = iter.next().?;
+    const maybe1 = iter.next() orelse return this.fail(Builtin.Kind.usageString(.seq));
     const int1 = std.fmt.parseFloat(f32, bun.sliceTo(maybe1, 0)) catch return this.fail("seq: invalid argument\n");
     if (!std.math.isFinite(int1)) return this.fail("seq: invalid argument\n");
     this._end = int1;

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -9,6 +9,36 @@ describe("seq", async () => {
     .stderr("usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last\n")
     .runAsTest("prints usage");
 
+  TestBuilder.command`seq -w`
+    .exitCode(1)
+    .stdout("")
+    .stderr("usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last\n")
+    .runAsTest("prints usage when only -w flag given");
+
+  TestBuilder.command`seq --fixed-width`
+    .exitCode(1)
+    .stdout("")
+    .stderr("usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last\n")
+    .runAsTest("prints usage when only --fixed-width flag given");
+
+  TestBuilder.command`seq -s ,`
+    .exitCode(1)
+    .stdout("")
+    .stderr("usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last\n")
+    .runAsTest("prints usage when only -s flag given");
+
+  TestBuilder.command`seq -t ,`
+    .exitCode(1)
+    .stdout("")
+    .stderr("usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last\n")
+    .runAsTest("prints usage when only -t flag given");
+
+  TestBuilder.command`seq -w -s , -t .`
+    .exitCode(1)
+    .stdout("")
+    .stderr("usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last\n")
+    .runAsTest("prints usage when only flags given");
+
   TestBuilder.command`seq -s`
     .exitCode(1)
     .stdout("")


### PR DESCRIPTION
## What

Fixes a null pointer dereference crash in the `seq` shell builtin when called with only flags and no numeric arguments.

## Reproduction

```js
await Bun.$`seq -w`       // crash
await Bun.$`seq -s ,`     // crash
await Bun.$`seq -t .`     // crash
```

```
panic(main thread): attempt to use null value
src/shell/builtin/seq.zig:47:31
```

Also crashes release builds (segfault).

## Root cause

The flag-parsing loop at line 17 consumes all arguments. When the user passes only flags, the iterator is exhausted after the loop exits. Line 47 then calls `iter.next().?` which panics on `null`.

The existing `args.len == 0` check on line 14 only catches the case where no args are passed at all — it does not cover the case where all args are consumed as flags.

## Fix

Changed `.?` to `orelse return this.fail(usageString)`, matching the behavior when `seq` is called with zero arguments.