### PR TITLE
Fix crash in FFI closeCallback when called with non-number argument

### DIFF
--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -831,7 +831,14 @@ pub const FFI = struct {
     }
 
     pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) JSValue {
-        var function: *Function = @ptrFromInt(ctx.asPtrAddress());
+        if (!ctx.isNumber()) {
+            return globalThis.toInvalidArguments("Expected a number", .{});
+        }
+        const addr = ctx.asPtrAddress();
+        if (addr == 0) {
+            return globalThis.toInvalidArguments("Expected a non-zero pointer", .{});
+        }
+        var function: *Function = @ptrFromInt(addr);
         function.deinit(globalThis);
         return .js_undefined;
     }

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -831,13 +831,14 @@ pub const FFI = struct {
     }
 
     pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) JSValue {
-        if (!ctx.isNumber()) {
+        if (!ctx.isFinite()) {
             return globalThis.toInvalidArguments("Expected a number", .{});
         }
-        const addr = ctx.asPtrAddress();
-        if (addr == 0) {
+        const num = ctx.asNumber();
+        if (num < 1 or num != @trunc(num)) {
             return globalThis.toInvalidArguments("Expected a non-zero pointer", .{});
         }
+        const addr: usize = @intFromFloat(num);
         var function: *Function = @ptrFromInt(addr);
         function.deinit(globalThis);
         return .js_undefined;

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -835,7 +835,7 @@ pub const FFI = struct {
             return globalThis.toInvalidArguments("Expected a number", .{});
         }
         const num = ctx.asNumber();
-        if (num < 1 or num != @trunc(num)) {
+        if (num < 1 or num != @trunc(num) or num > @as(f64, @floatFromInt(std.math.maxInt(usize)))) {
             return globalThis.toInvalidArguments("Expected a non-zero pointer", .{});
         }
         const addr: usize = @intFromFloat(num);

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -835,7 +835,7 @@ pub const FFI = struct {
             return globalThis.toInvalidArguments("Expected a number", .{});
         }
         const num = ctx.asNumber();
-        if (num < 1 or num != @trunc(num) or num > @as(f64, @floatFromInt(std.math.maxInt(usize)))) {
+        if (num < 1 or num != @trunc(num) or num >= @as(f64, @floatFromInt(std.math.maxInt(usize)))) {
             return globalThis.toInvalidArguments("Expected a non-zero pointer", .{});
         }
         const addr: usize = @intFromFloat(num);

--- a/test/js/bun/ffi/ffi-closeCallback.test.ts
+++ b/test/js/bun/ffi/ffi-closeCallback.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("FFI closeCallback does not crash with invalid arguments", () => {
   const ffi = Bun.FFI;

--- a/test/js/bun/ffi/ffi-closeCallback.test.ts
+++ b/test/js/bun/ffi/ffi-closeCallback.test.ts
@@ -14,5 +14,6 @@ test("FFI closeCallback does not crash with invalid arguments", () => {
   expect(() => ffi.closeCallback(-1)).toThrow("Expected a non-zero pointer");
   expect(() => ffi.closeCallback(1.5)).toThrow("Expected a non-zero pointer");
   expect(() => ffi.closeCallback(1e20)).toThrow("Expected a non-zero pointer");
+  expect(() => ffi.closeCallback(2 ** 64)).toThrow("Expected a non-zero pointer");
   expect(() => ffi.closeCallback(Number.MAX_VALUE)).toThrow("Expected a non-zero pointer");
 });

--- a/test/js/bun/ffi/ffi-closeCallback.test.ts
+++ b/test/js/bun/ffi/ffi-closeCallback.test.ts
@@ -7,5 +7,10 @@ test("FFI closeCallback does not crash with invalid arguments", () => {
   expect(() => ffi.closeCallback({})).toThrow("Expected a number");
   expect(() => ffi.closeCallback("str")).toThrow("Expected a number");
   expect(() => ffi.closeCallback(new Float64Array(1))).toThrow("Expected a number");
+  expect(() => ffi.closeCallback(NaN)).toThrow("Expected a number");
+  expect(() => ffi.closeCallback(Infinity)).toThrow("Expected a number");
+  expect(() => ffi.closeCallback(-Infinity)).toThrow("Expected a number");
   expect(() => ffi.closeCallback(0)).toThrow("Expected a non-zero pointer");
+  expect(() => ffi.closeCallback(-1)).toThrow("Expected a non-zero pointer");
+  expect(() => ffi.closeCallback(1.5)).toThrow("Expected a non-zero pointer");
 });

--- a/test/js/bun/ffi/ffi-closeCallback.test.ts
+++ b/test/js/bun/ffi/ffi-closeCallback.test.ts
@@ -13,4 +13,6 @@ test("FFI closeCallback does not crash with invalid arguments", () => {
   expect(() => ffi.closeCallback(0)).toThrow("Expected a non-zero pointer");
   expect(() => ffi.closeCallback(-1)).toThrow("Expected a non-zero pointer");
   expect(() => ffi.closeCallback(1.5)).toThrow("Expected a non-zero pointer");
+  expect(() => ffi.closeCallback(1e20)).toThrow("Expected a non-zero pointer");
+  expect(() => ffi.closeCallback(Number.MAX_VALUE)).toThrow("Expected a non-zero pointer");
 });

--- a/test/js/bun/ffi/ffi-closeCallback.test.ts
+++ b/test/js/bun/ffi/ffi-closeCallback.test.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "bun:test";
+
+test("FFI closeCallback does not crash with invalid arguments", () => {
+  const ffi = Bun.FFI;
+  // closeCallback is an internal function that expects a numeric pointer.
+  // Calling it with non-number arguments should not crash the process.
+  expect(() => ffi.closeCallback({})).toThrow("Expected a number");
+  expect(() => ffi.closeCallback("str")).toThrow("Expected a number");
+  expect(() => ffi.closeCallback(new Float64Array(1))).toThrow("Expected a number");
+  expect(() => ffi.closeCallback(0)).toThrow("Expected a non-zero pointer");
+});


### PR DESCRIPTION
closeCallback expects a numeric JSValue encoding a pointer address, but did not validate the argument type before calling `asPtrAddress()`. When called with a non-number value (e.g. an object or typed array), `asNumber()` hit an assertion failure (debug) or segfault (release).

This adds type validation to reject non-number and zero-pointer arguments with an error instead of crashing.

The function is normally hidden from user code (`delete ffi.closeCallback` in the JS module), but it's accessible via the raw `Bun.FFI` native object before the module is loaded.

---

Verification (robobun): CI build #40589 pending (previous build #40553 was canceled; its only failures were bundler_compile.test.ts timeouts, completely unrelated to FFI). Diff touches exactly two files: ffi.zig adds input validation, new test file exercises all invalid-argument paths. Validation chain is correct: isFinite() rejects non-numbers/NaN/±Infinity, then num<1 rejects zero/negatives, num!=@trunc(num) rejects non-integer floats, num>maxInt(usize) rejects overflow — all before @intFromFloat. Test covers 11 cases (object, string, typed array, NaN, Infinity, -Infinity, 0, -1, 1.5, 1e20, MAX_VALUE) that would crash on main via @intFromFloat UB or null-pointer deref. All 4 Claude review threads addressed in 2d286cb (isFinite, non-integer truncation, upper-bound overflow); memory leak note is pre-existing. No TODO/FIXME/HACK in diff.