### PR TITLE
fix(napi): prevent segfault from invalid cell pointers in napi_typeof (#27439)

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -42,6 +42,9 @@
 #include <JavaScriptCore/ExceptionScope.h>
 #include <JavaScriptCore/FunctionConstructor.h>
 #include <JavaScriptCore/Heap.h>
+#include <JavaScriptCore/Integrity.h>
+#include <JavaScriptCore/MarkedBlock.h>
+#include <JavaScriptCore/PreciseAllocation.h>
 #include <JavaScriptCore/Identifier.h>
 #include <JavaScriptCore/InitializeThreading.h>
 #include <JavaScriptCore/IteratorOperations.h>
@@ -2415,6 +2418,18 @@ extern "C" napi_status napi_typeof(napi_env env, napi_value val,
     if (value.isCell()) {
         JSCell* cell = value.asCell();
 
+        // Validate that the cell pointer is a real GC-managed object.
+        // Native modules may accidentally pass garbage (e.g. a C string pointer)
+        // as napi_value, which would crash when we dereference the cell.
+        // isSanePointer rejects obviously invalid addresses (null-near, non-canonical).
+        // The bloom filter provides fast rejection of pointers not in any known
+        // MarkedBlock, using only pointer arithmetic (no dereference).
+        if (!JSC::Integrity::isSanePointer(cell)
+            || (!JSC::PreciseAllocation::isPreciseAllocation(cell)
+                && toJS(env)->vm().heap.objectSpace().blocks().filter().ruleOut(
+                    std::bit_cast<uintptr_t>(JSC::MarkedBlock::blockFor(cell))))) [[unlikely]]
+            return napi_set_last_error(env, napi_invalid_arg);
+
         switch (cell->type()) {
         case JSC::JSFunctionType:
         case JSC::InternalFunctionType:
@@ -2986,6 +3001,11 @@ extern "C" uint32_t napi_internal_get_version(napi_env env)
 extern "C" JSGlobalObject* NapiEnv__globalObject(napi_env env)
 {
     return env->globalObject();
+}
+
+extern "C" bool NapiEnv__canRunFinalizer(napi_env env)
+{
+    return env && env->globalObject() && !env->isVMTerminating();
 }
 
 extern "C" bool NapiEnv__getAndClearPendingException(napi_env env, JSC::EncodedJSValue* exception)

--- a/src/napi/napi.zig
+++ b/src/napi/napi.zig
@@ -56,6 +56,7 @@ pub const NapiEnv = opaque {
     }
 
     extern fn NapiEnv__globalObject(*NapiEnv) *jsc.JSGlobalObject;
+    extern fn NapiEnv__canRunFinalizer(*NapiEnv) bool;
     extern fn NapiEnv__getAndClearPendingException(*NapiEnv, *JSValue) bool;
     extern fn napi_internal_get_version(*NapiEnv) u32;
     extern fn NapiEnv__deref(*NapiEnv) void;
@@ -1369,6 +1370,15 @@ pub const Finalizer = struct {
 
     pub fn run(this: *Finalizer) void {
         const env = this.env.get();
+
+        // Safety check: the env's globalObject may have been destroyed between
+        // when this finalizer was enqueued and when it runs on the JS thread.
+        // This can happen during VM teardown, particularly on Windows where
+        // NAPI module cleanup ordering differs from Unix.
+        if (!NapiEnv.NapiEnv__canRunFinalizer(env)) {
+            return;
+        }
+
         const handle_scope = NapiHandleScope.open(env, false);
         defer if (handle_scope) |scope| scope.close(env);
 

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -1522,26 +1522,26 @@ test_napi_typeof_invalid_pointer(const Napi::CallbackInfo &info) {
   napi_valuetype type;
   napi_status status = napi_typeof(env, near_null, &type);
 
-  if (status != napi_ok) {
-    printf("PASS: napi_typeof(0x8 pointer) returned error status %d "
-           "instead of crashing\n",
-           status);
+  if (status == napi_invalid_arg) {
+    printf("PASS: napi_typeof(0x8 pointer) returned napi_invalid_arg "
+           "instead of crashing\n");
   } else {
-    printf("FAIL: napi_typeof(0x8 pointer) returned napi_ok with type %d\n",
-           type);
+    printf("FAIL: napi_typeof(0x8 pointer) returned status %d, "
+           "expected napi_invalid_arg (%d)\n",
+           status, napi_invalid_arg);
   }
 
   // Test with another near-null address to cover the pattern.
   napi_value near_null2 = reinterpret_cast<napi_value>(static_cast<uintptr_t>(0x40));
   status = napi_typeof(env, near_null2, &type);
 
-  if (status != napi_ok) {
-    printf("PASS: napi_typeof(0x40 pointer) returned error status %d "
-           "instead of crashing\n",
-           status);
+  if (status == napi_invalid_arg) {
+    printf("PASS: napi_typeof(0x40 pointer) returned napi_invalid_arg "
+           "instead of crashing\n");
   } else {
-    printf("FAIL: napi_typeof(0x40 pointer) returned napi_ok with type %d\n",
-           type);
+    printf("FAIL: napi_typeof(0x40 pointer) returned status %d, "
+           "expected napi_invalid_arg (%d)\n",
+           status, napi_invalid_arg);
   }
 
   return ok(env);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -1508,6 +1508,45 @@ static napi_value test_napi_typeof_empty_value(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// Regression test for https://github.com/oven-sh/bun/issues/27439
+// napi_typeof must not segfault when given a near-null pointer like the
+// 0x8 address from the original crash report.
+static napi_value
+test_napi_typeof_invalid_pointer(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+
+  // Test with a pointer near null (the 0x8 address from the crash report).
+  // In JSC's NaN-boxing, 0x8 has tag bits 0x0000, so isCell() returns true
+  // and the code would try to dereference it without our validation.
+  napi_value near_null = reinterpret_cast<napi_value>(static_cast<uintptr_t>(0x8));
+  napi_valuetype type;
+  napi_status status = napi_typeof(env, near_null, &type);
+
+  if (status != napi_ok) {
+    printf("PASS: napi_typeof(0x8 pointer) returned error status %d "
+           "instead of crashing\n",
+           status);
+  } else {
+    printf("FAIL: napi_typeof(0x8 pointer) returned napi_ok with type %d\n",
+           type);
+  }
+
+  // Test with another near-null address to cover the pattern.
+  napi_value near_null2 = reinterpret_cast<napi_value>(static_cast<uintptr_t>(0x40));
+  status = napi_typeof(env, near_null2, &type);
+
+  if (status != napi_ok) {
+    printf("PASS: napi_typeof(0x40 pointer) returned error status %d "
+           "instead of crashing\n",
+           status);
+  } else {
+    printf("FAIL: napi_typeof(0x40 pointer) returned napi_ok with type %d\n",
+           type);
+  }
+
+  return ok(env);
+}
+
 // Test for Object.freeze and Object.seal with indexed properties
 static napi_value
 test_napi_freeze_seal_indexed(const Napi::CallbackInfo &info) {
@@ -2148,6 +2187,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_napi_create_array_boundary);
   REGISTER_FUNCTION(env, exports, test_napi_dataview_bounds_errors);
   REGISTER_FUNCTION(env, exports, test_napi_typeof_empty_value);
+  REGISTER_FUNCTION(env, exports, test_napi_typeof_invalid_pointer);
   REGISTER_FUNCTION(env, exports, test_napi_freeze_seal_indexed);
   REGISTER_FUNCTION(env, exports, test_napi_create_external_buffer_empty);
   REGISTER_FUNCTION(env, exports, test_napi_empty_buffer_info);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -829,6 +829,35 @@ describe("cleanup hooks", () => {
       expect(output).toContain("PASS: napi_create_threadsafe_function accepted AsyncContextFrame");
     });
 
+    it("should not crash with garbage cell pointer (#27439)", async () => {
+      // Regression test for https://github.com/oven-sh/bun/issues/27439
+      // napi_typeof should return an error status instead of segfaulting
+      // when a native module passes a garbage pointer as napi_value.
+      // This test is Bun-only because Node.js also crashes with garbage pointers.
+      const addonPath = join(__dirname, "napi-app", "build", "Debug", "napitests.node");
+      await using proc = spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const addon = require(${JSON.stringify(addonPath)}); addon.test_napi_typeof_invalid_pointer(() => { Bun.gc(true); });`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+
+      expect(stderr).toBe("");
+      expect(stdout).toContain("PASS: napi_typeof(0x8 pointer) returned error status");
+      expect(stdout).toContain("PASS: napi_typeof(0x40 pointer) returned error status");
+      expect(exitCode).toBe(0);
+    });
+
     it("should return napi_object for boxed primitives (String, Number, Boolean)", async () => {
       // Regression test for https://github.com/oven-sh/bun/issues/25351
       // napi_typeof was incorrectly returning napi_string for String objects (new String("hello"))

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -853,8 +853,8 @@ describe("cleanup hooks", () => {
       ]);
 
       expect(stderr).toBe("");
-      expect(stdout).toContain("PASS: napi_typeof(0x8 pointer) returned error status");
-      expect(stdout).toContain("PASS: napi_typeof(0x40 pointer) returned error status");
+      expect(stdout).toContain("PASS: napi_typeof(0x8 pointer) returned napi_invalid_arg");
+      expect(stdout).toContain("PASS: napi_typeof(0x40 pointer) returned napi_invalid_arg");
       expect(exitCode).toBe(0);
     });
 


### PR DESCRIPTION
## Summary

Fixes #27439 - Segmentation fault at address 0x8 when running `bun create next-app` on Windows.

The crash occurs when `next-swc.win32-x64-msvc.node` (a NAPI native module) passes an invalid/garbage pointer as `napi_value` to `napi_typeof`, which then dereferences it and segfaults. A secondary crash path exists when NAPI finalizers run after the env's globalObject has been destroyed during VM teardown.

**Changes:**

- **`napi_typeof` cell pointer validation** (`src/bun.js/bindings/napi.cpp`): Before dereferencing a cell pointer, validate it using `JSC::Integrity::isSanePointer()` (rejects near-null and non-canonical addresses) and JSC's MarkedBlock bloom filter (fast rejection of pointers not belonging to any GC-managed block). Returns `napi_invalid_arg` for invalid pointers instead of crashing.

- **Finalizer safety guard** (`src/napi/napi.zig`): Added `NapiEnv__canRunFinalizer()` check before executing deferred finalizers. This prevents null pointer dereference when the env's globalObject has been destroyed between finalizer scheduling and execution, which can happen during VM teardown on Windows.

## Test plan

- [x] Added regression test `test_napi_typeof_invalid_pointer` that passes near-null pointers (0x8, 0x40) to `napi_typeof` and verifies error status instead of crash
- [x] Test passes with `bun bd test` (fix applied)
- [x] Test fails with `USE_SYSTEM_BUN=1` (system Bun crashes with segfault)
- [x] All existing `napi_typeof` tests continue to pass (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)