### PR TITLE
fix(util): implement WeakMap/WeakSet inspection with showHidden

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -1096,6 +1096,8 @@ pub const Formatter = struct {
         MapIterator,
         SetIterator,
         Set,
+        WeakMap,
+        WeakSet,
         BigInt,
         Symbol,
 
@@ -1160,6 +1162,8 @@ pub const Formatter = struct {
                 MapIterator: void,
                 SetIterator: void,
                 Set: void,
+                WeakMap: void,
+                WeakSet: void,
                 BigInt: void,
                 Symbol: void,
                 CustomFormattedObject: CustomFormattedObject,
@@ -1326,10 +1330,12 @@ pub const Formatter = struct {
                     .Symbol => .Symbol,
                     .BooleanObject => .Boolean,
                     .JSFunction => .Function,
-                    .WeakMap, JSValue.JSType.Map => .Map,
+                    JSValue.JSType.Map => .Map,
+                    .WeakMap => .WeakMap,
                     .MapIterator => .MapIterator,
                     .SetIterator => .SetIterator,
-                    .WeakSet, JSValue.JSType.Set => .Set,
+                    JSValue.JSType.Set => .Set,
+                    .WeakSet => .WeakSet,
                     .JSDate => .JSON,
                     .JSPromise => .Promise,
 
@@ -2754,7 +2760,7 @@ pub const Formatter = struct {
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
 
-                const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
+                const map_name = "Map";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{map_name});
@@ -2861,7 +2867,7 @@ pub const Formatter = struct {
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
 
-                const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
+                const set_name = "Set";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{set_name});
@@ -2895,6 +2901,12 @@ pub const Formatter = struct {
                     this.writeIndent(Writer, writer_) catch {};
                 }
                 writer.writeAll("}");
+            },
+            .WeakMap => {
+                writer.writeAll("WeakMap { <items unknown> }");
+            },
+            .WeakSet => {
+                writer.writeAll("WeakSet { <items unknown> }");
             },
             .toJSON => {
                 if (try value.get(this.globalThis, "toJSON")) |func| brk: {

--- a/src/bun.js/modules/NodeUtilTypesModule.cpp
+++ b/src/bun.js/modules/NodeUtilTypesModule.cpp
@@ -516,7 +516,7 @@ namespace Zig {
 // Hardcoded module "node:util/types"
 DEFINE_NATIVE_MODULE_NOINLINE(NodeUtilTypes)
 {
-    INIT_NATIVE_MODULE(46);
+    INIT_NATIVE_MODULE(44);
 
     putNativeFn(Identifier::fromString(vm, "isExternal"_s), jsFunctionIsExternal);
     putNativeFn(Identifier::fromString(vm, "isDate"_s), jsFunctionIsDate);
@@ -562,8 +562,6 @@ DEFINE_NATIVE_MODULE_NOINLINE(NodeUtilTypes)
     putNativeFn(Identifier::fromString(vm, "isKeyObject"_s), jsFunctionIsKeyObject);
     putNativeFn(Identifier::fromString(vm, "isCryptoKey"_s), jsFunctionIsCryptoKey);
     putNativeFn(Identifier::fromString(vm, "isEventTarget"_s), jsFunctionIsEventTarget);
-    putNativeFn(Identifier::fromString(vm, "getWeakMapEntries"_s), jsFunctionGetWeakMapEntries);
-    putNativeFn(Identifier::fromString(vm, "getWeakSetEntries"_s), jsFunctionGetWeakSetEntries);
 
     RETURN_NATIVE_MODULE();
 }

--- a/src/bun.js/modules/NodeUtilTypesModule.cpp
+++ b/src/bun.js/modules/NodeUtilTypesModule.cpp
@@ -14,6 +14,10 @@
 #include <JavaScriptCore/ErrorPrototype.h>
 #include <JavaScriptCore/GeneratorFunctionPrototype.h>
 #include <JavaScriptCore/JSArrayBuffer.h>
+#include <JavaScriptCore/JSWeakMap.h>
+#include <JavaScriptCore/JSWeakSet.h>
+#include <JavaScriptCore/WeakMapImpl.h>
+#include <JavaScriptCore/WeakMapImplInlines.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include "ZigGeneratedClasses.h"
 #include "JSKeyObject.h"
@@ -461,12 +465,58 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionIsEventTarget,
     return JSValue::encode(jsBoolean(cell->inherits<WebCore::JSEventTarget>()));
 }
 
+JSC_DEFINE_HOST_FUNCTION(jsFunctionGetWeakMapEntries,
+    (JSC::JSGlobalObject * globalObject,
+        JSC::CallFrame* callframe))
+{
+    if (callframe->argumentCount() < 1)
+        return JSValue::encode(constructEmptyArray(globalObject, nullptr, 0));
+
+    JSValue value = callframe->uncheckedArgument(0);
+    if (!value.isCell() || value.asCell()->type() != JSWeakMapType)
+        return JSValue::encode(constructEmptyArray(globalObject, nullptr, 0));
+
+    JSWeakMap* weakMap = jsCast<JSWeakMap*>(value.asCell());
+    MarkedArgumentBuffer snapshot;
+    weakMap->takeSnapshot(snapshot);
+
+    // takeSnapshot returns interleaved [key, value, key, value, ...]
+    size_t size = snapshot.size();
+    JSArray* result = constructEmptyArray(globalObject, nullptr, size);
+    for (size_t i = 0; i < size; ++i) {
+        result->putDirectIndex(globalObject, i, snapshot.at(i));
+    }
+    return JSValue::encode(result);
+}
+JSC_DEFINE_HOST_FUNCTION(jsFunctionGetWeakSetEntries,
+    (JSC::JSGlobalObject * globalObject,
+        JSC::CallFrame* callframe))
+{
+    if (callframe->argumentCount() < 1)
+        return JSValue::encode(constructEmptyArray(globalObject, nullptr, 0));
+
+    JSValue value = callframe->uncheckedArgument(0);
+    if (!value.isCell() || value.asCell()->type() != JSWeakSetType)
+        return JSValue::encode(constructEmptyArray(globalObject, nullptr, 0));
+
+    JSWeakSet* weakSet = jsCast<JSWeakSet*>(value.asCell());
+    MarkedArgumentBuffer snapshot;
+    weakSet->takeSnapshot(snapshot);
+
+    size_t size = snapshot.size();
+    JSArray* result = constructEmptyArray(globalObject, nullptr, size);
+    for (size_t i = 0; i < size; ++i) {
+        result->putDirectIndex(globalObject, i, snapshot.at(i));
+    }
+    return JSValue::encode(result);
+}
+
 namespace Zig {
 
 // Hardcoded module "node:util/types"
 DEFINE_NATIVE_MODULE_NOINLINE(NodeUtilTypes)
 {
-    INIT_NATIVE_MODULE(44);
+    INIT_NATIVE_MODULE(46);
 
     putNativeFn(Identifier::fromString(vm, "isExternal"_s), jsFunctionIsExternal);
     putNativeFn(Identifier::fromString(vm, "isDate"_s), jsFunctionIsDate);
@@ -512,6 +562,8 @@ DEFINE_NATIVE_MODULE_NOINLINE(NodeUtilTypes)
     putNativeFn(Identifier::fromString(vm, "isKeyObject"_s), jsFunctionIsKeyObject);
     putNativeFn(Identifier::fromString(vm, "isCryptoKey"_s), jsFunctionIsCryptoKey);
     putNativeFn(Identifier::fromString(vm, "isEventTarget"_s), jsFunctionIsEventTarget);
+    putNativeFn(Identifier::fromString(vm, "getWeakMapEntries"_s), jsFunctionGetWeakMapEntries);
+    putNativeFn(Identifier::fromString(vm, "getWeakSetEntries"_s), jsFunctionGetWeakSetEntries);
 
     RETURN_NATIVE_MODULE();
 }

--- a/src/bun.js/modules/NodeUtilTypesModule.h
+++ b/src/bun.js/modules/NodeUtilTypesModule.h
@@ -9,6 +9,14 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionIsError,
     (JSC::JSGlobalObject * globalObject,
         JSC::CallFrame* callframe));
 
+JSC_DEFINE_HOST_FUNCTION(jsFunctionGetWeakMapEntries,
+    (JSC::JSGlobalObject * globalObject,
+        JSC::CallFrame* callframe));
+
+JSC_DEFINE_HOST_FUNCTION(jsFunctionGetWeakSetEntries,
+    (JSC::JSGlobalObject * globalObject,
+        JSC::CallFrame* callframe));
+
 namespace Zig {
 
 // Hardcoded module "node:util/types"

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -197,6 +197,8 @@ const {
   isSetIterator,
   isWeakMap,
   isWeakSet,
+  getWeakMapEntries,
+  getWeakSetEntries,
   isRegExp,
   isDate,
   isTypedArray,
@@ -2718,9 +2720,8 @@ function previewEntries(val, isIterator = false) {
     // perhaps we should add support for other iterators in the future? (e.g. ArrayIterator and StringIterator)
     else throw new Error("previewEntries(): Invalid iterator received");
   }
-  // TODO(bun): are there any JSC APIs for viewing the contents of these in JS?
-  if (isWeakMap(val)) return [];
-  if (isWeakSet(val)) return [];
+  if (isWeakMap(val)) return getWeakMapEntries(val);
+  if (isWeakSet(val)) return getWeakSetEntries(val);
   else throw new Error("previewEntries(): Invalid object received");
 }
 function internalGetConstructorName(val) {

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -197,8 +197,6 @@ const {
   isSetIterator,
   isWeakMap,
   isWeakSet,
-  getWeakMapEntries,
-  getWeakSetEntries,
   isRegExp,
   isDate,
   isTypedArray,
@@ -206,6 +204,9 @@ const {
   isNumberObject,
   isBooleanObject,
 } = require("node:util/types");
+
+const getWeakMapEntries = $newCppFunction("NodeUtilTypesModule.cpp", "jsFunctionGetWeakMapEntries", 1);
+const getWeakSetEntries = $newCppFunction("NodeUtilTypesModule.cpp", "jsFunctionGetWeakSetEntries", 1);
 
 //! temp workaround to apply is{BigInt,Symbol}Object fix
 const isBoxedPrimitive = val => isBigIntObject(val) || isSymbolObject(val) || _native_isBoxedPrimitive(val);

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -1931,7 +1931,7 @@ test("no assertion failures 3", () => {
     ],
     [
       class // Random { // comments /* */ are part of the toString() result
-        äß /**/
+      äß /**/
         extends /*{*/ TypeError {},
       "[class äß extends TypeError]",
     ],

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -1749,57 +1749,47 @@ test("no assertion failures 2", () => {
       [arr, obj],
     ]);
     let out = util.inspect(weakMap, { showHidden: true });
-    // TODO: WeakMap internals
-    // let expect = 'WeakMap { [ [length]: 0 ] => {}, {} => [ [length]: 0 ] }';
-    let expect = "WeakMap {  }";
-    assert.strictEqual(out, expect);
+    let expect = "WeakMap { [ [length]: 0 ] => {}, {} => [ [length]: 0 ] }";
+    let expectAlt = "WeakMap { {} => [ [length]: 0 ], [ [length]: 0 ] => {} }";
+    assert(out === expect || out === expectAlt, `Found: "${out}"\nrather than: "${expect}"\nor: "${expectAlt}"`);
 
     out = util.inspect(weakMap);
     expect = "WeakMap { <items unknown> }";
     assert.strictEqual(out, expect);
 
     out = util.inspect(weakMap, { maxArrayLength: 0, showHidden: true });
-    // expect = 'WeakMap { ... 2 more items }';
-    expect = "WeakMap {  }";
+    expect = "WeakMap { ... 2 more items }";
     assert.strictEqual(out, expect);
 
     weakMap.extra = true;
     out = util.inspect(weakMap, { maxArrayLength: 1, showHidden: true });
     // It is not possible to determine the output reliable.
-    // expect = 'WeakMap { [ [length]: 0 ] => {}, ... 1 more item, extra: true }';
-    // let expectAlt = 'WeakMap { {} => [ [length]: 0 ], ... 1 more item, extra: true }';
-    assert(
-      out === "WeakMap { extra: true }", //out === expect || out === expectAlt,
-      `Found: "${out}"\nrather than: "WeakMap { extra: true }"`,
-    ); //"${expect}"\nor: "${expectAlt}"`);
+    expect = "WeakMap { [ [length]: 0 ] => {}, ... 1 more item, extra: true }";
+    expectAlt = "WeakMap { {} => [ [length]: 0 ], ... 1 more item, extra: true }";
+    assert(out === expect || out === expectAlt, `Found: "${out}"\nrather than: "${expect}"\nor: "${expectAlt}"`);
 
     // Test WeakSet
     arr.push(1);
     const weakSet = new WeakSet([obj, arr]);
     out = util.inspect(weakSet, { showHidden: true });
-    // TODO: WeakSet internals
-    // expect = 'WeakSet { [ 1, [length]: 1 ], {} }';
-    expect = "WeakSet {  }";
-    assert.strictEqual(out, expect);
+    expect = "WeakSet { [ 1, [length]: 1 ], {} }";
+    expectAlt = "WeakSet { {}, [ 1, [length]: 1 ] }";
+    assert(out === expect || out === expectAlt, `Found: "${out}"\nrather than: "${expect}"\nor: "${expectAlt}"`);
 
     out = util.inspect(weakSet);
     expect = "WeakSet { <items unknown> }";
     assert.strictEqual(out, expect);
 
     out = util.inspect(weakSet, { maxArrayLength: -2, showHidden: true });
-    //expect = 'WeakSet { ... 2 more items }';
-    expect = "WeakSet {  }";
+    expect = "WeakSet { ... 2 more items }";
     assert.strictEqual(out, expect);
 
     weakSet.extra = true;
     out = util.inspect(weakSet, { maxArrayLength: 1, showHidden: true });
     // It is not possible to determine the output reliable.
-    // expect = 'WeakSet { {}, ... 1 more item, extra: true }';
-    // expectAlt = 'WeakSet { [ 1, [length]: 1 ], ... 1 more item, extra: true }';
-    assert(
-      out === "WeakSet { extra: true }", //out === expect || out === expectAlt,
-      `Found: "${out}"\nrather than: "WeakSet { extra: true }"`,
-    ); //"${expect}"\nor: "${expectAlt}"`);
+    expect = "WeakSet { {}, ... 1 more item, extra: true }";
+    expectAlt = "WeakSet { [ 1, [length]: 1 ], ... 1 more item, extra: true }";
+    assert(out === expect || out === expectAlt, `Found: "${out}"\nrather than: "${expect}"\nor: "${expectAlt}"`);
     // Keep references to the WeakMap entries, otherwise they could be GCed too early.
     assert(obj && arr);
   }
@@ -1941,7 +1931,7 @@ test("no assertion failures 3", () => {
     ],
     [
       class // Random { // comments /* */ are part of the toString() result
-      äß /**/
+        äß /**/
         extends /*{*/ TypeError {},
       "[class äß extends TypeError]",
     ],

--- a/test/regression/issue/28044.test.ts
+++ b/test/regression/issue/28044.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test";
+import { inspect } from "node:util";
+
+test("inspect(weakSet, { showHidden: true }) shows entries", () => {
+  const obj = { a: 1 };
+  const obj2 = { b: 2 };
+  const weakSet = new WeakSet([obj, obj2]);
+
+  const out = inspect(weakSet, { showHidden: true });
+  // Order of entries is not deterministic
+  expect(out).toContain("{ a: 1 }");
+  expect(out).toContain("{ b: 2 }");
+  expect(out).toStartWith("WeakSet {");
+  expect(out).toEndWith("}");
+});
+
+test("inspect(weakMap, { showHidden: true }) shows entries", () => {
+  const obj = { a: 1 };
+  const obj2 = { b: 2 };
+  const weakMap = new WeakMap([
+    [obj, "val1"],
+    [obj2, "val2"],
+  ]);
+
+  const out = inspect(weakMap, { showHidden: true });
+  // Order of entries is not deterministic
+  expect(out).toContain("{ a: 1 } => 'val1'");
+  expect(out).toContain("{ b: 2 } => 'val2'");
+  expect(out).toStartWith("WeakMap {");
+  expect(out).toEndWith("}");
+});
+
+test("inspect(weakSet) without showHidden shows items unknown", () => {
+  const obj = { a: 1 };
+  const weakSet = new WeakSet([obj]);
+
+  expect(inspect(weakSet)).toBe("WeakSet { <items unknown> }");
+});
+
+test("inspect(weakMap) without showHidden shows items unknown", () => {
+  const obj = { a: 1 };
+  const weakMap = new WeakMap([[obj, "val1"]]);
+
+  expect(inspect(weakMap)).toBe("WeakMap { <items unknown> }");
+});
+
+test("inspect(weakMap, { showHidden: true, maxArrayLength: 0 }) shows remaining count", () => {
+  const obj = { a: 1 };
+  const obj2 = { b: 2 };
+  const weakMap = new WeakMap([
+    [obj, "val1"],
+    [obj2, "val2"],
+  ]);
+
+  expect(inspect(weakMap, { showHidden: true, maxArrayLength: 0 })).toBe("WeakMap { ... 2 more items }");
+});
+
+test("inspect(weakSet, { showHidden: true, maxArrayLength: 0 }) shows remaining count", () => {
+  const obj = { a: 1 };
+  const obj2 = { b: 2 };
+  const weakSet = new WeakSet([obj, obj2]);
+
+  expect(inspect(weakSet, { showHidden: true, maxArrayLength: 0 })).toBe("WeakSet { ... 2 more items }");
+});

--- a/test/regression/issue/28044.test.ts
+++ b/test/regression/issue/28044.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { inspect } from "node:util";
 
 test("inspect(weakSet, { showHidden: true }) shows entries", () => {
@@ -61,4 +62,30 @@ test("inspect(weakSet, { showHidden: true, maxArrayLength: 0 }) shows remaining 
   const weakSet = new WeakSet([obj, obj2]);
 
   expect(inspect(weakSet, { showHidden: true, maxArrayLength: 0 })).toBe("WeakSet { ... 2 more items }");
+});
+
+test("console.log(weakSet) shows items unknown", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `const weakSet = new WeakSet([{a:1}]); console.log(weakSet);`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout.trim()).toBe("WeakSet { <items unknown> }");
+  expect(exitCode).toBe(0);
+});
+
+test("console.log(weakMap) shows items unknown", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `const weakMap = new WeakMap([[{a:1}, 'v']]); console.log(weakMap);`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout.trim()).toBe("WeakMap { <items unknown> }");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Summary
- Add `getWeakMapEntries` and `getWeakSetEntries` native functions to `node:util/types` that use JSC's `WeakMapImpl::takeSnapshot` API to enumerate entries
- Update `previewEntries()` in the `node:util` inspect implementation to use these new functions when `showHidden: true`
- Fix `console.log` for WeakMap/WeakSet to show `<items unknown>` instead of empty braces (matching Node.js behavior)

## Test plan
- [x] New regression test in `test/regression/issue/28044.test.ts` covers all combinations (showHidden on/off, maxArrayLength limits)
- [x] Updated existing test expectations in `test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js` 
- [x] Verified test fails with `USE_SYSTEM_BUN=1` and passes with `bun bd test`

Closes #28044

🤖 Generated with [Claude Code](https://claude.com/claude-code)