### PR TITLE
fix: use WriteBarrierEarlyInit for WriteBarriers initialized before finishCreation

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -228,16 +228,16 @@ To build for macOS x64:
 
 The order of the `--target` flag does not matter, as long as they're delimited by a `-`.
 
-| --target              | Operating System | Architecture | Modern | Baseline | Libc  |
-| --------------------- | ---------------- | ------------ | ------ | -------- | ----- |
-| bun-linux-x64         | Linux            | x64          | ✅     | ✅       | glibc |
-| bun-linux-arm64       | Linux            | arm64        | ✅     | N/A      | glibc |
-| bun-windows-x64       | Windows          | x64          | ✅     | ✅       | -     |
-| bun-windows-arm64     | Windows          | arm64        | ✅     | N/A      | -     |
-| bun-darwin-x64        | macOS            | x64          | ✅     | ✅       | -     |
-| bun-darwin-arm64      | macOS            | arm64        | ✅     | N/A      | -     |
-| bun-linux-x64-musl    | Linux            | x64          | ✅     | ✅       | musl  |
-| bun-linux-arm64-musl  | Linux            | arm64        | ✅     | N/A      | musl  |
+| --target             | Operating System | Architecture | Modern | Baseline | Libc  |
+| -------------------- | ---------------- | ------------ | ------ | -------- | ----- |
+| bun-linux-x64        | Linux            | x64          | ✅     | ✅       | glibc |
+| bun-linux-arm64      | Linux            | arm64        | ✅     | N/A      | glibc |
+| bun-windows-x64      | Windows          | x64          | ✅     | ✅       | -     |
+| bun-windows-arm64    | Windows          | arm64        | ✅     | N/A      | -     |
+| bun-darwin-x64       | macOS            | x64          | ✅     | ✅       | -     |
+| bun-darwin-arm64     | macOS            | arm64        | ✅     | N/A      | -     |
+| bun-linux-x64-musl   | Linux            | x64          | ✅     | ✅       | musl  |
+| bun-linux-arm64-musl | Linux            | arm64        | ✅     | N/A      | musl  |
 
 <Warning>
   On x64 platforms, Bun uses SIMD optimizations which require a modern CPU supporting AVX2 instructions. The `-baseline`

--- a/src/bun.js/bindings/NodeVMModule.cpp
+++ b/src/bun.js/bindings/NodeVMModule.cpp
@@ -154,7 +154,7 @@ NodeVMModule::NodeVMModule(JSC::VM& vm, JSC::Structure* structure, WTF::String i
     : Base(vm, structure)
     , m_identifier(WTF::move(identifier))
     , m_context(context && context.isObject() ? asObject(context) : nullptr, JSC::WriteBarrierEarlyInit)
-    , m_moduleWrapper(vm, this, moduleWrapper)
+    , m_moduleWrapper(moduleWrapper, JSC::WriteBarrierEarlyInit)
 {
 }
 

--- a/src/bun.js/bindings/NodeVMSyntheticModule.h
+++ b/src/bun.js/bindings/NodeVMSyntheticModule.h
@@ -54,7 +54,7 @@ private:
     NodeVMSyntheticModule(JSC::VM& vm, JSC::Structure* structure, WTF::String identifier, JSValue context, JSValue moduleWrapper, WTF::HashSet<String> exportNames, JSValue syntheticEvaluationSteps)
         : Base(vm, structure, WTF::move(identifier), context, moduleWrapper)
         , m_exportNames(WTF::move(exportNames))
-        , m_syntheticEvaluationSteps(vm, this, syntheticEvaluationSteps)
+        , m_syntheticEvaluationSteps(syntheticEvaluationSteps, JSC::WriteBarrierEarlyInit)
     {
     }
 


### PR DESCRIPTION
## Summary

Fix a latent GC safety issue in `NodeVMModule` and `NodeVMSyntheticModule` where `WriteBarrier` fields were initialized with the regular constructor before `finishCreation()` was called on the cell.

## Problem

The regular `WriteBarrier(vm, owner, value)` constructor calls `vm.writeBarrier(owner, value)`, which assumes the owner cell is already fully constructed and markable by the GC. However, in C++ member initializer lists, `finishCreation()` has not been called yet, so the cell is not in a valid state for the GC to process.

Two fields were affected:
- `NodeVMModule::m_moduleWrapper` (`NodeVMModule.cpp:157`)
- `NodeVMSyntheticModule::m_syntheticEvaluationSteps` (`NodeVMSyntheticModule.h:57`)

If a GC cycle happens to run during construction (between the member initializer list and `finishCreation()`), this could lead to a crash. The bug is timing-dependent and difficult to reproduce, but the code is clearly incorrect.

## Fix

Use `WriteBarrierEarlyInit` instead, which stores the pointer without issuing a write barrier. This is the standard JSC pattern — used extensively in upstream WebKit (`JSObject`, `Structure`, `CodeBlock`, `JSBoundFunction`, `JSPromiseReaction`, etc.) and already used by the adjacent `m_context` field in the same constructor.