### PR TITLE
fix(node): add missing `hasSubscribers` getter to `TracingChannel`

### DIFF
--- a/src/js/node/diagnostics_channel.ts
+++ b/src/js/node/diagnostics_channel.ts
@@ -255,6 +255,16 @@ class TracingChannel {
   asyncEnd;
   error;
 
+  get hasSubscribers() {
+    return (
+      this.start.hasSubscribers ||
+      this.end.hasSubscribers ||
+      this.asyncStart.hasSubscribers ||
+      this.asyncEnd.hasSubscribers ||
+      this.error.hasSubscribers
+    );
+  }
+
   constructor(nameOrChannels) {
     if (typeof nameOrChannels === "string") {
       this.start = channel(`tracing:${nameOrChannels}:start`);

--- a/test/js/node/test/parallel/test-diagnostics-channel-tracing-channel-has-subscribers.js
+++ b/test/js/node/test/parallel/test-diagnostics-channel-tracing-channel-has-subscribers.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const common = require('../common');
+const dc = require('diagnostics_channel');
+const assert = require('assert');
+
+const handler = common.mustNotCall();
+
+{
+  const handlers = {
+    start: common.mustNotCall()
+  };
+
+  const channel = dc.tracingChannel('test');
+
+  assert.strictEqual(channel.hasSubscribers, false);
+
+  channel.subscribe(handlers);
+  assert.strictEqual(channel.hasSubscribers, true);
+
+  channel.unsubscribe(handlers);
+  assert.strictEqual(channel.hasSubscribers, false);
+
+  channel.start.subscribe(handler);
+  assert.strictEqual(channel.hasSubscribers, true);
+
+  channel.start.unsubscribe(handler);
+  assert.strictEqual(channel.hasSubscribers, false);
+}
+
+{
+  const handlers = {
+    asyncEnd: common.mustNotCall()
+  };
+
+  const channel = dc.tracingChannel('test');
+
+  assert.strictEqual(channel.hasSubscribers, false);
+
+  channel.subscribe(handlers);
+  assert.strictEqual(channel.hasSubscribers, true);
+
+  channel.unsubscribe(handlers);
+  assert.strictEqual(channel.hasSubscribers, false);
+
+  channel.asyncEnd.subscribe(handler);
+  assert.strictEqual(channel.hasSubscribers, true);
+
+  channel.asyncEnd.unsubscribe(handler);
+  assert.strictEqual(channel.hasSubscribers, false);
+}


### PR DESCRIPTION
## Summary
- Add missing `hasSubscribers` getter to the `TracingChannel` class in `node:diagnostics_channel`
- Returns `true` if any of the five sub-channels (`start`, `end`, `asyncStart`, `asyncEnd`, `error`) have subscribers, matching Node.js behavior
- Includes vendored upstream Node.js test

## Test plan
- `bun test test/js/node/test/parallel/test-diagnostics-channel-tracing-channel-has-subscribers.js` — fails on release bun (`hasSubscribers` returns `undefined`), passes with fix
- `bun test test/js/node/diagnostics_channel/diagnostics_channel.test.ts` — no regressions

Closes #27805

Extracted from #27806 (which was used for testing).