### PR TITLE
add isolatedModules

### DIFF
--- a/src/cli/init/tsconfig.default.json
+++ b/src/cli/init/tsconfig.default.json
@@ -13,6 +13,7 @@
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
+    "isolatedModules": true,
 
     // Best practices
     "strict": true,


### PR DESCRIPTION
### What does this PR do?

when you do `export { Type } from "./types"` in bun, you'll get an error `"Type" is not exported by "./types"`, so adding `isolatedModules` gives you a clue before running your code.

### How did you verify your code works?
