### PR TITLE
Fix incorrect jsCast<JSFunction*> in Bun__JSValue__call

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -2796,6 +2796,8 @@ extern "C" JSC::EncodedJSValue Bun__JSValue__call(JSC::JSGlobalObject* globalObj
     ASSERT_WITH_MESSAGE(jsObject.isCallable(), "Function passed to .call must be callable.");
     ASSERT(callData.type != JSC::CallData::Type::None);
     if (callData.type == JSC::CallData::Type::None) {
+        if (asyncContextData)
+            asyncContextData->putInternalField(vm, 0, restoreAsyncContext);
         throwTypeError(globalObject, scope, "Function passed to .call must be callable."_s);
         return {};
     }

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -2793,8 +2793,6 @@ extern "C" JSC::EncodedJSValue Bun__JSValue__call(JSC::JSGlobalObject* globalObj
 
     auto callData = getCallData(jsObject);
 
-    ASSERT_WITH_MESSAGE(jsObject.isCallable(), "Function passed to .call must be callable.");
-    ASSERT(callData.type != JSC::CallData::Type::None);
     if (callData.type == JSC::CallData::Type::None) {
         if (asyncContextData)
             asyncContextData->putInternalField(vm, 0, restoreAsyncContext);

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -2795,7 +2795,7 @@ extern "C" JSC::EncodedJSValue Bun__JSValue__call(JSC::JSGlobalObject* globalObj
 
     ASSERT_WITH_MESSAGE(jsObject.isCallable(), "Function passed to .call must be callable.");
     ASSERT(callData.type != JSC::CallData::Type::None);
-    if (UNLIKELY(callData.type == JSC::CallData::Type::None)) {
+    if (callData.type == JSC::CallData::Type::None) {
         throwTypeError(globalObject, scope, "Function passed to .call must be callable."_s);
         return {};
     }

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -2765,7 +2765,7 @@ extern "C" JSC::EncodedJSValue Bun__JSValue__call(JSC::JSGlobalObject* globalObj
     JSValue restoreAsyncContext;
     InternalFieldTuple* asyncContextData = nullptr;
     if (auto* wrapper = jsDynamicCast<AsyncContextFrame*>(jsObject)) {
-        jsObject = jsCast<JSC::JSFunction*>(wrapper->callback.get());
+        jsObject = jsCast<JSC::JSObject*>(wrapper->callback.get());
         asyncContextData = globalObject->m_asyncContextData.get();
         restoreAsyncContext = asyncContextData->getInternalField(0);
         asyncContextData->putInternalField(vm, 0, wrapper->context.get());
@@ -2795,8 +2795,10 @@ extern "C" JSC::EncodedJSValue Bun__JSValue__call(JSC::JSGlobalObject* globalObj
 
     ASSERT_WITH_MESSAGE(jsObject.isCallable(), "Function passed to .call must be callable.");
     ASSERT(callData.type != JSC::CallData::Type::None);
-    if (callData.type == JSC::CallData::Type::None)
+    if (UNLIKELY(callData.type == JSC::CallData::Type::None)) {
+        throwTypeError(globalObject, scope, "Function passed to .call must be callable."_s);
         return {};
+    }
 
     auto result = JSC::profiledCall(globalObject, ProfilingReason::API, jsObject, callData, jsThisObject, argList);
 

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -2765,7 +2765,7 @@ extern "C" JSC::EncodedJSValue Bun__JSValue__call(JSC::JSGlobalObject* globalObj
     JSValue restoreAsyncContext;
     InternalFieldTuple* asyncContextData = nullptr;
     if (auto* wrapper = jsDynamicCast<AsyncContextFrame*>(jsObject)) {
-        jsObject = jsCast<JSC::JSObject*>(wrapper->callback.get());
+        jsObject = wrapper->callback.get();
         asyncContextData = globalObject->m_asyncContextData.get();
         restoreAsyncContext = asyncContextData->getInternalField(0);
         asyncContextData->putInternalField(vm, 0, wrapper->context.get());

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -2788,7 +2788,8 @@ extern "C" JSC::EncodedJSValue Bun__JSValue__call(JSC::JSGlobalObject* globalObj
     }
 
 #if ASSERT_ENABLED
-    JSC::Integrity::auditCellFully(vm, jsObject.asCell());
+    if (jsObject.isCell())
+        JSC::Integrity::auditCellFully(vm, jsObject.asCell());
 #endif
 
     auto callData = getCallData(jsObject);

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -582,12 +582,9 @@ describe("async context passes through", () => {
   test("Proxy-wrapped function as callback", async () => {
     const s = new AsyncLocalStorage<string>();
     const { promise, resolve } = Promise.withResolvers<string | undefined>();
-    const fn = new Proxy(
-      () => {
-        resolve(s.getStore());
-      },
-      {},
-    );
+    const fn = new Proxy(() => {
+      resolve(s.getStore());
+    }, {});
     s.run("proxy-value", () => {
       setTimeout(fn, 0);
     });

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -566,28 +566,4 @@ describe("async context passes through", () => {
     });
     expect(a).toBe("value");
   });
-
-  test("bound function as callback", async () => {
-    const s = new AsyncLocalStorage<string>();
-    const { promise, resolve } = Promise.withResolvers<string | undefined>();
-    function getStore() {
-      resolve(s.getStore());
-    }
-    s.run("bound-value", () => {
-      setTimeout(getStore.bind(null), 0);
-    });
-    expect(await promise).toBe("bound-value");
-  });
-
-  test("Proxy-wrapped function as callback", async () => {
-    const s = new AsyncLocalStorage<string>();
-    const { promise, resolve } = Promise.withResolvers<string | undefined>();
-    const fn = new Proxy(() => {
-      resolve(s.getStore());
-    }, {});
-    s.run("proxy-value", () => {
-      setTimeout(fn, 0);
-    });
-    expect(await promise).toBe("proxy-value");
-  });
 });

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -566,4 +566,31 @@ describe("async context passes through", () => {
     });
     expect(a).toBe("value");
   });
+
+  test("bound function as callback", async () => {
+    const s = new AsyncLocalStorage<string>();
+    const { promise, resolve } = Promise.withResolvers<string | undefined>();
+    function getStore() {
+      resolve(s.getStore());
+    }
+    s.run("bound-value", () => {
+      setTimeout(getStore.bind(null), 0);
+    });
+    expect(await promise).toBe("bound-value");
+  });
+
+  test("Proxy-wrapped function as callback", async () => {
+    const s = new AsyncLocalStorage<string>();
+    const { promise, resolve } = Promise.withResolvers<string | undefined>();
+    const fn = new Proxy(
+      () => {
+        resolve(s.getStore());
+      },
+      {},
+    );
+    s.run("proxy-value", () => {
+      setTimeout(fn, 0);
+    });
+    expect(await promise).toBe("proxy-value");
+  });
 });

--- a/test/js/valkey/valkey-noncallable-onclose.test.ts
+++ b/test/js/valkey/valkey-noncallable-onclose.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+import { isEnabled } from "./test-utils";
 
-test("non-callable onclose does not crash", async () => {
+test.skipIf(!isEnabled)("non-callable onclose does not crash", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/valkey/valkey-noncallable-onclose.test.ts
+++ b/test/js/valkey/valkey-noncallable-onclose.test.ts
@@ -12,15 +12,18 @@ test.skipIf(!isEnabled)("non-callable onclose does not crash", async () => {
       bunExe(),
       "-e",
       `
-      process.on("uncaughtException", (e) => {
+      const { promise, resolve } = Promise.withResolvers();
+      process.exitCode = 1;
+      process.once("uncaughtException", (e) => {
         console.log(e.constructor.name + ": " + e.message);
-        process.exit(0);
+        process.exitCode = 0;
+        resolve();
       });
       const client = new Bun.RedisClient(process.env.BUN_VALKEY_URL);
       client.onclose = 42;
       await client.ping();
       client.close();
-      await Bun.sleep(500);
+      await Promise.race([promise, Bun.sleep(5_000)]);
       `,
     ],
     env: { ...bunEnv, BUN_VALKEY_URL: DEFAULT_REDIS_URL },

--- a/test/js/valkey/valkey-noncallable-onclose.test.ts
+++ b/test/js/valkey/valkey-noncallable-onclose.test.ts
@@ -36,5 +36,6 @@ test.skipIf(!isEnabled)("non-callable onclose does not crash", async () => {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toContain("TypeError: Function passed to .call must be callable.");
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/js/valkey/valkey-noncallable-onclose.test.ts
+++ b/test/js/valkey/valkey-noncallable-onclose.test.ts
@@ -1,6 +1,10 @@
-import { expect, test } from "bun:test";
+import { beforeAll, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
-import { isEnabled } from "./test-utils";
+import { DEFAULT_REDIS_URL, isEnabled, setupDockerContainer } from "./test-utils";
+
+beforeAll(async () => {
+  if (isEnabled) await setupDockerContainer();
+});
 
 test.skipIf(!isEnabled)("non-callable onclose does not crash", async () => {
   await using proc = Bun.spawn({
@@ -12,14 +16,14 @@ test.skipIf(!isEnabled)("non-callable onclose does not crash", async () => {
         console.log(e.constructor.name + ": " + e.message);
         process.exit(0);
       });
-      const client = new Bun.RedisClient("redis://127.0.0.1:6379");
+      const client = new Bun.RedisClient(process.env.BUN_VALKEY_URL);
       client.onclose = 42;
       await client.ping();
       client.close();
       await Bun.sleep(500);
       `,
     ],
-    env: bunEnv,
+    env: { ...bunEnv, BUN_VALKEY_URL: DEFAULT_REDIS_URL },
     stderr: "pipe",
     stdout: "pipe",
   });

--- a/test/js/valkey/valkey-noncallable-onclose.test.ts
+++ b/test/js/valkey/valkey-noncallable-onclose.test.ts
@@ -20,6 +20,7 @@ test.skipIf(!isEnabled)("non-callable onclose does not crash", async () => {
           process.exitCode = 0;
         }
         resolve();
+        process.exit(process.exitCode);
       });
       const client = new Bun.RedisClient(process.env.BUN_VALKEY_URL);
       client.onclose = 42;

--- a/test/js/valkey/valkey-noncallable-onclose.test.ts
+++ b/test/js/valkey/valkey-noncallable-onclose.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("non-callable onclose does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      process.on("uncaughtException", (e) => {
+        console.log(e.constructor.name + ": " + e.message);
+        process.exit(0);
+      });
+      const client = new Bun.RedisClient("redis://127.0.0.1:6379");
+      client.onclose = 42;
+      await client.ping();
+      client.close();
+      await Bun.sleep(500);
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("TypeError");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/valkey/valkey-noncallable-onclose.test.ts
+++ b/test/js/valkey/valkey-noncallable-onclose.test.ts
@@ -16,7 +16,9 @@ test.skipIf(!isEnabled)("non-callable onclose does not crash", async () => {
       process.exitCode = 1;
       process.once("uncaughtException", (e) => {
         console.log(e.constructor.name + ": " + e.message);
-        process.exitCode = 0;
+        if (e instanceof TypeError && e.message.includes("must be callable")) {
+          process.exitCode = 0;
+        }
         resolve();
       });
       const client = new Bun.RedisClient(process.env.BUN_VALKEY_URL);
@@ -33,6 +35,6 @@ test.skipIf(!isEnabled)("non-callable onclose does not crash", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout).toContain("TypeError");
+  expect(stdout).toContain("TypeError: Function passed to .call must be callable.");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
The AsyncContextFrame unwrapping in `Bun__JSValue__call` used `jsCast<JSC::JSFunction*>` to extract the wrapped callback. In debug builds, `jsCast` validates the type via `inherits()` — this crashes when the callback is a callable that is not a `JSFunction` (e.g. a bound function, Proxy, or InternalFunction).

Changed to `jsCast<JSC::JSObject*>` to match the `ASYNCCONTEXTFRAME_CALL_IMPL` macro in `AsyncContextFrame.cpp`, which correctly handles all callable types.

Also made the non-callable fallback throw a `TypeError` instead of silently returning an empty JSValue without an exception, which would cause a mismatch with the Zig `fromJSHostCall` wrapper that expects zero return ↔ exception thrown.

---

Verified by robobun: CI Build #41353 in progress (Lint JS passed, pipeline passed). Diff touches exactly two files, no TODO/FIXME/HACK. Core fix at bindings.cpp:2768 drops the incorrect `jsCast<JSFunction*>` — `wrapper->callback.get()` returns JSValue directly, matching `ASYNCCONTEXTFRAME_CALL_IMPL` in AsyncContextFrame.cpp (confirmed line `functionObject = jsCast<JSC::JSObject*>(wrapper->callback.get())`). `isCell()` guard added for `auditCellFully` (line 2791) prevents crash on non-cell values. Non-callable path now restores async context before throwing TypeError instead of silently returning empty. Confirmed `withAsyncContextIfNeeded` wraps ANY value (including non-callables) when async context is active, so `onclose = 42` triggers the fixed path. Test `valkey-noncallable-onclose.test.ts` properly regresses: on system bun, old code either crashes at jsCast or silently returns {} (exitCode=1, no TypeError); on patched bun, throwTypeError fires (exitCode=0). Test uses `Promise.withResolvers`, checks specific TypeError message, and has `skipIf(!isEnabled)` guard. Jarred CHANGES_REQUESTED about old test passing on system bun was addressed by replacing it with the current Valkey-based test (commit e5e60f88). All CodeRabbit actionable comments resolved in follow-up commits.

Verification (iteration 12): Build #41353 (commit 8bad111b) all pipeline statuses green — sole test failure was unrelated test/bake/dev/stress.test.ts on Windows. Build #41366 (commit 6775deeb) in progress. Diff confirmed: two files, no TODO/FIXME/HACK. Read bindings.cpp lines 2765-2812 — fix at 2768 removes jsCast<JSFunction*>, isCell() guard at 2791 protects auditCellFully for primitive callbacks, TypeError path at 2797-2801 restores async context before throw. Confirmed withAsyncContextIfNeeded (AsyncContextFrame.cpp:37-58) wraps any value when context is active. Test subprocess sets onclose=42, asserts TypeError with 'must be callable' message, exitCode=0; would fail on old bun (crash or exitCode=1).

---

Verified: Build #41366 (commit 6775deeb) all 11 test steps green across Windows/Ubuntu/Debian/Alpine/ASAN; 2 failures were infra (linux-aarch64 build timeout). No TODO/FIXME/HACK in diff. Test spawns subprocess with client.onclose = 42, asserts TypeError and exitCode=0; fails on old bun (crash or silent empty return). Jarred CHANGES_REQUESTED addressed in e5e60f88.

---

Verified by robobun (iteration 13): CI green on prior commit 6775deeb (27 passing checks across Alpine/Debian/Ubuntu/Windows/ASAN; only infra failure on linux-aarch64 build). Latest commit 51375ade changes only the test (adds process.exit line) — C++ fix unchanged since green CI. Test properly regresses: on old code jsCast<JSFunction*> crashes or silently returns empty for non-callable onclose=42; on fixed code throwTypeError fires. Diff clean, no TODO/FIXME/HACK. Jarred's CHANGES_REQUESTED addressed by switching to Valkey-based test. All CodeRabbit comments resolved.