### PR TITLE
Percent-encode unix socket paths in server.url

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1174,8 +1174,21 @@ pub enum URLProto {
 /// spaces, brackets, etc. round-trip through the URL parser.
 fn url_needs_escape(c: u8, authority: bool) -> bool {
     match c {
-        0x00..=0x1F | b' ' | b'"' | b'#' | b'%' | b'<' | b'>' | b'?' | b'[' | b'\\' | b']'
-        | b'^' | b'`' | b'|' | b'~' => true,
+        0x00..=0x1F
+        | b' '
+        | b'"'
+        | b'#'
+        | b'%'
+        | b'<'
+        | b'>'
+        | b'?'
+        | b'['
+        | b'\\'
+        | b']'
+        | b'^'
+        | b'`'
+        | b'|'
+        | b'~' => true,
         // In the authority position (abstract sockets), @/:/ are
         // structural delimiters that must also be percent-encoded.
         b'/' | b'@' | b':' => authority,
@@ -1206,7 +1219,11 @@ impl Display for URLFormatter<'_> {
         match self.proto {
             URLProto::Unix | URLProto::Abstract => {
                 let is_abstract = self.proto == URLProto::Abstract;
-                f.write_str(if is_abstract { "abstract://" } else { "unix://" })?;
+                f.write_str(if is_abstract {
+                    "abstract://"
+                } else {
+                    "unix://"
+                })?;
                 if let Some(path) = self.hostname {
                     // Abstract socket names sit in the URL authority, so
                     // @, :, / must be escaped. Unix paths sit in the URL
@@ -1224,7 +1241,11 @@ impl Display for URLFormatter<'_> {
         write!(
             f,
             "{}://",
-            if self.proto == URLProto::Https { "https" } else { "http" }
+            if self.proto == URLProto::Https {
+                "https"
+            } else {
+                "http"
+            }
         )?;
 
         if let Some(hostname) = self.hostname {

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1169,17 +1169,62 @@ pub enum URLProto {
     Abstract,
 }
 
+/// Percent-encode bytes that are unsafe in a URL path component.
+/// Matches WTF's filePathEscapeTable so that unix socket paths with
+/// spaces, brackets, etc. round-trip through the URL parser.
+fn url_needs_escape(c: u8, authority: bool) -> bool {
+    match c {
+        0x00..=0x1F | b' ' | b'"' | b'#' | b'%' | b'<' | b'>' | b'?' | b'[' | b'\\' | b']'
+        | b'^' | b'`' | b'|' | b'~' => true,
+        // In the authority position (abstract sockets), @/:/ are
+        // structural delimiters that must also be percent-encoded.
+        b'/' | b'@' | b':' => authority,
+        _ => c >= 0x7F,
+    }
+}
+
+fn url_write_escaped(f: &mut impl fmt::Write, path: &[u8], authority: bool) -> fmt::Result {
+    let mut remaining = path;
+    while !remaining.is_empty() {
+        let mut safe_len = 0;
+        while safe_len < remaining.len() && !url_needs_escape(remaining[safe_len], authority) {
+            safe_len += 1;
+        }
+        write_bytes(f, &remaining[..safe_len])?;
+        remaining = &remaining[safe_len..];
+        if remaining.is_empty() {
+            break;
+        }
+        write!(f, "%{:02X}", remaining[0])?;
+        remaining = &remaining[1..];
+    }
+    Ok(())
+}
+
 impl Display for URLFormatter<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self.proto {
+            URLProto::Unix | URLProto::Abstract => {
+                let is_abstract = self.proto == URLProto::Abstract;
+                f.write_str(if is_abstract { "abstract://" } else { "unix://" })?;
+                if let Some(path) = self.hostname {
+                    // Abstract socket names sit in the URL authority, so
+                    // @, :, / must be escaped. Unix paths sit in the URL
+                    // path where / is a legitimate separator.
+                    url_write_escaped(f, path, is_abstract)?;
+                }
+                if is_abstract {
+                    f.write_str("/")?;
+                }
+                return Ok(());
+            }
+            URLProto::Http | URLProto::Https => {}
+        }
+
         write!(
             f,
             "{}://",
-            match self.proto {
-                URLProto::Http => "http",
-                URLProto::Https => "https",
-                URLProto::Unix => "unix",
-                URLProto::Abstract => "abstract",
-            }
+            if self.proto == URLProto::Https { "https" } else { "http" }
         )?;
 
         if let Some(hostname) = self.hostname {
@@ -1191,10 +1236,6 @@ impl Display for URLFormatter<'_> {
             }
         } else {
             f.write_str("localhost")?;
-        }
-
-        if self.proto == URLProto::Unix {
-            return Ok(());
         }
 
         let is_port_optional = self.port.is_none()

--- a/src/bun_core/fmt.zig
+++ b/src/bun_core/fmt.zig
@@ -488,13 +488,55 @@ pub const URLFormatter = struct {
         abstract,
     };
 
+    // Percent-encode bytes that are unsafe in a URL path component.
+    // Matches WTF's filePathEscapeTable so that unix socket paths with
+    // spaces, brackets, etc. round-trip through the URL parser.
+    fn needsEscape(c: u8, authority: bool) bool {
+        return switch (c) {
+            0x00...0x1F, ' ', '"', '#', '%', '<', '>', '?', '[', '\\', ']', '^', '`', '|', '~' => true,
+            // In the authority position (abstract sockets), @/:/ are
+            // structural delimiters that must also be percent-encoded.
+            '/', '@', ':' => authority,
+            else => c >= 0x7F,
+        };
+    }
+
+    fn writeEscaped(writer: *std.Io.Writer, path: []const u8, authority: bool) !void {
+        var remaining = path;
+        while (remaining.len > 0) {
+            var safe_len: usize = 0;
+            while (safe_len < remaining.len and !needsEscape(remaining[safe_len], authority)) {
+                safe_len += 1;
+            }
+            try writer.writeAll(remaining[0..safe_len]);
+            remaining = remaining[safe_len..];
+            if (remaining.len == 0) break;
+            const c = remaining[0];
+            try writer.print("%{X:0>2}", .{c});
+            remaining = remaining[1..];
+        }
+    }
+
     pub fn format(this: URLFormatter, writer: *std.Io.Writer) !void {
-        try writer.print("{s}://", .{switch (this.proto) {
-            .http => "http",
-            .https => "https",
-            .unix => "unix",
-            .abstract => "abstract",
-        }});
+        switch (this.proto) {
+            .unix, .abstract => {
+                const is_abstract = this.proto == .abstract;
+                try writer.writeAll(if (is_abstract) "abstract://" else "unix://");
+                if (this.hostname) |path| {
+                    // Abstract socket names sit in the URL authority, so
+                    // @, :, / must be escaped. Unix paths sit in the URL
+                    // path where / is a legitimate separator.
+                    try writeEscaped(writer, path, is_abstract);
+                }
+                if (is_abstract) {
+                    try writer.writeAll("/");
+                }
+                return;
+            },
+            .http, .https => {},
+        }
+
+        try writer.print("{s}://", .{if (this.proto == .https) "https" else "http"});
 
         if (this.hostname) |hostname| {
             const needs_brackets = hostname[0] != '[' and strings.isIPV6Address(hostname);
@@ -505,10 +547,6 @@ pub const URLFormatter = struct {
             }
         } else {
             try writer.writeAll("localhost");
-        }
-
-        if (this.proto == .unix) {
-            return;
         }
 
         const is_port_optional = this.port == null or (this.proto == .https and this.port == 443) or

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -590,8 +590,12 @@ extern "C" JSC::EncodedJSValue BunString__toJSDOMURL(JSC::JSGlobalObject* lexica
 
     auto str = bunString->toWTFString(BunString::ZeroCopy);
 
-    auto object = WebCore::DOMURL::create(str, String());
-    auto jsValue = WebCore::toJSNewlyCreated<WebCore::IDLInterface<WebCore::DOMURL>>(*lexicalGlobalObject, globalObject, throwScope, WTF::move(object));
+    auto result = WebCore::DOMURL::create(str, String());
+    if (result.hasException()) [[unlikely]] {
+        WebCore::propagateException(*lexicalGlobalObject, throwScope, result.releaseException());
+        return {};
+    }
+    auto jsValue = WebCore::toJSNewlyCreated<WebCore::IDLInterface<WebCore::DOMURL>>(*lexicalGlobalObject, globalObject, result.releaseReturnValue());
     RETURN_IF_EXCEPTION(throwScope, {});
     auto* jsDOMURL = uncheckedDowncast<WebCore::JSDOMURL>(jsValue.asCell());
     vm.heap.reportExtraMemoryAllocated(jsDOMURL, jsDOMURL->wrapped().memoryCostForGC());

--- a/test/js/bun/http/server-url-invalid.test.ts
+++ b/test/js/bun/http/server-url-invalid.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from "bun:test";
-import { tempDir } from "harness";
+import { isWindows, tempDir } from "harness";
+import { join } from "path";
 
-test("server.url does not crash when unix socket path produces invalid URL", () => {
-  // Passing an object as the unix socket path causes the URL formatter to produce
-  // a string like "unix://[object Bun]" which is not a valid URL. Accessing
-  // server.url should throw a proper JS error instead of crashing.
+test.skipIf(isWindows)("server.url percent-encodes unix socket paths with special characters", () => {
+  // Passing an object as the unix socket path stringifies to "[object Bun]".
+  // The path is percent-encoded so server.url yields a valid URL rather than
+  // a crash or parse error.
   //
   // The socket path is relative, so run inside a fresh temp dir to avoid
   // EADDRINUSE from a stale socket file left in cwd by an earlier run.
@@ -19,8 +20,24 @@ test("server.url does not crash when unix socket path produces invalid URL", () 
         return new Response("ok");
       },
     });
-    expect(() => server.url).toThrow();
+    expect(server.url.href).toBe("unix://%5Bobject%20Bun%5D");
   } finally {
     process.chdir(prev);
   }
+});
+
+test.skipIf(isWindows)("server.url escapes special characters in unix socket paths so pathname round-trips", () => {
+  using dir = tempDir("unix-socket-special", {});
+  // "#" and "?" would otherwise truncate the URL (start of fragment/query),
+  // and a space must be encoded too. After escaping, decodeURIComponent of
+  // the pathname yields the original socket path.
+  const socketPath = join(String(dir), "a b#c?d");
+
+  using server = Bun.serve({
+    unix: socketPath,
+    fetch() {
+      return new Response("ok");
+    },
+  });
+  expect(decodeURIComponent(server.url.pathname)).toBe(socketPath);
 });


### PR DESCRIPTION
Follow-up to #28309. Two fixes:

**1. Percent-encode the socket path.** The URL formatter wrote the raw path after `unix://`, placing it in the authority position. That breaks for anything with brackets (reserved for IPv6), and paths with `#` or `?` get truncated. Encode using the same character set as `file://` URLs (WTF's `filePathEscapeTable`) so any path byte sequence produces a valid URL and `decodeURIComponent(url.pathname)` round-trips the original path:

```js
// before: crash (or throw after #28309)
Bun.serve({ unix: "/tmp/my socket", fetch: ... }).url.href
// after: "unix:///tmp/my%20socket"
```

The encoding matches `pathToFileURL()`:

```js
pathToFileURL("/tmp/a [#]?%\\\"^|~b").href
// file:///tmp/a%20%5B%23%5D%3F%25%5C%22%5E%7C%7Eb
Bun.serve({ unix: "/tmp/a [#]?%\\\"^|~b", fetch: ... }).url.href
// unix:///tmp/a%20%5B%23%5D%3F%25%5C%22%5E%7C%7Eb
```

**2. Check URL validity before wrapping in a JS object.** In `BunString__toJSDOMURL`, test `hasException()` on the `ExceptionOr` result of `DOMURL::create` before calling `toJSNewlyCreated`, so the error path skips the template/converter machinery.

---

**Verification (robobun, iteration 10):** Format ✅, Lint JS ✅ on commit c9b3ac08. Buildkite build #41390 in progress; prior build #40694 failures were all unrelated (webview.test.ts timeouts on macOS, bundler_compile.test.ts on Linux, Windows agent infra). Diff clean — no TODO/FIXME/HACK/XXX, 137 lines across 3 files. C++ change correctly checks `result.hasException()` before unwrapping `DOMURL::create`. Zig `needsEscape` covers C0, space, `"#%<>?[\\]^`|~`, DEL, ≥0x80, plus `/@:` in authority mode — verified superset of WTF filePathEscapeTable and WHATWG forbidden host code points. Test 1 asserts `unix://%5Bobject%20Bun%5D` (would crash/throw on main). Test 2 round-trips space-in-path via `decodeURIComponent` (would fail on main since raw space makes invalid URL). All 5 prior review issues resolved.