### PR TITLE
fix: CString should always have byteLength and byteOffset properties

### DIFF
--- a/src/js/bun/ffi.ts
+++ b/src/js/bun/ffi.ts
@@ -125,12 +125,8 @@ class CString extends String {
         : "",
     );
     this.ptr = typeof ptr === "number" ? ptr : 0;
-    if (typeof byteOffset !== "undefined") {
-      this.byteOffset = byteOffset;
-    }
-    if (typeof byteLength !== "undefined") {
-      this.byteLength = byteLength;
-    }
+    this.byteOffset = typeof byteOffset === "number" ? byteOffset : 0;
+    this.byteLength = typeof byteLength === "number" ? byteLength : super.length;
   }
 
   ptr;


### PR DESCRIPTION
Fixes #22920

CString was missing `byteLength` and `byteOffset` properties when they weren't explicitly passed to the constructor.

## Problem
```ts
const buffer = Buffer.from('Hello world!');
const bufferPtr = ptr(buffer);
const cString = new CString(bufferPtr);

console.log(cString.byteLength, cString.byteOffset);
// Before: undefined undefined (❌)
```

This differs from other typed array types which always have these properties.

## Solution
CString now always initializes:
- `byteOffset`: defaults to `0` if not provided
- `byteLength`: defaults to string length if not provided

```ts
const cString = new CString(bufferPtr);

console.log(cString.byteLength, cString.byteOffset);
// After: 12 0 (✓)
```

## Changes
- Modified `src/js/bun/ffi.ts`
- Removed conditional property assignment
- Properties now always initialized with default values
- Matches behavior of Buffer, Uint8Array, etc.