### PR TITLE
fix(formdata): prevent silent truncation of files >= 4GB in req.formData()

### DIFF
--- a/src/url.zig
+++ b/src/url.zig
@@ -976,7 +976,9 @@ pub const FormData = struct {
     }
 
     pub const Field = struct {
-        value: bun.Semver.String = .{},
+        /// Raw slice into the input buffer. Not using `bun.Semver.String` because
+        /// file bodies can exceed 4 GB and Semver.String truncates to u32.
+        value: []const u8 = "",
         filename: bun.Semver.String = .{},
         content_type: bun.Semver.String = .{},
         is_file: bool = false,
@@ -1088,7 +1090,7 @@ pub const FormData = struct {
             form: *jsc.DOMFormData,
 
             pub fn onEntry(wrap: *@This(), name: bun.Semver.String, field: Field, buf: []const u8) void {
-                const value_str = field.value.slice(buf);
+                const value_str = field.value;
                 var key = jsc.ZigString.initUTF8(name.slice(buf));
 
                 if (field.is_file) {
@@ -1278,7 +1280,7 @@ pub const FormData = struct {
             if (strings.endsWithComptime(body, "\r\n")) {
                 body = body[0 .. body.len - 2];
             }
-            field.value = subslicer.sub(body).value();
+            field.value = body;
             field.filename = filename orelse .{};
             field.is_file = is_file;
 

--- a/test/regression/issue/27441.test.ts
+++ b/test/regression/issue/27441.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "bun:test";
+
+// Regression test for https://github.com/oven-sh/bun/issues/27441
+// req.formData() used bun.Semver.String (u32 length) for file body values,
+// which silently truncated files >= 4GB. The fix stores file body values as
+// native slices instead.
+//
+// We can't allocate 4GB+ in CI, but we verify the code path with a meaningful
+// payload size to ensure formData parsing preserves the full file body.
+
+test("formData() preserves file size for large uploads", async () => {
+  const FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+  const payload = Buffer.alloc(FILE_SIZE, 0x42);
+
+  using server = Bun.serve({
+    port: 0,
+    maxRequestBodySize: FILE_SIZE * 4,
+    async fetch(req) {
+      const formData = await req.formData();
+      const file = formData.get("file") as Blob;
+      return Response.json({
+        receivedSize: file?.size ?? 0,
+      });
+    },
+  });
+
+  const form = new FormData();
+  form.append("file", new Blob([payload]), "test.bin");
+
+  const res = await fetch(server.url, {
+    method: "POST",
+    body: form,
+  });
+  const { receivedSize } = (await res.json()) as { receivedSize: number };
+
+  expect(receivedSize).toBe(FILE_SIZE);
+});
+
+test("formData() file content is not corrupted", async () => {
+  // Verify content integrity, not just size
+  const content = "Hello, World! This is a test file for issue #27441.";
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const formData = await req.formData();
+      const file = formData.get("file") as Blob;
+      const text = await file.text();
+      return Response.json({
+        receivedSize: file?.size ?? 0,
+        content: text,
+      });
+    },
+  });
+
+  const form = new FormData();
+  form.append("file", new Blob([content]), "test.txt");
+
+  const res = await fetch(server.url, {
+    method: "POST",
+    body: form,
+  });
+  const json = (await res.json()) as { receivedSize: number; content: string };
+
+  expect(json.receivedSize).toBe(content.length);
+  expect(json.content).toBe(content);
+});
+
+test("formData() handles multiple files with correct sizes", async () => {
+  const sizes = [1024, 1024 * 100, 1024 * 1024]; // 1KB, 100KB, 1MB
+
+  using server = Bun.serve({
+    port: 0,
+    maxRequestBodySize: 1024 * 1024 * 10,
+    async fetch(req) {
+      const formData = await req.formData();
+      const results: number[] = [];
+      for (const size of sizes) {
+        const file = formData.get(`file_${size}`) as Blob;
+        results.push(file?.size ?? 0);
+      }
+      return Response.json({ receivedSizes: results });
+    },
+  });
+
+  const form = new FormData();
+  for (const size of sizes) {
+    form.append(`file_${size}`, new Blob([Buffer.alloc(size, 0x41)]), `test_${size}.bin`);
+  }
+
+  const res = await fetch(server.url, {
+    method: "POST",
+    body: form,
+  });
+  const { receivedSizes } = (await res.json()) as { receivedSizes: number[] };
+
+  expect(receivedSizes).toEqual(sizes);
+});


### PR DESCRIPTION
## Summary
- Fixed `req.formData()` silently truncating file data for uploads >= 4 GB
- The multipart parser's `Field.value` used `bun.Semver.String`, which stores lengths as `u32` — silently dropping high bits via `@truncate` for files exceeding 2^32 bytes
- Changed `Field.value` from `bun.Semver.String` to a native `[]const u8` slice, which supports the full address space

## Root Cause
The multipart form data parser in `src/url.zig` reused `bun.Semver.String` (designed for package manager semver strings) to store parsed field values. This type's internal `Pointer` struct uses `u32` for both offset and length, causing silent truncation at 4 GB boundaries via `@as(u32, @truncate(in.len))`.

## Test plan
- [x] Added regression test in `test/regression/issue/27441.test.ts`
- [x] Verified existing FormData tests pass (`test/js/web/html/FormData.test.ts` — 110/111 pass, 1 pre-existing timeout in debug build)
- [x] Verified fetch file upload tests pass (`test/js/bun/http/fetch-file-upload.test.ts`)
- [x] Verified fetch body tests pass (`test/js/web/fetch/body.test.ts`)

Closes #27441

🤖 Generated with [Claude Code](https://claude.com/claude-code)