### PR TITLE
fix(node:http): make upgrade socket.write() actually send data

### DIFF
--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -764,6 +764,15 @@ public:
         return httpResponseData->isConnectRequest;
     }
 
+    /* Mark this response as a connect-like request so that subsequent data
+     * is forwarded as raw bytes instead of going through the HTTP parser.
+     * Used for HTTP upgrade (e.g. WebSocket) when the application takes
+     * ownership of the socket via the node:http upgrade event. */
+    void markAsConnectRequest() {
+        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        httpResponseData->isConnectRequest = true;
+    }
+
     void setWriteOffset(uint64_t offset) {
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 

--- a/src/bun.js/api/server.classes.ts
+++ b/src/bun.js/api/server.classes.ts
@@ -155,6 +155,10 @@ export default [
         fn: "doResume",
         length: 0,
       },
+      markAsUpgraded: {
+        fn: "markAsUpgraded",
+        length: 0,
+      },
       bufferedAmount: {
         getter: "getBufferedAmount",
       },

--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -618,6 +618,17 @@ pub fn doResume(this: *NodeHTTPResponse, globalObject: *jsc.JSGlobalObject, _: *
     return result;
 }
 
+pub fn markAsUpgraded(this: *NodeHTTPResponse, _: *jsc.JSGlobalObject, _: *jsc.CallFrame) jsc.JSValue {
+    log("markAsUpgraded", .{});
+    if (this.raw_response) |resp| {
+        // Mark the uWS response as a connect request so that subsequent data
+        // is forwarded as raw bytes instead of going through the HTTP parser.
+        // This enables bidirectional streaming after an HTTP upgrade.
+        resp.markAsConnectRequest();
+    }
+    return .js_undefined;
+}
+
 pub fn onRequestComplete(this: *NodeHTTPResponse) void {
     if (this.flags.request_has_completed) {
         return;

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1842,6 +1842,18 @@ __attribute__((callback (corker, ctx)))
       return uwsRes->isConnectRequest();
     }
   }
+
+  void uws_res_mark_as_connect_request(int ssl, uws_res_r res)
+  {
+    if (ssl) {
+      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+      uwsRes->markAsConnectRequest();
+    } else {
+      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
+      uwsRes->markAsConnectRequest();
+    }
+  }
+
   void *uws_res_get_native_handle(int ssl, uws_res_r res)
   {
     if (ssl)

--- a/src/deps/uws/Response.zig
+++ b/src/deps/uws/Response.zig
@@ -42,6 +42,10 @@ pub fn NewResponse(ssl_flag: i32) type {
             return c.uws_res_is_connect_request(ssl_flag, res.downcast());
         }
 
+        pub fn markAsConnectRequest(res: *Response) void {
+            c.uws_res_mark_as_connect_request(ssl_flag, res.downcast());
+        }
+
         pub fn flushHeaders(res: *Response, flushImmediately: bool) void {
             c.uws_res_flush_headers(ssl_flag, res.downcast(), flushImmediately);
         }
@@ -590,6 +594,12 @@ pub const AnyResponse = union(enum) {
         };
     }
 
+    pub fn markAsConnectRequest(this: AnyResponse) void {
+        switch (this) {
+            inline else => |resp| resp.markAsConnectRequest(),
+        }
+    }
+
     pub fn endStream(this: AnyResponse, close_connection: bool) void {
         switch (this) {
             inline else => |resp| resp.endStream(close_connection),
@@ -672,6 +682,7 @@ const c = struct {
     pub extern fn us_socket_mark_needs_more_not_ssl(socket: ?*c.uws_res) void;
     pub extern fn uws_res_state(ssl: c_int, res: *const c.uws_res) State;
     pub extern fn uws_res_is_connect_request(ssl: i32, res: *c.uws_res) bool;
+    pub extern fn uws_res_mark_as_connect_request(ssl: i32, res: *c.uws_res) void;
     pub extern fn uws_res_get_remote_address_info(res: *c.uws_res, dest: *[*]const u8, port: *i32, is_ipv6: *bool) usize;
     pub extern fn uws_res_uncork(ssl: i32, res: *c.uws_res) void;
     pub extern fn uws_res_end(ssl: i32, res: *c.uws_res, data: [*c]const u8, length: usize, close_connection: bool) void;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -606,15 +606,28 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           http_res.end();
           socket.destroy();
         } else if (is_upgrade) {
-          server.emit("upgrade", http_req, socket, kEmptyBuffer);
-          if (!socket._httpMessage) {
-            if (canUseInternalAssignSocket) {
-              // ~10% performance improvement in JavaScriptCore due to avoiding .once("close", ...) and removing a listener
-              assignSocketInternal(http_res, socket);
-            } else {
-              http_res.assignSocket(socket);
-            }
+          if (server.listenerCount("upgrade") > 0) {
+            // Mark the underlying uWS response as a connect-like request so that
+            // subsequent data is forwarded as raw bytes (not parsed as HTTP).
+            // This enables bidirectional streaming after the upgrade handshake.
+            handle.markAsUpgraded();
+            // Enable raw socket streaming so that socket.write() actually sends data
+            socket[kEnableStreaming](true);
+            const { promise, resolve } = $newPromiseCapability(Promise);
+            socket.once("close", resolve);
+            // Pass the pipelined data (head buffer) if any was received with the upgrade request
+            const head = connectHead ? connectHead : kEmptyBuffer;
+            server.emit("upgrade", http_req, socket, head);
+            return promise;
           }
+          // No upgrade listener — fall through to normal "request" event,
+          // matching Node.js behavior (treats it as a regular HTTP request).
+          if (canUseInternalAssignSocket) {
+            assignSocketInternal(http_res, socket);
+          } else {
+            http_res.assignSocket(socket);
+          }
+          server.emit("request", http_req, http_res);
         } else if (http_req.headers.expect !== undefined) {
           if (http_req.headers.expect === "100-continue") {
             if (server.listenerCount("checkContinue") > 0) {
@@ -838,9 +851,11 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
 
   get bytesWritten() {
     const handle = this[kHandle];
-    return handle
-      ? (handle.response?.getBytesWritten?.() ?? handle.bytesWritten ?? this[kBytesWritten] ?? 0)
-      : (this[kBytesWritten] ?? 0);
+    if (!handle) return this[kBytesWritten] ?? 0;
+    // Response tracks bytes from HTTP response writes (normal path),
+    // handle.bytesWritten tracks bytes from raw socket writes (upgrade/CONNECT streaming path).
+    // These are mutually exclusive write paths, so sum them.
+    return (handle.response?.getBytesWritten?.() ?? 0) + (handle.bytesWritten ?? 0);
   }
   set bytesWritten(value) {
     this[kBytesWritten] = value;
@@ -860,7 +875,7 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   }
   #onDrain() {
     const handle = this[kHandle];
-    this[kBytesWritten] = handle ? (handle.response?.getBytesWritten?.() ?? handle.bytesWritten ?? 0) : 0;
+    this[kBytesWritten] = handle ? (handle.response?.getBytesWritten?.() ?? 0) + (handle.bytesWritten ?? 0) : 0;
     const callback = this.#pendingCallback;
     if (callback) {
       this.#pendingCallback = null;

--- a/test/js/node/http/node-http-upgrade-socket.test.ts
+++ b/test/js/node/http/node-http-upgrade-socket.test.ts
@@ -1,0 +1,523 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
+
+const fixturesDir = path.join(import.meta.dir, "fixtures");
+
+describe("node:http server upgrade", () => {
+  test("socket.write() sends data to the client", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const http = require("node:http");
+        const net = require("node:net");
+        const crypto = require("node:crypto");
+
+        const server = http.createServer((_req, res) => {
+          res.writeHead(200);
+          res.end("OK");
+        });
+
+        server.on("upgrade", (req, socket, _head) => {
+          const key = req.headers["sec-websocket-key"];
+          const accept = crypto
+            .createHash("sha1")
+            .update(key + "258EAFA5-E914-47DA-95CA-5AB53ADF711E2")
+            .digest("base64");
+
+          const response = [
+            "HTTP/1.1 101 Switching Protocols",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            "Sec-WebSocket-Accept: " + accept,
+            "",
+            "",
+          ].join("\\r\\n");
+
+          socket.write(response);
+        });
+
+        server.listen(0, "127.0.0.1", () => {
+          const port = server.address().port;
+          const key = crypto.randomBytes(16).toString("base64");
+          const socket = net.createConnection(port, "127.0.0.1", () => {
+            socket.write(
+              "GET / HTTP/1.1\\r\\nHost: 127.0.0.1:" + port + "\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\nSec-WebSocket-Key: " + key + "\\r\\nSec-WebSocket-Version: 13\\r\\n\\r\\n"
+            );
+          });
+
+          let buf = "";
+          socket.on("data", (chunk) => {
+            buf += chunk.toString();
+            if (buf.includes("\\r\\n\\r\\n")) {
+              socket.destroy();
+              const status = buf.split("\\r\\n")[0];
+              if (status.includes("101")) {
+                console.log("PASS");
+              } else {
+                console.log("FAIL: " + status);
+              }
+              server.close();
+            }
+          });
+          socket.on("error", (err) => {
+            console.log("FAIL: " + err.message);
+            server.close();
+          });
+          socket.setTimeout(3000, () => {
+            socket.destroy();
+            console.log("FAIL: timeout");
+            server.close();
+          });
+        });
+      `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim()).toBe("PASS");
+    expect(exitCode).toBe(0);
+  });
+
+  test("socket.bytesWritten reflects actual bytes sent", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const http = require("node:http");
+        const net = require("node:net");
+        const crypto = require("node:crypto");
+
+        const server = http.createServer((_req, res) => {
+          res.writeHead(200);
+          res.end("OK");
+        });
+
+        server.on("upgrade", (req, socket, _head) => {
+          const key = req.headers["sec-websocket-key"];
+          const accept = crypto
+            .createHash("sha1")
+            .update(key + "258EAFA5-E914-47DA-95CA-5AB53ADF711E2")
+            .digest("base64");
+
+          const response = [
+            "HTTP/1.1 101 Switching Protocols",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            "Sec-WebSocket-Accept: " + accept,
+            "",
+            "",
+          ].join("\\r\\n");
+
+          socket.write(response, () => {
+            console.log("bytesWritten:" + socket.bytesWritten);
+            socket.destroy();
+            server.close();
+          });
+        });
+
+        server.listen(0, "127.0.0.1", () => {
+          const port = server.address().port;
+          const key = crypto.randomBytes(16).toString("base64");
+          const socket = net.createConnection(port, "127.0.0.1", () => {
+            socket.write(
+              "GET / HTTP/1.1\\r\\nHost: 127.0.0.1:" + port + "\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\nSec-WebSocket-Key: " + key + "\\r\\nSec-WebSocket-Version: 13\\r\\n\\r\\n"
+            );
+          });
+          socket.setTimeout(3000, () => {
+            socket.destroy();
+            console.log("FAIL: timeout");
+            server.close();
+          });
+        });
+      `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const match = stdout.match(/bytesWritten:(\d+)/);
+    expect(match).not.toBeNull();
+    expect(Number(match![1])).toBeGreaterThan(0);
+    expect(exitCode).toBe(0);
+  });
+
+  test("bidirectional communication after upgrade", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const http = require("node:http");
+        const net = require("node:net");
+        const crypto = require("node:crypto");
+
+        const server = http.createServer((_req, res) => {
+          res.writeHead(200);
+          res.end("OK");
+        });
+
+        server.on("upgrade", (req, socket, _head) => {
+          const key = req.headers["sec-websocket-key"];
+          const accept = crypto
+            .createHash("sha1")
+            .update(key + "258EAFA5-E914-47DA-95CA-5AB53ADF711E2")
+            .digest("base64");
+
+          const response = [
+            "HTTP/1.1 101 Switching Protocols",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            "Sec-WebSocket-Accept: " + accept,
+            "",
+            "",
+          ].join("\\r\\n");
+
+          socket.write(response);
+
+          // Echo data back after upgrade
+          socket.on("data", (chunk) => {
+            socket.write(chunk);
+          });
+          socket.on("end", () => {
+            socket.end();
+          });
+        });
+
+        server.listen(0, "127.0.0.1", () => {
+          const port = server.address().port;
+          const key = crypto.randomBytes(16).toString("base64");
+          const client = net.createConnection(port, "127.0.0.1", () => {
+            client.write(
+              "GET / HTTP/1.1\\r\\nHost: 127.0.0.1:" + port + "\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\nSec-WebSocket-Key: " + key + "\\r\\nSec-WebSocket-Version: 13\\r\\n\\r\\n"
+            );
+          });
+
+          let phase = "handshake";
+          let buf = "";
+          client.on("data", (chunk) => {
+            buf += chunk.toString();
+            if (phase === "handshake" && buf.includes("\\r\\n\\r\\n")) {
+              const status = buf.split("\\r\\n")[0];
+              if (!status.includes("101")) {
+                console.log("FAIL: handshake " + status);
+                client.destroy();
+                server.close();
+                return;
+              }
+              phase = "echo";
+              buf = "";
+              // Send raw data after upgrade handshake
+              client.write("hello from client");
+            } else if (phase === "echo") {
+              if (buf === "hello from client") {
+                console.log("PASS");
+                client.destroy();
+                server.close();
+              }
+            }
+          });
+          client.on("error", (err) => {
+            console.log("FAIL: " + err.message);
+            server.close();
+          });
+          client.setTimeout(3000, () => {
+            client.destroy();
+            console.log("FAIL: timeout in phase " + phase);
+            server.close();
+          });
+        });
+      `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim()).toBe("PASS");
+    expect(exitCode).toBe(0);
+  });
+
+  test("upgrade request with no listeners falls through to request event", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const http = require("node:http");
+        const net = require("node:net");
+        const crypto = require("node:crypto");
+
+        const server = http.createServer((_req, res) => {
+          // No upgrade listener — this should fire for upgrade requests too
+          console.log("request-event");
+          res.writeHead(200);
+          res.end("OK");
+        });
+        // Intentionally NO server.on("upgrade", ...) listener
+
+        server.listen(0, "127.0.0.1", () => {
+          const port = server.address().port;
+          const key = crypto.randomBytes(16).toString("base64");
+          const socket = net.createConnection(port, "127.0.0.1", () => {
+            socket.write(
+              "GET / HTTP/1.1\\r\\nHost: 127.0.0.1:" + port + "\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\nSec-WebSocket-Key: " + key + "\\r\\nSec-WebSocket-Version: 13\\r\\n\\r\\n"
+            );
+          });
+
+          let buf = "";
+          socket.on("data", (chunk) => {
+            buf += chunk.toString();
+            if (buf.includes("\\r\\n\\r\\n")) {
+              socket.destroy();
+              const status = buf.split("\\r\\n")[0];
+              // Node.js responds with 200 OK when there are no upgrade listeners
+              console.log("status:" + status);
+              server.close();
+            }
+          });
+          socket.on("error", (err) => {
+            console.log("FAIL: " + err.message);
+            server.close();
+          });
+          socket.setTimeout(3000, () => {
+            socket.destroy();
+            console.log("FAIL: timeout");
+            server.close();
+          });
+        });
+      `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const lines = stdout.trim().split("\n");
+    expect(lines).toContain("request-event");
+    expect(lines.find(l => l.startsWith("status:"))).toBe("status:HTTP/1.1 200 OK");
+    expect(exitCode).toBe(0);
+  });
+
+  test("upgrade works over HTTPS/TLS", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const https = require("node:https");
+        const tls = require("node:tls");
+        const crypto = require("node:crypto");
+        const fs = require("node:fs");
+
+        const certDir = ${JSON.stringify(fixturesDir)};
+        const key = fs.readFileSync(certDir + "/cert.key", "utf8");
+        const cert = fs.readFileSync(certDir + "/cert.pem", "utf8");
+
+        const server = https.createServer({ key, cert }, (_req, res) => {
+          res.writeHead(200);
+          res.end("OK");
+        });
+
+        server.on("upgrade", (req, socket, _head) => {
+          const key = req.headers["sec-websocket-key"];
+          const accept = crypto
+            .createHash("sha1")
+            .update(key + "258EAFA5-E914-47DA-95CA-5AB53ADF711E2")
+            .digest("base64");
+
+          const response = [
+            "HTTP/1.1 101 Switching Protocols",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            "Sec-WebSocket-Accept: " + accept,
+            "",
+            "",
+          ].join("\\r\\n");
+
+          socket.write(response);
+
+          // Echo data back
+          socket.on("data", (chunk) => {
+            socket.write(chunk);
+          });
+        });
+
+        server.listen(0, "127.0.0.1", () => {
+          const port = server.address().port;
+          const key = crypto.randomBytes(16).toString("base64");
+          const client = tls.connect(port, "127.0.0.1", { rejectUnauthorized: false }, () => {
+            client.write(
+              "GET / HTTP/1.1\\r\\nHost: 127.0.0.1:" + port + "\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\nSec-WebSocket-Key: " + key + "\\r\\nSec-WebSocket-Version: 13\\r\\n\\r\\n"
+            );
+          });
+
+          let phase = "handshake";
+          let buf = "";
+          client.on("data", (chunk) => {
+            buf += chunk.toString();
+            if (phase === "handshake" && buf.includes("\\r\\n\\r\\n")) {
+              const status = buf.split("\\r\\n")[0];
+              if (!status.includes("101")) {
+                console.log("FAIL: handshake " + status);
+                client.destroy();
+                server.close();
+                return;
+              }
+              phase = "echo";
+              buf = "";
+              client.write("tls echo test");
+            } else if (phase === "echo") {
+              if (buf === "tls echo test") {
+                console.log("PASS");
+                client.destroy();
+                server.close();
+              }
+            }
+          });
+          client.on("error", (err) => {
+            console.log("FAIL: " + err.message);
+            server.close();
+          });
+          client.setTimeout(3000, () => {
+            client.destroy();
+            console.log("FAIL: timeout in phase " + phase);
+            server.close();
+          });
+        });
+      `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim()).toBe("PASS");
+    expect(exitCode).toBe(0);
+  });
+
+  test("socket.pipe() works for proxying after upgrade", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const http = require("node:http");
+        const net = require("node:net");
+        const crypto = require("node:crypto");
+
+        // Upstream server: accepts raw TCP, echoes back with a prefix
+        const upstream = net.createServer((conn) => {
+          conn.on("data", (chunk) => {
+            conn.write("echo:" + chunk.toString());
+          });
+        });
+
+        // Proxy server: upgrades HTTP, then pipes to upstream
+        const proxy = http.createServer((_req, res) => {
+          res.writeHead(200);
+          res.end("OK");
+        });
+
+        proxy.on("upgrade", (req, clientSocket, _head) => {
+          const key = req.headers["sec-websocket-key"];
+          const accept = crypto
+            .createHash("sha1")
+            .update(key + "258EAFA5-E914-47DA-95CA-5AB53ADF711E2")
+            .digest("base64");
+
+          const response = [
+            "HTTP/1.1 101 Switching Protocols",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            "Sec-WebSocket-Accept: " + accept,
+            "",
+            "",
+          ].join("\\r\\n");
+
+          clientSocket.write(response);
+
+          // Connect to upstream and pipe bidirectionally
+          const upstreamPort = upstream.address().port;
+          const upstreamConn = net.createConnection(upstreamPort, "127.0.0.1", () => {
+            clientSocket.pipe(upstreamConn);
+            upstreamConn.pipe(clientSocket);
+          });
+
+          clientSocket.on("error", () => upstreamConn.destroy());
+          upstreamConn.on("error", () => clientSocket.destroy());
+          clientSocket.on("close", () => upstreamConn.destroy());
+          upstreamConn.on("close", () => clientSocket.destroy());
+        });
+
+        upstream.listen(0, "127.0.0.1", () => {
+          proxy.listen(0, "127.0.0.1", () => {
+            const port = proxy.address().port;
+            const key = crypto.randomBytes(16).toString("base64");
+            const client = net.createConnection(port, "127.0.0.1", () => {
+              client.write(
+                "GET / HTTP/1.1\\r\\nHost: 127.0.0.1:" + port + "\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\nSec-WebSocket-Key: " + key + "\\r\\nSec-WebSocket-Version: 13\\r\\n\\r\\n"
+              );
+            });
+
+            let phase = "handshake";
+            let buf = "";
+            client.on("data", (chunk) => {
+              buf += chunk.toString();
+              if (phase === "handshake" && buf.includes("\\r\\n\\r\\n")) {
+                const status = buf.split("\\r\\n")[0];
+                if (!status.includes("101")) {
+                  console.log("FAIL: handshake " + status);
+                  client.destroy();
+                  proxy.close();
+                  upstream.close();
+                  return;
+                }
+                phase = "proxy";
+                buf = "";
+                client.write("proxy test");
+              } else if (phase === "proxy") {
+                if (buf === "echo:proxy test") {
+                  console.log("PASS");
+                  client.destroy();
+                  proxy.close();
+                  upstream.close();
+                }
+              }
+            });
+            client.on("error", (err) => {
+              console.log("FAIL: " + err.message);
+              proxy.close();
+              upstream.close();
+            });
+            client.setTimeout(3000, () => {
+              client.destroy();
+              console.log("FAIL: timeout in phase " + phase);
+              proxy.close();
+              upstream.close();
+            });
+          });
+        });
+      `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim()).toBe("PASS");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/http/node-http-upgrade-socket.test.ts
+++ b/test/js/node/http/node-http-upgrade-socket.test.ts
@@ -24,7 +24,7 @@ describe("node:http server upgrade", () => {
           const key = req.headers["sec-websocket-key"];
           const accept = crypto
             .createHash("sha1")
-            .update(key + "258EAFA5-E914-47DA-95CA-5AB53ADF711E2")
+            .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
             .digest("base64");
 
           const response = [
@@ -103,7 +103,7 @@ describe("node:http server upgrade", () => {
           const key = req.headers["sec-websocket-key"];
           const accept = crypto
             .createHash("sha1")
-            .update(key + "258EAFA5-E914-47DA-95CA-5AB53ADF711E2")
+            .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
             .digest("base64");
 
           const response = [
@@ -172,7 +172,7 @@ describe("node:http server upgrade", () => {
           const key = req.headers["sec-websocket-key"];
           const accept = crypto
             .createHash("sha1")
-            .update(key + "258EAFA5-E914-47DA-95CA-5AB53ADF711E2")
+            .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
             .digest("base64");
 
           const response = [
@@ -337,7 +337,7 @@ describe("node:http server upgrade", () => {
           const key = req.headers["sec-websocket-key"];
           const accept = crypto
             .createHash("sha1")
-            .update(key + "258EAFA5-E914-47DA-95CA-5AB53ADF711E2")
+            .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
             .digest("base64");
 
           const response = [
@@ -438,7 +438,7 @@ describe("node:http server upgrade", () => {
           const key = req.headers["sec-websocket-key"];
           const accept = crypto
             .createHash("sha1")
-            .update(key + "258EAFA5-E914-47DA-95CA-5AB53ADF711E2")
+            .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
             .digest("base64");
 
           const response = [

--- a/test/js/node/http/node-http-upgrade-socket.test.ts
+++ b/test/js/node/http/node-http-upgrade-socket.test.ts
@@ -145,9 +145,11 @@ describe("node:http server upgrade", () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const actual = Number(stdout.match(/bytesWritten:(\d+)/)?.[1]);
-    const expected = Number(stdout.match(/expected:(\d+)/)?.[1]);
-    expect(actual).toBe(expected);
+    const actualMatch = stdout.match(/bytesWritten:(\d+)/);
+    const expectedMatch = stdout.match(/expected:(\d+)/);
+    expect(actualMatch).not.toBeNull();
+    expect(expectedMatch).not.toBeNull();
+    expect(Number(actualMatch![1])).toBe(Number(expectedMatch![1]));
     expect(exitCode).toBe(0);
   });
 
@@ -305,6 +307,7 @@ describe("node:http server upgrade", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     const lines = stdout.trim().split("\n");
+    expect(lines.find(l => l.startsWith("FAIL:"))).toBeUndefined();
     expect(lines).toContain("request-event");
     expect(lines.find(l => l.startsWith("status:"))).toBe("status:HTTP/1.1 200 OK");
     expect(exitCode).toBe(0);

--- a/test/js/node/http/node-http-upgrade-socket.test.ts
+++ b/test/js/node/http/node-http-upgrade-socket.test.ts
@@ -117,6 +117,7 @@ describe("node:http server upgrade", () => {
 
           socket.write(response, () => {
             console.log("bytesWritten:" + socket.bytesWritten);
+            console.log("expected:" + Buffer.byteLength(response));
             socket.destroy();
             server.close();
           });
@@ -144,9 +145,9 @@ describe("node:http server upgrade", () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const match = stdout.match(/bytesWritten:(\d+)/);
-    expect(match).not.toBeNull();
-    expect(Number(match![1])).toBeGreaterThan(0);
+    const actual = Number(stdout.match(/bytesWritten:(\d+)/)?.[1]);
+    const expected = Number(stdout.match(/expected:(\d+)/)?.[1]);
+    expect(actual).toBe(expected);
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
## Summary

- **`socket.write()` was a silent no-op** on upgrade sockets — the `_write()` method checked `handle.ondrain` before calling `handle.write()`, but streaming was never enabled for upgrades, so writes were silently dropped. The client never received the HTTP 101 handshake.
- **No bidirectional streaming** after upgrade — the uWS HTTP parser continued treating incoming data as HTTP. Added `markAsConnectRequest()` to tell uWS to forward raw bytes via `onSocketData`, matching CONNECT behavior.
- **`bytesWritten` always returned 0** — the getter used `??` (nullish coalescing) which returned `0` from `response.getBytesWritten()` instead of falling through to the raw socket counter. Fixed to sum both write paths.
- **No-listener fallback** — upgrade requests with no `"upgrade"` listeners now fall through to the `"request"` event, matching Node.js behavior.

This broke every WebSocket proxy library in the Node ecosystem (`ws`, `http-proxy`, `node-http-proxy`, `vite`, `express-ws`, etc.) that relies on writing the 101 response to the upgrade socket and then piping bidirectionally.

Fixes #9882, fixes #18945, fixes #10441, fixes #14522, fixes #15489, fixes #16819

## Test plan

- [x] `socket.write()` sends data to the client (101 handshake received)
- [x] `socket.bytesWritten` reflects actual bytes sent (> 0)
- [x] Bidirectional communication after upgrade (echo test)
- [x] Upgrade request with no listeners falls through to `"request"` event (200 OK)
- [x] Upgrade works over HTTPS/TLS (echo test with self-signed cert)
- [x] `socket.pipe()` works for proxying after upgrade (proxy → upstream echo)
- [x] All 6 tests fail on system Bun (1.2.18), all 6 pass with fix
- [x] No regressions: `node-http-with-ws`, `node-http-parser`, `node-http-backpressure` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)