### PR TITLE
Fix crash when consuming Response body twice with async iterable

### DIFF
--- a/src/bun.js/bindings/webcore/ReadableStream.cpp
+++ b/src/bun.js/bindings/webcore/ReadableStream.cpp
@@ -539,14 +539,12 @@ extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToBytes(Zig::Globa
         return JSValue::encode(result);
 
     if (!object) [[unlikely]] {
-        auto throwScope = DECLARE_THROW_SCOPE(vm);
         throwTypeError(globalObject, throwScope, "Expected object"_s);
         return {};
     }
 
     JSC::JSPromise* promise = JSC::jsDynamicCast<JSC::JSPromise*>(object);
     if (!promise) [[unlikely]] {
-        auto throwScope = DECLARE_THROW_SCOPE(vm);
         throwTypeError(globalObject, throwScope, "Expected promise"_s);
         return {};
     }

--- a/src/bun.js/bindings/webcore/ReadableStream.cpp
+++ b/src/bun.js/bindings/webcore/ReadableStream.cpp
@@ -487,20 +487,20 @@ static inline JSC::EncodedJSValue ZigGlobalObject__readableStreamToArrayBufferBo
     auto callData = JSC::getCallData(function);
     JSValue result = call(globalObject, function, callData, JSC::jsUndefined(), arguments);
 
+    RETURN_IF_EXCEPTION(throwScope, {});
+
     JSC::JSObject* object = result.getObject();
 
     if (!result || result.isUndefinedOrNull()) [[unlikely]]
         return JSValue::encode(result);
 
     if (!object) [[unlikely]] {
-        auto throwScope = DECLARE_THROW_SCOPE(vm);
         throwTypeError(globalObject, throwScope, "Expected object"_s);
         return {};
     }
 
     JSC::JSPromise* promise = JSC::jsDynamicCast<JSC::JSPromise*>(object);
     if (!promise) [[unlikely]] {
-        auto throwScope = DECLARE_THROW_SCOPE(vm);
         throwTypeError(globalObject, throwScope, "Expected promise"_s);
         return {};
     }
@@ -530,6 +530,8 @@ extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToBytes(Zig::Globa
 
     auto callData = JSC::getCallData(function);
     JSValue result = call(globalObject, function, callData, JSC::jsUndefined(), arguments);
+
+    RETURN_IF_EXCEPTION(throwScope, {});
 
     JSC::JSObject* object = result.getObject();
 

--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -111,7 +111,7 @@ export function readableStreamToArray(stream: ReadableStream): Promise<unknown[]
   if (!$isReadableStream(stream)) throw $ERR_INVALID_ARG_TYPE("stream", "ReadableStream", typeof stream);
   // this is a direct stream
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
-  if (underlyingSource !== undefined) {
+  if (underlyingSource != null) {
     return $readableStreamToArrayDirect(stream, underlyingSource);
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
@@ -123,7 +123,7 @@ export function readableStreamToText(stream: ReadableStream): Promise<string> {
   if (!$isReadableStream(stream)) throw $ERR_INVALID_ARG_TYPE("stream", "ReadableStream", typeof stream);
   // this is a direct stream
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
-  if (underlyingSource !== undefined) {
+  if (underlyingSource != null) {
     return $readableStreamToTextDirect(stream, underlyingSource);
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
@@ -142,7 +142,7 @@ export function readableStreamToArrayBuffer(stream: ReadableStream<ArrayBuffer>)
   if (!$isReadableStream(stream)) throw $ERR_INVALID_ARG_TYPE("stream", "ReadableStream", typeof stream);
   // this is a direct stream
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
-  if (underlyingSource !== undefined) {
+  if (underlyingSource != null) {
     return $readableStreamToArrayBufferDirect(stream, underlyingSource, false);
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
@@ -223,7 +223,7 @@ export function readableStreamToBytes(stream: ReadableStream<ArrayBuffer>): Prom
   // this is a direct stream
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
 
-  if (underlyingSource !== undefined) {
+  if (underlyingSource != null) {
     return $readableStreamToArrayBufferDirect(stream, underlyingSource, true);
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));

--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -320,6 +320,7 @@ $linkTimeConstant;
 export function readableStreamToJSON(stream: ReadableStream): unknown {
   if (!$isReadableStream(stream)) throw $ERR_INVALID_ARG_TYPE("stream", "ReadableStream", typeof stream);
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
+  if ($isReadableStreamDisturbed(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
   let result = $tryUseReadableStreamBufferedFastPath(stream, "json");
   if (result) {
     return result;
@@ -342,6 +343,7 @@ $linkTimeConstant;
 export function readableStreamToBlob(stream: ReadableStream): Promise<Blob> {
   if (!$isReadableStream(stream)) throw $ERR_INVALID_ARG_TYPE("stream", "ReadableStream", typeof stream);
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
+  if ($isReadableStreamDisturbed(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
 
   return (
     $tryUseReadableStreamBufferedFastPath(stream, "blob") ||

--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -115,7 +115,8 @@ export function readableStreamToArray(stream: ReadableStream): Promise<unknown[]
     return $readableStreamToArrayDirect(stream, underlyingSource);
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
-  if ($isReadableStreamDisturbed(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
+  if ($isReadableStreamDisturbed(stream))
+    return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
   return $readableStreamIntoArray(stream);
 }
 
@@ -128,7 +129,8 @@ export function readableStreamToText(stream: ReadableStream): Promise<string> {
     return $readableStreamToTextDirect(stream, underlyingSource);
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
-  if ($isReadableStreamDisturbed(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
+  if ($isReadableStreamDisturbed(stream))
+    return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
 
   const result = $tryUseReadableStreamBufferedFastPath(stream, "text");
 
@@ -148,7 +150,8 @@ export function readableStreamToArrayBuffer(stream: ReadableStream<ArrayBuffer>)
     return $readableStreamToArrayBufferDirect(stream, underlyingSource, false);
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
-  if ($isReadableStreamDisturbed(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
+  if ($isReadableStreamDisturbed(stream))
+    return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
 
   let result = $tryUseReadableStreamBufferedFastPath(stream, "arrayBuffer");
 
@@ -230,7 +233,8 @@ export function readableStreamToBytes(stream: ReadableStream<ArrayBuffer>): Prom
     return $readableStreamToArrayBufferDirect(stream, underlyingSource, true);
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
-  if ($isReadableStreamDisturbed(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
+  if ($isReadableStreamDisturbed(stream))
+    return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
 
   let result = $tryUseReadableStreamBufferedFastPath(stream, "bytes");
 

--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -115,6 +115,7 @@ export function readableStreamToArray(stream: ReadableStream): Promise<unknown[]
     return $readableStreamToArrayDirect(stream, underlyingSource);
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
+  if ($isReadableStreamDisturbed(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
   return $readableStreamIntoArray(stream);
 }
 
@@ -127,6 +128,7 @@ export function readableStreamToText(stream: ReadableStream): Promise<string> {
     return $readableStreamToTextDirect(stream, underlyingSource);
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
+  if ($isReadableStreamDisturbed(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
 
   const result = $tryUseReadableStreamBufferedFastPath(stream, "text");
 
@@ -146,6 +148,7 @@ export function readableStreamToArrayBuffer(stream: ReadableStream<ArrayBuffer>)
     return $readableStreamToArrayBufferDirect(stream, underlyingSource, false);
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
+  if ($isReadableStreamDisturbed(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
 
   let result = $tryUseReadableStreamBufferedFastPath(stream, "arrayBuffer");
 
@@ -227,6 +230,7 @@ export function readableStreamToBytes(stream: ReadableStream<ArrayBuffer>): Prom
     return $readableStreamToArrayBufferDirect(stream, underlyingSource, true);
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
+  if ($isReadableStreamDisturbed(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
 
   let result = $tryUseReadableStreamBufferedFastPath(stream, "bytes");
 

--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -320,7 +320,8 @@ $linkTimeConstant;
 export function readableStreamToJSON(stream: ReadableStream): unknown {
   if (!$isReadableStream(stream)) throw $ERR_INVALID_ARG_TYPE("stream", "ReadableStream", typeof stream);
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
-  if ($isReadableStreamDisturbed(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
+  if ($isReadableStreamDisturbed(stream))
+    return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
   let result = $tryUseReadableStreamBufferedFastPath(stream, "json");
   if (result) {
     return result;
@@ -343,7 +344,8 @@ $linkTimeConstant;
 export function readableStreamToBlob(stream: ReadableStream): Promise<Blob> {
   if (!$isReadableStream(stream)) throw $ERR_INVALID_ARG_TYPE("stream", "ReadableStream", typeof stream);
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
-  if ($isReadableStreamDisturbed(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
+  if ($isReadableStreamDisturbed(stream))
+    return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is disturbed"));
 
   return (
     $tryUseReadableStreamBufferedFastPath(stream, "blob") ||

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2259,6 +2259,7 @@ export function readableStreamToArrayBufferDirect(
 ) {
   var sink = new Bun.ArrayBufferSink();
   $putByIdDirectPrivate(stream, "underlyingSource", null);
+  stream.$disturbed = true;
   var highWaterMark = $getByIdDirectPrivate(stream, "highWaterMark");
   sink.start({ highWaterMark, asUint8Array });
   var capability = $newPromiseCapability(Promise);

--- a/test/js/web/streams/response-double-consume.test.ts
+++ b/test/js/web/streams/response-double-consume.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-test("calling .bytes() twice on a Response with async iterable body does not crash", async () => {
+test.concurrent("calling .bytes() twice on a Response with async iterable body does not crash", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -9,15 +9,13 @@ test("calling .bytes() twice on a Response with async iterable body does not cra
       `
       async function* gen() { yield new Uint8Array([1, 2, 3]); }
       const r = new Response({ [Symbol.asyncIterator]: () => gen() });
-      r.bytes();
-      r.bytes();
-      Bun.gc(true);
-      process.exit(0);
+      const first = await r.bytes();
+      try { await r.bytes(); } catch (e) { process.exit(0); }
+      process.exit(1);
       `,
     ],
     env: bunEnv,
     stdout: "pipe",
-    stderr: "pipe",
   });
 
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
@@ -25,7 +23,7 @@ test("calling .bytes() twice on a Response with async iterable body does not cra
   expect(exitCode).toBe(0);
 });
 
-test("calling .text() twice on a Response with async iterable body does not crash", async () => {
+test.concurrent("calling .text() twice on a Response with async iterable body does not crash", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -33,15 +31,13 @@ test("calling .text() twice on a Response with async iterable body does not cras
       `
       async function* gen() { yield new Uint8Array([72, 105]); }
       const r = new Response({ [Symbol.asyncIterator]: () => gen() });
-      r.text();
-      r.text();
-      Bun.gc(true);
-      process.exit(0);
+      const first = await r.text();
+      try { await r.text(); } catch (e) { process.exit(0); }
+      process.exit(1);
       `,
     ],
     env: bunEnv,
     stdout: "pipe",
-    stderr: "pipe",
   });
 
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
@@ -49,7 +45,7 @@ test("calling .text() twice on a Response with async iterable body does not cras
   expect(exitCode).toBe(0);
 });
 
-test("calling .arrayBuffer() twice on a Response with async iterable body does not crash", async () => {
+test.concurrent("calling .arrayBuffer() twice on a Response with async iterable body does not crash", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -57,15 +53,13 @@ test("calling .arrayBuffer() twice on a Response with async iterable body does n
       `
       async function* gen() { yield new Uint8Array([1, 2, 3]); }
       const r = new Response({ [Symbol.asyncIterator]: () => gen() });
-      r.arrayBuffer();
-      r.arrayBuffer();
-      Bun.gc(true);
-      process.exit(0);
+      const first = await r.arrayBuffer();
+      try { await r.arrayBuffer(); } catch (e) { process.exit(0); }
+      process.exit(1);
       `,
     ],
     env: bunEnv,
     stdout: "pipe",
-    stderr: "pipe",
   });
 
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);

--- a/test/js/web/streams/response-double-consume.test.ts
+++ b/test/js/web/streams/response-double-consume.test.ts
@@ -1,68 +1,36 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
 
-test.concurrent("calling .bytes() twice on a Response with async iterable body does not crash", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-      async function* gen() { yield new Uint8Array([1, 2, 3]); }
-      const r = new Response({ [Symbol.asyncIterator]: () => gen() });
-      const first = await r.bytes();
-      try { await r.bytes(); } catch (e) { process.exit(0); }
-      process.exit(1);
-      `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-  });
-
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  expect(stdout).toBe("");
-  expect(exitCode).toBe(0);
+test("second .bytes() on async iterable Response rejects", async () => {
+  async function* gen() {
+    yield new Uint8Array([1, 2, 3]);
+  }
+  const r = new Response({ [Symbol.asyncIterator]: () => gen() });
+  const first = await r.bytes();
+  expect(first).toBeInstanceOf(Uint8Array);
+  expect(first.length).toBe(3);
+  expect(r.bodyUsed).toBe(true);
+  await expect(r.bytes()).rejects.toThrow();
 });
 
-test.concurrent("calling .text() twice on a Response with async iterable body does not crash", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-      async function* gen() { yield new Uint8Array([72, 105]); }
-      const r = new Response({ [Symbol.asyncIterator]: () => gen() });
-      const first = await r.text();
-      try { await r.text(); } catch (e) { process.exit(0); }
-      process.exit(1);
-      `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-  });
-
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  expect(stdout).toBe("");
-  expect(exitCode).toBe(0);
+test("second .text() on async iterable Response rejects", async () => {
+  async function* gen() {
+    yield new Uint8Array([72, 105]);
+  }
+  const r = new Response({ [Symbol.asyncIterator]: () => gen() });
+  const first = await r.text();
+  expect(first).toBe("Hi");
+  expect(r.bodyUsed).toBe(true);
+  await expect(r.text()).rejects.toThrow();
 });
 
-test.concurrent("calling .arrayBuffer() twice on a Response with async iterable body does not crash", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-      async function* gen() { yield new Uint8Array([1, 2, 3]); }
-      const r = new Response({ [Symbol.asyncIterator]: () => gen() });
-      const first = await r.arrayBuffer();
-      try { await r.arrayBuffer(); } catch (e) { process.exit(0); }
-      process.exit(1);
-      `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-  });
-
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  expect(stdout).toBe("");
-  expect(exitCode).toBe(0);
+test("second .arrayBuffer() on async iterable Response rejects", async () => {
+  async function* gen() {
+    yield new Uint8Array([1, 2, 3]);
+  }
+  const r = new Response({ [Symbol.asyncIterator]: () => gen() });
+  const first = await r.arrayBuffer();
+  expect(first).toBeInstanceOf(ArrayBuffer);
+  expect(first.byteLength).toBe(3);
+  expect(r.bodyUsed).toBe(true);
+  await expect(r.arrayBuffer()).rejects.toThrow();
 });

--- a/test/js/web/streams/response-double-consume.test.ts
+++ b/test/js/web/streams/response-double-consume.test.ts
@@ -9,7 +9,12 @@ test("second .bytes() on async iterable Response rejects", async () => {
   expect(first).toBeInstanceOf(Uint8Array);
   expect(first.length).toBe(3);
   expect(r.bodyUsed).toBe(true);
-  await expect(r.bytes()).rejects.toThrow();
+  try {
+    await r.bytes();
+    expect.unreachable();
+  } catch (e: any) {
+    expect(e.code).toBe("ERR_BODY_ALREADY_USED");
+  }
 });
 
 test("second .text() on async iterable Response rejects", async () => {
@@ -20,7 +25,12 @@ test("second .text() on async iterable Response rejects", async () => {
   const first = await r.text();
   expect(first).toBe("Hi");
   expect(r.bodyUsed).toBe(true);
-  await expect(r.text()).rejects.toThrow();
+  try {
+    await r.text();
+    expect.unreachable();
+  } catch (e: any) {
+    expect(e.code).toBe("ERR_BODY_ALREADY_USED");
+  }
 });
 
 test("second .arrayBuffer() on async iterable Response rejects", async () => {
@@ -32,5 +42,10 @@ test("second .arrayBuffer() on async iterable Response rejects", async () => {
   expect(first).toBeInstanceOf(ArrayBuffer);
   expect(first.byteLength).toBe(3);
   expect(r.bodyUsed).toBe(true);
-  await expect(r.arrayBuffer()).rejects.toThrow();
+  try {
+    await r.arrayBuffer();
+    expect.unreachable();
+  } catch (e: any) {
+    expect(e.code).toBe("ERR_BODY_ALREADY_USED");
+  }
 });

--- a/test/js/web/streams/response-double-consume.test.ts
+++ b/test/js/web/streams/response-double-consume.test.ts
@@ -9,12 +9,14 @@ test("second .bytes() on async iterable Response rejects", async () => {
   expect(first).toBeInstanceOf(Uint8Array);
   expect(first.length).toBe(3);
   expect(r.bodyUsed).toBe(true);
+  let threw = false;
   try {
     await r.bytes();
-    expect.unreachable();
   } catch (e: any) {
+    threw = true;
     expect(e.code).toBe("ERR_BODY_ALREADY_USED");
   }
+  expect(threw).toBe(true);
 });
 
 test("second .text() on async iterable Response rejects", async () => {
@@ -25,12 +27,14 @@ test("second .text() on async iterable Response rejects", async () => {
   const first = await r.text();
   expect(first).toBe("Hi");
   expect(r.bodyUsed).toBe(true);
+  let threw = false;
   try {
     await r.text();
-    expect.unreachable();
   } catch (e: any) {
+    threw = true;
     expect(e.code).toBe("ERR_BODY_ALREADY_USED");
   }
+  expect(threw).toBe(true);
 });
 
 test("second .arrayBuffer() on async iterable Response rejects", async () => {
@@ -42,10 +46,12 @@ test("second .arrayBuffer() on async iterable Response rejects", async () => {
   expect(first).toBeInstanceOf(ArrayBuffer);
   expect(first.byteLength).toBe(3);
   expect(r.bodyUsed).toBe(true);
+  let threw = false;
   try {
     await r.arrayBuffer();
-    expect.unreachable();
   } catch (e: any) {
+    threw = true;
     expect(e.code).toBe("ERR_BODY_ALREADY_USED");
   }
+  expect(threw).toBe(true);
 });

--- a/test/js/web/streams/response-double-consume.test.ts
+++ b/test/js/web/streams/response-double-consume.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { bunExe, bunEnv } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 test("calling .bytes() twice on a Response with async iterable body does not crash", async () => {
   await using proc = Bun.spawn({

--- a/test/js/web/streams/response-double-consume.test.ts
+++ b/test/js/web/streams/response-double-consume.test.ts
@@ -1,0 +1,74 @@
+import { test, expect } from "bun:test";
+import { bunExe, bunEnv } from "harness";
+
+test("calling .bytes() twice on a Response with async iterable body does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      async function* gen() { yield new Uint8Array([1, 2, 3]); }
+      const r = new Response({ [Symbol.asyncIterator]: () => gen() });
+      r.bytes();
+      r.bytes();
+      Bun.gc(true);
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(exitCode).toBe(0);
+});
+
+test("calling .text() twice on a Response with async iterable body does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      async function* gen() { yield new Uint8Array([72, 105]); }
+      const r = new Response({ [Symbol.asyncIterator]: () => gen() });
+      r.text();
+      r.text();
+      Bun.gc(true);
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(exitCode).toBe(0);
+});
+
+test("calling .arrayBuffer() twice on a Response with async iterable body does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      async function* gen() { yield new Uint8Array([1, 2, 3]); }
+      const r = new Response({ [Symbol.asyncIterator]: () => gen() });
+      r.arrayBuffer();
+      r.arrayBuffer();
+      Bun.gc(true);
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/streams/response-double-consume.test.ts
+++ b/test/js/web/streams/response-double-consume.test.ts
@@ -20,8 +20,8 @@ test("calling .bytes() twice on a Response with async iterable body does not cra
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).not.toContain("ASSERTION FAILED");
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe("");
   expect(exitCode).toBe(0);
 });
 
@@ -44,8 +44,8 @@ test("calling .text() twice on a Response with async iterable body does not cras
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).not.toContain("ASSERTION FAILED");
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe("");
   expect(exitCode).toBe(0);
 });
 
@@ -68,7 +68,7 @@ test("calling .arrayBuffer() twice on a Response with async iterable body does n
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).not.toContain("ASSERTION FAILED");
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe("");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
Fixes a deterministic crash (assertion failure in `releaseAssertNoException`) when calling `.bytes()`, `.arrayBuffer()`, `.text()`, or similar body consumption methods twice on a `Response` whose body is an async iterable.

**Root cause:** `readableStreamToArrayBufferDirect` sets the stream's `underlyingSource` private field to `null` after consuming it. However, the `readableStreamToBytes`/`readableStreamToArrayBuffer`/`readableStreamToText`/`readableStreamToArray` functions check `underlyingSource !== undefined`, which doesn't catch `null`. On the second consumption attempt, `null` passes through and gets forwarded to `readableStreamToArrayBufferDirect`, which tries to access properties on it, throwing a TypeError. This exception is then not properly handled by the C++ caller, triggering `releaseAssertNoException`.

**Fix:**
1. Change the JS checks from `!== undefined` to `!= null` (loose equality catches both `null` and `undefined`)
2. Add `RETURN_IF_EXCEPTION` after `call()` in the C++ `readableStreamToBytes` and `readableStreamToArrayBuffer` functions as a safety net
3. Mark stream as disturbed in `readableStreamToArrayBufferDirect`

---
Verification (robobun): Lint JavaScript passes. Diff clean — no TODO/FIXME/HACK, no unrelated changes. All four JS consumption paths consistently use `!= null`. C++ adds `RETURN_IF_EXCEPTION` after `call()` in both functions, reusing the outer `throwScope` (redundant inner `DECLARE_THROW_SCOPE` correctly removed). `stream.$disturbed = true` follows the established pattern (used in 6 other places in ReadableStreamInternals.ts). Three subprocess-based regression tests verify no crash on double-consume — these would fail on main due to the assertion crash. CodeRabbit feedback addressed; second review clean. Previous buildkite run (#41292) had only unrelated failures. Build #41320 still running at time of approval.