### PR TITLE
fix Windows isolated installs for patched peer variants

### DIFF
--- a/src/install/PackageInstaller.zig
+++ b/src/install/PackageInstaller.zig
@@ -1015,6 +1015,7 @@ pub const PackageInstaller = struct {
                             alias.slice(this.lockfile.buffers.string_bytes.items),
                             resolution,
                             context,
+                            patch_name_and_version_hash,
                         );
                     },
                     .remote_tarball => {

--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -1202,6 +1202,9 @@ pub fn enqueueExtractNPMPackage(
     tarball: *const ExtractTarball,
     network_task: *NetworkTask,
 ) *ThreadPool.Task {
+    const apply_patch_task = network_task.apply_patch_task;
+    network_task.apply_patch_task = null;
+
     var task = this.preallocated_resolve_tasks.get();
     task.* = Task{
         .package_manager = this,
@@ -1215,6 +1218,7 @@ pub fn enqueueExtractNPMPackage(
         },
         .id = network_task.task_id,
         .data = undefined,
+        .apply_patch_task = apply_patch_task,
     };
     task.request.extract.tarball.skip_verify = !this.options.do.verify_integrity;
     return &task.threadpool_task;

--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -130,6 +130,7 @@ pub fn enqueueTarballForReading(
     alias: string,
     resolution: *const Resolution,
     task_context: TaskCallbackContext,
+    patch_name_and_version_hash: ?u64,
 ) void {
     const path = this.lockfile.str(&resolution.value.local_tarball);
     const task_id = Task.Id.forTarball(path);
@@ -151,10 +152,12 @@ pub fn enqueueTarballForReading(
         this,
         task_id,
         dependency_id,
+        package_id,
         alias,
         path,
         resolution.*,
         integrity,
+        patch_name_and_version_hash,
     )));
 }
 
@@ -1168,10 +1171,12 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
                         this,
                         task_id,
                         id,
+                        package_id,
                         this.lockfile.str(&dependency.name),
                         url,
                         res,
                         .{},
+                        patch_name_and_version_hash,
                     )));
                 },
                 .remote => {
@@ -1334,10 +1339,12 @@ fn enqueueLocalTarball(
     this: *PackageManager,
     task_id: Task.Id,
     dependency_id: DependencyID,
+    package_id: PackageID,
     name: string,
     path: string,
     resolution: Resolution,
     integrity: Integrity,
+    patch_name_and_version_hash: ?u64,
 ) *ThreadPool.Task {
     var task = this.preallocated_resolve_tasks.get();
     task.* = Task{
@@ -1366,6 +1373,12 @@ fn enqueueLocalTarball(
                 },
             },
         },
+        .apply_patch_task = if (patch_name_and_version_hash) |h| brk: {
+            const patch_hash = this.lockfile.patched_dependencies.get(h).?.patchfileHash().?;
+            const pt = PatchTask.newApplyPatchHash(this, package_id, patch_hash, h);
+            pt.callback.apply.task_id = task_id;
+            break :brk pt;
+        } else null,
         .id = task_id,
         .data = undefined,
     };

--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -1171,12 +1171,12 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
                         this,
                         task_id,
                         id,
-                        package_id,
+                        invalid_package_id,
                         this.lockfile.str(&dependency.name),
                         url,
                         res,
                         .{},
-                        patch_name_and_version_hash,
+                        null,
                     )));
                 },
                 .remote => {
@@ -1265,10 +1265,7 @@ fn enqueueGitClone(
         .id = task_id,
         .apply_patch_task = if (patch_name_and_version_hash) |h| brk: {
             const dep = dependency;
-            const pkg_id = switch (this.lockfile.package_index.get(dep.name_hash) orelse @panic("Package not found")) {
-                .id => |p| p,
-                .ids => |ps| ps.items[0], // TODO is this correct
-            };
+            const pkg_id = this.lockfile.getPackageID(dep.name_hash, null, res) orelse @panic("Package not found");
             const patch_hash = this.lockfile.patched_dependencies.get(h).?.patchfileHash().?;
             const pt = PatchTask.newApplyPatchHash(this, pkg_id, patch_hash, h);
             pt.callback.apply.task_id = task_id;
@@ -1320,10 +1317,7 @@ pub fn enqueueGitCheckout(
         },
         .apply_patch_task = if (patch_name_and_version_hash) |h| brk: {
             const dep = this.lockfile.buffers.dependencies.items[dependency_id];
-            const pkg_id = switch (this.lockfile.package_index.get(dep.name_hash) orelse @panic("Package not found")) {
-                .id => |p| p,
-                .ids => |ps| ps.items[0], // TODO is this correct
-            };
+            const pkg_id = this.lockfile.getPackageID(dep.name_hash, null, &resolution) orelse @panic("Package not found");
             const patch_hash = this.lockfile.patched_dependencies.get(h).?.patchfileHash().?;
             const pt = PatchTask.newApplyPatchHash(this, pkg_id, patch_hash, h);
             pt.callback.apply.task_id = task_id;
@@ -1374,6 +1368,7 @@ fn enqueueLocalTarball(
             },
         },
         .apply_patch_task = if (patch_name_and_version_hash) |h| brk: {
+            bun.assert(package_id != invalid_package_id);
             const patch_hash = this.lockfile.patched_dependencies.get(h).?.patchfileHash().?;
             const pt = PatchTask.newApplyPatchHash(this, package_id, patch_hash, h);
             pt.callback.apply.task_id = task_id;

--- a/src/install/PackageManager/runTasks.zig
+++ b/src/install/PackageManager/runTasks.zig
@@ -39,9 +39,13 @@ pub fn runTasks(
         try ptask.runFromMainThread(manager, log_level);
         if (ptask.callback == .apply) {
             if (ptask.callback.apply.logger.errors == 0) {
+                manager.setPreinstallState(ptask.callback.apply.pkg_id, manager.lockfile, .done);
+
                 if (comptime @TypeOf(callbacks.onExtract) != void) {
                     if (ptask.callback.apply.task_id) |task_id| {
-                        _ = task_id; // autofix
+                        if (Ctx == *Store.Installer) {
+                            callbacks.onExtract(extract_ctx, task_id);
+                        }
 
                     } else if (Ctx == *PackageInstaller) {
                         if (ptask.callback.apply.install_context) |*ctx| {

--- a/src/install/PackageManagerTask.zig
+++ b/src/install/PackageManagerTask.zig
@@ -80,7 +80,9 @@ pub fn callback(task: *ThreadPool.Task) void {
                 defer pt.deinit();
                 bun.handleOom(pt.apply());
                 if (pt.callback.apply.logger.errors > 0) {
-                    defer pt.callback.apply.logger.deinit();
+                    bun.handleOom(pt.callback.apply.logger.cloneToWithRecycled(&this.log, true));
+                    this.err = error.InstallFailed;
+                    this.status = .fail;
                     // this.log.addErrorFmt(null, logger.Loc.Empty, bun.default_allocator, "failed to apply patch: {}", .{e}) catch unreachable;
                     pt.callback.apply.logger.print(Output.errorWriter()) catch {};
                 }

--- a/src/install/PackageManagerTask.zig
+++ b/src/install/PackageManagerTask.zig
@@ -83,8 +83,6 @@ pub fn callback(task: *ThreadPool.Task) void {
                     bun.handleOom(pt.callback.apply.logger.cloneToWithRecycled(&this.log, true));
                     this.err = error.InstallFailed;
                     this.status = .fail;
-                    // this.log.addErrorFmt(null, logger.Loc.Empty, bun.default_allocator, "failed to apply patch: {}", .{e}) catch unreachable;
-                    pt.callback.apply.logger.print(Output.errorWriter()) catch {};
                 }
             }
         }

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -967,42 +967,77 @@ pub fn installIsolatedPackages(
                     const cache_dir, const cache_dir_path = manager.getCacheDirectoryAndAbsPath();
                     defer cache_dir_path.deinit();
 
-                    const missing_from_cache = switch (manager.getPreinstallState(pkg_id)) {
-                        .done => false,
-                        else => missing_from_cache: {
-                            if (patch_info == .none) {
-                                const exists = switch (pkg_res_tag) {
-                                    .npm => exists: {
-                                        var cache_dir_path_save = pkg_cache_dir_subpath.save();
-                                        defer cache_dir_path_save.restore();
-                                        pkg_cache_dir_subpath.append("package.json");
-                                        break :exists sys.existsAt(cache_dir, pkg_cache_dir_subpath.sliceZ());
-                                    },
-                                    else => sys.directoryExistsAt(cache_dir, pkg_cache_dir_subpath.sliceZ()).unwrapOr(false),
-                                };
-                                if (exists) {
-                                    manager.setPreinstallState(pkg_id, installer.lockfile, .done);
-                                }
-                                break :missing_from_cache !exists;
-                            }
-
-                            // TODO: why does this look like it will never work?
-                            break :missing_from_cache true;
+                    const preinstall_state = manager.getPreinstallState(pkg_id);
+                    switch (preinstall_state) {
+                        .done => {
+                            installer.startTask(entry_id);
+                            continue;
                         },
+                        .apply_patch, .applying_patch => {
+                            const patch = switch (patch_info) {
+                                .patch => |patch| patch,
+                                else => unreachable,
+                            };
+
+                            const task_id = switch (pkg_res_tag) {
+                                .npm => install.Task.Id.forNPMPackage(pkg_name.slice(string_buf), pkg_res.value.npm.version),
+                                .git => install.Task.Id.forGitCheckout(
+                                    pkg_res.value.git.repo.slice(string_buf),
+                                    pkg_res.value.git.resolved.slice(string_buf),
+                                ),
+                                .github => github_task_id: {
+                                    const url = manager.allocGitHubURL(&pkg_res.value.git);
+                                    defer manager.allocator.free(url);
+                                    break :github_task_id install.Task.Id.forTarball(url);
+                                },
+                                .local_tarball => install.Task.Id.forTarball(pkg_res.value.local_tarball.slice(string_buf)),
+                                .remote_tarball => install.Task.Id.forTarball(pkg_res.value.remote_tarball.slice(string_buf)),
+                                else => comptime unreachable,
+                            };
+
+                            var task_queue = try manager.task_queue.getOrPut(manager.allocator, task_id);
+                            if (!task_queue.found_existing) {
+                                task_queue.value_ptr.* = .{};
+                            }
+                            try task_queue.value_ptr.append(manager.allocator, .{ .isolated_package_install_context = entry_id });
+
+                            if (preinstall_state == .apply_patch) {
+                                manager.setPreinstallState(pkg_id, installer.lockfile, .applying_patch);
+
+                                const patch_task = install.PatchTask.newApplyPatchHash(
+                                    manager,
+                                    pkg_id,
+                                    patch.contents_hash,
+                                    patch.name_and_version_hash,
+                                );
+                                patch_task.callback.apply.task_id = task_id;
+                                manager.enqueuePatchTask(patch_task);
+                            }
+                            continue;
+                        },
+                        else => {},
+                    }
+
+                    const missing_from_cache = switch (patch_info) {
+                        .none => missing_from_cache: {
+                            const exists = switch (pkg_res_tag) {
+                                .npm => exists: {
+                                    var cache_dir_path_save = pkg_cache_dir_subpath.save();
+                                    defer cache_dir_path_save.restore();
+                                    pkg_cache_dir_subpath.append("package.json");
+                                    break :exists sys.existsAt(cache_dir, pkg_cache_dir_subpath.sliceZ());
+                                },
+                                else => sys.directoryExistsAt(cache_dir, pkg_cache_dir_subpath.sliceZ()).unwrapOr(false),
+                            };
+                            if (exists) {
+                                manager.setPreinstallState(pkg_id, installer.lockfile, .done);
+                            }
+                            break :missing_from_cache !exists;
+                        },
+                        else => true,
                     };
 
                     if (!missing_from_cache) {
-                        if (patch_info == .patch) {
-                            var patch_log: bun.logger.Log = .init(manager.allocator);
-                            installer.applyPackagePatch(entry_id, patch_info.patch, &patch_log);
-                            if (patch_log.hasErrors()) {
-                                // monotonic is okay because we haven't started the task yet (it isn't running
-                                // on another thread)
-                                entry_steps[entry_id.get()].store(.done, .monotonic);
-                                installer.onTaskFail(entry_id, .{ .patching = patch_log });
-                                continue;
-                            }
-                        }
                         installer.startTask(entry_id);
                         continue;
                     }

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -1261,7 +1261,7 @@ pub fn installIsolatedPackages(
                 log(" and is able to run\n", .{});
             }
 
-            bun.debugAssert(done);
+            bun.debugAssert(done or manager.log.hasErrors());
         }
 
         installer.summary.successfully_installed = installer.installed;

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -1121,6 +1121,7 @@ pub fn installIsolatedPackages(
                                 dep.name.slice(string_buf),
                                 &pkg_res,
                                 ctx,
+                                patch_info.nameAndVersionHash(),
                             );
                         },
                         .remote_tarball => {

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -967,7 +967,18 @@ pub fn installIsolatedPackages(
                     const cache_dir, const cache_dir_path = manager.getCacheDirectoryAndAbsPath();
                     defer cache_dir_path.deinit();
 
-                    const preinstall_state = manager.getPreinstallState(pkg_id);
+                    var preinstall_state = manager.getPreinstallState(pkg_id);
+                    if (preinstall_state == .unknown) {
+                        var seeded_name_and_version_hash: ?u64 = null;
+                        var seeded_patchfile_hash: ?u64 = null;
+                        preinstall_state = manager.determinePreinstallState(
+                            lockfile.packages.get(pkg_id),
+                            installer.lockfile,
+                            &seeded_name_and_version_hash,
+                            &seeded_patchfile_hash,
+                        );
+                    }
+
                     switch (preinstall_state) {
                         .done => {
                             installer.startTask(entry_id);
@@ -986,7 +997,7 @@ pub fn installIsolatedPackages(
                                     pkg_res.value.git.resolved.slice(string_buf),
                                 ),
                                 .github => github_task_id: {
-                                    const url = manager.allocGitHubURL(&pkg_res.value.git);
+                                    const url = manager.allocGitHubURL(&pkg_res.value.github);
                                     defer manager.allocator.free(url);
                                     break :github_task_id install.Task.Id.forTarball(url);
                                 },
@@ -1087,7 +1098,7 @@ pub fn installIsolatedPackages(
                             );
                         },
                         .github => {
-                            const url = manager.allocGitHubURL(&pkg_res.value.git);
+                            const url = manager.allocGitHubURL(&pkg_res.value.github);
                             defer manager.allocator.free(url);
                             manager.enqueueTarballForDownload(
                                 dep_id,

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -44,64 +44,10 @@ pub const Installer = struct {
 
     pub fn onPackageExtracted(this: *Installer, task_id: install.Task.Id) void {
         if (this.manager.task_queue.fetchRemove(task_id)) |removed| {
-            const store = this.store;
-
-            const node_pkg_ids = store.nodes.items(.pkg_id);
-
-            const entries = store.entries.slice();
-            const entry_steps = entries.items(.step);
-            const entry_node_ids = entries.items(.node_id);
-
-            const pkgs = this.lockfile.packages.slice();
-            const pkg_names = pkgs.items(.name);
-            const pkg_name_hashes = pkgs.items(.name_hash);
-            const pkg_resolutions = pkgs.items(.resolution);
-
             for (removed.value.items) |install_ctx| {
                 const entry_id = install_ctx.isolated_package_install_context;
-
-                const node_id = entry_node_ids[entry_id.get()];
-                const pkg_id = node_pkg_ids[node_id.get()];
-                const pkg_name = pkg_names[pkg_id];
-                const pkg_name_hash = pkg_name_hashes[pkg_id];
-                const pkg_res = &pkg_resolutions[pkg_id];
-
-                const patch_info = bun.handleOom(this.packagePatchInfo(pkg_name, pkg_name_hash, pkg_res));
-
-                if (patch_info == .patch) {
-                    var log: bun.logger.Log = .init(this.manager.allocator);
-                    this.applyPackagePatch(entry_id, patch_info.patch, &log);
-                    if (log.hasErrors()) {
-                        // monotonic is okay because we haven't started the task yet (it isn't running
-                        // on another thread)
-                        entry_steps[entry_id.get()].store(.done, .monotonic);
-                        this.onTaskFail(entry_id, .{ .patching = log });
-                        continue;
-                    }
-                }
-
                 this.startTask(entry_id);
             }
-        }
-    }
-
-    pub fn applyPackagePatch(this: *Installer, entry_id: Store.Entry.Id, patch: PatchInfo.Patch, log: *bun.logger.Log) void {
-        const store = this.store;
-        const entry_node_ids = store.entries.items(.node_id);
-        const node_id = entry_node_ids[entry_id.get()];
-        const node_pkg_ids = store.nodes.items(.pkg_id);
-        const pkg_id = node_pkg_ids[node_id.get()];
-        const patch_task = install.PatchTask.newApplyPatchHash(
-            this.manager,
-            pkg_id,
-            patch.contents_hash,
-            patch.name_and_version_hash,
-        );
-        defer patch_task.deinit();
-        bun.handleOom(patch_task.apply());
-
-        if (patch_task.callback.apply.logger.hasErrors()) {
-            bun.handleOom(patch_task.callback.apply.logger.cloneToWithRecycled(log, true));
         }
     }
 

--- a/src/install/patch_install.zig
+++ b/src/install/patch_install.zig
@@ -130,11 +130,9 @@ pub const PatchTask = struct {
     }
 
     pub fn runFromMainThreadApply(this: *PatchTask, manager: *PackageManager) void {
-        _ = manager; // autofix
         if (this.callback.apply.logger.errors > 0) {
-            defer this.callback.apply.logger.deinit();
+            bun.handleOom(this.callback.apply.logger.cloneToWithRecycled(manager.log, true));
             Output.errGeneric("failed to apply patchfile ({s})", .{this.callback.apply.patchfilepath});
-            this.callback.apply.logger.print(Output.errorWriter()) catch {};
         }
     }
 

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1,9 +1,9 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, lstatSync, readlinkSync } from "fs";
+import { existsSync, lstatSync, readlinkSync, statSync } from "fs";
 import { mkdir, readlink, rm, symlink } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir } from "harness";
-import { join } from "path";
+import { VerdaccioRegistry, bunEnv, bunExe, isWindows, pack, readdirSorted, runBunInstall, tempDir } from "harness";
+import { dirname, join } from "path";
 
 const registry = new VerdaccioRegistry();
 
@@ -1342,4 +1342,212 @@ test("transitive peer deps are resolved when resolution is fully synchronous", a
   expect(readlinkSync(join(bunDir, usesStrictEntry!, "node_modules", "strict-peer-dep"))).toBe(
     join("..", "..", strictPeerEntry!, "node_modules", "strict-peer-dep"),
   );
+});
+
+test("patched peer variants reuse one patched cache hardlink source", async () => {
+  if (!isWindows) return;
+
+  using packageDir = tempDir("patched-peer-variants-", {});
+  const rootDir = String(packageDir);
+  const packageSourcesDir = join(rootDir, "package-sources");
+  const tarballsDir = join(rootDir, "tarballs");
+  const cacheDir = join(rootDir, ".bun-cache");
+
+  await Promise.all([
+    mkdir(packageSourcesDir, { recursive: true }),
+    mkdir(tarballsDir, { recursive: true }),
+    mkdir(join(rootDir, "patches"), { recursive: true }),
+  ]);
+
+  const manifests: Record<string, any> = {};
+
+  async function createRegistryPackage(
+    name: string,
+    version: string,
+    packageJson: Record<string, any>,
+    files: Record<string, string>,
+  ) {
+    const sourceDir = join(packageSourcesDir, `${name}-${version}`);
+    await mkdir(sourceDir, { recursive: true });
+
+    await write(
+      join(sourceDir, "package.json"),
+      JSON.stringify({
+        name,
+        version,
+        ...packageJson,
+      }),
+    );
+
+    for (const [relativePath, contents] of Object.entries(files)) {
+      await mkdir(dirname(join(sourceDir, relativePath)), { recursive: true });
+      await write(join(sourceDir, relativePath), contents);
+    }
+
+    await pack(sourceDir, bunEnv, `--destination=${tarballsDir}`);
+
+    manifests[name] ??= {
+      name,
+      versions: {},
+      "dist-tags": {},
+    };
+    manifests[name].versions[version] = {
+      name,
+      version,
+      ...packageJson,
+      dist: { tarball: "" },
+    };
+    manifests[name]["dist-tags"].latest = version;
+  }
+
+  await createRegistryPackage("peer-shared", "1.0.0", { main: "index.js" }, { "index.js": `module.exports = "v1";\n` });
+  await createRegistryPackage("peer-shared", "2.0.0", { main: "index.js" }, { "index.js": `module.exports = "v2";\n` });
+
+  const payload = Buffer.alloc(2048, "x").toString();
+  const targetFiles: Record<string, string> = {};
+  for (let i = 1; i <= 64; i++) {
+    targetFiles[`dist/vendors/file-${i.toString().padStart(4, "0")}.js`] = `module.exports = "file ${i} ${payload}";\n`;
+  }
+  for (let i = 1; i <= 64; i++) {
+    targetFiles[`dist/vendors/nested/deep/nested-${i.toString().padStart(4, "0")}.js`] = `module.exports = "nested ${i}";\n`;
+  }
+
+  await createRegistryPackage(
+    "target-pkg",
+    "1.0.0",
+    {
+      main: "dist/vendors/file-0001.js",
+      peerDependencies: {
+        "peer-shared": "*",
+      },
+    },
+    targetFiles,
+  );
+  await createRegistryPackage(
+    "uses-target",
+    "1.0.0",
+    {
+      main: "index.js",
+      dependencies: {
+        "target-pkg": "1.0.0",
+      },
+    },
+    {
+      "index.js": `module.exports = require("target-pkg");\n`,
+    },
+  );
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const pathname = decodeURIComponent(url.pathname);
+
+      if (pathname.endsWith(".tgz")) {
+        const tarball = file(join(tarballsDir, pathname.split("/").pop()!));
+        if (await tarball.exists()) {
+          return new Response(tarball, {
+            headers: { "Content-Type": "application/octet-stream" },
+          });
+        }
+        return new Response("Not found", { status: 404 });
+      }
+
+      const packageName = pathname.slice(1);
+      const manifest = manifests[packageName];
+      if (!manifest) {
+        return new Response("Not found", { status: 404 });
+      }
+
+      const body = JSON.parse(JSON.stringify(manifest));
+      for (const [version, info] of Object.entries(body.versions) as [string, any][]) {
+        info.dist.tarball = `http://127.0.0.1:${server.port}/${packageName}/-/${packageName}-${version}.tgz`;
+      }
+
+      return new Response(JSON.stringify(body), {
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "public, max-age=300",
+        },
+      });
+    },
+  });
+
+  await write(
+    join(rootDir, "bunfig.toml"),
+    `[install]\nregistry = "http://127.0.0.1:${server.port}/"\nlinker = "isolated"\ncache = "${cacheDir.replaceAll("\\", "\\\\")}"\n`,
+  );
+  await write(
+    join(rootDir, "package.json"),
+    JSON.stringify({
+      name: "patched-peer-variants-root",
+      private: true,
+      workspaces: ["packages/*"],
+      patchedDependencies: {
+        "target-pkg@1.0.0": "patches/target-pkg@1.0.0.patch",
+      },
+    }),
+  );
+  await write(
+    join(rootDir, "patches", "target-pkg@1.0.0.patch"),
+    [
+      "diff --git a/dist/vendors/file-0001.js b/dist/vendors/file-0001.js",
+      "index 1111111..2222222 100644",
+      "--- a/dist/vendors/file-0001.js",
+      "+++ b/dist/vendors/file-0001.js",
+      "@@ -1 +1 @@",
+      `-module.exports = \"file 1 ${payload}\";`,
+      '+module.exports = \"patched 1\";',
+      "",
+    ].join("\n"),
+  );
+
+  for (const [name, version] of Object.entries({ app1: "1.0.0", app2: "2.0.0" })) {
+    await mkdir(join(rootDir, "packages", name), { recursive: true });
+    await write(
+      join(rootDir, "packages", name, "package.json"),
+      JSON.stringify({
+        name,
+        version: "1.0.0",
+        dependencies: {
+          "uses-target": "1.0.0",
+          "peer-shared": version,
+        },
+      }),
+    );
+  }
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", "--backend", "hardlink"],
+    cwd: rootDir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("packages installed");
+  expect(stderr).toContain("Saved lockfile");
+  expect(exitCode).toBe(0);
+
+  const bunDir = join(rootDir, "node_modules", ".bun");
+  const entries = await readdirSorted(bunDir);
+  const targetEntries = entries.filter(entry => entry.startsWith("target-pkg@1.0.0+"));
+  expect(targetEntries).toHaveLength(2);
+
+  const patchedCacheEntry = (await readdirSorted(cacheDir)).find(
+    entry => entry.startsWith("target-pkg@1.0.0") && entry.includes("patch_hash="),
+  );
+  expect(patchedCacheEntry).toBeDefined();
+
+  const variantStats = targetEntries.map(entry =>
+    statSync(join(bunDir, entry, "node_modules", "target-pkg", "dist", "vendors", "file-0001.js")),
+  );
+  const cacheStat = statSync(join(cacheDir, patchedCacheEntry!, "dist", "vendors", "file-0001.js"));
+
+  expect(new Set([...variantStats.map(stat => String(stat.ino)), String(cacheStat.ino)])).toEqual(
+    new Set([String(cacheStat.ino)]),
+  );
+  expect(variantStats.map(stat => stat.nlink)).toEqual([3, 3]);
+  expect(cacheStat.nlink).toBe(3);
 });


### PR DESCRIPTION
## Summary
- route isolated installs through the existing patch-task lifecycle instead of reapplying patches while linking from cache
- preserve patch-task propagation across extracted, cached, and local tarball installs, and resume `Store.Installer` after patch completion so patched cache entries are ready before hardlinking
- report patch-task failures consistently and add a Windows regression test covering patched packages reused across multiple isolated peer variants

## Testing
- `build/debug/bun-debug.exe test test/cli/install/isolated-install.test.ts`
- `build/debug/bun-debug.exe test test/cli/install/bun-install-patch.test.ts`
- `build/debug/bun-debug.exe test test/cli/install/bun-patch.test.ts`
- `build/debug/bun-debug.exe test test/cli/install/bun-workspaces.test.ts`

Closes #28147
