### PR TITLE
fix(console): prepend 'Assertion failed:' to console.assert() with message 🤖🤖🤖

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -227,6 +227,14 @@ fn messageWithTypeAndLevel_(
         }
     }
 
+    if (message_type == .Assert and print_length > 0) {
+        const prefix = if (enable_colors)
+            Output.prettyFmt("<r><red>Assertion failed<r>: ", true)
+        else
+            "Assertion failed: ";
+        writer.writeAll(prefix) catch {};
+    }
+
     if (print_length > 0)
         try format2(
             level,


### PR DESCRIPTION
## Summary

Fixes #19953.

`console.assert(false, "message")` now correctly outputs `Assertion failed: message` instead of just `message`, matching Node.js behavior.

## Changes

- **src/bun.js/ConsoleObject.zig**: When `message_type == .Assert` and there are arguments, write the `Assertion failed: ` prefix before formatting the arguments. The no-args case (`console.assert(false)`) already correctly printed `Assertion failed`.

## Test

Before:
`console.assert(false, "message")` => `message`

After:
`console.assert(false, "message")` => `Assertion failed: message`

This matches Node.js behavior per the [WHATWG Console spec](https://console.spec.whatwg.org/#assert).
