### PR TITLE
fix: add shake-128 and shake-256 algorithm aliases for crypto.hash()

### DIFF
--- a/src/bun.js/api/crypto/CryptoHasher.zig
+++ b/src/bun.js/api/crypto/CryptoHasher.zig
@@ -487,7 +487,9 @@ const CryptoHasherZig = struct {
         .{ "sha3-384", std.crypto.hash.sha3.Sha3_384 },
         .{ "sha3-512", std.crypto.hash.sha3.Sha3_512 },
         .{ "shake128", std.crypto.hash.sha3.Shake128 },
+        .{ "shake-128", std.crypto.hash.sha3.Shake128 },
         .{ "shake256", std.crypto.hash.sha3.Shake256 },
+        .{ "shake-256", std.crypto.hash.sha3.Shake256 },
         .{ "blake2s256", std.crypto.hash.blake2.Blake2s256 },
     };
 


### PR DESCRIPTION
Fixes #18019

Node.js supports both `shake128` and `shake-128` (with hyphen) as algorithm names for `crypto.hash()`. Bun only supported `shake128` without the hyphen.

## Solution
Added aliases to match Node.js behavior:
- `'shake-128'` → Shake128
- `'shake-256'` → Shake256

## Test Case

```ts
import crypto from 'node:crypto';

// This now works in Bun (previously threw error)
console.log(crypto.hash('shake-128', '', 'base64url'));
// Output: f5wrpOiPgn1hYEVQdgWFPg

// Both forms now work
crypto.hash('shake128', data, 'hex')      // ✓
crypto.hash('shake-128', data, 'hex')     // ✓
crypto.hash('shake256', data, 'hex')      // ✓
crypto.hash('shake-256', data, 'hex')     // ✓
```

## Changes
- Modified `src/bun.js/api/crypto/CryptoHasher.zig`
- Added 2 algorithm aliases to `algo_map`
- Improves Node.js compatibility