### PR TITLE
feat(repl): add -e/-p flags, docs page, and shell completions

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -148,6 +148,9 @@ _bun_completions() {
         upgrade)
             COMPREPLY=( $(compgen -W "--version --cwd --help -v -h") );
             return;;
+        repl)
+            COMPREPLY=( $(compgen -W "--help -h --eval -e --print -p --preload -r --smol --config -c --cwd --env-file --no-env-file" -- "${cur_word}") );
+            return;;
         run)
             _file_arguments "!(*.@(js|ts|jsx|tsx|mjs|cjs)?($|))";
             COMPREPLY+=( $(compgen -W "--version --cwd --help --silent -v -h" -- "${cur_word}" ) );

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -35,7 +35,7 @@ end
 set -l bun_install_boolean_flags yarn production optional development no-save dry-run force no-cache silent verbose global
 set -l bun_install_boolean_flags_descriptions "Write a yarn.lock file (yarn v1)" "Don't install devDependencies" "Add dependency to optionalDependencies" "Add dependency to devDependencies" "Don't update package.json or save a lockfile" "Don't install anything" "Always request the latest versions from the registry & reinstall all dependencies" "Ignore manifest cache entirely" "Don't output anything" "Excessively verbose logging" "Use global folder"
 
-set -l bun_builtin_cmds_without_run dev create help bun upgrade discord install remove add update init pm x
+set -l bun_builtin_cmds_without_run dev create help bun upgrade discord install remove add update init pm x repl
 set -l bun_builtin_cmds_accepting_flags create help bun upgrade discord run init link unlink pm x update
 
 function __bun_complete_bins_scripts --inherit-variable bun_builtin_cmds_without_run -d "Emit bun completions for bins and scripts"
@@ -185,3 +185,6 @@ complete -c bun -n "__fish_use_subcommand" -a "x" -d "Execute a package binary, 
 complete -c bun -n "__fish_use_subcommand" -a "outdated" -d "Display the latest versions of outdated dependencies" -f
 complete -c bun -n "__fish_use_subcommand" -a "update" -d "Update dependencies to their latest versions" -f
 complete -c bun -n "__fish_use_subcommand" -a "publish" -d "Publish your package from local to npm" -f
+complete -c bun -n "__fish_use_subcommand" -a "repl" -d "Start a REPL session with Bun" -f
+complete -c bun -n "__fish_seen_subcommand_from repl" -s "e" -l "eval" -r -d "Evaluate argument as a script, then exit" -f
+complete -c bun -n "__fish_seen_subcommand_from repl" -s "p" -l "print" -r -d "Evaluate argument as a script, print the result, then exit" -f

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -188,3 +188,9 @@ complete -c bun -n "__fish_use_subcommand" -a "publish" -d "Publish your package
 complete -c bun -n "__fish_use_subcommand" -a "repl" -d "Start a REPL session with Bun" -f
 complete -c bun -n "__fish_seen_subcommand_from repl" -s "e" -l "eval" -r -d "Evaluate argument as a script, then exit" -f
 complete -c bun -n "__fish_seen_subcommand_from repl" -s "p" -l "print" -r -d "Evaluate argument as a script, print the result, then exit" -f
+complete -c bun -n "__fish_seen_subcommand_from repl" -s "r" -l "preload" -r -d "Import a module before other modules are loaded"
+complete -c bun -n "__fish_seen_subcommand_from repl" -l "smol" -d "Use less memory, but run garbage collection more often" -f
+complete -c bun -n "__fish_seen_subcommand_from repl" -s "c" -l "config" -r -d "Specify path to Bun config file"
+complete -c bun -n "__fish_seen_subcommand_from repl" -l "cwd" -r -d "Absolute path to resolve files & entry points from"
+complete -c bun -n "__fish_seen_subcommand_from repl" -l "env-file" -r -d "Load environment variables from the specified file(s)"
+complete -c bun -n "__fish_seen_subcommand_from repl" -l "no-env-file" -d "Disable automatic loading of .env files" -f

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -524,6 +524,33 @@ _bun_upgrade_completion() {
 
 }
 
+_bun_repl_completion() {
+    _arguments -s -C \
+        '1: :->cmd' \
+        '--help[Print this help menu]' \
+        '-h[Print this help menu]' \
+        '(-p --print)--eval[Evaluate argument as a script, then exit]:script' \
+        '(-p --print)-e[Evaluate argument as a script, then exit]:script' \
+        '(-e --eval)--print[Evaluate argument as a script, print the result, then exit]:script' \
+        '(-e --eval)-p[Evaluate argument as a script, print the result, then exit]:script' \
+        '--preload[Import a module before other modules are loaded]:preload' \
+        '-r[Import a module before other modules are loaded]:preload' \
+        '--smol[Use less memory, but run garbage collection more often]' \
+        '--config[Specify path to Bun config file]: :->config' \
+        '-c[Specify path to Bun config file]: :->config' \
+        '--cwd[Absolute path to resolve files & entry points from]:cwd' \
+        '--env-file[Load environment variables from the specified file(s)]:env-file' \
+        '--no-env-file[Disable automatic loading of .env files]' &&
+        ret=0
+
+    case $state in
+    config)
+        _bun_list_bunfig_toml
+
+        ;;
+    esac
+}
+
 _bun_build_completion() {
     _arguments -s -C \
         '1: :->cmd' \
@@ -788,6 +815,10 @@ _bun() {
             _bun_upgrade_completion
 
             ;;
+        repl)
+            _bun_repl_completion
+
+            ;;
         build)
             _bun_build_completion
 
@@ -869,6 +900,10 @@ _bun() {
                     ;;
                 upgrade)
                     _bun_upgrade_completion
+
+                    ;;
+                repl)
+                    _bun_repl_completion
 
                     ;;
                 build)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -75,7 +75,7 @@
           {
             "group": "Core Runtime",
             "icon": "cog",
-            "pages": ["/runtime/index", "/runtime/watch-mode", "/runtime/debugger", "/runtime/bunfig"]
+            "pages": ["/runtime/index", "/runtime/watch-mode", "/runtime/debugger", "/runtime/repl", "/runtime/bunfig"]
           },
           {
             "group": "File & Module System",

--- a/docs/runtime/repl.mdx
+++ b/docs/runtime/repl.mdx
@@ -84,7 +84,7 @@ Type `.help` at the prompt to see all available REPL commands.
 | ---------- | ------------------------------------------------------------------------------------------------ |
 | `.help`    | Print the help message listing commands and keybindings                                          |
 | `.exit`    | Exit the REPL                                                                                    |
-| `.clear`   | Clear the REPL context and screen                                                                |
+| `.clear`   | Clear the screen                                                                                 |
 | `.copy`    | Copy the last result to the clipboard. Pass an expression to evaluate and copy it: `.copy 1 + 1` |
 | `.load`    | Load a file into the REPL session: `.load ./script.ts`                                           |
 | `.save`    | Save the current REPL history to a file: `.save ./session.txt`                                   |
@@ -109,7 +109,6 @@ The REPL supports Emacs-style line editing.
 | `Ctrl+W`            | Delete word backward                                     |
 | `Ctrl+D`            | Delete character (or exit if line is empty)              |
 | `Ctrl+L`            | Clear screen                                             |
-| `Ctrl+R`            | Reverse history search                                   |
 | `Ctrl+T`            | Swap the two characters before the cursor                |
 | `Up` / `Down`       | Navigate history                                         |
 | `Tab`               | Auto-complete                                            |

--- a/docs/runtime/repl.mdx
+++ b/docs/runtime/repl.mdx
@@ -58,10 +58,10 @@ This uses the same transforms as the interactive REPL, so a bare object literal 
 
 The REPL exposes two special variables that update after each evaluation.
 
-| Variable | Description                         |
-| -------- | ----------------------------------- |
-| `_`      | The result of the last expression   |
-| `_error` | The last error that was thrown      |
+| Variable | Description                       |
+| -------- | --------------------------------- |
+| `_`      | The result of the last expression |
+| `_error` | The last error that was thrown    |
 
 ```txt
 > 2 + 2
@@ -80,17 +80,17 @@ SyntaxError: JSON Parse error: Unexpected identifier "oops"
 
 Type `.help` at the prompt to see all available REPL commands.
 
-| Command     | Description                                                                      |
-| ----------- | -------------------------------------------------------------------------------- |
-| `.help`     | Print the help message listing commands and keybindings                          |
-| `.exit`     | Exit the REPL                                                                    |
-| `.clear`    | Clear the REPL context and screen                                                |
-| `.copy`     | Copy the last result to the clipboard. Pass an expression to evaluate and copy it: `.copy 1 + 1` |
-| `.load`     | Load a file into the REPL session: `.load ./script.ts`                           |
-| `.save`     | Save the current REPL history to a file: `.save ./session.txt`                   |
-| `.editor`   | Enter multi-line editor mode (press `Ctrl+D` to evaluate, `Ctrl+C` to cancel)    |
-| `.break`    | Cancel the current multi-line input                                              |
-| `.history`  | Print the command history                                                        |
+| Command    | Description                                                                                      |
+| ---------- | ------------------------------------------------------------------------------------------------ |
+| `.help`    | Print the help message listing commands and keybindings                                          |
+| `.exit`    | Exit the REPL                                                                                    |
+| `.clear`   | Clear the REPL context and screen                                                                |
+| `.copy`    | Copy the last result to the clipboard. Pass an expression to evaluate and copy it: `.copy 1 + 1` |
+| `.load`    | Load a file into the REPL session: `.load ./script.ts`                                           |
+| `.save`    | Save the current REPL history to a file: `.save ./session.txt`                                   |
+| `.editor`  | Enter multi-line editor mode (press `Ctrl+D` to evaluate, `Ctrl+C` to cancel)                    |
+| `.break`   | Cancel the current multi-line input                                                              |
+| `.history` | Print the command history                                                                        |
 
 ---
 
@@ -98,22 +98,22 @@ Type `.help` at the prompt to see all available REPL commands.
 
 The REPL supports Emacs-style line editing.
 
-| Keybinding              | Action                                       |
-| ----------------------- | -------------------------------------------- |
-| `Ctrl+A`                | Move to start of line                        |
-| `Ctrl+E`                | Move to end of line                          |
-| `Ctrl+B` / `Ctrl+F`     | Move backward/forward one character          |
-| `Alt+B` / `Alt+F`       | Move backward/forward one word               |
-| `Ctrl+U`                | Delete to start of line                      |
-| `Ctrl+K`                | Delete to end of line                        |
-| `Ctrl+W`                | Delete word backward                         |
-| `Ctrl+D`                | Delete character (or exit if line is empty)  |
-| `Ctrl+L`                | Clear screen                                 |
-| `Ctrl+R`                | Reverse history search                       |
-| `Ctrl+T`                | Swap the two characters before the cursor    |
-| `Up` / `Down`           | Navigate history                             |
-| `Tab`                   | Auto-complete                                |
-| `Ctrl+C`                | Cancel current input (press twice on empty line to exit) |
+| Keybinding          | Action                                                   |
+| ------------------- | -------------------------------------------------------- |
+| `Ctrl+A`            | Move to start of line                                    |
+| `Ctrl+E`            | Move to end of line                                      |
+| `Ctrl+B` / `Ctrl+F` | Move backward/forward one character                      |
+| `Alt+B` / `Alt+F`   | Move backward/forward one word                           |
+| `Ctrl+U`            | Delete to start of line                                  |
+| `Ctrl+K`            | Delete to end of line                                    |
+| `Ctrl+W`            | Delete word backward                                     |
+| `Ctrl+D`            | Delete character (or exit if line is empty)              |
+| `Ctrl+L`            | Clear screen                                             |
+| `Ctrl+R`            | Reverse history search                                   |
+| `Ctrl+T`            | Swap the two characters before the cursor                |
+| `Up` / `Down`       | Navigate history                                         |
+| `Tab`               | Auto-complete                                            |
+| `Ctrl+C`            | Cancel current input (press twice on empty line to exit) |
 
 ---
 

--- a/docs/runtime/repl.mdx
+++ b/docs/runtime/repl.mdx
@@ -74,18 +74,18 @@ undefined
 
 ## Importing modules
 
-Use `import` or `require` to load modules. Module resolution uses the same rules as `bun run`, so you can import from `node_modules`, relative paths, or `node:` builtins.
+Just like Bun's runtime, you can use either `require` or `import` in the REPL and it Just Works — mix ESM and CommonJS freely at the prompt. Module resolution uses the same rules as `bun run`, so you can import from `node_modules`, relative paths, or `node:` builtins.
 
 ```txt
 > import { z } from "zod"
 undefined
-> z.string().parse("hello")
-'hello'
 > const path = require("path")
 undefined
-> path.join("/tmp", "file.txt")
+> z.string().parse(path.join("/tmp", "file.txt"))
 '/tmp/file.txt'
 ```
+
+Declarations persist for the rest of the session, and `const`/`let` can be redeclared across evaluations (unlike in regular scripts) so you can re-run `import` and `require` statements while iterating.
 
 ---
 

--- a/docs/runtime/repl.mdx
+++ b/docs/runtime/repl.mdx
@@ -1,0 +1,177 @@
+---
+title: "REPL"
+description: "An interactive JavaScript and TypeScript REPL with syntax highlighting, history, and tab completion"
+---
+
+`bun repl` starts an interactive Read-Eval-Print Loop (REPL) for evaluating JavaScript and TypeScript expressions. It's useful for quickly testing code snippets, exploring APIs, and debugging.
+
+```sh terminal icon="terminal"
+bun repl
+```
+
+```txt
+Welcome to Bun v1.3.3
+Type .copy [code] to copy to clipboard. .help for more info.
+
+> 1 + 1
+2
+> const greeting = "Hello, Bun!"
+undefined
+> greeting
+'Hello, Bun!'
+```
+
+---
+
+## Non-interactive mode
+
+Use `-e` / `--eval` to evaluate a script with REPL semantics and exit. Use `-p` / `--print` to additionally print the result.
+
+```sh terminal icon="terminal"
+bun repl -e "const x: number = 42; console.log(x)"
+# 42
+
+bun repl -p "await fetch('https://example.com').then(r => r.status)"
+# 200
+
+bun repl -p "{ a: 1, b: 2 }"
+# { a: 1, b: 2 }
+```
+
+This uses the same transforms as the interactive REPL, so a bare object literal like `{ a: 1 }` is treated as an object expression instead of a block statement. The process exits after the event loop drains (pending timers and I/O complete first). On error, the process exits with code `1`.
+
+---
+
+## Features
+
+- **TypeScript & JSX** — Write TypeScript and JSX directly. Bun transpiles everything on the fly.
+- **Top-level `await`** — Await promises directly at the prompt without wrapping in an async function.
+- **Syntax highlighting** — Input is highlighted as you type.
+- **Persistent history** — History is saved to `~/.bun_repl_history` and persists across sessions.
+- **Tab completion** — Press `Tab` to complete property names and REPL commands.
+- **Multi-line input** — Unclosed brackets, braces, and parentheses automatically continue on the next line.
+- **Node.js globals** — `require`, `module`, `__dirname`, and `__filename` are available, resolved relative to your current working directory.
+
+---
+
+## Special variables
+
+The REPL exposes two special variables that update after each evaluation.
+
+| Variable | Description                         |
+| -------- | ----------------------------------- |
+| `_`      | The result of the last expression   |
+| `_error` | The last error that was thrown      |
+
+```txt
+> 2 + 2
+4
+> _ * 10
+40
+> JSON.parse("oops")
+SyntaxError: JSON Parse error: Unexpected identifier "oops"
+> _error
+SyntaxError: JSON Parse error: Unexpected identifier "oops"
+```
+
+---
+
+## REPL commands
+
+Type `.help` at the prompt to see all available REPL commands.
+
+| Command     | Description                                                                      |
+| ----------- | -------------------------------------------------------------------------------- |
+| `.help`     | Print the help message listing commands and keybindings                          |
+| `.exit`     | Exit the REPL                                                                    |
+| `.clear`    | Clear the REPL context and screen                                                |
+| `.copy`     | Copy the last result to the clipboard. Pass an expression to evaluate and copy it: `.copy 1 + 1` |
+| `.load`     | Load a file into the REPL session: `.load ./script.ts`                           |
+| `.save`     | Save the current REPL history to a file: `.save ./session.txt`                   |
+| `.editor`   | Enter multi-line editor mode (press `Ctrl+D` to evaluate, `Ctrl+C` to cancel)    |
+| `.break`    | Cancel the current multi-line input                                              |
+| `.history`  | Print the command history                                                        |
+
+---
+
+## Keybindings
+
+The REPL supports Emacs-style line editing.
+
+| Keybinding              | Action                                       |
+| ----------------------- | -------------------------------------------- |
+| `Ctrl+A`                | Move to start of line                        |
+| `Ctrl+E`                | Move to end of line                          |
+| `Ctrl+B` / `Ctrl+F`     | Move backward/forward one character          |
+| `Alt+B` / `Alt+F`       | Move backward/forward one word               |
+| `Ctrl+U`                | Delete to start of line                      |
+| `Ctrl+K`                | Delete to end of line                        |
+| `Ctrl+W`                | Delete word backward                         |
+| `Ctrl+D`                | Delete character (or exit if line is empty)  |
+| `Ctrl+L`                | Clear screen                                 |
+| `Ctrl+R`                | Reverse history search                       |
+| `Ctrl+T`                | Swap the two characters before the cursor    |
+| `Up` / `Down`           | Navigate history                             |
+| `Tab`                   | Auto-complete                                |
+| `Ctrl+C`                | Cancel current input (press twice on empty line to exit) |
+
+---
+
+## Top-level `await`
+
+Promises are automatically awaited. You can `await` any expression directly at the prompt.
+
+```txt
+> await fetch("https://api.github.com/repos/oven-sh/bun").then(r => r.json()).then(r => r.stargazers_count)
+81234
+> const response = await fetch("https://example.com")
+undefined
+> response.status
+200
+```
+
+---
+
+## Importing modules
+
+Use `import` or `require` to load modules. Module resolution uses the same rules as `bun run`, so you can import from `node_modules`, relative paths, or `node:` builtins.
+
+```txt
+> import { z } from "zod"
+undefined
+> z.string().parse("hello")
+'hello'
+> const path = require("path")
+undefined
+> path.join("/tmp", "file.txt")
+'/tmp/file.txt'
+```
+
+---
+
+## Multi-line input
+
+When you press `Enter` on a line with unclosed brackets, braces, or parentheses, the REPL automatically continues on the next line. The prompt changes to `...` to indicate continuation.
+
+```txt
+> function add(a, b) {
+...   return a + b;
+... }
+undefined
+> add(2, 3)
+5
+```
+
+For longer multi-line entries, use `.editor` to enter editor mode, which buffers all input until you press `Ctrl+D`.
+
+---
+
+## History
+
+REPL history is automatically saved to `~/.bun_repl_history` (up to 1000 entries) and loaded at the start of each session. Use `Up`/`Down` to navigate or `Ctrl+R` to search.
+
+To export your history to a different file, use `.save`:
+
+```txt
+> .save ./my-session.txt
+```

--- a/docs/runtime/repl.mdx
+++ b/docs/runtime/repl.mdx
@@ -23,25 +23,6 @@ undefined
 
 ---
 
-## Non-interactive mode
-
-Use `-e` / `--eval` to evaluate a script with REPL semantics and exit. Use `-p` / `--print` to additionally print the result.
-
-```sh terminal icon="terminal"
-bun repl -e "const x: number = 42; console.log(x)"
-# 42
-
-bun repl -p "await fetch('https://example.com').then(r => r.status)"
-# 200
-
-bun repl -p "{ a: 1, b: 2 }"
-# { a: 1, b: 2 }
-```
-
-This uses the same transforms as the interactive REPL, so a bare object literal like `{ a: 1 }` is treated as an object expression instead of a block statement. The process exits after the event loop drains (pending timers and I/O complete first). On error, the process exits with code `1`.
-
----
-
 ## Features
 
 - **TypeScript & JSX** — Write TypeScript and JSX directly. Bun transpiles everything on the fly.
@@ -73,46 +54,6 @@ SyntaxError: JSON Parse error: Unexpected identifier "oops"
 > _error
 SyntaxError: JSON Parse error: Unexpected identifier "oops"
 ```
-
----
-
-## REPL commands
-
-Type `.help` at the prompt to see all available REPL commands.
-
-| Command    | Description                                                                                      |
-| ---------- | ------------------------------------------------------------------------------------------------ |
-| `.help`    | Print the help message listing commands and keybindings                                          |
-| `.exit`    | Exit the REPL                                                                                    |
-| `.clear`   | Clear the screen                                                                                 |
-| `.copy`    | Copy the last result to the clipboard. Pass an expression to evaluate and copy it: `.copy 1 + 1` |
-| `.load`    | Load a file into the REPL session: `.load ./script.ts`                                           |
-| `.save`    | Save the current REPL history to a file: `.save ./session.txt`                                   |
-| `.editor`  | Enter multi-line editor mode (press `Ctrl+D` to evaluate, `Ctrl+C` to cancel)                    |
-| `.break`   | Cancel the current multi-line input                                                              |
-| `.history` | Print the command history                                                                        |
-
----
-
-## Keybindings
-
-The REPL supports Emacs-style line editing.
-
-| Keybinding          | Action                                                   |
-| ------------------- | -------------------------------------------------------- |
-| `Ctrl+A`            | Move to start of line                                    |
-| `Ctrl+E`            | Move to end of line                                      |
-| `Ctrl+B` / `Ctrl+F` | Move backward/forward one character                      |
-| `Alt+B` / `Alt+F`   | Move backward/forward one word                           |
-| `Ctrl+U`            | Delete to start of line                                  |
-| `Ctrl+K`            | Delete to end of line                                    |
-| `Ctrl+W`            | Delete word backward                                     |
-| `Ctrl+D`            | Delete character (or exit if line is empty)              |
-| `Ctrl+L`            | Clear screen                                             |
-| `Ctrl+T`            | Swap the two characters before the cursor                |
-| `Up` / `Down`       | Navigate history                                         |
-| `Tab`               | Auto-complete                                            |
-| `Ctrl+C`            | Cancel current input (press twice on empty line to exit) |
 
 ---
 
@@ -165,12 +106,71 @@ For longer multi-line entries, use `.editor` to enter editor mode, which buffers
 
 ---
 
+## REPL commands
+
+Type `.help` at the prompt to see all available REPL commands.
+
+| Command    | Description                                                                                      |
+| ---------- | ------------------------------------------------------------------------------------------------ |
+| `.help`    | Print the help message listing commands and keybindings                                          |
+| `.exit`    | Exit the REPL                                                                                    |
+| `.clear`   | Clear the screen                                                                                 |
+| `.copy`    | Copy the last result to the clipboard. Pass an expression to evaluate and copy it: `.copy 1 + 1` |
+| `.load`    | Load a file into the REPL session: `.load ./script.ts`                                           |
+| `.save`    | Save the current REPL history to a file: `.save ./session.txt`                                   |
+| `.editor`  | Enter multi-line editor mode (press `Ctrl+D` to evaluate, `Ctrl+C` to cancel)                    |
+| `.break`   | Cancel the current multi-line input                                                              |
+| `.history` | Print the command history                                                                        |
+
+---
+
+## Keybindings
+
+The REPL supports Emacs-style line editing.
+
+| Keybinding          | Action                                                   |
+| ------------------- | -------------------------------------------------------- |
+| `Ctrl+A`            | Move to start of line                                    |
+| `Ctrl+E`            | Move to end of line                                      |
+| `Ctrl+B` / `Ctrl+F` | Move backward/forward one character                      |
+| `Alt+B` / `Alt+F`   | Move backward/forward one word                           |
+| `Ctrl+U`            | Delete to start of line                                  |
+| `Ctrl+K`            | Delete to end of line                                    |
+| `Ctrl+W`            | Delete word backward                                     |
+| `Ctrl+D`            | Delete character (or exit if line is empty)              |
+| `Ctrl+L`            | Clear screen                                             |
+| `Ctrl+T`            | Swap the two characters before the cursor                |
+| `Up` / `Down`       | Navigate history                                         |
+| `Tab`               | Auto-complete                                            |
+| `Ctrl+C`            | Cancel current input (press twice on empty line to exit) |
+
+---
+
 ## History
 
-REPL history is automatically saved to `~/.bun_repl_history` (up to 1000 entries) and loaded at the start of each session. Use `Up`/`Down` to navigate or `Ctrl+R` to search.
+REPL history is automatically saved to `~/.bun_repl_history` (up to 1000 entries) and loaded at the start of each session. Use `Up`/`Down` to navigate.
 
 To export your history to a different file, use `.save`:
 
 ```txt
 > .save ./my-session.txt
 ```
+
+---
+
+## Non-interactive mode
+
+Use `-e` / `--eval` to evaluate a script with REPL semantics and exit. Use `-p` / `--print` to additionally print the result.
+
+```sh terminal icon="terminal"
+bun repl -e "const x: number = 42; console.log(x)"
+# 42
+
+bun repl -p "await fetch('https://example.com').then(r => r.status)"
+# 200
+
+bun repl -p "{ a: 1, b: 2 }"
+# { a: 1, b: 2 }
+```
+
+This uses the same transforms as the interactive REPL, so a bare object literal like `{ a: 1 }` is treated as an object expression instead of a block statement. The process exits after the event loop drains (pending timers and I/O complete first). On error, the process exits with code `1`.

--- a/src/cli/repl_command.zig
+++ b/src/cli/repl_command.zig
@@ -134,8 +134,17 @@ const ReplRunner = struct {
         if (this.eval_script.len > 0 or this.eval_and_print) {
             // Non-interactive: evaluate the -e/--eval or -p/--print script,
             // drain the event loop, and exit
-            vm.exit_handler.exit_code = this.repl.evalScript(this.eval_script, this.eval_and_print);
+            const had_error = this.repl.evalScript(this.eval_script, this.eval_and_print);
             Output.flush();
+            if (had_error) {
+                // Only overwrite on error so `process.exitCode = N` in the
+                // script is preserved on success.
+                vm.exit_handler.exit_code = 1;
+            } else {
+                // Fire process.on("beforeExit") and re-drain as needed
+                // (matches bun -e / Node.js semantics).
+                vm.onBeforeExit();
+            }
         } else {
             // Interactive: run the REPL loop
             this.repl.runWithVM(vm) catch |err| {

--- a/src/cli/repl_command.zig
+++ b/src/cli/repl_command.zig
@@ -92,6 +92,8 @@ pub const ReplCommand = struct {
             .vm = vm,
             .arena = arena,
             .entry_path = repl_path,
+            .eval_script = ctx.runtime_options.eval.script,
+            .eval_and_print = ctx.runtime_options.eval.eval_and_print,
         };
 
         const callback = jsc.OpaqueWrap(ReplRunner, ReplRunner.start);
@@ -112,6 +114,8 @@ const ReplRunner = struct {
     vm: *jsc.VirtualMachine,
     arena: bun.allocators.MimallocArena,
     entry_path: []const u8,
+    eval_script: []const u8,
+    eval_and_print: bool,
 
     pub fn start(this: *ReplRunner) void {
         const vm = this.vm;
@@ -127,10 +131,17 @@ const ReplRunner = struct {
             vm.globalExit();
         };
 
-        // Run the REPL loop
-        this.repl.runWithVM(vm) catch |err| {
-            Output.prettyErrorln("<r><red>REPL error: {s}<r>", .{@errorName(err)});
-        };
+        if (this.eval_script.len > 0 or this.eval_and_print) {
+            // Non-interactive: evaluate the -e/--eval or -p/--print script,
+            // drain the event loop, and exit
+            vm.exit_handler.exit_code = this.repl.evalScript(this.eval_script, this.eval_and_print);
+            Output.flush();
+        } else {
+            // Interactive: run the REPL loop
+            this.repl.runWithVM(vm) catch |err| {
+                Output.prettyErrorln("<r><red>REPL error: {s}<r>", .{@errorName(err)});
+            };
+        }
 
         // Clean up
         vm.onExit();

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -1183,6 +1183,106 @@ fn evaluateAndPrint(self: *Repl, code: []const u8) void {
     vm.tick();
 }
 
+/// Evaluate a script from `bun repl -e/--eval` or `-p/--print` non-interactively.
+/// Uses the REPL transform pipeline (TypeScript/JSX, top-level await, object literal
+/// wrapping, declaration hoisting), drains the event loop, optionally prints the
+/// result, and returns an exit code (0 on success, 1 on error).
+pub fn evalScript(self: *Repl, code: []const u8, print_result: bool) u8 {
+    const global = self.global orelse return 1;
+    const vm = self.vm orelse return 1;
+
+    self.use_colors = Output.enable_ansi_colors_stdout and !bun.env_var.NO_COLOR.get();
+
+    // Empty / whitespace-only script: nothing to do (matches `node -e ""`)
+    if (strings.trim(code, " \t\n\r").len == 0) {
+        if (print_result) {
+            if (self.use_colors) {
+                self.print("{s}undefined{s}\n", .{ Color.dim, Color.reset });
+            } else {
+                self.print("undefined\n", .{});
+            }
+        }
+        return 0;
+    }
+
+    const transformed_code = self.transformForRepl(code) orelse {
+        // Transform failed — fall back to raw evaluation for the error message
+        var exception: jsc.JSValue = .js_undefined;
+        _ = Bun__REPL__evaluate(global, code.ptr, code.len, "[eval]".ptr, "[eval]".len, &exception);
+        if (!exception.isUndefined() and !exception.isNull()) {
+            self.printJSError(exception);
+        }
+        return 1;
+    };
+    defer self.allocator.free(transformed_code);
+
+    var exception: jsc.JSValue = .js_undefined;
+    const result = Bun__REPL__evaluate(
+        global,
+        transformed_code.ptr,
+        transformed_code.len,
+        "[eval]".ptr,
+        "[eval]".len,
+        &exception,
+    );
+
+    if (!exception.isUndefined() and !exception.isNull()) {
+        self.printJSError(exception);
+        return 1;
+    }
+
+    // If the transform wrapped in an async IIFE (top-level await), wait for it
+    var resolved_result = result;
+    if (result.asPromise()) |promise| {
+        promise.setHandled();
+        vm.waitForPromise(.{ .normal = promise });
+        switch (promise.status()) {
+            .fulfilled => resolved_result = promise.result(vm.jsc_vm),
+            .rejected => {
+                const rejection = promise.result(vm.jsc_vm);
+                self.printJSError(rejection);
+                return 1;
+            },
+            .pending => return 1,
+        }
+    }
+
+    // Unwrap the { value: expr } wrapper produced by transformForRepl
+    var actual_result = resolved_result;
+    if (resolved_result.isObject()) {
+        const maybe_value = resolved_result.getOwn(global, "value") catch |err| {
+            const exc = global.takeException(err);
+            self.printJSError(exc);
+            return 1;
+        };
+        if (maybe_value) |value| actual_result = value;
+    }
+    // Protect across tick() in case of GC
+    if (!actual_result.isUndefined()) actual_result.protect();
+    defer if (!actual_result.isUndefined()) actual_result.unprotect();
+
+    // Drain the event loop (timers, I/O, etc.) before printing / exiting
+    vm.tick();
+    while (vm.isEventLoopAlive()) {
+        vm.tick();
+        vm.eventLoop().autoTickActive();
+    }
+
+    if (print_result) {
+        if (actual_result.isUndefined()) {
+            if (self.use_colors) {
+                self.print("{s}undefined{s}\n", .{ Color.dim, Color.reset });
+            } else {
+                self.print("undefined\n", .{});
+            }
+        } else {
+            self.printFormattedValue(actual_result);
+        }
+    }
+
+    return 0;
+}
+
 /// Evaluate code without REPL transforms (fallback for errors)
 /// The C++ Bun__REPL__evaluate handles setting _ and _error
 fn evaluateRaw(self: *Repl, code: []const u8) void {

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -493,7 +493,7 @@ const ReplCommand = struct {
     pub const all = [_]ReplCommand{
         .{ .name = ".help", .help = "Print this help message", .handler = cmdHelp },
         .{ .name = ".exit", .help = "Exit the REPL", .handler = cmdExit },
-        .{ .name = ".clear", .help = "Clear the REPL context and screen", .handler = cmdClear },
+        .{ .name = ".clear", .help = "Clear the screen", .handler = cmdClear },
         .{ .name = ".copy", .help = "Copy result to clipboard (.copy [expr])", .handler = cmdCopy },
         .{ .name = ".load", .help = "Load a file into the REPL session", .handler = cmdLoad },
         .{ .name = ".save", .help = "Save REPL history to a file", .handler = cmdSave },
@@ -535,7 +535,6 @@ fn cmdHelp(repl: *Repl, _: []const u8) ReplResult {
     repl.print("  {s}Ctrl+W{s}       Delete word backward\n", .{ Color.cyan, Color.reset });
     repl.print("  {s}Ctrl+D{s}       Delete character / Exit if line empty\n", .{ Color.cyan, Color.reset });
     repl.print("  {s}Ctrl+L{s}       Clear screen\n", .{ Color.cyan, Color.reset });
-    repl.print("  {s}Ctrl+R{s}       Reverse history search\n", .{ Color.cyan, Color.reset });
     repl.print("  {s}Ctrl+T{s}       Swap characters\n", .{ Color.cyan, Color.reset });
     repl.print("  {s}Up/Down{s}      Navigate history\n", .{ Color.cyan, Color.reset });
     repl.print("  {s}Tab{s}          Auto-complete\n", .{ Color.cyan, Color.reset });
@@ -1185,13 +1184,17 @@ fn evaluateAndPrint(self: *Repl, code: []const u8) void {
 
 /// Evaluate a script from `bun repl -e/--eval` or `-p/--print` non-interactively.
 /// Uses the REPL transform pipeline (TypeScript/JSX, top-level await, object literal
-/// wrapping, declaration hoisting), drains the event loop, optionally prints the
-/// result, and returns an exit code (0 on success, 1 on error).
-pub fn evalScript(self: *Repl, code: []const u8, print_result: bool) u8 {
-    const global = self.global orelse return 1;
-    const vm = self.vm orelse return 1;
+/// wrapping, declaration hoisting), drains the event loop, and optionally prints the
+/// result to stdout. Errors are written to stderr.
+/// Returns true if an error occurred (the caller should set exit_code=1 and
+/// skip onBeforeExit); false on success (caller preserves process.exitCode).
+pub fn evalScript(self: *Repl, code: []const u8, print_result: bool) bool {
+    const global = self.global orelse return true;
+    const vm = self.vm orelse return true;
 
-    self.use_colors = Output.enable_ansi_colors_stdout and !bun.env_var.NO_COLOR.get();
+    const no_color = bun.env_var.NO_COLOR.get();
+    self.use_colors = Output.enable_ansi_colors_stdout and !no_color;
+    const stderr_colors = Output.enable_ansi_colors_stderr and !no_color;
 
     // Empty / whitespace-only script: nothing to do (matches `node -e ""`)
     if (strings.trim(code, " \t\n\r").len == 0) {
@@ -1202,7 +1205,7 @@ pub fn evalScript(self: *Repl, code: []const u8, print_result: bool) u8 {
                 self.print("undefined\n", .{});
             }
         }
-        return 0;
+        return false;
     }
 
     const transformed_code = self.transformForRepl(code) orelse {
@@ -1210,9 +1213,9 @@ pub fn evalScript(self: *Repl, code: []const u8, print_result: bool) u8 {
         var exception: jsc.JSValue = .js_undefined;
         _ = Bun__REPL__evaluate(global, code.ptr, code.len, "[eval]".ptr, "[eval]".len, &exception);
         if (!exception.isUndefined() and !exception.isNull()) {
-            self.printJSError(exception);
+            self.printJSErrorTo(exception, Output.errorWriter(), stderr_colors);
         }
-        return 1;
+        return true;
     };
     defer self.allocator.free(transformed_code);
 
@@ -1227,8 +1230,8 @@ pub fn evalScript(self: *Repl, code: []const u8, print_result: bool) u8 {
     );
 
     if (!exception.isUndefined() and !exception.isNull()) {
-        self.printJSError(exception);
-        return 1;
+        self.printJSErrorTo(exception, Output.errorWriter(), stderr_colors);
+        return true;
     }
 
     // If the transform wrapped in an async IIFE (top-level await), wait for it
@@ -1240,10 +1243,10 @@ pub fn evalScript(self: *Repl, code: []const u8, print_result: bool) u8 {
             .fulfilled => resolved_result = promise.result(vm.jsc_vm),
             .rejected => {
                 const rejection = promise.result(vm.jsc_vm);
-                self.printJSError(rejection);
-                return 1;
+                self.printJSErrorTo(rejection, Output.errorWriter(), stderr_colors);
+                return true;
             },
-            .pending => return 1,
+            .pending => return true,
         }
     }
 
@@ -1252,8 +1255,8 @@ pub fn evalScript(self: *Repl, code: []const u8, print_result: bool) u8 {
     if (resolved_result.isObject()) {
         const maybe_value = resolved_result.getOwn(global, "value") catch |err| {
             const exc = global.takeException(err);
-            self.printJSError(exc);
-            return 1;
+            self.printJSErrorTo(exc, Output.errorWriter(), stderr_colors);
+            return true;
         };
         if (maybe_value) |value| actual_result = value;
     }
@@ -1280,7 +1283,7 @@ pub fn evalScript(self: *Repl, code: []const u8, print_result: bool) u8 {
         }
     }
 
-    return 0;
+    return false;
 }
 
 /// Evaluate code without REPL transforms (fallback for errors)
@@ -1596,11 +1599,15 @@ fn setReplVariables(self: *Repl) void {
 }
 
 fn printJSError(self: *Repl, error_value: jsc.JSValue) void {
+    // Interactive REPL writes everything to stdout (single terminal stream).
+    self.printJSErrorTo(error_value, Output.writer(), self.use_colors);
+}
+
+fn printJSErrorTo(self: *Repl, error_value: jsc.JSValue, writer: *std.Io.Writer, enable_colors: bool) void {
     const global = self.global orelse return;
-    const writer = Output.writer();
     // Use .Error level for proper error formatting with Bun.inspect
     jsc.ConsoleObject.format2(.Error, global, @ptrCast(&error_value), 1, writer, .{
-        .enable_colors = self.use_colors,
+        .enable_colors = enable_colors,
         .add_newline = true,
         .flush = false,
         .quote_strings = true,
@@ -1609,7 +1616,7 @@ fn printJSError(self: *Repl, error_value: jsc.JSValue) void {
     }) catch {
         // Formatting the error itself threw — clear it to avoid recursion and show a fallback.
         global.clearException();
-        self.printError("error: [failed to format error]\n", .{});
+        writer.writeAll("error: [failed to format error]\n") catch {};
     };
 }
 

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -761,6 +761,138 @@ describe.concurrent("Bun REPL", () => {
       expect(exitCode).toBe(0);
     });
   });
+
+  describe("-e / --eval and -p / --print", () => {
+    async function runReplWith(args: string[]) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "repl", ...args],
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...bunEnv, NO_COLOR: "1" },
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout: stripAnsi(stdout), stderr: stripAnsi(stderr), exitCode };
+    }
+
+    test("-e evaluates and exits without printing result", async () => {
+      const { stdout, exitCode } = await runReplWith(["-e", "1 + 1"]);
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(0);
+    });
+
+    test("-e does not show welcome message", async () => {
+      const { stdout, exitCode } = await runReplWith(["-e", "1 + 1"]);
+      expect(stdout).not.toContain("Welcome to Bun");
+      expect(exitCode).toBe(0);
+    });
+
+    test("-e console.log output is shown", async () => {
+      const { stdout, exitCode } = await runReplWith(["-e", "console.log('hello from eval')"]);
+      expect(stdout).toBe("hello from eval\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("--eval works like -e", async () => {
+      const { stdout, exitCode } = await runReplWith(["--eval", "console.log(2 + 2)"]);
+      expect(stdout).toBe("4\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("-p prints the result and exits", async () => {
+      const { stdout, exitCode } = await runReplWith(["-p", "1 + 1"]);
+      expect(stdout).toBe("2\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("--print works like -p", async () => {
+      const { stdout, exitCode } = await runReplWith(["--print", "2 * 3"]);
+      expect(stdout).toBe("6\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("-p prints undefined for void expressions", async () => {
+      const { stdout, exitCode } = await runReplWith(["-p", "void 0"]);
+      expect(stdout).toBe("undefined\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("-p with empty script prints undefined and exits", async () => {
+      const { stdout, exitCode } = await runReplWith(["-p", ""]);
+      expect(stdout).toBe("undefined\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("-e supports TypeScript", async () => {
+      const { stdout, exitCode } = await runReplWith(["-p", "const x: number = 42; x * 2"]);
+      expect(stdout).toBe("84\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("-e supports top-level await", async () => {
+      const { stdout, exitCode } = await runReplWith(["-p", "await Promise.resolve(123)"]);
+      expect(stdout).toBe("123\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("-p wraps object literals", async () => {
+      const { stdout, exitCode } = await runReplWith(["-p", "{ a: 1, b: 2 }"]);
+      expect(stdout).toContain("a");
+      expect(stdout).toContain("1");
+      expect(stdout).toContain("b");
+      expect(stdout).toContain("2");
+      expect(exitCode).toBe(0);
+    });
+
+    test("-e with thrown error exits with code 1", async () => {
+      const { stdout, stderr, exitCode } = await runReplWith(["-e", "throw new Error('boom')"]);
+      expect(stdout + stderr).toContain("boom");
+      expect(exitCode).toBe(1);
+    });
+
+    test("-e with syntax error exits with code 1", async () => {
+      const { stdout, stderr, exitCode } = await runReplWith(["-e", "const ="]);
+      expect((stdout + stderr).toLowerCase()).toContain("syntaxerror");
+      expect(exitCode).toBe(1);
+    });
+
+    test("-e with rejected top-level await exits with code 1", async () => {
+      const { stdout, stderr, exitCode } = await runReplWith(["-e", "await Promise.reject(new Error('async fail'))"]);
+      expect(stdout + stderr).toContain("async fail");
+      expect(exitCode).toBe(1);
+    });
+
+    test("-e drains event loop (timers fire before exit)", async () => {
+      const { stdout, exitCode } = await runReplWith(["-e", "setTimeout(() => console.log('from timer'), 50)"]);
+      expect(stdout).toBe("from timer\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("-p drains event loop before printing", async () => {
+      // Result should be printed after the timer output, since we drain
+      // the event loop before printing the final result.
+      const { stdout, exitCode } = await runReplWith(["-p", "setTimeout(() => console.log('timer'), 50); 'result'"]);
+      expect(stdout).toBe('timer\n"result"\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test("-e supports require()", async () => {
+      const { stdout, exitCode } = await runReplWith(["-p", "require('path').posix.join('/a', 'b')"]);
+      expect(stdout).toBe('"/a/b"\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test("-e supports import statements", async () => {
+      const { stdout, exitCode } = await runReplWith(["-e", "import path from 'path'; console.log(typeof path.join)"]);
+      expect(stdout).toBe("function\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("-e has access to __dirname and __filename", async () => {
+      const { stdout, exitCode } = await runReplWith(["-e", "console.log(typeof __dirname, typeof __filename)"]);
+      expect(stdout).toBe("string string\n");
+      expect(exitCode).toBe(0);
+    });
+  });
 });
 
 // Interactive terminal-based REPL tests

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -843,22 +843,39 @@ describe.concurrent("Bun REPL", () => {
       expect(exitCode).toBe(0);
     });
 
-    test("-e with thrown error exits with code 1", async () => {
+    test("-e with thrown error writes to stderr and exits with code 1", async () => {
       const { stdout, stderr, exitCode } = await runReplWith(["-e", "throw new Error('boom')"]);
-      expect(stdout + stderr).toContain("boom");
+      expect(stdout).toBe("");
+      expect(stderr).toContain("boom");
       expect(exitCode).toBe(1);
     });
 
-    test("-e with syntax error exits with code 1", async () => {
+    test("-e with syntax error writes to stderr and exits with code 1", async () => {
       const { stdout, stderr, exitCode } = await runReplWith(["-e", "const ="]);
-      expect((stdout + stderr).toLowerCase()).toContain("syntaxerror");
+      expect(stdout).toBe("");
+      expect(stderr.toLowerCase()).toContain("syntaxerror");
       expect(exitCode).toBe(1);
     });
 
-    test("-e with rejected top-level await exits with code 1", async () => {
+    test("-e with rejected top-level await writes to stderr and exits with code 1", async () => {
       const { stdout, stderr, exitCode } = await runReplWith(["-e", "await Promise.reject(new Error('async fail'))"]);
-      expect(stdout + stderr).toContain("async fail");
+      expect(stdout).toBe("");
+      expect(stderr).toContain("async fail");
       expect(exitCode).toBe(1);
+    });
+
+    test("-e preserves process.exitCode set by the script", async () => {
+      const { exitCode } = await runReplWith(["-e", "process.exitCode = 42"]);
+      expect(exitCode).toBe(42);
+    });
+
+    test("-e fires process.on('beforeExit')", async () => {
+      const { stdout, exitCode } = await runReplWith([
+        "-e",
+        "process.on('beforeExit', () => console.log('beforeExit fired'))",
+      ]);
+      expect(stdout).toBe("beforeExit fired\n");
+      expect(exitCode).toBe(0);
     });
 
     test("-e drains event loop (timers fire before exit)", async () => {


### PR DESCRIPTION
## Summary

- Adds `bun repl -e <script>` / `-p <script>` for non-interactive evaluation using REPL semantics (object literal wrapping, declaration hoisting), draining the event loop before exit. Returns exit code 1 on error.
- Adds `docs/runtime/repl.mdx` documenting the interactive REPL (commands, keybindings, special variables, top-level await, imports) and the new non-interactive mode.
- Updates bash/fish/zsh completions for the `repl` subcommand and its flags.

## Test plan

- [x] `bun bd test test/js/bun/repl/repl.test.ts` — all 103 tests pass (20 new)
- [x] `USE_SYSTEM_BUN=1 bun test` — new tests fail (validates they test new behavior)
- [x] `bun run zig:check-all` — compiles on all platforms
- [x] `bash -n` / `fish -n` / `zsh -n` syntax checks on completion files

🤖 Generated with [Claude Code](https://claude.com/claude-code)