### PR TITLE
Fix assertion crash when hostname/unix coerces to empty string

### DIFF
--- a/src/bun.js/api/bun/socket/Handlers.zig
+++ b/src/bun.js/api/bun/socket/Handlers.zig
@@ -300,7 +300,7 @@ pub const SocketConfig = struct {
         if (result.fd != null) {
             // If a user passes a file descriptor then prefer it over hostname or unix
         } else if (generated.unix_.get()) |unix| {
-            bun.assertf(unix.length() > 0, "truthy bindgen string shouldn't be empty", .{});
+            if (unix.length() == 0) return global.throwInvalidArguments("Expected a non-empty \"unix\" path", .{});
             result.hostname_or_unix = unix.toUTF8(bun.default_allocator);
             const slice = result.hostname_or_unix.slice();
             if (strings.hasPrefixComptime(slice, "file://") or
@@ -312,7 +312,7 @@ pub const SocketConfig = struct {
                 result.hostname_or_unix = .init(bun.default_allocator, without_prefix);
             }
         } else if (generated.hostname.get()) |hostname| {
-            bun.assertf(hostname.length() > 0, "truthy bindgen string shouldn't be empty", .{});
+            if (hostname.length() == 0) return global.throwInvalidArguments("Expected a non-empty \"hostname\"", .{});
             result.hostname_or_unix = hostname.toUTF8(bun.default_allocator);
             const slice = result.hostname_or_unix.slice();
             result.port = generated.port orelse bun.URL.parse(slice).getPort() orelse {

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -796,6 +796,8 @@ it("should throw on empty hostname from truthy non-string value", () => {
 
 it("should throw on empty unix path from truthy non-string value", () => {
   const socket = { data() {}, open() {}, close() {} };
-  expect(() => Bun.listen({ unix: [] as any, socket })).toThrow();
-  expect(() => Bun.connect({ unix: [] as any, socket })).toThrow();
+  // unix uses a strict string type in bindgen, so non-string values are rejected before
+  // reaching the empty-string check — the error message differs from hostname
+  expect(() => Bun.listen({ unix: [] as any, socket })).toThrow("SocketOptions.unix must be a string");
+  expect(() => Bun.connect({ unix: [] as any, socket })).toThrow("SocketOptions.unix must be a string");
 });

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -787,9 +787,7 @@ it("should throw on empty hostname from truthy non-string value", () => {
   const socket = { data() {}, open() {}, close() {} };
   // A truthy value whose toString() returns "" should throw, not crash
   for (const hostname of [[], new String("")]) {
-    expect(() => Bun.listen({ hostname: hostname as any, port: 0, socket })).toThrow(
-      'Expected a non-empty "hostname"',
-    );
+    expect(() => Bun.listen({ hostname: hostname as any, port: 0, socket })).toThrow('Expected a non-empty "hostname"');
     expect(() => Bun.connect({ hostname: hostname as any, port: 0, socket })).toThrow(
       'Expected a non-empty "hostname"',
     );

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -782,3 +782,22 @@ it("should not leak memory", async () => {
 it("should not leak memory when connect() fails again", async () => {
   await expectMaxObjectTypeCount(expect, "TCPSocket", 5, 50);
 });
+
+it("should throw on empty hostname from truthy non-string value", () => {
+  const socket = { data() {}, open() {}, close() {} };
+  // A truthy value whose toString() returns "" should throw, not crash
+  for (const hostname of [[], new String("")]) {
+    expect(() => Bun.listen({ hostname: hostname as any, port: 0, socket })).toThrow(
+      'Expected a non-empty "hostname"',
+    );
+    expect(() => Bun.connect({ hostname: hostname as any, port: 0, socket })).toThrow(
+      'Expected a non-empty "hostname"',
+    );
+  }
+});
+
+it("should throw on empty unix path from truthy non-string value", () => {
+  const socket = { data() {}, open() {}, close() {} };
+  expect(() => Bun.listen({ unix: [] as any, socket })).toThrow();
+  expect(() => Bun.connect({ unix: [] as any, socket })).toThrow();
+});


### PR DESCRIPTION
`Bun.listen()` and `Bun.connect()` crash with an internal assertion failure when the `hostname` (or `unix`) option is a truthy value whose `toString()` returns an empty string — for example, an empty array `[]` or `new String("")`.

**Root cause:** The bindgen `IDLLooseNullable` conversion checks the truthiness of the original JS value (objects are truthy), then calls `toString()` to get a `WTF::String`. When `toString()` produces `""`, the result is a non-null `WTFStringImpl*` (the static empty string singleton) with `length == 0`. The Zig code then hits `assertf(hostname.length() > 0, "truthy bindgen string should not be empty")`.

**Fix:** Replace the assertions with proper validation that returns a `TypeError` when the coerced string is empty.

**Repro:**
```js
Bun.listen({ hostname: [], port: 0, socket: { data(){}, open(){}, close(){} } });
// Before: panic — "Internal assertion failure: truthy bindgen string should not be empty"
// After:  TypeError — Expected a non-empty "hostname"
```

---

🔍 **Verified by robobun**: Zig fix at Handlers.zig lines 303 and 315 replaces `bun.assertf` panics with `throwInvalidArguments` error returns — matches the existing pattern in the same function (line 319). Return type `bun.JSError!SocketConfig` supports this. On main, these lines have `bun.assertf(...)` which crashes. Regression test at socket.test.ts lines 786-803 exercises the exact crash path with `[]` and `new String("")` as hostname — both are truthy but `toString()` returns `""`. Would crash on main; does not exist on main. Unix test correctly asserts the bindgen-layer rejection message. Lint JavaScript passed. Buildkite build #41227 in progress. No TODO/FIXME/HACK in diff. CodeRabbit actionable comment addressed. Claude Code Review LGTM.