### PR TITLE
fix(valkey): reject in-flight commands on auto-reconnect

### DIFF
--- a/src/valkey/valkey.zig
+++ b/src/valkey/valkey.zig
@@ -380,6 +380,23 @@ pub const ValkeyClient = struct {
         }
     }
 
+    /// Reject only the in-flight commands (already written to the old socket).
+    /// Used during auto-reconnect to discard stale promise entries without
+    /// touching the offline queue, which can still be drained on the new
+    /// connection.
+    fn rejectInFlightCommands(this: *ValkeyClient) bun.JSTerminated!void {
+        var pending = this.in_flight;
+        defer pending.deinit();
+        this.in_flight = .init(this.allocator);
+
+        const globalThis = this.globalObject();
+        const err_value = protocol.valkeyErrorToJS(globalThis, "Connection lost; reconnecting", protocol.RedisError.ConnectionClosed);
+        for (pending.readableSlice(0)) |item| {
+            var command_pair = item;
+            try command_pair.rejectCommand(globalThis, err_value);
+        }
+    }
+
     /// Flush pending data to the socket
     pub fn flushData(this: *ValkeyClient) bool {
         const chunk = this.write_buffer.remaining();
@@ -498,6 +515,15 @@ pub const ValkeyClient = struct {
         }
 
         debug("reconnect in {d}ms (attempt {d}/{d})", .{ delay_ms, this.retry_attempts, this.max_retries });
+
+        // Reject all in-flight commands from the old connection. Their
+        // responses will never arrive on the new connection, so leaving
+        // them in the FIFO queue would cause new responses to be matched
+        // against stale promise entries.
+        // The offline `queue` is intentionally preserved — those commands
+        // have not been written to the wire yet and will be drained once
+        // the new connection is ready.
+        try this.rejectInFlightCommands();
 
         this.flags.is_reconnecting = true;
         this.flags.is_authenticated = false;

--- a/test/regression/issue/27861.test.ts
+++ b/test/regression/issue/27861.test.ts
@@ -1,22 +1,36 @@
 import { RedisClient } from "bun";
-import { beforeAll, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, dockerExe } from "harness";
 import * as net from "node:net";
-import * as dockerCompose from "../../docker/index.ts";
 
 let REDIS_HOST: string;
 let REDIS_PORT: number;
-let dockerAvailable = false;
 
-beforeAll(async () => {
-  try {
-    const redisInfo = await dockerCompose.ensure("redis_unified");
-    REDIS_HOST = redisInfo.host;
-    REDIS_PORT = redisInfo.ports[6379];
-    dockerAvailable = true;
-  } catch {
-    // Docker not available — tests will be skipped
-  }
-});
+// Synchronous Docker availability check (same pattern as valkey test-utils)
+const dockerCLI = dockerExe() as string;
+const dockerAvailable =
+  !!dockerCLI &&
+  (() => {
+    try {
+      const info = Bun.spawnSync({
+        cmd: [dockerCLI, "info"],
+        stdout: "pipe",
+        stderr: "pipe",
+        env: bunEnv,
+        timeout: 5_000,
+      });
+      return info.exitCode === 0 && !info.signalCode;
+    } catch {
+      return false;
+    }
+  })();
+
+if (dockerAvailable) {
+  const dockerCompose = await import("../../docker/index.ts");
+  const redisInfo = await dockerCompose.ensure("redis_unified");
+  REDIS_HOST = redisInfo.host;
+  REDIS_PORT = redisInfo.ports[6379];
+}
 
 /**
  * A minimal TCP proxy that allows us to forcibly kill the connection between
@@ -25,14 +39,13 @@ beforeAll(async () => {
 class TcpProxy {
   private server: net.Server | null = null;
   private connections: Set<{ client: net.Socket; upstream: net.Socket }> = new Set();
-  readonly port: number;
+  port: number = 0;
   private targetHost: string;
   private targetPort: number;
 
-  constructor(targetHost: string, targetPort: number, listenPort: number) {
+  constructor(targetHost: string, targetPort: number) {
     this.targetHost = targetHost;
     this.targetPort = targetPort;
-    this.port = listenPort;
   }
 
   async start(): Promise<void> {
@@ -64,7 +77,10 @@ class TcpProxy {
       });
 
       this.server.on("error", reject);
-      this.server.listen(this.port, "127.0.0.1", () => resolve());
+      this.server.listen(0, "127.0.0.1", () => {
+        this.port = (this.server!.address() as net.AddressInfo).port;
+        resolve();
+      });
     });
   }
 
@@ -84,19 +100,12 @@ class TcpProxy {
   }
 }
 
-test.skipIf(!dockerAvailable)(
-  "in-flight commands are rejected on auto-reconnect, not mismatched",
-  async () => {
-    // Use port 0 trick: find a free port first
-    const tmpServer = net.createServer();
-    await new Promise<void>(resolve => tmpServer.listen(0, "127.0.0.1", resolve));
-    const proxyPort = (tmpServer.address() as net.AddressInfo).port;
-    tmpServer.close();
-
-    const proxy = new TcpProxy(REDIS_HOST, REDIS_PORT, proxyPort);
+describe.skipIf(!dockerAvailable)("RedisClient reconnect", () => {
+  test("in-flight commands are rejected on auto-reconnect, not mismatched", async () => {
+    const proxy = new TcpProxy(REDIS_HOST, REDIS_PORT);
     await proxy.start();
 
-    const redis = new RedisClient(`redis://127.0.0.1:${proxyPort}`, {
+    const redis = new RedisClient(`redis://127.0.0.1:${proxy.port}`, {
       enableAutoReconnect: true,
       enableAutoPipelining: true,
     });
@@ -152,6 +161,5 @@ test.skipIf(!dockerAvailable)(
 
     redis.close();
     proxy.stop();
-  },
-  30_000,
-);
+  }, 30_000);
+});

--- a/test/regression/issue/27861.test.ts
+++ b/test/regression/issue/27861.test.ts
@@ -1,0 +1,157 @@
+import { RedisClient } from "bun";
+import { beforeAll, expect, test } from "bun:test";
+import * as net from "node:net";
+import * as dockerCompose from "../../docker/index.ts";
+
+let REDIS_HOST: string;
+let REDIS_PORT: number;
+let dockerAvailable = false;
+
+beforeAll(async () => {
+  try {
+    const redisInfo = await dockerCompose.ensure("redis_unified");
+    REDIS_HOST = redisInfo.host;
+    REDIS_PORT = redisInfo.ports[6379];
+    dockerAvailable = true;
+  } catch {
+    // Docker not available — tests will be skipped
+  }
+});
+
+/**
+ * A minimal TCP proxy that allows us to forcibly kill the connection between
+ * the RedisClient and the real Redis server, simulating a network blip.
+ */
+class TcpProxy {
+  private server: net.Server | null = null;
+  private connections: Set<{ client: net.Socket; upstream: net.Socket }> = new Set();
+  readonly port: number;
+  private targetHost: string;
+  private targetPort: number;
+
+  constructor(targetHost: string, targetPort: number, listenPort: number) {
+    this.targetHost = targetHost;
+    this.targetPort = targetPort;
+    this.port = listenPort;
+  }
+
+  async start(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.server = net.createServer(clientSocket => {
+        const upstream = net.createConnection({
+          host: this.targetHost,
+          port: this.targetPort,
+        });
+
+        const pair = { client: clientSocket, upstream };
+        this.connections.add(pair);
+
+        upstream.on("connect", () => {
+          clientSocket.pipe(upstream);
+          upstream.pipe(clientSocket);
+        });
+
+        const cleanup = () => {
+          this.connections.delete(pair);
+          clientSocket.destroy();
+          upstream.destroy();
+        };
+
+        upstream.on("error", cleanup);
+        upstream.on("close", cleanup);
+        clientSocket.on("error", cleanup);
+        clientSocket.on("close", cleanup);
+      });
+
+      this.server.on("error", reject);
+      this.server.listen(this.port, "127.0.0.1", () => resolve());
+    });
+  }
+
+  /** Kill all active connections to simulate a network drop */
+  disconnectAll(): void {
+    for (const pair of this.connections) {
+      pair.client.destroy();
+      pair.upstream.destroy();
+    }
+    this.connections.clear();
+  }
+
+  stop(): void {
+    this.disconnectAll();
+    this.server?.close();
+    this.server = null;
+  }
+}
+
+test.skipIf(!dockerAvailable)(
+  "in-flight commands are rejected on auto-reconnect, not mismatched",
+  async () => {
+    // Use port 0 trick: find a free port first
+    const tmpServer = net.createServer();
+    await new Promise<void>(resolve => tmpServer.listen(0, "127.0.0.1", resolve));
+    const proxyPort = (tmpServer.address() as net.AddressInfo).port;
+    tmpServer.close();
+
+    const proxy = new TcpProxy(REDIS_HOST, REDIS_PORT, proxyPort);
+    await proxy.start();
+
+    const redis = new RedisClient(`redis://127.0.0.1:${proxyPort}`, {
+      enableAutoReconnect: true,
+      enableAutoPipelining: true,
+    });
+
+    await redis.connect();
+
+    // Verify connection works
+    await redis.set("test:27861", "hello");
+    expect(await redis.get("test:27861")).toBe("hello");
+
+    // Fire off several pipelined commands that will be in-flight when we kill the
+    // connection. These should all reject (not silently resolve with wrong data).
+    const promises: Promise<any>[] = [];
+    for (let i = 0; i < 10; i++) {
+      promises.push(redis.set(`test:27861:${i}`, `value-${i}`));
+      promises.push(redis.get(`test:27861:${i}`));
+    }
+
+    // Kill the proxy connection immediately — the commands above are pipelined and
+    // likely still in-flight.
+    proxy.disconnectAll();
+
+    // All in-flight commands should reject with a connection error
+    const results = await Promise.allSettled(promises);
+    const rejected = results.filter(r => r.status === "rejected");
+    // At least some of the in-flight commands should have been rejected.
+    // (Some may have completed before the disconnect.)
+    expect(rejected.length).toBeGreaterThan(0);
+
+    // Wait for auto-reconnect to complete (up to 5s)
+    let reconnected = false;
+    for (let i = 0; i < 50; i++) {
+      try {
+        const pong = await redis.send("PING", []);
+        if (pong === "PONG") {
+          reconnected = true;
+          break;
+        }
+      } catch {
+        await Bun.sleep(100);
+      }
+    }
+    expect(reconnected).toBe(true);
+
+    // After reconnection, commands should work correctly — no response mismatches.
+    for (let i = 0; i < 10; i++) {
+      await redis.set(`test:27861:post:${i}`, `post-value-${i}`);
+    }
+    for (let i = 0; i < 10; i++) {
+      const val = await redis.get(`test:27861:post:${i}`);
+      expect(val).toBe(`post-value-${i}`);
+    }
+
+    redis.close();
+    proxy.stop();
+  },
+  30_000,
+);

--- a/test/regression/issue/27861.test.ts
+++ b/test/regression/issue/27861.test.ts
@@ -2,6 +2,7 @@ import { RedisClient } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, dockerExe } from "harness";
 import * as net from "node:net";
+import * as dockerCompose from "../../docker/index.ts";
 
 let REDIS_HOST: string;
 let REDIS_PORT: number;
@@ -26,7 +27,6 @@ const dockerAvailable =
   })();
 
 if (dockerAvailable) {
-  const dockerCompose = await import("../../docker/index.ts");
   const redisInfo = await dockerCompose.ensure("redis_unified");
   REDIS_HOST = redisInfo.host;
   REDIS_PORT = redisInfo.ports[6379];
@@ -110,56 +110,63 @@ describe.skipIf(!dockerAvailable)("RedisClient reconnect", () => {
       enableAutoPipelining: true,
     });
 
-    await redis.connect();
+    try {
+      await redis.connect();
 
-    // Verify connection works
-    await redis.set("test:27861", "hello");
-    expect(await redis.get("test:27861")).toBe("hello");
+      // Verify connection works
+      await redis.set("test:27861", "hello");
+      expect(await redis.get("test:27861")).toBe("hello");
 
-    // Fire off several pipelined commands that will be in-flight when we kill the
-    // connection. These should all reject (not silently resolve with wrong data).
-    const promises: Promise<any>[] = [];
-    for (let i = 0; i < 10; i++) {
-      promises.push(redis.set(`test:27861:${i}`, `value-${i}`));
-      promises.push(redis.get(`test:27861:${i}`));
-    }
-
-    // Kill the proxy connection immediately — the commands above are pipelined and
-    // likely still in-flight.
-    proxy.disconnectAll();
-
-    // All in-flight commands should reject with a connection error
-    const results = await Promise.allSettled(promises);
-    const rejected = results.filter(r => r.status === "rejected");
-    // At least some of the in-flight commands should have been rejected.
-    // (Some may have completed before the disconnect.)
-    expect(rejected.length).toBeGreaterThan(0);
-
-    // Wait for auto-reconnect to complete (up to 5s)
-    let reconnected = false;
-    for (let i = 0; i < 50; i++) {
-      try {
-        const pong = await redis.send("PING", []);
-        if (pong === "PONG") {
-          reconnected = true;
-          break;
-        }
-      } catch {
-        await Bun.sleep(100);
+      // Fire off several pipelined commands that will be in-flight when we kill the
+      // connection. These should all reject (not silently resolve with wrong data).
+      const promises: Promise<any>[] = [];
+      for (let i = 0; i < 10; i++) {
+        promises.push(redis.set(`test:27861:${i}`, `value-${i}`));
+        promises.push(redis.get(`test:27861:${i}`));
       }
-    }
-    expect(reconnected).toBe(true);
 
-    // After reconnection, commands should work correctly — no response mismatches.
-    for (let i = 0; i < 10; i++) {
-      await redis.set(`test:27861:post:${i}`, `post-value-${i}`);
-    }
-    for (let i = 0; i < 10; i++) {
-      const val = await redis.get(`test:27861:post:${i}`);
-      expect(val).toBe(`post-value-${i}`);
-    }
+      // Kill the proxy connection immediately — the commands above are pipelined and
+      // likely still in-flight.
+      proxy.disconnectAll();
 
-    redis.close();
-    proxy.stop();
+      // All in-flight commands should reject with a connection error
+      const results = await Promise.allSettled(promises);
+      const rejected = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+      // At least some of the in-flight commands should have been rejected.
+      // (Some may have completed before the disconnect.)
+      expect(rejected.length).toBeGreaterThan(0);
+
+      // Verify rejections are from our reconnect path, not unrelated errors
+      for (const r of rejected) {
+        expect(String(r.reason)).toContain("Connection lost; reconnecting");
+      }
+
+      // Wait for auto-reconnect to complete (up to 5s)
+      let reconnected = false;
+      for (let i = 0; i < 50; i++) {
+        try {
+          const pong = await redis.send("PING", []);
+          if (pong === "PONG") {
+            reconnected = true;
+            break;
+          }
+        } catch {
+          await Bun.sleep(100);
+        }
+      }
+      expect(reconnected).toBe(true);
+
+      // After reconnection, commands should work correctly — no response mismatches.
+      for (let i = 0; i < 10; i++) {
+        await redis.set(`test:27861:post:${i}`, `post-value-${i}`);
+      }
+      for (let i = 0; i < 10; i++) {
+        const val = await redis.get(`test:27861:post:${i}`);
+        expect(val).toBe(`post-value-${i}`);
+      }
+    } finally {
+      redis.close();
+      proxy.stop();
+    }
   }, 30_000);
 });


### PR DESCRIPTION
## Summary

- Fix response mismatch bug when `RedisClient` auto-reconnects after a connection drop
- When the connection drops with commands in-flight, their promises were left in the FIFO queue; after reconnect, new responses would resolve against stale promise entries, causing commands to receive wrong responses (e.g. `redis.get()` returning `"OK"` from another request's `SET`)
- Add `rejectInFlightCommands()` that rejects all in-flight promises with `"Connection lost; reconnecting"` during the auto-reconnect path in `onClose()`
- The offline queue (commands not yet written to the wire) is preserved and drained on the new connection

## Test plan

- [ ] Regression test `test/regression/issue/27861.test.ts` — uses a TCP proxy to simulate a connection drop while pipelined commands are in-flight, verifies they are rejected (not mismatched), and verifies post-reconnect commands work correctly
- [ ] Existing valkey tests pass (910 tests, no regressions in compilation)

Closes #27861

🤖 Generated with [Claude Code](https://claude.com/claude-code)