### PR TITLE
fix(init): correct docs link in generated CLAUDE.md

### DIFF
--- a/src/init/rule.md
+++ b/src/init/rule.md
@@ -108,4 +108,4 @@ Then, run index.ts
 bun --hot ./index.ts
 ```
 
-For more information, read the Bun API docs in `node_modules/bun-types/docs/**.mdx`.
+For more information, read the Bun API docs at https://bun.com/docs.


### PR DESCRIPTION
## What does this PR do?

`bun init` generates a CLAUDE.md (and `.cursor/rules/rule.mdc`) containing:

> For more information, read the Bun API docs in `node_modules/bun-types/docs/**.mdx`.

This path does not exist. The `bun-types` package contains only `.d.ts` files - there is no `docs/` subdirectory with `.mdx` files.

This PR changes the reference in `src/init/rule.md` line 111 to point to `https://bun.com/docs` instead.

Fixes #27950

## How did you verify your code works?

Confirmed `packages/bun-types/` has no `docs/` directory. The canonical docs URL `https://bun.com/docs` is already used throughout the codebase (see `docs/docs.json`).

This contribution was developed with AI assistance (Claude Code).