### PR TITLE
Fix crash in FFI linkSymbols when property values are not objects

### DIFF
--- a/docs/runtime/cron.mdx
+++ b/docs/runtime/cron.mdx
@@ -270,7 +270,12 @@ On headless servers and CI environments where the current user's [Security Ident
 #### Trigger limit
 
 <Warning>
-Windows Task Scheduler enforces a limit of [48 triggers per task](https://learn.microsoft.com/en-us/windows/win32/taskschd/taskschedulerschema-triggers-tasktype-element) (the `CalendarTrigger` element has [`maxOccurs="48"`](https://learn.microsoft.com/en-us/windows/win32/taskschd/taskschedulerschema-calendartrigger-triggergroup-element)). Some cron expressions that work on Linux and macOS exceed this limit on Windows. When a pattern exceeds the limit, `Bun.cron()` rejects it with an error message.
+  Windows Task Scheduler enforces a limit of [48 triggers per
+  task](https://learn.microsoft.com/en-us/windows/win32/taskschd/taskschedulerschema-triggers-tasktype-element) (the
+  `CalendarTrigger` element has
+  [`maxOccurs="48"`](https://learn.microsoft.com/en-us/windows/win32/taskschd/taskschedulerschema-calendartrigger-triggergroup-element)).
+  Some cron expressions that work on Linux and macOS exceed this limit on Windows. When a pattern exceeds the limit,
+  `Bun.cron()` rejects it with an error message.
 </Warning>
 
 **Expressions that work on all platforms:**
@@ -313,7 +318,8 @@ await Bun.cron("./job.ts", "*/5 * * * *", "my-job");
 #### Windows containers
 
 <Warning>
-`Bun.cron()` is not supported in Windows Docker containers. The Task Scheduler service is not running in `servercore` or `nanoserver` images. Use an in-process scheduler for containerized workloads.
+  `Bun.cron()` is not supported in Windows Docker containers. The Task Scheduler service is not running in `servercore`
+  or `nanoserver` images. Use an in-process scheduler for containerized workloads.
 </Warning>
 
 **Viewing registered jobs:**

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -1411,7 +1411,7 @@ pub const FFI = struct {
         while (try symbols_iter.next()) |prop| {
             const value = symbols_iter.value;
 
-            if (value.isEmptyOrUndefinedOrNull()) {
+            if (value.isEmptyOrUndefinedOrNull() or !value.isObject()) {
                 return global.toTypeError(.INVALID_ARG_VALUE, "Expected an object for key \"{f}\"", .{prop});
             }
 

--- a/test/js/bun/ffi/ffi-error-messages.test.ts
+++ b/test/js/bun/ffi/ffi-error-messages.test.ts
@@ -66,6 +66,16 @@ describe.skipIf(isFFIUnavailable)("FFI error messages", () => {
     }).toThrow(/myFunction.*ptr.*(linkSymbols|CFunction)/);
   });
 
+  test("linkSymbols with non-object property values throws TypeError", () => {
+    expect(() => {
+      linkSymbols({ foo: 42 });
+    }).toThrow("Expected an object");
+
+    expect(() => {
+      linkSymbols({ a: "hello", b: 123, c: true });
+    }).toThrow("Expected an object");
+  });
+
   test("linkSymbols with non-number ptr does not crash", () => {
     expect(() => {
       linkSymbols({


### PR DESCRIPTION
## Summary

`Bun.FFI.linkSymbols()` crashes when the input object has non-object property values (numbers, strings, booleans).

## Root Cause

`generateSymbols` iterates over all properties of the input object and passes each value to `generateSymbolForFunction`, which calls `.get()` / `.getTruthy()` on the value. These methods assert that the target is a JS object via `debugAssert(target.isObject())`.

The existing validation only checked `isEmptyOrUndefinedOrNull()`, which doesn't catch primitive values like numbers, strings, or booleans. When such a value reaches `generateSymbolForFunction`, the assertion fails.

## Fix

Add `!value.isObject()` to the existing validation check in `generateSymbols` to reject non-object property values early with a proper TypeError.

## Repro

```js
Bun.FFI.linkSymbols({ foo: 42 });
// Before: panic - reached unreachable code  
// After: TypeError: Expected an object for key "foo"
```