### PR TITLE
fix(release): use GitHub API instead of CDN for asset checksum computation

### DIFF
--- a/packages/bun-release/scripts/upload-assets.ts
+++ b/packages/bun-release/scripts/upload-assets.ts
@@ -1,7 +1,6 @@
 import { confirm, exit, log, stdin, warn } from "../src/console";
-import { fetch } from "../src/fetch";
 import { basename, blob, hash, join, rm, tmp, write } from "../src/fs";
-import { getRelease, uploadAsset } from "../src/github";
+import { downloadAssetContent, getRelease, uploadAsset } from "../src/github";
 import { spawn } from "../src/spawn";
 
 const [tag, ...paths] = process.argv.slice(2);
@@ -18,12 +17,11 @@ await confirm();
 
 log("Hashing assets...\n");
 const existing: Map<string, string> = new Map();
-for (const { name, browser_download_url } of assets) {
+for (const { name, id } of assets) {
   if (name.startsWith("SHASUMS256.txt")) {
     continue;
   }
-  const response = await fetch(browser_download_url);
-  const buffer = Buffer.from(await response.arrayBuffer());
+  const buffer = await downloadAssetContent(id);
   existing.set(name, await hash(buffer));
 }
 const updated: Map<string, string> = new Map();

--- a/packages/bun-release/src/github.ts
+++ b/packages/bun-release/src/github.ts
@@ -69,11 +69,18 @@ export async function downloadAssetContent(assetId: number): Promise<Buffer> {
   const url = `https://api.github.com/repos/${owner}/${repo}/releases/assets/${assetId}`;
   const token = process.env["GITHUB_TOKEN"];
   const response = await fetch(url, {
+    assert: false,
     headers: {
       Accept: "application/octet-stream",
       ...(token ? { Authorization: `token ${token}` } : {}),
     },
   });
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `Failed to download asset ${assetId}: ${response.status} ${response.statusText}${body ? ` - ${body}` : ""}`,
+    );
+  }
   return Buffer.from(await response.arrayBuffer());
 }
 

--- a/packages/bun-release/src/github.ts
+++ b/packages/bun-release/src/github.ts
@@ -65,14 +65,26 @@ export async function uploadAsset(tag: string, name: string, blob: Blob) {
   });
 }
 
+export async function downloadAssetContent(assetId: number): Promise<Buffer> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/releases/assets/${assetId}`;
+  const token = process.env["GITHUB_TOKEN"];
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/octet-stream",
+      ...(token ? { Authorization: `token ${token}` } : {}),
+    },
+  });
+  return Buffer.from(await response.arrayBuffer());
+}
+
 export async function downloadAsset(tag: string, name: string): Promise<Blob> {
   const release = await getRelease(tag);
   const asset = release.assets.find(asset => asset.name === name);
   if (!asset) {
     throw new Error(`Asset not found: ${name}`);
   }
-  const response = await fetch(asset.browser_download_url);
-  return response.blob();
+  const buffer = await downloadAssetContent(asset.id);
+  return new Blob([buffer]);
 }
 
 export async function getSha(tag: string, format?: "short" | "long") {


### PR DESCRIPTION
## Summary

- Fix canary release SHASUMS256.txt containing incorrect checksums by downloading assets via the GitHub API instead of the CDN
- `upload-assets.ts` was fetching archives from `browser_download_url` (GitHub CDN) to compute SHA256 hashes, but the CDN can serve stale/cached content when canary assets are overwritten via `--clobber`
- Switch to the GitHub API endpoint (`GET /repos/{owner}/{repo}/releases/assets/{id}` with `Accept: application/octet-stream`) which bypasses CDN caching and returns the actual current asset content

## Test plan

- [ ] Verify next canary release has matching checksums between `SHASUMS256.txt` and actual archive files
- [ ] Verify `sha256sum -c SHASUMS256.txt` passes for downloaded canary archives

Fixes #27830

🤖 Generated with [Claude Code](https://claude.com/claude-code)