### PR TITLE
fix(watch): fix off-by-one in file:// URL prefix stripping

### DIFF
--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -509,7 +509,7 @@ pub const StatWatcher = struct {
         defer bun.path_buffer_pool.put(buf);
         var slice = args.path.slice();
         if (bun.strings.startsWith(slice, "file://")) {
-            slice = slice[6..];
+            slice = slice["file://".len..];
         }
 
         var parts = [_]string{slice};

--- a/src/bun.js/node/node_fs_watcher.zig
+++ b/src/bun.js/node/node_fs_watcher.zig
@@ -634,7 +634,7 @@ pub const FSWatcher = struct {
             defer bun.path_buffer_pool.put(buf);
             var slice = args.path.slice();
             if (bun.strings.startsWith(slice, "file://")) {
-                slice = slice[6..];
+                slice = slice["file://".len..];
             }
 
             const cwd = switch (bun.sys.getcwd(buf)) {


### PR DESCRIPTION
## Summary

- Fix off-by-one error when stripping `file://` prefix in `node_fs_watcher.zig` and `node_fs_stat_watcher.zig`
- `"file://"` is 7 characters, but `slice[6..]` was used instead of `slice[7..]`, retaining the second `/`
- Use `slice["file://".len..]` for clarity, matching the existing pattern in `VirtualMachine.zig:1750`

The bug was masked by downstream path normalization in `joinAbsStringBufZ` which collapses the duplicate leading slash (e.g. `//tmp/foo` → `/tmp/foo`).

## Test plan

- [x] Existing `fs.watch` URL tests pass (`test/js/node/watch/fs.watch.test.ts`)
- [x] Existing `fs.watchFile` URL tests pass (`test/js/node/watch/fs.watchFile.test.ts`)
- [x] Debug build compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)