### PR TITLE
fix(cjs): make dynamic import of CJS with __esModule always use module.exports as default

### DIFF
--- a/src/bun.js/bindings/JSCommonJSModule.cpp
+++ b/src/bun.js/bindings/JSCommonJSModule.cpp
@@ -950,32 +950,21 @@ void populateESMExports(
 
     // Bun's interpretation of the "__esModule" annotation:
     //
-    //   - If a "default" export does not exist OR the __esModule annotation is not present, then we
-    //   set the default export to the exports object
+    //   The default export is always set to the module.exports object,
+    //   matching Node.js behavior. The __esModule annotation only affects
+    //   whether __esModule itself appears as a named export.
     //
-    //   - If a "default" export also exists, then we set the default export
-    //   to the value of it (matching Babel behavior)
+    //   When __esModule is present and truthy, we filter it from named
+    //   exports (it is accessible via .default.__esModule instead).
+    //   When __esModule is not present, all properties are exposed as
+    //   named exports.
     //
     // https://stackoverflow.com/questions/50943704/whats-the-purpose-of-object-definepropertyexports-esmodule-value-0
     // https://github.com/nodejs/node/issues/40891
     // https://github.com/evanw/bundler-esm-cjs-tests
     // https://github.com/evanw/esbuild/issues/1591
     // https://github.com/oven-sh/bun/issues/3383
-    //
-    // Note that this interpretation is slightly different
-    //
-    //    -  We do not ignore when "type": "module" or when the file
-    //       extension is ".mjs". Build tools determine that based on the
-    //       caller's behavior, but in a JS runtime, there is only one ModuleNamespaceObject.
-    //
-    //       It would be possible to match the behavior at runtime, but
-    //       it would need further engine changes which do not match the ES Module spec
-    //
-    //   -   We ignore the value of the annotation. We only look for the
-    //       existence of the value being set. This is for performance reasons, but also
-    //       this annotation is meant for tooling and the only usages of setting
-    //       it to something that does NOT evaluate to "true" I could find were in
-    //       unit tests of build tools. Happy to revisit this if users file an issue.
+    // https://github.com/oven-sh/bun/issues/27810
     bool needsToAssignDefault = true;
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -1008,10 +997,8 @@ void populateESMExports(
             if (canPerformFastEnumeration(structure)) {
                 exports->structure()->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
                     auto key = entry.key();
-                    if (key->isSymbol() || key == esModuleMarker)
+                    if (key->isSymbol() || key == esModuleMarker || key == vm.propertyNames->defaultKeyword)
                         return true;
-
-                    needsToAssignDefault = needsToAssignDefault && key != vm.propertyNames->defaultKeyword;
 
                     JSValue value = exports->getDirect(entry.offset());
 
@@ -1028,7 +1015,7 @@ void populateESMExports(
                 }
 
                 for (auto property : properties) {
-                    if (property.isEmpty() || property.isNull() || property == esModuleMarker || property.isPrivateName() || property.isSymbol()) [[unlikely]]
+                    if (property.isEmpty() || property.isNull() || property == esModuleMarker || property == vm.propertyNames->defaultKeyword || property.isPrivateName() || property.isSymbol()) [[unlikely]]
                         continue;
 
                     // ignore constructor
@@ -1060,8 +1047,6 @@ void populateESMExports(
                     }
 
                     exportValues.append(getterResult);
-
-                    needsToAssignDefault = needsToAssignDefault && property != vm.propertyNames->defaultKeyword;
                 }
             }
 

--- a/test/js/bun/resolve/esModule-annotation.test.js
+++ b/test/js/bun/resolve/esModule-annotation.test.js
@@ -24,7 +24,11 @@ describe('without type: "module"', () => {
   });
 
   test("exports.default = true; exports.__esModule = true;", () => {
-    expect(WithoutTypeModuleExportEsModuleAnnotation.default).toBeTrue();
+    // default is always module.exports, matching Node.js behavior
+    expect(WithoutTypeModuleExportEsModuleAnnotation.default).toEqual({
+      default: true,
+      __esModule: true,
+    });
     expect(WithoutTypeModuleExportEsModuleAnnotation.__esModule).toBeUndefined();
   });
 

--- a/test/regression/issue/27810.test.ts
+++ b/test/regression/issue/27810.test.ts
@@ -1,0 +1,141 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/27810
+// When dynamically importing a CJS module with __esModule marker,
+// .default should be module.exports (matching Node.js), not the
+// unwrapped exports.default value.
+
+test("dynamic import of CJS with __esModule gives module.exports as default", async () => {
+  using dir = tempDir("issue-27810", {
+    "config.cjs": `
+      "use strict";
+      Object.defineProperty(exports, "__esModule", { value: true });
+      function loadConfig(phase, dir, opts) {
+        return { phase, dir };
+      }
+      Object.defineProperty(exports, "default", {
+        enumerable: true,
+        get: function() { return loadConfig; }
+      });
+    `,
+    "test.mjs": `
+      const mod = await import('./config.cjs');
+      const results = {
+        defaultType: typeof mod.default,
+        defaultIsObject: typeof mod.default === 'object' && mod.default !== null,
+        defaultDefaultType: typeof mod.default?.default,
+        defaultDefaultIsFunction: typeof mod.default?.default === 'function',
+      };
+      console.log(JSON.stringify(results));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const results = JSON.parse(stdout.trim());
+
+  // .default should be the module.exports object (matching Node.js)
+  expect(results.defaultType).toBe("object");
+  expect(results.defaultIsObject).toBe(true);
+
+  // .default.default should be the loadConfig function
+  expect(results.defaultDefaultType).toBe("function");
+  expect(results.defaultDefaultIsFunction).toBe(true);
+
+  expect(exitCode).toBe(0);
+});
+
+test("static import of CJS with __esModule gives module.exports as default", async () => {
+  using dir = tempDir("issue-27810-static", {
+    "config.cjs": `
+      "use strict";
+      Object.defineProperty(exports, "__esModule", { value: true });
+      function loadConfig(phase, dir) {
+        return { phase, dir };
+      }
+      Object.defineProperty(exports, "default", {
+        enumerable: true,
+        get: function() { return loadConfig; }
+      });
+      exports.otherExport = 42;
+    `,
+    "test.mjs": `
+      import config from './config.cjs';
+      const results = {
+        defaultType: typeof config,
+        defaultIsObject: typeof config === 'object' && config !== null,
+        hasDefault: 'default' in config,
+        defaultDefaultType: typeof config?.default,
+        hasOtherExport: 'otherExport' in config,
+      };
+      console.log(JSON.stringify(results));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const results = JSON.parse(stdout.trim());
+
+  // default import should be the module.exports object
+  expect(results.defaultType).toBe("object");
+  expect(results.defaultIsObject).toBe(true);
+  expect(results.hasDefault).toBe(true);
+  expect(results.defaultDefaultType).toBe("function");
+  expect(results.hasOtherExport).toBe(true);
+
+  expect(exitCode).toBe(0);
+});
+
+test("CJS without __esModule still gives module.exports as default", async () => {
+  using dir = tempDir("issue-27810-no-marker", {
+    "config.cjs": `
+      function loadConfig(phase, dir) {
+        return { phase, dir };
+      }
+      module.exports = loadConfig;
+    `,
+    "test.mjs": `
+      const mod = await import('./config.cjs');
+      const results = {
+        defaultType: typeof mod.default,
+        defaultIsFunction: typeof mod.default === 'function',
+      };
+      console.log(JSON.stringify(results));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const results = JSON.parse(stdout.trim());
+
+  // .default should be the function (which is module.exports)
+  expect(results.defaultType).toBe("function");
+  expect(results.defaultIsFunction).toBe(true);
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fix CJS/ESM interop so that `(await import("./cjs-with-esmodule.cjs")).default` is always `module.exports`, matching Node.js behavior
- Previously, Bun unwrapped the default when `__esModule` was set, using `exports.default` directly (Babel/webpack convention), which differs from Node.js
- This broke Next.js + Turbopack builds that generate code like `(await import(...)).default.default(...)`

### Root cause

In `populateESMExports()` (`src/bun.js/bindings/JSCommonJSModule.cpp`), when `__esModule` was truthy and a `default` property existed on the exports object, the `default` value was used directly as the ESM default export instead of the whole `module.exports` object. Node.js ignores `__esModule` entirely for dynamic imports.

### Change

In the `hasESModuleMarker` code path, skip the `default` property during named export enumeration (same as the non-marker path) so the full `module.exports` object is always assigned as the ESM default.

Closes #27810

## Test plan

- [x] New regression test `test/regression/issue/27810.test.ts` — tests dynamic import, static import, and no-marker cases
- [x] Updated `test/js/bun/resolve/esModule-annotation.test.js` expectations to match new behavior
- [x] Verified regression test fails with system bun (`USE_SYSTEM_BUN=1`) and passes with debug build
- [x] All existing esModule-related tests pass (`esModule.test.ts`, `esm-defineProperty.test.ts`, `plugins.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)