### PR TITLE
feat(completions): add --watch and --update-snapshots to bun test completions

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -151,6 +151,9 @@ _bun_completions() {
         repl)
             COMPREPLY=( $(compgen -W "--help -h --eval -e --print -p --preload -r --smol --config -c --cwd --env-file --no-env-file" -- "${cur_word}") );
             return;;
+        test|t)
+            COMPREPLY=( $(compgen -W "--help -h --watch -w --update-snapshots -u --cwd --config -c --version -v" -- "${cur_word}") );
+            return;;
         run)
             _file_arguments "!(*.@(js|ts|jsx|tsx|mjs|cjs)?($|))";
             COMPREPLY+=( $(compgen -W "--version --cwd --help --silent -v -h" -- "${cur_word}" ) );


### PR DESCRIPTION
Fixes #2503

Adds bash completion support for test command options.

### Changes
- Added test case to bash completions
- Supports --watch/-w, --update-snapshots/-u, --cwd, --config/-c, --help/-h, --version/-v
- Matches existing zsh completion behavior

### Before
```bash
bun test <tab>
# Shows only global options
```

### After
```bash
bun test <tab>
# Shows --watch, --update-snapshots, and other test-specific options
```

Zsh completions already had these options. This brings bash completions to parity.