### PR TITLE
Send security scanner JSON data via IPC pipe instead of CLI args

### DIFF
--- a/src/async/posix_event_loop.zig
+++ b/src/async/posix_event_loop.zig
@@ -149,6 +149,7 @@ pub const FilePoll = struct {
     const Subprocess = jsc.Subprocess;
     const StaticPipeWriter = Subprocess.StaticPipeWriter.Poll;
     const ShellStaticPipeWriter = bun.shell.ShellSubprocess.StaticPipeWriter.Poll;
+    const SecurityScanSubprocessStaticPipeWriter = bun.install.SecurityScanSubprocess.StaticPipeWriter.Poll;
     const FileSink = jsc.WebCore.FileSink.Poll;
     const TerminalPoll = bun.api.Terminal.Poll;
     const DNSResolver = bun.api.dns.Resolver;
@@ -171,6 +172,7 @@ pub const FilePoll = struct {
 
         StaticPipeWriter,
         ShellStaticPipeWriter,
+        SecurityScanSubprocessStaticPipeWriter,
 
         // ShellBufferedWriter,
 
@@ -371,6 +373,10 @@ pub const FilePoll = struct {
             },
             @field(Owner.Tag, @typeName(StaticPipeWriter)) => {
                 var handler: *StaticPipeWriter = ptr.as(StaticPipeWriter);
+                handler.onPoll(size_or_offset, poll.flags.contains(.hup));
+            },
+            @field(Owner.Tag, @typeName(SecurityScanSubprocessStaticPipeWriter)) => {
+                var handler: *SecurityScanSubprocessStaticPipeWriter = ptr.as(SecurityScanSubprocessStaticPipeWriter);
                 handler.onPoll(size_or_offset, poll.flags.contains(.hup));
             },
             @field(Owner.Tag, @typeName(FileSink)) => {

--- a/src/install/PackageManager/scanner-entry.ts
+++ b/src/install/PackageManager/scanner-entry.ts
@@ -31,19 +31,9 @@ function sendAndExit(message: IPCMessage): never {
 
 // Read packages JSON from fd 4 (reads until EOF when parent closes the pipe)
 let packages: Bun.Security.Package[];
-let packagesJson: string = "";
 
 try {
-  packagesJson = await Bun.file(IPC_INPUT_FD).text();
-} catch (error) {
-  sendAndExit({
-    type: "error",
-    code: "SCAN_FAILED",
-    message: `Failed to read packages from FD ${IPC_INPUT_FD}: ${error instanceof Error ? error.message : String(error)}`,
-  });
-}
-
-try {
+  const packagesJson = await Bun.file(IPC_INPUT_FD).text();
   packages = JSON.parse(packagesJson);
   if (!Array.isArray(packages)) {
     throw new Error("Expected packages to be an array");
@@ -52,7 +42,7 @@ try {
   sendAndExit({
     type: "error",
     code: "SCAN_FAILED",
-    message: `Failed to parse packages JSON: ${error instanceof Error ? error.message : String(error)}`,
+    message: `Failed to read or parse packages: ${error instanceof Error ? error.message : String(error)}`,
   });
 }
 

--- a/src/install/PackageManager/scanner-entry.ts
+++ b/src/install/PackageManager/scanner-entry.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 
 const scannerModuleName = "__SCANNER_MODULE__";
-const packages = __PACKAGES_JSON__;
 const suppressError = __SUPPRESS_ERROR__;
 
 type IPCMessage =
@@ -10,24 +9,51 @@ type IPCMessage =
   | { type: "error"; code: "INVALID_VERSION"; message: string }
   | { type: "error"; code: "SCAN_FAILED"; message: string };
 
-const IPC_PIPE_FD = 3;
+// Two pipes for IPC:
+// - fd 3: output - child writes response here
+// - fd 4: input - child reads JSON package list here (reads until EOF)
+const IPC_OUTPUT_FD = 3;
+const IPC_INPUT_FD = 4;
 
-function writeAndExit(message: IPCMessage): never {
+function sendAndExit(message: IPCMessage): never {
   const data = JSON.stringify(message);
-
   for (let remaining = data; remaining.length > 0; ) {
-    const written = fs.writeSync(IPC_PIPE_FD, remaining);
-
+    const written = fs.writeSync(IPC_OUTPUT_FD, remaining);
     if (written === 0) {
       console.error("Failed to write to IPC pipe");
       process.exit(1);
     }
     remaining = remaining.slice(written);
   }
-
-  fs.closeSync(IPC_PIPE_FD);
-
+  fs.closeSync(IPC_OUTPUT_FD);
   process.exit(message.type === "error" ? 1 : 0);
+}
+
+// Read packages JSON from fd 4 (reads until EOF when parent closes the pipe)
+let packages: Bun.Security.Package[];
+let packagesJson: string = "";
+
+try {
+  packagesJson = await Bun.file(IPC_INPUT_FD).text();
+} catch (error) {
+  sendAndExit({
+    type: "error",
+    code: "SCAN_FAILED",
+    message: `Failed to read packages from FD ${IPC_INPUT_FD}: ${error instanceof Error ? error.message : String(error)}`,
+  });
+}
+
+try {
+  packages = JSON.parse(packagesJson);
+  if (!Array.isArray(packages)) {
+    throw new Error("Expected packages to be an array");
+  }
+} catch (error) {
+  sendAndExit({
+    type: "error",
+    code: "SCAN_FAILED",
+    message: `Failed to parse packages JSON: ${error instanceof Error ? error.message : String(error)}`,
+  });
 }
 
 let scanner: Bun.Security.Scanner;
@@ -41,13 +67,13 @@ try {
       console.error(msg);
     }
 
-    writeAndExit({
+    sendAndExit({
       type: "error",
       code: "MODULE_NOT_FOUND",
       module: scannerModuleName,
     });
   } else {
-    writeAndExit({
+    sendAndExit({
       type: "error",
       code: "SCAN_FAILED",
       message: error instanceof Error ? error.message : String(error),
@@ -61,7 +87,7 @@ try {
   }
 
   if (scanner.version !== "1") {
-    writeAndExit({
+    sendAndExit({
       type: "error",
       code: "INVALID_VERSION",
       message: `Security scanner must be version 1, got version ${scanner.version}`,
@@ -78,13 +104,13 @@ try {
     throw new Error("Security scanner must return an array of advisories");
   }
 
-  writeAndExit({ type: "result", advisories: result });
+  sendAndExit({ type: "result", advisories: result });
 } catch (error) {
   if (!suppressError) {
     console.error(error);
   }
 
-  writeAndExit({
+  sendAndExit({
     type: "error",
     code: "SCAN_FAILED",
     message: error instanceof Error ? error.message : "Unknown error occurred",

--- a/src/install/PackageManager/security_scanner.zig
+++ b/src/install/PackageManager/security_scanner.zig
@@ -673,17 +673,6 @@ fn attemptSecurityScanWithRetry(manager: *PackageManager, security_scanner: []co
         temp_source = code.items;
     }
 
-    const packages_placeholder = "__PACKAGES_JSON__";
-    if (std.mem.indexOf(u8, temp_source, packages_placeholder)) |index| {
-        var new_code = std.array_list.Managed(u8).init(manager.allocator);
-        try new_code.appendSlice(temp_source[0..index]);
-        try new_code.appendSlice(json_data);
-        try new_code.appendSlice(temp_source[index + packages_placeholder.len ..]);
-        code.deinit();
-        code = new_code;
-        temp_source = code.items;
-    }
-
     const suppress_placeholder = "__SUPPRESS_ERROR__";
     if (std.mem.indexOf(u8, temp_source, suppress_placeholder)) |index| {
         var new_code = std.array_list.Managed(u8).init(manager.allocator);
@@ -736,21 +725,15 @@ pub const SecurityScanSubprocess = struct {
     has_received_ipc: bool = false,
     exit_status: ?bun.spawn.Status = null,
     remaining_fds: i8 = 0,
+    stdin_writer: ?*StaticPipeWriter = null,
 
     pub const new = bun.TrivialNew(@This());
+    pub const StaticPipeWriter = jsc.Subprocess.NewStaticPipeWriter(@This());
 
     pub fn spawn(this: *SecurityScanSubprocess) !void {
         this.ipc_data = std.array_list.Managed(u8).init(this.manager.allocator);
         this.stderr_data = std.array_list.Managed(u8).init(this.manager.allocator);
         this.ipc_reader.setParent(this);
-
-        const pipe_result = bun.sys.pipe();
-        const pipe_fds = switch (pipe_result) {
-            .err => {
-                return error.IPCPipeFailed;
-            },
-            .result => |fds| fds,
-        };
 
         const exec_path = try bun.selfExePath();
 
@@ -768,34 +751,143 @@ pub const SecurityScanSubprocess = struct {
 
         const spawn_cwd = FileSystem.instance.top_level_dir;
 
+        if (comptime Environment.isWindows) {
+            try this.spawnWindows(&argv, spawn_cwd);
+        } else {
+            try this.spawnPosix(&argv, spawn_cwd);
+        }
+    }
+
+    fn spawnPosix(this: *SecurityScanSubprocess, argv: *[5]?[*:0]const u8, spawn_cwd: []const u8) !void {
+        // Create a pipe for the child to write IPC response back to parent (fd 3)
+        const ipc_output_fds = switch (bun.sys.pipe()) {
+            .err => return error.IPCPipeFailed,
+            .result => |fds| fds,
+        };
+
+        const extra_fds = [_]bun.spawn.SpawnOptions.Stdio{
+            .{ .pipe = ipc_output_fds[1] }, // fd 3: child writes response here
+            .ipc, // fd 4: parent writes JSON data here (socketpair, closed after write = EOF)
+        };
+
         const spawn_options = bun.spawn.SpawnOptions{
             .stdout = .inherit,
             .stderr = .inherit,
             .stdin = .inherit,
             .cwd = spawn_cwd,
-            .extra_fds = &.{.{ .pipe = pipe_fds[1] }},
-            .windows = if (Environment.isWindows) .{
-                .loop = jsc.EventLoopHandle.init(&this.manager.event_loop),
+            .extra_fds = &extra_fds,
+        };
+
+        var spawned = try (try bun.spawn.spawnProcess(&spawn_options, @ptrCast(argv), @ptrCast(std.os.environ.ptr))).unwrap();
+
+        // Close the write end of the output pipe in the parent
+        ipc_output_fds[1].close();
+
+        // Get the fd for reading child's output and the socketpair fd for writing JSON
+        const ipc_read_fd = ipc_output_fds[0];
+        const json_write_fd = spawned.extra_pipes.items[1];
+
+        this.remaining_fds = 1;
+        _ = bun.sys.setNonblocking(ipc_read_fd);
+        this.ipc_reader.flags.nonblocking = true;
+        this.ipc_reader.flags.socket = false;
+        try this.ipc_reader.start(ipc_read_fd, true).unwrap();
+
+        // Set up process and write JSON data to child via the IPC pipe
+        var process = spawned.toProcess(&this.manager.event_loop, false);
+        this.process = process;
+        process.setExitHandler(this);
+
+        const json_data_copy = try this.manager.allocator.dupe(u8, this.json_data);
+        const json_source = jsc.Subprocess.Source{
+            .blob = jsc.WebCore.Blob.Any.fromOwnedSlice(this.manager.allocator, json_data_copy),
+        };
+
+        this.stdin_writer = StaticPipeWriter.create(&this.manager.event_loop, this, json_write_fd, json_source);
+        errdefer {
+            if (this.stdin_writer) |writer| {
+                writer.source.detach();
+                writer.deref();
+                this.stdin_writer = null;
+            }
+        }
+
+        switch (this.stdin_writer.?.start()) {
+            .err => |err| {
+                Output.errGeneric("Failed to start JSON pipe writer: {f}", .{err});
+                return error.JSONPipeWriterFailed;
+            },
+            .result => {},
+        }
+
+        switch (process.watchOrReap()) {
+            .err => {
+                return error.ProcessWatchFailed;
+            },
+            .result => {},
+        }
+    }
+
+    fn spawnWindows(this: *SecurityScanSubprocess, argv: *[5]?[*:0]const u8, spawn_cwd: []const u8) !void {
+        const uv = bun.windows.libuv;
+
+        // On Windows, we use two libuv pipes for IPC:
+        // - fd 3: child writes response → parent reads (buffer pipe)
+        // - fd 4: parent writes JSON → child reads (ipc pipe)
+        const output_pipe = try bun.default_allocator.create(uv.Pipe);
+        errdefer bun.default_allocator.destroy(output_pipe);
+
+        const input_pipe = try bun.default_allocator.create(uv.Pipe);
+        errdefer bun.default_allocator.destroy(input_pipe);
+
+        const extra_fds = [_]bun.spawn.SpawnOptions.Stdio{
+            .{ .buffer = output_pipe }, // fd 3: child writes response here
+            .{ .ipc = input_pipe }, // fd 4: parent writes JSON here
+        };
+
+        const spawn_options = bun.spawn.SpawnOptions{
+            .stdout = .inherit,
+            .stderr = .inherit,
+            .stdin = .inherit,
+            .cwd = spawn_cwd,
+            .extra_fds = &extra_fds,
+            .windows = .{
+                .loop = .{ .mini = &this.manager.event_loop.mini },
             },
         };
 
-        var spawned = try (try bun.spawn.spawnProcess(&spawn_options, @ptrCast(&argv), @ptrCast(std.os.environ.ptr))).unwrap();
+        var spawned = try (try bun.spawn.spawnProcess(&spawn_options, @ptrCast(argv), @ptrCast(std.os.environ.ptr))).unwrap();
 
-        pipe_fds[1].close();
+        const result_output_pipe = spawned.extra_pipes.items[0].buffer;
 
-        if (comptime bun.Environment.isPosix) {
-            _ = bun.sys.setNonblocking(pipe_fds[0]);
-        }
         this.remaining_fds = 1;
-        this.ipc_reader.flags.nonblocking = true;
-        if (comptime bun.Environment.isPosix) {
-            this.ipc_reader.flags.socket = false;
-        }
-        try this.ipc_reader.start(pipe_fds[0], true).unwrap();
+        try this.ipc_reader.startWithPipe(result_output_pipe).unwrap();
 
         var process = spawned.toProcess(&this.manager.event_loop, false);
         this.process = process;
         process.setExitHandler(this);
+
+        const json_data_copy = try this.manager.allocator.dupe(u8, this.json_data);
+        const json_source = jsc.Subprocess.Source{
+            .blob = jsc.WebCore.Blob.Any.fromOwnedSlice(this.manager.allocator, json_data_copy),
+        };
+
+        this.stdin_writer = StaticPipeWriter.create(&this.manager.event_loop, this, spawned.extra_pipes.items[1], json_source);
+        errdefer {
+            if (this.stdin_writer) |writer| {
+                writer.source.detach();
+                writer.deref();
+                this.stdin_writer = null;
+            }
+        }
+
+        switch (this.stdin_writer.?.start()) {
+            .err => |err| {
+                Output.errGeneric("Failed to start JSON pipe writer: {f}", .{err});
+                return error.JSONPipeWriterFailed;
+            },
+            .result => {},
+        }
 
         switch (process.watchOrReap()) {
             .err => {
@@ -807,6 +899,14 @@ pub const SecurityScanSubprocess = struct {
 
     pub fn isDone(this: *SecurityScanSubprocess) bool {
         return this.has_process_exited and this.remaining_fds == 0;
+    }
+
+    pub fn onCloseIO(this: *SecurityScanSubprocess, _: jsc.Subprocess.StdioKind) void {
+        if (this.stdin_writer) |writer| {
+            writer.source.detach();
+            writer.deref();
+            this.stdin_writer = null;
+        }
     }
 
     pub fn eventLoop(this: *const SecurityScanSubprocess) *jsc.AnyEventLoop {

--- a/test/cli/install/bun-install-security-provider.test.ts
+++ b/test/cli/install/bun-install-security-provider.test.ts
@@ -1,3 +1,5 @@
+import { file } from "bun";
+import { basename, join } from "path";
 import { bunEnv, runBunInstall } from "harness";
 import {
   dummyAfterAll,
@@ -680,4 +682,76 @@ describe("Package Resolution", () => {
       expect(out).toContain("Latest tag:");
     },
   });
+});
+
+describe("Large payload via IPC pipe", () => {
+  // Generate many package names so the JSON payload to the scanner exceeds
+  // the OS maximum argument length (~128KB on Linux). Each package entry in
+  // the JSON is ~120 bytes, so 1500 packages ≈ 180KB which is enough.
+  const NUM_PACKAGES = 1500;
+  const packageNames = Array.from({ length: NUM_PACKAGES }, (_, i) => `test-pkg-${i}`);
+
+  it(
+    "handles JSON data larger than max arg length",
+    async () => {
+      // Custom registry handler that serves bar-0.0.2.tgz for any package name
+      const barTgzPath = join(import.meta.dir, "bar-0.0.2.tgz");
+      setHandler(async (request: Request) => {
+        const url = request.url.replaceAll("%2f", "/");
+        if (url.endsWith(".tgz")) {
+          return new Response(file(barTgzPath));
+        }
+        // Extract package name from URL
+        const name = url.slice(url.indexOf("/", root_url.length) + 1);
+        return new Response(
+          JSON.stringify({
+            name,
+            versions: {
+              "0.0.2": {
+                name,
+                version: "0.0.2",
+                dist: { tarball: `${url}-0.0.2.tgz` },
+              },
+            },
+            "dist-tags": { latest: "0.0.2" },
+          }),
+        );
+      });
+
+      await write(
+        "./scanner.ts",
+        `export const scanner = {
+  version: "1",
+  scan: async ({ packages }) => {
+    const jsonSize = JSON.stringify(packages).length;
+    console.log("Received " + packages.length + " packages (" + jsonSize + " bytes)");
+    if (packages.length < ${NUM_PACKAGES}) {
+      throw new Error("Expected at least ${NUM_PACKAGES} packages, got " + packages.length);
+    }
+    return [];
+  },
+};`,
+      );
+
+      const bunfig = await read("./bunfig.toml").text();
+      await write("./bunfig.toml", `${bunfig}\n[install.security]\nscanner = "./scanner.ts"`);
+
+      await write("package.json", {
+        name: "my-app",
+        version: "1.0.0",
+        dependencies: Object.fromEntries(packageNames.map(name => [name, "0.0.2"])),
+      });
+
+      const { out, err } = await runBunInstall(bunEnv, package_dir, {
+        allowErrors: true,
+        allowWarnings: false,
+        savesLockfile: false,
+        expectedExitCode: 0,
+      });
+
+      expect(out).toContain("Received");
+      expect(out).toContain("packages");
+    },
+    { timeout: 60_000 },
+  );
 });

--- a/test/cli/install/bun-install-security-provider.test.ts
+++ b/test/cli/install/bun-install-security-provider.test.ts
@@ -1,6 +1,6 @@
 import { file } from "bun";
-import { basename, join } from "path";
 import { bunEnv, runBunInstall } from "harness";
+import { join } from "path";
 import {
   dummyAfterAll,
   dummyAfterEach,


### PR DESCRIPTION
## Summary

Fixes #23607
Fixes #27716

When the security scanner subprocess is spawned, the JSON package list was embedded directly in the `-e` script argument. With many packages (>~790), this exceeds the OS maximum argument length (`MAX_ARG_STRLEN` on Linux is 128KB), causing `bun install` to hang indefinitely or silently skip processing.

**Root cause**: The `__PACKAGES_JSON__` placeholder in `scanner-entry.ts` was replaced with the full JSON string and passed as a CLI argument via `-e`. Large projects with hundreds of packages generate JSON payloads exceeding OS limits.

**Fix**: Send the JSON data through a dedicated IPC pipe (fd 4) instead of embedding it in the script. Two pipes are now used:
- fd 3: child → parent (scanner writes response, existing)
- fd 4: parent → child (parent writes JSON package list, new)

The child reads from fd 4 using `Bun.file(4).text()`, which reads until EOF when the parent finishes writing and closes the pipe. The child's stdin is left untouched so scanners can use it for interactive first-time setup.

On POSIX, fd 4 is a socketpair. On Windows, it's a libuv IPC pipe.

## Changes

- **scanner-entry.ts**: Removed `__PACKAGES_JSON__` placeholder. Reads packages from fd 4 via `Bun.file(IPC_INPUT_FD).text()`.
- **security_scanner.zig**: Removed `__PACKAGES_JSON__` template substitution. Added `StaticPipeWriter` to write JSON data to the child. Split spawn into `spawnPosix`/`spawnWindows` for platform-specific pipe setup. Added `onCloseIO` callback.
- **posix_event_loop.zig**: Registered `SecurityScanSubprocessStaticPipeWriter` poll type.

## Test plan

- [x] Added regression test with 1500 packages (~180KB JSON payload, exceeds Linux `MAX_ARG_STRLEN`)
- [x] `USE_SYSTEM_BUN=1 bun test` → fails (exit code 1, system bun can't handle large payload via args)
- [x] `bun bd test` → passes (IPC pipe handles arbitrary payload sizes)
- [ ] CI passes on Linux
- [ ] CI passes on Windows (uses libuv IPC pipe)