### PR TITLE
fix(s3): correct typo in checksumAlgorithm property name

### DIFF
--- a/src/s3/list_objects.zig
+++ b/src/s3/list_objects.zig
@@ -126,7 +126,7 @@ pub const S3ListObjectsV2Result = struct {
                 }
 
                 if (item.checksum_algorithme) |checksum_algorithme| {
-                    objectInfo.put(globalObject, jsc.ZigString.static("checksumAlgorithme"), try bun.String.createUTF8ForJS(globalObject, checksum_algorithme));
+                    objectInfo.put(globalObject, jsc.ZigString.static("checksumAlgorithm"), try bun.String.createUTF8ForJS(globalObject, checksum_algorithme));
                 }
 
                 if (item.checksum_type) |checksum_type| {


### PR DESCRIPTION
Fixes #19142

The property was incorrectly named "checksumAlgorithme" (French spelling)
instead of "checksumAlgorithm" (English spelling).

This aligns with the AWS S3 API specification and TypeScript types.

### Changes
- Changed "checksumAlgorithme" to "checksumAlgorithm" in S3ListObjectsResponse