### PR TITLE
fix(transpiler): treat emitDecoratorMetadata as implying legacy decorators

### DIFF
--- a/src/bundler/ParseTask.zig
+++ b/src/bundler/ParseTask.zig
@@ -1219,7 +1219,10 @@ fn runWithSourceCode(
     opts.features.minify_keep_names = transpiler.options.keep_names;
     opts.features.minify_whitespace = transpiler.options.minify_whitespace;
     opts.features.emit_decorator_metadata = task.emit_decorator_metadata;
-    opts.features.standard_decorators = !loader.isTypeScript() or !task.experimental_decorators;
+    // emitDecoratorMetadata implies legacy/experimental decorators, as it only
+    // makes sense with TypeScript's legacy decorator system (reflect-metadata).
+    // TC39 standard decorators have their own metadata mechanism.
+    opts.features.standard_decorators = !loader.isTypeScript() or !(task.experimental_decorators or task.emit_decorator_metadata);
     opts.features.unwrap_commonjs_packages = transpiler.options.unwrap_commonjs_packages;
     opts.features.bundler_feature_flags = transpiler.options.bundler_feature_flags;
     opts.features.hot_module_reloading = output_format == .internal_bake_dev and !source.index.isRuntime();

--- a/src/transpiler.zig
+++ b/src/transpiler.zig
@@ -1103,7 +1103,10 @@ pub const Transpiler = struct {
                 var opts = js_parser.Parser.Options.init(jsx, loader);
 
                 opts.features.emit_decorator_metadata = this_parse.emit_decorator_metadata;
-                opts.features.standard_decorators = !loader.isTypeScript() or !this_parse.experimental_decorators;
+                // emitDecoratorMetadata implies legacy/experimental decorators, as it only
+                // makes sense with TypeScript's legacy decorator system (reflect-metadata).
+                // TC39 standard decorators have their own metadata mechanism.
+                opts.features.standard_decorators = !loader.isTypeScript() or !(this_parse.experimental_decorators or this_parse.emit_decorator_metadata);
                 opts.features.allow_runtime = transpiler.options.allow_runtime;
                 opts.features.set_breakpoint_on_first_line = this_parse.set_breakpoint_on_first_line;
                 opts.features.trim_unused_imports = transpiler.options.trim_unused_imports orelse loader.isTypeScript();

--- a/test/regression/issue/27526.test.ts
+++ b/test/regression/issue/27526.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// When emitDecoratorMetadata is true in tsconfig but experimentalDecorators is
+// absent, Bun should use legacy decorator semantics (not TC39 standard).
+// emitDecoratorMetadata only makes sense with legacy decorators.
+test("legacy decorators work when emitDecoratorMetadata is true without experimentalDecorators", async () => {
+  using dir = tempDir("issue-27526", {
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2021",
+        module: "commonjs",
+        strict: true,
+        esModuleInterop: true,
+        emitDecoratorMetadata: true,
+      },
+    }),
+    "index.ts": `
+function MyDecorator(target: any, key: string, descriptor: PropertyDescriptor) {
+  const original = descriptor.value;
+  descriptor.value = function(...args: any[]) {
+    return "decorated:" + original.apply(this, args);
+  };
+}
+
+class Foo {
+  @MyDecorator
+  hello() {
+    return "world";
+  }
+}
+
+console.log(new Foo().hello());
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("decorated:world");
+  expect(exitCode).toBe(0);
+});
+
+// When neither emitDecoratorMetadata nor experimentalDecorators is set,
+// TypeScript files should use TC39 standard decorators.
+test("TC39 standard decorators work when neither emitDecoratorMetadata nor experimentalDecorators is set", async () => {
+  using dir = tempDir("issue-27526-standard", {
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2021",
+        module: "commonjs",
+        strict: true,
+      },
+    }),
+    "index.ts": `
+function MyDecorator(value: Function, context: ClassMethodDecoratorContext) {
+  return function(this: any, ...args: any[]) {
+    return "decorated:" + (value as any).apply(this, args);
+  };
+}
+
+class Foo {
+  @MyDecorator
+  hello() {
+    return "world";
+  }
+}
+
+console.log(new Foo().hello());
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("decorated:world");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- When `emitDecoratorMetadata: true` is set in tsconfig.json without `experimentalDecorators: true`, Bun now correctly uses legacy decorator semantics instead of TC39 standard decorator lowering
- `emitDecoratorMetadata` only makes sense with TypeScript's legacy decorator system (`reflect-metadata`), so its presence implies the user expects legacy decorator behavior
- This fixes a regression from ce715b5a0f where NestJS, TypeORM, Angular, and other legacy-decorator frameworks would crash with `descriptor.value` undefined

Closes #27526

## Test plan

- [x] Added regression test `test/regression/issue/27526.test.ts` with two cases:
  - Legacy decorators work when `emitDecoratorMetadata: true` but `experimentalDecorators` is absent
  - TC39 standard decorators still work when neither option is set
- [x] Verified test fails with system Bun (`USE_SYSTEM_BUN=1`) and passes with debug build (`bun bd test`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)