### PR TITLE
Fix unsharedBuffer() assertion failure on SharedArrayBuffer-backed typed arrays

### DIFF
--- a/src/bun.js/bindings/BunIDLConvert.h
+++ b/src/bun.js/bindings/BunIDLConvert.h
@@ -189,10 +189,9 @@ template<> struct WebCore::Converter<Bun::IDLArrayBufferRef>
             return jsBuffer;
         }
         if (auto* jsView = JSC::jsDynamicCast<JSC::JSArrayBufferView*>(value)) {
+            if (jsView->isShared())
+                return std::nullopt;
             return jsView->unsharedBuffer();
-        }
-        if (auto* jsDataView = JSC::jsDynamicCast<JSC::JSDataView*>(value)) {
-            return jsDataView->unsharedBuffer();
         }
         return std::nullopt;
     }

--- a/src/bun.js/bindings/webcore/StructuredClone.cpp
+++ b/src/bun.js/bindings/webcore/StructuredClone.cpp
@@ -90,12 +90,12 @@ JSC_DEFINE_HOST_FUNCTION(structuredCloneForStream, (JSGlobalObject * globalObjec
         auto* bufferView = jsCast<JSArrayBufferView*>(value);
         ASSERT(bufferView);
 
-        auto* buffer = bufferView->unsharedBuffer();
+        auto* buffer = bufferView->possiblySharedBuffer();
         if (!buffer) {
             throwDataCloneError(*globalObject, scope);
             return {};
         }
-        auto bufferClone = buffer->slice(0);
+        auto bufferClone = bufferView->isShared() ? Ref { *buffer } : buffer->slice(0);
         Structure* structure = bufferView->structure();
 
 #define CLONE_TYPED_ARRAY(name)                                                                                                                                                   \

--- a/src/bun.js/bindings/webcore/WebSocket.cpp
+++ b/src/bun.js/bindings/webcore/WebSocket.cpp
@@ -755,8 +755,10 @@ ExceptionOr<void> WebSocket::send(ArrayBufferView& arrayBufferView)
         return {};
     }
 
-    auto bufferRef = arrayBufferView.unsharedBuffer();
+    auto bufferRef = arrayBufferView.possiblySharedBuffer();
     auto* buffer = bufferRef.get();
+    if (!buffer)
+        return Exception { TypeError, "ArrayBufferView is detached"_s };
     char* baseAddress = reinterpret_cast<char*>(buffer->data()) + arrayBufferView.byteOffset();
     size_t length = arrayBufferView.byteLength();
     this->sendWebSocketData(baseAddress, length, Opcode::Binary);
@@ -1028,8 +1030,10 @@ ExceptionOr<void> WebSocket::ping(ArrayBufferView& arrayBufferView)
         return {};
     }
 
-    auto bufferRef = arrayBufferView.unsharedBuffer();
+    auto bufferRef = arrayBufferView.possiblySharedBuffer();
     auto* buffer = bufferRef.get();
+    if (!buffer)
+        return Exception { TypeError, "ArrayBufferView is detached"_s };
     char* baseAddress = reinterpret_cast<char*>(buffer->data()) + arrayBufferView.byteOffset();
     size_t length = arrayBufferView.byteLength();
     this->sendWebSocketData(baseAddress, length, Opcode::Ping);
@@ -1107,8 +1111,10 @@ ExceptionOr<void> WebSocket::pong(ArrayBufferView& arrayBufferView)
         return {};
     }
 
-    auto bufferRef = arrayBufferView.unsharedBuffer();
+    auto bufferRef = arrayBufferView.possiblySharedBuffer();
     auto* buffer = bufferRef.get();
+    if (!buffer)
+        return Exception { TypeError, "ArrayBufferView is detached"_s };
     char* baseAddress = reinterpret_cast<char*>(buffer->data()) + arrayBufferView.byteOffset();
     size_t length = arrayBufferView.byteLength();
     this->sendWebSocketData(baseAddress, length, Opcode::Pong);

--- a/test/js/web/structured-clone-shared-arraybuffer.test.ts
+++ b/test/js/web/structured-clone-shared-arraybuffer.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+
+test("Response.clone() with SharedArrayBuffer-backed stream does not crash", async () => {
+  const sab = new SharedArrayBuffer(16);
+  const view = new Uint8Array(sab);
+  view[0] = 0xab;
+
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(view);
+      controller.close();
+    },
+  });
+
+  const resp = new Response(stream);
+  const cloned = resp.clone();
+
+  const [orig, clone] = await Promise.all([resp.arrayBuffer(), cloned.arrayBuffer()]);
+
+  expect(orig.byteLength).toBe(16);
+  expect(clone.byteLength).toBe(16);
+  expect(new Uint8Array(orig)[0]).toBe(0xab);
+  expect(new Uint8Array(clone)[0]).toBe(0xab);
+});


### PR DESCRIPTION
Multiple call sites in Bun's C++ bindings call `JSArrayBufferView::unsharedBuffer()` without first checking whether the view is backed by a `SharedArrayBuffer`. When it is, WebKit's `RELEASE_ASSERT(!result || !result->isShared())` fires and crashes the process.

**Crash fingerprint:** `JSArrayBufferView.cpp(224)`

**Root cause:** Creating a typed array from a `SharedArrayBuffer` (e.g. `new Int16Array(new SharedArrayBuffer(...))`) and then passing that view through any code path that calls `unsharedBuffer()` triggers the assertion.

**Fix:**
- `StructuredClone.cpp`: Use `possiblySharedBuffer()` instead of `unsharedBuffer()`, and for shared views keep a `Ref` to the existing buffer instead of slicing (preserving shared-memory semantics per spec)
- `BunIDLConvert.h`: Return `std::nullopt` for shared views in the `IDLArrayBufferRef` converter instead of crashing. Also removes dead-code JSDataView branch (JSDataView inherits from JSArrayBufferView, so it was already caught)
- `WebSocket.cpp`: Use `possiblySharedBuffer()` instead of `unsharedBuffer()` for send/ping/pong operations since the data is only read, not mutated. Adds null guard for detached buffer case.

---

Verification (robobun): Lint JS passes, Buildkite build #40659 pipeline passed (full build in progress). Diff is clean — no TODO/FIXME/HACK/XXX in added lines. Reviewed all four changed files against the branch HEAD: StructuredClone.cpp correctly uses possiblySharedBuffer() and conditionally keeps a Ref for shared buffers via `bufferView->isShared() ? Ref{*buffer} : buffer->slice(0)` (spec-correct SAB clone semantics). WebSocket.cpp send/ping/pong all have null guards after possiblySharedBuffer(). BunIDLConvert.h removes the redundant JSDataView branch (dead code since JSDataView IS-A JSArrayBufferView). Test 1 (ReadableStream.tee with SAB-backed Int16Array) directly exercises structuredCloneForStream — the primary crash path — and asserts cloned chunk data integrity. Test 2 (server WebSocket send with SAB-backed Uint8Array) validates SAB-backed views work through the server WebSocket path. Note: client-side WebSocket.send with SAB is not tested but the fix is mechanically identical across all three methods and straightforward (read-only buffer access + null guard). Bot review findings (CodeRabbit and claude[bot]) were addressed across subsequent commits; remaining items are pre-existing edge cases (auto-length views on growable SABs) not introduced by this PR.

---

Verification (robobun, iteration 3): Lint JS green on 14ac02cb. Buildkite build #40693 in progress; prior build #40659 failures were all bundler_compile.test.ts (unrelated). Diff clean — no TODO/FIXME/HACK/XXX. Test 1 (ReadableStream.tee with SAB-backed Int16Array) directly exercises structuredCloneForStream, the primary crash path from StructuredClone.cpp, and asserts cloned chunk value integrity — would crash on main at unsharedBuffer() RELEASE_ASSERT. Test 2 (server WebSocket send) validates SAB-backed views work through the server WebSocket path. WebSocket.cpp client-side changes are mechanically identical across send/ping/pong (possiblySharedBuffer + null guard) and straightforward. BunIDLConvert.h correctly rejects shared views and removes dead JSDataView branch. All CodeRabbit and claude[bot] review items were addressed across commits; remaining comments concern pre-existing edge cases (auto-length views on growable SABs) not introduced by this PR.

---

Verification (robobun, iteration 6): CI — Lint JS green, Buildkite #40758 pipeline pass, full build/test in progress. Prior build #40699 failures were webview.test.ts timeouts and bundler_compile.test.ts timeouts — completely unrelated to SharedArrayBuffer changes. Diff clean — no TODO/FIXME/HACK/XXX. Confirmed JSDataView extends JSArrayBufferView (vendor/WebKit JSDataView.h line 32), validating removal of the dead JSDataView branch. Confirmed unsharedBuffer() has RELEASE_ASSERT(!result->isShared()) which is the root crash. BunIDLConvert.h: correctly guards isShared() before calling unsharedBuffer(). StructuredClone.cpp: uses possiblySharedBuffer() + conditional Ref vs slice for shared buffers — spec-correct SAB semantics. WebSocket.cpp: possiblySharedBuffer() + null guards on all 3 methods (send/ping/pong). Tests: Test 1 (ReadableStream.tee with SAB-backed Int16Array) directly exercises structuredCloneForStream and asserts data integrity (chunk[0] === 42). Test 2 (WebSocket server send with SAB-backed Uint8Array) validates no crash and correct data round-trip (byte 0xAB). Both tests would crash on main via RELEASE_ASSERT. CodeRabbit findings about TypeError for detached buffers and auto-length growable SABs are pre-existing/edge-case issues, not regressions from this PR.

---

Verification (robobun, iteration 13): Lint JS green. Buildkite #40921 in progress (all prior builds were canceled, not failed). Diff clean — no TODO/FIXME/HACK/XXX in added lines. Verified unsharedBuffer() at JSArrayBufferView.cpp:224 has RELEASE_ASSERT(!result->isShared()) confirming the crash. Fix correctly uses possiblySharedBuffer() in StructuredClone.cpp (line 93), WebSocket.cpp send/ping/pong (lines 757, 1032, 1113), and guards isShared() in BunIDLConvert.h (line 192). Dead JSDataView branch removal validated (JSDataView : public JSArrayBufferView at JSDataView.h:33). Test exercises the exact crash path: Response.clone() -> ReadableStream.tee() -> structuredCloneForStream (ReadableStreamInternals.ts:598) with a SAB-backed Uint8Array, asserts data integrity on both original and clone. No unresolved blocking review threads.