### PR TITLE
fix(docs): code block syntax for `server.tsx` in SSR guide

### DIFF
--- a/docs/guides/ecosystem/ssr-react.mdx
+++ b/docs/guides/ecosystem/ssr-react.mdx
@@ -33,7 +33,7 @@ const stream = await renderToReadableStream(<Component message="Hello from serve
 
 Combining this with `Bun.serve()`, we get a simple SSR HTTP server:
 
-```tsx server.ts icon="/icons/typescript.svg"
+```tsx server.tsx icon="/icons/typescript.svg"
 Bun.serve({
   async fetch() {
     const stream = await renderToReadableStream(<Component message="Hello from server!" />);


### PR DESCRIPTION
### What does this PR do?

TSX files may contain XML-like syntax, but TS files cannot.