### PR TITLE
fix(windows): fs.existsSync/access/mkdir crash on paths of 49151-98302 bytes

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -3338,10 +3338,14 @@ pub const NodeFS = struct {
     pub const ReturnType = Return;
 
     pub fn access(this: *NodeFS, args: Arguments.Access, _: Flavor) Maybe(Return.Access) {
+        // sync_error_buf is [98302]u8 align(2): fits an OSPathBuffer (65534 bytes on Windows).
+        const buf: *bun.OSPathBuffer = @ptrCast(&this.sync_error_buf);
         const path: bun.OSPathSliceZ = if (args.path.slice().len == 0)
             comptime bun.OSPathLiteral("")
         else
-            args.path.osPathKernel32(&this.sync_error_buf);
+            args.path.osPathKernel32(buf) catch |err| switch (err) {
+                error.NameTooLong => return .{ .err = .{ .errno = @intFromEnum(bun.sys.E.NAMETOOLONG), .syscall = .access, .path = args.path.slice() } },
+            };
         return switch (Syscall.access(path, args.mode.asInt())) {
             .err => |err| .{ .err = err.withPath(args.path.slice()) },
             .result => .{ .result = .{} },
@@ -3756,10 +3760,12 @@ pub const NodeFS = struct {
             }
         }
 
+        const buf: *bun.OSPathBuffer = @ptrCast(&this.sync_error_buf);
         const slice = if (path.slice().len == 0)
             comptime bun.OSPathLiteral("")
         else
-            path.osPathKernel32(&this.sync_error_buf);
+            // Over PATH_MAX_WIDE — can't exist on disk.
+            path.osPathKernel32(buf) catch return .{ .result = false };
 
         return .{ .result = bun.sys.existsOSPath(slice, false) };
     }
@@ -3939,9 +3945,11 @@ pub const NodeFS = struct {
     }
 
     pub fn mkdirRecursiveImpl(this: *NodeFS, args: Arguments.Mkdir, comptime Ctx: type, ctx: Ctx) Maybe(Return.Mkdir) {
-        const buf = bun.path_buffer_pool.get();
-        defer bun.path_buffer_pool.put(buf);
-        const path = args.path.osPathKernel32(buf);
+        const buf = bun.os_path_buffer_pool.get();
+        defer bun.os_path_buffer_pool.put(buf);
+        const path = args.path.osPathKernel32(buf) catch |err| switch (err) {
+            error.NameTooLong => return .{ .err = .{ .errno = @intFromEnum(bun.sys.E.NAMETOOLONG), .syscall = .mkdir, .path = args.path.slice() } },
+        };
 
         return switch (args.always_return_none) {
             inline else => |always_return_none| this.mkdirRecursiveOSPathImpl(Ctx, ctx, path, args.mode, !always_return_none),

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -642,7 +642,10 @@ pub const PathLike = union(enum) {
         return sliceZWithForceCopy(this, buf, false);
     }
 
-    pub fn osPathKernel32(this: PathLike, buf: *bun.PathBuffer) callconv(bun.callconv_inline) bun.OSPathSliceZ {
+    // error.NameTooLong means the normalized path won't fit in a WPathBuffer.
+    // NT caps paths at PATH_MAX_WIDE wchars anyway, so such a path can't exist
+    // on disk — callers map this to false/ENOENT or ENAMETOOLONG as they see fit.
+    pub fn osPathKernel32(this: PathLike, buf: *bun.OSPathBuffer) error{NameTooLong}!bun.OSPathSliceZ {
         if (comptime Environment.isWindows) {
             const s = this.slice();
             const b = bun.path_buffer_pool.get();
@@ -650,22 +653,37 @@ pub const PathLike = union(enum) {
             // Device paths (\\.\, \\?\) and NT object paths (\??\) should not be normalized
             // because the "." in \\.\pipe\name would be incorrectly stripped as a "current directory" component.
             if (s.len >= 4 and bun.path.isSepAny(s[0]) and bun.path.isSepAny(s[1]) and (s[2] == '.' or s[2] == '?') and bun.path.isSepAny(s[3])) {
-                return strings.toKernel32Path(@alignCast(std.mem.bytesAsSlice(u16, buf)), s);
+                try checkFitsAsWide(s, buf.len);
+                return strings.toKernel32Path(buf, s);
             }
             if (s.len > 0 and bun.path.isSepAny(s[0])) {
-                const resolve = path_handler.PosixToWinNormalizer.resolveCWDWithExternalBuf(buf, s) catch @panic("Error while resolving path.");
+                const resolve_scratch = bun.path_buffer_pool.get();
+                defer bun.path_buffer_pool.put(resolve_scratch);
+                const resolve = path_handler.PosixToWinNormalizer.resolveCWDWithExternalBuf(resolve_scratch, s) catch @panic("Error while resolving path.");
                 const normal = path_handler.normalizeBuf(resolve, b, .windows);
-                return strings.toKernel32Path(@alignCast(std.mem.bytesAsSlice(u16, buf)), normal);
+                try checkFitsAsWide(normal, buf.len);
+                return strings.toKernel32Path(buf, normal);
             }
             // Handle "." specially since normalizeStringBuf strips it to an empty string
             if (s.len == 1 and s[0] == '.') {
-                return strings.toKernel32Path(@alignCast(std.mem.bytesAsSlice(u16, buf)), ".");
+                return strings.toKernel32Path(buf, ".");
             }
             const normal = path_handler.normalizeStringBuf(s, b, true, .windows, false);
-            return strings.toKernel32Path(@alignCast(std.mem.bytesAsSlice(u16, buf)), normal);
+            try checkFitsAsWide(normal, buf.len);
+            return strings.toKernel32Path(buf, normal);
         }
 
         return sliceZWithForceCopy(this, buf, false);
+    }
+
+    fn checkFitsAsWide(utf8: []const u8, wbuf_len: usize) error{NameTooLong}!void {
+        // toKernel32Path may prepend \\?\ and always null-terminates.
+        const overhead = bun.windows.long_path_prefix.len + 1;
+        // UTF-8→UTF-16 never expands, so byte count fitting already proves it.
+        // Only compute the real UTF-16 count when it doesn't (i.e. >32KB input).
+        if (utf8.len + overhead <= wbuf_len) return;
+        if (bun.simdutf.length.utf16.from.utf8(utf8) + overhead <= wbuf_len) return;
+        return error.NameTooLong;
     }
 
     pub fn fromJS(ctx: *jsc.JSGlobalObject, arguments: *ArgumentsSlice) bun.JSError!?PathLike {

--- a/src/string/immutable/paths.zig
+++ b/src/string/immutable/paths.zig
@@ -272,6 +272,16 @@ fn isUNCPath(comptime T: type, path: []const T) bool {
 pub fn toWPathMaybeDir(wbuf: []u16, utf8: []const u8, comptime add_trailing_lash: bool) [:0]u16 {
     bun.unsafeAssert(wbuf.len > 0);
 
+    // simdutf only receives output.ptr — the slice bound below never reaches it.
+    // Callers must ensure fit. UTF-8→UTF-16 never expands, so the byte count
+    // fitting is sufficient; only check exact UTF-16 count when it doesn't.
+    if (comptime bun.Environment.allow_assert) {
+        const reserve = 1 + @as(usize, @intFromBool(add_trailing_lash));
+        if (utf8.len + reserve > wbuf.len) {
+            bun.assert(bun.simdutf.length.utf16.from.utf8(utf8) + reserve <= wbuf.len);
+        }
+    }
+
     var result = bun.simdutf.convert.utf8.to.utf16.with_errors.le(
         utf8,
         wbuf[0..wbuf.len -| (1 + @as(usize, @intFromBool(add_trailing_lash)))],

--- a/test/regression/issue/20258.test.ts
+++ b/test/regression/issue/20258.test.ts
@@ -1,0 +1,70 @@
+// #20258 — fs.existsSync crashed on Windows for paths of 49151-98302 bytes.
+// osPathKernel32 reinterpreted a [98302]u8 as []u16 (49151 slots) and simdutf
+// wrote past it. Spawns subprocesses so a broken build doesn't panic the runner.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+async function runInSubprocess(src: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: stdout.trim(), stderr, exitCode };
+}
+
+test.skipIf(!isWindows)("#20258 existsSync does not crash in the [49151, 98302] length range", async () => {
+  const { stdout, stderr, exitCode } = await runInSubprocess(/* js */ `
+    const { existsSync } = require("fs");
+    const out = [];
+    for (const n of [49150, 49151, 60000, 98302, 98303]) {
+      out.push(n + ":" + existsSync(Buffer.alloc(n, "A").toString()));
+    }
+    process.stdout.write(out.join(" "));
+  `);
+
+  expect(stderr).not.toContain("index out of bounds");
+  expect(stdout).toBe("49150:false 49151:false 60000:false 98302:false 98303:false");
+  expect(exitCode).toBe(0);
+});
+
+test.skipIf(!isWindows)(
+  "#20258 accessSync surfaces ENAMETOOLONG (not a crash) for paths past the WPathBuffer limit",
+  async () => {
+    // Boundary is PATH_MAX_WIDE - 5 (\\?\ prefix + null terminator).
+    const { stdout, exitCode } = await runInSubprocess(/* js */ `
+    const { accessSync } = require("fs");
+    const out = [];
+    for (const n of [32762, 32763, 49151, 98302]) {
+      try { accessSync(Buffer.alloc(n, "A").toString()); out.push(n + ":none"); }
+      catch (e) { out.push(n + ":" + e.code); }
+    }
+    try { accessSync(Buffer.alloc(50000, "A").toString()); }
+    catch (e) { out.push("path_len:" + (e.path?.length ?? "missing")); }
+    process.stdout.write(out.join(" "));
+  `);
+
+    expect(stdout).toBe("32762:ENOENT 32763:ENAMETOOLONG 49151:ENAMETOOLONG 98302:ENAMETOOLONG path_len:50000");
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.skipIf(!isWindows)(
+  "#20258 paths with large UTF-8 byte count but small UTF-16 count are not wrongly rejected",
+  async () => {
+    // 15000 3-byte chars = 45000 UTF-8 bytes but only 15000 UTF-16 units.
+    // A naive byte-count clamp would wrongly reject this.
+    const { stdout, exitCode } = await runInSubprocess(/* js */ `
+    const { existsSync } = require("fs");
+    const cjk = new Array(15001).join("\u6587");
+    if (Buffer.byteLength(cjk) !== 45000 || cjk.length !== 15000) throw new Error("wrong encoding assumption");
+    process.stdout.write(String(existsSync(cjk)));
+  `);
+
+    expect(stdout).toBe("false");
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
Fixes #20258

`osPathKernel32` took a `*PathBuffer` (`[98302]u8`), reinterpreted it as
`[]u16` via `bytesAsSlice` (49151 slots), and handed it to simdutf — which
only sees `output.ptr`, not `output.len`. Inputs of 49151–98302 bytes wrote
past the buffer into the vm pointer.

Real-world trigger: pdfmake passes data URLs to `fs.existsSync`.

Fix: `osPathKernel32` now takes `*OSPathBuffer` and returns
`error{NameTooLong}` when the normalized path won't fit. `exists` → `false`,
`access`/`mkdir` → `ENAMETOOLONG`. Also fixes `mkdirRecursiveImpl` pulling
from the wrong buffer pool, and adds a debug assert in `toWPathMaybeDir`.

Tests verify the crash range, the `ENAMETOOLONG` boundary at
`PATH_MAX_WIDE - 5`, and that multi-byte UTF-8 paths aren't wrongly rejected
by a naive byte-count clamp.