### PR TITLE
Fix crash when SharedArrayBuffer-backed TypedArray is passed to IDLArrayBufferRef converter

### DIFF
--- a/src/jsc/bindings/BunIDLConvert.h
+++ b/src/jsc/bindings/BunIDLConvert.h
@@ -189,10 +189,18 @@ template<> struct WebCore::Converter<Bun::IDLArrayBufferRef>
             return jsBuffer;
         }
         if (auto* jsView = dynamicDowncast<JSC::JSArrayBufferView>(value)) {
-            return jsView->unsharedBuffer();
+            if (jsView->isShared())
+                return std::nullopt;
+            if (auto* buf = jsView->unsharedBuffer())
+                return buf;
+            return std::nullopt;
         }
         if (auto* jsDataView = dynamicDowncast<JSC::JSDataView>(value)) {
-            return jsDataView->unsharedBuffer();
+            if (jsDataView->isShared())
+                return std::nullopt;
+            if (auto* buf = jsDataView->unsharedBuffer())
+                return buf;
+            return std::nullopt;
         }
         return std::nullopt;
     }

--- a/src/jsc/bindings/BunIDLConvert.h
+++ b/src/jsc/bindings/BunIDLConvert.h
@@ -188,8 +188,7 @@ template<> struct WebCore::Converter<Bun::IDLArrayBufferRef>
         if (auto* jsBuffer = JSC::toUnsharedArrayBuffer(vm, value)) {
             return jsBuffer;
         }
-        // This branch also matches DataView: dynamicDowncast<JSArrayBufferView>
-        // covers the whole typed-array JSType range, which ends at DataViewType.
+        // Also matches DataView: the JSArrayBufferView JSType range ends at DataViewType.
         if (auto* jsView = dynamicDowncast<JSC::JSArrayBufferView>(value)) {
             if (jsView->isShared())
                 return std::nullopt;

--- a/src/jsc/bindings/BunIDLConvert.h
+++ b/src/jsc/bindings/BunIDLConvert.h
@@ -188,17 +188,12 @@ template<> struct WebCore::Converter<Bun::IDLArrayBufferRef>
         if (auto* jsBuffer = JSC::toUnsharedArrayBuffer(vm, value)) {
             return jsBuffer;
         }
+        // This branch also matches DataView: dynamicDowncast<JSArrayBufferView>
+        // covers the whole typed-array JSType range, which ends at DataViewType.
         if (auto* jsView = dynamicDowncast<JSC::JSArrayBufferView>(value)) {
             if (jsView->isShared())
                 return std::nullopt;
             if (auto* buf = jsView->unsharedBuffer())
-                return buf;
-            return std::nullopt;
-        }
-        if (auto* jsDataView = dynamicDowncast<JSC::JSDataView>(value)) {
-            if (jsDataView->isShared())
-                return std::nullopt;
-            if (auto* buf = jsDataView->unsharedBuffer())
                 return buf;
             return std::nullopt;
         }

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -151,6 +151,20 @@ describe("Bun.serve SSL validations", () => {
       });
     }
   }
+
+  test("SharedArrayBuffer-backed TypedArray as ALPNProtocols does not crash", () => {
+    const shared = new SharedArrayBuffer(16);
+    const view = new Int16Array(shared);
+    expect(() => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("ok");
+        },
+        ALPNProtocols: view,
+      });
+    }).toThrow(TypeError);
+  });
 });
 
 describe("Bun.serve per-serverName client certificate policy", () => {

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -154,16 +154,17 @@ describe("Bun.serve SSL validations", () => {
 
   test("SharedArrayBuffer-backed TypedArray as ALPNProtocols does not crash", () => {
     const shared = new SharedArrayBuffer(16);
-    const view = new Int16Array(shared);
-    expect(() => {
-      using server = Bun.serve({
-        port: 0,
-        fetch() {
-          return new Response("ok");
-        },
-        ALPNProtocols: view,
-      });
-    }).toThrow(TypeError);
+    for (const view of [new Int16Array(shared), new DataView(shared)]) {
+      expect(() => {
+        using server = Bun.serve({
+          port: 0,
+          fetch() {
+            return new Response("ok");
+          },
+          ALPNProtocols: view,
+        });
+      }).toThrow(TypeError);
+    }
   });
 });
 


### PR DESCRIPTION
### Problem
- A TypedArray or DataView backed by a `SharedArrayBuffer` crashes the process when it is passed where an unshared `ArrayBuffer` is expected, for example `ALPNProtocols` in `Bun.serve()`. The crash is `ASSERTION FAILED: !result || !result->isShared()` at `JSArrayBufferView.cpp(224)`.
- The cause is `WebCore::Converter<Bun::IDLArrayBufferRef>::tryConvert` in `src/jsc/bindings/BunIDLConvert.h`. It called `unsharedBuffer()` on the view without an `isShared()` check, and `unsharedBuffer()` hits a `RELEASE_ASSERT` on a shared buffer.

### Fix
- Check `isShared()` on the view before the `unsharedBuffer()` call. Return `std::nullopt` for a shared view, so the converter throws a `TypeError` instead of crashing. Also return `std::nullopt` when `unsharedBuffer()` returns null.
- Remove the `JSDataView` branch. It was unreachable: `dynamicDowncast<JSC::JSArrayBufferView>` matches the whole typed-array JSType range, and that range ends at `DataViewType`. A comment on the remaining branch records this.
- Verified: `test/js/bun/http/bun-serve-ssl.test.ts` asserts that `Int16Array` and `DataView` over a `SharedArrayBuffer` as `ALPNProtocols` throw a `TypeError`. On the released bun the same input aborts the process. The full file (19 tests) passes with the fix.

### Background
- `IDLArrayBufferRef` is the IDL type for options that accept an `ArrayBuffer` or a view over one, such as TLS option buffers.
- `unsharedBuffer()` asserts that the backing buffer is not shared. The caller has to check `isShared()` first.

Repro:
```js
const v = new Int16Array(new SharedArrayBuffer(16));
Bun.serve({ fetch() { return new Response(); }, ALPNProtocols: v });
```

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/bun-serve-ssl.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [10.10ms]
(pass) Bun.serve SSL validations > invalid key #2 development [2.32ms]
(pass) Bun.serve SSL validations > invalid cert development [1.60ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [29.61ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [2.64ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [1.72ms]
(pass) Bun.serve SSL validations > invalid key production [2.25ms]
(pass) Bun.serve SSL validations > invalid key #2 production [1.80ms]
(pass) Bun.serve SSL validations > invalid cert production [2.04ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [5.50ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [2.29ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName production [2.00ms]
(pass) Bun.s
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.1-canary.1 (a6c4cc276)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [0.32ms]
(pass) Bun.serve SSL validations > invalid key #2 development [0.06ms]
(pass) Bun.serve SSL validations > invalid cert development [0.02ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [2.86ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [0.05ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [0.01ms]
(pass) Bun.serve SSL validations > invalid key production [0.05ms]
(pass) Bun.serve SSL validations > invalid key #2 production [0.04ms]
(pass) Bun.serve SSL validations > invalid cert production [0.03ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [0.29ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [0.02ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName production [0.01ms]
(pass) Bun.serve SSL validations > valid development [4.06ms]
(pass) Bun.serve SSL validations > valid 2 development [2.69ms]
(pass) Bun.serve SSL validations > valid productio
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/bun-serve-ssl.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [9.63ms]
(pass) Bun.serve SSL validations > invalid key #2 development [2.23ms]
(pass) Bun.serve SSL validations > invalid cert development [1.61ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [29.21ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [2.49ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [1.74ms]
(pass) Bun.serve SSL validations > invalid key production [2.26ms]
(pass) Bun.serve SSL validations > invalid key #2 production [1.79ms]
(pass) Bun.serve SSL validations > invalid cert production [2.09ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [5.23ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [2.29ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName production [2.24ms]
(pass) Bun.se
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     586932f3c5
  features     baseline

23 deps, 131 codegen, 1172 objects in 677ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 26 installs across 63 packages (no changes) [14.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 1 install across 2 packages (no changes) [8.00ms]
[3/1244] fetch zlib
[zlib] up to date
[4/1244] gen ErrorCode+*.h
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 111 installs across 104 packages (no changes) [15.00ms]
[6/1244] gen bindgenv2
[7/1244] fetch tinycc
[tinycc] up to date
[8/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 17ms

  react-refresh.js  4.81 KB  (entry point)

[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.serv
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunIDLConvert.h       | 10 ++++++----
 test/js/bun/http/bun-serve-ssl.test.ts | 15 +++++++++++++++
 2 files changed, 21 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/jsc/bindings/BunIDLConvert.h            1      2      4
test/js/bun/http/bun-serve-ssl.test.ts      1      1      4
```

</details>

**root cause** · written by the author bot

The converter for Bun::IDLArrayBufferRef assumed its input was backed by a non-shared ArrayBuffer and unconditionally fetched the unshared buffer, so passing a TypedArray backed by a SharedArrayBuffer, for example as ALPNProtocols to Bun.serve, hit a debug assertion in JSArrayBufferView and crashed the process. The fix checks isShared() on the view and returns std::nullopt for shared buffers, with a defensive null check on unsharedBuffer(), so the conversion fails cleanly and surfaces as a TypeError instead of an abort. A regression test covers TypedArray and DataView views over a SharedArr…

<!-- robobun:evidence:end -->