### PR TITLE
fix(http): harden request header buffer bounds in buildRequest

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -644,21 +644,30 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
         // Hash it as lowercase
         const hash = hashHeaderName(name);
 
+        // Whether this header will actually be written to the buffer.
+        // Override flags must only be set when the header is kept, otherwise
+        // the default header is suppressed but the user header is dropped,
+        // leaving the header entirely absent from the request.
+        const will_append = header_count < max_user_headers;
+
         // Skip host and connection header
         // we manage those
         switch (hash) {
             hashHeaderConst("Content-Length"),
             => {
+                // Content-Length is always consumed (never written to the buffer).
                 original_content_length = this.headerStr(header_values[i]);
                 continue;
             },
             hashHeaderConst("Connection") => {
-                override_connection_header = true;
-                const connection_value = this.headerStr(header_values[i]);
-                if (std.ascii.eqlIgnoreCase(connection_value, "close")) {
-                    this.flags.disable_keepalive = true;
-                } else if (std.ascii.eqlIgnoreCase(connection_value, "keep-alive")) {
-                    this.flags.disable_keepalive = false;
+                if (will_append) {
+                    override_connection_header = true;
+                    const connection_value = this.headerStr(header_values[i]);
+                    if (std.ascii.eqlIgnoreCase(connection_value, "close")) {
+                        this.flags.disable_keepalive = true;
+                    } else if (std.ascii.eqlIgnoreCase(connection_value, "keep-alive")) {
+                        this.flags.disable_keepalive = false;
+                    }
                 }
             },
             hashHeaderConst("if-modified-since") => {
@@ -667,32 +676,34 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
                 }
             },
             hashHeaderConst(host_header_name) => {
-                override_host_header = true;
+                if (will_append) override_host_header = true;
             },
             hashHeaderConst("Accept") => {
-                override_accept_header = true;
+                if (will_append) override_accept_header = true;
             },
             hashHeaderConst("User-Agent") => {
-                override_user_agent = true;
+                if (will_append) override_user_agent = true;
             },
             hashHeaderConst("Accept-Encoding") => {
-                override_accept_encoding = true;
+                if (will_append) override_accept_encoding = true;
             },
             hashHeaderConst("Upgrade") => {
-                const value = this.headerStr(header_values[i]);
-                if (!std.ascii.eqlIgnoreCase(value, "h2") and !std.ascii.eqlIgnoreCase(value, "h2c")) {
-                    this.flags.upgrade_state = .pending;
+                if (will_append) {
+                    const value = this.headerStr(header_values[i]);
+                    if (!std.ascii.eqlIgnoreCase(value, "h2") and !std.ascii.eqlIgnoreCase(value, "h2c")) {
+                        this.flags.upgrade_state = .pending;
+                    }
                 }
             },
             hashHeaderConst(chunked_encoded_header.name) => {
                 // We don't want to override chunked encoding header if it was set by the user
-                add_transfer_encoding = false;
+                if (will_append) add_transfer_encoding = false;
             },
             else => {},
         }
 
         // Silently drop excess headers to stay within the fixed-size request header buffer.
-        if (header_count >= max_user_headers) continue;
+        if (!will_append) continue;
 
         request_headers_buf[header_count] = .{
             .name = name,

--- a/src/http.zig
+++ b/src/http.zig
@@ -22,7 +22,8 @@ var print_every_i: usize = 0;
 
 // we always rewrite the entire HTTP request when write() returns EAGAIN
 // so we can reuse this buffer
-var shared_request_headers_buf: [256]picohttp.Header = undefined;
+const max_request_headers = 256;
+var shared_request_headers_buf: [max_request_headers]picohttp.Header = undefined;
 
 // this doesn't need to be stack memory because it is immediately cloned after use
 var shared_response_headers_buf: [256]picohttp.Header = undefined;
@@ -633,6 +634,11 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
     var add_transfer_encoding = true;
     var original_content_length: ?string = null;
 
+    // Reserve slots for default headers that may be appended after user headers
+    // (Connection, User-Agent, Accept, Host, Accept-Encoding, Content-Length/Transfer-Encoding).
+    const max_default_headers = 6;
+    const max_user_headers = max_request_headers - max_default_headers;
+
     for (header_names, 0..) |head, i| {
         const name = this.headerStr(head);
         // Hash it as lowercase
@@ -684,6 +690,9 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
             },
             else => {},
         }
+
+        // Silently drop excess headers to stay within the fixed-size request header buffer.
+        if (header_count >= max_user_headers) continue;
 
         request_headers_buf[header_count] = .{
             .name = name,

--- a/test/js/bun/http/fetch-header-count-limit.test.ts
+++ b/test/js/bun/http/fetch-header-count-limit.test.ts
@@ -3,7 +3,7 @@ import { once } from "node:events";
 import { createServer } from "node:net";
 
 // Use a raw TCP server to avoid header count limits in HTTP servers.
-// The server reads the raw request, counts headers, and sends a valid HTTP response.
+// The server reads the raw request, extracts header info, and sends a JSON response.
 function makeRawHttpServer() {
   const server = createServer(socket => {
     let data = "";
@@ -15,13 +15,18 @@ function makeRawHttpServer() {
         const lines = headerSection.split("\r\n");
         // First line is the request line, rest are headers.
         let customCount = 0;
+        const headerNames: string[] = [];
         for (let i = 1; i < lines.length; i++) {
           const lower = lines[i].toLowerCase();
+          const colonIdx = lines[i].indexOf(":");
+          if (colonIdx > 0) {
+            headerNames.push(lines[i].substring(0, colonIdx).toLowerCase());
+          }
           if (lower.startsWith("x-h-")) {
             customCount++;
           }
         }
-        const body = JSON.stringify(customCount);
+        const body = JSON.stringify({ customCount, headerNames });
         socket.write(
           `HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${body.length}\r\nConnection: close\r\n\r\n${body}`,
         );
@@ -46,10 +51,9 @@ test("fetch with many headers does not crash", async () => {
   const res = await fetch(`http://127.0.0.1:${port}/test`, { headers });
   expect(res.status).toBe(200);
 
-  const receivedCount = await res.json();
-  // The request must complete successfully rather than crashing.
+  const { customCount } = await res.json();
   // Excess headers beyond the internal cap (250 user headers) are silently dropped.
-  expect(receivedCount).toBe(250);
+  expect(customCount).toBe(250);
 });
 
 test("fetch with exactly 250 custom headers sends all of them", async () => {
@@ -65,6 +69,39 @@ test("fetch with exactly 250 custom headers sends all of them", async () => {
   const res = await fetch(`http://127.0.0.1:${port}/test`, { headers });
   expect(res.status).toBe(200);
 
-  const customCount = await res.json();
+  const { customCount } = await res.json();
   expect(customCount).toBe(250);
+});
+
+test("default headers preserved when user headers overflow the buffer", async () => {
+  await using server = makeRawHttpServer().listen(0);
+  await once(server, "listening");
+  const port = (server.address() as any).port;
+
+  // Use "a-" prefixed headers which sort alphabetically before "accept",
+  // "host", "user-agent", etc. This ensures the filler headers consume all
+  // 250 user-header slots first, pushing the special headers into overflow.
+  // Without the fix, the override flags for Host/Accept/User-Agent would
+  // still be set (suppressing defaults), but the headers themselves would be
+  // dropped — resulting in missing mandatory headers like Host.
+  const headers = new Headers();
+  for (let i = 0; i < 250; i++) {
+    headers.set(`a-${String(i).padStart(4, "0")}`, `v${i}`);
+  }
+  // These special headers sort after "a-*" and will overflow.
+  headers.set("Host", "custom-host.example.com");
+  headers.set("User-Agent", "custom-agent");
+  headers.set("Accept", "text/html");
+
+  const res = await fetch(`http://127.0.0.1:${port}/test`, { headers });
+  expect(res.status).toBe(200);
+
+  const { headerNames } = await res.json();
+
+  // Even though the user-supplied Host, User-Agent, and Accept were dropped
+  // due to overflow, the DEFAULT versions of these headers must still be
+  // present (the override flags should not have been set for dropped headers).
+  expect(headerNames).toContain("host");
+  expect(headerNames).toContain("user-agent");
+  expect(headerNames).toContain("accept");
 });

--- a/test/js/bun/http/fetch-header-count-limit.test.ts
+++ b/test/js/bun/http/fetch-header-count-limit.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test";
+import { once } from "node:events";
+import { createServer } from "node:net";
+
+// Use a raw TCP server to avoid header count limits in HTTP servers.
+// The server reads the raw request, counts headers, and sends a valid HTTP response.
+function makeRawHttpServer() {
+  const server = createServer(socket => {
+    let data = "";
+    socket.on("data", chunk => {
+      data += chunk.toString();
+      // Wait for the end of the HTTP headers (double CRLF).
+      if (data.includes("\r\n\r\n")) {
+        const headerSection = data.split("\r\n\r\n")[0];
+        const lines = headerSection.split("\r\n");
+        // First line is the request line, rest are headers.
+        let customCount = 0;
+        for (let i = 1; i < lines.length; i++) {
+          const lower = lines[i].toLowerCase();
+          if (lower.startsWith("x-h-")) {
+            customCount++;
+          }
+        }
+        const body = JSON.stringify(customCount);
+        socket.write(
+          `HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${body.length}\r\nConnection: close\r\n\r\n${body}`,
+        );
+        socket.end();
+      }
+    });
+  });
+  return server;
+}
+
+test("fetch with many headers does not crash", async () => {
+  await using server = makeRawHttpServer().listen(0);
+  await once(server, "listening");
+  const port = (server.address() as any).port;
+
+  // Build a request with more headers than the internal fixed-size buffer (256).
+  const headers = new Headers();
+  for (let i = 0; i < 300; i++) {
+    headers.set(`x-h-${i}`, `v${i}`);
+  }
+
+  const res = await fetch(`http://127.0.0.1:${port}/test`, { headers });
+  expect(res.status).toBe(200);
+
+  const receivedCount = await res.json();
+  // The request must complete successfully rather than crashing.
+  // Some headers may be silently dropped to stay within the internal buffer,
+  // but the request must not segfault or corrupt memory.
+  expect(receivedCount).toBeGreaterThan(0);
+});
+
+test("fetch with exactly 250 custom headers sends all of them", async () => {
+  await using server = makeRawHttpServer().listen(0);
+  await once(server, "listening");
+  const port = (server.address() as any).port;
+
+  const headers = new Headers();
+  for (let i = 0; i < 250; i++) {
+    headers.set(`x-h-${i}`, `v${i}`);
+  }
+
+  const res = await fetch(`http://127.0.0.1:${port}/test`, { headers });
+  expect(res.status).toBe(200);
+
+  const customCount = await res.json();
+  expect(customCount).toBe(250);
+});

--- a/test/js/bun/http/fetch-header-count-limit.test.ts
+++ b/test/js/bun/http/fetch-header-count-limit.test.ts
@@ -48,9 +48,8 @@ test("fetch with many headers does not crash", async () => {
 
   const receivedCount = await res.json();
   // The request must complete successfully rather than crashing.
-  // Some headers may be silently dropped to stay within the internal buffer,
-  // but the request must not segfault or corrupt memory.
-  expect(receivedCount).toBeGreaterThan(0);
+  // Excess headers beyond the internal cap (250 user headers) are silently dropped.
+  expect(receivedCount).toBe(250);
 });
 
 test("fetch with exactly 250 custom headers sends all of them", async () => {


### PR DESCRIPTION
## Summary

- Cap the number of user-supplied headers written into the fixed-size `shared_request_headers_buf` (256 entries) in `buildRequest` to prevent out-of-bounds writes when a `fetch()` call includes more headers than the buffer can hold.
- Six slots are reserved for default headers (Connection, User-Agent, Accept, Host, Accept-Encoding, Content-Length/Transfer-Encoding), leaving 250 for user-supplied headers. Excess headers are silently dropped while their semantic flags (e.g. `override_host_header`) are still processed correctly.
- Added tests verifying that fetch with 300 headers completes without crashing and that 250 custom headers are all delivered correctly.

## Test plan

- [x] `bun bd test test/js/bun/http/fetch-header-count-limit.test.ts` passes (2 tests)
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)