### PR TITLE
Fix crash when redis onclose/onconnect is set to non-callable value

### DIFF
--- a/src/valkey/js_valkey.zig
+++ b/src/valkey/js_valkey.zig
@@ -882,9 +882,11 @@ pub const JSValkeyClient = struct {
             js.helloSetCached(this_value, globalObject, hello_value);
             // Call onConnect callback if defined by the user
             if (js.onconnectGetCached(this_value)) |on_connect| {
-                const js_value = this_value;
-                js_value.ensureStillAlive();
-                globalObject.queueMicrotask(on_connect, &[_]JSValue{ js_value, hello_value });
+                if (on_connect.isCallable()) {
+                    const js_value = this_value;
+                    js_value.ensureStillAlive();
+                    globalObject.queueMicrotask(on_connect, &[_]JSValue{ js_value, hello_value });
+                }
             }
 
             if (js.connectionPromiseGetCached(this_value)) |promise| {
@@ -1016,11 +1018,13 @@ pub const JSValkeyClient = struct {
 
         // Call onClose callback if it exists
         if (js.oncloseGetCached(this_jsvalue)) |on_close| {
-            _ = on_close.call(
-                globalObject,
-                this_jsvalue,
-                &[_]JSValue{error_value},
-            ) catch |e| globalObject.reportActiveExceptionAsUnhandled(e);
+            if (on_close.isCallable()) {
+                _ = on_close.call(
+                    globalObject,
+                    this_jsvalue,
+                    &[_]JSValue{error_value},
+                ) catch |e| globalObject.reportActiveExceptionAsUnhandled(e);
+            }
         }
     }
 
@@ -1037,14 +1041,16 @@ pub const JSValkeyClient = struct {
         const this_value = this.this_value.tryGet() orelse return;
         const globalObject = this.globalObject;
         if (js.oncloseGetCached(this_value)) |on_close| {
-            const loop = this.client.vm.eventLoop();
-            loop.enter();
-            defer loop.exit();
-            _ = on_close.call(
-                globalObject,
-                this_value,
-                &[_]JSValue{value},
-            ) catch |e| globalObject.reportActiveExceptionAsUnhandled(e);
+            if (on_close.isCallable()) {
+                const loop = this.client.vm.eventLoop();
+                loop.enter();
+                defer loop.exit();
+                _ = on_close.call(
+                    globalObject,
+                    this_value,
+                    &[_]JSValue{value},
+                ) catch |e| globalObject.reportActiveExceptionAsUnhandled(e);
+            }
         }
     }
 

--- a/test/js/valkey/valkey-non-callable-callback.test.ts
+++ b/test/js/valkey/valkey-non-callable-callback.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("non-callable onclose does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const redis = new Bun.RedisClient("redis://localhost:6379");
+      redis.onclose = 42;
+      try { await redis.connect(); } catch(e) {}
+      try { redis.close(); } catch(e) {}
+      await Bun.sleep(500);
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(exitCode).not.toBe(6); // SIGABRT
+});
+
+test("non-callable onconnect does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const redis = new Bun.RedisClient("redis://localhost:6379");
+      redis.onconnect = "not a function";
+      try { await redis.connect(); } catch(e) {}
+      try { redis.close(); } catch(e) {}
+      await Bun.sleep(500);
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(exitCode).not.toBe(6); // SIGABRT
+});

--- a/test/js/valkey/valkey-non-callable-callback.test.ts
+++ b/test/js/valkey/valkey-non-callable-callback.test.ts
@@ -21,7 +21,7 @@ test("non-callable onclose does not crash", async () => {
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
   expect(stderr).not.toContain("ASSERTION FAILED");
-  expect(exitCode).not.toBe(6); // SIGABRT
+  expect(exitCode).toBe(0);
 });
 
 test("non-callable onconnect does not crash", async () => {
@@ -44,5 +44,5 @@ test("non-callable onconnect does not crash", async () => {
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
   expect(stderr).not.toContain("ASSERTION FAILED");
-  expect(exitCode).not.toBe(6); // SIGABRT
+  expect(exitCode).toBe(0);
 });

--- a/test/js/valkey/valkey-non-callable-callback.test.ts
+++ b/test/js/valkey/valkey-non-callable-callback.test.ts
@@ -15,12 +15,10 @@ test("non-callable onclose does not crash", async () => {
       `,
     ],
     env: bunEnv,
-    stderr: "pipe",
   });
 
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const exitCode = await proc.exited;
 
-  expect(stderr).not.toContain("ASSERTION FAILED");
   expect(exitCode).toBe(0);
 });
 
@@ -38,11 +36,9 @@ test("non-callable onconnect does not crash", async () => {
       `,
     ],
     env: bunEnv,
-    stderr: "pipe",
   });
 
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const exitCode = await proc.exited;
 
-  expect(stderr).not.toContain("ASSERTION FAILED");
   expect(exitCode).toBe(0);
 });

--- a/test/js/valkey/valkey-non-callable-callback.test.ts
+++ b/test/js/valkey/valkey-non-callable-callback.test.ts
@@ -1,17 +1,16 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-test("non-callable onclose does not crash", async () => {
+test.concurrent("non-callable onclose does not crash", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `
-      const redis = new Bun.RedisClient("redis://localhost:6379");
+      const redis = new Bun.RedisClient("redis://localhost:6379", { autoReconnect: false });
       redis.onclose = 42;
       try { await redis.connect(); } catch(e) {}
       try { redis.close(); } catch(e) {}
-      await Bun.sleep(500);
       `,
     ],
     env: bunEnv,
@@ -22,17 +21,16 @@ test("non-callable onclose does not crash", async () => {
   expect(exitCode).toBe(0);
 });
 
-test("non-callable onconnect does not crash", async () => {
+test.concurrent("non-callable onconnect does not crash", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `
-      const redis = new Bun.RedisClient("redis://localhost:6379");
+      const redis = new Bun.RedisClient("redis://localhost:6379", { autoReconnect: false });
       redis.onconnect = "not a function";
       try { await redis.connect(); } catch(e) {}
       try { redis.close(); } catch(e) {}
-      await Bun.sleep(500);
       `,
     ],
     env: bunEnv,


### PR DESCRIPTION
The valkey (redis) client caches `onclose` and `onconnect` callback values without validating that they are callable. When a connection event fires, the cached value is passed to `.call()` which triggers an assertion failure in `Bun__JSValue__call` if the value is not a function.

**Root cause:** `setOnConnect` and `setOnClose` store any JS value via the codegen cache, and `onValkeyClose`, `failWithJSValue`, and `onValkeyConnect` retrieve and invoke them without checking `isCallable()`.

**Fix:** Add `isCallable()` guards at the three call sites before invoking the cached callbacks.

**Repro:**
```js
const redis = new Bun.RedisClient("redis://localhost:6379");
redis.onclose = 42;
try { await redis.connect(); } catch(e) {}
try { redis.close(); } catch(e) {}
```

---

Verification (robobun): Zig diff adds `isCallable()` guards at all three call sites in `js_valkey.zig` (onValkeyConnect, onValkeyClose, failWithJSValue) — minimal and correct. Regression test spawns subprocesses with non-callable `onclose=42` / `onconnect="not a function"`, asserts `exitCode === 0`; on main this crashes via assertion failure in `Bun__JSValue__call`. All bot review feedback addressed across iterations (`.toBe(0)`, stderr removal, `autoReconnect: false`, `test.concurrent`). No TODO/FIXME/HACK in diff. Lint JavaScript passes. Buildkite #41347 shows 0 job/step failures; "failing" state is from infrastructure error annotation (macOS runners expired), not code.