### PR TITLE
fix(install): pass security scanner package data via stdin pipe

### DIFF
--- a/src/install/PackageManager/install_with_manager.zig
+++ b/src/install/PackageManager/install_with_manager.zig
@@ -645,7 +645,9 @@ pub fn installWithManager(
                         error.SecurityScannerInWorkspace => {
                             Output.pretty("<red>Security scanner cannot be a dependency of a workspace package. It must be a direct dependency of the root package.<r>\n", .{});
                         },
-                        else => {},
+                        else => {
+                            Output.errGeneric("Security scanner failed: {s}", .{@errorName(err)});
+                        },
                     }
 
                     Global.exit(1);

--- a/src/install/PackageManager/scanner-entry.ts
+++ b/src/install/PackageManager/scanner-entry.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 
 const scannerModuleName = "__SCANNER_MODULE__";
-const packages = __PACKAGES_JSON__;
+const packages = JSON.parse(fs.readFileSync(0, "utf-8"));
 const suppressError = __SUPPRESS_ERROR__;
 
 type IPCMessage =

--- a/src/install/PackageManager/security_scanner.zig
+++ b/src/install/PackageManager/security_scanner.zig
@@ -673,17 +673,6 @@ fn attemptSecurityScanWithRetry(manager: *PackageManager, security_scanner: []co
         temp_source = code.items;
     }
 
-    const packages_placeholder = "__PACKAGES_JSON__";
-    if (std.mem.indexOf(u8, temp_source, packages_placeholder)) |index| {
-        var new_code = std.array_list.Managed(u8).init(manager.allocator);
-        try new_code.appendSlice(temp_source[0..index]);
-        try new_code.appendSlice(json_data);
-        try new_code.appendSlice(temp_source[index + packages_placeholder.len ..]);
-        code.deinit();
-        code = new_code;
-        temp_source = code.items;
-    }
-
     const suppress_placeholder = "__SUPPRESS_ERROR__";
     if (std.mem.indexOf(u8, temp_source, suppress_placeholder)) |index| {
         var new_code = std.array_list.Managed(u8).init(manager.allocator);
@@ -724,6 +713,19 @@ fn attemptSecurityScanWithRetry(manager: *PackageManager, security_scanner: []co
     return try scanner.handleResults(&collector.package_paths, start_time, packages_scanned, security_scanner, security_scanner_pkg_id, command_ctx, original_cwd, is_retry);
 }
 
+fn writeAllToPipe(fd: bun.FileDescriptor, data: []const u8) void {
+    var remaining = data;
+    while (remaining.len > 0) {
+        switch (bun.sys.write(fd, remaining)) {
+            .result => |written| {
+                if (written == 0) return;
+                remaining = remaining[written..];
+            },
+            .err => return,
+        }
+    }
+}
+
 pub const SecurityScanSubprocess = struct {
     manager: *PackageManager,
     code: []const u8,
@@ -752,6 +754,17 @@ pub const SecurityScanSubprocess = struct {
             .result => |fds| fds,
         };
 
+        // Create a stdin pipe to pass package JSON data to the child process.
+        // This avoids embedding the (potentially large) JSON in the -e argument,
+        // which can exceed the OS per-argument size limit (MAX_ARG_STRLEN = 128KB on Linux).
+        const stdin_pipe_result = bun.sys.pipe();
+        const stdin_pipe_fds = switch (stdin_pipe_result) {
+            .err => {
+                return error.StdinPipeFailed;
+            },
+            .result => |fds| fds,
+        };
+
         const exec_path = try bun.selfExePath();
 
         var argv = [_]?[*:0]const u8{
@@ -771,7 +784,7 @@ pub const SecurityScanSubprocess = struct {
         const spawn_options = bun.spawn.SpawnOptions{
             .stdout = .inherit,
             .stderr = .inherit,
-            .stdin = .inherit,
+            .stdin = .{ .pipe = stdin_pipe_fds[0] },
             .cwd = spawn_cwd,
             .extra_fds = &.{.{ .pipe = pipe_fds[1] }},
             .windows = if (Environment.isWindows) .{
@@ -782,6 +795,14 @@ pub const SecurityScanSubprocess = struct {
         var spawned = try (try bun.spawn.spawnProcess(&spawn_options, @ptrCast(&argv), @ptrCast(std.os.environ.ptr))).unwrap();
 
         pipe_fds[1].close();
+        stdin_pipe_fds[0].close();
+
+        // Write JSON data to the child's stdin pipe then close it to signal EOF.
+        // The child process reads this data synchronously via fs.readFileSync(0).
+        // The write may block briefly if data exceeds the pipe buffer, but the child
+        // is already running and will drain it.
+        writeAllToPipe(stdin_pipe_fds[1], this.json_data);
+        stdin_pipe_fds[1].close();
 
         if (comptime bun.Environment.isPosix) {
             _ = bun.sys.setNonblocking(pipe_fds[0]);

--- a/test/regression/issue/27716.test.ts
+++ b/test/regression/issue/27716.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// Regression test for https://github.com/oven-sh/bun/issues/27716
+// bun install silently fails when a security scanner is configured and
+// the project has enough packages that the inline JSON would exceed the
+// OS per-argument size limit (MAX_ARG_STRLEN = 128KB on Linux).
+
+const PACKAGE_COUNT = 850;
+const tgzPath = join(import.meta.dir, "..", "..", "cli", "install", "bar-0.0.2.tgz");
+const tgzData = readFileSync(tgzPath);
+
+let server: ReturnType<typeof Bun.serve>;
+let registryUrl: string;
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const path = url.pathname;
+
+      if (path.endsWith(".tgz")) {
+        return new Response(tgzData);
+      }
+
+      // Package metadata request
+      const name = decodeURIComponent(path.slice(1));
+      return new Response(
+        JSON.stringify({
+          name,
+          versions: {
+            "1.0.0": {
+              name,
+              version: "1.0.0",
+              dist: {
+                tarball: `${registryUrl}${name}-1.0.0.tgz`,
+              },
+            },
+          },
+          "dist-tags": { latest: "1.0.0" },
+        }),
+      );
+    },
+  });
+  registryUrl = `http://localhost:${server.port}/`;
+});
+
+afterAll(() => {
+  server?.stop(true);
+});
+
+test("security scanner works with many packages", async () => {
+  using dir = tempDir("issue-27716", {
+    "scanner.ts": `export const scanner = {
+  version: "1",
+  scan: async ({ packages }) => {
+    return [];
+  },
+};`,
+  });
+
+  // Generate many dependencies
+  const deps: Record<string, string> = {};
+  for (let i = 0; i < PACKAGE_COUNT; i++) {
+    deps[`pkg-with-a-longer-name-for-testing-${String(i).padStart(4, "0")}`] = "1.0.0";
+  }
+
+  await Bun.write(
+    join(String(dir), "package.json"),
+    JSON.stringify({ name: "test-27716", version: "1.0.0", dependencies: deps }),
+  );
+
+  await Bun.write(
+    join(String(dir), "bunfig.toml"),
+    `[install]\nregistry = "${registryUrl}"\n\n[install.security]\nscanner = "./scanner.ts"\n`,
+  );
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("Security scanner failed");
+  expect(existsSync(join(String(dir), "bun.lock"))).toBe(true);
+  expect(existsSync(join(String(dir), "node_modules"))).toBe(true);
+  expect(exitCode).toBe(0);
+}, 60_000);


### PR DESCRIPTION
## Summary

- Fixes `bun install` silently failing (exit 1, no error, no lockfile) when a security scanner is configured and the project has ~750+ packages
- The security scanner subprocess received the entire package manifest JSON embedded in the `-e` command-line argument. With many packages, this exceeded Linux's `MAX_ARG_STRLEN` limit (128KB per argument), causing `posix_spawn` to fail with `E2BIG`
- The error was caught but silently swallowed by an `else => {}` branch, so users saw no error message

### Changes
- **`security_scanner.zig`**: Pass package JSON via a stdin pipe instead of inlining it in the `-e` argument. The child process reads from fd 0 (stdin) instead.
- **`scanner-entry.ts`**: Read packages from stdin (`fs.readFileSync(0, "utf-8")`) instead of an inline `__PACKAGES_JSON__` placeholder.
- **`install_with_manager.zig`**: Add error message for unhandled scanner errors so failures are no longer silent.

## Test plan

- [x] Regression test `test/regression/issue/27716.test.ts` — installs 850 packages with a security scanner configured
- [x] Verified test fails with system bun (v1.3.10) and passes with debug build
- [x] All 42 existing security scanner tests pass (`bun-install-security-provider.test.ts`)
- [x] All security scanner workspace tests pass (`bun-security-scanner-workspaces.test.ts`)
- [x] All security update tests pass (`bun-update-security-provider.test.ts`, `bun-update-security-simple.test.ts`)

Closes #27716

🤖 Generated with [Claude Code](https://claude.com/claude-code)