### PR TITLE
feat(redis): add Bun.RedisError runtime class

### DIFF
--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -1,4 +1,38 @@
 declare module "bun" {
+  export type RedisErrorCode =
+    | "ERR_REDIS_AUTHENTICATION_FAILED"
+    | "ERR_REDIS_CONNECTION_CLOSED"
+    | "ERR_REDIS_CONNECTION_TIMEOUT"
+    | "ERR_REDIS_IDLE_TIMEOUT"
+    | "ERR_REDIS_INVALID_ARGUMENT"
+    | "ERR_REDIS_INVALID_ARRAY"
+    | "ERR_REDIS_INVALID_BULK_STRING"
+    | "ERR_REDIS_INVALID_COMMAND"
+    | "ERR_REDIS_INVALID_DATABASE"
+    | "ERR_REDIS_INVALID_ERROR_STRING"
+    | "ERR_REDIS_INVALID_INTEGER"
+    | "ERR_REDIS_INVALID_PASSWORD"
+    | "ERR_REDIS_INVALID_RESPONSE"
+    | "ERR_REDIS_INVALID_RESPONSE_TYPE"
+    | "ERR_REDIS_INVALID_SIMPLE_STRING"
+    | "ERR_REDIS_INVALID_STATE"
+    | "ERR_REDIS_INVALID_USERNAME"
+    | "ERR_REDIS_TLS_NOT_AVAILABLE"
+    | "ERR_REDIS_TLS_UPGRADE_FAILED";
+
+  /**
+   * Errors produced by Bun's native Redis client.
+   *
+   * Native Redis failures are instances of `Bun.RedisError` and include one of
+   * the `ERR_REDIS_*` error codes.
+   */
+  export class RedisError extends Error {
+    readonly name: "RedisError";
+    readonly code: RedisErrorCode;
+
+    constructor(message?: string, options?: ErrorOptions & { code?: RedisErrorCode });
+  }
+
   export interface RedisOptions {
     /**
      * Connection timeout in milliseconds
@@ -86,7 +120,9 @@ declare module "bun" {
     /**
      * Callback fired when the client disconnects from the Redis server
      *
-     * @param error The error that caused the disconnection
+     * @param error The error that caused the disconnection. This is usually a
+     * `Bun.RedisError`, but transport setup failures may surface as other
+     * `Error` instances.
      */
     onclose: ((this: RedisClient, error: Error) => void) | null;
 

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -42,6 +42,7 @@
 #include "BunObjectModule.h"
 #include "JSCookie.h"
 #include "JSCookieMap.h"
+#include "RedisError.h"
 #include "Secrets.h"
 
 #ifdef WIN32
@@ -387,6 +388,12 @@ static JSValue constructBunShell(VM& vm, JSObject* bunObject)
     bunShell->putDirect(vm, JSC::Identifier::fromString(vm, "ShellError"_s), ShellError.getObject(), JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | 0);
 
     return bunShell;
+}
+
+static JSValue constructRedisError(VM& vm, JSObject* bunObject)
+{
+    auto* globalObject = jsCast<Zig::GlobalObject*>(bunObject->globalObject());
+    return globalObject->m_RedisErrorConstructor.getInitializedOnMainThread(globalObject);
 }
 
 static JSValue constructDNSObject(VM& vm, JSObject* bunObject)
@@ -998,6 +1005,7 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
     plugin                                         constructPluginObject                                               ReadOnly|DontDelete|PropertyCallback
     randomUUIDv7                                   Bun__randomUUIDv7                                                   DontDelete|Function 2
     randomUUIDv5                                   Bun__randomUUIDv5                                                   DontDelete|Function 3
+    RedisError                                     constructRedisError                                                 DontDelete|PropertyCallback
     readableStreamToArray                          JSBuiltin                                                           Builtin|Function 1
     readableStreamToArrayBuffer                    JSBuiltin                                                           Builtin|Function 1
     readableStreamToBytes                          JSBuiltin                                                           Builtin|Function 1

--- a/src/bun.js/bindings/BunObject.h
+++ b/src/bun.js/bindings/BunObject.h
@@ -17,5 +17,6 @@ JSC::JSObject* createBunObject(VM& vm, JSObject* globalObject);
 
 JSC::JSObject* BunShell(JSGlobalObject* globalObject);
 JSC::JSValue ShellError(JSGlobalObject* globalObject);
+JSC::JSObject* createRedisErrorConstructor(VM& vm, JSGlobalObject* globalObject);
 
 }

--- a/src/bun.js/bindings/ErrorCode.cpp
+++ b/src/bun.js/bindings/ErrorCode.cpp
@@ -28,6 +28,7 @@
 #include "JSDOMExceptionHandling.h"
 #include <openssl/err.h>
 #include "ErrorCode.h"
+#include "RedisError.h"
 #include "ErrorStackTrace.h"
 #include "KeyObject.h"
 
@@ -188,6 +189,11 @@ static ErrorCodeCache* errorCache(Zig::GlobalObject* globalObject)
     return static_cast<ErrorCodeCache*>(globalObject->nodeErrorCache());
 }
 
+static bool isRedisErrorName(WTF::ASCIILiteral name)
+{
+    return name == "RedisError"_s;
+}
+
 // clang-format on
 static Structure* createErrorStructure(JSC::VM& vm, JSGlobalObject* globalObject, JSC::ErrorType type, WTF::ASCIILiteral name, WTF::ASCIILiteral code)
 {
@@ -200,6 +206,15 @@ JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, E
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* cache = errorCache(globalObject);
     const auto& data = errors[static_cast<size_t>(code)];
+    if (isRedisErrorName(data.name)) {
+        auto* createdError = Bun::createRedisErrorInstance(vm, globalObject, message, data.code, options);
+        if (auto* thrown_exception = scope.exception()) [[unlikely]] {
+            (void)scope.tryClearException();
+            return jsCast<JSObject*>(thrown_exception->value());
+        }
+        return createdError;
+    }
+
     if (!cache->internalField(static_cast<unsigned>(code))) {
         auto* structure = createErrorStructure(vm, globalObject, data.type, data.name, data.code);
         cache->internalField(static_cast<unsigned>(code)).set(vm, cache, structure);
@@ -234,6 +249,10 @@ JSObject* createError(VM& vm, JSC::JSGlobalObject* globalObject, ErrorCode code,
 
 JSObject* createError(VM& vm, JSC::JSGlobalObject* globalObject, ErrorCode code, JSValue message)
 {
+    const auto& data = errors[static_cast<size_t>(code)];
+    if (isRedisErrorName(data.name))
+        return Bun::createRedisErrorInstance(vm, globalObject, message, data.code);
+
     if (auto* zigGlobalObject = jsDynamicCast<Zig::GlobalObject*>(globalObject))
         return createError(vm, zigGlobalObject, code, message, jsUndefined());
 

--- a/src/bun.js/bindings/RedisError.cpp
+++ b/src/bun.js/bindings/RedisError.cpp
@@ -90,6 +90,7 @@ Structure* createRedisErrorStructure(VM& vm, JSGlobalObject* globalObject)
 
 JSObject* createRedisErrorInstance(VM& vm, JSGlobalObject* globalObject, JSValue message, ASCIILiteral code, JSValue options)
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
     Structure* structure;
     if (auto* zigGlobal = jsDynamicCast<Zig::GlobalObject*>(globalObject)) {
         structure = zigGlobal->m_RedisErrorStructure.getInitializedOnMainThread(globalObject);
@@ -98,6 +99,7 @@ JSObject* createRedisErrorInstance(VM& vm, JSGlobalObject* globalObject, JSValue
     }
 
     auto* error = ErrorInstance::create(globalObject, structure, message, options, nullptr, RuntimeType::TypeNothing, ErrorType::Error, true);
+    RETURN_IF_EXCEPTION(scope, nullptr);
     error->putDirect(
         vm,
         WebCore::builtinNames(vm).codePublicName(),
@@ -131,7 +133,9 @@ JSC_DEFINE_HOST_FUNCTION(functionRedisErrorConstructor, (JSGlobalObject * global
         }
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(createRedisErrorInstance(vm, globalObject, message, code, options)));
+    auto* error = createRedisErrorInstance(vm, globalObject, message, code, options);
+    RETURN_IF_EXCEPTION(scope, {});
+    RELEASE_AND_RETURN(scope, JSValue::encode(error));
 }
 
 JSObject* createRedisErrorConstructor(VM& vm, JSGlobalObject* globalObject)

--- a/src/bun.js/bindings/RedisError.cpp
+++ b/src/bun.js/bindings/RedisError.cpp
@@ -1,0 +1,155 @@
+#include "root.h"
+
+#include "RedisError.h"
+
+#include <array>
+#include <JavaScriptCore/BuiltinNames.h>
+#include <JavaScriptCore/Error.h>
+#include <JavaScriptCore/ErrorInstance.h>
+#include <JavaScriptCore/ErrorInstanceInlines.h>
+#include <JavaScriptCore/JSFunction.h>
+#include <JavaScriptCore/ObjectConstructor.h>
+#include "ZigGlobalObject.h"
+
+namespace Bun {
+
+using namespace JSC;
+using namespace WTF;
+
+static ASCIILiteral redisErrorCodeFromString(StringView view)
+{
+    static constexpr std::array<ASCIILiteral, 19> redisErrorCodes = {
+        "ERR_REDIS_AUTHENTICATION_FAILED"_s,
+        "ERR_REDIS_CONNECTION_CLOSED"_s,
+        "ERR_REDIS_CONNECTION_TIMEOUT"_s,
+        "ERR_REDIS_IDLE_TIMEOUT"_s,
+        "ERR_REDIS_INVALID_ARGUMENT"_s,
+        "ERR_REDIS_INVALID_ARRAY"_s,
+        "ERR_REDIS_INVALID_BULK_STRING"_s,
+        "ERR_REDIS_INVALID_COMMAND"_s,
+        "ERR_REDIS_INVALID_DATABASE"_s,
+        "ERR_REDIS_INVALID_ERROR_STRING"_s,
+        "ERR_REDIS_INVALID_INTEGER"_s,
+        "ERR_REDIS_INVALID_PASSWORD"_s,
+        "ERR_REDIS_INVALID_RESPONSE"_s,
+        "ERR_REDIS_INVALID_RESPONSE_TYPE"_s,
+        "ERR_REDIS_INVALID_SIMPLE_STRING"_s,
+        "ERR_REDIS_INVALID_STATE"_s,
+        "ERR_REDIS_INVALID_USERNAME"_s,
+        "ERR_REDIS_TLS_NOT_AVAILABLE"_s,
+        "ERR_REDIS_TLS_UPGRADE_FAILED"_s,
+    };
+
+    for (auto code : redisErrorCodes) {
+        if (view == code)
+            return code;
+    }
+
+    return "ERR_REDIS_INVALID_RESPONSE"_s;
+}
+
+JSC_DEFINE_HOST_FUNCTION(RedisError_proto_toString, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto thisVal = callFrame->thisValue();
+
+    auto name = thisVal.get(globalObject, vm.propertyNames->name);
+    RETURN_IF_EXCEPTION(scope, {});
+    auto code = thisVal.get(globalObject, WebCore::builtinNames(vm).codePublicName());
+    RETURN_IF_EXCEPTION(scope, {});
+    auto message = thisVal.get(globalObject, vm.propertyNames->message);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    String nameString = name.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    String codeString = code.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    String messageString = message.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    return JSValue::encode(jsString(vm, makeString(nameString, " ["_s, codeString, "]: "_s, messageString)));
+}
+
+static JSObject* createRedisErrorPrototype(VM& vm, JSGlobalObject* globalObject)
+{
+    auto* prototype = JSC::constructEmptyObject(globalObject, globalObject->errorPrototype());
+    prototype->putDirect(vm, vm.propertyNames->name, jsString(vm, String("RedisError"_s)), 0);
+    prototype->putDirect(
+        vm,
+        vm.propertyNames->toString,
+        JSC::JSFunction::create(vm, globalObject, 0, "toString"_s, RedisError_proto_toString, JSC::ImplementationVisibility::Private),
+        0);
+    return prototype;
+}
+
+Structure* createRedisErrorStructure(VM& vm, JSGlobalObject* globalObject)
+{
+    return ErrorInstance::createStructure(vm, globalObject, createRedisErrorPrototype(vm, globalObject));
+}
+
+JSObject* createRedisErrorInstance(VM& vm, JSGlobalObject* globalObject, JSValue message, ASCIILiteral code, JSValue options)
+{
+    Structure* structure;
+    if (auto* zigGlobal = jsDynamicCast<Zig::GlobalObject*>(globalObject)) {
+        structure = zigGlobal->m_RedisErrorStructure.getInitializedOnMainThread(globalObject);
+    } else {
+        structure = createRedisErrorStructure(vm, globalObject);
+    }
+
+    auto* error = ErrorInstance::create(globalObject, structure, message, options, nullptr, RuntimeType::TypeNothing, ErrorType::Error, true);
+    error->putDirect(
+        vm,
+        WebCore::builtinNames(vm).codePublicName(),
+        jsString(vm, String(code)),
+        PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | 0);
+    return error;
+}
+
+JSC_DEFINE_HOST_FUNCTION(functionRedisErrorConstructor, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue message = callFrame->argumentCount() > 0 ? callFrame->uncheckedArgument(0) : jsEmptyString(vm);
+    JSValue options = callFrame->argumentCount() > 1 ? callFrame->uncheckedArgument(1) : jsUndefined();
+    if (!message.isString()) {
+        message = message.toString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    ASCIILiteral code = "ERR_REDIS_INVALID_RESPONSE"_s;
+    if (options.isObject()) {
+        JSValue codeValue = options.get(globalObject, WebCore::builtinNames(vm).codePublicName());
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!codeValue.isUndefined()) {
+            auto* codeString = codeValue.toString(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+            auto view = codeString->view(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+            code = redisErrorCodeFromString(view);
+        }
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(createRedisErrorInstance(vm, globalObject, message, code, options)));
+}
+
+JSObject* createRedisErrorConstructor(VM& vm, JSGlobalObject* globalObject)
+{
+    auto* constructor = JSFunction::create(
+        vm,
+        globalObject,
+        2,
+        "RedisError"_s,
+        functionRedisErrorConstructor,
+        ImplementationVisibility::Public,
+        NoIntrinsic,
+        functionRedisErrorConstructor);
+    auto* structure = defaultGlobalObject(globalObject)->m_RedisErrorStructure.getInitializedOnMainThread(globalObject);
+    auto* prototype = jsCast<JSObject*>(structure->storedPrototype());
+    constructor->putDirect(vm, vm.propertyNames->prototype, prototype, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly | 0);
+    prototype->putDirect(vm, vm.propertyNames->constructor, constructor, PropertyAttribute::DontEnum | 0);
+    return constructor;
+}
+
+}

--- a/src/bun.js/bindings/RedisError.h
+++ b/src/bun.js/bindings/RedisError.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace Bun {
+using namespace JSC;
+
+Structure* createRedisErrorStructure(VM& vm, JSGlobalObject* globalObject);
+JSObject* createRedisErrorConstructor(VM& vm, JSGlobalObject* globalObject);
+JSObject* createRedisErrorInstance(VM& vm, JSGlobalObject* globalObject, JSValue message, WTF::ASCIILiteral code, JSValue options = JSC::jsUndefined());
+}

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -78,6 +78,7 @@
 #include "JSAbortAlgorithm.h"
 #include "JSAbortController.h"
 #include "JSAbortSignal.h"
+#include "RedisError.h"
 #include "JSCompressionStream.h"
 #include "JSDecompressionStream.h"
 #include "JSBroadcastChannel.h"
@@ -1781,6 +1782,16 @@ void GlobalObject::finishCreation(VM& vm)
     m_JSS3FileStructure.initLater(
         [](const Initializer<Structure>& init) {
             init.set(Bun::createJSS3FileStructure(init.vm, init.owner));
+        });
+
+    m_RedisErrorConstructor.initLater(
+        [](const Initializer<JSObject>& init) {
+            init.set(Bun::createRedisErrorConstructor(init.vm, init.owner));
+        });
+
+    m_RedisErrorStructure.initLater(
+        [](const Initializer<Structure>& init) {
+            init.set(Bun::createRedisErrorStructure(init.vm, init.owner));
         });
 
     m_S3ErrorStructure.initLater(

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -518,6 +518,8 @@ public:
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_processEnvObject)                                      \
                                                                                                              \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_JSS3FileStructure)                                    \
+    V(public, LazyPropertyOfGlobalObject<JSObject>, m_RedisErrorConstructor)                                 \
+    V(public, LazyPropertyOfGlobalObject<Structure>, m_RedisErrorStructure)                                  \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_S3ErrorStructure)                                     \
                                                                                                              \
     V(public, JSC::LazyClassStructure, m_JSStatsClassStructure)                                              \

--- a/test/integration/bun-types/fixture/redis.ts
+++ b/test/integration/bun-types/fixture/redis.ts
@@ -2,6 +2,16 @@ import { expectType } from "./utilities";
 
 expectType(Bun.redis.publish("hello", "world")).is<Promise<number>>();
 
+const constructedRedisError = new Bun.RedisError("test", { code: "ERR_REDIS_CONNECTION_CLOSED" });
+expectType(constructedRedisError.name).is<"RedisError">();
+expectType(constructedRedisError.code).is<Bun.RedisErrorCode>();
+
+const causedRedisError = new Bun.RedisError("test", {
+  code: "ERR_REDIS_CONNECTION_CLOSED",
+  cause: new Error("cause"),
+});
+expectType(causedRedisError.cause).is<unknown>();
+
 const copy = await Bun.redis.duplicate();
 expectType(copy.connected).is<boolean>();
 expectType(copy).is<Bun.RedisClient>();
@@ -11,6 +21,18 @@ const listener: Bun.RedisClient.StringPubSubListener = (message, channel) => {
   expectType(channel).is<string>();
 };
 Bun.redis.subscribe("hello", listener);
+
+const onclose: NonNullable<Bun.RedisClient["onclose"]> = function (error) {
+  expectType(this).is<Bun.RedisClient>();
+  expectType(error).is<Error>();
+};
+Bun.redis.onclose = onclose;
+
+declare const maybeRedisError: unknown;
+if (maybeRedisError instanceof Bun.RedisError) {
+  expectType(maybeRedisError).is<Bun.RedisError>();
+  expectType(maybeRedisError.code).is<Bun.RedisErrorCode>();
+}
 
 // Buffer subscriptions are not yet implemented
 // const bufferListener: Bun.RedisClient.BufferPubSubListener = (message, channel) => {

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -27,6 +27,7 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(false).toBe(true); // Should not reach here
       } catch (error) {
         // Expect an error with connection closed message
+        expect(error).toBeInstanceOf(Bun.RedisError);
         expect(error.message).toMatch(/connection closed|socket closed|failed to connect/i);
       } finally {
         // Cleanup
@@ -85,9 +86,14 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         connectionTimeout: 2, // 2ms second timeout
         autoReconnect: false,
       });
-      expect(async () => {
+      try {
         await client.get("any-key");
-      }).toThrowErrorMatchingInlineSnapshot(`"Connection timeout reached after 2ms"`);
+        expect.unreachable();
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(Bun.RedisError);
+        expect(error.code).toBe("ERR_REDIS_CONNECTION_TIMEOUT");
+        expect(error.message).toBe("Connection timeout reached after 2ms");
+      }
     });
 
     test("should report correct connected status", async () => {

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -93,6 +93,8 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(error).toBeInstanceOf(Bun.RedisError);
         expect(error.code).toBe("ERR_REDIS_CONNECTION_TIMEOUT");
         expect(error.message).toBe("Connection timeout reached after 2ms");
+      } finally {
+        await client.close();
       }
     });
 

--- a/test/js/valkey/reliability/redis-error.test.ts
+++ b/test/js/valkey/reliability/redis-error.test.ts
@@ -2,7 +2,8 @@ import { RedisClient } from "bun";
 import { expect, test } from "bun:test";
 
 test("should expose Bun.RedisError as a runtime constructor", () => {
-  expect(Bun.RedisError).toBe(Bun.RedisError);
+  expect(typeof Bun.RedisError).toBe("function");
+  expect(Bun.RedisError.name).toBe("RedisError");
   expect(Bun.RedisError.prototype.constructor).toBe(Bun.RedisError);
 
   const cause = new Error("root cause");

--- a/test/js/valkey/reliability/redis-error.test.ts
+++ b/test/js/valkey/reliability/redis-error.test.ts
@@ -18,6 +18,19 @@ test("should expose Bun.RedisError as a runtime constructor", () => {
   expect(error.cause).toBe(cause);
 });
 
+test("should propagate exceptions from options while constructing Bun.RedisError", () => {
+  const thrown = new Error("boom");
+
+  expect(() => {
+    new Bun.RedisError("Connection closed", {
+      code: "ERR_REDIS_CONNECTION_CLOSED",
+      get cause() {
+        throw thrown;
+      },
+    });
+  }).toThrow(thrown);
+});
+
 test("should throw Bun.RedisError for connection failures", async () => {
   const client = new RedisClient("redis://localhost:12345", {
     connectionTimeout: 100,

--- a/test/js/valkey/reliability/redis-error.test.ts
+++ b/test/js/valkey/reliability/redis-error.test.ts
@@ -1,5 +1,37 @@
 import { RedisClient } from "bun";
 import { expect, test } from "bun:test";
+import { createServer } from "node:net";
+
+async function getUnusedPort() {
+  const server = createServer();
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to allocate TCP port");
+  }
+
+  const { port } = address;
+
+  await new Promise<void>((resolve, reject) => {
+    server.close(error => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+
+  return port;
+}
 
 test("should expose Bun.RedisError as a runtime constructor", () => {
   expect(typeof Bun.RedisError).toBe("function");
@@ -33,7 +65,8 @@ test("should propagate exceptions from options while constructing Bun.RedisError
 });
 
 test("should throw Bun.RedisError for connection failures", async () => {
-  const client = new RedisClient("redis://localhost:12345", {
+  const port = await getUnusedPort();
+  const client = new RedisClient(`redis://127.0.0.1:${port}`, {
     connectionTimeout: 100,
     autoReconnect: false,
   });

--- a/test/js/valkey/reliability/redis-error.test.ts
+++ b/test/js/valkey/reliability/redis-error.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "bun:test";
 import { createServer } from "node:net";
 
 async function getUnusedPort() {
-  const server = createServer();
+  await using server = createServer();
 
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
@@ -18,19 +18,7 @@ async function getUnusedPort() {
     throw new Error("Failed to allocate TCP port");
   }
 
-  const { port } = address;
-
-  await new Promise<void>((resolve, reject) => {
-    server.close(error => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve();
-    });
-  });
-
-  return port;
+  return address.port;
 }
 
 test("should expose Bun.RedisError as a runtime constructor", () => {

--- a/test/js/valkey/reliability/redis-error.test.ts
+++ b/test/js/valkey/reliability/redis-error.test.ts
@@ -1,0 +1,36 @@
+import { RedisClient } from "bun";
+import { expect, test } from "bun:test";
+
+test("should expose Bun.RedisError as a runtime constructor", () => {
+  expect(Bun.RedisError).toBe(Bun.RedisError);
+  expect(Bun.RedisError.prototype.constructor).toBe(Bun.RedisError);
+
+  const cause = new Error("root cause");
+  const error = new Bun.RedisError("Connection closed", {
+    code: "ERR_REDIS_CONNECTION_CLOSED",
+    cause,
+  });
+
+  expect(error).toBeInstanceOf(Bun.RedisError);
+  expect(error).toBeInstanceOf(Error);
+  expect(error.name).toBe("RedisError");
+  expect(error.code).toBe("ERR_REDIS_CONNECTION_CLOSED");
+  expect(error.cause).toBe(cause);
+});
+
+test("should throw Bun.RedisError for connection failures", async () => {
+  const client = new RedisClient("redis://localhost:12345", {
+    connectionTimeout: 100,
+    autoReconnect: false,
+  });
+
+  try {
+    await client.set("key", "value");
+    expect.unreachable();
+  } catch (error) {
+    expect(error).toBeInstanceOf(Bun.RedisError);
+    expect(error).toBeInstanceOf(Error);
+  } finally {
+    client.close();
+  }
+});

--- a/test/js/valkey/reliability/redis-error.test.ts
+++ b/test/js/valkey/reliability/redis-error.test.ts
@@ -44,6 +44,7 @@ test("should throw Bun.RedisError for connection failures", async () => {
   } catch (error) {
     expect(error).toBeInstanceOf(Bun.RedisError);
     expect(error).toBeInstanceOf(Error);
+    expect(error.code).toBe("ERR_REDIS_CONNECTION_CLOSED");
   } finally {
     client.close();
   }


### PR DESCRIPTION
### What does this PR do?

Adds a public `Bun.RedisError` runtime class for Redis client errors and wires native `ERR_REDIS_*` failures to create instances of it.

It also exposes Redis error typing in `bun-types` and adds runtime coverage for `new Bun.RedisError(...)` and `instanceof Bun.RedisError`.

### How did you verify your code works?

- Built `bun-debug` in Docker on `linux/arm64`
- Ran `./build/debug/bun-debug test test/js/valkey/reliability/redis-error.test.ts`
  - Result: `2 pass, 0 fail`
- Ran `./build/debug/bun-debug test test/js/valkey/reliability/connection-failures.test.ts`
  - Result: skipped in the container because `/var/run/docker.sock` was not available
- Previously ran `nix-shell shell.nix --run 'cd /Users/juan/Code/bun && bun test test/integration/bun-types/bun-types.test.ts'`\n  - Result: `11 pass, 0 fail`\n