### PR TITLE
fix(http): allow Latin-1 extended chars in header values for UTF-16 strings

### DIFF
--- a/src/bun.js/bindings/webcore/HTTPParsers.cpp
+++ b/src/bun.js/bindings/webcore/HTTPParsers.cpp
@@ -140,7 +140,7 @@ bool isValidHTTPHeaderValue(const StringView& value)
     } else {
         for (unsigned i = 0; i < value.length(); ++i) {
             c = value[i];
-            if (c == 0x00 || c == 0x0A || c == 0x0D || c > 0x7F)
+            if (c == 0x00 || c == 0x0A || c == 0x0D || c > 0xFF)
                 return false;
         }
     }

--- a/test/regression/issue/28266.test.ts
+++ b/test/regression/issue/28266.test.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "bun:test";
+import { basename, join, normalize, resolve } from "path";
+
+// https://github.com/oven-sh/bun/issues/28266
+// path.basename (and other path functions) internally converts Latin-1 strings
+// to UTF-16, which previously caused header validation to reject them.
+
+test("path.basename result with non-ASCII Latin-1 chars can be used as header value", () => {
+  const original = "ý.txt";
+  const fromBasename = basename(original);
+
+  expect(original).toBe(fromBasename);
+
+  const res = new Response("hello", {
+    headers: {
+      "X-Original": original,
+      "X-Basename": fromBasename,
+    },
+  });
+
+  expect(res.headers.get("X-Original")).toBe("ý.txt");
+  expect(res.headers.get("X-Basename")).toBe("ý.txt");
+});
+
+test("path.join result with non-ASCII Latin-1 chars can be used as header value", () => {
+  const result = join("ý.txt");
+  const res = new Response("hello", {
+    headers: { "X-Test": result },
+  });
+  expect(res.headers.get("X-Test")).toBe("ý.txt");
+});
+
+test("path.normalize result with non-ASCII Latin-1 chars can be used as header value", () => {
+  const result = normalize("ý.txt");
+  const res = new Response("hello", {
+    headers: { "X-Test": result },
+  });
+  expect(res.headers.get("X-Test")).toBe("ý.txt");
+});
+
+test("various Latin-1 extended chars work as header values after path functions", () => {
+  // Test multiple Latin-1 extended characters (0x80-0xFF range)
+  const chars = ["é", "ñ", "ü", "ß", "ø", "å", "ý"];
+  for (const ch of chars) {
+    const filename = `${ch}.txt`;
+    const result = basename(filename);
+    const res = new Response("hello", {
+      headers: { "X-Test": result },
+    });
+    expect(res.headers.get("X-Test")).toBe(filename);
+  }
+});

--- a/test/regression/issue/28266.test.ts
+++ b/test/regression/issue/28266.test.ts
@@ -40,7 +40,7 @@ test("path.normalize result with non-ASCII Latin-1 chars can be used as header v
 
 test("various Latin-1 extended chars work as header values after path functions", () => {
   // Test multiple Latin-1 extended characters (0x80-0xFF range)
-  const chars = ["é", "ñ", "ü", "ß", "ø", "å", "ý"];
+  const chars = ["\x80", "é", "ñ", "ü", "ß", "ø", "å", "ý", "\xFF"];
   for (const ch of chars) {
     const filename = `${ch}.txt`;
     const result = basename(filename);

--- a/test/regression/issue/28266.test.ts
+++ b/test/regression/issue/28266.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { basename, join, normalize, resolve } from "path";
+import { expect, test } from "bun:test";
+import { basename, join, normalize } from "path";
 
 // https://github.com/oven-sh/bun/issues/28266
 // path.basename (and other path functions) internally converts Latin-1 strings


### PR DESCRIPTION
## Summary
- Fix inconsistent HTTP header value validation between 8-bit and 16-bit string code paths in `isValidHTTPHeaderValue`
- The 16-bit path rejected Latin-1 extended characters (0x80-0xFF range like `ý`, `é`, `ñ`) while the 8-bit path correctly allowed them
- This caused strings returned by `path.basename` (and other `node:path` functions) to be rejected as header values because they get internally converted from Latin-1 to UTF-16

## Test plan
- [x] Added regression test `test/regression/issue/28266.test.ts` covering `basename`, `join`, `normalize` with various Latin-1 extended characters
- [x] Verified test fails with system bun (4/4 fail) and passes with debug build (4/4 pass)
- [x] Node.js correctly allows these values, confirming this is a Bun-specific bug

Closes #28266

🤖 Generated with [Claude Code](https://claude.com/claude-code)