### PR TITLE
fix(bundler): propagate star import through barrel namespace re-exports

### DIFF
--- a/src/bundler/barrel_imports.zig
+++ b/src/bundler/barrel_imports.zig
@@ -18,6 +18,9 @@ const BarrelExportResolution = struct {
     import_record_index: u32,
     /// The original alias in the source module (e.g. "d" for `export { d as c }`)
     original_alias: ?[]const u8,
+    /// True when the underlying import is `import * as ns` — propagation
+    /// through this export must treat the target as needing all exports.
+    alias_is_star: bool,
 };
 
 /// Look up an export name → import_record_index by chasing
@@ -26,7 +29,7 @@ const BarrelExportResolution = struct {
 fn resolveBarrelExport(alias: []const u8, named_exports: JSAst.NamedExports, named_imports: JSAst.NamedImports) ?BarrelExportResolution {
     const export_entry = named_exports.get(alias) orelse return null;
     const import_entry = named_imports.get(export_entry.ref) orelse return null;
-    return .{ .import_record_index = import_entry.import_record_index, .original_alias = import_entry.alias };
+    return .{ .import_record_index = import_entry.import_record_index, .original_alias = import_entry.alias, .alias_is_star = import_entry.alias_is_star };
 }
 
 /// Analyze a parsed file to determine if it's a barrel and mark unneeded
@@ -483,7 +486,9 @@ pub fn scheduleBarrelDeferredImports(this: *BundleV2, result: *ParseTask.Result.
                 rec = barrel_ir.slice()[resolution.import_record_index];
             }
             if (rec.source_index.isValid()) {
-                try queue.append(queue_alloc, .{ .barrel_source_index = rec.source_index.get(), .alias = propagate_alias, .is_star = false });
+                // When the barrel re-exports a namespace import (`import * as X; export { X }`),
+                // propagate as a star import so the target barrel loads all exports.
+                try queue.append(queue_alloc, .{ .barrel_source_index = rec.source_index.get(), .alias = propagate_alias, .is_star = resolution.alias_is_star });
             }
         }
     }

--- a/test/regression/issue/28170.test.ts
+++ b/test/regression/issue/28170.test.ts
@@ -88,7 +88,8 @@ test("barrel optimization propagates through namespace re-exports", async () => 
     cwd: String(dir),
     stderr: "pipe",
   });
-  await installProc.exited;
+  const [, installExit] = await Promise.all([installProc.stderr.text(), installProc.exited]);
+  expect(installExit).toBe(0);
 
   const outFile = path.join(String(dir), "dist", "index.js");
 

--- a/test/regression/issue/28170.test.ts
+++ b/test/regression/issue/28170.test.ts
@@ -88,7 +88,8 @@ test("barrel optimization propagates through namespace re-exports", async () => 
     cwd: String(dir),
     stderr: "pipe",
   });
-  const [, installExit] = await Promise.all([installProc.stderr.text(), installProc.exited]);
+  const [installStderr, installExit] = await Promise.all([installProc.stderr.text(), installProc.exited]);
+  expect(installStderr).not.toContain("error:");
   expect(installExit).toBe(0);
 
   const outFile = path.join(String(dir), "dist", "index.js");
@@ -109,12 +110,13 @@ test("barrel optimization propagates through namespace re-exports", async () => 
     stderr: "pipe",
   });
 
-  const [buildStdout, buildStderr, buildExit] = await Promise.all([
+  const [, buildStderr, buildExit] = await Promise.all([
     buildProc.stdout.text(),
     buildProc.stderr.text(),
     buildProc.exited,
   ]);
 
+  expect(buildStderr).toBe("");
   expect(buildExit).toBe(0);
 
   // Run the bundled output

--- a/test/regression/issue/28170.test.ts
+++ b/test/regression/issue/28170.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import path from "node:path";
 

--- a/test/regression/issue/28170.test.ts
+++ b/test/regression/issue/28170.test.ts
@@ -1,0 +1,131 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
+
+// Regression test for https://github.com/oven-sh/bun/issues/28170
+// When a barrel file with sideEffects:false re-exports a namespace import
+// (`import * as X from './mod'; export { X }`), the barrel optimization
+// failed to propagate the star import to the target module. This caused
+// the target's own re-exports to be incorrectly deferred, resulting in
+// missing function definitions in the bundled output.
+test("barrel optimization propagates through namespace re-exports", async () => {
+  using dir = tempDir("issue-28170", {
+    // Root workspace package.json
+    "package.json": JSON.stringify({
+      name: "test-root",
+      private: true,
+      workspaces: ["packages/*"],
+    }),
+    // Utils package — has sideEffects: false
+    "packages/pkg-utils/package.json": JSON.stringify({
+      name: "@test/utils",
+      version: "0.0.1",
+      private: true,
+      type: "module",
+      sideEffects: false,
+      exports: { ".": "./src/index.ts" },
+    }),
+    "packages/pkg-utils/src/arrays/typed/misc.ts": `
+      export function toDataView(buf) {
+        return new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+      }
+    `,
+    "packages/pkg-utils/src/arrays/u8/pool.ts": `
+      export function alloc(size) {
+        return new Uint8Array(size);
+      }
+    `,
+    "packages/pkg-utils/src/arrays/typed/index.ts": "export { toDataView } from './misc.js';\n",
+    "packages/pkg-utils/src/index.ts": `
+      import * as typed from './arrays/typed/index.js';
+      import * as u8 from './arrays/u8/pool.js';
+      export { typed, u8 };
+    `,
+    // Codec package — depends on utils, has sideEffects: false
+    "packages/pkg-codec/package.json": JSON.stringify({
+      name: "@test/codec",
+      version: "0.0.1",
+      private: true,
+      type: "module",
+      sideEffects: false,
+      exports: { ".": "./src/index.ts" },
+      dependencies: { "@test/utils": "workspace:*" },
+    }),
+    "packages/pkg-codec/src/intermediate.ts": `
+      import { typed } from '@test/utils';
+      export class Codec {
+        encode(data) {
+          return typed.toDataView(data);
+        }
+      }
+    `,
+    "packages/pkg-codec/src/index.ts": "export { Codec } from './intermediate.js';\n",
+    // App package — imports from both
+    "packages/pkg-app/package.json": JSON.stringify({
+      name: "@test/app",
+      private: true,
+      type: "module",
+      dependencies: {
+        "@test/codec": "workspace:*",
+        "@test/utils": "workspace:*",
+      },
+    }),
+    "packages/pkg-app/src/index.ts": `
+      import { u8 } from '@test/utils';
+      import { Codec } from '@test/codec';
+      const codec = new Codec();
+      const buf = u8.alloc(8);
+      const view = codec.encode(buf);
+      console.log(buf.length);
+      console.log(view.byteLength);
+    `,
+  });
+
+  // Install workspace dependencies
+  await using installProc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  await installProc.exited;
+
+  const outFile = path.join(String(dir), "dist", "index.js");
+
+  // Bundle the app
+  await using buildProc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "build",
+      path.join(String(dir), "packages/pkg-app/src/index.ts"),
+      "--outfile",
+      outFile,
+      "--target",
+      "bun",
+    ],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [buildStdout, buildStderr, buildExit] = await Promise.all([
+    buildProc.stdout.text(),
+    buildProc.stderr.text(),
+    buildProc.exited,
+  ]);
+
+  expect(buildExit).toBe(0);
+
+  // Run the bundled output
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), outFile],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("8\n8\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fixes barrel optimization dropping exports when a barrel re-exports namespace imports (`import * as X from './mod'; export { X }`) with `sideEffects: false`
- The BFS propagation now correctly threads `alias_is_star` through `BarrelExportResolution`, treating namespace re-exports as star imports in the target module

## Root Cause

When the barrel optimization BFS encountered a re-exported namespace import like:

```ts
// utils/index.ts (sideEffects: false)
import * as typed from './arrays/typed/index.js';
export { typed };
```

It propagated to `./arrays/typed/index.js` with `is_star = false` and an empty alias. The target barrel's own re-exports (e.g., `export { toDataView } from './misc.js'`) were then incorrectly deferred because the BFS tried to find an export named `""` instead of loading all exports.

## Fix

Added `alias_is_star` to `BarrelExportResolution` and used it during BFS propagation. When the underlying import is `import * as ns`, the propagation now uses `is_star = true`, ensuring the target module's exports are all loaded.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/regression/issue/28170.test.ts â FAIL (toDataView is not defined)
bun bd test test/regression/issue/28170.test.ts                â PASS
```

Closes #28170
Closes #28137