### PR TITLE
docs: fix dynamic import `.default` access in yaml.mdx and json5.mdx

### DIFF
--- a/docs/runtime/json5.mdx
+++ b/docs/runtime/json5.mdx
@@ -267,5 +267,5 @@ This means:
 JSON5 files can be dynamically imported:
 
 ```ts
-const config = await import("./config.json5");
+const { default: config } = await import("./config.json5");
 ```

--- a/docs/runtime/yaml.mdx
+++ b/docs/runtime/yaml.mdx
@@ -455,7 +455,7 @@ YAML files can be dynamically imported, useful for loading configuration on dema
 
 ```ts Load configuration based on environment
 const env = process.env.NODE_ENV || "development";
-const config = await import(`./configs/${env}.yaml`);
+const { default: config } = await import(`./configs/${env}.yaml`);
 
 // Load user-specific settings
 async function loadUserSettings(userId: string) {
@@ -463,7 +463,8 @@ async function loadUserSettings(userId: string) {
     const settings = await import(`./users/${userId}/settings.yaml`);
     return settings.default;
   } catch {
-    return await import("./users/default-settings.yaml");
+    const { default: defaults } = await import("./users/default-settings.yaml");
+    return defaults;
   }
 }
 ```


### PR DESCRIPTION
## Summary

- Fix dynamic import examples in `docs/runtime/yaml.mdx` and `docs/runtime/json5.mdx` to destructure `.default` instead of assigning the module namespace object directly
- The catch branch in the YAML dynamic import example now also correctly returns the default export, consistent with the try branch (which already used `settings.default`)

## Test plan

- Docs-only change — no runtime behavior affected
- Verified examples are consistent with `docs/runtime/file-types.mdx` which already uses `const { default: my_toml } = await import(...)`

Closes #28057

🤖 Generated with [Claude Code](https://claude.com/claude-code)