### PR TITLE
fix(install): avoid ENOENT race in Windows parallel cache publish

### DIFF
--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -324,7 +324,6 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
 
     // Now that we've extracted the archive, we rename.
     if (comptime Environment.isWindows) {
-        var did_retry = false;
         var path2_buf: bun.WPathBuffer = undefined;
         const path2 = bun.strings.toWPathNormalized(&path2_buf, folder_name);
         if (create_subdir) {
@@ -335,77 +334,47 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
 
         const path_to_use = path2;
 
-        while (true) {
-            const dir_to_move = bun.sys.openDirAtWindowsA(.fromStdDir(this.temp_dir), tmpname, .{
-                .can_rename_or_delete = true,
-                .iterable = false,
-                .read_only = true,
-            }).unwrap() catch |err| {
-                // i guess we just
-                log.addErrorFmt(
-                    null,
-                    logger.Loc.Empty,
-                    bun.default_allocator,
-                    "moving \"{s}\" to cache dir failed\n{}\n From: {s}\n   To: {s}",
-                    .{ name, err, tmpname, folder_name },
-                ) catch unreachable;
-                return error.InstallFailed;
-            };
+        const dir_to_move = bun.sys.openDirAtWindowsA(.fromStdDir(this.temp_dir), tmpname, .{
+            .can_rename_or_delete = true,
+            .iterable = false,
+            .read_only = true,
+        }).unwrap() catch |err| {
+            log.addErrorFmt(
+                null,
+                logger.Loc.Empty,
+                bun.default_allocator,
+                "moving \"{s}\" to cache dir failed\n{}\n From: {s}\n   To: {s}",
+                .{ name, err, tmpname, folder_name },
+            ) catch unreachable;
+            return error.InstallFailed;
+        };
 
-            switch (bun.windows.moveOpenedFileAt(dir_to_move, .fromStdDir(cache_dir), path_to_use, true)) {
-                .err => |err| {
-                    if (!did_retry) {
-                        switch (err.getErrno()) {
-                            .NOTEMPTY, .PERM, .BUSY, .EXIST => {
-
-                                // before we attempt to delete the destination, let's close the source dir.
-                                dir_to_move.close();
-
-                                // We tried to move the folder over
-                                // but it didn't work!
-                                // so instead of just simply deleting the folder
-                                // we rename it back into the temp dir
-                                // and then delete that temp dir
-                                // The goal is to make it more difficult for an application to reach this folder
-                                var tmpname_bytes = std.mem.asBytes(&tmpname_buf);
-                                const tmpname_len = tmpname.len;
-
-                                tmpname_bytes[tmpname_len..][0..4].* = .{ 't', 'm', 'p', 0 };
-                                const tempdest = tmpname_bytes[0 .. tmpname_len + 3 :0];
-                                switch (bun.sys.renameat(
-                                    .fromStdDir(cache_dir),
-                                    folder_name,
-                                    .fromStdDir(tmpdir),
-                                    tempdest,
-                                )) {
-                                    .err => {},
-                                    .result => {
-                                        tmpdir.deleteTree(tempdest) catch {};
-                                    },
-                                }
-                                tmpname_bytes[tmpname_len] = 0;
-                                did_retry = true;
-                                continue;
-                            },
-                            else => {},
-                        }
-                    }
-                    dir_to_move.close();
-                    log.addErrorFmt(
-                        null,
-                        logger.Loc.Empty,
-                        bun.default_allocator,
-                        "moving \"{s}\" to cache dir failed\n{f}\n  From: {s}\n    To: {s}",
-                        .{ name, err, tmpname, folder_name },
-                    ) catch unreachable;
-                    return error.InstallFailed;
-                },
-                .result => {
-                    dir_to_move.close();
-                },
-            }
-
-            break;
+        switch (bun.windows.moveOpenedFileAt(dir_to_move, .fromStdDir(cache_dir), path_to_use, true)) {
+            .err => |err| {
+                dir_to_move.close();
+                switch (err.getErrno()) {
+                    .NOTEMPTY, .PERM, .BUSY, .EXIST => {
+                        // The cache destination already exists, most likely placed
+                        // by a concurrent install of the same package@version.
+                        // Accept the existing entry instead of deleting and retrying,
+                        // which would cause ENOENT for other processes/threads that
+                        // have already resolved this cache path.
+                    },
+                    else => {
+                        log.addErrorFmt(
+                            null,
+                            logger.Loc.Empty,
+                            bun.default_allocator,
+                            "moving \"{s}\" to cache dir failed\n{f}\n  From: {s}\n    To: {s}",
+                            .{ name, err, tmpname, folder_name },
+                        ) catch unreachable;
+                        return error.InstallFailed;
+                    },
+                }
+            },
+            .result => {
+                dir_to_move.close();
+            },
         }
     } else {
         // Attempt to gracefully handle duplicate concurrent `bun install` calls
@@ -443,15 +412,29 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
 
     // We return a resolved absolute absolute file path to the cache dir.
     // To get that directory, we open the directory again.
-    var final_dir = bun.openDir(cache_dir, folder_name) catch |err| {
-        log.addErrorFmt(
-            null,
-            logger.Loc.Empty,
-            bun.default_allocator,
-            "failed to verify cache dir for \"{s}\": {s}",
-            .{ name, @errorName(err) },
-        ) catch unreachable;
-        return error.InstallFailed;
+    var final_dir = open_cache_dir: {
+        // On Windows, a concurrent install may be moving a directory into this
+        // location at the same moment. Retry a few times to handle the brief
+        // window where the target is not yet visible after an atomic move.
+        if (comptime Environment.isWindows) {
+            var open_retries: u8 = 0;
+            while (open_retries < 3) : (open_retries += 1) {
+                break :open_cache_dir bun.openDir(cache_dir, folder_name) catch {
+                    std.time.sleep(100 * std.time.ns_per_ms);
+                    continue;
+                };
+            }
+        }
+        break :open_cache_dir bun.openDir(cache_dir, folder_name) catch |err| {
+            log.addErrorFmt(
+                null,
+                logger.Loc.Empty,
+                bun.default_allocator,
+                "failed to verify cache dir for \"{s}\": {s}",
+                .{ name, @errorName(err) },
+            ) catch unreachable;
+            return error.InstallFailed;
+        };
     };
     defer final_dir.close();
     // and get the fd path

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -420,7 +420,7 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
             var open_retries: u8 = 0;
             while (open_retries < 3) : (open_retries += 1) {
                 break :open_cache_dir bun.openDir(cache_dir, folder_name) catch {
-                    std.time.sleep(100 * std.time.ns_per_ms);
+                    std.Thread.sleep(100 * std.time.ns_per_ms);
                     continue;
                 };
             }

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -324,6 +324,7 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
 
     // Now that we've extracted the archive, we rename.
     if (comptime Environment.isWindows) {
+        var did_retry = false;
         var path2_buf: bun.WPathBuffer = undefined;
         const path2 = bun.strings.toWPathNormalized(&path2_buf, folder_name);
         if (create_subdir) {
@@ -334,50 +335,85 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
 
         const path_to_use = path2;
 
-        const dir_to_move = bun.sys.openDirAtWindowsA(.fromStdDir(this.temp_dir), tmpname, .{
-            .can_rename_or_delete = true,
-            .iterable = false,
-            .read_only = true,
-        }).unwrap() catch |err| {
-            log.addErrorFmt(
-                null,
-                logger.Loc.Empty,
-                bun.default_allocator,
-                "moving \"{s}\" to cache dir failed\n{}\n From: {s}\n   To: {s}",
-                .{ name, err, tmpname, folder_name },
-            ) catch unreachable;
-            return error.InstallFailed;
-        };
+        while (true) {
+            const dir_to_move = bun.sys.openDirAtWindowsA(.fromStdDir(this.temp_dir), tmpname, .{
+                .can_rename_or_delete = true,
+                .iterable = false,
+                .read_only = true,
+            }).unwrap() catch |err| {
+                log.addErrorFmt(
+                    null,
+                    logger.Loc.Empty,
+                    bun.default_allocator,
+                    "moving \"{s}\" to cache dir failed\n{}\n From: {s}\n   To: {s}",
+                    .{ name, err, tmpname, folder_name },
+                ) catch unreachable;
+                return error.InstallFailed;
+            };
 
-        switch (bun.windows.moveOpenedFileAt(dir_to_move, .fromStdDir(cache_dir), path_to_use, true)) {
-            .err => |err| {
-                dir_to_move.close();
-                switch (err.getErrno()) {
-                    .NOTEMPTY, .PERM, .BUSY, .EXIST => {
-                        // The cache destination already exists, most likely placed
-                        // by a concurrent install of the same package@version.
-                        // Accept the existing entry instead of deleting and retrying,
-                        // which would cause ENOENT for other processes/threads that
-                        // have already resolved this cache path.
-                        //
-                        // Clean up our orphaned temp extraction since it won't be used.
-                        tmpdir.deleteTree(tmpname) catch {};
-                    },
-                    else => {
-                        log.addErrorFmt(
-                            null,
-                            logger.Loc.Empty,
-                            bun.default_allocator,
-                            "moving \"{s}\" to cache dir failed\n{f}\n  From: {s}\n    To: {s}",
-                            .{ name, err, tmpname, folder_name },
-                        ) catch unreachable;
-                        return error.InstallFailed;
-                    },
-                }
-            },
-            .result => {
-                dir_to_move.close();
-            },
+            switch (bun.windows.moveOpenedFileAt(dir_to_move, .fromStdDir(cache_dir), path_to_use, true)) {
+                .err => |err| {
+                    if (!did_retry) {
+                        switch (err.getErrno()) {
+                            .NOTEMPTY, .PERM, .BUSY, .EXIST => {
+                                dir_to_move.close();
+
+                                // Rename the existing cache entry aside so we can
+                                // retry the move. Unlike the previous approach, we
+                                // skip the expensive deleteTree here and defer it
+                                // to after the retry, minimizing the ENOENT window
+                                // for concurrent processes that already resolved
+                                // this cache path.
+                                var tmpname_bytes = std.mem.asBytes(&tmpname_buf);
+                                const tmpname_len = tmpname.len;
+
+                                tmpname_bytes[tmpname_len..][0..4].* = .{ 't', 'm', 'p', 0 };
+                                const tempdest = tmpname_bytes[0 .. tmpname_len + 3 :0];
+                                switch (bun.sys.renameat(
+                                    .fromStdDir(cache_dir),
+                                    folder_name,
+                                    .fromStdDir(tmpdir),
+                                    tempdest,
+                                )) {
+                                    .err => {},
+                                    .result => {},
+                                }
+                                tmpname_bytes[tmpname_len] = 0;
+                                did_retry = true;
+                                continue;
+                            },
+                            else => {},
+                        }
+                    }
+                    dir_to_move.close();
+                    log.addErrorFmt(
+                        null,
+                        logger.Loc.Empty,
+                        bun.default_allocator,
+                        "moving \"{s}\" to cache dir failed\n{f}\n  From: {s}\n    To: {s}",
+                        .{ name, err, tmpname, folder_name },
+                    ) catch unreachable;
+                    return error.InstallFailed;
+                },
+                .result => {
+                    dir_to_move.close();
+                },
+            }
+
+            break;
+        }
+
+        // Deferred cleanup: delete the renamed-aside old cache entry after
+        // the retry succeeded. This runs outside the retry loop so the
+        // ENOENT window (between rename-aside and successful move) is
+        // as short as possible.
+        if (did_retry) {
+            var tmpname_bytes = std.mem.asBytes(&tmpname_buf);
+            const tmpname_len = tmpname.len;
+            tmpname_bytes[tmpname_len..][0..4].* = .{ 't', 'm', 'p', 0 };
+            const tempdest = tmpname_bytes[0 .. tmpname_len + 3 :0];
+            tmpdir.deleteTree(tempdest) catch {};
+            tmpname_bytes[tmpname_len] = 0;
         }
     } else {
         // Attempt to gracefully handle duplicate concurrent `bun install` calls

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -359,7 +359,10 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
                         // it to avoid an ENOENT window that races with concurrent
                         // installs. If corrupt/incomplete, fall back to the
                         // rename-aside-and-retry approach.
+                        // GitHub dependencies may legitimately lack package.json,
+                        // so skip the probe for those resolutions.
                         const cache_valid = blk: {
+                            if (this.resolution.tag == .github) break :blk true;
                             var check_dir = cache_dir.openDir(folder_name, .{}) catch break :blk false;
                             defer check_dir.close();
                             check_dir.access("package.json", .{}) catch break :blk false;

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -359,6 +359,9 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
                         // Accept the existing entry instead of deleting and retrying,
                         // which would cause ENOENT for other processes/threads that
                         // have already resolved this cache path.
+                        //
+                        // Clean up our orphaned temp extraction since it won't be used.
+                        tmpdir.deleteTree(tmpname) catch {};
                     },
                     else => {
                         log.addErrorFmt(
@@ -413,28 +416,28 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
     // We return a resolved absolute absolute file path to the cache dir.
     // To get that directory, we open the directory again.
     var final_dir = open_cache_dir: {
-        // On Windows, a concurrent install may be moving a directory into this
-        // location at the same moment. Retry a few times to handle the brief
-        // window where the target is not yet visible after an atomic move.
-        if (comptime Environment.isWindows) {
-            var open_retries: u8 = 0;
-            while (open_retries < 3) : (open_retries += 1) {
-                break :open_cache_dir bun.openDir(cache_dir, folder_name) catch {
+        const max_open_attempts: u8 = if (comptime Environment.isWindows) 4 else 1;
+        var open_attempt: u8 = 0;
+        while (true) {
+            break :open_cache_dir bun.openDir(cache_dir, folder_name) catch |err| {
+                open_attempt += 1;
+                // On Windows, a concurrent install may be moving a directory
+                // into this location at the same moment. Retry a few times to
+                // handle the brief window where the target is not yet visible.
+                if (open_attempt < max_open_attempts) {
                     std.Thread.sleep(100 * std.time.ns_per_ms);
                     continue;
-                };
-            }
+                }
+                log.addErrorFmt(
+                    null,
+                    logger.Loc.Empty,
+                    bun.default_allocator,
+                    "failed to verify cache dir for \"{s}\": {s}",
+                    .{ name, @errorName(err) },
+                ) catch unreachable;
+                return error.InstallFailed;
+            };
         }
-        break :open_cache_dir bun.openDir(cache_dir, folder_name) catch |err| {
-            log.addErrorFmt(
-                null,
-                logger.Loc.Empty,
-                bun.default_allocator,
-                "failed to verify cache dir for \"{s}\": {s}",
-                .{ name, @errorName(err) },
-            ) catch unreachable;
-            return error.InstallFailed;
-        };
     };
     defer final_dir.close();
     // and get the fd path

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -324,7 +324,6 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
 
     // Now that we've extracted the archive, we rename.
     if (comptime Environment.isWindows) {
-        var did_retry = false;
         var path2_buf: bun.WPathBuffer = undefined;
         const path2 = bun.strings.toWPathNormalized(&path2_buf, folder_name);
         if (create_subdir) {
@@ -335,85 +334,98 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
 
         const path_to_use = path2;
 
-        while (true) {
-            const dir_to_move = bun.sys.openDirAtWindowsA(.fromStdDir(this.temp_dir), tmpname, .{
-                .can_rename_or_delete = true,
-                .iterable = false,
-                .read_only = true,
-            }).unwrap() catch |err| {
-                log.addErrorFmt(
-                    null,
-                    logger.Loc.Empty,
-                    bun.default_allocator,
-                    "moving \"{s}\" to cache dir failed\n{}\n From: {s}\n   To: {s}",
-                    .{ name, err, tmpname, folder_name },
-                ) catch unreachable;
-                return error.InstallFailed;
-            };
+        const dir_to_move = bun.sys.openDirAtWindowsA(.fromStdDir(this.temp_dir), tmpname, .{
+            .can_rename_or_delete = true,
+            .iterable = false,
+            .read_only = true,
+        }).unwrap() catch |err| {
+            log.addErrorFmt(
+                null,
+                logger.Loc.Empty,
+                bun.default_allocator,
+                "moving \"{s}\" to cache dir failed\n{}\n From: {s}\n   To: {s}",
+                .{ name, err, tmpname, folder_name },
+            ) catch unreachable;
+            return error.InstallFailed;
+        };
 
-            switch (bun.windows.moveOpenedFileAt(dir_to_move, .fromStdDir(cache_dir), path_to_use, true)) {
-                .err => |err| {
-                    if (!did_retry) {
-                        switch (err.getErrno()) {
-                            .NOTEMPTY, .PERM, .BUSY, .EXIST => {
-                                dir_to_move.close();
+        switch (bun.windows.moveOpenedFileAt(dir_to_move, .fromStdDir(cache_dir), path_to_use, true)) {
+            .err => |err| {
+                dir_to_move.close();
+                switch (err.getErrno()) {
+                    .NOTEMPTY, .PERM, .BUSY, .EXIST => {
+                        // The cache destination already exists. Check if it's
+                        // valid by probing for package.json. If valid, accept
+                        // it to avoid an ENOENT window that races with concurrent
+                        // installs. If corrupt/incomplete, fall back to the
+                        // rename-aside-and-retry approach.
+                        const cache_valid = blk: {
+                            var check_dir = cache_dir.openDir(folder_name, .{}) catch break :blk false;
+                            defer check_dir.close();
+                            check_dir.access("package.json", .{}) catch break :blk false;
+                            break :blk true;
+                        };
+                        if (cache_valid) {
+                            // Valid cache entry, likely placed by a concurrent
+                            // install of the same package@version. Clean up
+                            // our orphaned temp extraction.
+                            tmpdir.deleteTree(tmpname) catch {};
+                        } else {
+                            // Corrupt/incomplete cache entry. Rename it aside
+                            // and retry the move. This is the single-process
+                            // cache invalidation path.
+                            var tmpname_bytes = std.mem.asBytes(&tmpname_buf);
+                            const tmpname_len = tmpname.len;
 
-                                // Rename the existing cache entry aside so we can
-                                // retry the move. Unlike the previous approach, we
-                                // skip the expensive deleteTree here and defer it
-                                // to after the retry, minimizing the ENOENT window
-                                // for concurrent processes that already resolved
-                                // this cache path.
-                                var tmpname_bytes = std.mem.asBytes(&tmpname_buf);
-                                const tmpname_len = tmpname.len;
+                            tmpname_bytes[tmpname_len..][0..4].* = .{ 't', 'm', 'p', 0 };
+                            const tempdest = tmpname_bytes[0 .. tmpname_len + 3 :0];
+                            switch (bun.sys.renameat(
+                                .fromStdDir(cache_dir),
+                                folder_name,
+                                .fromStdDir(tmpdir),
+                                tempdest,
+                            )) {
+                                .err => {},
+                                .result => {
+                                    tmpdir.deleteTree(tempdest) catch {};
+                                },
+                            }
+                            tmpname_bytes[tmpname_len] = 0;
 
-                                tmpname_bytes[tmpname_len..][0..4].* = .{ 't', 'm', 'p', 0 };
-                                const tempdest = tmpname_bytes[0 .. tmpname_len + 3 :0];
-                                switch (bun.sys.renameat(
-                                    .fromStdDir(cache_dir),
-                                    folder_name,
-                                    .fromStdDir(tmpdir),
-                                    tempdest,
-                                )) {
-                                    .err => {},
-                                    .result => {},
-                                }
-                                tmpname_bytes[tmpname_len] = 0;
-                                did_retry = true;
-                                continue;
-                            },
-                            else => {},
+                            // Retry the move once.
+                            const retry_dir = bun.sys.openDirAtWindowsA(.fromStdDir(tmpdir), tmpname, .{
+                                .can_rename_or_delete = true,
+                                .iterable = false,
+                                .read_only = true,
+                            }).unwrap() catch {
+                                // Can't reopen temp dir, nothing we can do.
+                                return error.InstallFailed;
+                            };
+                            switch (bun.windows.moveOpenedFileAt(retry_dir, .fromStdDir(cache_dir), path_to_use, true)) {
+                                .err => {
+                                    retry_dir.close();
+                                },
+                                .result => {
+                                    retry_dir.close();
+                                },
+                            }
                         }
-                    }
-                    dir_to_move.close();
-                    log.addErrorFmt(
-                        null,
-                        logger.Loc.Empty,
-                        bun.default_allocator,
-                        "moving \"{s}\" to cache dir failed\n{f}\n  From: {s}\n    To: {s}",
-                        .{ name, err, tmpname, folder_name },
-                    ) catch unreachable;
-                    return error.InstallFailed;
-                },
-                .result => {
-                    dir_to_move.close();
-                },
-            }
-
-            break;
-        }
-
-        // Deferred cleanup: delete the renamed-aside old cache entry after
-        // the retry succeeded. This runs outside the retry loop so the
-        // ENOENT window (between rename-aside and successful move) is
-        // as short as possible.
-        if (did_retry) {
-            var tmpname_bytes = std.mem.asBytes(&tmpname_buf);
-            const tmpname_len = tmpname.len;
-            tmpname_bytes[tmpname_len..][0..4].* = .{ 't', 'm', 'p', 0 };
-            const tempdest = tmpname_bytes[0 .. tmpname_len + 3 :0];
-            tmpdir.deleteTree(tempdest) catch {};
-            tmpname_bytes[tmpname_len] = 0;
+                    },
+                    else => {
+                        log.addErrorFmt(
+                            null,
+                            logger.Loc.Empty,
+                            bun.default_allocator,
+                            "moving \"{s}\" to cache dir failed\n{f}\n  From: {s}\n    To: {s}",
+                            .{ name, err, tmpname, folder_name },
+                        ) catch unreachable;
+                        return error.InstallFailed;
+                    },
+                }
+            },
+            .result => {
+                dir_to_move.close();
+            },
         }
     } else {
         // Attempt to gracefully handle duplicate concurrent `bun install` calls

--- a/test/regression/issue/28062.test.ts
+++ b/test/regression/issue/28062.test.ts
@@ -1,0 +1,134 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { basename, join } from "path";
+
+// Minimal tarballs for testing - we reuse the ones from the install test fixtures
+const tgzDir = join(import.meta.dir, "..", "..", "cli", "install");
+
+let server: ReturnType<typeof Bun.serve>;
+let registryUrl: string;
+
+beforeAll(() => {
+  // Start a minimal registry server that serves package manifests and tarballs
+  server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const path = url.pathname;
+
+      // Serve tarball files
+      if (path.endsWith(".tgz")) {
+        const tgzPath = join(tgzDir, basename(path));
+        const file = Bun.file(tgzPath);
+        if (await file.exists()) {
+          return new Response(file);
+        }
+        return new Response("Not found", { status: 404 });
+      }
+
+      // Serve package manifests
+      if (path === "/baz") {
+        return Response.json({
+          name: "baz",
+          "dist-tags": { latest: "0.0.3" },
+          versions: {
+            "0.0.3": {
+              name: "baz",
+              version: "0.0.3",
+              dist: {
+                tarball: `${registryUrl}/baz-0.0.3.tgz`,
+                integrity: "",
+              },
+            },
+          },
+        });
+      }
+
+      if (path === "/bar") {
+        return Response.json({
+          name: "bar",
+          "dist-tags": { latest: "0.0.2" },
+          versions: {
+            "0.0.2": {
+              name: "bar",
+              version: "0.0.2",
+              dist: {
+                tarball: `${registryUrl}/bar-0.0.2.tgz`,
+                integrity: "",
+              },
+            },
+          },
+        });
+      }
+
+      return new Response("Not found", { status: 404 });
+    },
+  });
+  registryUrl = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  server?.stop(true);
+});
+
+test("parallel bun install with shared cache dir should not ENOENT", async () => {
+  using sharedCache = tempDir("shared-cache-", {});
+  const cacheDir = join(String(sharedCache), "install-cache");
+
+  const pkg = JSON.stringify({
+    name: "test-pkg",
+    private: true,
+    dependencies: {
+      bar: "0.0.2",
+      baz: "0.0.3",
+    },
+  });
+
+  const bunfig = `
+[install]
+registry = "${registryUrl}"
+`;
+
+  // Create two project directories with identical dependencies
+  using dirA = tempDir("project-a-", {
+    "package.json": pkg,
+    "bunfig.toml": bunfig,
+  });
+  using dirB = tempDir("project-b-", {
+    "package.json": pkg,
+    "bunfig.toml": bunfig,
+  });
+
+  const runInstall = async (cwd: string) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: cacheDir,
+      },
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    return { stdout, stderr, exitCode };
+  };
+
+  // Run both installs in parallel with the same shared cache directory.
+  // On Windows, this previously caused ENOENT when one process's collision
+  // handler deleted a cache entry that another process had already resolved.
+  const results = await Promise.all([runInstall(String(dirA)), runInstall(String(dirB))]);
+
+  for (const result of results) {
+    expect(result.stderr).not.toContain("ENOENT");
+    expect(result.stderr).not.toContain("failed opening cache");
+    expect(result.stderr).not.toContain("failed to verify cache dir");
+    expect(result.exitCode).toBe(0);
+  }
+}, 30_000);


### PR DESCRIPTION
## Summary

- Fix Windows-only race condition where parallel `bun install` processes sharing a `BUN_INSTALL_CACHE_DIR` could fail with ENOENT
- When the cache collision handler encountered an existing entry, it previously renamed it away and deleted it before retrying — this broke other processes/threads that had already resolved that cache path
- Now accepts the existing cache entry instead, since the folder name includes the package version so the content is equivalent
- Added retry logic to `openDir` on Windows for defense-in-depth against transient visibility delays

## Root Cause

In `extract_tarball.zig`, the Windows code path for publishing extracted packages to the cache had a TOCTOU race:

1. **Process A** moves package to cache via `moveOpenedFileAt` → succeeds
2. **Process B** tries to move to the same cache location → fails with `EXIST`/`NOTEMPTY`
3. **Process B** renames the existing cache entry away to temp and deletes it
4. **Process A** tries to `openDir` on the cache entry that Process B just deleted → **ENOENT**

The non-Windows path already handles this correctly using `renameatConcurrently` with atomic semantics.

## Test plan

- [x] Added regression test (`test/regression/issue/28062.test.ts`) that runs parallel installs with a shared cache directory
- [x] Debug build compiles successfully
- [x] Test passes with debug build
- [ ] Windows CI validates the fix on the affected platform

Closes #28062

🤖 Generated with [Claude Code](https://claude.com/claude-code)