### PR TITLE
fix(bundler): preserve original specifier in require.resolve() output

### DIFF
--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -2383,7 +2383,16 @@ fn NewPrinter(
                     }
 
                     p.print("(");
-                    p.printStringLiteralUTF8(p.importRecord(e.import_record_index).path.text, true);
+                    const record = p.importRecord(e.import_record_index);
+                    // Use the original specifier if available, so that require.resolve()
+                    // calls are resolved at runtime rather than being hardcoded to
+                    // an absolute path from the build machine. This is critical for
+                    // `bun build --compile` where the binary runs on different machines.
+                    const path_to_print = if (record.original_path.len > 0)
+                        record.original_path
+                    else
+                        record.path.text;
+                    p.printStringLiteralUTF8(path_to_print, true);
                     p.print(")");
 
                     if (wrap) {

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -3991,6 +3991,34 @@ describe("bundler", () => {
     },
     external: ["external-pkg", "@scope/external-pkg", "{{root}}/external-file"],
   });
+  // https://github.com/oven-sh/bun/issues/27530
+  itBundled("default/RequireResolvePreservesOriginalSpecifier", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require.resolve('my-pkg/package.json'))
+        console.log(require.resolve('my-pkg'))
+        console.log(require.resolve('@scope/my-pkg/subpath'))
+      `,
+      "/node_modules/my-pkg/package.json": JSON.stringify({ name: "my-pkg", version: "1.0.0", main: "index.js" }),
+      "/node_modules/my-pkg/index.js": `module.exports = {}`,
+      "/node_modules/@scope/my-pkg/package.json": JSON.stringify({
+        name: "@scope/my-pkg",
+        version: "1.0.0",
+        main: "index.js",
+      }),
+      "/node_modules/@scope/my-pkg/index.js": `module.exports = {}`,
+      "/node_modules/@scope/my-pkg/subpath.js": `module.exports = {}`,
+    },
+    target: "bun",
+    onAfterBundle(api) {
+      // require.resolve() should preserve the original specifier, not an absolute path
+      api.expectFile("/out.js").toContain('require.resolve("my-pkg/package.json")');
+      api.expectFile("/out.js").toContain('require.resolve("my-pkg")');
+      api.expectFile("/out.js").toContain('require.resolve("@scope/my-pkg/subpath")');
+      // Must not contain absolute paths from the build machine
+      api.expectFile("/out.js").not.toMatch(/require\.resolve\("\/[^"]*node_modules/);
+    },
+  });
   itBundled("default/InjectMissing", {
     files: {
       "/entry.js": ``,


### PR DESCRIPTION
## Summary
- **Fixes** `bun build --compile` producing binaries that fail with `Cannot find module '/absolute/path/from/build/machine/...'` when using packages like `playwright` that call `require.resolve()` at runtime.
- The bundler's printer was using the resolved absolute path (`import_record.path.text`) for `require.resolve()` calls instead of the original specifier (`import_record.original_path`). This hardcoded build-machine paths into the output.
- Now uses `original_path` (the specifier as written in source code, e.g. `"playwright-core/package.json"`) so `require.resolve()` resolves correctly at runtime.

Closes #27530

## Test plan
- [x] Added `default/RequireResolvePreservesOriginalSpecifier` bundler test that verifies original specifiers are preserved
- [x] Test fails with system bun (confirms the bug) and passes with the fix
- [x] Existing `RequireResolve`, `ConditionalRequireResolve`, and `compile/ResolveEmbeddedFile` tests continue to pass
- [x] Transpiler `require.resolve` test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)