### PR TITLE
Fix deadlocks and UAF in PathWatcherManager

### DIFF
--- a/src/Watcher.zig
+++ b/src/Watcher.zig
@@ -157,6 +157,7 @@ pub fn freeOwnedFilePaths(this: *Watcher) void {
 pub fn destroyFromOwner(this: *Watcher) void {
     this.freeOwnedFilePaths();
     this.watchlist.deinit(this.allocator);
+    WatcherTrace.deinit();
     const allocator = this.allocator;
     allocator.destroy(this);
 }
@@ -248,6 +249,7 @@ pub const WatchItem = struct {
     kind: Kind,
     package_json: ?*PackageJSON,
     eventlist_index: if (Environment.isLinux) Platform.EventListIndex else u0 = 0,
+    owns_file_path: bool = false,
 
     pub const Kind = enum { file, directory };
 };
@@ -428,6 +430,7 @@ fn appendFileAssumeCapacity(
         .parent_hash = parent_hash,
         .package_json = package_json,
         .kind = .file,
+        .owns_file_path = clone_file_path,
     };
 
     if (comptime Environment.isMac) {
@@ -490,6 +493,7 @@ fn appendDirectoryAssumeCapacity(
         .parent_hash = parent_hash,
         .kind = .directory,
         .package_json = null,
+        .owns_file_path = clone_file_path,
     };
 
     if (Environment.isMac) {

--- a/src/Watcher.zig
+++ b/src/Watcher.zig
@@ -232,11 +232,16 @@ fn threadMain(this: *Watcher) !void {
 
     switch (this.watchLoop()) {
         .err => |err| {
-            this.watchloop_handle = null;
+            // Do not clear watchloop_handle before onError: if the error
+            // callback triggers deinit → main_watcher.deinit(false), a null
+            // watchloop_handle makes deinit take the direct-destruction path,
+            // freeing this Watcher while threadMain still needs it.
+            // Keeping it non-null forces the signaling path (sets running=false).
             this.platform.stop();
             if (this.running) {
                 this.onError(this.ctx, err);
             }
+            this.watchloop_handle = null;
         },
         .result => {},
     }

--- a/src/Watcher.zig
+++ b/src/Watcher.zig
@@ -27,7 +27,7 @@ close_descriptors: bool = false,
 /// When true, the owner (e.g. PathWatcherManager) is responsible for
 /// cleaning up this Watcher's watchlist and memory. threadMain skips
 /// its destroy so in-flight tasks can still safely access the Watcher.
-pub skip_thread_destroy: bool = false,
+skip_thread_destroy: bool = false,
 
 evict_list: [max_eviction_count]WatchItemIndex = undefined,
 evict_list_i: WatchItemIndex = 0,

--- a/src/Watcher.zig
+++ b/src/Watcher.zig
@@ -24,6 +24,10 @@ cwd: string,
 thread: std.Thread = undefined,
 running: bool = true,
 close_descriptors: bool = false,
+/// When true, the owner (e.g. PathWatcherManager) is responsible for
+/// cleaning up this Watcher's watchlist and memory. threadMain skips
+/// its destroy so in-flight tasks can still safely access the Watcher.
+pub skip_thread_destroy: bool = false,
 
 evict_list: [max_eviction_count]WatchItemIndex = undefined,
 evict_list_i: WatchItemIndex = 0,
@@ -118,6 +122,10 @@ pub fn deinit(this: *Watcher, close_descriptors: bool) void {
         defer this.mutex.unlock();
         this.close_descriptors = close_descriptors;
         this.running = false;
+    } else if (this.skip_thread_destroy) {
+        // Owner (PathWatcherManager) set skip_thread_destroy and will handle
+        // cleanup. Just mark as not running.
+        this.running = false;
     } else {
         if (close_descriptors and this.running) {
             const fds = this.watchlist.items(.fd);
@@ -125,10 +133,32 @@ pub fn deinit(this: *Watcher, close_descriptors: bool) void {
                 fd.close();
             }
         }
+        this.freeOwnedFilePaths();
         this.watchlist.deinit(this.allocator);
         const allocator = this.allocator;
         allocator.destroy(this);
     }
+}
+
+pub fn freeOwnedFilePaths(this: *Watcher) void {
+    const slice = this.watchlist.slice();
+    const file_paths = slice.items(.file_path);
+    const owns = slice.items(.owns_file_path);
+    for (file_paths, owns) |fp, owned| {
+        if (owned and fp.len > 0) {
+            this.allocator.free(@constCast(fp.ptr[0 .. fp.len + 1]));
+        }
+    }
+}
+
+/// Destroy the Watcher, freeing its watchlist and memory.
+/// Called by PathWatcherManager.deinit() when the watcher thread already
+/// exited via the error path and set skip_thread_destroy.
+pub fn destroyFromOwner(this: *Watcher) void {
+    this.freeOwnedFilePaths();
+    this.watchlist.deinit(this.allocator);
+    const allocator = this.allocator;
+    allocator.destroy(this);
 }
 
 pub fn getHash(filepath: string) HashType {
@@ -246,6 +276,12 @@ fn threadMain(this: *Watcher) !void {
         .result => {},
     }
 
+    // When owned by a PathWatcherManager, skip_thread_destroy is set in
+    // onError. In-flight DirectoryRegisterTasks still reference this Watcher
+    // via manager.main_watcher, so threadMain must NOT destroy it. The
+    // manager's deferred deinit handles cleanup once all tasks complete.
+    if (this.skip_thread_destroy) return;
+
     // deinit and close descriptors if needed
     if (this.close_descriptors) {
         const fds = this.watchlist.items(.fd);
@@ -253,6 +289,7 @@ fn threadMain(this: *Watcher) !void {
             fd.close();
         }
     }
+    this.freeOwnedFilePaths();
     this.watchlist.deinit(this.allocator);
 
     // Close trace file if open

--- a/src/Watcher.zig
+++ b/src/Watcher.zig
@@ -264,16 +264,10 @@ fn threadMain(this: *Watcher) !void {
 
     switch (this.watchLoop()) {
         .err => |err| {
-            // Do not clear watchloop_handle before onError: if the error
-            // callback triggers deinit → main_watcher.deinit(false), a null
-            // watchloop_handle makes deinit take the direct-destruction path,
-            // freeing this Watcher while threadMain still needs it.
-            // Keeping it non-null forces the signaling path (sets running=false).
             this.platform.stop();
             if (this.running) {
                 this.onError(this.ctx, err);
             }
-            this.watchloop_handle = null;
         },
         .result => {},
     }
@@ -283,6 +277,14 @@ fn threadMain(this: *Watcher) !void {
     // via manager.main_watcher, so threadMain must NOT destroy it. The
     // manager's deferred deinit handles cleanup once all tasks complete.
     if (this.skip_thread_destroy) return;
+
+    // Clear watchloop_handle AFTER the skip_thread_destroy check. Writing
+    // it before the check creates a race: a thread pool thread calling
+    // deinit() can read watchloop_handle==null, call destroyFromOwner()
+    // freeing this Watcher, and then threadMain reads skip_thread_destroy
+    // on freed memory (UAF). watchloop_handle is also non-atomic, so the
+    // concurrent read/write is itself UB.
+    this.watchloop_handle = null;
 
     // deinit and close descriptors if needed
     if (this.close_descriptors) {

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -327,6 +327,14 @@ pub const PathWatcherManager = struct {
                     watcher.flush();
                 }
             }
+
+            // Tell threadMain not to destroy the Watcher when it exits. In-flight
+            // DirectoryRegisterTasks still access manager.main_watcher (addFile,
+            // addDirectory, remove), so the manager's deferred deinit must handle
+            // Watcher cleanup instead. Set under this.mutex so deinit() sees
+            // consistent values.
+            this.main_watcher.skip_thread_destroy = true;
+            this.main_watcher_exited = true;
         }
 
         // Release this.mutex before acquiring default_manager_mutex to
@@ -338,13 +346,6 @@ pub const PathWatcherManager = struct {
             defer default_manager_mutex.unlock();
             default_manager = null;
         }
-
-        // Tell threadMain not to destroy the Watcher when it exits. In-flight
-        // DirectoryRegisterTasks still access manager.main_watcher (addFile,
-        // addDirectory, remove), so the manager's deferred deinit must handle
-        // Watcher cleanup instead.
-        this.main_watcher.skip_thread_destroy = true;
-        this.main_watcher_exited = true;
 
         // deinit manager when all watchers are closed
         this.deinit();
@@ -753,6 +754,9 @@ pub const PathWatcherManager = struct {
         // Check watcher_count, pending_tasks, and set deferred-deinit flags
         // under this.mutex to prevent races with unregisterWatcher and
         // unrefPendingTask which modify these fields under the same lock.
+        // Also capture main_watcher_exited under the lock since onError
+        // writes it under this.mutex.
+        var main_watcher_exited: bool = undefined;
         {
             this.mutex.lock();
             defer this.mutex.unlock();
@@ -773,9 +777,10 @@ pub const PathWatcherManager = struct {
             }
 
             this.deinit_started = true;
+            main_watcher_exited = this.main_watcher_exited;
         }
 
-        if (this.main_watcher_exited) {
+        if (main_watcher_exited) {
             // Error path: the watcher thread exited via onError. It set
             // skip_thread_destroy so threadMain skipped the Watcher cleanup.
             // Check if the thread has fully exited before we destroy it.

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -14,7 +14,6 @@ pub const PathWatcherManager = struct {
     deinit_on_last_watcher: bool = false,
     pending_tasks: u32 = 0,
     deinit_on_last_task: bool = false,
-    has_pending_tasks: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     mutex: Mutex,
     const PathInfo = struct {
         fd: FD = .invalid,
@@ -30,21 +29,20 @@ pub const PathWatcherManager = struct {
         defer this.mutex.unlock();
         if (this.deinit_on_last_task) return false;
         this.pending_tasks += 1;
-        this.has_pending_tasks.store(true, .release);
         return true;
     }
 
-    fn hasPendingTasks(this: *PathWatcherManager) callconv(.c) bool {
-        return this.has_pending_tasks.load(.acquire);
-    }
-
     fn unrefPendingTask(this: *PathWatcherManager) void {
+        // deinit() may destroy(this). Defer it until after unlock so we don't
+        // unlock() a freed mutex.
+        var should_deinit = false;
+        defer if (should_deinit) this.deinit();
+
         this.mutex.lock();
         defer this.mutex.unlock();
         this.pending_tasks -= 1;
-        if (this.deinit_on_last_task and this.pending_tasks == 0) {
-            this.has_pending_tasks.store(false, .release);
-            this.deinit();
+        if (this.pending_tasks == 0 and this.deinit_on_last_task) {
+            should_deinit = true;
         }
     }
 
@@ -160,6 +158,17 @@ pub const PathWatcherManager = struct {
 
         for (events) |event| {
             if (event.index >= file_paths.len) continue;
+
+            // Skip entries pending eviction — these watches have been logically
+            // removed, so processing events for them could trigger callbacks
+            // for paths the user has stopped watching.
+            const dominated = std.mem.indexOfScalar(
+                Watcher.WatchItemIndex,
+                ctx.evict_list[0..ctx.evict_list_i],
+                event.index,
+            ) != null;
+            if (dominated) continue;
+
             const file_path = file_paths[event.index];
             const update_count = counts[event.index] + 1;
             counts[event.index] = update_count;
@@ -313,8 +322,13 @@ pub const PathWatcherManager = struct {
                     watcher.flush();
                 }
             }
+        }
 
-            // we need a new manager at this point
+        // Release this.mutex before acquiring default_manager_mutex to
+        // maintain consistent lock ordering (default_manager_mutex → this.mutex).
+        // deinit() acquires default_manager_mutex first, so reversing the order
+        // here would be an AB/BA deadlock.
+        {
             default_manager_mutex.lock();
             defer default_manager_mutex.unlock();
             default_manager = null;
@@ -390,7 +404,12 @@ pub const PathWatcherManager = struct {
             return error.UnexpectedFailure;
         }
 
-        fn getNext(this: *DirectoryRegisterTask) ?*PathWatcher {
+        const GetNextResult = struct {
+            watcher: ?*PathWatcher,
+            hash_to_remove: ?Watcher.HashType,
+        };
+
+        fn getNext(this: *DirectoryRegisterTask) GetNextResult {
             this.manager.mutex.lock();
             defer this.manager.mutex.unlock();
 
@@ -398,10 +417,10 @@ pub const PathWatcherManager = struct {
             if (watcher == null) {
                 // no more work todo, release the fd and path
                 _ = this.manager.current_fd_task.remove(this.path.fd);
-                this.manager._decrementPathRefNoLock(this.path.path);
-                return null;
+                const hash = this.manager._decrementPathRefNoLock(this.path.path);
+                return .{ .watcher = null, .hash_to_remove = hash };
             }
-            return watcher;
+            return .{ .watcher = watcher, .hash_to_remove = null };
         }
 
         fn processWatcher(
@@ -449,8 +468,13 @@ pub const PathWatcherManager = struct {
 
                 {
                     watcher.mutex.lock();
-                    defer watcher.mutex.unlock();
-                    watcher.file_paths.append(bun.default_allocator, child_path.path) catch |err| {
+                    const append_result = watcher.file_paths.append(bun.default_allocator, child_path.path);
+                    watcher.mutex.unlock();
+                    // On error, drop the ref we took in _fdFromAbsolutePathZ. Must do
+                    // this AFTER releasing watcher.mutex: _decrementPathRef acquires
+                    // manager.mutex, and unregisterWatcher acquires manager.mutex before
+                    // watcher.mutex — inverting here would AB/BA deadlock.
+                    append_result catch |err| {
                         manager._decrementPathRef(entry_path_z);
                         return switch (err) {
                             error.OutOfMemory => .{ .err = .{
@@ -470,7 +494,7 @@ pub const PathWatcherManager = struct {
                         options.Loader.file,
                         .invalid,
                         null,
-                        false,
+                        true,
                     )) {
                         .err => |err| return .{ .err = err },
                         .result => {},
@@ -495,7 +519,14 @@ pub const PathWatcherManager = struct {
 
             var buf: bun.PathBuffer = undefined;
 
-            while (this.getNext()) |watcher| {
+            while (true) {
+                const next = this.getNext();
+                // Deferred removal: call main_watcher.remove AFTER releasing
+                // manager.mutex (done inside getNext) to avoid deadlock.
+                if (next.hash_to_remove) |hash| {
+                    this.manager.main_watcher.remove(hash);
+                }
+                const watcher = next.watcher orelse break;
                 defer watcher.unrefPendingDirectory();
                 switch (this.processWatcher(watcher, &buf)) {
                     .err => |err| {
@@ -518,7 +549,7 @@ pub const PathWatcherManager = struct {
     // this should only be called if thread pool is not null
     fn _addDirectory(this: *PathWatcherManager, watcher: *PathWatcher, path: PathInfo) bun.sys.Maybe(void) {
         const fd = path.fd;
-        switch (this.main_watcher.addDirectory(fd, path.path, path.hash, false)) {
+        switch (this.main_watcher.addDirectory(fd, path.path, path.hash, true)) {
             .err => |err| return .{ .err = err.withPath(path.path) },
             .result => {},
         }
@@ -561,7 +592,7 @@ pub const PathWatcherManager = struct {
 
         const path = watcher.path;
         if (path.is_file) {
-            try this.main_watcher.addFile(path.fd, path.path, path.hash, .file, .invalid, null, false).unwrap();
+            try this.main_watcher.addFile(path.fd, path.path, path.hash, .file, .invalid, null, true).unwrap();
         } else {
             if (comptime Environment.isMac) {
                 if (watcher.fsevents_watcher != null) {
@@ -583,38 +614,70 @@ pub const PathWatcherManager = struct {
         }
     }
 
-    fn _decrementPathRefNoLock(this: *PathWatcherManager, file_path: [:0]const u8) void {
+    /// Decrement the reference count for a path. If the count reaches zero,
+    /// the path entry is removed from file_paths and freed, and the hash is
+    /// returned so the caller can call main_watcher.remove() AFTER releasing
+    /// manager.mutex. Calling main_watcher.remove() here would deadlock:
+    /// the watcher thread holds main_watcher.mutex → manager.mutex (via
+    /// onFileUpdate), so acquiring main_watcher.mutex under manager.mutex
+    /// is an AB/BA inversion.
+    fn _decrementPathRefNoLock(this: *PathWatcherManager, file_path: [:0]const u8) ?Watcher.HashType {
         if (this.file_paths.getEntry(file_path)) |entry| {
             var path = entry.value_ptr;
             if (path.refs > 0) {
                 path.refs -= 1;
                 if (path.refs == 0) {
+                    const hash = path.hash;
                     const path_ = path.path;
-                    this.main_watcher.remove(path.hash);
                     _ = this.file_paths.remove(path_);
                     bun.default_allocator.free(path_);
+                    return hash;
                 }
             }
         }
+        return null;
     }
 
     fn _decrementPathRef(this: *PathWatcherManager, file_path: [:0]const u8) void {
-        this.mutex.lock();
-        defer this.mutex.unlock();
-        this._decrementPathRefNoLock(file_path);
+        const maybe_hash = blk: {
+            this.mutex.lock();
+            defer this.mutex.unlock();
+            break :blk this._decrementPathRefNoLock(file_path);
+        };
+        // Remove from main_watcher AFTER releasing manager.mutex to avoid
+        // AB/BA deadlock with the watcher thread (see _decrementPathRefNoLock).
+        if (maybe_hash) |hash| {
+            this.main_watcher.remove(hash);
+        }
     }
 
-    // unregister is always called form main thread
+    // unregister is always called from main thread
     fn unregisterWatcher(this: *PathWatcherManager, watcher: *PathWatcher) void {
+        // Must defer deinit() to AFTER releasing this.mutex, for two reasons:
+        // 1. deinit() re-acquires this.mutex to check pending state.
+        //    os_unfair_lock is non-recursive, so calling deinit() while holding
+        //    the lock self-deadlocks.
+        // 2. deinit() may destroy(this). Unlocking a freed mutex is UAF.
+        var should_deinit = false;
+        defer if (should_deinit) this.deinit();
+
+        // Collect hashes whose refs dropped to zero. We must call
+        // main_watcher.remove() for these AFTER releasing manager.mutex,
+        // because the watcher thread holds main_watcher.mutex → manager.mutex
+        // (via onFileUpdate). Acquiring main_watcher.mutex while holding
+        // manager.mutex would be an AB/BA deadlock.
+        var hashes_to_remove = bun.BabyList(Watcher.HashType){};
+        defer {
+            for (hashes_to_remove.slice()) |hash| {
+                this.main_watcher.remove(hash);
+            }
+            hashes_to_remove.deinit(bun.default_allocator);
+        }
+
         this.mutex.lock();
         defer this.mutex.unlock();
 
         var watchers = this.watchers.slice();
-        defer {
-            if (this.deinit_on_last_watcher and this.watcher_count == 0) {
-                this.deinit();
-            }
-        }
 
         for (watchers, 0..) |w, i| {
             if (w) |item| {
@@ -626,18 +689,31 @@ pub const PathWatcherManager = struct {
                     }
                     this.watcher_count -= 1;
 
-                    this._decrementPathRefNoLock(watcher.path.path);
-                    if (comptime Environment.isMac) {
-                        if (watcher.fsevents_watcher != null) {
-                            break;
-                        }
-                    }
+                    should_deinit = this.deinit_on_last_watcher and this.watcher_count == 0;
 
-                    {
-                        watcher.mutex.lock();
-                        defer watcher.mutex.unlock();
-                        while (watcher.file_paths.pop()) |file_path| {
-                            this._decrementPathRefNoLock(file_path);
+                    // When this is the last watcher triggering deinit, skip
+                    // freeing paths here. deinit() will stop the watcher thread
+                    // first (setting running=false), then free ALL paths. Freeing
+                    // paths here while the thread is still running could cause it
+                    // to read freed PathWatcherManager state during onFileUpdate.
+                    if (!should_deinit) {
+                        if (this._decrementPathRefNoLock(watcher.path.path)) |hash| {
+                            hashes_to_remove.append(bun.default_allocator, hash) catch {};
+                        }
+                        if (comptime Environment.isMac) {
+                            if (watcher.fsevents_watcher != null) {
+                                break;
+                            }
+                        }
+
+                        {
+                            watcher.mutex.lock();
+                            defer watcher.mutex.unlock();
+                            while (watcher.file_paths.pop()) |file_path| {
+                                if (this._decrementPathRefNoLock(file_path)) |hash| {
+                                    hashes_to_remove.append(bun.default_allocator, hash) catch {};
+                                }
+                            }
                         }
                     }
                     break;
@@ -648,28 +724,43 @@ pub const PathWatcherManager = struct {
 
     fn deinit(this: *PathWatcherManager) void {
         // enable to create a new manager
-        default_manager_mutex.lock();
-        defer default_manager_mutex.unlock();
-        if (default_manager == this) {
-            default_manager = null;
+        {
+            default_manager_mutex.lock();
+            defer default_manager_mutex.unlock();
+            if (default_manager == this) {
+                default_manager = null;
+            }
         }
 
-        // only deinit if no watchers are registered
-        if (this.watcher_count > 0) {
-            // wait last watcher to close
-            this.deinit_on_last_watcher = true;
-            return;
-        }
-
-        if (this.hasPendingTasks()) {
+        // Check watcher_count, pending_tasks, and set deferred-deinit flags
+        // under this.mutex to prevent races with unregisterWatcher and
+        // unrefPendingTask which modify these fields under the same lock.
+        {
             this.mutex.lock();
             defer this.mutex.unlock();
-            // deinit when all tasks are done
-            this.deinit_on_last_task = true;
-            return;
+
+            if (this.watcher_count > 0) {
+                // wait last watcher to close
+                this.deinit_on_last_watcher = true;
+                return;
+            }
+
+            if (this.pending_tasks > 0) {
+                this.deinit_on_last_task = true;
+                return;
+            }
         }
 
+        // deinit(false) sets running=false under main_watcher.mutex.
+        // The watcher thread checks running inside processINotifyEventBatch /
+        // processKEvent under the same mutex, so after this returns the thread
+        // won't START a new onFileUpdate call.
         this.main_watcher.deinit(false);
+
+        // The thread reads file_paths only inside onFileUpdate, which holds
+        // this.mutex (PathWatcherManager's mutex). Acquire it to wait for any
+        // in-progress onFileUpdate to finish before freeing paths below.
+        this.mutex.lock();
 
         if (this.watcher_count > 0) {
             while (this.watchers.pop()) |watcher| {
@@ -691,6 +782,9 @@ pub const PathWatcherManager = struct {
         this.file_paths.deinit();
         this.watchers.deinit(bun.default_allocator);
         this.current_fd_task.deinit();
+
+        // Release our own mutex before destroying ourselves.
+        this.mutex.unlock();
         bun.default_allocator.destroy(this);
     }
 };
@@ -712,7 +806,6 @@ pub const PathWatcher = struct {
     pending_directories: u32 = 0,
     // only used on macOS
     resolved_path: ?string = null,
-    has_pending_directories: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     closed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     pub const ChangeEvent = struct {
         hash: Watcher.HashType = 0,
@@ -805,31 +898,26 @@ pub const PathWatcher = struct {
         defer this.mutex.unlock();
         if (this.isClosed()) return false;
         this.pending_directories += 1;
-        this.has_pending_directories.store(true, .release);
         return true;
-    }
-
-    pub fn hasPendingDirectories(this: *PathWatcher) callconv(.c) bool {
-        return this.has_pending_directories.load(.acquire);
     }
 
     pub fn isClosed(this: *PathWatcher) bool {
         return this.closed.load(.acquire);
     }
 
-    pub fn setClosed(this: *PathWatcher) void {
-        this.mutex.lock();
-        defer this.mutex.unlock();
-        this.closed.store(true, .release);
-    }
-
     pub fn unrefPendingDirectory(this: *PathWatcher) void {
+        // deinit() acquires this.mutex (to set closed and check
+        // pending_directories), and may then proceed to destroy(this).
+        // Defer it until after unlock so we don't self-deadlock or
+        // unlock() a freed mutex.
+        var should_deinit = false;
+        defer if (should_deinit) this.deinit();
+
         this.mutex.lock();
         defer this.mutex.unlock();
         this.pending_directories -= 1;
-        if (this.isClosed() and this.pending_directories == 0) {
-            this.has_pending_directories.store(false, .release);
-            this.deinit();
+        if (this.pending_directories == 0 and this.isClosed()) {
+            should_deinit = true;
         }
     }
 
@@ -874,10 +962,19 @@ pub const PathWatcher = struct {
     }
 
     pub fn deinit(this: *PathWatcher) void {
-        this.setClosed();
-        if (this.hasPendingDirectories()) {
-            // will be freed on last directory
-            return;
+        // Combine setting closed and checking pending_directories under a
+        // single mutex hold to prevent a double-deinit race: without this,
+        // a worker thread in unrefPendingDirectory() can observe closed=true
+        // and pending_directories==0 between the store and the check,
+        // causing both threads to proceed with destroy().
+        {
+            this.mutex.lock();
+            defer this.mutex.unlock();
+            this.closed.store(true, .release);
+            if (this.pending_directories > 0) {
+                // Will be freed by the last unrefPendingDirectory call.
+                return;
+            }
         }
 
         if (this.manager) |manager| {

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -781,12 +781,14 @@ pub const PathWatcherManager = struct {
         }
 
         if (main_watcher_exited) {
-            // Always let threadMain handle its own Watcher cleanup.
-            // We cannot safely read watchloop_handle here — it is written
-            // by the watcher thread without synchronization, making the
-            // concurrent read UB. Clear skip_thread_destroy so threadMain
-            // proceeds past the early-return check and destroys the Watcher.
-            this.main_watcher.skip_thread_destroy = false;
+            // Keep skip_thread_destroy true so threadMain early-returns without
+            // destroying the Watcher. We must NOT clear it to false here — a
+            // racing unregisterWatcher may still call main_watcher.remove()
+            // after releasing its mutex but before calling deinit(). Clearing
+            // skip_thread_destroy would let threadMain destroy the Watcher
+            // while those deferred remove() calls are pending (UAF).
+            // Instead, we destroy the Watcher ourselves at the end of deinit
+            // after all uses of main_watcher are complete.
         } else {
             // Normal shutdown: signal the watcher thread to stop.
             // deinit(false) sets running=false under main_watcher.mutex.
@@ -824,6 +826,15 @@ pub const PathWatcherManager = struct {
 
         // Release our own mutex before destroying ourselves.
         this.mutex.unlock();
+
+        if (main_watcher_exited) {
+            // The watcher thread has exited (via onError) and skip_thread_destroy
+            // is still true, so threadMain returned without cleaning up the Watcher.
+            // All deferred operations (hash removals, etc.) that reference
+            // main_watcher are now complete. Safe to destroy.
+            this.main_watcher.destroyFromOwner();
+        }
+
         bun.default_allocator.destroy(this);
     }
 };

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -14,9 +14,10 @@ pub const PathWatcherManager = struct {
     deinit_on_last_watcher: bool = false,
     pending_tasks: u32 = 0,
     deinit_on_last_task: bool = false,
-    /// Set when the watcher thread is exiting and will handle its own
-    /// Watcher cleanup in threadMain.  deinit() checks this to skip
-    /// main_watcher.deinit() and avoid a double-free.
+    deinit_started: bool = false,
+    /// Set when the watcher thread has exited the watch loop via an error.
+    /// deinit() uses this to decide whether to signal the thread to stop
+    /// (normal path) or destroy the Watcher directly (error path).
     main_watcher_exited: bool = false,
     mutex: Mutex,
     const PathInfo = struct {
@@ -338,33 +339,14 @@ pub const PathWatcherManager = struct {
             default_manager = null;
         }
 
-        // The watcher thread (threadMain) calls onError then continues to
-        // clean up its own Watcher (close fds, free watchlist, destroy struct).
-        // We must NOT call this.deinit() here — it would call
-        // main_watcher.deinit(false) which destroys the Watcher while
-        // threadMain still needs it (UAF / double-free).
-        //
-        // Instead, mark that the watcher thread owns its own destruction and
-        // defer manager cleanup to the last watcher/task unregistration.
+        // Tell threadMain not to destroy the Watcher when it exits. In-flight
+        // DirectoryRegisterTasks still access manager.main_watcher (addFile,
+        // addDirectory, remove), so the manager's deferred deinit must handle
+        // Watcher cleanup instead.
+        this.main_watcher.skip_thread_destroy = true;
         this.main_watcher_exited = true;
 
-        {
-            this.mutex.lock();
-            defer this.mutex.unlock();
-
-            if (this.watcher_count > 0) {
-                this.deinit_on_last_watcher = true;
-                return;
-            }
-
-            if (this.pending_tasks > 0) {
-                this.deinit_on_last_task = true;
-                return;
-            }
-        }
-
-        // No watchers and no pending tasks — safe to clean up manager now.
-        // main_watcher_exited is set so deinit() will skip main_watcher.deinit().
+        // deinit manager when all watchers are closed
         this.deinit();
     }
 
@@ -691,6 +673,12 @@ pub const PathWatcherManager = struct {
         var should_deinit = false;
         defer if (should_deinit) this.deinit();
 
+        // Save main_watcher to a local before releasing the mutex. A racing
+        // deinit() could free `this` (the PathWatcherManager) between the
+        // mutex.unlock() and the deferred hash removal, making `this.main_watcher`
+        // a UAF. The local keeps the pointer safe.
+        const main_watcher = this.main_watcher;
+
         // Collect hashes whose refs dropped to zero. We must call
         // main_watcher.remove() for these AFTER releasing manager.mutex,
         // because the watcher thread holds main_watcher.mutex → manager.mutex
@@ -699,7 +687,7 @@ pub const PathWatcherManager = struct {
         var hashes_to_remove = bun.BabyList(Watcher.HashType){};
         defer {
             for (hashes_to_remove.slice()) |hash| {
-                this.main_watcher.remove(hash);
+                main_watcher.remove(hash);
             }
             hashes_to_remove.deinit(bun.default_allocator);
         }
@@ -769,6 +757,10 @@ pub const PathWatcherManager = struct {
             this.mutex.lock();
             defer this.mutex.unlock();
 
+            // Guard against double-deinit: onError's deinit and
+            // unregisterWatcher's deferred deinit can race.
+            if (this.deinit_started) return;
+
             if (this.watcher_count > 0) {
                 // wait last watcher to close
                 this.deinit_on_last_watcher = true;
@@ -779,15 +771,27 @@ pub const PathWatcherManager = struct {
                 this.deinit_on_last_task = true;
                 return;
             }
+
+            this.deinit_started = true;
         }
 
         if (this.main_watcher_exited) {
-            // The watcher thread already exited the watch loop and will handle
-            // its own Watcher cleanup in threadMain.  Skip main_watcher.deinit()
-            // to avoid double-free.
+            // Error path: the watcher thread exited via onError. It set
+            // skip_thread_destroy so threadMain skipped the Watcher cleanup.
+            // Check if the thread has fully exited before we destroy it.
+            if (this.main_watcher.watchloop_handle == null) {
+                // Thread fully exited (deferred path). We destroy the Watcher.
+                this.main_watcher.destroyFromOwner();
+            } else {
+                // Synchronous path: still inside threadMain's call stack
+                // (onError → deinit). No tasks remain, so clear the flag and
+                // let threadMain handle its own cleanup when onError returns.
+                this.main_watcher.skip_thread_destroy = false;
+            }
         } else {
+            // Normal shutdown: signal the watcher thread to stop.
             // deinit(false) sets running=false under main_watcher.mutex.
-            // The watcher thread checks running inside processINotifyEventBatch /
+            // The thread checks running inside processINotifyEventBatch /
             // processKEvent under the same mutex, so after this returns the thread
             // won't START a new onFileUpdate call.
             this.main_watcher.deinit(false);

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -781,18 +781,12 @@ pub const PathWatcherManager = struct {
         }
 
         if (main_watcher_exited) {
-            // Error path: the watcher thread exited via onError. It set
-            // skip_thread_destroy so threadMain skipped the Watcher cleanup.
-            // Check if the thread has fully exited before we destroy it.
-            if (this.main_watcher.watchloop_handle == null) {
-                // Thread fully exited (deferred path). We destroy the Watcher.
-                this.main_watcher.destroyFromOwner();
-            } else {
-                // Synchronous path: still inside threadMain's call stack
-                // (onError → deinit). No tasks remain, so clear the flag and
-                // let threadMain handle its own cleanup when onError returns.
-                this.main_watcher.skip_thread_destroy = false;
-            }
+            // Always let threadMain handle its own Watcher cleanup.
+            // We cannot safely read watchloop_handle here — it is written
+            // by the watcher thread without synchronization, making the
+            // concurrent read UB. Clear skip_thread_destroy so threadMain
+            // proceeds past the early-return check and destroys the Watcher.
+            this.main_watcher.skip_thread_destroy = false;
         } else {
             // Normal shutdown: signal the watcher thread to stop.
             // deinit(false) sets running=false under main_watcher.mutex.

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -14,6 +14,10 @@ pub const PathWatcherManager = struct {
     deinit_on_last_watcher: bool = false,
     pending_tasks: u32 = 0,
     deinit_on_last_task: bool = false,
+    /// Set when the watcher thread is exiting and will handle its own
+    /// Watcher cleanup in threadMain.  deinit() checks this to skip
+    /// main_watcher.deinit() and avoid a double-free.
+    main_watcher_exited: bool = false,
     mutex: Mutex,
     const PathInfo = struct {
         fd: FD = .invalid,
@@ -334,7 +338,33 @@ pub const PathWatcherManager = struct {
             default_manager = null;
         }
 
-        // deinit manager when all watchers are closed
+        // The watcher thread (threadMain) calls onError then continues to
+        // clean up its own Watcher (close fds, free watchlist, destroy struct).
+        // We must NOT call this.deinit() here — it would call
+        // main_watcher.deinit(false) which destroys the Watcher while
+        // threadMain still needs it (UAF / double-free).
+        //
+        // Instead, mark that the watcher thread owns its own destruction and
+        // defer manager cleanup to the last watcher/task unregistration.
+        this.main_watcher_exited = true;
+
+        {
+            this.mutex.lock();
+            defer this.mutex.unlock();
+
+            if (this.watcher_count > 0) {
+                this.deinit_on_last_watcher = true;
+                return;
+            }
+
+            if (this.pending_tasks > 0) {
+                this.deinit_on_last_task = true;
+                return;
+            }
+        }
+
+        // No watchers and no pending tasks — safe to clean up manager now.
+        // main_watcher_exited is set so deinit() will skip main_watcher.deinit().
         this.deinit();
     }
 
@@ -751,11 +781,17 @@ pub const PathWatcherManager = struct {
             }
         }
 
-        // deinit(false) sets running=false under main_watcher.mutex.
-        // The watcher thread checks running inside processINotifyEventBatch /
-        // processKEvent under the same mutex, so after this returns the thread
-        // won't START a new onFileUpdate call.
-        this.main_watcher.deinit(false);
+        if (this.main_watcher_exited) {
+            // The watcher thread already exited the watch loop and will handle
+            // its own Watcher cleanup in threadMain.  Skip main_watcher.deinit()
+            // to avoid double-free.
+        } else {
+            // deinit(false) sets running=false under main_watcher.mutex.
+            // The watcher thread checks running inside processINotifyEventBatch /
+            // processKEvent under the same mutex, so after this returns the thread
+            // won't START a new onFileUpdate call.
+            this.main_watcher.deinit(false);
+        }
 
         // The thread reads file_paths only inside onFileUpdate, which holds
         // this.mutex (PathWatcherManager's mutex). Acquire it to wait for any

--- a/test/js/node/watch/fs.watch.concurrency.test.ts
+++ b/test/js/node/watch/fs.watch.concurrency.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for PathWatcherManager deadlock and UAF bugs:
+// - Self-deadlock in unregisterWatcher (deinit() called while holding mutex)
+// - UAF in deferred deinit (destroy while mutex held)
+// - AB/BA deadlock between main_watcher.mutex and manager.mutex
+// - Race in pending_tasks/deinit_on_last_task
+// - Race in PathWatcher.deinit (setClosed + hasPendingDirectories not atomic)
+//
+// Strategy: Create recursive watchers (which spawn directory-scanning thread
+// pool tasks), then close them while those tasks are in-flight. Mixed timing
+// of creation, file mutation, and closure maximizes race window coverage.
+// The test spawns child processes; if one deadlocks or crashes, the test fails.
+
+test("concurrent recursive fs.watch create/destroy does not deadlock or crash", async () => {
+  const RUNS = 3;
+  for (let run = 0; run < RUNS; run++) {
+    const script = `
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const base = fs.mkdtempSync(path.join(os.tmpdir(), "bun-watch-stress-"));
+
+// Create directory trees with enough depth for directory scanning work
+for (let i = 0; i < 4; i++) {
+  const sub = path.join(base, "sub" + i, "a", "b");
+  fs.mkdirSync(sub, { recursive: true });
+  fs.writeFileSync(path.join(sub, "f.txt"), "x");
+  fs.writeFileSync(path.join(base, "sub" + i, "f.txt"), "x");
+  fs.writeFileSync(path.join(base, "sub" + i, "a", "f.txt"), "x");
+}
+
+let cycle = 0;
+const CYCLES = 20;
+
+function tick() {
+  const watchers = [];
+  const idx = cycle % 4;
+
+  // Create recursive watchers on different directories each cycle
+  try { watchers.push(fs.watch(path.join(base, "sub" + idx), { recursive: true }, () => {})); } catch(e) {}
+  try { watchers.push(fs.watch(path.join(base, "sub" + ((idx+1)%4)), { recursive: true }, () => {})); } catch(e) {}
+  // Non-recursive watcher sharing same PathWatcherManager
+  try { watchers.push(fs.watch(base, { recursive: false }, () => {})); } catch(e) {}
+
+  // Mutate file while scanning tasks are in-flight
+  try { fs.writeFileSync(path.join(base, "sub" + idx, "a", "b", "f.txt"), "" + cycle); } catch(e) {}
+
+  // Close with mixed timing to maximize contention
+  for (let i = 0; i < watchers.length; i++) {
+    const w = watchers[i];
+    if (i % 3 === 0) { try { w.close(); } catch(e) {} }
+    else if (i % 3 === 1) { Promise.resolve().then(() => { try { w.close(); } catch(e) {} }); }
+    else { setTimeout(() => { try { w.close(); } catch(e) {} }, 0); }
+  }
+
+  cycle++;
+  if (cycle < CYCLES) {
+    if (cycle % 2 === 0) queueMicrotask(tick);
+    else setTimeout(tick, 0);
+  } else {
+    setTimeout(() => {
+      try { fs.rmSync(base, { recursive: true, force: true }); } catch(e) {}
+      process.exit(0);
+    }, 200);
+  }
+}
+tick();
+`;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const timeout = 60_000;
+    const result = await Promise.race([
+      proc.exited.then(code => ({ kind: "exit" as const, code })),
+      new Promise<{ kind: "timeout" }>(resolve => setTimeout(() => resolve({ kind: "timeout" }), timeout)),
+    ]);
+
+    if (result.kind === "timeout") {
+      proc.kill();
+      await proc.exited;
+      expect().fail(`Process deadlocked on run ${run + 1}/${RUNS} (did not exit within ${timeout}ms).`);
+    }
+
+    // Exit code 0 is the proof: deadlocks cause timeout (caught above),
+    // and crashes produce non-zero exit codes.
+    expect(result).toEqual({ kind: "exit", code: 0 });
+  }
+}, 360_000);


### PR DESCRIPTION
## Summary

Fixes multiple concurrency bugs in `PathWatcherManager` that cause deadlocks and use-after-free when `fs.watch()` watchers are created and destroyed concurrently:

- **AB/BA deadlock between `manager.mutex` and `main_watcher.mutex`**: The watcher thread holds `main_watcher.mutex` → `manager.mutex` (via `onFileUpdate`), while `_decrementPathRefNoLock` called `main_watcher.remove()` under `manager.mutex` — classic lock inversion. Fixed by deferring `main_watcher.remove()` calls to after releasing `manager.mutex`.
- **Self-deadlock in `unregisterWatcher`**: `deinit()` called while holding non-recursive mutex → deadlock. Fixed with deferred-deinit pattern.
- **UAF in deferred deinit**: `destroy(this)` called while mutex still held. Fixed by deferring destroy to after unlock.
- **Double-deinit race in `PathWatcher`**: `setClosed()` and `hasPendingDirectories()` were non-atomic separate calls. Fixed by combining under single mutex hold.
- **Lock ordering violation in `onError`**: Acquired `default_manager_mutex` while holding `manager.mutex`. Fixed by releasing `manager.mutex` first.

Based on #27469 by @chrislloyd.

Closes #27469

## Test plan

- [x] Added regression test `test/js/node/watch/fs.watch.concurrency.test.ts` that creates/destroys recursive watchers concurrently
- [x] Test passes with debug build (`bun bd test`)
- [x] Existing `fs.watch` tests unaffected

---
Verification: CI build [#39615](https://buildkite.com/bun/bun/builds/39615) complete. 58 checks passed. Darwin shard failures are pre-existing flakes (verified on baked main binary: `expect-assertions.test.ts` also fails 5 tests, `node-http-backpressure-max.test.ts` timeout is macOS-only, snapshot mismatches unrelated to fs.watch). Every darwin step has a passing shard. `upload-benchmark` is infra-only. Test proof confirmed: regression test fails on baked binary (reproduces deadlock/UAF), passes on PR binary. ASAN clean. All 11 bot review threads resolved.