### PR TITLE
fix(bindings): add missing null checks for invalid `this` in crypto/stream C++ bindings

### DIFF
--- a/src/bun.js/bindings/JSBufferList.cpp
+++ b/src/bun.js/bindings/JSBufferList.cpp
@@ -18,8 +18,10 @@ static JSC_DEFINE_CUSTOM_GETTER(JSBufferList_getLength, (JSC::JSGlobalObject * g
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSBufferList* bufferList = JSC::jsDynamicCast<JSBufferList*>(JSValue::decode(thisValue));
-    if (!bufferList)
+    if (!bufferList) [[unlikely]] {
         JSC::throwTypeError(globalObject, scope, "not calling on JSBufferList"_s);
+        return {};
+    }
 
     return JSValue::encode(JSC::jsNumber(bufferList->length()));
 }

--- a/src/bun.js/bindings/node/crypto/JSDiffieHellmanGroup.cpp
+++ b/src/bun.js/bindings/node/crypto/JSDiffieHellmanGroup.cpp
@@ -59,8 +59,8 @@ JSC_DEFINE_HOST_FUNCTION(jsDiffieHellmanGroupGetter_verifyError, (JSC::JSGlobalO
     JSValue thisValue = callFrame->thisValue();
 
     JSDiffieHellmanGroup* thisObject = jsDynamicCast<JSDiffieHellmanGroup*>(thisValue);
-    if (!thisObject) {
-        throwVMTypeError(globalObject, scope);
+    if (!thisObject) [[unlikely]] {
+        return ERR::INVALID_THIS(scope, globalObject, "DiffieHellmanGroup"_s);
     }
 
     auto& dh = thisObject->getImpl();

--- a/src/bun.js/bindings/node/crypto/JSHmac.cpp
+++ b/src/bun.js/bindings/node/crypto/JSHmac.cpp
@@ -172,6 +172,9 @@ JSC_DEFINE_HOST_FUNCTION(jsHmacProtoFuncDigest, (JSC::JSGlobalObject * lexicalGl
 
     // Get the HMAC instance
     JSHmac* hmac = jsDynamicCast<JSHmac*>(callFrame->thisValue());
+    if (!hmac) [[unlikely]] {
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "Hmac"_s);
+    }
 
     // Check if already finalized, return empty buffer if already finalized
     if (hmac->m_finalized) {

--- a/test/js/node/crypto/crypto-invalid-this.test.ts
+++ b/test/js/node/crypto/crypto-invalid-this.test.ts
@@ -1,0 +1,30 @@
+// Native crypto prototype methods must not segfault when called with an invalid `this`.
+// Before these fixes, jsDynamicCast returned null and the code dereferenced it anyway.
+import { test, expect } from "bun:test";
+import { createHmac, getDiffieHellman } from "node:crypto";
+
+function getNativeHandle(obj: any) {
+  const sym = Object.getOwnPropertySymbols(obj).find(s => s.description === "kHandle");
+  return obj[sym!];
+}
+
+test("Hmac native digest() throws ERR_INVALID_THIS instead of segfaulting on bad this", () => {
+  const hmac = createHmac("sha256", "key");
+  const native = getNativeHandle(hmac);
+  const nativeDigest = native.digest;
+
+  expect(() => nativeDigest.call({})).toThrow(expect.objectContaining({ code: "ERR_INVALID_THIS" }));
+  expect(() => nativeDigest.call(null)).toThrow(expect.objectContaining({ code: "ERR_INVALID_THIS" }));
+  expect(() => nativeDigest.call(42)).toThrow(expect.objectContaining({ code: "ERR_INVALID_THIS" }));
+});
+
+test("DiffieHellmanGroup verifyError getter throws ERR_INVALID_THIS instead of segfaulting on bad this", () => {
+  const dhg = getDiffieHellman("modp14");
+  const desc =
+    Object.getOwnPropertyDescriptor(Object.getPrototypeOf(dhg), "verifyError") ??
+    Object.getOwnPropertyDescriptor(dhg, "verifyError");
+  expect(desc?.get).toBeFunction();
+
+  expect(() => desc!.get!.call({})).toThrow(expect.objectContaining({ code: "ERR_INVALID_THIS" }));
+  expect(() => desc!.get!.call(null)).toThrow(expect.objectContaining({ code: "ERR_INVALID_THIS" }));
+});

--- a/test/js/node/crypto/crypto-invalid-this.test.ts
+++ b/test/js/node/crypto/crypto-invalid-this.test.ts
@@ -1,6 +1,6 @@
 // Native crypto prototype methods must not segfault when called with an invalid `this`.
 // Before these fixes, jsDynamicCast returned null and the code dereferenced it anyway.
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { createHmac, getDiffieHellman } from "node:crypto";
 
 function getNativeHandle(obj: any) {


### PR DESCRIPTION
Follow-up sweep after #28072 — three more places where `jsDynamicCast` on `thisValue()` can return null and the code dereferences it anyway.

## Bugs fixed

| File | Function | Problem |
|---|---|---|
| `JSHmac.cpp` | `jsHmacProtoFuncDigest` | No null check before `hmac->m_finalized` |
| `JSDiffieHellmanGroup.cpp` | `jsDiffieHellmanGroupGetter_verifyError` | Had `if (!thisObject) { throwVMTypeError(...); }` but no `return` — fell through to `thisObject->getImpl()` |
| `JSBufferList.cpp` | `JSBufferList_getLength` | Same — `if (!bufferList) throwTypeError(...);` with no `return`, fell through to `bufferList->length()` |

## Repro (segfaults on current Bun)

```js
const { createHmac } = require("crypto");
const hmac = createHmac("sha256", "key");
const sym = Object.getOwnPropertySymbols(hmac).find(s => s.description === "kHandle");
hmac[sym].digest.call({}); // Segmentation fault at address 0x20
```

Now throws `TypeError [ERR_INVALID_THIS]: Value of "this" must be of type Hmac`.