### PR TITLE
fix(types): make test function parameter optional in Test interface

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -469,7 +469,7 @@ declare module "bun:test" {
     (
       label: string,
 
-      fn: (
+      fn?: (
         ...args: __internal.IsTuple<T> extends true
           ? [...table: __internal.Flatten<T>, done: (err?: unknown) => void]
           : T


### PR DESCRIPTION
Fixes #25959

Makes the `fn` parameter optional in the Test interface to match
Jest behavior and support test.todo() with a single argument.

### Changes
- Changed `fn:` to `fn?:` in Test interface
- Allows test.todo with only a name parameter
- Matches behavior of Jest and other test runners
- Runtime already supports this; TypeScript types now match

### Example
```ts
import { test } from 'bun:test';

// Now works without TypeScript error
test.todo('unimplemented feature');

// Also works
test.todo('unimplemented feature', () => {
  // implementation
});
```

### Before
```
test.todo('unimplemented feature');
// TypeScript error: Expected 2-3 arguments, but got 1
```

### After
```
test.todo('unimplemented feature');
// No TypeScript error
```