### PR TITLE
Fix security scanner failing with many packages

### DIFF
--- a/src/install/PackageManager/security_scanner.zig
+++ b/src/install/PackageManager/security_scanner.zig
@@ -709,9 +709,9 @@ fn attemptSecurityScanWithRetry(manager: *PackageManager, security_scanner: []co
         var new_code = std.array_list.Managed(u8).init(manager.allocator);
         try new_code.appendSlice(temp_source[0..index]);
         try new_code.appendSlice("JSON.parse(require(\"fs\").readFileSync(");
-        // Write the path as a JSON string to properly escape backslashes etc.
+        // Format the path as a JSON string to properly escape backslashes etc.
         const path_slice: []const u8 = std.mem.sliceTo(json_tmp_path, 0);
-        try std.json.stringify(path_slice, .{}, new_code.writer());
+        try new_code.writer().print("{f}", .{bun.fmt.formatJSONStringUTF8(path_slice, .{})});
         try new_code.appendSlice(",\"utf8\"))");
         code.deinit();
         code = new_code;

--- a/src/install/PackageManager/security_scanner.zig
+++ b/src/install/PackageManager/security_scanner.zig
@@ -673,12 +673,46 @@ fn attemptSecurityScanWithRetry(manager: *PackageManager, security_scanner: []co
         temp_source = code.items;
     }
 
+    // Write the packages JSON to a temp file instead of inlining it in the code
+    // string. With many packages (>~790), the JSON exceeds the OS maximum
+    // argument length (MAX_ARG_STRLEN = 128KB on Linux), causing posix_spawn
+    // to fail silently.
+    var tmpname_buf: bun.PathBuffer = undefined;
+    const tmpname = try bun.fs.FileSystem.tmpname("bun-scan", &tmpname_buf, bun.fastRandom());
+    const top_dir = FileSystem.instance.top_level_dir;
+    var json_path_buf: bun.PathBuffer = undefined;
+    const json_tmp_path = bun.path.joinAbsStringBufZ(top_dir, &json_path_buf, &.{tmpname}, .auto);
+
+    {
+        var file = switch (bun.sys.File.open(json_tmp_path, bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o664)) {
+            .result => |f| f,
+            .err => |err| {
+                Output.errGeneric("Failed to create security scanner temp file: {f}", .{err});
+                return error.TempFileWriteFailed;
+            },
+        };
+        defer file.close();
+        switch (file.writeAll(json_data)) {
+            .result => {},
+            .err => |err| {
+                Output.errGeneric("Failed to write security scanner data: {f}", .{err});
+                return error.TempFileWriteFailed;
+            },
+        }
+    }
+    defer _ = bun.sys.unlink(json_tmp_path);
+
+    // Replace __PACKAGES_JSON__ with a readFileSync call that loads from the temp file.
+    // The path is JSON-escaped to handle any special characters (e.g. backslashes on Windows).
     const packages_placeholder = "__PACKAGES_JSON__";
     if (std.mem.indexOf(u8, temp_source, packages_placeholder)) |index| {
         var new_code = std.array_list.Managed(u8).init(manager.allocator);
         try new_code.appendSlice(temp_source[0..index]);
-        try new_code.appendSlice(json_data);
-        try new_code.appendSlice(temp_source[index + packages_placeholder.len ..]);
+        try new_code.appendSlice("JSON.parse(require(\"fs\").readFileSync(");
+        // Write the path as a JSON string to properly escape backslashes etc.
+        const path_slice: []const u8 = std.mem.sliceTo(json_tmp_path, 0);
+        try std.json.stringify(path_slice, .{}, new_code.writer());
+        try new_code.appendSlice(",\"utf8\"))");
         code.deinit();
         code = new_code;
         temp_source = code.items;
@@ -697,14 +731,12 @@ fn attemptSecurityScanWithRetry(manager: *PackageManager, security_scanner: []co
     var scanner = SecurityScanSubprocess.new(.{
         .manager = manager,
         .code = try manager.allocator.dupe(u8, code.items),
-        .json_data = try manager.allocator.dupe(u8, json_data),
         .ipc_data = undefined,
         .stderr_data = undefined,
     });
 
     defer {
         manager.allocator.free(scanner.code);
-        manager.allocator.free(scanner.json_data);
         bun.destroy(scanner);
     }
 
@@ -727,7 +759,6 @@ fn attemptSecurityScanWithRetry(manager: *PackageManager, security_scanner: []co
 pub const SecurityScanSubprocess = struct {
     manager: *PackageManager,
     code: []const u8,
-    json_data: []const u8,
     process: ?*bun.spawn.Process = null,
     ipc_reader: bun.io.BufferedReader = bun.io.BufferedReader.init(@This()),
     ipc_data: std.array_list.Managed(u8),

--- a/src/install/PackageManager/security_scanner.zig
+++ b/src/install/PackageManager/security_scanner.zig
@@ -713,6 +713,7 @@ fn attemptSecurityScanWithRetry(manager: *PackageManager, security_scanner: []co
         const path_slice: []const u8 = std.mem.sliceTo(json_tmp_path, 0);
         try new_code.writer().print("{f}", .{bun.fmt.formatJSONStringUTF8(path_slice, .{})});
         try new_code.appendSlice(",\"utf8\"))");
+        try new_code.appendSlice(temp_source[index + packages_placeholder.len ..]);
         code.deinit();
         code = new_code;
         temp_source = code.items;

--- a/src/install/PackageManager/security_scanner.zig
+++ b/src/install/PackageManager/security_scanner.zig
@@ -685,7 +685,7 @@ fn attemptSecurityScanWithRetry(manager: *PackageManager, security_scanner: []co
 
     defer _ = bun.sys.unlink(json_tmp_path);
     {
-        var file = switch (bun.sys.File.open(json_tmp_path, bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o664)) {
+        var file = switch (bun.sys.File.open(json_tmp_path, bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o600)) {
             .result => |f| f,
             .err => |err| {
                 Output.errGeneric("Failed to create security scanner temp file: {f}", .{err});

--- a/src/install/PackageManager/security_scanner.zig
+++ b/src/install/PackageManager/security_scanner.zig
@@ -683,6 +683,7 @@ fn attemptSecurityScanWithRetry(manager: *PackageManager, security_scanner: []co
     var json_path_buf: bun.PathBuffer = undefined;
     const json_tmp_path = bun.path.joinAbsStringBufZ(top_dir, &json_path_buf, &.{tmpname}, .auto);
 
+    defer _ = bun.sys.unlink(json_tmp_path);
     {
         var file = switch (bun.sys.File.open(json_tmp_path, bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o664)) {
             .result => |f| f,
@@ -700,7 +701,6 @@ fn attemptSecurityScanWithRetry(manager: *PackageManager, security_scanner: []co
             },
         }
     }
-    defer _ = bun.sys.unlink(json_tmp_path);
 
     // Replace __PACKAGES_JSON__ with a readFileSync call that loads from the temp file.
     // The path is JSON-escaped to handle any special characters (e.g. backslashes on Windows).

--- a/test/regression/issue/27716.test.ts
+++ b/test/regression/issue/27716.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 

--- a/test/regression/issue/27716.test.ts
+++ b/test/regression/issue/27716.test.ts
@@ -52,7 +52,7 @@ scanner = "./scanner.ts"
 
       if (pathname.endsWith(".tgz")) {
         // Serve a minimal valid npm tarball (empty package)
-        return new Response(makeTarball(pathname));
+        return new Response(makeTarball());
       }
 
       // Registry metadata response
@@ -96,12 +96,8 @@ scanner = "./scanner.ts"
 }, 120_000);
 
 // Creates a minimal valid npm tarball containing just a package.json
-function makeTarball(name: string): Uint8Array {
-  // Create a minimal tar.gz with just a package/package.json
+function makeTarball(): Uint8Array {
   const packageJson = JSON.stringify({ name: "pkg", version: "0.0.1" });
-
-  // Use pre-built minimal tarball bytes
-  // This is a gzipped tar containing package/package.json with {"name":"pkg","version":"0.0.1"}
   return createMinimalTarGz(packageJson);
 }
 

--- a/test/regression/issue/27716.test.ts
+++ b/test/regression/issue/27716.test.ts
@@ -1,0 +1,176 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// Issue #27716: bun install skips all processing when a security scanner is
+// present and the project has many packages. The root cause was that the
+// packages JSON was inlined into the -e argument to the scanner subprocess,
+// exceeding the OS maximum argument length (MAX_ARG_STRLEN = 128KB on Linux).
+//
+// The fix writes the JSON to a temp file instead of inlining it.
+
+const PACKAGE_COUNT = 1000; // ~160KB of JSON, exceeds MAX_ARG_STRLEN
+
+test("security scanner receives packages via temp file with large package count", async () => {
+  // Generate many dependencies
+  const dependencies: Record<string, string> = {};
+  for (let i = 0; i < PACKAGE_COUNT; i++) {
+    dependencies[`pkg-${String(i).padStart(4, "0")}`] = "0.0.1";
+  }
+
+  using dir = tempDir("issue-27716", {
+    "package.json": JSON.stringify({
+      name: "test-large-scanner",
+      version: "1.0.0",
+      dependencies,
+    }),
+    "scanner.ts": `
+      export const scanner = {
+        version: "1",
+        scan: async ({ packages }) => {
+          // Log the count so the parent can verify
+          console.log("SCANNER_PACKAGE_COUNT:" + packages.length);
+          return [];
+        },
+      };
+    `,
+    "bunfig.toml": `
+[install]
+registry = "http://localhost:__PORT__/"
+
+[install.security]
+scanner = "./scanner.ts"
+`,
+  });
+
+  // Start a tiny registry that serves identical tarballs for all packages
+  await using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const pathname = url.pathname;
+
+      if (pathname.endsWith(".tgz")) {
+        // Serve a minimal valid npm tarball (empty package)
+        return new Response(makeTarball(pathname));
+      }
+
+      // Registry metadata response
+      const name = pathname.slice(1); // strip leading /
+      return Response.json({
+        name,
+        versions: {
+          "0.0.1": {
+            name,
+            version: "0.0.1",
+            dist: {
+              tarball: `http://localhost:${server.port}/${name}-0.0.1.tgz`,
+            },
+          },
+        },
+        "dist-tags": { latest: "0.0.1" },
+      });
+    },
+  });
+
+  // Patch bunfig with the actual port
+  const bunfigPath = join(String(dir), "bunfig.toml");
+  const bunfig = await Bun.file(bunfigPath).text();
+  await Bun.write(bunfigPath, bunfig.replace("__PORT__", String(server.port)));
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", "--ignore-scripts"],
+    cwd: String(dir),
+    env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The scanner should have received all packages and logged the count.
+  // On the broken system bun, the scanner subprocess fails to start because
+  // the inlined JSON exceeds MAX_ARG_STRLEN, so this line won't appear.
+  expect(stdout).toContain(`SCANNER_PACKAGE_COUNT:${PACKAGE_COUNT}`);
+  expect(exitCode).toBe(0);
+}, 120_000);
+
+// Creates a minimal valid npm tarball containing just a package.json
+function makeTarball(name: string): Uint8Array {
+  // Create a minimal tar.gz with just a package/package.json
+  const packageJson = JSON.stringify({ name: "pkg", version: "0.0.1" });
+
+  // Use pre-built minimal tarball bytes
+  // This is a gzipped tar containing package/package.json with {"name":"pkg","version":"0.0.1"}
+  return createMinimalTarGz(packageJson);
+}
+
+function createMinimalTarGz(content: string): Uint8Array {
+  // Build a minimal tar archive
+  const encoder = new TextEncoder();
+  const contentBytes = encoder.encode(content);
+
+  // Tar header (512 bytes)
+  const header = new Uint8Array(512);
+  const filename = "package/package.json";
+
+  // Write filename
+  for (let i = 0; i < filename.length; i++) {
+    header[i] = filename.charCodeAt(i);
+  }
+
+  // File mode (0644)
+  writeOctal(header, 100, 8, 0o644);
+  // Owner/Group ID
+  writeOctal(header, 108, 8, 0);
+  writeOctal(header, 116, 8, 0);
+  // File size
+  writeOctal(header, 124, 12, contentBytes.length);
+  // Modification time
+  writeOctal(header, 136, 12, Math.floor(Date.now() / 1000));
+  // Type flag (regular file)
+  header[156] = 0x30; // '0'
+  // USTAR magic
+  const magic = "ustar\0";
+  for (let i = 0; i < magic.length; i++) {
+    header[257 + i] = magic.charCodeAt(i);
+  }
+  header[263] = 0x30; // version '0'
+  header[264] = 0x30; // version '0'
+
+  // Calculate checksum
+  // First fill checksum field with spaces
+  for (let i = 148; i < 156; i++) {
+    header[i] = 0x20;
+  }
+  let checksum = 0;
+  for (let i = 0; i < 512; i++) {
+    checksum += header[i];
+  }
+  writeOctal(header, 148, 7, checksum);
+  header[155] = 0x20; // space after checksum
+
+  // Content padded to 512-byte boundary
+  const contentPadded = new Uint8Array(Math.ceil(contentBytes.length / 512) * 512);
+  contentPadded.set(contentBytes);
+
+  // End-of-archive marker (two 512-byte blocks of zeros)
+  const endMarker = new Uint8Array(1024);
+
+  // Concatenate tar
+  const tar = new Uint8Array(header.length + contentPadded.length + endMarker.length);
+  tar.set(header, 0);
+  tar.set(contentPadded, header.length);
+  tar.set(endMarker, header.length + contentPadded.length);
+
+  // Gzip compress
+  return Bun.gzipSync(tar);
+}
+
+function writeOctal(buf: Uint8Array, offset: number, length: number, value: number): void {
+  const str = value.toString(8).padStart(length - 1, "0");
+  for (let i = 0; i < str.length && i < length - 1; i++) {
+    buf[offset + i] = str.charCodeAt(i);
+  }
+  buf[offset + length - 1] = 0;
+}

--- a/test/regression/issue/27716.test.ts
+++ b/test/regression/issue/27716.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { existsSync } from "node:fs";
 import { join } from "path";
 
 // Issue #27716: bun install skips all processing when a security scanner is
@@ -88,10 +89,19 @@ scanner = "./scanner.ts"
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  // Debug: print stderr to understand failures
+  if (!stdout.includes(`SCANNER_PACKAGE_COUNT:${PACKAGE_COUNT}`)) {
+    console.log("STDOUT:", stdout.slice(0, 500));
+    console.log("STDERR:", stderr.slice(0, 1000));
+    console.log("EXIT:", exitCode);
+  }
+
   // The scanner should have received all packages and logged the count.
   // On the broken system bun, the scanner subprocess fails to start because
   // the inlined JSON exceeds MAX_ARG_STRLEN, so this line won't appear.
   expect(stdout).toContain(`SCANNER_PACKAGE_COUNT:${PACKAGE_COUNT}`);
+  expect(existsSync(join(String(dir), "node_modules"))).toBe(true);
+  expect(existsSync(join(String(dir), "bun.lock"))).toBe(true);
   expect(exitCode).toBe(0);
 }, 120_000);
 


### PR DESCRIPTION
## Summary
- Fixes `bun install` silently skipping all processing when a security scanner is configured and the project has many packages (~790+)
- Packages JSON is now written to a temp file instead of being inlined in the `-e` code argument to the scanner subprocess
- The temp file is cleaned up after the subprocess finishes

## Root Cause
The security scanner subprocess received the packages JSON inlined directly in the code string passed via `-e` to `bun`. For large projects (>~790 packages), the JSON data pushed the total argument past `MAX_ARG_STRLEN` (128KB on Linux), causing `posix_spawn` to fail silently. The install would return immediately without creating `node_modules` or `bun.lock`.

## Fix
Instead of replacing `__PACKAGES_JSON__` with the raw JSON data in the code string, the fix:
1. Writes the JSON to a temp file in the project directory
2. Replaces `__PACKAGES_JSON__` with `JSON.parse(require("fs").readFileSync(path, "utf8"))`
3. Cleans up the temp file via `defer unlink` after the subprocess finishes

The path is JSON-escaped to handle special characters (e.g., backslashes on Windows). This approach is fully cross-platform — no pipes, no platform-specific spawn code.

## Test plan
- [x] Added regression test with 1000 packages (~160KB JSON payload, exceeds `MAX_ARG_STRLEN`)
- [x] `USE_SYSTEM_BUN=1 bun test` → **fails** (scanner subprocess never starts, output is just `bun install v1.3.10`)
- [x] `bun bd test` → pending local build (CI will validate)

Fixes #27716
Fixes #23607