### PR TITLE
fix(http): add Date header to error responses using endWithoutBody

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1981,6 +1981,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                             if (!node_response.flags.request_has_completed and raw_response.state().isResponsePending()) {
                                 if (raw_response.state().isHttpStatusCalled()) {
                                     raw_response.writeStatus("500 Internal Server Error");
+                                    raw_response.writeMark();
                                     raw_response.endWithoutBody(true);
                                 } else {
                                     raw_response.endStream(true);
@@ -2217,6 +2218,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                     // Abort the request very early.
                     if (len > this.config.max_request_body_size) {
                         resp.writeStatus("413 Request Entity Too Large");
+                        resp.writeMark();
                         resp.endWithoutBody(true);
                         return null;
                     }
@@ -2344,6 +2346,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 // require fetch method to be set otherwise we dont know what route to call
                 // this should be the fallback in case no route is provided to upgrade
                 resp.writeStatus("403 Forbidden");
+                resp.writeMark();
                 resp.endWithoutBody(true);
                 return;
             }

--- a/test/regression/issue/27512.test.ts
+++ b/test/regression/issue/27512.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+
+test("413 responses should include a Date header", async () => {
+  using server = Bun.serve({
+    port: 0,
+    maxRequestBodySize: 1,
+    fetch() {
+      return new Response("Hello Bun");
+    },
+  });
+
+  const res = await fetch(`http://localhost:${server.port}/`, {
+    method: "POST",
+    body: "12",
+  });
+  expect(res.status).toBe(413);
+  expect(res.headers.get("date")).not.toBeNull();
+});


### PR DESCRIPTION
## Summary
- Fixes #27512 — 413 (and other early error) HTTP responses were missing the `Date` header.
- The root cause was that `endWithoutBody()` calls in `server.zig` skipped `writeMark()`, which is the function responsible for writing the `Date` header. This is now called at all three affected sites: the 413 (request body too large), 403 (no onRequest handler), and 500 (exception/rejection) error paths.

## Test plan
- [x] Added regression test `test/regression/issue/27512.test.ts` that verifies a 413 response includes a `Date` header
- [x] Verified test fails with system bun (`USE_SYSTEM_BUN=1`)
- [x] Verified test passes with debug build (`bun bd test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)