### PR TITLE
fix(http): don't inject Content-Length into body for HTTP/1.0 streaming responses

### DIFF
--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -166,7 +166,7 @@ public:
                 writeMark();
 
                 /* WebSocket upgrades does not allow content-length */
-                if (allowContentLength) {
+                if (allowContentLength && !(httpResponseData->state & HttpResponseData<SSL>::HTTP_WRITE_CALLED)) {
                     /* Even zero is a valid content-length */
                     Super::write("Content-Length: ", 16);
                     writeUnsigned64(totalSize);

--- a/test/regression/issue/28019.test.ts
+++ b/test/regression/issue/28019.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test";
+import net from "node:net";
+
+// Regression test for https://github.com/oven-sh/bun/issues/28019
+// Bun.serve was injecting "Content-Length: <n>" into the response body
+// for large streaming responses over HTTP/1.0.
+test("HTTP/1.0 streaming response should not inject Content-Length into body", async () => {
+  const totalChunks = 10_000;
+  const chunkData = "Hello Bun!\n";
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch() {
+      let sent = 0;
+      return new Response(
+        new ReadableStream({
+          type: "bytes",
+          pull(ctrl) {
+            if (sent < totalChunks) {
+              ctrl.enqueue(Buffer.from(chunkData));
+              sent++;
+            } else {
+              ctrl.close();
+            }
+          },
+        }),
+      );
+    },
+  });
+
+  const body = await new Promise<string>((resolve, reject) => {
+    let data = "";
+    const socket = net.connect(server.port, "localhost", () => {
+      socket.write(`GET / HTTP/1.0\r\nHost: localhost\r\n\r\n`);
+    });
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk: string) => {
+      data += chunk;
+    });
+    socket.on("end", () => {
+      // Strip HTTP headers from response
+      const headerEnd = data.indexOf("\r\n\r\n");
+      if (headerEnd === -1) {
+        reject(new Error("No header terminator found in response"));
+        return;
+      }
+      resolve(data.slice(headerEnd + 4));
+    });
+    socket.on("error", reject);
+  });
+
+  // The body should be exactly totalChunks repetitions of chunkData
+  const expectedLength = totalChunks * chunkData.length;
+  expect(body.length).toBe(expectedLength);
+
+  // Verify no "Content-Length" text appears anywhere in the body
+  expect(body).not.toContain("Content-Length");
+
+  // Verify content is correct (spot-check first and last lines)
+  expect(body.startsWith("Hello Bun!\n")).toBe(true);
+  expect(body.endsWith("Hello Bun!\n")).toBe(true);
+});


### PR DESCRIPTION
## Summary
- Fixes a bug where `Bun.serve` would inject `Content-Length: <n>\r\n\r\n` into the **response body** (not headers) for large streaming responses over HTTP/1.0
- The root cause was in uWebSockets `internalEnd()` — when `write()` had already been called (flushing headers), `end()` would still write a Content-Length header into the socket, which ended up in the body
- The fix adds a guard: only write Content-Length if `HTTP_WRITE_CALLED` is not set (i.e., headers haven't been flushed yet)

## Test plan
- [x] Added regression test `test/regression/issue/28019.test.ts`
- [x] Test sends an HTTP/1.0 request to a streaming ReadableStream response and verifies no `Content-Length` text appears in the body
- [x] Test fails on system bun (unfixed), passes with debug build (fixed)

Closes #28019

🤖 Generated with [Claude Code](https://claude.com/claude-code)