### PR TITLE
fix: allow --frozen-lockfile --filter with missing workspace manifests

### DIFF
--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -8,6 +8,7 @@ timestamp_for_manifest_cache_control: u32 = 0,
 extracted_count: u32 = 0,
 default_features: Features = .{},
 summary: Lockfile.Package.Diff.Summary = .{},
+has_loaded_lockfile: bool = false,
 env: *DotEnv.Loader,
 progress: Progress = .{},
 downloads_node: ?*Progress.Node = null,
@@ -731,6 +732,7 @@ pub fn init(
                             &json_source,
                             prop.loc,
                             null,
+                            false,
                         ) catch break;
 
                         for (workspace_names.keys(), workspace_names.values()) |path, entry| {

--- a/src/install/PackageManager/install_with_manager.zig
+++ b/src/install/PackageManager/install_with_manager.zig
@@ -86,6 +86,7 @@ pub fn installWithManager(
             if (manager.options.enable.fail_early) Global.crash();
         },
         .ok => {
+            manager.has_loaded_lockfile = true;
             if (manager.subcommand == .update) {
                 // existing lockfile, get the original version is updating
                 const lockfile = manager.lockfile;
@@ -192,6 +193,35 @@ pub fn installWithManager(
                 );
 
                 had_any_diffs = manager.summary.hasDiffs();
+
+                // When --filter is used with --frozen-lockfile (e.g. Docker builds
+                // copying only a subset of workspace package.json files), missing
+                // workspaces appear as removals in the diff. Only suppress diffs
+                // when all removals match workspaces that exist in the loaded
+                // lockfile but were not found during workspace discovery on disk.
+                if (had_any_diffs and manager.options.filter_patterns.len > 0 and
+                    manager.options.enable.frozen_lockfile and
+                    manager.summary.remove > 0 and manager.summary.add == 0 and
+                    manager.summary.update == 0 and !manager.summary.overrides_changed and
+                    !manager.summary.catalogs_changed and
+                    manager.summary.added_trusted_dependencies.count() == 0 and
+                    manager.summary.removed_trusted_dependencies.count() == 0 and
+                    !manager.summary.patched_dependencies_changed)
+                {
+                    // Count workspaces in the loaded lockfile that were not
+                    // found during workspace discovery (absent from disk).
+                    // If this matches the removal count, all removals are
+                    // from missing workspace manifests, not intentional edits.
+                    var missing_workspace_count: u32 = 0;
+                    for (manager.lockfile.workspace_paths.keys()) |name_hash| {
+                        if (!lockfile.workspace_paths.contains(name_hash)) {
+                            missing_workspace_count += 1;
+                        }
+                    }
+                    if (manager.summary.remove == missing_workspace_count) {
+                        had_any_diffs = false;
+                    }
+                }
 
                 if (!had_any_diffs) {
                     // always grab latest scripts for root package

--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -1455,6 +1455,7 @@ pub fn Package(comptime SemverIntType: type) type {
                                 source,
                                 dependencies_q.loc,
                                 &string_builder,
+                                pm.options.filter_patterns.len > 0 and pm.options.enable.frozen_lockfile and pm.has_loaded_lockfile,
                             );
                         },
                         .e_object => |obj| {
@@ -1489,6 +1490,7 @@ pub fn Package(comptime SemverIntType: type) type {
                                         source,
                                         packages_query.loc,
                                         &string_builder,
+                                        pm.options.filter_patterns.len > 0 and pm.options.enable.frozen_lockfile and pm.has_loaded_lockfile,
                                     );
                                 }
 

--- a/src/install/lockfile/Package/WorkspaceMap.zig
+++ b/src/install/lockfile/Package/WorkspaceMap.zig
@@ -105,6 +105,7 @@ pub fn processNamesArray(
     source: *const logger.Source,
     loc: logger.Loc,
     string_builder: ?*StringBuilder,
+    skip_missing_workspaces: bool,
 ) !u32 {
     if (arr.items.len == 0) return 0;
 
@@ -153,7 +154,21 @@ pub fn processNamesArray(
         ) catch |err| {
             bun.handleErrorReturnTrace(err, @errorReturnTrace());
             switch (err) {
-                error.EISNOTDIR, error.EISDIR, error.EACCESS, error.EPERM, error.ENOENT, error.FileNotFound => {
+                error.ENOENT, error.FileNotFound => {
+                    // When --filter is used with --frozen-lockfile (e.g. Docker builds
+                    // that only copy a subset of workspace package.json files), missing
+                    // workspaces that aren't part of the filter target should not be errors.
+                    if (!skip_missing_workspaces) {
+                        log.addErrorFmt(
+                            source,
+                            item.loc,
+                            allocator,
+                            "Workspace not found \"{s}\"",
+                            .{input_path},
+                        ) catch {};
+                    }
+                },
+                error.EISNOTDIR, error.EISDIR, error.EACCESS, error.EPERM => {
                     log.addErrorFmt(
                         source,
                         item.loc,

--- a/src/install/migration.zig
+++ b/src/install/migration.zig
@@ -245,6 +245,7 @@ pub fn migrateNPMLockfile(
                 &json_src,
                 wksp.loc,
                 null,
+                false,
             );
             debug("found {d} workspace packages", .{workspace_packages_count});
             num_deps += workspace_packages_count;

--- a/test/regression/issue/28402.test.ts
+++ b/test/regression/issue/28402.test.ts
@@ -1,0 +1,226 @@
+import { spawn } from "bun";
+import { expect, test } from "bun:test";
+import { bunExe, bunEnv as env, tempDir } from "harness";
+import { join } from "path";
+
+test("frozen lockfile with filter succeeds when workspace manifests are missing", async () => {
+  // Create workspace directory structure
+  using dir = tempDir("issue-28402", {
+    "package.json": JSON.stringify({
+      name: "monorepo",
+      private: true,
+      workspaces: ["packages/*"],
+    }),
+    "packages/app/package.json": JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: {
+        "is-odd": "1.0.0",
+      },
+    }),
+    "packages/lib/package.json": JSON.stringify({
+      name: "lib",
+      version: "1.0.0",
+      dependencies: {
+        "is-even": "1.0.0",
+      },
+    }),
+  });
+
+  const cwd = String(dir);
+
+  // Generate lockfile from full workspace
+  await using installProc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  expect(await installProc.exited).toBe(0);
+
+  // Read the generated lockfile
+  const lockfileContent = await Bun.file(join(cwd, "bun.lock")).text();
+
+  // Simulate Docker pattern: new directory with only subset of workspace manifests
+  using dockerDir = tempDir("issue-28402-docker", {
+    "package.json": JSON.stringify({
+      name: "monorepo",
+      private: true,
+      workspaces: ["packages/*"],
+    }),
+    "bun.lock": lockfileContent,
+    "packages/app/package.json": JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: {
+        "is-odd": "1.0.0",
+      },
+    }),
+    // packages/lib/package.json is intentionally NOT present
+  });
+
+  const dockerCwd = String(dockerDir);
+
+  // Run frozen install with filter — should succeed
+  await using frozenProc = spawn({
+    cmd: [bunExe(), "install", "--frozen-lockfile", "--filter", "app"],
+    cwd: dockerCwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stderr, exitCode] = await Promise.all([frozenProc.stderr.text(), frozenProc.exited]);
+
+  expect(stderr).not.toContain("lockfile had changes");
+  expect(stderr).not.toContain("Workspace not found");
+  expect(exitCode).toBe(0);
+});
+
+test("frozen lockfile with filter still catches modified filtered workspace", async () => {
+  // Create workspace directory structure
+  using dir = tempDir("issue-28402-modified", {
+    "package.json": JSON.stringify({
+      name: "monorepo",
+      private: true,
+      workspaces: ["packages/*"],
+    }),
+    "packages/app/package.json": JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: {
+        "is-odd": "1.0.0",
+      },
+    }),
+    "packages/lib/package.json": JSON.stringify({
+      name: "lib",
+      version: "1.0.0",
+      dependencies: {
+        "is-even": "1.0.0",
+      },
+    }),
+  });
+
+  const cwd = String(dir);
+
+  // Generate lockfile from full workspace
+  await using installProc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  expect(await installProc.exited).toBe(0);
+
+  const lockfileContent = await Bun.file(join(cwd, "bun.lock")).text();
+
+  // Docker pattern but with a MODIFIED filtered workspace (added a new dep)
+  using dockerDir = tempDir("issue-28402-modified-docker", {
+    "package.json": JSON.stringify({
+      name: "monorepo",
+      private: true,
+      workspaces: ["packages/*"],
+    }),
+    "bun.lock": lockfileContent,
+    "packages/app/package.json": JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: {
+        "is-odd": "1.0.0",
+        "is-number": "2.0.0", // NEW dependency not in lockfile
+      },
+    }),
+  });
+
+  const dockerCwd = String(dockerDir);
+
+  // Should FAIL because the filtered workspace has changes not in the lockfile
+  await using frozenProc = spawn({
+    cmd: [bunExe(), "install", "--frozen-lockfile", "--filter", "app"],
+    cwd: dockerCwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stderr, exitCode] = await Promise.all([frozenProc.stderr.text(), frozenProc.exited]);
+
+  expect(stderr).toContain("lockfile had changes");
+  expect(exitCode).not.toBe(0);
+});
+
+test("frozen lockfile with filter succeeds with literal workspace paths", async () => {
+  // Same as first test but with literal workspace entries instead of globs
+  using dir = tempDir("issue-28402-literal", {
+    "package.json": JSON.stringify({
+      name: "monorepo",
+      private: true,
+      workspaces: ["packages/app", "packages/lib"],
+    }),
+    "packages/app/package.json": JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: {
+        "is-odd": "1.0.0",
+      },
+    }),
+    "packages/lib/package.json": JSON.stringify({
+      name: "lib",
+      version: "1.0.0",
+      dependencies: {
+        "is-even": "1.0.0",
+      },
+    }),
+  });
+
+  const cwd = String(dir);
+
+  await using installProc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  expect(await installProc.exited).toBe(0);
+
+  const lockfileContent = await Bun.file(join(cwd, "bun.lock")).text();
+
+  // Docker pattern with literal paths — only app present
+  using dockerDir = tempDir("issue-28402-literal-docker", {
+    "package.json": JSON.stringify({
+      name: "monorepo",
+      private: true,
+      workspaces: ["packages/app", "packages/lib"],
+    }),
+    "bun.lock": lockfileContent,
+    "packages/app/package.json": JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: {
+        "is-odd": "1.0.0",
+      },
+    }),
+  });
+
+  const dockerCwd = String(dockerDir);
+
+  await using frozenProc = spawn({
+    cmd: [bunExe(), "install", "--frozen-lockfile", "--filter", "app"],
+    cwd: dockerCwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stderr, exitCode] = await Promise.all([frozenProc.stderr.text(), frozenProc.exited]);
+
+  expect(stderr).not.toContain("lockfile had changes");
+  expect(stderr).not.toContain("Workspace not found");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Problem

`bun install --frozen-lockfile --filter <name>` fails in Docker builds when only a subset of workspace `package.json` files are present but `bun.lock` was generated from the full workspace.

This is a common Docker pattern: copy only the needed workspace manifests plus the lockfile, then run a frozen filtered install. npm supports this pattern with `npm ci`.

The install fails with:
```
error: lockfile had changes, but lockfile is frozen
```

## Root Cause

When the lockfile loads successfully, bun re-parses the root `package.json` to discover all workspace packages and diff them against the lockfile. During workspace discovery, `processNamesArray` tries to read every workspace `package.json` listed in the root manifest. Missing files cause errors that propagate up as `error.InstallFailed`, crashing the install before the `--filter` logic even runs.

## Fix

1. **Tolerate missing workspace package.json files** in `processNamesArray` when `--filter` + `--frozen-lockfile` are active — ENOENT/FileNotFound errors are silently skipped (other fs errors like EPERM still report). This lets the differ run even with partial workspace manifests.

2. **Suppress removal-only diffs from missing workspaces** in `install_with_manager.zig` — when `--filter` + `--frozen-lockfile` are active and the only changes are removals, the code counts workspace_paths keys present in the old lockfile but missing in the newly-parsed one. If this count matches `summary.remove`, all removals are from missing workspace manifests and the diff is suppressed.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28402.test.ts` -> **FAIL** (reproduces the bug)
- `bun bd test test/regression/issue/28402.test.ts` -> **PASS** (fix works)

Closes #28402

---

**Verification (robobun, iteration 11):** Commit 7f37c2ed. CI: Build #41093 in progress; previous build #41034 had 1 failure (webview.test.ts timeout on macOS x64 — unrelated to install). Format/Lint JS pass. Diff clean — no TODO/FIXME/HACK markers in added lines, 6 files changed with focused scope. All 4 processNamesArray callsites updated (2 in Package.zig with conditional filter+frozen+loaded_lockfile, 2 in init/migration with false). Diff suppression in install_with_manager.zig correctly guards against false suppression by checking add==0, update==0, no overrides/catalogs/trusted-deps/patches changes, and verifying summary.remove exactly equals missing_workspace_count. Three regression tests exercise: (1) happy path — missing workspace + frozen + filter succeeds, (2) negative path — modified filtered workspace correctly triggers frozen failure, (3) literal workspace paths variant. CodeRabbit paused reviews; last substantive concerns all addressed.