### PR TITLE
fix(install): stop replacing Windows cache dirs during concurrent publish

### DIFF
--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -324,7 +324,6 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
 
     // Now that we've extracted the archive, we rename.
     if (comptime Environment.isWindows) {
-        var did_retry = false;
         var path2_buf: bun.WPathBuffer = undefined;
         const path2 = bun.strings.toWPathNormalized(&path2_buf, folder_name);
         if (create_subdir) {
@@ -354,42 +353,31 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
 
             switch (bun.windows.moveOpenedFileAt(dir_to_move, .fromStdDir(cache_dir), path_to_use, true)) {
                 .err => |err| {
-                    if (!did_retry) {
-                        switch (err.getErrno()) {
-                            .NOTEMPTY, .PERM, .BUSY, .EXIST => {
+                    switch (err.getErrno()) {
+                        .NOTEMPTY, .PERM, .BUSY, .EXIST => {
+                            dir_to_move.close();
 
-                                // before we attempt to delete the destination, let's close the source dir.
-                                dir_to_move.close();
-
-                                // We tried to move the folder over
-                                // but it didn't work!
-                                // so instead of just simply deleting the folder
-                                // we rename it back into the temp dir
-                                // and then delete that temp dir
-                                // The goal is to make it more difficult for an application to reach this folder
-                                var tmpname_bytes = std.mem.asBytes(&tmpname_buf);
-                                const tmpname_len = tmpname.len;
-
-                                tmpname_bytes[tmpname_len..][0..4].* = .{ 't', 'm', 'p', 0 };
-                                const tempdest = tmpname_bytes[0 .. tmpname_len + 3 :0];
-                                switch (bun.sys.renameat(
-                                    .fromStdDir(cache_dir),
-                                    folder_name,
-                                    .fromStdDir(tmpdir),
-                                    tempdest,
-                                )) {
-                                    .err => {},
-                                    .result => {
-                                        tmpdir.deleteTree(tempdest) catch {};
-                                    },
-                                }
-                                tmpname_bytes[tmpname_len] = 0;
-                                did_retry = true;
-                                continue;
-                            },
-                            else => {},
-                        }
+                            // The install cache is write-once. If another process already created this
+                            // directory, prefer the existing entry instead of deleting and replacing it.
+                            // Deleting it creates a race where another installer has already resolved the
+                            // version symlink but then observes ENOENT while opening the cache dir.
+                            var existing_dir = bun.openDirNoRenamingOrDeletingWindows(.fromStdDir(cache_dir), folder_name) catch |open_err| {
+                                log.addErrorFmt(
+                                    null,
+                                    logger.Loc.Empty,
+                                    bun.default_allocator,
+                                    "moving \"{s}\" to cache dir failed\n{f}\n  From: {s}\n    To: {s}\nfailed to reuse existing cache dir: {s}",
+                                    .{ name, err, tmpname, folder_name, @errorName(open_err) },
+                                ) catch unreachable;
+                                return error.InstallFailed;
+                            };
+                            existing_dir.close();
+                            tmpdir.deleteTree(tmpname) catch {};
+                            break;
+                        },
+                        else => {},
                     }
+
                     dir_to_move.close();
                     log.addErrorFmt(
                         null,

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -334,7 +334,7 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
 
         const path_to_use = path2;
 
-        while (true) {
+        publish_to_cache: while (true) {
             const dir_to_move = bun.sys.openDirAtWindowsA(.fromStdDir(this.temp_dir), tmpname, .{
                 .can_rename_or_delete = true,
                 .iterable = false,
@@ -373,7 +373,7 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
                             };
                             existing_dir.close();
                             tmpdir.deleteTree(tmpname) catch {};
-                            break;
+                            break :publish_to_cache;
                         },
                         else => {},
                     }
@@ -393,7 +393,7 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
                 },
             }
 
-            break;
+            break :publish_to_cache;
         }
     } else {
         // Attempt to gracefully handle duplicate concurrent `bun install` calls

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -356,6 +356,7 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
                     switch (err.getErrno()) {
                         .NOTEMPTY, .PERM, .BUSY, .EXIST => {
                             dir_to_move.close();
+                            defer tmpdir.deleteTree(tmpname) catch {};
 
                             // The install cache is write-once. If another process already created this
                             // directory, prefer the existing entry instead of deleting and replacing it.
@@ -372,7 +373,6 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
                                 return error.InstallFailed;
                             };
                             existing_dir.close();
-                            tmpdir.deleteTree(tmpname) catch {};
                             break :publish_to_cache;
                         },
                         else => {},

--- a/test/regression/issue/28062.test.ts
+++ b/test/regression/issue/28062.test.ts
@@ -1,0 +1,171 @@
+// https://github.com/oven-sh/bun/issues/28062
+
+import { expect, setDefaultTimeout, test } from "bun:test";
+import { mkdir, readFile, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+const fixturePackagesDir = join(import.meta.dir, "..", "..", "cli", "install", "registry", "packages");
+const packageNames = [
+  "a-dep",
+  "uses-a-dep-1",
+  "uses-a-dep-2",
+  "uses-a-dep-3",
+  "uses-a-dep-4",
+  "uses-a-dep-5",
+  "uses-a-dep-6",
+  "uses-a-dep-7",
+  "uses-a-dep-8",
+  "uses-a-dep-9",
+  "uses-a-dep-10",
+] as const;
+
+// These tests install packages from a local registry and are a bit slow on Windows.
+setDefaultTimeout(30_000);
+
+type RegistryMetadata = {
+  versions: Record<string, { dist?: { tarball?: string } }>;
+};
+
+type InstallResult = {
+  cwd: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};
+
+function fixtureDirFor(packageName: string) {
+  return join(fixturePackagesDir, packageName);
+}
+
+async function loadMetadata(origin: string) {
+  return new Map(
+    await Promise.all(
+      packageNames.map(async packageName => {
+        const file = await readFile(join(fixtureDirFor(packageName), "package.json"), "utf8");
+        const metadata = JSON.parse(file) as RegistryMetadata;
+
+        for (const version of Object.values(metadata.versions)) {
+          if (version.dist?.tarball) {
+            version.dist.tarball = version.dist.tarball.replace("http://localhost:4873", origin);
+          }
+        }
+
+        return [packageName, JSON.stringify(metadata)] as const;
+      }),
+    ),
+  );
+}
+
+async function writeProject(projectDir: string, bunfig: string, packageJson: string) {
+  await mkdir(projectDir, { recursive: true });
+  await writeFile(join(projectDir, "bunfig.toml"), bunfig);
+  await writeFile(join(projectDir, "package.json"), packageJson);
+}
+
+async function resetProject(projectDir: string) {
+  await Promise.all([
+    rm(join(projectDir, "node_modules"), { recursive: true, force: true }),
+    rm(join(projectDir, "bun.lock"), { force: true }),
+    rm(join(projectDir, "package-lock.json"), { force: true }),
+  ]);
+}
+
+async function runInstall(cwd: string, sharedCacheDir: string): Promise<InstallResult> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", "--no-cache", "--verbose"],
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: sharedCacheDir,
+    },
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { cwd, stdout, stderr, exitCode };
+}
+
+function expectSuccessfulInstalls(label: string, results: InstallResult[]) {
+  for (const result of results) {
+    if (result.exitCode !== 0 || result.stderr.includes("failed opening cache/package/version dir")) {
+      console.error(`${label} failed for ${result.cwd}`);
+      console.error(result.stdout);
+      console.error(result.stderr);
+    }
+
+    expect(result.stderr).not.toContain("failed opening cache/package/version dir");
+    expect(result.exitCode).toBe(0);
+  }
+}
+
+test.skipIf(!isWindows)("parallel shared-cache installs with --no-cache should not lose cache package dirs", async () => {
+  using root = tempDir("issue-28062", {});
+  const rootDir = String(root);
+  const sharedCacheDir = join(rootDir, ".shared-cache");
+  const projects = [join(rootDir, "a"), join(rootDir, "b")];
+  const rootDependencies = Object.fromEntries(packageNames.slice(1).map(packageName => [packageName, "1.0.0"]));
+  let metadataByPackage = new Map<string, string>();
+
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      const parts = url.pathname.split("/").filter(Boolean).map(decodeURIComponent);
+
+      if (parts.length === 1 && metadataByPackage.has(parts[0])) {
+        return new Response(metadataByPackage.get(parts[0]), {
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      if (parts.length === 3 && parts[1] === "-" && metadataByPackage.has(parts[0])) {
+        return new Response(Bun.file(join(fixtureDirFor(parts[0]), parts[2])));
+      }
+
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  metadataByPackage = await loadMetadata(`http://localhost:${server.port}`);
+  const bunfig = `
+[install]
+saveTextLockfile = false
+registry = "http://localhost:${server.port}/"
+linker = "hoisted"
+`;
+  const packageJson = JSON.stringify(
+    {
+      name: "shared-cache-race",
+      private: true,
+      dependencies: rootDependencies,
+    },
+    null,
+    2,
+  );
+
+  await Promise.all(
+    projects.map(projectDir => writeProject(projectDir, bunfig, packageJson)),
+  );
+
+  const reset = async () => {
+    await Promise.all([
+      rm(sharedCacheDir, { recursive: true, force: true }),
+      ...projects.map(resetProject),
+    ]);
+    await mkdir(sharedCacheDir, { recursive: true });
+  };
+
+  await reset();
+  expectSuccessfulInstalls("serial", [
+    await runInstall(projects[0], sharedCacheDir),
+    await runInstall(projects[1], sharedCacheDir),
+  ]);
+
+  await reset();
+  expectSuccessfulInstalls(
+    "parallel",
+    await Promise.all(projects.map(projectDir => runInstall(projectDir, sharedCacheDir))),
+  );
+});

--- a/test/regression/issue/28062.test.ts
+++ b/test/regression/issue/28062.test.ts
@@ -67,6 +67,7 @@ async function resetProject(projectDir: string) {
   await Promise.all([
     rm(join(projectDir, "node_modules"), { recursive: true, force: true }),
     rm(join(projectDir, "bun.lock"), { force: true }),
+    rm(join(projectDir, "bun.lockb"), { force: true }),
     rm(join(projectDir, "package-lock.json"), { force: true }),
   ]);
 }


### PR DESCRIPTION
### What does this PR do?

- Fixes #28062.
- Reuses an existing Windows install cache entry when concurrent shared-cache installs race to publish the same package instead of deleting and replacing it.
- Adds a Windows regression test for parallel `bun install --no-cache` runs in separate projects sharing one `BUN_INSTALL_CACHE_DIR`.

### How did you verify your code works?

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28062.test.ts` fails 10/10 on Bun `1.3.10+30e609e08` with the minimized repro.
- `build/debug/bun-debug.exe test test/regression/issue/28062.test.ts` passes locally with the patch.
- The regression test added in `test/regression/issue/28062.test.ts` exercises the same shared-cache race locally.
