### PR TITLE
Fix SIGFPE in BlockList.estimatedSize during GC

### DIFF
--- a/src/bun.js/node/net/BlockList.zig
+++ b/src/bun.js/node/net/BlockList.zig
@@ -25,7 +25,7 @@ pub fn constructor(globalThis: *jsc.JSGlobalObject, callFrame: *jsc.CallFrame) b
 
 /// May be called from any thread.
 pub fn estimatedSize(this: *@This()) usize {
-    return (@sizeOf(@This()) + this.estimated_size.load(.seq_cst)) / this.ref_count.get();
+    return @sizeOf(@This()) + this.estimated_size.load(.seq_cst);
 }
 
 pub fn finalize(this: *@This()) void {


### PR DESCRIPTION
`BlockList.estimatedSize` divided by `ref_count.get()`, which can be zero when the GC calls `estimatedSize` on an object whose ref_count has already been decremented by another thread. Integer division by zero on x86-64 raises SIGFPE (signal 8).

No other `estimatedSize` implementation in the codebase divides by ref_count — the total memory footprint of the object does not change based on how many references exist. This removes the division.

**Before:**
```zig
return (@sizeOf(@This()) + this.estimated_size.load(.seq_cst)) / this.ref_count.get();
```

**After:**
```zig
return @sizeOf(@This()) + this.estimated_size.load(.seq_cst);
```

---
Verification (robobun): Confirmed main:BlockList.zig line 28 has the division by ref_count.get(); PR removes it. Diff is exactly 2 files (one-line Zig fix + 12-line regression test), no TODO/FIXME/HACK. Verified no other estimatedSize (20+ implementations) divides by ref_count. Test file does not exist on main, uses module-scope import, creates/discards BlockList instances then forces Bun.gc(true) — would SIGFPE on main, survives after fix. CI Build #41170 pending; prior failures were darwin infra issues and bundler_compile.test.ts timeouts, unrelated to BlockList. Bot reviews: CodeRabbit only remaining nit is inline comments in test body (non-blocking style); Claude LGTM multiple rounds.