### PR TITLE
fix(bundler): barrel optimization drops exports used by dynamic import

### DIFF
--- a/src/bundler/barrel_imports.zig
+++ b/src/bundler/barrel_imports.zig
@@ -301,10 +301,9 @@ pub fn scheduleBarrelDeferredImports(this: *BundleV2, result: *ParseTask.Result.
     // Handle import records without named bindings (not in named_imports).
     // - `import "x"` (bare statement): tree-shakeable with sideEffects: false — skip.
     // - `require("x")`: synchronous, needs full module — always mark as .all.
-    // - `import("x")`: mark as .all ONLY if the barrel has no prior requests,
-    //   meaning this is the sole reference. If the barrel already has a .partial
-    //   entry from a static import, the dynamic import is likely a secondary
-    //   (possibly circular) reference and should not escalate requirements.
+    // - `import("x")`: returns the full module namespace at runtime — consumer
+    //   can destructure or access any export. Must mark as .all. We cannot
+    //   safely assume which exports will be used.
     for (file_import_records.slice(), 0..) |ir, idx| {
         const target = if (ir.source_index.isValid())
             ir.source_index.get()
@@ -319,10 +318,9 @@ pub fn scheduleBarrelDeferredImports(this: *BundleV2, result: *ParseTask.Result.
             const gop = try this.requested_exports.getOrPut(this.allocator(), target);
             gop.value_ptr.* = .all;
         } else if (ir.kind == .dynamic) {
-            // Only escalate to .all if no prior requests exist for this target.
-            if (!this.requested_exports.contains(target)) {
-                try this.requested_exports.put(this.allocator(), target, .all);
-            }
+            // import() returns the full module namespace — must preserve all exports.
+            const gop = try this.requested_exports.getOrPut(this.allocator(), target);
+            gop.value_ptr.* = .all;
         }
     }
 
@@ -354,8 +352,8 @@ pub fn scheduleBarrelDeferredImports(this: *BundleV2, result: *ParseTask.Result.
         }
     }
 
-    // Add bare require/dynamic-import targets to BFS as star imports (matching
-    // the seeding logic above — require always, dynamic only when sole reference).
+    // Add bare require/dynamic-import targets to BFS as star imports — both
+    // always need the full namespace.
     for (file_import_records.slice(), 0..) |ir, idx| {
         const target = if (ir.source_index.isValid())
             ir.source_index.get()
@@ -366,8 +364,7 @@ pub fn scheduleBarrelDeferredImports(this: *BundleV2, result: *ParseTask.Result.
         if (ir.flags.is_internal) continue;
         if (named_ir_indices.contains(@intCast(idx))) continue;
         if (ir.flags.was_originally_bare_import) continue;
-        const is_all = if (this.requested_exports.get(target)) |re| re == .all else false;
-        const should_add = ir.kind == .require or (ir.kind == .dynamic and is_all);
+        const should_add = ir.kind == .require or ir.kind == .dynamic;
         if (should_add) {
             try queue.append(queue_alloc, .{ .barrel_source_index = target, .alias = "", .is_star = true });
         }

--- a/test/bundler/bundler_barrel.test.ts
+++ b/test/bundler/bundler_barrel.test.ts
@@ -617,6 +617,50 @@ describe("bundler", () => {
     },
   });
 
+  // Same as above but static and dynamic importers are in separate files.
+  // This was parse-order dependent — if the static importer's
+  // scheduleBarrelDeferredImports ran first, it seeded .partial and the dynamic
+  // importer's escalation was skipped. Now import() always escalates to .all.
+  itBundled("barrel/DynamicImportWithStaticImportSeparateFiles", {
+    files: {
+      "/static-user.js": /* js */ `
+        import { a } from "barrel2";
+        console.log(a);
+      `,
+      "/dynamic-user.js": /* js */ `
+        const run = async () => {
+          const { b } = await import("barrel2");
+          console.log(b);
+        };
+        run();
+      `,
+      "/node_modules/barrel2/package.json": JSON.stringify({
+        name: "barrel2",
+        main: "./index.js",
+        sideEffects: false,
+      }),
+      "/node_modules/barrel2/index.js": /* js */ `
+        export { a } from "./a.js";
+        export { b } from "./b.js";
+      `,
+      "/node_modules/barrel2/a.js": /* js */ `
+        export const a = "A";
+      `,
+      "/node_modules/barrel2/b.js": /* js */ `
+        export const b = "B";
+      `,
+    },
+    entryPoints: ["/static-user.js", "/dynamic-user.js"],
+    splitting: true,
+    format: "esm",
+    target: "bun",
+    outdir: "/out",
+    run: [
+      { file: "/out/static-user.js", stdout: "A" },
+      { file: "/out/dynamic-user.js", stdout: "B" },
+    ],
+  });
+
   // --- Ported from Rolldown: multiple-entries ---
   // Multiple entry points that each import different things from barrels
 

--- a/test/bundler/bundler_barrel.test.ts
+++ b/test/bundler/bundler_barrel.test.ts
@@ -541,7 +541,9 @@ describe("bundler", () => {
   });
 
   // --- Ported from Rolldown: dynamic-import-entry ---
-  // A submodule dynamically imports the barrel back
+  // A submodule dynamically imports the barrel back. import() returns the full
+  // module namespace — all barrel exports must be preserved, even if the
+  // import() result is discarded (we can't statically prove it isn't used).
 
   itBundled("barrel/DynamicImportInSubmodule", {
     files: {
@@ -562,14 +564,56 @@ describe("bundler", () => {
         export const a = 'dyn-a';
         import('./index.js');
       `,
-      // b.js has a syntax error — only a is imported, so b should be skipped
       "/node_modules/dynlib/b.js": /* js */ `
-        export const b = <<<SYNTAX_ERROR>>>;
+        export const b = 'dyn-b';
       `,
     },
     outdir: "/out",
     onAfterBundle(api) {
       api.expectFile("/out/entry.js").toContain("dyn-a");
+      // b must be included — import() needs the full namespace
+      api.expectFile("/out/entry.js").toContain("dyn-b");
+    },
+  });
+
+  // Dynamic import returns the full namespace at runtime — consumer can access any export.
+  // When a file also has a static named import of the same barrel, the barrel
+  // optimization must not drop exports the dynamic import might use.
+  // Previously, the dynamic import was ignored if a static import already seeded
+  // requested_exports, producing invalid JS (export clause referencing undeclared symbol).
+  itBundled("barrel/DynamicImportWithStaticImportSameTarget", {
+    files: {
+      "/entry.js": /* js */ `
+        import { a } from "barrel";
+        console.log(a);
+        const run = async () => {
+          const { b } = await import("barrel");
+          console.log(b);
+        };
+        run();
+      `,
+      "/node_modules/barrel/package.json": JSON.stringify({
+        name: "barrel",
+        main: "./index.js",
+        sideEffects: false,
+      }),
+      "/node_modules/barrel/index.js": /* js */ `
+        export { a } from "./a.js";
+        export { b } from "./b.js";
+      `,
+      "/node_modules/barrel/a.js": /* js */ `
+        export const a = "A";
+      `,
+      "/node_modules/barrel/b.js": /* js */ `
+        export const b = "B";
+      `,
+    },
+    splitting: true,
+    format: "esm",
+    target: "bun",
+    outdir: "/out",
+    run: {
+      stdout: "A\nB",
     },
   });
 


### PR DESCRIPTION
## What does this PR do?

Fixes invalid JS output when a `sideEffects: false` barrel is used by both a **static named import** and a **dynamic `import()`** in the same build with `--splitting --format=esm`.

## Root Cause

`src/bundler/barrel_imports.zig` had a heuristic that skipped escalating `requested_exports` to `.all` for `import()` when the target already had a partial entry from a static import:

```zig
} else if (ir.kind == .dynamic) {
    // Only escalate to .all if no prior requests exist for this target.
    if (!this.requested_exports.contains(target)) {
        try this.requested_exports.put(this.allocator(), target, .all);
    }
}
```

This is unsafe — `await import()` returns the **full module namespace** at runtime. The consumer can destructure or access any export and we can't statically determine which ones.

## Failure chain

1. Static `import { a } from "barrel"` seeds `requested_exports[barrel] = .partial{"a"}`
2. Dynamic `import("barrel")` is ignored because `requested_exports.contains(barrel)` is true
3. Barrel optimization marks `export { b } from "./b.js"` as `is_unused` → `source_index` cleared
4. Code splitting makes the barrel a chunk entry point (dynamic import → own chunk)
5. Linker can't resolve the barrel's re-export symbol for `b` → uses the unbound re-export ref directly
6. Output: `export { b2 as b }` where `b2` has no declaration → **SyntaxError at runtime**

With `--bytecode --compile` this manifests as an `OutputFileListBuilder` assertion (`total_insertions != output_files.items.len`) because JSC rejects the chunk during bytecode generation, leaving an unfilled slot.

## Real-world trigger

`@smithy/credential-provider-imds` is a `sideEffects: false` barrel used by:
- `@aws-sdk/credential-providers` — static: `import { fromInstanceMetadata } from "@smithy/credential-provider-imds"`
- `@smithy/util-defaults-mode-node` — dynamic: `const { getInstanceMetadataEndpoint, httpRequest } = await import("@smithy/credential-provider-imds")`

## Fix

Dynamic import **always** marks the target as `.all` in both Phase 1 seeding and Phase 2 BFS. This is the same treatment as `require()`.

## Tests

- **New:** `barrel/DynamicImportWithStaticImportSameTarget` — repros the bug with `--splitting`, verifies both exports work at runtime. Fails on system bun with `SyntaxError: Exported binding 'b' needs to refer to a top-level declared variable.`
- **Updated:** `barrel/DynamicImportInSubmodule` — was testing that a fire-and-forget `import()` doesn't force unused submodules to load. That optimization can't be safely applied, so the test now verifies the conservative (correct) behavior: all barrel exports are preserved.