### PR TITLE
fix: `Bun.write` with `new Response(req.body)` no longer hangs

### DIFF
--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -1577,6 +1577,21 @@ pub fn writeFileInternal(globalThis: *jsc.JSGlobalObject, path_or_blob_: *PathOr
                         destination_blob.detach();
                         return globalThis.throwInvalidArguments("ReadableStream has already been used", .{});
                     }
+
+                    // If the body is backed by a ReadableStream, pipe it to the file.
+                    // Without this, we'd only install an `onReceiveValue` callback and
+                    // never actually read from the stream, so the promise would never
+                    // settle (e.g. `Bun.write(path, new Response(req.body))`).
+                    // https://github.com/oven-sh/bun/issues/13237
+                    if (response.getBodyReadableStream(globalThis) orelse bodyValue.Locked.readable.get(globalThis)) |readable| {
+                        if (readable.isDisturbed(globalThis)) {
+                            destination_blob.detach();
+                            return globalThis.throwInvalidArguments("ReadableStream has already been used", .{});
+                        }
+                        defer destination_blob.detach();
+                        return destination_blob.pipeReadableStreamToBlob(globalThis, readable, options.extra_options);
+                    }
+
                     var task = bun.new(WriteFileWaitFromLockedValueTask, .{
                         .globalThis = globalThis,
                         .file_blob = destination_blob,
@@ -1640,6 +1655,21 @@ pub fn writeFileInternal(globalThis: *jsc.JSGlobalObject, path_or_blob_: *PathOr
                         destination_blob.detach();
                         return globalThis.throwInvalidArguments("ReadableStream has already been used", .{});
                     }
+
+                    // If the body is backed by a ReadableStream, pipe it to the file.
+                    // Without this, we'd only install an `onReceiveValue` callback and
+                    // never actually read from the stream, so the promise would never
+                    // settle (e.g. `Bun.write(path, req)` after accessing `req.body`).
+                    // https://github.com/oven-sh/bun/issues/13237
+                    if (request.getBodyReadableStream(globalThis) orelse locked.readable.get(globalThis)) |readable| {
+                        if (readable.isDisturbed(globalThis)) {
+                            destination_blob.detach();
+                            return globalThis.throwInvalidArguments("ReadableStream has already been used", .{});
+                        }
+                        defer destination_blob.detach();
+                        return destination_blob.pipeReadableStreamToBlob(globalThis, readable, options.extra_options);
+                    }
+
                     var task = bun.new(WriteFileWaitFromLockedValueTask, .{
                         .globalThis = globalThis,
                         .file_blob = destination_blob,
@@ -2551,20 +2581,21 @@ pub fn onFileStreamResolveRequestStream(globalThis: *jsc.JSGlobalObject, callfra
     var args = callframe.arguments_old(2);
     var this = args.ptr[args.len - 1].asPromisePtr(FileStreamWrapper);
     defer this.deinit();
+    const written = this.sink.written;
     var strong = this.readable_stream_ref;
     defer strong.deinit();
     this.readable_stream_ref = .{};
     if (strong.get(globalThis)) |stream| {
         stream.done(globalThis);
     }
-    try this.promise.resolve(globalThis, jsc.JSValue.jsNumber(0));
+    try this.promise.resolve(globalThis, jsc.JSValue.jsNumber(written));
     return .js_undefined;
 }
 
 pub fn onFileStreamRejectRequestStream(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
     const args = callframe.arguments_old(2);
     var this = args.ptr[args.len - 1].asPromisePtr(FileStreamWrapper);
-    defer this.sink.deref();
+    defer this.deinit();
     const err = args.ptr[0];
 
     var strong = this.readable_stream_ref;
@@ -2631,11 +2662,14 @@ pub fn pipeReadableStreamToBlob(this: *Blob, globalThis: *jsc.JSGlobalObject, re
                 const path = pathlike.path.sliceZ(&file_path);
                 switch (bun.sys.open(
                     path,
-                    bun.O.WRONLY | bun.O.CREAT | bun.O.NONBLOCK,
+                    bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC | bun.O.NONBLOCK,
                     write_permissions,
                 )) {
-                    .result => |result| {
-                        break :brk result;
+                    .result => |result| switch (result.makeLibUVOwnedForSyscall(.open, .close_on_fail)) {
+                        .result => |uv_fd| break :brk uv_fd,
+                        .err => |err| {
+                            return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, try err.withPath(path).toJS(globalThis));
+                        },
                     },
                     .err => |err| {
                         return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, try err.withPath(path).toJS(globalThis));
@@ -2737,8 +2771,10 @@ pub fn pipeReadableStreamToBlob(this: *Blob, globalThis: *jsc.JSGlobalObject, re
 
     assignment_result.ensureStillAlive();
 
-    // assert that it was updated
-    bun.assert(!signal.isDead());
+    // Note: signal may still be dead if readStreamIntoSink completed
+    // synchronously (readMany() returned done:true without awaiting).
+    // In that case $startDirectStream is never called, which is fine
+    // because the stream has already been fully consumed via sink.end().
 
     if (assignment_result.toError()) |err| {
         file_sink.deref();
@@ -2769,9 +2805,10 @@ pub fn pipeReadableStreamToBlob(this: *Blob, globalThis: *jsc.JSGlobalObject, re
                     return promise_value;
                 },
                 .fulfilled => {
+                    const written = file_sink.written;
                     file_sink.deref();
                     readable_stream.done(globalThis);
-                    return jsc.JSPromise.resolvedPromiseValue(globalThis, jsc.JSValue.jsNumber(0));
+                    return jsc.JSPromise.resolvedPromiseValue(globalThis, jsc.JSValue.jsNumber(written));
                 },
                 .rejected => {
                     file_sink.deref();
@@ -2789,9 +2826,10 @@ pub fn pipeReadableStreamToBlob(this: *Blob, globalThis: *jsc.JSGlobalObject, re
             return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, assignment_result);
         }
     }
+    const written = file_sink.written;
     file_sink.deref();
 
-    return jsc.JSPromise.resolvedPromiseValue(globalThis, jsc.JSValue.jsNumber(0));
+    return jsc.JSPromise.resolvedPromiseValue(globalThis, jsc.JSValue.jsNumber(written));
 }
 
 pub fn getWriter(

--- a/src/runtime/webcore/FileSink.zig
+++ b/src/runtime/webcore/FileSink.zig
@@ -66,9 +66,9 @@ pub const Options = struct {
     mode: bun.Mode = 0o664,
 
     pub fn flags(this: *const Options) i32 {
-        _ = this;
-
-        return bun.O.NONBLOCK | bun.O.CLOEXEC | bun.O.CREAT | bun.O.WRONLY;
+        var f: i32 = bun.O.NONBLOCK | bun.O.CLOEXEC | bun.O.CREAT | bun.O.WRONLY;
+        if (this.truncate) f |= bun.O.TRUNC;
+        return f;
     }
 };
 

--- a/test/regression/issue/13237.test.ts
+++ b/test/regression/issue/13237.test.ts
@@ -1,0 +1,168 @@
+// https://github.com/oven-sh/bun/issues/13237
+//
+// Bun.write with a Response/Request whose body is a ReadableStream used to
+// hang forever: the `.Locked` body path only installed an `onReceiveValue`
+// callback and never actually read from the stream, so the returned promise
+// never settled.
+//
+// These tests spawn subprocesses so a hang turns into a clean failure instead
+// of blocking the test runner.
+
+import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+async function run(dir: string, script: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 10_000,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("Bun.write with a ReadableStream-backed body", () => {
+  it("Bun.write(path, new Response(ReadableStream))", async () => {
+    using dir = tempDir("issue-13237-response-stream", {});
+    const out = join(String(dir), "out.txt");
+    const { stdout, stderr, exitCode } = await run(
+      String(dir),
+      `
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("hello "));
+            controller.enqueue(new TextEncoder().encode("world"));
+            controller.close();
+          },
+        });
+        const written = await Bun.write(${JSON.stringify(out)}, new Response(stream));
+        console.log(JSON.stringify({ written, text: await Bun.file(${JSON.stringify(out)}).text() }));
+      `,
+    );
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ written: 11, text: "hello world" });
+    expect(exitCode).toBe(0);
+  });
+
+  it("Bun.write(path, new Request(url, { body: ReadableStream }))", async () => {
+    using dir = tempDir("issue-13237-request-stream", {});
+    const out = join(String(dir), "out.txt");
+    const { stdout, stderr, exitCode } = await run(
+      String(dir),
+      `
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("from request"));
+            controller.close();
+          },
+        });
+        const req = new Request("http://example.com", { method: "POST", body: stream });
+        const written = await Bun.write(${JSON.stringify(out)}, req);
+        console.log(JSON.stringify({ written, text: await Bun.file(${JSON.stringify(out)}).text() }));
+      `,
+    );
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ written: 12, text: "from request" });
+    expect(exitCode).toBe(0);
+  });
+
+  it("Bun.file(path).write(new Response(ReadableStream))", async () => {
+    using dir = tempDir("issue-13237-file-write", {});
+    const out = join(String(dir), "out.txt");
+    const { stdout, stderr, exitCode } = await run(
+      String(dir),
+      `
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("instance method"));
+            controller.close();
+          },
+        });
+        const written = await Bun.file(${JSON.stringify(out)}).write(new Response(stream));
+        console.log(JSON.stringify({ written, text: await Bun.file(${JSON.stringify(out)}).text() }));
+      `,
+    );
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ written: 15, text: "instance method" });
+    expect(exitCode).toBe(0);
+  });
+
+  it("Bun.write(path, new Response(req.body)) inside a server handler", async () => {
+    using dir = tempDir("issue-13237-server-response-body", {});
+    const out = join(String(dir), "out.txt");
+    const { stdout, stderr, exitCode } = await run(
+      String(dir),
+      `
+        const server = Bun.serve({
+          port: 0,
+          async fetch(req) {
+            const written = await Bun.write(${JSON.stringify(out)}, new Response(req.body));
+            return new Response(String(written));
+          },
+        });
+        const res = await fetch(server.url, { method: "POST", body: "hello from server" });
+        const written = await res.text();
+        server.stop();
+        console.log(JSON.stringify({ written, text: await Bun.file(${JSON.stringify(out)}).text() }));
+      `,
+    );
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ written: "17", text: "hello from server" });
+    expect(exitCode).toBe(0);
+  });
+
+  it("Bun.write(path, new Response(ReadableStream)) truncates the destination file", async () => {
+    using dir = tempDir("issue-13237-truncate", {});
+    const out = join(String(dir), "out.txt");
+    const { stdout, stderr, exitCode } = await run(
+      String(dir),
+      `
+        const body = (n, c) =>
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(Buffer.alloc(n, c));
+                controller.close();
+              },
+            }),
+          );
+        await Bun.write(${JSON.stringify(out)}, body(1000, "A"));
+        await Bun.write(${JSON.stringify(out)}, body(100, "B"));
+        const text = await Bun.file(${JSON.stringify(out)}).text();
+        console.log(JSON.stringify({ length: text.length, ok: text === Buffer.alloc(100, "B").toString() }));
+      `,
+    );
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ length: 100, ok: true });
+    expect(exitCode).toBe(0);
+  });
+
+  it("Bun.write(path, req) after accessing req.body inside a server handler", async () => {
+    using dir = tempDir("issue-13237-server-body-access", {});
+    const out = join(String(dir), "out.txt");
+    const { stdout, stderr, exitCode } = await run(
+      String(dir),
+      `
+        const server = Bun.serve({
+          port: 0,
+          async fetch(req) {
+            if (!req.body) return new Response("no body", { status: 400 });
+            const written = await Bun.write(${JSON.stringify(out)}, req);
+            return new Response(String(written));
+          },
+        });
+        const res = await fetch(server.url, { method: "POST", body: "body was touched" });
+        const written = await res.text();
+        server.stop();
+        console.log(JSON.stringify({ written, text: await Bun.file(${JSON.stringify(out)}).text() }));
+      `,
+    );
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ written: "16", text: "body was touched" });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

`Bun.write(path, new Response(req.body))` — and any other `Bun.write` whose source is a Response/Request backed by a `ReadableStream` — hung forever. The `.Locked` body path in `writeFileInternal` only installed an `onReceiveValue` callback and returned; nothing ever *read* the stream, so the returned promise never settled.

## Repro

```js
const server = Bun.serve({
  port: 0,
  async fetch(req) {
    await Bun.write("out.txt", new Response(req.body)); // hangs
    return new Response("ok");
  },
});
await fetch(server.url, { method: "POST", body: "hello" });
```

Also hangs:
- `Bun.write(path, new Response(new ReadableStream({...})))`
- `Bun.write(path, req)` after touching `req.body`
- `Bun.file(path).write(new Response(stream))`

## Fix

In `Blob.writeFileInternal`'s `.Locked` branch for file destinations, if the body already has (or exposes) a `ReadableStream`, pipe it through `pipeReadableStreamToBlob` — the same mechanism the S3 branch already uses. The passive `WriteFileWaitFromLockedValueTask` path is kept as a fallback for the case where the body is still buffering server-side with no stream yet.

### Related fixes to `pipeReadableStreamToBlob`

Now that this path is reachable from the common `Bun.write` case (previously only S3→file used it), a few latent issues had to be addressed:

- **Byte count**: resolve with `file_sink.written` instead of hardcoded `0`.
- **Windows**: convert the opened fd via `makeLibUVOwnedForSyscall` so the `FileSink` writer (libuv) can use it; previously asserted.
- **Truncation**: open the destination with `O_TRUNC` (both the Windows open and `FileSink.Options.flags()`, whose `truncate` field was present but ignored) so overwriting a larger file with a smaller stream doesn't leave stale bytes.
- **Sync completion**: drop the `bun.assert(!signal.isDead())` — when the stream drains synchronously via `sink.end()`, `$startDirectStream` is never called and the signal legitimately stays dead.
- **Reject-path leak**: `onFileStreamRejectRequestStream` only deref'd the sink; now calls `FileStreamWrapper.deinit()` so the promise strong-ref and allocation are freed too.

## Tests

`test/regression/issue/13237.test.ts` — six subprocess-isolated cases (so a hang becomes a clean failure, not a stuck runner):
1. `Bun.write(path, new Response(ReadableStream))`
2. `Bun.write(path, new Request(url, { body: ReadableStream }))`
3. `Bun.file(path).write(new Response(ReadableStream))`
4. `Bun.write(path, new Response(req.body))` inside a server handler
5. `Bun.write(path, new Response(ReadableStream))` truncates the destination
6. `Bun.write(path, req)` after touching `req.body` inside a server handler

Without the fix: 0 pass / 6 fail (timeout). With the fix: 6 pass / 0 fail.

Fixes #13237