### PR TITLE
fix(fs): harden path length validation for multi-byte UTF-8 strings

### DIFF
--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -734,14 +734,13 @@ pub const PathLike = union(enum) {
     }
 
     pub fn fromBunString(global: *jsc.JSGlobalObject, str: *bun.String, will_be_async: bool, allocator: std.mem.Allocator) !PathLike {
-        // Validate using the UTF-8 byte length, not the UTF-16 code unit count,
-        // because the path will be stored as UTF-8 in a fixed-size PathBuffer.
-        try Valid.pathStringLength(str.utf8ByteLength(), global);
-
         if (will_be_async) {
             var sliced = try str.toThreadSafeSlice(allocator);
             errdefer sliced.deinit();
 
+            // Validate the UTF-8 byte length after conversion, since the path
+            // will be stored in a fixed-size PathBuffer.
+            try Valid.pathStringLength(sliced.slice().len, global);
             try Valid.pathNullBytes(sliced.slice(), global);
 
             sliced.reportExtraMemory(global.vm());
@@ -754,6 +753,9 @@ pub const PathLike = union(enum) {
             var sliced = str.toSlice(allocator);
             errdefer sliced.deinit();
 
+            // Validate the UTF-8 byte length after conversion, since the path
+            // will be stored in a fixed-size PathBuffer.
+            try Valid.pathStringLength(sliced.slice().len, global);
             try Valid.pathNullBytes(sliced.slice(), global);
 
             // Costs nothing to keep both around.

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -613,6 +613,14 @@ pub const PathLike = union(enum) {
             }
         }
 
+        if (sliced.len >= buf.len) {
+            bun.Output.debugWarn("path too long: {d} bytes exceeds PathBuffer capacity of {d}\n", .{ sliced.len, buf.len });
+            if (comptime !force) return "";
+
+            buf[0] = 0;
+            return buf[0..0 :0];
+        }
+
         @memcpy(buf[0..sliced.len], sliced);
         buf[sliced.len] = 0;
         return buf[0..sliced.len :0];
@@ -726,7 +734,9 @@ pub const PathLike = union(enum) {
     }
 
     pub fn fromBunString(global: *jsc.JSGlobalObject, str: *bun.String, will_be_async: bool, allocator: std.mem.Allocator) !PathLike {
-        try Valid.pathStringLength(str.length(), global);
+        // Validate using the UTF-8 byte length, not the UTF-16 code unit count,
+        // because the path will be stored as UTF-8 in a fixed-size PathBuffer.
+        try Valid.pathStringLength(str.utf8ByteLength(), global);
 
         if (will_be_async) {
             var sliced = try str.toThreadSafeSlice(allocator);

--- a/test/js/node/fs/fs-path-length.test.ts
+++ b/test/js/node/fs/fs-path-length.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { isPosix } from "harness";
+import fs from "node:fs";
+
+// On POSIX systems, MAX_PATH_BYTES is 4096.
+// Path validation must account for the actual UTF-8 byte length of strings,
+// not just the number of characters (UTF-16 code units), since multi-byte
+// characters expand when encoded as UTF-8.
+describe.if(isPosix)("path length validation with multi-byte characters", () => {
+  // U+4E00 (一) is a CJK character that is 3 bytes in UTF-8 (0xE4 0xB8 0x80).
+  // 2000 such characters = 2000 UTF-16 code units but 6000 UTF-8 bytes,
+  // which exceeds the 4096-byte PathBuffer.
+  const cjkPath = "\u4e00".repeat(2000);
+
+  it("rejects overly long multi-byte paths in openSync", () => {
+    expect(() => fs.openSync(cjkPath, "r")).toThrow("ENAMETOOLONG");
+  });
+
+  it("rejects overly long multi-byte paths in readFileSync", () => {
+    expect(() => fs.readFileSync(cjkPath)).toThrow("ENAMETOOLONG");
+  });
+
+  it("rejects overly long multi-byte paths in statSync", () => {
+    expect(() => fs.statSync(cjkPath)).toThrow("ENAMETOOLONG");
+  });
+
+  it("rejects overly long multi-byte paths in realpathSync", () => {
+    expect(() => fs.realpathSync(cjkPath)).toThrow("ENAMETOOLONG");
+  });
+
+  it("rejects overly long multi-byte paths in async readFile", async () => {
+    expect(async () => await fs.promises.readFile(cjkPath)).toThrow("ENAMETOOLONG");
+  });
+
+  it("rejects overly long multi-byte paths in async stat", async () => {
+    expect(async () => await fs.promises.stat(cjkPath)).toThrow("ENAMETOOLONG");
+  });
+
+  // 2-byte UTF-8 characters (U+0080 to U+07FF range)
+  it("rejects overly long 2-byte UTF-8 paths", () => {
+    // U+00E9 (é) is 2 bytes in UTF-8. 3000 chars = 6000 bytes > 4096
+    const accentPath = "\u00e9".repeat(3000);
+    expect(() => fs.statSync(accentPath)).toThrow("ENAMETOOLONG");
+  });
+
+  // Verify that the process does not crash - the key property is that these
+  // throw a proper JS error rather than segfaulting.
+  it("does not crash with 4-byte UTF-8 characters exceeding buffer", () => {
+    // U+1F600 (😀) is 4 bytes in UTF-8, 2 UTF-16 code units (surrogate pair).
+    // 1500 emoji = 3000 UTF-16 code units but 6000 UTF-8 bytes > 4096
+    const emojiPath = "\u{1F600}".repeat(1500);
+    expect(() => fs.statSync(emojiPath)).toThrow("ENAMETOOLONG");
+  });
+});


### PR DESCRIPTION
## Summary

- Fix `PathLike.fromBunString` to validate path length using `str.utf8ByteLength()` instead of `str.length()` (UTF-16 code units), since paths are stored as UTF-8 in a fixed-size `PathBuffer`
- Add defensive bounds check in `sliceZWithForceCopy` before `@memcpy` to guard against oversized slices
- Add tests covering multi-byte UTF-8 paths (CJK, accented, emoji characters) that exceed the buffer capacity

## Background

`PathLike.fromBunString` validated path length using `str.length()`, which returns UTF-16 code units. However, the path is ultimately stored as UTF-8 in a fixed-size `PathBuffer` (`[MAX_PATH_BYTES]u8`, 4096 bytes on Linux). Multi-byte UTF-8 characters (CJK, accented, emoji) use 2-4 bytes per character, so a string that passes the UTF-16 length check could exceed the buffer capacity after UTF-8 encoding. For example, 2000 CJK characters (U+4E00) = 2000 UTF-16 code units (passes the 4096 check) but 6000 UTF-8 bytes (overflows the buffer).

## Test plan

- [x] `bun bd test test/js/node/fs/fs-path-length.test.ts` — 8/8 tests pass
- [x] `USE_SYSTEM_BUN=1 bun test test/js/node/fs/fs-path-length.test.ts` — crashes with segfault (confirms the issue exists pre-fix)
- [x] Tests cover sync APIs (openSync, readFileSync, statSync, realpathSync), async APIs (promises.readFile, promises.stat), 2-byte (é), 3-byte (一), and 4-byte (😀) UTF-8 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)