### PR TITLE
Correct build and start script formatting in Next.js Vercel guide

### DIFF
--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -40,7 +40,8 @@ mode: center
     	{
     		"scripts": {
     			"dev": "bun --bun next dev", // [!code ++]
-    			"build": "bun --bun next build" // [!code ++]
+    			"build": "bun --bun next build", // [!code ++]
+				"start": "bun --bun next start" // [!code ++]
     		}
     	}
     	```

--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -41,7 +41,7 @@ mode: center
     		"scripts": {
     			"dev": "bun --bun next dev", // [!code ++]
     			"build": "bun --bun next build", // [!code ++]
-				"start": "bun --bun next start" // [!code ++]
+    			"start": "bun --bun next start" // [!code ++]
     		}
     	}
     	```


### PR DESCRIPTION
### What does this PR do?
Adds the missing Bun runtime script to the `package.json` to properly align it with the [Next.js guide](https://bun.com/docs/guides/ecosystem/nextjs)