### PR TITLE
fix(node:test): default to no timeout to match Node.js semantics

### DIFF
--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -304,14 +304,26 @@ function createTest(arg0: unknown, arg1: unknown, arg2: unknown) {
   checkNotInsideTest(ctx, "test");
   const context = new TestContext(true, name, Bun.main, ctx);
 
-  const runTest = async () => {
+  // Use a zero-parameter wrapper to avoid bun:test detecting a done-callback
+  // (fn.length >= 1 triggers done-callback mode). Preserve sync/async behavior:
+  // if fn() returns a Promise, chain context restoration via .then/.catch;
+  // if fn() is sync, restore context immediately.
+  const runTest = () => {
     const originalContext = ctx;
     ctx = context;
+    let result: unknown;
     try {
-      await fn(context);
-    } finally {
+      result = fn(context);
+    } catch (error) {
       ctx = originalContext;
+      throw error;
     }
+    if (result instanceof Promise) {
+      return (result as Promise<unknown>).finally(() => {
+        ctx = originalContext;
+      });
+    }
+    ctx = originalContext;
   };
 
   // Node.js node:test has no default timeout — only apply timeout: 0 (unlimited)
@@ -365,9 +377,11 @@ function parseHookOptions(arg0: unknown, arg1: unknown) {
 function createHook(arg0: unknown, arg1: unknown) {
   const { fn, options } = parseHookOptions(arg0, arg1);
 
-  const runHook = async () => {
-    await fn();
-  };
+  // Use a zero-parameter wrapper to avoid bun:test detecting a done-callback
+  // (fn.length >= 1 triggers done-callback mode). Preserve sync/async behavior
+  // by returning the result directly — if fn() returns a Promise, the wrapper
+  // returns a Promise; if fn() is sync, the wrapper is sync.
+  const runHook = () => fn();
 
   // Node.js node:test has no default timeout — only apply timeout: 0 (unlimited)
   // when the user hasn't explicitly set one via node:test options.

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -117,25 +117,25 @@ class TestContext {
   before(arg0: unknown, arg1: unknown) {
     const { fn, options } = createHook(arg0, arg1);
     const { beforeAll } = bunTest();
-    beforeAll(fn, { timeout: options.timeout ?? 0 });
+    beforeAll(fn, options);
   }
 
   after(arg0: unknown, arg1: unknown) {
     const { fn, options } = createHook(arg0, arg1);
     const { afterAll } = bunTest();
-    afterAll(fn, { timeout: options.timeout ?? 0 });
+    afterAll(fn, options);
   }
 
   beforeEach(arg0: unknown, arg1: unknown) {
     const { fn, options } = createHook(arg0, arg1);
     const { beforeEach } = bunTest();
-    beforeEach(fn, { timeout: options.timeout ?? 0 });
+    beforeEach(fn, options);
   }
 
   afterEach(arg0: unknown, arg1: unknown) {
     const { fn, options } = createHook(arg0, arg1);
     const { afterEach } = bunTest();
-    afterEach(fn, { timeout: options.timeout ?? 0 });
+    afterEach(fn, options);
   }
 
   waitFor(_condition: unknown, _options: { timeout?: number } = kEmptyObject) {
@@ -239,25 +239,25 @@ test.only = function (arg0: unknown, arg1: unknown, arg2: unknown) {
 function before(arg0: unknown, arg1: unknown) {
   const { fn, options } = createHook(arg0, arg1);
   const { beforeAll } = bunTest();
-  beforeAll(fn, { timeout: options.timeout ?? 0 });
+  beforeAll(fn, options);
 }
 
 function after(arg0: unknown, arg1: unknown) {
   const { fn, options } = createHook(arg0, arg1);
   const { afterAll } = bunTest();
-  afterAll(fn, { timeout: options.timeout ?? 0 });
+  afterAll(fn, options);
 }
 
 function beforeEach(arg0: unknown, arg1: unknown) {
   const { fn, options } = createHook(arg0, arg1);
   const { beforeEach } = bunTest();
-  beforeEach(fn, { timeout: options.timeout ?? 0 });
+  beforeEach(fn, options);
 }
 
 function afterEach(arg0: unknown, arg1: unknown) {
   const { fn, options } = createHook(arg0, arg1);
   const { afterEach } = bunTest();
-  afterEach(fn, { timeout: options.timeout ?? 0 });
+  afterEach(fn, options);
 }
 
 function parseTestOptions(arg0: unknown, arg1: unknown, arg2: unknown) {
@@ -304,34 +304,20 @@ function createTest(arg0: unknown, arg1: unknown, arg2: unknown) {
   checkNotInsideTest(ctx, "test");
   const context = new TestContext(true, name, Bun.main, ctx);
 
-  const runTest = (done: (error?: unknown) => void) => {
+  const runTest = async () => {
     const originalContext = ctx;
     ctx = context;
-    const endTest = (error?: unknown) => {
-      try {
-        done(error);
-      } finally {
-        ctx = originalContext;
-      }
-    };
-
-    let result: unknown;
     try {
-      result = fn(context);
-    } catch (error) {
-      endTest(error);
-      return;
-    }
-    if (result instanceof Promise) {
-      (result as Promise<unknown>).then(() => endTest()).catch(error => endTest(error));
-    } else {
-      endTest();
+      await fn(context);
+    } finally {
+      ctx = originalContext;
     }
   };
 
-  // Node.js node:test has no default timeout, so default to 0 (no timeout)
-  // to avoid inheriting bun:test's 5s default when using done-callback wrapper.
-  return { name, options: { ...options, timeout: options.timeout ?? 0 }, fn: runTest };
+  // Node.js node:test has no default timeout — only apply timeout: 0 (unlimited)
+  // when the user hasn't explicitly set one via node:test options.
+  const testOptions = options.timeout !== undefined ? options : { ...options, timeout: 0 };
+  return { name, options: testOptions, fn: runTest };
 }
 
 function createDescribe(arg0: unknown, arg1: unknown, arg2: unknown) {
@@ -379,22 +365,14 @@ function parseHookOptions(arg0: unknown, arg1: unknown) {
 function createHook(arg0: unknown, arg1: unknown) {
   const { fn, options } = parseHookOptions(arg0, arg1);
 
-  const runHook = (done: (error?: unknown) => void) => {
-    let result: unknown;
-    try {
-      result = fn();
-    } catch (error) {
-      done(error);
-      return;
-    }
-    if (result instanceof Promise) {
-      (result as Promise<unknown>).then(() => done()).catch(error => done(error));
-    } else {
-      done();
-    }
+  const runHook = async () => {
+    await fn();
   };
 
-  return { options, fn: runHook };
+  // Node.js node:test has no default timeout — only apply timeout: 0 (unlimited)
+  // when the user hasn't explicitly set one via node:test options.
+  const hookOptions = options.timeout !== undefined ? options : { ...options, timeout: 0 };
+  return { options: hookOptions, fn: runHook };
 }
 
 type TestFn = (ctx: TestContext) => unknown | Promise<unknown>;

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -286,7 +286,7 @@ function parseTestOptions(arg0: unknown, arg1: unknown, arg2: unknown) {
       fn = arg1 as TestFn;
       options = kDefaultOptions;
     } else {
-      fn = kDefaultFunction;
+      fn = typeof arg2 === "function" ? (arg2 as TestFn) : kDefaultFunction;
       options = kDefaultOptions;
     }
   } else {

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -115,27 +115,27 @@ class TestContext {
   }
 
   before(arg0: unknown, arg1: unknown) {
-    const { fn } = createHook(arg0, arg1);
+    const { fn, options } = createHook(arg0, arg1);
     const { beforeAll } = bunTest();
-    beforeAll(fn);
+    beforeAll(fn, { timeout: options.timeout ?? 0 });
   }
 
   after(arg0: unknown, arg1: unknown) {
-    const { fn } = createHook(arg0, arg1);
+    const { fn, options } = createHook(arg0, arg1);
     const { afterAll } = bunTest();
-    afterAll(fn);
+    afterAll(fn, { timeout: options.timeout ?? 0 });
   }
 
   beforeEach(arg0: unknown, arg1: unknown) {
-    const { fn } = createHook(arg0, arg1);
+    const { fn, options } = createHook(arg0, arg1);
     const { beforeEach } = bunTest();
-    beforeEach(fn);
+    beforeEach(fn, { timeout: options.timeout ?? 0 });
   }
 
   afterEach(arg0: unknown, arg1: unknown) {
-    const { fn } = createHook(arg0, arg1);
+    const { fn, options } = createHook(arg0, arg1);
     const { afterEach } = bunTest();
-    afterEach(fn);
+    afterEach(fn, { timeout: options.timeout ?? 0 });
   }
 
   waitFor(_condition: unknown, _options: { timeout?: number } = kEmptyObject) {
@@ -149,13 +149,13 @@ class TestContext {
 
     const { test } = bunTest();
     if (options.only) {
-      test.only(name, fn);
+      test.only(name, fn, options);
     } else if (options.todo) {
-      test.todo(name, fn);
+      test.todo(name, fn, options);
     } else if (options.skip) {
-      test.skip(name, fn);
+      test.skip(name, fn, options);
     } else {
-      test(name, fn);
+      test(name, fn, options);
     }
   }
 
@@ -237,27 +237,27 @@ test.only = function (arg0: unknown, arg1: unknown, arg2: unknown) {
 };
 
 function before(arg0: unknown, arg1: unknown) {
-  const { fn } = createHook(arg0, arg1);
+  const { fn, options } = createHook(arg0, arg1);
   const { beforeAll } = bunTest();
-  beforeAll(fn);
+  beforeAll(fn, { timeout: options.timeout ?? 0 });
 }
 
 function after(arg0: unknown, arg1: unknown) {
-  const { fn } = createHook(arg0, arg1);
+  const { fn, options } = createHook(arg0, arg1);
   const { afterAll } = bunTest();
-  afterAll(fn);
+  afterAll(fn, { timeout: options.timeout ?? 0 });
 }
 
 function beforeEach(arg0: unknown, arg1: unknown) {
-  const { fn } = createHook(arg0, arg1);
+  const { fn, options } = createHook(arg0, arg1);
   const { beforeEach } = bunTest();
-  beforeEach(fn);
+  beforeEach(fn, { timeout: options.timeout ?? 0 });
 }
 
 function afterEach(arg0: unknown, arg1: unknown) {
-  const { fn } = createHook(arg0, arg1);
+  const { fn, options } = createHook(arg0, arg1);
   const { afterEach } = bunTest();
-  afterEach(fn);
+  afterEach(fn, { timeout: options.timeout ?? 0 });
 }
 
 function parseTestOptions(arg0: unknown, arg1: unknown, arg2: unknown) {
@@ -329,7 +329,9 @@ function createTest(arg0: unknown, arg1: unknown, arg2: unknown) {
     }
   };
 
-  return { name, options, fn: runTest };
+  // Node.js node:test has no default timeout, so default to 0 (no timeout)
+  // to avoid inheriting bun:test's 5s default when using done-callback wrapper.
+  return { name, options: { ...options, timeout: options.timeout ?? 0 }, fn: runTest };
 }
 
 function createDescribe(arg0: unknown, arg1: unknown, arg2: unknown) {

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -268,14 +268,14 @@ function parseTestOptions(arg0: unknown, arg1: unknown, arg2: unknown) {
   if (typeof arg0 === "function") {
     name = arg0.name || kDefaultName;
     fn = arg0 as TestFn;
-    if (typeof arg1 === "object") {
+    if (typeof arg1 === "object" && arg1 !== null) {
       options = arg1 as TestOptions;
     } else {
       options = kDefaultOptions;
     }
   } else if (typeof arg0 === "string") {
     name = arg0;
-    if (typeof arg1 === "object") {
+    if (typeof arg1 === "object" && arg1 !== null) {
       options = arg1 as TestOptions;
       if (typeof arg2 === "function") {
         fn = arg2 as TestFn;
@@ -353,7 +353,7 @@ function parseHookOptions(arg0: unknown, arg1: unknown) {
     fn = kDefaultFunction;
   }
 
-  if (typeof arg1 === "object") {
+  if (typeof arg1 === "object" && arg1 !== null) {
     options = arg1 as HookOptions;
   } else {
     options = kDefaultOptions;

--- a/test/regression/issue/28190.test.ts
+++ b/test/regression/issue/28190.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 test("node:test async tests should not time out with default 5s timeout", async () => {

--- a/test/regression/issue/28190.test.ts
+++ b/test/regression/issue/28190.test.ts
@@ -113,3 +113,30 @@ it('test with explicit timeout', { timeout: 1000 }, async () => {
   expect(output).toContain("timed out");
   expect(exitCode).not.toBe(0);
 }, 15_000);
+
+test("node:test explicit per-test timeout overrides default no-timeout", async () => {
+  using dir = tempDir("28190", {
+    "test.test.mjs": `
+import { it } from 'node:test';
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+it('fast test with explicit timeout', { timeout: 2000 }, async () => {
+  await sleep(500);
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "test.test.mjs"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const output = stdout + stderr;
+  expect(output).toContain("pass");
+  expect(output).not.toContain("timed out");
+  expect(exitCode).toBe(0);
+}, 15_000);

--- a/test/regression/issue/28190.test.ts
+++ b/test/regression/issue/28190.test.ts
@@ -1,0 +1,115 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("node:test async tests should not time out with default 5s timeout", async () => {
+  using dir = tempDir("28190", {
+    "test.test.mjs": `
+import { it } from 'node:test';
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+it('long async test', async () => {
+  await sleep(6000);
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "test.test.mjs"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const output = stdout + stderr;
+  expect(output).not.toContain("timed out");
+  expect(output).toContain("pass");
+  expect(exitCode).toBe(0);
+}, 15_000);
+
+test("node:test before hook should not time out with default 5s timeout", async () => {
+  using dir = tempDir("28190", {
+    "test.test.mjs": `
+import { it, before } from 'node:test';
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+before(async () => {
+  await sleep(6000);
+});
+it('test after long before hook', async () => {
+  // pass
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "test.test.mjs"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const output = stdout + stderr;
+  expect(output).not.toContain("timed out");
+  expect(output).toContain("pass");
+  expect(exitCode).toBe(0);
+}, 15_000);
+
+test("node:test afterEach hook should not time out with default 5s timeout", async () => {
+  using dir = tempDir("28190", {
+    "test.test.mjs": `
+import { it, afterEach } from 'node:test';
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+afterEach(async () => {
+  await sleep(6000);
+});
+it('test with long afterEach hook', async () => {
+  // pass
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "test.test.mjs"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const output = stdout + stderr;
+  expect(output).not.toContain("timed out");
+  expect(output).toContain("pass");
+  expect(exitCode).toBe(0);
+}, 15_000);
+
+test("node:test explicit timeout should still be respected", async () => {
+  using dir = tempDir("28190", {
+    "test.test.mjs": `
+import { it } from 'node:test';
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+it('test with explicit timeout', { timeout: 1000 }, async () => {
+  await sleep(3000);
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "test.test.mjs"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const output = stdout + stderr;
+  expect(output).toContain("timed out");
+  expect(exitCode).not.toBe(0);
+}, 15_000);


### PR DESCRIPTION
## Summary

Fixes #28190.

- **`node:test` tests and hooks** wrapped user functions with a `(done) => {}` callback pattern, causing `bun:test` to interpret them as done-callback-style tests and apply its 5-second default timeout
- Node.js's `node:test` has **no default timeout** — tests and hooks run until completion
- Fixed by defaulting `timeout: 0` (no timeout) for both `createTest` and `createHook` when no explicit timeout is provided
- Hook functions (`before`, `after`, `beforeEach`, `afterEach`) now forward timeout options to the underlying `bun:test` hook functions (previously options were silently dropped)
- `TestContext.test()` now passes options to `bun:test` (previously only standalone `test()` did)

## Test plan

- [x] New regression test `test/regression/issue/28190.test.ts` covers:
  - Async test exceeding 5s completes without timeout
  - `before` hook exceeding 5s completes without timeout
  - `afterEach` hook exceeding 5s completes without timeout
  - Explicit `{ timeout: 1000 }` is still respected
- [x] Test fails with `USE_SYSTEM_BUN=1` (reproduces the bug)
- [x] Test passes with `bun bd test` (fix works)
- [x] Existing `test/js/node/test` tests still pass
- [x] Related regression test `test/regression/issue/23133.test.ts` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Verification (robobun): Format and Lint CI passed. BuildKite compilation/test jobs still pending at time of review — changes are JS-only (src/js/node/test.ts) so compilation risk is minimal. Diff is clean: no TODO/FIXME/HACK markers. CodeRabbit null-guard concern was addressed with arg1 !== null in parseTestOptions/parseHookOptions. Regression test exercises 6s sleeps exceeding the old 5s default timeout for tests, before hooks, and afterEach hooks, plus validates explicit per-test timeouts still work. The timeout: 0 override of --timeout CLI is intentional — matches Node.js semantics where node:test has no global timeout.