### PR TITLE
fix(lockfile): skip preprocessUpdateRequests for global installs

### DIFF
--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -662,7 +662,7 @@ pub fn cleanWithLogger(
     defer old_preinstall_state.deinit(old.allocator);
     @memset(preinstall_state.items, .unknown);
 
-    if (updates.len > 0) {
+    if (updates.len > 0 and !manager.options.global) {
         try old.preprocessUpdateRequests(manager, updates, exact_versions);
     }
 


### PR DESCRIPTION
## Summary

Fixes #28247

When running `bun update -g --latest`, the `preprocessUpdateRequests` function was being called for global installs. This caused an assertion failure when global packages had workspace dependencies that couldn't be resolved in the global context.

## Changes

Modified `cleanWithLogger` in `src/install/lockfile.zig` to skip `preprocessUpdateRequests` for global installs since they don't have a proper workspace context.

## Testing

This fix prevents the assertion failure by not attempting workspace-specific dependency preprocessing on global installs. The global update flow will still work correctly without this preprocessing step.