### PR TITLE
fix(types): add Map.getOrInsert and getOrInsertComputed type definitions

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1075,6 +1075,62 @@ interface SharedArrayBuffer {
   grow(size: number): SharedArrayBuffer;
 }
 
+interface Map<K, V> {
+  /**
+   * If the key already exists in the map, return the existing value. Otherwise,
+   * insert the given default value and return it.
+   *
+   * ```ts
+   * const m = new Map<string, number>();
+   * m.getOrInsert("a", 1); // 1
+   * m.getOrInsert("a", 2); // 1
+   * ```
+   *
+   * @param key - The key to look up.
+   * @param defaultValue - The value to insert if the key doesn't exist.
+   * @returns The existing value if the key exists, otherwise the inserted default value.
+   */
+  getOrInsert(key: K, defaultValue: V): V;
+
+  /**
+   * If the key already exists in the map, return the existing value. Otherwise,
+   * call the callback function to compute a value, insert it, and return it.
+   *
+   * ```ts
+   * const m = new Map<string, string>();
+   * m.getOrInsertComputed("key", (k) => k + "_value"); // "key_value"
+   * m.getOrInsertComputed("key", (k) => k + "_other"); // "key_value"
+   * ```
+   *
+   * @param key - The key to look up.
+   * @param callbackFunction - A function that receives the key and returns the value to insert.
+   * @returns The existing value if the key exists, otherwise the computed and inserted value.
+   */
+  getOrInsertComputed(key: K, callbackFunction: (key: K) => V): V;
+}
+
+interface WeakMap<K extends WeakKey, V> {
+  /**
+   * If the key already exists in the weak map, return the existing value. Otherwise,
+   * insert the given default value and return it.
+   *
+   * @param key - The key to look up.
+   * @param defaultValue - The value to insert if the key doesn't exist.
+   * @returns The existing value if the key exists, otherwise the inserted default value.
+   */
+  getOrInsert(key: K, defaultValue: V): V;
+
+  /**
+   * If the key already exists in the weak map, return the existing value. Otherwise,
+   * call the callback function to compute a value, insert it, and return it.
+   *
+   * @param key - The key to look up.
+   * @param callbackFunction - A function that receives the key and returns the value to insert.
+   * @returns The existing value if the key exists, otherwise the computed and inserted value.
+   */
+  getOrInsertComputed(key: K, callbackFunction: (key: K) => V): V;
+}
+
 interface ArrayConstructor {
   /**
    * Create an array from an iterable or async iterable object.

--- a/test/regression/issue/27380.test.ts
+++ b/test/regression/issue/27380.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+
+test("Map.prototype.getOrInsert", () => {
+  const m = new Map<string, number>();
+
+  // Insert new key
+  expect(m.getOrInsert("a", 1)).toBe(1);
+  expect(m.get("a")).toBe(1);
+
+  // Return existing value
+  expect(m.getOrInsert("a", 99)).toBe(1);
+  expect(m.get("a")).toBe(1);
+});
+
+test("Map.prototype.getOrInsertComputed", () => {
+  const m = new Map<string, string>();
+
+  // Insert computed value for new key
+  expect(m.getOrInsertComputed("key", k => k + "_value")).toBe("key_value");
+  expect(m.get("key")).toBe("key_value");
+
+  // Return existing value, callback not called
+  let called = false;
+  expect(
+    m.getOrInsertComputed("key", () => {
+      called = true;
+      return "other";
+    }),
+  ).toBe("key_value");
+  expect(called).toBe(false);
+});
+
+test("WeakMap.prototype.getOrInsert", () => {
+  const wm = new WeakMap<object, string>();
+  const obj = {};
+
+  expect(wm.getOrInsert(obj, "value")).toBe("value");
+  expect(wm.getOrInsert(obj, "other")).toBe("value");
+});
+
+test("WeakMap.prototype.getOrInsertComputed", () => {
+  const wm = new WeakMap<object, number>();
+  const obj = {};
+
+  expect(wm.getOrInsertComputed(obj, () => 42)).toBe(42);
+  expect(wm.getOrInsertComputed(obj, () => 99)).toBe(42);
+});


### PR DESCRIPTION
## Summary
- Add TypeScript type definitions for `Map.prototype.getOrInsert()`, `Map.prototype.getOrInsertComputed()`, `WeakMap.prototype.getOrInsert()`, and `WeakMap.prototype.getOrInsertComputed()` (TC39 upsert proposal)
- These methods already work at runtime but were missing from Bun's type declarations, causing `ts(2339)` errors

## Test plan
- [x] Added regression test at `test/regression/issue/27380.test.ts` covering both Map and WeakMap variants
- [x] Verified tests pass with `bun bd test`

Closes #27380
Closes #27934

🤖 Generated with [Claude Code](https://claude.com/claude-code)