### PR TITLE
fix(install): deduplicate transitive deps when upgrading root package

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -46,7 +46,7 @@ fn getTlsHostname(client: *const HTTPClient, allowProxyUrl: bool) []const u8 {
     }
     // Prefer the explicit TLS server_name (e.g. from Node.js servername option)
     if (client.tls_props) |props| {
-        if (props.server_name) |sn| {
+        if (props.get().server_name) |sn| {
             const sn_slice = bun.sliceTo(sn, 0);
             if (sn_slice.len > 0) return sn_slice;
         }

--- a/src/install/lockfile/Tree.zig
+++ b/src/install/lockfile/Tree.zig
@@ -52,6 +52,11 @@ pub const invalid_id: Id = std.math.maxInt(Id);
 pub const HoistDependencyResult = union(enum) {
     dependency_loop,
     hoisted,
+    /// Hoist and update the resolution to the given package ID.
+    /// Used when a dependency's version range is satisfied by an existing
+    /// resolution at a higher level (e.g., after `bun add pkg@latest`
+    /// updates a root dep but transitive deps still reference old versions).
+    hoist_with_resolve: PackageID,
     resolve: PackageID,
     resolve_replace: ResolveReplace,
     resolve_later,
@@ -581,6 +586,10 @@ pub fn processSubtree(
 
         switch (hoisted) {
             .dependency_loop, .hoisted => continue,
+            .hoist_with_resolve => |new_res_id| {
+                builder.resolutions[dep_id] = new_res_id;
+                continue;
+            },
 
             .resolve => |res_id| {
                 bun.debugAssert(pkg_id == invalid_package_id);
@@ -732,6 +741,21 @@ fn hoistDependency(
             if (builder.lockfile.isWorkspaceRootDependency(dep_id)) {
                 // TODO: warning about peer dependency version mismatch
                 return .hoisted; // 1
+            }
+        }
+
+        // For non-peer dependencies: if the existing resolution satisfies
+        // the dependency's version range, deduplicate by hoisting and
+        // updating the resolution to match. This handles the case where
+        // a root package was updated (e.g., `bun add pkg@latest`) but
+        // transitive deps still reference old resolutions in the lockfile.
+        if (!dependency.behavior.isPeer() and dependency.version.tag == .npm) {
+            const resolution: Resolution = builder.lockfile.packages.items(.resolution)[res_id];
+            if (resolution.tag == .npm) {
+                const version = dependency.version.value.npm.version;
+                if (version.satisfies(resolution.value.npm.version, builder.buf(), builder.buf())) {
+                    return .{ .hoist_with_resolve = res_id }; // 1
+                }
             }
         }
 

--- a/src/install/lockfile/Tree.zig
+++ b/src/install/lockfile/Tree.zig
@@ -752,9 +752,13 @@ fn hoistDependency(
         if (!dependency.behavior.isPeer() and dependency.version.tag == .npm) {
             const resolution: Resolution = builder.lockfile.packages.items(.resolution)[res_id];
             if (resolution.tag == .npm) {
-                const version = dependency.version.value.npm.version;
-                if (version.satisfies(resolution.value.npm.version, builder.buf(), builder.buf())) {
-                    return .{ .hoist_with_resolve = res_id }; // 1
+                const dep_real_name = dependency.version.value.npm.name;
+                const res_pkg_name = builder.lockfile.packages.items(.name)[res_id];
+                if (dep_real_name.eql(res_pkg_name, builder.buf(), builder.buf())) {
+                    const version = dependency.version.value.npm.version;
+                    if (version.satisfies(resolution.value.npm.version, builder.buf(), builder.buf())) {
+                        return .{ .hoist_with_resolve = res_id };
+                    }
                 }
             }
         }

--- a/test/regression/issue/27839.test.ts
+++ b/test/regression/issue/27839.test.ts
@@ -1,0 +1,222 @@
+import { spawn } from "bun";
+import { expect, test } from "bun:test";
+import { exists } from "fs/promises";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// Helper to create a minimal valid npm tarball in memory
+function createTarball(name: string, version: string, extraFields?: Record<string, unknown>): Uint8Array {
+  const packageJson = JSON.stringify({
+    name,
+    version,
+    ...extraFields,
+  });
+
+  const files: Record<string, string> = {
+    "package/package.json": packageJson,
+    "package/index.js": `module.exports = "${name}@${version}";`,
+  };
+
+  const entries: Buffer[] = [];
+  let tarSize = 0;
+
+  for (const [path, content] of Object.entries(files)) {
+    const contentBuf = Buffer.from(content, "utf8");
+    const blockSize = Math.ceil((contentBuf.length + 512) / 512) * 512;
+    const entry = Buffer.alloc(blockSize);
+
+    // Write tar header
+    entry.write(path, 0, Math.min(path.length, 99));
+    entry.write("0000644", 100, 7); // mode
+    entry.write("0000000", 108, 7); // uid
+    entry.write("0000000", 116, 7); // gid
+    entry.write(contentBuf.length.toString(8).padStart(11, "0"), 124, 11); // size
+    entry.write("00000000000", 136, 11); // mtime
+    entry.write("        ", 148, 8); // checksum space
+    entry.write("0", 156, 1); // type flag
+
+    // Calculate checksum
+    let checksum = 0;
+    for (let i = 0; i < 512; i++) {
+      checksum += i >= 148 && i < 156 ? 32 : entry[i];
+    }
+    entry.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148, 8);
+
+    // Write content
+    contentBuf.copy(entry, 512);
+    entries.push(entry);
+    tarSize += blockSize;
+  }
+
+  // Add end-of-archive marker
+  entries.push(Buffer.alloc(1024));
+  tarSize += 1024;
+
+  return Bun.gzipSync(Buffer.concat(entries, tarSize));
+}
+
+// Pre-create tarballs
+const tarballs: Record<string, Uint8Array> = {
+  "shared-dep-1.0.0": createTarball("shared-dep", "1.0.0"),
+  "shared-dep-1.1.0": createTarball("shared-dep", "1.1.0"),
+  "shared-dep-2.0.0": createTarball("shared-dep", "2.0.0"),
+  "consumer-1.0.0": createTarball("consumer", "1.0.0", {
+    dependencies: { "shared-dep": "^1.0.0" },
+  }),
+};
+
+// Package metadata for the mock registry
+const packages: Record<string, object> = {
+  "shared-dep": {
+    name: "shared-dep",
+    "dist-tags": { latest: "2.0.0" },
+    versions: {
+      "1.0.0": {
+        name: "shared-dep",
+        version: "1.0.0",
+        dist: { tarball: "REGISTRY_URL/shared-dep/-/shared-dep-1.0.0.tgz" },
+      },
+      "1.1.0": {
+        name: "shared-dep",
+        version: "1.1.0",
+        dist: { tarball: "REGISTRY_URL/shared-dep/-/shared-dep-1.1.0.tgz" },
+      },
+      "2.0.0": {
+        name: "shared-dep",
+        version: "2.0.0",
+        dist: { tarball: "REGISTRY_URL/shared-dep/-/shared-dep-2.0.0.tgz" },
+      },
+    },
+  },
+  consumer: {
+    name: "consumer",
+    "dist-tags": { latest: "1.0.0" },
+    versions: {
+      "1.0.0": {
+        name: "consumer",
+        version: "1.0.0",
+        dependencies: { "shared-dep": "^1.0.0" },
+        dist: { tarball: "REGISTRY_URL/consumer/-/consumer-1.0.0.tgz" },
+      },
+    },
+  },
+};
+
+function createMockRegistry() {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      const path = url.pathname;
+
+      // Serve tarballs
+      if (path.endsWith(".tgz")) {
+        const filename = path.split("/").pop()!.replace(".tgz", "");
+        const tarball = tarballs[filename];
+        if (tarball) {
+          return new Response(tarball, {
+            headers: { "content-type": "application/octet-stream" },
+          });
+        }
+        return new Response("Not found", { status: 404 });
+      }
+
+      // Serve package metadata
+      const pkgName = path.slice(1); // Remove leading /
+      const pkg = packages[pkgName];
+      if (pkg) {
+        const registryUrl = `http://localhost:${server.port}`;
+        const body = JSON.stringify(pkg).replaceAll("REGISTRY_URL", registryUrl);
+        return new Response(body, {
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      return new Response("Not found", { status: 404 });
+    },
+  });
+  return server;
+}
+
+test("bun add should deduplicate transitive deps when upgrading a root package (#27839)", async () => {
+  using server = createMockRegistry();
+  const registryUrl = `http://localhost:${server.port}`;
+
+  using dir = tempDir("issue-27839", {
+    "bunfig.toml": `[install]\ncache = false\nregistry = "${registryUrl}/"\nsaveTextLockfile = false\n`,
+    "package.json": JSON.stringify({
+      name: "test-project",
+      dependencies: {
+        "shared-dep": "1.0.0",
+        consumer: "1.0.0",
+      },
+    }),
+  });
+
+  const packageDir = String(dir);
+  const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache") };
+
+  // Step 1: Initial install
+  await using proc1 = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stderr: "pipe",
+    stdout: "pipe",
+    env,
+  });
+
+  const [stderr1, stdout1] = await Promise.all([proc1.stderr.text(), proc1.stdout.text()]);
+  expect(stderr1).toContain("Saved lockfile");
+  expect(stderr1).not.toContain("error:");
+  expect(await proc1.exited).toBe(0);
+
+  // shared-dep@1.0.0 should be hoisted (no nested copy)
+  expect(await Bun.file(join(packageDir, "node_modules", "shared-dep", "package.json")).json()).toMatchObject({
+    version: "1.0.0",
+  });
+  expect(await exists(join(packageDir, "node_modules", "consumer", "node_modules", "shared-dep"))).toBe(false);
+
+  // Step 2: Upgrade shared-dep to 1.1.0 (still satisfies ^1.0.0)
+  await using proc2 = spawn({
+    cmd: [bunExe(), "add", "shared-dep@1.1.0"],
+    cwd: packageDir,
+    stderr: "pipe",
+    stdout: "pipe",
+    env,
+  });
+
+  const [stderr2, stdout2] = await Promise.all([proc2.stderr.text(), proc2.stdout.text()]);
+  expect(stderr2).toContain("Saved lockfile");
+  expect(stderr2).not.toContain("error:");
+  expect(await proc2.exited).toBe(0);
+
+  // Root should have the new version
+  expect(await Bun.file(join(packageDir, "node_modules", "shared-dep", "package.json")).json()).toMatchObject({
+    version: "1.1.0",
+  });
+
+  // KEY ASSERTION: No nested copy should exist since 1.1.0 satisfies ^1.0.0
+  expect(await exists(join(packageDir, "node_modules", "consumer", "node_modules", "shared-dep"))).toBe(false);
+
+  // Step 3: Upgrade shared-dep to 2.0.0 (does NOT satisfy ^1.0.0)
+  await using proc3 = spawn({
+    cmd: [bunExe(), "add", "shared-dep@2.0.0"],
+    cwd: packageDir,
+    stderr: "pipe",
+    stdout: "pipe",
+    env,
+  });
+
+  const [stderr3, stdout3] = await Promise.all([proc3.stderr.text(), proc3.stdout.text()]);
+  expect(stderr3).toContain("Saved lockfile");
+  expect(stderr3).not.toContain("error:");
+  expect(await proc3.exited).toBe(0);
+
+  // Root should have 2.0.0
+  expect(await Bun.file(join(packageDir, "node_modules", "shared-dep", "package.json")).json()).toMatchObject({
+    version: "2.0.0",
+  });
+
+  // Nested copy SHOULD exist since 2.0.0 does NOT satisfy ^1.0.0
+  expect(await exists(join(packageDir, "node_modules", "consumer", "node_modules", "shared-dep"))).toBe(true);
+});

--- a/test/regression/issue/27839.test.ts
+++ b/test/regression/issue/27839.test.ts
@@ -219,4 +219,7 @@ test("bun add should deduplicate transitive deps when upgrading a root package (
 
   // Nested copy SHOULD exist since 2.0.0 does NOT satisfy ^1.0.0
   expect(await exists(join(packageDir, "node_modules", "consumer", "node_modules", "shared-dep"))).toBe(true);
+  expect(
+    await Bun.file(join(packageDir, "node_modules", "consumer", "node_modules", "shared-dep", "package.json")).json(),
+  ).toMatchObject({ version: "1.1.0" });
 });

--- a/test/regression/issue/27839.test.ts
+++ b/test/regression/issue/27839.test.ts
@@ -165,10 +165,10 @@ test("bun add should deduplicate transitive deps when upgrading a root package (
     env,
   });
 
-  const [stderr1, stdout1] = await Promise.all([proc1.stderr.text(), proc1.stdout.text()]);
+  const [stdout1, stderr1, exitCode1] = await Promise.all([proc1.stdout.text(), proc1.stderr.text(), proc1.exited]);
   expect(stderr1).toContain("Saved lockfile");
   expect(stderr1).not.toContain("error:");
-  expect(await proc1.exited).toBe(0);
+  expect(exitCode1).toBe(0);
 
   // shared-dep@1.0.0 should be hoisted (no nested copy)
   expect(await Bun.file(join(packageDir, "node_modules", "shared-dep", "package.json")).json()).toMatchObject({
@@ -185,10 +185,10 @@ test("bun add should deduplicate transitive deps when upgrading a root package (
     env,
   });
 
-  const [stderr2, stdout2] = await Promise.all([proc2.stderr.text(), proc2.stdout.text()]);
+  const [stdout2, stderr2, exitCode2] = await Promise.all([proc2.stdout.text(), proc2.stderr.text(), proc2.exited]);
   expect(stderr2).toContain("Saved lockfile");
   expect(stderr2).not.toContain("error:");
-  expect(await proc2.exited).toBe(0);
+  expect(exitCode2).toBe(0);
 
   // Root should have the new version
   expect(await Bun.file(join(packageDir, "node_modules", "shared-dep", "package.json")).json()).toMatchObject({
@@ -207,10 +207,10 @@ test("bun add should deduplicate transitive deps when upgrading a root package (
     env,
   });
 
-  const [stderr3, stdout3] = await Promise.all([proc3.stderr.text(), proc3.stdout.text()]);
+  const [stdout3, stderr3, exitCode3] = await Promise.all([proc3.stdout.text(), proc3.stderr.text(), proc3.exited]);
   expect(stderr3).toContain("Saved lockfile");
   expect(stderr3).not.toContain("error:");
-  expect(await proc3.exited).toBe(0);
+  expect(exitCode3).toBe(0);
 
   // Root should have 2.0.0
   expect(await Bun.file(join(packageDir, "node_modules", "shared-dep", "package.json")).json()).toMatchObject({


### PR DESCRIPTION
## Summary

- Fix `bun add pkg@latest` not deduplicating transitive dependencies whose semver range is satisfied by the upgraded version
- Extend tree hoisting logic to check version range compatibility for non-peer npm dependencies (matching existing peer dep behavior)
- Add `hoist_with_resolve` variant to update the lockfile resolution when deduplicating

Closes #27839

## Root Cause

When `bun add @tanstack/react-query@latest` upgrades the root package from 5.90.10 to 5.90.21, a new package ID is created. Transitive dependencies (e.g., `@tanstack/react-query@^5` from `@clo/react-mutation`) still resolve to the old package ID from the lockfile. The tree builder's hoisting check only compared exact package IDs (`res_id == package_id`), so the old and new versions were treated as different packages, creating a redundant nested copy.

The fix adds a semver range compatibility check after the existing peer dependency logic in `hoistDependency()`. When a non-peer dependency's npm version range is satisfied by an already-hoisted resolution at a higher tree level, the dependency is deduplicated and its resolution is updated.

## Test plan

- [x] New regression test `test/regression/issue/27839.test.ts` - verifies:
  - Compatible upgrade (1.0.0 → 1.1.0 with `^1.0.0` range): no nested duplicate
  - Incompatible upgrade (1.0.0 → 2.0.0 with `^1.0.0` range): nested copy correctly preserved
- [x] Test fails with system bun (`USE_SYSTEM_BUN=1`), passes with debug build
- [x] Manual reproduction with original issue steps (`@tanstack/react-query` + `@clo/react-mutation`) confirmed fixed


🤖 Generated with [Claude Code](https://claude.com/claude-code)