### PR TITLE
fix(tty): prevent tty.ReadStream from auto-closing the file descriptor

### DIFF
--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -16,7 +16,7 @@ function ReadStream(fd): void {
   if (!(this instanceof ReadStream)) {
     return new ReadStream(fd);
   }
-  fs.ReadStream.$apply(this, ["", { fd }]);
+  fs.ReadStream.$apply(this, ["", { fd, autoClose: false }]);
   this.isRaw = false;
   // Only set isTTY to true if the fd is actually a TTY
   this.isTTY = isatty(fd);

--- a/test/regression/issue/27285.test.ts
+++ b/test/regression/issue/27285.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/27285
+// tty.ReadStream was auto-destroying (and closing the fd) because autoClose
+// defaulted to true (inherited from fs.ReadStream). This caused node-pty to
+// crash with "ioctl(2) failed, EBADF" because the PTY master fd was closed
+// prematurely, sending SIGHUP to the child process.
+describe.skipIf(isWindows)("tty.ReadStream should not auto-close the fd", () => {
+  it("has autoClose set to false", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+const tty = require("tty");
+const fs = require("fs");
+const fd = fs.openSync("/dev/null", "r");
+const stream = new tty.ReadStream(fd);
+console.log("autoClose:" + stream.autoClose);
+console.log("autoDestroy:" + stream._readableState.autoDestroy);
+fs.closeSync(fd);
+process.exit(0);
+`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("autoClose:false");
+    expect(stdout).toContain("autoDestroy:false");
+    expect(exitCode).toBe(0);
+  });
+
+  it("fd stays valid after stream errors (does not auto-destroy)", async () => {
+    // This reproduces the node-pty scenario: create a tty.ReadStream on a
+    // PTY master fd, let it encounter errors during reading, and verify the
+    // fd is NOT auto-closed. With the bug, autoDestroy:true would close the
+    // fd within one event loop tick.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+const tty = require("tty");
+const fs = require("fs");
+
+let fd;
+try {
+  fd = fs.openSync("/dev/ptmx", "r+");
+} catch {
+  fd = fs.openSync("/dev/null", "r");
+}
+
+// Create a ReadStream on the fd (like node-pty does)
+const stream = new tty.ReadStream(fd);
+
+// node-pty adds an error handler and ignores EAGAIN
+stream.on("error", () => {});
+
+// After 200ms, check that the fd is still valid.
+// Before the fix, the fd would be closed within the first event loop tick
+// because autoDestroy:true caused the stream to destroy itself on errors.
+setTimeout(() => {
+  try {
+    fs.fstatSync(fd);
+    console.log("FD_STILL_VALID:true");
+  } catch {
+    console.log("FD_STILL_VALID:false");
+  }
+  process.exit(0);
+}, 200);
+`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("FD_STILL_VALID:true");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/regression/issue/27285.test.ts
+++ b/test/regression/issue/27285.test.ts
@@ -39,7 +39,7 @@ process.exit(0);
     // This reproduces the node-pty scenario: create a tty.ReadStream on a
     // PTY master fd, let it encounter errors during reading, and verify the
     // fd is NOT auto-closed. With the bug, autoDestroy:true would close the
-    // fd within one event loop tick.
+    // fd within the first event loop tick.
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -61,18 +61,26 @@ const stream = new tty.ReadStream(fd);
 // node-pty adds an error handler and ignores EAGAIN
 stream.on("error", () => {});
 
-// After 200ms, check that the fd is still valid.
-// Before the fix, the fd would be closed within the first event loop tick
-// because autoDestroy:true caused the stream to destroy itself on errors.
-setTimeout(() => {
+// Check fd validity across multiple event loop ticks using setImmediate.
+// The bug caused the fd to be closed within the first tick due to
+// autoDestroy:true, so polling with setImmediate directly targets that.
+let ticksRemaining = 10;
+function checkFd() {
+  ticksRemaining--;
   try {
     fs.fstatSync(fd);
-    console.log("FD_STILL_VALID:true");
+    if (ticksRemaining > 0) {
+      setImmediate(checkFd);
+    } else {
+      console.log("FD_STILL_VALID:true");
+      process.exit(0);
+    }
   } catch {
     console.log("FD_STILL_VALID:false");
+    process.exit(0);
   }
-  process.exit(0);
-}, 200);
+}
+setImmediate(checkFd);
 `,
       ],
       env: bunEnv,


### PR DESCRIPTION
## Summary

- Fix `tty.ReadStream` to pass `autoClose: false` to the underlying `fs.ReadStream`, matching the behavior already used by `tty.WriteStream`
- This prevents the PTY master fd from being auto-closed when the stream encounters read errors, which was causing `node-pty` (used by Gemini CLI) to crash with `ioctl(2) failed, EBADF`

## Root Cause

`tty.ReadStream` extends `fs.ReadStream` which defaults `autoClose` (and thus `autoDestroy`) to `true`. When the stream encountered a read error on a PTY fd, it would auto-destroy itself, calling `fs.close(fd)` on the PTY master fd. This closed the PTY master, causing the kernel to send SIGHUP to the child process and making subsequent `ioctl(TIOCSWINSZ)` calls from `node-pty`'s native addon fail with EBADF.

`tty.WriteStream` already passed `autoClose: false` — this applies the same fix to `ReadStream`.

In Node.js, `tty.ReadStream` extends `net.Socket` (not `fs.ReadStream`) and doesn't auto-close the fd, so this aligns Bun's behavior with Node.js.

Closes #27285

## Test plan

- [x] New regression test `test/regression/issue/27285.test.ts` verifies `autoClose: false` and fd validity after errors
- [x] Test fails with system bun (`autoClose:true`, fd closed), passes with fix
- [x] All existing tty tests pass (`tty.test.ts`, `tty-readstream-ref-unref.test.ts`, `tui-app-tty-pattern.test.ts`)
- [x] Verified with actual `@lydell/node-pty` reproduction — resize succeeds instead of EBADF crash


🤖 Generated with [Claude Code](https://claude.com/claude-code)