### PR TITLE
fix(install): suppress false "Slow filesystem" warning on WSL2

### DIFF
--- a/src/install/PackageManager/PackageManagerDirectories.zig
+++ b/src/install/PackageManager/PackageManagerDirectories.zig
@@ -97,10 +97,15 @@ var getTemporaryDirectoryOnce = bun.once(struct {
             if (elapsed > std.time.ns_per_ms * 100) {
                 var path_buf: bun.PathBuffer = undefined;
                 const cache_dir_path = bun.getFdPath(.fromStdDir(cache_directory), &path_buf) catch "it";
-                Output.prettyErrorln(
-                    "<r><yellow>warn<r>: Slow filesystem detected. If {s} is a network drive, consider setting $BUN_INSTALL_CACHE_DIR to a local folder.",
-                    .{cache_dir_path},
-                );
+                // Only warn if the filesystem is actually a network filesystem.
+                // This avoids false positives on WSL2 where local ext4 filesystems
+                // can be slow due to the virtualization layer.
+                if (isNetworkFilesystem(cache_dir_path)) {
+                    Output.prettyErrorln(
+                        "<r><yellow>warn<r>: Slow filesystem detected. If {s} is a network drive, consider setting $BUN_INSTALL_CACHE_DIR to a local folder.",
+                        .{cache_dir_path},
+                    );
+                }
             }
         }
 
@@ -748,6 +753,45 @@ const PatchHashFmt = struct {
 };
 
 var using_fallback_temp_dir: bool = false;
+
+/// Checks whether the given path is on a network filesystem by inspecting
+/// the filesystem type via statfs(). Returns true for known network/remote
+/// filesystem types (NFS, CIFS, SMB, 9p, AFS, etc.) and also returns true
+/// if the check fails (to preserve the warning in ambiguous cases).
+/// Returns false for local filesystems like ext4, btrfs, xfs, etc.
+/// This avoids false "slow filesystem" warnings on WSL2, where local
+/// filesystems can appear slow due to the virtualization layer.
+fn isNetworkFilesystem(path: []const u8) bool {
+    if (comptime !Environment.isLinux) return true;
+
+    var path_buf: bun.PathBuffer = undefined;
+    const len = @min(path.len, path_buf.len - 1);
+    @memcpy(path_buf[0..len], path[0..len]);
+    path_buf[len] = 0;
+    const path_z: [:0]const u8 = path_buf[0..len :0];
+
+    const result = bun.sys.statfs(path_z);
+    switch (result) {
+        .result => |statfs_| {
+            const fs_type = statfs_.f_type;
+            return switch (fs_type) {
+                0x6969 => true, // NFS_SUPER_MAGIC
+                0xFF534D42 => true, // CIFS_SUPER_MAGIC
+                0xFE534D42 => true, // SMB2_SUPER_MAGIC
+                0x01021997 => true, // V9FS_MAGIC (Plan 9 / 9p, used for WSL1 Windows mounts)
+                0x5346414F => true, // AFS_SUPER_MAGIC
+                0x00C36400 => true, // CEPH_SUPER_MAGIC
+                0x7461636f => true, // OCFS2_SUPER_MAGIC
+                0xBEEFDEAD => true, // SMBFS_SUPER_MAGIC
+                0x47504653 => true, // GPFS_SUPER_MAGIC
+                0x0BD00BD0 => true, // LUSTRE_SUPER_MAGIC
+                0xAAD7AAEA => true, // PANFS_SUPER_MAGIC
+                else => false,
+            };
+        },
+        .err => return true, // If we can't determine, show the warning.
+    }
+}
 
 const string = []const u8;
 const stringZ = [:0]const u8;

--- a/test/regression/issue/28215.test.ts
+++ b/test/regression/issue/28215.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 

--- a/test/regression/issue/28215.test.ts
+++ b/test/regression/issue/28215.test.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// https://github.com/oven-sh/bun/issues/28215
+// On WSL2, local ext4 filesystems can be slow enough to trigger the
+// "Slow filesystem detected" warning. The fix uses statfs() to check
+// whether the filesystem is actually a network filesystem before warning.
+test("bun install should not warn about slow filesystem on local filesystems", async () => {
+  using dir = tempDir("issue-28215", {
+    "package.json": JSON.stringify({
+      name: "issue-28215",
+      dependencies: {},
+    }),
+  });
+
+  const cacheDir = join(String(dir), ".cache");
+  const tmpDir = join(String(dir), ".tmp");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: cacheDir,
+      BUN_TMPDIR: tmpDir,
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+  // On a local filesystem, the "Slow filesystem" warning should never appear
+  expect(stderr).not.toContain("Slow filesystem detected");
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Use `statfs()` on Linux to check whether the cache directory is on a network filesystem before showing the "Slow filesystem detected" warning
- Previously the warning was purely timing-based (>100ms for temp file operations), which caused false positives on WSL2 where local ext4 filesystems can be slow due to the virtualization layer
- The warning now only appears for known network filesystem types: NFS, CIFS, SMB2, 9p, AFS, Ceph, OCFS2, SMBFS, GPFS, Lustre, PanFS
- On non-Linux platforms or if `statfs()` fails, the warning is preserved (safe fallback)

Closes #28215

## Test plan

- [x] Added regression test `test/regression/issue/28215.test.ts` that verifies `bun install` does not emit the "Slow filesystem" warning on local filesystems
- [x] Debug build compiles successfully
- [x] Test passes with `bun bd test test/regression/issue/28215.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)