### PR TITLE
Validate argument in FFI.closeCallback before using as pointer

### DIFF
--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -830,8 +830,11 @@ pub const FFI = struct {
         return js_object;
     }
 
-    pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) JSValue {
-        var function: *Function = @ptrFromInt(ctx.asPtrAddress());
+    pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) bun.JSError!JSValue {
+        if (!ctx.isNumber()) return globalThis.throwInvalidArguments("Expected a pointer", .{});
+        const addr = ctx.asPtrAddress();
+        if (addr == 0) return globalThis.throwInvalidArguments("Expected a non-null pointer", .{});
+        var function: *Function = @ptrFromInt(addr);
         function.deinit(globalThis);
         return .js_undefined;
     }

--- a/test/js/bun/ffi/ffi-closeCallback.test.ts
+++ b/test/js/bun/ffi/ffi-closeCallback.test.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "bun:test";
+
+test("FFI.closeCallback does not crash with invalid arguments", () => {
+  const ffi = Bun.FFI;
+  // closeCallback expects a numeric pointer argument;
+  // calling with non-numeric values should throw, not crash.
+  expect(() => ffi.closeCallback("not a pointer")).toThrow();
+  expect(() => ffi.closeCallback(undefined)).toThrow();
+  expect(() => ffi.closeCallback(null)).toThrow();
+  expect(() => ffi.closeCallback(9n)).toThrow();
+});


### PR DESCRIPTION
FFI.closeCallback assumed its argument was always a numeric pointer value encoded as a double. When called directly with a non-numeric argument (e.g. a string or bigint), `asNumber()` would hit an assertion/unreachable, causing a crash.

This adds a type check on the `ctx` parameter to throw a proper TypeError instead of crashing.

**Root cause:** `closeCallback` is an internal function meant to be called only from `JSCallback.close()` in `ffi.ts`, which always passes the numeric pointer context. However, it is briefly visible on the `Bun.FFI` object before the JS module captures and deletes it, so it can be called directly with arbitrary arguments.

**Fix:** Check `ctx.isNumber()` and that the address is non-zero before casting to a pointer. Return a TypeError on invalid input.

---
Verification: CI lint passes, buildkite still running (unrelated to this 4-line Zig change + test). Diff is minimal and clean — no TODO/FIXME/HACK. The fix adds `isNumber()` and null-address guards before the unsafe `asPtrAddress()` cast, with return type changed to `bun.JSError!JSValue` (consistent with sibling methods using `wrapStaticMethod`). Regression test covers string, undefined, null, and bigint inputs that would crash via `asNumber()` assertion on main but now throw properly. No bot reviews or unresolved threads.