### PR TITLE
fix(js): accept non-ErrorInstance objects in Error.prepareStackTrace

### DIFF
--- a/src/bun.js/bindings/FormatStackTraceForJS.cpp
+++ b/src/bun.js/bindings/FormatStackTraceForJS.cpp
@@ -609,10 +609,14 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionDefaultErrorPrepareStackTrace, (JSGlobalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
 
-    auto errorObject = jsDynamicCast<JSC::ErrorInstance*>(callFrame->argument(0));
+    // V8 accepts any object as the first argument, not just ErrorInstance.
+    // Libraries like @babel/core wrap Error.prepareStackTrace and delegate to the
+    // original, which can be called with non-ErrorInstance objects (e.g. from
+    // Error.captureStackTrace on a custom error class). See #27708.
+    JSC::JSObject* errorObject = callFrame->argument(0).getObject();
     auto callSites = jsDynamicCast<JSC::JSArray*>(callFrame->argument(1));
     if (!errorObject) {
-        throwTypeError(lexicalGlobalObject, scope, "First argument must be an Error object"_s);
+        throwTypeError(lexicalGlobalObject, scope, "First argument must be an object"_s);
         return {};
     }
     if (!callSites) {

--- a/test/regression/issue/27708.test.ts
+++ b/test/regression/issue/27708.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test";
+
+// Regression test for https://github.com/oven-sh/bun/issues/27708
+// Error.prepareStackTrace should accept non-ErrorInstance objects as first argument,
+// matching V8/Node.js behavior. Previously, Bun threw TypeError when the first
+// argument wasn't a JSC ErrorInstance, which caused hangs when libraries like
+// @babel/core wrapped Error.prepareStackTrace and delegated to the original.
+
+test("Error.prepareStackTrace accepts non-ErrorInstance objects", () => {
+  const orig = Error.prepareStackTrace;
+  try {
+    Error.prepareStackTrace = function (err, trace) {
+      return orig!(err, trace);
+    };
+
+    function CustomError(this: any, msg: string) {
+      this.message = msg;
+      Error.captureStackTrace(this, CustomError);
+    }
+    CustomError.prototype = Object.create(Error.prototype);
+    CustomError.prototype.constructor = CustomError;
+
+    // This should NOT throw - previously threw "First argument must be an Error object"
+    const err = new (CustomError as any)("test");
+    expect(err.stack).toBeString();
+    expect(err.stack).toContain("test");
+  } finally {
+    Error.prepareStackTrace = orig;
+  }
+});
+
+test("Error.prepareStackTrace works with class that extends Error prototype", () => {
+  const orig = Error.prepareStackTrace;
+  try {
+    Error.prepareStackTrace = function (err, trace) {
+      return orig!(err, trace);
+    };
+
+    // Simulate @xmldom/xmldom's ParseError pattern
+    function ParseError(this: any, message: string) {
+      this.message = message;
+      this.name = "ParseError";
+      Error.captureStackTrace(this, ParseError);
+    }
+    ParseError.prototype = Object.create(Error.prototype);
+
+    const err = new (ParseError as any)("unclosed xml tag");
+    expect(err.stack).toBeString();
+    expect(err.stack).toContain("unclosed xml tag");
+  } finally {
+    Error.prepareStackTrace = orig;
+  }
+});
+
+test("Error.prepareStackTrace still works normally with real Error instances", () => {
+  const orig = Error.prepareStackTrace;
+  try {
+    let callCount = 0;
+    Error.prepareStackTrace = function (err, trace) {
+      callCount++;
+      return orig!(err, trace);
+    };
+
+    const err = new Error("real error");
+    // Access stack to trigger prepareStackTrace
+    expect(err.stack).toBeString();
+    expect(err.stack).toContain("real error");
+    expect(callCount).toBe(1);
+  } finally {
+    Error.prepareStackTrace = orig;
+  }
+});


### PR DESCRIPTION
## Summary

- Fix `Error.prepareStackTrace` to accept any JS object as its first argument, matching V8/Node.js behavior
- Previously, Bun's default `Error.prepareStackTrace` threw `TypeError: First argument must be an Error object` when the first argument wasn't a JSC `ErrorInstance`
- This caused hangs when `@babel/core` (loaded by `@svgr/core`) wrapped `Error.prepareStackTrace` and delegated to the original, which was then called with non-ErrorInstance objects from `Error.captureStackTrace` on custom error classes like `@xmldom/xmldom`'s `ParseError`

### Root cause

In `jsFunctionDefaultErrorPrepareStackTrace`, `jsDynamicCast<JSC::ErrorInstance*>` was used to validate the first argument. When it failed, a TypeError was thrown. The downstream `formatStackTraceToJSValue` already accepted any `JSC::JSObject*`, so the fix simply uses `getObject()` instead of casting to `ErrorInstance*`.

### Interaction chain that caused the hang

1. `@svgr/core` → `@babel/core` wraps `Error.prepareStackTrace` with a delegating function
2. `@xmldom/xmldom` encounters invalid XML and creates `new ParseError()` which calls `Error.captureStackTrace(this, ParseError)` — `this` is NOT an `ErrorInstance`
3. Inside `captureStackTrace`, Bun detects the custom `prepareStackTrace` and calls it
4. The wrapper delegates to Bun's built-in which threw TypeError (**the bug**)
5. The unexpected TypeError propagates into xmldom's SAX parser error recovery, triggering an infinite loop

Closes #27708

## Test plan

- [x] Added regression test `test/regression/issue/27708.test.ts` covering:
  - Non-ErrorInstance objects with wrapped `Error.prepareStackTrace`
  - Simulated `@xmldom/xmldom` ParseError pattern
  - Normal `Error` instances still work correctly
- [x] Tests fail with system bun (pre-fix): `TypeError: First argument must be an Error object`
- [x] Tests pass with debug build (post-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)