### PR TITLE
Update README contributing section with quick links

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,11 @@ bun upgrade --canary
 
 Refer to the [Project > Contributing](https://bun.com/docs/project/contributing) guide to start contributing to Bun.
 
+- [Building from source](https://bun.com/docs/project/building)
+- [Contributing guide](https://bun.com/docs/project/contributing)
+- [Report a bug](https://github.com/oven-sh/bun/issues/new)
+- [Ask for help on Discord](https://discord.com/invite/CXdq2DP29u)
+
 ## License
 
 Refer to the [Project > License](https://bun.com/docs/project/licensing) page for information about Bun's licensing.


### PR DESCRIPTION
## Summary

- Add direct links to building from source, the contributing guide, bug reporting, and Discord to the Contributing section
- Makes it easier for new contributors to find relevant resources without having to navigate through the docs site first

## Test plan

- [x] Verify links are correct and point to valid pages
- [x] README renders correctly with the new list items

Closes #27779