### PR TITLE
fix(standalone): inherit env behavior flags in Worker threads

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1348,6 +1348,17 @@ pub fn initWorker(
     };
     vm.transpiler.resolver.standalone_module_graph = opts.graph;
 
+    // Mirror the env behavior logic from bootStandalone (src/bun.js.zig).
+    // Without this, workers in standalone executables with autoloadDotenv=false
+    // would still try to load .env files, causing cross-thread allocation panics.
+    if (opts.graph) |graph| {
+        if (graph.flags.disable_default_env_files) {
+            vm.transpiler.options.env.behavior = .disable;
+        } else {
+            vm.transpiler.options.env.behavior = .load_all_without_inlining;
+        }
+    }
+
     if (opts.graph == null) {
         vm.transpiler.configureLinker();
     } else {

--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -531,6 +531,35 @@ console.log("PRELOAD");
     },
   });
 
+  // Regression test for https://github.com/oven-sh/bun/issues/27431
+  // Standalone with autoloadDotenv=false crashed when spawning a Worker
+  // because the worker didn't inherit the disable_default_env_files flag,
+  // causing it to try loading .env files with the wrong thread's allocator.
+  itBundled("compile/AutoloadDotenvDisabledWithWorker", {
+    compile: {
+      autoloadDotenv: false,
+    },
+    backend: "cli",
+    files: {
+      "/entry.ts": /* js */ `
+        new Worker("./worker.ts");
+      `,
+      "/worker.ts": /* js */ `
+        console.log("Worker loaded!");
+    `.trim(),
+    },
+    runtimeFiles: {
+      "/.env": `TEST_VAR=from_dotenv`,
+    },
+    entryPointsRaw: ["./entry.ts", "./worker.ts"],
+    outfile: "dist/out",
+    run: {
+      stdout: "Worker loaded!\n",
+      file: "dist/out",
+      setCwd: true,
+    },
+  });
+
   // Test that both tsconfig and package.json can be enabled together
   itBundled("compile/AutoloadBothTsconfigAndPackageJson", {
     compile: {


### PR DESCRIPTION
## Summary
- Workers in standalone executables didn't inherit the `disable_default_env_files` flag from the standalone module graph, causing them to attempt loading `.env` files even when `autoloadDotenv: false` was set
- The worker's env loader used the parent thread's `MimallocArena` allocator, triggering a `ThreadLock` assertion panic (crash in debug builds, potential memory corruption in release builds)
- Mirror the env behavior logic from `bootStandalone` (`src/bun.js.zig:87-91`) in `initWorker` (`src/bun.js/VirtualMachine.zig`) so workers correctly respect the compile option

Closes #27431

## Test plan
- [x] Added `compile/AutoloadDotenvDisabledWithWorker` test in `test/bundler/bundler_compile_autoload.test.ts`
- [x] Test compiles a standalone binary with `autoloadDotenv: false`, a `.env` file present, and a Worker entry point
- [x] Verified test passes with system bun (`USE_SYSTEM_BUN=1`)
- [x] Verified debug build compiles successfully with fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)