### PR TITLE
fix(install): resolve GitHub deps that appear as both direct and transitive

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -450,8 +450,16 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
     if (dependency.behavior.isOptionalPeer()) return;
 
     var name = dependency.realname();
+    // For git/github/tarball dependencies, `realname()` returns the `package_name` field
+    // which is only populated after tarball extraction. If the tarball hasn't been extracted
+    // yet (or we're processing a transitive dependency whose `package_name` was never set),
+    // fall back to the dependency's own name and name_hash to ensure correct lockfile lookups.
     var name_hash = switch (dependency.version.tag) {
-        .dist_tag, .git, .github, .npm, .tarball, .workspace => String.Builder.stringHash(this.lockfile.str(&name)),
+        .git, .github, .tarball => if (name.isEmpty()) blk: {
+            name = dependency.name;
+            break :blk dependency.name_hash;
+        } else String.Builder.stringHash(this.lockfile.str(&name)),
+        .dist_tag, .npm, .workspace => String.Builder.stringHash(this.lockfile.str(&name)),
         else => dependency.name_hash,
     };
 

--- a/test/regression/issue/028284.test.ts
+++ b/test/regression/issue/028284.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { rmSync } from "fs";
+import { join } from "path";
+
+// Test for https://github.com/oven-sh/bun/issues/28284
+// When a GitHub dependency appears both as a direct dependency and as a transitive
+// dependency (through another GitHub package), `bun install` fails intermittently
+// with "failed to resolve" due to a race condition in name_hash computation.
+//
+// The root cause was that `realname()` returns `package_name` for GitHub deps,
+// which is only populated after tarball extraction. When processing a transitive
+// dependency whose tarball was already extracted via the direct dependency path,
+// `package_name` could be empty, causing the wrong name_hash and a failed lookup.
+test("github dependency resolves when it appears both as direct and transitive dependency", async () => {
+  // package-b depends on package-c via "github:rentalhost/bun-issue-package-c"
+  // package-c is also a direct dependency here
+  const dir = tempDirWithFiles("028284", {
+    "package.json": JSON.stringify({
+      name: "repro-28284",
+      private: true,
+      dependencies: {
+        "@rentalhost/bun-issue-package-b": "github:rentalhost/bun-issue-package-b",
+        "@rentalhost/bun-issue-package-c": "github:rentalhost/bun-issue-package-c",
+      },
+    }),
+  });
+
+  // Run bun install multiple times to increase the chance of hitting the race condition.
+  // Before the fix, this would fail ~20-50% of the time.
+  for (let i = 0; i < 5; i++) {
+    const { stdout, stderr, exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), "install"],
+      cwd: dir,
+      env: bunEnv,
+    });
+
+    const stderrText = stderr.toString();
+    expect(stderrText).not.toContain("failed to resolve");
+    expect(exitCode).toBe(0);
+
+    // Clean up for next iteration to force fresh resolution
+    rmSync(join(dir, "node_modules"), { recursive: true, force: true });
+    rmSync(join(dir, "bun.lock"), { force: true });
+  }
+}, 120_000);

--- a/test/regression/issue/028284.test.ts
+++ b/test/regression/issue/028284.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import { rmSync } from "fs";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 // Test for https://github.com/oven-sh/bun/issues/28284


### PR DESCRIPTION
## Summary

- Fixes a race condition where `bun install` would intermittently fail with `"failed to resolve"` when a GitHub dependency appeared **both** as a direct dependency and as a transitive dependency (through another GitHub package)
- The root cause was that `realname()` returns the `package_name` field for git/github/tarball dependencies, but this field is only populated after tarball extraction. When processing a transitive dependency whose `package_name` was never set, the `name_hash` would be computed from an empty string, causing `getPackageID` to fail to find the already-registered package
- Fix: when `package_name` is empty for git/github/tarball deps, fall back to `dependency.name` and `dependency.name_hash`

Closes #28284

## Test plan

- [x] Added regression test `test/regression/issue/028284.test.ts` that runs `bun install` 5 times with the reproducing package.json
- [x] Verified test **fails** with system bun (`USE_SYSTEM_BUN=1`) and **passes** with debug build (`bun bd test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)