### PR TITLE
fix(bmalloc): add backoff to SYSCALL macro and remove MADV_DONTDUMP

### DIFF
--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -299,28 +299,49 @@ if(EXISTS ${BSYSCALL_H})
     } \\
 } while (0);"
     BSYSCALL_CONTENT "${BSYSCALL_CONTENT}")
+  string(FIND "${BSYSCALL_CONTENT}" "BSYSCALL_MAX_RETRIES" BSYSCALL_PATCH_APPLIED)
+  if(BSYSCALL_PATCH_APPLIED EQUAL -1)
+    message(WARNING "BSyscall.h patch did not apply - header may have changed in new WebKit version")
+  else()
+    message(STATUS "Patched BSyscall.h: SYSCALL macro backoff")
+  endif()
   file(WRITE ${BSYSCALL_H} "${BSYSCALL_CONTENT}")
-  message(STATUS "Patched BSyscall.h: SYSCALL macro backoff")
 endif()
 
 # Patch pas_utils.h: add backoff and retry cap to PAS_SYSCALL macro
+# Also add #include <unistd.h> for usleep()
 set(PAS_UTILS_H ${BMALLOC_INCLUDE}/pas_utils.h)
 if(EXISTS ${PAS_UTILS_H})
   file(READ ${PAS_UTILS_H} PAS_UTILS_CONTENT)
   string(REPLACE
+    "#include <string.h>"
+    "#include <string.h>
+#if !PAS_OS(WINDOWS)
+#include <unistd.h>
+#endif"
+    PAS_UTILS_CONTENT "${PAS_UTILS_CONTENT}")
+  string(REPLACE
     "#define PAS_SYSCALL(x) do { \\
     while ((x) == -1 && errno == EAGAIN) { } \\
 } while (0)"
-    "#define PAS_SYSCALL(x) do { \\
+    "#define PAS_SYSCALL_MAX_RETRIES 100
+#define PAS_SYSCALL_RETRY_DELAY_US 1000
+
+#define PAS_SYSCALL(x) do { \\
     int _pas_syscall_tries = 0; \\
     while ((x) == -1 && errno == EAGAIN) { \\
-        if (++_pas_syscall_tries > 100) break; \\
-        usleep(1000); \\
+        if (++_pas_syscall_tries > PAS_SYSCALL_MAX_RETRIES) break; \\
+        usleep(PAS_SYSCALL_RETRY_DELAY_US); \\
     } \\
 } while (0)"
     PAS_UTILS_CONTENT "${PAS_UTILS_CONTENT}")
+  string(FIND "${PAS_UTILS_CONTENT}" "PAS_SYSCALL_MAX_RETRIES" PAS_PATCH_APPLIED)
+  if(PAS_PATCH_APPLIED EQUAL -1)
+    message(WARNING "pas_utils.h patch did not apply - header may have changed in new WebKit version")
+  else()
+    message(STATUS "Patched pas_utils.h: PAS_SYSCALL macro backoff")
+  endif()
   file(WRITE ${PAS_UTILS_H} "${PAS_UTILS_CONTENT}")
-  message(STATUS "Patched pas_utils.h: PAS_SYSCALL macro backoff")
 endif()
 
 # Patch VMAllocate.h: remove MADV_DONTDUMP/MADV_DODUMP (Linux only)
@@ -329,6 +350,7 @@ endif()
 set(VMALLOCATE_H ${BMALLOC_INCLUDE}/VMAllocate.h)
 if(EXISTS ${VMALLOCATE_H})
   file(READ ${VMALLOCATE_H} VMALLOCATE_CONTENT)
+  string(FIND "${VMALLOCATE_CONTENT}" "MADV_DONTDUMP" VMALLOCATE_HAS_DONTDUMP)
   string(REPLACE
     "    SYSCALL(madvise(p, vmSize, MADV_DONTNEED));
 #if BOS(LINUX)
@@ -343,6 +365,11 @@ if(EXISTS ${VMALLOCATE_H})
 #endif"
     "    SYSCALL(madvise(p, vmSize, MADV_NORMAL));"
     VMALLOCATE_CONTENT "${VMALLOCATE_CONTENT}")
+  string(FIND "${VMALLOCATE_CONTENT}" "MADV_DONTDUMP" VMALLOCATE_STILL_HAS_DONTDUMP)
+  if(NOT VMALLOCATE_HAS_DONTDUMP EQUAL -1 AND NOT VMALLOCATE_STILL_HAS_DONTDUMP EQUAL -1)
+    message(WARNING "VMAllocate.h patch did not apply - header may have changed in new WebKit version")
+  else()
+    message(STATUS "Patched VMAllocate.h: removed MADV_DONTDUMP/MADV_DODUMP")
+  endif()
   file(WRITE ${VMALLOCATE_H} "${VMALLOCATE_CONTENT}")
-  message(STATUS "Patched VMAllocate.h: removed MADV_DONTDUMP/MADV_DODUMP")
 endif()

--- a/cmake/tools/SetupWebKit.cmake
+++ b/cmake/tools/SetupWebKit.cmake
@@ -260,3 +260,89 @@ file(RENAME ${CACHE_PATH}/bun-webkit ${WEBKIT_PATH})
 if(APPLE)
   file(REMOVE_RECURSE ${WEBKIT_INCLUDE_PATH}/unicode)
 endif()
+
+# --- Apply bmalloc patches ---
+# Fix: SYSCALL/PAS_SYSCALL macros spin at 100% CPU on madvise EAGAIN (oven-sh/bun#27490)
+#
+# The SYSCALL macro retries syscalls returning EAGAIN in a zero-delay tight loop.
+# Under kernel mmap_write_lock contention (e.g. concurrent GC threads calling
+# madvise(MADV_DONTDUMP)), this causes 250K+ retries/sec/thread and 100% CPU.
+#
+# Fix has two parts:
+# 1. Add usleep(1000) backoff and 100-retry cap to SYSCALL/PAS_SYSCALL macros
+# 2. Remove MADV_DONTDUMP/MADV_DODUMP calls which require mmap_write_lock
+#    (MADV_DONTDUMP only affects core dump size, not allocation correctness)
+
+set(BMALLOC_INCLUDE ${WEBKIT_INCLUDE_PATH}/bmalloc)
+
+# Patch BSyscall.h: add backoff and retry cap to SYSCALL macro
+set(BSYSCALL_H ${BMALLOC_INCLUDE}/BSyscall.h)
+if(EXISTS ${BSYSCALL_H})
+  file(READ ${BSYSCALL_H} BSYSCALL_CONTENT)
+  string(REPLACE
+    "#include <errno.h>
+
+#define SYSCALL(x) do { \\
+    while ((x) == -1 && errno == EAGAIN) { } \\
+} while (0);"
+    "#include <errno.h>
+#include <unistd.h>
+
+#define BSYSCALL_MAX_RETRIES 100
+#define BSYSCALL_RETRY_DELAY_US 1000
+
+#define SYSCALL(x) do { \\
+    int _syscall_tries = 0; \\
+    while ((x) == -1 && errno == EAGAIN) { \\
+        if (++_syscall_tries > BSYSCALL_MAX_RETRIES) break; \\
+        usleep(BSYSCALL_RETRY_DELAY_US); \\
+    } \\
+} while (0);"
+    BSYSCALL_CONTENT "${BSYSCALL_CONTENT}")
+  file(WRITE ${BSYSCALL_H} "${BSYSCALL_CONTENT}")
+  message(STATUS "Patched BSyscall.h: SYSCALL macro backoff")
+endif()
+
+# Patch pas_utils.h: add backoff and retry cap to PAS_SYSCALL macro
+set(PAS_UTILS_H ${BMALLOC_INCLUDE}/pas_utils.h)
+if(EXISTS ${PAS_UTILS_H})
+  file(READ ${PAS_UTILS_H} PAS_UTILS_CONTENT)
+  string(REPLACE
+    "#define PAS_SYSCALL(x) do { \\
+    while ((x) == -1 && errno == EAGAIN) { } \\
+} while (0)"
+    "#define PAS_SYSCALL(x) do { \\
+    int _pas_syscall_tries = 0; \\
+    while ((x) == -1 && errno == EAGAIN) { \\
+        if (++_pas_syscall_tries > 100) break; \\
+        usleep(1000); \\
+    } \\
+} while (0)"
+    PAS_UTILS_CONTENT "${PAS_UTILS_CONTENT}")
+  file(WRITE ${PAS_UTILS_H} "${PAS_UTILS_CONTENT}")
+  message(STATUS "Patched pas_utils.h: PAS_SYSCALL macro backoff")
+endif()
+
+# Patch VMAllocate.h: remove MADV_DONTDUMP/MADV_DODUMP (Linux only)
+# These require mmap_write_lock and are the primary contention source.
+# MADV_DONTDUMP only affects core dump size, not allocation correctness.
+set(VMALLOCATE_H ${BMALLOC_INCLUDE}/VMAllocate.h)
+if(EXISTS ${VMALLOCATE_H})
+  file(READ ${VMALLOCATE_H} VMALLOCATE_CONTENT)
+  string(REPLACE
+    "    SYSCALL(madvise(p, vmSize, MADV_DONTNEED));
+#if BOS(LINUX)
+    SYSCALL(madvise(p, vmSize, MADV_DONTDUMP));
+#endif"
+    "    SYSCALL(madvise(p, vmSize, MADV_DONTNEED));"
+    VMALLOCATE_CONTENT "${VMALLOCATE_CONTENT}")
+  string(REPLACE
+    "    SYSCALL(madvise(p, vmSize, MADV_NORMAL));
+#if BOS(LINUX)
+    SYSCALL(madvise(p, vmSize, MADV_DODUMP));
+#endif"
+    "    SYSCALL(madvise(p, vmSize, MADV_NORMAL));"
+    VMALLOCATE_CONTENT "${VMALLOCATE_CONTENT}")
+  file(WRITE ${VMALLOCATE_H} "${VMALLOCATE_CONTENT}")
+  message(STATUS "Patched VMAllocate.h: removed MADV_DONTDUMP/MADV_DODUMP")
+endif()

--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -228,16 +228,16 @@ To build for macOS x64:
 
 The order of the `--target` flag does not matter, as long as they're delimited by a `-`.
 
-| --target              | Operating System | Architecture | Modern | Baseline | Libc  |
-| --------------------- | ---------------- | ------------ | ------ | -------- | ----- |
-| bun-linux-x64         | Linux            | x64          | ✅     | ✅       | glibc |
-| bun-linux-arm64       | Linux            | arm64        | ✅     | N/A      | glibc |
-| bun-windows-x64       | Windows          | x64          | ✅     | ✅       | -     |
-| bun-windows-arm64     | Windows          | arm64        | ✅     | N/A      | -     |
-| bun-darwin-x64        | macOS            | x64          | ✅     | ✅       | -     |
-| bun-darwin-arm64      | macOS            | arm64        | ✅     | N/A      | -     |
-| bun-linux-x64-musl    | Linux            | x64          | ✅     | ✅       | musl  |
-| bun-linux-arm64-musl  | Linux            | arm64        | ✅     | N/A      | musl  |
+| --target             | Operating System | Architecture | Modern | Baseline | Libc  |
+| -------------------- | ---------------- | ------------ | ------ | -------- | ----- |
+| bun-linux-x64        | Linux            | x64          | ✅     | ✅       | glibc |
+| bun-linux-arm64      | Linux            | arm64        | ✅     | N/A      | glibc |
+| bun-windows-x64      | Windows          | x64          | ✅     | ✅       | -     |
+| bun-windows-arm64    | Windows          | arm64        | ✅     | N/A      | -     |
+| bun-darwin-x64       | macOS            | x64          | ✅     | ✅       | -     |
+| bun-darwin-arm64     | macOS            | arm64        | ✅     | N/A      | -     |
+| bun-linux-x64-musl   | Linux            | x64          | ✅     | ✅       | musl  |
+| bun-linux-arm64-musl | Linux            | arm64        | ✅     | N/A      | musl  |
 
 <Warning>
   On x64 platforms, Bun uses SIMD optimizations which require a modern CPU supporting AVX2 instructions. The `-baseline`

--- a/test/regression/issue/27490.test.ts
+++ b/test/regression/issue/27490.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/27490
+// bmalloc SYSCALL macro was spinning at 100% CPU on madvise EAGAIN
+// due to zero-delay tight loop with no backoff or retry cap.
+//
+// This test verifies that heavy allocation workloads complete without
+// hanging. The original bug caused GC threads to spin indefinitely
+// on madvise(MADV_DONTDUMP) returning EAGAIN under mmap_write_lock
+// contention, freezing the process.
+test("heavy allocation workload completes without hanging", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      // Simulate allocation-heavy workload that triggers GC pressure
+      const arrays = [];
+      for (let i = 0; i < 100; i++) {
+        // Allocate and release large buffers to trigger GC decommit cycles
+        for (let j = 0; j < 100; j++) {
+          arrays.push(new ArrayBuffer(1024 * 64));
+        }
+        // Force some to be collected
+        arrays.length = 0;
+        Bun.gc(true);
+      }
+      console.log("OK");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+}, 30_000);


### PR DESCRIPTION
## Summary

Fixes #27490

bmalloc's `SYSCALL` macro retries syscalls returning `EAGAIN` in a zero-delay tight loop with no backoff or retry cap. When `madvise(MADV_DONTDUMP)` returns `EAGAIN` under kernel `mmap_write_lock` contention (concurrent GC threads), this causes 250K+ retries/sec/thread and 100% CPU usage, effectively freezing the process.

This fix patches the downloaded WebKit headers during the CMake build setup:

- **Add `usleep(1000)` backoff and 100-retry cap** to `SYSCALL` and `PAS_SYSCALL` macros in `BSyscall.h` and `pas_utils.h`. Zero overhead on the fast path (syscall succeeds first try). On `EAGAIN`, retries up to 100 times with 1ms delay (~100ms max), then gives up gracefully. This matches the existing Windows pattern (`virtual_alloc_with_retry()` uses `Sleep(50ms)` + 10 retries).

- **Remove `MADV_DONTDUMP`/`MADV_DODUMP` calls** from `VMAllocate.h` on Linux. These require the kernel's exclusive `mmap_write_lock` (unlike `MADV_DONTNEED` which only needs a read lock) and are the primary contention source. They only affect core dump size, not allocation correctness.

Likely related issues: #17723, #27371, #27196, #26982

## Test plan

- [x] `bun bd` compiles successfully with patched headers
- [x] `bun bd test test/regression/issue/27490.test.ts` passes
- [ ] Verify no 100% CPU spins under allocation-heavy workloads on Linux
- [ ] Verify no regression on macOS (patches are Linux-specific for MADV_DONTDUMP removal; SYSCALL backoff is platform-agnostic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)