### PR TITLE
fix(test): handle non-native thenables returned from test callbacks

### DIFF
--- a/src/bun.js/test/bun_test.zig
+++ b/src/bun.js/test/bun_test.zig
@@ -701,6 +701,40 @@ pub const BunTest = struct {
                         return cfg_data;
                     },
                 }
+            } else if (result.isObject()) {
+                // Check for non-native thenables (objects with a callable .then method).
+                // This handles libraries like supertest that return custom thenable objects
+                // rather than native Promises. Per the Promises/A+ spec and Jest's behavior,
+                // any object with a .then() method should be awaited.
+                const then_fn = result.getPropertyValue(globalThis, "then") catch |err| switch (err) {
+                    error.JSError => {
+                        this.onUncaughtException(globalThis, globalThis.tryTakeException(), false, cfg_data);
+                        return cfg_data;
+                    },
+                    error.OutOfMemory, error.JSTerminated => return cfg_data,
+                };
+                if (then_fn) |tfn| {
+                    if (tfn.isCell() and tfn.isCallable()) {
+                        group.log("callTestCallback -> thenable: data {f}", .{cfg_data});
+
+                        // Wrap the thenable in a native Promise. JSPromise.resolve() follows
+                        // the Promise resolution procedure, calling the thenable's .then()
+                        // method via a microtask to resolve/reject the wrapper promise.
+                        const wrapper_promise = jsc.JSPromise.create(globalThis);
+                        wrapper_promise.resolve(globalThis, result) catch {
+                            globalThis.clearTerminationException();
+                            return cfg_data;
+                        };
+
+                        // The wrapper promise is still pending (thenable unwrapping is async).
+                        // Register then/catch handlers to capture the eventual result.
+                        const wrapper_value = wrapper_promise.toJS();
+                        defer wrapper_value.ensureStillAlive();
+                        const this_ref: *RefData = if (dcb_ref) |dcb_ref_value| dcb_ref_value.dupe() else ref(this_strong, cfg_data);
+                        wrapper_value.then(globalThis, this_ref, bunTestThen, bunTestCatch) catch {};
+                        return null;
+                    }
+                }
             }
         }
 

--- a/src/bun.js/test/bun_test.zig
+++ b/src/bun.js/test/bun_test.zig
@@ -711,17 +711,37 @@ pub const BunTest = struct {
                         this.onUncaughtException(globalThis, globalThis.tryTakeException(), false, cfg_data);
                         return cfg_data;
                     },
-                    error.OutOfMemory, error.JSTerminated => return cfg_data,
+                    error.OutOfMemory => bun.handleOom(error.OutOfMemory),
+                    error.JSTerminated => {
+                        globalThis.clearTerminationException();
+                        return cfg_data;
+                    },
                 };
                 if (then_fn) |tfn| {
                     if (tfn.isCell() and tfn.isCallable()) {
                         group.log("callTestCallback -> thenable: data {f}", .{cfg_data});
 
-                        // Wrap the thenable in a native Promise. JSPromise.resolve() follows
-                        // the Promise resolution procedure, calling the thenable's .then()
-                        // method via a microtask to resolve/reject the wrapper promise.
+                        // Wrap the thenable in a native Promise by creating a wrapper object
+                        // with the captured .then function bound to the original result.
+                        // This avoids reading .then from the original object a second time
+                        // (Promises/A+ spec §2.3.3.1) while preserving the correct `this`.
+                        var then_name = bun.String.static("then");
+                        const bound_then = tfn.bind(globalThis, result, &then_name, 2, &.{}) catch |err| switch (err) {
+                            error.JSError => {
+                                this.onUncaughtException(globalThis, globalThis.tryTakeException(), false, cfg_data);
+                                return cfg_data;
+                            },
+                            error.OutOfMemory => bun.handleOom(error.OutOfMemory),
+                            error.JSTerminated => {
+                                globalThis.clearTerminationException();
+                                return cfg_data;
+                            },
+                        };
+                        const wrapper_obj = jsc.JSValue.createEmptyObject(globalThis, 1);
+                        wrapper_obj.put(globalThis, "then", bound_then);
+
                         const wrapper_promise = jsc.JSPromise.create(globalThis);
-                        wrapper_promise.resolve(globalThis, result) catch {
+                        wrapper_promise.resolve(globalThis, wrapper_obj) catch {
                             globalThis.clearTerminationException();
                             return cfg_data;
                         };
@@ -731,7 +751,11 @@ pub const BunTest = struct {
                         const wrapper_value = wrapper_promise.toJS();
                         defer wrapper_value.ensureStillAlive();
                         const this_ref: *RefData = if (dcb_ref) |dcb_ref_value| dcb_ref_value.dupe() else ref(this_strong, cfg_data);
-                        wrapper_value.then(globalThis, this_ref, bunTestThen, bunTestCatch) catch {};
+                        wrapper_value.then(globalThis, this_ref, bunTestThen, bunTestCatch) catch {
+                            globalThis.clearTerminationException();
+                            this_ref.deref();
+                            return cfg_data;
+                        };
                         return null;
                     }
                 }

--- a/test/regression/issue/27945.test.ts
+++ b/test/regression/issue/27945.test.ts
@@ -69,13 +69,18 @@ test("resolving thenable should pass the test and invoke .then", async () => {
 test("async resolving thenable should pass the test", async () => {
   using dir = tempDir("issue-27945", {
     "thenable.test.js": `
-      const { test, expect } = require("bun:test");
+      const { test, expect, afterAll } = require("bun:test");
+      let thenCalled = false;
       test("async resolving thenable", () => {
         return {
           then(resolve, reject) {
+            thenCalled = true;
             setTimeout(() => resolve("ok"), 10);
           }
         };
+      });
+      afterAll(() => {
+        expect(thenCalled).toBe(true);
       });
     `,
   });

--- a/test/regression/issue/27945.test.ts
+++ b/test/regression/issue/27945.test.ts
@@ -74,8 +74,10 @@ test("async resolving thenable should pass the test", async () => {
       test("async resolving thenable", () => {
         return {
           then(resolve, reject) {
-            thenCalled = true;
-            setTimeout(() => resolve("ok"), 10);
+            Promise.resolve().then(() => {
+              thenCalled = true;
+              resolve("ok");
+            });
           }
         };
       });
@@ -105,7 +107,7 @@ test("async rejecting thenable should fail the test", async () => {
       test("async rejecting thenable", () => {
         return {
           then(resolve, reject) {
-            setTimeout(() => reject(new Error("async thenable rejected")), 10);
+            Promise.resolve().then(() => reject(new Error("async thenable rejected")));
           }
         };
       });

--- a/test/regression/issue/27945.test.ts
+++ b/test/regression/issue/27945.test.ts
@@ -34,16 +34,21 @@ test("rejecting thenable should fail the test", async () => {
   expect(stderr).toContain("thenable rejected");
 });
 
-test("resolving thenable should pass the test", async () => {
+test("resolving thenable should pass the test and invoke .then", async () => {
   using dir = tempDir("issue-27945", {
     "thenable.test.js": `
-      const { test, expect } = require("bun:test");
+      const { test, expect, afterAll } = require("bun:test");
+      let thenCalled = false;
       test("resolving thenable", () => {
         return {
           then(resolve, reject) {
+            thenCalled = true;
             resolve("ok");
           }
         };
+      });
+      afterAll(() => {
+        expect(thenCalled).toBe(true);
       });
     `,
   });

--- a/test/regression/issue/27945.test.ts
+++ b/test/regression/issue/27945.test.ts
@@ -1,0 +1,172 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Test that the bun test runner correctly handles non-native thenables
+// (objects with a .then method that are not native Promises).
+// Previously, bun would only check for native JSPromise objects, causing
+// thenable rejections to be silently ignored and tests to incorrectly pass.
+
+test("rejecting thenable should fail the test", async () => {
+  using dir = tempDir("issue-27945", {
+    "thenable.test.js": `
+      const { test, expect } = require("bun:test");
+      test("rejecting thenable", () => {
+        return {
+          then(resolve, reject) {
+            reject(new Error("thenable rejected"));
+          }
+        };
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "thenable.test.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).not.toBe(0);
+  expect(stderr).toContain("thenable rejected");
+});
+
+test("resolving thenable should pass the test", async () => {
+  using dir = tempDir("issue-27945", {
+    "thenable.test.js": `
+      const { test, expect } = require("bun:test");
+      test("resolving thenable", () => {
+        return {
+          then(resolve, reject) {
+            resolve("ok");
+          }
+        };
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "thenable.test.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(0);
+});
+
+test("async resolving thenable should pass the test", async () => {
+  using dir = tempDir("issue-27945", {
+    "thenable.test.js": `
+      const { test, expect } = require("bun:test");
+      test("async resolving thenable", () => {
+        return {
+          then(resolve, reject) {
+            setTimeout(() => resolve("ok"), 10);
+          }
+        };
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "thenable.test.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(0);
+});
+
+test("async rejecting thenable should fail the test", async () => {
+  using dir = tempDir("issue-27945", {
+    "thenable.test.js": `
+      const { test, expect } = require("bun:test");
+      test("async rejecting thenable", () => {
+        return {
+          then(resolve, reject) {
+            setTimeout(() => reject(new Error("async thenable rejected")), 10);
+          }
+        };
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "thenable.test.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).not.toBe(0);
+  expect(stderr).toContain("async thenable rejected");
+});
+
+test("class-based thenable that rejects should fail", async () => {
+  using dir = tempDir("issue-27945", {
+    "thenable.test.js": `
+      const { test, expect } = require("bun:test");
+
+      class CustomThenable {
+        then(resolve, reject) {
+          reject(new Error("custom thenable rejected"));
+        }
+      }
+
+      test("class-based thenable rejection", () => {
+        return new CustomThenable();
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "thenable.test.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).not.toBe(0);
+  expect(stderr).toContain("custom thenable rejected");
+});
+
+test("native promise rejection still works", async () => {
+  using dir = tempDir("issue-27945", {
+    "thenable.test.js": `
+      const { test, expect } = require("bun:test");
+      test("native promise rejection", () => {
+        return Promise.reject(new Error("native promise rejected"));
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "thenable.test.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).not.toBe(0);
+  expect(stderr).toContain("native promise rejected");
+});


### PR DESCRIPTION
## Summary

- Fix test runner to handle non-native thenables (objects with a callable `.then` method) returned from test callbacks
- Previously only native `JSPromise` objects were checked, so libraries like **supertest** that return custom thenable objects would have their rejections silently ignored, causing tests to incorrectly pass
- Wraps detected thenables in a native `Promise` via `JSPromise.resolve()`, which follows the Promise resolution procedure to unwrap them

## Test plan

- [x] Regression test `test/regression/issue/27945.test.ts` covers: rejecting thenable, resolving thenable, async resolving/rejecting thenable, class-based thenable, native promise rejection (no regression)
- [x] Verified test fails with system bun (bug present) and passes with debug build (bug fixed)
- [x] Verified minimal reproduction from the issue now works correctly

Closes #27945

🤖 Generated with [Claude Code](https://claude.com/claude-code)