### PR TITLE
deflake serve-body-leak: skip on ASAN where RSS-based leak detection is not meaningful

### DIFF
--- a/test/js/bun/http/serve-body-leak.test.ts
+++ b/test/js/bun/http/serve-body-leak.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "bun:test";
-import { bunEnv, bunExe, isCI, isDebug, isFlaky, isLinux, isWindows } from "harness";
+import { bunEnv, bunExe, isASAN, isCI, isDebug, isFlaky, isLinux, isWindows } from "harness";
 import { join } from "path";
 
 const payload = Buffer.alloc(512 * 1024, "1").toString("utf-8"); // decent size payload to test memory leak
@@ -153,6 +153,9 @@ async function calculateMemoryLeak(fn: (url: URL) => Promise<void>, url: URL) {
 // Since the payload size is 512 KB
 // If it was leaking the body, the memory usage would be at least 512 KB * 10_000 = 5 GB
 // If it ends up around 280 MB, it's probably not leaking the body.
+//
+// Skip on ASAN: RSS-based memory leak detection is not meaningful under ASAN,
+// which adds massive memory overhead and has its own leak detection.
 for (const test_info of [
   ["#10265 should not leak memory when ignoring the body", callIgnore, false, 64],
   ["should not leak memory when buffering the body", callBuffering, false, 64],
@@ -163,7 +166,7 @@ for (const test_info of [
   ["should not leak memory when streaming the body and echoing it back", callStreamingEcho, false, 64],
 ] as const) {
   const [testName, fn, skip, maxMemoryGrowth] = test_info;
-  it.todoIf(skip || (isFlaky && isWindows))(
+  it.todoIf(skip || (isFlaky && isWindows) || isASAN)(
     testName,
     async () => {
       const { url, process } = await getURL();

--- a/test/js/bun/http/serve-body-leak.test.ts
+++ b/test/js/bun/http/serve-body-leak.test.ts
@@ -154,8 +154,9 @@ async function calculateMemoryLeak(fn: (url: URL) => Promise<void>, url: URL) {
 // If it was leaking the body, the memory usage would be at least 512 KB * 10_000 = 5 GB
 // If it ends up around 280 MB, it's probably not leaking the body.
 //
-// Skip on ASAN: RSS-based memory leak detection is not meaningful under ASAN,
-// which adds massive memory overhead and has its own leak detection.
+// Skip on ASAN: its quarantine (default 256MB) and allocator metadata inflate
+// RSS enough to break the `end_memory ≤ 512MB` threshold even without leaks,
+// and the 2x slowdown can hit the 40/60s timeout with 20k requests per case.
 for (const test_info of [
   ["#10265 should not leak memory when ignoring the body", callIgnore, false, 64],
   ["should not leak memory when buffering the body", callBuffering, false, 64],


### PR DESCRIPTION
The serve-body-leak test sends 10k warmup + 10k test requests per test case (7 cases = 140k requests) with 512KB payloads. Under ASAN this causes timeouts and crashes because:

- ASAN adds 2-3x memory overhead, making RSS measurements meaningless for leak detection
- ASAN significantly slows execution, causing test timeouts (40s/60s limits)
- The subprocess gets OOM-killed under the added memory pressure

RSS-based memory leak detection is not meaningful under ASAN, which has its own built-in leak detection. Skip these tests on ASAN builds.