### PR TITLE
fix(ipc): harden internal message handling for non-cluster subprocesses

### DIFF
--- a/src/bun.js/node/node_cluster_binding.zig
+++ b/src/bun.js/node/node_cluster_binding.zig
@@ -153,7 +153,14 @@ pub const InternalMsgHolder = struct {
         bun.assert(this.isReady());
         var messages = this.messages;
         this.messages = .{};
-        for (messages.items) |*strong| {
+        var i: usize = 0;
+        errdefer {
+            // Clean up remaining Strong refs and the array on error.
+            for (messages.items[i..]) |*s| s.deinit();
+            messages.deinit(bun.default_allocator);
+        }
+        while (i < messages.items.len) : (i += 1) {
+            var strong = &messages.items[i];
             if (strong.get()) |message| {
                 try this.dispatchUnsafe(message, globalThis);
             }

--- a/src/bun.js/node/node_cluster_binding.zig
+++ b/src/bun.js/node/node_cluster_binding.zig
@@ -214,37 +214,13 @@ pub fn onInternalMessagePrimary(globalThis: *jsc.JSGlobalObject, callframe: *jsc
     // TODO: remove these strongs.
     ipc_data.internal_msg_queue.worker = .create(arguments[1], globalThis);
     ipc_data.internal_msg_queue.cb = .create(arguments[2], globalThis);
+    try ipc_data.internal_msg_queue.flush(globalThis);
     return .js_undefined;
 }
 
 pub fn handleInternalMessagePrimary(globalThis: *jsc.JSGlobalObject, subprocess: *jsc.Subprocess, message: jsc.JSValue) bun.JSError!void {
     const ipc_data = subprocess.ipc() orelse return;
-
-    const event_loop = globalThis.bunVM().eventLoop();
-
-    // TODO: investigate if "ack" and "seq" are observable and if they're not, remove them entirely.
-    if (try message.get(globalThis, "ack")) |p| {
-        if (!p.isUndefined()) {
-            const ack = p.toInt32();
-            if (ipc_data.internal_msg_queue.callbacks.getEntry(ack)) |entry| {
-                var cbstrong = entry.value_ptr.*;
-                defer cbstrong.deinit();
-                _ = ipc_data.internal_msg_queue.callbacks.swapRemove(ack);
-                const cb = cbstrong.get().?;
-                event_loop.runCallback(cb, globalThis, ipc_data.internal_msg_queue.worker.get().?, &.{
-                    message,
-                    .null, // handle
-                });
-                return;
-            }
-        }
-    }
-    const cb = ipc_data.internal_msg_queue.cb.get().?;
-    event_loop.runCallback(cb, globalThis, ipc_data.internal_msg_queue.worker.get().?, &.{
-        message,
-        .null, // handle
-    });
-    return;
+    try ipc_data.internal_msg_queue.dispatch(message, globalThis);
 }
 
 //

--- a/test/js/bun/spawn/fixtures/ipc-internal-msg-child-json.js
+++ b/test/js/bun/spawn/fixtures/ipc-internal-msg-child-json.js
@@ -1,0 +1,16 @@
+// Child process that writes a raw internal-format message (JSON mode)
+// followed by a normal message, to verify the parent handles it gracefully.
+const fs = require("fs");
+const fd = 3; // NODE_CHANNEL_FD
+
+// In JSON IPC mode, byte 0x02 prefix marks a message as "internal" (cluster).
+// Write an internal-format message directly to the IPC fd.
+const internalMsg = Buffer.concat([
+  Buffer.from([0x02]),
+  Buffer.from(JSON.stringify({ cmd: "NODE_FAKE_INTERNAL" })),
+  Buffer.from("\n"),
+]);
+fs.writeSync(fd, internalMsg);
+
+// Now send a normal message through the standard API.
+process.send("normal_after_internal");

--- a/test/js/bun/spawn/spawn-ipc-internal-msg.test.ts
+++ b/test/js/bun/spawn/spawn-ipc-internal-msg.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { expect, it } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import path from "path";
 
 // Verify that the parent process handles internal-format IPC messages
@@ -8,7 +8,10 @@ import path from "path";
 // Previously, receiving such messages could cause the parent to crash
 // because the internal message handler assumed cluster state was initialized.
 
-it("parent handles internal-format IPC message in json mode without crashing", async () => {
+// The child fixture writes raw bytes (0x02 prefix) directly to fd 3, which
+// only works on Unix where IPC uses a socketpair. On Windows, IPC uses named
+// pipes and fd 3 is not the IPC channel.
+it.skipIf(isWindows)("parent handles internal-format IPC message in json mode without crashing", async () => {
   const { promise, resolve } = Promise.withResolvers<string>();
 
   await using child = spawn([bunExe(), path.join(__dirname, "fixtures", "ipc-internal-msg-child-json.js")], {

--- a/test/js/bun/spawn/spawn-ipc-internal-msg.test.ts
+++ b/test/js/bun/spawn/spawn-ipc-internal-msg.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { expect, it } from "bun:test";
-import { bunExe } from "harness";
+import { bunEnv, bunExe } from "harness";
 import path from "path";
 
 // Verify that the parent process handles internal-format IPC messages
@@ -11,17 +11,15 @@ import path from "path";
 it("parent handles internal-format IPC message in json mode without crashing", async () => {
   const { promise, resolve } = Promise.withResolvers<string>();
 
-  const child = spawn([bunExe(), path.join(__dirname, "fixtures", "ipc-internal-msg-child-json.js")], {
+  await using child = spawn([bunExe(), path.join(__dirname, "fixtures", "ipc-internal-msg-child-json.js")], {
     ipc: message => {
       resolve(String(message));
     },
     stdio: ["inherit", "inherit", "inherit"],
     serialization: "json",
+    env: bunEnv,
   });
 
   const message = await promise;
   expect(message).toBe("normal_after_internal");
-
-  child.kill();
-  await child.exited;
 });

--- a/test/js/bun/spawn/spawn-ipc-internal-msg.test.ts
+++ b/test/js/bun/spawn/spawn-ipc-internal-msg.test.ts
@@ -25,4 +25,5 @@ it.skipIf(isWindows)("parent handles internal-format IPC message in json mode wi
 
   const message = await promise;
   expect(message).toBe("normal_after_internal");
+  expect(await child.exited).toBe(0);
 });

--- a/test/js/bun/spawn/spawn-ipc-internal-msg.test.ts
+++ b/test/js/bun/spawn/spawn-ipc-internal-msg.test.ts
@@ -1,0 +1,27 @@
+import { spawn } from "bun";
+import { expect, it } from "bun:test";
+import { bunExe } from "harness";
+import path from "path";
+
+// Verify that the parent process handles internal-format IPC messages
+// gracefully when the subprocess was not spawned via cluster.fork().
+// Previously, receiving such messages could cause the parent to crash
+// because the internal message handler assumed cluster state was initialized.
+
+it("parent handles internal-format IPC message in json mode without crashing", async () => {
+  const { promise, resolve } = Promise.withResolvers<string>();
+
+  const child = spawn([bunExe(), path.join(__dirname, "fixtures", "ipc-internal-msg-child-json.js")], {
+    ipc: message => {
+      resolve(String(message));
+    },
+    stdio: ["inherit", "inherit", "inherit"],
+    serialization: "json",
+  });
+
+  const message = await promise;
+  expect(message).toBe("normal_after_internal");
+
+  child.kill();
+  await child.exited;
+});


### PR DESCRIPTION
## Summary

- `handleInternalMessagePrimary` previously accessed `cb` and `worker` fields directly via `.get().?`, which are only initialized for `cluster.fork()` subprocesses. For regular subprocesses (`Bun.spawn` with IPC, `child_process.fork`), these fields remain empty, causing a crash when an internal-format IPC message is received.
- Replaced the unsafe direct field access with the safe `dispatch()` path, which checks `isReady()` and queues messages until the handler is registered — matching how `handleInternalMessageChild` already works on the child side.
- Added `flush()` call in `onInternalMessagePrimary` to dispatch any queued messages once the handler is set up, matching the child-side `onInternalMessageChild` behavior.

## Test plan

- [x] New test `spawn-ipc-internal-msg.test.ts` verifies parent doesn't crash when child sends internal-format IPC message in JSON mode
- [x] Verified test crashes (segfault at 0x0) with system bun, passes with debug build
- [x] Existing IPC tests (`spawn.ipc.test.ts`, `spawn.ipc.bun-node.test.ts`, `spawn.ipc.node-bun.test.ts`) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)