### PR TITLE
fix: return empty blob promise when ByteBlobLoader store is already consumed

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,8 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    var empty: Blob.Any = .{ .Blob = Blob.initEmpty(globalThis) };
+    return empty.toPromise(globalThis, action);
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/test/js/web/streams/blob-stream-bytes-consumed.test.ts
+++ b/test/js/web/streams/blob-stream-bytes-consumed.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("bytes() on consumed blob ReadableStream returns valid result", async () => {
   // Create a blob-backed stream and fully consume it via reader

--- a/test/js/web/streams/blob-stream-bytes-consumed.test.ts
+++ b/test/js/web/streams/blob-stream-bytes-consumed.test.ts
@@ -18,10 +18,10 @@ test("calling bytes() on a consumed blob ReadableStream does not crash", async (
     ],
     env: bunEnv,
     stdout: "pipe",
-    stderr: "pipe",
+    stderr: "inherit",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
   expect(stdout.trim()).toBe("OK");
   expect(exitCode).toBe(0);

--- a/test/js/web/streams/blob-stream-bytes-consumed.test.ts
+++ b/test/js/web/streams/blob-stream-bytes-consumed.test.ts
@@ -1,23 +1,15 @@
-import { expect, test } from "bun:test";
+import { test, expect } from "bun:test";
 
-test("bytes() on consumed blob ReadableStream returns valid result", async () => {
-  // Create a blob-backed stream and fully consume it via reader
-  const blob = new Blob(["test data"]);
-  const stream = blob.stream();
-  const reader = stream.getReader();
-  const chunks: Uint8Array[] = [];
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    chunks.push(value);
-  }
-  reader.releaseLock();
-
-  // Stream is closed, source store is consumed.
-  // Calling bytes() should return a valid empty Uint8Array, not crash.
-  // Without the fix, the native toBufferedValue returns .zero without
-  // setting an exception, causing an assertion failure in debug builds.
-  const result = await stream.bytes();
+test("bytes() on consumed Response body does not crash", async () => {
+  const resp = new Response("test data");
+  const body = resp.body!;
+  // Response.bytes() uses the fast blob path which detaches the store
+  // without locking the ReadableStream.
+  await resp.bytes();
+  // body.bytes() now hits the native fast path with a null store.
+  // Without the fix, toBufferedValue returned .zero without setting
+  // a JS exception, crashing with a segfault or assertion failure.
+  const result = await body.bytes();
   expect(result).toBeInstanceOf(Uint8Array);
   expect(result.length).toBe(0);
 });

--- a/test/js/web/streams/blob-stream-bytes-consumed.test.ts
+++ b/test/js/web/streams/blob-stream-bytes-consumed.test.ts
@@ -1,28 +1,23 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { test, expect } from "bun:test";
 
-test("calling bytes() on a consumed blob ReadableStream does not crash", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-      const resp = new Response("test data");
-      // Consume the body, which clears the blob store
-      await resp.bytes();
-      // Access the body stream directly and call bytes() on it.
-      // This should not cause an assertion failure / crash.
-      try { await resp.body.bytes(); } catch {}
-      console.log("OK");
-    `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "inherit",
-  });
+test("bytes() on consumed blob ReadableStream returns valid result", async () => {
+  // Create a blob-backed stream and fully consume it via reader
+  const blob = new Blob(["test data"]);
+  const stream = blob.stream();
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  reader.releaseLock();
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-
-  expect(stdout.trim()).toBe("OK");
-  expect(exitCode).toBe(0);
+  // Stream is closed, source store is consumed.
+  // Calling bytes() should return a valid empty Uint8Array, not crash.
+  // Without the fix, the native toBufferedValue returns .zero without
+  // setting an exception, causing an assertion failure in debug builds.
+  const result = await stream.bytes();
+  expect(result).toBeInstanceOf(Uint8Array);
+  expect(result.length).toBe(0);
 });

--- a/test/js/web/streams/blob-stream-bytes-consumed.test.ts
+++ b/test/js/web/streams/blob-stream-bytes-consumed.test.ts
@@ -1,9 +1,12 @@
-import { test, expect } from "bun:test";
-import { bunExe, bunEnv } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 test("calling bytes() on a consumed blob ReadableStream does not crash", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       const resp = new Response("test data");
       // Consume the body, which clears the blob store
       await resp.bytes();
@@ -11,17 +14,14 @@ test("calling bytes() on a consumed blob ReadableStream does not crash", async (
       // This should not cause an assertion failure / crash.
       try { await resp.body.bytes(); } catch {}
       console.log("OK");
-    `],
+    `,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout.trim()).toBe("OK");
   expect(exitCode).toBe(0);

--- a/test/js/web/streams/blob-stream-bytes-consumed.test.ts
+++ b/test/js/web/streams/blob-stream-bytes-consumed.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test";
+import { bunExe, bunEnv } from "harness";
+
+test("calling bytes() on a consumed blob ReadableStream does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `
+      const resp = new Response("test data");
+      // Consume the body, which clears the blob store
+      await resp.bytes();
+      // Access the body stream directly and call bytes() on it.
+      // This should not cause an assertion failure / crash.
+      try { await resp.body.bytes(); } catch {}
+      console.log("OK");
+    `],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/streams/blob-stream-bytes-consumed.test.ts
+++ b/test/js/web/streams/blob-stream-bytes-consumed.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("bytes() on consumed Response body does not crash", async () => {
   const resp = new Response("test data");


### PR DESCRIPTION
When `Response.bytes()` consumes the body and then `response.body.bytes()` is called on the underlying ReadableStream, the ByteBlobLoader's store is already null. `toBufferedValue` returned `.zero` without setting a JS exception, causing the host function wrapper's assertion to panic with "Expected an exception to be thrown".

Fix: return a resolved promise with an empty blob instead of `.zero`, matching the behavior of an empty data source.

**Crash fingerprint:** `ef61c39a47cb4c67`

---

Verification (robobun, commit 854aa01c): JS Lint passed. Buildkite build #41586 pipeline passed, cross-platform builds compiling. Prior build #41580 failures were unrelated tests (24364.test.ts react-tailwind tsc, bun-types.test.ts). Diff: 2 lines in ByteBlobLoader.zig replacing `.zero` return (which violated host-function error contract) with `Blob.initEmpty(globalThis)` + `toPromise`, matching the existing happy-path on line 180. Test spawns subprocess exercising consume-then-read-again path — would crash on main. All 3 review threads (claude, coderabbit) resolved: stderr changed from "pipe" to "inherit" in commit 854aa01c. No TODO/FIXME/HACK. No unrelated changes.