### PR TITLE
Fix vm.Script/SourceTextModule/compileFunction leak via fetcher owner cycle

### DIFF
--- a/src/bun.js/bindings/NodeVMScriptFetcher.h
+++ b/src/bun.js/bindings/NodeVMScriptFetcher.h
@@ -3,6 +3,8 @@
 #include "root.h"
 
 #include <JavaScriptCore/ScriptFetcher.h>
+#include <JavaScriptCore/Weak.h>
+#include <JavaScriptCore/WeakInlines.h>
 #include <wtf/Scope.h>
 
 namespace Bun {
@@ -16,8 +18,19 @@ public:
 
     JSC::JSValue dynamicImportCallback() const { return m_dynamicImportCallback.get(); }
 
-    JSC::JSValue owner() const { return m_owner.get(); }
-    void owner(JSC::VM& vm, JSC::JSValue value) { m_owner.set(vm, value); }
+    JSC::JSValue owner() const
+    {
+        if (auto* cell = m_owner.get())
+            return JSC::JSValue(cell);
+        return JSC::jsUndefined();
+    }
+    void owner(JSC::VM&, JSC::JSValue value)
+    {
+        if (value.isCell())
+            m_owner = JSC::Weak<JSC::JSCell>(value.asCell());
+        else
+            m_owner.clear();
+    }
 
     bool isUsingDefaultLoader() const { return m_isUsingDefaultLoader; }
     auto temporarilyUseDefaultLoader()
@@ -30,13 +43,20 @@ public:
 
 private:
     JSC::Strong<JSC::Unknown> m_dynamicImportCallback;
-    JSC::Strong<JSC::Unknown> m_owner;
+    // m_owner is the NodeVMScript / JSFunction / module wrapper that holds this
+    // fetcher via m_source -> SourceProvider -> SourceOrigin -> RefPtr<fetcher>.
+    // A Strong handle here would form an uncollectable cycle (the owner keeps
+    // the fetcher alive via RefPtr, and the fetcher would keep the owner alive
+    // as a GC root). Use Weak instead: when the owner is collected its
+    // SourceCode chain drops the last RefPtr to this fetcher.
+    JSC::Weak<JSC::JSCell> m_owner;
     bool m_isUsingDefaultLoader = false;
 
     NodeVMScriptFetcher(JSC::VM& vm, JSC::JSValue dynamicImportCallback, JSC::JSValue owner)
         : m_dynamicImportCallback(vm, dynamicImportCallback)
-        , m_owner(vm, owner)
     {
+        if (owner.isCell())
+            m_owner = JSC::Weak<JSC::JSCell>(owner.asCell());
     }
 };
 

--- a/test/js/node/vm/vm-script-fetcher-leak.test.ts
+++ b/test/js/node/vm/vm-script-fetcher-leak.test.ts
@@ -1,0 +1,59 @@
+import { heapStats } from "bun:jsc";
+import { describe, expect, test } from "bun:test";
+import { expectMaxObjectTypeCount } from "harness";
+import vm from "node:vm";
+
+// Regression: NodeVMScriptFetcher held its owner via JSC::Strong, forming a
+// cycle (script -> m_source -> SourceProvider -> SourceOrigin ->
+// RefPtr<NodeVMScriptFetcher> -> Strong<m_owner> -> script) that caused every
+// vm.Script / vm.SourceTextModule / vm.compileFunction result to leak.
+
+describe("node:vm NodeVMScriptFetcher leak", () => {
+  test("vm.Script should not leak when references are dropped", async () => {
+    const baseline = heapStats().objectTypeCounts.Script || 0;
+
+    function iteration() {
+      new vm.Script("1 + 1");
+    }
+    for (let i = 0; i < 500; i++) iteration();
+
+    await expectMaxObjectTypeCount(expect, "Script", baseline + 20);
+  });
+
+  test("vm.compileFunction should not leak when references are dropped", async () => {
+    const baseline = heapStats().objectTypeCounts.FunctionExecutable || 0;
+
+    function iteration() {
+      vm.compileFunction("return 1");
+    }
+    for (let i = 0; i < 500; i++) iteration();
+
+    await expectMaxObjectTypeCount(expect, "FunctionExecutable", baseline + 50);
+  });
+
+  test("vm.SourceTextModule should not leak when references are dropped", async () => {
+    const baseline = heapStats().objectTypeCounts.NodeVMSourceTextModule || 0;
+
+    function iteration() {
+      new vm.SourceTextModule("export const a = 1;");
+    }
+    for (let i = 0; i < 500; i++) iteration();
+
+    await expectMaxObjectTypeCount(expect, "NodeVMSourceTextModule", baseline + 20);
+  });
+
+  test("vm.Script with importModuleDynamically callback should not leak", async () => {
+    const baseline = heapStats().objectTypeCounts.Script || 0;
+
+    function iteration() {
+      new vm.Script("1 + 1", {
+        importModuleDynamically: () => {
+          throw new Error("unreachable");
+        },
+      });
+    }
+    for (let i = 0; i < 500; i++) iteration();
+
+    await expectMaxObjectTypeCount(expect, "Script", baseline + 20);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a 100% leak of `vm.Script`, `vm.SourceTextModule`, and `vm.compileFunction` results. Every call to these APIs leaked the resulting object, regardless of user code.

## The cycle

```
NodeVMScript / JSFunction / moduleWrapper (JSCell)
  → m_source (SourceCode)
  → RefPtr<SourceProvider>
  → SourceOrigin (held by value)
  → RefPtr<NodeVMScriptFetcher>
  → JSC::Strong<Unknown> m_owner  ← GC root
  → owner  ★ cycle
```

`NodeVMScriptFetcher::m_owner` was a `JSC::Strong` handle pointing back to the owning script/function/module wrapper. Since the owner keeps the fetcher alive via the `SourceCode → SourceProvider → SourceOrigin → RefPtr<fetcher>` chain, and the fetcher kept the owner alive as a GC root, nothing could ever be collected.

### Before / After (heapStats objectTypeCounts, 500 iterations + GC)

| API | Before | After |
|---|---|---|
| `new vm.Script("1+1")` | Script: +500 | +0 |
| `vm.compileFunction("return 1")` | FunctionExecutable: +500 | +0 |
| `new vm.SourceTextModule("...")` | NodeVMSourceTextModule: +500 | +0 |

## The fix

Switch `m_owner` from `JSC::Strong<JSC::Unknown>` to `JSC::Weak<JSC::JSCell>`. The owner is always a JSCell, so Weak is appropriate. When the owner becomes unreachable it is collected, its `m_source` chain drops the last RefPtr to the fetcher, and the fetcher is freed.

`owner()` is only read during dynamic import (`import()` inside the script), at which point the executing context keeps the owner reachable — so the Weak ref always resolves when it matters. If the owner has already been collected (e.g. SourceProvider still cached in JSC's CodeCache but the script cell is gone), `owner()` returns `jsUndefined()`, but dynamic import can no longer be triggered at that point anyway.

This follows the same back-reference-via-Weak pattern as `JSCommonJSModule::m_parent` (`src/bun.js/bindings/JSCommonJSModule.h:69`), `JSEventListener::m_wrapper`, and `JSValueInWrappedObject::m_cell`.

## Known limitation (separate issue)

`m_dynamicImportCallback` remains `JSC::Strong` because it can hold non-cell values (the `USE_MAIN_CONTEXT_DEFAULT_LOADER` constant). If a user callback captures the owner in its closure, a separate cycle forms. This is user-code-dependent and requires a different approach (visitChildren from the owner side, complicated by `JSFunction` being JSC-internal). Since the callback is passed *before* the owner is created, this is uncommon in practice.

## How did you verify your code works?

- New regression test `test/js/node/vm/vm-script-fetcher-leak.test.ts` (4 cases) — fails on main, passes with this fix
- `test/js/node/vm/vm.test.ts` — 198 pass / 0 fail
- Node.js upstream `test/parallel/test-vm-module-dynamic-import.js` — exit 0
- Adversarial: `Bun.gc(true)` × 5 before dynamic import → `ref === script` still `true` (Weak resolves correctly while owner is reachable)