### PR TITLE
fix(workers): use-after-free when terminate() called from message handler

### DIFF
--- a/src/bun.js/bindings/webcore/Worker.cpp
+++ b/src/bun.js/bindings/webcore/Worker.cpp
@@ -69,8 +69,8 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Worker);
 
-extern "C" void WebWorker__notifyNeedTermination(
-    void* worker);
+extern "C" void WebWorker__notifyNeedTermination(void* worker);
+extern "C" void WebWorker__destroy(void* worker);
 
 static Lock allWorkersLock;
 static HashMap<ScriptExecutionContextIdentifier, Worker*>& allWorkers() WTF_REQUIRES_LOCK(allWorkersLock)
@@ -133,12 +133,14 @@ extern "C" void WebWorker__setRef(
 
 void Worker::setKeepAlive(bool keepAlive)
 {
-    WebWorker__setRef(impl_, keepAlive);
+    if (impl_)
+        WebWorker__setRef(impl_, keepAlive);
 }
 
 bool Worker::updatePtr()
 {
     if (!WebWorker__updatePtr(impl_, this)) {
+        impl_ = nullptr;
         m_onlineClosingFlags = ClosingFlag;
         m_terminationFlags.fetch_or(TerminatedFlag);
         return false;
@@ -263,7 +265,8 @@ void Worker::terminate()
 {
     // m_contextProxy.terminateWorkerGlobalScope();
     m_terminationFlags.fetch_or(TerminateRequestedFlag);
-    WebWorker__notifyNeedTermination(impl_);
+    if (impl_)
+        WebWorker__notifyNeedTermination(impl_);
 }
 
 // const char* Worker::activeDOMObjectName() const
@@ -444,6 +447,16 @@ void Worker::dispatchExit(int32_t exitCode)
             protectedThis->dispatchCloseEvent(event);
         }
         protectedThis->m_terminationFlags.fetch_or(TerminatedFlag);
+
+        // Destroy the Zig WebWorker struct now that all pending tasks
+        // that might call into it (via impl_) have been processed.
+        // This runs on the parent thread after all earlier-posted tasks
+        // (e.g. message events) have been handled, preventing UAF when
+        // a message handler calls worker.terminate().
+        if (protectedThis->impl_) {
+            WebWorker__destroy(protectedThis->impl_);
+            protectedThis->impl_ = nullptr;
+        }
     });
 }
 

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -610,6 +610,14 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
     }
     var arena = this.arena;
 
+    // Unref the parent poll ref here (this is thread-safe and idempotent).
+    // We don't call this.deinit() from the worker thread because the parent
+    // thread may still have pending tasks (e.g. message events) that call into
+    // the WebWorker struct via impl_. The C++ exit task (dispatchExit) will
+    // call WebWorker__destroy to free the struct after all prior tasks have
+    // been processed on the parent thread, preventing use-after-free.
+    this.parent_poll_ref.unrefConcurrently(this.parent);
+
     WebWorker__dispatchExit(globalObject, cpp_worker, exit_code);
     if (loop) |loop_| {
         loop_.internal_loop_data.jsc_vm = null;
@@ -625,8 +633,6 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
         bun.windows.libuv.Loop.shutdown();
     }
 
-    this.deinit();
-
     if (vm_to_deinit) |vm| {
         vm.deinit(); // NOTE: deinit here isn't implemented, so freeing workers will leak the vm.
     }
@@ -638,8 +644,22 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
     bun.exitThread();
 }
 
+/// Called from the parent thread (via the C++ exit task) to free the WebWorker
+/// struct and its owned memory. This runs after all pending event loop tasks
+/// that might reference the struct (via impl_) have been processed.
+pub fn destroy(this: *WebWorker) callconv(.c) void {
+    log("[{d}] destroy", .{this.execution_context_id});
+    bun.default_allocator.free(this.unresolved_specifier);
+    for (this.preloads) |preload| {
+        bun.default_allocator.free(preload);
+    }
+    bun.default_allocator.free(this.preloads);
+    bun.default_allocator.destroy(this);
+}
+
 comptime {
     @export(&create, .{ .name = "WebWorker__create" });
+    @export(&destroy, .{ .name = "WebWorker__destroy" });
     @export(&notifyNeedTermination, .{ .name = "WebWorker__notifyNeedTermination" });
     @export(&setRef, .{ .name = "WebWorker__setRef" });
     _ = WebWorker__updatePtr;

--- a/test/regression/issue/28121.test.ts
+++ b/test/regression/issue/28121.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // Regression test for https://github.com/oven-sh/bun/issues/28121

--- a/test/regression/issue/28121.test.ts
+++ b/test/regression/issue/28121.test.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/28121
+// ASan use-after-poison when terminate() is called from a message handler
+// after the worker has already exited and freed its Zig WebWorker struct.
+test("calling terminate() from onmessage after worker exits does not crash", async () => {
+  using dir = tempDir("issue-28121", {
+    "worker.js": `
+      self.postMessage("done");
+      // Worker exits after posting message (event loop drains)
+    `,
+    "main.js": `
+      const worker = new Worker(require("path").join(__dirname, "worker.js"));
+      worker.onmessage = (e) => {
+        // By the time this runs, the worker thread may have already exited
+        // and freed its WebWorker struct. terminate() must not access freed memory.
+        worker.terminate();
+        console.log("ok");
+        process.exit(0);
+      };
+      // Timeout to avoid hanging if the message is never received
+      setTimeout(() => {
+        console.log("ok");
+        process.exit(0);
+      }, 5000);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});
+
+// Also test calling terminate() multiple times after worker exits
+test("calling terminate() multiple times after worker exits does not crash", async () => {
+  using dir = tempDir("issue-28121-multi", {
+    "worker.js": `
+      self.postMessage("done");
+    `,
+    "main.js": `
+      const worker = new Worker(require("path").join(__dirname, "worker.js"));
+      worker.onmessage = (e) => {
+        worker.terminate();
+        worker.terminate();
+        worker.terminate();
+        console.log("ok");
+        process.exit(0);
+      };
+      setTimeout(() => {
+        console.log("ok");
+        process.exit(0);
+      }, 5000);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fix use-after-free in `WebWorker__notifyNeedTermination` when `worker.terminate()` is called from a `message` event handler after the worker thread has already exited
- Defer `WebWorker` struct destruction from the worker thread to the parent thread's exit task, ensuring the struct is alive while pending message tasks are processed
- Guard `terminate()` and `setKeepAlive()` against null `impl_` for defensive safety

## Root Cause

The Zig `WebWorker` struct was freed on the worker thread in `exitAndDeinit()` before the parent thread processed pending message event tasks posted via `postMessage`. When a JS `onmessage` handler called `worker.terminate()`, it called `WebWorker__notifyNeedTermination(impl_)` where `impl_` was a dangling pointer to freed memory, triggering ASan `use-after-poison` errors (shadow byte `f7` = mimalloc poison).

The sequence:
1. Worker thread: `postMessage("done")` → posts message task to parent event loop
2. Worker thread: event loop drains → `exitAndDeinit()` → posts exit task → **frees `WebWorker` struct**
3. Parent thread: processes message task (FIFO, before exit task) → JS calls `worker.terminate()` → **UAF on freed struct**

## Fix

Instead of freeing the `WebWorker` struct on the worker thread, defer destruction to the C++ `dispatchExit` task lambda that runs on the parent thread. Since the event loop is FIFO, this task runs after all earlier-posted tasks (including message events), so the struct is guaranteed to be alive during message handling.

Closes #28121

## Test plan

- [x] Added regression test `test/regression/issue/28121.test.ts` that calls `terminate()` from `onmessage` after worker exits
- [x] All existing worker tests pass with same results as baseline (19 pass, 4 pre-existing failures)
- [x] Debug build compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)