### PR TITLE
Cherry-pick 4 WebCore memory safety fixes from upstream WebKit

### DIFF
--- a/src/bun.js/bindings/webcore/BroadcastChannel.cpp
+++ b/src/bun.js/bindings/webcore/BroadcastChannel.cpp
@@ -54,9 +54,9 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BroadcastChannel);
 
 static Lock allBroadcastChannelsLock;
-static UncheckedKeyHashMap<BroadcastChannelIdentifier, BroadcastChannel*>& allBroadcastChannels() WTF_REQUIRES_LOCK(allBroadcastChannelsLock)
+static UncheckedKeyHashMap<BroadcastChannelIdentifier, ThreadSafeWeakPtr<BroadcastChannel>>& allBroadcastChannels() WTF_REQUIRES_LOCK(allBroadcastChannelsLock)
 {
-    static NeverDestroyed<UncheckedKeyHashMap<BroadcastChannelIdentifier, BroadcastChannel*>> map;
+    static NeverDestroyed<UncheckedKeyHashMap<BroadcastChannelIdentifier, ThreadSafeWeakPtr<BroadcastChannel>>> map;
     return map;
 }
 
@@ -165,7 +165,7 @@ BroadcastChannel::BroadcastChannel(ScriptExecutionContext& context, const String
 {
     {
         Locker locker { allBroadcastChannelsLock };
-        allBroadcastChannels().add(m_mainThreadBridge->identifier(), this);
+        allBroadcastChannels().add(m_mainThreadBridge->identifier(), *this);
     }
     m_mainThreadBridge->registerChannel(context);
     jsRef(context.jsGlobalObject());
@@ -241,7 +241,7 @@ void BroadcastChannel::dispatchMessageTo(BroadcastChannelIdentifier channelIdent
         RefPtr<BroadcastChannel> channel;
         {
             Locker locker { allBroadcastChannelsLock };
-            channel = allBroadcastChannels().get(channelIdentifier);
+            channel = allBroadcastChannels().get(channelIdentifier).get();
         }
         if (channel)
             channel->dispatchMessage(WTF::move(message));

--- a/src/bun.js/bindings/webcore/EventListenerMap.cpp
+++ b/src/bun.js/bindings/webcore/EventListenerMap.cpp
@@ -73,6 +73,7 @@ bool EventListenerMap::containsActive(const AtomString& eventType) const
 
 void EventListenerMap::clear()
 {
+    releaseAssertOrSetThreadUID();
     Locker locker { m_lock };
 
     for (auto& entry : m_entries) {
@@ -102,6 +103,7 @@ static inline size_t findListener(const EventListenerVector& listeners, EventLis
 
 void EventListenerMap::replace(const AtomString& eventType, EventListener& oldListener, Ref<EventListener>&& newListener, const RegisteredEventListener::Options& options)
 {
+    releaseAssertOrSetThreadUID();
     Locker locker { m_lock };
 
     auto* listeners = find(eventType);
@@ -115,6 +117,7 @@ void EventListenerMap::replace(const AtomString& eventType, EventListener& oldLi
 
 bool EventListenerMap::add(const AtomString& eventType, Ref<EventListener>&& listener, const RegisteredEventListener::Options& options)
 {
+    releaseAssertOrSetThreadUID();
     Locker locker { m_lock };
 
     if (auto* listeners = find(eventType)) {
@@ -141,6 +144,7 @@ static bool removeListenerFromVector(EventListenerVector& listeners, EventListen
 
 bool EventListenerMap::remove(const AtomString& eventType, EventListener& listener, bool useCapture)
 {
+    releaseAssertOrSetThreadUID();
     Locker locker { m_lock };
 
     for (unsigned i = 0; i < m_entries.size(); ++i) {
@@ -179,6 +183,7 @@ static void removeFirstListenerCreatedFromMarkup(EventListenerVector& listenerVe
 
 void EventListenerMap::removeFirstEventListenerCreatedFromMarkup(const AtomString& eventType)
 {
+    releaseAssertOrSetThreadUID();
     Locker locker { m_lock };
 
     for (unsigned i = 0; i < m_entries.size(); ++i) {

--- a/src/bun.js/bindings/webcore/EventListenerMap.h
+++ b/src/bun.js/bindings/webcore/EventListenerMap.h
@@ -35,8 +35,10 @@
 #include "RegisteredEventListener.h"
 #include <atomic>
 #include <memory>
+#include <wtf/Assertions.h>
 #include <wtf/Forward.h>
 #include <wtf/Lock.h>
+#include <wtf/Threading.h>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
@@ -70,8 +72,21 @@ public:
     Lock& lock() { return m_lock; }
 
 private:
+    void releaseAssertOrSetThreadUID()
+    {
+        if (!m_threadUID) {
+            ASSERT(!Thread::mayBeGCThread());
+            m_threadUID = Thread::currentSingleton().uid();
+            return;
+        }
+        if (m_threadUID == Thread::currentSingleton().uid()) [[likely]]
+            return;
+        RELEASE_ASSERT(Thread::mayBeGCThread());
+    }
+
     Vector<std::pair<AtomString, EventListenerVector>, 0, CrashOnOverflow, 4> m_entries;
     Lock m_lock;
+    uint32_t m_threadUID { 0 };
 };
 
 template<typename Visitor>

--- a/src/bun.js/bindings/webcore/JSAbortController.cpp
+++ b/src/bun.js/bindings/webcore/JSAbortController.cpp
@@ -242,6 +242,7 @@ void JSAbortController::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     addWebCoreOpaqueRoot(visitor, thisObject->wrapped().opaqueRoot());
+    thisObject->wrapped().signal().reason().visit(visitor);
 }
 
 DEFINE_VISIT_CHILDREN(JSAbortController);

--- a/src/bun.js/bindings/webcore/MessagePortChannel.cpp
+++ b/src/bun.js/bindings/webcore/MessagePortChannel.cpp
@@ -121,6 +121,9 @@ bool MessagePortChannel::postMessageToRemote(MessageWithMessagePorts&& message, 
     ASSERT(remoteTarget == m_ports[0] || remoteTarget == m_ports[1]);
     size_t i = remoteTarget == m_ports[0] ? 0 : 1;
 
+    if (m_isClosed[i])
+        return false;
+
     m_pendingMessages[i].append(WTF::move(message));
     // LOG(MessagePorts, "MessagePortChannel %s (%p) now has %zu messages pending on port %s", logString().utf8().data(), this, m_pendingMessages[i].size(), remoteTarget.logString().utf8().data());
 

--- a/test/js/web/abort/abort-controller-gc-reason.test.ts
+++ b/test/js/web/abort/abort-controller-gc-reason.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://bugs.webkit.org/show_bug.cgi?id=293319
+// AbortController.signal.reason is lost after garbage collection
+describe("AbortController GC", () => {
+  test("signal.reason survives GC when only controller is retained", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          function createAbortedController(message) {
+            const controller = new AbortController();
+            controller.abort(new Error(message));
+            return controller;
+          }
+
+          const errorMessage = "my potato";
+          const controller = createAbortedController(errorMessage);
+
+          // Force GC multiple times to trigger collection of signal.reason
+          // if it's not properly marked by JSAbortController::visitChildren
+          for (let i = 0; i < 10; i++) {
+            Bun.gc(true);
+          }
+
+          if (controller.signal.reason?.message !== errorMessage) {
+            console.error("FAIL: reason was", controller.signal.reason);
+            process.exit(1);
+          }
+          console.log("PASS");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("PASS");
+    expect(exitCode).toBe(0);
+  });
+
+  test("signal.reason survives GC with many controllers", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const controllers = [];
+          for (let i = 0; i < 100; i++) {
+            const c = new AbortController();
+            c.abort({ index: i, data: "x".repeat(100) });
+            controllers.push(c);
+          }
+
+          for (let i = 0; i < 10; i++) {
+            Bun.gc(true);
+          }
+
+          for (let i = 0; i < 100; i++) {
+            const reason = controllers[i].signal.reason;
+            if (!reason || reason.index !== i) {
+              console.error("FAIL at index", i, "reason:", reason);
+              process.exit(1);
+            }
+          }
+          console.log("PASS");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("PASS");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts
+++ b/test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // Regression test for use-after-free in BroadcastChannel global map.

--- a/test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts
+++ b/test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts
@@ -1,0 +1,139 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for use-after-free in BroadcastChannel global map.
+// Previously, the global map stored raw BroadcastChannel* pointers. If a Worker
+// created a BroadcastChannel and then terminated, a message dispatched from the
+// main thread could race with the Worker's destructor and dereference a dangling
+// pointer. Now the map stores ThreadSafeWeakPtr<BroadcastChannel>, so the lookup
+// returns null if the channel was destroyed.
+test("BroadcastChannel: no UAF when posting to channel after worker terminates", async () => {
+  const script = /* js */ `
+    const workerCode = \`
+      const bc = new BroadcastChannel("worker-gc-test");
+      bc.onmessage = (e) => {
+        // Keep a listener so the channel is registered.
+      };
+      postMessage("ready");
+    \`;
+
+    const mainChannel = new BroadcastChannel("worker-gc-test");
+    let receivedCount = 0;
+    mainChannel.onmessage = () => {
+      receivedCount++;
+    };
+
+    const workers = [];
+    const readyPromises = [];
+
+    // Spawn multiple workers that each create a BroadcastChannel.
+    for (let i = 0; i < 10; i++) {
+      const worker = new Worker(
+        URL.createObjectURL(new Blob([workerCode], { type: "application/javascript" }))
+      );
+      const { promise, resolve } = Promise.withResolvers();
+      worker.onmessage = () => resolve();
+      workers.push(worker);
+      readyPromises.push(promise);
+    }
+
+    await Promise.all(readyPromises);
+
+    // Terminate all workers. Their BroadcastChannel destructors will run on the
+    // worker threads, potentially racing with message dispatch on the main thread.
+    for (const worker of workers) {
+      worker.terminate();
+    }
+
+    // Post messages while workers are being torn down. Previously, the main
+    // thread's dispatchMessageTo could look up a raw pointer to a channel that
+    // was being destroyed on a worker thread.
+    for (let i = 0; i < 100; i++) {
+      mainChannel.postMessage("hello " + i);
+    }
+
+    // Give the event loop time to process any pending dispatches.
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Force GC to clean up any lingering references.
+    Bun.gc(true);
+
+    // Post more messages after GC.
+    for (let i = 0; i < 100; i++) {
+      mainChannel.postMessage("after-gc " + i);
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    mainChannel.close();
+    console.log("OK");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+});
+
+test("BroadcastChannel: repeated worker create/terminate stress", async () => {
+  const script = /* js */ `
+    const workerCode = \`
+      const bc = new BroadcastChannel("stress-test");
+      bc.onmessage = () => {};
+      postMessage("ready");
+    \`;
+    const blobUrl = URL.createObjectURL(new Blob([workerCode], { type: "application/javascript" }));
+
+    const mainChannel = new BroadcastChannel("stress-test");
+    mainChannel.onmessage = () => {};
+
+    // Rapidly create and terminate workers while posting messages.
+    for (let round = 0; round < 5; round++) {
+      const workers = [];
+      const readyPromises = [];
+
+      for (let i = 0; i < 5; i++) {
+        const worker = new Worker(blobUrl);
+        const { promise, resolve } = Promise.withResolvers();
+        worker.onmessage = () => resolve();
+        workers.push(worker);
+        readyPromises.push(promise);
+      }
+
+      await Promise.all(readyPromises);
+
+      // Post while terminating.
+      for (const worker of workers) {
+        mainChannel.postMessage("msg");
+        worker.terminate();
+        mainChannel.postMessage("msg");
+      }
+
+      Bun.gc(true);
+    }
+
+    mainChannel.close();
+    console.log("OK");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/workers/message-port-closed-leak.test.ts
+++ b/test/js/web/workers/message-port-closed-leak.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://bugs.webkit.org/show_bug.cgi?id=281662
+// Transferring buffers to a closed MessageChannel causes memory leaks
+describe("MessagePortChannel closed port", () => {
+  test("postMessage to closed port does not accumulate in pending queue", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { port1, port2 } = new MessageChannel();
+          port2.close();
+
+          // Warm up: first batch establishes allocator high-water mark
+          for (let i = 0; i < 5000; i++) {
+            port1.postMessage(Buffer.alloc(64 * 1024).toString());
+          }
+          Bun.gc(true);
+          Bun.gc(true);
+
+          // Measure: second batch should reuse freed memory if messages
+          // are dropped (not queued) for closed ports.
+          const rssBefore = process.memoryUsage().rss;
+          for (let i = 0; i < 5000; i++) {
+            port1.postMessage(Buffer.alloc(64 * 1024).toString());
+          }
+          Bun.gc(true);
+          Bun.gc(true);
+          const rssAfter = process.memoryUsage().rss;
+          const deltaMB = (rssAfter - rssBefore) / 1024 / 1024;
+
+          // Without fix: ~300+ MB growth (5000 * 64KB queued)
+          // With fix: ~0-5 MB (allocator reuses freed memory)
+          if (deltaMB > 50) {
+            console.error("FAIL: RSS grew by", deltaMB.toFixed(2), "MB on second batch");
+            process.exit(1);
+          }
+          console.log("PASS: delta", deltaMB.toFixed(2), "MB");
+          port1.close();
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain("PASS");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Cherry-picks 4 memory safety fixes from upstream WebKit into `src/bun.js/bindings/webcore/`.

## Why

Bun's WebCore code was forked from WebKit ~2022-03 and has since missed several GC/memory safety fixes. These are minimal, surgical backports of confirmed bug fixes.

## Changes

### 1. `MessagePortChannel`: drop messages to closed ports
**Upstream:** WebKit [281662](https://bugs.webkit.org/show_bug.cgi?id=281662)
Messages sent to a closed `MessagePort` were queued indefinitely in `m_pendingMessages`, never to be delivered.
**Measured:** 5000 × 64KB `postMessage` to closed port: RSS growth 332MB → 1.5MB

### 2. `JSAbortController`: visit `signal.reason` in GC
**Upstream:** WebKit [293319](https://bugs.webkit.org/show_bug.cgi?id=293319)
`controller.signal.reason` was not marked during GC when only the controller was retained, causing `reason` to become `undefined` after collection.

### 3. `BroadcastChannel`: use `ThreadSafeWeakPtr` in global map
**Upstream:** WebKit [267883](https://bugs.webkit.org/show_bug.cgi?id=267883)
The global channel map held raw `BroadcastChannel*` pointers. If a worker-owned channel was being destroyed while the main thread looked it up, the resulting `RefPtr` assignment could race. `ThreadSafeWeakPtr::get()` atomically checks liveness via the control block.

### 4. `EventListenerMap`: per-instance thread affinity assert
**Upstream:** WebKit [292397](https://bugs.webkit.org/show_bug.cgi?id=292397) + [304961](https://bugs.webkit.org/show_bug.cgi?id=304961)
Adds `releaseAssertOrSetThreadUID()` to mutation operations. Unlike a global `isMainThread()` check, this records the owning thread per-instance, so worker-owned `EventTarget`s work correctly. GC thread sweeps are exempted.

## Tests

- `test/js/web/abort/abort-controller-gc-reason.test.ts`
- `test/js/web/workers/message-port-closed-leak.test.ts`
- `test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts`

All 270 tests in `test/js/web/{abort,workers,broadcastchannel}/` + `test/js/deno/event/` pass.

## Not in this PR

`JSCallbackDataStrong` removal (WebKit [276563](https://bugs.webkit.org/show_bug.cgi?id=276563)) requires restructuring `AbortSignal::m_algorithms` to allow GC visitation. Deferred to a follow-up.