### PR TITLE
fix(fs): readdir with withFileTypes and encoding "buffer" returns Dirent with Buffer name

### DIFF
--- a/src/bun.js/bindings/NodeDirent.cpp
+++ b/src/bun.js/bindings/NodeDirent.cpp
@@ -20,6 +20,7 @@
 #include <JavaScriptCore/Structure.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include "ZigGlobalObject.h"
+#include "JSBuffer.h"
 
 namespace Bun {
 
@@ -328,7 +329,7 @@ extern "C" JSC::EncodedJSValue Bun__JSDirentObjectConstructor(Zig::GlobalObject*
     return JSValue::encode(globalobject->m_JSDirentClassStructure.constructor(globalobject));
 }
 
-extern "C" JSC::EncodedJSValue Bun__Dirent__toJS(Zig::GlobalObject* globalObject, int type, BunString* name, BunString* path, JSString** previousPath)
+extern "C" JSC::EncodedJSValue Bun__Dirent__toJS(Zig::GlobalObject* globalObject, int type, BunString* name, BunString* path, JSString** previousPath, bool nameAsBuffer)
 {
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -355,8 +356,15 @@ extern "C" JSC::EncodedJSValue Bun__Dirent__toJS(Zig::GlobalObject* globalObject
         }
     }
 
-    auto nameString = name->transferToWTFString();
-    auto nameValue = jsString(vm, WTF::move(nameString));
+    JSValue nameValue;
+    if (nameAsBuffer) {
+        auto nameString = name->transferToWTFString();
+        auto utf8 = nameString.utf8();
+        nameValue = WebCore::createBuffer(globalObject, utf8.data(), utf8.length());
+    } else {
+        auto nameString = name->transferToWTFString();
+        nameValue = jsString(vm, WTF::move(nameString));
+    }
     auto typeValue = jsNumber(type);
     object->putDirectOffset(vm, 0, nameValue);
     object->putDirectOffset(vm, 1, pathValue);

--- a/src/bun.js/bindings/NodeDirent.cpp
+++ b/src/bun.js/bindings/NodeDirent.cpp
@@ -358,9 +358,16 @@ extern "C" JSC::EncodedJSValue Bun__Dirent__toJS(Zig::GlobalObject* globalObject
 
     JSValue nameValue;
     if (nameAsBuffer) {
+        // The name was stored as Latin-1 to preserve raw filesystem bytes.
+        // Read the 8-bit data directly to avoid lossy UTF-8 round-tripping.
         auto nameString = name->transferToWTFString();
-        auto utf8 = nameString.utf8();
-        nameValue = WebCore::createBuffer(globalObject, utf8.data(), utf8.length());
+        if (nameString.is8Bit()) {
+            auto span = nameString.span8();
+            nameValue = WebCore::createBuffer(globalObject, reinterpret_cast<const char*>(span.data()), span.size());
+        } else {
+            auto utf8 = nameString.utf8();
+            nameValue = WebCore::createBuffer(globalObject, utf8.data(), utf8.length());
+        }
     } else {
         auto nameString = name->transferToWTFString();
         nameValue = jsString(vm, WTF::move(nameString));

--- a/src/bun.js/bindings/NodeDirent.cpp
+++ b/src/bun.js/bindings/NodeDirent.cpp
@@ -368,6 +368,7 @@ extern "C" JSC::EncodedJSValue Bun__Dirent__toJS(Zig::GlobalObject* globalObject
             auto utf8 = nameString.utf8();
             nameValue = WebCore::createBuffer(globalObject, utf8.data(), utf8.length());
         }
+        RETURN_IF_EXCEPTION(scope, {});
     } else {
         auto nameString = name->transferToWTFString();
         nameValue = jsString(vm, WTF::move(nameString));

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -4507,7 +4507,14 @@ pub const NodeFS = struct {
                         else
                             current.kind;
                         entries.append(.{
-                            .name = jsc.WebCore.encoding.toBunString(utf8_name, args.encoding),
+                            // When encoding is buffer, store raw bytes as Latin-1
+                            // to preserve non-UTF8 filesystem names. toBunString
+                            // with .buffer encoding would convert through UTF-16,
+                            // replacing invalid UTF-8 sequences with U+FFFD.
+                            .name = if (args.encoding == .buffer)
+                                bun.String.cloneLatin1(utf8_name)
+                            else
+                                jsc.WebCore.encoding.toBunString(utf8_name, args.encoding),
                             .path = dirent_path,
                             .kind = kind,
                             .name_as_buffer = args.encoding == .buffer,
@@ -4851,7 +4858,10 @@ pub const NodeFS = struct {
                         }
                         dirent_path_prev.ref();
                         entries.append(.{
-                            .name = jsc.WebCore.encoding.toBunString(utf8_name, args.encoding),
+                            .name = if (args.encoding == .buffer)
+                                bun.String.cloneLatin1(utf8_name)
+                            else
+                                jsc.WebCore.encoding.toBunString(utf8_name, args.encoding),
                             .path = dirent_path_prev,
                             .kind = effective_kind,
                             .name_as_buffer = args.encoding == .buffer,

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -2204,12 +2204,10 @@ pub const Arguments = struct {
         }
 
         pub fn tag(this: *const Readdir) Return.Readdir.Tag {
+            if (this.with_file_types) return .with_file_types;
             return switch (this.encoding) {
                 .buffer => .buffers,
-                else => if (this.with_file_types)
-                    .with_file_types
-                else
-                    .files,
+                else => .files,
             };
         }
 
@@ -4512,6 +4510,7 @@ pub const NodeFS = struct {
                             .name = jsc.WebCore.encoding.toBunString(utf8_name, args.encoding),
                             .path = dirent_path,
                             .kind = kind,
+                            .name_as_buffer = args.encoding == .buffer,
                         }) catch |err| bun.handleOom(err);
                     },
                     Buffer => {
@@ -4531,6 +4530,7 @@ pub const NodeFS = struct {
                             .name = bun.String.cloneUTF16(utf16_name),
                             .path = dirent_path,
                             .kind = current.kind,
+                            .name_as_buffer = args.encoding == .buffer,
                         }) catch |err| bun.handleOom(err);
                     },
                     bun.String => switch (args.encoding) {
@@ -4693,6 +4693,7 @@ pub const NodeFS = struct {
                         .name = bun.String.cloneUTF8(utf8_name),
                         .path = dirent_path_prev,
                         .kind = effective_kind,
+                        .name_as_buffer = args.encoding == .buffer,
                     }) catch |err| bun.handleOom(err);
                 },
                 Buffer => {
@@ -4853,6 +4854,7 @@ pub const NodeFS = struct {
                             .name = jsc.WebCore.encoding.toBunString(utf8_name, args.encoding),
                             .path = dirent_path_prev,
                             .kind = effective_kind,
+                            .name_as_buffer = args.encoding == .buffer,
                         }) catch |err| bun.handleOom(err);
                     },
                     Buffer => {

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -1154,13 +1154,14 @@ pub const Dirent = struct {
     path: bun.String,
     // not publicly exposed
     kind: Kind,
+    name_as_buffer: bool = false,
 
     pub const Kind = std.fs.File.Kind;
 
     extern fn Bun__JSDirentObjectConstructor(*jsc.JSGlobalObject) jsc.JSValue;
     pub const getConstructor = Bun__JSDirentObjectConstructor;
 
-    extern fn Bun__Dirent__toJS(*jsc.JSGlobalObject, i32, *bun.String, *bun.String, cached_previous_path_jsvalue: ?*?*jsc.JSString) jsc.JSValue;
+    extern fn Bun__Dirent__toJS(*jsc.JSGlobalObject, i32, *bun.String, *bun.String, cached_previous_path_jsvalue: ?*?*jsc.JSString, bool) jsc.JSValue;
     pub fn toJS(this: *Dirent, globalObject: *jsc.JSGlobalObject, cached_previous_path_jsvalue: ?*?*jsc.JSString) bun.JSError!jsc.JSValue {
         return bun.jsc.fromJSHostCall(globalObject, @src(), Bun__Dirent__toJS, .{
             globalObject,
@@ -1178,6 +1179,7 @@ pub const Dirent = struct {
             &this.name,
             &this.path,
             cached_previous_path_jsvalue,
+            this.name_as_buffer,
         });
     }
 

--- a/test/regression/issue/27914.test.ts
+++ b/test/regression/issue/27914.test.ts
@@ -64,6 +64,28 @@ test("readdirSync with withFileTypes and encoding 'buffer' recursive returns Dir
   }
 });
 
+test("readdir (async) with withFileTypes and encoding 'buffer' recursive returns Dirent with Buffer name", async () => {
+  using dir = tempDir("readdir-buffer-dirent-async-recursive", {
+    "a.txt": "hello",
+    "sub/b.txt": "world",
+  });
+
+  const entries = await readdir(String(dir), { withFileTypes: true, encoding: "buffer", recursive: true });
+
+  expect(entries.length).toBeGreaterThanOrEqual(3); // a.txt, sub, sub/b.txt
+
+  const names = entries.map((e: any) => e.name.toString()).sort();
+  expect(names).toContain("a.txt");
+  expect(names).toContain("sub");
+  expect(names).toContain("b.txt");
+
+  for (const entry of entries) {
+    expect(entry.name).toBeInstanceOf(Buffer);
+    expect(entry.name.length).toBeGreaterThan(0);
+    expect(typeof entry.parentPath).toBe("string");
+  }
+});
+
 test("readdirSync with withFileTypes without encoding 'buffer' still returns string names", () => {
   using dir = tempDir("readdir-dirent-string", {
     "test.txt": "content",

--- a/test/regression/issue/27914.test.ts
+++ b/test/regression/issue/27914.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { readdirSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+
+test("readdirSync with withFileTypes and encoding 'buffer' returns Dirent with Buffer name", () => {
+  using dir = tempDir("readdir-buffer-dirent", {
+    "file.txt": "hello",
+    "other.txt": "world",
+  });
+
+  const entries = readdirSync(String(dir), { withFileTypes: true, encoding: "buffer" });
+
+  expect(entries.length).toBe(2);
+
+  for (const entry of entries) {
+    // name should be a Buffer, not undefined
+    expect(entry.name).toBeInstanceOf(Buffer);
+    expect(entry.name.length).toBeGreaterThan(0);
+
+    // parentPath should still be a string
+    expect(typeof entry.parentPath).toBe("string");
+
+    // Dirent methods should work
+    expect(entry.isFile()).toBe(true);
+    expect(entry.isDirectory()).toBe(false);
+  }
+
+  // Check that the names match expected file names
+  const names = entries.map((e: any) => e.name.toString()).sort();
+  expect(names).toEqual(["file.txt", "other.txt"]);
+});
+
+test("readdir (async) with withFileTypes and encoding 'buffer' returns Dirent with Buffer name", async () => {
+  using dir = tempDir("readdir-buffer-dirent-async", {
+    "foo.js": "content",
+  });
+
+  const entries = await readdir(String(dir), { withFileTypes: true, encoding: "buffer" });
+
+  expect(entries.length).toBe(1);
+  const entry = entries[0];
+
+  expect(entry.name).toBeInstanceOf(Buffer);
+  expect(entry.name.toString()).toBe("foo.js");
+  expect(typeof entry.parentPath).toBe("string");
+  expect(entry.isFile()).toBe(true);
+});
+
+test("readdirSync with withFileTypes and encoding 'buffer' recursive returns Dirent with Buffer name", () => {
+  using dir = tempDir("readdir-buffer-dirent-recursive", {
+    "a.txt": "hello",
+    "sub/b.txt": "world",
+  });
+
+  const entries = readdirSync(String(dir), { withFileTypes: true, encoding: "buffer", recursive: true });
+
+  expect(entries.length).toBeGreaterThanOrEqual(3); // a.txt, sub, sub/b.txt
+
+  for (const entry of entries) {
+    expect(entry.name).toBeInstanceOf(Buffer);
+    expect(entry.name.length).toBeGreaterThan(0);
+    expect(typeof entry.parentPath).toBe("string");
+  }
+});
+
+test("readdirSync with withFileTypes without encoding 'buffer' still returns string names", () => {
+  using dir = tempDir("readdir-dirent-string", {
+    "test.txt": "content",
+  });
+
+  const entries = readdirSync(String(dir), { withFileTypes: true });
+
+  expect(entries.length).toBe(1);
+  expect(typeof entries[0].name).toBe("string");
+  expect(entries[0].name).toBe("test.txt");
+});
+
+test("readdirSync with encoding 'buffer' without withFileTypes returns Uint8Array array", () => {
+  using dir = tempDir("readdir-buffer-no-dirent", {
+    "test.txt": "content",
+  });
+
+  const entries = readdirSync(String(dir), { encoding: "buffer" });
+
+  expect(entries.length).toBe(1);
+  expect(entries[0]).toBeInstanceOf(Uint8Array);
+  expect(Buffer.from(entries[0]).toString()).toBe("test.txt");
+});

--- a/test/regression/issue/27914.test.ts
+++ b/test/regression/issue/27914.test.ts
@@ -55,7 +55,7 @@ test("readdirSync with withFileTypes and encoding 'buffer' recursive returns Dir
 
   const entries = readdirSync(String(dir), { withFileTypes: true, encoding: "buffer", recursive: true });
 
-  expect(entries.length).toBeGreaterThanOrEqual(3); // a.txt, sub, sub/b.txt
+  expect(entries.length).toBe(3); // a.txt, sub, sub/b.txt
 
   for (const entry of entries) {
     expect(entry.name).toBeInstanceOf(Buffer);
@@ -72,7 +72,7 @@ test("readdir (async) with withFileTypes and encoding 'buffer' recursive returns
 
   const entries = await readdir(String(dir), { withFileTypes: true, encoding: "buffer", recursive: true });
 
-  expect(entries.length).toBeGreaterThanOrEqual(3); // a.txt, sub, sub/b.txt
+  expect(entries.length).toBe(3); // a.txt, sub, sub/b.txt
 
   const names = entries.map((e: any) => e.name.toString()).sort();
   expect(names).toContain("a.txt");


### PR DESCRIPTION
## Summary
- Fix `readdirSync`/`readdir` with `{ withFileTypes: true, encoding: "buffer" }` returning raw `Uint8Array` objects instead of `Dirent` objects with `Buffer` names
- The `tag()` method in `Arguments.Readdir` unconditionally returned `.buffers` when encoding was `"buffer"`, completely ignoring the `withFileTypes` flag
- Now `withFileTypes` takes priority in `tag()`, and the buffer encoding is propagated through the `Dirent` struct to the C++ `Bun__Dirent__toJS` function so names are created as `Buffer` objects

Closes #27914

## Test plan
- [x] Added `test/regression/issue/27914.test.ts` covering:
  - Sync readdir with `withFileTypes: true` + `encoding: "buffer"` returns Dirent with Buffer name
  - Async readdir with `withFileTypes: true` + `encoding: "buffer"` returns Dirent with Buffer name  
  - Recursive sync readdir with `withFileTypes: true` + `encoding: "buffer"` returns Dirent with Buffer name
  - Control: `withFileTypes: true` without buffer encoding still returns string names
  - Control: `encoding: "buffer"` without `withFileTypes` still returns Uint8Array array
- [x] Tests fail with `USE_SYSTEM_BUN=1` and pass with `bun bd test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)