### PR TITLE
fix index out of bounds in braces lexer on empty input

### DIFF
--- a/src/shell/braces.zig
+++ b/src/shell/braces.zig
@@ -307,7 +307,7 @@ pub const Parser = struct {
         if (!self.is_at_end()) {
             self.current += 1;
         }
-        return self.prev();
+        return if (self.current > 0) self.prev() else self.peek();
     }
 
     fn is_at_end(self: *Parser) bool {
@@ -588,6 +588,7 @@ pub fn NewLexer(comptime encoding: Encoding) type {
         }
 
         fn flattenTokens(self: *@This()) Allocator.Error!void {
+            if (self.tokens.items.len == 0) return;
             var brace_count: u32 = if (self.tokens.items[0] == .open) 1 else 0;
             var i: u32 = 0;
             var j: u32 = 1;

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -50,6 +50,12 @@ describe("$.braces", () => {
     ]);
   });
 
+  test("empty string", () => {
+    expect($.braces("")).toEqual([""]);
+    expect($.braces("", { parse: true })).toBeString();
+    expect($.braces("", { tokenize: true })).toBeString();
+  });
+
   test("unicode", () => {
     const result = $.braces(`lol {😂,🫵,🤣}`);
     expect(result).toEqual(["lol 😂", "lol 🫵", "lol 🤣"]);


### PR DESCRIPTION
When `Bun.$.braces("")` is called with an empty string, the tokenizer produces zero tokens. `flattenTokens` then accesses `self.tokens.items[0]` unconditionally, causing an index-out-of-bounds panic. Additionally, `Parser.advance()` unconditionally calls `prev()` which underflows when `current == 0`.

The fix adds an early return when the token list is empty in `flattenTokens`, and guards `advance()` to return `peek()` instead of underflowing `prev()` when `current == 0`.

---
Verification (robobun, iteration 4): Build #41524 (commit 7045ab1) completed — 5 failing tests are all unrelated (bun-upgrade, issue/8254, webview timeout, issue/24364, bun-types), none in shell/braces. Build #41555 (CI retry commit 477200b, empty) is pending. Diff: 2 files, 8 added / 1 removed — `flattenTokens` early-return guard at braces.zig:591, `current > 0` guard in `advance()` at braces.zig:310, regression test at brace.test.ts:53-57 covering default, parse:true, and tokenize:true modes. Test would crash on main due to unchecked `self.tokens.items[0]` and usize underflow in `self.current - 1`. No TODO/FIXME/HACK in diff, no unrelated changes. CodeRabbit: no actionable comments.