### PR TITLE
Use direct property lookup instead of HashSet in FormData/CookieMap toJSON

### DIFF
--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -8,7 +8,6 @@
 #include "HTTPParsers.h"
 #include "decodeURIComponentSIMD.h"
 #include "BunString.h"
-#include <wtf/HashSet.h>
 namespace WebCore {
 
 template<typename Res>
@@ -234,23 +233,30 @@ JSC::JSValue CookieMap::toJSON(JSC::JSGlobalObject* globalObject) const
     auto* object = JSC::constructEmptyObject(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    HashSet<String> seenKeys;
-
     // Add modified cookies to the object
     for (const auto& cookie : m_modifiedCookies) {
         if (!cookie->value().isEmpty()) {
-            seenKeys.add(cookie->name());
             object->putDirectMayBeIndex(globalObject, JSC::Identifier::fromString(vm, cookie->name()), JSC::jsString(vm, cookie->value()));
             RETURN_IF_EXCEPTION(scope, {});
         }
     }
 
-    // Add original cookies to the object
+    // Add original cookies that weren't already set by a modified cookie.
+    // Check the object's own storage directly rather than a separate HashSet
+    // or hasProperty (which walks the prototype chain).
     for (const auto& cookie : m_originalCookies) {
-        // Skip if this cookie name was already added from modified cookies
-        if (seenKeys.add(cookie.key).isNewEntry) {
-            object->putDirectMayBeIndex(globalObject, JSC::Identifier::fromString(vm, cookie.key), JSC::jsString(vm, cookie.value));
+        auto ident = JSC::Identifier::fromString(vm, cookie.key);
+        if (auto index = JSC::parseIndex(ident)) [[unlikely]] {
+            JSValue existing = object->getDirectIndex(globalObject, index.value());
             RETURN_IF_EXCEPTION(scope, {});
+            if (existing)
+                continue;
+            object->putDirectIndex(globalObject, index.value(), JSC::jsString(vm, cookie.value));
+            RETURN_IF_EXCEPTION(scope, {});
+        } else {
+            if (object->getDirect(vm, ident))
+                continue;
+            object->putDirect(vm, ident, JSC::jsString(vm, cookie.value));
         }
     }
 

--- a/src/jsc/bindings/webcore/JSDOMFormData.cpp
+++ b/src/jsc/bindings/webcore/JSDOMFormData.cpp
@@ -636,7 +636,6 @@ JSC::JSValue getInternalProperties(JSC::VM& vm, JSGlobalObject* lexicalGlobalObj
     obj->putDirect(vm, vm.propertyNames->toStringTagSymbol, jsString(vm, String("FormData"_s)), PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
 
     auto iter = impl.items();
-    WTF::HashSet<String> seenKeys;
 
     auto toJSValue = [&](const DOMFormData::FormDataEntryValue& entry) -> JSValue {
         return toJS<IDLNullable<IDLUnion<IDLUSVString, IDLInterface<Blob>>>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, entry);
@@ -647,52 +646,66 @@ JSC::JSValue getInternalProperties(JSC::VM& vm, JSGlobalObject* lexicalGlobalObj
         auto& value = entry.data;
         auto ident = Identifier::fromString(vm, key);
         auto index = JSC::parseIndex(ident);
-        if (seenKeys.contains(key)) {
-            JSValue jsValue = index.has_value() ? obj->getDirectIndex(lexicalGlobalObject, index.value()) : obj->getDirect(vm, ident);
+
+        // Look up the existing value in the object's own storage directly
+        // (rather than tracking seen keys in a separate HashSet). getDirect
+        // only checks the structure's property map and cannot throw; indexed
+        // properties are stored in the butterfly, so use getDirectIndex.
+        JSValue existing;
+        if (index) [[unlikely]] {
+            existing = obj->getDirectIndex(lexicalGlobalObject, index.value());
             RETURN_IF_EXCEPTION(throwScope, {});
-            if (jsValue.isString() || jsValue.inherits<JSBlob>()) {
-                // Make sure this runs before the deferral scope is called.
-                JSValue resultValue = toJSValue(value);
-                RETURN_IF_EXCEPTION(throwScope, {});
-                ensureStillAliveHere(resultValue);
-
-                JSC::JSArray* array = nullptr;
-
-                {
-                    GCDeferralContext deferralContext(lexicalGlobalObject->vm());
-                    JSC::ObjectInitializationScope initializationScope(lexicalGlobalObject->vm());
-
-                    array = JSC::JSArray::tryCreateUninitializedRestricted(
-                        initializationScope, &deferralContext,
-                        lexicalGlobalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous),
-                        2);
-                    RELEASE_ASSERT(array);
-
-                    array->initializeIndex(initializationScope, 0, jsValue);
-                    array->initializeIndex(initializationScope, 1, resultValue);
-                }
-
-                if (index.has_value())
-                    obj->putDirectIndex(lexicalGlobalObject, index.value(), array);
-                else
-                    obj->putDirect(vm, ident, array, 0);
-                RETURN_IF_EXCEPTION(throwScope, {});
-            } else if (jsValue.isObject() && jsValue.getObject()->inherits<JSC::JSArray>()) {
-                JSC::JSArray* array = uncheckedDowncast<JSC::JSArray>(jsValue.getObject());
-                JSValue jsValue = toJSValue(value);
-                RETURN_IF_EXCEPTION(throwScope, {});
-                array->push(lexicalGlobalObject, jsValue);
-                RETURN_IF_EXCEPTION(throwScope, {});
-
-            } else {
-                RELEASE_ASSERT_NOT_REACHED();
-            }
         } else {
-            seenKeys.add(key);
+            existing = obj->getDirect(vm, ident);
+        }
+
+        auto put = [&](JSValue v) {
+            if (index) [[unlikely]]
+                obj->putDirectIndex(lexicalGlobalObject, index.value(), v);
+            else
+                obj->putDirect(vm, ident, v, 0);
+        };
+
+        if (!existing) {
             JSValue jsValue = toJSValue(value);
             RETURN_IF_EXCEPTION(throwScope, {});
-            obj->putDirectMayBeIndex(lexicalGlobalObject, ident, jsValue);
+            put(jsValue);
             RETURN_IF_EXCEPTION(throwScope, {});
+        } else if (existing.isString() || existing.inherits<JSBlob>()) {
+            // Make sure this runs before the deferral scope is called.
+            JSValue resultValue = toJSValue(value);
+            RETURN_IF_EXCEPTION(throwScope, {});
+            ensureStillAliveHere(resultValue);
+
+            JSC::JSArray* array = nullptr;
+
+            {
+                GCDeferralContext deferralContext(lexicalGlobalObject->vm());
+                JSC::ObjectInitializationScope initializationScope(lexicalGlobalObject->vm());
+
+                array = JSC::JSArray::tryCreateUninitializedRestricted(
+                    initializationScope, &deferralContext,
+                    lexicalGlobalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous),
+                    2);
+                if (!array) [[unlikely]] {
+                    throwScope.throwException(lexicalGlobalObject, createOutOfMemoryError(lexicalGlobalObject));
+                    return {};
+                }
+
+                array->initializeIndex(initializationScope, 0, existing);
+                array->initializeIndex(initializationScope, 1, resultValue);
+            }
+
+            put(array);
+            RETURN_IF_EXCEPTION(throwScope, {});
+        } else if (existing.isObject() && existing.getObject()->inherits<JSC::JSArray>()) {
+            JSC::JSArray* array = uncheckedDowncast<JSC::JSArray>(existing.getObject());
+            JSValue jsValue = toJSValue(value);
+            RETURN_IF_EXCEPTION(throwScope, {});
+            array->push(lexicalGlobalObject, jsValue);
+            RETURN_IF_EXCEPTION(throwScope, {});
+        } else {
+            RELEASE_ASSERT_NOT_REACHED();
         }
     }
 

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -247,6 +247,15 @@ describe("Bun.Cookie and Bun.CookieMap", () => {
     });
   });
 
+  test("CookieMap.toJSON() prefers modified value for numeric cookie names", () => {
+    const map = new Bun.CookieMap("0=original; 1=unchanged");
+    map.set("0", "modified");
+    expect(map.toJSON()).toEqual({
+      "0": "modified",
+      "1": "unchanged",
+    });
+  });
+
   test("CookieMap.toJSON() handles cookie names matching Object.prototype properties", () => {
     const map = new Bun.CookieMap("toString=hello; constructor=world; valueOf=test");
     expect(map.toJSON()).toEqual({

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -256,6 +256,25 @@ describe("Bun.Cookie and Bun.CookieMap", () => {
     });
   });
 
+  test("CookieMap.toJSON() keeps first value for duplicate numeric cookie names", () => {
+    // Two entries with the same numeric key live in the original-cookie list,
+    // so toJSON()'s second loop sees an index that is already on the output
+    // object and must skip the duplicate (getDirectIndex + continue).
+    const map = new Bun.CookieMap("0=first; 0=second; 1=unchanged");
+    expect(map.toJSON()).toEqual({
+      "0": "first",
+      "1": "unchanged",
+    });
+  });
+
+  test("CookieMap.toJSON() keeps first value for duplicate named cookie names", () => {
+    const map = new Bun.CookieMap("foo=first; foo=second; bar=baz");
+    expect(map.toJSON()).toEqual({
+      foo: "first",
+      bar: "baz",
+    });
+  });
+
   test("CookieMap.toJSON() handles cookie names matching Object.prototype properties", () => {
     const map = new Bun.CookieMap("toString=hello; constructor=world; valueOf=test");
     expect(map.toJSON()).toEqual({

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -669,30 +669,34 @@ describe("FormData", () => {
   // The minimum repro for this was to not call the .name and .type getter on the Blob
   // But the crux of the issue is that we called dupe() on the Blob, without also incrementing the reference count of the name string.
   // https://github.com/oven-sh/bun/issues/14918
-  it("should increment reference count of the name string on Blob", async () => {
-    const buffer = new File([Buffer.from(Buffer.alloc(48 * 1024, "abcdefh").toString("base64"), "base64")], "ok.jpg");
-    function test() {
-      let file = new File([buffer], "ok.jpg");
-      file.name;
-      file.type;
+  it(
+    "should increment reference count of the name string on Blob",
+    async () => {
+      const buffer = new File([Buffer.from(Buffer.alloc(48 * 1024, "abcdefh").toString("base64"), "base64")], "ok.jpg");
+      function test() {
+        let file = new File([buffer], "ok.jpg");
+        file.name;
+        file.type;
 
-      let formData = new FormData();
-      formData.append("foo", file);
-      formData.get("foo");
-      formData.get("foo")!.name;
-      formData.get("foo")!.type;
-      return formData;
-    }
-    for (let i = 0; i < 100000; i++) {
-      test();
-      if (i % 5000 === 0) {
-        Bun.gc();
+        let formData = new FormData();
+        formData.append("foo", file);
+        formData.get("foo");
+        formData.get("foo")!.name;
+        formData.get("foo")!.type;
+        return formData;
       }
-    }
-    // The 100k-iteration loop runs ~15x slower under the debug+ASAN build,
-    // where instrumented allocation dominates; give it a realistic budget
-    // instead of the 5s default so it doesn't time out on that lane.
-  }, isDebug ? 120_000 : 30_000);
+      for (let i = 0; i < 100000; i++) {
+        test();
+        if (i % 5000 === 0) {
+          Bun.gc();
+        }
+      }
+      // The 100k-iteration loop runs ~15x slower under the debug+ASAN build,
+      // where instrumented allocation dominates; give it a realistic budget
+      // instead of the 5s default so it doesn't time out on that lane.
+    },
+    isDebug ? 120_000 : 30_000,
+  );
 });
 
 // https://github.com/oven-sh/bun/issues/14988

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isDebug } from "harness";
 import { join } from "path";
 
 describe("FormData", () => {
@@ -689,7 +689,10 @@ describe("FormData", () => {
         Bun.gc();
       }
     }
-  });
+    // The 100k-iteration loop runs ~15x slower under the debug+ASAN build,
+    // where instrumented allocation dominates; give it a realistic budget
+    // instead of the 5s default so it doesn't time out on that lane.
+  }, isDebug ? 120_000 : 30_000);
 });
 
 // https://github.com/oven-sh/bun/issues/14988

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -278,6 +278,25 @@ describe("FormData", () => {
     expect(fd.toJSON()).toEqual({ "1": "1" });
   });
 
+  test("FormData.toJSON handles duplicate numeric keys", () => {
+    const fd = new FormData();
+    fd.append("42", "a");
+    fd.append("42", "b");
+    fd.append("42", "c");
+    // @ts-expect-error - toJSON is a Bun extension
+    expect(fd.toJSON()).toEqual({ "42": ["a", "b", "c"] });
+  });
+
+  test("FormData.toJSON handles mixed numeric and named duplicate keys", () => {
+    const fd = new FormData();
+    fd.append("0", "a");
+    fd.append("name", "x");
+    fd.append("0", "b");
+    fd.append("name", "y");
+    // @ts-expect-error - toJSON is a Bun extension
+    expect(fd.toJSON()).toEqual({ "0": ["a", "b"], name: ["x", "y"] });
+  });
+
   test("FormData.from throws on very large input instead of crashing", () => {
     // This test verifies that FormData.from throws an exception instead of crashing
     // when given input larger than WebKit's String::MaxLength (INT32_MAX ~= 2GB).


### PR DESCRIPTION
Follow-up to #28314 — the HashSet is unnecessary. We can check whether a key was already written by looking it up directly in the output object's own storage:

- For named properties, `getDirect(vm, ident)` is a single Structure lookup that returns an empty `JSValue` if the property doesn't exist and cannot throw.
- For numeric keys, properties live in the butterfly rather than the Structure, so use `getDirectIndex(globalObject, index)`.

Parsing the index once and branching also avoids the double-parse that `putDirectMayBeIndex` would do in the put path.

This also fixes a crash in `FormData.toJSON()` when the same numeric key is appended more than once. The duplicate-key path called `getDirect`, which only looks at the Structure and missed indexed properties, so it got an empty value and hit `RELEASE_ASSERT_NOT_REACHED`.

```js
const fd = new FormData();
fd.append("42", "a");
fd.append("42", "b");
fd.toJSON(); // crashed with SIGSEGV
```

Supersedes #28319.