### PR TITLE
Fix dangling log pointer in PackageManager after resolve

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1840,6 +1840,12 @@ pub fn resolveMaybeNeedsTrailingSlash(
         jsc_vm.log = old_log;
         jsc_vm.transpiler.linker.log = old_log;
         jsc_vm.transpiler.resolver.log = old_log;
+        // The package manager may have been initialized during this resolve
+        // with a pointer to the stack-local `log`. Restore it so it doesn't
+        // dangle after this frame returns.
+        if (jsc_vm.transpiler.resolver.package_manager) |pm| {
+            pm.log = old_log;
+        }
     }
     jsc_vm._resolve(&result, specifier_utf8.slice(), normalizeSource(source_utf8.slice()), is_esm, is_a_file_path) catch |err_| {
         var err = err_;

--- a/test/js/bun/test/mock/mock-module-resolve-crash.test.ts
+++ b/test/js/bun/test/mock/mock-module-resolve-crash.test.ts
@@ -1,12 +1,15 @@
 import { expect, test } from "bun:test";
-import { bunExe, bunEnv } from "harness";
+import { bunEnv, bunExe } from "harness";
 
 // Regression test: mock.module with a non-string specifier (e.g. Intl.Segmenter)
 // used to cause a stack-buffer-overflow because the PackageManager singleton could
 // capture a dangling pointer to a stack-local Log during module resolution.
 test("mock.module with non-string specifier does not crash", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       const { mock } = require("bun:test");
       try {
         mock.module(Intl.Segmenter, () => ({ default: 1 }));
@@ -14,17 +17,14 @@ test("mock.module with non-string specifier does not crash", async () => {
         // Expected to throw - we just need it not to crash
       }
       console.log("ok");
-    `],
+    `,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toContain("ok");
   expect(exitCode).toBe(0);

--- a/test/js/bun/test/mock/mock-module-resolve-crash.test.ts
+++ b/test/js/bun/test/mock/mock-module-resolve-crash.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import { bunExe, bunEnv } from "harness";
+
+// Regression test: mock.module with a non-string specifier (e.g. Intl.Segmenter)
+// used to cause a stack-buffer-overflow because the PackageManager singleton could
+// capture a dangling pointer to a stack-local Log during module resolution.
+test("mock.module with non-string specifier does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `
+      const { mock } = require("bun:test");
+      try {
+        mock.module(Intl.Segmenter, () => ({ default: 1 }));
+      } catch (e) {
+        // Expected to throw - we just need it not to crash
+      }
+      console.log("ok");
+    `],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout).toContain("ok");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Root Cause

`resolveMaybeNeedsTrailingSlash` temporarily swaps `resolver.log` to a stack-local `Log` for the duration of module resolution. If `getPackageManager()` is called during that resolve — initializing the PackageManager singleton for the first time via `bun.once` — the PM permanently captures the stack-local log pointer in its `.log` field.

After `resolveMaybeNeedsTrailingSlash` returns, the stack-local `Log` is destroyed but `PackageManager.log` still points to it. Later calls to `PM.runTasks` that use `manager.log.addErrorFmt(...)` then read from freed stack memory, causing a stack-buffer-overflow.

The crash was triggered by `mock.module(Intl.Segmenter, ...)` which stringifies the constructor to `"function Segmenter() { [native code] }"` and passes it through the resolver, triggering auto-install (and thus PM initialization) inside the poisoned scope.

## Fix

Include the package manager's `.log` in the `defer` block that restores log pointers after the resolve completes, matching the existing pattern for `jsc_vm.log`, `transpiler.resolver.log`, and `transpiler.linker.log`.

Fingerprint: `Address:stack-buffer-overflow:bun-debug+0x900741e`

---
Verification: Fix traced through resolver.zig (getPackageManager at line 532 captures this.log via initWithRuntime) confirming the dangling pointer. Only one log-swap site exists in VirtualMachine.zig. Test exercises the exact PM-init-during-resolve path via mock.module(Intl.Segmenter). CI: Lint JS pass, Buildkite pipeline pass, build in progress with no failures. No TODO/FIXME/HACK in diff. No unrelated changes.