### PR TITLE
implement X25519 deriveBits

### DIFF
--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmX25519.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmX25519.cpp
@@ -111,7 +111,7 @@ void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& paramete
             callback(WTF::move(*derivedKey));
             return;
         }
-        auto lengthInBytes = std::ceil(length / 8.);
+        auto lengthInBytes = static_cast<size_t>(std::ceil(length / 8.));
         if (lengthInBytes > (*derivedKey).size()) {
             exceptionCallback(ExceptionCode::OperationError, ""_s);
             return;

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmX25519.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmX25519.cpp
@@ -26,6 +26,7 @@
 #include "CryptoKeyOKP.h"
 #include "ScriptExecutionContext.h"
 #include "CryptoDigest.h"
+#include <openssl/curve25519.h>
 #include <wtf/CryptographicUtilities.h>
 
 namespace WebCore {
@@ -60,13 +61,16 @@ void CryptoAlgorithmX25519::generateKey(const CryptoAlgorithmParameters&, bool e
 }
 
 #if !PLATFORM(COCOA) && !USE(GCRYPT)
-std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP&, const CryptoKeyOKP&)
+std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP& baseKey, const CryptoKeyOKP& publicKey)
 {
-    return std::nullopt;
+    Vector<uint8_t> result(X25519_SHARED_KEY_LEN);
+    if (!X25519(result.begin(), baseKey.platformKey().begin(), publicKey.platformKey().begin()))
+        return std::nullopt;
+    return result;
 }
 #endif
 
-void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, size_t length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
     if (baseKey->type() != CryptoKey::Type::Private) {
         exceptionCallback(ExceptionCode::InvalidAccessError, ""_s);
@@ -89,21 +93,9 @@ void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& paramete
         return;
     }
 
-    // Return an empty string doesn't make much sense, but truncating either at all.
-    // https://github.com/WICG/webcrypto-secure-curves/pull/29
-    if (length && !(*length)) {
-        // Avoid executing the key-derivation, since we are going to return an empty string.
-        callback({});
-        return;
-    }
-
-    auto unifiedCallback = [callback = WTF::move(callback), exceptionCallback = WTF::move(exceptionCallback)](std::optional<Vector<uint8_t>>&& derivedKey, std::optional<size_t> length) mutable {
+    auto unifiedCallback = [length, callback = WTF::move(callback), exceptionCallback = WTF::move(exceptionCallback)](std::optional<Vector<uint8_t>>&& derivedKey) mutable {
         if (!derivedKey) {
             exceptionCallback(ExceptionCode::OperationError, ""_s);
-            return;
-        }
-        if (!length) {
-            callback(WTF::move(*derivedKey));
             return;
         }
 #if !HAVE(X25519_ZERO_CHECKS)
@@ -115,7 +107,11 @@ void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& paramete
             return;
         }
 #endif
-        auto lengthInBytes = std::ceil(*length / 8.);
+        if (!length) {
+            callback(WTF::move(*derivedKey));
+            return;
+        }
+        auto lengthInBytes = std::ceil(length / 8.);
         if (lengthInBytes > (*derivedKey).size()) {
             exceptionCallback(ExceptionCode::OperationError, ""_s);
             return;
@@ -127,10 +123,10 @@ void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& paramete
     // the result validation and callback dispatch into unifiedCallback.
     workQueue.dispatch(
         context.globalObject(),
-        [baseKey = WTF::move(baseKey), publicKey = ecParameters.publicKey, length, unifiedCallback = WTF::move(unifiedCallback), contextIdentifier = context.identifier()]() mutable {
+        [baseKey = WTF::move(baseKey), publicKey = ecParameters.publicKey, unifiedCallback = WTF::move(unifiedCallback), contextIdentifier = context.identifier()]() mutable {
             auto derivedKey = platformDeriveBits(downcast<CryptoKeyOKP>(baseKey.get()), downcast<CryptoKeyOKP>(*publicKey));
-            ScriptExecutionContext::postTaskTo(contextIdentifier, [derivedKey = WTF::move(derivedKey), length, unifiedCallback = WTF::move(unifiedCallback)](auto&) mutable {
-                unifiedCallback(WTF::move(derivedKey), length);
+            ScriptExecutionContext::postTaskTo(contextIdentifier, [derivedKey = WTF::move(derivedKey), unifiedCallback = WTF::move(unifiedCallback)](auto&) mutable {
+                unifiedCallback(WTF::move(derivedKey));
             });
         });
 }

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmX25519.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmX25519.h
@@ -38,7 +38,7 @@ private:
     CryptoAlgorithmIdentifier identifier() const final;
 
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&);
-    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&);
+    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
 

--- a/test/js/bun/crypto/x25519-derive-bits.test.ts
+++ b/test/js/bun/crypto/x25519-derive-bits.test.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "bun:test";
+
+// Test vectors from RFC 7748 / Node.js test suite
+const x25519Vector = {
+  pkcs8: "302e020100300506032b656e04220420c8838e76d057dfb7d8c95a69e138160add6373fd71a4d276bb56e3a81b64ff61",
+  spki: "302a300506032b656e0321001cf2b1e6022ec537371ed7f53e54fa1154d83e98eb64ea51fae5b3307cfe9706",
+  result: "2768409dfab99ec23b8c89b93ff5880295f76176088f89e43dfebe7ea1950008",
+};
+
+async function importX25519Keys(usages: KeyUsage[] = ["deriveBits"]) {
+  const [privateKey, publicKey] = await Promise.all([
+    crypto.subtle.importKey("pkcs8", Buffer.from(x25519Vector.pkcs8, "hex"), { name: "X25519" }, true, usages),
+    crypto.subtle.importKey("spki", Buffer.from(x25519Vector.spki, "hex"), { name: "X25519" }, true, []),
+  ]);
+  return { privateKey, publicKey };
+}
+
+test("X25519 deriveBits with known test vector", async () => {
+  const { privateKey, publicKey } = await importX25519Keys();
+
+  const bits = await crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, privateKey, 256);
+
+  expect(bits).toBeInstanceOf(ArrayBuffer);
+  expect(Buffer.from(bits).toString("hex")).toBe(x25519Vector.result);
+});
+
+test("X25519 deriveBits with null length returns full output", async () => {
+  const { privateKey, publicKey } = await importX25519Keys();
+
+  // @ts-expect-error types not updated to reflect WebCryptoAPI spec change
+  const bits = await crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, privateKey, null);
+
+  expect(bits).toBeInstanceOf(ArrayBuffer);
+  expect(bits.byteLength).toBe(32);
+  expect(Buffer.from(bits).toString("hex")).toBe(x25519Vector.result);
+});
+
+test("X25519 deriveBits with zero length returns full output", async () => {
+  const { privateKey, publicKey } = await importX25519Keys();
+
+  const bits = await crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, privateKey, 0);
+
+  expect(bits).toBeInstanceOf(ArrayBuffer);
+  expect(bits.byteLength).toBe(32);
+  expect(Buffer.from(bits).toString("hex")).toBe(x25519Vector.result);
+});
+
+test("X25519 deriveBits with shorter length", async () => {
+  const { privateKey, publicKey } = await importX25519Keys();
+
+  const bits = await crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, privateKey, 128);
+
+  expect(bits).toBeInstanceOf(ArrayBuffer);
+  expect(bits.byteLength).toBe(16);
+  expect(Buffer.from(bits).toString("hex")).toBe(x25519Vector.result.slice(0, 32));
+});
+
+test("X25519 deriveBits with generated keys", async () => {
+  const aliceKeys = await crypto.subtle.generateKey({ name: "X25519" }, true, ["deriveBits"]);
+  const bobKeys = await crypto.subtle.generateKey({ name: "X25519" }, true, ["deriveBits"]);
+
+  const [aliceShared, bobShared] = await Promise.all([
+    crypto.subtle.deriveBits({ name: "X25519", public: bobKeys.publicKey }, aliceKeys.privateKey, 256),
+    crypto.subtle.deriveBits({ name: "X25519", public: aliceKeys.publicKey }, bobKeys.privateKey, 256),
+  ]);
+
+  expect(Buffer.from(aliceShared).toString("hex")).toBe(Buffer.from(bobShared).toString("hex"));
+});
+
+test("X25519 deriveBits case insensitive algorithm name", async () => {
+  const { privateKey, publicKey } = await importX25519Keys();
+
+  const bits = await crypto.subtle.deriveBits({ name: "x25519", public: publicKey }, privateKey, 256);
+
+  expect(Buffer.from(bits).toString("hex")).toBe(x25519Vector.result);
+});
+
+test("X25519 deriveBits rejects when length exceeds output size", async () => {
+  const { privateKey, publicKey } = await importX25519Keys();
+
+  await expect(crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, privateKey, 512)).rejects.toThrow();
+});
+
+test("X25519 deriveBits rejects with wrong base key type", async () => {
+  const { publicKey } = await importX25519Keys();
+
+  await expect(crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, publicKey, 256)).rejects.toThrow();
+});
+
+test("X25519 deriveBits rejects with all-zero public key (RFC 7748 Section 6.1)", async () => {
+  const { privateKey } = await importX25519Keys();
+
+  // Import an all-zero public key (small-order point)
+  const zeroPublicKey = await crypto.subtle.importKey("raw", new Uint8Array(32), { name: "X25519" }, true, []);
+
+  await expect(crypto.subtle.deriveBits({ name: "X25519", public: zeroPublicKey }, privateKey, 256)).rejects.toThrow();
+});


### PR DESCRIPTION
### What does this PR do?

Implements SubtleCrypto deriveBits support for X25519.

### How did you verify your code works?

- added tests
- built and ran with `bun bd test`
- ran https://github.com/panva/jose and https://github.com/panva/hpke test suites with updated bun X25519 expectations to pass using the debug build

Refs: https://github.com/oven-sh/bun/issues/20148

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude [noreply@anthropic.com](mailto:noreply@anthropic.com)

---

Why? Bun is the only runtime not supporting X25519