### PR TITLE
fix(install): prevent panic on `bun install --prefix ./` on Windows

### DIFF
--- a/src/install/PackageInstall.zig
+++ b/src/install/PackageInstall.zig
@@ -1310,7 +1310,7 @@ pub const PackageInstall = struct {
             switch (bun.sys.symlinkOrJunction(dest_z, target_z, null)) {
                 .err => |err_| brk: {
                     var err = err_;
-                    if (err.getErrno() == .EXIST) {
+                    if (err.getErrno() == .EXIST and !strings.eqlComptime(dest_path, ".")) {
                         _ = bun.sys.rmdirat(.fromStdDir(destination_dir), this.destination_dir_subpath);
                         switch (bun.sys.symlinkOrJunction(dest_z, target_z, null)) {
                             .err => |e| err = e,

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -3512,7 +3512,7 @@ pub fn DeleteFileBun(sub_path_w: []const u16, options: DeleteFileOptions) bun.sy
         .Buffer = @constCast(sub_path_w.ptr),
     };
 
-    if (sub_path_w[0] == '.' and sub_path_w[1] == 0) {
+    if (sub_path_w.len == 2 and sub_path_w[0] == '.' and sub_path_w[1] == 0) {
         // Windows does not recognize this, but it does work with empty string.
         nt_name.Length = 0;
     }


### PR DESCRIPTION
## Summary

- Fix index out of bounds panic in `DeleteFileBun` when called with an empty wide-string path by adding a length check before array access
- Guard the `rmdirat` call in `installFromLink`'s symlink retry path to skip removal when `destination_dir_subpath` is `"."`, matching the existing guard on `uninstallBeforeInstall`

## Root Cause

When running `bun install --prefix ./ yaml-language-server@1.19.2` on Windows, the symlink creation in `installFromLink` could fail with `EXIST`. The retry logic then called `rmdirat` with `"."` as the subpath, which propagated to `DeleteFileBun` where accessing `sub_path_w[0]` on a short/empty wide-string slice caused a panic: `index out of bounds: index 0, len 0`.

## Test plan

- [x] Verified `bun install --prefix ./ yaml-language-server@1.19.2` works on Linux with the debug build
- [x] All platforms compile successfully (`bun run zig:check-all`)

Closes #25040

🤖 Generated with [Claude Code](https://claude.com/claude-code)