### PR TITLE
fix: write console.trace() output to stderr instead of stdout

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -111,7 +111,7 @@ fn messageWithTypeAndLevel_(
 
     // Lock/unlock a mutex incase two JS threads are console.log'ing at the same time
     // We do this the slightly annoying way to avoid assigning a pointer
-    if (level == .Warning or level == .Error or message_type == .Assert) {
+    if (level == .Warning or level == .Error or message_type == .Assert or message_type == .Trace) {
         if (stderr_lock_count == 0) {
             stderr_mutex.lock();
         }
@@ -126,7 +126,7 @@ fn messageWithTypeAndLevel_(
     }
 
     defer {
-        if (level == .Warning or level == .Error or message_type == .Assert) {
+        if (level == .Warning or level == .Error or message_type == .Assert or message_type == .Trace) {
             stderr_lock_count -= 1;
 
             if (stderr_lock_count == 0) {
@@ -156,12 +156,12 @@ fn messageWithTypeAndLevel_(
         return;
     }
 
-    const enable_colors = if (level == .Warning or level == .Error)
+    const enable_colors = if (level == .Warning or level == .Error or message_type == .Trace)
         Output.enable_ansi_colors_stderr
     else
         Output.enable_ansi_colors_stdout;
 
-    const writer = if (level == .Warning or level == .Error)
+    const writer = if (level == .Warning or level == .Error or message_type == .Trace)
         console.error_writer
     else
         console.writer;


### PR DESCRIPTION
Fixes #19952

console.trace() was writing to stdout instead of stderr. In Node.js, console.trace() writes to stderr.

The writer selection in ConsoleObject.zig only checked for Warning/Error message levels. Since console.trace() is dispatched with MessageLevel.Log but MessageType.Trace, it fell through to the stdout writer.

Added message_type == .Trace checks alongside existing level == .Warning or level == .Error checks in four places: stderr mutex locking, stderr mutex unlocking (defer), ANSI color detection, and writer selection.