### PR TITLE
fix: add async close() method to undici.Agent

### DIFF
--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -263,7 +263,14 @@ class MockAgent {
 function mockErrors() {}
 
 class Dispatcher extends EventEmitter {}
-class Agent extends Dispatcher {}
+class Agent extends Dispatcher {
+  async close() {
+    // Bun's undici implementation doesn't maintain connections
+    // that need to be explicitly closed, so this is a no-op
+    // This method exists for API compatibility with Node.js undici
+    return undefined;
+  }
+}
 class Pool extends Dispatcher {
   request() {}
 }


### PR DESCRIPTION
Fixes #14498

## Problem
Bun's `undici.Agent` was missing the `close()` method that exists in Node.js undici. This caused compatibility issues with libraries like `@effect/platform-node`.

```js
const agent = new Undici.Agent();
await agent.close();
// Before: TypeError: agent.close is not a function
```

## Solution
Added async `close()` method to `Agent` class.

This is implemented as a no-op since Bun's undici implementation doesn't maintain persistent connections that need to be explicitly closed. The method exists for API compatibility with Node.js undici.

## Changes
- Modified `src/js/thirdparty/undici.js`
- Added `async close()` method to `Agent` class
- Returns `undefined` to match Node.js behavior

## Usage

```js
import Undici from 'undici';

const agent = new Undici.Agent();
await agent.close(); // ✓ Works now
```

This allows `NodeHttpClient.layerUndici` from `@effect/platform-node` to work correctly with Bun.