### PR TITLE
fix(test): clear mock.module() mocks between test files and in mock.restore()

### DIFF
--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -391,13 +391,92 @@ JSC::JSObject* BunPlugin::Group::find(JSC::JSGlobalObject* globalObject, String&
 void BunPlugin::OnLoad::addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mockObject)
 {
     Zig::GlobalObject* globalObject = defaultGlobalObject(mockObject->globalObject());
-
-    if (globalObject->onLoadPlugins.virtualModules == nullptr) {
-        globalObject->onLoadPlugins.virtualModules = new BunPlugin::VirtualModuleMap;
+    if (globalObject->onLoadPlugins.moduleMocks == nullptr) {
+        globalObject->onLoadPlugins.moduleMocks = new BunPlugin::VirtualModuleMap;
     }
-    auto* virtualModules = globalObject->onLoadPlugins.virtualModules;
+    globalObject->onLoadPlugins.moduleMocks->set(path, JSC::Strong<JSC::JSObject> { vm, mockObject });
+}
 
-    virtualModules->set(path, JSC::Strong<JSC::JSObject> { vm, mockObject });
+void BunPlugin::OnLoad::beginModuleMockScope()
+{
+    moduleMockScopeMarkers.append(moduleMockEntries.size());
+}
+
+void BunPlugin::OnLoad::revertMockEntries(JSC::JSGlobalObject* globalObject, size_t fromIndex)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* zigGlobal = static_cast<Zig::GlobalObject*>(globalObject);
+
+    auto* esmRegistry = zigGlobal->esmRegistryMap();
+    if (scope.exception()) [[unlikely]] { (void)scope.tryClearException(); esmRegistry = nullptr; }
+
+    auto* requireMap = zigGlobal->requireMap();
+    if (scope.exception()) [[unlikely]] { (void)scope.tryClearException(); requireMap = nullptr; }
+
+    for (size_t i = moduleMockEntries.size(); i > fromIndex; --i) {
+        auto& entry = moduleMockEntries[i - 1];
+
+        if (moduleMocks)
+            moduleMocks->remove(entry.specifier);
+
+        if (entry.hadInPlacePatch && entry.patchedNamespace && entry.originalExportSnapshot) {
+            // The module was already loaded when mock.module() was called, so its
+            // namespace was mutated directly. Write back the saved export values
+            // to undo the mutation — this is the only way to fix it since JSC
+            // namespace objects are shared by reference across all importers.
+            auto* ns = jsDynamicCast<JSC::JSModuleNamespaceObject*>(entry.patchedNamespace.get());
+            auto* snapshot = entry.originalExportSnapshot.get();
+            if (ns && snapshot) {
+                JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
+                JSObject::getOwnPropertyNames(snapshot, globalObject, names, DontEnumPropertiesMode::Exclude);
+                if (scope.exception()) [[unlikely]] { (void)scope.tryClearException(); }
+                else {
+                    for (auto& name : names) {
+                        JSValue val = snapshot->get(globalObject, name);
+                        if (scope.exception()) [[unlikely]] { (void)scope.tryClearException(); continue; }
+                        ns->overrideExportValue(globalObject, name, val);
+                        if (scope.exception()) [[unlikely]] { (void)scope.tryClearException(); }
+                    }
+                }
+            }
+            // CJS exports were mutated too but we don't snapshot those — just evict.
+            if (requireMap) {
+                requireMap->remove(globalObject, jsString(vm, entry.specifier));
+                if (scope.exception()) [[unlikely]] { (void)scope.tryClearException(); }
+            }
+        } else {
+            // The mock was set up before the module was ever imported, so the
+            // factory result landed in the registry lazily. Evict the cached
+            // entries so the next import triggers a fresh evaluation from source.
+            auto* specifierJS = jsString(vm, entry.specifier);
+            if (esmRegistry) {
+                esmRegistry->remove(globalObject, specifierJS);
+                if (scope.exception()) [[unlikely]] { (void)scope.tryClearException(); }
+            }
+            if (requireMap) {
+                requireMap->remove(globalObject, specifierJS);
+                if (scope.exception()) [[unlikely]] { (void)scope.tryClearException(); }
+            }
+        }
+    }
+}
+
+void BunPlugin::OnLoad::endModuleMockScope(JSC::JSGlobalObject* globalObject)
+{
+    if (moduleMockScopeMarkers.isEmpty())
+        return;
+
+    size_t marker = moduleMockScopeMarkers.takeLast();
+    revertMockEntries(globalObject, marker);
+    moduleMockEntries.shrink(marker);
+
+    if (moduleMocks && moduleMocks->isEmpty()) {
+        delete moduleMocks;
+        moduleMocks = nullptr;
+        if (!virtualModules)
+            mustDoExpensiveRelativeLookup = false;
+    }
 }
 
 class JSModuleMock final : public JSC::JSNonFinalObject {
@@ -582,6 +661,9 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         return {};
     }
 
+    JSC::JSModuleNamespaceObject* patchedNamespaceObject = nullptr;
+    JSObject* exportSnapshotObject = nullptr;
+
     JSC::JSObject* callback = callbackValue.getObject();
 
     JSModuleMock* mock = JSModuleMock::create(vm, globalObject->mockModule.mockModuleStructure.getInitializedOnMainThread(globalObject), callback);
@@ -644,6 +726,20 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
                             JSObject::getOwnPropertyNames(object, globalObject, names, DontEnumPropertiesMode::Exclude);
                             RETURN_IF_EXCEPTION(scope, {});
 
+                            // Save the current export values so we can write them back
+                            // when the test file scope ends or mock.restore() is called.
+                            unsigned inlineCapacity = std::min(static_cast<unsigned>(names.size()), JSFinalObject::maxInlineCapacity);
+                            JSObject* snapshot = constructEmptyObject(globalObject, globalObject->objectPrototype(), inlineCapacity);
+                            for (auto& name : names) {
+                                auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+                                JSValue originalVal = moduleNamespaceObject->get(globalObject, name);
+                                if (topExceptionScope.exception()) [[unlikely]] {
+                                    (void)topExceptionScope.tryClearException();
+                                    originalVal = jsUndefined();
+                                }
+                                snapshot->putDirect(vm, name, originalVal, 0);
+                            }
+
                             for (auto& name : names) {
                                 // consistent with regular esm handling code
                                 auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
@@ -655,6 +751,9 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
                                 moduleNamespaceObject->overrideExportValue(globalObject, name, value);
                                 RETURN_IF_EXCEPTION(scope, {});
                             }
+
+                            patchedNamespaceObject = moduleNamespaceObject;
+                            exportSnapshotObject = snapshot;
 
                         } else {
                             // if it's not an object, I guess we just set the default export?
@@ -696,6 +795,17 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
     }
 
     globalObject->onLoadPlugins.addModuleMock(vm, specifier, mock);
+
+    if (!globalObject->onLoadPlugins.moduleMockScopeMarkers.isEmpty()) {
+        BunPlugin::ModuleMockEntry entry;
+        entry.specifier = specifier;
+        if (patchedNamespaceObject && exportSnapshotObject) {
+            entry.hadInPlacePatch = true;
+            entry.patchedNamespace = JSC::Strong<JSC::JSObject>(vm, patchedNamespaceObject);
+            entry.originalExportSnapshot = JSC::Strong<JSC::JSObject>(vm, exportSnapshotObject);
+        }
+        globalObject->onLoadPlugins.moduleMockEntries.append(WTF::move(entry));
+    }
 
     return JSValue::encode(jsUndefined());
 }
@@ -765,7 +875,13 @@ EncodedJSValue BunPlugin::OnLoad::run(JSC::JSGlobalObject* globalObject, BunStri
 
 std::optional<String> BunPlugin::OnLoad::resolveVirtualModule(const String& path, const String& from)
 {
-    ASSERT(virtualModules);
+    auto containsPath = [&](const String& p) -> bool {
+        if (moduleMocks && moduleMocks->contains(p))
+            return true;
+        if (virtualModules && virtualModules->contains(p))
+            return true;
+        return false;
+    };
 
     if (this->mustDoExpensiveRelativeLookup) {
         String joinedPath = path;
@@ -776,10 +892,10 @@ std::optional<String> BunPlugin::OnLoad::resolveVirtualModule(const String& path
             joinedPath = URL(url, path).fileSystemPath();
         }
 
-        return virtualModules->contains(joinedPath) ? std::optional<String> { joinedPath } : std::nullopt;
+        return containsPath(joinedPath) ? std::optional<String> { joinedPath } : std::nullopt;
     }
 
-    return virtualModules->contains(path) ? std::optional<String> { path } : std::nullopt;
+    return containsPath(path) ? std::optional<String> { path } : std::nullopt;
 }
 
 EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, BunString* namespaceString, BunString* path, BunString* importer)
@@ -894,10 +1010,21 @@ JSC::JSValue runVirtualModule(Zig::GlobalObject* globalObject, BunString* specif
     if (!globalObject->onLoadPlugins.hasVirtualModules()) {
         return fallback();
     }
-    auto& virtualModules = *globalObject->onLoadPlugins.virtualModules;
     WTF::String specifierString = specifier->toWTFString(BunString::ZeroCopy);
 
-    if (auto virtualModuleFn = virtualModules.get(specifierString)) {
+    JSC::Strong<JSC::JSObject> virtualModuleFn = [&]() -> JSC::Strong<JSC::JSObject> {
+        if (auto* mocks = globalObject->onLoadPlugins.moduleMocks) {
+            if (auto fn = mocks->get(specifierString))
+                return fn;
+        }
+        if (auto* vms = globalObject->onLoadPlugins.virtualModules) {
+            if (auto fn = vms->get(specifierString))
+                return fn;
+        }
+        return {};
+    }();
+
+    if (virtualModuleFn) {
         auto& vm = JSC::getVM(globalObject);
         JSC::JSObject* function = virtualModuleFn.get();
         auto throwScope = DECLARE_THROW_SCOPE(vm);
@@ -955,6 +1082,20 @@ BUN_DEFINE_HOST_FUNCTION(jsFunctionBunPluginClear, (JSC::JSGlobalObject * global
 
     delete global->onLoadPlugins.virtualModules;
     global->onLoadPlugins.virtualModules = nullptr;
+
+    // Undo all module mocks (restoring patched namespaces, evicting caches).
+    if (!global->onLoadPlugins.moduleMockEntries.isEmpty())
+        global->onLoadPlugins.revertMockEntries(globalObject, 0);
+
+    delete global->onLoadPlugins.moduleMocks;
+    global->onLoadPlugins.moduleMocks = nullptr;
+    global->onLoadPlugins.moduleMockEntries.clear();
+    // Keep scope markers alive but reset their positions — any mock.module()
+    // calls after this point within the same test file will still be tracked
+    // and cleaned up when the file scope ends.
+    for (auto& marker : global->onLoadPlugins.moduleMockScopeMarkers)
+        marker = 0;
+    global->onLoadPlugins.mustDoExpensiveRelativeLookup = false;
 
     return JSC::JSValue::encode(JSC::jsUndefined());
 }

--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -756,9 +756,24 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
                             exportSnapshotObject = snapshot;
 
                         } else {
-                            // if it's not an object, I guess we just set the default export?
+                            // Non-object return — override just the default export.
+                            // Snapshot the original default so it can be restored on scope end.
+                            JSObject* defaultSnapshot = constructEmptyObject(globalObject, globalObject->objectPrototype(), 1);
+                            {
+                                auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+                                JSValue originalDefault = moduleNamespaceObject->get(globalObject, vm.propertyNames->defaultKeyword);
+                                if (topExceptionScope.exception()) [[unlikely]] {
+                                    (void)topExceptionScope.tryClearException();
+                                    originalDefault = jsUndefined();
+                                }
+                                defaultSnapshot->putDirect(vm, vm.propertyNames->defaultKeyword, originalDefault, 0);
+                            }
+
                             moduleNamespaceObject->overrideExportValue(globalObject, vm.propertyNames->defaultKeyword, exportsValue);
                             RETURN_IF_EXCEPTION(scope, {});
+
+                            patchedNamespaceObject = moduleNamespaceObject;
+                            exportSnapshotObject = defaultSnapshot;
                         }
 
                         // TODO: do we need to handle intermediate loading state here?

--- a/src/bun.js/bindings/BunPlugin.h
+++ b/src/bun.js/bindings/BunPlugin.h
@@ -61,6 +61,14 @@ public:
         void append(JSC::VM& vm, JSC::RegExp* filter, JSC::JSObject* func, String& namespaceString);
     };
 
+    // Tracks a single mock.module() call so it can be undone when the scope ends.
+    struct ModuleMockEntry {
+        String specifier;
+        JSC::Strong<JSC::JSObject> patchedNamespace;
+        JSC::Strong<JSC::JSObject> originalExportSnapshot;
+        bool hadInPlacePatch { false };
+    };
+
     class OnLoad final : public Base {
 
     public:
@@ -70,12 +78,20 @@ public:
         }
 
         VirtualModuleMap* _Nullable virtualModules = nullptr;
+        VirtualModuleMap* _Nullable moduleMocks = nullptr;
         bool mustDoExpensiveRelativeLookup = false;
+        WTF::Vector<ModuleMockEntry> moduleMockEntries = {};
+        WTF::Vector<size_t> moduleMockScopeMarkers = {};
+
         JSC::EncodedJSValue run(JSC::JSGlobalObject* globalObject, BunString* namespaceString, BunString* path);
 
-        bool hasVirtualModules() const { return virtualModules != nullptr; }
+        bool hasVirtualModules() const { return virtualModules != nullptr || moduleMocks != nullptr; }
 
         void addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mock);
+
+        void beginModuleMockScope();
+        void endModuleMockScope(JSC::JSGlobalObject* globalObject);
+        void revertMockEntries(JSC::JSGlobalObject* globalObject, size_t fromIndex);
 
         std::optional<String> resolveVirtualModule(const String& path, const String& from);
 
@@ -83,6 +99,9 @@ public:
         {
             if (virtualModules) {
                 delete virtualModules;
+            }
+            if (moduleMocks) {
+                delete moduleMocks;
             }
         }
     };

--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -557,6 +557,14 @@ pub const JSGlobalObject = opaque {
         return bun.jsc.fromJSHostCallGeneric(this, @src(), JSC__JSGlobalObject__deleteModuleRegistryEntry, .{ this, name_ });
     }
 
+    pub fn beginTestModuleMockingScope(this: *JSGlobalObject) void {
+        JSMock__beginModuleMockScope(this);
+    }
+
+    pub fn endTestModuleMockingScope(this: *JSGlobalObject) void {
+        JSMock__endModuleMockScope(this);
+    }
+
     fn bunVMUnsafe(this: *JSGlobalObject) *anyopaque {
         return JSC__JSGlobalObject__bunVM(this);
     }
@@ -792,6 +800,8 @@ pub const JSGlobalObject = opaque {
     extern fn JSC__JSGlobalObject__bunVM(*JSGlobalObject) *VM;
     extern fn JSC__JSGlobalObject__vm(*JSGlobalObject) *VM;
     extern fn JSC__JSGlobalObject__deleteModuleRegistryEntry(*JSGlobalObject, *const ZigString) void;
+    extern fn JSMock__beginModuleMockScope(*JSGlobalObject) void;
+    extern fn JSMock__endModuleMockScope(*JSGlobalObject) void;
     extern fn JSGlobalObject__clearException(*JSGlobalObject) void;
     extern fn JSGlobalObject__clearExceptionExceptTermination(*JSGlobalObject) bool;
     extern fn JSGlobalObject__clearTerminationException(this: *JSGlobalObject) void;

--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -25,9 +25,12 @@
 #include <JavaScriptCore/DateInstance.h>
 #include <JavaScriptCore/JSModuleEnvironment.h>
 #include <JavaScriptCore/JSModuleNamespaceObject.h>
+#include <JavaScriptCore/JSMap.h>
 #include "BunPlugin.h"
 #include "AsyncContextFrame.h"
 #include "ErrorCode.h"
+#include "helpers.h"
+#include "headers.h"
 
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsNow);
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsSetSystemTime);
@@ -637,6 +640,16 @@ extern "C" void JSMock__resetSpies(Zig::GlobalObject* globalObject)
         spyObject->clearSpy();
     }
     globalObject->mockModule.activeSpies.clear();
+}
+
+extern "C" void JSMock__beginModuleMockScope(Zig::GlobalObject* globalObject)
+{
+    globalObject->onLoadPlugins.beginModuleMockScope();
+}
+
+extern "C" void JSMock__endModuleMockScope(Zig::GlobalObject* globalObject)
+{
+    globalObject->onLoadPlugins.endModuleMockScope(globalObject);
 }
 
 extern "C" void JSMock__clearAllMocks(Zig::GlobalObject* globalObject)
@@ -1465,7 +1478,28 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSetSystemTime, (JSC::JSGlobalObject * globalO
 
 BUN_DEFINE_HOST_FUNCTION(JSMock__jsRestoreAllMocks, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
-    JSMock__resetSpies(jsCast<Zig::GlobalObject*>(globalObject));
+    auto* zigGlobal = jsCast<Zig::GlobalObject*>(globalObject);
+    JSMock__resetSpies(zigGlobal);
+
+    // Undo module mocks but keep the scope open — mock.module() calls after
+    // this point should still be recorded and cleaned up at file boundary.
+    auto& scopeMarkers = zigGlobal->onLoadPlugins.moduleMockScopeMarkers;
+    if (!scopeMarkers.isEmpty()) {
+        size_t marker = scopeMarkers.last();
+        zigGlobal->onLoadPlugins.revertMockEntries(globalObject, marker);
+        zigGlobal->onLoadPlugins.moduleMockEntries.shrink(marker);
+
+        if (zigGlobal->onLoadPlugins.moduleMocks && zigGlobal->onLoadPlugins.moduleMocks->isEmpty()) {
+            delete zigGlobal->onLoadPlugins.moduleMocks;
+            zigGlobal->onLoadPlugins.moduleMocks = nullptr;
+            if (!zigGlobal->onLoadPlugins.virtualModules)
+                zigGlobal->onLoadPlugins.mustDoExpensiveRelativeLookup = false;
+        }
+        // Advance the scope marker to the current position so subsequent
+        // mock.module() calls within this file start a fresh change set.
+        scopeMarkers.last() = zigGlobal->onLoadPlugins.moduleMockEntries.size();
+    }
+
     return JSValue::encode(jsUndefined());
 }
 

--- a/src/bun.js/bindings/JSMockFunction.h
+++ b/src/bun.js/bindings/JSMockFunction.h
@@ -3,7 +3,6 @@
 #include "root.h"
 #include <JavaScriptCore/LazyProperty.h>
 #include <JavaScriptCore/Strong.h>
-
 namespace WebCore {
 }
 

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1908,7 +1908,11 @@ pub const TestCommand = struct {
             // Determine if this file should run tests concurrently based on glob pattern
             const should_run_concurrent = reporter.jest.shouldFileRunConcurrently(file_id);
             bun_test_root.enterFile(file_id, reporter, should_run_concurrent, first_last);
-            defer bun_test_root.exitFile();
+            vm.global.beginTestModuleMockingScope();
+            defer {
+                bun_test_root.exitFile();
+                vm.global.endTestModuleMockingScope();
+            }
 
             reporter.jest.current_file.set(file_title, file_prefix, repeat_count, repeat_index, reporter);
 

--- a/test/js/bun/test/mock/mock-module-leak.test.ts
+++ b/test/js/bun/test/mock/mock-module-leak.test.ts
@@ -1,0 +1,208 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("mock.module() on non-existent module does not leak across test files", async () => {
+  using dir = tempDir("mock-leak-nonexistent", {
+    "a.test.ts": `
+      import { mock, test, expect } from "bun:test";
+      test("mocks a non-existent module", async () => {
+        mock.module("ghost-module", () => ({ value: "mocked" }));
+        // @ts-expect-error
+        const m = await import("ghost-module");
+        expect(m.value).toBe("mocked");
+      });
+    `,
+    "b.test.ts": `
+      import { test, expect } from "bun:test";
+      test("mock from previous file does not leak", () => {
+        expect(() => require("ghost-module")).toThrow();
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "./a.test.ts", "./b.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const output = stdout + stderr;
+
+  expect(output).toContain("mocks a non-existent module");
+  expect(output).toContain("mock from previous file does not leak");
+  expect(exitCode).toBe(0);
+});
+
+test("mock.module() on real builtin does not leak across test files", async () => {
+  using dir = tempDir("mock-leak-builtin", {
+    "a.test.ts": `
+      import { mock, test, expect } from "bun:test";
+      test("mocks node:path", async () => {
+        mock.module("node:path", () => ({
+          join: (...args: string[]) => "mocked-join",
+        }));
+        const { join } = await import("node:path");
+        expect(join("a", "b")).toBe("mocked-join");
+      });
+    `,
+    "b.test.ts": `
+      import { join } from "node:path";
+      import { test, expect } from "bun:test";
+      test("node:path is real again", () => {
+        expect(join("a", "b")).not.toBe("mocked-join");
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "./a.test.ts", "./b.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const output = stdout + stderr;
+
+  expect(output).toContain("mocks node:path");
+  expect(output).toContain("node:path is real again");
+  expect(exitCode).toBe(0);
+});
+
+test("mock.restore() clears module mocks within a file", async () => {
+  using dir = tempDir("mock-restore-clears", {
+    "test.test.ts": `
+      import { mock, test, expect } from "bun:test";
+      test("restore clears module mocks", async () => {
+        mock.module("ephemeral-mod", () => ({ v: 1 }));
+        // @ts-expect-error
+        expect((await import("ephemeral-mod")).v).toBe(1);
+        mock.restore();
+        expect(() => require("ephemeral-mod")).toThrow();
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "./test.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const output = stdout + stderr;
+
+  expect(output).toContain("restore clears module mocks");
+  expect(exitCode).toBe(0);
+});
+
+test("re-mock after mock.restore() is tracked and cleaned up between files", async () => {
+  using dir = tempDir("mock-remock-leak", {
+    "a.test.ts": `
+      import { mock, test, expect } from "bun:test";
+      test("restore then remock", async () => {
+        mock.module("remock-mod", () => ({ v: 1 }));
+        // @ts-expect-error
+        expect((await import("remock-mod")).v).toBe(1);
+        mock.restore();
+        mock.module("remock-mod", () => ({ v: 2 }));
+        // @ts-expect-error
+        expect((await import("remock-mod")).v).toBe(2);
+      });
+    `,
+    "b.test.ts": `
+      import { test, expect } from "bun:test";
+      test("remock does not leak", () => {
+        expect(() => require("remock-mod")).toThrow();
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "./a.test.ts", "./b.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const output = stdout + stderr;
+
+  expect(output).toContain("restore then remock");
+  expect(output).toContain("remock does not leak");
+  expect(exitCode).toBe(0);
+});
+
+test("mock.module() on already-imported module restores namespace on cleanup", async () => {
+  using dir = tempDir("mock-inplace-restore", {
+    "greeting.ts": `export function greet(name: string) { return "Hello, " + name + "!"; }`,
+    "a.test.ts": `
+      import { greet } from "./greeting";
+      import { mock, test, expect } from "bun:test";
+      test("mock after import patches namespace", async () => {
+        expect(greet("world")).toBe("Hello, world!");
+        mock.module("./greeting", () => ({ greet: () => "MOCKED" }));
+        const { greet: g2 } = await import("./greeting");
+        expect(g2("world")).toBe("MOCKED");
+      });
+    `,
+    "b.test.ts": `
+      import { greet } from "./greeting";
+      import { test, expect } from "bun:test";
+      test("namespace is restored in next file", () => {
+        expect(greet("world")).toBe("Hello, world!");
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "./a.test.ts", "./b.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const output = stdout + stderr;
+
+  expect(output).toContain("mock after import patches namespace");
+  expect(output).toContain("namespace is restored in next file");
+  expect(exitCode).toBe(0);
+});
+
+test("mock.module() on large module (node:fs) does not crash", async () => {
+  using dir = tempDir("mock-large-module", {
+    "test.test.ts": `
+      import { mock, test, expect } from "bun:test";
+      test("mock node:fs without crash", async () => {
+        mock.module("node:fs", () => ({
+          readFileSync: () => "mocked-content",
+        }));
+        const { readFileSync } = await import("node:fs");
+        expect(readFileSync()).toBe("mocked-content");
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "./test.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const output = stdout + stderr;
+
+  expect(output).toContain("mock node:fs without crash");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes `mock.module()` mocks leaking across test files. The root cause is that all test files share a single `GlobalObject`, and module mocks stored in `virtualModules`, `esmRegistryMap`, and `requireMap` were never cleaned up between files. Additionally, `mock.restore()` only reset spies — it never touched module mocks.

This PR introduces scope-based mock tracking:

- **Separate mock map** — `mock.module()` entries are stored in a dedicated `moduleMocks` map, keeping `Bun.plugin` virtual modules untouched during cleanup.
- **Scope lifecycle** — `beginModuleMockScope()` is called before each test file, `endModuleMockScope()` after. All mocks registered during that scope are automatically reverted.
- **Export snapshotting** — When `mock.module()` patches an already-loaded module's namespace in-place via `overrideExportValue()`, the original export values are saved first. On scope end, they're written back to the namespace object, which is the only way to undo mutations since JSC namespace objects are shared by reference across all importers.
- **`mock.restore()` is scope-aware** — It reverts module mocks but keeps the scope open, so `mock.module()` calls after `restore()` within the same file are still tracked and cleaned up at file boundary.
- **`inlineCapacity` capping** — Prevents an assertion crash when mocking large modules like `node:fs` whose export count exceeds `JSFinalObject::maxInlineCapacity`.

### How did you verify your code works?

- `bun bd test test/js/bun/test/mock/mock-module-leak.test.ts` — 6 pass, 0 fail
- `USE_SYSTEM_BUN=1 bun test test/js/bun/test/mock/mock-module-leak.test.ts` — fails (confirms tests catch the bug)
- `bun bd test test/js/bun/test/mock/mock-module.test.ts` — 9 pass, 0 fail (no regressions)

Tests cover: cross-file leak of non-existent modules, cross-file leak of builtins, mock.restore() clearing module mocks, re-mock after restore, in-place namespace restoration for already-imported modules, and large module mocking.