### PR TITLE
fix(tls): `getPeerCertificate(false)` returns `{}` instead of peer cert

### DIFF
--- a/src/bun.js/api/bun/socket/tls_socket_functions.zig
+++ b/src/bun.js/api/bun/socket/tls_socket_functions.zig
@@ -108,15 +108,12 @@ pub fn getPeerCertificate(this: *This, globalObject: *jsc.JSGlobalObject, callfr
     // Node.js API: getPeerCertificate([detailed])
     // detailed=false (default): returns abbreviated cert (just the peer cert)
     // detailed=true: returns cert with issuerCertificate chain
+    //
+    // Node.js does not type-check the argument; it uses args[0]->IsTrue(),
+    // which only returns true for the boolean `true` value. Any other value
+    // (undefined, null, 1, 0, strings) yields the abbreviated cert.
     const args = callframe.arguments_old(1);
-    var detailed: bool = false;
-    if (args.len > 0) {
-        const arg = args.ptr[0];
-        if (!arg.isBoolean()) {
-            return globalObject.throw("Expected detailed to be a boolean", .{});
-        }
-        detailed = arg.toBoolean();
-    }
+    const detailed: bool = args.len > 0 and args.ptr[0] == .true;
 
     const ssl_ptr = this.socket.ssl() orelse return .js_undefined;
 
@@ -149,7 +146,8 @@ pub fn getPeerCertificate(this: *This, globalObject: *jsc.JSGlobalObject, callfr
 
     // Build the issuerCertificate chain. In Node.js, each cert's
     // issuerCertificate property points to the next cert in the chain,
-    // and the root CA's issuerCertificate points to itself.
+    // and the root CA's issuerCertificate points to itself (only when
+    // the cert is truly self-signed per X509_check_issued).
     const issuer_cert_key = jsc.ZigString.static("issuerCertificate");
 
     if (cert_chain) |chain| {
@@ -164,29 +162,34 @@ pub fn getPeerCertificate(this: *This, globalObject: *jsc.JSGlobalObject, callfr
             i -= 1;
             const chain_cert = BoringSSL.sk_X509_value(chain, i) orelse continue;
             const cert_obj = try X509.toJS(chain_cert, globalObject);
-            if (issuer_obj == .js_undefined) {
-                // Root cert: issuerCertificate points to itself
-                cert_obj.put(globalObject, issuer_cert_key, cert_obj);
-            } else {
+            if (issuer_obj != .js_undefined) {
                 cert_obj.put(globalObject, issuer_cert_key, issuer_obj);
+            } else if (BoringSSL.X509_check_issued(chain_cert, chain_cert) == BoringSSL.X509_V_OK) {
+                // Self-signed root: issuerCertificate points to itself.
+                cert_obj.put(globalObject, issuer_cert_key, cert_obj);
             }
+            // Otherwise the issuer is not in the sent chain; leave the
+            // property unset so callers can detect the end of the chain
+            // via `cert.issuerCertificate === undefined`, matching Node.js.
             issuer_obj = cert_obj;
         }
 
         // Build the peer cert object
         const peer_obj = try X509.toJS(first_cert.?, globalObject);
-        if (issuer_obj == .js_undefined) {
-            // Self-signed: issuerCertificate points to itself
-            peer_obj.put(globalObject, issuer_cert_key, peer_obj);
-        } else {
+        if (issuer_obj != .js_undefined) {
             peer_obj.put(globalObject, issuer_cert_key, issuer_obj);
+        } else if (BoringSSL.X509_check_issued(first_cert.?, first_cert.?) == BoringSSL.X509_V_OK) {
+            peer_obj.put(globalObject, issuer_cert_key, peer_obj);
         }
         return peer_obj;
     }
 
-    // No chain available, just return the peer cert with self-referencing issuer
+    // No chain available, just return the peer cert. Only self-reference
+    // when the cert is actually self-signed.
     const peer_obj = try X509.toJS(first_cert.?, globalObject);
-    peer_obj.put(globalObject, issuer_cert_key, peer_obj);
+    if (BoringSSL.X509_check_issued(first_cert.?, first_cert.?) == BoringSSL.X509_V_OK) {
+        peer_obj.put(globalObject, issuer_cert_key, peer_obj);
+    }
     return peer_obj;
 }
 

--- a/src/bun.js/api/bun/socket/tls_socket_functions.zig
+++ b/src/bun.js/api/bun/socket/tls_socket_functions.zig
@@ -120,8 +120,11 @@ pub fn getPeerCertificate(this: *This, globalObject: *jsc.JSGlobalObject, callfr
     if (!detailed) {
         // Abbreviated: return just the peer certificate
         if (this.isServer()) {
+            // SSL_get_peer_certificate increments the refcount; X509.toJS
+            // creates a non-owning view, so we must free it ourselves.
             const cert = BoringSSL.SSL_get_peer_certificate(ssl_ptr);
             if (cert) |x509| {
+                defer BoringSSL.X509_free(x509);
                 return X509.toJS(x509, globalObject);
             }
         }
@@ -131,66 +134,118 @@ pub fn getPeerCertificate(this: *This, globalObject: *jsc.JSGlobalObject, callfr
         return X509.toJS(cert, globalObject);
     }
 
-    // Detailed: return peer certificate with issuerCertificate chain
-    var cert: ?*BoringSSL.X509 = null;
-    if (this.isServer()) {
-        cert = BoringSSL.SSL_get_peer_certificate(ssl_ptr);
-    }
+    // Detailed: return peer certificate with issuerCertificate chain.
+    // This mirrors Node.js's GetPeerCert/AddIssuerChainToObject/
+    // GetLastIssuedCert in src/crypto/crypto_common.cc.
 
-    const cert_chain = BoringSSL.SSL_get_peer_cert_chain(ssl_ptr);
-    const first_cert = if (cert) |c| c else if (cert_chain) |cc| BoringSSL.sk_X509_value(cc, 0) else null;
+    // SSL_get_peer_certificate increments the refcount; balance it on every
+    // exit path. Only non-null on the server side.
+    const leaf: ?*BoringSSL.X509 = if (this.isServer()) BoringSSL.SSL_get_peer_certificate(ssl_ptr) else null;
+    defer if (leaf) |l| BoringSSL.X509_free(l);
+    // SSL_get_peer_cert_chain does NOT transfer ownership.
+    const ssl_certs = BoringSSL.SSL_get_peer_cert_chain(ssl_ptr);
+    const chain_len: usize = if (ssl_certs) |c| BoringSSL.sk_X509_num(c) else 0;
 
-    if (first_cert == null) {
+    if (leaf == null and chain_len == 0) {
         return .js_undefined;
     }
 
-    // Build the issuerCertificate chain. In Node.js, each cert's
-    // issuerCertificate property points to the next cert in the chain,
-    // and the root CA's issuerCertificate points to itself (only when
-    // the cert is truly self-signed per X509_check_issued).
+    // Collect all peer-sent certs into a flat borrowed array so we can
+    // search by issuer (not array position) and mark entries consumed,
+    // mirroring Node's sk_X509_delete-based iteration without needing
+    // the OPENSSL_sk_delete symbol.
+    var sfa = std.heap.stackFallback(16 * @sizeOf(*BoringSSL.X509), bun.default_allocator);
+    const allocator = sfa.get();
+    const total = chain_len + @as(usize, if (leaf != null) 1 else 0);
+    const certs = try allocator.alloc(?*BoringSSL.X509, total);
+    defer allocator.free(certs);
+    {
+        var w: usize = 0;
+        if (leaf) |l| {
+            certs[w] = l;
+            w += 1;
+        }
+        var i: usize = 0;
+        while (i < chain_len) : (i += 1) {
+            certs[w] = BoringSSL.sk_X509_value(ssl_certs, i);
+            w += 1;
+        }
+    }
+
     const issuer_cert_key = jsc.ZigString.static("issuerCertificate");
 
-    if (cert_chain) |chain| {
-        const chain_len = BoringSSL.sk_X509_num(chain);
-        const start_idx: usize = if (cert != null) 0 else 1;
+    // `cert` tracks the tail of the chain we've linked so far. It is a
+    // borrowed pointer while walking `certs`; once we enter the trust-store
+    // fallback below it becomes owned (`cert_owned` tracks which).
+    var cert: *BoringSSL.X509 = certs[0] orelse return .js_undefined;
+    var cert_owned = false;
+    defer if (cert_owned) BoringSSL.X509_free(cert);
+    certs[0] = null; // consumed
 
-        // Build chain objects from the end (root) to the start (peer),
-        // so we can link each cert's issuerCertificate to the next.
-        var issuer_obj: JSValue = .js_undefined;
-        var i: usize = chain_len;
-        while (i > start_idx) {
-            i -= 1;
-            const chain_cert = BoringSSL.sk_X509_value(chain, i) orelse continue;
-            const cert_obj = try X509.toJS(chain_cert, globalObject);
-            if (issuer_obj != .js_undefined) {
-                cert_obj.put(globalObject, issuer_cert_key, issuer_obj);
-            } else if (BoringSSL.X509_check_issued(chain_cert, chain_cert) == BoringSSL.X509_V_OK) {
-                // Self-signed root: issuerCertificate points to itself.
-                cert_obj.put(globalObject, issuer_cert_key, cert_obj);
-            }
-            // Otherwise the issuer is not in the sent chain; leave the
-            // property unset so callers can detect the end of the chain
-            // via `cert.issuerCertificate === undefined`, matching Node.js.
-            issuer_obj = cert_obj;
-        }
+    const result = try X509.toJS(cert, globalObject);
+    var tail_obj = result;
 
-        // Build the peer cert object
-        const peer_obj = try X509.toJS(first_cert.?, globalObject);
-        if (issuer_obj != .js_undefined) {
-            peer_obj.put(globalObject, issuer_cert_key, issuer_obj);
-        } else if (BoringSSL.X509_check_issued(first_cert.?, first_cert.?) == BoringSSL.X509_V_OK) {
-            peer_obj.put(globalObject, issuer_cert_key, peer_obj);
+    // AddIssuerChainToObject: repeatedly search the remaining peer certs for
+    // the issuer of `cert` via X509_check_issued (not array position), so
+    // misordered chains link correctly. Mark matches consumed to terminate.
+    outer: while (true) {
+        for (certs, 0..) |maybe_ca, i| {
+            const ca = maybe_ca orelse continue;
+            if (BoringSSL.X509_check_issued(ca, cert) != BoringSSL.X509_V_OK) continue;
+
+            const ca_obj = try X509.toJS(ca, globalObject);
+            tail_obj.put(globalObject, issuer_cert_key, ca_obj);
+            tail_obj = ca_obj;
+
+            cert = ca;
+            certs[i] = null; // consumed
+            continue :outer;
         }
-        return peer_obj;
+        break; // no issuer found among the remaining peer-sent certs
     }
 
-    // No chain available, just return the peer cert. Only self-reference
-    // when the cert is actually self-signed.
-    const peer_obj = try X509.toJS(first_cert.?, globalObject);
-    if (BoringSSL.X509_check_issued(first_cert.?, first_cert.?) == BoringSSL.X509_V_OK) {
-        peer_obj.put(globalObject, issuer_cert_key, peer_obj);
+    // GetLastIssuedCert: if the peer chain stopped short of the root, try to
+    // extend it from the local trust store (the SSL_CTX's X509_STORE).
+    while (BoringSSL.X509_check_issued(cert, cert) != BoringSSL.X509_V_OK) {
+        const ca = issuerFromStore(ssl_ptr, cert) orelse break;
+        errdefer BoringSSL.X509_free(ca);
+
+        const ca_obj = try X509.toJS(ca, globalObject);
+        tail_obj.put(globalObject, issuer_cert_key, ca_obj);
+        tail_obj = ca_obj;
+
+        // Guard against the store returning the same cert (pointer- or
+        // value-equal), which would loop forever.
+        if (ca == cert or BoringSSL.X509_cmp(ca, cert) == 0) {
+            BoringSSL.X509_free(ca);
+            break;
+        }
+        if (cert_owned) BoringSSL.X509_free(cert);
+        cert = ca;
+        cert_owned = true;
     }
-    return peer_obj;
+
+    // If we reached a self-signed root, make its issuerCertificate point to
+    // itself. Otherwise leave it unset so callers can detect the chain end.
+    if (BoringSSL.X509_check_issued(cert, cert) == BoringSSL.X509_V_OK) {
+        tail_obj.put(globalObject, issuer_cert_key, tail_obj);
+    }
+
+    return result;
+}
+
+// Look up the issuer of `cert` in the SSL connection's configured trust
+// store. Returns an owned X509* (caller must X509_free), or null if not
+// found. Mirrors Node's SSL_CTX_get_issuer / ncrypto X509Pointer::IssuerFrom.
+fn issuerFromStore(ssl: *BoringSSL.SSL, cert: *BoringSSL.X509) ?*BoringSSL.X509 {
+    const ssl_ctx = BoringSSL.SSL_get_SSL_CTX(ssl) orelse return null;
+    const store = BoringSSL.SSL_CTX_get_cert_store(ssl_ctx) orelse return null;
+    const store_ctx = BoringSSL.X509_STORE_CTX_new() orelse return null;
+    defer BoringSSL.X509_STORE_CTX_free(store_ctx);
+    if (BoringSSL.X509_STORE_CTX_init(store_ctx, store, null, null) == 0) return null;
+    var issuer: ?*BoringSSL.X509 = null;
+    if (BoringSSL.X509_STORE_CTX_get1_issuer(&issuer, store_ctx, cert) <= 0) return null;
+    return issuer;
 }
 
 pub fn getCertificate(this: *This, globalObject: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {

--- a/src/bun.js/api/bun/socket/tls_socket_functions.zig
+++ b/src/bun.js/api/bun/socket/tls_socket_functions.zig
@@ -105,19 +105,23 @@ pub fn setMaxSendFragment(this: *This, globalObject: *jsc.JSGlobalObject, callfr
 pub fn getPeerCertificate(this: *This, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
     jsc.markBinding(@src());
 
+    // Node.js API: getPeerCertificate([detailed])
+    // detailed=false (default): returns abbreviated cert (just the peer cert)
+    // detailed=true: returns cert with issuerCertificate chain
     const args = callframe.arguments_old(1);
-    var abbreviated: bool = true;
+    var detailed: bool = false;
     if (args.len > 0) {
         const arg = args.ptr[0];
         if (!arg.isBoolean()) {
-            return globalObject.throw("Expected abbreviated to be a boolean", .{});
+            return globalObject.throw("Expected detailed to be a boolean", .{});
         }
-        abbreviated = arg.toBoolean();
+        detailed = arg.toBoolean();
     }
 
     const ssl_ptr = this.socket.ssl() orelse return .js_undefined;
 
-    if (abbreviated) {
+    if (!detailed) {
+        // Abbreviated: return just the peer certificate
         if (this.isServer()) {
             const cert = BoringSSL.SSL_get_peer_certificate(ssl_ptr);
             if (cert) |x509| {
@@ -129,6 +133,8 @@ pub fn getPeerCertificate(this: *This, globalObject: *jsc.JSGlobalObject, callfr
         const cert = BoringSSL.sk_X509_value(cert_chain, 0) orelse return .js_undefined;
         return X509.toJS(cert, globalObject);
     }
+
+    // Detailed: return peer certificate with issuerCertificate chain
     var cert: ?*BoringSSL.X509 = null;
     if (this.isServer()) {
         cert = BoringSSL.SSL_get_peer_certificate(ssl_ptr);
@@ -141,8 +147,47 @@ pub fn getPeerCertificate(this: *This, globalObject: *jsc.JSGlobalObject, callfr
         return .js_undefined;
     }
 
-    // TODO: we need to support the non abbreviated version of this
-    return .js_undefined;
+    // Build the issuerCertificate chain. In Node.js, each cert's
+    // issuerCertificate property points to the next cert in the chain,
+    // and the root CA's issuerCertificate points to itself.
+    const issuer_cert_key = jsc.ZigString.static("issuerCertificate");
+
+    if (cert_chain) |chain| {
+        const chain_len = BoringSSL.sk_X509_num(chain);
+        const start_idx: usize = if (cert != null) 0 else 1;
+
+        // Build chain objects from the end (root) to the start (peer),
+        // so we can link each cert's issuerCertificate to the next.
+        var issuer_obj: JSValue = .js_undefined;
+        var i: usize = chain_len;
+        while (i > start_idx) {
+            i -= 1;
+            const chain_cert = BoringSSL.sk_X509_value(chain, i) orelse continue;
+            const cert_obj = try X509.toJS(chain_cert, globalObject);
+            if (issuer_obj == .js_undefined) {
+                // Root cert: issuerCertificate points to itself
+                cert_obj.put(globalObject, issuer_cert_key, cert_obj);
+            } else {
+                cert_obj.put(globalObject, issuer_cert_key, issuer_obj);
+            }
+            issuer_obj = cert_obj;
+        }
+
+        // Build the peer cert object
+        const peer_obj = try X509.toJS(first_cert.?, globalObject);
+        if (issuer_obj == .js_undefined) {
+            // Self-signed: issuerCertificate points to itself
+            peer_obj.put(globalObject, issuer_cert_key, peer_obj);
+        } else {
+            peer_obj.put(globalObject, issuer_cert_key, issuer_obj);
+        }
+        return peer_obj;
+    }
+
+    // No chain available, just return the peer cert with self-referencing issuer
+    const peer_obj = try X509.toJS(first_cert.?, globalObject);
+    peer_obj.put(globalObject, issuer_cert_key, peer_obj);
+    return peer_obj;
 }
 
 pub fn getCertificate(this: *This, globalObject: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {

--- a/src/bun.js/api/bun/socket/tls_socket_functions.zig
+++ b/src/bun.js/api/bun/socket/tls_socket_functions.zig
@@ -105,20 +105,14 @@ pub fn setMaxSendFragment(this: *This, globalObject: *jsc.JSGlobalObject, callfr
 pub fn getPeerCertificate(this: *This, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
     jsc.markBinding(@src());
 
-    // Node.js API: getPeerCertificate([detailed])
-    // detailed=false (default): returns abbreviated cert (just the peer cert)
-    // detailed=true: returns cert with issuerCertificate chain
-    //
     // Node.js does not type-check the argument; it uses args[0]->IsTrue(),
-    // which only returns true for the boolean `true` value. Any other value
-    // (undefined, null, 1, 0, strings) yields the abbreviated cert.
+    // so only boolean `true` yields the detailed chain.
     const args = callframe.arguments_old(1);
     const detailed: bool = args.len > 0 and args.ptr[0] == .true;
 
     const ssl_ptr = this.socket.ssl() orelse return .js_undefined;
 
     if (!detailed) {
-        // Abbreviated: return just the peer certificate
         if (this.isServer()) {
             // SSL_get_peer_certificate increments the refcount; X509.toJS
             // creates a non-owning view, so we must free it ourselves.
@@ -134,12 +128,8 @@ pub fn getPeerCertificate(this: *This, globalObject: *jsc.JSGlobalObject, callfr
         return X509.toJS(cert, globalObject);
     }
 
-    // Detailed: return peer certificate with issuerCertificate chain.
-    // This mirrors Node.js's GetPeerCert/AddIssuerChainToObject/
-    // GetLastIssuedCert in src/crypto/crypto_common.cc.
-
-    // SSL_get_peer_certificate increments the refcount; balance it on every
-    // exit path. Only non-null on the server side.
+    // Detailed chain. Mirrors Node.js GetPeerCert in src/crypto/crypto_common.cc.
+    // SSL_get_peer_certificate bumps the refcount; balance it on every exit.
     const leaf: ?*BoringSSL.X509 = if (this.isServer()) BoringSSL.SSL_get_peer_certificate(ssl_ptr) else null;
     defer if (leaf) |l| BoringSSL.X509_free(l);
     // SSL_get_peer_cert_chain does NOT transfer ownership.
@@ -151,9 +141,7 @@ pub fn getPeerCertificate(this: *This, globalObject: *jsc.JSGlobalObject, callfr
     }
 
     // Collect all peer-sent certs into a flat borrowed array so we can
-    // search by issuer (not array position) and mark entries consumed,
-    // mirroring Node's sk_X509_delete-based iteration without needing
-    // the OPENSSL_sk_delete symbol.
+    // search by issuer (not position) and mark entries consumed.
     var sfa = std.heap.stackFallback(16 * @sizeOf(*BoringSSL.X509), bun.default_allocator);
     const allocator = sfa.get();
     const total = chain_len + @as(usize, if (leaf != null) 1 else 0);
@@ -185,9 +173,7 @@ pub fn getPeerCertificate(this: *This, globalObject: *jsc.JSGlobalObject, callfr
     const result = try X509.toJS(cert, globalObject);
     var tail_obj = result;
 
-    // AddIssuerChainToObject: repeatedly search the remaining peer certs for
-    // the issuer of `cert` via X509_check_issued (not array position), so
-    // misordered chains link correctly. Mark matches consumed to terminate.
+    // Link issuers from the peer-sent set (handles misordered chains).
     outer: while (true) {
         for (certs, 0..) |maybe_ca, i| {
             const ca = maybe_ca orelse continue;
@@ -201,11 +187,10 @@ pub fn getPeerCertificate(this: *This, globalObject: *jsc.JSGlobalObject, callfr
             certs[i] = null; // consumed
             continue :outer;
         }
-        break; // no issuer found among the remaining peer-sent certs
+        break;
     }
 
-    // GetLastIssuedCert: if the peer chain stopped short of the root, try to
-    // extend it from the local trust store (the SSL_CTX's X509_STORE).
+    // If still not at a root, try to extend from the local trust store.
     while (BoringSSL.X509_check_issued(cert, cert) != BoringSSL.X509_V_OK) {
         const ca = issuerFromStore(ssl_ptr, cert) orelse break;
         errdefer BoringSSL.X509_free(ca);
@@ -234,9 +219,8 @@ pub fn getPeerCertificate(this: *This, globalObject: *jsc.JSGlobalObject, callfr
     return result;
 }
 
-// Look up the issuer of `cert` in the SSL connection's configured trust
-// store. Returns an owned X509* (caller must X509_free), or null if not
-// found. Mirrors Node's SSL_CTX_get_issuer / ncrypto X509Pointer::IssuerFrom.
+// Look up the issuer of `cert` in the SSL connection's trust store.
+// Returns an owned X509* (caller must X509_free), or null if not found.
 fn issuerFromStore(ssl: *BoringSSL.SSL, cert: *BoringSSL.X509) ?*BoringSSL.X509 {
     const ssl_ctx = BoringSSL.SSL_get_SSL_CTX(ssl) orelse return null;
     const store = BoringSSL.SSL_CTX_get_cert_store(ssl_ctx) orelse return null;

--- a/src/deps/boringssl.translated.zig
+++ b/src/deps/boringssl.translated.zig
@@ -4752,6 +4752,7 @@ pub fn sk_X509_VERIFY_PARAM_deep_copy(arg_sk: ?*const struct_stack_st_X509_VERIF
     return @as(?*struct_stack_st_X509_VERIFY_PARAM, @ptrCast(sk_deep_copy(@as([*c]const _STACK, @ptrCast(@alignCast(sk))), &sk_X509_VERIFY_PARAM_call_copy_func, @as(OPENSSL_sk_copy_func, @ptrCast(@alignCast(copy_func))), &sk_X509_VERIFY_PARAM_call_free_func, @as(OPENSSL_sk_free_func, @ptrCast(@alignCast(free_func))))));
 }
 pub extern fn X509_check_ca(x: ?*X509) c_int;
+pub extern fn X509_check_issued(issuer: ?*X509, subject: ?*X509) c_int;
 pub const X509_STORE_CTX_verify_cb = ?*const fn (c_int, ?*X509_STORE_CTX) callconv(.c) c_int;
 pub const X509_STORE_CTX_verify_fn = ?*const fn (?*X509_STORE_CTX) callconv(.c) c_int;
 pub const X509_STORE_CTX_get_issuer_fn = ?*const fn ([*c]?*X509, ?*X509_STORE_CTX, ?*X509) callconv(.c) c_int;

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -655,10 +655,10 @@ TLSSocket.prototype.setSession = function setSession(session) {
   return this._handle?.setSession?.(session);
 };
 
-TLSSocket.prototype.getPeerCertificate = function getPeerCertificate(abbreviated) {
+TLSSocket.prototype.getPeerCertificate = function getPeerCertificate(detailed) {
   if (this._handle) {
     const cert =
-      arguments.length < 1 ? this._handle.getPeerCertificate?.() : this._handle.getPeerCertificate?.(abbreviated);
+      arguments.length < 1 ? this._handle.getPeerCertificate?.() : this._handle.getPeerCertificate?.(detailed);
     if (cert) {
       return translatePeerCertificate(cert);
     }

--- a/test/regression/issue/28262.test.ts
+++ b/test/regression/issue/28262.test.ts
@@ -126,6 +126,9 @@ test("getPeerCertificate(true) returns detailed cert with issuerCertificate", as
           expect(cert.issuerCertificate).toBeDefined();
           expect(typeof cert.issuerCertificate).toBe("object");
           expect(cert.issuerCertificate.subject.CN).toBe("ca1");
+          // ca1 is self-signed, so its issuerCertificate should point to itself.
+          // This is the Node.js convention for detecting the root of the chain.
+          expect(cert.issuerCertificate.issuerCertificate).toBe(cert.issuerCertificate);
           resolve();
         } catch (e) {
           reject(e);
@@ -188,6 +191,95 @@ test("getPeerCertificate(false) works with socket upgrade pattern (mariadb)", as
       tlsSocket.on("error", reject);
     });
     tcpSocket.on("error", reject);
+  });
+
+  await promise;
+});
+
+test("getPeerCertificate(true) does not self-reference non-self-signed leaf", async () => {
+  // Server sends only the leaf cert (no CA in the chain). The leaf is NOT
+  // self-signed, so per Node.js semantics issuerCertificate must be left
+  // unset rather than fabricated as a self-reference. This matters because
+  // code commonly walks the chain via `while (c !== c.issuerCertificate)`.
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+  const server = tls.createServer({ key: serverKey, cert: serverCert }, socket => {
+    socket.end();
+  });
+
+  server.listen(0, "127.0.0.1", () => {
+    const addr = server.address() as { port: number };
+    const socket = tls.connect(
+      {
+        host: "127.0.0.1",
+        port: addr.port,
+        ca: [caCert],
+        servername: "agent1",
+        checkServerIdentity: () => undefined,
+      },
+      () => {
+        try {
+          const cert = socket.getPeerCertificate(true);
+          expect(cert).toBeDefined();
+          expect(cert.subject.CN).toBe("agent1");
+          // agent1 is issued by ca1, not self-signed. Since ca1 wasn't sent
+          // in the chain, issuerCertificate should be undefined — never a
+          // self-reference on a non-self-signed cert.
+          expect(cert.issuerCertificate).not.toBe(cert);
+          resolve();
+        } catch (e) {
+          reject(e);
+        } finally {
+          socket.destroy();
+          server.close();
+        }
+      },
+    );
+    socket.on("error", reject);
+  });
+
+  await promise;
+});
+
+test("getPeerCertificate coerces non-boolean argument instead of throwing", async () => {
+  // Node.js never type-checks the `detailed` argument; it uses
+  // args[0]->IsTrue(). Passing undefined/null/0/1 must not throw.
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+  const server = tls.createServer({ key: serverKey, cert: serverCert }, socket => {
+    socket.end();
+  });
+
+  server.listen(0, "127.0.0.1", () => {
+    const addr = server.address() as { port: number };
+    const socket = tls.connect(
+      {
+        host: "127.0.0.1",
+        port: addr.port,
+        ca: [caCert],
+        servername: "agent1",
+        checkServerIdentity: () => undefined,
+      },
+      () => {
+        try {
+          for (const arg of [undefined, null, 0, 1, "", "true"]) {
+            // @ts-expect-error — intentionally passing wrong types
+            const cert = socket.getPeerCertificate(arg);
+            expect(cert).toBeDefined();
+            expect(cert.subject.CN).toBe("agent1");
+            // All non-`true` values yield the abbreviated cert (no chain).
+            expect(cert.issuerCertificate).toBeUndefined();
+          }
+          resolve();
+        } catch (e) {
+          reject(e);
+        } finally {
+          socket.destroy();
+          server.close();
+        }
+      },
+    );
+    socket.on("error", reject);
   });
 
   await promise;

--- a/test/regression/issue/28262.test.ts
+++ b/test/regression/issue/28262.test.ts
@@ -198,9 +198,10 @@ test("getPeerCertificate(false) works with socket upgrade pattern (mariadb)", as
 
 test("getPeerCertificate(true) does not self-reference non-self-signed leaf", async () => {
   // Server sends only the leaf cert (no CA in the chain). The leaf is NOT
-  // self-signed, so per Node.js semantics issuerCertificate must be left
-  // unset rather than fabricated as a self-reference. This matters because
-  // code commonly walks the chain via `while (c !== c.issuerCertificate)`.
+  // self-signed, so per Node.js semantics issuerCertificate must never be
+  // a self-reference here. Node.js additionally looks the issuer up in the
+  // client's local trust store and appends it. This matters because code
+  // commonly walks the chain via `while (c !== c.issuerCertificate)`.
   const { promise, resolve, reject } = Promise.withResolvers<void>();
 
   const server = tls.createServer({ key: serverKey, cert: serverCert }, socket => {
@@ -222,10 +223,14 @@ test("getPeerCertificate(true) does not self-reference non-self-signed leaf", as
           const cert = socket.getPeerCertificate(true);
           expect(cert).toBeDefined();
           expect(cert.subject.CN).toBe("agent1");
-          // agent1 is issued by ca1, not self-signed. Since ca1 wasn't sent
-          // in the chain, issuerCertificate should be undefined — never a
-          // self-reference on a non-self-signed cert.
+          // agent1 is issued by ca1, not self-signed — must never self-ref.
           expect(cert.issuerCertificate).not.toBe(cert);
+          // ca1 wasn't sent in the chain, but it IS in the client's trust
+          // store (via `ca: [caCert]`), so Node.js looks it up and links it.
+          expect(cert.issuerCertificate).toBeDefined();
+          expect(cert.issuerCertificate.subject.CN).toBe("ca1");
+          // ca1 is self-signed → its issuerCertificate points to itself.
+          expect(cert.issuerCertificate.issuerCertificate).toBe(cert.issuerCertificate);
           resolve();
         } catch (e) {
           reject(e);

--- a/test/regression/issue/28262.test.ts
+++ b/test/regression/issue/28262.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { once } from "node:events";
 import fs from "node:fs";
 import net from "node:net";
 import path from "node:path";
@@ -9,283 +10,135 @@ const serverCert = fs.readFileSync(path.join(fixturesDir, "agent1-cert.pem"));
 const serverKey = fs.readFileSync(path.join(fixturesDir, "agent1-key.pem"));
 const caCert = fs.readFileSync(path.join(fixturesDir, "ca1-cert.pem"));
 
+async function withTlsClient(check: (socket: tls.TLSSocket) => void, cert: Buffer = serverCert) {
+  const server = tls.createServer({ key: serverKey, cert }, s => s.end());
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  try {
+    const { port } = server.address() as net.AddressInfo;
+    const socket = tls.connect({
+      host: "127.0.0.1",
+      port,
+      ca: [caCert],
+      servername: "agent1",
+      checkServerIdentity: () => undefined,
+    });
+    await once(socket, "secureConnect");
+    try {
+      check(socket);
+    } finally {
+      socket.destroy();
+    }
+  } finally {
+    server.close();
+  }
+}
+
 test("getPeerCertificate(false) returns abbreviated cert with fingerprint256", async () => {
-  // This is the core regression: getPeerCertificate(false) should return the
-  // abbreviated peer cert (same as no args), NOT an empty object.
-  // The mariadb npm package calls getPeerCertificate(false) and accesses
-  // .fingerprint256, which broke when this started returning {}.
-  const { promise, resolve, reject } = Promise.withResolvers<void>();
-
-  const server = tls.createServer({ key: serverKey, cert: serverCert }, socket => {
-    socket.end();
+  // Core regression: getPeerCertificate(false) should return the abbreviated
+  // peer cert (same as no args), NOT an empty object. The mariadb npm package
+  // calls getPeerCertificate(false) and reads .fingerprint256.
+  await withTlsClient(socket => {
+    const cert = socket.getPeerCertificate(false);
+    expect(cert).toBeDefined();
+    expect(typeof cert).toBe("object");
+    expect(cert.subject.CN).toBe("agent1");
+    expect(typeof cert.fingerprint256).toBe("string");
+    expect(cert.fingerprint256).toContain(":");
   });
-
-  server.listen(0, "127.0.0.1", () => {
-    const addr = server.address() as { port: number };
-    const socket = tls.connect(
-      {
-        host: "127.0.0.1",
-        port: addr.port,
-        ca: [caCert],
-        servername: "agent1",
-        checkServerIdentity: () => undefined,
-      },
-      () => {
-        try {
-          const cert = socket.getPeerCertificate(false);
-          expect(cert).toBeDefined();
-          expect(typeof cert).toBe("object");
-          expect(cert.subject).toBeDefined();
-          expect(cert.subject.CN).toBe("agent1");
-          expect(cert.fingerprint256).toBeDefined();
-          expect(typeof cert.fingerprint256).toBe("string");
-          expect(cert.fingerprint256).toContain(":");
-          resolve();
-        } catch (e) {
-          reject(e);
-        } finally {
-          socket.destroy();
-          server.close();
-        }
-      },
-    );
-    socket.on("error", reject);
-  });
-
-  await promise;
 });
 
 test("getPeerCertificate() returns abbreviated cert (no args)", async () => {
-  const { promise, resolve, reject } = Promise.withResolvers<void>();
-
-  const server = tls.createServer({ key: serverKey, cert: serverCert }, socket => {
-    socket.end();
+  await withTlsClient(socket => {
+    const cert = socket.getPeerCertificate();
+    expect(cert).toBeDefined();
+    expect(cert.subject.CN).toBe("agent1");
+    expect(typeof cert.fingerprint256).toBe("string");
+    expect(cert.issuerCertificate).toBeUndefined();
   });
-
-  server.listen(0, "127.0.0.1", () => {
-    const addr = server.address() as { port: number };
-    const socket = tls.connect(
-      {
-        host: "127.0.0.1",
-        port: addr.port,
-        ca: [caCert],
-        servername: "agent1",
-        checkServerIdentity: () => undefined,
-      },
-      () => {
-        try {
-          const cert = socket.getPeerCertificate();
-          expect(cert).toBeDefined();
-          expect(cert.subject.CN).toBe("agent1");
-          expect(cert.fingerprint256).toBeDefined();
-          expect(typeof cert.fingerprint256).toBe("string");
-          // No issuerCertificate on abbreviated cert
-          expect(cert.issuerCertificate).toBeUndefined();
-          resolve();
-        } catch (e) {
-          reject(e);
-        } finally {
-          socket.destroy();
-          server.close();
-        }
-      },
-    );
-    socket.on("error", reject);
-  });
-
-  await promise;
 });
 
 test("getPeerCertificate(true) returns detailed cert with issuerCertificate", async () => {
-  const { promise, resolve, reject } = Promise.withResolvers<void>();
-
-  // Provide the full chain (server cert + CA cert) so the client receives
-  // the issuer certificate in the chain from the TLS handshake.
-  const fullChain = Buffer.concat([serverCert, caCert]);
-  const server = tls.createServer({ key: serverKey, cert: fullChain }, socket => {
-    socket.end();
-  });
-
-  server.listen(0, "127.0.0.1", () => {
-    const addr = server.address() as { port: number };
-    const socket = tls.connect(
-      {
-        host: "127.0.0.1",
-        port: addr.port,
-        ca: [caCert],
-        servername: "agent1",
-        checkServerIdentity: () => undefined,
-      },
-      () => {
-        try {
-          const cert = socket.getPeerCertificate(true);
-          expect(cert).toBeDefined();
-          expect(cert.subject.CN).toBe("agent1");
-          expect(cert.fingerprint256).toBeDefined();
-          // Detailed cert should have issuerCertificate
-          expect(cert.issuerCertificate).toBeDefined();
-          expect(typeof cert.issuerCertificate).toBe("object");
-          expect(cert.issuerCertificate.subject.CN).toBe("ca1");
-          // ca1 is self-signed, so its issuerCertificate should point to itself.
-          // This is the Node.js convention for detecting the root of the chain.
-          expect(cert.issuerCertificate.issuerCertificate).toBe(cert.issuerCertificate);
-          resolve();
-        } catch (e) {
-          reject(e);
-        } finally {
-          socket.destroy();
-          server.close();
-        }
-      },
-    );
-    socket.on("error", reject);
-  });
-
-  await promise;
+  // Server sends the full chain (leaf + CA) so the client receives the issuer
+  // certificate from the handshake.
+  await withTlsClient(
+    socket => {
+      const cert = socket.getPeerCertificate(true);
+      expect(cert).toBeDefined();
+      expect(cert.subject.CN).toBe("agent1");
+      expect(cert.fingerprint256).toBeDefined();
+      expect(cert.issuerCertificate).toBeDefined();
+      expect(typeof cert.issuerCertificate).toBe("object");
+      expect(cert.issuerCertificate.subject.CN).toBe("ca1");
+      // ca1 is self-signed, so its issuerCertificate points to itself (Node.js
+      // convention for detecting the root of the chain).
+      expect(cert.issuerCertificate.issuerCertificate).toBe(cert.issuerCertificate);
+    },
+    Buffer.concat([serverCert, caCert]),
+  );
 });
 
 test("getPeerCertificate(false) works with socket upgrade pattern (mariadb)", async () => {
-  // This simulates the exact pattern used by the mariadb npm package:
-  // 1. Connect via TCP
-  // 2. Upgrade to TLS using tls.connect({ socket })
-  // 3. Call getPeerCertificate(false) and access fingerprint256
-  const { promise, resolve, reject } = Promise.withResolvers<void>();
-
-  const server = tls.createServer({ key: serverKey, cert: serverCert }, socket => {
-    socket.end();
-  });
-
-  server.listen(0, "127.0.0.1", () => {
-    const addr = server.address() as { port: number };
-
-    // Step 1: Plain TCP connection
-    const tcpSocket = net.connect({ host: "127.0.0.1", port: addr.port }, () => {
-      // Step 2: Upgrade to TLS (mariadb pattern - no servername, no host)
-      const tlsSocket = tls.connect(
-        {
-          socket: tcpSocket,
-          ca: [caCert],
-          checkServerIdentity: () => undefined,
-        },
-        () => {
-          try {
-            // Step 3: mariadb driver fingerprint check
-            const serverCertObj = tlsSocket.getPeerCertificate(false);
-            expect(serverCertObj).toBeDefined();
-            expect(typeof serverCertObj).toBe("object");
-
-            // This is the exact code pattern from the mariadb driver that broke:
-            const fingerprint = serverCertObj ? serverCertObj.fingerprint256.replace(/:/gi, "").toLowerCase() : null;
-            expect(fingerprint).toBeDefined();
-            expect(typeof fingerprint).toBe("string");
-            expect(fingerprint!.length).toBe(64); // SHA256 = 32 bytes = 64 hex chars
-            resolve();
-          } catch (e) {
-            reject(e);
-          } finally {
-            tlsSocket.destroy();
-            server.close();
-          }
-        },
-      );
-      tlsSocket.on("error", reject);
-    });
-    tcpSocket.on("error", reject);
-  });
-
-  await promise;
+  // Simulate the mariadb npm package pattern: plain TCP connect, then upgrade
+  // to TLS via tls.connect({ socket }), then getPeerCertificate(false) and
+  // read .fingerprint256.
+  const server = tls.createServer({ key: serverKey, cert: serverCert }, s => s.end());
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  try {
+    const { port } = server.address() as net.AddressInfo;
+    const tcpSocket = net.connect({ host: "127.0.0.1", port });
+    await once(tcpSocket, "connect");
+    // Upgrade to TLS (mariadb pattern — no servername, no host)
+    const tlsSocket = tls.connect({ socket: tcpSocket, ca: [caCert], checkServerIdentity: () => undefined });
+    await once(tlsSocket, "secureConnect");
+    try {
+      const serverCertObj = tlsSocket.getPeerCertificate(false);
+      expect(typeof serverCertObj).toBe("object");
+      // Exact mariadb driver code path that broke:
+      const fingerprint = serverCertObj ? serverCertObj.fingerprint256.replace(/:/gi, "").toLowerCase() : null;
+      expect(typeof fingerprint).toBe("string");
+      expect(fingerprint!.length).toBe(64); // SHA256 = 32 bytes = 64 hex chars
+    } finally {
+      tlsSocket.destroy();
+    }
+  } finally {
+    server.close();
+  }
 });
 
 test("getPeerCertificate(true) does not self-reference non-self-signed leaf", async () => {
   // Server sends only the leaf cert (no CA in the chain). The leaf is NOT
-  // self-signed, so per Node.js semantics issuerCertificate must never be
-  // a self-reference here. Node.js additionally looks the issuer up in the
-  // client's local trust store and appends it. This matters because code
-  // commonly walks the chain via `while (c !== c.issuerCertificate)`.
-  const { promise, resolve, reject } = Promise.withResolvers<void>();
-
-  const server = tls.createServer({ key: serverKey, cert: serverCert }, socket => {
-    socket.end();
+  // self-signed, so per Node.js semantics issuerCertificate must never be a
+  // self-reference. Node.js additionally looks the issuer up in the client's
+  // local trust store and appends it. This matters because code commonly
+  // walks the chain via `while (c !== c.issuerCertificate)`.
+  await withTlsClient(socket => {
+    const cert = socket.getPeerCertificate(true);
+    expect(cert).toBeDefined();
+    expect(cert.subject.CN).toBe("agent1");
+    // agent1 is issued by ca1, not self-signed — must never self-ref.
+    expect(cert.issuerCertificate).not.toBe(cert);
+    // ca1 wasn't sent in the chain, but it IS in the client's trust store
+    // (via `ca: [caCert]`), so Node.js looks it up and links it.
+    expect(cert.issuerCertificate).toBeDefined();
+    expect(cert.issuerCertificate.subject.CN).toBe("ca1");
+    // ca1 is self-signed → its issuerCertificate points to itself.
+    expect(cert.issuerCertificate.issuerCertificate).toBe(cert.issuerCertificate);
   });
-
-  server.listen(0, "127.0.0.1", () => {
-    const addr = server.address() as { port: number };
-    const socket = tls.connect(
-      {
-        host: "127.0.0.1",
-        port: addr.port,
-        ca: [caCert],
-        servername: "agent1",
-        checkServerIdentity: () => undefined,
-      },
-      () => {
-        try {
-          const cert = socket.getPeerCertificate(true);
-          expect(cert).toBeDefined();
-          expect(cert.subject.CN).toBe("agent1");
-          // agent1 is issued by ca1, not self-signed — must never self-ref.
-          expect(cert.issuerCertificate).not.toBe(cert);
-          // ca1 wasn't sent in the chain, but it IS in the client's trust
-          // store (via `ca: [caCert]`), so Node.js looks it up and links it.
-          expect(cert.issuerCertificate).toBeDefined();
-          expect(cert.issuerCertificate.subject.CN).toBe("ca1");
-          // ca1 is self-signed → its issuerCertificate points to itself.
-          expect(cert.issuerCertificate.issuerCertificate).toBe(cert.issuerCertificate);
-          resolve();
-        } catch (e) {
-          reject(e);
-        } finally {
-          socket.destroy();
-          server.close();
-        }
-      },
-    );
-    socket.on("error", reject);
-  });
-
-  await promise;
 });
 
 test("getPeerCertificate coerces non-boolean argument instead of throwing", async () => {
   // Node.js never type-checks the `detailed` argument; it uses
   // args[0]->IsTrue(). Passing undefined/null/0/1 must not throw.
-  const { promise, resolve, reject } = Promise.withResolvers<void>();
-
-  const server = tls.createServer({ key: serverKey, cert: serverCert }, socket => {
-    socket.end();
+  await withTlsClient(socket => {
+    for (const arg of [undefined, null, 0, 1, "", "true"]) {
+      // @ts-expect-error — intentionally passing wrong types
+      const cert = socket.getPeerCertificate(arg);
+      expect(cert).toBeDefined();
+      expect(cert.subject.CN).toBe("agent1");
+      // All non-`true` values yield the abbreviated cert (no chain).
+      expect(cert.issuerCertificate).toBeUndefined();
+    }
   });
-
-  server.listen(0, "127.0.0.1", () => {
-    const addr = server.address() as { port: number };
-    const socket = tls.connect(
-      {
-        host: "127.0.0.1",
-        port: addr.port,
-        ca: [caCert],
-        servername: "agent1",
-        checkServerIdentity: () => undefined,
-      },
-      () => {
-        try {
-          for (const arg of [undefined, null, 0, 1, "", "true"]) {
-            // @ts-expect-error — intentionally passing wrong types
-            const cert = socket.getPeerCertificate(arg);
-            expect(cert).toBeDefined();
-            expect(cert.subject.CN).toBe("agent1");
-            // All non-`true` values yield the abbreviated cert (no chain).
-            expect(cert.issuerCertificate).toBeUndefined();
-          }
-          resolve();
-        } catch (e) {
-          reject(e);
-        } finally {
-          socket.destroy();
-          server.close();
-        }
-      },
-    );
-    socket.on("error", reject);
-  });
-
-  await promise;
 });

--- a/test/regression/issue/28262.test.ts
+++ b/test/regression/issue/28262.test.ts
@@ -1,8 +1,8 @@
-import { test, expect } from "bun:test";
-import net from "node:net";
-import tls from "node:tls";
+import { expect, test } from "bun:test";
 import fs from "node:fs";
+import net from "node:net";
 import path from "node:path";
+import tls from "node:tls";
 
 const fixturesDir = path.join(import.meta.dirname, "../../js/node/tls/fixtures");
 const serverCert = fs.readFileSync(path.join(fixturesDir, "agent1-cert.pem"));

--- a/test/regression/issue/28262.test.ts
+++ b/test/regression/issue/28262.test.ts
@@ -1,0 +1,194 @@
+import { test, expect } from "bun:test";
+import net from "node:net";
+import tls from "node:tls";
+import fs from "node:fs";
+import path from "node:path";
+
+const fixturesDir = path.join(import.meta.dirname, "../../js/node/tls/fixtures");
+const serverCert = fs.readFileSync(path.join(fixturesDir, "agent1-cert.pem"));
+const serverKey = fs.readFileSync(path.join(fixturesDir, "agent1-key.pem"));
+const caCert = fs.readFileSync(path.join(fixturesDir, "ca1-cert.pem"));
+
+test("getPeerCertificate(false) returns abbreviated cert with fingerprint256", async () => {
+  // This is the core regression: getPeerCertificate(false) should return the
+  // abbreviated peer cert (same as no args), NOT an empty object.
+  // The mariadb npm package calls getPeerCertificate(false) and accesses
+  // .fingerprint256, which broke when this started returning {}.
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+  const server = tls.createServer({ key: serverKey, cert: serverCert }, socket => {
+    socket.end();
+  });
+
+  server.listen(0, "127.0.0.1", () => {
+    const addr = server.address() as { port: number };
+    const socket = tls.connect(
+      {
+        host: "127.0.0.1",
+        port: addr.port,
+        ca: [caCert],
+        servername: "agent1",
+        checkServerIdentity: () => undefined,
+      },
+      () => {
+        try {
+          const cert = socket.getPeerCertificate(false);
+          expect(cert).toBeDefined();
+          expect(typeof cert).toBe("object");
+          expect(cert.subject).toBeDefined();
+          expect(cert.subject.CN).toBe("agent1");
+          expect(cert.fingerprint256).toBeDefined();
+          expect(typeof cert.fingerprint256).toBe("string");
+          expect(cert.fingerprint256).toContain(":");
+          resolve();
+        } catch (e) {
+          reject(e);
+        } finally {
+          socket.destroy();
+          server.close();
+        }
+      },
+    );
+    socket.on("error", reject);
+  });
+
+  await promise;
+});
+
+test("getPeerCertificate() returns abbreviated cert (no args)", async () => {
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+  const server = tls.createServer({ key: serverKey, cert: serverCert }, socket => {
+    socket.end();
+  });
+
+  server.listen(0, "127.0.0.1", () => {
+    const addr = server.address() as { port: number };
+    const socket = tls.connect(
+      {
+        host: "127.0.0.1",
+        port: addr.port,
+        ca: [caCert],
+        servername: "agent1",
+        checkServerIdentity: () => undefined,
+      },
+      () => {
+        try {
+          const cert = socket.getPeerCertificate();
+          expect(cert).toBeDefined();
+          expect(cert.subject.CN).toBe("agent1");
+          expect(cert.fingerprint256).toBeDefined();
+          expect(typeof cert.fingerprint256).toBe("string");
+          // No issuerCertificate on abbreviated cert
+          expect(cert.issuerCertificate).toBeUndefined();
+          resolve();
+        } catch (e) {
+          reject(e);
+        } finally {
+          socket.destroy();
+          server.close();
+        }
+      },
+    );
+    socket.on("error", reject);
+  });
+
+  await promise;
+});
+
+test("getPeerCertificate(true) returns detailed cert with issuerCertificate", async () => {
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+  // Provide the full chain (server cert + CA cert) so the client receives
+  // the issuer certificate in the chain from the TLS handshake.
+  const fullChain = Buffer.concat([serverCert, caCert]);
+  const server = tls.createServer({ key: serverKey, cert: fullChain }, socket => {
+    socket.end();
+  });
+
+  server.listen(0, "127.0.0.1", () => {
+    const addr = server.address() as { port: number };
+    const socket = tls.connect(
+      {
+        host: "127.0.0.1",
+        port: addr.port,
+        ca: [caCert],
+        servername: "agent1",
+        checkServerIdentity: () => undefined,
+      },
+      () => {
+        try {
+          const cert = socket.getPeerCertificate(true);
+          expect(cert).toBeDefined();
+          expect(cert.subject.CN).toBe("agent1");
+          expect(cert.fingerprint256).toBeDefined();
+          // Detailed cert should have issuerCertificate
+          expect(cert.issuerCertificate).toBeDefined();
+          expect(typeof cert.issuerCertificate).toBe("object");
+          expect(cert.issuerCertificate.subject.CN).toBe("ca1");
+          resolve();
+        } catch (e) {
+          reject(e);
+        } finally {
+          socket.destroy();
+          server.close();
+        }
+      },
+    );
+    socket.on("error", reject);
+  });
+
+  await promise;
+});
+
+test("getPeerCertificate(false) works with socket upgrade pattern (mariadb)", async () => {
+  // This simulates the exact pattern used by the mariadb npm package:
+  // 1. Connect via TCP
+  // 2. Upgrade to TLS using tls.connect({ socket })
+  // 3. Call getPeerCertificate(false) and access fingerprint256
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+  const server = tls.createServer({ key: serverKey, cert: serverCert }, socket => {
+    socket.end();
+  });
+
+  server.listen(0, "127.0.0.1", () => {
+    const addr = server.address() as { port: number };
+
+    // Step 1: Plain TCP connection
+    const tcpSocket = net.connect({ host: "127.0.0.1", port: addr.port }, () => {
+      // Step 2: Upgrade to TLS (mariadb pattern - no servername, no host)
+      const tlsSocket = tls.connect(
+        {
+          socket: tcpSocket,
+          ca: [caCert],
+          checkServerIdentity: () => undefined,
+        },
+        () => {
+          try {
+            // Step 3: mariadb driver fingerprint check
+            const serverCertObj = tlsSocket.getPeerCertificate(false);
+            expect(serverCertObj).toBeDefined();
+            expect(typeof serverCertObj).toBe("object");
+
+            // This is the exact code pattern from the mariadb driver that broke:
+            const fingerprint = serverCertObj ? serverCertObj.fingerprint256.replace(/:/gi, "").toLowerCase() : null;
+            expect(fingerprint).toBeDefined();
+            expect(typeof fingerprint).toBe("string");
+            expect(fingerprint!.length).toBe(64); // SHA256 = 32 bytes = 64 hex chars
+            resolve();
+          } catch (e) {
+            reject(e);
+          } finally {
+            tlsSocket.destroy();
+            server.close();
+          }
+        },
+      );
+      tlsSocket.on("error", reject);
+    });
+    tcpSocket.on("error", reject);
+  });
+
+  await promise;
+});


### PR DESCRIPTION
## Summary

- Fix inverted argument semantics in `getPeerCertificate` native implementation — the boolean was treated as `abbreviated` when Node.js uses `detailed` (the opposite)
- `getPeerCertificate(false)` now correctly returns the abbreviated peer cert (same as no args), matching Node.js behavior
- Implement `getPeerCertificate(true)` detailed mode with `issuerCertificate` chain support

## Root cause

The `getPeerCertificate` native code (Zig) used a variable called `abbreviated` that directly received the JS argument. But Node.js's API parameter is `detailed` — the opposite meaning. So `getPeerCertificate(false)` ("not detailed" = abbreviated) was interpreted as `abbreviated=false`, hitting the unimplemented TODO path that returned `undefined`. The JS wrapper (changed in #27135) then converted `undefined` to `{}`.

The mariadb npm package calls `getPeerCertificate(false)` and does:
```js
serverCert.fingerprint256.replace(/:/gi, '').toLowerCase()
```
With `{}` being truthy, this crashes with `TypeError: undefined is not an object`, silently killing all MySQL/MariaDB SSL connections.

Closes #28262

## Test plan

- [x] New regression test `test/regression/issue/28262.test.ts` with 4 tests:
  - `getPeerCertificate(false)` returns abbreviated cert with fingerprint256
  - `getPeerCertificate()` (no args) returns abbreviated cert
  - `getPeerCertificate(true)` returns detailed cert with issuerCertificate chain
  - Socket upgrade pattern (mariadb driver pattern) works with `getPeerCertificate(false)`
- [x] Tests fail with `USE_SYSTEM_BUN=1` (3 of 4 fail), pass with debug build (4/4 pass)
- [x] Existing `test/regression/issue/24374.test.ts` continues to pass (4/4)
- [x] Existing `test/js/node/tls/node-tls-cert.test.ts` continues to pass (23/23, 2 pre-existing timeout failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)