### PR TITLE
fix(windows): patch libuv to fix pipe data loss from CancelIoEx race

### DIFF
--- a/patches/libuv/fix-win-pipe-cancel-race.patch
+++ b/patches/libuv/fix-win-pipe-cancel-race.patch
@@ -1,0 +1,38 @@
+--- a/src/win/pipe.c
++++ b/src/win/pipe.c
+@@ -2013,7 +2013,34 @@ static int uv__pipe_read_data(uv_loop_t* loop,
+         }
+       }
+     }
+-    more = *bytes_read == max_bytes;
++    /* Only indicate that more data may be available if we actually verify it.
++     * When bytes_read == max_bytes, the caller will loop back and call
++     * ReadFile again. If the pipe is empty at that point, ReadFile returns
++     * ERROR_IO_PENDING and we CancelIoEx the request. There is a Windows
++     * kernel race where data arriving on the pipe concurrently with the
++     * CancelIoEx can be drained from the pipe to satisfy the pending read,
++     * then silently discarded when the cancellation is applied. The read
++     * reports ERROR_OPERATION_ABORTED with 0 bytes transferred, but the
++     * data is no longer in the pipe either.
++     * Use PeekNamedPipe to confirm data is available before looping; if
++     * so, the next ReadFile will complete synchronously and we never enter
++     * the CancelIoEx path. */
++    if (*bytes_read == max_bytes) {
++      bytes_available = 0;
++      if (PeekNamedPipe(handle->handle,
++                        NULL,
++                        0,
++                        NULL,
++                        &bytes_available,
++                        NULL) &&
++          bytes_available > 0) {
++        more = 1;
++      } else {
++        more = 0;
++      }
++    } else {
++      more = 0;
++    }
+   }
+ 
+   /* Call the read callback. */


### PR DESCRIPTION
### What does this PR do?

Fixes #11297 — flaky Windows-only data loss when reading from subprocess pipes.

### Root Cause

A Windows kernel race in libuv's `uv__pipe_read_data`. When libuv's read loop fills the user buffer exactly (`bytes_read == buf.len`), it loops back for more. If the pipe is empty at that moment:
1. `ReadFile` returns `ERROR_IO_PENDING`
2. `CancelIoEx` is called to abort it
3. `GetOverlappedResult(TRUE)` blocks waiting for the cancellation

**The race**: if the child process writes to the pipe *during* step 3, the Windows kernel can drain that data from the pipe buffer to satisfy the pending read, then **discard it** when applying the cancellation. The read reports 0 bytes transferred, the user buffer is unmodified, but the data is gone from the pipe — **silent data loss**.

### Why Bun specifically?

Both Bun parent and Bun child use mimalloc. When the child reads stdin with `ensureUnusedCapacity(65536)`, mimalloc rounds to **74468 bytes**. The child then writes 74468-byte chunks to stdout. When the parent reads with the same mimalloc-rounded 74468-byte buffer, **every read fills the buffer exactly** → loop → `CancelIoEx` → race.

Node.js doesn't hit this because its allocator returns exactly 65536 bytes, so reads never align with writes.

Verified by writing chunks of exact sizes:
- `chunkSize=74467` → **20/20 OK**
- `chunkSize=74468` → **12/20 FAIL**
- `chunkSize=74469` → **20/20 OK**

### The Fix

Before looping, use `PeekNamedPipe` to verify data is actually available. If not, break and queue a zero-read — the `CancelIoEx` path is never entered. This replaces the [ReadFile → Cancel → Wait] sequence with a single `PeekNamedPipe` when the pipe is empty, so it's actually *faster* in the buggy case.

### Test Results

| | Before | After |
|---|---|---|
| `11297.test.ts` (30×) | flaky | 30/30 pass |
| `spawn-stdin-readable-stream.test.ts` | pass | pass |
| `spawn.test.ts` | pass | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)