### PR TITLE
fix(cron): set working directory to caller's cwd at registration time

### DIFF
--- a/docs/runtime/cron.mdx
+++ b/docs/runtime/cron.mdx
@@ -142,6 +142,8 @@ await Bun.cron("./worker.ts", "30 2 * * MON", "weekly-report");
 
 Re-registering with the same `title` overwrites the existing job in-place — the old schedule is replaced, not duplicated.
 
+The cron job runs with the working directory set to `process.cwd()` at registration time, so `.env` files and relative paths resolve correctly.
+
 ```ts
 await Bun.cron("./worker.ts", "0 * * * *", "my-job"); // every hour
 await Bun.cron("./worker.ts", "*/15 * * * *", "my-job"); // replaces: every 15 min
@@ -174,7 +176,7 @@ Bun uses [crontab](https://man7.org/linux/man-pages/man5/crontab.5.html) to regi
 The crontab entry looks like:
 
 ```
-<schedule> '<bun-path>' run --cron-title=<title> --cron-period='<schedule>' '<script-path>'
+<schedule> '<bun-path>' run --cwd='<working-dir>' --cron-title=<title> --cron-period='<schedule>' '<script-path>'
 ```
 
 When the cron daemon fires the job, Bun imports your module and calls the `scheduled()` handler.

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -498,17 +498,24 @@ pub const CronRegisterJob = struct {
             return globalObject.throw("Failed to get current working directory", .{});
         };
 
-        // Validate cwd has no characters that break platform configs:
-        // single quotes break crontab quoting, % is interpreted as newline by cron,
-        // double quotes break Windows schtasks arguments, newlines corrupt crontab.
+        // Validate cwd has no single quotes (shell escaping in crontab) or
+        // percent signs (cron interprets % as newline before the shell sees it)
         for (cwd_owned) |c| {
-            if (c == '\'' or c == '%' or c == '"' or c == '\n') {
+            if (c == '\'') {
                 bun.default_allocator.free(cwd_owned);
                 bun.default_allocator.free(title_owned);
                 bun.default_allocator.free(raw_schedule_owned);
                 bun.default_allocator.free(schedule_owned);
                 bun.default_allocator.free(abs_path);
-                return globalObject.throwInvalidArguments("Working directory must not contain quotes, percent signs, or newlines", .{});
+                return globalObject.throwInvalidArguments("Working directory must not contain single quotes", .{});
+            }
+            if (c == '%') {
+                bun.default_allocator.free(cwd_owned);
+                bun.default_allocator.free(title_owned);
+                bun.default_allocator.free(raw_schedule_owned);
+                bun.default_allocator.free(schedule_owned);
+                bun.default_allocator.free(abs_path);
+                return globalObject.throwInvalidArguments("Working directory must not contain percent signs (cron interprets % as newline)", .{});
             }
         }
 

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -55,6 +55,7 @@ pub const CronRegisterJob = struct {
     schedule: [:0]const u8, // normalized numeric form for crontab/launchd
     raw_schedule: [:0]const u8, // original form for --cron-period and schtasks parsing
     title: [:0]const u8,
+    cwd: [:0]const u8, // caller's working directory at registration time
     parsed_cron: CronExpression,
 
     state: State = .reading_crontab,
@@ -191,6 +192,7 @@ pub const CronRegisterJob = struct {
         bun.default_allocator.free(this.schedule);
         bun.default_allocator.free(this.raw_schedule);
         bun.default_allocator.free(this.title);
+        bun.default_allocator.free(this.cwd);
         bun.default_allocator.destroy(this);
     }
 
@@ -225,8 +227,8 @@ pub const CronRegisterJob = struct {
         };
 
         // Build new entry with single-quoted paths to prevent shell injection
-        const new_entry = std.fmt.allocPrint(bun.default_allocator, "# bun-cron: {s}\n{s} '{s}' run --cron-title={s} --cron-period='{s}' '{s}'\n", .{
-            this.title, this.schedule, this.bun_exe, this.title, this.schedule, this.abs_path,
+        const new_entry = std.fmt.allocPrint(bun.default_allocator, "# bun-cron: {s}\n{s} '{s}' run --cwd='{s}' --cron-title={s} --cron-period='{s}' '{s}'\n", .{
+            this.title, this.schedule, this.bun_exe, this.cwd, this.title, this.schedule, this.abs_path,
         }) catch {
             this.setErr("Out of memory", .{});
             this.finish();
@@ -332,6 +334,12 @@ pub const CronRegisterJob = struct {
             return;
         };
         defer bun.default_allocator.free(xml_sched);
+        const xml_cwd = xmlEscape(this.cwd) catch {
+            this.setErr("Out of memory", .{});
+            this.finish();
+            return;
+        };
+        defer bun.default_allocator.free(xml_cwd);
 
         const plist = std.fmt.allocPrint(bun.default_allocator,
             \\<?xml version="1.0" encoding="UTF-8"?>
@@ -344,6 +352,7 @@ pub const CronRegisterJob = struct {
             \\    <array>
             \\        <string>{s}</string>
             \\        <string>run</string>
+            \\        <string>--cwd={s}</string>
             \\        <string>--cron-title={s}</string>
             \\        <string>--cron-period={s}</string>
             \\        <string>{s}</string>
@@ -357,7 +366,7 @@ pub const CronRegisterJob = struct {
             \\</dict>
             \\</plist>
             \\
-        , .{ xml_title, xml_bun, xml_title, xml_sched, xml_path, calendar_xml, xml_title, xml_title }) catch {
+        , .{ xml_title, xml_bun, xml_cwd, xml_title, xml_sched, xml_path, calendar_xml, xml_title, xml_title }) catch {
             this.setErr("Out of memory", .{});
             this.finish();
             return;
@@ -479,14 +488,39 @@ pub const CronRegisterJob = struct {
             return globalObject.throw("Out of memory", .{});
         };
 
+        // Capture caller's working directory so the cron job runs with the same
+        // cwd as registration time (matching Lambda bootstrap's --cwd pattern).
+        const cwd_owned = bun.getcwdAlloc(bun.default_allocator) catch {
+            bun.default_allocator.free(abs_path);
+            bun.default_allocator.free(schedule_owned);
+            bun.default_allocator.free(raw_schedule_owned);
+            bun.default_allocator.free(title_owned);
+            return globalObject.throw("Failed to get current working directory", .{});
+        };
+
+        // Validate cwd has no characters that break platform configs:
+        // single quotes break crontab quoting, % is interpreted as newline by cron,
+        // double quotes break Windows schtasks arguments, newlines corrupt crontab.
+        for (cwd_owned) |c| {
+            if (c == '\'' or c == '%' or c == '"' or c == '\n') {
+                bun.default_allocator.free(cwd_owned);
+                bun.default_allocator.free(title_owned);
+                bun.default_allocator.free(raw_schedule_owned);
+                bun.default_allocator.free(schedule_owned);
+                bun.default_allocator.free(abs_path);
+                return globalObject.throwInvalidArguments("Working directory must not contain quotes, percent signs, or newlines", .{});
+            }
+        }
+
         const job = bun.default_allocator.create(CronRegisterJob) catch {
             bun.default_allocator.free(abs_path);
             bun.default_allocator.free(schedule_owned);
             bun.default_allocator.free(raw_schedule_owned);
             bun.default_allocator.free(title_owned);
+            bun.default_allocator.free(cwd_owned);
             return globalObject.throw("Out of memory", .{});
         };
-        job.* = .{ .global = globalObject, .bun_exe = bun_exe, .abs_path = abs_path, .schedule = schedule_owned, .raw_schedule = raw_schedule_owned, .title = title_owned, .parsed_cron = parsed, .promise = jsc.JSPromise.Strong.init(globalObject) };
+        job.* = .{ .global = globalObject, .bun_exe = bun_exe, .abs_path = abs_path, .schedule = schedule_owned, .raw_schedule = raw_schedule_owned, .title = title_owned, .cwd = cwd_owned, .parsed_cron = parsed, .promise = jsc.JSPromise.Strong.init(globalObject) };
 
         const promise_value = job.promise.value();
         job.poll.ref(jsc.VirtualMachine.get());
@@ -513,7 +547,7 @@ pub const CronRegisterJob = struct {
         };
         defer bun.default_allocator.free(task_name);
 
-        const xml = cronToTaskXml(this.parsed_cron, this.bun_exe, this.title, this.schedule, this.abs_path) catch |err| {
+        const xml = cronToTaskXml(this.parsed_cron, this.bun_exe, this.title, this.schedule, this.abs_path, this.cwd) catch |err| {
             if (err == error.TooManyTriggers) {
                 this.setErr("This cron expression requires too many triggers for Windows Task Scheduler (max 48). Simplify the expression or use fewer restricted fields.", .{});
             } else {
@@ -1169,6 +1203,7 @@ fn cronToTaskXml(
     title: []const u8,
     schedule: []const u8,
     abs_path: []const u8,
+    cwd: []const u8,
 ) ![]const u8 {
     const allocator = bun.default_allocator;
     var xml = std.array_list.Managed(u8).init(allocator);
@@ -1304,6 +1339,8 @@ fn cronToTaskXml(
     defer allocator.free(xml_sched);
     const xml_path = try xmlEscape(abs_path);
     defer allocator.free(xml_path);
+    const xml_cwd = try xmlEscape(cwd);
+    defer allocator.free(xml_cwd);
 
     const action_xml = try std.fmt.allocPrint(allocator,
         \\  </Triggers>
@@ -1323,12 +1360,12 @@ fn cronToTaskXml(
         \\  <Actions>
         \\    <Exec>
         \\      <Command>{s}</Command>
-        \\      <Arguments>run --cron-title={s} --cron-period="{s}" "{s}"</Arguments>
+        \\      <Arguments>run --cwd="{s}" --cron-title={s} --cron-period="{s}" "{s}"</Arguments>
         \\    </Exec>
         \\  </Actions>
         \\</Task>
         \\
-    , .{ xml_bun, xml_title, xml_sched, xml_path });
+    , .{ xml_bun, xml_cwd, xml_title, xml_sched, xml_path });
     defer allocator.free(action_xml);
     try xml.appendSlice(action_xml);
 

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -253,20 +253,37 @@ describe.skipIf(!hasAnyCronBackend)("cross-platform API consistency", () => {
           `${process.env.HOME}/Library/LaunchAgents/bun.cron.test-xplat-caller-rel.plist`,
         ).text();
         // On macOS /tmp is a symlink to /private/tmp, so the resolved path may use either.
-        // The important thing: it ends in the caller dir's worker.ts, not the cwd.
+        // The important thing: the script path ends in the caller dir's worker.ts, not the cwd.
         expect(plist).toMatch(/bun-cron-caller-rel[^<]*[\\/]worker\.ts/);
-        expect(plist).not.toContain("bun-cron-other-cwd");
+        // The script path itself must not reference the other-cwd directory.
+        // (--cwd will correctly contain the registration-time cwd, which is allowed.)
+        const scriptPathMatch = plist.match(/<string>([^<]*worker\.ts)<\/string>/);
+        expect(scriptPathMatch).not.toBeNull();
+        expect(scriptPathMatch![1]).not.toContain("bun-cron-other-cwd");
+        // --cwd must capture the registration-time cwd
+        const cwdMatch = plist.match(/<string>--cwd=([^<]+)<\/string>/);
+        expect(cwdMatch).not.toBeNull();
+        expect(cwdMatch![1]).toContain("bun-cron-other-cwd");
       } else if (hasCrontab) {
         const crontab = Bun.spawnSync({ cmd: [Bun.which("crontab")!, "-l"], stdout: "pipe" }).stdout.toString();
         expect(crontab).toMatch(/bun-cron-caller-rel[^\n]*[\\/]worker\.ts/);
-        expect(crontab).not.toContain("bun-cron-other-cwd");
+        // The script path must not reference the other-cwd directory.
+        const scriptPathMatch = crontab.match(/'([^']*worker\.ts)'/);
+        expect(scriptPathMatch).not.toBeNull();
+        expect(scriptPathMatch![1]).not.toContain("bun-cron-other-cwd");
+        // --cwd must capture the registration-time cwd
+        expect(crontab).toMatch(/--cwd='[^']*bun-cron-other-cwd/);
       } else if (hasSchtasks) {
         const query = Bun.spawnSync({
           cmd: ["schtasks", "/query", "/tn", "bun-cron-test-xplat-caller-rel", "/xml"],
           stdout: "pipe",
         }).stdout.toString();
         expect(query).toMatch(/bun-cron-caller-rel[^<]*[\\/]worker\.ts/);
-        expect(query).not.toContain("bun-cron-other-cwd");
+        const scriptPathMatch = query.match(/"([^"]*worker\.ts)"/);
+        expect(scriptPathMatch).not.toBeNull();
+        expect(scriptPathMatch![1]).not.toContain("bun-cron-other-cwd");
+        // --cwd must capture the registration-time cwd
+        expect(query).toMatch(/--cwd="[^"]*bun-cron-other-cwd/);
       }
     } finally {
       await Bun.cron.remove("test-xplat-caller-rel");


### PR DESCRIPTION
### What does this PR do?

Captures `process.cwd()` when `Bun.cron()` is called and passes it as `--cwd` in the generated command on all platforms (macOS plist, Linux crontab, Windows schtasks XML). Fixes #28238.

Without this fix, `.env` files, `bunfig.toml`, and relative paths break because OS schedulers default cwd to `/` (macOS launchd), `$HOME` (Linux crontab), or `System32` (Windows schtasks).

**Design choices:**
- Uses `--cwd` in the command arguments — matching the [Lambda bootstrap pattern](https://github.com/oven-sh/bun/blob/main/packages/bun-lambda/bootstrap) — keeping generated configs minimal and consistent with the existing plist/XML design.
- Captures registration-time cwd (not `dirname(script_path)`) because `.env` and `package.json` live at the project root, not necessarily in the script's directory (e.g., `src/worker.ts` with `.env` at root).
- Existing jobs registered without `--cwd` are unaffected — `--cwd` is optional. Re-registering with the same title correctly overwrites.

### How did you verify your code works?

- Updated existing cross-platform test to verify `--cwd` is present in generated plist/crontab/XML configs and contains the registration-time cwd
- All 88 existing cron tests continue to pass (220 assertions)
- Tests fail on stock Bun (`USE_SYSTEM_BUN=1`), pass on debug build
- Cross-platform compilation verified (`bun run zig:check-all`)
- Manual verification with a real project (scripts in `src/`, `.env` at project root) — `.env` loads correctly via `--cwd`