### PR TITLE
fix(ffi): segfault when threadsafe JSCallback invoked from multiple native threads

### DIFF
--- a/src/bun.js/bindings/JSFFIFunction.cpp
+++ b/src/bun.js/bindings/JSFFIFunction.cpp
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/VM.h>
 #include "ZigGlobalObject.h"
+#include "ScriptExecutionContext.h"
 
 #include <JavaScriptCore/CallData.h>
 #include <JavaScriptCore/DOMJITAbstractHeap.h>
@@ -37,24 +38,29 @@
 #include "DOMJITIDLTypeFilter.h"
 #include "DOMJITHelpers.h"
 
-class FFICallbackFunctionWrapper {
+class FFICallbackFunctionWrapper : public ThreadSafeRefCounted<FFICallbackFunctionWrapper> {
 
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(FFICallbackFunctionWrapper);
 
 public:
     JSC::Strong<JSC::JSFunction> m_function;
     JSC::Strong<Zig::GlobalObject> globalObject;
+    // Cached at construction time (on the JS thread) so that
+    // FFI_Callback_threadsafe_call can schedule work from arbitrary OS threads
+    // without touching any JSC::Strong<> handles.
+    WebCore::ScriptExecutionContextIdentifier m_contextIdentifier;
     ~FFICallbackFunctionWrapper() = default;
 
     FFICallbackFunctionWrapper(JSC::JSFunction* function, Zig::GlobalObject* globalObject)
         : m_function(globalObject->vm(), function)
         , globalObject(globalObject->vm(), globalObject)
+        , m_contextIdentifier(globalObject->scriptExecutionContext()->identifier())
     {
     }
 };
 extern "C" void FFICallbackFunctionWrapper_destroy(FFICallbackFunctionWrapper* wrapper)
 {
-    delete wrapper;
+    wrapper->deref();
 }
 
 extern "C" FFICallbackFunctionWrapper* Bun__createFFICallbackFunction(
@@ -66,9 +72,9 @@ extern "C" FFICallbackFunctionWrapper* Bun__createFFICallbackFunction(
 
     auto* callbackFunction = uncheckedDowncast<JSC::JSFunction>(JSC::JSValue::decode(callbackFn));
 
-    auto* wrapper = new FFICallbackFunctionWrapper(callbackFunction, globalObject);
+    Ref<FFICallbackFunctionWrapper> wrapper = adoptRef(*new FFICallbackFunctionWrapper(callbackFunction, globalObject));
 
-    return wrapper;
+    return &wrapper.leakRef();
 }
 
 extern "C" Zig::JSFFIFunction* Bun__CreateFFIFunctionWithData(Zig::GlobalObject* globalObject, const ZigString* symbolName, unsigned argCount, Zig::FFIFunction functionPointer, void* data)
@@ -206,17 +212,23 @@ FFI_Callback_call(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::Enc
 extern "C" void
 FFI_Callback_threadsafe_call(FFICallbackFunctionWrapper& wrapper, size_t argCount, JSC::EncodedJSValue* args)
 {
-
-    auto* globalObject = wrapper.globalObject.get();
+    // This trampoline is invoked from arbitrary OS threads. It must not touch
+    // any JSC heap state (including JSC::Strong<> handles, whose copy
+    // constructor allocates from the VM's non-thread-safe HandleSet).
+    // We only read the pre-cached context identifier (a plain integer),
+    // capture the encoded argument values by copy, and take a thread-safe
+    // Ref<> to the heap-allocated wrapper so it survives a concurrent
+    // close() while tasks are still queued. The Strong<> handles inside the
+    // wrapper are dereferenced later on the JS thread inside the posted task.
     WTF::Vector<JSC::EncodedJSValue, 8> argsVec;
     for (size_t i = 0; i < argCount; ++i)
         argsVec.append(args[i]);
 
-    WebCore::ScriptExecutionContext::postTaskTo(globalObject->scriptExecutionContext()->identifier(), [argsVec = WTF::move(argsVec), wrapper](WebCore::ScriptExecutionContext& ctx) mutable {
+    WebCore::ScriptExecutionContext::postTaskTo(wrapper.m_contextIdentifier, [argsVec = WTF::move(argsVec), wrapperRef = Ref { wrapper }](WebCore::ScriptExecutionContext& ctx) mutable {
         auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(ctx.jsGlobalObject());
         auto& vm = JSC::getVM(globalObject);
         JSC::MarkedArgumentBuffer arguments;
-        auto* function = wrapper.m_function.get();
+        auto* function = wrapperRef->m_function.get();
         for (size_t i = 0; i < argsVec.size(); ++i)
             arguments.appendWithCrashOnOverflow(JSC::JSValue::decode(argsVec[i]));
         WTF::NakedPtr<JSC::Exception> exception;

--- a/test/js/bun/ffi/ffi-threadsafe-callback.test.ts
+++ b/test/js/bun/ffi/ffi-threadsafe-callback.test.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "bun:test";
+import path from "node:path";
+import { bunEnv, bunExe, isArm64, isMacOS, isWindows, tempDir } from "harness";
+
+// TinyCC (and all of bun:ffi) is disabled on Windows ARM64.
+// On Windows x64 there is no system `cc`, so skip there too — the bug being
+// covered (JSC::Strong<> copied on a non-JS thread) is platform-independent.
+const canRun = !isWindows && !(isWindows && isArm64);
+
+// JSCallback({ threadsafe: true }) routes through FFI_Callback_threadsafe_call
+// which may be invoked from any native thread. Previously it captured the
+// FFICallbackFunctionWrapper by value, invoking JSC::Strong<>'s copy
+// constructor (HandleSet::allocate) on that foreign thread and racing with
+// the main-thread GC/HandleSet. This test compiles a tiny shared library
+// that fires the callback from real pthreads while the JS thread churns
+// HandleSet allocations, then verifies the process completes cleanly with
+// the expected callback count.
+test.skipIf(!canRun)("threadsafe JSCallback invoked from a native thread", async () => {
+  const srcDir = import.meta.dir;
+  const libName = isMacOS ? "libthreadsafecb.dylib" : "libthreadsafecb.so";
+
+  using dir = tempDir("ffi-threadsafe-cb", {});
+  const outDir = String(dir);
+  const libPath = path.join(outDir, libName);
+
+  {
+    const cmd = ["cc", "-shared", "-fPIC", "-o", libPath];
+    if (!isMacOS) cmd.push("-pthread");
+    cmd.push(path.join(srcDir, "threadsafe-callback.c"));
+    await using cc = Bun.spawn({ cmd, stderr: "pipe", stdout: "pipe" });
+    const [stderr, exitCode] = await Promise.all([cc.stderr.text(), cc.exited]);
+    if (exitCode !== 0) {
+      throw new Error("failed to compile threadsafe-callback.c: " + stderr);
+    }
+  }
+
+  const fixture = /* js */ `
+    const { dlopen, JSCallback } = require("bun:ffi");
+
+    const lib = dlopen(${JSON.stringify(libPath)}, {
+      start_threads: { args: ["ptr", "int32_t", "int32_t"], returns: "void" },
+      join_threads: { args: [], returns: "void" },
+    });
+
+    const perThread = 5000;
+    const nthreads = 4;
+    const total = perThread * nthreads;
+    let received = 0;
+
+    const cb = new JSCallback(
+      (i) => {
+        received++;
+      },
+      { args: ["int32_t"], returns: "void", threadsafe: true },
+    );
+
+    lib.symbols.start_threads(cb.ptr, perThread, nthreads);
+
+    // While native threads are posting tasks, keep the JS thread busy
+    // allocating and freeing Strong<> handles so the HandleSet free list is
+    // under contention. Creating/closing JSCallbacks exercises the exact same
+    // HandleSet that the buggy trampoline was mutating off-thread.
+    const noop = () => {};
+    const noopOpts = { args: [], returns: "void" };
+    while (received < total) {
+      for (let i = 0; i < 64; i++) {
+        const tmp = new JSCallback(noop, noopOpts);
+        tmp.close();
+      }
+      // Drain any posted threadsafe callbacks.
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    lib.symbols.join_threads();
+
+    // Drain any callbacks that were posted after the loop above observed
+    // the count but before join returned.
+    while (received < total) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    if (received !== total) {
+      throw new Error("received " + received + " expected " + total);
+    }
+
+    // Force a full GC so a corrupted strong-handle list is walked.
+    Bun.gc(true);
+
+    cb.close();
+    lib.close();
+    console.log("OK " + received);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK 20000");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/ffi/ffi-threadsafe-callback.test.ts
+++ b/test/js/bun/ffi/ffi-threadsafe-callback.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import path from "node:path";
 import { bunEnv, bunExe, isArm64, isMacOS, isWindows, tempDir } from "harness";
+import path from "node:path";
 
 // TinyCC (and all of bun:ffi) is disabled on Windows ARM64.
 // On Windows x64 there is no system `cc`, so skip there too — the bug being

--- a/test/js/bun/ffi/threadsafe-callback.c
+++ b/test/js/bun/ffi/threadsafe-callback.c
@@ -1,0 +1,80 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef _WIN32
+#define FFI_EXPORT __declspec(dllexport)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
+#define FFI_EXPORT __attribute__((visibility("default")))
+#include <pthread.h>
+#include <sched.h>
+#endif
+
+typedef void (*callback_t)(int32_t);
+
+#define MAX_THREADS 8
+
+struct worker_args {
+  callback_t cb;
+  int32_t count;
+};
+
+static struct worker_args g_args;
+static int g_nthreads = 0;
+
+#ifdef _WIN32
+static HANDLE g_threads[MAX_THREADS];
+static DWORD WINAPI worker(LPVOID ptr)
+#else
+static pthread_t g_threads[MAX_THREADS];
+static void *worker(void *ptr)
+#endif
+{
+  struct worker_args *args = (struct worker_args *)ptr;
+  for (int32_t i = 0; i < args->count; i++) {
+    args->cb(i);
+#ifndef _WIN32
+    // Encourage interleaving with the JS thread so both threads contend on
+    // the same HandleSet.
+    if ((i & 15) == 0) sched_yield();
+#endif
+  }
+  return 0;
+}
+
+// Spawn `nthreads` native threads that each invoke `cb` `count` times.
+// Returns immediately so the JS thread can keep running (and allocating)
+// while native threads fire callbacks concurrently.
+FFI_EXPORT void start_threads(callback_t cb, int32_t count, int32_t nthreads) {
+  if (nthreads < 1) nthreads = 1;
+  if (nthreads > MAX_THREADS) nthreads = MAX_THREADS;
+  g_args.cb = cb;
+  g_args.count = count;
+  g_nthreads = 0;
+  for (int i = 0; i < nthreads; i++) {
+#ifdef _WIN32
+    HANDLE h = CreateThread(NULL, 0, worker, &g_args, 0, NULL);
+    if (h) g_threads[g_nthreads++] = h;
+#else
+    if (pthread_create(&g_threads[g_nthreads], NULL, worker, &g_args) == 0) {
+      g_nthreads++;
+    }
+#endif
+  }
+}
+
+// Block until all worker threads have finished. By the time this returns,
+// all callback invocations have at least been posted to the JS thread's
+// queue.
+FFI_EXPORT void join_threads(void) {
+  for (int i = 0; i < g_nthreads; i++) {
+#ifdef _WIN32
+    WaitForSingleObject(g_threads[i], INFINITE);
+    CloseHandle(g_threads[i]);
+#else
+    pthread_join(g_threads[i], NULL);
+#endif
+  }
+  g_nthreads = 0;
+}


### PR DESCRIPTION
## Problem

`FFI_Callback_threadsafe_call` is the trampoline for `new JSCallback(fn, { threadsafe: true })` and is invoked from arbitrary native threads — that's its entire purpose. It was capturing `FFICallbackFunctionWrapper` **by value** in the `postTaskTo` lambda:

```cpp
WebCore::ScriptExecutionContext::postTaskTo(..., [argsVec = WTF::move(argsVec), wrapper](...) { ... });
//                                                                               ^^^^^^^ copy
```

That copy invokes `JSC::Strong<>`'s copy constructor on the calling native thread, which calls `HandleSet::allocate()` and `writeBarrier()`. `HandleSet` is a non-locked singly-linked free list + sentinel list owned by the VM. Mutating it from a non-JS thread races with the JS thread (which churns the same lists on every `Strong<>` create/destroy and during GC marking), corrupting the handle lists.

It also called `wrapper.globalObject.get()` on the foreign thread to fish out the script execution context, reading a `HandleSlot` concurrently with GC.

## Repro

```
Strong.h:147:46: runtime error: member call on null pointer of type 'JSC::HandleSet'
SentinelLinkedList.h:212:11: runtime error: member call on null pointer of type 'WTF::BasicRawSentinelNode<JSC::HandleNode>'
```

— from `test/js/bun/ffi/ffi-threadsafe-callback.test.ts`, which spawns 4 pthreads each firing a threadsafe `JSCallback` 5000× while the JS thread creates/closes throwaway `JSCallback`s to contend on the same `HandleSet`. Under debug+ASAN the unfixed build fails 5/5 runs within ~1s.

## Fix

- Cache `ScriptExecutionContextIdentifier` (a plain `uint32_t`) in the wrapper at construction time (on the JS thread).
- Make `FFICallbackFunctionWrapper` `ThreadSafeRefCounted` and capture a `Ref<>` in the lambda instead of copying it. Creating a `Ref` is just an atomic increment; the `Strong<>` members are never copied.
- `FFICallbackFunctionWrapper_destroy` becomes `deref()`, so the wrapper survives a `close()` that races with already-queued tasks.

The posted task still runs on the JS thread and dereferences `wrapperRef->m_function` there, which is safe.

## Verification

| | `bun bd test test/js/bun/ffi/ffi-threadsafe-callback.test.ts` |
|---|---|
| before | 5/5 fail — UBSan null `HandleSet` / `SentinelLinkedList` |
| after | 5/5 pass (~1.7s), all 20000 callbacks delivered |

All existing `test/js/bun/ffi/*` tests pass.

Closes #28113
