### PR TITLE
ws: support upgrade and unexpected-response events

### DIFF
--- a/src/http_jsc/websocket_client/CppWebSocket.rs
+++ b/src/http_jsc/websocket_client/CppWebSocket.rs
@@ -22,6 +22,19 @@ bun_opaque::opaque_ffi! {
     pub struct CppWebSocket;
 }
 
+/// A single HTTP response header passed across the FFI to
+/// `WebSocket__didReceiveHandshakeResponse`. Name/value point into the
+/// PicoHTTP-parsed response head, which the caller keeps alive for the
+/// duration of the synchronous dispatch. Matches `WebCore::WebSocket::
+/// HandshakeRawHeader` (src/jsc/bindings/webcore/WebSocket.h).
+#[repr(C)]
+pub struct RawHeader {
+    pub name_ptr: *const u8,
+    pub name_len: usize,
+    pub value_ptr: *const u8,
+    pub value_len: usize,
+}
+
 // FFI surface for `WebCore::WebSocket` (src/jsc/bindings/webcore/WebSocket.cpp).
 // Kept private to this module — the safe wrappers below are the only callers.
 //
@@ -45,6 +58,16 @@ unsafe extern "C" {
         deflate_params: *const websocket_deflate::Params,
     );
     safe fn WebSocket__didAbruptClose(websocket_context: &CppWebSocket, reason: ErrorCode);
+    fn WebSocket__didReceiveHandshakeResponse(
+        websocket_context: &CppWebSocket,
+        status_code: u16,
+        status_message: *const u8,
+        status_message_len: usize,
+        headers: *const RawHeader,
+        headers_len: usize,
+        body: *const u8,
+        body_len: usize,
+    );
     fn WebSocket__didClose(websocket_context: &CppWebSocket, code: u16, reason: *const BunString);
     fn WebSocket__didReceiveText(
         websocket_context: &CppWebSocket,
@@ -75,6 +98,39 @@ impl CppWebSocket {
         let event_loop = VirtualMachine::get().event_loop_mut();
         event_loop.enter();
         WebSocket__didAbruptClose(self, reason);
+        event_loop.exit();
+    }
+
+    /// Dispatch the native `'handshake'` event to the `ws` shim.
+    ///
+    /// `status_message`, `headers`, and `body` are borrowed for the call only
+    /// — the C++ side copies whatever it needs into JS values synchronously.
+    // Forwards raw pointers to C++ without dereferencing on the Rust side.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    pub(crate) fn did_receive_handshake_response(
+        &self,
+        status_code: u16,
+        status_message: &[u8],
+        headers: &[RawHeader],
+        body: &[u8],
+    ) {
+        // SAFETY: VirtualMachine::get() returns the live current-thread VM;
+        // event_loop() yields its raw event-loop pointer (live for VM lifetime).
+        let event_loop = VirtualMachine::get().event_loop_mut();
+        event_loop.enter();
+        // SAFETY: self is a valid C++ WebCore::WebSocket; the slices outlive the call.
+        unsafe {
+            WebSocket__didReceiveHandshakeResponse(
+                self,
+                status_code,
+                status_message.as_ptr(),
+                status_message.len(),
+                headers.as_ptr(),
+                headers.len(),
+                body.as_ptr(),
+                body.len(),
+            )
+        };
         event_loop.exit();
     }
 

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -88,6 +88,28 @@ enum State {
     Done,
 }
 
+/// Non-`None` while buffering the body of a non-101 response that spans
+/// multiple TCP reads. The `'handshake'` event is deferred until the full
+/// body is in hand so the `unexpected-response` consumer sees the complete
+/// payload instead of just the bytes colocated with the header block in the
+/// first read.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DeferredHandshake {
+    None,
+    /// Total expected buffer length (`head_len + Content-Length`).
+    WaitingForLength(usize),
+    /// No `Content-Length`; accumulate until the peer closes the connection.
+    WaitingForEof,
+}
+
+/// Maximum bytes buffered for a non-101 response body before bailing out.
+/// Real error pages (workerd restart text, JSON API errors, HTML) fit well
+/// under this; the cap stops a malicious or misbehaving server from making
+/// us accumulate unbounded data — either via a giant `Content-Length` header
+/// or a keep-alive connection that never closes after a no-`Content-Length`
+/// response.
+const MAX_NON_101_BODY: usize = 64 * 1024 * 1024;
+
 /// `NewHTTPUpgradeClient(comptime ssl: bool) type` — generic over `SSL`.
 ///
 /// `bun.ptr.RefCount(@This(), "ref_count", deinit, .{})` — intrusive single-thread
@@ -137,6 +159,11 @@ pub struct HTTPClient<const SSL: bool> {
     /// with a `Sec-WebSocket-Extensions` header anyway, `processResponse`
     /// fails the handshake per RFC 6455 §9.1 — matching upstream `ws`.
     offered_permessage_deflate: bool,
+
+    /// Tracks deferred dispatch of the `'handshake'` event for non-101
+    /// responses whose body straddles multiple TCP reads. See
+    /// [`DeferredHandshake`].
+    deferred_handshake: DeferredHandshake,
 }
 
 // Handler set referenced by `dispatch.zig` (kind = `.ws_client_upgrade[_tls]`).
@@ -354,6 +381,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
             expected_accept: request_result.expected_accept,
             offered_permessage_deflate: offer_permessage_deflate,
             subprotocols,
+            deferred_handshake: DeferredHandshake::None,
         }));
         bun_core::scoped_log!(alloc, "new({}) = {:p}", Self::TYPE_NAME, client);
         // SAFETY: just allocated above; we hold the only ref. This `&mut` is
@@ -705,6 +733,22 @@ impl<const SSL: bool> HTTPClient<SSL> {
     pub unsafe fn handle_close(this: *mut Self, _: Socket<SSL>, _: c_int, _: *mut c_void) {
         log!("onClose");
         bun_jsc::mark_binding!();
+
+        // If a non-101 response body was mid-accumulation when the peer reset
+        // the socket (RST rather than FIN, so `handle_end` never fires),
+        // flush whatever arrived BEFORE `clear_data()` frees `self.body`. The
+        // flush runs `process_response` which terminates the non-101 and
+        // clears `outgoing_websocket`, so `dispatch_abrupt_close` below is a
+        // no-op. We still `deref` once to balance the socket ref.
+        // SAFETY: forwards `this` with root provenance; no `&mut Self` is live.
+        if unsafe { Self::flush_deferred_on_close(this) } {
+            // SAFETY: short-lived `&mut` for the field detach.
+            unsafe { (*this).tcp.detach() };
+            // SAFETY: may free `this`; no `&mut Self` is live.
+            unsafe { Self::deref(this) };
+            return;
+        }
+
         // SAFETY: short-lived `&mut` borrows; each ends before the next call.
         unsafe { (*this).clear_data() };
         // SAFETY: short-lived `&mut` for the field detach; `this` is live per caller contract.
@@ -719,6 +763,19 @@ impl<const SSL: bool> HTTPClient<SSL> {
     /// # Safety
     /// `this` must point to a live `Self`. See `fail`.
     pub unsafe fn terminate(this: *mut Self, code: ErrorCode) {
+        // If a non-101 response body was being accumulated when the transport
+        // ended cleanly (peer close), flush the deferred handshake first so
+        // the `unexpected-response` listener sees what the server delivered.
+        // `handle_end`/`handle_close` flush directly for the plain-TCP path;
+        // the wss://-through-HTTP-CONNECT-proxy path comes in via
+        // `WebSocketProxyTunnel::on_close` → `terminate(Ended)` without going
+        // through either, so the flush must live here too.
+        if code == ErrorCode::Ended {
+            // SAFETY: forwards `this`; no `&mut Self` is live. May free `this`.
+            if unsafe { Self::flush_deferred_on_close(this) } {
+                return;
+            }
+        }
         // SAFETY: forwards `this` with root provenance.
         unsafe { Self::fail(this, code) };
         // We cannot access the pointer after fail is called.
@@ -927,8 +984,17 @@ impl<const SSL: bool> HTTPClient<SSL> {
             }
         }
 
+        // If we're mid-way through buffering a non-101 response body (a
+        // `Content-Length` larger than the first read, or a no-`Content-
+        // Length` response read until EOF), keep appending and check for
+        // completion before trying to parse again. See `DeferredHandshake`.
+        // SAFETY: forwards `this` with root provenance; no `&mut Self` is live.
+        if unsafe { Self::append_deferred_handshake_body(this.as_ptr(), data) } {
+            return;
+        }
+
         // SAFETY: short-lived `&mut` for body buffering; no reentrant calls in
-        // this region until `terminate`/`process_response` below.
+        // this region until `terminate`/`process_websocket_upgrade_response` below.
         let me = unsafe { &mut *this.as_ptr() };
         let mut body = data;
         if !me.body.is_empty() {
@@ -939,17 +1005,6 @@ impl<const SSL: bool> HTTPClient<SSL> {
             }
             me.body.extend_from_slice(data);
             body = &me.body;
-        }
-
-        let is_first = me.body.is_empty();
-        const HTTP_101: &[u8] = b"HTTP/1.1 101 ";
-        if is_first && body.len() > HTTP_101.len() {
-            // fail early if we receive a non-101 status code
-            if !body.starts_with(HTTP_101) {
-                // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
-                unsafe { Self::terminate(this.as_ptr(), ErrorCode::Expected101StatusCode) };
-                return;
-            }
         }
 
         let response = match picohttp::Response::parse(body, &mut me.headers_buf) {
@@ -972,14 +1027,279 @@ impl<const SSL: bool> HTTPClient<SSL> {
             }
         };
 
-        let bytes_read = usize::try_from(response.bytes_read).expect("int cast");
-        // PORT NOTE: reshaped for borrowck — copy remain_buf out before mutating self.
-        let remain_buf: Vec<u8> = body[bytes_read..].to_vec();
-        // PERF(port): was zero-copy slice into self.body.
+        // PORT NOTE: reshaped for borrowck — copy the full parsed buffer out
+        // before mutating self, since `process_websocket_upgrade_response`
+        // re-parses it and may mutate `self.body`/`headers_buf`.
+        let full: Vec<u8> = body.to_vec();
         // SAFETY: `me`'s last use is the `body` slice above (now copied out);
         // no `&mut Self` spans this call.
-        unsafe { Self::process_response(this.as_ptr(), response, &remain_buf) };
+        unsafe { Self::process_websocket_upgrade_response(this.as_ptr(), response, &full) };
         // `_guard` drops here, balancing the ref above. May free `this`.
+    }
+
+    /// Scan response headers for `Content-Length`; return the parsed value or
+    /// `None` when the header is absent or unparseable.
+    fn find_content_length(response: &picohttp::Response) -> Option<usize> {
+        for header in response.headers.list {
+            if header.name().len() == b"Content-Length".len()
+                && strings::eql_case_insensitive_ascii_ignore_length(
+                    header.name(),
+                    b"Content-Length",
+                )
+            {
+                let value = header.value();
+                let trimmed = core::str::from_utf8(value)
+                    .ok()?
+                    .trim_matches(|c| c == ' ' || c == '\t');
+                return trimmed.parse::<usize>().ok();
+            }
+        }
+        None
+    }
+
+    /// Append `data` to the deferred non-101 body buffer.
+    ///
+    /// Returns `true` when `data` was consumed as part of a deferred
+    /// handshake (and the caller should stop processing this read). Enforces
+    /// [`MAX_NON_101_BODY`] so neither a giant `Content-Length` nor a
+    /// never-closing no-`Content-Length` stream can grow `self.body` without
+    /// bound.
+    ///
+    /// # Safety
+    /// `this` must point to a live `Self`. Takes `*mut Self` because
+    /// `terminate`/`flush_deferred_handshake_and_process` may free `this`.
+    unsafe fn append_deferred_handshake_body(this: *mut Self, data: &[u8]) -> bool {
+        // SAFETY: short-lived read; ends before any dispatch below.
+        let state = unsafe { (*this).deferred_handshake };
+        match state {
+            DeferredHandshake::None => false,
+            DeferredHandshake::WaitingForLength(target_len) => {
+                // `target_len` was bounded to `head_len + MAX_NON_101_BODY`
+                // by `process_websocket_upgrade_response`, so the buffer can
+                // never exceed that limit.
+                //
+                // If this read carries past `target_len`, take only enough
+                // bytes to fill the declared body; the rest belong to the
+                // next pipelined response or are trailing garbage — matching
+                // the single-chunk fast path which truncates to
+                // `full[..target_len]` before dispatching.
+                // SAFETY: short-lived `&mut`; ends before the dispatch below.
+                let me = unsafe { &mut *this };
+                let available = target_len - me.body.len();
+                let take = available.min(data.len());
+                me.body.extend_from_slice(&data[..take]);
+                if me.body.len() >= target_len {
+                    me.body.truncate(target_len);
+                    me.deferred_handshake = DeferredHandshake::None;
+                    let full: Vec<u8> = core::mem::take(&mut me.body);
+                    // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
+                    unsafe { Self::flush_deferred_handshake_and_process(this, &full) };
+                }
+                true
+            }
+            DeferredHandshake::WaitingForEof => {
+                // SAFETY: short-lived `&mut`; ends before any dispatch.
+                let me = unsafe { &mut *this };
+                if me.body.len().saturating_add(data.len()) > MAX_NON_101_BODY {
+                    me.deferred_handshake = DeferredHandshake::None;
+                    // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
+                    unsafe { Self::terminate(this, ErrorCode::Expected101StatusCode) };
+                    return true;
+                }
+                me.body.extend_from_slice(data);
+                true
+            }
+        }
+    }
+
+    /// Shared between the plain-TCP and proxy-tunnel paths.
+    ///
+    /// For non-101 responses whose body straddles multiple TCP reads, defer
+    /// the handshake dispatch until the full body is in hand so the
+    /// `unexpected-response` listener sees the complete payload instead of a
+    /// truncated prefix.
+    ///
+    /// `full` is the complete parsed buffer (head + whatever body bytes are
+    /// on hand). `response` was parsed from it.
+    ///
+    /// # Safety
+    /// `this` must point to a live `Self`. Takes `*mut Self` because the
+    /// dispatch / `terminate` / `process_response` calls below may free
+    /// `this`.
+    unsafe fn process_websocket_upgrade_response(
+        this: *mut Self,
+        response: picohttp::Response,
+        full: &[u8],
+    ) {
+        let head_len = usize::try_from(response.bytes_read).expect("int cast");
+        let status_code = u16::try_from(response.status_code).unwrap_or(0);
+
+        // SAFETY: short-lived read; ends before any dispatch below.
+        let has_ws = unsafe { (*this).outgoing_websocket.is_some() };
+        if !has_ws {
+            // SAFETY: forwards `this`; no `&mut Self` is live.
+            unsafe { Self::process_response(this, response, &full[head_len..]) };
+            return;
+        }
+
+        if status_code != 101 {
+            // Defer the dispatch if the full body isn't present yet.
+            match Self::find_content_length(&response) {
+                Some(cl) => {
+                    // Reject an absurd Content-Length up front so the
+                    // saturating add below can't wrap and trap us in an
+                    // unbounded accumulate loop.
+                    if cl > MAX_NON_101_BODY {
+                        // SAFETY: no `&mut Self` is live.
+                        unsafe { Self::terminate(this, ErrorCode::Expected101StatusCode) };
+                        return;
+                    }
+                    let target_len = head_len + cl;
+                    if full.len() < target_len {
+                        // SAFETY: short-lived `&mut`; ends before return. Own
+                        // the accumulated bytes so subsequent reads append.
+                        let me = unsafe { &mut *this };
+                        if me.body.as_ptr() != full.as_ptr() {
+                            me.body.clear();
+                            me.body.extend_from_slice(full);
+                        }
+                        me.deferred_handshake = DeferredHandshake::WaitingForLength(target_len);
+                        return;
+                    }
+                    // Truncate at head_len + Content-Length — drop any bytes
+                    // beyond the declared body length.
+                    // SAFETY: forwards `this`; no `&mut Self` is live.
+                    unsafe {
+                        Self::flush_deferred_handshake_and_process(this, &full[..target_len]);
+                    }
+                    return;
+                }
+                None => {
+                    // No Content-Length — RFC 7230 §3.3.3: read until the
+                    // peer closes. Defer to handle_end / handle_close.
+                    // SAFETY: short-lived `&mut`; ends before return.
+                    let me = unsafe { &mut *this };
+                    if me.body.as_ptr() != full.as_ptr() {
+                        me.body.clear();
+                        me.body.extend_from_slice(full);
+                    }
+                    me.deferred_handshake = DeferredHandshake::WaitingForEof;
+                    return;
+                }
+            }
+        }
+
+        // 101 fast path — post-header bytes are the first WebSocket frame,
+        // not HTTP body; `dispatch_handshake_and_process` drops them from the
+        // handshake event and `process_response` hands them to the connected
+        // client as buffered overflow.
+        // SAFETY: forwards `this`; no `&mut Self` is live.
+        unsafe {
+            Self::dispatch_handshake_and_process(this, response, full, head_len, status_code);
+        }
+    }
+
+    /// Re-parse the accumulated (complete) buffer and dispatch. Called from
+    /// the deferred paths once `buffer` holds the full response.
+    ///
+    /// # Safety
+    /// `this` must point to a live `Self`; `terminate`/dispatch may free it.
+    unsafe fn flush_deferred_handshake_and_process(this: *mut Self, buffer: &[u8]) {
+        // PORT NOTE: re-parse into a local copy's headers_buf. Copy `buffer`
+        // so a re-parse against `self.headers_buf` doesn't alias `self.body`.
+        let owned: Vec<u8> = buffer.to_vec();
+        // SAFETY: short-lived `&mut` for the parse scratch buffer.
+        let me = unsafe { &mut *this };
+        let response = match picohttp::Response::parse(&owned, &mut me.headers_buf) {
+            Ok(r) => r,
+            Err(_) => {
+                // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
+                unsafe { Self::terminate(this, ErrorCode::InvalidResponse) };
+                return;
+            }
+        };
+        let head_len = usize::try_from(response.bytes_read).expect("int cast");
+        let status_code = u16::try_from(response.status_code).unwrap_or(0);
+        // SAFETY: short-lived read.
+        let has_ws = unsafe { (*this).outgoing_websocket.is_some() };
+        if !has_ws {
+            // SAFETY: forwards `this`; no `&mut Self` is live.
+            unsafe { Self::process_response(this, response, &owned[head_len..]) };
+            return;
+        }
+        // SAFETY: forwards `this`; no `&mut Self` is live.
+        unsafe {
+            Self::dispatch_handshake_and_process(this, response, &owned, head_len, status_code);
+        }
+    }
+
+    /// Dispatch the `'handshake'` event into JS (synchronous), then run
+    /// `process_response`.
+    ///
+    /// # Safety
+    /// `this` must point to a live `Self`. JS in the handshake listener can
+    /// call `ws.close()`/`ws.terminate()` which re-enters and may free
+    /// `this`; the `ref_guard` below keeps it alive across the dispatch.
+    unsafe fn dispatch_handshake_and_process(
+        this: *mut Self,
+        response: picohttp::Response,
+        full: &[u8],
+        head_len: usize,
+        status_code: u16,
+    ) {
+        // SAFETY: short-lived read of the handle; copied out before dispatch.
+        let Some(ws) = (unsafe { (*this).outgoing_websocket }) else {
+            // SAFETY: forwards `this`; no `&mut Self` is live.
+            unsafe { Self::process_response(this, response, &full[head_len..]) };
+            return;
+        };
+
+        // Keep `this` alive across the synchronous JS dispatch: the listener
+        // may `ws.terminate()` → didAbruptClose → free us mid-function.
+        // handle_data refs around its whole body, but handle_end / handle_close
+        // flush through here directly, so guard unconditionally.
+        // SAFETY: `this` carries root provenance; balanced on drop.
+        let _guard = unsafe { ThisPtr::new(this) }.ref_guard();
+
+        // On 101, the bytes after the header block are the first WebSocket
+        // frame — not HTTP body. Surface an empty body to the handshake
+        // event; `process_response` still hands `full[head_len..]` to the
+        // connected client as overflow.
+        let handshake_body: &[u8] = if status_code == 101 {
+            &[]
+        } else {
+            &full[head_len..]
+        };
+
+        // Build the raw-header array the C++ side copies into `rawHeaders`.
+        // SAFETY: the header name/value slices point into `full`, which
+        // outlives this synchronous call.
+        let mut raw_headers: Vec<super::cpp_websocket::RawHeader> =
+            Vec::with_capacity(response.headers.list.len());
+        for h in response.headers.list {
+            let name = h.name();
+            let value = h.value();
+            raw_headers.push(super::cpp_websocket::RawHeader {
+                name_ptr: name.as_ptr(),
+                name_len: name.len(),
+                value_ptr: value.as_ptr(),
+                value_len: value.len(),
+            });
+        }
+
+        CppWebSocket::opaque_ref(ws).did_receive_handshake_response(
+            status_code,
+            response.status,
+            &raw_headers,
+            handshake_body,
+        );
+
+        // SAFETY: short-lived read; the JS listener may have cleared it.
+        if unsafe { (*this).outgoing_websocket.is_none() } {
+            return;
+        }
+        // SAFETY: forwards `this`; no `&mut Self` is live.
+        unsafe { Self::process_response(this, response, &full[head_len..]) };
     }
 
     /// # Safety
@@ -1236,8 +1556,14 @@ impl<const SSL: bool> HTTPClient<SSL> {
     pub unsafe fn handle_decrypted_data(this: *mut Self, data: &[u8]) {
         log!("handleDecryptedData: {} bytes", data.len());
 
+        // Same deferred-body flushing as the plain-TCP path.
+        // SAFETY: forwards `this`; no `&mut Self` is live.
+        if unsafe { Self::append_deferred_handshake_body(this, data) } {
+            return;
+        }
+
         // SAFETY: short-lived `&mut` for body buffering; no reentrant calls in
-        // this region until `terminate`/`process_response` below.
+        // this region until `terminate`/`process_websocket_upgrade_response` below.
         let me = unsafe { &mut *this };
 
         // Process as if it came directly from the socket
@@ -1250,17 +1576,6 @@ impl<const SSL: bool> HTTPClient<SSL> {
             }
             me.body.extend_from_slice(data);
             body = &me.body;
-        }
-
-        let is_first = me.body.is_empty();
-        const HTTP_101: &[u8] = b"HTTP/1.1 101 ";
-        if is_first && body.len() > HTTP_101.len() {
-            // fail early if we receive a non-101 status code
-            if !body.starts_with(HTTP_101) {
-                // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
-                unsafe { Self::terminate(this, ErrorCode::Expected101StatusCode) };
-                return;
-            }
         }
 
         let response = match picohttp::Response::parse(body, &mut me.headers_buf) {
@@ -1283,13 +1598,11 @@ impl<const SSL: bool> HTTPClient<SSL> {
             }
         };
 
-        let bytes_read = usize::try_from(response.bytes_read).expect("int cast");
-        // PORT NOTE: reshaped for borrowck — copy remain_buf out before mutating self.
-        let remain_buf: Vec<u8> = body[bytes_read..].to_vec();
-        // PERF(port): was zero-copy slice.
+        // PORT NOTE: copy the full parsed buffer out before mutating self.
+        let full: Vec<u8> = body.to_vec();
         // SAFETY: `me`'s last use is the `body` slice above (now copied out);
         // no `&mut Self` spans this call.
-        unsafe { Self::process_response(this, response, &remain_buf) };
+        unsafe { Self::process_websocket_upgrade_response(this, response, &full) };
     }
 
     /// # Safety
@@ -1297,8 +1610,41 @@ impl<const SSL: bool> HTTPClient<SSL> {
     /// `terminate` may free `this`; see `fail`.
     pub unsafe fn handle_end(this: *mut Self, _: Socket<SSL>) {
         log!("onEnd");
+        // If we were waiting for the peer to close before dispatching a
+        // non-101 response body (Content-Length absent, or a short
+        // Content-Length that never completed), flush now with whatever
+        // arrived so the `unexpected-response` consumer sees the partial
+        // body rather than nothing.
+        // SAFETY: forwards `this` with root provenance; no `&mut Self` is live.
+        if unsafe { Self::flush_deferred_on_close(this) } {
+            return;
+        }
         // SAFETY: forwards `this` with root provenance; no `&mut Self` is live.
         unsafe { Self::terminate(this, ErrorCode::Ended) };
+    }
+
+    /// Flush a pending deferred-handshake body on clean/abrupt connection
+    /// end. Returns `true` when it dispatched (and thus consumed the
+    /// teardown — the caller should not also `terminate`).
+    ///
+    /// # Safety
+    /// `this` must point to a live `Self`; the dispatch may free `this`.
+    unsafe fn flush_deferred_on_close(this: *mut Self) -> bool {
+        // SAFETY: short-lived read/reset; ends before the dispatch.
+        let me = unsafe { &mut *this };
+        match me.deferred_handshake {
+            DeferredHandshake::None => false,
+            DeferredHandshake::WaitingForLength(_) | DeferredHandshake::WaitingForEof => {
+                me.deferred_handshake = DeferredHandshake::None;
+                if me.body.is_empty() {
+                    return false;
+                }
+                let full: Vec<u8> = core::mem::take(&mut me.body);
+                // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
+                unsafe { Self::flush_deferred_handshake_and_process(this, &full) };
+                true
+            }
+        }
     }
 
     /// # Safety

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -753,7 +753,10 @@ impl<const SSL: bool> HTTPClient<SSL> {
         // across the flush so the C++-ref release inside `cancel()` can't drop
         // us to 0 before our own trailing `deref`.
         // SAFETY: short-lived read; ends before the branch below.
-        let has_deferred = !matches!(unsafe { (*this).deferred_handshake }, DeferredHandshake::None);
+        let has_deferred = !matches!(
+            unsafe { (*this).deferred_handshake },
+            DeferredHandshake::None
+        );
         if has_deferred {
             // SAFETY: `this` carries root (userdata) provenance.
             let _guard = unsafe { ThisPtr::new(this) }.ref_guard();

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1057,6 +1057,24 @@ impl<const SSL: bool> HTTPClient<SSL> {
         None
     }
 
+    /// Whether the response carries a `Transfer-Encoding` header (chunked or
+    /// otherwise). Such bodies have no `Content-Length` and their wire bytes
+    /// are framing, not payload — the caller dispatches immediately instead
+    /// of accumulating raw framing until EOF.
+    fn has_transfer_encoding(response: &picohttp::Response) -> bool {
+        for header in response.headers.list {
+            if header.name().len() == b"Transfer-Encoding".len()
+                && strings::eql_case_insensitive_ascii_ignore_length(
+                    header.name(),
+                    b"Transfer-Encoding",
+                )
+            {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Append `data` to the deferred non-101 body buffer.
     ///
     /// Returns `true` when `data` was consumed as part of a deferred
@@ -1143,6 +1161,27 @@ impl<const SSL: bool> HTTPClient<SSL> {
         }
 
         if status_code != 101 {
+            // A `Transfer-Encoding` (e.g. chunked) body has no Content-Length
+            // and its framing bytes are not the payload. We don't decode
+            // chunked on this fallback path, and waiting-for-EOF on a
+            // keep-alive connection would just stall until the socket
+            // timeout. Dispatch immediately with whatever bytes are on hand
+            // so the `unexpected-response` listener still gets the correct
+            // status / headers (matching the pre-existing non-101 behavior,
+            // which surfaced no body at all).
+            if Self::has_transfer_encoding(&response) {
+                // SAFETY: forwards `this`; no `&mut Self` is live.
+                unsafe {
+                    Self::dispatch_handshake_and_process(
+                        this,
+                        response,
+                        full,
+                        head_len,
+                        status_code,
+                    );
+                }
+                return;
+            }
             // Defer the dispatch if the full body isn't present yet.
             match Self::find_content_length(&response) {
                 Some(cl) => {

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1197,11 +1197,12 @@ impl<const SSL: bool> HTTPClient<SSL> {
                     if full.len() < target_len {
                         // SAFETY: short-lived `&mut`; ends before return. Own
                         // the accumulated bytes so subsequent reads append.
+                        // `full` is always a fresh `to_vec()` from the caller
+                        // (borrowck forced the copy upstream), so it never
+                        // aliases `me.body` — just replace.
                         let me = unsafe { &mut *this };
-                        if me.body.as_ptr() != full.as_ptr() {
-                            me.body.clear();
-                            me.body.extend_from_slice(full);
-                        }
+                        me.body.clear();
+                        me.body.extend_from_slice(full);
                         me.deferred_handshake = DeferredHandshake::WaitingForLength(target_len);
                         return;
                     }
@@ -1216,12 +1217,11 @@ impl<const SSL: bool> HTTPClient<SSL> {
                 None => {
                     // No Content-Length — RFC 7230 §3.3.3: read until the
                     // peer closes. Defer to handle_end / handle_close.
-                    // SAFETY: short-lived `&mut`; ends before return.
+                    // SAFETY: short-lived `&mut`; ends before return. `full`
+                    // is a fresh `to_vec()` (never aliases `me.body`).
                     let me = unsafe { &mut *this };
-                    if me.body.as_ptr() != full.as_ptr() {
-                        me.body.clear();
-                        me.body.extend_from_slice(full);
-                    }
+                    me.body.clear();
+                    me.body.extend_from_slice(full);
                     me.deferred_handshake = DeferredHandshake::WaitingForEof;
                     return;
                 }

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -740,13 +740,52 @@ impl<const SSL: bool> HTTPClient<SSL> {
         // flush runs `process_response` which terminates the non-101 and
         // clears `outgoing_websocket`, so `dispatch_abrupt_close` below is a
         // no-op. We still `deref` once to balance the socket ref.
-        // SAFETY: forwards `this` with root provenance; no `&mut Self` is live.
-        if unsafe { Self::flush_deferred_on_close(this) } {
-            // SAFETY: short-lived `&mut` for the field detach.
+        //
+        // The flush dispatches `unexpected-response` into JS, and that handler
+        // may synchronously `ws.close()`/`ws.terminate()` → reentrant
+        // `cancel()`. Left to its own devices, `cancel()` would see `tcp` still
+        // attached + the socket's ext slot still pointing at us and so
+        // (a) release the socket ref a second time and (b) `tcp.close()` again,
+        // re-entering `handle_close` — a use-after-free on the `tcp.detach()`
+        // below plus a refcount underflow. Guard against all of it: take the
+        // ext slot and detach `tcp` up front so the reentrant `cancel()` finds
+        // `ext == None` / a detached `tcp` and no-ops both, and hold a ref
+        // across the flush so the C++-ref release inside `cancel()` can't drop
+        // us to 0 before our own trailing `deref`.
+        // SAFETY: short-lived read; ends before the branch below.
+        let has_deferred = !matches!(unsafe { (*this).deferred_handshake }, DeferredHandshake::None);
+        if has_deferred {
+            // SAFETY: `this` carries root (userdata) provenance.
+            let _guard = unsafe { ThisPtr::new(this) }.ref_guard();
+            // Take the socket-userdata ref's slot (matching `cancel`'s own
+            // take) and detach our `tcp` handle, before any dispatch, so a
+            // reentrant `cancel()` finds `ext == None` / a detached `tcp` and
+            // neither double-releases the socket ref nor re-enters `handle_close`.
+            // SAFETY: short-lived reads/writes on the JS thread; the ext slot
+            // is the `Option<NonNull<Self>>` written in `connect_group`.
+            let tcp = unsafe { (*this).tcp };
+            tcp.ext::<Option<core::ptr::NonNull<Self>>>()
+                .map(|ext| unsafe { (*ext).take() });
+            // SAFETY: short-lived `&mut` for the field detach/clear_data.
             unsafe { (*this).tcp.detach() };
-            // SAFETY: may free `this`; no `&mut Self` is live.
+            // SAFETY: forwards `this`; `_guard` + the still-held socket ref
+            // keep it alive across the dispatch even if JS frees the C++ ref.
+            unsafe { Self::flush_deferred_on_close(this) };
+            // Release the C++ `outgoing_websocket` ref if it's still held.
+            // A reentrant `cancel()` (from `ws.close()`/`terminate()` in the
+            // listener) or the flush's own `process_response` may already have
+            // taken it; `take()` makes this release exactly-once regardless of
+            // which path ran.
+            // SAFETY: short-lived `&mut` for the field take.
+            if unsafe { (*this).outgoing_websocket.take().is_some() } {
+                // SAFETY: no `&mut Self` is live; `_guard` still holds a ref.
+                unsafe { Self::deref(this) };
+            }
+            // Balance the socket ref whose ext slot we took above.
+            // SAFETY: no `&mut Self` is live; `_guard` still holds a ref.
             unsafe { Self::deref(this) };
             return;
+            // `_guard` drops here — the final release, may free `this`.
         }
 
         // SAFETY: short-lived `&mut` borrows; each ends before the next call.

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1173,7 +1173,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
             // `unexpected-response` listener still gets the correct status /
             // headers (matching the pre-existing non-101 behavior, which
             // surfaced no body at all).
-            let is_bodiless = status_code == 204 || status_code == 304 || (100..200).contains(&status_code);
+            let is_bodiless =
+                status_code == 204 || status_code == 304 || (100..200).contains(&status_code);
             if is_bodiless || Self::has_transfer_encoding(&response) {
                 // SAFETY: forwards `this`; no `&mut Self` is live.
                 unsafe {

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1161,15 +1161,20 @@ impl<const SSL: bool> HTTPClient<SSL> {
         }
 
         if status_code != 101 {
-            // A `Transfer-Encoding` (e.g. chunked) body has no Content-Length
-            // and its framing bytes are not the payload. We don't decode
-            // chunked on this fallback path, and waiting-for-EOF on a
-            // keep-alive connection would just stall until the socket
-            // timeout. Dispatch immediately with whatever bytes are on hand
-            // so the `unexpected-response` listener still gets the correct
-            // status / headers (matching the pre-existing non-101 behavior,
-            // which surfaced no body at all).
-            if Self::has_transfer_encoding(&response) {
+            // RFC 7230 §3.3.3 rule #1 — 1xx / 204 / 304 responses have no
+            // message body regardless of the header fields, so reading until
+            // the peer closes (rule #7, the `None` arm below) would stall a
+            // keep-alive connection until the 120s socket timeout — and
+            // `terminate(Timeout)` doesn't flush a deferred handshake, so
+            // `unexpected-response` would never fire. Rule #3
+            // (`Transfer-Encoding`) likewise preempts rule #7: we don't decode
+            // chunked on this fallback path. In both cases dispatch
+            // immediately with whatever bytes are on hand so the
+            // `unexpected-response` listener still gets the correct status /
+            // headers (matching the pre-existing non-101 behavior, which
+            // surfaced no body at all).
+            let is_bodiless = status_code == 204 || status_code == 304 || (100..200).contains(&status_code);
+            if is_bodiless || Self::has_transfer_encoding(&response) {
                 // SAFETY: forwards `this`; no `&mut Self` is live.
                 unsafe {
                     Self::dispatch_handshake_and_process(
@@ -1215,7 +1220,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
                     return;
                 }
                 None => {
-                    // No Content-Length — RFC 7230 §3.3.3: read until the
+                    // No Content-Length, and the bodiless / chunked cases were
+                    // handled above — RFC 7230 §3.3.3 rule #7: read until the
                     // peer closes. Defer to handle_end / handle_close.
                     // SAFETY: short-lived `&mut`; ends before return. `full`
                     // is a fresh `to_vec()` (never aliases `me.body`).

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1354,6 +1354,22 @@ impl<const SSL: bool> HTTPClient<SSL> {
         // SAFETY: `this` carries root provenance; balanced on drop.
         let _guard = unsafe { ThisPtr::new(this) }.ref_guard();
 
+        // On 101, nest the `did_receive_handshake_response` ('handshake'/
+        // 'upgrade') and `did_connect` ('open') dispatches below under one
+        // event-loop scope. Each of those calls its own enter()/exit(); exit()
+        // drains microtasks when the count drops 1→0. Without this outer scope
+        // the count would hit 0 between the two events, so a microtask queued
+        // in an 'upgrade' handler would run before 'open' and observe
+        // readyState CONNECTING. Holding the count ≥1 across both makes them
+        // fire back-to-back like npm `ws`, draining microtasks once after
+        // 'open'. Scope it to 101 only: on a non-101 response `process_response`
+        // below calls `terminate` instead of `did_connect`, and the
+        // 'unexpected-response' body stream relies on the microtask checkpoint
+        // at `did_receive_handshake_response`'s exit() running *before* that
+        // teardown — swallowing it hangs the stream.
+        let _loop_scope = (status_code == 101)
+            .then(|| bun_jsc::virtual_machine::VirtualMachine::get().enter_event_loop_scope());
+
         // On 101, the bytes after the header block are the first WebSocket
         // frame — not HTTP body. Surface an empty body to the handshake
         // event; `process_response` still hands `full[head_len..]` to the

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -764,11 +764,14 @@ impl<const SSL: bool> HTTPClient<SSL> {
             // take) and detach our `tcp` handle, before any dispatch, so a
             // reentrant `cancel()` finds `ext == None` / a detached `tcp` and
             // neither double-releases the socket ref nor re-enters `handle_close`.
-            // SAFETY: short-lived reads/writes on the JS thread; the ext slot
-            // is the `Option<NonNull<Self>>` written in `connect_group`.
+            // SAFETY: short-lived read of the `tcp` handle; `this` is live.
             let tcp = unsafe { (*this).tcp };
-            tcp.ext::<Option<core::ptr::NonNull<Self>>>()
-                .map(|ext| unsafe { (*ext).take() });
+            if let Some(ext) = tcp.ext::<Option<core::ptr::NonNull<Self>>>() {
+                // SAFETY: the ext slot is the `Option<NonNull<Self>>` written in
+                // `connect_group`; single-threaded (JS thread), no other `&mut`
+                // to it is live.
+                unsafe { (*ext).take() };
+            }
             // SAFETY: short-lived `&mut` for the field detach/clear_data.
             unsafe { (*this).tcp.detach() };
             // SAFETY: forwards `this`; `_guard` + the still-held socket ref

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1137,8 +1137,9 @@ impl<const SSL: bool> HTTPClient<SSL> {
     /// `unexpected-response` listener sees the complete payload instead of a
     /// truncated prefix.
     ///
-    /// `full` is the complete parsed buffer (head + whatever body bytes are
-    /// on hand). `response` was parsed from it.
+    /// `full` is the complete buffer contents (head + whatever body bytes are
+    /// on hand) — a copy of the buffer `response` was parsed from, so its
+    /// bytes match but `response`'s header pointers reference the original.
     ///
     /// # Safety
     /// `this` must point to a live `Self`. Takes `*mut Self` because the
@@ -1318,8 +1319,15 @@ impl<const SSL: bool> HTTPClient<SSL> {
         };
 
         // Build the raw-header array the C++ side copies into `rawHeaders`.
-        // SAFETY: the header name/value slices point into `full`, which
-        // outlives this synchronous call.
+        // SAFETY: the header name/value slices (and `response.status`) point
+        // into the buffer `response` was parsed from — `full` on the
+        // flush-deferred path, or the caller's `data`/`self.body` on the
+        // direct-dispatch paths (101 / bodiless / Transfer-Encoding), where
+        // `full` is a separate copy. Either buffer outlives this synchronous
+        // call: `data` is the uSockets read buffer live for the callback
+        // frame, `self.body` is owned by `*this` (kept alive by `_guard`
+        // above), and C++ copies every slice into a JS string before
+        // dispatchEvent runs any user JS.
         let mut raw_headers: Vec<super::cpp_websocket::RawHeader> =
             Vec::with_capacity(response.headers.list.len());
         for h in response.headers.list {

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1235,8 +1235,9 @@ impl<const SSL: bool> HTTPClient<SSL> {
             match Self::find_content_length(&response) {
                 Some(cl) => {
                     // Reject an absurd Content-Length up front so the
-                    // saturating add below can't wrap and trap us in an
-                    // unbounded accumulate loop.
+                    // `head_len + cl` below can't overflow `usize` (and so we
+                    // never trap in an unbounded accumulate loop). `cl` is now
+                    // bounded to 64 MB and `head_len` to the HTTP header limit.
                     if cl > MAX_NON_101_BODY {
                         // SAFETY: no `&mut Self` is live.
                         unsafe { Self::terminate(this, ErrorCode::Expected101StatusCode) };

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -164,6 +164,7 @@ using namespace JSC;
     macro(pullAlgorithm) \
     macro(pulling) \
     macro(queue) \
+    macro(rawHeaders) \
     macro(read) \
     macro(readIntoRequests) \
     macro(readRequests) \
@@ -193,6 +194,8 @@ using namespace JSC;
     macro(started) \
     macro(state) \
     macro(status) \
+    macro(statusCode) \
+    macro(statusMessage) \
     macro(statusText) \
     macro(storedError) \
     macro(strategy) \

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -420,11 +420,18 @@ class BunWebSocket extends EventEmitter {
       this.emit("upgrade", res);
       return;
     }
-    this.#unexpectedResponseEmitted = true;
     if (this.listenerCount("unexpected-response") > 0) {
+      // Only now may we suppress the native 'Expected 101' error that follows
+      // — the consumer handled the response via 'unexpected-response'. On the
+      // else-branch we leave the flag false so the native error still reaches
+      // `error` listeners (including `addEventListener('error')`/`onerror`).
+      this.#unexpectedResponseEmitted = true;
       // `unexpected-response` emits `(request, response)` per ws docs.
       this.emit("unexpected-response", this.#getSyntheticRequest(), res);
-    } else {
+    } else if (this.listenerCount("error") > 0) {
+      // Guard the emit: EventEmitter throws on `emit('error')` with no
+      // listeners, and handlers on `this.#ws` (addEventListener/onerror) get
+      // the native error directly rather than this synthesized one.
       this.emit("error", new Error("Unexpected server response: " + statusCode));
     }
   }
@@ -660,6 +667,10 @@ class BunWebSocket extends EventEmitter {
       return;
     }
     if (type === "error" && typeof listener === "function") {
+      // DOM dedup: re-registering the same listener is a no-op. We wrap below,
+      // so distinct wrappers would defeat the native EventTarget's identity
+      // dedup — check our own map instead (and avoid leaking the prior wrapper).
+      if (this.#errorListenerWrappers?.has(listener)) return;
       // Suppress the native 'Expected 101' error after 'unexpected-response'
       // fired, consistent with `on('error')` (line ~483) and real ws. Wrap in
       // a gated closure and remember it so `removeEventListener` can detach it.

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -190,7 +190,18 @@ class BunWebSocket extends EventEmitter {
   #paused = false;
   #fragments = false;
   #binaryType = "nodebuffer";
+  // True once an 'error' has already been surfaced to EventEmitter listeners
+  // (either a synthetic non-101 error or because 'unexpected-response' fired).
+  // Gates the bridge closure so the native 'Expected 101' error isn't
+  // re-emitted onto the EventEmitter a second time.
   #unexpectedResponseEmitted = false;
+  // True only when 'unexpected-response' actually fired — i.e. the consumer
+  // handled the non-101 response, so real ws emits no 'error' at all. Gates
+  // the `addEventListener('error')` / `onerror` wrappers (which live on
+  // `this.#ws`, not the EventEmitter). Kept separate from
+  // `#unexpectedResponseEmitted` so a synthetic `emit('error')` to an
+  // `on('error')` listener doesn't also swallow a DOM-style handler's error.
+  #unexpectedResponseHandled = false;
   // Wrappers for `addEventListener('error', h)` so the native 'Expected 101'
   // error is suppressed after 'unexpected-response' (matching `on('error')`
   // and real npm `ws`). Keyed by the user's listener so `removeEventListener`
@@ -421,19 +432,21 @@ class BunWebSocket extends EventEmitter {
       return;
     }
     if (this.listenerCount("unexpected-response") > 0) {
-      // The consumer handled the response via 'unexpected-response', so
-      // suppress the native 'Expected 101' error that follows.
+      // The consumer handled the response via 'unexpected-response'. Real ws
+      // emits no 'error' at all in this case, so suppress the native follow-up
+      // for every registration style (EventEmitter bridge AND the DOM-style
+      // wrappers).
       this.#unexpectedResponseEmitted = true;
+      this.#unexpectedResponseHandled = true;
       // `unexpected-response` emits `(request, response)` per ws docs.
       this.emit("unexpected-response", this.#getSyntheticRequest(), res);
     } else if (this.listenerCount("error") > 0) {
       // An EventEmitter 'error' listener (on/once/addListener/...) gets a
-      // synthetic error here; suppress the native follow-up so it isn't
-      // delivered twice via the bridge closure. `addEventListener('error')` /
-      // `onerror` handlers live on `this.#ws` and don't count toward
-      // `listenerCount('error')`, so when only those are registered this
-      // branch is skipped, the flag stays false, and they receive the native
-      // error directly (exactly once).
+      // synthetic error here; mark it emitted so the bridge closure doesn't
+      // deliver the native follow-up to the EventEmitter a second time. We do
+      // NOT set #unexpectedResponseHandled — a DOM-style handler
+      // (addEventListener('error')/onerror) registered alongside still gets the
+      // native error exactly once, since its wrapper gates on that flag.
       this.#unexpectedResponseEmitted = true;
       this.emit("error", new Error("Unexpected server response: " + statusCode));
     }
@@ -674,12 +687,15 @@ class BunWebSocket extends EventEmitter {
       // so distinct wrappers would defeat the native EventTarget's identity
       // dedup — check our own map instead (and avoid leaking the prior wrapper).
       if (this.#errorListenerWrappers?.has(listener)) return;
-      // Suppress the native 'Expected 101' error after 'unexpected-response'
-      // fired, consistent with `on('error')` (line ~483) and real ws. Wrap in
-      // a gated closure and remember it so `removeEventListener` can detach it.
+      // Suppress the native 'Expected 101' error only when 'unexpected-response'
+      // actually handled the non-101 (matching real ws, which emits no error
+      // then). Gate on #unexpectedResponseHandled — NOT #unexpectedResponse
+      // Emitted — so a synthetic emit to a co-registered `on('error')` listener
+      // doesn't also swallow this handler. Wrap in a gated closure and remember
+      // it so `removeEventListener` can detach it.
       const self = this;
       const wrapper = function (event) {
-        if (self.#unexpectedResponseEmitted) return;
+        if (self.#unexpectedResponseHandled) return;
         return listener.$call(this, event);
       };
       (this.#errorListenerWrappers ??= new WeakMap()).set(listener, wrapper);
@@ -729,12 +745,14 @@ class BunWebSocket extends EventEmitter {
       this.#ws.onerror = value;
       return;
     }
-    // Suppress the native 'Expected 101' error after 'unexpected-response',
-    // consistent with `on('error')` / `addEventListener('error')` and real ws.
+    // Suppress the native 'Expected 101' error only when 'unexpected-response'
+    // handled the non-101 (matching `addEventListener('error')` and real ws).
+    // Gate on #unexpectedResponseHandled so a co-registered `on('error')`
+    // listener's synthetic emit doesn't swallow this handler's error.
     const self = this;
     const fn = this.#onerror;
     this.#ws.onerror = function (event) {
-      if (self.#unexpectedResponseEmitted) return;
+      if (self.#unexpectedResponseHandled) return;
       return fn.$call(this, event);
     };
   }

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -673,6 +673,11 @@ class BunWebSocket extends EventEmitter {
     // `(response)` / `(request, response)` args.
     if (type === "upgrade" || type === "unexpected-response") {
       this.#ensureHandshakeListener();
+      // DOM dedup: `addEventListener` with the same listener is a no-op.
+      // EventEmitter.on/once don't dedup, so check the current listeners
+      // ourselves — matching real ws, which scans listeners(type) for every
+      // event type (and the 'error' branch below, which dedups too).
+      if (this.listeners(type).includes(listener)) return;
       // `addEventListener` returns undefined per the DOM spec / real ws —
       // use statement form so we don't leak EventEmitter's `this` return.
       if (options && options.once) {
@@ -694,7 +699,13 @@ class BunWebSocket extends EventEmitter {
       // doesn't also swallow this handler. Wrap in a gated closure and remember
       // it so `removeEventListener` can detach it.
       const self = this;
+      // With `{once:true}` the native EventTarget auto-removes the wrapper
+      // after it fires, so drop our dedup entry too — otherwise a later
+      // `addEventListener('error', listener)` would hit the guard above and
+      // silently no-op even though nothing is attached anymore.
+      const once = !!(options && options.once);
       const wrapper = function (event) {
+        if (once) self.#errorListenerWrappers?.delete(listener);
         if (self.#unexpectedResponseHandled) return;
         return listener.$call(this, event);
       };

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -89,6 +89,31 @@ const eventIds = {
 // must be identity-stable so `super.off` can remove it later if needed.
 function noopBridgeListener() {}
 
+// Headers for which Node's http.IncomingMessage keeps only the first value and
+// discards later duplicates, matching lib/_http_incoming.js matchKnownFields.
+// Real `ws` hands consumers that Node object, so the synthetic IncomingMessage
+// passed to 'unexpected-response' must coalesce the same way.
+const kSingletonHeaders = new Set([
+  "age",
+  "authorization",
+  "content-length",
+  "content-type",
+  "etag",
+  "expires",
+  "from",
+  "host",
+  "if-modified-since",
+  "if-unmodified-since",
+  "last-modified",
+  "location",
+  "max-forwards",
+  "proxy-authorization",
+  "referer",
+  "retry-after",
+  "server",
+  "user-agent",
+]);
+
 let lazyReadable;
 function makeHandshakeResponse(statusCode, statusMessage, rawHeaders, body) {
   lazyReadable ??= require("node:stream").Readable;
@@ -102,8 +127,14 @@ function makeHandshakeResponse(statusCode, statusMessage, rawHeaders, body) {
     if (lower === "set-cookie") {
       if (prev === undefined) headers[lower] = [value];
       else prev.push(value);
+    } else if (prev === undefined) {
+      headers[lower] = value;
+    } else if (kSingletonHeaders.has(lower)) {
+      // Keep the first occurrence; discard the duplicate.
+    } else if (lower === "cookie") {
+      headers[lower] = prev + "; " + value;
     } else {
-      headers[lower] = prev === undefined ? value : prev + ", " + value;
+      headers[lower] = prev + ", " + value;
     }
   }
   res.statusCode = statusCode;

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -421,17 +421,20 @@ class BunWebSocket extends EventEmitter {
       return;
     }
     if (this.listenerCount("unexpected-response") > 0) {
-      // Only now may we suppress the native 'Expected 101' error that follows
-      // — the consumer handled the response via 'unexpected-response'. On the
-      // else-branch we leave the flag false so the native error still reaches
-      // `error` listeners (including `addEventListener('error')`/`onerror`).
+      // The consumer handled the response via 'unexpected-response', so
+      // suppress the native 'Expected 101' error that follows.
       this.#unexpectedResponseEmitted = true;
       // `unexpected-response` emits `(request, response)` per ws docs.
       this.emit("unexpected-response", this.#getSyntheticRequest(), res);
     } else if (this.listenerCount("error") > 0) {
-      // Guard the emit: EventEmitter throws on `emit('error')` with no
-      // listeners, and handlers on `this.#ws` (addEventListener/onerror) get
-      // the native error directly rather than this synthesized one.
+      // An EventEmitter 'error' listener (on/once/addListener/...) gets a
+      // synthetic error here; suppress the native follow-up so it isn't
+      // delivered twice via the bridge closure. `addEventListener('error')` /
+      // `onerror` handlers live on `this.#ws` and don't count toward
+      // `listenerCount('error')`, so when only those are registered this
+      // branch is skipped, the flag stays false, and they receive the native
+      // error directly (exactly once).
+      this.#unexpectedResponseEmitted = true;
       this.emit("error", new Error("Unexpected server response: " + statusCode));
     }
   }

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -80,7 +80,42 @@ const eventIds = {
   error: 4,
   ping: 5,
   pong: 6,
+  upgrade: 7,
+  "unexpected-response": 8,
 };
+
+// Stable singleton used by `#armNativeBridge` to install the native-side
+// forwarder through `#onOrOnce` without pushing a user-visible listener. It
+// must be identity-stable so `super.off` can remove it later if needed.
+function noopBridgeListener() {}
+
+let lazyReadable;
+function makeHandshakeResponse(statusCode, statusMessage, rawHeaders, body) {
+  lazyReadable ??= require("node:stream").Readable;
+  const res = new lazyReadable({ read() {} });
+  const headers = (res.headers = { __proto__: null });
+  res.rawHeaders = rawHeaders;
+  for (let i = 0; i < rawHeaders.length; i += 2) {
+    const lower = rawHeaders[i].toLowerCase();
+    const value = rawHeaders[i + 1];
+    const prev = headers[lower];
+    if (lower === "set-cookie") {
+      if (prev === undefined) headers[lower] = [value];
+      else prev.push(value);
+    } else {
+      headers[lower] = prev === undefined ? value : prev + ", " + value;
+    }
+  }
+  res.statusCode = statusCode;
+  res.statusMessage = statusMessage;
+  res.httpVersion = "1.1";
+  res.httpVersionMajor = 1;
+  res.httpVersionMinor = 1;
+  res.socket = res.connection = null;
+  if (body && body.length) res.push(body);
+  res.push(null);
+  return res;
+}
 
 const emittedWarnings = new Set();
 function emitWarning(type, message) {
@@ -124,6 +159,7 @@ class BunWebSocket extends EventEmitter {
   #paused = false;
   #fragments = false;
   #binaryType = "nodebuffer";
+  #unexpectedResponseEmitted = false;
   // Bitset to track whether event handlers are set.
   #eventId = 0;
 
@@ -266,13 +302,104 @@ class BunWebSocket extends EventEmitter {
     }
     let ws = (this.#ws = new WebSocket(url, wsOptions));
     ws.binaryType = "nodebuffer";
+    // NOTE: the native 'handshake' listener is registered lazily from
+    // #ensureHandshakeListener() when the user subscribes to 'upgrade' or
+    // 'unexpected-response'. Keeping it off by default means callers that
+    // only listen to 'open'/'message'/'close' never exercise the Zig
+    // handshake-dispatch path (which has historically been fragile under
+    // ASAN, e.g. ws-proxy.test.ts).
 
     return ws;
   }
 
+  #handshakeListenerRegistered = false;
+  #ensureHandshakeListener() {
+    if (this.#handshakeListenerRegistered) return;
+    this.#handshakeListenerRegistered = true;
+    this.#ws.addEventListener("handshake", event => this.#onHandshake(event.data), onceObject);
+  }
+
+  // ws emits `'upgrade'` / `'unexpected-response'` with an `http.ClientRequest`
+  // as the first argument. We bypass node:http and talk to the native
+  // WebSocket directly, so there is no real ClientRequest to expose. Pass a
+  // minimal stub — `method`, `path`, and the no-op header helpers — so user
+  // code that inspects the request object (e.g. `req.getHeader(...)`) does
+  // not crash. Build it lazily on first emission to keep the common open/
+  // close path zero-cost.
+  #syntheticRequest;
+  #getSyntheticRequest() {
+    let req = this.#syntheticRequest;
+    if (req) return req;
+    const url = this.#ws?.url;
+    let path = "/";
+    try {
+      if (url) {
+        const parsed = new URL(url);
+        // Node's http.ClientRequest.path is pathname + search (no fragment)
+        // per RFC 7230 §5.3. Preserve the query string so handlers that log
+        // or reconstruct the failing URL see the full request target.
+        path = (parsed.pathname || "/") + (parsed.search || "");
+      }
+    } catch {}
+    req = this.#syntheticRequest = {
+      __proto__: Object.create(EventEmitter.prototype),
+      method: "GET",
+      path,
+      url,
+      headers: { __proto__: null },
+      rawHeaders: [],
+      getHeader() {},
+      getHeaders() {
+        return { __proto__: null };
+      },
+      setHeader() {},
+      removeHeader() {},
+      hasHeader() {
+        return false;
+      },
+      abort() {},
+      end() {},
+      write() {},
+      writeHead() {},
+      headersSent: true,
+      finished: true,
+      socket: null,
+      [Symbol.toStringTag]: "ClientRequest",
+    };
+    return req;
+  }
+
+  #onHandshake(data) {
+    const { statusCode, statusMessage, rawHeaders, body } = data;
+    // On 101, any bytes arriving after the header block are the first
+    // WebSocket frame, not HTTP response body — node's http layer delivers
+    // them as the `head` buffer on the 'upgrade' event and the native
+    // WebSocket client forwards them to the protocol reader on didConnect.
+    // Don't leak them into the `upgrade` event's IncomingMessage stream.
+    const res = makeHandshakeResponse(statusCode, statusMessage, rawHeaders, statusCode === 101 ? null : body);
+    if (statusCode === 101) {
+      // `upgrade` emits `(response)` per ws docs.
+      this.emit("upgrade", res);
+      return;
+    }
+    this.#unexpectedResponseEmitted = true;
+    if (this.listenerCount("unexpected-response") > 0) {
+      // `unexpected-response` emits `(request, response)` per ws docs.
+      this.emit("unexpected-response", this.#getSyntheticRequest(), res);
+    } else {
+      this.emit("error", new Error("Unexpected server response: " + statusCode));
+    }
+  }
+
   #onOrOnce(event, listener, once) {
-    if (event === "unexpected-response" || event === "upgrade" || event === "redirect") {
+    if (event === "redirect") {
       emitWarning(event, "ws.WebSocket '" + event + "' event is not implemented in bun");
+    }
+    if (event === "upgrade" || event === "unexpected-response") {
+      // Lazy-register the native handshake listener so callers that never
+      // subscribe to these events don't exercise the Zig handshake dispatch.
+      this.#ensureHandshakeListener();
+      return once ? super.once(event, listener) : super.on(event, listener);
     }
     const mask = 1 << eventIds[event];
     const hasPersistentListener = mask && (this.#eventId & mask) === mask;
@@ -322,6 +449,7 @@ class BunWebSocket extends EventEmitter {
         this.#ws.addEventListener(
           "error",
           err => {
+            if (this.#unexpectedResponseEmitted) return;
             this.emit("error", err);
           },
           once,
@@ -353,6 +481,53 @@ class BunWebSocket extends EventEmitter {
 
   once(event, listener) {
     return this.#onOrOnce(event, listener, onceObject);
+  }
+
+  // `on` is the conventional spelling, but ws / EventEmitter consumers also
+  // reach for `addListener` / `prependListener` / `prependOnceListener`. Each
+  // needs to arm the native bridge (the `#onOrOnce` path for standard events
+  // like 'open' / 'message', or `#ensureHandshakeListener()` for 'upgrade' /
+  // 'unexpected-response') — otherwise the handler sits on the EventEmitter
+  // list but the native event that would trigger `this.emit(...)` is never
+  // wired up, and the callback silently never fires.
+  addListener(event, listener) {
+    return this.#onOrOnce(event, listener, undefined);
+  }
+
+  prependListener(event, listener) {
+    this.#armNativeBridge(event);
+    return super.prependListener(event, listener);
+  }
+
+  prependOnceListener(event, listener) {
+    this.#armNativeBridge(event);
+    return super.prependOnceListener(event, listener);
+  }
+
+  // Install the native-side listener that eventually calls `this.emit(event,
+  // …)`, without pushing a new EventEmitter listener onto the list — that
+  // part is the caller's job (e.g. `super.prependListener`). Mirrors the
+  // bridge-installation branch of `#onOrOnce` for the cases where we need
+  // the side effect but not the `super.on`/`super.once` call.
+  #armNativeBridge(event) {
+    if (event === "upgrade" || event === "unexpected-response") {
+      this.#ensureHandshakeListener();
+      return;
+    }
+    // `1 << undefined` evaluates to `1` (ToInt32(undefined) = 0), so a
+    // naive `if (!mask) return` would silently fall through for unknown
+    // event names and install a spurious noopBridgeListener on bit 0.
+    // Guard explicitly against unknown events.
+    if (eventIds[event] === undefined) return;
+    const mask = 1 << eventIds[event];
+    const hasPersistentListener = (this.#eventId & mask) === mask;
+    if (hasPersistentListener) return;
+    // Register a persistent bridge listener once. A no-op noop callback
+    // goes into the EventEmitter list via `#onOrOnce` so the `#eventId` bit
+    // gets flipped and the native forwarder is installed; subsequent
+    // `prependListener` calls will then see `hasPersistentListener` and
+    // skip this branch.
+    this.#onOrOnce(event, noopBridgeListener, undefined);
   }
 
   send(data, opts, cb) {
@@ -422,10 +597,33 @@ class BunWebSocket extends EventEmitter {
 
   // deviation: this does not support `message` with `binaryType = "fragments"`
   addEventListener(type, listener, options) {
+    // 'upgrade' and 'unexpected-response' are Node-style events — they're
+    // emitted on the JS-side EventEmitter by `#onHandshake`, never by the
+    // native WebSocket. Register on `this` and arm the handshake listener.
+    // We deliberately don't wrap the handler in a DOM-style adapter: a
+    // wrapped closure would make `removeEventListener` fail to match the
+    // original listener, leaking the handler. Consumers that reach for
+    // `addEventListener` on a ws shim already accept a mixed API; for
+    // these two Node-only events they receive Node-style
+    // `(response)` / `(request, response)` args.
+    if (type === "upgrade" || type === "unexpected-response") {
+      this.#ensureHandshakeListener();
+      if (options && options.once) {
+        return super.once(type, listener);
+      }
+      return super.on(type, listener);
+    }
     this.#ws.addEventListener(type, listener, options);
   }
 
   removeEventListener(type, listener) {
+    // Symmetric with addEventListener: upgrade/unexpected-response
+    // listeners live on `this` (the EventEmitter), not on the native
+    // WebSocket, so removing them means calling `super.off`.
+    if (type === "upgrade" || type === "unexpected-response") {
+      super.off(type, listener);
+      return;
+    }
     this.#ws.removeEventListener(type, listener);
   }
 

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -608,10 +608,14 @@ class BunWebSocket extends EventEmitter {
     // `(response)` / `(request, response)` args.
     if (type === "upgrade" || type === "unexpected-response") {
       this.#ensureHandshakeListener();
+      // `addEventListener` returns undefined per the DOM spec / real ws —
+      // use statement form so we don't leak EventEmitter's `this` return.
       if (options && options.once) {
-        return super.once(type, listener);
+        super.once(type, listener);
+      } else {
+        super.on(type, listener);
       }
-      return super.on(type, listener);
+      return;
     }
     this.#ws.addEventListener(type, listener, options);
   }

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -191,6 +191,13 @@ class BunWebSocket extends EventEmitter {
   #fragments = false;
   #binaryType = "nodebuffer";
   #unexpectedResponseEmitted = false;
+  // Wrappers for `addEventListener('error', h)` so the native 'Expected 101'
+  // error is suppressed after 'unexpected-response' (matching `on('error')`
+  // and real npm `ws`). Keyed by the user's listener so `removeEventListener`
+  // can still find and detach the wrapper.
+  #errorListenerWrappers;
+  // The user's `onerror` function (the native slot holds a suppression wrapper).
+  #onerror;
   // Bitset to track whether event handlers are set.
   #eventId = 0;
 
@@ -652,6 +659,19 @@ class BunWebSocket extends EventEmitter {
       }
       return;
     }
+    if (type === "error" && typeof listener === "function") {
+      // Suppress the native 'Expected 101' error after 'unexpected-response'
+      // fired, consistent with `on('error')` (line ~483) and real ws. Wrap in
+      // a gated closure and remember it so `removeEventListener` can detach it.
+      const self = this;
+      const wrapper = function (event) {
+        if (self.#unexpectedResponseEmitted) return;
+        return listener.$call(this, event);
+      };
+      (this.#errorListenerWrappers ??= new WeakMap()).set(listener, wrapper);
+      this.#ws.addEventListener(type, wrapper, options);
+      return;
+    }
     this.#ws.addEventListener(type, listener, options);
   }
 
@@ -662,6 +682,16 @@ class BunWebSocket extends EventEmitter {
     if (type === "upgrade" || type === "unexpected-response") {
       super.off(type, listener);
       return;
+    }
+    if (type === "error") {
+      // `addEventListener('error', …)` registered a suppression wrapper, not
+      // the user's listener — detach the wrapper we stored for it.
+      const wrapper = this.#errorListenerWrappers?.get(listener);
+      if (wrapper !== undefined) {
+        this.#errorListenerWrappers.delete(listener);
+        this.#ws.removeEventListener(type, wrapper);
+        return;
+      }
     }
     this.#ws.removeEventListener(type, listener);
   }
@@ -675,11 +705,24 @@ class BunWebSocket extends EventEmitter {
   }
 
   get onerror() {
-    return this.#ws.onerror;
+    // Return the user's function, not the suppression wrapper we installed.
+    return this.#onerror ?? this.#ws.onerror;
   }
 
   set onerror(value) {
-    this.#ws.onerror = value;
+    this.#onerror = typeof value === "function" ? value : undefined;
+    if (this.#onerror === undefined) {
+      this.#ws.onerror = value;
+      return;
+    }
+    // Suppress the native 'Expected 101' error after 'unexpected-response',
+    // consistent with `on('error')` / `addEventListener('error')` and real ws.
+    const self = this;
+    const fn = this.#onerror;
+    this.#ws.onerror = function (event) {
+      if (self.#unexpectedResponseEmitted) return;
+      return fn.$call(this, event);
+    };
   }
 
   get onclose() {

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -522,12 +522,16 @@ class BunWebSocket extends EventEmitter {
     const mask = 1 << eventIds[event];
     const hasPersistentListener = (this.#eventId & mask) === mask;
     if (hasPersistentListener) return;
-    // Register a persistent bridge listener once. A no-op noop callback
-    // goes into the EventEmitter list via `#onOrOnce` so the `#eventId` bit
-    // gets flipped and the native forwarder is installed; subsequent
-    // `prependListener` calls will then see `hasPersistentListener` and
-    // skip this branch.
+    // Install the native forwarder once. `#onOrOnce` flips the `#eventId`
+    // bit and registers the native listener as a side effect, but it also
+    // appends the listener we pass to the EventEmitter list. We only want
+    // the side effect here (the caller, e.g. `super.prependListener`, owns
+    // the real listener), so register `noopBridgeListener` and immediately
+    // remove it — leaving the native forwarder installed and the
+    // EventEmitter list untouched. Subsequent calls see
+    // `hasPersistentListener` and skip this branch.
     this.#onOrOnce(event, noopBridgeListener, undefined);
+    super.off(event, noopBridgeListener);
   }
 
   send(data, opts, cb) {

--- a/src/jsc/bindings/webcore/EventNames.h
+++ b/src/jsc/bindings/webcore/EventNames.h
@@ -29,16 +29,17 @@
 
 namespace WebCore {
 
-#define DOM_EVENT_NAMES_FOR_EACH(macro)             \
-    macro(error)                                    \
-        macro(abort)                                \
-            macro(close)                            \
-                macro(open)                         \
-                    macro(rename)                   \
-                        macro(message)              \
-                            macro(change)           \
-                                macro(messageerror) \
-                                    macro(resourcetimingbufferfull)
+#define DOM_EVENT_NAMES_FOR_EACH(macro)              \
+    macro(error)                                     \
+        macro(abort)                                 \
+            macro(close)                             \
+                macro(open)                          \
+                    macro(rename)                    \
+                        macro(message)               \
+                            macro(change)            \
+                                macro(messageerror)  \
+                                    macro(handshake) \
+                                        macro(resourcetimingbufferfull)
 
 struct EventNames {
     WTF_MAKE_NONCOPYABLE(EventNames);

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -74,6 +74,7 @@
 #include <wtf/text/StringBuilder.h>
 
 #include "JSBuffer.h"
+#include "BunClientData.h"
 #include "ErrorEvent.h"
 #include "WebSocketDeflate.h"
 
@@ -1517,6 +1518,59 @@ void WebSocket::didReceiveBinaryData(const AtomString& eventName, const std::spa
     // });
 }
 
+void WebSocket::didReceiveHandshakeResponse(uint16_t statusCode, std::span<const uint8_t> statusMessage, std::span<const HandshakeRawHeader> headers, std::span<const uint8_t> body)
+{
+    // The only consumer is the `ws` package shim, which always registers a listener
+    // before connecting. The browser-style `new WebSocket()` path skips this entirely.
+    if (!this->hasEventListeners(eventNames().handshakeEvent))
+        return;
+
+    auto* context = scriptExecutionContext();
+    if (!context)
+        return;
+    auto* globalObject = context->jsGlobalObject();
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto& builtinNames = WebCore::builtinNames(vm);
+
+    auto* obj = JSC::constructEmptyObject(globalObject);
+    obj->putDirect(vm, builtinNames.statusCodePublicName(), JSC::jsNumber(statusCode));
+    obj->putDirect(vm, builtinNames.statusMessagePublicName(),
+        JSC::jsString(vm, WTF::String({ statusMessage.data(), statusMessage.size() })));
+
+    // PicoHTTP already parsed the response head, so surface its header list as
+    // a flat [name, value, name, value, ...] rawHeaders array.
+    auto* rawHeaders = JSC::constructEmptyArray(globalObject, nullptr, headers.size() * 2);
+    if (!rawHeaders || scope.exception()) [[unlikely]] {
+        scope.clearExceptionExceptTermination();
+        return;
+    }
+    for (size_t i = 0; i < headers.size(); i++) {
+        rawHeaders->putDirectIndex(globalObject, i * 2,
+            JSC::jsString(vm, WTF::String({ headers[i].name_ptr, headers[i].name_len })));
+        rawHeaders->putDirectIndex(globalObject, i * 2 + 1,
+            JSC::jsString(vm, WTF::String({ headers[i].value_ptr, headers[i].value_len })));
+    }
+    obj->putDirect(vm, builtinNames.rawHeadersPublicName(), rawHeaders);
+
+    JSC::JSUint8Array* bodyBuffer = createBuffer(globalObject, body);
+    if (!bodyBuffer || scope.exception()) [[unlikely]] {
+        scope.clearExceptionExceptTermination();
+        return;
+    }
+    obj->putDirect(vm, builtinNames.bodyPublicName(), bodyBuffer);
+
+    JSC::EnsureStillAliveScope ensureStillAlive(obj);
+
+    MessageEvent::Init init;
+    init.data = obj;
+    init.origin = m_url.string();
+
+    this->incPendingActivityCount();
+    dispatchEvent(MessageEvent::create(eventNames().handshakeEvent, WTF::move(init), EventIsTrusted::Yes));
+    this->decPendingActivityCount();
+}
+
 void WebSocket::didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::String reason, bool isConnectionError)
 {
     // LOG(Network, "WebSocket %p didReceiveErrorMessage()", this);
@@ -1884,6 +1938,11 @@ extern "C" void WebSocket__didConnect(WebCore::WebSocket* webSocket, us_socket_t
 extern "C" void WebSocket__didConnectWithTunnel(WebCore::WebSocket* webSocket, void* tunnel, char* bufferedData, size_t len, const PerMessageDeflateParams* deflate_params)
 {
     webSocket->didConnectWithTunnel(tunnel, bufferedData, len, deflate_params);
+}
+
+extern "C" void WebSocket__didReceiveHandshakeResponse(WebCore::WebSocket* webSocket, uint16_t statusCode, const uint8_t* statusMessage, size_t statusMessageLen, const WebCore::WebSocket::HandshakeRawHeader* headers, size_t headersLen, const uint8_t* body, size_t bodyLen)
+{
+    webSocket->didReceiveHandshakeResponse(statusCode, std::span(statusMessage, statusMessageLen), std::span(headers, headersLen), std::span(body, bodyLen));
 }
 
 extern "C" void WebSocket__didAbruptClose(WebCore::WebSocket* webSocket, Bun::WebSocketErrorCode errorCode)

--- a/src/jsc/bindings/webcore/WebSocket.h
+++ b/src/jsc/bindings/webcore/WebSocket.h
@@ -206,6 +206,13 @@ public:
     void didReceiveMessage(String&& message);
     void didReceiveData(const char* data, size_t length);
     void didReceiveBinaryData(const AtomString& eventName, const std::span<const uint8_t> binaryData);
+    struct HandshakeRawHeader {
+        const uint8_t* name_ptr;
+        size_t name_len;
+        const uint8_t* value_ptr;
+        size_t value_len;
+    };
+    void didReceiveHandshakeResponse(uint16_t statusCode, std::span<const uint8_t> statusMessage, std::span<const HandshakeRawHeader> headers, std::span<const uint8_t> body);
 
     void updateHasPendingActivity();
     bool hasPendingActivity() const

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -1,0 +1,239 @@
+// https://github.com/oven-sh/bun/issues/5951
+//
+// Exercises the public `ws` package surface (what miniflare/wrangler actually
+// listen for), not the native 'handshake' event covered in 24229.test.ts.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+
+async function run(script: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) console.error(stderr);
+  return { stdout: normalizeBunSnapshot(stdout), exitCode };
+}
+
+test("ws emits 'unexpected-response' with status, headers and body on non-101", { timeout: 30000 }, async () => {
+  const { stdout, exitCode } = await run(/* js */ `
+    const { createServer } = require("net");
+    const { once } = require("events");
+    const { WebSocket } = require("ws");
+
+    const server = createServer(s =>
+      s.once("data", () =>
+        s.end("HTTP/1.1 503 Service Unavailable\\r\\nX-Reason: not-ready\\r\\n\\r\\nworkerd starting"),
+      ),
+    ).listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const ws = new WebSocket("ws://127.0.0.1:" + server.address().port);
+    ws.on("error", () => {});
+    const [req, res] = await new Promise(resolve =>
+      ws.once("unexpected-response", (req, res) => resolve([req, res])),
+    );
+    let body = "";
+    for await (const chunk of res) body += chunk;
+    console.log(JSON.stringify({
+      reqMethod: req?.method,
+      reqPath: req?.path,
+      reqGetHeader: typeof req?.getHeader === "function" ? req.getHeader("x-anything") ?? null : "missing",
+      statusCode: res.statusCode,
+      statusMessage: res.statusMessage,
+      xReason: res.headers["x-reason"],
+      body,
+    }));
+    await once(ws, "close");
+    server.close();
+  `);
+  // ws emits 'unexpected-response' with (ClientRequest, IncomingMessage). We
+  // don't use node:http so the request is a minimal synthetic stub — assert
+  // its method/path/getHeader surface so code that inspects the request
+  // object doesn't crash.
+  expect(stdout).toMatchInlineSnapshot(
+    `"{"reqMethod":"GET","reqPath":"/","reqGetHeader":null,"statusCode":503,"statusMessage":"Service Unavailable","xReason":"not-ready","body":"workerd starting"}"`,
+  );
+  expect(exitCode).toBe(0);
+});
+
+// Diverges from real ws: with no 'unexpected-response' listener, real ws emits
+// "Unexpected server response: 503". Bun's shim only registers the native
+// handshake listener when the user subscribes to 'upgrade'/'unexpected-response',
+// so the unmodified native error surfaces instead.
+test("ws emits native 'error' on non-101 when no 'unexpected-response' listener", { timeout: 30000 }, async () => {
+  const { stdout, exitCode } = await run(/* js */ `
+    const { createServer } = require("net");
+    const { once } = require("events");
+    const { WebSocket } = require("ws");
+
+    const server = createServer(s =>
+      s.once("data", () => s.end("HTTP/1.1 503 Service Unavailable\\r\\n\\r\\n")),
+    ).listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const ws = new WebSocket("ws://127.0.0.1:" + server.address().port);
+    const [err] = await once(ws, "error");
+    console.log(/Expected 101/.test(err.message) ? "got native 101 error" : "unexpected: " + err.message);
+    server.close();
+    process.exit(0);
+  `);
+  expect(stdout).toMatchInlineSnapshot(`"got native 101 error"`);
+  expect(exitCode).toBe(0);
+});
+
+test("ws emits 'upgrade' with headers before 'open' on 101", { timeout: 30000 }, async () => {
+  const { stdout, exitCode } = await run(/* js */ `
+    const { createServer } = require("net");
+    const { createHash } = require("crypto");
+    const { once } = require("events");
+    const { WebSocket } = require("ws");
+
+    const server = createServer(conn => {
+      let buf = "";
+      const onData = chunk => {
+        buf += chunk.toString();
+        if (buf.indexOf("\\r\\n\\r\\n") === -1) return;
+        conn.off("data", onData);
+        const key = /Sec-WebSocket-Key: (.+)\\r\\n/i.exec(buf)[1];
+        const accept = createHash("sha1")
+          .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+          .digest("base64");
+        conn.write(
+          "HTTP/1.1 101 Switching Protocols\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\nSec-WebSocket-Accept: " +
+            accept + "\\r\\n\\r\\n",
+        );
+      };
+      conn.on("data", onData);
+    }).listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const ws = new WebSocket("ws://127.0.0.1:" + server.address().port);
+    const order = [];
+    ws.on("upgrade", res => order.push("upgrade:" + res.statusCode + ":" + typeof res.headers["sec-websocket-accept"]));
+    ws.on("open", () => {
+      order.push("open");
+      ws.terminate();
+      server.close();
+    });
+    await once(ws, "close");
+    console.log(order.join(","));
+  `);
+  expect(stdout).toMatchInlineSnapshot(`"upgrade:101:string,open"`);
+  expect(exitCode).toBe(0);
+});
+
+// The non-101 body can span multiple TCP reads. Previously the shim dispatched
+// on the first read, truncating large error bodies. The native client now
+// buffers until Content-Length is satisfied (or EOF) before dispatching.
+test(
+  "ws 'unexpected-response' waits for full Content-Length body across multiple writes",
+  { timeout: 30000 },
+  async () => {
+    const { stdout, exitCode } = await run(/* js */ `
+    const { createServer } = require("net");
+    const { once } = require("events");
+    const { WebSocket } = require("ws");
+
+    // 8 kB JSON-ish payload, sent in three separate writes with a tick between
+    // each so the client sees multiple TCP reads (at least in the common case).
+    const CHUNK_SIZE = 2600;
+    const chunk1 = "a".repeat(CHUNK_SIZE);
+    const chunk2 = "b".repeat(CHUNK_SIZE);
+    const chunk3 = "c".repeat(CHUNK_SIZE);
+    const bodyLen = CHUNK_SIZE * 3;
+
+    const server = createServer(s => {
+      s.once("data", () => {
+        s.write(
+          "HTTP/1.1 503 Service Unavailable\\r\\n" +
+          "Content-Type: text/plain\\r\\n" +
+          "Content-Length: " + bodyLen + "\\r\\n\\r\\n" +
+          chunk1
+        );
+        setTimeout(() => s.write(chunk2), 10);
+        setTimeout(() => { s.write(chunk3); s.end(); }, 20);
+      });
+    }).listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const ws = new WebSocket("ws://127.0.0.1:" + server.address().port);
+    ws.on("error", () => {});
+    const [req, res] = await new Promise(resolve =>
+      ws.once("unexpected-response", (req, res) => resolve([req, res])),
+    );
+    let body = "";
+    for await (const chunk of res) body += chunk;
+    console.log(JSON.stringify({
+      statusCode: res.statusCode,
+      contentLength: res.headers["content-length"],
+      bodyLength: body.length,
+      firstChar: body[0],
+      lastChar: body[body.length - 1],
+    }));
+    await once(ws, "close");
+    server.close();
+  `);
+    expect(stdout).toMatchInlineSnapshot(
+      `"{"statusCode":503,"contentLength":"7800","bodyLength":7800,"firstChar":"a","lastChar":"c"}"`,
+    );
+    expect(exitCode).toBe(0);
+  },
+);
+
+// `on()` / `once()` are not the only EventEmitter registration APIs — ws
+// consumers also reach for `addListener` / `prependListener` /
+// `prependOnceListener` and (from DOM-style code) `addEventListener`. Each
+// must arm the native handshake listener, otherwise the 'upgrade' /
+// 'unexpected-response' handler is installed on the EventEmitter list but
+// the native event that would `emit('upgrade', ...)` is never wired up and
+// the callback silently never fires.
+test(
+  "ws 'unexpected-response' fires for addListener / prependListener / addEventListener",
+  { timeout: 30000 },
+  async () => {
+    const { stdout, exitCode } = await run(/* js */ `
+    const { createServer } = require("net");
+    const { once } = require("events");
+    const { WebSocket } = require("ws");
+
+    async function runOne(register) {
+      const server = createServer(s =>
+        s.once("data", () => s.end("HTTP/1.1 503 Service Unavailable\\r\\n\\r\\n")),
+      ).listen(0, "127.0.0.1");
+      await once(server, "listening");
+
+      const ws = new WebSocket("ws://127.0.0.1:" + server.address().port);
+      ws.on("error", () => {});
+      const { promise, resolve } = Promise.withResolvers();
+      register(ws, resolve);
+      const res = await promise;
+      server.close();
+      try { ws.terminate(); } catch {}
+      return res;
+    }
+
+    const a = await runOne((ws, done) =>
+      ws.addListener("unexpected-response", (req, res) => done(res.statusCode)),
+    );
+    const b = await runOne((ws, done) =>
+      ws.prependListener("unexpected-response", (req, res) => done(res.statusCode)),
+    );
+    const c = await runOne((ws, done) =>
+      ws.prependOnceListener("unexpected-response", (req, res) => done(res.statusCode)),
+    );
+    const d = await runOne((ws, done) =>
+      // For upgrade/unexpected-response addEventListener is symmetric with
+      // removeEventListener (no DOM-style wrapping adapter) so handlers
+      // receive Node-style args.
+      ws.addEventListener("unexpected-response", (req, res) => done(res.statusCode)),
+    );
+    console.log(JSON.stringify({ a, b, c, d }));
+    process.exit(0);
+  `);
+    expect(stdout).toMatchInlineSnapshot(`"{"a":503,"b":503,"c":503,"d":503}"`);
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -387,8 +387,10 @@ test.concurrent("ws 'unexpected-response' fires for addListener / prependListene
 // response was handled). The suppression has to apply uniformly across every
 // registration API — on('error'), addEventListener('error', …) and the
 // onerror setter — not just on()/once().
-test.concurrent("ws suppresses the native error after 'unexpected-response' across on/addEventListener/onerror", async () => {
-  const { stdout, exitCode } = await run(/* js */ `
+test.concurrent(
+  "ws suppresses the native error after 'unexpected-response' across on/addEventListener/onerror",
+  async () => {
+    const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { once } = require("events");
     const { WebSocket } = require("ws");
@@ -419,9 +421,10 @@ test.concurrent("ws suppresses the native error after 'unexpected-response' acro
     console.log(JSON.stringify({ on, ael, prop }));
     process.exit(0);
   `);
-  // All three APIs: 'unexpected-response' seen (503), native 'error' suppressed.
-  expect(stdout).toMatchInlineSnapshot(
-    `"{"on":{"status":503,"errored":false},"ael":{"status":503,"errored":false},"prop":{"status":503,"errored":false}}"`,
-  );
-  expect(exitCode).toBe(0);
-});
+    // All three APIs: 'unexpected-response' seen (503), native 'error' suppressed.
+    expect(stdout).toMatchInlineSnapshot(
+      `"{"on":{"status":503,"errored":false},"ael":{"status":503,"errored":false},"prop":{"status":503,"errored":false}}"`,
+    );
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -646,3 +646,51 @@ test.concurrent(
     expect(exitCode).toBe(0);
   },
 );
+
+// DOM dedup must also apply to the Node-only 'upgrade'/'unexpected-response'
+// events. These register on the EventEmitter (super.on) which doesn't dedup,
+// so addEventListener with the same handler twice would fire it twice on a
+// 101 — real ws dedups every event type.
+test.concurrent("ws addEventListener('upgrade', h) dedupes the same handler", async () => {
+  const { stdout, exitCode } = await run(/* js */ `
+    const { createServer } = require("net");
+    const { createHash } = require("crypto");
+    const { once } = require("events");
+    const { WebSocket } = require("ws");
+
+    const server = createServer(conn => {
+      let buf = "";
+      const onData = chunk => {
+        buf += chunk.toString();
+        if (buf.indexOf("\\r\\n\\r\\n") === -1) return;
+        conn.off("data", onData);
+        const key = /Sec-WebSocket-Key: (.+)\\r\\n/i.exec(buf)[1];
+        const accept = createHash("sha1")
+          .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+          .digest("base64");
+        conn.write(
+          "HTTP/1.1 101 Switching Protocols\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\nSec-WebSocket-Accept: " +
+            accept + "\\r\\n\\r\\n",
+        );
+      };
+      conn.on("data", onData);
+    }).listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const ws = new WebSocket("ws://127.0.0.1:" + server.address().port);
+    let count = 0;
+    const h = () => { count++; };
+    ws.addEventListener("upgrade", h);
+    ws.addEventListener("upgrade", h); // duplicate — must be a no-op
+    await once(ws, "open");
+    // removeEventListener must fully detach the single registration.
+    ws.removeEventListener("upgrade", h);
+    console.log(JSON.stringify({ count }));
+    ws.terminate();
+    server.close();
+    process.exit(0);
+  `);
+  // The handler fires exactly once despite the duplicate addEventListener.
+  expect(stdout).toMatchInlineSnapshot(`"{"count":1}"`);
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -476,8 +476,10 @@ test.concurrent(
 // "Unexpected server response" error) and — via the native bridge closure — on
 // this.#ws (would get the native 'Expected 101' error too). It must fire
 // exactly once, like real ws, not twice.
-test.concurrent("ws on('error') fires once (not twice) for a non-101 with no 'unexpected-response' listener", async () => {
-  const { stdout, exitCode } = await run(/* js */ `
+test.concurrent(
+  "ws on('error') fires once (not twice) for a non-101 with no 'unexpected-response' listener",
+  async () => {
+    const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { once } = require("events");
     const { WebSocket } = require("ws");
@@ -498,13 +500,12 @@ test.concurrent("ws on('error') fires once (not twice) for a non-101 with no 'un
     console.log(JSON.stringify({ count: messages.length, first: messages[0] }));
     process.exit(0);
   `);
-  // Exactly one 'error' — the synthetic non-101 message — and the native
-  // 'Expected 101' follow-up is suppressed for EventEmitter listeners.
-  expect(stdout).toMatchInlineSnapshot(
-    `"{"count":1,"first":"Unexpected server response: 503"}"`,
-  );
-  expect(exitCode).toBe(0);
-});
+    // Exactly one 'error' — the synthetic non-101 message — and the native
+    // 'Expected 101' follow-up is suppressed for EventEmitter listeners.
+    expect(stdout).toMatchInlineSnapshot(`"{"count":1,"first":"Unexpected server response: 503"}"`);
+    expect(exitCode).toBe(0);
+  },
+);
 
 // DOM dedup: registering the identical listener twice via addEventListener is
 // a no-op. Because we wrap the listener in a suppression closure, a naive

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -179,6 +179,61 @@ test("ws 'unexpected-response' waits for full Content-Length body across multipl
   expect(exitCode).toBe(0);
 });
 
+// The synthetic IncomingMessage passed to 'unexpected-response' must coalesce
+// duplicate headers the way Node's http.IncomingMessage.headers does (real ws
+// hands the consumer that Node object): singleton headers keep the first value
+// and discard duplicates, duplicate `cookie` joins with "; ", everything else
+// joins with ", ", and set-cookie is always an array. rawHeaders stays verbatim.
+test("ws 'unexpected-response' coalesces duplicate headers like Node IncomingMessage", async () => {
+  const { stdout, exitCode } = await run(/* js */ `
+    const { createServer } = require("net");
+    const { once } = require("events");
+    const { WebSocket } = require("ws");
+
+    const server = createServer(s =>
+      s.once("data", () =>
+        s.end(
+          "HTTP/1.1 401 Unauthorized\\r\\n" +
+          // singleton header repeated -> first value kept
+          "Content-Length: 0\\r\\n" +
+          "Content-Length: 999\\r\\n" +
+          // duplicate cookie -> joined with "; "
+          "Cookie: a=1\\r\\n" +
+          "Cookie: b=2\\r\\n" +
+          // duplicate non-singleton -> joined with ", "
+          "X-Multi: one\\r\\n" +
+          "X-Multi: two\\r\\n" +
+          // set-cookie -> array
+          "Set-Cookie: s1=1\\r\\n" +
+          "Set-Cookie: s2=2\\r\\n" +
+          "\\r\\n",
+        ),
+      ),
+    ).listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const ws = new WebSocket("ws://127.0.0.1:" + server.address().port);
+    ws.on("error", () => {});
+    const [, res] = await new Promise(resolve =>
+      ws.once("unexpected-response", (req, res) => resolve([req, res])),
+    );
+    console.log(JSON.stringify({
+      contentLength: res.headers["content-length"],
+      cookie: res.headers["cookie"],
+      xMulti: res.headers["x-multi"],
+      setCookie: res.headers["set-cookie"],
+      rawContentLengths: res.rawHeaders.filter((_, i) => i % 2 === 0)
+        .reduce((n, k) => n + (k.toLowerCase() === "content-length" ? 1 : 0), 0),
+    }));
+    ws.terminate();
+    server.close();
+  `);
+  expect(stdout).toMatchInlineSnapshot(
+    `"{"contentLength":"0","cookie":"a=1; b=2","xMulti":"one, two","setCookie":["s1=1","s2=2"],"rawContentLengths":2}"`,
+  );
+  expect(exitCode).toBe(0);
+});
+
 // `on()` / `once()` are not the only EventEmitter registration APIs — ws
 // consumers also reach for `addListener` / `prependListener` /
 // `prependOnceListener` and (from DOM-style code) `addEventListener`. Each

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -128,10 +128,8 @@ test("ws emits 'upgrade' with headers before 'open' on 101", async () => {
 // The non-101 body can span multiple TCP reads. Previously the shim dispatched
 // on the first read, truncating large error bodies. The native client now
 // buffers until Content-Length is satisfied (or EOF) before dispatching.
-test(
-  "ws 'unexpected-response' waits for full Content-Length body across multiple writes",
-  async () => {
-    const { stdout, exitCode } = await run(/* js */ `
+test("ws 'unexpected-response' waits for full Content-Length body across multiple writes", async () => {
+  const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { once } = require("events");
     const { WebSocket } = require("ws");
@@ -175,12 +173,11 @@ test(
     await once(ws, "close");
     server.close();
   `);
-    expect(stdout).toMatchInlineSnapshot(
-      `"{"statusCode":503,"contentLength":"7800","bodyLength":7800,"firstChar":"a","lastChar":"c"}"`,
-    );
-    expect(exitCode).toBe(0);
-  },
-);
+  expect(stdout).toMatchInlineSnapshot(
+    `"{"statusCode":503,"contentLength":"7800","bodyLength":7800,"firstChar":"a","lastChar":"c"}"`,
+  );
+  expect(exitCode).toBe(0);
+});
 
 // `on()` / `once()` are not the only EventEmitter registration APIs — ws
 // consumers also reach for `addListener` / `prependListener` /
@@ -189,10 +186,8 @@ test(
 // 'unexpected-response' handler is installed on the EventEmitter list but
 // the native event that would `emit('upgrade', ...)` is never wired up and
 // the callback silently never fires.
-test(
-  "ws 'unexpected-response' fires for addListener / prependListener / addEventListener",
-  async () => {
-    const { stdout, exitCode } = await run(/* js */ `
+test("ws 'unexpected-response' fires for addListener / prependListener / addEventListener", async () => {
+  const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { once } = require("events");
     const { WebSocket } = require("ws");
@@ -231,7 +226,6 @@ test(
     console.log(JSON.stringify({ a, b, c, d }));
     process.exit(0);
   `);
-    expect(stdout).toMatchInlineSnapshot(`"{"a":503,"b":503,"c":503,"d":503}"`);
-    expect(exitCode).toBe(0);
-  },
-);
+  expect(stdout).toMatchInlineSnapshot(`"{"a":503,"b":503,"c":503,"d":503}"`);
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -3,7 +3,7 @@
 // Exercises the public `ws` package surface (what miniflare/wrangler actually
 // listen for), not the native 'handshake' event covered in 24229.test.ts.
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, normalizeBunSnapshot } from "harness";
 
 async function run(script: string) {
   await using proc = Bun.spawn({
@@ -271,6 +271,66 @@ test("ws 'unexpected-response' fires immediately for bodiless 204 on keep-alive"
   expect(stdout).toMatchInlineSnapshot(`"{"statusCode":204,"statusMessage":"No Content","xGone":"1"}"`);
   expect(exitCode).toBe(0);
 });
+
+// The RST teardown path (handle_close) flushes a mid-accumulation non-101
+// body into the 'unexpected-response' listener. If that listener synchronously
+// calls ws.terminate()/ws.close(), the reentrant cancel() releases the socket
+// ref while handle_close is still holding it — then handle_close's tcp.detach()
+// runs on freed memory (heap-use-after-free in NewSocketHandler::detach) and
+// its deref() underflows the refcount. Only an ASAN/debug build surfaces the
+// corruption as a crash; release builds survive by luck, so gate on it.
+//
+// The RST must arrive as on_close WITHOUT a preceding on_end (FIN): a Bun.listen
+// socket's terminate() sends a real RST while the client still has the body
+// un-satisfied (WaitingForLength). Node's net server destroy()/resetAndDestroy()
+// over loopback surfaces as FIN → on_end (a different, already-safe path).
+test.skipIf(!isDebug && !isASAN)(
+  "ws survives terminate() inside 'unexpected-response' when the socket RSTs mid-body",
+  async () => {
+    const { stdout, stderr, exitCode } = await run(/* js */ `
+      const { once } = require("events");
+      const { WebSocket } = require("ws");
+
+      // Declare a 100 kB body but send only a sliver, then RST a tick later so
+      // the client has parsed the headers and entered WaitingForLength. The
+      // RST then routes through handle_close, which flushes the deferred body
+      // into 'unexpected-response'.
+      const server = Bun.listen({
+        hostname: "127.0.0.1", port: 0,
+        socket: {
+          data(socket) {
+            socket.write(
+              "HTTP/1.1 503 Service Unavailable\\r\\n" +
+              "Content-Length: 100000\\r\\n\\r\\n" +
+              "partial body, server resets before sending the rest"
+            );
+            // Bun's socket.terminate() sends a real RST (not FIN). The small
+            // delay lets the partial body land first so the client is mid-body.
+            setTimeout(() => { try { socket.terminate(); } catch {} }, 10);
+          },
+          error() {}, open() {},
+        },
+      });
+
+      const ws = new WebSocket("ws://127.0.0.1:" + server.port);
+      ws.on("error", () => {});
+      ws.once("unexpected-response", (req, res) => {
+        console.log("status=" + res.statusCode);
+        // Reentrant teardown from inside the handshake dispatch — this is the
+        // path that used to UAF on the native client (handle_close then ran
+        // tcp.detach() on freed memory).
+        ws.terminate();
+      });
+      // Await 'close' rather than exiting immediately: the detach/deref that
+      // used to fault runs as handle_close unwinds, after terminate() returns.
+      await once(ws, "close");
+      server.stop(true);
+    `);
+    if (exitCode !== 0) console.error(stderr);
+    expect(stdout).toContain("status=503");
+    expect(exitCode).toBe(0);
+  },
+);
 
 // `on()` / `once()` are not the only EventEmitter registration APIs — ws
 // consumers also reach for `addListener` / `prependListener` /

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -475,8 +475,10 @@ test.concurrent(
 // a no-op. Because we wrap the listener in a suppression closure, a naive
 // implementation would create two distinct wrappers and fire the handler
 // twice; removeEventListener must also detach it completely.
-test.concurrent("ws addEventListener('error', h) dedupes the same handler and removeEventListener detaches it", async () => {
-  const { stdout, exitCode } = await run(/* js */ `
+test.concurrent(
+  "ws addEventListener('error', h) dedupes the same handler and removeEventListener detaches it",
+  async () => {
+    const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { once } = require("events");
     const { WebSocket } = require("ws");
@@ -499,7 +501,8 @@ test.concurrent("ws addEventListener('error', h) dedupes the same handler and re
     console.log(JSON.stringify({ count }));
     process.exit(0);
   `);
-  // The handler fires exactly once despite the duplicate registration.
-  expect(stdout).toMatchInlineSnapshot(`"{"count":1}"`);
-  expect(exitCode).toBe(0);
-});
+    // The handler fires exactly once despite the duplicate registration.
+    expect(stdout).toMatchInlineSnapshot(`"{"count":1}"`);
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -428,3 +428,78 @@ test.concurrent(
     expect(exitCode).toBe(0);
   },
 );
+
+// The suppression must NOT apply when the consumer never subscribed to
+// 'unexpected-response'. A client that listens for 'upgrade' (arming the
+// handshake bridge) but registers its error handling via addEventListener
+// ('error') / onerror must still receive the native non-101 error — otherwise
+// the error is swallowed entirely.
+test.concurrent(
+  "ws still delivers the native error to addEventListener/onerror when there is no 'unexpected-response' listener",
+  async () => {
+    const { stdout, exitCode } = await run(/* js */ `
+    const { createServer } = require("net");
+    const { once } = require("events");
+    const { WebSocket } = require("ws");
+
+    async function runOne(registerError) {
+      const server = createServer(s =>
+        s.once("data", () => s.end("HTTP/1.1 503 Service Unavailable\\r\\n\\r\\n")),
+      ).listen(0, "127.0.0.1");
+      await once(server, "listening");
+
+      const ws = new WebSocket("ws://127.0.0.1:" + server.address().port);
+      // Arm the handshake bridge via 'upgrade' but do NOT listen for
+      // 'unexpected-response', so the native error path is exercised.
+      ws.on("upgrade", () => {});
+      const { promise, resolve } = Promise.withResolvers();
+      registerError(ws, err => resolve(/Expected 101/.test(err?.message ?? String(err))));
+      const gotExpected101 = await promise;
+      server.close();
+      try { ws.terminate(); } catch {}
+      return gotExpected101;
+    }
+
+    const ael = await runOne((ws, done) => ws.addEventListener("error", done));
+    const prop = await runOne((ws, done) => { ws.onerror = done; });
+    console.log(JSON.stringify({ ael, prop }));
+    process.exit(0);
+  `);
+    // Both DOM-style APIs receive the native 'Expected 101' error.
+    expect(stdout).toMatchInlineSnapshot(`"{"ael":true,"prop":true}"`);
+    expect(exitCode).toBe(0);
+  },
+);
+
+// DOM dedup: registering the identical listener twice via addEventListener is
+// a no-op. Because we wrap the listener in a suppression closure, a naive
+// implementation would create two distinct wrappers and fire the handler
+// twice; removeEventListener must also detach it completely.
+test.concurrent("ws addEventListener('error', h) dedupes the same handler and removeEventListener detaches it", async () => {
+  const { stdout, exitCode } = await run(/* js */ `
+    const { createServer } = require("net");
+    const { once } = require("events");
+    const { WebSocket } = require("ws");
+
+    const server = createServer(s =>
+      s.once("data", () => s.end("HTTP/1.1 503 Service Unavailable\\r\\n\\r\\n")),
+    ).listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const ws = new WebSocket("ws://127.0.0.1:" + server.address().port);
+    let count = 0;
+    const h = () => { count++; };
+    ws.addEventListener("error", h);
+    ws.addEventListener("error", h); // duplicate — must be a no-op
+    await once(ws, "close").catch(() => {});
+    server.close();
+    try { ws.terminate(); } catch {}
+    // removeEventListener must fully detach (no leaked wrapper left behind).
+    ws.removeEventListener("error", h);
+    console.log(JSON.stringify({ count }));
+    process.exit(0);
+  `);
+  // The handler fires exactly once despite the duplicate registration.
+  expect(stdout).toMatchInlineSnapshot(`"{"count":1}"`);
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -137,9 +137,9 @@ test("ws 'unexpected-response' waits for full Content-Length body across multipl
     // 8 kB JSON-ish payload, sent in three separate writes with a tick between
     // each so the client sees multiple TCP reads (at least in the common case).
     const CHUNK_SIZE = 2600;
-    const chunk1 = "a".repeat(CHUNK_SIZE);
-    const chunk2 = "b".repeat(CHUNK_SIZE);
-    const chunk3 = "c".repeat(CHUNK_SIZE);
+    const chunk1 = Buffer.alloc(CHUNK_SIZE, "a").toString();
+    const chunk2 = Buffer.alloc(CHUNK_SIZE, "b").toString();
+    const chunk3 = Buffer.alloc(CHUNK_SIZE, "c").toString();
     const bodyLen = CHUNK_SIZE * 3;
 
     const server = createServer(s => {

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -17,7 +17,7 @@ async function run(script: string) {
   return { stdout: normalizeBunSnapshot(stdout), exitCode };
 }
 
-test("ws emits 'unexpected-response' with status, headers and body on non-101", async () => {
+test.concurrent("ws emits 'unexpected-response' with status, headers and body on non-101", async () => {
   const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { once } = require("events");
@@ -63,7 +63,7 @@ test("ws emits 'unexpected-response' with status, headers and body on non-101", 
 // "Unexpected server response: 503". Bun's shim only registers the native
 // handshake listener when the user subscribes to 'upgrade'/'unexpected-response',
 // so the unmodified native error surfaces instead.
-test("ws emits native 'error' on non-101 when no 'unexpected-response' listener", async () => {
+test.concurrent("ws emits native 'error' on non-101 when no 'unexpected-response' listener", async () => {
   const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { once } = require("events");
@@ -84,7 +84,7 @@ test("ws emits native 'error' on non-101 when no 'unexpected-response' listener"
   expect(exitCode).toBe(0);
 });
 
-test("ws emits 'upgrade' with headers before 'open' on 101", async () => {
+test.concurrent("ws emits 'upgrade' with headers before 'open' on 101", async () => {
   const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { createHash } = require("crypto");
@@ -128,7 +128,7 @@ test("ws emits 'upgrade' with headers before 'open' on 101", async () => {
 // The non-101 body can span multiple TCP reads. Previously the shim dispatched
 // on the first read, truncating large error bodies. The native client now
 // buffers until Content-Length is satisfied (or EOF) before dispatching.
-test("ws 'unexpected-response' waits for full Content-Length body across multiple writes", async () => {
+test.concurrent("ws 'unexpected-response' waits for full Content-Length body across multiple writes", async () => {
   const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { once } = require("events");
@@ -184,7 +184,7 @@ test("ws 'unexpected-response' waits for full Content-Length body across multipl
 // hands the consumer that Node object): singleton headers keep the first value
 // and discard duplicates, duplicate `cookie` joins with "; ", everything else
 // joins with ", ", and set-cookie is always an array. rawHeaders stays verbatim.
-test("ws 'unexpected-response' coalesces duplicate headers like Node IncomingMessage", async () => {
+test.concurrent("ws 'unexpected-response' coalesces duplicate headers like Node IncomingMessage", async () => {
   const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { once } = require("events");
@@ -241,7 +241,7 @@ test("ws 'unexpected-response' coalesces duplicate headers like Node IncomingMes
 // timeout and the event never fires. The server here deliberately keeps the
 // connection open: with the fix this resolves at once; without it the
 // subprocess hangs and the test times out.
-test("ws 'unexpected-response' fires immediately for bodiless 204 on keep-alive", async () => {
+test.concurrent("ws 'unexpected-response' fires immediately for bodiless 204 on keep-alive", async () => {
   const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { WebSocket } = require("ws");
@@ -284,7 +284,7 @@ test("ws 'unexpected-response' fires immediately for bodiless 204 on keep-alive"
 // socket's terminate() sends a real RST while the client still has the body
 // un-satisfied (WaitingForLength). Node's net server destroy()/resetAndDestroy()
 // over loopback surfaces as FIN → on_end (a different, already-safe path).
-test.skipIf(!isDebug && !isASAN)(
+test.concurrent.skipIf(!isDebug && !isASAN)(
   "ws survives terminate() inside 'unexpected-response' when the socket RSTs mid-body",
   async () => {
     const { stdout, exitCode } = await run(/* js */ `
@@ -338,7 +338,7 @@ test.skipIf(!isDebug && !isASAN)(
 // 'unexpected-response' handler is installed on the EventEmitter list but
 // the native event that would `emit('upgrade', ...)` is never wired up and
 // the callback silently never fires.
-test("ws 'unexpected-response' fires for addListener / prependListener / addEventListener", async () => {
+test.concurrent("ws 'unexpected-response' fires for addListener / prependListener / addEventListener", async () => {
   const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { once } = require("events");
@@ -379,5 +379,49 @@ test("ws 'unexpected-response' fires for addListener / prependListener / addEven
     process.exit(0);
   `);
   expect(stdout).toMatchInlineSnapshot(`"{"a":503,"b":503,"c":503,"d":503}"`);
+  expect(exitCode).toBe(0);
+});
+
+// Once 'unexpected-response' has fired, the native 'Expected 101' error must
+// NOT reach user 'error' handlers (real ws never emits 'error' when the
+// response was handled). The suppression has to apply uniformly across every
+// registration API — on('error'), addEventListener('error', …) and the
+// onerror setter — not just on()/once().
+test.concurrent("ws suppresses the native error after 'unexpected-response' across on/addEventListener/onerror", async () => {
+  const { stdout, exitCode } = await run(/* js */ `
+    const { createServer } = require("net");
+    const { once } = require("events");
+    const { WebSocket } = require("ws");
+
+    // Register the 'error' handler via one of the three APIs, subscribe to
+    // 'unexpected-response', and report whether a spurious 'error' still fired.
+    async function runOne(registerError) {
+      const server = createServer(s =>
+        s.once("data", () => s.end("HTTP/1.1 503 Service Unavailable\\r\\n\\r\\n")),
+      ).listen(0, "127.0.0.1");
+      await once(server, "listening");
+
+      const ws = new WebSocket("ws://127.0.0.1:" + server.address().port);
+      let errored = false;
+      registerError(ws, () => { errored = true; });
+      const { promise, resolve } = Promise.withResolvers();
+      ws.on("unexpected-response", (req, res) => resolve(res.statusCode));
+      const status = await promise;
+      // Give the native error a turn of the loop to (not) arrive.
+      await once(ws, "close").catch(() => {});
+      server.close();
+      return { status, errored };
+    }
+
+    const on = await runOne((ws, mark) => ws.on("error", mark));
+    const ael = await runOne((ws, mark) => ws.addEventListener("error", mark));
+    const prop = await runOne((ws, mark) => { ws.onerror = mark; });
+    console.log(JSON.stringify({ on, ael, prop }));
+    process.exit(0);
+  `);
+  // All three APIs: 'unexpected-response' seen (503), native 'error' suppressed.
+  expect(stdout).toMatchInlineSnapshot(
+    `"{"on":{"status":503,"errored":false},"ael":{"status":503,"errored":false},"prop":{"status":503,"errored":false}}"`,
+  );
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -287,7 +287,7 @@ test("ws 'unexpected-response' fires immediately for bodiless 204 on keep-alive"
 test.skipIf(!isDebug && !isASAN)(
   "ws survives terminate() inside 'unexpected-response' when the socket RSTs mid-body",
   async () => {
-    const { stdout, stderr, exitCode } = await run(/* js */ `
+    const { stdout, exitCode } = await run(/* js */ `
       const { once } = require("events");
       const { WebSocket } = require("ws");
 
@@ -326,7 +326,6 @@ test.skipIf(!isDebug && !isASAN)(
       await once(ws, "close");
       server.stop(true);
     `);
-    if (exitCode !== 0) console.error(stderr);
     expect(stdout).toContain("status=503");
     expect(exitCode).toBe(0);
   },

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -507,6 +507,53 @@ test.concurrent(
   },
 );
 
+// Mixed registration styles: on('error') (EventEmitter) AND addEventListener
+// ('error')/onerror (native this.#ws), with on('upgrade') but no
+// 'unexpected-response'. Each handler must fire exactly once — the synthetic
+// emit suppresses the EE bridge re-fire, but the DOM-style handler must still
+// receive the native error (gated on a separate "handled" flag).
+test.concurrent("ws error handlers each fire once when on('error') and addEventListener/onerror are mixed", async () => {
+  const { stdout, exitCode } = await run(/* js */ `
+    const { createServer } = require("net");
+    const { once } = require("events");
+    const { WebSocket } = require("ws");
+
+    async function runOne(registerDom) {
+      const server = createServer(s =>
+        s.once("data", () => s.end("HTTP/1.1 503 Service Unavailable\\r\\n\\r\\n")),
+      ).listen(0, "127.0.0.1");
+      await once(server, "listening");
+
+      const ws = new WebSocket("ws://127.0.0.1:" + server.address().port);
+      ws.on("upgrade", () => {});
+      let onCount = 0;
+      let domCount = 0;
+      // The synthetic error (on) fires synchronously in #onHandshake; the
+      // native error (DOM handler) arrives a tick later after the client
+      // terminates. Await BOTH so neither the test nor 'close' races ahead of
+      // the native delivery.
+      const onSeen = Promise.withResolvers();
+      const domSeen = Promise.withResolvers();
+      ws.on("error", () => { onCount++; onSeen.resolve(); });
+      registerDom(ws, () => { domCount++; domSeen.resolve(); });
+      await Promise.all([onSeen.promise, domSeen.promise]);
+      server.close();
+      try { ws.terminate(); } catch {}
+      return { onCount, domCount };
+    }
+
+    const ael = await runOne((ws, h) => ws.addEventListener("error", h));
+    const prop = await runOne((ws, h) => { ws.onerror = h; });
+    console.log(JSON.stringify({ ael, prop }));
+    process.exit(0);
+  `);
+  // Both the on('error') handler and the DOM-style handler fire exactly once.
+  expect(stdout).toMatchInlineSnapshot(
+    `"{"ael":{"onCount":1,"domCount":1},"prop":{"onCount":1,"domCount":1}}"`,
+  );
+  expect(exitCode).toBe(0);
+});
+
 // DOM dedup: registering the identical listener twice via addEventListener is
 // a no-op. Because we wrap the listener in a suppression closure, a naive
 // implementation would create two distinct wrappers and fire the handler

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -268,9 +268,7 @@ test("ws 'unexpected-response' fires immediately for bodiless 204 on keep-alive"
     server.close();
     process.exit(0);
   `);
-  expect(stdout).toMatchInlineSnapshot(
-    `"{"statusCode":204,"statusMessage":"No Content","xGone":"1"}"`,
-  );
+  expect(stdout).toMatchInlineSnapshot(`"{"statusCode":204,"statusMessage":"No Content","xGone":"1"}"`);
   expect(exitCode).toBe(0);
 });
 

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -512,8 +512,10 @@ test.concurrent(
 // 'unexpected-response'. Each handler must fire exactly once — the synthetic
 // emit suppresses the EE bridge re-fire, but the DOM-style handler must still
 // receive the native error (gated on a separate "handled" flag).
-test.concurrent("ws error handlers each fire once when on('error') and addEventListener/onerror are mixed", async () => {
-  const { stdout, exitCode } = await run(/* js */ `
+test.concurrent(
+  "ws error handlers each fire once when on('error') and addEventListener/onerror are mixed",
+  async () => {
+    const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { once } = require("events");
     const { WebSocket } = require("ws");
@@ -547,12 +549,11 @@ test.concurrent("ws error handlers each fire once when on('error') and addEventL
     console.log(JSON.stringify({ ael, prop }));
     process.exit(0);
   `);
-  // Both the on('error') handler and the DOM-style handler fire exactly once.
-  expect(stdout).toMatchInlineSnapshot(
-    `"{"ael":{"onCount":1,"domCount":1},"prop":{"onCount":1,"domCount":1}}"`,
-  );
-  expect(exitCode).toBe(0);
-});
+    // Both the on('error') handler and the DOM-style handler fire exactly once.
+    expect(stdout).toMatchInlineSnapshot(`"{"ael":{"onCount":1,"domCount":1},"prop":{"onCount":1,"domCount":1}}"`);
+    expect(exitCode).toBe(0);
+  },
+);
 
 // DOM dedup: registering the identical listener twice via addEventListener is
 // a no-op. Because we wrap the listener in a suppression closure, a naive

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -471,6 +471,41 @@ test.concurrent(
   },
 );
 
+// With on('upgrade') + on('error') but no 'unexpected-response' listener, the
+// on('error') handler lives on BOTH the EventEmitter (gets the synthetic
+// "Unexpected server response" error) and — via the native bridge closure — on
+// this.#ws (would get the native 'Expected 101' error too). It must fire
+// exactly once, like real ws, not twice.
+test.concurrent("ws on('error') fires once (not twice) for a non-101 with no 'unexpected-response' listener", async () => {
+  const { stdout, exitCode } = await run(/* js */ `
+    const { createServer } = require("net");
+    const { once } = require("events");
+    const { WebSocket } = require("ws");
+
+    const server = createServer(s =>
+      s.once("data", () => s.end("HTTP/1.1 503 Service Unavailable\\r\\n\\r\\n")),
+    ).listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const ws = new WebSocket("ws://127.0.0.1:" + server.address().port);
+    ws.on("upgrade", () => {});
+    const messages = [];
+    ws.on("error", err => messages.push(err?.message ?? String(err)));
+    // Wait for close, then report how many 'error' events arrived.
+    await once(ws, "close").catch(() => {});
+    server.close();
+    try { ws.terminate(); } catch {}
+    console.log(JSON.stringify({ count: messages.length, first: messages[0] }));
+    process.exit(0);
+  `);
+  // Exactly one 'error' — the synthetic non-101 message — and the native
+  // 'Expected 101' follow-up is suppressed for EventEmitter listeners.
+  expect(stdout).toMatchInlineSnapshot(
+    `"{"count":1,"first":"Unexpected server response: 503"}"`,
+  );
+  expect(exitCode).toBe(0);
+});
+
 // DOM dedup: registering the identical listener twice via addEventListener is
 // a no-op. Because we wrap the listener in a suppression closure, a naive
 // implementation would create two distinct wrappers and fire the handler

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -234,6 +234,46 @@ test("ws 'unexpected-response' coalesces duplicate headers like Node IncomingMes
   expect(exitCode).toBe(0);
 });
 
+// RFC 7230 §3.3.3 rule #1: 1xx/204/304 responses carry no body regardless of
+// headers. A bodiless non-101 status on a keep-alive connection (server never
+// closes the socket) must dispatch 'unexpected-response' immediately off the
+// header read — otherwise the client sits reading-until-EOF until the socket
+// timeout and the event never fires. The server here deliberately keeps the
+// connection open: with the fix this resolves at once; without it the
+// subprocess hangs and the test times out.
+test("ws 'unexpected-response' fires immediately for bodiless 204 on keep-alive", async () => {
+  const { stdout, exitCode } = await run(/* js */ `
+    const { createServer } = require("net");
+    const { WebSocket } = require("ws");
+
+    // 204 No Content: no Content-Length, no Transfer-Encoding, and the socket
+    // is intentionally left open (no s.end()) so the only way the event fires
+    // is the immediate-dispatch path, not a read-until-close.
+    const server = createServer(s =>
+      s.once("data", () => s.write("HTTP/1.1 204 No Content\\r\\nX-Gone: 1\\r\\n\\r\\n")),
+    ).listen(0, "127.0.0.1");
+    await new Promise(r => server.once("listening", r));
+
+    const ws = new WebSocket("ws://127.0.0.1:" + server.address().port);
+    ws.on("error", () => {});
+    const res = await new Promise(resolve =>
+      ws.once("unexpected-response", (req, res) => resolve(res)),
+    );
+    console.log(JSON.stringify({
+      statusCode: res.statusCode,
+      statusMessage: res.statusMessage,
+      xGone: res.headers["x-gone"],
+    }));
+    ws.terminate();
+    server.close();
+    process.exit(0);
+  `);
+  expect(stdout).toMatchInlineSnapshot(
+    `"{"statusCode":204,"statusMessage":"No Content","xGone":"1"}"`,
+  );
+  expect(exitCode).toBe(0);
+});
+
 // `on()` / `once()` are not the only EventEmitter registration APIs — ws
 // consumers also reach for `addListener` / `prependListener` /
 // `prependOnceListener` and (from DOM-style code) `addEventListener`. Each

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -17,7 +17,7 @@ async function run(script: string) {
   return { stdout: normalizeBunSnapshot(stdout), exitCode };
 }
 
-test("ws emits 'unexpected-response' with status, headers and body on non-101", { timeout: 30000 }, async () => {
+test("ws emits 'unexpected-response' with status, headers and body on non-101", async () => {
   const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { once } = require("events");
@@ -63,7 +63,7 @@ test("ws emits 'unexpected-response' with status, headers and body on non-101", 
 // "Unexpected server response: 503". Bun's shim only registers the native
 // handshake listener when the user subscribes to 'upgrade'/'unexpected-response',
 // so the unmodified native error surfaces instead.
-test("ws emits native 'error' on non-101 when no 'unexpected-response' listener", { timeout: 30000 }, async () => {
+test("ws emits native 'error' on non-101 when no 'unexpected-response' listener", async () => {
   const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { once } = require("events");
@@ -84,7 +84,7 @@ test("ws emits native 'error' on non-101 when no 'unexpected-response' listener"
   expect(exitCode).toBe(0);
 });
 
-test("ws emits 'upgrade' with headers before 'open' on 101", { timeout: 30000 }, async () => {
+test("ws emits 'upgrade' with headers before 'open' on 101", async () => {
   const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
     const { createHash } = require("crypto");
@@ -130,7 +130,6 @@ test("ws emits 'upgrade' with headers before 'open' on 101", { timeout: 30000 },
 // buffers until Content-Length is satisfied (or EOF) before dispatching.
 test(
   "ws 'unexpected-response' waits for full Content-Length body across multiple writes",
-  { timeout: 30000 },
   async () => {
     const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");
@@ -192,7 +191,6 @@ test(
 // the callback silently never fires.
 test(
   "ws 'unexpected-response' fires for addListener / prependListener / addEventListener",
-  { timeout: 30000 },
   async () => {
     const { stdout, exitCode } = await run(/* js */ `
     const { createServer } = require("net");

--- a/test/regression/issue/05951.test.ts
+++ b/test/regression/issue/05951.test.ts
@@ -125,6 +125,62 @@ test.concurrent("ws emits 'upgrade' with headers before 'open' on 101", async ()
   expect(exitCode).toBe(0);
 });
 
+// Real npm `ws` fires 'upgrade' and 'open' back-to-back in the same frame, so a
+// microtask queued inside an 'upgrade' handler runs after the socket is OPEN.
+// The native client dispatches 'upgrade' (handshake) then 'open' (connect); each
+// dispatch drains microtasks on exit, so without a shared event-loop scope the
+// queue drained *between* the two and the microtask observed readyState
+// CONNECTING (0). A single scope around both dispatches keeps the drain after
+// 'open', so the microtask sees OPEN (1).
+test.concurrent("ws microtask queued in 'upgrade' handler observes readyState OPEN", async () => {
+  const { stdout, exitCode } = await run(/* js */ `
+    const { createServer } = require("net");
+    const { createHash } = require("crypto");
+    const { once } = require("events");
+    const { WebSocket } = require("ws");
+
+    const server = createServer(conn => {
+      let buf = "";
+      const onData = chunk => {
+        buf += chunk.toString();
+        if (buf.indexOf("\\r\\n\\r\\n") === -1) return;
+        conn.off("data", onData);
+        const key = /Sec-WebSocket-Key: (.+)\\r\\n/i.exec(buf)[1];
+        const accept = createHash("sha1")
+          .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+          .digest("base64");
+        conn.write(
+          "HTTP/1.1 101 Switching Protocols\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\nSec-WebSocket-Accept: " +
+            accept + "\\r\\n\\r\\n",
+        );
+      };
+      conn.on("data", onData);
+    }).listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const ws = new WebSocket("ws://127.0.0.1:" + server.address().port);
+    const { promise, resolve } = Promise.withResolvers();
+    ws.on("upgrade", () => {
+      // Synchronously the socket is still CONNECTING; the microtask must not
+      // run until after 'open' has set it to OPEN.
+      const atUpgrade = ws.readyState;
+      queueMicrotask(() => resolve({ atUpgrade, inMicrotask: ws.readyState }));
+    });
+    const states = await promise;
+    console.log(JSON.stringify({
+      atUpgrade: states.atUpgrade,
+      inMicrotask: states.inMicrotask,
+      CONNECTING: WebSocket.CONNECTING,
+      OPEN: WebSocket.OPEN,
+    }));
+    ws.terminate();
+    server.close();
+  `);
+  // atUpgrade stays CONNECTING (0); the microtask drains after 'open' so it sees OPEN (1).
+  expect(stdout).toMatchInlineSnapshot(`"{"atUpgrade":0,"inMicrotask":1,"CONNECTING":0,"OPEN":1}"`);
+  expect(exitCode).toBe(0);
+});
+
 // The non-101 body can span multiple TCP reads. Previously the shim dispatched
 // on the first read, truncating large error bodies. The native client now
 // buffers until Content-Length is satisfied (or EOF) before dispatching.

--- a/test/regression/issue/24229.test.ts
+++ b/test/regression/issue/24229.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test";
+import { once } from "events";
+import { AddressInfo, createServer } from "net";
+
+// https://github.com/oven-sh/bun/issues/24229
+// https://github.com/oven-sh/bun/issues/5951
+//
+// The native WebSocket client now surfaces the handshake response to JS via
+// a 'handshake' event (statusCode + statusMessage + rawHeaders + body) so the `ws` package shim can
+// emit 'upgrade' / 'unexpected-response'. Previously non-101 responses were
+// silently discarded, which made miniflare's `dispatchFetch` hang forever.
+//
+// Tests the native 'handshake' event directly — what the ws.js shim consumes.
+test("WebSocket 'handshake' event surfaces status/head/body on non-101", async () => {
+  const server = createServer(socket =>
+    socket.once("data", () =>
+      socket.end(
+        "HTTP/1.1 503 Service Unavailable\r\n" +
+          "Content-Type: text/plain\r\n" +
+          "Set-Cookie: a=1\r\n" +
+          "Set-Cookie: b=2\r\n" +
+          "X-Multi: foo  \r\n\r\nworkerd starting",
+      ),
+    ),
+  ).listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  try {
+    const ws = new WebSocket("ws://127.0.0.1:" + (server.address() as AddressInfo).port);
+    ws.addEventListener("error", () => {}); // swallow the expected-101 error
+    const { promise, resolve } = Promise.withResolvers<{
+      statusCode: number;
+      statusMessage: string;
+      rawHeaders: string[];
+      body: Uint8Array;
+    }>();
+    // 'handshake' is a Bun extension consumed by the ws package shim.
+    ws.addEventListener("handshake" as any, ((e: MessageEvent) => resolve(e.data as any)) as any);
+    const { statusCode, statusMessage, rawHeaders, body } = await promise;
+
+    expect(statusCode).toBe(503);
+    expect(statusMessage).toBe("Service Unavailable");
+    expect(rawHeaders).toEqual([
+      "Content-Type",
+      "text/plain",
+      "Set-Cookie",
+      "a=1",
+      "Set-Cookie",
+      "b=2",
+      "X-Multi",
+      "foo",
+    ]);
+    expect(body).toBeInstanceOf(Uint8Array);
+    expect(new TextDecoder().decode(body)).toBe("workerd starting");
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
Adds `'upgrade'` and `'unexpected-response'` events to the `ws` package shim. The native WebSocket client now surfaces the handshake response (status, headers, body) to JS instead of discarding it on non-101.

This is the load-bearing fix for miniflare/wrangler hanging — `dispatchFetch` resolves a promise exclusively from these two events.

Fixes #5951
Fixes #24229