### PR TITLE
fix(bundler): use absolute asset URLs in HTML for `--compile` mode

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -219,9 +219,10 @@ pub const BundleV2 = struct {
             client_transpiler.options.chunk_naming = bun.options.PathTemplate.chunk.data;
             client_transpiler.options.entry_naming = "./[name]-[hash].[ext]";
 
-            // Avoid setting a public path for --compile since all the assets
-            // will be served relative to the server root.
-            client_transpiler.options.public_path = "";
+            // Use "/" so that asset URLs in HTML are absolute (e.g. "/chunk-abc.js"
+            // instead of "./chunk-abc.js"). Relative paths break when the HTML is
+            // served from a nested route like "/foo/".
+            client_transpiler.options.public_path = "/";
         }
 
         client_transpiler.setLog(this_transpiler.log);

--- a/test/regression/issue/27465.test.ts
+++ b/test/regression/issue/27465.test.ts
@@ -1,0 +1,71 @@
+import { describe } from "bun:test";
+import { itBundled } from "../../bundler/expectBundled";
+
+describe("bundler", () => {
+  // Test that `bun build --compile` produces absolute asset URLs in HTML,
+  // so that assets load correctly when served from nested routes like "/foo/".
+  // Regression test for https://github.com/oven-sh/bun/issues/27465
+  for (const backend of ["api", "cli"] as const) {
+    itBundled(`compile/${backend}/HTMLNestedRouteAssetURLs`, {
+      compile: true,
+      backend: backend,
+      files: {
+        "/entry.ts": /* js */ `
+          import { serve } from "bun";
+          import index from "./index.html";
+
+          const server = serve({
+            port: 0,
+            routes: {
+              "/foo/": index,
+              "/foo/*": index,
+            },
+          });
+
+          const res = await fetch(server.url + "foo/");
+          const html = await res.text();
+
+          const srcMatch = html.match(/src="([^"]+)"/);
+          if (!srcMatch) {
+            console.log("ERROR: no src attribute found in HTML");
+            server.stop(true);
+            process.exit(1);
+          }
+          const src = srcMatch[1];
+          if (src.startsWith("./")) {
+            console.log("FAIL: relative URL " + src);
+            server.stop(true);
+            process.exit(1);
+          }
+
+          // Asset URLs should be absolute (start with "/")
+          const assetRes = await fetch(server.url + src.slice(1));
+          if (!assetRes.ok) {
+            console.log("FAIL: asset not accessible at " + src);
+            server.stop(true);
+            process.exit(1);
+          }
+
+          console.log("Asset URL is absolute: " + src);
+          server.stop(true);
+        `,
+        "/index.html": /* html */ `
+          <!DOCTYPE html>
+          <html>
+            <head><title>Test</title></head>
+            <body>
+              <h1>Hello</h1>
+              <script src="./app.ts"></script>
+            </body>
+          </html>
+        `,
+        "/app.ts": /* js */ `
+          console.log("client loaded");
+        `,
+      },
+      run: {
+        stdout: /Asset URL is absolute: \/.+/,
+      },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- When `bun build --compile` bundles HTML with JS/CSS assets, the client transpiler's `public_path` was set to `""` (empty), which caused `cheapPrefixNormalizer` to produce relative URLs like `./chunk-abc.js`
- These relative URLs break when HTML is served from nested routes (e.g. `/foo/`) because the browser resolves them relative to the current path (producing `/foo/chunk-abc.js` instead of `/chunk-abc.js`)
- Changed the client transpiler's `public_path` from `""` to `"/"` so assets use absolute root-relative URLs like `/chunk-abc.js`

Closes #27465

## Test plan
- [ ] Regression test in `test/regression/issue/27465.test.ts` verifies compiled HTML serves assets with absolute URLs from nested routes
- [ ] Existing `test/bundler/bundler_html.test.ts` tests pass (21/21)
- [ ] Existing `test/bundler/html-import-manifest.test.ts` tests pass (3/3)
- [ ] Regular `bun build` (without `--compile`) still uses relative `./` paths as expected for static file serving
- [ ] Dev mode (`bun run`) continues to use `/_bun/client/` absolute paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)