### PR TITLE
fix: write console.trace() output to stderr instead of stdout 🤖🤖🤖

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -111,7 +111,7 @@ fn messageWithTypeAndLevel_(
 
     // Lock/unlock a mutex incase two JS threads are console.log'ing at the same time
     // We do this the slightly annoying way to avoid assigning a pointer
-    if (level == .Warning or level == .Error or message_type == .Assert) {
+    if (level == .Warning or level == .Error or message_type == .Assert or message_type == .Trace) {
         if (stderr_lock_count == 0) {
             stderr_mutex.lock();
         }
@@ -126,7 +126,7 @@ fn messageWithTypeAndLevel_(
     }
 
     defer {
-        if (level == .Warning or level == .Error or message_type == .Assert) {
+        if (level == .Warning or level == .Error or message_type == .Assert or message_type == .Trace) {
             stderr_lock_count -= 1;
 
             if (stderr_lock_count == 0) {
@@ -156,12 +156,12 @@ fn messageWithTypeAndLevel_(
         return;
     }
 
-    const enable_colors = if (level == .Warning or level == .Error)
+    const enable_colors = if (level == .Warning or level == .Error or message_type == .Trace)
         Output.enable_ansi_colors_stderr
     else
         Output.enable_ansi_colors_stdout;
 
-    const writer = if (level == .Warning or level == .Error)
+    const writer = if (level == .Warning or level == .Error or message_type == .Trace)
         console.error_writer
     else
         console.writer;


### PR DESCRIPTION
## Summary

\console.trace()\ was incorrectly writing its output to **stdout** instead of **stderr**. This doesn't match the behavior of Node.js, where \console.trace()\ writes to stderr.

## Changes

In \src/bun.js/ConsoleObject.zig\, added \message_type == .Trace\ to the conditions that route output to stderr. This affects:

1. **Mutex selection** — uses \stderr_mutex\ instead of \stdout_mutex\
2. **ANSI color detection** — uses \nable_ansi_colors_stderr\ instead of stdout
3. **Writer selection** — uses \console.error_writer\ instead of \console.writer\

## Reproduction

\\\js
// trace.js
console.trace('hello');
\\\

\\\ash
# Before: output goes to stdout (nothing printed when stdout redirected)
bun trace.js >/dev/null
# (no output)

# After: output goes to stderr (visible even when stdout redirected)
bun trace.js >/dev/null
# Trace: hello
#     at trace.js:1:9
\\\

## Node.js reference behavior

\\\ash
node trace.js >/dev/null
# Trace: hello
#     at Object.<anonymous> (/path/trace.js:1:9)
#     ...
\\\

Fixes #19952