### PR TITLE
fix(dev_server): prevent stale_files bitset OOB crash on Windows

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -2047,7 +2047,7 @@ fn generateClientBundle(dev: *DevServer, route_bundle: *RouteBundle) bun.OOM![]u
     if (dev.framework.react_fast_refresh) |rfr| brk: {
         const rfr_index = dev.client_graph.getFileIndex(rfr.import_source) orelse
             break :brk;
-        if (!dev.client_graph.stale_files.isSet(rfr_index.get())) {
+        if (!dev.client_graph.stale_files.isSetAllowOutOfBound(rfr_index.get(), true)) {
             try dev.client_graph.traceImports(rfr_index, &gts, .find_client_modules);
             react_fast_refresh_id = rfr.import_source;
         }
@@ -3114,7 +3114,7 @@ pub fn isFileCached(dev: *DevServer, path: []const u8, side: bake.Graph) ?CacheE
             };
             const index = g.bundled_files.getIndex(path) orelse
                 return null; // non-existent files are considered stale
-            if (!g.stale_files.isSet(index)) {
+            if (!g.stale_files.isSetAllowOutOfBound(index, true)) {
                 return .{ .kind = g.getFileByIndex(.init(@intCast(index))).fileKind() };
             }
             return null;
@@ -3138,8 +3138,8 @@ fn appendOpaqueEntryPoint(
 
     const file_index = fromOpaqueFileId(side, file);
     if (switch (side) {
-        .server => dev.server_graph.stale_files.isSet(file_index.get()),
-        .client => dev.client_graph.stale_files.isSet(file_index.get()),
+        .server => dev.server_graph.stale_files.isSetAllowOutOfBound(file_index.get(), true),
+        .client => dev.client_graph.stale_files.isSetAllowOutOfBound(file_index.get(), true),
     }) {
         try entry_points.appendJs(alloc, file_names[file_index.get()], side.graph());
     }

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -652,3 +652,35 @@ devTest("barrel optimization: two export-from blocks pointing to the same source
     await c.expectMessage("got: function");
   },
 });
+
+// --- Regression test for #27356 ---
+
+devTest("cjs module with many sub-requires does not crash", {
+  files: {
+    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
+    "index.ts": `import result from "./lib/index.js"; console.log(result);`,
+    "lib/index.js": `
+      const a = require("./mod1.js");
+      const b = require("./mod2.js");
+      const c = require("./mod3.js");
+      const d = require("./mod4.js");
+      const e = require("./mod5.js");
+      const f = require("./mod6.js");
+      const g = require("./mod7.js");
+      const h = require("./mod8.js");
+      module.exports = a + b + c + d + e + f + g + h;
+    `,
+    "lib/mod1.js": `module.exports = 1;`,
+    "lib/mod2.js": `module.exports = 2;`,
+    "lib/mod3.js": `module.exports = 3;`,
+    "lib/mod4.js": `module.exports = 4;`,
+    "lib/mod5.js": `module.exports = 5;`,
+    "lib/mod6.js": `module.exports = 6;`,
+    "lib/mod7.js": `module.exports = 7;`,
+    "lib/mod8.js": `module.exports = 8;`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage(36);
+  },
+});


### PR DESCRIPTION
## Summary
- Fix assertion failure / panic on Windows when the dev server bundles CJS modules with many sub-requires (e.g. `seedrandom`)
- The `stale_files` bitset could be queried with an index exceeding its current capacity before `ensureStaleBitCapacity()` resized it
- Windows release builds use `ReleaseSafe` (assertions enabled), so this triggers a panic; Linux/macOS use `ReleaseFast` where the assertion is elided
- Replace 4 `.isSet()` calls with `.isSetAllowOutOfBound(index, true)`, treating out-of-bounds files as stale (correct semantics for newly added files that haven't been bundled yet)

Closes #27356

## Test plan
- [x] Added regression test `"cjs module with many sub-requires does not crash"` in `test/bake/dev/bundle.test.ts`
- [x] All 18 dev server bundle tests pass
- [ ] Verify on Windows CI that the assertion failure no longer occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)