### PR TITLE
Fix assertion failure in lazy test module object initialization

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -1768,12 +1768,24 @@ void GlobalObject::finishCreation(VM& vm)
             JSC::JSGlobalObject* globalObject = init.owner;
 
             JSValue result = JSValue::decode(Bun__Jest__createTestModuleObject(globalObject));
+            if (result.isEmpty()) [[unlikely]] {
+                auto scope = DECLARE_TOP_EXCEPTION_SCOPE(init.vm);
+                scope.clearExceptionExceptTermination();
+                init.set(JSC::constructEmptyObject(globalObject));
+                return;
+            }
             init.set(result.toObject(globalObject));
         });
 
     m_testMatcherUtilsObject.initLater(
         [](const Initializer<JSObject>& init) {
             JSValue result = JSValue::decode(ExpectMatcherUtils_createSigleton(init.owner));
+            if (result.isEmpty()) [[unlikely]] {
+                auto scope = DECLARE_TOP_EXCEPTION_SCOPE(init.vm);
+                scope.clearExceptionExceptTermination();
+                init.set(JSC::constructEmptyObject(init.owner));
+                return;
+            }
             init.set(result.toObject(init.owner));
         });
 

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -192,7 +192,7 @@ pub const Jest = struct {
         const describe_scope_functions = try bun_test.ScopeFunctions.createBound(globalObject, .describe, .zero, .{}, bun_test.ScopeFunctions.strings.describe);
         module.put(globalObject, ZigString.static("describe"), describe_scope_functions);
 
-        const xdescribe_scope_functions = bun_test.ScopeFunctions.createBound(globalObject, .describe, .zero, .{ .self_mode = .skip }, bun_test.ScopeFunctions.strings.xdescribe) catch return .zero;
+        const xdescribe_scope_functions = try bun_test.ScopeFunctions.createBound(globalObject, .describe, .zero, .{ .self_mode = .skip }, bun_test.ScopeFunctions.strings.xdescribe);
         module.put(globalObject, ZigString.static("xdescribe"), xdescribe_scope_functions);
 
         module.put(globalObject, ZigString.static("beforeEach"), jsc.JSFunction.create(globalObject, "beforeEach", bun_test.js_fns.genericHook(.beforeEach).hookFn, 1, .{}));

--- a/test/js/bun/test/jest-create-test-module-error.test.ts
+++ b/test/js/bun/test/jest-create-test-module-error.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("Bun.jest() returns working test module object outside test runner", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const mod = Bun.jest(() => {});
+      console.log(typeof mod.expect);
+      console.log(typeof mod.test);
+      console.log(typeof mod.describe);
+      console.log(typeof mod.xdescribe);
+    `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("function\nfunction\nfunction\nfunction\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes a `releaseAssertNoException` assertion failure (fingerprint `0916637d6845876b`) that could occur when `Bun.jest()` is called and the internal test module object creation encounters an error.

**Root cause:**

In `createTestModule`, the `xdescribe` `ScopeFunctions.createBound` call used `catch return .zero` instead of `try` (unlike all other `createBound` calls in the same function). This returned `.zero` as a **success value** with a pending JS exception, rather than propagating the error. The caller `Bun__Jest__createTestModuleObject` would then return this `.zero` to the C++ lazy initializer, which called `toObject()` on a null JSValue with a pending exception, triggering the `releaseAssertNoException` assertion.

**Fix:**

1. Change `catch return .zero` to `try` for the xdescribe `createBound` call, consistent with the other calls in the function.
2. Add a guard in the C++ lazy test module initializer to handle the case where `Bun__Jest__createTestModuleObject` returns an empty value, clearing the pending exception and falling back to an empty object.

---
Verified by robobun: Zig fix changes `catch return .zero` to `try` for xdescribe createBound, consistent with all other calls in createTestModule. C++ isEmpty guards added to both `m_lazyTestModuleObject` and `m_testMatcherUtilsObject` initializers prevent releaseAssertNoException by checking isEmpty() before toObject(). Smoke test spawns subprocess with `Bun.jest(() => {})` and verifies expect/test/describe/xdescribe are all functions with exit code 0 (note: test is a smoke test covering the happy path; the crash requires internal error conditions not easily reproducible in tests). No TODO/FIXME/HACK in diff. Lint JS passed. No CHANGES_REQUESTED reviews. Buildkite build #40918 in progress with 0 failures at time of approval.

---
**Verification (robobun):** Lint JavaScript passed; Buildkite build #41058 pipeline dispatched. Diff is clean — 3 files, no TODO/FIXME/HACK. Zig fix correctly changes inconsistent catch-return-.zero to try matching all other createBound calls. C++ isEmpty guards on both lazy initializers follow established exception-clearing pattern. Smoke test verifies Bun.jest() returns functional module with exit code 0. No blocking reviews.