### PR TITLE
fix(bundler): include HTML-referenced assets in manifest files array

### DIFF
--- a/src/bundler/LinkerContext.zig
+++ b/src/bundler/LinkerContext.zig
@@ -1698,6 +1698,25 @@ pub const LinkerContext = struct {
             return;
         }
 
+        // HTML files can reference non-JS/CSS assets (favicons, images, etc.)
+        // via .url kind import records. Follow all import records for HTML files
+        // so these assets are marked live and included in the manifest.
+        if (c.parse_graph.input_files.items(.loader)[source_index] == .html) {
+            for (import_records[source_index].slice()) |*record| {
+                if (record.source_index.isValid()) {
+                    c.markFileLiveForTreeShaking(
+                        record.source_index.get(),
+                        side_effects,
+                        parts,
+                        import_records,
+                        entry_point_kinds,
+                        css_reprs,
+                    );
+                }
+            }
+            return;
+        }
+
         for (parts[source_index].slice(), 0..) |part, part_index| {
             var can_be_removed_if_unused = part.can_be_removed_if_unused;
 

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -103,11 +103,11 @@ console.log(favicon);
             "files": [
               {
                 "input": "client.html",
-                "path": "./client-b5m4ng86.js",
+                "path": "./client-sjg7egv9.js",
                 "loader": "js",
                 "isEntry": true,
                 "headers": {
-                  "etag": "Ax71YVYyZQc",
+                  "etag": "14Q4Q7Mm8TM",
                   "content-type": "text/javascript;charset=utf-8"
                 }
               },
@@ -146,6 +146,64 @@ console.log(favicon);
           "
         `);
       },
+    },
+  });
+
+  // Test that non-JS/CSS assets referenced directly in HTML (favicon, images)
+  // are included in the manifest files array (regression test for #27820)
+  itBundled("html-import/html-referenced-assets-in-manifest", {
+    outdir: "out/",
+    files: {
+      "/server.js": `
+import html from "./index.html";
+
+// Verify the favicon asset is in the manifest files array
+const faviconEntry = html.files.find(f => f.path.includes("favicon") && f.path.endsWith(".svg"));
+if (!faviconEntry) {
+  throw new Error("favicon.svg not found in manifest files: " + JSON.stringify(html.files.map(f => f.path)));
+}
+
+console.log(JSON.stringify(html, null, 2));
+`,
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
+    <title>Test</title>
+  </head>
+  <body>
+    <h1>Favicon Test</h1>
+    <script type="module" src="./app.ts"></script>
+  </body>
+</html>`,
+      "/app.ts": `console.log("app loaded");`,
+      "/favicon.svg": `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">T</text></svg>`,
+    },
+    entryPoints: ["/server.js"],
+    target: "bun",
+
+    run: {
+      validate({ stdout }) {
+        const manifest = JSON.parse(stdout);
+        // Verify manifest has a favicon entry with correct metadata
+        const favicon = manifest.files.find((f: any) => f.path.includes("favicon"));
+        expect(favicon).toBeDefined();
+        expect(favicon.loader).toBe("file");
+        expect(favicon.headers["content-type"]).toBe("image/svg+xml");
+      },
+    },
+
+    onAfterBundle(api) {
+      const serverCode = api.readFile("out/server.js");
+      const match = serverCode.match(/__jsonParse\("(.+?)"\)/s);
+      expect(match).not.toBeNull();
+      const manifest = JSON.parse(JSON.parse('"' + match![1] + '"'));
+      // The favicon.svg should be in the files array
+      const faviconFile = manifest.files.find((f: any) => f.path.includes("favicon"));
+      expect(faviconFile).toBeDefined();
+      expect(faviconFile.loader).toBe("file");
+      expect(faviconFile.headers["content-type"]).toBe("image/svg+xml");
     },
   });
 
@@ -229,12 +287,12 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/javascript;charset=utf-8",
-                  "etag": "DLJP98vzFzQ",
+                  "etag": "18fAEMlKmOw",
                 },
                 "input": "home.html",
                 "isEntry": true,
                 "loader": "js",
-                "path": "./home-5f8tg1jd.js",
+                "path": "./home-4688280z.js",
               },
               {
                 "headers": {
@@ -264,12 +322,12 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/javascript;charset=utf-8",
-                  "etag": "t8rrkgPylZo",
+                  "etag": "-3e3gOCTAZg",
                 },
                 "input": "about.html",
                 "isEntry": true,
                 "loader": "js",
-                "path": "./about-e59abjgr.js",
+                "path": "./about-0jghy87f.js",
               },
               {
                 "headers": {


### PR DESCRIPTION
## Summary
- Non-JS/CSS assets referenced directly in HTML tags (`<link rel="icon">`, `<img src>`, etc.) were emitted to disk but missing from the HTML bundle manifest's `files` array, causing `Bun.serve()` to return 404 for those assets
- Added an HTML-specific code path in `markFileLiveForTreeShaking` that follows all import records (not just `.stmt` kind), similar to the existing CSS code path
- Added a regression test that verifies a favicon SVG referenced via `<link rel="icon">` in HTML appears in the manifest with correct metadata

## Root cause
`markFileLiveForTreeShaking` in `LinkerContext.zig` only followed `.stmt` kind imports when processing parts. HTML asset references (favicons, images, etc.) produce `.url` kind import records, which were skipped. This meant the assets were never marked as live, never got entry bits set, and were excluded from the manifest — even though `findReachableFiles` separately emitted them to disk.

## Test plan
- [x] `bun bd test test/bundler/html-import-manifest.test.ts` — all 4 tests pass
- [x] Manual end-to-end verification: built the exact reproduction from the issue, confirmed favicon now returns 200

Closes #27820

🤖 Generated with [Claude Code](https://claude.com/claude-code)