### PR TITLE
fix(server): prevent segfault when server JS wrapper is finalized during request handling

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2047,14 +2047,26 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             const server = user_route.server;
             const index = user_route.id;
 
+            const server_js = server.js_value.tryGet() orelse {
+                // Server has been finalized (e.g. during --hot reload or after stop()).
+                // Reject the request since we can no longer invoke JS handlers.
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
+
             var should_deinit_context = false;
             var prepared = server.prepareJsRequestContext(req, resp, &should_deinit_context, .no, switch (user_route.route.method) {
                 .any => null,
                 .specific => |m| m,
             }) orelse return;
 
-            const server_request_list = js.routeListGetCached(server.jsValueAssertAlive()).?;
-            const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server.jsValueAssertAlive(), server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
+            const server_request_list = js.routeListGetCached(server_js) orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
+            const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server_js, server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
 
             server.handleRequest(&should_deinit_context, prepared, req, response_value);
         }
@@ -2089,16 +2101,21 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
         }
 
         pub fn onRequest(this: *ThisServer, req: *uws.Request, resp: *App.Response) void {
+            const server_js = this.js_value.tryGet() orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
+
             var should_deinit_context = false;
             const prepared = this.prepareJsRequestContext(req, resp, &should_deinit_context, .yes, null) orelse return;
 
             bun.assert(this.config.onRequest != .zero);
 
-            const js_value = this.jsValueAssertAlive();
             const response_value = this.config.onRequest.call(
                 this.globalThis,
-                js_value,
-                &.{ prepared.js_request, js_value },
+                server_js,
+                &.{ prepared.js_request, server_js },
             ) catch |err|
                 this.globalThis.takeException(err);
 
@@ -2124,10 +2141,15 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             const ctx = prepared.ctx;
 
             bun.assert(callback != .zero);
+            const server_js = this.js_value.tryGet() orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
             const args = .{prepared.js_request} ++ extra_args;
             const response_value = callback.call(
                 this.globalThis,
-                this.jsValueAssertAlive(),
+                server_js,
                 &args,
             ) catch |err|
                 this.globalThis.takeException(err);
@@ -2318,11 +2340,21 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             const server = this.server;
             const index = this.id;
 
+            const server_js = server.js_value.tryGet() orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
+
             var should_deinit_context = false;
             var prepared = server.prepareJsRequestContext(req, resp, &should_deinit_context, .no, method) orelse return;
             prepared.ctx.upgrade_context = upgrade_ctx; // set the upgrade context
-            const server_request_list = js.routeListGetCached(server.jsValueAssertAlive()).?;
-            const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server.jsValueAssertAlive(), server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
+            const server_request_list = js.routeListGetCached(server_js) orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
+            const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server_js, server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
 
             server.handleRequest(&should_deinit_context, prepared, req, response_value);
         }
@@ -2347,6 +2379,11 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 resp.endWithoutBody(true);
                 return;
             }
+            const server_js = this.js_value.tryGet() orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
             this.pending_requests += 1;
             req.setYield(false);
             var ctx = bun.handleOom(this.request_pool_allocator.tryGet());
@@ -2370,12 +2407,12 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             // We keep the Request object alive for the duration of the request so that we can remove the pointer to the UWS request object.
             var args = [_]jsc.JSValue{
                 request_object.toJS(this.globalThis),
-                this.jsValueAssertAlive(),
+                server_js,
             };
             const request_value = args[0];
             request_value.ensureStillAlive();
 
-            const response_value = this.config.onRequest.call(this.globalThis, this.jsValueAssertAlive(), &args) catch |err|
+            const response_value = this.config.onRequest.call(this.globalThis, server_js, &args) catch |err|
                 this.globalThis.takeException(err);
             defer {
                 // uWS request will not live longer than this function

--- a/test/regression/issue/21559.test.ts
+++ b/test/regression/issue/21559.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
 
 // Test that stopping a server and then sending a request doesn't crash with a segfault.
 // Previously, after server.stop() downgraded the JS reference to weak, GC could collect

--- a/test/regression/issue/21559.test.ts
+++ b/test/regression/issue/21559.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Test that stopping a server and then sending a request doesn't crash with a segfault.
+// Previously, after server.stop() downgraded the JS reference to weak, GC could collect
+// the JS wrapper while uWS route handlers were still registered, causing a null pointer
+// dereference in routeListGetCachedValue.
+test("server does not crash after stop() when requests arrive", async () => {
+  const server = Bun.serve({
+    port: 0,
+    routes: {
+      "/test": () => new Response("ok"),
+    },
+    fetch(req) {
+      return new Response("fallback");
+    },
+  });
+
+  const url = `http://${server.hostname}:${server.port}`;
+
+  // Verify server works
+  const res = await fetch(`${url}/test`);
+  expect(res.status).toBe(200);
+  expect(await res.text()).toBe("ok");
+
+  server.stop();
+
+  // After stop(), the server should gracefully reject or not accept new connections.
+  // The key invariant: no segfault/crash.
+  try {
+    // This may fail with a connection error, which is fine.
+    // The important thing is that Bun doesn't crash.
+    await fetch(`${url}/test`, { signal: AbortSignal.timeout(1000) });
+  } catch {
+    // Connection refused or timeout is expected after stop()
+  }
+});
+
+test("server does not crash when JS wrapper could be GC'd during request handling", async () => {
+  // Create a server with routes (which uses routeListGetCached internally)
+  const server = Bun.serve({
+    port: 0,
+    routes: {
+      "/api": () => new Response("api response"),
+      "/health": () => new Response("healthy"),
+    },
+    fetch(req) {
+      return new Response("default");
+    },
+  });
+
+  const url = `http://${server.hostname}:${server.port}`;
+
+  // Send multiple concurrent requests
+  const promises = [];
+  for (let i = 0; i < 10; i++) {
+    promises.push(fetch(`${url}/api`).then(r => r.text()));
+    promises.push(fetch(`${url}/health`).then(r => r.text()));
+  }
+
+  const results = await Promise.all(promises);
+  for (let i = 0; i < results.length; i += 2) {
+    expect(results[i]).toBe("api response");
+    expect(results[i + 1]).toBe("healthy");
+  }
+
+  // Force GC to stress-test the JS wrapper lifecycle
+  Bun.gc(true);
+
+  // Send more requests after GC
+  const res = await fetch(`${url}/api`);
+  expect(res.status).toBe(200);
+  expect(await res.text()).toBe("api response");
+
+  server.stop();
+});


### PR DESCRIPTION
## Summary
- Fix segfault at address 0x4A in `routeListGetCachedValue` when the server's JS wrapper has been garbage collected while uWS route handlers are still active
- Replace unsafe `jsValueAssertAlive()` (which uses `.?` on a potentially null optional — UB in release mode) with `js_value.tryGet()` null checks in all uWS callback handlers
- Return 503 Service Unavailable when the server JS wrapper is no longer available instead of crashing

## Root Cause
When `server.stop()` is called (or during `--hot` reload), the server's JS reference is downgraded from strong to weak via `js_value.downgrade()`. After GC collects the JS wrapper, `finalize()` sets `js_value` to `.finalized`. If uWS route handlers fire after this (e.g., from in-flight connections), `jsValueAssertAlive()` calls `.tryGet()` which returns `null`, then `.?` on null is `unreachable` in Zig — which is undefined behavior in release builds. The compiler optimizes away the null check, resulting in a null pointer being passed to C++ `jsCast`, which then dereferences it at offset 0x4A (the `m_routeList` WriteBarrier field), causing the segfault.

## Affected Handlers
- `onUserRouteRequest` — route-based request handling
- `onRequest` — default fetch handler
- `upgradeWebSocketUserRoute` — WebSocket upgrade via routes
- `onWebSocketUpgrade` — WebSocket upgrade via default handler
- `onSavedRequest` — Bake framework saved request handling

## Test plan
- [x] Added regression test in `test/regression/issue/21559.test.ts`
- [x] Debug build compiles successfully
- [x] Regression test passes with `bun bd test`
- [x] Existing `serve.test.ts` tests pass (no new regressions)

Closes #21559

🤖 Generated with [Claude Code](https://claude.com/claude-code)