### PR TITLE
Add blog link to README header navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
   <a href="https://github.com/oven-sh/bun/issues/new">Issues</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://github.com/oven-sh/bun/issues/159">Roadmap</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://bun.com/blog">Blog</a>
   <br />
 </div>
 


### PR DESCRIPTION
## Summary

- Adds a link to the [Bun blog](https://bun.com/blog) in the README header navigation bar, alongside the existing Documentation, Discord, Issues, and Roadmap links.

Closes #27773