### PR TITLE
Clear pending JS exception in createError*Instance format fallback paths

### DIFF
--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -286,9 +286,11 @@ pub const JSGlobalObject = opaque {
             var buf = std.Io.Writer.Allocating.initCapacity(stack_fallback.get(), 2048) catch unreachable;
             defer buf.deinit();
             var writer = &buf.writer;
-            writer.print(fmt, args) catch
+            writer.print(fmt, args) catch {
                 // if an exception occurs in the middle of formatting the error message, it's better to just return the formatting string than an error about an error
+                _ = this.clearExceptionExceptTermination();
                 return ZigString.static(fmt).toErrorInstance(this);
+            };
 
             // Ensure we clone it.
             var str = ZigString.initUTF8(buf.written());
@@ -309,7 +311,10 @@ pub const JSGlobalObject = opaque {
             var buf = bun.MutableString.init2048(stack_fallback.get()) catch unreachable;
             defer buf.deinit();
             var writer = buf.writer();
-            writer.print(fmt, args) catch return ZigString.static(fmt).toErrorInstance(this);
+            writer.print(fmt, args) catch {
+                _ = this.clearExceptionExceptTermination();
+                return ZigString.static(fmt).toErrorInstance(this);
+            };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toTypeErrorInstance(this);
         } else {
@@ -337,7 +342,10 @@ pub const JSGlobalObject = opaque {
             var buf = bun.MutableString.init2048(stack_fallback.get()) catch unreachable;
             defer buf.deinit();
             var writer = buf.writer();
-            writer.print(fmt, args) catch return ZigString.static(fmt).toErrorInstance(this);
+            writer.print(fmt, args) catch {
+                _ = this.clearExceptionExceptTermination();
+                return ZigString.static(fmt).toErrorInstance(this);
+            };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toSyntaxErrorInstance(this);
         } else {
@@ -351,7 +359,10 @@ pub const JSGlobalObject = opaque {
             var buf = bun.MutableString.init2048(stack_fallback.get()) catch unreachable;
             defer buf.deinit();
             var writer = buf.writer();
-            writer.print(fmt, args) catch return ZigString.static(fmt).toErrorInstance(this);
+            writer.print(fmt, args) catch {
+                _ = this.clearExceptionExceptTermination();
+                return ZigString.static(fmt).toErrorInstance(this);
+            };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toRangeErrorInstance(this);
         } else {

--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -313,7 +313,7 @@ pub const JSGlobalObject = opaque {
             var writer = buf.writer();
             writer.print(fmt, args) catch {
                 _ = this.clearExceptionExceptTermination();
-                return ZigString.static(fmt).toErrorInstance(this);
+                return ZigString.static(fmt).toTypeErrorInstance(this);
             };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toTypeErrorInstance(this);
@@ -344,7 +344,7 @@ pub const JSGlobalObject = opaque {
             var writer = buf.writer();
             writer.print(fmt, args) catch {
                 _ = this.clearExceptionExceptTermination();
-                return ZigString.static(fmt).toErrorInstance(this);
+                return ZigString.static(fmt).toSyntaxErrorInstance(this);
             };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toSyntaxErrorInstance(this);
@@ -361,7 +361,7 @@ pub const JSGlobalObject = opaque {
             var writer = buf.writer();
             writer.print(fmt, args) catch {
                 _ = this.clearExceptionExceptTermination();
-                return ZigString.static(fmt).toErrorInstance(this);
+                return ZigString.static(fmt).toRangeErrorInstance(this);
             };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toRangeErrorInstance(this);

--- a/test/js/bun/test/expect-assertions-toPrimitive.test.ts
+++ b/test/js/bun/test/expect-assertions-toPrimitive.test.ts
@@ -17,7 +17,8 @@ test("expect.assertions does not crash when argument has Symbol.toPrimitive retu
     stderr: "pipe",
   });
 
-  const exitCode = await proc.exited;
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
+  expect(stderr).not.toContain("error:");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/expect-assertions-toPrimitive.test.ts
+++ b/test/js/bun/test/expect-assertions-toPrimitive.test.ts
@@ -13,7 +13,7 @@ test("expect.assertions does not crash when argument has Symbol.toPrimitive retu
       `,
     ],
     env: bunEnv,
-    stdout: "pipe",
+    stdout: "ignore",
     stderr: "pipe",
   });
 

--- a/test/js/bun/test/expect-assertions-toPrimitive.test.ts
+++ b/test/js/bun/test/expect-assertions-toPrimitive.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("expect.assertions does not crash when argument has Symbol.toPrimitive returning an object", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const re = /test/;
+      Object.defineProperty(re, Symbol.toPrimitive, { value: () => [] });
+      try { Bun.jest().expect.assertions(re); } catch {}
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/expect-assertions-toPrimitive.test.ts
+++ b/test/js/bun/test/expect-assertions-toPrimitive.test.ts
@@ -17,8 +17,7 @@ test("expect.assertions does not crash when argument has Symbol.toPrimitive retu
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const exitCode = await proc.exited;
 
-  expect(stderr).not.toContain("ASSERTION FAILED");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
When `createErrorInstance`, `createTypeErrorInstance`, `createSyntaxErrorInstance`, or `createRangeErrorInstance` format an error message using `{f}` (the ConsoleObject formatter) and the formatting triggers a JS exception (e.g. `Symbol.toPrimitive` returning an object instead of a primitive), the pending exception must be cleared before falling back to the raw format string.

Without this fix, the subsequent `throwValue` call opens a `ThrowScope` which hits `releaseAssertNoException` because there's already a pending exception on the VM from the failed formatting attempt.

**Repro:**
```js
const re = /test/;
Object.defineProperty(re, Symbol.toPrimitive, { value: () => [] });
Bun.jest().expect.assertions(re);
```

`expect.assertions()` rejects non-number arguments and tries to format the value in the error message via `{f}`. When the value has a `Symbol.toPrimitive` that returns an object, JSC throws `TypeError: Symbol.toPrimitive returned an object`. The existing code already handled this case by falling back to the raw format string, but didn't clear the pending exception first.

---
Verification (iteration 4): Format ✅, Lint JS ✅, Buildkite build #40394 still compiling at review time (Zig-only change, no red signals). Diff adds `clearExceptionExceptTermination()` to 4 catch blocks and corrects 3 fallback error types (`toTypeErrorInstance`/`toSyntaxErrorInstance`/`toRangeErrorInstance` instead of generic `toErrorInstance`). Regression test spawns subprocess exercising the exact crash path (Symbol.toPrimitive returning object → format failure → releaseAssertNoException). All CodeRabbit major feedback addressed in current diff. No TODO/FIXME/HACK markers, no unrelated changes.