### PR TITLE
fix(JSONL): honor start/end offsets for string input in parseChunk

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -887,12 +887,14 @@ declare module "bun" {
      *
      * When a `TypedArray` is passed, the bytes are parsed directly without
      * copying if the content is ASCII. Optional `start` and `end` parameters
-     * allow slicing without copying, and `read` will be a byte offset into
-     * the original typed array.
+     * select a window of the input without copying. For typed arrays these
+     * are byte offsets and `read` will be a byte offset into the original
+     * typed array. For strings these are character offsets and `read` will
+     * be a character offset into the original string.
      *
      * @param input The JSONL string or typed array to parse
-     * @param start Byte offset to start parsing from (typed array only, default: 0)
-     * @param end Byte offset to stop parsing at (typed array only, default: input.byteLength)
+     * @param start Offset to start parsing from (bytes for typed arrays, characters for strings, default: 0)
+     * @param end Offset to stop parsing at (bytes for typed arrays, characters for strings, default: input length)
      * @returns An object with `values`, `read`, `done`, and `error` properties
      *
      * @example
@@ -907,9 +909,8 @@ declare module "bun" {
      * }
      * ```
      */
-    export function parseChunk(input: string): ParseChunkResult;
     export function parseChunk(
-      input: NodeJS.TypedArray | DataView<ArrayBuffer> | ArrayBufferLike,
+      input: string | NodeJS.TypedArray | DataView<ArrayBuffer> | ArrayBufferLike,
       start?: number,
       end?: number,
     ): ParseChunkResult;

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -520,18 +520,13 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionJSONLParseChunk, (JSGlobalObject * globalObje
     size_t readBytes = 0;
     bool isTypedArray = arg.isCell() && isTypedArrayType(arg.asCell()->type());
 
-    if (isTypedArray) {
-        auto* view = jsCast<JSC::JSArrayBufferView*>(arg.asCell());
-        if (view->isDetached()) {
-            throwTypeError(globalObject, scope, "ArrayBuffer is detached"_s);
-            return {};
-        }
-        auto* data = static_cast<const uint8_t*>(view->vector());
-        size_t length = view->byteLength();
-
-        // Apply optional start/end offsets (byte offsets for typed arrays)
-        size_t start = 0;
-        size_t end = length;
+    // Apply optional start/end offsets (byte offsets for typed arrays, character offsets for strings).
+    // Populates start/end clamped to [0, length], with start <= end.
+    size_t start;
+    size_t end;
+    const auto parseOffsets = [&](size_t length) {
+        start = 0;
+        end = length;
 
         JSValue startArg = callFrame->argument(1);
         if (startArg.isNumber()) {
@@ -549,6 +544,17 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionJSONLParseChunk, (JSGlobalObject * globalObje
 
         if (start > end)
             start = end;
+    };
+
+    if (isTypedArray) {
+        auto* view = jsCast<JSC::JSArrayBufferView*>(arg.asCell());
+        if (view->isDetached()) {
+            throwTypeError(globalObject, scope, "ArrayBuffer is detached"_s);
+            return {};
+        }
+        auto* data = static_cast<const uint8_t*>(view->vector());
+        size_t length = view->byteLength();
+        parseOffsets(length);
 
         const uint8_t* sliceData = data + start;
         size_t sliceLen = end - start;
@@ -590,8 +596,16 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionJSONLParseChunk, (JSGlobalObject * globalObje
         RETURN_IF_EXCEPTION(scope, {});
         auto view = inputString->view(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
-        result = JSC::streamingJSONParse(globalObject, view, values);
-        readBytes = result.charactersConsumed;
+
+        size_t length = view->length();
+        parseOffsets(length);
+
+        if (start != 0 || end != length) {
+            result = JSC::streamingJSONParse(globalObject, view->substring(start, end - start), values);
+        } else {
+            result = JSC::streamingJSONParse(globalObject, view, values);
+        }
+        readBytes = start + result.charactersConsumed;
     }
 
     RETURN_IF_EXCEPTION(scope, {});

--- a/test/js/bun/jsonl/jsonl-parse.test.ts
+++ b/test/js/bun/jsonl/jsonl-parse.test.ts
@@ -735,10 +735,54 @@ describe("Bun.JSONL", () => {
         expect(result.values).toStrictEqual([]);
       });
 
-      test("start/end ignored for string input", () => {
-        // start/end are typed-array byte offsets; for strings, they're ignored
+      test("start offset works for string input (character offsets)", () => {
         const result = Bun.JSONL.parseChunk('{"a":1}\n{"b":2}\n', 8);
+        expect(result.values).toStrictEqual([{ b: 2 }]);
+        expect(result.read).toBe(15);
+      });
+
+      test("end offset works for string input", () => {
+        const input = '{"a":1}\n{"b":2}\n{"c":3}\n';
+        const result = Bun.JSONL.parseChunk(input, 0, 16);
         expect(result.values).toStrictEqual([{ a: 1 }, { b: 2 }]);
+      });
+
+      test("start+end window works for string input", () => {
+        const input = '{"a":1}\n{"b":2}\n{"c":3}\n';
+        const result = Bun.JSONL.parseChunk(input, 8, 16);
+        expect(result.values).toStrictEqual([{ b: 2 }]);
+        expect(result.read).toBe(15);
+      });
+
+      test("string: start equals end returns empty", () => {
+        const result = Bun.JSONL.parseChunk('{"a":1}\n', 5, 5);
+        expect(result.values).toStrictEqual([]);
+        expect(result.read).toBe(5);
+        expect(result.done).toBe(true);
+      });
+
+      test("string: error-recovery loop with start offset terminates", () => {
+        // Regression: previously start was ignored for strings, so an
+        // error-recovery loop that advanced the offset would re-parse the
+        // same position forever. Now offsets are honored and each iteration
+        // makes progress.
+        const input = '{"a":1}\n{bad\n{"c":3}\n';
+        const collected: unknown[] = [];
+        let offset = 0;
+        let iterations = 0;
+        while (offset < input.length) {
+          iterations++;
+          if (iterations > 10) throw new Error("infinite loop");
+          const r = Bun.JSONL.parseChunk(input, offset);
+          collected.push(...r.values);
+          if (!r.error || r.done || r.read >= input.length) break;
+          const nl = input.indexOf("\n", r.read);
+          if (nl === -1) break;
+          offset = nl + 1;
+          if (offset <= r.read) offset = r.read + 1; // guarantee progress
+        }
+        expect(collected).toStrictEqual([{ a: 1 }, { c: 3 }]);
+        expect(iterations).toBeLessThanOrEqual(4);
       });
 
       test("non-ASCII with start offset", () => {
@@ -747,6 +791,101 @@ describe("Bun.JSONL", () => {
         const firstValueBytes = encode('{"jp":"日本"}\n').byteLength;
         const result = Bun.JSONL.parseChunk(buf, firstValueBytes);
         expect(result.values).toStrictEqual([{ a: 1 }]);
+      });
+
+      describe("invalid offset inputs", () => {
+        const input = '{"a":1}\n{"b":2}\n';
+        const buf = encode(input);
+
+        test.each([
+          ["NaN start", NaN, undefined],
+          ["NaN end", undefined, NaN],
+          ["Infinity start", Infinity, undefined],
+          ["-Infinity start", -Infinity, undefined],
+          ["Infinity end", undefined, Infinity],
+          ["-Infinity end", 0, -Infinity],
+          ["negative start", -5, undefined],
+          ["negative end", 0, -3],
+          ["fractional start", 0.7, undefined],
+          ["huge start", Number.MAX_SAFE_INTEGER, undefined],
+          ["huge end", 0, Number.MAX_SAFE_INTEGER],
+        ])("%s does not crash (string)", (_, start, end) => {
+          // Non-finite and out-of-range offsets should be clamped/ignored,
+          // never cause UB or out-of-bounds reads.
+          const r = Bun.JSONL.parseChunk(input, start as number, end as number);
+          expect(Array.isArray(r.values)).toBe(true);
+          expect(r.read).toBeGreaterThanOrEqual(0);
+          expect(r.read).toBeLessThanOrEqual(input.length);
+        });
+
+        test.each([
+          ["NaN start", NaN, undefined],
+          ["NaN end", undefined, NaN],
+          ["Infinity start", Infinity, undefined],
+          ["-Infinity start", -Infinity, undefined],
+          ["Infinity end", undefined, Infinity],
+          ["-Infinity end", 0, -Infinity],
+          ["negative start", -5, undefined],
+          ["negative end", 0, -3],
+          ["fractional start", 0.7, undefined],
+          ["huge start", Number.MAX_SAFE_INTEGER, undefined],
+          ["huge end", 0, Number.MAX_SAFE_INTEGER],
+        ])("%s does not crash (Buffer)", (_, start, end) => {
+          const r = Bun.JSONL.parseChunk(buf, start as number, end as number);
+          expect(Array.isArray(r.values)).toBe(true);
+          expect(r.read).toBeGreaterThanOrEqual(0);
+          expect(r.read).toBeLessThanOrEqual(buf.byteLength);
+        });
+
+        test("NaN start is treated as 0 (string)", () => {
+          const r = Bun.JSONL.parseChunk(input, NaN);
+          expect(r.values).toStrictEqual([{ a: 1 }, { b: 2 }]);
+        });
+
+        test("NaN start is treated as 0 (Buffer)", () => {
+          const r = Bun.JSONL.parseChunk(buf, NaN);
+          expect(r.values).toStrictEqual([{ a: 1 }, { b: 2 }]);
+        });
+
+        test("Infinity start clamps to length (string)", () => {
+          const r = Bun.JSONL.parseChunk(input, Infinity);
+          expect(r.values).toStrictEqual([]);
+          expect(r.read).toBe(input.length);
+        });
+
+        test("Infinity start clamps to length (Buffer)", () => {
+          const r = Bun.JSONL.parseChunk(buf, Infinity);
+          expect(r.values).toStrictEqual([]);
+          expect(r.read).toBe(buf.byteLength);
+        });
+
+        test("Infinity end clamps to length (string)", () => {
+          const r = Bun.JSONL.parseChunk(input, 0, Infinity);
+          expect(r.values).toStrictEqual([{ a: 1 }, { b: 2 }]);
+        });
+
+        test("Infinity end clamps to length (Buffer)", () => {
+          const r = Bun.JSONL.parseChunk(buf, 0, Infinity);
+          expect(r.values).toStrictEqual([{ a: 1 }, { b: 2 }]);
+        });
+
+        test("-Infinity end is ignored (treated as full length)", () => {
+          // Negative end values are rejected by the (e >= 0) guard, so end
+          // stays at input.length. This matches "ignore garbage offsets".
+          const r = Bun.JSONL.parseChunk(input, 0, -Infinity);
+          expect(r.values).toStrictEqual([{ a: 1 }, { b: 2 }]);
+        });
+
+        test("negative end is ignored (Buffer)", () => {
+          const r = Bun.JSONL.parseChunk(buf, 0, -10);
+          expect(r.values).toStrictEqual([{ a: 1 }, { b: 2 }]);
+        });
+
+        test("start > end clamps start down to end", () => {
+          const r = Bun.JSONL.parseChunk(input, 10, 5);
+          expect(r.values).toStrictEqual([]);
+          expect(r.read).toBe(5);
+        });
       });
     });
   });


### PR DESCRIPTION
## What

`Bun.JSONL.parseChunk(input, start, end)` now honors `start`/`end` when `input` is a string. Previously these offsets only worked for typed arrays and were silently ignored for strings.

## Why

This broke error-recovery loops that call `parseChunk(data, offset)` to skip past a malformed line — with string input the offset was ignored, so the same bad position was re-parsed forever, causing an infinite loop with O(n²) heap growth from repeated `concat` calls.

## How

- Extracted the `start`/`end` clamping logic into a shared lambda `parseOffsets(length)`. This also fixes a latent bug where the code referenced `length` before it was defined.
- String path: call `parseOffsets(view->length())`, use `view->substring(start, end - start)` when offsets differ from defaults, return `read = start + charactersConsumed` so the offset is absolute into the original string (UTF-16 code-unit positions).
- Collapsed the two `.d.ts` overloads into one; JSDoc now documents byte-vs-character offset semantics.

## Tests

- String offset tests mirroring the existing typed-array offset suite
- Error-recovery loop regression test (terminates in ≤4 iterations instead of spinning forever)
- `test.each` suites for `NaN`, `Infinity`, `-Infinity`, negative, fractional, `Number.MAX_SAFE_INTEGER` offsets on both string and Buffer — all clamp correctly without crashing