### PR TITLE
fix(http): harden maxRequestBodySize enforcement for chunked requests

### DIFF
--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -59,6 +59,9 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
         request_body: ?*WebCore.Body.Value.HiveRef = null,
         request_body_buf: std.ArrayListUnmanaged(u8) = .{},
         request_body_content_len: usize = 0,
+        /// Running total of bytes received via onBufferedBodyChunk, used to
+        /// enforce maxRequestBodySize when the body is consumed as a stream.
+        streamed_body_bytes_received: usize = 0,
 
         sink: ?*ResponseStream.JSSink = null,
         byte_stream: ?*jsc.WebCore.ByteStream = null,
@@ -2376,14 +2379,25 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                 // We have to ignore those chunks unless it's the last one
                 return;
             }
-            const vm = this.server.?.vm;
-            const globalThis = this.server.?.globalThis;
+            const server = this.server orelse return;
+            const vm = server.vm;
+            const globalThis = server.globalThis;
+            const max_body_size = server.config.max_request_body_size;
 
             // After the user does request.body,
             // if they then do .text(), .arrayBuffer(), etc
             // we can no longer hold the strong reference from the body value ref.
             if (this.request_body_readable_stream_ref.get(globalThis)) |readable| {
                 assert(this.request_body_buf.items.len == 0);
+
+                // Enforce max body size for streaming bodies (e.g. chunked transfer encoding
+                // where Content-Length is not set upfront).
+                this.streamed_body_bytes_received += chunk.len;
+                if (this.streamed_body_bytes_received > max_body_size) {
+                    this.rejectRequestBodyAsEntityTooLarge(resp);
+                    return;
+                }
+
                 vm.eventLoop().enter();
                 defer vm.eventLoop().exit();
 
@@ -2425,6 +2439,13 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                     var old = body.value;
 
                     const total = bytes.items.len + chunk.len;
+
+                    // Enforce max body size for the final chunk.
+                    if (total > max_body_size) {
+                        this.rejectRequestBodyAsEntityTooLarge(resp);
+                        return;
+                    }
+
                     getter: {
                         // if (total <= jsc.WebCore.InlineBlob.available_bytes) {
                         //     if (total == 0) {
@@ -2464,11 +2485,35 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                     return;
                 }
 
-                if (this.request_body_buf.capacity == 0) {
-                    this.request_body_buf.ensureTotalCapacityPrecise(this.allocator, @min(this.request_body_content_len, max_request_body_preallocate_length)) catch @panic("Out of memory while allocating request body buffer");
+                // Enforce max body size on cumulative buffered data.
+                const new_total = this.request_body_buf.items.len + chunk.len;
+                if (new_total > max_body_size) {
+                    this.rejectRequestBodyAsEntityTooLarge(resp);
+                    return;
                 }
-                this.request_body_buf.appendSlice(this.allocator, chunk) catch @panic("Out of memory while allocating request body");
+
+                if (this.request_body_buf.capacity == 0) {
+                    this.request_body_buf.ensureTotalCapacityPrecise(this.allocator, @min(this.request_body_content_len, max_request_body_preallocate_length)) catch {
+                        this.rejectRequestBodyAsEntityTooLarge(resp);
+                        return;
+                    };
+                }
+                this.request_body_buf.appendSlice(this.allocator, chunk) catch {
+                    this.rejectRequestBodyAsEntityTooLarge(resp);
+                    return;
+                };
             }
+        }
+
+        /// Send a 413 response and close the connection. Used when the
+        /// cumulative body size exceeds the configured maxRequestBodySize.
+        fn rejectRequestBodyAsEntityTooLarge(this: *RequestContext, resp: *App.Response) void {
+            assert(this.resp == resp);
+            if (!this.flags.has_written_status) {
+                this.flags.has_written_status = true;
+                resp.writeStatus("413 Request Entity Too Large");
+            }
+            this.endWithoutBody(true);
         }
 
         pub fn onStartStreamingRequestBody(this: *RequestContext) jsc.WebCore.DrainResult {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1546,6 +1546,119 @@ it("should response with HTTP 413 when request body is larger than maxRequestBod
   }
 });
 
+it("should enforce maxRequestBodySize for chunked transfer encoding requests", async () => {
+  using server = Bun.serve({
+    port: 0,
+    maxRequestBodySize: 64,
+    async fetch(req) {
+      const body = await req.text();
+      return new Response("OK:" + body.length);
+    },
+  });
+
+  const port = server.port;
+  const hostname = server.hostname;
+
+  // Test 1: chunked request within the limit should succeed
+  {
+    const { promise, resolve } = Promise.withResolvers<string>();
+    const socket = await Bun.connect({
+      hostname,
+      port,
+      socket: {
+        data(_socket, data) {
+          resolve(data.toString());
+          _socket.end();
+        },
+        open(socket) {
+          const body = "A".repeat(32);
+          const chunk = body.length.toString(16) + "\r\n" + body + "\r\n";
+          socket.write(
+            `POST / HTTP/1.1\r\nHost: ${hostname}:${port}\r\nTransfer-Encoding: chunked\r\n\r\n${chunk}0\r\n\r\n`,
+          );
+          socket.flush();
+        },
+        error() {},
+        close() {},
+      },
+    });
+    const response = await promise;
+    expect(response).toContain("200 OK");
+    expect(response).toContain("OK:32");
+  }
+
+  // Test 2: chunked request exceeding the limit should get 413
+  {
+    const { promise, resolve } = Promise.withResolvers<string>();
+    const socket = await Bun.connect({
+      hostname,
+      port,
+      socket: {
+        data(_socket, data) {
+          resolve(data.toString());
+          _socket.end();
+        },
+        open(socket) {
+          // Send a body larger than 64 bytes via chunked encoding (no Content-Length)
+          const body = "B".repeat(128);
+          const chunk = body.length.toString(16) + "\r\n" + body + "\r\n";
+          socket.write(
+            `POST / HTTP/1.1\r\nHost: ${hostname}:${port}\r\nTransfer-Encoding: chunked\r\n\r\n${chunk}0\r\n\r\n`,
+          );
+          socket.flush();
+        },
+        error() {},
+        close() {},
+      },
+    });
+    const response = await promise;
+    expect(response).toContain("413");
+  }
+
+  // Test 3: multiple small chunks that cumulatively exceed the limit should get 413
+  {
+    const { promise, resolve } = Promise.withResolvers<string>();
+    const socket = await Bun.connect({
+      hostname,
+      port,
+      socket: {
+        data(_socket, data) {
+          resolve(data.toString());
+          _socket.end();
+        },
+        open(socket) {
+          // First chunk of 40 bytes, below the 64 byte limit
+          const body1 = "C".repeat(40);
+          const chunk1 = body1.length.toString(16) + "\r\n" + body1 + "\r\n";
+          socket.write(`POST / HTTP/1.1\r\nHost: ${hostname}:${port}\r\nTransfer-Encoding: chunked\r\n\r\n${chunk1}`);
+          socket.flush();
+          // Second chunk of 40 bytes, pushing total to 80 which exceeds the 64 byte limit
+          setTimeout(() => {
+            const body2 = "D".repeat(40);
+            const chunk2 = body2.length.toString(16) + "\r\n" + body2 + "\r\n";
+            socket.write(chunk2 + "0\r\n\r\n");
+            socket.flush();
+          }, 50);
+        },
+        error() {},
+        close() {},
+      },
+    });
+    const response = await promise;
+    expect(response).toContain("413");
+  }
+
+  // Test 4: server should still work after rejecting oversized requests
+  {
+    const resp = await fetch(`http://${hostname}:${port}`, {
+      method: "POST",
+      body: "small",
+    });
+    expect(resp.status).toBe(200);
+    expect(await resp.text()).toBe("OK:5");
+  }
+});
+
 it("should support promise returned from error", async () => {
   const { promise, resolve } = Promise.withResolvers<string>();
 


### PR DESCRIPTION
## Summary

- Enforce `maxRequestBodySize` on cumulative body bytes during chunked transfer-encoding requests. Previously the limit was only checked against the `Content-Length` header, which is absent for chunked requests, so the check was effectively bypassed.
- Track accumulated bytes as chunks arrive in `onBufferedBodyChunk` across all three code paths (readable stream, final buffered chunk, intermediate buffered chunks) and return HTTP 413 when the configured limit is exceeded.
- Replace `@panic` on allocation failure in the body buffering path with a graceful 413 response and connection close instead of crashing the process.

## Test plan

- [x] New test: chunked request within limit succeeds (200)
- [x] New test: single chunked request exceeding limit returns 413
- [x] New test: multiple small chunks cumulatively exceeding limit returns 413  
- [x] New test: server continues working after rejecting oversized requests
- [x] Existing `maxRequestBodySize` test with Content-Length still passes
- [x] Existing regression test (issue #22353) still passes
- [x] Verified new test fails with system bun (`USE_SYSTEM_BUN=1`) and passes with debug build

🤖 Generated with [Claude Code](https://claude.com/claude-code)