### PR TITLE
Fix FFI toArrayBuffer/toBuffer/newCString crash on invalid pointer addresses

### DIFF
--- a/src/bun.js/api/FFIObject.zig
+++ b/src/bun.js/api/FFIObject.zig
@@ -3,7 +3,7 @@ const FFIObject = @This();
 pub fn newCString(globalThis: *JSGlobalObject, value: JSValue, byteOffset: ?JSValue, lengthValue: ?JSValue) bun.JSError!jsc.JSValue {
     switch (FFIObject.getPtrSlice(globalThis, value, byteOffset, lengthValue)) {
         .err => |err| {
-            return err;
+            return globalThis.throwValue(err);
         },
         .slice => |slice| {
             return bun.String.createUTF8ForJS(globalThis, slice);
@@ -464,7 +464,7 @@ pub fn getPtrSlice(globalThis: *JSGlobalObject, value: JSValue, byteOffset: ?JSV
         }
     }
 
-    if (addr == 0xDEADBEEF or addr == 0xaaaaaaaa or addr == 0xAAAAAAAA) {
+    if (addr == 0xDEADBEEF or addr == 0xaaaaaaaa or addr == 0xAAAAAAAA or addr < std.heap.page_size_min) {
         return .{ .err = globalThis.toInvalidArguments("ptr to invalid memory, that would segfault Bun :(", .{}) };
     }
 
@@ -520,7 +520,7 @@ pub fn toArrayBuffer(
 ) bun.JSError!jsc.JSValue {
     switch (getPtrSlice(globalThis, value, byteOffset, valueLength)) {
         .err => |erro| {
-            return erro;
+            return globalThis.throwValue(erro);
         },
         .slice => |slice| {
             var callback: jsc.C.JSTypedArrayBytesDeallocator = null;
@@ -533,17 +533,17 @@ pub fn toArrayBuffer(
                         if (getCPtr(ctx_value)) |ctx_ptr| {
                             ctx = @as(*anyopaque, @ptrFromInt(ctx_ptr));
                         } else if (!ctx_value.isUndefinedOrNull()) {
-                            return globalThis.toInvalidArguments("Expected user data to be a C pointer (number or BigInt)", .{});
+                            return globalThis.throwValue(globalThis.toInvalidArguments("Expected user data to be a C pointer (number or BigInt)", .{}));
                         }
                     }
                 } else if (!callback_value.isEmptyOrUndefinedOrNull()) {
-                    return globalThis.toInvalidArguments("Expected callback to be a C pointer (number or BigInt)", .{});
+                    return globalThis.throwValue(globalThis.toInvalidArguments("Expected callback to be a C pointer (number or BigInt)", .{}));
                 }
             } else if (finalizationCtxOrPtr) |callback_value| {
                 if (getCPtr(callback_value)) |callback_ptr| {
                     callback = @as(jsc.C.JSTypedArrayBytesDeallocator, @ptrFromInt(callback_ptr));
                 } else if (!callback_value.isEmptyOrUndefinedOrNull()) {
-                    return globalThis.toInvalidArguments("Expected callback to be a C pointer (number or BigInt)", .{});
+                    return globalThis.throwValue(globalThis.toInvalidArguments("Expected callback to be a C pointer (number or BigInt)", .{}));
                 }
             }
 
@@ -562,7 +562,7 @@ pub fn toBuffer(
 ) bun.JSError!jsc.JSValue {
     switch (getPtrSlice(globalThis, value, byteOffset, valueLength)) {
         .err => |err| {
-            return err;
+            return globalThis.throwValue(err);
         },
         .slice => |slice| {
             var callback: jsc.C.JSTypedArrayBytesDeallocator = null;
@@ -575,17 +575,17 @@ pub fn toBuffer(
                         if (getCPtr(ctx_value)) |ctx_ptr| {
                             ctx = @as(*anyopaque, @ptrFromInt(ctx_ptr));
                         } else if (!ctx_value.isEmptyOrUndefinedOrNull()) {
-                            return globalThis.toInvalidArguments("Expected user data to be a C pointer (number or BigInt)", .{});
+                            return globalThis.throwValue(globalThis.toInvalidArguments("Expected user data to be a C pointer (number or BigInt)", .{}));
                         }
                     }
                 } else if (!callback_value.isEmptyOrUndefinedOrNull()) {
-                    return globalThis.toInvalidArguments("Expected callback to be a C pointer (number or BigInt)", .{});
+                    return globalThis.throwValue(globalThis.toInvalidArguments("Expected callback to be a C pointer (number or BigInt)", .{}));
                 }
             } else if (finalizationCtxOrPtr) |callback_value| {
                 if (getCPtr(callback_value)) |callback_ptr| {
                     callback = @as(jsc.C.JSTypedArrayBytesDeallocator, @ptrFromInt(callback_ptr));
                 } else if (!callback_value.isEmptyOrUndefinedOrNull()) {
-                    return globalThis.toInvalidArguments("Expected callback to be a C pointer (number or BigInt)", .{});
+                    return globalThis.throwValue(globalThis.toInvalidArguments("Expected callback to be a C pointer (number or BigInt)", .{}));
                 }
             }
 

--- a/test/js/bun/ffi/ffi-error-messages.test.ts
+++ b/test/js/bun/ffi/ffi-error-messages.test.ts
@@ -1,4 +1,4 @@
-import { dlopen, linkSymbols } from "bun:ffi";
+import { dlopen, linkSymbols, toArrayBuffer, toBuffer } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
 import { isArm64, isMusl, isWindows } from "harness";
 
@@ -85,5 +85,21 @@ describe.skipIf(isFFIUnavailable)("FFI error messages", () => {
         },
       });
     }).toThrow('you must provide a "ptr" field with the memory address of the native function.');
+  });
+
+  test("toArrayBuffer throws for invalid pointer addresses instead of crashing", () => {
+    expect(() => toArrayBuffer(0)).toThrow();
+    expect(() => toArrayBuffer(1)).toThrow();
+    expect(() => toArrayBuffer(75)).toThrow();
+    expect(() => toArrayBuffer(4095)).toThrow();
+    expect(() => toArrayBuffer(0xdeadbeef)).toThrow();
+  });
+
+  test("toBuffer throws for invalid pointer addresses instead of crashing", () => {
+    expect(() => toBuffer(0)).toThrow();
+    expect(() => toBuffer(1)).toThrow();
+    expect(() => toBuffer(75)).toThrow();
+    expect(() => toBuffer(4095)).toThrow();
+    expect(() => toBuffer(0xdeadbeef)).toThrow();
   });
 });

--- a/test/js/bun/s3/s3-fd-validation.test.ts
+++ b/test/js/bun/s3/s3-fd-validation.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("S3Client.write does not crash with out-of-range float as path", () => {
   expect(() => Bun.S3Client.write(-1.5379890021597998e308, "data")).toThrow();


### PR DESCRIPTION
Two bugs fixed in `src/bun.js/api/FFIObject.zig`:

1. **Reject pointers in the first page of virtual memory (0-4095)**: `getPtrSlice` only checked for `addr == 0` and a few sentinel values (`0xDEADBEEF`, `0xAAAAAAAA`), but any address below 4096 points to the first page of virtual memory which is never mapped on any modern OS. Passing a small number like 75 as a pointer to `toArrayBuffer` caused `bun.span()` to try reading a null-terminated string from unmapped memory, resulting in a segfault (SIGSEGV).

2. **Fix error propagation in `toArrayBuffer`, `toBuffer`, and `newCString`**: These functions return `bun.JSError!jsc.JSValue` but were doing `return err` with a `JSValue` error object from `getPtrSlice`. This returned the error as a *success value* instead of throwing it as a JS exception. Fixed by using `globalThis.throwValue(err)` to properly propagate errors. The same fix was applied to `toInvalidArguments` calls inside these functions.

---
<!-- robobun verification -->
Verified by robobun: CI build #40968 in progress on commit 7ceeeac (identical code to 3e95eba which completed Format/Lint JS successfully; macOS test jobs passed on retries, only failures were infrastructure flakes — expired jobs, linux-aarch64-build-cpp exit 255). Diff is clean: no TODO/FIXME/HACK markers, three files changed (FFIObject.zig, ffi-error-messages.test.ts, trivial import reorder in s3-fd-validation.test.ts). Both fixes are type-correct: `throwValue` returns `JSError` matching the `bun.JSError!jsc.JSValue` return type, while the old `return err` silently returned error objects as success values. `addr < std.heap.page_size_min` guard uses Zig stdlib platform-aware constant per CodeRabbit suggestion. Tests exercise both bugs: addresses 1/75/4095 would segfault on main (no first-page guard), and 0xdeadbeef would return error as value instead of throwing — none would pass on main. Bot reviews only flag pre-existing issues outside this PR scope.