### PR TITLE
fix: write console.trace() output to stderr instead of stdout

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -111,7 +111,7 @@ fn messageWithTypeAndLevel_(
 
     // Lock/unlock a mutex incase two JS threads are console.log'ing at the same time
     // We do this the slightly annoying way to avoid assigning a pointer
-    if (level == .Warning or level == .Error or message_type == .Assert) {
+    if (level == .Warning or level == .Error or message_type == .Assert or message_type == .Trace) {
         if (stderr_lock_count == 0) {
             stderr_mutex.lock();
         }
@@ -126,7 +126,7 @@ fn messageWithTypeAndLevel_(
     }
 
     defer {
-        if (level == .Warning or level == .Error or message_type == .Assert) {
+        if (level == .Warning or level == .Error or message_type == .Assert or message_type == .Trace) {
             stderr_lock_count -= 1;
 
             if (stderr_lock_count == 0) {
@@ -156,12 +156,12 @@ fn messageWithTypeAndLevel_(
         return;
     }
 
-    const enable_colors = if (level == .Warning or level == .Error)
+    const enable_colors = if (level == .Warning or level == .Error or message_type == .Trace)
         Output.enable_ansi_colors_stderr
     else
         Output.enable_ansi_colors_stdout;
 
-    const writer = if (level == .Warning or level == .Error)
+    const writer = if (level == .Warning or level == .Error or message_type == .Trace)
         console.error_writer
     else
         console.writer;


### PR DESCRIPTION
## Summary

\console.trace()\ currently writes its output to **stdout**, but per the [Web Console specification](https://console.spec.whatwg.org/#trace) and Node.js behavior, it should write to **stderr**.

This is a minimal fix: adding \message_type == .Trace\ to the existing stderr routing conditions in \ConsoleObject.zig\.

## Changes

In \src/bun.js/ConsoleObject.zig\, the \.Trace\ message type is now routed to stderr alongside \.Assert\, \.Warning\, and \.Error\. This covers:
- **Mutex locking**: uses \stderr_mutex\ instead of \stdout_mutex\
- **ANSI color detection**: checks stderr instead of stdout  
- **Writer selection**: uses \rror_writer\ instead of \writer\

## Reproduction

\\\js
// trace.js
console.trace('hello');
\\\

**Before (bun):** output goes to stdout (\un trace.js >/dev/null\ shows nothing)
**After (bun):** output goes to stderr, matching Node.js behavior
**Node.js:** \
ode trace.js >/dev/null\ correctly shows trace on stderr

Fixes #19952