### PR TITLE
fix(node:fs): refactor StatWatcher to use JSRef instead of indirect Strong ref

### DIFF
--- a/src/bun.js/node/node.classes.ts
+++ b/src/bun.js/node/node.classes.ts
@@ -126,7 +126,7 @@ export default [
         length: 0,
       },
     },
-    values: ["listener"],
+    values: ["listener", "prevStat"],
   }),
   define({
     name: "Timeout",

--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -187,15 +187,11 @@ pub const StatWatcher = struct {
 
     globalThis: *jsc.JSGlobalObject,
 
-    /// Kept alive by `last_jsvalue` via `.bind(this)`, which holds a reference
-    /// to `this._handle`.
-    js_this: jsc.JSValue,
+    this_value: jsc.JSRef,
 
     poll_ref: bun.Async.KeepAlive = .{},
 
     #last_stat: bun.threading.Guarded(bun.sys.PosixStat),
-
-    last_jsvalue: jsc.Strong.Optional,
 
     scheduler: bun.ptr.RefPtr(StatWatcherScheduler),
 
@@ -244,7 +240,7 @@ pub const StatWatcher = struct {
         }
         this.poll_ref.unref(this.ctx);
         this.closed = true;
-        this.last_jsvalue.deinit();
+        this.this_value.deinit();
 
         bun.default_allocator.free(this.path);
         bun.default_allocator.destroy(this);
@@ -310,10 +306,7 @@ pub const StatWatcher = struct {
 
         pub fn createStatWatcher(this: Arguments) !jsc.JSValue {
             const obj = try StatWatcher.init(this);
-            if (obj.js_this != .zero) {
-                return obj.js_this;
-            }
-            return .js_undefined;
+            return obj.this_value.tryGet() orelse .js_undefined;
         }
     };
 
@@ -340,7 +333,7 @@ pub const StatWatcher = struct {
         }
         this.poll_ref.unref(this.ctx);
         this.closed = true;
-        this.last_jsvalue.clearWithoutDeallocation();
+        this.this_value.downgrade();
     }
 
     pub fn doClose(this: *StatWatcher, _: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!jsc.JSValue {
@@ -351,6 +344,7 @@ pub const StatWatcher = struct {
     /// If the scheduler is not using this, free instantly, otherwise mark for being freed.
     pub fn finalize(this: *StatWatcher) void {
         log("Finalize\n", .{});
+        this.this_value.finalize();
         this.closed = true;
         this.scheduler.deref();
         this.deref(); // but don't deinit until the scheduler drops its reference
@@ -407,10 +401,11 @@ pub const StatWatcher = struct {
             return;
         }
 
+        const js_this = this.this_value.tryGet() orelse return;
         const globalThis = this.globalThis;
 
         const jsvalue = statToJSStats(globalThis, &this.getLastStat(), this.bigint) catch |err| return globalThis.reportActiveExceptionAsUnhandled(err);
-        this.last_jsvalue.set(globalThis, jsvalue);
+        js.gc.prevStat.set(js_this, globalThis, jsvalue);
 
         this.scheduler.data.append(this);
     }
@@ -421,11 +416,12 @@ pub const StatWatcher = struct {
             return;
         }
 
+        const js_this = this.this_value.tryGet() orelse return;
         const globalThis = this.globalThis;
         const jsvalue = statToJSStats(globalThis, &this.getLastStat(), this.bigint) catch |err| return globalThis.reportActiveExceptionAsUnhandled(err);
-        this.last_jsvalue.set(globalThis, jsvalue);
+        js.gc.prevStat.set(js_this, globalThis, jsvalue);
 
-        _ = js.listenerGetCached(this.js_this).?.call(
+        _ = js.listenerGetCached(js_this).?.call(
             globalThis,
             .js_undefined,
             &[2]jsc.JSValue{
@@ -487,12 +483,13 @@ pub const StatWatcher = struct {
     /// After a restat found the file changed, this calls the listener function.
     pub fn swapAndCallListenerOnMainThread(this: *StatWatcher) void {
         defer this.deref(); // Balance the ref from restat().
-        const prev_jsvalue = this.last_jsvalue.swap();
+        const js_this = this.this_value.tryGet() orelse return;
         const globalThis = this.globalThis;
+        const prev_jsvalue = js.gc.prevStat.get(js_this) orelse .js_undefined;
         const current_jsvalue = statToJSStats(globalThis, &this.getLastStat(), this.bigint) catch return; // TODO: properly propagate exception upwards
-        this.last_jsvalue.set(globalThis, current_jsvalue);
+        js.gc.prevStat.set(js_this, globalThis, current_jsvalue);
 
-        _ = js.listenerGetCached(this.js_this).?.call(
+        _ = js.listenerGetCached(js_this).?.call(
             globalThis,
             .js_undefined,
             &[2]jsc.JSValue{
@@ -532,14 +529,13 @@ pub const StatWatcher = struct {
             .bigint = args.bigint,
             .interval = @max(5, args.interval),
             .globalThis = args.global_this,
-            .js_this = .zero,
+            .this_value = .empty(),
             .closed = false,
             .path = alloc_file_path,
             // Instant.now will not fail on our target platforms.
             .last_check = std.time.Instant.now() catch unreachable,
             // InitStatTask is responsible for setting this
             .#last_stat = .init(std.mem.zeroes(bun.sys.PosixStat)),
-            .last_jsvalue = .empty,
             .scheduler = vm.rareData().nodeFSStatWatcherScheduler(vm),
             .ref_count = .init(),
         };
@@ -550,7 +546,7 @@ pub const StatWatcher = struct {
         }
 
         const js_this = StatWatcher.toJS(this, this.globalThis);
-        this.js_this = js_this;
+        this.this_value = .initStrong(js_this, this.globalThis);
         js.listenerSetCached(js_this, this.globalThis, args.listener);
         InitialStatTask.createAndSchedule(this);
 

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -1,5 +1,5 @@
 import { pathToFileURL } from "bun";
-import { isWindows, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
 import fs from "node:fs";
 import path from "path";
 
@@ -199,4 +199,56 @@ describe("fs.watchFile", () => {
       EventEmitter.defaultMaxListeners = defaultMaxListeners;
     }
   }, 20000);
+
+  // https://github.com/oven-sh/bun/issues/28027
+  // Must run in a subprocess: on an unpatched build this segfaults the runtime.
+  // StatWatcher uses ThreadSafeRefCount so deinit() can run on the WorkPool
+  // thread; that path must never touch HandleSet (which is JS-thread-only).
+  test("no crash when native handle is GC'd without close()", async () => {
+    const dir = tempDirWithFiles(
+      "watchfile-gc",
+      Object.fromEntries(Array.from({ length: 50 }, (_, i) => [`file-${i}.txt`, `data-${i}`])),
+    );
+
+    const fixture = /* js */ `
+      const fs = require("fs");
+      const path = require("path");
+      const dir = ${JSON.stringify(dir)};
+
+      // Create watchers and disconnect native handles without calling close().
+      // The native StatWatcher holds a strong self-ref (JSRef) while active, so
+      // the wrapper stays rooted regardless of _handle being nulled. This used
+      // to crash when finalize() raced with the WorkPool thread's deref().
+      for (let i = 0; i < 50; i++) {
+        const w = fs.watchFile(path.join(dir, "file-" + i + ".txt"), { interval: 5 }, () => {});
+        w._handle = null;
+      }
+
+      // Wait for initial stat tasks to complete and watchers to enter scheduler.
+      await Bun.sleep(100);
+
+      // Force GC a few times while the scheduler is actively re-statting from
+      // the WorkPool thread. On an unpatched build, cross-thread HandleSet
+      // access corrupts the GC's handle linked list and segfaults here.
+      Bun.gc(true);
+      await Bun.sleep(200);
+      Bun.gc(true);
+      await Bun.sleep(100);
+      Bun.gc(true);
+
+      console.log("OK");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -201,49 +201,60 @@ describe("fs.watchFile", () => {
   }, 20000);
 
   // https://github.com/oven-sh/bun/issues/28027
-  // Must run in a subprocess: on an unpatched build this segfaults the runtime.
-  // StatWatcher uses ThreadSafeRefCount so deinit() can run on the WorkPool
-  // thread; that path must never touch HandleSet (which is JS-thread-only).
-  test("no crash when GC races WorkPool deref after unwatchFile", async () => {
+  // The old code held a jsc.Strong (last_jsvalue) and relied on an indirect
+  // chain to keep the JS wrapper alive. finalize() did not clear the Strong,
+  // so when the WorkPool scheduler later called deref() -> deinit(),
+  // HandleSet::deallocate() ran on a non-JS thread and corrupted the GC
+  // handle linked list -> segfault in visitStrongHandles.
+  //
+  // The unwatchFile path cannot reproduce this: close() sets closed=true
+  // before GC, so the scheduler derefs first and deinit() runs on the JS
+  // thread. Only the _handle=null path (no close) forces finalize() to be
+  // the one that sets closed=true, guaranteeing the WorkPool deref is last.
+  //
+  // Windows-only: the corruption is real UB on all platforms but was only
+  // observed to manifest as a crash on Windows (20 attempts on macOS with
+  // 200 watchers and 20 GC cycles never crashed).
+  test.skipIf(!isWindows)("no crash when finalize() races WorkPool deinit", async () => {
     const dir = tempDirWithFiles(
       "watchfile-gc",
-      Object.fromEntries(Array.from({ length: 50 }, (_, i) => [`file-${i}.txt`, `data-${i}`])),
+      Object.fromEntries(Array.from({ length: 50 }, (_, i) => [`f${i}.txt`, `d`])),
     );
 
     const fixture = /* js */ `
       const fs = require("fs");
       const path = require("path");
       const dir = ${JSON.stringify(dir)};
-      const files = Array.from({ length: 50 }, (_, i) => path.join(dir, "file-" + i + ".txt"));
 
-      // Create watchers. Each native StatWatcher strong-refs its JS wrapper
-      // and is ref'd by the scheduler's WorkPool queue.
-      for (const f of files) fs.watchFile(f, { interval: 5 }, () => {});
+      // unref(): release poll_ref so the fixed build can exit naturally
+      // even though JSRef keeps wrappers alive and closed is never set.
+      // _handle = null: disconnect the native wrapper from JS without
+      // calling close(). On the broken build, finalize() is now the only
+      // path that can set closed=true.
+      for (let i = 0; i < 50; i++) {
+        const w = fs.watchFile(path.join(dir, "f" + i + ".txt"), { interval: 5 }, () => {});
+        w.unref();
+        w._handle = null;
+      }
 
-      // Let initial stat tasks complete and watchers enter the scheduler queue.
+      // Let initial stat tasks complete: initialStatSuccessOnMainThread
+      // runs on the JS thread, allocates the Strong (last_jsvalue.set), and
+      // appends the watcher to the scheduler queue (ref_count now 2:
+      // construction + scheduler). Idle GC may also run during this sleep.
       await Bun.sleep(100);
 
-      // unwatchFile -> stop() -> _handle.close(): downgrades JSRef to weak
-      // (HandleSet dealloc on JS thread) and sets closed=true. The scheduler
-      // still holds a native ref and may have restats in flight. The JS
-      // wrapper is now collectable.
-      for (const f of files) fs.unwatchFile(f);
-
-      // Force GC: finalize() runs on JS thread (JSRef: .weak -> .finalized,
-      // no HandleSet touch). Concurrently, the WorkPool thread's scheduler
-      // loop sees closed=true and calls deref() -> deinit(). On an unpatched
-      // build, deinit() called Strong.deinit() -> HandleSet::deallocate()
-      // from the WorkPool thread, corrupting the GC handle list. Now the
-      // JSRef is .finalized so deinit() is a no-op.
+      // On the broken build: finalize() sets closed=true, deref (2->1).
+      // Timer fires, workPoolCallback sees closed=true, deref on WorkPool
+      // (1->0), deinit() calls last_jsvalue.deinit() on the WorkPool thread.
+      // On the fixed build: JSRef initStrong keeps wrappers rooted, none of
+      // this runs, the GC calls below are no-ops.
       Bun.gc(true);
-      await Bun.sleep(50);
+      await Bun.sleep(200);
       Bun.gc(true);
-      await Bun.sleep(50);
+      await Bun.sleep(100);
       Bun.gc(true);
 
       console.log("OK");
-      // Natural exit: close() unref'd poll_ref, scheduler drops all refs,
-      // event loop drains. Hanging here means cleanup is broken.
     `;
 
     await using proc = Bun.spawn({

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -204,7 +204,7 @@ describe("fs.watchFile", () => {
   // Must run in a subprocess: on an unpatched build this segfaults the runtime.
   // StatWatcher uses ThreadSafeRefCount so deinit() can run on the WorkPool
   // thread; that path must never touch HandleSet (which is JS-thread-only).
-  test("no crash when native handle is GC'd without close()", async () => {
+  test("no crash when GC races WorkPool deref after unwatchFile", async () => {
     const dir = tempDirWithFiles(
       "watchfile-gc",
       Object.fromEntries(Array.from({ length: 50 }, (_, i) => [`file-${i}.txt`, `data-${i}`])),
@@ -214,33 +214,36 @@ describe("fs.watchFile", () => {
       const fs = require("fs");
       const path = require("path");
       const dir = ${JSON.stringify(dir)};
+      const files = Array.from({ length: 50 }, (_, i) => path.join(dir, "file-" + i + ".txt"));
 
-      // Create watchers and disconnect native handles without calling close().
-      // The native StatWatcher holds a strong self-ref (JSRef) while active, so
-      // the wrapper stays rooted regardless of _handle being nulled. This used
-      // to crash when finalize() raced with the WorkPool thread's deref().
-      for (let i = 0; i < 50; i++) {
-        const w = fs.watchFile(path.join(dir, "file-" + i + ".txt"), { interval: 5 }, () => {});
-        w._handle = null;
-      }
+      // Create watchers. Each native StatWatcher strong-refs its JS wrapper
+      // and is ref'd by the scheduler's WorkPool queue.
+      for (const f of files) fs.watchFile(f, { interval: 5 }, () => {});
 
-      // Wait for initial stat tasks to complete and watchers to enter scheduler.
+      // Let initial stat tasks complete and watchers enter the scheduler queue.
       await Bun.sleep(100);
 
-      // Force GC a few times while the scheduler is actively re-statting from
-      // the WorkPool thread. On an unpatched build, cross-thread HandleSet
-      // access corrupts the GC's handle linked list and segfaults here.
+      // unwatchFile -> stop() -> _handle.close(): downgrades JSRef to weak
+      // (HandleSet dealloc on JS thread) and sets closed=true. The scheduler
+      // still holds a native ref and may have restats in flight. The JS
+      // wrapper is now collectable.
+      for (const f of files) fs.unwatchFile(f);
+
+      // Force GC: finalize() runs on JS thread (JSRef: .weak -> .finalized,
+      // no HandleSet touch). Concurrently, the WorkPool thread's scheduler
+      // loop sees closed=true and calls deref() -> deinit(). On an unpatched
+      // build, deinit() called Strong.deinit() -> HandleSet::deallocate()
+      // from the WorkPool thread, corrupting the GC handle list. Now the
+      // JSRef is .finalized so deinit() is a no-op.
       Bun.gc(true);
-      await Bun.sleep(200);
+      await Bun.sleep(50);
       Bun.gc(true);
-      await Bun.sleep(100);
+      await Bun.sleep(50);
       Bun.gc(true);
 
       console.log("OK");
-      // Watchers hold a strong self-ref (JSRef) and poll_ref while active, and
-      // we can't close() them (we nulled _handle). Exit explicitly — the test
-      // only needs to verify we survived the GC stress above without segfault.
-      process.exit(0);
+      // Natural exit: close() unref'd poll_ref, scheduler drops all refs,
+      // event loop drains. Hanging here means cleanup is broken.
     `;
 
     await using proc = Bun.spawn({

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -237,6 +237,10 @@ describe("fs.watchFile", () => {
       Bun.gc(true);
 
       console.log("OK");
+      // Watchers hold a strong self-ref (JSRef) and poll_ref while active, and
+      // we can't close() them (we nulled _handle). Exit explicitly — the test
+      // only needs to verify we survived the GC stress above without segfault.
+      process.exit(0);
     `;
 
     await using proc = Bun.spawn({


### PR DESCRIPTION
## What does this PR do?

Fixes a GC crash (segfault in `HandleSet::visitStrongHandles`) caused by a thread-safety bug in `StatWatcher`, by refactoring to the standard `jsc.JSRef` pattern.

### The bug

`StatWatcher` uses `ThreadSafeRefCount`, so `deref()` can drop the refcount to zero on any thread. `finalize()` set `closed = true` but did **not** clear `last_jsvalue` (a `jsc.Strong.Optional` backed by `HandleSet`). When the scheduler's WorkPool thread later called `deref()` → `deinit()` → `last_jsvalue.deinit()`, it would call `HandleSet::deallocate()` from a non-JS thread, corrupting the GC's handle linked list.

### The fix

Rather than patching `finalize()` to clear the Strong (https://github.com/oven-sh/bun/pull/28029), this refactors to the `jsc.JSRef` pattern used by `UDPSocket`, `Timer`, and `ServerWebSocket`:

| Before | After |
|---|---|
| `js_this: jsc.JSValue` (weak, indirectly kept alive) | `this_value: jsc.JSRef` (strong self-ref while active) |
| `last_jsvalue: jsc.Strong.Optional` | `prevStat` stored as a `WriteBarrier` on the JS wrapper via `values: [...]` codegen |

**HandleSet access is now fully confined to the JS thread:**

| Call site | Thread | JSRef transition | HandleSet access |
|---|---|---|---|
| `init()` → `.initStrong()` | JS | empty → strong | allocate |
| `close()` → `.downgrade()` | JS | strong → weak | deallocate |
| `finalize()` → `.finalize()` | JS (GC) | weak → finalized | none (already weak) |
| `deinit()` → `.deinit()` | **WorkPool** | finalized → no-op | **none** |

Since the wrapper strong-refs itself while active, `finalize()` can only be reached after `close()` downgrades. So by the time the WorkPool thread's `deref()` runs `deinit()`, `this_value` is always `.finalized` — a no-op.

The `prevStat` value is now a `JSC::WriteBarrier<JSC::Unknown>` visited by `visitChildren`, so it stays alive exactly as long as the JS wrapper does, with no extra `HandleSet` slot.

### How did you verify your code works?

- `bun run zig:check` passes
- Added the regression test from #28029 (50 watchers, `w._handle = null` without `close()`, force GC while scheduler re-stats from WorkPool thread)

Closes #28027
Closes https://github.com/oven-sh/bun/pull/28029