### PR TITLE
fix: receiveMessageOnPort should not drop falsy values

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -121,7 +121,7 @@ let workerData = _workerData;
 let threadId = _threadId;
 function receiveMessageOnPort(port: MessagePort) {
   let res = _receiveMessageOnPort(port);
-  if (!res) return undefined;
+  if (res === undefined || res === null) return undefined;
   return {
     message: res,
   };


### PR DESCRIPTION
Fixes #26501

The implementation was using a falsy check (!res) which incorrectly
dropped messages containing falsy values like null, 0, false, ''.

Changed to strict equality checks for undefined/null only, matching
Node.js behavior.

Test case shows all values including falsy ones are now correctly
received and wrapped in { message: value }.