### PR TITLE
fix: improve fetch() error message for URLs without hostname

### DIFF
--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -1,5 +1,5 @@
 pub const fetch_error_no_args = "fetch() expects a string but received no arguments.";
-pub const fetch_error_blank_url = "fetch() URL must not be a blank string.";
+pub const fetch_error_blank_url = "fetch() URL must have a hostname.";
 pub const fetch_error_unexpected_body = "fetch() request with GET/HEAD/OPTIONS method cannot have body.";
 pub const fetch_error_proxy_unix = "fetch() cannot use a proxy with a unix socket.";
 const JSTypeErrorEnum = std.enums.EnumArray(JSType, string);


### PR DESCRIPTION
Fixes #21361

## Problem
When calling `fetch()` with a value that doesn't have a hostname (e.g., `fetch(undefined)`, `fetch(123)`, `fetch('/path')`), the error message was misleading:
> `fetch() URL must not be a blank string`

This is inaccurate because the URL might not be "blank" - it might be a non-string value or a string without a hostname.

## Solution
Changed the error message to:
> `fetch() URL must have a hostname`

This more accurately describes the actual problem.

## Examples

### Before
```js
await fetch(123)
// Error: fetch() URL must not be a blank string. (misleading!)
```

### After
```js
await fetch(123)
// Error: fetch() URL must have a hostname. (accurate!)
```

## Changes
- Modified `src/bun.js/webcore/fetch.zig`
- Updated `fetch_error_blank_url` message