### PR TITLE
Emit upgrade event on http.ClientRequest for 101 responses

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -252,6 +252,7 @@ function doUpgradeRequest(
         abortSignal?.removeEventListener("abort", onAbortSocket);
         socket.removeListener("error", onSocketError);
         socket.removeListener("close", onSocketClose);
+        socket.removeListener("close", onAbortCleanup);
 
         const eventName = method === "CONNECT" ? "connect" : "upgrade";
         process.nextTick(() => {
@@ -367,11 +368,12 @@ function doUpgradeRequest(
     const onAbortSocket = () => {
       socket.destroy();
     };
+    const onAbortCleanup = () => {
+      abortSignal?.removeEventListener("abort", onAbortSocket);
+    };
     if (abortSignal) {
       abortSignal.addEventListener("abort", onAbortSocket, { once: true });
-      socket.on("close", () => {
-        abortSignal.removeEventListener("abort", onAbortSocket);
-      });
+      socket.on("close", onAbortCleanup);
     }
   });
 }
@@ -535,6 +537,7 @@ function ClientRequest(input, options, cb) {
   };
 
   const socketCloseListener = () => {
+    if (this[kUpgradeOrConnect]) return;
     this.destroyed = true;
 
     const res = this.res;

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -152,9 +152,7 @@ async function doUpgradeRequest(
     const requestPath = (parsedUrl.pathname || "/") + (parsedUrl.search || "");
 
     const socketPath = self[kSocketPath];
-    const connectOpts: any = socketPath
-      ? { path: socketPath }
-      : { host: connectHost, port: connectPort };
+    const connectOpts: any = socketPath ? { path: socketPath } : { host: connectHost, port: connectPort };
 
     if (isSecure) {
       const tlsConfig = self[kTls] || {};
@@ -270,9 +268,7 @@ async function doUpgradeRequest(
         });
 
         // Track remaining body bytes for Content-Length framing
-        const contentLength = parsed.headers["content-length"]
-          ? parseInt(parsed.headers["content-length"], 10)
-          : NaN;
+        const contentLength = parsed.headers["content-length"] ? parseInt(parsed.headers["content-length"], 10) : NaN;
         let bytesReceived = 0;
 
         if (parsed.head.length > 0) {

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -87,7 +87,7 @@ function parseRawHTTPResponse(buffer: Buffer) {
   const lines = headerStr.split("\r\n");
   const statusLine = lines[0];
   const statusMatch = statusLine.match(/^HTTP\/(\d)\.(\d) (\d{3})(?: (.*))?$/);
-  if (!statusMatch) return null;
+  if (!statusMatch) return false; // Separator found but status line malformed
 
   const httpVersion = `${statusMatch[1]}.${statusMatch[2]}`;
   const statusCode = parseInt(statusMatch[3], 10);
@@ -119,7 +119,7 @@ function parseRawHTTPResponse(buffer: Buffer) {
   return { httpVersion, statusCode, statusMessage, headers, rawHeaders, head };
 }
 
-async function doUpgradeRequest(
+function doUpgradeRequest(
   this: any,
   url: string,
   headers: any,
@@ -134,25 +134,7 @@ async function doUpgradeRequest(
   const net = require("node:net");
   const tls = require("node:tls");
 
-  // Resolve Blob body to ArrayBuffer before connecting, since Buffer.from()
-  // does not accept Blob objects and the socket write is synchronous.
-  let bodyBuffer: Buffer | string | null = null;
-  if (body != null) {
-    if (typeof body === "string") {
-      bodyBuffer = body;
-    } else if (body instanceof Blob) {
-      bodyBuffer = Buffer.from(await body.arrayBuffer());
-    } else {
-      bodyBuffer = Buffer.from(body);
-    }
-  }
-
   return new Promise<void>((resolve, reject) => {
-    // If abort was called during the async Blob resolution, bail out immediately
-    if (self[kAbortController]?.signal.aborted) {
-      reject(new DOMException("This operation was aborted.", "AbortError"));
-      return;
-    }
 
     const parsedUrl = new URL(url);
     const isSecure = parsedUrl.protocol === "https:";
@@ -196,8 +178,14 @@ async function doUpgradeRequest(
       request += "\r\n";
       socket.write(request);
 
-      if (bodyBuffer != null) {
-        socket.write(bodyBuffer);
+      if (body != null) {
+        if (typeof body === "string") {
+          socket.write(body);
+        } else if (body instanceof Blob) {
+          body.arrayBuffer().then(ab => socket.write(Buffer.from(ab)));
+        } else {
+          socket.write(Buffer.from(body));
+        }
       }
     });
 
@@ -221,7 +209,13 @@ async function doUpgradeRequest(
       }
 
       const parsed = parseRawHTTPResponse(responseBuffer);
-      if (!parsed) return; // Need more data
+      if (parsed === null) return; // Need more data
+      if (parsed === false) {
+        // Separator found but status line is malformed
+        socket.destroy();
+        reject(ObjectAssign(new Error("Parse Error"), { code: "HPE_INVALID_STATUS" }));
+        return;
+      }
 
       headersParsed = true;
       socket.removeListener("data", onData);
@@ -245,8 +239,10 @@ async function doUpgradeRequest(
 
         maybeEmitSocket();
 
-        // Remove abort listener — socket is now owned by user code
+        // Remove all HTTP-level listeners — socket is now owned by user code
         abortSignal?.removeEventListener("abort", onAbortSocket);
+        socket.removeListener("error", onSocketError);
+        socket.removeListener("close", onSocketClose);
 
         const eventName = method === "CONNECT" ? "connect" : "upgrade";
         process.nextTick(() => {
@@ -339,20 +335,23 @@ async function doUpgradeRequest(
 
     socket.on("data", onData);
 
-    socket.on("error", err => {
+    const onSocketError = err => {
       self[kClearTimeout]();
       if (!headersParsed) {
         reject(err);
       } else if (self.res && !self.res.complete) {
         self.res.destroy(err);
       }
-    });
+    };
 
-    socket.on("close", () => {
+    const onSocketClose = () => {
       if (!headersParsed) {
         reject(new Error("socket hang up"));
       }
-    });
+    };
+
+    socket.on("error", onSocketError);
+    socket.on("close", onSocketClose);
 
     // Wire up abort controller
     const abortSignal = self[kAbortController]?.signal;

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -15,8 +15,6 @@ const { throwOnInvalidTLSArray } = require("internal/tls");
 const { validateHeaderName } = require("node:_http_common");
 const { getTimerDuration } = require("internal/timers");
 const { ConnResetException } = require("internal/shared");
-const net = require("node:net");
-const tls = require("node:tls");
 const {
   kBodyChunks,
   abortedSymbol,
@@ -132,6 +130,9 @@ async function doUpgradeRequest(
   maybeEmitClose: () => void,
 ) {
   const self = this;
+  // Lazy require to avoid circular dependency at module load time
+  const net = require("node:net");
+  const tls = require("node:tls");
 
   // Resolve Blob body to ArrayBuffer before connecting, since Buffer.from()
   // does not accept Blob objects and the socket write is synchronous.

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -160,7 +160,8 @@ function doUpgradeRequest(
       // Synthesize Host header if not already present (HTTP/1.1 requires it)
       if (!headers["host"] && !headers["Host"]) {
         const defaultPort = isSecure ? 443 : 80;
-        const hostHeader = connectPort === defaultPort ? connectHost : `${connectHost}:${connectPort}`;
+        const bracketedHost = connectHost.includes(":") ? `[${connectHost}]` : connectHost;
+        const hostHeader = connectPort === defaultPort ? bracketedHost : `${bracketedHost}:${connectPort}`;
         request += `Host: ${hostHeader}\r\n`;
       }
 
@@ -181,7 +182,7 @@ function doUpgradeRequest(
         if (typeof body === "string") {
           socket.write(body);
         } else if (body instanceof Blob) {
-          body.arrayBuffer().then(ab => socket.write(Buffer.from(ab)));
+          body.arrayBuffer().then(ab => socket.write(Buffer.from(ab))).catch(err => socket.destroy(err));
         } else {
           socket.write(Buffer.from(body));
         }

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -15,6 +15,8 @@ const { throwOnInvalidTLSArray } = require("internal/tls");
 const { validateHeaderName } = require("node:_http_common");
 const { getTimerDuration } = require("internal/timers");
 const { ConnResetException } = require("internal/shared");
+const net = require("node:net");
+const tls = require("node:tls");
 const {
   kBodyChunks,
   abortedSymbol,
@@ -73,6 +75,211 @@ function emitErrorEventNT(self, err) {
   if (self.listenerCount("error") > 0) {
     self.emit("error", err);
   }
+}
+
+const kHeaderSeparator = Buffer.from("\r\n\r\n");
+
+function parseRawHTTPResponse(buffer: Buffer) {
+  const headerEndIdx = buffer.indexOf(kHeaderSeparator);
+  if (headerEndIdx === -1) return null;
+
+  const headerStr = buffer.slice(0, headerEndIdx).toString("latin1");
+  const head = buffer.slice(headerEndIdx + 4);
+
+  const lines = headerStr.split("\r\n");
+  const statusLine = lines[0];
+  const statusMatch = statusLine.match(/^HTTP\/(\d)\.(\d) (\d{3})(?: (.*))?$/);
+  if (!statusMatch) return null;
+
+  const httpVersion = `${statusMatch[1]}.${statusMatch[2]}`;
+  const statusCode = parseInt(statusMatch[3], 10);
+  const statusMessage = statusMatch[4] || "";
+
+  const headers = Object.create(null);
+  const rawHeaders: string[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    const colonIdx = line.indexOf(":");
+    if (colonIdx <= 0) continue;
+    const key = line.slice(0, colonIdx);
+    const value = line.slice(colonIdx + 1).trim();
+    const lowerKey = key.toLowerCase();
+    rawHeaders.push(key, value);
+    if (lowerKey === "set-cookie") {
+      if (headers[lowerKey]) {
+        headers[lowerKey].push(value);
+      } else {
+        headers[lowerKey] = [value];
+      }
+    } else {
+      headers[lowerKey] = value;
+    }
+  }
+
+  return { httpVersion, statusCode, statusMessage, headers, rawHeaders, head };
+}
+
+function doUpgradeRequest(
+  this: any,
+  url: string,
+  headers: any,
+  method: string,
+  body: any,
+  protocol: string,
+  maybeEmitSocket: () => void,
+  maybeEmitClose: () => void,
+) {
+  const self = this;
+  return new Promise<void>((resolve, reject) => {
+    const parsedUrl = new URL(url);
+    const isSecure = parsedUrl.protocol === "https:";
+    const connectHost = parsedUrl.hostname;
+    const connectPort = parseInt(parsedUrl.port) || (isSecure ? 443 : 80);
+    const requestPath = (parsedUrl.pathname || "/") + (parsedUrl.search || "");
+
+    const connectOpts: any = {
+      host: connectHost,
+      port: connectPort,
+    };
+
+    if (isSecure) {
+      const tlsConfig = self[kTls] || {};
+      ObjectAssign(connectOpts, tlsConfig);
+      if (!connectOpts.servername) {
+        connectOpts.servername = connectHost;
+      }
+    }
+
+    const connectModule = isSecure ? tls : net;
+    const socket = connectModule.connect(connectOpts, () => {
+      // Build and send the raw HTTP request
+      let request = `${method} ${requestPath} HTTP/1.1\r\n`;
+      for (const key of Object.keys(headers)) {
+        const value = headers[key];
+        if ($isJSArray(value)) {
+          for (const v of value) {
+            request += `${key}: ${v}\r\n`;
+          }
+        } else {
+          request += `${key}: ${value}\r\n`;
+        }
+      }
+      request += "\r\n";
+      socket.write(request);
+
+      if (body != null) {
+        socket.write(typeof body === "string" ? body : Buffer.from(body));
+      }
+    });
+
+    let responseBuffer = Buffer.alloc(0);
+    let headersParsed = false;
+
+    const onData = (chunk: Buffer) => {
+      if (headersParsed) return;
+
+      responseBuffer = Buffer.concat([responseBuffer, chunk]);
+
+      const parsed = parseRawHTTPResponse(responseBuffer);
+      if (!parsed) return; // Need more data
+
+      headersParsed = true;
+      socket.removeListener("data", onData);
+
+      self[kFetchRequest] = null;
+      self[kClearTimeout]();
+
+      if (parsed.statusCode === 101 || method === "CONNECT") {
+        self[kUpgradeOrConnect] = true;
+
+        const res = new IncomingMessage(null);
+        res.statusCode = parsed.statusCode;
+        res.statusMessage = parsed.statusMessage;
+        res.httpVersion = parsed.httpVersion;
+        res.headers = parsed.headers;
+        res.rawHeaders = parsed.rawHeaders;
+        res.complete = true;
+        res.req = self;
+        self.res = res;
+
+        maybeEmitSocket();
+
+        process.nextTick(() => {
+          self.emit("upgrade", res, socket, parsed.head);
+        });
+
+        resolve();
+      } else {
+        // Non-101 response on an upgrade request — emit as normal response
+        const res = new IncomingMessage(null);
+        res.statusCode = parsed.statusCode;
+        res.statusMessage = parsed.statusMessage;
+        res.httpVersion = parsed.httpVersion;
+        res.headers = parsed.headers;
+        res.rawHeaders = parsed.rawHeaders;
+        res.req = self;
+        self.res = res;
+
+        // Override _read to prevent default body-reading logic on null webRequestOrResponse
+        res._read = function () {
+          if (!this._consuming) {
+            this._readableState.readingMore = false;
+            this._consuming = true;
+          }
+        };
+
+        if (parsed.head.length > 0) {
+          res.push(parsed.head);
+        }
+
+        socket.on("data", dataChunk => {
+          if (!res._dumped) {
+            res.push(dataChunk);
+          }
+        });
+        socket.on("end", () => {
+          if (!res.complete) {
+            res.push(null);
+            res.complete = true;
+          }
+        });
+
+        process.nextTick(() => {
+          if (self.aborted || !self.emit("response", res)) {
+            res._dump();
+          }
+          maybeEmitClose();
+        });
+
+        resolve();
+      }
+    };
+
+    socket.on("data", onData);
+
+    socket.on("error", err => {
+      self[kClearTimeout]();
+      reject(err);
+    });
+
+    socket.on("close", () => {
+      if (!headersParsed) {
+        reject(new Error("socket hang up"));
+      }
+    });
+
+    // Wire up abort controller
+    const abortSignal = self[kAbortController]?.signal;
+    if (abortSignal) {
+      const onAbortSocket = () => {
+        socket.destroy();
+      };
+      abortSignal.addEventListener("abort", onAbortSocket, { once: true });
+      socket.on("close", () => {
+        abortSignal.removeEventListener("abort", onAbortSocket);
+      });
+    }
+  });
 }
 
 function ClientRequest(input, options, cb) {
@@ -307,12 +514,47 @@ function ClientRequest(input, options, cb) {
     };
 
     const go = (url, proxy, softFail = false) => {
-      const tls =
+      // Check if this is an upgrade request - use raw socket path for proper upgrade event support
+      const reqHeaders = this.getHeaders();
+      const connectionHeader = reqHeaders["connection"] || reqHeaders["Connection"];
+      const upgradeHeader = reqHeaders["upgrade"] || reqHeaders["Upgrade"];
+      const isUpgradeReq =
+        !proxy &&
+        upgradeHeader &&
+        typeof connectionHeader === "string" &&
+        connectionHeader.toLowerCase().includes("upgrade");
+
+      if (isUpgradeReq) {
+        this[kFetchRequest] = doUpgradeRequest.$call(
+          this,
+          url,
+          reqHeaders,
+          method,
+          customBody,
+          protocol,
+          maybeEmitSocket,
+          maybeEmitClose,
+        );
+        if (!softFail) {
+          this[kFetchRequest].catch(err => {
+            if (isAbortError(err)) return;
+            if (!!$debug) globalReportError(err);
+            try {
+              this.emit("error", err);
+            } catch (_err) {
+              void _err;
+            }
+          });
+        }
+        return this[kFetchRequest];
+      }
+
+      const tlsOpts =
         protocol === "https:" && this[kTls] ? { ...this[kTls], serverName: this[kTls].servername } : undefined;
 
       const fetchOptions: any = {
         method,
-        headers: this.getHeaders(),
+        headers: reqHeaders,
         redirect: "manual",
         signal: this[kAbortController]?.signal,
         // Timeouts are handled via this.setTimeout.
@@ -372,8 +614,8 @@ function ClientRequest(input, options, cb) {
         };
       }
 
-      if (tls) {
-        fetchOptions.tls = tls;
+      if (tlsOpts) {
+        fetchOptions.tls = tlsOpts;
       }
 
       if (!!$debug) {

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -125,7 +125,6 @@ function doUpgradeRequest(
   headers: any,
   method: string,
   body: any,
-  protocol: string,
   maybeEmitSocket: () => void,
   maybeEmitClose: () => void,
 ) {
@@ -135,6 +134,12 @@ function doUpgradeRequest(
   const tls = require("node:tls");
 
   return new Promise<void>((resolve, reject) => {
+    // Bail out immediately if already aborted
+    if (self[kAbortController]?.signal?.aborted) {
+      reject(new DOMException("This operation was aborted.", "AbortError"));
+      return;
+    }
+
     const parsedUrl = new URL(url);
     const isSecure = parsedUrl.protocol === "https:";
     const connectHost = parsedUrl.hostname;
@@ -624,7 +629,6 @@ function ClientRequest(input, options, cb) {
           reqHeaders,
           method,
           customBody,
-          protocol,
           maybeEmitSocket,
           maybeEmitClose,
         );

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -135,7 +135,6 @@ function doUpgradeRequest(
   const tls = require("node:tls");
 
   return new Promise<void>((resolve, reject) => {
-
     const parsedUrl = new URL(url);
     const isSecure = parsedUrl.protocol === "https:";
     const connectHost = parsedUrl.hostname;

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -111,6 +111,8 @@ function parseRawHTTPResponse(buffer: Buffer) {
       } else {
         headers[lowerKey] = [value];
       }
+    } else if (headers[lowerKey] !== undefined) {
+      headers[lowerKey] += `, ${value}`;
     } else {
       headers[lowerKey] = value;
     }
@@ -220,7 +222,7 @@ async function doUpgradeRequest(
       self[kFetchRequest] = null;
       self[kClearTimeout]();
 
-      if (parsed.statusCode === 101 || method === "CONNECT") {
+      if (parsed.statusCode === 101 || (method === "CONNECT" && parsed.statusCode === 200)) {
         self[kUpgradeOrConnect] = true;
 
         const res = new IncomingMessage(null);
@@ -238,7 +240,10 @@ async function doUpgradeRequest(
 
         const eventName = method === "CONNECT" ? "connect" : "upgrade";
         process.nextTick(() => {
-          self.emit(eventName, res, socket, parsed.head);
+          if (!self.emit(eventName, res, socket, parsed.head)) {
+            socket.destroy();
+          }
+          maybeEmitClose();
         });
 
         resolve();
@@ -318,7 +323,11 @@ async function doUpgradeRequest(
 
     socket.on("error", err => {
       self[kClearTimeout]();
-      reject(err);
+      if (!headersParsed) {
+        reject(err);
+      } else if (self.res && !self.res.complete) {
+        self.res.destroy(err);
+      }
     });
 
     socket.on("close", () => {

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -182,7 +182,10 @@ function doUpgradeRequest(
         if (typeof body === "string") {
           socket.write(body);
         } else if (body instanceof Blob) {
-          body.arrayBuffer().then(ab => socket.write(Buffer.from(ab))).catch(err => socket.destroy(err));
+          body
+            .arrayBuffer()
+            .then(ab => socket.write(Buffer.from(ab)))
+            .catch(err => socket.destroy(err));
         } else {
           socket.write(Buffer.from(body));
         }

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -119,7 +119,7 @@ function parseRawHTTPResponse(buffer: Buffer) {
   return { httpVersion, statusCode, statusMessage, headers, rawHeaders, head };
 }
 
-function doUpgradeRequest(
+async function doUpgradeRequest(
   this: any,
   url: string,
   headers: any,
@@ -130,6 +130,20 @@ function doUpgradeRequest(
   maybeEmitClose: () => void,
 ) {
   const self = this;
+
+  // Resolve Blob body to ArrayBuffer before connecting, since Buffer.from()
+  // does not accept Blob objects and the socket write is synchronous.
+  let bodyBuffer: Buffer | string | null = null;
+  if (body != null) {
+    if (typeof body === "string") {
+      bodyBuffer = body;
+    } else if (body instanceof Blob) {
+      bodyBuffer = Buffer.from(await body.arrayBuffer());
+    } else {
+      bodyBuffer = Buffer.from(body);
+    }
+  }
+
   return new Promise<void>((resolve, reject) => {
     const parsedUrl = new URL(url);
     const isSecure = parsedUrl.protocol === "https:";
@@ -137,10 +151,10 @@ function doUpgradeRequest(
     const connectPort = parseInt(parsedUrl.port) || (isSecure ? 443 : 80);
     const requestPath = (parsedUrl.pathname || "/") + (parsedUrl.search || "");
 
-    const connectOpts: any = {
-      host: connectHost,
-      port: connectPort,
-    };
+    const socketPath = self[kSocketPath];
+    const connectOpts: any = socketPath
+      ? { path: socketPath }
+      : { host: connectHost, port: connectPort };
 
     if (isSecure) {
       const tlsConfig = self[kTls] || {};
@@ -154,6 +168,14 @@ function doUpgradeRequest(
     const socket = connectModule.connect(connectOpts, () => {
       // Build and send the raw HTTP request
       let request = `${method} ${requestPath} HTTP/1.1\r\n`;
+
+      // Synthesize Host header if not already present (HTTP/1.1 requires it)
+      if (!headers["host"] && !headers["Host"]) {
+        const defaultPort = isSecure ? 443 : 80;
+        const hostHeader = connectPort === defaultPort ? connectHost : `${connectHost}:${connectPort}`;
+        request += `Host: ${hostHeader}\r\n`;
+      }
+
       for (const key of Object.keys(headers)) {
         const value = headers[key];
         if ($isJSArray(value)) {
@@ -167,18 +189,29 @@ function doUpgradeRequest(
       request += "\r\n";
       socket.write(request);
 
-      if (body != null) {
-        socket.write(typeof body === "string" ? body : Buffer.from(body));
+      if (bodyBuffer != null) {
+        socket.write(bodyBuffer);
       }
     });
 
+    // Bind socket to request so req.socket and the "socket" event reference
+    // the actual net.Socket/tls.TLSSocket used for the connection.
+    self.socket = socket;
+
     let responseBuffer = Buffer.alloc(0);
     let headersParsed = false;
+    const maxHeaderSize = self[kMaxHeaderSize] ?? 16384;
 
     const onData = (chunk: Buffer) => {
       if (headersParsed) return;
 
       responseBuffer = Buffer.concat([responseBuffer, chunk]);
+
+      if (responseBuffer.length > maxHeaderSize) {
+        socket.destroy();
+        reject(ObjectAssign(new Error("Parse Error: Header overflow"), { code: "HPE_HEADER_OVERFLOW" }));
+        return;
+      }
 
       const parsed = parseRawHTTPResponse(responseBuffer);
       if (!parsed) return; // Need more data
@@ -198,14 +231,16 @@ function doUpgradeRequest(
         res.httpVersion = parsed.httpVersion;
         res.headers = parsed.headers;
         res.rawHeaders = parsed.rawHeaders;
+        res.socket = socket;
         res.complete = true;
         res.req = self;
         self.res = res;
 
         maybeEmitSocket();
 
+        const eventName = method === "CONNECT" ? "connect" : "upgrade";
         process.nextTick(() => {
-          self.emit("upgrade", res, socket, parsed.head);
+          self.emit(eventName, res, socket, parsed.head);
         });
 
         resolve();
@@ -217,6 +252,7 @@ function doUpgradeRequest(
         res.httpVersion = parsed.httpVersion;
         res.headers = parsed.headers;
         res.rawHeaders = parsed.rawHeaders;
+        res.socket = socket;
         res.req = self;
         self.res = res;
 
@@ -228,21 +264,48 @@ function doUpgradeRequest(
           }
         };
 
+        // Ensure socket is cleaned up when response is consumed or destroyed
+        res.on("close", () => {
+          socket.destroy();
+        });
+
+        // Track remaining body bytes for Content-Length framing
+        const contentLength = parsed.headers["content-length"]
+          ? parseInt(parsed.headers["content-length"], 10)
+          : NaN;
+        let bytesReceived = 0;
+
         if (parsed.head.length > 0) {
           res.push(parsed.head);
+          bytesReceived += parsed.head.length;
         }
 
-        socket.on("data", dataChunk => {
-          if (!res._dumped) {
-            res.push(dataChunk);
-          }
-        });
-        socket.on("end", () => {
-          if (!res.complete) {
-            res.push(null);
-            res.complete = true;
-          }
-        });
+        // Complete immediately if Content-Length body is fully consumed
+        if (!isNaN(contentLength) && bytesReceived >= contentLength) {
+          res.push(null);
+          res.complete = true;
+          socket.destroy();
+        } else {
+          socket.on("data", dataChunk => {
+            if (!res._dumped) {
+              res.push(dataChunk);
+            }
+            bytesReceived += dataChunk.length;
+            // Complete when Content-Length body is fully received
+            if (!isNaN(contentLength) && bytesReceived >= contentLength && !res.complete) {
+              res.push(null);
+              res.complete = true;
+              socket.destroy();
+            }
+          });
+          socket.on("end", () => {
+            if (!res.complete) {
+              res.push(null);
+              res.complete = true;
+            }
+            socket.destroy();
+          });
+        }
 
         process.nextTick(() => {
           if (self.aborted || !self.emit("response", res)) {
@@ -536,15 +599,21 @@ function ClientRequest(input, options, cb) {
           maybeEmitClose,
         );
         if (!softFail) {
-          this[kFetchRequest].catch(err => {
-            if (isAbortError(err)) return;
-            if (!!$debug) globalReportError(err);
-            try {
-              this.emit("error", err);
-            } catch (_err) {
-              void _err;
-            }
-          });
+          this[kFetchRequest]
+            .catch(err => {
+              if (isAbortError(err)) return;
+              if (!!$debug) globalReportError(err);
+              try {
+                this.emit("error", err);
+              } catch (_err) {
+                void _err;
+              }
+            })
+            .finally(() => {
+              fetching = false;
+              this[kFetchRequest] = null;
+              this[kClearTimeout]();
+            });
         }
         return this[kFetchRequest];
       }

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -205,14 +205,15 @@ function doUpgradeRequest(
 
       responseBuffer = Buffer.concat([responseBuffer, chunk]);
 
-      if (responseBuffer.length > maxHeaderSize) {
-        socket.destroy();
-        reject(ObjectAssign(new Error("Parse Error: Header overflow"), { code: "HPE_HEADER_OVERFLOW" }));
-        return;
-      }
-
       const parsed = parseRawHTTPResponse(responseBuffer);
-      if (parsed === null) return; // Need more data
+      if (parsed === null) {
+        // Headers not yet complete — check overflow only on header bytes
+        if (responseBuffer.length > maxHeaderSize) {
+          socket.destroy();
+          reject(ObjectAssign(new Error("Parse Error: Header overflow"), { code: "HPE_HEADER_OVERFLOW" }));
+        }
+        return; // Need more data
+      }
       if (parsed === false) {
         // Separator found but status line is malformed
         socket.destroy();

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -147,6 +147,12 @@ async function doUpgradeRequest(
   }
 
   return new Promise<void>((resolve, reject) => {
+    // If abort was called during the async Blob resolution, bail out immediately
+    if (self[kAbortController]?.signal.aborted) {
+      reject(new DOMException("This operation was aborted.", "AbortError"));
+      return;
+    }
+
     const parsedUrl = new URL(url);
     const isSecure = parsedUrl.protocol === "https:";
     const connectHost = parsedUrl.hostname;
@@ -238,6 +244,9 @@ async function doUpgradeRequest(
 
         maybeEmitSocket();
 
+        // Remove abort listener — socket is now owned by user code
+        abortSignal?.removeEventListener("abort", onAbortSocket);
+
         const eventName = method === "CONNECT" ? "connect" : "upgrade";
         process.nextTick(() => {
           if (!self.emit(eventName, res, socket, parsed.head)) {
@@ -277,8 +286,9 @@ async function doUpgradeRequest(
         let bytesReceived = 0;
 
         if (parsed.head.length > 0) {
-          res.push(parsed.head);
-          bytesReceived += parsed.head.length;
+          const headToRead = !isNaN(contentLength) ? parsed.head.slice(0, contentLength) : parsed.head;
+          res.push(headToRead);
+          bytesReceived += headToRead.length;
         }
 
         // Complete immediately if Content-Length body is fully consumed
@@ -288,6 +298,13 @@ async function doUpgradeRequest(
           socket.destroy();
         } else {
           socket.on("data", dataChunk => {
+            if (!isNaN(contentLength)) {
+              const remaining = contentLength - bytesReceived;
+              if (remaining <= 0) return;
+              if (dataChunk.length > remaining) {
+                dataChunk = dataChunk.slice(0, remaining);
+              }
+            }
             if (!res._dumped) {
               res.push(dataChunk);
             }
@@ -338,10 +355,10 @@ async function doUpgradeRequest(
 
     // Wire up abort controller
     const abortSignal = self[kAbortController]?.signal;
+    const onAbortSocket = () => {
+      socket.destroy();
+    };
     if (abortSignal) {
-      const onAbortSocket = () => {
-        socket.destroy();
-      };
       abortSignal.addEventListener("abort", onAbortSocket, { once: true });
       socket.on("close", () => {
         abortSignal.removeEventListener("abort", onAbortSocket);
@@ -479,6 +496,10 @@ function ClientRequest(input, options, cb) {
     if (this.destroyed) return this;
     this.destroyed = true;
 
+    // After a successful upgrade/connect, the socket has been handed off
+    // to user code — don't destroy it from the HTTP request layer.
+    if (this[kUpgradeOrConnect]) return this;
+
     const res = this.res;
 
     // If we're aborting, we don't care about any more response data.
@@ -606,7 +627,7 @@ function ClientRequest(input, options, cb) {
         if (!softFail) {
           this[kFetchRequest]
             .catch(err => {
-              if (isAbortError(err)) return;
+              if (isAbortError(err) || this.destroyed || this.aborted) return;
               if (!!$debug) globalReportError(err);
               try {
                 this.emit("error", err);

--- a/test/regression/issue/28450.test.ts
+++ b/test/regression/issue/28450.test.ts
@@ -1,0 +1,236 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Issue #28450: http.ClientRequest does not emit "upgrade" event for 101 responses.
+// This breaks playwright-core and any library using the real `ws` package for WebSocket
+// connections via http.request() upgrade handshake.
+
+test("http.request emits upgrade event on 101 Switching Protocols", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const net = require('net');
+const http = require('http');
+const crypto = require('crypto');
+
+const server = net.createServer((socket) => {
+  let data = '';
+  let upgraded = false;
+  socket.on('data', (chunk) => {
+    if (upgraded) {
+      socket.write(chunk);
+      return;
+    }
+    data += chunk.toString();
+    if (data.includes('\\r\\n\\r\\n')) {
+      const keyMatch = data.match(/sec-websocket-key: (.+)\\r\\n/i);
+      if (keyMatch) {
+        const key = keyMatch[1];
+        const accept = crypto.createHash('sha1')
+          .update(key + '258EAFA5-E914-47DA-95CA-5AB5F06CA30E')
+          .digest('base64');
+        socket.write('HTTP/1.1 101 Switching Protocols\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\nSec-WebSocket-Accept: ' + accept + '\\r\\n\\r\\n');
+        upgraded = true;
+      }
+    }
+  });
+});
+
+server.listen(0, () => {
+  const port = server.address().port;
+  const req = http.request({
+    hostname: 'localhost',
+    port,
+    path: '/',
+    headers: {
+      'Connection': 'Upgrade',
+      'Upgrade': 'websocket',
+      'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
+      'Sec-WebSocket-Version': '13',
+    }
+  });
+  req.on('upgrade', (res, socket, head) => {
+    console.log('STATUS:' + res.statusCode);
+    console.log('UPGRADE:' + res.headers['upgrade']);
+    console.log('ACCEPT:' + res.headers['sec-websocket-accept']);
+    // Verify the socket is usable for bidirectional communication
+    socket.write('hello');
+    socket.once('data', (data) => {
+      console.log('ECHO:' + data.toString());
+      socket.destroy();
+      server.close();
+    });
+  });
+  req.on('response', (res) => {
+    console.log('UNEXPECTED_RESPONSE:' + res.statusCode);
+    server.close();
+  });
+  req.end();
+});
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("STATUS:101");
+  expect(stdout).toContain("UPGRADE:websocket");
+  expect(stdout).toContain("ECHO:hello");
+  expect(stdout).not.toContain("UNEXPECTED_RESPONSE");
+  expect(exitCode).toBe(0);
+});
+
+test("http.request upgrade event provides valid IncomingMessage headers", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const net = require('net');
+const http = require('http');
+const crypto = require('crypto');
+
+const server = net.createServer((socket) => {
+  let data = '';
+  socket.on('data', (chunk) => {
+    data += chunk.toString();
+    if (data.includes('\\r\\n\\r\\n')) {
+      const keyMatch = data.match(/sec-websocket-key: (.+)\\r\\n/i);
+      if (keyMatch) {
+        const key = keyMatch[1];
+        const accept = crypto.createHash('sha1')
+          .update(key + '258EAFA5-E914-47DA-95CA-5AB5F06CA30E')
+          .digest('base64');
+        socket.write('HTTP/1.1 101 Switching Protocols\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\nSec-WebSocket-Accept: ' + accept + '\\r\\nX-Custom-Header: test-value\\r\\n\\r\\n');
+      }
+    }
+  });
+});
+
+server.listen(0, () => {
+  const port = server.address().port;
+  const key = crypto.randomBytes(16).toString('base64');
+  const expectedAccept = crypto.createHash('sha1')
+    .update(key + '258EAFA5-E914-47DA-95CA-5AB5F06CA30E')
+    .digest('base64');
+  const req = http.request({
+    hostname: 'localhost',
+    port,
+    path: '/ws',
+    headers: {
+      'Connection': 'Upgrade',
+      'Upgrade': 'websocket',
+      'Sec-WebSocket-Key': key,
+      'Sec-WebSocket-Version': '13',
+    }
+  });
+  req.on('upgrade', (res, socket, head) => {
+    const results = {
+      statusCode: res.statusCode,
+      statusMessage: res.statusMessage,
+      upgrade: res.headers['upgrade'],
+      connection: res.headers['connection'],
+      accept: res.headers['sec-websocket-accept'],
+      expectedAccept: expectedAccept,
+      customHeader: res.headers['x-custom-header'],
+      hasRawHeaders: Array.isArray(res.rawHeaders) && res.rawHeaders.length > 0,
+      headIsBuffer: Buffer.isBuffer(head),
+    };
+    console.log(JSON.stringify(results));
+    socket.destroy();
+    server.close();
+  });
+  req.end();
+});
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const results = JSON.parse(stdout.trim());
+  expect(results).toEqual({
+    statusCode: 101,
+    statusMessage: "Switching Protocols",
+    upgrade: "websocket",
+    connection: "Upgrade",
+    accept: results.expectedAccept,
+    expectedAccept: results.expectedAccept,
+    customHeader: "test-value",
+    hasRawHeaders: true,
+    headIsBuffer: true,
+  });
+  expect(exitCode).toBe(0);
+});
+
+test("http.request emits response (not upgrade) for non-101 on upgrade request", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const net = require('net');
+const http = require('http');
+
+// Server that responds with 400 instead of upgrading
+const server = net.createServer((socket) => {
+  let data = '';
+  socket.on('data', (chunk) => {
+    data += chunk.toString();
+    if (data.includes('\\r\\n\\r\\n')) {
+      socket.write('HTTP/1.1 400 Bad Request\\r\\nContent-Type: text/plain\\r\\nContent-Length: 11\\r\\n\\r\\nBad Request');
+      socket.end();
+    }
+  });
+});
+
+server.listen(0, () => {
+  const port = server.address().port;
+  const req = http.request({
+    hostname: 'localhost',
+    port,
+    path: '/',
+    headers: {
+      'Connection': 'Upgrade',
+      'Upgrade': 'websocket',
+      'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
+      'Sec-WebSocket-Version': '13',
+    }
+  });
+  req.on('upgrade', () => {
+    console.log('UNEXPECTED_UPGRADE');
+    server.close();
+  });
+  req.on('response', (res) => {
+    let body = '';
+    res.on('data', (chunk) => body += chunk);
+    res.on('end', () => {
+      console.log('RESPONSE:' + res.statusCode);
+      console.log('BODY:' + body);
+      server.close();
+    });
+  });
+  req.end();
+});
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("RESPONSE:400");
+  expect(stdout).toContain("BODY:Bad Request");
+  expect(stdout).not.toContain("UNEXPECTED_UPGRADE");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/28450.test.ts
+++ b/test/regression/issue/28450.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // Issue #28450: http.ClientRequest does not emit "upgrade" event for 101 responses.

--- a/test/regression/issue/28450.test.ts
+++ b/test/regression/issue/28450.test.ts
@@ -78,7 +78,6 @@ server.listen(0, () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr.replace(/WARNING:.*\n/g, "")).toBe("");
   expect(stdout).toContain("STATUS:101");
   expect(stdout).toContain("UPGRADE:websocket");
   expect(stdout).toContain("ECHO:hello");
@@ -157,7 +156,6 @@ server.listen(0, () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr.replace(/WARNING:.*\n/g, "")).toBe("");
   const results = JSON.parse(stdout.trim());
   expect(results).toEqual({
     statusCode: 101,
@@ -231,7 +229,6 @@ server.listen(0, () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr.replace(/WARNING:.*\n/g, "")).toBe("");
   expect(stdout).toContain("RESPONSE:400");
   expect(stdout).toContain("BODY:Bad Request");
   expect(stdout).not.toContain("UNEXPECTED_UPGRADE");

--- a/test/regression/issue/28450.test.ts
+++ b/test/regression/issue/28450.test.ts
@@ -5,7 +5,7 @@ import { bunEnv, bunExe } from "harness";
 // This breaks playwright-core and any library using the real `ws` package for WebSocket
 // connections via http.request() upgrade handshake.
 
-test("http.request emits upgrade event on 101 Switching Protocols", async () => {
+test.concurrent("http.request emits upgrade event on 101 Switching Protocols", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -85,7 +85,7 @@ server.listen(0, () => {
   expect(exitCode).toBe(0);
 });
 
-test("http.request upgrade event provides valid IncomingMessage headers", async () => {
+test.concurrent("http.request upgrade event provides valid IncomingMessage headers", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -171,7 +171,7 @@ server.listen(0, () => {
   expect(exitCode).toBe(0);
 });
 
-test("http.request emits response (not upgrade) for non-101 on upgrade request", async () => {
+test.concurrent("http.request emits response (not upgrade) for non-101 on upgrade request", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/regression/issue/28450.test.ts
+++ b/test/regression/issue/28450.test.ts
@@ -78,6 +78,7 @@ server.listen(0, () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect(stderr.replace(/WARNING:.*\n/g, "")).toBe("");
   expect(stdout).toContain("STATUS:101");
   expect(stdout).toContain("UPGRADE:websocket");
   expect(stdout).toContain("ECHO:hello");
@@ -156,6 +157,7 @@ server.listen(0, () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect(stderr.replace(/WARNING:.*\n/g, "")).toBe("");
   const results = JSON.parse(stdout.trim());
   expect(results).toEqual({
     statusCode: 101,
@@ -229,6 +231,7 @@ server.listen(0, () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect(stderr.replace(/WARNING:.*\n/g, "")).toBe("");
   expect(stdout).toContain("RESPONSE:400");
   expect(stdout).toContain("BODY:Bad Request");
   expect(stdout).not.toContain("UNEXPECTED_UPGRADE");


### PR DESCRIPTION
## Problem

`http.ClientRequest` never emits the `upgrade` event for 101 Switching Protocols responses. It always emits `response` instead. This breaks playwright-core `connectOverCDP` and any library using the real `ws` npm package (not Bun's built-in shim) for WebSocket connections via `http.request()` upgrade handshake.

**Repro:** (from #28450)
```js
const req = http.request({
  hostname: "localhost", port,
  headers: { Connection: "Upgrade", Upgrade: "websocket", ... }
});
req.on("upgrade", (res, socket, head) => {
  // Node: fires this with a usable duplex socket
  // Bun (before fix): never fires
});
req.end();
```

## Root Cause

Bun's `ClientRequest` is built on top of `fetch()` internally. The fetch API returns a standard `Response` object with no access to the underlying TCP socket. When a 101 response arrives, the code unconditionally emits `response` instead of `upgrade`, and cannot provide the raw duplex socket that libraries like `ws` need.

## Fix

When `http.request()` is called with `Connection: Upgrade` headers, route the request through a raw TCP socket (`net.connect()` / `tls.connect()`) instead of the fetch-based path. This enables:

- Detecting 101 Switching Protocols responses and emitting `upgrade` with `(res, socket, head)`, providing a real duplex `net.Socket` for bidirectional communication
- Emitting `response` for non-101 responses on upgrade requests
- TLS support via `tls.connect()`

## Verification

```
USE_SYSTEM_BUN=1 bun test test/regression/issue/28450.test.ts -> 2 FAIL (tests 1 & 2), 1 PASS (test 3)
bun bd test test/regression/issue/28450.test.ts               -> 3 PASS
```

Closes #28450

---
Verified by robobun (iteration 2, pass 2): Build #41437 on b0d089b in progress (Lint JS passed, Buildkite building). Previous Build #41415 on 8bd951a passed — only failures were unrelated (24364.test.ts, bun-types.test.ts). Changes since that build are targeted fixes: malformed-status-line rejection, listener cleanup after 101 upgrade, Blob body race removal. All Claude and CodeRabbit review comments addressed with code fixes and replies; CodeRabbit confirmed resolutions on both latest review rounds. Diff clean: no TODO/FIXME/HACK/XXX, only _http_client.ts and new test file touched. Three regression tests exercise upgrade event (bidirectional echo), IncomingMessage fields (crypto-verified Sec-WebSocket-Accept), and non-101 fallback (400 body). Tests 1-2 fail on main, proving regression coverage.

---
Verified by robobun (iteration 3): Lint JS passed. Buildkite build #41443 on 3827eb4 in progress (previous builds canceled by new pushes). Code review: all Claude-bot and CodeRabbit issues addressed — socket binding (line 194), res.socket assignment (lines 235/264), CONNECT/upgrade eventName (line 247), Blob body async handling (line 185), fetching reset via .finally() (lines 638-642), Host header with IPv6 (lines 160-166), socket destroy on unhandled upgrade (lines 249-251), cleanup via res close and socket end (lines 277-278/316-322), header overflow (lines 205-208), malformed status rejection (lines 213-217), abort wiring (lines 356-365). Remaining CodeRabbit nits (primordials, chunked TE in fallback) are style/edge-case consistent with rest of file. Diff clean — no TODO/FIXME. Three regression tests: (1) 101 upgrade with bidirectional echo, (2) IncomingMessage fields with crypto-verified Accept, (3) non-101 fallback emitting response with body.

---
Verified by robobun (iteration 3, final pass): Lint JS passed on b224c859. Buildkite #41445 building; previous build #41438 on 73c37bda had only unrelated failures (worker_threads segfault aarch64, 24364.test.ts, bun-types.test.ts — none touched by this PR). Diff clean: no TODO/FIXME/HACK/XXX, only _http_client.ts and new 28450.test.ts touched. All symbols properly imported. Code verified: parseRawHTTPResponse with header overflow and malformed-status guards, doUpgradeRequest with socket binding, Host header synthesis with IPv6 brackets, abort wiring, destroy no-op after upgrade, Content-Length framing for non-101 fallback. Three regression tests exercise the new code path and would fail on main.

---
Verified by robobun: Lint JS passed on f4532d2. Buildkite #41463 building (pipeline passed); previous builds had only unrelated failures (worker_threads segfault aarch64, 24364.test.ts, bun-types.test.ts — none touched by this PR). All 33 review threads (claude, coderabbitai) resolved. Diff clean — no TODO/FIXME/HACK/XXX, only _http_client.ts and new 28450.test.ts touched. All symbols properly imported. Three regression tests: (1) 101 upgrade with bidirectional echo, (2) IncomingMessage fields with crypto-verified Accept, (3) non-101 fallback emitting response with body — tests 1-2 would fail on main, proving coverage.

---
Verified by robobun (iteration 4): Lint JS passed on 568b566. Buildkite #41479 building (pipeline passed); previous Build #41463 on f4532d2 had only unrelated failures (24364.test.ts, bun-types.test.ts — neither touched by this PR). Latest commit adds socketCloseListener kUpgradeOrConnect guard, extracts onAbortCleanup for proper removal after 101, and adds stderr assertions to all three tests. All claude-bot and coderabbitai review issues resolved. Diff clean — no TODO/FIXME/HACK/XXX, only _http_client.ts and new 28450.test.ts touched. Three regression tests exercise upgrade event (bidirectional echo), IncomingMessage fields (crypto-verified Accept), and non-101 fallback (400 body) — tests 1-2 would fail on main.