### PR TITLE
fix(dev_server): prevent crash on HMR when HTML file imported as text

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -2427,7 +2427,10 @@ pub fn finalizeBundle(
             false,
         );
         const client_index = ctx.getCachedIndex(.client, index).*.unwrap() orelse @panic("unresolved index");
-        const route_bundle_index = dev.client_graph.htmlRouteBundleIndex(client_index);
+        // Skip HTML chunks that don't correspond to an actual HTML route.
+        // This can happen when HTML files are imported with { type: "text" }
+        // and get incorrectly assigned the .html loader during HMR. (#22533)
+        const route_bundle_index = dev.client_graph.getFileByIndex(client_index).html_route_bundle_index orelse continue;
         const route_bundle = dev.routeBundlePtr(route_bundle_index);
         assert(route_bundle.data.html.bundled_file == client_index);
         const html = &route_bundle.data.html;

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -843,6 +843,19 @@ pub const BundleV2 = struct {
 
         const loader = brk: {
             const loader = path.loader(&this.transpiler.options.loaders) orelse .file;
+            // During HMR re-bundling, HTML files that were originally imported
+            // with { type: "text" } get incorrectly assigned the .html loader
+            // from their file extension. Check the dev server's client graph to
+            // detect non-route HTML files and use .text loader instead. (#22533)
+            if (loader == .html) {
+                if (this.transpiler.options.dev_server) |dev| {
+                    if (dev.client_graph.getFileIndex(path.text)) |fi| {
+                        if (dev.client_graph.getFileByIndex(fi).html_route_bundle_index == null) {
+                            break :brk options.Loader.text;
+                        }
+                    }
+                }
+            }
             break :brk loader;
         };
 

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -309,6 +309,36 @@ devTest("importing html file with text loader (#18154)", {
     await c.expectMessage("<div>hello world</div>");
   },
 });
+devTest("modifying html file imported as text does not crash (#22533)", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import html from "./page.html" with { type: "text" };
+      console.log(html);
+    `,
+    "page.html": "<h1>original</h1>",
+  },
+  htmlFiles: ["index.html"],
+  async test(dev) {
+    {
+      await using c = await dev.client("/", {});
+      await c.expectMessage("<h1>original</h1>");
+    }
+
+    // Writing to the text-imported HTML file should not crash the server.
+    // Before the fix, this caused a panic: "attempt to use null value"
+    // because non-route HTML files lack html_route_bundle_index.
+    await dev.write("page.html", "<h1>updated</h1>");
+
+    // Verify the server is still alive by connecting a fresh client
+    // that gets the updated content.
+    await using c2 = await dev.client("/", {});
+    await c2.expectMessage("<h1>updated</h1>");
+  },
+});
 devTest("importing bun on the client", {
   files: {
     "index.html": emptyHtmlFile({


### PR DESCRIPTION
## Summary
- Fix crash when modifying an HTML file imported with `{ type: "text" }` during dev server HMR
- The server panicked with "attempt to use null value" because the file was incorrectly assigned the `.html` loader from its file extension during re-bundling, causing it to be treated as an HTML route despite not having an `html_route_bundle_index`

## Root Cause
During HMR re-bundling, the `EntryPointList` only carries file paths — not import attributes. When `page.html` (imported as `text`) is modified, the bundler re-resolves it and determines the loader from the file extension (`.html`), overriding the original `text` loader from the import attribute. This causes the file to be added to `html_files` and processed as an HTML route chunk, which then crashes in `finalizeBundle` when it tries to access the non-existent `html_route_bundle_index`.

## Fix
Two-pronged approach:
1. **Root cause** (`bundle_v2.zig`): In `enqueueEntryItem`, detect non-route HTML files in the dev server's client graph and use `.text` loader instead of `.html` during HMR re-bundling
2. **Safety net** (`DevServer.zig`): In `finalizeBundle`, skip HTML chunks that don't have an `html_route_bundle_index` instead of panicking

## Test plan
- [x] New test: "modifying html file imported as text does not crash (#22533)" — verifies server survives file modification and serves updated content
- [x] Existing test: "importing html file with text loader (#18154)" — still passes
- [x] Full `test/bake/dev/bundle.test.ts` suite — all 18 tests pass

Closes #22533

🤖 Generated with [Claude Code](https://claude.com/claude-code)