### PR TITLE
Fix FormData.toJSON() crash with duplicate numeric keys

### DIFF
--- a/src/bun.js/bindings/webcore/JSDOMFormData.cpp
+++ b/src/bun.js/bindings/webcore/JSDOMFormData.cpp
@@ -646,8 +646,15 @@ JSC::JSValue getInternalProperties(JSC::VM& vm, JSGlobalObject* lexicalGlobalObj
         auto& key = entry.name;
         auto& value = entry.data;
         auto ident = Identifier::fromString(vm, key);
+        auto index = JSC::parseIndex(ident);
         if (seenKeys.contains(key)) {
-            JSValue jsValue = obj->getDirect(vm, ident);
+            JSValue jsValue;
+            if (index.has_value()) [[unlikely]] {
+                jsValue = obj->getDirectIndex(lexicalGlobalObject, index.value());
+                RETURN_IF_EXCEPTION(throwScope, {});
+            } else {
+                jsValue = obj->getDirect(vm, ident);
+            }
             if (jsValue.isString() || jsValue.inherits<JSBlob>()) {
                 // Make sure this runs before the deferral scope is called.
                 JSValue resultValue = toJSValue(value);
@@ -670,7 +677,12 @@ JSC::JSValue getInternalProperties(JSC::VM& vm, JSGlobalObject* lexicalGlobalObj
                     array->initializeIndex(initializationScope, 1, resultValue);
                 }
 
-                obj->putDirect(vm, ident, array, 0);
+                if (index.has_value()) [[unlikely]] {
+                    obj->putDirectIndex(lexicalGlobalObject, index.value(), array);
+                    RETURN_IF_EXCEPTION(throwScope, {});
+                } else {
+                    obj->putDirect(vm, ident, array, 0);
+                }
             } else if (jsValue.isObject() && jsValue.getObject()->inherits<JSC::JSArray>()) {
                 JSC::JSArray* array = jsCast<JSC::JSArray*>(jsValue.getObject());
                 JSValue jsValue = toJSValue(value);
@@ -685,8 +697,12 @@ JSC::JSValue getInternalProperties(JSC::VM& vm, JSGlobalObject* lexicalGlobalObj
             seenKeys.add(key);
             JSValue jsValue = toJSValue(value);
             RETURN_IF_EXCEPTION(throwScope, {});
-            obj->putDirectMayBeIndex(lexicalGlobalObject, ident, jsValue);
-            RETURN_IF_EXCEPTION(throwScope, {});
+            if (index.has_value()) [[unlikely]] {
+                obj->putDirectIndex(lexicalGlobalObject, index.value(), jsValue);
+                RETURN_IF_EXCEPTION(throwScope, {});
+            } else {
+                obj->putDirect(vm, ident, jsValue);
+            }
         }
     }
 

--- a/src/bun.js/bindings/webcore/JSDOMFormData.cpp
+++ b/src/bun.js/bindings/webcore/JSDOMFormData.cpp
@@ -671,7 +671,10 @@ JSC::JSValue getInternalProperties(JSC::VM& vm, JSGlobalObject* lexicalGlobalObj
                         initializationScope, &deferralContext,
                         lexicalGlobalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous),
                         2);
-                    RELEASE_ASSERT(array);
+                    if (!array) [[unlikely]] {
+                        throwScope.throwException(lexicalGlobalObject, createOutOfMemoryError(lexicalGlobalObject));
+                        return {};
+                    }
 
                     array->initializeIndex(initializationScope, 0, jsValue);
                     array->initializeIndex(initializationScope, 1, resultValue);

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -277,6 +277,25 @@ describe("FormData", () => {
     expect(fd.toJSON()).toEqual({ "1": "1" });
   });
 
+  test("FormData.toJSON handles duplicate numeric keys", () => {
+    const fd = new FormData();
+    fd.append("42", "a");
+    fd.append("42", "b");
+    fd.append("42", "c");
+    // @ts-expect-error - toJSON is a Bun extension
+    expect(fd.toJSON()).toEqual({ "42": ["a", "b", "c"] });
+  });
+
+  test("FormData.toJSON handles mixed numeric and named duplicate keys", () => {
+    const fd = new FormData();
+    fd.append("0", "first");
+    fd.append("name", "x");
+    fd.append("0", "second");
+    fd.append("name", "y");
+    // @ts-expect-error - toJSON is a Bun extension
+    expect(fd.toJSON()).toEqual({ "0": ["first", "second"], name: ["x", "y"] });
+  });
+
   test("FormData.from throws on very large input instead of crashing", () => {
     // This test verifies that FormData.from throws an exception instead of crashing
     // when given input larger than WebKit's String::MaxLength (INT32_MAX ~= 2GB).


### PR DESCRIPTION
Follow-up to #28314 — same class of bug in FormData.

`FormData.toJSON()` segfaults when a numeric key (e.g. `"42"`) appears more than once. The first occurrence is stored in indexed property storage via `putDirectMayBeIndex()`, but on the second occurrence `getDirect(vm, ident)` only searches named storage and returns an empty `JSValue`. The subsequent `inherits<JSBlob>()` call dereferences a null cell pointer → crash at address `0x5`.

**Minimal repro:**
```js
const fd = new FormData();
fd.append("42", "a");
fd.append("42", "b");
fd.toJSON(); // SEGV
```

**Fix:** Parse the index once with `JSC::parseIndex(ident)` and dispatch to `getDirectIndex`/`putDirectIndex` vs `getDirect`/`putDirect`. This matches the pattern in `JSURLSearchParams.cpp:431-476` (`putIntoObject<bool hasIndex>`).

**Verification:**
- New tests for duplicate numeric keys (2 and 3 occurrences) and mixed numeric+named duplicates
- Tests fail on release bun (segfault), pass with this fix
- Full FormData test suite passes (112/113 — the one failure is a pre-existing debug-build timeout on main)

---
Verified by robobun: CI build #40392 in progress with 0 failures (prior builds #40367/#40369 had only infrastructure hard_failed, no actual test failures). Fix correctly mirrors the established `putIntoObject<bool hasIndex>` pattern from JSURLSearchParams.cpp. Two regression tests exercise the exact crash path (duplicate numeric keys) and would segfault on main. No TODO/FIXME/HACK markers, no unrelated changes. CodeRabbit found no actionable issues.