### PR TITLE
fix: ignore VSCode inspector env vars in standalone executables

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1228,8 +1228,13 @@ fn configureDebugger(this: *VirtualMachine, cli_flag: bun.cli.Command.Debugger) 
         return;
     }
 
-    const unix = bun.env_var.BUN_INSPECT.get();
-    const connect_to = bun.env_var.BUN_INSPECT_CONNECT_TO.get();
+    const is_standalone = this.standalone_module_graph != null;
+
+    // In standalone executables, ignore the BUN_INSPECT and BUN_INSPECT_CONNECT_TO
+    // environment variables set by the VSCode extension. Users can still enable the
+    // inspector via BUN_OPTIONS=--inspect (which goes through the .enable path).
+    const unix = if (is_standalone) "" else bun.env_var.BUN_INSPECT.get();
+    const connect_to = if (is_standalone) "" else bun.env_var.BUN_INSPECT_CONNECT_TO.get();
 
     const set_breakpoint_on_first_line = unix.len > 0 and strings.endsWith(unix, "?break=1"); // If we should set a breakpoint on the first line
     const wait_for_debugger = unix.len > 0 and strings.endsWith(unix, "?wait=1"); // If we should wait for the debugger to connect before starting the event loop

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -682,7 +682,8 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
             const preloads = args.options("--preload");
             const preloads2 = args.options("--require");
             const preloads3 = args.options("--import");
-            const preload4 = bun.env_var.BUN_INSPECT_PRELOAD.get();
+            // In standalone executables, ignore BUN_INSPECT_PRELOAD set by the VSCode extension.
+            const preload4 = if (bun.StandaloneModuleGraph.get() != null) null else bun.env_var.BUN_INSPECT_PRELOAD.get();
 
             const total_preloads = ctx.preloads.len + preloads.len + preloads2.len + preloads3.len + (if (preload4 != null) @as(usize, 1) else @as(usize, 0));
             if (total_preloads > 0) {

--- a/test/cli/inspect/standalone-inspect.test.ts
+++ b/test/cli/inspect/standalone-inspect.test.ts
@@ -1,0 +1,72 @@
+import { spawnSync } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("standalone executables ignore VSCode inspector env vars", () => {
+  test("BUN_INSPECT is ignored in standalone executables", () => {
+    using dir = tempDir("standalone-inspect", {
+      "entry.ts": `
+        // If the inspector were enabled, this would hang waiting for a connection.
+        // We verify it runs and exits normally despite BUN_INSPECT being set.
+        console.log("EXIT_OK");
+      `,
+    });
+
+    const exePath = String(dir) + "/app";
+
+    // Compile
+    const build = spawnSync({
+      cmd: [bunExe(), "build", "--compile", String(dir) + "/entry.ts", "--outfile", exePath],
+      env: bunEnv,
+    });
+    expect(build.exitCode).toBe(0);
+
+    // Run with BUN_INSPECT set (as VSCode would set it in a debug terminal).
+    // In a non-standalone binary, this would enable the inspector and print
+    // inspector banner to stderr. In standalone, it should be ignored.
+    const result = spawnSync({
+      cmd: [exePath],
+      env: {
+        ...bunEnv,
+        BUN_INSPECT: "ws+unix:///tmp/fake-vscode-socket.sock?break=1",
+        BUN_INSPECT_NOTIFY: "unix:///tmp/fake-vscode-notify.sock",
+        BUN_INSPECT_CONNECT_TO: "",
+      },
+      timeout: 5_000,
+    });
+
+    expect(result.stdout.toString()).toContain("EXIT_OK");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("BUN_OPTIONS still works in standalone executables", () => {
+    using dir = tempDir("standalone-inspect-options", {
+      "entry.ts": `
+        // Verify BUN_OPTIONS is still processed in standalone executables.
+        console.log(JSON.stringify(process.execArgv));
+      `,
+    });
+
+    const exePath = String(dir) + "/app";
+
+    // Compile
+    const build = spawnSync({
+      cmd: [bunExe(), "build", "--compile", String(dir) + "/entry.ts", "--outfile", exePath],
+      env: bunEnv,
+    });
+    expect(build.exitCode).toBe(0);
+
+    // Run with BUN_OPTIONS=--smol (a harmless flag we can detect via execArgv)
+    const result = spawnSync({
+      cmd: [exePath],
+      env: {
+        ...bunEnv,
+        BUN_OPTIONS: "--smol",
+      },
+      timeout: 5_000,
+    });
+
+    expect(result.stdout.toString()).toContain("--smol");
+    expect(result.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- `BUN_INSPECT`, `BUN_INSPECT_CONNECT_TO`, and `BUN_INSPECT_PRELOAD` environment variables are now ignored when running as a `bun build --compile` standalone executable
- `BUN_OPTIONS` (e.g. `BUN_OPTIONS=--inspect`) continues to work as before, so users can still explicitly enable the inspector in standalone binaries

## Motivation
When VSCode's Bun extension opens a "JavaScript Debug Terminal", it sets `BUN_INSPECT`, `BUN_INSPECT_NOTIFY`, and `BUN_INSPECT_CONNECT_TO` in the terminal environment. Running a standalone executable in that terminal would unexpectedly enable the inspector — and with `?break=1`, hang indefinitely waiting for a debugger connection. Standalone executables are end-user programs that should not be affected by IDE debug instrumentation.

## Test plan
- [x] New test verifies `BUN_INSPECT` with `?break=1` is ignored in standalone (previously would hang)
- [x] New test verifies `BUN_OPTIONS=--smol` still works in standalone via `process.execArgv`
- [x] Test fails on system bun (confirming behavioral change) and passes on debug build


🤖 Generated with [Claude Code](https://claude.com/claude-code)