### PR TITLE
`--path-ignore-patterns` to exclude tests

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -177,6 +177,17 @@ Same as the top-level `preload` field, but only applies to `bun test`.
 preload = ["./setup.ts"]
 ```
 
+### `test.pathIgnorePatterns`
+
+Exclude files and directories from test discovery using glob patterns. Matched directories are pruned during scanning, so their contents are never traversed. This is useful when your project contains submodules or vendored code with `*.test.ts` files that you don't want `bun test` to pick up.
+
+```toml title="bunfig.toml" icon="settings"
+[test]
+pathIgnorePatterns = ["vendor/**", "submodules/**", "fixtures/**"]
+```
+
+Equivalent CLI flag: `--path-ignore-patterns`. CLI flags override the `bunfig.toml` value entirely.
+
 ### `test.smol`
 
 Same as the top-level `smol` field, but only applies to `bun test`.

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -91,6 +91,59 @@ mock.module("./external-api", () => ({
 }));
 ```
 
+### Path Ignore Patterns
+
+Exclude files and directories from test discovery entirely using glob patterns. Unlike `coveragePathIgnorePatterns` which only affects coverage reports, `pathIgnorePatterns` prevents matching paths from being discovered and run as tests.
+
+This is useful when your project contains submodules, vendored code, or other directories with `*.test.ts` files that you don't want `bun test` to pick up.
+
+```toml title="bunfig.toml" icon="settings"
+[test]
+# Single pattern
+pathIgnorePatterns = "vendor/**"
+
+# Multiple patterns
+pathIgnorePatterns = [
+  "vendor/**",
+  "submodules/**",
+  "fixtures/**"
+]
+```
+
+This is equivalent to using `--path-ignore-patterns` on the command line:
+
+```bash terminal icon="terminal"
+bun test --path-ignore-patterns 'vendor/**' --path-ignore-patterns 'fixtures/**'
+```
+
+Directories matching a pattern are pruned during scanning, so their contents are never traversed. This means ignoring a large directory tree is efficient -- Bun won't spend time reading files inside it.
+
+#### Common Use Cases
+
+```toml title="bunfig.toml" icon="settings"
+[test]
+pathIgnorePatterns = [
+  # Git submodules with their own test suites
+  "submodules/**",
+
+  # Vendored dependencies
+  "vendor/**",
+  "third-party/**",
+
+  # Test fixtures that look like tests but aren't
+  "fixtures/**",
+  "**/test-data/**",
+
+  # Integration / E2E tests you want to run separately
+  "**/integration/**",
+  "e2e/**"
+]
+```
+
+<Note>
+  Command-line `--path-ignore-patterns` flags override the `bunfig.toml` value entirely -- the two are not merged.
+</Note>
+
 ## Timeouts
 
 ### Default Timeout
@@ -415,6 +468,7 @@ exact = true
 # Test discovery
 root = "src"
 preload = ["./test-setup.ts", "./global-mocks.ts"]
+pathIgnorePatterns = ["vendor/**", "submodules/**"]
 
 # Execution settings
 timeout = 10000

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -485,8 +485,8 @@ pub const Bunfig = struct {
                     }
 
                     if (test_.get("pathIgnorePatterns")) |expr| brk: {
-                        // CLI --path-ignore-patterns overrides bunfig
-                        if (this.ctx.test_options.path_ignore_patterns.len > 0) break :brk;
+                        // Only skip if --path-ignore-patterns was explicitly passed via CLI
+                        if (this.ctx.test_options.path_ignore_patterns_from_cli) break :brk;
 
                         switch (expr.data) {
                             .e_string => |str| {

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -483,6 +483,37 @@ pub const Bunfig = struct {
                             },
                         }
                     }
+
+                    if (test_.get("pathIgnorePatterns")) |expr| brk: {
+                        // CLI --path-ignore-patterns overrides bunfig
+                        if (this.ctx.test_options.path_ignore_patterns.len > 0) break :brk;
+
+                        switch (expr.data) {
+                            .e_string => |str| {
+                                const pattern = try str.string(allocator);
+                                const patterns = try allocator.alloc(string, 1);
+                                patterns[0] = pattern;
+                                this.ctx.test_options.path_ignore_patterns = patterns;
+                            },
+                            .e_array => |arr| {
+                                if (arr.items.len == 0) break :brk;
+
+                                const patterns = try allocator.alloc(string, arr.items.len);
+                                for (arr.items.slice(), 0..) |item, i| {
+                                    if (item.data != .e_string) {
+                                        try this.addError(item.loc, "pathIgnorePatterns array must contain only strings");
+                                        return;
+                                    }
+                                    patterns[i] = try item.data.e_string.string(allocator);
+                                }
+                                this.ctx.test_options.path_ignore_patterns = patterns;
+                            },
+                            else => {
+                                try this.addError(expr.loc, "pathIgnorePatterns must be a string or array of strings");
+                                return;
+                            },
+                        }
+                    }
                 }
             }
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -352,6 +352,7 @@ pub const Command = struct {
         concurrent_test_glob: ?[]const []const u8 = null,
         bail: u32 = 0,
         coverage: TestCommand.CodeCoverageOptions = .{},
+        path_ignore_patterns: []const []const u8 = &.{},
         test_filter_pattern: ?[]const u8 = null,
         test_filter_regex: ?*RegularExpression = null,
         max_concurrency: u32 = 20,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -353,6 +353,7 @@ pub const Command = struct {
         bail: u32 = 0,
         coverage: TestCommand.CodeCoverageOptions = .{},
         path_ignore_patterns: []const []const u8 = &.{},
+        path_ignore_patterns_from_cli: bool = false,
         test_filter_pattern: ?[]const u8 = null,
         test_filter_regex: ?*RegularExpression = null,
         max_concurrency: u32 = 20,

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -548,6 +548,7 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
 
         if (args.options("--path-ignore-patterns").len > 0) {
             ctx.test_options.path_ignore_patterns = args.options("--path-ignore-patterns");
+            ctx.test_options.path_ignore_patterns_from_cli = true;
         }
 
         if (args.option("--bail")) |bail| {

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -239,6 +239,7 @@ pub const test_only_params = [_]ParamType{
     clap.parseParam("--dots                           Enable dots reporter. Shorthand for --reporter=dots.") catch unreachable,
     clap.parseParam("--only-failures                  Only display test failures, hiding passing tests.") catch unreachable,
     clap.parseParam("--max-concurrency <NUMBER>        Maximum number of concurrent tests to execute at once. Default is 20.") catch unreachable,
+    clap.parseParam("--path-ignore-patterns <STR>...   Glob patterns for test file paths to ignore.") catch unreachable,
 };
 pub const test_params = test_only_params ++ runtime_params_ ++ transpiler_params_ ++ base_params_;
 
@@ -543,6 +544,10 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
 
         if (args.option("--coverage-dir")) |dir| {
             ctx.test_options.coverage.reports_directory = dir;
+        }
+
+        if (args.options("--path-ignore-patterns").len > 0) {
+            ctx.test_options.path_ignore_patterns = args.options("--path-ignore-patterns");
         }
 
         if (args.option("--bail")) |bail| {

--- a/src/cli/test/Scanner.zig
+++ b/src/cli/test/Scanner.zig
@@ -5,6 +5,9 @@ exclusion_names: []const []const u8 = &.{},
 /// When this list is empty, no filters are applied.
 /// "test" suffixes (e.g. .spec.*) are always applied when traversing directories.
 filter_names: []const []const u8 = &.{},
+/// Glob patterns for paths to ignore. Matched against the path relative to the
+/// project root (top_level_dir). When a file matches any pattern, it is excluded.
+path_ignore_patterns: []const []const u8 = &.{},
 dirs_to_scan: Fifo,
 /// Paths to test files found while scanning.
 test_files: std.ArrayListUnmanaged(bun.PathString),
@@ -156,8 +159,19 @@ pub fn doesPathMatchFilter(this: *Scanner, name: []const u8) bool {
     return false;
 }
 
+/// Returns true if the given path matches any of the path ignore patterns.
+/// The path is matched as a relative path from the project root.
+pub fn matchesPathIgnorePattern(this: *Scanner, abs_path: []const u8) bool {
+    if (this.path_ignore_patterns.len == 0) return false;
+    const rel_path = bun.path.relative(this.fs.top_level_dir, abs_path);
+    for (this.path_ignore_patterns) |pattern| {
+        if (bun.glob.match(pattern, rel_path).matches()) return true;
+    }
+    return false;
+}
+
 pub fn isTestFile(this: *Scanner, name: []const u8) bool {
-    return this.couldBeTestFile(name, false) and this.doesPathMatchFilter(name);
+    return this.couldBeTestFile(name, false) and this.doesPathMatchFilter(name) and !this.matchesPathIgnorePattern(name);
 }
 
 pub fn next(this: *Scanner, entry: *FileSystem.Entry, fd: bun.StoredFileDescriptorType) void {
@@ -174,6 +188,13 @@ pub fn next(this: *Scanner, entry: *FileSystem.Entry, fd: bun.StoredFileDescript
 
             for (this.exclusion_names) |exclude_name| {
                 if (strings.eql(exclude_name, name)) return;
+            }
+
+            // Prune ignored directory trees early so we never traverse them.
+            if (this.path_ignore_patterns.len > 0) {
+                const parts = &[_][]const u8{ entry.dir, entry.base() };
+                const dir_path = this.fs.absBuf(parts, &this.open_dir_buf);
+                if (this.matchesPathIgnorePattern(dir_path)) return;
             }
 
             this.search_count += 1;
@@ -198,6 +219,8 @@ pub fn next(this: *Scanner, entry: *FileSystem.Entry, fd: bun.StoredFileDescript
                 const rel_path = bun.path.relative(this.fs.top_level_dir, path);
                 if (!this.doesPathMatchFilter(rel_path)) return;
             }
+
+            if (this.matchesPathIgnorePattern(path)) return;
 
             entry.abs_path = bun.PathString.init(this.fs.filename_store.append(@TypeOf(path), path) catch unreachable);
             this.test_files.append(this.allocator(), entry.abs_path) catch unreachable;

--- a/src/cli/test/Scanner.zig
+++ b/src/cli/test/Scanner.zig
@@ -166,6 +166,16 @@ pub fn matchesPathIgnorePattern(this: *Scanner, abs_path: []const u8) bool {
     const rel_path = bun.path.relative(this.fs.top_level_dir, abs_path);
     for (this.path_ignore_patterns) |pattern| {
         if (bun.glob.match(pattern, rel_path).matches()) return true;
+        // Also try with a trailing separator so directory paths match
+        // patterns like "vendor/**".
+        if (rel_path.len > 0 and rel_path[rel_path.len - 1] != '/') {
+            var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
+            if (rel_path.len < buf.len) {
+                @memcpy(buf[0..rel_path.len], rel_path);
+                buf[rel_path.len] = '/';
+                if (bun.glob.match(pattern, buf[0 .. rel_path.len + 1]).matches()) return true;
+            }
+        }
     }
     return false;
 }

--- a/src/cli/test/Scanner.zig
+++ b/src/cli/test/Scanner.zig
@@ -166,14 +166,17 @@ pub fn matchesPathIgnorePattern(this: *Scanner, abs_path: []const u8) bool {
     const rel_path = bun.path.relative(this.fs.top_level_dir, abs_path);
     for (this.path_ignore_patterns) |pattern| {
         if (bun.glob.match(pattern, rel_path).matches()) return true;
-        // Also try with a trailing separator so directory paths match
-        // patterns like "vendor/**".
-        if (rel_path.len > 0 and rel_path[rel_path.len - 1] != '/') {
-            var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-            if (rel_path.len < buf.len) {
-                @memcpy(buf[0..rel_path.len], rel_path);
-                buf[rel_path.len] = '/';
-                if (bun.glob.match(pattern, buf[0 .. rel_path.len + 1]).matches()) return true;
+        // Only try trailing separator for ** patterns (e.g. "vendor/**").
+        // Single-star patterns like "vendor/*" must not prune entire
+        // directories because * doesn't cross directory boundaries.
+        if (strings.indexOf(pattern, "**") != null) {
+            if (rel_path.len > 0 and rel_path[rel_path.len - 1] != '/') {
+                var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
+                if (rel_path.len < buf.len) {
+                    @memcpy(buf[0..rel_path.len], rel_path);
+                    buf[rel_path.len] = '/';
+                    if (bun.glob.match(pattern, buf[0 .. rel_path.len + 1]).matches()) return true;
+                }
             }
         }
     }

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1465,6 +1465,7 @@ pub const TestCommand = struct {
 
         var scanner = bun.handleOom(Scanner.init(ctx.allocator, &vm.transpiler, ctx.positionals.len));
         defer scanner.deinit();
+        scanner.path_ignore_patterns = ctx.test_options.path_ignore_patterns;
         const has_relative_path = for (ctx.positionals) |arg| {
             if (std.fs.path.isAbsolute(arg) or
                 strings.startsWith(arg, "./") or

--- a/test/cli/test/path-ignore-patterns.test.ts
+++ b/test/cli/test/path-ignore-patterns.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+describe("pathIgnorePatterns", () => {
+  test("bunfig - single pattern string", () => {
+    const dir = tempDirWithFiles("path-ignore", {
+      "bunfig.toml": `
+[test]
+pathIgnorePatterns = "ignore-me.test.ts"
+`,
+      "include-me.test.ts": `
+import { test, expect } from "bun:test";
+test("included test", () => {
+  expect(1).toBe(1);
+});
+`,
+      "ignore-me.test.ts": `
+import { test, expect } from "bun:test";
+test("ignored test", () => {
+  expect(1).toBe(1);
+});
+`,
+    });
+
+    const result = Bun.spawnSync([bunExe(), "test"], {
+      cwd: dir,
+      env: bunEnv,
+      stdio: [null, null, "pipe"],
+    });
+
+    const stderr = result.stderr.toString("utf-8");
+    expect(stderr).toContain("include-me.test.ts");
+    expect(stderr).not.toContain("ignore-me.test.ts");
+    expect(stderr).toContain("1 pass");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("bunfig - array of patterns", () => {
+    const dir = tempDirWithFiles("path-ignore", {
+      "bunfig.toml": `
+[test]
+pathIgnorePatterns = ["helpers/**", "*.setup.test.ts"]
+`,
+      "main.test.ts": `
+import { test, expect } from "bun:test";
+test("main test", () => {
+  expect(1).toBe(1);
+});
+`,
+      "helpers/util.test.ts": `
+import { test, expect } from "bun:test";
+test("helper test", () => {
+  expect(1).toBe(1);
+});
+`,
+      "db.setup.test.ts": `
+import { test, expect } from "bun:test";
+test("setup test", () => {
+  expect(1).toBe(1);
+});
+`,
+    });
+
+    const result = Bun.spawnSync([bunExe(), "test"], {
+      cwd: dir,
+      env: bunEnv,
+      stdio: [null, null, "pipe"],
+    });
+
+    const stderr = result.stderr.toString("utf-8");
+    expect(stderr).toContain("main.test.ts");
+    expect(stderr).not.toContain("helpers");
+    expect(stderr).not.toContain("db.setup.test.ts");
+    expect(stderr).toContain("1 pass");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("bunfig - glob pattern with **", () => {
+    const dir = tempDirWithFiles("path-ignore", {
+      "bunfig.toml": `
+[test]
+pathIgnorePatterns = "**/integration/**"
+`,
+      "unit/math.test.ts": `
+import { test, expect } from "bun:test";
+test("unit test", () => {
+  expect(1 + 1).toBe(2);
+});
+`,
+      "integration/api.test.ts": `
+import { test, expect } from "bun:test";
+test("integration test", () => {
+  expect(true).toBe(true);
+});
+`,
+    });
+
+    const result = Bun.spawnSync([bunExe(), "test"], {
+      cwd: dir,
+      env: bunEnv,
+      stdio: [null, null, "pipe"],
+    });
+
+    const stderr = result.stderr.toString("utf-8");
+    expect(stderr).toContain("unit/math.test.ts");
+    expect(stderr).not.toContain("integration");
+    expect(stderr).toContain("1 pass");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("CLI flag - single pattern", () => {
+    const dir = tempDirWithFiles("path-ignore", {
+      "keep.test.ts": `
+import { test, expect } from "bun:test";
+test("kept test", () => {
+  expect(1).toBe(1);
+});
+`,
+      "skip.test.ts": `
+import { test, expect } from "bun:test";
+test("skipped test", () => {
+  expect(1).toBe(1);
+});
+`,
+    });
+
+    const result = Bun.spawnSync([bunExe(), "test", "--path-ignore-patterns", "skip.test.ts"], {
+      cwd: dir,
+      env: bunEnv,
+      stdio: [null, null, "pipe"],
+    });
+
+    const stderr = result.stderr.toString("utf-8");
+    expect(stderr).toContain("keep.test.ts");
+    expect(stderr).not.toContain("skip.test.ts");
+    expect(stderr).toContain("1 pass");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("CLI flag - multiple patterns", () => {
+    const dir = tempDirWithFiles("path-ignore", {
+      "app.test.ts": `
+import { test, expect } from "bun:test";
+test("app test", () => {
+  expect(1).toBe(1);
+});
+`,
+      "e2e/login.test.ts": `
+import { test, expect } from "bun:test";
+test("e2e test", () => {
+  expect(1).toBe(1);
+});
+`,
+      "fixtures/data.test.ts": `
+import { test, expect } from "bun:test";
+test("fixture test", () => {
+  expect(1).toBe(1);
+});
+`,
+    });
+
+    const result = Bun.spawnSync(
+      [bunExe(), "test", "--path-ignore-patterns", "e2e/**", "--path-ignore-patterns", "fixtures/**"],
+      {
+        cwd: dir,
+        env: bunEnv,
+        stdio: [null, null, "pipe"],
+      },
+    );
+
+    const stderr = result.stderr.toString("utf-8");
+    expect(stderr).toContain("app.test.ts");
+    expect(stderr).not.toContain("e2e");
+    expect(stderr).not.toContain("fixtures");
+    expect(stderr).toContain("1 pass");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("bunfig - invalid config type", () => {
+    const dir = tempDirWithFiles("path-ignore", {
+      "bunfig.toml": `
+[test]
+pathIgnorePatterns = 123
+`,
+      "test.test.ts": `
+import { test, expect } from "bun:test";
+test("should pass", () => {
+  expect(true).toBe(true);
+});
+`,
+    });
+
+    const result = Bun.spawnSync([bunExe(), "test"], {
+      cwd: dir,
+      env: bunEnv,
+      stdio: [null, null, "pipe"],
+    });
+
+    const stderr = result.stderr.toString("utf-8");
+    expect(stderr).toContain("pathIgnorePatterns must be a string or array of strings");
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("bunfig - invalid array item", () => {
+    const dir = tempDirWithFiles("path-ignore", {
+      "bunfig.toml": `
+[test]
+pathIgnorePatterns = ["valid-pattern", 123]
+`,
+      "test.test.ts": `
+import { test, expect } from "bun:test";
+test("should pass", () => {
+  expect(true).toBe(true);
+});
+`,
+    });
+
+    const result = Bun.spawnSync([bunExe(), "test"], {
+      cwd: dir,
+      env: bunEnv,
+      stdio: [null, null, "pipe"],
+    });
+
+    const stderr = result.stderr.toString("utf-8");
+    expect(stderr).toContain("pathIgnorePatterns array must contain only strings");
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("bunfig - empty array is a no-op", () => {
+    const dir = tempDirWithFiles("path-ignore", {
+      "bunfig.toml": `
+[test]
+pathIgnorePatterns = []
+`,
+      "test.test.ts": `
+import { test, expect } from "bun:test";
+test("should pass", () => {
+  expect(true).toBe(true);
+});
+`,
+    });
+
+    const result = Bun.spawnSync([bunExe(), "test"], {
+      cwd: dir,
+      env: bunEnv,
+      stdio: [null, null, "pipe"],
+    });
+
+    const stderr = result.stderr.toString("utf-8");
+    expect(stderr).toContain("test.test.ts");
+    expect(stderr).toContain("1 pass");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("CLI flag overrides bunfig", () => {
+    const dir = tempDirWithFiles("path-ignore", {
+      "bunfig.toml": `
+[test]
+pathIgnorePatterns = "a.test.ts"
+`,
+      "a.test.ts": `
+import { test, expect } from "bun:test";
+test("a test", () => {
+  expect(1).toBe(1);
+});
+`,
+      "b.test.ts": `
+import { test, expect } from "bun:test";
+test("b test", () => {
+  expect(1).toBe(1);
+});
+`,
+    });
+
+    // CLI flag should override bunfig: ignore b.test.ts instead of a.test.ts
+    const result = Bun.spawnSync([bunExe(), "test", "--path-ignore-patterns", "b.test.ts"], {
+      cwd: dir,
+      env: bunEnv,
+      stdio: [null, null, "pipe"],
+    });
+
+    const stderr = result.stderr.toString("utf-8");
+    // CLI patterns override bunfig patterns, so a.test.ts should be included
+    // and b.test.ts should be ignored
+    expect(stderr).toContain("a.test.ts");
+    expect(stderr).not.toContain("b.test.ts");
+    expect(stderr).toContain("1 pass");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("bare directory name pattern prunes entire subtree", () => {
+    const dir = tempDirWithFiles("path-ignore", {
+      "root.test.ts": `
+import { test, expect } from "bun:test";
+test("root test", () => {
+  expect(1).toBe(1);
+});
+`,
+      "ignored/deep.test.ts": `
+import { test, expect } from "bun:test";
+test("deep ignored test", () => {
+  expect(1).toBe(1);
+});
+`,
+      "ignored/nested/deeper.test.ts": `
+import { test, expect } from "bun:test";
+test("deeper ignored test", () => {
+  expect(1).toBe(1);
+});
+`,
+    });
+
+    // A bare directory name (no "/**") should prune the directory at scan time,
+    // preventing any tests inside it from running.
+    const result = Bun.spawnSync([bunExe(), "test", "--path-ignore-patterns", "ignored"], {
+      cwd: dir,
+      env: bunEnv,
+      stdio: [null, null, "pipe"],
+    });
+
+    const stderr = result.stderr.toString("utf-8");
+    expect(stderr).toContain("root.test.ts");
+    expect(stderr).not.toContain("deep.test.ts");
+    expect(stderr).not.toContain("deeper.test.ts");
+    expect(stderr).toContain("1 pass");
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/test/cli/test/path-ignore-patterns.test.ts
+++ b/test/cli/test/path-ignore-patterns.test.ts
@@ -102,7 +102,7 @@ test("integration test", () => {
     });
 
     const stderr = result.stderr.toString("utf-8");
-    expect(stderr).toContain("unit/math.test.ts");
+    expect(stderr).toContain("math.test.ts");
     expect(stderr).not.toContain("integration");
     expect(stderr).toContain("1 pass");
     expect(result.exitCode).toBe(0);


### PR DESCRIPTION
### What does this PR do?

Picked up from #27452 by @ctjlewis (requested by @alii in https://github.com/oven-sh/bun/pull/27452#issuecomment-4059886598) so CI runs automatically and the autofixer works.

All commits preserve original authorship (Lewis <lewis@spellcraft.org>).

---

Adds `--path-ignore-patterns` argument and Bunfig option similar to `--coverage-path-ignore-patterns`.

https://bun.com/docs/test/configuration#coverage-path-ignore-patterns

- Closes #27388
- Closes #21395
- Closes #13963

### How did you verify your code works?

Tests in `test/cli/test/path-ignore-patterns.test.ts` (328 lines).

### Docs

Simple docs added for Bunfig and Configuration docs.

### Verification

Buildkite #39573 on `1a1af82`: only CI failure is a snapshot mismatch in `test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts` (111 passed, 1 failed snapshot) — completely unrelated to this PR. Main branch also failing on all recent commits (builds #39449, #39406, #39511, #39396). All 3 bot review threads resolved. Diff clean — no TODOs, changes scoped to bunfig parsing, CLI args, test scanner, docs, and tests. Ready for human review.

---
**Verification (robobun):** CI green (13/13 on `525b4dd`). Diff clean — no TODOs, changes well-scoped to bunfig parsing, CLI args, test scanner, docs, and tests. All 3 bot review threads resolved (coderabbit precedence fix applied, trailing-slash pruning restricted to `**` patterns). Feature PR — tests confirm baked binary lacks the feature (9 fail) while CI passes all platform suites.