### PR TITLE
fix(windows): fs.watch segfault when a failed watch is retried

### DIFF
--- a/src/bun.js/node/win_watcher.zig
+++ b/src/bun.js/node/win_watcher.zig
@@ -186,15 +186,9 @@ pub const PathWatcher = struct {
             .manager = manager,
         });
 
-        errdefer {
-            _ = manager.watchers.swapRemove(event_path);
-            this.manager = null;
-            this.deinit();
-        }
-
-        if (uv.uv_fs_event_init(manager.vm.uvLoop(), &this.handle).toError(.watch)) |err| {
-            return .{ .err = err };
-        }
+        // uv_fs_event_init on Windows unconditionally returns 0 (vendor/libuv/src/win/fs-event.c).
+        // bun.assert evaluates its argument before the inline early-return, so this runs in release too.
+        bun.assert(uv.uv_fs_event_init(manager.vm.uvLoop(), &this.handle) == .zero);
         this.handle.data = this;
 
         // UV_FS_EVENT_RECURSIVE only works for Windows and OSX
@@ -204,6 +198,12 @@ pub const PathWatcher = struct {
             event_path.ptr,
             if (recursive) uv.UV_FS_EVENT_RECURSIVE else 0,
         ).toError(.watch)) |err| {
+            // `errdefer` doesn't fire on `return .{ .err = ... }` (that's a successful return of a
+            // Maybe(T), not an error-union return). Clean up the map entry and the half-initialized
+            // watcher inline. See #26254.
+            _ = manager.watchers.swapRemove(event_path);
+            this.manager = null; // prevent deinit() from re-entering unregisterWatcher
+            this.deinit();
             return .{ .err = err };
         }
         // we handle this in node_fs_watcher

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -1,5 +1,5 @@
 import { pathToFileURL } from "bun";
-import { bunRun, bunRunAsScript, isWindows, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, bunRun, bunRunAsScript, isWindows, tempDir, tempDirWithFiles } from "harness";
 import fs, { FSWatcher } from "node:fs";
 import path from "path";
 
@@ -724,4 +724,65 @@ describe("immediately closing", () => {
     for (let i = 0; i < 100; i++) fs.watch(testDir, { persistent: true, recursive: true }).close();
     for (let i = 0; i < 100; i++) fs.watch(testDir, { persistent: false, recursive: false }).close();
   });
+});
+
+// On Windows, if fs.watch() fails after getOrPut() inserts into the internal path->watcher
+// map (e.g. uv_fs_event_start fails on a dangling junction, an ACL-protected dir, or a
+// directory deleted mid-watch), an errdefer that was silently broken by a !*T -> Maybe(*T)
+// refactor left the entry in place with a dangling key and an uninitialized value. The next
+// fs.watch() on the same path collided with the poisoned entry, returned the garbage value
+// as a *PathWatcher, and segfaulted at 0xFFFFFFFFFFFFFFFF calling .handlers.put() on it.
+//
+// https://github.com/oven-sh/bun/issues/26254
+// https://github.com/oven-sh/bun/issues/20203
+// https://github.com/oven-sh/bun/issues/19635
+//
+// Must run in a subprocess: on an unpatched build this segfaults the whole runtime.
+test.skipIf(!isWindows)("retrying a failed fs.watch does not crash (windows)", async () => {
+  using dir = tempDir("fswatch-retry-failed", { "index.js": "" });
+  const base = String(dir);
+
+  const fixture = /* js */ `
+    const { mkdirSync, rmdirSync, symlinkSync, watch } = require("node:fs");
+    const { join } = require("node:path");
+
+    const base   = ${JSON.stringify(base)};
+    const target = join(base, "target");
+    const link   = join(base, "link");
+
+    mkdirSync(target);
+    symlinkSync(target, link, "junction"); // junctions need no admin rights on Windows
+    rmdirSync(target);                     // junction now dangles
+
+    // Call 1: readlink(link) SUCCEEDS (returns the vanished target path into
+    // a stack-local buffer), then uv_fs_event_start(target) fails ENOENT.
+    // On unpatched builds: map entry left with dangling key + uninit value.
+    try { watch(link); throw new Error("expected first watch to fail"); }
+    catch (e) { if (e.code !== "ENOENT") throw e; }
+
+    // Call 2: identical stack frame layout -> identical outbuf address ->
+    // identical key slice -> getOrPut returns found_existing=true ->
+    // returns uninitialized value as a *PathWatcher -> segfault on unpatched builds.
+    // Correct behaviour: throw ENOENT again.
+    try { watch(link); throw new Error("expected second watch to fail"); }
+    catch (e) { if (e.code !== "ENOENT") throw e; }
+
+    // Call 3: a valid watch must still work (map must not be corrupted).
+    watch(base).close();
+
+    console.log("OK");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    cwd: base,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0); // unpatched: exitCode is 3 (Windows segfault)
 });


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows-only segfault at `0xFFFFFFFFFFFFFFFF` in `fs.watch()` that fires when a failed watch is retried on the same path. This is why every report involves a file-watching library (Vite, NestJS CLI, chokidar, watchpack) — their standard error-recovery is "catch → retry same path", which is the exact detonation sequence.

Fixes #26254
Fixes #20203
Fixes #19635

## Root cause

`PathWatcher.init()` uses an `errdefer` to clean up the `manager.watchers` map entry on failure. That `errdefer` became dead code when the function's return type was refactored from `!*PathWatcher` → `Maybe(*PathWatcher)`: `return .{ .err = ... }` is a *successful* return of a tagged union, not an error-union return, so `errdefer` never fires.

When `uv_fs_event_start` fails (dangling junction, ACL-denied dir, TOCTOU delete, AV lock, SMB share without `ReadDirectoryChangesW`), a map entry is left behind whose **key** points into a recycled stack/pool buffer and whose **value** was never written. The next `fs.watch()` on the same path collides with it, `getOrPut` returns `found_existing=true`, and we hand back garbage as a `*PathWatcher` → segfault in `.handlers.put()`.

### Why the second call detonates instead of just leaking

| `event_path` source | Why it's the same slice on retry |
|---|---|
| `path` (caller's buffer) | `FSWatcher.init` gets `joined_buf` from `bun.path_buffer_pool` (LIFO). After return it's released; the next `fs.watch` pops the same buffer and writes the same path to the same address. |
| `outbuf` (stack local) | `PathWatcher.init` is always called at the same stack depth from `fs.watch`. Same frame offset → same `&outbuf`. |

Same `ptr`, same `len` → `StringContext.eql` says equal → `getOrPut` hits the poisoned entry.

## Fix

Two changes in `src/bun.js/node/win_watcher.zig` inside `PathWatcher.init`:

1. **Replace the dead `errdefer` with inline cleanup** at the `uv_fs_event_start` failure return. Cleanup: remove the map entry, null out `manager` so `deinit()` doesn't re-enter `unregisterWatcher`, and call `deinit()` to `uv_close` the initialized handle.
2. **Remove the `uv_fs_event_init` error branch.** It unconditionally returns 0 on Windows (`vendor/libuv/src/win/fs-event.c:140-153`), and if that branch ever ran it would call `uv_close()` on a zeroed handle with a NULL loop pointer (crash inside libuv). Converted to `bun.assert`.

## How did you verify your code works?

Added a test in `test/js/node/watch/fs.watch.test.ts` that:
1. Creates a dangling junction (junctions need no admin rights on Windows)
2. Calls `fs.watch()` on it twice — first call poisons the map on unpatched builds, second call segfaults
3. Verifies a third watch on a valid dir still works (map not corrupted)

Runs in a subprocess since an unpatched build segfaults the whole runtime.

Windows-only test — CI will verify.

## Issues checked but excluded

| # | Why not this bug |
|---|---|
| [#19732](https://github.com/oven-sh/bun/issues/19732), [#20079](https://github.com/oven-sh/bun/issues/20079) | Caller frame is `resolver.zig resolveWithFramework` — bundler's module resolver map, not the watcher map |
| [#19651](https://github.com/oven-sh/bun/issues/19651) | Caller frame is `uws.zig onData` — HTTP server's map |
| [#20710](https://github.com/oven-sh/bun/issues/20710) | `node_fs_watcher.zig:248 run` — fires *after* a watcher successfully started and received an event; this bug crashes *before* start |
| [#24694](https://github.com/oven-sh/bun/issues/24694), [#24708](https://github.com/oven-sh/bun/issues/24708) | No `fs_watcher` in Features, `standalone_executable`; robobun dupe-linked these by text similarity only |
| [#26153](https://github.com/oven-sh/bun/issues/26153) | Already closed as duplicate of #26254 |