### PR TITLE
Validate ctx argument in FFI.closeCallback before dereferencing as pointer

### DIFF
--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -831,7 +831,12 @@ pub const FFI = struct {
     }
 
     pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) JSValue {
-        var function: *Function = @ptrFromInt(ctx.asPtrAddress());
+        if (!ctx.isNumber()) return .js_undefined;
+        const num = ctx.asNumber();
+        if (!std.math.isFinite(num) or num < 0 or num >= @as(f64, @floatFromInt(std.math.maxInt(usize))) or num != @trunc(num)) return .js_undefined;
+        const addr: usize = @intFromFloat(num);
+        if (addr == 0) return .js_undefined;
+        var function: *Function = @ptrFromInt(addr);
         function.deinit(globalThis);
         return .js_undefined;
     }

--- a/test/js/bun/ffi/ffi-closeCallback.test.ts
+++ b/test/js/bun/ffi/ffi-closeCallback.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+
+test("FFI.closeCallback does not crash with invalid arguments", () => {
+  const ffi = Bun.FFI;
+
+  // closeCallback should not crash when called with non-pointer arguments
+  expect(() => ffi.closeCallback("not a pointer")).not.toThrow();
+  expect(() => ffi.closeCallback({})).not.toThrow();
+  expect(() => ffi.closeCallback(undefined)).not.toThrow();
+  expect(() => ffi.closeCallback(null)).not.toThrow();
+  expect(() => ffi.closeCallback(0)).not.toThrow();
+  expect(() => ffi.closeCallback(NaN)).not.toThrow();
+  expect(() => ffi.closeCallback(Infinity)).not.toThrow();
+  expect(() => ffi.closeCallback(-Infinity)).not.toThrow();
+  expect(() => ffi.closeCallback(-1)).not.toThrow();
+  expect(() => ffi.closeCallback(1e100)).not.toThrow();
+  expect(() => ffi.closeCallback(Number.MAX_VALUE)).not.toThrow();
+  expect(() => ffi.closeCallback(2 ** 64)).not.toThrow();
+  expect(() => ffi.closeCallback(1.5)).not.toThrow();
+  expect(() => ffi.closeCallback(2.9)).not.toThrow();
+  expect(() => ffi.closeCallback(100.7)).not.toThrow();
+});

--- a/test/js/bun/s3/s3-fd-validation.test.ts
+++ b/test/js/bun/s3/s3-fd-validation.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("S3Client.write does not crash with out-of-range float as path", () => {
   expect(() => Bun.S3Client.write(-1.5379890021597998e308, "data")).toThrow();


### PR DESCRIPTION
FFI.closeCallback assumes its argument is a numeric JSValue encoding a pointer address created by FFI.callback(). When called directly with a non-numeric value (e.g. a function or object), `asNumber()` hits an assertion failure because the value is not a number, undefined, null, or boolean.

This adds a guard to return early if the argument is not a number or is zero, preventing the crash.

**Root cause:** `closeCallback` is exposed on `Bun.FFI` as a plain JS function. While `bun:ffi` module code deletes it from the public API after grabbing a reference, the raw `Bun.FFI` object can still be accessed directly. Calling `closeCallback` with an invalid argument (not a pointer returned by `callback()`) would crash.

**Fix:** Check that `ctx` is a number before calling `asPtrAddress()`. Return `undefined` for invalid arguments instead of crashing.

---
Verified by robobun: CI Build #40930 was canceled; Build #40949 shows only bundler_compile.test.ts failures (timeouts), completely unrelated to this FFI change. Lint JS and Format both pass. The fix adds a 5-condition guard in closeCallback (ffi.zig:834-838): isNumber(), isFinite(), non-negative, upper-bound via >= @floatFromInt(maxInt(usize)) correctly rejecting the 2^64 IEEE-754 boundary, integer check via num != @trunc(num), and non-zero addr check. Test file exercises 15 invalid inputs (strings, objects, undefined, null, 0, NaN, +/-Infinity, -1, 1e100, MAX_VALUE, 2^64, non-integer floats) — all would crash or UB on main. No TODO/FIXME/HACK in added lines. CodeRabbit bogus-positive-handle concern is a pre-existing design limitation out of scope for this defensive fix.