### PR TITLE
fix: route console.trace() output to stderr instead of stdout 🤖🤖🤖

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -111,7 +111,7 @@ fn messageWithTypeAndLevel_(
 
     // Lock/unlock a mutex incase two JS threads are console.log'ing at the same time
     // We do this the slightly annoying way to avoid assigning a pointer
-    if (level == .Warning or level == .Error or message_type == .Assert) {
+    if (level == .Warning or level == .Error or message_type == .Assert or message_type == .Trace) {
         if (stderr_lock_count == 0) {
             stderr_mutex.lock();
         }
@@ -126,7 +126,7 @@ fn messageWithTypeAndLevel_(
     }
 
     defer {
-        if (level == .Warning or level == .Error or message_type == .Assert) {
+        if (level == .Warning or level == .Error or message_type == .Assert or message_type == .Trace) {
             stderr_lock_count -= 1;
 
             if (stderr_lock_count == 0) {
@@ -156,12 +156,12 @@ fn messageWithTypeAndLevel_(
         return;
     }
 
-    const enable_colors = if (level == .Warning or level == .Error)
+    const enable_colors = if (level == .Warning or level == .Error or message_type == .Trace)
         Output.enable_ansi_colors_stderr
     else
         Output.enable_ansi_colors_stdout;
 
-    const writer = if (level == .Warning or level == .Error)
+    const writer = if (level == .Warning or level == .Error or message_type == .Trace)
         console.error_writer
     else
         console.writer;


### PR DESCRIPTION
## Summary

console.trace() was incorrectly writing to stdout instead of stderr, diverging from Node.js behavior.

## What changed

In ConsoleObject.zig, the writer/mutex selection logic now treats message_type == .Trace the same as .Assert - routing it to stderr with stderr ANSI color detection and the stderr mutex.

**4 locations updated:**
- Stderr mutex lock acquisition
- Stderr mutex unlock (defer block)
- ANSI color detection (enable_ansi_colors_stderr)
- Writer selection (console.error_writer)

## Verification

Per Node.js behavior, redirecting stdout should have no effect on console.trace() output. After this fix, Bun matches Node.js: console.trace() writes to stderr.

Fixes #19952
