### PR TITLE
Bun.WebView: EventTarget, screenshot formats, zero-copy mmap Blob, .cdp()

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7980,7 +7980,17 @@ declare module "bun" {
       | "chrome"
       | {
           type: "chrome";
-          /** Path to the Chrome/Chromium executable. Overrides auto-detection. */
+          /**
+           * Path to the Chrome/Chromium executable. Overrides
+           * auto-detection and forces Bun to spawn a fresh Chrome
+           * subprocess (skipping the existing-Chrome auto-connect).
+           *
+           * **Auto-connect**: when neither `path` nor `url` is set, Bun
+           * checks Chrome's `DevToolsActivePort` file — if a Chrome with
+           * remote debugging is already running, Bun connects to it over
+           * WebSocket instead of spawning. Pass `path` (or `argv`) to
+           * force spawn-mode.
+           */
           path?: string;
           /**
            * Connect to an **already-running** Chrome instead of spawning

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8193,6 +8193,38 @@ declare module "bun" {
     screenshot(options?: { format?: "png" | "jpeg" | "webp"; quality?: number }): Promise<Blob>;
 
     /**
+     * Send a raw Chrome DevTools Protocol command. **Chrome backend only.**
+     *
+     * The command is scoped to this view's session (targets the current
+     * tab). Returns the decoded `result` object from the CDP response, or
+     * rejects with the `error.message` if Chrome reports a protocol error.
+     *
+     * Call `await view.navigate(...)` at least once before using `cdp()` —
+     * the first navigate sets up the CDP session.
+     *
+     * @param method Domain-qualified method name, e.g.
+     *   `"Runtime.evaluate"`, `"DOM.querySelector"`,
+     *   `"Emulation.setUserAgentOverride"`.
+     * @param params Command parameters. Must be JSON-serializable.
+     *
+     * @example
+     * ```ts
+     * const view = new Bun.WebView({ backend: "chrome" });
+     * await view.navigate("https://example.com");
+     *
+     * const { root } = await view.cdp("DOM.getDocument");
+     * const { nodeId } = await view.cdp("DOM.querySelector", {
+     *   nodeId: root.nodeId,
+     *   selector: "input#search",
+     * });
+     * await view.cdp("DOM.focus", { nodeId });
+     * ```
+     *
+     * @see https://chromedevtools.github.io/devtools-protocol/
+     */
+    cdp<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T>;
+
+    /**
      * Click at the given viewport coordinates.
      *
      * Fires native `pointerdown`/`mousedown`/`pointerup`/`mouseup`/`click`

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8099,7 +8099,7 @@ declare module "bun" {
    *
    * @experimental
    */
-  class WebView {
+  class WebView extends EventTarget {
     /**
      * @throws on non-macOS platforms when `backend` is `"webkit"` (the
      * default). Pass `backend: "chrome"` for cross-platform support.
@@ -8175,9 +8175,22 @@ declare module "bun" {
     evaluate<T = unknown>(script: string): Promise<T>;
 
     /**
-     * Capture a PNG screenshot of the current viewport.
+     * Capture a screenshot of the current viewport.
+     *
+     * The returned `Blob` carries the right MIME type (`image/png`,
+     * `image/jpeg`, or `image/webp`) — composes with
+     * `Bun.write(path, blob)`, `new Response(blob)`, and `blob.bytes()`.
+     *
+     * On the **WebKit backend**, the image bytes live in a shared-memory
+     * segment mmap'd directly into the Blob's store — no copy. The mapping
+     * is released when the Blob is garbage-collected.
+     *
+     * @param options.format Image format. `"webp"` requires the Chrome
+     *   backend. @default `"png"`
+     * @param options.quality Compression quality for JPEG/WebP, 0-100.
+     *   Ignored for PNG. @default `80`
      */
-    screenshot(): Promise<Uint8Array>;
+    screenshot(options?: { format?: "png" | "jpeg" | "webp"; quality?: number }): Promise<Blob>;
 
     /**
      * Click at the given viewport coordinates.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8293,6 +8293,40 @@ declare module "bun" {
     cdp<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T>;
 
     /**
+     * Subscribe to CDP events. **Chrome backend only.**
+     *
+     * Event types are CDP method names directly —
+     * `"Network.responseReceived"`, `"Page.frameStartedLoading"`,
+     * `"DOM.documentUpdated"`, etc. The listener receives a
+     * `MessageEvent` with the CDP params as `event.data`.
+     *
+     * Enable the domain first with `cdp("Domain.enable")`, or Chrome
+     * won't send those events. Events without a registered listener
+     * are dropped before JSON parsing (no overhead for domains you
+     * enabled but don't fully listen to).
+     *
+     * @example
+     * ```ts
+     * await view.navigate("about:blank");
+     * await view.cdp("Network.enable");
+     * view.addEventListener("Network.responseReceived", e => {
+     *   console.log(e.data.response.status, e.data.response.url);
+     * });
+     * await view.navigate("https://example.com");
+     * ```
+     */
+    addEventListener<T = unknown>(
+      type: `${string}.${string}`,
+      listener: (event: MessageEvent<T>) => void,
+      options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions,
+    ): void;
+
+    /**
      * Click at the given viewport coordinates.
      *
      * Fires native `pointerdown`/`mousedown`/`pointerup`/`mouseup`/`click`

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7981,6 +7981,42 @@ declare module "bun" {
       | {
           type: "chrome";
           /**
+           * Connect to an existing Chrome's DevTools WebSocket directly.
+           * Get the URL from Chrome's `DevToolsActivePort` file
+           * (`<port>\n<path>`, in the profile directory) — the full URL
+           * is `ws://127.0.0.1:<port><path>`.
+           *
+           * Enable remote debugging in Chrome at
+           * `chrome://inspect/#remote-debugging`, or launch with
+           * `--remote-debugging-port=9222`. Both write
+           * `DevToolsActivePort`.
+           *
+           * **Note**: The `chrome://inspect` toggle shows an "Allow
+           * remote debugging?" dialog on **every** new connection.
+           *
+           * Mutually exclusive with `path`/`argv` — you're connecting
+           * to a Chrome that's already running, not spawning one.
+           */
+          url: string;
+        }
+      | {
+          type: "chrome";
+          /**
+           * Controls the connect-vs-spawn choice:
+           *
+           * - `false` — skip auto-detect, always spawn a fresh Chrome.
+           *   Executable path still auto-found unless `path` is set.
+           * - `undefined` (default) — **auto-detect**: if a
+           *   `DevToolsActivePort` file exists (Chrome with remote
+           *   debugging is running), connect to it; else spawn.
+           *
+           * Auto-detect falls back to spawn if the connect fails (stale
+           * file from a dead Chrome). The WebSocket auto-closes when
+           * the last `WebView` is closed. For unattended automation,
+           * pass `url: false`.
+           */
+          url?: false;
+          /**
            * Path to the Chrome/Chromium executable. Overrides
            * auto-detection and forces Bun to spawn a fresh Chrome
            * subprocess (skipping the existing-Chrome auto-connect).
@@ -7992,31 +8028,6 @@ declare module "bun" {
            * force spawn-mode.
            */
           path?: string;
-          /**
-           * Controls the connect-vs-spawn choice:
-           *
-           * - `"ws://..."` — connect to that DevTools WebSocket directly.
-           *   Get the URL from Chrome's `DevToolsActivePort` file
-           *   (`<port>\n<path>`, in the profile directory).
-           * - `false` — skip auto-detect, always spawn a fresh Chrome.
-           *   Executable path still auto-found unless `path` is set.
-           * - `undefined` (default) — **auto-detect**: if a
-           *   `DevToolsActivePort` file exists (Chrome with remote
-           *   debugging is running), connect to it; else spawn.
-           *
-           * Enable remote debugging in Chrome at
-           * `chrome://inspect/#remote-debugging`, or launch with
-           * `--remote-debugging-port=9222`. Both write
-           * `DevToolsActivePort`.
-           *
-           * **Note**: The `chrome://inspect` toggle shows an "Allow
-           * remote debugging?" dialog on **every** new connection.
-           * Auto-detect falls back to spawn if the connect fails (stale
-           * file from a dead Chrome). The WebSocket auto-closes when
-           * the last `WebView` is closed. For unattended automation,
-           * pass `url: false`.
-           */
-          url?: string | false;
           /**
            * Extra command-line arguments appended after the default flags.
            * Chrome's CommandLine does last-wins for duplicate switches, so

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7983,6 +7983,31 @@ declare module "bun" {
           /** Path to the Chrome/Chromium executable. Overrides auto-detection. */
           path?: string;
           /**
+           * Connect to an **already-running** Chrome instead of spawning
+           * one. Accepts:
+           *
+           * - `"127.0.0.1:9222"` — bare host:port (what Chrome's Remote
+           *   Debugging panel shows). Bun GETs `/json/version` to discover
+           *   the WebSocket debugger URL.
+           * - `"http://127.0.0.1:9222"` — same discovery.
+           * - `"ws://127.0.0.1:9222/devtools/browser/<id>"` — full URL,
+           *   connect directly.
+           *
+           * Enable remote debugging in Chrome at
+           * `chrome://inspect/#remote-debugging`, or launch with
+           * `--remote-debugging-port=9222`.
+           *
+           * **Note**: The `chrome://inspect` toggle shows an "Allow
+           * remote debugging?" dialog on **every** new connection. The
+           * WebSocket handshake blocks until the user clicks Allow. For
+           * unattended automation, launch Chrome with
+           * `--remote-debugging-port` instead (no dialog).
+           *
+           * Mutually exclusive with `path`, `argv`, `stdout`, `stderr`
+           * (there's no subprocess to configure).
+           */
+          url?: string;
+          /**
            * Extra command-line arguments appended after the default flags.
            * Chrome's CommandLine does last-wins for duplicate switches, so
            * `["--headless=new"]` would override the default `--headless`.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8177,20 +8177,42 @@ declare module "bun" {
     /**
      * Capture a screenshot of the current viewport.
      *
-     * The returned `Blob` carries the right MIME type (`image/png`,
-     * `image/jpeg`, or `image/webp`) — composes with
-     * `Bun.write(path, blob)`, `new Response(blob)`, and `blob.bytes()`.
+     * **`encoding` controls the return type:**
+     * - `"blob"` (default) — `Blob` with the right MIME type. WebKit:
+     *   zero-copy mmap-backed store. Composes with `Bun.write()`,
+     *   `new Response()`, `blob.bytes()`.
+     * - `"buffer"` — Node `Buffer`. WebKit: zero-copy (the same mmap'd
+     *   pages wrapped as an `ArrayBuffer` that munmap's on GC).
+     * - `"base64"` — base64-encoded `string`. Chrome: zero decode (CDP
+     *   returns base64 natively). Direct Kitty `t=d` transmission.
+     * - `"shmem"` — `{ name, size }`. The POSIX shm name is left linked;
+     *   caller owns `shm_unlink`. Kitty `t=s` transmission: pass `name`
+     *   as the payload, Kitty unlinks after reading. Not on Windows.
      *
-     * On the **WebKit backend**, the image bytes live in a shared-memory
-     * segment mmap'd directly into the Blob's store — no copy. The mapping
-     * is released when the Blob is garbage-collected.
-     *
-     * @param options.format Image format. `"webp"` requires the Chrome
-     *   backend. @default `"png"`
+     * @param options.format Image format. `"webp"` requires Chrome.
+     *   @default `"png"`
      * @param options.quality Compression quality for JPEG/WebP, 0-100.
      *   Ignored for PNG. @default `80`
+     * @param options.encoding Return-type encoding. @default `"blob"`
+     *
+     * @example Kitty graphics protocol, shared-memory transmission
+     * ```ts
+     * const { name, size } = await view.screenshot({ encoding: "shmem" });
+     * process.stdout.write(
+     *   `\x1b_Gf=100,t=s,a=T,S=${size};${btoa(name)}\x1b\\`
+     * );
+     * // Kitty shm_open's the name, reads ${size} PNG bytes, unlinks.
+     * ```
      */
-    screenshot(options?: { format?: "png" | "jpeg" | "webp"; quality?: number }): Promise<Blob>;
+    screenshot(options?: { encoding?: "blob"; format?: "png" | "jpeg" | "webp"; quality?: number }): Promise<Blob>;
+    screenshot(options: { encoding: "buffer"; format?: "png" | "jpeg" | "webp"; quality?: number }): Promise<Buffer>;
+    screenshot(options: { encoding: "base64"; format?: "png" | "jpeg" | "webp"; quality?: number }): Promise<string>;
+    screenshot(options: { encoding: "shmem"; format?: "png" | "jpeg" | "webp"; quality?: number }): Promise<{
+      /** POSIX shm name (pass to `shm_open(2)` or Kitty `t=s`). */
+      name: string;
+      /** Encoded image size in bytes. */
+      size: number;
+    }>;
 
     /**
      * Send a raw Chrome DevTools Protocol command. **Chrome backend only.**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7993,30 +7993,30 @@ declare module "bun" {
            */
           path?: string;
           /**
-           * Connect to an **already-running** Chrome instead of spawning
-           * one. Accepts:
+           * Controls the connect-vs-spawn choice:
            *
-           * - `"127.0.0.1:9222"` — bare host:port (what Chrome's Remote
-           *   Debugging panel shows). Bun GETs `/json/version` to discover
-           *   the WebSocket debugger URL.
-           * - `"http://127.0.0.1:9222"` — same discovery.
-           * - `"ws://127.0.0.1:9222/devtools/browser/<id>"` — full URL,
-           *   connect directly.
+           * - `"ws://..."` — connect to that DevTools WebSocket directly.
+           *   Get the URL from Chrome's `DevToolsActivePort` file
+           *   (`<port>\n<path>`, in the profile directory).
+           * - `false` — skip auto-detect, always spawn a fresh Chrome.
+           *   Executable path still auto-found unless `path` is set.
+           * - `undefined` (default) — **auto-detect**: if a
+           *   `DevToolsActivePort` file exists (Chrome with remote
+           *   debugging is running), connect to it; else spawn.
            *
            * Enable remote debugging in Chrome at
            * `chrome://inspect/#remote-debugging`, or launch with
-           * `--remote-debugging-port=9222`.
+           * `--remote-debugging-port=9222`. Both write
+           * `DevToolsActivePort`.
            *
            * **Note**: The `chrome://inspect` toggle shows an "Allow
-           * remote debugging?" dialog on **every** new connection. The
-           * WebSocket handshake blocks until the user clicks Allow. For
-           * unattended automation, launch Chrome with
-           * `--remote-debugging-port` instead (no dialog).
-           *
-           * Mutually exclusive with `path`, `argv`, `stdout`, `stderr`
-           * (there's no subprocess to configure).
+           * remote debugging?" dialog on **every** new connection.
+           * Auto-detect falls back to spawn if the connect fails (stale
+           * file from a dead Chrome). The WebSocket auto-closes when
+           * the last `WebView` is closed. For unattended automation,
+           * pass `url: false`.
            */
-          url?: string;
+          url?: string | false;
           /**
            * Extra command-line arguments appended after the default flags.
            * Chrome's CommandLine does last-wins for duplicate switches, so

--- a/src/bun.js/bindings/webcore/EventTargetFactory.cpp
+++ b/src/bun.js/bindings/webcore/EventTargetFactory.cpp
@@ -59,6 +59,8 @@ JSC::JSValue toJS(JSC::JSGlobalObject* state, JSDOMGlobalObject* globalObject, E
         // #endif
     case BroadcastChannelEventTargetInterfaceType:
         return toJS(state, globalObject, static_cast<BroadcastChannel&>(impl));
+    case BunWebViewEventTargetInterfaceType:
+        return Bun::toJS(state, globalObject, static_cast<Bun::WebViewEventTarget&>(impl));
         //     case ClipboardEventTargetInterfaceType:
         //         return toJS(state, globalObject, static_cast<Clipboard&>(impl));
         //     case DOMApplicationCacheEventTargetInterfaceType:

--- a/src/bun.js/bindings/webcore/EventTargetHeaders.h
+++ b/src/bun.js/bindings/webcore/EventTargetHeaders.h
@@ -47,6 +47,7 @@
 // #include "JSBaseAudioContext.h"
 // #endif
 #include "BroadcastChannel.h"
+#include "../../webview/JSWebView.h"
 // #include "Clipboard.h"
 // #include "DOMApplicationCache.h"
 // #include "DOMWindow.h"

--- a/src/bun.js/bindings/webcore/EventTargetInterfaces.h
+++ b/src/bun.js/bindings/webcore/EventTargetInterfaces.h
@@ -140,6 +140,7 @@ enum EventTargetInterface {
     WorkletGlobalScopeEventTargetInterfaceType = 72,
     XMLHttpRequestEventTargetInterfaceType = 73,
     XMLHttpRequestUploadEventTargetInterfaceType = 74,
+    BunWebViewEventTargetInterfaceType = 75,
 };
 
 } // namespace WebCore

--- a/src/bun.js/bindings/webcore/WebSocket.cpp
+++ b/src/bun.js/bindings/webcore/WebSocket.cpp
@@ -1436,6 +1436,7 @@ void WebSocket::didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::
     // onClose distinguishes by whether onOpen ever fired.
     if (m_native.onClose) {
         m_native.onClose(m_native.ctx, code);
+        disablePendingActivity();
         return;
     }
 
@@ -1496,10 +1497,13 @@ void WebSocket::didClose(unsigned unhandledBufferedAmount, unsigned short code, 
     this->m_upgradeClient = nullptr;
 
     // Native callback: state transition above is done, hand off the code.
-    // disablePendingActivity() is a JS-GC-root concern the native path
-    // doesn't need — the consumer holds a RefPtr and drops it on close.
+    // disablePendingActivity releases the GC-root ref connect() took —
+    // the native consumer holds a RefPtr so GC-rooting doesn't matter,
+    // but the count should balance for the ASSERT below and any future
+    // consumer of hasPendingActivity().
     if (m_native.onClose) {
         m_native.onClose(m_native.ctx, code);
+        disablePendingActivity();
         return;
     }
 

--- a/src/bun.js/bindings/webcore/WebSocket.cpp
+++ b/src/bun.js/bindings/webcore/WebSocket.cpp
@@ -1433,10 +1433,11 @@ void WebSocket::didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::
     // Native callback: state transitioned, hand off the close code.
     // Covers both connect-failure (didFailWithErrorCode →
     // didReceiveClose) and server-initiated close. The consumer's
-    // onClose distinguishes by whether onOpen ever fired.
+    // onClose distinguishes by whether onOpen ever fired. Cleanup
+    // (disablePendingActivity) is the caller's job — didFailWithErrorCode
+    // posts it after the switch.
     if (m_native.onClose) {
         m_native.onClose(m_native.ctx, code);
-        disablePendingActivity();
         return;
     }
 
@@ -1721,14 +1722,13 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
     }
     }
 
-    m_state = CLOSED;
-    if (auto* context = scriptExecutionContext()) {
-        context->postTask([protectedThis = Ref { *this }](ScriptExecutionContext& context) {
-            protectedThis->disablePendingActivity();
-        });
-    } else {
-        this->deref();
-    }
+    // didReceiveClose already set m_state = CLOSED. The connect() ref
+    // kept us alive across the switch (including across the native
+    // onClose callback dropping its RefPtr); release it from a task so
+    // the caller's stack frame unwinds first.
+    scriptExecutionContext()->postTask([protectedThis = Ref { *this }](ScriptExecutionContext&) {
+        protectedThis->disablePendingActivity();
+    });
 }
 
 void WebSocket::disablePendingActivity()

--- a/src/bun.js/bindings/webcore/WebSocket.cpp
+++ b/src/bun.js/bindings/webcore/WebSocket.cpp
@@ -1725,10 +1725,16 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
     // didReceiveClose already set m_state = CLOSED. The connect() ref
     // kept us alive across the switch (including across the native
     // onClose callback dropping its RefPtr); release it from a task so
-    // the caller's stack frame unwinds first.
-    scriptExecutionContext()->postTask([protectedThis = Ref { *this }](ScriptExecutionContext&) {
-        protectedThis->disablePendingActivity();
-    });
+    // the caller's stack frame unwinds first. ContextDestructionObserver
+    // holds a WeakPtr — a Worker terminated mid-connect returns null
+    // here; deref directly since there's no loop to post to.
+    if (auto* context = scriptExecutionContext()) {
+        context->postTask([protectedThis = Ref { *this }](ScriptExecutionContext&) {
+            protectedThis->disablePendingActivity();
+        });
+    } else {
+        this->deref();
+    }
 }
 
 void WebSocket::disablePendingActivity()

--- a/src/bun.js/bindings/webcore/WebSocket.cpp
+++ b/src/bun.js/bindings/webcore/WebSocket.cpp
@@ -34,6 +34,7 @@
 #include "WebSocketDeflate.h"
 #include "headers.h"
 #include "blob.h"
+#include "BunString.h"
 #include "ZigGeneratedClasses.h"
 #include "CloseEvent.h"
 #include <wtf/text/Base64.h>
@@ -1239,6 +1240,16 @@ void WebSocket::didConnect()
     }
     m_state = OPEN;
 
+    // Native callback: fire synchronously, skip Event construction +
+    // dispatchEvent + the postTask deferral. The m_state = OPEN above is
+    // the only bookkeeping the native path needs — sendTextNative checks
+    // it. incPendingActivityCount is a JS-GC-root concern; the native
+    // consumer holds a RefPtr so it doesn't need it.
+    if (m_native.onOpen) {
+        m_native.onOpen(m_native.ctx);
+        return;
+    }
+
     if (auto* context = scriptExecutionContext()) {
 
         if (this->hasEventListeners("open"_s)) {
@@ -1263,6 +1274,18 @@ void WebSocket::didReceiveMessage(String&& message)
     // queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [this, message = WTF::move(message)]() mutable {
     if (m_state != OPEN)
         return;
+
+    // Native callback: hand off the UTF-8 bytes directly. UTF8View checks
+    // is8Bit() && containsOnlyASCII() first — if true (the common case for
+    // CDP JSON), span() is a zero-copy view over the existing buffer.
+    // Only non-ASCII Latin1 or UTF-16 strings pay for a transcode into
+    // a CString. The callback reads the span, we drop it — no
+    // MessageEvent, no dispatchEvent, no postTask.
+    if (m_native.onMessage) {
+        Bun::UTF8View view(message);
+        m_native.onMessage(m_native.ctx, view.span());
+        return;
+    }
 
     // if (InspectorInstrumentation::hasFrontends()) [[unlikely]] {
     //     if (auto* inspector = m_channel->channelInspector()) {
@@ -1406,6 +1429,16 @@ void WebSocket::didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::
         return;
     const bool wasConnecting = m_state == CONNECTING;
     m_state = CLOSED;
+
+    // Native callback: state transitioned, hand off the close code.
+    // Covers both connect-failure (didFailWithErrorCode →
+    // didReceiveClose) and server-initiated close. The consumer's
+    // onClose distinguishes by whether onOpen ever fired.
+    if (m_native.onClose) {
+        m_native.onClose(m_native.ctx, code);
+        return;
+    }
+
     if (auto* context = scriptExecutionContext()) {
         this->incPendingActivityCount();
         if (wasConnecting && isConnectionError) {
@@ -1461,6 +1494,14 @@ void WebSocket::didClose(unsigned unhandledBufferedAmount, unsigned short code, 
     ASSERT(scriptExecutionContext());
     this->m_connectedWebSocketKind = ConnectedWebSocketKind::None;
     this->m_upgradeClient = nullptr;
+
+    // Native callback: state transition above is done, hand off the code.
+    // disablePendingActivity() is a JS-GC-root concern the native path
+    // doesn't need — the consumer holds a RefPtr and drops it on close.
+    if (m_native.onClose) {
+        m_native.onClose(m_native.ctx, code);
+        return;
+    }
 
     // since we are open and closing now we know that we have at least one pending activity
     // so we just call decPendingActivityCount() after dispatching the event

--- a/src/bun.js/bindings/webcore/WebSocket.h
+++ b/src/bun.js/bindings/webcore/WebSocket.h
@@ -227,8 +227,8 @@ public:
     {
         ASSERT(m_pendingActivityCount > 0);
         m_pendingActivityCount--;
-        deref();
         updateHasPendingActivity();
+        deref();
     }
 
     size_t memoryCost() const;

--- a/src/bun.js/bindings/webcore/WebSocket.h
+++ b/src/bun.js/bindings/webcore/WebSocket.h
@@ -168,6 +168,38 @@ public:
         m_rejectUnauthorized = rejectUnauthorized;
     }
 
+    // C++-only callback mode. When set, didConnect/didReceiveMessage/
+    // didClose call these function pointers directly instead of building
+    // Event objects and going through dispatchEvent. Fires synchronously
+    // from the socket's onData — no event-loop tick deferral, no JSValue
+    // allocation. Used when a C++ subsystem owns the socket lifecycle
+    // end-to-end (e.g. CDP::Transport connecting to an existing Chrome
+    // instance over ws://, where every message is handled by C++ JSON
+    // parsing and JS only sees the final settled promise).
+    //
+    // onMessage gets text frames only — binary frames are dropped (the
+    // only current consumer speaks JSON). If a consumer needs binary,
+    // add onBinary alongside. onClose fires for both clean and abrupt
+    // close; the error-code-to-string mapping is the caller's job.
+    struct NativeCallbacks {
+        void* ctx = nullptr;
+        void (*onOpen)(void* ctx) = nullptr;
+        void (*onMessage)(void* ctx, std::span<const char> utf8) = nullptr;
+        void (*onClose)(void* ctx, unsigned short code) = nullptr;
+    };
+    void setNativeCallbacks(NativeCallbacks cb) { m_native = cb; }
+    bool hasNativeCallbacks() const { return m_native.onMessage != nullptr; }
+
+    // Public wrapper for the native-callback consumer to send text frames.
+    // Bypasses the ExceptionOr<> wrapping — the caller has already checked
+    // m_state == OPEN (onOpen fired), and there's no JS caller to surface
+    // an exception to. Same underlying write path as send(String).
+    void sendTextNative(const String& message)
+    {
+        if (m_state != OPEN) return;
+        sendWebSocketString(message, Opcode::Text);
+    }
+
     bool rejectUnauthorized() const
     {
         return m_rejectUnauthorized;
@@ -258,6 +290,8 @@ private:
     void* m_sslConfig { nullptr };
 
     bool m_dispatchedErrorEvent { false };
+
+    NativeCallbacks m_native;
     // RefPtr<PendingActivity<WebSocket>> m_pendingActivity;
 };
 

--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -3121,6 +3121,85 @@ export fn Blob__fromBytes(globalThis: *jsc.JSGlobalObject, ptr: ?[*]const u8, le
     return new(initWithStore(store, globalThis));
 }
 
+/// Same as Blob__fromBytes but stamps content_type. `mime` must be a
+/// string literal with process lifetime (not freed by deinit — the caller
+/// passes one of the image/* constants). The Zig side copies the bytes;
+/// caller can free `ptr` immediately after this returns.
+export fn Blob__fromBytesWithType(globalThis: *jsc.JSGlobalObject, ptr: ?[*]const u8, len: usize, mime: [*:0]const u8) callconv(.c) *Blob {
+    const blob = Blob__fromBytes(globalThis, ptr, len);
+    const mime_slice = std.mem.span(mime);
+    if (mime_slice.len > 0) {
+        blob.content_type = mime_slice;
+        blob.content_type_was_set = true;
+        // content_type_allocated stays false — caller guarantees the string
+        // outlives the Blob (it's a C string literal in the caller's .rodata).
+    }
+    return blob;
+}
+
+// POSIX-only — bun.sys.munmap is a @compileError on Windows, and the only
+// caller (WebKit screenshot path) is macOS. The Chrome backend decodes
+// base64 into a mimalloc buffer and uses Blob__fromBytesWithType above.
+pub const MmapFreeInterface = if (bun.Environment.isPosix) struct {
+    // Stateless allocator vtable whose free() munmap's. Same pattern as
+    // LinuxMemFdAllocator but without the stateful fd — we're adopting an
+    // already-mmap'd, already-unlinked shm region where the ONLY live
+    // reference is the mapping itself. alloc returns null: Blob stores
+    // never grow. The vtable const is named so `allocator.vtable == vtable`
+    // comparisons work if anyone needs to detect this (same pattern as
+    // LinuxMemFdAllocator.isInstance).
+    fn alloc(_: *anyopaque, _: usize, _: std.mem.Alignment, _: usize) ?[*]u8 {
+        return null;
+    }
+    fn free(_: *anyopaque, buf: []u8, _: std.mem.Alignment, _: usize) void {
+        bun.sys.munmap(@ptrCast(@alignCast(buf))).unwrap() catch |err| {
+            bun.Output.debugWarn("Blob mmap-store munmap failed: {}", .{err});
+        };
+    }
+    const vtable_: std.mem.Allocator.VTable = .{
+        .alloc = &alloc,
+        .resize = &std.mem.Allocator.noResize,
+        .remap = &std.mem.Allocator.noRemap,
+        .free = &free,
+    };
+    pub const vtable: *const std.mem.Allocator.VTable = &vtable_;
+} else struct {};
+
+/// Adopts an mmap'd region — no copy. The Blob's store holds the mapping;
+/// when the store's refcount drops to zero, deinit calls allocator.free
+/// which munmap's. `ptr` must be page-aligned (mmap guarantees this) and
+/// `len` must be the exact mmap length (munmap needs the same len the
+/// caller passed to mmap — the kernel rounds len up to page size at mmap
+/// time and munmap(ptr, len) with the same len unmaps exactly those
+/// pages). `mime` is a static-lifetime literal as above.
+///
+/// WebKit screenshot path: child writes encoded image bytes to a POSIX
+/// shm segment, parent shm_open's + mmap's MAP_SHARED, then calls this.
+/// The shm segment lives until BOTH the name is unlinked AND all mappings
+/// drop — so unlinking before this call is fine, the Blob's mapping keeps
+/// the physical pages alive until the user drops the Blob. The image
+/// bytes are never copied into the JS heap; `await blob.bytes()` reads
+/// directly from the mapped pages.
+export fn Blob__fromMmapWithType(globalThis: *jsc.JSGlobalObject, ptr: [*]u8, len: usize, mime: [*:0]const u8) callconv(.c) *Blob {
+    if (comptime !bun.Environment.isPosix) {
+        // Windows Chrome backend never calls this; if it ever does, fall
+        // back to copying. The caller owns ptr afterward (no munmap
+        // happens here) — caller must free it.
+        return Blob__fromBytesWithType(globalThis, ptr, len, mime);
+    }
+    const store = Store.init(ptr[0..len], .{
+        .ptr = undefined,
+        .vtable = MmapFreeInterface.vtable,
+    });
+    const blob = new(initWithStore(store, globalThis));
+    const mime_slice = std.mem.span(mime);
+    if (mime_slice.len > 0) {
+        blob.content_type = mime_slice;
+        blob.content_type_was_set = true;
+    }
+    return blob;
+}
+
 pub fn getStat(this: *Blob, globalThis: *jsc.JSGlobalObject, callback: *jsc.CallFrame) bun.JSError!jsc.JSValue {
     const store = this.store orelse return .js_undefined;
     // TODO: make this async for files

--- a/src/bun.js/webview/ChromeBackend.cpp
+++ b/src/bun.js/webview/ChromeBackend.cpp
@@ -36,6 +36,41 @@
 #include <fcntl.h>
 #endif
 
+#if OS(LINUX)
+#include <dlfcn.h>
+// shm_open/shm_unlink live in librt on older glibc and musl; glibc 2.34+
+// moved them into libc. We don't link -lrt, so resolve at runtime.
+// RTLD_DEFAULT finds them in libc on 2.34+; librt fallback covers older
+// distros. macOS doesn't need this — libSystem (always linked) has both.
+namespace {
+struct Shm {
+    int (*open)(const char*, int, mode_t) = nullptr;
+    int (*unlink)(const char*) = nullptr;
+    bool load()
+    {
+        if (open) return true;
+        open = reinterpret_cast<decltype(open)>(dlsym(RTLD_DEFAULT, "shm_open"));
+        unlink = reinterpret_cast<decltype(unlink)>(dlsym(RTLD_DEFAULT, "shm_unlink"));
+        if (open && unlink) return true;
+        void* h = dlopen("librt.so.1", RTLD_NOLOAD | RTLD_LAZY);
+        if (!h) h = dlopen("librt.so.1", RTLD_NOW);
+        if (!h) return false;
+        open = reinterpret_cast<decltype(open)>(dlsym(h, "shm_open"));
+        unlink = reinterpret_cast<decltype(unlink)>(dlsym(h, "shm_unlink"));
+        return open && unlink;
+    }
+};
+Shm s_shm;
+} // namespace
+#define BUN_SHM_OPEN(n, f, m) s_shm.open((n), (f), (m))
+#define BUN_SHM_UNLINK(n) s_shm.unlink((n))
+#define BUN_SHM_LOAD() s_shm.load()
+#elif OS(DARWIN)
+#define BUN_SHM_OPEN(n, f, m) ::shm_open((n), (f), (m))
+#define BUN_SHM_UNLINK(n) ::shm_unlink((n))
+#define BUN_SHM_LOAD() true
+#endif
+
 #include "libusockets.h"
 #include "_libusockets.h"
 
@@ -861,10 +896,15 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
             // Name uses our pid + a monotonic counter — same scheme as the
             // WebKit child, different namespace (chrome- prefix) so they
             // never collide even if someone mixes backends in one process.
+            if (!BUN_SHM_LOAD()) {
+                settle(g, view, entry.slot, false,
+                    createError(g, "shm_open unavailable (librt not found)"_s));
+                return;
+            }
             static uint32_t shmSeq = 0;
             char name[48];
             snprintf(name, sizeof(name), "/bun-chrome-%d-%u", getpid(), ++shmSeq);
-            int fd = shm_open(name, O_CREAT | O_RDWR | O_EXCL, 0600);
+            int fd = BUN_SHM_OPEN(name, O_CREAT | O_RDWR | O_EXCL, 0600);
             if (fd < 0) {
                 settle(g, view, entry.slot, false,
                     createError(g, makeString("shm_open: "_s, WTF::String::fromUTF8(strerror(errno)))));
@@ -874,7 +914,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
             if (ftruncate(fd, static_cast<off_t>(sz)) != 0) {
                 int err = errno; // close/unlink can clobber errno
                 ::close(fd);
-                shm_unlink(name);
+                BUN_SHM_UNLINK(name);
                 settle(g, view, entry.slot, false,
                     createError(g, makeString("ftruncate: "_s, WTF::String::fromUTF8(strerror(err)))));
                 return;
@@ -883,7 +923,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
             int mmap_err = (map == MAP_FAILED) ? errno : 0;
             ::close(fd);
             if (map == MAP_FAILED) {
-                shm_unlink(name);
+                BUN_SHM_UNLINK(name);
                 settle(g, view, entry.slot, false,
                     createError(g, makeString("mmap: "_s, WTF::String::fromUTF8(strerror(mmap_err)))));
                 return;

--- a/src/bun.js/webview/ChromeBackend.cpp
+++ b/src/bun.js/webview/ChromeBackend.cpp
@@ -296,18 +296,20 @@ bool Transport::ensureSpawned(Zig::GlobalObject* zig, const WTF::String& userDat
     return true;
 }
 
-void Transport::send(Command&& cmd)
+void Transport::send(uint32_t cdpId, Command&& cmd)
 {
     if (m_mode == TransportMode::WebSocket) {
         // WS text frame per CDP message — the framing IS the delimiter.
-        // If the handshake hasn't completed, queue; wsOnOpen drains.
-        // sendTextNative is a no-op when m_state != OPEN, so we MUST
-        // queue here or commands silently drop.
+        // If the handshake hasn't completed, queue with the id; wsOnOpen
+        // drains, skipping ids that Ops::close already erased from
+        // m_pending (view closed before open = don't create its target).
+        // sendTextNative is a no-op when m_state != OPEN, so queuing is
+        // mandatory here or commands silently drop.
         auto body = cmd.finishToString();
         if (m_wsOpen) {
             m_ws->sendTextNative(body);
         } else {
-            m_wsPending.append(WTF::move(body));
+            m_wsPending.append({ cdpId, WTF::move(body) });
         }
         return;
     }
@@ -325,11 +327,16 @@ static void wsOnOpen(void* ctx)
 {
     auto& t = *static_cast<Transport*>(ctx);
     t.m_wsOpen = true;
-    // Drain commands queued during the handshake. The first navigate()
-    // kicks off Target.createTarget before onOpen fires; those frames
-    // sat in m_wsPending until now.
-    for (auto& body : t.m_wsPending)
-        t.m_ws->sendTextNative(body);
+    // Drain commands queued during the handshake, skipping ids whose
+    // Pending entry was erased (Ops::close → m_pending.removeIf). A
+    // view closed before the handshake completed shouldn't create its
+    // target — orphaned tab in the user's Chrome, visible until the WS
+    // closes. id==0 means untracked fire-and-forget (Runtime.enable);
+    // always send those — they don't create targets.
+    for (auto& cmd : t.m_wsPending) {
+        if (cmd.id && !t.m_pending.contains(cmd.id)) continue;
+        t.m_ws->sendTextNative(cmd.body);
+    }
     t.m_wsPending.clear();
 }
 
@@ -376,11 +383,12 @@ static void wsOnClose(void* ctx, unsigned short code)
         // let ensureSpawned's m_dead-reset clear it.
         auto pending = std::exchange(t.m_wsPending, {});
         if (t.ensureSpawned(t.m_global)) {
-            // Replay queued commands over the pipe. Each body is a
-            // complete CDP JSON; append the NUL terminator the pipe
-            // protocol needs.
-            for (auto& body : pending) {
-                Bun::UTF8View view(body);
+            // Replay over the pipe. Same cancellation check as wsOnOpen
+            // — skip ids close() already removed. Append the NUL
+            // terminator the pipe protocol needs.
+            for (auto& cmd : pending) {
+                if (cmd.id && !t.m_pending.contains(cmd.id)) continue;
+                Bun::UTF8View view(cmd.body);
                 auto s = view.span();
                 t.writeRaw(s.data(), s.size());
                 t.writeRaw("\0", 1);
@@ -647,7 +655,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
 
     auto* g = m_global;
     auto& vm = g->vm();
-    JSWebView* view = entry.view.get();
+    JSWebView* view = viewFor(entry.viewId);
     if (!view) return; // user dropped both view and the awaited promise
 
     if (!error.empty()) {
@@ -671,8 +679,8 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         auto tid = jsonString(jsonField(result, { "targetId", 8 }));
         view->m_targetId = WTF::String::fromUTF8(tid);
         uint32_t cid = nextId();
-        m_pending.add(cid, Pending { Method::TargetAttachToTarget, entry.slot, WTF::move(entry.view) });
-        send(Command(cid, "Target.attachToTarget"_s)
+        m_pending.add(cid, Pending { Method::TargetAttachToTarget, entry.slot, entry.viewId });
+        send(cid, Command(cid, "Target.attachToTarget"_s)
                 .str("targetId"_s, view->m_targetId)
                 .boolean("flatten"_s, true));
         return;
@@ -681,10 +689,10 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         // {"sessionId":"<base64ish>"}
         auto sid = jsonString(jsonField(result, { "sessionId", 9 }));
         view->m_sessionId = WTF::String::fromUTF8(sid);
-        // Route events to this view. The Weak's owner is the same
-        // pending-activity predicate; a view with a slot set is rooted.
-        m_sessions.add(view->m_sessionId,
-            Weak<JSWebView>(view, &webViewWeakOwner()));
+        // Route events to this view via its viewId — m_views holds the one
+        // Weak per view. A view with a slot set is rooted via the owner
+        // predicate reading m_pendingActivityCount.
+        m_sessions.add(view->m_sessionId, entry.viewId);
         updateKeepAlive();
 
         // Page.enable lets us receive frameNavigated / loadEventFired.
@@ -692,8 +700,8 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         auto ss = view->m_sessionId.utf8();
         std::span<const char> sidSpan(ss.data(), ss.length());
         uint32_t cid = nextId();
-        m_pending.add(cid, Pending { Method::PageEnable, entry.slot, WTF::move(entry.view) });
-        send(Command(cid, "Page.enable"_s, sidSpan));
+        m_pending.add(cid, Pending { Method::PageEnable, entry.slot, entry.viewId });
+        send(cid, Command(cid, "Page.enable"_s, sidSpan));
         return;
     }
     case Method::PageEnable: {
@@ -705,15 +713,15 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         // Runtime.enable — fire-and-forget, untracked. We don't need to
         // wait for its reply before navigating.
         uint32_t rid = nextId();
-        send(Command(rid, "Runtime.enable"_s, sidSpan));
+        send(0, Command(rid, "Runtime.enable"_s, sidSpan));
 
         // Page.navigate with the url stashed by the first navigate() call.
         // The response confirms the navigation STARTED; Page.loadEventFired
         // confirms completion. We keep the pending entry alive for the
         // response so errorText rejects the right slot.
         uint32_t cid = nextId();
-        m_pending.add(cid, Pending { Method::PageNavigate, entry.slot, WTF::move(entry.view) });
-        send(Command(cid, "Page.navigate"_s, sidSpan)
+        m_pending.add(cid, Pending { Method::PageNavigate, entry.slot, entry.viewId });
+        send(cid, Command(cid, "Page.navigate"_s, sidSpan)
                 .str("url"_s, view->m_pendingChromeNavigateUrl));
         view->m_pendingChromeNavigateUrl = WTF::String();
         return;
@@ -780,8 +788,8 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         int32_t entryId = elem ? elem->getInteger("id"_s).value_or(0) : 0;
         // Chain into navigateToHistoryEntry. Page.loadEventFired settles.
         uint32_t cid = nextId();
-        m_pending.add(cid, Pending { Method::PageNavigateToHistoryEntry, entry.slot, WTF::move(entry.view) });
-        send(Command(cid, "Page.navigateToHistoryEntry"_s, sidSpan(view->m_sessionId))
+        m_pending.add(cid, Pending { Method::PageNavigateToHistoryEntry, entry.slot, entry.viewId });
+        send(cid, Command(cid, "Page.navigateToHistoryEntry"_s, sidSpan(view->m_sessionId))
                 .num("entryId"_s, entryId));
         return;
     }
@@ -868,18 +876,20 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
             }
             size_t sz = decoded->size();
             if (ftruncate(fd, static_cast<off_t>(sz)) != 0) {
+                int err = errno; // close/unlink can clobber errno
                 ::close(fd);
                 shm_unlink(name);
                 settle(g, view, entry.slot, false,
-                    createError(g, makeString("ftruncate: "_s, WTF::String::fromUTF8(strerror(errno)))));
+                    createError(g, makeString("ftruncate: "_s, WTF::String::fromUTF8(strerror(err)))));
                 return;
             }
             void* map = mmap(nullptr, sz, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+            int mmap_err = (map == MAP_FAILED) ? errno : 0;
             ::close(fd);
             if (map == MAP_FAILED) {
                 shm_unlink(name);
                 settle(g, view, entry.slot, false,
-                    createError(g, makeString("mmap: "_s, WTF::String::fromUTF8(strerror(errno)))));
+                    createError(g, makeString("mmap: "_s, WTF::String::fromUTF8(strerror(mmap_err)))));
                 return;
             }
             memcpy(map, decoded->span().data(), sz);
@@ -962,7 +972,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
 
         // Pressed — untracked fire-and-forget.
         uint32_t idDown = nextId();
-        send(Command(idDown, "Input.dispatchMouseEvent"_s, sid)
+        send(0, Command(idDown, "Input.dispatchMouseEvent"_s, sid)
                 .raw("type"_s, "\"mousePressed\""_s)
                 .num("x"_s, cx)
                 .num("y"_s, cy)
@@ -971,8 +981,8 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
                 .num("modifiers"_s, mods));
         // Released — tracked, resolves the slot.
         uint32_t idUp = nextId();
-        m_pending.add(idUp, Pending { Method::InputDispatchMouseEvent, entry.slot, WTF::move(entry.view) });
-        send(Command(idUp, "Input.dispatchMouseEvent"_s, sid)
+        m_pending.add(idUp, Pending { Method::InputDispatchMouseEvent, entry.slot, entry.viewId });
+        send(idUp, Command(idUp, "Input.dispatchMouseEvent"_s, sid)
                 .raw("type"_s, "\"mouseReleased\""_s)
                 .num("x"_s, cx)
                 .num("y"_s, cy)
@@ -1013,15 +1023,17 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         auto sidStr = WTF::String::fromUTF8(sid);
         auto it = m_sessions.find(sidStr);
         if (it == m_sessions.end()) return;
-        JSWebView* view = it->value.get();
+        uint32_t vid = it->value;
         m_sessions.remove(it);
+        JSWebView* view = viewFor(vid);
+        m_views.remove(vid);
         if (!view) return;
         // Reject all pending slots. settle() is idempotent on empty slots.
         auto* err = createError(g, "page detached (crashed or closed)"_s);
         for (auto s : { PendingSlot::Navigate, PendingSlot::Evaluate, PendingSlot::Screenshot, PendingSlot::Misc, PendingSlot::Cdp })
             settle(g, view, s, false, err);
         // Erase stale m_pending entries — replies won't come.
-        m_pending.removeIf([&](auto& kv) { return kv.value.view.get() == view; });
+        m_pending.removeIf([vid](auto& kv) { return kv.value.viewId == vid; });
         view->m_closed = true;
         updateKeepAlive();
         return;
@@ -1029,10 +1041,11 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     auto sidStr = WTF::String::fromUTF8(sessionId);
     auto it = m_sessions.find(sidStr);
     if (it == m_sessions.end()) return;
-    JSWebView* view = it->value.get();
+    JSWebView* view = viewFor(it->value);
     if (!view) {
         // Weak died (user dropped view during a load). Chrome will keep
         // sending events; erasing here stops the lookup thrash.
+        m_views.remove(it->value);
         m_sessions.remove(it);
         return;
     }
@@ -1065,8 +1078,8 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
         view->m_loading = false;
         uint32_t tid = nextId();
-        m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, JSC::Weak<JSWebView>(view, &webViewWeakOwner(), view) });
-        send(Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId))
+        m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId });
+        send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId))
                 .str("expression"_s, "document.title"_s)
                 .boolean("returnByValue"_s, true));
         return;
@@ -1212,17 +1225,21 @@ void Transport::rejectAllAndMarkDead(const WTF::String& reason)
     // already-cleared slot — the first settle for a slot rejects, the rest
     // find barrier.get() == null and no-op.
     for (auto& [id, entry] : m_pending) {
-        if (JSWebView* v = entry.view.get())
+        if (JSWebView* v = viewFor(entry.viewId))
             settle(g, v, entry.slot, false, err);
     }
     m_pending.clear();
     m_sessions.clear();
+    m_views.clear();
     updateKeepAlive();
 }
 
 void Transport::updateKeepAlive()
 {
-    bool want = !m_sessions.isEmpty() || !m_pending.isEmpty();
+    // m_views is source-of-truth for live views (populated in
+    // createChrome, erased in close/destroy). m_pending covers in-flight
+    // ops on a view that was just closed but the response hasn't arrived.
+    bool want = !m_views.isEmpty() || !m_pending.isEmpty();
     if (want == m_sockRefd || !m_global) return;
     m_sockRefd = want;
     Bun__eventLoop__incrementRefConcurrently(
@@ -1247,6 +1264,13 @@ void Transport::updateKeepAlive()
         m_wasAutoDetected = false;
         m_mode = TransportMode::None;
     }
+}
+
+uint32_t Transport::registerView(JSWebView* v)
+{
+    uint32_t id = m_nextViewId++;
+    m_views.add(id, JSC::Weak<JSWebView>(v, &webViewWeakOwner()));
+    return id;
 }
 
 // --- CDP::Ops --------------------------------------------------------------
@@ -1279,8 +1303,8 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
     }
     v->m_pendingActivityCount.fetch_add(1, std::memory_order_release);
     slot.set(vm, v, promise);
-    t.m_pending.add(id, Pending { m, ps, Weak<JSWebView>(v, &webViewWeakOwner()) });
-    t.send(WTF::move(cmd));
+    t.m_pending.add(id, Pending { m, ps, v->m_viewId });
+    t.send(id, WTF::move(cmd));
     t.updateKeepAlive();
     return promise;
 }
@@ -1403,7 +1427,7 @@ JSPromise* click(JSGlobalObject* g, JSWebView* view, float x, float y, uint8_t b
     // Pressed — untracked. Chrome replies but we don't need the ack; the
     // Released event's reply confirms both were processed.
     uint32_t idDown = t.nextId();
-    t.send(Command(idDown, "Input.dispatchMouseEvent"_s, sid)
+    t.send(0, Command(idDown, "Input.dispatchMouseEvent"_s, sid)
             .raw("type"_s, "\"mousePressed\""_s)
             .num("x"_s, x)
             .num("y"_s, y)
@@ -1541,7 +1565,7 @@ JSPromise* press(JSGlobalObject* g, JSWebView* view, uint8_t key, uint8_t modifi
     // fired if text present) by the time we get the reply. No _doAfter*
     // dance like WKWebView's press().
     uint32_t idDown = t.nextId();
-    t.send(Command(idDown, "Input.dispatchKeyEvent"_s, sid)
+    t.send(0, Command(idDown, "Input.dispatchKeyEvent"_s, sid)
             .raw("type"_s, hasText ? "\"keyDown\""_s : "\"rawKeyDown\""_s)
             .str("key"_s, keyStr)
             .str("text"_s, textStr)
@@ -1641,18 +1665,19 @@ void close(JSWebView* view)
     // PageEnable sends Page.navigate, the tab navigates after dispose.
     // removeIf breaks the chain at the next reply — handleResponse's
     // find(id)==end() early-return drops it.
-    t.m_pending.removeIf([view](auto& pair) {
-        return pair.value.view.get() == view;
+    t.m_pending.removeIf([vid = view->m_viewId](auto& pair) {
+        return pair.value.viewId == vid;
     });
     // Target.closeTarget — fire-and-forget. targetId is stashed at
     // TargetCreateTarget's reply (before sessionId) so it's populated
     // earlier in the chain. Chrome tears down the tab; we ignore the
     // Target.targetDestroyed event. Erase sessionId so late events drop.
     if (!view->m_targetId.isEmpty()) {
-        t.send(Command(t.nextId(), "Target.closeTarget"_s)
+        t.send(0, Command(t.nextId(), "Target.closeTarget"_s)
                 .str("targetId"_s, view->m_targetId));
     }
     if (!view->m_sessionId.isEmpty()) t.m_sessions.remove(view->m_sessionId);
+    t.m_views.remove(view->m_viewId);
     t.updateKeepAlive();
 }
 

--- a/src/bun.js/webview/ChromeBackend.cpp
+++ b/src/bun.js/webview/ChromeBackend.cpp
@@ -7,6 +7,7 @@
 #include "ScriptExecutionContext.h"
 #include "BunString.h"
 #include "../bindings/webcore/WebSocket.h"
+#include "../bindings/webcore/MessageEvent.h"
 #include <JavaScriptCore/ConsoleClient.h>
 #include <JavaScriptCore/ScriptArguments.h>
 #include <JavaScriptCore/Strong.h>
@@ -1218,6 +1219,31 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         call(g, cb, callData, jsUndefined(), cbArgs);
         return;
     }
+
+    // Unhandled CDP event — dispatch to the view's EventTarget if it has
+    // a listener for this method name. Check hasEventListeners first:
+    // Chrome is chatty (frameScheduledNavigation, lifecycleEvent, etc.)
+    // and most events won't have listeners; skipping the JSONParse saves
+    // an alloc per unwanted event. The listener was added via
+    // view.addEventListener("Network.responseReceived", e => e.data.response).
+    auto methodAtom = AtomString::fromUTF8(method);
+    if (!view->wrapped().hasEventListeners(methodAtom)) return;
+
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue data = JSONParse(g, WTF::String::fromUTF8(params));
+    RETURN_IF_EXCEPTION(scope, void());
+    if (!data) data = jsUndefined();
+    // MessageEvent::m_jsData is a JSValueInWrappedObject (Weak<>). The
+    // wrapper's visitAdditionalChildren roots it AFTER wrapper creation;
+    // dispatchEvent allocates that wrapper which can GC in between. Keep
+    // the parsed object alive across the gap.
+    JSC::EnsureStillAliveScope dataRoot { data };
+
+    WebCore::MessageEvent::Init init;
+    init.data = data;
+    auto event = WebCore::MessageEvent::create(methodAtom, WTF::move(init), WebCore::Event::IsTrusted::Yes);
+    scope.release();
+    view->wrapped().dispatchEvent(event);
 }
 
 void Transport::onClose()

--- a/src/bun.js/webview/ChromeBackend.cpp
+++ b/src/bun.js/webview/ChromeBackend.cpp
@@ -14,8 +14,6 @@
 #include <JavaScriptCore/WeakInlines.h>
 #include <JavaScriptCore/JSONObject.h>
 #include <wtf/JSONValues.h>
-#include <JavaScriptCore/TypedArrayInlines.h>
-#include <JavaScriptCore/JSTypedArrays.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/Base64.h>
@@ -55,6 +53,8 @@ using namespace JSC;
 extern "C" int32_t Bun__Chrome__ensure(Zig::GlobalObject*, const char* userDataDir,
     const char* path, const char* const* extraArgv, uint32_t extraArgvLen,
     bool stdoutInherit, bool stderrInherit);
+extern "C" void* Blob__fromBytesWithType(JSC::JSGlobalObject*, const uint8_t* ptr, size_t len, const char* mime);
+extern "C" JSC::EncodedJSValue SYSV_ABI Blob__create(Zig::GlobalObject*, void* impl);
 extern "C" void Bun__eventLoop__incrementRefConcurrently(void* bunVM, int delta);
 extern "C" void Bun__EventLoop__enter(Zig::GlobalObject*);
 extern "C" void Bun__EventLoop__exit(Zig::GlobalObject*);
@@ -671,12 +671,12 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     }
 
     case Method::PageCaptureScreenshot: {
-        // {"data":"<base64 PNG>"} — decode into a Uint8Array. WTF::
-        // base64Decode allocates its own Vector then we memcpy into the JS
-        // heap. Two copies at peak (b64 source + decoded Vector), Vector
-        // drops after memcpy. Zero-copy decode-into-JSUint8Array-backing
-        // would need a WTF API we don't have; bun.base64's SIMD path is
-        // available but wiring it here costs more than the memcpy saves.
+        // {"data":"<base64 PNG>"} — decode into a Blob with image/png type.
+        // WTF::base64Decode allocates its own Vector then Blob__fromBytes
+        // copies into a Zig-owned store. Two copies at peak (b64 source +
+        // decoded Vector), Vector drops after Blob takes the bytes. The
+        // Blob's type carries the MIME so `Bun.write(path, blob)` and
+        // `new Response(blob)` work without the user remembering it's PNG.
         auto b64 = jsonString(jsonField(result, { "data", 4 }));
         auto decoded = WTF::base64Decode(
             std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(b64.data()), b64.size()));
@@ -684,23 +684,15 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
             settle(g, view, entry.slot, false, createError(g, "screenshot: invalid base64"_s));
             return;
         }
-        auto& vm = g->vm();
-        auto scope = DECLARE_THROW_SCOPE(vm);
-        auto* u8 = JSUint8Array::createUninitialized(g, g->m_typedArrayUint8.get(g),
-            static_cast<uint32_t>(decoded->size()));
-        if (auto* ex = scope.exception()) [[unlikely]] {
-            // createUninitialized threw (OOM for a large PNG). Reject with
-            // the exception itself — createError would allocate again and
-            // either OOM or succeed-then-be-shadowed-by the pending exception.
-            JSValue err = ex->value();
-            (void)scope.tryClearException();
-            scope.release();
-            settle(g, view, entry.slot, false, err);
-            return;
-        }
-        memcpy(u8->typedVector(), decoded->span().data(), decoded->size());
-        scope.release();
-        settle(g, view, entry.slot, true, u8);
+        // Blob__fromBytes allocates via mimalloc (bun.default_allocator), not
+        // the JS heap — handleOom crashes on failure rather than throwing, so
+        // no scope needed here. Blob__create wraps it in a JSBlob cell.
+        // m_screenshotFormat was stashed by JSWebView::screenshot before the
+        // CDP command went out; it tells us which MIME to stamp.
+        void* impl = Blob__fromBytesWithType(g, decoded->span().data(), decoded->size(),
+            screenshotMimeType(view->m_screenshotFormat));
+        JSValue blob = JSValue::decode(Blob__create(defaultGlobalObject(g), impl));
+        settle(g, view, entry.slot, true, blob);
         return;
     }
 
@@ -1090,14 +1082,25 @@ JSPromise* evaluate(JSGlobalObject* g, JSWebView* view, const WTF::String& scrip
             .boolean("awaitPromise"_s, true));
 }
 
-JSPromise* screenshot(JSGlobalObject* g, JSWebView* view)
+JSPromise* screenshot(JSGlobalObject* g, JSWebView* view, ScreenshotFormat format, uint8_t quality)
 {
     auto& t = transport();
     uint32_t id = t.nextId();
+    // CDP takes format as a JSON string. quality is ignored for PNG by
+    // Chrome; for JPEG/WebP it's 0-100. Pass it unconditionally — Chrome
+    // silently ignores quality for PNG, and the builder's && ref-qualifier
+    // means conditionals break the chain (lvalue after materialization).
+    // The response handler reads view->m_screenshotFormat (stashed by
+    // JSWebView::screenshot before dispatch) to stamp the right MIME type
+    // on the Blob.
+    ASCIILiteral fmtLit = format == ScreenshotFormat::Jpeg ? "\"jpeg\""_s
+        : format == ScreenshotFormat::Webp ? "\"webp\""_s
+        : "\"png\""_s;
     return sendChromeOp(g, view, view->m_pendingScreenshot, PendingSlot::Screenshot,
         Method::PageCaptureScreenshot, id,
         Command(id, "Page.captureScreenshot"_s, sidSpan(view->m_sessionId))
-            .raw("format"_s, "\"png\""_s));
+            .raw("format"_s, fmtLit)
+            .num("quality"_s, static_cast<int32_t>(quality)));
 }
 
 // One mousePressed + one mouseReleased. CDP's Input.dispatchMouseEvent is

--- a/src/bun.js/webview/ChromeBackend.cpp
+++ b/src/bun.js/webview/ChromeBackend.cpp
@@ -835,8 +835,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
             // safe to hold past the next onData), so one copy into the JS
             // heap via fromUTF8 → jsString.
             settle(g, view, entry.slot, true,
-                jsString(vm, WTF::String::fromUTF8(
-                    std::span<const char>(b64.data(), b64.size()))));
+                jsString(vm, WTF::String::fromUTF8(std::span<const char>(b64.data(), b64.size()))));
             return;
         }
 
@@ -895,8 +894,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
             // unlinks after shm_open'ing.
             auto* obj = constructEmptyObject(g);
             obj->putDirect(vm, Identifier::fromString(vm, "name"_s),
-                jsString(vm, WTF::String::fromUTF8(
-                    std::span<const char>(name, strlen(name)))));
+                jsString(vm, WTF::String::fromUTF8(std::span<const char>(name, strlen(name)))));
             obj->putDirect(vm, Identifier::fromString(vm, "size"_s),
                 jsNumber(static_cast<double>(sz)));
             settle(g, view, entry.slot, true, obj);
@@ -1365,8 +1363,8 @@ JSPromise* screenshot(JSGlobalObject* g, JSWebView* view, ScreenshotFormat forma
     // JSWebView::screenshot before dispatch) to stamp the right MIME type
     // on the Blob.
     ASCIILiteral fmtLit = format == ScreenshotFormat::Jpeg ? "\"jpeg\""_s
-        : format == ScreenshotFormat::Webp ? "\"webp\""_s
-        : "\"png\""_s;
+        : format == ScreenshotFormat::Webp                 ? "\"webp\""_s
+                                                           : "\"png\""_s;
     return sendChromeOp(g, view, view->m_pendingScreenshot, PendingSlot::Screenshot,
         Method::PageCaptureScreenshot, id,
         Command(id, "Page.captureScreenshot"_s, sidSpan(view->m_sessionId))

--- a/src/bun.js/webview/ChromeBackend.cpp
+++ b/src/bun.js/webview/ChromeBackend.cpp
@@ -13,6 +13,8 @@
 #include <JavaScriptCore/TopExceptionScope.h>
 #include <JavaScriptCore/WeakInlines.h>
 #include <JavaScriptCore/JSONObject.h>
+#include <JavaScriptCore/ObjectConstructor.h>
+#include "JSBuffer.h"
 #include <wtf/JSONValues.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/MakeString.h>
@@ -27,6 +29,8 @@
 #include <winsock2.h>
 #else
 #include <unistd.h>
+#include <sys/mman.h>
+#include <fcntl.h>
 #endif
 
 #include "libusockets.h"
@@ -505,6 +509,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     m_pending.remove(it);
 
     auto* g = m_global;
+    auto& vm = g->vm();
     JSWebView* view = entry.view.get();
     if (!view) return; // user dropped both view and the awaited promise
 
@@ -673,28 +678,97 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     }
 
     case Method::PageCaptureScreenshot: {
-        // {"data":"<base64 PNG>"} — decode into a Blob with image/png type.
-        // WTF::base64Decode allocates its own Vector then Blob__fromBytes
-        // copies into a Zig-owned store. Two copies at peak (b64 source +
-        // decoded Vector), Vector drops after Blob takes the bytes. The
-        // Blob's type carries the MIME so `Bun.write(path, blob)` and
-        // `new Response(blob)` work without the user remembering it's PNG.
+        // {"data":"<base64 encoded image>"} — the base64 string is the ONLY
+        // representation CDP gives us. All encodings except Base64 need to
+        // decode first. m_screenshotEncoding stashed by screenshot() before
+        // dispatch picks the JS shape.
         auto b64 = jsonString(jsonField(result, { "data", 4 }));
+        auto enc = view->m_screenshotEncoding;
+
+        if (enc == ScreenshotEncoding::Base64) {
+            // Zero decode — hand back the CDP "data" string as-is. The user
+            // wanted base64; CDP gave us base64. The string is allocated
+            // fresh (jsonString returns a span into the rx buffer, not
+            // safe to hold past the next onData), so one copy into the JS
+            // heap via fromUTF8 → jsString.
+            settle(g, view, entry.slot, true,
+                jsString(vm, WTF::String::fromUTF8(
+                    std::span<const char>(b64.data(), b64.size()))));
+            return;
+        }
+
         auto decoded = WTF::base64Decode(
             std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(b64.data()), b64.size()));
         if (!decoded) {
             settle(g, view, entry.slot, false, createError(g, "screenshot: invalid base64"_s));
             return;
         }
-        // Blob__fromBytes allocates via mimalloc (bun.default_allocator), not
-        // the JS heap — handleOom crashes on failure rather than throwing, so
-        // no scope needed here. Blob__create wraps it in a JSBlob cell.
-        // m_screenshotFormat was stashed by JSWebView::screenshot before the
-        // CDP command went out; it tells us which MIME to stamp.
+
+        if (enc == ScreenshotEncoding::Buffer) {
+            // createBuffer(span) copies into a JSC-allocated ArrayBuffer.
+            // decoded Vector drops after; one copy. We can't
+            // adopt-the-Vector because WTF::Vector uses WTF's bmalloc, not
+            // the JSC ArrayBuffer allocator — destructors wouldn't match.
+            settle(g, view, entry.slot, true,
+                createBuffer(g, decoded->span()));
+            return;
+        }
+
+#if !OS(WINDOWS)
+        if (enc == ScreenshotEncoding::Shmem) {
+            // Create a fresh POSIX shm segment, write decoded bytes, return
+            // {name, size}. Caller (or Kitty via t=s) owns shm_unlink.
+            // Name uses our pid + a monotonic counter — same scheme as the
+            // WebKit child, different namespace (chrome- prefix) so they
+            // never collide even if someone mixes backends in one process.
+            static uint32_t shmSeq = 0;
+            char name[48];
+            snprintf(name, sizeof(name), "/bun-chrome-%d-%u", getpid(), ++shmSeq);
+            int fd = shm_open(name, O_CREAT | O_RDWR | O_EXCL, 0600);
+            if (fd < 0) {
+                settle(g, view, entry.slot, false,
+                    createError(g, makeString("shm_open: "_s, WTF::String::fromUTF8(strerror(errno)))));
+                return;
+            }
+            size_t sz = decoded->size();
+            if (ftruncate(fd, static_cast<off_t>(sz)) != 0) {
+                ::close(fd);
+                shm_unlink(name);
+                settle(g, view, entry.slot, false,
+                    createError(g, makeString("ftruncate: "_s, WTF::String::fromUTF8(strerror(errno)))));
+                return;
+            }
+            void* map = mmap(nullptr, sz, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+            ::close(fd);
+            if (map == MAP_FAILED) {
+                shm_unlink(name);
+                settle(g, view, entry.slot, false,
+                    createError(g, makeString("mmap: "_s, WTF::String::fromUTF8(strerror(errno)))));
+                return;
+            }
+            memcpy(map, decoded->span().data(), sz);
+            munmap(map, sz);
+            // Don't unlink — the name IS the return value. User (Kitty)
+            // unlinks after shm_open'ing.
+            auto* obj = constructEmptyObject(g);
+            obj->putDirect(vm, Identifier::fromString(vm, "name"_s),
+                jsString(vm, WTF::String::fromUTF8(
+                    std::span<const char>(name, strlen(name)))));
+            obj->putDirect(vm, Identifier::fromString(vm, "size"_s),
+                jsNumber(static_cast<double>(sz)));
+            settle(g, view, entry.slot, true, obj);
+            return;
+        }
+#endif
+
+        // Blob — the default. Blob__fromBytes copies via mimalloc
+        // (handleOom crashes on failure, no JS exception). m_screenshotFormat
+        // picks the MIME so `Bun.write(path, blob)` / `new Response(blob)`
+        // don't need the user to remember what format they asked for.
         void* impl = Blob__fromBytesWithType(g, decoded->span().data(), decoded->size(),
             screenshotMimeType(view->m_screenshotFormat));
-        JSValue blob = JSValue::decode(Blob__create(defaultGlobalObject(g), impl));
-        settle(g, view, entry.slot, true, blob);
+        settle(g, view, entry.slot, true,
+            JSValue::decode(Blob__create(defaultGlobalObject(g), impl)));
         return;
     }
 

--- a/src/bun.js/webview/ChromeBackend.cpp
+++ b/src/bun.js/webview/ChromeBackend.cpp
@@ -1385,6 +1385,7 @@ void close(JSWebView* view)
         settleSlot(g, view, view->m_pendingEval, false, err);
         settleSlot(g, view, view->m_pendingScreenshot, false, err);
         settleSlot(g, view, view->m_pendingMisc, false, err);
+        settleSlot(g, view, view->m_pendingCdp, false, err);
     }
     // Prune m_pending entries for this view — the attach chain
     // (TargetCreateTarget → TargetAttachToTarget → PageEnable →

--- a/src/bun.js/webview/ChromeBackend.cpp
+++ b/src/bun.js/webview/ChromeBackend.cpp
@@ -417,7 +417,8 @@ static void wsOnClose(void* ctx, unsigned short code)
         // m_wsPending survives — we replay it below after spawn. Don't
         // let ensureSpawned's m_dead-reset clear it.
         auto pending = std::exchange(t.m_wsPending, {});
-        if (t.ensureSpawned(t.m_global)) {
+        if (t.ensureSpawned(t.m_global, t.m_fallbackUserDataDir, {}, {},
+                t.m_fallbackStdoutInherit, t.m_fallbackStderrInherit)) {
             // Replay over the pipe. Same cancellation check as wsOnOpen
             // — skip ids close() already removed. Append the NUL
             // terminator the pipe protocol needs.
@@ -430,7 +431,10 @@ static void wsOnClose(void* ctx, unsigned short code)
             }
             return;
         }
-        // Spawn also failed — fall through to reject.
+        // Spawn also failed. ensureSpawned set m_dead before returning
+        // false; rejectAllAndMarkDead's guard would short-circuit and
+        // the pending promises would hang. Clear it so reject runs.
+        t.m_dead = false;
     }
 
     // rejectAllAndMarkDead settles every pending promise with an error.
@@ -439,7 +443,8 @@ static void wsOnClose(void* ctx, unsigned short code)
     t.rejectAllAndMarkDead(makeString("Chrome WebSocket closed (code "_s, code, ')'));
 }
 
-bool Transport::ensureConnected(Zig::GlobalObject* zig, const WTF::String& wsUrl, bool autoDetected)
+bool Transport::ensureConnected(Zig::GlobalObject* zig, const WTF::String& wsUrl, bool autoDetected,
+    const WTF::String& userDataDir, bool stdoutInherit, bool stderrInherit)
 {
     // Already connected — singleton semantics, first call wins.
     if (m_mode != TransportMode::None && !m_dead) return true;
@@ -454,6 +459,11 @@ bool Transport::ensureConnected(Zig::GlobalObject* zig, const WTF::String& wsUrl
     m_global = zig;
     m_mode = TransportMode::WebSocket;
     m_wasAutoDetected = autoDetected;
+    if (autoDetected) {
+        m_fallbackUserDataDir = userDataDir;
+        m_fallbackStdoutInherit = stdoutInherit;
+        m_fallbackStderrInherit = stderrInherit;
+    }
 
     auto* ctx = zig->scriptExecutionContext();
     auto result = WebCore::WebSocket::create(*ctx, wsUrl);

--- a/src/bun.js/webview/ChromeBackend.cpp
+++ b/src/bun.js/webview/ChromeBackend.cpp
@@ -680,9 +680,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         view->m_targetId = WTF::String::fromUTF8(tid);
         uint32_t cid = nextId();
         m_pending.add(cid, Pending { Method::TargetAttachToTarget, entry.slot, entry.viewId });
-        send(cid, Command(cid, "Target.attachToTarget"_s)
-                .str("targetId"_s, view->m_targetId)
-                .boolean("flatten"_s, true));
+        send(cid, Command(cid, "Target.attachToTarget"_s).str("targetId"_s, view->m_targetId).boolean("flatten"_s, true));
         return;
     }
     case Method::TargetAttachToTarget: {
@@ -721,8 +719,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         // response so errorText rejects the right slot.
         uint32_t cid = nextId();
         m_pending.add(cid, Pending { Method::PageNavigate, entry.slot, entry.viewId });
-        send(cid, Command(cid, "Page.navigate"_s, sidSpan)
-                .str("url"_s, view->m_pendingChromeNavigateUrl));
+        send(cid, Command(cid, "Page.navigate"_s, sidSpan).str("url"_s, view->m_pendingChromeNavigateUrl));
         view->m_pendingChromeNavigateUrl = WTF::String();
         return;
     }
@@ -789,8 +786,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         // Chain into navigateToHistoryEntry. Page.loadEventFired settles.
         uint32_t cid = nextId();
         m_pending.add(cid, Pending { Method::PageNavigateToHistoryEntry, entry.slot, entry.viewId });
-        send(cid, Command(cid, "Page.navigateToHistoryEntry"_s, sidSpan(view->m_sessionId))
-                .num("entryId"_s, entryId));
+        send(cid, Command(cid, "Page.navigateToHistoryEntry"_s, sidSpan(view->m_sessionId)).num("entryId"_s, entryId));
         return;
     }
     case Method::PageNavigateToHistoryEntry:
@@ -972,23 +968,11 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
 
         // Pressed — untracked fire-and-forget.
         uint32_t idDown = nextId();
-        send(0, Command(idDown, "Input.dispatchMouseEvent"_s, sid)
-                .raw("type"_s, "\"mousePressed\""_s)
-                .num("x"_s, cx)
-                .num("y"_s, cy)
-                .raw("button"_s, btn)
-                .num("clickCount"_s, static_cast<int32_t>(view->m_selClickCount))
-                .num("modifiers"_s, mods));
+        send(0, Command(idDown, "Input.dispatchMouseEvent"_s, sid).raw("type"_s, "\"mousePressed\""_s).num("x"_s, cx).num("y"_s, cy).raw("button"_s, btn).num("clickCount"_s, static_cast<int32_t>(view->m_selClickCount)).num("modifiers"_s, mods));
         // Released — tracked, resolves the slot.
         uint32_t idUp = nextId();
         m_pending.add(idUp, Pending { Method::InputDispatchMouseEvent, entry.slot, entry.viewId });
-        send(idUp, Command(idUp, "Input.dispatchMouseEvent"_s, sid)
-                .raw("type"_s, "\"mouseReleased\""_s)
-                .num("x"_s, cx)
-                .num("y"_s, cy)
-                .raw("button"_s, btn)
-                .num("clickCount"_s, static_cast<int32_t>(view->m_selClickCount))
-                .num("modifiers"_s, mods));
+        send(idUp, Command(idUp, "Input.dispatchMouseEvent"_s, sid).raw("type"_s, "\"mouseReleased\""_s).num("x"_s, cx).num("y"_s, cy).raw("button"_s, btn).num("clickCount"_s, static_cast<int32_t>(view->m_selClickCount)).num("modifiers"_s, mods));
         return;
     }
 
@@ -1079,9 +1063,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         view->m_loading = false;
         uint32_t tid = nextId();
         m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId });
-        send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId))
-                .str("expression"_s, "document.title"_s)
-                .boolean("returnByValue"_s, true));
+        send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId)).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true));
         return;
     }
 
@@ -1427,13 +1409,7 @@ JSPromise* click(JSGlobalObject* g, JSWebView* view, float x, float y, uint8_t b
     // Pressed — untracked. Chrome replies but we don't need the ack; the
     // Released event's reply confirms both were processed.
     uint32_t idDown = t.nextId();
-    t.send(0, Command(idDown, "Input.dispatchMouseEvent"_s, sid)
-            .raw("type"_s, "\"mousePressed\""_s)
-            .num("x"_s, x)
-            .num("y"_s, y)
-            .raw("button"_s, btn)
-            .num("clickCount"_s, static_cast<int32_t>(clickCount))
-            .num("modifiers"_s, mods));
+    t.send(0, Command(idDown, "Input.dispatchMouseEvent"_s, sid).raw("type"_s, "\"mousePressed\""_s).num("x"_s, x).num("y"_s, y).raw("button"_s, btn).num("clickCount"_s, static_cast<int32_t>(clickCount)).num("modifiers"_s, mods));
     // Released — tracked, resolves the promise.
     uint32_t idUp = t.nextId();
     return sendChromeOp(g, view, view->m_pendingMisc, PendingSlot::Misc,
@@ -1565,12 +1541,7 @@ JSPromise* press(JSGlobalObject* g, JSWebView* view, uint8_t key, uint8_t modifi
     // fired if text present) by the time we get the reply. No _doAfter*
     // dance like WKWebView's press().
     uint32_t idDown = t.nextId();
-    t.send(0, Command(idDown, "Input.dispatchKeyEvent"_s, sid)
-            .raw("type"_s, hasText ? "\"keyDown\""_s : "\"rawKeyDown\""_s)
-            .str("key"_s, keyStr)
-            .str("text"_s, textStr)
-            .num("windowsVirtualKeyCode"_s, info.vk)
-            .num("modifiers"_s, mods));
+    t.send(0, Command(idDown, "Input.dispatchKeyEvent"_s, sid).raw("type"_s, hasText ? "\"keyDown\""_s : "\"rawKeyDown\""_s).str("key"_s, keyStr).str("text"_s, textStr).num("windowsVirtualKeyCode"_s, info.vk).num("modifiers"_s, mods));
     // keyUp — tracked, resolves the promise.
     uint32_t idUp = t.nextId();
     return sendChromeOp(g, view, view->m_pendingMisc, PendingSlot::Misc,
@@ -1673,8 +1644,7 @@ void close(JSWebView* view)
     // earlier in the chain. Chrome tears down the tab; we ignore the
     // Target.targetDestroyed event. Erase sessionId so late events drop.
     if (!view->m_targetId.isEmpty()) {
-        t.send(0, Command(t.nextId(), "Target.closeTarget"_s)
-                .str("targetId"_s, view->m_targetId));
+        t.send(0, Command(t.nextId(), "Target.closeTarget"_s).str("targetId"_s, view->m_targetId));
     }
     if (!view->m_sessionId.isEmpty()) t.m_sessions.remove(view->m_sessionId);
     t.m_views.remove(view->m_viewId);

--- a/src/bun.js/webview/ChromeBackend.cpp
+++ b/src/bun.js/webview/ChromeBackend.cpp
@@ -5,6 +5,7 @@
 #include "ZigGlobalObject.h"
 #include "BunClientData.h"
 #include "ScriptExecutionContext.h"
+#include "BunString.h"
 #include "../bindings/webcore/WebSocket.h"
 #include <JavaScriptCore/ConsoleClient.h>
 #include <JavaScriptCore/ScriptArguments.h>
@@ -351,69 +352,53 @@ static void wsOnMessage(void* ctx, std::span<const char> utf8)
 static void wsOnClose(void* ctx, unsigned short code)
 {
     auto& t = *static_cast<Transport*>(ctx);
+    bool neverOpened = !t.m_wsOpen;
     t.m_wsOpen = false;
-    // rejectAllAndMarkDead settles every pending promise with an error
-    // and flips m_dead. If onOpen never fired (connect failure), the
-    // pending map holds the first navigate's Target.createTarget — it
-    // rejects with this message, surfacing the failure to the user.
-    t.rejectAllAndMarkDead(makeString("WebSocket closed (code "_s, code, ')'));
     t.m_ws = nullptr;
-}
 
-// Actually create the WebSocket and wire native callbacks. Called
-// directly by ensureConnected when the user passed a full ws:// URL, or
-// by onDiscovered after /json/version resolves the ws:// URL for a bare
-// host:port.
-static void connectWebSocket(Transport& t, Zig::GlobalObject* zig, const WTF::String& wsUrl)
-{
-    auto* ctx = zig->scriptExecutionContext();
-    auto result = WebCore::WebSocket::create(*ctx, wsUrl);
-    if (result.hasException()) {
-        t.rejectAllAndMarkDead("invalid WebSocket URL"_s);
-        return;
+    // Stale-file fallback: if we auto-detected (read DevToolsActivePort
+    // ourselves, user didn't ask for WS) AND the connect never opened
+    // (stale port/path from a dead Chrome), fall back to spawn. The
+    // pending commands re-send over the pipe. If onOpen DID fire, the
+    // user's Chrome was reachable and now isn't — that's a real error
+    // (user killed Chrome, dialog dismissed, etc.), surface it.
+    //
+    // m_wsPending holds the Command bodies as WTF::Strings. Those are
+    // pipe-safe (the pipe also carries UTF-8 JSON, just NUL-delimited).
+    // ensureSpawned sets m_mode = Pipe; send() routes to writeRaw; the
+    // first spawn's onOpen path (socket adoption) drains the same way.
+    // But m_wsPending stores the NON-NUL-terminated body. The pipe needs
+    // the NUL. We write each body + NUL manually after spawn.
+    if (t.m_wasAutoDetected && neverOpened) {
+        t.m_mode = TransportMode::None;
+        t.m_wasAutoDetected = false;
+        // m_wsPending survives — we replay it below after spawn. Don't
+        // let ensureSpawned's m_dead-reset clear it.
+        auto pending = std::exchange(t.m_wsPending, {});
+        if (t.ensureSpawned(t.m_global)) {
+            // Replay queued commands over the pipe. Each body is a
+            // complete CDP JSON; append the NUL terminator the pipe
+            // protocol needs.
+            for (auto& body : pending) {
+                Bun::UTF8View view(body);
+                auto s = view.span();
+                t.writeRaw(s.data(), s.size());
+                t.writeRaw("\0", 1);
+            }
+            return;
+        }
+        // Spawn also failed — fall through to reject.
     }
-    t.m_ws = result.releaseReturnValue();
-    // setNativeCallbacks swaps the MessageEvent/dispatchEvent path for
-    // direct C++ calls BEFORE the upgrade kicks off — if we raced the
-    // handshake completing and a message arriving, the normal path
-    // would dispatch via EventTarget (empty listener map, silently
-    // dropped). Setting first is safe: create() queues the connect on
-    // the event loop, it can't fire before this function returns.
-    t.m_ws->setNativeCallbacks({
-        .ctx = &t,
-        .onOpen = wsOnOpen,
-        .onMessage = wsOnMessage,
-        .onClose = wsOnClose,
-    });
+
+    // rejectAllAndMarkDead settles every pending promise with an error.
+    // If onOpen never fired (connect failure), m_pending holds the first
+    // navigate's Target.createTarget — it rejects with this message.
+    t.rejectAllAndMarkDead(makeString("Chrome WebSocket closed (code "_s, code, ')'));
 }
 
-// Zig calls these on the JS thread after DiscoverTask (AsyncHTTP GET
-// /json/version) completes. onDiscovered gets the extracted ws:// URL;
-// onDiscoverFailed fires for connect-refused, timeout, non-200, or
-// missing field. Both paths already have the JS thread's usockets
-// context so WebSocket::create is safe here.
-extern "C" void Bun__CDPTransport__onDiscovered(Zig::GlobalObject* g, const char* url, size_t len)
+bool Transport::ensureConnected(Zig::GlobalObject* zig, const WTF::String& wsUrl, bool autoDetected)
 {
-    auto& t = transport();
-    if (t.m_dead) return; // user called closeAll during discovery
-    connectWebSocket(t, g, WTF::String::fromUTF8(std::span<const char>(url, len)));
-}
-
-extern "C" void Bun__CDPTransport__onDiscoverFailed(Zig::GlobalObject*)
-{
-    transport().rejectAllAndMarkDead(
-        "Chrome discovery failed: GET /json/version unreachable or malformed. "
-        "Check the port and that Remote Debugging is enabled (chrome://inspect/#remote-debugging)."_s);
-}
-
-// From ChromeProcess.zig — async GET /json/version on the HTTP thread,
-// calls back via Bun__CDPTransport__onDiscovered on the JS thread.
-extern "C" void Bun__Chrome__discover(Zig::GlobalObject*, const char* input, size_t len);
-
-bool Transport::ensureConnected(Zig::GlobalObject* zig, const WTF::String& url)
-{
-    // Already connected (or connecting/discovering) — singleton
-    // semantics, first call wins.
+    // Already connected — singleton semantics, first call wins.
     if (m_mode != TransportMode::None && !m_dead) return true;
     if (m_dead) {
         m_dead = false;
@@ -425,18 +410,27 @@ bool Transport::ensureConnected(Zig::GlobalObject* zig, const WTF::String& url)
     }
     m_global = zig;
     m_mode = TransportMode::WebSocket;
+    m_wasAutoDetected = autoDetected;
 
-    // Full ws:// URL → connect directly. Bare host:port or http:// →
-    // async GET /json/version to discover the ws:// URL, then
-    // onDiscovered does the connect. Commands queue in m_wsPending
-    // either way (they drain in wsOnOpen regardless of which path got
-    // us there).
-    if (url.startsWith("ws://"_s) || url.startsWith("wss://"_s)) {
-        connectWebSocket(*this, zig, url);
-    } else {
-        auto utf8 = url.utf8();
-        Bun__Chrome__discover(zig, utf8.data(), utf8.length());
+    auto* ctx = zig->scriptExecutionContext();
+    auto result = WebCore::WebSocket::create(*ctx, wsUrl);
+    if (result.hasException()) {
+        m_dead = true;
+        m_mode = TransportMode::None;
+        return false;
     }
+    m_ws = result.releaseReturnValue();
+    // setNativeCallbacks swaps the MessageEvent/dispatchEvent path for
+    // direct C++ calls BEFORE the upgrade completes — handshake is async
+    // (queued on the event loop, can't fire before this returns). If we
+    // raced, the normal path would dispatch via EventTarget into an
+    // empty listener map and the message would silently drop.
+    m_ws->setNativeCallbacks({
+        .ctx = this,
+        .onOpen = wsOnOpen,
+        .onMessage = wsOnMessage,
+        .onClose = wsOnClose,
+    });
     return true;
 }
 
@@ -1233,6 +1227,26 @@ void Transport::updateKeepAlive()
     m_sockRefd = want;
     Bun__eventLoop__incrementRefConcurrently(
         WebCore::clientData(m_global->vm())->bunVM, want ? 1 : -1);
+
+    // WebSocket mode: close the connection when the last view is gone.
+    // We're connected to the USER'S Chrome — keeping the WS open after
+    // they're done holds a DevTools session (shows "<Bun> is debugging
+    // this browser" in Chrome's UI). Pipe mode keeps the subprocess
+    // alive (it's OURS), but the user's Chrome should be released.
+    //
+    // m_mode reset to None means the next `new Bun.WebView()` re-runs
+    // auto-detect → reconnect (pops the Allow dialog again, which is
+    // correct — it's a new session). The close handshake is async but
+    // we don't wait; setNativeCallbacks({}) prevents wsOnClose from
+    // re-entering rejectAllAndMarkDead on the ack.
+    if (!want && m_mode == TransportMode::WebSocket && m_ws) {
+        auto ws = std::exchange(m_ws, nullptr);
+        ws->setNativeCallbacks({});
+        ws->close(std::nullopt, WTF::String());
+        m_wsOpen = false;
+        m_wasAutoDetected = false;
+        m_mode = TransportMode::None;
+    }
 }
 
 // --- CDP::Ops --------------------------------------------------------------

--- a/src/bun.js/webview/ChromeBackend.cpp
+++ b/src/bun.js/webview/ChromeBackend.cpp
@@ -395,6 +395,7 @@ static void wsOnClose(void* ctx, unsigned short code)
 {
     auto& t = *static_cast<Transport*>(ctx);
     bool neverOpened = !t.m_wsOpen;
+    bool wasAutoDetected = std::exchange(t.m_wasAutoDetected, false);
     t.m_wsOpen = false;
     t.m_ws = nullptr;
 
@@ -411,9 +412,8 @@ static void wsOnClose(void* ctx, unsigned short code)
     // first spawn's onOpen path (socket adoption) drains the same way.
     // But m_wsPending stores the NON-NUL-terminated body. The pipe needs
     // the NUL. We write each body + NUL manually after spawn.
-    if (t.m_wasAutoDetected && neverOpened) {
+    if (wasAutoDetected && neverOpened) {
         t.m_mode = TransportMode::None;
-        t.m_wasAutoDetected = false;
         // m_wsPending survives — we replay it below after spawn. Don't
         // let ensureSpawned's m_dead-reset clear it.
         auto pending = std::exchange(t.m_wsPending, {});

--- a/src/bun.js/webview/ChromeBackend.cpp
+++ b/src/bun.js/webview/ChromeBackend.cpp
@@ -4,6 +4,8 @@
 #include "ipc_protocol.h"
 #include "ZigGlobalObject.h"
 #include "BunClientData.h"
+#include "ScriptExecutionContext.h"
+#include "../bindings/webcore/WebSocket.h"
 #include <JavaScriptCore/ConsoleClient.h>
 #include <JavaScriptCore/ScriptArguments.h>
 #include <JavaScriptCore/Strong.h>
@@ -230,13 +232,14 @@ bool Transport::ensureSpawned(Zig::GlobalObject* zig, const WTF::String& userDat
     const WTF::String& path, const WTF::Vector<WTF::String>& extraArgv,
     bool stdoutInherit, bool stderrInherit)
 {
-    if (m_readSock && !m_dead) return true;
+    if (m_mode != TransportMode::None && !m_dead) return true;
     if (m_dead) {
         m_dead = false;
         m_readSock = nullptr;
         m_rx.clear();
         m_txQueue.clear();
     }
+    m_mode = TransportMode::Pipe;
 
     // Empty string ≠ null. WTF::String() utf8's to an empty CString (not
     // isNull), which on the Zig side passes "" into --user-data-dir= and
@@ -294,7 +297,147 @@ bool Transport::ensureSpawned(Zig::GlobalObject* zig, const WTF::String& userDat
 
 void Transport::send(Command&& cmd)
 {
+    if (m_mode == TransportMode::WebSocket) {
+        // WS text frame per CDP message — the framing IS the delimiter.
+        // If the handshake hasn't completed, queue; wsOnOpen drains.
+        // sendTextNative is a no-op when m_state != OPEN, so we MUST
+        // queue here or commands silently drop.
+        auto body = cmd.finishToString();
+        if (m_wsOpen) {
+            m_ws->sendTextNative(body);
+        } else {
+            m_wsPending.append(WTF::move(body));
+        }
+        return;
+    }
     cmd.finishAndWrite([this](const char* d, size_t n) { writeRaw(d, n); });
+}
+
+// --- WebSocket transport ----------------------------------------------------
+// Native-callback trampolines. Plain C function pointers (not capturing
+// lambdas) — the ctx arg is the Transport* singleton. Zig's CppWebSocket
+// wrapper already does eventLoop.enter()/exit() around the extern "C"
+// call, so any JS these end up running (settle → resolve → .then()) is
+// already in the right execution context.
+
+static void wsOnOpen(void* ctx)
+{
+    auto& t = *static_cast<Transport*>(ctx);
+    t.m_wsOpen = true;
+    // Drain commands queued during the handshake. The first navigate()
+    // kicks off Target.createTarget before onOpen fires; those frames
+    // sat in m_wsPending until now.
+    for (auto& body : t.m_wsPending)
+        t.m_ws->sendTextNative(body);
+    t.m_wsPending.clear();
+}
+
+static void wsOnMessage(void* ctx, std::span<const char> utf8)
+{
+    auto& t = *static_cast<Transport*>(ctx);
+    // One text frame = one CDP message. handleMessage is mode-agnostic
+    // — same JSON parsing as the pipe's NUL-delimited frames. The span
+    // is valid until this callback returns (UTF8View's storage on the
+    // caller's stack); handleMessage doesn't stash it.
+    auto& vm = t.m_global->vm();
+    auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    t.handleMessage(utf8);
+    if (auto* ex = catchScope.exception()) [[unlikely]] {
+        catchScope.clearExceptionExceptTermination();
+        t.m_global->reportUncaughtExceptionAtEventLoop(t.m_global, ex);
+    }
+}
+
+static void wsOnClose(void* ctx, unsigned short code)
+{
+    auto& t = *static_cast<Transport*>(ctx);
+    t.m_wsOpen = false;
+    // rejectAllAndMarkDead settles every pending promise with an error
+    // and flips m_dead. If onOpen never fired (connect failure), the
+    // pending map holds the first navigate's Target.createTarget — it
+    // rejects with this message, surfacing the failure to the user.
+    t.rejectAllAndMarkDead(makeString("WebSocket closed (code "_s, code, ')'));
+    t.m_ws = nullptr;
+}
+
+// Actually create the WebSocket and wire native callbacks. Called
+// directly by ensureConnected when the user passed a full ws:// URL, or
+// by onDiscovered after /json/version resolves the ws:// URL for a bare
+// host:port.
+static void connectWebSocket(Transport& t, Zig::GlobalObject* zig, const WTF::String& wsUrl)
+{
+    auto* ctx = zig->scriptExecutionContext();
+    auto result = WebCore::WebSocket::create(*ctx, wsUrl);
+    if (result.hasException()) {
+        t.rejectAllAndMarkDead("invalid WebSocket URL"_s);
+        return;
+    }
+    t.m_ws = result.releaseReturnValue();
+    // setNativeCallbacks swaps the MessageEvent/dispatchEvent path for
+    // direct C++ calls BEFORE the upgrade kicks off — if we raced the
+    // handshake completing and a message arriving, the normal path
+    // would dispatch via EventTarget (empty listener map, silently
+    // dropped). Setting first is safe: create() queues the connect on
+    // the event loop, it can't fire before this function returns.
+    t.m_ws->setNativeCallbacks({
+        .ctx = &t,
+        .onOpen = wsOnOpen,
+        .onMessage = wsOnMessage,
+        .onClose = wsOnClose,
+    });
+}
+
+// Zig calls these on the JS thread after DiscoverTask (AsyncHTTP GET
+// /json/version) completes. onDiscovered gets the extracted ws:// URL;
+// onDiscoverFailed fires for connect-refused, timeout, non-200, or
+// missing field. Both paths already have the JS thread's usockets
+// context so WebSocket::create is safe here.
+extern "C" void Bun__CDPTransport__onDiscovered(Zig::GlobalObject* g, const char* url, size_t len)
+{
+    auto& t = transport();
+    if (t.m_dead) return; // user called closeAll during discovery
+    connectWebSocket(t, g, WTF::String::fromUTF8(std::span<const char>(url, len)));
+}
+
+extern "C" void Bun__CDPTransport__onDiscoverFailed(Zig::GlobalObject*)
+{
+    transport().rejectAllAndMarkDead(
+        "Chrome discovery failed: GET /json/version unreachable or malformed. "
+        "Check the port and that Remote Debugging is enabled (chrome://inspect/#remote-debugging)."_s);
+}
+
+// From ChromeProcess.zig — async GET /json/version on the HTTP thread,
+// calls back via Bun__CDPTransport__onDiscovered on the JS thread.
+extern "C" void Bun__Chrome__discover(Zig::GlobalObject*, const char* input, size_t len);
+
+bool Transport::ensureConnected(Zig::GlobalObject* zig, const WTF::String& url)
+{
+    // Already connected (or connecting/discovering) — singleton
+    // semantics, first call wins.
+    if (m_mode != TransportMode::None && !m_dead) return true;
+    if (m_dead) {
+        m_dead = false;
+        m_ws = nullptr;
+        m_wsOpen = false;
+        m_wsPending.clear();
+        m_rx.clear();
+        m_txQueue.clear();
+    }
+    m_global = zig;
+    m_mode = TransportMode::WebSocket;
+
+    // Full ws:// URL → connect directly. Bare host:port or http:// →
+    // async GET /json/version to discover the ws:// URL, then
+    // onDiscovered does the connect. Commands queue in m_wsPending
+    // either way (they drain in wsOnOpen regardless of which path got
+    // us there).
+    if (url.startsWith("ws://"_s) || url.startsWith("wss://"_s)) {
+        connectWebSocket(*this, zig, url);
+    } else {
+        auto utf8 = url.utf8();
+        Bun__Chrome__discover(zig, utf8.data(), utf8.length());
+    }
+    return true;
 }
 
 // us_socket_write through usockets' own write path — it sets
@@ -1056,6 +1199,19 @@ void Transport::rejectAllAndMarkDead(const WTF::String& reason)
     // synchronously; the m_dead guard above short-circuits that reentrant
     // call so the caller's `reason` survives.
     if (auto* s = std::exchange(m_readSock, nullptr)) us_socket_close(0, s, 0, nullptr);
+    // WebSocket mode: drop our ref. The WS's native onClose calls us
+    // (wsOnClose → rejectAllAndMarkDead); that path nulls m_ws after
+    // this returns. If WE'RE initiating (closeAll), close() kicks off the
+    // closing handshake; we don't wait for it, just drop. The m_dead
+    // guard prevents wsOnClose from re-entering.
+    if (m_ws) {
+        auto ws = std::exchange(m_ws, nullptr);
+        ws->setNativeCallbacks({}); // prevent wsOnClose re-entry
+        ws->close(std::nullopt, WTF::String());
+    }
+    m_mode = TransportMode::None;
+    m_wsOpen = false;
+    m_wsPending.clear();
     if (!m_global) return;
     auto* g = m_global;
     JSValue err = createError(g, reason);
@@ -1101,8 +1257,12 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
     auto& vm = g->vm();
     auto& t = transport();
     auto* promise = JSPromise::create(vm, g->promiseStructure());
-    if (t.m_dead || !t.m_readSock) {
-        promise->reject(vm, g, createError(g, "Chrome process is not running"_s));
+    // m_mode == None means neither ensureSpawned nor ensureConnected ran
+    // (constructor already called one, so this is unreachable unless
+    // rejectAllAndMarkDead reset it). WebSocket mode doesn't need
+    // m_wsOpen here — send() queues until onOpen fires.
+    if (t.m_dead || t.m_mode == TransportMode::None) {
+        promise->reject(vm, g, createError(g, "Chrome connection is not available"_s));
         return promise;
     }
     v->m_pendingActivityCount.fetch_add(1, std::memory_order_release);

--- a/src/bun.js/webview/ChromeBackend.cpp
+++ b/src/bun.js/webview/ChromeBackend.cpp
@@ -432,6 +432,8 @@ static WriteBarrier<JSPromise>& slotFor(JSWebView* view, PendingSlot s)
         return view->m_pendingScreenshot;
     case PendingSlot::Misc:
         return view->m_pendingMisc;
+    case PendingSlot::Cdp:
+        return view->m_pendingCdp;
     }
     ASSERT_NOT_REACHED();
     return view->m_pendingMisc;
@@ -770,6 +772,18 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
                 .num("modifiers"_s, mods));
         return;
     }
+
+    case Method::UserRaw: {
+        // User-supplied raw command via view.cdp(). result is the verbatim
+        // CDP result object JSON; JSONParse it into a JSValue so the user
+        // gets the same object shape CDP documents. The error path is
+        // handled earlier in this function (error span non-empty → reject
+        // with createError). Some CDP methods legitimately return `{}`
+        // (Input.*, Page.reload) — JSONParse gives an empty JSObject.
+        JSValue v = JSONParse(g, WTF::String::fromUTF8(result));
+        settle(g, view, entry.slot, true, v ? v : jsUndefined());
+        return;
+    }
     }
 }
 
@@ -795,7 +809,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         if (!view) return;
         // Reject all pending slots. settle() is idempotent on empty slots.
         auto* err = createError(g, "page detached (crashed or closed)"_s);
-        for (auto s : { PendingSlot::Navigate, PendingSlot::Evaluate, PendingSlot::Screenshot, PendingSlot::Misc })
+        for (auto s : { PendingSlot::Navigate, PendingSlot::Evaluate, PendingSlot::Screenshot, PendingSlot::Misc, PendingSlot::Cdp })
             settle(g, view, s, false, err);
         // Erase stale m_pending entries — replies won't come.
         m_pending.removeIf([&](auto& kv) { return kv.value.view.get() == view; });
@@ -1080,6 +1094,29 @@ JSPromise* evaluate(JSGlobalObject* g, JSWebView* view, const WTF::String& scrip
             .str("expression"_s, body)
             .boolean("returnByValue"_s, true)
             .boolean("awaitPromise"_s, true));
+}
+
+// Raw CDP escape hatch. method is the domain-qualified name
+// ("Page.captureScreenshot", "DOM.querySelector", etc.); paramsJson is the
+// output of JSON.stringify(params) — a well-formed JSON object or "{}".
+// The Command::RawTag constructor passes both through: method gets
+// appendQuotedJSONString (it's user input, could have a stray quote),
+// paramsJson is inserted verbatim (JSON.stringify guarantees well-formed).
+// Response handler JSONParse's the result object and settles with the
+// decoded JSValue — caller gets the same object shape CDP documents.
+//
+// Scoped to the view's sessionId, so commands target THIS tab. Browser-
+// level commands (Target.*, Browser.*) need the sessionId omitted —
+// if m_sessionId is empty (first-navigate chain not yet complete) we send
+// browser-level. For explicit browser-level after attach, the user can
+// construct a second WebView or await Bun-side Target APIs (v2).
+JSPromise* cdp(JSGlobalObject* g, JSWebView* view, const WTF::String& method, const WTF::String& paramsJson)
+{
+    auto& t = transport();
+    uint32_t id = t.nextId();
+    return sendChromeOp(g, view, view->m_pendingCdp, PendingSlot::Cdp,
+        Method::UserRaw, id,
+        Command(Command::RawTag {}, id, method, sidSpan(view->m_sessionId), paramsJson));
 }
 
 JSPromise* screenshot(JSGlobalObject* g, JSWebView* view, ScreenshotFormat format, uint8_t quality)

--- a/src/bun.js/webview/ChromeBackend.h
+++ b/src/bun.js/webview/ChromeBackend.h
@@ -378,14 +378,17 @@ public:
         const WTF::String& path = {}, const WTF::Vector<WTF::String>& extraArgv = {},
         bool stdoutInherit = false, bool stderrInherit = false);
 
-    // Connect to an already-running Chrome's DevTools endpoint. url is
-    // the full WebSocket URL (ws://127.0.0.1:9222/devtools/browser/<id>
-    // — from GET /json/version's webSocketDebuggerUrl field). Same
-    // singleton semantics as ensureSpawned: first call wins, subsequent
-    // calls with a different URL no-op. Returns false if the connect
-    // throws synchronously (malformed URL); actual connection failure
-    // arrives via onClose → rejectAllAndMarkDead.
-    bool ensureConnected(Zig::GlobalObject*, const WTF::String& wsUrl);
+    // Connect to an already-running Chrome's DevTools endpoint. wsUrl is
+    // a full ws:// URL (from DevToolsActivePort or user-supplied). Same
+    // singleton semantics as ensureSpawned: first call wins.
+    //
+    // autoDetected=true means we read DevToolsActivePort ourselves and
+    // the user didn't explicitly ask for WS mode — if the connect fails
+    // (stale file: Chrome crashed/restarted), wsOnClose falls back to
+    // ensureSpawned instead of rejecting the user's promise with a
+    // confusing WebSocket error. autoDetected=false means explicit
+    // backend.url; connect failure surfaces directly.
+    bool ensureConnected(Zig::GlobalObject*, const WTF::String& wsUrl, bool autoDetected);
 
     // Next CDP id — caller uses it with Command(id, ...) then calls send().
     uint32_t nextId() { return m_nextId++; }
@@ -414,6 +417,10 @@ public:
     // sendTextNative until m_state == OPEN. Drained in wsOnOpen.
     WTF::Vector<WTF::String> m_wsPending;
     bool m_wsOpen = false;
+    // True when ensureConnected was called from auto-detect (the
+    // constructor read DevToolsActivePort) — gates the stale-file
+    // fallback in wsOnClose. False for explicit backend.url.
+    bool m_wasAutoDetected = false;
     bool m_dead = false;
 
     uint32_t m_nextId = 1;

--- a/src/bun.js/webview/ChromeBackend.h
+++ b/src/bun.js/webview/ChromeBackend.h
@@ -34,6 +34,10 @@ namespace Zig {
 class GlobalObject;
 }
 
+namespace WebCore {
+class WebSocket;
+}
+
 namespace Bun {
 
 class JSWebView;
@@ -170,6 +174,18 @@ public:
     // The trailing NUL frame delimiter: we write sink(body, len) then
     // sink("\0", 1). Two syscalls in the best case; a writev would be
     // one, but the pipe buffer coalesces anyway.
+    // WebSocket mode: return the JSON body as a WTF::String for
+    // WebSocket::sendTextNative. No NUL terminator — WS text-frame
+    // framing IS the delimiter. toString() moves the builder's buffer
+    // into the String if nothing else holds a ref — zero-copy for the
+    // 8-bit-ASCII case (our templates are ASCII, user strings go
+    // through appendQuotedJSONString which produces ASCII escapes).
+    WTF::String finishToString()
+    {
+        m_sb.append(m_paramsRaw ? "}"_s : "}}"_s);
+        return m_sb.toString();
+    }
+
     template<typename Sink> // void(const char*, size_t)
     void finishAndWrite(Sink&& sink)
     {
@@ -332,6 +348,23 @@ struct Pending {
     JSC::Weak<JSWebView> view;
 };
 
+// Transport mode. Pipe = we spawned Chrome with --remote-debugging-pipe,
+// socketpair bidi fd, NUL-delimited JSON frames. WebSocket = connect to an
+// already-running Chrome's /devtools/browser endpoint over ws://, one JSON
+// message per text frame (WS framing IS the delimiter).
+//
+// WebSocket mode reuses WebCore::WebSocket in native-callback mode — no
+// MessageEvent, no dispatchEvent, no postTask deferral. The onMessage
+// callback calls handleMessage directly with the text frame's UTF-8 bytes.
+// handleMessage/handleResponse/handleEvent are mode-agnostic — they take
+// std::span<const char> and don't care whether it came from a NUL-scan or
+// a WS frame.
+enum class TransportMode : uint8_t {
+    None, // not yet initialized
+    Pipe, // spawned Chrome, socketpair
+    WebSocket, // existing Chrome, ws://
+};
+
 class Transport {
 public:
     // Lazy-spawn Chrome. Returns false on spawn failure; caller throws.
@@ -344,6 +377,15 @@ public:
     bool ensureSpawned(Zig::GlobalObject*, const WTF::String& userDataDir = {},
         const WTF::String& path = {}, const WTF::Vector<WTF::String>& extraArgv = {},
         bool stdoutInherit = false, bool stderrInherit = false);
+
+    // Connect to an already-running Chrome's DevTools endpoint. url is
+    // the full WebSocket URL (ws://127.0.0.1:9222/devtools/browser/<id>
+    // — from GET /json/version's webSocketDebuggerUrl field). Same
+    // singleton semantics as ensureSpawned: first call wins, subsequent
+    // calls with a different URL no-op. Returns false if the connect
+    // throws synchronously (malformed URL); actual connection failure
+    // arrives via onClose → rejectAllAndMarkDead.
+    bool ensureConnected(Zig::GlobalObject*, const WTF::String& wsUrl);
 
     // Next CDP id — caller uses it with Command(id, ...) then calls send().
     uint32_t nextId() { return m_nextId++; }
@@ -359,7 +401,19 @@ public:
     void onClose();
 
     Zig::GlobalObject* m_global = nullptr;
+    TransportMode m_mode = TransportMode::None;
+    // Pipe mode: usockets-adopted socketpair fd.
     us_socket_t* m_readSock = nullptr;
+    // WebSocket mode: RefPtr keeps the WebCore::WebSocket alive across
+    // the singleton's lifetime. The WebSocket's native callbacks point
+    // back at this Transport (via static trampolines, not a captured
+    // lambda — the callbacks are plain C function pointers).
+    RefPtr<WebCore::WebSocket> m_ws;
+    // Commands queued while the WS handshake is in flight. The first
+    // navigate() on a view runs before onOpen fires; we can't
+    // sendTextNative until m_state == OPEN. Drained in wsOnOpen.
+    WTF::Vector<WTF::String> m_wsPending;
+    bool m_wsOpen = false;
     bool m_dead = false;
 
     uint32_t m_nextId = 1;

--- a/src/bun.js/webview/ChromeBackend.h
+++ b/src/bun.js/webview/ChromeBackend.h
@@ -84,6 +84,36 @@ public:
         m_sb.append(",\"params\":{"_s);
     }
 
+    // Raw passthrough — user-provided method string and pre-serialized
+    // params JSON (JSON.stringify on the JS side; arrives here as UTF-8).
+    // method goes through appendQuotedJSONString (a user can pass
+    // `Page.navigate"` with a stray quote — the method string IS user input
+    // for this entry point). paramsJson is trusted JSON — it came from
+    // JSON.stringify which guarantees well-formed output. The builder's
+    // finishAndWrite appends the closing }} so paramsJson must be the inner
+    // object without the outer braces; we write it verbatim and skip the
+    // normal str()/num() comma machinery.
+    struct RawTag {};
+    Command(RawTag, uint32_t id, const WTF::String& method, std::span<const char> sessionId, const WTF::String& paramsJson)
+    {
+        m_sb.append("{\"id\":"_s, id, ",\"method\":"_s);
+        m_sb.appendQuotedJSONString(method);
+        if (!sessionId.empty()) {
+            m_sb.append(",\"sessionId\":\""_s);
+            m_sb.append(std::span<const Latin1Character>(
+                reinterpret_cast<const Latin1Character*>(sessionId.data()), sessionId.size()));
+            m_sb.append('"');
+        }
+        // paramsJson is an object or {} — the user passed `params` or
+        // nothing. JSON.stringify already handled escapes/encoding. We
+        // write `,"params":` then the verbatim JSON, then cheat: set
+        // m_paramsRaw so finishAndWrite appends a single } (the frame
+        // close) instead of }} (frame close + our implicit params brace).
+        m_sb.append(",\"params\":"_s);
+        m_sb.append(paramsJson);
+        m_paramsRaw = true;
+    }
+
     // Named string param. appendQuotedJSONString adds the quotes + escapes.
     // Rvalue-ref-qualified returns Command&& so chaining on a temporary
     // (the usual `send(Command(...).str(...).num(...))` pattern) stays an
@@ -143,7 +173,10 @@ public:
     template<typename Sink> // void(const char*, size_t)
     void finishAndWrite(Sink&& sink)
     {
-        m_sb.append("}}"_s);
+        // RawTag constructor already wrote the complete params object;
+        // only the outer frame brace remains. Normal path needs both the
+        // params brace and the frame brace.
+        m_sb.append(m_paramsRaw ? "}"_s : "}}"_s);
         if (m_sb.is8Bit()) [[likely]] {
             auto s = m_sb.span8();
             // OR-accumulate: all bytes < 0x80 → no high bit → valid ASCII.
@@ -172,6 +205,7 @@ private:
 
     WTF::StringBuilder m_sb;
     bool m_hasParam = false;
+    bool m_paramsRaw = false;
 };
 
 // --- Method tags -----------------------------------------------------------
@@ -215,6 +249,11 @@ enum class Method : uint8_t {
     // block.
     ClickSelectorEval, // actionability → "cx,cy" → dispatchMouseEvent
     ScrollToSelectorEval, // scrollIntoView ran page-side → settle
+    // User-supplied raw command via view.cdp(method, params). Response
+    // handler runs the result/error JSON through JSC's JSONParse and
+    // settles the promise with the decoded JSValue — caller gets the
+    // same object shape CDP documents.
+    UserRaw,
 };
 
 // Shared actionability/scrollTo JS — same predicate as WKWebView's
@@ -281,6 +320,10 @@ enum class PendingSlot : uint8_t {
     Evaluate,
     Screenshot,
     Misc,
+    // Raw view.cdp() escape hatch. Separate slot so it doesn't block
+    // resize/goBack/etc. Still one-at-a-time (slot model, not id-keyed
+    // promise map) — lift in v2 when/if someone needs burst CDP.
+    Cdp,
 };
 
 struct Pending {
@@ -360,6 +403,10 @@ JSC::JSPromise* resize(JSC::JSGlobalObject*, JSWebView*, uint32_t width, uint32_
 JSC::JSPromise* goBack(JSC::JSGlobalObject*, JSWebView*);
 JSC::JSPromise* goForward(JSC::JSGlobalObject*, JSWebView*);
 JSC::JSPromise* reload(JSC::JSGlobalObject*, JSWebView*);
+// paramsJson is the output of JSON.stringify(params) — a well-formed JSON
+// object string, or "{}" if the user passed nothing. method is the CDP
+// domain-qualified name ("Page.captureScreenshot" etc.).
+JSC::JSPromise* cdp(JSC::JSGlobalObject*, JSWebView*, const WTF::String& method, const WTF::String& paramsJson);
 void close(JSWebView*);
 
 } // namespace Ops

--- a/src/bun.js/webview/ChromeBackend.h
+++ b/src/bun.js/webview/ChromeBackend.h
@@ -386,13 +386,20 @@ public:
     // a full ws:// URL (from DevToolsActivePort or user-supplied). Same
     // singleton semantics as ensureSpawned: first call wins.
     //
+    // When autoDetected=true, the trailing spawn args are stashed for
+    // the wsOnClose fallback (stale-file → spawn). createChrome only
+    // takes the auto-detect branch when path/argv are empty, so those
+    // aren't carried. When autoDetected=false (explicit backend.url),
+    // there's no fallback and the args are ignored.
+    //
     // autoDetected=true means we read DevToolsActivePort ourselves and
     // the user didn't explicitly ask for WS mode — if the connect fails
     // (stale file: Chrome crashed/restarted), wsOnClose falls back to
     // ensureSpawned instead of rejecting the user's promise with a
     // confusing WebSocket error. autoDetected=false means explicit
     // backend.url; connect failure surfaces directly.
-    bool ensureConnected(Zig::GlobalObject*, const WTF::String& wsUrl, bool autoDetected);
+    bool ensureConnected(Zig::GlobalObject*, const WTF::String& wsUrl, bool autoDetected,
+        const WTF::String& userDataDir = {}, bool stdoutInherit = false, bool stderrInherit = false);
 
     // Next CDP id — caller uses it with Command(id, ...) then calls send().
     uint32_t nextId() { return m_nextId++; }
@@ -436,6 +443,13 @@ public:
     // constructor read DevToolsActivePort) — gates the stale-file
     // fallback in wsOnClose. False for explicit backend.url.
     bool m_wasAutoDetected = false;
+    // Stashed for the wsOnClose fallback spawn. Auto-detect only runs
+    // when path/argv are empty (createChrome branches to spawn-mode
+    // otherwise), so userDataDir + stdio are the only carry-over. Set in
+    // ensureConnected when autoDetected=true.
+    WTF::String m_fallbackUserDataDir;
+    bool m_fallbackStdoutInherit = false;
+    bool m_fallbackStderrInherit = false;
     bool m_dead = false;
 
     uint32_t m_nextId = 1;

--- a/src/bun.js/webview/ChromeBackend.h
+++ b/src/bun.js/webview/ChromeBackend.h
@@ -37,6 +37,7 @@ class GlobalObject;
 namespace Bun {
 
 class JSWebView;
+enum class ScreenshotFormat : uint8_t;
 
 namespace CDP {
 
@@ -348,7 +349,7 @@ namespace Ops {
 
 JSC::JSPromise* navigate(JSC::JSGlobalObject*, JSWebView*, const WTF::String& url);
 JSC::JSPromise* evaluate(JSC::JSGlobalObject*, JSWebView*, const WTF::String& script);
-JSC::JSPromise* screenshot(JSC::JSGlobalObject*, JSWebView*);
+JSC::JSPromise* screenshot(JSC::JSGlobalObject*, JSWebView*, ScreenshotFormat, uint8_t quality);
 JSC::JSPromise* click(JSC::JSGlobalObject*, JSWebView*, float x, float y, uint8_t button, uint8_t modifiers, uint8_t clickCount);
 JSC::JSPromise* clickSelector(JSC::JSGlobalObject*, JSWebView*, const WTF::String& selector, uint32_t timeout, uint8_t button, uint8_t modifiers, uint8_t clickCount);
 JSC::JSPromise* type(JSC::JSGlobalObject*, JSWebView*, const WTF::String& text);

--- a/src/bun.js/webview/ChromeBackend.h
+++ b/src/bun.js/webview/ChromeBackend.h
@@ -342,10 +342,14 @@ enum class PendingSlot : uint8_t {
     Cdp,
 };
 
+// Per-CDP-id pending entry. viewId indirects through Transport::m_views
+// (one Weak per view) instead of holding its own Weak — a burst of
+// operations creates N ids but only one weak slot allocation. Response
+// handlers do m_views.find(entry.viewId)->value.get() to reach the view.
 struct Pending {
     Method method;
     PendingSlot slot;
-    JSC::Weak<JSWebView> view;
+    uint32_t viewId;
 };
 
 // Transport mode. Pipe = we spawned Chrome with --remote-debugging-pipe,
@@ -393,9 +397,11 @@ public:
     // Next CDP id — caller uses it with Command(id, ...) then calls send().
     uint32_t nextId() { return m_nextId++; }
 
-    // Finish the command and write to the pipe. Zero-copy when the command
-    // body is all-ASCII (the common case). See Command::finishAndWrite.
-    void send(Command&& cmd);
+    // Finish the command and write. Zero-copy when the body is all-ASCII.
+    // Pipe mode: NUL-delimited via writeRaw. WebSocket mode: one text
+    // frame via sendTextNative, or queue with its CDP id pre-open so
+    // close() can cancel (m_pending.removeIf erases the id, drain skips).
+    void send(uint32_t cdpId, Command&& cmd);
 
     // Called from usockets onData. Parses complete NUL-delimited messages
     // out of rx, dispatches each to handleMessage.
@@ -415,7 +421,16 @@ public:
     // Commands queued while the WS handshake is in flight. The first
     // navigate() on a view runs before onOpen fires; we can't
     // sendTextNative until m_state == OPEN. Drained in wsOnOpen.
-    WTF::Vector<WTF::String> m_wsPending;
+    //
+    // Keyed by CDP id so Ops::close() can cancel: m_pending.removeIf
+    // erases the id, and drain skips bodies whose id is gone. Without
+    // this, closing a view pre-open would still send its
+    // Target.createTarget — orphaned tab in the user's Chrome.
+    struct WsPendingCmd {
+        uint32_t id;
+        WTF::String body;
+    };
+    WTF::Vector<WsPendingCmd> m_wsPending;
     bool m_wsOpen = false;
     // True when ensureConnected was called from auto-detect (the
     // constructor read DevToolsActivePort) — gates the stale-file
@@ -424,10 +439,18 @@ public:
     bool m_dead = false;
 
     uint32_t m_nextId = 1;
+    uint32_t m_nextViewId = 1;
     WTF::HashMap<uint32_t, Pending> m_pending;
-    // sessionId → JSWebView. The string is the raw slice from
-    // Target.attachedToTarget — base64-ish, no escapes, stored as-is.
-    WTF::HashMap<WTF::String, JSC::Weak<JSWebView>> m_sessions;
+    // viewId → JSWebView. ONE Weak per view (not per CDP request).
+    // Mirrors WebKitBackend's HostClient::viewsById. All routing
+    // dereferences through here. Populated in createChrome, erased in
+    // Ops::close. The Weak's owner predicate reads
+    // m_pendingActivityCount — same GC-root pattern as HostClient.
+    WTF::HashMap<uint32_t, JSC::Weak<JSWebView>> m_views;
+    // sessionId → viewId. The string is the raw slice from
+    // Target.attachedToTarget — base64-ish, no escapes. Indirects through
+    // m_views so there's still only one Weak per view total.
+    WTF::HashMap<WTF::String, uint32_t> m_sessions;
 
     WTF::Vector<uint8_t> m_rx;
     WTF::Vector<uint8_t> m_txQueue;
@@ -439,6 +462,22 @@ public:
     void rejectAllAndMarkDead(const WTF::String& reason);
     void updateKeepAlive();
     void writeRaw(const char* data, size_t len);
+
+    // Resolve viewId → JSWebView* through m_views. Null if the view was
+    // collected (user dropped both the view and its awaited promise —
+    // m_pendingActivityCount == 0 so the Weak predicate stopped rooting
+    // it). Responses on a null view silently drop, same as WebKit's
+    // handleReply early-return.
+    JSWebView* viewFor(uint32_t viewId)
+    {
+        auto it = m_views.find(viewId);
+        if (it == m_views.end()) return nullptr;
+        return it->value.get();
+    }
+
+    // Register a fresh view. Returns its viewId and stores one Weak.
+    // Called from JSWebView::createChrome after the transport is up.
+    uint32_t registerView(JSWebView*);
 };
 
 Transport& transport();

--- a/src/bun.js/webview/ChromeProcess.zig
+++ b/src/bun.js/webview/ChromeProcess.zig
@@ -108,6 +108,7 @@ fn findChrome(alloc: std.mem.Allocator, explicitPath: ?[*:0]const u8) !?[:0]cons
         "google-chrome",
         "chromium-browser",
         "chromium",
+        "brave-browser",
         "microsoft-edge",
         "chrome", // brew cask symlink, some CI setups
     };
@@ -128,6 +129,7 @@ fn findChrome(alloc: std.mem.Allocator, explicitPath: ?[*:0]const u8) !?[:0]cons
             "Google Chrome.app/Contents/MacOS/Google Chrome",
             "Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
             "Chromium.app/Contents/MacOS/Chromium",
+            "Brave Browser.app/Contents/MacOS/Brave Browser",
             "Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
         };
         // /Applications then ~/Applications — per-user installs (non-admin
@@ -150,6 +152,8 @@ fn findChrome(alloc: std.mem.Allocator, explicitPath: ?[*:0]const u8) !?[:0]cons
             "/usr/bin/chromium-browser",
             "/usr/bin/chromium",
             "/snap/bin/chromium",
+            "/usr/bin/brave-browser",
+            "/snap/bin/brave",
             "/usr/bin/microsoft-edge",
         };
         for (absolute) |c| {
@@ -366,75 +370,13 @@ fn spawn(vm: *jsc.VirtualMachine, userDataDir: ?[*:0]const u8, explicitPath: ?[*
 // Implemented in ChromeBackend.cpp. Rejects all pending CDP promises.
 extern fn Bun__Chrome__died(signo: i32) void;
 
-// --- /json/version discovery ------------------------------------------------
-// When the user passes backend.url as a bare host:port (or http://) instead
-// of the full ws://.../devtools/browser/<id>, we GET /json/version to read
-// webSocketDebuggerUrl. Chrome's Remote Debugging panel shows "127.0.0.1:9222"
-// — that's the HTTP endpoint, not the WS URL, so this discovery step makes
-// `url: "127.0.0.1:9222"` Just Work.
-//
-// Async via AsyncHTTP on the HTTP thread — the endpoint might not be
-// listening (wrong port, Chrome not running, firewalled). onHttpResult fires
-// on the HTTP thread; we bounce to the JS thread via ConcurrentTask before
-// calling back into C++ (which will WebSocket::create, which needs the JS
-// thread's usockets context).
-
-const DiscoverTask = struct {
-    http: bun.http.AsyncHTTP,
-    response: bun.MutableString,
-    url_buf: []u8, // owned — http://<host:port>/json/version
-    vm: *jsc.VirtualMachine,
-    result_ok: bool = false,
-
-    pub const new = bun.TrivialNew(@This());
-
-    // HTTP thread — stash result, enqueue JS-thread continuation.
-    // ConcurrentTask.fromCallback heap-allocates the task wrapper (auto-
-    // deleted after the callback runs); we only stash what runOnJSThread
-    // needs. The response body is in this.response — the MutableString
-    // is heap-backed, safe to read from the JS thread.
-    fn onHttpResult(this: *DiscoverTask, _: *bun.http.AsyncHTTP, result: bun.http.HTTPClientResult) void {
-        this.result_ok = result.isSuccess() and
-            if (result.metadata) |m| m.response.status_code == 200 else false;
-        this.vm.eventLoop().enqueueTaskConcurrent(
-            jsc.ConcurrentTask.fromCallback(this, DiscoverTask.runOnJSThread),
-        );
-    }
-
-    // JS thread — parse webSocketDebuggerUrl, call C++, clean up.
-    fn runOnJSThread(this: *DiscoverTask) void {
-        defer this.deinit();
-        if (!this.result_ok) {
-            Bun__CDPTransport__onDiscoverFailed(this.vm.global);
-            return;
-        }
-        // Response body: {"Browser":"...","Protocol-Version":"...",
-        // "webSocketDebuggerUrl":"ws://127.0.0.1:9222/devtools/browser/<id>",
-        // ...}. The URL has no escapes (it's ASCII host:port/path), so a
-        // substring scan beats pulling in a JSON parser for one field.
-        const body = this.response.list.items;
-        const key = "\"webSocketDebuggerUrl\":\"";
-        const start = bun.strings.indexOf(body, key) orelse {
-            Bun__CDPTransport__onDiscoverFailed(this.vm.global);
-            return;
-        };
-        const url_start = start + key.len;
-        const url_end = bun.strings.indexOfChar(body[url_start..], '"') orelse {
-            Bun__CDPTransport__onDiscoverFailed(this.vm.global);
-            return;
-        };
-        const ws_url = body[url_start..][0..url_end];
-        Bun__CDPTransport__onDiscovered(this.vm.global, ws_url.ptr, ws_url.len);
-    }
-
-    fn deinit(this: *DiscoverTask) void {
-        this.response.deinit();
-        this.http.clearData();
-        this.http.client.deinit();
-        bun.default_allocator.free(this.url_buf);
-        bun.destroy(this);
-    }
-};
+// --- DevToolsActivePort discovery -------------------------------------------
+// Chrome writes <port>\n/devtools/browser/<id> to DevToolsActivePort in its
+// profile dir when remote debugging is on (via --remote-debugging-port OR
+// the chrome://inspect toggle). Sync file read — instant answer, no network.
+// The new chrome://inspect toggle does NOT expose /json/version (404), so
+// this file is the ONLY discovery mechanism for that mode. chrome-devtools-
+// mcp does the same.
 
 /// Read DevToolsActivePort from Chrome's default profile directory.
 /// Chrome writes this when --remote-debugging-port is set OR when the
@@ -443,10 +385,6 @@ const DiscoverTask = struct {
 /// full ws:// URL in out_buf, or null if the file doesn't exist /
 /// is malformed / the profile dir is non-standard.
 ///
-/// This is the fast path — no network, instant answer. chrome-devtools-mcp
-/// does the same. Falls back to HTTP GET /json/version (below) when the
-/// file isn't there or the user passed an explicit host:port that might
-/// be a different profile or a remote Chrome.
 fn readDevToolsActivePort(out_buf: *std.ArrayListUnmanaged(u8)) ?void {
     // Default profile locations. Multiple Chrome channels (stable/beta/
     // canary) have distinct dirs; try each. Chromium and Edge also
@@ -463,12 +401,14 @@ fn readDevToolsActivePort(out_buf: *std.ArrayListUnmanaged(u8)) ?void {
         "Library/Application Support/Google/Chrome Canary/DevToolsActivePort",
         "Library/Application Support/Google/Chrome Beta/DevToolsActivePort",
         "Library/Application Support/Chromium/DevToolsActivePort",
+        "Library/Application Support/BraveSoftware/Brave-Browser/DevToolsActivePort",
         "Library/Application Support/Microsoft Edge/DevToolsActivePort",
     } else if (comptime bun.Environment.isLinux) &.{
         ".config/google-chrome/DevToolsActivePort",
         ".config/google-chrome-beta/DevToolsActivePort",
         ".config/google-chrome-unstable/DevToolsActivePort",
         ".config/chromium/DevToolsActivePort",
+        ".config/BraveSoftware/Brave-Browser/DevToolsActivePort",
         ".config/microsoft-edge/DevToolsActivePort",
     } else if (comptime bun.Environment.isWindows) &.{
         // Windows installer layout: <vendor>\<channel>\User Data\
@@ -476,6 +416,7 @@ fn readDevToolsActivePort(out_buf: *std.ArrayListUnmanaged(u8)) ?void {
         "Google\\Chrome SxS\\User Data\\DevToolsActivePort", // Canary
         "Google\\Chrome Beta\\User Data\\DevToolsActivePort",
         "Chromium\\User Data\\DevToolsActivePort",
+        "BraveSoftware\\Brave-Browser\\User Data\\DevToolsActivePort",
         "Microsoft\\Edge\\User Data\\DevToolsActivePort",
     } else &.{};
 
@@ -512,12 +453,11 @@ fn readDevToolsActivePort(out_buf: *std.ArrayListUnmanaged(u8)) ?void {
 /// Chrome; else spawn our own. Sync file read means the constructor
 /// stays synchronous and the decision is made before any I/O kicks off.
 ///
-/// The file can be stale (Chrome crashed without cleaning up, or was
-/// restarted with a different browser-id). The subsequent WS connect
-/// will fail with the dialog-dismissed/connection-refused close code;
-/// onClose → rejectAllAndMarkDead surfaces that to the user's first
-/// `await navigate()`. We don't pre-validate (that'd need a network
-/// round-trip which defeats the point of the file).
+/// The file can be stale — Chrome crashed without cleaning up, or was
+/// restarted with a different browser-id. The subsequent WS connect
+/// fails with a close code; C++ falls back to spawn in that case
+/// (m_wasAutoDetected gate in wsOnClose). We don't pre-validate here
+/// because that'd need a network round-trip which defeats the file.
 pub export fn Bun__Chrome__autoDetect(out_buf: [*]u8, out_cap: usize) usize {
     var buf: std.ArrayListUnmanaged(u8) = .empty;
     defer buf.deinit(bun.default_allocator);
@@ -528,114 +468,6 @@ pub export fn Bun__Chrome__autoDetect(out_buf: [*]u8, out_cap: usize) usize {
     }
     return 0;
 }
-
-/// Discover the ws:// debugger URL for a bare host:port. Two paths:
-///
-/// 1. DevToolsActivePort file (sync, instant): Chrome's new
-///    chrome://inspect/#remote-debugging toggle writes this file but does
-///    NOT expose /json/version (404). If the file's port matches the
-///    user's input and the host is localhost-ish, use the file's path
-///    directly. This is the primary path for the new toggle.
-///
-/// 2. GET /json/version (async, HTTP thread): classic --remote-debugging-
-///    port Chrome exposes this. Fallback for when the file doesn't match
-///    (different profile, remote host, or classic launch).
-///
-/// `input` is bare host:port or http://host:port. Calls
-/// Bun__CDPTransport__onDiscovered (JS thread) with the ws:// URL on
-/// success, or __onDiscoverFailed on any error. C++ owns the input
-/// string; we copy into url_buf.
-pub export fn Bun__Chrome__discover(global: *jsc.JSGlobalObject, input: [*]const u8, input_len: usize) void {
-    const alloc = bun.default_allocator;
-    const in = input[0..input_len];
-
-    // Normalize: strip http:// prefix if present.
-    const host = if (bun.strings.hasPrefixComptime(in, "http://"))
-        in["http://".len..]
-    else
-        in;
-
-    // Fast path: DevToolsActivePort file. Only valid when the host is
-    // localhost (the file is per-machine) and the port matches what
-    // Chrome wrote. A user passing a remote host or non-default port
-    // skips this and goes to HTTP GET.
-    if (isLocalhost(host)) {
-        var buf: std.ArrayListUnmanaged(u8) = .empty;
-        defer buf.deinit(alloc);
-        if (readDevToolsActivePort(&buf)) |_| {
-            // buf is "ws://127.0.0.1:<port>/devtools/browser/<id>".
-            // Check the port in buf matches what the user asked for.
-            // Extract user's port (after the last ':').
-            const colon = std.mem.lastIndexOfScalar(u8, host, ':') orelse 0;
-            const user_port = host[colon + 1 ..];
-            // Find ":<port>/" in the ws:// URL we built.
-            var needle_buf: [8]u8 = undefined;
-            const needle = std.fmt.bufPrint(&needle_buf, ":{s}/", .{user_port}) catch {
-                // port string too long to be a valid port — skip to HTTP
-                return discoverViaHttp(global, alloc, host);
-            };
-            if (bun.strings.contains(buf.items, needle)) {
-                Bun__CDPTransport__onDiscovered(global, buf.items.ptr, buf.items.len);
-                return;
-            }
-            // Port mismatch — the file is for a different Chrome. Fall
-            // through to HTTP GET (the user's port might be a second
-            // Chrome with classic --remote-debugging-port).
-        }
-    }
-
-    discoverViaHttp(global, alloc, host);
-}
-
-fn isLocalhost(host: []const u8) bool {
-    // host:port — strip the port for the check.
-    const h = if (std.mem.lastIndexOfScalar(u8, host, ':')) |c| host[0..c] else host;
-    return bun.strings.eqlComptime(h, "localhost") or
-        bun.strings.eqlComptime(h, "127.0.0.1") or
-        bun.strings.eqlComptime(h, "[::1]") or
-        bun.strings.eqlComptime(h, "::1");
-}
-
-fn discoverViaHttp(global: *jsc.JSGlobalObject, alloc: std.mem.Allocator, host: []const u8) void {
-    const url_buf = std.fmt.allocPrint(alloc, "http://{s}/json/version", .{host}) catch bun.outOfMemory();
-
-    const vm = global.bunVM();
-    var task = DiscoverTask.new(.{
-        .http = undefined,
-        .response = bun.MutableString.initEmpty(alloc),
-        .url_buf = url_buf,
-        .vm = vm,
-    });
-
-    const url = bun.URL.parse(url_buf);
-    task.http = bun.http.AsyncHTTP.init(
-        alloc,
-        .GET,
-        url,
-        .{},
-        "",
-        &task.response,
-        "",
-        bun.http.HTTPClientResult.Callback.New(*DiscoverTask, DiscoverTask.onHttpResult).init(task),
-        .manual,
-        .{},
-    );
-    // Localhost GET is instant; a dead port fails fast with
-    // ECONNREFUSED. The HTTP client's default 5-minute timeout only
-    // matters if something accepts but never responds — unlikely for
-    // /json/version but the user's `await navigate()` would hang
-    // either way, so they'd notice.
-    bun.http.HTTPThread.init(&.{});
-    var batch = bun.ThreadPool.Batch{};
-    task.http.schedule(alloc, &batch);
-    bun.http.http_thread.schedule(batch);
-}
-
-// C++ side (ChromeBackend.cpp): onDiscovered does WebSocket::create with
-// the ws:// URL; onDiscoverFailed calls rejectAllAndMarkDead. Both must
-// run on the JS thread (DiscoverTask.runOnJSThread ensures that).
-extern fn Bun__CDPTransport__onDiscovered(global: *jsc.JSGlobalObject, url: [*]const u8, len: usize) void;
-extern fn Bun__CDPTransport__onDiscoverFailed(global: *jsc.JSGlobalObject) void;
 
 const log = bun.Output.scoped(.Chrome, .hidden);
 

--- a/src/bun.js/webview/ChromeProcess.zig
+++ b/src/bun.js/webview/ChromeProcess.zig
@@ -366,6 +366,269 @@ fn spawn(vm: *jsc.VirtualMachine, userDataDir: ?[*:0]const u8, explicitPath: ?[*
 // Implemented in ChromeBackend.cpp. Rejects all pending CDP promises.
 extern fn Bun__Chrome__died(signo: i32) void;
 
+// --- /json/version discovery ------------------------------------------------
+// When the user passes backend.url as a bare host:port (or http://) instead
+// of the full ws://.../devtools/browser/<id>, we GET /json/version to read
+// webSocketDebuggerUrl. Chrome's Remote Debugging panel shows "127.0.0.1:9222"
+// — that's the HTTP endpoint, not the WS URL, so this discovery step makes
+// `url: "127.0.0.1:9222"` Just Work.
+//
+// Async via AsyncHTTP on the HTTP thread — the endpoint might not be
+// listening (wrong port, Chrome not running, firewalled). onHttpResult fires
+// on the HTTP thread; we bounce to the JS thread via ConcurrentTask before
+// calling back into C++ (which will WebSocket::create, which needs the JS
+// thread's usockets context).
+
+const DiscoverTask = struct {
+    http: bun.http.AsyncHTTP,
+    response: bun.MutableString,
+    url_buf: []u8, // owned — http://<host:port>/json/version
+    vm: *jsc.VirtualMachine,
+    result_ok: bool = false,
+
+    pub const new = bun.TrivialNew(@This());
+
+    // HTTP thread — stash result, enqueue JS-thread continuation.
+    // ConcurrentTask.fromCallback heap-allocates the task wrapper (auto-
+    // deleted after the callback runs); we only stash what runOnJSThread
+    // needs. The response body is in this.response — the MutableString
+    // is heap-backed, safe to read from the JS thread.
+    fn onHttpResult(this: *DiscoverTask, _: *bun.http.AsyncHTTP, result: bun.http.HTTPClientResult) void {
+        this.result_ok = result.isSuccess() and
+            if (result.metadata) |m| m.response.status_code == 200 else false;
+        this.vm.eventLoop().enqueueTaskConcurrent(
+            jsc.ConcurrentTask.fromCallback(this, DiscoverTask.runOnJSThread),
+        );
+    }
+
+    // JS thread — parse webSocketDebuggerUrl, call C++, clean up.
+    fn runOnJSThread(this: *DiscoverTask) void {
+        defer this.deinit();
+        if (!this.result_ok) {
+            Bun__CDPTransport__onDiscoverFailed(this.vm.global);
+            return;
+        }
+        // Response body: {"Browser":"...","Protocol-Version":"...",
+        // "webSocketDebuggerUrl":"ws://127.0.0.1:9222/devtools/browser/<id>",
+        // ...}. The URL has no escapes (it's ASCII host:port/path), so a
+        // substring scan beats pulling in a JSON parser for one field.
+        const body = this.response.list.items;
+        const key = "\"webSocketDebuggerUrl\":\"";
+        const start = bun.strings.indexOf(body, key) orelse {
+            Bun__CDPTransport__onDiscoverFailed(this.vm.global);
+            return;
+        };
+        const url_start = start + key.len;
+        const url_end = bun.strings.indexOfChar(body[url_start..], '"') orelse {
+            Bun__CDPTransport__onDiscoverFailed(this.vm.global);
+            return;
+        };
+        const ws_url = body[url_start..][0..url_end];
+        Bun__CDPTransport__onDiscovered(this.vm.global, ws_url.ptr, ws_url.len);
+    }
+
+    fn deinit(this: *DiscoverTask) void {
+        this.response.deinit();
+        this.http.clearData();
+        this.http.client.deinit();
+        bun.default_allocator.free(this.url_buf);
+        bun.destroy(this);
+    }
+};
+
+/// Read DevToolsActivePort from Chrome's default profile directory.
+/// Chrome writes this when --remote-debugging-port is set OR when the
+/// user flips the "Allow remote debugging" toggle in chrome://inspect.
+/// Two lines: port, then path (/devtools/browser/<id>). Returns the
+/// full ws:// URL in out_buf, or null if the file doesn't exist /
+/// is malformed / the profile dir is non-standard.
+///
+/// This is the fast path — no network, instant answer. chrome-devtools-mcp
+/// does the same. Falls back to HTTP GET /json/version (below) when the
+/// file isn't there or the user passed an explicit host:port that might
+/// be a different profile or a remote Chrome.
+fn readDevToolsActivePort(out_buf: *std.ArrayListUnmanaged(u8)) ?void {
+    // Default profile locations. Multiple Chrome channels (stable/beta/
+    // canary) have distinct dirs; try each. Chromium and Edge also
+    // respond to the same debugging protocol.
+    // Windows roots under %LOCALAPPDATA%; POSIX under $HOME. The subdir
+    // names come from each browser's installer — hardcoded, not
+    // discoverable. Edge uses the same CDP + file format as Chrome.
+    const root = if (comptime bun.Environment.isWindows)
+        bun.getenvZ("LOCALAPPDATA") orelse return null
+    else
+        bun.getenvZ("HOME") orelse return null;
+    const candidates: []const []const u8 = if (comptime bun.Environment.isMac) &.{
+        "Library/Application Support/Google/Chrome/DevToolsActivePort",
+        "Library/Application Support/Google/Chrome Canary/DevToolsActivePort",
+        "Library/Application Support/Google/Chrome Beta/DevToolsActivePort",
+        "Library/Application Support/Chromium/DevToolsActivePort",
+        "Library/Application Support/Microsoft Edge/DevToolsActivePort",
+    } else if (comptime bun.Environment.isLinux) &.{
+        ".config/google-chrome/DevToolsActivePort",
+        ".config/google-chrome-beta/DevToolsActivePort",
+        ".config/google-chrome-unstable/DevToolsActivePort",
+        ".config/chromium/DevToolsActivePort",
+        ".config/microsoft-edge/DevToolsActivePort",
+    } else if (comptime bun.Environment.isWindows) &.{
+        // Windows installer layout: <vendor>\<channel>\User Data\
+        "Google\\Chrome\\User Data\\DevToolsActivePort",
+        "Google\\Chrome SxS\\User Data\\DevToolsActivePort", // Canary
+        "Google\\Chrome Beta\\User Data\\DevToolsActivePort",
+        "Chromium\\User Data\\DevToolsActivePort",
+        "Microsoft\\Edge\\User Data\\DevToolsActivePort",
+    } else &.{};
+
+    var path_buf: bun.PathBuffer = undefined;
+    for (candidates) |rel| {
+        const path = bun.path.joinAbsStringBufZ(root, &path_buf, &.{rel}, .auto);
+        const contents = switch (bun.sys.File.readFrom(bun.FD.cwd(), path, bun.default_allocator)) {
+            .err => continue, // ENOENT or EACCES — try next
+            .result => |c| c,
+        };
+        defer bun.default_allocator.free(contents);
+
+        // Parse: line 1 = port, line 2 = path.
+        var lines = std.mem.splitScalar(u8, contents, '\n');
+        const port_str = std.mem.trim(u8, lines.next() orelse continue, " \r\t");
+        const ws_path = std.mem.trim(u8, lines.next() orelse continue, " \r\t");
+        // Validate port (catch stale/corrupt files).
+        const port = std.fmt.parseInt(u16, port_str, 10) catch continue;
+        if (port == 0 or ws_path.len == 0 or ws_path[0] != '/') continue;
+
+        out_buf.clearRetainingCapacity();
+        out_buf.writer(bun.default_allocator).print("ws://127.0.0.1:{d}{s}", .{ port, ws_path }) catch return null;
+        return;
+    }
+    return null;
+}
+
+/// Auto-discover a running Chrome's WebSocket debugger URL. Tries the
+/// DevToolsActivePort file first (instant, no network); falls through to
+/// failed if not found. The HTTP GET path (Bun__Chrome__discover) is for
+/// explicit host:port where we can't assume the default profile.
+///
+/// Returns true if found (C++ gets the URL via onDiscovered synchronously
+/// before this returns — it's a file read, not async). Returns false if no
+/// file found; caller decides whether to spawn or error.
+pub export fn Bun__Chrome__autoDetect(global: *jsc.JSGlobalObject) bool {
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer buf.deinit(bun.default_allocator);
+    if (readDevToolsActivePort(&buf)) |_| {
+        Bun__CDPTransport__onDiscovered(global, buf.items.ptr, buf.items.len);
+        return true;
+    }
+    return false;
+}
+
+/// Discover the ws:// debugger URL for a bare host:port. Two paths:
+///
+/// 1. DevToolsActivePort file (sync, instant): Chrome's new
+///    chrome://inspect/#remote-debugging toggle writes this file but does
+///    NOT expose /json/version (404). If the file's port matches the
+///    user's input and the host is localhost-ish, use the file's path
+///    directly. This is the primary path for the new toggle.
+///
+/// 2. GET /json/version (async, HTTP thread): classic --remote-debugging-
+///    port Chrome exposes this. Fallback for when the file doesn't match
+///    (different profile, remote host, or classic launch).
+///
+/// `input` is bare host:port or http://host:port. Calls
+/// Bun__CDPTransport__onDiscovered (JS thread) with the ws:// URL on
+/// success, or __onDiscoverFailed on any error. C++ owns the input
+/// string; we copy into url_buf.
+pub export fn Bun__Chrome__discover(global: *jsc.JSGlobalObject, input: [*]const u8, input_len: usize) void {
+    const alloc = bun.default_allocator;
+    const in = input[0..input_len];
+
+    // Normalize: strip http:// prefix if present.
+    const host = if (bun.strings.hasPrefixComptime(in, "http://"))
+        in["http://".len..]
+    else
+        in;
+
+    // Fast path: DevToolsActivePort file. Only valid when the host is
+    // localhost (the file is per-machine) and the port matches what
+    // Chrome wrote. A user passing a remote host or non-default port
+    // skips this and goes to HTTP GET.
+    if (isLocalhost(host)) {
+        var buf: std.ArrayListUnmanaged(u8) = .empty;
+        defer buf.deinit(alloc);
+        if (readDevToolsActivePort(&buf)) |_| {
+            // buf is "ws://127.0.0.1:<port>/devtools/browser/<id>".
+            // Check the port in buf matches what the user asked for.
+            // Extract user's port (after the last ':').
+            const colon = std.mem.lastIndexOfScalar(u8, host, ':') orelse 0;
+            const user_port = host[colon + 1 ..];
+            // Find ":<port>/" in the ws:// URL we built.
+            var needle_buf: [8]u8 = undefined;
+            const needle = std.fmt.bufPrint(&needle_buf, ":{s}/", .{user_port}) catch {
+                // port string too long to be a valid port — skip to HTTP
+                return discoverViaHttp(global, alloc, host);
+            };
+            if (bun.strings.contains(buf.items, needle)) {
+                Bun__CDPTransport__onDiscovered(global, buf.items.ptr, buf.items.len);
+                return;
+            }
+            // Port mismatch — the file is for a different Chrome. Fall
+            // through to HTTP GET (the user's port might be a second
+            // Chrome with classic --remote-debugging-port).
+        }
+    }
+
+    discoverViaHttp(global, alloc, host);
+}
+
+fn isLocalhost(host: []const u8) bool {
+    // host:port — strip the port for the check.
+    const h = if (std.mem.lastIndexOfScalar(u8, host, ':')) |c| host[0..c] else host;
+    return bun.strings.eqlComptime(h, "localhost") or
+        bun.strings.eqlComptime(h, "127.0.0.1") or
+        bun.strings.eqlComptime(h, "[::1]") or
+        bun.strings.eqlComptime(h, "::1");
+}
+
+fn discoverViaHttp(global: *jsc.JSGlobalObject, alloc: std.mem.Allocator, host: []const u8) void {
+    const url_buf = std.fmt.allocPrint(alloc, "http://{s}/json/version", .{host}) catch bun.outOfMemory();
+
+    const vm = global.bunVM();
+    var task = DiscoverTask.new(.{
+        .http = undefined,
+        .response = bun.MutableString.initEmpty(alloc),
+        .url_buf = url_buf,
+        .vm = vm,
+    });
+
+    const url = bun.URL.parse(url_buf);
+    task.http = bun.http.AsyncHTTP.init(
+        alloc,
+        .GET,
+        url,
+        .{},
+        "",
+        &task.response,
+        "",
+        bun.http.HTTPClientResult.Callback.New(*DiscoverTask, DiscoverTask.onHttpResult).init(task),
+        .manual,
+        .{},
+    );
+    // Localhost GET is instant; a dead port fails fast with
+    // ECONNREFUSED. The HTTP client's default 5-minute timeout only
+    // matters if something accepts but never responds — unlikely for
+    // /json/version but the user's `await navigate()` would hang
+    // either way, so they'd notice.
+    bun.http.HTTPThread.init(&.{});
+    var batch = bun.ThreadPool.Batch{};
+    task.http.schedule(alloc, &batch);
+    bun.http.http_thread.schedule(batch);
+}
+
+// C++ side (ChromeBackend.cpp): onDiscovered does WebSocket::create with
+// the ws:// URL; onDiscoverFailed calls rejectAllAndMarkDead. Both must
+// run on the JS thread (DiscoverTask.runOnJSThread ensures that).
+extern fn Bun__CDPTransport__onDiscovered(global: *jsc.JSGlobalObject, url: [*]const u8, len: usize) void;
+extern fn Bun__CDPTransport__onDiscoverFailed(global: *jsc.JSGlobalObject) void;
+
 const log = bun.Output.scoped(.Chrome, .hidden);
 
 const std = @import("std");

--- a/src/bun.js/webview/ChromeProcess.zig
+++ b/src/bun.js/webview/ChromeProcess.zig
@@ -503,22 +503,30 @@ fn readDevToolsActivePort(out_buf: *std.ArrayListUnmanaged(u8)) ?void {
     return null;
 }
 
-/// Auto-discover a running Chrome's WebSocket debugger URL. Tries the
-/// DevToolsActivePort file first (instant, no network); falls through to
-/// failed if not found. The HTTP GET path (Bun__Chrome__discover) is for
-/// explicit host:port where we can't assume the default profile.
+/// Auto-discover a running Chrome's WebSocket debugger URL by reading
+/// DevToolsActivePort (instant, no network). Writes the ws:// URL into
+/// out_buf and returns its length, or 0 if no file found.
 ///
-/// Returns true if found (C++ gets the URL via onDiscovered synchronously
-/// before this returns — it's a file read, not async). Returns false if no
-/// file found; caller decides whether to spawn or error.
-pub export fn Bun__Chrome__autoDetect(global: *jsc.JSGlobalObject) bool {
+/// C++ calls this from the constructor when backend:"chrome" has no
+/// explicit path or url — if we get a URL back, connect to the existing
+/// Chrome; else spawn our own. Sync file read means the constructor
+/// stays synchronous and the decision is made before any I/O kicks off.
+///
+/// The file can be stale (Chrome crashed without cleaning up, or was
+/// restarted with a different browser-id). The subsequent WS connect
+/// will fail with the dialog-dismissed/connection-refused close code;
+/// onClose → rejectAllAndMarkDead surfaces that to the user's first
+/// `await navigate()`. We don't pre-validate (that'd need a network
+/// round-trip which defeats the point of the file).
+pub export fn Bun__Chrome__autoDetect(out_buf: [*]u8, out_cap: usize) usize {
     var buf: std.ArrayListUnmanaged(u8) = .empty;
     defer buf.deinit(bun.default_allocator);
     if (readDevToolsActivePort(&buf)) |_| {
-        Bun__CDPTransport__onDiscovered(global, buf.items.ptr, buf.items.len);
-        return true;
+        if (buf.items.len > out_cap) return 0;
+        @memcpy(out_buf[0..buf.items.len], buf.items);
+        return buf.items.len;
     }
-    return false;
+    return 0;
 }
 
 /// Discover the ws:// debugger URL for a bare host:port. Two paths:

--- a/src/bun.js/webview/JSWebView.cpp
+++ b/src/bun.js/webview/JSWebView.cpp
@@ -320,11 +320,20 @@ JSWebView* JSWebView::createAndSend(JSGlobalObject* g, Structure* structure,
 JSWebView* JSWebView::createChrome(JSGlobalObject* g, Structure* structure,
     uint32_t width, uint32_t height, const WTF::String& userDataDir,
     const WTF::String& path, const WTF::Vector<WTF::String>& extraArgv,
-    bool stdoutInherit, bool stderrInherit)
+    bool stdoutInherit, bool stderrInherit, const WTF::String& wsUrl)
 {
     auto* zig = defaultGlobalObject(g);
     auto& t = CDP::transport();
-    if (!t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit)) return nullptr;
+    // wsUrl non-empty → connect to an existing Chrome over WebSocket.
+    // Empty → spawn our own with --remote-debugging-pipe. Both end up in
+    // the same Transport singleton; first call wins (singleton semantics).
+    // A second WebView with a conflicting mode (wsUrl after a spawn, or
+    // vice versa) silently uses the existing transport — same as how
+    // mismatched path/argv are ignored after the first spawn.
+    bool ok = wsUrl.isEmpty()
+        ? t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit)
+        : t.ensureConnected(zig, wsUrl);
+    if (!ok) return nullptr;
 
     auto impl = WebViewEventTarget::create(*zig->scriptExecutionContext());
     JSWebView* view = create(structure, zig, WTF::move(impl));

--- a/src/bun.js/webview/JSWebView.cpp
+++ b/src/bun.js/webview/JSWebView.cpp
@@ -317,6 +317,11 @@ JSWebView* JSWebView::createAndSend(JSGlobalObject* g, Structure* structure,
 }
 #endif
 
+// Reads DevToolsActivePort from default profile locations. Returns 0
+// if no file found, else writes ws://127.0.0.1:<port>/devtools/... into
+// out and returns the length. Sync file read — instant.
+extern "C" size_t Bun__Chrome__autoDetect(char* out, size_t cap);
+
 JSWebView* JSWebView::createChrome(JSGlobalObject* g, Structure* structure,
     uint32_t width, uint32_t height, const WTF::String& userDataDir,
     const WTF::String& path, const WTF::Vector<WTF::String>& extraArgv,
@@ -324,15 +329,34 @@ JSWebView* JSWebView::createChrome(JSGlobalObject* g, Structure* structure,
 {
     auto* zig = defaultGlobalObject(g);
     auto& t = CDP::transport();
-    // wsUrl non-empty → connect to an existing Chrome over WebSocket.
-    // Empty → spawn our own with --remote-debugging-pipe. Both end up in
-    // the same Transport singleton; first call wins (singleton semantics).
-    // A second WebView with a conflicting mode (wsUrl after a spawn, or
-    // vice versa) silently uses the existing transport — same as how
-    // mismatched path/argv are ignored after the first spawn.
-    bool ok = wsUrl.isEmpty()
-        ? t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit)
-        : t.ensureConnected(zig, wsUrl);
+
+    // Transport selection. Explicit url → connect. Explicit path/argv →
+    // spawn (the user picked an executable; don't redirect them to a
+    // different running Chrome). Neither → auto-detect: if
+    // DevToolsActivePort exists, connect to the existing Chrome; else
+    // spawn. The file read is sync/instant so the constructor stays
+    // synchronous; a stale file surfaces as a connect failure on the
+    // user's first `await navigate()` (onClose → rejectAllAndMarkDead).
+    //
+    // All paths end up in the same singleton; first call wins. Second
+    // WebView with a conflicting mode silently uses the existing
+    // transport — same as mismatched path/argv after first spawn.
+    bool ok;
+    if (!wsUrl.isEmpty()) {
+        ok = t.ensureConnected(zig, wsUrl);
+    } else if (!path.isEmpty() || !extraArgv.isEmpty()) {
+        ok = t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit);
+    } else {
+        // Auto-detect. DevToolsActivePort URL is at most
+        // ws://127.0.0.1:65535/devtools/browser/<36-char-uuid> ≈ 70B.
+        char buf[128];
+        size_t len = Bun__Chrome__autoDetect(buf, sizeof(buf));
+        if (len > 0) {
+            ok = t.ensureConnected(zig, WTF::String::fromUTF8(std::span<const char>(buf, len)));
+        } else {
+            ok = t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit);
+        }
+    }
     if (!ok) return nullptr;
 
     auto impl = WebViewEventTarget::create(*zig->scriptExecutionContext());

--- a/src/bun.js/webview/JSWebView.cpp
+++ b/src/bun.js/webview/JSWebView.cpp
@@ -118,6 +118,7 @@ JSWebView::~JSWebView()
     if (m_backend == WebViewBackend::Chrome) {
         auto& t = CDP::transport();
         if (!m_sessionId.isEmpty()) t.m_sessions.remove(m_sessionId);
+        if (m_viewId) t.m_views.remove(m_viewId);
         t.updateKeepAlive();
         return;
     }
@@ -364,6 +365,10 @@ JSWebView* JSWebView::createChrome(JSGlobalObject* g, Structure* structure,
     view->m_backend = WebViewBackend::Chrome;
     view->m_width = width;
     view->m_height = height;
+    // One Weak per view, stored in Transport::m_views. All CDP routing
+    // dereferences through this — m_pending and m_sessions hold just the
+    // viewId, not their own Weaks. Mirrors WebKit's HostClient::viewsById.
+    view->m_viewId = t.registerView(view);
     // Target.createTarget deferred to first navigate() — keeps the constructor
     // synchronous and the attach chain owned by the navigate promise (which
     // resolves on Page.loadEventFired, so one await covers the whole sequence).

--- a/src/bun.js/webview/JSWebView.cpp
+++ b/src/bun.js/webview/JSWebView.cpp
@@ -353,7 +353,7 @@ JSWebView* JSWebView::createChrome(JSGlobalObject* g, Structure* structure,
         if (len > 0) {
             ok = t.ensureConnected(zig,
                 WTF::String::fromUTF8(std::span<const char>(buf, len)),
-                /* autoDetected */ true);
+                /* autoDetected */ true, userDataDir, stdoutInherit, stderrInherit);
         } else {
             ok = t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit);
         }

--- a/src/bun.js/webview/JSWebView.cpp
+++ b/src/bun.js/webview/JSWebView.cpp
@@ -10,6 +10,8 @@
 #include "ipc_protocol.h"
 #include "ZigGlobalObject.h"
 #include "BunClientData.h"
+#include "ScriptExecutionContext.h"
+#include "ScriptWrappableInlines.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/LazyClassStructure.h>
 #include <JavaScriptCore/LazyClassStructureInlines.h>
@@ -64,17 +66,39 @@ void settleSlot(JSGlobalObject* g, JSWebView* v,
         p->reject(g->vm(), g, value);
 }
 
+// --- WebViewEventTarget ----------------------------------------------------
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebViewEventTarget);
+
+JSValue toJS(JSGlobalObject*, WebCore::JSDOMGlobalObject*, WebViewEventTarget& impl)
+{
+    // The impl's ScriptWrappable holds a Weak<JSDOMObject> set by
+    // JSWebView::create → impl.setWrapper(). EventTargetFactory calls here
+    // to produce event.target/currentTarget — just return the existing
+    // wrapper. If it was collected (user dropped the view mid-event), return
+    // null; event.target will be null, which is unusual but not fatal.
+    if (auto* wrapper = impl.wrapper())
+        return wrapper;
+    return jsNull();
+}
+
 // --- JSWebView class -------------------------------------------------------
 
-JSWebView::JSWebView(VM& vm, Structure* structure)
-    : Base(vm, structure)
+JSWebView::JSWebView(Structure* structure, WebCore::JSDOMGlobalObject& global, Ref<WebViewEventTarget>&& impl)
+    : Base(structure, global, WTF::move(impl))
 {
 }
 
-JSWebView* JSWebView::create(VM& vm, Structure* structure)
+JSWebView* JSWebView::create(Structure* structure, WebCore::JSDOMGlobalObject* global, Ref<WebViewEventTarget>&& impl)
 {
-    JSWebView* instance = new (NotNull, allocateCell<JSWebView>(vm)) JSWebView(vm, structure);
+    auto& vm = global->vm();
+    JSWebView* instance = new (NotNull, allocateCell<JSWebView>(vm)) JSWebView(structure, *global, WTF::move(impl));
     instance->finishCreation(vm);
+    // Wire impl→wrapper so event.target resolves. JSDOMWrapper ctor already
+    // moved the impl into m_wrapped; read it back via wrapped(). The Weak's
+    // owner is our existing activity-count predicate — same one the backend
+    // routing tables use.
+    instance->wrapped().setWrapper(instance, &webViewWeakOwner(), nullptr);
     return instance;
 }
 
@@ -121,6 +145,10 @@ void JSWebView::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
     JSWebView* thisObject = jsCast<JSWebView*>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    // Base::visitChildren → JSEventTarget::visitAdditionalChildren →
+    // wrapped().visitJSEventListeners(visitor) — marks all registered
+    // addEventListener callbacks. The WriteBarrier slots below are our own
+    // promise/handler refs; they're not in the EventTarget listener map.
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_onNavigated);
     visitor.append(thisObject->m_onNavigationFailed);
@@ -165,10 +193,11 @@ JSPromise* JSWebView::evaluate(JSGlobalObject* g, const WTF::String& script)
     WK_DISPATCH(WK::Ops::evaluate(g, this, script));
 }
 
-JSPromise* JSWebView::screenshot(JSGlobalObject* g)
+JSPromise* JSWebView::screenshot(JSGlobalObject* g, ScreenshotFormat format, uint8_t quality)
 {
-    if (m_backend == WebViewBackend::Chrome) return CDP::Ops::screenshot(g, this);
-    WK_DISPATCH(WK::Ops::screenshot(g, this));
+    m_screenshotFormat = format;
+    if (m_backend == WebViewBackend::Chrome) return CDP::Ops::screenshot(g, this, format, quality);
+    WK_DISPATCH(WK::Ops::screenshot(g, this, format, quality));
 }
 
 JSPromise* JSWebView::click(JSGlobalObject* g, float x, float y, uint8_t button, uint8_t modifiers, uint8_t clickCount)
@@ -260,7 +289,8 @@ JSWebView* JSWebView::createAndSend(JSGlobalObject* g, Structure* structure,
     auto& c = WK::client();
     if (!c.ensureSpawned(zig, stdoutInherit, stderrInherit)) return nullptr;
 
-    JSWebView* view = create(g->vm(), structure);
+    auto impl = WebViewEventTarget::create(*zig->scriptExecutionContext());
+    JSWebView* view = create(structure, zig, WTF::move(impl));
     view->m_viewId = c.nextViewId++;
     c.viewsById.emplace(view->m_viewId, Weak<JSWebView>(view, &webViewWeakOwner()));
     c.updateKeepAlive();
@@ -286,7 +316,8 @@ JSWebView* JSWebView::createChrome(JSGlobalObject* g, Structure* structure,
     auto& t = CDP::transport();
     if (!t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit)) return nullptr;
 
-    JSWebView* view = create(g->vm(), structure);
+    auto impl = WebViewEventTarget::create(*zig->scriptExecutionContext());
+    JSWebView* view = create(structure, zig, WTF::move(impl));
     view->m_backend = WebViewBackend::Chrome;
     view->m_width = width;
     view->m_height = height;

--- a/src/bun.js/webview/JSWebView.cpp
+++ b/src/bun.js/webview/JSWebView.cpp
@@ -325,34 +325,34 @@ extern "C" size_t Bun__Chrome__autoDetect(char* out, size_t cap);
 JSWebView* JSWebView::createChrome(JSGlobalObject* g, Structure* structure,
     uint32_t width, uint32_t height, const WTF::String& userDataDir,
     const WTF::String& path, const WTF::Vector<WTF::String>& extraArgv,
-    bool stdoutInherit, bool stderrInherit, const WTF::String& wsUrl)
+    bool stdoutInherit, bool stderrInherit, const WTF::String& wsUrl, bool skipAutoDetect)
 {
     auto* zig = defaultGlobalObject(g);
     auto& t = CDP::transport();
 
-    // Transport selection. Explicit url → connect. Explicit path/argv →
-    // spawn (the user picked an executable; don't redirect them to a
-    // different running Chrome). Neither → auto-detect: if
-    // DevToolsActivePort exists, connect to the existing Chrome; else
-    // spawn. The file read is sync/instant so the constructor stays
-    // synchronous; a stale file surfaces as a connect failure on the
-    // user's first `await navigate()` (onClose → rejectAllAndMarkDead).
+    // Transport selection, in priority order:
+    //   1. url: "ws://..." → connect (autoDetected=false → no fallback)
+    //   2. path/argv set OR url:false → spawn, skip auto-detect
+    //   3. neither → auto-detect DevToolsActivePort → connect OR spawn
     //
-    // All paths end up in the same singleton; first call wins. Second
-    // WebView with a conflicting mode silently uses the existing
-    // transport — same as mismatched path/argv after first spawn.
+    // All paths end up in the same singleton; first call wins. A stale
+    // DevToolsActivePort (Chrome crashed/restarted) triggers the
+    // wsOnClose fallback to spawn (autoDetected=true). The file read is
+    // sync/instant so the constructor stays synchronous.
     bool ok;
     if (!wsUrl.isEmpty()) {
-        ok = t.ensureConnected(zig, wsUrl);
-    } else if (!path.isEmpty() || !extraArgv.isEmpty()) {
+        ok = t.ensureConnected(zig, wsUrl, /* autoDetected */ false);
+    } else if (skipAutoDetect || !path.isEmpty() || !extraArgv.isEmpty()) {
         ok = t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit);
     } else {
-        // Auto-detect. DevToolsActivePort URL is at most
+        // Auto-detect. DevToolsActivePort URL caps at
         // ws://127.0.0.1:65535/devtools/browser/<36-char-uuid> ≈ 70B.
         char buf[128];
         size_t len = Bun__Chrome__autoDetect(buf, sizeof(buf));
         if (len > 0) {
-            ok = t.ensureConnected(zig, WTF::String::fromUTF8(std::span<const char>(buf, len)));
+            ok = t.ensureConnected(zig,
+                WTF::String::fromUTF8(std::span<const char>(buf, len)),
+                /* autoDetected */ true);
         } else {
             ok = t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit);
         }

--- a/src/bun.js/webview/JSWebView.cpp
+++ b/src/bun.js/webview/JSWebView.cpp
@@ -157,6 +157,7 @@ void JSWebView::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_pendingEval);
     visitor.append(thisObject->m_pendingScreenshot);
     visitor.append(thisObject->m_pendingMisc);
+    visitor.append(thisObject->m_pendingCdp);
 }
 
 DEFINE_VISIT_CHILDREN(JSWebView);
@@ -198,6 +199,15 @@ JSPromise* JSWebView::screenshot(JSGlobalObject* g, ScreenshotFormat format, uin
     m_screenshotFormat = format;
     if (m_backend == WebViewBackend::Chrome) return CDP::Ops::screenshot(g, this, format, quality);
     WK_DISPATCH(WK::Ops::screenshot(g, this, format, quality));
+}
+
+JSPromise* JSWebView::cdp(JSGlobalObject* g, const WTF::String& method, const WTF::String& paramsJson)
+{
+    // Chrome-only — the prototype function already threw for WebKit. The
+    // backend check here is defensive (RELEASE_ASSERT would work but costs
+    // nothing to return a rejected promise instead).
+    ASSERT(m_backend == WebViewBackend::Chrome);
+    return CDP::Ops::cdp(g, this, method, paramsJson);
 }
 
 JSPromise* JSWebView::click(JSGlobalObject* g, float x, float y, uint8_t button, uint8_t modifiers, uint8_t clickCount)

--- a/src/bun.js/webview/JSWebView.h
+++ b/src/bun.js/webview/JSWebView.h
@@ -48,9 +48,12 @@ enum class ScreenshotEncoding : uint8_t {
 inline const char* screenshotMimeType(ScreenshotFormat f)
 {
     switch (f) {
-    case ScreenshotFormat::Png: return "image/png";
-    case ScreenshotFormat::Jpeg: return "image/jpeg";
-    case ScreenshotFormat::Webp: return "image/webp";
+    case ScreenshotFormat::Png:
+        return "image/png";
+    case ScreenshotFormat::Jpeg:
+        return "image/jpeg";
+    case ScreenshotFormat::Webp:
+        return "image/webp";
     }
     return "image/png";
 }

--- a/src/bun.js/webview/JSWebView.h
+++ b/src/bun.js/webview/JSWebView.h
@@ -111,6 +111,9 @@ public:
     JSC::WriteBarrier<JSC::JSPromise> m_pendingScreenshot;
     // Resize/Back/Forward/Reload/Close — one at a time, the child is fast.
     JSC::WriteBarrier<JSC::JSPromise> m_pendingMisc;
+    // Chrome-only: raw view.cdp(method, params) escape hatch. Separate
+    // slot so it doesn't block resize/goBack. Still one raw op at a time.
+    JSC::WriteBarrier<JSC::JSPromise> m_pendingCdp;
     // Read by isReachableFromOpaqueRoots on the GC thread — the barriers
     // themselves are not safe to read there. Inc BEFORE slot.set(), dec
     // AFTER slot.clear(), so GC never sees a set slot with count==0.
@@ -134,6 +137,10 @@ public:
     JSC::JSPromise* navigate(JSC::JSGlobalObject*, const WTF::String& url);
     JSC::JSPromise* evaluate(JSC::JSGlobalObject*, const WTF::String& script);
     JSC::JSPromise* screenshot(JSC::JSGlobalObject*, ScreenshotFormat, uint8_t quality);
+    // Chrome-only. Raw CDP escape hatch — method is "Domain.method",
+    // paramsJson is JSON.stringify(params) or "{}". Returns the decoded
+    // result object from the CDP response.
+    JSC::JSPromise* cdp(JSC::JSGlobalObject*, const WTF::String& method, const WTF::String& paramsJson);
     JSC::JSPromise* click(JSC::JSGlobalObject*, float x, float y, uint8_t button, uint8_t modifiers, uint8_t clickCount);
     JSC::JSPromise* clickSelector(JSC::JSGlobalObject*, const WTF::String& selector, uint32_t timeout, uint8_t button, uint8_t modifiers, uint8_t clickCount);
     JSC::JSPromise* type(JSC::JSGlobalObject*, const WTF::String& text);

--- a/src/bun.js/webview/JSWebView.h
+++ b/src/bun.js/webview/JSWebView.h
@@ -27,6 +27,24 @@ enum class ScreenshotFormat : uint8_t {
           // WebKit via CGImageDestination with public.webp UTI (macOS 11+).
 };
 
+// How the image bytes are handed back to JS. The child (WebKit host,
+// Chrome) always produces encoded image bytes; only the parent-side
+// post-receive handling differs.
+enum class ScreenshotEncoding : uint8_t {
+    Blob, // default. WebKit: mmap'd shm → Blob store (zero-copy).
+          // Chrome: base64-decode → Blob.
+    Buffer, // WebKit: mmap'd shm → ArrayBuffer with munmap destructor
+            // (zero-copy — same mapping as Blob, just wrapped as a
+            // JSUint8Array Buffer). Chrome: base64-decode → Buffer.
+    Base64, // WebKit: mmap → base64Encode → string, munmap.
+            // Chrome: return the CDP "data" field as-is (zero decode).
+    Shmem, // POSIX shm name + size. Parent does NOT shm_unlink —
+           // caller (or Kitty via its t=s transmission mode) owns
+           // cleanup. WebKit: the child already wrote here; just skip
+           // our unlink. Chrome: create a fresh shm, write decoded
+           // bytes, return name. Not supported on Windows.
+};
+
 inline const char* screenshotMimeType(ScreenshotFormat f)
 {
     switch (f) {
@@ -86,11 +104,13 @@ public:
     // goBack/goForward stash — PageGetNavigationHistory chains into
     // navigateToHistoryEntry with entries[currentIndex + delta].id.
     int8_t m_chromeHistoryDelta = 0;
-    // Screenshot format stash — set by screenshot() before dispatch, read
-    // by both backends' response handlers to stamp the right MIME type on
-    // the Blob. The CDP/IPC payloads don't echo the format; stashing here
-    // is simpler than threading it through Pending/viewId routing.
+    // Screenshot format/encoding stash — set by screenshot() before
+    // dispatch, read by both backends' response handlers. CDP/IPC payloads
+    // don't echo these; stashing here is simpler than threading them
+    // through Pending/viewId routing. format → MIME type on the Blob;
+    // encoding → how the bytes are wrapped (Blob/Buffer/base64/shmem).
     ScreenshotFormat m_screenshotFormat = ScreenshotFormat::Png;
+    ScreenshotEncoding m_screenshotEncoding = ScreenshotEncoding::Blob;
 
     JSC::WriteBarrier<JSC::JSObject> m_onNavigated;
     JSC::WriteBarrier<JSC::JSObject> m_onNavigationFailed;

--- a/src/bun.js/webview/JSWebView.h
+++ b/src/bun.js/webview/JSWebView.h
@@ -195,7 +195,8 @@ public:
     static JSWebView* createChrome(JSC::JSGlobalObject*, JSC::Structure*,
         uint32_t width, uint32_t height, const WTF::String& userDataDir,
         const WTF::String& path, const WTF::Vector<WTF::String>& extraArgv,
-        bool stdoutInherit, bool stderrInherit, const WTF::String& wsUrl = {});
+        bool stdoutInherit, bool stderrInherit, const WTF::String& wsUrl = {},
+        bool skipAutoDetect = false);
 
     void finishCreation(JSC::VM&);
     static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue prototype);

--- a/src/bun.js/webview/JSWebView.h
+++ b/src/bun.js/webview/JSWebView.h
@@ -2,7 +2,8 @@
 
 #include "root.h"
 #include "BunClientData.h"
-#include <JavaScriptCore/JSDestructibleObject.h>
+#include "JSEventTarget.h"
+#include "WebViewEventTarget.h"
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/LazyClassStructure.h>
@@ -19,15 +20,39 @@ enum class WebViewBackend : uint8_t {
     Chrome, // Chrome DevTools Protocol via --remote-debugging-pipe
 };
 
-// IPC client. For WebKit, the actual WKWebView lives in the host subprocess;
-// this object holds a viewId and writes length-prefixed frames. For Chrome,
-// this holds a CDP sessionId and writes NUL-delimited JSON to the pipe.
-// Promises for pending ops live in the WriteBarrier slots — no Strong<>.
-class JSWebView final : public JSC::JSDestructibleObject {
+enum class ScreenshotFormat : uint8_t {
+    Png, // lossless, default.
+    Jpeg, // lossy, quality 0-100.
+    Webp, // lossy/lossless by quality. Chrome via CDP format:"webp";
+          // WebKit via CGImageDestination with public.webp UTI (macOS 11+).
+};
+
+inline const char* screenshotMimeType(ScreenshotFormat f)
+{
+    switch (f) {
+    case ScreenshotFormat::Png: return "image/png";
+    case ScreenshotFormat::Jpeg: return "image/jpeg";
+    case ScreenshotFormat::Webp: return "image/webp";
+    }
+    return "image/png";
+}
+
+// IPC client + EventTarget wrapper. For WebKit, the actual WKWebView lives
+// in the host subprocess; this object holds a viewId and writes length-
+// prefixed frames. For Chrome, this holds a CDP sessionId and writes NUL-
+// delimited JSON to the pipe. Promises for pending ops live in the
+// WriteBarrier slots — no Strong<>.
+//
+// Inherits JSEventTarget so addEventListener/removeEventListener/
+// dispatchEvent work. The EventTarget impl (m_wrapped) is a thin
+// WebViewEventTarget that holds just the listener map — all WebView state
+// stays on this wrapper. The Ref<EventTarget> keeps the impl alive; the
+// impl's Weak<JSDOMObject> points back here (set by setWrapper in create).
+class JSWebView final : public WebCore::JSEventTarget {
 public:
-    using Base = JSC::JSDestructibleObject;
+    using Base = WebCore::JSEventTarget;
+    using DOMWrapped = WebViewEventTarget;
     static constexpr unsigned StructureFlags = Base::StructureFlags;
-    static constexpr JSC::DestructionMode needsDestruction = JSC::NeedsDestruction;
 
     WebViewBackend m_backend = WebViewBackend::WebKit;
 
@@ -61,6 +86,11 @@ public:
     // goBack/goForward stash — PageGetNavigationHistory chains into
     // navigateToHistoryEntry with entries[currentIndex + delta].id.
     int8_t m_chromeHistoryDelta = 0;
+    // Screenshot format stash — set by screenshot() before dispatch, read
+    // by both backends' response handlers to stamp the right MIME type on
+    // the Blob. The CDP/IPC payloads don't echo the format; stashing here
+    // is simpler than threading it through Pending/viewId routing.
+    ScreenshotFormat m_screenshotFormat = ScreenshotFormat::Png;
 
     JSC::WriteBarrier<JSC::JSObject> m_onNavigated;
     JSC::WriteBarrier<JSC::JSObject> m_onNavigationFailed;
@@ -86,9 +116,11 @@ public:
     // AFTER slot.clear(), so GC never sees a set slot with count==0.
     std::atomic<uint32_t> m_pendingActivityCount { 0 };
 
-    static JSWebView* create(JSC::VM&, JSC::Structure*);
+    static JSWebView* create(JSC::Structure*, WebCore::JSDOMGlobalObject*, Ref<WebViewEventTarget>&&);
     static void destroy(JSC::JSCell*);
     ~JSWebView();
+
+    WebViewEventTarget& wrapped() const { return static_cast<WebViewEventTarget&>(Base::wrapped()); }
 
     // Instance-level operations. Called from JSWebViewPrototype.cpp after arg
     // validation. Each branches on m_backend: WebKit path encodes binary
@@ -101,7 +133,7 @@ public:
     // (constructor already threw).
     JSC::JSPromise* navigate(JSC::JSGlobalObject*, const WTF::String& url);
     JSC::JSPromise* evaluate(JSC::JSGlobalObject*, const WTF::String& script);
-    JSC::JSPromise* screenshot(JSC::JSGlobalObject*);
+    JSC::JSPromise* screenshot(JSC::JSGlobalObject*, ScreenshotFormat, uint8_t quality);
     JSC::JSPromise* click(JSC::JSGlobalObject*, float x, float y, uint8_t button, uint8_t modifiers, uint8_t clickCount);
     JSC::JSPromise* clickSelector(JSC::JSGlobalObject*, const WTF::String& selector, uint32_t timeout, uint8_t button, uint8_t modifiers, uint8_t clickCount);
     JSC::JSPromise* type(JSC::JSGlobalObject*, const WTF::String& text);
@@ -153,8 +185,14 @@ public:
     }
 
 private:
-    JSWebView(JSC::VM&, JSC::Structure*);
+    JSWebView(JSC::Structure*, WebCore::JSDOMGlobalObject&, Ref<WebViewEventTarget>&&);
 };
+
+// toJS overload for WebViewEventTarget. EventTargetFactory dispatches here
+// when event.target (or event.currentTarget) needs to produce a JS wrapper
+// for a WebViewEventTarget impl. The impl's ScriptWrappable holds a
+// Weak<JSDOMObject> set by create() → wrapper().
+JSC::JSValue toJS(JSC::JSGlobalObject*, WebCore::JSDOMGlobalObject*, WebViewEventTarget&);
 
 void setupJSWebViewClassStructure(JSC::LazyClassStructure::Initializer&);
 

--- a/src/bun.js/webview/JSWebView.h
+++ b/src/bun.js/webview/JSWebView.h
@@ -187,10 +187,12 @@ public:
     // auto-detection; extraArgv appends to the built-in flags. Works on
     // all platforms where Chrome runs (not just Darwin). Returns nullptr
     // if Chrome spawn failed.
+    // wsUrl: connect to an existing Chrome's WebSocket debugger endpoint
+    // instead of spawning. Empty → spawn with --remote-debugging-pipe.
     static JSWebView* createChrome(JSC::JSGlobalObject*, JSC::Structure*,
         uint32_t width, uint32_t height, const WTF::String& userDataDir,
         const WTF::String& path, const WTF::Vector<WTF::String>& extraArgv,
-        bool stdoutInherit, bool stderrInherit);
+        bool stdoutInherit, bool stderrInherit, const WTF::String& wsUrl = {});
 
     void finishCreation(JSC::VM&);
     static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue prototype);

--- a/src/bun.js/webview/JSWebViewConstructor.cpp
+++ b/src/bun.js/webview/JSWebViewConstructor.cpp
@@ -65,7 +65,13 @@ const ClassInfo JSWebViewConstructor::s_info = { "WebView"_s, &Base::s_info, nul
 
 InternalFunction* createJSWebViewConstructor(VM& vm, JSGlobalObject* globalObject, JSObject* prototype)
 {
-    auto* structure = JSWebViewConstructor::createStructure(vm, globalObject, globalObject->functionPrototype());
+    // Bun.WebView.__proto__ === EventTarget (constructor chain, not instance
+    // prototype). Matches DOM convention: BroadcastChannel.__proto__ ===
+    // EventTarget. Lets static-method lookup fall through, and `extends
+    // Bun.WebView` in user code transitively picks up EventTarget's own
+    // static Symbol.hasInstance-less instanceof behavior.
+    auto* etCtor = WebCore::JSEventTarget::getConstructor(vm, globalObject).getObject();
+    auto* structure = JSWebViewConstructor::createStructure(vm, globalObject, etCtor);
     return JSWebViewConstructor::create(vm, structure, prototype);
 }
 

--- a/src/bun.js/webview/JSWebViewConstructor.cpp
+++ b/src/bun.js/webview/JSWebViewConstructor.cpp
@@ -233,6 +233,10 @@ JSC_DEFINE_HOST_FUNCTION(constructWebView, (JSGlobalObject * globalObject, CallF
                     "backend.argv must be an array of strings"_s);
             }
 
+            if (!chromeWsUrl.isEmpty() && (!chromePath.isEmpty() || !chromeArgv.isEmpty()))
+                return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_VALUE,
+                    "backend.url (connect mode) cannot be combined with backend.path or backend.argv (spawn mode)"_s);
+
             // stdout/stderr: "inherit" | "ignore" — whether the subprocess's
             // streams flow to Bun's. Chrome is chatty on stderr (GCM
             // registration errors, updater noise, font-config warnings) even

--- a/src/bun.js/webview/JSWebViewConstructor.cpp
+++ b/src/bun.js/webview/JSWebViewConstructor.cpp
@@ -115,6 +115,7 @@ JSC_DEFINE_HOST_FUNCTION(constructWebView, (JSGlobalObject * globalObject, CallF
 #endif
     WTF::String chromePath;
     WTF::String chromeWsUrl;
+    bool chromeSkipAutoDetect = false;
     WTF::Vector<WTF::String> chromeArgv;
     bool stdoutInherit = false;
     bool stderrInherit = false;
@@ -185,15 +186,15 @@ JSC_DEFINE_HOST_FUNCTION(constructWebView, (JSGlobalObject * globalObject, CallF
                     "backend.path must be a string"_s);
             }
 
-            // url: connect to an already-running Chrome instead of
-            // spawning. Accepts three forms:
-            //   - "127.0.0.1:9222" (bare host:port, what Chrome's Remote
-            //     Debugging panel shows) — we GET /json/version to
-            //     discover webSocketDebuggerUrl
-            //   - "http://127.0.0.1:9222" — same discovery
-            //   - "ws://127.0.0.1:9222/devtools/browser/<id>" — full URL,
-            //     connect directly
-            // Conflicts with path/argv/stdout/stderr (no subprocess).
+            // url: controls the connect-vs-spawn choice.
+            //   - "ws://..." — connect to that DevTools WebSocket directly
+            //   - false — skip DevToolsActivePort auto-detect, always spawn
+            //     (executable path still auto-found if `path` unset)
+            //   - undefined (default) — auto-detect: if DevToolsActivePort
+            //     exists, connect to the existing Chrome; else spawn
+            // Bare host:port isn't accepted — Chrome's new chrome://inspect
+            // toggle 404s /json/version so there's no HTTP discovery path;
+            // the file IS the discovery source.
             JSValue urlOpt = beObj->get(globalObject, Identifier::fromString(vm, "url"_s));
             RETURN_IF_EXCEPTION(scope, {});
             if (urlOpt.isString()) {
@@ -202,9 +203,15 @@ JSC_DEFINE_HOST_FUNCTION(constructWebView, (JSGlobalObject * globalObject, CallF
                         "backend.url requires type: \"chrome\""_s);
                 chromeWsUrl = urlOpt.toWTFString(globalObject);
                 RETURN_IF_EXCEPTION(scope, {});
+                if (!chromeWsUrl.startsWith("ws://"_s) && !chromeWsUrl.startsWith("wss://"_s))
+                    return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_VALUE,
+                        "backend.url must be a ws:// URL (read DevToolsActivePort from Chrome's profile dir, "
+                        "or omit url to auto-detect)"_s);
+            } else if (urlOpt.isFalse()) {
+                chromeSkipAutoDetect = true;
             } else if (!urlOpt.isUndefined()) {
                 return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
-                    "backend.url must be a string"_s);
+                    "backend.url must be a ws:// string or false"_s);
             }
 
             JSValue argvVal = beObj->get(globalObject, Identifier::fromString(vm, "argv"_s));
@@ -332,7 +339,8 @@ JSC_DEFINE_HOST_FUNCTION(constructWebView, (JSGlobalObject * globalObject, CallF
     if (backend == WebViewBackend::Chrome) {
         Bun__Feature__webview_chrome += 1;
         JSWebView* view = JSWebView::createChrome(globalObject, structure, width, height,
-            persistDir, chromePath, chromeArgv, stdoutInherit, stderrInherit, chromeWsUrl);
+            persistDir, chromePath, chromeArgv, stdoutInherit, stderrInherit, chromeWsUrl,
+            chromeSkipAutoDetect);
         if (!view) {
             return Bun::throwError(globalObject, scope, ErrorCode::ERR_DLOPEN_FAILED,
                 chromeWsUrl.isEmpty()

--- a/src/bun.js/webview/JSWebViewConstructor.cpp
+++ b/src/bun.js/webview/JSWebViewConstructor.cpp
@@ -114,6 +114,7 @@ JSC_DEFINE_HOST_FUNCTION(constructWebView, (JSGlobalObject * globalObject, CallF
     WebViewBackend backend = WebViewBackend::Chrome;
 #endif
     WTF::String chromePath;
+    WTF::String chromeWsUrl;
     WTF::Vector<WTF::String> chromeArgv;
     bool stdoutInherit = false;
     bool stderrInherit = false;
@@ -182,6 +183,28 @@ JSC_DEFINE_HOST_FUNCTION(constructWebView, (JSGlobalObject * globalObject, CallF
             } else if (!path.isUndefined()) {
                 return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
                     "backend.path must be a string"_s);
+            }
+
+            // url: connect to an already-running Chrome instead of
+            // spawning. Accepts three forms:
+            //   - "127.0.0.1:9222" (bare host:port, what Chrome's Remote
+            //     Debugging panel shows) — we GET /json/version to
+            //     discover webSocketDebuggerUrl
+            //   - "http://127.0.0.1:9222" — same discovery
+            //   - "ws://127.0.0.1:9222/devtools/browser/<id>" — full URL,
+            //     connect directly
+            // Conflicts with path/argv/stdout/stderr (no subprocess).
+            JSValue urlOpt = beObj->get(globalObject, Identifier::fromString(vm, "url"_s));
+            RETURN_IF_EXCEPTION(scope, {});
+            if (urlOpt.isString()) {
+                if (backend != WebViewBackend::Chrome)
+                    return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_VALUE,
+                        "backend.url requires type: \"chrome\""_s);
+                chromeWsUrl = urlOpt.toWTFString(globalObject);
+                RETURN_IF_EXCEPTION(scope, {});
+            } else if (!urlOpt.isUndefined()) {
+                return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
+                    "backend.url must be a string"_s);
             }
 
             JSValue argvVal = beObj->get(globalObject, Identifier::fromString(vm, "argv"_s));
@@ -309,10 +332,12 @@ JSC_DEFINE_HOST_FUNCTION(constructWebView, (JSGlobalObject * globalObject, CallF
     if (backend == WebViewBackend::Chrome) {
         Bun__Feature__webview_chrome += 1;
         JSWebView* view = JSWebView::createChrome(globalObject, structure, width, height,
-            persistDir, chromePath, chromeArgv, stdoutInherit, stderrInherit);
+            persistDir, chromePath, chromeArgv, stdoutInherit, stderrInherit, chromeWsUrl);
         if (!view) {
             return Bun::throwError(globalObject, scope, ErrorCode::ERR_DLOPEN_FAILED,
-                "Failed to spawn Chrome (set BUN_CHROME_PATH, backend.path, or install Chrome/Chromium)"_s);
+                chromeWsUrl.isEmpty()
+                    ? "Failed to spawn Chrome (set BUN_CHROME_PATH, backend.path, or install Chrome/Chromium)"_s
+                    : "Failed to connect to Chrome (check backend.url is a valid ws:// debugger endpoint)"_s);
         }
         view->m_consoleIsGlobal = consoleIsGlobal;
         if (consoleCallback) view->m_onConsole.set(vm, view, consoleCallback);

--- a/src/bun.js/webview/JSWebViewPrototype.cpp
+++ b/src/bun.js/webview/JSWebViewPrototype.cpp
@@ -9,6 +9,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
+#include <JavaScriptCore/JSONObject.h>
 #include <wtf/text/MakeString.h>
 
 #include "ipc_protocol.h" // VirtualKey, Mod*
@@ -20,6 +21,7 @@ using namespace JSC;
 static JSC_DECLARE_HOST_FUNCTION(jsWebViewProtoFuncNavigate);
 static JSC_DECLARE_HOST_FUNCTION(jsWebViewProtoFuncEvaluate);
 static JSC_DECLARE_HOST_FUNCTION(jsWebViewProtoFuncScreenshot);
+static JSC_DECLARE_HOST_FUNCTION(jsWebViewProtoFuncCdp);
 static JSC_DECLARE_HOST_FUNCTION(jsWebViewProtoFuncClick);
 static JSC_DECLARE_HOST_FUNCTION(jsWebViewProtoFuncType);
 static JSC_DECLARE_HOST_FUNCTION(jsWebViewProtoFuncPress);
@@ -43,6 +45,7 @@ static const HashTableValue JSWebViewPrototypeTableValues[] = {
     { "navigate"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsWebViewProtoFuncNavigate, 1 } },
     { "evaluate"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsWebViewProtoFuncEvaluate, 1 } },
     { "screenshot"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsWebViewProtoFuncScreenshot, 0 } },
+    { "cdp"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsWebViewProtoFuncCdp, 1 } },
     { "click"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsWebViewProtoFuncClick, 2 } },
     { "type"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsWebViewProtoFuncType, 1 } },
     { "press"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsWebViewProtoFuncPress, 1 } },
@@ -292,6 +295,69 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncScreenshot, (JSGlobalObject * globalO
     }
 
     return JSValue::encode(thisObject->screenshot(globalObject, format, quality));
+}
+
+// Raw Chrome DevTools Protocol escape hatch. view.cdp("Domain.method",
+// {params}) → JSON.parse(response.result). Chrome-only: WebKit's host
+// subprocess speaks a binary frame protocol, not CDP. WKWebView DOES have
+// _WKInspector SPI but wiring it through the host process + shm is a
+// different project.
+//
+// params is JSON.stringify'd here and inserted verbatim into the CDP
+// envelope. JSONStringify rejects cycles and non-serializable values with
+// a TypeError — same as `JSON.stringify(params)` in user code.
+//
+// The command carries this view's sessionId, so it targets THIS tab.
+// Domain-qualified: "Page.captureScreenshot", "Runtime.evaluate",
+// "DOM.querySelector", etc. Not validated here — Chrome returns a
+// {"code":-32601,"message":"'Foo.bar' wasn't found"} error which rejects
+// the promise.
+JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncCdp, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* thisObject = unwrapThis(globalObject, scope, callFrame, "cdp"_s);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (thisObject->m_backend != WebViewBackend::Chrome)
+        return Bun::throwError(globalObject, scope, ErrorCode::ERR_METHOD_NOT_IMPLEMENTED,
+            "WebView.cdp() requires backend: \"chrome\""_s);
+
+    // Must have attached (first navigate() completes the target→session
+    // chain). Before attach there's no sessionId; a browser-level CDP
+    // command here would reach the wrong target. The user can `await
+    // navigate(...)` first to get a session, or use Bun.WebView.chrome()
+    // for browser-level commands (v2).
+    if (thisObject->m_sessionId.isEmpty())
+        return Bun::ERR::INVALID_STATE(scope, globalObject,
+            "WebView.cdp(): no session - await navigate() first"_s);
+
+    JSValue methodArg = callFrame->argument(0);
+    if (!methodArg.isString())
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "method"_s, "string"_s, methodArg);
+    WTF::String method = methodArg.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    // params: JSON.stringify or default to "{}". JSONStringify handles
+    // escape/encoding; its output is well-formed JSON we can insert
+    // verbatim into the CDP envelope. undefined/null → "{}" (most CDP
+    // methods accept empty params).
+    JSValue paramsArg = callFrame->argument(1);
+    WTF::String paramsJson;
+    if (paramsArg.isUndefinedOrNull()) {
+        paramsJson = "{}"_s;
+    } else {
+        paramsJson = JSONStringify(globalObject, paramsArg, 0);
+        RETURN_IF_EXCEPTION(scope, {});
+        // JSONStringify returns empty for non-serializable (function,
+        // symbol as root). CDP params must be an object.
+        if (paramsJson.isEmpty() || paramsJson[0] != '{')
+            return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
+                "params must be a JSON-serializable object"_s);
+    }
+
+    if (!checkSlot(globalObject, scope, thisObject->m_pendingCdp, "a cdp()"_s)) return {};
+    return JSValue::encode(thisObject->cdp(globalObject, method, paramsJson));
 }
 
 // --- Native input -----------------------------------------------------------

--- a/src/bun.js/webview/JSWebViewPrototype.cpp
+++ b/src/bun.js/webview/JSWebViewPrototype.cpp
@@ -112,7 +112,13 @@ const ClassInfo JSWebViewPrototype::s_info = { "WebView"_s, &Base::s_info, nullp
 
 JSObject* createJSWebViewPrototype(VM& vm, JSGlobalObject* globalObject)
 {
-    auto* structure = JSWebViewPrototype::createStructure(vm, globalObject, globalObject->objectPrototype());
+    // Chain to EventTarget.prototype — addEventListener/removeEventListener/
+    // dispatchEvent live there and unwrap `this` via jsDynamicCast<JSEventTarget*>,
+    // which succeeds for JSWebView : JSEventTarget. WebView.prototype.__proto__
+    // === EventTarget.prototype; `view instanceof EventTarget` is true.
+    auto* domGlobal = jsCast<WebCore::JSDOMGlobalObject*>(globalObject);
+    auto* etProto = WebCore::JSEventTarget::prototype(vm, *domGlobal);
+    auto* structure = JSWebViewPrototype::createStructure(vm, globalObject, etProto);
     return JSWebViewPrototype::create(vm, globalObject, structure);
 }
 
@@ -241,7 +247,51 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncScreenshot, (JSGlobalObject * globalO
     auto* thisObject = unwrapThis(globalObject, scope, callFrame, "screenshot"_s);
     RETURN_IF_EXCEPTION(scope, {});
     if (!checkSlot(globalObject, scope, thisObject->m_pendingScreenshot, "a screenshot()"_s)) return {};
-    return JSValue::encode(thisObject->screenshot(globalObject));
+
+    ScreenshotFormat format = ScreenshotFormat::Png;
+    uint8_t quality = 80; // CDP default for jpeg/webp. Ignored for png.
+
+    JSValue optsVal = callFrame->argument(0);
+    if (optsVal.isObject()) {
+        JSObject* opts = optsVal.getObject();
+        JSValue fmtVal = opts->get(globalObject, Identifier::fromString(vm, "format"_s));
+        RETURN_IF_EXCEPTION(scope, {});
+        if (fmtVal.isString()) {
+            auto s = fmtVal.toWTFString(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (s == "png"_s)
+                format = ScreenshotFormat::Png;
+            else if (s == "jpeg"_s)
+                format = ScreenshotFormat::Jpeg;
+            else if (s == "webp"_s) {
+                // NSBitmapImageRep's representationUsingType: has no WebP
+                // enum value — would need ImageIO's CGImageDestination with
+                // public.webp UTI (macOS 11+), which is a separate dlsym
+                // surface not yet wired. Chrome-only until then.
+                if (thisObject->m_backend != WebViewBackend::Chrome)
+                    return Bun::throwError(globalObject, scope, ErrorCode::ERR_METHOD_NOT_IMPLEMENTED,
+                        "format: \"webp\" requires backend: \"chrome\""_s);
+                format = ScreenshotFormat::Webp;
+            } else
+                return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_VALUE,
+                    "format must be \"png\", \"jpeg\", or \"webp\""_s);
+        } else if (!fmtVal.isUndefined())
+            return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
+                "format must be a string"_s);
+
+        JSValue qVal = opts->get(globalObject, Identifier::fromString(vm, "quality"_s));
+        RETURN_IF_EXCEPTION(scope, {});
+        if (qVal.isNumber()) {
+            double q = qVal.asNumber();
+            if (q < 0 || q > 100)
+                return Bun::ERR::OUT_OF_RANGE(scope, globalObject, "quality"_s, 0, 100, qVal);
+            quality = static_cast<uint8_t>(q);
+        } else if (!qVal.isUndefined())
+            return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
+                "quality must be a number"_s);
+    }
+
+    return JSValue::encode(thisObject->screenshot(globalObject, format, quality));
 }
 
 // --- Native input -----------------------------------------------------------

--- a/src/bun.js/webview/JSWebViewPrototype.cpp
+++ b/src/bun.js/webview/JSWebViewPrototype.cpp
@@ -252,6 +252,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncScreenshot, (JSGlobalObject * globalO
     if (!checkSlot(globalObject, scope, thisObject->m_pendingScreenshot, "a screenshot()"_s)) return {};
 
     ScreenshotFormat format = ScreenshotFormat::Png;
+    ScreenshotEncoding encoding = ScreenshotEncoding::Blob;
     uint8_t quality = 80; // CDP default for jpeg/webp. Ignored for png.
 
     JSValue optsVal = callFrame->argument(0);
@@ -292,8 +293,39 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncScreenshot, (JSGlobalObject * globalO
         } else if (!qVal.isUndefined())
             return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
                 "quality must be a number"_s);
+
+        // encoding: how the bytes are handed back. "shmem" is for Kitty
+        // graphics protocol t=s — returns {name, size}, we skip our
+        // shm_unlink, the terminal handles cleanup.
+        JSValue encVal = opts->get(globalObject, Identifier::fromString(vm, "encoding"_s));
+        RETURN_IF_EXCEPTION(scope, {});
+        if (encVal.isString()) {
+            auto s = encVal.toWTFString(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (s == "blob"_s)
+                encoding = ScreenshotEncoding::Blob;
+            else if (s == "buffer"_s)
+                encoding = ScreenshotEncoding::Buffer;
+            else if (s == "base64"_s)
+                encoding = ScreenshotEncoding::Base64;
+            else if (s == "shmem"_s) {
+#if OS(WINDOWS)
+                // No POSIX shm. Kitty on Windows uses temp files (t=t)
+                // or direct (t=d) transmission anyway.
+                return Bun::throwError(globalObject, scope, ErrorCode::ERR_METHOD_NOT_IMPLEMENTED,
+                    "encoding: \"shmem\" is not supported on Windows"_s);
+#else
+                encoding = ScreenshotEncoding::Shmem;
+#endif
+            } else
+                return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_VALUE,
+                    "encoding must be \"blob\", \"buffer\", \"base64\", or \"shmem\""_s);
+        } else if (!encVal.isUndefined())
+            return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
+                "encoding must be a string"_s);
     }
 
+    thisObject->m_screenshotEncoding = encoding;
     return JSValue::encode(thisObject->screenshot(globalObject, format, quality));
 }
 

--- a/src/bun.js/webview/JSWebViewPrototype.cpp
+++ b/src/bun.js/webview/JSWebViewPrototype.cpp
@@ -249,7 +249,6 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncScreenshot, (JSGlobalObject * globalO
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = unwrapThis(globalObject, scope, callFrame, "screenshot"_s);
     RETURN_IF_EXCEPTION(scope, {});
-    if (!checkSlot(globalObject, scope, thisObject->m_pendingScreenshot, "a screenshot()"_s)) return {};
 
     ScreenshotFormat format = ScreenshotFormat::Png;
     ScreenshotEncoding encoding = ScreenshotEncoding::Blob;
@@ -324,6 +323,12 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncScreenshot, (JSGlobalObject * globalO
             return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
                 "encoding must be a string"_s);
     }
+
+    // checkSlot after option parsing: opts->get() can invoke Proxy getters
+    // that call view.close() between the guard and the screenshot() send.
+    if (!checkSlot(globalObject, scope, thisObject->m_pendingScreenshot, "a screenshot()"_s)) return {};
+    if (thisObject->m_closed)
+        return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_STATE, "WebView is closed"_s);
 
     thisObject->m_screenshotEncoding = encoding;
     return JSValue::encode(thisObject->screenshot(globalObject, format, quality));
@@ -602,13 +607,22 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncResize, (JSGlobalObject * globalObjec
     return JSValue::encode(thisObject->resize(globalObject, w, h));
 }
 
+// Chrome back/forward chains Page.getNavigationHistory →
+// Page.navigateToHistoryEntry and settles via Page.loadEventFired, which
+// only resolves PendingSlot::Navigate. WebKit's Op::History Ack is sync
+// (Misc). Same backend-dependent slot as reload.
+static auto& navSlot(JSWebView* view)
+{
+    return view->m_backend == WebViewBackend::Chrome ? view->m_pendingNavigate : view->m_pendingMisc;
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncBack, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = unwrapThis(globalObject, scope, callFrame, "goBack"_s);
     RETURN_IF_EXCEPTION(scope, {});
-    if (!checkSlot(globalObject, scope, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
+    if (!checkSlot(globalObject, scope, navSlot(thisObject), "a navigation"_s)) return {};
     return JSValue::encode(thisObject->goBack(globalObject));
 }
 
@@ -618,7 +632,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncForward, (JSGlobalObject * globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = unwrapThis(globalObject, scope, callFrame, "goForward"_s);
     RETURN_IF_EXCEPTION(scope, {});
-    if (!checkSlot(globalObject, scope, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
+    if (!checkSlot(globalObject, scope, navSlot(thisObject), "a navigation"_s)) return {};
     return JSValue::encode(thisObject->goForward(globalObject));
 }
 
@@ -628,12 +642,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncReload, (JSGlobalObject * globalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = unwrapThis(globalObject, scope, callFrame, "reload"_s);
     RETURN_IF_EXCEPTION(scope, {});
-    // Chrome reload uses the Navigate slot (Page.loadEventFired settles it);
-    // WebKit reload uses Misc (Op::Reload Ack is sync). Check the backend's.
-    auto& slot = thisObject->m_backend == WebViewBackend::Chrome
-        ? thisObject->m_pendingNavigate
-        : thisObject->m_pendingMisc;
-    if (!checkSlot(globalObject, scope, slot, "a navigation"_s)) return {};
+    if (!checkSlot(globalObject, scope, navSlot(thisObject), "a navigation"_s)) return {};
     return JSValue::encode(thisObject->reload(globalObject));
 }
 

--- a/src/bun.js/webview/JSWebViewPrototype.cpp
+++ b/src/bun.js/webview/JSWebViewPrototype.cpp
@@ -393,6 +393,10 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncCdp, (JSGlobalObject * globalObject, 
                 "params must be a JSON-serializable object"_s);
     }
 
+    // Same TOCTOU as screenshot: JSONStringify can call a user-supplied
+    // .toJSON() that closes the view between the earlier guards and send.
+    if (thisObject->m_closed)
+        return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_STATE, "WebView is closed"_s);
     if (!checkSlot(globalObject, scope, thisObject->m_pendingCdp, "a cdp()"_s)) return {};
     return JSValue::encode(thisObject->cdp(globalObject, method, paramsJson));
 }

--- a/src/bun.js/webview/JSWebViewPrototype.cpp
+++ b/src/bun.js/webview/JSWebViewPrototype.cpp
@@ -286,7 +286,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncScreenshot, (JSGlobalObject * globalO
         RETURN_IF_EXCEPTION(scope, {});
         if (qVal.isNumber()) {
             double q = qVal.asNumber();
-            if (q < 0 || q > 100)
+            if (!std::isfinite(q) || q < 0 || q > 100)
                 return Bun::ERR::OUT_OF_RANGE(scope, globalObject, "quality"_s, 0, 100, qVal);
             quality = static_cast<uint8_t>(q);
         } else if (!qVal.isUndefined())

--- a/src/bun.js/webview/ObjCRuntime.h
+++ b/src/bun.js/webview/ObjCRuntime.h
@@ -159,6 +159,12 @@ struct NSDictionary : Ref {
     static SEL s_dictionaryWithObjects_forKeys_count;
     static SEL s_objectForKey;
     id objectForKey(id key) const { return msg<id>(s_objectForKey, key); }
+    static NSDictionary with1(id v1, id k1)
+    {
+        id vs[1] = { v1 };
+        id ks[1] = { k1 };
+        return msgCls<id>(cls, s_dictionaryWithObjects_forKeys_count, vs, ks, (unsigned long)1);
+    }
     static NSDictionary with2(id v1, id k1, id v2, id k2)
     {
         id vs[2] = { v1, v2 };
@@ -282,15 +288,19 @@ struct NSBitmapImageRep : Ref {
     static SEL s_initWithCGImage;
     static SEL s_representationUsingType_properties;
 
-    // Autoreleased NSData PNG bytes. rep is released before return.
-    static NSData pngFromCGImage(id cgimage)
+    // Autoreleased NSData encoded bytes. rep is released before return.
+    // NSBitmapImageFileType: PNG=4, JPEG=3. WebP is NOT in this enum —
+    // representationUsingType: only does TIFF/BMP/GIF/JPEG/PNG/JPEG2000.
+    // quality (0.0-1.0) goes via NSImageCompressionFactor in the properties
+    // dict; ignored for PNG. nil props means defaults (PNG lossless, JPEG
+    // at some framework default ~0.75).
+    static NSData encodeFromCGImage(id cgimage, unsigned long fileType, id propsDict)
     {
         NSBitmapImageRep rep(msgCls<id>(cls, s_alloc));
         rep.m_id = rep.msg<id>(s_initWithCGImage, cgimage);
-        id png = rep.msg<id>(s_representationUsingType_properties,
-            (unsigned long)4 /* NSBitmapImageFileTypePNG */, (id) nullptr);
+        id data = rep.msg<id>(s_representationUsingType_properties, fileType, propsDict);
         rep.release();
-        return png;
+        return data;
     }
 };
 

--- a/src/bun.js/webview/WebKitBackend.cpp
+++ b/src/bun.js/webview/WebKitBackend.cpp
@@ -14,8 +14,6 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
 #include <JavaScriptCore/JSPromise.h>
-#include <JavaScriptCore/TypedArrayInlines.h>
-#include <JavaScriptCore/JSTypedArrays.h>
 #include <JavaScriptCore/JSONObject.h>
 #include <JavaScriptCore/Weak.h>
 #include <JavaScriptCore/WeakInlines.h>
@@ -40,6 +38,8 @@ using namespace WebViewProto;
 
 // Spawn + process-exit watch in Zig (reuses bun.spawn.Process / EVFILT_PROC).
 extern "C" int32_t Bun__WebViewHost__ensure(Zig::GlobalObject*, bool stdoutInherit, bool stderrInherit);
+extern "C" void* Blob__fromMmapWithType(JSC::JSGlobalObject*, uint8_t* ptr, size_t len, const char* mime);
+extern "C" JSC::EncodedJSValue SYSV_ABI Blob__create(Zig::GlobalObject*, void* impl);
 extern "C" void Bun__eventLoop__incrementRefConcurrently(void* bunVM, int delta);
 // Bracket the whole onData batch. exit() drains microtasks when outermost,
 // so all the promise reactions from this batch run before we return to usockets.
@@ -199,41 +199,45 @@ void HostClient::onWritable()
     }
 }
 
-// Returns Uint8Array on success, JS Error on failure. May throw (OOM in
-// createUninitialized); onData's TopExceptionScope reports + clears.
-static JSValue openShmScreenshot(JSGlobalObject* g, const char* name, uint32_t nameLen, uint32_t pngLen)
+// Returns a Blob on success, JS Error on failure. The Blob adopts the
+// mmap'd shm region directly — no copy. Its store's allocator vtable
+// munmap's on free (when the last ref drops). The shm segment survives
+// the name-unlink because the mapping is a live reference; the physical
+// pages free when the user drops the Blob AND the child's write-side
+// mapping is gone (child unmaps after sendReply, so by the time we're
+// here the child side is already dropped — our mapping is the only one).
+static JSValue openShmScreenshot(JSGlobalObject* g, const char* name, uint32_t nameLen, uint32_t byteLen, const char* mime, bool& ok)
 {
-    auto& vm = g->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
+    ok = false;
 
-    // Parent owns the unlink — we know when the JS side is done with the bytes.
     WTF::Vector<char, 64> zname;
     zname.grow(nameLen + 1);
     memcpy(zname.mutableSpan().data(), name, nameLen);
     zname[nameLen] = '\0';
 
-    int fd = shm_open(zname.span().data(), O_RDONLY, 0);
+    // O_RDWR + PROT_WRITE — the Zig allocator wrapper poisons freed memory
+    // with @memset(undefined) in safe builds BEFORE calling the vtable's
+    // free (which munmap's). A PROT_READ mapping SIGBUS'd on that poison.
+    // MAP_SHARED is required for POSIX shm objects on macOS — MAP_PRIVATE
+    // returns EINVAL (the kernel's posix_shm vfs doesn't implement the
+    // VM_BEHAVIOR_COPY path). The child already munmapped its side before
+    // sendReply, so we're the sole mapper; writes don't race with anyone.
+    // The name is unlinked next, so no third process can shm_open it.
+    int fd = shm_open(zname.span().data(), O_RDWR, 0);
     if (fd < 0)
-        RELEASE_AND_RETURN(scope, createError(g, makeString("shm_open: "_s, WTF::String::fromUTF8(strerror(errno)))));
-    void* map = mmap(nullptr, pngLen, PROT_READ, MAP_SHARED, fd, 0);
+        return createError(g, makeString("shm_open: "_s, WTF::String::fromUTF8(strerror(errno))));
+    void* map = mmap(nullptr, byteLen, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     ::close(fd);
     shm_unlink(zname.span().data());
     if (map == MAP_FAILED)
-        RELEASE_AND_RETURN(scope, createError(g, makeString("mmap: "_s, WTF::String::fromUTF8(strerror(errno)))));
+        return createError(g, makeString("mmap: "_s, WTF::String::fromUTF8(strerror(errno))));
 
-    auto* u8 = JSUint8Array::createUninitialized(g, g->m_typedArrayUint8.get(g), pngLen);
-    if (scope.exception() || !u8) [[unlikely]] {
-        munmap(map, pngLen);
-        // createUninitialized threw (OOM). Propagate — the caller's
-        // TopExceptionScope reports and clears between frames. The promise
-        // rejects with jsUndefined (result.inherits<JSUint8Array>() is false),
-        // which isn't pretty, but OOM during a screenshot memcpy means we're
-        // about to die anyway.
-        RELEASE_AND_RETURN(scope, jsUndefined());
-    }
-    memcpy(u8->typedVector(), map, pngLen);
-    munmap(map, pngLen);
-    RELEASE_AND_RETURN(scope, u8);
+    // Blob adopts the mapping — no copy. Store's allocator.free munmap's
+    // when the Blob's refcount drops to zero. `await blob.bytes()` reads
+    // directly from these pages; `Bun.write(path, blob)` writes from them.
+    void* impl = Blob__fromMmapWithType(g, static_cast<uint8_t*>(map), byteLen, mime);
+    ok = true;
+    return JSValue::decode(Blob__create(defaultGlobalObject(g), impl));
 }
 
 void HostClient::handleReply(const Frame& h, Reader r)
@@ -355,8 +359,10 @@ void HostClient::handleReply(const Frame& h, Reader r)
         uint32_t nameLen = r.u32();
         const char* name = reinterpret_cast<const char*>(r.bytes(nameLen));
         uint32_t pngLen = r.u32();
-        JSValue result = openShmScreenshot(g, name, nameLen, pngLen);
-        settleSlot(g, view, view->m_pendingScreenshot, result.inherits<JSUint8Array>(), result);
+        bool ok;
+        JSValue result = openShmScreenshot(g, name, nameLen, pngLen,
+            screenshotMimeType(view->m_screenshotFormat), ok);
+        settleSlot(g, view, view->m_pendingScreenshot, ok, result);
         return;
     }
     case Reply::ScreenshotFailed:
@@ -434,7 +440,7 @@ void HostClient::onData(const char* data, int length)
         off += sizeof(Frame) + h.len;
 
         handleReply(h, r);
-        // createError/jsString/createUninitialized can throw (OOM). Report +
+        // createError/jsString/Blob__create can throw (OOM). Report +
         // clear so one bad frame doesn't poison the rest of the batch.
         if (auto* exception = catchScope.exception()) [[unlikely]] {
             if (!catchScope.clearExceptionExceptTermination()) break;
@@ -491,9 +497,16 @@ JSPromise* evaluate(JSGlobalObject* g, JSWebView* view, const WTF::String& scrip
         payload.span().data(), static_cast<uint32_t>(payload.size()));
 }
 
-JSPromise* screenshot(JSGlobalObject* g, JSWebView* view)
+JSPromise* screenshot(JSGlobalObject* g, JSWebView* view, ScreenshotFormat format, uint8_t quality)
 {
-    return sendOp(g, view, view->m_pendingScreenshot, Op::Screenshot, nullptr, 0);
+    // Two bytes: format enum + quality. Child picks the CGImageDestination
+    // UTI (public.png / public.jpeg / public.webp) and
+    // kCGImageDestinationLossyCompressionQuality. The reply's pngLen field
+    // is misnamed — it's byteLen regardless of format. The response handler
+    // reads view->m_screenshotFormat (stashed by JSWebView::screenshot) to
+    // stamp the right MIME on the Blob.
+    uint8_t payload[2] = { static_cast<uint8_t>(format), quality };
+    return sendOp(g, view, view->m_pendingScreenshot, Op::Screenshot, payload, sizeof(payload));
 }
 
 JSPromise* click(JSGlobalObject* g, JSWebView* view, float x, float y, uint8_t button, uint8_t modifiers, uint8_t clickCount)

--- a/src/bun.js/webview/WebKitBackend.cpp
+++ b/src/bun.js/webview/WebKitBackend.cpp
@@ -210,12 +210,16 @@ void HostClient::onWritable()
 // objects on macOS — MAP_PRIVATE returns EINVAL (the kernel's posix_shm
 // vfs doesn't implement VM_BEHAVIOR_COPY). Returns nullptr on failure
 // with errno set; caller reports it.
-static void* mapShm(const char* zname, size_t byteLen)
+static void* mapShm(const char* zname, size_t byteLen, int& outErr)
 {
     int fd = shm_open(zname, O_RDWR, 0);
-    if (fd < 0) return nullptr;
+    if (fd < 0) {
+        outErr = errno;
+        return nullptr;
+    }
     void* map = mmap(nullptr, byteLen, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-    ::close(fd);
+    outErr = (map == MAP_FAILED) ? errno : 0;
+    ::close(fd); // after capturing errno
     if (map == MAP_FAILED) return nullptr;
     return map;
 }
@@ -252,14 +256,15 @@ static JSValue openShmScreenshot(JSGlobalObject* g, const char* name, uint32_t n
         return obj;
     }
 
-    void* map = mapShm(zname.span().data(), byteLen);
+    int shmErr = 0;
+    void* map = mapShm(zname.span().data(), byteLen, shmErr);
     // Unlink after we have a mapping — the name can go away, the physical
     // pages live until the last mapping drops. For the error path
     // (map==null), we still unlink to avoid leaking the name; the user
     // gets an Error and there's nothing to read anyway.
     shm_unlink(zname.span().data());
     if (!map)
-        return createError(g, makeString("shm: "_s, WTF::String::fromUTF8(strerror(errno))));
+        return createError(g, makeString("shm: "_s, WTF::String::fromUTF8(strerror(shmErr))));
 
     switch (enc) {
     case ScreenshotEncoding::Blob: {

--- a/src/bun.js/webview/WebKitBackend.cpp
+++ b/src/bun.js/webview/WebKitBackend.cpp
@@ -15,12 +15,14 @@
 #include <JavaScriptCore/TopExceptionScope.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/JSONObject.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/Weak.h>
 #include <JavaScriptCore/WeakInlines.h>
 #include <JavaScriptCore/ConsoleClient.h>
 #include <JavaScriptCore/ScriptArguments.h>
 #include <JavaScriptCore/Strong.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/Base64.h>
 #include <wtf/NeverDestroyed.h>
 #include <mutex>
 
@@ -40,6 +42,7 @@ using namespace WebViewProto;
 extern "C" int32_t Bun__WebViewHost__ensure(Zig::GlobalObject*, bool stdoutInherit, bool stderrInherit);
 extern "C" void* Blob__fromMmapWithType(JSC::JSGlobalObject*, uint8_t* ptr, size_t len, const char* mime);
 extern "C" JSC::EncodedJSValue SYSV_ABI Blob__create(Zig::GlobalObject*, void* impl);
+extern "C" JSC::EncodedJSValue JSBuffer__fromMmap(Zig::GlobalObject*, void* ptr, size_t length);
 extern "C" void Bun__eventLoop__incrementRefConcurrently(void* bunVM, int delta);
 // Bracket the whole onData batch. exit() drains microtasks when outermost,
 // so all the promise reactions from this batch run before we return to usockets.
@@ -199,45 +202,100 @@ void HostClient::onWritable()
     }
 }
 
-// Returns a Blob on success, JS Error on failure. The Blob adopts the
-// mmap'd shm region directly — no copy. Its store's allocator vtable
-// munmap's on free (when the last ref drops). The shm segment survives
-// the name-unlink because the mapping is a live reference; the physical
-// pages free when the user drops the Blob AND the child's write-side
-// mapping is gone (child unmaps after sendReply, so by the time we're
-// here the child side is already dropped — our mapping is the only one).
-static JSValue openShmScreenshot(JSGlobalObject* g, const char* name, uint32_t nameLen, uint32_t byteLen, const char* mime, bool& ok)
+// Open + mmap the child-written shm segment. The child already munmapped
+// its side before sendReply, so we're the sole mapper. O_RDWR + PROT_WRITE
+// because the Zig allocator wrapper poisons with @memset(undefined) in
+// safe builds BEFORE the vtable free (which munmap's) — a PROT_READ
+// mapping SIGBUS'd on that poison. MAP_SHARED is required for POSIX shm
+// objects on macOS — MAP_PRIVATE returns EINVAL (the kernel's posix_shm
+// vfs doesn't implement VM_BEHAVIOR_COPY). Returns nullptr on failure
+// with errno set; caller reports it.
+static void* mapShm(const char* zname, size_t byteLen)
+{
+    int fd = shm_open(zname, O_RDWR, 0);
+    if (fd < 0) return nullptr;
+    void* map = mmap(nullptr, byteLen, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    ::close(fd);
+    if (map == MAP_FAILED) return nullptr;
+    return map;
+}
+
+// Dispatch the child-written shm segment to the requested JS shape. For
+// Blob/Buffer the mapping is adopted zero-copy — the JS object's
+// destructor munmap's. For Base64 we map, encode into a JS string, unmap
+// (one materialization, unavoidable). For Shmem we don't touch the
+// segment at all — just hand back the name + size for Kitty graphics
+// protocol t=s transmission (or manual shm_open from another process);
+// caller owns shm_unlink.
+static JSValue openShmScreenshot(JSGlobalObject* g, const char* name, uint32_t nameLen, uint32_t byteLen, const char* mime, ScreenshotEncoding enc, bool& ok)
 {
     ok = false;
+    auto& vm = g->vm();
 
     WTF::Vector<char, 64> zname;
     zname.grow(nameLen + 1);
     memcpy(zname.mutableSpan().data(), name, nameLen);
     zname[nameLen] = '\0';
 
-    // O_RDWR + PROT_WRITE — the Zig allocator wrapper poisons freed memory
-    // with @memset(undefined) in safe builds BEFORE calling the vtable's
-    // free (which munmap's). A PROT_READ mapping SIGBUS'd on that poison.
-    // MAP_SHARED is required for POSIX shm objects on macOS — MAP_PRIVATE
-    // returns EINVAL (the kernel's posix_shm vfs doesn't implement the
-    // VM_BEHAVIOR_COPY path). The child already munmapped its side before
-    // sendReply, so we're the sole mapper; writes don't race with anyone.
-    // The name is unlinked next, so no third process can shm_open it.
-    int fd = shm_open(zname.span().data(), O_RDWR, 0);
-    if (fd < 0)
-        return createError(g, makeString("shm_open: "_s, WTF::String::fromUTF8(strerror(errno))));
-    void* map = mmap(nullptr, byteLen, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-    ::close(fd);
-    shm_unlink(zname.span().data());
-    if (map == MAP_FAILED)
-        return createError(g, makeString("mmap: "_s, WTF::String::fromUTF8(strerror(errno))));
+    // Shmem: return {name, size} without opening. The name is the child-
+    // picked /bun-webview-<pid>-<seq> — the user (or Kitty) shm_open's it.
+    // We don't unlink; the caller owns cleanup. The child already
+    // munmapped its side, so the ONLY live ref is the name itself — if the
+    // user drops the name without unlinking, the pages leak until process
+    // exit (macOS POSIX shm is per-login-session, not system-wide). Kitty
+    // unlinks immediately after reading (verified: kitty/shm.c shm_unlink
+    // right after mmap), so the normal path doesn't leak.
+    if (enc == ScreenshotEncoding::Shmem) {
+        auto* obj = JSC::constructEmptyObject(g);
+        obj->putDirect(vm, Identifier::fromString(vm, "name"_s),
+            jsString(vm, WTF::String::fromUTF8(std::span<const char>(name, nameLen))));
+        obj->putDirect(vm, Identifier::fromString(vm, "size"_s), jsNumber(byteLen));
+        ok = true;
+        return obj;
+    }
 
-    // Blob adopts the mapping — no copy. Store's allocator.free munmap's
-    // when the Blob's refcount drops to zero. `await blob.bytes()` reads
-    // directly from these pages; `Bun.write(path, blob)` writes from them.
-    void* impl = Blob__fromMmapWithType(g, static_cast<uint8_t*>(map), byteLen, mime);
-    ok = true;
-    return JSValue::decode(Blob__create(defaultGlobalObject(g), impl));
+    void* map = mapShm(zname.span().data(), byteLen);
+    // Unlink after we have a mapping — the name can go away, the physical
+    // pages live until the last mapping drops. For the error path
+    // (map==null), we still unlink to avoid leaking the name; the user
+    // gets an Error and there's nothing to read anyway.
+    shm_unlink(zname.span().data());
+    if (!map)
+        return createError(g, makeString("shm: "_s, WTF::String::fromUTF8(strerror(errno))));
+
+    switch (enc) {
+    case ScreenshotEncoding::Blob: {
+        // Blob adopts the mapping — no copy. Store's allocator.free
+        // munmap's when the Blob's refcount drops to zero.
+        // `await blob.bytes()` reads directly from these pages.
+        void* impl = Blob__fromMmapWithType(g, static_cast<uint8_t*>(map), byteLen, mime);
+        ok = true;
+        return JSValue::decode(Blob__create(defaultGlobalObject(g), impl));
+    }
+    case ScreenshotEncoding::Buffer: {
+        // ArrayBuffer adopts the mapping — createFromBytes + a
+        // SharedTask<void(void*)> destructor that munmap's. Same
+        // zero-copy as Blob, just wrapped as a Node Buffer
+        // (JSUint8Array with JSBufferSubclassStructure).
+        ok = true;
+        return JSValue::decode(JSBuffer__fromMmap(defaultGlobalObject(g), map, byteLen));
+    }
+    case ScreenshotEncoding::Base64: {
+        // base64Encode copies into the output String — one
+        // materialization, unavoidable (the user explicitly wants the
+        // text form). WTF's encoder is vectorized (SIMD on the 3→4
+        // table-lookup). Unmap after — the string owns its own copy.
+        WTF::String b64 = WTF::base64EncodeToString(
+            std::span<const uint8_t>(static_cast<const uint8_t*>(map), byteLen));
+        munmap(map, byteLen);
+        ok = true;
+        return jsString(vm, WTF::move(b64));
+    }
+    case ScreenshotEncoding::Shmem:
+        RELEASE_ASSERT_NOT_REACHED(); // handled above
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return jsUndefined();
 }
 
 void HostClient::handleReply(const Frame& h, Reader r)
@@ -361,7 +419,8 @@ void HostClient::handleReply(const Frame& h, Reader r)
         uint32_t pngLen = r.u32();
         bool ok;
         JSValue result = openShmScreenshot(g, name, nameLen, pngLen,
-            screenshotMimeType(view->m_screenshotFormat), ok);
+            screenshotMimeType(view->m_screenshotFormat),
+            view->m_screenshotEncoding, ok);
         settleSlot(g, view, view->m_pendingScreenshot, ok, result);
         return;
     }

--- a/src/bun.js/webview/WebKitBackend.cpp
+++ b/src/bun.js/webview/WebKitBackend.cpp
@@ -242,9 +242,7 @@ static JSValue openShmScreenshot(JSGlobalObject* g, const char* name, uint32_t n
     // We don't unlink; the caller owns cleanup. The child already
     // munmapped its side, so the ONLY live ref is the name itself — if the
     // user drops the name without unlinking, the pages leak until process
-    // exit (macOS POSIX shm is per-login-session, not system-wide). Kitty
-    // unlinks immediately after reading (verified: kitty/shm.c shm_unlink
-    // right after mmap), so the normal path doesn't leak.
+    // exit (macOS POSIX shm is per-login-session, not system-wide).
     if (enc == ScreenshotEncoding::Shmem) {
         auto* obj = JSC::constructEmptyObject(g);
         obj->putDirect(vm, Identifier::fromString(vm, "name"_s),

--- a/src/bun.js/webview/WebKitBackend.h
+++ b/src/bun.js/webview/WebKitBackend.h
@@ -26,6 +26,7 @@ class GlobalObject;
 namespace Bun {
 
 class JSWebView;
+enum class ScreenshotFormat : uint8_t;
 
 namespace WebViewProto {
 struct Frame;
@@ -69,7 +70,7 @@ namespace Ops {
 
 JSC::JSPromise* navigate(JSC::JSGlobalObject*, JSWebView*, const WTF::String& url);
 JSC::JSPromise* evaluate(JSC::JSGlobalObject*, JSWebView*, const WTF::String& script);
-JSC::JSPromise* screenshot(JSC::JSGlobalObject*, JSWebView*);
+JSC::JSPromise* screenshot(JSC::JSGlobalObject*, JSWebView*, ScreenshotFormat, uint8_t quality);
 JSC::JSPromise* click(JSC::JSGlobalObject*, JSWebView*, float x, float y, uint8_t button, uint8_t modifiers, uint8_t clickCount);
 JSC::JSPromise* clickSelector(JSC::JSGlobalObject*, JSWebView*, const WTF::String& selector, uint32_t timeout, uint8_t button, uint8_t modifiers, uint8_t clickCount);
 JSC::JSPromise* type(JSC::JSGlobalObject*, JSWebView*, const WTF::String& text);

--- a/src/bun.js/webview/WebViewEventTarget.h
+++ b/src/bun.js/webview/WebViewEventTarget.h
@@ -1,0 +1,52 @@
+#pragma once
+
+// Thin EventTarget impl for JSWebView. Its only job is to hold the
+// addEventListener/removeEventListener listener map and implement the
+// EventTarget virtuals — all WebView state (promise slots, url, sessionId,
+// etc.) stays on the JSWebView wrapper. This keeps the refactor minimal:
+// the existing Weak<JSWebView> routing tables in both backends remain
+// unchanged, and visitChildren already handles the WriteBarrier slots.
+//
+// The wrapper→impl link is via JSDOMWrapper<EventTarget>::m_wrapped (a
+// Ref<>, so this object lives as long as the JS wrapper). The impl→wrapper
+// link is ScriptWrappable::m_wrapper (a Weak<>) — set by toJSNewlyCreated.
+// We don't use the impl→wrapper link; the backend dispatch goes straight
+// through the JSWebView* already held in the Weak<> maps.
+
+#include "root.h"
+#include "ContextDestructionObserver.h"
+#include "EventTarget.h"
+#include "EventTargetInterfaces.h"
+#include "ScriptExecutionContext.h"
+#include <wtf/RefCounted.h>
+
+namespace Bun {
+
+class WebViewEventTarget final : public RefCounted<WebViewEventTarget>,
+                                 public WebCore::EventTargetWithInlineData,
+                                 private WebCore::ContextDestructionObserver {
+    WTF_MAKE_TZONE_ALLOCATED(WebViewEventTarget);
+
+public:
+    static Ref<WebViewEventTarget> create(WebCore::ScriptExecutionContext& ctx)
+    {
+        return adoptRef(*new WebViewEventTarget(ctx));
+    }
+
+    using RefCounted::ref;
+    using RefCounted::deref;
+
+private:
+    explicit WebViewEventTarget(WebCore::ScriptExecutionContext& ctx)
+        : ContextDestructionObserver(&ctx)
+    {
+    }
+
+    WebCore::EventTargetInterface eventTargetInterface() const final { return WebCore::BunWebViewEventTargetInterfaceType; }
+    WebCore::ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+
+    void refEventTarget() final { ref(); }
+    void derefEventTarget() final { deref(); }
+};
+
+} // namespace Bun

--- a/src/bun.js/webview/WebViewEventTarget.h
+++ b/src/bun.js/webview/WebViewEventTarget.h
@@ -33,8 +33,8 @@ public:
         return adoptRef(*new WebViewEventTarget(ctx));
     }
 
-    using RefCounted::ref;
     using RefCounted::deref;
+    using RefCounted::ref;
 
 private:
     explicit WebViewEventTarget(WebCore::ScriptExecutionContext& ctx)

--- a/src/bun.js/webview/WebViewHost.cpp
+++ b/src/bun.js/webview/WebViewHost.cpp
@@ -784,8 +784,8 @@ void WebViewHost::onScreenshotComplete(id nsimage, id error)
         auto factor = objc::NSNumber::withDouble(static_cast<double>(m_screenshotQuality) / 100.0);
         props = objc::NSDictionary::with1(
             factor.m_id,
-            objc::NSString::fromWTF("NSImageCompressionFactor"_s).m_id
-        ).m_id;
+            objc::NSString::fromWTF("NSImageCompressionFactor"_s).m_id)
+                    .m_id;
     }
     auto data = objc::NSBitmapImageRep::encodeFromCGImage(cg, fileType, props);
     if (!data) {

--- a/src/bun.js/webview/WebViewHost.cpp
+++ b/src/bun.js/webview/WebViewHost.cpp
@@ -270,13 +270,15 @@ void WebViewHost::evaluateIPC(const WTF::String& script)
         makeHostBlock<&WebViewHost::onEvalComplete, id, id>(*this));
 }
 
-void WebViewHost::screenshotIPC()
+void WebViewHost::screenshotIPC(uint8_t format, uint8_t quality)
 {
     if (m_screenshotPending) {
         hostWriter()->sendReplyStr(m_viewId, Reply::ScreenshotFailed, "screenshot already pending"_s);
         return;
     }
     m_screenshotPending = true;
+    m_screenshotFormat = format;
+    m_screenshotQuality = quality;
     m_webview.takeSnapshot(makeHostBlock<&WebViewHost::onScreenshotComplete, id, id>(*this));
 }
 
@@ -770,12 +772,27 @@ void WebViewHost::onScreenshotComplete(id nsimage, id error)
         hostWriter()->sendReplyStr(m_viewId, Reply::ScreenshotFailed, "CGImage extraction failed"_s);
         return;
     }
-    auto png = objc::NSBitmapImageRep::pngFromCGImage(cg);
-    if (!png) {
-        hostWriter()->sendReplyStr(m_viewId, Reply::ScreenshotFailed, "PNG encoding failed"_s);
+    // NSBitmapImageFileType: 3=JPEG, 4=PNG. WebP (format==2) rejected at
+    // the prototype layer — representationUsingType: has no WebP entry in
+    // the enum; CGImageDestination with public.webp UTI would need a
+    // separate dlsym surface (ImageIO.framework) not yet wired.
+    unsigned long fileType = m_screenshotFormat == 1 ? 3 /* JPEG */ : 4 /* PNG */;
+    id props = nullptr;
+    if (m_screenshotFormat == 1) {
+        // NSImageCompressionFactor takes a [0.0, 1.0] NSNumber. Our quality
+        // is 0-100 matching CDP; map linearly.
+        auto factor = objc::NSNumber::withDouble(static_cast<double>(m_screenshotQuality) / 100.0);
+        props = objc::NSDictionary::with1(
+            factor.m_id,
+            objc::NSString::fromWTF("NSImageCompressionFactor"_s).m_id
+        ).m_id;
+    }
+    auto data = objc::NSBitmapImageRep::encodeFromCGImage(cg, fileType, props);
+    if (!data) {
+        hostWriter()->sendReplyStr(m_viewId, Reply::ScreenshotFailed, "image encoding failed"_s);
         return;
     }
-    unsigned long length = png.length();
+    unsigned long length = data.length();
 
     // PNG goes in POSIX shared memory — reply frame stays tiny. The parent
     // shm_open's the same name, mmaps, wraps in a Uint8Array, then
@@ -806,7 +823,7 @@ void WebViewHost::onScreenshotComplete(id nsimage, id error)
         hostWriter()->sendReplyStr(m_viewId, Reply::ScreenshotFailed, makeString("mmap: "_s, WTF::String::fromUTF8(strerror(errno))));
         return;
     }
-    memcpy(map, png.bytes(), length);
+    memcpy(map, data.bytes(), length);
     munmap(map, length);
 
     // Payload: u32 nameLen + name + u32 pngLen.

--- a/src/bun.js/webview/WebViewHost.h
+++ b/src/bun.js/webview/WebViewHost.h
@@ -26,7 +26,7 @@ public:
 
     void navigateIPC(const WTF::String& url);
     void evaluateIPC(const WTF::String& js);
-    void screenshotIPC();
+    void screenshotIPC(uint8_t format, uint8_t quality);
 
     // Native input. clickIPC/typeIPC and most of pressIPC are async with
     // proper WebKit-owned completion: _doAfterProcessingAllPendingMouseEvents:
@@ -79,6 +79,11 @@ private:
     bool m_navPending = false;
     bool m_evalPending = false;
     bool m_screenshotPending = false;
+    // Stashed by screenshotIPC; read by onScreenshotComplete to pick the
+    // NSBitmapImageFileType and compression factor. format values match
+    // the parent's ScreenshotFormat enum (0=png 1=jpeg 2=webp).
+    uint8_t m_screenshotFormat = 0;
+    uint8_t m_screenshotQuality = 80;
     bool m_inputPending = false;
     bool m_scrollPending = false;
 

--- a/src/bun.js/webview/host_main.cpp
+++ b/src/bun.js/webview/host_main.cpp
@@ -253,9 +253,14 @@ void Host::dispatch(uint32_t viewId, Op op, Reader r)
     case Op::Evaluate:
         if (auto* v = view(viewId, op)) v->evaluateIPC(r.str());
         return;
-    case Op::Screenshot:
-        if (auto* v = view(viewId, op)) v->screenshotIPC();
+    case Op::Screenshot: {
+        // Two bytes: format (0=png 1=jpeg 2=webp), quality (0-100).
+        // Older parents sent an empty payload — default to png.
+        uint8_t fmt = r.remaining() >= 1 ? r.u8() : 0;
+        uint8_t q = r.remaining() >= 1 ? r.u8() : 80;
+        if (auto* v = view(viewId, op)) v->screenshotIPC(fmt, q);
         return;
+    }
     case Op::Close:
         views.erase(viewId);
         writer.sendReply(viewId, Reply::Ack);

--- a/src/bun.js/webview/ipc_protocol.h
+++ b/src/bun.js/webview/ipc_protocol.h
@@ -40,7 +40,7 @@ enum class Op : uint8_t {
     Create = 1, // u32 w, u32 h, u8 dataStoreKind, [u32 dirLen, dir bytes]
     Navigate = 2, // u32 urlLen, url bytes
     Evaluate = 3, // u32 scriptLen, script bytes
-    Screenshot = 4, // (empty)
+    Screenshot = 4, // u8 format (0=png 1=jpeg 2=webp), u8 quality (0-100, ignored for png)
     Close = 5, // (empty)
     Resize = 6, // u32 w, u32 h
     GoBack = 7, // (empty)

--- a/test/js/bun/webview/webview-chrome-ws.test.ts
+++ b/test/js/bun/webview/webview-chrome-ws.test.ts
@@ -20,9 +20,13 @@ import { bunEnv, bunExe } from "harness";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 
-// Read DevToolsActivePort → ws:// URL. Mirrors the Zig readDevToolsActivePort
-// path list so tests probe the same locations the runtime does.
-function probeRemoteChrome(): { wsUrl: string; port: string } | undefined {
+// Read DevToolsActivePort → ws:// URL, then verify the WS actually
+// accepts (the file can be stale, or the new chrome://inspect toggle
+// pops an Allow dialog that the user isn't clicking). Without the
+// verify step, tests time out on the dialog, leaving the Transport
+// singleton stuck and poisoning the other test files in this directory
+// (bun test <dir> runs all files in one process).
+function findDevToolsActivePort(): { wsUrl: string; port: string } | undefined {
   const home = homedir();
   const local = process.env.LOCALAPPDATA;
   const paths =
@@ -59,7 +63,32 @@ function probeRemoteChrome(): { wsUrl: string; port: string } | undefined {
   return undefined;
 }
 
-const remote = probeRemoteChrome();
+// Actually connect and send Browser.getVersion. If the user clicks
+// Allow within 2s, we get a response → tests enabled. If not (nobody
+// at the keyboard, stale file, dialog dismissed), test.todo — the
+// singleton stays clean and webview-chrome.test.ts runs unaffected.
+async function probeRemoteChrome(): Promise<{ wsUrl: string; port: string } | undefined> {
+  const port = findDevToolsActivePort();
+  if (!port) return undefined;
+  return new Promise(resolve => {
+    const ws = new WebSocket(port.wsUrl);
+    const bail = () => {
+      ws.close();
+      resolve(undefined);
+    };
+    const timer = setTimeout(bail, 2000);
+    ws.onopen = () => ws.send('{"id":1,"method":"Browser.getVersion"}');
+    ws.onmessage = () => {
+      clearTimeout(timer);
+      ws.close();
+      resolve(port);
+    };
+    ws.onerror = bail;
+    ws.onclose = () => clearTimeout(timer);
+  });
+}
+
+const remote = await probeRemoteChrome();
 const it = remote ? test : test.todo;
 
 const html = (h: string) => "data:text/html," + encodeURIComponent(h);

--- a/test/js/bun/webview/webview-chrome-ws.test.ts
+++ b/test/js/bun/webview/webview-chrome-ws.test.ts
@@ -1,0 +1,136 @@
+// WebSocket-transport tests — connect to an already-running Chrome via CDP
+// over ws://, instead of spawning our own with --remote-debugging-pipe.
+//
+// Separate file from webview-chrome.test.ts because Transport is a singleton:
+// pipe-mode and connect-mode can't coexist in one process. The first
+// constructor call locks the mode for the rest of the process lifetime.
+//
+// Enable these tests by turning on Remote Debugging in Chrome:
+// chrome://inspect/#remote-debugging (the "Allow remote debugging" toggle).
+// Chrome writes DevToolsActivePort to its profile dir; that file is the
+// discovery source. The new toggle does NOT expose /json/version (404) —
+// only the classic --remote-debugging-port flag does.
+//
+// INTERACTIVE: the new toggle pops "Allow remote debugging?" on every
+// new WS connection. These tests run only when a dev is at the keyboard
+// to click Allow. CI never hits this (no DevToolsActivePort → test.todo).
+
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+
+// Read DevToolsActivePort → ws:// URL. Mirrors the Zig readDevToolsActivePort
+// path list so tests probe the same locations the runtime does.
+function probeRemoteChrome(): { wsUrl: string; port: string } | undefined {
+  const home = homedir();
+  const local = process.env.LOCALAPPDATA;
+  const paths =
+    process.platform === "darwin"
+      ? [
+          `${home}/Library/Application Support/Google/Chrome/DevToolsActivePort`,
+          `${home}/Library/Application Support/Google/Chrome Canary/DevToolsActivePort`,
+          `${home}/Library/Application Support/Chromium/DevToolsActivePort`,
+          `${home}/Library/Application Support/Microsoft Edge/DevToolsActivePort`,
+        ]
+      : process.platform === "linux"
+        ? [
+            `${home}/.config/google-chrome/DevToolsActivePort`,
+            `${home}/.config/chromium/DevToolsActivePort`,
+            `${home}/.config/microsoft-edge/DevToolsActivePort`,
+          ]
+        : process.platform === "win32" && local
+          ? [
+              `${local}\\Google\\Chrome\\User Data\\DevToolsActivePort`,
+              `${local}\\Google\\Chrome SxS\\User Data\\DevToolsActivePort`,
+              `${local}\\Chromium\\User Data\\DevToolsActivePort`,
+              `${local}\\Microsoft\\Edge\\User Data\\DevToolsActivePort`,
+            ]
+          : [];
+  for (const p of paths) {
+    try {
+      const [port, path] = readFileSync(p, "utf8").trim().split("\n");
+      if (!port || !path) continue;
+      return { wsUrl: `ws://127.0.0.1:${port.trim()}${path.trim()}`, port: port.trim() };
+    } catch {
+      // ENOENT — try next
+    }
+  }
+  return undefined;
+}
+
+const remote = probeRemoteChrome();
+const it = remote ? test : test.todo;
+
+const html = (h: string) => "data:text/html," + encodeURIComponent(h);
+
+it("connect via full ws:// URL", async () => {
+  // Direct connect, no discovery. Commands queue in Transport's
+  // m_wsPending until the handshake completes; navigate() resolves after.
+  const view = new Bun.WebView({
+    backend: { type: "chrome", url: remote!.wsUrl },
+    width: 400,
+    height: 300,
+  });
+  try {
+    await view.navigate(html("<h1 id=t>ws-direct</h1>"));
+    expect(await view.evaluate("document.getElementById('t').textContent")).toBe("ws-direct");
+  } finally {
+    view.close();
+  }
+});
+
+it("connect via bare host:port (DevToolsActivePort discovery)", async () => {
+  // "127.0.0.1:<port>" → Zig reads DevToolsActivePort (sync file read),
+  // builds ws:// URL, calls onDiscovered synchronously. No HTTP GET —
+  // the new toggle 404s /json/version anyway. Commands still queue
+  // until the WS handshake completes (async).
+  const view = new Bun.WebView({
+    backend: { type: "chrome", url: `127.0.0.1:${remote!.port}` },
+    width: 400,
+    height: 300,
+  });
+  try {
+    await view.navigate(html("<body>file-discovery</body>"));
+    expect(await view.evaluate("document.body.textContent")).toBe("file-discovery");
+  } finally {
+    view.close();
+  }
+});
+
+it("screenshot over WebSocket transport", async () => {
+  // Same CDP Page.captureScreenshot; only the wire differs (WS text frames
+  // instead of NUL-delimited pipe). The response handler's base64-decode →
+  // Blob path is mode-agnostic.
+  const view = new Bun.WebView({
+    backend: { type: "chrome", url: remote!.wsUrl },
+    width: 200,
+    height: 150,
+  });
+  try {
+    await view.navigate(html("<body style='background:red'></body>"));
+    const blob = await view.screenshot();
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe("image/png");
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+    expect(bytes[0]).toBe(0x89); // PNG magic
+  } finally {
+    view.close();
+  }
+});
+
+it("cdp() over WebSocket transport", async () => {
+  // Command::RawTag goes through the same finishToString() → sendTextNative
+  // as every other command. Browser.getVersion is the simplest round-trip.
+  const view = new Bun.WebView({
+    backend: { type: "chrome", url: remote!.wsUrl },
+    width: 100,
+    height: 100,
+  });
+  try {
+    await view.navigate(html("<body></body>"));
+    const v = await view.cdp<{ product: string }>("Browser.getVersion");
+    expect(v.product).toContain("Chrome");
+  } finally {
+    view.close();
+  }
+});

--- a/test/js/bun/webview/webview-chrome-ws.test.ts
+++ b/test/js/bun/webview/webview-chrome-ws.test.ts
@@ -16,6 +16,7 @@
 // to click Allow. CI never hits this (no DevToolsActivePort → test.todo).
 
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 
@@ -79,22 +80,49 @@ it("connect via full ws:// URL", async () => {
   }
 });
 
-it("connect via bare host:port (DevToolsActivePort discovery)", async () => {
-  // "127.0.0.1:<port>" → Zig reads DevToolsActivePort (sync file read),
-  // builds ws:// URL, calls onDiscovered synchronously. No HTTP GET —
-  // the new toggle 404s /json/version anyway. Commands still queue
-  // until the WS handshake completes (async).
+it("auto-detect: backend:'chrome' without url/path reads DevToolsActivePort", async () => {
+  // No url, no path, no argv → Zig reads DevToolsActivePort (sync file
+  // read), builds ws:// URL, ensureConnected with autoDetected=true.
+  // Commands queue until the WS handshake completes. If the file were
+  // stale (dead Chrome), wsOnClose would fall back to spawn — but
+  // since probeRemoteChrome found the same file, we know Chrome IS up.
   const view = new Bun.WebView({
-    backend: { type: "chrome", url: `127.0.0.1:${remote!.port}` },
+    backend: "chrome",
     width: 400,
     height: 300,
   });
   try {
-    await view.navigate(html("<body>file-discovery</body>"));
-    expect(await view.evaluate("document.body.textContent")).toBe("file-discovery");
+    await view.navigate(html("<body>auto-detect</body>"));
+    expect(await view.evaluate("document.body.textContent")).toBe("auto-detect");
   } finally {
     view.close();
   }
+});
+
+it("url:false skips auto-detect even when DevToolsActivePort exists", async () => {
+  // Subprocess-isolated — spawning would lock this process's singleton
+  // into Pipe mode (pipe doesn't idle-close; the subprocess is ours),
+  // breaking subsequent WS tests. Explicit opt-out — spawn headless
+  // Chrome despite the file. This is the automation-friendly path (no
+  // dialog, no visible tabs).
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const view = new Bun.WebView({ backend: {type:"chrome", url:false}, width: 200, height: 200 });
+        await view.navigate("data:text/html,<body>spawned</body>");
+        const t = await view.evaluate("document.body.textContent");
+        if (t !== "spawned") throw new Error("got: " + t);
+        view.close();
+        console.log("ok");
+      `,
+    ],
+    env: bunEnv,
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
 });
 
 it("screenshot over WebSocket transport", async () => {

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -282,7 +282,7 @@ it("chrome: cdp() raw passthrough", async () => {
   }
 });
 
-it("chrome: cdp() guards — WebKit backend and before navigate", async () => {
+it("chrome: cdp() guards — before navigate and params validation", async () => {
   // Chrome before first navigate → no sessionId → INVALID_STATE.
   const crView = new Bun.WebView({ backend: chrome, width: 100, height: 100 });
   try {
@@ -293,6 +293,23 @@ it("chrome: cdp() guards — WebKit backend and before navigate", async () => {
   } finally {
     crView.close();
   }
+});
+
+// Validation throws before any I/O — doesn't need Chrome installed, so
+// `test` directly (not the `it` alias that todo-gates on chromePath).
+test("chrome: constructor rejects url combined with spawn options", () => {
+  expect(
+    () =>
+      new Bun.WebView({
+        backend: { type: "chrome", url: "ws://localhost:9222/devtools/browser/x", path: "/foo" } as any,
+      }),
+  ).toThrow(/connect mode.*cannot be combined.*spawn/i);
+  expect(
+    () =>
+      new Bun.WebView({
+        backend: { type: "chrome", url: "ws://localhost:9222/devtools/browser/x", argv: ["--foo"] } as any,
+      }),
+  ).toThrow(/connect mode.*cannot be combined.*spawn/i);
 });
 
 it("chrome: screenshot quality option affects JPEG size", async () => {

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -141,17 +141,62 @@ it("chrome: evaluate awaits Promises", async () => {
   }
 });
 
-it("chrome: screenshot returns PNG bytes", async () => {
+it("chrome: screenshot returns a PNG Blob", async () => {
   const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
   try {
     await view.navigate(html("<body style='background:red'></body>"));
-    const png = await view.screenshot();
-    expect(png).toBeInstanceOf(Uint8Array);
+    const blob = await view.screenshot();
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe("image/png");
+    const bytes = new Uint8Array(await blob.arrayBuffer());
     // PNG magic: 89 50 4E 47
-    expect(png[0]).toBe(0x89);
-    expect(png[1]).toBe(0x50);
-    expect(png[2]).toBe(0x4e);
-    expect(png[3]).toBe(0x47);
+    expect(bytes[0]).toBe(0x89);
+    expect(bytes[1]).toBe(0x50);
+    expect(bytes[2]).toBe(0x4e);
+    expect(bytes[3]).toBe(0x47);
+    // Bun.write accepts the Blob directly — the MIME type carries through.
+    expect(blob.size).toBeGreaterThan(100);
+  } finally {
+    view.close();
+  }
+});
+
+it("chrome: screenshot format options produce the right magic bytes", async () => {
+  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  try {
+    await view.navigate(html("<body style='background:linear-gradient(red,blue)'></body>"));
+
+    const jpeg = await view.screenshot({ format: "jpeg", quality: 90 });
+    expect(jpeg.type).toBe("image/jpeg");
+    const jb = new Uint8Array(await jpeg.arrayBuffer());
+    // JPEG magic: FF D8 FF
+    expect([jb[0], jb[1], jb[2]]).toEqual([0xff, 0xd8, 0xff]);
+
+    const webp = await view.screenshot({ format: "webp", quality: 80 });
+    expect(webp.type).toBe("image/webp");
+    const wb = new Uint8Array(await webp.arrayBuffer());
+    // WebP magic: "RIFF" <4-byte size> "WEBP"
+    expect(String.fromCharCode(wb[0], wb[1], wb[2], wb[3])).toBe("RIFF");
+    expect(String.fromCharCode(wb[8], wb[9], wb[10], wb[11])).toBe("WEBP");
+
+    // WebP should be smaller than PNG for a gradient (lossy wins).
+    const png = await view.screenshot({ format: "png" });
+    expect(webp.size).toBeLessThan(png.size);
+  } finally {
+    view.close();
+  }
+});
+
+it("chrome: screenshot quality option affects JPEG size", async () => {
+  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  try {
+    // Gradient + text → lossy compression has work to do.
+    await view.navigate(
+      html("<body style='background:linear-gradient(red,blue);color:white;font-size:40px'>Hello</body>"),
+    );
+    const lo = await view.screenshot({ format: "jpeg", quality: 10 });
+    const hi = await view.screenshot({ format: "jpeg", quality: 95 });
+    expect(lo.size).toBeLessThan(hi.size);
   } finally {
     view.close();
   }

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -6,8 +6,26 @@ import { bunEnv, bunExe } from "harness";
 // ChromeProcess.zig's findChrome() — $PATH names, then hardcoded absolute
 // paths, then Playwright cache — so the test detects Chrome whenever the
 // runtime would.
-import { accessSync, constants as fsConstants, readdirSync } from "node:fs";
+import { accessSync, constants as fsConstants, readdirSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
+import { dlopen, FFIType, ptr } from "bun:ffi";
+
+// shm_unlink for encoding:"shmem" test cleanup. macOS has no /dev/shm
+// filesystem mount, so we go through libc. Linux exposes POSIX shm at
+// /dev/shm/<name-without-leading-slash> — a plain unlink works.
+const libcShm =
+  process.platform === "darwin"
+    ? dlopen("libc.dylib", {
+        shm_unlink: { args: [FFIType.cstring], returns: FFIType.i32 },
+      })
+    : null;
+function shmUnlinkChrome(name: string): void {
+  if (process.platform === "darwin") {
+    libcShm!.symbols.shm_unlink(ptr(Buffer.from(name + "\0")));
+  } else if (process.platform === "linux") {
+    rmSync("/dev/shm" + name, { force: true });
+  }
+}
 import { join } from "node:path";
 
 function findChrome(): string | undefined {
@@ -182,6 +200,41 @@ it("chrome: screenshot format options produce the right magic bytes", async () =
     // WebP should be smaller than PNG for a gradient (lossy wins).
     const png = await view.screenshot({ format: "png" });
     expect(webp.size).toBeLessThan(png.size);
+  } finally {
+    view.close();
+  }
+});
+
+it("chrome: screenshot encoding options", async () => {
+  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  try {
+    await view.navigate(html("<body style='background:red'></body>"));
+
+    const buf = await view.screenshot({ encoding: "buffer" });
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(buf[0]).toBe(0x89); // PNG magic
+
+    // base64 — zero decode (CDP returns base64 natively). Same PNG
+    // after we decode it.
+    const b64 = await view.screenshot({ encoding: "base64" });
+    expect(typeof b64).toBe("string");
+    const decoded = Buffer.from(b64, "base64");
+    expect(decoded[0]).toBe(0x89);
+    expect(decoded[1]).toBe(0x50);
+
+    // shmem — fresh segment written by the parent (Chrome doesn't use
+    // shm internally, we create one after decoding). Name uses the
+    // bun-chrome- prefix to disambiguate from WebKit's child-created
+    // segments.
+    if (process.platform !== "win32") {
+      const shm = await view.screenshot({ encoding: "shmem" });
+      expect(typeof shm.name).toBe("string");
+      expect(shm.name.startsWith("/bun-chrome-")).toBe(true);
+      expect(shm.size).toBeGreaterThan(100);
+      // Clean up — the test owns it since we told the backend not to.
+      // Kitty does this in real use after shm_open'ing.
+      shmUnlinkChrome(shm.name);
+    }
   } finally {
     view.close();
   }

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -6,9 +6,10 @@ import { bunEnv, bunExe } from "harness";
 // ChromeProcess.zig's findChrome() — $PATH names, then hardcoded absolute
 // paths, then Playwright cache — so the test detects Chrome whenever the
 // runtime would.
+import { dlopen, FFIType, ptr } from "bun:ffi";
 import { accessSync, constants as fsConstants, readdirSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
-import { dlopen, FFIType, ptr } from "bun:ffi";
+import { join } from "node:path";
 
 // shm_unlink for encoding:"shmem" test cleanup. macOS has no /dev/shm
 // filesystem mount, so we go through libc. Linux exposes POSIX shm at
@@ -26,7 +27,6 @@ function shmUnlinkChrome(name: string): void {
     rmSync("/dev/shm" + name, { force: true });
   }
 }
-import { join } from "node:path";
 
 function findChrome(): string | undefined {
   const isExecutable = (p: string) => {

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -206,10 +206,6 @@ it("chrome: screenshot format options produce the right magic bytes", async () =
     // WebP magic: "RIFF" <4-byte size> "WEBP"
     expect(String.fromCharCode(wb[0], wb[1], wb[2], wb[3])).toBe("RIFF");
     expect(String.fromCharCode(wb[8], wb[9], wb[10], wb[11])).toBe("WEBP");
-
-    // WebP should be smaller than PNG for a gradient (lossy wins).
-    const png = await view.screenshot({ format: "png" });
-    expect(webp.size).toBeLessThan(png.size);
   } finally {
     view.close();
   }

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -106,16 +106,15 @@ function findChrome(): string | undefined {
 const chromePath = findChrome();
 const it = chromePath ? test : test.todo;
 
-// Force spawn-mode by passing the explicit path. Without this, the
-// constructor auto-detects a running Chrome via DevToolsActivePort and
-// connects to it over WebSocket — which (a) pops Chrome's "Allow remote
-// debugging?" dialog on every test and (b) creates visible tabs in the
-// user's Chrome. The explicit path skips auto-detect.
+// url:false forces spawn-mode — skips DevToolsActivePort auto-detect
+// which would connect to the dev's running Chrome, pop the "Allow remote
+// debugging?" dialog on every test, and create visible tabs. The
+// executable path is still auto-found.
 //
 // WebSocket-transport tests live in webview-chrome-ws.test.ts — the
 // Transport singleton means you can't mix pipe-mode (this file) and
 // connect-mode in one process.
-const chrome = { type: "chrome" as const, path: chromePath };
+const chrome = { type: "chrome" as const, url: false as const };
 
 const html = (h: string) => "data:text/html," + encodeURIComponent(h);
 
@@ -528,9 +527,7 @@ it("chrome: closeAll() kills the subprocess and pending promises reject", async 
       bunExe(),
       "-e",
       `
-        // Explicit path forces spawn-mode — skips DevToolsActivePort
-        // auto-detect that would connect to the dev's running Chrome.
-        const view = new Bun.WebView({ backend: {type:"chrome", path:process.env.CHROME_PATH}, width: 200, height: 200 });
+        const view = new Bun.WebView({ backend: {type:"chrome", url:false}, width: 200, height: 200 });
         await view.navigate("data:text/html,<body>test</body>");
         const p = view.evaluate("new Promise(() => {})"); // never resolves
         Bun.WebView.closeAll();
@@ -544,7 +541,7 @@ it("chrome: closeAll() kills the subprocess and pending promises reject", async 
         console.log("rejected");
       `,
     ],
-    env: { ...bunEnv, CHROME_PATH: chromePath },
+    env: bunEnv,
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
@@ -561,12 +558,12 @@ it("chrome: backend.stderr defaults to ignore (Chrome noise hidden)", async () =
       bunExe(),
       "-e",
       `
-        const view = new Bun.WebView({ backend: {type:"chrome", path:process.env.CHROME_PATH}, width: 200, height: 200 });
+        const view = new Bun.WebView({ backend: {type:"chrome", url:false}, width: 200, height: 200 });
         await view.navigate("data:text/html,<body>test</body>");
         view.close();
       `,
     ],
-    env: { ...bunEnv, CHROME_PATH: chromePath },
+    env: bunEnv,
     stderr: "pipe",
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
@@ -1001,7 +998,7 @@ it("chrome: console: globalThis.console forwards to parent's stdout", async () =
       "-e",
       `
       const view = new Bun.WebView({
-        backend: {type:"chrome", path:process.env.CHROME_PATH}, width: 200, height: 200,
+        backend: {type:"chrome", url:false}, width: 200, height: 200,
         console: globalThis.console,
       });
       await view.navigate("data:text/html,<body></body>");
@@ -1010,7 +1007,7 @@ it("chrome: console: globalThis.console forwards to parent's stdout", async () =
       view.close();
       `,
     ],
-    env: { ...bunEnv, CHROME_PATH: chromePath },
+    env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -106,20 +106,27 @@ function findChrome(): string | undefined {
 const chromePath = findChrome();
 const it = chromePath ? test : test.todo;
 
+// Force spawn-mode by passing the explicit path. Without this, the
+// constructor auto-detects a running Chrome via DevToolsActivePort and
+// connects to it over WebSocket — which (a) pops Chrome's "Allow remote
+// debugging?" dialog on every test and (b) creates visible tabs in the
+// user's Chrome. The explicit path skips auto-detect.
+//
 // WebSocket-transport tests live in webview-chrome-ws.test.ts — the
 // Transport singleton means you can't mix pipe-mode (this file) and
 // connect-mode in one process.
+const chrome = { type: "chrome" as const, path: chromePath };
 
 const html = (h: string) => "data:text/html," + encodeURIComponent(h);
 
 it("backend: chrome constructor returns a WebView", () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 400, height: 300 });
+  const view = new Bun.WebView({ backend: chrome, width: 400, height: 300 });
   expect(view).toBeInstanceOf(Bun.WebView);
   view.close();
 });
 
 it("chrome: navigate + evaluate round-trip", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 400, height: 300 });
+  const view = new Bun.WebView({ backend: chrome, width: 400, height: 300 });
   try {
     // First navigate kicks off the Target.createTarget → attachToTarget →
     // Page.enable → Page.navigate chain; awaiting it means the sessionId
@@ -133,7 +140,7 @@ it("chrome: navigate + evaluate round-trip", async () => {
 });
 
 it("chrome: evaluate returns native JS values", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     await view.navigate(html("<body></body>"));
     // Runtime.evaluate with returnByValue serializes the result page-side;
@@ -151,7 +158,7 @@ it("chrome: evaluate returns native JS values", async () => {
 });
 
 it("chrome: evaluate awaits Promises", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     await view.navigate(html("<body></body>"));
     // awaitPromise:true + the (async()=>{return await (...)})() wrap.
@@ -164,7 +171,7 @@ it("chrome: evaluate awaits Promises", async () => {
 });
 
 it("chrome: screenshot returns a PNG Blob", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     await view.navigate(html("<body style='background:red'></body>"));
     const blob = await view.screenshot();
@@ -184,7 +191,7 @@ it("chrome: screenshot returns a PNG Blob", async () => {
 });
 
 it("chrome: screenshot format options produce the right magic bytes", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     await view.navigate(html("<body style='background:linear-gradient(red,blue)'></body>"));
 
@@ -210,7 +217,7 @@ it("chrome: screenshot format options produce the right magic bytes", async () =
 });
 
 it("chrome: screenshot encoding options", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     await view.navigate(html("<body style='background:red'></body>"));
 
@@ -245,7 +252,7 @@ it("chrome: screenshot encoding options", async () => {
 });
 
 it("chrome: cdp() raw passthrough", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     await view.navigate(html("<body><input id=q value='hello'></body>"));
 
@@ -282,7 +289,7 @@ it("chrome: cdp() raw passthrough", async () => {
 
 it("chrome: cdp() guards — WebKit backend and before navigate", async () => {
   // Chrome before first navigate → no sessionId → INVALID_STATE.
-  const crView = new Bun.WebView({ backend: "chrome", width: 100, height: 100 });
+  const crView = new Bun.WebView({ backend: chrome, width: 100, height: 100 });
   try {
     expect(() => crView.cdp("Page.enable")).toThrow(/session.*navigate/i);
     // params validation: non-object rejected before any I/O.
@@ -294,7 +301,7 @@ it("chrome: cdp() guards — WebKit backend and before navigate", async () => {
 });
 
 it("chrome: screenshot quality option affects JPEG size", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     // Gradient + text → lossy compression has work to do.
     await view.navigate(
@@ -309,7 +316,7 @@ it("chrome: screenshot quality option affects JPEG size", async () => {
 });
 
 it("chrome: click dispatches mousedown/mouseup/click", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 300, height: 300 });
+  const view = new Bun.WebView({ backend: chrome, width: 300, height: 300 });
   try {
     await view.navigate(
       html(`
@@ -333,7 +340,7 @@ it("chrome: click dispatches mousedown/mouseup/click", async () => {
 });
 
 it("chrome: click(selector) waits for actionability, clicks center", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 300, height: 300 });
+  const view = new Bun.WebView({ backend: chrome, width: 300, height: 300 });
   try {
     await view.navigate(
       html(`
@@ -358,7 +365,7 @@ it("chrome: click(selector) waits for actionability, clicks center", async () =>
 });
 
 it("chrome: click(selector) waits for element to appear", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 300, height: 300 });
+  const view = new Bun.WebView({ backend: chrome, width: 300, height: 300 });
   try {
     await view.navigate(
       html(`
@@ -384,7 +391,7 @@ it("chrome: click(selector) waits for element to appear", async () => {
 });
 
 it("chrome: click(selector) rejects on timeout when obscured", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 300, height: 300 });
+  const view = new Bun.WebView({ backend: chrome, width: 300, height: 300 });
   try {
     await view.navigate(
       html(`
@@ -401,7 +408,7 @@ it("chrome: click(selector) rejects on timeout when obscured", async () => {
 });
 
 it("chrome: scrollTo(selector) scrolls element into view", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 300, height: 300 });
+  const view = new Bun.WebView({ backend: chrome, width: 300, height: 300 });
   try {
     await view.navigate(
       html(`
@@ -420,7 +427,7 @@ it("chrome: scrollTo(selector) scrolls element into view", async () => {
 });
 
 it("chrome: type inserts text at focused element", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 300, height: 300 });
+  const view = new Bun.WebView({ backend: chrome, width: 300, height: 300 });
   try {
     await view.navigate(html("<input id=i>"));
     // Input.insertText inserts at the caret — need focus first. autofocus
@@ -436,7 +443,7 @@ it("chrome: type inserts text at focused element", async () => {
 });
 
 it("chrome: scroll dispatches wheel event", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 300, height: 300 });
+  const view = new Bun.WebView({ backend: chrome, width: 300, height: 300 });
   try {
     await view.navigate(html("<body style='height:2000px'></body>"));
     await view.scroll(0, 100);
@@ -467,7 +474,7 @@ it("chrome: scroll dispatches wheel event", async () => {
 });
 
 it("chrome: url getter reflects committed URL", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     const url = html("<body>test</body>");
     await view.navigate(url);
@@ -479,7 +486,7 @@ it("chrome: url getter reflects committed URL", async () => {
 });
 
 it("chrome: close() rejects pending promises", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   await view.navigate(html("<body></body>"));
   // Kick off an eval that awaits forever.
   const p = view.evaluate("new Promise(() => {})");
@@ -488,8 +495,8 @@ it("chrome: close() rejects pending promises", async () => {
 });
 
 it("chrome: two views have independent sessions", async () => {
-  const a = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
-  const b = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const a = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  const b = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     // Each view has its own Target → its own sessionId → its own page.
     await Promise.all([a.navigate(html("<body>A</body>")), b.navigate(html("<body>B</body>"))]);
@@ -521,7 +528,9 @@ it("chrome: closeAll() kills the subprocess and pending promises reject", async 
       bunExe(),
       "-e",
       `
-        const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+        // Explicit path forces spawn-mode — skips DevToolsActivePort
+        // auto-detect that would connect to the dev's running Chrome.
+        const view = new Bun.WebView({ backend: {type:"chrome", path:process.env.CHROME_PATH}, width: 200, height: 200 });
         await view.navigate("data:text/html,<body>test</body>");
         const p = view.evaluate("new Promise(() => {})"); // never resolves
         Bun.WebView.closeAll();
@@ -535,7 +544,7 @@ it("chrome: closeAll() kills the subprocess and pending promises reject", async 
         console.log("rejected");
       `,
     ],
-    env: bunEnv,
+    env: { ...bunEnv, CHROME_PATH: chromePath },
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
@@ -552,12 +561,12 @@ it("chrome: backend.stderr defaults to ignore (Chrome noise hidden)", async () =
       bunExe(),
       "-e",
       `
-        const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+        const view = new Bun.WebView({ backend: {type:"chrome", path:process.env.CHROME_PATH}, width: 200, height: 200 });
         await view.navigate("data:text/html,<body>test</body>");
         view.close();
       `,
     ],
-    env: bunEnv,
+    env: { ...bunEnv, CHROME_PATH: chromePath },
     stderr: "pipe",
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
@@ -589,7 +598,10 @@ test("backend option validates", () => {
 });
 
 it("backend: { type: 'chrome' } object form works", async () => {
-  const view = new Bun.WebView({ backend: { type: "chrome" }, width: 200, height: 200 });
+  // path forces spawn-mode — without it, the bare object form would
+  // auto-detect DevToolsActivePort and connect to the dev's Chrome,
+  // locking the singleton into WS mode for subsequent tests.
+  const view = new Bun.WebView({ backend: { type: "chrome", path: chromePath }, width: 200, height: 200 });
   try {
     await view.navigate(html("<body>obj</body>"));
     expect(await view.evaluate("document.body.textContent")).toBe("obj");
@@ -628,7 +640,7 @@ it("backend.argv appends after core flags", async () => {
 // --- Error handling --------------------------------------------------------
 
 it("chrome: evaluate() throwing Error carries page-side stack", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     await view.navigate(html("<body></body>"));
     // CDP exceptionDetails.exception.description is V8's formatted stack.
@@ -657,7 +669,7 @@ it("chrome: evaluate() throwing Error carries page-side stack", async () => {
 });
 
 it("chrome: evaluate() rejected Promise carries rejection reason", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     await view.navigate(html("<body></body>"));
     await expect(view.evaluate("Promise.reject(new TypeError('bad'))")).rejects.toThrow(/bad/);
@@ -667,7 +679,7 @@ it("chrome: evaluate() rejected Promise carries rejection reason", async () => {
 });
 
 it("chrome: evaluate() with circular reference throws", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     await view.navigate(html("<body></body>"));
     // returnByValue can't serialize circular — Chrome throws page-side.
@@ -678,7 +690,7 @@ it("chrome: evaluate() with circular reference throws", async () => {
 });
 
 it("chrome: click(selector) rejects on invalid selector syntax", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     await view.navigate(html("<body></body>"));
     // querySelector throws SyntaxError page-side; the IIFE rejects.
@@ -691,7 +703,7 @@ it("chrome: click(selector) rejects on invalid selector syntax", async () => {
 // --- Input variants --------------------------------------------------------
 
 it("chrome: click with right button fires contextmenu", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 300, height: 300 });
+  const view = new Bun.WebView({ backend: chrome, width: 300, height: 300 });
   try {
     await view.navigate(
       html(`
@@ -712,7 +724,7 @@ it("chrome: click with right button fires contextmenu", async () => {
 });
 
 it("chrome: click with modifiers sets MouseEvent flags", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 300, height: 300 });
+  const view = new Bun.WebView({ backend: chrome, width: 300, height: 300 });
   try {
     await view.navigate(
       html(`
@@ -732,7 +744,7 @@ it("chrome: click with modifiers sets MouseEvent flags", async () => {
 });
 
 it("chrome: click(selector) is injection-safe", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 300, height: 300 });
+  const view = new Bun.WebView({ backend: chrome, width: 300, height: 300 });
   try {
     // Selector string contains double-quote + close-paren + close-brace —
     // characters that would break naive `")(sel,${timeout})` interpolation
@@ -751,7 +763,7 @@ it("chrome: click(selector) is injection-safe", async () => {
 });
 
 it("chrome: click(selector) waits for animation to stop", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 300, height: 300 });
+  const view = new Bun.WebView({ backend: chrome, width: 300, height: 300 });
   try {
     await view.navigate(
       html(`
@@ -775,7 +787,7 @@ it("chrome: click(selector) waits for animation to stop", async () => {
 // --- scrollTo variants -----------------------------------------------------
 
 it("chrome: scrollTo with block: start aligns top", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 300, height: 300 });
+  const view = new Bun.WebView({ backend: chrome, width: 300, height: 300 });
   try {
     await view.navigate(
       html(`
@@ -796,7 +808,7 @@ it("chrome: scrollTo with block: start aligns top", async () => {
 // --- Lifecycle -------------------------------------------------------------
 
 it("chrome: resize changes viewport dimensions", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 300, height: 300 });
+  const view = new Bun.WebView({ backend: chrome, width: 300, height: 300 });
   try {
     await view.navigate(html("<body></body>"));
     await view.resize(500, 400);
@@ -810,7 +822,7 @@ it("chrome: resize changes viewport dimensions", async () => {
 });
 
 it("chrome: reload resolves after Page.loadEventFired", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     await view.navigate(html("<script>window.__n = Date.now()</script>"));
     const before = await view.evaluate("__n");
@@ -825,7 +837,7 @@ it("chrome: reload resolves after Page.loadEventFired", async () => {
 });
 
 it("chrome: sequential navigates work", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     // First navigate does the attach chain; subsequent go direct.
     await view.navigate(html("<body>A</body>"));
@@ -848,7 +860,7 @@ it("chrome: close() during attach chain doesn't leak the tab", async () => {
   // tab would navigate and fire Page.frameNavigated → onNavigated on a
   // disposed view.
   const navigated: string[] = [];
-  const view = new Bun.WebView({ backend: "chrome", width: 100, height: 100 });
+  const view = new Bun.WebView({ backend: chrome, width: 100, height: 100 });
   view.onNavigated = (u: string) => navigated.push(u);
   // navigate() kicks off the chain; don't await.
   const navP = view.navigate("data:text/html,<body>leaked</body>");
@@ -862,7 +874,7 @@ it("chrome: close() during attach chain doesn't leak the tab", async () => {
 });
 
 it("chrome: url/title getters populated after navigate", async () => {
-  await using view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   await view.navigate(html("<title>Page Title</title><body>hi</body>"));
   // Page.loadEventFired chains Runtime.evaluate("document.title") before
   // settling — navigate() resolves with m_title populated. Same guarantee
@@ -875,7 +887,7 @@ it("chrome: url/title getters populated after navigate", async () => {
 });
 
 it("chrome: onNavigated fires with committed URL", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     const urls: string[] = [];
     view.onNavigated = (url: string) => urls.push(url);
@@ -891,7 +903,7 @@ it("chrome: onNavigated fires with committed URL", async () => {
 });
 
 it("chrome: press() dispatches keydown/keyup pair", async () => {
-  await using view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   // Listeners in the HTML so they're live before any press. evaluate() wraps
   // as `await (${script})` — statement sequences need IIFE, but putting the
   // setup in the navigate body sidesteps that entirely.
@@ -913,7 +925,7 @@ it("chrome: press() dispatches keydown/keyup pair", async () => {
 });
 
 it("chrome: press() with modifiers", async () => {
-  await using view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   await view.navigate(
     html(`
     <body><script>
@@ -927,7 +939,7 @@ it("chrome: press() with modifiers", async () => {
 });
 
 it("chrome: goBack/goForward navigates history", async () => {
-  await using view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   await view.navigate(html("<body>A</body>"));
   await view.navigate(html("<body>B</body>"));
   await view.navigate(html("<body>C</body>"));
@@ -942,7 +954,7 @@ it("chrome: goBack/goForward navigates history", async () => {
 });
 
 it("chrome: goBack at history start resolves undefined (no-op)", async () => {
-  await using view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   await view.navigate(html("<body>only</body>"));
   // Target.createTarget({url:"about:blank"}) means history[0]=about:blank,
   // history[1]=our page after navigate. goBack once → about:blank.
@@ -960,7 +972,7 @@ it("chrome: goBack at history start resolves undefined (no-op)", async () => {
 it("chrome: console callback receives (type, ...args)", async () => {
   const calls: [string, ...unknown[]][] = [];
   await using view = new Bun.WebView({
-    backend: "chrome",
+    backend: chrome,
     width: 200,
     height: 200,
     console: (type: string, ...args: unknown[]) => calls.push([type, ...args]),
@@ -989,7 +1001,7 @@ it("chrome: console: globalThis.console forwards to parent's stdout", async () =
       "-e",
       `
       const view = new Bun.WebView({
-        backend: "chrome", width: 200, height: 200,
+        backend: {type:"chrome", path:process.env.CHROME_PATH}, width: 200, height: 200,
         console: globalThis.console,
       });
       await view.navigate("data:text/html,<body></body>");
@@ -998,7 +1010,7 @@ it("chrome: console: globalThis.console forwards to parent's stdout", async () =
       view.close();
       `,
     ],
-    env: bunEnv,
+    env: { ...bunEnv, CHROME_PATH: chromePath },
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -1013,16 +1025,16 @@ it("chrome: console: globalThis.console forwards to parent's stdout", async () =
 });
 
 it("chrome: console option validates", () => {
-  expect(() => new Bun.WebView({ backend: "chrome", console: 42 } as any)).toThrow(
+  expect(() => new Bun.WebView({ backend: chrome, console: 42 } as any)).toThrow(
     /console must be globalThis.console or a function/,
   );
-  expect(() => new Bun.WebView({ backend: "chrome", console: {} } as any)).toThrow(
+  expect(() => new Bun.WebView({ backend: chrome, console: {} } as any)).toThrow(
     /console must be globalThis.console or a function/,
   );
 });
 
 it("chrome: large evaluate payload crosses the pipe", async () => {
-  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {
     await view.navigate(html("<body></body>"));
     // 100KB string. The socketpair buffer is ~256KB default; a single

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -187,6 +187,55 @@ it("chrome: screenshot format options produce the right magic bytes", async () =
   }
 });
 
+it("chrome: cdp() raw passthrough", async () => {
+  const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
+  try {
+    await view.navigate(html("<body><input id=q value='hello'></body>"));
+
+    // DOM.getDocument → root nodeId. The result shape is documented CDP.
+    const doc = await view.cdp<{ root: { nodeId: number } }>("DOM.getDocument");
+    expect(typeof doc.root.nodeId).toBe("number");
+
+    // DOM.querySelector chained through the nodeId.
+    const { nodeId } = await view.cdp<{ nodeId: number }>("DOM.querySelector", {
+      nodeId: doc.root.nodeId,
+      selector: "#q",
+    });
+    expect(nodeId).toBeGreaterThan(0);
+
+    // Runtime.evaluate as a sanity check — same mechanism as view.evaluate()
+    // but we get the raw CDP result object (including .type).
+    const r = await view.cdp<{ result: { type: string; value: string } }>("Runtime.evaluate", {
+      expression: "document.querySelector('#q').value",
+      returnByValue: true,
+    });
+    expect(r.result.type).toBe("string");
+    expect(r.result.value).toBe("hello");
+
+    // Unknown method rejects with Chrome's -32601.
+    await expect(view.cdp("NotADomain.nope")).rejects.toThrow(/wasn't found|method/i);
+
+    // Empty result object (Input.* style) — should resolve {}.
+    const empty = await view.cdp<object>("Page.bringToFront");
+    expect(empty).toEqual({});
+  } finally {
+    view.close();
+  }
+});
+
+it("chrome: cdp() guards — WebKit backend and before navigate", async () => {
+  // Chrome before first navigate → no sessionId → INVALID_STATE.
+  const crView = new Bun.WebView({ backend: "chrome", width: 100, height: 100 });
+  try {
+    expect(() => crView.cdp("Page.enable")).toThrow(/session.*navigate/i);
+    // params validation: non-object rejected before any I/O.
+    await crView.navigate(html("<body></body>"));
+    expect(() => crView.cdp("Page.enable", 42 as any)).toThrow(/object/);
+  } finally {
+    crView.close();
+  }
+});
+
 it("chrome: screenshot quality option affects JPEG size", async () => {
   const view = new Bun.WebView({ backend: "chrome", width: 200, height: 200 });
   try {

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -106,6 +106,10 @@ function findChrome(): string | undefined {
 const chromePath = findChrome();
 const it = chromePath ? test : test.todo;
 
+// WebSocket-transport tests live in webview-chrome-ws.test.ts — the
+// Transport singleton means you can't mix pipe-mode (this file) and
+// connect-mode in one process.
+
 const html = (h: string) => "data:text/html," + encodeURIComponent(h);
 
 it("backend: chrome constructor returns a WebView", () => {

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -312,6 +312,45 @@ test("chrome: constructor rejects url combined with spawn options", () => {
   ).toThrow(/connect mode.*cannot be combined.*spawn/i);
 });
 
+it("chrome: cdp() enable + addEventListener receives CDP events", async () => {
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  try {
+    // First navigate to get a sessionId (cdp() guards before that).
+    await view.navigate(html("<body>init</body>"));
+
+    // Network.enable starts streaming. The listener type IS the CDP
+    // method name — handleEvent's fallthrough dispatches any
+    // non-internal event as a MessageEvent with the params as .data.
+    await view.cdp("Network.enable");
+    const events: any[] = [];
+    const onReq = (e: MessageEvent) => events.push(e.data);
+    view.addEventListener("Network.requestWillBeSent", onReq);
+
+    // Second navigate triggers a Network.requestWillBeSent for the
+    // data: URL itself. Await resolves on Page.loadEventFired — by
+    // then Chrome has sent the Network event (it precedes load).
+    await view.navigate(html("<body>second</body>"));
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(events[0].request.url).toStartWith("data:text/html");
+    expect(typeof events[0].requestId).toBe("string");
+
+    // removeEventListener stops delivery. Third navigate generates
+    // more Network events but the count shouldn't grow.
+    view.removeEventListener("Network.requestWillBeSent", onReq);
+    const before = events.length;
+    await view.navigate(html("<body>third</body>"));
+    expect(events.length).toBe(before);
+
+    // Unhandled events without a listener are dropped (hasEventListeners
+    // check) — no parse, no dispatch. This navigate also fired
+    // Network.responseReceived but we never listened for it; no crash,
+    // no accumulation.
+  } finally {
+    view.close();
+  }
+});
+
 it("chrome: screenshot quality option affects JPEG size", async () => {
   const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   try {

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -1,6 +1,6 @@
+import { dlopen, FFIType, ptr, toArrayBuffer } from "bun:ffi";
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isCI, isMacOS, tempDir } from "harness";
-import { dlopen, FFIType, ptr, toArrayBuffer } from "bun:ffi";
 
 // FFI shm access for encoding:"shmem" tests. In real use Kitty (or
 // whoever opens the segment) does this — shm_open + mmap + read + unlink.

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -1,5 +1,51 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isCI, isMacOS, tempDir } from "harness";
+import { dlopen, FFIType, ptr, toArrayBuffer } from "bun:ffi";
+
+// FFI shm access for encoding:"shmem" tests. In real use Kitty (or
+// whoever opens the segment) does this — shm_open + mmap + read + unlink.
+// The test does the same to verify end-to-end that the bytes landed in
+// the segment and are readable from another "process" (same-process,
+// different fd — good enough to prove the IPC boundary).
+const libc = isMacOS
+  ? dlopen("libc.dylib", {
+      shm_open: { args: [FFIType.cstring, FFIType.i32, FFIType.u16], returns: FFIType.i32 },
+      shm_unlink: { args: [FFIType.cstring], returns: FFIType.i32 },
+      mmap: {
+        args: [FFIType.ptr, FFIType.u64, FFIType.i32, FFIType.i32, FFIType.i32, FFIType.i64],
+        returns: FFIType.ptr,
+      },
+      munmap: { args: [FFIType.ptr, FFIType.u64], returns: FFIType.i32 },
+      close: { args: [FFIType.i32], returns: FFIType.i32 },
+    })
+  : null;
+function shmUnlink(name: string): void {
+  libc?.symbols.shm_unlink(ptr(Buffer.from(name + "\0")));
+}
+// Read the first `n` bytes from a named POSIX shm segment. Mirrors what
+// Kitty does for t=s transmission. Returns a fresh Buffer (copy —
+// we unmap immediately).
+function shmRead(name: string, n: number): Buffer {
+  const O_RDONLY = 0;
+  const PROT_READ = 1;
+  const MAP_SHARED = 1;
+  const namez = Buffer.from(name + "\0");
+  const fd = libc!.symbols.shm_open(ptr(namez), O_RDONLY, 0);
+  if (fd < 0) throw new Error(`shm_open(${name}) failed`);
+  const map = libc!.symbols.mmap(0, n, PROT_READ, MAP_SHARED, fd, 0);
+  libc!.symbols.close(fd);
+  // mmap returns MAP_FAILED = (void*)-1; ptr arithmetic over bigint.
+  // A valid mapping is page-aligned (low bits zero), so any nonzero
+  // return here means we got pages.
+  if (!map) throw new Error("mmap failed");
+  // Copy into a JS-owned Buffer — the mapping goes away with munmap.
+  // `toBuffer(ptr, byteOffset, byteLength)` wraps without copying;
+  // `Buffer.from(...)` then copies so munmap is safe.
+  const live = new Uint8Array(toArrayBuffer(map, 0, n));
+  const out = Buffer.from(live); // copies
+  libc!.symbols.munmap(map, n);
+  return out;
+}
 
 // Bun.WebView only exists on darwin for now.
 const it = isMacOS ? test : test.skip;
@@ -316,6 +362,47 @@ it("screenshot format options", async () => {
 
   // cdp() is Chrome-only.
   expect(() => view.cdp("Page.enable")).toThrow(/chrome/i);
+});
+
+it("screenshot encoding options", async () => {
+  await using view = new Bun.WebView({ width: 200, height: 150 });
+  await view.navigate(html("<body style='background:#00f'>blue</body>"));
+
+  // buffer — zero-copy mmap-backed on WebKit. Same PNG magic.
+  const buf = await view.screenshot({ encoding: "buffer" });
+  expect(Buffer.isBuffer(buf)).toBe(true);
+  expect(buf[0]).toBe(0x89);
+  expect(buf[1]).toBe(0x50);
+  expect(buf[2]).toBe(0x4e);
+  expect(buf[3]).toBe(0x47);
+  // Mutate the buffer — the ArrayBuffer adopts the mapping PROT_WRITE,
+  // so this is safe (writes the mmap'd page; munmap's on GC).
+  buf[0] = 0xff;
+  expect(buf[0]).toBe(0xff);
+
+  // base64 — string encoding. Decodes to the same PNG bytes.
+  const b64 = await view.screenshot({ encoding: "base64" });
+  expect(typeof b64).toBe("string");
+  const decoded = Buffer.from(b64, "base64");
+  expect(decoded[0]).toBe(0x89);
+  expect(decoded[1]).toBe(0x50);
+
+  // shmem — POSIX shm name + size. We don't unlink; the user (Kitty)
+  // does after shm_open'ing. Verify end-to-end by reading the segment
+  // ourselves — same thing Kitty does.
+  const shm = await view.screenshot({ encoding: "shmem" });
+  expect(typeof shm.name).toBe("string");
+  expect(shm.name.startsWith("/bun-webview-")).toBe(true);
+  expect(shm.size).toBeGreaterThan(100);
+  // shm_open + mmap + read — proves the bytes landed in the segment
+  // and are PNG. This is what Kitty's t=s handler does.
+  const bytes = shmRead(shm.name, 8);
+  expect(bytes[0]).toBe(0x89);
+  expect(bytes[1]).toBe(0x50);
+  expect(bytes[2]).toBe(0x4e);
+  expect(bytes[3]).toBe(0x47);
+  // Clean up — Kitty does this after reading.
+  shmUnlink(shm.name);
 });
 
 it("screenshot Blob survives GC (mmap-backed store)", async () => {

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -391,18 +391,22 @@ it("screenshot encoding options", async () => {
   // does after shm_open'ing. Verify end-to-end by reading the segment
   // ourselves — same thing Kitty does.
   const shm = await view.screenshot({ encoding: "shmem" });
-  expect(typeof shm.name).toBe("string");
-  expect(shm.name.startsWith("/bun-webview-")).toBe(true);
-  expect(shm.size).toBeGreaterThan(100);
-  // shm_open + mmap + read — proves the bytes landed in the segment
-  // and are PNG. This is what Kitty's t=s handler does.
-  const bytes = shmRead(shm.name, 8);
-  expect(bytes[0]).toBe(0x89);
-  expect(bytes[1]).toBe(0x50);
-  expect(bytes[2]).toBe(0x4e);
-  expect(bytes[3]).toBe(0x47);
-  // Clean up — Kitty does this after reading.
-  shmUnlink(shm.name);
+  try {
+    expect(typeof shm.name).toBe("string");
+    expect(shm.name.startsWith("/bun-webview-")).toBe(true);
+    expect(shm.size).toBeGreaterThan(100);
+    // shm_open + mmap + read — proves the bytes landed in the segment
+    // and are PNG. This is what Kitty's t=s handler does.
+    const bytes = shmRead(shm.name, 8);
+    expect(bytes[0]).toBe(0x89);
+    expect(bytes[1]).toBe(0x50);
+    expect(bytes[2]).toBe(0x4e);
+    expect(bytes[3]).toBe(0x47);
+  } finally {
+    // Clean up even if assertions fail — leaked shm names persist
+    // until logout on macOS.
+    shmUnlink(shm.name);
+  }
 });
 
 it("screenshot Blob survives GC (mmap-backed store)", async () => {

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -27,6 +27,54 @@ test("calling without new throws", () => {
   expect(() => (Bun.WebView as any)({ width: 100, height: 100 })).toThrow(/without 'new'/);
 });
 
+it("is an EventTarget", () => {
+  const view = new Bun.WebView({ width: 100, height: 100 });
+  try {
+    expect(view).toBeInstanceOf(EventTarget);
+    expect(Object.getPrototypeOf(Object.getPrototypeOf(view))).toBe(EventTarget.prototype);
+    // addEventListener/removeEventListener/dispatchEvent inherited from
+    // EventTarget.prototype — unwrap via jsDynamicCast<JSEventTarget*>
+    // which succeeds for JSWebView : JSEventTarget.
+    expect(typeof view.addEventListener).toBe("function");
+    expect(typeof view.removeEventListener).toBe("function");
+    expect(typeof view.dispatchEvent).toBe("function");
+  } finally {
+    view.close();
+  }
+});
+
+it("dispatchEvent fires addEventListener callbacks", () => {
+  const view = new Bun.WebView({ width: 100, height: 100 });
+  try {
+    let fired = 0;
+    let target: EventTarget | null = null;
+    view.addEventListener("test", e => {
+      fired++;
+      target = e.target;
+    });
+    const dispatched = view.dispatchEvent(new Event("test"));
+    expect(dispatched).toBe(true);
+    expect(fired).toBe(1);
+    // event.target resolved via WebViewEventTarget's ScriptWrappable →
+    // impl→wrapper Weak — returns the JSWebView instance.
+    expect(target).toBe(view);
+
+    // removeEventListener unhooks.
+    view.removeEventListener("test", view.addEventListener as any); // wrong fn, no-op
+    view.dispatchEvent(new Event("test"));
+    expect(fired).toBe(2); // still registered
+
+    // Multiple listeners on same event fire in registration order.
+    const order: number[] = [];
+    view.addEventListener("multi", () => order.push(1));
+    view.addEventListener("multi", () => order.push(2));
+    view.dispatchEvent(new Event("multi"));
+    expect(order).toEqual([1, 2]);
+  } finally {
+    view.close();
+  }
+});
+
 it("width/height validation", () => {
   expect(() => new Bun.WebView({ width: 0, height: 100 })).toThrow();
   expect(() => new Bun.WebView({ width: 100, height: 0 })).toThrow();
@@ -225,17 +273,52 @@ it("onNavigationFailed callback fires", async () => {
   expect(failed).toBe(true);
 });
 
-it("screenshot returns PNG bytes", async () => {
+it("screenshot returns a PNG Blob", async () => {
   await using view = new Bun.WebView({ width: 200, height: 150 });
   await view.navigate(html("<body style='background:#f00'>red</body>"));
-  const png = await view.screenshot();
-  expect(png).toBeInstanceOf(Uint8Array);
-  expect(png.length).toBeGreaterThan(8);
+  const blob = await view.screenshot();
+  expect(blob).toBeInstanceOf(Blob);
+  expect(blob.type).toBe("image/png");
+  expect(blob.size).toBeGreaterThan(8);
+  const bytes = new Uint8Array(await blob.arrayBuffer());
   // PNG magic: 89 50 4E 47 0D 0A 1A 0A
-  expect(png[0]).toBe(0x89);
-  expect(png[1]).toBe(0x50);
-  expect(png[2]).toBe(0x4e);
-  expect(png[3]).toBe(0x47);
+  expect(bytes[0]).toBe(0x89);
+  expect(bytes[1]).toBe(0x50);
+  expect(bytes[2]).toBe(0x4e);
+  expect(bytes[3]).toBe(0x47);
+});
+
+it("screenshot format options", async () => {
+  await using view = new Bun.WebView({ width: 200, height: 150 });
+  await view.navigate(html("<body style='background:linear-gradient(red,blue)'></body>"));
+
+  const jpeg = await view.screenshot({ format: "jpeg", quality: 90 });
+  expect(jpeg.type).toBe("image/jpeg");
+  const jb = new Uint8Array(await jpeg.arrayBuffer());
+  // JPEG magic: FF D8 FF
+  expect([jb[0], jb[1], jb[2]]).toEqual([0xff, 0xd8, 0xff]);
+
+  // WebP rejected on WebKit — NSBitmapImageRep has no WebP in its enum.
+  // Thrown synchronously (arg validation), not promise-rejection.
+  expect(() => view.screenshot({ format: "webp" })).toThrow(/webp.*chrome/i);
+
+  // quality validation
+  expect(() => view.screenshot({ quality: 101 } as any)).toThrow(/quality.*0.*100/);
+  expect(() => view.screenshot({ format: "gif" } as any)).toThrow(/png.*jpeg.*webp/i);
+});
+
+it("screenshot Blob survives GC (mmap-backed store)", async () => {
+  // The WebKit path mmap's the shm segment directly into the Blob's store
+  // — no copy. The store's allocator vtable munmap's on free (when the
+  // Blob's refcount drops). This verifies the mapping is valid across a
+  // GC cycle and that `await blob.bytes()` reads live pages.
+  await using view = new Bun.WebView({ width: 200, height: 150 });
+  await view.navigate(html("<body style='background:#0f0'>green</body>"));
+  const blob = await view.screenshot();
+  Bun.gc(true);
+  const bytes = await blob.bytes();
+  expect(bytes[0]).toBe(0x89); // PNG magic still readable
+  expect(bytes.length).toBe(blob.size);
 });
 
 // Probe test — if click(selector) times out on CI, this tells us whether

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -34,10 +34,10 @@ function shmRead(name: string, n: number): Buffer {
   if (fd < 0) throw new Error(`shm_open(${name}) failed`);
   const map = libc!.symbols.mmap(0, n, PROT_READ, MAP_SHARED, fd, 0);
   libc!.symbols.close(fd);
-  // mmap returns MAP_FAILED = (void*)-1; ptr arithmetic over bigint.
-  // A valid mapping is page-aligned (low bits zero), so any nonzero
-  // return here means we got pages.
-  if (!map) throw new Error("mmap failed");
+  // MAP_FAILED = (void*)-1 — all bits set, so low 12 bits are 0xfff.
+  // A valid mapping is page-aligned: low 12 bits zero. FFIType.ptr
+  // returns a JS number; we mask the low bits to distinguish.
+  if (!map || (Number(map) & 0xfff) !== 0) throw new Error("mmap failed");
   // Copy into a JS-owned Buffer — the mapping goes away with munmap.
   // `toBuffer(ptr, byteOffset, byteLength)` wraps without copying;
   // `Buffer.from(...)` then copies so munmap is safe.

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -305,6 +305,9 @@ it("screenshot format options", async () => {
   // quality validation
   expect(() => view.screenshot({ quality: 101 } as any)).toThrow(/quality.*0.*100/);
   expect(() => view.screenshot({ format: "gif" } as any)).toThrow(/png.*jpeg.*webp/i);
+
+  // cdp() is Chrome-only.
+  expect(() => view.cdp("Page.enable")).toThrow(/chrome/i);
 });
 
 it("screenshot Blob survives GC (mmap-backed store)", async () => {

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -48,10 +48,11 @@ it("dispatchEvent fires addEventListener callbacks", () => {
   try {
     let fired = 0;
     let target: EventTarget | null = null;
-    view.addEventListener("test", e => {
+    const handler = (e: Event) => {
       fired++;
       target = e.target;
-    });
+    };
+    view.addEventListener("test", handler);
     const dispatched = view.dispatchEvent(new Event("test"));
     expect(dispatched).toBe(true);
     expect(fired).toBe(1);
@@ -59,10 +60,15 @@ it("dispatchEvent fires addEventListener callbacks", () => {
     // impl→wrapper Weak — returns the JSWebView instance.
     expect(target).toBe(view);
 
-    // removeEventListener unhooks.
-    view.removeEventListener("test", view.addEventListener as any); // wrong fn, no-op
+    // removeEventListener with a different function reference is a no-op.
+    view.removeEventListener("test", () => {});
     view.dispatchEvent(new Event("test"));
     expect(fired).toBe(2); // still registered
+
+    // removeEventListener with the exact reference unhooks.
+    view.removeEventListener("test", handler);
+    view.dispatchEvent(new Event("test"));
+    expect(fired).toBe(2); // unchanged — handler removed
 
     // Multiple listeners on same event fire in registration order.
     const order: number[] = [];
@@ -302,8 +308,10 @@ it("screenshot format options", async () => {
   // Thrown synchronously (arg validation), not promise-rejection.
   expect(() => view.screenshot({ format: "webp" })).toThrow(/webp.*chrome/i);
 
-  // quality validation
+  // quality validation — NaN/Infinity are rejected (isfinite check).
   expect(() => view.screenshot({ quality: 101 } as any)).toThrow(/quality.*0.*100/);
+  expect(() => view.screenshot({ quality: NaN } as any)).toThrow(/quality.*0.*100/);
+  expect(() => view.screenshot({ quality: Infinity } as any)).toThrow(/quality.*0.*100/);
   expect(() => view.screenshot({ format: "gif" } as any)).toThrow(/png.*jpeg.*webp/i);
 
   // cdp() is Chrome-only.


### PR DESCRIPTION
## EventTarget inheritance

`Bun.WebView` now extends `EventTarget` — `addEventListener`/`removeEventListener`/`dispatchEvent` are inherited. The impl side (`WebViewEventTarget`) is a thin wrapper holding just the listener map; all WebView state stays on the JS cell.

## screenshot({format, quality}) returning zero-copy mmap-backed Blob

```ts
const png = await view.screenshot();                          // Blob, image/png
const jpeg = await view.screenshot({ format: "jpeg", quality: 90 });
const webp = await view.screenshot({ format: "webp" });       // chrome-only
```

**WebKit**: zero-copy — the child writes encoded image bytes to a POSIX shm segment; the parent `mmap`'s it directly into the `Blob`'s backing store. The mapping is released when the `Blob` is garbage-collected. `await blob.bytes()` reads straight from the mapped pages.

**Chrome**: decodes the CDP base64 response and copies into a mimalloc-owned buffer (the base64 decode allocation is unavoidable).

`format: "webp"` requires the Chrome backend (NSBitmapImageRep has no WebP encoding; the ImageIO CGImageDestination path with `public.webp` UTI is deferred).

## .cdp(method, params?) — raw CDP escape hatch (Chrome-only)

```ts
const view = new Bun.WebView({ backend: "chrome" });
await view.navigate("https://example.com");

const { root } = await view.cdp("DOM.getDocument");
const { nodeId } = await view.cdp("DOM.querySelector", {
  nodeId: root.nodeId, selector: "input#search"
});
await view.cdp("DOM.focus", { nodeId });
```

The command is scoped to the view's sessionId. Resolves with `JSON.parse(response.result)`; rejects with `error.message` on protocol errors.