### PR TITLE
fix(napi): guard against null globalObject in deferred finalizer

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -2988,6 +2988,11 @@ extern "C" JSGlobalObject* NapiEnv__globalObject(napi_env env)
     return env->globalObject();
 }
 
+extern "C" bool NapiEnv__canRunFinalizer(napi_env env)
+{
+    return env && env->globalObject() && !env->isVMTerminating();
+}
+
 extern "C" bool NapiEnv__getAndClearPendingException(napi_env env, JSC::EncodedJSValue* exception)
 {
     if (std::optional<JSC::JSValue> pending = env->pendingException()) {

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -56,6 +56,7 @@ pub const NapiEnv = opaque {
     }
 
     extern fn NapiEnv__globalObject(*NapiEnv) *jsc.JSGlobalObject;
+    extern fn NapiEnv__canRunFinalizer(*NapiEnv) bool;
     extern fn NapiEnv__getAndClearPendingException(*NapiEnv, *JSValue) bool;
     extern fn napi_internal_get_version(*NapiEnv) u32;
     extern fn NapiEnv__deref(*NapiEnv) void;
@@ -1369,6 +1370,14 @@ pub const Finalizer = struct {
 
     pub fn run(this: *Finalizer) void {
         const env = this.env.get();
+
+        // Safety check: the env's globalObject may have been destroyed between
+        // when this finalizer was enqueued and when it runs on the JS thread.
+        // This can happen during VM teardown in embedded Bun instances.
+        if (!NapiEnv.NapiEnv__canRunFinalizer(env)) {
+            return;
+        }
+
         const handle_scope = NapiHandleScope.open(env, false);
         defer if (handle_scope) |scope| scope.close(env);
 


### PR DESCRIPTION
## Summary

- Fixes a segfault (null pointer dereference at address `0x40`) in `Finalizer.run()` when a deferred NAPI finalizer executes after the env's `globalObject` has been freed
- Adds `NapiEnv__canRunFinalizer()` C++ function that checks the env pointer, globalObject validity, and VM termination state
- Guards `Finalizer.run()` with this check so it safely returns early instead of crashing

## Root Cause

When a NAPI native module's objects are garbage collected, finalizers are deferred (enqueued as `NapiFinalizerTask` on the event loop) rather than run during GC. Between enqueue and execution, the `NapiEnv`'s `m_globalObject` raw pointer can become stale — particularly during VM teardown in embedded Bun instances. The `NapiEnv` survives via `ExternalShared` ref-counting, but the `globalObject` it points to may already be destroyed, causing a segfault when `NapiHandleScope::open()` dereferences it.

## Test plan

- [x] Debug build compiles successfully (`bun bd`)
- [x] Existing NAPI test suite passes (53/53 non-timeout tests pass; timeouts are pre-existing in debug+ASAN builds)
- [ ] CI passes on all platforms

Fixes #28182

🤖 Generated with [Claude Code](https://claude.com/claude-code)