### PR TITLE
fix(docs): correct off-by-one and comment in Range request example

### DIFF
--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -218,7 +218,7 @@ You can send part of a file using the [`slice(start, end)`](https://developer.mo
 ```ts
 Bun.serve({
   fetch(req) {
-    // parse `Range` header
+    // parse `Range` header (supports "bytes=N-M" and "bytes=N-" forms)
     const [startStr = "0", endStr] = req.headers
       .get("Range") // "bytes=0-100"
       .split("=") // ["bytes", "0-100"]

--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -221,14 +221,14 @@ Bun.serve({
     // parse `Range` header
     const [start = 0, end = Infinity] = req.headers
       .get("Range") // Range: bytes=0-100
-      .split("=") // ["Range: bytes", "0-100"]
+      .split("=") // ["bytes", "0-100"]
       .at(-1) // "0-100"
       .split("-") // ["0", "100"]
       .map(Number); // [0, 100]
 
     // return a slice of the file
     const bigFile = Bun.file("./big-video.mp4");
-    return new Response(bigFile.slice(start, end));
+    return new Response(bigFile.slice(start, end + 1));
   },
 });
 ```

--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -218,9 +218,13 @@ You can send part of a file using the [`slice(start, end)`](https://developer.mo
 ```ts
 Bun.serve({
   fetch(req) {
+    const bigFile = Bun.file("./big-video.mp4");
+
     // parse `Range` header (supports "bytes=N-M" and "bytes=N-" forms)
-    const [startStr = "0", endStr] = req.headers
-      .get("Range") // "bytes=0-100"
+    const range = req.headers.get("Range");
+    if (!range) return new Response(bigFile);
+
+    const [startStr = "0", endStr] = range
       .split("=") // ["bytes", "0-100"]
       .at(-1) // "0-100"
       .split("-"); // ["0", "100"]
@@ -229,8 +233,6 @@ Bun.serve({
     // Range end is inclusive, but slice() end is exclusive
     const end = endStr ? Number(endStr) + 1 : undefined;
 
-    // return a slice of the file
-    const bigFile = Bun.file("./big-video.mp4");
     return new Response(bigFile.slice(start, end));
   },
 });

--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -219,16 +219,19 @@ You can send part of a file using the [`slice(start, end)`](https://developer.mo
 Bun.serve({
   fetch(req) {
     // parse `Range` header
-    const [start = 0, end = Infinity] = req.headers
-      .get("Range") // Range: bytes=0-100
+    const [startStr = "0", endStr] = req.headers
+      .get("Range") // "bytes=0-100"
       .split("=") // ["bytes", "0-100"]
       .at(-1) // "0-100"
-      .split("-") // ["0", "100"]
-      .map(Number); // [0, 100]
+      .split("-"); // ["0", "100"]
+
+    const start = Number(startStr);
+    // Range end is inclusive, but slice() end is exclusive
+    const end = endStr ? Number(endStr) + 1 : undefined;
 
     // return a slice of the file
     const bigFile = Bun.file("./big-video.mp4");
-    return new Response(bigFile.slice(start, end + 1));
+    return new Response(bigFile.slice(start, end));
   },
 });
 ```


### PR DESCRIPTION
## Summary
- Fix off-by-one in Range request example: use `end + 1` in `Blob.slice()` since HTTP Range headers are end-inclusive but `slice()` is end-exclusive
- Fix misleading comment: `.split("=")` on `"bytes=0-100"` produces `["bytes", "0-100"]`, not `["Range: bytes", "0-100"]`

Closes #28030

## Test plan
- [x] Verified `Blob.slice()` is end-exclusive: `new Blob(["0123456789"]).slice(0, 4).text()` returns `"0123"` (4 bytes)
- [x] Verified `.split("=")` output: `"bytes=0-100".split("=")` returns `["bytes", "0-100"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)