### PR TITLE
fix(allocator): give MimallocArena a non-zero heap tag to prevent free-list corruption

### DIFF
--- a/src/allocators/MimallocArena.zig
+++ b/src/allocators/MimallocArena.zig
@@ -165,8 +165,14 @@ pub fn deinit(self: *Self) void {
     self.* = undefined;
 }
 
+/// Use a non-zero heap tag so that mimalloc's _mi_heap_by_tag routes
+/// reclaimed pages from dead threads to the backing heap (tag 0) instead
+/// of to this arena. Without this, mi_heap_destroy frees those reclaimed
+/// pages and their live blocks, corrupting the malloc free-list.
+const arena_heap_tag = 111;
+
 pub fn init() Self {
-    const mimalloc_heap = mimalloc.mi_heap_new() orelse bun.outOfMemory();
+    const mimalloc_heap = mimalloc.mi_heap_new_ex(arena_heap_tag, true, null) orelse bun.outOfMemory();
     if (comptime !safety_checks) return .{ .#heap = mimalloc_heap };
     const heap: Owned(*DebugHeap) = .new(.{
         .inner = mimalloc_heap,

--- a/src/bun.js/bindings/node/crypto/JSHash.cpp
+++ b/src/bun.js/bindings/node/crypto/JSHash.cpp
@@ -178,6 +178,9 @@ JSC_DEFINE_HOST_FUNCTION(jsHashProtoFuncUpdate, (JSC::JSGlobalObject * globalObj
         RETURN_IF_EXCEPTION(scope, {});
 
         auto* convertedView = jsDynamicCast<JSC::JSArrayBufferView*>(converted);
+        if (!convertedView) {
+            return Bun::ERR::CRYPTO_HASH_UPDATE_FAILED(scope, globalObject);
+        }
 
         if (!hash->update(std::span { reinterpret_cast<const uint8_t*>(convertedView->vector()), convertedView->byteLength() })) {
             return Bun::ERR::CRYPTO_HASH_UPDATE_FAILED(scope, globalObject);


### PR DESCRIPTION
## Summary

- Fix heap corruption caused by `MimallocArena` using `mi_heap_new()` with the default tag 0 (same as the backing heap). When worker threads exit, their abandoned pages are reclaimed by the arena instead of the backing heap, and `mi_heap_destroy` then frees live blocks, corrupting the malloc free-list.
- Use `mi_heap_new_ex` with a non-zero tag (111) so `_mi_heap_by_tag` routes reclaimed pages to the backing heap where they belong.
- Add null check for `jsDynamicCast` result in `jsHashProtoFuncUpdate` to prevent a potential null pointer dereference if `constructFromEncoding` fails.

## Test plan

- [x] `bun bd` compiles successfully
- [x] `bun bd test test/js/node/crypto/crypto.test.ts` — 369 tests pass
- [x] `bun bd test test/js/node/crypto/crypto-lazyhash.test.ts` — 2 tests pass
- [x] Hash update stress test with worker threads passes (10K hashes + 4 workers)

Fixes #28024

🤖 Generated with [Claude Code](https://claude.com/claude-code)