### PR TITLE
Fix crash in FFI.viewSource when symbol descriptor values are not objects

### DIFF
--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -960,6 +960,9 @@ pub const FFI = struct {
             for (symbols.keys()) |key| {
                 allocator.free(@constCast(key));
             }
+            for (symbols.values()) |*function_| {
+                function_.arg_types.deinit(allocator);
+            }
             symbols.clearAndFree(allocator);
             return val;
         }
@@ -1051,6 +1054,9 @@ pub const FFI = struct {
             // an error while validating symbols
             for (symbols.keys()) |key| {
                 bun.default_allocator.free(@constCast(key));
+            }
+            for (symbols.values()) |*function_| {
+                function_.arg_types.deinit(bun.default_allocator);
             }
             symbols.clearAndFree(bun.default_allocator);
             return val;
@@ -1194,6 +1200,9 @@ pub const FFI = struct {
             // an error while validating symbols
             for (symbols.keys()) |key| {
                 allocator.free(@constCast(key));
+            }
+            for (symbols.values()) |*function_| {
+                function_.arg_types.deinit(allocator);
             }
             symbols.clearAndFree(allocator);
             return val;

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -1411,7 +1411,7 @@ pub const FFI = struct {
         while (try symbols_iter.next()) |prop| {
             const value = symbols_iter.value;
 
-            if (value.isEmptyOrUndefinedOrNull()) {
+            if (value.isEmptyOrUndefinedOrNull() or !value.isObject()) {
                 return global.toTypeError(.INVALID_ARG_VALUE, "Expected an object for key \"{f}\"", .{prop});
             }
 

--- a/test/js/bun/ffi/ffi-viewSource-non-object.test.ts
+++ b/test/js/bun/ffi/ffi-viewSource-non-object.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { isArm64, isWindows } from "harness";
+
+const isFFIUnavailable = isWindows && isArm64;
+
+describe.skipIf(isFFIUnavailable)("FFI viewSource", () => {
+  test("rejects non-object symbol descriptor values", () => {
+    // These should throw a TypeError because each symbol descriptor
+    // must be an object like { args: [...], returns: "void" }.
+    // Previously, non-object values like numbers or strings would
+    // cause a debug assertion failure (crash) in generateSymbolForFunction.
+    expect(() => Bun.FFI.viewSource({ myFunc: 42 })).toThrow("Expected an object");
+    expect(() => Bun.FFI.viewSource({ myFunc: "not_an_object" })).toThrow("Expected an object");
+    expect(() => Bun.FFI.viewSource({ myFunc: true })).toThrow("Expected an object");
+  });
+});


### PR DESCRIPTION
In `generateSymbols`, the existing check only rejected null/undefined/empty values before passing them to `generateSymbolForFunction`. That function calls `value.getTruthy()` → `value.get()`, which asserts that the target is an object. Non-object values like numbers, strings, or booleans would trigger a debug assertion failure (`panic: reached unreachable code`).

Add an `isObject()` check alongside the existing `isEmptyOrUndefinedOrNull()` check so non-object symbol descriptor values are properly rejected with a TypeError instead of crashing.

Reproducer:
```js
Bun.FFI.viewSource({ myFunc: 42 });
// or
Bun.FFI.viewSource(SharedArrayBuffer);
```

---

Verified by robobun: CI Lint passes; Format failure is unrelated (autofix cherry-pick conflict in docs/runtime/cron.mdx); buildkite still building. Diff adds `!value.isObject()` guard in `generateSymbols` (line 1423) preventing crash on non-object symbol descriptors, plus three `arg_types.deinit()` calls fixing a pre-existing memory leak in error paths of `print`, `open`, and `linkSymbols`. Regression test in `ffi-viewSource-non-object.test.ts` asserts TypeError on number/string/boolean inputs — these would crash on main (debug assertion in `getOwn` on non-objects), so the test is meaningful. No TODO/FIXME/HACK in added lines. CodeRabbit review found no actionable issues.