### PR TITLE
Clear pending JS exception in create*ErrorInstance when formatting fails

### DIFF
--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -286,9 +286,11 @@ pub const JSGlobalObject = opaque {
             var buf = std.Io.Writer.Allocating.initCapacity(stack_fallback.get(), 2048) catch unreachable;
             defer buf.deinit();
             var writer = &buf.writer;
-            writer.print(fmt, args) catch
+            writer.print(fmt, args) catch {
                 // if an exception occurs in the middle of formatting the error message, it's better to just return the formatting string than an error about an error
+                _ = this.clearExceptionExceptTermination();
                 return ZigString.static(fmt).toErrorInstance(this);
+            };
 
             // Ensure we clone it.
             var str = ZigString.initUTF8(buf.written());
@@ -309,7 +311,10 @@ pub const JSGlobalObject = opaque {
             var buf = bun.MutableString.init2048(stack_fallback.get()) catch unreachable;
             defer buf.deinit();
             var writer = buf.writer();
-            writer.print(fmt, args) catch return ZigString.static(fmt).toErrorInstance(this);
+            writer.print(fmt, args) catch {
+                _ = this.clearExceptionExceptTermination();
+                return ZigString.static(fmt).toTypeErrorInstance(this);
+            };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toTypeErrorInstance(this);
         } else {
@@ -337,7 +342,10 @@ pub const JSGlobalObject = opaque {
             var buf = bun.MutableString.init2048(stack_fallback.get()) catch unreachable;
             defer buf.deinit();
             var writer = buf.writer();
-            writer.print(fmt, args) catch return ZigString.static(fmt).toErrorInstance(this);
+            writer.print(fmt, args) catch {
+                _ = this.clearExceptionExceptTermination();
+                return ZigString.static(fmt).toSyntaxErrorInstance(this);
+            };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toSyntaxErrorInstance(this);
         } else {
@@ -351,7 +359,10 @@ pub const JSGlobalObject = opaque {
             var buf = bun.MutableString.init2048(stack_fallback.get()) catch unreachable;
             defer buf.deinit();
             var writer = buf.writer();
-            writer.print(fmt, args) catch return ZigString.static(fmt).toErrorInstance(this);
+            writer.print(fmt, args) catch {
+                _ = this.clearExceptionExceptTermination();
+                return ZigString.static(fmt).toRangeErrorInstance(this);
+            };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toRangeErrorInstance(this);
         } else {

--- a/test/js/bun/s3/s3-fd-validation.test.ts
+++ b/test/js/bun/s3/s3-fd-validation.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("S3Client.write does not crash with out-of-range float as path", () => {
   expect(() => Bun.S3Client.write(-1.5379890021597998e308, "data")).toThrow();

--- a/test/js/bun/test/expect-format-exception.test.ts
+++ b/test/js/bun/test/expect-format-exception.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("expect error formatting does not crash when formatting throws", async () => {
+  // When expect() receives a non-mock value and the error formatter encounters
+  // a JS exception while formatting the value, it should throw a proper error
+  // instead of crashing with an assertion failure in releaseAssertNoException.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      delete globalThis.Loader;
+      const v1 = Bun.jest();
+      const v2 = v1.expect(Bun);
+      let threw = false;
+      try { v2.nthCalledWith(Bun, v2, v2, Bun, v2); } catch { threw = true; }
+      if (!threw) process.exit(2);
+      console.log("ok");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // stderr is not asserted because ASAN debug builds emit warnings to stderr
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
When creating error instances (`createErrorInstance`, `createTypeErrorInstance`, `createSyntaxErrorInstance`, `createRangeErrorInstance`), the format string args may include `{f}` formatters that invoke `ZigFormatter.format`, which can trigger JS property access and throw a JS exception. The exception gets converted to `WriteFailed` by `jsErrorToWriteError`, but the pending exception remains on the VM.

When the caller (e.g. `throwPretty`) subsequently calls `vm.throwError()` to throw the fallback error, `assertNoException` fires because the stale exception from formatting is still pending.

The crash path is:
1. `toHaveBeenNthCalledWith` receives a non-mock value
2. `this.throw()` → `throwPretty()` → `createErrorInstance()`
3. `writer.print(fmt, args)` invokes `ZigFormatter.format` for the `{f}` arg
4. Formatting triggers JS property access that throws (e.g. "ReflectGet is not a function")
5. `jsErrorToWriteError` converts JSError → WriteFailed, but the JS exception stays pending
6. `createErrorInstance` catches WriteFailed and returns a fallback error
7. `throwPretty` → `throwValue` → `vm.throwError()` → `scope.assertNoException()` **crashes**

Fix: call `clearExceptionExceptTermination()` in each `create*ErrorInstance` catch path before returning the fallback error instance. Also fixes pre-existing bug where `createTypeErrorInstance`, `createSyntaxErrorInstance`, and `createRangeErrorInstance` returned generic `Error` in fallback paths instead of their respective error types.

---
Verified (iteration 13, robobun): Lint JavaScript CI passed. Buildkite build #40572 compiling with 0 failures (prior builds canceled due to autofix pushes, not failures). Code verified: `clearExceptionExceptTermination()` added in all 4 catch blocks in `JSGlobalObject.zig`; fallback error types corrected to match function names; `createDOMExceptionInstance` correctly excluded (uses `try` propagation). Regression test spawns subprocess, deletes `globalThis.Loader`, calls `expect(Bun).nthCalledWith(...)`, guards against false pass with exit(2), asserts exit code 0 and stdout "ok\n". No TODO/FIXME/HACK. All reviews non-blocking.

---
**Verification (robobun, iteration 14):** Lint JavaScript ✅, Format ✅, Buildkite pipeline ✅, Build #40578 compiling (Build #40577 was auto-canceled by build_skipping with 0 failures, not actual build failures). Diff touches only JSGlobalObject.zig (4 catch blocks) + new regression test + autofix import reorder in s3 test. No TODO/FIXME/HACK. `clearExceptionExceptTermination()` correctly used in all 4 catch blocks; `createDOMExceptionInstance` correctly excluded (uses `try` propagation). Fallback error types match function names. Regression test spawns subprocess, deletes `globalThis.Loader`, triggers crash path, guards false-pass with `exit(2)`, asserts exit 0 + stdout `ok`. All bot reviews are LGTM/non-blocking.

---
**Verification (robobun, iteration 20):** CI build #40686 pending (pipeline step passed). Diff verified: 4 catch blocks in JSGlobalObject.zig add `clearExceptionExceptTermination()` before returning fallback error instances; fallback types corrected to match function names (TypeErrorInstance, SyntaxErrorInstance, RangeErrorInstance). Regression test spawns subprocess that deletes `globalThis.Loader`, calls `expect(Bun).nthCalledWith(...)`, catches the expected throw (exits 2 if no throw), asserts exit 0 + stdout `ok`. No TODO/FIXME/HACK in diff. All bot reviews resolved or non-blocking nits.

---
**Verification (robobun, iteration 22):** CI Build #40715 pending (pipeline step passed, compilation in progress). Diff verified: 4 catch blocks in JSGlobalObject.zig correctly add clearExceptionExceptTermination() before returning fallback error instances; fallback types corrected to match function names. Regression test spawns subprocess, deletes globalThis.Loader, triggers crash path, guards false-pass with exit(2), asserts exit 0 + stdout ok. No TODO/FIXME/HACK. All bot reviews resolved. Import reorder in s3 test is harmless autofix.

---
**Verification (robobun, iteration 39):** CI Build #41040 compiling (pending). Prior build #40973 had 4 failures — all unrelated to this change: webview-chrome.test.ts (macOS), webview.test.ts (macOS timeout), bundler_compile.test.ts (Linux timeout), next-pages segfault (Windows). Diff verified at commit a863011: 4 catch blocks in JSGlobalObject.zig (lines 289-293, 314-317, 345-348, 362-365) correctly add clearExceptionExceptTermination() before returning fallback error instances; fallback types match function names (toTypeErrorInstance, toSyntaxErrorInstance, toRangeErrorInstance); createDOMExceptionInstance correctly excluded (uses try propagation, line 331). Regression test (expect-format-exception.test.ts) spawns subprocess, deletes globalThis.Loader, calls nthCalledWith to trigger formatting exception, guards false-pass with exit(2), asserts exit 0 + stdout ok. No TODO/FIXME/HACK. All reviews COMMENTED (non-blocking). Import reorder in s3-fd-validation.test.ts is harmless autofix.

---
**Verification (robobun, iteration 41):** CI Build #41070 pending (just started on commit 5d15a5c). Prior builds had only unrelated failures (webview, bundler_compile, next-pages). Diff verified: 4 catch blocks in JSGlobalObject.zig add clearExceptionExceptTermination() before returning fallback error instances; fallback types correctly match function names. Regression test spawns subprocess, deletes globalThis.Loader, triggers crash path via nthCalledWith, guards false-pass with exit(2), asserts exit 0 + stdout ok. No TODO/FIXME/HACK. All reviews COMMENTED (non-blocking).