### PR TITLE
refactor: propagate SSLConfig.SharedPtr through fetch/http layers

### DIFF
--- a/src/bun.js/api/server/SSLConfig.zig
+++ b/src/bun.js/api/server/SSLConfig.zig
@@ -36,20 +36,10 @@ pub const SharedPtr = bun.ptr.shared.WithOptions(*SSLConfig, .{
 
 const WeakPtr = SharedPtr.Weak;
 
-/// Increments the strong refcount. `this` MUST have originated from
-/// `GlobalRegistry.intern()` (i.e., it points inside a `SharedPtr` allocation).
-/// Calling this on a stack-allocated or directly-heap-allocated SSLConfig is UB.
-pub fn ref(this: *SSLConfig) void {
-    var cloned = SharedPtr.cloneFromRawUnsafe(this);
-    _ = cloned.leak();
-}
-
-/// Decrements the strong refcount. Same precondition as `ref()`.
-/// When the last strong ref drops, shared.zig calls `deinit()` on this struct,
-/// which removes it from the registry and frees the string fields.
-pub fn deref(this: *SSLConfig) void {
-    var adopted = SharedPtr.adoptRawUnsafe(this);
-    adopted.deinit();
+/// Extract the raw `*SSLConfig` from an optional SharedPtr for pointer-equality
+/// comparison (interned configs have stable addresses).
+pub inline fn rawPtr(maybe_shared: ?SharedPtr) ?*SSLConfig {
+    return if (maybe_shared) |s| s.get() else null;
 }
 
 const ReadFromBlobError = bun.JSError || error{
@@ -316,11 +306,10 @@ pub const GlobalRegistry = struct {
 
     /// Takes a by-value SSLConfig, wraps it in a `SharedPtr` (strong=1), and
     /// either returns an existing equivalent (upgraded) or the new one. Either
-    /// way, caller owns exactly one strong ref on the result (leaked as a raw
-    /// pointer for ergonomic passing through the fetch/http layers).
+    /// way, caller owns exactly one strong ref on the result.
     ///
-    /// The returned `*SSLConfig` must eventually be `deref()`d.
-    pub fn intern(config: SSLConfig) *SSLConfig {
+    /// The returned `SharedPtr` must eventually be `.deinit()`d.
+    pub fn intern(config: SSLConfig) SharedPtr {
         var new_shared = SharedPtr.new(config);
         const new_ptr = new_shared.get();
 
@@ -339,8 +328,7 @@ pub const GlobalRegistry = struct {
             if (gop.value_ptr.upgrade()) |existing_shared| {
                 // Existing config is still alive; dispose the new duplicate.
                 dispose_new = new_shared;
-                var upgraded = existing_shared;
-                return upgraded.leak();
+                return existing_shared;
             }
             // strong==0: existing is dying. Its `deinit()` is blocked in
             // `remove()` waiting for this mutex, so content is still intact
@@ -350,7 +338,7 @@ pub const GlobalRegistry = struct {
             gop.key_ptr.* = new_ptr;
         }
         gop.value_ptr.* = new_shared.cloneWeak();
-        return new_shared.leak();
+        return new_shared;
     }
 
     /// Called from `SSLConfig.deinit()` on strong 1->0. If `intern()` replaced

--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -240,7 +240,7 @@ fn fetchImpl(
     };
     var url_type = URLType.remote;
 
-    var ssl_config: ?*SSLConfig = null;
+    var ssl_config: ?SSLConfig.SharedPtr = null;
     var reject_unauthorized = vm.getTLSRejectUnauthorized();
     var check_server_identity: JSValue = .zero;
 
@@ -273,9 +273,9 @@ fn fetchImpl(
             range = null;
         }
 
-        if (ssl_config) |conf| {
+        if (ssl_config) |*conf| {
+            conf.deinit();
             ssl_config = null;
-            conf.deref();
         }
     }
 

--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -1287,7 +1287,7 @@ pub const FetchTasklet = struct {
         hostname: ?[]u8 = null,
         check_server_identity: jsc.Strong.Optional = .empty,
         unix_socket_path: ZigString.Slice,
-        ssl_config: ?*SSLConfig = null,
+        ssl_config: ?SSLConfig.SharedPtr = null,
         upgraded_connection: bool = false,
     };
 

--- a/src/http.zig
+++ b/src/http.zig
@@ -481,7 +481,7 @@ progress_node: ?*Progress.Node = null,
 flags: Flags = Flags{},
 
 state: InternalState = .{},
-tls_props: ?*SSLConfig = null,
+tls_props: ?SSLConfig.SharedPtr = null,
 /// The custom SSL context used for this request (null = default context).
 /// Set by HTTPThread.connect() when using custom TLS configs.
 custom_ssl_ctx: ?*NewHTTPContext(true) = null,
@@ -518,11 +518,9 @@ pub fn deinit(this: *HTTPClient) void {
         this.proxy_tunnel = null;
         tunnel.detachAndDeref();
     }
-    // Release our reference on the interned SSLConfig
-    if (this.tls_props) |config| {
-        config.deref();
-        this.tls_props = null;
-    }
+    // Release our strong ref on the interned SSLConfig
+    if (this.tls_props) |*tls| tls.deinit();
+    this.tls_props = null;
     this.unix_socket_path.deinit();
     this.unix_socket_path = jsc.ZigString.Slice.empty;
 }
@@ -1454,7 +1452,7 @@ pub fn closeAndFail(this: *HTTPClient, err: anyerror, comptime is_ssl: bool, soc
 fn startProxyHandshake(this: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket, start_payload: []const u8) void {
     log("startProxyHandshake", .{});
     // if we have options we pass them (ca, reject_unauthorized, etc) otherwise use the default
-    const ssl_options = if (this.tls_props != null) this.tls_props.?.* else jsc.API.ServerConfig.SSLConfig.zero;
+    const ssl_options = if (this.tls_props) |tls| tls.get().* else jsc.API.ServerConfig.SSLConfig.zero;
     ProxyTunnel.start(this, is_ssl, socket, ssl_options, start_payload);
 }
 

--- a/src/http/AsyncHTTP.zig
+++ b/src/http/AsyncHTTP.zig
@@ -102,7 +102,7 @@ pub const Options = struct {
     disable_keepalive: ?bool = null,
     disable_decompression: ?bool = null,
     reject_unauthorized: ?bool = null,
-    tls_props: ?*SSLConfig = null,
+    tls_props: ?SSLConfig.SharedPtr = null,
 };
 
 const Preconnect = struct {

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -9,8 +9,8 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             /// If you set `rejectUnauthorized` to `false`, the connection fails to verify,
             did_have_handshaking_error_while_reject_unauthorized_is_false: bool = false,
             /// The interned SSLConfig this socket was created with (null = default context).
-            /// Holds a ref while the socket is in the keepalive pool.
-            ssl_config: ?*SSLConfig = null,
+            /// Owns a strong ref while the socket is in the keepalive pool.
+            ssl_config: ?SSLConfig.SharedPtr = null,
             /// The context that owns this pooled socket's memory (for returning to correct pool).
             owner: *Context,
         };
@@ -96,10 +96,8 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                 var iter = this.pending_sockets.used.iterator(.{ .kind = .set });
                 while (iter.next()) |idx| {
                     const pooled = this.pending_sockets.at(@intCast(idx));
-                    if (pooled.ssl_config) |config| {
-                        config.deref();
-                        pooled.ssl_config = null;
-                    }
+                    if (pooled.ssl_config) |*s| s.deinit();
+                    pooled.ssl_config = null;
                     pooled.http_socket.close(.failure);
                 }
             }
@@ -114,7 +112,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             if (!comptime ssl) {
                 @compileError("ssl only");
             }
-            const opts = client.tls_props.?.asUSocketsForClientVerification();
+            const opts = client.tls_props.?.get().asUSocketsForClientVerification();
             try this.initWithOpts(&opts);
         }
 
@@ -188,7 +186,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
         /// If `did_have_handshaking_error_while_reject_unauthorized_is_false`
         /// is set, then we can only reuse the socket for HTTP Keep Alive if
         /// `reject_unauthorized` is set to `false`.
-        pub fn releaseSocket(this: *@This(), socket: HTTPSocket, did_have_handshaking_error_while_reject_unauthorized_is_false: bool, hostname: []const u8, port: u16, ssl_config: ?*SSLConfig) void {
+        pub fn releaseSocket(this: *@This(), socket: HTTPSocket, did_have_handshaking_error_while_reject_unauthorized_is_false: bool, hostname: []const u8, port: u16, ssl_config: ?SSLConfig.SharedPtr) void {
             // log("releaseSocket(0x{f})", .{bun.fmt.hexIntUpper(@intFromPtr(socket.socket))});
 
             if (comptime Environment.allow_assert) {
@@ -214,11 +212,9 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     pending.hostname_len = @as(u8, @truncate(hostname.len));
                     pending.port = port;
                     pending.owner = this;
-                    // Hold a ref on ssl_config while it's in the keepalive pool
-                    pending.ssl_config = ssl_config;
-                    if (ssl_config) |config| {
-                        config.ref();
-                    }
+                    // Clone a strong ref for the keepalive pool; the caller retains
+                    // its own ref via HTTPClient.tls_props.
+                    pending.ssl_config = if (ssl_config) |s| s.clone() else null;
 
                     log("Keep-Alive release {s}:{d}", .{
                         hostname,
@@ -332,11 +328,8 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             }
 
             fn addMemoryBackToPool(pooled: *PooledSocket) void {
-                // Release the ssl_config ref held by this pooled socket
-                if (pooled.ssl_config) |config| {
-                    config.deref();
-                    pooled.ssl_config = null;
-                }
+                if (pooled.ssl_config) |*s| s.deinit();
+                pooled.ssl_config = null;
                 assert(pooled.owner.pending_sockets.put(pooled));
             }
 
@@ -443,7 +436,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                 }
 
                 // Match ssl_config by pointer equality (interned configs)
-                if (socket.ssl_config != ssl_config) {
+                if (SSLConfig.rawPtr(socket.ssl_config) != ssl_config) {
                     continue;
                 }
 
@@ -464,11 +457,9 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                         continue;
                     }
 
-                    // Release the pooled socket's ssl_config ref (caller has its own ref)
-                    if (socket.ssl_config) |config| {
-                        config.deref();
-                        socket.ssl_config = null;
-                    }
+                    // Release the pool's strong ref (caller has its own via tls_props)
+                    if (socket.ssl_config) |*s| s.deinit();
+                    socket.ssl_config = null;
                     assert(this.pending_sockets.put(socket));
                     log("+ Keep-Alive reuse {s}:{d}", .{ hostname, port });
                     return http_socket;
@@ -500,7 +491,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             client.connected_url.hostname = hostname;
 
             if (client.isKeepAlivePossible()) {
-                if (this.existingSocket(client.flags.reject_unauthorized, hostname, port, client.tls_props)) |sock| {
+                if (this.existingSocket(client.flags.reject_unauthorized, hostname, port, SSLConfig.rawPtr(client.tls_props))) |sock| {
                     if (sock.ext(**anyopaque)) |ctx| {
                         ctx.* = bun.cast(**anyopaque, ActiveSocket.init(client).ptr());
                     }

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -6,6 +6,8 @@ const HTTPThread = @This();
 const SslContextCacheEntry = struct {
     ctx: *NewHTTPContext(true),
     last_used_ns: u64,
+    /// Strong ref held by the cache entry (released on eviction).
+    config_ref: SSLConfig.SharedPtr,
 };
 const ssl_context_cache_max_size = 60;
 const ssl_context_cache_ttl_ns = 30 * std.time.ns_per_min;
@@ -232,10 +234,10 @@ pub fn connect(this: *@This(), client: *HTTPClient, comptime is_ssl: bool) !NewH
         return try this.context(is_ssl).connectSocket(client, client.unix_socket_path.slice());
     }
 
-    if (comptime is_ssl) {
-        const needs_own_context = client.tls_props != null and client.tls_props.?.requires_custom_request_ctx;
-        if (needs_own_context) {
-            const requested_config = client.tls_props.?;
+    if (comptime is_ssl) custom_ctx: {
+        if (client.tls_props) |tls| {
+            if (!tls.get().requires_custom_request_ctx) break :custom_ctx;
+            const requested_config = tls.get();
 
             // Evict stale entries from the cache
             evictStaleSslContexts(this);
@@ -270,12 +272,12 @@ pub fn connect(this: *@This(), client: *HTTPClient, comptime is_ssl: bool) !NewH
                 };
             };
 
-            // Hold a ref on the config for the cache entry
-            requested_config.ref();
             const now = this.timer.read();
             bun.handleOom(custom_ssl_context_map.put(requested_config, .{
                 .ctx = custom_context,
                 .last_used_ns = now,
+                // Clone a strong ref for the cache entry; client.tls_props keeps its own.
+                .config_ref = tls.clone(),
             }));
 
             // Enforce max cache size - evict oldest entry
@@ -315,12 +317,11 @@ fn evictStaleSslContexts(this: *@This()) void {
     const now = this.timer.read();
     var i: usize = 0;
     while (i < custom_ssl_context_map.count()) {
-        const entry = custom_ssl_context_map.values()[i];
+        var entry = custom_ssl_context_map.values()[i];
         if (now -| entry.last_used_ns > ssl_context_cache_ttl_ns) {
-            const config = custom_ssl_context_map.keys()[i];
             custom_ssl_context_map.swapRemoveAt(i);
             entry.ctx.deinit();
-            config.deref();
+            entry.config_ref.deinit();
         } else {
             i += 1;
         }
@@ -338,11 +339,10 @@ fn evictOldestSslContext() void {
             oldest_idx = i;
         }
     }
-    const entry = custom_ssl_context_map.values()[oldest_idx];
-    const config = custom_ssl_context_map.keys()[oldest_idx];
+    var entry = custom_ssl_context_map.values()[oldest_idx];
     custom_ssl_context_map.swapRemoveAt(oldest_idx);
     entry.ctx.deinit();
-    config.deref();
+    entry.config_ref.deinit();
 }
 
 fn drainQueuedShutdowns(this: *@This()) void {


### PR DESCRIPTION
**Stacked on #27838** (follows up on #27872 which was already merged into #27838).

## What

#27872 migrated `SSLConfig` refcounting to `bun.ptr.shared` but kept consumers using raw `*SSLConfig` pointers, bridging via `leak()` / `adoptRawUnsafe()` / `cloneFromRawUnsafe()`. This PR eliminates that escape hatch by propagating `SSLConfig.SharedPtr` through the ownership chain end-to-end.

## Changes

| File | Change |
|---|---|
| `SSLConfig.zig` | `ref()`/`deref()` removed (were unsafe wrappers); `intern()` returns `SharedPtr` directly; `rawPtr()` helper added for ptr-eq comparison |
| `fetch.zig` | `ssl_config: ?SSLConfig.SharedPtr`; `.deinit()` in error-path defer |
| `FetchTasklet.zig` | `FetchOptions.ssl_config: ?SSLConfig.SharedPtr` |
| `AsyncHTTP.zig` | `options.tls_props: ?SSLConfig.SharedPtr` |
| `http.zig` | `HTTPClient.tls_props: ?SSLConfig.SharedPtr`; `.deinit()` in `HTTPClient.deinit()`; `.get()` for data access |
| `HTTPContext.zig` | `PooledSocket.ssl_config: ?SSLConfig.SharedPtr`; `.clone()` in `releaseSocket`; `rawPtr()` for comparison in `existingSocket` |
| `HTTPThread.zig` | `SslContextCacheEntry.config_ref: SharedPtr` (strong ref held by cache, `.clone()` on insert, `.deinit()` on evict) |

**-23 LOC net.**

## Ownership model (after)

```
intern() → SharedPtr              (strong=1)
  → ssl_config (fetch.zig)        move
  → FetchOptions.ssl_config        move (vehicle struct, never deinit'd)
  → AsyncHTTP options.tls_props    move
  → HTTPClient.tls_props           move → .deinit() at end

Branches:
  → releaseSocket: .clone()        pool holds +1 → .deinit() on reuse/close
  → SslContextCache: .clone()      entry holds +1 → .deinit() on evict
```

Pointer-equality lookups (`custom_ssl_context_map` key, `existingSocket` match) use `rawPtr()` = `if (maybe) |s| s.get() else null` — interned configs have stable addresses inside their `FullData` wrapper.

`releaseSocket` receives `?SharedPtr` by value as a **borrowed view** — never deinits the parameter, only clones if the socket is actually pooled (avoiding leak-on-closeSocket-fallthrough).

## Testing

Race repro test `fetch-proxy-tls-intern-race.test.ts`: **5/5 passes under ASAN** with `ASAN_OPTIONS=abort_on_error=1:halt_on_error=1`. Each run:
- Fixture subprocess completes 100+ intern/deref probe cycles
- Driver loop cycles strong count through 0 repeatedly
- Zero heap-use-after-free / SEGV / ASAN aborts

Also passing:
- `fetch.tls.test.ts` (16 tests)
- `fetch.tls.wildcard.test.ts`, `fetch-tls-abortsignal-timeout.test.ts` (13 tests)
- `bun-serve-ssl.test.ts` (16 tests — verifies value-type `SSLConfig` path unaffected)