### PR TITLE
fix OOB in pathToFileURL with long relative paths

### DIFF
--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -2048,13 +2048,18 @@ export fn ResolvePath__joinAbsStringBufCurrentPlatformBunString(
     const str = in.toUTF8WithoutRef(bun.default_allocator);
     defer str.deinit();
 
-    const out_slice = joinAbsStringBuf(
-        globalObject.bunVM().transpiler.fs.top_level_dir,
-        &join_buf,
-        &.{str.slice()},
-        .auto,
-    );
+    const cwd = globalObject.bunVM().transpiler.fs.top_level_dir;
+    const input = str.slice();
+    const total = cwd.len + input.len + 2;
 
+    if (total < join_buf.len) {
+        const out_slice = joinAbsStringBuf(cwd, &join_buf, &.{input}, .auto);
+        return bun.String.cloneUTF8(out_slice);
+    }
+
+    const buf = bun.handleOom(bun.default_allocator.alloc(u8, total));
+    defer bun.default_allocator.free(buf);
+    const out_slice = joinAbsStringBuf(cwd, buf, &.{input}, .auto);
     return bun.String.cloneUTF8(out_slice);
 }
 

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -2052,7 +2052,7 @@ export fn ResolvePath__joinAbsStringBufCurrentPlatformBunString(
     const input = str.slice();
     const total = cwd.len + input.len + 2;
 
-    if (total < join_buf.len) {
+    if (total <= join_buf.len) {
         const out_slice = joinAbsStringBuf(cwd, &join_buf, &.{input}, .auto);
         return bun.String.cloneUTF8(out_slice);
     }

--- a/test/js/node/url/pathToFileURL.test.ts
+++ b/test/js/node/url/pathToFileURL.test.ts
@@ -6,7 +6,10 @@ test("pathToFileURL doesn't leak memory", () => {
 });
 
 test("pathToFileURL handles relative paths longer than 4096 bytes", () => {
-  expect(["-e", 'const p = Buffer.alloc(200000, "a").toString(); const u = Bun.pathToFileURL(p); if (!u.href.endsWith("/" + p)) throw new Error(u.href)']).toRun();
+  expect([
+    "-e",
+    'const p = Buffer.alloc(200000, "a").toString(); const u = Bun.pathToFileURL(p); if (!u.href.endsWith("/" + p)) throw new Error(u.href)',
+  ]).toRun();
 });
 
 test("pathToFileURL escapes special characters", () => {

--- a/test/js/node/url/pathToFileURL.test.ts
+++ b/test/js/node/url/pathToFileURL.test.ts
@@ -9,7 +9,11 @@ test("pathToFileURL doesn't leak memory", () => {
 test("pathToFileURL handles relative paths longer than 4096 bytes", async () => {
   const longPath = Buffer.alloc(5000, "a").toString();
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `const url = Bun.pathToFileURL(Buffer.alloc(5000, "a").toString()); console.log(url.href.endsWith("${longPath}"))`],
+    cmd: [
+      bunExe(),
+      "-e",
+      `const url = Bun.pathToFileURL(Buffer.alloc(5000, "a").toString()); console.log(url.href.endsWith("${longPath}"))`,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",

--- a/test/js/node/url/pathToFileURL.test.ts
+++ b/test/js/node/url/pathToFileURL.test.ts
@@ -1,8 +1,23 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import path from "path";
 
 test("pathToFileURL doesn't leak memory", () => {
   expect([path.join(import.meta.dir, "pathToFileURL-leak-fixture.js")]).toRun();
+});
+
+test("pathToFileURL handles relative paths longer than 4096 bytes", async () => {
+  const longPath = Buffer.alloc(5000, "a").toString();
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `const url = Bun.pathToFileURL(Buffer.alloc(5000, "a").toString()); console.log(url.href.endsWith("${longPath}"))`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout.trim()).toBe("true");
+  expect(exitCode).toBe(0);
 });
 
 test("pathToFileURL escapes special characters", () => {

--- a/test/js/node/url/pathToFileURL.test.ts
+++ b/test/js/node/url/pathToFileURL.test.ts
@@ -1,27 +1,13 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunExe } from "harness";
 import path from "path";
 
 test("pathToFileURL doesn't leak memory", () => {
   expect([path.join(import.meta.dir, "pathToFileURL-leak-fixture.js")]).toRun();
 });
 
-test("pathToFileURL handles relative paths longer than 4096 bytes", async () => {
-  const longPath = Buffer.alloc(5000, "a").toString();
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `const url = Bun.pathToFileURL(Buffer.alloc(5000, "a").toString()); console.log(url.href.endsWith("/${longPath}"))`,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "ignore",
-  });
-
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  expect(stdout.trim()).toBe("true");
-  expect(exitCode).toBe(0);
+test("pathToFileURL handles relative paths longer than 4096 bytes", () => {
+  expect([bunExe(), "-e", 'Bun.pathToFileURL("a".repeat(200000))']).toRun();
 });
 
 test("pathToFileURL escapes special characters", () => {

--- a/test/js/node/url/pathToFileURL.test.ts
+++ b/test/js/node/url/pathToFileURL.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from "bun:test";
-import { bunExe } from "harness";
 import path from "path";
 
 test("pathToFileURL doesn't leak memory", () => {
@@ -7,7 +6,7 @@ test("pathToFileURL doesn't leak memory", () => {
 });
 
 test("pathToFileURL handles relative paths longer than 4096 bytes", () => {
-  expect([bunExe(), "-e", 'Bun.pathToFileURL("a".repeat(200000))']).toRun();
+  expect(["-e", 'Bun.pathToFileURL(Buffer.alloc(200000, "a").toString())']).toRun();
 });
 
 test("pathToFileURL escapes special characters", () => {

--- a/test/js/node/url/pathToFileURL.test.ts
+++ b/test/js/node/url/pathToFileURL.test.ts
@@ -6,7 +6,7 @@ test("pathToFileURL doesn't leak memory", () => {
 });
 
 test("pathToFileURL handles relative paths longer than 4096 bytes", () => {
-  expect(["-e", 'Bun.pathToFileURL(Buffer.alloc(200000, "a").toString())']).toRun();
+  expect(["-e", 'const p = Buffer.alloc(200000, "a").toString(); const u = Bun.pathToFileURL(p); if (!u.href.endsWith("/" + p)) throw new Error(u.href)']).toRun();
 });
 
 test("pathToFileURL escapes special characters", () => {

--- a/test/js/node/url/pathToFileURL.test.ts
+++ b/test/js/node/url/pathToFileURL.test.ts
@@ -12,11 +12,11 @@ test("pathToFileURL handles relative paths longer than 4096 bytes", async () => 
     cmd: [
       bunExe(),
       "-e",
-      `const url = Bun.pathToFileURL(Buffer.alloc(5000, "a").toString()); console.log(url.href.endsWith("${longPath}"))`,
+      `const url = Bun.pathToFileURL(Buffer.alloc(5000, "a").toString()); console.log(url.href.endsWith("/${longPath}"))`,
     ],
     env: bunEnv,
     stdout: "pipe",
-    stderr: "pipe",
+    stderr: "ignore",
   });
 
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);


### PR DESCRIPTION
## What

Fix an out-of-bounds write in `Bun.pathToFileURL()` when called with a relative path longer than ~4096 bytes.

## Root Cause

`ResolvePath__joinAbsStringBufCurrentPlatformBunString` passes the fixed 4096-byte threadlocal `join_buf` as the output buffer to `joinAbsStringBuf`. When the input path (combined with CWD) exceeds the buffer size, `normalizeStringGenericTZ` writes past the end of the buffer:

```
panic: index out of bounds: index 5354, len 4095
```

## Fix

When the total length (CWD + input + separators) exceeds `join_buf`, heap-allocate a buffer of the right size instead. The result is cloned into a `bun.String` immediately after, so the allocation is short-lived.

## Repro

```js
Bun.pathToFileURL("a".repeat(5000));
```

---

Verified by robobun: CI Build #41383 in progress on commit 67e6b740 (retry of #41364 whose only failures were unrelated macOS webview timeouts). Lint JS ✅. Traced `_joinAbsStringBuf` to confirm `buf` output is bounded by `cwd.len + 1 + input.len`; heap-alloc size `cwd.len + input.len + 2` is sufficient. Boundary `<=` is correct (max output `total - 1` fits `join_buf.len`). Regression test spawns subprocess with 5000-byte relative path, asserts exit 0 and URL ends with `"/" + longPath` — would OOB-panic on main. All 3 review comments (separator assertion, stderr, boundary) addressed in 4f09afa. No TODO/FIXME/HACK. No unrelated changes.