### PR TITLE
deflake hot.test.ts: fix duplicate error handling and buffer management

### DIFF
--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -512,7 +512,7 @@ throw new Error('0');`,
     });
     const reloadCounter = await driveErrorReloadCycle(runner, {
       targetCount: 50,
-      onReload: (counter) => {
+      onReload: counter => {
         writeFileSync(
           hotRunnerRoot,
           `// source content
@@ -567,7 +567,7 @@ throw new Error('0');`,
     const reloadCounter = await Promise.race([
       driveErrorReloadCycle(runner, {
         targetCount: 50,
-        onReload: (counter) => {
+        onReload: counter => {
           writeFileSync(
             bundleIn,
             `// source content
@@ -648,7 +648,7 @@ throw new Error('0');`,
     const reloadCounter = await Promise.race([
       driveErrorReloadCycle(runner, {
         targetCount: 50,
-        onReload: (counter) => {
+        onReload: counter => {
           writeFileSync(
             bundleIn,
             `// ${long_comment}

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -72,6 +72,11 @@ async function driveErrorReloadCycle(
 
       reloadCounter++;
       triggered = true;
+
+      if (reloadCounter >= targetCount) {
+        runner.kill();
+        return reloadCounter;
+      }
     }
 
     if (triggered) {
@@ -561,25 +566,30 @@ throw new Error('0');`,
       stderr: "pipe",
       stdin: "ignore",
     });
-    const reloadCounter = await driveErrorReloadCycle(runner, {
-      targetCount: 50,
-      onReload: (counter, nonce) => {
-        writeFileSync(
-          bundleIn,
-          `// source content /*nonce:${nonce}*/
+    const reloadCounter = await Promise.race([
+      driveErrorReloadCycle(runner, {
+        targetCount: 50,
+        onReload: (counter, nonce) => {
+          writeFileSync(
+            bundleIn,
+            `// source content /*nonce:${nonce}*/
 // etc etc
 // etc etc
 ${" ".repeat(counter * 2)}throw new Error(${counter});`,
-        );
-      },
-      verifyLine: (_errorLine, nextLine, counter) => {
-        expect(nextLine).toInclude("bundle_in.ts");
-        const match = nextLine!.match(/\s*at.*?:4:(\d+)$/);
-        if (!match) throw new Error("invalid stack trace: " + nextLine);
-        const col = match[1];
-        expect(Number(col)).toBe(1 + "throw ".length + counter * 2);
-      },
-    });
+          );
+        },
+        verifyLine: (_errorLine, nextLine, counter) => {
+          expect(nextLine).toInclude("bundle_in.ts");
+          const match = nextLine!.match(/\s*at.*?:4:(\d+)$/);
+          if (!match) throw new Error("invalid stack trace: " + nextLine);
+          const col = match[1];
+          expect(Number(col)).toBe(1 + "throw ".length + counter * 2);
+        },
+      }),
+      bundler.exited.then((code) => {
+        throw new Error(`bundler exited early with code ${code}`);
+      }),
+    ]);
     expect(reloadCounter).toBe(50);
     bundler.kill();
   },
@@ -633,25 +643,30 @@ throw new Error('0');`,
       stderr: "pipe",
       stdin: "ignore",
     });
-    const reloadCounter = await driveErrorReloadCycle(runner, {
-      targetCount: 50,
-      onReload: (counter, nonce) => {
-        writeFileSync(
-          bundleIn,
-          `// ${long_comment} /*nonce:${nonce}*/
+    const reloadCounter = await Promise.race([
+      driveErrorReloadCycle(runner, {
+        targetCount: 50,
+        onReload: (counter, nonce) => {
+          writeFileSync(
+            bundleIn,
+            `// ${long_comment} /*nonce:${nonce}*/
 console.error("RSS: %s", process.memoryUsage().rss);
 //
 ${" ".repeat(counter * 2)}throw new Error(${counter});`,
-        );
-      },
-      verifyLine: (_errorLine, nextLine, counter) => {
-        expect(nextLine).toInclude("bundle_in.ts");
-        const match = nextLine!.match(/\s*at.*?:4:(\d+)$/);
-        if (!match) throw new Error("invalid stack trace: " + nextLine);
-        const col = match[1];
-        expect(Number(col)).toBe(1 + "throw ".length + counter * 2);
-      },
-    });
+          );
+        },
+        verifyLine: (_errorLine, nextLine, counter) => {
+          expect(nextLine).toInclude("bundle_in.ts");
+          const match = nextLine!.match(/\s*at.*?:4:(\d+)$/);
+          if (!match) throw new Error("invalid stack trace: " + nextLine);
+          const col = match[1];
+          expect(Number(col)).toBe(1 + "throw ".length + counter * 2);
+        },
+      }),
+      bundler.exited.then((code) => {
+        throw new Error(`bundler exited early with code ${code}`);
+      }),
+    ]);
     expect(reloadCounter).toBe(50);
     bundler.kill();
     await runner.exited;

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -54,9 +54,12 @@ async function driveErrorReloadCycle(
       // taken effect yet. Re-save with a new nonce to force a watcher event,
       // then skip to reading the next chunk.
       if (line.includes(`error: ${reloadCounter - 1}`)) {
-        // Put remaining unprocessed lines back into str so they aren't lost
+        // Put remaining unprocessed lines back into str so they aren't lost.
+        // Always keep a trailing \n so the next chunk starts a new logical line.
         const remaining = lines.slice(i + 1).join("\n");
-        str = remaining ? (str ? `${remaining}\n${str}` : remaining) : str;
+        if (remaining) {
+          str = `${remaining}\n${str}`;
+        }
         nonce++;
         onReload(reloadCounter, nonce);
         break;

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -590,7 +590,9 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
           const col = match[1];
           expect(Number(col)).toBe(1 + "throw ".length + counter * 2);
         },
-      }).finally(() => { done = true; }),
+      }).finally(() => {
+        done = true;
+      }),
       bundler.exited.then(code => {
         if (!done) throw new Error(`bundler exited early with code ${code}`);
         return -1; // Ignored — race already resolved
@@ -669,7 +671,9 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
           const col = match[1];
           expect(Number(col)).toBe(1 + "throw ".length + counter * 2);
         },
-      }).finally(() => { done2 = true; }),
+      }).finally(() => {
+        done2 = true;
+      }),
       bundler.exited.then(code => {
         if (!done2) throw new Error(`bundler exited early with code ${code}`);
         return -1; // Ignored — race already resolved

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -573,7 +573,9 @@ ${" ".repeat(counter * 2)}throw new Error(${counter});`,
       },
       verifyLine: (_errorLine, nextLine, counter) => {
         expect(nextLine).toInclude("bundle_in.ts");
-        const col = nextLine!.match(/\s*at.*?:4:(\d+)$/)![1];
+        const match = nextLine!.match(/\s*at.*?:4:(\d+)$/);
+        if (!match) throw new Error("invalid stack trace: " + nextLine);
+        const col = match[1];
         expect(Number(col)).toBe(1 + "throw ".length + counter * 2);
       },
     });
@@ -643,7 +645,9 @@ ${" ".repeat(counter * 2)}throw new Error(${counter});`,
       },
       verifyLine: (_errorLine, nextLine, counter) => {
         expect(nextLine).toInclude("bundle_in.ts");
-        const col = nextLine!.match(/\s*at.*?:4:(\d+)$/)![1];
+        const match = nextLine!.match(/\s*at.*?:4:(\d+)$/);
+        if (!match) throw new Error("invalid stack trace: " + nextLine);
+        const col = match[1];
         expect(Number(col)).toBe(1 + "throw ".length + counter * 2);
       },
     });

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -524,7 +524,7 @@ throw new Error('0');`,
           hotRunnerRoot,
           `// source content /*nonce:${nonce}*/
 ${comment_spam}
-${" ".repeat(counter * 2)}throw new Error(${counter});`,
+${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
         );
       },
       verifyLine: (errorLine, nextLine, counter) => {
@@ -570,6 +570,7 @@ throw new Error('0');`,
       stderr: "pipe",
       stdin: "ignore",
     });
+    let done = false;
     const reloadCounter = await Promise.race([
       driveErrorReloadCycle(runner, {
         targetCount: 50,
@@ -579,7 +580,7 @@ throw new Error('0');`,
             `// source content /*nonce:${nonce}*/
 // etc etc
 // etc etc
-${" ".repeat(counter * 2)}throw new Error(${counter});`,
+${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
           );
         },
         verifyLine: (_errorLine, nextLine, counter) => {
@@ -589,9 +590,10 @@ ${" ".repeat(counter * 2)}throw new Error(${counter});`,
           const col = match[1];
           expect(Number(col)).toBe(1 + "throw ".length + counter * 2);
         },
-      }),
+      }).finally(() => { done = true; }),
       bundler.exited.then(code => {
-        throw new Error(`bundler exited early with code ${code}`);
+        if (!done) throw new Error(`bundler exited early with code ${code}`);
+        return -1; // Ignored — race already resolved
       }),
     ]);
     expect(reloadCounter).toBe(50);
@@ -647,6 +649,7 @@ throw new Error('0');`,
       stderr: "pipe",
       stdin: "ignore",
     });
+    let done2 = false;
     const reloadCounter = await Promise.race([
       driveErrorReloadCycle(runner, {
         targetCount: 50,
@@ -656,7 +659,7 @@ throw new Error('0');`,
             `// ${long_comment} /*nonce:${nonce}*/
 console.error("RSS: %s", process.memoryUsage().rss);
 //
-${" ".repeat(counter * 2)}throw new Error(${counter});`,
+${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
           );
         },
         verifyLine: (_errorLine, nextLine, counter) => {
@@ -666,9 +669,10 @@ ${" ".repeat(counter * 2)}throw new Error(${counter});`,
           const col = match[1];
           expect(Number(col)).toBe(1 + "throw ".length + counter * 2);
         },
-      }),
+      }).finally(() => { done2 = true; }),
       bundler.exited.then(code => {
-        throw new Error(`bundler exited early with code ${code}`);
+        if (!done2) throw new Error(`bundler exited early with code ${code}`);
+        return -1; // Ignored — race already resolved
       }),
     ]);
     expect(reloadCounter).toBe(50);

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -12,24 +12,21 @@ const longTimeout = isDebug ? Infinity : 30_000;
  * Drives the reload cycle: reads error lines from stderr, verifies them,
  * and calls onReload to trigger the next file change.
  *
- * This avoids the previous pattern where duplicate error handling could
- * write identical file content (causing the watcher to not fire) or
- * discard buffered lines via `continue outer`.
+ * This fixes the original `continue outer` pattern which discarded any
+ * remaining buffered lines from the current chunk when a duplicate error
+ * was encountered, potentially losing data and causing test hangs.
  */
 async function driveErrorReloadCycle(
   runner: ReturnType<typeof spawn>,
   opts: {
     targetCount: number;
-    onReload: (counter: number, nonce: number) => void;
+    onReload: (counter: number) => void;
     verifyLine?: (errorLine: string, nextLine: string | undefined, counter: number) => void;
   },
 ): Promise<number> {
   const { targetCount, onReload, verifyLine } = opts;
   let reloadCounter = 0;
   let str = "";
-  // Nonce ensures file content always changes, even when re-saving on duplicate errors.
-  // Without this, writing the same content may not trigger the file watcher.
-  let nonce = 0;
 
   for await (const chunk of runner.stderr) {
     str += new TextDecoder().decode(chunk);
@@ -51,17 +48,14 @@ async function driveErrorReloadCycle(
       }
 
       // If we see the previous error repeated, the pending reload hasn't
-      // taken effect yet. Re-save with a new nonce to force a watcher event,
-      // then skip to reading the next chunk.
+      // taken effect yet. Re-save the file and put remaining unprocessed
+      // lines back into the buffer so they aren't lost.
       if (line.includes(`error: ${reloadCounter - 1}`)) {
-        // Put remaining unprocessed lines back into str so they aren't lost.
-        // Always keep a trailing \n so the next chunk starts a new logical line.
         const remaining = lines.slice(i + 1).join("\n");
         if (remaining) {
           str = `${remaining}\n${str}`;
         }
-        nonce++;
-        onReload(reloadCounter, nonce);
+        onReload(reloadCounter);
         triggered = false; // onReload already called; skip post-loop call
         break;
       }
@@ -84,8 +78,7 @@ async function driveErrorReloadCycle(
     }
 
     if (triggered) {
-      nonce++;
-      onReload(reloadCounter, nonce);
+      onReload(reloadCounter);
     }
   }
 
@@ -519,10 +512,10 @@ throw new Error('0');`,
     });
     const reloadCounter = await driveErrorReloadCycle(runner, {
       targetCount: 50,
-      onReload: (counter, nonce) => {
+      onReload: (counter) => {
         writeFileSync(
           hotRunnerRoot,
-          `// source content /*nonce:${nonce}*/
+          `// source content
 ${comment_spam}
 ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
         );
@@ -574,10 +567,10 @@ throw new Error('0');`,
     const reloadCounter = await Promise.race([
       driveErrorReloadCycle(runner, {
         targetCount: 50,
-        onReload: (counter, nonce) => {
+        onReload: (counter) => {
           writeFileSync(
             bundleIn,
-            `// source content /*nonce:${nonce}*/
+            `// source content
 // etc etc
 // etc etc
 ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
@@ -655,10 +648,10 @@ throw new Error('0');`,
     const reloadCounter = await Promise.race([
       driveErrorReloadCycle(runner, {
         targetCount: 50,
-        onReload: (counter, nonce) => {
+        onReload: (counter) => {
           writeFileSync(
             bundleIn,
-            `// ${long_comment} /*nonce:${nonce}*/
+            `// ${long_comment}
 console.error("RSS: %s", process.memoryUsage().rss);
 //
 ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -62,6 +62,7 @@ async function driveErrorReloadCycle(
         }
         nonce++;
         onReload(reloadCounter, nonce);
+        triggered = false; // onReload already called; skip post-loop call
         break;
       }
 

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -586,7 +586,7 @@ ${" ".repeat(counter * 2)}throw new Error(${counter});`,
           expect(Number(col)).toBe(1 + "throw ".length + counter * 2);
         },
       }),
-      bundler.exited.then((code) => {
+      bundler.exited.then(code => {
         throw new Error(`bundler exited early with code ${code}`);
       }),
     ]);
@@ -663,7 +663,7 @@ ${" ".repeat(counter * 2)}throw new Error(${counter});`,
           expect(Number(col)).toBe(1 + "throw ".length + counter * 2);
         },
       }),
-      bundler.exited.then((code) => {
+      bundler.exited.then(code => {
         throw new Error(`bundler exited early with code ${code}`);
       }),
     ]);

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -67,9 +67,8 @@ async function driveErrorReloadCycle(
       const nextLine = lines[i + 1];
       if (verifyLine) {
         verifyLine(line, nextLine, reloadCounter);
+        i++; // Skip the next line (stack trace)
       }
-      // Skip the next line (stack trace) since verifyLine consumed it
-      if (verifyLine) i++;
 
       reloadCounter++;
       triggered = true;

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -7,6 +7,81 @@ import { join } from "path";
 const timeout = isDebug ? Infinity : 10_000;
 const longTimeout = isDebug ? Infinity : 30_000;
 
+/**
+ * Helper to parse stderr from a --hot process that throws errors.
+ * Drives the reload cycle: reads error lines from stderr, verifies them,
+ * and calls onReload to trigger the next file change.
+ *
+ * This avoids the previous pattern where duplicate error handling could
+ * write identical file content (causing the watcher to not fire) or
+ * discard buffered lines via `continue outer`.
+ */
+async function driveErrorReloadCycle(
+  runner: ReturnType<typeof spawn>,
+  opts: {
+    targetCount: number;
+    onReload: (counter: number, nonce: number) => void;
+    verifyLine?: (errorLine: string, nextLine: string | undefined, counter: number) => void;
+  },
+): Promise<number> {
+  const { targetCount, onReload, verifyLine } = opts;
+  let reloadCounter = 0;
+  let str = "";
+  // Nonce ensures file content always changes, even when re-saving on duplicate errors.
+  // Without this, writing the same content may not trigger the file watcher.
+  let nonce = 0;
+
+  for await (const chunk of runner.stderr) {
+    str += new TextDecoder().decode(chunk);
+    // Need at least one error line followed by a newline, then another line followed by a newline
+    if (!/error: .*[0-9]\n.*?\n/g.test(str)) continue;
+
+    const lines = str.split("\n");
+    str = "";
+    let triggered = false;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (!line.includes("error:")) continue;
+
+      if (reloadCounter >= targetCount) {
+        runner.kill();
+        return reloadCounter;
+      }
+
+      // If we see the previous error repeated, the pending reload hasn't
+      // taken effect yet. Re-save with a new nonce to force a watcher event,
+      // then skip to reading the next chunk.
+      if (line.includes(`error: ${reloadCounter - 1}`)) {
+        // Put remaining unprocessed lines back into str so they aren't lost
+        str = lines.slice(i + 1).join("\n");
+        nonce++;
+        onReload(reloadCounter, nonce);
+        break;
+      }
+
+      expect(line).toContain(`error: ${reloadCounter}`);
+
+      const nextLine = lines[i + 1];
+      if (verifyLine) {
+        verifyLine(line, nextLine, reloadCounter);
+      }
+      // Skip the next line (stack trace) since verifyLine consumed it
+      if (verifyLine) i++;
+
+      reloadCounter++;
+      triggered = true;
+    }
+
+    if (triggered) {
+      nonce++;
+      onReload(reloadCounter, nonce);
+    }
+  }
+
+  return reloadCounter;
+}
+
 let hotRunnerRoot: string = "",
   cwd = "";
 beforeEach(() => {
@@ -432,50 +507,24 @@ throw new Error('0');`,
       stderr: "pipe",
       stdin: "ignore",
     });
-    let reloadCounter = 0;
-    function onReload() {
-      writeFileSync(
-        hotRunnerRoot,
-        `// source content
+    const reloadCounter = await driveErrorReloadCycle(runner, {
+      targetCount: 50,
+      onReload: (counter, nonce) => {
+        writeFileSync(
+          hotRunnerRoot,
+          `// source content /*nonce:${nonce}*/
 ${comment_spam}
-${" ".repeat(reloadCounter * 2)}throw new Error(${reloadCounter});`,
-      );
-    }
-    let str = "";
-    outer: for await (const chunk of runner.stderr) {
-      str += new TextDecoder().decode(chunk);
-      var any = false;
-      if (!/error: .*[0-9]\n.*?\n/g.test(str)) continue;
-
-      let it = str.split("\n");
-      let line;
-      while ((line = it.shift())) {
-        if (!line.includes("error:")) continue;
-        str = "";
-
-        if (reloadCounter === 50) {
-          runner.kill();
-          break;
-        }
-
-        if (line.includes(`error: ${reloadCounter - 1}`)) {
-          onReload(); // re-save file to prevent deadlock
-          continue outer;
-        }
-        expect(line).toContain(`error: ${reloadCounter}`);
-        reloadCounter++;
-
-        let next = it.shift()!;
-        if (!next) throw new Error(line);
-        const match = next.match(/\s*at.*?:1003:(\d+)$/);
-        if (!match) throw new Error("invalid string: " + next);
+${" ".repeat(counter * 2)}throw new Error(${counter});`,
+        );
+      },
+      verifyLine: (errorLine, nextLine, counter) => {
+        if (!nextLine) throw new Error(errorLine);
+        const match = nextLine.match(/\s*at.*?:1003:(\d+)$/);
+        if (!match) throw new Error("invalid string: " + nextLine);
         const col = match[1];
-        expect(Number(col)).toBe(1 + "throw new ".length + (reloadCounter - 1) * 2);
-        any = true;
-      }
-
-      if (any) await onReload();
-    }
+        expect(Number(col)).toBe(1 + "throw new ".length + counter * 2);
+      },
+    });
     await runner.exited;
     expect(reloadCounter).toBe(50);
   },
@@ -498,8 +547,8 @@ throw new Error('0');`,
       cmd: [bunExe(), "build", "--watch", bundleIn, "--target=bun", "--sourcemap=inline", "--outfile", hotRunnerRoot],
       env: bunEnv,
       cwd,
-      stdout: "inherit",
-      stderr: "inherit",
+      stdout: "ignore",
+      stderr: "ignore",
       stdin: "ignore",
     });
     waitForFileToExist(hotRunnerRoot, 20);
@@ -511,50 +560,23 @@ throw new Error('0');`,
       stderr: "pipe",
       stdin: "ignore",
     });
-    let reloadCounter = 0;
-    function onReload() {
-      writeFileSync(
-        bundleIn,
-        `// source content
+    const reloadCounter = await driveErrorReloadCycle(runner, {
+      targetCount: 50,
+      onReload: (counter, nonce) => {
+        writeFileSync(
+          bundleIn,
+          `// source content /*nonce:${nonce}*/
 // etc etc
 // etc etc
-${" ".repeat(reloadCounter * 2)}throw new Error(${reloadCounter});`,
-      );
-    }
-    let str = "";
-    outer: for await (const chunk of runner.stderr) {
-      const s = new TextDecoder().decode(chunk);
-      str += s;
-      var any = false;
-      if (!/error: .*[0-9]\n.*?\n/g.test(str)) continue;
-
-      let it = str.split("\n");
-      let line;
-      while ((line = it.shift())) {
-        if (!line.includes("error:")) continue;
-        str = "";
-
-        if (reloadCounter === 50) {
-          runner.kill();
-          break;
-        }
-
-        if (line.includes(`error: ${reloadCounter - 1}`)) {
-          onReload(); // re-save file to prevent deadlock
-          continue outer;
-        }
-        expect(line).toContain(`error: ${reloadCounter}`);
-        reloadCounter++;
-
-        let next = it.shift()!;
-        expect(next).toInclude("bundle_in.ts");
-        const col = next.match(/\s*at.*?:4:(\d+)$/)![1];
-        expect(Number(col)).toBe(1 + "throw ".length + (reloadCounter - 1) * 2);
-        any = true;
-      }
-
-      if (any) await onReload();
-    }
+${" ".repeat(counter * 2)}throw new Error(${counter});`,
+        );
+      },
+      verifyLine: (_errorLine, nextLine, counter) => {
+        expect(nextLine).toInclude("bundle_in.ts");
+        const col = nextLine!.match(/\s*at.*?:4:(\d+)$/)![1];
+        expect(Number(col)).toBe(1 + "throw ".length + counter * 2);
+      },
+    });
     expect(reloadCounter).toBe(50);
     bundler.kill();
   },
@@ -604,68 +626,31 @@ throw new Error('0');`,
       ],
       env: bunEnv,
       cwd,
-      stdout: "inherit",
+      stdout: "ignore",
       stderr: "pipe",
       stdin: "ignore",
     });
-    let reloadCounter = 0;
-    function onReload() {
-      writeFileSync(
-        bundleIn,
-        `// ${long_comment}
+    const reloadCounter = await driveErrorReloadCycle(runner, {
+      targetCount: 50,
+      onReload: (counter, nonce) => {
+        writeFileSync(
+          bundleIn,
+          `// ${long_comment} /*nonce:${nonce}*/
 console.error("RSS: %s", process.memoryUsage().rss);
 //
-${" ".repeat(reloadCounter * 2)}throw new Error(${reloadCounter});`,
-      );
-    }
-    let str = "";
-    let sampleMemory10: number | undefined;
-    let sampleMemory100: number | undefined;
-    outer: for await (const chunk of runner.stderr) {
-      str += new TextDecoder().decode(chunk);
-      var any = false;
-      if (!/error: .*[0-9]\n.*?\n/g.test(str)) continue;
-
-      let it = str.split("\n");
-      let line;
-      while ((line = it.shift())) {
-        if (!line.includes("error:")) continue;
-        let rssMatch = str.match(/RSS: (\d+(\.\d+)?)\n/);
-        let rss;
-        if (rssMatch) rss = Number(rssMatch[1]);
-        str = "";
-
-        if (reloadCounter == 10) {
-          sampleMemory10 = rss;
-        }
-
-        if (reloadCounter >= 50) {
-          sampleMemory100 = rss;
-          runner.kill();
-          break;
-        }
-
-        if (line.includes(`error: ${reloadCounter - 1}`)) {
-          onReload(); // re-save file to prevent deadlock
-          continue outer;
-        }
-        expect(line).toContain(`error: ${reloadCounter}`);
-
-        reloadCounter++;
-        let next = it.shift()!;
-        expect(next).toInclude("bundle_in.ts");
-        const col = next.match(/\s*at.*?:4:(\d+)$/)![1];
-        expect(Number(col)).toBe(1 + "throw ".length + (reloadCounter - 1) * 2);
-        any = true;
-      }
-
-      if (any) await onReload();
-    }
+${" ".repeat(counter * 2)}throw new Error(${counter});`,
+        );
+      },
+      verifyLine: (_errorLine, nextLine, counter) => {
+        expect(nextLine).toInclude("bundle_in.ts");
+        const col = nextLine!.match(/\s*at.*?:4:(\d+)$/)![1];
+        expect(Number(col)).toBe(1 + "throw ".length + counter * 2);
+      },
+    });
     expect(reloadCounter).toBe(50);
     bundler.kill();
     await runner.exited;
     // TODO: bun has a memory leak when --hot is used on very large files
-    // console.log({ sampleMemory10, sampleMemory100 });
   },
   longTimeout,
 );

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -37,7 +37,8 @@ async function driveErrorReloadCycle(
     if (!/error: .*[0-9]\n.*?\n/g.test(str)) continue;
 
     const lines = str.split("\n");
-    str = "";
+    // Preserve trailing partial line for the next chunk
+    str = lines.pop() ?? "";
     let triggered = false;
 
     for (let i = 0; i < lines.length; i++) {
@@ -54,7 +55,8 @@ async function driveErrorReloadCycle(
       // then skip to reading the next chunk.
       if (line.includes(`error: ${reloadCounter - 1}`)) {
         // Put remaining unprocessed lines back into str so they aren't lost
-        str = lines.slice(i + 1).join("\n");
+        const remaining = lines.slice(i + 1).join("\n");
+        str = remaining ? (str ? `${remaining}\n${str}` : remaining) : str;
         nonce++;
         onReload(reloadCounter, nonce);
         break;

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -492,7 +492,8 @@ it(
   timeout,
 );
 
-const comment_spam = ("//" + "B".repeat(2000) + "\n").repeat(1000);
+const comment_line = "//" + Buffer.alloc(2000, "B").toString() + "\n";
+const comment_spam = Buffer.alloc(comment_line.length * 1000, comment_line).toString();
 it(
   "should work with sourcemap generation",
   async () => {
@@ -598,7 +599,7 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
   timeout,
 );
 
-const long_comment = "BBBB".repeat(100000);
+const long_comment = Buffer.alloc(400000, "BBBB").toString();
 
 it(
   "should work with sourcemap loading with large files",

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -577,8 +577,9 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
           );
         },
         verifyLine: (_errorLine, nextLine, counter) => {
+          if (!nextLine) throw new Error(_errorLine);
           expect(nextLine).toInclude("bundle_in.ts");
-          const match = nextLine!.match(/\s*at.*?:4:(\d+)$/);
+          const match = nextLine.match(/\s*at.*?:4:(\d+)$/);
           if (!match) throw new Error("invalid stack trace: " + nextLine);
           const col = match[1];
           expect(Number(col)).toBe(1 + "throw ".length + counter * 2);
@@ -658,8 +659,9 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
           );
         },
         verifyLine: (_errorLine, nextLine, counter) => {
+          if (!nextLine) throw new Error(_errorLine);
           expect(nextLine).toInclude("bundle_in.ts");
-          const match = nextLine!.match(/\s*at.*?:4:(\d+)$/);
+          const match = nextLine.match(/\s*at.*?:4:(\d+)$/);
           if (!match) throw new Error("invalid stack trace: " + nextLine);
           const col = match[1];
           expect(Number(col)).toBe(1 + "throw ".length + counter * 2);


### PR DESCRIPTION
The three sourcemap tests (generation, loading, loading with large files) used a `continue outer` pattern in their error-handling loops. When a duplicate/stale error was encountered, `continue outer` jumped back to reading the next stderr chunk, but any remaining lines from `str.split("\n")` that had not yet been processed were discarded because `str` was set to `""` inside the inner loop. This lost data and could cause the test to hang waiting for output that was already consumed and thrown away.

Additionally, the bundler processes in the sourcemap loading tests used `stdout: "inherit"` / `stderr: "inherit"`, which could cause pipe buffer backpressure blocking the bundler.

Fixes both issues with a shared `driveErrorReloadCycle` helper that:
- Preserves unprocessed lines when encountering duplicate errors (uses `lines.pop()` for trailing partial lines and re-buffers remaining lines via `lines.slice(i + 1)`)
- Pipes bundler stdout/stderr to `ignore` to avoid pipe buffer backpressure
- Races `bundler.exited` against the reload driver for early-exit detection in the two bundler-based tests

---
Verification: Format and Lint JavaScript CI checks pass. Buildkite build #39875 still compiling at time of review. Only `test/cli/hot/hot.test.ts` changed (test-only deflake, no production code). Jarred's CHANGES_REQUESTED about the nonce mechanism was addressed in commit 50f3f4ed (nonce removed). No TODO/FIXME/HACK in added lines. The driveErrorReloadCycle helper correctly preserves partial line fragments and remaining unprocessed lines, prevents double onReload calls via the triggered flag, and uses Buffer.alloc per test/CLAUDE.md convention.