### PR TITLE
Fix namespace IIFE parameter not being renamed across files

### DIFF
--- a/src/ast/parseTypescript.zig
+++ b/src/ast/parseTypescript.zig
@@ -285,10 +285,12 @@ pub fn ParseTypescript(
                     // run the renamer. For external-facing things the renamer will avoid
                     // collisions automatically so this isn't important for correctness.
                     arg_ref = p.newSymbol(.hoisted, strings.cat(p.allocator, "_", name_text) catch unreachable) catch unreachable;
-                    bun.handleOom(p.current_scope.generated.append(p.allocator, arg_ref));
                 } else {
                     arg_ref = p.newSymbol(.hoisted, name_text) catch unreachable;
                 }
+                // Always add to scope.generated so the renamer can see it and
+                // avoid collisions with same-named symbols from other files.
+                bun.handleOom(p.current_scope.generated.append(p.allocator, arg_ref));
                 ts_namespace.arg_ref = arg_ref;
             }
             p.popScope();

--- a/test/regression/issue/28391.test.ts
+++ b/test/regression/issue/28391.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("bundler handles same-named namespace re-exports across files", async () => {
+  using dir = tempDir("issue-28391", {
+    "a.ts": `export namespace Foo {
+  export const value = 42
+}`,
+    "b.ts": `import { Foo as S } from "./a"
+export namespace Foo {
+  export const value = S.value
+}
+console.log(Foo.value)`,
+  });
+
+  // Bundle
+  await using bundleProc = Bun.spawn({
+    cmd: [bunExe(), "build", "b.ts", "--outdir=dist", "--target=bun"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [, bundleExit] = await Promise.all([bundleProc.stderr.text(), bundleProc.exited]);
+  expect(bundleExit).toBe(0);
+
+  // Run bundled output
+  await using runProc = Bun.spawn({
+    cmd: [bunExe(), "run", "dist/b.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("42\n");
+  expect(exitCode).toBe(0);
+});
+
+test("bundler handles same-named namespace with functions across files", async () => {
+  using dir = tempDir("issue-28391-fn", {
+    "a.ts": `export namespace Bar {
+  export function greet() { return "hello" }
+}`,
+    "b.ts": `import { Bar as X } from "./a"
+export namespace Bar {
+  export const msg = X.greet()
+}
+console.log(Bar.msg)`,
+  });
+
+  await using bundleProc = Bun.spawn({
+    cmd: [bunExe(), "build", "b.ts", "--outdir=dist", "--target=bun"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [, bundleExit] = await Promise.all([bundleProc.stderr.text(), bundleProc.exited]);
+  expect(bundleExit).toBe(0);
+
+  await using runProc = Bun.spawn({
+    cmd: [bunExe(), "run", "dist/b.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("hello\n");
+  expect(exitCode).toBe(0);
+});
+
+test("bundler handles star import with same-named namespace", async () => {
+  using dir = tempDir("issue-28391-star", {
+    "a.ts": `export namespace Foo {
+  export const value = 99
+}`,
+    "b.ts": `import * as A from "./a"
+export namespace Foo {
+  export const value = A.Foo.value
+}
+console.log(Foo.value)`,
+  });
+
+  await using bundleProc = Bun.spawn({
+    cmd: [bunExe(), "build", "b.ts", "--outdir=dist", "--target=bun"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [, bundleExit] = await Promise.all([bundleProc.stderr.text(), bundleProc.exited]);
+  expect(bundleExit).toBe(0);
+
+  await using runProc = Bun.spawn({
+    cmd: [bunExe(), "run", "dist/b.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("99\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #28391

## Repro

Two files with identically-named `namespace` declarations, where one re-exports from the other:

```ts
// a.ts
export namespace Foo {
  export const value = 42
}

// b.ts
import { Foo as S } from "./a"
export namespace Foo {
  export const value = S.value
}
console.log(Foo.value)
```

`bun run b.ts` prints `42`, but the bundled output prints `undefined` because the generated code contains a self-assignment:

```js
var Foo2;
((Foo) => {
  Foo.value = Foo.value;  // self-assignment — should reference outer Foo
})(Foo2 ||= {});
```

## Cause

When parsing a TypeScript namespace, the IIFE parameter symbol (`arg_ref`) was only added to `scope.generated` in the self-collision case (namespace exports a member with the same name as the namespace itself). In the common case, `arg_ref` was not added to any scope, making it invisible to the `NumberRenamer`. When `nameForSymbol` was called for the IIFE parameter, it fell back to `original_name` (e.g. `"Foo"`), which shadowed the same-named symbol from the other file.

## Fix

Always add `arg_ref` to `scope.generated` so the renamer can see it and assign a unique name when there's a collision with symbols from other files. The bundled output now correctly generates:

```js
var Foo2;
((Foo3) => {
  Foo3.value = Foo.value;  // Foo3 is the IIFE param, Foo is from a.ts
})(Foo2 ||= {});
```

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28391.test.ts` — 3 fail (bug exists on main)
- `bun bd test test/regression/issue/28391.test.ts` — 3 pass (fix works)

---
**Verification (robobun):** CI: JS Lint passed, Buildkite build #40933 in progress with 0 failures (prior builds canceled by build_skipping on new commits). Diff verified: surgical 3-line move of `scope.generated.append(arg_ref)` from inside the self-collision branch to unconditional, matching the enum analog pattern (`declareSymbol` auto-registers). Three regression tests bundle cross-file same-named namespaces (named import, function namespace, star import) and assert correct runtime output (42, "hello", 99) plus exit codes — these would produce `undefined` on main due to IIFE parameter shadowing. All CodeRabbit feedback addressed (exit code assertions added). No TODO/FIXME/HACK, no unresolved review threads. One cosmetic import reorder in s3-fd-validation.test.ts is harmless.
