### PR TITLE
fix: use isObject() instead of isCell() for dns.lookup options check

### DIFF
--- a/src/bun.js/api/bun/dns.zig
+++ b/src/bun.js/api/bun/dns.zig
@@ -2719,7 +2719,7 @@ pub const Resolver = struct {
         var options = GetAddrInfo.Options{};
         var port: u16 = 0;
 
-        if (arguments.len > 1 and arguments.ptr[1].isCell()) {
+        if (arguments.len > 1 and arguments.ptr[1].isObject()) {
             const optionsObject = arguments.ptr[1];
 
             if (try optionsObject.getTruthy(globalThis, "port")) |port_value| {

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -112,4 +112,13 @@ describe("dns", () => {
       });
     });
   });
+
+  test("lookup with non-object second argument should not crash", async () => {
+    // Non-object cell values (like strings) passed as options should be ignored, not crash.
+    // @ts-expect-error
+    const result = await dns.lookup("localhost", "cat");
+    expect(result).toBeArray();
+    expect(result.length).toBeGreaterThan(0);
+    expect(isIP(result[0].address)).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
When `Bun.dns.lookup()` receives a non-object cell (e.g. a string) as the second argument, the `isCell()` guard at line 2722 passes, but then `getTruthy()` calls `JSValue.get()` which asserts `target.isObject()`, causing a crash.

The fix changes the guard from `isCell()` to `isObject()` so non-object cells are properly skipped as options arguments.

**Root cause:** `isCell()` returns true for strings and other non-object JS cells, but `JSValue.get()` requires the target to be an actual object.

**Repro:**
```js
const dns = Bun.dns;
dns.lookup("127.0.0.1", "cat");
```

---

Verification (iteration 6): CI build #41167 pending (Lint JS passed); previous build #41087 failures were only webview.test.ts (macOS timeout) and bundler_compile.test.ts (Linux timeout), both unrelated to DNS. Diff is a single-line guard change isCell()->isObject() in dns.zig and a regression test that exercises the exact crash path (string arg triggers debugAssert in JSValue.get on main). All 3 review threads resolved. No TODO/FIXME/HACK in diff, no unrelated changes.