### PR TITLE
Fix crash in FFI.closeCallback when called with non-numeric argument

### DIFF
--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -830,9 +830,18 @@ pub const FFI = struct {
         return js_object;
     }
 
+    fn parseJsNumberAsPtr(value: JSValue) ?usize {
+        if (!value.isNumber()) return null;
+        const n = value.asNumber();
+        if (!std.math.isFinite(n) or n <= 0 or n >= @as(f64, @floatFromInt(std.math.maxInt(usize))) or @trunc(n) != n) return null;
+        return @intFromFloat(n);
+    }
+
     pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) JSValue {
-        var function: *Function = @ptrFromInt(ctx.asPtrAddress());
+        const addr = parseJsNumberAsPtr(ctx) orelse return .js_undefined;
+        const function: *Function = @ptrFromInt(addr);
         function.deinit(globalThis);
+        bun.default_allocator.destroy(function);
         return .js_undefined;
     }
 
@@ -1390,10 +1399,8 @@ pub const FFI = struct {
         };
 
         if (try value.get(global, "ptr")) |ptr| {
-            if (ptr.isNumber()) {
-                const num = ptr.asPtrAddress();
-                if (num > 0)
-                    function.symbol_from_dynamic_library = @as(*anyopaque, @ptrFromInt(num));
+            if (parseJsNumberAsPtr(ptr)) |num| {
+                function.symbol_from_dynamic_library = @as(*anyopaque, @ptrFromInt(num));
             } else if (ptr.isHeapBigInt()) {
                 const num = ptr.toUInt64NoTruncate();
                 if (num > 0) {

--- a/test/js/bun/ffi/ffi-error-messages.test.ts
+++ b/test/js/bun/ffi/ffi-error-messages.test.ts
@@ -1,6 +1,6 @@
 import { dlopen, linkSymbols } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
-import { isArm64, isMusl, isWindows } from "harness";
+import { bunEnv, bunExe, isArm64, isMusl, isWindows } from "harness";
 
 // TinyCC (and all of bun:ffi) is disabled on Windows ARM64
 const isFFIUnavailable = isWindows && isArm64;
@@ -85,5 +85,54 @@ describe.skipIf(isFFIUnavailable)("FFI error messages", () => {
         },
       });
     }).toThrow('you must provide a "ptr" field with the memory address of the native function.');
+  });
+
+  test("closeCallback with invalid argument does not crash", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const cb = Bun.FFI.closeCallback;
+        cb("not a pointer");
+        cb(undefined);
+        cb(null);
+        cb({});
+        cb(true);
+        cb(0);
+        cb(NaN);
+        cb(Infinity);
+        cb(-Infinity);
+        cb(-1);
+        cb(1.5);
+        cb(1e20);
+        cb(2**64);
+        cb(Number.MAX_VALUE);
+      `,
+      ],
+      env: bunEnv,
+    });
+    expect(await proc.exited).toBe(0);
+  });
+
+  test("linkSymbols with numeric ptr edge cases does not crash", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const tryLink = (ptr) => { try { Bun.FFI.linkSymbols({ fn: { args: [], returns: "void", ptr } }); } catch {} };
+        tryLink(NaN);
+        tryLink(Infinity);
+        tryLink(-Infinity);
+        tryLink(-1);
+        tryLink(1.5);
+        tryLink(1e20);
+        tryLink(2**64);
+      `,
+      ],
+      env: bunEnv,
+    });
+    expect(await proc.exited).toBe(0);
   });
 });


### PR DESCRIPTION
`FFI.closeCallback` crashes when called with a non-numeric argument (e.g. a string, object, or undefined). The function calls `ctx.asPtrAddress()` which calls `ctx.asNumber()`, and that asserts the value is a number, undefined, null, or boolean. When the value is something like a string or object, the assertion fails with `panic: reached unreachable code`.

This can happen when user code or a fuzzer discovers `closeCallback` on the `Bun.FFI` object and calls it with arbitrary arguments.

**Fix:** Validate that `ctx` is a number and non-zero before interpreting it as a pointer address. Non-numeric or zero values return `undefined` silently.

---

**Verification (robobun, iteration 12):** Final commit fa36aa59. Lint JS passed; Buildkite #40974 running (prior build #40826 had only bundler_compile.test.ts timeouts — unrelated to FFI). Diff adds `parseJsNumberAsPtr` helper with five correct guards (isNumber, isFinite, n<=0, n>=2^64 IEEE754 boundary, @trunc!=n) used by both `closeCallback` and `generateSymbolForFunction`. Also fixes pre-existing memory leak via `bun.default_allocator.destroy(function)`. Two subprocess regression tests cover 14+7 edge cases that crash on main via `asPtrAddress` assertion panic — verified by reading the old code path. No TODO/FIXME/HACK. CodeRabbit and Claude reviews both LGTM; all actionable items addressed across iterations.