### PR TITLE
Fix Bun.write hanging with Response(stream) body

### DIFF
--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -1413,6 +1413,21 @@ pub fn writeFileInternal(globalThis: *jsc.JSGlobalObject, path_or_blob_: *PathOr
                         destination_blob.detach();
                         return globalThis.throwInvalidArguments("ReadableStream has already been used", .{});
                     }
+                    // If the body already has a readable stream (e.g. `new Response(req.body)`),
+                    // pipe it directly to the file instead of waiting for `onReceiveValue` which
+                    // would never fire because there is no entity that will call `resolve()` on
+                    // this disconnected body value.
+                    if (response.getBodyReadableStream(globalThis) orelse bodyValue.Locked.readable.get(globalThis)) |readable| {
+                        if (readable.isDisturbed(globalThis)) {
+                            destination_blob.detach();
+                            return globalThis.throwInvalidArguments("ReadableStream has already been used", .{});
+                        }
+                        errdefer destination_blob.detach();
+                        const result = try destination_blob.pipeReadableStreamToBlob(globalThis, readable, options.extra_options);
+                        destination_blob.detach();
+                        return result;
+                    }
+
                     var task = bun.new(WriteFileWaitFromLockedValueTask, .{
                         .globalThis = globalThis,
                         .file_blob = destination_blob,
@@ -1476,6 +1491,20 @@ pub fn writeFileInternal(globalThis: *jsc.JSGlobalObject, path_or_blob_: *PathOr
                         destination_blob.detach();
                         return globalThis.throwInvalidArguments("ReadableStream has already been used", .{});
                     }
+                    // If the body already has a readable stream (e.g. `new Request(url, { body: stream })`),
+                    // pipe it directly to the file instead of waiting for `onReceiveValue` which
+                    // may never fire if there is no entity that will call `resolve()` on this body.
+                    if (request.getBodyReadableStream(globalThis) orelse locked.readable.get(globalThis)) |readable| {
+                        if (readable.isDisturbed(globalThis)) {
+                            destination_blob.detach();
+                            return globalThis.throwInvalidArguments("ReadableStream has already been used", .{});
+                        }
+                        errdefer destination_blob.detach();
+                        const result = try destination_blob.pipeReadableStreamToBlob(globalThis, readable, options.extra_options);
+                        destination_blob.detach();
+                        return result;
+                    }
+
                     var task = bun.new(WriteFileWaitFromLockedValueTask, .{
                         .globalThis = globalThis,
                         .file_blob = destination_blob,
@@ -2391,14 +2420,14 @@ pub fn onFileStreamResolveRequestStream(globalThis: *jsc.JSGlobalObject, callfra
     if (strong.get(globalThis)) |stream| {
         stream.done(globalThis);
     }
-    try this.promise.resolve(globalThis, jsc.JSValue.jsNumber(0));
+    try this.promise.resolve(globalThis, jsc.JSValue.jsNumber(this.sink.written));
     return .js_undefined;
 }
 
 pub fn onFileStreamRejectRequestStream(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
     const args = callframe.arguments_old(2);
     var this = args.ptr[args.len - 1].asPromisePtr(FileStreamWrapper);
-    defer this.sink.deref();
+    defer this.deinit();
     const err = args.ptr[0];
 
     var strong = this.readable_stream_ref;
@@ -2571,8 +2600,10 @@ pub fn pipeReadableStreamToBlob(this: *Blob, globalThis: *jsc.JSGlobalObject, re
 
     assignment_result.ensureStillAlive();
 
-    // assert that it was updated
-    bun.assert(!signal.isDead());
+    // Note: signal may still be dead if readStreamIntoSink completed
+    // synchronously (readMany() returned done:true without awaiting).
+    // In that case $startDirectStream is never called, which is fine
+    // because the stream has already been fully consumed via sink.end().
 
     if (assignment_result.toError()) |err| {
         file_sink.deref();
@@ -2603,9 +2634,10 @@ pub fn pipeReadableStreamToBlob(this: *Blob, globalThis: *jsc.JSGlobalObject, re
                     return promise_value;
                 },
                 .fulfilled => {
+                    const written = file_sink.written;
                     file_sink.deref();
                     readable_stream.done(globalThis);
-                    return jsc.JSPromise.resolvedPromiseValue(globalThis, jsc.JSValue.jsNumber(0));
+                    return jsc.JSPromise.resolvedPromiseValue(globalThis, jsc.JSValue.jsNumber(written));
                 },
                 .rejected => {
                     file_sink.deref();
@@ -2623,9 +2655,10 @@ pub fn pipeReadableStreamToBlob(this: *Blob, globalThis: *jsc.JSGlobalObject, re
             return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, assignment_result);
         }
     }
+    const written = file_sink.written;
     file_sink.deref();
 
-    return jsc.JSPromise.resolvedPromiseValue(globalThis, jsc.JSValue.jsNumber(0));
+    return jsc.JSPromise.resolvedPromiseValue(globalThis, jsc.JSValue.jsNumber(written));
 }
 
 pub fn getWriter(

--- a/test/regression/issue/28090.test.ts
+++ b/test/regression/issue/28090.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { join } from "path";
+
+test("Bun.write with new Response(req.body) does not hang", async () => {
+  using dir = tempDir("issue-28090-", {});
+  const outFile = join(String(dir), "test.txt");
+
+  await using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      await Bun.write(outFile, new Response(req.body));
+      return new Response("ok");
+    },
+  });
+
+  const res = await fetch(`http://localhost:${server.port}/`, {
+    method: "POST",
+    body: "hello from request body",
+  });
+
+  expect(await res.text()).toBe("ok");
+  expect(await Bun.file(outFile).text()).toBe("hello from request body");
+});
+
+test("Bun.write with new Response(ReadableStream) does not hang", async () => {
+  using dir = tempDir("issue-28090-", {});
+  const outFile = join(String(dir), "test.txt");
+
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("hello from stream"));
+      controller.close();
+    },
+  });
+
+  await Bun.write(outFile, new Response(stream));
+  expect(await Bun.file(outFile).text()).toBe("hello from stream");
+});
+
+test("Bun.write with new Response(req.body) after accessing req.body does not hang", async () => {
+  using dir = tempDir("issue-28090-", {});
+  const outFile = join(String(dir), "test.txt");
+
+  await using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      // Accessing req.body before wrapping it in a new Response
+      if (!req.body) {
+        return new Response("no body", { status: 400 });
+      }
+      await Bun.write(outFile, new Response(req.body));
+      return new Response("ok");
+    },
+  });
+
+  const res = await fetch(`http://localhost:${server.port}/`, {
+    method: "POST",
+    body: "body after access check",
+  });
+
+  expect(await res.text()).toBe("ok");
+  expect(await Bun.file(outFile).text()).toBe("body after access check");
+});


### PR DESCRIPTION
## Summary

Fixes `Bun.write(file, new Response(req.body))` hanging indefinitely.

- When a `Response` body is in `Locked` state with a readable stream already available (e.g. from `new Response(req.body)`), the code was creating a `WriteFileWaitFromLockedValueTask` waiting for `onReceiveValue` — but nobody would ever call `resolve()` on the disconnected body, causing a permanent hang
- Fix: detect when a Locked body already has a readable stream and pipe it directly via `pipeReadableStreamToBlob`, matching the pattern already used for S3 uploads
- Also removes an incorrect assertion in `pipeReadableStreamToBlob` that could fire when `readStreamIntoSink` completes synchronously
- Returns actual written byte count instead of hardcoded 0
- Fixes resource leak in `onFileStreamRejectRequestStream`

Closes #28090

## Test plan

- [x] `USE_SYSTEM_BUN=1 bun test test/regression/issue/28090.test.ts` → 3 failures (timeouts — confirms the hang)
- [x] `bun bd test test/regression/issue/28090.test.ts` → 3 passes
- Tests cover: `Bun.write` with `new Response(req.body)`, `new Response(ReadableStream)`, and `new Response(req.body)` after accessing `req.body`

https://claude.ai/code/session_01SMXk6VCYpNEAHd8evEDkac