### PR TITLE
Add Windows version requirement note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Bun supports Linux (x64 & arm64), macOS (x64 & Apple Silicon) and Windows (x64 &
 
 > **Linux users** — Kernel version 5.6 or higher is strongly recommended, but the minimum is 5.1.
 
+> **Windows users** — Bun supports Windows 10 version 1809 and later.
+
 > **x64 users** — if you see "illegal instruction" or similar errors, check our [CPU requirements](https://bun.com/docs/installation#cpu-requirements-and-baseline-builds)
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Bun supports Linux (x64 & arm64), macOS (x64 & Apple Silicon) and Windows (x64 &
 
 > **Linux users** — Kernel version 5.6 or higher is strongly recommended, but the minimum is 5.1.
 
-> **Windows users** — Bun supports Windows 10 version 1809 and later.
+> **Windows users** — Windows 10 version 1809 or later is required.
 
 > **x64 users** — if you see "illegal instruction" or similar errors, check our [CPU requirements](https://bun.com/docs/installation#cpu-requirements-and-baseline-builds)
 


### PR DESCRIPTION
## Summary
- Add a note about Windows 10 version 1809 minimum requirement to the Install section of the README
- This sits alongside the existing Linux kernel version and x64 CPU requirement notes, giving Windows users the same visibility into system requirements

## Test plan
- [x] Verified the README renders correctly with the new note