### PR TITLE
Fix WebView type declarations for screenshot() and asyncDispose()

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8665,8 +8665,6 @@ declare module "bun" {
 
     /** Alias for {@link close}. Enables `using view = new Bun.WebView(...)`. */
     [Symbol.dispose](): void;
-    /** Alias for {@link close}. Enables `await using view = new Bun.WebView(...)`. */
-    [Symbol.asyncDispose](): void;
   }
 
   /**

--- a/src/bun.js/webview/JSWebViewPrototype.cpp
+++ b/src/bun.js/webview/JSWebViewPrototype.cpp
@@ -102,12 +102,9 @@ private:
         JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 
         // close() is synchronous: writes the Close frame, rejects any pending
-        // promises, erases from the routing table. `using` calls dispose;
-        // `await using` calls asyncDispose if present (else dispose). Both
-        // point to close — no async teardown to wait for.
+        // promises, erases from the routing table. No async teardown to wait for.
         auto* closeFn = JSFunction::create(vm, globalObject, 0, "close"_s, jsWebViewProtoFuncClose, ImplementationVisibility::Public);
         putDirect(vm, vm.propertyNames->disposeSymbol, closeFn, PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum | 0);
-        putDirect(vm, vm.propertyNames->asyncDisposeSymbol, closeFn, PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum | 0);
     }
 };
 

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -228,20 +228,13 @@ it("scroll(NaN/Infinity) throws before sending", () => {
   expect(() => view.scroll(0, 0 / 0)).toThrow(/must be finite/);
 });
 
-it("Symbol.dispose / Symbol.asyncDispose call close()", async () => {
-  // Both symbols point to the same JSFunction (close). close() is
-  // synchronous — writes the Close frame, rejects pending promises,
-  // erases from the routing table. No async teardown to await.
+it("Symbol.dispose calls close()", async () => {
+  // Symbol.dispose points to close(). close() is synchronous — writes
+  // the Close frame, rejects pending promises, erases from the routing
+  // table. No async teardown to await.
   {
     using view = new Bun.WebView({ width: 100, height: 100 });
-    expect(view[Symbol.dispose]).toBe(view[Symbol.asyncDispose]);
     expect(typeof view[Symbol.dispose]).toBe("function");
-  }
-  // `await using` prefers asyncDispose.
-  {
-    await using view = new Bun.WebView({ width: 100, height: 100 });
-    await view.navigate(html("<body></body>"));
-    expect(await view.evaluate("1+1")).toBe(2);
   }
   // And it's close() — idempotent, second close no-ops.
   const view = new Bun.WebView({ width: 100, height: 100 });


### PR DESCRIPTION
Followup to #28185 addressing @alii's review of the WebView dispose semantics.

`close()` is genuinely synchronous: it sets `m_closed`, rejects all pending promise slots (`navigate`/`evaluate`/`screenshot`/`misc`) with `Error("WebView closed")` via `settleSlot`, writes a fire-and-forget Close frame to the IPC socket (WebKit) or sends `Target.closeTarget` (Chrome), erases the view from the routing table, and updates the keep-alive ref. The subprocess-side teardown (releasing the WKWebView/NSWindow, or Chrome closing the tab) happens asynchronously in the host process, but no confirmation is awaited and no failure can propagate back to JS — late-arriving replies are discarded because the routing table is already cleared.

Since there is no async work to await, the `asyncDisposeSymbol` registration on the prototype was redundant. `await using` falls back to `Symbol.dispose` when `asyncDispose` is absent, so both `using` and `await using` still work.

### Changes
- Removed `asyncDisposeSymbol` registration from `JSWebViewPrototype.cpp`
- Removed `[Symbol.asyncDispose](): void` from the `WebView` type declaration
- Updated the dispose test to reflect that only `Symbol.dispose` is on the prototype

### Rebase notes
Rebased over #28185's `screenshot()` API redesign (now multiple overloads for `blob`/`buffer`/`base64`/`shmem` encodings). The original `screenshot()` type-fix hunk is dropped since it's been superseded.