### PR TITLE
fix(streams): prevent integer cast panic when draining >4GB buffers

### DIFF
--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -1902,8 +1902,8 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                                 // If we've received the complete body by the time this function is called
                                 // we can avoid streaming it and just send it all at once.
                                 if (byte_stream.has_received_last_chunk) {
-                                    var byte_list = byte_stream.drain();
-                                    this.blob = .fromArrayList(byte_list.moveToListManaged(bun.default_allocator));
+                                    var drained = byte_stream.drain();
+                                    this.blob = .fromArrayList(drained.toManaged(bun.default_allocator));
                                     this.response_body_readable_stream_ref.deinit();
                                     this.doRenderBlob();
                                     return;
@@ -1916,8 +1916,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                                 this.response_body_readable_stream_ref = jsc.WebCore.ReadableStream.Strong.init(stream, globalThis);
 
                                 this.byte_stream = byte_stream;
-                                var response_buf = byte_stream.drain();
-                                this.response_buf_owned = response_buf.moveToList();
+                                this.response_buf_owned = byte_stream.drain();
 
                                 // we don't set size here because even if we have a hint
                                 // uWebSockets won't let us partially write streaming content

--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -160,18 +160,18 @@ fn clearData(this: *ByteBlobLoader) void {
     }
 }
 
-pub fn drain(this: *ByteBlobLoader) bun.ByteList {
+pub fn drain(this: *ByteBlobLoader) std.ArrayListUnmanaged(u8) {
     const store = this.store orelse return .{};
     var temporary = store.sharedView();
     temporary = temporary[this.offset..];
     temporary = temporary[0..@min(16384, @min(temporary.len, this.remain))];
 
-    var byte_list = bun.ByteList.fromBorrowedSliceDangerous(temporary);
-    const cloned = bun.handleOom(byte_list.clone(bun.default_allocator));
-    this.offset +|= @as(Blob.SizeType, cloned.len);
-    this.remain -|= @as(Blob.SizeType, cloned.len);
+    const cloned = bun.default_allocator.alloc(u8, temporary.len) catch bun.outOfMemory();
+    @memcpy(cloned, temporary);
+    this.offset +|= @as(Blob.SizeType, @truncate(temporary.len));
+    this.remain -|= @as(Blob.SizeType, @truncate(temporary.len));
 
-    return cloned;
+    return .{ .items = cloned, .capacity = cloned.len };
 }
 
 pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, action: streams.BufferAction.Tag) bun.JSError!JSValue {
@@ -191,6 +191,7 @@ pub fn memoryCost(this: *const ByteBlobLoader) usize {
     return 0;
 }
 
+const std = @import("std");
 const bun = @import("bun");
 
 const jsc = bun.jsc;

--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -191,8 +191,8 @@ pub fn memoryCost(this: *const ByteBlobLoader) usize {
     return 0;
 }
 
-const std = @import("std");
 const bun = @import("bun");
+const std = @import("std");
 
 const jsc = bun.jsc;
 const JSGlobalObject = jsc.JSGlobalObject;

--- a/src/bun.js/webcore/ByteStream.zig
+++ b/src/bun.js/webcore/ByteStream.zig
@@ -387,9 +387,9 @@ pub fn deinit(this: *@This()) void {
     this.parent().deinit();
 }
 
-pub fn drain(this: *@This()) bun.ByteList {
+pub fn drain(this: *@This()) std.ArrayListUnmanaged(u8) {
     if (this.buffer.items.len > 0) {
-        return bun.ByteList.moveFromList(&this.buffer);
+        return this.buffer.moveToUnmanaged();
     }
     return .{};
 }

--- a/src/bun.js/webcore/FileReader.zig
+++ b/src/bun.js/webcore/FileReader.zig
@@ -461,29 +461,48 @@ fn isPulling(this: *const FileReader) bool {
 pub fn onPull(this: *FileReader, buffer: []u8, array: jsc.JSValue) streams.Result {
     array.ensureStillAlive();
     defer array.ensureStillAlive();
-    const drained = this.drain();
+    var drained = this.drain();
 
-    if (drained.len > 0) {
-        log("onPull({d}) = {d}", .{ buffer.len, drained.len });
+    if (drained.items.len > 0) {
+        log("onPull({d}) = {d}", .{ buffer.len, drained.items.len });
 
         this.pending_value.clearWithoutDeallocation();
         this.pending_view = &.{};
 
-        if (buffer.len >= @as(usize, drained.len)) {
-            @memcpy(buffer[0..drained.len], drained.slice());
+        if (buffer.len >= drained.items.len) {
+            @memcpy(buffer[0..drained.items.len], drained.items);
+            drained.deinit(bun.default_allocator);
             this.buffered.clearAndFree(bun.default_allocator);
 
             if (this.reader.isDone()) {
-                return .{ .into_array_and_done = .{ .value = array, .len = drained.len } };
+                return .{ .into_array_and_done = .{ .value = array, .len = @truncate(drained.items.len) } };
             } else {
-                return .{ .into_array = .{ .value = array, .len = drained.len } };
+                return .{ .into_array = .{ .value = array, .len = @truncate(drained.items.len) } };
             }
         }
 
+        // If the drained data fits in a ByteList (<=4GB), return as owned.
+        if (drained.items.len <= std.math.maxInt(u32)) {
+            const byte_list = bun.ByteList.fromOwnedSlice(drained.items);
+            if (this.reader.isDone()) {
+                return .{ .owned_and_done = byte_list };
+            } else {
+                return .{ .owned = byte_list };
+            }
+        }
+
+        // Drained data exceeds ByteList capacity (>4GB): copy what fits into the
+        // caller's buffer and re-buffer the rest for subsequent pulls.
+        @memcpy(buffer, drained.items[0..buffer.len]);
+        const remaining = drained.items.len - buffer.len;
+        std.mem.copyForwards(u8, drained.items[0..remaining], drained.items[buffer.len..]);
+        drained.items.len = remaining;
+        this.buffered = drained;
+
         if (this.reader.isDone()) {
-            return .{ .owned_and_done = drained };
+            return .{ .into_array_and_done = .{ .value = array, .len = @truncate(buffer.len) } };
         } else {
-            return .{ .owned = drained };
+            return .{ .into_array = .{ .value = array, .len = @truncate(buffer.len) } };
         }
     }
 
@@ -555,12 +574,13 @@ pub fn onPull(this: *FileReader, buffer: []u8, array: jsc.JSValue) streams.Resul
     return .{ .pending = &this.pending };
 }
 
-pub fn drain(this: *FileReader) bun.ByteList {
+pub fn drain(this: *FileReader) std.ArrayListUnmanaged(u8) {
     if (this.buffered.items.len > 0) {
-        const out = bun.ByteList.moveFromList(&this.buffered);
+        const out = this.buffered;
         if (comptime Environment.allow_assert) {
-            bun.assert(this.reader.buffer().items.ptr != out.ptr);
+            bun.assert(this.reader.buffer().items.ptr != out.items.ptr);
         }
+        this.buffered = .{};
         return out;
     }
 
@@ -568,7 +588,7 @@ pub fn drain(this: *FileReader) bun.ByteList {
         return .{};
     }
 
-    return bun.ByteList.moveFromList(this.reader.buffer());
+    return this.reader.buffer().moveToUnmanaged();
 }
 
 pub fn setRefOrUnref(this: *FileReader, enable: bool) void {

--- a/src/bun.js/webcore/ReadableStream.zig
+++ b/src/bun.js/webcore/ReadableStream.zig
@@ -430,7 +430,7 @@ pub fn NewSource(
     comptime onCancel: fn (this: *Context) void,
     comptime deinit_fn: fn (this: *Context) void,
     comptime setRefUnrefFn: ?fn (this: *Context, enable: bool) void,
-    comptime drainInternalBuffer: ?fn (this: *Context) bun.ByteList,
+    comptime drainInternalBuffer: ?fn (this: *Context) std.ArrayListUnmanaged(u8),
     comptime memoryCostFn: ?fn (this: *const Context) usize,
     comptime toBufferedValue: ?fn (this: *Context, globalThis: *jsc.JSGlobalObject, action: streams.BufferAction.Tag) bun.JSError!jsc.JSValue,
 ) type {
@@ -546,7 +546,7 @@ pub fn NewSource(
             return null;
         }
 
-        pub fn drain(this: *This) bun.ByteList {
+        pub fn drain(this: *This) std.ArrayListUnmanaged(u8) {
             if (drainInternalBuffer) |drain_fn| {
                 return drain_fn(&this.context);
             }
@@ -782,9 +782,11 @@ pub fn NewSource(
             pub fn drain(this: *ReadableStreamSourceType, globalThis: *JSGlobalObject, callFrame: *jsc.CallFrame) bun.JSError!jsc.JSValue {
                 jsc.markBinding(@src());
                 this.this_jsvalue = callFrame.this();
-                var list = this.drain();
-                if (list.len > 0) {
-                    return jsc.ArrayBuffer.fromBytes(list.slice(), .Uint8Array).toJS(globalThis);
+                const list = this.drain();
+                if (list.items.len > 0) {
+                    // Use JSUint8Array.fromBytes which accepts usize length,
+                    // avoiding the u32 overflow in ArrayBuffer.fromBytes for >4GB buffers.
+                    return jsc.JSUint8Array.fromBytes(globalThis, list.items);
                 }
                 return .js_undefined;
             }
@@ -852,6 +854,7 @@ pub fn NewSource(
     };
 }
 
+const std = @import("std");
 const bun = @import("bun");
 const Environment = bun.Environment;
 const Syscall = bun.sys;

--- a/src/bun.js/webcore/ReadableStream.zig
+++ b/src/bun.js/webcore/ReadableStream.zig
@@ -855,6 +855,7 @@ pub fn NewSource(
 }
 
 const std = @import("std");
+
 const bun = @import("bun");
 const Environment = bun.Environment;
 const Syscall = bun.sys;

--- a/src/bun.js/webcore/ResumableSink.zig
+++ b/src/bun.js/webcore/ResumableSink.zig
@@ -95,8 +95,8 @@ pub fn ResumableSink(
 
                         var bytes = byte_stream.drain();
                         defer bytes.deinit(bun.default_allocator);
-                        log("onWrite {}", .{bytes.len});
-                        _ = onWrite(this.context, bytes.slice());
+                        log("onWrite {}", .{bytes.items.len});
+                        _ = onWrite(this.context, bytes.items);
                         onEnd(this.context, err);
                         this.deref();
                         return this;
@@ -105,11 +105,11 @@ pub fn ResumableSink(
                     var bytes = byte_stream.drain();
                     defer bytes.deinit(bun.default_allocator);
                     // lets write and see if we can still pipe or if we have backpressure
-                    if (bytes.len > 0) {
-                        log("onWrite {}", .{bytes.len});
+                    if (bytes.items.len > 0) {
+                        log("onWrite {}", .{bytes.items.len});
                         // we ignore the return value here because we dont want to pause the stream
                         // if we pause will just buffer in the pipe and we can do the buffer in one place
-                        _ = onWrite(this.context, bytes.slice());
+                        _ = onWrite(this.context, bytes.items);
                     }
                     this.status = .piped;
                     byte_stream.pipe = jsc.WebCore.Pipe.Wrap(@This(), onStreamPipe).init(this);

--- a/test/regression/issue/23065.test.ts
+++ b/test/regression/issue/23065.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
 
 // Regression test for https://github.com/oven-sh/bun/issues/23065
 // Streaming large files through ReadableStream drain path should not panic

--- a/test/regression/issue/23065.test.ts
+++ b/test/regression/issue/23065.test.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/23065
+// Streaming large files through ReadableStream drain path should not panic
+// with "integer cast truncated bits" when buffer sizes are large.
+// The underlying fix changes drain() to return std.ArrayListUnmanaged(u8)
+// (usize length) instead of ByteList (u32 length), avoiding overflow for >4GB buffers.
+
+test("streaming a file through ReadableStream drain path works correctly", async () => {
+  // Create a file with enough data to exercise the drain path
+  const size = 10 * 1024 * 1024; // 10MB
+  const data = Buffer.alloc(size, 0xab);
+
+  using dir = tempDir("issue-23065", {
+    "test.bin": data,
+  });
+
+  const file = Bun.file(`${dir}/test.bin`);
+  const stream = file.stream();
+  const result = await new Response(stream).arrayBuffer();
+
+  expect(result.byteLength).toBe(size);
+  // Verify first and last bytes to ensure data integrity
+  const view = new Uint8Array(result);
+  expect(view[0]).toBe(0xab);
+  expect(view[size - 1]).toBe(0xab);
+});
+
+test("piping Bun.file through HTTP server exercises ByteStream drain", async () => {
+  using dir = tempDir("issue-23065-http", {
+    "upload.bin": Buffer.alloc(1024 * 1024, 0xcd), // 1MB
+  });
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const body = await req.arrayBuffer();
+      return new Response(String(body.byteLength));
+    },
+  });
+
+  const file = Bun.file(`${dir}/upload.bin`);
+  const resp = await fetch(server.url, {
+    method: "POST",
+    body: file,
+  });
+
+  const text = await resp.text();
+  expect(text).toBe("1048576");
+});
+
+test("ReadableStream from file can be consumed via Bun.write", async () => {
+  const size = 5 * 1024 * 1024; // 5MB
+  using dir = tempDir("issue-23065-write", {
+    "source.bin": Buffer.alloc(size, 0xef),
+  });
+
+  const source = Bun.file(`${dir}/source.bin`);
+  const destPath = `${dir}/dest.bin`;
+  await Bun.write(destPath, source);
+
+  const dest = Bun.file(destPath);
+  expect(dest.size).toBe(size);
+  const destData = new Uint8Array(await dest.arrayBuffer());
+  expect(destData[0]).toBe(0xef);
+  expect(destData[size - 1]).toBe(0xef);
+});


### PR DESCRIPTION
## Summary
- Change stream `drain()` functions to return `std.ArrayListUnmanaged(u8)` (usize length/capacity) instead of `ByteList` (u32 length/capacity), fixing a panic when streaming files larger than 4GB
- The `ByteList` type uses `u32` for length and capacity fields, which overflows via `@intCast` when buffers exceed ~4.29GB, causing: `panic: integer cast truncated bits`
- This was triggered when uploading large files (e.g., 18GB) to S3 via `Bun.file()` + `S3Client`

### Changes
- **`FileReader.drain()`** — returns `std.ArrayListUnmanaged(u8)` by directly transferring ownership of internal `buffered` list or calling `moveToUnmanaged()` on the reader's buffer
- **`ByteStream.drain()`** — uses `moveToUnmanaged()` instead of `ByteList.moveFromList()`
- **`ByteBlobLoader.drain()`** — allocates directly as `std.ArrayListUnmanaged(u8)` (max 16KB chunks, no overflow risk but type changed for consistency)
- **`ReadableStream.NewSource`** — updated `drainInternalBuffer` function pointer type and wrapper
- **JS-exposed drain** — uses `JSUint8Array.fromBytes()` (usize length) instead of `ArrayBuffer.fromBytes()` (u32 length)
- **`ResumableSink`** — updated to use `.items`/`.items.len` instead of `.slice()`/`.len`
- **`RequestContext`** — updated to use `.toManaged()` and direct assignment instead of ByteList conversion methods
- **`FileReader.onPull()`** — handles >4GB drained data by copying what fits into the caller's buffer and re-buffering the rest

Fixes #23065

## Test plan
- [x] Added regression test in `test/regression/issue/23065.test.ts` exercising the drain path via file streaming
- [x] Debug build compiles successfully
- [x] All ReadableStream tests pass (21/21)
- [x] All HTTP server streaming tests pass (12/12)
- [x] All HTTP server Bun.file tests pass (40/40)
- [x] Regression test passes (3/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)