### PR TITLE
fix(serve): set Cache-Control header on content-hashed HTML import assets

### DIFF
--- a/src/bun.js/api/server/HTMLBundle.zig
+++ b/src/bun.js/api/server/HTMLBundle.zig
@@ -378,7 +378,7 @@ pub const Route = struct {
                             error.NoSpaceLeft => unreachable,
                         };
                         bun.handleOom(headers.append("ETag", etag_str));
-                        if (!server.config().isDevelopment() and (output_file.output_kind == .chunk))
+                        if (!server.config().isDevelopment())
                             bun.handleOom(headers.append("Cache-Control", "public, max-age=31536000"));
                     }
 

--- a/src/bundler/HTMLImportManifest.zig
+++ b/src/bundler/HTMLImportManifest.zig
@@ -91,6 +91,13 @@ fn writeEntryItem(
         }).value,
     });
 
+    // Content-hashed assets are immutable — if the content changes, the hash
+    // (and therefore the URL) changes too, so aggressive caching is always safe.
+    // Exclude HTML since it's served at a user-specified URL, not a hashed path.
+    if (hash > 0 and loader != .html) {
+        try writer.writeAll(",\"cache-control\":\"public, max-age=31536000\"");
+    }
+
     try writer.writeAll("}}");
 }
 

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -108,7 +108,8 @@ console.log(favicon);
                 "isEntry": true,
                 "headers": {
                   "etag": "14Q4Q7Mm8TM",
-                  "content-type": "text/javascript;charset=utf-8"
+                  "content-type": "text/javascript;charset=utf-8",
+                  "cache-control": "public, max-age=31536000"
                 }
               },
               {
@@ -128,7 +129,8 @@ console.log(favicon);
                 "isEntry": true,
                 "headers": {
                   "etag": "0k_h5oYVQlA",
-                  "content-type": "text/css;charset=utf-8"
+                  "content-type": "text/css;charset=utf-8",
+                  "cache-control": "public, max-age=31536000"
                 }
               },
               {
@@ -138,7 +140,8 @@ console.log(favicon);
                 "isEntry": false,
                 "headers": {
                   "etag": "fFLOVvPDEZc",
-                  "content-type": "image/png"
+                  "content-type": "image/png",
+                  "cache-control": "public, max-age=31536000"
                 }
               }
             ]
@@ -286,6 +289,7 @@ console.log("About manifest:", aboutHtml);
             "files": [
               {
                 "headers": {
+                  "cache-control": "public, max-age=31536000",
                   "content-type": "text/javascript;charset=utf-8",
                   "etag": "18fAEMlKmOw",
                 },
@@ -306,6 +310,7 @@ console.log("About manifest:", aboutHtml);
               },
               {
                 "headers": {
+                  "cache-control": "public, max-age=31536000",
                   "content-type": "text/css;charset=utf-8",
                   "etag": "6qg2qb7a2qo",
                 },
@@ -321,6 +326,7 @@ console.log("About manifest:", aboutHtml);
             "files": [
               {
                 "headers": {
+                  "cache-control": "public, max-age=31536000",
                   "content-type": "text/javascript;charset=utf-8",
                   "etag": "-3e3gOCTAZg",
                 },
@@ -341,6 +347,7 @@ console.log("About manifest:", aboutHtml);
               },
               {
                 "headers": {
+                  "cache-control": "public, max-age=31536000",
                   "content-type": "text/css;charset=utf-8",
                   "etag": "DE8kdBXWhVg",
                 },

--- a/test/regression/issue/27996.test.ts
+++ b/test/regression/issue/27996.test.ts
@@ -3,16 +3,18 @@ import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 
 describe("HTML imports Cache-Control headers (#27996)", () => {
   for (const development of [true, false]) {
-    test(`content-hashed assets ${development ? "omit" : "include"} Cache-Control when development: ${development}`, async () => {
-      const dir = tempDirWithFiles("html-cache-control", {
-        "index.html": `<!DOCTYPE html>
+    test(
+      `content-hashed assets ${development ? "omit" : "include"} Cache-Control when development: ${development}`,
+      async () => {
+        const dir = tempDirWithFiles("html-cache-control", {
+          "index.html": `<!DOCTYPE html>
 <html>
 <head><link rel="stylesheet" href="./style.css" /></head>
 <body><script type="module" src="./app.ts"></script></body>
 </html>`,
-        "style.css": `body { background: red; }`,
-        "app.ts": `console.log("hello")`,
-        "server.ts": `
+          "style.css": `body { background: red; }`,
+          "app.ts": `console.log("hello")`,
+          "server.ts": `
 import index from "./index.html";
 
 const server = Bun.serve({
@@ -24,71 +26,77 @@ const server = Bun.serve({
 // Signal the port to the parent process
 process.send(server.port);
 `,
-      });
+        });
 
-      let portResolve: (port: number) => void;
-      const portPromise = new Promise<number>(r => {
-        portResolve = r;
-      });
+        let portResolve: (port: number) => void;
+        const portPromise = new Promise<number>(r => {
+          portResolve = r;
+        });
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "--smol", "server.ts"],
-        cwd: dir,
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-        ipc(message) {
-          portResolve(message as number);
-        },
-      });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "--smol", "server.ts"],
+          cwd: dir,
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+          ipc(message) {
+            portResolve(message as number);
+          },
+        });
 
-      const port = await Promise.race([
-        portPromise,
-        proc.exited.then(() => {
-          throw new Error("child exited before sending port");
-        }),
-      ]);
-      const baseUrl = `http://localhost:${port}`;
+        const port = await Promise.race([
+          portPromise,
+          proc.exited.then(() => {
+            throw new Error("child exited before sending port");
+          }),
+        ]);
+        const baseUrl = `http://localhost:${port}`;
 
-      // Fetch the HTML page to discover asset URLs
-      const htmlResponse = await fetch(baseUrl);
-      expect(htmlResponse.status).toBe(200);
-      const htmlText = await htmlResponse.text();
+        // Fetch the HTML page to discover asset URLs
+        const htmlResponse = await fetch(baseUrl);
+        expect(htmlResponse.status).toBe(200);
+        const htmlText = await htmlResponse.text();
 
-      // HTML page itself should NOT have Cache-Control
-      expect(htmlResponse.headers.get("cache-control")).toBeNull();
+        // HTML page itself should NOT have Cache-Control
+        expect(htmlResponse.headers.get("cache-control")).toBeNull();
 
-      // Extract chunk URLs from the HTML
-      const cssMatch = htmlText.match(/href="([^"]+\.css)"/);
-      const jsMatch = htmlText.match(/src="([^"]+\.js)"/);
+        // Extract chunk URLs from the HTML and verify they are content-hashed
+        const cssMatch = htmlText.match(/href="([^"]+\.css)"/);
+        const jsMatch = htmlText.match(/src="([^"]+\.js)"/);
 
-      if (!cssMatch) throw new Error("CSS asset URL not found in HTML: " + htmlText);
-      if (!jsMatch) throw new Error("JS asset URL not found in HTML: " + htmlText);
+        if (!cssMatch) throw new Error("CSS asset URL not found in HTML: " + htmlText);
+        if (!jsMatch) throw new Error("JS asset URL not found in HTML: " + htmlText);
 
-      // Fetch CSS asset and check headers
-      const cssResponse = await fetch(new URL(cssMatch[1], baseUrl));
-      expect(cssResponse.headers.get("etag")).not.toBeNull();
-      expect(cssResponse.headers.get("content-type")).toBe("text/css;charset=utf-8");
-      expect(cssResponse.status).toBe(200);
+        // Verify assets have content hashes in their filenames
+        expect(cssMatch[1]).toMatch(/[0-9a-z]{6,}\.(css)$/);
+        expect(jsMatch[1]).toMatch(/[0-9a-z]{6,}\.(js)$/);
 
-      // Fetch JS asset and check headers
-      const jsResponse = await fetch(new URL(jsMatch[1], baseUrl));
-      expect(jsResponse.headers.get("etag")).not.toBeNull();
-      expect(jsResponse.headers.get("content-type")).toBe("text/javascript;charset=utf-8");
-      expect(jsResponse.status).toBe(200);
+        // Fetch CSS asset and check headers
+        const cssResponse = await fetch(new URL(cssMatch[1], baseUrl));
+        expect(cssResponse.headers.get("etag")).not.toBeNull();
+        expect(cssResponse.headers.get("content-type")).toBe("text/css;charset=utf-8");
+        expect(cssResponse.status).toBe(200);
 
-      if (development) {
-        // In development mode, Cache-Control should NOT be set
-        expect(cssResponse.headers.get("cache-control")).toBeNull();
-        expect(jsResponse.headers.get("cache-control")).toBeNull();
-      } else {
-        // In production mode, content-hashed assets should have Cache-Control
-        expect(cssResponse.headers.get("cache-control")).toBe("public, max-age=31536000");
-        expect(jsResponse.headers.get("cache-control")).toBe("public, max-age=31536000");
-      }
+        // Fetch JS asset and check headers
+        const jsResponse = await fetch(new URL(jsMatch[1], baseUrl));
+        expect(jsResponse.headers.get("etag")).not.toBeNull();
+        expect(jsResponse.headers.get("content-type")).toBe("text/javascript;charset=utf-8");
+        expect(jsResponse.status).toBe(200);
 
-      proc.kill();
-      await proc.exited;
-    });
+        if (development) {
+          // In development mode, Cache-Control should NOT be set
+          expect(cssResponse.headers.get("cache-control")).toBeNull();
+          expect(jsResponse.headers.get("cache-control")).toBeNull();
+        } else {
+          // In production mode, content-hashed assets should have Cache-Control
+          expect(cssResponse.headers.get("cache-control")).toBe("public, max-age=31536000");
+          expect(jsResponse.headers.get("cache-control")).toBe("public, max-age=31536000");
+        }
+
+        proc.kill();
+        await proc.exited;
+      },
+      { timeout: 15_000 },
+    );
   }
 });

--- a/test/regression/issue/27996.test.ts
+++ b/test/regression/issue/27996.test.ts
@@ -26,6 +26,11 @@ process.send(server.port);
 `,
       });
 
+      let portResolve: (port: number) => void;
+      const portPromise = new Promise<number>(r => {
+        portResolve = r;
+      });
+
       await using proc = Bun.spawn({
         cmd: [bunExe(), "--smol", "server.ts"],
         cwd: dir,
@@ -37,12 +42,12 @@ process.send(server.port);
         },
       });
 
-      let portResolve: (port: number) => void;
-      const portPromise = new Promise<number>(r => {
-        portResolve = r;
-      });
-
-      const port = await portPromise;
+      const port = await Promise.race([
+        portPromise,
+        proc.exited.then(() => {
+          throw new Error("child exited before sending port");
+        }),
+      ]);
       const baseUrl = `http://localhost:${port}`;
 
       // Fetch the HTML page to discover asset URLs
@@ -83,6 +88,7 @@ process.send(server.port);
       }
 
       proc.kill();
+      await proc.exited;
     });
   }
 });

--- a/test/regression/issue/27996.test.ts
+++ b/test/regression/issue/27996.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+describe("HTML imports Cache-Control headers (#27996)", () => {
+  for (const development of [true, false]) {
+    test(`content-hashed assets ${development ? "omit" : "include"} Cache-Control when development: ${development}`, async () => {
+      const dir = tempDirWithFiles("html-cache-control", {
+        "index.html": `<!DOCTYPE html>
+<html>
+<head><link rel="stylesheet" href="./style.css" /></head>
+<body><script type="module" src="./app.ts"></script></body>
+</html>`,
+        "style.css": `body { background: red; }`,
+        "app.ts": `console.log("hello")`,
+        "server.ts": `
+import index from "./index.html";
+
+const server = Bun.serve({
+  development: ${development},
+  port: 0,
+  routes: { "/": index },
+});
+
+// Signal the port to the parent process
+process.send(server.port);
+`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--smol", "server.ts"],
+        cwd: dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        ipc(message) {
+          portResolve(message as number);
+        },
+      });
+
+      let portResolve: (port: number) => void;
+      const portPromise = new Promise<number>(r => {
+        portResolve = r;
+      });
+
+      const port = await portPromise;
+      const baseUrl = `http://localhost:${port}`;
+
+      // Fetch the HTML page to discover asset URLs
+      const htmlResponse = await fetch(baseUrl);
+      expect(htmlResponse.status).toBe(200);
+      const htmlText = await htmlResponse.text();
+
+      // HTML page itself should NOT have Cache-Control
+      expect(htmlResponse.headers.get("cache-control")).toBeNull();
+
+      // Extract chunk URLs from the HTML
+      const cssMatch = htmlText.match(/href="([^"]+\.css)"/);
+      const jsMatch = htmlText.match(/src="([^"]+\.js)"/);
+
+      if (!cssMatch) throw new Error("CSS asset URL not found in HTML: " + htmlText);
+      if (!jsMatch) throw new Error("JS asset URL not found in HTML: " + htmlText);
+
+      // Fetch CSS asset and check headers
+      const cssResponse = await fetch(new URL(cssMatch[1], baseUrl));
+      expect(cssResponse.headers.get("etag")).not.toBeNull();
+      expect(cssResponse.headers.get("content-type")).toBe("text/css;charset=utf-8");
+      expect(cssResponse.status).toBe(200);
+
+      // Fetch JS asset and check headers
+      const jsResponse = await fetch(new URL(jsMatch[1], baseUrl));
+      expect(jsResponse.headers.get("etag")).not.toBeNull();
+      expect(jsResponse.headers.get("content-type")).toBe("text/javascript;charset=utf-8");
+      expect(jsResponse.status).toBe(200);
+
+      if (development) {
+        // In development mode, Cache-Control should NOT be set
+        expect(cssResponse.headers.get("cache-control")).toBeNull();
+        expect(jsResponse.headers.get("cache-control")).toBeNull();
+      } else {
+        // In production mode, content-hashed assets should have Cache-Control
+        expect(cssResponse.headers.get("cache-control")).toBe("public, max-age=31536000");
+        expect(jsResponse.headers.get("cache-control")).toBe("public, max-age=31536000");
+      }
+
+      proc.kill();
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #27996

Content-hashed assets (CSS, JS, images) served through HTML imports were missing `Cache-Control: public, max-age=31536000` headers when `development: false`, despite the [docs](https://bun.sh/docs/bundler/fullstack#runtime-bundling) stating this should be enabled. Only `ETag` and `Content-Type` were being set.

Two bugs fixed:

- **`HTMLBundle.zig` (runtime bundling path)**: The condition `output_kind == .chunk` was too restrictive — CSS outputs always get `.asset` kind (not `.chunk`) in the linker. Removed the `output_kind` check since we're already inside a block that only processes non-HTML files with content hashes (ETag block).

- **`HTMLImportManifest.zig` (compiled binary / AOT path)**: The manifest JSON written at build time never included `cache-control` headers. Added `cache-control: public, max-age=31536000` for all content-hashed non-HTML assets in the manifest, which is then read at serve-time by `server.zig`.

## Test plan

- [x] New regression test `test/regression/issue/27996.test.ts` — verifies both CSS and JS assets get `Cache-Control` when `development: false` and don't get it when `development: true`
- [x] Test fails with system Bun (`USE_SYSTEM_BUN=1`) and passes with debug build
- [x] Updated inline snapshot in `test/bundler/html-import-manifest.test.ts` for new `cache-control` field
- [x] Existing `bun-serve-html.test.ts` and `bun-serve-html-manifest.test.ts` tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)