### PR TITLE
fix(bundler): apply import attribute loader to dynamic import() records

### DIFF
--- a/src/ast/P.zig
+++ b/src/ast/P.zig
@@ -594,6 +594,10 @@ pub fn NewParser_(
                     p.import_records.items[import_record_index].tag = tag;
                 }
 
+                if (state.import_loader) |loader| {
+                    p.import_records.items[import_record_index].loader = loader;
+                }
+
                 p.import_records.items[import_record_index].flags.handles_import_errors = (state.is_await_target and p.fn_or_arrow_data_visit.try_body_count != 0) or state.is_then_catch_target;
                 p.import_records_for_current_part.append(p.allocator, import_record_index) catch unreachable;
 

--- a/test/regression/issue/28042.test.ts
+++ b/test/regression/issue/28042.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/28042
+// Dynamic import() with { with: { type: 'text' } } on .html files
+// was not applying the loader from import attributes, causing
+// --compile builds to fail with "require_bar is not defined".
+
+test("dynamic import with type: 'text' attribute works with --compile for .html files", async () => {
+  using dir = tempDir("issue-28042", {
+    "index.ts": `const foo = await import('./bar.html', { with: { type: 'text' } });
+console.log(foo.default);`,
+    "bar.html": `<h1>Hello</h1>`,
+  });
+
+  // Build with --compile
+  await using buildProc = Bun.spawn({
+    cmd: [bunExe(), "build", "index.ts", "--compile", "--outfile", `${dir}/out`],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [buildStderr, buildExitCode] = await Promise.all([buildProc.stderr.text(), buildProc.exited]);
+
+  expect(buildStderr).not.toContain("error");
+  expect(buildExitCode).toBe(0);
+
+  // Run the compiled binary
+  await using runProc = Bun.spawn({
+    cmd: [`${dir}/out`],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
+
+  expect(stdout.trim()).toBe("<h1>Hello</h1>");
+  expect(exitCode).toBe(0);
+});
+
+test("dynamic import with type: 'text' attribute works with bundle for .html files", async () => {
+  using dir = tempDir("issue-28042-bundle", {
+    "index.ts": `const foo = await import('./bar.html', { with: { type: 'text' } });
+console.log(foo.default);`,
+    "bar.html": `<h1>Hello</h1>`,
+  });
+
+  // Build without --compile (regular bundle)
+  await using buildProc = Bun.spawn({
+    cmd: [bunExe(), "build", "index.ts", "--outfile", `${dir}/out.js`],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [buildStderr, buildExitCode] = await Promise.all([buildProc.stderr.text(), buildProc.exited]);
+
+  expect(buildStderr).not.toContain("error");
+  expect(buildExitCode).toBe(0);
+
+  // Run the bundled output
+  await using runProc = Bun.spawn({
+    cmd: [bunExe(), `${dir}/out.js`],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
+
+  expect(stdout.trim()).toBe("<h1>Hello</h1>");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fix dynamic `import()` with import attributes (e.g. `{ with: { type: 'text' } }`) not applying the loader to the import record during bundling
- The `import_loader` field in `TransposeState` was being populated but never consumed in `transposeImport`, causing `.html` files to use the wrong loader

Closes #28042

## Root Cause

In `src/ast/P.zig`, the `transposeImport` function applied `state.import_record_tag` to the import record but skipped `state.import_loader`. This meant dynamic imports with `{ with: { type: 'text' } }` on `.html` files would fall back to the path-based `.html` loader instead of the `.text` loader specified by the import attribute.

The fix adds 3 lines mirroring the existing `import_record_tag` pattern:

```zig
if (state.import_loader) |loader| {
    p.import_records.items[import_record_index].loader = loader;
}
```

## Test plan

- [x] Regression test `test/regression/issue/28042.test.ts` — tests both `--compile` and `--outfile` with dynamic import of `.html` using `{ with: { type: 'text' } }`
- [x] Test fails with system bun (`USE_SYSTEM_BUN=1`), passes with debug build

🤖 Generated with [Claude Code](https://claude.com/claude-code)