### PR TITLE
fix(http): 304 Not Modified through proxy tunnel hangs indefinitely

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -2385,19 +2385,20 @@ pub fn handleResponseMetadata(
         response.status_code = 304;
     }
 
+    // According to RFC 7230 section 3.3.3:
+    //   1. Any response to a HEAD request and any response with a 1xx (Informational),
+    //      204 (No Content), or 304 (Not Modified) status code
+    //      [...] cannot contain a message body or trailer section.
+    // Therefore in these cases set content-length to 0, so the response body is always ignored
+    // and is not waited for (which could cause a timeout).
+    // This applies regardless of whether we're using a proxy tunnel or not,
+    // since these status codes NEVER have a body per the HTTP spec.
+    if ((response.status_code >= 100 and response.status_code < 200) or response.status_code == 204 or response.status_code == 304) {
+        this.state.content_length = 0;
+    }
+
     // Don't do this for proxies because those connections will be open for awhile.
     if (!this.flags.proxy_tunneling) {
-
-        // according to RFC 7230 section 3.3.3:
-        //   1. Any response to a HEAD request and any response with a 1xx (Informational),
-        //      204 (No Content), or 304 (Not Modified) status code
-        //      [...] cannot contain a message body or trailer section.
-        // therefore in these cases set content-length to 0, so the response body is always ignored
-        // and is not waited for (which could cause a timeout)
-        if ((response.status_code >= 100 and response.status_code < 200) or response.status_code == 204 or response.status_code == 304) {
-            this.state.content_length = 0;
-        }
-
         //
         // according to RFC 7230 section 6.3:
         //   In order to remain persistent, all messages on a connection need to
@@ -2407,7 +2408,7 @@ pub fn handleResponseMetadata(
         // the keep-alive behavior (keep-alive being the default behavior for HTTP/1.1 and not for HTTP/1.0)
         //
         // but, we must only do this IF the status code allows it to contain a body.
-        else if (this.state.content_length == null and this.state.transfer_encoding != .chunked) {
+        if (this.state.content_length == null and this.state.transfer_encoding != .chunked) {
             this.state.flags.allow_keepalive = false;
         }
     }

--- a/test/regression/issue/17793.test.ts
+++ b/test/regression/issue/17793.test.ts
@@ -1,0 +1,253 @@
+// Regression test for https://github.com/oven-sh/bun/issues/17793
+//
+// Bug: In handleResponseMetadata (src/http.zig), the RFC 9112 §6.3 logic
+// setting content_length=0 for 304 responses was inside `if (!proxy_tunneling)`,
+// so 304 through CONNECT tunnels left content_length=null → continue_streaming → hang.
+//
+// This test is fully self-contained (no external proxy or internet needed):
+// - Mock HTTPS registry (raw TLS server for full control over response headers)
+// - Mock CONNECT proxy
+// - Runs `bun install` twice: first populates cache, second triggers 304
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir, tls as tlsCert } from "harness";
+import { once } from "node:events";
+import { readdir, rm } from "node:fs/promises";
+import net from "node:net";
+import { join } from "node:path";
+import tls from "node:tls";
+
+/**
+ * Creates a minimal valid npm tarball (.tgz) containing only package/package.json.
+ * Constructs a USTAR tar archive and gzip-compresses it.
+ */
+function createMinimalTarball(pkgJson: object): Buffer {
+  const content = Buffer.from(JSON.stringify(pkgJson));
+  const filename = "package/package.json";
+
+  const header = Buffer.alloc(512, 0);
+  header.write(filename, 0);
+  header.write("0000644\0", 100); // mode
+  header.write("0001000\0", 108); // uid
+  header.write("0001000\0", 116); // gid
+  header.write(content.length.toString(8).padStart(11, "0") + "\0", 124); // size
+  header.write(
+    Math.floor(Date.now() / 1000)
+      .toString(8)
+      .padStart(11, "0") + "\0",
+    136,
+  ); // mtime
+  header.write("        ", 148); // checksum placeholder (8 spaces)
+  header.write("0", 156); // typeflag: regular file
+  header.write("ustar\0", 257); // magic
+  header.write("00", 263); // version
+
+  let checksum = 0;
+  for (let i = 0; i < 512; i++) checksum += header[i];
+  header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148);
+
+  const dataBlocks = Buffer.alloc(Math.ceil(content.length / 512) * 512, 0);
+  content.copy(dataBlocks);
+
+  return Buffer.from(Bun.gzipSync(Buffer.concat([header, dataBlocks, Buffer.alloc(1024, 0)])));
+}
+
+test("bun install with proxy does not hang on 304 cached response", async () => {
+  const pkgName = "test-pkg-304";
+  const pkgVersion = "1.0.0";
+  const etag = '"test-etag-304-regression"';
+  const requests: Array<{ path: string; ifNoneMatch: boolean }> = [];
+
+  const tarball = createMinimalTarball({ name: pkgName, version: pkgVersion });
+  const shasum = new Bun.CryptoHasher("sha1").update(tarball).digest("hex");
+  const integrity = "sha512-" + new Bun.CryptoHasher("sha512").update(tarball).digest("base64");
+
+  // --- Mock HTTPS registry (raw TLS for full control over headers) ---
+  // Using raw tls.createServer instead of Bun.serve because we need to send
+  // 304 responses WITHOUT a Content-Length header. Bun.serve may auto-add it.
+  let registryPort = 0;
+
+  const registryServer = tls.createServer({ key: tlsCert.key, cert: tlsCert.cert }, (socket: tls.TLSSocket) => {
+    let buf = Buffer.alloc(0);
+
+    socket.on("data", (chunk: Buffer) => {
+      buf = Buffer.concat([buf, chunk]);
+
+      while (true) {
+        const end = buf.indexOf("\r\n\r\n");
+        if (end === -1) break;
+
+        const headerStr = buf.subarray(0, end).toString();
+        buf = buf.subarray(end + 4);
+
+        const lines = headerStr.split("\r\n");
+        const path = lines[0].split(" ")[1];
+        const ifNoneMatch = lines.some(l => l.toLowerCase().startsWith("if-none-match:"));
+        requests.push({ path, ifNoneMatch });
+
+        if (path.endsWith(".tgz")) {
+          socket.write(
+            `HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: ${tarball.length}\r\n\r\n`,
+          );
+          socket.write(tarball);
+        } else if (path.startsWith(`/${pkgName}`)) {
+          if (ifNoneMatch) {
+            // 304 WITHOUT Content-Length — this is what triggers the bug
+            // when going through a CONNECT tunnel without the fix.
+            socket.write(`HTTP/1.1 304 Not Modified\r\nETag: ${etag}\r\n\r\n`);
+          } else {
+            const manifest = JSON.stringify({
+              name: pkgName,
+              "dist-tags": { latest: pkgVersion },
+              versions: {
+                [pkgVersion]: {
+                  name: pkgName,
+                  version: pkgVersion,
+                  dist: {
+                    tarball: `https://localhost:${registryPort}/${pkgName}/-/${pkgName}-${pkgVersion}.tgz`,
+                    shasum,
+                    integrity,
+                  },
+                },
+              },
+            });
+            socket.write(
+              `HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${Buffer.byteLength(manifest)}\r\nETag: ${etag}\r\n\r\n${manifest}`,
+            );
+          }
+        } else {
+          socket.write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n");
+        }
+      }
+    });
+
+    socket.on("error", () => {});
+  });
+
+  registryServer.listen(0);
+  await once(registryServer, "listening");
+  registryPort = (registryServer.address() as net.AddressInfo).port;
+
+  // --- Mock CONNECT proxy ---
+  const proxyServer = net.createServer((clientSocket: net.Socket) => {
+    clientSocket.once("data", (data: Buffer) => {
+      const match = data.toString().match(/^CONNECT\s+([^:]+):(\d+)\s+HTTP/);
+      if (!match) {
+        clientSocket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
+        clientSocket.end();
+        return;
+      }
+
+      const [, host, port] = match;
+      const serverSocket = net.connect(parseInt(port), host, () => {
+        clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+        serverSocket.pipe(clientSocket, { end: false });
+        clientSocket.pipe(serverSocket, { end: false });
+      });
+
+      serverSocket.on("error", () => clientSocket.destroy());
+      clientSocket.on("error", () => serverSocket.destroy());
+      clientSocket.on("close", () => serverSocket.destroy());
+      serverSocket.on("close", () => clientSocket.destroy());
+    });
+
+    clientSocket.on("error", () => {});
+  });
+
+  proxyServer.listen(0);
+  await once(proxyServer, "listening");
+  const proxyPort = (proxyServer.address() as net.AddressInfo).port;
+
+  // --- Test project ---
+  // Use a version range (^) so bun revalidates the manifest on the second install.
+  // Exact versions bypass revalidation even when the cache is expired.
+  using dir = tempDir("proxy-304-regression", {
+    "package.json": JSON.stringify({
+      name: "test-project",
+      version: "1.0.0",
+      dependencies: { [pkgName]: `^${pkgVersion}` },
+    }),
+    "bunfig.toml": `[install]\nregistry = "https://localhost:${registryPort}/"\n`,
+  });
+
+  const installEnv = {
+    ...bunEnv,
+    HTTPS_PROXY: `http://localhost:${proxyPort}`,
+    HTTP_PROXY: `http://localhost:${proxyPort}`,
+    https_proxy: `http://localhost:${proxyPort}`,
+    http_proxy: `http://localhost:${proxyPort}`,
+    NO_PROXY: "",
+    no_proxy: "",
+    NODE_TLS_REJECT_UNAUTHORIZED: "0",
+    BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+  };
+
+  const spawnInstall = (extraArgs: string[] = []) =>
+    Bun.spawn({
+      cmd: [bunExe(), "install", ...extraArgs],
+      cwd: String(dir),
+      env: installEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+  try {
+    // First install: registry returns 200 + ETag → populates manifest cache
+    {
+      await using proc = spawnInstall();
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        Promise.race([proc.exited, new Promise<"timeout">(r => setTimeout(() => r("timeout"), 15000))]),
+      ]);
+
+      if (exitCode === "timeout") proc.kill();
+      expect(exitCode).not.toBe("timeout");
+      expect(exitCode).toBe(0);
+    }
+
+    // Wait for the async manifest cache save to complete.
+    // bun saves manifests asynchronously; without this, the second install
+    // may not find the cached manifest and skip the If-None-Match path.
+    const cacheDir = join(String(dir), ".bun-cache");
+    let cachePopulated = false;
+    for (let i = 0; i < 40; i++) {
+      const entries = await readdir(cacheDir).catch(() => []);
+      if (entries.length > 0) {
+        cachePopulated = true;
+        break;
+      }
+      await Bun.sleep(50);
+    }
+    expect(cachePopulated).toBe(true);
+
+    // Clear local artifacts but keep global manifest cache
+    await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
+    await rm(join(String(dir), "bun.lock"), { force: true });
+
+    // Second install with --force: bypasses manifest cache freshness check, so bun
+    // revalidates with If-None-Match → 304 through CONNECT tunnel.
+    // Without the fix, content_length stays null for 304 responses through proxy tunnels,
+    // causing the connection to hang in continue_streaming.
+    {
+      await using proc = spawnInstall(["--force"]);
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        Promise.race([proc.exited, new Promise<"timeout">(r => setTimeout(() => r("timeout"), 15000))]),
+      ]);
+
+      if (exitCode === "timeout") proc.kill();
+      expect(exitCode).not.toBe("timeout");
+      expect(exitCode).toBe(0);
+    }
+
+    // Verify that the 304 code path was actually exercised
+    const manifestReqs = requests.filter(r => r.path.startsWith(`/${pkgName}`) && !r.path.endsWith(".tgz"));
+    expect(manifestReqs.length).toBeGreaterThanOrEqual(2);
+    expect(manifestReqs.some(r => r.ifNoneMatch)).toBe(true);
+  } finally {
+    registryServer.close();
+    proxyServer.close();
+  }
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #17793

Fixes `bun install` hanging for ~300 seconds per dependency when using an HTTP proxy (`http_proxy`/`https_proxy`) with cached packages.

### Root Cause

In `handleResponseMetadata` (`src/http.zig`), the RFC 7230 §3.3.3 logic that sets `content_length = 0` for 1xx/204/304 responses was inside an `if (!proxy_tunneling)` guard:

```zig
// BEFORE (bug): entire block skipped when proxy_tunneling=true
if (!this.flags.proxy_tunneling) {
    if (status == 304) { this.state.content_length = 0; }  // ← skipped!
    else if (...) { ... }
}
```

When a 304 response came through a CONNECT tunnel (which has no body and typically no `Content-Length` header), `content_length` stayed `null`. The client then entered body streaming mode and waited indefinitely for data that would never come.

### Fix

Move the no-body status check outside the proxy guard. RFC 7230 §3.3.3 / RFC 9112 §6.3 states these status codes "cannot contain a message body" — this is unconditional, regardless of connection type. A CONNECT tunnel is transparent (RFC 9110 §9.3.6), so HTTP semantics are identical to a direct connection.

```zig
// AFTER (fix): check applies regardless of proxy_tunneling
if (status >= 100 and status < 200 or status == 204 or status == 304) {
    this.state.content_length = 0;
}
if (!this.flags.proxy_tunneling) {
    // keep-alive inference (correctly remains proxy-guarded)
}
```

### Test

Self-contained regression test in `test/regression/issue/17793.test.ts`:
- Mock HTTPS registry (raw TLS server) that returns 304 without Content-Length
- Mock CONNECT proxy
- Runs `bun install` twice: first populates manifest cache, second triggers 304 through the tunnel
- Verifies the install completes without hanging and that the 304 code path was exercised