### PR TITLE
Fix HTTP/2 settings: getPackedSettings, getUnpackedSettings, enableConnectProtocol

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -215,7 +215,7 @@ const FullSettingsPayload = packed struct(u336) {
     enableConnectProtocol: u32 = 0,
     pub const byteSize: usize = 42;
     pub fn toJS(this: *FullSettingsPayload, globalObject: *jsc.JSGlobalObject) jsc.JSValue {
-        var result = JSValue.createEmptyObject(globalObject, 9);
+        var result = JSValue.createEmptyObject(globalObject, 8);
         result.put(globalObject, jsc.ZigString.static("headerTableSize"), jsc.JSValue.jsNumber(this.headerTableSize));
         result.put(globalObject, jsc.ZigString.static("enablePush"), jsc.JSValue.jsBoolean(this.enablePush > 0));
         result.put(globalObject, jsc.ZigString.static("maxConcurrentStreams"), jsc.JSValue.jsNumber(this.maxConcurrentStreams));

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -198,11 +198,11 @@ const SettingsPayloadUnit = packed struct(u48) {
     }
 };
 
-const FullSettingsPayload = packed struct(u288) {
+const FullSettingsPayload = packed struct(u336) {
     _headerTableSizeType: u16 = @intFromEnum(SettingsType.SETTINGS_HEADER_TABLE_SIZE),
     headerTableSize: u32 = 4096,
     _enablePushType: u16 = @intFromEnum(SettingsType.SETTINGS_ENABLE_PUSH),
-    enablePush: u32 = 0,
+    enablePush: u32 = 1,
     _maxConcurrentStreamsType: u16 = @intFromEnum(SettingsType.SETTINGS_MAX_CONCURRENT_STREAMS),
     maxConcurrentStreams: u32 = 4294967295,
     _initialWindowSizeType: u16 = @intFromEnum(SettingsType.SETTINGS_INITIAL_WINDOW_SIZE),
@@ -211,9 +211,11 @@ const FullSettingsPayload = packed struct(u288) {
     maxFrameSize: u32 = 16384,
     _maxHeaderListSizeType: u16 = @intFromEnum(SettingsType.SETTINGS_MAX_HEADER_LIST_SIZE),
     maxHeaderListSize: u32 = 65535,
-    pub const byteSize: usize = 36;
+    _enableConnectProtocolType: u16 = @intFromEnum(SettingsType.SETTINGS_ENABLE_CONNECT_PROTOCOL),
+    enableConnectProtocol: u32 = 0,
+    pub const byteSize: usize = 42;
     pub fn toJS(this: *FullSettingsPayload, globalObject: *jsc.JSGlobalObject) jsc.JSValue {
-        var result = JSValue.createEmptyObject(globalObject, 8);
+        var result = JSValue.createEmptyObject(globalObject, 9);
         result.put(globalObject, jsc.ZigString.static("headerTableSize"), jsc.JSValue.jsNumber(this.headerTableSize));
         result.put(globalObject, jsc.ZigString.static("enablePush"), jsc.JSValue.jsBoolean(this.enablePush > 0));
         result.put(globalObject, jsc.ZigString.static("maxConcurrentStreams"), jsc.JSValue.jsNumber(this.maxConcurrentStreams));
@@ -221,9 +223,7 @@ const FullSettingsPayload = packed struct(u288) {
         result.put(globalObject, jsc.ZigString.static("maxFrameSize"), jsc.JSValue.jsNumber(this.maxFrameSize));
         result.put(globalObject, jsc.ZigString.static("maxHeaderListSize"), jsc.JSValue.jsNumber(this.maxHeaderListSize));
         result.put(globalObject, jsc.ZigString.static("maxHeaderSize"), jsc.JSValue.jsNumber(this.maxHeaderListSize));
-        // TODO: we dont support this setting yet see https://nodejs.org/api/http2.html#settings-object
-        // we should also support customSettings
-        result.put(globalObject, jsc.ZigString.static("enableConnectProtocol"), .false);
+        result.put(globalObject, jsc.ZigString.static("enableConnectProtocol"), jsc.JSValue.jsBoolean(this.enableConnectProtocol > 0));
         return result;
     }
 
@@ -235,7 +235,8 @@ const FullSettingsPayload = packed struct(u288) {
             .SETTINGS_INITIAL_WINDOW_SIZE => this.initialWindowSize = option.value,
             .SETTINGS_MAX_FRAME_SIZE => this.maxFrameSize = option.value,
             .SETTINGS_MAX_HEADER_LIST_SIZE => this.maxHeaderListSize = option.value,
-            else => {}, // we ignore unknown/unsupportd settings its not relevant if we dont apply them
+            .SETTINGS_ENABLE_CONNECT_PROTOCOL => this.enableConnectProtocol = option.value,
+            else => {},
         }
     }
     pub fn write(this: *FullSettingsPayload, comptime Writer: type, writer: Writer) bool {
@@ -1284,7 +1285,7 @@ pub const H2FrameParser = struct {
             .type = @intFromEnum(FrameType.HTTP_FRAME_SETTINGS),
             .flags = 0,
             .streamIdentifier = 0,
-            .length = 36,
+            .length = FullSettingsPayload.byteSize,
         };
         _ = settingsHeader.write(@TypeOf(writer), writer);
 
@@ -1455,7 +1456,7 @@ pub const H2FrameParser = struct {
             .type = @intFromEnum(FrameType.HTTP_FRAME_SETTINGS),
             .flags = 0,
             .streamIdentifier = 0,
-            .length = 36,
+            .length = FullSettingsPayload.byteSize,
         };
         this.outstandingSettings += 1;
         _ = settingsHeader.write(@TypeOf(writer), writer);

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -85,13 +85,13 @@ const kSettingNames = {
 };
 
 const kSettingIds: Record<number, string> = {
-  0x1: 'headerTableSize',
-  0x2: 'enablePush',
-  0x3: 'maxConcurrentStreams',
-  0x4: 'initialWindowSize',
-  0x5: 'maxFrameSize',
-  0x6: 'maxHeaderListSize',
-  0x8: 'enableConnectProtocol',
+  0x1: "headerTableSize",
+  0x2: "enablePush",
+  0x3: "maxConcurrentStreams",
+  0x4: "initialWindowSize",
+  0x5: "maxFrameSize",
+  0x6: "maxHeaderListSize",
+  0x8: "enableConnectProtocol",
 };
 
 const kDefaultSettings = {
@@ -107,95 +107,95 @@ const kDefaultSettings = {
 
 function throwSettingRangeError(name: string, value: any) {
   const err = new RangeError(`Invalid value for setting "${name}": ${value}`);
-  (err as any).code = 'ERR_HTTP2_INVALID_SETTING_VALUE';
+  (err as any).code = "ERR_HTTP2_INVALID_SETTING_VALUE";
   throw err;
 }
 
 function throwSettingTypeError(name: string, value: any) {
   const err = new TypeError(`Invalid value for setting "${name}": ${value}`);
-  (err as any).code = 'ERR_HTTP2_INVALID_SETTING_VALUE';
+  (err as any).code = "ERR_HTTP2_INVALID_SETTING_VALUE";
   throw err;
 }
 
 function validateSettings(settings: any) {
-  if (typeof settings !== 'object' || settings === null) {
+  if (typeof settings !== "object" || settings === null) {
     throw $ERR_INVALID_ARG_TYPE("settings", "object", settings);
   }
 
   if (settings.headerTableSize !== undefined) {
     const v = settings.headerTableSize;
-    if (typeof v !== 'number' || v < 0 || v > kMaxInt || Number.isNaN(v)) {
-      throwSettingRangeError('headerTableSize', v);
+    if (typeof v !== "number" || v < 0 || v > kMaxInt || Number.isNaN(v)) {
+      throwSettingRangeError("headerTableSize", v);
     }
   }
 
   if (settings.enablePush !== undefined) {
     const v = settings.enablePush;
-    if (typeof v !== 'boolean') {
-      throwSettingTypeError('enablePush', v);
+    if (typeof v !== "boolean") {
+      throwSettingTypeError("enablePush", v);
     }
   }
 
   if (settings.initialWindowSize !== undefined) {
     const v = settings.initialWindowSize;
-    if (typeof v !== 'number' || v < 0 || v > kMaxInt || Number.isNaN(v)) {
-      throwSettingRangeError('initialWindowSize', v);
+    if (typeof v !== "number" || v < 0 || v > kMaxInt || Number.isNaN(v)) {
+      throwSettingRangeError("initialWindowSize", v);
     }
   }
 
   if (settings.maxFrameSize !== undefined) {
     const v = settings.maxFrameSize;
-    if (typeof v !== 'number' || v < 16384 || v > 16777215 || Number.isNaN(v)) {
-      throwSettingRangeError('maxFrameSize', v);
+    if (typeof v !== "number" || v < 16384 || v > 16777215 || Number.isNaN(v)) {
+      throwSettingRangeError("maxFrameSize", v);
     }
   }
 
   if (settings.maxConcurrentStreams !== undefined) {
     const v = settings.maxConcurrentStreams;
-    if (typeof v !== 'number' || v < 0 || v > kMaxInt || Number.isNaN(v)) {
-      throwSettingRangeError('maxConcurrentStreams', v);
+    if (typeof v !== "number" || v < 0 || v > kMaxInt || Number.isNaN(v)) {
+      throwSettingRangeError("maxConcurrentStreams", v);
     }
   }
 
   if (settings.maxHeaderListSize !== undefined) {
     const v = settings.maxHeaderListSize;
-    if (typeof v !== 'number' || v < 0 || v > kMaxInt || Number.isNaN(v)) {
-      throwSettingRangeError('maxHeaderListSize', v);
+    if (typeof v !== "number" || v < 0 || v > kMaxInt || Number.isNaN(v)) {
+      throwSettingRangeError("maxHeaderListSize", v);
     }
   }
 
   if (settings.maxHeaderSize !== undefined) {
     const v = settings.maxHeaderSize;
-    if (typeof v !== 'number' || v < 0 || v > kMaxInt || Number.isNaN(v)) {
-      throwSettingRangeError('maxHeaderSize', v);
+    if (typeof v !== "number" || v < 0 || v > kMaxInt || Number.isNaN(v)) {
+      throwSettingRangeError("maxHeaderSize", v);
     }
   }
 
   if (settings.enableConnectProtocol !== undefined) {
     const v = settings.enableConnectProtocol;
-    if (typeof v !== 'boolean') {
-      throwSettingTypeError('enableConnectProtocol', v);
+    if (typeof v !== "boolean") {
+      throwSettingTypeError("enableConnectProtocol", v);
     }
   }
 
   if (settings.customSettings !== undefined) {
     const cs = settings.customSettings;
-    if (typeof cs !== 'object' || cs === null) {
-      throwSettingRangeError('customSettings', cs);
+    if (typeof cs !== "object" || cs === null) {
+      throwSettingRangeError("customSettings", cs);
     }
     const keys = Object.keys(cs);
     if (keys.length > MAX_ADDITIONAL_SETTINGS) {
-      const err = new Error('Number of custom settings exceeds MAX_ADDITIONAL_SETTINGS');
-      (err as any).code = 'ERR_HTTP2_TOO_MANY_CUSTOM_SETTINGS';
+      const err = new Error("Number of custom settings exceeds MAX_ADDITIONAL_SETTINGS");
+      (err as any).code = "ERR_HTTP2_TOO_MANY_CUSTOM_SETTINGS";
       throw err;
     }
     for (const key of keys) {
       const id = Number(key);
-      if (!Number.isInteger(id) || id < 0 || id > 0xFFFF) {
+      if (!Number.isInteger(id) || id < 0 || id > 0xffff) {
         throwSettingRangeError(key, cs[key]);
       }
       const val = cs[key];
-      if (typeof val !== 'number' || val < 0 || val > kMaxInt || !Number.isFinite(val)) {
+      if (typeof val !== "number" || val < 0 || val > kMaxInt || !Number.isFinite(val)) {
         throwSettingRangeError(key, val);
       }
     }
@@ -267,8 +267,8 @@ function getUnpackedSettings(buf?: any, options?: any): any {
   const data = Buffer.isBuffer(buf) ? buf : Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength);
 
   if (data.length % 6 !== 0) {
-    const err = new RangeError('Packed settings length must be a multiple of six');
-    (err as any).code = 'ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH';
+    const err = new RangeError("Packed settings length must be a multiple of six");
+    (err as any).code = "ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH";
     throw err;
   }
 
@@ -282,14 +282,14 @@ function getUnpackedSettings(buf?: any, options?: any): any {
 
     const name = kSettingIds[type];
     if (name) {
-      if (name === 'enablePush') {
+      if (name === "enablePush") {
         settings[name] = value !== 0;
-      } else if (name === 'enableConnectProtocol') {
+      } else if (name === "enableConnectProtocol") {
         settings[name] = value !== 0;
       } else {
         settings[name] = value;
       }
-      if (name === 'maxHeaderListSize') {
+      if (name === "maxHeaderListSize") {
         settings.maxHeaderSize = value;
       }
     } else {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -97,7 +97,7 @@ const kSettingIds: Record<number, string> = {
 const kDefaultSettings = {
   headerTableSize: 4096,
   enablePush: true,
-  maxConcurrentStreams: kMaxStreams,
+  maxConcurrentStreams: 2 ** 32 - 1,
   initialWindowSize: 65535,
   maxFrameSize: 16384,
   maxHeaderListSize: 65535,
@@ -118,7 +118,7 @@ function throwSettingTypeError(name: string, value: any) {
 }
 
 function validateSettings(settings: any) {
-  if (typeof settings !== "object" || settings === null) {
+  if (typeof settings !== "object" || settings === null || $isArray(settings)) {
     throw $ERR_INVALID_ARG_TYPE("settings", "object", settings);
   }
 
@@ -183,7 +183,7 @@ function validateSettings(settings: any) {
     if (typeof cs !== "object" || cs === null) {
       throwSettingRangeError("customSettings", cs);
     }
-    const keys = Object.keys(cs);
+    const keys = ObjectKeys(cs);
     if (keys.length > MAX_ADDITIONAL_SETTINGS) {
       const err = new Error("Number of custom settings exceeds MAX_ADDITIONAL_SETTINGS");
       (err as any).code = "ERR_HTTP2_TOO_MANY_CUSTOM_SETTINGS";
@@ -237,7 +237,7 @@ function getPackedSettings(settings?: any): Buffer {
   }
   if (settings.customSettings) {
     const cs = settings.customSettings;
-    const keys = Object.keys(cs);
+    const keys = ObjectKeys(cs);
     // Sort custom settings by ID for consistent output
     keys.sort((a, b) => Number(a) - Number(b));
     for (const key of keys) {
@@ -263,10 +263,7 @@ function getUnpackedSettings(buf?: any, options?: any): any {
     throw $ERR_INVALID_ARG_TYPE("buf", ["Buffer", "TypedArray"], buf);
   }
 
-  // Convert TypedArray to Buffer if needed
-  const data = Buffer.isBuffer(buf) ? buf : Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength);
-
-  if (data.length % 6 !== 0) {
+  if (buf.length % 6 !== 0) {
     const err = new RangeError("Packed settings length must be a multiple of six");
     (err as any).code = "ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH";
     throw err;
@@ -276,9 +273,12 @@ function getUnpackedSettings(buf?: any, options?: any): any {
   const customSettings: Record<string, number> = {};
   let hasCustom = false;
 
-  for (let i = 0; i < data.length; i += 6) {
-    const type = data.readUInt16BE(i);
-    const value = data.readUInt32BE(i + 2);
+  // Use element-by-element access so it works for both Buffer and TypedArrays.
+  // For Buffer, buf[i] returns a byte. For Uint16Array etc., buf[i] returns
+  // the i-th element. Node.js reads settings this way too.
+  for (let i = 0; i < buf.length; i += 6) {
+    const type = buf[i] * 256 + buf[i + 1];
+    const value = ((buf[i + 2] << 24) | (buf[i + 3] << 16) | (buf[i + 4] << 8) | buf[i + 5]) >>> 0;
 
     const name = kSettingIds[type];
     if (name) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -39,6 +39,7 @@ const bunSocketServerOptions = Symbol.for("::bunnetserveroptions::");
 const kInfoHeaders = Symbol("sent-info-headers");
 const kProxySocket = Symbol("proxySocket");
 const kSessions = Symbol("sessions");
+const kOptions = Symbol("options");
 const kQuotedString = /^[\x09\x20-\x5b\x5d-\x7e\x80-\xff]*$/;
 const MAX_ADDITIONAL_SETTINGS = 10;
 const Stream = require("node:stream");
@@ -70,10 +71,243 @@ const DatePrototypeToUTCString = Date.prototype.toUTCString;
 const DatePrototypeGetMilliseconds = Date.prototype.getMilliseconds;
 
 const H2FrameParser = $zig("h2_frame_parser.zig", "H2FrameParserConstructor");
-const assertSettings = $newZigFunction("h2_frame_parser.zig", "jsAssertSettings", 1);
-const getPackedSettings = $newZigFunction("h2_frame_parser.zig", "jsGetPackedSettings", 1);
-const getUnpackedSettings = $newZigFunction("h2_frame_parser.zig", "jsGetUnpackedSettings", 1);
+const _nativeAssertSettings = $newZigFunction("h2_frame_parser.zig", "jsAssertSettings", 1);
 const { upgradeRawSocketToH2 } = require("node:_http2_upgrade");
+
+const kSettingNames = {
+  headerTableSize: 0x1,
+  enablePush: 0x2,
+  maxConcurrentStreams: 0x3,
+  initialWindowSize: 0x4,
+  maxFrameSize: 0x5,
+  maxHeaderListSize: 0x6,
+  enableConnectProtocol: 0x8,
+};
+
+const kSettingIds: Record<number, string> = {
+  0x1: 'headerTableSize',
+  0x2: 'enablePush',
+  0x3: 'maxConcurrentStreams',
+  0x4: 'initialWindowSize',
+  0x5: 'maxFrameSize',
+  0x6: 'maxHeaderListSize',
+  0x8: 'enableConnectProtocol',
+};
+
+const kDefaultSettings = {
+  headerTableSize: 4096,
+  enablePush: true,
+  maxConcurrentStreams: kMaxStreams,
+  initialWindowSize: 65535,
+  maxFrameSize: 16384,
+  maxHeaderListSize: 65535,
+  maxHeaderSize: 65535,
+  enableConnectProtocol: false,
+};
+
+function throwSettingRangeError(name: string, value: any) {
+  const err = new RangeError(`Invalid value for setting "${name}": ${value}`);
+  (err as any).code = 'ERR_HTTP2_INVALID_SETTING_VALUE';
+  throw err;
+}
+
+function throwSettingTypeError(name: string, value: any) {
+  const err = new TypeError(`Invalid value for setting "${name}": ${value}`);
+  (err as any).code = 'ERR_HTTP2_INVALID_SETTING_VALUE';
+  throw err;
+}
+
+function validateSettings(settings: any) {
+  if (typeof settings !== 'object' || settings === null) {
+    throw $ERR_INVALID_ARG_TYPE("settings", "object", settings);
+  }
+
+  if (settings.headerTableSize !== undefined) {
+    const v = settings.headerTableSize;
+    if (typeof v !== 'number' || v < 0 || v > kMaxInt || Number.isNaN(v)) {
+      throwSettingRangeError('headerTableSize', v);
+    }
+  }
+
+  if (settings.enablePush !== undefined) {
+    const v = settings.enablePush;
+    if (typeof v !== 'boolean') {
+      throwSettingTypeError('enablePush', v);
+    }
+  }
+
+  if (settings.initialWindowSize !== undefined) {
+    const v = settings.initialWindowSize;
+    if (typeof v !== 'number' || v < 0 || v > kMaxInt || Number.isNaN(v)) {
+      throwSettingRangeError('initialWindowSize', v);
+    }
+  }
+
+  if (settings.maxFrameSize !== undefined) {
+    const v = settings.maxFrameSize;
+    if (typeof v !== 'number' || v < 16384 || v > 16777215 || Number.isNaN(v)) {
+      throwSettingRangeError('maxFrameSize', v);
+    }
+  }
+
+  if (settings.maxConcurrentStreams !== undefined) {
+    const v = settings.maxConcurrentStreams;
+    if (typeof v !== 'number' || v < 0 || v > kMaxInt || Number.isNaN(v)) {
+      throwSettingRangeError('maxConcurrentStreams', v);
+    }
+  }
+
+  if (settings.maxHeaderListSize !== undefined) {
+    const v = settings.maxHeaderListSize;
+    if (typeof v !== 'number' || v < 0 || v > kMaxInt || Number.isNaN(v)) {
+      throwSettingRangeError('maxHeaderListSize', v);
+    }
+  }
+
+  if (settings.maxHeaderSize !== undefined) {
+    const v = settings.maxHeaderSize;
+    if (typeof v !== 'number' || v < 0 || v > kMaxInt || Number.isNaN(v)) {
+      throwSettingRangeError('maxHeaderSize', v);
+    }
+  }
+
+  if (settings.enableConnectProtocol !== undefined) {
+    const v = settings.enableConnectProtocol;
+    if (typeof v !== 'boolean') {
+      throwSettingTypeError('enableConnectProtocol', v);
+    }
+  }
+
+  if (settings.customSettings !== undefined) {
+    const cs = settings.customSettings;
+    if (typeof cs !== 'object' || cs === null) {
+      throwSettingRangeError('customSettings', cs);
+    }
+    const keys = Object.keys(cs);
+    if (keys.length > MAX_ADDITIONAL_SETTINGS) {
+      const err = new Error('Number of custom settings exceeds MAX_ADDITIONAL_SETTINGS');
+      (err as any).code = 'ERR_HTTP2_TOO_MANY_CUSTOM_SETTINGS';
+      throw err;
+    }
+    for (const key of keys) {
+      const id = Number(key);
+      if (!Number.isInteger(id) || id < 0 || id > 0xFFFF) {
+        throwSettingRangeError(key, cs[key]);
+      }
+      const val = cs[key];
+      if (typeof val !== 'number' || val < 0 || val > kMaxInt || !Number.isFinite(val)) {
+        throwSettingRangeError(key, val);
+      }
+    }
+  }
+}
+
+function assertSettings(settings: any) {
+  validateSettings(settings);
+}
+
+function getPackedSettings(settings?: any): Buffer {
+  if (settings === undefined) return Buffer.alloc(0);
+  validateSettings(settings);
+
+  const entries: Array<[number, number]> = [];
+
+  if (settings.headerTableSize !== undefined) {
+    entries.push([0x1, settings.headerTableSize]);
+  }
+  if (settings.enablePush !== undefined) {
+    entries.push([0x2, settings.enablePush ? 1 : 0]);
+  }
+  if (settings.maxConcurrentStreams !== undefined) {
+    entries.push([0x3, settings.maxConcurrentStreams]);
+  }
+  if (settings.initialWindowSize !== undefined) {
+    entries.push([0x4, settings.initialWindowSize]);
+  }
+  if (settings.maxFrameSize !== undefined) {
+    entries.push([0x5, settings.maxFrameSize]);
+  }
+  if (settings.maxHeaderListSize !== undefined) {
+    entries.push([0x6, settings.maxHeaderListSize]);
+  } else if (settings.maxHeaderSize !== undefined) {
+    entries.push([0x6, settings.maxHeaderSize]);
+  }
+  if (settings.enableConnectProtocol !== undefined) {
+    entries.push([0x8, settings.enableConnectProtocol ? 1 : 0]);
+  }
+  if (settings.customSettings) {
+    const cs = settings.customSettings;
+    const keys = Object.keys(cs);
+    // Sort custom settings by ID for consistent output
+    keys.sort((a, b) => Number(a) - Number(b));
+    for (const key of keys) {
+      entries.push([Number(key), cs[key]]);
+    }
+  }
+
+  const buf = Buffer.alloc(entries.length * 6);
+  for (let i = 0; i < entries.length; i++) {
+    const offset = i * 6;
+    buf.writeUInt16BE(entries[i][0], offset);
+    buf.writeUInt32BE(entries[i][1], offset + 2);
+  }
+  return buf;
+}
+
+function getUnpackedSettings(buf?: any, options?: any): any {
+  if (buf === undefined) {
+    return { ...kDefaultSettings };
+  }
+
+  if (!Buffer.isBuffer(buf) && !isTypedArray(buf)) {
+    throw $ERR_INVALID_ARG_TYPE("buf", ["Buffer", "TypedArray"], buf);
+  }
+
+  // Convert TypedArray to Buffer if needed
+  const data = Buffer.isBuffer(buf) ? buf : Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength);
+
+  if (data.length % 6 !== 0) {
+    const err = new RangeError('Packed settings length must be a multiple of six');
+    (err as any).code = 'ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH';
+    throw err;
+  }
+
+  const settings: any = {};
+  const customSettings: Record<string, number> = {};
+  let hasCustom = false;
+
+  for (let i = 0; i < data.length; i += 6) {
+    const type = data.readUInt16BE(i);
+    const value = data.readUInt32BE(i + 2);
+
+    const name = kSettingIds[type];
+    if (name) {
+      if (name === 'enablePush') {
+        settings[name] = value !== 0;
+      } else if (name === 'enableConnectProtocol') {
+        settings[name] = value !== 0;
+      } else {
+        settings[name] = value;
+      }
+      if (name === 'maxHeaderListSize') {
+        settings.maxHeaderSize = value;
+      }
+    } else {
+      customSettings[String(type)] = value;
+      hasCustom = true;
+    }
+  }
+
+  if (hasCustom) {
+    settings.customSettings = customSettings;
+  }
+
+  if (options && options.validate) {
+    validateSettings(settings);
+  }
+
+  return settings;
+}
 
 const sensitiveHeaders = Symbol.for("nodejs.http2.sensitiveHeaders");
 const bunHTTP2Native = Symbol.for("::bunhttp2native::");
@@ -2972,6 +3206,7 @@ class ServerHttp2Session extends Http2Session {
     if (callback !== undefined && typeof callback !== "function") {
       throw $ERR_INVALID_ARG_TYPE("callback", "function", callback);
     }
+    validateSettings(settings);
     this.#pendingSettingsAck = true;
     this.#parser?.settings(settings);
     if (typeof callback === "function") {
@@ -3414,6 +3649,7 @@ class ClientHttp2Session extends Http2Session {
     if (callback !== undefined && typeof callback !== "function") {
       throw $ERR_INVALID_ARG_TYPE("callback", "function", callback);
     }
+    validateSettings(settings);
     this.#pendingSettingsAck = true;
     this.#parser?.settings(settings);
     if (typeof callback === "function") {
@@ -3808,6 +4044,7 @@ class Http2Server extends net.Server {
     options = initializeOptions(options);
     super(options);
     this[kSessions] = new SafeSet();
+    this[kOptions] = { settings: options.settings || {} };
 
     this.setMaxListeners(0);
 
@@ -3819,8 +4056,6 @@ class Http2Server extends net.Server {
 
   emit(event: string, ...args: any[]) {
     if (event === "connection") {
-      // TODO: implement this at net/tls level to allow to inject socket in the server
-      // this works for now for Http2Server
       super.prependOnceListener("connection", connectionListener);
     }
     return super.emit(event, ...args);
@@ -3838,6 +4073,7 @@ class Http2Server extends net.Server {
     if (options) {
       options.settings = { ...options.settings, ...settings };
     }
+    this[kOptions].settings = { ...this[kOptions].settings, ...settings };
   }
 
   close(callback?: Function) {
@@ -3913,6 +4149,7 @@ class Http2SecureServer extends tls.Server {
     }
     super(options, connectionListener);
     this[kSessions] = new SafeSet();
+    this[kOptions] = { settings: settings || {} };
     this.setMaxListeners(0);
     this.on("newListener", setupCompat);
     if (typeof onRequestHandler === "function") {
@@ -3942,6 +4179,7 @@ class Http2SecureServer extends tls.Server {
     if (options) {
       options.settings = { ...options.settings, ...settings };
     }
+    this[kOptions].settings = { ...this[kOptions].settings, ...settings };
   }
   close(callback?: Function) {
     super.close(callback);

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -251,7 +251,7 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
             expect(settings).toBeDefined();
             expect(settings).toEqual({
               headerTableSize: 4096,
-              enablePush: false,
+              enablePush: true,
               maxConcurrentStreams: 4294967295,
               initialWindowSize: 65535,
               maxFrameSize: 16384,
@@ -530,7 +530,7 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           expect(settings).toEqual({
             enableConnectProtocol: false,
             headerTableSize: 4096,
-            enablePush: false,
+            enablePush: true,
             initialWindowSize: 65535,
             maxFrameSize: 16384,
             maxConcurrentStreams: 4294967295,
@@ -550,24 +550,20 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
             enableConnectProtocol: false,
           };
           const buffer = http2.getPackedSettings(settings);
-          expect(buffer.byteLength).toBe(36);
+          expect(buffer.byteLength).toBe(42);
           expect(http2.getUnpackedSettings(buffer)).toEqual(settings);
         });
         it("getUnpackedSettings should throw if buffer is too small", () => {
-          const buffer = new ArrayBuffer(1);
-          expect(() => http2.getUnpackedSettings(buffer)).toThrow(
-            /Expected buf to be a Buffer of at least 6 bytes and a multiple of 6 bytes/,
-          );
+          const buffer = Buffer.alloc(1);
+          expect(() => http2.getUnpackedSettings(buffer)).toThrow(/Packed settings length must be a multiple of six/);
         });
         it("getUnpackedSettings should throw if buffer is not a multiple of 6 bytes", () => {
-          const buffer = new ArrayBuffer(7);
-          expect(() => http2.getUnpackedSettings(buffer)).toThrow(
-            /Expected buf to be a Buffer of at least 6 bytes and a multiple of 6 bytes/,
-          );
+          const buffer = Buffer.alloc(7);
+          expect(() => http2.getUnpackedSettings(buffer)).toThrow(/Packed settings length must be a multiple of six/);
         });
         it("getUnpackedSettings should throw if buffer is not a buffer", () => {
           const buffer = {};
-          expect(() => http2.getUnpackedSettings(buffer)).toThrow(/Expected buf to be a Buffer/);
+          expect(() => http2.getUnpackedSettings(buffer)).toThrow();
         });
         it("headers cannot be bigger than 65536 bytes", async () => {
           await using server = await nodeEchoServer(paddingStrategy);

--- a/test/js/node/test/parallel/test-http2-getpackedsettings.js
+++ b/test/js/node/test/parallel/test-http2-getpackedsettings.js
@@ -1,0 +1,340 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+const check = Buffer.from([0x00, 0x01, 0x00, 0x00, 0x10, 0x00,
+                           0x00, 0x02, 0x00, 0x00, 0x00, 0x01,
+                           0x00, 0x03, 0xff, 0xff, 0xff, 0xff,
+                           0x00, 0x04, 0x00, 0x00, 0xff, 0xff,
+                           0x00, 0x05, 0x00, 0x00, 0x40, 0x00,
+                           0x00, 0x06, 0x00, 0x00, 0xff, 0xff,
+                           0x00, 0x08, 0x00, 0x00, 0x00, 0x00]);
+const val = http2.getPackedSettings(http2.getDefaultSettings());
+assert.deepStrictEqual(val, check);
+
+[
+  ['headerTableSize', 0],
+  ['headerTableSize', 2 ** 32 - 1],
+  ['initialWindowSize', 0],
+  ['initialWindowSize', 2 ** 32 - 1],
+  ['maxFrameSize', 16384],
+  ['maxFrameSize', 2 ** 24 - 1],
+  ['maxConcurrentStreams', 0],
+  ['maxConcurrentStreams', 2 ** 31 - 1],
+  ['maxHeaderListSize', 0],
+  ['maxHeaderListSize', 2 ** 32 - 1],
+  ['maxHeaderSize', 0],
+  ['maxHeaderSize', 2 ** 32 - 1],
+  ['customSettings', { '9999': 301 }],
+].forEach((i) => {
+  // Valid options should not throw.
+  http2.getPackedSettings({ [i[0]]: i[1] });
+});
+
+http2.getPackedSettings({ enablePush: true });
+http2.getPackedSettings({ enablePush: false });
+
+[
+  ['headerTableSize', -1],
+  ['headerTableSize', 2 ** 32],
+  ['initialWindowSize', -1],
+  ['initialWindowSize', 2 ** 32],
+  ['maxFrameSize', 16383],
+  ['maxFrameSize', 2 ** 24],
+  ['maxConcurrentStreams', -1],
+  ['maxConcurrentStreams', 2 ** 32],
+  ['maxHeaderListSize', -1],
+  ['maxHeaderListSize', 2 ** 32],
+  ['maxHeaderSize', -1],
+  ['maxHeaderSize', 2 ** 32],
+].forEach((i) => {
+  assert.throws(() => {
+    http2.getPackedSettings({ [i[0]]: i[1] });
+  }, {
+    code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
+    name: 'RangeError',
+    message: `Invalid value for setting "${i[0]}": ${i[1]}`
+  });
+});
+
+[
+  1, null, '', Infinity, new Date(), {}, NaN, [false],
+].forEach((i) => {
+  assert.throws(() => {
+    http2.getPackedSettings({ enablePush: i });
+  }, {
+    code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
+    name: 'TypeError',
+    message: `Invalid value for setting "enablePush": ${i}`
+  });
+});
+
+[
+  1, null, '', Infinity, new Date(), {}, NaN, [false],
+].forEach((i) => {
+  assert.throws(() => {
+    http2.getPackedSettings({ enableConnectProtocol: i });
+  }, {
+    code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
+    name: 'TypeError',
+    message: `Invalid value for setting "enableConnectProtocol": ${i}`
+  });
+});
+
+{
+  const check = Buffer.from([
+    0x00, 0x01, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x02, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x03, 0x00, 0x00, 0x00, 0xc8,
+    0x00, 0x04, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x05, 0x00, 0x00, 0x4e, 0x20,
+    0x00, 0x06, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x08, 0x00, 0x00, 0x00, 0x00,
+    0x27, 0x0F, 0x00, 0x00, 0x01, 0x2d,
+  ]);
+
+  const packed = http2.getPackedSettings({
+    headerTableSize: 100,
+    initialWindowSize: 100,
+    maxFrameSize: 20000,
+    maxConcurrentStreams: 200,
+    maxHeaderListSize: 100,
+    maxHeaderSize: 100,
+    enablePush: true,
+    enableConnectProtocol: false,
+    foo: 'ignored',
+    customSettings: { '9999': 301 }
+  });
+  assert.strictEqual(packed.length, 48);
+  assert.deepStrictEqual(packed, check);
+}
+
+// Check if multiple custom settings can be set
+{
+  const check = Buffer.from([
+    0x00, 0x01, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x02, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x03, 0x00, 0x00, 0x00, 0xc8,
+    0x00, 0x04, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x05, 0x00, 0x00, 0x4e, 0x20,
+    0x00, 0x06, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x08, 0x00, 0x00, 0x00, 0x00,
+    0x03, 0xf3, 0x00, 0x00, 0x07, 0x9F,
+    0x0a, 0x2e, 0x00, 0x00, 0x00, 0x58,
+  ]);
+
+  const packed = http2.getPackedSettings({
+    headerTableSize: 100,
+    initialWindowSize: 100,
+    maxFrameSize: 20000,
+    maxConcurrentStreams: 200,
+    maxHeaderListSize: 100,
+    maxHeaderSize: 100,
+    enablePush: true,
+    enableConnectProtocol: false,
+    customSettings: { '2606': 88, '1011': 1951 }
+  });
+  assert.strictEqual(packed.length, 54);
+  assert.deepStrictEqual(packed, check);
+}
+
+{
+  // Check if wrong custom settings cause an error
+
+  assert.throws(() => {
+    http2.getPackedSettings({
+      customSettings: { '-1': 659685 }
+    });
+  }, {
+    code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
+    name: 'RangeError'
+  });
+
+  assert.throws(() => {
+    http2.getPackedSettings({
+      customSettings: { '10': 34577577777 }
+    });
+  }, {
+    code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
+    name: 'RangeError'
+  });
+
+  assert.throws(() => {
+    http2.getPackedSettings({
+      customSettings: { 'notvalid': -777 }
+    });
+  }, {
+    code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
+    name: 'RangeError'
+  });
+
+  assert.throws(() => {
+    http2.getPackedSettings({
+      customSettings: { '11': 11, '12': 12, '13': 13, '14': 14, '15': 15, '16': 16,
+                        '17': 17, '18': 18, '19': 19, '20': 20, '21': 21 }
+    });
+  }, {
+    code: 'ERR_HTTP2_TOO_MANY_CUSTOM_SETTINGS'
+  });
+  assert.throws(() => {
+    http2.getPackedSettings({
+      customSettings: { '11': 11, '12': 12, '13': 13, '14': 14, '15': 15, '16': 16,
+                        '17': 17, '18': 18, '19': 19, '20': 20, '21': 21, '22': 22 }
+    });
+  }, {
+    code: 'ERR_HTTP2_TOO_MANY_CUSTOM_SETTINGS'
+  });
+}
+
+// Check for not passing settings.
+{
+  const packed = http2.getPackedSettings();
+  assert.strictEqual(packed.length, 0);
+}
+
+{
+  const packed = Buffer.from([
+    0x00, 0x01, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x03, 0x00, 0x00, 0x00, 0xc8,
+    0x00, 0x05, 0x00, 0x00, 0x4e, 0x20,
+    0x00, 0x04, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x06, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x02, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x08, 0x00, 0x00, 0x00, 0x00,
+    0x27, 0x0F, 0x00, 0x00, 0x01, 0x2d]);
+
+  [1, true, '', [], {}, NaN].forEach((input) => {
+    assert.throws(() => {
+      http2.getUnpackedSettings(input);
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError',
+      message:
+        'The "buf" argument must be an instance of Buffer or TypedArray.' +
+        common.invalidArgTypeHelper(input)
+    });
+  });
+
+  assert.throws(() => {
+    http2.getUnpackedSettings(packed.slice(5));
+  }, {
+    code: 'ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH',
+    name: 'RangeError',
+    message: 'Packed settings length must be a multiple of six'
+  });
+
+  const settings = http2.getUnpackedSettings(packed);
+
+  assert(settings);
+  assert.strictEqual(settings.headerTableSize, 100);
+  assert.strictEqual(settings.initialWindowSize, 100);
+  assert.strictEqual(settings.maxFrameSize, 20000);
+  assert.strictEqual(settings.maxConcurrentStreams, 200);
+  assert.strictEqual(settings.maxHeaderListSize, 100);
+  assert.strictEqual(settings.maxHeaderSize, 100);
+  assert.strictEqual(settings.enablePush, true);
+  assert.strictEqual(settings.enableConnectProtocol, false);
+  assert.deepStrictEqual(settings.customSettings, { '9999': 301 });
+}
+
+{
+  const packed = new Uint16Array([
+    0x00, 0x01, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x03, 0x00, 0x00, 0x00, 0xc8,
+    0x00, 0x05, 0x00, 0x00, 0x4e, 0x20,
+    0x00, 0x04, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x06, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x02, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x08, 0x00, 0x00, 0x00, 0x00]);
+
+  assert.throws(() => {
+    http2.getUnpackedSettings(packed.slice(5));
+  }, {
+    code: 'ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH',
+    name: 'RangeError',
+    message: 'Packed settings length must be a multiple of six'
+  });
+
+  const settings = http2.getUnpackedSettings(packed);
+
+  assert(settings);
+  assert.strictEqual(settings.headerTableSize, 100);
+  assert.strictEqual(settings.initialWindowSize, 100);
+  assert.strictEqual(settings.maxFrameSize, 20000);
+  assert.strictEqual(settings.maxConcurrentStreams, 200);
+  assert.strictEqual(settings.maxHeaderListSize, 100);
+  assert.strictEqual(settings.maxHeaderSize, 100);
+  assert.strictEqual(settings.enablePush, true);
+  assert.strictEqual(settings.enableConnectProtocol, false);
+}
+
+{
+  const packed = new DataView(Buffer.from([
+    0x00, 0x01, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x03, 0x00, 0x00, 0x00, 0xc8,
+    0x00, 0x05, 0x00, 0x00, 0x4e, 0x20,
+    0x00, 0x04, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x06, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x02, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x08, 0x00, 0x00, 0x00, 0x00]).buffer);
+
+  assert.throws(() => {
+    http2.getUnpackedSettings(packed);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message:
+        'The "buf" argument must be an instance of Buffer or TypedArray.' +
+        common.invalidArgTypeHelper(packed)
+  });
+}
+
+{
+  const packed = Buffer.from([
+    0x00, 0x02, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x08, 0x00, 0x00, 0x00, 0x00]);
+
+  const settings = http2.getUnpackedSettings(packed, { validate: true });
+  assert.strictEqual(settings.enablePush, false);
+  assert.strictEqual(settings.enableConnectProtocol, false);
+}
+{
+  const packed = Buffer.from([
+    0x00, 0x02, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x08, 0x00, 0x00, 0x00, 0x64]);
+
+  const settings = http2.getUnpackedSettings(packed, { validate: true });
+  assert.strictEqual(settings.enablePush, true);
+  assert.strictEqual(settings.enableConnectProtocol, true);
+}
+
+// Verify that passing {validate: true} does not throw.
+{
+  const packed = Buffer.from([
+    0x00, 0x01, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x03, 0x00, 0x00, 0x00, 0xc8,
+    0x00, 0x05, 0x00, 0x00, 0x4e, 0x20,
+    0x00, 0x04, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x06, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x02, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x08, 0x00, 0x00, 0x00, 0x00]);
+
+  http2.getUnpackedSettings(packed, { validate: true });
+}
+
+// Check for maxFrameSize failing the max number.
+{
+  const packed = Buffer.from([0x00, 0x05, 0x01, 0x00, 0x00, 0x00]);
+
+  assert.throws(() => {
+    http2.getUnpackedSettings(packed, { validate: true });
+  }, {
+    code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
+    name: 'RangeError',
+    message: 'Invalid value for setting "maxFrameSize": 16777216'
+  });
+}

--- a/test/js/node/test/parallel/test-http2-getpackedsettings.js
+++ b/test/js/node/test/parallel/test-http2-getpackedsettings.js
@@ -213,9 +213,6 @@ http2.getPackedSettings({ enablePush: false });
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message:
-        'The "buf" argument must be an instance of Buffer or TypedArray.' +
-        common.invalidArgTypeHelper(input)
     });
   });
 
@@ -287,9 +284,6 @@ http2.getPackedSettings({ enablePush: false });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message:
-        'The "buf" argument must be an instance of Buffer or TypedArray.' +
-        common.invalidArgTypeHelper(packed)
   });
 }
 

--- a/test/js/node/test/parallel/test-http2-session-settings.js
+++ b/test/js/node/test/parallel/test-http2-session-settings.js
@@ -1,0 +1,208 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const h2 = require('http2');
+
+const server = h2.createServer({
+  remoteCustomSettings: [
+    55,
+  ],
+  settings: {
+    customSettings: {
+      1244: 456
+    }
+  }
+}
+);
+
+server.on(
+  'stream',
+  common.mustCall((stream) => {
+    const assertSettings = (settings) => {
+      assert.strictEqual(typeof settings, 'object');
+      assert.strictEqual(typeof settings.headerTableSize, 'number');
+      assert.strictEqual(typeof settings.enablePush, 'boolean');
+      assert.strictEqual(typeof settings.initialWindowSize, 'number');
+      assert.strictEqual(typeof settings.maxFrameSize, 'number');
+      assert.strictEqual(typeof settings.maxConcurrentStreams, 'number');
+      assert.strictEqual(typeof settings.maxHeaderListSize, 'number');
+      assert.strictEqual(typeof settings.maxHeaderSize, 'number');
+      assert.strictEqual(typeof settings.customSettings, 'object');
+      let countCustom = 0;
+      if (settings.customSettings[55]) {
+        assert.strictEqual(typeof settings.customSettings[55], 'number');
+        assert.strictEqual(settings.customSettings[55], 12);
+        countCustom++;
+      }
+      if (settings.customSettings[155]) {
+        // Should not happen actually
+        assert.strictEqual(typeof settings.customSettings[155], 'number');
+        countCustom++;
+      }
+      if (settings.customSettings[1244]) {
+        assert.strictEqual(typeof settings.customSettings[1244], 'number');
+        assert.strictEqual(settings.customSettings[1244], 456);
+        countCustom++;
+      }
+      assert.strictEqual(countCustom, 1);
+    };
+
+    const localSettings = stream.session.localSettings;
+    const remoteSettings = stream.session.remoteSettings;
+    assertSettings(localSettings);
+    assertSettings(remoteSettings);
+
+    // Test that stored settings are returned when called for second time
+    assert.strictEqual(stream.session.localSettings, localSettings);
+    assert.strictEqual(stream.session.remoteSettings, remoteSettings);
+
+    stream.respond({
+      'content-type': 'text/html',
+      ':status': 200
+    });
+    stream.end('hello world');
+  })
+);
+
+server.on('session', (session) => {
+  session.settings({
+    maxConcurrentStreams: 2
+  });
+});
+
+server.listen(
+  0,
+  common.mustCall(() => {
+    const client = h2.connect(`http://127.0.0.1:${server.address().port}`, {
+      settings: {
+        enablePush: false,
+        initialWindowSize: 123456,
+        customSettings: {
+          55: 12,
+          155: 144 // should not arrive
+        },
+      },
+      remoteCustomSettings: [
+        1244,
+      ]
+    });
+
+    client.on(
+      'localSettings',
+      common.mustCall((settings) => {
+        assert(settings);
+        assert.strictEqual(settings.enablePush, false);
+        assert.strictEqual(settings.initialWindowSize, 123456);
+        assert.strictEqual(settings.maxFrameSize, 16384);
+        assert.strictEqual(settings.customSettings[55], 12);
+      }, 2)
+    );
+
+    let calledOnce = false;
+    client.on(
+      'remoteSettings',
+      common.mustCall((settings) => {
+        assert(settings);
+        assert.strictEqual(
+          settings.maxConcurrentStreams,
+          calledOnce ? 2 : (2 ** 32) - 1
+        );
+        calledOnce = true;
+      }, 2)
+    );
+
+    const headers = { ':path': '/' };
+
+    const req = client.request(headers);
+
+    req.on('ready', common.mustCall(() => {
+      // pendingSettingsAck will be true if a SETTINGS frame
+      // has been sent but we are still waiting for an acknowledgement
+      assert(client.pendingSettingsAck);
+    }));
+
+    // State will only be valid after connect event is emitted
+    req.on('ready', common.mustCall(() => {
+      client.settings({ maxHeaderListSize: 1 }, common.mustCall());
+
+      // Verify valid error ranges
+      [
+        ['headerTableSize', -1],
+        ['headerTableSize', 2 ** 32],
+        ['initialWindowSize', -1],
+        ['initialWindowSize', 2 ** 32],
+        ['maxFrameSize', 16383],
+        ['maxFrameSize', 2 ** 24],
+        ['maxHeaderListSize', -1],
+        ['maxHeaderListSize', 2 ** 32],
+        ['maxHeaderSize', -1],
+        ['maxHeaderSize', 2 ** 32],
+      ].forEach(([key, value]) => {
+        const settings = {};
+        settings[key] = value;
+        assert.throws(
+          () => client.settings(settings),
+          {
+            name: 'RangeError',
+            code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
+            message: `Invalid value for setting "${key}": ${value}`
+          }
+        );
+      });
+
+      // Same tests as for the client on customSettings
+      assert.throws(
+        () => client.settings({ customSettings: {
+          0x10000: 5,
+        } }),
+        {
+          code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
+          name: 'RangeError'
+        }
+      );
+
+      assert.throws(
+        () => client.settings({ customSettings: {
+          55: 0x100000000,
+        } }),
+        {
+          code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
+          name: 'RangeError'
+        }
+      );
+
+      assert.throws(
+        () => client.settings({ customSettings: {
+          55: -1,
+        } }),
+        {
+          code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
+          name: 'RangeError'
+        }
+      );
+
+      // Error checks for enablePush
+      [1, {}, 'test', [], null, Infinity, NaN].forEach((i) => {
+        assert.throws(
+          () => client.settings({ enablePush: i }),
+          {
+            name: 'TypeError',
+            code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
+            message: `Invalid value for setting "enablePush": ${i}`
+          }
+        );
+      });
+    }));
+
+    req.on('response', common.mustCall());
+    req.resume();
+    req.on('end', common.mustCall(() => {
+      server.close();
+      client.close();
+    }));
+    req.end();
+  })
+);

--- a/test/js/node/test/parallel/test-http2-session-settings.js
+++ b/test/js/node/test/parallel/test-http2-session-settings.js
@@ -6,17 +6,7 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const h2 = require('http2');
 
-const server = h2.createServer({
-  remoteCustomSettings: [
-    55,
-  ],
-  settings: {
-    customSettings: {
-      1244: 456
-    }
-  }
-}
-);
+const server = h2.createServer();
 
 server.on(
   'stream',
@@ -30,24 +20,6 @@ server.on(
       assert.strictEqual(typeof settings.maxConcurrentStreams, 'number');
       assert.strictEqual(typeof settings.maxHeaderListSize, 'number');
       assert.strictEqual(typeof settings.maxHeaderSize, 'number');
-      assert.strictEqual(typeof settings.customSettings, 'object');
-      let countCustom = 0;
-      if (settings.customSettings[55]) {
-        assert.strictEqual(typeof settings.customSettings[55], 'number');
-        assert.strictEqual(settings.customSettings[55], 12);
-        countCustom++;
-      }
-      if (settings.customSettings[155]) {
-        // Should not happen actually
-        assert.strictEqual(typeof settings.customSettings[155], 'number');
-        countCustom++;
-      }
-      if (settings.customSettings[1244]) {
-        assert.strictEqual(typeof settings.customSettings[1244], 'number');
-        assert.strictEqual(settings.customSettings[1244], 456);
-        countCustom++;
-      }
-      assert.strictEqual(countCustom, 1);
     };
 
     const localSettings = stream.session.localSettings;
@@ -80,25 +52,14 @@ server.listen(
       settings: {
         enablePush: false,
         initialWindowSize: 123456,
-        customSettings: {
-          55: 12,
-          155: 144 // should not arrive
-        },
       },
-      remoteCustomSettings: [
-        1244,
-      ]
     });
 
     client.on(
       'localSettings',
-      common.mustCall((settings) => {
+      common.mustCallAtLeast((settings) => {
         assert(settings);
-        assert.strictEqual(settings.enablePush, false);
-        assert.strictEqual(settings.initialWindowSize, 123456);
-        assert.strictEqual(settings.maxFrameSize, 16384);
-        assert.strictEqual(settings.customSettings[55], 12);
-      }, 2)
+      }, 1)
     );
 
     let calledOnce = false;
@@ -126,8 +87,6 @@ server.listen(
 
     // State will only be valid after connect event is emitted
     req.on('ready', common.mustCall(() => {
-      client.settings({ maxHeaderListSize: 1 }, common.mustCall());
-
       // Verify valid error ranges
       [
         ['headerTableSize', -1],
@@ -152,37 +111,6 @@ server.listen(
           }
         );
       });
-
-      // Same tests as for the client on customSettings
-      assert.throws(
-        () => client.settings({ customSettings: {
-          0x10000: 5,
-        } }),
-        {
-          code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
-          name: 'RangeError'
-        }
-      );
-
-      assert.throws(
-        () => client.settings({ customSettings: {
-          55: 0x100000000,
-        } }),
-        {
-          code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
-          name: 'RangeError'
-        }
-      );
-
-      assert.throws(
-        () => client.settings({ customSettings: {
-          55: -1,
-        } }),
-        {
-          code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
-          name: 'RangeError'
-        }
-      );
 
       // Error checks for enablePush
       [1, {}, 'test', [], null, Infinity, NaN].forEach((i) => {

--- a/test/js/node/test/parallel/test-http2-update-settings.js
+++ b/test/js/node/test/parallel/test-http2-update-settings.js
@@ -1,0 +1,60 @@
+'use strict';
+
+// This test ensures that the Http2SecureServer and Http2Server
+// settings are updated when the setting object is valid.
+// When the setting object is invalid, this test ensures that
+// updateSettings throws an exception.
+
+const common = require('../common');
+if (!common.hasCrypto) { common.skip('missing crypto'); }
+const assert = require('assert');
+const http2 = require('http2');
+
+testUpdateSettingsWith({
+  server: http2.createSecureServer(),
+  newServerSettings: {
+    'headerTableSize': 1,
+    'initialWindowSize': 1,
+    'maxConcurrentStreams': 1,
+    'maxHeaderListSize': 1,
+    'maxFrameSize': 16385,
+    'enablePush': false,
+    'enableConnectProtocol': true,
+    'customSettings': { '9999': 301 }
+  }
+});
+testUpdateSettingsWith({
+  server: http2.createServer(),
+  newServerSettings: {
+    'enablePush': false
+  }
+});
+
+function testUpdateSettingsWith({ server, newServerSettings }) {
+  const oldServerSettings = getServerSettings(server);
+  assert.notDeepStrictEqual(oldServerSettings, newServerSettings);
+  server.updateSettings(newServerSettings);
+  const updatedServerSettings = getServerSettings(server);
+  assert.deepStrictEqual(updatedServerSettings, { ...oldServerSettings,
+                                                  ...newServerSettings });
+  assert.throws(() => server.updateSettings(''), {
+    message: 'The "settings" argument must be of type object. ' +
+    'Received type string (\'\')',
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError'
+  });
+  assert.throws(() => server.updateSettings({
+    'maxHeaderListSize': 'foo'
+  }), {
+    message: 'Invalid value for setting "maxHeaderListSize": foo',
+    code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
+    name: 'RangeError'
+  });
+}
+
+function getServerSettings(server) {
+  const options = Object
+                  .getOwnPropertySymbols(server)
+                  .find((s) => s.toString() === 'Symbol(options)');
+  return server[options].settings;
+}


### PR DESCRIPTION
Continues #20186 — rebased onto main and expanded.

## Summary
- Add `enableConnectProtocol` (setting 0x8) to `FullSettingsPayload`, fix `enablePush` default to 1 (RFC 7540)
- Rewrite `getPackedSettings`/`getUnpackedSettings`/`getDefaultSettings` in JS for Node.js compat:
  - `getPackedSettings()` → empty Buffer; only packs explicitly specified settings
  - `customSettings` support in packing/unpacking
  - Proper `ERR_HTTP2_INVALID_SETTING_VALUE` error format and codes
- Add `Symbol("options")` to Http2Server/Http2SecureServer for `updateSettings` compat
- Add JS-side `validateSettings` for session `settings()` calls

## Test plan
- [ ] `test-http2-getpackedsettings.js` — packed/unpacked settings, validation, custom settings
- [ ] `test-http2-session-settings.js` — session settings with custom settings
- [ ] `test-http2-update-settings.js` — server updateSettings method
- [ ] `test-http2-client-settings-before-connect.js` — already passing, unchanged