### PR TITLE
Add regression test for --compile --bytecode --format esm barrel import (#27955)

### DIFF
--- a/test/bundler/bundler_barrel.test.ts
+++ b/test/bundler/bundler_barrel.test.ts
@@ -1591,4 +1591,46 @@ describe("bundler", () => {
     compile: true,
     run: { stdout: "ok" },
   });
+
+  // Regression #27955: Same barrel-deferred pattern but the deferred import's
+  // target module (diff/base.js) IS used by another module in the bundle
+  // (patch/create.js imports it directly). The barrel file's import record for
+  // ./diff/base.js is marked is_unused by barrel optimization, but the module
+  // itself is included through a different import path. This pattern matches
+  // real packages like diff@8.x where libesm/ has sideEffects: false.
+  itBundled("barrel/ESMBytecodeCompileDeferredImportUsedElsewhere", {
+    files: {
+      "/entry.js": /* js */ `
+        import { createPatch } from 'difflib';
+        console.log(createPatch());
+      `,
+      "/node_modules/difflib/package.json": JSON.stringify({
+        name: "difflib",
+        type: "module",
+        exports: { ".": { import: "./libesm/index.js" } },
+      }),
+      "/node_modules/difflib/libesm/package.json": JSON.stringify({
+        type: "module",
+        sideEffects: false,
+      }),
+      "/node_modules/difflib/libesm/index.js": /* js */ `
+        import Diff from './diff/base.js';
+        import { createPatch } from './patch/create.js';
+        export { Diff, createPatch };
+      `,
+      "/node_modules/difflib/libesm/diff/base.js": /* js */ `
+        export default class Diff { diff() { return "diffresult"; } }
+      `,
+      "/node_modules/difflib/libesm/patch/create.js": /* js */ `
+        import Diff from '../diff/base.js';
+        const d = new Diff();
+        export function createPatch() { return d.diff(); }
+      `,
+    },
+    target: "bun",
+    format: "esm",
+    bytecode: true,
+    compile: true,
+    run: { stdout: "diffresult" },
+  });
 });


### PR DESCRIPTION
## Summary

- Add regression test covering the `diff@8.x` pattern reported in #27955
- The test verifies that `bun build --compile --bytecode --format esm` works correctly when a barrel file's deferred import target is also used by another bundled module through a different import path
- This pattern was already fixed by #27534 (skip `is_unused` records in ESM bytecode ModuleInfo), but the existing test only covered the simple case where the deferred module was truly unused

## Root Cause

The `diff` package uses a structure where `libesm/package.json` has `"sideEffects": false`, enabling barrel optimization. When the user imports only `createTwoFilesPatch`, the barrel optimizer marks the `import Diff from './diff/base.js'` record in the barrel file as `is_unused`. However, `patch/create.js` (which IS included) also imports `base.js` through a different path.

Before #27534, the `postProcessJSChunk` code scanned original AST parts for ESM bytecode ModuleInfo and incorrectly recorded the `is_unused` import as an external dependency (because `source_index` was invalid). At runtime, JSC would try to resolve `./diff/base.js` from `/$bunfs/root/out` and fail.

## Test plan

- [x] New test `barrel/ESMBytecodeCompileDeferredImportUsedElsewhere` passes with `bun bd test`
- [x] Test fails with `USE_SYSTEM_BUN=1` (v1.3.10, before #27534) — confirms it catches the regression
- [x] Existing test `barrel/ESMBytecodeCompileSkipsDeferredImports` still passes

Closes #27955