### PR TITLE
fix(install): handle file:// and other non-HTTP/SSH git URL schemes

### DIFF
--- a/src/install/PackageManagerTask.zig
+++ b/src/install/PackageManagerTask.zig
@@ -210,9 +210,24 @@ pub fn callback(task: *ThreadPool.Task) void {
                 this.status = Status.fail;
                 this.data = .{ .git_clone = bun.invalid_fd };
                 return;
-            } else {
-                return;
-            };
+            } else
+                // For URL schemes not recognized as HTTPS or SSH (e.g. file://, git://),
+                // try passing the URL directly to git clone which handles them natively.
+                Repository.download(
+                    manager.allocator,
+                    this.request.git_clone.env,
+                    &this.log,
+                    manager.getCacheDirectory(),
+                    this.id,
+                    name,
+                    url,
+                    attempt,
+                ) catch |err| {
+                    this.err = err;
+                    this.status = Status.fail;
+                    this.data = .{ .git_clone = bun.invalid_fd };
+                    return;
+                };
 
             this.err = null;
             this.data = .{ .git_clone = .fromStdDir(dir) };

--- a/test/regression/issue/28105.test.ts
+++ b/test/regression/issue/28105.test.ts
@@ -1,0 +1,63 @@
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let repoDir: string;
+
+beforeAll(() => {
+  // Create a local git repo to use as a file:// dependency.
+  // We cannot use `using tempDir()` because it would be cleaned up when
+  // beforeAll returns, before the test runs.
+  repoDir = mkdtempSync(join(tmpdir(), "git-repo-28105-"));
+  writeFileSync(join(repoDir, "package.json"), JSON.stringify({ name: "test-git-pkg", version: "1.0.0" }));
+  writeFileSync(join(repoDir, "index.js"), "module.exports = 'hello';");
+
+  const gitEnv = { ...bunEnv, GIT_CONFIG_NOSYSTEM: "1" };
+
+  expect(Bun.spawnSync({ cmd: ["git", "init"], cwd: repoDir, env: gitEnv }).exitCode).toBe(0);
+  Bun.spawnSync({ cmd: ["git", "config", "user.email", "test@test.com"], cwd: repoDir, env: gitEnv });
+  Bun.spawnSync({ cmd: ["git", "config", "user.name", "Test"], cwd: repoDir, env: gitEnv });
+  expect(Bun.spawnSync({ cmd: ["git", "add", "."], cwd: repoDir, env: gitEnv }).exitCode).toBe(0);
+  expect(Bun.spawnSync({ cmd: ["git", "commit", "-m", "initial"], cwd: repoDir, env: gitEnv }).exitCode).toBe(0);
+});
+
+afterAll(() => {
+  rmSync(repoDir, { recursive: true, force: true });
+});
+
+test("bun install with git+file:// dependency succeeds", async () => {
+  // Create a separate project directory that depends on the git repo
+  const projectDir = mkdtempSync(join(tmpdir(), "test-28105-"));
+  writeFileSync(
+    join(projectDir, "package.json"),
+    JSON.stringify({
+      name: "test-project",
+      dependencies: {
+        "test-git-pkg": `git+file://${repoDir}`,
+      },
+    }),
+  );
+
+  try {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: projectDir,
+      env: { ...bunEnv, GIT_ASKPASS: "echo", GIT_CONFIG_NOSYSTEM: "1" },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // With the fix, file:// git dependencies should install successfully.
+    // Before the fix, the debug build would panic with:
+    //   "access of union field 'git_clone' while field 'package_manifest' is active"
+    // and the release build would produce a misleading error due to undefined behavior.
+    expect(stdout).toContain("test-git-pkg");
+    expect(exitCode).toBe(0);
+  } finally {
+    rmSync(projectDir, { recursive: true, force: true });
+  }
+});

--- a/test/regression/issue/28105.test.ts
+++ b/test/regression/issue/28105.test.ts
@@ -1,63 +1,54 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe } from "harness";
-import { tmpdir } from "os";
-import { join } from "path";
+import { bunEnv, bunExe, tempDir } from "harness";
 
-let repoDir: string;
+let repoDir: ReturnType<typeof tempDir>;
 
 beforeAll(() => {
   // Create a local git repo to use as a file:// dependency.
-  // We cannot use `using tempDir()` because it would be cleaned up when
-  // beforeAll returns, before the test runs.
-  repoDir = mkdtempSync(join(tmpdir(), "git-repo-28105-"));
-  writeFileSync(join(repoDir, "package.json"), JSON.stringify({ name: "test-git-pkg", version: "1.0.0" }));
-  writeFileSync(join(repoDir, "index.js"), "module.exports = 'hello';");
+  // We don't use `using` because the directory must survive until afterAll.
+  repoDir = tempDir("git-repo-28105", {
+    "package.json": JSON.stringify({ name: "test-git-pkg", version: "1.0.0" }),
+    "index.js": "module.exports = 'hello';",
+  });
 
   const gitEnv = { ...bunEnv, GIT_CONFIG_NOSYSTEM: "1" };
+  const cwd = String(repoDir);
 
-  expect(Bun.spawnSync({ cmd: ["git", "init"], cwd: repoDir, env: gitEnv }).exitCode).toBe(0);
-  Bun.spawnSync({ cmd: ["git", "config", "user.email", "test@test.com"], cwd: repoDir, env: gitEnv });
-  Bun.spawnSync({ cmd: ["git", "config", "user.name", "Test"], cwd: repoDir, env: gitEnv });
-  expect(Bun.spawnSync({ cmd: ["git", "add", "."], cwd: repoDir, env: gitEnv }).exitCode).toBe(0);
-  expect(Bun.spawnSync({ cmd: ["git", "commit", "-m", "initial"], cwd: repoDir, env: gitEnv }).exitCode).toBe(0);
+  expect(Bun.spawnSync({ cmd: ["git", "init"], cwd, env: gitEnv }).exitCode).toBe(0);
+  expect(Bun.spawnSync({ cmd: ["git", "config", "user.email", "test@test.com"], cwd, env: gitEnv }).exitCode).toBe(0);
+  expect(Bun.spawnSync({ cmd: ["git", "config", "user.name", "Test"], cwd, env: gitEnv }).exitCode).toBe(0);
+  expect(Bun.spawnSync({ cmd: ["git", "add", "."], cwd, env: gitEnv }).exitCode).toBe(0);
+  expect(Bun.spawnSync({ cmd: ["git", "commit", "-m", "initial"], cwd, env: gitEnv }).exitCode).toBe(0);
 });
 
 afterAll(() => {
-  rmSync(repoDir, { recursive: true, force: true });
+  repoDir[Symbol.dispose]();
 });
 
 test("bun install with git+file:// dependency succeeds", async () => {
-  // Create a separate project directory that depends on the git repo
-  const projectDir = mkdtempSync(join(tmpdir(), "test-28105-"));
-  writeFileSync(
-    join(projectDir, "package.json"),
-    JSON.stringify({
+  using projectDir = tempDir("test-28105", {
+    "package.json": JSON.stringify({
       name: "test-project",
       dependencies: {
         "test-git-pkg": `git+file://${repoDir}`,
       },
     }),
-  );
+  });
 
-  try {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: projectDir,
-      env: { ...bunEnv, GIT_ASKPASS: "echo", GIT_CONFIG_NOSYSTEM: "1" },
-      stderr: "pipe",
-      stdout: "pipe",
-    });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(projectDir),
+    env: { ...bunEnv, GIT_ASKPASS: "echo", GIT_CONFIG_NOSYSTEM: "1" },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // With the fix, file:// git dependencies should install successfully.
-    // Before the fix, the debug build would panic with:
-    //   "access of union field 'git_clone' while field 'package_manifest' is active"
-    // and the release build would produce a misleading error due to undefined behavior.
-    expect(stdout).toContain("test-git-pkg");
-    expect(exitCode).toBe(0);
-  } finally {
-    rmSync(projectDir, { recursive: true, force: true });
-  }
+  // With the fix, file:// git dependencies should install successfully.
+  // Before the fix, the debug build would panic with:
+  //   "access of union field 'git_clone' while field 'package_manifest' is active"
+  // and the release build would produce a misleading error due to undefined behavior.
+  expect(stdout).toContain("test-git-pkg");
+  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/28105.test.ts
+++ b/test/regression/issue/28105.test.ts
@@ -1,6 +1,6 @@
-import { test, expect, beforeAll, afterAll } from "bun:test";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { bunEnv, bunExe } from "harness";
-import { mkdtempSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 


### PR DESCRIPTION
## Summary

- Fix crash/panic when `bun install` encounters git dependencies with URL schemes not recognized as HTTPS or SSH (e.g. `file://`, `git://`)
- The `git_clone` task callback in `PackageManagerTask.zig` returned without initializing `task.data` or `task.status`, causing a panic (debug) or undefined behavior (release) when the task was later processed
- Fix passes unrecognized URL schemes directly to `git clone`, which natively supports `file://`, `git://`, and other protocols

## Root cause

In `PackageManagerTask.zig`, the `git_clone` callback tried `tryHTTPS()` then `trySSH()` to normalize the URL. When both returned `null` (for schemes like `file://`), the `else` branch simply returned without setting `this.data`, `this.status`, or `this.err`. The deferred cleanup unconditionally pushed the task to the resolve queue, where `runTasks.zig` accessed the uninitialized union field `task.data.git_clone`.

## Test plan

- [x] New regression test `test/regression/issue/28105.test.ts` creates a local git repo and installs it via `git+file://` protocol
- [x] Test fails with system bun (the bug), passes with the fix
- [x] Debug build verified: no panic, install succeeds

Closes #28105

🤖 Generated with [Claude Code](https://claude.com/claude-code)