### PR TITLE
fix(transpiler): fix tsconfig use-after-free and memory leak in async transform

### DIFF
--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -584,9 +584,8 @@ pub const TransformTask = struct {
         this.log.deinit();
         this.input_code.deinitAndUnprotect();
         this.output_code.deref();
-        if (this.tsconfig) |tsconfig| {
-            tsconfig.deinit();
-        }
+        // tsconfig is owned by JSTranspiler, not by TransformTask.
+        // Do not free it here — JSTranspiler.deinit handles it.
         this.js_instance.deref();
         bun.destroy(this);
     }
@@ -744,6 +743,9 @@ pub fn deinit(this: *JSTranspiler) void {
         this.buffer_writer.?.buffer.deinit();
     }
 
+    if (this.config.tsconfig) |tsconfig| {
+        tsconfig.deinit();
+    }
     this.arena.deinit();
     bun.destroy(this);
 }

--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -659,6 +659,9 @@ pub fn constructor(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) b
     });
     errdefer {
         this.config.log.deinit();
+        if (this.config.tsconfig) |tsconfig| {
+            tsconfig.deinit();
+        }
         this.arena.deinit();
         this.ref_count.clearWithoutDestructor();
         bun.destroy(this);

--- a/test/js/bun/transpiler/transpiler-tsconfig-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-tsconfig-uaf.test.ts
@@ -39,7 +39,7 @@ describe("Transpiler tsconfig lifetime", () => {
       }),
     });
 
-    // Async transform frees tsconfig in TransformTask.deinit
+    // Before this fix, async transform freed tsconfig in TransformTask.deinit
     const result1 = await transpiler.transform("const a: string = 'hello';");
     expect(result1).toContain('const a = "hello"');
 

--- a/test/js/bun/transpiler/transpiler-tsconfig-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-tsconfig-uaf.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+
+describe("Transpiler tsconfig lifetime", () => {
+  test("multiple async transform() calls with tsconfig do not crash", async () => {
+    const transpiler = new Bun.Transpiler({
+      loader: "tsx",
+      tsconfig: JSON.stringify({
+        compilerOptions: {
+          experimentalDecorators: true,
+          jsx: "react",
+          jsxFactory: "React.createElement",
+        },
+      }),
+    });
+
+    // First async transform
+    const result1 = await transpiler.transform("const x: number = 1;");
+    expect(result1).toContain("const x = 1");
+
+    // Second async transform — would crash before the fix due to use-after-free
+    // on the tsconfig pointer that was freed by the first TransformTask.deinit
+    const result2 = await transpiler.transform("const y: number = 2;");
+    expect(result2).toContain("const y = 2");
+
+    // Third call to be safe
+    const result3 = await transpiler.transform("const z: number = 3;");
+    expect(result3).toContain("const z = 3");
+  });
+
+  test("async transform() followed by transformSync() with tsconfig does not crash", async () => {
+    const transpiler = new Bun.Transpiler({
+      loader: "tsx",
+      tsconfig: JSON.stringify({
+        compilerOptions: {
+          experimentalDecorators: true,
+          jsx: "react",
+          jsxFactory: "React.createElement",
+        },
+      }),
+    });
+
+    // Async transform frees tsconfig in TransformTask.deinit
+    const result1 = await transpiler.transform("const a: string = 'hello';");
+    expect(result1).toContain('const a = "hello"');
+
+    // Sync transform would read freed memory without the fix
+    const result2 = transpiler.transformSync("const b: string = 'world';");
+    expect(result2).toContain('const b = "world"');
+  });
+
+  test("tsconfig jsx settings are preserved across multiple async transforms", async () => {
+    const transpiler = new Bun.Transpiler({
+      loader: "tsx",
+      tsconfig: JSON.stringify({
+        compilerOptions: {
+          jsx: "react",
+          jsxFactory: "h",
+          jsxFragmentFactory: "Fragment",
+        },
+      }),
+    });
+
+    const code = "export default <div>hello</div>;";
+
+    const result1 = await transpiler.transform(code);
+    expect(result1).toContain("h(");
+
+    // After the first async transform, tsconfig should still be valid
+    const result2 = await transpiler.transform(code);
+    expect(result2).toContain("h(");
+
+    // Sync should also work
+    const result3 = transpiler.transformSync(code);
+    expect(result3).toContain("h(");
+  });
+});


### PR DESCRIPTION
## Summary

- **Fixed use-after-free**: `TransformTask.deinit()` was calling `tsconfig.deinit()` on a pointer shallow-copied from `JSTranspiler.config.tsconfig`. After the first async `transform()` completed, the JSTranspiler's tsconfig became a dangling pointer — subsequent `transform()`/`transformSync()` calls would read freed memory, and a second async `transform()` would double-free.
- **Fixed memory leak**: `JSTranspiler.deinit()` never freed `config.tsconfig`, so sync-only usage leaked the `TSConfigJSON` allocation.
- **Root cause**: No ownership protocol — both `TransformTask` and `JSTranspiler` believed they owned the tsconfig pointer. Fix assigns sole ownership to `JSTranspiler`.

### Trigger scenario

```js
const transpiler = new Bun.Transpiler({
  tsconfig: JSON.stringify({
    compilerOptions: { experimentalDecorators: true, jsx: "react" }
  }),
});

await transpiler.transform("const x = 1;"); // TransformTask.deinit frees tsconfig
await transpiler.transform("const y = 2;"); // use-after-free + double-free
```

### Changes

| File | Change |
|------|--------|
| `src/bun.js/api/JSTranspiler.zig` | Remove `tsconfig.deinit()` from `TransformTask.deinit` (borrower) |
| `src/bun.js/api/JSTranspiler.zig` | Add `tsconfig.deinit()` to `JSTranspiler.deinit` (owner) |
| `test/js/bun/transpiler/transpiler-tsconfig-uaf.test.ts` | Regression test: multiple async/sync transforms with tsconfig |

## Test plan

- [x] `bun bd test test/js/bun/transpiler/transpiler-tsconfig-uaf.test.ts` — 3/3 pass
- [ ] CI passes on all platforms

> **Note**: The use-after-free is non-deterministic — mimalloc may not immediately reuse freed memory, so the old code may not always crash. Under ASan the original code would reliably fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)