### PR TITLE
fix(cli): terminate child processes on Ctrl+C with `--parallel` on Windows

### DIFF
--- a/src/cli/filter_run.zig
+++ b/src/cli/filter_run.zig
@@ -371,25 +371,37 @@ const State = struct {
 };
 
 const AbortHandler = struct {
-    const This = @This();
+    /// Accessed atomically because the Windows ctrl handler runs on a separate thread.
+    var should_abort: bool = false;
 
-    var should_abort = false;
+    /// On Windows, a reference to the uv event loop so the ctrl handler can wake it.
+    var uv_loop: if (Environment.isWindows) ?*bun.windows.libuv.Loop else void =
+        if (Environment.isWindows) null else {};
+
+    fn shouldAbort() bool {
+        return @atomicLoad(bool, &should_abort, .acquire);
+    }
 
     fn posixSignalHandler(sig: i32, info: *const std.posix.siginfo_t, _: ?*const anyopaque) callconv(.c) void {
         _ = sig;
         _ = info;
-        should_abort = true;
+        @atomicStore(bool, &should_abort, true, .release);
     }
 
     fn windowsCtrlHandler(dwCtrlType: std.os.windows.DWORD) callconv(.winapi) std.os.windows.BOOL {
         if (dwCtrlType == std.os.windows.CTRL_C_EVENT) {
-            should_abort = true;
+            @atomicStore(bool, &should_abort, true, .release);
+            // Wake the event loop so the main thread can observe the abort flag.
+            // uv_async_send is thread-safe and designed for cross-thread wakeups.
+            if (uv_loop) |loop| {
+                loop.wakeup();
+            }
             return std.os.windows.TRUE;
         }
         return std.os.windows.FALSE;
     }
 
-    pub fn install() void {
+    pub fn install(event_loop: *bun.jsc.MiniEventLoop) void {
         if (Environment.isPosix) {
             const action = std.posix.Sigaction{
                 .handler = .{ .sigaction = AbortHandler.posixSignalHandler },
@@ -398,6 +410,7 @@ const AbortHandler = struct {
             };
             std.posix.sigaction(std.posix.SIG.INT, &action, null);
         } else {
+            uv_loop = event_loop.loop.uv_loop;
             const res = bun.c.SetConsoleCtrlHandler(windowsCtrlHandler, std.os.windows.TRUE);
             if (res == 0) {
                 if (Environment.isDebug) {
@@ -634,10 +647,10 @@ pub fn runScriptsWithFilter(ctx: Command.Context) !noreturn {
         }
     }
 
-    AbortHandler.install();
+    AbortHandler.install(event_loop);
 
     while (!state.isDone()) {
-        if (AbortHandler.should_abort and !state.aborted) {
+        if (AbortHandler.shouldAbort() and !state.aborted) {
             // We uninstall the custom abort handler so that if the user presses Ctrl+C again,
             // the process is aborted immediately and doesn't wait for the event loop to tick.
             // This can be useful if one of the processes is stuck and doesn't react to SIGINT.

--- a/src/cli/multi_run.zig
+++ b/src/cli/multi_run.zig
@@ -349,23 +349,37 @@ const State = struct {
 };
 
 const AbortHandler = struct {
-    var should_abort = false;
+    /// Accessed atomically because the Windows ctrl handler runs on a separate thread.
+    var should_abort: bool = false;
+
+    /// On Windows, a reference to the uv event loop so the ctrl handler can wake it.
+    var uv_loop: if (Environment.isWindows) ?*bun.windows.libuv.Loop else void =
+        if (Environment.isWindows) null else {};
+
+    fn shouldAbort() bool {
+        return @atomicLoad(bool, &should_abort, .acquire);
+    }
 
     fn posixSignalHandler(sig: i32, info: *const std.posix.siginfo_t, _: ?*const anyopaque) callconv(.c) void {
         _ = sig;
         _ = info;
-        should_abort = true;
+        @atomicStore(bool, &should_abort, true, .release);
     }
 
     fn windowsCtrlHandler(dwCtrlType: std.os.windows.DWORD) callconv(.winapi) std.os.windows.BOOL {
         if (dwCtrlType == std.os.windows.CTRL_C_EVENT) {
-            should_abort = true;
+            @atomicStore(bool, &should_abort, true, .release);
+            // Wake the event loop so the main thread can observe the abort flag.
+            // uv_async_send is thread-safe and designed for cross-thread wakeups.
+            if (uv_loop) |loop| {
+                loop.wakeup();
+            }
             return std.os.windows.TRUE;
         }
         return std.os.windows.FALSE;
     }
 
-    pub fn install() void {
+    pub fn install(event_loop: *bun.jsc.MiniEventLoop) void {
         if (Environment.isPosix) {
             const action = std.posix.Sigaction{
                 .handler = .{ .sigaction = AbortHandler.posixSignalHandler },
@@ -374,6 +388,7 @@ const AbortHandler = struct {
             };
             std.posix.sigaction(std.posix.SIG.INT, &action, null);
         } else {
+            uv_loop = event_loop.loop.uv_loop;
             const res = bun.c.SetConsoleCtrlHandler(windowsCtrlHandler, std.os.windows.TRUE);
             if (res == 0) {
                 if (Environment.isDebug) {
@@ -806,10 +821,10 @@ pub fn run(ctx: Command.Context) !noreturn {
         }
     }
 
-    AbortHandler.install();
+    AbortHandler.install(event_loop);
 
     while (!state.isDone()) {
-        if (AbortHandler.should_abort and !state.aborted) {
+        if (AbortHandler.shouldAbort() and !state.aborted) {
             AbortHandler.uninstall();
             state.abort();
         }


### PR DESCRIPTION
## Summary

- Fix `bun --parallel` and `bun --filter` not terminating child processes when pressing Ctrl+C on Windows
- The `should_abort` flag was a plain `bool` accessed from both the main thread and the Windows console ctrl handler thread (which runs on a separate OS thread), causing a data race where the main thread might never observe the flag
- The libuv event loop could be blocked on IOCP in `tickOnce` with no mechanism to wake it after the flag was set
- Use atomic load/store for the flag and call `uv_async_send` via `loop.wakeup()` from the ctrl handler to unblock the event loop

## Test plan

- [x] Existing `multi-run.test.ts` abort tests pass (116/118 pass; 2 timeout in debug build due to slowness, pass with `--timeout 30000`)
- [ ] Manual verification on Windows: run `bun --parallel` with long-running scripts, press Ctrl+C, verify child processes are terminated

Fixes #28197

🤖 Generated with [Claude Code](https://claude.com/claude-code)