### PR TITLE
fix(windows): use TerminateProcess to prevent NAPI module segfault on exit

### DIFF
--- a/src/Global.zig
+++ b/src/Global.zig
@@ -121,7 +121,25 @@ pub fn exit(code: u32) noreturn {
         .mac => std.c.exit(@bitCast(code)),
         .windows => {
             Bun__onExit();
-            std.os.windows.kernel32.ExitProcess(code);
+            // Use TerminateProcess instead of ExitProcess to skip
+            // DLL_PROCESS_DETACH notifications. ExitProcess terminates all
+            // threads first, then calls DllMain(DLL_PROCESS_DETACH) for every
+            // loaded DLL. Native addons (NAPI modules such as skia-canvas)
+            // can crash during this phase because their worker threads have
+            // been killed and GC-dependent buffer finalizers haven't run.
+            // TerminateProcess skips DLL cleanup entirely, matching the
+            // behavior on Linux where quick_exit() also skips library
+            // teardown. Bun's own cleanup has already run via Bun__onExit().
+            const rc = std.os.windows.kernel32.TerminateProcess(
+                std.os.windows.kernel32.GetCurrentProcess(),
+                code,
+            );
+            // TerminateProcess should not return on the current process, but
+            // if it somehow fails, fall back to ExitProcess.
+            if (rc == 0) {
+                std.os.windows.kernel32.ExitProcess(code);
+            }
+            unreachable;
         },
         else => {
             if (Environment.enable_asan) {


### PR DESCRIPTION
## Summary

- On Windows, replace `ExitProcess()` with `TerminateProcess()` in the process exit path to prevent segfaults caused by `DLL_PROCESS_DETACH` cleanup in NAPI native addon DLLs

## Root Cause

When `ExitProcess()` is called on Windows, it:
1. Terminates all threads except the calling thread
2. Calls `DllMain(DLL_PROCESS_DETACH)` for every loaded DLL

NAPI modules like `skia-canvas` can crash during step 2 because:
- Their worker threads have been forcibly killed in step 1
- GC-dependent buffer finalizers (from `napi_create_external_buffer` / `napi_create_external_arraybuffer`) haven't run, so native resources are in an inconsistent state when the DLL's cleanup code tries to access them
- Unlike Node.js, Bun does not destroy the JS VM on exit (no full GC pass), so these finalizers never execute before `ExitProcess`

## Fix

`TerminateProcess()` skips `DLL_PROCESS_DETACH` entirely. This is safe because Bun's own cleanup has already completed via `Bun__onExit()` (NAPI env cleanup hooks, output flushing, stdio restore) before reaching this point. This matches the behavior on Linux where `quick_exit()` also skips library teardown.

## Test Plan

- [x] Windows cross-compilation passes (`bun run zig:check-windows` — all 4 targets: x86_64/aarch64 × debug/release)
- [ ] Verify with skia-canvas on Windows: `bun add skia-canvas --trust`, create canvas, call `toBuffer()`, `process.exit(0)` — should exit cleanly without segfault
- [ ] Existing NAPI tests pass on Windows CI

Closes #27828

🤖 Generated with [Claude Code](https://claude.com/claude-code)