### PR TITLE
fix(node:fs): clear Strong handle in StatWatcher.finalize() before cross-thread deref

### DIFF
--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -351,7 +351,13 @@ pub const StatWatcher = struct {
     /// If the scheduler is not using this, free instantly, otherwise mark for being freed.
     pub fn finalize(this: *StatWatcher) void {
         log("Finalize\n", .{});
-        this.closed = true;
+        // Clean up all JS-thread-sensitive state now, while we're on the JS thread.
+        // close() clears last_jsvalue, unrefs poll_ref, and sets closed=true.
+        // We must also fully free the HandleSet Impl via deinit(), because the
+        // scheduler's WorkPool thread may later call deref() -> deinit() from
+        // a non-JS thread, and HandleSet is not thread-safe.
+        this.close();
+        this.last_jsvalue.deinit();
         this.scheduler.deref();
         this.deref(); // but don't deinit until the scheduler drops its reference
     }

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -1,5 +1,5 @@
 import { pathToFileURL } from "bun";
-import { isWindows, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
 import fs from "node:fs";
 import path from "path";
 
@@ -199,4 +199,54 @@ describe("fs.watchFile", () => {
       EventEmitter.defaultMaxListeners = defaultMaxListeners;
     }
   }, 20000);
+
+  // Must run in a subprocess: on an unpatched build this segfaults the runtime.
+  // Regression: StatWatcher.finalize() must clear last_jsvalue before the
+  // WorkPool thread can call deinit(), otherwise HandleSet::deallocate() runs
+  // on the WorkPool thread and corrupts the GC handle linked list.
+  test("no crash when native handle is GC'd without close()", async () => {
+    const dir = tempDirWithFiles("watchfile-gc", Object.fromEntries(
+      Array.from({ length: 50 }, (_, i) => [`file-${i}.txt`, `data-${i}`]),
+    ));
+
+    const fixture = /* js */ `
+      const fs = require("fs");
+      const path = require("path");
+      const dir = ${JSON.stringify(dir)};
+
+      // Create watchers and disconnect native handles without calling close().
+      // This makes the native StatWatcher eligible for GC finalization without
+      // the safe cleanup path (close() clears last_jsvalue, finalize() must too).
+      for (let i = 0; i < 50; i++) {
+        const w = fs.watchFile(path.join(dir, "file-" + i + ".txt"), { interval: 5 }, () => {});
+        w._handle = null;
+      }
+
+      // Wait for initial stat tasks to complete and watchers to enter scheduler.
+      await Bun.sleep(100);
+
+      // Force GC: finalize() sets closed=true and deref(). The WorkPool thread
+      // will then call deref() -> deinit(). If last_jsvalue was not cleared in
+      // finalize(), deinit() calls HandleSet::deallocate() from the wrong thread.
+      Bun.gc(true);
+      await Bun.sleep(200);
+      Bun.gc(true);
+      await Bun.sleep(100);
+      Bun.gc(true);
+
+      console.log("OK");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -205,9 +205,10 @@ describe("fs.watchFile", () => {
   // WorkPool thread can call deinit(), otherwise HandleSet::deallocate() runs
   // on the WorkPool thread and corrupts the GC handle linked list.
   test("no crash when native handle is GC'd without close()", async () => {
-    const dir = tempDirWithFiles("watchfile-gc", Object.fromEntries(
-      Array.from({ length: 50 }, (_, i) => [`file-${i}.txt`, `data-${i}`]),
-    ));
+    const dir = tempDirWithFiles(
+      "watchfile-gc",
+      Object.fromEntries(Array.from({ length: 50 }, (_, i) => [`file-${i}.txt`, `data-${i}`])),
+    );
 
     const fixture = /* js */ `
       const fs = require("fs");


### PR DESCRIPTION
### What does this PR do?

Fixes a GC crash (segfault at address `0x10` in `HandleSet::visitStrongHandles`) caused by a thread-safety bug in `StatWatcher.finalize()`.

`StatWatcher` uses `ThreadSafeRefCount`, meaning `deref()` can drop the refcount to zero on any thread. The `finalize()` method (called by GC on the JS thread) set `closed=true` and called `deref()`, but did **not** clean up `last_jsvalue` (a `Strong.Optional` backed by `HandleSet`). When the scheduler's WorkPool thread later called `deref()` → `deinit()` → `last_jsvalue.deinit()`, it would call `HandleSet::deallocate()` from a non-JS thread, corrupting the GC's handle linked list.

**Fix:** Call `close()` + `last_jsvalue.deinit()` in `finalize()` so all `HandleSet` mutations happen on the JS thread. The WorkPool thread's eventual `deinit()` finds an empty handle and skips deallocation. This follows the same pattern used by `FileSink.finalize()` (deinit Strong refs on the JS thread, then `deref()`).

Closes https://github.com/oven-sh/bun/issues/28027

### How did you verify your code works?

- Added a regression test in `test/js/node/watch/fs.watchFile.test.ts` that creates 50 `fs.watchFile` watchers, disconnects the native handles without calling `close()`, then forces GC. On an unpatched build this segfaults 100% of the time (exit code 3 on Windows). With the fix, exits cleanly.
- Verified with `bun test` (unpatched): **crashes 5/5 runs**
- Verified with `bun-debug` (patched): **passes 5/5 runs**
- Existing `fs.watchFile` tests continue to pass