### PR TITLE
Fix null pointer deref in Bun.$ lazy init during stack overflow

### DIFF
--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -320,7 +320,7 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
 #if BUN_DEBUG
     if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
 #endif
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
 
@@ -332,7 +332,7 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
 #if BUN_DEBUG
     if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
 #endif
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));
 }
@@ -367,20 +367,20 @@ static JSValue constructBunShell(VM& vm, JSObject* bunObject)
     args.append(createShellInterpreterFunction);
     args.append(createParsedShellScript);
     JSC::JSValue shell = JSC::call(globalObject, createShellFn, args, "BunShell"_s);
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
 
     if (!shell.isObject()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Internal error: BunShell constructor did not return an object"_s);
-        return {};
+        return jsUndefined();
     }
 
     auto* bunShell = shell.getObject();
 
     auto ShellError = bunShell->get(globalObject, JSC::Identifier::fromString(vm, "ShellError"_s));
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
     if (!ShellError.isObject()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Internal error: BunShell.ShellError is not an object"_s);
-        return {};
+        return jsUndefined();
     }
 
     bunShell->putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "braces"_s), 1, Generated::BunObject::jsBraces, ImplementationVisibility::Public, NoIntrinsic, JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | 0);

--- a/test/js/bun/shell/shell-lazy-init-crash.test.ts
+++ b/test/js/bun/shell/shell-lazy-init-crash.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("accessing Bun.$ during stack overflow does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      function F(...a) {
+        if (!new.target) throw 'must be called with new';
+        try { new F(a); } catch (e) {}
+        Bun.$;
+      }
+      try { new F([]); } catch (e) {}
+      console.log("ok");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("ok");
+  expect(exitCode).toBe(0);
+});
+

--- a/test/js/bun/shell/shell-lazy-init-crash.test.ts
+++ b/test/js/bun/shell/shell-lazy-init-crash.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("accessing Bun.$ during stack overflow does not crash", async () => {
@@ -26,4 +26,3 @@ test("accessing Bun.$ during stack overflow does not crash", async () => {
   expect(stdout).toContain("ok");
   expect(exitCode).toBe(0);
 });
-


### PR DESCRIPTION
## Problem

Accessing `Bun.$`, `Bun.sql`, `Bun.postgres`, or `Bun.SQL` during a stack overflow causes a null pointer dereference crash in `JSC::reifyStaticProperty` → `putDirect` → `isGetterSetter()`.

**Fingerprint**: `JSCJSValueCellInlines.h:67:34:member call on null pointer of type 'JSC::JSCell'`

## Root Cause

`constructBunShell` (the `PropertyCallback` for `Bun.$`), `defaultBunSQLObject` (`Bun.sql`/`Bun.postgres`), and `constructBunSQLObject` (`Bun.SQL`) all execute JavaScript during lazy initialization. When a stack overflow exception occurs, `RETURN_IF_EXCEPTION(scope, {})` returns an empty `JSValue` (`{}`).

The caller in WebKit's `Lookup.h:reifyStaticProperty` passes this empty value directly to `putDirect`, which calls `isGetterSetter()` on a null cell pointer:

```cpp
JSValue result = value.lazyPropertyCallback()(vm, &thisObj);
thisObj.putDirect(vm, propertyName, result, ...); // crashes when result is empty
```

## Fix

Return `jsUndefined()` instead of `{}` from all three callbacks' error paths. This gives `putDirect` a valid JSValue while the exception still propagates normally through JSC's exception mechanism.

## Repro

```js
function F(...a) {
  if (!new.target) throw 'must be called with new';
  try { new F(a); } catch (e) {}
  Bun.$;
}
try { new F([]); } catch (e) {}
```

---

**Verification (robobun, iteration 16):** Buildkite #41146 running; all prior builds canceled — none failed on this PR code. Diff: 2 files, 81 lines. BunObject.cpp changes 7 error-return paths from {} to jsUndefined() in 3 PropertyCallback functions. New regression test spawns subprocess triggering stack overflow during Bun.$ lazy init, asserts exit 0 + stdout ok — would segfault on main. No TODO/FIXME/HACK. Claude bot LGTM; CodeRabbit stderr nit non-blocking.