### PR TITLE
cmake: use buildkite-agent for artifact discovery

### DIFF
--- a/cmake/tools/SetupBuildkite.cmake
+++ b/cmake/tools/SetupBuildkite.cmake
@@ -4,33 +4,11 @@ if(NOT BUILDKITE_CACHE OR NOT BUN_LINK_ONLY)
   return()
 endif()
 
-optionx(BUILDKITE_ORGANIZATION_SLUG STRING "The organization slug to use on Buildkite" DEFAULT "bun")
-optionx(BUILDKITE_PIPELINE_SLUG STRING "The pipeline slug to use on Buildkite" DEFAULT "bun")
-optionx(BUILDKITE_BUILD_ID STRING "The build ID (UUID) to use on Buildkite")
-optionx(BUILDKITE_BUILD_NUMBER STRING "The build number to use on Buildkite")
-optionx(BUILDKITE_GROUP_ID STRING "The group ID to use on Buildkite")
-
-if(ENABLE_BASELINE)
-  set(DEFAULT_BUILDKITE_GROUP_KEY ${OS}-${ARCH}-baseline)
-else()
-  set(DEFAULT_BUILDKITE_GROUP_KEY ${OS}-${ARCH})
-endif()
-
-optionx(BUILDKITE_GROUP_KEY STRING "The group key to use on Buildkite" DEFAULT ${DEFAULT_BUILDKITE_GROUP_KEY})
-
-if(BUILDKITE)
-  optionx(BUILDKITE_BUILD_ID_OVERRIDE STRING "The build ID to use on Buildkite")
-  if(BUILDKITE_BUILD_ID_OVERRIDE)
-    setx(BUILDKITE_BUILD_ID ${BUILDKITE_BUILD_ID_OVERRIDE})
-  endif()
-endif()
-
 # This runs inside the ${targetKey}-build-bun step (see .buildkite/ci.mjs), which
 # links artifacts from ${targetKey}-build-cpp and ${targetKey}-build-zig in the
-# same build. Step keys follow a fixed ${targetKey}-build-{cpp,zig,bun} pattern, so
-# we derive the sibling step keys by swapping the suffix on our own BUILDKITE_STEP_KEY.
-# That avoids having to reconstruct targetKey (which includes abi/baseline/profile
-# components) from CMake-side platform detection.
+# same build. Step keys follow a fixed ${targetKey}-build-{cpp,zig,bun} pattern
+# and build-bun's depends_on lists exactly those two steps, so we derive the
+# siblings by swapping the suffix on our own BUILDKITE_STEP_KEY.
 
 if(NOT DEFINED ENV{BUILDKITE_STEP_KEY})
   message(FATAL_ERROR "BUILDKITE_STEP_KEY is not set (expected inside a Buildkite job)")
@@ -42,96 +20,63 @@ if(NOT BUILDKITE_STEP_KEY MATCHES "^(.+)-build-bun$")
 endif()
 set(BUILDKITE_TARGET_KEY ${CMAKE_MATCH_1})
 
-set(BUILDKITE_SOURCE_STEPS
-  ${BUILDKITE_TARGET_KEY}-build-cpp
-  ${BUILDKITE_TARGET_KEY}-build-zig
-)
+# Download everything from both sibling steps at configure time. The agent
+# scopes to the current build via $BUILDKITE_BUILD_ID; --step resolves by
+# key within that build. No enumeration, no path parsing.
 
-# `buildkite-agent artifact search` lists artifacts from a sibling step in the
-# current build using the agent token — no HTTP scraping, no dependence on the
-# public buildkite.com JSON (which stopped inlining the jobs array in early 2026).
-# Output is one artifact path per line; empty if the step produced nothing.
-#
-# We only want linkable/archive artifacts. Asking the agent for each extension
-# separately and then flattening keeps us out of the brace-expansion-in-CMake
-# tarpit, and the extra round-trips are negligible (agent is local).
-set(BUILDKITE_ARTIFACT_GLOBS "*.o" "*.a" "*.lib" "*.zip" "*.tar" "*.gz")
+file(MAKE_DIRECTORY ${BUILD_PATH})
 
-set(BUILDKITE_STEPS_MATCHED)
-set(BUILDKITE_STEPS_EMPTY)
-
-foreach(STEP ${BUILDKITE_SOURCE_STEPS})
-  set(STEP_ARTIFACTS)
-  foreach(GLOB ${BUILDKITE_ARTIFACT_GLOBS})
-    execute_process(
-      COMMAND buildkite-agent artifact search ${GLOB} --step ${STEP} --format "%p\\n" --allow-empty-results
-      OUTPUT_VARIABLE SEARCH_OUT
-      ERROR_VARIABLE SEARCH_ERR
-      RESULT_VARIABLE SEARCH_RC
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    if(NOT SEARCH_RC EQUAL 0)
-      message(FATAL_ERROR "buildkite-agent artifact search failed for ${STEP} ${GLOB}: ${SEARCH_ERR}")
-    endif()
-    if(SEARCH_OUT)
-      string(REPLACE "\n" ";" SEARCH_OUT "${SEARCH_OUT}")
-      list(APPEND STEP_ARTIFACTS ${SEARCH_OUT})
-    endif()
-  endforeach()
-
-  if(NOT STEP_ARTIFACTS)
-    list(APPEND BUILDKITE_STEPS_EMPTY ${STEP})
-    continue()
+foreach(SUFFIX cpp zig)
+  set(STEP ${BUILDKITE_TARGET_KEY}-build-${SUFFIX})
+  message(STATUS "Downloading artifacts from ${STEP}")
+  execute_process(
+    COMMAND buildkite-agent artifact download * . --step ${STEP}
+    WORKING_DIRECTORY ${BUILD_PATH}
+    RESULT_VARIABLE DOWNLOAD_RC
+    ERROR_VARIABLE DOWNLOAD_ERR
+  )
+  if(NOT DOWNLOAD_RC EQUAL 0)
+    message(FATAL_ERROR "buildkite-agent artifact download from ${STEP} failed: ${DOWNLOAD_ERR}")
   endif()
-  list(REMOVE_DUPLICATES STEP_ARTIFACTS)
-  list(APPEND BUILDKITE_STEPS_MATCHED ${STEP})
-
-  foreach(ARTIFACT_PATH ${STEP_ARTIFACTS})
-    # build-cpp uploads libbun-*.a but the consuming step gzipped it first
-    # (upload bandwidth), so the actual artifact on the wire is the .gz.
-    # Search finds the .gz; only the bare .a needs this remap.
-    if(ARTIFACT_PATH STREQUAL "libbun-profile.a")
-      set(ARTIFACT_PATH libbun-profile.a.gz)
-    elseif(ARTIFACT_PATH STREQUAL "libbun-asan.a")
-      set(ARTIFACT_PATH libbun-asan.a.gz)
-    endif()
-
-    add_custom_command(
-      COMMENT "Downloading ${ARTIFACT_PATH} from ${STEP}"
-      VERBATIM COMMAND
-        buildkite-agent artifact download ${ARTIFACT_PATH} . --step ${STEP}
-      WORKING_DIRECTORY ${BUILD_PATH}
-      OUTPUT ${BUILD_PATH}/${ARTIFACT_PATH}
-    )
-
-    if(ARTIFACT_PATH STREQUAL "libbun-profile.a.gz")
-      add_custom_command(
-        COMMENT "Unpacking libbun-profile.a.gz"
-        VERBATIM COMMAND gunzip libbun-profile.a.gz
-        WORKING_DIRECTORY ${BUILD_PATH}
-        OUTPUT ${BUILD_PATH}/libbun-profile.a
-        DEPENDS ${BUILD_PATH}/libbun-profile.a.gz
-      )
-    elseif(ARTIFACT_PATH STREQUAL "libbun-asan.a.gz")
-      add_custom_command(
-        COMMENT "Unpacking libbun-asan.a.gz"
-        VERBATIM COMMAND gunzip libbun-asan.a.gz
-        WORKING_DIRECTORY ${BUILD_PATH}
-        OUTPUT ${BUILD_PATH}/libbun-asan.a
-        DEPENDS ${BUILD_PATH}/libbun-asan.a.gz
-      )
-    endif()
-  endforeach()
 endforeach()
 
-if(BUILDKITE_STEPS_EMPTY)
-  list(JOIN BUILDKITE_STEPS_EMPTY " " BUILDKITE_STEPS_EMPTY)
-  message(WARNING "No linkable artifacts from: ${BUILDKITE_STEPS_EMPTY}")
+# libbun-profile.a and libbun-asan.a are gzipped before upload (see
+# register_command's ARTIFACTS handling in Globals.cmake). Windows .lib
+# files are not gzipped, so this glob is empty there.
+
+file(GLOB BUILDKITE_GZ_ARTIFACTS "${BUILD_PATH}/*.gz")
+foreach(GZ ${BUILDKITE_GZ_ARTIFACTS})
+  message(STATUS "Unpacking ${GZ}")
+  execute_process(
+    COMMAND gunzip -f ${GZ}
+    RESULT_VARIABLE GUNZIP_RC
+    ERROR_VARIABLE GUNZIP_ERR
+  )
+  if(NOT GUNZIP_RC EQUAL 0)
+    message(FATAL_ERROR "gunzip ${GZ} failed: ${GUNZIP_ERR}")
+  endif()
+endforeach()
+
+# Register a no-op custom command for each linkable artifact so register_command
+# (Globals.cmake) sees them as GENERATED and shims its own output to
+# ${output}.always_run_${target} instead of overwriting them with a rebuild.
+# With no DEPENDS, the no-op never fires — the file already exists.
+
+file(GLOB BUILDKITE_LINK_ARTIFACTS
+  "${BUILD_PATH}/*.o"
+  "${BUILD_PATH}/*.a"
+  "${BUILD_PATH}/*.lib"
+)
+if(NOT BUILDKITE_LINK_ARTIFACTS)
+  message(FATAL_ERROR "No linkable artifacts found in ${BUILD_PATH} after download")
 endif()
 
-if(BUILDKITE_STEPS_MATCHED)
-  list(JOIN BUILDKITE_STEPS_MATCHED " " BUILDKITE_STEPS_MATCHED)
-  message(STATUS "Found artifacts from: ${BUILDKITE_STEPS_MATCHED}")
-else()
-  message(FATAL_ERROR "No artifacts found from any of: ${BUILDKITE_SOURCE_STEPS}")
-endif()
+foreach(ARTIFACT ${BUILDKITE_LINK_ARTIFACTS})
+  add_custom_command(
+    OUTPUT ${ARTIFACT}
+    COMMAND ${CMAKE_COMMAND} -E true
+  )
+endforeach()
+
+list(LENGTH BUILDKITE_LINK_ARTIFACTS BUILDKITE_LINK_COUNT)
+message(STATUS "Found ${BUILDKITE_LINK_COUNT} linkable artifacts from ${BUILDKITE_TARGET_KEY}-build-{cpp,zig}")

--- a/cmake/tools/SetupBuildkite.cmake
+++ b/cmake/tools/SetupBuildkite.cmake
@@ -20,56 +20,72 @@ if(NOT BUILDKITE_STEP_KEY MATCHES "^(.+)-build-bun$")
 endif()
 set(BUILDKITE_TARGET_KEY ${CMAKE_MATCH_1})
 
-# Download everything from both sibling steps at configure time. The agent
-# scopes to the current build via $BUILDKITE_BUILD_ID; --step resolves by
-# key within that build. No enumeration, no path parsing.
+# scripts/build.mjs deletes CMakeCache.txt on every invocation, so configure
+# always runs fresh. If artifacts are already on disk (Buildkite retry on a
+# warm agent), skip the download — the .a is several GB.
 
 file(MAKE_DIRECTORY ${BUILD_PATH})
-
-foreach(SUFFIX cpp zig)
-  set(STEP ${BUILDKITE_TARGET_KEY}-build-${SUFFIX})
-  message(STATUS "Downloading artifacts from ${STEP}")
-  execute_process(
-    COMMAND buildkite-agent artifact download * . --step ${STEP}
-    WORKING_DIRECTORY ${BUILD_PATH}
-    RESULT_VARIABLE DOWNLOAD_RC
-    ERROR_VARIABLE DOWNLOAD_ERR
-  )
-  if(NOT DOWNLOAD_RC EQUAL 0)
-    message(FATAL_ERROR "buildkite-agent artifact download from ${STEP} failed: ${DOWNLOAD_ERR}")
-  endif()
-endforeach()
-
-# libbun-profile.a and libbun-asan.a are gzipped before upload (see
-# register_command's ARTIFACTS handling in Globals.cmake). Windows .lib
-# files are not gzipped, so this glob is empty there.
-
-file(GLOB BUILDKITE_GZ_ARTIFACTS "${BUILD_PATH}/*.gz")
-foreach(GZ ${BUILDKITE_GZ_ARTIFACTS})
-  message(STATUS "Unpacking ${GZ}")
-  execute_process(
-    COMMAND gunzip -f ${GZ}
-    RESULT_VARIABLE GUNZIP_RC
-    ERROR_VARIABLE GUNZIP_ERR
-  )
-  if(NOT GUNZIP_RC EQUAL 0)
-    message(FATAL_ERROR "gunzip ${GZ} failed: ${GUNZIP_ERR}")
-  endif()
-endforeach()
-
-# Register a no-op custom command for each linkable artifact so register_command
-# (Globals.cmake) sees them as GENERATED and shims its own output to
-# ${output}.always_run_${target} instead of overwriting them with a rebuild.
-# With no DEPENDS, the no-op never fires — the file already exists.
 
 file(GLOB BUILDKITE_LINK_ARTIFACTS
   "${BUILD_PATH}/*.o"
   "${BUILD_PATH}/*.a"
   "${BUILD_PATH}/*.lib"
 )
-if(NOT BUILDKITE_LINK_ARTIFACTS)
-  message(FATAL_ERROR "No linkable artifacts found in ${BUILD_PATH} after download")
+
+if(BUILDKITE_LINK_ARTIFACTS)
+  list(LENGTH BUILDKITE_LINK_ARTIFACTS BUILDKITE_LINK_COUNT)
+  message(STATUS "Found ${BUILDKITE_LINK_COUNT} linkable artifacts already in ${BUILD_PATH}, skipping download")
+else()
+  # The agent scopes to the current build via $BUILDKITE_BUILD_ID; --step
+  # resolves by key within that build.
+
+  foreach(SUFFIX cpp zig)
+    set(STEP ${BUILDKITE_TARGET_KEY}-build-${SUFFIX})
+    message(STATUS "Downloading artifacts from ${STEP}")
+    execute_process(
+      COMMAND buildkite-agent artifact download * . --step ${STEP}
+      WORKING_DIRECTORY ${BUILD_PATH}
+      RESULT_VARIABLE DOWNLOAD_RC
+      ERROR_VARIABLE DOWNLOAD_ERR
+    )
+    if(NOT DOWNLOAD_RC EQUAL 0)
+      message(FATAL_ERROR "buildkite-agent artifact download from ${STEP} failed: ${DOWNLOAD_ERR}")
+    endif()
+  endforeach()
+
+  # libbun-profile.a and libbun-asan.a are gzipped before upload (see
+  # register_command's ARTIFACTS handling in Globals.cmake). Windows .lib
+  # files are not gzipped, so this glob is empty there.
+
+  file(GLOB BUILDKITE_GZ_ARTIFACTS "${BUILD_PATH}/*.gz")
+  foreach(GZ ${BUILDKITE_GZ_ARTIFACTS})
+    message(STATUS "Unpacking ${GZ}")
+    execute_process(
+      COMMAND gunzip -f ${GZ}
+      RESULT_VARIABLE GUNZIP_RC
+      ERROR_VARIABLE GUNZIP_ERR
+    )
+    if(NOT GUNZIP_RC EQUAL 0)
+      message(FATAL_ERROR "gunzip ${GZ} failed: ${GUNZIP_ERR}")
+    endif()
+  endforeach()
+
+  file(GLOB BUILDKITE_LINK_ARTIFACTS
+    "${BUILD_PATH}/*.o"
+    "${BUILD_PATH}/*.a"
+    "${BUILD_PATH}/*.lib"
+  )
+  if(NOT BUILDKITE_LINK_ARTIFACTS)
+    message(FATAL_ERROR "No linkable artifacts found in ${BUILD_PATH} after download")
+  endif()
+  list(LENGTH BUILDKITE_LINK_ARTIFACTS BUILDKITE_LINK_COUNT)
+  message(STATUS "Downloaded ${BUILDKITE_LINK_COUNT} linkable artifacts from ${BUILDKITE_TARGET_KEY}-build-{cpp,zig}")
 endif()
+
+# Register a no-op custom command for each linkable artifact so register_command
+# (Globals.cmake) sees them as GENERATED and shims its own output to
+# ${output}.always_run_${target} instead of overwriting them with a rebuild.
+# With no DEPENDS, the no-op never fires — the file already exists.
 
 foreach(ARTIFACT ${BUILDKITE_LINK_ARTIFACTS})
   add_custom_command(
@@ -77,6 +93,3 @@ foreach(ARTIFACT ${BUILDKITE_LINK_ARTIFACTS})
     COMMAND ${CMAKE_COMMAND} -E true
   )
 endforeach()
-
-list(LENGTH BUILDKITE_LINK_ARTIFACTS BUILDKITE_LINK_COUNT)
-message(STATUS "Found ${BUILDKITE_LINK_COUNT} linkable artifacts from ${BUILDKITE_TARGET_KEY}-build-{cpp,zig}")

--- a/cmake/tools/SetupBuildkite.cmake
+++ b/cmake/tools/SetupBuildkite.cmake
@@ -20,67 +20,65 @@ if(NOT BUILDKITE_STEP_KEY MATCHES "^(.+)-build-bun$")
 endif()
 set(BUILDKITE_TARGET_KEY ${CMAKE_MATCH_1})
 
-# scripts/build.mjs deletes CMakeCache.txt on every invocation, so configure
-# always runs fresh. If artifacts are already on disk (Buildkite retry on a
-# warm agent), skip the download — the .a is several GB.
+# Clear any stale artifacts from a previous build (macOS agents are not
+# ephemeral). Always download fresh — correctness over saving bandwidth
+# on the rare within-build retry.
 
 file(MAKE_DIRECTORY ${BUILD_PATH})
+file(GLOB BUILDKITE_STALE_ARTIFACTS
+  "${BUILD_PATH}/*.o"
+  "${BUILD_PATH}/*.a"
+  "${BUILD_PATH}/*.lib"
+  "${BUILD_PATH}/*.gz"
+)
+if(BUILDKITE_STALE_ARTIFACTS)
+  file(REMOVE ${BUILDKITE_STALE_ARTIFACTS})
+endif()
+
+# The agent scopes to the current build via $BUILDKITE_BUILD_ID; --step
+# resolves by key within that build.
+
+foreach(SUFFIX cpp zig)
+  set(STEP ${BUILDKITE_TARGET_KEY}-build-${SUFFIX})
+  message(STATUS "Downloading artifacts from ${STEP}")
+  execute_process(
+    COMMAND buildkite-agent artifact download * . --step ${STEP}
+    WORKING_DIRECTORY ${BUILD_PATH}
+    RESULT_VARIABLE DOWNLOAD_RC
+    ERROR_VARIABLE DOWNLOAD_ERR
+  )
+  if(NOT DOWNLOAD_RC EQUAL 0)
+    message(FATAL_ERROR "buildkite-agent artifact download from ${STEP} failed: ${DOWNLOAD_ERR}")
+  endif()
+endforeach()
+
+# libbun-profile.a and libbun-asan.a are gzipped before upload (see
+# register_command's ARTIFACTS handling in Globals.cmake). Windows .lib
+# files are not gzipped, so this glob is empty there.
+
+file(GLOB BUILDKITE_GZ_ARTIFACTS "${BUILD_PATH}/*.gz")
+foreach(GZ ${BUILDKITE_GZ_ARTIFACTS})
+  message(STATUS "Unpacking ${GZ}")
+  execute_process(
+    COMMAND gunzip -f ${GZ}
+    RESULT_VARIABLE GUNZIP_RC
+    ERROR_VARIABLE GUNZIP_ERR
+  )
+  if(NOT GUNZIP_RC EQUAL 0)
+    message(FATAL_ERROR "gunzip ${GZ} failed: ${GUNZIP_ERR}")
+  endif()
+endforeach()
 
 file(GLOB BUILDKITE_LINK_ARTIFACTS
   "${BUILD_PATH}/*.o"
   "${BUILD_PATH}/*.a"
   "${BUILD_PATH}/*.lib"
 )
-
-if(BUILDKITE_LINK_ARTIFACTS)
-  list(LENGTH BUILDKITE_LINK_ARTIFACTS BUILDKITE_LINK_COUNT)
-  message(STATUS "Found ${BUILDKITE_LINK_COUNT} linkable artifacts already in ${BUILD_PATH}, skipping download")
-else()
-  # The agent scopes to the current build via $BUILDKITE_BUILD_ID; --step
-  # resolves by key within that build.
-
-  foreach(SUFFIX cpp zig)
-    set(STEP ${BUILDKITE_TARGET_KEY}-build-${SUFFIX})
-    message(STATUS "Downloading artifacts from ${STEP}")
-    execute_process(
-      COMMAND buildkite-agent artifact download * . --step ${STEP}
-      WORKING_DIRECTORY ${BUILD_PATH}
-      RESULT_VARIABLE DOWNLOAD_RC
-      ERROR_VARIABLE DOWNLOAD_ERR
-    )
-    if(NOT DOWNLOAD_RC EQUAL 0)
-      message(FATAL_ERROR "buildkite-agent artifact download from ${STEP} failed: ${DOWNLOAD_ERR}")
-    endif()
-  endforeach()
-
-  # libbun-profile.a and libbun-asan.a are gzipped before upload (see
-  # register_command's ARTIFACTS handling in Globals.cmake). Windows .lib
-  # files are not gzipped, so this glob is empty there.
-
-  file(GLOB BUILDKITE_GZ_ARTIFACTS "${BUILD_PATH}/*.gz")
-  foreach(GZ ${BUILDKITE_GZ_ARTIFACTS})
-    message(STATUS "Unpacking ${GZ}")
-    execute_process(
-      COMMAND gunzip -f ${GZ}
-      RESULT_VARIABLE GUNZIP_RC
-      ERROR_VARIABLE GUNZIP_ERR
-    )
-    if(NOT GUNZIP_RC EQUAL 0)
-      message(FATAL_ERROR "gunzip ${GZ} failed: ${GUNZIP_ERR}")
-    endif()
-  endforeach()
-
-  file(GLOB BUILDKITE_LINK_ARTIFACTS
-    "${BUILD_PATH}/*.o"
-    "${BUILD_PATH}/*.a"
-    "${BUILD_PATH}/*.lib"
-  )
-  if(NOT BUILDKITE_LINK_ARTIFACTS)
-    message(FATAL_ERROR "No linkable artifacts found in ${BUILD_PATH} after download")
-  endif()
-  list(LENGTH BUILDKITE_LINK_ARTIFACTS BUILDKITE_LINK_COUNT)
-  message(STATUS "Downloaded ${BUILDKITE_LINK_COUNT} linkable artifacts from ${BUILDKITE_TARGET_KEY}-build-{cpp,zig}")
+if(NOT BUILDKITE_LINK_ARTIFACTS)
+  message(FATAL_ERROR "No linkable artifacts found in ${BUILD_PATH} after download")
 endif()
+list(LENGTH BUILDKITE_LINK_ARTIFACTS BUILDKITE_LINK_COUNT)
+message(STATUS "Downloaded ${BUILDKITE_LINK_COUNT} linkable artifacts from ${BUILDKITE_TARGET_KEY}-build-{cpp,zig}")
 
 # Register a no-op custom command for each linkable artifact so register_command
 # (Globals.cmake) sees them as GENERATED and shims its own output to

--- a/cmake/tools/SetupBuildkite.cmake
+++ b/cmake/tools/SetupBuildkite.cmake
@@ -25,206 +25,113 @@ if(BUILDKITE)
   endif()
 endif()
 
-set(BUILDKITE_PATH ${BUILD_PATH}/buildkite)
-set(BUILDKITE_BUILDS_PATH ${BUILDKITE_PATH}/builds)
+# This runs inside the ${targetKey}-build-bun step (see .buildkite/ci.mjs), which
+# links artifacts from ${targetKey}-build-cpp and ${targetKey}-build-zig in the
+# same build. Step keys follow a fixed ${targetKey}-build-{cpp,zig,bun} pattern, so
+# we derive the sibling step keys by swapping the suffix on our own BUILDKITE_STEP_KEY.
+# That avoids having to reconstruct targetKey (which includes abi/baseline/profile
+# components) from CMake-side platform detection.
 
-if(NOT BUILDKITE_BUILD_ID)
-  # TODO: find the latest build on the main branch that passed
-  return()
+if(NOT DEFINED ENV{BUILDKITE_STEP_KEY})
+  message(FATAL_ERROR "BUILDKITE_STEP_KEY is not set (expected inside a Buildkite job)")
 endif()
+set(BUILDKITE_STEP_KEY $ENV{BUILDKITE_STEP_KEY})
 
-# Use BUILDKITE_BUILD_NUMBER for the URL if available, as the UUID format causes a 302 redirect
-# that CMake's file(DOWNLOAD) doesn't follow, resulting in empty response.
-if(BUILDKITE_BUILD_NUMBER)
-  setx(BUILDKITE_BUILD_URL https://buildkite.com/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER})
-else()
-  setx(BUILDKITE_BUILD_URL https://buildkite.com/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_ID})
+if(NOT BUILDKITE_STEP_KEY MATCHES "^(.+)-build-bun$")
+  message(FATAL_ERROR "Unexpected BUILDKITE_STEP_KEY '${BUILDKITE_STEP_KEY}' (expected '<target>-build-bun')")
 endif()
-setx(BUILDKITE_BUILD_PATH ${BUILDKITE_BUILDS_PATH}/builds/${BUILDKITE_BUILD_ID})
+set(BUILDKITE_TARGET_KEY ${CMAKE_MATCH_1})
 
-file(
-  DOWNLOAD ${BUILDKITE_BUILD_URL}
-  HTTPHEADER "Accept: application/json"
-  TIMEOUT 15
-  STATUS BUILDKITE_BUILD_STATUS
-  ${BUILDKITE_BUILD_PATH}/build.json
+set(BUILDKITE_SOURCE_STEPS
+  ${BUILDKITE_TARGET_KEY}-build-cpp
+  ${BUILDKITE_TARGET_KEY}-build-zig
 )
-if(NOT BUILDKITE_BUILD_STATUS EQUAL 0)
-  message(FATAL_ERROR "No build found: ${BUILDKITE_BUILD_STATUS} ${BUILDKITE_BUILD_URL}")
-  return()
-endif()
 
-file(READ ${BUILDKITE_BUILD_PATH}/build.json BUILDKITE_BUILD)
-# CMake's string(JSON ...) interprets escape sequences like \n, \r, \t.
-# We need to escape these specific sequences while preserving valid JSON escapes like \" and \\.
-# Strategy: Use a unique placeholder to protect \\ sequences, escape \n/\r/\t, then restore \\.
-# This prevents \\n (literal backslash + n) from being corrupted to \\\n.
-set(BKSLASH_PLACEHOLDER "___BKSLASH_PLACEHOLDER_7f3a9b2c___")
-string(REPLACE "\\\\" "${BKSLASH_PLACEHOLDER}" BUILDKITE_BUILD "${BUILDKITE_BUILD}")
-string(REPLACE "\\n" "\\\\n" BUILDKITE_BUILD "${BUILDKITE_BUILD}")
-string(REPLACE "\\r" "\\\\r" BUILDKITE_BUILD "${BUILDKITE_BUILD}")
-string(REPLACE "\\t" "\\\\t" BUILDKITE_BUILD "${BUILDKITE_BUILD}")
-string(REPLACE "${BKSLASH_PLACEHOLDER}" "\\\\" BUILDKITE_BUILD "${BUILDKITE_BUILD}")
-# CMake treats semicolons as list separators in unquoted variable expansions.
-# Commit messages and other JSON string fields can contain semicolons, which would
-# cause string(JSON) to receive garbled arguments. Escape them before parsing.
-string(REPLACE ";" "\\;" BUILDKITE_BUILD "${BUILDKITE_BUILD}")
+# `buildkite-agent artifact search` lists artifacts from a sibling step in the
+# current build using the agent token — no HTTP scraping, no dependence on the
+# public buildkite.com JSON (which stopped inlining the jobs array in early 2026).
+# Output is one artifact path per line; empty if the step produced nothing.
+#
+# We only want linkable/archive artifacts. Asking the agent for each extension
+# separately and then flattening keeps us out of the brace-expansion-in-CMake
+# tarpit, and the extra round-trips are negligible (agent is local).
+set(BUILDKITE_ARTIFACT_GLOBS "*.o" "*.a" "*.lib" "*.zip" "*.tar" "*.gz")
 
-string(JSON BUILDKITE_BUILD_UUID GET "${BUILDKITE_BUILD}" id)
-string(JSON BUILDKITE_JOBS GET "${BUILDKITE_BUILD}" jobs)
-string(JSON BUILDKITE_JOBS_COUNT LENGTH "${BUILDKITE_JOBS}")
+set(BUILDKITE_STEPS_MATCHED)
+set(BUILDKITE_STEPS_EMPTY)
 
-if(NOT BUILDKITE_JOBS_COUNT GREATER 0)
-  message(FATAL_ERROR "No jobs found: ${BUILDKITE_BUILD_URL}")
-  return()
-endif()
-
-set(BUILDKITE_JOBS_FAILED)
-set(BUILDKITE_JOBS_NOT_FOUND)
-set(BUILDKITE_JOBS_NO_ARTIFACTS)
-set(BUILDKITE_JOBS_NO_MATCH)
-set(BUILDKITE_JOBS_MATCH)
-
-math(EXPR BUILDKITE_JOBS_MAX_INDEX "${BUILDKITE_JOBS_COUNT} - 1")
-foreach(i RANGE ${BUILDKITE_JOBS_MAX_INDEX})
-  string(JSON BUILDKITE_JOB GET "${BUILDKITE_JOBS}" ${i})
-  string(JSON BUILDKITE_JOB_ID GET "${BUILDKITE_JOB}" id)
-  string(JSON BUILDKITE_JOB_PASSED GET "${BUILDKITE_JOB}" passed)
-  string(JSON BUILDKITE_JOB_GROUP_ID GET "${BUILDKITE_JOB}" group_uuid)
-  string(JSON BUILDKITE_JOB_GROUP_KEY GET "${BUILDKITE_JOB}" group_identifier)
-  string(JSON BUILDKITE_JOB_NAME GET "${BUILDKITE_JOB}" step_key)
-  if(NOT BUILDKITE_JOB_NAME)
-    string(JSON BUILDKITE_JOB_NAME GET "${BUILDKITE_JOB}" name)
-  endif()
-
-  if(NOT BUILDKITE_JOB_PASSED)
-    list(APPEND BUILDKITE_JOBS_FAILED ${BUILDKITE_JOB_NAME})
-    continue()
-  endif()
-
-  if(NOT (BUILDKITE_GROUP_ID AND BUILDKITE_GROUP_ID STREQUAL BUILDKITE_JOB_GROUP_ID) AND
-     NOT (BUILDKITE_GROUP_KEY AND BUILDKITE_GROUP_KEY STREQUAL BUILDKITE_JOB_GROUP_KEY))
-    list(APPEND BUILDKITE_JOBS_NO_MATCH ${BUILDKITE_JOB_NAME})
-    continue()
-  endif()
-
-  set(BUILDKITE_ARTIFACTS_URL https://buildkite.com/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_UUID}/jobs/${BUILDKITE_JOB_ID}/artifacts)
-  set(BUILDKITE_ARTIFACTS_PATH ${BUILDKITE_BUILD_PATH}/artifacts/${BUILDKITE_JOB_ID}.json)
-
-  file(
-    DOWNLOAD ${BUILDKITE_ARTIFACTS_URL}
-    HTTPHEADER "Accept: application/json"
-    TIMEOUT 15
-    STATUS BUILDKITE_ARTIFACTS_STATUS
-    ${BUILDKITE_ARTIFACTS_PATH}
-  )
-
-  if(NOT BUILDKITE_ARTIFACTS_STATUS EQUAL 0)
-    list(APPEND BUILDKITE_JOBS_NOT_FOUND ${BUILDKITE_JOB_NAME})
-    continue()
-  endif()
-  
-  file(READ ${BUILDKITE_ARTIFACTS_PATH} BUILDKITE_ARTIFACTS)
-  string(REPLACE ";" "\\;" BUILDKITE_ARTIFACTS "${BUILDKITE_ARTIFACTS}")
-  string(JSON BUILDKITE_ARTIFACTS_LENGTH LENGTH "${BUILDKITE_ARTIFACTS}")
-  if(NOT BUILDKITE_ARTIFACTS_LENGTH GREATER 0)
-    list(APPEND BUILDKITE_JOBS_NO_ARTIFACTS ${BUILDKITE_JOB_NAME})
-    continue()
-  endif()
-
-  math(EXPR BUILDKITE_ARTIFACTS_MAX_INDEX "${BUILDKITE_ARTIFACTS_LENGTH} - 1")
-  foreach(i RANGE 0 ${BUILDKITE_ARTIFACTS_MAX_INDEX})
-    string(JSON BUILDKITE_ARTIFACT GET "${BUILDKITE_ARTIFACTS}" ${i})
-    string(JSON BUILDKITE_ARTIFACT_ID GET "${BUILDKITE_ARTIFACT}" id)
-    string(JSON BUILDKITE_ARTIFACT_PATH GET "${BUILDKITE_ARTIFACT}" path)
-
-    if(NOT BUILDKITE_ARTIFACT_PATH MATCHES "\\.(o|a|lib|zip|tar|gz)")
-      continue()
-    endif()
-
-    if(BUILDKITE)
-      if(BUILDKITE_ARTIFACT_PATH STREQUAL "libbun-profile.a")
-        set(BUILDKITE_ARTIFACT_PATH libbun-profile.a.gz)
-      elseif(BUILDKITE_ARTIFACT_PATH STREQUAL "libbun-asan.a")
-        set(BUILDKITE_ARTIFACT_PATH libbun-asan.a.gz)
-      endif()
-      set(BUILDKITE_DOWNLOAD_COMMAND buildkite-agent artifact download ${BUILDKITE_ARTIFACT_PATH} . --build ${BUILDKITE_BUILD_UUID} --step ${BUILDKITE_JOB_ID})
-    else()
-      set(BUILDKITE_DOWNLOAD_COMMAND curl -L -o ${BUILDKITE_ARTIFACT_PATH} ${BUILDKITE_ARTIFACTS_URL}/${BUILDKITE_ARTIFACT_ID})
-    endif()
-
-    add_custom_command(
-      COMMENT
-        "Downloading ${BUILDKITE_ARTIFACT_PATH}"
-      VERBATIM COMMAND
-        ${BUILDKITE_DOWNLOAD_COMMAND}
-      WORKING_DIRECTORY
-        ${BUILD_PATH}
-      OUTPUT
-        ${BUILD_PATH}/${BUILDKITE_ARTIFACT_PATH}
+foreach(STEP ${BUILDKITE_SOURCE_STEPS})
+  set(STEP_ARTIFACTS)
+  foreach(GLOB ${BUILDKITE_ARTIFACT_GLOBS})
+    execute_process(
+      COMMAND buildkite-agent artifact search ${GLOB} --step ${STEP} --format "%p\n" --allow-empty-results
+      OUTPUT_VARIABLE SEARCH_OUT
+      ERROR_VARIABLE SEARCH_ERR
+      RESULT_VARIABLE SEARCH_RC
+      OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-    if(BUILDKITE_ARTIFACT_PATH STREQUAL "libbun-profile.a.gz")
-      add_custom_command(
-        COMMENT
-          "Unpacking libbun-profile.a.gz"
-        VERBATIM COMMAND
-          gunzip libbun-profile.a.gz
-        WORKING_DIRECTORY
-          ${BUILD_PATH}
-        OUTPUT
-          ${BUILD_PATH}/libbun-profile.a
-        DEPENDS
-          ${BUILD_PATH}/libbun-profile.a.gz
-      )
-    elseif(BUILDKITE_ARTIFACT_PATH STREQUAL "libbun-asan.a.gz")
-      add_custom_command(
-        COMMENT
-          "Unpacking libbun-asan.a.gz"
-        VERBATIM COMMAND
-          gunzip libbun-asan.a.gz
-        WORKING_DIRECTORY
-          ${BUILD_PATH}
-        OUTPUT
-          ${BUILD_PATH}/libbun-asan.a
-        DEPENDS
-          ${BUILD_PATH}/libbun-asan.a.gz
-      )
+    if(NOT SEARCH_RC EQUAL 0)
+      message(FATAL_ERROR "buildkite-agent artifact search failed for ${STEP} ${GLOB}: ${SEARCH_ERR}")
+    endif()
+    if(SEARCH_OUT)
+      string(REPLACE "\n" ";" SEARCH_OUT "${SEARCH_OUT}")
+      list(APPEND STEP_ARTIFACTS ${SEARCH_OUT})
     endif()
   endforeach()
 
-  list(APPEND BUILDKITE_JOBS_MATCH ${BUILDKITE_JOB_NAME})
+  if(NOT STEP_ARTIFACTS)
+    list(APPEND BUILDKITE_STEPS_EMPTY ${STEP})
+    continue()
+  endif()
+  list(REMOVE_DUPLICATES STEP_ARTIFACTS)
+  list(APPEND BUILDKITE_STEPS_MATCHED ${STEP})
+
+  foreach(ARTIFACT_PATH ${STEP_ARTIFACTS})
+    # build-cpp uploads libbun-*.a but the consuming step gzipped it first
+    # (upload bandwidth), so the actual artifact on the wire is the .gz.
+    # Search finds the .gz; only the bare .a needs this remap.
+    if(ARTIFACT_PATH STREQUAL "libbun-profile.a")
+      set(ARTIFACT_PATH libbun-profile.a.gz)
+    elseif(ARTIFACT_PATH STREQUAL "libbun-asan.a")
+      set(ARTIFACT_PATH libbun-asan.a.gz)
+    endif()
+
+    add_custom_command(
+      COMMENT "Downloading ${ARTIFACT_PATH} from ${STEP}"
+      VERBATIM COMMAND
+        buildkite-agent artifact download ${ARTIFACT_PATH} . --step ${STEP}
+      WORKING_DIRECTORY ${BUILD_PATH}
+      OUTPUT ${BUILD_PATH}/${ARTIFACT_PATH}
+    )
+
+    if(ARTIFACT_PATH STREQUAL "libbun-profile.a.gz")
+      add_custom_command(
+        COMMENT "Unpacking libbun-profile.a.gz"
+        VERBATIM COMMAND gunzip libbun-profile.a.gz
+        WORKING_DIRECTORY ${BUILD_PATH}
+        OUTPUT ${BUILD_PATH}/libbun-profile.a
+        DEPENDS ${BUILD_PATH}/libbun-profile.a.gz
+      )
+    elseif(ARTIFACT_PATH STREQUAL "libbun-asan.a.gz")
+      add_custom_command(
+        COMMENT "Unpacking libbun-asan.a.gz"
+        VERBATIM COMMAND gunzip libbun-asan.a.gz
+        WORKING_DIRECTORY ${BUILD_PATH}
+        OUTPUT ${BUILD_PATH}/libbun-asan.a
+        DEPENDS ${BUILD_PATH}/libbun-asan.a.gz
+      )
+    endif()
+  endforeach()
 endforeach()
 
-if(BUILDKITE_JOBS_FAILED)
-  list(SORT BUILDKITE_JOBS_FAILED COMPARE STRING)
-  list(JOIN BUILDKITE_JOBS_FAILED " " BUILDKITE_JOBS_FAILED)
-  message(WARNING "The following jobs were found, but failed: ${BUILDKITE_JOBS_FAILED}")
+if(BUILDKITE_STEPS_EMPTY)
+  list(JOIN BUILDKITE_STEPS_EMPTY " " BUILDKITE_STEPS_EMPTY)
+  message(WARNING "No linkable artifacts from: ${BUILDKITE_STEPS_EMPTY}")
 endif()
 
-if(BUILDKITE_JOBS_NOT_FOUND)
-  list(SORT BUILDKITE_JOBS_NOT_FOUND COMPARE STRING)
-  list(JOIN BUILDKITE_JOBS_NOT_FOUND " " BUILDKITE_JOBS_NOT_FOUND)
-  message(WARNING "The following jobs were found, but could not fetch their data: ${BUILDKITE_JOBS_NOT_FOUND}")
-endif()
-
-if(BUILDKITE_JOBS_NO_MATCH)
-  list(SORT BUILDKITE_JOBS_NO_MATCH COMPARE STRING)
-  list(JOIN BUILDKITE_JOBS_NO_MATCH " " BUILDKITE_JOBS_NO_MATCH)
-  message(WARNING "The following jobs were found, but did not match the group ID: ${BUILDKITE_JOBS_NO_MATCH}")
-endif()
-
-if(BUILDKITE_JOBS_NO_ARTIFACTS)
-  list(SORT BUILDKITE_JOBS_NO_ARTIFACTS COMPARE STRING)
-  list(JOIN BUILDKITE_JOBS_NO_ARTIFACTS " " BUILDKITE_JOBS_NO_ARTIFACTS)
-  message(WARNING "The following jobs were found, but had no artifacts: ${BUILDKITE_JOBS_NO_ARTIFACTS}")
-endif()
-
-if(BUILDKITE_JOBS_MATCH)
-  list(SORT BUILDKITE_JOBS_MATCH COMPARE STRING)
-  list(JOIN BUILDKITE_JOBS_MATCH " " BUILDKITE_JOBS_MATCH)
-  message(STATUS "The following jobs were found, and matched the group ID: ${BUILDKITE_JOBS_MATCH}")
-endif()
-
-if(NOT BUILDKITE_JOBS_FAILED AND NOT BUILDKITE_JOBS_NOT_FOUND AND NOT BUILDKITE_JOBS_NO_MATCH AND NOT BUILDKITE_JOBS_NO_ARTIFACTS AND NOT BUILDKITE_JOBS_MATCH)
-  message(FATAL_ERROR "Something went wrong with Buildkite?")
+if(BUILDKITE_STEPS_MATCHED)
+  list(JOIN BUILDKITE_STEPS_MATCHED " " BUILDKITE_STEPS_MATCHED)
+  message(STATUS "Found artifacts from: ${BUILDKITE_STEPS_MATCHED}")
+else()
+  message(FATAL_ERROR "No artifacts found from any of: ${BUILDKITE_SOURCE_STEPS}")
 endif()

--- a/cmake/tools/SetupBuildkite.cmake
+++ b/cmake/tools/SetupBuildkite.cmake
@@ -64,7 +64,7 @@ foreach(STEP ${BUILDKITE_SOURCE_STEPS})
   set(STEP_ARTIFACTS)
   foreach(GLOB ${BUILDKITE_ARTIFACT_GLOBS})
     execute_process(
-      COMMAND buildkite-agent artifact search ${GLOB} --step ${STEP} --format "%p\n" --allow-empty-results
+      COMMAND buildkite-agent artifact search ${GLOB} --step ${STEP} --format "%p\\n" --allow-empty-results
       OUTPUT_VARIABLE SEARCH_OUT
       ERROR_VARIABLE SEARCH_ERR
       RESULT_VARIABLE SEARCH_RC

--- a/cmake/tools/SetupBuildkite.cmake
+++ b/cmake/tools/SetupBuildkite.cmake
@@ -59,15 +59,17 @@ foreach(GZ ${BUILDKITE_GZ_ARTIFACTS})
 endforeach()
 
 # Artifacts are uploaded with subdirectory paths (lolhtml/release/liblolhtml.a,
-# zstd/.../libzstd.a, etc.) and the agent recreates that structure on download.
-# Recurse, but skip CMakeFiles/ (compiler detection) and cache/.
+# mimalloc/CMakeFiles/mimalloc-obj.dir/src/static.c.o, etc.) and the agent
+# recreates that structure on download. Recurse, but skip top-level CMakeFiles/
+# (our own compiler detection) and cache/ — nested CMakeFiles/ are real artifacts.
 
 file(GLOB_RECURSE BUILDKITE_LINK_ARTIFACTS
   "${BUILD_PATH}/*.o"
   "${BUILD_PATH}/*.a"
   "${BUILD_PATH}/*.lib"
 )
-list(FILTER BUILDKITE_LINK_ARTIFACTS EXCLUDE REGEX "/CMakeFiles/|/cache/")
+string(REGEX REPLACE "\\." "\\\\." BUILD_PATH_RE "${BUILD_PATH}")
+list(FILTER BUILDKITE_LINK_ARTIFACTS EXCLUDE REGEX "^${BUILD_PATH_RE}/(CMakeFiles|cache)/")
 
 if(NOT BUILDKITE_LINK_ARTIFACTS)
   message(FATAL_ERROR "No linkable artifacts found in ${BUILD_PATH} after download")

--- a/cmake/tools/SetupBuildkite.cmake
+++ b/cmake/tools/SetupBuildkite.cmake
@@ -20,23 +20,12 @@ if(NOT BUILDKITE_STEP_KEY MATCHES "^(.+)-build-bun$")
 endif()
 set(BUILDKITE_TARGET_KEY ${CMAKE_MATCH_1})
 
-# Clear any stale artifacts from a previous build (macOS agents are not
-# ephemeral). Always download fresh — correctness over saving bandwidth
-# on the rare within-build retry.
+# Download all artifacts from both sibling steps. The agent scopes to the
+# current build via $BUILDKITE_BUILD_ID; --step resolves by key within it.
+# git clean -ffxdq runs between builds (BUILDKITE_GIT_CLEAN_FLAGS), so
+# ${BUILD_PATH} starts clean.
 
 file(MAKE_DIRECTORY ${BUILD_PATH})
-file(GLOB BUILDKITE_STALE_ARTIFACTS
-  "${BUILD_PATH}/*.o"
-  "${BUILD_PATH}/*.a"
-  "${BUILD_PATH}/*.lib"
-  "${BUILD_PATH}/*.gz"
-)
-if(BUILDKITE_STALE_ARTIFACTS)
-  file(REMOVE ${BUILDKITE_STALE_ARTIFACTS})
-endif()
-
-# The agent scopes to the current build via $BUILDKITE_BUILD_ID; --step
-# resolves by key within that build.
 
 foreach(SUFFIX cpp zig)
   set(STEP ${BUILDKITE_TARGET_KEY}-build-${SUFFIX})
@@ -69,16 +58,22 @@ foreach(GZ ${BUILDKITE_GZ_ARTIFACTS})
   endif()
 endforeach()
 
-file(GLOB BUILDKITE_LINK_ARTIFACTS
+# Artifacts are uploaded with subdirectory paths (lolhtml/release/liblolhtml.a,
+# zstd/.../libzstd.a, etc.) and the agent recreates that structure on download.
+# Recurse, but skip CMakeFiles/ (compiler detection) and cache/.
+
+file(GLOB_RECURSE BUILDKITE_LINK_ARTIFACTS
   "${BUILD_PATH}/*.o"
   "${BUILD_PATH}/*.a"
   "${BUILD_PATH}/*.lib"
 )
+list(FILTER BUILDKITE_LINK_ARTIFACTS EXCLUDE REGEX "/CMakeFiles/|/cache/")
+
 if(NOT BUILDKITE_LINK_ARTIFACTS)
   message(FATAL_ERROR "No linkable artifacts found in ${BUILD_PATH} after download")
 endif()
 list(LENGTH BUILDKITE_LINK_ARTIFACTS BUILDKITE_LINK_COUNT)
-message(STATUS "Downloaded ${BUILDKITE_LINK_COUNT} linkable artifacts from ${BUILDKITE_TARGET_KEY}-build-{cpp,zig}")
+message(STATUS "Registered ${BUILDKITE_LINK_COUNT} linkable artifacts from ${BUILDKITE_TARGET_KEY}-build-{cpp,zig}")
 
 # Register a no-op custom command for each linkable artifact so register_command
 # (Globals.cmake) sees them as GENERATED and shims its own output to


### PR DESCRIPTION
## What

Replace HTTP scraping of `buildkite.com/.../builds/<N>` JSON with `buildkite-agent artifact search`.

## Why

All CI link steps are currently failing with:

```
CMake Error at cmake/tools/SetupBuildkite.cmake:78 (message):
  No jobs found: https://buildkite.com/bun/bun/builds/...
```

Buildkite stopped inlining the `jobs` array in the public build JSON — the response now has `jobs: []` while `statistics.jobs_count: 276`. This applies retroactively (old build URLs show the same). The endpoint was undocumented and unversioned.

## How

Step keys follow a fixed `${targetKey}-build-{cpp,zig,bun}` pattern (see `.buildkite/ci.mjs`). The link step is `-build-bun`, so derive the two sibling step keys from `$BUILDKITE_STEP_KEY` and ask the agent directly:

```cmake
buildkite-agent artifact search "*.a" --step <target>-build-cpp --format "%p\n" --allow-empty-results
```

This drops the JSON escape-sequence repair, the `string(JSON)` walk over 276 jobs, and the second per-job artifacts fetch. The download/gunzip `add_custom_command` blocks are unchanged.

Also drops the `if(NOT BUILDKITE)` local-download branch — it scraped the same dead endpoint.