### PR TITLE
fix(node:fs): translate numeric open flags from Windows constants to internal representation

### DIFF
--- a/src/bun.js/modules/NodeConstantsModule.h
+++ b/src/bun.js/modules/NodeConstantsModule.h
@@ -654,7 +654,11 @@ DEFINE_NATIVE_MODULE(NodeConstants)
 #ifdef O_EXCL
     put(Identifier::fromString(vm, "O_EXCL"_s), jsNumber(O_EXCL));
 #endif
+#if OS(WINDOWS)
+    put(Identifier::fromString(vm, "UV_FS_O_FILEMAP"_s), jsNumber(536870912));
+#else
     put(Identifier::fromString(vm, "UV_FS_O_FILEMAP"_s), jsNumber(0));
+#endif
 
 #ifdef O_NOCTTY
     put(Identifier::fromString(vm, "O_NOCTTY"_s), jsNumber(O_NOCTTY));

--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -1053,7 +1053,15 @@ pub const FileSystemFlags = enum(c_int) {
                 return ctx.throwValue(ctx.ERR(.OUT_OF_RANGE, "The value of \"flags\" is out of range. It must be an integer. Received {d}", .{val.asNumber()}).toJS());
             }
             const number = try val.coerce(i32, ctx);
-            return @as(FileSystemFlags, @enumFromInt(@max(number, 0)));
+            const flags = @max(number, 0);
+            // On Windows, numeric flags from fs.constants (e.g. O_CREAT=0x100)
+            // use the platform's native MSVC/libuv values which differ from the
+            // internal bun.O representation. Convert them here so downstream
+            // code that operates on bun.O flags works correctly.
+            if (comptime bun.Environment.isWindows) {
+                return @as(FileSystemFlags, @enumFromInt(bun.windows.libuv.O.toBunO(flags)));
+            }
+            return @as(FileSystemFlags, @enumFromInt(flags));
         }
 
         const jsType = val.jsType();

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -190,19 +190,53 @@ pub const O = struct {
     pub const SYMLINK = UV_FS_O_SYMLINK;
     pub const SYNC = UV_FS_O_SYNC;
 
+    /// Convert from internal bun.O flags to libuv/Windows flags.
+    ///
+    /// Note: NONBLOCK, NOFOLLOW, DIRECTORY, NOATIME, NOCTTY, SYMLINK map to
+    /// 0 in libuv on Windows (see UV_FS_O_* constants below), so they are
+    /// included here for correctness but are effectively no-ops.
+    /// When adding new flag mappings, keep in sync with toBunO.
     pub fn fromBunO(c_flags: i32) i32 {
         var flags: i32 = 0;
 
-        if (c_flags & bun.O.NONBLOCK != 0) flags |= NONBLOCK;
-        if (c_flags & bun.O.CREAT != 0) flags |= CREAT;
-        if (c_flags & bun.O.NOFOLLOW != 0) flags |= NOFOLLOW;
         if (c_flags & bun.O.WRONLY != 0) flags |= WRONLY;
-        if (c_flags & bun.O.RDONLY != 0) flags |= RDONLY;
         if (c_flags & bun.O.RDWR != 0) flags |= RDWR;
+        if (c_flags & bun.O.CREAT != 0) flags |= CREAT;
+        if (c_flags & bun.O.EXCL != 0) flags |= EXCL;
         if (c_flags & bun.O.TRUNC != 0) flags |= TRUNC;
         if (c_flags & bun.O.APPEND != 0) flags |= APPEND;
-        if (c_flags & bun.O.EXCL != 0) flags |= EXCL;
+        if (c_flags & bun.O.NONBLOCK != 0) flags |= NONBLOCK;
+        if (c_flags & bun.O.DSYNC != 0) flags |= DSYNC;
+        if (c_flags & bun.O.SYNC != 0) flags |= SYNC;
+        if (c_flags & bun.O.NOFOLLOW != 0) flags |= NOFOLLOW;
+        if (c_flags & bun.O.DIRECT != 0) flags |= DIRECT;
         if (c_flags & FILEMAP != 0) flags |= FILEMAP;
+
+        return flags;
+    }
+
+    /// Convert from libuv/Windows MSVC O_ flags to internal bun.O flags.
+    /// This is the inverse of fromBunO and is needed because fs.constants
+    /// exposes the platform's native C values to JavaScript, but internally
+    /// Bun normalizes all flags to the bun.O (POSIX-like) representation.
+    ///
+    /// Only maps flags that have non-zero libuv values on Windows.
+    /// NOFOLLOW, NONBLOCK, DIRECTORY, NOATIME, NOCTTY, SYMLINK are all 0
+    /// in libuv on Windows (no-ops) and cannot be recovered from a bitmask.
+    /// When adding new flag mappings, keep in sync with fromBunO.
+    pub fn toBunO(uv_flags: i32) i32 {
+        var flags: i32 = 0;
+
+        if (uv_flags & WRONLY != 0) flags |= bun.O.WRONLY;
+        if (uv_flags & RDWR != 0) flags |= bun.O.RDWR;
+        if (uv_flags & CREAT != 0) flags |= bun.O.CREAT;
+        if (uv_flags & EXCL != 0) flags |= bun.O.EXCL;
+        if (uv_flags & TRUNC != 0) flags |= bun.O.TRUNC;
+        if (uv_flags & APPEND != 0) flags |= bun.O.APPEND;
+        if (uv_flags & DSYNC != 0) flags |= bun.O.DSYNC;
+        if (uv_flags & SYNC != 0) flags |= bun.O.SYNC;
+        if (uv_flags & DIRECT != 0) flags |= bun.O.DIRECT;
+        if (uv_flags & FILEMAP != 0) flags |= FILEMAP;
 
         return flags;
     }

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -206,8 +206,15 @@ pub const O = struct {
         if (c_flags & bun.O.TRUNC != 0) flags |= TRUNC;
         if (c_flags & bun.O.APPEND != 0) flags |= APPEND;
         if (c_flags & bun.O.NONBLOCK != 0) flags |= NONBLOCK;
-        if (c_flags & bun.O.DSYNC != 0) flags |= DSYNC;
-        if (c_flags & bun.O.SYNC != 0) flags |= SYNC;
+        // SYNC and DSYNC must be mutually exclusive for libuv on Windows.
+        // On Linux, bun.O.SYNC (0o4010000) is a superset of bun.O.DSYNC
+        // (0o10000), so checking SYNC first ensures we emit only UV_FS_O_SYNC
+        // when both bits are present. libuv's fs__open rejects having both set.
+        if (c_flags & bun.O.SYNC != 0) {
+            flags |= SYNC;
+        } else if (c_flags & bun.O.DSYNC != 0) {
+            flags |= DSYNC;
+        }
         if (c_flags & bun.O.NOFOLLOW != 0) flags |= NOFOLLOW;
         if (c_flags & bun.O.DIRECT != 0) flags |= DIRECT;
         if (c_flags & FILEMAP != 0) flags |= FILEMAP;
@@ -233,8 +240,12 @@ pub const O = struct {
         if (uv_flags & EXCL != 0) flags |= bun.O.EXCL;
         if (uv_flags & TRUNC != 0) flags |= bun.O.TRUNC;
         if (uv_flags & APPEND != 0) flags |= bun.O.APPEND;
-        if (uv_flags & DSYNC != 0) flags |= bun.O.DSYNC;
-        if (uv_flags & SYNC != 0) flags |= bun.O.SYNC;
+        // SYNC takes priority over DSYNC (see fromBunO comment).
+        if (uv_flags & SYNC != 0) {
+            flags |= bun.O.SYNC;
+        } else if (uv_flags & DSYNC != 0) {
+            flags |= bun.O.DSYNC;
+        }
         if (uv_flags & DIRECT != 0) flags |= bun.O.DIRECT;
         if (uv_flags & FILEMAP != 0) flags |= FILEMAP;
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3776,3 +3776,56 @@ describe("numeric flags produce same result as string flags", () => {
     expect(() => openSync(file, numericFlag, 0o666)).toThrow();
   });
 });
+
+describe("synchronous I/O string flags", () => {
+  it("'rs' opens existing file for reading", () => {
+    using dir = tempDir("sync-flags", {
+      "existing.txt": "sync content",
+    });
+
+    const fd = openSync(join(String(dir), "existing.txt"), "rs");
+    const buf = Buffer.alloc(20);
+    const bytesRead = readSync(fd, buf);
+    closeSync(fd);
+
+    expect(buf.slice(0, bytesRead).toString("utf8")).toBe("sync content");
+  });
+
+  it("'rs+' opens existing file for read-write", () => {
+    using dir = tempDir("sync-flags", {
+      "existing.txt": "original",
+    });
+    const file = join(String(dir), "existing.txt");
+
+    const fd = openSync(file, "rs+");
+    writeSync(fd, "replaced");
+    closeSync(fd);
+
+    expect(readFileSync(file, "utf8")).toBe("replaced");
+  });
+
+  it("'as' creates and appends to file", () => {
+    using dir = tempDir("sync-flags", {});
+    const file = join(String(dir), "appended.txt");
+
+    const fd = openSync(file, "as");
+    writeSync(fd, "sync-append");
+    closeSync(fd);
+
+    expect(readFileSync(file, "utf8")).toBe("sync-append");
+  });
+
+  it("'as+' creates and appends with read access", () => {
+    using dir = tempDir("sync-flags", {});
+    const file = join(String(dir), "appended-rw.txt");
+
+    const fd = openSync(file, "as+");
+    writeSync(fd, "hello");
+
+    const buf = Buffer.alloc(10);
+    const bytesRead = readSync(fd, buf, 0, 10, 0);
+    closeSync(fd);
+
+    expect(buf.toString("utf8", 0, bytesRead)).toBe("hello");
+  });
+});

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -8,6 +8,7 @@ import {
   isIntelMacOS,
   isPosix,
   isWindows,
+  tempDir,
   tempDirWithFiles,
   tmpdirSync,
 } from "harness";
@@ -3679,4 +3680,99 @@ it("overflowing mode doesn't crash", () => {
       path: "./a.txt",
     }),
   );
+});
+
+describe("numeric flags produce same result as string flags", () => {
+  it("numeric O_CREAT|O_TRUNC|O_WRONLY is equivalent to 'w'", () => {
+    const { O_CREAT, O_TRUNC, O_WRONLY } = constants;
+    const numericFlag = O_CREAT | O_TRUNC | O_WRONLY;
+
+    using dir = tempDir("numeric-flags", {});
+    const fileStr = join(String(dir), "string.txt");
+    const fileNum = join(String(dir), "numeric.txt");
+
+    const fd1 = openSync(fileStr, "w", 0o666);
+    writeSync(fd1, "hello");
+    closeSync(fd1);
+
+    const fd2 = openSync(fileNum, numericFlag, 0o666);
+    writeSync(fd2, "hello");
+    closeSync(fd2);
+
+    expect(readFileSync(fileNum, "utf8")).toBe(readFileSync(fileStr, "utf8"));
+  });
+
+  it("numeric O_CREAT|O_WRONLY|O_APPEND is equivalent to 'a'", () => {
+    const { O_APPEND, O_CREAT, O_WRONLY } = constants;
+    const numericFlag = O_CREAT | O_WRONLY | O_APPEND;
+
+    using dir = tempDir("numeric-flags", {});
+    const fileStr = join(String(dir), "string.txt");
+    const fileNum = join(String(dir), "numeric.txt");
+
+    const fd1 = openSync(fileStr, "a", 0o666);
+    writeSync(fd1, "first");
+    closeSync(fd1);
+    const fd1b = openSync(fileStr, "a", 0o666);
+    writeSync(fd1b, "second");
+    closeSync(fd1b);
+
+    const fd2 = openSync(fileNum, numericFlag, 0o666);
+    writeSync(fd2, "first");
+    closeSync(fd2);
+    const fd2b = openSync(fileNum, numericFlag, 0o666);
+    writeSync(fd2b, "second");
+    closeSync(fd2b);
+
+    expect(readFileSync(fileNum, "utf8")).toBe(readFileSync(fileStr, "utf8"));
+    expect(readFileSync(fileNum, "utf8")).toBe("firstsecond");
+  });
+
+  it("numeric O_CREAT|O_RDWR|O_TRUNC is equivalent to 'w+'", () => {
+    const { O_CREAT, O_RDWR, O_TRUNC } = constants;
+    const numericFlag = O_CREAT | O_RDWR | O_TRUNC;
+
+    using dir = tempDir("numeric-flags", {});
+    const file = join(String(dir), "readwrite.txt");
+
+    const fd = openSync(file, numericFlag, 0o666);
+    writeSync(fd, "read-write");
+
+    // Read back from the same fd to verify O_RDWR actually grants read access.
+    const buf = Buffer.alloc(10);
+    const bytesRead = readSync(fd, buf, 0, 10, 0);
+    closeSync(fd);
+
+    expect(buf.toString("utf8", 0, bytesRead)).toBe("read-write");
+  });
+
+  it("numeric O_RDONLY reads existing file", () => {
+    const { O_RDONLY } = constants;
+    using dir = tempDir("numeric-flags", {});
+    const file = join(String(dir), "readonly.txt");
+
+    writeFileSync(file, "existing content");
+
+    const fd = openSync(file, O_RDONLY);
+    const buf = Buffer.alloc(50);
+    const bytesRead = readSync(fd, buf);
+    closeSync(fd);
+
+    expect(buf.slice(0, bytesRead).toString("utf8")).toBe("existing content");
+  });
+
+  it("numeric O_CREAT|O_EXCL|O_RDWR fails on existing file", () => {
+    const { O_CREAT, O_EXCL, O_RDWR } = constants;
+    const numericFlag = O_CREAT | O_EXCL | O_RDWR;
+
+    using dir = tempDir("numeric-flags", {});
+    const file = join(String(dir), "excl.txt");
+
+    // First open should succeed (creates the file).
+    const fd = openSync(file, numericFlag, 0o666);
+    closeSync(fd);
+
+    // Second open with O_EXCL should fail (file already exists).
+    expect(() => openSync(file, numericFlag, 0o666)).toThrow();
+  });
 });

--- a/test/regression/issue/27974.test.ts
+++ b/test/regression/issue/27974.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
+import { isWindows, tempDir } from "harness";
 import { closeSync, constants, open as openCb, openSync, readFileSync, writeSync } from "node:fs";
 import { open } from "node:fs/promises";
 import { join } from "node:path";
-import { isWindows, tempDir } from "harness";
 
 test("fs.openSync with numeric O_CREAT | O_TRUNC | O_WRONLY flags", () => {
   const { O_CREAT, O_TRUNC, O_WRONLY } = constants;

--- a/test/regression/issue/27974.test.ts
+++ b/test/regression/issue/27974.test.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "bun:test";
+import { closeSync, constants, open as openCb, openSync, readFileSync, writeSync } from "node:fs";
+import { open } from "node:fs/promises";
+import { join } from "node:path";
+import { isWindows, tempDir } from "harness";
+
+test("fs.openSync with numeric O_CREAT | O_TRUNC | O_WRONLY flags", () => {
+  const { O_CREAT, O_TRUNC, O_WRONLY } = constants;
+  const flag = O_TRUNC | O_CREAT | O_WRONLY;
+
+  using dir = tempDir("issue-27974", {});
+  const file = join(String(dir), "test.txt");
+
+  const fd = openSync(file, flag, 0o666);
+  writeSync(fd, "hello world");
+  closeSync(fd);
+
+  expect(readFileSync(file, "utf8")).toBe("hello world");
+});
+
+test("fs.openSync with numeric O_CREAT | O_WRONLY flags (no O_TRUNC)", () => {
+  const { O_CREAT, O_WRONLY } = constants;
+  const flag = O_CREAT | O_WRONLY;
+
+  using dir = tempDir("issue-27974", {});
+  const file = join(String(dir), "test2.txt");
+
+  const fd = openSync(file, flag, 0o666);
+  writeSync(fd, "created");
+  closeSync(fd);
+
+  expect(readFileSync(file, "utf8")).toBe("created");
+});
+
+test.if(isWindows)("fs.openSync with UV_FS_O_FILEMAP | O_CREAT | O_TRUNC | O_WRONLY", () => {
+  const { O_CREAT, O_TRUNC, O_WRONLY, UV_FS_O_FILEMAP } = constants;
+  const flag = UV_FS_O_FILEMAP | O_TRUNC | O_CREAT | O_WRONLY;
+
+  using dir = tempDir("issue-27974", {});
+  const file = join(String(dir), "filemap.txt");
+
+  const fd = openSync(file, flag, 0o666);
+  writeSync(fd, "filemap content");
+  closeSync(fd);
+
+  expect(readFileSync(file, "utf8")).toBe("filemap content");
+});
+
+test("fs.openSync with numeric O_RDWR | O_CREAT | O_EXCL flags", () => {
+  const { O_CREAT, O_RDWR, O_EXCL } = constants;
+  const flag = O_CREAT | O_RDWR | O_EXCL;
+
+  using dir = tempDir("issue-27974", {});
+  const file = join(String(dir), "exclusive.txt");
+
+  const fd = openSync(file, flag, 0o666);
+  writeSync(fd, "exclusive");
+  closeSync(fd);
+
+  expect(readFileSync(file, "utf8")).toBe("exclusive");
+
+  // Opening again with O_EXCL should fail since file exists.
+  expect(() => openSync(file, flag, 0o666)).toThrow();
+});
+
+test("fs.promises.open with numeric O_CREAT | O_TRUNC | O_WRONLY flags", async () => {
+  const { O_CREAT, O_TRUNC, O_WRONLY } = constants;
+  const flag = O_TRUNC | O_CREAT | O_WRONLY;
+
+  using dir = tempDir("issue-27974", {});
+  const file = join(String(dir), "async.txt");
+
+  await using fh = await open(file, flag, 0o666);
+  await fh.write("async hello");
+
+  expect(readFileSync(file, "utf8")).toBe("async hello");
+});
+
+test("fs.open (callback) with numeric O_CREAT | O_TRUNC | O_WRONLY flags", async () => {
+  const { O_CREAT, O_TRUNC, O_WRONLY } = constants;
+  const flag = O_TRUNC | O_CREAT | O_WRONLY;
+
+  using dir = tempDir("issue-27974", {});
+  const file = join(String(dir), "callback.txt");
+
+  const { promise, resolve, reject } = Promise.withResolvers<number>();
+  openCb(file, flag, 0o666, (err, fd) => {
+    if (err) reject(err);
+    else resolve(fd);
+  });
+
+  const fd = await promise;
+  writeSync(fd, "callback hello");
+  closeSync(fd);
+
+  expect(readFileSync(file, "utf8")).toBe("callback hello");
+});
+
+test("fs.openSync with numeric O_APPEND | O_CREAT | O_WRONLY flags", () => {
+  const { O_APPEND, O_CREAT, O_WRONLY } = constants;
+  const flag = O_APPEND | O_CREAT | O_WRONLY;
+
+  using dir = tempDir("issue-27974", {});
+  const file = join(String(dir), "append.txt");
+
+  const fd1 = openSync(file, flag, 0o666);
+  writeSync(fd1, "first");
+  closeSync(fd1);
+
+  const fd2 = openSync(file, flag, 0o666);
+  writeSync(fd2, "second");
+  closeSync(fd2);
+
+  expect(readFileSync(file, "utf8")).toBe("firstsecond");
+});


### PR DESCRIPTION
### What does this PR do?

Fixes `fs.openSync` / `fs.promises.open` throwing `EINVAL` on Windows when passed numeric flags from `fs.constants`.

`fs.constants` exports native MSVC values (e.g. `O_CREAT=0x100`) but `FileSystemFlags.fromJS` stored them as-is into the internal `bun.O` representation (where `O_CREAT=0o100`). Bits like `O_CREAT` were silently dropped during the `bun.O → libuv` conversion, causing `CreateFileW` to get `TRUNCATE_EXISTING` instead of `CREATE_ALWAYS`.

**Changes:**
- Add `libuv.O.toBunO()` (inverse of `fromBunO`) and call it in `FileSystemFlags.fromJS` on Windows
- Add missing `DSYNC`/`SYNC`/`DIRECT` mappings to `fromBunO` (string flags like `"rs+"` were also silently dropping these)
- Fix `UV_FS_O_FILEMAP` in `NodeConstantsModule.h` — was unconditionally `0`, should be `0x20000000` on Windows (matching `ProcessBindingConstants.cpp`)

Closes #27974, closes #12696

### How did you verify your code works?

- Regression test `test/regression/issue/27974.test.ts` (6 tests) and unit tests in `test/js/node/fs/fs.test.ts` (5 tests) covering numeric flag combinations and string/numeric equivalence
- All 11 pass on `bun-debug`, all fail on system bun 1.3.10