### PR TITLE
fix(repl): distinguish thrown values from expression results with 'Uncaught' prefix

### DIFF
--- a/src/repl.zig
+++ b/src/repl.zig
@@ -1079,7 +1079,7 @@ fn evaluateAndPrint(self: *Repl, code: []const u8) void {
     defer self.allocator.free(transformed_code);
 
     // Evaluate the transformed code
-    var exception: jsc.JSValue = .js_undefined;
+    var exception: jsc.JSValue = .zero;
     const result = Bun__REPL__evaluate(
         global,
         transformed_code.ptr,
@@ -1089,8 +1089,8 @@ fn evaluateAndPrint(self: *Repl, code: []const u8) void {
         &exception,
     );
 
-    // Check for exception
-    if (!exception.isUndefined() and !exception.isNull()) {
+    // Check for exception (use .zero sentinel so throw null/undefined are detected)
+    if (exception != .zero) {
         self.setLastError(exception);
         self.printJSError(exception);
         return;
@@ -1210,16 +1210,16 @@ pub fn evalScript(self: *Repl, code: []const u8, print_result: bool) bool {
 
     const transformed_code = self.transformForRepl(code) orelse {
         // Transform failed — fall back to raw evaluation for the error message
-        var exception: jsc.JSValue = .js_undefined;
+        var exception: jsc.JSValue = .zero;
         _ = Bun__REPL__evaluate(global, code.ptr, code.len, "[eval]".ptr, "[eval]".len, &exception);
-        if (!exception.isUndefined() and !exception.isNull()) {
+        if (exception != .zero) {
             self.printJSErrorTo(exception, Output.errorWriter(), stderr_colors);
         }
         return true;
     };
     defer self.allocator.free(transformed_code);
 
-    var exception: jsc.JSValue = .js_undefined;
+    var exception: jsc.JSValue = .zero;
     const result = Bun__REPL__evaluate(
         global,
         transformed_code.ptr,
@@ -1229,7 +1229,7 @@ pub fn evalScript(self: *Repl, code: []const u8, print_result: bool) bool {
         &exception,
     );
 
-    if (!exception.isUndefined() and !exception.isNull()) {
+    if (exception != .zero) {
         self.printJSErrorTo(exception, Output.errorWriter(), stderr_colors);
         return true;
     }
@@ -1291,7 +1291,7 @@ pub fn evalScript(self: *Repl, code: []const u8, print_result: bool) bool {
 fn evaluateRaw(self: *Repl, code: []const u8) void {
     const global = self.global orelse return;
 
-    var exception: jsc.JSValue = .js_undefined;
+    var exception: jsc.JSValue = .zero;
     const result = Bun__REPL__evaluate(
         global,
         code.ptr,
@@ -1301,7 +1301,7 @@ fn evaluateRaw(self: *Repl, code: []const u8) void {
         &exception,
     );
 
-    if (!exception.isUndefined() and !exception.isNull()) {
+    if (exception != .zero) {
         self.setLastError(exception);
         self.printJSError(exception);
         return;
@@ -1335,7 +1335,7 @@ fn evaluateAndCopy(self: *Repl, code: []const u8) void {
     };
     defer self.allocator.free(transformed_code);
 
-    var exception: jsc.JSValue = .js_undefined;
+    var exception: jsc.JSValue = .zero;
     const result = Bun__REPL__evaluate(
         global,
         transformed_code.ptr,
@@ -1345,7 +1345,7 @@ fn evaluateAndCopy(self: *Repl, code: []const u8) void {
         &exception,
     );
 
-    if (!exception.isUndefined() and !exception.isNull()) {
+    if (exception != .zero) {
         self.setLastError(exception);
         self.printJSError(exception);
         return;
@@ -1600,7 +1600,14 @@ fn setReplVariables(self: *Repl) void {
 
 fn printJSError(self: *Repl, error_value: jsc.JSValue) void {
     // Interactive REPL writes everything to stdout (single terminal stream).
-    self.printJSErrorTo(error_value, Output.writer(), self.use_colors);
+    const writer = Output.writer();
+    // Print "Uncaught" prefix to distinguish thrown values from expression results (matches Node.js)
+    if (self.use_colors) {
+        writer.writeAll(Color.red ++ "Uncaught " ++ Color.reset) catch {};
+    } else {
+        writer.writeAll("Uncaught ") catch {};
+    }
+    self.printJSErrorTo(error_value, writer, self.use_colors);
 }
 
 fn printJSErrorTo(self: *Repl, error_value: jsc.JSValue, writer: *std.Io.Writer, enable_colors: bool) void {

--- a/test/regression/issue/28265.test.ts
+++ b/test/regression/issue/28265.test.ts
@@ -31,8 +31,9 @@ const stripAnsi = Bun.stripANSI;
 // prompt/echo lines (contain \r), and blank lines.
 function getOutputLines(stdout: string): string[] {
   return stripAnsi(stdout)
+    .replace(/\r/g, "")
     .split("\n")
-    .filter(l => !l.includes("\r") && !l.startsWith("Welcome to") && !l.startsWith("Type ") && l.trim() !== "");
+    .filter(l => !l.startsWith("Welcome to") && !l.startsWith("Type ") && l.trim() !== "");
 }
 
 describe("REPL thrown values should show 'Uncaught' prefix", () => {

--- a/test/regression/issue/28265.test.ts
+++ b/test/regression/issue/28265.test.ts
@@ -94,9 +94,10 @@ describe("REPL thrown values should show 'Uncaught' prefix", () => {
   });
 
   test("REPL continues after throwing null/undefined", async () => {
-    const { stdout, exitCode } = await runRepl(["throw null", "1 + 1", ".exit"]);
+    const { stdout, exitCode } = await runRepl(["throw null", "throw undefined", "1 + 1", ".exit"]);
     const lines = getOutputLines(stdout);
     expect(lines).toContainEqual("Uncaught null");
+    expect(lines).toContainEqual("Uncaught undefined");
     expect(lines).toContainEqual("2");
     expect(exitCode).toBe(0);
   });

--- a/test/regression/issue/28265.test.ts
+++ b/test/regression/issue/28265.test.ts
@@ -27,59 +27,67 @@ async function runRepl(input: string | string[]): Promise<{ stdout: string; stde
 
 const stripAnsi = Bun.stripANSI;
 
+// Extract meaningful output lines from REPL stdout, filtering out banner,
+// prompt/echo lines (contain \r), and blank lines.
+function getOutputLines(stdout: string): string[] {
+  return stripAnsi(stdout)
+    .split("\n")
+    .filter(l => !l.includes("\r") && !l.startsWith("Welcome to") && !l.startsWith("Type ") && l.trim() !== "");
+}
+
 describe("REPL thrown values should show 'Uncaught' prefix", () => {
   test("throw undefined shows 'Uncaught undefined'", async () => {
     const { stdout, exitCode } = await runRepl(["throw undefined", ".exit"]);
-    const output = stripAnsi(stdout);
-    expect(output).toContain("Uncaught undefined");
+    const lines = getOutputLines(stdout);
+    expect(lines).toContainEqual("Uncaught undefined");
     expect(exitCode).toBe(0);
   });
 
   test("throw null shows 'Uncaught null'", async () => {
     const { stdout, exitCode } = await runRepl(["throw null", ".exit"]);
-    const output = stripAnsi(stdout);
-    expect(output).toContain("Uncaught null");
+    const lines = getOutputLines(stdout);
+    expect(lines).toContainEqual("Uncaught null");
     expect(exitCode).toBe(0);
   });
 
   test("throw 42 shows 'Uncaught 42'", async () => {
     const { stdout, exitCode } = await runRepl(["throw 42", ".exit"]);
-    const output = stripAnsi(stdout);
-    expect(output).toContain("Uncaught 42");
+    const lines = getOutputLines(stdout);
+    expect(lines).toContainEqual("Uncaught 42");
     expect(exitCode).toBe(0);
   });
 
-  test("throw string shows 'Uncaught' with the string", async () => {
+  test("throw string shows 'Uncaught' with the string value", async () => {
     const { stdout, exitCode } = await runRepl(["throw 'hello'", ".exit"]);
-    const output = stripAnsi(stdout);
-    expect(output).toContain("Uncaught");
-    expect(output).toContain("hello");
+    const lines = getOutputLines(stdout);
+    const uncaughtLine = lines.find(l => l.startsWith("Uncaught"));
+    expect(uncaughtLine).toBeDefined();
+    expect(uncaughtLine).toContain("hello");
     expect(exitCode).toBe(0);
   });
 
-  test("throw Error shows 'Uncaught' with the error", async () => {
+  test("throw Error shows 'Uncaught' with the error message", async () => {
     const { stdout, exitCode } = await runRepl(["throw new Error('boom')", ".exit"]);
-    const output = stripAnsi(stdout);
-    expect(output).toContain("Uncaught");
-    expect(output).toContain("boom");
+    const lines = getOutputLines(stdout);
+    const uncaughtLine = lines.find(l => l.startsWith("Uncaught"));
+    expect(uncaughtLine).toBeDefined();
+    expect(uncaughtLine).toContain("boom");
     expect(exitCode).toBe(0);
   });
 
   test("normal expression result does NOT show 'Uncaught'", async () => {
     const { stdout, exitCode } = await runRepl(["undefined", ".exit"]);
-    const output = stripAnsi(stdout);
-    expect(output).not.toContain("Uncaught");
+    const lines = getOutputLines(stdout);
+    expect(lines.some(l => l.includes("Uncaught"))).toBe(false);
+    expect(lines).toContainEqual("undefined");
     expect(exitCode).toBe(0);
   });
 
   test("thrown values are distinguishable from expression results", async () => {
     const { stdout, exitCode } = await runRepl(["42", "throw 42", ".exit"]);
-    const output = stripAnsi(stdout);
-    const lines = output.split("\n");
-    // Find the lines with "42" in output (excluding input echo)
-    // The plain 42 should not have "Uncaught", the thrown one should
+    const lines = getOutputLines(stdout);
     const resultLine = lines.find(l => l.trim() === "42");
-    const thrownLine = lines.find(l => l.includes("Uncaught 42"));
+    const thrownLine = lines.find(l => l.trim() === "Uncaught 42");
     expect(resultLine).toBeDefined();
     expect(thrownLine).toBeDefined();
     expect(exitCode).toBe(0);
@@ -87,9 +95,9 @@ describe("REPL thrown values should show 'Uncaught' prefix", () => {
 
   test("REPL continues after throwing null/undefined", async () => {
     const { stdout, exitCode } = await runRepl(["throw null", "1 + 1", ".exit"]);
-    const output = stripAnsi(stdout);
-    expect(output).toContain("Uncaught null");
-    expect(output).toContain("2");
+    const lines = getOutputLines(stdout);
+    expect(lines).toContainEqual("Uncaught null");
+    expect(lines).toContainEqual("2");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/regression/issue/28265.test.ts
+++ b/test/regression/issue/28265.test.ts
@@ -1,0 +1,95 @@
+// https://github.com/oven-sh/bun/issues/28265
+// REPL output should distinguish between expression results and thrown errors
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+async function runRepl(input: string | string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const inputStr = Array.isArray(input) ? input.join("\n") + "\n" : input;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "repl"],
+    stdin: Buffer.from(inputStr),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...bunEnv,
+      TERM: "dumb",
+      NO_COLOR: "1",
+    },
+  });
+
+  const exitCode = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+
+  return { stdout, stderr, exitCode };
+}
+
+const stripAnsi = Bun.stripANSI;
+
+describe("REPL thrown values should show 'Uncaught' prefix", () => {
+  test("throw undefined shows 'Uncaught undefined'", async () => {
+    const { stdout, exitCode } = await runRepl(["throw undefined", ".exit"]);
+    const output = stripAnsi(stdout);
+    expect(output).toContain("Uncaught undefined");
+    expect(exitCode).toBe(0);
+  });
+
+  test("throw null shows 'Uncaught null'", async () => {
+    const { stdout, exitCode } = await runRepl(["throw null", ".exit"]);
+    const output = stripAnsi(stdout);
+    expect(output).toContain("Uncaught null");
+    expect(exitCode).toBe(0);
+  });
+
+  test("throw 42 shows 'Uncaught 42'", async () => {
+    const { stdout, exitCode } = await runRepl(["throw 42", ".exit"]);
+    const output = stripAnsi(stdout);
+    expect(output).toContain("Uncaught 42");
+    expect(exitCode).toBe(0);
+  });
+
+  test("throw string shows 'Uncaught' with the string", async () => {
+    const { stdout, exitCode } = await runRepl(["throw 'hello'", ".exit"]);
+    const output = stripAnsi(stdout);
+    expect(output).toContain("Uncaught");
+    expect(output).toContain("hello");
+    expect(exitCode).toBe(0);
+  });
+
+  test("throw Error shows 'Uncaught' with the error", async () => {
+    const { stdout, exitCode } = await runRepl(["throw new Error('boom')", ".exit"]);
+    const output = stripAnsi(stdout);
+    expect(output).toContain("Uncaught");
+    expect(output).toContain("boom");
+    expect(exitCode).toBe(0);
+  });
+
+  test("normal expression result does NOT show 'Uncaught'", async () => {
+    const { stdout, exitCode } = await runRepl(["undefined", ".exit"]);
+    const output = stripAnsi(stdout);
+    expect(output).not.toContain("Uncaught");
+    expect(exitCode).toBe(0);
+  });
+
+  test("thrown values are distinguishable from expression results", async () => {
+    const { stdout, exitCode } = await runRepl(["42", "throw 42", ".exit"]);
+    const output = stripAnsi(stdout);
+    const lines = output.split("\n");
+    // Find the lines with "42" in output (excluding input echo)
+    // The plain 42 should not have "Uncaught", the thrown one should
+    const resultLine = lines.find(l => l.trim() === "42");
+    const thrownLine = lines.find(l => l.includes("Uncaught 42"));
+    expect(resultLine).toBeDefined();
+    expect(thrownLine).toBeDefined();
+    expect(exitCode).toBe(0);
+  });
+
+  test("REPL continues after throwing null/undefined", async () => {
+    const { stdout, exitCode } = await runRepl(["throw null", "1 + 1", ".exit"]);
+    const output = stripAnsi(stdout);
+    expect(output).toContain("Uncaught null");
+    expect(output).toContain("2");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes thrown values in the REPL being indistinguishable from normal expression results
- `throw undefined` and `throw null` were silently swallowed due to using `.js_undefined` as the exception sentinel — now uses `.zero` to detect all thrown values
- Adds "Uncaught " prefix when printing errors in the interactive REPL, matching Node.js behavior

Before:
```
> throw undefined
undefined          ← same as expression result
> throw null
undefined          ← wrong value AND no indication of throw
> throw 42
42                 ← same as expression result
```

After:
```
> throw undefined
Uncaught undefined
> throw null
Uncaught null
> throw 42
Uncaught 42
```

Closes #28265

## Test plan
- [x] New regression tests in `test/regression/issue/28265.test.ts` (8 tests)
- [x] All 105 existing REPL tests pass (`test/js/bun/repl/repl.test.ts`)
- [x] Tests fail with system bun (without fix) and pass with debug build (with fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)