### PR TITLE
fix(napi): don't fail napi_create_error when a pending exception exists

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -1070,8 +1070,6 @@ static napi_status createErrorWithNapiValues(napi_env env, napi_value code, napi
 {
     auto* globalObject = toJS(env);
     auto& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    RETURN_IF_EXCEPTION(scope, napi_pending_exception);
 
     NAPI_CHECK_ARG(env, result);
     NAPI_CHECK_ARG(env, message);
@@ -1081,15 +1079,16 @@ static napi_status createErrorWithNapiValues(napi_env env, napi_value code, napi
         js_message.isString() && (js_code.isEmpty() || js_code.isString()),
         napi_string_expected);
 
+    // Do not check for pending exceptions here. This matches Node.js behavior
+    // where napi_create_error and friends only create error values without
+    // checking the VM exception state. The inputs are already validated as
+    // strings above, so getString() won't throw new exceptions.
     auto wtf_code = js_code.isEmpty() ? WTF::String() : js_code.getString(globalObject);
-    RETURN_IF_EXCEPTION(scope, napi_set_last_error(env, napi_pending_exception));
     auto wtf_message = js_message.getString(globalObject);
-    RETURN_IF_EXCEPTION(scope, napi_set_last_error(env, napi_pending_exception));
 
     *result = toNapi(
         createErrorWithCode(vm, globalObject, wtf_code, wtf_message, type),
         globalObject);
-    RETURN_IF_EXCEPTION(scope, napi_set_last_error(env, napi_pending_exception));
     return napi_set_last_error(env, napi_ok);
 }
 

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -1034,6 +1034,72 @@ static napi_value test_deferred_exceptions(const Napi::CallbackInfo &info) {
 
   puts("string retrieval succeeded");
 
+  // napi_create_error should succeed even with a pending exception,
+  // matching Node.js behavior. This is the bug from issue #22259 where
+  // @napi-rs/canvas would crash because napi_create_error returned an
+  // error status when called with a pending exception, causing napi-rs
+  // to call napi_fatal_error.
+  do_throw();
+
+  napi_value error_msg;
+  status = napi_create_string_utf8(env, "test error", NAPI_AUTO_LENGTH, &error_msg);
+
+  if (status != napi_ok) {
+    printf("napi_create_string_utf8 (for error) failed: %d\n", status);
+    return nullptr;
+  }
+
+  napi_value error_code;
+  status = napi_create_string_utf8(env, "ERR_TEST", NAPI_AUTO_LENGTH, &error_code);
+
+  if (status != napi_ok) {
+    printf("napi_create_string_utf8 (for error code) failed: %d\n", status);
+    return nullptr;
+  }
+
+  napi_value error_val;
+  status = napi_create_error(env, error_code, error_msg, &error_val);
+
+  if (status != napi_ok) {
+    printf("napi_create_error failed during pending exception: %d\n", status);
+    return nullptr;
+  }
+
+  napi_value type_error_val;
+  status = napi_create_type_error(env, error_code, error_msg, &type_error_val);
+
+  if (status != napi_ok) {
+    printf("napi_create_type_error failed during pending exception: %d\n", status);
+    return nullptr;
+  }
+
+  napi_value range_error_val;
+  status = napi_create_range_error(env, error_code, error_msg, &range_error_val);
+
+  if (status != napi_ok) {
+    printf("napi_create_range_error failed during pending exception: %d\n", status);
+    return nullptr;
+  }
+
+  puts("napi_create_error functions succeeded during pending exception");
+
+  clear();
+
+  // Verify the created error is a proper object
+  status = napi_typeof(env, error_val, &type);
+
+  if (status != napi_ok) {
+    printf("napi_typeof (error) failed: %d\n", status);
+    return nullptr;
+  }
+
+  if (type != napi_object) {
+    printf("error napi_typeof produced %d, expected object\n", type);
+    return nullptr;
+  }
+
+  puts("napi_create_error produced valid error object");
+
   napi_value function;
 
   expect_failure_during_exception("napi_create_function", [&] {

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -1081,24 +1081,68 @@ static napi_value test_deferred_exceptions(const Napi::CallbackInfo &info) {
     return nullptr;
   }
 
+  napi_value syntax_error_val;
+  status = node_api_create_syntax_error(env, error_code, error_msg, &syntax_error_val);
+
+  if (status != napi_ok) {
+    printf("node_api_create_syntax_error failed during pending exception: %d\n", status);
+    return nullptr;
+  }
+
   puts("napi_create_error functions succeeded during pending exception");
 
   clear();
 
-  // Verify the created error is a proper object
+  // Verify each created error is a proper object
   status = napi_typeof(env, error_val, &type);
 
   if (status != napi_ok) {
-    printf("napi_typeof (error) failed: %d\n", status);
+    printf("napi_typeof (error_val) failed: %d\n", status);
     return nullptr;
   }
 
   if (type != napi_object) {
-    printf("error napi_typeof produced %d, expected object\n", type);
+    printf("error_val napi_typeof produced %d, expected object\n", type);
     return nullptr;
   }
 
-  puts("napi_create_error produced valid error object");
+  status = napi_typeof(env, type_error_val, &type);
+
+  if (status != napi_ok) {
+    printf("napi_typeof (type_error_val) failed: %d\n", status);
+    return nullptr;
+  }
+
+  if (type != napi_object) {
+    printf("type_error_val napi_typeof produced %d, expected object\n", type);
+    return nullptr;
+  }
+
+  status = napi_typeof(env, range_error_val, &type);
+
+  if (status != napi_ok) {
+    printf("napi_typeof (range_error_val) failed: %d\n", status);
+    return nullptr;
+  }
+
+  if (type != napi_object) {
+    printf("range_error_val napi_typeof produced %d, expected object\n", type);
+    return nullptr;
+  }
+
+  status = napi_typeof(env, syntax_error_val, &type);
+
+  if (status != napi_ok) {
+    printf("napi_typeof (syntax_error_val) failed: %d\n", status);
+    return nullptr;
+  }
+
+  if (type != napi_object) {
+    printf("syntax_error_val napi_typeof produced %d, expected object\n", type);
+    return nullptr;
+  }
+
+  puts("napi_create_error produced valid error objects");
 
   napi_value function;
 


### PR DESCRIPTION
## Summary

- Remove ThrowScope and RETURN_IF_EXCEPTION checks from `createErrorWithNapiValues`, which caused `napi_create_error` (and `napi_create_type_error`, `napi_create_range_error`, `node_api_create_syntax_error`) to return `napi_pending_exception` when called while a JavaScript exception was already pending on the VM
- This matches Node.js behavior where error creation functions never check for pending exceptions
- Add test in `test_deferred_exceptions` verifying all error creation functions succeed with pending exceptions

## Root Cause

`createErrorWithNapiValues` in `napi.cpp` used a `DECLARE_THROW_SCOPE` + `RETURN_IF_EXCEPTION` that would bail out when a pre-existing exception existed on the VM. Node.js's `napi_create_error` ([js_native_api_v8.cc:1920](https://github.com/nodejs/node/blob/main/src/js_native_api_v8.cc#L1920)) only uses `CHECK_ENV_NOT_IN_GC` without any exception check.

When NAPI modules like `@napi-rs/canvas` encountered errors (e.g. ENOSPC) and tried to create error objects to report them, the pending exception from the prior failure caused `napi_create_error` to fail, triggering `napi_fatal_error` and a process crash.

## Test plan

- [x] `bun bd test test/napi/napi.test.ts -t "behaves as expected when performing operations with an exception pending"` passes
- [x] `bun bd test test/napi/napi.test.ts -t "has the right code and message"` passes (exhaustive error creation test)
- [x] Output matches Node.js for the deferred exceptions test

Closes #22259

🤖 Generated with [Claude Code](https://claude.com/claude-code)