### PR TITLE
docs: mention native S3Client support for Clever Cloud Cellar Object …

### DIFF
--- a/docs/runtime/s3.mdx
+++ b/docs/runtime/s3.mdx
@@ -39,6 +39,7 @@ await metadata.delete();
 S3 is the [de facto standard](https://en.wikipedia.org/wiki/De_facto_standard) internet filesystem. Bun's S3 API works with S3-compatible storage services like:
 
 - AWS S3
+- Clever Cloud
 - Cloudflare R2
 - DigitalOcean Spaces
 - MinIO
@@ -318,6 +319,36 @@ const s3 = new S3Client({
   bucket: "my-bucket",
   // endpoint: "https://s3.us-east-1.amazonaws.com",
   // region: "us-east-1",
+});
+```
+
+### Using Bun's S3Client with Clever Cloud Cellar
+
+To use Bun's S3 client with [Clever Cloud Cellar](https://www.clever-cloud.com/developers/doc/addons/cellar/), set `endpoint` to the Cellar endpoint in the `S3Client` constructor.
+
+```ts
+import { S3Client } from "bun";
+
+// Clever Cloud Cellar
+const cellar = new S3Client({
+  accessKeyId: "access-key",
+  secretAccessKey: "secret-key",
+  bucket: "my-bucket",
+  endpoint: "https://cellar-c2.services.clever-cloud.com",
+});
+```
+
+If you've linked a Cellar add-on to a Clever Cloud application, you can just use automatically added environment variables:
+
+```ts
+import { S3Client } from "bun";
+
+// Clever Cloud Cellar
+const cellar = new S3Client({
+  accessKeyId: process.env.CELLAR_ADDON_KEY_ID,
+  secretAccessKey: process.env.CELLAR_ADDON_KEY_SECRET,
+  bucket: "my-bucket",
+  endpoint: process.env.CELLAR_ADDON_HOST,
 });
 ```
 


### PR DESCRIPTION
### What does this PR do?

This pull request updates the S3 documentation to add support and usage instructions for Clever Cloud Cellar, a new S3-compatible storage provider. The most important changes are:

**Documentation Updates for Clever Cloud Cellar:**

* Added "Clever Cloud" to the list of S3-compatible storage services supported by Bun's S3 API in `docs/runtime/s3.mdx`.
* Added a new section with code examples explaining how to configure Bun's `S3Client` to work with Clever Cloud Cellar, including usage with environment variables for applications linked to a Cellar add-on.

### How did you verify your code works?

I've check it by creating a Cellar add-on and testing integration mentioned here, in [Clever Cloud documentation](https://www.clever.cloud/developers/doc/addons/cellar/#using-sdks) and [in examples](https://github.com/CleverCloud/bun-addons-examples). 