### PR TITLE
harden chunked encoding to handle CRLF split across TCP segments

### DIFF
--- a/packages/bun-uws/src/ChunkedEncoding.h
+++ b/packages/bun-uws/src/ChunkedEncoding.h
@@ -35,14 +35,13 @@ namespace uWS {
     constexpr uint64_t STATE_WAITING_FOR_LF = 1ull << (sizeof(uint64_t) * 8 - 4);//0x1000000000000000;
     constexpr uint64_t STATE_SIZE_MASK = ~(STATE_HAS_SIZE | STATE_IS_CHUNKED | STATE_IS_CHUNKED_EXTENSION | STATE_WAITING_FOR_LF);//0x0FFFFFFFFFFFFFFF;
     constexpr uint64_t STATE_IS_ERROR = ~0ull;//0xFFFFFFFFFFFFFFFF;
-    constexpr uint64_t STATE_SIZE_OVERFLOW = 0x0Full << (sizeof(uint64_t) * 8 - 8);//0x0F00000000000000;
+    /* Overflow guard: if any of bits 55-59 are set before the next *16, one more
+     * hex digit (plus the +2 for the trailing CRLF of chunk-data) would carry into
+     * STATE_WAITING_FOR_LF at bit 60. Limits chunk size to 14 hex digits (~72 PB). */
+    constexpr uint64_t STATE_SIZE_OVERFLOW = 0x1Full << (sizeof(uint64_t) * 8 - 9);//0x0F80000000000000;
 
     inline uint64_t chunkSize(uint64_t state) {
         return state & STATE_SIZE_MASK;
-    }
-
-    inline bool isParsingChunkedExtension(uint64_t state) {
-        return (state & STATE_IS_CHUNKED_EXTENSION) != 0;
     }
 
     /* Parses the chunk-size line: HEXDIG+ [;ext...] CRLF

--- a/packages/bun-uws/src/ChunkedEncoding.h
+++ b/packages/bun-uws/src/ChunkedEncoding.h
@@ -67,7 +67,7 @@ namespace uWS {
      *   chunk-ext-name = token
      *   chunk-ext-val  = token / quoted-string  (TODO: quoted-string unsupported)
      */
-    inline uint64_t consumeHexNumber(std::string_view & __restrict data, uint64_t state) {
+    inline uint64_t consumeHexNumber(std::string_view &data, uint64_t state) {
         /* Resume: '\r' was the last byte of the previous segment. Rare path,
          * use data directly to avoid the p/len load on the hot path. */
         if (state & STATE_WAITING_FOR_LF) [[unlikely]] {
@@ -79,9 +79,9 @@ namespace uWS {
         }
 
         /* Load pointer+length into locals so the loops operate in registers.
-         * Without this, Clang writes back to the string_view on every iteration
-         * (store-per-iter despite __restrict). Error paths skip the writeback:
-         * HttpParser returns immediately on STATE_IS_ERROR and never reads data. */
+         * Without this, Clang writes back to the string_view on every iteration.
+         * Error paths skip the writeback: HttpParser returns immediately on
+         * STATE_IS_ERROR and never reads data. */
         const char *p = data.data();
         size_t len = data.length();
 

--- a/packages/bun-uws/src/ChunkedEncoding.h
+++ b/packages/bun-uws/src/ChunkedEncoding.h
@@ -32,7 +32,8 @@ namespace uWS {
     constexpr uint64_t STATE_HAS_SIZE = 1ull << (sizeof(uint64_t) * 8 - 1);//0x8000000000000000;
     constexpr uint64_t STATE_IS_CHUNKED = 1ull << (sizeof(uint64_t) * 8 - 2);//0x4000000000000000;
     constexpr uint64_t STATE_IS_CHUNKED_EXTENSION = 1ull << (sizeof(uint64_t) * 8 - 3);//0x2000000000000000;
-    constexpr uint64_t STATE_SIZE_MASK = ~(STATE_HAS_SIZE | STATE_IS_CHUNKED | STATE_IS_CHUNKED_EXTENSION);//0x1FFFFFFFFFFFFFFF;
+    constexpr uint64_t STATE_WAITING_FOR_LF = 1ull << (sizeof(uint64_t) * 8 - 4);//0x1000000000000000;
+    constexpr uint64_t STATE_SIZE_MASK = ~(STATE_HAS_SIZE | STATE_IS_CHUNKED | STATE_IS_CHUNKED_EXTENSION | STATE_WAITING_FOR_LF);//0x0FFFFFFFFFFFFFFF;
     constexpr uint64_t STATE_IS_ERROR = ~0ull;//0xFFFFFFFFFFFFFFFF;
     constexpr uint64_t STATE_SIZE_OVERFLOW = 0x0Full << (sizeof(uint64_t) * 8 - 8);//0x0F00000000000000;
 
@@ -48,6 +49,20 @@ namespace uWS {
     inline void consumeHexNumber(std::string_view &data, uint64_t &state) {
 
         /* RFC 9110: 5.5 Field Values (TLDR; anything above 31 is allowed \r, \n ; depending on context)*/
+
+        /* Resume after a lone \r was consumed on a previous call */
+        if (state & STATE_WAITING_FOR_LF) {
+            if (!data.length()) return; // need more data
+            if (data[0] == '\n') {
+                state &= ~STATE_WAITING_FOR_LF;
+                state += 2; // include the two last \r\n
+                state |= STATE_HAS_SIZE | STATE_IS_CHUNKED;
+                data.remove_prefix(1);
+                return;
+            }
+            state = STATE_IS_ERROR;
+            return;
+        }
 
         if(!isParsingChunkedExtension(state)){
             /* Consume everything higher than 32 and not ; (extension)*/
@@ -134,6 +149,12 @@ namespace uWS {
                 state |= STATE_HAS_SIZE | STATE_IS_CHUNKED;
 
                 data.remove_prefix(2);
+            } else if (data.length() == 1 && data[0] == '\r') {
+                /* Lone \r at end of buffer — consume it and wait for \n on next call.
+                 * This handles the case where a TCP segment boundary falls between
+                 * the \r and \n of the chunk-size CRLF terminator. */
+                state |= STATE_WAITING_FOR_LF;
+                data.remove_prefix(1);
             }
         }
         // short read
@@ -203,6 +224,10 @@ namespace uWS {
                     }
 
                     return std::string_view(nullptr, 0);
+                }
+                if (!hasChunkSize(state)) {
+                    /* Incomplete chunk-size line — need more data from the network. */
+                    return std::nullopt;
                 }
                 continue;
             }

--- a/packages/bun-uws/src/ChunkedEncoding.h
+++ b/packages/bun-uws/src/ChunkedEncoding.h
@@ -68,7 +68,8 @@ namespace uWS {
      *   chunk-ext-val  = token / quoted-string  (TODO: quoted-string unsupported)
      */
     inline uint64_t consumeHexNumber(std::string_view & __restrict data, uint64_t state) {
-        /* Resume: '\r' was the last byte of the previous segment. */
+        /* Resume: '\r' was the last byte of the previous segment. Rare path,
+         * use data directly to avoid the p/len load on the hot path. */
         if (state & STATE_WAITING_FOR_LF) [[unlikely]] {
             if (!data.length()) return state;
             if (data[0] != '\n') return STATE_IS_ERROR;
@@ -77,40 +78,52 @@ namespace uWS {
                    | STATE_HAS_SIZE | STATE_IS_CHUNKED;
         }
 
+        /* Load pointer+length into locals so the loops operate in registers.
+         * Without this, Clang writes back to the string_view on every iteration
+         * (store-per-iter despite __restrict). Error paths skip the writeback:
+         * HttpParser returns immediately on STATE_IS_ERROR and never reads data. */
+        const char *p = data.data();
+        size_t len = data.length();
+
         /* Hex digits. Skipped when resuming mid-extension so that extension bytes
          * like 'a' aren't misparsed as hex. */
         if (!(state & STATE_IS_CHUNKED_EXTENSION)) {
-            while (data.length()) {
-                unsigned char c = (unsigned char) data[0];
+            while (len) {
+                unsigned char c = (unsigned char) *p;
                 if (c <= 32 || c == ';') break; /* fall through to drain loop */
                 unsigned int d = c | 0x20; /* fold A-F -> a-f; '0'..'9' unchanged */
                 unsigned int n;
-                if      ((unsigned)(d - '0') < 10) n = d - '0';
-                else if ((unsigned)(d - 'a') < 6)  n = d - 'a' + 10;
+                if      ((unsigned)(d - '0') < 10) [[likely]] n = d - '0';
+                else if ((unsigned)(d - 'a') < 6)            n = d - 'a' + 10;
                 else return STATE_IS_ERROR;
                 if (chunkSize(state) & STATE_SIZE_OVERFLOW) [[unlikely]] return STATE_IS_ERROR;
                 state = ((state & STATE_SIZE_MASK) * 16ull + n) | STATE_IS_CHUNKED;
-                data.remove_prefix(1);
+                ++p; --len;
             }
         }
 
         /* Drain [;ext...] \r \n. Upstream-style forward scan for LF, with strict
          * validation: only >32 bytes (extension) and exactly one '\r' immediately
          * before '\n' are allowed. */
-        while (data.length()) {
-            unsigned char c = (unsigned char) data[0];
+        while (len) {
+            unsigned char c = (unsigned char) *p;
             if (c == '\n') return STATE_IS_ERROR; /* bare LF */
-            data.remove_prefix(1);
+            ++p; --len;
             if (c == '\r') {
-                if (!data.length()) return state | STATE_WAITING_FOR_LF;
-                if (data[0] != '\n') return STATE_IS_ERROR;
-                data.remove_prefix(1);
+                if (!len) {
+                    data = std::string_view(p, len);
+                    return state | STATE_WAITING_FOR_LF;
+                }
+                if (*p != '\n') return STATE_IS_ERROR;
+                ++p; --len;
+                data = std::string_view(p, len);
                 return ((state & ~STATE_IS_CHUNKED_EXTENSION) + 2)
                        | STATE_HAS_SIZE | STATE_IS_CHUNKED;
             }
             if (c <= 32) return STATE_IS_ERROR;
             state |= STATE_IS_CHUNKED_EXTENSION;
         }
+        data = std::string_view(p, len);
         return state; /* short read */
     }
 

--- a/packages/bun-uws/src/ChunkedEncoding.h
+++ b/packages/bun-uws/src/ChunkedEncoding.h
@@ -45,128 +45,77 @@ namespace uWS {
         return (state & STATE_IS_CHUNKED_EXTENSION) != 0;
     }
 
-    /* Reads hex number until CR or out of data to consume. Updates state. Returns bytes consumed. */
-    inline void consumeHexNumber(std::string_view &data, uint64_t &state) {
-
-        /* RFC 9110: 5.5 Field Values (TLDR; anything above 31 is allowed \r, \n ; depending on context)*/
-
-        /* Resume after a lone \r was consumed on a previous call */
-        if (state & STATE_WAITING_FOR_LF) {
-            if (!data.length()) return; // need more data
-            if (data[0] == '\n') {
-                state &= ~STATE_WAITING_FOR_LF;
-                state += 2; // include the two last \r\n
-                state |= STATE_HAS_SIZE | STATE_IS_CHUNKED;
-                data.remove_prefix(1);
-                return;
-            }
-            state = STATE_IS_ERROR;
-            return;
+    /* Parses the chunk-size line: HEXDIG+ [;ext...] CRLF
+     *
+     * Returns the new state. On return, exactly one of:
+     *   - state has STATE_HAS_SIZE set (success, data advanced past LF)
+     *   - state == STATE_IS_ERROR     (malformed input)
+     *   - data is empty                (short read; flags persist for resume)
+     *
+     * Resume flags:
+     *   STATE_WAITING_FOR_LF       -> saw '\r' on previous call, need '\n'
+     *   STATE_IS_CHUNKED_EXTENSION -> mid-extension, skip hex parsing on resume
+     *
+     * Structure follows upstream uWS (scan-for-LF) with strict CRLF validation
+     * added. Every byte is consumed in a forward scan so TCP segment boundaries
+     * splitting the line at any point are handled by construction.
+     *
+     * RFC 7230 4.1.1:
+     *   chunk          = chunk-size [ chunk-ext ] CRLF chunk-data CRLF
+     *   chunk-size     = 1*HEXDIG
+     *   chunk-ext      = *( ";" chunk-ext-name [ "=" chunk-ext-val ] )
+     *   chunk-ext-name = token
+     *   chunk-ext-val  = token / quoted-string  (TODO: quoted-string unsupported)
+     */
+    inline uint64_t consumeHexNumber(std::string_view & __restrict data, uint64_t state) {
+        /* Resume: '\r' was the last byte of the previous segment. */
+        if (state & STATE_WAITING_FOR_LF) [[unlikely]] {
+            if (!data.length()) return state;
+            if (data[0] != '\n') return STATE_IS_ERROR;
+            data.remove_prefix(1);
+            return ((state & ~(STATE_WAITING_FOR_LF | STATE_IS_CHUNKED_EXTENSION)) + 2)
+                   | STATE_HAS_SIZE | STATE_IS_CHUNKED;
         }
 
-        if(!isParsingChunkedExtension(state)){
-            /* Consume everything higher than 32 and not ; (extension)*/
-            while (data.length() && data[0] > 32 && data[0] != ';') {
-
-                unsigned char digit = (unsigned char)data[0];
-                unsigned int number;
-                if (digit >= '0' && digit <= '9') {
-                    number = digit - '0';
-                } else if (digit >= 'a' && digit <= 'f') {
-                    number = digit - 'a' + 10;
-                } else if (digit >= 'A' && digit <= 'F') {
-                    number = digit - 'A' + 10;
-                } else {
-                    state = STATE_IS_ERROR;
-                    return;
-                }
-
-                if ((chunkSize(state) & STATE_SIZE_OVERFLOW)) {
-                    state = STATE_IS_ERROR;
-                    return;
-                }
-
-                // extract state bits
-                uint64_t bits = /*state &*/ STATE_IS_CHUNKED;
-
-                state = (state & STATE_SIZE_MASK) * 16ull + number;
-
-                state |= bits;
+        /* Hex digits. Skipped when resuming mid-extension so that extension bytes
+         * like 'a' aren't misparsed as hex. */
+        if (!(state & STATE_IS_CHUNKED_EXTENSION)) {
+            while (data.length()) {
+                unsigned char c = (unsigned char) data[0];
+                if (c <= 32 || c == ';') break; /* fall through to drain loop */
+                unsigned int d = c | 0x20; /* fold A-F -> a-f; '0'..'9' unchanged */
+                unsigned int n;
+                if      ((unsigned)(d - '0') < 10) n = d - '0';
+                else if ((unsigned)(d - 'a') < 6)  n = d - 'a' + 10;
+                else return STATE_IS_ERROR;
+                if (chunkSize(state) & STATE_SIZE_OVERFLOW) [[unlikely]] return STATE_IS_ERROR;
+                state = ((state & STATE_SIZE_MASK) * 16ull + n) | STATE_IS_CHUNKED;
                 data.remove_prefix(1);
             }
         }
 
-        auto len = data.length();
-        if(len) {
-            // consume extension
-            if(data[0] == ';' || isParsingChunkedExtension(state)) {
-                // mark that we are parsing chunked extension
-                state |= STATE_IS_CHUNKED_EXTENSION;
-                /* we got chunk extension lets remove it*/
-                while(data.length()) {
-                    if(data[0] == '\r') {
-                        // we are done parsing extension
-                        state &= ~STATE_IS_CHUNKED_EXTENSION;
-                        break;
-                    }
-                    /* RFC 9110: Token format (TLDR; anything bellow 32 is not allowed)
-                    * TODO: add support for quoted-strings values (RFC 9110: 3.2.6. Quoted-String)
-                    * Example of chunked encoding with extensions:
-                    *
-                    * 4;key=value\r\n
-                    * Wiki\r\n
-                    * 5;foo=bar;baz=quux\r\n
-                    * pedia\r\n
-                    * 0\r\n
-                    * \r\n
-                    *
-                    * The chunk size is in hex (4, 5, 0), followed by optional
-                    * semicolon-separated extensions. Extensions consist of a key
-                    * (token) and optional value. The value may be a token or a
-                    * quoted string. The chunk data follows the CRLF after the
-                    * extensions and must be exactly the size specified.
-                    *
-                    * RFC 7230 Section 4.1.1 defines chunk extensions as:
-                    * chunk-ext = *( ";" chunk-ext-name [ "=" chunk-ext-val ] )
-                    * chunk-ext-name = token
-                    * chunk-ext-val = token / quoted-string
-                    */
-                    if(data[0] <= 32) {
-                        state = STATE_IS_ERROR;
-                        return;
-                    }
-
-                    data.remove_prefix(1);
-                }
-            }
-            if(data.length() >= 2) {
-                /* Consume \r\n */
-                if((data[0] != '\r' || data[1] != '\n')) {
-                    state = STATE_IS_ERROR;
-                    return;
-                }
-                state += 2; // include the two last /r/n
-                state |= STATE_HAS_SIZE | STATE_IS_CHUNKED;
-
-                data.remove_prefix(2);
-            } else if (data.length() == 1 && data[0] == '\r') {
-                /* Lone \r at end of buffer — consume it and wait for \n on next call.
-                 * This handles the case where a TCP segment boundary falls between
-                 * the \r and \n of the chunk-size CRLF terminator. */
-                state |= STATE_WAITING_FOR_LF;
+        /* Drain [;ext...] \r \n. Upstream-style forward scan for LF, with strict
+         * validation: only >32 bytes (extension) and exactly one '\r' immediately
+         * before '\n' are allowed. */
+        while (data.length()) {
+            unsigned char c = (unsigned char) data[0];
+            if (c == '\n') return STATE_IS_ERROR; /* bare LF */
+            data.remove_prefix(1);
+            if (c == '\r') {
+                if (!data.length()) return state | STATE_WAITING_FOR_LF;
+                if (data[0] != '\n') return STATE_IS_ERROR;
                 data.remove_prefix(1);
+                return ((state & ~STATE_IS_CHUNKED_EXTENSION) + 2)
+                       | STATE_HAS_SIZE | STATE_IS_CHUNKED;
             }
+            if (c <= 32) return STATE_IS_ERROR;
+            state |= STATE_IS_CHUNKED_EXTENSION;
         }
-        // short read
+        return state; /* short read */
     }
 
     inline void decChunkSize(uint64_t &state, uint64_t by) {
-
-        //unsigned int bits = state & STATE_IS_CHUNKED;
-
         state = (state & ~STATE_SIZE_MASK) | (chunkSize(state) - by);
-
-        //state |= bits;
     }
 
     inline bool hasChunkSize(uint64_t state) {
@@ -208,8 +157,8 @@ namespace uWS {
             }
 
             if (!hasChunkSize(state)) {
-                consumeHexNumber(data, state);
-                if (isParsingInvalidChunkedEncoding(state)) {
+                state = consumeHexNumber(data, state);
+                if (isParsingInvalidChunkedEncoding(state)) [[unlikely]] {
                     return std::nullopt;
                 }
                 if (hasChunkSize(state) && chunkSize(state) == 2) {
@@ -225,7 +174,7 @@ namespace uWS {
 
                     return std::string_view(nullptr, 0);
                 }
-                if (!hasChunkSize(state)) {
+                if (!hasChunkSize(state)) [[unlikely]] {
                     /* Incomplete chunk-size line — need more data from the network. */
                     return std::nullopt;
                 }

--- a/test/js/bun/http/http-server-chunking.test.ts
+++ b/test/js/bun/http/http-server-chunking.test.ts
@@ -108,6 +108,128 @@ describe.if(isPosix)("HTTP server handles chunked transfer encoding", () => {
   });
 });
 
+describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
+  test("handles lone CR at end of chunk-size line across TCP segments", async () => {
+    // Regression test: when a TCP segment boundary falls between the \r and \n
+    // of a chunk-size line (e.g. "5\r" in one segment, "\n..." in the next),
+    // the server must buffer and resume correctly instead of spinning.
+    const script = `
+      const server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const body = await req.text();
+          return new Response("Got: " + body);
+        },
+      });
+      const { promise, resolve } = Promise.withResolvers();
+      const socket = await Bun.connect({
+        hostname: "localhost",
+        port: server.port,
+        socket: {
+          data(socket, data) {
+            console.log(data.toString());
+            socket.end();
+          },
+          open(socket) {
+            // Send headers
+            socket.write("PUT / HTTP/1.1\\r\\nHost: localhost\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n");
+            socket.flush();
+            // After a delay, send chunk size with lone \\r (no \\n yet)
+            setTimeout(() => {
+              socket.write("5\\r");
+              socket.flush();
+              // After another delay, send the rest: \\n, chunk data, and final chunk
+              setTimeout(() => {
+                socket.write("\\nHello\\r\\n0\\r\\n\\r\\n");
+                socket.flush();
+              }, 50);
+            }, 50);
+          },
+          error() {},
+          close() { resolve(); },
+        },
+      });
+      await promise;
+      server.stop();
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toContain("200 OK");
+    expect(stdout).toContain("Got: Hello");
+    expect(exitCode).toBe(0);
+  });
+
+  test("handles lone CR in chunk-size with extensions", async () => {
+    // Same split but with a chunk extension before the CRLF
+    const script = `
+      const server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const body = await req.text();
+          return new Response("Got: " + body);
+        },
+      });
+      const { promise, resolve } = Promise.withResolvers();
+      const socket = await Bun.connect({
+        hostname: "localhost",
+        port: server.port,
+        socket: {
+          data(socket, data) {
+            console.log(data.toString());
+            socket.end();
+          },
+          open(socket) {
+            socket.write("PUT / HTTP/1.1\\r\\nHost: localhost\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n");
+            socket.flush();
+            setTimeout(() => {
+              // chunk size with extension, CR split from LF
+              socket.write("5;ext=val\\r");
+              socket.flush();
+              setTimeout(() => {
+                socket.write("\\nHello\\r\\n0\\r\\n\\r\\n");
+                socket.flush();
+              }, 50);
+            }, 50);
+          },
+          error() {},
+          close() { resolve(); },
+        },
+      });
+      await promise;
+      server.stop();
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toContain("200 OK");
+    expect(stdout).toContain("Got: Hello");
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe.if(isPosix)("HTTP server handles fragmented requests", () => {
   test("handles requests with tiny send buffer (regression test)", async () => {
     using server = Bun.serve({

--- a/test/js/bun/http/http-server-chunking.test.ts
+++ b/test/js/bun/http/http-server-chunking.test.ts
@@ -228,6 +228,62 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
     expect(stdout).toContain("Got: Hello");
     expect(exitCode).toBe(0);
   });
+
+  test("rejects bare LF in chunk-size position (invalid byte not stranded)", async () => {
+    // A byte <=32 that isn't \r in chunk-size position must error immediately.
+    // Previously this could strand the byte in HttpParser's fallback buffer,
+    // corrupting header parsing on the next request.
+    const script = `
+      const server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          try {
+            await req.text();
+            return new Response("OK");
+          } catch {
+            return new Response("Body error", { status: 400 });
+          }
+        },
+      });
+      const { promise, resolve } = Promise.withResolvers();
+      let received = "";
+      const socket = await Bun.connect({
+        hostname: "localhost",
+        port: server.port,
+        socket: {
+          data(socket, data) {
+            received += data.toString();
+          },
+          open(socket) {
+            // Bare LF (0x0A) where chunk-size hex is expected
+            socket.write("PUT / HTTP/1.1\\r\\nHost: localhost\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n\\n");
+            socket.flush();
+          },
+          error() {},
+          close() {
+            console.log(received);
+            resolve();
+          },
+        },
+      });
+      await promise;
+      server.stop();
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Server should reject with 400, not hang or accept
+    expect(stderr).toBe("");
+    expect(stdout).toContain("400");
+    expect(exitCode).toBe(0);
+  });
 });
 
 describe.if(isPosix)("HTTP server handles fragmented requests", () => {

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -719,6 +719,7 @@ describe("chunk size strict hex digit validation", () => {
     const request =
       "POST / HTTP/1.1\r\n" +
       "Host: localhost\r\n" +
+      "Connection: close\r\n" +
       "Transfer-Encoding: chunked\r\n" +
       "\r\n" +
       chunkSizeLine +
@@ -737,10 +738,7 @@ describe("chunk size strict hex digit validation", () => {
       client.on("close", () => {
         resolve(responseData);
       });
-      client.write(request, () => {
-        // Give the server time to process before half-closing
-        setTimeout(() => client.end(), 100);
-      });
+      client.write(request);
     });
   }
 


### PR DESCRIPTION
## Summary

- Harden the chunked encoding parser to correctly handle chunk-size CRLF terminators split across TCP segments
- When a segment boundary falls between `\r` and `\n` of a chunk-size line (e.g. `"5\r"` in one packet, `"\nHello..."` in the next), the parser now correctly buffers the partial CRLF state and resumes on the next data arrival
- Add `STATE_WAITING_FOR_LF` flag to `consumeHexNumber()` to track when `\r` has been consumed but `\n` is still pending
- Add defense-in-depth check in `getNextChunk()` to break out of the parsing loop if no progress is made

Reported by [sim1222 (Kokecchi)](https://github.com/sim1222).

## Test plan

- [x] New test: "handles lone CR at end of chunk-size line across TCP segments" — sends chunk-size `\r` and `\n` in separate TCP segments, verifies server processes the request correctly
- [x] New test: "handles lone CR in chunk-size with extensions" — same split but with chunk extensions before the CRLF
- [x] Existing test "handles fragmented chunk terminators" still passes
- [x] Existing test "rejects invalid terminator in fragmented reads" still passes
- [x] Verified new tests timeout/fail with `USE_SYSTEM_BUN=1` (unpatched) and pass with `bun bd test` (patched)


🤖 Generated with [Claude Code](https://claude.com/claude-code)