### PR TITLE
fix: add hasSubscribers property to TracingChannel

### DIFF
--- a/src/js/node/diagnostics_channel.ts
+++ b/src/js/node/diagnostics_channel.ts
@@ -255,6 +255,14 @@ class TracingChannel {
   asyncEnd;
   error;
 
+  get hasSubscribers() {
+    return this.start.hasSubscribers ||
+           this.end.hasSubscribers ||
+           this.asyncStart.hasSubscribers ||
+           this.asyncEnd.hasSubscribers ||
+           this.error.hasSubscribers;
+  }
+
   constructor(nameOrChannels) {
     if (typeof nameOrChannels === "string") {
       this.start = channel(`tracing:${nameOrChannels}:start`);


### PR DESCRIPTION
Fixes #27805

## Problem
`TracingChannel` was missing the `hasSubscribers` property that exists in Node.js. This made it impossible to check if any channels have subscribers before calling trace methods.

## Solution
Added a `hasSubscribers` getter that returns `true` if any of the underlying channels have subscribers:
- start
- end
- asyncStart
- asyncEnd
- error

## Usage Example

```js
const { tracingChannel } = require('diagnostics_channel');

const trace = tracingChannel('some:random:tracing:channel');

trace.subscribe({
  start (ctx) { console.log('start fired:', ctx.name) },
  end (ctx) { console.log('end fired:', ctx.name) },
  error (ctx) { console.log('error fired:', ctx.error.message) },
});

console.log('has subscribers:', trace.hasSubscribers);
// Before: undefined
// After: true

if (trace.hasSubscribers) {
  trace.traceSync(() => {
    return 'ok:demo';
  }, { name: 'demo' });
}
```

## Changes
- Added `hasSubscribers` getter to `TracingChannel` class
- Returns `true` if any of the 5 channels have subscribers
- Matches Node.js `diagnostics_channel` API