### PR TITLE
fix(transpiler): correct decorator init order with TS parameter properties

### DIFF
--- a/src/ast/lowerDecorators.zig
+++ b/src/ast/lowerDecorators.zig
@@ -1327,7 +1327,15 @@ pub fn LowerDecorators(
                             super_index = index;
                             break;
                         }
-                        const insert_at = if (super_index) |j| j + 1 else 0;
+                        // Skip past TypeScript parameter property assignments
+                        // (e.g. `this.options = options` from `constructor(private options: any)`)
+                        // that were already inserted by the TS parameter property lowering phase.
+                        var insert_at = if (super_index) |j| j + 1 else @as(usize, 0);
+                        for (func.func.args) |arg| {
+                            if (arg.is_typescript_ctor_field and arg.binding.data == .b_identifier) {
+                                insert_at += 1;
+                            }
+                        }
                         body_stmts.insertSlice(insert_at, constructor_inject_stmts.items) catch unreachable;
                         func.func.body.stmts = body_stmts.items;
                         found_constructor = true;

--- a/test/regression/issue/27922.test.ts
+++ b/test/regression/issue/27922.test.ts
@@ -1,0 +1,122 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// TC39 standard decorators + TypeScript parameter properties:
+// Decorator field initializers must be injected AFTER parameter property
+// assignments in the constructor body.
+
+test("decorator field initializers run after TS parameter properties are assigned", async () => {
+  using dir = tempDir("issue-27922", {
+    "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+    "test.ts": `
+      function init(value: undefined, context: ClassFieldDecoratorContext) {
+        return function(this: any, initialValue: any) {
+          return this.options?.prefix ? this.options.prefix + initialValue : initialValue;
+        };
+      }
+
+      class Xterm {
+        @init
+        tokenUrl: string = "default";
+
+        constructor(private options: any) {}
+      }
+
+      const x = new Xterm({ prefix: "pfx-" });
+      console.log(x.tokenUrl);
+      console.log(x.options.prefix);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("pfx-default\npfx-\n");
+  expect(exitCode).toBe(0);
+});
+
+test("decorator field initializers run after multiple TS parameter properties", async () => {
+  using dir = tempDir("issue-27922-multi", {
+    "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+    "test.ts": `
+      function init(value: undefined, context: ClassFieldDecoratorContext) {
+        return function(this: any, initialValue: any) {
+          return this.a + this.b + initialValue;
+        };
+      }
+
+      class Foo {
+        @init
+        result: number = 10;
+
+        constructor(private a: number, private b: number) {}
+      }
+
+      const f = new Foo(1, 2);
+      console.log(f.result);
+      console.log(f.a);
+      console.log(f.b);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("13\n1\n2\n");
+  expect(exitCode).toBe(0);
+});
+
+test("decorator field initializers with super() and TS parameter properties", async () => {
+  using dir = tempDir("issue-27922-super", {
+    "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+    "test.ts": `
+      function init(value: undefined, context: ClassFieldDecoratorContext) {
+        return function(this: any, initialValue: any) {
+          return this.options?.tag ? this.options.tag + initialValue : initialValue;
+        };
+      }
+
+      class Base {
+        base = true;
+      }
+
+      class Derived extends Base {
+        @init
+        name: string = "world";
+
+        constructor(private options: any) {
+          super();
+        }
+      }
+
+      const d = new Derived({ tag: "hello-" });
+      console.log(d.name);
+      console.log(d.base);
+      console.log(d.options.tag);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("hello-world\ntrue\nhello-\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/27922.test.ts
+++ b/test/regression/issue/27922.test.ts
@@ -5,6 +5,14 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // Decorator field initializers must be injected AFTER parameter property
 // assignments in the constructor body.
 
+function filterStderr(stderr: string) {
+  return stderr
+    .split("\n")
+    .filter(line => !line.startsWith("WARNING: ASAN"))
+    .join("\n")
+    .trim();
+}
+
 test("decorator field initializers run after TS parameter properties are assigned", async () => {
   using dir = tempDir("issue-27922", {
     "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
@@ -38,6 +46,7 @@ test("decorator field initializers run after TS parameter properties are assigne
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toBe("pfx-default\npfx-\n");
+  expect(filterStderr(stderr)).toBe("");
   expect(exitCode).toBe(0);
 });
 
@@ -75,6 +84,7 @@ test("decorator field initializers run after multiple TS parameter properties", 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toBe("13\n1\n2\n");
+  expect(filterStderr(stderr)).toBe("");
   expect(exitCode).toBe(0);
 });
 
@@ -118,5 +128,6 @@ test("decorator field initializers with super() and TS parameter properties", as
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toBe("hello-world\ntrue\nhello-\n");
+  expect(filterStderr(stderr)).toBe("");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Summary
- Fix incorrect constructor initialization order when TC39 standard decorators are combined with TypeScript parameter properties (`constructor(private x: any)`)
- Decorator field initializers (`__runInitializers(...)`) were inserted **before** parameter property assignments (`this.x = x`), causing runtime errors when decorator code accessed uninitialized properties
- The fix skips past TS parameter property assignments when calculating the insertion point in `lowerDecorators.zig`

Closes #27922

## Test plan
- [x] New regression test `test/regression/issue/27922.test.ts` with 3 cases:
  - Single parameter property + field decorator
  - Multiple parameter properties + field decorator
  - Subclass with `super()` + parameter property + field decorator
- [x] Test fails with system bun (unfixed), passes with debug build (fixed)
- [x] All existing decorator test suites pass (27/27 + 147/147 + 22/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)