### PR TITLE
fix(cli): resolve symlinks for entry point in execAsIfNode

### DIFF
--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1663,7 +1663,31 @@ pub const RunCommand = struct {
             );
         };
 
-        Run.boot(ctx, normalized_filename, null) catch |err| {
+        // Like Node.js, resolve symlinks on the main entry point by default.
+        // This is critical for .bin/ symlinks: without resolution, __dirname and
+        // module resolution are relative to .bin/ instead of the real package location.
+        // Controlled by --preserve-symlinks-main / NODE_PRESERVE_SYMLINKS_MAIN=1.
+        const entry_point = if (ctx.runtime_options.preserve_symlinks_main or
+            bun.env_var.NODE_PRESERVE_SYMLINKS_MAIN.get())
+            normalized_filename
+        else brk: {
+            var realpath_buf: bun.PathBuffer = undefined;
+            const flags = if (comptime Environment.isLinux)
+                bun.O.PATH
+            else
+                bun.O.RDONLY | bun.O.NONBLOCK | bun.O.NOCTTY;
+            const fd = switch (bun.sys.openA(normalized_filename, flags, 0)) {
+                .err => break :brk normalized_filename,
+                .result => |fd_| fd_,
+            };
+            defer fd.close();
+            break :brk switch (bun.sys.getFdPath(fd, &realpath_buf)) {
+                .err => normalized_filename,
+                .result => |real| bun.handleOom(bun.default_allocator.dupe(u8, real)),
+            };
+        };
+
+        Run.boot(ctx, entry_point, null) catch |err| {
             ctx.log.print(Output.errorWriter()) catch {};
 
             Output.err(err, "Failed to run script \"<b>{s}<r>\"", .{std.fs.path.basename(normalized_filename)});

--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { join } from "path";
-import { fakeNodeRun, tempDirWithFiles } from "../../harness";
+import { join, dirname } from "path";
+import { chmodSync, symlinkSync } from "fs";
+import { bunEnv, bunExe, fakeNodeRun, isWindows, tempDirWithFiles } from "../../harness";
 
 describe("fake node cli", () => {
   test("the node cli actually works", () => {
@@ -100,5 +101,135 @@ describe("fake node cli", () => {
   test("no args is exit code zero for now", () => {
     const temp = tempDirWithFiles("fake-node", {});
     expect(() => fakeNodeRun(temp, [])).toThrow();
+  });
+
+  test.skipIf(isWindows)("resolves symlinks for entry point so relative imports work", () => {
+    // When bun runs as "node" and the entry point is a symlink (e.g.
+    // node_modules/.bin/tool -> ../my-tool/cli.mjs), relative imports in
+    // the script must resolve relative to the *target* file's directory,
+    // not the symlink's directory. This matches Node.js default behavior.
+    // Without symlink resolution, `import "./lib.mjs"` from a script in
+    // node_modules/my-tool/ would look in .bin/ instead, and __dirname
+    // would point to .bin/ rather than the real package directory.
+    const temp = tempDirWithFiles("fake-node-symlink", {
+      // The "real" tool with a relative import between sibling files
+      "node_modules/my-tool/cli.mjs": `
+        import { greet } from "./lib.mjs";
+        console.log(greet());
+      `,
+      "node_modules/my-tool/lib.mjs": `
+        export function greet() { return "hello from my-tool"; }
+      `,
+      ".bin/.gitkeep": "",
+    });
+    const realScript = join(temp, "node_modules/my-tool/cli.mjs");
+    const symlinkPath = join(temp, ".bin/my-tool");
+    symlinkSync(realScript, symlinkPath);
+
+    // Create a symlink named "node" pointing to the bun binary so
+    // argv[0] ends with "node" and triggers the execAsIfNode codepath.
+    const nodePath = join(temp, "node");
+    symlinkSync(bunExe(), nodePath);
+
+    // Run the symlink through bun-as-node. Without symlink resolution,
+    // the import of "./lib.mjs" would look in .bin/ instead of
+    // node_modules/my-tool/ and fail with "Cannot find module".
+    const result = Bun.spawnSync([nodePath, symlinkPath], {
+      cwd: temp,
+      env: bunEnv,
+    });
+    const stdout = result.stdout.toString("utf8").trim();
+    const stderr = result.stderr.toString("utf8").trim();
+    expect(stderr).toBe("");
+    expect(stdout).toBe("hello from my-tool");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test.skipIf(isWindows)("resolves symlinks for entry point — __dirname points to real location", () => {
+    // Verify that __dirname reflects the resolved (real) path, not the
+    // symlink's directory. This is the Node.js default behavior controlled
+    // by --preserve-symlinks-main.
+    const temp = tempDirWithFiles("fake-node-dirname", {
+      "node_modules/my-tool/cli.js": `console.log(__dirname)`,
+      ".bin/.gitkeep": "",
+    });
+    const realScript = join(temp, "node_modules/my-tool/cli.js");
+    const symlinkPath = join(temp, ".bin/my-tool");
+    symlinkSync(realScript, symlinkPath);
+
+    const nodePath = join(temp, "node");
+    symlinkSync(bunExe(), nodePath);
+
+    const result = Bun.spawnSync([nodePath, symlinkPath], {
+      cwd: temp,
+      env: bunEnv,
+    });
+    const stdout = result.stdout.toString("utf8").trim();
+    const stderr = result.stderr.toString("utf8").trim();
+    expect(stderr).toBe("");
+    expect(stdout).toBe(dirname(realScript));
+    expect(result.exitCode).toBe(0);
+  });
+
+  test.skipIf(isWindows)("resolves symlinks for entry point — process.argv[1] is real path", () => {
+    // Node.js sets process.argv[1] to the resolved real path by default.
+    const temp = tempDirWithFiles("fake-node-argv", {
+      "node_modules/my-tool/cli.js": `console.log(process.argv[1])`,
+      ".bin/.gitkeep": "",
+    });
+    const realScript = join(temp, "node_modules/my-tool/cli.js");
+    const symlinkPath = join(temp, ".bin/my-tool");
+    symlinkSync(realScript, symlinkPath);
+
+    const nodePath = join(temp, "node");
+    symlinkSync(bunExe(), nodePath);
+
+    const result = Bun.spawnSync([nodePath, symlinkPath], {
+      cwd: temp,
+      env: bunEnv,
+    });
+    const stdout = result.stdout.toString("utf8").trim();
+    expect(result.stderr.toString("utf8").trim()).toBe("");
+    expect(stdout).toBe(realScript);
+    expect(result.exitCode).toBe(0);
+  });
+
+  test.skipIf(isWindows)("bun run --bun resolves .bin symlinks for relative imports", () => {
+    // End-to-end test for the full `bun run --bun <name>` flow:
+    // 1. bun run finds the tool via PATH (node_modules/.bin/)
+    // 2. spawns it via posix_spawn
+    // 3. kernel reads shebang #!/usr/bin/env node
+    // 4. bun (as fake node) runs the script
+    // 5. relative imports must resolve against the real file location,
+    //    not the .bin/ symlink directory
+    const temp = tempDirWithFiles("bun-run-symlink", {
+      "node_modules/my-tool/cli.mjs": `#!/usr/bin/env node
+import { greet } from "./lib.mjs";
+console.log(greet());
+`,
+      "node_modules/my-tool/lib.mjs": `export function greet() { return "it works"; }
+`,
+      "node_modules/.bin/.gitkeep": "",
+      "package.json": "{}",
+    });
+    // Make the script executable and create the .bin symlink like `bun install` would
+    chmodSync(join(temp, "node_modules/my-tool/cli.mjs"), 0o755);
+    symlinkSync(join(temp, "node_modules/my-tool/cli.mjs"), join(temp, "node_modules/.bin/my-tool"));
+
+    // Use --bun to force bun to act as node (creates fake node in PATH).
+    // This is critical: without --bun, if real node is on PATH, the
+    // shebang delegates to node which resolves symlinks correctly,
+    // masking the bug.
+    const result = Bun.spawnSync([bunExe(), "run", "--bun", "my-tool"], {
+      cwd: temp,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = result.stdout.toString("utf8").trim();
+    const stderr = result.stderr.toString("utf8").trim();
+    expect(stderr).toBe("");
+    expect(stdout).toBe("it works");
+    expect(result.exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #28331

- When bun is invoked as `node` (argv[0] ends with "node"), `execAsIfNode` now resolves symlinks on the entry point path before passing it to `Run.boot()`, matching [Node.js's default behavior](https://github.com/nodejs/node/blob/69fdff9d30f4794f503a1700d16b07d20455248f/lib/internal/modules/run_main.js#L38-L42)
- Uses `open()` + `getFdPath()` (the same approach as Bun's `fs.realpath` implementation) to resolve the real path
- Respects `--preserve-symlinks-main` and `NODE_PRESERVE_SYMLINKS_MAIN=1` to skip resolution, [same as Node.js](https://github.com/nodejs/node/blob/69fdff9d30f4794f503a1700d16b07d20455248f/lib/internal/modules/cjs/loader.js#L769-L777)
- Falls back gracefully to the original path if resolution fails (e.g., file doesn't exist yet)

## Test plan

- [x] Added test in `test/cli/run/as-node.test.ts` that creates a `.bin/`-style symlink, invokes it via a bun binary symlinked as `node`, and verifies `process.argv[1]` contains the real path
- [x] Verified test **fails** without the fix (`process.argv[1]` = `.bin/my-tool`)
- [x] Verified test **passes** with the fix (`process.argv[1]` = `node_modules/my-tool/cli.js`)
- [x] All 12 existing `as-node.test.ts` tests continue to pass