### PR TITLE
Add Scoop and WinGet install options to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ powershell -c "irm bun.sh/install.ps1 | iex"
 # with npm
 npm install -g bun
 
+# with Scoop
+scoop install bun
+
+# with WinGet
+winget install Oven-sh.Bun
+
 # with Homebrew
 brew tap oven-sh/bun
 brew install bun


### PR DESCRIPTION
## Summary
- Add Scoop (`scoop install bun`) install instructions to README
- Add WinGet (`winget install Oven-sh.Bun`) install instructions to README

These are popular Windows package managers that were missing from the install section alongside the existing PowerShell, npm, Homebrew, and Docker options.

Closes #27808