### PR TITLE
Fix Windows vendor sub-builds leaking dynamic CRT (/MD)

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -40,6 +40,13 @@ endif()
 
 # --- MSVC runtime ---
 if(WIN32)
+  # CMP0091 NEW (Policies.cmake) makes CMake use this property instead of
+  # injecting /MD into CMAKE_<LANG>_FLAGS_<CONFIG>. Without it, CMake defaults
+  # to MultiThreadedDLL and appends -MD after our /MT, poisoning vendor libs
+  # with /DEFAULTLIB:msvcrt.lib. Set it explicitly so the property matches the
+  # raw /MT flags below.
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
   register_compiler_flags(
     DESCRIPTION "Use static MSVC runtime"
     /MTd ${DEBUG}

--- a/cmake/Globals.cmake
+++ b/cmake/Globals.cmake
@@ -784,7 +784,7 @@ function(register_cmake_command)
 
   set(MAKE_EFFECTIVE_ARGS -B${MAKE_BUILD_PATH} ${CMAKE_ARGS})
 
-  set(setFlags GENERATOR BUILD_TYPE)
+  set(setFlags GENERATOR BUILD_TYPE MSVC_RUNTIME_LIBRARY)
   set(appendFlags C_FLAGS CXX_FLAGS LINKER_FLAGS STATIC_LINKER_FLAGS EXE_LINKER_FLAGS SHARED_LINKER_FLAGS MODULE_LINKER_FLAGS)
   set(specialFlags POSITION_INDEPENDENT_CODE)
   set(flags ${setFlags} ${appendFlags} ${specialFlags})

--- a/test/js/bun/symbols.test.ts
+++ b/test/js/bun/symbols.test.ts
@@ -1,5 +1,5 @@
 import { $, semver } from "bun";
-import { test } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunExe } from "harness";
 
 const BUN_EXE = bunExe();
@@ -60,5 +60,98 @@ ${errors.join("\n")}
 
 To fix this, figure out which C math symbol is being used that causes it, and wrap it in workaround-missing-symbols.cpp.`);
     }
+  });
+}
+
+if (process.platform === "win32") {
+  // Allowlist of DLLs bun.exe may import (static or delay-load). All are
+  // Windows system DLLs that ship with the OS.
+  //
+  // If this test fails, bun.exe has gained a dependency on a non-system DLL
+  // (most commonly VCRUNTIME140.dll / api-ms-win-crt-*.dll from the dynamic
+  // MSVC CRT). This causes STATUS_DLL_NOT_FOUND on machines without the
+  // VC++ redistributable — bun must be fully statically linked.
+  //
+  // Common cause: a vendored CMake sub-build using CMP0091 NEW (implied by
+  // cmake_minimum_required ≥ 3.15) without setting MSVC_RUNTIME_LIBRARY,
+  // which defaults to /MD (dynamic CRT). Fix:
+  //   set_property(TARGET <name> PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  // or pass -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded to the sub-build.
+  const ALLOWED_DLL_IMPORTS = new Set([
+    "advapi32.dll",
+    "api-ms-win-core-synch-l1-2-0.dll", // forwards to kernel32; OS-provided (NOT api-ms-win-crt-*)
+    "bcrypt.dll",
+    "bcryptprimitives.dll",
+    "crypt32.dll",
+    "dbghelp.dll",
+    "iphlpapi.dll",
+    "kernel32.dll",
+    "ntdll.dll",
+    "ole32.dll",
+    "oleaut32.dll",
+    "shell32.dll",
+    "user32.dll",
+    "userenv.dll",
+    "winmm.dll",
+    "ws2_32.dll",
+    "wsock32.dll",
+  ]);
+
+  // vcruntime140_1.dll (__CxxFrameHandler4 only) is tolerated IF delay-loaded
+  // since it resolves lazily at first C++ unwind, not at process startup.
+  // BuildBun.cmake sets /delayload:VCRUNTIME140_1.dll for this reason.
+  // As a hard (static) import it would still break on machines without VC++ redist.
+  const ALLOWED_DELAY_ONLY = new Set(["vcruntime140_1.dll"]);
+
+  test("PE import table contains only allowlisted system DLLs", async () => {
+    const readobj = Bun.which("llvm-readobj");
+    if (!readobj) {
+      throw new Error("llvm-readobj not found. It ships with LLVM (required to build bun).");
+    }
+
+    // --coff-imports dumps both the static import table and the delay-load table.
+    //   Import {           ← static (hard dep, checked at process start)
+    //     Name: KERNEL32.dll
+    //   DelayImport {      ← delay-load (resolved on first call)
+    //     Name: ole32.dll
+    const output = await $`${readobj} --coff-imports ${BUN_EXE}`.text();
+
+    const imports: { dll: string; kind: "static" | "delay" }[] = [];
+    let currentKind: "static" | "delay" | null = null;
+    for (const line of output.split("\n")) {
+      if (/^Import\s*\{/.test(line)) currentKind = "static";
+      else if (/^DelayImport\s*\{/.test(line)) currentKind = "delay";
+      else if (currentKind) {
+        const m = line.match(/^\s*Name:\s*(\S+)/);
+        if (m) {
+          imports.push({ dll: m[1], kind: currentKind });
+          currentKind = null;
+        }
+      }
+    }
+
+    if (imports.length === 0) {
+      throw new Error("Failed to parse imports from llvm-readobj — parser broken?\n\n" + output.slice(0, 500));
+    }
+
+    const violations = imports.filter(({ dll, kind }) => {
+      const lower = dll.toLowerCase();
+      if (ALLOWED_DLL_IMPORTS.has(lower)) return false;
+      if (ALLOWED_DELAY_ONLY.has(lower) && kind === "delay") return false;
+      return true;
+    });
+
+    if (violations.length > 0) {
+      throw new Error(
+        `bun.exe imports non-allowlisted DLLs. This causes STATUS_DLL_NOT_FOUND on machines without VC++ redist.\n\n` +
+          Bun.inspect.table(violations, { colors: true }) +
+          `\nFull import list (${imports.length}):\n` +
+          imports.map(i => `  [${i.kind.padEnd(6)}] ${i.dll}`).join("\n") +
+          `\n\nCommon fix: a vendored CMake sub-build is missing MSVC_RUNTIME_LIBRARY — see comment at top of this test.`,
+      );
+    }
+
+    // Sanity check: we actually parsed something meaningful.
+    expect(imports.some(i => i.dll.toLowerCase() === "kernel32.dll")).toBe(true);
   });
 }


### PR DESCRIPTION
CMP0091 NEW defaults to `MultiThreadedDLL` and appends `-MD` after our `/MT`, so every `register_cmake_command` sub-build embeds `/DEFAULTLIB:msvcrt.lib` — currently masked only by linker library ordering. This sets `CMAKE_MSVC_RUNTIME_LIBRARY` explicitly, forwards it to sub-builds, and adds a PE import allowlist test so CI fails if `VCRUNTIME140.dll` or any other non-system DLL ever leaks into `bun.exe`.