### PR TITLE
fix: prevent use-after-poison in TranspilerJob by deferring pool return

### DIFF
--- a/src/bun.js/RuntimeTranspilerStore.zig
+++ b/src/bun.js/RuntimeTranspilerStore.zig
@@ -272,7 +272,12 @@ pub const RuntimeTranspilerStore = struct {
             this.promise.deinit();
             this.deinit();
 
-            _ = vm.transpiler_store.store.put(this);
+            // Delay returning the slot to the pool until after fulfill() completes.
+            // fulfill() executes JavaScript synchronously, which may trigger new
+            // transpile() calls that recycle this slot via store.get(). Returning the
+            // slot before fulfill() causes the HiveArray to poison the memory, and
+            // a new worker thread accessing the recycled slot hits use-after-poison.
+            defer _ = vm.transpiler_store.store.put(this);
 
             try AsyncModule.fulfill(globalThis, promise, &resolved_source, parse_error, specifier, referrer, &log);
         }


### PR DESCRIPTION
## Summary

- Defer `store.put(this)` in `TranspilerJob.runFromJSThread()` to after `AsyncModule.fulfill()` completes, preventing ASAN use-after-poison when synchronous JS execution during `fulfill()` triggers new transpilation that recycles the same HiveArray slot

## Root Cause

In `runFromJSThread()`, the TranspilerJob slot was returned to the HiveArray pool via `store.put(this)` **before** `AsyncModule.fulfill()` executed JavaScript. `HiveArray.put()` poisons the slot memory. If `fulfill()` synchronously triggered a new `transpile()` call, `store.get()` could recycle the same slot for a new worker thread, which would then access memory that ASAN had marked as poisoned — causing a use-after-poison in `strlen` on the path text.

## Fix

A single `defer` ensures the slot is only returned to the pool after all synchronous JS execution in `fulfill()` completes:

```zig
// Before: slot poisoned before JS runs
_ = vm.transpiler_store.store.put(this);
try AsyncModule.fulfill(...);

// After: slot poisoned after JS completes
defer _ = vm.transpiler_store.store.put(this);
try AsyncModule.fulfill(...);
```

## Test plan

- [x] Verified `rm.test.ts` passes (3/4 pass, 1 pre-existing failure on main)
- [x] Verified the pre-existing `node_modules` test failure exists on main too
- [ ] ASAN CI build should no longer crash with use-after-poison in this code path

Closes #28177

🤖 Generated with [Claude Code](https://claude.com/claude-code)