### PR TITLE
fix(allocator): MimallocArena destroys live blocks from reclaimed pages

### DIFF
--- a/src/allocators/MimallocArena.zig
+++ b/src/allocators/MimallocArena.zig
@@ -165,8 +165,15 @@ pub fn deinit(self: *Self) void {
     self.* = undefined;
 }
 
+/// Marks the arena as "not the general-purpose heap." When mimalloc reclaims
+/// an abandoned page from a dead thread, it routes it by tag to a heap on the
+/// current thread — and with the default tag 0 that's us, not the backing
+/// heap. `mi_heap_destroy` then nukes the page and the live blocks inside it.
+/// Any non-zero value works.
+const arena_heap_tag = 111;
+
 pub fn init() Self {
-    const mimalloc_heap = mimalloc.mi_heap_new() orelse bun.outOfMemory();
+    const mimalloc_heap = mimalloc.mi_heap_new_ex(arena_heap_tag, true, null) orelse bun.outOfMemory();
     if (comptime !safety_checks) return .{ .#heap = mimalloc_heap };
     const heap: Owned(*DebugHeap) = .new(.{
         .inner = mimalloc_heap,


### PR DESCRIPTION
## What

`MimallocArena.init()` was creating its heap with tag 0 — the same tag as the thread's backing heap. When mimalloc reclaimed an abandoned segment from a dead thread, `_mi_heap_by_tag` (segment.c:1215) routed the pages to the arena instead of the backing heap, because the arena sits at the front of `tld->heaps`. `mi_heap_destroy` then freed those pages and every live block inside them.

## Mechanism

1. Thread A's backing heap allocates something long-lived (e.g. libuv's `uv__loops` via `mi_realloc`) on page P, tag 0
2. Thread A exits → page P abandoned
3. Thread B starts → `MimallocArena.init()` → `mi_heap_new()` → tag 0, pushed to front of `tld->heaps`
4. Thread B's backing heap reclaims the abandoned segment
5. `_mi_heap_by_tag(heap, 0)` walks `tld->heaps`, finds the arena first → page P assigned to the arena
6. `arena.deinit()` → `mi_heap_destroy` → page P destroyed, `uv__loops` is now dangling
7. Thread C writes `uv__loops[size] = loop` → segfault

`no_reclaim=true` doesn't help — it only stops the arena from *initiating* a reclaim, not from *receiving* a page routed by tag.

## Fix

Give the arena a non-zero heap tag. `_mi_heap_by_tag(_, 0)` now skips it and finds the backing heap.

## Impact

No memory overhead — the tag is 1 byte of existing page metadata. The "reuse" we lose (arena adopting partially-used backing-heap pages) was exactly the bug. Arena pages are still carved from the same TLD segments as before.

Fixes #15942

🤖 Generated with [Claude Code](https://claude.com/claude-code)
