### PR TITLE
fix(blob): don't set size to 0 for non-seekable files in resolveSize()

### DIFF
--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -3191,6 +3191,11 @@ pub fn resolveSize(this: *Blob) void {
                 this.size = store_size -| offset;
                 return;
             }
+
+            // For non-seekable files (pipes, FIFOs) or files where stat
+            // failed, the size is genuinely unknown — leave it as max_size
+            // so that stream readers don't treat it as an empty file.
+            return;
         }
 
         this.size = 0;

--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -3192,10 +3192,12 @@ pub fn resolveSize(this: *Blob) void {
                 return;
             }
 
-            // For non-seekable files (pipes, FIFOs) or files where stat
-            // failed, the size is genuinely unknown — leave it as max_size
-            // so that stream readers don't treat it as an empty file.
-            return;
+            // For non-seekable files (pipes, FIFOs), the size is genuinely
+            // unknown — leave it as max_size so that stream readers don't
+            // treat it as an empty file.
+            if (store.data.file.seekable != null and store.data.file.seekable.? == false) {
+                return;
+            }
         }
 
         this.size = 0;

--- a/test/regression/issue/27849.test.ts
+++ b/test/regression/issue/27849.test.ts
@@ -6,32 +6,30 @@ import { bunEnv, bunExe } from "harness";
 // the read to return empty on Linux because resolveSize()
 // incorrectly set the blob size to 0 for pipes.
 
-test("Bun.stdin.stream() works after Bun.stdin.exists()", async () => {
+async function runStdinTest(script: string, input = "hello from pipe\n") {
   await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `await Bun.stdin.exists();
-       const chunks = [];
-       for await (const chunk of Bun.stdin.stream()) {
-         chunks.push(Buffer.from(chunk).toString());
-       }
-       process.stdout.write(chunks.join(""));`,
-    ],
+    cmd: [bunExe(), "-e", script],
     env: bunEnv,
     stdin: "pipe",
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  proc.stdin.write("hello from pipe\n");
+  proc.stdin.write(input);
   proc.stdin.end();
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
+  return await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited]);
+}
+
+test("Bun.stdin.stream() works after Bun.stdin.exists()", async () => {
+  const [stdout, stderr, exitCode] = await runStdinTest(`
+    await Bun.stdin.exists();
+    const chunks = [];
+    for await (const chunk of Bun.stdin.stream()) {
+      chunks.push(Buffer.from(chunk).toString());
+    }
+    process.stdout.write(chunks.join(""));
+  `);
 
   expect(stdout.trim()).toBe("hello from pipe");
   expect(stderr).toBe("");
@@ -39,27 +37,10 @@ test("Bun.stdin.stream() works after Bun.stdin.exists()", async () => {
 });
 
 test("Bun.stdin.text() works after Bun.stdin.exists()", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `await Bun.stdin.exists();
-       process.stdout.write(await Bun.stdin.text());`,
-    ],
-    env: bunEnv,
-    stdin: "pipe",
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  proc.stdin.write("hello from pipe\n");
-  proc.stdin.end();
-
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await runStdinTest(`
+    await Bun.stdin.exists();
+    process.stdout.write(await Bun.stdin.text());
+  `);
 
   expect(stdout.trim()).toBe("hello from pipe");
   expect(stderr).toBe("");
@@ -67,31 +48,14 @@ test("Bun.stdin.text() works after Bun.stdin.exists()", async () => {
 });
 
 test("Bun.stdin.stream() works after accessing Bun.stdin.size", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `const s = Bun.stdin.size;
-       const chunks = [];
-       for await (const chunk of Bun.stdin.stream()) {
-         chunks.push(Buffer.from(chunk).toString());
-       }
-       process.stdout.write(chunks.join(""));`,
-    ],
-    env: bunEnv,
-    stdin: "pipe",
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  proc.stdin.write("hello from pipe\n");
-  proc.stdin.end();
-
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await runStdinTest(`
+    const s = Bun.stdin.size;
+    const chunks = [];
+    for await (const chunk of Bun.stdin.stream()) {
+      chunks.push(Buffer.from(chunk).toString());
+    }
+    process.stdout.write(chunks.join(""));
+  `);
 
   expect(stdout.trim()).toBe("hello from pipe");
   expect(stderr).toBe("");

--- a/test/regression/issue/27849.test.ts
+++ b/test/regression/issue/27849.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/27849
+// Calling Bun.stdin.exists() before reading stdin caused
+// the read to return empty on Linux because resolveSize()
+// incorrectly set the blob size to 0 for pipes.
+
+test("Bun.stdin.stream() works after Bun.stdin.exists()", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      "bash",
+      "-c",
+      `echo "hello from pipe" | ${bunExe()} -e '
+        await Bun.stdin.exists();
+        const chunks = [];
+        for await (const chunk of Bun.stdin.stream()) {
+          chunks.push(Buffer.from(chunk).toString());
+        }
+        process.stdout.write(chunks.join(""));
+      '`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  expect(stdout.trim()).toBe("hello from pipe");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test("Bun.stdin.text() works after Bun.stdin.exists()", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      "bash",
+      "-c",
+      `echo "hello from pipe" | ${bunExe()} -e '
+        await Bun.stdin.exists();
+        process.stdout.write(await Bun.stdin.text());
+      '`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  expect(stdout.trim()).toBe("hello from pipe");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test("Bun.stdin.stream() works after accessing Bun.stdin.size", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      "bash",
+      "-c",
+      `echo "hello from pipe" | ${bunExe()} -e '
+        const s = Bun.stdin.size;
+        const chunks = [];
+        for await (const chunk of Bun.stdin.stream()) {
+          chunks.push(Buffer.from(chunk).toString());
+        }
+        process.stdout.write(chunks.join(""));
+      '`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  expect(stdout.trim()).toBe("hello from pipe");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/27849.test.ts
+++ b/test/regression/issue/27849.test.ts
@@ -9,21 +9,23 @@ import { bunEnv, bunExe } from "harness";
 test("Bun.stdin.stream() works after Bun.stdin.exists()", async () => {
   await using proc = Bun.spawn({
     cmd: [
-      "bash",
-      "-c",
-      `echo "hello from pipe" | ${bunExe()} -e '
-        await Bun.stdin.exists();
-        const chunks = [];
-        for await (const chunk of Bun.stdin.stream()) {
-          chunks.push(Buffer.from(chunk).toString());
-        }
-        process.stdout.write(chunks.join(""));
-      '`,
+      bunExe(),
+      "-e",
+      `await Bun.stdin.exists();
+       const chunks = [];
+       for await (const chunk of Bun.stdin.stream()) {
+         chunks.push(Buffer.from(chunk).toString());
+       }
+       process.stdout.write(chunks.join(""));`,
     ],
     env: bunEnv,
+    stdin: "pipe",
     stdout: "pipe",
     stderr: "pipe",
   });
+
+  proc.stdin.write("hello from pipe\n");
+  proc.stdin.end();
 
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
@@ -39,17 +41,19 @@ test("Bun.stdin.stream() works after Bun.stdin.exists()", async () => {
 test("Bun.stdin.text() works after Bun.stdin.exists()", async () => {
   await using proc = Bun.spawn({
     cmd: [
-      "bash",
-      "-c",
-      `echo "hello from pipe" | ${bunExe()} -e '
-        await Bun.stdin.exists();
-        process.stdout.write(await Bun.stdin.text());
-      '`,
+      bunExe(),
+      "-e",
+      `await Bun.stdin.exists();
+       process.stdout.write(await Bun.stdin.text());`,
     ],
     env: bunEnv,
+    stdin: "pipe",
     stdout: "pipe",
     stderr: "pipe",
   });
+
+  proc.stdin.write("hello from pipe\n");
+  proc.stdin.end();
 
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
@@ -65,21 +69,23 @@ test("Bun.stdin.text() works after Bun.stdin.exists()", async () => {
 test("Bun.stdin.stream() works after accessing Bun.stdin.size", async () => {
   await using proc = Bun.spawn({
     cmd: [
-      "bash",
-      "-c",
-      `echo "hello from pipe" | ${bunExe()} -e '
-        const s = Bun.stdin.size;
-        const chunks = [];
-        for await (const chunk of Bun.stdin.stream()) {
-          chunks.push(Buffer.from(chunk).toString());
-        }
-        process.stdout.write(chunks.join(""));
-      '`,
+      bunExe(),
+      "-e",
+      `const s = Bun.stdin.size;
+       const chunks = [];
+       for await (const chunk of Bun.stdin.stream()) {
+         chunks.push(Buffer.from(chunk).toString());
+       }
+       process.stdout.write(chunks.join(""));`,
     ],
     env: bunEnv,
+    stdin: "pipe",
     stdout: "pipe",
     stderr: "pipe",
   });
+
+  proc.stdin.write("hello from pipe\n");
+  proc.stdin.end();
 
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),


### PR DESCRIPTION
## Summary
- Fixes `Bun.stdin.stream()` / `Bun.stdin.text()` returning empty after calling `Bun.stdin.exists()` or accessing `Bun.stdin.size` on Linux
- The root cause was `resolveSize()` falling through to `this.size = 0` for pipe-backed file descriptors where the size is genuinely unknown
- Added early return in the file store branch of `resolveSize()` so that non-seekable files (pipes, FIFOs) retain their `max_size` sentinel value

## Root Cause
When `resolveSize()` was called on a pipe fd (e.g. stdin):
1. `resolveFileStat()` sets `seekable = false` and `max_size = Blob.max_size` (unknown)
2. The condition `seekable != null and max_size != Blob.max_size` fails (max_size IS max_size)
3. Execution falls through to `this.size = 0`
4. `ReadableStream.fromBlobCopyRef()` passes `max_size = 0` to `FileReader`
5. `FileReader.onReadChunk()` sees `0 >= 0` and immediately stops — no data read

## Test plan
- [x] New regression tests in `test/regression/issue/27849.test.ts` verify `stream()`, `text()`, and `.size` access before reading from a real pipe
- [x] Tests fail with system bun (`USE_SYSTEM_BUN=1`), pass with debug build
- [x] Existing blob tests pass (`blob.test.ts`, `bun-file.test.ts`, `bun-file-exists.test.js`)

Closes #27849

🤖 Generated with [Claude Code](https://claude.com/claude-code)