### PR TITLE
fix(allocator): use non-zero heap tag for MimallocArena to prevent heap corruption

### DIFF
--- a/src/allocators/MimallocArena.zig
+++ b/src/allocators/MimallocArena.zig
@@ -165,8 +165,16 @@ pub fn deinit(self: *Self) void {
     self.* = undefined;
 }
 
+/// Heap tag for MimallocArena heaps — must be non-zero to avoid colliding
+/// with the default backing-heap tag (0). Without this, `_mi_heap_by_tag`
+/// in mimalloc's segment reclaim path can route abandoned pages from dead
+/// threads' backing heaps into a MimallocArena heap. When that arena is
+/// later destroyed via `mi_heap_destroy`, the reclaimed pages (which may
+/// still contain live blocks) are freed, corrupting the heap.
+const arena_heap_tag: c_int = 1;
+
 pub fn init() Self {
-    const mimalloc_heap = mimalloc.mi_heap_new() orelse bun.outOfMemory();
+    const mimalloc_heap = mimalloc.mi_heap_new_ex(arena_heap_tag, true, null) orelse bun.outOfMemory();
     if (comptime !safety_checks) return .{ .#heap = mimalloc_heap };
     const heap: Owned(*DebugHeap) = .new(.{
         .inner = mimalloc_heap,

--- a/test/regression/issue/21675.test.ts
+++ b/test/regression/issue/21675.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Regression test for #21675: Segfault in readdirSync during concurrent operations.
+// The crash was caused by MimallocArena using mi_heap_new() with tag 0 (same as the
+// backing heap), causing mimalloc to misroute abandoned pages from dead threads into
+// arena heaps. When those arenas were destroyed, live blocks were freed, corrupting
+// the heap and causing segfaults during subsequent allocations (e.g. in readdirSync).
+test("concurrent readdirSync from worker threads does not crash", async () => {
+  using dir = tempDir("issue-21675", {
+    "worker.js": `
+      const { Worker, isMainThread, parentPort, workerData } = require("worker_threads");
+      const fs = require("fs");
+      const path = require("path");
+
+      if (isMainThread) {
+        const workerCount = 8;
+        let finished = 0;
+        const errors = [];
+
+        for (let i = 0; i < workerCount; i++) {
+          const worker = new Worker(__filename);
+          worker.on("message", (msg) => {
+            if (msg.error) errors.push(msg.error);
+          });
+          worker.on("exit", () => {
+            finished++;
+            if (finished === workerCount) {
+              if (errors.length > 0) {
+                console.error("Errors:", errors);
+                process.exit(1);
+              }
+              console.log("OK");
+              process.exit(0);
+            }
+          });
+        }
+      } else {
+        try {
+          for (let i = 0; i < 100; i++) {
+            fs.readdirSync(process.cwd(), { withFileTypes: true });
+          }
+          parentPort.postMessage({ done: true });
+        } catch (e) {
+          parentPort.postMessage({ error: e.message });
+        }
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "worker.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+}, 30_000);

--- a/test/regression/issue/21675.test.ts
+++ b/test/regression/issue/21675.test.ts
@@ -23,7 +23,11 @@ test("concurrent readdirSync from worker threads does not crash", async () => {
           worker.on("message", (msg) => {
             if (msg.error) errors.push(msg.error);
           });
-          worker.on("exit", () => {
+          worker.on("error", (err) => {
+            errors.push(err && err.message || String(err));
+          });
+          worker.on("exit", (code) => {
+            if (code !== 0) errors.push("worker exit code " + code);
             finished++;
             if (finished === workerCount) {
               if (errors.length > 0) {
@@ -63,5 +67,6 @@ test("concurrent readdirSync from worker threads does not crash", async () => {
   ]);
 
   expect(stdout.trim()).toBe("OK");
+  expect(stderr.trim()).toBe("");
   expect(exitCode).toBe(0);
 }, 30_000);


### PR DESCRIPTION
## Summary
- Fix heap corruption crash caused by `MimallocArena` using `mi_heap_new()` with the default tag 0, which collides with the backing heap tag
- Use `mi_heap_new_ex(1, true, null)` with a non-zero heap tag so arena heaps are never confused with backing heaps during mimalloc's segment reclamation

## Root Cause
When concurrent threads exit, mimalloc's `_mi_heap_by_tag` routes abandoned pages to the first heap with a matching tag. Since `MimallocArena` heaps had tag 0 (same as the backing heap), abandoned pages from dead threads could be misrouted into an arena heap. When that arena was later destroyed via `mi_heap_destroy`, the reclaimed pages — still containing live blocks from other threads — were freed, corrupting the heap.

This manifested as segfaults in `readdirSync` when running multiple prettier instances concurrently via lint-staged (`RunAsNodeCommand` mode). The segfault address `0x6F0070006D0069` decoded to UTF-16 "impo" (part of "import"), confirming string data was being interpreted as a pointer due to heap corruption.

Closes #21675

## Test plan
- [x] Added `test/regression/issue/21675.test.ts` — spawns 8 worker threads each doing 100 `readdirSync` calls concurrently
- [x] Test passes with `bun bd test test/regression/issue/21675.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)