### PR TITLE
fix(init): correct API docs URL in generated CLAUDE.md

### DIFF
--- a/src/init/rule.md
+++ b/src/init/rule.md
@@ -108,4 +108,4 @@ Then, run index.ts
 bun --hot ./index.ts
 ```
 
-For more information, read the Bun API docs in `node_modules/bun-types/docs/**.mdx`.
+For more information, read the Bun API docs at https://bun.sh/docs.


### PR DESCRIPTION
## Summary

- `bun init` generates a CLAUDE.md that references `node_modules/bun-types/docs/**.mdx`, but that path doesn't exist when installing `@types/bun`
- Updated the reference to point to the primary Bun documentation at https://bun.sh/docs

Closes #27950
Closes #27964

## Test plan

- Ran `bun init` with debug build and verified the generated CLAUDE.md contains `https://bun.sh/docs` instead of the old `node_modules/bun-types/docs/**.mdx` path
- Existing init tests pass (3 pre-existing snapshot failures unrelated to this change)