### PR TITLE
docs(sqlite): clarify WAL sidecar cleanup behavior after close

### DIFF
--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -133,6 +133,25 @@ db.close(true);
   has no effect after the first.
 </Note>
 
+<Important title="WAL sidecar files">
+  When using WAL (Write-Ahead Logging) mode with a file-based database, SQLite creates additional sidecar files:
+  `-wal` (write-ahead log) and `-shm` (shared memory). The cleanup behavior of these files after calling `.close()` 
+  varies by platform and SQLite configuration:
+
+  - **Linux**: Sidecar files are typically cleaned up after close
+  - **macOS**: Sidecar files may persist after close due to platform-specific SQLite behavior
+  - **Windows**: Behavior varies by Windows version and SQLite configuration
+
+  If you need to ensure sidecar files are cleaned up, consider manually removing them after closing the database:
+  ```ts
+  import { rmSync } from "node:fs";
+
+  db.close();
+  rmSync("mydb.sqlite-wal");
+  rmSync("mydb.sqlite-shm");
+  ```
+</Important>
+
 ### `using` statement
 
 You can use the `using` statement to ensure that a database connection is closed when the `using` block is exited.


### PR DESCRIPTION
Fixes #27481

Documents that WAL sidecar files (.db-wal, .db-shm) cleanup behavior
varies by platform and SQLite configuration after db.close():

- Linux: sidecar files typically cleaned up after close
- macOS: sidecar files may persist after close
- Windows: behavior varies by version and configuration

Provides guidance for manual cleanup when needed.

### Changes
- Added Important note about WAL sidecar file behavior
- Clarified platform-specific cleanup differences
- Provided example for manual cleanup when needed