### PR TITLE
Preserve non-ASCII in tagged template literals and regex source

### DIFF
--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -238,6 +238,18 @@ impl Value {
                 if bytes.is_empty() {
                     return BunString::EMPTY;
                 }
+                // Bundler output may contain raw UTF-8 bytes from tagged
+                // template literals or regex source with non-ASCII characters.
+                // `create_external` with `is_latin1=true` can't represent
+                // multi-byte UTF-8, so fall back to `clone_utf8` when non-ASCII
+                // is present. This function transfers ownership of `bytes` —
+                // the ASCII path hands it to `on_free`; the non-ASCII path must
+                // drop it explicitly.
+                if !bun_core::strings::is_all_ascii(&bytes) {
+                    let result = BunString::clone_utf8(&bytes);
+                    drop(bytes);
+                    return result;
+                }
                 // Use ExternalStringImpl to avoid cloning the string, at
                 // the cost of allocating space to remember the arena.
                 //
@@ -292,6 +304,14 @@ impl Value {
             Value::Buffer { bytes } => {
                 if bytes.is_empty() {
                     return BunString::EMPTY;
+                }
+                // Bundler output may contain raw UTF-8 bytes from tagged
+                // template literals or regex source with non-ASCII characters.
+                // `create_external` with `is_latin1=true` can't represent
+                // multi-byte UTF-8, so fall back to `clone_utf8` when non-ASCII
+                // is present. (Borrowing variant — bytes stay owned by caller.)
+                if !bun_core::strings::is_all_ascii(bytes) {
+                    return BunString::clone_utf8(bytes);
                 }
                 extern "C" fn noop(_: *mut c_void, _: *mut c_void, _: usize) {}
                 // latin1 = true (matches Zig).

--- a/src/bundler/OutputFile.zig
+++ b/src/bundler/OutputFile.zig
@@ -129,6 +129,13 @@ pub const Value = union(Kind) {
         return switch (v) {
             .noop => bun.String.empty,
             .buffer => |buf| {
+                // Bundler output may contain raw UTF-8 bytes from tagged
+                // template literals or regex source with non-ASCII characters.
+                // createExternal with isLatin1=true can't handle multi-byte
+                // UTF-8, so fall back to cloneUTF8 when non-ASCII is present.
+                if (!bun.strings.isAllASCII(buf.bytes)) {
+                    return bun.String.cloneUTF8(buf.bytes);
+                }
                 // Use ExternalStringImpl to avoid cloning the string, at
                 // the cost of allocating space to remember the allocator.
                 const FreeContext = struct {

--- a/src/bundler/OutputFile.zig
+++ b/src/bundler/OutputFile.zig
@@ -133,7 +133,11 @@ pub const Value = union(Kind) {
                 // template literals or regex source with non-ASCII characters.
                 // createExternal with isLatin1=true can't handle multi-byte
                 // UTF-8, so fall back to cloneUTF8 when non-ASCII is present.
+                // This function transfers ownership of buf.bytes — the ASCII
+                // path hands it to FreeContext.onFree, so the non-ASCII path
+                // must free it explicitly after cloning.
                 if (!bun.strings.isAllASCII(buf.bytes)) {
+                    defer buf.allocator.free(buf.bytes);
                     return bun.String.cloneUTF8(buf.bytes);
                 }
                 // Use ExternalStringImpl to avoid cloning the string, at

--- a/src/js_printer/js_printer.zig
+++ b/src/js_printer/js_printer.zig
@@ -1990,6 +1990,8 @@ fn NewPrinter(
             // Raw template literals must preserve bytes verbatim because they are
             // exposed to JavaScript via the .raw property and String.raw. Escaping
             // non-ASCII characters to \uXXXX would change the runtime string value.
+            const saved = p.prefers_ascii;
+            defer p.prefers_ascii = saved;
             if (p.prefers_ascii and !strings.isAllASCII(bytes)) p.prefers_ascii = false;
             p.print(bytes);
         }
@@ -3201,10 +3203,14 @@ fn NewPrinter(
             // RegExp literals cannot be printed ascii-only because they expose a
             // .source property to JavaScript. Escaping non-ASCII would change the
             // runtime value of that property.
-            if (p.prefers_ascii and !strings.isAllASCII(e.value)) {
-                p.prefers_ascii = false;
+            {
+                const saved = p.prefers_ascii;
+                defer p.prefers_ascii = saved;
+                if (p.prefers_ascii and !strings.isAllASCII(e.value)) {
+                    p.prefers_ascii = false;
+                }
+                p.print(e.value);
             }
-            p.print(e.value);
 
             // Need a space before the next identifier to avoid it turning into flags
             p.prev_reg_exp_end = p.writer.written;

--- a/src/js_printer/js_printer.zig
+++ b/src/js_printer/js_printer.zig
@@ -5,6 +5,9 @@ const first_high_surrogate = 0xD800;
 const first_low_surrogate = 0xDC00;
 const last_low_surrogate = 0xDFFF;
 
+/// For support JavaScriptCore
+const ascii_only_always_on_unless_minifying = true;
+
 fn formatUnsignedIntegerBetween(comptime len: u16, buf: *[len]u8, val: u64) void {
     comptime var i: u16 = len;
     var remainder = val;
@@ -23,11 +26,11 @@ pub fn writeModuleId(comptime Writer: type, writer: Writer, module_id: u32) void
     std.fmt.formatInt(module_id, 16, .lower, .{}, writer) catch unreachable;
 }
 
-pub fn canPrintWithoutEscape(comptime CodePointType: type, c: CodePointType, prefers_ascii: bool) bool {
+pub fn canPrintWithoutEscape(comptime CodePointType: type, c: CodePointType, comptime ascii_only: bool) bool {
     if (c <= last_ascii) {
         return c >= first_ascii and c != '\\' and c != '"' and c != '\'' and c != '`' and c != '$';
     } else {
-        return !prefers_ascii and c != 0xFEFF and c != 0x2028 and c != 0x2029 and (c < first_high_surrogate or c > last_low_surrogate);
+        return !ascii_only and c != 0xFEFF and c != 0x2028 and c != 0x2029 and (c < first_high_surrogate or c > last_low_surrogate);
     }
 }
 
@@ -106,7 +109,7 @@ fn ws(comptime str: []const u8) Whitespacer {
     return .{ .normal = Static.with, .minify = Static.without };
 }
 
-pub fn estimateLengthForUTF8(input: []const u8, comptime prefers_ascii: bool, comptime quote_char: u8) usize {
+pub fn estimateLengthForUTF8(input: []const u8, comptime ascii_only: bool, comptime quote_char: u8) usize {
     var remaining = input;
     var len: usize = 2; // for quotes
 
@@ -127,7 +130,7 @@ pub fn estimateLengthForUTF8(input: []const u8, comptime prefers_ascii: bool, co
             i32,
             0,
         );
-        if (canPrintWithoutEscape(i32, c, prefers_ascii)) {
+        if (canPrintWithoutEscape(i32, c, ascii_only)) {
             len += @as(usize, char_len);
         } else if (c <= 0xFFFF) {
             len += 6;
@@ -142,7 +145,7 @@ pub fn estimateLengthForUTF8(input: []const u8, comptime prefers_ascii: bool, co
     return len;
 }
 
-pub fn writePreQuotedString(text_in: []const u8, comptime Writer: type, writer: Writer, comptime quote_char: u8, prefers_ascii: bool, comptime json: bool, comptime encoding: strings.Encoding) !void {
+pub fn writePreQuotedString(text_in: []const u8, comptime Writer: type, writer: Writer, comptime quote_char: u8, comptime ascii_only: bool, comptime json: bool, comptime encoding: strings.Encoding) !void {
     const text = if (comptime encoding == .utf16) @as([]const u16, @alignCast(std.mem.bytesAsSlice(u16, text_in))) else text_in;
     if (comptime json and quote_char != '"') @compileError("for json, quote_char must be '\"'");
     var i: usize = 0;
@@ -180,7 +183,7 @@ pub fn writePreQuotedString(text_in: []const u8, comptime Writer: type, writer: 
                 break :brk @as(i32, text[i]);
             },
         };
-        if (canPrintWithoutEscape(i32, c, prefers_ascii)) {
+        if (canPrintWithoutEscape(i32, c, ascii_only)) {
             const remain = text[i + clamped_width ..];
 
             switch (encoding) {
@@ -335,12 +338,12 @@ pub fn writePreQuotedString(text_in: []const u8, comptime Writer: type, writer: 
         }
     }
 }
-pub fn quoteForJSON(text: []const u8, bytes: *MutableString, comptime prefers_ascii: bool) !void {
+pub fn quoteForJSON(text: []const u8, bytes: *MutableString, comptime ascii_only: bool) !void {
     const writer = bytes.writer();
 
-    try bytes.growIfNeeded(estimateLengthForUTF8(text, prefers_ascii, '"'));
+    try bytes.growIfNeeded(estimateLengthForUTF8(text, ascii_only, '"'));
     try bytes.appendChar('"');
-    try writePreQuotedString(text, @TypeOf(writer), writer, '"', prefers_ascii, true, .utf8);
+    try writePreQuotedString(text, @TypeOf(writer), writer, '"', ascii_only, true, .utf8);
     bytes.appendChar('"') catch unreachable;
 }
 
@@ -594,6 +597,7 @@ const ImportVariant = enum {
 };
 
 fn NewPrinter(
+    comptime ascii_only: bool,
     comptime Writer: type,
     comptime rewrite_esm_to_cjs: bool,
     comptime is_bun_platform: bool,
@@ -615,7 +619,6 @@ fn NewPrinter(
         prev_reg_exp_end: i32 = -1,
         call_target: ?Expr.Data = null,
         writer: Writer,
-        prefers_ascii: bool,
 
         has_printed_bundled_import_statement: bool = false,
 
@@ -1581,9 +1584,9 @@ fn NewPrinter(
         pub fn printStringCharactersUTF8(e: *Printer, text: []const u8, quote: u8) void {
             const writer = e.writer.stdWriter();
             (switch (quote) {
-                '\'' => writePreQuotedString(text, @TypeOf(writer), writer, '\'', e.prefers_ascii, false, .utf8),
-                '"' => writePreQuotedString(text, @TypeOf(writer), writer, '"', e.prefers_ascii, false, .utf8),
-                '`' => writePreQuotedString(text, @TypeOf(writer), writer, '`', e.prefers_ascii, false, .utf8),
+                '\'' => writePreQuotedString(text, @TypeOf(writer), writer, '\'', ascii_only, false, .utf8),
+                '"' => writePreQuotedString(text, @TypeOf(writer), writer, '"', ascii_only, false, .utf8),
+                '`' => writePreQuotedString(text, @TypeOf(writer), writer, '`', ascii_only, false, .utf8),
                 else => unreachable,
             }) catch |err| switch (err) {};
         }
@@ -1592,9 +1595,9 @@ fn NewPrinter(
 
             const writer = e.writer.stdWriter();
             (switch (quote) {
-                '\'' => writePreQuotedString(slice, @TypeOf(writer), writer, '\'', e.prefers_ascii, false, .utf16),
-                '"' => writePreQuotedString(slice, @TypeOf(writer), writer, '"', e.prefers_ascii, false, .utf16),
-                '`' => writePreQuotedString(slice, @TypeOf(writer), writer, '`', e.prefers_ascii, false, .utf16),
+                '\'' => writePreQuotedString(slice, @TypeOf(writer), writer, '\'', ascii_only, false, .utf16),
+                '"' => writePreQuotedString(slice, @TypeOf(writer), writer, '"', ascii_only, false, .utf16),
+                '`' => writePreQuotedString(slice, @TypeOf(writer), writer, '`', ascii_only, false, .utf16),
                 else => unreachable,
             }) catch |err| switch (err) {};
         }
@@ -1978,8 +1981,8 @@ fn NewPrinter(
             }
         }
 
-        pub inline fn canPrintIdentifierUTF16(p: *Printer, name: []const u16) bool {
-            if (p.prefers_ascii) {
+        pub inline fn canPrintIdentifierUTF16(_: *Printer, name: []const u16) bool {
+            if (comptime ascii_only or ascii_only_always_on_unless_minifying) {
                 return js_lexer.isLatin1Identifier([]const u16, name);
             } else {
                 return js_lexer.isIdentifierUTF16(name);
@@ -1990,9 +1993,6 @@ fn NewPrinter(
             // Raw template literals must preserve bytes verbatim because they are
             // exposed to JavaScript via the .raw property and String.raw. Escaping
             // non-ASCII characters to \uXXXX would change the runtime string value.
-            const saved = p.prefers_ascii;
-            defer p.prefers_ascii = saved;
-            if (p.prefers_ascii and !strings.isAllASCII(bytes)) p.prefers_ascii = false;
             p.print(bytes);
         }
 
@@ -3203,14 +3203,7 @@ fn NewPrinter(
             // RegExp literals cannot be printed ascii-only because they expose a
             // .source property to JavaScript. Escaping non-ASCII would change the
             // runtime value of that property.
-            {
-                const saved = p.prefers_ascii;
-                defer p.prefers_ascii = saved;
-                if (p.prefers_ascii and !strings.isAllASCII(e.value)) {
-                    p.prefers_ascii = false;
-                }
-                p.print(e.value);
-            }
+            p.print(e.value);
 
             // Need a space before the next identifier to avoid it turning into flags
             p.prev_reg_exp_end = p.writer.written;
@@ -5156,7 +5149,7 @@ fn NewPrinter(
         }
 
         pub fn printIdentifier(p: *Printer, identifier: string) void {
-            if (p.prefers_ascii) {
+            if (comptime ascii_only) {
                 p.printIdentifierAsciiOnly(identifier);
             } else {
                 p.print(identifier);
@@ -5208,7 +5201,7 @@ fn NewPrinter(
                     i += 1;
                 }
 
-                if (p.prefers_ascii and c > last_ascii) {
+                if ((comptime ascii_only) and c > last_ascii) {
                     switch (c) {
                         0...0xFFFF => {
                             p.print(
@@ -5341,7 +5334,6 @@ fn NewPrinter(
             opts: Options,
             renamer: bun.renamer.Renamer,
             source_map_builder: SourceMap.Chunk.Builder,
-            prefers_ascii: bool,
         ) Printer {
             var printer = Printer{
                 .import_records = import_records,
@@ -5349,7 +5341,6 @@ fn NewPrinter(
                 .writer = writer,
                 .renamer = renamer,
                 .source_map_builder = source_map_builder,
-                .prefers_ascii = prefers_ascii,
             };
             if (comptime generate_source_map) {
                 // This seems silly to cache but the .items() function apparently costs 1ms according to Instruments.
@@ -5836,7 +5827,7 @@ pub fn printAst(
     tree: Ast,
     symbols: js_ast.Symbol.Map,
     source: *const logger.Source,
-    comptime is_bun_platform: bool,
+    comptime ascii_only: bool,
     opts: Options,
     comptime generate_source_map: bool,
 ) !usize {
@@ -5915,9 +5906,11 @@ pub fn printAst(
     }
 
     const PrinterType = NewPrinter(
+        ascii_only,
         Writer,
         false,
-        is_bun_platform,
+        // if it's ascii_only, it is also bun
+        ascii_only,
         false,
         generate_source_map,
     );
@@ -5928,8 +5921,7 @@ pub fn printAst(
         tree.import_records.slice(),
         opts,
         renamer,
-        getSourceMapBuilder(if (generate_source_map) .lazy else .disable, is_bun_platform, opts, source, &tree),
-        is_bun_platform,
+        getSourceMapBuilder(if (generate_source_map) .lazy else .disable, ascii_only, opts, source, &tree),
     );
     defer {
         if (comptime generate_source_map) {
@@ -6019,7 +6011,7 @@ pub fn printJSON(
     source: *const logger.Source,
     opts: Options,
 ) !usize {
-    const PrinterType = NewPrinter(Writer, false, false, true, false);
+    const PrinterType = NewPrinter(false, Writer, false, false, true, false);
     const writer = _writer;
     var s_expr = S.SExpr{ .value = expr };
     const stmt = Stmt{ .loc = logger.Loc.Empty, .data = .{
@@ -6038,7 +6030,6 @@ pub fn printJSON(
         opts,
         renamer.toRenamer(),
         undefined,
-        false,
     );
     var bin_stack_heap = std.heap.stackFallback(1024, bun.default_allocator);
     printer.binary_expression_stack = std.array_list.Managed(PrinterType.BinaryExpressionVisitor).init(bin_stack_heap.get());
@@ -6130,6 +6121,8 @@ pub fn printWithWriterAndPlatform(
     bun.crash_handler.current_action = .{ .print = source.path.text };
 
     const PrinterType = NewPrinter(
+        // if it's bun, it is also ascii_only
+        is_bun_platform,
         Writer,
         false,
         is_bun_platform,
@@ -6142,7 +6135,6 @@ pub fn printWithWriterAndPlatform(
         opts,
         renamer,
         getSourceMapBuilder(if (generate_source_maps) .eager else .disable, is_bun_platform, opts, source, &ast),
-        is_bun_platform,
     );
     printer.was_lazy_export = ast.has_lazy_export;
     if (PrinterType.may_have_module_info) {
@@ -6212,7 +6204,7 @@ pub fn printCommonJS(
     tree: Ast,
     symbols: js_ast.Symbol.Map,
     source: *const logger.Source,
-    comptime prefers_ascii: bool,
+    comptime ascii_only: bool,
     opts: Options,
     comptime generate_source_map: bool,
 ) !usize {
@@ -6220,7 +6212,7 @@ pub fn printCommonJS(
     defer bun.crash_handler.current_action = prev_action;
     bun.crash_handler.current_action = .{ .print = source.path.text };
 
-    const PrinterType = NewPrinter(Writer, true, false, false, generate_source_map);
+    const PrinterType = NewPrinter(ascii_only, Writer, true, false, false, generate_source_map);
     const writer = _writer;
     var renamer = rename.NoOpRenamer.init(symbols, source);
     var printer = PrinterType.init(
@@ -6229,7 +6221,6 @@ pub fn printCommonJS(
         opts,
         renamer.toRenamer(),
         getSourceMapBuilder(if (generate_source_map) .lazy else .disable, false, opts, source, &tree),
-        prefers_ascii,
     );
     var bin_stack_heap = std.heap.stackFallback(1024, bun.default_allocator);
     printer.binary_expression_stack = std.array_list.Managed(PrinterType.BinaryExpressionVisitor).init(bin_stack_heap.get());

--- a/src/js_printer/js_printer.zig
+++ b/src/js_printer/js_printer.zig
@@ -1992,7 +1992,8 @@ fn NewPrinter(
         fn printRawTemplateLiteral(p: *Printer, bytes: []const u8) void {
             // Raw template literals must preserve bytes verbatim because they are
             // exposed to JavaScript via the .raw property and String.raw. Escaping
-            // non-ASCII characters to \uXXXX would change the runtime string value.
+            // non-ASCII characters to unicode escape sequences would change the
+            // runtime string value.
             p.print(bytes);
         }
 

--- a/src/js_printer/js_printer.zig
+++ b/src/js_printer/js_printer.zig
@@ -5,9 +5,6 @@ const first_high_surrogate = 0xD800;
 const first_low_surrogate = 0xDC00;
 const last_low_surrogate = 0xDFFF;
 
-/// For support JavaScriptCore
-const ascii_only_always_on_unless_minifying = true;
-
 fn formatUnsignedIntegerBetween(comptime len: u16, buf: *[len]u8, val: u64) void {
     comptime var i: u16 = len;
     var remainder = val;
@@ -26,11 +23,11 @@ pub fn writeModuleId(comptime Writer: type, writer: Writer, module_id: u32) void
     std.fmt.formatInt(module_id, 16, .lower, .{}, writer) catch unreachable;
 }
 
-pub fn canPrintWithoutEscape(comptime CodePointType: type, c: CodePointType, comptime ascii_only: bool) bool {
+pub fn canPrintWithoutEscape(comptime CodePointType: type, c: CodePointType, prefers_ascii: bool) bool {
     if (c <= last_ascii) {
         return c >= first_ascii and c != '\\' and c != '"' and c != '\'' and c != '`' and c != '$';
     } else {
-        return !ascii_only and c != 0xFEFF and c != 0x2028 and c != 0x2029 and (c < first_high_surrogate or c > last_low_surrogate);
+        return !prefers_ascii and c != 0xFEFF and c != 0x2028 and c != 0x2029 and (c < first_high_surrogate or c > last_low_surrogate);
     }
 }
 
@@ -109,7 +106,7 @@ fn ws(comptime str: []const u8) Whitespacer {
     return .{ .normal = Static.with, .minify = Static.without };
 }
 
-pub fn estimateLengthForUTF8(input: []const u8, comptime ascii_only: bool, comptime quote_char: u8) usize {
+pub fn estimateLengthForUTF8(input: []const u8, comptime prefers_ascii: bool, comptime quote_char: u8) usize {
     var remaining = input;
     var len: usize = 2; // for quotes
 
@@ -130,7 +127,7 @@ pub fn estimateLengthForUTF8(input: []const u8, comptime ascii_only: bool, compt
             i32,
             0,
         );
-        if (canPrintWithoutEscape(i32, c, ascii_only)) {
+        if (canPrintWithoutEscape(i32, c, prefers_ascii)) {
             len += @as(usize, char_len);
         } else if (c <= 0xFFFF) {
             len += 6;
@@ -145,7 +142,7 @@ pub fn estimateLengthForUTF8(input: []const u8, comptime ascii_only: bool, compt
     return len;
 }
 
-pub fn writePreQuotedString(text_in: []const u8, comptime Writer: type, writer: Writer, comptime quote_char: u8, comptime ascii_only: bool, comptime json: bool, comptime encoding: strings.Encoding) !void {
+pub fn writePreQuotedString(text_in: []const u8, comptime Writer: type, writer: Writer, comptime quote_char: u8, prefers_ascii: bool, comptime json: bool, comptime encoding: strings.Encoding) !void {
     const text = if (comptime encoding == .utf16) @as([]const u16, @alignCast(std.mem.bytesAsSlice(u16, text_in))) else text_in;
     if (comptime json and quote_char != '"') @compileError("for json, quote_char must be '\"'");
     var i: usize = 0;
@@ -183,7 +180,7 @@ pub fn writePreQuotedString(text_in: []const u8, comptime Writer: type, writer: 
                 break :brk @as(i32, text[i]);
             },
         };
-        if (canPrintWithoutEscape(i32, c, ascii_only)) {
+        if (canPrintWithoutEscape(i32, c, prefers_ascii)) {
             const remain = text[i + clamped_width ..];
 
             switch (encoding) {
@@ -338,12 +335,12 @@ pub fn writePreQuotedString(text_in: []const u8, comptime Writer: type, writer: 
         }
     }
 }
-pub fn quoteForJSON(text: []const u8, bytes: *MutableString, comptime ascii_only: bool) !void {
+pub fn quoteForJSON(text: []const u8, bytes: *MutableString, comptime prefers_ascii: bool) !void {
     const writer = bytes.writer();
 
-    try bytes.growIfNeeded(estimateLengthForUTF8(text, ascii_only, '"'));
+    try bytes.growIfNeeded(estimateLengthForUTF8(text, prefers_ascii, '"'));
     try bytes.appendChar('"');
-    try writePreQuotedString(text, @TypeOf(writer), writer, '"', ascii_only, true, .utf8);
+    try writePreQuotedString(text, @TypeOf(writer), writer, '"', prefers_ascii, true, .utf8);
     bytes.appendChar('"') catch unreachable;
 }
 
@@ -597,7 +594,6 @@ const ImportVariant = enum {
 };
 
 fn NewPrinter(
-    comptime ascii_only: bool,
     comptime Writer: type,
     comptime rewrite_esm_to_cjs: bool,
     comptime is_bun_platform: bool,
@@ -619,6 +615,7 @@ fn NewPrinter(
         prev_reg_exp_end: i32 = -1,
         call_target: ?Expr.Data = null,
         writer: Writer,
+        prefers_ascii: bool,
 
         has_printed_bundled_import_statement: bool = false,
 
@@ -1584,9 +1581,9 @@ fn NewPrinter(
         pub fn printStringCharactersUTF8(e: *Printer, text: []const u8, quote: u8) void {
             const writer = e.writer.stdWriter();
             (switch (quote) {
-                '\'' => writePreQuotedString(text, @TypeOf(writer), writer, '\'', ascii_only, false, .utf8),
-                '"' => writePreQuotedString(text, @TypeOf(writer), writer, '"', ascii_only, false, .utf8),
-                '`' => writePreQuotedString(text, @TypeOf(writer), writer, '`', ascii_only, false, .utf8),
+                '\'' => writePreQuotedString(text, @TypeOf(writer), writer, '\'', e.prefers_ascii, false, .utf8),
+                '"' => writePreQuotedString(text, @TypeOf(writer), writer, '"', e.prefers_ascii, false, .utf8),
+                '`' => writePreQuotedString(text, @TypeOf(writer), writer, '`', e.prefers_ascii, false, .utf8),
                 else => unreachable,
             }) catch |err| switch (err) {};
         }
@@ -1595,9 +1592,9 @@ fn NewPrinter(
 
             const writer = e.writer.stdWriter();
             (switch (quote) {
-                '\'' => writePreQuotedString(slice, @TypeOf(writer), writer, '\'', ascii_only, false, .utf16),
-                '"' => writePreQuotedString(slice, @TypeOf(writer), writer, '"', ascii_only, false, .utf16),
-                '`' => writePreQuotedString(slice, @TypeOf(writer), writer, '`', ascii_only, false, .utf16),
+                '\'' => writePreQuotedString(slice, @TypeOf(writer), writer, '\'', e.prefers_ascii, false, .utf16),
+                '"' => writePreQuotedString(slice, @TypeOf(writer), writer, '"', e.prefers_ascii, false, .utf16),
+                '`' => writePreQuotedString(slice, @TypeOf(writer), writer, '`', e.prefers_ascii, false, .utf16),
                 else => unreachable,
             }) catch |err| switch (err) {};
         }
@@ -1981,8 +1978,8 @@ fn NewPrinter(
             }
         }
 
-        pub inline fn canPrintIdentifierUTF16(_: *Printer, name: []const u16) bool {
-            if (comptime ascii_only or ascii_only_always_on_unless_minifying) {
+        pub inline fn canPrintIdentifierUTF16(p: *Printer, name: []const u16) bool {
+            if (p.prefers_ascii) {
                 return js_lexer.isLatin1Identifier([]const u16, name);
             } else {
                 return js_lexer.isIdentifierUTF16(name);
@@ -1990,62 +1987,11 @@ fn NewPrinter(
         }
 
         fn printRawTemplateLiteral(p: *Printer, bytes: []const u8) void {
-            if (comptime is_json or !ascii_only) {
-                p.print(bytes);
-                return;
-            }
-
-            // Translate any non-ASCII to unicode escape sequences
-            // Note that this does not correctly handle malformed template literal strings
-            // template literal strings can contain invalid unicode code points
-            // and pretty much anything else
-            //
-            // we use WTF-8 here, but that's still not good enough.
-            //
-            var ascii_start: usize = 0;
-            var is_ascii = false;
-            var iter = CodepointIterator.init(bytes);
-            var cursor = CodepointIterator.Cursor{};
-
-            while (iter.next(&cursor)) {
-                switch (cursor.c) {
-                    // unlike other versions, we only want to mutate > 0x7F
-                    0...last_ascii => {
-                        if (!is_ascii) {
-                            ascii_start = cursor.i;
-                            is_ascii = true;
-                        }
-                    },
-                    else => {
-                        if (is_ascii) {
-                            p.print(bytes[ascii_start..cursor.i]);
-                            is_ascii = false;
-                        }
-
-                        switch (cursor.c) {
-                            0...0xFFFF => {
-                                p.print([_]u8{
-                                    '\\',
-                                    'u',
-                                    hex_chars[cursor.c >> 12],
-                                    hex_chars[(cursor.c >> 8) & 15],
-                                    hex_chars[(cursor.c >> 4) & 15],
-                                    hex_chars[cursor.c & 15],
-                                });
-                            },
-                            else => {
-                                p.print("\\u{");
-                                p.fmt("{x}", .{cursor.c}) catch unreachable;
-                                p.print("}");
-                            },
-                        }
-                    },
-                }
-            }
-
-            if (is_ascii) {
-                p.print(bytes[ascii_start..]);
-            }
+            // Raw template literals must preserve bytes verbatim because they are
+            // exposed to JavaScript via the .raw property and String.raw. Escaping
+            // non-ASCII characters to \uXXXX would change the runtime string value.
+            if (p.prefers_ascii and !strings.isAllASCII(bytes)) p.prefers_ascii = false;
+            p.print(bytes);
         }
 
         pub fn printExpr(p: *Printer, expr: Expr, level: Level, in_flags: ExprFlag.Set) void {
@@ -3252,70 +3198,13 @@ fn NewPrinter(
                 p.print(" ");
             }
 
-            if (comptime is_bun_platform) {
-                // Translate any non-ASCII to unicode escape sequences
-                var ascii_start: usize = 0;
-                var is_ascii = false;
-                var iter = CodepointIterator.init(e.value);
-                var cursor = CodepointIterator.Cursor{};
-                while (iter.next(&cursor)) {
-                    switch (cursor.c) {
-                        first_ascii...last_ascii => {
-                            if (!is_ascii) {
-                                ascii_start = cursor.i;
-                                is_ascii = true;
-                            }
-                        },
-                        else => {
-                            if (is_ascii) {
-                                p.print(e.value[ascii_start..cursor.i]);
-                                is_ascii = false;
-                            }
-
-                            switch (cursor.c) {
-                                0...0xFFFF => {
-                                    p.print([_]u8{
-                                        '\\',
-                                        'u',
-                                        hex_chars[cursor.c >> 12],
-                                        hex_chars[(cursor.c >> 8) & 15],
-                                        hex_chars[(cursor.c >> 4) & 15],
-                                        hex_chars[cursor.c & 15],
-                                    });
-                                },
-
-                                else => |c| {
-                                    const k = c - 0x10000;
-                                    const lo = @as(usize, @intCast(first_high_surrogate + ((k >> 10) & 0x3FF)));
-                                    const hi = @as(usize, @intCast(first_low_surrogate + (k & 0x3FF)));
-
-                                    p.print(&[_]u8{
-                                        '\\',
-                                        'u',
-                                        hex_chars[lo >> 12],
-                                        hex_chars[(lo >> 8) & 15],
-                                        hex_chars[(lo >> 4) & 15],
-                                        hex_chars[lo & 15],
-                                        '\\',
-                                        'u',
-                                        hex_chars[hi >> 12],
-                                        hex_chars[(hi >> 8) & 15],
-                                        hex_chars[(hi >> 4) & 15],
-                                        hex_chars[hi & 15],
-                                    });
-                                },
-                            }
-                        },
-                    }
-                }
-
-                if (is_ascii) {
-                    p.print(e.value[ascii_start..]);
-                }
-            } else {
-                // UTF8 sequence is fine
-                p.print(e.value);
+            // RegExp literals cannot be printed ascii-only because they expose a
+            // .source property to JavaScript. Escaping non-ASCII would change the
+            // runtime value of that property.
+            if (p.prefers_ascii and !strings.isAllASCII(e.value)) {
+                p.prefers_ascii = false;
             }
+            p.print(e.value);
 
             // Need a space before the next identifier to avoid it turning into flags
             p.prev_reg_exp_end = p.writer.written;
@@ -5261,7 +5150,7 @@ fn NewPrinter(
         }
 
         pub fn printIdentifier(p: *Printer, identifier: string) void {
-            if (comptime ascii_only) {
+            if (p.prefers_ascii) {
                 p.printIdentifierAsciiOnly(identifier);
             } else {
                 p.print(identifier);
@@ -5313,7 +5202,7 @@ fn NewPrinter(
                     i += 1;
                 }
 
-                if ((comptime ascii_only) and c > last_ascii) {
+                if (p.prefers_ascii and c > last_ascii) {
                     switch (c) {
                         0...0xFFFF => {
                             p.print(
@@ -5446,6 +5335,7 @@ fn NewPrinter(
             opts: Options,
             renamer: bun.renamer.Renamer,
             source_map_builder: SourceMap.Chunk.Builder,
+            prefers_ascii: bool,
         ) Printer {
             var printer = Printer{
                 .import_records = import_records,
@@ -5453,6 +5343,7 @@ fn NewPrinter(
                 .writer = writer,
                 .renamer = renamer,
                 .source_map_builder = source_map_builder,
+                .prefers_ascii = prefers_ascii,
             };
             if (comptime generate_source_map) {
                 // This seems silly to cache but the .items() function apparently costs 1ms according to Instruments.
@@ -5939,7 +5830,7 @@ pub fn printAst(
     tree: Ast,
     symbols: js_ast.Symbol.Map,
     source: *const logger.Source,
-    comptime ascii_only: bool,
+    comptime is_bun_platform: bool,
     opts: Options,
     comptime generate_source_map: bool,
 ) !usize {
@@ -6018,11 +5909,9 @@ pub fn printAst(
     }
 
     const PrinterType = NewPrinter(
-        ascii_only,
         Writer,
         false,
-        // if it's ascii_only, it is also bun
-        ascii_only,
+        is_bun_platform,
         false,
         generate_source_map,
     );
@@ -6033,7 +5922,8 @@ pub fn printAst(
         tree.import_records.slice(),
         opts,
         renamer,
-        getSourceMapBuilder(if (generate_source_map) .lazy else .disable, ascii_only, opts, source, &tree),
+        getSourceMapBuilder(if (generate_source_map) .lazy else .disable, is_bun_platform, opts, source, &tree),
+        is_bun_platform,
     );
     defer {
         if (comptime generate_source_map) {
@@ -6123,7 +6013,7 @@ pub fn printJSON(
     source: *const logger.Source,
     opts: Options,
 ) !usize {
-    const PrinterType = NewPrinter(false, Writer, false, false, true, false);
+    const PrinterType = NewPrinter(Writer, false, false, true, false);
     const writer = _writer;
     var s_expr = S.SExpr{ .value = expr };
     const stmt = Stmt{ .loc = logger.Loc.Empty, .data = .{
@@ -6142,6 +6032,7 @@ pub fn printJSON(
         opts,
         renamer.toRenamer(),
         undefined,
+        false,
     );
     var bin_stack_heap = std.heap.stackFallback(1024, bun.default_allocator);
     printer.binary_expression_stack = std.array_list.Managed(PrinterType.BinaryExpressionVisitor).init(bin_stack_heap.get());
@@ -6233,8 +6124,6 @@ pub fn printWithWriterAndPlatform(
     bun.crash_handler.current_action = .{ .print = source.path.text };
 
     const PrinterType = NewPrinter(
-        // if it's bun, it is also ascii_only
-        is_bun_platform,
         Writer,
         false,
         is_bun_platform,
@@ -6247,6 +6136,7 @@ pub fn printWithWriterAndPlatform(
         opts,
         renamer,
         getSourceMapBuilder(if (generate_source_maps) .eager else .disable, is_bun_platform, opts, source, &ast),
+        is_bun_platform,
     );
     printer.was_lazy_export = ast.has_lazy_export;
     if (PrinterType.may_have_module_info) {
@@ -6316,7 +6206,7 @@ pub fn printCommonJS(
     tree: Ast,
     symbols: js_ast.Symbol.Map,
     source: *const logger.Source,
-    comptime ascii_only: bool,
+    comptime prefers_ascii: bool,
     opts: Options,
     comptime generate_source_map: bool,
 ) !usize {
@@ -6324,7 +6214,7 @@ pub fn printCommonJS(
     defer bun.crash_handler.current_action = prev_action;
     bun.crash_handler.current_action = .{ .print = source.path.text };
 
-    const PrinterType = NewPrinter(ascii_only, Writer, true, false, false, generate_source_map);
+    const PrinterType = NewPrinter(Writer, true, false, false, generate_source_map);
     const writer = _writer;
     var renamer = rename.NoOpRenamer.init(symbols, source);
     var printer = PrinterType.init(
@@ -6333,6 +6223,7 @@ pub fn printCommonJS(
         opts,
         renamer.toRenamer(),
         getSourceMapBuilder(if (generate_source_map) .lazy else .disable, false, opts, source, &tree),
+        prefers_ascii,
     );
     var bin_stack_heap = std.heap.stackFallback(1024, bun.default_allocator);
     printer.binary_expression_stack = std.array_list.Managed(PrinterType.BinaryExpressionVisitor).init(bin_stack_heap.get());

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3230,53 +3230,11 @@ pub mod __gated_printer {
         }
 
         fn print_raw_template_literal(&mut self, bytes: &[u8]) {
-            if IS_JSON || !ASCII_ONLY {
-                self.print(bytes);
-                return;
-            }
-
-            // Translate any non-ASCII to unicode escape sequences
-            // Note that this does not correctly handle malformed template literal strings
-            // template literal strings can contain invalid unicode code points
-            // and pretty much anything else
-            //
-            // we use WTF-8 here, but that's still not good enough.
-            //
-            let mut ascii_start: usize = 0;
-            let mut is_ascii = false;
-            let mut iter = CodepointIterator::init(bytes);
-            let mut cursor = strings::Cursor::default();
-
-            while iter.next(&mut cursor) {
-                match cursor.c as u32 {
-                    // unlike other versions, we only want to mutate > 0x7F
-                    0..=LAST_ASCII => {
-                        if !is_ascii {
-                            ascii_start = (cursor.i as usize);
-                            is_ascii = true;
-                        }
-                    }
-                    _ => {
-                        if is_ascii {
-                            self.print(&bytes[ascii_start..(cursor.i as usize)]);
-                            is_ascii = false;
-                        }
-
-                        match cursor.c as u32 {
-                            c @ 0..=0xFFFF => self.print(&bmp_escape(c)[..]),
-                            _ => {
-                                self.print(b"\\u{");
-                                let _ = self.fmt(format_args!("{:x}", cursor.c));
-                                self.print(b"}");
-                            }
-                        }
-                    }
-                }
-            }
-
-            if is_ascii {
-                self.print(&bytes[ascii_start..]);
-            }
+            // Raw template literals must preserve bytes verbatim because they are
+            // exposed to JavaScript via the .raw property and String.raw. Escaping
+            // non-ASCII characters to unicode escape sequences would change the
+            // runtime string value.
+            self.print(bytes);
         }
 
         pub fn print_expr(&mut self, expr: Expr, level: Level, in_flags: ExprFlagSet) {
@@ -4629,41 +4587,10 @@ pub mod __gated_printer {
                 self.print(b" ");
             }
 
-            if IS_BUN_PLATFORM {
-                // Translate any non-ASCII to unicode escape sequences
-                let mut ascii_start: usize = 0;
-                let mut is_ascii = false;
-                let mut iter = CodepointIterator::init(&e.value);
-                let mut cursor = strings::Cursor::default();
-                while iter.next(&mut cursor) {
-                    match cursor.c as u32 {
-                        FIRST_ASCII..=LAST_ASCII => {
-                            if !is_ascii {
-                                ascii_start = (cursor.i as usize);
-                                is_ascii = true;
-                            }
-                        }
-                        _ => {
-                            if is_ascii {
-                                self.print(&e.value[ascii_start..(cursor.i as usize)]);
-                                is_ascii = false;
-                            }
-
-                            match cursor.c as u32 {
-                                c @ 0..=0xFFFF => self.print(&bmp_escape(c)[..]),
-                                c => self.print(&surrogate_pair_escape(c)[..]),
-                            }
-                        }
-                    }
-                }
-
-                if is_ascii {
-                    self.print(&e.value[ascii_start..]);
-                }
-            } else {
-                // UTF8 sequence is fine
-                self.print(&e.value[..]);
-            }
+            // RegExp literals cannot be printed ascii-only because they expose a
+            // .source property to JavaScript. Escaping non-ASCII would change the
+            // runtime value of that property.
+            self.print(&e.value[..]);
 
             // Need a space before the next identifier to avoid it turning into flags
             self.prev_reg_exp_end = self.writer.written();

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -1363,16 +1363,9 @@ impl AsyncModule {
 
         // SAFETY: per-thread VM.
         if unsafe { (*jsc_vm).is_watcher_enabled() } {
-            // SAFETY: per-thread VM.
-            let mut resolved_source = unsafe {
-                (*jsc_vm).ref_counted_resolved_source::<false>(
-                    printer.ctx.get_written(),
-                    BunString::init(specifier),
-                    path.text,
-                    None,
-                )
-            };
-
+            // Register the source file with the watcher. This has nothing to
+            // do with the output encoding — run it whether we take the
+            // ref-counted Latin-1 path or fall through to `clone_utf8` below.
             if let Some(fd_) = input_fd {
                 if bun_paths::is_absolute(path.text)
                     && !strings::contains(path.text, b"node_modules")
@@ -1404,13 +1397,29 @@ impl AsyncModule {
                 }
             }
 
-            resolved_source.is_commonjs_module = is_commonjs_module;
-
-            return Ok(resolved_source);
+            // The ref-counted watcher path creates Latin-1 strings, which
+            // cannot represent multi-byte UTF-8 sequences. If the output
+            // contains non-ASCII (from raw template literals or regex
+            // source), fall through to the normal path which uses
+            // `clone_utf8`.
+            let written = printer.ctx.get_written();
+            if bun_core::strings::is_all_ascii(written) {
+                // SAFETY: per-thread VM.
+                let mut resolved_source = unsafe {
+                    (*jsc_vm).ref_counted_resolved_source::<false>(
+                        written,
+                        BunString::init(specifier),
+                        path.text,
+                        None,
+                    )
+                };
+                resolved_source.is_commonjs_module = is_commonjs_module;
+                return Ok(resolved_source);
+            }
         }
 
         Ok(ResolvedSource {
-            source_code: BunString::clone_latin1(printer.ctx.get_written()),
+            source_code: BunString::clone_utf8(printer.ctx.get_written()),
             specifier: BunString::init(specifier),
             source_url: BunString::init(path.text),
             is_commonjs_module,

--- a/src/jsc/AsyncModule.zig
+++ b/src/jsc/AsyncModule.zig
@@ -726,7 +726,7 @@ pub const AsyncModule = struct {
 
         return ResolvedSource{
             .allocator = null,
-            .source_code = bun.String.cloneLatin1(printer.ctx.getWritten()),
+            .source_code = bun.String.cloneUTF8(printer.ctx.getWritten()),
             .specifier = String.init(specifier),
             .source_url = String.init(path.text),
             .is_commonjs_module = parse_result.ast.has_commonjs_export_names or parse_result.ast.exports_kind == .cjs,

--- a/src/jsc/AsyncModule.zig
+++ b/src/jsc/AsyncModule.zig
@@ -702,7 +702,11 @@ pub const AsyncModule = struct {
             dumpSource(jsc_vm, specifier, &printer);
         }
 
-        if (jsc_vm.isWatcherEnabled()) {
+        // The ref-counted watcher path creates Latin-1 strings, which cannot
+        // represent multi-byte UTF-8 sequences. If the output contains non-ASCII
+        // (from raw template literals or regex source), fall through to the
+        // normal path which uses cloneUTF8.
+        if (jsc_vm.isWatcherEnabled() and bun.strings.isAllASCII(printer.ctx.written)) {
             var resolved_source = jsc_vm.refCountedResolvedSource(printer.ctx.written, bun.String.init(specifier), path.text, null, false);
 
             if (parse_result.input_fd) |fd_| {

--- a/src/jsc/AsyncModule.zig
+++ b/src/jsc/AsyncModule.zig
@@ -702,13 +702,7 @@ pub const AsyncModule = struct {
             dumpSource(jsc_vm, specifier, &printer);
         }
 
-        // The ref-counted watcher path creates Latin-1 strings, which cannot
-        // represent multi-byte UTF-8 sequences. If the output contains non-ASCII
-        // (from raw template literals or regex source), fall through to the
-        // normal path which uses cloneUTF8.
-        if (jsc_vm.isWatcherEnabled() and bun.strings.isAllASCII(printer.ctx.written)) {
-            var resolved_source = jsc_vm.refCountedResolvedSource(printer.ctx.written, bun.String.init(specifier), path.text, null, false);
-
+        if (jsc_vm.isWatcherEnabled()) {
             if (parse_result.input_fd) |fd_| {
                 if (std.fs.path.isAbsolute(path.text) and !strings.contains(path.text, "node_modules")) {
                     _ = jsc_vm.bun_watcher.addFile(
@@ -723,9 +717,15 @@ pub const AsyncModule = struct {
                 }
             }
 
-            resolved_source.is_commonjs_module = parse_result.ast.has_commonjs_export_names or parse_result.ast.exports_kind == .cjs;
-
-            return resolved_source;
+            // The ref-counted watcher path creates Latin-1 strings, which cannot
+            // represent multi-byte UTF-8 sequences. If the output contains non-ASCII
+            // (from raw template literals or regex source), fall through to the
+            // normal path which uses cloneUTF8.
+            if (bun.strings.isAllASCII(printer.ctx.written)) {
+                var resolved_source = jsc_vm.refCountedResolvedSource(printer.ctx.written, bun.String.init(specifier), path.text, null, false);
+                resolved_source.is_commonjs_module = parse_result.ast.has_commonjs_export_names or parse_result.ast.exports_kind == .cjs;
+                return resolved_source;
+            }
         }
 
         return ResolvedSource{

--- a/src/jsc/ModuleLoader.zig
+++ b/src/jsc/ModuleLoader.zig
@@ -550,7 +550,11 @@ pub fn transpileSourceCode(
 
             const module_info_deserialized: ?*anyopaque = if (module_info) |mi| @ptrCast(mi.asDeserialized()) else null;
 
-            if (jsc_vm.isWatcherEnabled()) {
+            // The ref-counted watcher path creates Latin-1 strings, which cannot
+            // represent multi-byte UTF-8 sequences. If the output contains non-ASCII
+            // (from raw template literals or regex source), fall through to the
+            // normal path which uses cloneUTF8.
+            if (jsc_vm.isWatcherEnabled() and bun.strings.isAllASCII(printer.ctx.written)) {
                 var resolved_source = jsc_vm.refCountedResolvedSource(printer.ctx.written, input_specifier, path.text, null, false);
                 resolved_source.is_commonjs_module = is_commonjs_module;
                 resolved_source.module_info = module_info_deserialized;

--- a/src/jsc/ModuleLoader.zig
+++ b/src/jsc/ModuleLoader.zig
@@ -387,7 +387,7 @@ pub fn transpileSourceCode(
                 const bytecode_slice = parse_result.already_bundled.bytecodeSlice();
                 return ResolvedSource{
                     .allocator = null,
-                    .source_code = bun.String.cloneLatin1(source.contents),
+                    .source_code = bun.String.cloneUTF8(source.contents),
                     .specifier = input_specifier,
                     .source_url = input_specifier.createIfDifferent(path.text),
                     .already_bundled = true,
@@ -576,7 +576,7 @@ pub fn transpileSourceCode(
                 .allocator = null,
                 .source_code = brk: {
                     const written = printer.ctx.getWritten();
-                    const result = cache.output_code orelse bun.String.cloneLatin1(written);
+                    const result = cache.output_code orelse bun.String.cloneUTF8(written);
 
                     if (written.len > 1024 * 1024 * 2 or jsc_vm.smol) {
                         printer.ctx.buffer.deinit();

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -1056,7 +1056,7 @@ impl RuntimeTranspilerCache {
         }
         #[cfg(debug_assertions)]
         {
-            bun_core::scoped_log!(cache, "put() = {} bytes", output_code.latin1().len());
+            bun_core::scoped_log!(cache, "put() = {} bytes", output_code.length());
         }
     }
 }
@@ -1107,16 +1107,17 @@ bun_ast::link_impl_TranspilerCacheImpl! {
             }
             debug_assert!(this.entry.is_none());
 
-            // Borrowed Latin-1 view for ASCII output (the common case): `to_file`
-            // only reads `byte_slice()` + the encoding tag (unmarked 8-bit
-            // ZigString -> Encoding::LATIN1), and `output_code_bytes` outlives
-            // the synchronous `to_file` call. For non-ASCII output (raw
-            // template/regex with unicode), clone as UTF-8 so `to_file` takes
-            // the UTF-8 branch and the bytes aren't misinterpreted as Latin-1.
+            // Borrowed view — `output_code_bytes` outlives the synchronous
+            // `to_file` call and `to_file` only reads `byte_slice()` + the
+            // encoding tag. ASCII: unmarked 8-bit ZigString -> Encoding::LATIN1.
+            // Non-ASCII: UTF-8 mark so `to_file` takes the UTF-8 branch and
+            // the bytes aren't misinterpreted as Latin-1. Both variants are
+            // refcount-free (no WTFStringImpl), so BunString's lack of Drop
+            // doesn't leak.
             let output_code = if bun_core::strings::is_all_ascii(output_code_bytes) {
                 BunString::ascii(output_code_bytes)
             } else {
-                BunString::clone_utf8(output_code_bytes)
+                BunString::borrow_utf8(output_code_bytes)
             };
             let result = RuntimeTranspilerCache::to_file(
                 this.input_byte_length.unwrap(),

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -43,7 +43,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 22: Serialize `has_tla` in the cached ESM record flags byte. Entries
 /// written before #30888 carried `has_tla=false` for every module; the cache-HIT
 /// path reinstates the bug for any previously-cached TLA module (#30887).
-const EXPECTED_VERSION: u32 = 22;
+/// Version 23: Emits UTF-8 files in rare cases (tagged templates, regex with unicode)
+const EXPECTED_VERSION: u32 = 23;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a
@@ -1036,7 +1037,7 @@ impl RuntimeTranspilerCache {
             return;
         }
         debug_assert!(self.entry.is_none());
-        let output_code = BunString::clone_latin1(output_code_bytes);
+        let output_code = BunString::clone_utf8(output_code_bytes);
         // Zig: `this.output_code = output_code;` — refcount stays at 1, sole owner.
         // BunString is Copy with no Drop, so an extra dupe_ref here would leak.
         self.output_code = Some(output_code);
@@ -1106,10 +1107,17 @@ bun_ast::link_impl_TranspilerCacheImpl! {
             }
             debug_assert!(this.entry.is_none());
 
-            // Borrowed Latin-1 view: `to_file` only reads `byte_slice()` + the encoding
-            // tag (unmarked 8-bit ZigString -> Encoding::LATIN1, same as clone_latin1),
-            // and `output_code_bytes` outlives the synchronous `to_file` call.
-            let output_code = BunString::ascii(output_code_bytes);
+            // Borrowed Latin-1 view for ASCII output (the common case): `to_file`
+            // only reads `byte_slice()` + the encoding tag (unmarked 8-bit
+            // ZigString -> Encoding::LATIN1), and `output_code_bytes` outlives
+            // the synchronous `to_file` call. For non-ASCII output (raw
+            // template/regex with unicode), clone as UTF-8 so `to_file` takes
+            // the UTF-8 branch and the bytes aren't misinterpreted as Latin-1.
+            let output_code = if bun_core::strings::is_all_ascii(output_code_bytes) {
+                BunString::ascii(output_code_bytes)
+            } else {
+                BunString::clone_utf8(output_code_bytes)
+            };
             let result = RuntimeTranspilerCache::to_file(
                 this.input_byte_length.unwrap(),
                 this.input_hash.unwrap(),

--- a/src/jsc/RuntimeTranspilerCache.zig
+++ b/src/jsc/RuntimeTranspilerCache.zig
@@ -17,7 +17,8 @@
 /// Version 18: Include ESM record (module info) with an ES Module, see #15758
 /// Version 19: Sourcemap blob is InternalSourceMap (varint stream + sync points), not VLQ.
 /// Version 20: InternalSourceMap stream is bit-packed windows.
-const expected_version = 20;
+/// Version 21: Emits UTF-8 files in rare cases (tagged templates, regex with unicode)
+const expected_version = 21;
 
 const debug = Output.scoped(.cache, .visible);
 // Source files smaller than this are not written to / read from the on-disk
@@ -696,7 +697,7 @@ pub const RuntimeTranspilerCache = struct {
             return;
         }
         bun.assert(this.entry == null);
-        const output_code = bun.String.cloneLatin1(output_code_bytes);
+        const output_code = bun.String.cloneUTF8(output_code_bytes);
         this.output_code = output_code;
 
         toFile(this.input_byte_length.?, this.input_hash.?, this.features_hash.?, sourcemap, esm_record, output_code, this.exports_kind) catch |err| {
@@ -704,7 +705,7 @@ pub const RuntimeTranspilerCache = struct {
             return;
         };
         if (comptime bun.Environment.allow_assert)
-            debug("put() = {d} bytes", .{output_code.latin1().len});
+            debug("put() = {d} bytes", .{output_code.length()});
     }
 };
 

--- a/src/jsc/RuntimeTranspilerCache.zig
+++ b/src/jsc/RuntimeTranspilerCache.zig
@@ -324,6 +324,11 @@ pub const RuntimeTranspilerCache = struct {
                     if (read_bytes != this.metadata.output_byte_length) {
                         return error.MissingData;
                     }
+                    if (this.metadata.output_hash != 0) {
+                        if (hash(utf8) != this.metadata.output_hash) {
+                            return error.InvalidHash;
+                        }
+                    }
                     break :brk .{ .utf8 = utf8 };
                 },
                 .latin1 => brk: {

--- a/src/jsc/RuntimeTranspilerCache.zig
+++ b/src/jsc/RuntimeTranspilerCache.zig
@@ -17,8 +17,9 @@
 /// Version 18: Include ESM record (module info) with an ES Module, see #15758
 /// Version 19: Sourcemap blob is InternalSourceMap (varint stream + sync points), not VLQ.
 /// Version 20: InternalSourceMap stream is bit-packed windows.
-/// Version 21: Emits UTF-8 files in rare cases (tagged templates, regex with unicode)
-const expected_version = 21;
+/// Version 21: ModuleInfo records a phase byte per requested module (`import defer`).
+/// Version 22: Emits UTF-8 files in rare cases (tagged templates, regex with unicode)
+const expected_version = 22;
 
 const debug = Output.scoped(.cache, .visible);
 // Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.zig
+++ b/src/jsc/RuntimeTranspilerCache.zig
@@ -18,8 +18,12 @@
 /// Version 19: Sourcemap blob is InternalSourceMap (varint stream + sync points), not VLQ.
 /// Version 20: InternalSourceMap stream is bit-packed windows.
 /// Version 21: ModuleInfo records a phase byte per requested module (`import defer`).
-/// Version 22: Emits UTF-8 files in rare cases (tagged templates, regex with unicode)
-const expected_version = 22;
+/// Version 22: Serialize `has_tla` in the cached ESM record flags byte. Entries
+///             written before #30888 carried `has_tla=false` for every module;
+///             the cache-HIT path reinstates the bug for any previously-cached
+///             TLA module (#30887).
+/// Version 23: Emits UTF-8 files in rare cases (tagged templates, regex with unicode)
+const expected_version = 23;
 
 const debug = Output.scoped(.cache, .visible);
 // Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -1041,7 +1041,7 @@ impl TranspilerJob {
         if !matches!(parse_result.already_bundled, AlreadyBundled::None) {
             let bytecode_slice = parse_result.already_bundled.bytecode_slice();
             self.resolved_source = OwnedResolvedSource::new(ResolvedSource {
-                source_code: String::clone_latin1(&parse_result.source.contents),
+                source_code: String::clone_utf8(&parse_result.source.contents),
                 already_bundled: true,
                 bytecode_cache: if !bytecode_slice.is_empty() {
                     bytecode_slice.as_ptr().cast_mut()
@@ -1191,7 +1191,7 @@ impl TranspilerJob {
             // `cache.output_code` (only the `r#impl == None` fallback does,
             // and `r#impl` is `Some(Jsc)` here), so it is always `None`.
             debug_assert!(cache.output_code.is_none());
-            let result = String::clone_latin1(written);
+            let result = String::clone_utf8(written);
 
             // SAFETY: leaf scalar field read on `*vm`; see `vm` PORT NOTE above.
             if written.len() > 1024 * 1024 * 2 || unsafe { (*vm).smol } {

--- a/src/jsc/RuntimeTranspilerStore.zig
+++ b/src/jsc/RuntimeTranspilerStore.zig
@@ -510,7 +510,7 @@ pub const RuntimeTranspilerStore = struct {
                 const bytecode_slice = parse_result.already_bundled.bytecodeSlice();
                 this.resolved_source = ResolvedSource{
                     .allocator = null,
-                    .source_code = bun.String.cloneLatin1(parse_result.source.contents),
+                    .source_code = bun.String.cloneUTF8(parse_result.source.contents),
                     .already_bundled = true,
                     .bytecode_cache = if (bytecode_slice.len > 0) bytecode_slice.ptr else null,
                     .bytecode_cache_size = bytecode_slice.len,
@@ -589,7 +589,7 @@ pub const RuntimeTranspilerStore = struct {
             const source_code = brk: {
                 const written = printer.ctx.getWritten();
 
-                const result = cache.output_code orelse bun.String.cloneLatin1(written);
+                const result = cache.output_code orelse bun.String.cloneUTF8(written);
 
                 if (written.len > 1024 * 1024 * 2 or vm.smol) {
                     printer.ctx.buffer.deinit();

--- a/src/jsc/bindings/ZigSourceProvider.cpp
+++ b/src/jsc/bindings/ZigSourceProvider.cpp
@@ -9,6 +9,7 @@
 #include <JavaScriptCore/BytecodeCacheError.h>
 #include "ZigGlobalObject.h"
 #include "wtf/Assertions.h"
+#include "wtf/SIMDUTF.h"
 
 #include <JavaScriptCore/Completion.h>
 #include <wtf/Scope.h>
@@ -208,10 +209,26 @@ static JSC::VM& getVMForBytecodeCache()
     return *vmForBytecodeCache;
 }
 
+// Bundler output may contain raw UTF-8 multi-byte sequences (non-ASCII chars
+// in tagged template literals and regex `.source`). If interpreted as Latin-1,
+// the SourceCodeKey computed here at build time will not match the key
+// computed at runtime when the same chunk is loaded via the UTF-8 path
+// (helpers.h `toStringCopy` decodes UTF-8-tagged ZigStrings with
+// `fromUTF8ReplacingInvalidSequences`), and the cached bytecode is silently
+// discarded. Detect non-ASCII and decode as UTF-8 so the two keys agree.
+static WTF::String makeBundledSourceString(const Latin1Character* inputSourceCode, size_t inputSourceCodeSize)
+{
+    if (simdutf::validate_ascii(reinterpret_cast<const char*>(inputSourceCode), inputSourceCodeSize))
+        return WTF::String(std::span<const Latin1Character>(inputSourceCode, inputSourceCodeSize));
+    return WTF::String::fromUTF8ReplacingInvalidSequences(std::span<const Latin1Character>(inputSourceCode, inputSourceCodeSize));
+}
+
 extern "C" bool generateCachedModuleByteCodeFromSourceCode(BunString* sourceProviderURL, const Latin1Character* inputSourceCode, size_t inputSourceCodeSize, const uint8_t** outputByteCode, size_t* outputByteCodeSize, JSC::CachedBytecode** cachedBytecodePtr)
 {
-    std::span<const Latin1Character> sourceCodeSpan(inputSourceCode, inputSourceCodeSize);
-    JSC::SourceCode sourceCode = JSC::makeSource(WTF::String(sourceCodeSpan), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
+    WTF::String source = makeBundledSourceString(inputSourceCode, inputSourceCodeSize);
+    if (source.isNull())
+        return false;
+    JSC::SourceCode sourceCode = JSC::makeSource(WTF::move(source), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
 
     JSC::VM& vm = getVMForBytecodeCache();
 
@@ -245,9 +262,10 @@ extern "C" bool generateCachedModuleByteCodeFromSourceCode(BunString* sourceProv
 
 extern "C" bool generateCachedCommonJSProgramByteCodeFromSourceCode(BunString* sourceProviderURL, const Latin1Character* inputSourceCode, size_t inputSourceCodeSize, const uint8_t** outputByteCode, size_t* outputByteCodeSize, JSC::CachedBytecode** cachedBytecodePtr)
 {
-    std::span<const Latin1Character> sourceCodeSpan(inputSourceCode, inputSourceCodeSize);
-
-    JSC::SourceCode sourceCode = JSC::makeSource(WTF::String(sourceCodeSpan), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
+    WTF::String source = makeBundledSourceString(inputSourceCode, inputSourceCodeSize);
+    if (source.isNull())
+        return false;
+    JSC::SourceCode sourceCode = JSC::makeSource(WTF::move(source), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
     JSC::VM& vm = getVMForBytecodeCache();
 
     JSC::JSLockHolder locker(vm);

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4245,7 +4245,7 @@ pub fn finalize_bundle(
                 }
             }
         } else {
-            match c::bake_load_server_hmr_patch(global, BunString::clone_latin1(&server_bundle)) {
+            match c::bake_load_server_hmr_patch(global, BunString::clone_utf8(&server_bundle)) {
                 Ok(v) => v,
                 Err(err) => {
                     // SAFETY: vm is JSC_BORROW — valid for DevServer lifetime;

--- a/src/runtime/bake/DevServer.zig
+++ b/src/runtime/bake/DevServer.zig
@@ -2586,7 +2586,7 @@ pub fn finalizeBundle(
                 dev.vm.printErrorLikeObjectToConsole(dev.vm.global.takeException(err));
                 @panic("Error thrown while evaluating server code. This is always a bug in the bundler.");
             };
-        } else c.BakeLoadServerHmrPatch(@ptrCast(dev.vm.global), bun.String.cloneLatin1(server_bundle)) catch |err| {
+        } else c.BakeLoadServerHmrPatch(@ptrCast(dev.vm.global), bun.String.cloneUTF8(server_bundle)) catch |err| {
             dev.vm.printErrorLikeObjectToConsole(dev.vm.global.takeException(err));
             @panic("Error thrown while evaluating server code. This is always a bug in the bundler.");
         };

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2696,7 +2696,7 @@ fn transpile_source_code_inner(
                         _ => (core::ptr::null_mut(), 0),
                     };
                     return Ok(OwnedResolvedSource::new(ResolvedSource {
-                        source_code: bun_core::String::clone_latin1(&source.contents),
+                        source_code: bun_core::String::clone_utf8(&source.contents),
                         specifier: input_specifier.dupe_ref(),
                         source_url: create_if_different(input_specifier, path.text),
                         already_bundled: true,
@@ -2961,24 +2961,32 @@ fn transpile_source_code_inner(
                 // `is_commonjs_module`/`module_info` patched on). Gated so the
                 // fall-through to the non-watcher tail below is an explicit,
                 // intentional degradation rather than a silent live divergence.
+                // The ref-counted watcher path creates Latin-1 strings, which
+                // cannot represent multi-byte UTF-8 sequences. If the output
+                // contains non-ASCII (from raw template literals or regex
+                // source), fall through to the normal path which uses
+                // `clone_utf8`.
                 if unsafe { &*jsc_vm }.is_watcher_enabled() {
                     // SAFETY: `extra.source_code_printer` is non-null per
                     // `TranspileExtra` contract; rederive after the print block
                     // (Stacked Borrows — see the matching note below).
                     let printer: &mut bun_js_printer::BufferPrinter =
                         unsafe { &mut *(*extra).source_code_printer };
-                    let mut resolved_source = unsafe {
-                        (*jsc_vm).ref_counted_resolved_source::<false>(
-                            printer.ctx.get_written(),
-                            input_specifier.dupe_ref(),
-                            path.text,
-                            None,
-                        )
-                    };
-                    resolved_source.is_commonjs_module = is_commonjs_module;
-                    // TODO(b2-blocked): `analyze_transpiled_module::ModuleInfo::create`.
-                    resolved_source.module_info = core::ptr::null_mut();
-                    return Ok(OwnedResolvedSource::new(resolved_source));
+                    let written = printer.ctx.get_written();
+                    if bun_core::strings::is_all_ascii(written) {
+                        let mut resolved_source = unsafe {
+                            (*jsc_vm).ref_counted_resolved_source::<false>(
+                                written,
+                                input_specifier.dupe_ref(),
+                                path.text,
+                                None,
+                            )
+                        };
+                        resolved_source.is_commonjs_module = is_commonjs_module;
+                        // TODO(b2-blocked): `analyze_transpiled_module::ModuleInfo::create`.
+                        resolved_source.module_info = core::ptr::null_mut();
+                        return Ok(OwnedResolvedSource::new(resolved_source));
+                    }
                 }
 
                 // Spec :561-592 — final ResolvedSource.
@@ -3045,7 +3053,7 @@ fn transpile_source_code_inner(
                 // does, and `r#impl` is `Some(Jsc)` here), so it is always
                 // `None`.
                 debug_assert!(cache.output_code.is_none());
-                let source_code = bun_core::String::clone_latin1(written);
+                let source_code = bun_core::String::clone_utf8(written);
                 if written.len() > 1024 * 1024 * 2 || unsafe { &*jsc_vm }.smol {
                     // PERF(port): spec deinits the printer buffer; Rust drops on
                     // next `reset()`. TODO(port): expose `BufferWriter::deinit`.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2961,32 +2961,38 @@ fn transpile_source_code_inner(
                 // `is_commonjs_module`/`module_info` patched on). Gated so the
                 // fall-through to the non-watcher tail below is an explicit,
                 // intentional degradation rather than a silent live divergence.
+                //
                 // The ref-counted watcher path creates Latin-1 strings, which
                 // cannot represent multi-byte UTF-8 sequences. If the output
                 // contains non-ASCII (from raw template literals or regex
                 // source), fall through to the normal path which uses
                 // `clone_utf8`.
-                if unsafe { &*jsc_vm }.is_watcher_enabled() {
+                if unsafe { &*jsc_vm }.is_watcher_enabled()
+                    && bun_core::strings::is_all_ascii({
+                        // SAFETY: `extra.source_code_printer` is non-null per
+                        // `TranspileExtra` contract.
+                        let p: &bun_js_printer::BufferPrinter =
+                            unsafe { &*(*extra).source_code_printer };
+                        p.ctx.get_written()
+                    })
+                {
                     // SAFETY: `extra.source_code_printer` is non-null per
                     // `TranspileExtra` contract; rederive after the print block
                     // (Stacked Borrows — see the matching note below).
                     let printer: &mut bun_js_printer::BufferPrinter =
                         unsafe { &mut *(*extra).source_code_printer };
-                    let written = printer.ctx.get_written();
-                    if bun_core::strings::is_all_ascii(written) {
-                        let mut resolved_source = unsafe {
-                            (*jsc_vm).ref_counted_resolved_source::<false>(
-                                written,
-                                input_specifier.dupe_ref(),
-                                path.text,
-                                None,
-                            )
-                        };
-                        resolved_source.is_commonjs_module = is_commonjs_module;
-                        // TODO(b2-blocked): `analyze_transpiled_module::ModuleInfo::create`.
-                        resolved_source.module_info = core::ptr::null_mut();
-                        return Ok(OwnedResolvedSource::new(resolved_source));
-                    }
+                    let mut resolved_source = unsafe {
+                        (*jsc_vm).ref_counted_resolved_source::<false>(
+                            printer.ctx.get_written(),
+                            input_specifier.dupe_ref(),
+                            path.text,
+                            None,
+                        )
+                    };
+                    resolved_source.is_commonjs_module = is_commonjs_module;
+                    // TODO(b2-blocked): `analyze_transpiled_module::ModuleInfo::create`.
+                    resolved_source.module_info = core::ptr::null_mut();
+                    return Ok(OwnedResolvedSource::new(resolved_source));
                 }
 
                 // Spec :561-592 — final ResolvedSource.

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1931,10 +1931,6 @@ impl<'bump> Parser<'bump> {
             // The `with_capacity_in(1, ...)` hint above does not bound the
             // actual capacity — BabyVec::grow_to rounds up to max(2×cap, 4),
             // so the initial allocation is 4 slots regardless of the hint.
-            // A prior `debug_assert!(atoms.capacity() == 1)` here was stale
-            // from a hypothetical exact-sized allocation and fired on every
-            // single-atom command in debug builds once the path was hit with
-            // non-ASCII input.
             1 => Some(ast::Atom::new_simple(atoms.into_iter().next().unwrap())),
             _ => Some(ast::Atom::Compound(ast::CompoundAtom {
                 atoms: atoms.into_bump_slice(),

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1928,10 +1928,14 @@ impl<'bump> Parser<'bump> {
 
         Ok(match atoms.len() {
             0 => None,
-            1 => {
-                debug_assert!(atoms.capacity() == 1);
-                Some(ast::Atom::new_simple(atoms.into_iter().next().unwrap()))
-            }
+            // The `with_capacity_in(1, ...)` hint above does not bound the
+            // actual capacity — BabyVec::grow_to rounds up to max(2×cap, 4),
+            // so the initial allocation is 4 slots regardless of the hint.
+            // A prior `debug_assert!(atoms.capacity() == 1)` here was stale
+            // from a hypothetical exact-sized allocation and fired on every
+            // single-atom command in debug builds once the path was hit with
+            // non-ASCII input.
+            1 => Some(ast::Atom::new_simple(atoms.into_iter().next().unwrap())),
             _ => Some(ast::Atom::Compound(ast::CompoundAtom {
                 atoms: atoms.into_bump_slice(),
                 brace_expansion_hint: has_brace_open && has_brace_close && has_comma,

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -908,7 +908,17 @@ pub fn to_bytes(
             loader: output_file.loader,
             contents: string_builder.append_count_z(buf_bytes),
             encoding: match output_file.loader {
-                Loader::Js | Loader::Jsx | Loader::Ts | Loader::Tsx => Encoding::Latin1,
+                // Bundler output is usually pure ASCII, which lets us use the
+                // zero-copy Latin-1 path at load time. Only fall back to UTF-8
+                // when the output actually contains non-ASCII bytes from tagged
+                // template literals or regex source.
+                Loader::Js | Loader::Jsx | Loader::Ts | Loader::Tsx => {
+                    if bun_core::strings::is_all_ascii(buf_bytes) {
+                        Encoding::Latin1
+                    } else {
+                        Encoding::Utf8
+                    }
+                }
                 _ => Encoding::Binary,
             },
             module_format: if output_file.loader.is_javascript_like() {

--- a/src/standalone_graph/StandaloneModuleGraph.zig
+++ b/src/standalone_graph/StandaloneModuleGraph.zig
@@ -525,7 +525,9 @@ pub const StandaloneModuleGraph = struct {
                 .loader = output_file.loader,
                 .contents = string_builder.appendCountZ(output_file.value.buffer.bytes),
                 .encoding = switch (output_file.loader) {
-                    .js, .jsx, .ts, .tsx => .latin1,
+                    // Bundler output may contain raw UTF-8 bytes from tagged
+                    // template literals or regex source with non-ASCII characters.
+                    .js, .jsx, .ts, .tsx => .utf8,
                     else => .binary,
                 },
                 .module_format = if (output_file.loader.isJavaScriptLike()) switch (output_format) {

--- a/src/standalone_graph/StandaloneModuleGraph.zig
+++ b/src/standalone_graph/StandaloneModuleGraph.zig
@@ -525,9 +525,14 @@ pub const StandaloneModuleGraph = struct {
                 .loader = output_file.loader,
                 .contents = string_builder.appendCountZ(output_file.value.buffer.bytes),
                 .encoding = switch (output_file.loader) {
-                    // Bundler output may contain raw UTF-8 bytes from tagged
-                    // template literals or regex source with non-ASCII characters.
-                    .js, .jsx, .ts, .tsx => .utf8,
+                    // Bundler output is usually pure ASCII, which lets us use
+                    // the zero-copy .latin1 path at load time. Only fall back
+                    // to .utf8 when the output actually contains non-ASCII
+                    // bytes from tagged template literals or regex source.
+                    .js, .jsx, .ts, .tsx => if (bun.strings.isAllASCII(output_file.value.buffer.bytes))
+                        .latin1
+                    else
+                        .utf8,
                     else => .binary,
                 },
                 .module_format = if (output_file.loader.isJavaScriptLike()) switch (output_format) {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -295,10 +295,7 @@ describe("bunshell", () => {
 
     test("escape unicode", async () => {
       const { stdout } = await $`echo \\弟\\気`;
-      // TODO: Uncomment and replace after unicode in template tags is supported
-      // expect(stdout.toString("utf8")).toEqual(`\弟\気\n`);
-      // Set this here for now, because unicode in template tags while using .raw is broken, but should be fixed
-      expect(stdout.toString("utf8")).toEqual("\\u5F1F\\u6C17\n");
+      expect(stdout.toString("utf8")).toEqual(`\\弟\\気\n`);
     });
 
     /**

--- a/test/regression/issue/14976/14976.test.ts
+++ b/test/regression/issue/14976/14976.test.ts
@@ -70,7 +70,7 @@ test("constant-folded equals doesn't lie", async () => {
   console.log("\"" === '"');
 });
 
-test.skip("template literal raw property with unicode in an ascii-only build", async () => {
+test("template literal raw property with unicode in an ascii-only build", async () => {
   expect(String.raw`你好𐃘\\`).toBe("你好𐃘\\\\");
   expect((await $`echo 你好𐃘`.text()).trim()).toBe("你好𐃘");
 });

--- a/test/regression/issue/18115.test.ts
+++ b/test/regression/issue/18115.test.ts
@@ -10,8 +10,8 @@ describe("String.raw preserves non-ASCII characters", () => {
       stderr: "pipe",
     });
     const [stdout, , exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
+      proc.stdout.text(),
+      proc.stderr.text(),
       proc.exited,
     ]);
     expect(stdout).toBe("a\n中\n");
@@ -26,8 +26,8 @@ describe("String.raw preserves non-ASCII characters", () => {
       stderr: "pipe",
     });
     const [stdout, , exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
+      proc.stdout.text(),
+      proc.stderr.text(),
       proc.exited,
     ]);
     expect(stdout).toBe("Redémarrage\n");
@@ -42,8 +42,8 @@ describe("String.raw preserves non-ASCII characters", () => {
       stderr: "pipe",
     });
     const [stdout, , exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
+      proc.stdout.text(),
+      proc.stderr.text(),
       proc.exited,
     ]);
     expect(stdout).toBe("æ™弟気👋\n");
@@ -58,8 +58,8 @@ describe("String.raw preserves non-ASCII characters", () => {
       stderr: "pipe",
     });
     const [stdout, , exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
+      proc.stdout.text(),
+      proc.stderr.text(),
       proc.exited,
     ]);
     expect(stdout).toBe("before中middleafter弟\n");
@@ -75,8 +75,8 @@ test("RegExp source preserves non-ASCII characters", async () => {
     stderr: "pipe",
   });
   const [stdout, , exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
+    proc.stdout.text(),
+    proc.stderr.text(),
     proc.exited,
   ]);
   expect(stdout).toBe("æ™\n");
@@ -99,8 +99,8 @@ test("String.raw with non-ASCII via runtime transpiler cache", async () => {
     stderr: "pipe",
   });
   const [stdout1, , exitCode1] = await Promise.all([
-    new Response(proc1.stdout).text(),
-    new Response(proc1.stderr).text(),
+    proc1.stdout.text(),
+    proc1.stderr.text(),
     proc1.exited,
   ]);
   expect(stdout1).toBe("æ™弟気👋\n");
@@ -114,8 +114,8 @@ test("String.raw with non-ASCII via runtime transpiler cache", async () => {
     stderr: "pipe",
   });
   const [stdout2, , exitCode2] = await Promise.all([
-    new Response(proc2.stdout).text(),
-    new Response(proc2.stderr).text(),
+    proc2.stdout.text(),
+    proc2.stderr.text(),
     proc2.exited,
   ]);
   expect(stdout2).toBe("æ™弟気👋\n");
@@ -135,8 +135,8 @@ test("String.raw with non-ASCII after bun build", async () => {
     stderr: "pipe",
   });
   const [, , buildExitCode] = await Promise.all([
-    new Response(buildProc.stdout).text(),
-    new Response(buildProc.stderr).text(),
+    buildProc.stdout.text(),
+    buildProc.stderr.text(),
     buildProc.exited,
   ]);
   expect(buildExitCode).toBe(0);
@@ -149,8 +149,8 @@ test("String.raw with non-ASCII after bun build", async () => {
     stderr: "pipe",
   });
   const [stdout, , exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
+    proc.stdout.text(),
+    proc.stderr.text(),
     proc.exited,
   ]);
   expect(stdout).toBe("æ™弟気👋\n");

--- a/test/regression/issue/18115.test.ts
+++ b/test/regression/issue/18115.test.ts
@@ -83,6 +83,45 @@ test("RegExp source preserves non-ASCII characters", async () => {
   expect(exitCode).toBe(0);
 });
 
+test("String.raw with non-ASCII via runtime transpiler cache", async () => {
+  using dir = tempDir("string-raw-rtc", {
+    // Pad to >50KB to exceed MINIMUM_CACHE_SIZE in RuntimeTranspilerCache.zig
+    "index.ts": 'console.log(String.raw`æ™弟気👋`);' + " ".repeat(64 * 1024),
+  });
+  using cacheDir = tempDir("string-raw-rtc-cache", {});
+  const env = { ...bunEnv, BUN_RUNTIME_TRANSPILER_CACHE_PATH: String(cacheDir) };
+
+  // First run — populates the cache
+  await using proc1 = Bun.spawn({
+    cmd: [bunExe(), String(dir) + "/index.ts"],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout1, , exitCode1] = await Promise.all([
+    new Response(proc1.stdout).text(),
+    new Response(proc1.stderr).text(),
+    proc1.exited,
+  ]);
+  expect(stdout1).toBe("æ™弟気👋\n");
+  expect(exitCode1).toBe(0);
+
+  // Second run — restores from cache
+  await using proc2 = Bun.spawn({
+    cmd: [bunExe(), String(dir) + "/index.ts"],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout2, , exitCode2] = await Promise.all([
+    new Response(proc2.stdout).text(),
+    new Response(proc2.stderr).text(),
+    proc2.exited,
+  ]);
+  expect(stdout2).toBe("æ™弟気👋\n");
+  expect(exitCode2).toBe(0);
+});
+
 test("String.raw with non-ASCII after bun build", async () => {
   using dir = tempDir("string-raw-unicode", {
     "index.ts": "console.log(String.raw`æ™弟気👋`);",

--- a/test/regression/issue/18115.test.ts
+++ b/test/regression/issue/18115.test.ts
@@ -86,7 +86,7 @@ test("RegExp source preserves non-ASCII characters", async () => {
 test("String.raw with non-ASCII via runtime transpiler cache", async () => {
   using dir = tempDir("string-raw-rtc", {
     // Pad to >50KB to exceed MINIMUM_CACHE_SIZE in RuntimeTranspilerCache.zig
-    "index.ts": "console.log(String.raw`æ™弟気👋`);" + " ".repeat(64 * 1024),
+    "index.ts": "console.log(String.raw`æ™弟気👋`);" + Buffer.alloc(64 * 1024, " ").toString(),
   });
   using cacheDir = tempDir("string-raw-rtc-cache", {});
   const env = { ...bunEnv, BUN_RUNTIME_TRANSPILER_CACHE_PATH: String(cacheDir) };

--- a/test/regression/issue/18115.test.ts
+++ b/test/regression/issue/18115.test.ts
@@ -3,13 +3,13 @@ import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("String.raw preserves non-ASCII characters", () => {
   test("Chinese characters", async () => {
-    const proc = Bun.spawn({
-      cmd: [bunExe(), "-e", "const text = String.raw`a中`; for (const char of text) { console.log(char); }"],
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", 'const text = String.raw`a中`; for (const char of text) { console.log(char); }'],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
+    const [stdout, , exitCode] = await Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
       proc.exited,
@@ -19,13 +19,13 @@ describe("String.raw preserves non-ASCII characters", () => {
   });
 
   test("accented characters", async () => {
-    const proc = Bun.spawn({
-      cmd: [bunExe(), "-e", "console.log(String.raw`Redémarrage`)"],
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", 'console.log(String.raw`Redémarrage`)'],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
+    const [stdout, , exitCode] = await Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
       proc.exited,
@@ -35,13 +35,13 @@ describe("String.raw preserves non-ASCII characters", () => {
   });
 
   test("emoji and CJK characters", async () => {
-    const proc = Bun.spawn({
-      cmd: [bunExe(), "-e", "console.log(String.raw`æ™弟気👋`)"],
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", 'console.log(String.raw`æ™弟気👋`)'],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
+    const [stdout, , exitCode] = await Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
       proc.exited,
@@ -51,13 +51,13 @@ describe("String.raw preserves non-ASCII characters", () => {
   });
 
   test("template expressions with non-ASCII", async () => {
-    const proc = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", 'console.log(String.raw`before中${"middle"}after弟`)'],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
+    const [stdout, , exitCode] = await Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
       proc.exited,
@@ -68,13 +68,13 @@ describe("String.raw preserves non-ASCII characters", () => {
 });
 
 test("RegExp source preserves non-ASCII characters", async () => {
-  const proc = Bun.spawn({
-    cmd: [bunExe(), "-e", "console.log(/æ™/.source)"],
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", 'console.log(/æ™/.source)'],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
+  const [stdout, , exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
     proc.exited,
@@ -85,26 +85,31 @@ test("RegExp source preserves non-ASCII characters", async () => {
 
 test("String.raw with non-ASCII after bun build", async () => {
   using dir = tempDir("string-raw-unicode", {
-    "index.ts": "console.log(String.raw`æ™弟気👋`);",
+    "index.ts": 'console.log(String.raw`æ™弟気👋`);',
   });
 
   // Build
-  const buildProc = Bun.spawn({
+  await using buildProc = Bun.spawn({
     cmd: [bunExe(), "build", "--target", "bun", "--outfile", String(dir) + "/out.js", String(dir) + "/index.ts"],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(await buildProc.exited).toBe(0);
+  const [, , buildExitCode] = await Promise.all([
+    new Response(buildProc.stdout).text(),
+    new Response(buildProc.stderr).text(),
+    buildProc.exited,
+  ]);
+  expect(buildExitCode).toBe(0);
 
   // Run the built output
-  const proc = Bun.spawn({
+  await using proc = Bun.spawn({
     cmd: [bunExe(), String(dir) + "/out.js"],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
+  const [stdout, , exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
     proc.exited,

--- a/test/regression/issue/18115.test.ts
+++ b/test/regression/issue/18115.test.ts
@@ -1,0 +1,114 @@
+import { expect, test, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("String.raw preserves non-ASCII characters", () => {
+  test("Chinese characters", async () => {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "-e", 'const text = String.raw`a中`; for (const char of text) { console.log(char); }'],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    expect(stdout).toBe("a\n中\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("accented characters", async () => {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "-e", 'console.log(String.raw`Redémarrage`)'],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    expect(stdout).toBe("Redémarrage\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("emoji and CJK characters", async () => {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "-e", 'console.log(String.raw`æ™弟気👋`)'],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    expect(stdout).toBe("æ™弟気👋\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("template expressions with non-ASCII", async () => {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "-e", 'console.log(String.raw`before中${"middle"}after弟`)'],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    expect(stdout).toBe("before中middleafter弟\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
+test("RegExp source preserves non-ASCII characters", async () => {
+  const proc = Bun.spawn({
+    cmd: [bunExe(), "-e", 'console.log(/æ™/.source)'],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  expect(stdout).toBe("æ™\n");
+  expect(exitCode).toBe(0);
+});
+
+test("String.raw with non-ASCII after bun build", async () => {
+  using dir = tempDir("string-raw-unicode", {
+    "index.ts": 'console.log(String.raw`æ™弟気👋`);',
+  });
+
+  // Build
+  const buildProc = Bun.spawn({
+    cmd: [bunExe(), "build", "--target", "bun", "--outfile", String(dir) + "/out.js", String(dir) + "/index.ts"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(await buildProc.exited).toBe(0);
+
+  // Run the built output
+  const proc = Bun.spawn({
+    cmd: [bunExe(), String(dir) + "/out.js"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  expect(stdout).toBe("æ™弟気👋\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/18115.test.ts
+++ b/test/regression/issue/18115.test.ts
@@ -9,11 +9,7 @@ describe("String.raw preserves non-ASCII characters", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe("a\n中\n");
     expect(exitCode).toBe(0);
   });
@@ -25,11 +21,7 @@ describe("String.raw preserves non-ASCII characters", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe("Redémarrage\n");
     expect(exitCode).toBe(0);
   });
@@ -41,11 +33,7 @@ describe("String.raw preserves non-ASCII characters", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe("æ™弟気👋\n");
     expect(exitCode).toBe(0);
   });
@@ -57,11 +45,7 @@ describe("String.raw preserves non-ASCII characters", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe("before中middleafter弟\n");
     expect(exitCode).toBe(0);
   });
@@ -74,11 +58,7 @@ test("RegExp source preserves non-ASCII characters", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("æ™\n");
   expect(exitCode).toBe(0);
 });
@@ -98,11 +78,7 @@ test("String.raw with non-ASCII via runtime transpiler cache", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout1, , exitCode1] = await Promise.all([
-    proc1.stdout.text(),
-    proc1.stderr.text(),
-    proc1.exited,
-  ]);
+  const [stdout1, , exitCode1] = await Promise.all([proc1.stdout.text(), proc1.stderr.text(), proc1.exited]);
   expect(stdout1).toBe("æ™弟気👋\n");
   expect(exitCode1).toBe(0);
 
@@ -113,11 +89,7 @@ test("String.raw with non-ASCII via runtime transpiler cache", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout2, , exitCode2] = await Promise.all([
-    proc2.stdout.text(),
-    proc2.stderr.text(),
-    proc2.exited,
-  ]);
+  const [stdout2, , exitCode2] = await Promise.all([proc2.stdout.text(), proc2.stderr.text(), proc2.exited]);
   expect(stdout2).toBe("æ™弟気👋\n");
   expect(exitCode2).toBe(0);
 });
@@ -134,11 +106,7 @@ test("String.raw with non-ASCII after bun build", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [, , buildExitCode] = await Promise.all([
-    buildProc.stdout.text(),
-    buildProc.stderr.text(),
-    buildProc.exited,
-  ]);
+  const [, , buildExitCode] = await Promise.all([buildProc.stdout.text(), buildProc.stderr.text(), buildProc.exited]);
   expect(buildExitCode).toBe(0);
 
   // Run the built output
@@ -148,11 +116,7 @@ test("String.raw with non-ASCII after bun build", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("æ™弟気👋\n");
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/18115.test.ts
+++ b/test/regression/issue/18115.test.ts
@@ -86,7 +86,7 @@ test("RegExp source preserves non-ASCII characters", async () => {
 test("String.raw with non-ASCII via runtime transpiler cache", async () => {
   using dir = tempDir("string-raw-rtc", {
     // Pad to >50KB to exceed MINIMUM_CACHE_SIZE in RuntimeTranspilerCache.zig
-    "index.ts": 'console.log(String.raw`æ™弟気👋`);' + " ".repeat(64 * 1024),
+    "index.ts": "console.log(String.raw`æ™弟気👋`);" + " ".repeat(64 * 1024),
   });
   using cacheDir = tempDir("string-raw-rtc-cache", {});
   const env = { ...bunEnv, BUN_RUNTIME_TRANSPILER_CACHE_PATH: String(cacheDir) };

--- a/test/regression/issue/18115.test.ts
+++ b/test/regression/issue/18115.test.ts
@@ -4,7 +4,7 @@ import { bunEnv, bunExe, tempDir } from "harness";
 describe("String.raw preserves non-ASCII characters", () => {
   test("Chinese characters", async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", 'const text = String.raw`a中`; for (const char of text) { console.log(char); }'],
+      cmd: [bunExe(), "-e", "const text = String.raw`a中`; for (const char of text) { console.log(char); }"],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -20,7 +20,7 @@ describe("String.raw preserves non-ASCII characters", () => {
 
   test("accented characters", async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", 'console.log(String.raw`Redémarrage`)'],
+      cmd: [bunExe(), "-e", "console.log(String.raw`Redémarrage`)"],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -36,7 +36,7 @@ describe("String.raw preserves non-ASCII characters", () => {
 
   test("emoji and CJK characters", async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", 'console.log(String.raw`æ™弟気👋`)'],
+      cmd: [bunExe(), "-e", "console.log(String.raw`æ™弟気👋`)"],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -69,7 +69,7 @@ describe("String.raw preserves non-ASCII characters", () => {
 
 test("RegExp source preserves non-ASCII characters", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", 'console.log(/æ™/.source)'],
+    cmd: [bunExe(), "-e", "console.log(/æ™/.source)"],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
@@ -85,7 +85,7 @@ test("RegExp source preserves non-ASCII characters", async () => {
 
 test("String.raw with non-ASCII after bun build", async () => {
   using dir = tempDir("string-raw-unicode", {
-    "index.ts": 'console.log(String.raw`æ™弟気👋`);',
+    "index.ts": "console.log(String.raw`æ™弟気👋`);",
   });
 
   // Build

--- a/test/regression/issue/18115.test.ts
+++ b/test/regression/issue/18115.test.ts
@@ -1,10 +1,10 @@
-import { expect, test, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("String.raw preserves non-ASCII characters", () => {
   test("Chinese characters", async () => {
     const proc = Bun.spawn({
-      cmd: [bunExe(), "-e", 'const text = String.raw`a中`; for (const char of text) { console.log(char); }'],
+      cmd: [bunExe(), "-e", "const text = String.raw`a中`; for (const char of text) { console.log(char); }"],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -20,7 +20,7 @@ describe("String.raw preserves non-ASCII characters", () => {
 
   test("accented characters", async () => {
     const proc = Bun.spawn({
-      cmd: [bunExe(), "-e", 'console.log(String.raw`Redémarrage`)'],
+      cmd: [bunExe(), "-e", "console.log(String.raw`Redémarrage`)"],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -36,7 +36,7 @@ describe("String.raw preserves non-ASCII characters", () => {
 
   test("emoji and CJK characters", async () => {
     const proc = Bun.spawn({
-      cmd: [bunExe(), "-e", 'console.log(String.raw`æ™弟気👋`)'],
+      cmd: [bunExe(), "-e", "console.log(String.raw`æ™弟気👋`)"],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -69,7 +69,7 @@ describe("String.raw preserves non-ASCII characters", () => {
 
 test("RegExp source preserves non-ASCII characters", async () => {
   const proc = Bun.spawn({
-    cmd: [bunExe(), "-e", 'console.log(/æ™/.source)'],
+    cmd: [bunExe(), "-e", "console.log(/æ™/.source)"],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
@@ -85,7 +85,7 @@ test("RegExp source preserves non-ASCII characters", async () => {
 
 test("String.raw with non-ASCII after bun build", async () => {
   using dir = tempDir("string-raw-unicode", {
-    "index.ts": 'console.log(String.raw`æ™弟気👋`);',
+    "index.ts": "console.log(String.raw`æ™弟気👋`);",
   });
 
   // Build

--- a/test/regression/issue/18115.test.ts
+++ b/test/regression/issue/18115.test.ts
@@ -9,7 +9,8 @@ describe("String.raw preserves non-ASCII characters", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
     expect(stdout).toBe("a\n中\n");
     expect(exitCode).toBe(0);
   });
@@ -21,7 +22,8 @@ describe("String.raw preserves non-ASCII characters", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
     expect(stdout).toBe("Redémarrage\n");
     expect(exitCode).toBe(0);
   });
@@ -33,7 +35,8 @@ describe("String.raw preserves non-ASCII characters", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
     expect(stdout).toBe("æ™弟気👋\n");
     expect(exitCode).toBe(0);
   });
@@ -45,7 +48,8 @@ describe("String.raw preserves non-ASCII characters", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
     expect(stdout).toBe("before中middleafter弟\n");
     expect(exitCode).toBe(0);
   });
@@ -58,7 +62,8 @@ test("RegExp source preserves non-ASCII characters", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
   expect(stdout).toBe("æ™\n");
   expect(exitCode).toBe(0);
 });
@@ -78,7 +83,8 @@ test("String.raw with non-ASCII via runtime transpiler cache", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout1, , exitCode1] = await Promise.all([proc1.stdout.text(), proc1.stderr.text(), proc1.exited]);
+  const [stdout1, stderr1, exitCode1] = await Promise.all([proc1.stdout.text(), proc1.stderr.text(), proc1.exited]);
+  expect(stderr1).toBe("");
   expect(stdout1).toBe("æ™弟気👋\n");
   expect(exitCode1).toBe(0);
 
@@ -89,7 +95,8 @@ test("String.raw with non-ASCII via runtime transpiler cache", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout2, , exitCode2] = await Promise.all([proc2.stdout.text(), proc2.stderr.text(), proc2.exited]);
+  const [stdout2, stderr2, exitCode2] = await Promise.all([proc2.stdout.text(), proc2.stderr.text(), proc2.exited]);
+  expect(stderr2).toBe("");
   expect(stdout2).toBe("æ™弟気👋\n");
   expect(exitCode2).toBe(0);
 });
@@ -99,14 +106,20 @@ test("String.raw with non-ASCII after bun build", async () => {
     "index.ts": "console.log(String.raw`æ™弟気👋`);",
   });
 
-  // Build
+  // Build — `bun build` writes a summary to stderr by design, so only assert
+  // absence of an error keyword rather than empty stderr.
   await using buildProc = Bun.spawn({
     cmd: [bunExe(), "build", "--target", "bun", "--outfile", String(dir) + "/out.js", String(dir) + "/index.ts"],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [, , buildExitCode] = await Promise.all([buildProc.stdout.text(), buildProc.stderr.text(), buildProc.exited]);
+  const [, buildStderr, buildExitCode] = await Promise.all([
+    buildProc.stdout.text(),
+    buildProc.stderr.text(),
+    buildProc.exited,
+  ]);
+  expect(buildStderr).not.toContain("error");
   expect(buildExitCode).toBe(0);
 
   // Run the built output
@@ -116,7 +129,8 @@ test("String.raw with non-ASCII after bun build", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
   expect(stdout).toBe("æ™弟気👋\n");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Reproduction

```javascript
const text = String.raw`a中`;
for (const char of text) { console.log(char); }
// Bun (before): a \ u 4 E 2 D
// Node / Bun (after): a 中

console.log(String.raw`Redémarrage`);
// Bun (before): Red\u00E9marrage
// Node / Bun (after): Redémarrage

console.log(/æ™/.source);
// Bun (before): \u00E6\u2122
// Node / Bun (after): æ™
```

## Root Cause

In `src/js_printer.zig`, the `printRawTemplateLiteral` function escapes non-ASCII characters to `\uXXXX` sequences when `ascii_only` is true (which it is for all bun platform output). But raw template literals must preserve the exact source bytes, since they are exposed to JavaScript via `String.raw` and the `.raw` property of tagged template arguments. Escaping `中` to `\u4E2D` changes the runtime string value from one character to six.

The same issue exists in `printRegExpLiteral`, where non-ASCII characters in regex source are escaped even though the `.source` property is visible to JavaScript.

## Fix

- Replace the comptime `ascii_only` parameter on `NewPrinter` with a runtime `prefers_ascii` field
- When printing raw template content or regex source containing non-ASCII, set `prefers_ascii = false` so bytes are preserved verbatim
- Switch `cloneLatin1` → `cloneUTF8` for transpiler output since it may now contain non-ASCII bytes
- Bump the runtime transpiler cache version to invalidate stale Latin-1 cached entries

Based on the approach from #15047 by @pfg.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/18115.test.ts` → 6 failures (bug exists)
- `bun bd test test/regression/issue/18115.test.ts` → 6 passes (fix works)
- Previously skipped test in `test/regression/issue/14976/14976.test.ts` now passes
- Shell unicode escape test in `bunshell.test.ts` updated with correct expectation

Fixes #18115, fixes #8745, fixes #15492, fixes #16763, fixes #8207