### PR TITLE
Fix null pointer dereference in BunString__toJSDOMURL

### DIFF
--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -576,6 +576,7 @@ extern "C" JSC::EncodedJSValue BunString__toJSDOMURL(JSC::JSGlobalObject* lexica
 
     auto object = WebCore::DOMURL::create(str, String());
     auto jsValue = WebCore::toJSNewlyCreated<WebCore::IDLInterface<WebCore::DOMURL>>(*lexicalGlobalObject, globalObject, throwScope, WTF::move(object));
+    RETURN_IF_EXCEPTION(throwScope, {});
     auto* jsDOMURL = jsCast<WebCore::JSDOMURL*>(jsValue.asCell());
     vm.heap.reportExtraMemoryAllocated(jsDOMURL, jsDOMURL->wrapped().memoryCostForGC());
     RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(jsValue));

--- a/test/js/bun/http/server-url-invalid.test.ts
+++ b/test/js/bun/http/server-url-invalid.test.ts
@@ -4,16 +4,12 @@ test("server.url does not crash when unix socket path produces invalid URL", () 
   // Passing an object as the unix socket path causes the URL formatter to produce
   // a string like "unix://[object Bun]" which is not a valid URL. Accessing
   // server.url should throw a proper JS error instead of crashing.
-  const server = Bun.serve({
+  using server = Bun.serve({
     // @ts-expect-error: intentionally passing invalid type
     unix: Bun,
     fetch() {
       return new Response("ok");
     },
   });
-  try {
-    expect(() => server.url).toThrow();
-  } finally {
-    server.stop(true);
-  }
+  expect(() => server.url).toThrow();
 });

--- a/test/js/bun/http/server-url-invalid.test.ts
+++ b/test/js/bun/http/server-url-invalid.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("server.url does not crash when unix socket path produces invalid URL", () => {
   // Passing an object as the unix socket path causes the URL formatter to produce

--- a/test/js/bun/http/server-url-invalid.test.ts
+++ b/test/js/bun/http/server-url-invalid.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "bun:test";
+
+test("server.url does not crash when unix socket path produces invalid URL", () => {
+  // Passing an object as the unix socket path causes the URL formatter to produce
+  // a string like "unix://[object Bun]" which is not a valid URL. Accessing
+  // server.url should throw a proper JS error instead of crashing.
+  const server = Bun.serve({
+    // @ts-expect-error: intentionally passing invalid type
+    unix: Bun,
+    fetch() {
+      return new Response("ok");
+    },
+  });
+  try {
+    expect(() => server.url).toThrow();
+  } finally {
+    server.stop(true);
+  }
+});


### PR DESCRIPTION
**Root cause:** `BunString__toJSDOMURL` calls `DOMURL::create()` which returns an `ExceptionOr<Ref<DOMURL>>`. When the URL string is invalid (e.g. `"unix://[object Bun]"`), this returns an exception. `toJSNewlyCreated` propagates the exception onto the throw scope and returns an empty `JSValue`. However, the code then unconditionally called `jsCast<JSDOMURL*>(jsValue.asCell())` on the null cell, causing a null pointer dereference.

**Fix:** Add `RETURN_IF_EXCEPTION(throwScope, {})` after `toJSNewlyCreated` to return early when URL parsing fails, properly propagating the exception back to JavaScript.

**Reproduction:** Pass a non-string value (like the `Bun` object) as the `unix` option to `Bun.serve()`, then access `server.url`. The URL formatter produces `"unix://[object Bun]"` which is not parseable by the WHATWG URL parser.

```js
const server = Bun.serve({ unix: Bun, fetch() { return new Response("ok"); } });
server.url; // crash
```

---
Verified by robobun: Single-line fix adds `RETURN_IF_EXCEPTION` guard in `BunString.cpp:579`, consistent with the same pattern used ~10 other times in the same file. Code path confirmed: `server.url` → `getURL` → `toJSDOMURL` → `BunString__toJSDOMURL`. Test in `server-url-invalid.test.ts` reproduces the exact crash scenario (invalid unix path → unparseable URL → null cell dereference). No TODO/FIXME/HACK in diff. CI pending (build #40232) but change is minimal and mechanical.