### PR TITLE
Catch errors from dest.write() in Readable.prototype.pipe

### DIFF
--- a/src/js/internal/streams/readable.ts
+++ b/src/js/internal/streams/readable.ts
@@ -912,10 +912,14 @@ Readable.prototype.pipe = function (dest, pipeOpts) {
   src.on("data", ondata);
   function ondata(chunk) {
     $debug("ondata");
-    const ret = dest.write(chunk);
-    $debug("dest.write", ret);
-    if (ret === false) {
-      pause();
+    try {
+      const ret = dest.write(chunk);
+      $debug("dest.write", ret);
+      if (ret === false) {
+        pause();
+      }
+    } catch (err) {
+      dest.destroy(err);
     }
   }
 

--- a/test/regression/issue/28431.test.ts
+++ b/test/regression/issue/28431.test.ts
@@ -1,5 +1,7 @@
-import { expect, test } from "bun:test";
+// Ensure this test runs in both Node.js & Bun to verify compatibility.
+import assert from "node:assert";
 import { Readable, Transform } from "node:stream";
+import { test } from "node:test";
 
 test("piping object-mode source into byte-mode destination emits catchable error", async () => {
   const objectReadable = Readable.from([{ hello: "world" }]);
@@ -29,9 +31,9 @@ test("piping object-mode source into byte-mode destination emits catchable error
     caughtError = e;
   }
 
-  expect(caughtError).toBeDefined();
-  expect((caughtError as any).code).toBe("ERR_INVALID_ARG_TYPE");
+  assert.ok(caughtError);
+  assert.strictEqual((caughtError as any).code, "ERR_INVALID_ARG_TYPE");
 
-  expect(errors.length).toBe(1);
-  expect((errors[0] as any).code).toBe("ERR_INVALID_ARG_TYPE");
+  assert.strictEqual(errors.length, 1);
+  assert.strictEqual((errors[0] as any).code, "ERR_INVALID_ARG_TYPE");
 });

--- a/test/regression/issue/28431.test.ts
+++ b/test/regression/issue/28431.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import { Readable, Transform } from "node:stream";
+
+test("piping object-mode source into byte-mode destination emits catchable error", async () => {
+  const objectReadable = Readable.from([{ hello: "world" }]);
+
+  const passThrough = new Transform({
+    objectMode: false,
+    transform(chunk, _encoding, cb) {
+      this.push(chunk);
+      cb();
+    },
+  });
+
+  const errors: Error[] = [];
+
+  passThrough.on("error", err => {
+    errors.push(err);
+  });
+
+  objectReadable.pipe(passThrough);
+
+  let caughtError: Error | undefined;
+  try {
+    for await (const _v of passThrough) {
+      // should not receive any data
+    }
+  } catch (e: any) {
+    caughtError = e;
+  }
+
+  expect(caughtError).toBeDefined();
+  expect((caughtError as any).code).toBe("ERR_INVALID_ARG_TYPE");
+
+  expect(errors.length).toBe(1);
+  expect((errors[0] as any).code).toBe("ERR_INVALID_ARG_TYPE");
+});


### PR DESCRIPTION
Closes #28431

## Problem

When piping an object-mode `Readable` into a byte-mode `Transform`/`Writable`, `dest.write()` throws `ERR_INVALID_ARG_TYPE` because the chunk is an object instead of a string/Buffer/TypedArray. This error was uncatchable — it crashed the process instead of being emitted on the destination stream's `error` event.

## Root Cause

In `Readable.prototype.pipe`, the `ondata` handler called `dest.write(chunk)` without a try/catch:

```javascript
function ondata(chunk) {
    const ret = dest.write(chunk); // throws uncaught
    if (ret === false) { pause(); }
}
```

## Fix

Wrap `dest.write(chunk)` in a try/catch and call `dest.destroy(err)` in the catch block, matching Node.js behavior:

```javascript
function ondata(chunk) {
    try {
      const ret = dest.write(chunk);
      if (ret === false) { pause(); }
    } catch (err) {
      dest.destroy(err);
    }
}
```

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28431.test.ts` → FAIL (bug exists on main)
- `bun bd test test/regression/issue/28431.test.ts` → PASS (fix works)

---

**Verification (robobun, iteration 9):** CI on prior commit ea5b22f6: Lint JS ✅, Format ✅, alpine-aarch64 ✅, debian-x64-ASAN ✅, windows-aarch64 ✅, darwin builds ✅. Only failure was linux-aarch64-build-cpp — unrelated to this pure JS change. Latest commit 1516e0b9 build #41235 still in progress. Diff: two files, no TODO/FIXME/HACK, no unrelated changes. Test pipes object-mode Readable into byte-mode Transform, asserts ERR_INVALID_ARG_TYPE on both error event and async iterator throw — would crash on main without the fix. Claude reviews LGTM (confirmed fix matches Node.js v22 upstream). CodeRabbit pre-merge checks all passed.