### PR TITLE
fix(server): add Date header to 413 responses

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2216,6 +2216,8 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
                     // Abort the request very early.
                     if (len > this.config.max_request_body_size) {
+                        // Ensure Date header is up-to-date (RFC 9110: 4xx responses should include Date)
+                        this.vm.uwsLoop().updateDate();
                         resp.writeStatus("413 Request Entity Too Large");
                         resp.endWithoutBody(true);
                         return null;


### PR DESCRIPTION
According to RFC 9110, HTTP servers should include a Date header in all 2xx, 3xx, and 4xx responses. Previously, 413 responses sent when maxRequestBodySize was exceeded did not include this header.

This fix ensures the Date header is up-to-date before sending the 413 response by calling uwsLoop().updateDate().

Fixes #27512