### PR TITLE
fix: prevent segfault when require() and import() race on mocked modules

### DIFF
--- a/src/bun.js/bindings/ModuleLoader.cpp
+++ b/src/bun.js/bindings/ModuleLoader.cpp
@@ -400,6 +400,21 @@ static JSValue handleVirtualModuleResult(
     case OnLoadResultTypeObject: {
         JSC::JSObject* object = onLoadResult.value.object.getObject();
         if (commonJSModule) {
+            // For module mocks loaded via require(), directly assign the mock
+            // object as CJS exports. Going through the ESM pipeline (returning
+            // -1 from fetchCommonJSModule) would cause $loadEsmIntoCjs to
+            // synchronously parse/link/evaluate the module via JSC's module
+            // loader. If a dynamic import() for the same mocked module is
+            // already in flight (microtasks queued but not yet run), this leads
+            // to a double-fulfill of JSC's internal module loading promise,
+            // causing a segfault (or an assertion failure in debug builds).
+            // See: https://github.com/oven-sh/bun/issues/22877
+            if (wasModuleMock) {
+                commonJSModule->setExportsObject(onLoadResult.value.object);
+                commonJSModule->hasEvaluated = true;
+                return commonJSModule;
+            }
+
             const auto& __esModuleIdentifier = vm.propertyNames->__esModule;
             auto esModuleValue = object->getIfPropertyExists(globalObject, __esModuleIdentifier);
             if (scope.exception()) [[unlikely]] {

--- a/test/regression/issue/22877.test.ts
+++ b/test/regression/issue/22877.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // https://github.com/oven-sh/bun/issues/22877

--- a/test/regression/issue/22877.test.ts
+++ b/test/regression/issue/22877.test.ts
@@ -50,9 +50,6 @@ test("import() then require() on same mocked module does not crash", async () =>
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   const output = stdout + stderr;
-  expect(output).not.toContain("Segmentation fault");
-  expect(output).not.toContain("ASSERTION FAILED");
-  expect(output).not.toContain("panic");
   expect(output).toContain("1 pass");
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/22877.test.ts
+++ b/test/regression/issue/22877.test.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/22877
+// When a mocked module has a pending dynamic import() and require() is called
+// synchronously on the same module before the import microtasks complete,
+// JSC's internal module loading promise could be fulfilled twice, causing a
+// segfault (or assertion failure in debug builds).
+//
+// The fix makes require() on mocked modules directly assign the mock object
+// as CJS exports, avoiding the ESM pipeline entirely. This prevents the
+// double-fulfill and also means the exports don't get wrapped with __esModule.
+
+test("import() then require() on same mocked module does not crash", async () => {
+  using dir = tempDir("22877", {
+    "repro.test.ts": `
+      import { test, expect, mock } from "bun:test";
+
+      test("require on mocked module returns mock object directly", async () => {
+        mock.module("test-mod", () => ({ value: 42, nested: { x: 1 } }));
+
+        // Start import (queues microtasks in JSC's module pipeline)
+        const importPromise = import("test-mod");
+
+        // Synchronously require the same module - with the fix, this returns
+        // the mock object directly instead of going through the ESM pipeline.
+        const required = require("test-mod");
+        expect(required.value).toBe(42);
+        expect(required.nested.x).toBe(1);
+
+        // With the fix, require() returns the mock object directly,
+        // so __esModule should NOT be set. Without the fix, require()
+        // goes through the ESM pipeline which sets __esModule = true.
+        expect(required.__esModule).toBeUndefined();
+
+        const imported = await importPromise;
+        expect(imported.value).toBe(42);
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "repro.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const output = stdout + stderr;
+  expect(output).not.toContain("Segmentation fault");
+  expect(output).not.toContain("ASSERTION FAILED");
+  expect(output).not.toContain("panic");
+  expect(output).toContain("1 pass");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fix segfault (or assertion failure in debug builds) when `require()` and `import()` are called on the same `mock.module()` module before the import microtasks complete
- When `import("m")` starts JSC's module loading pipeline and `require("m")` is called synchronously before the microtasks run, the CJS path previously went through JSC's ESM pipeline (`$loadEsmIntoCjs`), which synchronously fulfilled the same internal promise that the import's microtasks would later try to fulfill — causing a double-fulfill crash
- The fix makes `require()` on mocked modules directly assign the mock object as CJS exports, bypassing the ESM pipeline entirely

Closes #22877

## Test plan

- [x] New regression test `test/regression/issue/22877.test.ts` exercises the exact code path (import then require on same mocked module)
- [x] Test fails with unfixed bun (`__esModule` is incorrectly set from ESM pipeline), passes with fix
- [x] Debug build assertion failure (`ASSERTION FAILED: status() == Status::Pending` in `JSPromise::fulfillPromise`) no longer triggers
- [x] All existing `mock.module` tests pass: `mock-module.test.ts`, `6874/`, `6879/`, `11664.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)