### PR TITLE
fix(css): preserve unicode-range values in @font-face rules

### DIFF
--- a/src/css/rules/font_face.zig
+++ b/src/css/rules/font_face.zig
@@ -287,7 +287,7 @@ pub const UnicodeRange = struct {
         if (digit < 10) return digit;
         // Force the 6th bit to be set to ensure ascii is lower case.
         // digit = (@as(u32, b) | 0b10_0000).wrapping_sub('a' as u32).saturating_add(10);
-        digit = (@as(u32, b) | 0b10_0000) -% (@as(u32, 'a') +% 10);
+        digit = ((@as(u32, b) | 0b10_0000) -% @as(u32, 'a')) +| 10;
         return if (digit < 16) digit else null;
     }
 };
@@ -696,7 +696,7 @@ pub const FontFaceDeclarationParser = struct {
                         return .{ .result = .{ .font_stretch = c } };
                     }
                 }
-            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "unicode-renage")) {
+            } else if (bun.strings.eqlCaseInsensitiveASCIIICheckLength(name, "unicode-range")) {
                 if (input.parseList(UnicodeRange, UnicodeRange.parse).asValue()) |c| {
                     if (input.expectExhausted().isOk()) {
                         return .{ .result = .{ .unicode_range = c } };

--- a/test/regression/issue/27598.test.ts
+++ b/test/regression/issue/27598.test.ts
@@ -1,0 +1,40 @@
+import { cssInternals } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+
+const { minifyTest, testWithOptions } = cssInternals;
+
+test("unicode-range in @font-face is preserved", () => {
+  const source = `@font-face {
+  font-family: "Roboto Variable";
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153;
+}`;
+  const expected = `@font-face {
+  font-family: Roboto Variable;
+  unicode-range: U+??, U+131, U+152-153;
+}`;
+  expect(testWithOptions(source, expected)).toEqualIgnoringWhitespace(expected);
+});
+
+test("unicode-range in @font-face is preserved when minified", () => {
+  const source = `@font-face { font-family: "Roboto Variable"; unicode-range: U+0000-00FF, U+0131, U+0152-0153; }`;
+  const expected = `@font-face{font-family:Roboto Variable;unicode-range:U+??,U+131,U+152-153}`;
+  expect(minifyTest(source, expected)).toEqual(expected);
+});
+
+test("unicode-range wildcard in @font-face is preserved", () => {
+  const source = `@font-face { font-family: "Test"; unicode-range: U+4??; }`;
+  const expected = `@font-face{font-family:Test;unicode-range:U+4??}`;
+  expect(minifyTest(source, expected)).toEqual(expected);
+});
+
+test("unicode-range with hex letters in @font-face is preserved", () => {
+  const source = `@font-face { font-family: "Test"; unicode-range: U+A640-A69F; }`;
+  const expected = `@font-face{font-family:Test;unicode-range:U+a640-a69f}`;
+  expect(minifyTest(source, expected)).toEqual(expected);
+});
+
+test("unicode-range single hex value in @font-face is preserved", () => {
+  const source = `@font-face { font-family: "Test"; unicode-range: U+00FF; }`;
+  const expected = `@font-face{font-family:Test;unicode-range:U+ff}`;
+  expect(minifyTest(source, expected)).toEqual(expected);
+});


### PR DESCRIPTION
## Summary

- Fix typo `"unicode-renage"` → `"unicode-range"` in the font-face property name matching that caused the `unicode-range` property to never be recognized and fall through to `CustomProperty` parsing, which corrupted the `U+` prefix syntax
- Fix incorrect Rust-to-Zig translation in `toHexDigit()` where `(b | 0x20) -% ('a' +% 10)` should be `((b | 0x20) -% 'a') +| 10`, causing hex letters A-F to be rejected as invalid

Together these two bugs meant all `unicode-range` values in `@font-face` rules were mangled (e.g., `U+0000-00FF` → `U0-0FF`), causing browsers to silently ignore the entire `@font-face` rule and fonts to not load.

Closes #27598

## Test plan

- [x] Added regression tests in `test/regression/issue/27598.test.ts` covering single values, ranges, wildcards, hex letters, and comma-separated lists
- [x] All 5 new tests fail with system bun (`USE_SYSTEM_BUN=1`) and pass with the fix (`bun bd test`)
- [x] All 1028 existing CSS tests pass (`test/js/bun/css/css.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)