### PR TITLE
fix crash in expect.extend with numeric index keys

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -957,9 +957,9 @@ pub const Expect = struct {
 
                 const wrapper_fn = Bun__JSWrappingFunction__create(globalThis, matcher_name, jsc.toJSHostFn(Expect.applyCustomMatcher), matcher_fn, true);
 
-                expect_proto.put(globalThis, matcher_name, wrapper_fn);
-                expect_constructor.put(globalThis, matcher_name, wrapper_fn);
-                expect_static_proto.put(globalThis, matcher_name, wrapper_fn);
+                try expect_proto.putMayBeIndex(globalThis, matcher_name, wrapper_fn);
+                try expect_constructor.putMayBeIndex(globalThis, matcher_name, wrapper_fn);
+                try expect_static_proto.putMayBeIndex(globalThis, matcher_name, wrapper_fn);
             }
         }
 

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -379,6 +379,17 @@ it("works on classes", () => {
   expect(123)._toBeBar();
 });
 
+test("expect.extend with numeric index keys does not crash", () => {
+  // Numeric keys are valid array indices. putDirect asserts they are not indices,
+  // so putMayBeIndex must be used instead. Without the fix, putDirect incorrectly
+  // stores the property in the Structure table rather than indexed storage,
+  // making the matcher inaccessible via normal property lookup.
+  expect.extend({
+    1073741820: (received) => ({ pass: received === 42, message: () => "not 42" }),
+  });
+  expect(typeof expect[1073741820]).toBe("function");
+});
+
 describe("MatcherContext", () => {
   describe("utils", () => {
     test("RECEIVED_COLOR is a function", () => {

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -385,7 +385,7 @@ test("expect.extend with numeric index keys does not crash", () => {
   // stores the property in the Structure table rather than indexed storage,
   // making the matcher inaccessible via normal property lookup.
   expect.extend({
-    1073741820: (received) => ({ pass: received === 42, message: () => "not 42" }),
+    1073741820: received => ({ pass: received === 42, message: () => "not 42" }),
   });
   expect(typeof expect[1073741820]).toBe("function");
 });


### PR DESCRIPTION
expect.extend iterates the matchers object and calls `putDirect` for each property. `putDirect` asserts `!parseIndex(propertyName)`, which fails when numeric keys like `1073741820` (valid array indices) are present.

Set `own_properties_only` and `only_non_index_properties` to `true` on the `JSPropertyIterator` so index properties are skipped during enumeration.

**Crash fingerprint:** `JSObjectInlines.h(451)`

**Repro:**
```js
const v1 = { 1073741820: Request };
Bun.jest().expect.extend(v1);
```