### PR TITLE
fix bun-types test: remove stale fixture lockfile

### DIFF
--- a/test/integration/bun-types/fixture/.gitignore
+++ b/test/integration/bun-types/fixture/.gitignore
@@ -1,0 +1,2 @@
+bun.lock
+node_modules/


### PR DESCRIPTION
## Problem

The fixture's committed `bun.lock` pinned TypeScript to 5.8.2, but the test uses the root's TS compiler (5.9.2). TS 5.9 added new lib files (`lib.esnext.float16.d.ts`, `lib.esnext.error.d.ts`, `lib.esnext.sharedmemory.d.ts`) that the compiler expects to find. The stale lockfile prevented `bun add` from resolving the latest TypeScript during test setup.

## Fix

Remove the committed `bun.lock` so the fixture always resolves latest TypeScript and `@types/node`, matching the intent of the `package.json` (`"typescript": "latest"`). Added `.gitignore` to prevent the lockfile from being re-committed.

## Verification

All 11 tests pass:
```
 11 pass
 0 fail
Ran 11 tests across 1 file. [52.99s]
```

---

Verified: Diff is 2 test-fixture files only (lockfile deletion + .gitignore). Root cause confirmed — test's `getDefaultLibFileName` resolves TS lib files from fixture's `node_modules/typescript/lib/` using root TS 5.9 API; stale lockfile installed TS 5.8.2, missing new lib files. Fix removes lockfile so `"typescript": "latest"` resolves correctly during `bun add` in beforeAll setup. No TODO/HACK markers. Lint JS passed; Format and Buildkite still building but no compiled code is touched.