### PR TITLE
fix(server): prevent segfault when server JS wrapper is finalized during request handling

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -631,9 +631,11 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             return globalThis.throw2("Server() is not a constructor", .{});
         }
 
-        pub fn jsValueAssertAlive(server: *ThisServer) jsc.JSValue {
-            bun.assert(server.js_value.isNotEmpty());
-            return server.js_value.tryGet().?;
+        /// Returns the server's JS wrapper value, or null if it has been
+        /// finalized (e.g. after stop() + GC).  Callers that originate from
+        /// uWS callbacks must handle the null case gracefully (e.g. 503).
+        pub fn tryGetJSValue(server: *ThisServer) ?jsc.JSValue {
+            return server.js_value.tryGet();
         }
 
         pub fn requestIP(this: *ThisServer, request: *jsc.WebCore.Request) bun.JSError!jsc.JSValue {
@@ -1249,9 +1251,12 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             var request = Request.new(existing_request);
 
             bun.assert(this.config.onRequest != .zero); // confirmed above
+            const server_js = this.tryGetJSValue() orelse {
+                return JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(ctx, ZigString.init("Server is shutting down").toErrorInstance(ctx));
+            };
             const response_value = this.config.onRequest.call(
                 this.globalThis,
-                this.jsValueAssertAlive(),
+                server_js,
                 &[_]jsc.JSValue{request.toJS(this.globalThis)},
             ) catch |err| this.globalThis.takeException(err);
 
@@ -2047,14 +2052,20 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             const server = user_route.server;
             const index = user_route.id;
 
+            const server_js = server.tryGetJSValue() orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
+
             var should_deinit_context = false;
             var prepared = server.prepareJsRequestContext(req, resp, &should_deinit_context, .no, switch (user_route.route.method) {
                 .any => null,
                 .specific => |m| m,
             }) orelse return;
 
-            const server_request_list = js.routeListGetCached(server.jsValueAssertAlive()).?;
-            const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server.jsValueAssertAlive(), server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
+            const server_request_list = js.routeListGetCached(server_js).?;
+            const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server_js, server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
 
             server.handleRequest(&should_deinit_context, prepared, req, response_value);
         }
@@ -2089,16 +2100,21 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
         }
 
         pub fn onRequest(this: *ThisServer, req: *uws.Request, resp: *App.Response) void {
+            const server_js = this.tryGetJSValue() orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
+
             var should_deinit_context = false;
             const prepared = this.prepareJsRequestContext(req, resp, &should_deinit_context, .yes, null) orelse return;
 
             bun.assert(this.config.onRequest != .zero);
 
-            const js_value = this.jsValueAssertAlive();
             const response_value = this.config.onRequest.call(
                 this.globalThis,
-                js_value,
-                &.{ prepared.js_request, js_value },
+                server_js,
+                &.{ prepared.js_request, server_js },
             ) catch |err|
                 this.globalThis.takeException(err);
 
@@ -2124,10 +2140,16 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             const ctx = prepared.ctx;
 
             bun.assert(callback != .zero);
+            const server_js = this.tryGetJSValue() orelse {
+                // Server JS wrapper was finalized; reject with 503.
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
             const args = .{prepared.js_request} ++ extra_args;
             const response_value = callback.call(
                 this.globalThis,
-                this.jsValueAssertAlive(),
+                server_js,
                 &args,
             ) catch |err|
                 this.globalThis.takeException(err);
@@ -2318,11 +2340,17 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             const server = this.server;
             const index = this.id;
 
+            const server_js = server.tryGetJSValue() orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
+
             var should_deinit_context = false;
             var prepared = server.prepareJsRequestContext(req, resp, &should_deinit_context, .no, method) orelse return;
             prepared.ctx.upgrade_context = upgrade_ctx; // set the upgrade context
-            const server_request_list = js.routeListGetCached(server.jsValueAssertAlive()).?;
-            const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server.jsValueAssertAlive(), server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
+            const server_request_list = js.routeListGetCached(server_js).?;
+            const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server_js, server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
 
             server.handleRequest(&should_deinit_context, prepared, req, response_value);
         }
@@ -2347,6 +2375,11 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 resp.endWithoutBody(true);
                 return;
             }
+            const server_js = this.tryGetJSValue() orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
             this.pending_requests += 1;
             req.setYield(false);
             var ctx = bun.handleOom(this.request_pool_allocator.tryGet());
@@ -2370,12 +2403,12 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             // We keep the Request object alive for the duration of the request so that we can remove the pointer to the UWS request object.
             var args = [_]jsc.JSValue{
                 request_object.toJS(this.globalThis),
-                this.jsValueAssertAlive(),
+                server_js,
             };
             const request_value = args[0];
             request_value.ensureStillAlive();
 
-            const response_value = this.config.onRequest.call(this.globalThis, this.jsValueAssertAlive(), &args) catch |err|
+            const response_value = this.config.onRequest.call(this.globalThis, server_js, &args) catch |err|
                 this.globalThis.takeException(err);
             defer {
                 // uWS request will not live longer than this function

--- a/test/regression/issue/22809.test.ts
+++ b/test/regression/issue/22809.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // Regression test for https://github.com/oven-sh/bun/issues/22809

--- a/test/regression/issue/22809.test.ts
+++ b/test/regression/issue/22809.test.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/22809
+// Segfault when server JS wrapper is finalized but uWS callbacks still fire.
+// After server.stop() downgrades the JS reference, GC can collect the wrapper.
+// Incoming requests must not crash (null pointer deref) but should get 503.
+
+test("server does not segfault when request arrives after stop + GC", async () => {
+  // We run this in a subprocess because a segfault would crash the test runner.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          return new Response("ok");
+        },
+      });
+
+      const url = server.url.href;
+
+      // Verify server works before stop
+      const res1 = await fetch(url);
+      if (res1.status !== 200) {
+        process.exit(10);
+      }
+
+      // Stop the server (downgrades the JS reference to weak)
+      server.stop();
+
+      // Force GC to collect the weak JS wrapper
+      Bun.gc(true);
+      Bun.gc(true);
+
+      // Try to make a request - if the server is still listening, it should
+      // either respond with 503 or refuse the connection, but NOT segfault.
+      try {
+        const res2 = await fetch(url);
+        // If we get here, the server is still listening - check we got 503
+        if (res2.status !== 503 && res2.status !== 200) {
+          process.exit(11);
+        }
+      } catch (e) {
+        // Connection refused is also acceptable - server may have fully stopped
+      }
+
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The important thing: exit code must NOT be a signal (segfault = 11 on Linux)
+  // and must not be our sentinel values
+  if (exitCode !== 0) {
+    console.log("stdout:", stdout);
+    console.log("stderr:", stderr);
+  }
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fix null pointer dereference (segfault at address 0x0) when HTTP requests arrive after `server.stop()` + GC collects the server's JS wrapper
- Replace unsafe `jsValueAssertAlive()` (which used `.?` unwrap — UB when null in release builds) with safe `tryGetJSValue()` returning `?JSValue`
- All 8 call sites now handle the null case gracefully: uWS callbacks return 503, the `fetch()` path returns a rejected promise

## Test plan

- [x] Added regression test in `test/regression/issue/22809.test.ts`
- [x] Existing server stop tests pass (`bun bd test -t "should be able to await server.stop"`, `bun bd test -t "should be able to abruptly stop"`)
- [x] Debug build compiles successfully

Fixes #22809

🤖 Generated with [Claude Code](https://claude.com/claude-code)