### PR TITLE
fix(debugger): implement /json/list and /json inspector discovery endpoints

### DIFF
--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -339,7 +339,7 @@ class Debugger {
         return Response.json(versionInfo());
       case "/json":
       case "/json/list":
-      // TODO?
+        return Response.json(targetListInfo(this.#url!));
     }
 
     if (!this.#url!.protocol.includes("unix") && this.#url!.pathname !== pathname) {
@@ -516,6 +516,21 @@ function versionInfo(): unknown {
     "Bun-Version": Bun.version,
     "Bun-Revision": Bun.revision,
   };
+}
+
+function targetListInfo(url: URL): unknown[] {
+  const wsUrl = `${url.hostname}:${url.port}${url.pathname}`;
+  return [
+    {
+      description: "Bun instance",
+      devtoolsFrontendUrl: `devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=${wsUrl}`,
+      id: url.pathname.slice(1),
+      title: process.argv[1] || `bun[${process.pid}]`,
+      type: "node",
+      url: `file://${process.argv[1] || ""}`,
+      webSocketDebuggerUrl: `ws://${wsUrl}`,
+    },
+  ];
 }
 
 function webSocketWriter(ws: ServerWebSocket<unknown>): Writer {

--- a/test/regression/issue/28181.test.ts
+++ b/test/regression/issue/28181.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "node:path";
+import { WebSocket } from "ws";
 
 async function startInspectee(): Promise<{ proc: ReturnType<typeof Bun.spawn>; wsUrl: URL }> {
   const proc = Bun.spawn({
@@ -96,45 +97,29 @@ describe("inspector /json endpoints", () => {
     const targets = await res.json();
     const debugUrl = targets[0].webSocketDebuggerUrl;
 
-    // Connect using the discovered URL
+    // Connect using the discovered URL (use `ws` package like existing inspect tests)
     const ws = new WebSocket(debugUrl);
 
-    const opened = await new Promise<boolean>((resolve, reject) => {
-      ws.addEventListener("open", () => resolve(true));
-      ws.addEventListener("error", () => reject(new Error("WebSocket error")));
-    });
-    expect(opened).toBe(true);
+    expect(
+      new Promise<void>((resolve, reject) => {
+        ws.addEventListener("open", () => resolve());
+        ws.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
+        ws.addEventListener("close", cause => reject(new Error("WebSocket closed", { cause })));
+      }),
+    ).resolves.toBeUndefined();
 
-    // Verify we can execute commands over the discovered WebSocket
+    // Register message listener before sending (avoids race on slow ASAN builds)
     ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "2 + 2" } }));
-
-    const result = await new Promise<any>((resolve, reject) => {
-      const cleanup = () => {
-        ws.removeEventListener("message", onMessage);
-        ws.removeEventListener("error", onError);
-        ws.removeEventListener("close", onClose);
-      };
-      const onMessage = (event: MessageEvent) => {
-        const parsed = JSON.parse(String(event.data));
-        if (parsed.id === 1) {
-          cleanup();
-          resolve(parsed);
-        }
-      };
-      const onError = () => {
-        cleanup();
-        reject(new Error("WebSocket error while waiting for response"));
-      };
-      const onClose = () => {
-        cleanup();
-        reject(new Error("WebSocket closed while waiting for response"));
-      };
-      ws.addEventListener("message", onMessage);
-      ws.addEventListener("error", onError);
-      ws.addEventListener("close", onClose);
-    });
-
-    expect(result).toMatchObject({
+    expect(
+      new Promise(resolve => {
+        ws.addEventListener("message", ({ data }) => {
+          const parsed = JSON.parse(data.toString());
+          if (parsed.id === 1) {
+            resolve(parsed);
+          }
+        });
+      }),
+    ).resolves.toMatchObject({
       id: 1,
       result: {
         result: {

--- a/test/regression/issue/28181.test.ts
+++ b/test/regression/issue/28181.test.ts
@@ -20,7 +20,9 @@ async function startInspectee(): Promise<{ proc: ReturnType<typeof Bun.spawn>; w
     }
   }
 
-  const match = stderr.match(/ws:\/\/[^\s\x1b]+/);
+  // Strip ANSI escape sequences before extracting the URL
+  const cleaned = stderr.replace(/\x1b\[[0-9;]*m/g, "").replace(/\x1b\]8;;[^\x1b]*\x1b\\/g, "");
+  const match = cleaned.match(/ws:\/\/\S+/);
   if (!match) {
     proc.kill();
     throw new Error("Unable to find listening URL in stderr: " + stderr);
@@ -59,10 +61,12 @@ describe("inspector /json endpoints", () => {
     await using _ = proc;
     const httpUrl = `http://${wsUrl.hostname}:${wsUrl.port}`;
 
-    const [listRes, jsonRes] = await Promise.all([
-      fetch(`${httpUrl}/json/list`).then(r => r.json()),
-      fetch(`${httpUrl}/json`).then(r => r.json()),
-    ]);
+    const [listResponse, jsonResponse] = await Promise.all([fetch(`${httpUrl}/json/list`), fetch(`${httpUrl}/json`)]);
+
+    expect(listResponse.status).toBe(200);
+    expect(jsonResponse.status).toBe(200);
+
+    const [listRes, jsonRes] = await Promise.all([listResponse.json(), jsonResponse.json()]);
 
     expect(jsonRes).toEqual(listRes);
   });
@@ -104,15 +108,30 @@ describe("inspector /json endpoints", () => {
     // Verify we can execute commands over the discovered WebSocket
     ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "2 + 2" } }));
 
-    const result = await new Promise<any>(resolve => {
-      const handler = (event: MessageEvent) => {
+    const result = await new Promise<any>((resolve, reject) => {
+      const cleanup = () => {
+        ws.removeEventListener("message", onMessage);
+        ws.removeEventListener("error", onError);
+        ws.removeEventListener("close", onClose);
+      };
+      const onMessage = (event: MessageEvent) => {
         const parsed = JSON.parse(String(event.data));
         if (parsed.id === 1) {
-          ws.removeEventListener("message", handler);
+          cleanup();
           resolve(parsed);
         }
       };
-      ws.addEventListener("message", handler);
+      const onError = () => {
+        cleanup();
+        reject(new Error("WebSocket error while waiting for response"));
+      };
+      const onClose = () => {
+        cleanup();
+        reject(new Error("WebSocket closed while waiting for response"));
+      };
+      ws.addEventListener("message", onMessage);
+      ws.addEventListener("error", onError);
+      ws.addEventListener("close", onClose);
     });
 
     expect(result).toMatchObject({

--- a/test/regression/issue/28181.test.ts
+++ b/test/regression/issue/28181.test.ts
@@ -1,0 +1,132 @@
+import { spawn } from "bun";
+import { afterEach, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+let inspectee: ReturnType<typeof spawn> | undefined;
+
+afterEach(() => {
+  inspectee?.kill();
+  inspectee = undefined;
+});
+
+async function startInspectee(): Promise<URL> {
+  inspectee = spawn({
+    cwd: join(import.meta.dir, "../../cli/inspect"),
+    cmd: [bunExe(), "--inspect=127.0.0.1:0", "inspectee.js"],
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+
+  let stderr = "";
+  const decoder = new TextDecoder();
+  for await (const chunk of inspectee.stderr as ReadableStream) {
+    stderr += decoder.decode(chunk);
+    if (stderr.includes("Listening:")) {
+      break;
+    }
+  }
+
+  const match = stderr.match(/ws:\/\/[^\s\x1b]+/);
+  if (!match) {
+    throw new Error("Unable to find listening URL in stderr: " + stderr);
+  }
+  return new URL(match[0]);
+}
+
+describe("inspector /json endpoints", () => {
+  test("/json/list returns target info with webSocketDebuggerUrl", async () => {
+    const wsUrl = await startInspectee();
+    const httpUrl = `http://${wsUrl.hostname}:${wsUrl.port}`;
+
+    const res = await fetch(`${httpUrl}/json/list`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+
+    const targets = await res.json();
+    expect(targets).toBeArray();
+    expect(targets).toHaveLength(1);
+
+    const target = targets[0];
+    expect(target).toMatchObject({
+      description: "Bun instance",
+      type: "node",
+    });
+    expect(target.webSocketDebuggerUrl).toStartWith("ws://");
+    expect(target.id).toBeString();
+    expect(target.title).toBeString();
+    expect(target.url).toStartWith("file://");
+    expect(target.devtoolsFrontendUrl).toBeString();
+  });
+
+  test("/json returns the same as /json/list", async () => {
+    const wsUrl = await startInspectee();
+    const httpUrl = `http://${wsUrl.hostname}:${wsUrl.port}`;
+
+    const [listRes, jsonRes] = await Promise.all([
+      fetch(`${httpUrl}/json/list`).then(r => r.json()),
+      fetch(`${httpUrl}/json`).then(r => r.json()),
+    ]);
+
+    // Both should have the same structure
+    expect(jsonRes).toHaveLength(1);
+    expect(listRes).toHaveLength(1);
+    expect(jsonRes[0].type).toBe(listRes[0].type);
+    expect(jsonRes[0].description).toBe(listRes[0].description);
+  });
+
+  test("/json/version still works", async () => {
+    const wsUrl = await startInspectee();
+    const httpUrl = `http://${wsUrl.hostname}:${wsUrl.port}`;
+
+    const res = await fetch(`${httpUrl}/json/version`);
+    expect(res.status).toBe(200);
+
+    const version = await res.json();
+    expect(version).toMatchObject({
+      "Protocol-Version": "1.3",
+      "Browser": "Bun",
+    });
+    expect(version["Bun-Version"]).toBeString();
+  });
+
+  test("webSocketDebuggerUrl from /json/list is connectable", async () => {
+    const wsUrl = await startInspectee();
+    const httpUrl = `http://${wsUrl.hostname}:${wsUrl.port}`;
+
+    const res = await fetch(`${httpUrl}/json/list`);
+    const targets = await res.json();
+    const debugUrl = targets[0].webSocketDebuggerUrl;
+
+    // Connect using the discovered URL
+    const ws = new WebSocket(debugUrl);
+
+    const opened = await new Promise<boolean>((resolve, reject) => {
+      ws.addEventListener("open", () => resolve(true));
+      ws.addEventListener("error", () => reject(new Error("WebSocket error")));
+    });
+    expect(opened).toBe(true);
+
+    // Verify we can execute commands over the discovered WebSocket
+    ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "2 + 2" } }));
+
+    const result = await new Promise<any>(resolve => {
+      ws.addEventListener("message", event => {
+        resolve(JSON.parse(String(event.data)));
+      });
+    });
+
+    expect(result).toMatchObject({
+      id: 1,
+      result: {
+        result: {
+          type: "number",
+          value: 4,
+        },
+      },
+    });
+
+    ws.close();
+  });
+});

--- a/test/regression/issue/28181.test.ts
+++ b/test/regression/issue/28181.test.ts
@@ -1,17 +1,9 @@
-import { spawn } from "bun";
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "node:path";
 
-let inspectee: ReturnType<typeof spawn> | undefined;
-
-afterEach(() => {
-  inspectee?.kill();
-  inspectee = undefined;
-});
-
-async function startInspectee(): Promise<URL> {
-  inspectee = spawn({
+async function startInspectee(): Promise<{ proc: ReturnType<typeof Bun.spawn>; wsUrl: URL }> {
+  const proc = Bun.spawn({
     cwd: join(import.meta.dir, "../../cli/inspect"),
     cmd: [bunExe(), "--inspect=127.0.0.1:0", "inspectee.js"],
     env: bunEnv,
@@ -21,7 +13,7 @@ async function startInspectee(): Promise<URL> {
 
   let stderr = "";
   const decoder = new TextDecoder();
-  for await (const chunk of inspectee.stderr as ReadableStream) {
+  for await (const chunk of proc.stderr as ReadableStream) {
     stderr += decoder.decode(chunk);
     if (stderr.includes("Listening:")) {
       break;
@@ -30,14 +22,16 @@ async function startInspectee(): Promise<URL> {
 
   const match = stderr.match(/ws:\/\/[^\s\x1b]+/);
   if (!match) {
+    proc.kill();
     throw new Error("Unable to find listening URL in stderr: " + stderr);
   }
-  return new URL(match[0]);
+  return { proc, wsUrl: new URL(match[0]) };
 }
 
 describe("inspector /json endpoints", () => {
   test("/json/list returns target info with webSocketDebuggerUrl", async () => {
-    const wsUrl = await startInspectee();
+    const { proc, wsUrl } = await startInspectee();
+    await using _ = proc;
     const httpUrl = `http://${wsUrl.hostname}:${wsUrl.port}`;
 
     const res = await fetch(`${httpUrl}/json/list`);
@@ -61,7 +55,8 @@ describe("inspector /json endpoints", () => {
   });
 
   test("/json returns the same as /json/list", async () => {
-    const wsUrl = await startInspectee();
+    const { proc, wsUrl } = await startInspectee();
+    await using _ = proc;
     const httpUrl = `http://${wsUrl.hostname}:${wsUrl.port}`;
 
     const [listRes, jsonRes] = await Promise.all([
@@ -69,15 +64,12 @@ describe("inspector /json endpoints", () => {
       fetch(`${httpUrl}/json`).then(r => r.json()),
     ]);
 
-    // Both should have the same structure
-    expect(jsonRes).toHaveLength(1);
-    expect(listRes).toHaveLength(1);
-    expect(jsonRes[0].type).toBe(listRes[0].type);
-    expect(jsonRes[0].description).toBe(listRes[0].description);
+    expect(jsonRes).toEqual(listRes);
   });
 
   test("/json/version still works", async () => {
-    const wsUrl = await startInspectee();
+    const { proc, wsUrl } = await startInspectee();
+    await using _ = proc;
     const httpUrl = `http://${wsUrl.hostname}:${wsUrl.port}`;
 
     const res = await fetch(`${httpUrl}/json/version`);
@@ -92,7 +84,8 @@ describe("inspector /json endpoints", () => {
   });
 
   test("webSocketDebuggerUrl from /json/list is connectable", async () => {
-    const wsUrl = await startInspectee();
+    const { proc, wsUrl } = await startInspectee();
+    await using _ = proc;
     const httpUrl = `http://${wsUrl.hostname}:${wsUrl.port}`;
 
     const res = await fetch(`${httpUrl}/json/list`);
@@ -112,9 +105,14 @@ describe("inspector /json endpoints", () => {
     ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "2 + 2" } }));
 
     const result = await new Promise<any>(resolve => {
-      ws.addEventListener("message", event => {
-        resolve(JSON.parse(String(event.data)));
-      });
+      const handler = (event: MessageEvent) => {
+        const parsed = JSON.parse(String(event.data));
+        if (parsed.id === 1) {
+          ws.removeEventListener("message", handler);
+          resolve(parsed);
+        }
+      };
+      ws.addEventListener("message", handler);
     });
 
     expect(result).toMatchObject({


### PR DESCRIPTION
## Summary

- Implement the `/json/list` and `/json` HTTP discovery endpoints on the inspector server, matching the Node.js inspector protocol format
- These endpoints were stubbed with a `// TODO?` comment and returned 404, which prevented IDEs like WebStorm from discovering the debug target

IDEs (WebStorm, IntelliJ, etc.) query `/json/list` to discover debuggable targets and obtain the `webSocketDebuggerUrl` before connecting via WebSocket. Without these endpoints, the IDE cannot find the inspector and fails with "Unexpected server response" or similar errors.

The response format matches Node.js's inspector:
```json
[{
  "description": "Bun instance",
  "devtoolsFrontendUrl": "devtools://devtools/bundled/js_app.html?...",
  "id": "<session-id>",
  "title": "<script-path>",
  "type": "node",
  "url": "file://<script-path>",
  "webSocketDebuggerUrl": "ws://<host>:<port>/<id>"
}]
```

Closes #28181

## Test plan

- [x] New test `test/regression/issue/28181.test.ts` verifies:
  - `/json/list` returns 200 with correct target info including `webSocketDebuggerUrl`
  - `/json` returns the same data as `/json/list`
  - `/json/version` continues to work
  - The `webSocketDebuggerUrl` from `/json/list` is actually connectable and can execute inspector commands
- [x] Tests pass with `bun bd test` and fail with `USE_SYSTEM_BUN=1` (confirming the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)