### PR TITLE
fix(windows): bypass bmalloc/libpas to fix GC crashes under memory pressure

### DIFF
--- a/cmake/targets/BuildBun.cmake
+++ b/cmake/targets/BuildBun.cmake
@@ -1265,6 +1265,14 @@ if(BUN_LINK_ONLY)
 endif()
 
 if(WIN32)
+  # bmalloc/libpas causes GC crashes on Windows under memory pressure
+  # (see https://github.com/oven-sh/bun/issues/21569). Bun overrides
+  # bmalloc's SystemHeap on Windows (BmallocSystemHeapOverride.cpp) to use
+  # mimalloc instead of the unimplemented stubs. Combined with setting
+  # Malloc=1 at startup, this bypasses libpas for all allocations.
+  # bmalloc.lib is still linked because WTF.lib references bmalloc symbols.
+  # Once oven-sh/WebKit prebuilts are rebuilt without libpas on Windows,
+  # bmalloc.lib can be removed entirely.
   if(DEBUG)
     target_link_libraries(${bun} PRIVATE
       ${WEBKIT_LIB_PATH}/WTF.lib

--- a/src/bun.js/bindings/BmallocSystemHeapOverride.cpp
+++ b/src/bun.js/bindings/BmallocSystemHeapOverride.cpp
@@ -1,0 +1,287 @@
+/**
+ * Working SystemHeap implementation for Windows using mimalloc.
+ *
+ * bmalloc's SystemHeap is unimplemented on Windows (all methods crash with
+ * RELEASE_BASSERT_NOT_REACHED). This file provides a functional replacement
+ * that uses mimalloc for allocations.
+ *
+ * Combined with setting the "Malloc" environment variable at process startup,
+ * this causes bmalloc/libpas to redirect all allocations through this
+ * SystemHeap instead of using libpas directly. This avoids GC crashes caused
+ * by libpas instability on Windows under memory pressure.
+ *
+ * See: https://github.com/oven-sh/bun/issues/21569
+ *      https://github.com/oven-sh/bun/issues/28097
+ *
+ * How it works:
+ *   1. Bun sets Malloc=1 env var early in main() (see src/main.zig)
+ *   2. bmalloc's Environment reads Malloc=1 and sets
+ *      shouldBmallocAllocateThroughSystemHeap() = true
+ *   3. All bmalloc allocations route through SystemHeap
+ *   4. This file provides SystemHeap using mimalloc instead of crashing
+ *
+ * Link-time override:
+ *   This object file defines the same symbols as bmalloc.lib's
+ *   SystemHeap.cpp.o. Since object files are processed before static
+ *   libraries, the linker uses these definitions and skips bmalloc.lib's
+ *   unimplemented stubs.
+ */
+
+#include <bmalloc/BPlatform.h>
+
+// Only override on Windows where SystemHeap is unimplemented.
+#if BOS(WINDOWS)
+
+#include <bmalloc/SystemHeap.h>
+#include <bmalloc/Algorithm.h>
+#include <bmalloc/BAssert.h>
+#include <bmalloc/VMAllocate.h>
+#include "mimalloc.h"
+
+#if BENABLE(LIBPAS)
+#include <bmalloc/pas_system_heap.h>
+#endif
+
+namespace bmalloc {
+
+SystemHeap* systemHeapCache { nullptr };
+
+BALLOW_DEPRECATED_DECLARATIONS_BEGIN
+DEFINE_STATIC_PER_PROCESS_STORAGE(SystemHeap);
+BALLOW_DEPRECATED_DECLARATIONS_END
+
+SystemHeap::SystemHeap(const LockHolder&)
+    : m_pageSize(vmPageSize())
+{
+}
+
+void* SystemHeap::malloc(size_t size, FailureAction action)
+{
+    void* result = mi_malloc(size);
+    RELEASE_BASSERT(action == FailureAction::ReturnNull || result);
+    return result;
+}
+
+void* SystemHeap::memalign(size_t alignment, size_t size, FailureAction action)
+{
+    void* result = mi_malloc_aligned(size, alignment);
+    RELEASE_BASSERT(action == FailureAction::ReturnNull || result);
+    return result;
+}
+
+void* SystemHeap::realloc(void* object, size_t size, FailureAction action)
+{
+    void* result = mi_realloc(object, size);
+    RELEASE_BASSERT(action == FailureAction::ReturnNull || result);
+    return result;
+}
+
+void SystemHeap::free(void* object)
+{
+    mi_free(object);
+}
+
+void SystemHeap::scavenge()
+{
+    mi_collect(false);
+}
+
+void SystemHeap::dump()
+{
+}
+
+// memalignLarge / freeLarge use virtual memory directly (same as upstream).
+void* SystemHeap::memalignLarge(size_t alignment, size_t size)
+{
+    alignment = roundUpToMultipleOf(m_pageSize, alignment);
+    size = roundUpToMultipleOf(m_pageSize, size);
+    void* result = tryVMAllocate(alignment, size);
+    if (!result)
+        return nullptr;
+    {
+        LockHolder locker(mutex());
+        m_sizeMap[result] = size;
+    }
+    return result;
+}
+
+void SystemHeap::freeLarge(void* base)
+{
+    if (!base)
+        return;
+
+    size_t size;
+    {
+        LockHolder locker(mutex());
+        size = m_sizeMap[base];
+        size_t numErased = m_sizeMap.erase(base);
+        RELEASE_BASSERT(numErased == 1);
+    }
+
+    vmDeallocate(base, size);
+}
+
+SystemHeap* SystemHeap::tryGetSlow()
+{
+    SystemHeap* result;
+    if (Environment::get()->isSystemHeapEnabled()) {
+        systemHeapCache = SystemHeap::get();
+        result = systemHeapCache;
+    } else {
+        systemHeapCache = systemHeapDisabled();
+        result = nullptr;
+    }
+    RELEASE_BASSERT(systemHeapCache);
+    return result;
+}
+
+} // namespace bmalloc
+
+// libpas integration — same as upstream, but our SystemHeap actually works.
+#if BENABLE(LIBPAS)
+
+#if BUSE(LIBPAS)
+
+using namespace bmalloc;
+
+bool pas_system_heap_is_enabled(pas_heap_config_kind kind)
+{
+    switch (kind) {
+    case pas_heap_config_kind_bmalloc:
+        return !!SystemHeap::tryGet();
+    case pas_heap_config_kind_jit:
+    case pas_heap_config_kind_pas_utility:
+        return false;
+    default:
+        BCRASH();
+        return false;
+    }
+}
+
+bool pas_system_heap_should_supplant_bmalloc(pas_heap_config_kind kind)
+{
+    SystemHeap* heap;
+    switch (kind) {
+    case pas_heap_config_kind_bmalloc:
+        heap = SystemHeap::tryGet();
+        if (!heap)
+            return false;
+        return heap->shouldSupplantBmalloc();
+    case pas_heap_config_kind_jit:
+    case pas_heap_config_kind_pas_utility:
+        return false;
+    default:
+        BCRASH();
+        return false;
+    }
+}
+
+void* pas_system_heap_malloc(size_t size)
+{
+    return SystemHeap::getExisting()->malloc(size, FailureAction::ReturnNull);
+}
+
+void* pas_system_heap_memalign(size_t alignment, size_t size)
+{
+    return SystemHeap::getExisting()->memalign(alignment, size, FailureAction::ReturnNull);
+}
+
+void* pas_system_heap_realloc(void* ptr, size_t size)
+{
+    return SystemHeap::getExisting()->realloc(ptr, size, FailureAction::ReturnNull);
+}
+
+void pas_system_heap_free(void* ptr)
+{
+    SystemHeap::getExisting()->free(ptr);
+}
+
+void* pas_system_heap_malloc_compact(size_t size)
+{
+    return SystemHeap::getExisting()->malloc(size, FailureAction::ReturnNull);
+}
+
+void* pas_system_heap_memalign_compact(size_t alignment, size_t size)
+{
+    return SystemHeap::getExisting()->memalign(alignment, size, FailureAction::ReturnNull);
+}
+
+void* pas_system_heap_realloc_compact(void* ptr, size_t size)
+{
+    return SystemHeap::getExisting()->realloc(ptr, size, FailureAction::ReturnNull);
+}
+
+#else // !BUSE(LIBPAS)
+
+bool pas_system_heap_is_enabled(pas_heap_config_kind kind)
+{
+    BUNUSED_PARAM(kind);
+    return false;
+}
+
+bool pas_system_heap_should_supplant_bmalloc(pas_heap_config_kind kind)
+{
+    BUNUSED_PARAM(kind);
+    return false;
+}
+
+void* pas_system_heap_malloc(size_t size)
+{
+    BUNUSED_PARAM(size);
+    RELEASE_BASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+void* pas_system_heap_memalign(size_t alignment, size_t size)
+{
+    BUNUSED_PARAM(size);
+    BUNUSED_PARAM(alignment);
+    RELEASE_BASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+void* pas_system_heap_realloc(void* ptr, size_t size)
+{
+    BUNUSED_PARAM(ptr);
+    BUNUSED_PARAM(size);
+    RELEASE_BASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+void* pas_system_heap_malloc_compact(size_t size)
+{
+    BUNUSED_PARAM(size);
+    RELEASE_BASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+void* pas_system_heap_memalign_compact(size_t alignment, size_t size)
+{
+    BUNUSED_PARAM(size);
+    BUNUSED_PARAM(alignment);
+    RELEASE_BASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+void* pas_system_heap_realloc_compact(void* ptr, size_t size)
+{
+    BUNUSED_PARAM(ptr);
+    BUNUSED_PARAM(size);
+    RELEASE_BASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-noreturn"
+void pas_system_heap_free(void* ptr)
+{
+    BUNUSED_PARAM(ptr);
+    RELEASE_BASSERT_NOT_REACHED();
+}
+#pragma clang diagnostic pop
+
+#endif // BUSE(LIBPAS)
+
+#endif // BENABLE(LIBPAS)
+
+#endif // BOS(WINDOWS)

--- a/src/c-headers-for-zig.h
+++ b/src/c-headers-for-zig.h
@@ -59,6 +59,7 @@
 #if WINDOWS
 #include <windows.h>
 #include <winternl.h>
+#include <stdlib.h> // _putenv
 #endif
 
 #undef lstat

--- a/src/main.zig
+++ b/src/main.zig
@@ -21,6 +21,17 @@ pub extern "c" var environ: ?*anyopaque;
 pub fn main() void {
     _bun.crash_handler.init();
 
+    // Force bmalloc to use SystemHeap (mimalloc) instead of libpas on Windows.
+    // bmalloc's libpas allocator causes GC crashes under memory pressure on
+    // Windows. Setting "Malloc" causes bmalloc::Environment to route all
+    // allocations through SystemHeap, which we implement using mimalloc
+    // (see BmallocSystemHeapOverride.cpp). Must be set before any bmalloc
+    // allocation triggers Environment initialization.
+    // See: https://github.com/oven-sh/bun/issues/21569
+    if (Environment.isWindows) {
+        _ = _bun.c._putenv("Malloc=1");
+    }
+
     if (Environment.isPosix) {
         var act: std.posix.Sigaction = .{
             .handler = .{ .handler = std.posix.SIG.IGN },


### PR DESCRIPTION
## Summary

- Fixes segmentation fault on Windows during GC sweep (`MarkedBlock::isNewlyAllocatedStale`) caused by bmalloc's libpas allocator under memory pressure
- Implements bmalloc's `SystemHeap` on Windows using mimalloc as the backing allocator (upstream WebKit leaves this unimplemented — all methods crash with `RELEASE_BASSERT_NOT_REACHED()`)
- Sets `Malloc=1` environment variable early in `main()` to trigger bmalloc's system heap bypass, routing all allocations through our mimalloc-backed SystemHeap instead of libpas

### How it works

1. **`BmallocSystemHeapOverride.cpp`** — Provides a working `bmalloc::SystemHeap` for Windows using mimalloc (`mi_malloc`, `mi_malloc_aligned`, `mi_realloc`, `mi_free`). At link time, these symbols override bmalloc.lib's unimplemented stubs because object files are resolved before static libraries.

2. **`main.zig`** — Sets `Malloc=1` via `_putenv` before any bmalloc initialization. bmalloc's `Environment` class reads this and sets `shouldBmallocAllocateThroughSystemHeap() = true`, causing all allocations to route through `SystemHeap`.

3. **`c-headers-for-zig.h`** — Adds `<stdlib.h>` to Windows includes so `_putenv` is available to Zig code.

### Why bmalloc.lib is still linked

`WTF.lib` references ~230 bmalloc symbols, so bmalloc.lib cannot be removed without rebuilding WebKit prebuilts. This fix works *alongside* bmalloc.lib by overriding only the `SystemHeap` symbols. Once oven-sh/WebKit prebuilts are rebuilt without libpas on Windows, bmalloc.lib can be removed entirely.

Fixes #21569

## Test plan

- [x] `bun bd` compiles successfully on Linux
- [x] `bun run zig:check-windows` passes (Windows cross-compilation check)
- [x] `bun run zig:check-all` passes (all platform compilation checks)
- [ ] Windows CI: verify no GC crashes under memory pressure
- [ ] Windows CI: verify no duplicate symbol errors at link time

🤖 Generated with [Claude Code](https://claude.com/claude-code)