### PR TITLE
Validate ctx argument in FFI.closeCallback before casting to pointer

### DIFF
--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -830,8 +830,12 @@ pub const FFI = struct {
         return js_object;
     }
 
-    pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) JSValue {
-        var function: *Function = @ptrFromInt(ctx.asPtrAddress());
+    pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) bun.JSError!JSValue {
+        if (!ctx.isNumber()) return globalThis.throwInvalidArguments("Expected a FFI callback context", .{});
+        const num = ctx.asNumber();
+        if (!std.math.isFinite(num) or num != @trunc(num) or !(num >= @as(f64, @floatFromInt(std.heap.page_size_min))) or num >= @as(f64, @floatFromInt(std.math.maxInt(u56))))
+            return globalThis.throwInvalidArguments("Expected a FFI callback context", .{});
+        var function: *Function = @ptrFromInt(@as(usize, @intFromFloat(num)));
         function.deinit(globalThis);
         return .js_undefined;
     }

--- a/test/js/bun/ffi/ffi-closeCallback.test.ts
+++ b/test/js/bun/ffi/ffi-closeCallback.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("FFI.closeCallback throws on invalid arguments instead of crashing", () => {
+  const result = Bun.spawnSync({
+    cmd: [
+      bunExe(),
+      "-e",
+      'const c = Bun.FFI.closeCallback; for (const a of [208,0,-1,65536.5,2**56,null,undefined,"x",{},NaN,Infinity,-Infinity,true]) { try { c(a); process.exit(1); } catch(e) { if (!e.message.includes("FFI callback")) process.exit(1); } } console.log("ok");',
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  expect(result.stdout.toString().trim()).toBe("ok");
+  expect(result.exitCode).toBe(0);
+}, 30_000);


### PR DESCRIPTION
FFI.closeCallback directly called `ctx.asPtrAddress()` without checking that `ctx` is a valid number. When called with non-numeric arguments (e.g. a string or object), this triggers an assertion failure in `asNumber()` → `panic: reached unreachable code`.

This adds validation that `ctx` is a number and non-zero before interpreting it as a pointer address, returning a proper JS error instead of crashing.

While `closeCallback` is intended to be internal-only (it is deleted from the public FFI object by the JS wrapper in `ffi.ts`), it is still accessible via `Bun.FFI` which exposes the raw native object before the wrapper runs.

---
Verified by @robobun (iteration 4): Lint JS passed, Buildkite pipeline accepted (build #40753 running), Format pending. Diff touches 2 files: `ffi.zig` adds layered validation (isNumber, isFinite, integrality, lower bound via page_size_min, upper bound via maxInt(u56) with >=) before @intFromFloat, return type changed to bun.JSError!JSValue (compatible with wrapStaticMethod binding). Regression test spawns subprocess and covers 13 invalid-argument cases across all validation branches — confirmed it would crash/panic on main. No TODO/FIXME/HACK in added lines. Claude bot LGTM, CodeRabbit handle-table concern is pre-existing and out of scope.