### PR TITLE
fix(MessagePort): emit "close" event on both ports when one side is closed

### DIFF
--- a/src/bun.js/bindings/webcore/JSMessagePort.cpp
+++ b/src/bun.js/bindings/webcore/JSMessagePort.cpp
@@ -73,6 +73,8 @@ static JSC_DECLARE_CUSTOM_GETTER(jsMessagePort_onmessage);
 static JSC_DECLARE_CUSTOM_SETTER(setJSMessagePort_onmessage);
 static JSC_DECLARE_CUSTOM_GETTER(jsMessagePort_onmessageerror);
 static JSC_DECLARE_CUSTOM_SETTER(setJSMessagePort_onmessageerror);
+static JSC_DECLARE_CUSTOM_GETTER(jsMessagePort_onclose);
+static JSC_DECLARE_CUSTOM_SETTER(setJSMessagePort_onclose);
 
 class JSMessagePortPrototype final : public JSC::JSNonFinalObject {
 public:
@@ -130,6 +132,7 @@ static const HashTableValue JSMessagePortPrototypeTableValues[] = {
     { "constructor"_s, static_cast<unsigned>(PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsMessagePortConstructor, 0 } },
     { "onmessage"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsMessagePort_onmessage, setJSMessagePort_onmessage } },
     { "onmessageerror"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsMessagePort_onmessageerror, setJSMessagePort_onmessageerror } },
+    { "onclose"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsMessagePort_onclose, setJSMessagePort_onclose } },
     { "postMessage"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMessagePortPrototypeFunction_postMessage, 1 } },
     { "start"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMessagePortPrototypeFunction_start, 0 } },
     { "close"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMessagePortPrototypeFunction_close, 0 } },
@@ -241,6 +244,33 @@ JSC_DEFINE_CUSTOM_SETTER(setJSMessagePort_onmessageerror, (JSGlobalObject * lexi
     return IDLAttribute<JSMessagePort>::set<setJSMessagePort_onmessageerrorSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
 
+static inline JSValue jsMessagePort_oncloseGetter(JSGlobalObject& lexicalGlobalObject, JSMessagePort& thisObject)
+{
+    UNUSED_PARAM(lexicalGlobalObject);
+    return eventHandlerAttribute(thisObject.wrapped(), eventNames().closeEvent, worldForDOMObject(thisObject));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsMessagePort_onclose, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSMessagePort>::get<jsMessagePort_oncloseGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSMessagePort_oncloseSetter(JSGlobalObject& lexicalGlobalObject, JSMessagePort& thisObject, JSValue value)
+{
+    auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    setEventHandlerAttribute<JSEventListener>(thisObject.wrapped(), eventNames().closeEvent, value, thisObject);
+    vm.writeBarrier(&thisObject, value);
+    ensureStillAliveHere(value);
+
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSMessagePort_onclose, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSMessagePort>::set<setJSMessagePort_oncloseSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
 static inline JSC::EncodedJSValue jsMessagePortPrototypeFunction_postMessage1Body(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSMessagePort>::ClassParameter castedThis)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
@@ -329,7 +359,7 @@ static inline JSC::EncodedJSValue jsMessagePortPrototypeFunction_closeBody(JSC::
     UNUSED_PARAM(callFrame);
     auto& impl = castedThis->wrapped();
     impl.jsUnref(lexicalGlobalObject);
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.close(); })));
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.closeWithEvent(); })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsMessagePortPrototypeFunction_close, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/bun.js/bindings/webcore/MessagePort.cpp
+++ b/src/bun.js/bindings/webcore/MessagePort.cpp
@@ -101,6 +101,28 @@ void MessagePort::notifyMessageAvailable(const MessagePortIdentifier& identifier
     });
 }
 
+void MessagePort::notifyRemotePortClosed(const MessagePortIdentifier& identifier)
+{
+    std::optional<ScriptExecutionContextIdentifier> scriptExecutionContextIdentifier;
+    ThreadSafeWeakPtr<MessagePort> weakPort;
+    {
+        Locker locker { allMessagePortsLock };
+        scriptExecutionContextIdentifier = portToContextIdentifier().getOptional(identifier);
+        weakPort = allMessagePorts().get(identifier);
+    }
+    if (!scriptExecutionContextIdentifier)
+        return;
+
+    ScriptExecutionContext::ensureOnContextThread(*scriptExecutionContextIdentifier, [weakPort = WTF::move(weakPort)](auto&) {
+        RefPtr port = weakPort.get();
+        if (!port)
+            return;
+        port->m_entangled = false;
+        auto event = Event::create(eventNames().closeEvent, Event::CanBubble::No, Event::IsCancelable::No);
+        port->dispatchEvent(event);
+    });
+}
+
 Ref<MessagePort> MessagePort::create(ScriptExecutionContext& scriptExecutionContext, const MessagePortIdentifier& local, const MessagePortIdentifier& remote)
 {
     auto messagePort = adoptRef(*new MessagePort(scriptExecutionContext, local, remote));
@@ -130,15 +152,16 @@ MessagePort::MessagePort(ScriptExecutionContext& scriptExecutionContext, const M
 
 MessagePort::~MessagePort()
 {
+    {
+        Locker locker { allMessagePortsLock };
 
-    Locker locker { allMessagePortsLock };
-
-    auto iterator = allMessagePorts().find(m_identifier);
-    if (iterator != allMessagePorts().end()) {
-        // ThreadSafeWeakPtr::get() returns null as soon as the object has started destruction.
-        if (RefPtr messagePort = iterator->value.get(); !messagePort) {
-            allMessagePorts().remove(iterator);
-            portToContextIdentifier().remove(m_identifier);
+        auto iterator = allMessagePorts().find(m_identifier);
+        if (iterator != allMessagePorts().end()) {
+            // ThreadSafeWeakPtr::get() returns null as soon as the object has started destruction.
+            if (RefPtr messagePort = iterator->value.get(); !messagePort) {
+                allMessagePorts().remove(iterator);
+                portToContextIdentifier().remove(m_identifier);
+            }
         }
     }
 
@@ -238,6 +261,28 @@ void MessagePort::close()
         return;
     m_isDetached = true;
 
+    MessagePortChannelProvider::singleton().messagePortClosed(m_identifier);
+
+    removeAllEventListeners();
+}
+
+void MessagePort::closeWithEvent()
+{
+    if (m_isDetached)
+        return;
+    m_isDetached = true;
+
+    // Dispatch the close event on this (closing) port before notifying the remote.
+    // This ensures the closing port's close event fires first, matching Node.js behavior.
+    // We use EventTarget::dispatchEvent directly because our override blocks
+    // dispatching when m_isDetached is true, but the close event is the one
+    // exception that must fire even on the port being closed.
+    if (scriptExecutionContext()) {
+        auto event = Event::create(eventNames().closeEvent, Event::CanBubble::No, Event::IsCancelable::No);
+        EventTarget::dispatchEvent(event);
+    }
+
+    // Notify the channel (and the remote port) after dispatching the local close event.
     MessagePortChannelProvider::singleton().messagePortClosed(m_identifier);
 
     removeAllEventListeners();
@@ -385,34 +430,42 @@ void MessagePort::contextDestroyed()
 
 void MessagePort::onDidChangeListenerImpl(EventTarget& self, const AtomString& eventType, OnDidChangeListenerKind kind)
 {
-    if (eventType == eventNames().messageEvent) {
-        auto& port = static_cast<MessagePort&>(self);
-        switch (kind) {
-        case Add:
-            if (port.m_messageEventCount == 0) {
-                auto* context = port.scriptExecutionContext();
-                if (context)
-                    context->refEventLoop();
-            }
-            port.m_messageEventCount++;
-            break;
-        case Remove:
-            port.m_messageEventCount--;
-            if (port.m_messageEventCount == 0) {
-                auto* context = port.scriptExecutionContext();
-                if (context)
-                    context->unrefEventLoop();
-            }
-            break;
-        case Clear:
-            if (port.m_messageEventCount > 0) {
-                auto* context = port.scriptExecutionContext();
-                if (context)
-                    context->unrefEventLoop();
-            }
-            port.m_messageEventCount = 0;
-            break;
+    auto& port = static_cast<MessagePort&>(self);
+
+    uint32_t* counter = nullptr;
+    if (eventType == eventNames().messageEvent)
+        counter = &port.m_messageEventCount;
+    else if (eventType == eventNames().closeEvent)
+        counter = &port.m_closeEventCount;
+
+    if (!counter)
+        return;
+
+    switch (kind) {
+    case Add:
+        if (*counter == 0) {
+            auto* context = port.scriptExecutionContext();
+            if (context)
+                context->refEventLoop();
         }
+        (*counter)++;
+        break;
+    case Remove:
+        (*counter)--;
+        if (*counter == 0) {
+            auto* context = port.scriptExecutionContext();
+            if (context)
+                context->unrefEventLoop();
+        }
+        break;
+    case Clear:
+        if (*counter > 0) {
+            auto* context = port.scriptExecutionContext();
+            if (context)
+                context->unrefEventLoop();
+        }
+        *counter = 0;
+        break;
     }
 };
 

--- a/src/bun.js/bindings/webcore/MessagePort.h
+++ b/src/bun.js/bindings/webcore/MessagePort.h
@@ -61,6 +61,7 @@ public:
 
     void start();
     void close();
+    void closeWithEvent();
     void entangle();
 
     // Returns nullptr if the passed-in vector is empty.
@@ -69,6 +70,7 @@ public:
 
     WEBCORE_EXPORT static bool isMessagePortAliveForTesting(const MessagePortIdentifier&);
     WEBCORE_EXPORT static void notifyMessageAvailable(const MessagePortIdentifier&);
+    WEBCORE_EXPORT static void notifyRemotePortClosed(const MessagePortIdentifier&);
 
     WEBCORE_EXPORT void messageAvailable();
     bool started() const { return m_started; }
@@ -148,6 +150,7 @@ private:
     bool m_hasRef { false };
 
     uint32_t m_messageEventCount { 0 };
+    uint32_t m_closeEventCount { 0 };
     static void onDidChangeListenerImpl(EventTarget& self, const AtomString& eventType, OnDidChangeListenerKind kind);
 };
 

--- a/src/bun.js/bindings/webcore/MessagePortChannel.cpp
+++ b/src/bun.js/bindings/webcore/MessagePortChannel.cpp
@@ -98,6 +98,13 @@ void MessagePortChannel::disentanglePort(const MessagePortIdentifier& port)
     auto protectedThis = WTF::move(m_entangledToProcessProtectors[i]);
 }
 
+bool MessagePortChannel::isPortClosed(const MessagePortIdentifier& port) const
+{
+    ASSERT(port == m_ports[0] || port == m_ports[1]);
+    size_t i = port == m_ports[0] ? 0 : 1;
+    return m_isClosed[i];
+}
+
 void MessagePortChannel::closePort(const MessagePortIdentifier& port)
 {
     ASSERT(port == m_ports[0] || port == m_ports[1]);

--- a/src/bun.js/bindings/webcore/MessagePortChannel.h
+++ b/src/bun.js/bindings/webcore/MessagePortChannel.h
@@ -52,6 +52,7 @@ public:
     void entanglePortWithProcess(const MessagePortIdentifier&, ProcessIdentifier);
     void disentanglePort(const MessagePortIdentifier&);
     void closePort(const MessagePortIdentifier&);
+    bool isPortClosed(const MessagePortIdentifier&) const;
     bool postMessageToRemote(MessageWithMessagePorts&&, const MessagePortIdentifier& remoteTarget);
 
     void takeAllMessagesForPort(const MessagePortIdentifier&, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&);

--- a/src/bun.js/bindings/webcore/MessagePortChannelRegistry.cpp
+++ b/src/bun.js/bindings/webcore/MessagePortChannelRegistry.cpp
@@ -29,6 +29,7 @@
 #include "MessagePortChannelRegistry.h"
 
 // #include "Logging.h"
+#include "MessagePort.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/MainThread.h>
 
@@ -116,10 +117,15 @@ void MessagePortChannelRegistry::didCloseMessagePort(const MessagePortIdentifier
     //     LOG(MessagePorts, "Registry: (Note) The channel closed for port %s had messages pending or in flight", port.logString().utf8().data());
 #endif
 
+    // Determine the remote port and whether it is already closed before we close this port.
+    auto remotePort = (channel->port1() == port) ? channel->port2() : channel->port1();
+    bool remoteAlreadyClosed = channel->isPortClosed(remotePort);
+
     channel->closePort(port);
 
-    // FIXME: When making message ports be multi-process, this should probably push a notification
-    // to the remaining port to tell it this port closed.
+    // Notify the remote port that this port was closed, so it can fire a "close" event.
+    if (!remoteAlreadyClosed)
+        MessagePort::notifyRemotePortClosed(remotePort);
 }
 
 bool MessagePortChannelRegistry::didPostMessageToRemote(MessageWithMessagePorts&& message, const MessagePortIdentifier& remoteTarget)

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -323,3 +323,95 @@ test("cloneable and non-transferable equals (net.BlockList)", async () => {
   mc.port2.postMessage(blocklist);
   await promise;
 });
+
+test("close event fires on the port that called close()", done => {
+  const { port1, port2 } = new MessageChannel();
+
+  port1.addEventListener("close", () => {
+    port2.close();
+    done();
+  });
+
+  port1.start();
+  port2.start();
+  port1.close();
+});
+
+test("close event fires on the remote port when the other side closes", done => {
+  const { port1, port2 } = new MessageChannel();
+
+  port2.addEventListener("close", () => {
+    done();
+  });
+
+  port1.start();
+  port2.start();
+  port1.close();
+});
+
+test("close event fires on both ports", async () => {
+  const { port1, port2 } = new MessageChannel();
+
+  const events: string[] = [];
+  const { promise, resolve } = Promise.withResolvers<void>();
+
+  port1.addEventListener("close", () => {
+    events.push("port1");
+    if (events.length === 2) resolve();
+  });
+
+  port2.addEventListener("close", () => {
+    events.push("port2");
+    if (events.length === 2) resolve();
+  });
+
+  port1.start();
+  port2.start();
+  port1.close();
+
+  await promise;
+
+  expect(events).toContain("port1");
+  expect(events).toContain("port2");
+});
+
+test("onclose property works", done => {
+  const { port1, port2 } = new MessageChannel();
+
+  expect(port1.onclose).toBeNull();
+
+  port1.onclose = () => {
+    port2.close();
+    done();
+  };
+
+  port1.start();
+  port2.start();
+  port1.close();
+});
+
+test("close event fires with addEventListener and onclose on remote port", async () => {
+  const { port1, port2 } = new MessageChannel();
+
+  const events: string[] = [];
+  const { promise, resolve } = Promise.withResolvers<void>();
+
+  port2.addEventListener("close", () => {
+    events.push("addEventListener");
+    if (events.length === 2) resolve();
+  });
+
+  port2.onclose = () => {
+    events.push("onclose");
+    if (events.length === 2) resolve();
+  };
+
+  port1.start();
+  port2.start();
+  port1.close();
+
+  await promise;
+
+  expect(events).toContain("addEventListener");
+  expect(events).toContain("onclose");
+});


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/oven-sh/bun/issues/19862

When `MessagePort.close()` is called, the `"close"` event should fire on both the closing port and
the remote (paired) port. Previously, Bun did not emit this event at all, there was even a FIXME
comment in `MessagePortChannelRegistry.cpp` acknowledging the gap.

### How did you verify your code works?
- Added 5 new tests to `test/js/web/workers/message-channel.test.ts`:
  - Close event fires on the port that called `close()`
  - Close event fires on the remote port when the other side closes
  - Close event fires on both ports
  - `onclose` property works
  - Close event fires with both `addEventListener` and `onclose` on remote port
- All 17 tests pass (12 existing + 5 new)