### PR TITLE
bundler(splitting): skip dead dynamic imports during tree-shaking

### DIFF
--- a/src/bundler/LinkerContext.zig
+++ b/src/bundler/LinkerContext.zig
@@ -1767,10 +1767,12 @@ pub const LinkerContext = struct {
             // Include all parts in this file with side effects, or just include
             // everything if tree-shaking is disabled. Note that we still want to
             // perform tree-shaking on the runtime even if tree-shaking is disabled.
+            // Dynamic-import entry points are always tree-shaken — their exports
+            // are preserved through the entry point part's dependencies.
             if (!can_be_removed_if_unused or
                 (!part.force_tree_shaking and
                     !c.options.tree_shaking and
-                    entry_point_kinds[source_index].isEntryPoint()))
+                    entry_point_kinds[source_index].isUserSpecifiedEntryPoint()))
             {
                 c.markPartLiveForTreeShaking(
                     @intCast(part_index),

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -437,6 +437,35 @@ pub const BundleV2 = struct {
             },
         }
 
+        // Remove dynamic import entry points whose import() call sites will
+        // be dead-code-eliminated during tree-shaking. A call site is
+        // considered dead if its containing part can be removed when unused
+        // AND no non-removable part in the same file references any symbol
+        // declared by that part.
+        if (this.dynamic_import_entry_points.count() > 0) {
+            const all_parts = this.graph.ast.items(.parts);
+            const all_import_records = this.graph.ast.items(.import_records);
+            const all_named_exports = this.graph.ast.items(.named_exports);
+
+            // Iterate until stable: removing a target may make other targets'
+            // exported-symbol checks no longer relevant (transitive chains).
+            var removed = true;
+            while (removed) {
+                removed = false;
+                var i: usize = 0;
+                while (i < this.dynamic_import_entry_points.count()) {
+                    const target = this.dynamic_import_entry_points.keys()[i];
+
+                    if (this.dynamicImportHasLiveCaller(target, visitor.reachable.items, all_parts, all_import_records, all_named_exports)) {
+                        i += 1;
+                    } else {
+                        this.dynamic_import_entry_points.swapRemoveAt(i);
+                        removed = true;
+                    }
+                }
+            }
+        }
+
         const DebugLog = bun.Output.Scoped(.ReachableFiles, .visible);
         if (DebugLog.isVisible()) {
             DebugLog.log("Reachable count: {d} / {d}", .{ visitor.reachable.items.len, this.graph.input_files.len });
@@ -469,6 +498,79 @@ pub const BundleV2 = struct {
         }
 
         return visitor.reachable.toOwnedSlice();
+    }
+
+    /// Check if any live (non-removable) code contains an import() to the target.
+    /// A call site is live if its part has side effects (!can_be_removed_if_unused),
+    /// or if a non-removable part references symbols declared by the call site's part.
+    fn dynamicImportHasLiveCaller(
+        this: *BundleV2,
+        target: Index.Int,
+        reachable: []const Index,
+        all_parts: []bun.BabyList(Part),
+        all_import_records: []ImportRecord.List,
+        all_named_exports: []JSAst.NamedExports,
+    ) bool {
+        for (reachable) |reachable_idx| {
+            const source_index = reachable_idx.get();
+            const file_parts = all_parts[source_index].slice();
+
+            // Exports only matter if this file is a user entry point or
+            // is still a dynamic import entry point (not yet removed).
+            var is_entry_or_dynamic_target = this.dynamic_import_entry_points.contains(source_index);
+            if (!is_entry_or_dynamic_target) {
+                for (this.graph.entry_points.items) |ep| {
+                    if (ep.get() == source_index) {
+                        is_entry_or_dynamic_target = true;
+                        break;
+                    }
+                }
+            }
+
+            for (file_parts) |part| {
+                // Find parts containing import() to the target.
+                var has_import_to_target = false;
+                for (part.import_record_indices.slice()) |import_record_index| {
+                    const record = all_import_records[source_index].at(import_record_index);
+                    if (record.kind == .dynamic and
+                        record.source_index.isValid() and
+                        record.source_index.get() == target)
+                    {
+                        has_import_to_target = true;
+                        break;
+                    }
+                }
+                if (!has_import_to_target) continue;
+
+                // The part has side effects — the import() is definitely live.
+                if (!part.can_be_removed_if_unused) return true;
+
+                // The part is removable, but check if it might be kept alive:
+                // 1. Any non-removable part in this file uses its symbols
+                // 2. Its symbols are exported AND the file is a live entry
+                //    point (user-specified or still a dynamic import target)
+                const named_exports = all_named_exports[source_index];
+                for (part.declared_symbols.refs()) |ref| {
+                    // Check if this symbol is exported from a live entry
+                    if (is_entry_or_dynamic_target) {
+                        for (named_exports.values()) |export_data| {
+                            if (export_data.ref.eql(ref)) {
+                                return true;
+                            }
+                        }
+                    }
+
+                    // Check within-file references from non-removable parts
+                    for (file_parts) |other_part| {
+                        if (other_part.can_be_removed_if_unused) continue;
+                        if (other_part.symbol_uses.getIndex(ref)) |_| {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     fn isDone(this: *BundleV2) bool {

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -1,5 +1,6 @@
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
 import { bunEnv } from "harness";
+import { readdirSync } from "node:fs";
 import { itBundled } from "./expectBundled";
 
 const env = {
@@ -321,6 +322,170 @@ describe("bundler", () => {
       file: "/out/entry.js",
       env,
       stdout: "a.js executed\na loaded from entry\nb.js executed\nb.js imports a {}\nb loaded from entry, value: B",
+    },
+  });
+
+  // Orphan chunk DCE: when all `import()` call sites for a dynamic chunk are
+  // removed by tree-shaking, the chunk itself should not be emitted.
+
+  itBundled("splitting/OrphanChunkDCE_NeverCalled", {
+    files: {
+      "/entry.ts": /* ts */ `
+        async function dead() { return await import('./secret.ts') }
+        console.log('done')
+      `,
+      "/secret.ts": `export const SECRET = 'this_should_not_be_in_output'`,
+    },
+    entryPoints: ["/entry.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    target: "bun",
+    minifySyntax: true,
+    treeShaking: true,
+    run: { stdout: "done" },
+    onAfterBundle(api) {
+      const files = readdirSync(api.outdir);
+      expect(files).toEqual(["entry.js"]);
+      expect(api.readFile("/out/entry.js")).not.toContain("this_should_not_be_in_output");
+    },
+  });
+
+  itBundled("splitting/OrphanChunkDCE_DefineFalse", {
+    files: {
+      "/entry.ts": /* ts */ `
+        async function loadSecret() { return await import('./secret.ts') }
+        if (process.env.GATE === 'on') {
+          const m = await loadSecret()
+          console.log(m.SECRET)
+        }
+        console.log('done')
+      `,
+      "/secret.ts": `export const SECRET = 'this_should_not_be_in_output'`,
+    },
+    entryPoints: ["/entry.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    target: "bun",
+    minifySyntax: true,
+    treeShaking: true,
+    define: { "process.env.GATE": '"off"' },
+    run: { stdout: "done" },
+    onAfterBundle(api) {
+      const files = readdirSync(api.outdir);
+      expect(files).toEqual(["entry.js"]);
+      expect(api.readFile("/out/entry.js")).not.toContain("this_should_not_be_in_output");
+    },
+  });
+
+  itBundled("splitting/OrphanChunkDCE_DefineTrueKeepsChunk", {
+    files: {
+      "/entry.ts": /* ts */ `
+        async function loadSecret() { return await import('./secret.ts') }
+        if (process.env.GATE === 'on') {
+          const m = await loadSecret()
+          console.log(m.SECRET)
+        }
+        console.log('done')
+      `,
+      "/secret.ts": `export const SECRET = 'secret_value_present'`,
+    },
+    entryPoints: ["/entry.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    target: "bun",
+    minifySyntax: true,
+    treeShaking: true,
+    define: { "process.env.GATE": '"on"' },
+    run: { stdout: "secret_value_present\ndone" },
+    onAfterBundle(api) {
+      const files = readdirSync(api.outdir).sort();
+      const secretChunk = files.find(f => f.startsWith("secret-"));
+      expect(secretChunk).toBeDefined();
+      expect(api.readFile("/out/entry.js")).toContain(`import("./${secretChunk}")`);
+    },
+  });
+
+  itBundled("splitting/OrphanChunkDCE_TransitiveChainDead", {
+    files: {
+      "/entry.ts": /* ts */ `
+        async function loadA() { return await import('./a.ts') }
+        console.log('done')
+      `,
+      "/a.ts": /* ts */ `
+        export async function loadB() { return await import('./b.ts') }
+        export const A = 'chain_a_value'
+      `,
+      "/b.ts": `export const B = 'chain_b_value'`,
+    },
+    entryPoints: ["/entry.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    target: "bun",
+    minifySyntax: true,
+    treeShaking: true,
+    run: { stdout: "done" },
+    onAfterBundle(api) {
+      const files = readdirSync(api.outdir);
+      expect(files).toEqual(["entry.js"]);
+      const entry = api.readFile("/out/entry.js");
+      expect(entry).not.toContain("chain_a_value");
+      expect(entry).not.toContain("chain_b_value");
+    },
+  });
+
+  itBundled("splitting/OrphanChunkDCE_TransitiveChainLive", {
+    files: {
+      "/entry.ts": /* ts */ `
+        const a = await import('./a.ts')
+        const b = await a.loadB()
+        console.log(a.A, b.B)
+      `,
+      "/a.ts": /* ts */ `
+        export async function loadB() { return await import('./b.ts') }
+        export const A = 'chain_a_live'
+      `,
+      "/b.ts": `export const B = 'chain_b_live'`,
+    },
+    entryPoints: ["/entry.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    target: "bun",
+    minifySyntax: true,
+    treeShaking: true,
+    run: { stdout: "chain_a_live chain_b_live" },
+    onAfterBundle(api) {
+      const files = readdirSync(api.outdir).sort();
+      expect(files.some(f => f.startsWith("a-"))).toBe(true);
+      expect(files.some(f => f.startsWith("b-"))).toBe(true);
+    },
+  });
+
+  itBundled("splitting/OrphanChunkDCE_StaticImportPlusDeadDynamic", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { SECRET } from './secret.ts'
+        async function dead() { return await import('./secret.ts') }
+        console.log(SECRET)
+      `,
+      "/secret.ts": `export const SECRET = 'inlined_secret'`,
+    },
+    entryPoints: ["/entry.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    target: "bun",
+    minifySyntax: true,
+    treeShaking: true,
+    run: { stdout: "inlined_secret" },
+    onAfterBundle(api) {
+      const files = readdirSync(api.outdir);
+      expect(files).toEqual(["entry.js"]);
+      expect(api.readFile("/out/entry.js")).toContain("inlined_secret");
     },
   });
 });


### PR DESCRIPTION
## Problem

Dynamic import targets are unconditionally promoted to entry points before tree-shaking, causing separate chunks to be emitted even when all `import()` call sites are in dead code.

```js
// entry.ts
async function dead() { return await import("./secret.ts") }
console.log("done")
```

With `--splitting`, this emits a chunk for `secret.ts` even though `dead()` is never called and tree-shaking removes it.

## Solution

In `findReachableFiles`, after the reachability visitor collects dynamic import targets, filter out targets whose `import()` call sites are all in dead parts. A call site is dead if:

1. Its containing part has `can_be_removed_if_unused = true`, AND
2. No non-removable part in the same file uses its declared symbols, AND  
3. Its declared symbols are not exported from a live entry point

This removes dead dynamic imports before they ever become entry points in `LinkerGraph.load()`. No changes to tree-shaking or code-splitting logic are needed. The only linker change is using `isUserSpecifiedEntryPoint()` to ensure dynamic import targets get proper per-part tree-shaking.

### Changes

- **`src/bundler/bundle_v2.zig`**: Add filtering step in `findReachableFiles` and `dynamicImportHasLiveCaller` helper
- **`src/bundler/LinkerContext.zig`**: Use `isUserSpecifiedEntryPoint()` for tree-shaking within dynamic import targets
- **`test/bundler/bundler_splitting.test.ts`**: 6 new test cases

## Verification

| Test | System bun | Debug build |
|------|-----------|-------------|
| OrphanChunkDCE_NeverCalled | :x: | :white_check_mark: |
| OrphanChunkDCE_DefineFalse | :x: | :white_check_mark: |
| OrphanChunkDCE_DefineTrueKeepsChunk | :white_check_mark: | :white_check_mark: |
| OrphanChunkDCE_TransitiveChainDead | :x: | :white_check_mark: |
| OrphanChunkDCE_TransitiveChainLive | :white_check_mark: | :white_check_mark: |
| OrphanChunkDCE_StaticImportPlusDeadDynamic | :x: | :white_check_mark: |