### PR TITLE
fix(install): deduplicate isolated store entries when peer deps resolve to same-named packages

### DIFF
--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -394,9 +394,6 @@ pub fn installIsolatedPackages(
         var dedupe: std.AutoHashMapUnmanaged(PackageID, std.ArrayListUnmanaged(DedupeInfo)) = .empty;
         defer dedupe.deinit(lockfile.allocator);
 
-        var res_fmt_buf: std.array_list.Managed(u8) = .init(lockfile.allocator);
-        defer res_fmt_buf.deinit();
-
         const nodes_slice = nodes.slice();
         const node_pkg_ids = nodes_slice.items(.pkg_id);
         const node_dep_ids = nodes_slice.items(.dep_id);
@@ -495,10 +492,9 @@ pub fn installIsolatedPackages(
                 for (peers.slice()) |peer_ids| {
                     const pkg_name = pkg_names[peer_ids.pkg_id];
                     hasher.update(pkg_name.slice(string_buf));
-                    const pkg_res = pkg_resolutions[peer_ids.pkg_id];
-                    res_fmt_buf.clearRetainingCapacity();
-                    try res_fmt_buf.writer().print("{f}", .{pkg_res.fmt(string_buf, .posix)});
-                    hasher.update(res_fmt_buf.items);
+                    // Only hash peer names, not their resolved versions. This
+                    // ensures a stable store path when workspaces resolve the
+                    // same peer dependency to different compatible versions.
                 }
                 break :peer_hash .from(hasher.final());
             };

--- a/src/install/isolated_install/Store.zig
+++ b/src/install/isolated_install/Store.zig
@@ -418,8 +418,17 @@ pub const Store = struct {
                 pkg_names: []const String,
 
                 pub fn eql(ctx: *const OrderedArraySetCtx, l_item: TransitivePeer, r_item: TransitivePeer) bool {
-                    _ = ctx;
-                    return l_item.pkg_id == r_item.pkg_id;
+                    if (l_item.pkg_id == r_item.pkg_id) return true;
+                    // Compare by package name rather than pkg_id so that peers
+                    // resolving to different versions of the same package (e.g.
+                    // effect@3.19.15 vs effect@3.19.19) are treated as equivalent
+                    // for deduplication. This prevents duplicate store entries for
+                    // the same package version when workspaces use different but
+                    // compatible version specifiers for peer dependencies.
+                    const pkg_names = ctx.pkg_names;
+                    const l_pkg_name = pkg_names[l_item.pkg_id];
+                    const r_pkg_name = pkg_names[r_item.pkg_id];
+                    return l_pkg_name.order(&r_pkg_name, ctx.string_buf, ctx.string_buf) == .eq;
                 }
 
                 pub fn order(ctx: *const OrderedArraySetCtx, l: TransitivePeer, r: TransitivePeer) std.math.Order {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -467,23 +467,64 @@ describe("isolated workspaces", () => {
   });
 });
 
+// Regression test for https://github.com/oven-sh/bun/issues/27847
+// When workspaces resolve the same peer dependency to different compatible versions,
+// the package depending on that peer should be deduplicated into a single store entry
+// instead of creating separate entries with different peer hashes.
+test("workspaces with different peer version resolutions deduplicate store entries", async () => {
+  const { packageDir } = await registry.createTestDir({
+    bunfigOpts: { linker: "isolated" },
+    files: {
+      "package.json": JSON.stringify({
+        name: "workspace-peer-dedup",
+        workspaces: ["packages/*"],
+      }),
+      // pkg-1 depends on no-deps@1.0.0 (peer dep resolved to 1.0.0)
+      "packages/pkg1/package.json": JSON.stringify({
+        name: "pkg1",
+        dependencies: {
+          "one-optional-peer-dep": "1.0.1",
+          "no-deps": "1.0.0",
+        },
+      }),
+      // pkg-2 depends on no-deps@1.0.1 (peer dep resolved to different version)
+      "packages/pkg2/package.json": JSON.stringify({
+        name: "pkg2",
+        dependencies: {
+          "one-optional-peer-dep": "1.0.1",
+          "no-deps": "1.0.1",
+        },
+      }),
+    },
+  });
+
+  await runBunInstall(bunEnv, packageDir);
+
+  const bunDir = await readdirSorted(join(packageDir, "node_modules/.bun"));
+  // There should be only ONE entry for one-optional-peer-dep, not two with different hashes.
+  // Both no-deps@1.0.0 and no-deps@1.0.1 satisfy the peer dep range (^1.0.0),
+  // so one-optional-peer-dep@1.0.1 should be deduplicated.
+  const peerDepEntries = bunDir.filter((e: string) => e.startsWith("one-optional-peer-dep@"));
+  expect(peerDepEntries).toHaveLength(1);
+});
+
 describe("optional peers", () => {
   const tests = [
     // non-optional versions
     {
       name: "non-optional transitive only",
       deps: [{ "one-optional-peer-dep": "1.0.1" }, { "one-optional-peer-dep": "1.0.1" }],
-      expected: ["no-deps@1.1.0", "node_modules", "one-optional-peer-dep@1.0.1+7ff199101204a65d"],
+      expected: ["no-deps@1.1.0", "node_modules", "one-optional-peer-dep@1.0.1+472ae378b15ad7b8"],
     },
     {
       name: "non-optional direct pkg1",
       deps: [{ "one-optional-peer-dep": "1.0.1", "no-deps": "1.0.1" }, { "one-optional-peer-dep": "1.0.1" }],
-      expected: ["no-deps@1.0.1", "node_modules", "one-optional-peer-dep@1.0.1+f8a822eca018d0a1"],
+      expected: ["no-deps@1.0.1", "node_modules", "one-optional-peer-dep@1.0.1+472ae378b15ad7b8"],
     },
     {
       name: "non-optional direct pkg2",
       deps: [{ "one-optional-peer-dep": "1.0.1" }, { "one-optional-peer-dep": "1.0.1", "no-deps": "1.0.1" }],
-      expected: ["no-deps@1.0.1", "node_modules", "one-optional-peer-dep@1.0.1+f8a822eca018d0a1"],
+      expected: ["no-deps@1.0.1", "node_modules", "one-optional-peer-dep@1.0.1+472ae378b15ad7b8"],
     },
     // optional versions
     {
@@ -494,12 +535,12 @@ describe("optional peers", () => {
     {
       name: "optional direct pkg1",
       deps: [{ "one-optional-peer-dep": "1.0.2", "no-deps": "1.0.1" }, { "one-optional-peer-dep": "1.0.2" }],
-      expected: ["no-deps@1.0.1", "node_modules", "one-optional-peer-dep@1.0.2+f8a822eca018d0a1"],
+      expected: ["no-deps@1.0.1", "node_modules", "one-optional-peer-dep@1.0.2+472ae378b15ad7b8"],
     },
     {
       name: "optional direct pkg2",
       deps: [{ "one-optional-peer-dep": "1.0.2" }, { "one-optional-peer-dep": "1.0.2", "no-deps": "1.0.1" }],
-      expected: ["no-deps@1.0.1", "node_modules", "one-optional-peer-dep@1.0.2+f8a822eca018d0a1"],
+      expected: ["no-deps@1.0.1", "node_modules", "one-optional-peer-dep@1.0.2+472ae378b15ad7b8"],
     },
   ];
 


### PR DESCRIPTION
## Summary

- Fix workspace isolated installs creating duplicate store entries for the same package version when peer dependencies resolve to different compatible versions
- Change `TransitivePeer.eql` to compare by package name instead of `pkg_id` for deduplication
- Change peer hash computation to hash only peer names (not resolved versions) for stable store paths

## Problem

When two workspace packages depend on the same package (e.g. `@effect-atom/atom@0.4.13`) but specify different versions of a peer dependency (e.g. `effect@3.19.15` vs `effect@3.19.19`), Bun's isolated install mode creates two separate store entries with different peer hashes:

```
@effect-atom+atom@0.4.13+549b804b132c4989
@effect-atom+atom@0.4.13+4af35f8644fa81d5
```

The package files are byte-identical, but TypeScript sees them as different module identities, breaking nominal type compatibility.

## Root Cause

The deduplication logic in `isolated_install.zig` compared transitive peers by `pkg_id`. When workspaces resolve the same peer dependency name to different versions (both satisfying the peer range), the `pkg_id` values differ, causing deduplication to fail.

## Fix

1. **`Store.zig`**: Changed `TransitivePeer.eql` to compare by package name string instead of `pkg_id`, so peers resolving to different versions of the same package are treated as equivalent for deduplication.

2. **`isolated_install.zig`**: Changed the peer hash computation to hash only peer dependency names (not their resolved versions), ensuring a stable store path regardless of which specific compatible version was resolved.

## Test plan

- [x] Manual test: created workspace with `no-deps@1.0.0` (exact) and `no-deps@1.0.1` (exact) in two workspace packages, both depending on `one-optional-peer-dep@1.0.1` (which has `peerDependencies: {"no-deps": "^1.0.0"}`). Verified only 1 store entry is created (was 2 before fix).
- [x] Updated hardcoded peer hash expectations in existing `isolated-install.test.ts` tests
- [x] Added regression test for #27847

Closes #27847

🤖 Generated with [Claude Code](https://claude.com/claude-code)