### PR TITLE
Clear pending JSC exception before creating fallback error instance

### DIFF
--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -286,9 +286,12 @@ pub const JSGlobalObject = opaque {
             var buf = std.Io.Writer.Allocating.initCapacity(stack_fallback.get(), 2048) catch unreachable;
             defer buf.deinit();
             var writer = &buf.writer;
-            writer.print(fmt, args) catch
+            writer.print(fmt, args) catch {
                 // if an exception occurs in the middle of formatting the error message, it's better to just return the formatting string than an error about an error
+                // Clear any pending exception (e.g. stack overflow during formatting) before creating the fallback error.
+                this.clearException();
                 return ZigString.static(fmt).toErrorInstance(this);
+            };
 
             // Ensure we clone it.
             var str = ZigString.initUTF8(buf.written());
@@ -309,7 +312,10 @@ pub const JSGlobalObject = opaque {
             var buf = bun.MutableString.init2048(stack_fallback.get()) catch unreachable;
             defer buf.deinit();
             var writer = buf.writer();
-            writer.print(fmt, args) catch return ZigString.static(fmt).toErrorInstance(this);
+            writer.print(fmt, args) catch {
+                this.clearException();
+                return ZigString.static(fmt).toErrorInstance(this);
+            };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toTypeErrorInstance(this);
         } else {
@@ -337,7 +343,10 @@ pub const JSGlobalObject = opaque {
             var buf = bun.MutableString.init2048(stack_fallback.get()) catch unreachable;
             defer buf.deinit();
             var writer = buf.writer();
-            writer.print(fmt, args) catch return ZigString.static(fmt).toErrorInstance(this);
+            writer.print(fmt, args) catch {
+                this.clearException();
+                return ZigString.static(fmt).toErrorInstance(this);
+            };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toSyntaxErrorInstance(this);
         } else {
@@ -351,7 +360,10 @@ pub const JSGlobalObject = opaque {
             var buf = bun.MutableString.init2048(stack_fallback.get()) catch unreachable;
             defer buf.deinit();
             var writer = buf.writer();
-            writer.print(fmt, args) catch return ZigString.static(fmt).toErrorInstance(this);
+            writer.print(fmt, args) catch {
+                this.clearException();
+                return ZigString.static(fmt).toErrorInstance(this);
+            };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toRangeErrorInstance(this);
         } else {

--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -314,7 +314,7 @@ pub const JSGlobalObject = opaque {
             var writer = buf.writer();
             writer.print(fmt, args) catch {
                 this.clearException();
-                return ZigString.static(fmt).toErrorInstance(this);
+                return ZigString.static(fmt).toTypeErrorInstance(this);
             };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toTypeErrorInstance(this);
@@ -345,7 +345,7 @@ pub const JSGlobalObject = opaque {
             var writer = buf.writer();
             writer.print(fmt, args) catch {
                 this.clearException();
-                return ZigString.static(fmt).toErrorInstance(this);
+                return ZigString.static(fmt).toSyntaxErrorInstance(this);
             };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toSyntaxErrorInstance(this);
@@ -362,7 +362,7 @@ pub const JSGlobalObject = opaque {
             var writer = buf.writer();
             writer.print(fmt, args) catch {
                 this.clearException();
-                return ZigString.static(fmt).toErrorInstance(this);
+                return ZigString.static(fmt).toRangeErrorInstance(this);
             };
             var str = ZigString.fromUTF8(buf.slice());
             return str.toRangeErrorInstance(this);

--- a/test/js/bun/test/expect-stack-overflow.test.ts
+++ b/test/js/bun/test/expect-stack-overflow.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("expect matcher error formatting after stack overflow does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      // Exhaust the stack, catch it, then call a failing expect matcher.
+      // The matcher's error formatting must not crash with a pending exception.
+      `var done = false;
+      function exhaust() {
+        try { exhaust(); } catch (e) {
+          if (!done) {
+            done = true;
+            try { Bun.jest(undefined).expect({}).toBeSymbol(); } catch (e2) {}
+          }
+        }
+      }
+      exhaust();`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  // Must not crash with SIGABRT (exit code 134) from releaseAssertNoException
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/expect-stack-overflow.test.ts
+++ b/test/js/bun/test/expect-stack-overflow.test.ts
@@ -9,11 +9,13 @@ test("expect matcher error formatting after stack overflow does not crash", asyn
       // Exhaust the stack, catch it, then call a failing expect matcher.
       // The matcher's error formatting must not crash with a pending exception.
       `var done = false;
+      var matcherThrew = false;
       function exhaust() {
         try { exhaust(); } catch (e) {
           if (!done) {
             done = true;
-            try { Bun.jest(undefined).expect({}).toBeSymbol(); } catch (e2) {}
+            try { Bun.jest(undefined).expect({}).toBeSymbol(); } catch (e2) { matcherThrew = true; }
+            if (!matcherThrew) process.exit(1);
           }
         }
       }
@@ -31,6 +33,5 @@ test("expect matcher error formatting after stack overflow does not crash", asyn
   ]);
 
   // Must not crash with SIGABRT (exit code 134) from releaseAssertNoException
-  expect(stderr).not.toContain("ASSERTION FAILED");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
When `createErrorInstance` fails to format args (e.g. due to a stack overflow during value formatting), it catches the Zig error and falls back to creating an error with the raw format string. However, the JSC exception from the stack overflow remained pending on the VM.

Creating a new Error object with a pending exception caused `releaseAssertNoException` to fire in debug builds, aborting the process.

Clear the exception before creating the fallback error so the new error object can be created cleanly.

Applies to `createErrorInstance`, `createTypeErrorInstance`, `createSyntaxErrorInstance`, and `createRangeErrorInstance`.