### PR TITLE
fix(bundler): resolve virtual files from HTML `<script src>` with absolute paths

### DIFF
--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -66,12 +66,7 @@ pub const JSBundler = struct {
             // Must use getKey to return the map's owned key, not the parameter
             if (comptime !bun.Environment.isWindows) {
                 if (self.map.getKey(specifier)) |key| {
-                    return _resolver.Result{
-                        .path_pair = .{
-                            .primary = Fs.Path.initWithNamespace(key, "file"),
-                        },
-                        .module_type = .unknown,
-                    };
+                    return makeResult(key);
                 }
             } else {
                 const buf = bun.path_buffer_pool.get();
@@ -79,52 +74,44 @@ pub const JSBundler = struct {
                 const normalized_specifier = bun.path.pathToPosixBuf(u8, specifier, buf);
 
                 if (self.map.getKey(normalized_specifier)) |key| {
-                    return _resolver.Result{
-                        .path_pair = .{
-                            .primary = Fs.Path.initWithNamespace(key, "file"),
-                        },
-                        .module_type = .unknown,
-                    };
+                    return makeResult(key);
                 }
             }
 
             // For absolute specifiers, check if the specifier was produced by the HTML
             // scanner's top_level_dir join (e.g., "/virtual/foo.tsx" -> "<CWD>/virtual/foo.tsx").
-            // If so, try looking up the original path with "/" prefix.
-            if (specifier.len > 0 and (specifier[0] == '/' or
-                (specifier.len >= 3 and specifier[1] == ':' and (specifier[2] == '/' or specifier[2] == '\\'))))
-            {
+            // If so, try stripping the top_level_dir prefix and looking up the original path.
+            if (specifier.len > 0 and isAbsolutePath(specifier)) {
                 const top_level_dir = Fs.FileSystem.instance.top_level_dir;
                 if (top_level_dir.len > 0 and bun.strings.hasPrefix(specifier, top_level_dir)) {
-                    const remainder = specifier[top_level_dir.len..];
-                    // The remainder may already start with '/' (e.g. top_level_dir="/workspace/bun"
-                    // and specifier="/workspace/bun/virtual/foo.tsx" gives remainder="/virtual/foo.tsx").
-                    // If not, prepend '/' to form the original absolute path.
-                    if (remainder.len > 0 and remainder[0] == '/') {
-                        if (self.map.getKey(remainder)) |key| {
-                            return _resolver.Result{
-                                .path_pair = .{
-                                    .primary = Fs.Path.initWithNamespace(key, "file"),
-                                },
-                                .module_type = .unknown,
-                            };
+                    const after_prefix = specifier[top_level_dir.len..];
+                    if (after_prefix.len == 0) {
+                        // specifier == top_level_dir exactly, nothing to look up
+                    } else if (after_prefix[0] == '/' or after_prefix[0] == '\\') {
+                        // top_level_dir ended without separator, remainder starts with one.
+                        // e.g. top_level_dir="/workspace/bun", specifier="/workspace/bun/virtual/foo.tsx"
+                        //   -> after_prefix="/virtual/foo.tsx" (already a valid absolute path)
+                        if (self.map.getKey(after_prefix)) |key| {
+                            return makeResult(key);
                         }
-                    } else {
+                    } else if (top_level_dir[top_level_dir.len - 1] == '/' or
+                        top_level_dir[top_level_dir.len - 1] == '\\')
+                    {
+                        // top_level_dir ended with separator (e.g. "/workspace/bun/"),
+                        // so after_prefix is "virtual/foo.tsx" — prepend "/" to reconstruct
+                        // the original absolute path "/virtual/foo.tsx".
                         const orig_buf = bun.path_buffer_pool.get();
                         defer bun.path_buffer_pool.put(orig_buf);
                         orig_buf[0] = '/';
-                        @memcpy(orig_buf[1..][0..remainder.len], remainder);
-                        const original_path = orig_buf[0 .. remainder.len + 1];
+                        @memcpy(orig_buf[1..][0..after_prefix.len], after_prefix);
+                        const original_path = orig_buf[0 .. after_prefix.len + 1];
 
                         if (self.map.getKey(original_path)) |key| {
-                            return _resolver.Result{
-                                .path_pair = .{
-                                    .primary = Fs.Path.initWithNamespace(key, "file"),
-                                },
-                                .module_type = .unknown,
-                            };
+                            return makeResult(key);
                         }
                     }
+                    // else: partial segment match (e.g. "/work" matched "/workspace/..."),
+                    // not a valid top_level_dir prefix — skip this fallback.
                 }
             }
 
@@ -173,12 +160,7 @@ pub const JSBundler = struct {
                 const joined = buf[0..joined_len];
                 // Must use getKey to return the map's owned key, not the temporary buffer
                 if (self.map.getKey(joined)) |key| {
-                    return _resolver.Result{
-                        .path_pair = .{
-                            .primary = Fs.Path.initWithNamespace(key, "file"),
-                        },
-                        .module_type = .unknown,
-                    };
+                    return makeResult(key);
                 }
             }
 
@@ -200,6 +182,15 @@ pub const JSBundler = struct {
             // Windows UNC path (e.g., "\\server\share")
             if (path.len >= 2 and path[0] == '\\' and path[1] == '\\') return true;
             return false;
+        }
+
+        fn makeResult(key: []const u8) _resolver.Result {
+            return _resolver.Result{
+                .path_pair = .{
+                    .primary = Fs.Path.initWithNamespace(key, "file"),
+                },
+                .module_type = .unknown,
+            };
         }
 
         /// Parse the files option from JavaScript.

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -88,6 +88,46 @@ pub const JSBundler = struct {
                 }
             }
 
+            // For absolute specifiers, check if the specifier was produced by the HTML
+            // scanner's top_level_dir join (e.g., "/virtual/foo.tsx" -> "<CWD>/virtual/foo.tsx").
+            // If so, try looking up the original path with "/" prefix.
+            if (specifier.len > 0 and (specifier[0] == '/' or
+                (specifier.len >= 3 and specifier[1] == ':' and (specifier[2] == '/' or specifier[2] == '\\'))))
+            {
+                const top_level_dir = Fs.FileSystem.instance.top_level_dir;
+                if (top_level_dir.len > 0 and bun.strings.hasPrefix(specifier, top_level_dir)) {
+                    const remainder = specifier[top_level_dir.len..];
+                    // The remainder may already start with '/' (e.g. top_level_dir="/workspace/bun"
+                    // and specifier="/workspace/bun/virtual/foo.tsx" gives remainder="/virtual/foo.tsx").
+                    // If not, prepend '/' to form the original absolute path.
+                    if (remainder.len > 0 and remainder[0] == '/') {
+                        if (self.map.getKey(remainder)) |key| {
+                            return _resolver.Result{
+                                .path_pair = .{
+                                    .primary = Fs.Path.initWithNamespace(key, "file"),
+                                },
+                                .module_type = .unknown,
+                            };
+                        }
+                    } else {
+                        const orig_buf = bun.path_buffer_pool.get();
+                        defer bun.path_buffer_pool.put(orig_buf);
+                        orig_buf[0] = '/';
+                        @memcpy(orig_buf[1..][0..remainder.len], remainder);
+                        const original_path = orig_buf[0 .. remainder.len + 1];
+
+                        if (self.map.getKey(original_path)) |key| {
+                            return _resolver.Result{
+                                .path_pair = .{
+                                    .primary = Fs.Path.initWithNamespace(key, "file"),
+                                },
+                                .module_type = .unknown,
+                            };
+                        }
+                    }
+                }
+            }
+
             // Also try with source directory joined for relative specifiers
             // Check for relative specifiers (not starting with / and not Windows absolute like C:/)
             if (specifier.len > 0 and specifier[0] != '/' and

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -81,37 +81,48 @@ pub const JSBundler = struct {
             // For absolute specifiers, check if the specifier was produced by the HTML
             // scanner's top_level_dir join (e.g., "/virtual/foo.tsx" -> "<CWD>/virtual/foo.tsx").
             // If so, try stripping the top_level_dir prefix and looking up the original path.
+            //
+            // On Windows, both the specifier and top_level_dir may use backslashes, so we
+            // normalize both to posix before prefix-matching and map lookup.
             if (specifier.len > 0 and isAbsolutePath(specifier)) {
                 const top_level_dir = Fs.FileSystem.instance.top_level_dir;
-                if (top_level_dir.len > 0 and bun.strings.hasPrefix(specifier, top_level_dir)) {
-                    const after_prefix = specifier[top_level_dir.len..];
-                    if (after_prefix.len == 0) {
-                        // specifier == top_level_dir exactly, nothing to look up
-                    } else if (after_prefix[0] == '/' or after_prefix[0] == '\\') {
-                        // top_level_dir ended without separator, remainder starts with one.
-                        // e.g. top_level_dir="/workspace/bun", specifier="/workspace/bun/virtual/foo.tsx"
-                        //   -> after_prefix="/virtual/foo.tsx" (already a valid absolute path)
-                        if (self.map.getKey(after_prefix)) |key| {
-                            return makeResult(key);
-                        }
-                    } else if (top_level_dir[top_level_dir.len - 1] == '/' or
-                        top_level_dir[top_level_dir.len - 1] == '\\')
-                    {
-                        // top_level_dir ended with separator (e.g. "/workspace/bun/"),
-                        // so after_prefix is "virtual/foo.tsx" — prepend "/" to reconstruct
-                        // the original absolute path "/virtual/foo.tsx".
-                        const orig_buf = bun.path_buffer_pool.get();
-                        defer bun.path_buffer_pool.put(orig_buf);
-                        orig_buf[0] = '/';
-                        @memcpy(orig_buf[1..][0..after_prefix.len], after_prefix);
-                        const original_path = orig_buf[0 .. after_prefix.len + 1];
+                if (top_level_dir.len > 0) {
+                    // Normalize both specifier and top_level_dir to posix for consistent matching.
+                    const norm_spec_buf = bun.path_buffer_pool.get();
+                    defer bun.path_buffer_pool.put(norm_spec_buf);
+                    const norm_tld_buf = bun.path_buffer_pool.get();
+                    defer bun.path_buffer_pool.put(norm_tld_buf);
+                    const norm_specifier = bun.path.pathToPosixBuf(u8, specifier, norm_spec_buf);
+                    const norm_top_level_dir = bun.path.pathToPosixBuf(u8, top_level_dir, norm_tld_buf);
 
-                        if (self.map.getKey(original_path)) |key| {
-                            return makeResult(key);
+                    if (bun.strings.hasPrefix(norm_specifier, norm_top_level_dir)) {
+                        const after_prefix = norm_specifier[norm_top_level_dir.len..];
+                        if (after_prefix.len == 0) {
+                            // specifier == top_level_dir exactly, nothing to look up
+                        } else if (after_prefix[0] == '/') {
+                            // top_level_dir ended without separator, remainder starts with one.
+                            // e.g. top_level_dir="/workspace/bun", specifier="/workspace/bun/virtual/foo.tsx"
+                            //   -> after_prefix="/virtual/foo.tsx" (already a valid absolute path)
+                            if (self.map.getKey(after_prefix)) |key| {
+                                return makeResult(key);
+                            }
+                        } else if (norm_top_level_dir[norm_top_level_dir.len - 1] == '/') {
+                            // top_level_dir ended with separator (e.g. "/workspace/bun/"),
+                            // so after_prefix is "virtual/foo.tsx" — prepend "/" to reconstruct
+                            // the original absolute path "/virtual/foo.tsx".
+                            const orig_buf = bun.path_buffer_pool.get();
+                            defer bun.path_buffer_pool.put(orig_buf);
+                            orig_buf[0] = '/';
+                            @memcpy(orig_buf[1..][0..after_prefix.len], after_prefix);
+                            const original_path = orig_buf[0 .. after_prefix.len + 1];
+
+                            if (self.map.getKey(original_path)) |key| {
+                                return makeResult(key);
+                            }
                         }
+                        // else: partial segment match (e.g. "/work" matched "/workspace/..."),
+                        // not a valid top_level_dir prefix — skip this fallback.
                     }
-                    // else: partial segment match (e.g. "/work" matched "/workspace/..."),
-                    // not a valid top_level_dir prefix — skip this fallback.
                 }
             }
 

--- a/test/regression/issue/27687.test.ts
+++ b/test/regression/issue/27687.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+
+describe("issue #27687 - virtual HTML entrypoint with absolute script src", () => {
+  test("resolves virtual script referenced via absolute path from virtual HTML", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/virtual/index.html"],
+      target: "browser",
+      format: "esm",
+      minify: false,
+      files: {
+        "/virtual/index.html": `
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/virtual/_hydrate.tsx"></script>
+</body>
+</html>`,
+        "/virtual/_hydrate.tsx": `console.log("Hydration entry loaded");`,
+      },
+    });
+
+    if (!result.success) {
+      console.error(result.logs);
+    }
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(2);
+
+    const htmlOutput = result.outputs.find(o => o.type?.startsWith("text/html"));
+    expect(htmlOutput).toBeDefined();
+
+    const jsOutput = result.outputs.find(o => o.type?.startsWith("text/javascript"));
+    expect(jsOutput).toBeDefined();
+
+    const jsContent = await jsOutput!.text();
+    expect(jsContent).toContain("Hydration entry loaded");
+  });
+
+  test("resolves virtual script with absolute path from different virtual directory", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/app/index.html"],
+      target: "browser",
+      format: "esm",
+      minify: false,
+      files: {
+        "/app/index.html": `
+<!DOCTYPE html>
+<html>
+<body>
+  <script type="module" src="/shared/utils.js"></script>
+</body>
+</html>`,
+        "/shared/utils.js": `export const msg = "cross-directory import works";
+console.log(msg);`,
+      },
+    });
+
+    if (!result.success) {
+      console.error(result.logs);
+    }
+
+    expect(result.success).toBe(true);
+
+    const jsOutput = result.outputs.find(o => o.type?.startsWith("text/javascript"));
+    expect(jsOutput).toBeDefined();
+
+    const jsContent = await jsOutput!.text();
+    expect(jsContent).toContain("cross-directory import works");
+  });
+
+  test("resolves virtual script with root-level absolute path from virtual HTML", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/index.html"],
+      target: "browser",
+      format: "esm",
+      minify: false,
+      files: {
+        "/index.html": `
+<!DOCTYPE html>
+<html>
+<body>
+  <script type="module" src="/app.js"></script>
+</body>
+</html>`,
+        "/app.js": `console.log("root level script");`,
+      },
+    });
+
+    if (!result.success) {
+      console.error(result.logs);
+    }
+
+    expect(result.success).toBe(true);
+
+    const jsOutput = result.outputs.find(o => o.type?.startsWith("text/javascript"));
+    expect(jsOutput).toBeDefined();
+
+    const jsContent = await jsOutput!.text();
+    expect(jsContent).toContain("root level script");
+  });
+});


### PR DESCRIPTION
## Summary

- Fix `Bun.build()` failing with "Could not resolve" when a virtual HTML entrypoint references other virtual files through absolute `<script src="/...">` paths
- The `HTMLScanner` rewrites absolute paths by joining with `top_level_dir` (CWD), causing `FileMap` lookups to fail since map keys use the original paths
- Add a fallback in `FileMap.resolve` that strips the `top_level_dir` prefix and retries with the original path

Closes #27687

## Test plan

- [x] Added regression test `test/regression/issue/27687.test.ts` with 3 test cases:
  - Virtual HTML with absolute `<script src="/virtual/_hydrate.tsx">`
  - Cross-directory absolute references (`/shared/utils.js` from `/app/index.html`)
  - Root-level absolute references (`/app.js` from `/index.html`)
- [x] Verified test fails with system Bun (v1.3.10) and passes with debug build
- [x] All 23 existing `bundler_files.test.ts` tests pass
- [x] All 21 existing `bundler_html.test.ts` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)