### PR TITLE
fix(install): resolve absolute paths for Windows CopyFileW in FileCopier

### DIFF
--- a/src/install/isolated_install/FileCopier.zig
+++ b/src/install/isolated_install/FileCopier.zig
@@ -69,13 +69,20 @@ pub const FileCopier = struct {
         };
         defer dest_dir.close();
 
-        var copy_file_state: bun.CopyFileState = .{};
+        if (comptime Environment.isWindows) {
+            // On Windows, CopyFileW and CreateDirectoryExW require absolute paths.
+            // The dest_subpath is relative to CWD, so we must resolve it to an
+            // absolute path with the NT prefix to handle long paths correctly.
+            const cwd_buf = bun.w_path_buffer_pool.get();
+            defer bun.w_path_buffer_pool.put(cwd_buf);
+            const dest_cwd = FD.cwd().getFdPathW(cwd_buf) catch {
+                return .{ .err = bun.sys.Error.fromCode(.ACCES, .copyfile) };
+            };
 
-        while (switch (this.walker.next()) {
-            .result => |res| res,
-            .err => |err| return .initErr(err),
-        }) |entry| {
-            if (comptime Environment.isWindows) {
+            while (switch (this.walker.next()) {
+                .result => |res| res,
+                .err => |err| return .initErr(err),
+            }) |entry| {
                 switch (entry.kind) {
                     .directory, .file => {},
                     else => continue,
@@ -91,17 +98,30 @@ pub const FileCopier = struct {
 
                 this.dest_subpath.append(entry.path);
 
+                const dest_abs_buf = bun.w_path_buffer_pool.get();
+                defer bun.w_path_buffer_pool.put(dest_abs_buf);
+                const dest_abs_buf2 = bun.w_path_buffer_pool.get();
+                defer bun.w_path_buffer_pool.put(dest_abs_buf2);
+                const dest_abs = bun.strings.addNTPathPrefixIfNeeded(
+                    dest_abs_buf2,
+                    bun.path.joinStringBufWZ(
+                        dest_abs_buf,
+                        &[_][]const u16{ dest_cwd, this.dest_subpath.slice() },
+                        .windows,
+                    ),
+                );
+
                 switch (entry.kind) {
                     .directory => {
-                        if (bun.windows.CreateDirectoryExW(this.src_path.sliceZ(), this.dest_subpath.sliceZ(), null) == 0) {
+                        if (bun.windows.CreateDirectoryExW(this.src_path.sliceZ(), dest_abs, null) == 0) {
                             bun.MakePath.makePath(u16, dest_dir, entry.path) catch {};
                         }
                     },
                     .file => {
-                        bun.copyFile(this.src_path.sliceZ(), this.dest_subpath.sliceZ()).unwrap() catch {
+                        bun.copyFile(this.src_path.sliceZ(), dest_abs).unwrap() catch {
                             if (bun.Dirname.dirname(u16, entry.path)) |entry_dirname| {
                                 bun.MakePath.makePath(u16, dest_dir, entry_dirname) catch {};
-                                switch (bun.copyFile(this.src_path.sliceZ(), this.dest_subpath.sliceZ())) {
+                                switch (bun.copyFile(this.src_path.sliceZ(), dest_abs)) {
                                     .result => {},
                                     .err => |err| {
                                         return .initErr(err);
@@ -112,7 +132,14 @@ pub const FileCopier = struct {
                     },
                     else => unreachable,
                 }
-            } else {
+            }
+        } else {
+            var copy_file_state: bun.CopyFileState = .{};
+
+            while (switch (this.walker.next()) {
+                .result => |res| res,
+                .err => |err| return .initErr(err),
+            }) |entry| {
                 if (entry.kind != .file) {
                     continue;
                 }

--- a/src/install/isolated_install/FileCopier.zig
+++ b/src/install/isolated_install/FileCopier.zig
@@ -79,6 +79,11 @@ pub const FileCopier = struct {
                 return .{ .err = bun.sys.Error.fromCode(.ACCES, .copyfile) };
             };
 
+            const dest_abs_buf = bun.w_path_buffer_pool.get();
+            defer bun.w_path_buffer_pool.put(dest_abs_buf);
+            const dest_abs_buf2 = bun.w_path_buffer_pool.get();
+            defer bun.w_path_buffer_pool.put(dest_abs_buf2);
+
             while (switch (this.walker.next()) {
                 .result => |res| res,
                 .err => |err| return .initErr(err),
@@ -98,10 +103,6 @@ pub const FileCopier = struct {
 
                 this.dest_subpath.append(entry.path);
 
-                const dest_abs_buf = bun.w_path_buffer_pool.get();
-                defer bun.w_path_buffer_pool.put(dest_abs_buf);
-                const dest_abs_buf2 = bun.w_path_buffer_pool.get();
-                defer bun.w_path_buffer_pool.put(dest_abs_buf2);
                 const dest_abs = bun.strings.addNTPathPrefixIfNeeded(
                     dest_abs_buf2,
                     bun.path.joinStringBufWZ(

--- a/test/regression/issue/28133.test.ts
+++ b/test/regression/issue/28133.test.ts
@@ -1,4 +1,4 @@
-import { spawn, write } from "bun";
+import { spawn } from "bun";
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";

--- a/test/regression/issue/28133.test.ts
+++ b/test/regression/issue/28133.test.ts
@@ -1,0 +1,81 @@
+import { spawn, write } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// Regression test for https://github.com/oven-sh/bun/issues/28133
+// On Windows, FileCopier passed relative paths to CopyFileW which requires
+// absolute paths. This caused ENOENT errors during `bun install` with
+// copyfile backend, especially for packages with long scoped names.
+test("isolated install with copyfile backend handles scoped packages", async () => {
+  using dir = tempDir("issue-28133", {
+    "package.json": JSON.stringify({
+      name: "test-issue-28133",
+      dependencies: {
+        // Use a scoped file dependency with a long name similar to
+        // @emotion/use-insertion-effect-with-fallbacks to exercise
+        // the copyfile path with long paths.
+        "@scoped/long-package-name-for-testing": "file:./scoped-pkg",
+        "file-dep": "file:./file-dep",
+      },
+    }),
+    "bunfig.toml": `[install]\nlinker = "isolated"\n`,
+    "scoped-pkg/package.json": JSON.stringify({
+      name: "@scoped/long-package-name-for-testing",
+      version: "1.0.0",
+    }),
+    "scoped-pkg/lib/index.js": "module.exports = 'scoped';",
+    "file-dep/package.json": JSON.stringify({
+      name: "file-dep",
+      version: "1.0.0",
+    }),
+    "file-dep/src/nested/deep/index.js": "module.exports = 'deep';",
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install", "--backend", "copyfile"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("error:");
+  expect(stderr).not.toContain("ENOENT");
+
+  // Verify scoped package was copied correctly
+  const scopedPkgJson = await Bun.file(
+    join(
+      String(dir),
+      "node_modules",
+      ".bun",
+      "@scoped+long-package-name-for-testing@file+scoped-pkg",
+      "node_modules",
+      "@scoped",
+      "long-package-name-for-testing",
+      "package.json",
+    ),
+  ).json();
+  expect(scopedPkgJson.name).toBe("@scoped/long-package-name-for-testing");
+
+  // Verify nested files were copied
+  const deepFile = await Bun.file(
+    join(
+      String(dir),
+      "node_modules",
+      ".bun",
+      "file-dep@file+file-dep",
+      "node_modules",
+      "file-dep",
+      "src",
+      "nested",
+      "deep",
+      "index.js",
+    ),
+  ).text();
+  expect(deepFile).toBe("module.exports = 'deep';");
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fix Windows-only ENOENT error during `bun install` when using the copyfile backend (isolated installs)
- `FileCopier` was passing relative `dest_subpath` to `CopyFileW` and `CreateDirectoryExW`, which require absolute paths to handle long paths correctly
- Resolve CWD to an absolute path once before the copy loop, then join with `dest_subpath` for each entry and add the NT path prefix — matching the pattern already used by `Hardlinker.zig`

## Root Cause

On Windows, `CopyFileW` resolves relative paths against the process CWD but fails with ENOENT when the resulting path exceeds `MAX_PATH` (260 chars) without the `\\?\` NT prefix. Packages with long scoped names like `@emotion/use-insertion-effect-with-fallbacks` easily exceed this limit when combined with the `node_modules/.bun/install/packages/` prefix.

The POSIX code path was unaffected because it uses fd-relative operations (`openat`, `createFileZ`, fd-based copy).

## Test plan

- [x] Added regression test (`test/regression/issue/28133.test.ts`) that tests copyfile backend with isolated install for scoped packages
- [x] Debug build compiles successfully
- [x] Test passes with debug build
- [ ] Windows CI validates the fix on the affected platform

Closes #28133

🤖 Generated with [Claude Code](https://claude.com/claude-code)