### PR TITLE
fix(codegen): correct typo - 'seperately' → 'separately'

### DIFF
--- a/src/codegen/cppbind.ts
+++ b/src/codegen/cppbind.ts
@@ -553,7 +553,7 @@ async function processFile(parser: CppParser, file: string, allFunctions: CppFn[
 
       queryFoundLines.add(lineInfo.get(zigExportAttr.from).line);
 
-      // disabled because lezer parses (extern "C") seperately to the function definition / block
+      // disabled because lezer parses (extern "C") separately to the function definition / block
       /* const linkage = closest(fnNode, "LinkageSpecification");
       const linkageString = linkage?.getChild("String");
       if (!linkage || !linkageString || text(linkageString, ctx) !== '"C"') {


### PR DESCRIPTION
Fixed spelling mistake in comment.

### Changes
- Changed 'seperately' to 'separately'
- Minor documentation improvement