### PR TITLE
Clear pending JS exceptions in ExpectCustomAsymmetricMatcher.execute()

### DIFF
--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2665,7 +2665,11 @@ impl ExpectCustomAsymmetricMatcher {
         Expect::execute_custom_matcher(global_this, matcher_name, matcher_fn, &matcher_args, this.flags, true)
     }
 
-    /// Function called by c++ function "matchAsymmetricMatcher" to execute the custom matcher against the provided leftValue
+    /// Function called by c++ function "matchAsymmetricMatcher" to execute the custom matcher against the provided leftValue.
+    ///
+    /// Errors are swallowed here because the C++ caller (`matchAsymmetricMatcherAndGetFlags`) does not check for a pending
+    /// JS exception after this call — it only inspects the bool return value. Leaving the exception pending would trip
+    /// `releaseAssertNoException` in a downstream `ThrowScope` destructor. Clear the exception to match the C ABI contract.
     ///
     /// # Safety
     /// `this` must point to a live `Self` and `global_this` must point to a live
@@ -2678,7 +2682,11 @@ impl ExpectCustomAsymmetricMatcher {
         received: JSValue,
     ) -> bool {
         // SAFETY: called from C++ with valid pointers
-        unsafe { Self::execute_impl(&*this, this_value, &*global_this, received) }.unwrap_or(false)
+        unsafe { Self::execute_impl(&*this, this_value, &*global_this, received) }.unwrap_or_else(|_| {
+            // SAFETY: same pointer validity as above
+            unsafe { (*global_this).clear_exception() };
+            false
+        })
     }
 
     #[bun_jsc::host_fn(method)]

--- a/test/js/bun/test/expect-extend-undefined-return.test.ts
+++ b/test/js/bun/test/expect-extend-undefined-return.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+
+describe("expect.extend", () => {
+  test("custom matcher returning undefined throws InvalidMatcherError", () => {
+    expect.extend({
+      _returnsUndefined() {},
+    });
+
+    expect(() => expect(42)._returnsUndefined()).toThrow("Unexpected return from matcher function");
+  });
+
+  test("custom asymmetric matcher returning undefined does not crash", () => {
+    expect.extend({
+      _asymmetricReturnsUndefined() {},
+    });
+
+    expect({ a: 1 }).not.toEqual({
+      a: expect._asymmetricReturnsUndefined(),
+    });
+  });
+});


### PR DESCRIPTION
## What

Fix an assertion failure (crash) in JSC's exception scope verification when a custom matcher returns an invalid value during asymmetric matching.

## Root Cause

`ExpectCustomAsymmetricMatcher.execute()` returns `bool` via `callconv(.c)` and is called from C++ (`matchAsymmetricMatcherAndGetFlags`). The C++ caller does not check for pending JS exceptions after the call — it only uses the `bool` return value.

When `executeCustomMatcher` threw a JS exception (e.g. via `throwInvalidMatcherError` when a custom matcher returns `undefined`), the Zig `catch` converted the error to `false` but **left the JS exception pending on the VM**. The C++ caller continued with this pending exception, eventually triggering JSC's `releaseAssertNoException` assertion in a `ThrowScope` destructor.

## Fix

Call `globalThis.clearException()` on all error paths in `execute()` to ensure no pending JS exception leaks back to the C++ caller.

## Crash Info

- Fingerprint: `3b93ba86f53b347c`
- Signal: SIGABRT (assertion failure)
- Assertion: `!exception()` in `ExceptionScope::releaseAssertNoException()`
- Flaky: yes (depends on fuzzilli's random exploration picking a custom matcher that returns undefined)

---

Iteration 4 verification by @robobun: CI build #40922 pending on commit f92cb12; prior build #40891 failures were all unrelated (bundler_compile.test.ts timeouts, elysia stream test, asan-only regression tests, v8-heap-snapshot SIGKILL). Final diff touches only expect.zig and a new test file — no unrelated changes. All 8 error paths in the callconv(.c) execute() function now call globalThis.clearException() before return false. Regression test second case exercises the exact crash path: asymmetric matcher returning undefined inside toEqual → executeCustomMatcher → throwInvalidMatcherError → pending exception, which on main would SIGABRT. No TODO/FIXME/HACK. CodeRabbit and Claude reviews all resolved/LGTM.