### PR TITLE
Validate ctx argument in FFI.closeCallback before converting to pointer

### DIFF
--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -830,8 +830,11 @@ pub const FFI = struct {
         return js_object;
     }
 
-    pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) JSValue {
-        var function: *Function = @ptrFromInt(ctx.asPtrAddress());
+    pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) bun.JSError!JSValue {
+        if (!ctx.isAnyInt()) return globalThis.throwInvalidArguments("Expected a FFI callback context", .{});
+        const num = ctx.asNumber();
+        if (num <= 0 or num >= @as(f64, @floatFromInt(std.math.maxInt(usize)))) return globalThis.throwInvalidArguments("Expected a FFI callback context", .{});
+        var function: *Function = @ptrFromInt(@as(usize, @intFromFloat(num)));
         function.deinit(globalThis);
         return .js_undefined;
     }

--- a/test/js/bun/ffi/ffi-error-messages.test.ts
+++ b/test/js/bun/ffi/ffi-error-messages.test.ts
@@ -1,6 +1,6 @@
 import { dlopen, linkSymbols } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
-import { isArm64, isMusl, isWindows } from "harness";
+import { bunEnv, bunExe, isArm64, isMusl, isWindows } from "harness";
 
 // TinyCC (and all of bun:ffi) is disabled on Windows ARM64
 const isFFIUnavailable = isWindows && isArm64;
@@ -75,5 +75,35 @@ describe.skipIf(isFFIUnavailable)("FFI error messages", () => {
         },
       });
     }).toThrow('you must provide a "ptr" field with the memory address of the native function.');
+  });
+
+  test("closeCallback with invalid argument does not crash", async () => {
+    // Bun.FFI.closeCallback is available before `bun:ffi` module init
+    // runs (which deletes it). Using `-e` without importing `bun:ffi`
+    // lets us access the native binding directly.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const closeCallback = Bun.FFI.closeCallback;
+        if (typeof closeCallback !== "function") throw new Error("closeCallback not found on Bun.FFI");
+        let caught = 0;
+        for (const v of ["str", {}, 0, -1, 1.5, NaN, Infinity, 1e20, 2**64]) {
+          try { closeCallback(v); } catch { caught++; }
+        }
+        if (caught !== 9) throw new Error("expected 9 catches, got " + caught);
+        console.log("ok");
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("ok\n");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
FFI.closeCallback calls `asPtrAddress()` on its `ctx` argument, which internally asserts the value is numeric via `asNumber()`. When called with a non-numeric value (e.g. a string or object), this triggers a `panic: reached unreachable code` assertion crash.

The fix adds an `isAnyInt()` check before calling `asPtrAddress()`, throwing a TypeError instead of crashing.

**Root cause**: `closeCallback` is intended to be internal (deleted from `Bun.FFI` in ffi.ts after capture), but the native binding can still be reached. No validation was performed on the `ctx` argument before interpreting it as a pointer address.

**Fix**: Check `ctx.isAnyInt()` before converting to pointer, with range validation (`num <= 0` and `num >= maxInt(usize)`), matching the pattern used elsewhere in ffi.zig. Return type changed to `bun.JSError!JSValue` to support error returns.

---

**Verification (robobun):** CI: Lint JS pass, Buildkite pipeline step pass, full Buildkite build and Format still pending at time of review. All four red issues from Claude bot review are addressed — (1) zero pointer: rejected by `num <= 0`, (2) non-integer floats/NaN/Infinity: rejected by `isAnyInt()`, (3) usize overflow from 1e20: rejected by `num >= maxInt(usize)`, (4) boundary `>=` vs `>`: code uses `>=` correctly since `@floatFromInt(maxInt(usize))` rounds up to 2^64. Return type `bun.JSError!JSValue` matches established pattern (e.g. `callback`, `print` in same file, also wrapped via `wrapStaticMethod`). Test exercises 9 edge cases (`"str"`, `{}`, `0`, `-1`, `1.5`, `NaN`, `Infinity`, `1e20`, `2**64`) — all would crash on main, all must throw with the fix. No TODO/FIXME/HACK in diff. No unrelated changes.