### PR TITLE
fix: console.trace() should write to stderr instead of stdout

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -156,12 +156,13 @@ fn messageWithTypeAndLevel_(
         return;
     }
 
-    const enable_colors = if (level == .Warning or level == .Error)
+    const use_stderr = level == .Warning or level == .Error or message_type == .Trace;
+    const enable_colors = if (use_stderr)
         Output.enable_ansi_colors_stderr
     else
         Output.enable_ansi_colors_stdout;
 
-    const writer = if (level == .Warning or level == .Error)
+    const writer = if (use_stderr)
         console.error_writer
     else
         console.writer;


### PR DESCRIPTION
## Summary

\console.trace()\ currently writes its output to **stdout**, but per the [console spec](https://console.spec.whatwg.org/#trace) and Node.js behavior, it should write to **stderr**.

## Root Cause

In \src/bun.js/ConsoleObject.zig\, the writer selection only checked the message level (\Warning\/\Error\) to decide between stderr and stdout. Since \console.trace()\ is dispatched with \Log\ level, it incorrectly used stdout.

## Fix

Added a check for \message_type == .Trace\ alongside the level check, so trace output is correctly routed to stderr.

## Reproduction

\\\js
// trace.js
console.trace('hello');
\\\

\\\ash
# Node.js (correct - output goes to stderr)
$ node trace.js >/dev/null
Trace: hello
    at Object.<anonymous> ...

# Bun before fix (broken - output goes to stdout, suppressed by redirect)
$ bun trace.js >/dev/null
# (no output)

# Bun after fix (correct - output goes to stderr)
$ bun trace.js >/dev/null
Trace: hello
    at ...
\\\

Fixes #19952