### PR TITLE
Implement process.loadEnvFile

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -161,7 +161,7 @@ BUN_DECLARE_HOST_FUNCTION(Bun__Process__loadEnvFile);
 
 extern "C" EncodedJSValue Bun__getProcessEnvObject(JSGlobalObject* globalObject)
 {
-    return JSValue::encode(jsCast<Zig::GlobalObject*>(globalObject)->processEnvObject());
+    return JSValue::encode(defaultGlobalObject(globalObject)->processEnvObject());
 }
 
 extern "C" void Process__emitDisconnectEvent(Zig::GlobalObject* global);

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -157,6 +157,12 @@ extern "C" bool Bun__GlobalObject__hasIPC(JSGlobalObject*);
 extern "C" bool Bun__ensureProcessIPCInitialized(JSGlobalObject*);
 extern "C" const char* Bun__githubURL;
 BUN_DECLARE_HOST_FUNCTION(Bun__Process__send);
+BUN_DECLARE_HOST_FUNCTION(Bun__Process__loadEnvFile);
+
+extern "C" EncodedJSValue Bun__getProcessEnvObject(JSGlobalObject* globalObject)
+{
+    return JSValue::encode(jsCast<Zig::GlobalObject*>(globalObject)->processEnvObject());
+}
 
 extern "C" void Process__emitDisconnectEvent(Zig::GlobalObject* global);
 extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValue value);
@@ -948,6 +954,11 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionHRTimeBigInt, (JSC::JSGlobalObject * gl
 {
     Zig::GlobalObject* globalObject = static_cast<Zig::GlobalObject*>(globalObject_);
     return JSC::JSValue::encode(JSValue(JSC::JSBigInt::createFrom(globalObject, Bun__readOriginTimer(globalObject->bunVM()))));
+}
+
+JSC_DEFINE_HOST_FUNCTION(Process_functionLoadEnvFile, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    return Bun__Process__loadEnvFile(globalObject, callFrame);
 }
 
 JSC_DEFINE_HOST_FUNCTION(Process_functionChdir, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
@@ -4012,6 +4023,7 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
   hrtime                           constructProcessHrtimeObject                        PropertyCallback
   isBun                            constructIsBun                                      PropertyCallback
   kill                             Process_functionKill                                Function 2
+  loadEnvFile                      Process_functionLoadEnvFile                         Function 1
   mainModule                       constructMainModuleProperty                         PropertyCallback
   memoryUsage                      constructMemoryUsage                                PropertyCallback
   moduleLoadList                   Process_stubEmptyArray                              PropertyCallback

--- a/src/bun.js/node/node_process.zig
+++ b/src/bun.js/node/node_process.zig
@@ -395,15 +395,9 @@ fn loadEnvFile(globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun
             );
         },
     };
-    // Do NOT defer-free contents. The parser returns key slices that point into
-    // this buffer, and the env map stores them directly. This matches how
-    // loadEnvFileDynamic (env_loader.zig:897-898) uses errdefer, not defer.
-    errdefer allocator.free(contents);
+    defer allocator.free(contents);
 
     // Parse into a temporary map to track which keys this file sets.
-    // Parser.parseKey returns key slices into contents (not duped).
-    // Parser._parse dupes values via allocator.dupe. Both survive deinit
-    // of the temp map's hash table structure.
     var file_map = DotEnv.Map.init(allocator);
     defer file_map.map.deinit();
 
@@ -414,20 +408,28 @@ fn loadEnvFile(globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun
     // Get the JS process.env object via extern C++ call
     const env_object = Bun__getProcessEnvObject(globalObject);
 
-    // For each parsed entry, store into the Zig env map and update the JS object.
-    // Map.put stores key/value slices directly (no duplication):
-    //   - keys point into contents (kept alive, not freed on success)
-    //   - values were duped by the parser (kept alive, not freed by deinit)
+    // For each parsed entry, copy into the persistent env map and update JS.
+    // putAllocKeyAndValue dupes both key and value into owned storage so
+    // they remain valid after contents is freed.
     var it = file_map.map.iterator();
     while (it.next()) |entry| {
         const key = entry.key_ptr.*;
         const value = entry.value_ptr.value;
 
-        vm.transpiler.env.map.put(key, value) catch |err| switch (err) {
+        vm.transpiler.env.map.putAllocKeyAndValue(allocator, key, value) catch |err| switch (err) {
             error.OutOfMemory => return globalObject.throwOutOfMemory(),
         };
 
         env_object.put(globalObject, &ZigString.initUTF8(key), ZigString.initUTF8(value).toJS(globalObject));
+
+        // On Windows, also update the OS environment block so child
+        // processes inherit the loaded variables.
+        if (comptime Environment.isWindows) {
+            Bun__Process__editWindowsEnvVar(
+                bun.String.cloneUTF8(key),
+                bun.String.cloneUTF8(value),
+            );
+        }
     }
 
     return .js_undefined;

--- a/src/bun.js/node/node_process.zig
+++ b/src/bun.js/node/node_process.zig
@@ -447,11 +447,10 @@ pub export const Bun__version_sha: [*:0]const u8 = bun.Environment.git_sha;
 const std = @import("std");
 
 const bun = @import("bun");
+const DotEnv = bun.DotEnv;
 const Environment = bun.Environment;
 const Syscall = bun.sys;
 const strings = bun.strings;
-
-const DotEnv = bun.DotEnv;
 
 const jsc = bun.jsc;
 const JSGlobalObject = jsc.JSGlobalObject;

--- a/src/bun.js/node/node_process.zig
+++ b/src/bun.js/node/node_process.zig
@@ -10,6 +10,7 @@ comptime {
     @export(&getExecPath, .{ .name = "Bun__Process__getExecPath" });
     @export(&bun.jsc.host_fn.wrap1(createExecArgv), .{ .name = "Bun__Process__createExecArgv" });
     @export(&getEval, .{ .name = "Bun__Process__getEval" });
+    @export(&jsc.host_fn.toJSHostFn(loadEnvFile), .{ .name = "Bun__Process__loadEnvFile" });
 }
 
 var title_mutex = bun.Mutex{};
@@ -350,6 +351,81 @@ comptime {
     }
 }
 
+/// Reads and parses a .env file, updating the Zig env map and JS process.env object.
+fn loadEnvFile(globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+    const vm = globalObject.bunVM();
+    const allocator = bun.default_allocator;
+
+    // Get path argument, default to ".env"
+    const arg = callframe.argument(0);
+    const path_slice: []const u8 = if (arg == .js_undefined)
+        ".env"
+    else brk: {
+        if (!arg.isString()) {
+            return globalObject.throwInvalidArguments("The \"path\" argument must be of type string", .{});
+        }
+        const str = try arg.toBunString(globalObject);
+        defer str.deref();
+        break :brk str.toOwnedSlice(allocator) catch return globalObject.throwOutOfMemory();
+    };
+    const path_is_allocated = arg != .js_undefined;
+    defer if (path_is_allocated) allocator.free(path_slice);
+
+    // Resolve the path relative to cwd
+    var path_buf: bun.PathBuffer = undefined;
+    const resolved = bun.path.joinAbsStringBufZ(
+        vm.transpiler.fs.top_level_dir,
+        &path_buf,
+        &.{path_slice},
+        .auto,
+    );
+
+    // Open and read the file
+    const contents = switch (bun.sys.File.readFrom(bun.FD.cwd(), resolved, allocator)) {
+        .result => |bytes| bytes,
+        .err => |err| {
+            const sys_err = err.toSystemError();
+            const utf8 = sys_err.message.toUTF8(allocator);
+            defer utf8.deinit();
+            return globalObject.throwValue(
+                globalObject.createTypeErrorInstance(
+                    "Cannot read the .env file at: \"{s}\". Error: {s}",
+                    .{ resolved, utf8.slice() },
+                ),
+            );
+        },
+    };
+    defer allocator.free(contents);
+
+    // Parse the env file into a temporary map
+    var map = DotEnv.Map.init(allocator);
+    DotEnv.parseEnvBuf(contents, path_slice, allocator, &map) catch |err| switch (err) {
+        error.OutOfMemory => return globalObject.throwOutOfMemory(),
+    };
+
+    // Get the JS process.env object via extern C++ call
+    const env_object = Bun__getProcessEnvObject(globalObject);
+
+    // Update both the Zig env map and the JS process.env object
+    var it = map.map.iterator();
+    while (it.next()) |entry| {
+        const key = entry.key_ptr.*;
+        const value = entry.value_ptr.value;
+
+        // Update Zig env map (override existing values)
+        vm.transpiler.env.map.put(key, value) catch |err| switch (err) {
+            error.OutOfMemory => return globalObject.throwOutOfMemory(),
+        };
+
+        // Update JS process.env object
+        env_object.put(globalObject, &ZigString.initUTF8(key), ZigString.initUTF8(value).toJS(globalObject));
+    }
+
+    return .js_undefined;
+}
+
+extern fn Bun__getProcessEnvObject(globalObject: *jsc.JSGlobalObject) jsc.JSValue;
+
 pub export fn Bun__NODE_NO_WARNINGS() bool {
     return bun.feature_flag.NODE_NO_WARNINGS.get();
 }
@@ -374,6 +450,8 @@ const bun = @import("bun");
 const Environment = bun.Environment;
 const Syscall = bun.sys;
 const strings = bun.strings;
+
+const DotEnv = bun.DotEnv;
 
 const jsc = bun.jsc;
 const JSGlobalObject = jsc.JSGlobalObject;

--- a/src/bun.js/node/node_process.zig
+++ b/src/bun.js/node/node_process.zig
@@ -395,29 +395,38 @@ fn loadEnvFile(globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun
             );
         },
     };
-    defer allocator.free(contents);
+    // Do NOT defer-free contents. The parser returns key slices that point into
+    // this buffer, and the env map stores them directly. This matches how
+    // loadEnvFileDynamic (env_loader.zig:897-898) uses errdefer, not defer.
+    errdefer allocator.free(contents);
 
-    // Parse the env file into a temporary map
-    var map = DotEnv.Map.init(allocator);
-    DotEnv.parseEnvBuf(contents, path_slice, allocator, &map) catch |err| switch (err) {
+    // Parse into a temporary map to track which keys this file sets.
+    // Parser.parseKey returns key slices into contents (not duped).
+    // Parser._parse dupes values via allocator.dupe. Both survive deinit
+    // of the temp map's hash table structure.
+    var file_map = DotEnv.Map.init(allocator);
+    defer file_map.map.deinit();
+
+    DotEnv.parseEnvBuf(contents, path_slice, allocator, &file_map) catch |err| switch (err) {
         error.OutOfMemory => return globalObject.throwOutOfMemory(),
     };
 
     // Get the JS process.env object via extern C++ call
     const env_object = Bun__getProcessEnvObject(globalObject);
 
-    // Update both the Zig env map and the JS process.env object
-    var it = map.map.iterator();
+    // For each parsed entry, store into the Zig env map and update the JS object.
+    // Map.put stores key/value slices directly (no duplication):
+    //   - keys point into contents (kept alive, not freed on success)
+    //   - values were duped by the parser (kept alive, not freed by deinit)
+    var it = file_map.map.iterator();
     while (it.next()) |entry| {
         const key = entry.key_ptr.*;
         const value = entry.value_ptr.value;
 
-        // Update Zig env map (override existing values)
         vm.transpiler.env.map.put(key, value) catch |err| switch (err) {
             error.OutOfMemory => return globalObject.throwOutOfMemory(),
         };
 
-        // Update JS process.env object
         env_object.put(globalObject, &ZigString.initUTF8(key), ZigString.initUTF8(value).toJS(globalObject));
     }
 

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -1193,6 +1193,28 @@ const Parser = struct {
     }
 };
 
+/// Parse a .env file contents string into the given map.
+/// Public wrapper around the private Parser for use by process.loadEnvFile.
+pub fn parseEnvBuf(
+    contents: []const u8,
+    file_path: []const u8,
+    allocator: std.mem.Allocator,
+    map: *Map,
+) OOM!void {
+    const source = logger.Source.initPathString(file_path, contents);
+    var value_buffer = std.array_list.Managed(u8).init(allocator);
+    defer value_buffer.deinit();
+    try Parser.parse(
+        &source,
+        allocator,
+        map,
+        &value_buffer,
+        true, // override
+        false, // is_process
+        true, // expand
+    );
+}
+
 pub const Map = struct {
     pub const HashTableValue = struct {
         value: string,

--- a/test/regression/issue/28479.test.ts
+++ b/test/regression/issue/28479.test.ts
@@ -123,6 +123,37 @@ COMMENT_28479=value # inline comment
     expect(exitCode).toBe(0);
   });
 
+  test("loaded vars are visible in child processes", async () => {
+    using dir = tempDir("loadEnvFile-subprocess", {
+      "test.env": "CHILD_28479=from_env_file\n",
+      "index.js": `
+        const { loadEnvFile } = require('node:process');
+        loadEnvFile('./test.env');
+        const child = Bun.spawn([process.execPath, '-e', 'console.log(process.env.CHILD_28479)'], {
+          env: { ...process.env },
+        });
+        const text = await new Response(child.stdout).text();
+        console.log(text.trim());
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toBe("from_env_file\n");
+    expect(exitCode).toBe(0);
+  });
+
   test("overrides existing env vars", async () => {
     using dir = tempDir("loadEnvFile-override", {
       "test.env": "OVERRIDE_28479=new_value\n",

--- a/test/regression/issue/28479.test.ts
+++ b/test/regression/issue/28479.test.ts
@@ -144,11 +144,7 @@ COMMENT_28479=value # inline comment
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("from_env_file\n");
     expect(exitCode).toBe(0);

--- a/test/regression/issue/28479.test.ts
+++ b/test/regression/issue/28479.test.ts
@@ -1,0 +1,168 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("process.loadEnvFile", () => {
+  test("loads .env file and sets variables in process.env", async () => {
+    using dir = tempDir("loadEnvFile", {
+      "test.env": "FOO_28479=hello\nBAR_28479=world\n",
+      "index.js": `
+        process.loadEnvFile('./test.env');
+        console.log(process.env.FOO_28479);
+        console.log(process.env.BAR_28479);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toBe("hello\nworld\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("defaults to .env when no path is given", async () => {
+    using dir = tempDir("loadEnvFile-default", {
+      ".env": "DEFAULT_28479=yes\n",
+      "index.js": `
+        process.loadEnvFile();
+        console.log(process.env.DEFAULT_28479);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--no-env-file", "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toBe("yes\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("throws TypeError when file does not exist", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `
+        try {
+          process.loadEnvFile('./nonexistent.env');
+          console.log("FAIL: no error thrown");
+        } catch (err) {
+          console.log(err instanceof TypeError);
+          console.log(err.message.includes("Cannot read the .env file"));
+        }
+      `],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toBe("true\ntrue\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("supports quoted values and comments", async () => {
+    using dir = tempDir("loadEnvFile-quoted", {
+      "test.env": `
+QUOTED_28479="hello world"
+SINGLE_28479='no expansion'
+COMMENT_28479=value # inline comment
+`,
+      "index.js": `
+        process.loadEnvFile('./test.env');
+        console.log(process.env.QUOTED_28479);
+        console.log(process.env.SINGLE_28479);
+        console.log(process.env.COMMENT_28479);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toBe("hello world\nno expansion\nvalue\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("is importable as named export from node:process", async () => {
+    using dir = tempDir("loadEnvFile-import", {
+      "test.env": "NAMED_28479=imported\n",
+      "index.mjs": `
+        import { loadEnvFile } from 'node:process';
+        loadEnvFile('./test.env');
+        console.log(process.env.NAMED_28479);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toBe("imported\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("overrides existing env vars", async () => {
+    using dir = tempDir("loadEnvFile-override", {
+      "test.env": "OVERRIDE_28479=new_value\n",
+      "index.js": `
+        process.env.OVERRIDE_28479 = "old_value";
+        process.loadEnvFile('./test.env');
+        console.log(process.env.OVERRIDE_28479);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toBe("new_value\n");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/regression/issue/28479.test.ts
+++ b/test/regression/issue/28479.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("process.loadEnvFile", () => {
@@ -19,11 +19,7 @@ describe("process.loadEnvFile", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("hello\nworld\n");
     expect(exitCode).toBe(0);
@@ -45,11 +41,7 @@ describe("process.loadEnvFile", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("yes\n");
     expect(exitCode).toBe(0);
@@ -57,7 +49,10 @@ describe("process.loadEnvFile", () => {
 
   test("throws TypeError when file does not exist", async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", `
+      cmd: [
+        bunExe(),
+        "-e",
+        `
         try {
           process.loadEnvFile('./nonexistent.env');
           console.log("FAIL: no error thrown");
@@ -65,16 +60,13 @@ describe("process.loadEnvFile", () => {
           console.log(err instanceof TypeError);
           console.log(err.message.includes("Cannot read the .env file"));
         }
-      `],
+      `,
+      ],
       env: bunEnv,
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("true\ntrue\n");
     expect(exitCode).toBe(0);
@@ -102,11 +94,7 @@ COMMENT_28479=value # inline comment
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("hello world\nno expansion\nvalue\n");
     expect(exitCode).toBe(0);
@@ -129,11 +117,7 @@ COMMENT_28479=value # inline comment
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("imported\n");
     expect(exitCode).toBe(0);
@@ -156,11 +140,7 @@ COMMENT_28479=value # inline comment
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("new_value\n");
     expect(exitCode).toBe(0);


### PR DESCRIPTION
Fixes #28479

## Problem
`process.loadEnvFile` is a Node.js API (added in v20.12.0) that reads a `.env` file and sets the parsed key-value pairs into `process.env`. Bun did not implement it — calling `process.loadEnvFile()` returned `undefined`, and importing `{ loadEnvFile }` from `node:process` threw a `SyntaxError`.

## Cause
The `loadEnvFile` method was not registered on the process object. Bun already had the full `.env` parser infrastructure in `src/env_loader.zig`, but no runtime API exposed it.

## Fix
- Added `loadEnvFile` function in `src/bun.js/node/node_process.zig` that:
  - Accepts an optional path argument (defaults to `.env`)
  - Resolves the path relative to cwd
  - Opens and reads the file, throwing `TypeError` on failure (matching Node.js)
  - Parses the file using Bun's existing dotenv parser
  - Updates both the internal Zig env map and the JS `process.env` object
- Added public `parseEnvBuf` wrapper in `src/env_loader.zig` to expose the private parser
- Registered `loadEnvFile` in the process object table in `BunProcess.cpp`
- Added `Bun__getProcessEnvObject` C++ helper to bridge the process.env object to Zig

## Verification
- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28479.test.ts` → 6 fail (feature missing on main)
- `bun bd test test/regression/issue/28479.test.ts` → 6 pass (fix works)

Tests cover: basic loading, default path, error on missing file, quoted values/comments, named ESM import from `node:process`, and overriding existing env vars.

---
**Verification (robobun):** CI lint and format both pass on 61bea77. Buildkite Build #41465 still running (no failures yet). Previous Build #41460 on older commit 4abb5c0 had Windows test failures for 28479.test.ts and musl build failures — those were addressed in the latest commit which switched to putAllocKeyAndValue (dupes both key+value so contents can be safely freed via defer), uses defaultGlobalObject() for cross-realm safety, and adds editWindowsEnvVar for Windows child-process env inheritance. Diff is clean: no TODO/FIXME/HACK. 4 files changed, all scoped to the feature. 7 regression tests spawn subprocesses calling process.loadEnvFile() which does not exist on main, so they cannot false-pass.