### PR TITLE
Disable runtime transpiler cache when debugger is active via env var

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1271,11 +1271,18 @@ fn configureDebugger(this: *VirtualMachine, cli_flag: bun.cli.Command.Debugger) 
         },
     }
 
-    if (this.isInspectorEnabled() and this.debugger.?.mode != .connect) {
-        this.transpiler.options.minify_identifiers = false;
-        this.transpiler.options.minify_syntax = false;
-        this.transpiler.options.minify_whitespace = false;
-        this.transpiler.options.debugger = true;
+    if (this.isInspectorEnabled()) {
+        // The runtime transpiler cache does not store inline source maps needed
+        // by the debugger frontend. Disable it so the printer always runs and
+        // generates the inline sourceMappingURL for the inspector.
+        jsc.RuntimeTranspilerCache.is_disabled = true;
+
+        if (this.debugger.?.mode != .connect) {
+            this.transpiler.options.minify_identifiers = false;
+            this.transpiler.options.minify_syntax = false;
+            this.transpiler.options.minify_whitespace = false;
+            this.transpiler.options.debugger = true;
+        }
     }
 }
 

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -838,8 +838,6 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                 Command.Debugger{ .enable = .{
                     .path_or_port = inspect_flag,
                 } };
-
-            bun.jsc.RuntimeTranspilerCache.is_disabled = true;
         } else if (args.option("--inspect-wait")) |inspect_flag| {
             ctx.runtime_options.debugger = if (inspect_flag.len == 0)
                 Command.Debugger{ .enable = .{
@@ -850,8 +848,6 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                     .path_or_port = inspect_flag,
                     .wait_for_connection = true,
                 } };
-
-            bun.jsc.RuntimeTranspilerCache.is_disabled = true;
         } else if (args.option("--inspect-brk")) |inspect_flag| {
             ctx.runtime_options.debugger = if (inspect_flag.len == 0)
                 Command.Debugger{ .enable = .{
@@ -864,8 +860,6 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                     .wait_for_connection = true,
                     .set_breakpoint_on_first_line = true,
                 } };
-
-            bun.jsc.RuntimeTranspilerCache.is_disabled = true;
         }
 
         const cpu_prof_flag = args.flag("--cpu-prof");

--- a/test/regression/issue/28159.test.ts
+++ b/test/regression/issue/28159.test.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+import { readdirSync, mkdirSync } from "fs";
+
+test("runtime transpiler cache is disabled when BUN_INSPECT is set", async () => {
+  // When the debugger is active (via BUN_INSPECT env var), the runtime
+  // transpiler cache must be disabled. The cached output does not contain the
+  // inline //# sourceMappingURL= comment that the debugger frontend needs to
+  // correctly map breakpoint line numbers. Without it, debugger; statements
+  // and breakpoints resolve to the transpiled line instead of the source line.
+  //
+  // See: https://github.com/oven-sh/bun/issues/28159
+
+  // Generate a large TypeScript file (>50KB) to trigger caching.
+  const lines: string[] = [];
+  lines.push("export function run() {");
+  for (let i = 0; i < 700; i++) {
+    lines.push(`  const value_${i}: number = ${i};`);
+    lines.push(`  if (value_${i} !== ${i}) throw new Error("fail");`);
+    lines.push("");
+  }
+  lines.push('  console.log("ok");');
+  lines.push("}");
+  lines.push("run();");
+
+  const largeSource = lines.join("\n");
+  expect(largeSource.length).toBeGreaterThan(50 * 1024);
+
+  using dir = tempDir("issue-28159", {
+    "large_module.ts": largeSource,
+  });
+
+  const cacheDir = join(String(dir), "cache");
+  mkdirSync(cacheDir, { recursive: true });
+
+  // Run with BUN_INSPECT set — the cache should NOT be populated.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "large_module.ts"],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_RUNTIME_TRANSPILER_CACHE_PATH: cacheDir,
+      BUN_INSPECT: "ws+unix:///tmp/bun-inspect-fake-" + Date.now() + ".sock",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+
+  // The cache directory should be empty because the cache was disabled.
+  const cacheFiles = readdirSync(cacheDir);
+  expect(cacheFiles).toEqual([]);
+});

--- a/test/regression/issue/28159.test.ts
+++ b/test/regression/issue/28159.test.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
+import { mkdirSync, readdirSync } from "fs";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
-import { readdirSync, mkdirSync } from "fs";
 
 test("runtime transpiler cache is disabled when BUN_INSPECT is set", async () => {
   // When the debugger is active (via BUN_INSPECT env var), the runtime
@@ -42,19 +42,13 @@ test("runtime transpiler cache is disabled when BUN_INSPECT is set", async () =>
       ...bunEnv,
       BUN_RUNTIME_TRANSPILER_CACHE_PATH: cacheDir,
       BUN_INSPECT:
-        process.platform === "win32"
-          ? "127.0.0.1:0"
-          : "ws+unix:///tmp/bun-inspect-fake-" + Date.now() + ".sock",
+        process.platform === "win32" ? "127.0.0.1:0" : "ws+unix:///tmp/bun-inspect-fake-" + Date.now() + ".sock",
     },
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout.trim()).toBe("ok");
   expect(exitCode).toBe(0);

--- a/test/regression/issue/28159.test.ts
+++ b/test/regression/issue/28159.test.ts
@@ -41,7 +41,10 @@ test("runtime transpiler cache is disabled when BUN_INSPECT is set", async () =>
     env: {
       ...bunEnv,
       BUN_RUNTIME_TRANSPILER_CACHE_PATH: cacheDir,
-      BUN_INSPECT: "ws+unix:///tmp/bun-inspect-fake-" + Date.now() + ".sock",
+      BUN_INSPECT:
+        process.platform === "win32"
+          ? "127.0.0.1:0"
+          : "ws+unix:///tmp/bun-inspect-fake-" + Date.now() + ".sock",
     },
     stdout: "pipe",
     stderr: "pipe",


### PR DESCRIPTION
## Reproduction

When using VSCode's debug terminal (which sets `BUN_INSPECT` environment variable), breakpoints in files over 50KB land at wrong line numbers. The debugger shows line 1494 instead of the expected line 1979 (from issue #28159).

## Root Cause

The runtime transpiler cache (`RuntimeTranspilerCache`) has a 50KB minimum file size threshold. When the cache is hit, the printer step is skipped entirely, and the cached transpiled output is used directly. This cached output does **not** contain the inline `//# sourceMappingURL=data:...` comment that the debugger frontend needs to correctly map breakpoint line numbers.

The `--inspect`/`--inspect-wait`/`--inspect-brk` CLI flags correctly disabled the transpiler cache in `Arguments.zig`. However, when the debugger is configured via the `BUN_INSPECT` environment variable (used by VSCode's debug terminal), the cache was not disabled — the `configureDebugger()` function in `VirtualMachine.zig` did not set `RuntimeTranspilerCache.is_disabled = true`.

## Fix

Move the cache disable into `configureDebugger()` so it runs whenever the inspector is enabled, regardless of how it was activated (CLI flag or environment variable). This ensures the printer always runs and generates the inline source map for the debugger frontend.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28159.test.ts` → **FAILS** (cache file is created with `BUN_INSPECT` set)
- `bun bd test test/regression/issue/28159.test.ts` → **PASSES** (cache is disabled when inspector is enabled)

Closes #28159

---

Verified by robobun: CI build #39802 still in progress (all cpp builds passed, zig builds pending); previous build #39801 failures were unrelated vendored code warnings (libuv/tinycc) and infra issues. Diff is clean — no TODO/FIXME/HACK. Single Zig line adds `RuntimeTranspilerCache.is_disabled = true` inside `configureDebugger()` (already done in Arguments.zig for CLI flags, this closes the BUN_INSPECT env var gap). Test in test/regression/issue/28159.test.ts generates a >50KB TS file, runs with BUN_INSPECT + BUN_RUNTIME_TRANSPILER_CACHE_PATH, and asserts the cache dir stays empty — this would fail on main where the env var path did not disable caching. CodeRabbit's Windows cross-platform feedback was addressed in commit 1ccb921. No unresolved review threads.