### PR TITLE
Fix cross-drive compile target download on Windows

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -1103,6 +1103,21 @@ pub const StandaloneModuleGraph = struct {
                             \\Could not extract executable for {}
                         , .{target.*});
                     },
+                    error.CacheDirectoryError => {
+                        Output.errGeneric(
+                            \\Cannot open or create the cache directory for {}.
+                            \\
+                            \\Check permissions on the bun install cache directory,
+                            \\or set BUN_INSTALL_CACHE_DIR to a writable path.
+                        , .{target.*});
+                    },
+                    error.NoSpaceLeft => {
+                        Output.errGeneric(
+                            \\Not enough disk space to extract {}.
+                            \\
+                            \\Free up disk space and try again.
+                        , .{target.*});
+                    },
                     else => {
                         Output.errGeneric("Failed to download {}: {s}", .{ target.*, @errorName(err) });
                     },
@@ -1157,6 +1172,8 @@ pub const StandaloneModuleGraph = struct {
                         error.NetworkError => CompileResult.failFmt("Network error downloading executable for '{f}'. Check your internet connection and proxy settings.", .{target}),
                         error.InvalidResponse => CompileResult.failFmt("Downloaded file for '{f}' appears to be corrupted. Please try again.", .{target}),
                         error.ExtractionFailed => CompileResult.failFmt("Failed to extract executable for '{f}'. The download may be incomplete.", .{target}),
+                        error.CacheDirectoryError => CompileResult.failFmt("Cannot open or create the cache directory for '{f}'. Check permissions on the bun install cache, or set BUN_INSTALL_CACHE_DIR to a writable path.", .{target}),
+                        error.NoSpaceLeft => CompileResult.failFmt("Not enough disk space to extract '{f}'. Free up disk space and try again.", .{target}),
                         error.UnsupportedTarget => CompileResult.failFmt("Target '{f}' is not supported", .{target}),
                         else => CompileResult.failFmt("Failed to download '{f}': {s}", .{ target, @errorName(err) }),
                     };

--- a/src/compile_target.zig
+++ b/src/compile_target.zig
@@ -52,6 +52,7 @@ pub const DownloadError = error{
     NetworkError,
     InvalidResponse,
     ExtractionFailed,
+    CacheDirectoryError,
     InvalidTarget,
     OutOfMemory,
     NoSpaceLeft,
@@ -215,6 +216,7 @@ pub fn downloadToPath(this: *const CompileTarget, env: *bun.DotEnv.Loader, alloc
         }
 
         var tarball_bytes = std.ArrayListUnmanaged(u8){};
+        defer tarball_bytes.deinit(allocator);
         {
             refresher.refresh();
             defer compressed_archive_bytes.list.deinit(allocator);
@@ -248,9 +250,37 @@ pub fn downloadToPath(this: *const CompileTarget, env: *bun.DotEnv.Loader, alloc
                 const libarchive = bun.libarchive;
                 var tmpname_buf: [1024]u8 = undefined;
                 const tempdir_name = try bun.fs.FileSystem.tmpname("tmp", &tmpname_buf, bun.fastRandom());
-                var tmpdir = try std.fs.cwd().makeOpenPath(tempdir_name, .{});
+
+                // Create the temp directory in the same parent directory as
+                // the destination so that the final rename never crosses a
+                // filesystem / drive boundary. On Windows, renameat cannot
+                // move files across drives (returns XDEV), which caused
+                // "Failed to extract executable" when cwd was on a different
+                // drive than the bun install cache.
+                const dest_dir = bun.path.dirname(dest_z, .loose);
+                if (dest_dir.len > 0) {
+                    bun.makePath(std.fs.cwd(), dest_dir) catch {};
+                }
+
+                // Open the destination's parent directory so we can create
+                // the temp dir inside it, guaranteeing same-filesystem rename.
+                var tmpdir_parent = if (dest_dir.len > 0)
+                    std.fs.cwd().openDir(dest_dir, .{}) catch
+                        return error.CacheDirectoryError
+                else
+                    std.fs.cwd();
+                defer if (dest_dir.len > 0) tmpdir_parent.close();
+
+                var tmpdir = tmpdir_parent.makeOpenPath(tempdir_name, .{}) catch |e| return switch (e) {
+                    error.NoSpaceLeft, error.DiskQuota => error.NoSpaceLeft,
+                    else => error.CacheDirectoryError,
+                };
+                // deleteTree registered first so it runs after tmpdir.close()
+                // (Zig defers are LIFO). On Windows, RemoveDirectoryW fails
+                // with ERROR_SHARING_VIOLATION if the handle is still open.
+                defer tmpdir_parent.deleteTree(tempdir_name) catch {};
                 defer tmpdir.close();
-                defer std.fs.cwd().deleteTree(tempdir_name) catch {};
+
                 _ = libarchive.Archiver.extractToDir(
                     tarball_bytes.items,
                     tmpdir,
@@ -263,29 +293,13 @@ pub fn downloadToPath(this: *const CompileTarget, env: *bun.DotEnv.Loader, alloc
                     },
                 ) catch {
                     node.end();
-                    // Return error without printing - let caller handle the messaging
                     return error.ExtractionFailed;
                 };
 
-                var did_retry = false;
-                while (true) {
-                    bun.sys.moveFileZ(.fromStdDir(tmpdir), if (this.os == .windows) "bun.exe" else "bun", bun.invalid_fd, dest_z) catch {
-                        if (!did_retry) {
-                            did_retry = true;
-                            const dirname = bun.path.dirname(dest_z, .loose);
-                            if (dirname.len > 0) {
-                                std.fs.cwd().makePath(dirname) catch {};
-                                continue;
-                            }
-
-                            // fallthrough, failed for another reason
-                        }
-                        node.end();
-                        // Return error without printing - let caller handle the messaging
-                        return error.ExtractionFailed;
-                    };
-                    break;
-                }
+                bun.sys.moveFileZ(.fromStdDir(tmpdir), if (this.os == .windows) "bun.exe" else "bun", bun.invalid_fd, dest_z) catch {
+                    node.end();
+                    return error.ExtractionFailed;
+                };
             }
             refresher.refresh();
         }


### PR DESCRIPTION
## Problem

When running `bun build --compile` with a cross-compilation target (e.g. `--target=bun-windows-x64-baseline`) on Windows, the build fails with:

```
Failed to extract executable for 'bun-windows-x64-baseline-v1.3.11'. The download may be incomplete.
```

This happens when the current working directory is on a different drive than the bun install cache (e.g. cwd on `D:\` but cache on `C:\Users\...\.bun\install\cache\`).

Closes #28327. Related: #11198, #25346.

## Root Cause

In `downloadToPath`, the temp directory for extracting the downloaded tarball was created relative to `std.fs.cwd()`. The extracted binary was then renamed from this temp directory to the cache directory using `moveFileZ`. On Windows, `renameat` (via `NtSetInformationFile`) cannot move files across drive boundaries — it returns `XDEV` (mapped from `NOT_SAME_DEVICE`). Although `moveFileZ` has an XDEV fallback path (`moveFileZSlow`), the fallback has issues on Windows (unlinking before copying, then trying to resolve the deleted path via `GetFinalPathNameByHandleW`).

## Fix

Create the temp directory in the same parent directory as the destination cache path instead of relative to cwd. This ensures the final rename always stays on the same filesystem/drive, avoiding the XDEV error entirely.

Also simplified the retry logic — the parent directory is now created upfront before extraction.

## Verification

- `bun bd` builds successfully
- `bun bd test test/bundler/bun-build-compile.test.ts -t "compile with current platform target string"` passes
- The bug is Windows-specific (cross-drive rename) and cannot be directly reproduced on Linux

---
**Verified by robobun (iter 21)**: CI: Lint JS ✅, Buildkite #40952 in progress (275 jobs, 0 failures). Diff verified: compile_target.zig creates temp dir in dest parent directory to avoid cross-drive XDEV rename on Windows; defer ordering correct (LIFO: tmpdir.close() before deleteTree); tarball_bytes leak fixed; CacheDirectoryError + NoSpaceLeft added to DownloadError and handled at both call sites in StandaloneModuleGraph.zig with actionable messages. No TODO/FIXME/HACK. std.fs.cwd() usage unchanged (3 to 3). S3 test change is trivial autoformat. All review threads resolved.