### PR TITLE
fix: console.trace() should write to stderr instead of stdout

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -156,12 +156,12 @@ fn messageWithTypeAndLevel_(
         return;
     }
 
-    const enable_colors = if (level == .Warning or level == .Error)
+    const enable_colors = if (level == .Warning or level == .Error or message_type == .Trace)
         Output.enable_ansi_colors_stderr
     else
         Output.enable_ansi_colors_stdout;
 
-    const writer = if (level == .Warning or level == .Error)
+    const writer = if (level == .Warning or level == .Error or message_type == .Trace)
         console.error_writer
     else
         console.writer;


### PR DESCRIPTION
Fixes #19952

## Problem
`console.trace()` was writing to stdout instead of stderr, which differs from Node.js behavior. This means when stdout is redirected (`>file`), trace output still appears.

## Expected Behavior (Node.js)
```bash
$ node trace.js >/dev/null
Trace: hello
    at Object.<anonymous> (/Users/trace.js:1:9)
    ...
```

## Actual Behavior (Bun, before fix)
```bash
$ bun trace.js >/dev/null
# no output (because trace goes to stdout which is redirected)
```

## Solution
Modified the writer selection logic in `src/bun.js/ConsoleObject.zig` to treat `console.trace()` like errors/warnings and route it to stderr.

Changes:
- Added `message_type == .Trace` check to stderr routing logic
- Now correctly writes to stderr, matching Node.js behavior