### PR TITLE
docs(sqlite): fix inaccurate WAL accordion text about -shm file

### DIFF
--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -207,9 +207,10 @@ db.run("PRAGMA journal_mode = WAL;");
 ```
 
 <Accordion title="What is WAL mode?">
-  In WAL mode, writes to the database are written directly to a separate file called the "WAL file" (`-wal`) and a
-  shared-memory file (`-shm`). These will be later integrated into the main database file. Think of it as a buffer for
-  pending writes. Refer to the [SQLite docs](https://www.sqlite.org/wal.html) for a more detailed overview.
+  In WAL mode, writes to the database are written directly to a separate file called the "WAL file" (`-wal`). A
+  shared-memory index file (`-shm`) is also created for read coordination. The WAL file will be later integrated into
+  the main database file. Think of it as a buffer for pending writes. Refer to the [SQLite
+  docs](https://www.sqlite.org/wal.html) for a more detailed overview.
 </Accordion>
 
 ### WAL sidecar file cleanup


### PR DESCRIPTION
Followup to #28212 — fixes an inaccuracy in the WAL mode accordion text flagged in [review](https://github.com/oven-sh/bun/pull/28212#discussion_r2951182965).

## Problem

The accordion text said writes go to both the `-wal` and `-shm` files, and that both get "integrated" into the main database. Only the `-wal` file receives writes; the `-shm` file is a shared-memory index for read coordination and is never checkpointed.

## Fix

Reword to clarify that writes go only to the WAL file, and that the `-shm` file is a shared-memory index created for read coordination. This is now consistent with the accurate description in the WAL sidecar file cleanup section just below.

---
**Verification:** CI green (Build #39929 passed, Lint JavaScript passed, no failures). Docs-only change to docs/runtime/sqlite.mdx — corrects the WAL accordion text to accurately state that writes go only to the -wal file and that -shm is a shared-memory index for read coordination, consistent with SQLite documentation. No TODO/FIXME markers. No test needed (prose fix). No reviews to triage.