### PR TITLE
fix(bundler): error on --splitting with non-ESM format instead of crashing

### DIFF
--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -1063,6 +1063,10 @@ pub const JSBundler = struct {
                 }
             }
 
+            if (this.code_splitting and this.format != .esm) {
+                return globalThis.throwInvalidArguments("Cannot use splitting with a non-ESM output format", .{});
+            }
+
             // ESM bytecode requires compile because module_info (import/export metadata)
             // is only available in compiled binaries. Without it, JSC must parse the file
             // twice (once for module analysis, once for bytecode), which is a deopt.

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -183,6 +183,12 @@ pub const BuildCommand = struct {
             }
         }
 
+        if (this_transpiler.options.code_splitting and this_transpiler.options.output_format != .esm) {
+            Output.prettyErrorln("<r><red>error<r><d>:<r> Cannot use <b>--splitting<r> with a non-ESM output format", .{});
+            Global.exit(1);
+            return;
+        }
+
         if (ctx.bundler_options.outdir.len == 0 and !ctx.bundler_options.compile and fetcher == null) {
             if (this_transpiler.options.entry_points.len > 1) {
                 Output.prettyErrorln("<r><red>error<r><d>:<r> Must use <b>--outdir<r> when specifying more than one entry point.", .{});

--- a/test/regression/issue/21287.test.ts
+++ b/test/regression/issue/21287.test.ts
@@ -45,13 +45,13 @@ test("bun build --splitting with --format=iife should error, not crash", async (
   expect(exitCode).not.toBe(0);
 });
 
-test("Bun.build splitting with format cjs should throw", async () => {
+test("Bun.build splitting with format cjs should throw", () => {
   using dir = tempDir("issue-21287-api", {
     "entry.ts": `export const a = 1;`,
   });
 
-  expect(async () => {
-    await Bun.build({
+  expect(() => {
+    Bun.build({
       entrypoints: [dir + "/entry.ts"],
       splitting: true,
       format: "cjs",
@@ -75,7 +75,8 @@ test("bun build --splitting with --format=esm should succeed", async () => {
     stdout: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/21287.test.ts
+++ b/test/regression/issue/21287.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 test("bun build --splitting with --format=cjs should error, not crash", async () => {

--- a/test/regression/issue/21287.test.ts
+++ b/test/regression/issue/21287.test.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("bun build --splitting with --format=cjs should error, not crash", async () => {
+  using dir = tempDir("issue-21287", {
+    "shared.ts": `export function sharedFn() { return "shared"; }`,
+    "entry1.ts": `import { sharedFn } from "./shared"; export const a = sharedFn();`,
+    "entry2.ts": `import { sharedFn } from "./shared"; export const b = sharedFn();`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "entry1.ts", "entry2.ts", "--splitting", "--format=cjs", "--outdir=out"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("Cannot use");
+  expect(stderr).toContain("splitting");
+  expect(exitCode).not.toBe(0);
+});
+
+test("bun build --splitting with --format=iife should error, not crash", async () => {
+  using dir = tempDir("issue-21287", {
+    "shared.ts": `export function sharedFn() { return "shared"; }`,
+    "entry1.ts": `import { sharedFn } from "./shared"; export const a = sharedFn();`,
+    "entry2.ts": `import { sharedFn } from "./shared"; export const b = sharedFn();`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "entry1.ts", "entry2.ts", "--splitting", "--format=iife", "--outdir=out"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("Cannot use");
+  expect(stderr).toContain("splitting");
+  expect(exitCode).not.toBe(0);
+});
+
+test("Bun.build splitting with format cjs should throw", async () => {
+  using dir = tempDir("issue-21287-api", {
+    "entry.ts": `export const a = 1;`,
+  });
+
+  expect(async () => {
+    await Bun.build({
+      entrypoints: [dir + "/entry.ts"],
+      splitting: true,
+      format: "cjs",
+      outdir: dir + "/out",
+    });
+  }).toThrow(/splitting/i);
+});
+
+test("bun build --splitting with --format=esm should succeed", async () => {
+  using dir = tempDir("issue-21287", {
+    "shared.ts": `export function sharedFn() { return "shared"; }`,
+    "entry1.ts": `import { sharedFn } from "./shared"; export const a = sharedFn();`,
+    "entry2.ts": `import { sharedFn } from "./shared"; export const b = sharedFn();`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "entry1.ts", "entry2.ts", "--splitting", "--format=esm", "--outdir=out"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fixes a crash ("panic: attempt to use null value") when using `--splitting` with `--format=cjs` or `--format=iife`
- The crash occurred because cross-chunk exports were only generated for ESM format, while cross-chunk imports were populated unconditionally for all formats. This caused a null unwrap in `sortedCrossChunkImports`
- Now rejects this invalid combination upfront with a clear error message, matching esbuild's behavior
- Validation added in both the CLI path (`build_command.zig`) and the `Bun.build()` JS API (`JSBundler.zig`)

Closes #21287

## Test plan

- [x] `bun build entry1.ts entry2.ts --splitting --format=cjs --outdir=out` now prints error instead of crashing
- [x] `bun build entry1.ts entry2.ts --splitting --format=iife --outdir=out` now prints error instead of crashing
- [x] `bun build entry1.ts entry2.ts --splitting --format=esm --outdir=out` still works correctly
- [x] `Bun.build({ splitting: true, format: "cjs" })` throws instead of crashing
- [x] Regression test added: `test/regression/issue/21287.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)