### PR TITLE
fix: sync PackageManager.log with resolver.log in resolveMaybeNeedsTrailingSlash

### DIFF
--- a/src/transpiler.zig
+++ b/src/transpiler.zig
@@ -317,9 +317,6 @@ pub const Transpiler = struct {
         this.log = log;
         this.linker.log = log;
         this.resolver.log = log;
-        if (this.resolver.package_manager) |pm| {
-            pm.log = log;
-        }
     }
 
     // TODO: remove this method. it does not make sense

--- a/src/transpiler.zig
+++ b/src/transpiler.zig
@@ -317,6 +317,9 @@ pub const Transpiler = struct {
         this.log = log;
         this.linker.log = log;
         this.resolver.log = log;
+        if (this.resolver.package_manager) |pm| {
+            pm.log = log;
+        }
     }
 
     // TODO: remove this method. it does not make sense

--- a/test/js/bun/resolve/resolve-require-nonexistent-no-crash.test.ts
+++ b/test/js/bun/resolve/resolve-require-nonexistent-no-crash.test.ts
@@ -12,7 +12,7 @@ test("require of nonexistent module does not crash", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
   expect(stderr).not.toContain("AddressSanitizer");
   expect(exitCode).not.toBe(null);

--- a/test/js/bun/resolve/resolve-require-nonexistent-no-crash.test.ts
+++ b/test/js/bun/resolve/resolve-require-nonexistent-no-crash.test.ts
@@ -12,10 +12,7 @@ test("require of nonexistent module does not crash", async () => {
     stderr: "pipe",
   });
 
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const exitCode = await proc.exited;
 
-  expect(stderr).not.toContain("AddressSanitizer");
-  expect(exitCode).not.toBe(null);
-  // Should exit cleanly or with a non-crash error, not SIGABRT (134)
-  expect(exitCode).not.toBe(134);
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/resolve/resolve-require-nonexistent-no-crash.test.ts
+++ b/test/js/bun/resolve/resolve-require-nonexistent-no-crash.test.ts
@@ -1,13 +1,14 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 // Regression test: require() of a nonexistent package should not crash
 // due to PackageManager.log pointing at a stale stack-allocated Log
 // when the resolve path triggers auto-install network activity.
 test("require of nonexistent module does not crash", async () => {
+  using installDir = tempDir("resolve-require-nonexistent-no-crash-", {});
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", `try { require("nonexistent-pkg-38391"); } catch (e) {}`],
-    env: { ...bunEnv, BUN_INSTALL_GLOBAL_DIR: "/tmp/bun-test-resolve-crash" },
+    env: { ...bunEnv, BUN_INSTALL_GLOBAL_DIR: String(installDir) },
     stderr: "pipe",
   });
 

--- a/test/js/bun/resolve/resolve-require-nonexistent-no-crash.test.ts
+++ b/test/js/bun/resolve/resolve-require-nonexistent-no-crash.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test: require() of a nonexistent package should not crash
+// due to PackageManager.log pointing at a stale stack-allocated Log
+// when the resolve path triggers auto-install network activity.
+test("require of nonexistent module does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `try { require("nonexistent-pkg-38391"); } catch (e) {}`],
+    env: { ...bunEnv, BUN_INSTALL_GLOBAL_DIR: "/tmp/bun-test-resolve-crash" },
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).not.toContain("AddressSanitizer");
+  expect(exitCode).not.toBe(null);
+  // Should exit cleanly or with a non-crash error, not SIGABRT (134)
+  expect(exitCode).not.toBe(134);
+});

--- a/test/js/bun/resolve/resolve-require-nonexistent-no-crash.test.ts
+++ b/test/js/bun/resolve/resolve-require-nonexistent-no-crash.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // Regression test: require() of a nonexistent package should not crash
@@ -11,11 +11,7 @@ test("require of nonexistent module does not crash", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).not.toContain("AddressSanitizer");
   expect(exitCode).not.toBe(null);

--- a/test/js/bun/resolve/resolve-require-nonexistent-no-crash.test.ts
+++ b/test/js/bun/resolve/resolve-require-nonexistent-no-crash.test.ts
@@ -9,7 +9,7 @@ test("require of nonexistent module does not crash", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", `try { require("nonexistent-pkg-38391"); } catch (e) {}`],
     env: { ...bunEnv, BUN_INSTALL_GLOBAL_DIR: String(installDir) },
-    stderr: "pipe",
+    stderr: "inherit",
   });
 
   const exitCode = await proc.exited;


### PR DESCRIPTION
Fixes a flaky stack-buffer-overflow crash (fingerprint `0182409cb972ff92`) found by Fuzzilli.

## Root Cause

`resolveMaybeNeedsTrailingSlash` in `VirtualMachine.zig` temporarily points `resolver.log` at a stack-allocated `logger.Log`, but does not update `PackageManager.log` to match. The companion function `transpileSourceCode` already does this correctly.

When `require()` triggers auto-install and the PackageManager's `sleepUntil` spins the JS event loop via `event_loop.tick()`, any HTTP error during `runTasks` calls `manager.log.addErrorFmt()`. Since `pm.log` was never updated, it still points at a previous (possibly dead) stack frame, causing a stack-buffer-overflow when writing `log.errors += 1`.

## Fix

Update `pm.log` alongside `resolver.log` in `resolveMaybeNeedsTrailingSlash`, and restore it in the defer block — matching the existing pattern in `transpileSourceCode`.

## Repro
```js
try { require("nonexistent-pkg"); } catch (e) {}
```
Crashes intermittently under ASAN when auto-install attempts a network request that fails.