### PR TITLE
fix(archive): support non-ASCII UTF-8 filenames in Bun.Archive

### DIFF
--- a/src/bun.js/api/Archive.zig
+++ b/src/bun.js/api/Archive.zig
@@ -236,7 +236,10 @@ fn buildTarballFromObject(globalThis: *jsc.JSGlobalObject, obj: jsc.JSValue) bun
         // Write entry to archive
         const data = data_slice.slice();
         _ = entry.clear();
-        entry.setPathname(key_str);
+        if (comptime bun.Environment.isWindows)
+            entry.setPathnameUtf8(key_str)
+        else
+            entry.setPathname(key_str);
         entry.setSize(@intCast(data.len));
         entry.setFiletype(@intFromEnum(lib.FileType.regular));
         entry.setPerm(0o644);
@@ -822,7 +825,16 @@ const FilesContext = struct {
         while (archive.readNextHeader(&entry) == .ok) {
             if (entry.filetype() != @intFromEnum(lib.FileType.regular)) continue;
 
-            const pathname = entry.pathname();
+            const pathname: [:0]const u8 = if (comptime bun.Environment.isWindows) blk: {
+                const pathname_w = entry.pathnameW();
+                var list = bun.handleOom(bun.strings.toUTF8ListWithType(
+                    std.array_list.Managed(u8).init(bun.default_allocator),
+                    pathname_w,
+                ));
+                defer list.deinit();
+                break :blk bun.handleOom(bun.default_allocator.dupeZ(u8, list.items));
+            } else entry.pathname();
+            defer if (comptime bun.Environment.isWindows) bun.default_allocator.free(pathname);
             // Apply glob pattern filtering (supports both positive and negative patterns)
             if (this.glob_patterns) |patterns| {
                 if (!matchGlobPatterns(patterns, pathname)) continue;
@@ -1026,7 +1038,16 @@ fn extractToDiskFiltered(
     var entry: *lib.Archive.Entry = undefined;
 
     while (archive.readNextHeader(&entry) == .ok) {
-        const pathname = entry.pathname();
+        const pathname: [:0]const u8 = if (comptime bun.Environment.isWindows) blk: {
+            const pathname_w = entry.pathnameW();
+            var list = bun.handleOom(bun.strings.toUTF8ListWithType(
+                std.array_list.Managed(u8).init(bun.default_allocator),
+                pathname_w,
+            ));
+            defer list.deinit();
+            break :blk bun.handleOom(bun.default_allocator.dupeZ(u8, list.items));
+        } else entry.pathname();
+        defer if (comptime bun.Environment.isWindows) bun.default_allocator.free(pathname);
 
         // Validate path safety (reject absolute paths, path traversal)
         if (!isSafePath(pathname)) continue;

--- a/src/bun.js/api/Archive.zig
+++ b/src/bun.js/api/Archive.zig
@@ -187,6 +187,13 @@ fn buildTarballFromObject(globalThis: *jsc.JSGlobalObject, obj: jsc.JSValue) bun
         return globalThis.throwInvalidArguments("Failed to create tarball: ArchiveFormatError", .{});
     }
 
+    // Disable charset conversion so non-ASCII UTF-8 filenames work without
+    // iconv (which is not enabled in this build). BINARY mode stores bytes
+    // as-is, which is correct since our filenames are already valid UTF-8.
+    if (archive.writeSetOptions("hdrcharset=BINARY") != .ok) {
+        return globalThis.throwInvalidArguments("Failed to create tarball: ArchiveOptionError", .{});
+    }
+
     if (lib.archive_write_open2(
         @ptrCast(archive),
         @ptrCast(&growing_buffer),
@@ -229,7 +236,7 @@ fn buildTarballFromObject(globalThis: *jsc.JSGlobalObject, obj: jsc.JSValue) bun
         // Write entry to archive
         const data = data_slice.slice();
         _ = entry.clear();
-        entry.setPathnameUtf8(key_str);
+        entry.setPathname(key_str);
         entry.setSize(@intCast(data.len));
         entry.setFiletype(@intFromEnum(lib.FileType.regular));
         entry.setPerm(0o644);
@@ -815,7 +822,7 @@ const FilesContext = struct {
         while (archive.readNextHeader(&entry) == .ok) {
             if (entry.filetype() != @intFromEnum(lib.FileType.regular)) continue;
 
-            const pathname = entry.pathnameUtf8();
+            const pathname = entry.pathname();
             // Apply glob pattern filtering (supports both positive and negative patterns)
             if (this.glob_patterns) |patterns| {
                 if (!matchGlobPatterns(patterns, pathname)) continue;
@@ -1019,7 +1026,7 @@ fn extractToDiskFiltered(
     var entry: *lib.Archive.Entry = undefined;
 
     while (archive.readNextHeader(&entry) == .ok) {
-        const pathname = entry.pathnameUtf8();
+        const pathname = entry.pathname();
 
         // Validate path safety (reject absolute paths, path traversal)
         if (!isSafePath(pathname)) continue;

--- a/src/bun.js/api/Archive.zig
+++ b/src/bun.js/api/Archive.zig
@@ -184,14 +184,14 @@ fn buildTarballFromObject(globalThis: *jsc.JSGlobalObject, obj: jsc.JSValue) bun
     defer _ = archive.writeFree();
 
     if (archive.writeSetFormatPaxRestricted() != .ok) {
-        return globalThis.throwInvalidArguments("Failed to create tarball: ArchiveFormatError", .{});
+        return globalThis.throwInvalidArguments("Failed to create tarball: ArchiveFormatError: {s}", .{archive.errorString()});
     }
 
     // Disable charset conversion so non-ASCII UTF-8 filenames work without
     // iconv (which is not enabled in this build). BINARY mode stores bytes
     // as-is, which is correct since our filenames are already valid UTF-8.
     if (archive.writeSetOptions("hdrcharset=BINARY") != .ok) {
-        return globalThis.throwInvalidArguments("Failed to create tarball: ArchiveOptionError", .{});
+        return globalThis.throwInvalidArguments("Failed to create tarball: ArchiveOptionError: {s}", .{archive.errorString()});
     }
 
     if (lib.archive_write_open2(
@@ -202,7 +202,7 @@ fn buildTarballFromObject(globalThis: *jsc.JSGlobalObject, obj: jsc.JSValue) bun
         &lib.GrowingBuffer.closeCallback,
         null,
     ) != 0) {
-        return globalThis.throwInvalidArguments("Failed to create tarball: ArchiveOpenError", .{});
+        return globalThis.throwInvalidArguments("Failed to create tarball: ArchiveOpenError: {s}", .{archive.errorString()});
     }
 
     const entry = lib.Archive.Entry.new();
@@ -243,18 +243,18 @@ fn buildTarballFromObject(globalThis: *jsc.JSGlobalObject, obj: jsc.JSValue) bun
         entry.setMtime(now_secs, 0);
 
         if (archive.writeHeader(entry) != .ok) {
-            return globalThis.throwInvalidArguments("Failed to create tarball: ArchiveHeaderError", .{});
+            return globalThis.throwInvalidArguments("Failed to create tarball: ArchiveHeaderError: {s}", .{archive.errorString()});
         }
         if (archive.writeData(data) < 0) {
-            return globalThis.throwInvalidArguments("Failed to create tarball: ArchiveWriteError", .{});
+            return globalThis.throwInvalidArguments("Failed to create tarball: ArchiveWriteError: {s}", .{archive.errorString()});
         }
         if (archive.writeFinishEntry() != .ok) {
-            return globalThis.throwInvalidArguments("Failed to create tarball: ArchiveFinishEntryError", .{});
+            return globalThis.throwInvalidArguments("Failed to create tarball: ArchiveFinishEntryError: {s}", .{archive.errorString()});
         }
     }
 
     if (archive.writeClose() != .ok) {
-        return globalThis.throwInvalidArguments("Failed to create tarball: ArchiveCloseError", .{});
+        return globalThis.throwInvalidArguments("Failed to create tarball: ArchiveCloseError: {s}", .{archive.errorString()});
     }
 
     return growing_buffer.toOwnedSlice() catch {

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -1111,8 +1111,14 @@ describe("Bun.Archive", () => {
         { compress: "gzip" },
       );
 
+      // Produce actual gzip-compressed bytes via bytes()
+      const gzipBytes = await archive.bytes();
+
+      // Feed gzip bytes into a new Archive so extract() exercises the gzip decoder
+      const archive2 = new Bun.Archive(gzipBytes);
+
       using dir = tempDir("archive-gzip-unicode", {});
-      await archive.extract(String(dir));
+      await archive2.extract(String(dir));
 
       expect(await Bun.file(join(String(dir), "package/Søreng.json")).text()).toBe('{"ok": true}');
       expect(await Bun.file(join(String(dir), "package/données.txt")).text()).toBe("french data");

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -1019,6 +1019,104 @@ describe("Bun.Archive", () => {
       const content = await Bun.file(join(String(dir), "unicode.txt")).text();
       expect(content).toBe("Hello, 世界! Привет! Γειά σου!");
     });
+
+    test("handles non-ASCII Norwegian characters in filenames", async () => {
+      const archive = new Bun.Archive({
+        "package/Søreng.json": '{"ok": true}',
+        "package/blåbær.txt": "blueberry",
+        "package/ærlig.txt": "honest",
+      });
+
+      using dir = tempDir("archive-norwegian", {});
+      await archive.extract(String(dir));
+
+      expect(await Bun.file(join(String(dir), "package/Søreng.json")).text()).toBe('{"ok": true}');
+      expect(await Bun.file(join(String(dir), "package/blåbær.txt")).text()).toBe("blueberry");
+      expect(await Bun.file(join(String(dir), "package/ærlig.txt")).text()).toBe("honest");
+    });
+
+    test("handles non-ASCII Polish characters in filenames", async () => {
+      const archive = new Bun.Archive({
+        "zażółć.txt": "zażółć gęślą jaźń",
+        "gęślą.txt": "polish diacritics",
+        "jaźń.txt": "more polish",
+      });
+
+      using dir = tempDir("archive-polish", {});
+      await archive.extract(String(dir));
+
+      expect(await Bun.file(join(String(dir), "zażółć.txt")).text()).toBe("zażółć gęślą jaźń");
+      expect(await Bun.file(join(String(dir), "gęślą.txt")).text()).toBe("polish diacritics");
+      expect(await Bun.file(join(String(dir), "jaźń.txt")).text()).toBe("more polish");
+    });
+
+    test("handles non-ASCII CJK characters in filenames", async () => {
+      const archive = new Bun.Archive({
+        "日本語.txt": "Japanese",
+        "中文.txt": "Chinese",
+        "한국어.txt": "Korean",
+      });
+
+      using dir = tempDir("archive-cjk", {});
+      await archive.extract(String(dir));
+
+      expect(await Bun.file(join(String(dir), "日本語.txt")).text()).toBe("Japanese");
+      expect(await Bun.file(join(String(dir), "中文.txt")).text()).toBe("Chinese");
+      expect(await Bun.file(join(String(dir), "한국어.txt")).text()).toBe("Korean");
+    });
+
+    test("handles mixed ASCII and non-ASCII filenames in same archive", async () => {
+      const archive = new Bun.Archive({
+        "readme.txt": "hello",
+        "données.json": '{"data": 1}',
+        "config.yaml": "key: value",
+        "ñoño.txt": "spanish",
+      });
+
+      using dir = tempDir("archive-mixed", {});
+      await archive.extract(String(dir));
+
+      expect(await Bun.file(join(String(dir), "readme.txt")).text()).toBe("hello");
+      expect(await Bun.file(join(String(dir), "données.json")).text()).toBe('{"data": 1}');
+      expect(await Bun.file(join(String(dir), "config.yaml")).text()).toBe("key: value");
+      expect(await Bun.file(join(String(dir), "ñoño.txt")).text()).toBe("spanish");
+    });
+
+    test("non-ASCII filenames round-trip through bytes() and back", async () => {
+      const original = {
+        "Søreng.json": '{"ok": true}',
+        "日本語.txt": "Japanese",
+        "données.json": '{"data": 1}',
+      };
+
+      const archive1 = new Bun.Archive(original);
+      const bytes = await archive1.bytes();
+
+      const archive2 = new Bun.Archive(bytes);
+      const files = await archive2.files();
+
+      for (const [name, content] of Object.entries(original)) {
+        const file = files.get(name);
+        expect(file).toBeDefined();
+        expect(await file!.text()).toBe(content);
+      }
+    });
+
+    test("gzip-compressed archive with non-ASCII filenames", async () => {
+      const archive = new Bun.Archive(
+        {
+          "package/Søreng.json": '{"ok": true}',
+          "package/données.txt": "french data",
+        },
+        { compress: "gzip" },
+      );
+
+      using dir = tempDir("archive-gzip-unicode", {});
+      await archive.extract(String(dir));
+
+      expect(await Bun.file(join(String(dir), "package/Søreng.json")).text()).toBe('{"ok": true}');
+      expect(await Bun.file(join(String(dir), "package/données.txt")).text()).toBe("french data");
+    });
   });
 
   describe("archive.files()", () => {


### PR DESCRIPTION
Fixes #28012

## What does this PR do?

Fixes `Bun.Archive` failing with `ArchiveHeaderError` when filenames contain non-ASCII UTF-8 characters (e.g., Norwegian ø, æ, å; Polish ż, ó, ł; CJK characters).

### Root cause

Bun builds libarchive with `ENABLE_ICONV=OFF`. The `setPathnameUtf8` / `pathnameUtf8` functions internally call `archive_entry_set_pathname_utf8` / `archive_entry_pathname_utf8`, which rely on iconv for charset conversion. Without iconv, non-ASCII characters are silently lost, and `archive_write_header` returns an error.

### Fix

**Commit 1** — `fix(archive): support non-ASCII UTF-8 filenames in Bun.Archive`
- Sets `hdrcharset=BINARY` on the PAX restricted writer to disable charset conversion entirely — bytes are stored as-is, which is correct since our filenames are already valid UTF-8 from JavaScript.
- Switches from `setPathnameUtf8` → `setPathname` and `pathnameUtf8()` → `pathname()` so libarchive doesn't attempt any charset conversion on read or write.

This matches the approach used in `pack_command.zig`, which already uses the non-UTF-8 variant on non-Windows platforms.

**Commit 2** — `refactor(archive): include error details in tarball creation error messages`
Adds `archive.errorString()` to all error messages in `buildTarballFromObject` for better debuggability when archive operations fail.

## How did you verify your code works?

6 new tests in `test/js/bun/archive.test.ts`:

- Norwegian characters (ø, æ, å) in filenames
- Polish characters (ż, ó, ł, ś, ć, ź, ń) in filenames
- CJK characters (Japanese, Chinese, Korean) in filenames
- Mixed ASCII and non-ASCII filenames in the same archive
- Round-trip through `bytes()` and back
- Gzip-compressed archive with non-ASCII filenames

```sh
bun bd test test/js/bun/archive.test.ts
# 105 pass, 0 fail
```