### PR TITLE
fix(dns): stale cache entries never expire while refcount > 0

### DIFF
--- a/src/bun.js/api/bun/dns.zig
+++ b/src/bun.js/api/bun/dns.zig
@@ -1227,7 +1227,7 @@ pub const internal = struct {
         can_retry_for_addrconfig: bool = default_hints.flags.ADDRCONFIG,
 
         pub fn isExpired(this: *Request, timestamp_to_store: *u32) bool {
-            if (this.refcount > 0 or this.result == null) {
+            if (this.result == null) {
                 return false;
             }
 
@@ -1284,9 +1284,11 @@ pub const internal = struct {
                 if (entry.key.hash == key.hash and entry.valid) {
                     if (entry.isExpired(timestamp_to_store)) {
                         log("get: expired entry", .{});
-                        _ = this.deleteEntryAt(len, i);
-                        entry.deinit();
-                        len = this.len;
+                        if (entry.refcount == 0) {
+                            _ = this.deleteEntryAt(len, i);
+                            entry.deinit();
+                            len = this.len;
+                        }
                         continue;
                     }
 

--- a/src/bun.js/api/bun/dns.zig
+++ b/src/bun.js/api/bun/dns.zig
@@ -1791,7 +1791,9 @@ pub const internal = struct {
         global_cache.lock.lock();
         defer global_cache.lock.unlock();
 
-        req.valid = err == 0;
+        if (err != 0) {
+            req.valid = false;
+        }
         dns_cache_errors += @as(usize, @intFromBool(err != 0));
 
         bun.assert(req.refcount > 0);


### PR DESCRIPTION
`isExpired` returned false whenever `refcount > 0`, keeping stale entries alive indefinitely as long as any connect to that host was in flight. The guard was there to prevent the caller from `deinit()`-ing memory an in-flight request still holds; this moves the check to the caller so expiry and memory safety are decided separately.