### PR TITLE
fix(fs): preserve sub-millisecond precision in stat *Ms properties

### DIFF
--- a/src/bun.js/node/Stat.zig
+++ b/src/bun.js/node/Stat.zig
@@ -41,10 +41,11 @@ pub fn StatType(comptime big: bool) type {
                 return @as(i64, sec * std.time.ms_per_s) +|
                     @as(i64, @divTrunc(nsec, std.time.ns_per_ms));
             } else {
-                return @floatFromInt(bun.timespec.ms(&bun.timespec{
-                    .sec = @intCast(tv_sec),
-                    .nsec = @intCast(tv_nsec),
-                }));
+                // Use floating-point arithmetic to preserve sub-millisecond precision.
+                // Node.js returns fractional milliseconds (e.g. 1773248895434.0544).
+                const sec_ms: f64 = @as(f64, @floatFromInt(tv_sec)) * 1000.0;
+                const nsec_ms: f64 = @as(f64, @floatFromInt(tv_nsec)) / 1_000_000.0;
+                return sec_ms + nsec_ms;
             }
         }
 

--- a/test/regression/issue/28017.test.ts
+++ b/test/regression/issue/28017.test.ts
@@ -23,9 +23,9 @@ test("fs.stat *Ms properties preserve sub-millisecond precision", async () => {
     expect(Number.isInteger(s.atimeMs)).toBe(false);
     expect(Number.isInteger(s.mtimeMs)).toBe(false);
 
-    // Verify the values match what we set (within floating-point tolerance)
+    // Verify the values match what we set (within microsecond tolerance)
     const expectedMs = fractionalTime * 1000; // 1700000000123.456
-    expect(s.atimeMs).toBeCloseTo(expectedMs, 0);
-    expect(s.mtimeMs).toBeCloseTo(expectedMs, 0);
+    expect(s.atimeMs).toBeCloseTo(expectedMs, 3);
+    expect(s.mtimeMs).toBeCloseTo(expectedMs, 3);
   }
 });

--- a/test/regression/issue/28017.test.ts
+++ b/test/regression/issue/28017.test.ts
@@ -1,24 +1,31 @@
 import { expect, test } from "bun:test";
-import { statSync } from "fs";
+import { statSync, utimesSync } from "fs";
 import { stat } from "fs/promises";
+import { tempDir } from "harness";
+import { join } from "path";
 
 test("fs.stat *Ms properties preserve sub-millisecond precision", async () => {
-  // Use the test file itself as the target
-  const stats = statSync(import.meta.path);
-  const asyncStats = await stat(import.meta.path);
+  using dir = tempDir("stat-ms-precision", {
+    "test.txt": "hello",
+  });
 
-  for (const s of [stats, asyncStats]) {
-    // At least one of the *Ms properties should have a fractional component,
-    // since nanosecond-precision filesystems almost always produce non-integer ms values.
-    const msValues = [s.mtimeMs, s.atimeMs, s.ctimeMs, s.birthtimeMs];
-    const hasFractional = msValues.some(v => !Number.isInteger(v));
-    expect(hasFractional).toBe(true);
+  const filePath = join(String(dir), "test.txt");
 
-    // All *Ms values should be finite positive numbers
-    for (const v of msValues) {
-      expect(typeof v).toBe("number");
-      expect(Number.isFinite(v)).toBe(true);
-      expect(v).toBeGreaterThan(0);
-    }
+  // Set known fractional timestamps: 1700000000.123456 seconds = 1700000000123.456 ms
+  const fractionalTime = 1700000000.123456;
+  utimesSync(filePath, fractionalTime, fractionalTime);
+
+  const syncStats = statSync(filePath);
+  const asyncStats = await stat(filePath);
+
+  for (const s of [syncStats, asyncStats]) {
+    // atimeMs and mtimeMs should have fractional milliseconds
+    expect(Number.isInteger(s.atimeMs)).toBe(false);
+    expect(Number.isInteger(s.mtimeMs)).toBe(false);
+
+    // Verify the values match what we set (within floating-point tolerance)
+    const expectedMs = fractionalTime * 1000; // 1700000000123.456
+    expect(s.atimeMs).toBeCloseTo(expectedMs, 0);
+    expect(s.mtimeMs).toBeCloseTo(expectedMs, 0);
   }
 });

--- a/test/regression/issue/28017.test.ts
+++ b/test/regression/issue/28017.test.ts
@@ -11,21 +11,24 @@ test("fs.stat *Ms properties preserve sub-millisecond precision", async () => {
 
   const filePath = join(String(dir), "test.txt");
 
-  // Set known fractional timestamps: 1700000000.123456 seconds = 1700000000123.456 ms
-  const fractionalTime = 1700000000.123456;
+  // Set known fractional timestamps: 1700000000.5005 seconds = 1700000000500.5 ms
+  // Using .5005 (500.5ms) ensures clear sub-millisecond component (.5ms)
+  // that survives filesystem round-trip even with microsecond-precision utimes.
+  const fractionalTime = 1700000000.5005;
   utimesSync(filePath, fractionalTime, fractionalTime);
 
   const syncStats = statSync(filePath);
   const asyncStats = await stat(filePath);
+
+  const expectedMs = fractionalTime * 1000; // 1700000000500.5
 
   for (const s of [syncStats, asyncStats]) {
     // atimeMs and mtimeMs should have fractional milliseconds
     expect(Number.isInteger(s.atimeMs)).toBe(false);
     expect(Number.isInteger(s.mtimeMs)).toBe(false);
 
-    // Verify the values match what we set (within microsecond tolerance)
-    const expectedMs = fractionalTime * 1000; // 1700000000123.456
-    expect(s.atimeMs).toBeCloseTo(expectedMs, 3);
-    expect(s.mtimeMs).toBeCloseTo(expectedMs, 3);
+    // Verify the values match what we set (within 0.05ms / 50 microsecond tolerance)
+    expect(s.atimeMs).toBeCloseTo(expectedMs, 1);
+    expect(s.mtimeMs).toBeCloseTo(expectedMs, 1);
   }
 });

--- a/test/regression/issue/28017.test.ts
+++ b/test/regression/issue/28017.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { statSync } from "fs";
+import { stat } from "fs/promises";
+
+test("fs.stat *Ms properties preserve sub-millisecond precision", async () => {
+  // Use the test file itself as the target
+  const stats = statSync(import.meta.path);
+  const asyncStats = await stat(import.meta.path);
+
+  for (const s of [stats, asyncStats]) {
+    // At least one of the *Ms properties should have a fractional component,
+    // since nanosecond-precision filesystems almost always produce non-integer ms values.
+    const msValues = [s.mtimeMs, s.atimeMs, s.ctimeMs, s.birthtimeMs];
+    const hasFractional = msValues.some(v => !Number.isInteger(v));
+    expect(hasFractional).toBe(true);
+
+    // All *Ms values should be finite positive numbers
+    for (const v of msValues) {
+      expect(typeof v).toBe("number");
+      expect(Number.isFinite(v)).toBe(true);
+      expect(v).toBeGreaterThan(0);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- Fix `fs.stat` truncating sub-millisecond precision from `mtimeMs`, `atimeMs`, `ctimeMs`, and `birthtimeMs` properties
- The non-BigInt path in `toTimeMS()` was using `bun.timespec.ms()` which performs integer division, losing the nanosecond remainder
- Switch to floating-point arithmetic so fractional milliseconds are preserved, matching Node.js behavior

## Before
```
$ bun mtime-test.js
mtimeMs: 1773248895434
```

## After
```
$ bun mtime-test.js
mtimeMs: 1773248895434.0544
```

## Test plan
- [x] Added regression test `test/regression/issue/28017.test.ts` that verifies `*Ms` properties have fractional components
- [x] Test fails with system bun (`USE_SYSTEM_BUN=1`) and passes with debug build
- [x] Existing stat tests (`fs-stats-truncate.test.ts`) still pass

Closes #28017
Closes #21943 
🤖 Generated with [Claude Code](https://claude.com/claude-code)