### PR TITLE
fix(repl): duplicate property names in completions

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -89,6 +89,7 @@
 #include "wtf/text/StringView.h"
 #include "wtf/text/WTFString.h"
 #include "wtf/GregorianDateTime.h"
+#include "wtf/HashSet.h"
 
 #include "JavaScriptCore/FunctionPrototype.h"
 #include "JSFetchHeaders.h"
@@ -6237,11 +6238,18 @@ extern "C" JSC::EncodedJSValue Bun__REPL__getCompletions(
     JSC::JSArray* completions = JSC::constructEmptyArray(globalObject, nullptr, 0);
     RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
 
+    // Use a set to track already added property names and avoid duplicates
+    // This fixes the issue where properties that appear multiple times in the prototype chain
+    // (e.g., toString appearing in both Function.prototype and Object.prototype)
+    // would be listed multiple times in completions
+    WTF::HashSet<WTF::String> addedNames;
+
     unsigned completionIndex = 0;
     for (const auto& propertyName : propertyNames) {
         WTF::String name = propertyName.string();
-        if (prefix.isEmpty() || name.startsWith(prefix)) {
+        if ((prefix.isEmpty() || name.startsWith(prefix)) && !addedNames.contains(name)) {
             completions->putDirectIndex(globalObject, completionIndex++, JSC::jsString(vm, name));
+            addedNames.add(name);
             RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
         }
     }
@@ -6258,8 +6266,9 @@ extern "C" JSC::EncodedJSValue Bun__REPL__getCompletions(
 
         for (const auto& propertyName : protoNames) {
             WTF::String name = propertyName.string();
-            if (prefix.isEmpty() || name.startsWith(prefix)) {
+            if ((prefix.isEmpty() || name.startsWith(prefix)) && !addedNames.contains(name)) {
                 completions->putDirectIndex(globalObject, completionIndex++, JSC::jsString(vm, name));
+                addedNames.add(name);
                 RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(completions));
             }
         }


### PR DESCRIPTION
### What does this PR do?

Try to fix duplicate property names in REPL tab completion when properties appear multiple times in the prototype chain. https://github.com/oven-sh/bun/issues/27516

**Problem**: When using tab completion in the Bun REPL, property names were being duplicated in the completion suggestions. For example, entering `{}.to` and pressing Tab would show:
```
toString
toLocaleString
toString
toLocaleString
```

This happened because the completion function traversed the entire prototype chain and added properties from each level without checking for duplicates. Since properties like `toString` exist in multiple prototype objects (e.g., both `Function.prototype` and `Object.prototype`), they would appear multiple times in the completion list.

**Solution**: Introduce a `WTF::HashSet<WTF::String>` to track property names that have already been added to the completion list. Before adding any property name to the completion array, the code now checks if it's already in the set. Only unique property names are added, ensuring each property appears exactly once regardless of how many times it appears in the prototype chain.

**Changes**:

- Added `#include "wtf/HashSet.h"` to the bindings.cpp header includes
- Modified `Bun__REPL__getCompletions` function in `src/bun.js/bindings/bindings.cpp` to use a HashSet for deduplication
- Added check `!addedNames.contains(name)` before adding property names to the completion array
- Added `addedNames.add(name)` call when a property is successfully added to track it


### How did you verify your code works?

- Passed `bun run zig:check-all` and `bun run build`
- After compilation, self-tested locally via `build/debug/bun-debug repl` in my terminal