### PR TITLE
fix(dgram): enable SO_REUSEPORT on macOS and improve error reporting

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -901,8 +901,7 @@ static int bsd_set_reuseaddr(LIBUS_SOCKET_DESCRIPTOR listenFd) {
 }
 
 static int bsd_set_reuseport(LIBUS_SOCKET_DESCRIPTOR listenFd) {
-#if defined(__linux__)
-    // Among Bun's supported platforms, only Linux does load balancing with SO_REUSEPORT.
+#if defined(SO_REUSEPORT) && !defined(_WIN32)
     const int one = 1;
     return setsockopt(listenFd, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one));
 #else
@@ -1232,6 +1231,14 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
     }
 
     if (bsd_set_reuse(listenFd, options) != 0) {
+        if (err != NULL) {
+#ifdef _WIN32
+            *err = WSAGetLastError();
+#else
+            *err = errno;
+#endif
+        }
+        bsd_close_socket(listenFd);
         freeaddrinfo(result);
         return LIBUS_SOCKET_ERROR;
     }

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -96,7 +96,7 @@ enum {
     LIBUS_LISTEN_EXCLUSIVE_PORT = 1,
     /* Allow socket to keep writing after readable side closes */
     LIBUS_SOCKET_ALLOW_HALF_OPEN = 2,
-    /* Setting reusePort allows multiple sockets on the same host to bind to the same port. Incoming connections are distributed by the operating system to listening sockets. This option is available only on some platforms, such as Linux 3.9+, DragonFlyBSD 3.6+, FreeBSD 12.0+, Solaris 11.4, and AIX 7.2.5+*/
+    /* Setting reusePort allows multiple sockets on the same host to bind to the same port. Incoming connections are distributed by the operating system to listening sockets. This option is available on platforms that define SO_REUSEPORT, such as Linux 3.9+, macOS, DragonFlyBSD 3.6+, FreeBSD 12.0+, Solaris 11.4, and AIX 7.2.5+. Note: on Linux, SO_REUSEPORT provides kernel-level load balancing; on macOS and other BSDs it allows port sharing without load balancing.*/
     LIBUS_LISTEN_REUSE_PORT = 4,
     /* Setting ipv6Only will disable dual-stack support, i.e., binding to host :: won't make 0.0.0.0 be bound.*/
     LIBUS_SOCKET_IPV6_ONLY = 8,

--- a/test/regression/issue/27771.test.ts
+++ b/test/regression/issue/27771.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { createSocket, type Socket } from "node:dgram";
 
-function bindSocket(reusePort: boolean): Promise<{ ok: boolean; error: Error | null; socket: Socket }> {
+function bindSocket(reusePort: boolean, port?: number): Promise<{ ok: boolean; error: Error | null; socket: Socket }> {
   return new Promise(resolve => {
     const socket = createSocket({ type: "udp4", reuseAddr: true, reusePort });
     let done = false;
@@ -11,7 +11,7 @@ function bindSocket(reusePort: boolean): Promise<{ ok: boolean; error: Error | n
       resolve(result);
     };
     socket.once("error", (err: Error) => finish({ ok: false, error: err, socket }));
-    socket.bind(0, "0.0.0.0", () => finish({ ok: true, error: null, socket }));
+    socket.bind(port ?? 0, "0.0.0.0", () => finish({ ok: true, error: null, socket }));
   });
 }
 
@@ -30,17 +30,7 @@ test("dgram reusePort: two sockets can bind to the same port", async () => {
   const port = a.socket.address().port;
 
   // Bind second socket to the same port
-  const b = await new Promise<{ ok: boolean; error: Error | null; socket: Socket }>(resolve => {
-    const socket = createSocket({ type: "udp4", reuseAddr: true, reusePort: true });
-    let done = false;
-    const finish = (result: { ok: boolean; error: Error | null; socket: Socket }) => {
-      if (done) return;
-      done = true;
-      resolve(result);
-    };
-    socket.once("error", (err: Error) => finish({ ok: false, error: err, socket }));
-    socket.bind(port, "0.0.0.0", () => finish({ ok: true, error: null, socket }));
-  });
+  const b = await bindSocket(true, port);
 
   expect(b.ok).toBe(true);
   expect(b.error).toBeNull();

--- a/test/regression/issue/27771.test.ts
+++ b/test/regression/issue/27771.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test";
+import { createSocket, type Socket } from "node:dgram";
+
+function bindSocket(reusePort: boolean): Promise<{ ok: boolean; error: Error | null; socket: Socket }> {
+  return new Promise(resolve => {
+    const socket = createSocket({ type: "udp4", reuseAddr: true, reusePort });
+    let done = false;
+    const finish = (result: { ok: boolean; error: Error | null; socket: Socket }) => {
+      if (done) return;
+      done = true;
+      resolve(result);
+    };
+    socket.once("error", (err: Error) => finish({ ok: false, error: err, socket }));
+    socket.bind(0, "0.0.0.0", () => finish({ ok: true, error: null, socket }));
+  });
+}
+
+test("dgram reusePort: single socket binds successfully", async () => {
+  const result = await bindSocket(true);
+  expect(result.ok).toBe(true);
+  expect(result.error).toBeNull();
+  await new Promise<void>(r => result.socket.close(() => r()));
+});
+
+test("dgram reusePort: two sockets can bind to the same port", async () => {
+  const a = await bindSocket(true);
+  expect(a.ok).toBe(true);
+  expect(a.error).toBeNull();
+
+  const port = a.socket.address().port;
+
+  // Bind second socket to the same port
+  const b = await new Promise<{ ok: boolean; error: Error | null; socket: Socket }>(resolve => {
+    const socket = createSocket({ type: "udp4", reuseAddr: true, reusePort: true });
+    let done = false;
+    const finish = (result: { ok: boolean; error: Error | null; socket: Socket }) => {
+      if (done) return;
+      done = true;
+      resolve(result);
+    };
+    socket.once("error", (err: Error) => finish({ ok: false, error: err, socket }));
+    socket.bind(port, "0.0.0.0", () => finish({ ok: true, error: null, socket }));
+  });
+
+  expect(b.ok).toBe(true);
+  expect(b.error).toBeNull();
+
+  await new Promise<void>(r => b.socket.close(() => r()));
+  await new Promise<void>(r => a.socket.close(() => r()));
+});


### PR DESCRIPTION
## Summary

Fixes #27771.

- **Enable `SO_REUSEPORT` on macOS** (and other BSDs): `bsd_set_reuseport()` was restricted to `#if defined(__linux__)` only, causing `reusePort: true` in `node:dgram` to always fail on macOS with ENOTSUP. macOS has supported `SO_REUSEPORT` since at least 10.12 (Sierra), and the reporter confirmed it works with raw C sockets. Changed the guard to `#if defined(SO_REUSEPORT) && !defined(_WIN32)` to enable it on all platforms that define the constant.
- **Fix missing errno propagation**: When `bsd_set_reuse()` failed in `bsd_create_udp_socket()`, `errno` was not stored into `*err`, causing the Zig layer to fall through to a generic "Failed to bind socket" error instead of a descriptive one (e.g., "bind ENOTSUP 0.0.0.0:56780"). Now properly propagates the errno.
- **Fix socket fd leak**: The failed `bsd_set_reuse()` path in `bsd_create_udp_socket()` was not calling `bsd_close_socket()` before returning, leaking the file descriptor.

## Test plan

- [x] Existing `test-dgram-reuseport.js` passes on Linux
- [x] Existing `node-dgram.test.js` has no new failures
- [x] New regression test `test/regression/issue/27771.test.ts` passes
- [x] Repro script from the issue works correctly with both `reusePort: false` and `reusePort: true`
- [ ] CI validates macOS behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)