### PR TITLE
fix(install): don't crash on unexpected resolution tag during package install

### DIFF
--- a/src/install/PackageInstaller.zig
+++ b/src/install/PackageInstaller.zig
@@ -954,8 +954,12 @@ pub const PackageInstaller = struct {
                 }
             },
             else => {
+                // This can happen when a dependency (e.g. a workspace:* dep from a
+                // git-hosted monorepo) failed to resolve earlier. The error was
+                // already reported during resolution; skip the package gracefully
+                // instead of crashing.
                 if (comptime Environment.allow_assert) {
-                    @panic("Internal assertion failure: unexpected resolution tag");
+                    debug("Skipping package with unexpected resolution tag: {d}", .{@intFromEnum(resolution.tag)});
                 }
                 this.incrementTreeInstallCount(this.current_tree_id, !is_pending_package_install, log_level);
                 return;

--- a/test/regression/issue/28247.test.ts
+++ b/test/regression/issue/28247.test.ts
@@ -45,7 +45,7 @@ globalBinDir = "${globalBinDir.replace(/\\/g, "\\\\")}"
     },
   });
 
-  const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+  const [stderr, , exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
 
   // The workspace deps can't be resolved, so we expect an error exit - but NOT a crash/panic.
   expect(stderr).not.toContain("panic");

--- a/test/regression/issue/28247.test.ts
+++ b/test/regression/issue/28247.test.ts
@@ -1,0 +1,58 @@
+import { spawn } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// Regression test for https://github.com/oven-sh/bun/issues/28247
+// `bun update -g --latest` panics with "Internal assertion failure" when
+// global package.json contains workspace:* dependencies that can't be resolved.
+// On Windows (ReleaseSafe builds), this triggered a @panic in
+// PackageInstaller.installDependency's else branch for unexpected resolution tags.
+test("bun update -g --latest does not crash with unresolvable workspace:* dependencies", async () => {
+  using dir = tempDir("issue-28247", {
+    "global-install/install/global/package.json": JSON.stringify({
+      dependencies: {
+        "@fake-scope/plugin": "workspace:*",
+        "@fake-scope/sdk": "workspace:*",
+      },
+    }),
+    "bunfig.toml": "",
+  });
+
+  const globalDir = join(String(dir), "global-install");
+  const globalBinDir = join(String(dir), "global-bin");
+
+  // Overwrite bunfig.toml with the correct path (needs globalBinDir which depends on dir)
+  await Bun.write(
+    join(String(dir), "bunfig.toml"),
+    `
+[install]
+cache = false
+globalBinDir = "${globalBinDir.replace(/\\/g, "\\\\")}"
+`,
+  );
+
+  const bunfigPath = join(String(dir), "bunfig.toml");
+
+  await using proc = spawn({
+    cmd: [bunExe(), "update", "-g", "--latest", `--config=${bunfigPath}`],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...bunEnv,
+      BUN_INSTALL: globalDir,
+    },
+  });
+
+  const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+  // The workspace deps can't be resolved, so we expect an error exit - but NOT a crash/panic.
+  expect(stderr).not.toContain("panic");
+  expect(stderr).not.toContain("Internal assertion failure");
+  expect(stderr).toContain("Workspace dependency");
+  expect(stderr).toContain("failed to resolve");
+
+  // Should exit with error code 1 (resolution failure), not a signal/crash
+  expect(exitCode).toBe(1);
+});


### PR DESCRIPTION
## Summary
- Replace `@panic` with a graceful skip in `PackageInstaller` when encountering an unexpected resolution tag
- This fixes a Windows-specific crash in `bun update -g --latest` when globally installed git packages have unresolvable `workspace:*` dependencies

## Root Cause
When a git-hosted monorepo (like `opencode@github:sst/opencode`) is installed globally, its internal `workspace:*` dependencies can't be resolved in the global context. The resolution errors are logged, but on **Windows** (built with `ReleaseSafe` where `allow_assert = true`), the `@panic` in `PackageInstaller.installDependency()`'s `else` branch would crash the process.

On Linux/macOS (`ReleaseFast`), the `@panic` was compiled out and the existing graceful fallback (increment tree count + return) was used instead.

## Fix
Replace the `@panic` with a debug log message, so the graceful skip path is always used regardless of build mode. The resolution error was already reported earlier in the pipeline.

## Test plan
- [x] Added regression test `test/regression/issue/28247.test.ts`
- [x] Test verifies `bun update -g --latest` with unresolvable `workspace:*` deps exits with code 1 (not a crash)
- [x] Test verifies stderr contains error messages but no panic

Closes #28247

🤖 Generated with [Claude Code](https://claude.com/claude-code)