### PR TITLE
Move CPU profiler state from process-global statics to per-VM storage

### DIFF
--- a/src/bun.js.zig
+++ b/src/bun.js.zig
@@ -323,8 +323,8 @@ pub const Run = struct {
                 .json_format = cpu_prof_opts.json_format,
                 .interval = cpu_prof_opts.interval,
             };
-            CPUProfiler.setSamplingInterval(cpu_prof_opts.interval);
-            CPUProfiler.startCPUProfiler(vm.jsc_vm);
+            CPUProfiler.setSamplingInterval(vm.global, cpu_prof_opts.interval);
+            CPUProfiler.startCPUProfiler(vm.global);
             bun.analytics.Features.cpu_profile += 1;
         }
 

--- a/src/jsc/BunCPUProfiler.zig
+++ b/src/jsc/BunCPUProfiler.zig
@@ -7,25 +7,25 @@ pub const CPUProfilerConfig = struct {
 };
 
 // C++ function declarations
-extern fn Bun__startCPUProfiler(vm: *jsc.VM) void;
-extern fn Bun__stopCPUProfiler(vm: *jsc.VM, outJSON: ?*bun.String, outText: ?*bun.String) void;
-extern fn Bun__setSamplingInterval(intervalMicroseconds: c_int) void;
+extern fn Bun__startCPUProfiler(globalObject: *jsc.JSGlobalObject) void;
+extern fn Bun__stopCPUProfiler(globalObject: *jsc.JSGlobalObject, outJSON: ?*bun.String, outText: ?*bun.String) void;
+extern fn Bun__setSamplingInterval(globalObject: *jsc.JSGlobalObject, intervalMicroseconds: c_int) void;
 
-pub fn setSamplingInterval(interval: u32) void {
-    Bun__setSamplingInterval(@intCast(interval));
+pub fn setSamplingInterval(globalObject: *jsc.JSGlobalObject, interval: u32) void {
+    Bun__setSamplingInterval(globalObject, @intCast(interval));
 }
 
-pub fn startCPUProfiler(vm: *jsc.VM) void {
-    Bun__startCPUProfiler(vm);
+pub fn startCPUProfiler(globalObject: *jsc.JSGlobalObject) void {
+    Bun__startCPUProfiler(globalObject);
 }
 
-pub fn stopAndWriteProfile(vm: *jsc.VM, config: CPUProfilerConfig) !void {
+pub fn stopAndWriteProfile(globalObject: *jsc.JSGlobalObject, config: CPUProfilerConfig) !void {
     var json_string: bun.String = .empty;
     var text_string: bun.String = .empty;
 
     // Call the unified C++ function with pointers for requested formats
     Bun__stopCPUProfiler(
-        vm,
+        globalObject,
         if (config.json_format) &json_string else null,
         if (config.md_format) &text_string else null,
     );

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -925,7 +925,7 @@ pub fn onExit(this: *VirtualMachine) void {
     // Grab the config and null it out to make this idempotent
     if (this.cpu_profiler_config) |config| {
         this.cpu_profiler_config = null;
-        CPUProfiler.stopAndWriteProfile(this.jsc_vm, config) catch |err| {
+        CPUProfiler.stopAndWriteProfile(this.global, config) catch |err| {
             Output.err(err, "Failed to write CPU profile", .{});
         };
     }

--- a/src/jsc/bindings/BunCPUProfiler.cpp
+++ b/src/jsc/bindings/BunCPUProfiler.cpp
@@ -18,48 +18,47 @@
 #include <algorithm>
 #include <limits>
 
-extern "C" void Bun__startCPUProfiler(JSC::VM* vm);
-extern "C" void Bun__stopCPUProfiler(JSC::VM* vm, BunString* outJSON, BunString* outText);
-extern "C" void Bun__setSamplingInterval(int intervalMicroseconds);
+extern "C" void Bun__startCPUProfiler(JSC::JSGlobalObject* globalObject);
+extern "C" void Bun__stopCPUProfiler(JSC::JSGlobalObject* globalObject, BunString* outJSON, BunString* outText);
+extern "C" void Bun__setSamplingInterval(JSC::JSGlobalObject* globalObject, int intervalMicroseconds);
 
-void Bun__setSamplingInterval(int intervalMicroseconds)
+void Bun__setSamplingInterval(JSC::JSGlobalObject* globalObject, int intervalMicroseconds)
 {
-    Bun::setSamplingInterval(intervalMicroseconds);
+    Bun::setSamplingInterval(globalObject, intervalMicroseconds);
 }
 
 namespace Bun {
 
-// Store the profiling start time in microseconds since Unix epoch
-static double s_profilingStartTime = 0.0;
-// Set sampling interval to 1ms (1000 microseconds) to match Node.js
-static int s_samplingInterval = 1000;
-static bool s_isProfilerRunning = false;
-
-void setSamplingInterval(int intervalMicroseconds)
+void setSamplingInterval(JSC::JSGlobalObject* globalObject, int intervalMicroseconds)
 {
-    s_samplingInterval = intervalMicroseconds;
+    auto* zigGlobal = uncheckedDowncast<Zig::GlobalObject>(globalObject);
+    zigGlobal->m_cpuSamplingInterval = intervalMicroseconds;
 }
 
-bool isCPUProfilerRunning()
+bool isCPUProfilerRunning(JSC::JSGlobalObject* globalObject)
 {
-    return s_isProfilerRunning;
+    auto* zigGlobal = uncheckedDowncast<Zig::GlobalObject>(globalObject);
+    return zigGlobal->m_isCPUProfilerRunning;
 }
 
-void startCPUProfiler(JSC::VM& vm)
+void startCPUProfiler(JSC::JSGlobalObject* globalObject)
 {
+    auto* zigGlobal = uncheckedDowncast<Zig::GlobalObject>(globalObject);
+    auto& vm = globalObject->vm();
+
     // Capture the wall clock time when profiling starts (before creating stopwatch)
     // This will be used as the profile's startTime
-    s_profilingStartTime = MonotonicTime::now().approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
+    zigGlobal->m_profilingStartTime = MonotonicTime::now().approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
 
     // Create a stopwatch and start it
     auto stopwatch = WTF::Stopwatch::create();
     stopwatch->start();
 
     JSC::SamplingProfiler& samplingProfiler = vm.ensureSamplingProfiler(WTF::move(stopwatch));
-    samplingProfiler.setTimingInterval(WTF::Seconds::fromMicroseconds(s_samplingInterval));
+    samplingProfiler.setTimingInterval(WTF::Seconds::fromMicroseconds(zigGlobal->m_cpuSamplingInterval));
     samplingProfiler.noticeCurrentThreadAsJSCExecutionThread();
     samplingProfiler.start();
-    s_isProfilerRunning = true;
+    zigGlobal->m_isCPUProfilerRunning = true;
 }
 
 struct ProfileNode {
@@ -270,13 +269,12 @@ static WTF::String formatCodeSpan(const WTF::String& str)
 }
 
 // Helper to generate a minimal valid cpuprofile JSON with no samples
-static WTF::String generateEmptyProfileJSON()
+static WTF::String generateEmptyProfileJSON(double profilingStartTime)
 {
     // Return a minimal valid Chrome DevTools CPU profile format
-    // Use s_profilingStartTime if available, otherwise fall back to current time
     long long timestamp;
-    if (s_profilingStartTime > 0)
-        timestamp = static_cast<long long>(s_profilingStartTime);
+    if (profilingStartTime > 0)
+        timestamp = static_cast<long long>(profilingStartTime);
     else
         timestamp = static_cast<long long>(WTF::WallTime::now().secondsSinceEpoch().value() * 1000000.0);
 
@@ -290,9 +288,11 @@ static WTF::String generateEmptyProfileJSON()
 }
 
 // Unified function that stops the profiler and generates requested output formats
-void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
+void stopCPUProfiler(JSC::JSGlobalObject* globalObject, WTF::String* outJSON, WTF::String* outText)
 {
-    s_isProfilerRunning = false;
+    auto* zigGlobal = uncheckedDowncast<Zig::GlobalObject>(globalObject);
+    auto& vm = globalObject->vm();
+    zigGlobal->m_isCPUProfilerRunning = false;
 
     JSC::SamplingProfiler* profiler = vm.samplingProfiler();
     if (!profiler) {
@@ -321,7 +321,7 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
         return;
 
     if (stackTraces.isEmpty()) {
-        if (outJSON) *outJSON = generateEmptyProfileJSON();
+        if (outJSON) *outJSON = generateEmptyProfileJSON(zigGlobal->m_profilingStartTime);
         if (outText) *outText = "No samples collected.\n"_s;
         return;
     }
@@ -357,8 +357,8 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
         WTF::Vector<int> samples;
         WTF::Vector<long long> timeDeltas;
 
-        double startTime = s_profilingStartTime;
-        double lastTime = s_profilingStartTime;
+        double startTime = zigGlobal->m_profilingStartTime;
+        double lastTime = zigGlobal->m_profilingStartTime;
 
         for (size_t idx : sortedIndices) {
             auto& stackTrace = stackTraces[idx];
@@ -617,8 +617,8 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
 
     // Generate text format if requested
     if (outText) {
-        double startTime = s_profilingStartTime;
-        double lastTime = s_profilingStartTime;
+        double startTime = zigGlobal->m_profilingStartTime;
+        double lastTime = zigGlobal->m_profilingStartTime;
         double endTime = startTime;
 
         WTF::HashMap<WTF::String, FunctionStats> functionStatsMap;
@@ -746,7 +746,7 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
         output.append(" | "_s);
         output.append(totalSamples);
         output.append(" | "_s);
-        output.append(formatTime(s_samplingInterval));
+        output.append(formatTime(zigGlobal->m_cpuSamplingInterval));
         output.append(" | "_s);
         output.append(numFunctions);
         output.append(" |\n\n"_s);
@@ -930,16 +930,16 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
 
 } // namespace Bun
 
-extern "C" void Bun__startCPUProfiler(JSC::VM* vm)
+extern "C" void Bun__startCPUProfiler(JSC::JSGlobalObject* globalObject)
 {
-    Bun::startCPUProfiler(*vm);
+    Bun::startCPUProfiler(globalObject);
 }
 
-extern "C" void Bun__stopCPUProfiler(JSC::VM* vm, BunString* outJSON, BunString* outText)
+extern "C" void Bun__stopCPUProfiler(JSC::JSGlobalObject* globalObject, BunString* outJSON, BunString* outText)
 {
     WTF::String jsonResult;
     WTF::String textResult;
-    Bun::stopCPUProfiler(*vm, outJSON ? &jsonResult : nullptr, outText ? &textResult : nullptr);
+    Bun::stopCPUProfiler(globalObject, outJSON ? &jsonResult : nullptr, outText ? &textResult : nullptr);
     if (outJSON)
         *outJSON = Bun::toStringRef(jsonResult);
     if (outText)

--- a/src/jsc/bindings/BunCPUProfiler.h
+++ b/src/jsc/bindings/BunCPUProfiler.h
@@ -5,19 +5,18 @@
 
 namespace JSC {
 class JSGlobalObject;
-class VM;
 }
 
 namespace Bun {
 
-void setSamplingInterval(int intervalMicroseconds);
-bool isCPUProfilerRunning();
+void setSamplingInterval(JSC::JSGlobalObject* globalObject, int intervalMicroseconds);
+bool isCPUProfilerRunning(JSC::JSGlobalObject* globalObject);
 
 // Start the CPU profiler
-void startCPUProfiler(JSC::VM& vm);
+void startCPUProfiler(JSC::JSGlobalObject* globalObject);
 
 // Stop the CPU profiler and get profile data in requested formats.
 // Pass non-null pointers for the formats you want. Null pointers are skipped.
-void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText);
+void stopCPUProfiler(JSC::JSGlobalObject* globalObject, WTF::String* outJSON, WTF::String* outText);
 
 } // namespace Bun

--- a/src/jsc/bindings/JSInspectorProfiler.cpp
+++ b/src/jsc/bindings/JSInspectorProfiler.cpp
@@ -44,7 +44,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_setCPUSamplingInterval, (JSGlobalObject * gl
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsFunction_isCPUProfilerRunning);
-JSC_DEFINE_HOST_FUNCTION(jsFunction_isCPUProfilerRunning, (JSGlobalObject* globalObject, CallFrame*))
+JSC_DEFINE_HOST_FUNCTION(jsFunction_isCPUProfilerRunning, (JSGlobalObject * globalObject, CallFrame*))
 {
     return JSValue::encode(jsBoolean(Bun::isCPUProfilerRunning(globalObject)));
 }

--- a/src/jsc/bindings/JSInspectorProfiler.cpp
+++ b/src/jsc/bindings/JSInspectorProfiler.cpp
@@ -11,7 +11,7 @@ using namespace JSC;
 JSC_DECLARE_HOST_FUNCTION(jsFunction_startCPUProfiler);
 JSC_DEFINE_HOST_FUNCTION(jsFunction_startCPUProfiler, (JSGlobalObject * globalObject, CallFrame*))
 {
-    Bun::startCPUProfiler(globalObject->vm());
+    Bun::startCPUProfiler(globalObject);
     return JSValue::encode(jsUndefined());
 }
 
@@ -20,7 +20,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_stopCPUProfiler, (JSGlobalObject * globalObj
 {
     auto& vm = globalObject->vm();
     WTF::String result;
-    Bun::stopCPUProfiler(vm, &result, nullptr);
+    Bun::stopCPUProfiler(globalObject, &result, nullptr);
     return JSValue::encode(jsString(vm, result));
 }
 
@@ -39,12 +39,12 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_setCPUSamplingInterval, (JSGlobalObject * gl
     Bun::V::validateInteger(scope, globalObject, callFrame->uncheckedArgument(0), "interval"_s, jsNumber(1), jsUndefined(), &interval);
     RETURN_IF_EXCEPTION(scope, {});
 
-    Bun::setSamplingInterval(interval);
+    Bun::setSamplingInterval(globalObject, interval);
     return JSValue::encode(jsUndefined());
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsFunction_isCPUProfilerRunning);
-JSC_DEFINE_HOST_FUNCTION(jsFunction_isCPUProfilerRunning, (JSGlobalObject*, CallFrame*))
+JSC_DEFINE_HOST_FUNCTION(jsFunction_isCPUProfilerRunning, (JSGlobalObject* globalObject, CallFrame*))
 {
-    return JSValue::encode(jsBoolean(Bun::isCPUProfilerRunning()));
+    return JSValue::encode(jsBoolean(Bun::isCPUProfilerRunning(globalObject)));
 }

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -436,6 +436,13 @@ public:
     double INSPECT_MAX_BYTES = 50;
     bool isInsideErrorPrepareStackTraceCallback = false;
 
+    // CPU profiler state per GlobalObject. Each worker has its own VM and GlobalObject,
+    // so this must not be process-global. The node:inspector API always operates on the
+    // GlobalObject that loaded the module, so this is the correct granularity.
+    double m_profilingStartTime = 0.0;
+    int m_cpuSamplingInterval = 1000;
+    bool m_isCPUProfilerRunning = false;
+
     template<typename T>
     using LazyPropertyOfGlobalObject = LazyProperty<JSGlobalObject, T>;
 

--- a/test/regression/issue/28472.test.ts
+++ b/test/regression/issue/28472.test.ts
@@ -65,4 +65,5 @@ if (isMainThread) {
 
   expect(stdout).toContain("WORKER_RESULT:ok");
   expect(stdout).toContain("MAIN_RESULT:ok");
+  expect(result.exitCode).toBe(0);
 }, 15_000);

--- a/test/regression/issue/28472.test.ts
+++ b/test/regression/issue/28472.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("worker_threads inspector Profiler.stop returns profile in worker", () => {
+  using dir = tempDir("issue-28472", {
+    "index.cjs": `
+const { Worker, isMainThread, parentPort } = require('worker_threads');
+const inspector = require('inspector');
+
+if (isMainThread) {
+  const session = new inspector.Session();
+  session.connect();
+  session.post('Profiler.enable', () => {
+    session.post('Profiler.start', () => {
+      const worker = new Worker(__filename);
+      worker.on('message', (msg) => {
+        console.log('WORKER_RESULT:' + msg);
+        session.post('Profiler.stop', (err, result) => {
+          if (err) { console.log('MAIN_RESULT:error:' + err.message); }
+          else if (!result || !result.profile) { console.log('MAIN_RESULT:null_profile'); }
+          else if (!result.profile.nodes || !result.profile.nodes.length) { console.log('MAIN_RESULT:empty_nodes'); }
+          else { console.log('MAIN_RESULT:ok'); }
+          session.disconnect();
+          setTimeout(() => process.exit(0), 10);
+        });
+      });
+      worker.on('error', (e) => { console.log('WORKER_RESULT:thread_error:' + e.message); process.exit(1); });
+    });
+  });
+} else {
+  const session = new inspector.Session();
+  session.connect();
+  session.post('Profiler.enable', () => {
+    session.post('Profiler.start', () => {
+      let x = 0;
+      for (let i = 0; i < 1e5; i++) x += i;
+      session.post('Profiler.stop', (err, result) => {
+        let msg;
+        if (err) msg = 'error:' + err.message;
+        else if (!result || !result.profile) msg = 'null_profile';
+        else if (!result.profile.nodes || !result.profile.nodes.length) msg = 'empty_nodes';
+        else msg = 'ok';
+        session.disconnect();
+        parentPort.postMessage(msg);
+      });
+    });
+  });
+}
+`,
+  });
+
+  const result = Bun.spawnSync({
+    cmd: [bunExe(), "index.cjs"],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      // Pre-existing GC timer leaks in the child cause non-zero exit under ASAN.
+      ASAN_OPTIONS: "detect_leaks=0:" + (bunEnv.ASAN_OPTIONS ?? ""),
+    },
+    stderr: "pipe",
+    timeout: 14_000,
+  });
+
+  const stdout = result.stdout.toString();
+
+  expect(stdout).toContain("WORKER_RESULT:ok");
+  expect(stdout).toContain("MAIN_RESULT:ok");
+}, 15_000);


### PR DESCRIPTION
## Problem

When CPU profiling is active in both the main thread and a worker thread, calling `Profiler.stop` in the worker returns null instead of `{ profile }`. Node.js handles this correctly.

The CPU profiler used three process-global static variables (`s_profilingStartTime`, `s_samplingInterval`, `s_isProfilerRunning`) in `BunCPUProfiler.cpp` shared across all VMs. This caused two issues:

1. **Worker's `Profiler.stop` clears main thread state**: When the worker calls `stopCPUProfiler()`, it sets `s_isProfilerRunning = false` globally. The main thread's `isCPUProfilerRunning()` then returns `false`, causing the JS layer to return an error instead of calling the native stop function.

2. **Worker gets corrupted JSON**: The shared `s_profilingStartTime` was overwritten by the main thread's start time, producing invalid timing data.

## Fix

Move the three static variables to `ZigGlobalObject` member fields (`m_profilingStartTime`, `m_cpuSamplingInterval`, `m_isCPUProfilerRunning`) so each VM (main thread and each worker) has independent profiler state. Update all profiler functions to take `JSGlobalObject*` instead of `VM*` to access per-instance state.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28472.test.ts` → **FAIL** (bug exists on main)
- `bun bd test test/regression/issue/28472.test.ts` → **PASS** (fix works)

Fixes #28472

---

**Verification (robobun):** CI Buildkite #41426 building (Lint JS pass, compilation pending — expected for C++/Zig changes). Diff verified: all three statics fully removed (grep confirms zero references); all 6 call sites (bun.js.zig, VirtualMachine.zig, BunCPUProfiler.cpp/.h/.zig, JSInspectorProfiler.cpp) consistently updated from VM* to JSGlobalObject*. Dead `stopCPUProfilerAndGetJSON` function removed, stale `class VM;` forward decl removed. No TODO/FIXME/HACK in added lines. Regression test in 28472.test.ts exercises exact concurrent main+worker profiling scenario with explicit 15s timeout — asserts both WORKER_RESULT:ok and MAIN_RESULT:ok, which would fail on main where worker stop clears global state. All 3 CodeRabbit actionable comments and 2 claude nits addressed in commit 731494a.