### PR TITLE
docs(sqlite): document WAL sidecar file cleanup behavior across platforms

### DIFF
--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -207,11 +207,33 @@ db.run("PRAGMA journal_mode = WAL;");
 ```
 
 <Accordion title="What is WAL mode?">
-In WAL mode, writes to the database are written directly to a separate file called the "WAL file" (write-ahead log). This file will be later integrated into the main database file. Think of it as a buffer for pending writes. Refer to the [SQLite docs](https://www.sqlite.org/wal.html) for a more detailed overview.
-
-On macOS, WAL files may be persistent by default. This is not a bug, it is how macOS configured the system version of SQLite.
-
+In WAL mode, writes to the database are written directly to a separate file called the "WAL file" (`-wal`) and a shared-memory file (`-shm`). These will be later integrated into the main database file. Think of it as a buffer for pending writes. Refer to the [SQLite docs](https://www.sqlite.org/wal.html) for a more detailed overview.
 </Accordion>
+
+### WAL sidecar file cleanup
+
+When using WAL mode with a file-based database, SQLite creates two sidecar files alongside your database: a write-ahead log (`-wal`) and a shared-memory index (`-shm`). Whether these files are automatically removed after `.close()` depends on your platform:
+
+- **macOS**: Bun uses the system-provided SQLite, which Apple builds with persistent WAL enabled. The `-wal` and `-shm` files **will persist** after close. This is not a bug — it is how Apple configured the system SQLite.
+- **Linux** and **Windows**: Bun statically links its own SQLite build, which follows upstream defaults. The sidecar files are **typically removed** after close when no other connections are open.
+
+To ensure sidecar files are cleaned up on all platforms, disable WAL persistence and run a truncating checkpoint before closing:
+
+```ts db.ts icon="/icons/typescript.svg"
+import { Database, constants } from "bun:sqlite";
+
+const db = new Database("mydb.sqlite");
+db.run("PRAGMA journal_mode = WAL;");
+
+// ... use the database ...
+
+// Disable persistent WAL (needed on macOS)
+db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, 0);
+// Checkpoint and truncate the WAL file
+db.run("PRAGMA wal_checkpoint(TRUNCATE);");
+db.close();
+// Only mydb.sqlite remains — no -wal or -shm files
+```
 
 ---
 
@@ -627,14 +649,14 @@ db.loadExtension("myext");
 
 ### `.fileControl(cmd: number, value: any)`
 
-To use the advanced `sqlite3_file_control` API, call `.fileControl(cmd, value)` on your `Database` instance.
+To use the advanced `sqlite3_file_control` API, call `.fileControl(cmd, value)` on your `Database` instance. See [WAL sidecar file cleanup](#wal-sidecar-file-cleanup) for a practical example.
 
 ```ts db.ts icon="/icons/typescript.svg" highlight={6}
 import { Database, constants } from "bun:sqlite";
 
 const db = new Database();
 // Ensure WAL mode is NOT persistent
-// this prevents wal files from lingering after the database is closed
+// this prevents WAL files from lingering after the database is closed
 db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, 0);
 ```
 

--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -207,7 +207,9 @@ db.run("PRAGMA journal_mode = WAL;");
 ```
 
 <Accordion title="What is WAL mode?">
-In WAL mode, writes to the database are written directly to a separate file called the "WAL file" (`-wal`) and a shared-memory file (`-shm`). These will be later integrated into the main database file. Think of it as a buffer for pending writes. Refer to the [SQLite docs](https://www.sqlite.org/wal.html) for a more detailed overview.
+  In WAL mode, writes to the database are written directly to a separate file called the "WAL file" (`-wal`) and a
+  shared-memory file (`-shm`). These will be later integrated into the main database file. Think of it as a buffer for
+  pending writes. Refer to the [SQLite docs](https://www.sqlite.org/wal.html) for a more detailed overview.
 </Accordion>
 
 ### WAL sidecar file cleanup


### PR DESCRIPTION
Closes #27481

## Problem

`bun:sqlite` documentation did not mention that WAL sidecar file (`.db-wal`, `.db-shm`) cleanup behavior varies by platform after `db.close()`. Users on macOS were surprised to find these files persisting.

## Root Cause

On **macOS**, Bun dynamically loads the system-provided SQLite (`LAZY_LOAD_SQLITE=1`), which Apple builds with persistent WAL enabled by default. On **Linux** and **Windows**, Bun statically links its own SQLite build (`USE_STATIC_SQLITE=ON`), which follows upstream defaults where sidecar files are removed on close.

Bun's `close()` implementation calls `sqlite3_close`/`sqlite3_close_v2` without any explicit WAL checkpoint or cleanup — the behavior is entirely determined by the underlying SQLite library.

## Fix

Expanded the WAL mode documentation section to:

1. Explain that `-wal` and `-shm` sidecar files may persist on macOS due to Apple's system SQLite configuration
2. Explain that Linux/Windows use statically linked SQLite with upstream defaults (sidecar files typically removed)
3. Document the deterministic cleanup pattern using `fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, 0)` + `PRAGMA wal_checkpoint(TRUNCATE)` — verified against the [existing test](https://github.com/oven-sh/bun/blob/main/test/js/bun/sqlite/sqlite.test.js#L1347-L1359)
4. Added a cross-reference from the `.fileControl()` section

## Verification

All claims verified against implementation:
- `cmake/Options.cmake`: `USE_STATIC_SQLITE` defaults to `OFF` on macOS, `ON` elsewhere
- `cmake/targets/BuildBun.cmake`: maps `USE_STATIC_SQLITE` → `LAZY_LOAD_SQLITE` compile definition
- `src/bun.js/bindings/sqlite/JSSQLStatement.cpp`: `close()` calls only `sqlite3_close`/`sqlite3_close_v2` with no WAL cleanup
- `src/js/bun/sqlite.ts`: `constants.SQLITE_FCNTL_PERSIST_WAL` is exported as `10`
- `test/js/bun/sqlite/sqlite.test.js`: existing test at line 1347 confirms the recommended cleanup pattern works