### PR TITLE
fix(node:util): make styleText respect NO_COLOR and FORCE_COLOR

### DIFF
--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -3,7 +3,7 @@ const types = require("node:util/types");
 /** @type {import('node-inspect-extracted')} */
 const utl = require("internal/util/inspect");
 const { promisify } = require("internal/promisify");
-const { validateString, validateOneOf } = require("internal/validators");
+const { validateString, validateOneOf, validateBoolean } = require("internal/validators");
 const { MIMEType, MIMEParams } = require("internal/util/mime");
 const { deprecate } = require("internal/util/deprecate");
 
@@ -195,30 +195,79 @@ var toUSVString = input => {
   return (input + "").toWellFormed();
 };
 
-function styleText(format, text) {
+function styleText(format, text, options?) {
   validateString(text, "text");
 
-  if ($isJSArray(format)) {
-    let left = "";
-    let right = "";
-    for (const key of format) {
-      const formatCodes = inspect.colors[key];
-      if (formatCodes == null) {
-        validateOneOf(key, "format", ObjectKeys(inspect.colors));
-      }
-      left += `\u001b[${formatCodes[0]}m`;
-      right = `\u001b[${formatCodes[1]}m${right}`;
+  const { validateStream: vs = true, stream = process.stdout } = options || {};
+  validateBoolean(vs, "options.validateStream");
+
+  let skipColorize;
+  if (vs) {
+    // Check if stream is a valid Node.js stream or Web stream
+    const isStream =
+      (stream &&
+        (typeof stream.pipe === "function" || typeof stream.write === "function") &&
+        typeof stream.on === "function") ||
+      stream instanceof ReadableStream ||
+      stream instanceof WritableStream;
+    if (!isStream) {
+      throw $ERR_INVALID_ARG_TYPE("stream", ["ReadableStream", "WritableStream", "Stream"], stream);
     }
-
-    return `${left}${text}${right}`;
+    skipColorize = !require("internal/util/colors").shouldColorize(stream);
   }
 
-  let formatCodes = inspect.colors[format];
+  const formatArray = $isJSArray(format) ? format : [format];
 
-  if (formatCodes == null) {
-    validateOneOf(format, "format", ObjectKeys(inspect.colors));
+  const codes: number[][] = [];
+  for (const key of formatArray) {
+    if (key === "none") continue;
+    const formatCodes = inspect.colors[key];
+    if (formatCodes == null) {
+      validateOneOf(key, "format", ObjectKeys(inspect.colors));
+    }
+    if (skipColorize) continue;
+    codes.push(formatCodes);
   }
-  return `\u001b[${formatCodes[0]}m${text}\u001b[${formatCodes[1]}m`;
+
+  if (skipColorize) {
+    return text;
+  }
+
+  // Build opening codes
+  let openCodes = "";
+  for (let i = 0; i < codes.length; i++) {
+    openCodes += `\u001b[${codes[i][0]}m`;
+  }
+
+  // Process text to handle nested styles
+  let processedText;
+  if (codes.length > 0) {
+    processedText = codes.reduce(
+      (txt, code) =>
+        txt.replace(new RegExp(`\\u001b\\[${code[1]}m`, "g"), (match, offset) => {
+          // Check if there's more content after this reset
+          if (offset + match.length < txt.length) {
+            if (code[0] === inspect.colors.dim[0] || code[0] === inspect.colors.bold[0]) {
+              // Dim and bold are not mutually exclusive, so we need to reapply
+              return `${match}\u001b[${code[0]}m`;
+            }
+            return `\u001b[${code[0]}m`;
+          }
+          return match;
+        }),
+      text,
+    );
+  } else {
+    processedText = text;
+  }
+
+  // Build closing codes in reverse order
+  let closeCodes = "";
+  for (let i = codes.length - 1; i >= 0; i--) {
+    closeCodes += `\u001b[${codes[i][1]}m`;
+  }
+
+  return `${openCodes}${processedText}${closeCodes}`;
 }
 
 function getSystemErrorName(err: any) {

--- a/test/js/node/test/parallel/test-util-styletext.js
+++ b/test/js/node/test/parallel/test-util-styletext.js
@@ -1,7 +1,12 @@
 'use strict';
-require('../common');
-const assert = require('assert');
-const util = require('util');
+
+const common = require('../common');
+const assert = require('node:assert');
+const util = require('node:util');
+const { WriteStream } = require('node:tty');
+
+const styled = '\u001b[31mtest\u001b[39m';
+const noChange = 'test';
 
 [
   undefined,
@@ -31,13 +36,155 @@ assert.throws(() => {
   code: 'ERR_INVALID_ARG_VALUE',
 });
 
-assert.strictEqual(util.styleText('red', 'test'), '\u001b[31mtest\u001b[39m');
+assert.strictEqual(
+  util.styleText('red', 'test', { validateStream: false }),
+  '\u001b[31mtest\u001b[39m',
+);
 
-assert.strictEqual(util.styleText(['bold', 'red'], 'test'), '\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m');
-assert.strictEqual(util.styleText(['bold', 'red'], 'test'), util.styleText('bold', util.styleText('red', 'test')));
+assert.strictEqual(
+  util.styleText(['bold', 'red'], 'test', { validateStream: false }),
+  '\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m',
+);
+
+assert.strictEqual(
+  util.styleText('red',
+                 'A' + util.styleText('blue', 'B', { validateStream: false }) + 'C',
+                 { validateStream: false }),
+  '\u001b[31mA\u001b[34mB\u001b[31mC\u001b[39m'
+);
+
+assert.strictEqual(
+  util.styleText('red',
+                 'red' +
+    util.styleText('blue', 'blue', { validateStream: false }) +
+    'red' +
+    util.styleText('blue', 'blue', { validateStream: false }) +
+    'red',
+                 { validateStream: false }
+  ),
+  '\x1B[31mred\x1B[34mblue\x1B[31mred\x1B[34mblue\x1B[31mred\x1B[39m'
+);
+
+assert.strictEqual(
+  util.styleText('red',
+                 'red' +
+    util.styleText('blue', 'blue', { validateStream: false }) +
+    'red' +
+    util.styleText('red', 'red', { validateStream: false }) +
+    'red' +
+    util.styleText('blue', 'blue', { validateStream: false }),
+                 { validateStream: false }
+  ),
+  '\x1b[31mred\x1b[34mblue\x1b[31mred\x1b[31mred\x1b[31mred\x1b[34mblue\x1b[39m\x1b[39m'
+);
+
+assert.strictEqual(
+  util.styleText('red',
+                 'A' + util.styleText(['bgRed', 'blue'], 'B', { validateStream: false }) +
+    'C', { validateStream: false }),
+  '\x1B[31mA\x1B[41m\x1B[34mB\x1B[31m\x1B[49mC\x1B[39m'
+);
+
+assert.strictEqual(
+  util.styleText('dim',
+                 'dim' +
+    util.styleText('bold', 'bold', { validateStream: false }) +
+  'dim', { validateStream: false }),
+  '\x1B[2mdim\x1B[1mbold\x1B[22m\x1B[2mdim\x1B[22m'
+);
+
+assert.strictEqual(
+  util.styleText('blue',
+                 'blue' +
+    util.styleText('red',
+                   'red' +
+      util.styleText('green', 'green', { validateStream: false }) +
+      'red', { validateStream: false }) +
+    'blue', { validateStream: false }),
+  '\x1B[34mblue\x1B[31mred\x1B[32mgreen\x1B[31mred\x1B[34mblue\x1B[39m'
+);
+
+assert.strictEqual(
+  util.styleText(
+    'red',
+    'red' +
+    util.styleText(
+      'blue',
+      'blue' + util.styleText('red', 'red', {
+        validateStream: false,
+      }) + 'blue',
+      {
+        validateStream: false,
+      }
+    ) + 'red', {
+      validateStream: false,
+    }
+  ),
+  '\x1b[31mred\x1b[34mblue\x1b[31mred\x1b[34mblue\x1b[31mred\x1b[39m'
+);
+
+assert.strictEqual(
+  util.styleText(['bold', 'red'], 'test', { validateStream: false }),
+  util.styleText(
+    'bold',
+    util.styleText('red', 'test', { validateStream: false }),
+    { validateStream: false },
+  ),
+);
 
 assert.throws(() => {
   util.styleText(['invalid'], 'text');
 }, {
   code: 'ERR_INVALID_ARG_VALUE',
 });
+
+assert.throws(() => {
+  util.styleText('red', 'text', { stream: {} });
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+// does not throw
+util.styleText('red', 'text', { stream: {}, validateStream: false });
+
+assert.strictEqual(
+  util.styleText('red', 'test', { validateStream: false }),
+  styled,
+);
+
+assert.strictEqual(util.styleText('none', 'test'), 'test');
+
+const fd = common.getTTYfd();
+if (fd !== -1) {
+  const writeStream = new WriteStream(fd);
+
+  const originalEnv = process.env;
+  [
+    { isTTY: true, env: {}, expected: styled },
+    { isTTY: false, env: {}, expected: noChange },
+    { isTTY: true, env: { NODE_DISABLE_COLORS: '1' }, expected: noChange },
+    { isTTY: true, env: { NO_COLOR: '1' }, expected: noChange },
+    { isTTY: true, env: { FORCE_COLOR: '1' }, expected: styled },
+    { isTTY: true, env: { FORCE_COLOR: '1', NODE_DISABLE_COLORS: '1' }, expected: styled },
+    { isTTY: false, env: { FORCE_COLOR: '1', NO_COLOR: '1', NODE_DISABLE_COLORS: '1' }, expected: styled },
+    { isTTY: true, env: { FORCE_COLOR: '1', NO_COLOR: '1', NODE_DISABLE_COLORS: '1' }, expected: styled },
+  ].forEach((testCase) => {
+    writeStream.isTTY = testCase.isTTY;
+    process.env = {
+      ...process.env,
+      ...testCase.env
+    };
+    {
+      const output = util.styleText('red', 'test', { stream: writeStream });
+      assert.strictEqual(output, testCase.expected);
+    }
+    {
+      // Check that when passing an array of styles, the output behaves the same
+      const output = util.styleText(['red'], 'test', { stream: writeStream });
+      assert.strictEqual(output, testCase.expected);
+    }
+    process.env = originalEnv;
+  });
+} else {
+  common.skip('Could not create TTY fd');
+}

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -342,9 +342,11 @@ describe("util", () => {
   });
 
   it("multiplecolors", () => {
-    expect(util.styleText(["bold", "red"], "test")).toBe("\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m");
-    expect(util.styleText("bold", "test")).toBe("\u001b[1mtest\u001b[22m");
-    expect(util.styleText("red", "test")).toBe("\u001b[31mtest\u001b[39m");
+    expect(util.styleText(["bold", "red"], "test", { validateStream: false })).toBe(
+      "\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m",
+    );
+    expect(util.styleText("bold", "test", { validateStream: false })).toBe("\u001b[1mtest\u001b[22m");
+    expect(util.styleText("red", "test", { validateStream: false })).toBe("\u001b[31mtest\u001b[39m");
   });
 
   it("styleText", () => {
@@ -376,7 +378,7 @@ describe("util", () => {
       },
     );
 
-    assert.strictEqual(util.styleText("red", "test"), "\u001b[31mtest\u001b[39m");
+    assert.strictEqual(util.styleText("red", "test", { validateStream: false }), "\u001b[31mtest\u001b[39m");
   });
 
   describe("getSystemErrorName", () => {

--- a/test/regression/issue/27678.test.ts
+++ b/test/regression/issue/27678.test.ts
@@ -1,0 +1,131 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/27678
+// styleText should respect NO_COLOR and FORCE_COLOR environment variables
+
+test("styleText respects NO_COLOR environment variable", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import { styleText } from "node:util"; console.log(JSON.stringify(styleText("green", "hello")));`,
+    ],
+    env: { ...bunEnv, NO_COLOR: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe('"hello"');
+  expect(exitCode).toBe(0);
+});
+
+test("styleText respects FORCE_COLOR=0 environment variable", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import { styleText } from "node:util"; console.log(JSON.stringify(styleText("green", "hello")));`,
+    ],
+    env: { ...bunEnv, FORCE_COLOR: "0" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe('"hello"');
+  expect(exitCode).toBe(0);
+});
+
+test("styleText respects FORCE_COLOR=1 to enable colors", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import { styleText } from "node:util"; console.log(JSON.stringify(styleText("green", "hello")));`,
+    ],
+    env: { ...bunEnv, FORCE_COLOR: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe('"\\u001b[32mhello\\u001b[39m"');
+  expect(exitCode).toBe(0);
+});
+
+test("styleText respects NO_COLOR set at runtime via process.env", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import { styleText } from "node:util"; process.env.NO_COLOR = "1"; console.log(JSON.stringify(styleText("green", "hello")));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe('"hello"');
+  expect(exitCode).toBe(0);
+});
+
+test("styleText with validateStream: false ignores NO_COLOR", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import { styleText } from "node:util"; console.log(JSON.stringify(styleText("green", "hello", { validateStream: false })));`,
+    ],
+    env: { ...bunEnv, NO_COLOR: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe('"\\u001b[32mhello\\u001b[39m"');
+  expect(exitCode).toBe(0);
+});
+
+test("styleText 'none' format returns plain text", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import { styleText } from "node:util"; console.log(JSON.stringify(styleText("none", "hello")));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe('"hello"');
+  expect(exitCode).toBe(0);
+});
+
+test("styleText throws ERR_INVALID_ARG_TYPE for invalid stream", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import { styleText } from "node:util"; try { styleText("red", "text", { stream: {} }); console.log("no-throw"); } catch(e) { console.log(e.code); }`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("ERR_INVALID_ARG_TYPE");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fix `util.styleText` to respect `NO_COLOR`, `FORCE_COLOR`, and `NODE_DISABLE_COLORS` environment variables, matching Node.js behavior
- Add `validateStream` and `stream` options to the `styleText` API (aligning with Node.js v22+)
- Support `'none'` format and proper nested style handling (dim/bold interop)

Closes #27678

## What changed

**`src/js/node/util.ts`**: Rewrote `styleText` to:
1. Accept optional third parameter `{ validateStream, stream }` (defaults to `{ true, process.stdout }`)
2. When `validateStream` is true, validate the stream and check `shouldColorize(stream)` which respects `NO_COLOR`, `FORCE_COLOR`, `NODE_DISABLE_COLORS`, and `stream.isTTY`
3. When colors should be skipped, return plain text without ANSI codes
4. Support `'none'` format that passes text through unchanged
5. Handle nested style re-application (matching Node.js behavior for dim/bold interop)

**Before (Bun):**
```
$ NO_COLOR=1 bun -e "console.log(JSON.stringify(require('util').styleText('green','hello')))"
"\u001b[32mhello\u001b[39m"    # ANSI codes applied despite NO_COLOR
```

**After (matches Node.js):**
```
$ NO_COLOR=1 bun -e "console.log(JSON.stringify(require('util').styleText('green','hello')))"
"hello"                         # Plain text, as expected
```

## Test plan
- [x] `bun bd test test/regression/issue/27678.test.ts` — 7 new tests covering NO_COLOR, FORCE_COLOR=0, FORCE_COLOR=1, runtime env changes, validateStream:false, 'none' format, and invalid stream validation
- [x] `bun bd test test/js/node/util/util.test.js` — 192 existing tests pass (updated 2 to use `validateStream: false`)
- [x] `bun bd test ./test/js/node/test/parallel/test-util-styletext.js` — Updated to match current Node.js test suite (with `validateStream: false` and nested style tests)
- [x] Verified regression test fails with `USE_SYSTEM_BUN=1` (5 of 7 tests fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)