### PR TITLE
fix(sql): throw clear error instead of panic when query exceeds 65535 parameter limit

### DIFF
--- a/src/sql/postgres/AnyPostgresError.zig
+++ b/src/sql/postgres/AnyPostgresError.zig
@@ -25,6 +25,7 @@ pub const AnyPostgresError = error{
     ShortRead,
     TLSNotAvailable,
     TLSUpgradeFailed,
+    TooManyParameters,
     UnexpectedMessage,
     UNKNOWN_AUTHENTICATION_METHOD,
     UNSUPPORTED_AUTHENTICATION_METHOD,
@@ -101,6 +102,13 @@ pub fn postgresErrorToJS(globalObject: *jsc.JSGlobalObject, message: ?[]const u8
         error.SASL_SIGNATURE_INVALID_BASE64 => "ERR_POSTGRES_SASL_SIGNATURE_INVALID_BASE64",
         error.TLSNotAvailable => "ERR_POSTGRES_TLS_NOT_AVAILABLE",
         error.TLSUpgradeFailed => "ERR_POSTGRES_TLS_UPGRADE_FAILED",
+        error.TooManyParameters => {
+            const too_many_msg = "query has too many parameters - the PostgreSQL wire protocol supports a maximum of 65535 parameters per query. Try reducing your batch size.";
+            return createPostgresError(globalObject, too_many_msg, .{
+                .code = "ERR_POSTGRES_TOO_MANY_PARAMETERS",
+                .hint = "Reduce the number of rows in your batch insert so that total_rows * columns_per_row does not exceed 65535.",
+            }) catch |e| globalObject.takeError(e);
+        },
         error.UnexpectedMessage => "ERR_POSTGRES_UNEXPECTED_MESSAGE",
         error.UNKNOWN_AUTHENTICATION_METHOD => "ERR_POSTGRES_UNKNOWN_AUTHENTICATION_METHOD",
         error.UNSUPPORTED_AUTHENTICATION_METHOD => "ERR_POSTGRES_UNSUPPORTED_AUTHENTICATION_METHOD",

--- a/src/sql/postgres/PostgresRequest.zig
+++ b/src/sql/postgres/PostgresRequest.zig
@@ -15,7 +15,11 @@ pub fn writeBind(
     try writer.String(cursor_name);
     try writer.string(name);
 
-    const len: u32 = @truncate(parameter_fields.len);
+    if (parameter_fields.len > max_parameters) {
+        return error.TooManyParameters;
+    }
+
+    const len: u16 = @intCast(parameter_fields.len);
 
     // The number of parameter format codes that follow (denoted C
     // below). This can be zero to indicate that there are no
@@ -168,6 +172,9 @@ pub fn writeBind(
     }
 
     if (any_non_text_fields) {
+        if (result_fields.len > max_parameters) {
+            return error.TooManyParameters;
+        }
         try writer.short(result_fields.len);
         for (result_fields) |field| {
             try writer.short(
@@ -339,6 +346,9 @@ const types = @import("./PostgresTypes.zig");
 const AnyPostgresError = @import("./PostgresTypes.zig").AnyPostgresError;
 const int4 = types.int4;
 const short = types.short;
+
+/// The PostgreSQL wire protocol uses 16-bit integers for parameter and column counts.
+const max_parameters = std.math.maxInt(u16);
 
 const bun = @import("bun");
 const String = bun.String;

--- a/src/sql/postgres/PostgresRequest.zig
+++ b/src/sql/postgres/PostgresRequest.zig
@@ -334,6 +334,9 @@ pub const Queue = bun.LinearFifo(*PostgresSQLQuery, .Dynamic);
 
 const debug = bun.Output.scoped(.Postgres, .visible);
 
+/// The PostgreSQL wire protocol uses 16-bit integers for parameter and column counts.
+const max_parameters = std.math.maxInt(u16);
+
 const PostgresSQLConnection = @import("./PostgresSQLConnection.zig");
 const PostgresSQLQuery = @import("./PostgresSQLQuery.zig");
 const PostgresSQLStatement = @import("./PostgresSQLStatement.zig");
@@ -346,9 +349,6 @@ const types = @import("./PostgresTypes.zig");
 const AnyPostgresError = @import("./PostgresTypes.zig").AnyPostgresError;
 const int4 = types.int4;
 const short = types.short;
-
-/// The PostgreSQL wire protocol uses 16-bit integers for parameter and column counts.
-const max_parameters = std.math.maxInt(u16);
 
 const bun = @import("bun");
 const String = bun.String;

--- a/src/sql/postgres/PostgresSQLQuery.zig
+++ b/src/sql/postgres/PostgresSQLQuery.zig
@@ -344,8 +344,9 @@ pub fn doRun(this: *PostgresSQLQuery, globalObject: *jsc.JSGlobalObject, callfra
     var did_write = false;
     enqueue: {
         var connection_entry_value: ?**PostgresSQLStatement = null;
+        const signature_hash: u64 = bun.hash(signature.name);
         if (!connection.flags.use_unnamed_prepared_statements) {
-            const entry = connection.statements.getOrPut(bun.default_allocator, bun.hash(signature.name)) catch |err| {
+            const entry = connection.statements.getOrPut(bun.default_allocator, signature_hash) catch |err| {
                 signature.deinit();
                 return globalObject.throwError(err, "failed to allocate statement");
             };
@@ -402,6 +403,9 @@ pub fn doRun(this: *PostgresSQLQuery, globalObject: *jsc.JSGlobalObject, callfra
                 debug("prepareAndQueryWithSignature", .{});
                 // prepareAndQueryWithSignature will write + bind + execute, it will change to running after binding is complete
                 PostgresRequest.prepareAndQueryWithSignature(globalObject, query_str.slice(), binding_value, PostgresSQLConnection.Writer, writer, &signature) catch |err| {
+                    if (connection_entry_value != null) {
+                        _ = connection.statements.remove(signature_hash);
+                    }
                     signature.deinit();
                     if (this.statement) |stmt| {
                         this.statement = null;
@@ -420,6 +424,9 @@ pub fn doRun(this: *PostgresSQLQuery, globalObject: *jsc.JSGlobalObject, callfra
                 debug("writeQuery", .{});
 
                 PostgresRequest.writeQuery(query_str.slice(), signature.prepared_statement_name, signature.fields, PostgresSQLConnection.Writer, writer) catch |err| {
+                    if (connection_entry_value != null) {
+                        _ = connection.statements.remove(signature_hash);
+                    }
                     signature.deinit();
                     if (this.statement) |stmt| {
                         this.statement = null;
@@ -431,6 +438,9 @@ pub fn doRun(this: *PostgresSQLQuery, globalObject: *jsc.JSGlobalObject, callfra
                     return error.JSError;
                 };
                 writer.write(&protocol.Sync) catch |err| {
+                    if (connection_entry_value != null) {
+                        _ = connection.statements.remove(signature_hash);
+                    }
                     signature.deinit();
                     if (!globalObject.hasException())
                         return globalObject.throwValue(postgresErrorToJS(globalObject, "failed to flush", err));
@@ -443,6 +453,9 @@ pub fn doRun(this: *PostgresSQLQuery, globalObject: *jsc.JSGlobalObject, callfra
         }
         {
             const stmt = bun.default_allocator.create(PostgresSQLStatement) catch {
+                if (connection_entry_value != null) {
+                    _ = connection.statements.remove(signature_hash);
+                }
                 this.deref();
                 return globalObject.throwOutOfMemory();
             };

--- a/src/sql/postgres/protocol/NewWriter.zig
+++ b/src/sql/postgres/protocol/NewWriter.zig
@@ -69,7 +69,12 @@ pub fn NewWriterWrap(
         }
 
         pub fn short(this: @This(), value: anytype) !void {
-            try this.write(std.mem.asBytes(&@byteSwap(@as(u16, @intCast(value)))));
+            const T = @TypeOf(value);
+            const int_value = switch (@typeInfo(T)) {
+                .int, .comptime_int => value,
+                else => @compileError("short() requires an integer type"),
+            };
+            try this.write(std.mem.asBytes(&@byteSwap(std.math.cast(u16, int_value) orelse return error.TooManyParameters)));
         }
 
         pub fn string(this: @This(), value: []const u8) !void {

--- a/src/sql/postgres/protocol/Parse.zig
+++ b/src/sql/postgres/protocol/Parse.zig
@@ -14,6 +14,9 @@ pub fn writeInternal(
     writer: NewWriter(Context),
 ) !void {
     const parameters = this.params;
+    if (parameters.len > std.math.maxInt(u16)) {
+        return error.TooManyParameters;
+    }
     const count: usize = @sizeOf((u32)) + @sizeOf(u16) + (parameters.len * @sizeOf(u32)) + @max(zCount(this.name), 1) + @max(zCount(this.query), 1);
     const header = [_]u8{
         'P',

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -12366,24 +12366,18 @@ CREATE TABLE ${table_name} (
       await using db = postgres(options);
       const tableName = `test_${randomUUIDv7("hex").replaceAll("-", "")}`;
 
-      await db`CREATE TEMPORARY TABLE ${db(tableName)} (a INT, b INT, c INT, d INT, e INT, f INT, g INT, h INT, i INT, j INT)`;
+      await db`CREATE TEMPORARY TABLE ${db(tableName)} (a INT, b INT, c INT)`;
 
-      // 10 columns * 7000 rows = 70000 parameters, exceeding the 65535 limit
-      const rows = Array.from({ length: 7000 }, (_, i) => ({
-        a: i,
-        b: i,
-        c: i,
-        d: i,
-        e: i,
-        f: i,
-        g: i,
-        h: i,
-        i: i,
-        j: i,
-      }));
+      // 3 columns * 21845 rows = 65535 parameters, exactly at the limit - should succeed
+      const maxRows = Array.from({ length: 21845 }, (_, i) => ({ a: i, b: i, c: i }));
+      await db`INSERT INTO ${db(tableName)} ${db(maxRows)}`;
+      const [{ count }] = await db`SELECT count(*)::int as count FROM ${db(tableName)}`;
+      expect(count).toBe(21845);
 
+      // 3 columns * 21846 rows = 65538 parameters, just over the limit - should throw
+      const overLimitRows = Array.from({ length: 21846 }, (_, i) => ({ a: i, b: i, c: i }));
       try {
-        await db`INSERT INTO ${db(tableName)} ${db(rows)}`;
+        await db`INSERT INTO ${db(tableName)} ${db(overLimitRows)}`;
         expect.unreachable("should have thrown");
       } catch (e: any) {
         expect(e.code).toBe("ERR_POSTGRES_TOO_MANY_PARAMETERS");

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -12362,5 +12362,33 @@ CREATE TABLE ${table_name} (
       expect(result2).toBeArray();
       expect(Array.from(result2[0].numbers)).toEqual([]);
     });
+    test("throws clear error when query exceeds 65535 parameter limit", async () => {
+      await using db = postgres(options);
+      const tableName = `test_${randomUUIDv7("hex").replaceAll("-", "")}`;
+
+      await db`CREATE TEMPORARY TABLE ${db(tableName)} (a INT, b INT, c INT, d INT, e INT, f INT, g INT, h INT, i INT, j INT)`;
+
+      // 10 columns * 7000 rows = 70000 parameters, exceeding the 65535 limit
+      const rows = Array.from({ length: 7000 }, (_, i) => ({
+        a: i,
+        b: i,
+        c: i,
+        d: i,
+        e: i,
+        f: i,
+        g: i,
+        h: i,
+        i: i,
+        j: i,
+      }));
+
+      try {
+        await db`INSERT INTO ${db(tableName)} ${db(rows)}`;
+        expect.unreachable("should have thrown");
+      } catch (e: any) {
+        expect(e.code).toBe("ERR_POSTGRES_TOO_MANY_PARAMETERS");
+        expect(e.message).toContain("65535");
+      }
+    });
   }); // Close "PostgreSQL tests" describe
 } // Close if (isDockerEnabled())


### PR DESCRIPTION
## Summary
- Large batch inserts with more than 65,535 total parameters (e.g. 7,000 rows × 10 columns = 70,000 params) caused a Zig `@intCast` panic ("integer does not fit in destination type") because the PostgreSQL wire protocol uses 16-bit integers for parameter counts.
- Now validates parameter counts upfront in `writeBind()` and `Parse.writeInternal()`, returning a descriptive `TooManyParameters` error with code `ERR_POSTGRES_TOO_MANY_PARAMETERS` and a hint to reduce batch size.
- Changed `len` type from `u32` (via `@truncate`) to `u16` (via `@intCast` after validation) in `writeBind()` for correctness.

Before:
```
panic: integer does not fit in destination type
```

After:
```
PostgresError: query has too many parameters - the PostgreSQL wire protocol supports a maximum of 65535 parameters per query. Try reducing your batch size.
  code: "ERR_POSTGRES_TOO_MANY_PARAMETERS"
  hint: "Reduce the number of rows in your batch insert so that total_rows * columns_per_row does not exceed 65535."
```

## Test plan
- [ ] New test in `test/js/sql/sql.test.ts`: "throws clear error when query exceeds 65535 parameter limit" — creates a 10-column table and attempts inserting 7,000 rows (70,000 params), expecting the new error code and message

🤖 Generated with [Claude Code](https://claude.com/claude-code)