### PR TITLE
fix(sql): don't treat URL pathname as Unix socket path

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -617,7 +617,14 @@ function parseOptions(
     username ||= options.user || options.username || decodeIfValid(url.username);
     password ||= options.pass || options.password || decodeIfValid(url.password);
 
-    path ||= options.path || url.pathname;
+    // Only use url.pathname as the Unix socket path for unix:// URLs.
+    // For postgres://, mysql://, etc., the pathname is the database name (e.g. "/mydb"),
+    // not a socket path. Using it as the socket path causes FailedToOpenSocket (#27713).
+    if (url.protocol === "unix:") {
+      path ||= options.path || url.pathname;
+    } else {
+      path ||= options.path;
+    }
 
     const queryObject = url.searchParams.toJSON();
     for (const key in queryObject) {

--- a/test/regression/issue/27713.test.ts
+++ b/test/regression/issue/27713.test.ts
@@ -32,22 +32,16 @@ describe("SQL should not treat URL pathname as Unix socket path (#27713)", () =>
   });
 
   afterAll(() => {
-    for (const key of Object.keys(process.env).concat(...Object.keys(Bun.env), ...Object.keys(import.meta.env))) {
-      delete process.env[key];
-      delete Bun.env[key];
-      delete import.meta.env[key];
-    }
-
-    for (const key in originalEnv) {
-      process.env[key] = originalEnv[key];
-      Bun.env[key] = originalEnv[key];
-      import.meta.env[key] = originalEnv[key];
-    }
-
     for (const key of SQL_ENV_VARS) {
-      delete process.env[key];
-      delete Bun.env[key];
-      delete import.meta.env[key];
+      if (key in originalEnv) {
+        process.env[key] = originalEnv[key]!;
+        Bun.env[key] = originalEnv[key]!;
+        import.meta.env[key] = originalEnv[key]!;
+      } else {
+        delete process.env[key];
+        delete Bun.env[key];
+        delete import.meta.env[key];
+      }
     }
   });
 
@@ -120,14 +114,15 @@ describe("SQL should not treat URL pathname as Unix socket path (#27713)", () =>
   });
 
   test.skipIf(isWindows)("unix:// protocol should still use pathname as socket path", () => {
+    const socketPath = `/tmp/bun-test-27713-${process.pid}.sock`;
     using sock = Bun.listen({
-      unix: "/tmp/bun-test-27713.sock",
+      unix: socketPath,
       socket: {
         data: () => {},
       },
     });
 
     const sql = new SQL(`unix://${sock.unix}`, { adapter: "postgres" });
-    expect(sql.options.path).toBe("/tmp/bun-test-27713.sock");
+    expect(sql.options.path).toBe(socketPath);
   });
 });

--- a/test/regression/issue/27713.test.ts
+++ b/test/regression/issue/27713.test.ts
@@ -1,0 +1,133 @@
+import { SQL } from "bun";
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { isWindows } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/27713
+// Bun SQL was treating the Postgres URL path component (the database name)
+// as a Unix domain socket path, causing FailedToOpenSocket on any URL with
+// a database name.
+
+describe("SQL should not treat URL pathname as Unix socket path (#27713)", () => {
+  const originalEnv = { ...process.env };
+
+  // prettier-ignore
+  const SQL_ENV_VARS = [
+    "DATABASE_URL", "DATABASEURL",
+    "TLS_DATABASE_URL",
+    "POSTGRES_URL", "PGURL", "PG_URL",
+    "TLS_POSTGRES_DATABASE_URL",
+    "MYSQL_URL", "MYSQLURL",
+    "TLS_MYSQL_DATABASE_URL",
+    "PGHOST", "PGUSER", "PGPASSWORD", "PGDATABASE", "PGPORT",
+    "PG_HOST", "PG_USER", "PG_PASSWORD", "PG_DATABASE", "PG_PORT",
+    "MYSQL_HOST", "MYSQL_USER", "MYSQL_PASSWORD", "MYSQL_DATABASE", "MYSQL_PORT",
+  ];
+
+  beforeEach(() => {
+    for (const key of SQL_ENV_VARS) {
+      delete process.env[key];
+      delete Bun.env[key];
+      delete import.meta.env[key];
+    }
+  });
+
+  afterAll(() => {
+    for (const key of Object.keys(process.env).concat(...Object.keys(Bun.env), ...Object.keys(import.meta.env))) {
+      delete process.env[key];
+      delete Bun.env[key];
+      delete import.meta.env[key];
+    }
+
+    for (const key in originalEnv) {
+      process.env[key] = originalEnv[key];
+      Bun.env[key] = originalEnv[key];
+      import.meta.env[key] = originalEnv[key];
+    }
+
+    for (const key of SQL_ENV_VARS) {
+      delete process.env[key];
+      delete Bun.env[key];
+      delete import.meta.env[key];
+    }
+  });
+
+  test("postgres URL with database name should not set path", () => {
+    const sql = new SQL("postgres://user:pass@myhost:5432/mydb");
+    expect(sql.options.hostname).toBe("myhost");
+    expect(sql.options.port).toBe(5432);
+    expect(sql.options.database).toBe("mydb");
+    // path must not be the database name "/mydb"
+    expect(sql.options.path).toBeUndefined();
+  });
+
+  test("postgres URL passed via url option should not set path", () => {
+    const sql = new SQL({
+      url: "postgres://user:pass@myhost:5432/mydb",
+    });
+    expect(sql.options.hostname).toBe("myhost");
+    expect(sql.options.port).toBe(5432);
+    expect(sql.options.database).toBe("mydb");
+    expect(sql.options.path).toBeUndefined();
+  });
+
+  test("DATABASE_URL with database name should not set path when using explicit options", () => {
+    process.env.DATABASE_URL = "postgres://user:pass@envhost:5432/envdb";
+
+    const sql = new SQL({
+      hostname: "myhost",
+      port: 5432,
+      username: "user",
+      password: "pass",
+      database: "mydb",
+    });
+
+    expect(sql.options.hostname).toBe("myhost");
+    expect(sql.options.database).toBe("mydb");
+    // path must not be "/envdb" from DATABASE_URL
+    expect(sql.options.path).toBeUndefined();
+  });
+
+  test("DATABASE_URL with database name should not set path when used implicitly", () => {
+    process.env.DATABASE_URL = "postgres://user:pass@envhost:5432/envdb";
+
+    const sql = new SQL();
+    expect(sql.options.hostname).toBe("envhost");
+    expect(sql.options.port).toBe(5432);
+    expect(sql.options.database).toBe("envdb");
+    // path must not be "/envdb"
+    expect(sql.options.path).toBeUndefined();
+  });
+
+  test("postgres URL with database name matching existing directory should not set path", () => {
+    // This is the actual bug: when the URL pathname matches an existing filesystem
+    // path (like /tmp), the old code would pass it as a Unix socket path.
+    // The database name in postgres://.../<dbname> is "/tmp" here, which exists.
+    const sql = new SQL("postgres://user:pass@myhost:5432/tmp");
+    expect(sql.options.hostname).toBe("myhost");
+    expect(sql.options.port).toBe(5432);
+    expect(sql.options.database).toBe("tmp");
+    // Before the fix, this would be "/tmp" (or "/tmp/.s.PGSQL.5432" if that exists),
+    // causing the connection to use Unix domain socket instead of TCP.
+    expect(sql.options.path).toBeUndefined();
+  });
+
+  test("mysql URL with database name should not set path", () => {
+    const sql = new SQL("mysql://user:pass@myhost:3306/mydb");
+    expect(sql.options.hostname).toBe("myhost");
+    expect(sql.options.port).toBe(3306);
+    expect(sql.options.database).toBe("mydb");
+    expect(sql.options.path).toBeUndefined();
+  });
+
+  test.skipIf(isWindows)("unix:// protocol should still use pathname as socket path", () => {
+    using sock = Bun.listen({
+      unix: "/tmp/bun-test-27713.sock",
+      socket: {
+        data: () => {},
+      },
+    });
+
+    const sql = new SQL(`unix://${sock.unix}`, { adapter: "postgres" });
+    expect(sql.options.path).toBe("/tmp/bun-test-27713.sock");
+  });
+});


### PR DESCRIPTION
## Summary
- Fix Bun SQL treating the URL path component (database name) as a Unix domain socket path, causing `FailedToOpenSocket` for any standard Postgres/MySQL connection URL
- Only use `url.pathname` as the socket path for `unix://` protocol URLs; for `postgres://`, `mysql://`, etc., the pathname is the database name, not a socket path

## Root cause

In `src/js/internal/sql/shared.ts`, the line:
```typescript
path ||= options.path || url.pathname;
```
was extracting `url.pathname` (e.g. `/mydb` from `postgres://user:pass@host:5432/mydb`) and setting it as the Unix socket path. The native Zig code sees a non-empty `path` and uses `connectUnixAnon()` instead of TCP, resulting in `FailedToOpenSocket` or `ECONNREFUSED` when the database name happens to match an existing filesystem path (common in Docker/Kubernetes environments).

## Fix

Only use `url.pathname` as the socket path when `url.protocol === "unix:"`. For all other protocols, the pathname is the database name.

## Test plan
- [x] New regression test `test/regression/issue/27713.test.ts` with 7 test cases
- [x] Test verifies `path` is not set from URL pathname for postgres/mysql URLs
- [x] Test verifies `unix://` protocol still correctly uses pathname as socket path
- [x] Test fails with `USE_SYSTEM_BUN=1` (system Bun 1.3.10) and passes with debug build
- [x] Existing `adapter-env-var-precedence.test.ts` (38 tests) all pass
- [x] Existing `sqlite-url-parsing.test.ts` (176 tests) all pass

Closes #27713

🤖 Generated with [Claude Code](https://claude.com/claude-code)