### PR TITLE
Update client transpiler options for browser support

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -205,6 +205,8 @@ pub const BundleV2 = struct {
         client_transpiler.options = this_transpiler.options;
 
         client_transpiler.options.target = .browser;
+        client_transpiler.options.polyfill_node_globals = true;
+        client_transpiler.options.mark_builtins_as_external = false;
         client_transpiler.options.main_fields = options.Target.DefaultMainFields.get(options.Target.browser);
         client_transpiler.options.conditions = try options.ESMConditions.init(
             alloc,
@@ -235,6 +237,7 @@ pub const BundleV2 = struct {
         try client_transpiler.configureDefines();
         client_transpiler.resolver.opts = client_transpiler.options;
         client_transpiler.resolver.env_loader = client_transpiler.env;
+        client_transpiler.resolver.care_about_browser_field = true;
         this.client_transpiler = client_transpiler;
         return client_transpiler;
     }


### PR DESCRIPTION
### What does this PR do?
Sets up the client transpiler the same way it would for target browser and conditions browser. It doesn't seem like anything else would make any sense here.
Bun also doesn't seem to respect: "browser": { "fs": false, "http": false, "https": false, "zlib": false } no matter what.

### How did you verify your code works?
Did not, it's 3 lines praying that someone can at least consider.

#closes 24077