### PR TITLE
Fix lazy property assertion failure in utilInspect initializers

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -1903,12 +1903,12 @@ void GlobalObject::finishCreation(VM& vm)
 
     m_utilInspectFunction.initLater(
         [](const Initializer<JSFunction>& init) {
-            auto scope = DECLARE_THROW_SCOPE(init.vm);
+            auto scope = DECLARE_TOP_EXCEPTION_SCOPE(init.vm);
             JSValue nodeUtilValue = jsCast<Zig::GlobalObject*>(init.owner)->internalModuleRegistry()->requireId(init.owner, init.vm, Bun::InternalModuleRegistry::Field::NodeUtil);
-            RETURN_IF_EXCEPTION(scope, );
+            scope.assertNoExceptionExceptTermination();
             RELEASE_ASSERT(nodeUtilValue.isObject());
             auto prop = nodeUtilValue.getObject()->getIfPropertyExists(init.owner, Identifier::fromString(init.vm, "inspect"_s));
-            RETURN_IF_EXCEPTION(scope, );
+            scope.assertNoExceptionExceptTermination();
             ASSERT(prop);
             init.set(jsCast<JSFunction*>(prop));
         });
@@ -1929,23 +1929,23 @@ void GlobalObject::finishCreation(VM& vm)
 
     m_utilInspectStylizeColorFunction.initLater(
         [](const Initializer<JSFunction>& init) {
-            auto scope = DECLARE_THROW_SCOPE(init.vm);
+            auto scope = DECLARE_TOP_EXCEPTION_SCOPE(init.vm);
             JSC::MarkedArgumentBuffer args;
             args.append(jsCast<Zig::GlobalObject*>(init.owner)->utilInspectFunction());
-            RETURN_IF_EXCEPTION(scope, );
+            scope.assertNoExceptionExceptTermination();
 
             JSC::JSFunction* getStylize = JSC::JSFunction::create(init.vm, init.owner, utilInspectGetStylizeWithColorCodeGenerator(init.vm), init.owner);
-            RETURN_IF_EXCEPTION(scope, );
+            scope.assertNoExceptionExceptTermination();
 
             JSC::CallData callData = JSC::getCallData(getStylize);
             NakedPtr<JSC::Exception> returnedException = nullptr;
             auto result = JSC::profiledCall(init.owner, ProfilingReason::API, getStylize, callData, jsNull(), args, returnedException);
-            RETURN_IF_EXCEPTION(scope, );
+            scope.assertNoExceptionExceptTermination();
 
             if (returnedException) {
-                throwException(init.owner, scope, returnedException.get());
+                init.set(JSC::JSFunction::create(init.vm, init.owner, utilInspectStylizeWithNoColorCodeGenerator(init.vm), init.owner));
+                return;
             }
-            RETURN_IF_EXCEPTION(scope, );
             init.set(jsCast<JSFunction*>(result));
         });
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { normalizeBunSnapshot, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tmpdirSync } from "harness";
 import { join } from "path";
 import util from "util";
 it("prototype", () => {
@@ -739,4 +739,15 @@ it("CustomEvent", () => {
       BUBBLING_PHASE: 3,
     }"
   `);
+});
+
+it("Bun.inspect does not crash after deleting globalThis.Loader", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `delete globalThis.Loader; Bun.inspect(Bun.spawnSync(["echo"])); Bun.gc(true);`],
+    env: bunEnv,
+  });
+
+  const exitCode = await proc.exited;
+
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
The `m_utilInspectFunction` and `m_utilInspectStylizeColorFunction` `initLater` lambdas used `DECLARE_THROW_SCOPE` with `RETURN_IF_EXCEPTION` that could return without calling `init.set()`. This violates `LazyProperty`'s contract — `callFunc()` asserts that `lazyTag` is cleared after the initializer runs, meaning `init.set()` must always be called.  When a termination exception occurred during initialization (e.g. from `Bun.inspect(Bun.spawnSync(...))` after deleting `globalThis.Loader`), the early return skipped `init.set()`, triggering: ``` ASSERTION FAILED: !(initializer.property.m_pointer & lazyTag) LazyPropertyInlines.h(104) ```  Fix: replace `DECLARE_THROW_SCOPE` + `RETURN_IF_EXCEPTION` with `DECLARE_TOP_EXCEPTION_SCOPE` + `assertNoExceptionExceptTermination()`, matching the pattern used by other lazy property initializers in the same file (e.g. `m_JSBufferSubclassStructure`). This ensures `init.set()` is always reached.  ---  Verification (robobun, iteration 15): Lint JS green. Buildkite build #40724 compiling on commit 0e398c2. Diff verified: two initLater lambdas in ZigGlobalObject.cpp switch from DECLARE_THROW_SCOPE/RETURN_IF_EXCEPTION to DECLARE_TOP_EXCEPTION_SCOPE/assertNoExceptionExceptTermination, exactly matching the m_JSBufferSubclassStructure pattern at lines 1887-1895. Dead returnedException/throwException block replaced with ASSERT(!returnedException). DeferTerminationForAWhile in LazyProperty::callFunc prevents termination mid-lambda, making ASSERT-only guards safe. Regression test at inspect.test.js:744 exercises the exact crash path (delete globalThis.Loader then Bun.inspect(Bun.spawnSync(["echo"])) then assert exit 0); confirmed test does not exist on main. No TODO/FIXME/HACK in added lines. s3 file is autofix import sort only. All Claude reviews LGTM with concerns resolved. CodeRabbit paused (no actionable findings).  Verification (robobun, iteration 18): Lint JS passed. Buildkite build #40790 running (compiling). Diff is clean: two initLater lambdas in ZigGlobalObject.cpp switch from DECLARE_THROW_SCOPE/RETURN_IF_EXCEPTION to DECLARE_TOP_EXCEPTION_SCOPE/assertNoExceptionExceptTermination, matching established m_JSBufferSubclassStructure pattern at lines 1887-1895. DeferTerminationForAWhile in LazyPropertyInlines.h:101 wraps callFunc, confirming termination cannot occur inside initLater lambdas. The returnedException path now falls back to utilInspectStylizeWithNoColorCodeGenerator instead of skipping init.set(). Regression test at inspect.test.js:744 spawns subprocess that deletes globalThis.Loader, calls Bun.inspect(Bun.spawnSync(["echo"])), forces GC, and asserts exit code 0. No TODO/FIXME/HACK/XXX in added lines. All 13 Claude reviews resolved with LGTM. 

Verification (robobun, iteration 19): Lint JS passed. Buildkite build #40790 was canceled (infrastructure), not a compilation or test failure from this PR. Diff verified: two initLater lambdas switch from DECLARE_THROW_SCOPE/RETURN_IF_EXCEPTION to DECLARE_TOP_EXCEPTION_SCOPE/assertNoExceptionExceptTermination, matching m_JSBufferSubclassStructure pattern. DeferTerminationForAWhile confirmed at LazyPropertyInlines.h:101. returnedException fallback calls init.set() with no-color stylize function. Regression test at inspect.test.js:744 exercises crash path and is absent from main. No TODO/FIXME/HACK. All reviews resolved LGTM.

Verification (robobun, iteration 20): Lint JS passed, Format and Buildkite build #40794 still in progress. Independently verified: DeferTerminationForAWhile at LazyPropertyInlines.h:101 wraps callFunc, confirming termination cannot fire inside initLater lambdas. Both modified lambdas call init.set() on all code paths — m_utilInspectFunction flows straight to init.set(jsCast<JSFunction*>(prop)), m_utilInspectStylizeColorFunction has fallback init.set() with no-color stylize on returnedException. Pattern matches m_JSBufferSubclassStructure at lines 1887-1895. Regression test at inspect.test.js:744 confirmed absent from main. No TODO/FIXME/HACK. All reviews resolved.