### PR TITLE
fix(install): support `--filter` and `--recursive` flags for `bun remove`

### DIFF
--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -177,6 +177,7 @@ pub const Subcommand = enum {
             .outdated => true,
             .install => true,
             .update => true,
+            .remove => true,
             // .pack => true,
             // .add => true,
             else => false,

--- a/src/install/PackageManager/CommandLineArguments.zig
+++ b/src/install/PackageManager/CommandLineArguments.zig
@@ -105,6 +105,8 @@ pub const add_params: []const ParamType = &(shared_params ++ [_]ParamType{
 });
 
 pub const remove_params: []const ParamType = &(shared_params ++ [_]ParamType{
+    clap.parseParam("--filter <STR>...                     Remove packages for the matching workspaces") catch unreachable,
+    clap.parseParam("-r, --recursive                       Remove packages from all workspaces") catch unreachable,
     clap.parseParam("<POS> ...                         \"name\" of package(s) to remove from package.json") catch unreachable,
 });
 
@@ -1054,6 +1056,10 @@ pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !Com
     if (comptime subcommand == .update) {
         cli.latest = args.flag("--latest");
         cli.interactive = args.flag("--interactive");
+        cli.recursive = args.flag("--recursive");
+    }
+
+    if (comptime subcommand == .remove) {
         cli.recursive = args.flag("--recursive");
     }
 

--- a/src/install/PackageManager/install_with_manager.zig
+++ b/src/install/PackageManager/install_with_manager.zig
@@ -1065,8 +1065,8 @@ pub fn getWorkspaceFilters(manager: *PackageManager, original_cwd: []const u8) !
     defer bun.path_buffer_pool.put(path_buf);
 
     var workspace_filters: std.ArrayListUnmanaged(WorkspaceFilter) = .{};
-    // only populated when subcommand is `.install`
-    if (manager.subcommand == .install and manager.options.filter_patterns.len > 0) {
+    // populated when subcommand is `.install` or `.remove`
+    if ((manager.subcommand == .install or manager.subcommand == .remove) and manager.options.filter_patterns.len > 0) {
         try workspace_filters.ensureUnusedCapacity(manager.allocator, manager.options.filter_patterns.len);
         for (manager.options.filter_patterns) |pattern| {
             try workspace_filters.append(manager.allocator, try WorkspaceFilter.init(manager.allocator, pattern, original_cwd, path_buf[0..]));

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -951,16 +951,22 @@ fn saveWorkspacePackageJSON(
 
     const new_source = try manager.allocator.dupe(u8, package_json_writer.ctx.writtenWithoutTrailingZero());
 
-    const file = std.fs.cwd().createFile(pkg_json_path, .{}) catch |err| {
-        Output.errGeneric("failed to write package.json at \"{s}\": {s}", .{ pkg_json_path, @errorName(err) });
-        Global.crash();
-    };
-    defer file.close();
+    const path_z = try manager.allocator.dupeZ(u8, pkg_json_path);
+    defer manager.allocator.free(path_z);
 
-    file.writeAll(new_source) catch |err| {
+    const workspace_pkg_json_file = (try bun.sys.File.openat(
+        .cwd(),
+        path_z,
+        bun.O.RDWR,
+        0,
+    ).unwrap()).handle.stdFile();
+    defer workspace_pkg_json_file.close();
+
+    workspace_pkg_json_file.pwriteAll(new_source, 0) catch |err| {
         Output.errGeneric("failed to write package.json at \"{s}\": {s}", .{ pkg_json_path, @errorName(err) });
         Global.crash();
     };
+    std.posix.ftruncate(workspace_pkg_json_file.handle, new_source.len) catch {};
 }
 
 const std = @import("std");

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -697,34 +697,6 @@ pub fn updatePackageJSONAndInstall(
 
 const string = []const u8;
 
-const std = @import("std");
-
-const bun = @import("bun");
-const Environment = bun.Environment;
-const Global = bun.Global;
-const JSON = bun.json;
-const JSPrinter = bun.js_printer;
-const Output = bun.Output;
-const default_allocator = bun.default_allocator;
-const logger = bun.logger;
-const strings = bun.strings;
-const Command = bun.cli.Command;
-const File = bun.sys.File;
-const PackageNameHash = bun.install.PackageNameHash;
-
-const Semver = bun.Semver;
-const String = Semver.String;
-
-const Fs = bun.fs;
-const FileSystem = Fs.FileSystem;
-const js_ast = bun.ast;
-const Expr = js_ast.Expr;
-
-const Lockfile = bun.install.Lockfile;
-const WorkspaceFilter = PackageManager.WorkspaceFilter;
-const WorkspaceMap = Lockfile.Package.WorkspaceMap;
-const WorkspacePackageJSONCache = PackageManager.WorkspacePackageJSONCache;
-
 /// Remove the given dependencies from all dependency sections of a package.json AST.
 /// Returns true if any changes were made.
 fn removeDepsFromPackageJSON(root: *Expr, updates: []const UpdateRequest) bool {
@@ -941,10 +913,39 @@ fn saveWorkspacePackageJSON(
     };
 }
 
+const std = @import("std");
+
+const bun = @import("bun");
+const Environment = bun.Environment;
+const Global = bun.Global;
+const JSON = bun.json;
+const JSPrinter = bun.js_printer;
+const Output = bun.Output;
+const default_allocator = bun.default_allocator;
+const logger = bun.logger;
+const strings = bun.strings;
+const Command = bun.cli.Command;
+const File = bun.sys.File;
+
+const Semver = bun.Semver;
+const String = Semver.String;
+
+const js_ast = bun.ast;
+const Expr = js_ast.Expr;
+
+const Fs = bun.fs;
+const FileSystem = Fs.FileSystem;
+
+const Lockfile = bun.install.Lockfile;
+const PackageNameHash = bun.install.PackageNameHash;
+const WorkspaceMap = Lockfile.Package.WorkspaceMap;
+
 const PackageManager = bun.install.PackageManager;
 const CommandLineArguments = PackageManager.CommandLineArguments;
 const PackageJSONEditor = PackageManager.PackageJSONEditor;
 const PatchCommitResult = PackageManager.PatchCommitResult;
 const Subcommand = PackageManager.Subcommand;
 const UpdateRequest = PackageManager.UpdateRequest;
+const WorkspaceFilter = PackageManager.WorkspaceFilter;
+const WorkspacePackageJSONCache = PackageManager.WorkspacePackageJSONCache;
 const attemptToCreatePackageJSON = PackageManager.attemptToCreatePackageJSON;

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -104,7 +104,10 @@ fn updatePackageJSONAndInstallWithManagerWithUpdates(
     const preserve_trailing_newline_at_eof_for_package_json = current_package_json.source.contents.len > 0 and
         current_package_json.source.contents[current_package_json.source.contents.len - 1] == '\n';
 
-    if (subcommand == .remove) {
+    const is_workspace_remove = subcommand == .remove and
+        (manager.options.do.recursive or manager.options.filter_patterns.len > 0);
+
+    if (subcommand == .remove and !is_workspace_remove) {
         if (current_package_json.root.data != .e_object) {
             Output.errGeneric("package.json is not an Object {{}}, so there's nothing to {s}!", .{@tagName(subcommand)});
             Global.crash();
@@ -136,48 +139,11 @@ fn updatePackageJSONAndInstallWithManagerWithUpdates(
         .remove => {
             // if we're removing, they don't have to specify where it is installed in the dependencies list
             // they can even put it multiple times and we will just remove all of them
-            for (updates.*) |request| {
-                inline for ([_]string{ "dependencies", "devDependencies", "optionalDependencies", "peerDependencies" }) |list| {
-                    if (current_package_json.root.asProperty(list)) |query| {
-                        if (query.expr.data == .e_object) {
-                            var dependencies = query.expr.data.e_object.properties.slice();
-                            var i: usize = 0;
-                            var new_len = dependencies.len;
-                            while (i < dependencies.len) : (i += 1) {
-                                if (dependencies[i].key.?.data == .e_string) {
-                                    if (dependencies[i].key.?.data.e_string.eql(string, request.name)) {
-                                        if (new_len > 1) {
-                                            dependencies[i] = dependencies[new_len - 1];
-                                            new_len -= 1;
-                                        } else {
-                                            new_len = 0;
-                                        }
+            any_changes = removeDepsFromPackageJSON(&current_package_json.root, updates.*);
 
-                                        any_changes = true;
-                                    }
-                                }
-                            }
-
-                            const changed = new_len != dependencies.len;
-                            if (changed) {
-                                query.expr.data.e_object.properties.len = @as(u32, @truncate(new_len));
-
-                                // If the dependencies list is now empty, remove it from the package.json
-                                // since we're swapRemove, we have to re-sort it
-                                if (query.expr.data.e_object.properties.len == 0) {
-                                    // TODO: Theoretically we could change these two lines to
-                                    // `.orderedRemove(query.i)`, but would that change user-facing
-                                    // behavior?
-                                    _ = current_package_json.root.data.e_object.properties.swapRemove(query.i);
-                                    current_package_json.root.data.e_object.packageJSONSort();
-                                } else {
-                                    var obj = query.expr.data.e_object;
-                                    obj.alphabetizeProperties();
-                                }
-                            }
-                        }
-                    }
-                }
+            // When --filter or --recursive is used, also remove from matching workspace package.json files
+            if (is_workspace_remove) {
+                try removeFromWorkspacePackageJSONs(manager, updates.*, original_cwd);
             }
         },
 
@@ -751,6 +717,229 @@ const String = Semver.String;
 
 const Fs = bun.fs;
 const FileSystem = Fs.FileSystem;
+const js_ast = bun.ast;
+const Expr = js_ast.Expr;
+
+const Lockfile = bun.install.Lockfile;
+const WorkspaceFilter = PackageManager.WorkspaceFilter;
+const WorkspaceMap = Lockfile.Package.WorkspaceMap;
+const WorkspacePackageJSONCache = PackageManager.WorkspacePackageJSONCache;
+
+/// Remove the given dependencies from all dependency sections of a package.json AST.
+/// Returns true if any changes were made.
+fn removeDepsFromPackageJSON(root: *Expr, updates: []const UpdateRequest) bool {
+    var changed = false;
+    for (updates) |request| {
+        inline for ([_]string{ "dependencies", "devDependencies", "optionalDependencies", "peerDependencies" }) |list| {
+            if (root.asProperty(list)) |query| {
+                if (query.expr.data == .e_object) {
+                    var dependencies = query.expr.data.e_object.properties.slice();
+                    var i: usize = 0;
+                    var new_len = dependencies.len;
+                    while (i < dependencies.len) : (i += 1) {
+                        if (dependencies[i].key.?.data == .e_string) {
+                            if (dependencies[i].key.?.data.e_string.eql(string, request.name)) {
+                                if (new_len > 1) {
+                                    dependencies[i] = dependencies[new_len - 1];
+                                    new_len -= 1;
+                                } else {
+                                    new_len = 0;
+                                }
+
+                                changed = true;
+                            }
+                        }
+                    }
+
+                    const deps_changed = new_len != dependencies.len;
+                    if (deps_changed) {
+                        query.expr.data.e_object.properties.len = @as(u32, @truncate(new_len));
+
+                        if (query.expr.data.e_object.properties.len == 0) {
+                            _ = root.data.e_object.properties.swapRemove(query.i);
+                            root.data.e_object.packageJSONSort();
+                        } else {
+                            var obj = query.expr.data.e_object;
+                            obj.alphabetizeProperties();
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return changed;
+}
+
+/// Remove dependencies from workspace package.json files that match the given filter/recursive options.
+fn removeFromWorkspacePackageJSONs(
+    manager: *PackageManager,
+    updates: []const UpdateRequest,
+    original_cwd: string,
+) !void {
+    const top_level_dir = strings.withoutTrailingSlash(FileSystem.instance.top_level_dir);
+    const root_package_json_path = manager.original_package_json_path;
+
+    // Build workspace filters from --filter patterns
+    const path_buf = bun.path_buffer_pool.get();
+    defer bun.path_buffer_pool.put(path_buf);
+
+    var workspace_filters: std.ArrayListUnmanaged(WorkspaceFilter) = .{};
+    defer {
+        for (workspace_filters.items) |filter| filter.deinit(manager.allocator);
+        workspace_filters.deinit(manager.allocator);
+    }
+
+    if (manager.options.filter_patterns.len > 0) {
+        try workspace_filters.ensureUnusedCapacity(manager.allocator, manager.options.filter_patterns.len);
+        for (manager.options.filter_patterns) |pattern| {
+            try workspace_filters.append(manager.allocator, try WorkspaceFilter.init(manager.allocator, pattern, original_cwd, path_buf[0..]));
+        }
+    }
+    const is_recursive = manager.options.do.recursive;
+
+    // Discover workspace directories from root package.json's "workspaces" field.
+    // Use processNamesArray to properly handle glob patterns in workspace definitions.
+    const root_entry = manager.workspace_package_json_cache.getWithPath(
+        manager.allocator,
+        manager.log,
+        root_package_json_path,
+        .{},
+    ).unwrap() catch return;
+
+    const workspaces_array = if (root_entry.root.asProperty("workspaces")) |prop| switch (prop.expr.data) {
+        .e_array => |arr| arr,
+        .e_object => |obj| if (obj.get("packages")) |packages| switch (packages.data) {
+            .e_array => |arr| arr,
+            else => null,
+        } else null,
+        else => null,
+    } else null;
+
+    if (workspaces_array == null) return;
+
+    var workspace_names = WorkspaceMap.init(manager.allocator);
+    defer workspace_names.map.deinit();
+
+    var discover_log = logger.Log.init(manager.allocator);
+    defer discover_log.deinit();
+
+    _ = workspace_names.processNamesArray(
+        manager.allocator,
+        &manager.workspace_package_json_cache,
+        &discover_log,
+        workspaces_array.?,
+        &root_entry.source,
+        logger.Loc{},
+        null,
+    ) catch return;
+
+    // Iterate over discovered workspaces and remove matching dependencies.
+    var filepath_buf: bun.PathBuffer = undefined;
+    for (workspace_names.keys(), workspace_names.values()) |rel_path, entry| {
+        // Build absolute package.json path for this workspace
+        const abs_pkg_json_path = bun.path.joinAbsStringBuf(
+            top_level_dir,
+            &filepath_buf,
+            &[_]string{ rel_path, "package.json" },
+            .auto,
+        );
+
+        // Skip root
+        if (strings.eqlLong(abs_pkg_json_path, root_package_json_path, false)) continue;
+
+        // Check if this workspace matches the filter
+        if (!is_recursive and workspace_filters.items.len > 0) {
+            if (!workspaceMatchesFilter(entry.name, rel_path, workspace_filters.items))
+                continue;
+        }
+
+        // Load workspace package.json from cache (it was added by processNamesArray)
+        var pkg_json = manager.workspace_package_json_cache.getWithPath(
+            manager.allocator,
+            manager.log,
+            abs_pkg_json_path,
+            .{ .guess_indentation = true },
+        ).unwrap() catch continue;
+
+        if (pkg_json.root.data != .e_object) continue;
+
+        // Remove the requested dependencies
+        if (removeDepsFromPackageJSON(&pkg_json.root, updates)) {
+            try saveWorkspacePackageJSON(manager, pkg_json, abs_pkg_json_path);
+        }
+    }
+}
+
+/// Check if a workspace matches the given filters by name or path.
+fn workspaceMatchesFilter(
+    pkg_name: string,
+    workspace_path: string,
+    filters: []const WorkspaceFilter,
+) bool {
+    var matched = false;
+    for (filters) |filter| {
+        const pattern, const name_or_path = switch (filter) {
+            .name => |pattern| .{ pattern, pkg_name },
+            .path => |pattern| .{ pattern, workspace_path },
+            .all => {
+                matched = true;
+                continue;
+            },
+        };
+
+        switch (bun.glob.match(pattern, name_or_path)) {
+            .match, .negate_match => matched = true,
+            .negate_no_match => {
+                matched = false;
+                break;
+            },
+            .no_match => {},
+        }
+    }
+    return matched;
+}
+
+/// Serialize and write a workspace package.json back to disk.
+fn saveWorkspacePackageJSON(
+    manager: *PackageManager,
+    pkg_json: *WorkspacePackageJSONCache.MapEntry,
+    pkg_json_path: string,
+) !void {
+    const preserve_trailing_newline = pkg_json.source.contents.len > 0 and
+        pkg_json.source.contents[pkg_json.source.contents.len - 1] == '\n';
+
+    var buffer_writer = JSPrinter.BufferWriter.init(manager.allocator);
+    try buffer_writer.buffer.list.ensureTotalCapacity(manager.allocator, pkg_json.source.contents.len + 1);
+    buffer_writer.append_newline = preserve_trailing_newline;
+    var package_json_writer = JSPrinter.BufferPrinter.init(buffer_writer);
+
+    _ = JSPrinter.printJSON(
+        @TypeOf(&package_json_writer),
+        &package_json_writer,
+        pkg_json.root,
+        &pkg_json.source,
+        .{
+            .indent = pkg_json.indentation,
+            .mangled_props = null,
+        },
+    ) catch |err| {
+        Output.prettyErrorln("package.json failed to write due to error {s}", .{@errorName(err)});
+        Global.crash();
+    };
+
+    const new_source = try manager.allocator.dupe(u8, package_json_writer.ctx.writtenWithoutTrailingZero());
+
+    const file = std.fs.cwd().createFile(pkg_json_path, .{}) catch |err| {
+        Output.errGeneric("failed to write package.json at \"{s}\": {s}", .{ pkg_json_path, @errorName(err) });
+        Global.crash();
+    };
+    defer file.close();
+
+    file.writeAll(new_source) catch |err| {
+        Output.errGeneric("failed to write package.json at \"{s}\": {s}", .{ pkg_json_path, @errorName(err) });
+        Global.crash();
+    };
+}
 
 const PackageManager = bun.install.PackageManager;
 const CommandLineArguments = PackageManager.CommandLineArguments;

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -139,11 +139,25 @@ fn updatePackageJSONAndInstallWithManagerWithUpdates(
         .remove => {
             // if we're removing, they don't have to specify where it is installed in the dependencies list
             // they can even put it multiple times and we will just remove all of them
-            any_changes = removeDepsFromPackageJSON(&current_package_json.root, updates.*);
+
+            // When --filter is used (without --recursive), only modify root if filter matches the root package name.
+            // With --recursive or no filter, always modify root.
+            const should_modify_root = if (manager.options.filter_patterns.len > 0 and !manager.options.do.recursive) blk: {
+                const root_name = if (current_package_json.root.asProperty("name")) |name_prop|
+                    (if (name_prop.expr.data == .e_string) name_prop.expr.data.e_string.data else "")
+                else
+                    "";
+                break :blk removeFromWorkspacePackageJSONs_filterMatches(manager, root_name, "", original_cwd);
+            } else true;
+
+            if (should_modify_root) {
+                any_changes = removeDepsFromPackageJSON(&current_package_json.root, updates.*);
+            }
 
             // When --filter or --recursive is used, also remove from matching workspace package.json files
             if (is_workspace_remove) {
-                try removeFromWorkspacePackageJSONs(manager, updates.*, original_cwd);
+                const workspace_changes = try removeFromWorkspacePackageJSONs(manager, updates.*, original_cwd);
+                any_changes = any_changes or workspace_changes;
             }
         },
 
@@ -742,12 +756,45 @@ fn removeDepsFromPackageJSON(root: *Expr, updates: []const UpdateRequest) bool {
     return changed;
 }
 
+/// Check if the given name/path matches the manager's --filter patterns.
+/// Used to determine whether the root package should be modified.
+fn removeFromWorkspacePackageJSONs_filterMatches(
+    manager: *PackageManager,
+    pkg_name: string,
+    workspace_path: string,
+    original_cwd: string,
+) bool {
+    if (manager.options.filter_patterns.len == 0) return true;
+
+    const path_buf = bun.path_buffer_pool.get();
+    defer bun.path_buffer_pool.put(path_buf);
+
+    for (manager.options.filter_patterns) |pattern| {
+        const filter = WorkspaceFilter.init(manager.allocator, pattern, original_cwd, path_buf[0..]) catch continue;
+        defer filter.deinit(manager.allocator);
+
+        const match_pattern, const name_or_path = switch (filter) {
+            .name => |p| .{ p, pkg_name },
+            .path => |p| .{ p, workspace_path },
+            .all => return true,
+        };
+
+        switch (bun.glob.match(match_pattern, name_or_path)) {
+            .match, .negate_match => return true,
+            .negate_no_match => return false,
+            .no_match => {},
+        }
+    }
+    return false;
+}
+
 /// Remove dependencies from workspace package.json files that match the given filter/recursive options.
+/// Returns true if any workspace package.json files were modified.
 fn removeFromWorkspacePackageJSONs(
     manager: *PackageManager,
     updates: []const UpdateRequest,
     original_cwd: string,
-) !void {
+) !bool {
     const top_level_dir = strings.withoutTrailingSlash(FileSystem.instance.top_level_dir);
     const root_package_json_path = manager.original_package_json_path;
 
@@ -776,7 +823,7 @@ fn removeFromWorkspacePackageJSONs(
         manager.log,
         root_package_json_path,
         .{},
-    ).unwrap() catch return;
+    ).unwrap() catch return false;
 
     const workspaces_array = if (root_entry.root.asProperty("workspaces")) |prop| switch (prop.expr.data) {
         .e_array => |arr| arr,
@@ -787,7 +834,7 @@ fn removeFromWorkspacePackageJSONs(
         else => null,
     } else null;
 
-    if (workspaces_array == null) return;
+    if (workspaces_array == null) return false;
 
     var workspace_names = WorkspaceMap.init(manager.allocator);
     defer workspace_names.map.deinit();
@@ -803,9 +850,10 @@ fn removeFromWorkspacePackageJSONs(
         &root_entry.source,
         logger.Loc{},
         null,
-    ) catch return;
+    ) catch return false;
 
     // Iterate over discovered workspaces and remove matching dependencies.
+    var any_workspace_changes = false;
     var filepath_buf: bun.PathBuffer = undefined;
     for (workspace_names.keys(), workspace_names.values()) |rel_path, entry| {
         // Build absolute package.json path for this workspace
@@ -838,8 +886,10 @@ fn removeFromWorkspacePackageJSONs(
         // Remove the requested dependencies
         if (removeDepsFromPackageJSON(&pkg_json.root, updates)) {
             try saveWorkspacePackageJSON(manager, pkg_json, abs_pkg_json_path);
+            any_workspace_changes = true;
         }
     }
+    return any_workspace_changes;
 }
 
 /// Check if a workspace matches the given filters by name or path.

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -959,14 +959,14 @@ fn saveWorkspacePackageJSON(
         path_z,
         bun.O.RDWR,
         0,
-    ).unwrap()).handle.stdFile();
+    ).unwrap());
     defer workspace_pkg_json_file.close();
 
-    workspace_pkg_json_file.pwriteAll(new_source, 0) catch |err| {
-        Output.errGeneric("failed to write package.json at \"{s}\": {s}", .{ pkg_json_path, @errorName(err) });
+    workspace_pkg_json_file.pwriteAll(new_source, 0).unwrap() catch {
+        Output.errGeneric("failed to write package.json at \"{s}\"", .{pkg_json_path});
         Global.crash();
     };
-    std.posix.ftruncate(workspace_pkg_json_file.handle, new_source.len) catch {};
+    _ = bun.sys.ftruncate(workspace_pkg_json_file.handle, @intCast(new_source.len));
 }
 
 const std = @import("std");

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -722,7 +722,7 @@ fn removeDepsFromPackageJSON(root: *Expr, updates: []const UpdateRequest) bool {
                     var dependencies = query.expr.data.e_object.properties.slice();
                     var i: usize = 0;
                     var new_len = dependencies.len;
-                    while (i < dependencies.len) : (i += 1) {
+                    while (i < new_len) {
                         if (dependencies[i].key.?.data == .e_string) {
                             if (dependencies[i].key.?.data.e_string.eql(string, request.name)) {
                                 if (new_len > 1) {
@@ -731,10 +731,12 @@ fn removeDepsFromPackageJSON(root: *Expr, updates: []const UpdateRequest) bool {
                                 } else {
                                     new_len = 0;
                                 }
-
                                 changed = true;
+                                // Don't increment i: re-check the swapped element
+                                continue;
                             }
                         }
+                        i += 1;
                     }
 
                     const deps_changed = new_len != dependencies.len;
@@ -839,6 +841,7 @@ fn removeFromWorkspacePackageJSONs(
         manager.log,
         root_package_json_path,
         .{},
+        // If root package.json can't be read/parsed, there are no workspaces to process.
     ).unwrap() catch return false;
 
     const workspaces_array = if (root_entry.root.asProperty("workspaces")) |prop| switch (prop.expr.data) {
@@ -889,7 +892,8 @@ fn removeFromWorkspacePackageJSONs(
                 continue;
         }
 
-        // Load workspace package.json from cache (it was added by processNamesArray)
+        // Load workspace package.json from cache (it was added by processNamesArray).
+        // Skip workspaces whose package.json can't be read/parsed rather than failing the entire operation.
         var pkg_json = manager.workspace_package_json_cache.getWithPath(
             manager.allocator,
             manager.log,

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -769,6 +769,7 @@ fn removeFromWorkspacePackageJSONs_filterMatches(
     const path_buf = bun.path_buffer_pool.get();
     defer bun.path_buffer_pool.put(path_buf);
 
+    var matched = false;
     for (manager.options.filter_patterns) |pattern| {
         const filter = WorkspaceFilter.init(manager.allocator, pattern, original_cwd, path_buf[0..]) catch continue;
         defer filter.deinit(manager.allocator);
@@ -776,16 +777,22 @@ fn removeFromWorkspacePackageJSONs_filterMatches(
         const match_pattern, const name_or_path = switch (filter) {
             .name => |p| .{ p, pkg_name },
             .path => |p| .{ p, workspace_path },
-            .all => return true,
+            .all => {
+                matched = true;
+                continue;
+            },
         };
 
         switch (bun.glob.match(match_pattern, name_or_path)) {
-            .match, .negate_match => return true,
-            .negate_no_match => return false,
+            .match, .negate_match => matched = true,
+            .negate_no_match => {
+                matched = false;
+                break;
+            },
             .no_match => {},
         }
     }
-    return false;
+    return matched;
 }
 
 /// Remove dependencies from workspace package.json files that match the given filter/recursive options.
@@ -796,7 +803,16 @@ fn removeFromWorkspacePackageJSONs(
     original_cwd: string,
 ) !bool {
     const top_level_dir = strings.withoutTrailingSlash(FileSystem.instance.top_level_dir);
-    const root_package_json_path = manager.original_package_json_path;
+    // Use top_level_dir (which is resolved to the workspace root during init)
+    // rather than original_package_json_path (which may point to a child workspace
+    // package.json when running from a subdirectory).
+    var root_pkg_json_buf: bun.PathBuffer = undefined;
+    const root_package_json_path = bun.path.joinAbsStringBuf(
+        top_level_dir,
+        &root_pkg_json_buf,
+        &[_]string{"package.json"},
+        .auto,
+    );
 
     // Build workspace filters from --filter patterns
     const path_buf = bun.path_buffer_pool.get();

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -973,16 +973,15 @@ fn saveWorkspacePackageJSON(
     const workspace_pkg_json_file = (try bun.sys.File.openat(
         .cwd(),
         path_z,
-        bun.O.RDWR,
-        0,
+        bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC,
+        0o644,
     ).unwrap());
     defer workspace_pkg_json_file.close();
 
-    workspace_pkg_json_file.pwriteAll(new_source, 0).unwrap() catch {
+    workspace_pkg_json_file.writeAll(new_source).unwrap() catch {
         Output.errGeneric("failed to write package.json at \"{s}\"", .{pkg_json_path});
         Global.crash();
     };
-    _ = bun.sys.ftruncate(workspace_pkg_json_file.handle, @intCast(new_source.len));
 }
 
 const std = @import("std");

--- a/test/regression/issue/27897.test.ts
+++ b/test/regression/issue/27897.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("bun remove --filter", () => {
+  test("removes package from matching workspace packages", async () => {
+    using dir = tempDir("bun-remove-filter", {
+      "package.json": JSON.stringify(
+        {
+          name: "root",
+          workspaces: ["packages/*"],
+        },
+        null,
+        2,
+      ),
+      "packages/pkg-a/package.json": JSON.stringify(
+        {
+          name: "pkg-a",
+          devDependencies: {
+            "is-even": "^1.0.0",
+          },
+        },
+        null,
+        2,
+      ),
+      "packages/pkg-b/package.json": JSON.stringify(
+        {
+          name: "pkg-b",
+          dependencies: {
+            "is-even": "^1.0.0",
+          },
+        },
+        null,
+        2,
+      ),
+      "packages/other/package.json": JSON.stringify(
+        {
+          name: "other",
+          dependencies: {
+            "is-even": "^1.0.0",
+          },
+        },
+        null,
+        2,
+      ),
+    });
+
+    // Install first
+    await using installProc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await installProc.exited).toBe(0);
+
+    // Remove with --filter matching only pkg-* packages
+    await using removeProc = Bun.spawn({
+      cmd: [bunExe(), "remove", "--filter", "pkg-*", "is-even"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      removeProc.stdout.text(),
+      removeProc.stderr.text(),
+      removeProc.exited,
+    ]);
+
+    expect(stderr).not.toContain("error");
+    expect(exitCode).toBe(0);
+
+    // pkg-a should have is-even removed
+    const pkgA = await Bun.file(`${dir}/packages/pkg-a/package.json`).json();
+    expect(pkgA.devDependencies).toBeUndefined();
+
+    // pkg-b should have is-even removed
+    const pkgB = await Bun.file(`${dir}/packages/pkg-b/package.json`).json();
+    expect(pkgB.dependencies).toBeUndefined();
+
+    // other should NOT have is-even removed (doesn't match pkg-*)
+    const other = await Bun.file(`${dir}/packages/other/package.json`).json();
+    expect(other.dependencies).toEqual({ "is-even": "^1.0.0" });
+  });
+
+  test("--filter does not produce 'unrecognised dependency format' error", async () => {
+    using dir = tempDir("bun-remove-filter-err", {
+      "package.json": JSON.stringify(
+        {
+          name: "root",
+          workspaces: ["packages/*"],
+        },
+        null,
+        2,
+      ),
+      "packages/es6tween-core/package.json": JSON.stringify(
+        {
+          name: "es6tween-core",
+          devDependencies: {
+            "uglify-js": "^3.0.0",
+          },
+        },
+        null,
+        2,
+      ),
+    });
+
+    await using installProc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await installProc.exited).toBe(0);
+
+    await using removeProc = Bun.spawn({
+      cmd: [bunExe(), "remove", "--filter", "es6tween-*", "uglify-js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      removeProc.stdout.text(),
+      removeProc.stderr.text(),
+      removeProc.exited,
+    ]);
+
+    expect(stderr).not.toContain("unrecognised dependency format");
+    expect(stderr).not.toContain("error");
+    expect(exitCode).toBe(0);
+
+    const pkgJson = await Bun.file(`${dir}/packages/es6tween-core/package.json`).json();
+    expect(pkgJson.devDependencies).toBeUndefined();
+  });
+});
+
+describe("bun remove --recursive", () => {
+  test("removes package from all workspace packages", async () => {
+    using dir = tempDir("bun-remove-recursive", {
+      "package.json": JSON.stringify(
+        {
+          name: "root",
+          workspaces: ["packages/*"],
+          devDependencies: {
+            "is-even": "^1.0.0",
+          },
+        },
+        null,
+        2,
+      ),
+      "packages/pkg-a/package.json": JSON.stringify(
+        {
+          name: "pkg-a",
+          devDependencies: {
+            "is-even": "^1.0.0",
+          },
+        },
+        null,
+        2,
+      ),
+      "packages/pkg-b/package.json": JSON.stringify(
+        {
+          name: "pkg-b",
+          dependencies: {
+            "is-even": "^1.0.0",
+            "is-odd": "^1.0.0",
+          },
+        },
+        null,
+        2,
+      ),
+    });
+
+    await using installProc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await installProc.exited).toBe(0);
+
+    await using removeProc = Bun.spawn({
+      cmd: [bunExe(), "remove", "--recursive", "is-even"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      removeProc.stdout.text(),
+      removeProc.stderr.text(),
+      removeProc.exited,
+    ]);
+
+    expect(stderr).not.toContain("error");
+    expect(exitCode).toBe(0);
+
+    // Root should have is-even removed
+    const root = await Bun.file(`${dir}/package.json`).json();
+    expect(root.devDependencies).toBeUndefined();
+
+    // pkg-a should have is-even removed
+    const pkgA = await Bun.file(`${dir}/packages/pkg-a/package.json`).json();
+    expect(pkgA.devDependencies).toBeUndefined();
+
+    // pkg-b should have is-even removed but keep is-odd
+    const pkgB = await Bun.file(`${dir}/packages/pkg-b/package.json`).json();
+    expect(pkgB.dependencies).toEqual({ "is-odd": "^1.0.0" });
+  });
+});

--- a/test/regression/issue/27897.test.ts
+++ b/test/regression/issue/27897.test.ts
@@ -85,6 +85,67 @@ describe("bun remove --filter", () => {
     expect(other.dependencies).toEqual({ "is-even": "^1.0.0" });
   });
 
+  test("--filter does not remove from root when root does not match filter", async () => {
+    using dir = tempDir("bun-remove-filter-root", {
+      "package.json": JSON.stringify(
+        {
+          name: "root",
+          workspaces: ["packages/*"],
+          devDependencies: {
+            "is-even": "^1.0.0",
+          },
+        },
+        null,
+        2,
+      ),
+      "packages/pkg-a/package.json": JSON.stringify(
+        {
+          name: "pkg-a",
+          devDependencies: {
+            "is-even": "^1.0.0",
+          },
+        },
+        null,
+        2,
+      ),
+    });
+
+    await using installProc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await installProc.exited).toBe(0);
+
+    // --filter 'pkg-*' should NOT match the root (named "root")
+    await using removeProc = Bun.spawn({
+      cmd: [bunExe(), "remove", "--filter", "pkg-*", "is-even"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      removeProc.stdout.text(),
+      removeProc.stderr.text(),
+      removeProc.exited,
+    ]);
+
+    expect(stderr).not.toContain("error");
+    expect(exitCode).toBe(0);
+
+    // Root should still have is-even (filter doesn't match "root")
+    const root = await Bun.file(`${dir}/package.json`).json();
+    expect(root.devDependencies).toEqual({ "is-even": "^1.0.0" });
+
+    // pkg-a should have is-even removed (matches pkg-*)
+    const pkgA = await Bun.file(`${dir}/packages/pkg-a/package.json`).json();
+    expect(pkgA.devDependencies).toBeUndefined();
+  });
+
   test("--filter does not produce 'unrecognised dependency format' error", async () => {
     using dir = tempDir("bun-remove-filter-err", {
       "package.json": JSON.stringify(


### PR DESCRIPTION
## Summary

Closes #27897.

- Adds `--filter <pattern>` flag to `bun remove` to remove packages from matching workspace packages
- Adds `--recursive` / `-r` flag to `bun remove` to remove packages from all workspace packages
- Fixes the "unrecognised dependency format" error when using `--filter` with `bun remove`

Previously, `bun remove` only operated on the root `package.json` and did not support workspace-aware removal. The `--filter` flag was not recognized for the `remove` subcommand, causing the filter pattern to be parsed as a package name and failing validation.

### Changes

- **`CommandLineArguments.zig`**: Added `--filter` and `--recursive` flags to `remove_params`, and parsing for `--recursive` in the remove subcommand
- **`PackageManager.zig`**: Added `.remove` to `supportsWorkspaceFiltering()` 
- **`install_with_manager.zig`**: Extended `getWorkspaceFilters()` to populate filters for `.remove` subcommand
- **`updatePackageJSONAndInstall.zig`**: Refactored remove logic to support workspace-aware removal. When `--filter` or `--recursive` is used, discovers workspace directories via `processNamesArray`, then iterates matching workspace `package.json` files to remove the specified dependencies

## Test plan

- [x] `bun remove --filter 'pkg-*' is-even` removes from matching workspace packages only
- [x] `bun remove --filter 'es6tween-*' uglify-js` no longer produces "unrecognised dependency format" error
- [x] `bun remove --recursive is-even` removes from all workspace packages (including root)
- [x] Existing `bun remove` behavior is unchanged (5 existing tests pass)
- [x] New regression tests in `test/regression/issue/27897.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)