### PR TITLE
Fix PropertySlot assertion by stripping static hash table attribute bits

### DIFF
--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -1529,12 +1529,12 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
         auto* mock = JSMockFunction::create(vm, globalObject, globalObject->mockModule.mockFunctionStructure.getInitializedOnMainThread(globalObject), CallbackKind::GetterSetter);
         mock->spyTarget = JSC::Weak<JSObject>(object, &weakValueHandleOwner(), nullptr);
         mock->spyIdentifier = propertyKey.isSymbol() ? Identifier::fromUid(vm, propertyKey.uid()) : Identifier::fromString(vm, propertyKey.publicName());
-        mock->spyAttributes = hasValue ? slot.attributes() : 0;
+        mock->spyAttributes = hasValue ? attributesForStructure(slot.attributes()) : 0;
         unsigned attributes = 0;
 
         if (hasValue && ((slot.attributes() & PropertyAttribute::Function) != 0 || (value.isCell() && value.isCallable()))) {
             if (hasValue)
-                attributes = slot.attributes();
+                attributes = attributesForStructure(slot.attributes());
 
             mock->copyNameAndLength(vm, globalObject, value);
 
@@ -1553,7 +1553,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
             pushImpl(mock, globalObject, JSMockImplementation::Kind::Call, value);
         } else {
             if (hasValue)
-                attributes = slot.attributes();
+                attributes = attributesForStructure(slot.attributes());
 
             attributes |= PropertyAttribute::Accessor;
 

--- a/src/bun.js/bindings/NodeVM.cpp
+++ b/src/bun.js/bindings/NodeVM.cpp
@@ -906,7 +906,7 @@ bool NodeVMSpecialSandbox::getOwnPropertySlot(JSObject* cell, JSGlobalObject* gl
     if (propertyName.uid()->utf8() == "globalThis") [[unlikely]] {
         slot.disableCaching();
         slot.setThisValue(thisObject);
-        slot.setValue(thisObject, slot.attributes(), thisObject);
+        slot.setValue(thisObject, 0, thisObject);
         return true;
     }
 
@@ -932,7 +932,7 @@ bool NodeVMGlobalObject::getOwnPropertySlot(JSObject* cell, JSGlobalObject* glob
     if (notContextified && propertyName.uid()->utf8() == "globalThis") [[unlikely]] {
         slot.disableCaching();
         slot.setThisValue(thisObject);
-        slot.setValue(thisObject, slot.attributes(), thisObject->specialSandbox());
+        slot.setValue(thisObject, 0, thisObject->specialSandbox());
         return true;
     }
 

--- a/test/js/bun/test/spyon-static-property.test.ts
+++ b/test/js/bun/test/spyon-static-property.test.ts
@@ -1,61 +1,18 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { expect, test, spyOn } from "bun:test";
 
-test.concurrent("spyOn works on static hash table function properties", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-      const { spyOn, jest } = Bun.jest(import.meta.path);
-      const spy = spyOn(Bun, "gc");
-      Bun.gc(true);
-      if (spy.mock.calls.length !== 1) {
-        throw new Error("Expected 1 call, got " + spy.mock.calls.length);
-      }
-      spy.mockRestore();
-      Bun.gc(true);
-      console.log("OK");
-    `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stderr).toBe("");
-  expect(stdout.trim()).toBe("OK");
-  expect(exitCode).toBe(0);
+test("spyOn works on static hash table function properties", () => {
+  const spy = spyOn(Bun, "gc");
+  try {
+    Bun.gc(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+  } finally {
+    spy.mockRestore();
+  }
 });
 
-test.concurrent("spyOn preserves correct attributes after mockRestore", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-      const { spyOn, jest } = Bun.jest(import.meta.path);
-      const spy = spyOn(Bun, "peek");
-      spy.mockRestore();
-      // After restore, the property should still work
-      const p = Promise.resolve(42);
-      const val = Bun.peek(p);
-      if (val !== 42) {
-        throw new Error("Expected 42, got " + val);
-      }
-      console.log("OK");
-    `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stderr).toBe("");
-  expect(stdout.trim()).toBe("OK");
-  expect(exitCode).toBe(0);
+test("spyOn preserves correct attributes after mockRestore", () => {
+  const spy = spyOn(Bun, "peek");
+  spy.mockRestore();
+  const p = Promise.resolve(42);
+  expect(Bun.peek(p)).toBe(42);
 });

--- a/test/js/bun/test/spyon-static-property.test.ts
+++ b/test/js/bun/test/spyon-static-property.test.ts
@@ -1,9 +1,12 @@
-import { test, expect } from "bun:test";
-import { bunExe, bunEnv } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 test("spyOn works on static hash table function properties", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       const { spyOn, jest } = Bun.jest(import.meta.path);
       const spy = spyOn(Bun, "gc");
       Bun.gc(true);
@@ -13,17 +16,14 @@ test("spyOn works on static hash table function properties", async () => {
       spy.mockRestore();
       Bun.gc(true);
       console.log("OK");
-    `],
+    `,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout.trim()).toBe("OK");
   expect(exitCode).toBe(0);
@@ -31,7 +31,10 @@ test("spyOn works on static hash table function properties", async () => {
 
 test("spyOn preserves correct attributes after mockRestore", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       const { spyOn, jest } = Bun.jest(import.meta.path);
       const spy = spyOn(Bun, "peek");
       spy.mockRestore();
@@ -42,17 +45,14 @@ test("spyOn preserves correct attributes after mockRestore", async () => {
         throw new Error("Expected 42, got " + val);
       }
       console.log("OK");
-    `],
+    `,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout.trim()).toBe("OK");
   expect(exitCode).toBe(0);

--- a/test/js/bun/test/spyon-static-property.test.ts
+++ b/test/js/bun/test/spyon-static-property.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-test("spyOn works on static hash table function properties", async () => {
+test.concurrent("spyOn works on static hash table function properties", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -30,7 +30,7 @@ test("spyOn works on static hash table function properties", async () => {
   expect(exitCode).toBe(0);
 });
 
-test("spyOn preserves correct attributes after mockRestore", async () => {
+test.concurrent("spyOn preserves correct attributes after mockRestore", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/bun/test/spyon-static-property.test.ts
+++ b/test/js/bun/test/spyon-static-property.test.ts
@@ -25,6 +25,7 @@ test("spyOn works on static hash table function properties", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect(stderr).toBe("");
   expect(stdout.trim()).toBe("OK");
   expect(exitCode).toBe(0);
 });
@@ -54,6 +55,7 @@ test("spyOn preserves correct attributes after mockRestore", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect(stderr).toBe("");
   expect(stdout.trim()).toBe("OK");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/spyon-static-property.test.ts
+++ b/test/js/bun/test/spyon-static-property.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, spyOn } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 
 test("spyOn works on static hash table function properties", () => {
   const spy = spyOn(Bun, "gc");

--- a/test/js/bun/test/spyon-static-property.test.ts
+++ b/test/js/bun/test/spyon-static-property.test.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "bun:test";
+import { bunExe, bunEnv } from "harness";
+
+test("spyOn works on static hash table function properties", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `
+      const { spyOn, jest } = Bun.jest(import.meta.path);
+      const spy = spyOn(Bun, "gc");
+      Bun.gc(true);
+      if (spy.mock.calls.length !== 1) {
+        throw new Error("Expected 1 call, got " + spy.mock.calls.length);
+      }
+      spy.mockRestore();
+      Bun.gc(true);
+      console.log("OK");
+    `],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+});
+
+test("spyOn preserves correct attributes after mockRestore", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `
+      const { spyOn, jest } = Bun.jest(import.meta.path);
+      const spy = spyOn(Bun, "peek");
+      spy.mockRestore();
+      // After restore, the property should still work
+      const p = Promise.resolve(42);
+      const val = Bun.peek(p);
+      if (val !== 42) {
+        throw new Error("Expected 42, got " + val);
+      }
+      console.log("OK");
+    `],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fuzzilli found a flaky assertion failure at `PropertySlot.h(219)`:

```
ASSERTION FAILED: attributes == attributesForStructure(attributes) && !(attributes & PropertyAttribute::Accessor)
```

`PropertySlot::setValue` asserts that property attributes contain no static hash table bits (bits 8+, like `Function`, `DOMAttribute`, `PropertyCallback`, etc.) and no `Accessor` flag. JSC's own code always strips these via `attributesForStructure()` before storing (see `Lookup.h` lines 462, 488, 496, 503, etc.), but two places in Bun's bindings passed raw `slot.attributes()`:

**JSMockFunction.cpp** (`spyOn`): When spying on a property from a static hash table (e.g. `Bun.gc`), `slot.attributes()` contains the `Function` bit (bit 8). This was passed directly to `putDirect` and saved in `spyAttributes` for later `mockRestore`, propagating invalid attribute bits into the Structure and triggering the assertion on subsequent property lookups.

**NodeVM.cpp** (`getOwnPropertySlot` for `globalThis`): Passed `slot.attributes()` from an uninitialized/stale slot to `setValue`. Use `0` since `globalThis` is a plain value property with no special attributes.

Fix: call `attributesForStructure()` to mask to the low 8 bits in `spyOn`, and use `0` for the NodeVM `globalThis` slot.

---

Verified: CI Format ✅, Lint ✅, Pipeline ✅, Buildkite Build #40400 compiling on latest commit 4a75d44. Prior Build #40398 was canceled (superseded), not failed. Diff is clean — 3 files changed, all scoped to the fix. Two regression tests exercise spyOn on static hash table functions (Bun.gc, Bun.peek), assert spy call recording, mockRestore, and post-restore functionality; these would crash on main in debug builds. CodeRabbit stderr-assertion nit resolved.

---
Verified by robobun: CI on commit 4a75d44 passed all build/test jobs across all platforms (Build #40400 shows canceled but all individual jobs succeeded before supersede). Latest commit 96def6f (Build #40409) only adds test.concurrent and stderr assertions to the test file. Format ✅, Lint ✅. Diff is clean — no TODO/FIXME/HACK. Tests exercise spyOn on static hash table functions (Bun.gc, Bun.peek) which would crash with an assertion failure on main in debug builds. CodeRabbit stderr nit resolved; Claude review threads are nits about pre-existing dead code. No blocking reviews.

---
Verified by robobun (iteration 3): Commit 27c7dd1, Build #40463 in progress — Lint JS ✅, pipeline ✅, Format pending. Prior Build #40409 failures were solely bundler_compile.test.ts (unrelated to mock/NodeVM changes). Diff is clean (3 files, no TODO/FIXME/HACK). Tests run in-process: spyOn(Bun, "gc") asserts call tracking + mockRestore, spyOn(Bun, "peek") asserts restore preserves functionality — both exercise the exact assertion-failure path fixed. Code changes follow JSC's own attributesForStructure() pattern from Lookup.h. No blocking reviews.