### PR TITLE
Add regression test for baseline WebKit SIGILL crash

### DIFF
--- a/test/regression/issue/28163.test.ts
+++ b/test/regression/issue/28163.test.ts
@@ -1,0 +1,145 @@
+// Regression test for https://github.com/oven-sh/bun/issues/28163
+//
+// Bun v1.3.10 baseline builds linked against non-baseline WebKit (with AVX/AVX2),
+// causing SIGILL on pre-Haswell CPUs. The crash manifested during GC when
+// computing error stack traces: computeErrorInfo → Bun__remapStackFramePositions
+// → displaySourceURLIfNeeded → BunString__fromLatin1 → libpas allocator (AVX).
+//
+// Two-part test:
+// 1. Build system: verify the WebKit download URL includes "-baseline" for
+//    baseline x64 builds (the root cause was a missing suffix).
+// 2. Runtime: exercise the exact crash code path (error stack trace formatting
+//    with source map remapping under GC pressure).
+
+import { describe, test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("build system: baseline WebKit suffix", () => {
+  // The root cause was that the build system did not append "-baseline"
+  // when downloading WebKit for x64 baseline builds. Verify both the
+  // cmake and TypeScript build systems include the fix.
+
+  test("cmake SetupWebKit.cmake appends -baseline for x64 baseline builds", () => {
+    const cmake = readFileSync(resolve(import.meta.dir, "../../../cmake/tools/SetupWebKit.cmake"), "utf-8");
+    // The fix: when ENABLE_BASELINE is set and arch is amd64, append -baseline
+    expect(cmake).toContain('if(ENABLE_BASELINE AND WEBKIT_ARCH STREQUAL "amd64")');
+    expect(cmake).toContain('set(WEBKIT_SUFFIX "${WEBKIT_SUFFIX}-baseline")');
+  });
+
+  test("TypeScript webkit.ts appends -baseline for x64 baseline builds", () => {
+    const ts = readFileSync(resolve(import.meta.dir, "../../../scripts/build/deps/webkit.ts"), "utf-8");
+    // The fix: cfg.baseline && cfg.x64 → suffix includes "-baseline"
+    expect(ts).toContain("cfg.baseline && cfg.x64");
+    expect(ts).toContain('-baseline"');
+  });
+});
+
+describe("runtime: error stack trace with source map remapping under GC", () => {
+  // Exercises the exact crash path: TypeScript → transpilation + source maps →
+  // error thrown → GC → computeErrorInfo → Bun__remapStackFramePositions →
+  // displaySourceURLIfNeeded → BunString__fromLatin1 → bmalloc allocator.
+
+  test("stack trace with source map remapping does not crash during GC", async () => {
+    using dir = tempDir("issue-28163", {
+      "entry.ts": `
+        function deepCall(n: number): never {
+          if (n <= 0) {
+            Bun.gc(true);
+            throw new Error("crash-repro");
+          }
+          return deepCall(n - 1);
+        }
+
+        try {
+          deepCall(10);
+        } catch (err: any) {
+          // Accessing .stack triggers computeErrorInfo which calls
+          // Bun__remapStackFramePositions with source map lookup.
+          const stack = err.stack;
+
+          // Force GC after accessing the stack to exercise the lazy
+          // evaluation path that the original bug hit.
+          Bun.gc(true);
+
+          // Verify the stack trace was correctly source-mapped
+          if (!stack.includes("entry.ts")) {
+            process.exit(2);
+          }
+          if (!stack.includes("deepCall")) {
+            process.exit(3);
+          }
+          if (!stack.includes("crash-repro")) {
+            process.exit(4);
+          }
+
+          console.log("OK");
+          process.exit(0);
+        }
+
+        process.exit(1);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("OK\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("many errors with source-mapped stacks under GC pressure", async () => {
+    using dir = tempDir("issue-28163-gc", {
+      "stress.ts": `
+        function makeError(label: string): Error {
+          return new Error("error-" + label);
+        }
+
+        const errors: Error[] = [];
+        for (let i = 0; i < 100; i++) {
+          errors.push(makeError(String(i)));
+        }
+
+        // Force GC to trigger lazy stack trace computation
+        Bun.gc(true);
+
+        let count = 0;
+        for (const err of errors) {
+          const stack = err.stack!;
+          if (stack.includes("stress.ts")) {
+            count++;
+          }
+        }
+
+        // Force another GC after all stacks have been materialized
+        Bun.gc(true);
+
+        if (count !== 100) {
+          console.error("Expected 100 source-mapped stacks, got " + count);
+          process.exit(1);
+        }
+
+        console.log("OK");
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "stress.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("OK\n");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/regression/issue/28163.test.ts
+++ b/test/regression/issue/28163.test.ts
@@ -11,7 +11,7 @@
 // 2. Runtime: exercise the exact crash code path (error stack trace formatting
 //    with source map remapping under GC pressure).
 
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";


### PR DESCRIPTION
## Summary

Adds regression tests for #28163 — Bun v1.3.10 baseline builds linked against non-baseline WebKit (with AVX/AVX2 instructions), causing `SIGILL` on pre-Haswell CPUs.

## Root Cause (already fixed on main)

The `cmake/tools/SetupWebKit.cmake` file did not append `-baseline` when downloading the WebKit library for baseline builds. This meant the baseline Bun binary (`-march=nehalem`, no AVX) was linked against a WebKit compiled for Haswell+ CPUs. The crash manifested during GC when formatting error stack traces:

1. `JSC::Heap::runEndPhase` → `JSC::ErrorInstance::computeErrorInfo`
2. → `Bun__remapStackFramePositions` → `displaySourceURLIfNeeded`
3. → `BunString__fromLatin1` → `tryFastCompactMalloc` → libpas allocator
4. **SIGILL**: libpas code uses AVX instruction not available on the CPU

The fix (commit `66cd0c6bdb`) added `-baseline` suffix for baseline WebKit downloads. Further hardened by `fbfd069cf7` (static baseline CPU instruction verifier).

## What this PR adds

**Build system tests** (prevent accidental reversion):
- Verify `cmake/tools/SetupWebKit.cmake` contains the baseline suffix logic
- Verify `scripts/build/deps/webkit.ts` contains the baseline suffix logic

**Runtime tests** (exercise the crash code path):
- Error stack trace formatting with source map remapping under GC pressure
- Stress test: 100 errors with source-mapped stacks under repeated GC cycles

## Test proof note

This is a **build-system fix** (which WebKit library to download), not a runtime code change. The `SIGILL` only occurs on pre-AVX2 CPUs when the wrong WebKit is linked. The `USE_SYSTEM_BUN=1` proof cannot distinguish the binaries because the runtime code is identical — only the linked library differs. The build system tests verify the source files contain the fix; the runtime tests exercise the affected code path.

Closes #28163

---
**Verification**: All 4 tests pass on baked binary (main). CI failures are pre-existing infra (benchmark upload script fails on main #39698; darwin-13-aarch64 puppeteer browser launch is a CI machine issue). Build system strings confirmed present. Bot threads resolved (3 total). Ready for review.

Verified on `0f392b2`: CI complete (50+ green, 3 pre-existing flakes proven on baked binary), all bot threads resolved (3/3), no TODOs in diff, test follows established patterns.