### PR TITLE
Change `.bun_repl_history` path to avoid polluting the home dir.

### DIFF
--- a/src/repl.zig
+++ b/src/repl.zig
@@ -38,7 +38,7 @@ extern fn Bun__REPL__getCompletions(
 
 const MAX_HISTORY_SIZE: usize = 1000;
 const MAX_LINE_LENGTH: usize = 16384;
-const HISTORY_FILENAME = ".bun_repl_history";
+const HISTORY_FILENAME = ".local/share/bun/.bun_repl_history";
 const TAB_WIDTH: usize = 2;
 
 // ANSI escape codes


### PR DESCRIPTION
For some reason, the location of `.bun_repl_history` was hardcoded in the new `bun repl` rewrite. This breaks existing users: https://github.com/oven-sh/bun/issues/28291

This PR is meant to start a discussion about fixing the regression for users who have `$XDG_DATA_HOME ` set, using the path that comes from using the default value. A proper fix would be to restore the fallback calculations that `bun` used to use. However, that would be a much larger change.

### What does this PR do?

### How did you verify your code works?
