### PR TITLE
feat(bundler): add --allow-unresolved to gate dynamic import specifiers

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2583,6 +2583,21 @@ declare module "bun" {
     plugins?: BunPlugin[];
     // manifest?: boolean; // whether to return manifest
     external?: string[];
+    /**
+     * Control whether dynamic `import()` / `require()` specifiers (non-literal
+     * arguments like `` `./locales/${lang}.json` ``) are allowed to pass through
+     * to runtime without being bundled.
+     *
+     * - `["*"]` (default) — allow all dynamic specifiers
+     * - `[]` — fail the build on any dynamic specifier
+     * - `["./locales/*.json", ...]` — allow only specifiers whose static
+     *   template parts match one of these glob patterns
+     *
+     * Add `""` to the list to allow fully opaque specifiers like `import(fn())`.
+     *
+     * @default ["*"]
+     */
+    allowUnresolved?: string[];
     packages?: "bundle" | "external";
     publicPath?: string;
     define?: Record<string, string>;

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2584,7 +2584,7 @@ declare module "bun" {
     // manifest?: boolean; // whether to return manifest
     external?: string[];
     /**
-     * Control whether dynamic `import()` / `require()` specifiers (non-literal
+     * Control whether dynamic `import()`, `require()`, or `require.resolve()` specifiers (non-literal
      * arguments like `` `./locales/${lang}.json` ``) are allowed to pass through
      * to runtime without being bundled.
      *

--- a/src/ast/P.zig
+++ b/src/ast/P.zig
@@ -511,6 +511,67 @@ pub fn NewParser_(
             return p.options.bundle and p.source.index.isRuntime();
         }
 
+        /// Extracts a matchable "shape" from a dynamic import argument.
+        /// Template literals: static parts joined by \x00 placeholders.
+        /// Everything else: empty string.
+        fn extractDynamicSpecifierShape(p: *P, arg: Expr, buf: *std.array_list.Managed(u8)) []const u8 {
+            if (arg.data.as(.e_template)) |tmpl| {
+                if (tmpl.tag != null) return ""; // tagged template — opaque
+                switch (tmpl.head) {
+                    .cooked => |*head| {
+                        buf.appendSlice(head.slice(p.allocator)) catch bun.outOfMemory();
+                    },
+                    .raw => return "", // shouldn't happen post-visit but be safe
+                }
+                for (tmpl.parts) |*part| {
+                    buf.append(0) catch bun.outOfMemory(); // \x00 placeholder per interpolation
+                    switch (part.tail) {
+                        .cooked => |*tail| {
+                            buf.appendSlice(tail.slice(p.allocator)) catch bun.outOfMemory();
+                        },
+                        .raw => {},
+                    }
+                }
+                return buf.items;
+            }
+            return "";
+        }
+
+        pub fn checkDynamicSpecifier(p: *P, arg: Expr, loc: logger.Loc, comptime kind: []const u8) void {
+            if (!p.options.bundle or p.options.allow_unresolved.* == .all) return;
+
+            var shape_buf = std.array_list.Managed(u8).init(p.allocator);
+            const shape = p.extractDynamicSpecifierShape(arg, &shape_buf);
+            if (!p.options.allow_unresolved.allows(shape)) {
+                const r = js_lexer.rangeOfIdentifier(p.source, loc);
+                if (shape.len > 0) {
+                    // Print a human-readable shape: replace \x00 with *
+                    const display = p.allocator.dupe(u8, shape) catch bun.outOfMemory();
+                    for (display) |*c| if (c.* == 0) {
+                        c.* = '*';
+                    };
+                    p.log.addRangeErrorFmtWithNote(
+                        p.source,
+                        r,
+                        p.allocator,
+                        "This " ++ kind ++ " expression will not be bundled because the argument is not a string literal",
+                        .{},
+                        "The specifier shape \"{s}\" does not match any --allow-unresolved pattern",
+                        .{display},
+                        r,
+                    ) catch bun.outOfMemory();
+                } else {
+                    p.log.addRangeErrorFmt(
+                        p.source,
+                        r,
+                        p.allocator,
+                        "This " ++ kind ++ " expression will not be bundled because the argument is not a string literal",
+                        .{},
+                    ) catch bun.outOfMemory();
+                }
+            }
+        }
+
         pub fn transposeImport(noalias p: *P, arg: Expr, state: *const TransposeState) Expr {
             // The argument must be a string
             if (arg.data.as(.e_string)) |str| {
@@ -543,6 +604,8 @@ pub fn NewParser_(
                 p.log.addRangeDebug(p.source, r, "This \"import\" expression cannot be bundled because the argument is not a string literal") catch unreachable;
             }
 
+            p.checkDynamicSpecifier(arg, state.loc, "import()");
+
             return p.newExpr(E.Import{
                 .expr = arg,
                 .options = state.import_options,
@@ -561,6 +624,8 @@ pub fn NewParser_(
                 const r = js_lexer.rangeOfIdentifier(p.source, arg.loc);
                 p.log.addRangeDebug(p.source, r, "This \"require.resolve\" expression cannot be bundled because the argument is not a string literal") catch unreachable;
             }
+
+            p.checkDynamicSpecifier(arg, arg.loc, "require.resolve()");
 
             const args = p.allocator.alloc(Expr, 1) catch unreachable;
             args[0] = arg;
@@ -673,6 +738,7 @@ pub fn NewParser_(
                     return p.newExpr(E.RequireString{ .import_record_index = import_record_index }, arg.loc);
                 },
                 else => {
+                    p.checkDynamicSpecifier(arg, arg.loc, "require()");
                     p.recordUsageOfRuntimeRequire();
                     const args = p.allocator.alloc(Expr, 1) catch unreachable;
                     args[0] = arg;

--- a/src/ast/P.zig
+++ b/src/ast/P.zig
@@ -548,6 +548,7 @@ pub fn NewParser_(
                 if (shape.len > 0) {
                     // Print a human-readable shape: replace \x00 with *
                     const display = p.allocator.dupe(u8, shape) catch bun.outOfMemory();
+                    defer p.allocator.free(display);
                     for (display) |*c| if (c.* == 0) {
                         c.* = '*';
                     };

--- a/src/ast/P.zig
+++ b/src/ast/P.zig
@@ -558,17 +558,21 @@ pub fn NewParser_(
                         p.allocator,
                         "This " ++ kind ++ " expression will not be bundled because the argument is not a string literal",
                         .{},
-                        "The specifier shape \"{s}\" does not match any --allow-unresolved pattern",
-                        .{display},
+                        "The specifier shape \"{s}\" does not match any --allow-unresolved pattern. " ++
+                            "To allow it, add a matching pattern: Bun.build({{ allowUnresolved: [\"{s}\"] }}) or --allow-unresolved '{s}'",
+                        .{ display, display, display },
                         r,
                     ) catch bun.outOfMemory();
                 } else {
-                    p.log.addRangeErrorFmt(
+                    p.log.addRangeErrorFmtWithNote(
                         p.source,
                         r,
                         p.allocator,
                         "This " ++ kind ++ " expression will not be bundled because the argument is not a string literal",
                         .{},
+                        "To allow opaque dynamic specifiers, use Bun.build({{ allowUnresolved: [\"\"] }}) or pass --allow-unresolved with an empty-string pattern",
+                        .{},
+                        r,
                     ) catch bun.outOfMemory();
                 }
             }

--- a/src/ast/P.zig
+++ b/src/ast/P.zig
@@ -529,7 +529,7 @@ pub fn NewParser_(
                         .cooked => |*tail| {
                             buf.appendSlice(tail.slice(p.allocator)) catch bun.outOfMemory();
                         },
-                        .raw => {},
+                        .raw => return "", // raw tail — treat as opaque
                     }
                 }
                 return buf.items;
@@ -541,6 +541,7 @@ pub fn NewParser_(
             if (!p.options.bundle or p.options.allow_unresolved.* == .all) return;
 
             var shape_buf = std.array_list.Managed(u8).init(p.allocator);
+            defer shape_buf.deinit();
             const shape = p.extractDynamicSpecifierShape(arg, &shape_buf);
             if (!p.options.allow_unresolved.allows(shape)) {
                 const r = js_lexer.rangeOfIdentifier(p.source, loc);

--- a/src/ast/Parser.zig
+++ b/src/ast/Parser.zig
@@ -26,6 +26,8 @@ pub const Parser = struct {
 
         warn_about_unbundled_modules: bool = true,
 
+        allow_unresolved: *const options.AllowUnresolved = &options.AllowUnresolved.default,
+
         module_type: options.ModuleType = .unknown,
         output_format: options.Format = .esm,
 

--- a/src/ast/visitExpr.zig
+++ b/src/ast/visitExpr.zig
@@ -1357,7 +1357,7 @@ pub fn VisitExpr(
                         p.log.addRangeDebug(p.source, r, "This call to \"require\" will not be bundled because it has multiple arguments") catch unreachable;
                     }
 
-                    if (e_.args.len == 1) {
+                    if (e_.args.len >= 1) {
                         p.checkDynamicSpecifier(e_.args.slice()[0], e_.target.loc, "require()");
                     }
 
@@ -1391,8 +1391,10 @@ pub fn VisitExpr(
                             },
                             else => {},
                         }
+                    }
 
-                        p.checkDynamicSpecifier(first, e_.target.loc, "require.resolve()");
+                    if (e_.args.len >= 1) {
+                        p.checkDynamicSpecifier(e_.args.slice()[0], e_.target.loc, "require.resolve()");
                     }
 
                     return expr;

--- a/src/ast/visitExpr.zig
+++ b/src/ast/visitExpr.zig
@@ -1357,6 +1357,10 @@ pub fn VisitExpr(
                         p.log.addRangeDebug(p.source, r, "This call to \"require\" will not be bundled because it has multiple arguments") catch unreachable;
                     }
 
+                    if (e_.args.len == 1) {
+                        p.checkDynamicSpecifier(e_.args.slice()[0], e_.target.loc, "require()");
+                    }
+
                     if (p.options.features.allow_runtime) {
                         p.recordUsageOfRuntimeRequire();
                     }
@@ -1387,6 +1391,8 @@ pub fn VisitExpr(
                             },
                             else => {},
                         }
+
+                        p.checkDynamicSpecifier(first, e_.target.loc, "require.resolve()");
                     }
 
                     return expr;

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -234,6 +234,7 @@ pub const JSBundler = struct {
         emit_dce_annotations: ?bool = null,
         names: Names = .{},
         external: bun.StringSet = bun.StringSet.init(bun.default_allocator),
+        allow_unresolved: ?bun.StringSet = null,
         source_map: options.SourceMapOption = .none,
         public_path: OwnedString = OwnedString.initEmpty(bun.default_allocator),
         conditions: bun.StringSet = bun.StringSet.init(bun.default_allocator),
@@ -806,6 +807,23 @@ pub const JSBundler = struct {
                 }
             }
 
+            if (try config.getOwn(globalThis, "allowUnresolved")) |allow_unresolved_val| {
+                if (!allow_unresolved_val.isUndefined() and !allow_unresolved_val.isNull()) {
+                    if (!allow_unresolved_val.jsTypeLoose().isArray()) {
+                        return globalThis.throwInvalidArguments("allowUnresolved must be an array", .{});
+                    }
+                    this.allow_unresolved = bun.StringSet.init(bun.default_allocator);
+                    if (try allow_unresolved_val.getLength(globalThis) > 0) {
+                        var iter = try allow_unresolved_val.arrayIterator(globalThis);
+                        while (try iter.next()) |entry| {
+                            var slice = try entry.toSliceOrNull(globalThis);
+                            defer slice.deinit();
+                            try this.allow_unresolved.?.insert(slice.slice());
+                        }
+                    }
+                }
+            }
+
             if (try config.getOwnArray(globalThis, "drop")) |drops| {
                 var iter = try drops.arrayIterator(globalThis);
                 while (try iter.next()) |entry| {
@@ -1106,6 +1124,7 @@ pub const JSBundler = struct {
         pub fn deinit(self: *Config, allocator: std.mem.Allocator) void {
             self.entry_points.deinit();
             self.external.deinit();
+            if (self.allow_unresolved) |*a| a.deinit();
             self.define.deinit();
             self.dir.deinit();
             self.serve.deinit(allocator);

--- a/src/bundler/ParseTask.zig
+++ b/src/bundler/ParseTask.zig
@@ -1204,6 +1204,7 @@ fn runWithSourceCode(
     var opts = js_parser.Parser.Options.init(task.jsx, loader);
     opts.bundle = true;
     opts.warn_about_unbundled_modules = false;
+    opts.allow_unresolved = &transpiler.options.allow_unresolved;
     opts.macro_context = &transpiler.macro_context.?;
     opts.package_version = task.package_version;
 

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -1999,6 +1999,7 @@ pub const BundleV2 = struct {
             transpiler.options.inlining = config.minify.syntax;
             transpiler.options.source_map = config.source_map;
             transpiler.options.packages = config.packages;
+            transpiler.options.allow_unresolved = if (config.allow_unresolved) |*a| options.AllowUnresolved.fromStrings(a.keys()) else .all;
             transpiler.options.code_splitting = config.code_splitting;
             transpiler.options.emit_dce_annotations = config.emit_dce_annotations orelse !config.minify.whitespace;
             transpiler.options.ignore_dce_annotations = config.ignore_dce_annotations;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -480,6 +480,7 @@ pub const Command = struct {
             compile_autoload_package_json: bool = false,
             compile_executable_path: ?[]const u8 = null,
             windows: options.WindowsOptions = .{},
+            allow_unresolved: ?[]const []const u8 = null,
         };
 
         pub fn create(allocator: std.mem.Allocator, log: *logger.Log, comptime command: Command.Tag) anyerror!Context {

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -184,6 +184,7 @@ pub const build_only_params = [_]ParamType{
     clap.parseParam("--splitting                      Enable code splitting") catch unreachable,
     clap.parseParam("--public-path <STR>              A prefix to be appended to any import paths in bundled code") catch unreachable,
     clap.parseParam("-e, --external <STR>...          Exclude module from transpilation (can use * wildcards). ex: -e react") catch unreachable,
+    clap.parseParam("--allow-unresolved <STR>...      Allow unresolved dynamic import()/require() specifiers matching these glob patterns. Default is '*' (allow all).") catch unreachable,
     clap.parseParam("--packages <STR>                 Add dependencies to bundle or keep them external. \"external\", \"bundle\" is supported. Defaults to \"bundle\".") catch unreachable,
     clap.parseParam("--entry-naming <STR>             Customize entry point filenames. Defaults to \"[dir]/[name].[ext]\"") catch unreachable,
     clap.parseParam("--chunk-naming <STR>             Customize chunk filenames. Defaults to \"[name]-[hash].[ext]\"") catch unreachable,
@@ -1028,6 +1029,15 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                 externals[i] = external;
             }
             opts.external = externals;
+        }
+
+        if (args.options("--allow-unresolved").len > 0) {
+            const raw = args.options("--allow-unresolved");
+            var allow = try allocator.alloc([]const u8, raw.len);
+            for (raw, 0..) |val, i| {
+                allow[i] = val;
+            }
+            ctx.bundler_options.allow_unresolved = allow;
         }
 
         if (args.option("--packages")) |packages| {

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -1041,7 +1041,8 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
             const raw = args.options("--allow-unresolved");
             var allow = try allocator.alloc([]const u8, raw.len);
             for (raw, 0..) |val, i| {
-                allow[i] = val;
+                // "<empty>" sentinel represents the empty-string pattern (for matching opaque specifiers)
+                allow[i] = if (strings.eqlComptime(val, "<empty>")) "" else val;
             }
             ctx.bundler_options.allow_unresolved = allow;
         }

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -1032,7 +1032,10 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
             opts.external = externals;
         }
 
-        if (args.flag("--reject-unresolved")) {
+        if (args.flag("--reject-unresolved") and args.options("--allow-unresolved").len > 0) {
+            Output.prettyErrorln("<r><red>error<r>: --reject-unresolved and --allow-unresolved cannot be used together", .{});
+            Global.crash();
+        } else if (args.flag("--reject-unresolved")) {
             ctx.bundler_options.allow_unresolved = &.{};
         } else if (args.options("--allow-unresolved").len > 0) {
             const raw = args.options("--allow-unresolved");

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -184,7 +184,7 @@ pub const build_only_params = [_]ParamType{
     clap.parseParam("--splitting                      Enable code splitting") catch unreachable,
     clap.parseParam("--public-path <STR>              A prefix to be appended to any import paths in bundled code") catch unreachable,
     clap.parseParam("-e, --external <STR>...          Exclude module from transpilation (can use * wildcards). ex: -e react") catch unreachable,
-    clap.parseParam("--allow-unresolved <STR>...      Allow unresolved dynamic import()/require() specifiers matching these glob patterns. Default is '*' (allow all).") catch unreachable,
+    clap.parseParam("--allow-unresolved <STR>...      Allow unresolved dynamic import()/require() specifiers matching these glob patterns. Use '<empty>' for opaque specifiers. Default is '*' (allow all).") catch unreachable,
     clap.parseParam("--reject-unresolved              Fail the build on any dynamic import()/require() specifier that cannot be resolved at build time.") catch unreachable,
     clap.parseParam("--packages <STR>                 Add dependencies to bundle or keep them external. \"external\", \"bundle\" is supported. Defaults to \"bundle\".") catch unreachable,
     clap.parseParam("--entry-naming <STR>             Customize entry point filenames. Defaults to \"[dir]/[name].[ext]\"") catch unreachable,

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -185,6 +185,7 @@ pub const build_only_params = [_]ParamType{
     clap.parseParam("--public-path <STR>              A prefix to be appended to any import paths in bundled code") catch unreachable,
     clap.parseParam("-e, --external <STR>...          Exclude module from transpilation (can use * wildcards). ex: -e react") catch unreachable,
     clap.parseParam("--allow-unresolved <STR>...      Allow unresolved dynamic import()/require() specifiers matching these glob patterns. Default is '*' (allow all).") catch unreachable,
+    clap.parseParam("--reject-unresolved              Fail the build on any dynamic import()/require() specifier that cannot be resolved at build time.") catch unreachable,
     clap.parseParam("--packages <STR>                 Add dependencies to bundle or keep them external. \"external\", \"bundle\" is supported. Defaults to \"bundle\".") catch unreachable,
     clap.parseParam("--entry-naming <STR>             Customize entry point filenames. Defaults to \"[dir]/[name].[ext]\"") catch unreachable,
     clap.parseParam("--chunk-naming <STR>             Customize chunk filenames. Defaults to \"[name]-[hash].[ext]\"") catch unreachable,
@@ -1031,7 +1032,9 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
             opts.external = externals;
         }
 
-        if (args.options("--allow-unresolved").len > 0) {
+        if (args.flag("--reject-unresolved")) {
+            ctx.bundler_options.allow_unresolved = &.{};
+        } else if (args.options("--allow-unresolved").len > 0) {
             const raw = args.options("--allow-unresolved");
             var allow = try allocator.alloc([]const u8, raw.len);
             for (raw, 0..) |val, i| {

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -85,6 +85,7 @@ pub const BuildCommand = struct {
         this_transpiler.options.drop = ctx.args.drop;
         this_transpiler.options.bundler_feature_flags = Runtime.Features.initBundlerFeatureFlags(allocator, ctx.args.feature_flags);
 
+        this_transpiler.options.allow_unresolved = if (ctx.bundler_options.allow_unresolved) |a| options.AllowUnresolved.fromStrings(a) else .all;
         this_transpiler.options.css_chunking = ctx.bundler_options.css_chunking;
         this_transpiler.options.metafile = ctx.bundler_options.metafile.len > 0 or ctx.bundler_options.metafile_md.len > 0;
 

--- a/src/options.zig
+++ b/src/options.zig
@@ -50,6 +50,36 @@ pub fn stringHashMapFromArrays(comptime t: type, allocator: std.mem.Allocator, t
     return hash_map;
 }
 
+pub const AllowUnresolved = union(enum) {
+    /// Default. Skip all checks — current behavior.
+    all,
+    /// Always error on dynamic specifiers.
+    none,
+    /// Glob patterns; at least one must match the extracted shape.
+    patterns: []const string,
+
+    pub const default: AllowUnresolved = .all;
+
+    /// Normalize from raw CLI/JS input.
+    /// [] → .none, contains "*" → .all, else → .patterns
+    pub fn fromStrings(strs: []const string) AllowUnresolved {
+        if (strs.len == 0) return .none;
+        for (strs) |s| if (bun.strings.eqlComptime(s, "*")) return .all;
+        return .{ .patterns = strs };
+    }
+
+    /// shape is the extracted template representation (may be "").
+    pub fn allows(self: AllowUnresolved, shape: []const u8) bool {
+        return switch (self) {
+            .all => true,
+            .none => false,
+            .patterns => |pats| for (pats) |p| {
+                if (bun.glob.match(p, shape).matches()) break true;
+            } else false,
+        };
+    }
+};
+
 pub const ExternalModules = struct {
     node_modules: std.BufSet,
     abs_paths: std.BufSet,
@@ -1774,6 +1804,7 @@ pub const BundleOptions = struct {
     /// TODO: remove this in favor accessing bundler.log
     log: *logger.Log,
     external: ExternalModules,
+    allow_unresolved: AllowUnresolved = .all,
     entry_points: []const string,
     entry_naming: []const u8 = "",
     asset_naming: []const u8 = "",

--- a/test/bundler/bundler_allow_unresolved.test.ts
+++ b/test/bundler/bundler_allow_unresolved.test.ts
@@ -1,0 +1,199 @@
+import { describe } from "bun:test";
+import { itBundled } from "./expectBundled";
+
+describe("bundler", () => {
+  // 1. Default passes — dynamic import with no allowUnresolved → build succeeds
+  itBundled("allow-unresolved/DefaultPasses", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo";
+        import(\`./a/\${x}.js\`);
+      `,
+    },
+    outdir: "/out",
+  });
+
+  // 2. Empty array rejects template
+  itBundled("allow-unresolved/EmptyArrayRejectsTemplate", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo";
+        import(\`./a/\${x}.js\`);
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: [],
+    bundleErrors: {
+      "/entry.js": ["will not be bundled"],
+    },
+  });
+
+  // 3. Empty array rejects opaque
+  itBundled("allow-unresolved/EmptyArrayRejectsOpaque", {
+    files: {
+      "/entry.js": /* js */ `
+        function fn() { return "./foo.js"; }
+        import(fn());
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: [],
+    bundleErrors: {
+      "/entry.js": ["will not be bundled"],
+    },
+  });
+
+  // 4. Matching pattern allows
+  itBundled("allow-unresolved/MatchingPatternAllows", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "en";
+        import(\`./locales/\${x}.json\`);
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: ["./locales/*.json"],
+  });
+
+  // 5. Non-matching pattern rejects
+  itBundled("allow-unresolved/NonMatchingPatternRejects", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo";
+        import(\`./vendor/\${x}.js\`);
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: ["./locales/*"],
+    bundleErrors: {
+      "/entry.js": ["will not be bundled"],
+    },
+  });
+
+  // 6. Empty-string pattern allows opaque
+  itBundled("allow-unresolved/EmptyStringPatternAllowsOpaque", {
+    files: {
+      "/entry.js": /* js */ `
+        function getPath() { return "./foo.js"; }
+        import(getPath());
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: [""],
+  });
+
+  // 7. Empty-string pattern still rejects templates
+  itBundled("allow-unresolved/EmptyStringPatternRejectsTemplates", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo";
+        import(\`./a/\${x}.js\`);
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: [""],
+    bundleErrors: {
+      "/entry.js": ["will not be bundled"],
+    },
+  });
+
+  // 8. try/catch does NOT bypass
+  itBundled("allow-unresolved/TryCatchDoesNotBypass", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo";
+        try { await import(\`./a/\${x}.js\`) } catch {}
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: [],
+    bundleErrors: {
+      "/entry.js": ["will not be bundled"],
+    },
+  });
+
+  // 9. .catch() does NOT bypass
+  itBundled("allow-unresolved/DotCatchDoesNotBypass", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo";
+        import(\`./a/\${x}.js\`).catch(() => {});
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: [],
+    bundleErrors: {
+      "/entry.js": ["will not be bundled"],
+    },
+  });
+
+  // 10. require() variant
+  itBundled("allow-unresolved/RequireVariant", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo";
+        require(\`./a/\${x}.js\`);
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: [],
+    bundleErrors: {
+      "/entry.js": ["will not be bundled"],
+    },
+  });
+
+  // 11. require() in try/catch does NOT bypass
+  itBundled("allow-unresolved/RequireTryCatchDoesNotBypass", {
+    files: {
+      "/entry.js": /* js */ `
+        try { require(someVar) } catch {}
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: [],
+    bundleErrors: {
+      "/entry.js": ["will not be bundled"],
+    },
+  });
+
+  // 12. require.resolve()
+  itBundled("allow-unresolved/RequireResolve", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo";
+        require.resolve(\`./a/\${x}.js\`);
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: [],
+    bundleErrors: {
+      "/entry.js": ["will not be bundled"],
+    },
+  });
+
+  // 13. Multiple interpolations
+  itBundled("allow-unresolved/MultipleInterpolations", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo", y = "bar";
+        import(\`./a/\${x}/b/\${y}.js\`);
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: ["./a/*/b/*.js"],
+  });
+
+  // 14. "*" anywhere collapses to .all
+  itBundled("allow-unresolved/StarCollapsesToAll", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo";
+        import(\`./a/\${x}.js\`);
+        function fn() { return "./b.js"; }
+        import(fn());
+      `,
+    },
+    outdir: "/out",
+    allowUnresolved: ["./locales/*", "*"],
+  });
+});

--- a/test/bundler/bundler_allow_unresolved.test.ts
+++ b/test/bundler/bundler_allow_unresolved.test.ts
@@ -146,6 +146,7 @@ describe("bundler", () => {
   itBundled("allow-unresolved/RequireTryCatchDoesNotBypass", {
     files: {
       "/entry.js": /* js */ `
+        const someVar = "./dynamic.js";
         try { require(someVar) } catch {}
       `,
     },
@@ -195,5 +196,34 @@ describe("bundler", () => {
     },
     outdir: "/out",
     allowUnresolved: ["./locales/*", "*"],
+  });
+
+  // 15. CLI path: empty array rejects (--reject-unresolved)
+  itBundled("allow-unresolved/CLIRejectUnresolved", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "foo";
+        import(\`./a/\${x}.js\`);
+      `,
+    },
+    outdir: "/out",
+    backend: "cli",
+    allowUnresolved: [],
+    bundleErrors: {
+      "/entry.js": ["will not be bundled"],
+    },
+  });
+
+  // 16. CLI path: matching pattern allows
+  itBundled("allow-unresolved/CLIMatchingPatternAllows", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = "en";
+        import(\`./locales/\${x}.json\`);
+      `,
+    },
+    outdir: "/out",
+    backend: "cli",
+    allowUnresolved: ["./locales/*.json"],
   });
 });

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -581,6 +581,9 @@ function expectBundled(
   if (ESBUILD && _throw) {
     throw new Error("throw not implemented in esbuild");
   }
+  if (ESBUILD && allowUnresolved !== undefined) {
+    throw new Error("allowUnresolved not possible in esbuild backend");
+  }
   if (dryRun) {
     return testRef(id, opts);
   }
@@ -723,9 +726,6 @@ function expectBundled(
       if (optimizeImports) {
         throw new Error("optimizeImports not possible in backend=CLI (API-only option)");
       }
-      if (ESBUILD && allowUnresolved !== undefined) {
-        throw new Error("allowUnresolved not possible in esbuild backend");
-      }
       const cmd = (
         !ESBUILD
           ? [
@@ -755,7 +755,7 @@ function expectBundled(
               allowUnresolved !== undefined &&
                 (allowUnresolved.length === 0
                   ? "--reject-unresolved"
-                  : allowUnresolved.map(x => ["--allow-unresolved", x === "" ? '""' : x])),
+                  : allowUnresolved.map(x => ["--allow-unresolved", x === "" ? "<empty>" : x])),
               packages && ["--packages", packages],
               conditions && conditions.map(x => ["--conditions", x]),
               minifyIdentifiers && `--minify-identifiers`,

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -723,6 +723,9 @@ function expectBundled(
       if (optimizeImports) {
         throw new Error("optimizeImports not possible in backend=CLI (API-only option)");
       }
+      if (ESBUILD && allowUnresolved !== undefined) {
+        throw new Error("allowUnresolved not possible in esbuild backend");
+      }
       const cmd = (
         !ESBUILD
           ? [
@@ -749,7 +752,10 @@ function expectBundled(
               `--target=${target}`,
               `--format=${format}`,
               external && external.map(x => ["--external", x]),
-              allowUnresolved && allowUnresolved.map(x => ["--allow-unresolved", x]),
+              allowUnresolved !== undefined &&
+                (allowUnresolved.length === 0
+                  ? "--reject-unresolved"
+                  : allowUnresolved.map(x => ["--allow-unresolved", x === "" ? '""' : x])),
               packages && ["--packages", packages],
               conditions && conditions.map(x => ["--conditions", x]),
               minifyIdentifiers && `--minify-identifiers`,

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -176,6 +176,7 @@ export interface BundlerTestInput {
   extensionOrder?: string[];
   /** Replaces "{{root}}" with the file root */
   external?: string[];
+  allowUnresolved?: string[];
   /** Defaults to "bundle" */
   packages?: "bundle" | "external";
   /** Defaults to "esm" */
@@ -446,6 +447,7 @@ function expectBundled(
     entryPointsRaw,
     env,
     external,
+    allowUnresolved,
     packages,
     drop = [],
     features = [],
@@ -747,6 +749,7 @@ function expectBundled(
               `--target=${target}`,
               `--format=${format}`,
               external && external.map(x => ["--external", x]),
+              allowUnresolved && allowUnresolved.map(x => ["--allow-unresolved", x]),
               packages && ["--packages", packages],
               conditions && conditions.map(x => ["--conditions", x]),
               minifyIdentifiers && `--minify-identifiers`,
@@ -1094,6 +1097,7 @@ function expectBundled(
         const buildConfig: BuildConfig = {
           entrypoints: [...entryPaths, ...(entryPointsRaw ?? [])],
           external,
+          allowUnresolved,
           banner,
           format,
           footer,


### PR DESCRIPTION
## Summary

- Adds `--allow-unresolved` CLI flag and `allowUnresolved: string[]` JS API option to control whether dynamic `import()`/`require()` specifiers with non-literal arguments are allowed during bundling
- Template literal shapes are extracted (e.g., `` `./locales/${lang}.json` `` → `./locales/*.json`) and matched against user-provided glob patterns
- Default is `["*"]` (allow all) preserving backward compatibility; `[]` rejects all dynamic specifiers
- Opaque expressions like `import(fn())` match against empty string `""` — users can add `""` to the pattern list to specifically allow them
- try/catch and `.catch()` do NOT bypass the filter — if you opted into strictness, you get strictness

## Test plan

- [x] 14 tests in `test/bundler/bundler_allow_unresolved.test.ts` covering:
  - Default permissive behavior
  - Empty array rejection (template + opaque)
  - Matching/non-matching glob patterns
  - Empty-string pattern for opaque specifiers
  - try/catch and .catch() non-bypass
  - require() and require.resolve() variants
  - Multiple interpolations
  - `*` shortcut collapsing to `.all`
- [x] Verified tests fail with `USE_SYSTEM_BUN=1` (9 fail)
- [x] Verified tests pass with `bun bd test` (14 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)