### PR TITLE
docs: add Oxford comma to platform support list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ bunx cowsay 'Hello, world!'   # execute a package
 
 ## Install
 
-Bun supports Linux (x64 & arm64), macOS (x64 & Apple Silicon) and Windows (x64 & arm64).
+Bun supports Linux (x64 & arm64), macOS (x64 & Apple Silicon), and Windows (x64 & arm64).
 
 > **Linux users** — Kernel version 5.6 or higher is strongly recommended, but the minimum is 5.1.
 


### PR DESCRIPTION
Adds a serial (Oxford) comma before "and Windows" in the platform support line for grammatical consistency.