### PR TITLE
Fix panic in fd validation when float is outside i64 range

### DIFF
--- a/src/fd.zig
+++ b/src/fd.zig
@@ -331,10 +331,10 @@ pub const FD = packed struct(backing_int) {
         if (@mod(float, 1) != 0) {
             return global.throwRangeError(float, .{ .field_name = "fd", .msg = "an integer" });
         }
-        const int: i64 = @intFromFloat(float);
-        if (int < 0 or int > std.math.maxInt(i32)) {
-            return global.throwRangeError(int, .{ .field_name = "fd", .min = 0, .max = std.math.maxInt(i32) });
+        if (float < 0 or float > @as(f64, @floatFromInt(std.math.maxInt(i32)))) {
+            return global.throwRangeError(float, .{ .field_name = "fd", .min = 0, .max = std.math.maxInt(i32) });
         }
+        const int: i64 = @intFromFloat(float);
         const fd: c_int = @intCast(int);
         if (os == .windows) {
             if (Stdio.fromInt(fd)) |stdio| {

--- a/test/js/bun/s3/s3-fd-validation.test.ts
+++ b/test/js/bun/s3/s3-fd-validation.test.ts
@@ -1,7 +1,5 @@
 import { test, expect } from "bun:test";
 
-// Regression: passing a very large float as a file descriptor to S3Client.write
-// caused a panic in @intFromFloat because the value was outside i64 range.
 test("S3Client.write does not crash with out-of-range float as path", () => {
   expect(() => Bun.S3Client.write(-1.5379890021597998e308, "data")).toThrow();
   expect(() => Bun.S3Client.write(1e308, "data")).toThrow();

--- a/test/js/bun/s3/s3-fd-validation.test.ts
+++ b/test/js/bun/s3/s3-fd-validation.test.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "bun:test";
+
+// Regression: passing a very large float as a file descriptor to S3Client.write
+// caused a panic in @intFromFloat because the value was outside i64 range.
+test("S3Client.write does not crash with out-of-range float as path", () => {
+  expect(() => Bun.S3Client.write(-1.5379890021597998e308, "data")).toThrow();
+  expect(() => Bun.S3Client.write(1e308, "data")).toThrow();
+  expect(() => Bun.S3Client.write(Infinity, "data")).toThrow();
+  expect(() => Bun.S3Client.write(-Infinity, "data")).toThrow();
+});

--- a/test/js/bun/s3/s3-fd-validation.test.ts
+++ b/test/js/bun/s3/s3-fd-validation.test.ts
@@ -7,4 +7,5 @@ test("S3Client.write does not crash with out-of-range float as path", () => {
   expect(() => Bun.S3Client.write(1e308, "data")).toThrow();
   expect(() => Bun.S3Client.write(Infinity, "data")).toThrow();
   expect(() => Bun.S3Client.write(-Infinity, "data")).toThrow();
+  expect(() => Bun.S3Client.write(NaN, "data")).toThrow();
 });


### PR DESCRIPTION
Passing a very large float (e.g. `-1.5e308`) as a file descriptor to any API that uses `FD.fromJSValidated` (such as `S3Client.write`) caused a panic:

```
panic(main thread): integer part of floating point value out of bounds
```

The `@mod(float, 1) != 0` check correctly identifies non-integers, but very large finite floats like `1e308` are integers in IEEE 754 (all doubles above 2^52 are), so they pass that check. The subsequent `@intFromFloat` then panics because the value exceeds the i64 range.

The fix validates the float against the valid fd range (`0` to `maxInt(i32)`) *before* the `@intFromFloat` conversion.

---

Verified: CI lint passed, buildkite build pending (build #40545). Diff is a minimal 3-line reorder in `fd.zig` moving the range check before `@intFromFloat`. Regression test in `s3-fd-validation.test.ts` exercises all four panic-triggering cases (large positive/negative floats, ±Infinity). No TODO/FIXME/HACK markers, no unrelated changes, no reviews to triage.