### PR TITLE
fix(run): replace stale node symlinks in /tmp/bun-node-* when binary is moved

### DIFF
--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -676,7 +676,17 @@ pub const RunCommand = struct {
                 while (true) {
                     inner: {
                         std.posix.symlinkZ(argv0, path) catch |err| {
-                            if (err == error.PathAlreadyExists) break :inner;
+                            if (err == error.PathAlreadyExists) {
+                                // Check if the existing symlink points to the current executable.
+                                // If not (e.g. the binary was moved), replace the stale symlink.
+                                var target_buf: bun.PathBuffer = undefined;
+                                const target = bun.sys.readlink(path, &target_buf).unwrap() catch break :inner;
+                                if (!std.mem.eql(u8, target, std.mem.span(argv0))) {
+                                    _ = bun.sys.unlink(path);
+                                    std.posix.symlinkZ(argv0, path) catch {};
+                                }
+                                break :inner;
+                            }
                             if (retried)
                                 return;
 

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -679,11 +679,16 @@ pub const RunCommand = struct {
                             if (err == error.PathAlreadyExists) {
                                 // Check if the existing symlink points to the current executable.
                                 // If not (e.g. the binary was moved), replace the stale symlink.
+                                const argv0_span = std.mem.span(argv0);
                                 var target_buf: bun.PathBuffer = undefined;
-                                const target = bun.sys.readlink(path, &target_buf).unwrap() catch break :inner;
-                                if (!std.mem.eql(u8, target, std.mem.span(argv0))) {
+                                const needs_replace = if (bun.sys.readlink(path, &target_buf).unwrap()) |target|
+                                    !std.mem.eql(u8, target, argv0_span)
+                                else |_|
+                                    // readlink failed (e.g. not a symlink) — try to replace it.
+                                    true;
+                                if (needs_replace) {
                                     _ = bun.sys.unlink(path);
-                                    std.posix.symlinkZ(argv0, path) catch {};
+                                    _ = bun.sys.symlink(argv0_span, path);
                                 }
                                 break :inner;
                             }

--- a/test/regression/issue/27722.test.ts
+++ b/test/regression/issue/27722.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { readlinkSync, symlinkSync, unlinkSync } from "fs";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/27722
+// When bun creates symlinks in /tmp/bun-node-{sha}/ for the fake "node" binary,
+// it should replace stale symlinks that point to a non-existent path.
+test.skipIf(isWindows)("stale node symlink is replaced when binary path changes", () => {
+  using dir = tempDir("issue-27722", {
+    "package.json": JSON.stringify({
+      scripts: {
+        "which-node": "which node",
+        "test-node": `node -e "process.stdout.write('works')"`,
+      },
+    }),
+  });
+
+  // Step 1: Run once to create the bun-node directory with correct symlinks
+  const whichResult = Bun.spawnSync({
+    cmd: [bunExe(), "--bun", "run", "--silent", "which-node"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const nodeSymlink = whichResult.stdout.toString().trim();
+  expect(nodeSymlink).toContain("bun-node");
+  expect(whichResult.exitCode).toBe(0);
+
+  // Step 2: Replace symlinks with stale ones pointing to a non-existent path
+  const bunSymlink = nodeSymlink.replace(/\/node$/, "/bun");
+  unlinkSync(nodeSymlink);
+  symlinkSync("/nonexistent/path/to/bun", nodeSymlink);
+  unlinkSync(bunSymlink);
+  symlinkSync("/nonexistent/path/to/bun", bunSymlink);
+
+  // Verify the symlinks are now stale
+  expect(readlinkSync(nodeSymlink)).toBe("/nonexistent/path/to/bun");
+
+  // Step 3: Run again - bun should detect and fix stale symlinks
+  const testResult = Bun.spawnSync({
+    cmd: [bunExe(), "--bun", "run", "--silent", "test-node"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  expect(testResult.stdout.toString()).toBe("works");
+  expect(testResult.exitCode).toBe(0);
+
+  // Verify the symlink now points to the actual bun binary
+  expect(readlinkSync(nodeSymlink)).not.toBe("/nonexistent/path/to/bun");
+});

--- a/test/regression/issue/27722.test.ts
+++ b/test/regression/issue/27722.test.ts
@@ -50,6 +50,7 @@ test.skipIf(isWindows)("stale node symlink is replaced when binary path changes"
   expect(testResult.stdout.toString()).toBe("works");
   expect(testResult.exitCode).toBe(0);
 
-  // Verify the symlink now points to the actual bun binary
+  // Verify both symlinks now point to the actual bun binary
   expect(readlinkSync(nodeSymlink)).not.toBe("/nonexistent/path/to/bun");
+  expect(readlinkSync(bunSymlink)).not.toBe("/nonexistent/path/to/bun");
 });


### PR DESCRIPTION
## Summary

- When `bun run` creates symlinks in `/tmp/bun-node-{sha}/` for the fake `node` executable, it previously skipped creation if the symlink already existed (`PathAlreadyExists`). This caused failures when the Bun binary was moved to a new location, as the stale symlinks still pointed to the old path.
- Now when `PathAlreadyExists` is returned, the existing symlink target is read via `readlink`. If it doesn't match the current executable path, the stale symlink is replaced.

Closes #27722

## Test plan

- [x] Added regression test `test/regression/issue/27722.test.ts` that creates stale symlinks and verifies they are replaced
- [x] Test fails with unpatched system bun (`USE_SYSTEM_BUN=1`) and passes with debug build (`bun bd test`)
- [x] Debug build compiles and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)