### PR TITLE
fix(server): prevent segfault when server JS wrapper is finalized during request handling

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -631,9 +631,11 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             return globalThis.throw2("Server() is not a constructor", .{});
         }
 
-        pub fn jsValueAssertAlive(server: *ThisServer) jsc.JSValue {
-            bun.assert(server.js_value.isNotEmpty());
-            return server.js_value.tryGet().?;
+        /// Returns the server's JS wrapper value, or null if the server has been
+        /// finalized (e.g. after stop() + GC). Callers must handle the null case
+        /// to avoid a segfault when accessing C++ cached properties.
+        pub fn tryGetJSValue(server: *ThisServer) ?jsc.JSValue {
+            return server.js_value.tryGet();
         }
 
         pub fn requestIP(this: *ThisServer, request: *jsc.WebCore.Request) bun.JSError!jsc.JSValue {
@@ -1249,9 +1251,12 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             var request = Request.new(existing_request);
 
             bun.assert(this.config.onRequest != .zero); // confirmed above
+            const server_js = this.tryGetJSValue() orelse {
+                return JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(ctx, ZigString.init("Server is no longer available").toErrorInstance(ctx));
+            };
             const response_value = this.config.onRequest.call(
                 this.globalThis,
-                this.jsValueAssertAlive(),
+                server_js,
                 &[_]jsc.JSValue{request.toJS(this.globalThis)},
             ) catch |err| this.globalThis.takeException(err);
 
@@ -2053,8 +2058,17 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 .specific => |m| m,
             }) orelse return;
 
-            const server_request_list = js.routeListGetCached(server.jsValueAssertAlive()).?;
-            const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server.jsValueAssertAlive(), server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
+            const server_js = server.tryGetJSValue() orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
+            const server_request_list = js.routeListGetCached(server_js) orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
+            const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server_js, server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
 
             server.handleRequest(&should_deinit_context, prepared, req, response_value);
         }
@@ -2094,7 +2108,11 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
             bun.assert(this.config.onRequest != .zero);
 
-            const js_value = this.jsValueAssertAlive();
+            const js_value = this.tryGetJSValue() orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
             const response_value = this.config.onRequest.call(
                 this.globalThis,
                 js_value,
@@ -2124,10 +2142,15 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             const ctx = prepared.ctx;
 
             bun.assert(callback != .zero);
+            const server_js = this.tryGetJSValue() orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
             const args = .{prepared.js_request} ++ extra_args;
             const response_value = callback.call(
                 this.globalThis,
-                this.jsValueAssertAlive(),
+                server_js,
                 &args,
             ) catch |err|
                 this.globalThis.takeException(err);
@@ -2321,8 +2344,17 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             var should_deinit_context = false;
             var prepared = server.prepareJsRequestContext(req, resp, &should_deinit_context, .no, method) orelse return;
             prepared.ctx.upgrade_context = upgrade_ctx; // set the upgrade context
-            const server_request_list = js.routeListGetCached(server.jsValueAssertAlive()).?;
-            const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server.jsValueAssertAlive(), server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
+            const server_js = server.tryGetJSValue() orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
+            const server_request_list = js.routeListGetCached(server_js) orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
+            const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server_js, server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
 
             server.handleRequest(&should_deinit_context, prepared, req, response_value);
         }
@@ -2347,6 +2379,11 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 resp.endWithoutBody(true);
                 return;
             }
+            const server_js = this.tryGetJSValue() orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
             this.pending_requests += 1;
             req.setYield(false);
             var ctx = bun.handleOom(this.request_pool_allocator.tryGet());
@@ -2370,12 +2407,12 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             // We keep the Request object alive for the duration of the request so that we can remove the pointer to the UWS request object.
             var args = [_]jsc.JSValue{
                 request_object.toJS(this.globalThis),
-                this.jsValueAssertAlive(),
+                server_js,
             };
             const request_value = args[0];
             request_value.ensureStillAlive();
 
-            const response_value = this.config.onRequest.call(this.globalThis, this.jsValueAssertAlive(), &args) catch |err|
+            const response_value = this.config.onRequest.call(this.globalThis, server_js, &args) catch |err|
                 this.globalThis.takeException(err);
             defer {
                 // uWS request will not live longer than this function

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2052,22 +2052,19 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             const server = user_route.server;
             const index = user_route.id;
 
+            const server_js = server.tryGetJSValue() orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
+
             var should_deinit_context = false;
             var prepared = server.prepareJsRequestContext(req, resp, &should_deinit_context, .no, switch (user_route.route.method) {
                 .any => null,
                 .specific => |m| m,
             }) orelse return;
 
-            const server_js = server.tryGetJSValue() orelse {
-                resp.writeStatus("503 Service Unavailable");
-                resp.endWithoutBody(true);
-                return;
-            };
-            const server_request_list = js.routeListGetCached(server_js) orelse {
-                resp.writeStatus("503 Service Unavailable");
-                resp.endWithoutBody(true);
-                return;
-            };
+            const server_request_list = js.routeListGetCached(server_js).?;
             const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server_js, server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
 
             server.handleRequest(&should_deinit_context, prepared, req, response_value);
@@ -2103,9 +2100,6 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
         }
 
         pub fn onRequest(this: *ThisServer, req: *uws.Request, resp: *App.Response) void {
-            var should_deinit_context = false;
-            const prepared = this.prepareJsRequestContext(req, resp, &should_deinit_context, .yes, null) orelse return;
-
             bun.assert(this.config.onRequest != .zero);
 
             const js_value = this.tryGetJSValue() orelse {
@@ -2113,6 +2107,10 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 resp.endWithoutBody(true);
                 return;
             };
+
+            var should_deinit_context = false;
+            const prepared = this.prepareJsRequestContext(req, resp, &should_deinit_context, .yes, null) orelse return;
+
             const response_value = this.config.onRequest.call(
                 this.globalThis,
                 js_value,
@@ -2131,6 +2129,13 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             comptime arg_count: comptime_int,
             extra_args: [arg_count]JSValue,
         ) void {
+            bun.assert(callback != .zero);
+            const server_js = this.tryGetJSValue() orelse {
+                resp.writeStatus("503 Service Unavailable");
+                resp.endWithoutBody(true);
+                return;
+            };
+
             const prepared: PreparedRequest = switch (req) {
                 .stack => |r| this.prepareJsRequestContext(r, resp, null, .bake, null) orelse return,
                 .saved => |data| .{
@@ -2140,13 +2145,6 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 },
             };
             const ctx = prepared.ctx;
-
-            bun.assert(callback != .zero);
-            const server_js = this.tryGetJSValue() orelse {
-                resp.writeStatus("503 Service Unavailable");
-                resp.endWithoutBody(true);
-                return;
-            };
             const args = .{prepared.js_request} ++ extra_args;
             const response_value = callback.call(
                 this.globalThis,
@@ -2341,19 +2339,16 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             const server = this.server;
             const index = this.id;
 
-            var should_deinit_context = false;
-            var prepared = server.prepareJsRequestContext(req, resp, &should_deinit_context, .no, method) orelse return;
-            prepared.ctx.upgrade_context = upgrade_ctx; // set the upgrade context
             const server_js = server.tryGetJSValue() orelse {
                 resp.writeStatus("503 Service Unavailable");
                 resp.endWithoutBody(true);
                 return;
             };
-            const server_request_list = js.routeListGetCached(server_js) orelse {
-                resp.writeStatus("503 Service Unavailable");
-                resp.endWithoutBody(true);
-                return;
-            };
+
+            var should_deinit_context = false;
+            var prepared = server.prepareJsRequestContext(req, resp, &should_deinit_context, .no, method) orelse return;
+            prepared.ctx.upgrade_context = upgrade_ctx; // set the upgrade context
+            const server_request_list = js.routeListGetCached(server_js).?;
             const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server_js, server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
 
             server.handleRequest(&should_deinit_context, prepared, req, response_value);

--- a/test/regression/issue/22927.test.ts
+++ b/test/regression/issue/22927.test.ts
@@ -1,0 +1,100 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for #22927: Segfault in HTTP server route handler after
+// server.stop() + GC. When the server's JS wrapper is garbage collected,
+// route handlers must not crash accessing the null JSHTTPServer pointer.
+
+test("server does not crash when requests arrive after stop() + GC", async () => {
+  // We run this in a subprocess because the crash is a segfault that would
+  // kill the test runner process.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          return new Response("OK");
+        },
+      });
+
+      const url = server.url;
+
+      // Establish a keep-alive connection
+      await fetch(url);
+
+      // Stop the server (downgrades JS ref to weak)
+      server.stop();
+
+      // Force GC to potentially collect the weak reference
+      Bun.gc(true);
+      Bun.gc(true);
+
+      // Try making requests - these may arrive on keep-alive connections
+      // after the JS wrapper has been collected
+      const results = await Promise.allSettled(
+        Array.from({ length: 20 }, () => fetch(url).catch(() => null))
+      );
+
+      // We don't care about the results, just that we didn't crash
+      console.log("OK");
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("panic");
+  expect(stderr).not.toContain("Segmentation fault");
+  expect(stdout).toContain("OK");
+  // The process should exit cleanly (0) or at worst with a connection error,
+  // but never with a signal-based crash (segfault = 139 on Linux, 134 for abort)
+  expect(exitCode).not.toBe(139);
+  expect(exitCode).not.toBe(134);
+  expect(exitCode).toBe(0);
+});
+
+test("server.fetch() does not crash after stop() + GC", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          return new Response("OK");
+        },
+      });
+
+      // Stop the server
+      server.stop();
+
+      // Force GC
+      Bun.gc(true);
+      Bun.gc(true);
+
+      // Try using server.fetch() after GC - should not segfault
+      try {
+        await server.fetch(new Request("http://localhost/"));
+      } catch (e) {
+        // Expected to fail, but not crash
+      }
+
+      console.log("OK");
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("Segmentation fault");
+  expect(stdout).toContain("OK");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/22927.test.ts
+++ b/test/regression/issue/22927.test.ts
@@ -13,7 +13,7 @@ test("server does not crash when requests arrive after stop() + GC", async () =>
       bunExe(),
       "-e",
       `
-      const server = Bun.serve({
+      let server = Bun.serve({
         port: 0,
         fetch(req) {
           return new Response("OK");
@@ -22,23 +22,33 @@ test("server does not crash when requests arrive after stop() + GC", async () =>
 
       const url = server.url;
 
-      // Establish a keep-alive connection
-      await fetch(url);
+      // Establish a keep-alive connection and consume the response body
+      const warmup = await fetch(url);
+      await warmup.text();
 
-      // Stop the server (downgrades JS ref to weak)
+      // Stop the server (downgrades JS ref to weak) and drop the strong reference
       server.stop();
+      server = null;
 
-      // Force GC to potentially collect the weak reference
+      // Force GC to collect the weak reference
       Bun.gc(true);
       Bun.gc(true);
 
       // Try making requests - these may arrive on keep-alive connections
       // after the JS wrapper has been collected
       const results = await Promise.allSettled(
-        Array.from({ length: 20 }, () => fetch(url).catch(() => null))
+        Array.from({ length: 20 }, () => fetch(url))
       );
 
-      // We don't care about the results, just that we didn't crash
+      // All requests should have either failed or returned non-200
+      // since the server is stopped
+      for (const r of results) {
+        if (r.status === "fulfilled") {
+          await r.value.text();
+        }
+      }
+
+      // We got here without crashing
       console.log("OK");
       `,
     ],
@@ -48,13 +58,7 @@ test("server does not crash when requests arrive after stop() + GC", async () =>
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).not.toContain("panic");
-  expect(stderr).not.toContain("Segmentation fault");
   expect(stdout).toContain("OK");
-  // The process should exit cleanly (0) or at worst with a connection error,
-  // but never with a signal-based crash (segfault = 139 on Linux, 134 for abort)
-  expect(exitCode).not.toBe(139);
-  expect(exitCode).not.toBe(134);
   expect(exitCode).toBe(0);
 });
 
@@ -64,25 +68,31 @@ test("server.fetch() does not crash after stop() + GC", async () => {
       bunExe(),
       "-e",
       `
-      const server = Bun.serve({
+      let server = Bun.serve({
         port: 0,
         fetch(req) {
           return new Response("OK");
         },
       });
 
-      // Stop the server
+      // Keep a reference to call server.fetch() later
+      const fetchFn = server.fetch.bind(server);
+
+      // Stop the server and drop the strong reference
       server.stop();
+      server = null;
 
-      // Force GC
+      // Force GC to collect the weak reference
       Bun.gc(true);
       Bun.gc(true);
 
-      // Try using server.fetch() after GC - should not segfault
+      // Try using server.fetch() after GC - should reject, not segfault
       try {
-        await server.fetch(new Request("http://localhost/"));
+        const res = await fetchFn(new Request("http://localhost/"));
+        // If it somehow resolves, consume the body
+        await res.text();
       } catch (e) {
-        // Expected to fail, but not crash
+        // Expected to reject with "Server is no longer available"
       }
 
       console.log("OK");
@@ -94,7 +104,6 @@ test("server.fetch() does not crash after stop() + GC", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).not.toContain("Segmentation fault");
   expect(stdout).toContain("OK");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Summary
- Fixes a segmentation fault at address 0x4A when HTTP requests arrive on keep-alive connections after `server.stop()` + GC collects the server's JS wrapper
- Replaces the unsafe `jsValueAssertAlive()` (which force-unwraps a null optional) with `tryGetJSValue()` that returns an optional, handling the null case gracefully at all 6 call sites
- uWS route handlers (`onUserRouteRequest`, `onRequest`, `onSavedRequest`, `upgradeWebSocketUserRoute`, `onWebSocketUpgrade`) now return **503 Service Unavailable** when the server is finalized
- `onFetch` returns a rejected promise instead of crashing

## Root Cause
When `server.stop()` is called, the JS reference is downgraded from strong to weak. If GC runs and collects the wrapper, then a request arrives on a keep-alive connection before `app.close()` runs, `jsValueAssertAlive()` calls `.?` on `tryGet()` which returns null — undefined behavior in release mode, resulting in a null pointer dereference at offset 0x4A (`m_routeList` field in `JSHTTPServer`).

## Test plan
- [x] Added regression test in `test/regression/issue/22927.test.ts` — subprocess tests verify no crash after stop+GC
- [x] Existing `server-stop-with-pending-requests.test.ts` passes
- [x] `serve.test.ts` — 185 pass, 5 pre-existing failures (same on main)

Closes #22927
Closes #21559

🤖 Generated with [Claude Code](https://claude.com/claude-code)