### PR TITLE
Fix bun install hang with security scanner and many packages

### DIFF
--- a/src/install/PackageManager/scanner-entry-globals.d.ts
+++ b/src/install/PackageManager/scanner-entry-globals.d.ts
@@ -1,2 +1,1 @@
-declare const __PACKAGES_JSON__: Bun.Security.Package[];
 declare const __SUPPRESS_ERROR__: boolean;

--- a/src/install/PackageManager/scanner-entry.ts
+++ b/src/install/PackageManager/scanner-entry.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 
 const scannerModuleName = "__SCANNER_MODULE__";
-const packages = __PACKAGES_JSON__;
+const packages = JSON.parse(fs.readFileSync("__PACKAGES_FILE__", "utf8"));
 const suppressError = __SUPPRESS_ERROR__;
 
 type IPCMessage =

--- a/src/install/PackageManager/security_scanner.zig
+++ b/src/install/PackageManager/security_scanner.zig
@@ -682,16 +682,37 @@ fn attemptSecurityScanWithRetry(manager: *PackageManager, security_scanner: []co
         @as(u64, @bitCast(std.time.milliTimestamp())),
     }) catch return error.PathTooLong;
 
-    switch (bun.sys.File.writeFile(bun.FD.cwd(), tmp_path, json_data)) {
-        .result => {},
-        .err => return error.TempFileWriteFailed,
+    {
+        const tmp_fd = switch (bun.sys.open(tmp_path, bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o664)) {
+            .result => |fd| fd,
+            .err => return error.TempFileWriteFailed,
+        };
+        defer tmp_fd.close();
+        var remaining = json_data;
+        while (remaining.len > 0) {
+            switch (bun.sys.write(tmp_fd, remaining)) {
+                .result => |written| remaining = remaining[written..],
+                .err => return error.TempFileWriteFailed,
+            }
+        }
     }
+
+    // On Windows, normalize backslashes to forward slashes so the path can be
+    // safely embedded in a JS string literal without backslash escape issues.
+    // Node/Bun fs.readFileSync accepts forward slashes on all platforms.
+    const tmp_path_for_js: []const u8 = if (comptime bun.Environment.isWindows) blk: {
+        const buf = try manager.allocator.alloc(u8, tmp_path.len);
+        @memcpy(buf, tmp_path);
+        std.mem.replaceScalar(u8, buf, '\\', '/');
+        break :blk buf;
+    } else tmp_path;
+    defer if (comptime bun.Environment.isWindows) manager.allocator.free(tmp_path_for_js);
 
     const packages_placeholder = "__PACKAGES_FILE__";
     if (std.mem.indexOf(u8, temp_source, packages_placeholder)) |index| {
         var new_code = std.array_list.Managed(u8).init(manager.allocator);
         try new_code.appendSlice(temp_source[0..index]);
-        try new_code.appendSlice(tmp_path);
+        try new_code.appendSlice(tmp_path_for_js);
         try new_code.appendSlice(temp_source[index + packages_placeholder.len ..]);
         code.deinit();
         code = new_code;

--- a/src/install/PackageManager/security_scanner.zig
+++ b/src/install/PackageManager/security_scanner.zig
@@ -673,11 +673,25 @@ fn attemptSecurityScanWithRetry(manager: *PackageManager, security_scanner: []co
         temp_source = code.items;
     }
 
-    const packages_placeholder = "__PACKAGES_JSON__";
+    // Write package data to a temp file instead of embedding it inline in the
+    // -e argument. Large projects (>~790 packages) exceed the OS per-argument
+    // size limit (MAX_ARG_STRLEN = 128KB on Linux), causing posix_spawn to fail.
+    var tmp_path_buf: bun.PathBuffer = undefined;
+    const tmp_path = std.fmt.bufPrintZ(&tmp_path_buf, "{s}/bun_scan_{x}", .{
+        FileSystem.RealFS.tmpdirPath(),
+        @as(u64, @bitCast(std.time.milliTimestamp())),
+    }) catch return error.PathTooLong;
+
+    switch (bun.sys.File.writeFile(bun.FD.cwd(), tmp_path, json_data)) {
+        .result => {},
+        .err => return error.TempFileWriteFailed,
+    }
+
+    const packages_placeholder = "__PACKAGES_FILE__";
     if (std.mem.indexOf(u8, temp_source, packages_placeholder)) |index| {
         var new_code = std.array_list.Managed(u8).init(manager.allocator);
         try new_code.appendSlice(temp_source[0..index]);
-        try new_code.appendSlice(json_data);
+        try new_code.appendSlice(tmp_path);
         try new_code.appendSlice(temp_source[index + packages_placeholder.len ..]);
         code.deinit();
         code = new_code;
@@ -697,14 +711,13 @@ fn attemptSecurityScanWithRetry(manager: *PackageManager, security_scanner: []co
     var scanner = SecurityScanSubprocess.new(.{
         .manager = manager,
         .code = try manager.allocator.dupe(u8, code.items),
-        .json_data = try manager.allocator.dupe(u8, json_data),
         .ipc_data = undefined,
         .stderr_data = undefined,
     });
 
     defer {
         manager.allocator.free(scanner.code);
-        manager.allocator.free(scanner.json_data);
+        _ = bun.sys.unlink(tmp_path);
         bun.destroy(scanner);
     }
 
@@ -727,7 +740,6 @@ fn attemptSecurityScanWithRetry(manager: *PackageManager, security_scanner: []co
 pub const SecurityScanSubprocess = struct {
     manager: *PackageManager,
     code: []const u8,
-    json_data: []const u8,
     process: ?*bun.spawn.Process = null,
     ipc_reader: bun.io.BufferedReader = bun.io.BufferedReader.init(@This()),
     ipc_data: std.array_list.Managed(u8),

--- a/test/regression/issue/23607.test.ts
+++ b/test/regression/issue/23607.test.ts
@@ -1,7 +1,6 @@
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { test, expect, describe } from "bun:test";
 import path from "node:path";
-import fs from "node:fs";
 
 // Issue #23607: bun install hangs indefinitely with security scanner enabled
 // when node_modules exceeds ~790 packages. Root cause: package JSON was embedded

--- a/test/regression/issue/23607.test.ts
+++ b/test/regression/issue/23607.test.ts
@@ -1,0 +1,75 @@
+import { bunEnv, bunExe, tempDir } from "harness";
+import { test, expect, describe } from "bun:test";
+import path from "node:path";
+import fs from "node:fs";
+
+// Issue #23607: bun install hangs indefinitely with security scanner enabled
+// when node_modules exceeds ~790 packages. Root cause: package JSON was embedded
+// inline in the -e argument, exceeding OS MAX_ARG_STRLEN (128KB on Linux).
+// Fix: write packages JSON to a temp file and have scanner-entry read from it.
+
+describe("issue #23607", () => {
+  test("security scanner receives packages via temp file mechanism", async () => {
+    // The scanner module checks that packages were loaded from a temp file
+    // (via fs.readFileSync) rather than being embedded inline as JSON in the
+    // -e argument. On the old binary, __PACKAGES_JSON__ is replaced with raw
+    // JSON inline, so the readFileSync call would fail or not exist.
+    using dir = tempDir("issue-23607", {
+      "package.json": JSON.stringify({
+        name: "test-23607",
+        version: "1.0.0",
+        dependencies: {
+          "is-number": "7.0.0",
+        },
+      }),
+      "bunfig.toml": `[install.security]\nscanner = "./scanner.ts"`,
+      "scanner.ts": `
+        import fs from "node:fs";
+
+        export const scanner = {
+          version: "1",
+          scan: async ({ packages }) => {
+            if (!Array.isArray(packages)) {
+              throw new Error("packages is not an array: " + typeof packages);
+            }
+
+            // Look for evidence of the temp file mechanism: there should be
+            // a bun_scan_* file in the temp directory that was used to pass
+            // the packages JSON. On the old binary this file won't exist
+            // because packages were passed inline via __PACKAGES_JSON__.
+            const tmpDir = process.env.BUN_TMPDIR || require("os").tmpdir();
+            const tmpFiles = fs.readdirSync(tmpDir);
+            const scanFile = tmpFiles.find(f => f.startsWith("bun_scan_"));
+            if (!scanFile) {
+              throw new Error("TEMP_FILE_NOT_FOUND: no bun_scan_* file in " + tmpDir);
+            }
+
+            // Verify the temp file contains valid JSON matching our packages
+            const contents = fs.readFileSync(tmpDir + "/" + scanFile, "utf8");
+            const parsed = JSON.parse(contents);
+            if (!Array.isArray(parsed)) {
+              throw new Error("TEMP_FILE_INVALID: expected array, got " + typeof parsed);
+            }
+
+            console.error("SCANNER_TEMP_FILE_VERIFIED:" + scanFile);
+            return [];
+          },
+        };
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: path.join(String(dir), ".cache") },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The scanner should have found and verified the temp file
+    expect(stderr).toContain("SCANNER_TEMP_FILE_VERIFIED:");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes `bun install` hanging indefinitely when a security scanner is configured and the project has >~790 packages
- Packages JSON is now written to a temporary file instead of being embedded inline in the `-e` code argument
- The temp file is cleaned up after the scanner subprocess completes

## Root Cause
The security scanner subprocess received package metadata embedded directly in the TypeScript code string passed via `bun -e "..."`. For large projects (>~790 packages), the JSON payload exceeds the OS per-argument size limit (`MAX_ARG_STRLEN` = 128KB on Linux), causing `posix_spawn` to fail silently and the parent process to wait indefinitely.

## Fix
- **`security_scanner.zig`**: Write `json_data` to a temp file in the system temp directory before spawning the subprocess. Replace the `__PACKAGES_FILE__` placeholder in the code template with the temp file path (a short string). Clean up the temp file in the defer block after the scanner completes.
- **`scanner-entry.ts`**: Read package data from the temp file path using `fs.readFileSync` instead of using the inline `__PACKAGES_JSON__` placeholder.
- Removed the unused `json_data` field from `SecurityScanSubprocess` since data is no longer passed via the struct.

## Verification
- All 42 existing security scanner tests pass with the debug build (2 pre-existing timing flakes in ASAN debug builds unrelated to this change)
- Added regression test `test/regression/issue/23607.test.ts` that verifies the scanner correctly receives packages via the temp file mechanism
- Test proof: `USE_SYSTEM_BUN=1` fails (old code doesn't have temp file reading), `bun bd test` passes

Fixes #23607

---
**Verification:** CI green — all Linux, Windows, macOS, ASAN passed. Two darwin-14-aarch64 test failures verified as pre-existing flakes (both also fail on baked main binary): `dev-server.test.ts` (puppeteer timeout) and `snapshot.test.ts` (hangs). `upload-benchmark.mjs` infra flake. Test proof holds: baked binary fails on regression test, PR binary passes. Diff clean. Bot threads resolved. Suggested reviewer: @dylan-conway.