### PR TITLE
Clear pending JS exception when error message formatting fails

### DIFF
--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -314,7 +314,7 @@ pub const JSGlobalObject = opaque {
             var writer = buf.writer();
             writer.print(fmt, args) catch {
                 _ = this.clearExceptionExceptTermination();
-                return ZigString.static(fmt).toErrorInstance(this);
+                return ZigString.static(fmt).toTypeErrorInstance(this);
             };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toTypeErrorInstance(this);
@@ -345,7 +345,7 @@ pub const JSGlobalObject = opaque {
             var writer = buf.writer();
             writer.print(fmt, args) catch {
                 _ = this.clearExceptionExceptTermination();
-                return ZigString.static(fmt).toErrorInstance(this);
+                return ZigString.static(fmt).toSyntaxErrorInstance(this);
             };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toSyntaxErrorInstance(this);
@@ -362,7 +362,7 @@ pub const JSGlobalObject = opaque {
             var writer = buf.writer();
             writer.print(fmt, args) catch {
                 _ = this.clearExceptionExceptTermination();
-                return ZigString.static(fmt).toErrorInstance(this);
+                return ZigString.static(fmt).toRangeErrorInstance(this);
             };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toRangeErrorInstance(this);

--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -286,9 +286,12 @@ pub const JSGlobalObject = opaque {
             var buf = std.Io.Writer.Allocating.initCapacity(stack_fallback.get(), 2048) catch unreachable;
             defer buf.deinit();
             var writer = &buf.writer;
-            writer.print(fmt, args) catch
-                // if an exception occurs in the middle of formatting the error message, it's better to just return the formatting string than an error about an error
+            writer.print(fmt, args) catch {
+                // if an exception occurs in the middle of formatting the error message, it's better to just return the formatting string than an error about an error.
+                // Clear any pending JS exception (e.g. from Symbol.toPrimitive) so that throwValue doesn't hit assertNoException.
+                _ = this.clearExceptionExceptTermination();
                 return ZigString.static(fmt).toErrorInstance(this);
+            };
 
             // Ensure we clone it.
             var str = ZigString.initUTF8(buf.written());
@@ -309,7 +312,10 @@ pub const JSGlobalObject = opaque {
             var buf = bun.MutableString.init2048(stack_fallback.get()) catch unreachable;
             defer buf.deinit();
             var writer = buf.writer();
-            writer.print(fmt, args) catch return ZigString.static(fmt).toErrorInstance(this);
+            writer.print(fmt, args) catch {
+                _ = this.clearExceptionExceptTermination();
+                return ZigString.static(fmt).toErrorInstance(this);
+            };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toTypeErrorInstance(this);
         } else {
@@ -337,7 +343,10 @@ pub const JSGlobalObject = opaque {
             var buf = bun.MutableString.init2048(stack_fallback.get()) catch unreachable;
             defer buf.deinit();
             var writer = buf.writer();
-            writer.print(fmt, args) catch return ZigString.static(fmt).toErrorInstance(this);
+            writer.print(fmt, args) catch {
+                _ = this.clearExceptionExceptTermination();
+                return ZigString.static(fmt).toErrorInstance(this);
+            };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toSyntaxErrorInstance(this);
         } else {
@@ -351,7 +360,10 @@ pub const JSGlobalObject = opaque {
             var buf = bun.MutableString.init2048(stack_fallback.get()) catch unreachable;
             defer buf.deinit();
             var writer = buf.writer();
-            writer.print(fmt, args) catch return ZigString.static(fmt).toErrorInstance(this);
+            writer.print(fmt, args) catch {
+                _ = this.clearExceptionExceptTermination();
+                return ZigString.static(fmt).toErrorInstance(this);
+            };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toRangeErrorInstance(this);
         } else {

--- a/test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts
+++ b/test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts
@@ -1,22 +1,23 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("expect does not crash when value has Symbol.toPrimitive returning a Symbol", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       const obj = /foo/;
       obj[Symbol.toPrimitive] = Symbol;
       try { Bun.jest().expect(obj).toBeFalse(); } catch {}
-    `],
+    `,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stderr, exitCode] = await Promise.all([
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
   expect(stderr).not.toContain("ASSERTION FAILED");
   expect(exitCode).toBe(0);

--- a/test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts
+++ b/test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts
@@ -13,7 +13,6 @@ test("expect does not crash when value has Symbol.toPrimitive returning a Symbol
     `,
     ],
     env: bunEnv,
-    stdout: "pipe",
   });
 
   const exitCode = await proc.exited;

--- a/test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts
+++ b/test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts
@@ -14,11 +14,9 @@ test("expect does not crash when value has Symbol.toPrimitive returning a Symbol
     ],
     env: bunEnv,
     stdout: "pipe",
-    stderr: "pipe",
   });
 
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const exitCode = await proc.exited;
 
-  expect(stderr).not.toContain("ASSERTION FAILED");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts
+++ b/test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("expect does not crash when value has Symbol.toPrimitive returning a Symbol", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `
+      const obj = /foo/;
+      obj[Symbol.toPrimitive] = Symbol;
+      try { Bun.jest().expect(obj).toBeFalse(); } catch {}
+    `],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
When `createErrorInstance` (and related functions) format an error message, the `{f}` formatter may call into JS (e.g. via `Symbol.toPrimitive`). If the formatting itself throws a JS exception (like "Cannot convert a symbol to a string" when `Symbol.toPrimitive` returns a Symbol), the catch branch returns a fallback format string but leaves the exception pending on the VM.

When `throwPretty` → `throwValue` → `JSC__VM__throwError` then tries to throw the new error, it hits `scope.assertNoException()` and crashes because there's already a pending exception.

**Fix:** Call `clearExceptionExceptTermination()` in the catch branch of all four `create*ErrorInstance` functions before returning the fallback, so the VM is in a clean state for the subsequent `throwValue`.

**Repro:**
```js
const v = /foo/;
v[Symbol.toPrimitive] = Symbol;
Bun.jest().expect(v).toBeFalse();
```

---
Verification (commit 362eb28): Lint JS ✅, buildkite #41519 still building (no individual step has failed; pipeline passed). Diff confirmed correct — four catch branches in JSGlobalObject.zig gain `clearExceptionExceptTermination()` calls (7 existing usages in same file), each returning the correctly-typed error instance (TypeError/SyntaxError/RangeError). `createDOMExceptionInstance` correctly unchanged (uses `try` propagation). Regression test spawns subprocess with exact repro, asserts exit 0 only (no forbidden assertion-absence checks). All 6 coderabbit+claude review comments addressed across follow-up commits. No TODO/FIXME/HACK in added lines.