### PR TITLE
fix(install): use normalized url_hash for cache folder naming

### DIFF
--- a/src/install/PackageManager/PackageManagerDirectories.zig
+++ b/src/install/PackageManager/PackageManagerDirectories.zig
@@ -251,7 +251,7 @@ pub fn cachedNPMPackageFolderNamePrint(this: *const PackageManager, buf: []u8, n
         const visible_hostname = scope.url.hostname[0..@min(scope.url.hostname.len, 12)];
         end = std.fmt.bufPrint(available, "@@{s}__{f}{f}{f}", .{
             visible_hostname,
-            bun.fmt.hexIntLower(String.Builder.stringHash(scope.url.href)),
+            bun.fmt.hexIntLower(scope.url_hash),
             CacheVersion.Formatter{ .version_number = CacheVersion.current },
             PatchHashFmt{ .hash = patch_hash },
         }) catch unreachable;

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -493,4 +493,64 @@ registry=https://somehost.com/org1/npm/registry/
     // Should be empty since there's no matching token for /org1/npm/registry/
     expect(result.default_registry_token).toBe("");
   });
+
+  it("second install with both global and local npmrc does not re-fetch packages", async () => {
+    // Regression test: when both global ~/.npmrc sets registry and a local .npmrc
+    // exists, a second `bun install` should not make unnecessary network requests
+    // for packages already installed in node_modules with a valid lockfile.
+    const { packageDir, packageJson } = await registry.createTestDir();
+
+    await Bun.$`rm -rf ${packageDir}/bunfig.toml`;
+
+    const homeDir = `${packageDir}/home_dir`;
+    await Bun.$`mkdir -p ${homeDir}`;
+
+    // Global .npmrc: sets default registry
+    const homeIni = /* ini */ `
+  registry=http://localhost:${registry.port}/
+  `;
+    await Bun.$`echo ${homeIni} > ${homeDir}/.npmrc`;
+
+    // Local .npmrc: sets scoped registry on the same host
+    const localIni = /* ini */ `
+  @types:registry=http://localhost:${registry.port}/
+  `;
+    await Bun.$`echo ${localIni} > ${packageDir}/.npmrc`;
+
+    await Bun.$`echo ${JSON.stringify({
+      name: "foo",
+      dependencies: {
+        "no-deps": "1.0.0",
+        "@types/no-deps": "1.0.0",
+      },
+    })} > package.json`.cwd(packageDir);
+
+    const installEnv = {
+      ...env,
+      XDG_CONFIG_HOME: `${homeDir}`,
+    };
+
+    // First install - should download packages
+    await Bun.$`${bunExe()} install`.env(installEnv).cwd(packageDir).throws(true);
+
+    // Verify node_modules and lockfile exist
+    expect(await Bun.file(join(packageDir, "node_modules", "no-deps", "package.json")).exists()).toBeTrue();
+    expect(await Bun.file(join(packageDir, "bun.lock")).exists()).toBeTrue();
+
+    // Second install - should not re-download anything
+    await using result2 = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      env: installEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [out2, err2, exitCode2] = await Promise.all([result2.stdout.text(), result2.stderr.text(), result2.exited]);
+
+    expect(stderrForInstall(err2)).not.toContain("error:");
+    // Second install should show "no changes" - not re-install packages
+    expect(out2).not.toContain("packages installed");
+    expect(exitCode2).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- Fix inconsistency in cache folder hash computation for npm packages with custom registries
- `cachedNPMPackageFolderNamePrint` was using `String.Builder.stringHash(scope.url.href)` (raw URL, no normalization) for the hash in cache folder names
- But `scope.url_hash` (used for manifest cache keys) normalizes trailing slashes via `withoutTrailingSlash()`
- This meant the same registry URL with/without a trailing slash could produce different cache folder names, causing unnecessary re-downloads when both a global `~/.npmrc` and a project-local `.npmrc` were present

## Fix
Use `scope.url_hash` directly instead of recomputing from `scope.url.href`. This ensures:
1. Cache folder names are stable regardless of trailing slash differences in registry URLs
2. Cache folder hash is consistent with manifest cache key hash
3. Two-pass `.npmrc` loading (global then local) produces the same cache path as single-file loading

## Test plan
- [x] Added integration test for second install with both global and local `.npmrc`
- [x] Verified debug build compiles successfully
- [x] Manually verified cache folder names are consistent with/without trailing slash
- [x] Manually verified second install shows "no changes" with both `.npmrc` files present

🤖 Generated with [Claude Code](https://claude.com/claude-code)