### PR TITLE
fix(install): update root package name in lockfile when renamed in package.json

### DIFF
--- a/src/install/PackageManager/install_with_manager.zig
+++ b/src/install/PackageManager/install_with_manager.zig
@@ -770,8 +770,9 @@ pub fn installWithManager(
     const packages_len_before_install = manager.lockfile.packages.len;
 
     if (manager.options.enable.frozen_lockfile and load_result != .not_found) frozen_lockfile: {
-        if (had_any_diffs) {
-            // hasDiffs() includes dependency, override, catalog, patched dependency, and root name changes
+        if (manager.summary.root_name_changed) {
+            // root name changes are invisible to eql() and hasMetaHashChanged()
+            // because both skip the root package (index 0)
         } else if (load_result.loadedFromTextLockfile()) {
             if (bun.handleOom(manager.lockfile.eql(lockfile_before_clean, packages_len_before_install, manager.allocator))) {
                 break :frozen_lockfile;

--- a/src/install/PackageManager/install_with_manager.zig
+++ b/src/install/PackageManager/install_with_manager.zig
@@ -51,6 +51,7 @@ pub fn installWithManager(
     // this defaults to false
     // but we force allowing updates to the lockfile when you do bun add
     var had_any_diffs = false;
+    var root_name_changed = false;
     manager.progress = .{};
 
     switch (load_result) {
@@ -193,18 +194,32 @@ pub fn installWithManager(
 
                 had_any_diffs = manager.summary.hasDiffs();
 
+                // Check if root package name changed
+                root_name_changed = root.name_hash != maybe_root.name_hash or
+                    (root.name_hash == 0 and maybe_root.name_hash == 0 and
+                    !root.name.eql(maybe_root.name, manager.lockfile.buffers.string_bytes.items, lockfile.buffers.string_bytes.items));
+
                 if (!had_any_diffs) {
-                    // always grab latest scripts for root package
+                    // always grab latest scripts and name for root package
                     var builder_ = manager.lockfile.stringBuilder();
                     var builder = &builder_;
 
                     maybe_root.scripts.count(lockfile.buffers.string_bytes.items, *Lockfile.StringBuilder, builder);
+                    if (root_name_changed) {
+                        const new_name = maybe_root.name.slice(lockfile.buffers.string_bytes.items);
+                        builder.count(new_name);
+                    }
                     try builder.allocate();
                     manager.lockfile.packages.items(.scripts)[0] = maybe_root.scripts.clone(
                         lockfile.buffers.string_bytes.items,
                         *Lockfile.StringBuilder,
                         builder,
                     );
+                    if (root_name_changed) {
+                        const new_name = maybe_root.name.slice(lockfile.buffers.string_bytes.items);
+                        manager.lockfile.packages.items(.name)[0] = builder.append(String, new_name);
+                        manager.lockfile.packages.items(.name_hash)[0] = maybe_root.name_hash;
+                    }
                     builder.clamp();
                 } else {
                     var builder_ = manager.lockfile.stringBuilder();
@@ -224,6 +239,9 @@ pub fn installWithManager(
                     lockfile.overrides.count(&lockfile, builder);
                     lockfile.catalogs.count(&lockfile, builder);
                     maybe_root.scripts.count(lockfile.buffers.string_bytes.items, *Lockfile.StringBuilder, builder);
+                    if (root_name_changed) {
+                        builder.count(maybe_root.name.slice(lockfile.buffers.string_bytes.items));
+                    }
 
                     const off = @as(u32, @truncate(manager.lockfile.buffers.dependencies.items.len));
                     const len = @as(u32, @truncate(new_dependencies.len));
@@ -289,6 +307,12 @@ pub fn installWithManager(
                         *Lockfile.StringBuilder,
                         builder,
                     );
+
+                    if (root_name_changed) {
+                        const new_name = maybe_root.name.slice(lockfile.buffers.string_bytes.items);
+                        manager.lockfile.packages.items(.name)[0] = builder.append(String, new_name);
+                        manager.lockfile.packages.items(.name_hash)[0] = maybe_root.name_hash;
+                    }
 
                     // Update workspace paths
                     try manager.lockfile.workspace_paths.ensureTotalCapacity(manager.lockfile.allocator, lockfile.workspace_paths.entries.len);
@@ -880,6 +904,7 @@ pub fn installWithManager(
         (manager.options.do.save_lockfile and
             (did_meta_hash_change or
                 had_any_diffs or
+                root_name_changed or
                 manager.update_requests.len > 0 or
                 (load_result == .ok and (load_result.ok.serializer_result.packages_need_update or load_result.ok.serializer_result.migrated_from_lockb_v2)) or
                 manager.lockfile.isEmpty() or

--- a/src/install/PackageManager/install_with_manager.zig
+++ b/src/install/PackageManager/install_with_manager.zig
@@ -51,7 +51,6 @@ pub fn installWithManager(
     // this defaults to false
     // but we force allowing updates to the lockfile when you do bun add
     var had_any_diffs = false;
-    var root_name_changed = false;
     manager.progress = .{};
 
     switch (load_result) {
@@ -194,32 +193,18 @@ pub fn installWithManager(
 
                 had_any_diffs = manager.summary.hasDiffs();
 
-                // Check if root package name changed
-                root_name_changed = root.name_hash != maybe_root.name_hash or
-                    (root.name_hash == 0 and maybe_root.name_hash == 0 and
-                    !root.name.eql(maybe_root.name, manager.lockfile.buffers.string_bytes.items, lockfile.buffers.string_bytes.items));
-
                 if (!had_any_diffs) {
-                    // always grab latest scripts and name for root package
+                    // always grab latest scripts for root package
                     var builder_ = manager.lockfile.stringBuilder();
                     var builder = &builder_;
 
                     maybe_root.scripts.count(lockfile.buffers.string_bytes.items, *Lockfile.StringBuilder, builder);
-                    if (root_name_changed) {
-                        const new_name = maybe_root.name.slice(lockfile.buffers.string_bytes.items);
-                        builder.count(new_name);
-                    }
                     try builder.allocate();
                     manager.lockfile.packages.items(.scripts)[0] = maybe_root.scripts.clone(
                         lockfile.buffers.string_bytes.items,
                         *Lockfile.StringBuilder,
                         builder,
                     );
-                    if (root_name_changed) {
-                        const new_name = maybe_root.name.slice(lockfile.buffers.string_bytes.items);
-                        manager.lockfile.packages.items(.name)[0] = builder.append(String, new_name);
-                        manager.lockfile.packages.items(.name_hash)[0] = maybe_root.name_hash;
-                    }
                     builder.clamp();
                 } else {
                     var builder_ = manager.lockfile.stringBuilder();
@@ -239,7 +224,7 @@ pub fn installWithManager(
                     lockfile.overrides.count(&lockfile, builder);
                     lockfile.catalogs.count(&lockfile, builder);
                     maybe_root.scripts.count(lockfile.buffers.string_bytes.items, *Lockfile.StringBuilder, builder);
-                    if (root_name_changed) {
+                    if (manager.summary.root_name_changed) {
                         builder.count(maybe_root.name.slice(lockfile.buffers.string_bytes.items));
                     }
 
@@ -308,7 +293,7 @@ pub fn installWithManager(
                         builder,
                     );
 
-                    if (root_name_changed) {
+                    if (manager.summary.root_name_changed) {
                         const new_name = maybe_root.name.slice(lockfile.buffers.string_bytes.items);
                         manager.lockfile.packages.items(.name)[0] = builder.append(String, new_name);
                         manager.lockfile.packages.items(.name_hash)[0] = maybe_root.name_hash;
@@ -785,7 +770,9 @@ pub fn installWithManager(
     const packages_len_before_install = manager.lockfile.packages.len;
 
     if (manager.options.enable.frozen_lockfile and load_result != .not_found) frozen_lockfile: {
-        if (load_result.loadedFromTextLockfile()) {
+        if (had_any_diffs) {
+            // hasDiffs() includes dependency, override, catalog, patched dependency, and root name changes
+        } else if (load_result.loadedFromTextLockfile()) {
             if (bun.handleOom(manager.lockfile.eql(lockfile_before_clean, packages_len_before_install, manager.allocator))) {
                 break :frozen_lockfile;
             }
@@ -904,7 +891,6 @@ pub fn installWithManager(
         (manager.options.do.save_lockfile and
             (did_meta_hash_change or
                 had_any_diffs or
-                root_name_changed or
                 manager.update_requests.len > 0 or
                 (load_result == .ok and (load_result.ok.serializer_result.packages_need_update or load_result.ok.serializer_result.migrated_from_lockb_v2)) or
                 manager.lockfile.isEmpty() or

--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -943,7 +943,7 @@ pub fn Package(comptime SemverIntType: type) type {
                 if (is_root) {
                     if (from.name_hash != to.name_hash or
                         (from.name_hash == 0 and to.name_hash == 0 and
-                        !from.name.eql(to.name, from_lockfile.buffers.string_bytes.items, to_lockfile.buffers.string_bytes.items)))
+                            !from.name.eql(to.name, from_lockfile.buffers.string_bytes.items, to_lockfile.buffers.string_bytes.items)))
                     {
                         summary.root_name_changed = true;
                     }

--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -538,6 +538,7 @@ pub fn Package(comptime SemverIntType: type) type {
                 removed_trusted_dependencies: TrustedDependenciesSet = .{},
 
                 patched_dependencies_changed: bool = false,
+                root_name_changed: bool = false,
 
                 pub inline fn sum(this: *Summary, that: Summary) void {
                     this.add += that.add;
@@ -549,7 +550,8 @@ pub fn Package(comptime SemverIntType: type) type {
                     return this.add > 0 or this.remove > 0 or this.update > 0 or this.overrides_changed or this.catalogs_changed or
                         this.added_trusted_dependencies.count() > 0 or
                         this.removed_trusted_dependencies.count() > 0 or
-                        this.patched_dependencies_changed;
+                        this.patched_dependencies_changed or
+                        this.root_name_changed;
                 }
             };
 
@@ -935,6 +937,15 @@ pub fn Package(comptime SemverIntType: type) type {
                             // We found a changed life-cycle script
                             summary.update += 1;
                         }
+                    }
+                }
+
+                if (is_root) {
+                    if (from.name_hash != to.name_hash or
+                        (from.name_hash == 0 and to.name_hash == 0 and
+                        !from.name.eql(to.name, from_lockfile.buffers.string_bytes.items, to_lockfile.buffers.string_bytes.items)))
+                    {
+                        summary.root_name_changed = true;
                     }
                 }
 

--- a/test/cli/install/__snapshots__/bun-install.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-install.test.ts.snap
@@ -33,7 +33,7 @@ error: "workspaces.packages" expects an array of strings, e.g.
 "
 `;
 
-exports[`should handle modified git resolutions in bun.lock 1`] = `"{"lockfileVersion":0,"configVersion":1,"workspaces":{"":{"dependencies":{"jquery":"3.7.1"}}},"packages":{"jquery":["jquery@git+ssh://git@github.com/dylan-conway/install-test-8.git#3a1288830817d13da39e9231302261896f8721ea",{},"3a1288830817d13da39e9231302261896f8721ea"]}}"`;
+exports[`should handle modified git resolutions in bun.lock 1`] = `"{"lockfileVersion":0,"configVersion":1,"workspaces":{"":{"name":"foo","dependencies":{"jquery":"3.7.1"}}},"packages":{"jquery":["jquery@git+ssh://git@github.com/dylan-conway/install-test-8.git#3a1288830817d13da39e9231302261896f8721ea",{},"3a1288830817d13da39e9231302261896f8721ea"]}}"`;
 
 exports[`bun-install should report error on invalid format for package.json 1`] = `
 "1 | foo
@@ -68,4 +68,4 @@ error: "workspaces.packages" expects an array of strings, e.g.
 "
 `;
 
-exports[`bun-install should handle modified git resolutions in bun.lock 1`] = `"{"lockfileVersion":0,"configVersion":1,"workspaces":{"":{"dependencies":{"jquery":"3.7.1"}}},"packages":{"jquery":["jquery@git+ssh://git@github.com/dylan-conway/install-test-8.git#3a1288830817d13da39e9231302261896f8721ea",{},"3a1288830817d13da39e9231302261896f8721ea"]}}"`;
+exports[`bun-install should handle modified git resolutions in bun.lock 1`] = `"{"lockfileVersion":0,"configVersion":1,"workspaces":{"":{"name":"foo","dependencies":{"jquery":"3.7.1"}}},"packages":{"jquery":["jquery@git+ssh://git@github.com/dylan-conway/install-test-8.git#3a1288830817d13da39e9231302261896f8721ea",{},"3a1288830817d13da39e9231302261896f8721ea"]}}"`;

--- a/test/cli/install/__snapshots__/bun-lock.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-lock.test.ts.snap
@@ -134,7 +134,7 @@ exports[`should convert a binary lockfile with invalid optional peers 1`] = `
   "configVersion": 0,
   "workspaces": {
     "": {
-      "name": "eassist",
+      "name": "pkg1",
       "dependencies": {
         "langchain": "^0.0.194",
       },

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -8821,6 +8821,7 @@ describe.concurrent("bun-install", () => {
             "configVersion": 1,
             "workspaces": {
               "": {
+                "name": "foo",
                 "dependencies": {
                   "jquery": "3.7.1",
                 },

--- a/test/cli/install/config-version.test.ts
+++ b/test/cli/install/config-version.test.ts
@@ -164,7 +164,7 @@ describe("configVersion", () => {
         "configVersion": 0,
         "workspaces": {
           "": {
-            "name": "new-proj",
+            "name": "root-1",
             "dependencies": {
               "pkg1": "workspace:*",
             },

--- a/test/regression/issue/026039.test.ts
+++ b/test/regression/issue/026039.test.ts
@@ -23,6 +23,7 @@ example = { url = "https://npm.pkg.github.com" }
         lockfileVersion: 1,
         workspaces: {
           "": {
+            name: "test-scoped-registry",
             dependencies: {
               "@example/test-package": "^1.0.0",
             },
@@ -75,6 +76,7 @@ example = { url = "https://npm.pkg.github.com" }
         lockfileVersion: 1,
         workspaces: {
           "": {
+            name: "test-non-scoped-registry",
             dependencies: {
               "fake-nonexistent-package": "^1.0.0",
             },

--- a/test/regression/issue/28411.test.ts
+++ b/test/regression/issue/28411.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 test("bun install updates bun.lock when root package name changes", async () => {

--- a/test/regression/issue/28411.test.ts
+++ b/test/regression/issue/28411.test.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("bun install updates bun.lock when root package name changes", async () => {
+  using dir = tempDir("issue-28411", {
+    "package.json": JSON.stringify({
+      name: "original-name",
+      dependencies: {
+        "is-even": "1.0.0",
+      },
+    }),
+  });
+
+  // Initial install
+  await using proc1 = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc1.exited;
+
+  // Verify initial lockfile has original-name
+  const lockfile1 = await Bun.file(`${dir}/bun.lock`).text();
+  expect(lockfile1).toContain('"name": "original-name"');
+
+  // Rename the package
+  const pkg = JSON.parse(await Bun.file(`${dir}/package.json`).text());
+  pkg.name = "another-name";
+  await Bun.write(`${dir}/package.json`, JSON.stringify(pkg));
+
+  // Re-install
+  await using proc2 = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc2.exited;
+
+  // Verify lockfile now has another-name and not original-name
+  const lockfile2 = await Bun.file(`${dir}/bun.lock`).text();
+  expect(lockfile2).toContain('"name": "another-name"');
+  expect(lockfile2).not.toContain("original-name");
+});
+
+test("bun install updates bun.lock when root package name is added", async () => {
+  using dir = tempDir("issue-28411-add", {
+    "package.json": JSON.stringify({
+      dependencies: {
+        "is-even": "1.0.0",
+      },
+    }),
+  });
+
+  // Initial install (no name)
+  await using proc1 = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc1.exited;
+
+  const lockfile1 = await Bun.file(`${dir}/bun.lock`).text();
+  expect(lockfile1).not.toContain('"name"');
+
+  // Add a name
+  const pkg = JSON.parse(await Bun.file(`${dir}/package.json`).text());
+  pkg.name = "new-name";
+  await Bun.write(`${dir}/package.json`, JSON.stringify(pkg));
+
+  // Re-install
+  await using proc2 = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc2.exited;
+
+  const lockfile2 = await Bun.file(`${dir}/bun.lock`).text();
+  expect(lockfile2).toContain('"name": "new-name"');
+});

--- a/test/regression/issue/28411.test.ts
+++ b/test/regression/issue/28411.test.ts
@@ -87,6 +87,48 @@ test("bun install updates bun.lock when root package name is added", async () =>
   expect(lockfile2).toContain('"name": "new-name"');
 });
 
+test("bun add updates bun.lock when root package name was changed", async () => {
+  using dir = tempDir("issue-28411-add-cmd", {
+    "package.json": JSON.stringify({
+      name: "original-name",
+      dependencies: {
+        "is-even": "1.0.0",
+      },
+    }),
+  });
+
+  // Initial install
+  await using proc1 = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(await proc1.exited).toBe(0);
+
+  const lockfile1 = await Bun.file(`${dir}/bun.lock`).text();
+  expect(lockfile1).toContain('"name": "original-name"');
+
+  // Rename the package and add a new dependency via bun add
+  const pkg = JSON.parse(await Bun.file(`${dir}/package.json`).text());
+  pkg.name = "renamed-pkg";
+  await Bun.write(`${dir}/package.json`, JSON.stringify(pkg));
+
+  await using proc2 = Bun.spawn({
+    cmd: [bunExe(), "add", "is-odd@0.1.2"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(await proc2.exited).toBe(0);
+
+  const lockfile2 = await Bun.file(`${dir}/bun.lock`).text();
+  expect(lockfile2).toContain('"name": "renamed-pkg"');
+  expect(lockfile2).not.toContain("original-name");
+});
+
 test("bun install updates bun.lock when workspace sub-package name changes", async () => {
   using dir = tempDir("issue-28411-ws", {
     "package.json": JSON.stringify({

--- a/test/regression/issue/28411.test.ts
+++ b/test/regression/issue/28411.test.ts
@@ -19,11 +19,12 @@ test("bun install updates bun.lock when root package name changes", async () => 
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(await proc1.exited).toBe(0);
+  const exitCode1 = await proc1.exited;
 
   // Verify initial lockfile has original-name
   const lockfile1 = await Bun.file(`${dir}/bun.lock`).text();
   expect(lockfile1).toContain('"name": "original-name"');
+  expect(exitCode1).toBe(0);
 
   // Rename the package
   const pkg = JSON.parse(await Bun.file(`${dir}/package.json`).text());
@@ -38,12 +39,13 @@ test("bun install updates bun.lock when root package name changes", async () => 
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(await proc2.exited).toBe(0);
+  const exitCode2 = await proc2.exited;
 
   // Verify lockfile now has another-name and not original-name
   const lockfile2 = await Bun.file(`${dir}/bun.lock`).text();
   expect(lockfile2).toContain('"name": "another-name"');
   expect(lockfile2).not.toContain("original-name");
+  expect(exitCode2).toBe(0);
 });
 
 test("bun install updates bun.lock when root package name is added", async () => {
@@ -63,10 +65,11 @@ test("bun install updates bun.lock when root package name is added", async () =>
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(await proc1.exited).toBe(0);
+  const exitCode1 = await proc1.exited;
 
   const lockfile1 = await Bun.file(`${dir}/bun.lock`).text();
   expect(lockfile1).not.toContain('"name"');
+  expect(exitCode1).toBe(0);
 
   // Add a name
   const pkg = JSON.parse(await Bun.file(`${dir}/package.json`).text());
@@ -81,10 +84,11 @@ test("bun install updates bun.lock when root package name is added", async () =>
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(await proc2.exited).toBe(0);
+  const exitCode2 = await proc2.exited;
 
   const lockfile2 = await Bun.file(`${dir}/bun.lock`).text();
   expect(lockfile2).toContain('"name": "new-name"');
+  expect(exitCode2).toBe(0);
 });
 
 test("bun add updates bun.lock when root package name was changed", async () => {
@@ -105,10 +109,11 @@ test("bun add updates bun.lock when root package name was changed", async () => 
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(await proc1.exited).toBe(0);
+  const exitCode1 = await proc1.exited;
 
   const lockfile1 = await Bun.file(`${dir}/bun.lock`).text();
   expect(lockfile1).toContain('"name": "original-name"');
+  expect(exitCode1).toBe(0);
 
   // Rename the package and add a new dependency via bun add
   const pkg = JSON.parse(await Bun.file(`${dir}/package.json`).text());
@@ -122,11 +127,12 @@ test("bun add updates bun.lock when root package name was changed", async () => 
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(await proc2.exited).toBe(0);
+  const exitCode2 = await proc2.exited;
 
   const lockfile2 = await Bun.file(`${dir}/bun.lock`).text();
   expect(lockfile2).toContain('"name": "renamed-pkg"');
   expect(lockfile2).not.toContain("original-name");
+  expect(exitCode2).toBe(0);
 });
 
 test("bun install updates bun.lock when workspace sub-package name changes", async () => {
@@ -152,10 +158,11 @@ test("bun install updates bun.lock when workspace sub-package name changes", asy
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(await proc1.exited).toBe(0);
+  const exitCode1 = await proc1.exited;
 
   const lockfile1 = await Bun.file(`${dir}/bun.lock`).text();
   expect(lockfile1).toContain('"name": "original-name"');
+  expect(exitCode1).toBe(0);
 
   // Rename workspace sub-package
   await Bun.write(
@@ -177,11 +184,12 @@ test("bun install updates bun.lock when workspace sub-package name changes", asy
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(await proc2.exited).toBe(0);
+  const exitCode2 = await proc2.exited;
 
   const lockfile2 = await Bun.file(`${dir}/bun.lock`).text();
   expect(lockfile2).toContain('"name": "another-name"');
   expect(lockfile2).not.toContain('"name": "original-name"');
+  expect(exitCode2).toBe(0);
 });
 
 test("bun install --frozen-lockfile errors when root package name changed", async () => {
@@ -202,7 +210,11 @@ test("bun install --frozen-lockfile errors when root package name changed", asyn
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(await proc1.exited).toBe(0);
+  const exitCode1 = await proc1.exited;
+
+  const lockfileBefore = await Bun.file(`${dir}/bun.lock`).text();
+  expect(lockfileBefore).toContain('"name": "original-name"');
+  expect(exitCode1).toBe(0);
 
   // Rename the package
   const pkg = JSON.parse(await Bun.file(`${dir}/package.json`).text());
@@ -219,5 +231,9 @@ test("bun install --frozen-lockfile errors when root package name changed", asyn
   });
   const stderr = await proc2.stderr.text();
   expect(stderr).toContain("lockfile had changes");
+
+  // Verify the lockfile was NOT modified on disk
+  const lockfileAfter = await Bun.file(`${dir}/bun.lock`).text();
+  expect(lockfileAfter).toBe(lockfileBefore);
   expect(await proc2.exited).not.toBe(0);
 });

--- a/test/regression/issue/28411.test.ts
+++ b/test/regression/issue/28411.test.ts
@@ -19,7 +19,7 @@ test("bun install updates bun.lock when root package name changes", async () => 
     stdout: "pipe",
     stderr: "pipe",
   });
-  await proc1.exited;
+  expect(await proc1.exited).toBe(0);
 
   // Verify initial lockfile has original-name
   const lockfile1 = await Bun.file(`${dir}/bun.lock`).text();
@@ -38,7 +38,7 @@ test("bun install updates bun.lock when root package name changes", async () => 
     stdout: "pipe",
     stderr: "pipe",
   });
-  await proc2.exited;
+  expect(await proc2.exited).toBe(0);
 
   // Verify lockfile now has another-name and not original-name
   const lockfile2 = await Bun.file(`${dir}/bun.lock`).text();
@@ -63,7 +63,7 @@ test("bun install updates bun.lock when root package name is added", async () =>
     stdout: "pipe",
     stderr: "pipe",
   });
-  await proc1.exited;
+  expect(await proc1.exited).toBe(0);
 
   const lockfile1 = await Bun.file(`${dir}/bun.lock`).text();
   expect(lockfile1).not.toContain('"name"');
@@ -81,8 +81,63 @@ test("bun install updates bun.lock when root package name is added", async () =>
     stdout: "pipe",
     stderr: "pipe",
   });
-  await proc2.exited;
+  expect(await proc2.exited).toBe(0);
 
   const lockfile2 = await Bun.file(`${dir}/bun.lock`).text();
   expect(lockfile2).toContain('"name": "new-name"');
+});
+
+test("bun install updates bun.lock when workspace sub-package name changes", async () => {
+  using dir = tempDir("issue-28411-ws", {
+    "package.json": JSON.stringify({
+      name: "my-monorepo",
+      workspaces: ["packages/*"],
+    }),
+    "packages/my-pkg/package.json": JSON.stringify({
+      name: "original-name",
+      version: "1.0.0",
+      dependencies: {
+        "is-even": "1.0.0",
+      },
+    }),
+  });
+
+  // Initial install
+  await using proc1 = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(await proc1.exited).toBe(0);
+
+  const lockfile1 = await Bun.file(`${dir}/bun.lock`).text();
+  expect(lockfile1).toContain('"name": "original-name"');
+
+  // Rename workspace sub-package
+  await Bun.write(
+    `${dir}/packages/my-pkg/package.json`,
+    JSON.stringify({
+      name: "another-name",
+      version: "1.0.0",
+      dependencies: {
+        "is-even": "1.0.0",
+      },
+    }),
+  );
+
+  // Re-install
+  await using proc2 = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(await proc2.exited).toBe(0);
+
+  const lockfile2 = await Bun.file(`${dir}/bun.lock`).text();
+  expect(lockfile2).toContain('"name": "another-name"');
+  expect(lockfile2).not.toContain('"name": "original-name"');
 });

--- a/test/regression/issue/28411.test.ts
+++ b/test/regression/issue/28411.test.ts
@@ -183,3 +183,41 @@ test("bun install updates bun.lock when workspace sub-package name changes", asy
   expect(lockfile2).toContain('"name": "another-name"');
   expect(lockfile2).not.toContain('"name": "original-name"');
 });
+
+test("bun install --frozen-lockfile errors when root package name changed", async () => {
+  using dir = tempDir("issue-28411-frozen", {
+    "package.json": JSON.stringify({
+      name: "original-name",
+      dependencies: {
+        "is-even": "1.0.0",
+      },
+    }),
+  });
+
+  // Initial install
+  await using proc1 = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(await proc1.exited).toBe(0);
+
+  // Rename the package
+  const pkg = JSON.parse(await Bun.file(`${dir}/package.json`).text());
+  pkg.name = "another-name";
+  await Bun.write(`${dir}/package.json`, JSON.stringify(pkg));
+
+  // Frozen lockfile should reject the name change
+  await using proc2 = Bun.spawn({
+    cmd: [bunExe(), "install", "--frozen-lockfile"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stderr = await proc2.stderr.text();
+  expect(stderr).toContain("lockfile had changes");
+  expect(await proc2.exited).not.toBe(0);
+});


### PR DESCRIPTION
Closes #28411

## Problem

When a root package's `"name"` field is changed in `package.json`, running `bun install` does not update the name in `bun.lock`. The lockfile retains the stale old name.

## Root Cause

`Diff.generate` in `Package.zig` only compares dependencies, overrides, catalogs, trusted dependencies, and patched dependencies between the old and new root package. It never compares the package **name**. Since a name-only change produces no diffs, `had_any_diffs` stays false, and the code path that runs when there are no diffs only updates scripts — not the name.

## Fix

After computing the diff, compare `root.name_hash` vs `maybe_root.name_hash`. When they differ:

1. Clone the new name into the lockfile's string buffer
2. Update `name_hash` on the root package entry
3. Include `root_name_changed` in the `should_save_lockfile` condition so the lockfile is written to disk
4. Make `--frozen-lockfile` correctly reject root name changes

Also updated 4 existing test fixtures that had bun.lock entries with names not matching their package.json — these are now correctly detected as name mismatches.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/regression/issue/28411.test.ts  → 4 FAIL (bug exists)
bun bd test test/regression/issue/28411.test.ts                → 5 PASS (fix works)
```

---
Verified by robobun: Code logic confirmed correct — `manager.summary` is directly assigned from `Package.Diff.generate()` (not accumulated via `sum()`), so `root_name_changed` propagates properly. `hasDiffs()` includes `root_name_changed` driving both `should_save_lockfile` and the frozen-lockfile rejection path. Five regression tests cover rename, add-name, bun-add, workspace rename, and frozen-lockfile; all assert exit codes. Both CodeRabbit actionable comments (exit code assertions, workspace test) addressed and confirmed. Autofix commit was cosmetic (import order, Zig indent). Lint JS passed; Buildkite builds compiling with zero failures. No TODO/FIXME/HACK in diff.