### PR TITLE
Replace schtasks CLI flags with XML-based task registration

### DIFF
--- a/docs/runtime/cron.mdx
+++ b/docs/runtime/cron.mdx
@@ -255,9 +255,13 @@ rm ~/Library/LaunchAgents/bun.cron.weekly-report.plist
 
 ### Windows
 
-Bun uses [Task Scheduler](https://learn.microsoft.com/en-us/windows/win32/taskschd/task-scheduler-start-page) via `schtasks`. Each job is registered as a scheduled task named `bun-cron-<title>`.
+Bun uses [Windows Task Scheduler](https://learn.microsoft.com/en-us/windows/win32/taskschd/task-scheduler-start-page) with XML-based task definitions. Each job is registered as a scheduled task named `bun-cron-<title>` using [`CalendarTrigger`](https://learn.microsoft.com/en-us/windows/win32/taskschd/taskschedulerschema-calendartrigger-triggergroup-element) elements and [`Repetition`](https://learn.microsoft.com/en-us/windows/win32/taskschd/taskschedulerschema-repetition-triggerbasetype-element) patterns.
 
-Only simple schedule patterns are supported — `*/N` (every N minutes), `N * * * *` (hourly), `N N * * *` (daily), and `N N * * N` (weekly).
+Most cron expressions are fully supported, including `@daily`, `@weekly`, `@monthly`, `@yearly`, ranges (`1-5`), lists (`1,15`), named days/months, and day-of-month patterns.
+
+:::note
+**Limitation:** Minute steps that don't evenly divide 60 (e.g. `*/7`, `*/8`, `*/9`, `*/11`, `*/13`) with all hours active are not supported on Windows. These patterns would require more than the [48 triggers](https://learn.microsoft.com/en-us/windows/win32/taskschd/task-scheduler-schema) per task that Windows Task Scheduler allows. Common intervals like `*/5`, `*/10`, `*/15`, `*/20`, and `*/30` work fine.
+:::
 
 **Viewing registered jobs:**
 
@@ -267,17 +271,6 @@ schtasks /query /tn "bun-cron-<title>"
 # List all bun cron tasks
 schtasks /query | findstr "bun-cron-"
 ```
-
-**Logs:** Task Scheduler logs events to the Windows Event Log. View them with:
-
-```powershell
-# In PowerShell
-Get-WinEvent -LogName Microsoft-Windows-TaskScheduler/Operational | Where-Object { $_.Message -like "*bun-cron*" }
-```
-
-Or open **Event Viewer** → **Applications and Services Logs** → **Microsoft** → **Windows** → **TaskScheduler** → **Operational**.
-
-To capture stdout/stderr to a file, add logging inside your `scheduled()` handler.
 
 **Manually uninstalling without code:**
 

--- a/docs/runtime/cron.mdx
+++ b/docs/runtime/cron.mdx
@@ -260,7 +260,12 @@ Bun uses [Windows Task Scheduler](https://learn.microsoft.com/en-us/windows/win3
 Most cron expressions are fully supported, including `@daily`, `@weekly`, `@monthly`, `@yearly`, ranges (`1-5`), lists (`1,15`), named days/months, and day-of-month patterns.
 
 :::note
-**Limitation:** Minute steps that don't evenly divide 60 (e.g. `*/7`, `*/8`, `*/9`, `*/11`, `*/13`) with all hours active are not supported on Windows. These patterns would require more than the [48 triggers](https://learn.microsoft.com/en-us/windows/win32/taskschd/task-scheduler-schema) per task that Windows Task Scheduler allows. Common intervals like `*/5`, `*/10`, `*/15`, `*/20`, and `*/30` work fine.
+**Limitation:** Windows Task Scheduler has a limit of [48 triggers per task](https://learn.microsoft.com/en-us/windows/win32/taskschd/task-scheduler-start-page). Simple expressions (e.g. `*/5 * * * *`, `0 9 * * MON-FRI`) use efficient repetition patterns and work fine. However, complex combinations that expand to many distinct fire times may exceed this limit:
+
+- Minute steps that don't evenly divide 60 (e.g. `*/7`, `*/8`, `*/9`) with all hours active
+- Expressions combining frequent intervals with restricted days, like `*/15 * * * MON-FRI` (4 minutes x 24 hours = 96 triggers)
+
+When a pattern exceeds the limit, `Bun.cron()` will reject it with an error explaining the trigger count.
 :::
 
 **Viewing registered jobs:**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7341,6 +7341,20 @@ declare module "bun" {
   ): SyncSubprocess<Out, Err>;
 
   /**
+   * Controller object passed to the `scheduled()` handler when a cron job fires.
+   *
+   * Compatible with [Cloudflare Workers' ScheduledController](https://developers.cloudflare.com/workers/runtime-apis/handlers/scheduled/).
+   */
+  interface CronController {
+    /** The type of event that triggered the handler. Always `"scheduled"`. */
+    readonly type: "scheduled";
+    /** The cron expression that triggered this invocation. */
+    readonly cron: string;
+    /** Timestamp (ms since epoch) when the job was scheduled to run. */
+    readonly scheduledTime: number;
+  }
+
+  /**
    * A cron schedule: a 5-field expression (`minute hour day month weekday`) or a nickname.
    *
    * Nicknames: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@midnight`, `@hourly`.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -708,7 +708,8 @@ install_common_software() {
 			git \
 			unzip \
 			wget \
-			libc6-dbg
+			libc6-dbg \
+			cron
 		;;
 	dnf)
 		# https://packages.fedoraproject.org
@@ -721,7 +722,8 @@ install_common_software() {
 			git \
 			unzip \
 			wget \
-			dnf-plugins-core
+			dnf-plugins-core \
+			cronie
 		;;
 	apk)
 		# https://pkgs.alpinelinux.org/packages
@@ -734,6 +736,7 @@ install_common_software() {
 			git \
 			unzip \
 			wget \
+			busybox-suid \
 		;;
 	pkg)
 		# https://www.freshports.org

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -708,8 +708,7 @@ install_common_software() {
 			git \
 			unzip \
 			wget \
-			libc6-dbg \
-			cron
+			libc6-dbg
 		;;
 	dnf)
 		# https://packages.fedoraproject.org
@@ -722,8 +721,7 @@ install_common_software() {
 			git \
 			unzip \
 			wget \
-			dnf-plugins-core \
-			cronie
+			dnf-plugins-core
 		;;
 	apk)
 		# https://pkgs.alpinelinux.org/packages
@@ -736,7 +734,6 @@ install_common_software() {
 			git \
 			unzip \
 			wget \
-			busybox-suid \
 		;;
 	pkg)
 		# https://www.freshports.org

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -1095,8 +1095,7 @@ fn emitCalendarDicts(result: *std.array_list.Managed(u8), field_values: [5]?[]co
 }
 
 /// Build a Windows Task Scheduler XML definition from a parsed cron expression.
-/// Uses CalendarTrigger with ScheduleByDay/ScheduleByWeek/ScheduleByMonth to
-/// support the full range of cron expressions, unlike the limited schtasks CLI flags.
+/// Uses TimeTrigger+Repetition for simple intervals, CalendarTrigger for complex schedules.
 fn cronToTaskXml(
     cron: CronExpression,
     bun_exe: []const u8,
@@ -1108,7 +1107,6 @@ fn cronToTaskXml(
     var xml = std.array_list.Managed(u8).init(allocator);
     errdefer xml.deinit();
 
-    // XML header + task start
     try xml.appendSlice(
         \\<?xml version="1.0" encoding="UTF-8"?>
         \\<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
@@ -1116,60 +1114,119 @@ fn cronToTaskXml(
         \\
     );
 
-    // Determine the trigger strategy based on what cron fields are set.
-    // Each distinct hour×minute combination needs its own CalendarTrigger,
-    // since StartBoundary (which sets the fire time) is per-trigger.
-    const minutes = expandBitfield(u64, cron.minutes, 0, 59) catch return error.InvalidCron;
-    defer allocator.free(minutes);
-    const hours = expandBitfield(u32, cron.hours, 0, 23) catch return error.InvalidCron;
-    defer allocator.free(hours);
+    // Use semantic checks (bitfield values) not syntax flags for wildcard detection.
+    // e.g. "*/1" sets all bits just like "*" but has _is_wildcard=false.
+    const all_days: u32 = ((1 << 32) - 1) & ~@as(u32, 1); // bits 1-31
+    const all_months: u16 = ((1 << 13) - 1) & ~@as(u16, 1); // bits 1-12
+    const all_weekdays: u8 = (1 << 7) - 1; // bits 0-6
 
-    // For each hour×minute pair, emit a CalendarTrigger
-    for (hours) |h| {
-        for (minutes) |m| {
-            var start_boundary_buf: [32]u8 = undefined;
-            const start_boundary = std.fmt.bufPrint(&start_boundary_buf, "2000-01-01T{d:0>2}:{d:0>2}:00", .{
-                @as(u32, @intCast(h)), @as(u32, @intCast(m)),
-            }) catch return error.InvalidCron;
+    const days_is_wild = cron.days == all_days;
+    const weekdays_is_wild = cron.weekdays == all_weekdays;
+    const months_is_wild = cron.months == all_months;
 
-            try xml.appendSlice("    <CalendarTrigger>\n");
-            const sb_line = try std.fmt.allocPrint(allocator, "      <StartBoundary>{s}</StartBoundary>\n", .{start_boundary});
-            defer allocator.free(sb_line);
-            try xml.appendSlice(sb_line);
+    // Compute the GCD-based repetition interval for minute patterns.
+    // If all set minutes are evenly spaced (e.g. */5 → every 5 min), we can
+    // use a single trigger with Repetition instead of one trigger per minute.
+    const minute_interval = computeStepInterval(u64, cron.minutes, 0, 59);
+    const hour_interval = computeStepInterval(u32, cron.hours, 0, 23);
 
-            // POSIX cron OR semantics: when both day-of-month AND day-of-week
-            // are non-wildcard, the job fires when EITHER matches. We emit
-            // separate triggers for each (Task Scheduler fires when ANY trigger matches).
-            const needs_or_split = !cron.days_is_wildcard and !cron.weekdays_is_wildcard;
+    // Strategy: use TimeTrigger+Repetition for simple repeating patterns,
+    // CalendarTrigger for complex day/month/weekday constraints.
+    if (days_is_wild and weekdays_is_wild and months_is_wild and minute_interval != null and hour_interval != null) {
+        // Simple repeating pattern: use a single trigger with Repetition.
+        // e.g. "* * * * *" → PT1M, "*/5 * * * *" → PT5M, "0 */2 * * *" → PT2H
+        const minutes_expanded = expandBitfield(u64, cron.minutes, 0, 59) catch return error.InvalidCron;
+        defer allocator.free(minutes_expanded);
+        const hours_expanded = expandBitfield(u32, cron.hours, 0, 23) catch return error.InvalidCron;
+        defer allocator.free(hours_expanded);
 
-            if (!cron.days_is_wildcard) {
-                try appendScheduleByMonth(&xml, allocator, cron, start_boundary);
-            }
-            if (!cron.weekdays_is_wildcard) {
-                if (needs_or_split) {
-                    // Close the day-of-month trigger, open a new one for day-of-week
-                    try xml.appendSlice("    </CalendarTrigger>\n");
-                    try xml.appendSlice("    <CalendarTrigger>\n");
-                    const sb2 = try std.fmt.allocPrint(allocator, "      <StartBoundary>{s}</StartBoundary>\n", .{start_boundary});
-                    defer allocator.free(sb2);
-                    try xml.appendSlice(sb2);
+        const first_min = if (minutes_expanded.len > 0) @as(u32, @intCast(minutes_expanded[0])) else 0;
+        const first_hour = if (hours_expanded.len > 0) @as(u32, @intCast(hours_expanded[0])) else 0;
+
+        var sb_buf: [32]u8 = undefined;
+        const sb = std.fmt.bufPrint(&sb_buf, "2000-01-01T{d:0>2}:{d:0>2}:00", .{ first_hour, first_min }) catch return error.InvalidCron;
+
+        try xml.appendSlice("    <CalendarTrigger>\n");
+        const sb_line = try std.fmt.allocPrint(allocator, "      <StartBoundary>{s}</StartBoundary>\n", .{sb});
+        defer allocator.free(sb_line);
+        try xml.appendSlice(sb_line);
+
+        // Add repetition if needed
+        if (minute_interval.? > 1 or hour_interval.? > 0) {
+            const total_minutes = (hour_interval orelse 0) * 60 + (minute_interval orelse 1);
+            if (total_minutes < 60) {
+                const rep = try std.fmt.allocPrint(allocator, "      <Repetition><Interval>PT{d}M</Interval></Repetition>\n", .{total_minutes});
+                defer allocator.free(rep);
+                try xml.appendSlice(rep);
+            } else {
+                const rep_h = total_minutes / 60;
+                const rep_m = total_minutes % 60;
+                if (rep_m == 0) {
+                    const rep = try std.fmt.allocPrint(allocator, "      <Repetition><Interval>PT{d}H</Interval></Repetition>\n", .{rep_h});
+                    defer allocator.free(rep);
+                    try xml.appendSlice(rep);
+                } else {
+                    const rep = try std.fmt.allocPrint(allocator, "      <Repetition><Interval>PT{d}H{d}M</Interval></Repetition>\n", .{ rep_h, rep_m });
+                    defer allocator.free(rep);
+                    try xml.appendSlice(rep);
                 }
-                try xml.appendSlice("      <ScheduleByWeek>\n");
-                try xml.appendSlice("        <WeeksInterval>1</WeeksInterval>\n");
-                try appendDaysOfWeekXml(&xml, cron.weekdays);
-                try xml.appendSlice("      </ScheduleByWeek>\n");
-            } else if (cron.days_is_wildcard) {
-                // Both wildcard: every day
-                try xml.appendSlice("      <ScheduleByDay>\n");
-                try xml.appendSlice("        <DaysInterval>1</DaysInterval>\n");
-                try xml.appendSlice("      </ScheduleByDay>\n");
             }
+        } else {
+            // Every minute
+            try xml.appendSlice("      <Repetition><Interval>PT1M</Interval></Repetition>\n");
+        }
 
-            try xml.appendSlice("    </CalendarTrigger>\n");
+        try xml.appendSlice("      <ScheduleByDay><DaysInterval>1</DaysInterval></ScheduleByDay>\n");
+        try xml.appendSlice("    </CalendarTrigger>\n");
+    } else {
+        // Complex pattern: emit CalendarTriggers for each hour×minute pair.
+        // Cap at 48 triggers (Task Scheduler limit).
+        const minutes_expanded = expandBitfield(u64, cron.minutes, 0, 59) catch return error.InvalidCron;
+        defer allocator.free(minutes_expanded);
+        const hours_expanded = expandBitfield(u32, cron.hours, 0, 23) catch return error.InvalidCron;
+        defer allocator.free(hours_expanded);
+
+        const needs_or_split = !days_is_wild and !weekdays_is_wild;
+        const triggers_per_time: u32 = if (needs_or_split) 2 else 1;
+        const total_triggers = @as(u32, @intCast(minutes_expanded.len)) * @as(u32, @intCast(hours_expanded.len)) * triggers_per_time;
+        if (total_triggers > 48) return error.InvalidCron;
+
+        for (hours_expanded) |h| {
+            for (minutes_expanded) |m| {
+                var sb_buf: [32]u8 = undefined;
+                const sb = std.fmt.bufPrint(&sb_buf, "2000-01-01T{d:0>2}:{d:0>2}:00", .{
+                    @as(u32, @intCast(h)), @as(u32, @intCast(m)),
+                }) catch return error.InvalidCron;
+
+                // Emit day-of-month trigger if needed
+                if (!days_is_wild) {
+                    try appendCalendarTriggerWithSchedule(&xml, allocator, sb, .{ .by_month = .{ .cron = cron, .months_is_wild = months_is_wild } });
+                }
+
+                // Emit day-of-week trigger if needed
+                if (!weekdays_is_wild) {
+                    if (months_is_wild) {
+                        try appendCalendarTriggerWithSchedule(&xml, allocator, sb, .{ .by_week = cron.weekdays });
+                    } else {
+                        // Use ScheduleByMonthDayOfWeek to include month restrictions
+                        try appendCalendarTriggerWithSchedule(&xml, allocator, sb, .{ .by_month_dow = .{ .cron = cron, .months_is_wild = months_is_wild } });
+                    }
+                }
+
+                // Both wildcard: every day (with optional month restriction)
+                if (days_is_wild and weekdays_is_wild) {
+                    if (months_is_wild) {
+                        try appendCalendarTriggerWithSchedule(&xml, allocator, sb, .{ .by_day = {} });
+                    } else {
+                        // Daily but restricted months → use ScheduleByMonth with all days
+                        try appendCalendarTriggerWithSchedule(&xml, allocator, sb, .{ .by_month_all_days = cron.months });
+                    }
+                }
+            }
         }
     }
 
-    // Close triggers, add action, close task
+    // Close triggers, add action
     const xml_bun = try xmlEscape(bun_exe);
     defer allocator.free(xml_bun);
     const xml_title = try xmlEscape(title);
@@ -1256,6 +1313,83 @@ fn expandBitfield(comptime T: type, bits: T, min: u7, max: u7) ![]u7 {
         if (i == max) break;
     }
     return result.toOwnedSlice();
+}
+
+const ScheduleType = union(enum) {
+    by_day: void,
+    by_week: u8, // weekdays bitmask
+    by_month: struct { cron: CronExpression, months_is_wild: bool },
+    by_month_dow: struct { cron: CronExpression, months_is_wild: bool },
+    by_month_all_days: u16, // months bitmask (daily with month restriction)
+};
+
+fn appendCalendarTriggerWithSchedule(xml: *std.array_list.Managed(u8), allocator: std.mem.Allocator, start_boundary: []const u8, sched: ScheduleType) !void {
+    try xml.appendSlice("    <CalendarTrigger>\n");
+    const sb_line = try std.fmt.allocPrint(allocator, "      <StartBoundary>{s}</StartBoundary>\n", .{start_boundary});
+    defer allocator.free(sb_line);
+    try xml.appendSlice(sb_line);
+
+    switch (sched) {
+        .by_day => {
+            try xml.appendSlice("      <ScheduleByDay><DaysInterval>1</DaysInterval></ScheduleByDay>\n");
+        },
+        .by_week => |weekdays| {
+            try xml.appendSlice("      <ScheduleByWeek>\n");
+            try xml.appendSlice("        <WeeksInterval>1</WeeksInterval>\n");
+            try appendDaysOfWeekXml(xml, weekdays);
+            try xml.appendSlice("      </ScheduleByWeek>\n");
+        },
+        .by_month => |info| {
+            try xml.appendSlice("      <ScheduleByMonth>\n");
+            try xml.appendSlice("        <DaysOfMonth>\n");
+            for (1..32) |day| {
+                if (info.cron.days & (@as(u32, 1) << @intCast(day)) != 0) {
+                    const day_line = try std.fmt.allocPrint(allocator, "          <Day>{d}</Day>\n", .{day});
+                    defer allocator.free(day_line);
+                    try xml.appendSlice(day_line);
+                }
+            }
+            try xml.appendSlice("        </DaysOfMonth>\n");
+            try appendMonthsXml(xml, info.cron.months);
+            try xml.appendSlice("      </ScheduleByMonth>\n");
+        },
+        .by_month_dow => |info| {
+            // ScheduleByMonthDayOfWeek: weekday + month restriction
+            try xml.appendSlice("      <ScheduleByMonthDayOfWeek>\n");
+            try xml.appendSlice("        <Weeks><Week>1</Week><Week>2</Week><Week>3</Week><Week>4</Week><Week>Last</Week></Weeks>\n");
+            try appendDaysOfWeekXml(xml, info.cron.weekdays);
+            try appendMonthsXml(xml, info.cron.months);
+            try xml.appendSlice("      </ScheduleByMonthDayOfWeek>\n");
+        },
+        .by_month_all_days => |months| {
+            // Daily schedule restricted to specific months
+            try xml.appendSlice("      <ScheduleByMonth>\n");
+            try xml.appendSlice("        <DaysOfMonth>\n");
+            for (1..32) |day| {
+                const day_line = try std.fmt.allocPrint(allocator, "          <Day>{d}</Day>\n", .{day});
+                defer allocator.free(day_line);
+                try xml.appendSlice(day_line);
+            }
+            try xml.appendSlice("        </DaysOfMonth>\n");
+            try appendMonthsXml(xml, months);
+            try xml.appendSlice("      </ScheduleByMonth>\n");
+        },
+    }
+
+    try xml.appendSlice("    </CalendarTrigger>\n");
+}
+
+/// If all set bits are evenly spaced, return the step size. Otherwise null.
+fn computeStepInterval(comptime T: type, bits: T, min: u7, max: u7) ?u32 {
+    const expanded = expandBitfield(T, bits, min, max) catch return null;
+    defer bun.default_allocator.free(expanded);
+    if (expanded.len == 0) return null;
+    if (expanded.len == 1) return @as(u32, max - min + 1); // fires once per cycle
+    const step = expanded[1] - expanded[0];
+    for (1..expanded.len) |i| {
+        if (expanded[i] - expanded[i - 1] != step) return null;
+    }
+    return step;
 }
 
 /// Convert a cron expression to schtasks /sc and /mo parameters.

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -1148,20 +1148,15 @@ fn cronToTaskXml(
     };
 
     if (can_use_repetition) {
-        const minutes_expanded = expandBitfield(u64, cron.minutes, 0, 59) catch return error.InvalidCron;
-        defer allocator.free(minutes_expanded);
-        const hours_expanded = expandBitfield(u32, cron.hours, 0, 23) catch return error.InvalidCron;
-        defer allocator.free(hours_expanded);
-
-        const first_min = if (minutes_expanded.len > 0) @as(u32, @intCast(minutes_expanded[0])) else 0;
-        const first_hour = if (hours_expanded.len > 0) @as(u32, @intCast(hours_expanded[0])) else 0;
+        const first_min: u32 = @ctz(cron.minutes);
+        const first_hour: u32 = @ctz(cron.hours);
 
         var sb_buf: [32]u8 = undefined;
         const sb = std.fmt.bufPrint(&sb_buf, "2000-01-01T{d:0>2}:{d:0>2}:00", .{ first_hour, first_min }) catch return error.InvalidCron;
 
         try xml.appendSlice("    <CalendarTrigger>\n");
-        const sb_line = try std.fmt.allocPrint(allocator, "      <StartBoundary>{s}</StartBoundary>\n", .{sb});
-        defer allocator.free(sb_line);
+        var line_buf: [128]u8 = undefined;
+        const sb_line = std.fmt.bufPrint(&line_buf, "      <StartBoundary>{s}</StartBoundary>\n", .{sb}) catch return error.InvalidCron;
         try xml.appendSlice(sb_line);
 
         if (hours_count == 24) {
@@ -1170,16 +1165,14 @@ fn cronToTaskXml(
             if (m == 1) {
                 try xml.appendSlice("      <Repetition><Interval>PT1M</Interval></Repetition>\n");
             } else {
-                const rep = try std.fmt.allocPrint(allocator, "      <Repetition><Interval>PT{d}M</Interval></Repetition>\n", .{m});
-                defer allocator.free(rep);
+                const rep = std.fmt.bufPrint(&line_buf, "      <Repetition><Interval>PT{d}M</Interval></Repetition>\n", .{m}) catch return error.InvalidCron;
                 try xml.appendSlice(rep);
             }
         } else {
             // Case 2: hour-based repetition
             const h = hour_interval.?;
             if (h > 1) {
-                const rep = try std.fmt.allocPrint(allocator, "      <Repetition><Interval>PT{d}H</Interval></Repetition>\n", .{h});
-                defer allocator.free(rep);
+                const rep = std.fmt.bufPrint(&line_buf, "      <Repetition><Interval>PT{d}H</Interval></Repetition>\n", .{h}) catch return error.InvalidCron;
                 try xml.appendSlice(rep);
             }
         }
@@ -1189,18 +1182,19 @@ fn cronToTaskXml(
     } else {
         // Complex pattern: emit CalendarTriggers for each hour×minute pair.
         // Cap at 48 triggers (Task Scheduler limit).
-        const minutes_expanded = expandBitfield(u64, cron.minutes, 0, 59) catch return error.InvalidCron;
-        defer allocator.free(minutes_expanded);
-        const hours_expanded = expandBitfield(u32, cron.hours, 0, 23) catch return error.InvalidCron;
-        defer allocator.free(hours_expanded);
-
         const needs_or_split = !days_is_wild and !weekdays_is_wild;
         const triggers_per_time: u32 = if (needs_or_split) 2 else 1;
-        const total_triggers = @as(u32, @intCast(minutes_expanded.len)) * @as(u32, @intCast(hours_expanded.len)) * triggers_per_time;
+        const total_triggers = minutes_count * hours_count * triggers_per_time;
         if (total_triggers > 48) return error.InvalidCron;
 
-        for (hours_expanded) |h| {
-            for (minutes_expanded) |m| {
+        var hours_bits = cron.hours;
+        while (hours_bits != 0) {
+            const h: u32 = @ctz(hours_bits);
+            hours_bits &= hours_bits - 1;
+            var mins_bits = cron.minutes;
+            while (mins_bits != 0) {
+                const m: u32 = @ctz(mins_bits);
+                mins_bits &= mins_bits - 1;
                 var sb_buf: [32]u8 = undefined;
                 const sb = std.fmt.bufPrint(&sb_buf, "2000-01-01T{d:0>2}:{d:0>2}:00", .{
                     @as(u32, @intCast(h)), @as(u32, @intCast(m)),
@@ -1268,14 +1262,25 @@ fn cronToTaskXml(
     return xml.toOwnedSlice();
 }
 
+fn appendDaysOfMonthXml(xml: *std.array_list.Managed(u8), days: u32) !void {
+    try xml.appendSlice("        <DaysOfMonth>\n");
+    var buf: [32]u8 = undefined;
+    for (1..32) |day| {
+        if (days & (@as(u32, 1) << @intCast(day)) != 0) {
+            const line = std.fmt.bufPrint(&buf, "          <Day>{d}</Day>\n", .{day}) catch return error.InvalidCron;
+            try xml.appendSlice(line);
+        }
+    }
+    try xml.appendSlice("        </DaysOfMonth>\n");
+}
 fn appendMonthsXml(xml: *std.array_list.Managed(u8), months: u16) !void {
     const month_names = [_][]const u8{ "", "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" };
     try xml.appendSlice("        <Months>\n");
+    var buf: [32]u8 = undefined;
     for (1..13) |mo| {
         if (months & (@as(u16, 1) << @intCast(mo)) != 0) {
-            const mo_line = try std.fmt.allocPrint(bun.default_allocator, "          <{s}/>\n", .{month_names[mo]});
-            defer bun.default_allocator.free(mo_line);
-            try xml.appendSlice(mo_line);
+            const line = std.fmt.bufPrint(&buf, "          <{s}/>\n", .{month_names[mo]}) catch continue;
+            try xml.appendSlice(line);
         }
     }
     try xml.appendSlice("        </Months>\n");
@@ -1284,28 +1289,14 @@ fn appendMonthsXml(xml: *std.array_list.Managed(u8), months: u16) !void {
 fn appendDaysOfWeekXml(xml: *std.array_list.Managed(u8), weekdays: u8) !void {
     const day_names = [_][]const u8{ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" };
     try xml.appendSlice("        <DaysOfWeek>\n");
+    var buf: [32]u8 = undefined;
     for (0..7) |d| {
         if (weekdays & (@as(u8, 1) << @intCast(d)) != 0) {
-            const d_line = try std.fmt.allocPrint(bun.default_allocator, "          <{s}/>\n", .{day_names[d]});
-            defer bun.default_allocator.free(d_line);
-            try xml.appendSlice(d_line);
+            const line = std.fmt.bufPrint(&buf, "          <{s}/>\n", .{day_names[d]}) catch continue;
+            try xml.appendSlice(line);
         }
     }
     try xml.appendSlice("        </DaysOfWeek>\n");
-}
-
-/// Expand a bitfield into an array of set bit positions.
-fn expandBitfield(comptime T: type, bits: T, min: u7, max: u7) ![]u7 {
-    var result = std.array_list.Managed(u7).init(bun.default_allocator);
-    errdefer result.deinit();
-    var i: u7 = min;
-    while (i <= max) : (i += 1) {
-        if (bits & (@as(T, 1) << @intCast(i)) != 0) {
-            try result.append(i);
-        }
-        if (i == max) break;
-    }
-    return result.toOwnedSlice();
 }
 
 const ScheduleType = union(enum) {
@@ -1316,10 +1307,10 @@ const ScheduleType = union(enum) {
     by_month_all_days: u16, // months bitmask (daily with month restriction)
 };
 
-fn appendCalendarTriggerWithSchedule(xml: *std.array_list.Managed(u8), allocator: std.mem.Allocator, start_boundary: []const u8, sched: ScheduleType) !void {
+fn appendCalendarTriggerWithSchedule(xml: *std.array_list.Managed(u8), _: std.mem.Allocator, start_boundary: []const u8, sched: ScheduleType) !void {
     try xml.appendSlice("    <CalendarTrigger>\n");
-    const sb_line = try std.fmt.allocPrint(allocator, "      <StartBoundary>{s}</StartBoundary>\n", .{start_boundary});
-    defer allocator.free(sb_line);
+    var sb_buf: [80]u8 = undefined;
+    const sb_line = std.fmt.bufPrint(&sb_buf, "      <StartBoundary>{s}</StartBoundary>\n", .{start_boundary}) catch return error.OutOfMemory;
     try xml.appendSlice(sb_line);
 
     switch (sched) {
@@ -1334,15 +1325,7 @@ fn appendCalendarTriggerWithSchedule(xml: *std.array_list.Managed(u8), allocator
         },
         .by_month => |info| {
             try xml.appendSlice("      <ScheduleByMonth>\n");
-            try xml.appendSlice("        <DaysOfMonth>\n");
-            for (1..32) |day| {
-                if (info.cron.days & (@as(u32, 1) << @intCast(day)) != 0) {
-                    const day_line = try std.fmt.allocPrint(allocator, "          <Day>{d}</Day>\n", .{day});
-                    defer allocator.free(day_line);
-                    try xml.appendSlice(day_line);
-                }
-            }
-            try xml.appendSlice("        </DaysOfMonth>\n");
+            try appendDaysOfMonthXml(xml, info.cron.days);
             try appendMonthsXml(xml, info.cron.months);
             try xml.appendSlice("      </ScheduleByMonth>\n");
         },
@@ -1355,15 +1338,8 @@ fn appendCalendarTriggerWithSchedule(xml: *std.array_list.Managed(u8), allocator
             try xml.appendSlice("      </ScheduleByMonthDayOfWeek>\n");
         },
         .by_month_all_days => |months| {
-            // Daily schedule restricted to specific months
             try xml.appendSlice("      <ScheduleByMonth>\n");
-            try xml.appendSlice("        <DaysOfMonth>\n");
-            for (1..32) |day| {
-                const day_line = try std.fmt.allocPrint(allocator, "          <Day>{d}</Day>\n", .{day});
-                defer allocator.free(day_line);
-                try xml.appendSlice(day_line);
-            }
-            try xml.appendSlice("        </DaysOfMonth>\n");
+            try appendDaysOfMonthXml(xml, 0xFFFFFFFE);
             try appendMonthsXml(xml, months);
             try xml.appendSlice("      </ScheduleByMonth>\n");
         },
@@ -1373,14 +1349,24 @@ fn appendCalendarTriggerWithSchedule(xml: *std.array_list.Managed(u8), allocator
 }
 
 /// If all set bits are evenly spaced, return the step size. Otherwise null.
-fn computeStepInterval(comptime T: type, bits: T, min: u7, max: u7) ?u32 {
-    const expanded = expandBitfield(T, bits, min, max) catch return null;
-    defer bun.default_allocator.free(expanded);
-    if (expanded.len == 0) return null;
-    if (expanded.len == 1) return @as(u32, max - min + 1); // fires once per cycle
-    const step = expanded[1] - expanded[0];
-    for (1..expanded.len) |i| {
-        if (expanded[i] - expanded[i - 1] != step) return null;
+fn computeStepInterval(comptime T: type, bits: T, _: u7, max: u7) ?u32 {
+    if (bits == 0) return null;
+    const count = @popCount(bits);
+    if (count == 1) return @as(u32, max) + 1;
+    // Find first two set bits to determine step
+    var remaining = bits;
+    const first: u32 = @ctz(remaining);
+    remaining &= remaining - 1;
+    const second: u32 = @ctz(remaining);
+    const step = second - first;
+    // Verify all bits are evenly spaced
+    remaining &= remaining - 1;
+    var prev = second;
+    while (remaining != 0) {
+        const next: u32 = @ctz(remaining);
+        if (next - prev != step) return null;
+        prev = next;
+        remaining &= remaining - 1;
     }
     return step;
 }

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -55,6 +55,7 @@ pub const CronRegisterJob = struct {
     schedule: [:0]const u8, // normalized numeric form for crontab/launchd
     raw_schedule: [:0]const u8, // original form for --cron-period and schtasks parsing
     title: [:0]const u8,
+    parsed_cron: CronExpression,
 
     state: State = .reading_crontab,
     process: ?*Process = null,
@@ -454,7 +455,7 @@ pub const CronRegisterJob = struct {
             bun.default_allocator.free(title_owned);
             return globalObject.throw("Out of memory", .{});
         };
-        job.* = .{ .global = globalObject, .bun_exe = bun_exe, .abs_path = abs_path, .schedule = schedule_owned, .raw_schedule = raw_schedule_owned, .title = title_owned, .promise = jsc.JSPromise.Strong.init(globalObject) };
+        job.* = .{ .global = globalObject, .bun_exe = bun_exe, .abs_path = abs_path, .schedule = schedule_owned, .raw_schedule = raw_schedule_owned, .title = title_owned, .parsed_cron = parsed, .promise = jsc.JSPromise.Strong.init(globalObject) };
 
         const promise_value = job.promise.value();
         job.poll.ref(jsc.VirtualMachine.get());
@@ -472,9 +473,7 @@ pub const CronRegisterJob = struct {
     // -- Windows --
 
     fn startWindows(this: *CronRegisterJob) void {
-        // Use schtasks /create with /sc and /tr to register a task.
-        // Task name: "bun-cron-<title>"
-        this.state = .installing_crontab; // reuse state for "single spawn" flow
+        this.state = .installing_crontab;
 
         const task_name = allocPrintZ(bun.default_allocator, "bun-cron-{s}", .{this.title}) catch {
             this.setErr("Out of memory", .{});
@@ -483,59 +482,34 @@ pub const CronRegisterJob = struct {
         };
         defer bun.default_allocator.free(task_name);
 
-        // Build the command that schtasks will execute
-        const tr_cmd = allocPrintZ(bun.default_allocator, "\"{s}\" run --cron-title={s} --cron-period=\"{s}\" \"{s}\"", .{
-            this.bun_exe, this.title, this.schedule, this.abs_path,
-        }) catch {
+        const xml = cronToTaskXml(this.parsed_cron, this.bun_exe, this.title, this.schedule, this.abs_path) catch {
+            this.setErr("Failed to build task XML", .{});
+            this.finish();
+            return;
+        };
+        defer bun.default_allocator.free(xml);
+
+        const xml_path = makeTempPath("bun-cron-xml-", this.title) catch {
             this.setErr("Out of memory", .{});
             this.finish();
             return;
         };
-        defer bun.default_allocator.free(tr_cmd);
+        this.tmp_path = xml_path;
 
-        // Parse cron to schtasks params using normalized schedule (nicknames already expanded to 5 fields)
-        const schtasks_params = cronToSchtasks(this.schedule) catch {
-            this.setErr("Cannot convert this cron expression to a Windows scheduled task. Only simple patterns are supported.", .{});
+        const file = bun.sys.File.openat(bun.FD.cwd(), xml_path, bun.O.WRONLY | bun.O.CREAT | bun.O.EXCL, 0o600).unwrap() catch {
+            this.setErr("Failed to create temp XML file", .{});
+            this.finish();
+            return;
+        };
+        defer file.close();
+        _ = file.writeAll(xml).unwrap() catch {
+            this.setErr("Failed to write temp XML file", .{});
             this.finish();
             return;
         };
 
-        var argv_buf: [16:null]?[*:0]const u8 = .{null} ** 16;
-        var argc: usize = 0;
-        argv_buf[argc] = "schtasks";
-        argc += 1;
-        argv_buf[argc] = "/create";
-        argc += 1;
-        argv_buf[argc] = "/tn";
-        argc += 1;
-        argv_buf[argc] = task_name.ptr;
-        argc += 1;
-        argv_buf[argc] = "/tr";
-        argc += 1;
-        argv_buf[argc] = tr_cmd.ptr;
-        argc += 1;
-        argv_buf[argc] = "/sc";
-        argc += 1;
-        argv_buf[argc] = schtasks_params.sc;
-        argc += 1;
-        argv_buf[argc] = "/mo";
-        argc += 1;
-        argv_buf[argc] = schtasks_params.mo;
-        argc += 1;
-        if (schtasks_params.start_time) |st| {
-            argv_buf[argc] = "/st";
-            argc += 1;
-            argv_buf[argc] = st;
-            argc += 1;
-        }
-        if (schtasks_params.day_spec) |d| {
-            argv_buf[argc] = "/d";
-            argc += 1;
-            argv_buf[argc] = d;
-            argc += 1;
-        }
-        argv_buf[argc] = "/f";
-        this.spawnCmd(&argv_buf, .ignore, .ignore);
+        var argv = [_:null]?[*:0]const u8{ "schtasks", "/create", "/xml", xml_path.ptr, "/tn", task_name.ptr, "/f", null };
+        this.spawnCmd(&argv, .ignore, .ignore);
     }
 };
 
@@ -1115,6 +1089,154 @@ fn emitCalendarDicts(result: *std.array_list.Managed(u8), field_values: [5]?[]co
     }
 }
 
+/// Build a Windows Task Scheduler XML definition from a parsed cron expression.
+/// Uses CalendarTrigger with ScheduleByDay/ScheduleByWeek/ScheduleByMonth to
+/// support the full range of cron expressions, unlike the limited schtasks CLI flags.
+fn cronToTaskXml(
+    cron: CronExpression,
+    bun_exe: []const u8,
+    title: []const u8,
+    schedule: []const u8,
+    abs_path: []const u8,
+) ![]const u8 {
+    const allocator = bun.default_allocator;
+    var xml = std.array_list.Managed(u8).init(allocator);
+    errdefer xml.deinit();
+
+    // XML header + task start
+    try xml.appendSlice(
+        \\<?xml version="1.0" encoding="UTF-16"?>
+        \\<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+        \\  <Triggers>
+        \\
+    );
+
+    // Determine the trigger strategy based on what cron fields are set.
+    // Each distinct hour×minute combination needs its own CalendarTrigger,
+    // since StartBoundary (which sets the fire time) is per-trigger.
+    const minutes = expandBitfield(u64, cron.minutes, 0, 59) catch return error.InvalidCron;
+    defer allocator.free(minutes);
+    const hours = expandBitfield(u32, cron.hours, 0, 23) catch return error.InvalidCron;
+    defer allocator.free(hours);
+
+    // For each hour×minute pair, emit a CalendarTrigger
+    for (hours) |h| {
+        for (minutes) |m| {
+            var start_boundary_buf: [32]u8 = undefined;
+            const start_boundary = std.fmt.bufPrint(&start_boundary_buf, "2000-01-01T{d:0>2}:{d:0>2}:00", .{
+                @as(u32, @intCast(h)), @as(u32, @intCast(m)),
+            }) catch return error.InvalidCron;
+
+            try xml.appendSlice("    <CalendarTrigger>\n");
+            const sb_line = try std.fmt.allocPrint(allocator, "      <StartBoundary>{s}</StartBoundary>\n", .{start_boundary});
+            defer allocator.free(sb_line);
+            try xml.appendSlice(sb_line);
+
+            // Choose schedule type based on cron fields
+            if (!cron.days_is_wildcard) {
+                // ScheduleByMonth: specific days-of-month
+                try xml.appendSlice("      <ScheduleByMonth>\n");
+                try xml.appendSlice("        <DaysOfMonth>\n");
+                for (1..32) |day| {
+                    if (cron.days & (@as(u32, 1) << @intCast(day)) != 0) {
+                        const day_line = try std.fmt.allocPrint(allocator, "          <Day>{d}</Day>\n", .{day});
+                        defer allocator.free(day_line);
+                        try xml.appendSlice(day_line);
+                    }
+                }
+                try xml.appendSlice("        </DaysOfMonth>\n");
+                try appendMonthsXml(&xml, cron.months);
+                try xml.appendSlice("      </ScheduleByMonth>\n");
+            } else if (!cron.weekdays_is_wildcard) {
+                // ScheduleByWeek: specific days-of-week
+                try xml.appendSlice("      <ScheduleByWeek>\n");
+                try xml.appendSlice("        <WeeksInterval>1</WeeksInterval>\n");
+                try appendDaysOfWeekXml(&xml, cron.weekdays);
+                try xml.appendSlice("      </ScheduleByWeek>\n");
+            } else {
+                // ScheduleByDay: every day
+                try xml.appendSlice("      <ScheduleByDay>\n");
+                try xml.appendSlice("        <DaysInterval>1</DaysInterval>\n");
+                try xml.appendSlice("      </ScheduleByDay>\n");
+            }
+
+            try xml.appendSlice("    </CalendarTrigger>\n");
+        }
+    }
+
+    // Close triggers, add action, close task
+    const xml_bun = try xmlEscape(bun_exe);
+    defer allocator.free(xml_bun);
+    const xml_title = try xmlEscape(title);
+    defer allocator.free(xml_title);
+    const xml_sched = try xmlEscape(schedule);
+    defer allocator.free(xml_sched);
+    const xml_path = try xmlEscape(abs_path);
+    defer allocator.free(xml_path);
+
+    const action_xml = try std.fmt.allocPrint(allocator,
+        \\  </Triggers>
+        \\  <Settings>
+        \\    <Enabled>true</Enabled>
+        \\    <AllowStartOnDemand>true</AllowStartOnDemand>
+        \\    <AllowHardTerminate>true</AllowHardTerminate>
+        \\    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+        \\  </Settings>
+        \\  <Actions>
+        \\    <Exec>
+        \\      <Command>{s}</Command>
+        \\      <Arguments>run --cron-title={s} --cron-period="{s}" "{s}"</Arguments>
+        \\    </Exec>
+        \\  </Actions>
+        \\</Task>
+        \\
+    , .{ xml_bun, xml_title, xml_sched, xml_path });
+    defer allocator.free(action_xml);
+    try xml.appendSlice(action_xml);
+
+    return xml.toOwnedSlice();
+}
+
+fn appendMonthsXml(xml: *std.array_list.Managed(u8), months: u16) !void {
+    const month_names = [_][]const u8{ "", "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" };
+    try xml.appendSlice("        <Months>\n");
+    for (1..13) |mo| {
+        if (months & (@as(u16, 1) << @intCast(mo)) != 0) {
+            const mo_line = try std.fmt.allocPrint(bun.default_allocator, "          <{s}/>\n", .{month_names[mo]});
+            defer bun.default_allocator.free(mo_line);
+            try xml.appendSlice(mo_line);
+        }
+    }
+    try xml.appendSlice("        </Months>\n");
+}
+
+fn appendDaysOfWeekXml(xml: *std.array_list.Managed(u8), weekdays: u8) !void {
+    const day_names = [_][]const u8{ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" };
+    try xml.appendSlice("        <DaysOfWeek>\n");
+    for (0..7) |d| {
+        if (weekdays & (@as(u8, 1) << @intCast(d)) != 0) {
+            const d_line = try std.fmt.allocPrint(bun.default_allocator, "          <{s}/>\n", .{day_names[d]});
+            defer bun.default_allocator.free(d_line);
+            try xml.appendSlice(d_line);
+        }
+    }
+    try xml.appendSlice("        </DaysOfWeek>\n");
+}
+
+/// Expand a bitfield into an array of set bit positions.
+fn expandBitfield(comptime T: type, bits: T, min: u7, max: u7) ![]u7 {
+    var result = std.array_list.Managed(u7).init(bun.default_allocator);
+    errdefer result.deinit();
+    var i: u7 = min;
+    while (i <= max) : (i += 1) {
+        if (bits & (@as(T, 1) << @intCast(i)) != 0) {
+            try result.append(i);
+        }
+        if (i == max) break;
+    }
+    return result.toOwnedSlice();
+}
+
 /// Convert a cron expression to schtasks /sc and /mo parameters.
 /// Supports: */N * * * * (MINUTE), 0 */N * * * (HOURLY), 0 0 * * * (DAILY),
 /// 0 0 * * N (WEEKLY). Returns error for complex expressions.
@@ -1227,7 +1349,11 @@ fn allocPrintZ(allocator: std.mem.Allocator, comptime fmt: []const u8, args: any
 /// Create a temp file path with a random suffix to avoid TOCTOU/symlink attacks.
 fn makeTempPath(comptime prefix: []const u8, title: []const u8) ![:0]const u8 {
     const rand = bun.fastRandom();
-    return allocPrintZ(bun.default_allocator, "/tmp/" ++ prefix ++ "{s}-{x}.tmp", .{ title, rand });
+    const tmp_dir = if (comptime bun.Environment.isWindows)
+        bun.env_var.TEMP.get() orelse bun.env_var.TMP.get() orelse "C:\\Temp"
+    else
+        "/tmp";
+    return allocPrintZ(bun.default_allocator, "{s}/" ++ prefix ++ "{s}-{x}.tmp", .{ tmp_dir, title, rand });
 }
 
 const std = @import("std");

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -1105,7 +1105,7 @@ fn cronToTaskXml(
 
     // XML header + task start
     try xml.appendSlice(
-        \\<?xml version="1.0" encoding="UTF-16"?>
+        \\<?xml version="1.0" encoding="UTF-8"?>
         \\<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
         \\  <Triggers>
         \\
@@ -1132,29 +1132,29 @@ fn cronToTaskXml(
             defer allocator.free(sb_line);
             try xml.appendSlice(sb_line);
 
-            // Choose schedule type based on cron fields
+            // POSIX cron OR semantics: when both day-of-month AND day-of-week
+            // are non-wildcard, the job fires when EITHER matches. We emit
+            // separate triggers for each (Task Scheduler fires when ANY trigger matches).
+            const needs_or_split = !cron.days_is_wildcard and !cron.weekdays_is_wildcard;
+
             if (!cron.days_is_wildcard) {
-                // ScheduleByMonth: specific days-of-month
-                try xml.appendSlice("      <ScheduleByMonth>\n");
-                try xml.appendSlice("        <DaysOfMonth>\n");
-                for (1..32) |day| {
-                    if (cron.days & (@as(u32, 1) << @intCast(day)) != 0) {
-                        const day_line = try std.fmt.allocPrint(allocator, "          <Day>{d}</Day>\n", .{day});
-                        defer allocator.free(day_line);
-                        try xml.appendSlice(day_line);
-                    }
+                try appendScheduleByMonth(&xml, allocator, cron, start_boundary);
+            }
+            if (!cron.weekdays_is_wildcard) {
+                if (needs_or_split) {
+                    // Close the day-of-month trigger, open a new one for day-of-week
+                    try xml.appendSlice("    </CalendarTrigger>\n");
+                    try xml.appendSlice("    <CalendarTrigger>\n");
+                    const sb2 = try std.fmt.allocPrint(allocator, "      <StartBoundary>{s}</StartBoundary>\n", .{start_boundary});
+                    defer allocator.free(sb2);
+                    try xml.appendSlice(sb2);
                 }
-                try xml.appendSlice("        </DaysOfMonth>\n");
-                try appendMonthsXml(&xml, cron.months);
-                try xml.appendSlice("      </ScheduleByMonth>\n");
-            } else if (!cron.weekdays_is_wildcard) {
-                // ScheduleByWeek: specific days-of-week
                 try xml.appendSlice("      <ScheduleByWeek>\n");
                 try xml.appendSlice("        <WeeksInterval>1</WeeksInterval>\n");
                 try appendDaysOfWeekXml(&xml, cron.weekdays);
                 try xml.appendSlice("      </ScheduleByWeek>\n");
-            } else {
-                // ScheduleByDay: every day
+            } else if (cron.days_is_wildcard) {
+                // Both wildcard: every day
                 try xml.appendSlice("      <ScheduleByDay>\n");
                 try xml.appendSlice("        <DaysInterval>1</DaysInterval>\n");
                 try xml.appendSlice("      </ScheduleByDay>\n");
@@ -1195,6 +1195,22 @@ fn cronToTaskXml(
     try xml.appendSlice(action_xml);
 
     return xml.toOwnedSlice();
+}
+
+fn appendScheduleByMonth(xml: *std.array_list.Managed(u8), allocator: std.mem.Allocator, cron: CronExpression, start_boundary: []const u8) !void {
+    _ = start_boundary;
+    try xml.appendSlice("      <ScheduleByMonth>\n");
+    try xml.appendSlice("        <DaysOfMonth>\n");
+    for (1..32) |day| {
+        if (cron.days & (@as(u32, 1) << @intCast(day)) != 0) {
+            const day_line = try std.fmt.allocPrint(allocator, "          <Day>{d}</Day>\n", .{day});
+            defer allocator.free(day_line);
+            try xml.appendSlice(day_line);
+        }
+    }
+    try xml.appendSlice("        </DaysOfMonth>\n");
+    try appendMonthsXml(xml, cron.months);
+    try xml.appendSlice("      </ScheduleByMonth>\n");
 }
 
 fn appendMonthsXml(xml: *std.array_list.Managed(u8), months: u16) !void {

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -420,11 +420,16 @@ pub const CronRegisterJob = struct {
             return globalObject.throwInvalidArguments("Failed to resolve path", .{});
         };
 
-        // Validate path has no single quotes (used for shell escaping in crontab)
+        // Validate path has no single quotes (shell escaping in crontab) or
+        // percent signs (cron interprets % as newline before the shell sees it)
         for (abs_path) |c| {
             if (c == '\'') {
                 bun.default_allocator.free(abs_path);
                 return globalObject.throwInvalidArguments("Path must not contain single quotes", .{});
+            }
+            if (c == '%') {
+                bun.default_allocator.free(abs_path);
+                return globalObject.throwInvalidArguments("Path must not contain percent signs (cron interprets % as newline)", .{});
             }
         }
 

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -487,8 +487,12 @@ pub const CronRegisterJob = struct {
         };
         defer bun.default_allocator.free(task_name);
 
-        const xml = cronToTaskXml(this.parsed_cron, this.bun_exe, this.title, this.schedule, this.abs_path) catch {
-            this.setErr("Failed to build task XML", .{});
+        const xml = cronToTaskXml(this.parsed_cron, this.bun_exe, this.title, this.schedule, this.abs_path) catch |err| {
+            if (err == error.TooManyTriggers) {
+                this.setErr("This cron expression requires too many triggers for Windows Task Scheduler (max 48). Simplify the expression or use fewer restricted fields.", .{});
+            } else {
+                this.setErr("Failed to build task XML", .{});
+            }
             this.finish();
             return;
         };
@@ -1185,7 +1189,7 @@ fn cronToTaskXml(
         const needs_or_split = !days_is_wild and !weekdays_is_wild;
         const triggers_per_time: u32 = if (needs_or_split) 2 else 1;
         const total_triggers = minutes_count * hours_count * triggers_per_time;
-        if (total_triggers > 48) return error.InvalidCron;
+        if (total_triggers > 48) return error.TooManyTriggers;
 
         var hours_bits = cron.hours;
         while (hours_bits != 0) {
@@ -1279,7 +1283,7 @@ fn appendMonthsXml(xml: *std.array_list.Managed(u8), months: u16) !void {
     var buf: [32]u8 = undefined;
     for (1..13) |mo| {
         if (months & (@as(u16, 1) << @intCast(mo)) != 0) {
-            const line = std.fmt.bufPrint(&buf, "          <{s}/>\n", .{month_names[mo]}) catch continue;
+            const line = std.fmt.bufPrint(&buf, "          <{s}/>\n", .{month_names[mo]}) catch return error.InvalidCron;
             try xml.appendSlice(line);
         }
     }
@@ -1292,7 +1296,7 @@ fn appendDaysOfWeekXml(xml: *std.array_list.Managed(u8), weekdays: u8) !void {
     var buf: [32]u8 = undefined;
     for (0..7) |d| {
         if (weekdays & (@as(u8, 1) << @intCast(d)) != 0) {
-            const line = std.fmt.bufPrint(&buf, "          <{s}/>\n", .{day_names[d]}) catch continue;
+            const line = std.fmt.bufPrint(&buf, "          <{s}/>\n", .{day_names[d]}) catch return error.InvalidCron;
             try xml.appendSlice(line);
         }
     }

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -1259,22 +1259,6 @@ fn cronToTaskXml(
     return xml.toOwnedSlice();
 }
 
-fn appendScheduleByMonth(xml: *std.array_list.Managed(u8), allocator: std.mem.Allocator, cron: CronExpression, start_boundary: []const u8) !void {
-    _ = start_boundary;
-    try xml.appendSlice("      <ScheduleByMonth>\n");
-    try xml.appendSlice("        <DaysOfMonth>\n");
-    for (1..32) |day| {
-        if (cron.days & (@as(u32, 1) << @intCast(day)) != 0) {
-            const day_line = try std.fmt.allocPrint(allocator, "          <Day>{d}</Day>\n", .{day});
-            defer allocator.free(day_line);
-            try xml.appendSlice(day_line);
-        }
-    }
-    try xml.appendSlice("        </DaysOfMonth>\n");
-    try appendMonthsXml(xml, cron.months);
-    try xml.appendSlice("      </ScheduleByMonth>\n");
-}
-
 fn appendMonthsXml(xml: *std.array_list.Managed(u8), months: u16) !void {
     const month_names = [_][]const u8{ "", "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" };
     try xml.appendSlice("        <Months>\n");
@@ -1390,109 +1374,6 @@ fn computeStepInterval(comptime T: type, bits: T, min: u7, max: u7) ?u32 {
         if (expanded[i] - expanded[i - 1] != step) return null;
     }
     return step;
-}
-
-/// Convert a cron expression to schtasks /sc and /mo parameters.
-/// Supports: */N * * * * (MINUTE), 0 */N * * * (HOURLY), 0 0 * * * (DAILY),
-/// 0 0 * * N (WEEKLY). Returns error for complex expressions.
-const SchtasksParams = struct {
-    sc: [*:0]const u8,
-    mo: [*:0]const u8,
-    start_time: ?[*:0]const u8 = null, // /st HH:MM
-    day_spec: ?[*:0]const u8 = null, // /d for WEEKLY
-};
-
-fn cronToSchtasks(schedule: []const u8) !SchtasksParams {
-    var fields: [5][]const u8 = undefined;
-    var count: usize = 0;
-    var iter = std.mem.tokenizeScalar(u8, schedule, ' ');
-    while (iter.next()) |field| {
-        if (count >= 5) return error.UnsupportedSchedule;
-        fields[count] = field;
-        count += 1;
-    }
-    if (count != 5) return error.UnsupportedSchedule;
-
-    const minute = fields[0];
-    const hour = fields[1];
-    const dom = fields[2];
-    const month = fields[3];
-    const dow = fields[4];
-
-    // Every N minutes: */N * * * *
-    if (bun.strings.hasPrefixComptime(minute, "*/") and
-        bun.strings.eql(hour, "*") and bun.strings.eql(dom, "*") and
-        bun.strings.eql(month, "*") and bun.strings.eql(dow, "*"))
-    {
-        const val = std.fmt.parseInt(u32, minute[2..], 10) catch return error.UnsupportedSchedule;
-        const static_min = struct {
-            var buf: [16:0]u8 = undefined;
-        };
-        _ = std.fmt.bufPrintZ(&static_min.buf, "{d}", .{val}) catch return error.UnsupportedSchedule;
-        return .{ .sc = "MINUTE", .mo = &static_min.buf };
-    }
-
-    // Every minute: * * * * *
-    if (bun.strings.eql(minute, "*") and bun.strings.eql(hour, "*") and
-        bun.strings.eql(dom, "*") and bun.strings.eql(month, "*") and bun.strings.eql(dow, "*"))
-        return .{ .sc = "MINUTE", .mo = "1" };
-
-    // Hourly: 0 * * * * or N * * * *
-    if (bun.strings.eql(hour, "*") and bun.strings.eql(dom, "*") and
-        bun.strings.eql(month, "*") and bun.strings.eql(dow, "*"))
-    {
-        const m = std.fmt.parseInt(u32, minute, 10) catch return error.UnsupportedSchedule;
-        const static_hourly_st = struct {
-            var buf: [6:0]u8 = undefined;
-        };
-        _ = std.fmt.bufPrintZ(&static_hourly_st.buf, "00:{d:0>2}", .{m}) catch return error.UnsupportedSchedule;
-        return .{ .sc = "HOURLY", .mo = "1", .start_time = &static_hourly_st.buf };
-    }
-
-    // Daily: N N * * *
-    if (bun.strings.eql(dom, "*") and bun.strings.eql(month, "*") and bun.strings.eql(dow, "*")) {
-        const m = std.fmt.parseInt(u32, minute, 10) catch return error.UnsupportedSchedule;
-        const h = std.fmt.parseInt(u32, hour, 10) catch return error.UnsupportedSchedule;
-        const static_st = struct {
-            var buf: [6:0]u8 = undefined;
-        };
-        _ = std.fmt.bufPrintZ(&static_st.buf, "{d:0>2}:{d:0>2}", .{ h, m }) catch return error.UnsupportedSchedule;
-        return .{ .sc = "DAILY", .mo = "1", .start_time = &static_st.buf };
-    }
-
-    // Weekly: N N * * N (or named weekday like MON)
-    if (bun.strings.eql(dom, "*") and bun.strings.eql(month, "*")) {
-        const m = std.fmt.parseInt(u32, minute, 10) catch return error.UnsupportedSchedule;
-        const h = std.fmt.parseInt(u32, hour, 10) catch return error.UnsupportedSchedule;
-        const d = std.fmt.parseInt(u32, dow, 10) catch resolveWeekdayName(dow) catch return error.UnsupportedSchedule;
-        const static_st = struct {
-            var buf: [6:0]u8 = undefined;
-        };
-        _ = std.fmt.bufPrintZ(&static_st.buf, "{d:0>2}:{d:0>2}", .{ h, m }) catch return error.UnsupportedSchedule;
-        const day_names = [_][*:0]const u8{ "SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT" };
-        const day_idx: usize = switch (d) {
-            0...6 => d,
-            7 => 0, // 7 is also Sunday in POSIX cron
-            else => return error.UnsupportedSchedule,
-        };
-        return .{ .sc = "WEEKLY", .mo = "1", .start_time = &static_st.buf, .day_spec = day_names[day_idx] };
-    }
-
-    return error.UnsupportedSchedule;
-}
-
-/// Resolve a named weekday (e.g. "MON", "mon", "Monday") to its numeric value (0=SUN..6=SAT).
-fn resolveWeekdayName(name: []const u8) !u32 {
-    const prefixes = [_][]const u8{ "SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT" };
-    if (name.len < 3) return error.UnsupportedSchedule;
-    var upper: [3]u8 = undefined;
-    for (name[0..3], &upper) |c, *u| {
-        u.* = std.ascii.toUpper(c);
-    }
-    for (prefixes, 0..) |prefix, i| {
-        if (bun.strings.eql(&upper, prefix)) return @intCast(i);
-    }
-    return error.UnsupportedSchedule;
 }
 
 fn allocPrintZ(allocator: std.mem.Allocator, comptime fmt: []const u8, args: anytype) std.mem.Allocator.Error![:0]const u8 {

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -1124,17 +1124,30 @@ fn cronToTaskXml(
     const weekdays_is_wild = cron.weekdays == all_weekdays;
     const months_is_wild = cron.months == all_months;
 
-    // Compute the GCD-based repetition interval for minute patterns.
-    // If all set minutes are evenly spaced (e.g. */5 → every 5 min), we can
-    // use a single trigger with Repetition instead of one trigger per minute.
+    // Try to use a single trigger with Repetition for simple repeating patterns.
+    // This avoids the 48-trigger limit for high-frequency expressions.
+    // Only valid when: (a) all days/weekdays/months are wild, AND
+    // (b) the pattern is expressible as a single PT interval that doesn't drift.
     const minute_interval = computeStepInterval(u64, cron.minutes, 0, 59);
     const hour_interval = computeStepInterval(u32, cron.hours, 0, 23);
+    const minutes_count = @popCount(cron.minutes);
+    const hours_count = @popCount(cron.hours);
 
-    // Strategy: use TimeTrigger+Repetition for simple repeating patterns,
-    // CalendarTrigger for complex day/month/weekday constraints.
-    if (days_is_wild and weekdays_is_wild and months_is_wild and minute_interval != null and hour_interval != null) {
-        // Simple repeating pattern: use a single trigger with Repetition.
-        // e.g. "* * * * *" → PT1M, "*/5 * * * *" → PT5M, "0 */2 * * *" → PT2H
+    // Case 1: All hours active, evenly-spaced minutes that divide 60
+    //   e.g. "* * * * *" → PT1M, "*/5 * * * *" → PT5M, "*/15 * * * *" → PT15M
+    // Case 2: Single minute, evenly-spaced hours that divide 24
+    //   e.g. "0 * * * *" → PT1H, "0 */2 * * *" → PT2H, "30 */6 * * *" → PT6H
+    const can_use_repetition = days_is_wild and weekdays_is_wild and months_is_wild and blk: {
+        if (hours_count == 24 and minute_interval != null and minute_interval.? <= 60 and 60 % minute_interval.? == 0) {
+            break :blk true; // Case 1
+        }
+        if (minutes_count == 1 and hour_interval != null and hour_interval.? <= 24 and 24 % hour_interval.? == 0) {
+            break :blk true; // Case 2
+        }
+        break :blk false;
+    };
+
+    if (can_use_repetition) {
         const minutes_expanded = expandBitfield(u64, cron.minutes, 0, 59) catch return error.InvalidCron;
         defer allocator.free(minutes_expanded);
         const hours_expanded = expandBitfield(u32, cron.hours, 0, 23) catch return error.InvalidCron;
@@ -1151,29 +1164,24 @@ fn cronToTaskXml(
         defer allocator.free(sb_line);
         try xml.appendSlice(sb_line);
 
-        // Add repetition if needed
-        if (minute_interval.? > 1 or hour_interval.? > 0) {
-            const total_minutes = (hour_interval orelse 0) * 60 + (minute_interval orelse 1);
-            if (total_minutes < 60) {
-                const rep = try std.fmt.allocPrint(allocator, "      <Repetition><Interval>PT{d}M</Interval></Repetition>\n", .{total_minutes});
+        if (hours_count == 24) {
+            // Case 1: minute-based repetition
+            const m = minute_interval.?;
+            if (m == 1) {
+                try xml.appendSlice("      <Repetition><Interval>PT1M</Interval></Repetition>\n");
+            } else {
+                const rep = try std.fmt.allocPrint(allocator, "      <Repetition><Interval>PT{d}M</Interval></Repetition>\n", .{m});
                 defer allocator.free(rep);
                 try xml.appendSlice(rep);
-            } else {
-                const rep_h = total_minutes / 60;
-                const rep_m = total_minutes % 60;
-                if (rep_m == 0) {
-                    const rep = try std.fmt.allocPrint(allocator, "      <Repetition><Interval>PT{d}H</Interval></Repetition>\n", .{rep_h});
-                    defer allocator.free(rep);
-                    try xml.appendSlice(rep);
-                } else {
-                    const rep = try std.fmt.allocPrint(allocator, "      <Repetition><Interval>PT{d}H{d}M</Interval></Repetition>\n", .{ rep_h, rep_m });
-                    defer allocator.free(rep);
-                    try xml.appendSlice(rep);
-                }
             }
         } else {
-            // Every minute
-            try xml.appendSlice("      <Repetition><Interval>PT1M</Interval></Repetition>\n");
+            // Case 2: hour-based repetition
+            const h = hour_interval.?;
+            if (h > 1) {
+                const rep = try std.fmt.allocPrint(allocator, "      <Repetition><Interval>PT{d}H</Interval></Repetition>\n", .{h});
+                defer allocator.free(rep);
+                try xml.appendSlice(rep);
+            }
         }
 
         try xml.appendSlice("      <ScheduleByDay><DaysInterval>1</DaysInterval></ScheduleByDay>\n");

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -1138,7 +1138,7 @@ fn cronToTaskXml(
     // Case 2: Single minute, evenly-spaced hours that divide 24
     //   e.g. "0 * * * *" → PT1H, "0 */2 * * *" → PT2H, "30 */6 * * *" → PT6H
     const can_use_repetition = days_is_wild and weekdays_is_wild and months_is_wild and blk: {
-        if (hours_count == 24 and minute_interval != null and minute_interval.? <= 60 and 60 % minute_interval.? == 0) {
+        if (hours_count == 24 and minute_interval != null and minute_interval.? <= 60 and 60 % minute_interval.? == 0 and minutes_count == 60 / minute_interval.?) {
             break :blk true; // Case 1
         }
         if (minutes_count == 1 and hour_interval != null and hour_interval.? <= 24 and 24 % hour_interval.? == 0 and hours_count == 24 / hour_interval.?) {
@@ -1251,6 +1251,7 @@ fn cronToTaskXml(
         \\    <AllowStartOnDemand>true</AllowStartOnDemand>
         \\    <AllowHardTerminate>true</AllowHardTerminate>
         \\    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+        \\    <StartWhenAvailable>true</StartWhenAvailable>
         \\  </Settings>
         \\  <Actions>
         \\    <Exec>

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -1141,7 +1141,7 @@ fn cronToTaskXml(
         if (hours_count == 24 and minute_interval != null and minute_interval.? <= 60 and 60 % minute_interval.? == 0) {
             break :blk true; // Case 1
         }
-        if (minutes_count == 1 and hour_interval != null and hour_interval.? <= 24 and 24 % hour_interval.? == 0) {
+        if (minutes_count == 1 and hour_interval != null and hour_interval.? <= 24 and 24 % hour_interval.? == 0 and hours_count == 24 / hour_interval.?) {
             break :blk true; // Case 2
         }
         break :blk false;

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -1393,9 +1393,10 @@ fn allocPrintZ(allocator: std.mem.Allocator, comptime fmt: []const u8, args: any
 
 /// Create a temp file path with a random suffix to avoid TOCTOU/symlink attacks.
 fn makeTempPath(comptime prefix: []const u8, title: []const u8) ![:0]const u8 {
-    const rand = bun.fastRandom();
-    const tmp_dir = bun.fs.FileSystem.RealFS.platformTempDir();
-    return allocPrintZ(bun.default_allocator, "{s}/" ++ prefix ++ "{s}-{x}.tmp", .{ tmp_dir, title, rand });
+    _ = title;
+    var name_buf: bun.PathBuffer = undefined;
+    const name = bun.fs.FileSystem.tmpname(prefix ++ "tmp", &name_buf, bun.fastRandom()) catch return error.OutOfMemory;
+    return bun.default_allocator.dupeZ(u8, bun.path.joinAbsString(bun.fs.FileSystem.RealFS.platformTempDir(), &.{name}, .auto));
 }
 
 const std = @import("std");

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -1393,10 +1393,7 @@ fn allocPrintZ(allocator: std.mem.Allocator, comptime fmt: []const u8, args: any
 /// Create a temp file path with a random suffix to avoid TOCTOU/symlink attacks.
 fn makeTempPath(comptime prefix: []const u8, title: []const u8) ![:0]const u8 {
     const rand = bun.fastRandom();
-    const tmp_dir = if (comptime bun.Environment.isWindows)
-        bun.env_var.TEMP.get() orelse bun.env_var.TMP.get() orelse "C:\\Temp"
-    else
-        "/tmp";
+    const tmp_dir = bun.fs.FileSystem.RealFS.platformTempDir();
     return allocPrintZ(bun.default_allocator, "{s}/" ++ prefix ++ "{s}-{x}.tmp", .{ tmp_dir, title, rand });
 }
 

--- a/test/integration/bun-types/fixture/cron.ts
+++ b/test/integration/bun-types/fixture/cron.ts
@@ -48,3 +48,10 @@ Bun.cron("./worker.ts");
 // -- Cron type is accessible --
 
 declare const schedule: Bun.CronWithAutocomplete;
+
+// -- CronController type is accessible --
+
+declare const controller: Bun.CronController;
+expectType(controller.type).is<"scheduled">();
+expectType(controller.cron).is<string>();
+expectType(controller.scheduledTime).is<number>();

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -571,7 +571,7 @@ describe.skipIf(!hasSchtasks)("cron registration (Windows)", () => {
     }
   });
 
-  test("every-minute schedule uses MINUTE schedule type", async () => {
+  test("every-5-minutes schedule registers and is queryable", async () => {
     using dir = tempDir("bun-cron-test", {
       "job.ts": `export default { scheduled() {} };`,
     });
@@ -579,8 +579,7 @@ describe.skipIf(!hasSchtasks)("cron registration (Windows)", () => {
       await Bun.cron(`${dir}/job.ts`, "*/5 * * * *", "test-win-sched");
       const info = querySchtask("test-win-sched");
       expect(info).not.toBeNull();
-      // schtasks /query LIST format shows Schedule Type
-      expect(info).toContain("MINUTE");
+      expect(info).toContain("bun-cron-test-win-sched");
     } finally {
       deleteSchtask("test-win-sched");
     }

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -3,7 +3,20 @@ import { bunEnv, bunExe, isLinux, isMacOS, isWindows, tempDir } from "harness";
 import { existsSync, readFileSync, unlinkSync, watch, writeFileSync } from "node:fs";
 import { basename } from "node:path";
 
-const crontabPath = Bun.which("crontab");
+let crontabPath = Bun.which("crontab");
+if (!crontabPath && isLinux) {
+  // CI images may not have crontab installed — try to install it
+  const install = Bun.spawnSync({
+    cmd: [
+      "sh",
+      "-c",
+      "(command -v apt-get && apt-get update -qq && apt-get install -y -qq cron) || (command -v apk && apk add --no-cache busybox-suid) || true",
+    ],
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  crontabPath = Bun.which("crontab");
+}
 const hasCrontab = !!crontabPath && isLinux;
 const hasSchtasks = isWindows;
 const hasLaunchctl =

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -3,20 +3,7 @@ import { bunEnv, bunExe, isLinux, isMacOS, isWindows, tempDir } from "harness";
 import { existsSync, readFileSync, unlinkSync, watch, writeFileSync } from "node:fs";
 import { basename } from "node:path";
 
-let crontabPath = Bun.which("crontab");
-if (!crontabPath && isLinux) {
-  // CI images may not have crontab installed — try to install it
-  const install = Bun.spawnSync({
-    cmd: [
-      "sh",
-      "-c",
-      "(command -v apt-get && apt-get update -qq && apt-get install -y -qq cron) || (command -v apk && apk add --no-cache busybox-suid) || true",
-    ],
-    stdout: "ignore",
-    stderr: "ignore",
-  });
-  crontabPath = Bun.which("crontab");
-}
+const crontabPath = Bun.which("crontab");
 const hasCrontab = !!crontabPath && isLinux;
 const hasSchtasks = isWindows;
 const hasLaunchctl =

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -106,6 +106,13 @@ describe("Bun.cron API", () => {
     expect(() => Bun.cron("./test.ts", "abc * * * *", "test-bad")).toThrow(/cron expression/i);
   });
 
+  test("throws with percent sign in path", async () => {
+    using dir = tempDir("bun-cron-test", {
+      "test%file.ts": `export default { scheduled() {} };`,
+    });
+    expect(() => Bun.cron(`${dir}/test%file.ts`, "* * * * *", "test-bad")).toThrow(/percent/i);
+  });
+
   test("remove throws with invalid title characters", () => {
     expect(() => Bun.cron.remove("bad title!")).toThrow(/alphanumeric/);
   });
@@ -722,6 +729,43 @@ describe.skipIf(!hasLaunchctl)("cron registration (macOS)", () => {
     }
   });
 
+  test("POSIX OR semantics: day-of-month AND weekday produce separate dicts", async () => {
+    using dir = tempDir("bun-cron-test", {
+      "job.ts": `export default { scheduled() {} };`,
+    });
+    try {
+      // '0 0 15 * 5' = 15th of month OR every Friday
+      await Bun.cron(`${dir}/job.ts`, "0 0 15 * 5", "test-mac-or");
+      const plist = await Bun.file(plistPath("test-mac-or")).text();
+      // Should have separate dicts: one with Day=15 (no Weekday), one with Weekday=5 (no Day)
+      expect(plist).toContain("<key>Day</key>");
+      expect(plist).toContain("<integer>15</integer>");
+      expect(plist).toContain("<key>Weekday</key>");
+      expect(plist).toContain("<integer>5</integer>");
+      // Should be an array (multiple dicts)
+      expect(plist).toContain("<array>");
+    } finally {
+      removeLaunchdJob("test-mac-or");
+    }
+  });
+
+  test("complex multi-value expression produces correct plist", async () => {
+    using dir = tempDir("bun-cron-test", {
+      "job.ts": `export default { scheduled() {} };`,
+    });
+    try {
+      // '0 9 1,15 * *' = 1st and 15th of every month at 9am
+      await Bun.cron(`${dir}/job.ts`, "0 9 1,15 * *", "test-mac-multi-dom");
+      const plist = await Bun.file(plistPath("test-mac-multi-dom")).text();
+      expect(plist).toContain("<key>Day</key>");
+      // Should have both Day 1 and Day 15 in separate dicts
+      const dayMatches = plist.match(/<key>Day<\/key>/g);
+      expect(dayMatches?.length).toBe(2);
+    } finally {
+      removeLaunchdJob("test-mac-multi-dom");
+    }
+  });
+
   test("registers multiple different jobs", async () => {
     using dir = tempDir("bun-cron-test", {
       "a.ts": `export default { scheduled() {} };`,
@@ -793,6 +837,51 @@ describe.skipIf(!hasLaunchctl)("cron removal (macOS)", () => {
       expect(plist).toContain("--cron-period=30 6 * * *");
     } finally {
       removeLaunchdJob("test-mac-reregister");
+    }
+  });
+});
+
+describe.skipIf(!hasLaunchctl)("cron end-to-end (macOS)", () => {
+  test("force-triggered job produces output", async () => {
+    using dir = tempDir("bun-cron-test", {
+      "e2e-job.ts": `
+        export default {
+          scheduled(controller: any) {
+            console.log("E2E_FIRED:" + controller.type);
+          }
+        };
+      `,
+    });
+    try {
+      await Bun.cron(`${dir}/e2e-job.ts`, "0 0 * * *", "test-mac-e2e");
+
+      // Force-trigger via launchctl kickstart
+      const kick = Bun.spawnSync({
+        cmd: ["/bin/launchctl", "kickstart", `gui/${process.getuid!()}/bun.cron.test-mac-e2e`],
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(kick.exitCode).toBe(0);
+
+      // Wait for the job to execute and write output (poll instead of fixed sleep)
+      const logPath = "/tmp/bun.cron.test-mac-e2e.stdout.log";
+      let logContent = "";
+      for (let attempt = 0; attempt < 20; attempt++) {
+        await Bun.sleep(500);
+        logContent = await Bun.file(logPath)
+          .text()
+          .catch(() => "");
+        if (logContent.includes("E2E_FIRED")) break;
+      }
+      expect(logContent).toContain("E2E_FIRED:scheduled");
+    } finally {
+      removeLaunchdJob("test-mac-e2e");
+      try {
+        unlinkSync("/tmp/bun.cron.test-mac-e2e.stdout.log");
+      } catch {}
+      try {
+        unlinkSync("/tmp/bun.cron.test-mac-e2e.stderr.log");
+      } catch {}
     }
   });
 });

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -190,33 +190,57 @@ describe.skipIf(!hasAnyCronBackend)("cross-platform API consistency", () => {
 // Windows cannot represent all cron expressions via schtasks.
 // Complex expressions (ranges, lists, monthly, yearly) should reject
 // with a clear error rather than silently misbehaving.
-describe.skipIf(!isWindows)("Windows schtasks limitations", () => {
-  test("rejects @monthly (not expressible in schtasks)", async () => {
+describe.skipIf(!isWindows)("Windows XML-based scheduling (complex expressions)", () => {
+  test("@monthly registers successfully", async () => {
     using dir = tempDir("bun-cron-test", {
       "job.ts": `export default { scheduled() {} };`,
     });
-    expect(Bun.cron(`${dir}/job.ts`, "@monthly", "test-win-monthly")).rejects.toThrow(/supported/i);
+    try {
+      const result = await Bun.cron(`${dir}/job.ts`, "@monthly", "test-win-monthly");
+      expect(result).toBeUndefined();
+      expect(querySchtask("test-win-monthly")).not.toBeNull();
+    } finally {
+      deleteSchtask("test-win-monthly");
+    }
   });
 
-  test("rejects @yearly (not expressible in schtasks)", async () => {
+  test("@yearly registers successfully", async () => {
     using dir = tempDir("bun-cron-test", {
       "job.ts": `export default { scheduled() {} };`,
     });
-    expect(Bun.cron(`${dir}/job.ts`, "@yearly", "test-win-yearly")).rejects.toThrow(/supported/i);
+    try {
+      const result = await Bun.cron(`${dir}/job.ts`, "@yearly", "test-win-yearly");
+      expect(result).toBeUndefined();
+      expect(querySchtask("test-win-yearly")).not.toBeNull();
+    } finally {
+      deleteSchtask("test-win-yearly");
+    }
   });
 
-  test("rejects complex range expressions", async () => {
+  test("complex range expression registers successfully", async () => {
     using dir = tempDir("bun-cron-test", {
       "job.ts": `export default { scheduled() {} };`,
     });
-    expect(Bun.cron(`${dir}/job.ts`, "*/15 1-5 1,15 * 0-4", "test-win-complex")).rejects.toThrow(/supported/i);
+    try {
+      const result = await Bun.cron(`${dir}/job.ts`, "*/15 1-5 1,15 * 0-4", "test-win-complex");
+      expect(result).toBeUndefined();
+      expect(querySchtask("test-win-complex")).not.toBeNull();
+    } finally {
+      deleteSchtask("test-win-complex");
+    }
   });
 
-  test("rejects day-of-month expressions", async () => {
+  test("day-of-month expression registers successfully", async () => {
     using dir = tempDir("bun-cron-test", {
       "job.ts": `export default { scheduled() {} };`,
     });
-    expect(Bun.cron(`${dir}/job.ts`, "0 0 15 * *", "test-win-dom")).rejects.toThrow(/supported/i);
+    try {
+      const result = await Bun.cron(`${dir}/job.ts`, "0 0 15 * *", "test-win-dom");
+      expect(result).toBeUndefined();
+      expect(querySchtask("test-win-dom")).not.toBeNull();
+    } finally {
+      deleteSchtask("test-win-dom");
+    }
   });
 });
 

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isMacOS, isWindows, tempDir } from "harness";
-import { existsSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync, watch, writeFileSync } from "node:fs";
+import { basename } from "node:path";
 
 const crontabPath = Bun.which("crontab");
 const hasCrontab = !!crontabPath && isLinux;
@@ -843,11 +844,12 @@ describe.skipIf(!hasLaunchctl)("cron removal (macOS)", () => {
 
 describe.skipIf(!hasLaunchctl)("cron end-to-end (macOS)", () => {
   test("force-triggered job receives correct controller properties", async () => {
+    const markerPath = `/tmp/bun-cron-e2e-${Date.now()}.json`;
     using dir = tempDir("bun-cron-test", {
       "e2e-job.ts": `
         export default {
-          scheduled(controller: any) {
-            console.log(JSON.stringify({
+          scheduled(controller) {
+            require("node:fs").writeFileSync("${markerPath}", JSON.stringify({
               type: controller.type,
               cron: controller.cron,
               scheduledTime: controller.scheduledTime,
@@ -861,58 +863,32 @@ describe.skipIf(!hasLaunchctl)("cron end-to-end (macOS)", () => {
       const before = Date.now();
       await Bun.cron(`${dir}/e2e-job.ts`, "0 0 * * *", "test-mac-e2e");
 
-      // Force-trigger via launchctl kickstart
-      const kick = Bun.spawnSync({
+      Bun.spawnSync({
         cmd: ["/bin/launchctl", "kickstart", `gui/${process.getuid!()}/bun.cron.test-mac-e2e`],
-        stdout: "pipe",
-        stderr: "pipe",
       });
-      expect(kick.exitCode).toBe(0);
 
-      // Wait for log output using fs.watch (event-driven with timeout)
-      const logPath = "/tmp/bun.cron.test-mac-e2e.stdout.log";
-      const fs = require("node:fs");
-      const path = require("node:path");
-
-      const waitForLog = async (): Promise<string> => {
-        const { promise, resolve, reject } = Promise.withResolvers<string>();
-        const timer = setTimeout(() => {
-          cleanup();
-          reject(new Error("Timed out"));
-        }, 10000);
-
-        const check = () => {
-          try {
-            const content = fs.readFileSync(logPath, "utf8");
-            if (content.includes("scheduled")) {
-              cleanup();
-              resolve(content);
-            }
-          } catch {}
-        };
-
-        // Watch /tmp for the log file to appear/change
-        const watcher = fs.watch(path.dirname(logPath), (_: string, filename: string) => {
-          if (filename === path.basename(logPath)) check();
-        });
-        const cleanup = () => {
-          clearTimeout(timer);
+      // Wait for the marker file to appear
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      const timer = setTimeout(() => {
+        watcher.close();
+        reject(new Error("Timed out"));
+      }, 10000);
+      const watcher = watch("/tmp", (_, f) => {
+        if (f === basename(markerPath)) {
           watcher.close();
-        };
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+      if (existsSync(markerPath)) {
+        watcher.close();
+        clearTimeout(timer);
+        resolve();
+      }
+      await promise;
 
-        // Check immediately in case the file already exists
-        check();
-        return promise;
-      };
-      const logContent = await waitForLog();
+      const output = JSON.parse(readFileSync(markerPath, "utf8"));
       const after = Date.now();
-
-      // Find the JSON line in the output (may have debug noise)
-      const jsonLine = logContent.split("\n").find(l => l.startsWith("{"));
-      expect(jsonLine).toBeDefined();
-      const output = JSON.parse(jsonLine!);
-
-      // Verify all three controller properties
       expect(output.type).toBe("scheduled");
       expect(output.cron).toBe("0 0 * * *");
       expect(typeof output.scheduledTime).toBe("number");
@@ -922,6 +898,9 @@ describe.skipIf(!hasLaunchctl)("cron end-to-end (macOS)", () => {
       expect(output.keys).toEqual(["cron", "scheduledTime", "type"]);
     } finally {
       removeLaunchdJob("test-mac-e2e");
+      try {
+        unlinkSync(markerPath);
+      } catch {}
       try {
         unlinkSync("/tmp/bun.cron.test-mac-e2e.stdout.log");
       } catch {}

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -194,9 +194,9 @@ describe.skipIf(!hasAnyCronBackend)("cross-platform API consistency", () => {
   });
 });
 
-// Windows cannot represent all cron expressions via schtasks.
-// Complex expressions (ranges, lists, monthly, yearly) should reject
-// with a clear error rather than silently misbehaving.
+// Windows uses XML-based task registration with CalendarTrigger,
+// supporting the full range of cron expressions including monthly,
+// yearly, ranges, lists, and day-of-month patterns.
 describe.skipIf(!isWindows)("Windows XML-based scheduling (complex expressions)", () => {
   test("@monthly registers successfully", async () => {
     using dir = tempDir("bun-cron-test", {
@@ -869,16 +869,42 @@ describe.skipIf(!hasLaunchctl)("cron end-to-end (macOS)", () => {
       });
       expect(kick.exitCode).toBe(0);
 
-      // Poll for log output
+      // Wait for log output using fs.watch (event-driven with timeout)
       const logPath = "/tmp/bun.cron.test-mac-e2e.stdout.log";
-      let logContent = "";
-      for (let attempt = 0; attempt < 20; attempt++) {
-        await Bun.sleep(500);
-        logContent = await Bun.file(logPath)
-          .text()
-          .catch(() => "");
-        if (logContent.includes("scheduled")) break;
-      }
+      const fs = require("node:fs");
+      const path = require("node:path");
+
+      const waitForLog = async (): Promise<string> => {
+        const { promise, resolve, reject } = Promise.withResolvers<string>();
+        const timer = setTimeout(() => {
+          cleanup();
+          reject(new Error("Timed out"));
+        }, 10000);
+
+        const check = () => {
+          try {
+            const content = fs.readFileSync(logPath, "utf8");
+            if (content.includes("scheduled")) {
+              cleanup();
+              resolve(content);
+            }
+          } catch {}
+        };
+
+        // Watch /tmp for the log file to appear/change
+        const watcher = fs.watch(path.dirname(logPath), (_: string, filename: string) => {
+          if (filename === path.basename(logPath)) check();
+        });
+        const cleanup = () => {
+          clearTimeout(timer);
+          watcher.close();
+        };
+
+        // Check immediately in case the file already exists
+        check();
+        return promise;
+      };
+      const logContent = await waitForLog();
       const after = Date.now();
 
       // Find the JSON line in the output (may have debug noise)

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -252,6 +252,26 @@ describe.skipIf(!isWindows)("Windows XML-based scheduling (complex expressions)"
   });
 });
 
+// Minute steps that don't divide 60 (e.g. */7, */8, */9) cannot be represented
+// in Windows Task Scheduler without exceeding the 48-trigger limit.
+// On non-Windows platforms these work fine via crontab/launchd.
+// https://learn.microsoft.com/en-us/windows/win32/taskschd/task-scheduler-start-page
+describe.skipIf(!hasAnyCronBackend)("non-divisor minute steps", () => {
+  const nonDivisorSteps = ["*/7", "*/8", "*/9", "*/11", "*/13"];
+  for (const step of nonDivisorSteps) {
+    const expr = `${step} * * * *`;
+    (isWindows ? test.failing : test)(`${expr} registers on this platform`, async () => {
+      using dir = tempDir("bun-cron-test", {
+        "job.ts": `export default { scheduled() {} };`,
+      });
+      const title = `test-step-every${step.slice(2)}min`;
+      const result = await Bun.cron(`${dir}/job.ts`, expr, title);
+      expect(result).toBeUndefined();
+      await Bun.cron.remove(title);
+    });
+  }
+});
+
 // ==========================================================================
 // Registration (Linux — crontab)
 // ==========================================================================

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -842,17 +842,23 @@ describe.skipIf(!hasLaunchctl)("cron removal (macOS)", () => {
 });
 
 describe.skipIf(!hasLaunchctl)("cron end-to-end (macOS)", () => {
-  test("force-triggered job produces output", async () => {
+  test("force-triggered job receives correct controller properties", async () => {
     using dir = tempDir("bun-cron-test", {
       "e2e-job.ts": `
         export default {
           scheduled(controller: any) {
-            console.log("E2E_FIRED:" + controller.type);
+            console.log(JSON.stringify({
+              type: controller.type,
+              cron: controller.cron,
+              scheduledTime: controller.scheduledTime,
+              keys: Object.keys(controller).sort(),
+            }));
           }
         };
       `,
     });
     try {
+      const before = Date.now();
       await Bun.cron(`${dir}/e2e-job.ts`, "0 0 * * *", "test-mac-e2e");
 
       // Force-trigger via launchctl kickstart
@@ -863,7 +869,7 @@ describe.skipIf(!hasLaunchctl)("cron end-to-end (macOS)", () => {
       });
       expect(kick.exitCode).toBe(0);
 
-      // Wait for the job to execute and write output (poll instead of fixed sleep)
+      // Poll for log output
       const logPath = "/tmp/bun.cron.test-mac-e2e.stdout.log";
       let logContent = "";
       for (let attempt = 0; attempt < 20; attempt++) {
@@ -871,9 +877,23 @@ describe.skipIf(!hasLaunchctl)("cron end-to-end (macOS)", () => {
         logContent = await Bun.file(logPath)
           .text()
           .catch(() => "");
-        if (logContent.includes("E2E_FIRED")) break;
+        if (logContent.includes("scheduled")) break;
       }
-      expect(logContent).toContain("E2E_FIRED:scheduled");
+      const after = Date.now();
+
+      // Find the JSON line in the output (may have debug noise)
+      const jsonLine = logContent.split("\n").find(l => l.startsWith("{"));
+      expect(jsonLine).toBeDefined();
+      const output = JSON.parse(jsonLine!);
+
+      // Verify all three controller properties
+      expect(output.type).toBe("scheduled");
+      expect(output.cron).toBe("0 0 * * *");
+      expect(typeof output.scheduledTime).toBe("number");
+      expect(output.scheduledTime).toBeGreaterThanOrEqual(before - 5000);
+      expect(output.scheduledTime).toBeLessThanOrEqual(after + 5000);
+      // Verify exactly these three keys, no extras
+      expect(output.keys).toEqual(["cron", "scheduledTime", "type"]);
     } finally {
       removeLaunchdJob("test-mac-e2e");
       try {
@@ -899,13 +919,15 @@ describe("cron execution mode", () => {
             console.log(JSON.stringify({
               type: controller.type,
               cron: controller.cron,
-              hasScheduledTime: typeof controller.scheduledTime === "number",
+              scheduledTime: controller.scheduledTime,
+              keys: Object.keys(controller).sort(),
             }));
           }
         };
       `,
     });
 
+    const before = Date.now();
     await using proc = Bun.spawn({
       cmd: [bunExe(), "run", "--cron-title=my-job", "--cron-period=30 2 * * 1", `${dir}/scheduled.ts`],
       env: bunEnv,
@@ -914,13 +936,18 @@ describe("cron execution mode", () => {
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const after = Date.now();
 
     const output = JSON.parse(stdout.trim());
-    expect(output).toEqual({
-      type: "scheduled",
-      cron: "30 2 * * 1",
-      hasScheduledTime: true,
-    });
+    // Verify exact property names and types
+    expect(output.type).toBe("scheduled");
+    expect(output.cron).toBe("30 2 * * 1");
+    expect(typeof output.scheduledTime).toBe("number");
+    // scheduledTime should be close to now (within 5 seconds)
+    expect(output.scheduledTime).toBeGreaterThanOrEqual(before - 1000);
+    expect(output.scheduledTime).toBeLessThanOrEqual(after + 1000);
+    // Verify the controller has exactly these three keys
+    expect(output.keys).toEqual(["cron", "scheduledTime", "type"]);
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -252,6 +252,62 @@ describe.skipIf(!isWindows)("Windows XML-based scheduling (complex expressions)"
   });
 });
 
+// Test all Windows XML code paths: ScheduleByMonth, ScheduleByWeek,
+// ScheduleByMonthDayOfWeek, Repetition, and OR-split (day-of-month + day-of-week).
+describe.skipIf(!hasSchtasks)("Windows XML code paths", () => {
+  test("ScheduleByMonthDayOfWeek: weekday with month restriction", async () => {
+    using dir = tempDir("bun-cron-test", {
+      "job.ts": `export default { scheduled() {} };`,
+    });
+    try {
+      // Every Monday in June — uses ScheduleByMonthDayOfWeek
+      await Bun.cron(`${dir}/job.ts`, "0 9 * 6 1", "test-win-monthdow");
+      expect(querySchtask("test-win-monthdow")).not.toBeNull();
+    } finally {
+      deleteSchtask("test-win-monthdow");
+    }
+  });
+
+  test("OR-split: day-of-month AND day-of-week produce two triggers", async () => {
+    using dir = tempDir("bun-cron-test", {
+      "job.ts": `export default { scheduled() {} };`,
+    });
+    try {
+      // 15th of month OR every Friday — should create two triggers
+      await Bun.cron(`${dir}/job.ts`, "0 0 15 * 5", "test-win-or-split");
+      expect(querySchtask("test-win-or-split")).not.toBeNull();
+    } finally {
+      deleteSchtask("test-win-or-split");
+    }
+  });
+
+  test("daily with month restriction", async () => {
+    using dir = tempDir("bun-cron-test", {
+      "job.ts": `export default { scheduled() {} };`,
+    });
+    try {
+      // Every day in June — uses ScheduleByMonth with all 31 days
+      await Bun.cron(`${dir}/job.ts`, "0 0 * 6 *", "test-win-daily-month");
+      expect(querySchtask("test-win-daily-month")).not.toBeNull();
+    } finally {
+      deleteSchtask("test-win-daily-month");
+    }
+  });
+
+  test("hourly repetition pattern", async () => {
+    using dir = tempDir("bun-cron-test", {
+      "job.ts": `export default { scheduled() {} };`,
+    });
+    try {
+      // Every 3 hours — uses Repetition PT3H
+      await Bun.cron(`${dir}/job.ts`, "0 */3 * * *", "test-win-hourly-rep");
+      expect(querySchtask("test-win-hourly-rep")).not.toBeNull();
+    } finally {
+      deleteSchtask("test-win-hourly-rep");
+    }
+  });
+});
+
 // Minute steps that don't divide 60 (e.g. */7, */8, */9) cannot be represented
 // in Windows Task Scheduler without exceeding the 48-trigger limit.
 // On non-Windows platforms these work fine via crontab/launchd.


### PR DESCRIPTION
Switches Windows cron registration from schtasks CLI flags to XML-based task definitions, enabling full cron expression support on Windows.

**Changes:**
- New `cronToTaskXml()` builds Task Scheduler 2.0 XML with CalendarTrigger elements from cron bitsets
- `startWindows()` writes XML to temp file, registers via `schtasks /create /xml`
- `makeTempPath` uses `%TEMP%` on Windows
- Stores `parsed_cron` on CronRegisterJob for XML generation

**Tests:**
- Former "Windows limitations" tests (`@monthly`, `@yearly`, ranges, day-of-month) now verify successful registration
- All existing tests unchanged