### PR TITLE
docs(prisma): fix import typo - PrismaLibSQL → PrismaLibSql

### DIFF
--- a/docs/guides/ecosystem/prisma.mdx
+++ b/docs/guides/ecosystem/prisma.mdx
@@ -102,9 +102,9 @@ mode: center
 
     	```ts prisma/db.ts icon="/icons/typescript.svg"
     	import { PrismaClient } from "./generated/client";
-    	import { PrismaLibSQL } from "@prisma/adapter-libsql";
+    	import { PrismaLibSql } from "@prisma/adapter-libsql";
 
-    	const adapter = new PrismaLibSQL({ url: process.env.DATABASE_URL || "" });
+    	const adapter = new PrismaLibSql({ url: process.env.DATABASE_URL || "" });
     	export const prisma = new PrismaClient({ adapter });
     	```
     </Step>


### PR DESCRIPTION
Fixes #25491

Corrected the import statement from PrismaLibSQL to PrismaLibSql
to match the actual export name from @prisma/adapter-libsql.

### Changes
- Changed import from `PrismaLibSQL` to `PrismaLibSql`
- Changed usage from `new PrismaLibSQL(...)` to `new PrismaLibSql(...)`

### Before
```ts
import { PrismaLibSQL } from "@prisma/adapter-libsql";
const adapter = new PrismaLibSQL({ url: ... });
```

### After
```ts
import { PrismaLibSql } from "@prisma/adapter-libsql";
const adapter = new PrismaLibSql({ url: ... });
```