### PR TITLE
fix: prevent segfault in MessagePort.postMessage when context is destroyed

### DIFF
--- a/src/bun.js/bindings/webcore/MessagePort.cpp
+++ b/src/bun.js/bindings/webcore/MessagePort.cpp
@@ -183,7 +183,11 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
 
     MessageWithMessagePorts message { messageData.releaseReturnValue(), WTF::move(transferredPorts) };
 
-    MessagePortChannelProvider::fromContext(*protectedScriptExecutionContext()).postMessageToRemote(WTF::move(message), m_remoteIdentifier);
+    auto protectedContext = protectedScriptExecutionContext();
+    if (!protectedContext)
+        return {};
+
+    MessagePortChannelProvider::fromContext(*protectedContext).postMessageToRemote(WTF::move(message), m_remoteIdentifier);
     return {};
 }
 

--- a/test/regression/issue/22471.test.ts
+++ b/test/regression/issue/22471.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // Regression test for https://github.com/oven-sh/bun/issues/22471

--- a/test/regression/issue/22471.test.ts
+++ b/test/regression/issue/22471.test.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/22471
+// Segfault in MessagePort.postMessage when ScriptExecutionContext is destroyed
+// during high-frequency message passing between workers.
+test("MessagePort.postMessage does not crash after worker termination", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const { Worker, MessageChannel } = require("worker_threads");
+
+const workers = [];
+const ports = [];
+
+for (let i = 0; i < 10; i++) {
+  const { port1, port2 } = new MessageChannel();
+  const worker = new Worker(
+    'const { parentPort } = require("worker_threads");' +
+    'parentPort.on("message", ({ port }) => {' +
+    '  if (port) {' +
+    '    port.on("message", () => {});' +
+    '    for (let j = 0; j < 50; j++) try { port.postMessage({ j }); } catch(e) {}' +
+    '  }' +
+    '});',
+    { eval: true }
+  );
+
+  worker.postMessage({ port: port2 }, [port2]);
+  workers.push(worker);
+  ports.push(port1);
+
+  for (let j = 0; j < 50; j++) {
+    try { port1.postMessage({ j }); } catch(e) {}
+  }
+}
+
+// Terminate all workers without awaiting
+for (const w of workers) w.terminate();
+
+// Post messages after termination has been initiated
+for (const p of ports) {
+  try { p.postMessage({ afterTerminate: true }); } catch(e) {}
+  p.close();
+}
+
+console.log("SUCCESS");
+setTimeout(() => process.exit(0), 500);
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("SUCCESS");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Add null check for `protectedScriptExecutionContext()` in `MessagePort::postMessage` to prevent segfault when the `ScriptExecutionContext` has been destroyed
- Add regression test that exercises the postMessage-after-worker-termination code path

## Root Cause

`protectedScriptExecutionContext()` returns a `RefPtr<ScriptExecutionContext>` from a `WeakPtr`. When the context is destroyed (e.g., during worker termination with high-frequency message passing), this returns null. The code at line 186 dereferenced it with `*` without a null check, causing a segfault at address `0x00000018` (null pointer + member offset).

This follows the same null-check pattern already used elsewhere in the same file (`messageAvailable()`, `dispatchMessages()`, `hasPendingActivity()`).

This fix was previously applied in c7af3289d5 (#23194) but was lost when subsequent WebKit upgrades overwrote `MessagePort.cpp`.

Fixes #22471

## Test plan

- [x] `bun bd test test/regression/issue/22471.test.ts` passes
- [x] `bun bd test test/js/web/workers/message-channel.test.ts` passes (12/12)
- [x] Existing worker_threads tests unaffected (4 pre-existing failures in debug build, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)