### PR TITLE
Fix Bun.Archive creating empty files when using Bun.file() as input

### DIFF
--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -4,7 +4,9 @@ use std::ffi::CString;
 
 use crate::webcore::Blob;
 use crate::webcore::BlobExt as _;
-use crate::webcore::blob::{Store as BlobStore, StoreRef};
+use crate::webcore::blob::store::Data;
+use crate::webcore::blob::{MAX_SIZE, Store as BlobStore, StoreRef};
+use crate::webcore::node_types::PathOrFileDescriptor;
 use bun_core::zig_string::Slice as ZigStringSlice;
 use bun_core::{self, Output, ZBox};
 use bun_event_loop::{TaskTag, Taskable, task_tag};
@@ -391,9 +393,12 @@ fn build_tarball_from_object(global: &JSGlobalObject, obj: JSValue) -> JsResult<
 
 /// Returns data as a ZigString.Slice (handles ownership automatically via deinit)
 fn get_entry_data(global: &JSGlobalObject, value: JSValue) -> JsResult<ZigStringSlice> {
-    // For Blob, use sharedView (no copy needed). The backing store outlives
-    // the returned slice for the duration of the caller's tarball build.
+    // For Blob, use sharedView for in-memory blobs; read the file for
+    // file-backed blobs (Bun.file()), whose shared_view() is empty.
     if let Some(blob) = blob_from_js(value) {
+        if blob.needs_to_read_file() {
+            return read_file_backed_blob(global, blob);
+        }
         return Ok(ZigStringSlice::from_utf8_never_free(blob.shared_view()));
     }
 
@@ -404,6 +409,47 @@ fn get_entry_data(global: &JSGlobalObject, value: JSValue) -> JsResult<ZigString
 
     // For strings, convert (allocates)
     value.to_slice(global)
+}
+
+/// Reads data from a file-backed Blob synchronously, respecting blob offset and size.
+fn read_file_backed_blob(global: &JSGlobalObject, blob: &Blob) -> JsResult<ZigStringSlice> {
+    let Some(store) = blob.store() else {
+        return Ok(ZigStringSlice::EMPTY);
+    };
+    let Data::File(file) = &store.data else {
+        return Ok(ZigStringSlice::EMPTY);
+    };
+
+    // Read the full file first since bun_sys::File has no offset/length read.
+    let file_data = match &file.pathlike {
+        PathOrFileDescriptor::Path(path) => bun_sys::File::read_from(Fd::cwd(), path.slice())
+            .map_err(|e| e.with_path(path.slice()).throw(global))?,
+        // borrow(): the fd is owned by the blob, so this must not close it on drop.
+        PathOrFileDescriptor::Fd(fd) => bun_sys::File::borrow(fd)
+            .read_to_end()
+            .map_err(|e| e.throw(global))?,
+    };
+
+    if file_data.is_empty() {
+        return Ok(ZigStringSlice::EMPTY);
+    }
+
+    // Apply blob offset and size to support sliced file-backed blobs.
+    let offset = blob.offset.get() as usize;
+    if offset >= file_data.len() {
+        return Ok(ZigStringSlice::EMPTY);
+    }
+    let remaining = file_data.len() - offset;
+    let size = if blob.size.get() == MAX_SIZE {
+        remaining
+    } else {
+        (blob.size.get() as usize).min(remaining)
+    };
+
+    if offset == 0 && size == file_data.len() {
+        return Ok(ZigStringSlice::init_owned(file_data));
+    }
+    Ok(ZigStringSlice::init_owned(file_data[offset..offset + size].to_vec()))
 }
 
 /// Static method: Archive.write(path, data, options?)

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -449,7 +449,9 @@ fn read_file_backed_blob(global: &JSGlobalObject, blob: &Blob) -> JsResult<ZigSt
     if offset == 0 && size == file_data.len() {
         return Ok(ZigStringSlice::init_owned(file_data));
     }
-    Ok(ZigStringSlice::init_owned(file_data[offset..offset + size].to_vec()))
+    Ok(ZigStringSlice::init_owned(
+        file_data[offset..offset + size].to_vec(),
+    ))
 }
 
 /// Static method: Archive.write(path, data, options?)

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -174,6 +174,77 @@ describe("Bun.Archive", () => {
     });
   });
 
+  describe("Bun.file() input", () => {
+    test("includes file content when using Bun.file() as input", async () => {
+      const content = "Hello, World! This is test content.\n";
+
+      using dir = tempDir("archive-file-input", {
+        "input.txt": content,
+      });
+
+      const archive = new Bun.Archive({
+        "test.txt": Bun.file(`${dir}/input.txt`),
+      });
+
+      const files = await archive.files();
+      const f = files.get("test.txt");
+      expect(f).toBeDefined();
+      expect(await f!.text()).toBe(content);
+      expect(f!.size).toBe(content.length);
+    });
+
+    test("handles multiple Bun.file() entries", async () => {
+      using dir = tempDir("archive-multi-file", {
+        "a.txt": "file a content",
+        "b.txt": "file b content",
+      });
+
+      const archive = new Bun.Archive({
+        "a.txt": Bun.file(`${dir}/a.txt`),
+        "b.txt": Bun.file(`${dir}/b.txt`),
+        "c.txt": "inline content",
+      });
+
+      const files = await archive.files();
+      expect(await files.get("a.txt")!.text()).toBe("file a content");
+      expect(await files.get("b.txt")!.text()).toBe("file b content");
+      expect(await files.get("c.txt")!.text()).toBe("inline content");
+    });
+
+    test("roundtrips Bun.file() through Bun.write", async () => {
+      const content = "roundtrip test content";
+
+      using dir = tempDir("archive-roundtrip", {
+        "source.txt": content,
+      });
+
+      const archive = new Bun.Archive({
+        "dest.txt": Bun.file(`${dir}/source.txt`),
+      });
+
+      await Bun.write(`${dir}/output.tar`, archive);
+
+      const loaded = new Bun.Archive(await Bun.file(`${dir}/output.tar`).bytes());
+      const files = await loaded.files();
+      expect(await files.get("dest.txt")!.text()).toBe(content);
+    });
+
+    test("handles sliced Bun.file() blobs", async () => {
+      const content = "0123456789abcdef";
+
+      using dir = tempDir("archive-sliced-file", {
+        "data.txt": content,
+      });
+
+      const archive = new Bun.Archive({
+        "sliced.txt": Bun.file(`${dir}/data.txt`).slice(5, 10),
+      });
+
+      const files = await archive.files();
+      expect(await files.get("sliced.txt")!.text()).toBe("56789");
+    });
+  });
+
   describe("archive.blob()", () => {
     test("returns a Blob", async () => {
       const archive = new Bun.Archive({

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -183,7 +183,7 @@ describe("Bun.Archive", () => {
       });
 
       const archive = new Bun.Archive({
-        "test.txt": Bun.file(`${dir}/input.txt`),
+        "test.txt": Bun.file(join(String(dir), "input.txt")),
       });
 
       const files = await archive.files();
@@ -200,8 +200,8 @@ describe("Bun.Archive", () => {
       });
 
       const archive = new Bun.Archive({
-        "a.txt": Bun.file(`${dir}/a.txt`),
-        "b.txt": Bun.file(`${dir}/b.txt`),
+        "a.txt": Bun.file(join(String(dir), "a.txt")),
+        "b.txt": Bun.file(join(String(dir), "b.txt")),
         "c.txt": "inline content",
       });
 
@@ -219,12 +219,12 @@ describe("Bun.Archive", () => {
       });
 
       const archive = new Bun.Archive({
-        "dest.txt": Bun.file(`${dir}/source.txt`),
+        "dest.txt": Bun.file(join(String(dir), "source.txt")),
       });
 
-      await Bun.write(`${dir}/output.tar`, archive);
+      await Bun.write(join(String(dir), "output.tar"), archive);
 
-      const loaded = new Bun.Archive(await Bun.file(`${dir}/output.tar`).bytes());
+      const loaded = new Bun.Archive(await Bun.file(join(String(dir), "output.tar")).bytes());
       const files = await loaded.files();
       expect(await files.get("dest.txt")!.text()).toBe(content);
     });
@@ -237,7 +237,7 @@ describe("Bun.Archive", () => {
       });
 
       const archive = new Bun.Archive({
-        "sliced.txt": Bun.file(`${dir}/data.txt`).slice(5, 10),
+        "sliced.txt": Bun.file(join(String(dir), "data.txt")).slice(5, 10),
       });
 
       const files = await archive.files();


### PR DESCRIPTION
## Problem

`Bun.Archive` creates empty files when `Bun.file()` is passed as an entry value, even though `Bun.file()` returns a `Blob` (a documented supported input type).

```ts
const archive = new Bun.Archive({
  "test.txt": Bun.file("./test.txt"), // file content is empty in the archive
});
```

## Cause

`Bun.file()` creates a file-backed Blob (its store has `data == File`). In `get_entry_data()`, the code called `blob.shared_view()`, which only returns data for in-memory (`Bytes`) stores. For file-backed stores it returns an empty slice, so archives always got 0 bytes for these entries.

## Fix

`get_entry_data()` now checks `blob.needs_to_read_file()` and, for file-backed blobs, reads the file synchronously via `bun_sys::File::read_from` (path-based) or `File::borrow(fd).read_to_end()` (fd-based), then applies the blob offset/size window so sliced `Bun.file().slice(...)` blobs archive the correct range.

## Verification

- Without the fix, all 4 new tests fail (empty content).
- With the fix, they pass; the full `archive.test.ts` suite (105 tests) passes.

---

Note: this PR was rebased onto main after `Bun.Archive` was ported from Zig to Rust. The fix was reapplied to `src/runtime/api/Archive.rs` (previously `Archive.zig`); tests live in the existing `test/js/bun/archive.test.ts` under a `describe("Bun.file() input")` block.

Closes #28459