### PR TITLE
fix(http): harden header parsing for pipelined requests with empty headers

### DIFF
--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -721,7 +721,8 @@ namespace uWS
 
             /* Check for empty headers (no headers, just \r\n) */
             if (postPaddedBuffer[0] == '\r' && postPaddedBuffer[1] == '\n') {
-                /* Valid request with no headers */
+                /* Valid request with no headers - write null terminator like the normal path */
+                headers[1].key = std::string_view(nullptr, 0);
                 return HttpParserResult::success((unsigned int) ((postPaddedBuffer + 2) - start));
             }
 


### PR DESCRIPTION
## Summary

- Write a null terminator to the headers array when the empty-headers early return path is taken in `getHeaders()` (`HttpParser.h:723`). This matches the existing behavior on the normal parsing path (line 796) and ensures headers are properly isolated between pipelined requests.
- Without this, when a pipelined request has no headers (request line immediately followed by `\r\n\r\n`), stale header `string_view`s from the previous request on the same connection could remain in the reused `HttpRequest` object's headers array.

## Test plan

- [x] Added 3 new pipelined request header isolation tests to `test/js/bun/http/request-smuggling.test.ts`
- [x] Verified new test (`pipelined headerless request is rejected and does not inherit stale content-length`) **fails without the fix** and **passes with the fix**
- [x] All 17 tests in the request-smuggling test file pass
- [x] `bun bd test test/js/bun/http/request-smuggling.test.ts` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)