### PR TITLE
fix(windows): disable bmalloc/libpas linking to fix crash

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -1269,7 +1269,6 @@ if(WIN32)
     target_link_libraries(${bun} PRIVATE
       ${WEBKIT_LIB_PATH}/WTF.lib
       ${WEBKIT_LIB_PATH}/JavaScriptCore.lib
-      ${WEBKIT_LIB_PATH}/bmalloc.lib
       ${WEBKIT_LIB_PATH}/sicudtd.lib
       ${WEBKIT_LIB_PATH}/sicuind.lib
       ${WEBKIT_LIB_PATH}/sicuucd.lib
@@ -1278,7 +1277,6 @@ if(WIN32)
     target_link_libraries(${bun} PRIVATE
       ${WEBKIT_LIB_PATH}/WTF.lib
       ${WEBKIT_LIB_PATH}/JavaScriptCore.lib
-      ${WEBKIT_LIB_PATH}/bmalloc.lib
       ${WEBKIT_LIB_PATH}/sicudt.lib
       ${WEBKIT_LIB_PATH}/sicuin.lib
       ${WEBKIT_LIB_PATH}/sicuuc.lib

--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -1269,6 +1269,7 @@ if(WIN32)
     target_link_libraries(${bun} PRIVATE
       ${WEBKIT_LIB_PATH}/WTF.lib
       ${WEBKIT_LIB_PATH}/JavaScriptCore.lib
+      ${WEBKIT_LIB_PATH}/bmalloc.lib
       ${WEBKIT_LIB_PATH}/sicudtd.lib
       ${WEBKIT_LIB_PATH}/sicuind.lib
       ${WEBKIT_LIB_PATH}/sicuucd.lib
@@ -1277,6 +1278,7 @@ if(WIN32)
     target_link_libraries(${bun} PRIVATE
       ${WEBKIT_LIB_PATH}/WTF.lib
       ${WEBKIT_LIB_PATH}/JavaScriptCore.lib
+      ${WEBKIT_LIB_PATH}/bmalloc.lib
       ${WEBKIT_LIB_PATH}/sicudt.lib
       ${WEBKIT_LIB_PATH}/sicuin.lib
       ${WEBKIT_LIB_PATH}/sicuuc.lib

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -103,6 +103,22 @@ function bmallocLib(cfg: Config): string {
 }
 
 /**
+ * Guard: bmalloc/libpas must never be linked on Windows — it causes crashes
+ * under memory pressure (see #20931, #26982, #26985, #28097). Call this after
+ * assembling the final libs array so CI catches any accidental reintroduction.
+ */
+function assertNoBmallocOnWindows(cfg: Config, libs: string[]): void {
+  if (!cfg.windows) return;
+  const bad = libs.filter(l => /bmalloc|libpas/i.test(l));
+  if (bad.length > 0) {
+    throw new Error(
+      `bmalloc/libpas must not be linked on Windows (crashes under memory pressure). ` +
+        `Found: ${bad.join(", ")}. See #20931, #26982, #26985, #28097.`,
+    );
+  }
+}
+
+/**
  * ICU libs — prebuilt bundles them on linux/windows. macOS uses system ICU.
  * Local mode: system ICU on posix (linked via -licu* in bun.ts); built from
  * source on Windows (see icuDir/icuLibs).
@@ -268,6 +284,7 @@ export const webkit: Dependency = {
       // postExtract.
       if (!cfg.darwin) includes.push("include/wtf/unicode");
 
+      assertNoBmallocOnWindows(cfg, libs);
       return { libs, includes };
     }
 
@@ -301,6 +318,7 @@ export const webkit: Dependency = {
     // Windows: ICU headers from preBuild output.
     if (cfg.windows) includes.push(resolve(icuDir(cfg), "include"));
 
+    assertNoBmallocOnWindows(cfg, libs);
     return { libs, includes };
   },
 };

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -258,7 +258,10 @@ export const webkit: Dependency = {
       // it. If a future version drops libbmalloc.a, you'll get a clear
       // "file not found" at link time (not silent omission + cryptic
       // undefined symbols).
-      const libs = [...coreLibs(cfg), ...prebuiltIcuLibs(cfg), bmallocLib(cfg)];
+      //
+      // Windows: bmalloc/libpas is disabled due to crash-causing instability
+      // (see #20931, #26982, #26985, #28097).
+      const libs = [...coreLibs(cfg), ...prebuiltIcuLibs(cfg), ...(cfg.windows ? [] : [bmallocLib(cfg)])];
 
       const includes = ["include"];
       // Linux/windows: ICU headers under wtf/unicode. macOS: deleted by
@@ -281,7 +284,9 @@ export const webkit: Dependency = {
     // which source.ts appends to the resolved libs automatically. Listing
     // them here would make dep_build also claim to produce them (dup error).
     // Posix uses system ICU (linked via -licu* in bun.ts).
-    const libs = [...coreLibs(cfg), bmallocLib(cfg)];
+    // Windows: bmalloc/libpas is disabled due to crash-causing instability
+    // (see #20931, #26982, #26985, #28097).
+    const libs = [...coreLibs(cfg), ...(cfg.windows ? [] : [bmallocLib(cfg)])];
 
     const includes = [
       // ABSOLUTE — resolved here because they're in the build dir, not src.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -103,22 +103,6 @@ function bmallocLib(cfg: Config): string {
 }
 
 /**
- * Guard: bmalloc/libpas must never be linked on Windows — it causes crashes
- * under memory pressure (see #20931, #26982, #26985, #28097). Call this after
- * assembling the final libs array so CI catches any accidental reintroduction.
- */
-function assertNoBmallocOnWindows(cfg: Config, libs: string[]): void {
-  if (!cfg.windows) return;
-  const bad = libs.filter(l => /bmalloc|libpas/i.test(l));
-  if (bad.length > 0) {
-    throw new Error(
-      `bmalloc/libpas must not be linked on Windows (crashes under memory pressure). ` +
-        `Found: ${bad.join(", ")}. See #20931, #26982, #26985, #28097.`,
-    );
-  }
-}
-
-/**
  * ICU libs — prebuilt bundles them on linux/windows. macOS uses system ICU.
  * Local mode: system ICU on posix (linked via -licu* in bun.ts); built from
  * source on Windows (see icuDir/icuLibs).
@@ -275,16 +259,16 @@ export const webkit: Dependency = {
       // "file not found" at link time (not silent omission + cryptic
       // undefined symbols).
       //
-      // Windows: bmalloc/libpas is disabled due to crash-causing instability
-      // (see #20931, #26982, #26985, #28097).
-      const libs = [...coreLibs(cfg), ...prebuiltIcuLibs(cfg), ...(cfg.windows ? [] : [bmallocLib(cfg)])];
+      // TODO(#28097): bmalloc/libpas causes crashes on Windows under memory
+      // pressure. Once oven-sh/WebKit rebuilds prebuilts with
+      // -DUSE_SYSTEM_MALLOC=ON, exclude bmallocLib on Windows here.
+      const libs = [...coreLibs(cfg), ...prebuiltIcuLibs(cfg), bmallocLib(cfg)];
 
       const includes = ["include"];
       // Linux/windows: ICU headers under wtf/unicode. macOS: deleted by
       // postExtract.
       if (!cfg.darwin) includes.push("include/wtf/unicode");
 
-      assertNoBmallocOnWindows(cfg, libs);
       return { libs, includes };
     }
 
@@ -301,9 +285,9 @@ export const webkit: Dependency = {
     // which source.ts appends to the resolved libs automatically. Listing
     // them here would make dep_build also claim to produce them (dup error).
     // Posix uses system ICU (linked via -licu* in bun.ts).
-    // Windows: bmalloc/libpas is disabled due to crash-causing instability
-    // (see #20931, #26982, #26985, #28097).
-    const libs = [...coreLibs(cfg), ...(cfg.windows ? [] : [bmallocLib(cfg)])];
+    // TODO(#28097): same as above — exclude bmallocLib on Windows once
+    // prebuilts are rebuilt with -DUSE_SYSTEM_MALLOC=ON.
+    const libs = [...coreLibs(cfg), bmallocLib(cfg)];
 
     const includes = [
       // ABSOLUTE — resolved here because they're in the build dir, not src.
@@ -318,7 +302,6 @@ export const webkit: Dependency = {
     // Windows: ICU headers from preBuild output.
     if (cfg.windows) includes.push(resolve(icuDir(cfg), "include"));
 
-    assertNoBmallocOnWindows(cfg, libs);
     return { libs, includes };
   },
 };


### PR DESCRIPTION
## Summary

bmalloc/libpas causes crashes on Windows under memory pressure during garbage collection (10GB+ RSS). This was previously fixed in WebKit PR #97 (`-DUSE_SYSTEM_MALLOC=ON`) and Bun PR #20931 (removing `bmalloc.lib` from link targets), but a later WebKit update dropped the `USE_SYSTEM_MALLOC=ON` flag from `windows-release.ps1`, re-enabling bmalloc in the prebuilt binaries.

## Root cause

The prebuilt WebKit for Windows (commit `00e825523d`) is compiled **without** `-DUSE_SYSTEM_MALLOC=ON`, so `WTF.lib` and `JavaScriptCore.lib` contain references to bmalloc symbols. Simply removing `bmalloc.lib` from the Bun link step causes unresolved symbol errors (CI build #39584 failed on `windows-x64-build-bun`).

## What this PR does

Adds `TODO(#28097)` comments in `scripts/build/deps/webkit.ts` marking where bmalloc should be excluded on Windows once the upstream fix is applied.

## Required upstream fix (tracked in #28101)

The full fix requires a coordinated change:
1. **oven-sh/WebKit**: Re-add `-DUSE_SYSTEM_MALLOC=ON` to `windows-release.ps1` and publish new prebuilts
2. **oven-sh/bun**: Remove `bmalloc.lib` from Windows link targets, exclude `bmallocLib(cfg)` on Windows, add CI regression guard

## Related issues
- Refs #28097
- Tracked in #28101
- Related: #26985, #26982, #20931

🤖 Generated with [Claude Code](https://claude.com/claude-code)