### PR TITLE
Fix crash in FFI.closeCallback when called with non-number argument

### DIFF
--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -831,7 +831,8 @@ pub const FFI = struct {
     }
 
     pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) bun.JSError!JSValue {
-        if (!ctx.isNumber()) {
+        const max_addr = @as(f64, @as(comptime_float, std.math.maxInt(usize)));
+        if (!ctx.isNumber() or !(ctx.asNumber() >= 0 and ctx.asNumber() <= max_addr)) {
             return globalThis.throwInvalidArguments("Expected a FFI callback context", .{});
         }
         const addr = ctx.asPtrAddress();

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -830,8 +830,15 @@ pub const FFI = struct {
         return js_object;
     }
 
-    pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) JSValue {
-        var function: *Function = @ptrFromInt(ctx.asPtrAddress());
+    pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) bun.JSError!JSValue {
+        if (!ctx.isNumber()) {
+            return globalThis.throwInvalidArguments("Expected a FFI callback context", .{});
+        }
+        const addr = ctx.asPtrAddress();
+        if (addr == 0) {
+            return globalThis.throwInvalidArguments("Expected a FFI callback context", .{});
+        }
+        var function: *Function = @ptrFromInt(addr);
         function.deinit(globalThis);
         return .js_undefined;
     }

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -831,16 +831,17 @@ pub const FFI = struct {
     }
 
     pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) bun.JSError!JSValue {
-        const max_addr = @as(f64, @as(comptime_float, std.math.maxInt(usize)));
-        if (!ctx.isNumber() or !(ctx.asNumber() >= 0 and ctx.asNumber() <= max_addr)) {
+        const max_addr_exclusive = @as(f64, @as(comptime_float, @as(u128, std.math.maxInt(usize)) + 1));
+        if (!ctx.isNumber() or !(ctx.asNumber() >= 0 and ctx.asNumber() < max_addr_exclusive)) {
             return globalThis.throwInvalidArguments("Expected a FFI callback context", .{});
         }
         const addr = ctx.asPtrAddress();
         if (addr == 0) {
             return globalThis.throwInvalidArguments("Expected a FFI callback context", .{});
         }
-        var function: *Function = @ptrFromInt(addr);
+        const function: *Function = @ptrFromInt(addr);
         function.deinit(globalThis);
+        bun.default_allocator.destroy(function);
         return .js_undefined;
     }
 

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -842,7 +842,6 @@ pub const FFI = struct {
         }
         const function: *Function = @ptrFromInt(addr);
         function.deinit(globalThis);
-        bun.default_allocator.destroy(function);
         return .js_undefined;
     }
 

--- a/src/bun.js/api/ffi.zig
+++ b/src/bun.js/api/ffi.zig
@@ -832,7 +832,8 @@ pub const FFI = struct {
 
     pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) bun.JSError!JSValue {
         const max_addr_exclusive = @as(f64, @as(comptime_float, @as(u128, std.math.maxInt(usize)) + 1));
-        if (!ctx.isNumber() or !(ctx.asNumber() >= 0 and ctx.asNumber() < max_addr_exclusive)) {
+        const num = if (ctx.isNumber()) ctx.asNumber() else return globalThis.throwInvalidArguments("Expected a FFI callback context", .{});
+        if (!(num >= 0 and num < max_addr_exclusive) or std.math.trunc(num) != num) {
             return globalThis.throwInvalidArguments("Expected a FFI callback context", .{});
         }
         const addr = ctx.asPtrAddress();

--- a/test/js/bun/ffi/ffi-closeCallback.test.ts
+++ b/test/js/bun/ffi/ffi-closeCallback.test.ts
@@ -7,4 +7,9 @@ test("FFI.closeCallback with invalid argument does not crash", () => {
   expect(() => FFI.closeCallback({})).toThrow();
   expect(() => FFI.closeCallback(undefined)).toThrow();
   expect(() => FFI.closeCallback(null)).toThrow();
+  expect(() => FFI.closeCallback(0)).toThrow();
+  expect(() => FFI.closeCallback(NaN)).toThrow();
+  expect(() => FFI.closeCallback(Infinity)).toThrow();
+  expect(() => FFI.closeCallback(-Infinity)).toThrow();
+  expect(() => FFI.closeCallback(-1)).toThrow();
 });

--- a/test/js/bun/ffi/ffi-closeCallback.test.ts
+++ b/test/js/bun/ffi/ffi-closeCallback.test.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "bun:test";
+
+test("FFI.closeCallback with invalid argument does not crash", () => {
+  const FFI = Bun.FFI;
+
+  expect(() => FFI.closeCallback("not a pointer")).toThrow();
+  expect(() => FFI.closeCallback({})).toThrow();
+  expect(() => FFI.closeCallback(undefined)).toThrow();
+  expect(() => FFI.closeCallback(null)).toThrow();
+});

--- a/test/js/bun/ffi/ffi-closeCallback.test.ts
+++ b/test/js/bun/ffi/ffi-closeCallback.test.ts
@@ -12,4 +12,5 @@ test("FFI.closeCallback with invalid argument does not crash", () => {
   expect(() => FFI.closeCallback(Infinity)).toThrow();
   expect(() => FFI.closeCallback(-Infinity)).toThrow();
   expect(() => FFI.closeCallback(-1)).toThrow();
+  expect(() => FFI.closeCallback(1.5)).toThrow();
 });


### PR DESCRIPTION
FFI.closeCallback blindly called `asPtrAddress()` on its `ctx` argument, which internally asserts the value is a number. When called with a non-number argument (e.g. an object or string), this hit an unreachable assertion and crashed with `panic: reached unreachable code`.

The `closeCallback` function is intended to be called only internally by `JSCallback.close()` with a valid pointer context, but the raw function was accessible via `Bun.FFI.closeCallback` before the JS wrapper deletes it.

### Fix
Validate that `ctx` is a number and non-zero before interpreting it as a pointer address. Throw a TypeError for invalid arguments instead of crashing.

### Test
Added `test/js/bun/ffi/ffi-closeCallback.test.ts` — confirms invalid arguments throw instead of crashing.

---
Verified by robobun (iteration 2): CI lint-js passed, Buildkite #40954 building. Diff is clean (no TODO/FIXME/HACK/XXX). Two files changed: ffi.zig adds input validation to closeCallback (type check, range check via u128-based exclusive bound, integrality check, zero check) before calling asPtrAddress(). Test file exercises 10 invalid inputs (non-numbers, NaN, Infinity, -Infinity, negatives, non-integers, zero) that would all crash on main. CodeRabbit concern about arbitrary valid pointer values (e.g. closeCallback(4096)) is a pre-existing issue not introduced by this PR — the function is semi-internal and has always trusted its ctx argument.