### PR TITLE
fix(glob): match dot files when pattern explicitly starts with '.'

### DIFF
--- a/src/glob/GlobWalker.zig
+++ b/src/glob/GlobWalker.zig
@@ -1338,7 +1338,7 @@ pub fn GlobWalker_(
             is_last: bool,
             add: *bool,
         ) ?u32 {
-            if (!this.dot and GlobWalker.startsWithDot(entry_name)) return null;
+            if (!this.dot and GlobWalker.startsWithDot(entry_name) and !GlobWalker.patternStartsWithExplicitDot(pattern, this.pattern)) return null;
             if (is_ignored(entry_name)) return null;
 
             // Handle double wildcard `**`, this could possibly
@@ -1421,7 +1421,7 @@ pub fn GlobWalker_(
             filepath: []const u8,
         ) bool {
             log("matchPatternImpl: {s}", .{filepath});
-            if (!this.dot and GlobWalker.startsWithDot(filepath)) return false;
+            if (!this.dot and GlobWalker.startsWithDot(filepath) and !GlobWalker.patternStartsWithExplicitDot(pattern_component, this.pattern)) return false;
             if (is_ignored(filepath)) return false;
 
             return switch (pattern_component.syntax_hint) {
@@ -1521,6 +1521,14 @@ pub fn GlobWalker_(
 
         inline fn startsWithDot(filepath: []const u8) bool {
             return filepath.len > 0 and filepath[0] == '.';
+        }
+
+        /// Returns true if the pattern component starts with an explicit dot literal.
+        /// When a pattern explicitly starts with '.', it should match dot files
+        /// even when dot mode is disabled, matching standard glob behavior (e.g. minimatch).
+        inline fn patternStartsWithExplicitDot(component: *Component, pattern: []const u8) bool {
+            const slice = component.patternSlice(pattern);
+            return slice.len > 1 and slice[0] == '.' and slice[1] != '.' and slice[1] != '/';
         }
 
         const syntax_tokens = "*[{?!";

--- a/test/regression/issue/28021.test.ts
+++ b/test/regression/issue/28021.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { globSync, mkdirSync, writeFileSync } from "node:fs";
+import { glob as asyncGlob } from "node:fs/promises";
+import { join } from "node:path";
+
+describe("fs.glob matches dot files with explicit dot patterns", () => {
+  function setup() {
+    const dir = tempDir("glob-dot-test", {
+      ".hidden": "hidden file",
+      ".hidden2": "another hidden",
+      "visible": "visible file",
+      "visible2": "another visible",
+    });
+    mkdirSync(join(String(dir), ".hidden-dir"), { recursive: true });
+    writeFileSync(join(String(dir), ".hidden-dir", "inside"), "inside hidden dir");
+    return dir;
+  }
+
+  async function collectAsync(pattern: string): Promise<string[]> {
+    const results: string[] = [];
+    for await (const match of asyncGlob(pattern)) {
+      results.push(match);
+    }
+    return results.sort();
+  }
+
+  function collectSync(pattern: string): string[] {
+    const results: string[] = [];
+    for (const match of globSync(pattern)) {
+      results.push(match);
+    }
+    return results.sort();
+  }
+
+  test("wildcard * should NOT match dot files", async () => {
+    using dir = setup();
+    const results = await collectAsync(join(String(dir), "*"));
+    expect(results.every(r => !r.includes("/."))).toBe(true);
+    expect(results.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test(".* pattern should match dot files (async)", async () => {
+    using dir = setup();
+    const results = await collectAsync(join(String(dir), ".*"));
+    const basenames = results.map(r => r.split("/").pop()!);
+    expect(basenames).toContain(".hidden");
+    expect(basenames).toContain(".hidden2");
+    expect(basenames).toContain(".hidden-dir");
+  });
+
+  test(".* pattern should match dot files (sync)", () => {
+    using dir = setup();
+    const results = collectSync(join(String(dir), ".*"));
+    const basenames = results.map(r => r.split("/").pop()!);
+    expect(basenames).toContain(".hidden");
+    expect(basenames).toContain(".hidden2");
+    expect(basenames).toContain(".hidden-dir");
+  });
+
+  test(".h* pattern should match dot files starting with .h", async () => {
+    using dir = setup();
+    const results = await collectAsync(join(String(dir), ".h*"));
+    expect(results.length).toBeGreaterThanOrEqual(2);
+    const basenames = results.map(r => r.split("/").pop()!);
+    expect(basenames).toContain(".hidden");
+    expect(basenames).toContain(".hidden2");
+  });
+
+  test("Bun.Glob with .* pattern and dot:false should match dot files", () => {
+    using dir = setup();
+    const cwd = String(dir);
+    const results = Array.from(new Bun.Glob(".*").scanSync({ cwd, onlyFiles: false })).sort();
+    expect(results).toContain(".hidden");
+    expect(results).toContain(".hidden2");
+    expect(results).toContain(".hidden-dir");
+  });
+
+  test("Bun.Glob with .h* pattern and dot:false should match dot files", () => {
+    using dir = setup();
+    const cwd = String(dir);
+    const results = Array.from(new Bun.Glob(".h*").scanSync({ cwd, onlyFiles: false })).sort();
+    expect(results).toContain(".hidden");
+    expect(results).toContain(".hidden2");
+    expect(results).toContain(".hidden-dir");
+  });
+
+  test("Bun.Glob with * and dot:false should NOT match dot files", () => {
+    using dir = setup();
+    const cwd = String(dir);
+    const results = Array.from(new Bun.Glob("*").scanSync({ cwd }));
+    expect(results.every(r => !r.startsWith("."))).toBe(true);
+  });
+
+  test("Bun.Glob with literal .hidden and dot:false should match", () => {
+    using dir = setup();
+    const cwd = String(dir);
+    const results = Array.from(new Bun.Glob(".hidden").scanSync({ cwd }));
+    expect(results).toContain(".hidden");
+  });
+});

--- a/test/regression/issue/28021.test.ts
+++ b/test/regression/issue/28021.test.ts
@@ -70,7 +70,7 @@ describe("fs.glob matches dot files with explicit dot patterns", () => {
   test("Bun.Glob with .* pattern and dot:false should match dot files", () => {
     using dir = setup();
     const cwd = String(dir);
-    const results = Array.from(new Bun.Glob(".*").scanSync({ cwd, onlyFiles: false })).sort();
+    const results = Array.from(new Bun.Glob(".*").scanSync({ cwd, dot: false, onlyFiles: false })).sort();
     expect(results).toContain(".hidden");
     expect(results).toContain(".hidden2");
     expect(results).toContain(".hidden-dir");
@@ -79,7 +79,7 @@ describe("fs.glob matches dot files with explicit dot patterns", () => {
   test("Bun.Glob with .h* pattern and dot:false should match dot files", () => {
     using dir = setup();
     const cwd = String(dir);
-    const results = Array.from(new Bun.Glob(".h*").scanSync({ cwd, onlyFiles: false })).sort();
+    const results = Array.from(new Bun.Glob(".h*").scanSync({ cwd, dot: false, onlyFiles: false })).sort();
     expect(results).toContain(".hidden");
     expect(results).toContain(".hidden2");
     expect(results).toContain(".hidden-dir");
@@ -88,14 +88,14 @@ describe("fs.glob matches dot files with explicit dot patterns", () => {
   test("Bun.Glob with * and dot:false should NOT match dot files", () => {
     using dir = setup();
     const cwd = String(dir);
-    const results = Array.from(new Bun.Glob("*").scanSync({ cwd }));
+    const results = Array.from(new Bun.Glob("*").scanSync({ cwd, dot: false }));
     expect(results.every(r => !r.startsWith("."))).toBe(true);
   });
 
   test("Bun.Glob with literal .hidden and dot:false should match", () => {
     using dir = setup();
     const cwd = String(dir);
-    const results = Array.from(new Bun.Glob(".hidden").scanSync({ cwd }));
+    const results = Array.from(new Bun.Glob(".hidden").scanSync({ cwd, dot: false }));
     expect(results).toContain(".hidden");
   });
 });

--- a/test/regression/issue/28021.test.ts
+++ b/test/regression/issue/28021.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { tempDir } from "harness";
 import { globSync, mkdirSync, writeFileSync } from "node:fs";
 import { glob as asyncGlob } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 describe("fs.glob matches dot files with explicit dot patterns", () => {
   function setup() {
@@ -36,14 +36,14 @@ describe("fs.glob matches dot files with explicit dot patterns", () => {
   test("wildcard * should NOT match dot files", async () => {
     using dir = setup();
     const results = await collectAsync(join(String(dir), "*"));
-    expect(results.every(r => !r.includes("/."))).toBe(true);
+    expect(results.every(r => !basename(r).startsWith("."))).toBe(true);
     expect(results.length).toBeGreaterThanOrEqual(2);
   });
 
   test(".* pattern should match dot files (async)", async () => {
     using dir = setup();
     const results = await collectAsync(join(String(dir), ".*"));
-    const basenames = results.map(r => r.split("/").pop()!);
+    const basenames = results.map(r => basename(r));
     expect(basenames).toContain(".hidden");
     expect(basenames).toContain(".hidden2");
     expect(basenames).toContain(".hidden-dir");
@@ -52,7 +52,7 @@ describe("fs.glob matches dot files with explicit dot patterns", () => {
   test(".* pattern should match dot files (sync)", () => {
     using dir = setup();
     const results = collectSync(join(String(dir), ".*"));
-    const basenames = results.map(r => r.split("/").pop()!);
+    const basenames = results.map(r => basename(r));
     expect(basenames).toContain(".hidden");
     expect(basenames).toContain(".hidden2");
     expect(basenames).toContain(".hidden-dir");
@@ -62,7 +62,7 @@ describe("fs.glob matches dot files with explicit dot patterns", () => {
     using dir = setup();
     const results = await collectAsync(join(String(dir), ".h*"));
     expect(results.length).toBeGreaterThanOrEqual(2);
-    const basenames = results.map(r => r.split("/").pop()!);
+    const basenames = results.map(r => basename(r));
     expect(basenames).toContain(".hidden");
     expect(basenames).toContain(".hidden2");
   });

--- a/test/regression/issue/28021.test.ts
+++ b/test/regression/issue/28021.test.ts
@@ -104,6 +104,8 @@ describe("fs.glob matches dot files with explicit dot patterns", () => {
     using dir = setup();
     const cwd = String(dir);
     const results = Array.from(new Bun.Glob("*").scanSync({ cwd, dot: false }));
+    expect(results).toContain("visible");
+    expect(results).toContain("visible2");
     expect(results.every(r => !r.startsWith("."))).toBe(true);
   });
 

--- a/test/regression/issue/28021.test.ts
+++ b/test/regression/issue/28021.test.ts
@@ -17,17 +17,22 @@ describe("fs.glob matches dot files with explicit dot patterns", () => {
     return dir;
   }
 
-  async function collectAsync(pattern: string): Promise<string[]> {
+  interface GlobOptions {
+    cwd?: string;
+    exclude?: ((ent: string) => boolean) | string[];
+  }
+
+  async function collectAsync(pattern: string, options?: GlobOptions): Promise<string[]> {
     const results: string[] = [];
-    for await (const match of asyncGlob(pattern)) {
+    for await (const match of asyncGlob(pattern, options)) {
       results.push(match);
     }
     return results.sort();
   }
 
-  function collectSync(pattern: string): string[] {
+  function collectSync(pattern: string, options?: GlobOptions): string[] {
     const results: string[] = [];
-    for (const match of globSync(pattern)) {
+    for (const match of globSync(pattern, options)) {
       results.push(match);
     }
     return results.sort();
@@ -65,6 +70,16 @@ describe("fs.glob matches dot files with explicit dot patterns", () => {
     const basenames = results.map(r => basename(r));
     expect(basenames).toContain(".hidden");
     expect(basenames).toContain(".hidden2");
+  });
+
+  test("fs.glob with cwd option and relative dot pattern", async () => {
+    using dir = setup();
+    const cwd = String(dir);
+    const results = await collectAsync(".*", { cwd });
+    const basenames = results.map(r => basename(r));
+    expect(basenames).toContain(".hidden");
+    expect(basenames).toContain(".hidden2");
+    expect(basenames).toContain(".hidden-dir");
   });
 
   test("Bun.Glob with .* pattern and dot:false should match dot files", () => {


### PR DESCRIPTION
## Summary

- Fixes `fs.glob` and `Bun.Glob` to match dot files when the glob pattern explicitly starts with a literal `.` (e.g. `.*`, `.hidden`, `.h*`), even when the `dot` option is `false`
- This matches standard glob behavior (minimatch, bash, Python glob) where explicit `.` in a pattern opts into dot file matching, while wildcards like `*` still skip dot files by default
- Adds `patternStartsWithExplicitDot` helper to `GlobWalker` and uses it in both `matchPatternDir` and `matchPatternImpl` to make the dot-file filter pattern-aware

Fixes #28021

## Test plan

- [x] Added regression test `test/regression/issue/28021.test.ts` with 8 test cases covering:
  - `*` still skips dot files (no regression)
  - `.*` matches dot files via `fs.glob` (async and sync)
  - `.h*` matches dot files starting with `.h`
  - `Bun.Glob(".*").scanSync()` with `dot: false` now matches dot files
  - `Bun.Glob(".h*").scanSync()` with `dot: false` now matches dot files
  - `Bun.Glob("*").scanSync()` still does NOT match dot files
  - `Bun.Glob(".hidden").scanSync()` matches the literal dot file
- [x] Tests fail with system Bun (5 failures), pass with debug build (0 failures)
- [x] All 26 existing `test/js/node/fs/glob.test.ts` tests pass
- [x] All 169 existing `test/js/bun/glob/scan.test.ts` tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)