### PR TITLE
Add building from source note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,10 @@ bun upgrade --canary
 
 Refer to the [Project > Contributing](https://bun.com/docs/project/contributing) guide to start contributing to Bun.
 
+### Building from source
+
+Bun is written primarily in Zig, C++, and JavaScript. To build from source, see the [Development guide](https://bun.com/docs/project/development).
+
 ## License
 
 Refer to the [Project > License](https://bun.com/docs/project/licensing) page for information about Bun's licensing.

--- a/README.md
+++ b/README.md
@@ -414,6 +414,10 @@ Refer to the [Project > Contributing](https://bun.com/docs/project/contributing)
 
 Bun is written primarily in Zig, C++, and JavaScript. To build from source, see the [Development guide](https://bun.com/docs/project/development).
 
+### Getting help
+
+If you run into problems or have questions, join the [Bun Discord](https://bun.com/discord) community.
+
 ## License
 
 Refer to the [Project > License](https://bun.com/docs/project/licensing) page for information about Bun's licensing.


### PR DESCRIPTION
## Summary
- Adds a short "Building from source" subsection under the Contributing heading in the README, linking to the Development guide.

## Test plan
- Visual inspection of the README rendering on GitHub.