### PR TITLE
fix: Split srcset-attribute values into separate URLs before resolving

### DIFF
--- a/src/HTMLScanner.zig
+++ b/src/HTMLScanner.zig
@@ -69,23 +69,19 @@ pub fn onTag(this: *HTMLScanner, _: *lol.Element, path: []const u8, url_attribut
             // Skip leading whitespace
             while (i < path.len and std.ascii.isWhitespace(path[i])) : (i += 1) {}
             if (i >= path.len) break;
-
-            // Read the URL until first whitespace
             const url_start = i;
-            while (i < path.len and !std.ascii.isWhitespace(path[i])) : (i += 1) {}
-            const raw_end = i;
 
-            // Strip any trailing commas
-            var url_end = raw_end;
-            while (url_end > url_start and path[url_end - 1] == ',') : (url_end -= 1) {}
+            // data: URLs can contain commas, so only treat commas as terminators for non-data URLs.
+            const is_data_url = bun.strings.hasPrefix(path[url_start..], "data:");
+            if (is_data_url) {
+                while (i < path.len and !std.ascii.isWhitespace(path[i])) : (i += 1) {}
+            } else {
+                while (i < path.len and !std.ascii.isWhitespace(path[i]) and path[i] != ',') : (i += 1) {}
+            }
+            const url_end = i;
 
             if (url_end > url_start) {
                 this.createImportRecord(path[url_start..url_end], kind) catch {};
-            }
-
-            if (raw_end > url_end) {
-                // If url ended on comma, start parsing next URL
-                continue;
             }
 
             // Read until next comma to find start of next URL

--- a/src/HTMLScanner.zig
+++ b/src/HTMLScanner.zig
@@ -62,7 +62,28 @@ pub fn onHTMLParseError(this: *HTMLScanner, message: []const u8) void {
 }
 
 pub fn onTag(this: *HTMLScanner, _: *lol.Element, path: []const u8, url_attribute: []const u8, kind: ImportKind) void {
-    _ = url_attribute;
+    if (std.mem.eql(u8, url_attribute, "srcset")) {
+        // srcset can have multiple URLs, we need to split them and create import records for each one
+        var start: usize = 0;
+        while (start < path.len) {
+            // URLS in srcset are separated by commas, pixel density descriptors (e.g. "image.png 2x") or width descriptors (e.g. "image.png 100w"), so we need to split on commas and then trim the resulting URLs
+            const comma_index = std.mem.indexOfScalar(u8, path[start..], ',') orelse path.len - start;
+            const url_with_descriptor = path[start .. start + comma_index];
+            // Trim whitespace and descriptors from the URL
+            var url_start: usize = 0;
+            while (url_start < url_with_descriptor.len and std.ascii.isWhitespace(url_with_descriptor[url_start])) : (url_start += 1) {}
+            var url_end: usize = url_start;
+            while (url_end < url_with_descriptor.len and !std.ascii.isWhitespace(url_with_descriptor[url_end])) : (url_end += 1) {}
+            const clean_url = url_with_descriptor[url_start..url_end];
+
+            if (clean_url.len > 0) {
+                this.createImportRecord(clean_url, kind) catch {};
+            }
+            start += comma_index + 1;
+        }
+        return;
+    }
+
     this.createImportRecord(path, kind) catch {};
 }
 

--- a/src/HTMLScanner.zig
+++ b/src/HTMLScanner.zig
@@ -62,24 +62,35 @@ pub fn onHTMLParseError(this: *HTMLScanner, message: []const u8) void {
 }
 
 pub fn onTag(this: *HTMLScanner, _: *lol.Element, path: []const u8, url_attribute: []const u8, kind: ImportKind) void {
-    if (std.mem.eql(u8, url_attribute, "srcset")) {
-        // srcset can have multiple URLs, we need to split them and create import records for each one
-        var start: usize = 0;
-        while (start < path.len) {
-            // URLS in srcset are separated by commas, pixel density descriptors (e.g. "image.png 2x") or width descriptors (e.g. "image.png 100w"), so we need to split on commas and then trim the resulting URLs
-            const comma_index = std.mem.indexOfScalar(u8, path[start..], ',') orelse path.len - start;
-            const url_with_descriptor = path[start .. start + comma_index];
-            // Trim whitespace and descriptors from the URL
-            var url_start: usize = 0;
-            while (url_start < url_with_descriptor.len and std.ascii.isWhitespace(url_with_descriptor[url_start])) : (url_start += 1) {}
-            var url_end: usize = url_start;
-            while (url_end < url_with_descriptor.len and !std.ascii.isWhitespace(url_with_descriptor[url_end])) : (url_end += 1) {}
-            const clean_url = url_with_descriptor[url_start..url_end];
+    if (bun.strings.eqlComptime(url_attribute, "srcset")) {
+        // srcset can have multiple URLs
+        var i: usize = 0;
+        while (i < path.len) {
+            // Skip leading whitespace
+            while (i < path.len and std.ascii.isWhitespace(path[i])) : (i += 1) {}
+            if (i >= path.len) break;
 
-            if (clean_url.len > 0) {
-                this.createImportRecord(clean_url, kind) catch {};
+            // Read the URL until first whitespace
+            const url_start = i;
+            while (i < path.len and !std.ascii.isWhitespace(path[i])) : (i += 1) {}
+            const raw_end = i;
+
+            // Strip any trailing commas
+            var url_end = raw_end;
+            while (url_end > url_start and path[url_end - 1] == ',') : (url_end -= 1) {}
+
+            if (url_end > url_start) {
+                this.createImportRecord(path[url_start..url_end], kind) catch {};
             }
-            start += comma_index + 1;
+
+            if (raw_end > url_end) {
+                // If url ended on comma, start parsing next URL
+                continue;
+            }
+
+            // Read until next comma to find start of next URL
+            while (i < path.len and path[i] != ',') : (i += 1) {}
+            if (i < path.len) i += 1;
         }
         return;
     }

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.zig
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.zig
@@ -33,6 +33,12 @@ fn generateCompileResultForHTMLChunkImpl(worker: *ThreadPool.Worker, c: *LinkerC
     const import_records = c.graph.ast.items(.import_records);
 
     const HTMLLoader = struct {
+        const TagAction = union(enum) {
+            keep,
+            remove,
+            set: []const u8,
+        };
+
         linker: *LinkerContext,
         source_index: Index.Int,
         import_records: []const ImportRecord,
@@ -60,7 +66,8 @@ fn generateCompileResultForHTMLChunkImpl(worker: *ThreadPool.Worker, c: *LinkerC
             Output.panic("Parsing HTML during replacement phase errored, which should never happen since the first pass succeeded: {s}", .{err});
         }
 
-        pub fn onTag(this: *@This(), element: *lol.Element, _: []const u8, url_attribute: []const u8, _: ImportKind) void {
+        // Determine what to do with the next tag import: keep it, remove it, or replace its attribute.
+        fn getTagAction(this: *@This()) TagAction {
             if (this.current_import_record_index >= this.import_records.len) {
                 Output.panic("Assertion failure in HTMLLoader.onTag: current_import_record_index ({d}) >= import_records.len ({d})", .{ this.current_import_record_index, this.import_records.len });
             }
@@ -71,59 +78,115 @@ fn generateCompileResultForHTMLChunkImpl(worker: *ThreadPool.Worker, c: *LinkerC
                 this.linker.parse_graph.input_files.items(.unique_key_for_additional_file)[import_record.source_index.get()]
             else
                 "";
-            const loader: Loader = if (import_record.source_index.isValid())
+            const loader = if (import_record.source_index.isValid())
                 this.linker.parse_graph.input_files.items(.loader)[import_record.source_index.get()]
             else
                 .file;
 
             if (import_record.flags.is_external_without_side_effects) {
                 debug("Leaving external import: {s}", .{import_record.path.text});
-                return;
+                return .keep;
             }
 
             if (this.linker.dev_server != null) {
                 if (unique_key_for_additional_files.len > 0) {
-                    element.setAttribute(url_attribute, unique_key_for_additional_files) catch {
-                        std.debug.panic("unexpected error from Element.setAttribute", .{});
-                    };
+                    return .{ .set = unique_key_for_additional_files };
                 } else if (import_record.path.is_disabled or loader.isJavaScriptLike() or loader.isCSS()) {
-                    element.remove();
+                    return .remove;
                 } else {
-                    element.setAttribute(url_attribute, import_record.path.pretty) catch {
-                        std.debug.panic("unexpected error from Element.setAttribute", .{});
-                    };
+                    return .{ .set = import_record.path.pretty };
                 }
-                return;
             }
 
             if (import_record.source_index.isInvalid()) {
                 debug("Leaving import with invalid source index: {s}", .{import_record.path.text});
-                return;
+                return .keep;
             }
 
             if (loader.isJavaScriptLike() or loader.isCSS()) {
                 // Remove the original non-external tags
-                element.remove();
-                return;
+                return .remove;
             }
 
             if (this.compile_to_standalone_html and import_record.source_index.isValid()) {
                 // In standalone HTML mode, inline assets as data: URIs
                 const url_for_css = this.linker.parse_graph.ast.items(.url_for_css)[import_record.source_index.get()];
                 if (url_for_css.len > 0) {
-                    element.setAttribute(url_attribute, url_for_css) catch {
-                        std.debug.panic("unexpected error from Element.setAttribute", .{});
-                    };
-                    return;
+                    return .{ .set = url_for_css };
                 }
             }
 
             if (unique_key_for_additional_files.len > 0) {
                 // Replace the external href/src with the unique key so that we later will rewrite it to the final URL or pathname
-                element.setAttribute(url_attribute, unique_key_for_additional_files) catch {
+                return .{ .set = unique_key_for_additional_files };
+            }
+
+            return .keep;
+        }
+
+        pub fn onTag(this: *@This(), element: *lol.Element, path: []const u8, url_attribute: []const u8, _: ImportKind) void {
+            if (strings.eqlComptime(url_attribute, "srcset")) {
+                var appender = std.heap.stackFallback(256, bun.default_allocator);
+                const allocator = appender.get();
+                var rewritten = std.array_list.Managed(u8).init(allocator);
+                defer rewritten.deinit();
+
+                var last_emit: usize = 0;
+                var i: usize = 0;
+                while (i < path.len) {
+                    // Skip leading whitespace
+                    while (i < path.len and std.ascii.isWhitespace(path[i])) : (i += 1) {}
+                    if (i >= path.len) break;
+                    const url_start = i;
+
+                    // Find the end of the URL, which is either whitespace or a comma
+                    while (i < path.len and !std.ascii.isWhitespace(path[i])) : (i += 1) {}
+                    const raw_end = i;
+                    var url_end = raw_end;
+                    while (url_end > url_start and path[url_end - 1] == ',') : (url_end -= 1) {}
+
+                    const replacement = brk: {
+                        switch (this.getTagAction()) {
+                            .keep => break :brk path[url_start..url_end],
+                            .remove => {
+                                element.remove();
+                                return;
+                            },
+                            .set => |value| break :brk value,
+                        }
+                    };
+
+                    bun.handleOom(rewritten.appendSlice(path[last_emit..url_start]));
+                    bun.handleOom(rewritten.appendSlice(replacement));
+                    last_emit = url_end;
+
+                    if (raw_end > url_end) {
+                        continue;
+                    }
+
+                    while (i < path.len and path[i] != ',') : (i += 1) {}
+                    if (i < path.len) i += 1;
+                }
+
+                bun.handleOom(rewritten.appendSlice(path[last_emit..]));
+                element.setAttribute(url_attribute, rewritten.items) catch {
                     std.debug.panic("unexpected error from Element.setAttribute", .{});
                 };
                 return;
+            }
+
+            switch (this.getTagAction()) {
+                .keep => return,
+                .remove => {
+                    element.remove();
+                    return;
+                },
+                .set => |value| {
+                    element.setAttribute(url_attribute, value) catch {
+                        std.debug.panic("unexpected error from Element.setAttribute", .{});
+                    };
+                    return;
+                },
             }
         }
 

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.zig
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.zig
@@ -139,11 +139,14 @@ fn generateCompileResultForHTMLChunkImpl(worker: *ThreadPool.Worker, c: *LinkerC
                     if (i >= path.len) break;
                     const url_start = i;
 
-                    // Find the end of the URL, which is either whitespace or a comma
-                    while (i < path.len and !std.ascii.isWhitespace(path[i])) : (i += 1) {}
-                    const raw_end = i;
-                    var url_end = raw_end;
-                    while (url_end > url_start and path[url_end - 1] == ',') : (url_end -= 1) {}
+                    // data: URLs can contain commas, so only treat commas as terminators for non-data URLs.
+                    const is_data_url = strings.hasPrefix(path[url_start..], "data:");
+                    if (is_data_url) {
+                        while (i < path.len and !std.ascii.isWhitespace(path[i])) : (i += 1) {}
+                    } else {
+                        while (i < path.len and !std.ascii.isWhitespace(path[i]) and path[i] != ',') : (i += 1) {}
+                    }
+                    const url_end = i;
 
                     const replacement = brk: {
                         switch (this.getTagAction()) {
@@ -159,10 +162,6 @@ fn generateCompileResultForHTMLChunkImpl(worker: *ThreadPool.Worker, c: *LinkerC
                     bun.handleOom(rewritten.appendSlice(path[last_emit..url_start]));
                     bun.handleOom(rewritten.appendSlice(replacement));
                     last_emit = url_end;
-
-                    if (raw_end > url_end) {
-                        continue;
-                    }
 
                     while (i < path.len and path[i] != ',') : (i += 1) {}
                     if (i < path.len) i += 1;

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -146,6 +146,33 @@ describe("bundler", () => {
     },
   });
 
+  // Test srcset with data URL containing commas
+  itBundled("html/srcset-data-url-with-comma", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <body>
+    <img srcset="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A//www.w3.org/2000/svg'%3E%3C/svg%3E 1x, data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A//www.w3.org/2000/svg'%3E%3C/svg%3E 2x">
+    <img srcset="./logo.png 1x, ./logo-2x.png 2x">
+    <img srcset="./logo.png, ./logo-2x.png">
+  </body>
+</html>`,
+      "/logo.png": "fake image content",
+      "/logo-2x.png": "fake image content",
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      api.expectFile("out/index.html").toMatch(/data:image\/svg\+xml,.* 1x, data:image\/svg\+xml/);
+      api.expectFile("out/index.html").not.toContain("./logo-2x.png");
+      api.expectFile("out/index.html").not.toContain("./logo.png");
+      api.expectFile("out/index.html").toMatch(/srcset="(.*-[a-zA-Z0-9]+\.png [0-9]x,?\s*){2}"/);
+      api.expectFile("out/index.html").toMatch(/srcset="(.*-[a-zA-Z0-9]+\.png,?\s*){2}"/);
+      console.log("index contents: " + api.readFile("out/index.html"));
+    },
+  });
+
   // Test mixed local and external assets
   itBundled("html/mixed-assets", {
     outdir: "out/",

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -157,6 +157,7 @@ describe("bundler", () => {
     <img srcset="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A//www.w3.org/2000/svg'%3E%3C/svg%3E 1x, data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A//www.w3.org/2000/svg'%3E%3C/svg%3E 2x">
     <img srcset="./logo.png 1x, ./logo-2x.png 2x">
     <img srcset="./logo.png, ./logo-2x.png">
+    <img srcset="./logo.png,./logo-2x.png">
   </body>
 </html>`,
       "/logo.png": "fake image content",
@@ -169,7 +170,6 @@ describe("bundler", () => {
       api.expectFile("out/index.html").not.toContain("./logo.png");
       api.expectFile("out/index.html").toMatch(/srcset="(.*-[a-zA-Z0-9]+\.png [0-9]x,?\s*){2}"/);
       api.expectFile("out/index.html").toMatch(/srcset="(.*-[a-zA-Z0-9]+\.png,?\s*){2}"/);
-      console.log("index contents: " + api.readFile("out/index.html"));
     },
   });
 

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -157,7 +157,8 @@ describe("bundler", () => {
     <img srcset="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A//www.w3.org/2000/svg'%3E%3C/svg%3E 1x, data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A//www.w3.org/2000/svg'%3E%3C/svg%3E 2x">
     <img srcset="./logo.png 1x, ./logo-2x.png 2x">
     <img srcset="./logo.png, ./logo-2x.png">
-    <img srcset="./logo.png,./logo-2x.png">
+    <img id="space" srcset="./logo.png, ./logo-2x.png">
+    <img id="no-space" srcset="./logo.png,./logo-2x.png">
   </body>
 </html>`,
       "/logo.png": "fake image content",
@@ -169,7 +170,8 @@ describe("bundler", () => {
       api.expectFile("out/index.html").not.toContain("./logo-2x.png");
       api.expectFile("out/index.html").not.toContain("./logo.png");
       api.expectFile("out/index.html").toMatch(/srcset="(.*-[a-zA-Z0-9]+\.png [0-9]x,?\s*){2}"/);
-      api.expectFile("out/index.html").toMatch(/srcset="(.*-[a-zA-Z0-9]+\.png,?\s*){2}"/);
+      api.expectFile("out/index.html").toMatch(/id="space" srcset="(.*-[a-zA-Z0-9]+\.png,?\s*){2}"/);
+      api.expectFile("out/index.html").toMatch(/id="no-space" srcset="(.*-[a-zA-Z0-9]+\.png,?\s*){2}"/);
     },
   });
 


### PR DESCRIPTION
### What does this PR do?
This pull request updates the handling of the `srcset` attribute in the `onTag` method of `HTMLScanner.zig` to properly extract and process multiple URLs from a `srcset` value.  Previously, the srcset-attribute was treated as a single URL and resolving it would always result in failure. This PR ensures the srcset is split into and imported as separate URLs, removing any whitespaces and descriptors (like `1024w` or `2x`).

### How did you verify your code works?
This fix can be verified by serving any html file containing image/source elements with the srcset-attribute, like:
`<img src="/img/image.jpg"
    srcset="/img/image.jpg 1x, /img/image-2x.jpg 2x, /img/image-3x.jpg 3x"/>`

Before this fix, this would result in an error as follows:
`error: Could not resolve: "/img/image.jpg 1x, /img/image-2x.jpg 2x, /img/image-3x.jpg 3x". Maybe you need to "bun install"?
    at /[...]/index.html`

### Related issues
Fixes #19529 
