### PR TITLE
fix(secrets): preserve keychain ACL when updating existing entries

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -228,16 +228,16 @@ To build for macOS x64:
 
 The order of the `--target` flag does not matter, as long as they're delimited by a `-`.
 
-| --target              | Operating System | Architecture | Modern | Baseline | Libc  |
-| --------------------- | ---------------- | ------------ | ------ | -------- | ----- |
-| bun-linux-x64         | Linux            | x64          | ✅     | ✅       | glibc |
-| bun-linux-arm64       | Linux            | arm64        | ✅     | N/A      | glibc |
-| bun-windows-x64       | Windows          | x64          | ✅     | ✅       | -     |
-| bun-windows-arm64     | Windows          | arm64        | ✅     | N/A      | -     |
-| bun-darwin-x64        | macOS            | x64          | ✅     | ✅       | -     |
-| bun-darwin-arm64      | macOS            | arm64        | ✅     | N/A      | -     |
-| bun-linux-x64-musl    | Linux            | x64          | ✅     | ✅       | musl  |
-| bun-linux-arm64-musl  | Linux            | arm64        | ✅     | N/A      | musl  |
+| --target             | Operating System | Architecture | Modern | Baseline | Libc  |
+| -------------------- | ---------------- | ------------ | ------ | -------- | ----- |
+| bun-linux-x64        | Linux            | x64          | ✅     | ✅       | glibc |
+| bun-linux-arm64      | Linux            | arm64        | ✅     | N/A      | glibc |
+| bun-windows-x64      | Windows          | x64          | ✅     | ✅       | -     |
+| bun-windows-arm64    | Windows          | arm64        | ✅     | N/A      | -     |
+| bun-darwin-x64       | macOS            | x64          | ✅     | ✅       | -     |
+| bun-darwin-arm64     | macOS            | arm64        | ✅     | N/A      | -     |
+| bun-linux-x64-musl   | Linux            | x64          | ✅     | ✅       | musl  |
+| bun-linux-arm64-musl | Linux            | arm64        | ✅     | N/A      | musl  |
 
 <Warning>
   On x64 platforms, Bun uses SIMD optimizations which require a modern CPU supporting AVX2 instructions. The `-baseline`

--- a/src/bun.js/bindings/SecretsDarwin.cpp
+++ b/src/bun.js/bindings/SecretsDarwin.cpp
@@ -364,13 +364,25 @@ Error setPassword(const CString& service, const CString& name, CString&& passwor
 
     OSStatus status = framework->SecItemAdd((CFDictionaryRef)query.get(), NULL);
 
-    // Clean up accessRef if it was created
+    // Clean up accessRef if it was created (only needed for the initial add)
     if (accessRef) {
         framework->CFRelease(accessRef);
     }
 
     if (status == errSecDuplicateItem) {
-        // Password exists -- update it
+        // Password already exists — update only the value.
+        // We must use a fresh search query here. The add-query has been
+        // polluted with kSecValueData (and possibly kSecAttrAccess), which
+        // are not search attributes. Passing them to SecItemUpdate's search
+        // dict causes macOS to reset the item's ACL, so subsequent reads
+        // trigger a new Keychain prompt even if the user chose "Always Allow".
+        ScopedCFRef searchQuery = createQuery(service, name);
+        if (!searchQuery) {
+            err.type = ErrorType::PlatformError;
+            err.message = "Failed to create search query for update"_s;
+            return err;
+        }
+
         ScopedCFRef attributesToUpdate(framework->CFDictionaryCreateMutable(
             framework->kCFAllocatorDefault, 0,
             framework->kCFTypeDictionaryKeyCallBacks,
@@ -384,7 +396,8 @@ Error setPassword(const CString& service, const CString& name, CString&& passwor
 
         framework->CFDictionaryAddValue((CFMutableDictionaryRef)attributesToUpdate.get(),
             framework->kSecValueData, cfPassword.get());
-        status = framework->SecItemUpdate((CFDictionaryRef)query.get(),
+
+        status = framework->SecItemUpdate((CFDictionaryRef)searchQuery.get(),
             (CFDictionaryRef)attributesToUpdate.get());
     }
 

--- a/test/js/bun/secrets.test.ts
+++ b/test/js/bun/secrets.test.ts
@@ -273,7 +273,7 @@ test.todoIf(isCI && !isWindows)("Bun.secrets handles unicode", async () => {
   await Bun.secrets.delete({ service: testService, name: testUser });
 });
 
-test.todoIf(isCI && !isWindows)("Bun.secrets update preserves access after repeated updates", async () => {
+test.todoIf(!isMacOS)("Bun.secrets update preserves access after repeated updates", async () => {
   const testService = "bun-test-acl-update-" + Date.now();
   const testUser = "test-acl-user";
 

--- a/test/js/bun/secrets.test.ts
+++ b/test/js/bun/secrets.test.ts
@@ -273,6 +273,41 @@ test.todoIf(isCI && !isWindows)("Bun.secrets handles unicode", async () => {
   await Bun.secrets.delete({ service: testService, name: testUser });
 });
 
+test.todoIf(isCI && !isWindows)("Bun.secrets update preserves access after repeated updates", async () => {
+  const testService = "bun-test-acl-update-" + Date.now();
+  const testUser = "test-acl-user";
+
+  // Create a credential
+  await Bun.secrets.set({
+    service: testService,
+    name: testUser,
+    value: "initial-value",
+    ...(shouldUseUnrestrictedAccess() && { allowUnrestrictedAccess: true }),
+  });
+  expect(await Bun.secrets.get({ service: testService, name: testUser })).toBe("initial-value");
+
+  // Perform multiple updates in sequence - this exercises the SecItemUpdate path
+  // repeatedly. Before the fix, each update could corrupt the ACL, causing
+  // subsequent reads to trigger a Keychain prompt.
+  for (let i = 0; i < 5; i++) {
+    const value = `updated-value-${i}`;
+    await Bun.secrets.set({
+      service: testService,
+      name: testUser,
+      value,
+      ...(shouldUseUnrestrictedAccess() && { allowUnrestrictedAccess: true }),
+    });
+    const retrieved = await Bun.secrets.get({ service: testService, name: testUser });
+    expect(retrieved).toBe(value);
+  }
+
+  // Verify the final value is accessible
+  expect(await Bun.secrets.get({ service: testService, name: testUser })).toBe("updated-value-4");
+
+  // Clean up
+  await Bun.secrets.delete({ service: testService, name: testUser });
+});
+
 test.todoIf(isCI && !isWindows)("Bun.secrets handles concurrent operations", async () => {
   const promises: Promise<void>[] = [];
   const count = 10;


### PR DESCRIPTION
### What does this PR do?

Fixes macOS Keychain ACL corruption when updating existing secrets via Bun.secrets.set(). Previously, the SecItemUpdate call reused the dictionary that was built for SecItemAdd, which contained non-search attributes (kSecValueData and kSecAttrAccess). Passing these in the search dictionary caused macOS to reset the item's ACL, triggering additional Keychain prompts on subsequent access, even if the user had previously chosen "Always Allow." This change creates a fresh, clean search query containing only kSecClass, kSecAttrService, and kSecAttrAccount for the update path.

### How did you verify your code works?

All existing Bun.secrets tests pass. Added a new test ("Bun.secrets update preserves access after repeated updates") that creates a credential and then performs 5 sequential updates, verifying each subsequent read succeeds without error. Ran the full test suite with bun bd test test/js/bun/secrets.test.ts
7 tests, 0 failures.