### PR TITLE
Fix segfault in FFI CString with low pointer addresses

### DIFF
--- a/src/bun.js/api/FFIObject.zig
+++ b/src/bun.js/api/FFIObject.zig
@@ -435,6 +435,10 @@ pub fn getPtrSlice(globalThis: *JSGlobalObject, value: JSValue, byteOffset: ?JSV
         return .{ .err = globalThis.toInvalidArguments("ptr cannot be zero, that would segfault Bun :(", .{}) };
     }
 
+    if (num < std.heap.page_size_min) {
+        return .{ .err = globalThis.toInvalidArguments("ptr to invalid memory, that would segfault Bun :(", .{}) };
+    }
+
     // if (!std.math.isFinite(num)) {
     //     return .{ .err = globalThis.toInvalidArguments("ptr must be a finite number.", .{}) };
     // }
@@ -464,7 +468,7 @@ pub fn getPtrSlice(globalThis: *JSGlobalObject, value: JSValue, byteOffset: ?JSV
         }
     }
 
-    if (addr == 0xDEADBEEF or addr == 0xaaaaaaaa or addr == 0xAAAAAAAA) {
+    if (addr < std.heap.page_size_min or addr == 0xDEADBEEF or addr == 0xaaaaaaaa or addr == 0xAAAAAAAA) {
         return .{ .err = globalThis.toInvalidArguments("ptr to invalid memory, that would segfault Bun :(", .{}) };
     }
 

--- a/test/js/bun/ffi/ffi-error-messages.test.ts
+++ b/test/js/bun/ffi/ffi-error-messages.test.ts
@@ -1,4 +1,4 @@
-import { dlopen, linkSymbols } from "bun:ffi";
+import { CString, dlopen, linkSymbols } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
 import { isArm64, isMusl, isWindows } from "harness";
 
@@ -74,6 +74,14 @@ describe.skipIf(isFFIUnavailable)("FFI error messages", () => {
     expect(() => {
       linkSymbols({ a: "hello", b: 123, c: true });
     }).toThrow("Expected an object");
+  });
+
+  test("CString with invalid low address does not crash", () => {
+    // Addresses below the page size are in unmapped memory and must not segfault
+    expect(String(new CString(512))).toContain("invalid memory");
+    expect(String(new CString(1))).toContain("invalid memory");
+    // Low base address with byteOffset that crosses page boundary must also be rejected
+    expect(String(new CString(512, 3585))).toContain("invalid memory");
   });
 
   test("linkSymbols with non-number ptr does not crash", () => {

--- a/test/js/bun/s3/s3-fd-validation.test.ts
+++ b/test/js/bun/s3/s3-fd-validation.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("S3Client.write does not crash with out-of-range float as path", () => {
   expect(() => Bun.S3Client.write(-1.5379890021597998e308, "data")).toThrow();


### PR DESCRIPTION
`Bun.FFI.CString(512)` would dereference address 0x200, which is in the unmapped null guard page, causing a segfault.

The existing validation in `getPtrSlice` checked for `0`, `0xDEADBEEF`, and `0xAAAAAAAA` but not for other addresses below the page size boundary. Any address below `page_size_min` (typically 4096) is never a valid userspace pointer.

**Fix:** Add `addr < std.heap.page_size_min` check in `getPtrSlice` to reject all addresses in the null guard page.

**Repro:**
```js
const { CString } = require("bun:ffi");
new CString(512); // segfault before fix, error after
```

Crash: https://bun.report/1.3.11/lt1af24e28gGgkggC48hp5E+++Pkvl+5D_izrhkE4othkEms15jEs9owsFqlkzrEqqsytD4i0ytDu31ytD2xtppDixt7pDm5jpkD44+0rEsjt67Cw7mr8C6l/+1Cov1+1CA2AggB

---
Verification: CI build #40596 pending (Lint JS passed). Previous build #40569 failures all unrelated (libuv/tinycc clang warnings, bundler_compile timeouts, bake test). Diff adds two guards in getPtrSlice: a pre-offset num < page_size_min check (catches low base pointers before byteOffset arithmetic) and a post-offset addr < page_size_min check (catches addresses reduced into guard page by negative offsets). Regression test asserts CString(512), CString(1), and CString(512, 3585) all produce "invalid memory" errors instead of segfaulting — all three would crash on main. CString imported at module scope per project convention. No TODO/FIXME/HACK. Bot review concerns (CodeRabbit import nit, Claude byteOffset bypass) both addressed in current diff.