### PR TITLE
fix: return resolved promise from ByteBlobLoader.toBufferedValue when store is consumed

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,8 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    var empty: Blob.Any = .{ .Blob = .{} };
+    return empty.toPromise(globalThis, action);
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/test/js/web/fetch/body-stream.test.ts
+++ b/test/js/web/fetch/body-stream.test.ts
@@ -582,3 +582,17 @@ for (let doClone of [true, false]) {
     }
   });
 }
+
+test("body.text() after response.json() returns empty string", async () => {
+  const response = Response.json({ hello: "world" });
+  const body = response.body!;
+
+  // response.json() drains the blob store via toBlobIfPossible() without
+  // setting $disturbed on the stream, so the subsequent body.text() takes
+  // the fast path with store==null, exercising ByteBlobLoader.toBufferedValue.
+  const json = await response.json();
+  expect(json).toEqual({ hello: "world" });
+
+  const text = await body.text();
+  expect(text).toBe("");
+});


### PR DESCRIPTION
When a blob-backed ReadableStream's internal store was already consumed (e.g. by a prior `.text()` or `.blob()` call), `ByteBlobLoader.toBufferedValue` returned `.zero` without throwing an exception. This violated the host function contract where `.zero` means an exception was thrown, triggering an assertion failure:

```
panic(main thread): Internal assertion failure: Expected an exception to be thrown
```

The crash path: `ReadableStream.prototype.text()` → `readableStreamToText` → `BlobInternalReadableStreamSourcePrototype.text()` → `ByteBlobLoader.toBufferedValue` → returns `.zero` with no exception → assertion failure in `TopExceptionScope`.

**Fix:** When the blob store is already consumed (`toAnyBlob()` returns `null`), create an empty `Blob.Any` and return a resolved promise with empty content, matching the pattern used elsewhere in the codebase (e.g. `ByteStream.toBufferedValue`).

---
Verified by robobun: Diff is a 2-line change in ByteBlobLoader.zig (line 183-184) replacing contract-violating `return .zero` with `var empty: Blob.Any = .{ .Blob = .{} }; return empty.toPromise(...)` — follows the established pattern in ByteStream.toBufferedValue. No TODO/FIXME/HACK markers. Lint JavaScript passed. Build #41490 ran tests: body-stream.test.ts (the regression test) passed on all platforms; only unrelated failures (webview timeouts on macOS, 24364.test.ts react-tailwind template, bun-types.test.ts — none touch ByteBlobLoader or ReadableStream). Build #41516 compiling at time of review. Coderabbit actionable comment was against a prior commit's reader-based test; current test (9adf63b6) is a clean response.text()-then-body.text() assertion with no reader pattern.

---
Verified by robobun (iteration 11): Diff is a 2-line change in ByteBlobLoader.zig (line 183-184) replacing contract-violating return .zero with var empty: Blob.Any = .{ .Blob = .{} }; return empty.toPromise(globalThis, action) -- follows the established pattern in ByteStream.toBufferedValue. Regression test in body-stream.test.ts exercises the exact crash path: Response.json() drains the blob store via toBlobIfPossible() without setting $disturbed, then body.text() hits ByteBlobLoader.toBufferedValue with null store. No TODO/FIXME/HACK markers. Lint JavaScript passed. Build 41490 passed body-stream.test.ts on all platforms; build 41523 (commit e837f410, squashed rebase of same diff) compiling. Coderabbit actionable comment was about a prior commit reader-based test; current test uses response.json() per review feedback.