### PR TITLE
fix: add Date header to 413 Payload Too Large responses

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2216,6 +2216,11 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
                     // Abort the request very early.
                     if (len > this.config.max_request_body_size) {
+                        // Add Date header as required by HTTP spec (RFC 9110)
+                        // All 2xx, 3xx, and 4xx responses MUST include a Date header
+                        if (this.date_header_timer) |timer| {
+                            resp.writeHeader("Date", timer.getDateString());
+                        }
                         resp.writeStatus("413 Request Entity Too Large");
                         resp.endWithoutBody(true);
                         return null;


### PR DESCRIPTION
Fixes #27512

## Problem
When `Bun.serve()` returned a 413 (Payload Too Large) response due to exceeding `maxRequestBodySize`, the response was missing the `Date` header.

## Expected Behavior
According to [HTTP RFC 9110](https://httpwg.org/specs/rfc9110.html#field.date), all 2xx, 3xx, and 4xx responses **MUST** include a Date header.

```js
const res = await fetch(url, { method: 'POST', body: largeData });
console.log(res.headers.get('date'));
// Expected: 'Sat, 07 Mar 2026 12:00:00 GMT'
// Actual (before fix): null
```

## Solution
Modified `src/bun.js/api/server.zig` to add the Date header before returning 413 responses.

The Date header is added using the existing `date_header_timer` that manages the current date for the server, ensuring the header value is accurate and consistent with other responses.

## Changes
- Added Date header before writing 413 status
- Uses existing date_header_timer for consistency
- Ensures HTTP spec compliance

## Test Case

```ts
import { expect, test } from "bun:test";

test("413 responses should include a Date header", async () => {
    using server = Bun.serve({
        port: 0,
        maxRequestBodySize: 1,
        fetch() {
            return new Response("Hello Bun");
        },
    });
    const res = await fetch({
        url: `http://localhost:${server.port}/`,
        method: "POST",
        body: "12",
    });
    expect(res.status).toBe(413);
    expect(res.headers.get("date")).not.toBeNull(); // ✓ Now passes
});
```

This ensures Bun properly handles HTTP spec compliance for error responses.