### PR TITLE
Add --affected flag for `bun run` (git-aware workspace filtering)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -430,6 +430,7 @@ pub const Command = struct {
         affected: bool = false,
         base_ref: []const u8 = "main",
         head_ref: []const u8 = "HEAD",
+        explicit_refs: bool = false,
         list_affected: bool = false,
         if_present: bool = false,
         parallel: bool = false,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -427,6 +427,10 @@ pub const Command = struct {
 
         filters: []const []const u8 = &.{},
         workspaces: bool = false,
+        affected: bool = false,
+        base_ref: []const u8 = "main",
+        head_ref: []const u8 = "HEAD",
+        list_affected: bool = false,
         if_present: bool = false,
         parallel: bool = false,
         sequential: bool = false,

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -131,6 +131,10 @@ pub const auto_or_run_params = [_]ParamType{
     clap.parseParam("-b, --bun                         Force a script or package to use Bun's runtime instead of Node.js (via symlinking node)") catch unreachable,
     clap.parseParam("--shell <STR>                     Control the shell used for package.json scripts. Supports either 'bun' or 'system'") catch unreachable,
     clap.parseParam("--workspaces                      Run a script in all workspace packages (from the \"workspaces\" field in package.json)") catch unreachable,
+    clap.parseParam("--affected                        Run a script only in workspace packages affected by git changes") catch unreachable,
+    clap.parseParam("--base <STR>                      Base git ref for --affected (default: \"main\")") catch unreachable,
+    clap.parseParam("--head <STR>                      Head git ref for --affected (default: \"HEAD\")") catch unreachable,
+    clap.parseParam("--list                            List affected packages without running scripts (with --affected)") catch unreachable,
     clap.parseParam("--parallel                        Run multiple scripts concurrently with Foreman-style output") catch unreachable,
     clap.parseParam("--sequential                      Run multiple scripts sequentially with Foreman-style output") catch unreachable,
     clap.parseParam("--no-exit-on-error                Continue running other scripts when one fails (with --parallel/--sequential)") catch unreachable,
@@ -457,10 +461,19 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
     if (cmd == .RunCommand or cmd == .AutoCommand) {
         ctx.filters = args.options("--filter");
         ctx.workspaces = args.flag("--workspaces");
+        ctx.affected = args.flag("--affected");
         ctx.if_present = args.flag("--if-present");
         ctx.parallel = args.flag("--parallel");
         ctx.sequential = args.flag("--sequential");
         ctx.no_exit_on_error = args.flag("--no-exit-on-error");
+        ctx.list_affected = args.flag("--list");
+
+        if (args.option("--base")) |base| {
+            ctx.base_ref = base;
+        }
+        if (args.option("--head")) |head| {
+            ctx.head_ref = head;
+        }
 
         if (args.option("--elide-lines")) |elide_lines| {
             if (elide_lines.len > 0) {
@@ -469,6 +482,20 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                     Global.exit(1);
                 };
             }
+        }
+
+        // --affected implies --workspaces (run across all workspace packages, then filter)
+        if (ctx.affected) {
+            if (ctx.filters.len > 0) {
+                Output.prettyErrorln("<r><red>error<r>: --affected and --filter cannot be used together", .{});
+                Global.exit(1);
+            }
+            ctx.workspaces = true;
+        }
+
+        if (ctx.list_affected and !ctx.affected) {
+            Output.prettyErrorln("<r><red>error<r>: --list requires --affected", .{});
+            Global.exit(1);
         }
     }
 

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -470,9 +470,11 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
 
         if (args.option("--base")) |base| {
             ctx.base_ref = base;
+            ctx.explicit_refs = true;
         }
         if (args.option("--head")) |head| {
             ctx.head_ref = head;
+            ctx.explicit_refs = true;
         }
 
         if (args.option("--elide-lines")) |elide_lines| {

--- a/src/cli/affected.zig
+++ b/src/cli/affected.zig
@@ -40,16 +40,21 @@ pub fn filterAffectedScripts(
     defer changed_files.deinit();
 
     // Get merge-base for accurate diff on diverged branches
-    const merge_base = runGitOneLine(allocator, &.{ "git", "merge-base", base_ref, head_ref }, resolve_root) orelse base_ref;
+    const merge_base = try runGitOneLine(allocator, &.{ "git", "merge-base", base_ref, head_ref }, resolve_root);
 
     // Committed changes: merge-base..head
-    try collectGitLines(allocator, &changed_files, &.{ "git", "diff", "--name-only", "--no-renames", "--relative", merge_base, head_ref }, resolve_root);
+    try collectGitLines(allocator, &changed_files, &.{ "git", "diff", "--name-only", "--no-renames", "--relative", merge_base orelse base_ref, head_ref }, resolve_root);
 
-    // Uncommitted changes (staged + unstaged vs HEAD)
-    try collectGitLines(allocator, &changed_files, &.{ "git", "diff", "--name-only", "--no-renames", "--relative", "HEAD" }, resolve_root);
+    // Include working tree changes only when using default refs (local dev workflow).
+    // When custom --base/--head are provided, only committed diffs matter (CI use case).
+    const is_default_refs = strings.eql(base_ref, "main") and strings.eql(head_ref, "HEAD");
+    if (is_default_refs) {
+        // Uncommitted changes (staged + unstaged vs HEAD)
+        try collectGitLines(allocator, &changed_files, &.{ "git", "diff", "--name-only", "--no-renames", "--relative", "HEAD" }, resolve_root);
 
-    // Untracked files
-    try collectGitLines(allocator, &changed_files, &.{ "git", "ls-files", "--others", "--exclude-standard" }, resolve_root);
+        // Untracked files
+        try collectGitLines(allocator, &changed_files, &.{ "git", "ls-files", "--others", "--exclude-standard" }, resolve_root);
+    }
 
     // Phase 2: Check for global file changes
     for (changed_files.items) |file| {
@@ -164,8 +169,12 @@ pub fn listAffectedAndExit(
 
     for (scripts.items) |script| {
         if (!seen.contains(script.package_name)) {
-            seen.put(script.package_name, {}) catch {};
-            names.append(script.package_name) catch {};
+            seen.put(script.package_name, {}) catch |err| switch (err) {
+                error.OutOfMemory => bun.outOfMemory(),
+            };
+            names.append(script.package_name) catch |err| switch (err) {
+                error.OutOfMemory => bun.outOfMemory(),
+            };
         }
     }
 
@@ -194,7 +203,7 @@ fn isRootLevel(path: []const u8, basename: []const u8) bool {
 }
 
 fn makeRelative(abs_path: []const u8, root: []const u8) []const u8 {
-    if (std.mem.startsWith(u8, abs_path, root)) {
+    if (strings.hasPrefix(abs_path, root)) {
         var rel = abs_path[root.len..];
         if (rel.len > 0 and rel[0] == '/') {
             rel = rel[1..];
@@ -216,9 +225,12 @@ fn mapFileToPackage(file_path: []const u8, package_roots: *const bun.StringHashM
     return null;
 }
 
-/// Run a git command and return a single trimmed line of output.
-fn runGitOneLine(allocator: std.mem.Allocator, argv: []const []const u8, cwd: []const u8) ?[]const u8 {
-    const output = runGitSync(allocator, argv, cwd, true) catch return null;
+/// Run a git command and return a single trimmed line of output, or null if empty.
+fn runGitOneLine(allocator: std.mem.Allocator, argv: []const []const u8, cwd: []const u8) !?[]const u8 {
+    const output = runGitSync(allocator, argv, cwd, true) catch |err| {
+        Output.warn("git command failed: {s}\n", .{@errorName(err)});
+        return null;
+    };
     const trimmed = std.mem.trimRight(u8, output, "\n\r ");
     if (trimmed.len == 0) return null;
     return trimmed;
@@ -231,7 +243,10 @@ fn collectGitLines(
     argv: []const []const u8,
     cwd: []const u8,
 ) !void {
-    const output = runGitSync(allocator, argv, cwd, false) catch return;
+    const output = runGitSync(allocator, argv, cwd, false) catch |err| {
+        Output.warn("git command failed: {s}\n", .{@errorName(err)});
+        return;
+    };
     var lines = std.mem.splitScalar(u8, output, '\n');
     while (lines.next()) |line| {
         const trimmed = std.mem.trimRight(u8, line, "\r ");
@@ -257,7 +272,12 @@ fn runGitSync(allocator: std.mem.Allocator, argv: []const []const u8, cwd: []con
     try child.collectOutput(allocator, &stdout, &stderr, 1024 * 1024);
     const term = try child.wait();
 
-    if (term.Exited != 0 and !allow_non_zero) {
+    const exit_code = switch (term) {
+        .Exited => |code| code,
+        .Signal, .Stopped, .Unknown => 1,
+    };
+
+    if (exit_code != 0 and !allow_non_zero) {
         stdout.deinit(allocator);
         return error.GitCommandFailed;
     }

--- a/src/cli/affected.zig
+++ b/src/cli/affected.zig
@@ -34,6 +34,7 @@ pub fn filterAffectedScripts(
     resolve_root: []const u8,
     base_ref: []const u8,
     head_ref: []const u8,
+    explicit_refs: bool,
 ) !void {
     // Phase 1: Get changed files via git
     var changed_files = std.array_list.Managed([]const u8).init(allocator);
@@ -47,8 +48,7 @@ pub fn filterAffectedScripts(
 
     // Include working tree changes only when using default refs (local dev workflow).
     // When custom --base/--head are provided, only committed diffs matter (CI use case).
-    const is_default_refs = strings.eql(base_ref, "main") and strings.eql(head_ref, "HEAD");
-    if (is_default_refs) {
+    if (!explicit_refs) {
         // Uncommitted changes (staged + unstaged vs HEAD)
         try collectGitLines(allocator, &changed_files, &.{ "git", "diff", "--name-only", "--no-renames", "--relative", "HEAD" }, resolve_root);
 

--- a/src/cli/affected.zig
+++ b/src/cli/affected.zig
@@ -1,0 +1,274 @@
+/// Affected detection for workspace packages.
+///
+/// Algorithm:
+///   1. Run `git diff --name-only` between base and head refs
+///   2. Map changed files to workspace packages (longest prefix match)
+///   3. Build reverse dependency graph from workspace deps
+///   4. BFS from directly changed packages to find transitively affected ones
+///
+const std = @import("std");
+const bun = @import("bun");
+const strings = bun.strings;
+const Output = bun.Output;
+const Global = bun.Global;
+
+const FilterRun = @import("./filter_run.zig");
+const ScriptConfig = FilterRun.ScriptConfig;
+const DependencyMap = @import("../resolver/package_json.zig").DependencyMap;
+
+/// Root-level files that, when changed, mark ALL packages as affected.
+const GLOBAL_FILES = [_][]const u8{
+    "bun.lock",
+    "bun.lockb",
+    "package.json",
+    "tsconfig.json",
+    "tsconfig.base.json",
+    ".npmrc",
+};
+
+/// Given a list of collected scripts and workspace root, filter to only
+/// those in affected packages.
+pub fn filterAffectedScripts(
+    allocator: std.mem.Allocator,
+    scripts: *std.array_list.Managed(ScriptConfig),
+    resolve_root: []const u8,
+    base_ref: []const u8,
+    head_ref: []const u8,
+) !void {
+    // Phase 1: Get changed files via git
+    var changed_files = std.ArrayList([]const u8).init(allocator);
+    defer changed_files.deinit();
+
+    // Get merge-base for accurate diff on diverged branches
+    const merge_base = runGitOneLine(allocator, &.{ "git", "merge-base", base_ref, head_ref }, resolve_root) orelse base_ref;
+
+    // Committed changes: merge-base..head
+    try collectGitLines(allocator, &changed_files, &.{ "git", "diff", "--name-only", "--no-renames", "--relative", merge_base, head_ref }, resolve_root);
+
+    // Uncommitted changes (staged + unstaged vs HEAD)
+    try collectGitLines(allocator, &changed_files, &.{ "git", "diff", "--name-only", "--no-renames", "--relative", "HEAD" }, resolve_root);
+
+    // Untracked files
+    try collectGitLines(allocator, &changed_files, &.{ "git", "ls-files", "--others", "--exclude-standard" }, resolve_root);
+
+    // Phase 2: Check for global file changes
+    for (changed_files.items) |file| {
+        const basename = std.fs.path.basename(file);
+        for (&GLOBAL_FILES) |global| {
+            if (strings.eql(basename, global) and isRootLevel(file, basename)) {
+                // Global file changed — all packages are affected, no filtering needed
+                return;
+            }
+        }
+    }
+
+    // Build package_roots map: relative dir path → package name
+    var package_roots = std.StringHashMap([]const u8).init(allocator);
+    defer package_roots.deinit();
+
+    for (scripts.items) |*script| {
+        const dir = std.fs.path.dirname(script.package_json_path) orelse continue;
+        const rel = makeRelative(dir, resolve_root);
+        if (!package_roots.contains(rel)) {
+            try package_roots.put(rel, script.package_name);
+        }
+    }
+
+    // Map changed files → directly changed packages
+    var directly_changed = std.StringHashMap(void).init(allocator);
+    defer directly_changed.deinit();
+
+    for (changed_files.items) |file| {
+        if (mapFileToPackage(file, &package_roots)) |pkg_name| {
+            try directly_changed.put(pkg_name, {});
+        }
+    }
+
+    // Phase 3: Build reverse dependency graph
+    var workspace_names = std.StringHashMap(void).init(allocator);
+    defer workspace_names.deinit();
+    for (scripts.items) |*script| {
+        if (!workspace_names.contains(script.package_name)) {
+            try workspace_names.put(script.package_name, {});
+        }
+    }
+
+    var reverse_deps = std.StringHashMap(std.ArrayList([]const u8)).init(allocator);
+    defer {
+        var rev_iter = reverse_deps.valueIterator();
+        while (rev_iter.next()) |list| {
+            list.deinit();
+        }
+        reverse_deps.deinit();
+    }
+
+    for (scripts.items) |*script| {
+        const source_buf = script.deps.source_buf;
+        var iter = script.deps.map.iterator();
+        while (iter.next()) |entry| {
+            const dep_name = entry.key_ptr.slice(source_buf);
+            if (workspace_names.contains(dep_name)) {
+                const res = try reverse_deps.getOrPut(dep_name);
+                if (!res.found_existing) {
+                    res.value_ptr.* = std.ArrayList([]const u8).init(allocator);
+                }
+                try res.value_ptr.append(script.package_name);
+            }
+        }
+    }
+
+    // Phase 4: BFS from directly changed packages
+    var affected = std.StringHashMap(void).init(allocator);
+    defer affected.deinit();
+
+    var queue = std.ArrayList([]const u8).init(allocator);
+    defer queue.deinit();
+
+    var dc_iter = directly_changed.keyIterator();
+    while (dc_iter.next()) |name_ptr| {
+        try affected.put(name_ptr.*, {});
+        try queue.append(name_ptr.*);
+    }
+
+    var qi: usize = 0;
+    while (qi < queue.items.len) : (qi += 1) {
+        const current = queue.items[qi];
+        if (reverse_deps.get(current)) |dependents| {
+            for (dependents.items) |dependent| {
+                if (!affected.contains(dependent)) {
+                    try affected.put(dependent, {});
+                    try queue.append(dependent);
+                }
+            }
+        }
+    }
+
+    // Phase 5: Filter scripts — keep only those in affected set
+    var write_idx: usize = 0;
+    for (scripts.items) |script| {
+        if (affected.contains(script.package_name)) {
+            scripts.items[write_idx] = script;
+            write_idx += 1;
+        }
+    }
+    scripts.shrinkRetainingCapacity(write_idx);
+}
+
+/// Print affected package names to stdout and exit.
+pub fn listAffectedAndExit(
+    allocator: std.mem.Allocator,
+    scripts: *const std.array_list.Managed(ScriptConfig),
+) noreturn {
+    var seen = std.StringHashMap(void).init(allocator);
+    var names = std.ArrayList([]const u8).init(allocator);
+
+    for (scripts.items) |script| {
+        if (!seen.contains(script.package_name)) {
+            seen.put(script.package_name, {}) catch {};
+            names.append(script.package_name) catch {};
+        }
+    }
+
+    std.mem.sort([]const u8, names.items, {}, struct {
+        fn lessThan(_: void, a: []const u8, b: []const u8) bool {
+            return bun.strings.cmpStringsAsc({}, a, b);
+        }
+    }.lessThan);
+
+    if (names.items.len == 0) {
+        Output.prettyln("No packages affected.", .{});
+    } else {
+        Output.prettyln("{d} affected package(s):\n", .{names.items.len});
+        for (names.items) |name| {
+            Output.prettyln("  {s}", .{name});
+        }
+    }
+    Output.flush();
+    Global.exit(0);
+}
+
+// --- Internal helpers ---
+
+fn isRootLevel(path: []const u8, basename: []const u8) bool {
+    return path.len == basename.len;
+}
+
+fn makeRelative(abs_path: []const u8, root: []const u8) []const u8 {
+    if (std.mem.startsWith(u8, abs_path, root)) {
+        var rel = abs_path[root.len..];
+        if (rel.len > 0 and rel[0] == '/') {
+            rel = rel[1..];
+        }
+        return rel;
+    }
+    return abs_path;
+}
+
+fn mapFileToPackage(file_path: []const u8, package_roots: *const std.StringHashMap([]const u8)) ?[]const u8 {
+    var current = file_path;
+    while (true) {
+        current = std.fs.path.dirname(current) orelse break;
+        if (current.len == 0 or strings.eql(current, ".")) break;
+        if (package_roots.get(current)) |pkg_name| {
+            return pkg_name;
+        }
+    }
+    return null;
+}
+
+/// Run a git command and return a single trimmed line of output.
+fn runGitOneLine(allocator: std.mem.Allocator, argv: []const []const u8, cwd: []const u8) ?[]const u8 {
+    const output = runGitSync(allocator, argv, cwd, true) catch return null;
+    const trimmed = std.mem.trimRight(u8, output, "\n\r ");
+    if (trimmed.len == 0) return null;
+    return trimmed;
+}
+
+/// Run a git command and add each output line to the list.
+fn collectGitLines(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayList([]const u8),
+    argv: []const []const u8,
+    cwd: []const u8,
+) !void {
+    const output = runGitSync(allocator, argv, cwd, false) catch return;
+    var lines = std.mem.splitScalar(u8, output, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trimRight(u8, line, "\r ");
+        if (trimmed.len > 0) {
+            try out.append(try allocator.dupe(u8, trimmed));
+        }
+    }
+}
+
+/// Execute a git command synchronously and return stdout.
+fn runGitSync(allocator: std.mem.Allocator, argv: []const []const u8, cwd: []const u8, allow_non_zero: bool) ![]const u8 {
+    var child = std.process.Child.init(argv, allocator);
+    child.cwd = cwd;
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Ignore;
+
+    try child.spawn();
+
+    var stdout: std.ArrayListUnmanaged(u8) = .empty;
+    var stderr: std.ArrayListUnmanaged(u8) = .empty;
+    defer stderr.deinit(allocator);
+
+    try child.collectOutput(allocator, &stdout, &stderr, 1024 * 1024);
+    const term = try child.wait();
+
+    switch (term) {
+        .Exited => |code| {
+            if (code != 0 and !allow_non_zero) {
+                stdout.deinit(allocator);
+                return error.GitCommandFailed;
+            }
+        },
+        else => {
+            stdout.deinit(allocator);
+            return error.GitCommandFailed;
+        },
+    }
+
+    return stdout.items;
+}

--- a/src/cli/affected.zig
+++ b/src/cli/affected.zig
@@ -36,7 +36,7 @@ pub fn filterAffectedScripts(
     head_ref: []const u8,
 ) !void {
     // Phase 1: Get changed files via git
-    var changed_files = std.ArrayList([]const u8).init(allocator);
+    var changed_files = std.array_list.Managed([]const u8).init(allocator);
     defer changed_files.deinit();
 
     // Get merge-base for accurate diff on diverged branches
@@ -63,7 +63,7 @@ pub fn filterAffectedScripts(
     }
 
     // Build package_roots map: relative dir path → package name
-    var package_roots = std.StringHashMap([]const u8).init(allocator);
+    var package_roots = bun.StringHashMap([]const u8).init(allocator);
     defer package_roots.deinit();
 
     for (scripts.items) |*script| {
@@ -75,7 +75,7 @@ pub fn filterAffectedScripts(
     }
 
     // Map changed files → directly changed packages
-    var directly_changed = std.StringHashMap(void).init(allocator);
+    var directly_changed = bun.StringHashMap(void).init(allocator);
     defer directly_changed.deinit();
 
     for (changed_files.items) |file| {
@@ -85,7 +85,7 @@ pub fn filterAffectedScripts(
     }
 
     // Phase 3: Build reverse dependency graph
-    var workspace_names = std.StringHashMap(void).init(allocator);
+    var workspace_names = bun.StringHashMap(void).init(allocator);
     defer workspace_names.deinit();
     for (scripts.items) |*script| {
         if (!workspace_names.contains(script.package_name)) {
@@ -93,7 +93,7 @@ pub fn filterAffectedScripts(
         }
     }
 
-    var reverse_deps = std.StringHashMap(std.ArrayList([]const u8)).init(allocator);
+    var reverse_deps = bun.StringHashMap(std.array_list.Managed([]const u8)).init(allocator);
     defer {
         var rev_iter = reverse_deps.valueIterator();
         while (rev_iter.next()) |list| {
@@ -110,7 +110,7 @@ pub fn filterAffectedScripts(
             if (workspace_names.contains(dep_name)) {
                 const res = try reverse_deps.getOrPut(dep_name);
                 if (!res.found_existing) {
-                    res.value_ptr.* = std.ArrayList([]const u8).init(allocator);
+                    res.value_ptr.* = std.array_list.Managed([]const u8).init(allocator);
                 }
                 try res.value_ptr.append(script.package_name);
             }
@@ -118,10 +118,10 @@ pub fn filterAffectedScripts(
     }
 
     // Phase 4: BFS from directly changed packages
-    var affected = std.StringHashMap(void).init(allocator);
+    var affected = bun.StringHashMap(void).init(allocator);
     defer affected.deinit();
 
-    var queue = std.ArrayList([]const u8).init(allocator);
+    var queue = std.array_list.Managed([]const u8).init(allocator);
     defer queue.deinit();
 
     var dc_iter = directly_changed.keyIterator();
@@ -159,8 +159,8 @@ pub fn listAffectedAndExit(
     allocator: std.mem.Allocator,
     scripts: *const std.array_list.Managed(ScriptConfig),
 ) noreturn {
-    var seen = std.StringHashMap(void).init(allocator);
-    var names = std.ArrayList([]const u8).init(allocator);
+    var seen = bun.StringHashMap(void).init(allocator);
+    var names = std.array_list.Managed([]const u8).init(allocator);
 
     for (scripts.items) |script| {
         if (!seen.contains(script.package_name)) {
@@ -204,7 +204,7 @@ fn makeRelative(abs_path: []const u8, root: []const u8) []const u8 {
     return abs_path;
 }
 
-fn mapFileToPackage(file_path: []const u8, package_roots: *const std.StringHashMap([]const u8)) ?[]const u8 {
+fn mapFileToPackage(file_path: []const u8, package_roots: *const bun.StringHashMap([]const u8)) ?[]const u8 {
     var current = file_path;
     while (true) {
         current = std.fs.path.dirname(current) orelse break;
@@ -227,7 +227,7 @@ fn runGitOneLine(allocator: std.mem.Allocator, argv: []const []const u8, cwd: []
 /// Run a git command and add each output line to the list.
 fn collectGitLines(
     allocator: std.mem.Allocator,
-    out: *std.ArrayList([]const u8),
+    out: *std.array_list.Managed([]const u8),
     argv: []const []const u8,
     cwd: []const u8,
 ) !void {
@@ -246,7 +246,7 @@ fn runGitSync(allocator: std.mem.Allocator, argv: []const []const u8, cwd: []con
     var child = std.process.Child.init(argv, allocator);
     child.cwd = cwd;
     child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Ignore;
+    child.stderr_behavior = .Pipe;
 
     try child.spawn();
 
@@ -257,17 +257,9 @@ fn runGitSync(allocator: std.mem.Allocator, argv: []const []const u8, cwd: []con
     try child.collectOutput(allocator, &stdout, &stderr, 1024 * 1024);
     const term = try child.wait();
 
-    switch (term) {
-        .Exited => |code| {
-            if (code != 0 and !allow_non_zero) {
-                stdout.deinit(allocator);
-                return error.GitCommandFailed;
-            }
-        },
-        else => {
-            stdout.deinit(allocator);
-            return error.GitCommandFailed;
-        },
+    if (term.Exited != 0 and !allow_non_zero) {
+        stdout.deinit(allocator);
+        return error.GitCommandFailed;
     }
 
     return stdout.items;

--- a/src/cli/filter_run.zig
+++ b/src/cli/filter_run.zig
@@ -484,7 +484,7 @@ pub fn runScriptsWithFilter(ctx: Command.Context) !noreturn {
 
         for (&[3][]const u8{ pre_script_name, script_name, post_script_name }, 0..) |name, i| {
             const original_content = pkgscripts.get(name) orelse {
-                if (i == 1 and ctx.workspaces and !ctx.if_present) {
+                if (i == 1 and ctx.workspaces and !ctx.if_present and !ctx.affected) {
                     Output.errGeneric("Missing '{s}' script at '{s}'", .{ script_name, path });
                     Global.exit(1);
                 }

--- a/src/cli/filter_run.zig
+++ b/src/cli/filter_run.zig
@@ -525,7 +525,7 @@ pub fn runScriptsWithFilter(ctx: Command.Context) !noreturn {
 
     // If --affected is set, filter scripts to only affected packages
     if (ctx.affected) {
-        Affected.filterAffectedScripts(ctx.allocator, &scripts, resolve_root, ctx.base_ref, ctx.head_ref) catch |err| {
+        Affected.filterAffectedScripts(ctx.allocator, &scripts, resolve_root, ctx.base_ref, ctx.head_ref, ctx.explicit_refs) catch |err| {
             Output.prettyErrorln("<r><red>error<r>: Failed to detect affected packages: {s}", .{@errorName(err)});
             Global.exit(1);
         };

--- a/src/cli/filter_run.zig
+++ b/src/cli/filter_run.zig
@@ -1,4 +1,4 @@
-const ScriptConfig = struct {
+pub const ScriptConfig = struct {
     package_json_path: []u8,
     package_name: []const u8,
     script_name: []const u8,
@@ -523,9 +523,22 @@ pub fn runScriptsWithFilter(ctx: Command.Context) !noreturn {
         }
     }
 
+    // If --affected is set, filter scripts to only affected packages
+    if (ctx.affected) {
+        Affected.filterAffectedScripts(ctx.allocator, &scripts, resolve_root, ctx.base_ref, ctx.head_ref) catch |err| {
+            Output.prettyErrorln("<r><red>error<r>: Failed to detect affected packages: {s}", .{@errorName(err)});
+            Global.exit(1);
+        };
+
+        // If --list is set, print affected packages and exit
+        if (ctx.list_affected) {
+            Affected.listAffectedAndExit(ctx.allocator, &scripts);
+        }
+    }
+
     if (scripts.items.len == 0) {
-        if (ctx.if_present) {
-            // Exit silently with success when --if-present is set
+        if (ctx.if_present or ctx.affected) {
+            // Exit silently with success when --if-present or --affected with no changes
             Global.exit(0);
         }
         if (ctx.workspaces) {
@@ -668,6 +681,7 @@ fn hasCycle(current: *ProcessHandle) bool {
     return false;
 }
 
+const Affected = @import("./affected.zig");
 const FilterArg = @import("./filter_arg.zig");
 const std = @import("std");
 const DependencyMap = @import("../resolver/package_json.zig").DependencyMap;

--- a/test/cli/run/affected-filter.test.ts
+++ b/test/cli/run/affected-filter.test.ts
@@ -1,0 +1,200 @@
+import { spawnSync } from "bun";
+import { describe, expect, test, beforeAll } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { join } from "path";
+import { writeFileSync, mkdirSync } from "fs";
+import { execSync } from "child_process";
+
+function git(cwd: string, ...args: string[]) {
+  execSync(`git ${args.join(" ")}`, { cwd, stdio: "pipe" });
+}
+
+function setupGitWorkspace() {
+  const cwd = tempDirWithFiles("affected-test", {
+    packages: {
+      "pkg-a": {
+        "index.ts": "export const a = 1;",
+        "package.json": JSON.stringify({
+          name: "pkg-a",
+          scripts: { test: "echo test-a" },
+        }),
+      },
+      "pkg-b": {
+        "index.ts": "export const b = 1;",
+        "package.json": JSON.stringify({
+          name: "pkg-b",
+          scripts: { test: "echo test-b" },
+          dependencies: { "pkg-a": "workspace:*" },
+        }),
+      },
+      "pkg-c": {
+        "index.ts": "export const c = 1;",
+        "package.json": JSON.stringify({
+          name: "pkg-c",
+          scripts: { test: "echo test-c" },
+        }),
+      },
+    },
+    "package.json": JSON.stringify({
+      name: "ws-root",
+      workspaces: ["packages/*"],
+    }),
+  });
+
+  // Initialize git repo with a baseline commit
+  git(cwd, "init");
+  git(cwd, "add", "-A");
+  git(cwd, 'commit', '-m', '"initial"');
+  git(cwd, "branch", "-M", "main");
+
+  return cwd;
+}
+
+describe("bun run --affected", () => {
+  test("runs only scripts in packages with changed files", () => {
+    const cwd = setupGitWorkspace();
+
+    // Modify only pkg-a
+    writeFileSync(join(cwd, "packages/pkg-a/index.ts"), "export const a = 2;");
+
+    const result = spawnSync({
+      cmd: [bunExe(), "run", "--affected", "test"],
+      cwd,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stdout = result.stdout.toString();
+    const stderr = result.stderr.toString();
+    const output = stdout + stderr;
+
+    // pkg-a is directly changed
+    expect(output).toContain("pkg-a");
+    // pkg-b depends on pkg-a, so it should be affected transitively
+    expect(output).toContain("pkg-b");
+    // pkg-c has no changes and no dependency on pkg-a
+    expect(output).not.toContain("pkg-c");
+  });
+
+  test("exits with 0 when no packages are affected", () => {
+    const cwd = setupGitWorkspace();
+
+    // No changes — everything is committed
+    const result = spawnSync({
+      cmd: [bunExe(), "run", "--affected", "test"],
+      cwd,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("--list prints affected package names without running", () => {
+    const cwd = setupGitWorkspace();
+
+    // Modify pkg-c only
+    writeFileSync(join(cwd, "packages/pkg-c/index.ts"), "export const c = 2;");
+
+    const result = spawnSync({
+      cmd: [bunExe(), "run", "--affected", "--list", "test"],
+      cwd,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stdout = result.stdout.toString();
+    expect(stdout).toContain("pkg-c");
+    expect(stdout).not.toContain("pkg-a");
+    expect(stdout).not.toContain("pkg-b");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("global file change marks all packages as affected", () => {
+    const cwd = setupGitWorkspace();
+
+    // Modify root package.json (global file)
+    writeFileSync(
+      join(cwd, "package.json"),
+      JSON.stringify({
+        name: "ws-root",
+        workspaces: ["packages/*"],
+        version: "2.0.0",
+      }),
+    );
+
+    const result = spawnSync({
+      cmd: [bunExe(), "run", "--affected", "--list", "test"],
+      cwd,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stdout = result.stdout.toString();
+    expect(stdout).toContain("pkg-a");
+    expect(stdout).toContain("pkg-b");
+    expect(stdout).toContain("pkg-c");
+  });
+
+  test("--affected and --filter cannot be used together", () => {
+    const cwd = setupGitWorkspace();
+
+    const result = spawnSync({
+      cmd: [bunExe(), "run", "--affected", "--filter", "pkg-a", "test"],
+      cwd,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain("--affected and --filter cannot be used together");
+  });
+
+  test("--list requires --affected", () => {
+    const cwd = setupGitWorkspace();
+
+    const result = spawnSync({
+      cmd: [bunExe(), "run", "--list", "test"],
+      cwd,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain("--list requires --affected");
+  });
+
+  test("custom --base ref", () => {
+    const cwd = setupGitWorkspace();
+
+    // Create a new commit modifying pkg-a
+    writeFileSync(join(cwd, "packages/pkg-a/index.ts"), "export const a = 2;");
+    git(cwd, "add", "-A");
+    git(cwd, "commit", "-m", '"change-a"');
+
+    // Create another commit modifying pkg-c
+    writeFileSync(join(cwd, "packages/pkg-c/index.ts"), "export const c = 2;");
+    git(cwd, "add", "-A");
+    git(cwd, "commit", "-m", '"change-c"');
+
+    // Using HEAD~1 as base should only show pkg-c (changed in the last commit)
+    const result = spawnSync({
+      cmd: [bunExe(), "run", "--affected", "--base", "HEAD~1", "--list", "test"],
+      cwd,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stdout = result.stdout.toString();
+    expect(stdout).toContain("pkg-c");
+    // pkg-a was changed before HEAD~1, so should not be affected
+    expect(stdout).not.toContain("pkg-a");
+  });
+});

--- a/test/cli/run/affected-filter.test.ts
+++ b/test/cli/run/affected-filter.test.ts
@@ -43,6 +43,8 @@ function setupGitWorkspace() {
 
   // Initialize git repo with a baseline commit
   git(cwd, "init");
+  git(cwd, "config", "user.name", "Bun Test");
+  git(cwd, "config", "user.email", "test@bun.sh");
   git(cwd, "add", "-A");
   git(cwd, 'commit', '-m', '"initial"');
   git(cwd, "branch", "-M", "main");
@@ -75,6 +77,7 @@ describe("bun run --affected", () => {
     expect(output).toContain("pkg-b");
     // pkg-c has no changes and no dependency on pkg-a
     expect(output).not.toContain("pkg-c");
+    expect(result.exitCode).toBe(0);
   });
 
   test("exits with 0 when no packages are affected", () => {
@@ -138,6 +141,7 @@ describe("bun run --affected", () => {
     expect(stdout).toContain("pkg-a");
     expect(stdout).toContain("pkg-b");
     expect(stdout).toContain("pkg-c");
+    expect(result.exitCode).toBe(0);
   });
 
   test("--affected and --filter cannot be used together", () => {
@@ -196,5 +200,6 @@ describe("bun run --affected", () => {
     expect(stdout).toContain("pkg-c");
     // pkg-a was changed before HEAD~1, so should not be affected
     expect(stdout).not.toContain("pkg-a");
+    expect(result.exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## What does this PR do?

Adds a `--affected` flag to `bun run` that detects which workspace packages are affected by git changes and only runs scripts in those packages.

Closes #27943

**Problem:** In monorepos, `bun run --filter '*' test` runs scripts in **all** packages even when only a few files changed. This wastes CI time and resources. Teams must build custom detect-affected scripts.

**Solution:** Bun already has the workspace dependency graph internally (`filter_run.zig`). This PR connects it to git changes.

```bash
bun run --affected test                          # vs main
bun run --affected --base=abc123 test            # custom base SHA
bun run --affected --base=main --head=feat test  # PR diff
bun run --affected --list test                   # print names only
bun run --affected --concurrency 4 typecheck     # with #27855
```

### Algorithm (4 phases)

1. **git merge-base** + `git diff --name-only` (committed + uncommitted + untracked)
2. **Map files → packages** — walk up `dirname()` to find owning workspace package
3. **Global file detection** — `bun.lock`, `package.json`, `tsconfig.json` → all affected
4. **Reverse dependency graph BFS** — if A depends on B and B changed, A is affected

### Changes

- `src/cli/affected.zig` — New module: git diff, file mapping, reverse graph BFS, filtering
- `src/cli/Arguments.zig` — Parse `--affected`, `--base`, `--head`, `--list` flags
- `src/cli.zig` — Add fields to `ContextData`
- `src/cli/filter_run.zig` — Call `filterAffectedScripts()` after collecting workspace packages

Without the flag, behavior is unchanged (no git commands, no filtering).

### Flags

| Flag | Default | Description |
|------|---------|-------------|
| `--affected` | — | Enable affected detection |
| `--base` | `main` | Base git ref for diff |
| `--head` | `HEAD` | Head git ref for diff |
| `--list` | false | Print affected names, don't run |

### Composability

- `--affected` implies `--workspaces` (scans all packages, then filters)
- `--affected` + `--filter` → error (mutually exclusive)
- `--list` requires `--affected`
- Works with `--concurrency` (#27855)

## How did you verify your code works?

Added `test/cli/run/affected-filter.test.ts` with 7 test cases:
- Direct file change → only affected package runs
- Transitive dependency → dependent packages included
- No changes → exit 0 silently
- `--list` prints package names without running
- Global file change (`package.json`) → all packages affected
- `--affected` + `--filter` → error
- Custom `--base` ref works

## Prior art

- Nx: `nx affected --target=test --base=main`
- Turborepo: `turbo run test --filter=...[main]`
- Lerna: `lerna run test --since=main`