### PR TITLE
fix(bundler): resolve barrel exports from HMR-deduplicated import records

### DIFF
--- a/src/bundler/barrel_imports.zig
+++ b/src/bundler/barrel_imports.zig
@@ -232,6 +232,57 @@ fn resolveBarrelRecords(this: *BundleV2, barrel_idx: u32, barrels_to_resolve: *s
     return scheduled;
 }
 
+/// In dev server mode, ConvertESMExportsForHmr deduplicates import records by
+/// path — when a file has multiple `import {...} from "pkg"` statements, only
+/// the first record survives (path resolved) while duplicates get is_unused=true
+/// and their paths stay as the bare module specifier. resolveImportRecords skips
+/// is_unused records, so dead records never get their paths resolved.
+///
+/// This function builds a map from original_path (the unresolved module
+/// specifier, e.g. "@tanstack/react-query") → resolved target source_index,
+/// using the surviving records that DID get resolved. Dead records can then
+/// look up their original_path in this map to find the correct target.
+fn buildSpecifierToTargetMap(
+    file_import_records: ImportRecord.List,
+    path_to_source_index_map: *const PathToSourceIndexMap,
+    alloc: std.mem.Allocator,
+) bun.StringArrayHashMapUnmanaged(u32) {
+    var map = bun.StringArrayHashMapUnmanaged(u32){};
+    for (file_import_records.slice()) |ir| {
+        if (ir.original_path.len == 0) continue;
+        if (map.contains(ir.original_path)) continue;
+        // Try source_index first, then fall back to path map lookup.
+        const target_idx = if (ir.source_index.isValid())
+            ir.source_index.get()
+        else
+            path_to_source_index_map.getPath(&ir.path) orelse continue;
+        map.put(alloc, ir.original_path, target_idx) catch continue;
+    }
+    return map;
+}
+
+/// Resolve a named_import's import record to a target source_index.
+/// Tries source_index, then path map, then the specifier fallback map
+/// (for dead HMR-dedup'd records whose paths were never resolved).
+inline fn resolveImportTarget(
+    ir: ImportRecord,
+    path_to_source_index_map: ?*const PathToSourceIndexMap,
+    specifier_fallback: ?*const bun.StringArrayHashMapUnmanaged(u32),
+) ?u32 {
+    if (ir.source_index.isValid()) return ir.source_index.get();
+    if (path_to_source_index_map) |map| {
+        if (map.getPath(&ir.path)) |idx| return idx;
+    }
+    if (specifier_fallback) |fb| {
+        if (ir.original_path.len > 0) {
+            if (fb.get(ir.original_path)) |idx| return idx;
+        }
+        // Dead records may also have path.text == original specifier
+        return fb.get(ir.path.text);
+    }
+    return null;
+}
+
 /// After a new file's import records are patched with source_indices,
 /// record what this file requests from each target in requested_exports
 /// (eagerly, before barrels are known), then BFS through barrel chains
@@ -262,6 +313,21 @@ pub fn scheduleBarrelDeferredImports(this: *BundleV2, result: *ParseTask.Result.
     else
         null;
 
+    // In dev server mode, ConvertESMExportsForHmr deduplicates import records
+    // by path — dead records retain the unresolved module specifier. Build a
+    // fallback map from original specifier → target source_index so that
+    // named_imports pointing to dead records can still seed correctly.
+    var specifier_to_target_stack = std.heap.stackFallback(1024, this.allocator());
+    const specifier_to_target_alloc = specifier_to_target_stack.get();
+    var specifier_to_target: bun.StringArrayHashMapUnmanaged(u32) = if (path_to_source_index_map) |map|
+        buildSpecifierToTargetMap(file_import_records, map, specifier_to_target_alloc)
+    else
+        .{};
+    defer specifier_to_target.deinit(specifier_to_target_alloc);
+
+    const specifier_fallback: ?*const bun.StringArrayHashMapUnmanaged(u32) =
+        if (specifier_to_target.count() > 0) &specifier_to_target else null;
+
     var ni_iter = result.ast.named_imports.iterator();
     while (ni_iter.next()) |ni_entry| {
         const ni = ni_entry.value_ptr;
@@ -272,12 +338,7 @@ pub fn scheduleBarrelDeferredImports(this: *BundleV2, result: *ParseTask.Result.
         // path map as a read-only fallback. Do NOT write back to the import
         // record — the dev server intentionally leaves source_indices unset
         // and other code (IncrementalGraph, printer) depends on that.
-        const target = if (ir.source_index.isValid())
-            ir.source_index.get()
-        else if (path_to_source_index_map) |map|
-            map.getPath(&ir.path) orelse continue
-        else
-            continue;
+        const target = resolveImportTarget(ir, path_to_source_index_map, specifier_fallback) orelse continue;
 
         const gop = try this.requested_exports.getOrPut(this.allocator(), target);
         if (ni.alias_is_star) {
@@ -294,7 +355,17 @@ pub fn scheduleBarrelDeferredImports(this: *BundleV2, result: *ParseTask.Result.
             }
             // Persist the export request on DevServer so it survives across builds.
             if (this.transpiler.options.dev_server) |dev| {
-                persistBarrelExport(dev, ir.path.text, alias);
+                // For dead HMR-dedup'd records, ir.path.text may be the unresolved
+                // specifier. Use the resolved path from the graph for persistence.
+                const persist_path = if (path_to_source_index_map) |map| blk: {
+                    // Try to get the resolved path from the graph source.
+                    if (map.getPath(&ir.path)) |_| break :blk ir.path.text;
+                    // Dead record — use the resolved path from the target's source entry.
+                    if (target < this.graph.input_files.len)
+                        break :blk this.graph.input_files.items(.source)[target].path.text;
+                    break :blk ir.path.text;
+                } else ir.path.text;
+                persistBarrelExport(dev, persist_path, alias);
             }
         } else if (!gop.found_existing) {
             gop.value_ptr.* = .{ .partial = .{} };
@@ -308,12 +379,7 @@ pub fn scheduleBarrelDeferredImports(this: *BundleV2, result: *ParseTask.Result.
     //   can destructure or access any export. Must mark as .all. We cannot
     //   safely assume which exports will be used.
     for (file_import_records.slice(), 0..) |ir, idx| {
-        const target = if (ir.source_index.isValid())
-            ir.source_index.get()
-        else if (path_to_source_index_map) |map|
-            map.getPath(&ir.path) orelse continue
-        else
-            continue;
+        const target = resolveImportTarget(ir, path_to_source_index_map, specifier_fallback) orelse continue;
         if (ir.flags.is_internal) continue;
         if (named_ir_indices.contains(@intCast(idx))) continue;
         if (ir.flags.was_originally_bare_import) continue;
@@ -341,12 +407,7 @@ pub fn scheduleBarrelDeferredImports(this: *BundleV2, result: *ParseTask.Result.
         const ni = ni_entry.value_ptr;
         if (ni.import_record_index >= file_import_records.len) continue;
         const ir = file_import_records.slice()[ni.import_record_index];
-        const ir_target = if (ir.source_index.isValid())
-            ir.source_index.get()
-        else if (path_to_source_index_map) |map|
-            map.getPath(&ir.path) orelse continue
-        else
-            continue;
+        const ir_target = resolveImportTarget(ir, path_to_source_index_map, specifier_fallback) orelse continue;
 
         if (ni.alias_is_star) {
             try queue.append(queue_alloc, .{ .barrel_source_index = ir_target, .alias = "", .is_star = true });
@@ -358,12 +419,7 @@ pub fn scheduleBarrelDeferredImports(this: *BundleV2, result: *ParseTask.Result.
     // Add bare require/dynamic-import targets to BFS as star imports — both
     // always need the full namespace.
     for (file_import_records.slice(), 0..) |ir, idx| {
-        const target = if (ir.source_index.isValid())
-            ir.source_index.get()
-        else if (path_to_source_index_map) |map|
-            map.getPath(&ir.path) orelse continue
-        else
-            continue;
+        const target = resolveImportTarget(ir, path_to_source_index_map, specifier_fallback) orelse continue;
         if (ir.flags.is_internal) continue;
         if (named_ir_indices.contains(@intCast(idx))) continue;
         if (ir.flags.was_originally_bare_import) continue;
@@ -529,3 +585,4 @@ const Output = bun.Output;
 
 const Index = bun.ast.Index;
 const JSAst = bun.ast.BundledAst;
+const PathToSourceIndexMap = @import("./PathToSourceIndexMap.zig");

--- a/src/bundler/barrel_imports.zig
+++ b/src/bundler/barrel_imports.zig
@@ -575,6 +575,7 @@ fn persistBarrelExport(dev: *bun.bake.DevServer, barrel_path: []const u8, alias:
     }
 }
 
+const PathToSourceIndexMap = @import("./PathToSourceIndexMap.zig");
 const std = @import("std");
 const BundleV2 = @import("./bundle_v2.zig").BundleV2;
 const ParseTask = @import("./ParseTask.zig").ParseTask;
@@ -585,4 +586,3 @@ const Output = bun.Output;
 
 const Index = bun.ast.Index;
 const JSAst = bun.ast.BundledAst;
-const PathToSourceIndexMap = @import("./PathToSourceIndexMap.zig");

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -613,6 +613,189 @@ devTest("barrel optimization: export star target not deferred (#27521)", {
   },
 });
 
+devTest("barrel optimization: import+export barrel with deferred sub-modules (#28235)", {
+  files: {
+    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
+    // The user code imports from consumer-lib which imports from barrel-lib.
+    // consumer-lib uses Provider (a component from a sub-module of barrel-lib)
+    // that the barrel optimizer defers because it's not requested by the user code.
+    "index.ts": `
+      import { render } from 'consumer-lib';
+      console.log('result: ' + render());
+    `,
+    // consumer-lib imports Provider and createClient from barrel-lib.
+    // This mirrors @refinedev/core importing QueryClientProvider from @tanstack/react-query.
+    // The key: consumer-lib imports Provider which comes from barrel-lib's own
+    // sub-module (./Provider.js), NOT from the export * chain.
+    "node_modules/consumer-lib/package.json": JSON.stringify({
+      name: "consumer-lib",
+      version: "1.0.0",
+      main: "./index.js",
+    }),
+    "node_modules/consumer-lib/index.js": `
+      import { Provider, createClient } from 'barrel-lib';
+      export function render() {
+        const client = createClient();
+        if (typeof Provider !== 'function') return 'FAIL:Provider=' + typeof Provider;
+        if (typeof client !== 'object') return 'FAIL:client=' + typeof client;
+        return 'PASS';
+      }
+    `,
+    // barrel-lib mirrors @tanstack/react-query: sideEffects:false, uses
+    // "import { X } from './sub.js'; export { X }" pattern (not "export from").
+    // Also has export * from a core lib (like query-core).
+    // Has many sub-modules to trigger barrel optimization thresholds.
+    "node_modules/barrel-lib/package.json": JSON.stringify({
+      name: "barrel-lib",
+      version: "1.0.0",
+      main: "./index.js",
+      sideEffects: false,
+    }),
+    "node_modules/barrel-lib/index.js": `
+      export * from 'core-lib';
+      export * from './types.js';
+      import { Provider } from './Provider.js';
+      import { useHookA } from './useHookA.js';
+      import { useHookB } from './useHookB.js';
+      import { useHookC } from './useHookC.js';
+      import { useHookD } from './useHookD.js';
+      import { useHookE } from './useHookE.js';
+      import { Boundary } from './Boundary.js';
+      import { ErrorReset } from './ErrorReset.js';
+      import { Fetching } from './Fetching.js';
+      import { Mutation } from './Mutation.js';
+      import { Restoring } from './Restoring.js';
+      export {
+        Provider, useHookA, useHookB, useHookC, useHookD, useHookE,
+        Boundary, ErrorReset, Fetching, Mutation, Restoring
+      };
+    `,
+    "node_modules/barrel-lib/types.js": `export const TypeA = "a";`,
+    "node_modules/barrel-lib/Provider.js": `export function Provider(props) { return props.children; }`,
+    "node_modules/barrel-lib/useHookA.js": `export function useHookA() { return null; }`,
+    "node_modules/barrel-lib/useHookB.js": `export function useHookB() { return null; }`,
+    "node_modules/barrel-lib/useHookC.js": `export function useHookC() { return null; }`,
+    "node_modules/barrel-lib/useHookD.js": `export function useHookD() { return null; }`,
+    "node_modules/barrel-lib/useHookE.js": `export function useHookE() { return null; }`,
+    "node_modules/barrel-lib/Boundary.js": `export function Boundary() { return null; }`,
+    "node_modules/barrel-lib/ErrorReset.js": `export function ErrorReset() { return null; }`,
+    "node_modules/barrel-lib/Fetching.js": `export function Fetching() { return null; }`,
+    "node_modules/barrel-lib/Mutation.js": `export function Mutation() { return null; }`,
+    "node_modules/barrel-lib/Restoring.js": `export function Restoring() { return null; }`,
+    // core-lib provides createClient via export *. Since it's an export star
+    // target, it should not be deferred (fixed in #27524).
+    "node_modules/core-lib/package.json": JSON.stringify({
+      name: "core-lib",
+      version: "1.0.0",
+      main: "./index.js",
+      sideEffects: false,
+    }),
+    "node_modules/core-lib/index.js": `
+      export { createClient } from './client.js';
+      export { Other } from './other.js';
+    `,
+    "node_modules/core-lib/client.js": `
+      export function createClient() { return { ready: true }; }
+    `,
+    "node_modules/core-lib/other.js": `export const Other = "OTHER";`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("result: PASS");
+  },
+});
+
+devTest("barrel optimization: multiple import statements from same barrel dedup'd (#28235)", {
+  files: {
+    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
+    // User code imports from consumer-lib which has multiple import statements
+    // from the same barrel package. ConvertESMExportsForHmr deduplicates these
+    // into one surviving record; the dead records retain unresolved paths.
+    // Without the fix, only exports from the first import statement are seeded
+    // into requested_exports — all others are deferred and become undefined.
+    "index.ts": `
+      import { render } from 'consumer-lib';
+      console.log('result: ' + render());
+    `,
+    // consumer-lib mirrors @refinedev/core: multiple separate import statements
+    // from the same barrel package. Each import statement creates a separate
+    // import record. ConvertESMExportsForHmr merges them, but named_imports
+    // entries still point to the original (now dead) records.
+    "node_modules/consumer-lib/package.json": JSON.stringify({
+      name: "consumer-lib",
+      version: "1.0.0",
+      main: "./index.js",
+    }),
+    "node_modules/consumer-lib/index.js": `
+      import { useHookA } from 'barrel-lib';
+      import { Provider } from 'barrel-lib';
+      import { useHookB } from 'barrel-lib';
+      export function render() {
+        if (typeof useHookA !== 'function') return 'FAIL:useHookA=' + typeof useHookA;
+        if (typeof Provider !== 'function') return 'FAIL:Provider=' + typeof Provider;
+        if (typeof useHookB !== 'function') return 'FAIL:useHookB=' + typeof useHookB;
+        return 'PASS';
+      }
+    `,
+    // barrel-lib mirrors @tanstack/react-query: sideEffects:false, many sub-modules.
+    "node_modules/barrel-lib/package.json": JSON.stringify({
+      name: "barrel-lib",
+      version: "1.0.0",
+      main: "./index.js",
+      sideEffects: false,
+    }),
+    "node_modules/barrel-lib/index.js": `
+      export * from 'core-lib';
+      export * from './types.js';
+      import { Provider } from './Provider.js';
+      import { useHookA } from './useHookA.js';
+      import { useHookB } from './useHookB.js';
+      import { useHookC } from './useHookC.js';
+      import { useHookD } from './useHookD.js';
+      import { useHookE } from './useHookE.js';
+      import { Boundary } from './Boundary.js';
+      import { ErrorReset } from './ErrorReset.js';
+      import { Fetching } from './Fetching.js';
+      import { Mutation } from './Mutation.js';
+      import { Restoring } from './Restoring.js';
+      export {
+        Provider, useHookA, useHookB, useHookC, useHookD, useHookE,
+        Boundary, ErrorReset, Fetching, Mutation, Restoring
+      };
+    `,
+    "node_modules/barrel-lib/types.js": `export const TypeA = "a";`,
+    "node_modules/barrel-lib/Provider.js": `export function Provider(props) { return props.children; }`,
+    "node_modules/barrel-lib/useHookA.js": `export function useHookA() { return null; }`,
+    "node_modules/barrel-lib/useHookB.js": `export function useHookB() { return null; }`,
+    "node_modules/barrel-lib/useHookC.js": `export function useHookC() { return null; }`,
+    "node_modules/barrel-lib/useHookD.js": `export function useHookD() { return null; }`,
+    "node_modules/barrel-lib/useHookE.js": `export function useHookE() { return null; }`,
+    "node_modules/barrel-lib/Boundary.js": `export function Boundary() { return null; }`,
+    "node_modules/barrel-lib/ErrorReset.js": `export function ErrorReset() { return null; }`,
+    "node_modules/barrel-lib/Fetching.js": `export function Fetching() { return null; }`,
+    "node_modules/barrel-lib/Mutation.js": `export function Mutation() { return null; }`,
+    "node_modules/barrel-lib/Restoring.js": `export function Restoring() { return null; }`,
+    "node_modules/core-lib/package.json": JSON.stringify({
+      name: "core-lib",
+      version: "1.0.0",
+      main: "./index.js",
+      sideEffects: false,
+    }),
+    "node_modules/core-lib/index.js": `
+      export { createClient } from './client.js';
+      export { Other } from './other.js';
+    `,
+    "node_modules/core-lib/client.js": `
+      export function createClient() { return { ready: true }; }
+    `,
+    "node_modules/core-lib/other.js": `export const Other = "OTHER";`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("result: PASS");
+  },
+});
+
 devTest("barrel optimization: two export-from blocks pointing to the same source", {
   files: {
     "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),


### PR DESCRIPTION
## Summary

Fixes #28235

In dev server mode, `ConvertESMExportsForHmr` deduplicates import records by path — when a file like `@refinedev/core` has multiple `import {...} from "@tanstack/react-query"` statements, only the first record survives (gets its path resolved) while duplicates are marked `is_unused` with their paths left as the bare module specifier.

`resolveImportRecords` skips `is_unused` records, so dead records never get their paths resolved. When `scheduleBarrelDeferredImports` iterates `named_imports`, entries pointing to dead records fail the `pathToSourceIndexMap` lookup because they use the unresolved specifier (e.g. `"@tanstack/react-query"`) instead of the resolved absolute path. This causes most export requests to be lost — only exports from the first import statement are seeded into `requested_exports`.

When the barrel file (`@tanstack/react-query`) is later optimized via `applyBarrelOptimization`, it sees very few requested exports and defers most sub-module imports. The deferred imports become empty objects (`{}`) in the bundle output, causing `QueryClientProvider` and other components to be `undefined` at runtime.

- Build a fallback map from `original_path` (the unresolved module specifier) → resolved target `source_index` using the surviving import records that DID get their paths resolved
- Use this map as a fallback in `resolveImportTarget()` when the primary path map lookup fails for dead/dedup'd records
- Also fix `persistBarrelExport` to use the resolved path from the graph instead of the dead record's unresolved specifier

## Test plan

- [x] Added regression test: "barrel optimization: multiple import statements from same barrel dedup'd (#28235)" — consumer-lib with multiple separate import statements from barrel-lib
- [x] All 19 dev server bundle tests pass (`test/bake/dev/bundle.test.ts`)
- [x] All 48 bundler barrel tests pass (`test/bundler/bundler_barrel.test.ts`)
- [x] Verified with real @refinedev/core + @tanstack/react-query reproduction: `QueryClientProvider` is no longer `undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)