### PR TITLE
fix(ci): add llvm-symbolizer symlink for Alpine Linux

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1130,7 +1130,18 @@ install_llvm() {
 			"clang$(llvm_version)" \
 			"scudo-malloc" \
 			"lld$(llvm_version)" \
-			"llvm$(llvm_version)-dev" # Ensures llvm-symbolizer is installed
+			"llvm$(llvm_version)-dev"
+		# Alpine uses versioned binary names (e.g. llvm-symbolizer-21, llvm21-symbolizer).
+		# Create unversioned symlinks so tools like bun-tracestrings can find them.
+		if ! command -v llvm-symbolizer > /dev/null 2>&1; then
+			local llvm_v="$(llvm_version)"
+			# Try Debian-style naming (llvm-symbolizer-21), then Alpine-style (llvm21-symbolizer)
+			if command -v "llvm-symbolizer-${llvm_v}" > /dev/null 2>&1; then
+				execute_sudo ln -sf "$(which "llvm-symbolizer-${llvm_v}")" /usr/bin/llvm-symbolizer
+			elif command -v "llvm${llvm_v}-symbolizer" > /dev/null 2>&1; then
+				execute_sudo ln -sf "$(which "llvm${llvm_v}-symbolizer")" /usr/bin/llvm-symbolizer
+			fi
+		fi
 		;;
 	esac
 }

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -1700,8 +1700,9 @@ pub fn dumpStackTrace(trace: std.builtin.StackTrace, limits: WriteStackTraceLimi
 
     const programs: []const [:0]const u8 = switch (bun.Environment.os) {
         .windows => &.{"pdb-addr2line"},
-        // if `llvm-symbolizer` doesn't work, also try `llvm-symbolizer-21`
-        else => &.{ "llvm-symbolizer", "llvm-symbolizer-21" },
+        // if `llvm-symbolizer` doesn't work, also try versioned names:
+        // `llvm-symbolizer-21` (Debian/Ubuntu) or `llvm21-symbolizer` (Alpine)
+        else => &.{ "llvm-symbolizer", "llvm-symbolizer-21", "llvm21-symbolizer" },
     };
     for (programs) |program| {
         var arena = bun.ArenaAllocator.init(bun.default_allocator);


### PR DESCRIPTION
## Summary

- **bootstrap.sh**: After installing LLVM packages on Alpine (`apk`), create an unversioned `/usr/bin/llvm-symbolizer` symlink. Alpine's `llvm21` package installs the binary as `llvm21-symbolizer` (version-prefixed), but `bun-tracestrings` (the CI crash report parser) looks for the unversioned `llvm-symbolizer` via `Bun.which("llvm-symbolizer")`.
- **crash_handler.zig**: Add `llvm21-symbolizer` (Alpine's naming convention) to the fallback symbolizer list, so Bun's built-in crash handler can also find it on Alpine without the symlink.

### Root cause

The `install_llvm()` function in `bootstrap.sh` installs `llvm21` and `llvm21-dev` on Alpine, but unlike Ubuntu (where `install_gcc()` creates symlinks), no unversioned symlink was created for `llvm-symbolizer`. Alpine packages LLVM tools with a version prefix (`llvm21-symbolizer`) rather than a version suffix (`llvm-symbolizer-21`), so neither the CI crash report server nor Bun's crash handler could find it.

## Test plan

- [ ] Verify Alpine ARM64 CI test runs show "crash reports parsed on port XXXXX" without the "llvm-symbolizer missing" warning
- [ ] Verify crash symbolization works on Alpine when a test crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)