### PR TITLE
Include --feature flags in RuntimeTranspilerCache hash

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -227,6 +227,7 @@ pub const Runtime = struct {
 
         /// Initialize bundler feature flags for dead-code elimination via `import { feature } from "bun:bundle"`.
         /// Returns a pointer to a StringSet containing the enabled flags, or the empty set if no flags are provided.
+        /// Keys are kept sorted so iteration order is deterministic (for RuntimeTranspilerCache hashing).
         pub fn initBundlerFeatureFlags(allocator: std.mem.Allocator, feature_flags: []const []const u8) *const bun.StringSet {
             if (feature_flags.len == 0) {
                 return &empty_bundler_feature_flags;
@@ -237,6 +238,12 @@ pub const Runtime = struct {
             for (feature_flags) |flag| {
                 bun.handleOom(set.insert(flag));
             }
+            set.map.sort(struct {
+                keys: []const []const u8,
+                pub fn lessThan(ctx: @This(), a: usize, b: usize) bool {
+                    return std.mem.lessThan(u8, ctx.keys[a], ctx.keys[b]);
+                }
+            }{ .keys = set.map.keys() });
             return set;
         }
 
@@ -271,6 +278,15 @@ pub const Runtime = struct {
             }
 
             hasher.update(std.mem.asBytes(&bools));
+
+            // Hash --feature flags. These directly affect transpiled output via
+            // feature("NAME") replacement in visitExpr.zig. When empty, we add
+            // nothing to the hash so existing cache entries remain valid.
+            // Keys are sorted in initBundlerFeatureFlags so flag order on the CLI doesn't matter.
+            for (this.bundler_feature_flags.keys()) |flag| {
+                hasher.update(flag);
+                hasher.update("\x00");
+            }
         }
 
         pub fn shouldUnwrapRequire(this: *const Features, package_name: string) bool {

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -186,4 +186,42 @@ describe("transpiler cache", () => {
     expect(b.stdout == "production 5");
     expect(newCacheCount()).toBe(0);
   });
+  test("--feature flag invalidates cache", () => {
+    // feature() can only appear in an if/ternary, so wrap it
+    const code = `import { feature } from "bun:bundle";\nif (feature("SUPER_SECRET")) console.log("enabled"); else console.log("disabled");`;
+    const filler = Buffer.alloc((50 * 1024 * 1.5) | 0, "/").toString();
+    writeFileSync(join(temp_dir, "a.js"), code + "\n//" + filler);
+
+    const run = (extra: string[]) => {
+      const result = Bun.spawnSync({
+        cmd: [bunExe(), ...extra, "a.js"],
+        cwd: temp_dir,
+        env,
+      });
+      if (!result.success) throw new Error(result.stderr.toString());
+      return result.stdout.toString().trim();
+    };
+
+    // First run with flag: cache miss, write entry
+    expect(run(["--feature=SUPER_SECRET"])).toBe("enabled");
+    expect(newCacheCount()).toBe(1);
+
+    // Same flag: cache hit
+    expect(run(["--feature=SUPER_SECRET"])).toBe("enabled");
+    expect(newCacheCount()).toBe(0);
+
+    // No flag: features_hash differs -> old entry deleted, new entry written
+    expect(run([])).toBe("disabled");
+    expect(newCacheCount()).toBe(0); // deleted + written = net 0
+
+    // Flag again: another delete + write
+    expect(run(["--feature=SUPER_SECRET"])).toBe("enabled");
+    expect(newCacheCount()).toBe(0);
+
+    // Multiple flags, different order: same hash, cache hit
+    expect(run(["--feature=SUPER_SECRET", "--feature=OTHER"])).toBe("enabled");
+    expect(newCacheCount()).toBe(0); // delete + write
+    expect(run(["--feature=OTHER", "--feature=SUPER_SECRET"])).toBe("enabled");
+    expect(newCacheCount()).toBe(0); // cache hit, order doesn't matter
+  });
 });


### PR DESCRIPTION
## Summary
- `feature("NAME")` from `bun:bundle` is replaced at transpile time based on `--feature` CLI flags, but the transpiler cache wasn't aware of them — toggling a flag would serve stale cached output.
- Feature flag keys are now sorted on init and hashed into the cache key (null-separated). Flag order on the CLI doesn't matter, and empty flag sets add nothing so existing cache entries remain valid.

## Test plan
- [x] `bun bd test test/cli/run/transpiler-cache.test.ts -t "feature flag"`
  - Verifies same flag hits cache, different flag misses, flag order is irrelevant, and removing flag goes back to original entry