### PR TITLE
fix(node): coerce process.env values to strings like Node.js

### DIFF
--- a/src/bun.js/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/bun.js/bindings/JSEnvironmentVariableMap.cpp
@@ -305,7 +305,7 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
     bool hasNodeTLSRejectUnauthorized = false;
     bool hasBunConfigVerboseFetch = false;
 
-    auto* cached_getter_setter = JSC::CustomGetterSetter::create(vm, jsGetterEnvironmentVariable, nullptr);
+    auto* cached_getter_setter = JSC::CustomGetterSetter::create(vm, jsGetterEnvironmentVariable, jsSetterEnvironmentVariable);
 
     for (size_t i = 0; i < count; i++) {
         unsigned char* chars;

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -393,7 +393,7 @@ export function windowsEnv(
     set(_, p, value) {
       const k = String(p).toUpperCase();
       $assert(typeof p === "string"); // proxy is only string and symbol. the symbol would have thrown by now
-      value = String(value); // If toString() throws, we want to avoid it existing in the envMapList
+      value = "" + value; // If toString() throws, we want to avoid it existing in the envMapList
       if (!(k in internalEnv) && !envMapList.includes(p)) {
         envMapList.push(p);
       }

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -158,6 +158,18 @@ it("process.env", () => {
   expect(process.env["LOL SMILE latin1 <abc>"]).toBe("<abc>");
   delete process.env["LOL SMILE latin1 <abc>"];
   expect(process.env["LOL SMILE latin1 <abc>"]).toBe(undefined);
+
+  // Node.js coerces non-string values to strings
+  process.env.BUN_TEST_ENV_COERCE = undefined;
+  expect(process.env.BUN_TEST_ENV_COERCE).toBe("undefined");
+  process.env.BUN_TEST_ENV_COERCE = null;
+  expect(process.env.BUN_TEST_ENV_COERCE).toBe("null");
+  process.env.BUN_TEST_ENV_COERCE = 123;
+  expect(process.env.BUN_TEST_ENV_COERCE).toBe("123");
+  delete process.env.BUN_TEST_ENV_COERCE;
+
+  // Symbol assignment should throw TypeError, matching Node.js
+  expect(() => { process.env.BUN_TEST_ENV_COERCE = Symbol("test"); }).toThrow(TypeError);
 });
 
 it("process.env is spreadable and editable", () => {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -169,7 +169,9 @@ it("process.env", () => {
   delete process.env.BUN_TEST_ENV_COERCE;
 
   // Symbol assignment should throw TypeError, matching Node.js
-  expect(() => { process.env.BUN_TEST_ENV_COERCE = Symbol("test"); }).toThrow(TypeError);
+  expect(() => {
+    process.env.BUN_TEST_ENV_COERCE = Symbol("test");
+  }).toThrow(TypeError);
 });
 
 it("process.env is spreadable and editable", () => {


### PR DESCRIPTION
## Summary

Fixes inconsistent behavior where `process.env.FOO = undefined` stored raw JS `undefined` on macOS/Linux but the string `"undefined"` on Windows. Node.js coerces to string on all platforms.

**Two fixes:**

1. **Non-Windows** (`JSEnvironmentVariableMap.cpp`): The `CustomGetterSetter` for env var properties was created with `nullptr` for the setter, so assignments stored raw JS values. Wire up the existing `jsSetterEnvironmentVariable` (which calls `JSValue::toString`, implementing ECMAScript's `ToString` abstract op) as the setter.

2. **Windows** (`ProcessObjectInternals.ts`): The Proxy `set` trap used `String(value)` which coerces `Symbol("x")` to `"Symbol(x)"` instead of throwing. Change to `"" + value` so Symbols throw `TypeError`, matching Node.js.

| Value assigned | Node.js | Old Bun (macOS/Linux) | Old Bun (Windows) | New Bun (all) |
|---|---|---|---|---|
| `undefined` | `"undefined"` | `undefined` | `"undefined"` | `"undefined"` |
| `null` | `"null"` | `null` | `"null"` | `"null"` |
| `123` | `"123"` | `123` | `"123"` | `"123"` |
| `Symbol()` | throws TypeError | no-op | `"Symbol()"` | throws TypeError |

## Root cause

`jsSetterEnvironmentVariable` was updated in Jan 2024 (commit `345a061d`) to call `.toString()` for proper coercion, but was never wired up as the setter on non-Windows — it remained dead code. This fixes it.

Supersedes #26389 and #19382.