### PR TITLE
fix(repl): restore XDG_DATA_HOME and BUN_INSTALL support for history path

### DIFF
--- a/src/repl.zig
+++ b/src/repl.zig
@@ -248,7 +248,7 @@ const History = struct {
 
         // Ensure parent directory exists (e.g. $XDG_DATA_HOME/bun/).
         if (std.fs.path.dirnamePosix(path) orelse std.fs.path.dirnameWindows(path)) |dir| {
-            std.fs.cwd().makePath(dir) catch {};
+            bun.makePath(bun.FD.cwd().stdDir(), dir) catch {};
         }
 
         const file = switch (bun.sys.openA(path, bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o644)) {

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -638,7 +638,7 @@ fn cmdSave(repl: *Repl, args: []const u8) ReplResult {
         content.append('\n') catch return .skip_eval;
     }
 
-    const file = switch (bun.sys.openA(filename, bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o644)) {
+    const file = switch (bun.sys.openA(filename, bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o600)) {
         .result => |fd| bun.sys.File{ .handle = fd },
         .err => |err| {
             repl.printError("{f}\n", .{err});

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -247,9 +247,9 @@ const History = struct {
         }
 
         // Ensure parent directory exists (e.g. $XDG_DATA_HOME/bun/).
-        const dir = bun.path.dirname(path, .auto);
-        if (dir.len > 0) {
-            bun.makePath(bun.FD.cwd().stdDir(), dir) catch {};
+        const parent = bun.path.dirname(path, .auto);
+        if (parent.len > 0) {
+            bun.FD.cwd().makePath(u8, parent) catch {};
         }
 
         const file = switch (bun.sys.openA(path, bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o644)) {

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -252,7 +252,7 @@ const History = struct {
             bun.FD.cwd().makePath(u8, parent) catch {};
         }
 
-        const file = switch (bun.sys.openA(path, bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o644)) {
+        const file = switch (bun.sys.openA(path, bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o600)) {
             .result => |fd| bun.sys.File{ .handle = fd },
             .err => return,
         };

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -247,7 +247,8 @@ const History = struct {
         }
 
         // Ensure parent directory exists (e.g. $XDG_DATA_HOME/bun/).
-        if (std.fs.path.dirnamePosix(path) orelse std.fs.path.dirnameWindows(path)) |dir| {
+        const dir = bun.path.dirname(path, .auto);
+        if (dir.len > 0) {
             bun.makePath(bun.FD.cwd().stdDir(), dir) catch {};
         }
 

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -181,12 +181,29 @@ const History = struct {
         }
     }
 
-    pub fn load(self: *History) !void {
-        const home_path = bun.env_var.HOME.get() orelse return;
-        if (home_path.len == 0) return;
+    /// Resolves the history file path using the same priority as the old TS REPL:
+    ///   1. $XDG_DATA_HOME/bun/.bun_repl_history
+    ///   2. $BUN_INSTALL/.bun_repl_history
+    ///   3. $HOME/.bun_repl_history
+    fn resolveHistoryPath(buf: *bun.PathBuffer) ?[]const u8 {
+        if (bun.env_var.XDG_DATA_HOME.get()) |xdg| {
+            if (xdg.len > 0)
+                return bun.path.joinZBuf(buf, &[_][]const u8{ xdg, "bun", HISTORY_FILENAME }, .auto);
+        }
+        if (bun.env_var.BUN_INSTALL.get()) |install| {
+            if (install.len > 0)
+                return bun.path.joinZBuf(buf, &[_][]const u8{ install, HISTORY_FILENAME }, .auto);
+        }
+        if (bun.env_var.HOME.get()) |home| {
+            if (home.len > 0)
+                return bun.path.joinZBuf(buf, &[_][]const u8{ home, HISTORY_FILENAME }, .auto);
+        }
+        return null;
+    }
 
+    pub fn load(self: *History) !void {
         var path_buf: bun.PathBuffer = undefined;
-        const path = bun.path.joinZBuf(&path_buf, &[_][]const u8{ home_path, HISTORY_FILENAME }, .auto);
+        const path = resolveHistoryPath(&path_buf) orelse return;
         self.file_path = try self.allocator.dupe(u8, path);
 
         const content = switch (bun.sys.File.readFrom(bun.FD.cwd(), path, self.allocator)) {
@@ -227,6 +244,11 @@ const History = struct {
         for (self.entries.items[start..]) |entry| {
             content.appendSlice(entry) catch return;
             content.append('\n') catch return;
+        }
+
+        // Ensure parent directory exists (e.g. $XDG_DATA_HOME/bun/).
+        if (std.fs.path.dirnamePosix(path) orelse std.fs.path.dirnameWindows(path)) |dir| {
+            std.fs.cwd().makePath(dir) catch {};
         }
 
         const file = switch (bun.sys.openA(path, bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o644)) {

--- a/test/regression/issue/28291.test.ts
+++ b/test/regression/issue/28291.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import path from "path";
 import fs from "fs";
 
 const HISTORY_FILENAME = ".bun_repl_history";
+
+// On Windows, bun.env_var.HOME reads USERPROFILE instead of HOME.
+function homeEnv(dir: string): Record<string, string> {
+  return isWindows ? { USERPROFILE: dir } : { HOME: dir };
+}
 
 async function runReplWithEnv(env: Record<string, string>): Promise<number> {
   await using proc = Bun.spawn({
@@ -31,7 +36,7 @@ describe("REPL history respects XDG_DATA_HOME and BUN_INSTALL", () => {
     const fakeHome = path.join(String(dir), "home");
 
     const exitCode = await runReplWithEnv({
-      HOME: fakeHome,
+      ...homeEnv(fakeHome),
       XDG_DATA_HOME: xdgDataHome,
       BUN_INSTALL: "",
     });
@@ -39,7 +44,7 @@ describe("REPL history respects XDG_DATA_HOME and BUN_INSTALL", () => {
 
     const expectedPath = path.join(xdgDataHome, "bun", HISTORY_FILENAME);
     expect(fs.existsSync(expectedPath)).toBe(true);
-    // Should NOT be written to $HOME
+    // Should NOT be written to home dir
     expect(fs.existsSync(path.join(fakeHome, HISTORY_FILENAME))).toBe(false);
   });
 
@@ -52,7 +57,7 @@ describe("REPL history respects XDG_DATA_HOME and BUN_INSTALL", () => {
     const fakeHome = path.join(String(dir), "home");
 
     const exitCode = await runReplWithEnv({
-      HOME: fakeHome,
+      ...homeEnv(fakeHome),
       XDG_DATA_HOME: "",
       BUN_INSTALL: bunInstall,
     });
@@ -60,16 +65,16 @@ describe("REPL history respects XDG_DATA_HOME and BUN_INSTALL", () => {
 
     const expectedPath = path.join(bunInstall, HISTORY_FILENAME);
     expect(fs.existsSync(expectedPath)).toBe(true);
-    // Should NOT be written to $HOME
+    // Should NOT be written to home dir
     expect(fs.existsSync(path.join(fakeHome, HISTORY_FILENAME))).toBe(false);
   });
 
-  test("falls back to $HOME when neither XDG_DATA_HOME nor BUN_INSTALL is set", async () => {
+  test("falls back to home dir when neither XDG_DATA_HOME nor BUN_INSTALL is set", async () => {
     using dir = tempDir("repl-home", { ".keep": "" });
     const fakeHome = String(dir);
 
     const exitCode = await runReplWithEnv({
-      HOME: fakeHome,
+      ...homeEnv(fakeHome),
       XDG_DATA_HOME: "",
       BUN_INSTALL: "",
     });
@@ -90,7 +95,7 @@ describe("REPL history respects XDG_DATA_HOME and BUN_INSTALL", () => {
     const fakeHome = path.join(String(dir), "home");
 
     const exitCode = await runReplWithEnv({
-      HOME: fakeHome,
+      ...homeEnv(fakeHome),
       XDG_DATA_HOME: xdgDataHome,
       BUN_INSTALL: bunInstall,
     });

--- a/test/regression/issue/28291.test.ts
+++ b/test/regression/issue/28291.test.ts
@@ -14,8 +14,8 @@ async function runReplWithEnv(env: Record<string, string>): Promise<number> {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "repl"],
     stdin: Buffer.from("1+1\n.exit\n"),
-    stdout: "pipe",
-    stderr: "pipe",
+    stdout: "ignore",
+    stderr: "ignore",
     env: {
       ...bunEnv,
       TERM: "dumb",
@@ -27,7 +27,7 @@ async function runReplWithEnv(env: Record<string, string>): Promise<number> {
 }
 
 describe("REPL history respects XDG_DATA_HOME and BUN_INSTALL", () => {
-  test("uses $XDG_DATA_HOME/bun/ when XDG_DATA_HOME is set", async () => {
+  test.concurrent("uses $XDG_DATA_HOME/bun/ when XDG_DATA_HOME is set", async () => {
     using dir = tempDir("repl-xdg", {
       "xdg-data": { ".keep": "" },
       "home": { ".keep": "" },
@@ -48,7 +48,7 @@ describe("REPL history respects XDG_DATA_HOME and BUN_INSTALL", () => {
     expect(fs.existsSync(path.join(fakeHome, HISTORY_FILENAME))).toBe(false);
   });
 
-  test("uses $BUN_INSTALL when BUN_INSTALL is set and XDG_DATA_HOME is not", async () => {
+  test.concurrent("uses $BUN_INSTALL when BUN_INSTALL is set and XDG_DATA_HOME is not", async () => {
     using dir = tempDir("repl-install", {
       "bun-install": { ".keep": "" },
       "home": { ".keep": "" },
@@ -69,7 +69,7 @@ describe("REPL history respects XDG_DATA_HOME and BUN_INSTALL", () => {
     expect(fs.existsSync(path.join(fakeHome, HISTORY_FILENAME))).toBe(false);
   });
 
-  test("falls back to home dir when neither XDG_DATA_HOME nor BUN_INSTALL is set", async () => {
+  test.concurrent("falls back to home dir when neither XDG_DATA_HOME nor BUN_INSTALL is set", async () => {
     using dir = tempDir("repl-home", { ".keep": "" });
     const fakeHome = String(dir);
 
@@ -84,7 +84,7 @@ describe("REPL history respects XDG_DATA_HOME and BUN_INSTALL", () => {
     expect(fs.existsSync(expectedPath)).toBe(true);
   });
 
-  test("XDG_DATA_HOME takes priority over BUN_INSTALL", async () => {
+  test.concurrent("XDG_DATA_HOME takes priority over BUN_INSTALL", async () => {
     using dir = tempDir("repl-priority", {
       "xdg-data": { ".keep": "" },
       "bun-install": { ".keep": "" },

--- a/test/regression/issue/28291.test.ts
+++ b/test/regression/issue/28291.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "path";
+import fs from "fs";
+
+const HISTORY_FILENAME = ".bun_repl_history";
+
+async function runReplWithEnv(env: Record<string, string>): Promise<number> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "repl"],
+    stdin: Buffer.from("1+1\n.exit\n"),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...bunEnv,
+      TERM: "dumb",
+      NO_COLOR: "1",
+      ...env,
+    },
+  });
+  return await proc.exited;
+}
+
+describe("REPL history respects XDG_DATA_HOME and BUN_INSTALL", () => {
+  test("uses $XDG_DATA_HOME/bun/ when XDG_DATA_HOME is set", async () => {
+    using dir = tempDir("repl-xdg", {
+      "xdg-data": { ".keep": "" },
+      "home": { ".keep": "" },
+    });
+    const xdgDataHome = path.join(String(dir), "xdg-data");
+    const fakeHome = path.join(String(dir), "home");
+
+    const exitCode = await runReplWithEnv({
+      HOME: fakeHome,
+      XDG_DATA_HOME: xdgDataHome,
+      BUN_INSTALL: "",
+    });
+    expect(exitCode).toBe(0);
+
+    const expectedPath = path.join(xdgDataHome, "bun", HISTORY_FILENAME);
+    expect(fs.existsSync(expectedPath)).toBe(true);
+    // Should NOT be written to $HOME
+    expect(fs.existsSync(path.join(fakeHome, HISTORY_FILENAME))).toBe(false);
+  });
+
+  test("uses $BUN_INSTALL when BUN_INSTALL is set and XDG_DATA_HOME is not", async () => {
+    using dir = tempDir("repl-install", {
+      "bun-install": { ".keep": "" },
+      "home": { ".keep": "" },
+    });
+    const bunInstall = path.join(String(dir), "bun-install");
+    const fakeHome = path.join(String(dir), "home");
+
+    const exitCode = await runReplWithEnv({
+      HOME: fakeHome,
+      XDG_DATA_HOME: "",
+      BUN_INSTALL: bunInstall,
+    });
+    expect(exitCode).toBe(0);
+
+    const expectedPath = path.join(bunInstall, HISTORY_FILENAME);
+    expect(fs.existsSync(expectedPath)).toBe(true);
+    // Should NOT be written to $HOME
+    expect(fs.existsSync(path.join(fakeHome, HISTORY_FILENAME))).toBe(false);
+  });
+
+  test("falls back to $HOME when neither XDG_DATA_HOME nor BUN_INSTALL is set", async () => {
+    using dir = tempDir("repl-home", { ".keep": "" });
+    const fakeHome = String(dir);
+
+    const exitCode = await runReplWithEnv({
+      HOME: fakeHome,
+      XDG_DATA_HOME: "",
+      BUN_INSTALL: "",
+    });
+    expect(exitCode).toBe(0);
+
+    const expectedPath = path.join(fakeHome, HISTORY_FILENAME);
+    expect(fs.existsSync(expectedPath)).toBe(true);
+  });
+
+  test("XDG_DATA_HOME takes priority over BUN_INSTALL", async () => {
+    using dir = tempDir("repl-priority", {
+      "xdg-data": { ".keep": "" },
+      "bun-install": { ".keep": "" },
+      "home": { ".keep": "" },
+    });
+    const xdgDataHome = path.join(String(dir), "xdg-data");
+    const bunInstall = path.join(String(dir), "bun-install");
+    const fakeHome = path.join(String(dir), "home");
+
+    const exitCode = await runReplWithEnv({
+      HOME: fakeHome,
+      XDG_DATA_HOME: xdgDataHome,
+      BUN_INSTALL: bunInstall,
+    });
+    expect(exitCode).toBe(0);
+
+    // Should be in XDG path, not BUN_INSTALL
+    expect(fs.existsSync(path.join(xdgDataHome, "bun", HISTORY_FILENAME))).toBe(true);
+    expect(fs.existsSync(path.join(bunInstall, HISTORY_FILENAME))).toBe(false);
+  });
+});

--- a/test/regression/issue/28291.test.ts
+++ b/test/regression/issue/28291.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import fs from "fs";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import path from "path";
-import fs from "fs";
 
 const HISTORY_FILENAME = ".bun_repl_history";
 


### PR DESCRIPTION
## Summary

- Restore the original REPL history file path resolution that was lost during the TypeScript-to-Zig rewrite (#26304)
- The priority order now matches the old behavior: `$XDG_DATA_HOME/bun/.bun_repl_history` > `$BUN_INSTALL/.bun_repl_history` > `$HOME/.bun_repl_history`
- Ensure the parent directory is created on save (needed for the `$XDG_DATA_HOME/bun/` subdirectory)

## Test plan

- [x] New regression tests in `test/regression/issue/28291.test.ts` verify all 4 scenarios:
  - XDG_DATA_HOME is respected
  - BUN_INSTALL is respected as fallback
  - HOME is used as final fallback
  - XDG_DATA_HOME takes priority over BUN_INSTALL
- [x] Tests fail with system bun (`USE_SYSTEM_BUN=1`) confirming the regression
- [x] Tests pass with debug build (`bun bd test`)

Closes #28291

---
Verification: CI build #40194 pending (Lint JS passed, BuildKite compiling). Diff is clean — 2 files touched (src/repl.zig, test/regression/issue/28291.test.ts), no TODO/FIXME/HACK. All bot review comments (CodeRabbit dirname nit, Claude 0o600/stdout-ignore nits, ban-words .stdDir() fix) resolved across follow-up commits. Tests confirmed to fail 3/4 on main via USE_SYSTEM_BUN=1 and pass 4/4 with debug build. Code uses correct project APIs (bun.env_var, bun.path.joinZBuf/.dirname, bun.FD.cwd().makePath).