### PR TITLE
fix: correct typo checksumAlgorithme -> checksumAlgorithm in S3 response

### DIFF
--- a/src/s3/list_objects.zig
+++ b/src/s3/list_objects.zig
@@ -126,7 +126,7 @@ pub const S3ListObjectsV2Result = struct {
                 }
 
                 if (item.checksum_algorithme) |checksum_algorithme| {
-                    objectInfo.put(globalObject, jsc.ZigString.static("checksumAlgorithme"), try bun.String.createUTF8ForJS(globalObject, checksum_algorithme));
+                    objectInfo.put(globalObject, jsc.ZigString.static("checksumAlgorithm"), try bun.String.createUTF8ForJS(globalObject, checksum_algorithme));
                 }
 
                 if (item.checksum_type) |checksum_type| {


### PR DESCRIPTION
Fixes #19142

## Problem
The property name in the S3 response was using French spelling (checksumAlgorithme) instead of English (checksumAlgorithm), causing a mismatch between the runtime response and the TypeScript type definition at `packages/bun-types/s3.d.ts`.

## Solution
Changed the property name from `checksumAlgorithme` to `checksumAlgorithm` in `src/s3/list_objects.zig`.

## Testing
- Verified the TypeScript definition has the correct spelling: `checksumAlgorithm`
- Changed Zig source to match the type definition