### PR TITLE
Fix dgram UDP socket creation bugs on macOS

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -901,8 +901,7 @@ static int bsd_set_reuseaddr(LIBUS_SOCKET_DESCRIPTOR listenFd) {
 }
 
 static int bsd_set_reuseport(LIBUS_SOCKET_DESCRIPTOR listenFd) {
-#if defined(__linux__)
-    // Among Bun's supported platforms, only Linux does load balancing with SO_REUSEPORT.
+#if defined(SO_REUSEPORT) && !defined(_WIN32)
     const int one = 1;
     return setsockopt(listenFd, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one));
 #else
@@ -1232,6 +1231,14 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
     }
 
     if (bsd_set_reuse(listenFd, options) != 0) {
+        if (err != NULL) {
+#ifdef _WIN32
+            *err = WSAGetLastError();
+#else
+            *err = errno;
+#endif
+        }
+        bsd_close_socket(listenFd);
         freeaddrinfo(result);
         return LIBUS_SOCKET_ERROR;
     }
@@ -1254,23 +1261,15 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
 
     int enabled = 1;
     if (setsockopt(listenFd, IPPROTO_IPV6, IPV6_RECVPKTINFO, &enabled, sizeof(enabled)) == -1) {
-        if (errno == 92) {
-            if (setsockopt(listenFd, IPPROTO_IP, IP_PKTINFO, &enabled, sizeof(enabled)) != 0) {
-                //printf("Error setting IPv4 pktinfo!\n");
-            }
-        } else {
-            //printf("Error setting IPv6 pktinfo!\n");
+        if (errno == ENOPROTOOPT || errno == EINVAL) {
+            setsockopt(listenFd, IPPROTO_IP, IP_PKTINFO, &enabled, sizeof(enabled));
         }
     }
 
     /* These are used for getting the ECN */
     if (setsockopt(listenFd, IPPROTO_IPV6, IPV6_RECVTCLASS, &enabled, sizeof(enabled)) == -1) {
-        if (errno == 92) {
-            if (setsockopt(listenFd, IPPROTO_IP, IP_RECVTOS, &enabled, sizeof(enabled)) != 0) {
-                //printf("Error setting IPv4 ECN!\n");
-            }
-        } else {
-            //printf("Error setting IPv6 ECN!\n");
+        if (errno == ENOPROTOOPT || errno == EINVAL) {
+            setsockopt(listenFd, IPPROTO_IP, IP_RECVTOS, &enabled, sizeof(enabled));
         }
     }
 

--- a/src/errno/windows_errno.zig
+++ b/src/errno/windows_errno.zig
@@ -1073,6 +1073,7 @@ pub const SystemErrno = enum(u16) {
                 Win32Error.DIR_NOT_EMPTY => SystemErrno.ENOTEMPTY,
                 Win32Error.WSAENOTSOCK => SystemErrno.ENOTSOCK,
                 Win32Error.NOT_SUPPORTED => SystemErrno.ENOTSUP,
+                Win32Error.WSAEOPNOTSUPP => SystemErrno.ENOTSUP,
                 Win32Error.BROKEN_PIPE => SystemErrno.EPIPE,
                 Win32Error.ACCESS_DENIED => SystemErrno.EPERM,
                 Win32Error.PRIVILEGE_NOT_HELD => SystemErrno.EPERM,

--- a/test/regression/issue/28083.test.ts
+++ b/test/regression/issue/28083.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 describe("dgram implicit bind on send", () => {

--- a/test/regression/issue/28083.test.ts
+++ b/test/regression/issue/28083.test.ts
@@ -53,16 +53,21 @@ describe("dgram implicit bind on send", () => {
         `
         const dgram = require("dgram");
         const socket = dgram.createSocket("udp4");
+        const target = dgram.createSocket("udp4");
         let listeningFired = false;
 
         socket.on("listening", () => {
           listeningFired = true;
         });
 
-        socket.send(Buffer.from("test"), 0, 4, 41234, "127.0.0.1", (err) => {
-          process.nextTick(() => {
-            process.stdout.write(String(listeningFired) + "\\n");
-            socket.close();
+        target.bind(0, "127.0.0.1", () => {
+          const port = target.address().port;
+          socket.send(Buffer.from("test"), 0, 4, port, "127.0.0.1", (err) => {
+            process.nextTick(() => {
+              process.stdout.write(String(listeningFired) + "\\n");
+              socket.close();
+              target.close();
+            });
           });
         });
         `,

--- a/test/regression/issue/28083.test.ts
+++ b/test/regression/issue/28083.test.ts
@@ -1,7 +1,71 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 
 describe("dgram implicit bind on send", () => {
+  test("reusePort option works with dgram sockets", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const dgram = require("dgram");
+        const isWin = process.platform === "win32";
+
+        // Create two sockets with reusePort: true bound to the same port
+        const s1 = dgram.createSocket({ type: "udp4", reusePort: !isWin });
+        const s2 = dgram.createSocket({ type: "udp4", reusePort: !isWin });
+
+        s1.bind(0, "127.0.0.1", () => {
+          const port = s1.address().port;
+          process.stdout.write("s1:" + port + "\\n");
+
+          if (isWin) {
+            // On Windows, reusePort is not supported - just verify s1 works
+            process.stdout.write("ok\\n");
+            s1.close();
+            s2.close();
+            return;
+          }
+
+          // On non-Windows, second socket should be able to bind to the same port
+          s2.bind(port, "127.0.0.1", () => {
+            const port2 = s2.address().port;
+            process.stdout.write("s2:" + port2 + "\\n");
+            process.stdout.write("same:" + String(port === port2) + "\\n");
+            s1.close();
+            s2.close();
+          });
+
+          s2.on("error", (err) => {
+            process.stdout.write("s2error:" + err.message + "\\n");
+            s1.close();
+            s2.close();
+            process.exit(1);
+          });
+        });
+
+        s1.on("error", (err) => {
+          process.stdout.write("s1error:" + err.message + "\\n");
+          s1.close();
+          process.exit(1);
+        });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    if (isWindows) {
+      expect(stdout).toContain("ok\n");
+    } else {
+      expect(stdout).toContain("same:true\n");
+    }
+    expect(exitCode).toBe(0);
+  });
+
   test("send() without bind() implicitly binds and delivers the message", async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/regression/issue/28083.test.ts
+++ b/test/regression/issue/28083.test.ts
@@ -1,0 +1,199 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+describe("dgram implicit bind on send", () => {
+  test("send() without bind() implicitly binds and delivers the message", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const dgram = require("dgram");
+        const receiver = dgram.createSocket("udp4");
+        const sender = dgram.createSocket("udp4");
+
+        receiver.bind(0, "127.0.0.1", () => {
+          const port = receiver.address().port;
+
+          receiver.on("message", (msg, rinfo) => {
+            process.stdout.write(msg.toString() + "\\n");
+            process.stdout.write(String(rinfo.port > 0) + "\\n");
+            sender.close();
+            receiver.close();
+          });
+
+          sender.send(Buffer.from("hello"), 0, 5, port, "127.0.0.1", (err) => {
+            if (err) {
+              process.stdout.write("ERROR:" + err.message + "\\n");
+              process.exit(1);
+            }
+            const addr = sender.address();
+            process.stdout.write(addr.address + "\\n");
+            process.stdout.write(String(addr.port > 0) + "\\n");
+          });
+        });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    expect(stdout).toBe("0.0.0.0\ntrue\nhello\ntrue\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("listening event fires after implicit bind", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const dgram = require("dgram");
+        const socket = dgram.createSocket("udp4");
+        let listeningFired = false;
+
+        socket.on("listening", () => {
+          listeningFired = true;
+        });
+
+        socket.send(Buffer.from("test"), 0, 4, 41234, "127.0.0.1", (err) => {
+          process.nextTick(() => {
+            process.stdout.write(String(listeningFired) + "\\n");
+            socket.close();
+          });
+        });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    expect(stdout).toBe("true\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("multiple sends without bind() are all delivered", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const dgram = require("dgram");
+        const receiver = dgram.createSocket("udp4");
+        const sender = dgram.createSocket("udp4");
+        const messages = [];
+
+        receiver.bind(0, "127.0.0.1", () => {
+          const port = receiver.address().port;
+
+          receiver.on("message", (msg) => {
+            messages.push(msg.toString());
+            if (messages.length === 3) {
+              messages.sort();
+              process.stdout.write(messages.join(",") + "\\n");
+              sender.close();
+              receiver.close();
+            }
+          });
+
+          sender.send(Buffer.from("aaa"), 0, 3, port, "127.0.0.1");
+          sender.send(Buffer.from("bbb"), 0, 3, port, "127.0.0.1");
+          sender.send(Buffer.from("ccc"), 0, 3, port, "127.0.0.1");
+        });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    expect(stdout).toBe("aaa,bbb,ccc\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("send(buffer, port, address, callback) short form works without bind", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const dgram = require("dgram");
+        const receiver = dgram.createSocket("udp4");
+        const sender = dgram.createSocket("udp4");
+
+        receiver.bind(0, "127.0.0.1", () => {
+          const port = receiver.address().port;
+
+          receiver.on("message", (msg) => {
+            process.stdout.write(msg.toString() + "\\n");
+            sender.close();
+            receiver.close();
+          });
+
+          sender.send(Buffer.from("short-form"), port, "127.0.0.1", (err) => {
+            if (err) {
+              process.stdout.write("ERROR:" + err.message + "\\n");
+              process.exit(1);
+            }
+          });
+        });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    expect(stdout).toBe("short-form\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bidirectional communication works with implicit bind (k-rpc pattern)", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const dgram = require("dgram");
+        const receiver = dgram.createSocket("udp4");
+        const sender = dgram.createSocket("udp4");
+
+        sender.on("message", (msg) => {
+          process.stdout.write("reply:" + msg.toString() + "\\n");
+          sender.close();
+          receiver.close();
+        });
+
+        receiver.bind(0, "127.0.0.1", () => {
+          const port = receiver.address().port;
+
+          receiver.on("message", (msg, rinfo) => {
+            process.stdout.write("request:" + msg.toString() + "\\n");
+            receiver.send(Buffer.from("pong"), 0, 4, rinfo.port, rinfo.address);
+          });
+
+          sender.send(Buffer.from("ping"), 0, 4, port, "127.0.0.1");
+        });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    expect(stdout).toBe("request:ping\nreply:pong\n");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes three bugs in `bsd_create_udp_socket()` in uSockets that affect macOS dgram socket behavior:

- **`bsd_set_reuseport()` was Linux-only**: Changed `#if defined(__linux__)` to `#if defined(SO_REUSEPORT) && !defined(_WIN32)` so `reusePort: true` works on macOS
- **Socket fd leak + missing errno on `bsd_set_reuse()` failure**: Added `bsd_close_socket()` and errno propagation so failures produce diagnostic error messages instead of generic "Failed to bind socket"
- **Hardcoded errno 92 (Linux ENOPROTOOPT)**: Replaced with `ENOPROTOOPT` macro so IPv4 fallbacks for `IP_PKTINFO` and `IP_RECVTOS` are correctly attempted on macOS (where ENOPROTOOPT is 42, not 92)

Also adds regression tests for the implicit bind-on-send behavior reported in #28083, covering basic send-without-bind, listening event emission, multiple queued sends, short-form send, and bidirectional communication (k-rpc pattern).

### Context

The reporter is on macOS (Darwin arm64, M4 Mac) and reports that calling `send()` on an unbound dgram socket silently fails to bind in Bun 1.3. This cannot be reproduced on Linux — the implicit bind code path works correctly there. The C-layer fixes in this PR address macOS-specific issues in the socket creation path that could cause silent failures or missing error diagnostics on that platform.

Closes #28083

## Test plan

- [x] `bun bd test test/regression/issue/28083.test.ts` — 5 pass
- [x] Tests cover: implicit bind delivery, listening event, multiple queued sends, short-form send args, bidirectional k-rpc pattern
- [x] C-layer fixes verified by code review (errno, fd leak, SO_REUSEPORT guard)