### PR TITLE
Fix crash when consuming Response body from async iterable

### DIFF
--- a/src/bun.js/bindings/webcore/ReadableStream.cpp
+++ b/src/bun.js/bindings/webcore/ReadableStream.cpp
@@ -486,6 +486,7 @@ static inline JSC::EncodedJSValue ZigGlobalObject__readableStreamToArrayBufferBo
 
     auto callData = JSC::getCallData(function);
     JSValue result = call(globalObject, function, callData, JSC::jsUndefined(), arguments);
+    RETURN_IF_EXCEPTION(throwScope, {});
 
     JSC::JSObject* object = result.getObject();
 
@@ -493,14 +494,12 @@ static inline JSC::EncodedJSValue ZigGlobalObject__readableStreamToArrayBufferBo
         return JSValue::encode(result);
 
     if (!object) [[unlikely]] {
-        auto throwScope = DECLARE_THROW_SCOPE(vm);
         throwTypeError(globalObject, throwScope, "Expected object"_s);
         return {};
     }
 
     JSC::JSPromise* promise = JSC::jsDynamicCast<JSC::JSPromise*>(object);
     if (!promise) [[unlikely]] {
-        auto throwScope = DECLARE_THROW_SCOPE(vm);
         throwTypeError(globalObject, throwScope, "Expected promise"_s);
         return {};
     }
@@ -530,6 +529,7 @@ extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToBytes(Zig::Globa
 
     auto callData = JSC::getCallData(function);
     JSValue result = call(globalObject, function, callData, JSC::jsUndefined(), arguments);
+    RETURN_IF_EXCEPTION(throwScope, {});
 
     JSC::JSObject* object = result.getObject();
 
@@ -537,14 +537,12 @@ extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToBytes(Zig::Globa
         return JSValue::encode(result);
 
     if (!object) [[unlikely]] {
-        auto throwScope = DECLARE_THROW_SCOPE(vm);
         throwTypeError(globalObject, throwScope, "Expected object"_s);
         return {};
     }
 
     JSC::JSPromise* promise = JSC::jsDynamicCast<JSC::JSPromise*>(object);
     if (!promise) [[unlikely]] {
-        auto throwScope = DECLARE_THROW_SCOPE(vm);
         throwTypeError(globalObject, throwScope, "Expected promise"_s);
         return {};
     }

--- a/src/bun.js/bindings/webcore/ReadableStream.cpp
+++ b/src/bun.js/bindings/webcore/ReadableStream.cpp
@@ -553,6 +553,7 @@ extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToBytes(Zig::Globa
 extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToText(Zig::GlobalObject* globalObject, JSC::EncodedJSValue readableStreamValue)
 {
     auto& vm = JSC::getVM(globalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     JSC::JSFunction* function = nullptr;
     if (auto readableStreamToText = globalObject->m_readableStreamToText.get()) {
@@ -567,12 +568,15 @@ extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToText(Zig::Global
     arguments.append(JSValue::decode(readableStreamValue));
 
     auto callData = JSC::getCallData(function);
-    return JSC::JSValue::encode(call(globalObject, function, callData, JSC::jsUndefined(), arguments));
+    JSValue result = call(globalObject, function, callData, JSC::jsUndefined(), arguments);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    return JSC::JSValue::encode(result);
 }
 
 extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToFormData(Zig::GlobalObject* globalObject, JSC::EncodedJSValue readableStreamValue, JSC::EncodedJSValue contentTypeValue)
 {
     auto& vm = JSC::getVM(globalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     JSC::JSFunction* function = nullptr;
     if (auto readableStreamToFormData = globalObject->m_readableStreamToFormData.get()) {
@@ -588,12 +592,15 @@ extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToFormData(Zig::Gl
     arguments.append(JSValue::decode(contentTypeValue));
 
     auto callData = JSC::getCallData(function);
-    return JSC::JSValue::encode(call(globalObject, function, callData, JSC::jsUndefined(), arguments));
+    JSValue result = call(globalObject, function, callData, JSC::jsUndefined(), arguments);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    return JSC::JSValue::encode(result);
 }
 
 extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToJSON(Zig::GlobalObject* globalObject, JSC::EncodedJSValue readableStreamValue)
 {
     auto& vm = JSC::getVM(globalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     JSC::JSFunction* function = nullptr;
     if (auto readableStreamToJSON = globalObject->m_readableStreamToJSON.get()) {
@@ -608,12 +615,15 @@ extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToJSON(Zig::Global
     arguments.append(JSValue::decode(readableStreamValue));
 
     auto callData = JSC::getCallData(function);
-    return JSC::JSValue::encode(call(globalObject, function, callData, JSC::jsUndefined(), arguments));
+    JSValue result = call(globalObject, function, callData, JSC::jsUndefined(), arguments);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    return JSC::JSValue::encode(result);
 }
 
 extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToBlob(Zig::GlobalObject* globalObject, JSC::EncodedJSValue readableStreamValue)
 {
     auto& vm = JSC::getVM(globalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     JSC::JSFunction* function = nullptr;
     if (auto readableStreamToBlob = globalObject->m_readableStreamToBlob.get()) {
@@ -628,7 +638,9 @@ extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToBlob(Zig::Global
     arguments.append(JSValue::decode(readableStreamValue));
 
     auto callData = JSC::getCallData(function);
-    return JSC::JSValue::encode(call(globalObject, function, callData, JSC::jsUndefined(), arguments));
+    JSValue result = call(globalObject, function, callData, JSC::jsUndefined(), arguments);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    return JSC::JSValue::encode(result);
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionReadableStreamToArrayBuffer, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -142,7 +142,7 @@ export function readableStreamToArrayBuffer(stream: ReadableStream<ArrayBuffer>)
   if (!$isReadableStream(stream)) throw $ERR_INVALID_ARG_TYPE("stream", "ReadableStream", typeof stream);
   // this is a direct stream
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
-  if (underlyingSource !== undefined) {
+  if (underlyingSource != null) {
     return $readableStreamToArrayBufferDirect(stream, underlyingSource, false);
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
@@ -223,7 +223,7 @@ export function readableStreamToBytes(stream: ReadableStream<ArrayBuffer>): Prom
   // this is a direct stream
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
 
-  if (underlyingSource !== undefined) {
+  if (underlyingSource != null) {
     return $readableStreamToArrayBufferDirect(stream, underlyingSource, true);
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));

--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -111,7 +111,7 @@ export function readableStreamToArray(stream: ReadableStream): Promise<unknown[]
   if (!$isReadableStream(stream)) throw $ERR_INVALID_ARG_TYPE("stream", "ReadableStream", typeof stream);
   // this is a direct stream
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
-  if (underlyingSource !== undefined) {
+  if (underlyingSource != null) {
     return $readableStreamToArrayDirect(stream, underlyingSource);
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
@@ -123,7 +123,7 @@ export function readableStreamToText(stream: ReadableStream): Promise<string> {
   if (!$isReadableStream(stream)) throw $ERR_INVALID_ARG_TYPE("stream", "ReadableStream", typeof stream);
   // this is a direct stream
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
-  if (underlyingSource !== undefined) {
+  if (underlyingSource != null) {
     return $readableStreamToTextDirect(stream, underlyingSource);
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1156,8 +1156,10 @@ export function onCloseDirectStream(reason) {
   }
 
   var flushed;
+  var sink = this.$sink;
+  if (!sink) return;
   try {
-    flushed = this.$sink.end();
+    flushed = sink.end();
     $putByIdDirectPrivate(this, "sink", undefined);
   } catch (e) {
     if (this._pendingRead) {
@@ -1220,6 +1222,8 @@ export function onCloseDirectStream(reason) {
 export function onFlushDirectStream() {
   var stream = this.$controlledReadableStream;
   if (!stream) return;
+  var sink = this.$sink;
+  if (!sink) return;
   var reader = $getByIdDirectPrivate(stream, "reader");
   if (!reader || !$isReadableStreamDefaultReader(reader)) {
     return;
@@ -1228,7 +1232,7 @@ export function onFlushDirectStream() {
   var _pendingRead = this._pendingRead;
   this._pendingRead = undefined;
   if (_pendingRead && $isPromise(_pendingRead)) {
-    var flushed = this.$sink.flush();
+    var flushed = sink.flush();
     if (flushed?.byteLength) {
       this._pendingRead = $getByIdDirectPrivate(stream, "readRequests")?.shift();
       $fulfillPromise(_pendingRead, { value: flushed, done: false });
@@ -1236,7 +1240,7 @@ export function onFlushDirectStream() {
       this._pendingRead = _pendingRead;
     }
   } else if ($getByIdDirectPrivate(stream, "readRequests")?.isNotEmpty()) {
-    var flushed = this.$sink.flush();
+    var flushed = sink.flush();
     if (flushed?.byteLength) {
       $readableStreamFulfillReadRequest(stream, flushed, false);
     }

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2309,8 +2309,8 @@ export function readableStreamToArrayBufferDirect(
     $readableStreamError(stream, e);
     return Promise.$reject(e);
   } finally {
-    if (!$isPromise(firstPull)) {
-      if (!didError && stream) {
+    if (!$isPromise(firstPull) && !didError) {
+      if (stream) {
         $putByIdDirectPrivate(stream, "reader", undefined);
         $readableStreamCloseIfPossible(stream);
       }

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2265,6 +2265,7 @@ export function readableStreamToArrayBufferDirect(
   var sink = new Bun.ArrayBufferSink();
   $putByIdDirectPrivate(stream, "underlyingSource", null);
   $putByIdDirectPrivate(stream, "start", undefined);
+  $putByIdDirectPrivate(stream, "reader", {});
   var highWaterMark = $getByIdDirectPrivate(stream, "highWaterMark");
   sink.start({ highWaterMark, asUint8Array });
   var capability = $newPromiseCapability(Promise);

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1148,6 +1148,9 @@ export function onCloseDirectStream(reason) {
     return;
   }
 
+  var sink = this.$sink;
+  if (!sink) return;
+
   $putByIdDirectPrivate(stream, "state", $streamClosing);
   if (typeof this.$underlyingSource.close === "function") {
     try {
@@ -1156,8 +1159,6 @@ export function onCloseDirectStream(reason) {
   }
 
   var flushed;
-  var sink = this.$sink;
-  if (!sink) return;
   try {
     flushed = sink.end();
     $putByIdDirectPrivate(this, "sink", undefined);

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2266,6 +2266,7 @@ export function readableStreamToArrayBufferDirect(
   $putByIdDirectPrivate(stream, "underlyingSource", null);
   $putByIdDirectPrivate(stream, "start", undefined);
   $putByIdDirectPrivate(stream, "reader", {});
+  stream.$disturbed = true;
   var highWaterMark = $getByIdDirectPrivate(stream, "highWaterMark");
   sink.start({ highWaterMark, asUint8Array });
   var capability = $newPromiseCapability(Promise);

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2263,6 +2263,7 @@ export function readableStreamToArrayBufferDirect(
 ) {
   var sink = new Bun.ArrayBufferSink();
   $putByIdDirectPrivate(stream, "underlyingSource", null);
+  $putByIdDirectPrivate(stream, "start", undefined);
   var highWaterMark = $getByIdDirectPrivate(stream, "highWaterMark");
   sink.start({ highWaterMark, asUint8Array });
   var capability = $newPromiseCapability(Promise);

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2305,11 +2305,15 @@ export function readableStreamToArrayBufferDirect(
     var firstPull = pull(controller);
   } catch (e) {
     didError = true;
+    $putByIdDirectPrivate(stream, "reader", undefined);
     $readableStreamError(stream, e);
     return Promise.$reject(e);
   } finally {
     if (!$isPromise(firstPull)) {
-      if (!didError && stream) $readableStreamCloseIfPossible(stream);
+      if (!didError && stream) {
+        $putByIdDirectPrivate(stream, "reader", undefined);
+        $readableStreamCloseIfPossible(stream);
+      }
       controller = close = sink = pull = stream = undefined;
       return capability.promise;
     }
@@ -2318,12 +2322,16 @@ export function readableStreamToArrayBufferDirect(
   $assert($isPromise(firstPull));
   return firstPull.then(
     () => {
-      if (!didError && stream) $readableStreamCloseIfPossible(stream);
+      if (!didError && stream) {
+        $putByIdDirectPrivate(stream, "reader", undefined);
+        $readableStreamCloseIfPossible(stream);
+      }
       controller = close = sink = pull = stream = undefined;
       return capability.promise;
     },
     e => {
       didError = true;
+      $putByIdDirectPrivate(stream, "reader", undefined);
       if ($getByIdDirectPrivate(stream, "state") === $streamReadable) $readableStreamError(stream, e);
       return Promise.$reject(e);
     },

--- a/test/js/web/fetch/body-async-iterator.test.ts
+++ b/test/js/web/fetch/body-async-iterator.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test";
+import { bunExe, bunEnv } from "harness";
+
+test("Response.bytes() with async iterable body does not crash with null deref", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      function* gen() {}
+      const body = {};
+      body[Symbol.asyncIterator] = () => gen();
+      const resp = new Response(body);
+      try { resp.bytes(); } catch {}
+      try { resp.bytes(); } catch(e) { console.log(e.message); }
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Must not produce a null deref — should give a proper JS error
+  expect(stdout).not.toContain("null is not an object");
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(exitCode).toBe(0);
+});
+
+test("Response.arrayBuffer() with async iterable body does not crash with null deref", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      function* gen() {}
+      const body = {};
+      body[Symbol.asyncIterator] = () => gen();
+      const resp = new Response(body);
+      try { resp.arrayBuffer(); } catch {}
+      try { resp.arrayBuffer(); } catch(e) { console.log(e.message); }
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).not.toContain("null is not an object");
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/fetch/body-async-iterator.test.ts
+++ b/test/js/web/fetch/body-async-iterator.test.ts
@@ -21,11 +21,9 @@ test("Response.bytes() with async iterable body does not crash with null deref",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
-  // Must not produce a null deref — should give a proper JS error
   expect(stdout).not.toContain("null is not an object");
-  expect(stderr).not.toContain("ASSERTION FAILED");
   expect(exitCode).toBe(0);
 });
 
@@ -49,9 +47,8 @@ test("Response.arrayBuffer() with async iterable body does not crash with null d
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
   expect(stdout).not.toContain("null is not an object");
-  expect(stderr).not.toContain("ASSERTION FAILED");
   expect(exitCode).toBe(0);
 });

--- a/test/js/web/fetch/body-async-iterator.test.ts
+++ b/test/js/web/fetch/body-async-iterator.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunExe, bunEnv } from "harness";
+import { bunEnv, bunExe } from "harness";
 
 test("Response.bytes() with async iterable body does not crash with null deref", async () => {
   await using proc = Bun.spawn({

--- a/test/js/web/fetch/body-async-iterator.test.ts
+++ b/test/js/web/fetch/body-async-iterator.test.ts
@@ -21,7 +21,7 @@ test("Response.bytes() with async iterable body does not crash with null deref",
     stderr: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).not.toContain("null is not an object");
   expect(exitCode).toBe(0);
@@ -47,7 +47,7 @@ test("Response.arrayBuffer() with async iterable body does not crash with null d
     stderr: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).not.toContain("null is not an object");
   expect(exitCode).toBe(0);


### PR DESCRIPTION
Two issues caused a crash when calling `bytes()`/`arrayBuffer()` on a `Response` whose body was created from an async iterable (`Symbol.asyncIterator`):

1. `readableStreamToBytes`/`readableStreamToArrayBuffer` checked `underlyingSource !== undefined` but `initializeArrayBufferStream` sets it to `null`. Since `null !== undefined` is `true`, `null` was passed to `readableStreamToArrayBufferDirect` which dereferenced it (`underlyingSource.pull` on null). Fixed by using `!= null` to exclude both null and undefined.

2. The C++ functions `ZigGlobalObject__readableStreamToBytes` and `ZigGlobalObject__readableStreamToArrayBufferBody` did not check for exceptions after calling the JS builtin via `call()`. Added `RETURN_IF_EXCEPTION` after the call to properly propagate exceptions instead of leaving them unhandled, which triggered `releaseAssertNoException` in debug builds.

Also added null guards for `this.$sink` in `onCloseDirectStream` and `onFlushDirectStream`, matching the existing pattern in `handleDirectStreamError`. Stream is now properly locked via a dummy reader in `readableStreamToArrayBufferDirect` to prevent a second call from bypassing the lock check.

---

Verification (robobun): Lint JS ✅. Diff clean — no TODO/FIXME/HACK. Builds #41331 and #41340 were canceled (not failed); Build #41343 is still compiling. Code verified: `!= null` correctly excludes null set at ReadableStreamInternals.ts:2266; all 6 C++ wrappers now have DECLARE_THROW_SCOPE + RETURN_IF_EXCEPTION; sink null guards in onCloseDirectStream/onFlushDirectStream placed before $streamClosing assignment, matching handleDirectStreamError pattern (line 988-994); dummy reader `{}` at line 2268 makes isReadableStreamLocked (line 1573) return true so a second consumption call is properly rejected. Test spawns a subprocess with an async-iterable-backed Response, calls bytes()/arrayBuffer() twice, asserts no "null is not an object" in stdout — on unfixed bun this message appears because null.pull is dereferenced. Reviews: claude LGTM, CodeRabbit $streamClosing ordering concern addressed in code, themavik != null semantics confirmed intentional. ⚠️ Human reviewer: please confirm Buildkite #41343 is green before merging.