### PR TITLE
Fix assertion failure in dns.setServers with short inner arrays

### DIFF
--- a/src/bun.js/api/bun/dns.zig
+++ b/src/bun.js/api/bun/dns.zig
@@ -3290,8 +3290,12 @@ pub const Resolver = struct {
                 return globalThis.throwInvalidArgumentType("setServers", "triple", "array");
             }
 
-            const family = (try triple.getIndex(globalThis, 0)).toInt32();
-            const port = (try triple.getIndex(globalThis, 2)).toInt32();
+            if (try triple.getLength(globalThis) < 3) {
+                return globalThis.throwInvalidArguments("Invalid server entry: expected [addressFamily, address, port]", .{});
+            }
+
+            const family = try (try triple.getIndex(globalThis, 0)).coerceToInt32(globalThis);
+            const port = try (try triple.getIndex(globalThis, 2)).coerceToInt32(globalThis);
 
             if (family != 4 and family != 6) {
                 return globalThis.throwInvalidArguments("Invalid address family", .{});

--- a/test/js/bun/dns/dns-setServers.test.ts
+++ b/test/js/bun/dns/dns-setServers.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test";
+
+test("dns.setServers with empty inner array does not crash", () => {
+  expect(() => Bun.dns.setServers([[]])).toThrow();
+});
+
+test("dns.setServers with short inner array does not crash", () => {
+  expect(() => Bun.dns.setServers([[4]])).toThrow();
+  expect(() => Bun.dns.setServers([[4, "1.1.1.1"]])).toThrow();
+});


### PR DESCRIPTION
When `Bun.dns.setServers` receives an inner array with fewer than 3 elements (e.g. `[[]]`), `getIndex` returns `undefined` for the missing indices. Calling `.toInt32()` on `undefined` triggers an assertion failure (`isInt32()`) in `JSCJSValue.h(994)`.

This adds a length check on each inner triple array before accessing its elements, throwing an `Invalid server entry: expected [addressFamily, address, port]` error for malformed entries. Also replaces `toInt32()` with `coerceToInt32()` so non-integer family/port values throw a JS error instead of asserting.

**Crash:** `ASSERTION FAILED: isInt32() — JSCJSValue.h(994)`  
**Repro:** `Bun.dns.setServers([[]])`

---

**Verification (robobun, iteration 5):** Buildkite #40770 in progress (0 failures, 1/275 jobs complete, Lint JS passed). Diff is minimal: 4-line length guard in dns.zig (line 3293, `triple.getLength < 3`) plus `toInt32()` → `coerceToInt32(globalThis)` with `try` propagation. Test file has 3 assertions covering lengths 0, 1, 2 — all would process-crash on main (assertion failure, not a catchable throw), so they are valid regression tests that fail with `USE_SYSTEM_BUN=1`. Valid-triple test removed in f8c1a75 since it passes on main. No TODO/FIXME/HACK in diff. CodeRabbit had no actionable comments. Claude bot issues (error message clarity, coerceToInt32 safety) all addressed.