### PR TITLE
fix(websocket): send empty frame for ping()/pong() without arguments

### DIFF
--- a/src/bun.js/bindings/webcore/WebSocket.cpp
+++ b/src/bun.js/bindings/webcore/WebSocket.cpp
@@ -959,20 +959,16 @@ ExceptionOr<void> WebSocket::terminate()
 
 ExceptionOr<void> WebSocket::ping()
 {
-    auto message = WTF::String::number(WTF::jsCurrentTime());
-    // LOG(Network, "WebSocket %p ping() Sending Timestamp '%s'", this, message.data());
     if (m_state == CONNECTING)
         return Exception { InvalidStateError };
 
     // No exception is raised if the connection was once established but has subsequently been closed.
     if (m_state == CLOSING || m_state == CLOSED) {
-        size_t payloadSize = message.length();
-        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, payloadSize);
-        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, getFramingOverhead(payloadSize));
         return {};
     }
 
-    this->sendWebSocketString(message, Opcode::Ping);
+    // Send empty ping frame per RFC 6455 and Node.js ws compatibility
+    this->sendWebSocketData(nullptr, 0, Opcode::Ping);
 
     return {};
 }
@@ -1042,20 +1038,16 @@ ExceptionOr<void> WebSocket::ping(ArrayBufferView& arrayBufferView)
 
 ExceptionOr<void> WebSocket::pong()
 {
-    auto message = WTF::String::number(WTF::jsCurrentTime());
-    // LOG(Network, "WebSocket %p pong() Sending Timestamp '%s'", this, message.data());
     if (m_state == CONNECTING)
         return Exception { InvalidStateError };
 
     // No exception is raised if the connection was once established but has subsequently been closed.
     if (m_state == CLOSING || m_state == CLOSED) {
-        size_t payloadSize = message.length();
-        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, payloadSize);
-        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, getFramingOverhead(payloadSize));
         return {};
     }
 
-    this->sendWebSocketString(message, Opcode::Pong);
+    // Send empty pong frame per RFC 6455 and Node.js ws compatibility
+    this->sendWebSocketData(nullptr, 0, Opcode::Pong);
 
     return {};
 }

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -476,7 +476,8 @@ class BunWebSocket extends EventEmitter {
     if (typeof data === "number") data = data.toString();
 
     try {
-      this.#ws.ping(data);
+      if (data === undefined) this.#ws.ping();
+      else this.#ws.ping(data);
     } catch (error) {
       if (typeof cb === "function") {
         cb(error);
@@ -505,7 +506,8 @@ class BunWebSocket extends EventEmitter {
     if (typeof data === "number") data = data.toString();
 
     try {
-      this.#ws.pong(data);
+      if (data === undefined) this.#ws.pong();
+      else this.#ws.pong(data);
     } catch (error) {
       if (typeof cb === "function") {
         cb(error);
@@ -905,7 +907,8 @@ class BunWebSocketMocked extends EventEmitter {
     if (typeof data === "number") data = data.toString();
 
     try {
-      this.#ws.ping(data);
+      if (data === undefined) this.#ws.ping();
+      else this.#ws.ping(data);
     } catch (error) {
       if (typeof cb === "function") cb(error);
       return;
@@ -930,7 +933,8 @@ class BunWebSocketMocked extends EventEmitter {
     if (typeof data === "number") data = data.toString();
 
     try {
-      this.#ws.pong(data);
+      if (data === undefined) this.#ws.pong();
+      else this.#ws.pong(data);
     } catch (error) {
       if (typeof cb === "function") cb(error);
       return;

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -806,3 +806,103 @@ it("Server should be able to send empty pings", async () => {
     expect(pingMessage).not.toBe(pingPayload);
   }
 });
+
+// Verify ws.ping() / ws.pong() without arguments send empty control frames,
+// not the literal string "undefined" (9 bytes).
+describe("ping/pong no-arg payload", () => {
+  it("ws.ping() sends empty payload", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    const { resolve, reject, promise } = Promise.withResolvers<void>();
+
+    wss.on("connection", serverWs => {
+      serverWs.on("ping", (data: Buffer) => {
+        try {
+          expect(data).toBeInstanceOf(Buffer);
+          expect(data.length).toBe(0);
+          resolve();
+        } catch (e) {
+          reject(e);
+        } finally {
+          serverWs.close();
+          wss.close();
+        }
+      });
+    });
+
+    const ws = new WebSocket("ws://localhost:" + (wss.address() as AddressInfo).port);
+    ws.on("open", () => ws.ping());
+    await promise;
+  });
+
+  it("ws.pong() sends empty payload", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    const { resolve, reject, promise } = Promise.withResolvers<void>();
+
+    wss.on("connection", serverWs => {
+      serverWs.on("pong", (data: Buffer) => {
+        try {
+          expect(data).toBeInstanceOf(Buffer);
+          expect(data.length).toBe(0);
+          resolve();
+        } catch (e) {
+          reject(e);
+        } finally {
+          serverWs.close();
+          wss.close();
+        }
+      });
+    });
+
+    const ws = new WebSocket("ws://localhost:" + (wss.address() as AddressInfo).port);
+    ws.on("open", () => ws.pong());
+    await promise;
+  });
+
+  it("ws.ping(data) sends correct payload", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    const { resolve, reject, promise } = Promise.withResolvers<void>();
+
+    wss.on("connection", serverWs => {
+      serverWs.on("ping", (data: Buffer) => {
+        try {
+          expect(data).toBeInstanceOf(Buffer);
+          expect(data.toString()).toBe("hello");
+          resolve();
+        } catch (e) {
+          reject(e);
+        } finally {
+          serverWs.close();
+          wss.close();
+        }
+      });
+    });
+
+    const ws = new WebSocket("ws://localhost:" + (wss.address() as AddressInfo).port);
+    ws.on("open", () => ws.ping(Buffer.from("hello")));
+    await promise;
+  });
+
+  it("ws.pong(data) sends correct payload", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    const { resolve, reject, promise } = Promise.withResolvers<void>();
+
+    wss.on("connection", serverWs => {
+      serverWs.on("pong", (data: Buffer) => {
+        try {
+          expect(data).toBeInstanceOf(Buffer);
+          expect(data.toString()).toBe("hello");
+          resolve();
+        } catch (e) {
+          reject(e);
+        } finally {
+          serverWs.close();
+          wss.close();
+        }
+      });
+    });
+
+    const ws = new WebSocket("ws://localhost:" + (wss.address() as AddressInfo).port);
+    ws.on("open", () => ws.pong(Buffer.from("hello")));
+    await promise;
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes `ws.ping()` and `ws.pong()` called without arguments to send **empty control frames** (0-byte payload) instead of incorrect non-empty payloads.

**Two bugs were causing incorrect behavior:**

1. **C++ `WebSocket::ping()`/`pong()` 0-arg overloads** (introduced in #3257) sent `WTF::jsCurrentTime()` as a 13-byte timestamp payload. The server-side Zig `ServerWebSocket.sendPing()` already correctly sends empty frames for 0-arg calls — this aligns the client-side C++ implementation.

2. **`ws.js` shim** passed `undefined` directly to native bindings, which `IDLUSVString` converted to the literal string `"undefined"` (9 bytes).

**Fix:**
- C++ 0-arg overloads now send empty frames via `sendWebSocketData(nullptr, 0, Opcode::Ping/Pong)`
- JS shim guards `undefined` to dispatch to the native 0-arg overload

This restores compliance with [RFC 6455 §5.5.2](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.2) and Node.js `ws` module behavior, and fixes disconnections with strict WebSocket servers (e.g. Binance) that validate pong payload matches ping payload.

Related: websockets/ws#2258

### How did you verify your code works?

- `bun bd test test/js/first_party/ws/ws.test.ts` — **45 pass, 0 fail**
- `USE_SYSTEM_BUN=1 bun test test/js/first_party/ws/ws.test.ts -t "ping/pong no-arg payload"` — **2 fail** (Expected: 0, Received: 9), confirming tests catch the bug on stock Bun

4 new tests added to verify wire-level payload correctness:
- `ws.ping()` sends empty payload (0 bytes)
- `ws.pong()` sends empty payload (0 bytes)
- `ws.ping(data)` sends correct payload
- `ws.pong(data)` sends correct payload
