### PR TITLE
fix(install): preserve catalog references during `bun update`

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.zig
+++ b/src/install/PackageManager/PackageJSONEditor.zig
@@ -296,6 +296,21 @@ pub fn editUpdateNoArgs(
                                         if (!manager.options.do.update_to_latest and npm_version.version.isExact()) break :updated;
                                     }
 
+                                    // For catalog dependencies, update the catalog section in
+                                    // package.json and preserve the "catalog:" reference.
+                                    if (strings.hasPrefixComptime(entry.value.original_version_literal, "catalog:")) {
+                                        try updateCatalogVersion(
+                                            current_package_json,
+                                            allocator,
+                                            dep_name,
+                                            entry.value.original_version_literal["catalog:".len..],
+                                            resolution.value.npm.version,
+                                            string_buf,
+                                            options.exact_versions,
+                                        );
+                                        break :updated;
+                                    }
+
                                     const new_version = new_version: {
                                         const version_fmt = resolution.value.npm.version.fmt(string_buf);
                                         if (options.exact_versions) {
@@ -772,6 +787,73 @@ pub fn edit(
                 else => try allocator.dupe(u8, request.version.literal.slice(request.version_buf)),
             };
         }
+    }
+}
+
+/// Updates a version entry in the "catalog" or "catalogs" section of a package.json.
+/// Used by `bun update` to update catalog versions while preserving "catalog:" references
+/// in dependency entries.
+fn updateCatalogVersion(
+    package_json: *Expr,
+    allocator: std.mem.Allocator,
+    dep_name: string,
+    catalog_group: string,
+    resolved_npm_version: Semver.Version,
+    buf: string,
+    exact_versions: bool,
+) !void {
+    const catalog_obj: *E.Object = if (catalog_group.len == 0) blk: {
+        // Default catalog: package.json#catalog
+        const prop = package_json.asProperty("catalog") orelse return;
+        if (prop.expr.data != .e_object) return;
+        break :blk prop.expr.data.e_object;
+    } else blk: {
+        // Named catalog: package.json#catalogs.{group}
+        const catalogs_prop = package_json.asProperty("catalogs") orelse return;
+        if (catalogs_prop.expr.data != .e_object) return;
+        for (catalogs_prop.expr.data.e_object.properties.slice()) |group_prop| {
+            const gk = group_prop.key orelse continue;
+            if (gk.data != .e_string) continue;
+            const gk_str = gk.asString(allocator) orelse continue;
+            if (!strings.eqlLong(gk_str, catalog_group, true)) continue;
+            const gv = group_prop.value orelse continue;
+            if (gv.data != .e_object) return;
+            break :blk gv.data.e_object;
+        }
+        return;
+    };
+
+    for (catalog_obj.properties.slice()) |*entry| {
+        const ek = entry.key orelse continue;
+        if (ek.data != .e_string) continue;
+        const ek_str = ek.asString(allocator) orelse continue;
+        if (!strings.eqlLong(ek_str, dep_name, true)) continue;
+
+        // Found the catalog entry — compute the new version using the
+        // catalog's current version literal to determine pinning.
+        const version_fmt = resolved_npm_version.fmt(buf);
+
+        if (exact_versions) {
+            entry.value = Expr.allocate(allocator, E.String, .{
+                .data = try std.fmt.allocPrint(allocator, "{f}", .{version_fmt}),
+            }, logger.Loc.Empty);
+            return;
+        }
+
+        const current_literal: ?string = if (entry.value) |v|
+            (if (v.data == .e_string) v.asString(allocator) else null)
+        else
+            null;
+
+        const pinned = Semver.Version.whichVersionIsPinned(current_literal orelse "^");
+        entry.value = Expr.allocate(allocator, E.String, .{
+            .data = try switch (pinned) {
+                .patch => std.fmt.allocPrint(allocator, "{f}", .{version_fmt}),
+                .minor => std.fmt.allocPrint(allocator, "~{f}", .{version_fmt}),
+                .major => std.fmt.allocPrint(allocator, "^{f}", .{version_fmt}),
+            },
+        }, logger.Loc.Empty);
+        return;
     }
 }
 

--- a/test/regression/issue/28073.test.ts
+++ b/test/regression/issue/28073.test.ts
@@ -51,8 +51,9 @@ describe("issue #28073 - bun update preserves catalog references", () => {
     // The catalog: reference in devDependencies must be preserved
     expect(rootPkg.devDependencies["is-odd"]).toBe("catalog:");
 
-    // The catalog section should be updated with the resolved version
-    expect(rootPkg.catalog["is-odd"]).toMatch(/^\^3\./);
+    // The catalog section should be updated with a valid semver pin, not the seeded value
+    expect(rootPkg.catalog["is-odd"]).not.toBe("^3.0.0");
+    expect(rootPkg.catalog["is-odd"]).toMatch(/^[~^]?\d+\./);
 
     // Sub-workspace catalog: references must also be preserved
     const appPkg = await file(join(String(dir), "packages", "app", "package.json")).json();
@@ -106,8 +107,9 @@ describe("issue #28073 - bun update preserves catalog references", () => {
     // The catalog:tools reference must be preserved
     expect(rootPkg.devDependencies["is-odd"]).toBe("catalog:tools");
 
-    // The named catalog section should be updated
-    expect(rootPkg.catalogs.tools["is-odd"]).toMatch(/^\^3\./);
+    // The named catalog section should be updated with a valid semver pin, not the seeded value
+    expect(rootPkg.catalogs.tools["is-odd"]).not.toBe("^3.0.0");
+    expect(rootPkg.catalogs.tools["is-odd"]).toMatch(/^[~^]?\d+\./);
 
     // Sub-workspace catalog: references must also be preserved
     const appPkg = await file(join(String(dir), "packages", "app", "package.json")).json();
@@ -159,8 +161,9 @@ describe("issue #28073 - bun update preserves catalog references", () => {
     // catalog: references must be preserved
     expect(rootPkg.devDependencies["is-odd"]).toBe("catalog:");
 
-    // The catalog section should be updated
-    expect(rootPkg.catalog["is-odd"]).toMatch(/^\^3\./);
+    // The catalog section should be updated with a valid semver pin, not the seeded value
+    expect(rootPkg.catalog["is-odd"]).not.toBe("^3.0.0");
+    expect(rootPkg.catalog["is-odd"]).toMatch(/^[~^]?\d+\./);
 
     // Sub-workspace must preserve catalog: references
     const appPkg = await file(join(String(dir), "packages", "app", "package.json")).json();

--- a/test/regression/issue/28073.test.ts
+++ b/test/regression/issue/28073.test.ts
@@ -1,6 +1,6 @@
 import { file } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunExe, bunEnv, tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 describe("issue #28073 - bun update preserves catalog references", () => {

--- a/test/regression/issue/28073.test.ts
+++ b/test/regression/issue/28073.test.ts
@@ -3,6 +3,17 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
+async function runBun(cwd: string, ...args: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    cwd,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(await proc.exited).toBe(0);
+}
+
 describe("issue #28073 - bun update preserves catalog references", () => {
   test("default catalog: bun update preserves catalog: in devDependencies", async () => {
     using dir = tempDir("28073-default-catalog", {
@@ -26,25 +37,8 @@ describe("issue #28073 - bun update preserves catalog references", () => {
       }),
     });
 
-    // Install first
-    await using installProc = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    expect(await installProc.exited).toBe(0);
-
-    // Run bun update
-    await using updateProc = Bun.spawn({
-      cmd: [bunExe(), "update"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    expect(await updateProc.exited).toBe(0);
+    await runBun(String(dir), "install");
+    await runBun(String(dir), "update");
 
     const rootPkg = await file(join(String(dir), "package.json")).json();
 
@@ -71,7 +65,7 @@ describe("issue #28073 - bun update preserves catalog references", () => {
             "is-odd": "^3.0.0",
           },
         },
-        devDependencies: {
+        dependencies: {
           "is-odd": "catalog:tools",
         },
       }),
@@ -84,28 +78,13 @@ describe("issue #28073 - bun update preserves catalog references", () => {
       }),
     });
 
-    await using installProc = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    expect(await installProc.exited).toBe(0);
-
-    await using updateProc = Bun.spawn({
-      cmd: [bunExe(), "update"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    expect(await updateProc.exited).toBe(0);
+    await runBun(String(dir), "install");
+    await runBun(String(dir), "update");
 
     const rootPkg = await file(join(String(dir), "package.json")).json();
 
     // The catalog:tools reference must be preserved
-    expect(rootPkg.devDependencies["is-odd"]).toBe("catalog:tools");
+    expect(rootPkg.dependencies["is-odd"]).toBe("catalog:tools");
 
     // The named catalog section should be updated with a valid semver pin, not the seeded value
     expect(rootPkg.catalogs.tools["is-odd"]).not.toBe("^3.0.0");
@@ -138,23 +117,8 @@ describe("issue #28073 - bun update preserves catalog references", () => {
       }),
     });
 
-    await using installProc = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    expect(await installProc.exited).toBe(0);
-
-    await using updateProc = Bun.spawn({
-      cmd: [bunExe(), "update", "-r"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    expect(await updateProc.exited).toBe(0);
+    await runBun(String(dir), "install");
+    await runBun(String(dir), "update", "-r");
 
     const rootPkg = await file(join(String(dir), "package.json")).json();
 

--- a/test/regression/issue/28073.test.ts
+++ b/test/regression/issue/28073.test.ts
@@ -11,7 +11,10 @@ async function runBun(cwd: string, ...args: string[]) {
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(await proc.exited).toBe(0);
+  const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
+  if (exitCode !== 0) {
+    throw new Error(`bun ${args.join(" ")} exited with code ${exitCode}:\n${stderr}`);
+  }
 }
 
 describe("issue #28073 - bun update preserves catalog references", () => {

--- a/test/regression/issue/28073.test.ts
+++ b/test/regression/issue/28073.test.ts
@@ -1,0 +1,169 @@
+import { file } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunExe, bunEnv, tempDir } from "harness";
+import { join } from "path";
+
+describe("issue #28073 - bun update preserves catalog references", () => {
+  test("default catalog: bun update preserves catalog: in devDependencies", async () => {
+    using dir = tempDir("28073-default-catalog", {
+      "package.json": JSON.stringify({
+        name: "catalog-monorepo",
+        private: true,
+        workspaces: ["packages/*"],
+        catalog: {
+          "is-odd": "^3.0.0",
+        },
+        devDependencies: {
+          "is-odd": "catalog:",
+        },
+      }),
+      "packages/app/package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: {
+          "is-odd": "catalog:",
+        },
+      }),
+    });
+
+    // Install first
+    await using installProc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await installProc.exited).toBe(0);
+
+    // Run bun update
+    await using updateProc = Bun.spawn({
+      cmd: [bunExe(), "update"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await updateProc.exited).toBe(0);
+
+    const rootPkg = await file(join(String(dir), "package.json")).json();
+
+    // The catalog: reference in devDependencies must be preserved
+    expect(rootPkg.devDependencies["is-odd"]).toBe("catalog:");
+
+    // The catalog section should be updated with the resolved version
+    expect(rootPkg.catalog["is-odd"]).toMatch(/^\^3\./);
+
+    // Sub-workspace catalog: references must also be preserved
+    const appPkg = await file(join(String(dir), "packages", "app", "package.json")).json();
+    expect(appPkg.dependencies["is-odd"]).toBe("catalog:");
+  });
+
+  test("named catalog: bun update preserves catalog:group in dependencies", async () => {
+    using dir = tempDir("28073-named-catalog", {
+      "package.json": JSON.stringify({
+        name: "catalog-monorepo",
+        private: true,
+        workspaces: ["packages/*"],
+        catalogs: {
+          tools: {
+            "is-odd": "^3.0.0",
+          },
+        },
+        devDependencies: {
+          "is-odd": "catalog:tools",
+        },
+      }),
+      "packages/app/package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: {
+          "is-odd": "catalog:tools",
+        },
+      }),
+    });
+
+    await using installProc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await installProc.exited).toBe(0);
+
+    await using updateProc = Bun.spawn({
+      cmd: [bunExe(), "update"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await updateProc.exited).toBe(0);
+
+    const rootPkg = await file(join(String(dir), "package.json")).json();
+
+    // The catalog:tools reference must be preserved
+    expect(rootPkg.devDependencies["is-odd"]).toBe("catalog:tools");
+
+    // The named catalog section should be updated
+    expect(rootPkg.catalogs.tools["is-odd"]).toMatch(/^\^3\./);
+
+    // Sub-workspace catalog: references must also be preserved
+    const appPkg = await file(join(String(dir), "packages", "app", "package.json")).json();
+    expect(appPkg.dependencies["is-odd"]).toBe("catalog:tools");
+  });
+
+  test("bun update -r preserves catalog references", async () => {
+    using dir = tempDir("28073-update-r", {
+      "package.json": JSON.stringify({
+        name: "catalog-monorepo",
+        private: true,
+        workspaces: ["packages/*"],
+        catalog: {
+          "is-odd": "^3.0.0",
+        },
+        devDependencies: {
+          "is-odd": "catalog:",
+        },
+      }),
+      "packages/app/package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: {
+          "is-odd": "catalog:",
+        },
+      }),
+    });
+
+    await using installProc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await installProc.exited).toBe(0);
+
+    await using updateProc = Bun.spawn({
+      cmd: [bunExe(), "update", "-r"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await updateProc.exited).toBe(0);
+
+    const rootPkg = await file(join(String(dir), "package.json")).json();
+
+    // catalog: references must be preserved
+    expect(rootPkg.devDependencies["is-odd"]).toBe("catalog:");
+
+    // The catalog section should be updated
+    expect(rootPkg.catalog["is-odd"]).toMatch(/^\^3\./);
+
+    // Sub-workspace must preserve catalog: references
+    const appPkg = await file(join(String(dir), "packages", "app", "package.json")).json();
+    expect(appPkg.dependencies["is-odd"]).toBe("catalog:");
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `bun update` overwriting `"catalog:"` / `"catalog:<group>"` references in `dependencies`/`devDependencies` with hardcoded semver strings
- Instead of modifying dependency entries, update the corresponding `"catalog"` or `"catalogs"` section in package.json with the resolved version
- Handles both default catalogs (`"catalog:"`) and named catalog groups (`"catalog:tools"`)

Closes #28073

## Test plan
- [x] New regression test `test/regression/issue/28073.test.ts` with 3 test cases:
  - Default catalog: `bun update` preserves `catalog:` in devDependencies
  - Named catalog: `bun update` preserves `catalog:tools` in dependencies
  - `bun update -r` preserves catalog references
- [x] Tests fail with system bun (confirming the bug) and pass with debug build (confirming the fix)
- [x] Manual verification: catalog section updated correctly (e.g. `"^3.0.0"` → `"^3.0.1"`) while dep entries remain `"catalog:"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)