### PR TITLE
Handle pending exception in throw helpers to prevent releaseAssertNoException crash

### DIFF
--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -51,6 +51,7 @@ pub const JSGlobalObject = opaque {
 
     pub fn throwTODO(this: *JSGlobalObject, msg: []const u8) bun.JSError {
         const err = this.createErrorInstance("{s}", .{msg});
+        if (err == .zero) return error.JSError;
         err.put(this, ZigString.static("name"), (bun.String.static("TODOError").toJS(this)) catch return error.JSError);
         return this.throwValue(err);
     }
@@ -361,6 +362,7 @@ pub const JSGlobalObject = opaque {
 
     pub fn createRangeError(this: *JSGlobalObject, comptime fmt: [:0]const u8, args: anytype) JSValue {
         const err = createErrorInstance(this, fmt, args);
+        if (err == .zero) return .zero;
         err.put(this, ZigString.static("code"), ZigString.static(@tagName(jsc.Node.ErrorCode.ERR_OUT_OF_RANGE)).toJS(this));
         return err;
     }
@@ -381,6 +383,7 @@ pub const JSGlobalObject = opaque {
         args: anytype,
     ) JSError {
         const err = createErrorInstance(this, message, args);
+        if (err == .zero) return error.JSError;
         err.put(this, ZigString.static("code"), ZigString.init(@tagName(opts.code)).toJS(this));
         if (opts.name) |name| err.put(this, ZigString.static("name"), ZigString.init(name).toJS(this));
         if (opts.errno) |errno| err.put(this, ZigString.static("errno"), try .fromAny(this, i32, errno));
@@ -393,7 +396,11 @@ pub const JSGlobalObject = opaque {
     /// chances are you should be using `.ERR(...).throw()` instead.
     pub fn throw(this: *JSGlobalObject, comptime fmt: [:0]const u8, args: anytype) JSError {
         const instance = this.createErrorInstance(fmt, args);
-        bun.assert(instance != .zero);
+        if (instance == .zero) {
+            // createErrorInstance can fail and set its own exception (e.g. on
+            // stack overflow). In that case an exception is already pending.
+            return error.JSError;
+        }
         return this.throwValue(instance);
     }
 
@@ -401,7 +408,9 @@ pub const JSGlobalObject = opaque {
         const instance = switch (Output.enable_ansi_colors_stderr) {
             inline else => |enabled| this.createErrorInstance(Output.prettyFmt(fmt, enabled), args),
         };
-        bun.assert(instance != .zero);
+        if (instance == .zero) {
+            return error.JSError;
+        }
         return this.throwValue(instance);
     }
 
@@ -447,11 +456,13 @@ pub const JSGlobalObject = opaque {
 
     pub fn throwTypeError(this: *JSGlobalObject, comptime fmt: [:0]const u8, args: anytype) bun.JSError {
         const instance = this.createTypeErrorInstance(fmt, args);
+        if (instance == .zero) return error.JSError;
         return this.throwValue(instance);
     }
 
     pub fn throwDOMException(this: *JSGlobalObject, code: jsc.WebCore.DOMExceptionCode, comptime fmt: [:0]const u8, args: anytype) bun.JSError {
         const instance = try this.createDOMExceptionInstance(code, fmt, args);
+        if (instance == .zero) return error.JSError;
         return this.throwValue(instance);
     }
 
@@ -472,6 +483,7 @@ pub const JSGlobalObject = opaque {
         defer allocator_.free(buffer);
         const str = ZigString.initUTF8(buffer);
         const err_value = str.toErrorInstance(this);
+        if (err_value == .zero) return error.JSError;
         return this.vm().throwError(this, err_value);
     }
 


### PR DESCRIPTION
When `createErrorInstance` fails (e.g. due to stack overflow or OOM during Error object construction), it returns an empty JSValue (`.zero`) with an exception already set on the VM. Previously, `throw()`, `throwPretty()`, `throwTypeError()`, and `throwSysError()` would either assert that the instance is non-zero or call `throwValue()` directly, which calls `JSC__VM__throwError` in C++. That function has a `scope.assertNoException()` check that crashes if an exception is already pending.

The fix checks if `createErrorInstance` returned `.zero` and returns `error.JSError` directly, since the original exception from the failed error construction is already pending on the VM.

Crash fingerprint: `d136aa5b4ea0a09f`

The crash was flaky and reproduced via Fuzzilli calling `expect.extend()` without arguments under resource pressure. The `throwPretty` call in `Expect.extend` triggered the assertion when `createErrorInstance` failed internally.

---

**Verification (robobun, iteration 11):** CI Build #40936 pending; prior builds (#40858, #40822) showed only unrelated failures (bundler_compile.test.ts timeouts on Linux, webview.test.ts timeouts on macOS). Diff is +14/-2 in JSGlobalObject.zig plus a trivial import-order autoformat in s3-fd-validation.test.ts. All 8 error-instance creation call sites are guarded: throwTODO, createRangeError, throwSysError, throw, throwPretty, throwTypeError, throwDOMException, throwError — each returns the correct type (error.JSError or .zero for JSValue-returning createRangeError). Two bun.assert crash points replaced with graceful early returns. No TODO/FIXME/HACK markers. All bot review concerns resolved. Claude reviewer confirmed LGTM on final diff.

**Verification (robobun, iteration 14):** CI Build #40977 in progress — Lint JavaScript ✅, pipeline ✅, Zig builds compiling across all 10 platform targets. Diff is a single file: +14/-2 in src/bun.js/bindings/JSGlobalObject.zig. All 8 call sites guarded: throwTODO, createRangeError, throwSysError, throw, throwPretty, throwTypeError, throwDOMException, throwError. Each returns error.JSError (or .zero for JSValue-returning createRangeError) when error construction fails with an exception already pending. No TODO/FIXME/HACK markers. No test — the .zero path requires OOM/stack overflow (reproduced via Fuzzilli). All bot review concerns resolved.

**Verification (robobun, iteration 17):** CI Build #41069 pending. Prior build #40983 failures were all unrelated (webview.test.ts timeouts on macOS, bundler_compile.test.ts timeouts on Linux). Diff is a single file: +14/-2 in src/bun.js/bindings/JSGlobalObject.zig. All 8 call sites guarded with .zero checks after createErrorInstance/createTypeErrorInstance/createDOMExceptionInstance/toErrorInstance calls. Four unresolved review threads are all pre-existing issues or acknowledged test limitations — none blocking. No TODO/FIXME/HACK markers in added lines. Claude reviewer LGTM across multiple rounds.