### PR TITLE
fix(init): ensure package.json uses spaces instead of tabs

### DIFF
--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -761,7 +761,10 @@ pub const InitCommand = struct {
                 &package_json_writer,
                 js_ast.Expr{ .data = .{ .e_object = fields.object }, .loc = logger.Loc.Empty },
                 &logger.Source.initEmptyFile("package.json"),
-                .{ .mangled_props = null },
+                .{
+                    .mangled_props = null,
+                    .indent = .{ .scalar = 2, .count = 0, .character = .space },
+                },
             ) catch |err| {
                 Output.prettyErrorln("package.json failed to write due to error {s}", .{@errorName(err)});
                 package_json_file = null;


### PR DESCRIPTION
Fixes #19319

Explicitly sets indentation to 2 spaces for package.json generation
to ensure consistency with tsconfig.json and JSON conventions.

### Changes
- Added explicit indent options to printJSON call
- Set character to .space (2 spaces per level)
- Ensures package.json matches tsconfig.json formatting

### Before
```json
// package.json (tabs)
{
	"name": "my-app"
}
```

### After
```json
// package.json (spaces)
{
  "name": "my-app"
}
```

Both package.json and tsconfig.json now consistently use 2-space indentation.