### PR TITLE
Fix 413 responses missing Date header

### DIFF
--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1338,6 +1338,7 @@ extern "C"
       }
       if (!(data->state & uWS::HttpResponseData<true>::HTTP_END_CALLED))
       {
+        uwsRes->writeMark();
         uwsRes->AsyncSocket<true>::write("\r\n", 2);
       }
       data->state |= uWS::HttpResponseData<true>::HTTP_END_CALLED;
@@ -1360,6 +1361,7 @@ extern "C"
       {
         // Some HTTP clients require the complete "<header>\r\n\r\n" to be sent.
         // If not, they may throw a ConnectionError.
+        uwsRes->writeMark();
         uwsRes->AsyncSocket<false>::write("\r\n", 2);
       }
       data->state |= uWS::HttpResponseData<false>::HTTP_END_CALLED;


### PR DESCRIPTION
Fixes #27512

According to RFC 9110 spec, origin servers MUST generate a Date header field in all 2xx 3xx and 4xx responses.

Previously, when a request exceeded maxRequestBodySize and returned a 413 response, the Date header was not included because uws_res_end_without_body did not call writeMark() which writes the Date header.

This fix adds writeMark() calls before writing the final "\r\n" in both SSL and non-SSL code paths, ensuring the Date header is included in all 413 responses.