### PR TITLE
fix(shell): don't panic when `cp` hits EBUSY on Windows

### DIFF
--- a/src/shell/builtin/cp.zig
+++ b/src/shell/builtin/cp.zig
@@ -99,6 +99,10 @@ pub fn ignoreEbusyErrorIfPossible(this: *Cp) Yield {
     if (!bun.Environment.isWindows) @compileError("dont call this plz");
 
     var exit_code = this.state.ebusy.main_exit_code;
+    // Collect error output for non-ignorable EBUSY tasks. We write errors
+    // directly here instead of going through printShellCpTask, which
+    // accesses the .exec union field that is no longer active.
+    var error_buf: std.ArrayListUnmanaged(u8) = .{};
 
     for (this.state.ebusy.state.tasks.items) |task_| {
         const task: *ShellCpTask = task_;
@@ -109,17 +113,23 @@ pub fn ignoreEbusyErrorIfPossible(this: *Cp) Yield {
 
         if (!can_ignore) {
             exit_code = 1;
-            // Write error directly instead of going through printShellCpTask,
-            // which accesses the .exec union field that is no longer active.
             if (task.err) |cp_err| {
                 const error_string = this.bltn().taskErrorToString(.cp, cp_err);
-                _ = this.bltn().writeNoIO(.stderr, error_string);
+                bun.handleOom(error_buf.appendSlice(bun.default_allocator, error_string));
             }
         }
         task.deinit();
     }
 
     this.state.ebusy.state.deinit();
+
+    if (error_buf.items.len > 0) {
+        defer error_buf.deinit(bun.default_allocator);
+        // Use writeFailingError which handles both sync and async
+        // (fd-backed) stderr correctly.
+        return this.writeFailingError(error_buf.items, exit_code);
+    }
+
     this.state = .done;
     return this.bltn().done(exit_code);
 }

--- a/src/shell/builtin/cp.zig
+++ b/src/shell/builtin/cp.zig
@@ -18,7 +18,6 @@ state: union(enum) {
     },
     ebusy: struct {
         state: EbusyState,
-        idx: usize = 0,
         main_exit_code: ExitCode = 0,
     },
     waiting_write_err,
@@ -99,26 +98,28 @@ pub fn start(this: *Cp) Yield {
 pub fn ignoreEbusyErrorIfPossible(this: *Cp) Yield {
     if (!bun.Environment.isWindows) @compileError("dont call this plz");
 
-    if (this.state.ebusy.idx < this.state.ebusy.state.tasks.items.len) {
-        outer_loop: for (this.state.ebusy.state.tasks.items[this.state.ebusy.idx..], 0..) |task_, i| {
-            const task: *ShellCpTask = task_;
-            const failure_src = task.src_absolute.?;
-            const failure_tgt = task.tgt_absolute.?;
-            if (this.state.ebusy.state.absolute_targets.get(failure_tgt)) |_| {
-                task.deinit();
-                continue :outer_loop;
+    var exit_code = this.state.ebusy.main_exit_code;
+
+    for (this.state.ebusy.state.tasks.items) |task_| {
+        const task: *ShellCpTask = task_;
+        const failure_src = task.src_absolute.?;
+        const failure_tgt = task.tgt_absolute.?;
+        const can_ignore = this.state.ebusy.state.absolute_targets.get(failure_tgt) != null or
+            this.state.ebusy.state.absolute_srcs.get(failure_src) != null;
+
+        if (!can_ignore) {
+            exit_code = 1;
+            // Write error directly instead of going through printShellCpTask,
+            // which accesses the .exec union field that is no longer active.
+            if (task.err) |cp_err| {
+                const error_string = this.bltn().taskErrorToString(.cp, cp_err);
+                _ = this.bltn().writeNoIO(.stderr, error_string);
             }
-            if (this.state.ebusy.state.absolute_srcs.get(failure_src)) |_| {
-                task.deinit();
-                continue :outer_loop;
-            }
-            this.state.ebusy.idx += i + 1;
-            return this.printShellCpTask(task);
         }
+        task.deinit();
     }
 
     this.state.ebusy.state.deinit();
-    const exit_code = this.state.ebusy.main_exit_code;
     this.state = .done;
     return this.bltn().done(exit_code);
 }
@@ -214,10 +215,10 @@ pub fn onShellCpTaskDone(this: *Cp, task: *ShellCpTask) void {
         if (task.err) |*err| {
             if (err.* == .sys and
                 err.sys.getErrno() == .BUSY and
-                (task.tgt_absolute != null and
+                ((task.tgt_absolute != null and
                     err.sys.path.eqlUTF8(task.tgt_absolute.?)) or
-                (task.src_absolute != null and
-                    err.sys.path.eqlUTF8(task.src_absolute.?)))
+                    (task.src_absolute != null and
+                        err.sys.path.eqlUTF8(task.src_absolute.?))))
             {
                 log("{f} got ebusy {d} {d}", .{ this, this.state.exec.ebusy.tasks.items.len, this.state.exec.paths_to_copy.len });
                 bun.handleOom(this.state.exec.ebusy.tasks.append(bun.default_allocator, task));

--- a/test/regression/issue/27961.test.ts
+++ b/test/regression/issue/27961.test.ts
@@ -15,17 +15,22 @@ describe.if(process.platform === "win32")("cp over running exe on Windows", () =
       env: bunEnv,
       cwd: String(dir),
     });
-    await setup.exited;
+    expect(await setup.exited).toBe(0);
 
-    // Run the dummy executable (keeps it locked on Windows)
+    // Run the dummy executable (keeps it locked on Windows).
+    // It prints "ready" to stdout so we can wait for it deterministically.
     await using proc = Bun.spawn({
-      cmd: [dummyExe, "-e", "setTimeout(() => {}, 30000)"],
+      cmd: [dummyExe, "-e", "console.log('ready'); setTimeout(() => {}, 30000)"],
       env: bunEnv,
       cwd: String(dir),
+      stdout: "pipe",
     });
 
-    // Give the process time to start
-    await Bun.sleep(500);
+    // Wait for the child to signal it has started (exe is now locked).
+    const reader = proc.stdout.getReader();
+    const { value } = await reader.read();
+    expect(Buffer.from(value!).toString().trim()).toBe("ready");
+    reader.releaseLock();
 
     // Try to overwrite the running exe via shell cp - this should fail
     // gracefully with an error, not panic.
@@ -42,16 +47,12 @@ describe.if(process.platform === "win32")("cp over running exe on Windows", () =
       ],
       env: bunEnv,
       cwd: String(dir),
-      stderr: "pipe",
     });
 
-    const [stderr, exitCode] = await Promise.all([cpProc.stderr.text(), cpProc.exited]);
-
-    // The process should exit with code 1 (error), not crash with a panic.
     // Before the fix, this would panic with:
     // "access of union field 'exec' while field 'ebusy' is active"
-    expect(stderr).not.toContain("panic");
-    expect(exitCode).toBe(1);
+    // The process should exit with code 1 (graceful error), not crash.
+    expect(await cpProc.exited).toBe(1);
 
     proc.kill();
   });

--- a/test/regression/issue/27961.test.ts
+++ b/test/regression/issue/27961.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/27961
+// On Windows, `cp` panics with "access of union field 'exec' while field 'ebusy'
+// is active" when overwriting a running .exe (EBUSY error).
+describe.if(process.platform === "win32")("cp over running exe on Windows", () => {
+  test("does not panic when overwriting a running executable", async () => {
+    using dir = tempDir("cp-ebusy-27961");
+    const dummyExe = String(dir) + "\\dummy-process.exe";
+
+    // Copy bun to create a dummy executable
+    await using setup = Bun.spawn({
+      cmd: [bunExe(), "-e", `require('fs').copyFileSync(process.execPath, ${JSON.stringify(dummyExe)})`],
+      env: bunEnv,
+      cwd: String(dir),
+    });
+    await setup.exited;
+
+    // Run the dummy executable (keeps it locked on Windows)
+    await using proc = Bun.spawn({
+      cmd: [dummyExe, "-e", "setTimeout(() => {}, 30000)"],
+      env: bunEnv,
+      cwd: String(dir),
+    });
+
+    // Give the process time to start
+    await Bun.sleep(500);
+
+    // Try to overwrite the running exe via shell cp - this should fail
+    // gracefully with an error, not panic.
+    await using cpProc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { $ } = require("bun");
+        $.nothrow();
+        const result = await $\`cp \${process.execPath} ${JSON.stringify(dummyExe)}\`;
+        process.exit(result.exitCode);
+      `,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stderr, exitCode] = await Promise.all([cpProc.stderr.text(), cpProc.exited]);
+
+    // The process should exit with code 1 (error), not crash with a panic.
+    // Before the fix, this would panic with:
+    // "access of union field 'exec' while field 'ebusy' is active"
+    expect(stderr).not.toContain("panic");
+    expect(exitCode).toBe(1);
+
+    proc.kill();
+  });
+});

--- a/test/regression/issue/27961.test.ts
+++ b/test/regression/issue/27961.test.ts
@@ -6,7 +6,7 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // is active" when overwriting a running .exe (EBUSY error).
 describe.if(process.platform === "win32")("cp over running exe on Windows", () => {
   test("does not panic when overwriting a running executable", async () => {
-    using dir = tempDir("cp-ebusy-27961");
+    using dir = tempDir("cp-ebusy-27961", {});
     const dummyExe = String(dir) + "\\dummy-process.exe";
 
     // Copy bun to create a dummy executable


### PR DESCRIPTION
## Summary

- Fix panic "access of union field 'exec' while field 'ebusy' is active" when `cp` tries to overwrite a running `.exe` on Windows
- Fix operator precedence bug in EBUSY detection condition

## Root Cause

When `cp` overwrites a locked file on Windows, the copy task fails with EBUSY. The state machine transitions from `.exec` to `.ebusy`, but then `ignoreEbusyErrorIfPossible` called `printShellCpTask` which accessed `this.state.exec.err` — panicking because the active union field is `.ebusy`.

The fix writes errors directly to stderr in `ignoreEbusyErrorIfPossible` instead of going through `printShellCpTask` and its VTable callbacks that assume `.exec` state.

Additionally, the EBUSY detection condition at `onShellCpTaskDone` had incorrect `and`/`or` precedence that could match non-EBUSY errors when the source path matched.

## Test plan

- [x] Added Windows-only regression test in `test/regression/issue/27961.test.ts`
- [ ] CI passes on Windows (where the EBUSY path is exercised)

Closes #27961

🤖 Generated with [Claude Code](https://claude.com/claude-code)