### PR TITLE
fix(install): ignore patchedDependencies from workspace members

### DIFF
--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -1318,14 +1318,15 @@ pub fn Package(comptime SemverIntType: type) type {
                 }
             }
 
-            if (comptime features.is_main) {
+            if (comptime features.patched_dependencies) {
                 if (json.asProperty("patchedDependencies")) |patched_deps| {
-                    const obj = patched_deps.expr.data.e_object;
-                    for (obj.properties.slice()) |prop| {
-                        const key = prop.key.?;
-                        const value = prop.value.?;
-                        if (key.isString() and value.isString()) {
-                            string_builder.count(value.asString(allocator).?);
+                    if (patched_deps.expr.data == .e_object) {
+                        for (patched_deps.expr.data.e_object.properties.slice()) |prop| {
+                            const key = prop.key.?;
+                            const value = prop.value.?;
+                            if (key.isString() and value.isString()) {
+                                string_builder.count(value.asString(allocator).?);
+                            }
                         }
                     }
                 }
@@ -1650,18 +1651,20 @@ pub fn Package(comptime SemverIntType: type) type {
                 };
             }
 
-            if (comptime features.is_main) {
+            if (comptime features.patched_dependencies) {
                 if (json.asProperty("patchedDependencies")) |patched_deps| {
-                    const obj = patched_deps.expr.data.e_object;
-                    lockfile.patched_dependencies.ensureTotalCapacity(allocator, obj.properties.len) catch unreachable;
-                    for (obj.properties.slice()) |prop| {
-                        const key = prop.key.?;
-                        const value = prop.value.?;
-                        if (key.isString() and value.isString()) {
-                            var sfb = std.heap.stackFallback(1024, allocator);
-                            const keyhash = try key.asStringHash(sfb.get(), String.Builder.stringHash) orelse unreachable;
-                            const patch_path = string_builder.append(String, value.asString(allocator).?);
-                            lockfile.patched_dependencies.put(allocator, keyhash, .{ .path = patch_path }) catch unreachable;
+                    if (patched_deps.expr.data == .e_object) {
+                        const obj = patched_deps.expr.data.e_object;
+                        lockfile.patched_dependencies.ensureTotalCapacity(allocator, obj.properties.len) catch unreachable;
+                        for (obj.properties.slice()) |prop| {
+                            const key = prop.key.?;
+                            const value = prop.value.?;
+                            if (key.isString() and value.isString()) {
+                                var sfb = std.heap.stackFallback(1024, allocator);
+                                const keyhash = try key.asStringHash(sfb.get(), String.Builder.stringHash) orelse unreachable;
+                                const patch_path = string_builder.append(String, value.asString(allocator).?);
+                                lockfile.patched_dependencies.put(allocator, keyhash, .{ .path = patch_path }) catch unreachable;
+                            }
                         }
                     }
                 }

--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -1318,13 +1318,15 @@ pub fn Package(comptime SemverIntType: type) type {
                 }
             }
 
-            if (json.asProperty("patchedDependencies")) |patched_deps| {
-                const obj = patched_deps.expr.data.e_object;
-                for (obj.properties.slice()) |prop| {
-                    const key = prop.key.?;
-                    const value = prop.value.?;
-                    if (key.isString() and value.isString()) {
-                        string_builder.count(value.asString(allocator).?);
+            if (comptime features.is_main) {
+                if (json.asProperty("patchedDependencies")) |patched_deps| {
+                    const obj = patched_deps.expr.data.e_object;
+                    for (obj.properties.slice()) |prop| {
+                        const key = prop.key.?;
+                        const value = prop.value.?;
+                        if (key.isString() and value.isString()) {
+                            string_builder.count(value.asString(allocator).?);
+                        }
                     }
                 }
             }
@@ -1648,17 +1650,19 @@ pub fn Package(comptime SemverIntType: type) type {
                 };
             }
 
-            if (json.asProperty("patchedDependencies")) |patched_deps| {
-                const obj = patched_deps.expr.data.e_object;
-                lockfile.patched_dependencies.ensureTotalCapacity(allocator, obj.properties.len) catch unreachable;
-                for (obj.properties.slice()) |prop| {
-                    const key = prop.key.?;
-                    const value = prop.value.?;
-                    if (key.isString() and value.isString()) {
-                        var sfb = std.heap.stackFallback(1024, allocator);
-                        const keyhash = try key.asStringHash(sfb.get(), String.Builder.stringHash) orelse unreachable;
-                        const patch_path = string_builder.append(String, value.asString(allocator).?);
-                        lockfile.patched_dependencies.put(allocator, keyhash, .{ .path = patch_path }) catch unreachable;
+            if (comptime features.is_main) {
+                if (json.asProperty("patchedDependencies")) |patched_deps| {
+                    const obj = patched_deps.expr.data.e_object;
+                    lockfile.patched_dependencies.ensureTotalCapacity(allocator, obj.properties.len) catch unreachable;
+                    for (obj.properties.slice()) |prop| {
+                        const key = prop.key.?;
+                        const value = prop.value.?;
+                        if (key.isString() and value.isString()) {
+                            var sfb = std.heap.stackFallback(1024, allocator);
+                            const keyhash = try key.asStringHash(sfb.get(), String.Builder.stringHash) orelse unreachable;
+                            const patch_path = string_builder.append(String, value.asString(allocator).?);
+                            lockfile.patched_dependencies.put(allocator, keyhash, .{ .path = patch_path }) catch unreachable;
+                        }
                     }
                 }
             }

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -572,6 +572,66 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
     }
   });
 
+  // https://github.com/oven-sh/bun/issues/27894
+  test("workspace member's patchedDependencies should be ignored", async () => {
+    // When a workspace member has its own `patchedDependencies`, installing from
+    // the workspace root should ignore it. Only the install root's `patchedDependencies`
+    // is honored (matching `overrides`, `workspaces`, and `catalogs` behavior).
+    //
+    // Previously the member's patch paths were written to the root lockfile and
+    // resolved relative to the root directory, failing with "Couldn't find patch file".
+    const filedir = tempDirWithFiles("patch-workspace-member", {
+      "package.json": JSON.stringify({
+        name: "workspace-root",
+        workspaces: ["packages/*"],
+      }),
+      packages: {
+        lib: {
+          "package.json": JSON.stringify({
+            name: "lib",
+            dependencies: {
+              "is-even": "1.0.0",
+            },
+            // This only applies when `lib` itself is the install root.
+            patchedDependencies: {
+              "is-even@1.0.0": "patches/is-even@1.0.0.patch",
+            },
+          }),
+          patches: {
+            "is-even@1.0.0.patch": is_even_patch,
+          },
+          "index.ts": `import isEven from 'is-even'; isEven(4);`,
+        },
+        app: {
+          "package.json": JSON.stringify({
+            name: "app",
+            dependencies: {
+              lib: "workspace:*",
+            },
+          }),
+        },
+      },
+    });
+
+    // Use an isolated install cache so this test isn't affected by other
+    // tests in this file that patch `is-even` into the shared cache.
+    const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(filedir, ".bun-cache") };
+
+    const install = await $`${bunExe()} install`.env(env).cwd(filedir).throws(false);
+    expect(install.stderr.toString()).not.toContain("Couldn't find patch file");
+    expect(install.exitCode).toBe(0);
+
+    // The member's patch was not applied (root has no patchedDependencies).
+    const run = await $`${bunExe()} run index.ts`.env(env).cwd(join(filedir, "packages", "lib")).throws(false);
+    expect(run.stderr.toString()).not.toContain("error:");
+    expect(run.stdout.toString()).not.toContain("HI");
+    expect(run.exitCode).toBe(0);
+
+    // The member's patchedDependencies did not leak into the root lockfile.
+    const lockfile = await Bun.file(join(filedir, "bun.lock")).text();
+    expect(lockfile).not.toContain("patchedDependencies");
+  });
+
   describe("bun patch with --linker=isolated", () => {
     const patchEnv = bunEnv;
 

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -622,7 +622,10 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
     expect(install.exitCode).toBe(0);
 
     // The member's patch was not applied (root has no patchedDependencies).
-    const run = await $`${bunExe()} run index.ts`.env(env).cwd(join(filedir, "packages", "lib")).throws(false);
+    const run = await $`${bunExe()} run index.ts`
+      .env(env)
+      .cwd(join(filedir, "packages", "lib"))
+      .throws(false);
     expect(run.stderr.toString()).not.toContain("error:");
     expect(run.stdout.toString()).not.toContain("HI");
     expect(run.exitCode).toBe(0);


### PR DESCRIPTION
## Summary

Only parse `patchedDependencies` from the install root's `package.json`, matching the behavior of `overrides`, `workspaces`, and `catalogs`.

## Problem

When a workspace member has its own `patchedDependencies` field, `bun install` from the workspace root fails:

```
error: Couldn't find patch file: 'patches/foo@1.0.0.patch'
```

This forces contradictory manifest shapes: a package needs top-level `patchedDependencies` to work as its own install root, but that same field breaks the install when the package is consumed as a workspace member.

## Root cause

In `Package.parseWithJSON`, `patchedDependencies` was parsed from **every** `package.json` unconditionally (both the counting pass and the appending pass). Other root-only fields like `overrides` and `catalogs` are guarded with `if (comptime features.is_main)`, but `patchedDependencies` was not.

When a workspace member had `patchedDependencies`, its patch paths (e.g. `patches/foo@1.0.0.patch`) were stored in the root lockfile and later resolved relative to the workspace **root** directory instead of the member's directory, causing the file-not-found error.

## Fix

Wrap both `patchedDependencies` parsing blocks with `if (comptime features.is_main)`, consistent with how `overrides` and `catalogs` are handled in the same function.

## Verification

- New test in `test/cli/install/bun-install-patch.test.ts`: a workspace root with a member that declares `patchedDependencies`. Verifies install succeeds, the member's patch is not applied, and the lockfile does not contain `patchedDependencies`.
- Test fails on current Bun, passes with this change.

Closes #27894
