### PR TITLE
fix(test): use API backend for target=node bundler tests to fix flaky timeout

### DIFF
--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -589,7 +589,6 @@ function expectBundled(
         dotenv ||
         typeof production !== "undefined" ||
         bundling === false ||
-        (run && target === "node") ||
         emitDCEAnnotations ||
         bundleWarnings ||
         env ||


### PR DESCRIPTION
## Summary
- Removed the `(run && target === "node")` condition from CLI backend selection in `test/bundler/expectBundled.ts`
- This condition unnecessarily forced the CLI backend (which spawns a `bun build` subprocess) for bundler tests with `target: "node"` and a `run` step
- On resource-constrained CI runners (Alpine aarch64), this subprocess sometimes hangs, causing 90s timeouts (`cjs/__toESM_target_node`)
- The `Bun.build()` API fully supports `target: "node"` and produces identical output without subprocess overhead

## Test plan
- [x] `bun bd test test/bundler/bundler_cjs.test.ts` — all 23 tests pass (including previously flaky `__toESM_target_node`)
- [x] `target: "node"` tests in `test/bundler/esbuild/default.test.ts` — all pass with API backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)