### PR TITLE
fix: copy websocket subprotocol into owned storage

### DIFF
--- a/src/http/websocket_client/WebSocketUpgradeClient.zig
+++ b/src/http/websocket_client/WebSocketUpgradeClient.zig
@@ -830,7 +830,6 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
 
                                 if (this.outgoing_websocket) |ws| {
                                     var protocol_str = bun.String.cloneLatin1(protocol);
-                                    defer protocol_str.deref();
                                     ws.setProtocol(&protocol_str);
                                 }
                                 break :brk true;

--- a/src/http/websocket_client/WebSocketUpgradeClient.zig
+++ b/src/http/websocket_client/WebSocketUpgradeClient.zig
@@ -829,7 +829,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                                 if (!this.subprotocols.contains(protocol)) break :brk false;
 
                                 if (this.outgoing_websocket) |ws| {
-                                    var protocol_str = bun.String.init(protocol);
+                                    var protocol_str = bun.String.cloneLatin1(protocol);
                                     defer protocol_str.deref();
                                     ws.setProtocol(&protocol_str);
                                 }

--- a/test/js/web/websocket/websocket-subprotocol-strict.test.ts
+++ b/test/js/web/websocket/websocket-subprotocol-strict.test.ts
@@ -272,13 +272,32 @@ describe("WebSocket strict RFC 6455 subprotocol handling", () => {
     ws.binaryType = "arraybuffer";
 
     let protocolAtOpen = "";
+    let settled = false;
+
+    const resolveOnce = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+
+    const rejectOnce = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
 
     try {
       ws.onopen = () => {
         protocolAtOpen = ws.protocol;
       };
 
-      ws.onerror = reject;
+      ws.onerror = event => {
+        rejectOnce(new Error(`unexpected error event: ${event.type}`));
+      };
+
+      ws.onclose = event => {
+        rejectOnce(new Error(`unexpected close: ${event.code} ${event.reason} (protocolAtOpen=${protocolAtOpen})`));
+      };
 
       ws.onmessage = event => {
         try {
@@ -286,17 +305,17 @@ describe("WebSocket strict RFC 6455 subprotocol handling", () => {
           expect(protocolAtOpen).toBe(protocol);
           expect(event.data).toBeInstanceOf(ArrayBuffer);
           expect((event.data as ArrayBuffer).byteLength).toBe(payload.length);
-          resolve();
+          resolveOnce();
         } catch (error) {
-          reject(error);
+          rejectOnce(error);
         } finally {
-          ws.close();
+          ws.terminate();
         }
       };
 
       await promise;
     } finally {
-      ws.close();
+      ws.terminate();
     }
   });
 });

--- a/test/js/web/websocket/websocket-subprotocol-strict.test.ts
+++ b/test/js/web/websocket/websocket-subprotocol-strict.test.ts
@@ -60,6 +60,77 @@ describe("WebSocket strict RFC 6455 subprotocol handling", () => {
     };
   }
 
+  async function createSplitFrameServer(
+    protocol: string,
+    payload: Buffer,
+  ): Promise<{ port: number; [Symbol.asyncDispose]: () => Promise<void> }> {
+    const server = net.createServer();
+    let port: number;
+
+    await new Promise<void>(resolve => {
+      server.listen(0, () => {
+        port = (server.address() as any).port;
+        resolve();
+      });
+    });
+
+    server.on("connection", socket => {
+      let requestData = "";
+      let upgraded = false;
+
+      socket.on("error", () => {});
+
+      socket.on("data", data => {
+        if (upgraded) return;
+
+        requestData += data.toString("latin1");
+
+        if (!requestData.includes("\r\n\r\n")) {
+          return;
+        }
+
+        upgraded = true;
+
+        const lines = requestData.split("\r\n");
+        let websocketKey = "";
+
+        for (const line of lines) {
+          if (line.startsWith("Sec-WebSocket-Key:")) {
+            websocketKey = line.split(":")[1].trim();
+            break;
+          }
+        }
+
+        const acceptKey = crypto
+          .createHash("sha1")
+          .update(websocketKey + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+          .digest("base64");
+
+        const response = [
+          "HTTP/1.1 101 Switching Protocols",
+          "Upgrade: websocket",
+          "Connection: Upgrade",
+          `Sec-WebSocket-Accept: ${acceptKey}`,
+          `Sec-WebSocket-Protocol: ${protocol}`,
+          "\r\n",
+        ].join("\r\n");
+
+        socket.write(response);
+
+        const frameHeader = Buffer.from([0x82, 0x7e, payload.length >> 8, payload.length & 0xff]);
+        socket.write(frameHeader);
+        socket.write(payload);
+      });
+    });
+
+    return {
+      port: port!,
+      [Symbol.asyncDispose]: async () => {
+        server.close();
+      },
+    };
+  }
+
   async function expectConnectionFailure(port: number, protocols: string[], expectedCode = 1002) {
     const { promise: closePromise, resolve: resolveClose } = Promise.withResolvers();
 
@@ -187,5 +258,45 @@ describe("WebSocket strict RFC 6455 subprotocol handling", () => {
   it("should handle protocol with dots", async () => {
     await using server = await createTestServer(["Sec-WebSocket-Protocol: com.example.chat"]);
     await expectConnectionSuccess(server.port, ["com.example.chat", "other"], "com.example.chat");
+  });
+
+  it("should keep protocol stable after receiving a split frame", async () => {
+    const protocol = "v1.kernel.websocket.jupyter.org";
+    // 178 bytes fully overwrote the negotiated protocol string before the fix.
+    const payload = Buffer.alloc(178, "A");
+
+    await using server = await createSplitFrameServer(protocol, payload);
+
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const ws = new WebSocket(`ws://localhost:${server.port}`, [protocol]);
+    ws.binaryType = "arraybuffer";
+
+    let protocolAtOpen = "";
+
+    try {
+      ws.onopen = () => {
+        protocolAtOpen = ws.protocol;
+      };
+
+      ws.onerror = reject;
+
+      ws.onmessage = event => {
+        try {
+          expect(ws.protocol).toBe(protocol);
+          expect(protocolAtOpen).toBe(protocol);
+          expect(event.data).toBeInstanceOf(ArrayBuffer);
+          expect((event.data as ArrayBuffer).byteLength).toBe(payload.length);
+          resolve();
+        } catch (error) {
+          reject(error);
+        } finally {
+          ws.close();
+        }
+      };
+
+      await promise;
+    } finally {
+      ws.close();
+    }
   });
 });


### PR DESCRIPTION
Fixes #28014

This copies the negotiated websocket subprotocol into owned storage before exposing it on `WebSocket.protocol`.

Without the copy, the selected protocol can alias the HTTP upgrade response buffer and later be overwritten by websocket frame bytes. A minimal raw websocket repro is included in the linked issue.

Change:

```diff
- var protocol_str = bun.String.init(protocol);
+ var protocol_str = bun.String.cloneLatin1(protocol);
```

Verification:

- reproduced on stock Bun 1.3.10 with a raw split-frame websocket server
- rebuilt Bun with this one-line change
- verified patched `bun-debug` keeps `WebSocket.protocol` stable under the same repro
