### PR TITLE
resolver: reject invalid chars in package names to prevent stack-buffer-overflow

### DIFF
--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -1472,6 +1472,12 @@ pub const ESModule = struct {
                 parseSubpath(&package.subpath, specifier[package.name.len..], subpath_buf);
             }
 
+            // Validate the final package name (after version splitting) against
+            // the npm package name allowlist. This prevents names with characters
+            // like <, >, spaces, quotes, etc. from reaching the auto-install path.
+            if (!strings.isNPMPackageNameIgnoreLength(package.name))
+                return null;
+
             return package;
         }
 

--- a/test/js/bun/resolve/resolve-invalid-package-name.test.ts
+++ b/test/js/bun/resolve/resolve-invalid-package-name.test.ts
@@ -11,7 +11,7 @@ test("require with invalid package name containing special chars", async () => {
     // 33 bytes, contains <, >, ", space — all invalid in npm package names
     "run.js": [
       "const t = Bun.nanoseconds();",
-      'try { require(\'<a name="undefined">38391</a>\'); } catch {}',
+      "try { require('<a name=\"undefined\">38391</a>'); } catch {}",
       "const ms = (Bun.nanoseconds() - t) / 1e6;",
       "// Without the fix: auto-install is attempted (100-300ms network roundtrip)",
       "// With the fix: ESModule.Package.parse rejects the name (<50ms)",

--- a/test/js/bun/resolve/resolve-invalid-package-name.test.ts
+++ b/test/js/bun/resolve/resolve-invalid-package-name.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Requiring a package name with invalid characters (>, <, spaces, etc.)
+// should not trigger auto-install. Before the fix, ESModule.Package.parse
+// accepted these names, causing the resolver to attempt npm registry
+// lookups for nonsensical package names.
+test("require with invalid package name containing special chars", async () => {
+  using dir = tempDir("resolve-invalid-pkg", {
+    "package.json": "{}",
+    // 33 bytes, contains <, >, ", space — all invalid in npm package names
+    "run.js": [
+      "const t = Bun.nanoseconds();",
+      'try { require(\'<a name="undefined">38391</a>\'); } catch {}',
+      "const ms = (Bun.nanoseconds() - t) / 1e6;",
+      "// Without the fix: auto-install is attempted (100-300ms network roundtrip)",
+      "// With the fix: ESModule.Package.parse rejects the name (<50ms)",
+      "process.exit(ms > 50 ? 99 : 0);",
+    ].join("\n"),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--install=fallback", "run.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // 99 = auto-install was attempted (unfixed), 0 = skipped (fixed)
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What this PR does

Expands character validation in `ESModule.Package.parse` to reject characters that are invalid in npm package names (`<`, `>`, `"`, `'`, backtick, `!`, `#`, `$`, `&`, `|`, `(`, `)`, `{`, `}`, `[`, `]`, and space), in addition to the previously rejected `\\` and `%`.

When `require()` is called with a string like `<a name="undefined">38391</a>` (33 bytes, from `String.prototype.anchor()`), the name would pass validation and reach the auto-install path. If the name exceeds 31 bytes (`StringOrTinyString::Max`), it gets stored as a pointer to temporary memory rather than copied inline. When the package manager later processes the network response, the original memory may have been reused, causing a stack-buffer-overflow.

With this fix, `ESModule.Package.parse` returns `null` for names containing these characters, so the auto-install codepath at line 1907 of `resolver.zig` (`esm_ != null` check) is never entered.

## How did you verify your code works?

1. Confirmed the original ASAN crash repro no longer crashes with `$BUN_DEBUG_FUZZ /tmp/crash.js`
2. Verified the test fails on system bun (unfixed): `require()` with the invalid 33-byte name triggers auto-install (network request, ~100-300ms). With the fix, auto-install is skipped (<50ms).
3. Verified valid package names (`lodash`, `@types/node`, `my-package`, etc.) still resolve normally.

Crash fingerprint: `4ee3dd1e44a56032`