### PR TITLE
fix: console.assert() should include "Assertion failed" prefix

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -146,14 +146,22 @@ fn messageWithTypeAndLevel_(
         return;
     }
 
-    if (message_type == .Assert and len == 0) {
-        const text = if (Output.enable_ansi_colors_stderr)
-            Output.prettyFmt("<r><red>Assertion failed<r>\n", true)
+    if (message_type == .Assert) {
+        if (len == 0) {
+            const text = if (Output.enable_ansi_colors_stderr)
+                Output.prettyFmt("<r><red>Assertion failed<r>\n", true)
+            else
+                "Assertion failed\n";
+            console.error_writer.writeAll(text) catch {};
+            console.error_writer.flush() catch {};
+            return;
+        }
+        // For assertions with a message, prepend "Assertion failed: "
+        const prefix = if (Output.enable_ansi_colors_stderr)
+            Output.prettyFmt("<r><red>Assertion failed: <r>", false)
         else
-            "Assertion failed\n";
-        console.error_writer.writeAll(text) catch {};
-        console.error_writer.flush() catch {};
-        return;
+            "Assertion failed: ";
+        console.error_writer.writeAll(prefix) catch {};
     }
 
     const enable_colors = if (level == .Warning or level == .Error)


### PR DESCRIPTION
Fixes #19953

## Problem
`console.assert(false, "message")` was only printing the message without the "Assertion failed:" prefix that Node.js includes.

## Expected Behavior (Node.js)
```bash
$ node -e 'console.assert(false, "message")'
Assertion failed: message
```

## Actual Behavior (Bun, before fix)
```bash
$ bun -e 'console.assert(false, "message")'
message
```

## Solution
Modified `src/bun.js/ConsoleObject.zig` to prepend "Assertion failed: " when an assertion has a message, matching Node.js behavior.

Changes:
- Added prefix logic for assertions with messages
- Maintains existing behavior for assertions without messages
- Consistent with Node.js console.assert() output format