### PR TITLE
Defer TranspilerJob pool return until after module fulfillment

### DIFF
--- a/src/bun.js/RuntimeTranspilerStore.zig
+++ b/src/bun.js/RuntimeTranspilerStore.zig
@@ -272,7 +272,13 @@ pub const RuntimeTranspilerStore = struct {
             this.promise.deinit();
             this.deinit();
 
-            _ = vm.transpiler_store.store.put(this);
+            // Delay returning the slot to the pool until after fulfill() completes.
+            // fulfill() calls Bun__onFulfillAsyncModule which synchronously evaluates
+            // JavaScript (module initialization). That JS may trigger new transpile()
+            // calls which call store.get(). If the slot was already returned via put(),
+            // get() could recycle it for a new worker while fulfill()'s C++ stack frames
+            // still reference the slot's address range, causing ASAN use-after-poison.
+            defer _ = vm.transpiler_store.store.put(this);
 
             try AsyncModule.fulfill(globalThis, promise, &resolved_source, parse_error, specifier, referrer, &log);
         }

--- a/test/regression/issue/028177.test.ts
+++ b/test/regression/issue/028177.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // Regression test for https://github.com/oven-sh/bun/issues/28177
@@ -38,11 +38,7 @@ test("chained static imports do not cause use-after-poison in TranspilerJob pool
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout.trim()).toBe('{"value":42}');
   expect(exitCode).toBe(0);
@@ -59,10 +55,7 @@ test("concurrent dynamic imports stress TranspilerJob pool recycling", async () 
   }
 
   // Dynamically import all modules concurrently
-  const imports = Array.from(
-    { length: moduleCount },
-    (_, i) => `import("./dep_${i}.ts")`,
-  ).join(",\n    ");
+  const imports = Array.from({ length: moduleCount }, (_, i) => `import("./dep_${i}.ts")`).join(",\n    ");
 
   files["index.ts"] = `
     const results = await Promise.all([
@@ -82,11 +75,7 @@ test("concurrent dynamic imports stress TranspilerJob pool recycling", async () 
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   const expected = Array.from({ length: moduleCount }, (_, i) => i);
   expect(JSON.parse(stdout.trim())).toEqual(expected);

--- a/test/regression/issue/028177.test.ts
+++ b/test/regression/issue/028177.test.ts
@@ -1,0 +1,94 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/28177
+// ASAN use-after-poison in TranspilerJob when module fulfillment
+// triggers new transpilation that recycles the same HiveArray slot.
+//
+// The fix defers store.put() in TranspilerJob.runFromJSThread() until
+// after AsyncModule.fulfill() completes, preventing premature slot
+// recycling while the C++ fulfill stack is still active.
+
+test("chained static imports do not cause use-after-poison in TranspilerJob pool", async () => {
+  // Create a chain of modules where each module's evaluation triggers
+  // importing the next module. This exercises the TranspilerJob pool
+  // slot recycling during fulfill().
+  const chainLength = 70; // exceed HiveArray capacity of 64 to stress the pool
+  const files: Record<string, string> = {};
+
+  // Build a chain: mod_0 imports mod_1, mod_1 imports mod_2, etc.
+  for (let i = 0; i < chainLength - 1; i++) {
+    files[`mod_${i}.ts`] = `export { value } from "./mod_${i + 1}.ts";`;
+  }
+  files[`mod_${chainLength - 1}.ts`] = `export const value = 42;`;
+
+  // Entry point that starts the chain
+  files["index.ts"] = `
+    import { value } from "./mod_0.ts";
+    console.log(JSON.stringify({ value }));
+  `;
+
+  using dir = tempDir("issue-28177", files);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "index.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout.trim()).toBe('{"value":42}');
+  expect(exitCode).toBe(0);
+});
+
+test("concurrent dynamic imports stress TranspilerJob pool recycling", async () => {
+  // Multiple independent dynamic imports that all resolve concurrently,
+  // stressing the pool with many put/get cycles during fulfill.
+  const moduleCount = 80;
+  const files: Record<string, string> = {};
+
+  for (let i = 0; i < moduleCount; i++) {
+    files[`dep_${i}.ts`] = `export const id = ${i};`;
+  }
+
+  // Dynamically import all modules concurrently
+  const imports = Array.from(
+    { length: moduleCount },
+    (_, i) => `import("./dep_${i}.ts")`,
+  ).join(",\n    ");
+
+  files["index.ts"] = `
+    const results = await Promise.all([
+      ${imports}
+    ]);
+    const ids = results.map(m => m.id);
+    console.log(JSON.stringify(ids));
+  `;
+
+  using dir = tempDir("issue-28177-concurrent", files);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "index.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  const expected = Array.from({ length: moduleCount }, (_, i) => i);
+  expect(JSON.parse(stdout.trim())).toEqual(expected);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

Defer `store.put()` in `TranspilerJob.runFromJSThread()` until after `AsyncModule.fulfill()` completes using `defer`, and add regression tests.

## Root Cause

In `runFromJSThread()`, the TranspilerJob slot was returned to the HiveArray pool via `store.put(this)` **before** `AsyncModule.fulfill()` executed. `HiveArray.put()` poisons the slot memory (ASAN) and sets `undefined` (Zig). `fulfill()` calls `Bun__onFulfillAsyncModule` in C++, which resolves the module promise and synchronously evaluates module initialization JavaScript. That JS can trigger new `transpile()` calls — each one calls `store.get()`, which may recycle the same HiveArray slot for a new worker thread.

The crash in the ASAN CI build (`strlen` hitting use-after-poison on `f7` shadow bytes) occurs on a worker thread accessing a TranspilerJob's string fields. The slot was poisoned by `put()` and then recycled by a concurrent `get()`/`schedule()` during `fulfill()`, creating a window where the slot's address range is referenced by both the C++ fulfill stack and the new worker thread.

## Fix

A single `defer` ensures the slot is only returned to the pool after all synchronous JS execution in `fulfill()` completes:

```zig
// Before: slot returned before JS runs
_ = vm.transpiler_store.store.put(this);
try AsyncModule.fulfill(...);

// After: slot returned after JS completes
defer _ = vm.transpiler_store.store.put(this);
try AsyncModule.fulfill(...);
```

This keeps the slot's `used` bit set during `fulfill()`, preventing `get()` from recycling it for a new worker while the C++ stack is still active. All data needed by `fulfill()` is already copied into local variables before `deinit()`, so delaying `put()` has no functional cost.

## Regression Tests

- **Chained static imports**: 70-module chain (`mod_0` → `mod_1` → ... → `mod_69`) exceeding HiveArray capacity of 64, forcing pool recycling during module fulfillment
- **Concurrent dynamic imports**: 80 `import()` calls via `Promise.all`, stressing put/get cycles with concurrent worker threads

## Verification

```
USE_SYSTEM_BUN=1 bun test test/regression/issue/028177.test.ts  → 2 pass
bun bd test test/regression/issue/028177.test.ts                 → 2 pass
```

Note: This is an ASAN-only crash (shadow byte poisoning), so the regression test exercises the code path but cannot reproduce the crash without an ASAN build. The tests will catch regressions in ASAN CI.

Closes #28177