### PR TITLE
fix(bundler): skip barrel-deferred imports in ESM bytecode ModuleInfo

### DIFF
--- a/src/bundler/linker_context/postProcessJSChunk.zig
+++ b/src/bundler/linker_context/postProcessJSChunk.zig
@@ -155,6 +155,10 @@ pub fn postProcessJSChunk(ctx: GenerateChunkCtx, worker: *ThreadPool.Worker, chu
                             // imports by the linker. The printer already recorded them
                             // when printing cross_chunk_prefix_stmts.
                             if (record.source_index.isValid()) continue;
+                            // Skip barrel-optimized-away imports — marked is_unused by
+                            // barrel_imports.zig. Never resolved (source_index invalid),
+                            // and removed by convertStmtsForChunk. Not in emitted code.
+                            if (record.flags.is_unused) continue;
 
                             const import_path = record.path.text;
                             const irp_id = mi.str(import_path) catch continue;


### PR DESCRIPTION
## Problem

When building with `--compile --bytecode --format=esm`, imports marked `is_unused` by barrel optimization are recorded in bytecode ModuleInfo as external dependencies, causing runtime crashes.

Regression from #26892 (barrel import optimization).

## Repro

```js
// node_modules/fakelib/package.json
{"name":"fakelib","type":"module","sideEffects":false,"main":"./index.js"}

// node_modules/fakelib/index.js
import Unused from './sub/unused.js';
import { used } from './sub/used.js';
export { Unused, used };

// entry.ts
import { used } from 'fakelib'
console.log(used())
```

```sh
bun build entry.ts --compile --format=esm --bytecode --outfile=out
./out
# error: Cannot find module './sub/unused.js' from '/$bunfs/root/out'
```

Affects real packages like `diff@8.x` (`"sideEffects": false` barrel with many re-exports).

## Root cause

1. `barrel_imports.zig` marks unused re-export imports as `is_unused = true`. Never resolved → `source_index` stays invalid.
2. `convertStmtsForChunk` correctly drops these via `shouldRemoveImportExportStmt` (checks `is_unused`) → emitted JS is fine.
3. But `postProcessJSChunk.zig` section 2 scans the **original** AST parts to populate bytecode ModuleInfo. It finds the `s_import` with `!record.source_index.isValid()` and records the relative specifier as an external module dependency.
4. At runtime, JSC reads ModuleInfo and tries to resolve `./sub/unused.js` from `$bunfs/root/` → fails.

Debug build assertion catches this as `Imports different between parseFromSourceCode and fallbackParse`.

## Fix

Skip `is_unused` records when scanning for external imports in ModuleInfo generation (they're not in the emitted code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)