### PR TITLE
install: respect --backend for local file: dependencies

### DIFF
--- a/src/install/PackageInstall.zig
+++ b/src/install/PackageInstall.zig
@@ -374,6 +374,9 @@ pub const PackageInstall = struct {
     else
         Method.hardlink;
 
+    /// Set by --backend. Null means use defaults (symlink for local, supported_method otherwise).
+    pub var requested_method: ?Method = null;
+
     fn installWithClonefileEachDir(this: *@This(), destination_dir: std.fs.Dir) !Result {
         var cached_package_dir = bun.openDir(this.cache_dir, this.cache_dir_subpath) catch |err| return Result.fail(err, .opening_cache_dir, @errorReturnTrace());
         defer cached_package_dir.close();
@@ -1342,7 +1345,9 @@ pub const PackageInstall = struct {
     }
 
     pub fn getInstallMethod(this: *const @This()) Method {
-        return if (strings.eqlComptime(this.cache_dir_subpath, ".") or strings.hasPrefixComptime(this.cache_dir_subpath, ".."))
+        return if (requested_method == supported_method)
+            supported_method
+        else if (strings.eqlComptime(this.cache_dir_subpath, ".") or strings.hasPrefixComptime(this.cache_dir_subpath, ".."))
             Method.symlink
         else
             supported_method;

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -604,6 +604,7 @@ pub fn load(
             this.do.save_yarn_lock = true;
         }
 
+        PackageInstall.requested_method = null;
         if (cli.backend) |backend| {
             PackageInstall.requested_method = backend;
             PackageInstall.supported_method = backend;

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -605,6 +605,7 @@ pub fn load(
         }
 
         if (cli.backend) |backend| {
+            PackageInstall.requested_method = backend;
             PackageInstall.supported_method = backend;
         }
 


### PR DESCRIPTION
## Summary

Local `file:` dependencies are hardcoded to use symlinks in `getInstallMethod`, ignoring the `--backend` flag. This means `--backend=copyfile` has no effect on local dependencies.

This PR adds a `requested_method` field that tracks when `--backend` is explicitly set. When the requested method still matches `supported_method` (i.e., no runtime fallback has occurred), it takes priority over the local dep symlink default.

**Use case:** Docker builds where local packages are provided via read-only bind mounts. Symlinks back to the mount break when the mount is removed after build. `--backend=copyfile` should copy the files instead.

Relates to #13223

## Changes

- Add `requested_method: ?Method` to `PackageInstall` (null when `--backend` is not passed)
- Set `requested_method` alongside `supported_method` when `--backend` is parsed
- In `getInstallMethod`, check `requested_method == supported_method` first; if they match, use it for all deps including local ones

## Behavior

| `--backend` | Local dep | Runtime fallback? | Result |
|---|---|---|---|
| (none) | yes | n/a | symlink (unchanged) |
| (none) | no | n/a | platform default (unchanged) |
| copyfile | yes | no | **copyfile** (new) |
| copyfile | no | n/a | copyfile (unchanged) |
| hardlink | yes | yes (fell back) | symlink (safe) |
| hardlink | no | n/a | hardlink (unchanged) |