### PR TITLE
Add link to building from source in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,8 @@ bun upgrade --canary
 
 Refer to the [Project > Contributing](https://bun.com/docs/project/contributing) guide to start contributing to Bun.
 
+To build Bun from source, refer to the [Project > Building](https://bun.com/docs/project/building) guide.
+
 ## License
 
 Refer to the [Project > License](https://bun.com/docs/project/licensing) page for information about Bun's licensing.


### PR DESCRIPTION
## Summary

- Add a link to the [Building from Source](https://bun.com/docs/project/building) guide in the Contributing section of the README
- The Contributing section previously only linked to the contributing guide, but new contributors also need to know how to build Bun from source

Closes #27777