### PR TITLE
fix(css): preserve `geometry-box` values in mask shorthand parsing

### DIFF
--- a/src/css/properties/masking.zig
+++ b/src/css/properties/masking.zig
@@ -270,14 +270,14 @@ pub const Mask = struct {
 
         while (true) {
             if (image == null) {
-                if (@call(.auto, @field(Image, "parse"), .{input}).asValue()) |value| {
+                if (input.tryParse(Image.parse, .{}).asValue()) |value| {
                     image = value;
                     continue;
                 }
             }
 
             if (position == null) {
-                if (Position.parse(input).asValue()) |value| {
+                if (input.tryParse(Position.parse, .{}).asValue()) |value| {
                     position = value;
                     size = input.tryParse(struct {
                         pub inline fn parseFn(i: *css.Parser) css.Result(BackgroundSize) {
@@ -290,35 +290,35 @@ pub const Mask = struct {
             }
 
             if (repeat == null) {
-                if (BackgroundRepeat.parse(input).asValue()) |value| {
+                if (input.tryParse(BackgroundRepeat.parse, .{}).asValue()) |value| {
                     repeat = value;
                     continue;
                 }
             }
 
             if (origin == null) {
-                if (GeometryBox.parse(input).asValue()) |value| {
+                if (input.tryParse(GeometryBox.parse, .{}).asValue()) |value| {
                     origin = value;
                     continue;
                 }
             }
 
             if (clip == null) {
-                if (MaskClip.parse(input).asValue()) |value| {
+                if (input.tryParse(MaskClip.parse, .{}).asValue()) |value| {
                     clip = value;
                     continue;
                 }
             }
 
             if (composite == null) {
-                if (MaskComposite.parse(input).asValue()) |value| {
+                if (input.tryParse(MaskComposite.parse, .{}).asValue()) |value| {
                     composite = value;
                     continue;
                 }
             }
 
             if (mode == null) {
-                if (MaskMode.parse(input).asValue()) |value| {
+                if (input.tryParse(MaskMode.parse, .{}).asValue()) |value| {
                     mode = value;
                     continue;
                 }

--- a/test/bundler/css/mask-geometry-box.test.ts
+++ b/test/bundler/css/mask-geometry-box.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect } from "bun:test";
+import { itBundled } from "../expectBundled";
+
+describe("css", () => {
+  itBundled("css/mask-geometry-box-preserved", {
+    files: {
+      "index.css": /* css */ `
+        .test-a::after {
+            mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
+        }
+        .test-b::after {
+            mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+        }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.css"],
+    onAfterBundle(api) {
+      const output = api.readFile("/out/index.css");
+      expect(output).toContain("padding-box");
+      expect(output).toContain("content-box");
+      expect(output).toContain(".test-a");
+      expect(output).toContain(".test-b");
+      expect(output).not.toContain(".test-a:after, .test-b:after");
+    },
+  });
+
+  itBundled("css/webkit-mask-geometry-box-preserved", {
+    files: {
+      "index.css": /* css */ `
+        .test-c::after {
+            -webkit-mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
+            -webkit-mask-composite: xor;
+        }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.css"],
+    onAfterBundle(api) {
+      const output = api.readFile("/out/index.css");
+      expect(output).toContain("padding-box");
+    },
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Wrap parse calls in `Mask.parse()` with `input.tryParse()` to restore parser state on failure, matching the pattern used in `background.zig` ([#L55-L105](https://github.com/oven-sh/bun/blob/97c113d010304b7adf4d19ba7f9e8528b955bc1c/src/css/properties/background.zig#L55-L105)). Without this, failed parsers consume tokens before returning errors, causing `geometry-box` values (`padding-box`, `content-box`) to be silently dropped and rules with different geometry boxes to be incorrectly merged.

### How did you verify your code works?

Ran `test/bundler/css/mask-geometry-box.test.ts` against the fixed build and against `v1.3.10` + `v1.3.11-canary.60`:

- Fixed build: 2 pass, 0 fail
  - All existing CSS bundler tests pass (166 tests across 8 files)
- `v1.3.10` / `v1.3.11-canary.60`: 0 pass, 2 fail
  - confirms `geometry-box` values (`padding-box`, `content-box`) are stripped and rules are incorrectly merged