### PR TITLE
fix(transpiler): pass experimentalDecorators/emitDecoratorMetadata to Bun.Transpiler parse options

### DIFF
--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -515,6 +515,8 @@ pub const TransformTask = struct {
             .path = source.path,
             .virtual_source = &source,
             .replace_exports = this.replace_exports,
+            .experimental_decorators = if (this.tsconfig) |ts| ts.experimental_decorators else false,
+            .emit_decorator_metadata = if (this.tsconfig) |ts| ts.emit_decorator_metadata else false,
         };
 
         const parse_result = this.transpiler.parse(parse_options, null) orelse {
@@ -806,7 +808,8 @@ fn getParseResult(this: *JSTranspiler, allocator: std.mem.Allocator, code: []con
         .virtual_source = source,
         .replace_exports = this.config.runtime.replace_exports,
         .macro_js_ctx = macro_js_ctx,
-        // .allocator = this.
+        .experimental_decorators = if (this.config.tsconfig) |ts| ts.experimental_decorators else false,
+        .emit_decorator_metadata = if (this.config.tsconfig) |ts| ts.emit_decorator_metadata else false,
     };
 
     return this.transpiler.parse(parse_options, null);

--- a/test/regression/issue/27575.test.ts
+++ b/test/regression/issue/27575.test.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/27575
+// Bun.Transpiler ignored experimentalDecorators: true from tsconfig,
+// always emitting TC39-style decorators instead of legacy TypeScript decorators.
+
+test("Bun.Transpiler respects experimentalDecorators: true from tsconfig", () => {
+  const transpiler = new Bun.Transpiler({
+    loader: "ts",
+    target: "browser",
+    tsconfig: JSON.stringify({
+      compilerOptions: {
+        experimentalDecorators: true,
+      },
+    }),
+  });
+
+  const code = `
+function Prop() { return function(target: any, key: string) {}; }
+
+class Foo {
+  @Prop() bar: number = 0;
+}
+`;
+
+  const result = transpiler.transformSync(code);
+
+  // Legacy decorators use __legacyDecorateClassTS, NOT TC39 helpers
+  expect(result).not.toContain("__decorateElement");
+  expect(result).not.toContain("__decoratorStart");
+  expect(result).not.toContain("__runInitializers");
+
+  // Legacy decorators produce __legacyDecorateClassTS calls
+  expect(result).toContain("__legacyDecorateClassTS");
+});
+
+test("Bun.Transpiler respects emitDecoratorMetadata: true from tsconfig", () => {
+  const transpiler = new Bun.Transpiler({
+    loader: "ts",
+    target: "browser",
+    tsconfig: JSON.stringify({
+      compilerOptions: {
+        experimentalDecorators: true,
+        emitDecoratorMetadata: true,
+      },
+    }),
+  });
+
+  const code = `
+function Dec() { return function(target: any, key: string) {}; }
+
+class Foo {
+  @Dec() bar: string = "";
+}
+`;
+
+  const result = transpiler.transformSync(code);
+
+  // Should emit legacy decorators with metadata
+  expect(result).not.toContain("__decorateElement");
+  expect(result).toContain("__legacyDecorateClassTS");
+  expect(result).toContain("__legacyMetadataTS");
+});
+
+test("Bun.Transpiler emits TC39 decorators when experimentalDecorators is not set", () => {
+  const transpiler = new Bun.Transpiler({
+    loader: "ts",
+    target: "browser",
+    tsconfig: JSON.stringify({
+      compilerOptions: {},
+    }),
+  });
+
+  const code = `
+function Prop() { return function(target: any, key: string) {}; }
+
+class Foo {
+  @Prop() bar: number = 0;
+}
+`;
+
+  const result = transpiler.transformSync(code);
+
+  // TC39 decorators use __decorateElement / __decoratorStart / __runInitializers
+  expect(result).toContain("__decorateElement");
+  expect(result).not.toContain("__legacyDecorateClassTS");
+});
+
+test("Bun.Transpiler.transform (async) respects experimentalDecorators: true", async () => {
+  const transpiler = new Bun.Transpiler({
+    loader: "ts",
+    target: "browser",
+    tsconfig: JSON.stringify({
+      compilerOptions: {
+        experimentalDecorators: true,
+      },
+    }),
+  });
+
+  const code = `
+function Prop() { return function(target: any, key: string) {}; }
+
+class Foo {
+  @Prop() bar: number = 0;
+}
+`;
+
+  const result = await transpiler.transform(code);
+
+  // Legacy decorators use __legacyDecorateClassTS, NOT TC39 helpers
+  expect(result).not.toContain("__decorateElement");
+  expect(result).not.toContain("__decoratorStart");
+  expect(result).not.toContain("__runInitializers");
+  expect(result).toContain("__legacyDecorateClassTS");
+});


### PR DESCRIPTION
## Summary
- Fix `Bun.Transpiler` API ignoring `experimentalDecorators: true` from tsconfig, always emitting TC39-style decorators instead of legacy TypeScript decorators
- Add missing `experimental_decorators` and `emit_decorator_metadata` fields to `ParseOptions` in both sync (`getParseResult`) and async (`TransformTask.run`) code paths in `JSTranspiler.zig`

Fixes #27575

## Root Cause
The `ParseOptions` structs constructed in `src/bun.js/api/JSTranspiler.zig` did not include the `experimental_decorators` and `emit_decorator_metadata` fields from the parsed tsconfig. Since `ParseOptions` defaults both to `false`, the `Bun.Transpiler` API always emitted TC39 decorators regardless of tsconfig settings. Other code paths (bundler via `ParseTask.zig`, runtime via `ModuleLoader.zig`) already propagated these fields correctly.

## Test plan
- [x] New regression test `test/regression/issue/27575.test.ts` verifying:
  - `transformSync` emits legacy decorators with `experimentalDecorators: true`
  - `transformSync` emits decorator metadata with `emitDecoratorMetadata: true`
  - `transformSync` emits TC39 decorators when `experimentalDecorators` is not set
  - `transform` (async) emits legacy decorators with `experimentalDecorators: true`
- [x] Test fails with system Bun (3/4 fail), passes with debug build (4/4 pass)
- [x] Existing decorator test suites all pass (54 tests across 3 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)