### PR TITLE
feat(cli): add --concurrency flag for bun run --filter

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -431,6 +431,7 @@ pub const Command = struct {
         parallel: bool = false,
         sequential: bool = false,
         no_exit_on_error: bool = false,
+        concurrency: ?usize = null,
 
         preloads: []const string = &.{},
         has_loaded_global_config: bool = false,

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -134,7 +134,7 @@ pub const auto_or_run_params = [_]ParamType{
     clap.parseParam("--parallel                        Run multiple scripts concurrently with Foreman-style output") catch unreachable,
     clap.parseParam("--sequential                      Run multiple scripts sequentially with Foreman-style output") catch unreachable,
     clap.parseParam("--no-exit-on-error                Continue running other scripts when one fails (with --parallel/--sequential)") catch unreachable,
-    clap.parseParam("--concurrency <NUMBER>            Maximum number of scripts to run concurrently with --filter (default: unlimited)") catch unreachable,
+    clap.parseParam("--concurrency <NUMBER>            Maximum number of scripts to run concurrently with --filter, --parallel, or --sequential (default: unlimited)") catch unreachable,
 };
 
 pub const auto_only_params = [_]ParamType{

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -134,6 +134,7 @@ pub const auto_or_run_params = [_]ParamType{
     clap.parseParam("--parallel                        Run multiple scripts concurrently with Foreman-style output") catch unreachable,
     clap.parseParam("--sequential                      Run multiple scripts sequentially with Foreman-style output") catch unreachable,
     clap.parseParam("--no-exit-on-error                Continue running other scripts when one fails (with --parallel/--sequential)") catch unreachable,
+    clap.parseParam("--concurrency <NUMBER>            Maximum number of scripts to run concurrently with --filter (default: unlimited)") catch unreachable,
 };
 
 pub const auto_only_params = [_]ParamType{
@@ -461,6 +462,20 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
         ctx.parallel = args.flag("--parallel");
         ctx.sequential = args.flag("--sequential");
         ctx.no_exit_on_error = args.flag("--no-exit-on-error");
+
+        if (args.option("--concurrency")) |concurrency| {
+            if (concurrency.len > 0) {
+                const value = std.fmt.parseInt(usize, concurrency, 10) catch {
+                    Output.prettyErrorln("<r><red>error<r>: Invalid concurrency: \"{s}\"", .{concurrency});
+                    Global.exit(1);
+                };
+                if (value == 0) {
+                    Output.prettyErrorln("<r><red>error<r>: --concurrency must be at least 1", .{});
+                    Global.exit(1);
+                }
+                ctx.concurrency = value;
+            }
+        }
 
         if (args.option("--elide-lines")) |elide_lines| {
             if (elide_lines.len > 0) {

--- a/src/cli/filter_run.zig
+++ b/src/cli/filter_run.zig
@@ -45,6 +45,7 @@ pub const ProcessHandle = struct {
 
     fn start(this: *This) !void {
         this.state.remaining_scripts += 1;
+        this.state.running_count += 1;
         const handle = this;
 
         var argv = [_:null]?[*:0]const u8{ this.state.shell_bin, if (Environment.isPosix) "-c" else "exec", this.config.combined, null };
@@ -146,6 +147,8 @@ const State = struct {
     handles: []ProcessHandle,
     event_loop: *bun.jsc.MiniEventLoop,
     remaining_scripts: usize = 0,
+    running_count: usize = 0,
+    max_concurrency: ?usize = null,
     // buffer for batched output
     draw_buf: std.array_list.Managed(u8) = std.array_list.Managed(u8).init(bun.default_allocator),
     last_lines_written: usize = 0,
@@ -195,14 +198,32 @@ const State = struct {
 
     fn processExit(this: *This, handle: *ProcessHandle) !void {
         this.remaining_scripts -= 1;
+        this.running_count -= 1;
         if (!this.aborted) {
             for (handle.dependents.items) |dependent| {
                 dependent.remaining_dependencies -= 1;
                 if (dependent.remaining_dependencies == 0) {
+                    if (this.max_concurrency) |max| {
+                        if (this.running_count >= max) continue;
+                    }
                     dependent.start() catch {
                         Output.prettyErrorln("<r><red>error<r>: Failed to start process", .{});
                         Global.exit(1);
                     };
+                }
+            }
+            // Start any other ready handles that were waiting for a concurrency slot
+            if (this.max_concurrency != null) {
+                for (this.handles) |*h| {
+                    if (this.max_concurrency) |max| {
+                        if (this.running_count >= max) break;
+                    }
+                    if (h.remaining_dependencies == 0 and h.process == null and h != handle) {
+                        h.start() catch {
+                            Output.prettyErrorln("<r><red>error<r>: Failed to start process", .{});
+                            Global.exit(1);
+                        };
+                    }
                 }
             }
         }
@@ -548,6 +569,7 @@ pub fn runScriptsWithFilter(ctx: Command.Context) !noreturn {
         .pretty_output = if (Environment.isWindows) windowsIsTerminal() and Output.enable_ansi_colors_stdout else Output.enable_ansi_colors_stdout,
         .shell_bin = shell_bin,
         .env = this_transpiler.env,
+        .max_concurrency = ctx.concurrency,
     };
 
     // Check if elide-lines is used in a non-terminal environment
@@ -623,9 +645,12 @@ pub fn runScriptsWithFilter(ctx: Command.Context) !noreturn {
         }
     }
 
-    // start inital scripts
+    // start initial scripts (respecting concurrency limit)
     for (state.handles) |*handle| {
         if (handle.remaining_dependencies == 0) {
+            if (state.max_concurrency) |max| {
+                if (state.running_count >= max) continue;
+            }
             handle.start() catch {
                 // todo this should probably happen in "start"
                 Output.prettyErrorln("<r><red>error<r>: Failed to start process", .{});

--- a/src/cli/filter_run.zig
+++ b/src/cli/filter_run.zig
@@ -638,18 +638,7 @@ pub fn runScriptsWithFilter(ctx: Command.Context) !noreturn {
     }
 
     // start initial scripts (respecting concurrency limit)
-    for (state.handles) |*handle| {
-        if (handle.remaining_dependencies == 0) {
-            if (state.max_concurrency) |max| {
-                if (state.running_count >= max) continue;
-            }
-            handle.start() catch {
-                // todo this should probably happen in "start"
-                Output.prettyErrorln("<r><red>error<r>: Failed to start process", .{});
-                Global.exit(1);
-            };
-        }
-    }
+    state.startReadyHandles();
 
     AbortHandler.install();
 

--- a/src/cli/filter_run.zig
+++ b/src/cli/filter_run.zig
@@ -196,36 +196,28 @@ const State = struct {
         }
     }
 
+    fn startReadyHandles(this: *This) void {
+        for (this.handles) |*h| {
+            if (this.max_concurrency) |max| {
+                if (this.running_count >= max) break;
+            }
+            if (h.remaining_dependencies == 0 and h.process == null) {
+                h.start() catch {
+                    Output.prettyErrorln("<r><red>error<r>: Failed to start process", .{});
+                    Global.exit(1);
+                };
+            }
+        }
+    }
+
     fn processExit(this: *This, handle: *ProcessHandle) !void {
         this.remaining_scripts -= 1;
         this.running_count -= 1;
         if (!this.aborted) {
             for (handle.dependents.items) |dependent| {
                 dependent.remaining_dependencies -= 1;
-                if (dependent.remaining_dependencies == 0) {
-                    if (this.max_concurrency) |max| {
-                        if (this.running_count >= max) continue;
-                    }
-                    dependent.start() catch {
-                        Output.prettyErrorln("<r><red>error<r>: Failed to start process", .{});
-                        Global.exit(1);
-                    };
-                }
             }
-            // Start any other ready handles that were waiting for a concurrency slot
-            if (this.max_concurrency != null) {
-                for (this.handles) |*h| {
-                    if (this.max_concurrency) |max| {
-                        if (this.running_count >= max) break;
-                    }
-                    if (h.remaining_dependencies == 0 and h.process == null and h != handle) {
-                        h.start() catch {
-                            Output.prettyErrorln("<r><red>error<r>: Failed to start process", .{});
-                            Global.exit(1);
-                        };
-                    }
-                }
-            }
+            this.startReadyHandles();
         }
         if (this.pretty_output) {
             this.redraw(false) catch {};

--- a/src/cli/multi_run.zig
+++ b/src/cli/multi_run.zig
@@ -63,6 +63,7 @@ pub const ProcessHandle = struct {
     end_time: ?std.time.Instant = null,
 
     remaining_dependencies: usize = 0,
+    skipped: bool = false,
     /// Dependents within the same script group (pre->main->post chain).
     /// These are NOT started if this handle fails, even with --no-exit-on-error.
     group_dependents: std.array_list.Managed(*This) = std.array_list.Managed(*This).init(bun.default_allocator),
@@ -310,7 +311,7 @@ const State = struct {
             if (this.max_concurrency) |max| {
                 if (this.running_count >= max) break;
             }
-            if (h.remaining_dependencies == 0 and h.process == null) {
+            if (!h.skipped and h.remaining_dependencies == 0 and h.process == null) {
                 h.start() catch {
                     Output.prettyErrorln("<r><red>error<r>: Failed to start process", .{});
                     Global.exit(1);
@@ -323,6 +324,7 @@ const State = struct {
     /// failed. Recursively skip their group dependents too.
     fn skipDependents(this: *This, dependents: []*ProcessHandle) void {
         for (dependents) |dependent| {
+            dependent.skipped = true;
             dependent.remaining_dependencies -= 1;
             if (dependent.remaining_dependencies == 0) {
                 this.skipDependents(dependent.group_dependents.items);

--- a/src/cli/multi_run.zig
+++ b/src/cli/multi_run.zig
@@ -72,6 +72,7 @@ pub const ProcessHandle = struct {
 
     fn start(this: *This) !void {
         this.state.remaining_scripts += 1;
+        this.state.running_count += 1;
 
         var argv = [_:null]?[*:0]const u8{
             this.state.shell_bin,
@@ -164,6 +165,8 @@ const State = struct {
     handles: []ProcessHandle,
     event_loop: *bun.jsc.MiniEventLoop,
     remaining_scripts: usize = 0,
+    running_count: usize = 0,
+    max_concurrency: ?usize = null,
     max_label_len: usize,
     shell_bin: [:0]const u8,
     aborted: bool = false,
@@ -230,6 +233,7 @@ const State = struct {
 
     fn processExit(this: *This, handle: *ProcessHandle) std.Io.Writer.Error!void {
         this.remaining_scripts -= 1;
+        this.running_count -= 1;
 
         // Flush remaining buffers (stdout first, then stderr)
         try this.flushPipeBuffer(handle, &handle.stdout_reader);
@@ -294,14 +298,31 @@ const State = struct {
         }
     }
 
-    fn startDependents(_: *This, dependents: []*ProcessHandle) void {
+    fn startDependents(this: *This, dependents: []*ProcessHandle) void {
         for (dependents) |dependent| {
             dependent.remaining_dependencies -= 1;
             if (dependent.remaining_dependencies == 0) {
+                if (this.max_concurrency) |max| {
+                    if (this.running_count >= max) continue;
+                }
                 dependent.start() catch {
                     Output.prettyErrorln("<r><red>error<r>: Failed to start process", .{});
                     Global.exit(1);
                 };
+            }
+        }
+        // Start any other ready handles that were waiting for a concurrency slot
+        if (this.max_concurrency != null) {
+            for (this.handles) |*h| {
+                if (this.max_concurrency) |max| {
+                    if (this.running_count >= max) break;
+                }
+                if (h.remaining_dependencies == 0 and h.process == null) {
+                    h.start() catch {
+                        Output.prettyErrorln("<r><red>error<r>: Failed to start process", .{});
+                        Global.exit(1);
+                    };
+                }
             }
         }
     }
@@ -743,6 +764,7 @@ pub fn run(ctx: Command.Context) !noreturn {
         .no_exit_on_error = ctx.no_exit_on_error,
         .env = this_transpiler.env,
         .use_colors = use_colors,
+        .max_concurrency = ctx.concurrency,
     };
 
     // Initialize handles
@@ -796,9 +818,12 @@ pub fn run(ctx: Command.Context) !noreturn {
         }
     }
 
-    // Start handles with no dependencies
+    // Start handles with no dependencies (respecting concurrency limit)
     for (state.handles) |*handle| {
         if (handle.remaining_dependencies == 0) {
+            if (state.max_concurrency) |max| {
+                if (state.running_count >= max) continue;
+            }
             handle.start() catch {
                 Output.prettyErrorln("<r><red>error<r>: Failed to start process", .{});
                 Global.exit(1);

--- a/src/cli/multi_run.zig
+++ b/src/cli/multi_run.zig
@@ -813,17 +813,7 @@ pub fn run(ctx: Command.Context) !noreturn {
     }
 
     // Start handles with no dependencies (respecting concurrency limit)
-    for (state.handles) |*handle| {
-        if (handle.remaining_dependencies == 0) {
-            if (state.max_concurrency) |max| {
-                if (state.running_count >= max) continue;
-            }
-            handle.start() catch {
-                Output.prettyErrorln("<r><red>error<r>: Failed to start process", .{});
-                Global.exit(1);
-            };
-        }
-    }
+    state.startReadyHandles();
 
     AbortHandler.install();
 

--- a/src/cli/multi_run.zig
+++ b/src/cli/multi_run.zig
@@ -301,28 +301,20 @@ const State = struct {
     fn startDependents(this: *This, dependents: []*ProcessHandle) void {
         for (dependents) |dependent| {
             dependent.remaining_dependencies -= 1;
-            if (dependent.remaining_dependencies == 0) {
-                if (this.max_concurrency) |max| {
-                    if (this.running_count >= max) continue;
-                }
-                dependent.start() catch {
+        }
+        this.startReadyHandles();
+    }
+
+    fn startReadyHandles(this: *This) void {
+        for (this.handles) |*h| {
+            if (this.max_concurrency) |max| {
+                if (this.running_count >= max) break;
+            }
+            if (h.remaining_dependencies == 0 and h.process == null) {
+                h.start() catch {
                     Output.prettyErrorln("<r><red>error<r>: Failed to start process", .{});
                     Global.exit(1);
                 };
-            }
-        }
-        // Start any other ready handles that were waiting for a concurrency slot
-        if (this.max_concurrency != null) {
-            for (this.handles) |*h| {
-                if (this.max_concurrency) |max| {
-                    if (this.running_count >= max) break;
-                }
-                if (h.remaining_dependencies == 0 and h.process == null) {
-                    h.start() catch {
-                        Output.prettyErrorln("<r><red>error<r>: Failed to start process", .{});
-                        Global.exit(1);
-                    };
-                }
             }
         }
     }

--- a/test/cli/run/concurrency-filter.test.ts
+++ b/test/cli/run/concurrency-filter.test.ts
@@ -1,0 +1,210 @@
+import { spawnSync } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+function createWorkspaceWithSleepScripts(count: number) {
+  const packages: Record<string, object> = {};
+  for (let i = 0; i < count; i++) {
+    packages[`pkg${i}`] = {
+      "index.js": `
+        const start = Date.now();
+        await Bun.write('timing.txt', String(start));
+        await new Promise(resolve => setTimeout(resolve, 500));
+        console.log('done-pkg${i}');
+      `,
+      "package.json": JSON.stringify({
+        name: `pkg${i}`,
+        scripts: {
+          build: `${bunExe()} run index.js`,
+        },
+      }),
+    };
+  }
+  return tempDirWithFiles("concurrency-test", {
+    packages,
+    "package.json": JSON.stringify({
+      name: "ws",
+      workspaces: ["packages/*"],
+    }),
+  });
+}
+
+describe("--concurrency flag", () => {
+  test("limits concurrent scripts with --filter", () => {
+    const dir = createWorkspaceWithSleepScripts(4);
+
+    const start = Date.now();
+    const { exitCode, stdout } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run", "--filter", "*", "--concurrency", "2", "build"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const elapsed = Date.now() - start;
+    const output = stdout.toString();
+
+    // All 4 packages should complete
+    expect(output).toMatch(/done-pkg0/);
+    expect(output).toMatch(/done-pkg1/);
+    expect(output).toMatch(/done-pkg2/);
+    expect(output).toMatch(/done-pkg3/);
+    expect(exitCode).toBe(0);
+
+    // With concurrency=2 and 4 packages sleeping 500ms each,
+    // it should take at least ~1000ms (2 batches of 2).
+    // Without concurrency limit it would take ~500ms.
+    expect(elapsed).toBeGreaterThan(800);
+  });
+
+  test("unlimited concurrency without flag", () => {
+    const dir = createWorkspaceWithSleepScripts(4);
+
+    const start = Date.now();
+    const { exitCode, stdout } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run", "--filter", "*", "build"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const elapsed = Date.now() - start;
+    const output = stdout.toString();
+
+    expect(output).toMatch(/done-pkg0/);
+    expect(output).toMatch(/done-pkg1/);
+    expect(output).toMatch(/done-pkg2/);
+    expect(output).toMatch(/done-pkg3/);
+    expect(exitCode).toBe(0);
+
+    // Without limit, all 4 run in parallel — should finish in ~500ms
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  test("concurrency=1 runs sequentially", () => {
+    const dir = createWorkspaceWithSleepScripts(3);
+
+    const start = Date.now();
+    const { exitCode, stdout } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run", "--filter", "*", "--concurrency", "1", "build"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const elapsed = Date.now() - start;
+    const output = stdout.toString();
+
+    expect(output).toMatch(/done-pkg0/);
+    expect(output).toMatch(/done-pkg1/);
+    expect(output).toMatch(/done-pkg2/);
+    expect(exitCode).toBe(0);
+
+    // With concurrency=1, 3 packages × 500ms = at least 1500ms
+    expect(elapsed).toBeGreaterThan(1200);
+  });
+
+  test("errors on --concurrency 0", () => {
+    const dir = createWorkspaceWithSleepScripts(2);
+
+    const { exitCode, stderr } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run", "--filter", "*", "--concurrency", "0", "build"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(stderr.toString()).toMatch(/--concurrency must be at least 1/);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("errors on --concurrency with non-numeric value", () => {
+    const dir = createWorkspaceWithSleepScripts(2);
+
+    const { exitCode, stderr } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run", "--filter", "*", "--concurrency", "abc", "build"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(stderr.toString()).toMatch(/Invalid concurrency/);
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("respects dependency order with concurrency limit", () => {
+    const dir = tempDirWithFiles("concurrency-deps", {
+      packages: {
+        dep0: {
+          "index.js": `
+            await new Promise(resolve => setTimeout(resolve, 200));
+            await Bun.write('out.txt', 'dep0-done');
+            console.log('done-dep0');
+          `,
+          "package.json": JSON.stringify({
+            name: "dep0",
+            scripts: { build: `${bunExe()} run index.js` },
+          }),
+        },
+        dep1: {
+          "index.js": `
+            const content = await Bun.file('../dep0/out.txt').text();
+            console.log('dep1-read:' + content);
+          `,
+          "package.json": JSON.stringify({
+            name: "dep1",
+            dependencies: { dep0: "*" },
+            scripts: { build: `${bunExe()} run index.js` },
+          }),
+        },
+      },
+      "package.json": JSON.stringify({
+        name: "ws",
+        workspaces: ["packages/*"],
+      }),
+    });
+
+    const { exitCode, stdout } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run", "--filter", "*", "--concurrency", "1", "build"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const output = stdout.toString();
+    expect(output).toMatch(/done-dep0/);
+    expect(output).toMatch(/dep1-read:dep0-done/);
+    expect(exitCode).toBe(0);
+  });
+
+  test("works with --parallel mode", () => {
+    const dir = createWorkspaceWithSleepScripts(4);
+
+    const start = Date.now();
+    const { exitCode, stdout } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run", "--parallel", "--filter", "*", "--concurrency", "2", "build"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const elapsed = Date.now() - start;
+    const output = stdout.toString();
+
+    expect(output).toMatch(/done-pkg0/);
+    expect(output).toMatch(/done-pkg1/);
+    expect(output).toMatch(/done-pkg2/);
+    expect(output).toMatch(/done-pkg3/);
+    expect(exitCode).toBe(0);
+
+    // With concurrency=2, should take at least ~1000ms
+    expect(elapsed).toBeGreaterThan(800);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds a `--concurrency <N>` flag to `bun run --filter` that limits how many workspace scripts run in parallel.

Closes #27858

**Problem:** In large monorepos (60+ packages), `bun run --filter '*' typecheck` launches all packages simultaneously, causing OOM kills (~500MB per `tsc` × 68 packages = ~34GB peak).

**Solution:** A new `--concurrency` option that caps the number of concurrent child processes while preserving the existing dependency graph ordering.

```bash
bun run --filter '*' --concurrency 4 typecheck
bun run --filter '*' --concurrency 1 build        # sequential
bun run --parallel --filter '*' --concurrency 2 build
```

### Changes

- `src/cli/Arguments.zig` — parse `--concurrency <N>` with validation
- `src/cli.zig` — add `concurrency` field to Context
- `src/cli/filter_run.zig` — gate process starts on running count (dependency-aware mode)
- `src/cli/multi_run.zig` — same for `--parallel` mode

Without the flag, behavior is unchanged (unlimited parallelism).

## How did you verify your code works?

Added `test/cli/run/concurrency-filter.test.ts` with 7 test cases:
- Concurrency=2 with 4 packages → verifies batched execution (~1000ms vs ~500ms)
- Unlimited (no flag) → all run in parallel
- Concurrency=1 → sequential execution
- Error on `--concurrency 0`
- Error on non-numeric value
- Dependency order respected with concurrency limit
- Works with `--parallel` mode