### PR TITLE
feat(test): add jest.mocked() and vi.mocked() helper

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -110,25 +110,36 @@ declare module "bun:test" {
     ): Mock<Extract<T[K], (...args: any[]) => any>>;
 
     /**
+     * Takes a function or object and returns it typed as deeply mocked.
+     * This is a type-only helper — at runtime it returns the input unchanged.
+     */
+    function mocked<T extends object>(source: T, options?: { shallow?: false }): JestMock.Mocked<T>;
+    /**
+     * Takes a function or object and returns it typed as shallowly mocked.
+     * This is a type-only helper — at runtime it returns the input unchanged.
+     */
+    function mocked<T extends object>(source: T, options: { shallow: true }): JestMock.MockedShallow<T>;
+
+    /**
      * Constructs the type of a mock function, e.g. the return type of `jest.fn()`.
      */
     type Mock<T extends (...args: any[]) => any = (...args: any[]) => any> = JestMock.Mock<T>;
     /**
      * Wraps a class, function or object type with Jest mock type definitions.
      */
-    // type Mocked<T extends object> = JestMock.Mocked<T>;
+    type Mocked<T extends object> = JestMock.Mocked<T>;
     /**
      * Wraps a class type with Jest mock type definitions.
      */
-    // type MockedClass<T extends JestMock.ClassLike> = JestMock.MockedClass<T>;
+    type MockedClass<T extends JestMock.ClassLike> = JestMock.MockedClass<T>;
     /**
      * Wraps a function type with Jest mock type definitions.
      */
-    // type MockedFunction<T extends (...args: any[]) => any> = JestMock.MockedFunction<T>;
+    type MockedFunction<T extends (...args: any[]) => any> = JestMock.MockedFunction<T>;
     /**
      * Wraps an object type with Jest mock type definitions.
      */
-    // type MockedObject<T extends object> = JestMock.MockedObject<T>;
+    type MockedObject<T extends object> = JestMock.MockedObject<T>;
     /**
      * Constructs the type of a replaced property.
      */
@@ -189,6 +200,11 @@ declare module "bun:test" {
      */
     clearAllMocks: typeof jest.clearAllMocks;
     resetAllMocks: typeof jest.resetAllMocks;
+    /**
+     * Takes a function or object and returns it typed as a mock.
+     * This is a type-only helper — at runtime it returns the input unchanged.
+     */
+    mocked: typeof jest.mocked;
     useFakeTimers: typeof jest.useFakeTimers;
     useRealTimers: typeof jest.useRealTimers;
     advanceTimersByTime: typeof jest.advanceTimersByTime;
@@ -2032,64 +2048,49 @@ declare module "bun:test" {
     //   (...args: Parameters<T>): ReturnType<T>;
     // }
 
-    // export type Mocked<T> = T extends ClassLike
-    //   ? MockedClass<T>
-    //   : T extends FunctionLike
-    //   ? MockedFunction<T>
-    //   : T extends object
-    //   ? MockedObject<T>
-    //   : T;
+    export type Mocked<T> = T extends ClassLike
+      ? MockedClass<T>
+      : T extends FunctionLike
+      ? MockedFunction<T>
+      : T extends object
+      ? MockedObject<T>
+      : T;
 
-    // export const mocked: {
-    //   <T extends object>(
-    //     source: T,
-    //     options?: {
-    //       shallow: false;
-    //     },
-    //   ): Mocked<T>;
-    //   <T_1 extends object>(
-    //     source: T_1,
-    //     options: {
-    //       shallow: true;
-    //     },
-    //   ): MockedShallow<T_1>;
-    // };
+    export type MockedClass<T extends ClassLike> = MockInstance<
+      (...args: ConstructorParameters<T>) => Mocked<InstanceType<T>>
+    > &
+      MockedObject<T>;
 
-    // export type MockedClass<T extends ClassLike> = MockInstance<
-    //   (...args: ConstructorParameters<T>) => Mocked<InstanceType<T>>
-    // > &
-    //   MockedObject<T>;
+    export type MockedFunction<T extends FunctionLike> = MockInstance<T> &
+      MockedObject<T>;
 
-    // export type MockedFunction<T extends FunctionLike> = MockInstance<T> &
-    //   MockedObject<T>;
+    type MockedFunctionShallow<T extends FunctionLike> = MockInstance<T> & T;
 
-    // type MockedFunctionShallow<T extends FunctionLike> = MockInstance<T> & T;
+    export type MockedObject<T extends object> = {
+      [K in keyof T]: T[K] extends ClassLike
+        ? MockedClass<T[K]>
+        : T[K] extends FunctionLike
+        ? MockedFunction<T[K]>
+        : T[K] extends object
+        ? MockedObject<T[K]>
+        : T[K];
+    } & T;
 
-    // export type MockedObject<T extends object> = {
-    //   [K in keyof T]: T[K] extends ClassLike
-    //     ? MockedClass<T[K]>
-    //     : T[K] extends FunctionLike
-    //     ? MockedFunction<T[K]>
-    //     : T[K] extends object
-    //     ? MockedObject<T[K]>
-    //     : T[K];
-    // } & T;
+    type MockedObjectShallow<T extends object> = {
+      [K in keyof T]: T[K] extends ClassLike
+        ? MockedClass<T[K]>
+        : T[K] extends FunctionLike
+        ? MockedFunctionShallow<T[K]>
+        : T[K];
+    } & T;
 
-    // type MockedObjectShallow<T extends object> = {
-    //   [K in keyof T]: T[K] extends ClassLike
-    //     ? MockedClass<T[K]>
-    //     : T[K] extends FunctionLike
-    //     ? MockedFunctionShallow<T[K]>
-    //     : T[K];
-    // } & T;
-
-    // export type MockedShallow<T> = T extends ClassLike
-    //   ? MockedClass<T>
-    //   : T extends FunctionLike
-    //   ? MockedFunctionShallow<T>
-    //   : T extends object
-    //   ? MockedObjectShallow<T>
-    //   : T;
+    export type MockedShallow<T> = T extends ClassLike
+      ? MockedClass<T>
+      : T extends FunctionLike
+      ? MockedFunctionShallow<T>
+      : T extends object
+      ? MockedObjectShallow<T>
+      : T;
 
     // export type MockFunctionMetadata<
     //   T = unknown,

--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -35,6 +35,7 @@ BUN_DECLARE_HOST_FUNCTION(JSMock__jsRestoreAllMocks);
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsClearAllMocks);
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsSpyOn);
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsMockFn);
+BUN_DECLARE_HOST_FUNCTION(JSMock__jsMocked);
 
 #define CHECK_IS_MOCK_FUNCTION(thisValue)                                                              \
     if (!thisObject) [[unlikely]] {                                                                    \
@@ -1473,6 +1474,11 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsClearAllMocks, (JSC::JSGlobalObject * globalO
 {
     JSMock__clearAllMocks(jsCast<Zig::GlobalObject*>(globalObject));
     return JSValue::encode(jsUndefined());
+}
+
+BUN_DEFINE_HOST_FUNCTION(JSMock__jsMocked, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
+{
+    return JSValue::encode(callframe->argument(0));
 }
 
 BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callframe))

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -219,14 +219,16 @@ pub const Jest = struct {
         const restoreAllMocks = jsc.JSFunction.create(globalObject, "restoreAllMocks", JSMock__jsRestoreAllMocks, 2, .{});
         const clearAllMocks = jsc.JSFunction.create(globalObject, "clearAllMocks", JSMock__jsClearAllMocks, 2, .{});
         const mockModuleFn = jsc.JSFunction.create(globalObject, "module", JSMock__jsModuleMock, 2, .{});
+        const mockedFn = jsc.JSFunction.create(globalObject, "mocked", JSMock__jsMocked, 1, .{});
         module.put(globalObject, ZigString.static("mock"), mockFn);
         mockFn.put(globalObject, ZigString.static("module"), mockModuleFn);
         mockFn.put(globalObject, ZigString.static("restore"), restoreAllMocks);
         mockFn.put(globalObject, ZigString.static("clearAllMocks"), clearAllMocks);
 
-        const jest = JSValue.createEmptyObject(globalObject, 9 + bun_test.FakeTimers.timerFnsCount);
+        const jest = JSValue.createEmptyObject(globalObject, 10 + bun_test.FakeTimers.timerFnsCount);
         jest.put(globalObject, ZigString.static("fn"), mockFn);
         jest.put(globalObject, ZigString.static("mock"), mockModuleFn);
+        jest.put(globalObject, ZigString.static("mocked"), mockedFn);
         jest.put(globalObject, ZigString.static("spyOn"), spyOn);
         jest.put(globalObject, ZigString.static("restoreAllMocks"), restoreAllMocks);
         jest.put(globalObject, ZigString.static("clearAllMocks"), clearAllMocks);
@@ -239,9 +241,10 @@ pub const Jest = struct {
         module.put(globalObject, ZigString.static("spyOn"), spyOn);
         module.put(globalObject, ZigString.static("expect"), Expect.js.getConstructor(globalObject));
 
-        const vi = JSValue.createEmptyObject(globalObject, 6 + bun_test.FakeTimers.timerFnsCount);
+        const vi = JSValue.createEmptyObject(globalObject, 7 + bun_test.FakeTimers.timerFnsCount);
         vi.put(globalObject, ZigString.static("fn"), mockFn);
         vi.put(globalObject, ZigString.static("mock"), mockModuleFn);
+        vi.put(globalObject, ZigString.static("mocked"), mockedFn);
         vi.put(globalObject, ZigString.static("spyOn"), spyOn);
         vi.put(globalObject, ZigString.static("restoreAllMocks"), restoreAllMocks);
         vi.put(globalObject, ZigString.static("resetAllMocks"), clearAllMocks);
@@ -259,6 +262,7 @@ pub const Jest = struct {
     extern fn JSMock__jsRestoreAllMocks(*JSGlobalObject, *CallFrame) callconv(jsc.conv) JSValue;
     extern fn JSMock__jsClearAllMocks(*JSGlobalObject, *CallFrame) callconv(jsc.conv) JSValue;
     extern fn JSMock__jsSpyOn(*JSGlobalObject, *CallFrame) callconv(jsc.conv) JSValue;
+    extern fn JSMock__jsMocked(*JSGlobalObject, *CallFrame) callconv(jsc.conv) JSValue;
 
     pub fn call(
         globalObject: *JSGlobalObject,

--- a/test/js/bun/test/mock/mock-mocked.test.ts
+++ b/test/js/bun/test/mock/mock-mocked.test.ts
@@ -1,0 +1,74 @@
+import { expect, expectTypeOf, jest, test, vi } from "bun:test";
+
+// =============================================================================
+// Runtime behavior: jest.mocked() / vi.mocked() return their input unchanged.
+// =============================================================================
+
+test("jest.mocked returns the input unchanged at runtime", () => {
+  const fn = jest.fn(() => 42);
+  const mocked = jest.mocked(fn);
+  expect(mocked).toBe(fn);
+});
+
+test("jest.mocked returns objects unchanged at runtime", () => {
+  const obj = { a: 1, b: jest.fn() };
+  expect(jest.mocked(obj)).toBe(obj);
+});
+
+test("jest.mocked with shallow option returns input unchanged", () => {
+  const obj = { nested: { fn: jest.fn() } };
+  expect(jest.mocked(obj, { shallow: true })).toBe(obj);
+  expect(jest.mocked(obj, { shallow: false })).toBe(obj);
+});
+
+test("vi.mocked returns the input unchanged at runtime", () => {
+  const fn = jest.fn(() => 42);
+  expect(vi.mocked(fn)).toBe(fn);
+});
+
+test("vi.mocked with shallow option returns input unchanged", () => {
+  const obj = { nested: { fn: jest.fn() } };
+  expect(vi.mocked(obj, { shallow: true })).toBe(obj);
+});
+
+test("jest.mocked with no arguments returns undefined", () => {
+  // @ts-expect-error - testing runtime behavior with no args
+  expect(jest.mocked()).toBe(undefined);
+});
+
+// =============================================================================
+// Type-level validation
+// =============================================================================
+
+test("jest.mocked types a function as MockedFunction", () => {
+  const fn = jest.fn((x: number) => x * 2);
+  const mocked = jest.mocked(fn);
+
+  // Return type should expose mock control methods
+  expectTypeOf(mocked.mockReturnValue).toBeFunction();
+  expectTypeOf(mocked.mockImplementation).toBeFunction();
+  expectTypeOf(mocked.mockReset).toBeFunction();
+  expectTypeOf(mocked.mock.calls).toEqualTypeOf<number[][]>();
+});
+
+test("jest.mocked types object properties correctly", () => {
+  const obj = {
+    greet: jest.fn((name: string) => `Hello, ${name}`),
+    count: 42,
+  };
+  const mocked = jest.mocked(obj);
+
+  // Function property should be typed as MockedFunction
+  expectTypeOf(mocked.greet.mockReturnValue).toBeFunction();
+
+  // Non-function property retains original type
+  expectTypeOf(mocked.count).toEqualTypeOf<number>();
+});
+
+test("vi.mocked types match jest.mocked types", () => {
+  const fn = jest.fn((x: number) => x * 2);
+  const mocked = vi.mocked(fn);
+
+  expectTypeOf(mocked.mockReturnValue).toBeFunction();
+  expectTypeOf(mocked.mockImplementation).toBeFunction();
+});


### PR DESCRIPTION
  ### What does this PR do?

  - Add `jest.mocked()` and `vi.mocked()` — identity functions that return their input typed as `Mocked<T>`
  - Uncomment and activate `Mocked<T>`, `MockedClass<T>`, `MockedFunction<T>`, `MockedObject<T>`, and `MockedShallow<T>` types in bun-types
  - Supports overloaded signatures: deep mock (default) and `{ shallow: true }`
  - Consistent with Jest v29+

  Addresses #6937

  ### How did you verify your code works?

  - `bun bd test test/js/bun/test/mock/mock-mocked.test.ts`
  - `bun bd test test/js/bun/test/mock/`
  - Verified new tests fail with `USE_SYSTEM_BUN=1 bun test test/js/bun/test/mock/mock-mocked.test.ts`
  - Executed jest tests utilizing `jest.mocked()` in my codebase with `bun-debug` build