### PR TITLE
fix(devserver): replace panic with graceful error handling for server code evaluation errors

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -2554,34 +2554,40 @@ pub fn finalizeBundle(
                 json.ptr,
                 json.len,
             ) catch |err| {
-                // No user code has been evaluated yet, since everything is to
-                // be wrapped in a function clousure. This means that the likely
-                // error is going to be a syntax error, or other mistake in the
-                // bundler.
+                // User code syntax errors (e.g. invalid regex patterns) can
+                // surface here because the bundler does not fully validate all
+                // JS syntax. Log the error and continue instead of crashing.
                 dev.vm.printErrorLikeObjectToConsole(dev.vm.global.takeException(err));
-                @panic("Error thrown while evaluating server code. This is always a bug in the bundler.");
+                Output.prettyError("<red>error<r>: Server code evaluation failed. This is likely a syntax error in your code.\n", .{});
+                break :blk null;
             };
-        } else c.BakeLoadServerHmrPatch(@ptrCast(dev.vm.global), bun.String.cloneLatin1(server_bundle)) catch |err| {
-            dev.vm.printErrorLikeObjectToConsole(dev.vm.global.takeException(err));
-            @panic("Error thrown while evaluating server code. This is always a bug in the bundler.");
+        } else blk: {
+            break :blk c.BakeLoadServerHmrPatch(@ptrCast(dev.vm.global), bun.String.cloneLatin1(server_bundle)) catch |err| {
+                dev.vm.printErrorLikeObjectToConsole(dev.vm.global.takeException(err));
+                Output.prettyError("<red>error<r>: Server code evaluation failed. This is likely a syntax error in your code.\n", .{});
+                break :blk null;
+            };
         };
-        const errors = dev.server_register_update_callback.get().?.call(
-            dev.vm.global,
-            dev.vm.global.toJSValue(),
-            &.{
-                server_modules,
-                try dev.makeArrayForServerComponentsPatch(dev.vm.global, dev.incremental_result.client_components_added.items),
-                try dev.makeArrayForServerComponentsPatch(dev.vm.global, dev.incremental_result.client_components_removed.items),
-            },
-        ) catch |err| {
-            // One module replacement error should NOT prevent follow-up
-            // module replacements to fail. It is the HMR runtime's
-            // responsibility to collect all module load errors, and
-            // bubble them up.
-            dev.vm.printErrorLikeObjectToConsole(dev.vm.global.takeException(err));
-            @panic("Error thrown in Hot-module-replacement code. This is always a bug in the HMR runtime.");
-        };
-        _ = errors; // TODO:
+        if (server_modules) |modules| {
+            if (dev.server_register_update_callback.get().?.call(
+                dev.vm.global,
+                dev.vm.global.toJSValue(),
+                &.{
+                    modules,
+                    try dev.makeArrayForServerComponentsPatch(dev.vm.global, dev.incremental_result.client_components_added.items),
+                    try dev.makeArrayForServerComponentsPatch(dev.vm.global, dev.incremental_result.client_components_removed.items),
+                },
+            )) |_| {
+                // TODO: handle returned errors
+            } else |err| {
+                // One module replacement error should NOT prevent follow-up
+                // module replacements to fail. It is the HMR runtime's
+                // responsibility to collect all module load errors, and
+                // bubble them up.
+                dev.vm.printErrorLikeObjectToConsole(dev.vm.global.takeException(err));
+                Output.prettyError("<red>error<r>: Error thrown in Hot-module-replacement runtime.\n", .{});
+            }
+        }
     }
 
     var route_bits = try DynamicBitSetUnmanaged.initEmpty(stack_alloc, dev.route_bundles.items.len);

--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -2577,8 +2577,13 @@ pub fn finalizeBundle(
                     try dev.makeArrayForServerComponentsPatch(dev.vm.global, dev.incremental_result.client_components_added.items),
                     try dev.makeArrayForServerComponentsPatch(dev.vm.global, dev.incremental_result.client_components_removed.items),
                 },
-            )) |_| {
-                // TODO: handle returned errors
+            )) |update_result| {
+                // The HMR runtime's registerUpdate returns a Promise<void>.
+                // If it somehow returned an error value, log it for debugging.
+                if (update_result.isAnyError()) {
+                    dev.vm.printErrorLikeObjectToConsole(update_result);
+                    Output.prettyError("<red>error<r>: HMR module update returned an error.\n", .{});
+                }
             } else |err| {
                 // One module replacement error should NOT prevent follow-up
                 // module replacements to fail. It is the HMR runtime's

--- a/test/bake/dev/dev-server-eval-error.test.ts
+++ b/test/bake/dev/dev-server-eval-error.test.ts
@@ -1,0 +1,46 @@
+// Tests for server-side code evaluation errors that are not caught by the bundler.
+// See: https://github.com/oven-sh/bun/issues/15530
+import { expect } from "bun:test";
+import { devTest, minimalFramework } from "../bake-harness";
+
+devTest("invalid regex does not crash dev server (#15530)", {
+  framework: minimalFramework,
+  files: {
+    "routes/index.ts": `
+      export default function (req, meta) {
+        return new Response("hello");
+      }
+    `,
+  },
+  async test(dev) {
+    // First, verify the route works normally
+    await dev.fetch("/").equals("hello");
+
+    // Write a file with an invalid regex pattern. Bun's lexer does not
+    // validate regex semantics (only flags and structure), so /+/ passes
+    // through the bundler. When JSC evaluates the bundled server code,
+    // it throws "Invalid regular expression: nothing to repeat".
+    // The dev server must NOT panic - it should handle this gracefully.
+    await dev.write(
+      "routes/index.ts",
+      'export const re = /+/;\nexport default function (req, meta) {\n  return new Response("with regex " + re);\n}\n',
+      { dedent: false },
+    );
+
+    // The dev server should NOT panic. The route should still be
+    // accessible (previous version continues to work).
+    const response = await dev.fetch("/");
+    expect(response.status).toBe(200);
+
+    // Fix the regex error and verify the server recovers
+    await dev.write(
+      "routes/index.ts",
+      `
+      export default function (req, meta) {
+        return new Response("recovered");
+      }
+    `,
+    );
+    await dev.fetch("/").equals("recovered");
+  },
+});


### PR DESCRIPTION
## Summary
- Replace `@panic` in `DevServer.finalizeBundle()` with graceful error handling when server code evaluation fails (e.g. due to invalid regex patterns that pass through the bundler's lexer but are rejected by JSC)
- The dev server now logs the error to the console and continues serving requests with the previous working version of the code, instead of crashing
- Also replace `@panic` in the HMR update callback with graceful error logging

## Test plan
- [x] New test `test/bake/dev/dev-server-eval-error.test.ts` verifies the dev server doesn't crash when a file with an invalid regex (`/+/`) is written, and recovers when the file is fixed
- [x] All existing `test/bake/dev/bundle.test.ts` tests pass (17/17)
- [x] All existing `test/bake/dev/hot.test.ts` tests pass (8/8)

Fixes #15530

🤖 Generated with [Claude Code](https://claude.com/claude-code)