### PR TITLE
fix(install): skip registry resolution for bundled dependencies

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -448,6 +448,7 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
     comptime failFn: ?FailFn,
 ) !void {
     if (dependency.behavior.isOptionalPeer()) return;
+    if (dependency.behavior.isBundled()) return;
 
     var name = dependency.realname();
     var name_hash = switch (dependency.version.tag) {

--- a/src/install/PackageManager/PackageManagerResolution.zig
+++ b/src/install/PackageManager/PackageManagerResolution.zig
@@ -189,6 +189,8 @@ pub fn verifyResolutions(this: *PackageManager, log_level: PackageManager.Option
             // TODO lockfile rewrite: remove this and make non-optional peer dependencies error if they did not resolve.
             //      Need to keep this for now because old lockfiles might have a peer dependency without the optional flag set.
             if (failed_dep.behavior.isPeer()) continue;
+            // Bundled dependencies are included inside the parent tarball and don't need resolution.
+            if (failed_dep.behavior.isBundled()) continue;
 
             const features = switch (pkg_resolutions[parent_id].tag) {
                 .root, .workspace, .folder => this.options.local_package_features,

--- a/test/regression/issue/27418.test.ts
+++ b/test/regression/issue/27418.test.ts
@@ -1,0 +1,68 @@
+import { spawn } from "bun";
+import { expect, test } from "bun:test";
+import { mkdir, writeFile } from "fs/promises";
+import { bunEnv, bunExe, pack, tempDir } from "harness";
+import { join } from "path";
+
+// Regression test for https://github.com/oven-sh/bun/issues/27418
+// bun install should not contact the npm registry for bundled dependencies
+// since they are already included inside the tarball.
+test("bun install does not fetch bundled dependencies from registry", async () => {
+  using dir = tempDir("issue-27418", {});
+
+  // Create the package that will be packed as a tarball
+  const pkgDir = join(String(dir), "my-pkg");
+  const bundledPkgDir = join(pkgDir, "node_modules", "fake-nonexistent-pkg-27418");
+  await mkdir(bundledPkgDir, { recursive: true });
+
+  await Promise.all([
+    writeFile(
+      join(pkgDir, "package.json"),
+      JSON.stringify({
+        name: "my-pkg",
+        version: "1.0.0",
+        dependencies: {
+          "fake-nonexistent-pkg-27418": "1.0.0",
+        },
+        bundleDependencies: ["fake-nonexistent-pkg-27418"],
+      }),
+    ),
+    writeFile(
+      join(bundledPkgDir, "package.json"),
+      JSON.stringify({
+        name: "fake-nonexistent-pkg-27418",
+        version: "1.0.0",
+      }),
+    ),
+  ]);
+
+  // Pack the tarball (bundled deps get included in node_modules inside the tarball)
+  await pack(pkgDir, bunEnv);
+
+  // Create a consumer package that installs the tarball
+  const consumerDir = join(String(dir), "consumer");
+  await mkdir(consumerDir, { recursive: true });
+  await writeFile(
+    join(consumerDir, "package.json"),
+    JSON.stringify({
+      name: "consumer",
+      version: "1.0.0",
+    }),
+  );
+
+  // Install the tarball — this should NOT try to resolve the bundled dep from the registry
+  await using proc = spawn({
+    cmd: [bunExe(), "install", join(pkgDir, "my-pkg-1.0.0.tgz")],
+    cwd: consumerDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Should not contain any error about failing to resolve the bundled dependency
+  expect(stderr).not.toContain("failed to resolve");
+  expect(stderr).not.toContain("error:");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/27418.test.ts
+++ b/test/regression/issue/27418.test.ts
@@ -50,9 +50,10 @@ test("bun install does not fetch bundled dependencies from registry", async () =
     }),
   );
 
-  // Install the tarball — this should NOT try to resolve the bundled dep from the registry
+  // Install the tarball with the registry pointed at an unreachable address so that
+  // any accidental registry fetch fails fast instead of hitting the real npm registry.
   await using proc = spawn({
-    cmd: [bunExe(), "install", join(pkgDir, "my-pkg-1.0.0.tgz")],
+    cmd: [bunExe(), "install", "--registry", "http://localhost:0", join(pkgDir, "my-pkg-1.0.0.tgz")],
     cwd: consumerDir,
     stdout: "pipe",
     stderr: "pipe",
@@ -64,5 +65,6 @@ test("bun install does not fetch bundled dependencies from registry", async () =
   // Should not contain any error about failing to resolve the bundled dependency
   expect(stderr).not.toContain("failed to resolve");
   expect(stderr).not.toContain("error:");
+  expect(stdout).toContain("installed my-pkg");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Summary
- When installing a tarball with `bundleDependencies`, Bun was incorrectly fetching bundled dependencies from the NPM registry, causing 404 errors for packages that only exist inside the tarball
- Added early-return checks for bundled dependencies in both the enqueue phase (`PackageManagerEnqueue.zig`) and the resolution verification phase (`PackageManagerResolution.zig`), matching npm's behavior of skipping registry resolution for bundled deps

Closes #27418

## Test plan
- [x] New regression test `test/regression/issue/27418.test.ts` creates a tarball with a bundled dependency (`fake-nonexistent-pkg-27418`) that doesn't exist on npm, installs it, and verifies no resolution errors occur
- [x] Test fails with `USE_SYSTEM_BUN=1` (confirms the bug exists in released Bun)
- [x] Test passes with `bun bd test` (confirms the fix works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)