### PR TITLE
deflake: split compile-windows-metadata invalid version test into concurrent cases

### DIFF
--- a/test/bundler/compile-windows-metadata.test.ts
+++ b/test/bundler/compile-windows-metadata.test.ts
@@ -322,39 +322,35 @@ describe.skipIf(!isWindows).concurrent("Windows compile metadata", () => {
       expect(version).toBe(expected);
     });
 
-    test("invalid version format should error gracefully", async () => {
+    test.each([
+      { version: "not.a.version" },
+      { version: "1.2.3.4.5" },
+      { version: "1.-2.3.4" },
+      { version: "65536.0.0.0" }, // > 65535
+      { version: "" },
+    ])("invalid version format should error gracefully: $version", async ({ version }) => {
       using dir = tempDir("windows-invalid-version", {
         "app.js": `console.log("Invalid version test");`,
       });
 
-      const invalidVersions = [
-        "not.a.version",
-        "1.2.3.4.5",
-        "1.-2.3.4",
-        "65536.0.0.0", // > 65535
-        "",
-      ];
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "build",
+          "--compile",
+          join(String(dir), "app.js"),
+          "--outfile",
+          join(String(dir), "test.exe"),
+          "--windows-version",
+          version,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
 
-      for (const version of invalidVersions) {
-        await using proc = Bun.spawn({
-          cmd: [
-            bunExe(),
-            "build",
-            "--compile",
-            join(String(dir), "app.js"),
-            "--outfile",
-            join(String(dir), "test.exe"),
-            "--windows-version",
-            version,
-          ],
-          env: bunEnv,
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-
-        const exitCode = await proc.exited;
-        expect(exitCode).not.toBe(0);
-      }
+      const exitCode = await proc.exited;
+      expect(exitCode).not.toBe(0);
     });
   });
 


### PR DESCRIPTION
The `invalid version format should error gracefully` test was running 5 sequential `bun build --compile` invocations in a single test case. On slow Windows CI machines under load, this easily exceeds the 90s test timeout.

Split the sequential loop into `test.each` so each invalid version is a separate test case. Since the parent `describe` block uses `.concurrent`, these now run in parallel, each with its own timeout budget.