### PR TITLE
fix: yarn.lock migration preserves @scope for npm: aliased packages

### DIFF
--- a/src/install/yarn.zig
+++ b/src/install/yarn.zig
@@ -234,7 +234,7 @@ pub const YarnLock = struct {
                     }
                 }
 
-                if (last_slash < dash_idx and url[last_slash + 1] == '@') {
+                if (last_slash < dash_idx and url[second_last_slash + 1] == '@') {
                     return url[second_last_slash + 1 .. dash_idx];
                 } else {
                     return url[last_slash + 1 .. dash_idx];


### PR DESCRIPTION
Fixes #27781

## Problem
When migrating from `yarn.lock` v1, `bun install` was incorrectly stripping the `@scope/` prefix from scoped packages referenced via `npm:` aliases, resulting in 404 errors.

**Example:**
```
# yarn.lock entry:
"monaco-editor@npm:@codingame/monaco-editor-treemended@>=1.83.3 <1.84.0":
  version "1.83.16"
  resolved "https://registry.yarnpkg.com/@codingame/monaco-editor-treemended/-/monaco-editor-treemended-1.83.16.tgz"
```

**Before (Bug):**
```
$ bun install
error: GET https://registry.npmjs.org/monaco-editor-treemended/-/monaco-editor-treemended-1.83.16.tgz - 404
# Stripped @codingame/ prefix ❌
```

## Root Cause
In `getPackageNameFromResolvedUrl` (src/install/yarn.zig), the condition to check if a package is scoped was checking the wrong position.

For scoped packages, the URL structure is:
```
https://registry.yarnpkg.com/@codingame/monaco-editor-treemended/-/package-1.0.0.tgz
                            ^            ^-last_slash                      ^-dash_idx
                            second_last_slash
```

The `@` appears after `second_last_slash`, not after `last_slash`.

**Before:**
```zig
if (url[last_slash + 1] == '@')  // ❌ Wrong position
```

**After:**
```zig
if (url[second_last_slash + 1] == '@')  // ✓ Correct position
```

## Solution
Changed the condition from `url[last_slash + 1]` to `url[second_last_slash + 1]`.

## Changes
- Modified `src/install/yarn.zig`
- Fixed scoped package detection in `getPackageNameFromResolvedUrl`
- Preserves `@scope/` prefix during yarn.lock migration

## After (Fixed)
```
$ bun install
✓ install @codingame/monaco-editor-treemended@1.83.16
# Correctly preserves @codingame/ prefix ✓
```

This ensures scoped packages are correctly identified and their full names (including scope) are preserved during migration from yarn.lock.