### PR TITLE
fix(test): apply --preserve-symlinks-main to test file path resolution

### DIFF
--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1556,7 +1556,7 @@ pub const TestCommand = struct {
                 else => {},
             }
 
-            runAllTests(reporter, vm, test_files, ctx.allocator);
+            runAllTests(reporter, vm, test_files, ctx.allocator, ctx.runtime_options.preserve_symlinks_main or bun.env_var.NODE_PRESERVE_SYMLINKS_MAIN.get());
         }
 
         const write_snapshots_success = try jest.Jest.runner.?.snapshots.writeInlineSnapshots();
@@ -1822,12 +1822,14 @@ pub const TestCommand = struct {
         vm_: *jsc.VirtualMachine,
         files_: []const PathString,
         allocator_: std.mem.Allocator,
+        preserve_symlinks_main: bool,
     ) void {
         const Context = struct {
             reporter: *CommandLineReporter,
             vm: *jsc.VirtualMachine,
             files: []const PathString,
             allocator: std.mem.Allocator,
+            preserve_symlinks_main: bool,
             pub fn begin(this: *@This()) void {
                 const reporter = this.reporter;
                 const vm = this.vm;
@@ -1836,13 +1838,13 @@ pub const TestCommand = struct {
 
                 if (files.len > 1) {
                     for (files[0 .. files.len - 1], 0..) |file_name, i| {
-                        TestCommand.run(reporter, vm, file_name.slice(), .{ .first = i == 0, .last = false }) catch |err| handleTopLevelTestErrorBeforeJavaScriptStart(err);
+                        TestCommand.run(reporter, vm, file_name.slice(), .{ .first = i == 0, .last = false }, this.preserve_symlinks_main) catch |err| handleTopLevelTestErrorBeforeJavaScriptStart(err);
                         reporter.jest.default_timeout_override = std.math.maxInt(u32);
                         Global.mimalloc_cleanup(false);
                     }
                 }
 
-                TestCommand.run(reporter, vm, files[files.len - 1].slice(), .{ .first = files.len == 1, .last = true }) catch |err| handleTopLevelTestErrorBeforeJavaScriptStart(err);
+                TestCommand.run(reporter, vm, files[files.len - 1].slice(), .{ .first = files.len == 1, .last = true }, this.preserve_symlinks_main) catch |err| handleTopLevelTestErrorBeforeJavaScriptStart(err);
             }
         };
 
@@ -1850,7 +1852,7 @@ pub const TestCommand = struct {
         vm_.eventLoop().ensureWaker();
         vm_.arena = &arena;
         vm_.allocator = arena.allocator();
-        var ctx = Context{ .reporter = reporter_, .vm = vm_, .files = files_, .allocator = allocator_ };
+        var ctx = Context{ .reporter = reporter_, .vm = vm_, .files = files_, .allocator = allocator_, .preserve_symlinks_main = preserve_symlinks_main };
         vm_.runWithAPILock(Context, &ctx, Context.begin);
     }
 
@@ -1861,6 +1863,7 @@ pub const TestCommand = struct {
         vm: *jsc.VirtualMachine,
         file_name: string,
         first_last: bun_test.BunTestRoot.FirstLast,
+        preserve_symlinks_main: bool,
     ) !void {
         defer {
             js_ast.Expr.Data.Store.reset();
@@ -1879,7 +1882,17 @@ pub const TestCommand = struct {
         const prev_only = reporter.jest.only;
         defer reporter.jest.only = prev_only;
 
-        const resolution = try vm.transpiler.resolveEntryPoint(file_name);
+        // Scope preserve_symlinks_main to entry point resolution only, matching the
+        // pattern in run_command.zig. This stores the symlink path (not the real path)
+        // for snapshot directory lookups, while leaving resolver behaviour unchanged
+        // for subsequent imports within the test file.
+        // OR with the existing flag so --preserve-symlinks is not clobbered.
+        const resolution = brk: {
+            const prev_preserve_symlinks = vm.transpiler.resolver.opts.preserve_symlinks;
+            defer vm.transpiler.resolver.opts.preserve_symlinks = prev_preserve_symlinks;
+            vm.transpiler.resolver.opts.preserve_symlinks = prev_preserve_symlinks or preserve_symlinks_main;
+            break :brk try vm.transpiler.resolveEntryPoint(file_name);
+        };
         try vm.clearEntryPoint();
 
         const file_path = bun.handleOom(bun.fs.FileSystem.instance.filename_store.append([]const u8, resolution.path_pair.primary.text));

--- a/test/regression/issue/026695.test.ts
+++ b/test/regression/issue/026695.test.ts
@@ -1,0 +1,149 @@
+import { expect, test } from "bun:test";
+import { mkdirSync, symlinkSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+// Test for https://github.com/oven-sh/bun/issues/26695
+// --preserve-symlinks-main should apply to test file path resolution for snapshot tests
+// Skip on Windows: symlinkSync requires elevated privileges or developer mode
+test.skipIf(isWindows)("--preserve-symlinks-main applies to snapshot test file path resolution", async () => {
+  using dir = tempDir("symlink-snapshot-test", {});
+
+  // Create real directory structure
+  const realDir = join(String(dir), "real-dir");
+  mkdirSync(realDir);
+  mkdirSync(join(realDir, "__snapshots__"));
+
+  // Create test file in real directory
+  writeFileSync(
+    join(realDir, "test.test.ts"),
+    `import { test, expect } from "bun:test";
+test("snapshot", () => {
+  expect({ hello: "world" }).toMatchSnapshot();
+});
+`,
+  );
+
+  // Create snapshot in real directory - this should NOT be used when running via symlink
+  writeFileSync(
+    join(realDir, "__snapshots__", "test.test.ts.snap"),
+    `exports[\`snapshot 1\`] = \`
+{
+  "hello": "real-dir-snapshot",
+}
+\`;
+`,
+  );
+
+  // Create symlink directory structure
+  const symlinkDir = join(String(dir), "symlink-dir");
+  mkdirSync(symlinkDir);
+  mkdirSync(join(symlinkDir, "__snapshots__"));
+
+  // Create symlink to the test file
+  symlinkSync(join(realDir, "test.test.ts"), join(symlinkDir, "test.test.ts"));
+
+  // Create snapshot in symlink directory - this SHOULD be used when running via symlink with --preserve-symlinks-main
+  writeFileSync(
+    join(symlinkDir, "__snapshots__", "test.test.ts.snap"),
+    `exports[\`snapshot 1\`] = \`
+{
+  "hello": "world",
+}
+\`;
+`,
+  );
+
+  // Run test via symlink WITH --preserve-symlinks-main
+  // The snapshot should be looked up in symlink-dir, not real-dir
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--preserve-symlinks-main", "test.test.ts"],
+    cwd: symlinkDir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  // With --preserve-symlinks-main, the test should pass because it uses
+  // symlink-dir/__snapshots__/test.test.ts.snap (which has "world")
+  // Without the fix, it would look in real-dir/__snapshots__/test.test.ts.snap (which has "real-dir-snapshot")
+  expect(stderr).toContain("1 pass");
+  expect(stderr).not.toContain("real-dir-snapshot");
+  expect(exitCode).toBe(0);
+});
+
+// Skip on Windows: symlinkSync requires elevated privileges or developer mode
+test.skipIf(isWindows)("snapshot uses resolved path without --preserve-symlinks-main", async () => {
+  using dir = tempDir("symlink-snapshot-test-no-flag", {});
+
+  // Create real directory structure
+  const realDir = join(String(dir), "real-dir");
+  mkdirSync(realDir);
+  mkdirSync(join(realDir, "__snapshots__"));
+
+  // Create test file in real directory
+  writeFileSync(
+    join(realDir, "test.test.ts"),
+    `import { test, expect } from "bun:test";
+test("snapshot", () => {
+  expect({ hello: "world" }).toMatchSnapshot();
+});
+`,
+  );
+
+  // Create snapshot in real directory - this SHOULD be used without --preserve-symlinks-main
+  writeFileSync(
+    join(realDir, "__snapshots__", "test.test.ts.snap"),
+    `exports[\`snapshot 1\`] = \`
+{
+  "hello": "world",
+}
+\`;
+`,
+  );
+
+  // Create symlink directory structure
+  const symlinkDir = join(String(dir), "symlink-dir");
+  mkdirSync(symlinkDir);
+  mkdirSync(join(symlinkDir, "__snapshots__"));
+
+  // Create symlink to the test file
+  symlinkSync(join(realDir, "test.test.ts"), join(symlinkDir, "test.test.ts"));
+
+  // Create a DIFFERENT snapshot in symlink directory
+  writeFileSync(
+    join(symlinkDir, "__snapshots__", "test.test.ts.snap"),
+    `exports[\`snapshot 1\`] = \`
+{
+  "hello": "wrong-snapshot",
+}
+\`;
+`,
+  );
+
+  // Run test via symlink WITHOUT --preserve-symlinks-main
+  // The snapshot should be looked up in real-dir (symlink resolved)
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "test.test.ts"],
+    cwd: symlinkDir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  // Without --preserve-symlinks-main, the test should pass because it uses
+  // real-dir/__snapshots__/test.test.ts.snap (which has "world")
+  expect(stderr).toContain("1 pass");
+  expect(stderr).not.toContain("wrong-snapshot");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

Fixes #26695. Supersedes #26696.

When `bun test` is run with a symlinked test file (e.g. in a Bazel sandbox where runfiles are symlinks into the source tree), Bun resolves the symlink to the real path before storing it. The snapshot system constructs the `__snapshots__/` path relative to the real (resolved) path, which lies outside the sandbox — causing ENOENT on lookup even when the snapshot exists at the symlink path.

## Changes

**`src/resolver/resolver.zig`** — guard symlink resolution in `finalizeResult()` behind `preserve_symlinks`:

```zig
// Only resolve symlinks if preserve_symlinks is not set
if (!r.opts.preserve_symlinks) {
    // ... existing setRealpath() logic ...
}
```

**`src/cli/test_command.zig`** — thread `preserve_symlinks_main` (from `--preserve-symlinks-main` or `NODE_PRESERVE_SYMLINKS_MAIN`) through `runAllTests()` → `Context` → `run()`, scoped tightly to `resolveEntryPoint()` only:

```zig
const resolution = brk: {
    const prev = vm.transpiler.resolver.opts.preserve_symlinks;
    defer vm.transpiler.resolver.opts.preserve_symlinks = prev;
    vm.transpiler.resolver.opts.preserve_symlinks = prev or preserve_symlinks_main;
    break :brk try vm.transpiler.resolveEntryPoint(file_name);
};
```

**`test/regression/issue/026695.test.ts`** — regression tests verifying snapshot resolution uses the symlink path (with flag) vs the real path (without flag). Skipped on Windows where `symlinkSync` requires elevated privileges.

## Fixes vs #26696

#26696 had the right approach but two bugs:

1. **Flag clobbering** — used `opts.preserve_symlinks = preserve_symlinks_main` (unconditional assignment). When `--preserve-symlinks-main` is not set, `preserve_symlinks_main` is `false`, silently disabling any pre-existing `--preserve-symlinks` setting for the entire `run()` call. Fixed with OR: `prev or preserve_symlinks_main`.

2. **Scope too broad** — the `defer` restoration was scoped to `run()` returning, so all module import resolutions within the test file also had `preserve_symlinks` forced to the value of `preserve_symlinks_main`. Only the entry point lookup needs the temporary override. Fixed with a Zig labeled block (`brk:`) so the defer fires immediately after `resolveEntryPoint()` returns — matching the pattern already used in `run_command.zig`.

