### PR TITLE
fix: use isObject() instead of isCell() in dns.lookup options check

### DIFF
--- a/src/bun.js/api/bun/dns.zig
+++ b/src/bun.js/api/bun/dns.zig
@@ -2719,7 +2719,7 @@ pub const Resolver = struct {
         var options = GetAddrInfo.Options{};
         var port: u16 = 0;
 
-        if (arguments.len > 1 and arguments.ptr[1].isCell()) {
+        if (arguments.len > 1 and arguments.ptr[1].isObject()) {
             const optionsObject = arguments.ptr[1];
 
             if (try optionsObject.getTruthy(globalThis, "port")) |port_value| {

--- a/test/js/bun/dns/dns-lookup-non-object-options.test.ts
+++ b/test/js/bun/dns/dns-lookup-non-object-options.test.ts
@@ -1,0 +1,9 @@
+import { dns } from "bun";
+import { describe, expect, test } from "bun:test";
+
+describe("dns.lookup", () => {
+  test("does not crash when options argument is a non-object cell", async () => {
+    const result = await dns.lookup("localhost", "not-an-object" as any);
+    expect(result).toBeArray();
+  });
+});


### PR DESCRIPTION
Passing a non-object cell (e.g. a string or function) as the second argument to `Bun.dns.lookup()` would crash in debug builds. The options guard checked `isCell()`, which matches strings, arrays, functions, etc. — but `getTruthy()` calls `get()` which asserts `isObject()`, hitting unreachable.

Fix: change `isCell()` to `isObject()` so only actual objects are treated as options.

---
Verification (robobun, iteration 54): Confirmed fix at dns.zig:2722 — `isObject()` correctly guards the options branch where downstream `getTruthy`/`get()` asserts object type. Test (9 lines, in-process) calls `dns.lookup("localhost", "not-an-object" as any)` and asserts `toBeArray()`, directly exercising the former crash path. Jarred-Sumner CHANGES_REQUESTED ("run in-process") addressed. Build #41358 (commit 981a09a) building; previous builds on same code (#41255) showed 52/57 pass with 5 infra-only failures (darwin runners, linux-x64-musl build-cpp), none DNS-related. Lint JS ✅, Format ✅. No TODO/FIXME/HACK. CodeRabbit function-case nit non-blocking.

---
Verified by robobun (iteration 56): Fix at dns.zig:2722 changes isCell() to isObject(), correctly aligning the guard with downstream getTruthy()/get() assertions. In-process test (9 lines) calls dns.lookup("localhost", "not-an-object") and asserts toBeArray(), directly exercising the former crash path. Jarred-Sumner CHANGES_REQUESTED ("run in-process") addressed. Lint JS pass on 6434a2d. Build 41381 pending; prior build 41358 on identical code (0 file diff) had only darwin runner infra failures, unrelated to DNS. No TODO/FIXME/HACK.