### PR TITLE
fix(napi): allow structuredClone on napi_create_object results

### DIFF
--- a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
@@ -117,6 +117,7 @@
 #include "JSPrivateKeyObject.h"
 #include "CryptoKeyType.h"
 #include "JSNodePerformanceHooksHistogram.h"
+#include "../napi.h"
 #include <limits>
 #include <algorithm>
 
@@ -2665,7 +2666,9 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
             // objects have been handled. If we reach this point and
             // the input is not an Object object then we should throw
             // a DataCloneError.
-            if (inObject->classInfo() != JSFinalObject::info())
+            // NapiPrototype is allowed because napi_create_object should behave
+            // like a plain object from JS's perspective (matches Node.js).
+            if (inObject->classInfo() != JSFinalObject::info() && inObject->classInfo() != Zig::NapiPrototype::info())
                 return SerializationReturnCode::DataCloneError;
             inputObjectStack.append(inObject);
             indexStack.append(0);

--- a/test/napi/napi-app/js_test_helpers.cpp
+++ b/test/napi/napi-app/js_test_helpers.cpp
@@ -236,6 +236,13 @@ static napi_value make_empty_array(const Napi::CallbackInfo &info) {
   return array;
 }
 
+static napi_value make_empty_object(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value object;
+  NODE_API_CALL(env, napi_create_object(env, &object));
+  return object;
+}
+
 // add_tag(object, lower, upper)
 static napi_value add_tag(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
@@ -424,6 +431,7 @@ void register_js_test_helpers(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, throw_error);
   REGISTER_FUNCTION(env, exports, create_and_throw_error);
   REGISTER_FUNCTION(env, exports, make_empty_array);
+  REGISTER_FUNCTION(env, exports, make_empty_object);
   REGISTER_FUNCTION(env, exports, add_tag);
   REGISTER_FUNCTION(env, exports, try_add_tag);
   REGISTER_FUNCTION(env, exports, check_tag);

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -446,6 +446,22 @@ nativeTests.test_reflect_construct_no_prototype_crash = () => {
   console.log("✓ Success - no crash!");
 };
 
+nativeTests.test_napi_create_object_structured_clone = () => {
+  // https://github.com/oven-sh/bun/issues/25658
+  const obj = nativeTests.make_empty_object();
+  assert.deepStrictEqual(obj, {});
+  const cloned = structuredClone(obj);
+  assert.deepStrictEqual(cloned, {});
+
+  obj.foo = "bar";
+  obj.nested = { x: 1 };
+  const cloned2 = structuredClone(obj);
+  assert.deepStrictEqual(cloned2, { foo: "bar", nested: { x: 1 } });
+  assert(cloned2 !== obj);
+  assert(cloned2.nested !== obj.nested);
+  console.log("pass");
+};
+
 nativeTests.test_napi_wrap = () => {
   const values = [
     {},

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -426,6 +426,13 @@ describe.concurrent("napi", () => {
     });
   });
 
+  describe("napi_create_object", () => {
+    // https://github.com/oven-sh/bun/issues/25658
+    it("result is clonable with structuredClone", async () => {
+      await checkSameOutput("test_napi_create_object_structured_clone", []);
+    });
+  });
+
   // TODO(@190n) test allocating in a finalizer from a napi module with the right version
 
   describe("napi_wrap", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes #25658 — `structuredClone()` throwing `DataCloneError` on objects created via `napi_create_object`, which works in Node.js.

## Root cause

Bun's `napi_create_object` creates a `NapiPrototype` (a `JSDestructibleObject` subclass with an inline `napiRef` field for fast `napi_wrap`/`napi_unwrap`), not a plain `JSFinalObject`. 

WebKit's `SerializedScriptValue` serializer checks:
```cpp
if (inObject->classInfo() != JSFinalObject::info())
    return SerializationReturnCode::DataCloneError;
```

`NapiPrototype` has its own `ClassInfo`, so the check fails.

Node.js uses `v8::Object::New()` which creates a truly plain V8 object — V8's serializer clones it fine.

## Fix

Add `NapiPrototype::info()` to the serializer's allowlist. The inline `napiRef` C++ field is invisible to property enumeration (serializer uses `getOwnPropertyNames` with `PrivateSymbolMode::Exclude`), so cloned objects correctly contain only JS properties — matching Node.js, where `napi_unwrap` on a clone also fails.

## How did you verify your code works?

- Added `test_napi_create_object_structured_clone` using `checkSameOutput` which runs on both Node and Bun and asserts identical output
- Verified test **fails** with `USE_SYSTEM_BUN=1` (throws `DataCloneError`)
- Verified test **passes** with `bun bd test`
- Verified existing `test/js/web/workers/structured-clone.test.ts` still passes (118 tests)