### PR TITLE
Fix crash in FFI.closeCallback with invalid argument

### DIFF
--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -830,8 +830,19 @@ pub const FFI = struct {
         return js_object;
     }
 
-    pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) JSValue {
-        var function: *Function = @ptrFromInt(ctx.asPtrAddress());
+    pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) bun.JSError!JSValue {
+        if (!ctx.isNumber()) return globalThis.throwInvalidArguments("Expected a callback context", .{});
+        const num = ctx.asNumber();
+        if (!std.math.isFinite(num) or num < 1 or num != @trunc(num)) {
+            return globalThis.throwInvalidArguments("Expected a callback context", .{});
+        }
+        const max_addr = comptime @as(f64, @floatFromInt(@as(u128, std.math.maxInt(usize)) + 1));
+        if (num >= max_addr) {
+            return globalThis.throwInvalidArguments("Expected a callback context", .{});
+        }
+        const addr: usize = @intFromFloat(num);
+        if (addr == 0 or addr % @alignOf(Function) != 0) return globalThis.throwInvalidArguments("Expected a callback context", .{});
+        var function: *Function = @ptrFromInt(addr);
         function.deinit(globalThis);
         return .js_undefined;
     }

--- a/test/js/bun/ffi/ffi-closeCallback-invalid.test.ts
+++ b/test/js/bun/ffi/ffi-closeCallback-invalid.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "bun:test";
+
+test("FFI.closeCallback does not crash with invalid argument", () => {
+  const ffi = Bun.FFI;
+  expect(() => ffi.closeCallback("not a pointer")).toThrow("Expected a callback context");
+  expect(() => ffi.closeCallback(undefined)).toThrow("Expected a callback context");
+  expect(() => ffi.closeCallback({})).toThrow("Expected a callback context");
+  expect(() => ffi.closeCallback(0)).toThrow("Expected a callback context");
+  expect(() => ffi.closeCallback(NaN)).toThrow("Expected a callback context");
+  expect(() => ffi.closeCallback(Infinity)).toThrow("Expected a callback context");
+  expect(() => ffi.closeCallback(1.5)).toThrow("Expected a callback context");
+  expect(() => ffi.closeCallback(16.5)).toThrow("Expected a callback context");
+  expect(() => ffi.closeCallback(Number.MAX_VALUE)).toThrow("Expected a callback context");
+  expect(() => ffi.closeCallback(2 ** 64)).toThrow("Expected a callback context");
+  expect(() => ffi.closeCallback(-1.0)).toThrow("Expected a callback context");
+});


### PR DESCRIPTION
`FFI.closeCallback` is an internal function that expects its argument to be a number-encoded pointer (created by `nativeCallback()`). However, it's accessible via `Bun.FFI.closeCallback` and can be called with arbitrary arguments from JavaScript.

When called with a non-number value (e.g. a string or object), it calls `asPtrAddress()` → `asNumber()` which hits an assertion failure / unreachable because the value isn't a number.

**Fix**: Validate that `ctx` is a number before interpreting it as a pointer address. If not, throw a proper JS error.

**Crash trace**:
```
panic(main thread): reached unreachable code
bun.js.bindings.JSValue.JSValue.asNumber
bun.js.bindings.JSValue.JSValue.asPtrAddress
bun.js.api.ffi.FFI.closeCallback
```

---
**Verification (robobun)**: CI Lint JavaScript passed; Format check pending (non-blocking). Prior Buildkite build #40675 failed only on unrelated `bundler_compile.test.ts` timeouts (not FFI-related). Diff adds multi-stage validation (isNumber, isFinite, >=1, integer check via `num != @trunc(num)`, usize upper-bound via u128+1 with `>=`, zero check, alignment check) to `closeCallback` and changes return type to `bun.JSError!JSValue`. Upper-bound uses `@as(u128, maxInt(usize)) + 1` cast to f64 with `>=` — correctly rejects 2^64 boundary. Regression test exercises 11 invalid inputs — all would crash on main. Six bot review comments: all critical ones addressed in final commit; pre-existing memory leak in `deinit` is out of scope. No TODO/FIXME/HACK. No unrelated changes.