### PR TITLE
Handle exceptions from toStringOrNull in Bun.plugin target parsing

### DIFF
--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -301,11 +301,13 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     if (targetValue) {
         if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
             String targetString = targetJSString->value(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, {});
             if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
                 JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
                 return {};
             }
         }
+        RETURN_IF_EXCEPTION(throwScope, {});
     }
 
     JSObject* builderObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 4);

--- a/test/js/bun/plugin/plugin-toprimitive-crash.test.ts
+++ b/test/js/bun/plugin/plugin-toprimitive-crash.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test";
+
+test("Bun.plugin does not crash when target has Symbol.toPrimitive returning an object", () => {
+  const obj = { setup() {} };
+  Object.defineProperty(obj, "target", {
+    get() {
+      return {
+        [Symbol.toPrimitive]() {
+          return {};
+        },
+      };
+    },
+  });
+  expect(() => Bun.plugin(obj)).toThrow("toPrimitive");
+});


### PR DESCRIPTION
When `Bun.plugin()` receives an object whose `target` property has a `Symbol.toPrimitive` that returns a non-primitive value, `toStringOrNull` throws a JS exception and returns `nullptr`. The code correctly skipped the inner `if` block, but then continued execution with the pending exception still active, eventually hitting `assertNoException()` in `constructEmptyObject`.

This adds `RETURN_IF_EXCEPTION` checks after both `toStringOrNull()` (which can throw when `Symbol.toPrimitive` returns a non-primitive) and `value()` (which can also throw) to properly propagate the exception back to JavaScript.

**Repro:**
```js
const obj = { setup() {} };
Object.defineProperty(obj, "target", {
  get() { return { [Symbol.toPrimitive]() { return {}; } }; }
});
Bun.plugin(obj); // was: assertion failure / crash; now: throws TypeError
```

---
robobun verification (iter 40): Diff is exactly two `RETURN_IF_EXCEPTION(throwScope, {})` guards in BunPlugin.cpp (lines 304 and 310) matching the established pattern at lines 290/293/300 of the same function. On main, execution falls through to `constructEmptyObject` with a pending exception, hitting `assertNoException()`. Regression test (15 lines, in-process) exercises the exact crash path via `Symbol.toPrimitive` returning non-primitive `{}`; asserts `.toThrow("toPrimitive")` — would crash/SIGABRT on main, not pass. Lint JS passed on both a960e7d and cbbbd50. No TODO/FIXME/HACK. No CHANGES_REQUESTED reviews. No unrelated changes in final diff. Buildkite #41233 pending at time of approval.