### PR TITLE
fix(console): write console.trace() to stderr instead of stdout 🤖🤖🤖

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -111,7 +111,7 @@ fn messageWithTypeAndLevel_(
 
     // Lock/unlock a mutex incase two JS threads are console.log'ing at the same time
     // We do this the slightly annoying way to avoid assigning a pointer
-    if (level == .Warning or level == .Error or message_type == .Assert) {
+    if (level == .Warning or level == .Error or message_type == .Assert or message_type == .Trace) {
         if (stderr_lock_count == 0) {
             stderr_mutex.lock();
         }
@@ -126,7 +126,7 @@ fn messageWithTypeAndLevel_(
     }
 
     defer {
-        if (level == .Warning or level == .Error or message_type == .Assert) {
+        if (level == .Warning or level == .Error or message_type == .Assert or message_type == .Trace) {
             stderr_lock_count -= 1;
 
             if (stderr_lock_count == 0) {
@@ -156,12 +156,12 @@ fn messageWithTypeAndLevel_(
         return;
     }
 
-    const enable_colors = if (level == .Warning or level == .Error)
+    const enable_colors = if (level == .Warning or level == .Error or message_type == .Trace)
         Output.enable_ansi_colors_stderr
     else
         Output.enable_ansi_colors_stdout;
 
-    const writer = if (level == .Warning or level == .Error)
+    const writer = if (level == .Warning or level == .Error or message_type == .Trace)
         console.error_writer
     else
         console.writer;


### PR DESCRIPTION
## Summary

\console.trace()\ was incorrectly writing to stdout instead of stderr. Per the Node.js specification and browser behavior, \console.trace()\ should write to stderr.

## Changes

In \src/bun.js/ConsoleObject.zig\, added \message_type == .Trace\ checks alongside existing \.Assert\ checks in four places:

1. **Mutex lock selection** — use stderr mutex for trace output
2. **Mutex unlock selection** — match the lock
3. **ANSI color detection** — use stderr color support
4. **Writer selection** — use \rror_writer\ (stderr) instead of \writer\ (stdout)

## Reproducer

\\\js
// trace.js
console.trace('hello');
\\\

\\\ash
# Before: trace goes to stdout (disappears when redirected)
bun trace.js >/dev/null
# (no output)

# After: trace goes to stderr (visible even with stdout redirected)
bun trace.js >/dev/null
# Trace: hello
#     at ...
\\\

Fixes #19952