### PR TITLE
Fix crash in S3 presign with missing credentials

### DIFF
--- a/src/bun.js/webcore/S3Client.zig
+++ b/src/bun.js/webcore/S3Client.zig
@@ -162,9 +162,11 @@ pub const S3Client = struct {
         var aws_options = try S3Credentials.getCredentialsWithOptions(ptr.credentials.*, ptr.options, options, ptr.acl, ptr.storage_class, ptr.request_payer, globalThis);
         defer aws_options.deinit();
 
-        // Normalize the path (strip s3:// prefix, leading slashes)
-        // the same way Store.S3.path() does via URL.parse().s3Path().
-        const s3_path = bun.URL.parse(path.slice()).s3Path();
+        // Normalize the path the same way Store.S3.path() does:
+        // URL.parse().s3Path() then strip one leading slash.
+        var s3_path = bun.URL.parse(path.slice()).s3Path();
+        if (s3_path.len > 0 and (s3_path[0] == '/' or s3_path[0] == '\\'))
+            s3_path = s3_path[1..];
         return S3File.presignFromCredentials(globalThis, s3_path, options, &aws_options);
     }
 

--- a/src/bun.js/webcore/S3Client.zig
+++ b/src/bun.js/webcore/S3Client.zig
@@ -162,7 +162,10 @@ pub const S3Client = struct {
         var aws_options = try S3Credentials.getCredentialsWithOptions(ptr.credentials.*, ptr.options, options, ptr.acl, ptr.storage_class, ptr.request_payer, globalThis);
         defer aws_options.deinit();
 
-        return S3File.presignFromCredentials(globalThis, path.slice(), options, &aws_options);
+        // Normalize the path (strip s3:// prefix, leading slashes)
+        // the same way Store.S3.path() does via URL.parse().s3Path().
+        const s3_path = bun.URL.parse(path.slice()).s3Path();
+        return S3File.presignFromCredentials(globalThis, s3_path, options, &aws_options);
     }
 
     pub fn exists(ptr: *@This(), globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {

--- a/src/bun.js/webcore/S3Client.zig
+++ b/src/bun.js/webcore/S3Client.zig
@@ -151,22 +151,18 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path to presign", .{});
         };
-        errdefer path.deinit();
+        defer path.deinit();
 
         const options = args.nextEat();
 
-        // Validate credentials before constructing the blob to avoid
-        // errors during signRequest that interact badly with deferred cleanup.
+        // Compute credentials and sign the request directly without
+        // constructing a temporary blob. Creating and then cleaning up
+        // a blob store while an error is being thrown from signRequest
+        // corrupts the exception scope chain and crashes during GC.
         var aws_options = try S3Credentials.getCredentialsWithOptions(ptr.credentials.*, ptr.options, options, ptr.acl, ptr.storage_class, ptr.request_payer, globalThis);
         defer aws_options.deinit();
 
-        if (aws_options.credentials.accessKeyId.len == 0 or aws_options.credentials.secretAccessKey.len == 0) {
-            return globalThis.ERR(.S3_MISSING_CREDENTIALS, "Missing S3 credentials. 'accessKeyId', 'secretAccessKey', 'bucket', and 'endpoint' are required", .{}).throw();
-        }
-
-        var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
-        defer blob.detach();
-        return S3File.getPresignUrlFrom(&blob, globalThis, options);
+        return S3File.presignFromCredentials(globalThis, path.slice(), options, &aws_options);
     }
 
     pub fn exists(ptr: *@This(), globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {

--- a/src/bun.js/webcore/S3Client.zig
+++ b/src/bun.js/webcore/S3Client.zig
@@ -159,7 +159,9 @@ pub const S3Client = struct {
         // constructing a temporary blob. Creating and then cleaning up
         // a blob store while an error is being thrown from signRequest
         // corrupts the exception scope chain and crashes during GC.
-        var aws_options = try S3Credentials.getCredentialsWithOptions(ptr.credentials.*, ptr.options, options, ptr.acl, ptr.storage_class, ptr.request_payer, globalThis);
+        // Pass null for acl/storage_class to match the old getPresignUrlFrom
+        // behavior, which only included them when explicitly set in options.
+        var aws_options = try S3Credentials.getCredentialsWithOptions(ptr.credentials.*, ptr.options, options, null, null, ptr.request_payer, globalThis);
         defer aws_options.deinit();
 
         // Normalize the path the same way Store.S3.path() does:

--- a/src/bun.js/webcore/S3Client.zig
+++ b/src/bun.js/webcore/S3Client.zig
@@ -159,9 +159,21 @@ pub const S3Client = struct {
         // constructing a temporary blob. Creating and then cleaning up
         // a blob store while an error is being thrown from signRequest
         // corrupts the exception scope chain and crashes during GC.
-        // Pass null for acl/storage_class to match the old getPresignUrlFrom
-        // behavior, which only included them when explicitly set in options.
-        var aws_options = try S3Credentials.getCredentialsWithOptions(ptr.credentials.*, ptr.options, options, null, null, ptr.request_payer, globalThis);
+        //
+        // Match getPresignUrlFrom behavior: acl/storage_class are only
+        // used as defaults when extra options are provided (the old code
+        // only called s3.getCredentialsWithOptions when extra_options
+        // was non-null). Without options, they default to null.
+        const has_options = options != null and options.?.isObject();
+        var aws_options = try S3Credentials.getCredentialsWithOptions(
+            ptr.credentials.*,
+            ptr.options,
+            options,
+            if (has_options) ptr.acl else null,
+            if (has_options) ptr.storage_class else null,
+            ptr.request_payer,
+            globalThis,
+        );
         defer aws_options.deinit();
 
         // Normalize the path the same way Store.S3.path() does:

--- a/src/bun.js/webcore/S3Client.zig
+++ b/src/bun.js/webcore/S3Client.zig
@@ -154,6 +154,16 @@ pub const S3Client = struct {
         errdefer path.deinit();
 
         const options = args.nextEat();
+
+        // Validate credentials before constructing the blob to avoid
+        // errors during signRequest that interact badly with deferred cleanup.
+        var aws_options = try S3Credentials.getCredentialsWithOptions(ptr.credentials.*, ptr.options, options, ptr.acl, ptr.storage_class, ptr.request_payer, globalThis);
+        defer aws_options.deinit();
+
+        if (aws_options.credentials.accessKeyId.len == 0 or aws_options.credentials.secretAccessKey.len == 0) {
+            return globalThis.ERR(.S3_MISSING_CREDENTIALS, "Missing S3 credentials. 'accessKeyId', 'secretAccessKey', 'bucket', and 'endpoint' are required", .{}).throw();
+        }
+
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
         defer blob.detach();
         return S3File.getPresignUrlFrom(&blob, globalThis, options);

--- a/src/bun.js/webcore/S3Client.zig
+++ b/src/bun.js/webcore/S3Client.zig
@@ -135,7 +135,7 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path", .{});
         };
-        errdefer path.deinit();
+        defer path.deinit();
         const options = args.nextEat();
         var blob = Blob.new(try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer));
         return blob.toJS(globalThis);
@@ -180,7 +180,7 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path to check if it exists", .{});
         };
-        errdefer path.deinit();
+        defer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
         defer blob.detach();
@@ -197,7 +197,7 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path to check the size of", .{});
         };
-        errdefer path.deinit();
+        defer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
         defer blob.detach();
@@ -214,7 +214,7 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path to check the stat of", .{});
         };
-        errdefer path.deinit();
+        defer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
         defer blob.detach();
@@ -228,7 +228,7 @@ pub const S3Client = struct {
         const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             return globalThis.ERR(.MISSING_ARGS, "Expected a path to write to", .{}).throw();
         };
-        errdefer path.deinit();
+        defer path.deinit();
         const data = args.nextEat() orelse {
             return globalThis.ERR(.MISSING_ARGS, "Expected a Blob-y thing to write", .{}).throw();
         };
@@ -262,7 +262,7 @@ pub const S3Client = struct {
         const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             return globalThis.ERR(.MISSING_ARGS, "Expected a path to unlink", .{}).throw();
         };
-        errdefer path.deinit();
+        defer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
         defer blob.detach();
@@ -310,6 +310,7 @@ pub const S3Client = struct {
         const path = (try jsc.Node.PathLike.fromJS(globalThis, &args)) orelse {
             return globalThis.throwInvalidArguments("Expected file path string", .{});
         };
+        defer path.deinit();
 
         return try S3File.constructInternalJS(globalThis, path, args.nextEat());
     }

--- a/src/bun.js/webcore/S3Client.zig
+++ b/src/bun.js/webcore/S3Client.zig
@@ -135,7 +135,7 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path", .{});
         };
-        defer path.deinit();
+        errdefer path.deinit();
         const options = args.nextEat();
         var blob = Blob.new(try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer));
         return blob.toJS(globalThis);
@@ -180,7 +180,7 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path to check if it exists", .{});
         };
-        defer path.deinit();
+        errdefer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
         defer blob.detach();
@@ -197,7 +197,7 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path to check the size of", .{});
         };
-        defer path.deinit();
+        errdefer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
         defer blob.detach();
@@ -214,7 +214,7 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path to check the stat of", .{});
         };
-        defer path.deinit();
+        errdefer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
         defer blob.detach();
@@ -228,7 +228,7 @@ pub const S3Client = struct {
         const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             return globalThis.ERR(.MISSING_ARGS, "Expected a path to write to", .{}).throw();
         };
-        defer path.deinit();
+        errdefer path.deinit();
         const data = args.nextEat() orelse {
             return globalThis.ERR(.MISSING_ARGS, "Expected a Blob-y thing to write", .{}).throw();
         };
@@ -262,7 +262,7 @@ pub const S3Client = struct {
         const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             return globalThis.ERR(.MISSING_ARGS, "Expected a path to unlink", .{}).throw();
         };
-        defer path.deinit();
+        errdefer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
         defer blob.detach();
@@ -310,7 +310,6 @@ pub const S3Client = struct {
         const path = (try jsc.Node.PathLike.fromJS(globalThis, &args)) orelse {
             return globalThis.throwInvalidArguments("Expected file path string", .{});
         };
-        defer path.deinit();
 
         return try S3File.constructInternalJS(globalThis, path, args.nextEat());
     }

--- a/src/bun.js/webcore/S3Client.zig
+++ b/src/bun.js/webcore/S3Client.zig
@@ -163,8 +163,10 @@ pub const S3Client = struct {
         defer aws_options.deinit();
 
         // Normalize the path the same way Store.S3.path() does:
-        // URL.parse().s3Path() then strip one leading slash.
+        // URL.parse().s3Path(), strip trailing backslash, strip leading slash.
         var s3_path = bun.URL.parse(path.slice()).s3Path();
+        if (s3_path.len > 0 and s3_path[s3_path.len - 1] == '\\')
+            s3_path = s3_path[0 .. s3_path.len - 1];
         if (s3_path.len > 0 and (s3_path[0] == '/' or s3_path[0] == '\\'))
             s3_path = s3_path[1..];
         return S3File.presignFromCredentials(globalThis, s3_path, options, &aws_options);

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -83,6 +83,18 @@ pub fn presign(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.J
                 return globalThis.throwInvalidArguments("Expected a S3 or path to presign", .{});
             }
             const options = args.nextEat();
+
+            // Validate credentials before constructing the blob to produce
+            // the error without interaction with deferred blob cleanup.
+            const existing_credentials = globalThis.bunVM().transpiler.env.getS3Credentials();
+            if (existing_credentials.accessKeyId.len == 0 or existing_credentials.secretAccessKey.len == 0) {
+                var aws_options = try S3.S3Credentials.getCredentialsWithOptions(existing_credentials, .{}, options, null, null, false, globalThis);
+                defer aws_options.deinit();
+                if (aws_options.credentials.accessKeyId.len == 0 or aws_options.credentials.secretAccessKey.len == 0) {
+                    return globalThis.ERR(.S3_MISSING_CREDENTIALS, "Missing S3 credentials. 'accessKeyId', 'secretAccessKey', 'bucket', and 'endpoint' are required", .{}).throw();
+                }
+            }
+
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
             defer blob.deinit();
             return try getPresignUrlFrom(&blob, globalThis, options);

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -84,20 +84,15 @@ pub fn presign(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.J
             }
             const options = args.nextEat();
 
-            // Validate credentials before constructing the blob to produce
-            // the error without interaction with deferred blob cleanup.
+            // Compute credentials and sign directly without constructing
+            // a temporary blob. Creating and cleaning up a blob store
+            // while an error is being thrown from signRequest corrupts
+            // the exception scope chain and crashes during GC.
             const existing_credentials = globalThis.bunVM().transpiler.env.getS3Credentials();
-            if (existing_credentials.accessKeyId.len == 0 or existing_credentials.secretAccessKey.len == 0) {
-                var aws_options = try S3.S3Credentials.getCredentialsWithOptions(existing_credentials, .{}, options, null, null, false, globalThis);
-                defer aws_options.deinit();
-                if (aws_options.credentials.accessKeyId.len == 0 or aws_options.credentials.secretAccessKey.len == 0) {
-                    return globalThis.ERR(.S3_MISSING_CREDENTIALS, "Missing S3 credentials. 'accessKeyId', 'secretAccessKey', 'bucket', and 'endpoint' are required", .{}).throw();
-                }
-            }
+            var aws_options = try S3.S3Credentials.getCredentialsWithOptions(existing_credentials, .{}, options, null, null, false, globalThis);
+            defer aws_options.deinit();
 
-            var blob = try constructS3FileInternalStore(globalThis, path.path, options);
-            defer blob.deinit();
-            return try getPresignUrlFrom(&blob, globalThis, options);
+            return try presignFromCredentials(globalThis, path.path.slice(), options, &aws_options);
         },
         .blob => return try getPresignUrlFrom(&path_or_blob.blob, globalThis, args.nextEat()),
     }
@@ -475,6 +470,43 @@ pub const S3BlobStatTask = struct {
         bun.destroy(this);
     }
 };
+
+/// Compute a presigned URL from already-resolved credentials, without
+/// constructing a blob. Used by S3Client.presign and S3File.presign to
+/// avoid the interaction between deferred blob cleanup and error throwing
+/// from signRequest that corrupts the exception scope chain.
+pub fn presignFromCredentials(globalThis: *jsc.JSGlobalObject, request_path: []const u8, extra_options: ?JSValue, credentialsWithOptions: *S3.S3CredentialsWithOptions) bun.JSError!JSValue {
+    var method: bun.http.Method = .GET;
+    var expires: usize = 86400;
+
+    if (extra_options) |options| {
+        if (options.isObject()) {
+            if (try options.getTruthyComptime(globalThis, "method")) |method_| {
+                method = try Method.fromJS(globalThis, method_) orelse {
+                    return globalThis.throwInvalidArguments("method must be GET, PUT, DELETE or HEAD when using s3 protocol", .{});
+                };
+            }
+            if (try options.getOptional(globalThis, "expiresIn", i32)) |expires_| {
+                if (expires_ <= 0) return globalThis.throwInvalidArguments("expiresIn must be greather than 0", .{});
+                expires = @intCast(expires_);
+            }
+        }
+    }
+
+    const result = credentialsWithOptions.credentials.signRequest(.{
+        .path = request_path,
+        .method = method,
+        .acl = credentialsWithOptions.acl,
+        .storage_class = credentialsWithOptions.storage_class,
+        .request_payer = credentialsWithOptions.request_payer,
+        .content_disposition = credentialsWithOptions.content_disposition,
+        .content_type = credentialsWithOptions.content_type,
+    }, false, .{ .expires = expires }) catch |sign_err| {
+        return S3.throwSignError(sign_err, globalThis);
+    };
+    defer result.deinit();
+    return bun.String.createUTF8ForJS(globalThis, result.url);
+}
 
 pub fn getPresignUrlFrom(this: *Blob, globalThis: *jsc.JSGlobalObject, extra_options: ?JSValue) bun.JSError!JSValue {
     if (!this.isS3()) {

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -93,8 +93,10 @@ pub fn presign(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.J
             defer aws_options.deinit();
 
             // Normalize the path the same way Store.S3.path() does:
-            // URL.parse().s3Path() then strip one leading slash.
+            // URL.parse().s3Path(), strip trailing backslash, strip leading slash.
             var s3_path = bun.URL.parse(path.path.slice()).s3Path();
+            if (s3_path.len > 0 and s3_path[s3_path.len - 1] == '\\')
+                s3_path = s3_path[0 .. s3_path.len - 1];
             if (s3_path.len > 0 and (s3_path[0] == '/' or s3_path[0] == '\\'))
                 s3_path = s3_path[1..];
             return try presignFromCredentials(globalThis, s3_path, options, &aws_options);

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -92,9 +92,11 @@ pub fn presign(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.J
             var aws_options = try S3.S3Credentials.getCredentialsWithOptions(existing_credentials, .{}, options, null, null, false, globalThis);
             defer aws_options.deinit();
 
-            // Normalize the path (strip s3:// prefix, leading slashes)
-            // the same way Store.S3.path() does via URL.parse().s3Path().
-            const s3_path = bun.URL.parse(path.path.slice()).s3Path();
+            // Normalize the path the same way Store.S3.path() does:
+            // URL.parse().s3Path() then strip one leading slash.
+            var s3_path = bun.URL.parse(path.path.slice()).s3Path();
+            if (s3_path.len > 0 and (s3_path[0] == '/' or s3_path[0] == '\\'))
+                s3_path = s3_path[1..];
             return try presignFromCredentials(globalThis, s3_path, options, &aws_options);
         },
         .blob => return try getPresignUrlFrom(&path_or_blob.blob, globalThis, args.nextEat()),

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -487,7 +487,7 @@ pub fn presignFromCredentials(globalThis: *jsc.JSGlobalObject, request_path: []c
                 };
             }
             if (try options.getOptional(globalThis, "expiresIn", i32)) |expires_| {
-                if (expires_ <= 0) return globalThis.throwInvalidArguments("expiresIn must be greather than 0", .{});
+                if (expires_ <= 0) return globalThis.throwInvalidArguments("expiresIn must be greater than 0", .{});
                 expires = @intCast(expires_);
             }
         }
@@ -533,7 +533,7 @@ pub fn getPresignUrlFrom(this: *Blob, globalThis: *jsc.JSGlobalObject, extra_opt
                 };
             }
             if (try options.getOptional(globalThis, "expiresIn", i32)) |expires_| {
-                if (expires_ <= 0) return globalThis.throwInvalidArguments("expiresIn must be greather than 0", .{});
+                if (expires_ <= 0) return globalThis.throwInvalidArguments("expiresIn must be greater than 0", .{});
                 expires = @intCast(expires_);
             }
         }

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -110,7 +110,7 @@ pub fn unlink(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
-    errdefer {
+    defer {
         if (path_or_blob == .path) {
             path_or_blob.path.deinit();
         }
@@ -142,7 +142,7 @@ pub fn write(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSE
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
-    errdefer {
+    defer {
         if (path_or_blob == .path) {
             path_or_blob.path.deinit();
         }
@@ -185,7 +185,7 @@ pub fn size(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
-    errdefer {
+    defer {
         if (path_or_blob == .path) {
             path_or_blob.path.deinit();
         }
@@ -218,7 +218,7 @@ pub fn exists(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
-    errdefer {
+    defer {
         if (path_or_blob == .path) {
             path_or_blob.path.deinit();
         }
@@ -608,7 +608,7 @@ pub fn stat(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
-    errdefer {
+    defer {
         if (path_or_blob == .path) {
             path_or_blob.path.deinit();
         }

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -67,7 +67,7 @@ pub fn presign(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.J
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
-    errdefer {
+    defer {
         if (path_or_blob == .path) {
             path_or_blob.path.deinit();
         }
@@ -92,7 +92,10 @@ pub fn presign(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.J
             var aws_options = try S3.S3Credentials.getCredentialsWithOptions(existing_credentials, .{}, options, null, null, false, globalThis);
             defer aws_options.deinit();
 
-            return try presignFromCredentials(globalThis, path.path.slice(), options, &aws_options);
+            // Normalize the path (strip s3:// prefix, leading slashes)
+            // the same way Store.S3.path() does via URL.parse().s3Path().
+            const s3_path = bun.URL.parse(path.path.slice()).s3Path();
+            return try presignFromCredentials(globalThis, s3_path, options, &aws_options);
         },
         .blob => return try getPresignUrlFrom(&path_or_blob.blob, globalThis, args.nextEat()),
     }

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -553,6 +553,7 @@ pub fn getPresignUrlFrom(this: *Blob, globalThis: *jsc.JSGlobalObject, extra_opt
         .request_payer = credentialsWithOptions.request_payer,
         .content_disposition = credentialsWithOptions.content_disposition,
         .content_type = credentialsWithOptions.content_type,
+        .content_encoding = credentialsWithOptions.content_encoding,
     }, false, .{ .expires = expires }) catch |sign_err| {
         return S3.throwSignError(sign_err, globalThis);
     };

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -504,6 +504,7 @@ pub fn presignFromCredentials(globalThis: *jsc.JSGlobalObject, request_path: []c
         .request_payer = credentialsWithOptions.request_payer,
         .content_disposition = credentialsWithOptions.content_disposition,
         .content_type = credentialsWithOptions.content_type,
+        .content_encoding = credentialsWithOptions.content_encoding,
     }, false, .{ .expires = expires }) catch |sign_err| {
         return S3.throwSignError(sign_err, globalThis);
     };

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -110,7 +110,7 @@ pub fn unlink(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
-    defer {
+    errdefer {
         if (path_or_blob == .path) {
             path_or_blob.path.deinit();
         }
@@ -142,7 +142,7 @@ pub fn write(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSE
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
-    defer {
+    errdefer {
         if (path_or_blob == .path) {
             path_or_blob.path.deinit();
         }
@@ -185,7 +185,7 @@ pub fn size(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
-    defer {
+    errdefer {
         if (path_or_blob == .path) {
             path_or_blob.path.deinit();
         }
@@ -218,7 +218,7 @@ pub fn exists(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
-    defer {
+    errdefer {
         if (path_or_blob == .path) {
             path_or_blob.path.deinit();
         }
@@ -608,7 +608,7 @@ pub fn stat(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
-    defer {
+    errdefer {
         if (path_or_blob == .path) {
             path_or_blob.path.deinit();
         }

--- a/src/s3/credentials.zig
+++ b/src/s3/credentials.zig
@@ -156,7 +156,7 @@ pub const S3Credentials = struct {
                                 new_credentials.changed_credentials = true;
                             }
                         } else {
-                            return globalObject.throwInvalidArgumentTypeValue("bucket", "string", js_value);
+                            return globalObject.throwInvalidArgumentTypeValue("sessionToken", "string", js_value);
                         }
                     }
                 }

--- a/test/js/bun/s3/s3-presign-missing-credentials.test.ts
+++ b/test/js/bun/s3/s3-presign-missing-credentials.test.ts
@@ -42,8 +42,6 @@ test("S3 presign with missing credentials throws instead of crashing", async () 
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout.trim()).toBe(
-    "ERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nok",
-  );
+  expect(stdout.trim()).toBe("ERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nok");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/s3/s3-presign-missing-credentials.test.ts
+++ b/test/js/bun/s3/s3-presign-missing-credentials.test.ts
@@ -42,7 +42,8 @@ test("S3 presign with missing credentials throws instead of crashing", async () 
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout.trim()).toBe("ERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nok");
-  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe(
+    "ERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nok",
+  );
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/s3/s3-presign-missing-credentials.test.ts
+++ b/test/js/bun/s3/s3-presign-missing-credentials.test.ts
@@ -42,6 +42,7 @@ test("S3 presign with missing credentials throws instead of crashing", async () 
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect(stderr).not.toContain("error:");
   expect(stdout.trim()).toBe("ERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nok");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/s3/s3-presign-missing-credentials.test.ts
+++ b/test/js/bun/s3/s3-presign-missing-credentials.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 // Regression test: S3 presign with missing credentials should throw
 // ERR_S3_MISSING_CREDENTIALS instead of crashing.

--- a/test/js/bun/s3/s3-presign-missing-credentials.test.ts
+++ b/test/js/bun/s3/s3-presign-missing-credentials.test.ts
@@ -1,23 +1,49 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 // Regression test: S3 presign with missing credentials should throw
 // ERR_S3_MISSING_CREDENTIALS instead of crashing.
-test("Bun.s3.presign throws with missing credentials", () => {
-  expect(() => Bun.s3.presign("test-path")).toThrow("Missing S3 credentials");
-});
 
-test("new S3Client().presign throws with missing credentials", () => {
-  const client = new Bun.S3Client();
-  expect(() => client.presign("test-path")).toThrow("Missing S3 credentials");
-});
+// Spawn subprocesses with S3 credential env vars explicitly unset so
+// the tests are not affected by ambient AWS credentials in the host.
+const cleanEnv = {
+  ...bunEnv,
+  AWS_ACCESS_KEY_ID: undefined,
+  AWS_SECRET_ACCESS_KEY: undefined,
+  S3_ACCESS_KEY_ID: undefined,
+  S3_SECRET_ACCESS_KEY: undefined,
+  AWS_SESSION_TOKEN: undefined,
+  S3_SESSION_TOKEN: undefined,
+  S3_ENDPOINT: undefined,
+  S3_BUCKET: undefined,
+  S3_REGION: undefined,
+  AWS_ENDPOINT: undefined,
+  AWS_BUCKET: undefined,
+  AWS_REGION: undefined,
+};
 
-test("S3Client.presign static throws with missing credentials", () => {
-  expect(() => Bun.S3Client.presign("test-path")).toThrow("Missing S3 credentials");
-});
+test("S3 presign with missing credentials throws instead of crashing", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `
+      try { Bun.s3.presign("test-path"); } catch(e) { console.log(e.code); }
+      try { new Bun.S3Client().presign("test-path"); } catch(e) { console.log(e.code); }
+      try { Bun.S3Client.presign("test-path"); } catch(e) { console.log(e.code); }
+      Bun.gc(true);
+      console.log("ok");
+    `],
+    env: cleanEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-test("S3 presign with missing credentials does not crash on GC", () => {
-  try {
-    Bun.s3.presign("test-path");
-  } catch {}
-  Bun.gc(true);
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  expect(stdout.trim()).toBe(
+    "ERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nok",
+  );
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/s3/s3-presign-missing-credentials.test.ts
+++ b/test/js/bun/s3/s3-presign-missing-credentials.test.ts
@@ -46,9 +46,7 @@ test("S3 presign with missing credentials throws instead of crashing", async () 
     proc.exited,
   ]);
 
-  expect(stdout.trim()).toBe(
-    "ERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nok",
-  );
+  expect(stdout.trim()).toBe("ERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nok");
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/s3/s3-presign-missing-credentials.test.ts
+++ b/test/js/bun/s3/s3-presign-missing-credentials.test.ts
@@ -40,11 +40,7 @@ test("S3 presign with missing credentials throws instead of crashing", async () 
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout.trim()).toBe("ERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nok");
   expect(stderr).toBe("");

--- a/test/js/bun/s3/s3-presign-missing-credentials.test.ts
+++ b/test/js/bun/s3/s3-presign-missing-credentials.test.ts
@@ -41,8 +41,8 @@ test("S3 presign with missing credentials throws instead of crashing", async () 
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
+    proc.stdout.text(),
+    proc.stderr.text(),
     proc.exited,
   ]);
 

--- a/test/js/bun/s3/s3-presign-missing-credentials.test.ts
+++ b/test/js/bun/s3/s3-presign-missing-credentials.test.ts
@@ -24,13 +24,17 @@ const cleanEnv = {
 
 test("S3 presign with missing credentials throws instead of crashing", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       try { Bun.s3.presign("test-path"); } catch(e) { console.log(e.code); }
       try { new Bun.S3Client().presign("test-path"); } catch(e) { console.log(e.code); }
       try { Bun.S3Client.presign("test-path"); } catch(e) { console.log(e.code); }
       Bun.gc(true);
       console.log("ok");
-    `],
+    `,
+    ],
     env: cleanEnv,
     stdout: "pipe",
     stderr: "pipe",
@@ -42,8 +46,6 @@ test("S3 presign with missing credentials throws instead of crashing", async () 
     proc.exited,
   ]);
 
-  expect(stdout.trim()).toBe(
-    "ERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nok",
-  );
+  expect(stdout.trim()).toBe("ERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nok");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/s3/s3-presign-missing-credentials.test.ts
+++ b/test/js/bun/s3/s3-presign-missing-credentials.test.ts
@@ -46,6 +46,9 @@ test("S3 presign with missing credentials throws instead of crashing", async () 
     proc.exited,
   ]);
 
-  expect(stdout.trim()).toBe("ERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nok");
+  expect(stdout.trim()).toBe(
+    "ERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nERR_S3_MISSING_CREDENTIALS\nok",
+  );
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/s3/s3-presign-missing-credentials.test.ts
+++ b/test/js/bun/s3/s3-presign-missing-credentials.test.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "bun:test";
+
+// Regression test: S3 presign with missing credentials should throw
+// ERR_S3_MISSING_CREDENTIALS instead of crashing.
+test("Bun.s3.presign throws with missing credentials", () => {
+  expect(() => Bun.s3.presign("test-path")).toThrow("Missing S3 credentials");
+});
+
+test("new S3Client().presign throws with missing credentials", () => {
+  const client = new Bun.S3Client();
+  expect(() => client.presign("test-path")).toThrow("Missing S3 credentials");
+});
+
+test("S3Client.presign static throws with missing credentials", () => {
+  expect(() => Bun.S3Client.presign("test-path")).toThrow("Missing S3 credentials");
+});
+
+test("S3 presign with missing credentials does not crash on GC", () => {
+  try {
+    Bun.s3.presign("test-path");
+  } catch {}
+  Bun.gc(true);
+});


### PR DESCRIPTION
Calling `Bun.s3.presign()`, `new Bun.S3Client().presign()`, or `Bun.S3Client.presign()` without configured S3 credentials caused a crash (SIGFPE / division by zero in `StringImpl::costDuringGC`) during garbage collection.

The root cause: when `signRequest` returned `error.MissingCredentials`, the error was thrown via `throwSignError` while a stack-allocated blob with deferred cleanup was still alive. The interaction between the error throw path and the deferred blob/store cleanup corrupted the exception scope chain, leaving a `StringImpl` with a zero refcount that was later visited during GC.

The fix avoids blob construction entirely for the path-based presign case: credentials are resolved via `getCredentialsWithOptions` first, then `presignFromCredentials` signs the request directly. This eliminates the problematic interaction between deferred blob cleanup and error throwing from `signRequest`.

Minimal repro:
```js
try { Bun.s3.presign("X"); } catch (e) {}
Bun.gc(true);
```

---
Verification (robobun, iteration 11): Build #41219 on commit 33ddd8a is pending. Prior Build #41193 failures were all in bundler_compile.test.ts (Linux timeouts/code 1) and webview-chrome.test.ts — completely unrelated to S3 (PR only touches S3Client.zig, S3File.zig, and the new S3 test). No TODO/FIXME/HACK in added lines. Diff reviewed: S3Client.zig errdefer→defer path leak fix + direct credential resolution bypassing blob construction; S3File.zig same pattern + new presignFromCredentials helper including content_encoding, typo fix greather→greater, content_encoding added to getPresignUrlFrom for parity. Test spawns isolated subprocess clearing 12 AWS/S3 env vars, exercises all 3 presign APIs + Bun.gc(true), asserts ERR_S3_MISSING_CREDENTIALS and exit 0 — would SIGFPE on main. All 4 CodeRabbit actionable items resolved.

---
Verification (robobun, final review): CI Build #41316 on latest commit be37445 is in progress (Lint JavaScript passed, Format/Buildkite pending). Prior Build #41219 on 33ddd8a had failures in darwin/linux test-bun jobs, not in any S3 test. No TODO/FIXME/HACK in added lines. Diff verified: S3Client.zig presign() bypasses blob construction, resolves credentials via getCredentialsWithOptions + signs via presignFromCredentials directly; all errdefer→defer for PathLike cleanup is correct (initS3 copies path via toThreadSafe, original must always free). S3File.zig same direct-credential pattern + new presignFromCredentials helper with content_encoding, getPresignUrlFrom gets content_encoding for parity, greather→greater typo fixed. Test is a genuine regression test: subprocess clears 12 AWS/S3 env vars, exercises Bun.s3.presign + new S3Client().presign + S3Client.presign, asserts ERR_S3_MISSING_CREDENTIALS for each, forces Bun.gc(true) (the crash trigger on main), asserts exit 0 and no error in stderr. Both CodeRabbit actionable items (typo + content_encoding) resolved in current diff.

---
Verification (robobun, iteration 7): Commit 66a46dd (CI retry, zero code diff from dae75e49). Build #41372 pending; prior Build #41357 failures were all bundler_compile.test.ts timeouts/code-1 on Linux — completely unrelated to S3. Lint JavaScript passed. No TODO/FIXME/HACK in added lines. Diff: S3Client.zig and S3File.zig presign() bypass blob construction, resolve credentials via getCredentialsWithOptions, sign via new presignFromCredentials helper; errdefer→defer correct since path is never consumed. content_encoding added to both signing paths, greather→greater typo fixed. Regression test spawns subprocess with 12 AWS/S3 env vars cleared, exercises all 3 presign APIs + Bun.gc(true), asserts ERR_S3_MISSING_CREDENTIALS and exit 0 — would SIGFPE on main.

---
Verification (robobun, iteration 7 final): CI Build #41378 on commit a53d6a7 is pending. Prior builds (41357, 41372) had failures only in generic test-bun steps (bundler_compile.test.ts timeouts on Linux aarch64/x64, Darwin expired) — zero S3-related failures across all builds. Lint JavaScript and Format passed on prior commits. No TODO/FIXME/HACK in added lines. Diff (3 files, 190 lines): S3Client.zig and S3File.zig presign() bypass blob construction and resolve credentials directly via getCredentialsWithOptions + new presignFromCredentials helper, eliminating the deferred-blob-cleanup/error-throw interaction that caused SIGFPE. errdefer→defer correct since path ownership never transfers. content_encoding added to both signing paths for parity. greather→greater typo fixed. Latest commit adds trailing backslash stripping to match Store.S3.path() normalization. Regression test spawns isolated subprocess with 12 AWS/S3 env vars cleared, exercises all 3 presign APIs (Bun.s3, new S3Client(), S3Client.presign) + Bun.gc(true), asserts ERR_S3_MISSING_CREDENTIALS and exit 0 — would SIGFPE on main. CodeRabbit reviews resolved.

---
Verification (robobun, iteration 14): CI on commit eace518 — Lint JavaScript passed, Format and Buildkite Build #41470 pending. Prior builds across this PR had zero S3-related failures; all failures were in bundler_compile.test.ts (Linux timeouts) and webview-chrome.test.ts — completely unrelated. No TODO/FIXME/HACK in added lines. Diff (4 files, 203 lines): S3Client.zig and S3File.zig presign() bypass blob construction entirely, resolving credentials via getCredentialsWithOptions and signing via new presignFromCredentials helper — eliminates deferred-blob-cleanup/error-throw interaction for ALL signRequest errors, not just MissingCredentials. errdefer→defer correct since path ownership never transfers. content_encoding added to both signing paths. greather→greater typo fixed. credentials.zig fixes pre-existing copy-paste bug (bucket→sessionToken in error message). Regression test spawns isolated subprocess with 12 AWS/S3 env vars cleared, exercises all 3 presign APIs + Bun.gc(true), asserts ERR_S3_MISSING_CREDENTIALS and exit 0 — would SIGFPE on main. CodeRabbit actionable items resolved. Claude reviews all LGTM.

---
Verification (robobun, iteration 21): CI Build #41543 on HEAD 45e975d pending (Lint JavaScript passed). Prior Build #41535 on 29db14d completed with 3 failures: webview-chrome.test.ts and regression/issue/24364.test.ts — zero S3-related failures. No TODO/FIXME/HACK in added lines. Diff (4 files): S3Client.zig and S3File.zig presign() bypass blob construction, resolve credentials via getCredentialsWithOptions, sign via presignFromCredentials helper; errdefer→defer correct since path never transfers ownership. content_encoding added to both signing paths. greather→greater typo fixed. credentials.zig fixes copy-paste bug (bucket→sessionToken). Regression test spawns subprocess with 12 AWS/S3 env vars cleared, exercises all 3 presign APIs + Bun.gc(true), asserts ERR_S3_MISSING_CREDENTIALS and exit 0 — would SIGFPE on main. CodeRabbit actionable items resolved.

---
Verification (robobun, iteration 24): CI Build #41572 on HEAD a33b019 in progress (Lint JavaScript passed). Prior Build #41559 on 2d52389 (identical code) failures: node-http-backpressure-max, webview, test-stdin-pipe-large, regression/issue/24364, bun-types — zero S3-related. Diff verified: S3Client.zig and S3File.zig presign() bypass blob construction, resolve credentials via getCredentialsWithOptions, sign via presignFromCredentials; errdefer→defer correct since path never transfers ownership. credentials.zig fixes copy-paste bug. Regression test exercises all 3 presign APIs + Bun.gc(true), asserts ERR_S3_MISSING_CREDENTIALS and exit 0. No TODO/FIXME/HACK.