### PR TITLE
fix(sql/mysql): fix caching_sha2_password auth for passwords > 19 chars

### DIFF
--- a/src/sql/mysql/protocol/Auth.rs
+++ b/src/sql/mysql/protocol/Auth.rs
@@ -13,6 +13,11 @@ use crate::shared::Data;
 
 bun_core::declare_scope!(Auth, hidden);
 
+/// Every current auth plugin's nonce is this many bytes (MySQL's `SCRAMBLE_LENGTH`).
+/// HandshakeV10 and AuthSwitchRequest both wire-terminate it with a NUL that is not
+/// part of the nonce (#26195); storage sites truncate to this length by position.
+pub const SCRAMBLE_LENGTH: usize = 20;
+
 pub(crate) mod mysql_native_password {
     use super::*;
 
@@ -28,7 +33,7 @@ pub(crate) mod mysql_native_password {
         // A malicious or broken server can send an AuthSwitchRequest with a
         // short plugin_data; without this check the slicing below reads past
         // the end of the buffer.
-        if nonce.len() < 20 {
+        if nonce.len() < SCRAMBLE_LENGTH {
             return Err(crate::Error::MissingAuthData);
         }
 
@@ -71,6 +76,12 @@ pub mod caching_sha2_password {
         let mut digest2 = [0u8; 32];
         let mut digest3 = [0u8; 32];
         let mut result: [u8; 32] = [0u8; 32];
+
+        // Same short-plugin_data hazard as mysql_native_password::scramble (#26195).
+        if nonce.len() < SCRAMBLE_LENGTH {
+            return Err(crate::Error::MissingAuthData);
+        }
+        let nonce = &nonce[..SCRAMBLE_LENGTH];
 
         // SHA256(password)
         // Null ENGINE — see note in mysql_native_password::scramble.

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -669,17 +669,16 @@ impl MySQLConnection {
         self.auth_data.clear();
         self.auth_data.shrink_to_fit();
 
-        // `auth_plugin_data_part_2` carries a trailing NUL per the wire
-        // protocol. caching_sha2_password's RSA path XORs the password
-        // cyclically against the full nonce, so an unstripped 21-byte nonce
-        // leaves byte 20 of the password unmasked (#26195). Drop the NUL so
-        // the stored nonce is the expected 20 bytes.
-        let part_1 = &handshake.auth_plugin_data_part_1[..];
-        let part_2 = &handshake.auth_plugin_data_part_2[..];
-        let part_2 = part_2.strip_suffix(&[0]).unwrap_or(part_2);
-        self.auth_data.reserve(part_1.len() + part_2.len());
-        self.auth_data.extend_from_slice(part_1);
-        self.auth_data.extend_from_slice(part_2);
+        // The wire nonce is NUL-terminated; that byte is not part of the
+        // scramble (#26195). Truncate by position, not by value.
+        self.auth_data.reserve(
+            handshake.auth_plugin_data_part_1.len() + handshake.auth_plugin_data_part_2.len(),
+        );
+        self.auth_data
+            .extend_from_slice(&handshake.auth_plugin_data_part_1[..]);
+        self.auth_data
+            .extend_from_slice(&handshake.auth_plugin_data_part_2[..]);
+        self.auth_data.truncate(Auth::SCRAMBLE_LENGTH);
 
         // Get auth plugin
         if !handshake.auth_plugin_name.slice().is_empty() {
@@ -926,7 +925,10 @@ impl MySQLConnection {
                 }
                 self.auth_switch_count += 1;
 
+                // Terminated the same way as the handshake's auth-plugin-data
+                // (see above); truncate by position, not by value (#26195).
                 let auth_data = auth_switch.plugin_data.slice();
+                let auth_data = &auth_data[..auth_data.len().min(Auth::SCRAMBLE_LENGTH)];
                 self.auth_plugin = Some(auth_method);
                 self.auth_data.clear();
                 self.auth_data.extend_from_slice(auth_data);

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -669,14 +669,17 @@ impl MySQLConnection {
         self.auth_data.clear();
         self.auth_data.shrink_to_fit();
 
-        // Store auth data
-        self.auth_data.reserve(
-            handshake.auth_plugin_data_part_1.len() + handshake.auth_plugin_data_part_2.len(),
-        );
-        self.auth_data
-            .extend_from_slice(&handshake.auth_plugin_data_part_1[..]);
-        self.auth_data
-            .extend_from_slice(&handshake.auth_plugin_data_part_2[..]);
+        // `auth_plugin_data_part_2` carries a trailing NUL per the wire
+        // protocol. caching_sha2_password's RSA path XORs the password
+        // cyclically against the full nonce, so an unstripped 21-byte nonce
+        // leaves byte 20 of the password unmasked (#26195). Drop the NUL so
+        // the stored nonce is the expected 20 bytes.
+        let part_1 = &handshake.auth_plugin_data_part_1[..];
+        let part_2 = &handshake.auth_plugin_data_part_2[..];
+        let part_2 = part_2.strip_suffix(&[0]).unwrap_or(part_2);
+        self.auth_data.reserve(part_1.len() + part_2.len());
+        self.auth_data.extend_from_slice(part_1);
+        self.auth_data.extend_from_slice(part_2);
 
         // Get auth plugin
         if !handshake.auth_plugin_name.slice().is_empty() {

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -116,6 +116,26 @@ services:
       start_period: 60s
       start_interval: 1s
 
+  mysql_caching_sha2:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: bun
+      MYSQL_DATABASE: bun_sql_test
+      MYSQL_ROOT_HOST: "%"
+    ports:
+      - target: 3306
+        published: 0
+        protocol: tcp
+    tmpfs:
+      - /var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysql", "-h", "127.0.0.1", "-uroot", "-pbun", "-e", "SELECT 1"]
+      interval: 1h # Effectively disable after startup
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+      start_interval: 1s
+
   mysql_tls:
     build:
       context: ../js/sql/mysql-tls

--- a/test/docker/index.ts
+++ b/test/docker/index.ts
@@ -12,6 +12,7 @@ export type ServiceName =
   | "postgres_auth"
   | "mysql_plain"
   | "mysql_native_password"
+  | "mysql_caching_sha2"
   | "mysql_tls"
   | "redis_plain"
   | "redis_unified"
@@ -50,6 +51,7 @@ const serviceMeta: Record<ServiceName, { ports: number[]; tls?: ServiceInfo["tls
   },
   mysql_plain: { ports: [3306] },
   mysql_native_password: { ports: [3306] },
+  mysql_caching_sha2: { ports: [3306] },
   mysql_tls: {
     ports: [3306],
     tls: {
@@ -406,6 +408,7 @@ class DockerComposeHelper {
 
       case "mysql_plain":
       case "mysql_native_password":
+      case "mysql_caching_sha2":
       case "mysql_tls":
         env.MYSQL_HOST = info.host;
         env.MYSQL_PORT = info.ports[3306].toString();
@@ -594,7 +597,7 @@ export async function withPostgres(
 }
 
 export async function withMySQL(
-  opts: { variant?: "plain" | "native_password" | "tls" },
+  opts: { variant?: "plain" | "native_password" | "caching_sha2" | "tls" },
   fn: (info: ServiceInfo & { url: string }) => Promise<void>,
 ): Promise<void> {
   const variant = opts.variant || "plain";

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1139,6 +1139,7 @@ export async function describeWithContainer(
     "postgres_auth": 5432,
     "mysql_plain": 3306,
     "mysql_native_password": 3306,
+    "mysql_caching_sha2": 3306,
     "mysql_tls": 3306,
     "mysql:8": 3306, // Map mysql:8 to mysql_plain
     "mysql:9": 3306, // Map mysql:9 to mysql_native_password

--- a/test/js/sql/sql-mysql-auth-short-nonce.test.ts
+++ b/test/js/sql/sql-mysql-auth-short-nonce.test.ts
@@ -10,6 +10,8 @@
 // straight into scramble() as the nonce — OOB read (panic under safety
 // checks, silent heap over-read in release). With the fix the client rejects
 // with ERR_MYSQL_MISSING_AUTH_DATA before touching the buffer.
+// caching_sha2_password::scramble() takes the same nonce from the same packet
+// and got the same length guard (#26195), so it rejects a short one too.
 
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
@@ -21,58 +23,64 @@ import {
   mysqlReadPackets,
 } from "./wire-frames";
 
-test("MySQL: AuthSwitchRequest with a short mysql_native_password nonce is rejected, not OOB-read", async () => {
-  let sawAuthSwitchResponse = false;
+test.concurrent.each([
+  { switchTo: "mysql_native_password", greeting: "caching_sha2_password" },
+  { switchTo: "caching_sha2_password", greeting: "mysql_native_password" },
+] as const)(
+  "MySQL: AuthSwitchRequest with a short $switchTo nonce is rejected, not OOB-read",
+  async ({ switchTo, greeting: greetingPlugin }) => {
+    let sawAuthSwitchResponse = false;
 
-  // Advertise caching_sha2_password in the initial handshake so the client has
-  // to follow the AuthSwitchRequest path to reach mysql_native_password.scramble()
-  // with the server-controlled plugin_data.
-  const greeting = mysqlHandshakeV10({ authPlugin: "caching_sha2_password" });
+    // Advertise the other plugin in the initial handshake so the client has to
+    // follow the AuthSwitchRequest path to reach `switchTo`.scramble() with the
+    // server-controlled plugin_data.
+    const greeting = mysqlHandshakeV10({ authPlugin: greetingPlugin });
 
-  const { server, port } = await listeningServer(socket => {
-    let buffered = Buffer.alloc(0);
-    let sentAuthSwitch = false;
-    socket.write(greeting);
-    socket.on("data", chunk => {
-      buffered = Buffer.concat([buffered, chunk]);
-      while (buffered.length >= 4) {
-        const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
-        if (buffered.length < 4 + len) break;
-        const seq = buffered[3];
-        buffered = buffered.subarray(4 + len);
-        if (!sentAuthSwitch) {
-          // Reply to HandshakeResponse41 with the short-nonce AuthSwitch: only 4
-          // bytes of plugin_data — well under the 20 bytes scramble() slices.
-          sentAuthSwitch = true;
-          socket.write(mysqlAuthSwitchRequest(seq + 1, "mysql_native_password", Buffer.alloc(4, 0x63)));
-        } else {
-          // Pre-fix release builds OOB-read garbage into the scramble and
-          // still send an AuthSwitchResponse; reaching here means the
-          // length check did not fire. Close so the client does not hang.
-          sawAuthSwitchResponse = true;
-          socket.end();
+    const { server, port } = await listeningServer(socket => {
+      let buffered = Buffer.alloc(0);
+      let sentAuthSwitch = false;
+      socket.write(greeting);
+      socket.on("data", chunk => {
+        buffered = Buffer.concat([buffered, chunk]);
+        while (buffered.length >= 4) {
+          const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
+          if (buffered.length < 4 + len) break;
+          const seq = buffered[3];
+          buffered = buffered.subarray(4 + len);
+          if (!sentAuthSwitch) {
+            // Reply to HandshakeResponse41 with the short-nonce AuthSwitch: only 4
+            // bytes of plugin_data — well under the 20 bytes scramble() slices.
+            sentAuthSwitch = true;
+            socket.write(mysqlAuthSwitchRequest(seq + 1, switchTo, Buffer.alloc(4, 0x63)));
+          } else {
+            // Pre-fix release builds OOB-read garbage into the scramble and
+            // still send an AuthSwitchResponse; reaching here means the
+            // length check did not fire. Close so the client does not hang.
+            sawAuthSwitchResponse = true;
+            socket.end();
+          }
         }
-      }
+      });
+      socket.on("error", () => {});
     });
-    socket.on("error", () => {});
-  });
 
-  try {
-    // Non-empty password so scramble() proceeds past the empty-password early return.
-    await using sql = new SQL({ url: `mysql://root:pw@127.0.0.1:${port}/db`, max: 1 });
-    const err = await sql`select 1`.then(
-      () => ({ code: "UNEXPECTED_SUCCESS" }),
-      e => ({ code: e?.code ?? String(e) }),
-    );
+    try {
+      // Non-empty password so scramble() proceeds past the empty-password early return.
+      await using sql = new SQL({ url: `mysql://root:pw@127.0.0.1:${port}/db`, max: 1 });
+      const err = await sql`select 1`.then(
+        () => ({ code: "UNEXPECTED_SUCCESS" }),
+        e => ({ code: e?.code ?? String(e) }),
+      );
 
-    expect({ err, sawAuthSwitchResponse }).toEqual({
-      err: { code: "ERR_MYSQL_MISSING_AUTH_DATA" },
-      sawAuthSwitchResponse: false,
-    });
-  } finally {
-    await new Promise<void>(r => server.close(() => r()));
-  }
-});
+      expect({ err, sawAuthSwitchResponse }).toEqual({
+        err: { code: "ERR_MYSQL_MISSING_AUTH_DATA" },
+        sawAuthSwitchResponse: false,
+      });
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  },
+);
 
 test("MySQL: an AuthSwitchRequest frame declaring a zero-length payload is rejected", async () => {
   const greeting = mysqlHandshakeV10();

--- a/test/js/sql/sql-mysql.auth.test.ts
+++ b/test/js/sql/sql-mysql.auth.test.ts
@@ -207,14 +207,75 @@ test("caching_sha2_password scramble hashes the double-SHA256 before the nonce",
       const digest3 = sha256(Buffer.concat([digest2, nonce]));
       return Buffer.from(digest1.map((byte, i) => byte ^ digest3[i])).toString("hex");
     };
-    // The spec nonce is 20 bytes (part1 + the first 12 bytes of part2). Bun currently
-    // also keeps part2's trailing filler byte (#26195, fixed separately in #28161), so
-    // accept either nonce length: this test pins only the concatenation order.
+    // The spec nonce is 20 bytes (part1 + the first 12 bytes of part2); part2's 13th
+    // byte is the protocol's trailing NUL filler, not nonce data (#26195, fixed in #28161).
     const nonce20 = Buffer.concat([MYSQL_MOCK_AUTH_DATA_PART_1, MYSQL_MOCK_AUTH_DATA_PART_2.subarray(0, 12)]);
     const nonce21 = Buffer.concat([MYSQL_MOCK_AUTH_DATA_PART_1, MYSQL_MOCK_AUTH_DATA_PART_2]);
-    expect([expected(nonce20), expected(nonce21)]).toContain(sent.toString("hex"));
+    expect(sent.toString("hex")).toBe(expected(nonce20));
+    expect(sent.toString("hex")).not.toBe(expected(nonce21));
     expect(rows).toEqual([{ v: "REAL-ROW" }]);
   } finally {
     server.close();
   }
 });
+
+// Regression for #26195: caching_sha2_password's RSA path XORs the password
+// cyclically against the server nonce, so a stray trailing NUL (21-byte nonce)
+// leaves byte 20 of the password unmasked. Use a container whose default
+// plugin is caching_sha2_password so the bug is reached via the initial
+// handshake rather than via AuthSwitchRequest.
+describeWithContainer(
+  "mysql caching_sha2_password",
+  {
+    image: "mysql_caching_sha2",
+    env: {},
+    args: [],
+    concurrent: true,
+  },
+  container => {
+    const userUrl = (user: string, password: string) =>
+      `mysql://${user}:${password}@${container.host}:${container.port}/bun_sql_test`;
+
+    async function createUser(user: string, password: string) {
+      // `simple` (text protocol) doesn't take bound parameters; user/password
+      // are test-controlled string literals, so inline them.
+      await using sql = new SQL({
+        url: `mysql://root:bun@${container.host}:${container.port}/bun_sql_test`,
+        max: 1,
+        allowPublicKeyRetrieval: true,
+      });
+      await sql.unsafe(`DROP USER IF EXISTS '${user}'@'%';`).simple();
+      await sql
+        .unsafe(
+          `CREATE USER '${user}'@'%' IDENTIFIED WITH caching_sha2_password BY '${password}';
+           GRANT ALL PRIVILEGES ON bun_sql_test.* TO '${user}'@'%';
+           FLUSH PRIVILEGES;`,
+        )
+        .simple();
+    }
+
+    async function expectAuthSucceeds(user: string, password: string) {
+      await using sql = new SQL({ url: userUrl(user, password), allowPublicKeyRetrieval: true });
+      const result = await sql`select 1 as x`;
+      expect(result).toEqual([{ x: 1 }]);
+    }
+
+    test("short password (< 20 chars)", async () => {
+      await createUser("short_pass", "short");
+      // Twice: first connection hits the RSA path, second hits the cached
+      // fast-auth path. Both must succeed.
+      await expectAuthSucceeds("short_pass", "short");
+      await expectAuthSucceeds("short_pass", "short");
+    });
+
+    test("boundary password (exactly 20 chars)", async () => {
+      await createUser("boundary", "exactly20charpasswd!");
+      await expectAuthSucceeds("boundary", "exactly20charpasswd!");
+    });
+
+    test("long password (> 19 chars)", async () => {
+      await createUser("long_pass", "ThisIsAVeryLongPassword123!");
+      await expectAuthSucceeds("long_pass", "ThisIsAVeryLongPassword123!");
+    });
+  },
+);

--- a/test/js/sql/sql-mysql.auth.test.ts
+++ b/test/js/sql/sql-mysql.auth.test.ts
@@ -1,13 +1,14 @@
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
 import { describeWithContainer } from "harness";
-import { createHash } from "node:crypto";
+import { constants, createHash, generateKeyPairSync, privateDecrypt } from "node:crypto";
 import {
   listeningServer,
   MYSQL_FAST_AUTH_SUCCESS,
   MYSQL_MOCK_AUTH_DATA_PART_1,
   MYSQL_MOCK_AUTH_DATA_PART_2,
   mysqlAuthMoreData,
+  mysqlAuthSwitchRequest,
   mysqlHandshakeV10,
   mysqlOkPacket,
   mysqlParseHandshakeResponse41,
@@ -167,6 +168,15 @@ test.each(["split", "coalesced"] as const)(
 // The scramble is XOR(SHA256(pw), SHA256(SHA256(SHA256(pw)) || nonce)) with the double
 // hash hashed FIRST: MySQL's Generate_scramble, mysql2, go-sql-driver, and Connector/J all
 // agree. mysql_native_password concatenates the other way around, which is NOT correct here.
+// `nonce` must be the 20-byte scramble, never a longer server-controlled slice (#26195).
+function cachingSha2Token(password: string, nonce: Buffer): Buffer {
+  const sha256 = (b: Buffer) => createHash("sha256").update(b).digest();
+  const digest1 = sha256(Buffer.from(password));
+  const digest2 = sha256(digest1);
+  const digest3 = sha256(Buffer.concat([digest2, nonce]));
+  return Buffer.from(digest1.map((byte, i) => byte ^ digest3[i]));
+}
+
 test("caching_sha2_password scramble hashes the double-SHA256 before the nonce", async () => {
   const password = "pw";
   const scrambleSent = Promise.withResolvers<Buffer>();
@@ -200,19 +210,131 @@ test("caching_sha2_password scramble hashes the double-SHA256 before the nonce",
     await using sql = new SQL({ url: `mysql://root:${password}@127.0.0.1:${port}/db`, max: 1 });
     const [sent, rows] = await Promise.all([scrambleSent.promise, sql`SELECT 'REAL-ROW' AS v`.simple()]);
 
-    const sha256 = (b: Buffer) => createHash("sha256").update(b).digest();
-    const digest1 = sha256(Buffer.from(password));
-    const digest2 = sha256(digest1);
-    const expected = (nonce: Buffer) => {
-      const digest3 = sha256(Buffer.concat([digest2, nonce]));
-      return Buffer.from(digest1.map((byte, i) => byte ^ digest3[i])).toString("hex");
-    };
     // The spec nonce is 20 bytes (part1 + the first 12 bytes of part2); part2's 13th
     // byte is the protocol's trailing NUL filler, not nonce data (#26195, fixed in #28161).
     const nonce20 = Buffer.concat([MYSQL_MOCK_AUTH_DATA_PART_1, MYSQL_MOCK_AUTH_DATA_PART_2.subarray(0, 12)]);
     const nonce21 = Buffer.concat([MYSQL_MOCK_AUTH_DATA_PART_1, MYSQL_MOCK_AUTH_DATA_PART_2]);
-    expect(sent.toString("hex")).toBe(expected(nonce20));
-    expect(sent.toString("hex")).not.toBe(expected(nonce21));
+    expect(sent.toString("hex")).toBe(cachingSha2Token(password, nonce20).toString("hex"));
+    expect(sent.toString("hex")).not.toBe(cachingSha2Token(password, nonce21).toString("hex"));
+    expect(rows).toEqual([{ v: "REAL-ROW" }]);
+  } finally {
+    server.close();
+  }
+});
+
+// Regression for #26195, reached via AuthSwitchRequest instead of the initial handshake.
+test("caching_sha2_password scramble via AuthSwitchRequest strips the trailing NUL from the nonce", async () => {
+  const password = "pw";
+  const switchNonce = Buffer.concat([Buffer.alloc(20, 0x78), Buffer.from([0])]);
+  const scrambleSent = Promise.withResolvers<Buffer>();
+  const { server, port } = await listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let step = 0;
+    socket.write(mysqlHandshakeV10());
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        switch (step++) {
+          case 0:
+            // HandshakeResponse41 for the advertised mysql_native_password; switch
+            // the account over to caching_sha2_password with a 21-byte plugin_data.
+            socket.write(mysqlAuthSwitchRequest(seq + 1, "caching_sha2_password", switchNonce));
+            return;
+          case 1:
+            scrambleSent.resolve(payload);
+            socket.write(mysqlOkPacket(seq + 1));
+            return;
+          default:
+            if (payload[0] === COM_QUERY) {
+              socket.write(mysqlTextResultSet(1, [{ name: "v", type: MYSQL_TYPE_VAR_STRING }], [["REAL-ROW"]]));
+            } else {
+              socket.end();
+            }
+        }
+      });
+    });
+    socket.on("error", () => {});
+  });
+
+  try {
+    await using sql = new SQL({ url: `mysql://root:${password}@127.0.0.1:${port}/db`, max: 1 });
+    const [sent, rows] = await Promise.all([scrambleSent.promise, sql`SELECT 'REAL-ROW' AS v`.simple()]);
+
+    expect(sent.toString("hex")).toBe(cachingSha2Token(password, switchNonce.subarray(0, 20)).toString("hex"));
+    expect(sent.toString("hex")).not.toBe(cachingSha2Token(password, switchNonce).toString("hex"));
+    expect(rows).toEqual([{ v: "REAL-ROW" }]);
+  } finally {
+    server.close();
+  }
+});
+
+// Regression for #26195: the RSA-encrypted full-auth password is XORed against
+// `self.auth_data` directly, bypassing scramble()'s own nonce truncation — so this path
+// only stays correct if the AuthSwitchRequest storage site truncates the nonce itself.
+const rsaKeyPair = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+test("caching_sha2_password full auth via AuthSwitchRequest XORs the password against the 20-byte nonce", async () => {
+  // Longer than the nonce so the cyclic XOR wraps and a wrong nonce length is visible.
+  const password = `pw-${Buffer.alloc(24, "x").toString()}`;
+  const nonce = Buffer.from(Array.from({ length: 20 }, (_, i) => 0x41 + i));
+  const switchNonce = Buffer.concat([nonce, Buffer.from([0])]);
+  const decrypted = Promise.withResolvers<Buffer>();
+  const { server, port } = await listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let step = 0;
+    socket.write(mysqlHandshakeV10());
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        switch (step++) {
+          case 0:
+            socket.write(mysqlAuthSwitchRequest(seq + 1, "caching_sha2_password", switchNonce));
+            return;
+          case 1:
+            // Cold cache: demand the full RSA exchange instead of accepting the scramble.
+            socket.write(mysqlAuthMoreData(seq + 1, Buffer.from([0x04])));
+            return;
+          case 2:
+            socket.write(mysqlAuthMoreData(seq + 1, Buffer.from(rsaKeyPair.publicKey)));
+            return;
+          case 3:
+            try {
+              decrypted.resolve(
+                privateDecrypt({ key: rsaKeyPair.privateKey, padding: constants.RSA_PKCS1_OAEP_PADDING }, payload),
+              );
+            } catch (e) {
+              decrypted.reject(e);
+            }
+            socket.write(mysqlOkPacket(seq + 1));
+            return;
+          default:
+            if (payload[0] === COM_QUERY) {
+              socket.write(mysqlTextResultSet(1, [{ name: "v", type: MYSQL_TYPE_VAR_STRING }], [["REAL-ROW"]]));
+            } else {
+              socket.end();
+            }
+        }
+      });
+    });
+    socket.on("error", () => {});
+  });
+
+  try {
+    await using sql = new SQL({
+      url: `mysql://root:${password}@127.0.0.1:${port}/db`,
+      max: 1,
+      allowPublicKeyRetrieval: true,
+    });
+    const [plain, rows] = await Promise.all([decrypted.promise, sql`SELECT 'REAL-ROW' AS v`.simple()]);
+
+    const obfuscate = (nonce: Buffer) => {
+      const plaintext = Buffer.from(`${password}\0`, "utf-8");
+      return Buffer.from(plaintext.map((byte, i) => byte ^ nonce[i % nonce.length]));
+    };
+    expect(plain.toString("hex")).toBe(obfuscate(nonce).toString("hex"));
+    expect(plain.toString("hex")).not.toBe(obfuscate(switchNonce).toString("hex"));
     expect(rows).toEqual([{ v: "REAL-ROW" }]);
   } finally {
     server.close();


### PR DESCRIPTION
### What does this PR do?

Fixes `caching_sha2_password` authentication failing with `Access denied` for passwords longer than 19 characters.

~~Two bugs~~ One bug in the MySQL auth handshake:

1. **Nonce trailing null (root cause of #26195):** `auth_plugin_data_part_2` from the server `HandshakeV10` includes a trailing null byte per the MySQL wire protocol. This byte was included in the stored nonce, making it 21 bytes instead of 20. The RSA-encrypted password path XORs `(password + \0)` with the nonce cyclically — at position 20, `nonce[20 % 21] = 0x00` (the stray null) instead of `nonce[0]`, corrupting auth for any password where `len(password) >= 20`. Passwords ≤ 19 chars never reach position 20 in the XOR, so they work fine. Compare with [mysql2](https://github.com/sidorares/node-mysql2) which explicitly does `scramble = data.slice(0, 20)`.

2. ~~**Scramble byte order:** The `caching_sha2_password` scramble concatenated `nonce || digest2` instead of `digest2 || nonce` per the [MySQL protocol spec](https://dev.mysql.com/doc/dev/mysql-server/latest/page_caching_sha2_authentication_exchanges.html). This caused the fast-auth path to always fail, forcing every connection through the RSA fallback — where bug 1 manifests.~~ Removed, see [comment](https://github.com/oven-sh/bun/pull/28161#issuecomment-4071041610).

Supersedes #26196 which ~~only~~ addressed ~~bug 2~~ the scramble byte order.

### How did you verify your code works?

Built bun locally, tested against a MySQL 8.0 Docker container with `caching_sha2_password` users using short (5-char), boundary (20-char), and long (27-char) passwords. Before fix: boundary and long passwords fail with `Access denied`. After fix: all pass.

Fixes #26195