### PR TITLE
fix(css): dead errdefer leaks in Result(T)-returning parsers

### DIFF
--- a/src/css/declaration.zig
+++ b/src/css/declaration.zig
@@ -70,8 +70,6 @@ pub const DeclarationBlock = struct {
             .declarations = &declarations,
             .options = options,
         };
-        errdefer decl_parser.deinit();
-
         var parser = css.RuleBodyParser(PropertyDeclarationParser).new(input, &decl_parser);
 
         while (parser.next()) |res| {
@@ -80,6 +78,10 @@ pub const DeclarationBlock = struct {
                     options.warn(e);
                     continue;
                 }
+                // errdefer doesn't fire on `return .{ .err = ... }` — Result(T) is a tagged
+                // union, not an error union. Free any declarations accumulated so far.
+                css.deepDeinit(css.Property, input.allocator(), &declarations);
+                css.deepDeinit(css.Property, input.allocator(), &important_declarations);
                 return .{ .err = e };
             }
         }

--- a/src/css/properties/custom.zig
+++ b/src/css/properties/custom.zig
@@ -951,19 +951,23 @@ pub const UnresolvedColor = union(enum) {
                 options: *const css.ParserOptions,
                 parser: *ComponentParser,
                 pub fn parsefn(this: *@This(), input2: *css.Parser) Result(UnresolvedColor) {
-                    const light = switch (input2.parseUntilBefore(css.Delimiters{ .comma = true }, TokenList, this, @This().parsefn2)) {
+                    // errdefer doesn't fire on `return .{ .err = ... }` — Result(T) is a
+                    // tagged union, not an error union. Clean up `light` inline.
+                    var light = switch (input2.parseUntilBefore(css.Delimiters{ .comma = true }, TokenList, this, @This().parsefn2)) {
                         .result => |vv| vv,
                         .err => |e| return .{ .err = e },
                     };
-                    // TODO: fix this
-                    errdefer light.deinit();
-                    if (input2.expectComma().asErr()) |e| return .{ .err = e };
+                    if (input2.expectComma().asErr()) |e| {
+                        light.deinit(input2.allocator());
+                        return .{ .err = e };
+                    }
                     const dark = switch (TokenListFns.parse(input2, this.options, 0)) {
                         .result => |vv| vv,
-                        .err => |e| return .{ .err = e },
+                        .err => |e| {
+                            light.deinit(input2.allocator());
+                            return .{ .err = e };
+                        },
                     };
-                    // TODO: fix this
-                    errdefer dark.deinit();
                     return .{ .result = UnresolvedColor{
                         .light_dark = .{
                             .light = light,


### PR DESCRIPTION
## What does this PR do?

Found during a sweep for the bug pattern that caused #26254 (the Windows `fs.watch` segfault, fixed in #27705).

`Result(T)` is `Maybe(T, ParseError)` — a **tagged union**. `return .{ .err = ... }` is a *successful* return, so `errdefer` never fires.

Both dead `errdefer`s in this PR also referenced **code that wouldn't compile if live** — Zig's lazy analysis never checked them because they were in dead positions:
- `decl_parser.deinit()` — method doesn't exist
- `light.deinit()` — needs a mutable receiver + an allocator argument; was called on a `const` with zero args

[Zig lang proposal #2654](https://github.com/ziglang/zig/issues/2654) (accepted since 2020, unimplemented) would have caught both at compile time.

### `src/css/declaration.zig` — `DeclarationBlock.parse`

Leaks all declarations accumulated so far when one fails to parse and `error_recovery` is off.

Fixed with inline `css.deepDeinit` (same cleanup `context.zig:19-20` uses for these exact lists).

### `src/css/properties/custom.zig` — `light-dark()` parsing

Leaks the `light` TokenList when the comma or `dark` fails to parse. The second `errdefer (dark.deinit)` was both dead and unreachable — nothing fallible follows it — so it's simply removed. These already had `// TODO: fix this` comments.

Fixed with inline `light.deinit(input2.allocator())` at both failure returns.

## How did you verify your code works?

CI will verify compile. Both codepaths are CSS parser error paths — previously they compiled only because Zig doesn't analyze dead `errdefer` bodies; now they compile because they're correct.

## Detection pattern

All `errdefer` instances in functions that also do `return .{ .err = ... }`:

```bash
for f in $(rg -l 'errdefer' src --type zig); do
  awk -v file="$f" '
    /^[[:space:]]*(pub )?(inline )?fn / {
      if (has_errdefer && has_err_return) print file ":" fn_line ": " fn_sig
      fn_line = NR; fn_sig = $0; has_errdefer = 0; has_err_return = 0
    }
    /errdefer/ { has_errdefer = 1 }
    /return[[:space:]]+\.\{[[:space:]]*\.err[[:space:]]*=/ { has_err_return = 1 }
    END { if (has_errdefer && has_err_return) print file ":" fn_line ": " fn_sig }
  ' "$f"
done
```

Results at time of sweep:
- `win_watcher.zig:163` — fixed in #27705 (segfault)
- `css/declaration.zig:65` — this PR
- `css/properties/custom.zig:953` — this PR
- `process.zig spawnProcessPosix/Windows` — **false positives**: return type is `!Maybe(T)` (hybrid); `errdefer` fires on the `try` paths, and `.err` paths use a manual `failed` flag + `defer` for cleanup