### PR TITLE
fix: return empty blob promise when ByteBlobLoader store is already consumed

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -105,6 +105,7 @@ pub fn toAnyBlob(this: *ByteBlobLoader, globalThis: *JSGlobalObject) ?Blob.Any {
         if (this.offset == 0 and this.remain == store.size() and this.content_type.len == 0) {
             if (store.toAnyBlob()) |blob| {
                 defer store.deref();
+                this.parent().is_closed = true;
                 return blob;
             }
         }
@@ -180,7 +181,9 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    this.parent().is_closed = true;
+    var empty: Blob.Any = .{ .Blob = Blob.initEmpty(globalThis) };
+    return empty.toPromise(globalThis, action);
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/test/js/web/streams/blob-stream-text-after-consume.test.ts
+++ b/test/js/web/streams/blob-stream-text-after-consume.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+
+// Regression test: calling buffered consumption methods on a ReadableStream
+// backed by a Blob after the blob store has already been consumed should
+// return a resolved promise with empty data, not crash with an assertion
+// failure ("Expected an exception to be thrown").
+
+test("calling .text() on a Blob ReadableStream after consume returns empty string", async () => {
+  const blob = new Blob(["hello"]);
+  const stream = blob.stream();
+
+  // First call detaches the blob store
+  stream.blob();
+
+  // Second call should resolve with empty data, not crash
+  const result = await stream.text();
+  expect(result).toBe("");
+});
+
+test("calling .bytes() on a Blob ReadableStream after consume returns empty Uint8Array", async () => {
+  const blob = new Blob(["hello"]);
+  const stream = blob.stream();
+
+  stream.blob();
+
+  const result = await stream.bytes();
+  expect(result).toBeInstanceOf(Uint8Array);
+  expect(result.length).toBe(0);
+});


### PR DESCRIPTION
When calling `.text()`, `.bytes()`, or other buffered consumption methods on a `ReadableStream` backed by a `BlobInternalReadableStreamSource` whose underlying blob store has already been consumed (detached/cleared), `ByteBlobLoader.toBufferedValue` returned `.zero` without setting a JS exception.

This violated the host function contract that returning `.zero` (null JSValue) must always be accompanied by a pending exception, causing an assertion failure: `Expected an exception to be thrown`.

The fix creates an empty blob and resolves the promise with empty data when the store is null, matching the behavior of consuming an empty blob.

**Root cause:** `toAnyBlob()` returns `null` when `this.store` is `null` (already consumed/detached/cleared). The old code path fell through to `return .zero` without throwing.

**Fix:** Instead of returning `.zero`, create an empty `Blob.Any` and call `toPromise()` on it, which returns a properly resolved promise with the appropriate empty value for each action type (empty string for `.text()`, empty `Uint8Array` for `.bytes()`, etc.).

---

Verification (robobun): Commit 99625bb on Build #41365 (pending). Previous build on 925603b had all compilations green; only macOS test failures (darwin-13-x64, darwin-14-aarch64, darwin-13-aarch64) from unrelated webview/lifecycle-script timeouts. Diff is 4 lines in ByteBlobLoader.zig across two hunks: (1) toAnyBlob fast path now sets is_closed=true (fixes pre-existing bug per Jarred-Sumner review), (2) toBufferedValue null-store fallback sets is_closed, creates empty blob, returns resolved promise instead of .zero. Test file (29 lines) exercises the exact crash path: stream.blob() detaches the store, then stream.text()/bytes() hits the null-store fallback that previously returned .zero — these would assert-fail on main. No TODO/FIXME/HACK in added lines. No unrelated changes. All review feedback addressed including Jarred-Sumner is_closed request. CodeRabbit found no issues.