### PR TITLE
fix(test): check average coverage against threshold

### DIFF
--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1210,6 +1210,10 @@ pub const CommandLineReporter = struct {
                     avg.functions /= avg_count;
                     avg.lines /= avg_count;
                     avg.stmts /= avg_count;
+
+                    if (avg.functions < base_fraction.functions or avg.lines < base_fraction.lines) {
+                        failing = true;
+                    }
                 }
 
                 const failed = if (avg_count > 0) base_fraction else bun.SourceMap.coverage.Fraction{

--- a/test/regression/issue/7367.test.ts
+++ b/test/regression/issue/7367.test.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/7367
+// bun test --coverage should exit non-zero when coverage is below the configured threshold.
+
+test("exits non-zero when function coverage is below threshold", async () => {
+  using dir = tempDir("coverage-threshold", {
+    "bunfig.toml": `
+[test]
+coverage = true
+coverageThreshold = { functions = 0.9, lines = 0.9 }
+`,
+    "lib.ts": `
+export function used() { return 1; }
+export function unused1() { return 2; }
+export function unused2() { return 3; }
+export function unused3() { return 4; }
+export function unused4() { return 5; }
+export function unused5() { return 6; }
+export function unused6() { return 7; }
+export function unused7() { return 8; }
+export function unused8() { return 9; }
+export function unused9() { return 10; }
+`,
+    "lib.test.ts": `
+import { test, expect } from "bun:test";
+import { used } from "./lib";
+test("uses one function", () => {
+  expect(used()).toBe(1);
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // lib.ts has 10% function coverage (1/10) which is below the 90% threshold.
+  // Coverage table is on stderr.
+  expect(stderr).toContain("lib.ts");
+  expect(exitCode).not.toBe(0);
+});
+
+test("exits zero when coverage meets threshold", async () => {
+  using dir = tempDir("coverage-threshold-pass", {
+    "bunfig.toml": `
+[test]
+coverage = true
+coverageThreshold = { functions = 0.5, lines = 0.5 }
+`,
+    "lib.ts": `
+export function a() { return 1; }
+export function b() { return 2; }
+`,
+    "lib.test.ts": `
+import { test, expect } from "bun:test";
+import { a, b } from "./lib";
+test("uses all functions", () => {
+  expect(a()).toBe(1);
+  expect(b()).toBe(2);
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // lib.ts has 100% coverage which is above the 50% threshold.
+  expect(stderr).toContain("lib.ts");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Add average coverage check against configured `coverageThreshold` in `test_command.zig`
- When all files' average function/line coverage falls below the threshold, the test runner now exits non-zero
- Excludes `stmts` from the average check, consistent with the per-file check in `CodeCoverage.zig:135`
- Add regression test for #7367

## Root Cause
The test runner computed average coverage across all files but never checked it against the configured threshold. Only per-file checks could trigger a non-zero exit. The "All files" summary row could show below-threshold coverage while the runner exited 0.

## Fix
After computing the average, check `avg.functions < base_fraction.functions or avg.lines < base_fraction.lines` and set `failing = true` if below threshold. The `stmts` field is intentionally excluded to match the per-file behavior.

Based on community PR #27933 by @ssing2, with fixes:
- Removed unrelated file changes (docs/runtime/sqlite.mdx, packages/bun-types/overrides.d.ts)
- Removed `stmts` from the average check for consistency with per-file check
- Added regression test

## Test plan
- [x] `bun bd test test/regression/issue/7367.test.ts` passes
- [x] Test verifies exit code 1 when coverage below threshold
- [x] Test verifies exit code 0 when coverage meets threshold
- [x] `bun run zig:check` compiles successfully

Closes #7367