### PR TITLE
fix(streams): preserve AsyncLocalStorage context in `stream.finished` callback

### DIFF
--- a/src/js/internal/streams/end-of-stream.ts
+++ b/src/js/internal/streams/end-of-stream.ts
@@ -26,6 +26,7 @@ const SymbolDispose = Symbol.dispose;
 const PromisePrototypeThen = $Promise.prototype.$then;
 
 let addAbortListener;
+let AsyncLocalStorage;
 
 function isRequest(stream) {
   return stream.setHeader && typeof stream.abort === "function";
@@ -45,7 +46,8 @@ function eos(stream, options, callback) {
   validateFunction(callback, "callback");
   validateAbortSignal(options.signal, "options.signal");
 
-  callback = once(callback);
+  AsyncLocalStorage ??= require("node:async_hooks").AsyncLocalStorage;
+  callback = once(AsyncLocalStorage.bind(callback));
 
   if (isReadableStream(stream) || isWritableStream(stream)) {
     return eosWeb(stream, options, callback);

--- a/test/regression/issue/27428.test.ts
+++ b/test/regression/issue/27428.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("stream.finished callback preserves AsyncLocalStorage context", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const asyncHooks = require('async_hooks');
+const http = require('http');
+const finished = require('stream').finished;
+
+const asyncLocalStorage = new asyncHooks.AsyncLocalStorage();
+const store = { foo: 'bar' };
+
+const server = http.createServer(function (req, res) {
+  asyncLocalStorage.run(store, function () {
+    finished(res, function () {
+      const value = asyncLocalStorage.getStore()?.foo;
+      if (value !== 'bar') {
+        console.log('FAIL: expected "bar" but got ' + value);
+        process.exitCode = 1;
+      } else {
+        console.log('PASS');
+      }
+    });
+  });
+  setTimeout(res.end.bind(res), 0);
+}).listen(0, function () {
+  const port = this.address().port;
+  http.get('http://127.0.0.1:' + port, function onResponse(res) {
+    res.resume();
+    res.on('end', server.close.bind(server));
+  });
+});
+`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("PASS");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Bind the `stream.finished` callback with `AsyncLocalStorage.bind()` before wrapping with `once()`, matching [Node.js behavior](https://github.com/nodejs/node/blob/main/lib/internal/streams/end-of-stream.js#L70). Without this, the async context active when `finished()` is called is lost by the time the callback fires.

Closes #27428

## Test plan
- [x] Added regression test `test/regression/issue/27428.test.ts` that spawns an HTTP server using `stream.finished` inside `AsyncLocalStorage.run()` and verifies the store is preserved in the callback
- [x] Verified test fails with system bun (`USE_SYSTEM_BUN=1`) and passes with the debug build
- [x] Existing stream finished tests (`test-stream-finished.js`, `test-stream-end-of-streams.js`, `test-http-outgoing-finished.js`, `test-http-client-finished.js`) continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)