### PR TITLE
Fix REPRL process crash from unhandled promise rejections

### DIFF
--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -13,6 +13,12 @@ globalThis.require = require;
 globalThis.__dirname = "/";
 globalThis.__filename = "/fuzzilli.js";
 
+// Prevent unhandled promise rejections from killing the REPRL process.
+// Fuzzed scripts may create async operations whose rejections fire after
+// eval completes. Synchronous exceptions are already caught by the
+// try/catch around eval in the REPRL loop below.
+process.on("unhandledRejection", () => {});
+
 // ============================================================================
 // REPRL Protocol Loop
 // ============================================================================


### PR DESCRIPTION
Fuzzed scripts that create async operations (e.g. `Bun.sql` with invalid args) generate promise rejections that fire after `eval` completes. These unhandled rejections kill the REPRL process.

**Fix:** Added `process.on("unhandledRejection", () => {})` in `src/js/eval/fuzzilli-reprl.ts` to prevent async promise rejections from fuzzed scripts from killing the REPRL process. Synchronous exceptions are already caught by the try/catch around eval in the REPRL loop.

**Note:** Earlier commits also modified `src/js/internal/sql/query.ts` (invalidHandle guard + $markPromiseAsHandled), but those changes were reverted (commit 8f617eb) because they caused side effects on normal SQL error handling. The REPRL handler alone is sufficient. A subprocess regression test was also attempted but removed as too fragile across platforms.

---
Verified: Final diff is 1 file (`src/js/eval/fuzzilli-reprl.ts`), 1 functional line adding `process.on("unhandledRejection", () => {})`. Format and Lint JavaScript pass. No TODO/FIXME/HACK in added lines. Prior CI Build #41339 failures were all `bundler_compile.test.ts` timeouts — completely unrelated to this JS-only fuzzer harness change. Current Build #41356 compiling. No regression test (fuzzer harness only exercisable under Fuzzilli; subprocess test was attempted but removed as fragile). All bot review threads from 16 review iterations resolved; final diff addresses every concern raised.