### PR TITLE
Send security scanner package data via IPC pipe instead of -e arg

### DIFF
--- a/src/install/PackageManager/scanner-entry-globals.d.ts
+++ b/src/install/PackageManager/scanner-entry-globals.d.ts
@@ -1,2 +1,1 @@
-declare const __PACKAGES_JSON__: Bun.Security.Package[];
 declare const __SUPPRESS_ERROR__: boolean;

--- a/src/install/PackageManager/scanner-entry.ts
+++ b/src/install/PackageManager/scanner-entry.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 
 const scannerModuleName = "__SCANNER_MODULE__";
-const packages = __PACKAGES_JSON__;
 const suppressError = __SUPPRESS_ERROR__;
 
 type IPCMessage =
@@ -10,24 +9,56 @@ type IPCMessage =
   | { type: "error"; code: "INVALID_VERSION"; message: string }
   | { type: "error"; code: "SCAN_FAILED"; message: string };
 
-const IPC_PIPE_FD = 3;
+// Two pipes for IPC:
+// - fd 3: output - child writes response here
+// - fd 4: input - child reads JSON package list here (reads until EOF)
+const IPC_OUTPUT_FD = 3;
+const IPC_INPUT_FD = 4;
 
-function writeAndExit(message: IPCMessage): never {
+function sendAndExit(message: IPCMessage): never {
   const data = JSON.stringify(message);
-
   for (let remaining = data; remaining.length > 0; ) {
-    const written = fs.writeSync(IPC_PIPE_FD, remaining);
-
+    const written = fs.writeSync(IPC_OUTPUT_FD, remaining);
     if (written === 0) {
       console.error("Failed to write to IPC pipe");
       process.exit(1);
     }
     remaining = remaining.slice(written);
   }
-
-  fs.closeSync(IPC_PIPE_FD);
-
+  fs.closeSync(IPC_OUTPUT_FD);
   process.exit(message.type === "error" ? 1 : 0);
+}
+
+// Read packages JSON from fd 4 (reads until EOF when parent closes the pipe)
+let packages: Bun.Security.Package[];
+
+try {
+  const chunks: Buffer[] = [];
+  const buf = Buffer.alloc(65536);
+  while (true) {
+    try {
+      const bytesRead = fs.readSync(IPC_INPUT_FD, buf);
+      if (bytesRead === 0) break;
+      const chunk = Buffer.allocUnsafe(bytesRead);
+      buf.copy(chunk, 0, 0, bytesRead);
+      chunks.push(chunk);
+    } catch (e: any) {
+      if (e?.code === "EOF" || e?.code === "EAGAIN") break;
+      throw e;
+    }
+  }
+  fs.closeSync(IPC_INPUT_FD);
+  const packagesJson = Buffer.concat(chunks).toString("utf-8");
+  packages = JSON.parse(packagesJson);
+  if (!Array.isArray(packages)) {
+    throw new Error("Expected packages to be an array");
+  }
+} catch (error) {
+  sendAndExit({
+    type: "error",
+    code: "SCAN_FAILED",
+    message: `Failed to read packages from IPC pipe: ${error instanceof Error ? error.message : String(error)}`,
+  });
 }
 
 let scanner: Bun.Security.Scanner;
@@ -41,13 +72,13 @@ try {
       console.error(msg);
     }
 
-    writeAndExit({
+    sendAndExit({
       type: "error",
       code: "MODULE_NOT_FOUND",
       module: scannerModuleName,
     });
   } else {
-    writeAndExit({
+    sendAndExit({
       type: "error",
       code: "SCAN_FAILED",
       message: error instanceof Error ? error.message : String(error),
@@ -61,7 +92,7 @@ try {
   }
 
   if (scanner.version !== "1") {
-    writeAndExit({
+    sendAndExit({
       type: "error",
       code: "INVALID_VERSION",
       message: `Security scanner must be version 1, got version ${scanner.version}`,
@@ -78,13 +109,13 @@ try {
     throw new Error("Security scanner must return an array of advisories");
   }
 
-  writeAndExit({ type: "result", advisories: result });
+  sendAndExit({ type: "result", advisories: result });
 } catch (error) {
   if (!suppressError) {
     console.error(error);
   }
 
-  writeAndExit({
+  sendAndExit({
     type: "error",
     code: "SCAN_FAILED",
     message: error instanceof Error ? error.message : "Unknown error occurred",

--- a/src/install/PackageManager/security_scanner.zig
+++ b/src/install/PackageManager/security_scanner.zig
@@ -673,17 +673,6 @@ fn attemptSecurityScanWithRetry(manager: *PackageManager, security_scanner: []co
         temp_source = code.items;
     }
 
-    const packages_placeholder = "__PACKAGES_JSON__";
-    if (std.mem.indexOf(u8, temp_source, packages_placeholder)) |index| {
-        var new_code = std.array_list.Managed(u8).init(manager.allocator);
-        try new_code.appendSlice(temp_source[0..index]);
-        try new_code.appendSlice(json_data);
-        try new_code.appendSlice(temp_source[index + packages_placeholder.len ..]);
-        code.deinit();
-        code = new_code;
-        temp_source = code.items;
-    }
-
     const suppress_placeholder = "__SUPPRESS_ERROR__";
     if (std.mem.indexOf(u8, temp_source, suppress_placeholder)) |index| {
         var new_code = std.array_list.Managed(u8).init(manager.allocator);
@@ -744,14 +733,6 @@ pub const SecurityScanSubprocess = struct {
         this.stderr_data = std.array_list.Managed(u8).init(this.manager.allocator);
         this.ipc_reader.setParent(this);
 
-        const pipe_result = bun.sys.pipe();
-        const pipe_fds = switch (pipe_result) {
-            .err => {
-                return error.IPCPipeFailed;
-            },
-            .result => |fds| fds,
-        };
-
         const exec_path = try bun.selfExePath();
 
         var argv = [_]?[*:0]const u8{
@@ -768,34 +749,159 @@ pub const SecurityScanSubprocess = struct {
 
         const spawn_cwd = FileSystem.instance.top_level_dir;
 
+        if (comptime Environment.isWindows) {
+            try this.spawnWindows(&argv, spawn_cwd);
+        } else {
+            try this.spawnPosix(&argv, spawn_cwd);
+        }
+    }
+
+    fn spawnPosix(this: *SecurityScanSubprocess, argv: *[5]?[*:0]const u8, spawn_cwd: []const u8) !void {
+        // Create two pipes:
+        // - ipc_output_fds: child writes response (fd 3), parent reads
+        // - json_input_fds: parent writes JSON data, child reads (fd 4)
+        const ipc_output_fds = switch (bun.sys.pipe()) {
+            .err => return error.IPCPipeFailed,
+            .result => |fds| fds,
+        };
+
+        const json_input_fds = switch (bun.sys.pipe()) {
+            .err => {
+                ipc_output_fds[0].close();
+                ipc_output_fds[1].close();
+                return error.IPCPipeFailed;
+            },
+            .result => |fds| fds,
+        };
+
+        // Set CLOEXEC on fds the child should not inherit (beyond the dup2 targets).
+        // The dup2 actions in posix_spawn happen before exec, so they work fine even with CLOEXEC.
+        // Without this, the child inherits the write end of the JSON pipe, preventing EOF.
+        _ = bun.sys.setCloseOnExec(ipc_output_fds[0]); // parent's read end
+        _ = bun.sys.setCloseOnExec(json_input_fds[1]); // parent's write end
+
+        const extra_fds = [_]bun.spawn.SpawnOptions.Stdio{
+            .{ .pipe = ipc_output_fds[1] }, // fd 3: child writes here
+            .{ .pipe = json_input_fds[0] }, // fd 4: child reads JSON here
+        };
+
         const spawn_options = bun.spawn.SpawnOptions{
             .stdout = .inherit,
             .stderr = .inherit,
             .stdin = .inherit,
             .cwd = spawn_cwd,
-            .extra_fds = &.{.{ .pipe = pipe_fds[1] }},
-            .windows = if (Environment.isWindows) .{
+            .extra_fds = &extra_fds,
+        };
+
+        var spawned = try (try bun.spawn.spawnProcess(&spawn_options, @ptrCast(argv), @ptrCast(std.os.environ.ptr))).unwrap();
+
+        // Close the write end of the output pipe and read end of the input pipe in the parent
+        ipc_output_fds[1].close();
+        json_input_fds[0].close();
+
+        // Set up IPC reader for child's response (fd 3)
+        const ipc_read_fd = ipc_output_fds[0];
+        _ = bun.sys.setNonblocking(ipc_read_fd);
+
+        this.remaining_fds = 1;
+        this.ipc_reader.flags.nonblocking = true;
+        this.ipc_reader.flags.socket = false;
+        try this.ipc_reader.start(ipc_read_fd, true).unwrap();
+
+        // Set up process
+        var process = spawned.toProcess(&this.manager.event_loop, false);
+        this.process = process;
+        process.setExitHandler(this);
+
+        // Write JSON data to child via pipe (fd 4) and close when done
+        const json_write_fd = json_input_fds[1];
+        var remaining = this.json_data;
+        while (remaining.len > 0) {
+            switch (bun.sys.write(json_write_fd, remaining)) {
+                .result => |written| {
+                    if (written == 0) {
+                        Output.errGeneric("Failed to write JSON data to pipe: write returned 0", .{});
+                        return error.JSONPipeWriteFailed;
+                    }
+                    remaining = remaining[written..];
+                },
+                .err => |err| {
+                    Output.errGeneric("Failed to write JSON data to pipe: {f}", .{err});
+                    return error.JSONPipeWriteFailed;
+                },
+            }
+        }
+        json_write_fd.close();
+
+        switch (process.watchOrReap()) {
+            .err => {
+                return error.ProcessWatchFailed;
+            },
+            .result => {},
+        }
+    }
+
+    fn spawnWindows(this: *SecurityScanSubprocess, argv: *[5]?[*:0]const u8, spawn_cwd: []const u8) !void {
+        const uv = bun.windows.libuv;
+
+        // On Windows, we use two libuv pipes for IPC:
+        // - fd 3: child writes response → parent reads (buffer pipe)
+        // - fd 4: parent writes JSON → child reads (buffer pipe)
+        const output_pipe = try bun.default_allocator.create(uv.Pipe);
+        errdefer bun.default_allocator.destroy(output_pipe);
+
+        const input_pipe = try bun.default_allocator.create(uv.Pipe);
+        errdefer bun.default_allocator.destroy(input_pipe);
+
+        const extra_fds = [_]bun.spawn.SpawnOptions.Stdio{
+            .{ .buffer = output_pipe }, // fd 3: child writes here
+            .{ .buffer = input_pipe }, // fd 4: parent writes JSON here
+        };
+
+        const spawn_options = bun.spawn.SpawnOptions{
+            .stdout = .inherit,
+            .stderr = .inherit,
+            .stdin = .inherit,
+            .cwd = spawn_cwd,
+            .extra_fds = &extra_fds,
+            .windows = .{
                 .loop = jsc.EventLoopHandle.init(&this.manager.event_loop),
             },
         };
 
-        var spawned = try (try bun.spawn.spawnProcess(&spawn_options, @ptrCast(&argv), @ptrCast(std.os.environ.ptr))).unwrap();
+        var spawned = try (try bun.spawn.spawnProcess(&spawn_options, @ptrCast(argv), @ptrCast(std.os.environ.ptr))).unwrap();
 
-        pipe_fds[1].close();
+        const result_output_pipe = spawned.extra_pipes.items[0].buffer;
+        const result_input_pipe = spawned.extra_pipes.items[1].buffer;
 
-        if (comptime bun.Environment.isPosix) {
-            _ = bun.sys.setNonblocking(pipe_fds[0]);
-        }
+        // Set up IPC reader for child's response
         this.remaining_fds = 1;
-        this.ipc_reader.flags.nonblocking = true;
-        if (comptime bun.Environment.isPosix) {
-            this.ipc_reader.flags.socket = false;
-        }
-        try this.ipc_reader.start(pipe_fds[0], true).unwrap();
+        try this.ipc_reader.startWithPipe(result_output_pipe).unwrap();
 
+        // Set up process
         var process = spawned.toProcess(&this.manager.event_loop, false);
         this.process = process;
         process.setExitHandler(this);
+
+        // Write JSON data synchronously to child via the input pipe fd
+        const input_fd = result_input_pipe.fd();
+        var remaining = this.json_data;
+        while (remaining.len > 0) {
+            switch (bun.sys.write(input_fd, remaining)) {
+                .result => |written| {
+                    if (written == 0) {
+                        Output.errGeneric("Failed to write JSON data to pipe: write returned 0", .{});
+                        return error.JSONPipeWriteFailed;
+                    }
+                    remaining = remaining[written..];
+                },
+                .err => |err| {
+                    Output.errGeneric("Failed to write JSON data to pipe: {f}", .{err});
+                    return error.JSONPipeWriteFailed;
+                },
+            }
+        }
+        result_input_pipe.closeAndDestroy();
 
         switch (process.watchOrReap()) {
             .err => {

--- a/test/cli/install/bun-install-security-provider.test.ts
+++ b/test/cli/install/bun-install-security-provider.test.ts
@@ -1,4 +1,6 @@
-import { bunEnv, runBunInstall } from "harness";
+import { file } from "bun";
+import { join } from "path";
+import { bunEnv, bunExe, runBunInstall } from "harness";
 import {
   dummyAfterAll,
   dummyAfterEach,
@@ -30,13 +32,15 @@ function test(
     bunfigScanner?: string | false;
     packages?: string[];
     scannerFile?: string;
+    packageJson?: object;
+    customRegistry?: (urls: string[]) => any;
   },
 ) {
   it(
     name,
     async () => {
       const urls: string[] = [];
-      setHandler(dummyRegistry(urls));
+      setHandler(options.customRegistry ? options.customRegistry(urls) : dummyRegistry(urls));
 
       const scannerPath = options.scannerFile || "./scanner.ts";
       if (typeof options.scanner === "string") {
@@ -55,11 +59,14 @@ function test(
         await write("./bunfig.toml", `${bunfig}\n[install.security]\nscanner = "${scannerPath}"`);
       }
 
-      await write("package.json", {
-        name: "my-app",
-        version: "1.0.0",
-        dependencies: {},
-      });
+      await write(
+        "package.json",
+        options.packageJson ?? {
+          name: "my-app",
+          version: "1.0.0",
+          dependencies: {},
+        },
+      );
 
       const expectedExitCode = options.expectedExitCode ?? (options.fails ? 1 : 0);
       const packages = options.packages ?? ["bar"];
@@ -680,4 +687,84 @@ describe("Package Resolution", () => {
       expect(out).toContain("Latest tag:");
     },
   });
+});
+
+describe("Large payload via IPC pipe", () => {
+  // Regression test for https://github.com/oven-sh/bun/issues/23607
+  // When the number of packages is large enough, the JSON payload exceeds OS arg length limits.
+  // The fix sends package data via an IPC pipe (fd 4) instead of embedding it inline.
+
+  function manyPackagesRegistry(urls: string[]) {
+    const barTarball = join(import.meta.dir, "bar-0.0.2.tgz");
+    return async (request: Request) => {
+      urls.push(request.url);
+      const url = request.url.replaceAll("%2f", "/");
+
+      if (url.endsWith(".tgz")) {
+        return new Response(file(barTarball));
+      }
+
+      const name = url.slice(url.indexOf("/", root_url.length) + 1);
+      return new Response(
+        JSON.stringify({
+          name,
+          versions: {
+            "0.0.2": {
+              name,
+              version: "0.0.2",
+              dist: {
+                tarball: `${url}-0.0.2.tgz`,
+              },
+            },
+          },
+          "dist-tags": { latest: "0.0.2" },
+        }),
+      );
+    };
+  }
+
+  it(
+    "handles 1000+ packages without hitting arg length limits",
+    async () => {
+      const urls: string[] = [];
+      setHandler(manyPackagesRegistry(urls));
+
+      const scannerCode = `export const scanner = {
+  version: "1",
+  scan: async ({ packages }) => {
+    if (packages.length < 900) {
+      throw new Error("Expected at least 900 packages, got " + packages.length);
+    }
+    return [];
+  },
+};`;
+      await write("./scanner.ts", scannerCode);
+
+      const bunfig = await read("./bunfig.toml").text();
+      await write("./bunfig.toml", `${bunfig}\n[install.security]\nscanner = "./scanner.ts"`);
+
+      const dependencies: Record<string, string> = {};
+      for (let i = 0; i < 1000; i++) {
+        dependencies[`test-pkg-${i}`] = "0.0.2";
+      }
+      await write("package.json", {
+        name: "my-app",
+        version: "1.0.0",
+        dependencies,
+      });
+
+      const { stdout, stderr, exited } = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: package_dir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: bunEnv,
+      });
+
+      const exitCode = await exited;
+      expect(exitCode).toBe(0);
+    },
+    { timeout: 120_000 },
+  );
 });

--- a/test/cli/install/bun-install-security-provider.test.ts
+++ b/test/cli/install/bun-install-security-provider.test.ts
@@ -1,6 +1,6 @@
 import { file } from "bun";
-import { join } from "path";
 import { bunEnv, bunExe, runBunInstall } from "harness";
+import { join } from "path";
 import {
   dummyAfterAll,
   dummyAfterEach,


### PR DESCRIPTION
## Summary

Fixes #23607

`bun install` hangs with security scanners when projects have ~790+ packages because the package JSON data was embedded inline in the `-e` argument, hitting OS argument length limits (`E2BIG`).

- **Root cause**: Package JSON was injected as `__PACKAGES_JSON__` in the `-e` script argument passed to `posix_spawn`. With ~790+ packages, this exceeds the OS `ARG_MAX` limit, causing `E2BIG`.
- **Fix**: Send package JSON via an IPC pipe (fd 4, parent→child) instead of embedding it inline. The child reads from fd 4 until EOF, then parses the JSON. The existing fd 3 pipe (child→parent results) is unchanged.
- **Buffer bug fix**: Also fixes a data corruption bug in `scanner-entry.ts` where `Buffer.from(buf.buffer, 0, bytesRead)` created views sharing the same underlying ArrayBuffer, causing earlier chunks to be overwritten on subsequent reads.

## Changes

- `scanner-entry.ts`: Read packages from fd 4 IPC pipe instead of inline `__PACKAGES_JSON__` global; fix buffer aliasing in chunk collection
- `security_scanner.zig`: Create two pipes (fd 3 output, fd 4 input); write JSON data synchronously to fd 4 before entering event loop; set CLOEXEC on parent-only fds to ensure child sees EOF
- `scanner-entry-globals.d.ts`: Remove unused `__PACKAGES_JSON__` declaration
- `bun-install-security-provider.test.ts`: Add regression test with 1000 packages served via custom registry

## Test plan

- [x] All 43 security provider tests pass with `bun bd test`
- [x] New "handles 1000+ packages" test passes with `bun bd test` 
- [x] New test fails with `USE_SYSTEM_BUN=1` (system bun uses old inline approach)
- [x] Existing 42 tests still pass (no regressions)

https://claude.ai/code/session_01MSsHBP9Yx25jZ7vuNM4yzs

---
**Verification:** CI green on 9cc031f (all Linux/macOS/Windows/Alpine/ASAN test jobs pass; only failure is benchmark upload infra step). Test proof: baked binary (main) fails the new 1000-package test with exit code 1 (E2BIG), PR binary passes all 43 tests. Bot threads (CodeRabbit, claude[bot]) triaged and resolved — no blocking findings.