### PR TITLE
build: compile windows shim for native arch on aarch64

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -98,7 +98,7 @@ const BunBuildOptions = struct {
 
     pub fn windowsShim(this: *BunBuildOptions, b: *Build) WindowsShim {
         return this.windows_shim orelse {
-            this.windows_shim = WindowsShim.create(b);
+            this.windows_shim = WindowsShim.create(b, this.arch);
             return this.windows_shim.?;
         };
     }
@@ -759,7 +759,6 @@ fn configureObj(b: *Build, opts: *BunBuildOptions, obj: *Compile) void {
 
     obj.no_link_obj = opts.os != .windows and !opts.no_llvm;
 
-
     if (opts.enable_asan and !enableFastBuild(b)) {
         if (@hasField(Build.Module, "sanitize_address")) {
             if (opts.enable_fuzzilli) {
@@ -986,10 +985,16 @@ const WindowsShim = struct {
     exe: *Compile,
     dbg: *Compile,
 
-    fn create(b: *Build) WindowsShim {
+    fn create(b: *Build, arch: Arch) WindowsShim {
         const target = b.resolveTargetQuery(.{
-            .cpu_model = .{ .explicit = &std.Target.x86.cpu.nehalem },
-            .cpu_arch = .x86_64,
+            .cpu_model = switch (arch) {
+                .aarch64 => .baseline,
+                else => .{ .explicit = &std.Target.x86.cpu.nehalem },
+            },
+            .cpu_arch = switch (arch) {
+                .aarch64 => .aarch64,
+                else => .x86_64,
+            },
             .os_tag = .windows,
             .os_version_min = getOSVersionMin(.windows),
         });

--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -228,16 +228,16 @@ To build for macOS x64:
 
 The order of the `--target` flag does not matter, as long as they're delimited by a `-`.
 
-| --target              | Operating System | Architecture | Modern | Baseline | Libc  |
-| --------------------- | ---------------- | ------------ | ------ | -------- | ----- |
-| bun-linux-x64         | Linux            | x64          | ✅     | ✅       | glibc |
-| bun-linux-arm64       | Linux            | arm64        | ✅     | N/A      | glibc |
-| bun-windows-x64       | Windows          | x64          | ✅     | ✅       | -     |
-| bun-windows-arm64     | Windows          | arm64        | ✅     | N/A      | -     |
-| bun-darwin-x64        | macOS            | x64          | ✅     | ✅       | -     |
-| bun-darwin-arm64      | macOS            | arm64        | ✅     | N/A      | -     |
-| bun-linux-x64-musl    | Linux            | x64          | ✅     | ✅       | musl  |
-| bun-linux-arm64-musl  | Linux            | arm64        | ✅     | N/A      | musl  |
+| --target             | Operating System | Architecture | Modern | Baseline | Libc  |
+| -------------------- | ---------------- | ------------ | ------ | -------- | ----- |
+| bun-linux-x64        | Linux            | x64          | ✅     | ✅       | glibc |
+| bun-linux-arm64      | Linux            | arm64        | ✅     | N/A      | glibc |
+| bun-windows-x64      | Windows          | x64          | ✅     | ✅       | -     |
+| bun-windows-arm64    | Windows          | arm64        | ✅     | N/A      | -     |
+| bun-darwin-x64       | macOS            | x64          | ✅     | ✅       | -     |
+| bun-darwin-arm64     | macOS            | arm64        | ✅     | N/A      | -     |
+| bun-linux-x64-musl   | Linux            | x64          | ✅     | ✅       | musl  |
+| bun-linux-arm64-musl | Linux            | arm64        | ✅     | N/A      | musl  |
 
 <Warning>
   On x64 platforms, Bun uses SIMD optimizations which require a modern CPU supporting AVX2 instructions. The `-baseline`


### PR DESCRIPTION
## What does this PR do?

The `bun_shim_impl.exe` used for `node_modules/.bin/*` on Windows was hardcoded to build for x86_64 (nehalem), even when building bun for Windows ARM64. This meant every package binary invocation on ARM64 ran under x64 emulation.

This PR makes `WindowsShim.create()` use the bun build's target arch — building a native aarch64 shim when building `bun.exe` for aarch64.

## Why is this safe?

The shim source (`src/install/windows-shim/bun_shim_impl.zig`) contains no arch-specific code:
- Uses only NTDLL (`NtCreateFile`, `NtReadFile`, `NtClose`, `RtlExitUserProcess`) and kernel32 (`CreateProcessW`, `WaitForSingleObject`, etc.)
- Uses `std.os.windows.teb()` which already has a native aarch64 implementation (`mov %[ptr], x18`)
- No inline assembly, no x86-specific intrinsics

Verified the ARM64 shim compiles cleanly to a 12.5KB PE32+ Aarch64 binary.

## How did you verify your code works?

- Built the ReleaseFast shim for `aarch64-windows` locally — compiles without errors
- CI will verify the embedded build path on Windows ARM64

Note: the `zig build windows-shim` standalone helper currently fails on Debug builds due to a pre-existing `fmtUtf16Le` format string issue — this is unrelated to this change (same error on x64) and does not affect the ReleaseFast shim that gets embedded into bun.exe.