### PR TITLE
fix(repl): prevent duplicated lines when pasting text wider than terminal

### DIFF
--- a/src/repl.zig
+++ b/src/repl.zig
@@ -681,6 +681,7 @@ use_colors: bool = false,
 terminal_width: u16 = 80,
 terminal_height: u16 = 24,
 ctrl_c_pressed: bool = false,
+prev_extra_lines: usize = 0, // extra terminal lines from previous refreshLine render
 
 // Buffered stdin
 stdin_buf: [256]u8 = .{0} ** 256,
@@ -746,8 +747,14 @@ fn setupTerminal(self: *Repl) void {
     // Check for NO_COLOR
     self.use_colors = !bun.env_var.NO_COLOR.get();
 
-    // Get terminal size
-    if (Output.terminal_size.col > 0) {
+    // Get terminal size via ioctl (Output.terminal_size may not be initialized)
+    if (Environment.isPosix) {
+        var size: std.posix.winsize = undefined;
+        if (std.posix.system.ioctl(std.posix.STDOUT_FILENO, std.posix.T.IOCGWINSZ, @intFromPtr(&size)) == 0) {
+            if (size.col > 0) self.terminal_width = size.col;
+            if (size.row > 0) self.terminal_height = size.row;
+        }
+    } else if (Output.terminal_size.col > 0) {
         self.terminal_width = Output.terminal_size.col;
         self.terminal_height = Output.terminal_size.row;
     }
@@ -959,10 +966,37 @@ fn refreshLine(self: *Repl) void {
     const prompt = self.getPrompt();
     const prompt_len = self.getPromptLength();
     const line = self.line_editor.getLine();
+    const tw: usize = if (self.terminal_width > 0) @as(usize, self.terminal_width) else 80;
+    var buf: [32]u8 = undefined;
 
-    // Move to beginning of line
+    // When previous render spanned multiple terminal rows (due to soft wrapping),
+    // the cursor is on the last row. Move up to the first row and clear all rows
+    // that were part of the previous render to avoid ghost/duplicate lines.
+    if (self.prev_extra_lines > 0) {
+        // Move cursor up from last row to first row
+        const seq = std.fmt.bufPrint(&buf, CSI ++ "{d}A", .{self.prev_extra_lines}) catch return;
+        self.write(seq);
+    }
+
+    // Clear the first row
     self.write("\r");
     self.write(Cursor.clear_line);
+
+    // Clear all extra rows from previous render
+    {
+        var i: usize = 0;
+        while (i < self.prev_extra_lines) : (i += 1) {
+            self.write("\n");
+            self.write(Cursor.clear_line);
+        }
+    }
+
+    // Move back up to the first row
+    if (self.prev_extra_lines > 0) {
+        const seq = std.fmt.bufPrint(&buf, CSI ++ "{d}A", .{self.prev_extra_lines}) catch return;
+        self.write(seq);
+    }
+    self.write("\r");
 
     // Write prompt
     self.write(prompt);
@@ -974,12 +1008,20 @@ fn refreshLine(self: *Repl) void {
         self.write(line);
     }
 
-    // Position cursor
-    const cursor_pos = prompt_len + self.line_editor.cursor;
-    if (cursor_pos < self.terminal_width) {
+    // Calculate how many extra terminal rows the content occupies due to wrapping.
+    // After writing N visible chars from col 0, the last char is on row (N-1)/tw,
+    // so extra_lines (rows beyond the first) = (N-1)/tw for N > 0.
+    const total_len = prompt_len + line.len;
+    const extra_lines: usize = if (total_len > tw) (total_len -| 1) / tw else 0;
+    self.prev_extra_lines = extra_lines;
+
+    // Position cursor. When content wraps to multiple rows, the cursor is left
+    // at the end of the content (last row) which is the correct position for
+    // typing. When content fits on one row, reposition to the exact cursor column.
+    if (extra_lines == 0) {
+        const cursor_pos = prompt_len + self.line_editor.cursor;
         self.write("\r");
         if (cursor_pos > 0) {
-            var buf: [16]u8 = undefined;
             const seq = std.fmt.bufPrint(&buf, CSI ++ "{d}C", .{cursor_pos}) catch return;
             self.write(seq);
         }
@@ -1668,6 +1710,7 @@ pub fn runWithVM(self: *Repl, vm: ?*jsc.VirtualMachine) !void {
     while (self.running) {
         const key = self.readKey() orelse {
             // EOF
+            self.movePastMultilineContent();
             self.print("\n", .{});
             break;
         };
@@ -1681,6 +1724,7 @@ pub fn runWithVM(self: *Repl, vm: ?*jsc.VirtualMachine) !void {
             .ctrl_d => {
                 if (self.editor_mode) {
                     // Finish editor mode
+                    self.movePastMultilineContent();
                     self.print("\n", .{});
                     const code = self.editor_buffer.items;
                     if (code.len > 0) {
@@ -1690,6 +1734,7 @@ pub fn runWithVM(self: *Repl, vm: ?*jsc.VirtualMachine) !void {
                     self.editor_buffer.clearRetainingCapacity();
                     self.refreshLine();
                 } else if (self.line_editor.buffer.items.len == 0 and !self.in_multiline) {
+                    self.movePastMultilineContent();
                     self.print("\n", .{});
                     self.running = false;
                 } else {
@@ -1698,6 +1743,7 @@ pub fn runWithVM(self: *Repl, vm: ?*jsc.VirtualMachine) !void {
                 }
             },
             .ctrl_l => {
+                self.prev_extra_lines = 0;
                 self.write(Cursor.clear_screen);
                 self.write(Cursor.home);
                 self.refreshLine();
@@ -1788,7 +1834,20 @@ pub fn runWithVM(self: *Repl, vm: ?*jsc.VirtualMachine) !void {
     self.history.save();
 }
 
+/// Move cursor past all wrapped content so that subsequent output (newline,
+/// evaluation result) appears below it rather than overwriting wrapped lines.
+fn movePastMultilineContent(self: *Repl) void {
+    if (self.prev_extra_lines > 0) {
+        // Cursor is on the last row of wrapped content (refreshLine leaves it there).
+        // Move to end of that row so the next newline goes below all content.
+        self.write("\r");
+        self.write(Cursor.clear_to_end);
+        self.prev_extra_lines = 0;
+    }
+}
+
 fn handleEnter(self: *Repl) !void {
+    self.movePastMultilineContent();
     self.print("\n", .{});
 
     const line = self.line_editor.getLine();
@@ -1879,6 +1938,7 @@ fn handleEnter(self: *Repl) !void {
 }
 
 fn handleCtrlC(self: *Repl) void {
+    self.movePastMultilineContent();
     if (self.editor_mode) {
         self.print("\n{s}// Editor mode cancelled{s}\n", .{ Color.dim, Color.reset });
         self.editor_mode = false;

--- a/test/regression/issue/27670.test.ts
+++ b/test/regression/issue/27670.test.ts
@@ -1,0 +1,161 @@
+// Regression test for #27670: bun repl duplicated lines when pasting text
+// that exceeds terminal width.
+//
+// When pasting text wider than the available terminal columns, the REPL's
+// refreshLine() used to only clear the current terminal line, leaving
+// "ghost" copies of the wrapped text on rows above/below. The fix adds
+// cursor-up sequences to return to the first row and clear all wrapped
+// rows before redrawing.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+const stripAnsi = Bun.stripANSI;
+
+// Helper to run REPL in a PTY with a specific terminal width and capture raw output
+async function withNarrowTerminalRepl(
+  cols: number,
+  fn: (helpers: {
+    terminal: Bun.Terminal;
+    proc: Bun.ChildProcess;
+    send: (text: string) => void;
+    waitFor: (pattern: string | RegExp, timeoutMs?: number) => Promise<string>;
+    allOutput: () => string;
+    rawOutput: () => string;
+  }) => Promise<void>,
+) {
+  const received: string[] = [];
+  let cursor = 0;
+  let resolveWaiter: (() => void) | null = null;
+
+  await using terminal = new Bun.Terminal({
+    cols,
+    rows: 40,
+    data(_term, data) {
+      const str = Buffer.from(data).toString();
+      received.push(str);
+      if (resolveWaiter) {
+        resolveWaiter();
+        resolveWaiter = null;
+      }
+    },
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "repl"],
+    terminal,
+    env: {
+      ...bunEnv,
+      TERM: "xterm-256color",
+    },
+  });
+
+  const send = (text: string) => terminal.write(text);
+
+  const waitFor = async (pattern: string | RegExp, timeoutMs = 5000): Promise<string> => {
+    const deadline = Date.now() + timeoutMs;
+    while (true) {
+      const all = received.join("");
+      const recent = all.slice(cursor);
+      const matched = typeof pattern === "string" ? recent.includes(pattern) : pattern.test(recent);
+      if (matched) {
+        cursor = all.length;
+        return recent;
+      }
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        throw new Error(
+          `Timed out waiting for pattern: ${pattern}\nReceived so far:\n${stripAnsi(received.join("").slice(cursor))}`,
+        );
+      }
+      await new Promise<void>(resolve => {
+        resolveWaiter = resolve;
+      });
+      resolveWaiter = null;
+    }
+  };
+
+  const allOutput = () => stripAnsi(received.join(""));
+  const rawOutput = () => received.join("");
+
+  await waitFor(/\u276f|> /); // Wait for initial prompt
+
+  await fn({ terminal, proc, send, waitFor, allOutput, rawOutput });
+
+  // Clean exit
+  send(".exit\n");
+  await Promise.race([proc.exited, Bun.sleep(2000)]);
+  if (!proc.killed) proc.kill();
+}
+
+describe.todoIf(isWindows)("REPL wrapped line duplication (#27670)", () => {
+  test("refreshLine emits cursor-up sequences when content wraps", async () => {
+    const termWidth = 40;
+    // The prompt "❯ " takes 2 visible columns. With 40 chars of input,
+    // total = 42 > 40, causing wrapping. We need at least 2 chars past the
+    // wrap point so that the second wrapped refresh sees prev_extra_lines > 0
+    // and emits cursor-up sequences to clean up the previous wrapped content.
+    const overflowInput = "x".repeat(termWidth);
+
+    await withNarrowTerminalRepl(termWidth, async ({ send, waitFor, rawOutput }) => {
+      // Send text that will wrap past the terminal width
+      send(overflowInput);
+      // Wait until all characters appear in output
+      await waitFor("x".repeat(termWidth));
+
+      // Check the raw output for cursor-up escape sequences (CSI n A).
+      // The fix adds these to move the cursor back to the first row before
+      // clearing and redrawing wrapped content. Without the fix, there are
+      // no cursor-up sequences and ghost lines accumulate.
+      const raw = rawOutput();
+      const cursorUpPattern = /\x1b\[\d+A/;
+      expect(cursorUpPattern.test(raw)).toBe(true);
+    });
+  });
+
+  test("long expression evaluates correctly after wrapping", async () => {
+    const termWidth = 30;
+
+    await withNarrowTerminalRepl(termWidth, async ({ send, waitFor }) => {
+      // Type a valid JS expression wider than the terminal
+      // "1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1" is 31 chars, + 2 for prompt = 33 > 30
+      const expr = "1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1";
+      send(expr + "\n");
+
+      // The result should be 16
+      await waitFor("16");
+    });
+  });
+
+  test("subsequent expression works after wrapped input", async () => {
+    const termWidth = 30;
+
+    await withNarrowTerminalRepl(termWidth, async ({ send, waitFor }) => {
+      // Type a long expression that wraps
+      send("1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1\n");
+      await waitFor("16");
+
+      // Type a short expression — should work fine
+      send("2 + 3\n");
+      await waitFor("5");
+    });
+  });
+
+  test("wrapped content is cleaned up when line is cleared", async () => {
+    const termWidth = 30;
+
+    await withNarrowTerminalRepl(termWidth, async ({ send, waitFor }) => {
+      // Type enough to wrap: 35 + 2 prompt = 37 > 30
+      const longText = "a".repeat(35);
+      send(longText);
+      await Bun.sleep(200);
+
+      // Clear the line with Ctrl+U
+      send("\x15"); // Ctrl+U
+      await Bun.sleep(200);
+
+      // Type a short expression — it should evaluate correctly
+      send("42\n");
+      await waitFor("42");
+    });
+  });
+});

--- a/test/regression/issue/27670.test.ts
+++ b/test/regression/issue/27670.test.ts
@@ -147,11 +147,13 @@ describe.todoIf(isWindows)("REPL wrapped line duplication (#27670)", () => {
       // Type enough to wrap: 35 + 2 prompt = 37 > 30
       const longText = "a".repeat(35);
       send(longText);
-      await Bun.sleep(200);
+      // Wait for the full text to appear in output
+      await waitFor("a".repeat(35));
 
-      // Clear the line with Ctrl+U
+      // Clear the line with Ctrl+U, then wait for the prompt to reappear
+      // (refreshLine redraws a clean prompt after clearing the line)
       send("\x15"); // Ctrl+U
-      await Bun.sleep(200);
+      await waitFor(/\u276f|> /);
 
       // Type a short expression — it should evaluate correctly
       send("42\n");


### PR DESCRIPTION
## Summary

- Fix `refreshLine()` to properly handle terminal soft-wrapping by tracking extra lines across renders and clearing all wrapped rows before redrawing
- Fix terminal width detection to use `ioctl(TIOCGWINSZ)` instead of the never-initialized `Output.terminal_size`, which caused the REPL to always assume 80 columns
- Add `movePastMultilineContent()` helper to ensure output after wrapped input (Enter, Ctrl+C, Ctrl+D, EOF) appears below all content

Closes #27670

## Test plan

- [x] New regression test `test/regression/issue/27670.test.ts` with 4 test cases:
  - Verifies cursor-up escape sequences are emitted when content wraps (fails on system bun, passes on debug build)
  - Verifies long expressions evaluate correctly after wrapping
  - Verifies subsequent expressions work after wrapped input
  - Verifies wrapped content is cleaned up when line is cleared (Ctrl+U)
- [x] All 105 existing REPL tests pass (`test/js/bun/repl/repl.test.ts`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)