### PR TITLE
Warn and continue when security scanner fails instead of silently exiting

### DIFF
--- a/src/install/PackageManager/install_with_manager.zig
+++ b/src/install/PackageManager/install_with_manager.zig
@@ -640,15 +640,18 @@ pub fn installWithManager(
             const is_subcommand_to_run_scanner = manager.subcommand == .add or manager.subcommand == .update or manager.subcommand == .install or manager.subcommand == .remove;
 
             if (is_subcommand_to_run_scanner) {
-                if (security_scanner.performSecurityScanAfterResolution(manager, ctx, original_cwd) catch |err| {
+                if (security_scanner.performSecurityScanAfterResolution(manager, ctx, original_cwd) catch |err| blk: {
                     switch (err) {
                         error.SecurityScannerInWorkspace => {
                             Output.pretty("<red>Security scanner cannot be a dependency of a workspace package. It must be a direct dependency of the root package.<r>\n", .{});
+                            Global.exit(1);
                         },
-                        else => {},
+                        else => {
+                            Output.warn("Security scanner failed to run: {s}. Continuing installation without security scan.\n", .{@errorName(err)});
+                        },
                     }
 
-                    Global.exit(1);
+                    break :blk @as(?security_scanner.SecurityScanResults, null);
                 }) |results| {
                     defer {
                         var results_mut = results;

--- a/src/install/PackageManager/security_scanner.zig
+++ b/src/install/PackageManager/security_scanner.zig
@@ -183,7 +183,14 @@ pub fn performSecurityScanAfterResolution(manager: *PackageManager, command_ctx:
             const retry_result = try attemptSecurityScanWithRetry(manager, security_scanner, scan_all, command_ctx, original_cwd, true);
             switch (retry_result) {
                 .success => |scan_results| return scan_results,
-                else => return error.SecurityScannerRetryFailed,
+                .needs_install => {
+                    Output.errGeneric("Security scanner '{s}' still could not be loaded after installation. It may have unmet dependencies.", .{security_scanner});
+                    return error.SecurityScannerRetryFailed;
+                },
+                .@"error" => |retry_err| {
+                    Output.errGeneric("Security scanner '{s}' failed after installation: {s}", .{ security_scanner, @errorName(retry_err) });
+                    return error.SecurityScannerRetryFailed;
+                },
             }
         },
         .@"error" => |err| return err,
@@ -750,7 +757,10 @@ pub const SecurityScanSubprocess = struct {
 
         // fd 3 output pipe: bun.sys.pipe() + .pipe (inherit_fd) on both platforms.
         const ipc_output_fds = switch (bun.sys.pipe()) {
-            .err => return error.IPCPipeFailed,
+            .err => {
+                Output.errGeneric("Failed to create IPC pipe for security scanner", .{});
+                return error.IPCPipeFailed;
+            },
             .result => |fds| fds,
         };
 
@@ -906,7 +916,10 @@ pub const SecurityScanSubprocess = struct {
         }
 
         switch (process.watchOrReap()) {
-            .err => return error.ProcessWatchFailed,
+            .err => {
+                Output.errGeneric("Failed to watch security scanner process", .{});
+                return error.ProcessWatchFailed;
+            },
             .result => {},
         }
     }

--- a/test/regression/issue/28193.test.ts
+++ b/test/regression/issue/28193.test.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("bun install warns and continues when security scanner is unavailable", async () => {
+  using dir = tempDir("issue-28193", {
+    "package.json": JSON.stringify({
+      name: "test-28193",
+      dependencies: {
+        "is-even": "1.0.0",
+      },
+    }),
+    "bunfig.toml": `[install.security]\nscanner = "@nonexistent-scanner/does-not-exist"\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: String(dir) + "/.cache" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The install should succeed (exit code 0) even though the scanner is unavailable
+  expect(stderr).toContain("Continuing installation without security scan");
+  expect(exitCode).toBe(0);
+});
+
+test("bun install silently exits with code 1 when scanner fails (old behavior check)", async () => {
+  // When the scanner is a devDependency that can't be loaded,
+  // the install should still complete with a warning
+  using dir = tempDir("issue-28193-devdep", {
+    "package.json": JSON.stringify({
+      name: "test-28193-devdep",
+      devDependencies: {
+        "is-even": "1.0.0",
+      },
+    }),
+    "bunfig.toml": `[install.security]\nscanner = "is-even"\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: String(dir) + "/.cache" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The install should succeed (exit code 0) even though the scanner module is invalid
+  // (is-even is not a valid security scanner - it won't have the right exports)
+  expect(stderr).toContain("Continuing installation without security scan");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/28193.test.ts
+++ b/test/regression/issue/28193.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 test("bun install warns and continues when security scanner is unavailable", async () => {


### PR DESCRIPTION
## Reproduction

When a security scanner is configured in `bunfig.toml` via `[install.security]`, and the scanner package can't be loaded (e.g., it's a devDependency being installed for the first time in CI), `bun install` silently exits with code 1. No error message is printed.

```toml
[install.security]
scanner = "@bun-security-scanner/osv"
```

```
bun install v1.3.10 (30e609e0)
Resolving dependencies
Resolved, downloaded and extracted [6]
Error: Process completed with exit code 1.
```

## Root Cause

In `install_with_manager.zig`, the catch handler for security scanner errors had an empty `else => {}` branch that swallowed all errors, immediately followed by `Global.exit(1)`. Only `SecurityScannerInWorkspace` printed a message; all other scanner failures were completely silent.

Additionally, several error paths in `security_scanner.zig` (`IPCPipeFailed`, `ProcessWatchFailed`, `SecurityScannerRetryFailed`) returned errors without printing any diagnostic message.

## Fix

- **install_with_manager.zig**: The catch handler now warns and continues installation for non-fatal scanner errors instead of calling `Global.exit(1)`. `SecurityScannerInWorkspace` remains a hard error since it's a user configuration mistake.
- **security_scanner.zig**: Added error messages to previously silent error paths so users always see what went wrong.

This matches the expected behavior described in #28193: gracefully skip the scanner when it's unavailable and proceed with installation.

## Verification

```
# System bun (no fix) — both tests FAIL (silent exit with code 1)
USE_SYSTEM_BUN=1 bun test test/regression/issue/28193.test.ts

# Debug build (with fix) — both tests PASS (warns and continues)
bun bd test test/regression/issue/28193.test.ts
```

Closes #28193