### PR TITLE
fix(bake): preserve CSS import order in dev server

### DIFF
--- a/src/bake/DevServer/IncrementalGraph.zig
+++ b/src/bake/DevServer/IncrementalGraph.zig
@@ -761,9 +761,10 @@ pub fn IncrementalGraph(comptime side: bake.Side) type {
             // removing edges.
             const quick_lookup_values_to_care_len = quick_lookup.count();
 
-            // A new import linked list is constructed. A side effect of this
-            // approach is that the order of the imports is reversed on every
-            // save. However, the ordering here doesn't matter.
+            // A new import linked list is constructed. Edges are prepended
+            // (stack-style) during processing, then reversed afterward to
+            // preserve the original source order. This matters for CSS,
+            // where import order determines the cascade.
             var new_imports: EdgeIndex.Optional = .none;
             defer g.first_import.items[file_index.get()] = new_imports;
 
@@ -789,6 +790,22 @@ pub fn IncrementalGraph(comptime side: bake.Side) type {
             switch (mode) {
                 .normal => try g.processChunkImportRecords(ctx, temp_alloc, &quick_lookup, &new_imports, file_index, bundle_graph_index),
                 .css => try g.processCSSChunkImportRecords(ctx, temp_alloc, &quick_lookup, &new_imports, file_index, bundle_graph_index),
+            }
+
+            // Reverse the linked list so that imports are in source order.
+            // The list was built by prepending (stack-style), so it ends up
+            // reversed relative to the order import records were processed.
+            {
+                var prev: EdgeIndex.Optional = .none;
+                var current = new_imports;
+                while (current.unwrap()) |edge_index| {
+                    const edge = &g.edges.items[edge_index.get()];
+                    const next = edge.next_import;
+                    edge.next_import = prev;
+                    prev = current;
+                    current = next;
+                }
+                new_imports = prev;
             }
 
             // We need to add this here to not trip up

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -502,6 +502,40 @@ devTest("css import before create project relative", {
   },
 });
 
+devTest("css import order is preserved (#28117)", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+      body: `<div class="test">hello</div>`,
+    }),
+    "index.ts": `
+      import './foo.css';
+      import './bar.css';
+      export default function () { return "hello"; }
+      import.meta.hot.accept();
+    `,
+    "foo.css": `
+      .test {
+        color: red;
+      }
+    `,
+    "bar.css": `
+      .test {
+        color: blue;
+      }
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    // bar.css is imported after foo.css, so blue should win the cascade
+    const color = await c.js`getComputedStyle(document.querySelector(".test")).color`;
+    expect(color).toBe("#00f");
+    await c.hardReload();
+    const color2 = await c.js`getComputedStyle(document.querySelector(".test")).color`;
+    expect(color2).toBe("#00f");
+  },
+});
+
 function extractCssUrl(backgroundImage: string): string {
   const url = backgroundImage.match(/url\((['"])(.*?)\1\)/);
   if (!url) {


### PR DESCRIPTION
## Summary
- Fix CSS import order being reversed in `Bun.serve` dev server, causing incorrect cascade behavior
- The incremental graph built import linked lists by prepending each edge (stack-style), which reversed the order relative to source code. When `traceImports` traversed these lists to collect CSS files, they appeared in reversed order, making earlier CSS imports override later ones
- Reverse the linked list after construction in `processChunkDependencies` so imports are traversed in source order, matching `Bun.build` behavior

Fixes #28117

## Test plan
- [x] Added test `css import order is preserved (#28117)` in `test/bake/dev/css.test.ts`
- [x] Test imports `foo.css` (color: red) then `bar.css` (color: blue) and verifies blue wins the cascade via `getComputedStyle`
- [x] Test verifies correct order persists after hard reload
- [x] Verified test fails with `USE_SYSTEM_BUN=1` (receives "red") and passes with debug build (receives "#00f")
- [x] All 13 existing CSS dev server tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)