### PR TITLE
fix(zlib): prevent use-after-free in WorkPool compression operations

### DIFF
--- a/src/bun.js/node/node_zlib_binding.zig
+++ b/src/bun.js/node/node_zlib_binding.zig
@@ -117,6 +117,14 @@ pub fn CompressionStream(comptime T: type) type {
             // And make sure to clear it when we are done.
             this.this_value.set(globalThis, this_value);
 
+            // Hold strong references to the input/output buffers to prevent
+            // GC from collecting them while the WorkPool thread is using the
+            // underlying memory.
+            if (!arguments[1].isNull()) {
+                this.in_buf_value.set(globalThis, arguments[1]);
+            }
+            this.out_buf_value.set(globalThis, arguments[4]);
+
             const vm = globalThis.bunVM();
             this.task = .{ .callback = &AsyncJob.runTask };
             this.poll_ref.ref(vm);
@@ -148,6 +156,11 @@ pub fn CompressionStream(comptime T: type) type {
             defer this.poll_ref.unref(vm);
 
             this.write_in_progress = false;
+
+            // Release the strong references to the input/output buffers now
+            // that the WorkPool thread is done using them.
+            this.in_buf_value.deinit();
+            this.out_buf_value.deinit();
 
             // Clear the strong handle before we call any callbacks.
             const this_value = this.this_value.trySwap() orelse {
@@ -267,6 +280,8 @@ pub fn CompressionStream(comptime T: type) type {
             this.pending_close = false;
             this.closed = true;
             this.this_value.deinit();
+            this.in_buf_value.deinit();
+            this.out_buf_value.deinit();
             this.stream.close();
         }
 

--- a/src/bun.js/node/zlib/NativeBrotli.zig
+++ b/src/bun.js/node/zlib/NativeBrotli.zig
@@ -23,6 +23,9 @@ stream: Context = .{},
 write_result: ?[*]u32 = null,
 poll_ref: CountedKeepAlive = .{},
 this_value: jsc.Strong.Optional = .empty,
+/// Strong references to input/output buffers to prevent GC during async WorkPool operations.
+in_buf_value: jsc.Strong.Optional = .empty,
+out_buf_value: jsc.Strong.Optional = .empty,
 write_in_progress: bool = false,
 pending_close: bool = false,
 closed: bool = false,
@@ -110,6 +113,8 @@ pub fn params(this: *@This(), globalThis: *jsc.JSGlobalObject, callframe: *jsc.C
 
 fn deinit(this: *@This()) void {
     this.this_value.deinit();
+    this.in_buf_value.deinit();
+    this.out_buf_value.deinit();
     this.poll_ref.deinit();
     switch (this.stream.mode) {
         .BROTLI_ENCODE, .BROTLI_DECODE => this.stream.close(),

--- a/src/bun.js/node/zlib/NativeZlib.zig
+++ b/src/bun.js/node/zlib/NativeZlib.zig
@@ -23,6 +23,9 @@ stream: Context = .{},
 write_result: ?[*]u32 = null,
 poll_ref: CountedKeepAlive = .{},
 this_value: jsc.Strong.Optional = .empty,
+/// Strong references to input/output buffers to prevent GC during async WorkPool operations.
+in_buf_value: jsc.Strong.Optional = .empty,
+out_buf_value: jsc.Strong.Optional = .empty,
 write_in_progress: bool = false,
 pending_close: bool = false,
 closed: bool = false,
@@ -107,6 +110,8 @@ pub fn params(this: *@This(), globalThis: *jsc.JSGlobalObject, callframe: *jsc.C
 
 fn deinit(this: *@This()) void {
     this.this_value.deinit();
+    this.in_buf_value.deinit();
+    this.out_buf_value.deinit();
     this.poll_ref.deinit();
     this.stream.close();
     bun.destroy(this);

--- a/src/bun.js/node/zlib/NativeZstd.zig
+++ b/src/bun.js/node/zlib/NativeZstd.zig
@@ -23,6 +23,9 @@ stream: Context = .{},
 write_result: ?[*]u32 = null,
 poll_ref: CountedKeepAlive = .{},
 this_value: jsc.Strong.Optional = .empty,
+/// Strong references to input/output buffers to prevent GC during async WorkPool operations.
+in_buf_value: jsc.Strong.Optional = .empty,
+out_buf_value: jsc.Strong.Optional = .empty,
 write_in_progress: bool = false,
 pending_close: bool = false,
 closed: bool = false,
@@ -111,6 +114,9 @@ pub fn params(this: *@This(), globalThis: *jsc.JSGlobalObject, callframe: *jsc.C
 }
 
 fn deinit(this: *@This()) void {
+    this.this_value.deinit();
+    this.in_buf_value.deinit();
+    this.out_buf_value.deinit();
     this.poll_ref.deinit();
     switch (this.stream.mode) {
         .ZSTD_COMPRESS, .ZSTD_DECOMPRESS => this.stream.close(),

--- a/test/regression/issue/22567.test.ts
+++ b/test/regression/issue/22567.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Test that piping HTTP responses through zlib.createGunzip() does not crash.
+// Issue #22567: use-after-free when GC collects input/output buffers during
+// async WorkPool decompression.
+test("pipe HTTP response through createGunzip without crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const http = require("node:http");
+const zlib = require("node:zlib");
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { "Content-Type": "application/octet-stream" });
+  const gzip = zlib.createGzip();
+  gzip.pipe(res);
+  for (let i = 0; i < 50; i++) {
+    gzip.write("Line " + i + ": " + "x".repeat(80) + "\\n");
+  }
+  gzip.end();
+});
+
+server.listen(0, () => {
+  const port = server.address().port;
+  let completed = 0;
+  const total = 3;
+
+  for (let i = 0; i < total; i++) {
+    http.get("http://localhost:" + port + "/", (response) => {
+      const gunzip = zlib.createGunzip();
+      const stream = response.pipe(gunzip);
+      let data = "";
+      stream.on("data", (chunk) => { data += chunk.toString(); });
+      stream.on("end", () => {
+        Bun.gc(true);
+        completed++;
+        if (completed >= total) {
+          console.log("OK");
+          server.close(() => process.exit(0));
+        }
+      });
+      stream.on("error", (err) => {
+        console.error("error:", err.message);
+        process.exit(1);
+      });
+    });
+  }
+});
+
+setTimeout(() => { console.error("timeout"); process.exit(1); }, 10000);
+`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  if (exitCode !== 0) {
+    console.log("stderr:", stderr);
+  }
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+}, 15000);

--- a/test/regression/issue/22567.test.ts
+++ b/test/regression/issue/22567.test.ts
@@ -49,8 +49,6 @@ server.listen(0, () => {
     });
   }
 });
-
-setTimeout(() => { console.error("timeout"); process.exit(1); }, 10000);
 `,
     ],
     env: bunEnv,
@@ -64,4 +62,4 @@ setTimeout(() => { console.error("timeout"); process.exit(1); }, 10000);
   }
   expect(stdout.trim()).toBe("OK");
   expect(exitCode).toBe(0);
-}, 15000);
+}, 15_000);

--- a/test/regression/issue/22567.test.ts
+++ b/test/regression/issue/22567.test.ts
@@ -46,6 +46,9 @@ server.listen(0, () => {
         console.error("error:", err.message);
         process.exit(1);
       });
+    }).on("error", (err) => {
+      console.error("request error:", err.message);
+      process.exit(1);
     });
   }
 });


### PR DESCRIPTION
## Summary

- Fix use-after-free crash when piping HTTP responses through `zlib.createGunzip()` (and other compression streams)
- Hold strong GC references to input/output buffer JSValues during async WorkPool decompression to prevent garbage collection while native threads are still using the underlying memory
- Apply the fix consistently across NativeZlib, NativeBrotli, and NativeZstd

## Root Cause

In `CompressionStream.write()`, raw pointers to JS ArrayBuffer backing stores are extracted and passed to a WorkPool thread for async compression/decompression. However, no strong references held the original JS buffer objects alive, so the GC could collect them between scheduling the WorkPool task and its completion — causing a segfault when the native thread accesses freed memory.

The fix adds `in_buf_value` and `out_buf_value` `Strong.Optional` fields that are set before scheduling work and cleared when the work completes.

Closes #22567

## Test plan

- [x] Added regression test `test/regression/issue/22567.test.ts` that pipes HTTP responses through `createGunzip()` with forced GC
- [x] Existing zlib tests pass (`deflate-streaming`, `zlib-handle-bounds-check`, `bytesWritten`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)