### PR TITLE
fix(windows): fix fd leak and use-after-free in ReadFileUV error paths

### DIFF
--- a/src/bun.js/webcore/blob/read_file.zig
+++ b/src/bun.js/webcore/blob/read_file.zig
@@ -691,8 +691,9 @@ pub const ReadFileUV = struct {
             return;
         }
         // add an extra 16 bytes to the buffer to avoid having to resize it for trailing extra data
-        this.buffer.ensureTotalCapacityPrecise(this.byte_store.allocator, @min(this.size + 16, @as(usize, std.math.maxInt(bun.windows.ULONG)))) catch |err| {
-            this.errno = err;
+        this.buffer.ensureTotalCapacityPrecise(this.byte_store.allocator, @min(this.size + 16, @as(usize, std.math.maxInt(bun.windows.ULONG)))) catch {
+            this.errno = error.OutOfMemory;
+            this.system_error = bun.sys.Error.fromCode(bun.sys.E.NOMEM, .read).toSystemError();
             this.onFinish();
             return;
         };
@@ -719,8 +720,9 @@ pub const ReadFileUV = struct {
                 // non-regular files have variable sizes, so we always ensure
                 // theres at least 4096 bytes of free space. there has already
                 // been an initial allocation done for us
-                this.buffer.ensureUnusedCapacity(this.byte_store.allocator, 4096) catch |err| {
-                    this.errno = err;
+                this.buffer.ensureUnusedCapacity(this.byte_store.allocator, 4096) catch {
+                    this.errno = error.OutOfMemory;
+                    this.system_error = bun.sys.Error.fromCode(bun.sys.E.NOMEM, .read).toSystemError();
                     this.onFinish();
                     return;
                 };
@@ -751,8 +753,9 @@ pub const ReadFileUV = struct {
 
             // We are done reading.
             this.byte_store = ByteStore.init(
-                this.buffer.toOwnedSlice(this.byte_store.allocator) catch |err| {
-                    this.errno = err;
+                this.buffer.toOwnedSlice(this.byte_store.allocator) catch {
+                    this.errno = error.OutOfMemory;
+                    this.system_error = bun.sys.Error.fromCode(bun.sys.E.NOMEM, .read).toSystemError();
                     this.onFinish();
                     return;
                 },
@@ -777,8 +780,9 @@ pub const ReadFileUV = struct {
         if (result.int() == 0) {
             // We are done reading.
             this.byte_store = ByteStore.init(
-                this.buffer.toOwnedSlice(this.byte_store.allocator) catch |err| {
-                    this.errno = err;
+                this.buffer.toOwnedSlice(this.byte_store.allocator) catch {
+                    this.errno = error.OutOfMemory;
+                    this.system_error = bun.sys.Error.fromCode(bun.sys.E.NOMEM, .read).toSystemError();
                     this.onFinish();
                     return;
                 },

--- a/src/bun.js/webcore/blob/read_file.zig
+++ b/src/bun.js/webcore/blob/read_file.zig
@@ -722,6 +722,7 @@ pub const ReadFileUV = struct {
                 this.buffer.ensureUnusedCapacity(this.byte_store.allocator, 4096) catch |err| {
                     this.errno = err;
                     this.onFinish();
+                    return;
                 };
             }
 
@@ -769,7 +770,7 @@ pub const ReadFileUV = struct {
         if (result.errEnum()) |errno| {
             this.errno = bun.errnoToZigErr(errno);
             this.system_error = bun.sys.Error.fromCode(errno, .read).toSystemError();
-            this.finalize();
+            this.onFinish();
             return;
         }
 


### PR DESCRIPTION
## Summary

Fixes two error handling bugs in `ReadFileUV` (identified in [PR #26633 review](https://github.com/oven-sh/bun/pull/26633)):

- **`onRead()` fd leak**: The error path at line 772 called `this.finalize()` directly instead of `this.onFinish()`, bypassing `doClose()` and leaking the open file descriptor. Every other error path correctly goes through `onFinish()` → `doClose()` → `finalize()`.

- **`queueRead()` use-after-free**: The OOM catch block for non-regular file buffer expansion called `this.onFinish()` but was missing a `return`, causing execution to fall through to `this.remainingBuffer()` on freed memory.

## Test plan

- [x] `bun run zig:check-windows` passes (all 25/25 build steps succeeded)
- These are Windows-only code paths (`ReadFileUV` uses libuv), so they only affect Windows builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)