### PR TITLE
Fix segfault in FFI toBuffer/toArrayBuffer with low pointer addresses

### DIFF
--- a/src/bun.js/api/FFIObject.zig
+++ b/src/bun.js/api/FFIObject.zig
@@ -432,7 +432,7 @@ pub fn getPtrSlice(globalThis: *JSGlobalObject, value: JSValue, byteOffset: ?JSV
 
     const num = value.asPtrAddress();
     if (num < std.heap.page_size_min) {
-        return .{ .err = globalThis.toInvalidArguments("ptr cannot be zero, that would segfault Bun :(", .{}) };
+        return .{ .err = globalThis.toInvalidArguments("ptr is in low unmapped memory and would segfault Bun :(", .{}) };
     }
 
     // if (!std.math.isFinite(num)) {
@@ -451,7 +451,7 @@ pub fn getPtrSlice(globalThis: *JSGlobalObject, value: JSValue, byteOffset: ?JSV
             }
 
             if (addr < std.heap.page_size_min) {
-                return .{ .err = globalThis.toInvalidArguments("ptr cannot be zero, that would segfault Bun :(", .{}) };
+                return .{ .err = globalThis.toInvalidArguments("ptr is in low unmapped memory and would segfault Bun :(", .{}) };
             }
 
             if (!std.math.isFinite(byte_off.asNumber())) {

--- a/src/bun.js/api/FFIObject.zig
+++ b/src/bun.js/api/FFIObject.zig
@@ -431,7 +431,7 @@ pub fn getPtrSlice(globalThis: *JSGlobalObject, value: JSValue, byteOffset: ?JSV
     }
 
     const num = value.asPtrAddress();
-    if (num == 0) {
+    if (num < std.heap.page_size_min) {
         return .{ .err = globalThis.toInvalidArguments("ptr cannot be zero, that would segfault Bun :(", .{}) };
     }
 
@@ -450,7 +450,7 @@ pub fn getPtrSlice(globalThis: *JSGlobalObject, value: JSValue, byteOffset: ?JSV
                 addr +|= @as(usize, @intCast(off));
             }
 
-            if (addr == 0) {
+            if (addr < std.heap.page_size_min) {
                 return .{ .err = globalThis.toInvalidArguments("ptr cannot be zero, that would segfault Bun :(", .{}) };
             }
 

--- a/test/js/bun/ffi/ffi-ptr-low-address.test.ts
+++ b/test/js/bun/ffi/ffi-ptr-low-address.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+
+describe("FFI toBuffer/toArrayBuffer with low pointer addresses", () => {
+  test("toBuffer rejects addresses in the zero page", () => {
+    const { toBuffer } = Bun.FFI;
+    expect(() => toBuffer(0)).toThrow();
+    expect(() => toBuffer(1)).toThrow();
+    expect(() => toBuffer(64)).toThrow();
+    expect(() => toBuffer(4095)).toThrow();
+  });
+
+  test("toArrayBuffer rejects addresses in the zero page", () => {
+    const { toArrayBuffer } = Bun.FFI;
+    expect(() => toArrayBuffer(0)).toThrow();
+    expect(() => toArrayBuffer(1)).toThrow();
+    expect(() => toArrayBuffer(64)).toThrow();
+    expect(() => toArrayBuffer(4095)).toThrow();
+  });
+});

--- a/test/js/bun/ffi/ffi-ptr-low-address.test.ts
+++ b/test/js/bun/ffi/ffi-ptr-low-address.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
 describe("FFI toBuffer/toArrayBuffer with low pointer addresses", () => {
+  const HIGH_PTR = 1024 * 1024;
+
   test("toBuffer rejects addresses in the zero page", () => {
     const { toBuffer } = Bun.FFI;
     expect(() => toBuffer(0)).toThrow();
     expect(() => toBuffer(1)).toThrow();
     expect(() => toBuffer(64)).toThrow();
     expect(() => toBuffer(4095)).toThrow();
+    expect(() => toBuffer(HIGH_PTR, -HIGH_PTR)).toThrow();
   });
 
   test("toArrayBuffer rejects addresses in the zero page", () => {
@@ -15,5 +18,6 @@ describe("FFI toBuffer/toArrayBuffer with low pointer addresses", () => {
     expect(() => toArrayBuffer(1)).toThrow();
     expect(() => toArrayBuffer(64)).toThrow();
     expect(() => toArrayBuffer(4095)).toThrow();
+    expect(() => toArrayBuffer(HIGH_PTR, -HIGH_PTR)).toThrow();
   });
 });

--- a/test/js/bun/ffi/ffi-ptr-low-address.test.ts
+++ b/test/js/bun/ffi/ffi-ptr-low-address.test.ts
@@ -9,7 +9,7 @@ describe("FFI toBuffer/toArrayBuffer with low pointer addresses", () => {
     expect(() => toBuffer(1)).toThrow();
     expect(() => toBuffer(64)).toThrow();
     expect(() => toBuffer(4095)).toThrow();
-    expect(() => toBuffer(HIGH_PTR, -HIGH_PTR)).toThrow();
+    expect(() => toBuffer(HIGH_PTR + 64, -HIGH_PTR)).toThrow();
   });
 
   test("toArrayBuffer rejects addresses in the zero page", () => {
@@ -18,6 +18,6 @@ describe("FFI toBuffer/toArrayBuffer with low pointer addresses", () => {
     expect(() => toArrayBuffer(1)).toThrow();
     expect(() => toArrayBuffer(64)).toThrow();
     expect(() => toArrayBuffer(4095)).toThrow();
-    expect(() => toArrayBuffer(HIGH_PTR, -HIGH_PTR)).toThrow();
+    expect(() => toArrayBuffer(HIGH_PTR + 64, -HIGH_PTR)).toThrow();
   });
 });


### PR DESCRIPTION
When `Bun.FFI.toBuffer()` or `Bun.FFI.toArrayBuffer()` is called with a small integer as the pointer argument (e.g. 64), `getPtrSlice` only checked for `addr == 0` before eventually calling `strlen` on the pointer. Any address in the zero page (below page_size_min / 4096) is unmapped memory and will segfault.

This extends the existing zero-check to reject all addresses below `std.heap.page_size_min`, which covers the entire zero page that is never valid memory on any supported platform.

**Repro:**
```js
Bun.FFI.toBuffer(64); // segfault before fix, throws TypeError after
```

---
Verification: Lint JavaScript passed on a56b64f. Format failure on prior commit 4fe6dba was the autofix-ci bot applying formatting corrections (git exit code 1), which produced the current HEAD commit; Buildkite builds still in progress. Diff is clean (no TODO/FIXME/HACK), two Zig check sites updated from `== 0` to `< std.heap.page_size_min` with corrected error messages. Test file exercises toBuffer and toArrayBuffer with addresses 0, 1, 64, 4095 (would segfault on main for non-zero values) plus negative-offset path. Both CodeRabbit actionable comments (stale error text, negative-offset test) were addressed in the follow-up commit.

---
**Verification (robobun):** CI Lint JavaScript passed on a56b64f; Buildkite build #40735 in progress on HEAD 55f17af (test-only delta from prior commit). Diff is clean — no TODO/FIXME/HACK, two Zig check sites properly updated from == 0 to < std.heap.page_size_min with corrected error messages. Regression test exercises toBuffer and toArrayBuffer with addresses 0, 1, 64, 4095 (values 1/64/4095 would segfault on main) and negative-offset path yielding addr=64 (distinguishes new check from old == 0). Both CodeRabbit actionable comments addressed. Claude Code Review findings are all pre-existing issues.