### PR TITLE
Fix null deref in forEachProperty when prototype is a Proxy

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5238,7 +5238,13 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototype" trap.
+            if (scope.exception()) [[unlikely]] {
+                (void)scope.tryClearException();
+                break;
+            }
+            iterating = proto.getObject();
         }
     }
 

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5127,7 +5127,7 @@ restart:
                         }
                     }
                 }
-                // Ignore exceptions from Proxy "getPrototype" trap.
+                // Ignore exceptions from Proxy "getPrototypeOf" trap.
                 CLEAR_IF_EXCEPTION(scope);
             }
             return;
@@ -5239,7 +5239,7 @@ restart:
             if (iterating == globalObject)
                 break;
             JSValue proto = iterating->getPrototype(globalObject);
-            // Ignore exceptions from Proxy "getPrototype" trap.
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
             if (scope.exception()) [[unlikely]] {
                 (void)scope.tryClearException();
                 break;

--- a/test/js/bun/test/expect/proxy-prototype-crash.test.ts
+++ b/test/js/bun/test/expect/proxy-prototype-crash.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("Bun.inspect does not crash when prototype is a Proxy with throwing getPrototypeOf", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const obj = {};
+      const origProto = Object.getPrototypeOf(obj);
+      const newProto = new Proxy(origProto, {
+        getPrototypeOf() { throw new Error("trap"); },
+        get(target, key, receiver) { return Reflect.get(target, key, receiver); },
+      });
+      Object.setPrototypeOf(obj, newProto);
+      try { Bun.inspect(obj); } catch(e) {}
+      console.log("OK");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("OK");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/expect/proxy-prototype-crash.test.ts
+++ b/test/js/bun/test/expect/proxy-prototype-crash.test.ts
@@ -25,6 +25,7 @@ test("Bun.inspect does not crash when prototype is a Proxy with throwing getProt
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout).toContain("OK");
+  expect(stderr).toBe("");
+  expect(stdout).toBe("OK\n");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## What

Fix a null pointer dereference in `forEachPropertyImpl` when walking the prototype chain of an object whose prototype has been replaced with a Proxy.

## Root Cause

`forEachPropertyImpl` in `bindings.cpp` walks the prototype chain by calling `getPrototype(globalObject)` on each object. When a prototype is a Proxy, this triggers the Proxy's `getPrototypeOf` trap, which can throw an exception. The return value in that case is an invalid JSValue, and calling `.getObject()` on it dereferences a null cell pointer.

The fast path in the same function (line 5131) already handles this case correctly with `CLEAR_IF_EXCEPTION(scope)`, but the slow path at line 5241 did not.

## Fix

Check for exceptions after `getPrototype()` and break out of the prototype walk if one occurred, matching the pattern used in the fast path.

## Repro

```js
const v = Bun.jest().expect();
const origProto = Object.getPrototypeOf(v);
const newProto = new Proxy(origProto, {
  get(target, key, receiver) { return Reflect.get(target, key, receiver); },
});
Object.setPrototypeOf(v, newProto);
v.toContainValue(v); // crashed with null deref, now throws proper JS error
```

Crash fingerprint: `JSCJSValueCellInlines.h:92:33:member call on null pointer of type 'JSC::JSCell'`

---
Verification (robobun, iteration 11): CI build #40600 is in progress (Lint JS passed, Buildkite building). Previous build #40599 shows Canceled statuses (superseded by new commit), not real failures. Diff touches 3 files: bindings.cpp (6-line fix splitting chained getPrototype().getObject() with exception check, matching existing fast-path pattern at line ~5131), proxy-prototype-crash.test.ts (regression test spawning subprocess with Proxy prototype that throws on getPrototypeOf, asserting exit 0 and stdout OK), and s3-fd-validation.test.ts (trivial import reorder). No TODO/FIXME/HACK in added lines. All reviewer feedback addressed. CodeRabbit found no actionable issues on latest revision.