### PR TITLE
fix(repl): use external clipboard tools for .copy command

### DIFF
--- a/src/repl.zig
+++ b/src/repl.zig
@@ -1433,7 +1433,9 @@ fn valueToClipboardString(self: *Repl, value: jsc.JSValue) bun.JSError!?[]const 
     return self.allocator.dupe(u8, array.written()) catch null;
 }
 
-/// Copy a JS value to the system clipboard via OSC 52.
+/// Copy a JS value to the system clipboard.
+/// Tries external clipboard tools first (xclip, xsel, wl-copy, pbcopy),
+/// then falls back to OSC 52 escape sequences.
 /// Propagates JS exceptions from value formatting; swallows I/O errors.
 fn copyValueToClipboard(self: *Repl, value: jsc.JSValue) bun.JSError!void {
     const text = (try self.valueToClipboardString(value)) orelse {
@@ -1442,44 +1444,100 @@ fn copyValueToClipboard(self: *Repl, value: jsc.JSValue) bun.JSError!void {
     };
     defer self.allocator.free(text);
 
-    self.copyToClipboardOSC52(text) catch {
+    const clean_text = self.stripAnsiForClipboard(text) catch {
         self.printError("Failed to write to clipboard\n", .{});
         return;
     };
+    defer self.allocator.free(clean_text);
+
+    // Try external clipboard tools first (works on terminals without OSC 52),
+    // then fall back to OSC 52 escape sequences (works over SSH).
+    if (!self.copyToClipboardExternal(clean_text)) {
+        self.copyToClipboardOSC52(clean_text) catch {
+            self.printError("Failed to write to clipboard\n", .{});
+            return;
+        };
+    }
     if (self.use_colors) {
-        self.print("{s}Copied {d} characters to clipboard{s}\n", .{ Color.dim, text.len, Color.reset });
+        self.print("{s}Copied {d} characters to clipboard{s}\n", .{ Color.dim, clean_text.len, Color.reset });
     } else {
-        self.print("Copied {d} characters to clipboard\n", .{text.len});
+        self.print("Copied {d} characters to clipboard\n", .{clean_text.len});
     }
 }
 
-/// Write text to clipboard using OSC 52 escape sequence.
-fn copyToClipboardOSC52(self: *Repl, text: []const u8) !void {
+/// Strip ANSI escape sequences from text for clipboard use.
+/// Caller owns the returned memory.
+fn stripAnsiForClipboard(self: *Repl, text: []const u8) ![]const u8 {
     var it = strings.ANSIIterator.init(text);
-    const first = it.next() orelse return;
+    const first = it.next() orelse return try self.allocator.dupe(u8, "");
 
     if (first.len == text.len) {
-        // No ANSI sequences - encode the original directly
-        var encoded = try bun.base64.encodeAlloc(self.allocator, text);
-        defer encoded.deinit(self.allocator);
-        self.write("\x1b]52;c;");
-        self.write(encoded.slice());
-        self.write("\x07");
-    } else {
-        // Has ANSI sequences - collect clean slices then encode
-        var clean = ArrayList(u8).init(self.allocator);
-        defer clean.deinit();
-        try clean.ensureTotalCapacity(text.len);
-        clean.appendSliceAssumeCapacity(first);
-        while (it.next()) |slice| {
-            clean.appendSliceAssumeCapacity(slice);
-        }
-        var encoded = try bun.base64.encodeAlloc(self.allocator, clean.items);
-        defer encoded.deinit(self.allocator);
-        self.write("\x1b]52;c;");
-        self.write(encoded.slice());
-        self.write("\x07");
+        // No ANSI sequences
+        return try self.allocator.dupe(u8, text);
     }
+
+    // Has ANSI sequences - collect clean slices
+    var clean = ArrayList(u8).init(self.allocator);
+    errdefer clean.deinit();
+    try clean.ensureTotalCapacity(text.len);
+    clean.appendSliceAssumeCapacity(first);
+    while (it.next()) |slice| {
+        clean.appendSliceAssumeCapacity(slice);
+    }
+    return try clean.toOwnedSlice();
+}
+
+/// Try to copy text to clipboard using platform-specific external tools.
+/// Returns true if the text was successfully copied.
+fn copyToClipboardExternal(_: *Repl, text: []const u8) bool {
+    const ClipboardCmd = struct {
+        argv: []const []const u8,
+    };
+    const commands: []const ClipboardCmd = if (Environment.isMac)
+        &.{
+            .{ .argv = &.{"pbcopy"} },
+        }
+    else if (Environment.isLinux)
+        &.{
+            .{ .argv = &.{ "xclip", "-selection", "clipboard" } },
+            .{ .argv = &.{ "xsel", "--clipboard", "--input" } },
+            .{ .argv = &.{"wl-copy"} },
+        }
+    else
+        return false;
+
+    for (commands) |cmd| {
+        var child = std.process.Child.init(cmd.argv, bun.default_allocator);
+        child.stdin_behavior = .Pipe;
+        child.stdout_behavior = .Ignore;
+        child.stderr_behavior = .Ignore;
+
+        child.spawn() catch continue;
+
+        if (child.stdin) |stdin| {
+            stdin.writeAll(text) catch {
+                _ = child.wait() catch {};
+                continue;
+            };
+            stdin.close();
+            child.stdin = null;
+        }
+
+        const term = child.wait() catch continue;
+        if (term == .Exited and term.Exited == 0) return true;
+    }
+
+    return false;
+}
+
+/// Write text to clipboard using OSC 52 escape sequence.
+/// Expects text with ANSI sequences already stripped.
+fn copyToClipboardOSC52(self: *Repl, text: []const u8) !void {
+    var encoded = try bun.base64.encodeAlloc(self.allocator, text);
+    defer encoded.deinit(self.allocator);
+    self.write("\x1b]52;c;");
+    self.write(encoded.slice());
+    self.write("\x07");
 }
 
 /// Transform code using the REPL parser (hoists declarations, wraps expressions)

--- a/test/regression/issue/27671.test.ts
+++ b/test/regression/issue/27671.test.ts
@@ -54,6 +54,7 @@ describe("issue #27671 - .copy with external clipboard tools", () => {
     using dir = tempDir("repl-copy-test", {});
     const clipOutputFile = await setupFakeClipboard(String(dir));
 
+    // Fake tool dir is first in PATH so it is found before any host tools.
     const { stdout, exitCode } = await runRepl([".copy 42", ".exit"], {
       env: {
         PATH: `${dir}:${process.env.PATH}`,
@@ -97,7 +98,7 @@ describe("issue #27671 - .copy with external clipboard tools", () => {
 
     const { stdout, exitCode } = await runRepl([".copy 42", ".exit"], {
       env: {
-        // Only include bun's directory and our empty dir (no clipboard tools)
+        // Only bun's directory and empty dir - no clipboard tools available
         PATH: `${dir}:${path.dirname(bunExe())}`,
       },
     });

--- a/test/regression/issue/27671.test.ts
+++ b/test/regression/issue/27671.test.ts
@@ -1,9 +1,14 @@
 // Test for #27671: .copy command should work with external clipboard tools
 // when OSC 52 is not supported by the terminal.
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isMacOS, isWindows, tempDir } from "harness";
+import path from "path";
 
-// Helper to run REPL with piped stdin and capture output
+// The REPL tries "pbcopy" on macOS, "xclip" on Linux.
+const fakeClipboardName = isMacOS ? "pbcopy" : "xclip";
+
+// Helper to run REPL with piped stdin and capture raw output (no ANSI stripping
+// so we can inspect OSC 52 sequences when needed).
 async function runRepl(
   input: string[],
   options: {
@@ -39,15 +44,15 @@ describe("issue #27671 - .copy with external clipboard tools", () => {
 
     const clipOutputFile = `${dir}/clip-output.txt`;
 
-    // Create a fake xclip that saves stdin to a file (ignores -selection clipboard args)
-    const fakeClipboard = `${dir}/xclip`;
+    // Create a fake clipboard tool that saves stdin to a file
+    const fakeClipboard = `${dir}/${fakeClipboardName}`;
     await Bun.write(fakeClipboard, `#!/bin/sh\ncat > "${clipOutputFile}"\n`);
     const { exitCode: chmodExit } = Bun.spawnSync({
       cmd: ["chmod", "+x", fakeClipboard],
     });
     expect(chmodExit).toBe(0);
 
-    // Run the REPL with our fake xclip first in PATH
+    // Run the REPL with our fake tool first in PATH
     const { stdout, exitCode } = await runRepl([".copy 42", ".exit"], {
       env: {
         PATH: `${dir}:${process.env.PATH}`,
@@ -69,9 +74,12 @@ describe("issue #27671 - .copy with external clipboard tools", () => {
     using dir = tempDir("repl-copy-test2", {});
 
     const clipOutputFile = `${dir}/clip-output.txt`;
-    const fakeClipboard = `${dir}/xclip`;
+    const fakeClipboard = `${dir}/${fakeClipboardName}`;
     await Bun.write(fakeClipboard, `#!/bin/sh\ncat > "${clipOutputFile}"\n`);
-    Bun.spawnSync({ cmd: ["chmod", "+x", fakeClipboard] });
+    const { exitCode: chmodExit } = Bun.spawnSync({
+      cmd: ["chmod", "+x", fakeClipboard],
+    });
+    expect(chmodExit).toBe(0);
 
     const { stdout, exitCode } = await runRepl([".copy 'hello world'", ".exit"], {
       env: {
@@ -89,16 +97,19 @@ describe("issue #27671 - .copy with external clipboard tools", () => {
     expect(exitCode).toBe(0);
   });
 
-  test(".copy falls back to OSC 52 when no external tools available", async () => {
+  test.skipIf(isWindows)(".copy falls back to OSC 52 when no external tools available", async () => {
     // Use an empty temp dir as the only PATH entry - no clipboard tools found
     using dir = tempDir("repl-copy-empty", {});
 
     const { stdout, exitCode } = await runRepl([".copy 42", ".exit"], {
       env: {
-        // Only include the dir containing bun itself, plus our empty dir
-        PATH: `${dir}:${require("path").dirname(bunExe())}`,
+        // Only include bun's directory and our empty dir (no clipboard tools)
+        PATH: `${dir}:${path.dirname(bunExe())}`,
       },
     });
+
+    // Raw stdout should contain the OSC 52 escape sequence
+    expect(stdout).toContain("\x1b]52;c;");
 
     const output = Bun.stripANSI(stdout);
     // Should still report success (via OSC 52 fallback)

--- a/test/regression/issue/27671.test.ts
+++ b/test/regression/issue/27671.test.ts
@@ -38,21 +38,22 @@ async function runRepl(
   return { stdout, stderr, exitCode };
 }
 
+// Create a fake clipboard tool that writes stdin to a capture file.
+// Returns the path to the capture file.
+async function setupFakeClipboard(dir: string): Promise<string> {
+  const clipOutputFile = `${dir}/clip-output.txt`;
+  const fakeClipboard = `${dir}/${fakeClipboardName}`;
+  await Bun.write(fakeClipboard, `#!/bin/sh\ncat > "${clipOutputFile}"\n`);
+  const { exitCode } = Bun.spawnSync({ cmd: ["chmod", "+x", fakeClipboard] });
+  expect(exitCode).toBe(0);
+  return clipOutputFile;
+}
+
 describe("issue #27671 - .copy with external clipboard tools", () => {
   test.skipIf(isWindows)(".copy pipes text to external clipboard tool", async () => {
     using dir = tempDir("repl-copy-test", {});
+    const clipOutputFile = await setupFakeClipboard(String(dir));
 
-    const clipOutputFile = `${dir}/clip-output.txt`;
-
-    // Create a fake clipboard tool that saves stdin to a file
-    const fakeClipboard = `${dir}/${fakeClipboardName}`;
-    await Bun.write(fakeClipboard, `#!/bin/sh\ncat > "${clipOutputFile}"\n`);
-    const { exitCode: chmodExit } = Bun.spawnSync({
-      cmd: ["chmod", "+x", fakeClipboard],
-    });
-    expect(chmodExit).toBe(0);
-
-    // Run the REPL with our fake tool first in PATH
     const { stdout, exitCode } = await runRepl([".copy 42", ".exit"], {
       env: {
         PATH: `${dir}:${process.env.PATH}`,
@@ -72,14 +73,7 @@ describe("issue #27671 - .copy with external clipboard tools", () => {
 
   test.skipIf(isWindows)(".copy pipes string value without quotes", async () => {
     using dir = tempDir("repl-copy-test2", {});
-
-    const clipOutputFile = `${dir}/clip-output.txt`;
-    const fakeClipboard = `${dir}/${fakeClipboardName}`;
-    await Bun.write(fakeClipboard, `#!/bin/sh\ncat > "${clipOutputFile}"\n`);
-    const { exitCode: chmodExit } = Bun.spawnSync({
-      cmd: ["chmod", "+x", fakeClipboard],
-    });
-    expect(chmodExit).toBe(0);
+    const clipOutputFile = await setupFakeClipboard(String(dir));
 
     const { stdout, exitCode } = await runRepl([".copy 'hello world'", ".exit"], {
       env: {

--- a/test/regression/issue/27671.test.ts
+++ b/test/regression/issue/27671.test.ts
@@ -1,0 +1,109 @@
+// Test for #27671: .copy command should work with external clipboard tools
+// when OSC 52 is not supported by the terminal.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// Helper to run REPL with piped stdin and capture output
+async function runRepl(
+  input: string[],
+  options: {
+    env?: Record<string, string>;
+  } = {},
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const inputStr = input.join("\n") + "\n";
+  const { env = {} } = options;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "repl"],
+    stdin: Buffer.from(inputStr),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...bunEnv,
+      TERM: "dumb",
+      NO_COLOR: "1",
+      ...env,
+    },
+  });
+
+  const exitCode = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+
+  return { stdout, stderr, exitCode };
+}
+
+describe("issue #27671 - .copy with external clipboard tools", () => {
+  test.skipIf(isWindows)(".copy pipes text to external clipboard tool", async () => {
+    using dir = tempDir("repl-copy-test", {});
+
+    const clipOutputFile = `${dir}/clip-output.txt`;
+
+    // Create a fake xclip that saves stdin to a file (ignores -selection clipboard args)
+    const fakeClipboard = `${dir}/xclip`;
+    await Bun.write(fakeClipboard, `#!/bin/sh\ncat > "${clipOutputFile}"\n`);
+    const { exitCode: chmodExit } = Bun.spawnSync({
+      cmd: ["chmod", "+x", fakeClipboard],
+    });
+    expect(chmodExit).toBe(0);
+
+    // Run the REPL with our fake xclip first in PATH
+    const { stdout, exitCode } = await runRepl([".copy 42", ".exit"], {
+      env: {
+        PATH: `${dir}:${process.env.PATH}`,
+      },
+    });
+
+    const output = Bun.stripANSI(stdout);
+    expect(output).toContain("Copied");
+    expect(output).toContain("clipboard");
+
+    // Verify the fake clipboard tool received the correct text
+    const clipContent = await Bun.file(clipOutputFile).text();
+    expect(clipContent).toBe("42");
+
+    expect(exitCode).toBe(0);
+  });
+
+  test.skipIf(isWindows)(".copy pipes string value without quotes", async () => {
+    using dir = tempDir("repl-copy-test2", {});
+
+    const clipOutputFile = `${dir}/clip-output.txt`;
+    const fakeClipboard = `${dir}/xclip`;
+    await Bun.write(fakeClipboard, `#!/bin/sh\ncat > "${clipOutputFile}"\n`);
+    Bun.spawnSync({ cmd: ["chmod", "+x", fakeClipboard] });
+
+    const { stdout, exitCode } = await runRepl([".copy 'hello world'", ".exit"], {
+      env: {
+        PATH: `${dir}:${process.env.PATH}`,
+      },
+    });
+
+    const output = Bun.stripANSI(stdout);
+    expect(output).toContain("Copied");
+
+    const clipContent = await Bun.file(clipOutputFile).text();
+    // String values are copied raw (without quotes)
+    expect(clipContent).toBe("hello world");
+
+    expect(exitCode).toBe(0);
+  });
+
+  test(".copy falls back to OSC 52 when no external tools available", async () => {
+    // Use an empty temp dir as the only PATH entry - no clipboard tools found
+    using dir = tempDir("repl-copy-empty", {});
+
+    const { stdout, exitCode } = await runRepl([".copy 42", ".exit"], {
+      env: {
+        // Only include the dir containing bun itself, plus our empty dir
+        PATH: `${dir}:${require("path").dirname(bunExe())}`,
+      },
+    });
+
+    const output = Bun.stripANSI(stdout);
+    // Should still report success (via OSC 52 fallback)
+    expect(output).toContain("Copied");
+    expect(output).toContain("clipboard");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- The `.copy` command in the REPL previously relied exclusively on OSC 52 escape sequences to copy text to the clipboard
- OSC 52 is not supported by VTE-based terminals (XFCE4 Terminal, GNOME Terminal, and others), causing `.copy` to silently fail
- Now tries external clipboard tools first (`xclip`, `xsel`, `wl-copy` on Linux; `pbcopy` on macOS), then falls back to OSC 52 for SSH sessions and terminals that support it

## Test plan
- [x] Added regression test (`test/regression/issue/27671.test.ts`) with fake `xclip` that verifies text is piped correctly
- [x] Tests verify numeric values, string values (copied without quotes), and OSC 52 fallback when no tools are available
- [x] All 105 existing REPL tests continue to pass
- [x] Verified regression test fails with system bun (pre-fix) and passes with debug build (post-fix)

Closes #27671

🤖 Generated with [Claude Code](https://claude.com/claude-code)