### PR TITLE
fix: clear in_flight queue on auto-reconnect to prevent response mismatch

### DIFF
--- a/src/valkey/valkey.zig
+++ b/src/valkey/valkey.zig
@@ -499,6 +499,14 @@ pub const ValkeyClient = struct {
 
         debug("reconnect in {d}ms (attempt {d}/{d})", .{ delay_ms, this.retry_attempts, this.max_retries });
 
+        // Clear in-flight commands to prevent response mismatch after reconnect
+        // These commands failed to complete and will not receive responses from the new connection
+        if (this.in_flight.count > 0) {
+            const globalThis = this.globalObject();
+            const error = protocol.valkeyErrorToJS(globalThis, "Connection lost during command execution, reconnecting...", protocol.RedisError.ConnectionClosed);
+            _ = rejectAllPendingCommands(&this.in_flight, null, globalThis, this.allocator, error);
+        }
+
         this.flags.is_reconnecting = true;
         this.flags.is_authenticated = false;
         this.flags.is_selecting_db_internal = false;


### PR DESCRIPTION
Fixes #27861

## Problem
When `RedisClient` auto-reconnects after a connection drop, the `in_flight` promise queue was NOT cleared. This caused new responses from the reconnected connection to be matched against stale promises from the old connection, resulting in **severe response mismatch**.

### Impact
- `redis.get(key)` returned `"OK"` (SET response) instead of actual value
- Distributed locks failed due to mismatched responses
- Data corruption in production systems

### Root Cause
In `onClose()`, the auto-reconnect path did NOT call `fail()`, so `in_flight` remained populated with stale entries.

## Solution
Before entering auto-reconnect, clear `in_flight` by rejecting pending commands with `ConnectionClosed` error. The `queue` is preserved for retry after reconnect.

### Timeline (Fixed)
```
t0: Commands A, B sent        → in_flight: [A, B]
t1: Connection drops
t2: onClose → in_flight cleared (✓ NEW)
t3: New connection established
t4: Command C sent           → in_flight: [C]
t5: Server responds to C     → C gets correct response ✓
```

## Changes
- Modified `src/valkey/valkey.zig`
- Added `in_flight` cleanup before auto-reconnect
- Rejects pending commands with clear error message
- Preserves `queue` for automatic retry

## Production Fix
This bug caused production issues on Google Cloud Run with singleton `RedisClient`. The fix prevents response mismatch in cloud environments with transient network interruptions.