### PR TITLE
docs: Correct CREATE TABLE statement for SQLite Bun documentation

### DIFF
--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -306,7 +306,7 @@ Internally, this calls [`sqlite3_reset`](https://www.sqlite.org/capi3ref.html#sq
 Use `.run()` to run a query and get back an object with execution metadata. This is useful for schema-modifying queries (e.g. `CREATE TABLE`) or bulk write operations.
 
 ```ts db.ts icon="/icons/typescript.svg" highlight={2}
-const query = db.query(`create table foo;`);
+const query = db.query(`create table foo (f1 integer primary key, f2 text)`);
 query.run();
 ```
 
@@ -448,10 +448,10 @@ const results = query.all("hello", "goodbye");
 
 ```txt
 [
-	{
-		"?1": "hello",
-		"?2": "goodbye",
-	},
+ {
+  "?1": "hello",
+  "?2": "goodbye",
+ },
 ];
 ```
 

--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -448,10 +448,10 @@ const results = query.all("hello", "goodbye");
 
 ```txt
 [
- {
-  "?1": "hello",
-  "?2": "goodbye",
- },
+  {
+    "?1": "hello",
+    "?2": "goodbye",
+  },
 ];
 ```
 


### PR DESCRIPTION
### What does this PR do?
I corrected the CREATE TABLE statement for the SQLite - Bun documentation section and the indentation of a section of the file. This PR closes #12119
