### PR TITLE
bundler(splitting): skip dead dynamic imports during tree-shaking

### DIFF
--- a/src/bundler/LinkerContext.zig
+++ b/src/bundler/LinkerContext.zig
@@ -582,8 +582,11 @@ pub const LinkerContext = struct {
             const trace2 = bun.perf.trace("Bundler.markFileLiveForTreeShaking");
             defer trace2.end();
 
-            // Tree shaking: Each entry point marks all files reachable from itself
+            // Tree shaking: Each entry point marks all files reachable from itself.
+            // Skip dynamic-import entry points — they should only become live if a
+            // live part actually contains an import() referencing them.
             for (entry_points) |entry_point| {
+                if (entry_point_kinds[entry_point] == .dynamic_import) continue;
                 c.markFileLiveForTreeShaking(
                     entry_point,
                     side_effects,
@@ -592,6 +595,16 @@ pub const LinkerContext = struct {
                     entry_point_kinds,
                     css_reprs,
                 );
+            }
+
+            // Demote dynamic-import entry points whose import() call sites were
+            // all in dead code. This prevents chunk generation for unreachable
+            // dynamic targets.
+            if (c.graph.code_splitting) {
+                for (entry_points) |ep| {
+                    if (entry_point_kinds[ep] == .dynamic_import and !c.graph.live_dynamic_import_targets.isSet(ep))
+                        entry_point_kinds[ep] = .none;
+                }
             }
         }
 
@@ -615,6 +628,7 @@ pub const LinkerContext = struct {
             // between live parts within the same file. All liveness has to be computed
             // first before determining which entry points can reach which files.
             for (entry_points, 0..) |entry_point, i| {
+                if (!entry_point_kinds[entry_point].isEntryPoint()) continue;
                 c.markFileReachableForCodeSplitting(
                     entry_point,
                     i,
@@ -1849,6 +1863,17 @@ pub const LinkerContext = struct {
                 entry_point_kinds,
                 css_reprs,
             );
+        }
+
+        // Follow dynamic imports: if this live part contains an import() call,
+        // the target file must also be live.
+        for (part.import_record_indices.slice()) |import_record_index| {
+            const record = import_records[source_index].at(import_record_index);
+            if (record.kind == .dynamic and record.source_index.isValid()) {
+                const target = record.source_index.get();
+                c.graph.live_dynamic_import_targets.set(target);
+                c.markFileLiveForTreeShaking(target, side_effects, parts, import_records, entry_point_kinds, css_reprs);
+            }
         }
     }
 

--- a/src/bundler/LinkerGraph.zig
+++ b/src/bundler/LinkerGraph.zig
@@ -4,6 +4,9 @@ const debug = Output.scoped(.LinkerGraph, .visible);
 
 files: File.List = .{},
 files_live: BitSet = undefined,
+/// Tracks which dynamic import targets are referenced by live import() calls.
+/// Used to demote dynamic-import entry points whose call sites are dead.
+live_dynamic_import_targets: BitSet = .{},
 entry_points: EntryPoint.List = .{},
 symbols: js_ast.Symbol.Map = .{},
 
@@ -39,6 +42,7 @@ pub fn init(allocator: std.mem.Allocator, file_count: usize) !LinkerGraph {
     return LinkerGraph{
         .allocator = allocator,
         .files_live = try BitSet.initEmpty(allocator, file_count),
+        .live_dynamic_import_targets = try BitSet.initEmpty(allocator, file_count),
     };
 }
 
@@ -232,6 +236,10 @@ pub fn load(
     try this.files.setCapacity(this.allocator, sources.len);
     this.files.zero();
     this.files_live = try BitSet.initEmpty(
+        this.allocator,
+        sources.len,
+    );
+    this.live_dynamic_import_targets = try BitSet.initEmpty(
         this.allocator,
         sources.len,
     );

--- a/src/bundler/linker_context/computeChunks.zig
+++ b/src/bundler/linker_context/computeChunks.zig
@@ -29,10 +29,15 @@ pub noinline fn computeChunks(
     const code_splitting = this.graph.code_splitting;
     const could_be_browser_target_from_server_build = this.options.target.isServerSide() and this.parse_graph.html_imports.html_source_indices.len > 0;
     const has_server_html_imports = this.parse_graph.html_imports.server_source_indices.len > 0;
+    const entry_point_kinds = this.graph.files.items(.entry_point_kind);
 
     // Create chunks for entry points
     for (entry_source_indices, 0..) |source_index, entry_id_| {
         const entry_bit = @as(Chunk.EntryPoint.ID, @truncate(entry_id_));
+
+        // Skip dynamic-import entry points that were demoted during tree-shaking
+        // because their import() call sites were in dead code.
+        if (!entry_point_kinds[source_index].isEntryPoint()) continue;
 
         var entry_bits = &this.graph.files.items(.entry_bits)[source_index];
         entry_bits.set(entry_bit);

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -1,5 +1,6 @@
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
 import { bunEnv } from "harness";
+import { readdirSync } from "node:fs";
 import { itBundled } from "./expectBundled";
 
 const env = {
@@ -321,6 +322,170 @@ describe("bundler", () => {
       file: "/out/entry.js",
       env,
       stdout: "a.js executed\na loaded from entry\nb.js executed\nb.js imports a {}\nb loaded from entry, value: B",
+    },
+  });
+
+  // Orphan chunk DCE: when all `import()` call sites for a dynamic chunk are
+  // removed by tree-shaking, the chunk itself should not be emitted.
+
+  itBundled("splitting/OrphanChunkDCE_NeverCalled", {
+    files: {
+      "/entry.ts": /* ts */ `
+        async function dead() { return await import('./secret.ts') }
+        console.log('done')
+      `,
+      "/secret.ts": `export const SECRET = 'this_should_not_be_in_output'`,
+    },
+    entryPoints: ["/entry.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    target: "bun",
+    minifySyntax: true,
+    treeShaking: true,
+    run: { stdout: "done" },
+    onAfterBundle(api) {
+      const files = readdirSync(api.outdir);
+      expect(files).toEqual(["entry.js"]);
+      expect(api.readFile("/out/entry.js")).not.toContain("this_should_not_be_in_output");
+    },
+  });
+
+  itBundled("splitting/OrphanChunkDCE_DefineFalse", {
+    files: {
+      "/entry.ts": /* ts */ `
+        async function loadSecret() { return await import('./secret.ts') }
+        if (process.env.GATE === 'on') {
+          const m = await loadSecret()
+          console.log(m.SECRET)
+        }
+        console.log('done')
+      `,
+      "/secret.ts": `export const SECRET = 'this_should_not_be_in_output'`,
+    },
+    entryPoints: ["/entry.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    target: "bun",
+    minifySyntax: true,
+    treeShaking: true,
+    define: { "process.env.GATE": '"off"' },
+    run: { stdout: "done" },
+    onAfterBundle(api) {
+      const files = readdirSync(api.outdir);
+      expect(files).toEqual(["entry.js"]);
+      expect(api.readFile("/out/entry.js")).not.toContain("this_should_not_be_in_output");
+    },
+  });
+
+  itBundled("splitting/OrphanChunkDCE_DefineTrueKeepsChunk", {
+    files: {
+      "/entry.ts": /* ts */ `
+        async function loadSecret() { return await import('./secret.ts') }
+        if (process.env.GATE === 'on') {
+          const m = await loadSecret()
+          console.log(m.SECRET)
+        }
+        console.log('done')
+      `,
+      "/secret.ts": `export const SECRET = 'secret_value_present'`,
+    },
+    entryPoints: ["/entry.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    target: "bun",
+    minifySyntax: true,
+    treeShaking: true,
+    define: { "process.env.GATE": '"on"' },
+    run: { stdout: "secret_value_present\ndone" },
+    onAfterBundle(api) {
+      const files = readdirSync(api.outdir).sort();
+      const secretChunk = files.find(f => f.startsWith("secret-"));
+      expect(secretChunk).toBeDefined();
+      expect(api.readFile("/out/entry.js")).toContain(`import("./${secretChunk}")`);
+    },
+  });
+
+  itBundled("splitting/OrphanChunkDCE_TransitiveChainDead", {
+    files: {
+      "/entry.ts": /* ts */ `
+        async function loadA() { return await import('./a.ts') }
+        console.log('done')
+      `,
+      "/a.ts": /* ts */ `
+        export async function loadB() { return await import('./b.ts') }
+        export const A = 'chain_a_value'
+      `,
+      "/b.ts": `export const B = 'chain_b_value'`,
+    },
+    entryPoints: ["/entry.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    target: "bun",
+    minifySyntax: true,
+    treeShaking: true,
+    run: { stdout: "done" },
+    onAfterBundle(api) {
+      const files = readdirSync(api.outdir);
+      expect(files).toEqual(["entry.js"]);
+      const entry = api.readFile("/out/entry.js");
+      expect(entry).not.toContain("chain_a_value");
+      expect(entry).not.toContain("chain_b_value");
+    },
+  });
+
+  itBundled("splitting/OrphanChunkDCE_TransitiveChainLive", {
+    files: {
+      "/entry.ts": /* ts */ `
+        const a = await import('./a.ts')
+        const b = await a.loadB()
+        console.log(a.A, b.B)
+      `,
+      "/a.ts": /* ts */ `
+        export async function loadB() { return await import('./b.ts') }
+        export const A = 'chain_a_live'
+      `,
+      "/b.ts": `export const B = 'chain_b_live'`,
+    },
+    entryPoints: ["/entry.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    target: "bun",
+    minifySyntax: true,
+    treeShaking: true,
+    run: { stdout: "chain_a_live chain_b_live" },
+    onAfterBundle(api) {
+      const files = readdirSync(api.outdir).sort();
+      expect(files.some(f => f.startsWith("a-"))).toBe(true);
+      expect(files.some(f => f.startsWith("b-"))).toBe(true);
+    },
+  });
+
+  itBundled("splitting/OrphanChunkDCE_StaticImportPlusDeadDynamic", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { SECRET } from './secret.ts'
+        async function dead() { return await import('./secret.ts') }
+        console.log(SECRET)
+      `,
+      "/secret.ts": `export const SECRET = 'inlined_secret'`,
+    },
+    entryPoints: ["/entry.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    target: "bun",
+    minifySyntax: true,
+    treeShaking: true,
+    run: { stdout: "inlined_secret" },
+    onAfterBundle(api) {
+      const files = readdirSync(api.outdir);
+      expect(files).toEqual(["entry.js"]);
+      expect(api.readFile("/out/entry.js")).toContain("inlined_secret");
     },
   });
 });


### PR DESCRIPTION
## Summary

Follows up on the feedback from #27836 — the fix is now earlier in the pipeline: dynamic import targets are no longer treated as tree-shaking roots, so chunks for dead `import()` calls are never generated in the first place.

- **Root cause**: `findReachableFiles` promoted all dynamic import targets to entry points before tree-shaking. Tree-shaking treated all entry points as roots, so dead `import()` call sites (inside never-called functions or `--define`-gated dead branches) still produced chunks.
- **Fix**: Skip `.dynamic_import` entry points from the initial tree-shaking root set. During `markPartLiveForTreeShaking`, follow dynamic import records from live parts to mark their targets live. After tree-shaking, demote dynamic entries that were never reached — they are skipped in `markFileReachableForCodeSplitting` and `computeChunks`.

## Changes

- `LinkerGraph.zig`: Add `live_dynamic_import_targets` BitSet to track which dynamic import targets are actually referenced by live code
- `LinkerContext.zig`: Skip `.dynamic_import` entries as tree-shaking roots; follow dynamic import records from live parts; demote unreached entries
- `computeChunks.zig`: Skip demoted (non-entry-point) entries during chunk creation
- `bundler_splitting.test.ts`: 6 new tests covering dead/live dynamic import scenarios

## Test plan

- [x] `USE_SYSTEM_BUN=1 bun test` → 4/6 new tests fail (expected; the 2 "live" tests correctly pass on both)
- [x] `bun bd test` → all 6 new tests pass
- [x] All 10 existing splitting tests still pass

https://claude.ai/code/session_012ma6eQ8WLae1FccuqGjovu