### PR TITLE
fix(windows): resolve bare command names from cwd in whichWin

### DIFF
--- a/src/which.zig
+++ b/src/which.zig
@@ -156,6 +156,12 @@ pub fn whichWin(buf: *bun.WPathBuffer, path: []const u8, cwd: []const u8, bin: [
         return null;
     }
 
+    // On Windows, check cwd for bare command names (matching cmd.exe behavior)
+    if (searchBinInPath(buf, path_buf, cwd, bin, check_windows_extensions)) |bin_path| {
+        bun.path.posixToPlatformInPlace(u16, bin_path);
+        return bin_path;
+    }
+
     // iterate over system path delimiter
     var path_iter = std.mem.tokenizeScalar(u8, path, ';');
     while (path_iter.next()) |segment_part| {

--- a/test/js/bun/util/which.test.ts
+++ b/test/js/bun/util/which.test.ts
@@ -129,6 +129,14 @@ test("Bun.which does not look in the current directory for bins on POSIX", async
     if (isWindows) {
       // On Windows, cmd.exe checks cwd before PATH, so Bun matches that behavior
       expect(which("some_program_name")).toBe(join(dir, "some_program_name.cmd"));
+
+      // Verify CWD takes priority over PATH even when the same name exists on PATH
+      const dir2 = tempDirWithFiles("which-path", {
+        "some_program_name.cmd": "@echo PATH_COPY\n@exit 0\n",
+      });
+      expect(which("some_program_name", { PATH: dir2 + ";" + process.env.PATH })).toBe(
+        join(dir, "some_program_name.cmd"),
+      );
     } else {
       expect(which("some_program_name")).toBe(null);
       expect((await $`some_program_name`).exitCode).not.toBe(0);

--- a/test/js/bun/util/which.test.ts
+++ b/test/js/bun/util/which.test.ts
@@ -114,7 +114,7 @@ if (isWindows) {
   });
 }
 
-test("Bun.which does not look in the current directory for bins", async () => {
+test("Bun.which does not look in the current directory for bins on POSIX", async () => {
   const cwd = process.cwd();
   const dir = tempDirWithFiles("which", {
     "some_program_name": "#!/usr/bin/env sh\necho FAIL\nexit 0\n",
@@ -126,8 +126,13 @@ test("Bun.which does not look in the current directory for bins", async () => {
       await $`chmod +x ./some_program_name`;
     }
 
-    expect(which("some_program_name")).toBe(null);
-    expect((await $`some_program_name`).exitCode).not.toBe(0);
+    if (isWindows) {
+      // On Windows, cmd.exe checks cwd before PATH, so Bun matches that behavior
+      expect(which("some_program_name")).toBe(join(dir, "some_program_name.cmd"));
+    } else {
+      expect(which("some_program_name")).toBe(null);
+      expect((await $`some_program_name`).exitCode).not.toBe(0);
+    }
   } finally {
     process.chdir(cwd);
   }

--- a/test/regression/issue/27988.test.ts
+++ b/test/regression/issue/27988.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/27988
+// On Windows, `bun run` should resolve local .bat/.cmd files from CWD
+// when referenced as bare command names in package.json scripts
+test.todoIf(
+  process.platform !== "win32",
+  "bun run resolves local .bat files in package.json scripts on Windows",
+  async () => {
+    using dir = tempDir("issue-27988", {
+      "package.json": JSON.stringify({
+        name: "bun-test-27988",
+        scripts: {
+          recovery: "WebRecovery.bat",
+        },
+      }),
+      "WebRecovery.bat": "@echo Hello from WebRecovery.bat\n",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "recovery"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("Hello from WebRecovery.bat");
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
## Summary

- On Windows, `cmd.exe` checks the current working directory before searching `PATH` when resolving commands. Bun's `whichWin()` was only checking CWD when the command contained path separators (e.g. `./foo.bat`), but not for bare names like `foo.bat`
- This caused `bun run` to fail with `command not found` when package.json scripts referenced local `.bat`/`.cmd` files by name, while the same scripts worked with `npm run`
- Added a CWD check for bare command names in `whichWin()` before iterating over `PATH`, matching native Windows behavior

## Test plan

- [x] Updated existing `which.test.ts` to expect Windows CWD resolution behavior
- [x] Added regression test `test/regression/issue/27988.test.ts` (Windows-only, uses `test.todoIf`)
- [x] All existing `which` tests pass on Linux (5/5)
- [x] Debug build compiles successfully

Closes #27988

🤖 Generated with [Claude Code](https://claude.com/claude-code)