### PR TITLE
fix(fs): clear Strong handle in StatWatcher.finalize() to prevent GC race

### DIFF
--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -352,6 +352,15 @@ pub const StatWatcher = struct {
     pub fn finalize(this: *StatWatcher) void {
         log("Finalize\n", .{});
         this.closed = true;
+        // Clean up JS-thread-bound resources now, while we're still on the JS
+        // thread. If we defer this to deinit(), the WorkPool thread may be the
+        // one that triggers it, and calling HandleSet::deallocate() from a
+        // non-JS thread corrupts the HandleSet linked list (GH-28027).
+        if (this.persistent) {
+            this.persistent = false;
+        }
+        this.poll_ref.unref(this.ctx);
+        this.last_jsvalue.deinit();
         this.scheduler.deref();
         this.deref(); // but don't deinit until the scheduler drops its reference
     }

--- a/test/regression/issue/028027.test.ts
+++ b/test/regression/issue/028027.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// GH-28027: StatWatcher finalize() didn't clear the Strong handle before
+// deref(), causing HandleSet::deallocate() to be called from a WorkPool
+// thread when deinit() ran, corrupting the HandleSet linked list.
+test("StatWatcher GC after dropping _handle does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bun-gc-28027-"));
+
+for (let i = 0; i < 20; i++) {
+  fs.writeFileSync(path.join(dir, "f" + i + ".txt"), "data-" + i);
+}
+
+for (let i = 0; i < 20; i++) {
+  const w = fs.watchFile(path.join(dir, "f" + i + ".txt"), { interval: 5 }, () => {});
+  w._handle = null;
+}
+
+await Bun.sleep(100);
+Bun.gc(true);
+await Bun.sleep(200);
+Bun.gc(true);
+await Bun.sleep(100);
+Bun.gc(true);
+
+fs.rmSync(dir, { recursive: true, force: true });
+console.log("OK");
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("OK");
+  expect(stderr).not.toContain("panic");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/028027.test.ts
+++ b/test/regression/issue/028027.test.ts
@@ -44,6 +44,5 @@ console.log("OK");
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout.trim()).toBe("OK");
-  expect(stderr).not.toContain("panic");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Summary

- Fix thread-safety race in `StatWatcher.finalize()` where the `last_jsvalue` Strong handle and `poll_ref` were not cleaned up before calling `deref()`, causing `HandleSet::deallocate()` to be called from a WorkPool thread when `deinit()` ran — corrupting the HandleSet linked list and segfaulting on the next GC cycle
- `finalize()` now clears `poll_ref`, `persistent`, and `last_jsvalue` while still on the JS thread; all operations are idempotent so `deinit()` safely no-ops them

### The race (before fix)

1. **GC (JS thread)**: `finalize()` sets `closed=true`, calls `deref()` (refcount 2→1) — does NOT clear `last_jsvalue`
2. **WorkPool thread**: `workPoolCallback` sees `closed==true`, calls `deref()` (refcount 1→0) → triggers `deinit()`
3. **WorkPool thread (in deinit)**: `last_jsvalue.deinit()` → `HandleSet::deallocate()` from non-JS thread → corrupts HandleSet linked list
4. **Next GC**: `visitStrongHandles` iterates corrupted list → segfault

Closes #28027

## Test plan

- [x] New regression test `test/regression/issue/028027.test.ts`
- [x] Existing `test/js/node/watch/fs.watchFile.test.ts` passes (6/6)
- [ ] Windows CI (the crash is 100% reproducible on Windows per the issue report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)