### PR TITLE
fix(install): resolve relative tarball paths for global installs

### DIFF
--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -574,7 +574,10 @@ pub fn init(
     const user_cwd: string = if (cli.global) brk: {
         const cwd = switch (bun.sys.getcwd(&user_cwd_buf)) {
             .result => |cwd| cwd,
-            .err => "",
+            .err => |e| {
+                Output.err(e, "failed to get current working directory", .{});
+                Global.crash();
+            },
         };
         break :brk bun.handleOom(ctx.allocator.dupe(u8, cwd));
     } else "";

--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -116,6 +116,10 @@ any_failed_to_install: bool = false,
 // workspace package. We keep track of the original here.
 original_package_json_path: stringZ,
 
+// The user's original working directory before any CWD changes (e.g., for --global).
+// Used to resolve relative local tarball paths correctly.
+user_cwd: string = "",
+
 // null means root. Used during `cleanWithLogger` to identifier which
 // workspace is adding/removing packages
 workspace_name_hash: ?PackageNameHash = null,
@@ -564,6 +568,17 @@ pub fn init(
     cli: CommandLineArguments,
     subcommand: Subcommand,
 ) !struct { *PackageManager, string } {
+    // Save the user's original CWD before switching to the global install directory.
+    // This is needed to resolve relative local tarball paths (e.g., `bun add ./pkg.tgz --global`).
+    var user_cwd_buf: bun.PathBuffer = undefined;
+    const user_cwd: string = if (cli.global) brk: {
+        const cwd = switch (bun.sys.getcwd(&user_cwd_buf)) {
+            .result => |cwd| cwd,
+            .err => "",
+        };
+        break :brk bun.handleOom(ctx.allocator.dupe(u8, cwd));
+    } else "";
+
     if (cli.global) {
         var explicit_global_dir: string = "";
         if (ctx.install) |opts| {
@@ -877,6 +892,7 @@ pub fn init(
         .workspace_name_hash = workspace_name_hash,
         .subcommand = subcommand,
         .root_package_json_name_at_time_of_init = root_package_json_name_at_time_of_init,
+        .user_cwd = user_cwd,
     };
     manager.event_loop.loop().internal_loop_data.setParentEventLoop(bun.jsc.EventLoopHandle.init(&manager.event_loop));
     manager.lockfile = try ctx.allocator.create(Lockfile);

--- a/src/install/PackageManagerTask.zig
+++ b/src/install/PackageManagerTask.zig
@@ -246,10 +246,12 @@ pub fn callback(task: *ThreadPool.Task) void {
             const workspace_pkg_id = manager.lockfile.getWorkspacePkgIfWorkspaceDep(this.request.local_tarball.tarball.dependency_id);
 
             var abs_buf: bun.PathBuffer = undefined;
+            const raw_url = this.request.local_tarball.tarball.url.slice();
+
             const tarball_path, const normalize = if (workspace_pkg_id != invalid_package_id) tarball_path: {
                 const workspace_res = manager.lockfile.packages.items(.resolution)[workspace_pkg_id];
 
-                if (workspace_res.tag != .workspace) break :tarball_path .{ this.request.local_tarball.tarball.url.slice(), true };
+                if (workspace_res.tag != .workspace) break :tarball_path resolveLocalTarball(manager, raw_url, &abs_buf);
 
                 // Construct an absolute path to the tarball.
                 // Normally tarball paths are always relative to the root directory, but if a
@@ -261,13 +263,13 @@ pub fn callback(task: *ThreadPool.Task) void {
                         &abs_buf,
                         &[_][]const u8{
                             workspace_path,
-                            this.request.local_tarball.tarball.url.slice(),
+                            raw_url,
                         },
                         .auto,
                     ),
                     false,
                 };
-            } else .{ this.request.local_tarball.tarball.url.slice(), true };
+            } else resolveLocalTarball(manager, raw_url, &abs_buf);
 
             const result = readAndExtract(
                 manager.allocator,
@@ -289,6 +291,23 @@ pub fn callback(task: *ThreadPool.Task) void {
             this.status = Status.success;
         },
     }
+}
+
+/// Resolve a local tarball path. For global installs, relative paths are resolved
+/// against the user's original working directory instead of the global install directory.
+fn resolveLocalTarball(manager: *const PackageManager, raw_url: string, abs_buf: *bun.PathBuffer) struct { string, bool } {
+    if (manager.user_cwd.len > 0 and !std.fs.path.isAbsolute(raw_url)) {
+        return .{
+            Path.joinAbsStringBuf(
+                manager.user_cwd,
+                abs_buf,
+                &[_][]const u8{raw_url},
+                .auto,
+            ),
+            false,
+        };
+    }
+    return .{ raw_url, true };
 }
 
 fn readAndExtract(

--- a/src/install/PackageManagerTask.zig
+++ b/src/install/PackageManagerTask.zig
@@ -296,7 +296,7 @@ pub fn callback(task: *ThreadPool.Task) void {
 /// Resolve a local tarball path. For global installs, relative paths are resolved
 /// against the user's original working directory instead of the global install directory.
 fn resolveLocalTarball(manager: *const PackageManager, raw_url: string, abs_buf: *bun.PathBuffer) struct { string, bool } {
-    if (manager.user_cwd.len > 0 and !std.fs.path.isAbsolute(raw_url)) {
+    if (manager.user_cwd.len > 0 and !Path.Platform.isAbsolute(.auto, raw_url)) {
         return .{
             Path.joinAbsStringBuf(
                 manager.user_cwd,

--- a/test/regression/issue/28208.test.ts
+++ b/test/regression/issue/28208.test.ts
@@ -1,5 +1,7 @@
 import { expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { existsSync } from "fs";
+import { join } from "path";
 
 setDefaultTimeout(30_000);
 
@@ -10,10 +12,12 @@ test("bun add with relative tarball path and --global should work", async () => 
   });
 
   // Create the tarball
-  Bun.spawnSync({
+  const tarResult = Bun.spawnSync({
     cmd: ["tar", "czf", "test.tgz", "-C", "test-pkg", "."],
     cwd: String(dir),
   });
+  expect(tarResult.exitCode).toBe(0);
+  expect(existsSync(join(String(dir), "test.tgz"))).toBe(true);
 
   // Test: bun add ./test.tgz --global with a relative path
   await using proc = Bun.spawn({

--- a/test/regression/issue/28208.test.ts
+++ b/test/regression/issue/28208.test.ts
@@ -1,0 +1,38 @@
+import { expect, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+setDefaultTimeout(30_000);
+
+test("bun add with relative tarball path and --global should work", async () => {
+  using dir = tempDir("tarball-global", {
+    "test-pkg/package.json": JSON.stringify({ name: "test-global-tarball-28208", version: "1.0.0", main: "index.js" }),
+    "test-pkg/index.js": "module.exports = 'hello';",
+  });
+
+  // Create the tarball
+  Bun.spawnSync({
+    cmd: ["tar", "czf", "test.tgz", "-C", "test-pkg", "."],
+    cwd: String(dir),
+  });
+
+  // Test: bun add ./test.tgz --global with a relative path
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "add", "./test.tgz", "--global"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Clean up: remove the globally installed package
+  Bun.spawnSync({
+    cmd: [bunExe(), "remove", "test-global-tarball-28208", "--global"],
+    env: bunEnv,
+  });
+
+  expect(stderr).not.toContain("ENOENT extracting tarball");
+  expect(stderr).not.toContain("failed to resolve");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/28208.test.ts
+++ b/test/regression/issue/28208.test.ts
@@ -1,6 +1,6 @@
 import { expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
 import { existsSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 setDefaultTimeout(30_000);

--- a/test/regression/issue/28208.test.ts
+++ b/test/regression/issue/28208.test.ts
@@ -31,10 +31,11 @@ test("bun add with relative tarball path and --global should work", async () => 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // Clean up: remove the globally installed package
-  Bun.spawnSync({
+  const removeResult = Bun.spawnSync({
     cmd: [bunExe(), "remove", "test-global-tarball-28208", "--global"],
     env: bunEnv,
   });
+  expect(removeResult.exitCode).toBe(0);
 
   expect(stderr).not.toContain("ENOENT extracting tarball");
   expect(stderr).not.toContain("failed to resolve");


### PR DESCRIPTION
## Summary
- Fix `bun add ./pkg.tgz --global` failing with `ENOENT extracting tarball` when using relative paths
- Save the user's original CWD before switching to the global install directory
- Resolve relative local tarball paths against the saved CWD instead of the global directory

## Root Cause
When `--global` is used, `PackageManager.init` changes the CWD to the global install directory (`~/.bun/install/global/`) **before** tarball paths are resolved. This causes relative paths like `./test.tgz` to resolve against the global directory instead of the user's working directory.

## Changes
- **`PackageManager.zig`**: Capture the user's CWD before the global `setAsCwd()` call and store it in a new `user_cwd` field
- **`PackageManagerTask.zig`**: Add `resolveLocalTarball()` helper that resolves relative tarball paths against `user_cwd` for global installs. Applied in both the workspace fallthrough and non-workspace branches.

## Test plan
- [x] `bun add ./test.tgz --global` — previously ENOENT, now succeeds
- [x] `bun add test.tgz --global` — previously ENOENT, now succeeds
- [x] `bun add /absolute/path/test.tgz --global` — still works
- [x] `bun add ./test.tgz` (non-global) — still works
- [x] Regression test added: `test/regression/issue/28208.test.ts`
- [x] Test fails with `USE_SYSTEM_BUN=1`, passes with `bun bd test`

Closes #28208

🤖 Generated with [Claude Code](https://claude.com/claude-code)