### PR TITLE
Shrink path ignore pattern stack buffer (follow-up to #28089)

### DIFF
--- a/src/cli/test/Scanner.zig
+++ b/src/cli/test/Scanner.zig
@@ -164,19 +164,27 @@ pub fn doesPathMatchFilter(this: *Scanner, name: []const u8) bool {
 pub fn matchesPathIgnorePattern(this: *Scanner, abs_path: []const u8) bool {
     if (this.path_ignore_patterns.len == 0) return false;
     const rel_path = bun.path.relative(this.fs.top_level_dir, abs_path);
+
+    // Build rel_path + '/' once. rel_path is a relative path from the project
+    // root; 4096 bytes covers any sane test directory depth (POSIX PATH_MAX).
+    var buf: [4096]u8 = undefined;
+    const rel_with_slash: ?[]const u8 = if (rel_path.len > 0 and
+        rel_path.len + 1 <= buf.len and
+        rel_path[rel_path.len - 1] != '/')
+    blk: {
+        @memcpy(buf[0..rel_path.len], rel_path);
+        buf[rel_path.len] = '/';
+        break :blk buf[0 .. rel_path.len + 1];
+    } else null;
+
     for (this.path_ignore_patterns) |pattern| {
         if (bun.glob.match(pattern, rel_path).matches()) return true;
         // Only try trailing separator for ** patterns (e.g. "vendor/**").
         // Single-star patterns like "vendor/*" must not prune entire
         // directories because * doesn't cross directory boundaries.
-        if (strings.indexOf(pattern, "**") != null) {
-            if (rel_path.len > 0 and rel_path[rel_path.len - 1] != '/') {
-                var buf: [bun.MAX_PATH_BYTES]u8 = undefined;
-                if (rel_path.len < buf.len) {
-                    @memcpy(buf[0..rel_path.len], rel_path);
-                    buf[rel_path.len] = '/';
-                    if (bun.glob.match(pattern, buf[0 .. rel_path.len + 1]).matches()) return true;
-                }
+        if (rel_with_slash) |p| {
+            if (strings.indexOf(pattern, "**") != null) {
+                if (bun.glob.match(pattern, p).matches()) return true;
             }
         }
     }


### PR DESCRIPTION
Follow-up to #28089.

`matchesPathIgnorePattern` in `src/cli/test/Scanner.zig` allocates `var buf: [bun.MAX_PATH_BYTES]u8` on the stack. On Windows that's `32767 * 3 + 1` ≈ 96KB to hold a relative path from the project root plus a trailing slash — realistically under 200 bytes.

Changes:
- Shrink the buffer to `[4096]u8` (POSIX PATH_MAX — covers any realistic test directory depth)
- Hoist the `rel_path + '/'` construction outside the `for (patterns)` loop since `rel_path` is loop-invariant (was re-memcpy'ing the same path once per pattern)

Behavior is unchanged. If a relative path somehow exceeds 4095 bytes, the trailing-slash fallback is skipped (same silent-degrade as before, just at a lower threshold) — early directory pruning is lost for that one path but files inside still get filtered by the direct glob match.