### PR TITLE
fix(install): skip env flags like -S when parsing shebangs on Windows

### DIFF
--- a/src/install/windows-shim/BinLinkingShim.zig
+++ b/src/install/windows-shim/BinLinkingShim.zig
@@ -195,11 +195,23 @@ pub const Shebang = struct {
         var tokenizer = std.mem.tokenizeScalar(u8, line, ' ');
         const first = tokenizer.next() orelse return parseFromBinPath(bin_path);
         if (eqlComptime(first, "/usr/bin/env") or eqlComptime(first, "/bin/env")) {
-            // Skip flags passed to env (e.g. -S, -u, -i, --split-string)
-            // to find the actual program name.
+            // Skip flags passed to env to find the actual program name.
+            // Note: -S/--split-string is NOT treated as consuming the next token
+            // because in shebang context the text after -S IS the command to run
+            // (e.g. "#!/usr/bin/env -S node" — "node" is the program, not an arg to -S).
             const program = program: while (true) {
                 const token = tokenizer.next() orelse return parseFromBinPath(bin_path);
-                if (token.len > 0 and token[0] == '-') continue;
+                if (token.len > 0 and token[0] == '-') {
+                    // These flags consume the next token as their value:
+                    //   -u/--unset NAME, -C/--chdir DIR, -a/--argv0 ARG
+                    if (eqlComptime(token, "-u") or eqlComptime(token, "--unset") or
+                        eqlComptime(token, "-C") or eqlComptime(token, "--chdir") or
+                        eqlComptime(token, "-a") or eqlComptime(token, "--argv0"))
+                    {
+                        _ = tokenizer.next(); // consume the flag's value
+                    }
+                    continue;
+                }
                 break :program token;
             };
             const rest_after_program = tokenizer.rest();

--- a/src/install/windows-shim/BinLinkingShim.zig
+++ b/src/install/windows-shim/BinLinkingShim.zig
@@ -195,10 +195,22 @@ pub const Shebang = struct {
         var tokenizer = std.mem.tokenizeScalar(u8, line, ' ');
         const first = tokenizer.next() orelse return parseFromBinPath(bin_path);
         if (eqlComptime(first, "/usr/bin/env") or eqlComptime(first, "/bin/env")) {
-            const rest = tokenizer.rest();
-            const program = tokenizer.next() orelse return parseFromBinPath(bin_path);
+            // Skip flags passed to env (e.g. -S, -u, -i, --split-string)
+            // to find the actual program name.
+            const program = program: while (true) {
+                const token = tokenizer.next() orelse return parseFromBinPath(bin_path);
+                if (token.len > 0 and token[0] == '-') continue;
+                break :program token;
+            };
+            const rest_after_program = tokenizer.rest();
             const is_node_or_bun = eqlComptime(program, "bun") or eqlComptime(program, "node");
-            return try Shebang.init(rest, is_node_or_bun);
+            // Reconstruct the launcher as "program rest_args..." so the shim
+            // invokes the right interpreter with any trailing arguments.
+            const launcher = if (rest_after_program.len > 0)
+                program.ptr[0 .. @intFromPtr(rest_after_program.ptr) - @intFromPtr(program.ptr) + rest_after_program.len]
+            else
+                program;
+            return try Shebang.init(launcher, is_node_or_bun);
         }
 
         return try Shebang.init(line, false);

--- a/test/regression/issue/28126.test.ts
+++ b/test/regression/issue/28126.test.ts
@@ -123,3 +123,42 @@ test("bin linking handles shebang with env -S bun", async () => {
   expect(stdout).toContain("hello from env -S bun");
   expect(exitCode).toBe(0);
 });
+
+test("bin linking handles shebang with env -u flag before program", async () => {
+  using dir = tempDir("issue-28126-u", {
+    "pkg/package.json": JSON.stringify({
+      name: "test-env-u-shebang",
+      version: "1.0.0",
+      bin: {
+        "test-env-u": "index.js",
+      },
+    }),
+    // -u takes a value (variable name to unset), which must be skipped
+    "pkg/index.js": '#!/usr/bin/env -S -u HOME node\nconsole.log("hello from env -u");\n',
+    "consumer/package.json": JSON.stringify({
+      name: "consumer",
+      version: "1.0.0",
+      dependencies: {
+        "test-env-u-shebang": "file:../pkg",
+      },
+    }),
+  });
+
+  const consumerDir = join(String(dir), "consumer");
+
+  await runBunInstall(env, consumerDir);
+
+  await using proc = spawn({
+    cmd: [bunExe(), "run", "test-env-u"],
+    cwd: consumerDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("interpreter executable");
+  expect(stdout).toContain("hello from env -u");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/28126.test.ts
+++ b/test/regression/issue/28126.test.ts
@@ -1,0 +1,125 @@
+import { spawn } from "bun";
+import { expect, test } from "bun:test";
+import { bunExe, bunEnv as env, runBunInstall, tempDir } from "harness";
+import { join } from "path";
+
+// Test that shebangs with env flags like -S are parsed correctly during bin linking.
+// On Windows, the shebang is parsed to create a .bunx metadata file. Previously,
+// the parser would treat "-S" as the program name instead of skipping it.
+// See also: #27924
+test("bin linking handles shebang with env -S flag", async () => {
+  using dir = tempDir("issue-28126", {
+    "pkg/package.json": JSON.stringify({
+      name: "test-env-s-shebang",
+      version: "1.0.0",
+      bin: {
+        "test-env-s": "index.js",
+      },
+    }),
+    "pkg/index.js": '#!/usr/bin/env -S node\nconsole.log("hello from env -S");\n',
+    "consumer/package.json": JSON.stringify({
+      name: "consumer",
+      version: "1.0.0",
+      dependencies: {
+        "test-env-s-shebang": "file:../pkg",
+      },
+    }),
+  });
+
+  const consumerDir = join(String(dir), "consumer");
+
+  await runBunInstall(env, consumerDir);
+
+  await using proc = spawn({
+    cmd: [bunExe(), "run", "test-env-s"],
+    cwd: consumerDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // On Windows, the previous bug would cause:
+  // error: interpreter executable "-S" not found in %PATH%
+  expect(stderr).not.toContain("interpreter executable");
+  expect(stderr).not.toContain("not found in %PATH%");
+  expect(stdout).toContain("hello from env -S");
+  expect(exitCode).toBe(0);
+});
+
+test("bin linking handles shebang with env -S and additional args", async () => {
+  using dir = tempDir("issue-28126-args", {
+    "pkg/package.json": JSON.stringify({
+      name: "test-env-s-args",
+      version: "1.0.0",
+      bin: {
+        "test-env-s-args": "index.js",
+      },
+    }),
+    "pkg/index.js": '#!/usr/bin/env -S node --no-warnings\nconsole.log("hello with args");\n',
+    "consumer/package.json": JSON.stringify({
+      name: "consumer",
+      version: "1.0.0",
+      dependencies: {
+        "test-env-s-args": "file:../pkg",
+      },
+    }),
+  });
+
+  const consumerDir = join(String(dir), "consumer");
+
+  await runBunInstall(env, consumerDir);
+
+  await using proc = spawn({
+    cmd: [bunExe(), "run", "test-env-s-args"],
+    cwd: consumerDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("interpreter executable");
+  expect(stdout).toContain("hello with args");
+  expect(exitCode).toBe(0);
+});
+
+test("bin linking handles shebang with env -S bun", async () => {
+  using dir = tempDir("issue-28126-bun", {
+    "pkg/package.json": JSON.stringify({
+      name: "test-env-s-bun",
+      version: "1.0.0",
+      bin: {
+        "test-env-s-bun": "index.js",
+      },
+    }),
+    "pkg/index.js": '#!/usr/bin/env -S bun\nconsole.log("hello from env -S bun");\n',
+    "consumer/package.json": JSON.stringify({
+      name: "consumer",
+      version: "1.0.0",
+      dependencies: {
+        "test-env-s-bun": "file:../pkg",
+      },
+    }),
+  });
+
+  const consumerDir = join(String(dir), "consumer");
+
+  await runBunInstall(env, consumerDir);
+
+  await using proc = spawn({
+    cmd: [bunExe(), "run", "test-env-s-bun"],
+    cwd: consumerDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("interpreter executable");
+  expect(stdout).toContain("hello from env -S bun");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/28126.test.ts
+++ b/test/regression/issue/28126.test.ts
@@ -1,164 +1,168 @@
 import { spawn } from "bun";
-import { expect, test } from "bun:test";
-import { bunExe, bunEnv as env, runBunInstall, tempDir } from "harness";
+import { expect, test, describe } from "bun:test";
+import { bunExe, bunEnv as env, isMusl, runBunInstall, tempDir } from "harness";
 import { join } from "path";
 
-// Test that shebangs with env flags like -S are parsed correctly during bin linking.
-// On Windows, the shebang is parsed to create a .bunx metadata file. Previously,
-// the parser would treat "-S" as the program name instead of skipping it.
-// See also: #27924
-test("bin linking handles shebang with env -S flag", async () => {
-  using dir = tempDir("issue-28126", {
-    "pkg/package.json": JSON.stringify({
-      name: "test-env-s-shebang",
-      version: "1.0.0",
-      bin: {
-        "test-env-s": "index.js",
-      },
-    }),
-    "pkg/index.js": '#!/usr/bin/env -S node\nconsole.log("hello from env -S");\n',
-    "consumer/package.json": JSON.stringify({
-      name: "consumer",
-      version: "1.0.0",
-      dependencies: {
-        "test-env-s-shebang": "file:../pkg",
-      },
-    }),
+// BusyBox env (used on Alpine/musl) does not support -S flag.
+// Skip these tests on musl since they rely on `env -S` working at runtime.
+describe.skipIf(isMusl)("env -S shebang parsing", () => {
+  // Test that shebangs with env flags like -S are parsed correctly during bin linking.
+  // On Windows, the shebang is parsed to create a .bunx metadata file. Previously,
+  // the parser would treat "-S" as the program name instead of skipping it.
+  // See also: #27924
+  test("bin linking handles shebang with env -S flag", async () => {
+    using dir = tempDir("issue-28126", {
+      "pkg/package.json": JSON.stringify({
+        name: "test-env-s-shebang",
+        version: "1.0.0",
+        bin: {
+          "test-env-s": "index.js",
+        },
+      }),
+      "pkg/index.js": '#!/usr/bin/env -S node\nconsole.log("hello from env -S");\n',
+      "consumer/package.json": JSON.stringify({
+        name: "consumer",
+        version: "1.0.0",
+        dependencies: {
+          "test-env-s-shebang": "file:../pkg",
+        },
+      }),
+    });
+
+    const consumerDir = join(String(dir), "consumer");
+
+    await runBunInstall(env, consumerDir);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "run", "test-env-s"],
+      cwd: consumerDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // On Windows, the previous bug would cause:
+    // error: interpreter executable "-S" not found in %PATH%
+    expect(stderr).not.toContain("interpreter executable");
+    expect(stderr).not.toContain("not found in %PATH%");
+    expect(stdout).toContain("hello from env -S");
+    expect(exitCode).toBe(0);
   });
 
-  const consumerDir = join(String(dir), "consumer");
+  test("bin linking handles shebang with env -S and additional args", async () => {
+    using dir = tempDir("issue-28126-args", {
+      "pkg/package.json": JSON.stringify({
+        name: "test-env-s-args",
+        version: "1.0.0",
+        bin: {
+          "test-env-s-args": "index.js",
+        },
+      }),
+      "pkg/index.js": '#!/usr/bin/env -S node --no-warnings\nconsole.log("hello with args");\n',
+      "consumer/package.json": JSON.stringify({
+        name: "consumer",
+        version: "1.0.0",
+        dependencies: {
+          "test-env-s-args": "file:../pkg",
+        },
+      }),
+    });
 
-  await runBunInstall(env, consumerDir);
+    const consumerDir = join(String(dir), "consumer");
 
-  await using proc = spawn({
-    cmd: [bunExe(), "run", "test-env-s"],
-    cwd: consumerDir,
-    stdout: "pipe",
-    stderr: "pipe",
-    env,
+    await runBunInstall(env, consumerDir);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "run", "test-env-s-args"],
+      cwd: consumerDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("interpreter executable");
+    expect(stdout).toContain("hello with args");
+    expect(exitCode).toBe(0);
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  test("bin linking handles shebang with env -S bun", async () => {
+    using dir = tempDir("issue-28126-bun", {
+      "pkg/package.json": JSON.stringify({
+        name: "test-env-s-bun",
+        version: "1.0.0",
+        bin: {
+          "test-env-s-bun": "index.js",
+        },
+      }),
+      "pkg/index.js": '#!/usr/bin/env -S bun\nconsole.log("hello from env -S bun");\n',
+      "consumer/package.json": JSON.stringify({
+        name: "consumer",
+        version: "1.0.0",
+        dependencies: {
+          "test-env-s-bun": "file:../pkg",
+        },
+      }),
+    });
 
-  // On Windows, the previous bug would cause:
-  // error: interpreter executable "-S" not found in %PATH%
-  expect(stderr).not.toContain("interpreter executable");
-  expect(stderr).not.toContain("not found in %PATH%");
-  expect(stdout).toContain("hello from env -S");
-  expect(exitCode).toBe(0);
-});
+    const consumerDir = join(String(dir), "consumer");
 
-test("bin linking handles shebang with env -S and additional args", async () => {
-  using dir = tempDir("issue-28126-args", {
-    "pkg/package.json": JSON.stringify({
-      name: "test-env-s-args",
-      version: "1.0.0",
-      bin: {
-        "test-env-s-args": "index.js",
-      },
-    }),
-    "pkg/index.js": '#!/usr/bin/env -S node --no-warnings\nconsole.log("hello with args");\n',
-    "consumer/package.json": JSON.stringify({
-      name: "consumer",
-      version: "1.0.0",
-      dependencies: {
-        "test-env-s-args": "file:../pkg",
-      },
-    }),
+    await runBunInstall(env, consumerDir);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "run", "test-env-s-bun"],
+      cwd: consumerDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("interpreter executable");
+    expect(stdout).toContain("hello from env -S bun");
+    expect(exitCode).toBe(0);
   });
 
-  const consumerDir = join(String(dir), "consumer");
+  test("bin linking handles shebang with env -u flag before program", async () => {
+    using dir = tempDir("issue-28126-u", {
+      "pkg/package.json": JSON.stringify({
+        name: "test-env-u-shebang",
+        version: "1.0.0",
+        bin: {
+          "test-env-u": "index.js",
+        },
+      }),
+      // -u takes a value (variable name to unset), which must be skipped
+      "pkg/index.js": '#!/usr/bin/env -S -u HOME node\nconsole.log("hello from env -u");\n',
+      "consumer/package.json": JSON.stringify({
+        name: "consumer",
+        version: "1.0.0",
+        dependencies: {
+          "test-env-u-shebang": "file:../pkg",
+        },
+      }),
+    });
 
-  await runBunInstall(env, consumerDir);
+    const consumerDir = join(String(dir), "consumer");
 
-  await using proc = spawn({
-    cmd: [bunExe(), "run", "test-env-s-args"],
-    cwd: consumerDir,
-    stdout: "pipe",
-    stderr: "pipe",
-    env,
+    await runBunInstall(env, consumerDir);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "run", "test-env-u"],
+      cwd: consumerDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("interpreter executable");
+    expect(stdout).toContain("hello from env -u");
+    expect(exitCode).toBe(0);
   });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stderr).not.toContain("interpreter executable");
-  expect(stdout).toContain("hello with args");
-  expect(exitCode).toBe(0);
-});
-
-test("bin linking handles shebang with env -S bun", async () => {
-  using dir = tempDir("issue-28126-bun", {
-    "pkg/package.json": JSON.stringify({
-      name: "test-env-s-bun",
-      version: "1.0.0",
-      bin: {
-        "test-env-s-bun": "index.js",
-      },
-    }),
-    "pkg/index.js": '#!/usr/bin/env -S bun\nconsole.log("hello from env -S bun");\n',
-    "consumer/package.json": JSON.stringify({
-      name: "consumer",
-      version: "1.0.0",
-      dependencies: {
-        "test-env-s-bun": "file:../pkg",
-      },
-    }),
-  });
-
-  const consumerDir = join(String(dir), "consumer");
-
-  await runBunInstall(env, consumerDir);
-
-  await using proc = spawn({
-    cmd: [bunExe(), "run", "test-env-s-bun"],
-    cwd: consumerDir,
-    stdout: "pipe",
-    stderr: "pipe",
-    env,
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stderr).not.toContain("interpreter executable");
-  expect(stdout).toContain("hello from env -S bun");
-  expect(exitCode).toBe(0);
-});
-
-test("bin linking handles shebang with env -u flag before program", async () => {
-  using dir = tempDir("issue-28126-u", {
-    "pkg/package.json": JSON.stringify({
-      name: "test-env-u-shebang",
-      version: "1.0.0",
-      bin: {
-        "test-env-u": "index.js",
-      },
-    }),
-    // -u takes a value (variable name to unset), which must be skipped
-    "pkg/index.js": '#!/usr/bin/env -S -u HOME node\nconsole.log("hello from env -u");\n',
-    "consumer/package.json": JSON.stringify({
-      name: "consumer",
-      version: "1.0.0",
-      dependencies: {
-        "test-env-u-shebang": "file:../pkg",
-      },
-    }),
-  });
-
-  const consumerDir = join(String(dir), "consumer");
-
-  await runBunInstall(env, consumerDir);
-
-  await using proc = spawn({
-    cmd: [bunExe(), "run", "test-env-u"],
-    cwd: consumerDir,
-    stdout: "pipe",
-    stderr: "pipe",
-    env,
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stderr).not.toContain("interpreter executable");
-  expect(stdout).toContain("hello from env -u");
-  expect(exitCode).toBe(0);
-});
+}); // describe

--- a/test/regression/issue/28126.test.ts
+++ b/test/regression/issue/28126.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "bun";
-import { expect, test, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunExe, bunEnv as env, isMusl, runBunInstall, tempDir } from "harness";
 import { join } from "path";
 


### PR DESCRIPTION
## Summary
- Fix Windows shebang parser to skip `env` flags (e.g. `-S`, `-u`, `-i`, `--split-string`) when resolving the interpreter program name
- Previously, `#!/usr/bin/env -S node` would cause the shim to look for `-S` as an executable, failing with "interpreter executable '-S' not found in %PATH%"
- Affects any npm package using `#!/usr/bin/env -S <interpreter>` shebangs when installed on Windows (e.g. `@google/gemini-cli`)

## Test plan
- [x] Added regression test `test/regression/issue/28126.test.ts` with 3 test cases:
  - `env -S node` shebang
  - `env -S node --no-warnings` (with additional args)
  - `env -S bun` shebang
- [x] All tests pass with `bun bd test test/regression/issue/28126.test.ts`

Closes #28126

🤖 Generated with [Claude Code](https://claude.com/claude-code)