### PR TITLE
docs: add MCP server URL documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -365,6 +365,7 @@
               "/guides/ecosystem/elysia",
               "/guides/ecosystem/express",
               "/guides/ecosystem/hono",
+              "/guides/ecosystem/mcp-server",
               "/guides/ecosystem/mongoose",
               "/guides/ecosystem/neon-drizzle",
               "/guides/ecosystem/neon-serverless-postgres",

--- a/docs/guides/ecosystem/mcp-server.mdx
+++ b/docs/guides/ecosystem/mcp-server.mdx
@@ -12,7 +12,7 @@ The server URL is:
 https://bun.com/docs/mcp
 ```
 
-It uses Streamable HTTP transport and requires no authentication.
+It uses Streamable HTTP transport and requires no authentication or API key. There are no usage limits.
 
 ## Claude Code
 
@@ -58,6 +58,22 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
   "mcpServers": {
     "bun-docs": {
       "serverUrl": "https://bun.com/docs/mcp"
+    }
+  }
+}
+```
+
+## Zed
+
+Add to Zed's settings (`Zed > Settings > Open Settings`), under `"context_servers"`:
+
+```json
+{
+  "context_servers": {
+    "bun-docs": {
+      "settings": {
+        "url": "https://bun.com/docs/mcp"
+      }
     }
   }
 }

--- a/docs/guides/ecosystem/mcp-server.mdx
+++ b/docs/guides/ecosystem/mcp-server.mdx
@@ -1,0 +1,68 @@
+---
+title: MCP server for Bun docs
+sidebarTitle: MCP Server
+mode: center
+---
+
+Bun's documentation site provides a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that exposes a search tool for AI coding assistants to query the docs programmatically.
+
+The server URL is:
+
+```
+https://bun.com/docs/mcp
+```
+
+It uses Streamable HTTP transport and requires no authentication.
+
+## Claude Code
+
+```bash
+claude mcp add --transport http bun-docs https://bun.com/docs/mcp
+```
+
+## Cursor
+
+Add to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "bun-docs": {
+      "url": "https://bun.com/docs/mcp"
+    }
+  }
+}
+```
+
+## VS Code
+
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "bun-docs": {
+      "type": "http",
+      "url": "https://bun.com/docs/mcp"
+    }
+  }
+}
+```
+
+## Windsurf
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "bun-docs": {
+      "serverUrl": "https://bun.com/docs/mcp"
+    }
+  }
+}
+```
+
+## What it provides
+
+The MCP server exposes a single `search` tool that queries the Bun documentation. AI assistants can use this to look up API details, configuration options, and guides without leaving your editor.


### PR DESCRIPTION
## What does this PR do?

Every page on bun.com/docs has a "Copy MCP server URL" button (configured via the `mcp` option in `docs/docs.json` line 47), but there's no documentation page explaining what `https://bun.com/docs/mcp` is or how to use it.

Adds `docs/guides/ecosystem/mcp-server.mdx` with:
- The MCP server URL and transport type (Streamable HTTP)
- Configuration examples for Claude Code, Cursor, VS Code, and Windsurf
- Brief description of the exposed search tool

Also adds the nav entry in `docs/docs.json` under "Ecosystem & Frameworks".

Fixes #28187

## How did you verify your code works?

- Confirmed `https://bun.com/docs/mcp` returns 405 on GET (expected for a Streamable HTTP MCP endpoint that only accepts POST)
- Verified configuration format against [Mintlify's MCP docs](https://mintlify.com/docs/ai/model-context-protocol)
- Checked existing `.mdx` files in `docs/guides/ecosystem/` for frontmatter conventions

This contribution was developed with AI assistance (Claude Code).