### PR TITLE
fix(resolver): prevent buffer overflow on very long import paths

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1684,6 +1684,9 @@ fn _resolve(
                     const buster_name = name: {
                         if (std.fs.path.isAbsolute(normalized_specifier)) {
                             if (std.fs.path.dirname(normalized_specifier)) |dir| {
+                                if (dir.len > specifier_cache_resolver_buf.len) {
+                                    return error.ModuleNotFound;
+                                }
                                 // Normalized without trailing slash
                                 break :name bun.strings.normalizeSlashesOnly(&specifier_cache_resolver_buf, dir, std.fs.path.sep);
                             }

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1689,6 +1689,12 @@ fn _resolve(
                             }
                         }
 
+                        // If the specifier is too long to join, it can't name a real
+                        // directory — skip the cache bust and fail.
+                        if (source_to_use.len + normalized_specifier.len + 4 >= specifier_cache_resolver_buf.len) {
+                            return error.ModuleNotFound;
+                        }
+
                         var parts = [_]string{
                             source_to_use,
                             normalized_specifier,

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -496,6 +496,13 @@ pub const FileSystem = struct {
         return path_handler.joinAbsStringBuf(f.top_level_dir, buf, parts, .loose);
     }
 
+    /// Like `absBuf`, but returns null when the joined path (after `..`/`.`
+    /// normalization) would overflow `buf`. Use when `parts` may contain
+    /// user-controlled input of arbitrary length.
+    pub fn absBufChecked(f: *@This(), parts: []const string, buf: []u8) ?string {
+        return path_handler.joinAbsStringBufChecked(f.top_level_dir, buf, parts, .loose);
+    }
+
     pub fn absBufZ(f: *@This(), parts: anytype, buf: []u8) stringZ {
         return path_handler.joinAbsStringBufZ(f.top_level_dir, buf, parts, .loose);
     }

--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -1476,6 +1476,10 @@ pub const ESModule = struct {
         }
 
         pub fn parseSubpath(subpath: *[]const u8, specifier: string, subpath_buf: []u8) void {
+            if (specifier.len + 1 > subpath_buf.len) {
+                subpath.* = "";
+                return;
+            }
             subpath_buf[0] = '.';
             bun.copy(u8, subpath_buf[1..], specifier);
             subpath.* = subpath_buf[0 .. specifier.len + 1];

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -1307,9 +1307,9 @@ pub fn joinStringBufT(comptime T: type, buf: []T, parts: anytype, comptime platf
 /// for arbitrarily long inputs while preserving zero-alloc behaviour for the
 /// common case.
 const JoinScratch = struct {
-    sfa: std.heap.StackFallbackAllocator(bun.MAX_PATH_BYTES * 2) = undefined,
-    alloc: std.mem.Allocator = undefined,
-    buf: []u8 = &.{},
+    sfa: std.heap.StackFallbackAllocator(bun.MAX_PATH_BYTES * 2),
+    alloc: std.mem.Allocator,
+    buf: []u8,
 
     pub fn init(self: *JoinScratch, base: usize, parts: []const []const u8) []u8 {
         self.sfa = std.heap.stackFallback(bun.MAX_PATH_BYTES * 2, bun.default_allocator);
@@ -1434,7 +1434,7 @@ fn _joinAbsStringBuf(comptime is_sentinel: bool, comptime ReturnType: type, _cwd
         }
     }
 
-    var scratch: JoinScratch = .{};
+    var scratch: JoinScratch = undefined;
     const temp_buf = scratch.init(cwd.len, parts);
     defer scratch.deinit();
 
@@ -1554,7 +1554,7 @@ fn _joinAbsStringBufWindows(
     if (set_cwd.len > 0)
         assert(isSepAny(set_cwd[0]));
 
-    var scratch: JoinScratch = .{};
+    var scratch: JoinScratch = undefined;
     const temp_buf = scratch.init(root.len + set_cwd.len, parts[n_start..]);
     defer scratch.deinit();
 

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -1335,6 +1335,7 @@ pub fn joinAbsStringBuf(cwd: []const u8, buf: []u8, _parts: anytype, comptime pl
 /// whose unnormalized length exceeds `buf.len` but normalizes down will still
 /// succeed.
 pub fn joinAbsStringBufChecked(cwd: []const u8, buf: []u8, parts: []const []const u8, comptime platform: Platform) ?[]const u8 {
+    comptime if (platform == .nt) @compileError("joinAbsStringBufChecked does not support .nt (the \\\\?\\ prefix is not accounted for in scratch sizing)");
     var scratch: JoinScratch = .{};
     const tmp = scratch.init(cwd.len, parts);
     defer scratch.deinit();

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -1336,12 +1336,20 @@ pub fn joinAbsStringBuf(cwd: []const u8, buf: []u8, _parts: anytype, comptime pl
 /// succeed.
 pub fn joinAbsStringBufChecked(cwd: []const u8, buf: []u8, parts: []const []const u8, comptime platform: Platform) ?[]const u8 {
     comptime if (platform == .nt) @compileError("joinAbsStringBufChecked does not support .nt (the \\\\?\\ prefix is not accounted for in scratch sizing)");
-    var scratch: JoinScratch = .{};
-    const tmp = scratch.init(cwd.len, parts);
-    defer scratch.deinit();
-    if (tmp.len < buf.len) return joinAbsStringBuf(cwd, buf, parts, platform);
+    // Fast path: size check only — don't allocate a JoinScratch here since the
+    // inner joinAbsStringBuf already has its own (avoids doubling stack usage).
+    var total: usize = cwd.len + 2;
+    for (parts) |p| total += p.len + 1;
+    if (total < buf.len) return joinAbsStringBuf(cwd, buf, parts, platform);
 
-    const joined = joinAbsStringBuf(cwd, tmp, parts, platform);
+    // Slow path: allocate a large scratch for the result. The inner
+    // joinAbsStringBuf will heap-allocate its own temp buffer for the concat
+    // since `total > MAX_PATH_BYTES * 2 > sfa inline size` is likely here.
+    var sfa = std.heap.stackFallback(bun.MAX_PATH_BYTES, bun.default_allocator);
+    const alloc = sfa.get();
+    const scratch = bun.handleOom(alloc.alloc(u8, total));
+    defer alloc.free(scratch);
+    const joined = joinAbsStringBuf(cwd, scratch, parts, platform);
     if (joined.len > buf.len) return null;
     bun.copy(u8, buf, joined);
     return buf[0..joined.len];

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -1302,8 +1302,48 @@ pub fn joinStringBufT(comptime T: type, buf: []T, parts: anytype, comptime platf
     return normalizeStringNodeT(T, temp_buf[0..written], buf, platform);
 }
 
+/// Inline `MAX_PATH_BYTES * 2` stack buffer that heap-allocates when the
+/// requested size exceeds it. Keeps `_joinAbsStringBuf`'s scratch buffer safe
+/// for arbitrarily long inputs while preserving zero-alloc behaviour for the
+/// common case.
+const JoinScratch = struct {
+    sfa: std.heap.StackFallbackAllocator(bun.MAX_PATH_BYTES * 2) = undefined,
+    alloc: std.mem.Allocator = undefined,
+    buf: []u8 = &.{},
+
+    pub fn init(self: *JoinScratch, base: usize, parts: []const []const u8) []u8 {
+        self.sfa = std.heap.stackFallback(bun.MAX_PATH_BYTES * 2, bun.default_allocator);
+        self.alloc = self.sfa.get();
+        var total = base + 2;
+        for (parts) |p| total += p.len + 1;
+        self.buf = bun.handleOom(self.alloc.alloc(u8, total));
+        return self.buf;
+    }
+
+    pub fn deinit(self: *JoinScratch) void {
+        self.alloc.free(self.buf);
+    }
+};
+
 pub fn joinAbsStringBuf(cwd: []const u8, buf: []u8, _parts: anytype, comptime platform: Platform) []const u8 {
     return _joinAbsStringBuf(false, []const u8, cwd, buf, _parts, platform);
+}
+
+/// Like `joinAbsStringBuf`, but returns null when the *normalized* result is
+/// too large for `buf`. Use this when `parts` may contain user-controlled
+/// input of arbitrary length. `..` segments are handled correctly: a path
+/// whose unnormalized length exceeds `buf.len` but normalizes down will still
+/// succeed.
+pub fn joinAbsStringBufChecked(cwd: []const u8, buf: []u8, parts: []const []const u8, comptime platform: Platform) ?[]const u8 {
+    var scratch: JoinScratch = .{};
+    const tmp = scratch.init(cwd.len, parts);
+    defer scratch.deinit();
+    if (tmp.len < buf.len) return joinAbsStringBuf(cwd, buf, parts, platform);
+
+    const joined = joinAbsStringBuf(cwd, tmp, parts, platform);
+    if (joined.len > buf.len) return null;
+    bun.copy(u8, buf, joined);
+    return buf[0..joined.len];
 }
 
 pub fn joinAbsStringBufZ(cwd: []const u8, buf: []u8, _parts: anytype, comptime platform: Platform) [:0]const u8 {
@@ -1347,7 +1387,6 @@ fn _joinAbsStringBuf(comptime is_sentinel: bool, comptime ReturnType: type, _cwd
     }
 
     var parts: []const []const u8 = _parts;
-    var temp_buf: [bun.MAX_PATH_BYTES * 2]u8 = undefined;
     if (parts.len == 0) {
         if (comptime is_sentinel) {
             unreachable;
@@ -1386,7 +1425,11 @@ fn _joinAbsStringBuf(comptime is_sentinel: bool, comptime ReturnType: type, _cwd
         }
     }
 
-    bun.copy(u8, &temp_buf, cwd);
+    var scratch: JoinScratch = .{};
+    const temp_buf = scratch.init(cwd.len, parts);
+    defer scratch.deinit();
+
+    bun.copy(u8, temp_buf, cwd);
     out = cwd.len;
 
     for (parts) |_part| {
@@ -1502,7 +1545,9 @@ fn _joinAbsStringBufWindows(
     if (set_cwd.len > 0)
         assert(isSepAny(set_cwd[0]));
 
-    var temp_buf: [bun.MAX_PATH_BYTES * 2]u8 = undefined;
+    var scratch: JoinScratch = .{};
+    const temp_buf = scratch.init(root.len + set_cwd.len, parts[n_start..]);
+    defer scratch.deinit();
 
     @memcpy(temp_buf[0..root.len], root);
     @memcpy(temp_buf[root.len .. root.len + set_cwd.len], set_cwd);

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2641,6 +2641,11 @@ pub const Resolver = struct {
             input_path = r.fs.top_level_dir;
         }
 
+        // A path longer than MAX_PATH_BYTES cannot name a real directory.
+        // Bailing here also prevents overflowing `dir_info_uncached_path`
+        // below when called with user-controlled absolute import paths.
+        if (input_path.len > bun.MAX_PATH_BYTES) return null;
+
         if (comptime Environment.isWindows) {
             input_path = r.fs.normalizeBuf(&win32_normalized_dir_info_cache_buf, input_path);
             // kind of a patch on the fact normalizeBuf isn't 100% perfect what we want

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1111,7 +1111,7 @@ pub const Resolver = struct {
                         import_path[import_path.len - 2] == '.' and
                         import_path[import_path.len - 1] == '.');
                 const buf = bufs(.relative_abs_path);
-                import_path = r.fs.absBuf(&.{import_path}, buf);
+                import_path = r.fs.absBufChecked(&.{import_path}, buf) orelse return .{ .not_found = {} };
                 if (ends_with_dir) {
                     buf[import_path.len] = platform.separator();
                     import_path.len += 1;
@@ -1309,8 +1309,7 @@ pub const Resolver = struct {
     }
 
     pub fn checkRelativePath(r: *ThisResolver, source_dir: string, import_path: string, kind: ast.ImportKind, global_cache: GlobalCache) Result.Union {
-        const parts = [_]string{ source_dir, import_path };
-        const abs_path = r.fs.absBuf(&parts, bufs(.relative_abs_path));
+        const abs_path = r.fs.absBufChecked(&.{ source_dir, import_path }, bufs(.relative_abs_path)) orelse return .{ .not_found = {} };
 
         if (r.opts.external.abs_paths.count() > 0 and r.opts.external.abs_paths.contains(abs_path)) {
             // If the string literal in the source text is an absolute path and has
@@ -1725,13 +1724,11 @@ pub const Resolver = struct {
             // Try looking up the path relative to the base URL
             if (tsconfig.hasBaseURL()) {
                 const base = tsconfig.base_url;
-                const paths = [_]string{ base, import_path };
-                const abs = r.fs.absBuf(&paths, bufs(.load_as_file_or_directory_via_tsconfig_base_path));
-
-                if (r.loadAsFileOrDirectory(abs, kind)) |res| {
-                    return .{ .success = res };
+                if (r.fs.absBufChecked(&.{ base, import_path }, bufs(.load_as_file_or_directory_via_tsconfig_base_path))) |abs| {
+                    if (r.loadAsFileOrDirectory(abs, kind)) |res| {
+                        return .{ .success = res };
+                    }
                 }
-                // r.allocator.free(abs);
             }
         }
 
@@ -1774,14 +1771,12 @@ pub const Resolver = struct {
         while (use_node_module_resolver) {
             // Skip directories that are themselves called "node_modules", since we
             // don't ever want to search for "node_modules/node_modules"
-            if (dir_info.hasNodeModules() or is_self_reference) {
+            if (dir_info.hasNodeModules() or is_self_reference) node_modules: {
                 any_node_modules_folder = true;
                 const abs_path = if (is_self_reference)
                     dir_info.abs_path
-                else brk: {
-                    var _parts = [_]string{ dir_info.abs_path, "node_modules", import_path };
-                    break :brk r.fs.absBuf(&_parts, bufs(.node_modules_check));
-                };
+                else
+                    r.fs.absBufChecked(&.{ dir_info.abs_path, "node_modules", import_path }, bufs(.node_modules_check)) orelse break :node_modules;
                 if (r.debug_logs) |*debug| {
                     debug.addNoteFmt("Checking for a package in the directory \"{s}\"", .{abs_path});
                 }
@@ -1896,7 +1891,7 @@ pub const Resolver = struct {
         if (node_path.len > 0) {
             var it = std.mem.tokenizeScalar(u8, node_path, if (Environment.isWindows) ';' else ':');
             while (it.next()) |path| {
-                const abs_path = r.fs.absBuf(&[_]string{ path, import_path }, bufs(.node_modules_check));
+                const abs_path = r.fs.absBufChecked(&.{ path, import_path }, bufs(.node_modules_check)) orelse continue;
                 if (r.debug_logs) |*debug| {
                     debug.addNoteFmt("Checking for a package in the NODE_PATH directory \"{s}\"", .{abs_path});
                 }
@@ -2160,8 +2155,7 @@ pub const Resolver = struct {
                             }
                         }
 
-                        var _paths = [_]string{ pkg_dir_info.abs_path, esm.subpath };
-                        const abs_path = r.fs.absBuf(&_paths, bufs(.node_modules_check));
+                        const abs_path = r.fs.absBufChecked(&.{ pkg_dir_info.abs_path, esm.subpath }, bufs(.node_modules_check)) orelse return .{ .not_found = {} };
                         if (r.debug_logs) |*debug| {
                             debug.addNoteFmt("Checking for a package in the directory \"{s}\"", .{abs_path});
                         }
@@ -2398,12 +2392,12 @@ pub const Resolver = struct {
             esm_resolution.path.len > 0 and esm_resolution.path[0] == std.fs.path.sep))
             return null;
 
-        const abs_esm_path: string = brk: {
-            var parts = [_]string{
-                abs_package_path,
-                strings.withoutLeadingPathSeparator(esm_resolution.path),
-            };
-            break :brk r.fs.absBuf(&parts, bufs(.esm_absolute_package_path_joined));
+        const abs_esm_path: string = r.fs.absBufChecked(
+            &.{ abs_package_path, strings.withoutLeadingPathSeparator(esm_resolution.path) },
+            bufs(.esm_absolute_package_path_joined),
+        ) orelse {
+            esm_resolution.status = .ModuleNotFound;
+            return null;
         };
 
         var missing_suffix: string = "";
@@ -2528,8 +2522,7 @@ pub const Resolver = struct {
         if (isPackagePath(import_path)) {
             return r.loadNodeModules(import_path, kind, source_dir_info, global_cache, false);
         } else {
-            const paths = [_]string{ source_dir_info.abs_path, import_path };
-            const resolved = r.fs.absBuf(&paths, bufs(.resolve_without_remapping));
+            const resolved = r.fs.absBufChecked(&.{ source_dir_info.abs_path, import_path }, bufs(.resolve_without_remapping)) orelse return .{ .not_found = {} };
             if (r.loadAsFileOrDirectory(resolved, kind)) |result| {
                 return .{ .success = result };
             }
@@ -3079,6 +3072,7 @@ pub const Resolver = struct {
                 if (total_length != null) {
                     const suffix = std.mem.trimLeft(u8, original_path[total_length orelse original_path.len ..], "*");
                     matched_text_with_suffix_len = matched_text.len + suffix.len;
+                    if (matched_text_with_suffix_len > matched_text_with_suffix.len) continue;
                     bun.concat(u8, matched_text_with_suffix, &.{ matched_text, suffix });
                 }
 
@@ -3093,10 +3087,10 @@ pub const Resolver = struct {
                     if (matched_text_with_suffix_len > 0) std.mem.trimLeft(u8, matched_text_with_suffix[0..matched_text_with_suffix_len], "/") else "",
                     std.mem.trimLeft(u8, longest_match.suffix, "/"),
                 };
-                const absolute_original_path = r.fs.absBuf(
+                const absolute_original_path = r.fs.absBufChecked(
                     &parts,
                     bufs(.tsconfig_match_full_buf),
-                );
+                ) orelse continue;
 
                 if (r.loadAsFileOrDirectory(absolute_original_path, kind)) |res| {
                     return res;

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2711,6 +2711,10 @@ pub const Resolver = struct {
                 top_parent = result;
                 break;
             }
+            // Path has more uncached components than our fixed queue can hold.
+            // This only happens for user-controlled absolute import paths with
+            // hundreds of short components — no real directory is this deep.
+            if (@as(usize, @intCast(i)) >= bufs(.dir_entry_paths_to_resolve).len) return null;
             bufs(.dir_entry_paths_to_resolve)[@as(usize, @intCast(i))] = DirEntryResolveQueueItem{
                 .unsafe_path = top,
                 .result = result,
@@ -3083,7 +3087,7 @@ pub const Resolver = struct {
 
                 // 1. Normalize the base path
                 // so that "/Users/foo/project/", "../components/*" => "/Users/foo/components/""
-                const prefix = r.fs.absBuf(&prefix_parts, bufs(.tsconfig_match_full_buf2));
+                const prefix = r.fs.absBufChecked(&prefix_parts, bufs(.tsconfig_match_full_buf2)) orelse continue;
 
                 // 2. Join the new base path with the matched result
                 // so that "/Users/foo/components/", "/foo/bar" => /Users/foo/components/foo/bar

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -60,45 +60,34 @@ describe("ResolveMessage", () => {
       await import(":://filesystem");
     }).toThrow("Cannot find module");
   });
+});
 
-  it("doesn't crash on very long import paths with tsconfig baseUrl", async () => {
-    // Reproduces a panic where joining tsconfig baseUrl + a long import path
-    // overflowed a fixed-size PathBuffer in normalizeStringGenericTZ.
-    // The bug triggers when import_path < PATH_MAX but baseUrl + import_path > PATH_MAX.
-    // PATH_MAX is 1024 on macOS, 4096 on Linux/Windows. Pick a length just under
-    // PATH_MAX so the specifier itself doesn't hit ENAMETOOLONG earlier.
-    // Any length > 512 also exercises the esm_subpath buffer overflow.
-    // "a".repeat is slow in debug builds; use Buffer.alloc instead.
-    const len = process.platform === "darwin" ? 1020 : 4090;
-    const long = Buffer.alloc(len, "a").toString();
-    using dir = tempDir("resolve-long-path", {
-      // package.json + node_modules/ prevent the resolver from attempting
-      // auto-install (which has an unrelated pre-existing bug).
+// These tests reproduce panics where the module resolver wrote past fixed-size
+// PathBuffers when given very long import specifiers. The bug triggers when
+// `import_path < PATH_MAX` but `baseUrl + import_path > PATH_MAX` (otherwise a
+// syscall returns ENAMETOOLONG first). PATH_MAX is 1024 on macOS, 4096 on
+// Linux/Windows, so pick a length just under it per platform.
+// Any length > 512 also exercises the `esm_subpath` buffer.
+describe.concurrent("long import path overflow", () => {
+  const len = process.platform === "darwin" ? 1020 : 4090;
+  // "a".repeat is slow in debug builds; use Buffer.alloc instead.
+  const long = Buffer.alloc(len, "a").toString();
+
+  function makeDir() {
+    // package.json + node_modules/ prevent the resolver from attempting
+    // auto-install (which has an unrelated pre-existing bug).
+    return tempDir("resolve-long-path", {
       "package.json": `{"name": "test", "version": "0.0.0"}`,
       "node_modules/.keep": "",
       "tsconfig.json": `{"compilerOptions": {"baseUrl": ".", "paths": {"@x/*": ["./src/*"]}}}`,
-      "test.js": `
-        const long = ${JSON.stringify(long)};
-        // bare package (tsconfig baseUrl path)
-        try { await import(\`@nonexistent/pkg/build/\${long}.js\`); } catch {}
-        // tsconfig paths wildcard (captures long text)
-        try { await import(\`@x/\${long}\`); } catch {}
-        // relative path
-        try { await import(\`./\${long}.js\`); } catch {}
-        // very long with .. segments (tests normalization handling)
-        try { await import(\`./\${"x/../".repeat(${len})}\${long}.js\`); } catch {}
-        // absolute path > PATH_MAX (dirInfoCached buffer overflow)
-        try { await import(\`/\${long}/mixed\`); } catch {}
-        // deep path with >256 short components (dir_entry_paths_to_resolve overflow)
-        try { await import(\`/\${"a/".repeat(300)}x\`); } catch {}
-        console.log("ok");
-      `,
     });
+  }
 
+  async function run(dir: string, importExpr: string) {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "test.js"],
+      cmd: [bunExe(), "-e", `try { await import(${importExpr}); } catch {} console.log("ok");`],
       env: bunEnv,
-      cwd: String(dir),
+      cwd: dir,
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -106,5 +95,41 @@ describe("ResolveMessage", () => {
     expect(stderr).toBe("");
     expect(stdout.trim()).toBe("ok");
     expect(exitCode).toBe(0);
+  }
+
+  it("bare package specifier (tsconfig baseUrl + import_path join)", async () => {
+    using dir = makeDir();
+    // normalizeStringGenericTZ: `@memcpy(buf[buf_i..][0..count], ...)` past PathBuffer
+    await run(String(dir), `\`@nonexistent/pkg/build/${long}.js\``);
+  });
+
+  it("tsconfig paths wildcard (matched text captured from import path)", async () => {
+    using dir = makeDir();
+    // matchTSConfigPaths: bun.concat into fixed tsconfig_match_full_buf3
+    await run(String(dir), `\`@x/${long}\``);
+  });
+
+  it("relative path (source_dir + import_path join)", async () => {
+    using dir = makeDir();
+    // checkRelativePath / resolveWithoutRemapping absBuf
+    await run(String(dir), `\`./${long}.js\``);
+  });
+
+  it("relative path full of `..` segments (exercises normalization fallback)", async () => {
+    using dir = makeDir();
+    // Concat length >> PATH_MAX but normalizes down; JoinScratch heap fallback
+    await run(String(dir), `\`./\${"x/../".repeat(${len})}${long}.js\``);
+  });
+
+  it("absolute path longer than PATH_MAX (dirInfoCached buffer)", async () => {
+    using dir = makeDir();
+    // dirInfoCachedMaybeLog: bun.copy into dir_info_uncached_path
+    await run(String(dir), `\`/${long}/mixed\``);
+  });
+
+  it("absolute path with >256 short components (dir_entry_paths_to_resolve queue)", async () => {
+    using dir = makeDir();
+    // Walk-up loop indexed into a fixed [256]DirEntryResolveQueueItem
+    await run(String(dir), `\`/\${"a/".repeat(300)}x\``);
   });
 });

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -69,7 +69,7 @@ describe("ResolveMessage", () => {
     // PATH_MAX so the specifier itself doesn't hit ENAMETOOLONG earlier.
     // Any length > 512 also exercises the esm_subpath buffer overflow.
     // "a".repeat is slow in debug builds; use Buffer.alloc instead.
-    const len = process.platform === "darwin" ? 1000 : 4000;
+    const len = process.platform === "darwin" ? 1020 : 4090;
     const long = Buffer.alloc(len, "a").toString();
     using dir = tempDir("resolve-long-path", {
       // package.json + node_modules/ prevent the resolver from attempting
@@ -87,6 +87,8 @@ describe("ResolveMessage", () => {
         try { await import(\`./\${long}.js\`); } catch {}
         // very long with .. segments (tests normalization handling)
         try { await import(\`./\${"x/../".repeat(${len})}\${long}.js\`); } catch {}
+        // absolute path > PATH_MAX (dirInfoCached buffer overflow)
+        try { await import(\`/\${long}/mixed\`); } catch {}
         console.log("ok");
       `,
     });

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -64,8 +64,13 @@ describe("ResolveMessage", () => {
   it("doesn't crash on very long import paths with tsconfig baseUrl", async () => {
     // Reproduces a panic where joining tsconfig baseUrl + a long import path
     // overflowed a fixed-size PathBuffer in normalizeStringGenericTZ.
+    // The bug triggers when import_path < PATH_MAX but baseUrl + import_path > PATH_MAX.
+    // PATH_MAX is 1024 on macOS, 4096 on Linux/Windows. Pick a length just under
+    // PATH_MAX so the specifier itself doesn't hit ENAMETOOLONG earlier.
+    // Any length > 512 also exercises the esm_subpath buffer overflow.
     // "a".repeat is slow in debug builds; use Buffer.alloc instead.
-    const long = Buffer.alloc(1000, "a").toString();
+    const len = process.platform === "darwin" ? 1000 : 4000;
+    const long = Buffer.alloc(len, "a").toString();
     using dir = tempDir("resolve-long-path", {
       // package.json + node_modules/ prevent the resolver from attempting
       // auto-install (which has an unrelated pre-existing bug).
@@ -81,7 +86,7 @@ describe("ResolveMessage", () => {
         // relative path
         try { await import(\`./\${long}.js\`); } catch {}
         // very long with .. segments (tests normalization handling)
-        try { await import(\`./\${"x/../".repeat(500)}\${long}.js\`); } catch {}
+        try { await import(\`./\${"x/../".repeat(${len})}\${long}.js\`); } catch {}
         console.log("ok");
       `,
     });

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -89,6 +89,8 @@ describe("ResolveMessage", () => {
         try { await import(\`./\${"x/../".repeat(${len})}\${long}.js\`); } catch {}
         // absolute path > PATH_MAX (dirInfoCached buffer overflow)
         try { await import(\`/\${long}/mixed\`); } catch {}
+        // deep path with >256 short components (dir_entry_paths_to_resolve overflow)
+        try { await import(\`/\${"a/".repeat(300)}x\`); } catch {}
         console.log("ok");
       `,
     });

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("ResolveMessage", () => {
   it("position object does not segfault", async () => {
@@ -58,5 +59,43 @@ describe("ResolveMessage", () => {
       // @ts-ignore
       await import(":://filesystem");
     }).toThrow("Cannot find module");
+  });
+
+  it("doesn't crash on very long import paths with tsconfig baseUrl", async () => {
+    // Reproduces a panic where joining tsconfig baseUrl + a long import path
+    // overflowed a fixed-size PathBuffer in normalizeStringGenericTZ.
+    // "a".repeat is slow in debug builds; use Buffer.alloc instead.
+    const long = Buffer.alloc(1000, "a").toString();
+    using dir = tempDir("resolve-long-path", {
+      // package.json + node_modules/ prevent the resolver from attempting
+      // auto-install (which has an unrelated pre-existing bug).
+      "package.json": `{"name": "test", "version": "0.0.0"}`,
+      "node_modules/.keep": "",
+      "tsconfig.json": `{"compilerOptions": {"baseUrl": ".", "paths": {"@x/*": ["./src/*"]}}}`,
+      "test.js": `
+        const long = ${JSON.stringify(long)};
+        // bare package (tsconfig baseUrl path)
+        try { await import(\`@nonexistent/pkg/build/\${long}.js\`); } catch {}
+        // tsconfig paths wildcard (captures long text)
+        try { await import(\`@x/\${long}\`); } catch {}
+        // relative path
+        try { await import(\`./\${long}.js\`); } catch {}
+        // very long with .. segments (tests normalization handling)
+        try { await import(\`./\${"x/../".repeat(500)}\${long}.js\`); } catch {}
+        console.log("ok");
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("ok");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- `_joinAbsStringBuf` used a fixed `MAX_PATH_BYTES * 2` stack buffer for its scratch space; joining a long user-provided import specifier with tsconfig `baseUrl` / `node_modules` / source dir would overflow it and panic in `normalizeStringGenericTZ`.
- Replace the fixed buffer with a `JoinScratch` stack-fallback allocator sized to the input (zero-alloc for normal paths, heap-alloc only for pathological inputs).
- Add `absBufChecked` / `joinAbsStringBufChecked` that return `null` when the normalized result would still exceed the destination buffer, and switch resolver call sites that handle user-controlled specifiers to use it (treating overflow as not-found).
- Guard `ESModule.Package.parseSubpath`, tsconfig `paths` wildcard concat, and the VM cache-bust join against overflow.

## Test plan
- [ ] `bun bd test test/js/bun/resolve/resolve-error.test.ts` — new test exercises bare packages via tsconfig baseUrl, tsconfig `paths` wildcards, relative paths, and long paths with `..` normalization, none of which should crash
- [ ] CI green on all platforms (Windows path joining also changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code) (0% 31-shotted by claude)