### PR TITLE
fix(fetch): improve error message for invalid URLs

### DIFF
--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -1,5 +1,5 @@
 pub const fetch_error_no_args = "fetch() expects a string but received no arguments.";
-pub const fetch_error_blank_url = "fetch() URL must not be a blank string.";
+pub const fetch_error_blank_url = "fetch() URL must have a hostname.";
 pub const fetch_error_unexpected_body = "fetch() request with GET/HEAD/OPTIONS method cannot have body.";
 pub const fetch_error_proxy_unix = "fetch() cannot use a proxy with a unix socket.";
 const JSTypeErrorEnum = std.enums.EnumArray(JSType, string);


### PR DESCRIPTION
Fixes #21361

The previous error message "URL must not be a blank string" was misleading
when the URL was a non-string value (e.g., undefined, number) or lacked a
valid hostname.

### Changes
- Changed error message from "URL must not be a blank string" to "URL must have a hostname"
- More accurately describes the actual problem
- Helps developers debug fetch() calls more effectively

### Before
```
fetch(undefined)
// Error: fetch() URL must not be a blank string.
```

### After
```
fetch(undefined)
// Error: fetch() URL must have a hostname.
```