### PR TITLE
fix (crypto): aes ccm node crypto

### DIFF
--- a/patches/boringssl/cipher.h.patch
+++ b/patches/boringssl/cipher.h.patch
@@ -1,0 +1,12 @@
+--- a/include/openssl/cipher.h
++++ b/include/openssl/cipher.h
+@@ -539,6 +539,9 @@
+ // not act on it until the entire operation is complete.
+ OPENSSL_EXPORT const EVP_CIPHER *EVP_aes_128_gcm(void);
+ OPENSSL_EXPORT const EVP_CIPHER *EVP_aes_256_gcm(void);
++OPENSSL_EXPORT const EVP_CIPHER *EVP_aes_128_ccm(void);
++OPENSSL_EXPORT const EVP_CIPHER *EVP_aes_192_ccm(void);
++OPENSSL_EXPORT const EVP_CIPHER *EVP_aes_256_ccm(void);
+ 
+ // These are deprecated, 192-bit version of AES.
+ OPENSSL_EXPORT const EVP_CIPHER *EVP_aes_192_ecb(void);

--- a/patches/boringssl/e_aesccm.cc.inc.patch
+++ b/patches/boringssl/e_aesccm.cc.inc.patch
@@ -1,0 +1,289 @@
+--- a/crypto/fipsmodule/cipher/e_aesccm.cc.inc
++++ b/crypto/fipsmodule/cipher/e_aesccm.cc.inc
+@@ -438,3 +438,286 @@
+   out->sealv = aead_aes_ccm_sealv;
+   out->openv_detached = aead_aes_ccm_openv_detached;
+ }
++
++
++namespace {
++struct evp_aes_ccm_ctx {
++  AES_KEY ks;
++  struct ccm128_context ccm;
++  unsigned M;
++  unsigned L;
++  uint8_t iv[16];
++  uint8_t tag[16];
++  uint8_t *aad;
++  size_t aad_len;
++  size_t aad_cap;
++  size_t msg_len;
++  int key_set;
++  int iv_set;
++  int len_set;
++  int tag_set;
++  int data_processed;
++};
++}  // namespace
++
++static int evp_aes_ccm_reserve_aad(struct evp_aes_ccm_ctx *cctx, size_t append_len) {
++  if (append_len == 0) {
++    return 1;
++  }
++  if (cctx->aad_len > SIZE_MAX - append_len) {
++    OPENSSL_PUT_ERROR(CIPHER, CIPHER_R_TOO_LARGE);
++    return 0;
++  }
++  size_t needed = cctx->aad_len + append_len;
++  if (needed <= cctx->aad_cap) {
++    return 1;
++  }
++
++  size_t new_cap = cctx->aad_cap ? cctx->aad_cap : 64;
++  while (new_cap < needed) {
++    if (new_cap > SIZE_MAX / 2) {
++      new_cap = needed;
++      break;
++    }
++    new_cap *= 2;
++  }
++
++  uint8_t *next = reinterpret_cast<uint8_t *>(OPENSSL_realloc(cctx->aad, new_cap));
++  if (next == nullptr) {
++    OPENSSL_PUT_ERROR(CIPHER, ERR_R_MALLOC_FAILURE);
++    return 0;
++  }
++  cctx->aad = next;
++  cctx->aad_cap = new_cap;
++  return 1;
++}
++
++static int evp_aes_ccm_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr) {
++  auto *cctx = reinterpret_cast<evp_aes_ccm_ctx *>(ctx->cipher_data);
++  switch (type) {
++    case EVP_CTRL_INIT:
++      cctx->key_set = 0;
++      cctx->iv_set = 0;
++      cctx->L = 3;
++      cctx->M = 12;
++      cctx->tag_set = 0;
++      cctx->len_set = 0;
++      cctx->data_processed = 0;
++      cctx->aad = nullptr;
++      cctx->aad_len = 0;
++      cctx->aad_cap = 0;
++      cctx->msg_len = 0;
++      return 1;
++    case EVP_CTRL_GET_IVLEN:
++      *reinterpret_cast<int *>(ptr) = static_cast<int>(15 - cctx->L);
++      return 1;
++    case EVP_CTRL_AEAD_SET_IVLEN:
++      arg = 15 - arg;
++      if (arg < 2 || arg > 8) {
++        return 0;
++      }
++      cctx->L = static_cast<unsigned>(arg);
++      return 1;
++    case EVP_CTRL_AEAD_SET_TAG:
++      if ((arg & 1) || arg < 4 || arg > 16) {
++        return 0;
++      }
++      if (EVP_CIPHER_CTX_encrypting(ctx) && ptr != nullptr) {
++        return 0;
++      }
++      cctx->M = static_cast<unsigned>(arg);
++      if (ptr != nullptr) {
++        cctx->tag_set = 1;
++        CopySpan(Span(reinterpret_cast<const uint8_t *>(ptr), cctx->M), Span(cctx->tag).first(cctx->M));
++      }
++      return 1;
++    case EVP_CTRL_AEAD_GET_TAG:
++      if (!EVP_CIPHER_CTX_encrypting(ctx) || !cctx->tag_set) {
++        return 0;
++      }
++      if (arg < 0 || static_cast<unsigned>(arg) > cctx->M) {
++        return 0;
++      }
++      CopySpan(Span(cctx->tag).first(static_cast<size_t>(arg)),
++               Span(reinterpret_cast<uint8_t *>(ptr), static_cast<size_t>(arg)));
++      cctx->tag_set = 0;
++      cctx->iv_set = 0;
++      cctx->len_set = 0;
++      cctx->data_processed = 0;
++      cctx->aad_len = 0;
++      return 1;
++    default:
++      return -1;
++  }
++}
++
++static int evp_aes_ccm_init_key(EVP_CIPHER_CTX *ctx, const uint8_t *key, const uint8_t *iv, int /*enc*/) {
++  auto *cctx = reinterpret_cast<evp_aes_ccm_ctx *>(ctx->cipher_data);
++  if (key != nullptr) {
++    block128_f block;
++    ctr128_f ctr = aes_ctr_set_key(&cctx->ks, nullptr, &block, key, EVP_CIPHER_CTX_key_length(ctx));
++    if (!CRYPTO_ccm128_init(&cctx->ccm, &cctx->ks, block, ctr, cctx->M, cctx->L)) {
++      OPENSSL_PUT_ERROR(CIPHER, ERR_R_INTERNAL_ERROR);
++      return 0;
++    }
++    cctx->key_set = 1;
++    cctx->len_set = 0;
++    cctx->tag_set = 0;
++    cctx->data_processed = 0;
++    cctx->aad_len = 0;
++  }
++  if (iv != nullptr) {
++    OPENSSL_memcpy(cctx->iv, iv, 15 - cctx->L);
++    cctx->iv_set = 1;
++  }
++  return 1;
++}
++
++static int evp_aes_ccm_update_aad(EVP_CIPHER_CTX *ctx, const uint8_t *in, size_t in_len) {
++  auto *cctx = reinterpret_cast<evp_aes_ccm_ctx *>(ctx->cipher_data);
++  if (!cctx->key_set || !cctx->iv_set || cctx->data_processed) {
++    return 0;
++  }
++  // Plaintext length for CCM is passed as update_aad(nullptr, len) before AAD; see
++  // EVP_EncryptUpdate when |EVP_CIPH_FLAG_CUSTOM_CIPHER| and out==nullptr.
++  if (in == nullptr) {
++    if (in_len == 0) {
++      return 1;
++    }
++    if (cctx->len_set) {
++      OPENSSL_PUT_ERROR(CIPHER, CIPHER_R_INVALID_OPERATION);
++      return 0;
++    }
++    cctx->msg_len = in_len;
++    cctx->len_set = 1;
++    return 1;
++  }
++  if (!cctx->len_set) {
++    OPENSSL_PUT_ERROR(CIPHER, CIPHER_R_INVALID_OPERATION);
++    return 0;
++  }
++  if (!evp_aes_ccm_reserve_aad(cctx, in_len)) {
++    return 0;
++  }
++  OPENSSL_memcpy(cctx->aad + cctx->aad_len, in, in_len);
++  cctx->aad_len += in_len;
++  return 1;
++}
++
++static int evp_aes_ccm_cipher_update(EVP_CIPHER_CTX *ctx, uint8_t *out, const uint8_t *in, size_t in_len) {
++  auto *cctx = reinterpret_cast<evp_aes_ccm_ctx *>(ctx->cipher_data);
++  if (!cctx->key_set || !cctx->iv_set) {
++    return 0;
++  }
++
++  if (out == nullptr) {
++    if (in == nullptr) {
++      cctx->msg_len = in_len;
++      cctx->len_set = 1;
++      return 1;
++    }
++    return evp_aes_ccm_update_aad(ctx, in, in_len);
++  }
++
++  if (!cctx->len_set) {
++    cctx->msg_len = in_len;
++    cctx->len_set = 1;
++  }
++  if (cctx->msg_len != in_len || cctx->data_processed) {
++    OPENSSL_PUT_ERROR(CIPHER, CIPHER_R_INVALID_OPERATION);
++    return 0;
++  }
++
++  CRYPTO_IOVEC iovec = {.out = out, .in = in, .len = in_len};
++  CRYPTO_IVEC aadvec = {.in = cctx->aad, .len = cctx->aad_len};
++  auto aadvecs = cctx->aad_len ? Span(&aadvec, 1) : Span<const CRYPTO_IVEC>();
++  bool ok = false;
++
++  if (EVP_CIPHER_CTX_encrypting(ctx)) {
++    ok = CRYPTO_ccm128_encrypt(&cctx->ccm, &cctx->ks, Span(&iovec, 1), Span(cctx->tag).first(cctx->M),
++                               Span(cctx->iv).first(15 - cctx->L), aadvecs);
++    if (ok) cctx->tag_set = 1;
++  } else {
++    if (!cctx->tag_set) {
++      OPENSSL_PUT_ERROR(CIPHER, CIPHER_R_INVALID_OPERATION);
++      return 0;
++    }
++    uint8_t computed_tag[16];
++    ok = CRYPTO_ccm128_decrypt(&cctx->ccm, &cctx->ks, Span(&iovec, 1), Span(computed_tag).first(cctx->M),
++                               Span(cctx->iv).first(15 - cctx->L), aadvecs) &&
++         CRYPTO_memcmp(computed_tag, cctx->tag, cctx->M) == 0;
++    if (!ok) OPENSSL_cleanse(out, in_len);
++    cctx->tag_set = 0;
++  }
++
++  cctx->data_processed = 1;
++  cctx->aad_len = 0;
++  return ok ? 1 : 0;
++}
++
++static int evp_aes_ccm_cipher_final(EVP_CIPHER_CTX *ctx) {
++  auto *cctx = reinterpret_cast<evp_aes_ccm_ctx *>(ctx->cipher_data);
++  cctx->iv_set = 0;
++  cctx->len_set = 0;
++  cctx->data_processed = 0;
++  cctx->aad_len = 0;
++  return 1;
++}
++
++static void evp_aes_ccm_cleanup(EVP_CIPHER_CTX *ctx) {
++  auto *cctx = reinterpret_cast<evp_aes_ccm_ctx *>(ctx->cipher_data);
++  OPENSSL_free(cctx->aad);
++  cctx->aad = nullptr;
++  cctx->aad_len = 0;
++  cctx->aad_cap = 0;
++}
++
++#define EVP_AES_CCM_COMMON_FLAGS (EVP_CIPH_CCM_MODE | EVP_CIPH_CUSTOM_IV | EVP_CIPH_CUSTOM_COPY | EVP_CIPH_FLAG_CUSTOM_CIPHER | EVP_CIPH_ALWAYS_CALL_INIT | EVP_CIPH_CTRL_INIT | EVP_CIPH_FLAG_AEAD_CIPHER)
++
++DEFINE_METHOD_FUNCTION(EVP_CIPHER, EVP_aes_128_ccm) {
++  memset(out, 0, sizeof(EVP_CIPHER));
++  out->nid = NID_aes_128_ccm;
++  out->block_size = 1;
++  out->key_len = 16;
++  out->iv_len = 12;
++  out->ctx_size = sizeof(evp_aes_ccm_ctx);
++  out->flags = EVP_AES_CCM_COMMON_FLAGS;
++  out->init = evp_aes_ccm_init_key;
++  out->cipher_update = evp_aes_ccm_cipher_update;
++  out->cipher_final = evp_aes_ccm_cipher_final;
++  out->update_aad = evp_aes_ccm_update_aad;
++  out->cleanup = evp_aes_ccm_cleanup;
++  out->ctrl = evp_aes_ccm_ctrl;
++}
++
++DEFINE_METHOD_FUNCTION(EVP_CIPHER, EVP_aes_192_ccm) {
++  memset(out, 0, sizeof(EVP_CIPHER));
++  out->nid = NID_aes_192_ccm;
++  out->block_size = 1;
++  out->key_len = 24;
++  out->iv_len = 12;
++  out->ctx_size = sizeof(evp_aes_ccm_ctx);
++  out->flags = EVP_AES_CCM_COMMON_FLAGS;
++  out->init = evp_aes_ccm_init_key;
++  out->cipher_update = evp_aes_ccm_cipher_update;
++  out->cipher_final = evp_aes_ccm_cipher_final;
++  out->update_aad = evp_aes_ccm_update_aad;
++  out->cleanup = evp_aes_ccm_cleanup;
++  out->ctrl = evp_aes_ccm_ctrl;
++}
++
++DEFINE_METHOD_FUNCTION(EVP_CIPHER, EVP_aes_256_ccm) {
++  memset(out, 0, sizeof(EVP_CIPHER));
++  out->nid = NID_aes_256_ccm;
++  out->block_size = 1;
++  out->key_len = 32;
++  out->iv_len = 12;
++  out->ctx_size = sizeof(evp_aes_ccm_ctx);
++  out->flags = EVP_AES_CCM_COMMON_FLAGS;
++  out->init = evp_aes_ccm_init_key;
++  out->cipher_update = evp_aes_ccm_cipher_update;
++  out->cipher_final = evp_aes_ccm_cipher_final;
++  out->update_aad = evp_aes_ccm_update_aad;
++  out->cleanup = evp_aes_ccm_cleanup;
++  out->ctrl = evp_aes_ccm_ctrl;
++}

--- a/patches/boringssl/get_cipher.cc.patch
+++ b/patches/boringssl/get_cipher.cc.patch
@@ -1,0 +1,23 @@
+--- a/crypto/cipher/get_cipher.cc
++++ b/crypto/cipher/get_cipher.cc
+@@ -35,17 +35,20 @@
+     {NID_aes_128_ctr, "aes-128-ctr", EVP_aes_128_ctr},
+     {NID_aes_128_ecb, "aes-128-ecb", EVP_aes_128_ecb},
+     {NID_aes_128_gcm, "aes-128-gcm", EVP_aes_128_gcm},
++    {NID_aes_128_ccm, "aes-128-ccm", EVP_aes_128_ccm},
+     {NID_aes_128_ofb128, "aes-128-ofb", EVP_aes_128_ofb},
+     {NID_aes_192_cbc, "aes-192-cbc", EVP_aes_192_cbc},
+     {NID_aes_192_ctr, "aes-192-ctr", EVP_aes_192_ctr},
+     {NID_aes_192_ecb, "aes-192-ecb", EVP_aes_192_ecb},
+     {NID_aes_192_gcm, "aes-192-gcm", EVP_aes_192_gcm},
++    {NID_aes_192_ccm, "aes-192-ccm", EVP_aes_192_ccm},
+     {NID_aes_192_ofb128, "aes-192-ofb", EVP_aes_192_ofb},
+     {NID_aes_256_cbc, "aes-256-cbc", EVP_aes_256_cbc},
+     {NID_aes_256_cfb128, "aes-256-cfb", EVP_aes_256_cfb128},
+     {NID_aes_256_ctr, "aes-256-ctr", EVP_aes_256_ctr},
+     {NID_aes_256_ecb, "aes-256-ecb", EVP_aes_256_ecb},
+     {NID_aes_256_gcm, "aes-256-gcm", EVP_aes_256_gcm},
++    {NID_aes_256_ccm, "aes-256-ccm", EVP_aes_256_ccm},
+     {NID_aes_256_ofb128, "aes-256-ofb", EVP_aes_256_ofb},
+     {NID_bf_cbc, "bf-cbc", EVP_bf_cbc},
+     {NID_bf_cfb64, "bf-cfb", EVP_bf_cfb},

--- a/scripts/build/deps/boringssl.ts
+++ b/scripts/build/deps/boringssl.ts
@@ -11,6 +11,12 @@ export const boringssl: Dependency = {
   name: "boringssl",
   versionMacro: "BORINGSSL",
 
+  patches: [
+    "patches/boringssl/cipher.h.patch",
+    "patches/boringssl/e_aesccm.cc.inc.patch",
+    "patches/boringssl/get_cipher.cc.patch",
+  ],
+
   source: () => ({
     kind: "github-archive",
     repo: "oven-sh/boringssl",

--- a/src/bun.js/bindings/ncrypto.cpp
+++ b/src/bun.js/bindings/ncrypto.cpp
@@ -1986,8 +1986,7 @@ const EVP_MD* getDigestByName(const WTF::StringView name)
 
 const EVP_CIPHER* getCipherByName(const WTF::StringView name)
 {
-    auto nameUtf8 = name.utf8();
-    return EVP_get_cipherbyname(nameUtf8.data());
+    return Cipher::FromName(name).get();
 }
 
 bool checkHkdfLength(const Digest& md, size_t length)
@@ -3146,7 +3145,6 @@ bool SSLCtxPointer::setCipherSuites(WTF::StringView ciphers)
 
 const Cipher Cipher::FromName(WTF::StringView name)
 {
-
     if (name.startsWithIgnoringASCIICase("aes"_s)) {
         auto remain = name.substring(3);
         if (remain == "128"_s) return Cipher::AES_128_CBC();
@@ -3155,7 +3153,10 @@ const Cipher Cipher::FromName(WTF::StringView name)
     }
 
     auto nameUtf8 = name.utf8();
-    return Cipher(EVP_get_cipherbyname(nameUtf8.data()));
+    if (const EVP_CIPHER* fromEvp = EVP_get_cipherbyname(nameUtf8.data()))
+        return Cipher(fromEvp);
+
+    return Cipher();
 }
 
 const Cipher Cipher::FromNid(int nid)

--- a/src/bun.js/bindings/node/crypto/node_crypto_binding.cpp
+++ b/src/bun.js/bindings/node/crypto/node_crypto_binding.cpp
@@ -121,6 +121,22 @@ JSC_DEFINE_HOST_FUNCTION(jsGetCiphers, (JSC::JSGlobalObject * lexicalGlobalObjec
     EVP_CIPHER_do_all_sorted(callback, &ctx);
     RETURN_IF_EXCEPTION(scope, {});
 
+#ifdef OPENSSL_IS_BORINGSSL
+    // BoringSSL's EVP_CIPHER_do_all_sorted omits AES-CCM; append names if EVP has them.
+    static constexpr const char* ccmCipherNames[] = {
+        "aes-128-ccm",
+        "aes-192-ccm",
+        "aes-256-ccm",
+    };
+    for (auto cipherName : ccmCipherNames) {
+        if (EVP_get_cipherbyname(cipherName) != nullptr) {
+            auto cipherStr = JSC::jsString(vm, String::fromUTF8(cipherName));
+            result->putDirectIndex(lexicalGlobalObject, ctx.index++, cipherStr);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
+    }
+#endif
+
     return JSValue::encode(result);
 }
 

--- a/test/regression/issue/24197.test.ts
+++ b/test/regression/issue/24197.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test";
+import crypto from "crypto";
+
+test("#24197 getCipherInfo: aes-128/192/256-ccm", () => {
+  const cases: { name: "aes-128-ccm" | "aes-192-ccm" | "aes-256-ccm"; keyLength: number }[] = [
+    { name: "aes-128-ccm", keyLength: 16 },
+    { name: "aes-192-ccm", keyLength: 24 },
+    { name: "aes-256-ccm", keyLength: 32 },
+  ];
+  for (const { name, keyLength } of cases) {
+    const info = crypto.getCipherInfo(name);
+    expect(info, `getCipherInfo(${name})`).toBeDefined();
+    expect(info!.mode).toBe("ccm");
+    expect(info!.keyLength).toBe(keyLength);
+    expect(info!.blockSize).toBe(1);
+  }
+});
+
+test("#24197 aes-128-ccm encrypt/decrypt round-trip", () => {
+  const key = crypto.randomBytes(16);
+  const iv = crypto.randomBytes(12);
+  const authTagLength = 16;
+  const plaintext = "matter-style payload";
+
+  const cipher = crypto.createCipheriv("aes-128-ccm", key, iv, { authTagLength });
+  const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final(), cipher.getAuthTag()]);
+
+  const decipher = crypto.createDecipheriv("aes-128-ccm", key, iv, { authTagLength });
+  decipher.setAuthTag(ciphertext.subarray(-authTagLength));
+  const decrypted = Buffer.concat([decipher.update(ciphertext.subarray(0, -authTagLength)), decipher.final()]);
+
+  expect(decrypted.toString("utf8")).toBe(plaintext);
+});
+
+test("#24197 aes-192-ccm and aes-256-ccm round-trip", () => {
+  for (const bits of [192, 256] as const) {
+    const name = `aes-${bits}-ccm` as const;
+    const key = crypto.randomBytes(bits / 8);
+    const iv = crypto.randomBytes(12);
+    const authTagLength = 16;
+    const plaintext = Buffer.from(`pt-${bits}`);
+
+    const cipher = crypto.createCipheriv(name, key, iv, { authTagLength });
+    const out = Buffer.concat([cipher.update(plaintext), cipher.final(), cipher.getAuthTag()]);
+
+    const decipher = crypto.createDecipheriv(name, key, iv, { authTagLength });
+    decipher.setAuthTag(out.subarray(-authTagLength));
+    const decrypted = Buffer.concat([decipher.update(out.subarray(0, -authTagLength)), decipher.final()]);
+
+    expect(decrypted.equals(plaintext), `${name} round-trip`).toBe(true);
+  }
+});
+
+test("#28067 aes-256-ccm createCipheriv round-trip (parity with Node)", () => {
+  const key = crypto.randomBytes(32);
+  const iv = crypto.randomBytes(12);
+  const authTagLength = 16;
+  const plaintext = "hello";
+
+  const cipher = crypto.createCipheriv("aes-256-ccm", key, iv, { authTagLength });
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final(), cipher.getAuthTag()]);
+
+  const decipher = crypto.createDecipheriv("aes-256-ccm", key, iv, { authTagLength });
+  decipher.setAuthTag(encrypted.subarray(-authTagLength));
+  const decrypted = Buffer.concat([decipher.update(encrypted.subarray(0, -authTagLength)), decipher.final()]);
+
+  expect(decrypted.toString("utf8")).toBe(plaintext);
+});
+
+test("#24197 aes-128-ccm setAAD with plaintextLength", () => {
+  const key = crypto.randomBytes(16);
+  const iv = crypto.randomBytes(12);
+  const authTagLength = 16;
+  const aad = Buffer.from("associated");
+  const data = Buffer.from("payload bytes");
+
+  const cipher = crypto.createCipheriv("aes-128-ccm", key, iv, { authTagLength });
+  cipher.setAAD(aad, { plaintextLength: data.length });
+  const encrypted = Buffer.concat([cipher.update(data), cipher.final(), cipher.getAuthTag()]);
+
+  const plaintextLength = encrypted.length - authTagLength;
+  const decipher = crypto.createDecipheriv("aes-128-ccm", key, iv, { authTagLength });
+  decipher.setAAD(aad, { plaintextLength });
+  decipher.setAuthTag(encrypted.subarray(plaintextLength));
+  const decrypted = Buffer.concat([decipher.update(encrypted.subarray(0, plaintextLength)), decipher.final()]);
+
+  expect(decrypted.equals(data)).toBe(true);
+});
+
+test("#24197 getCiphers includes aes-128-ccm, aes-192-ccm, aes-256-ccm", () => {
+  const names = crypto.getCiphers();
+  expect(names).toContain("aes-128-ccm");
+  expect(names).toContain("aes-192-ccm");
+  expect(names).toContain("aes-256-ccm");
+});


### PR DESCRIPTION
### What does this PR do?
Fixes AES CCM encryption decryption support compatible to Node by adding patches for BoringSSL.

Fixes https://github.com/oven-sh/bun/issues/24197
Fixes https://github.com/oven-sh/bun/issues/28067

### How did you verify your code works?
Created and ran regression tests: `test/regression/issue/24197.test.ts`.

