### PR TITLE
Add resumable multipart upload support for S3

### DIFF
--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -270,6 +270,35 @@ declare module "bun" {
     retry?: number;
 
     /**
+     * Upload ID from a previous multipart upload to resume.
+     * When provided, skips CreateMultipartUpload and reuses the existing upload session.
+     *
+     * @example
+     *    const writer = s3file.writer({
+     *       uploadId: "previous-upload-id",
+     *       partNumber: 3,
+     *       previousParts: [
+     *         { partNumber: 1, etag: '"abc"' },
+     *         { partNumber: 2, etag: '"def"' },
+     *       ],
+     *    });
+     */
+    uploadId?: string;
+
+    /**
+     * Starting part number for resumed uploads (1-based).
+     * Must be provided with `uploadId`. Range: 1–10001 (10001 for completion-only).
+     */
+    partNumber?: number;
+
+    /**
+     * Previously uploaded parts to include in CompleteMultipartUpload.
+     * Each entry must have a `partNumber` (less than the starting `partNumber`) and an `etag`.
+     * Requires `uploadId`.
+     */
+    previousParts?: Array<{ partNumber: number; etag: string }>;
+
+    /**
      * The Content-Type of the file.
      * Automatically set based on file extension when possible.
      *

--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -1127,6 +1127,9 @@ pub fn writeFileWithSourceDestination(ctx: *jsc.JSGlobalObject, source_blob: *Bl
                             aws_options.request_payer,
                             null,
                             undefined,
+                            null,
+                            1,
+                            &.{},
                         );
                     } else {
                         return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(ctx, ctx.createErrorInstance("Failed to stream bytes to s3 bucket", .{}));
@@ -1200,6 +1203,9 @@ pub fn writeFileWithSourceDestination(ctx: *jsc.JSGlobalObject, source_blob: *Bl
                         aws_options.request_payer,
                         null,
                         undefined,
+                        null,
+                        1,
+                        &.{},
                     );
                 } else {
                     return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(ctx, ctx.createErrorInstance("Failed to stream bytes to s3 bucket", .{}));
@@ -1408,6 +1414,9 @@ pub fn writeFileInternal(globalThis: *jsc.JSGlobalObject, path_or_blob_: *PathOr
                                 aws_options.request_payer,
                                 null,
                                 undefined,
+                                null,
+                                1,
+                                &.{},
                             );
                         }
                         destination_blob.detach();
@@ -1471,6 +1480,9 @@ pub fn writeFileInternal(globalThis: *jsc.JSGlobalObject, path_or_blob_: *PathOr
                                 aws_options.request_payer,
                                 null,
                                 undefined,
+                                null,
+                                1,
+                                &.{},
                             );
                         }
                         destination_blob.detach();
@@ -2450,6 +2462,9 @@ pub fn pipeReadableStreamToBlob(this: *Blob, globalThis: *jsc.JSGlobalObject, re
             aws_options.request_payer,
             null,
             undefined,
+            null,
+            1,
+            &.{},
         );
     }
 
@@ -2703,6 +2718,9 @@ pub fn getWriter(
                     proxy_url,
                     credentialsWithOptions.storage_class,
                     credentialsWithOptions.request_payer,
+                    credentialsWithOptions.upload_id,
+                    credentialsWithOptions.part_number,
+                    credentialsWithOptions.previous_parts.items,
                 );
             }
         }
@@ -2717,6 +2735,9 @@ pub fn getWriter(
             proxy_url,
             null,
             s3.request_payer,
+            null,
+            1,
+            &.{},
         );
     }
 

--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -1106,7 +1106,7 @@ pub fn writeFileWithSourceDestination(ctx: *jsc.JSGlobalObject, source_blob: *Bl
         const proxy_url = if (proxy) |p| p.href else null;
         switch (source_store.data) {
             .bytes => |bytes| {
-                if (bytes.len > S3.MultiPartUploadOptions.MAX_SINGLE_UPLOAD_SIZE) {
+                if (aws_options.upload_id != null or bytes.len > S3.MultiPartUploadOptions.MAX_SINGLE_UPLOAD_SIZE) {
                     if (try jsc.WebCore.ReadableStream.fromJS(try jsc.WebCore.ReadableStream.fromBlobCopyRef(
                         ctx,
                         source_blob,
@@ -1127,9 +1127,9 @@ pub fn writeFileWithSourceDestination(ctx: *jsc.JSGlobalObject, source_blob: *Bl
                             aws_options.request_payer,
                             null,
                             undefined,
-                            null,
-                            1,
-                            &.{},
+                            aws_options.upload_id,
+                            aws_options.part_number,
+                            aws_options.previous_parts.items,
                         );
                     } else {
                         return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(ctx, ctx.createErrorInstance("Failed to stream bytes to s3 bucket", .{}));
@@ -1203,9 +1203,9 @@ pub fn writeFileWithSourceDestination(ctx: *jsc.JSGlobalObject, source_blob: *Bl
                         aws_options.request_payer,
                         null,
                         undefined,
-                        null,
-                        1,
-                        &.{},
+                        aws_options.upload_id,
+                        aws_options.part_number,
+                        aws_options.previous_parts.items,
                     );
                 } else {
                     return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(ctx, ctx.createErrorInstance("Failed to stream bytes to s3 bucket", .{}));
@@ -1414,9 +1414,9 @@ pub fn writeFileInternal(globalThis: *jsc.JSGlobalObject, path_or_blob_: *PathOr
                                 aws_options.request_payer,
                                 null,
                                 undefined,
-                                null,
-                                1,
-                                &.{},
+                                aws_options.upload_id,
+                                aws_options.part_number,
+                                aws_options.previous_parts.items,
                             );
                         }
                         destination_blob.detach();
@@ -1480,9 +1480,9 @@ pub fn writeFileInternal(globalThis: *jsc.JSGlobalObject, path_or_blob_: *PathOr
                                 aws_options.request_payer,
                                 null,
                                 undefined,
-                                null,
-                                1,
-                                &.{},
+                                aws_options.upload_id,
+                                aws_options.part_number,
+                                aws_options.previous_parts.items,
                             );
                         }
                         destination_blob.detach();
@@ -2462,9 +2462,9 @@ pub fn pipeReadableStreamToBlob(this: *Blob, globalThis: *jsc.JSGlobalObject, re
             aws_options.request_payer,
             null,
             undefined,
-            null,
-            1,
-            &.{},
+            aws_options.upload_id,
+            aws_options.part_number,
+            aws_options.previous_parts.items,
         );
     }
 

--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -1309,6 +1309,9 @@ fn fetchImpl(
                 credentialsWithOptions.request_payer,
                 @ptrCast(&Wrapper.resolve),
                 s3_stream,
+                null,
+                1,
+                &.{},
             );
             url = .{};
             url_proxy_buffer = "";

--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -1309,9 +1309,9 @@ fn fetchImpl(
                 credentialsWithOptions.request_payer,
                 @ptrCast(&Wrapper.resolve),
                 s3_stream,
-                null,
-                1,
-                &.{},
+                credentialsWithOptions.upload_id,
+                credentialsWithOptions.part_number,
+                credentialsWithOptions.previous_parts.items,
             );
             url = .{};
             url_proxy_buffer = "";

--- a/src/s3/client.zig
+++ b/src/s3/client.zig
@@ -271,6 +271,9 @@ pub fn writableStream(
     proxy: ?[]const u8,
     storage_class: ?StorageClass,
     request_payer: bool,
+    resume_upload_id: ?[]const u8,
+    resume_part_number: u16,
+    resume_previous_parts: []const S3CredentialsWithOptions.PreviousPart,
 ) bun.JSError!jsc.JSValue {
     const Wrapper = struct {
         pub fn callback(result: S3UploadResult, sink: *jsc.WebCore.NetworkSink) bun.JSTerminated!void {
@@ -323,6 +326,23 @@ pub fn writableStream(
         .options = options,
         .vm = jsc.VirtualMachine.get(),
     });
+
+    // Set up resume state if an upload ID is provided
+    if (resume_upload_id) |id| {
+        const duped = bun.handleOom(bun.default_allocator.alloc(u8, id.len));
+        @memcpy(duped, id);
+        task.uploadid_buffer = .{ .allocator = bun.default_allocator, .list = .{ .items = duped, .capacity = duped.len } };
+        task.upload_id = duped;
+        task.state = .multipart_completed;
+        task.currentPartNumber = resume_part_number;
+
+        for (resume_previous_parts) |part| {
+            task.multipart_etags.append(bun.default_allocator, .{
+                .number = part.number,
+                .etag = bun.handleOom(bun.default_allocator.dupe(u8, part.etag)),
+            }) catch |err| bun.handleOom(err);
+        }
+    }
 
     task.poll_ref.ref(task.vm);
 
@@ -460,6 +480,9 @@ pub fn uploadStream(
     request_payer: bool,
     callback: ?*const fn (S3UploadResult, *anyopaque) void,
     callback_context: *anyopaque,
+    resume_upload_id: ?[]const u8,
+    resume_part_number: u16,
+    resume_previous_parts: []const S3CredentialsWithOptions.PreviousPart,
 ) bun.JSError!jsc.JSValue {
     this.ref(); // ref the credentials
     const proxy_url = (proxy orelse "");
@@ -505,6 +528,22 @@ pub fn uploadStream(
         .request_payer = request_payer,
         .vm = jsc.VirtualMachine.get(),
     });
+
+    // Set up resume state if an upload ID is provided
+    if (resume_upload_id) |id| {
+        const duped = bun.handleOom(bun.default_allocator.alloc(u8, id.len));
+        @memcpy(duped, id);
+        task.uploadid_buffer = .{ .allocator = bun.default_allocator, .list = .{ .items = duped, .capacity = duped.len } };
+        task.upload_id = duped;
+        task.currentPartNumber = resume_part_number;
+
+        for (resume_previous_parts) |part| {
+            task.multipart_etags.append(bun.default_allocator, .{
+                .number = part.number,
+                .etag = bun.handleOom(bun.default_allocator.dupe(u8, part.etag)),
+            }) catch |err| bun.handleOom(err);
+        }
+    }
 
     task.poll_ref.ref(task.vm);
 

--- a/src/s3/client.zig
+++ b/src/s3/client.zig
@@ -334,6 +334,7 @@ pub fn writableStream(
         task.uploadid_buffer = .{ .allocator = bun.default_allocator, .list = .{ .items = duped, .capacity = duped.len } };
         task.upload_id = duped;
         task.state = .multipart_completed;
+        task.is_resumed = true;
         task.currentPartNumber = resume_part_number;
 
         for (resume_previous_parts) |part| {
@@ -535,6 +536,7 @@ pub fn uploadStream(
         @memcpy(duped, id);
         task.uploadid_buffer = .{ .allocator = bun.default_allocator, .list = .{ .items = duped, .capacity = duped.len } };
         task.upload_id = duped;
+        task.is_resumed = true;
         task.currentPartNumber = resume_part_number;
 
         for (resume_previous_parts) |part| {

--- a/src/s3/credentials.zig
+++ b/src/s3/credentials.zig
@@ -348,7 +348,12 @@ pub const S3Credentials = struct {
                             const etag_str = try bun.String.fromJS(etag_js, globalObject);
                             defer etag_str.deref();
                             const etag_utf8 = etag_str.toUTF8(bun.default_allocator);
-                            const etag_duped = bun.handleOom(bun.default_allocator.dupe(u8, etag_utf8.slice()));
+                            const etag_slice = etag_utf8.slice();
+                            if (strings.indexOfAny(etag_slice, "<>&") != null) {
+                                etag_utf8.deinit();
+                                return globalObject.throwInvalidArguments("previousParts[].etag must not contain XML special characters (<, >, &)", .{});
+                            }
+                            const etag_duped = bun.handleOom(bun.default_allocator.dupe(u8, etag_slice));
                             etag_utf8.deinit();
                             new_credentials.previous_parts.append(bun.default_allocator, .{
                                 .number = @intCast(pn),

--- a/src/s3/credentials.zig
+++ b/src/s3/credentials.zig
@@ -282,7 +282,14 @@ pub const S3Credentials = struct {
                             defer str.deref();
                             if (str.tag != .Empty and str.tag != .Dead) {
                                 new_credentials._uploadIdSlice = str.toUTF8(bun.default_allocator);
-                                new_credentials.upload_id = new_credentials._uploadIdSlice.?.slice();
+                                const slice = new_credentials._uploadIdSlice.?.slice();
+                                if (containsNewlineOrCR(slice)) {
+                                    return globalObject.throwInvalidArguments("uploadId must not contain newline characters (CR/LF)", .{});
+                                }
+                                if (slice.len > 1024) {
+                                    return globalObject.throwInvalidArguments("uploadId must not exceed 1024 characters", .{});
+                                }
+                                new_credentials.upload_id = slice;
                             }
                         } else {
                             return globalObject.throwInvalidArgumentTypeValue("uploadId", "string", js_value);
@@ -291,10 +298,11 @@ pub const S3Credentials = struct {
                 }
 
                 if (try opts.getOptional(globalObject, "partNumber", i32)) |partNumber| {
-                    if (partNumber < 1 or partNumber > 10000) {
+                    // Allow up to 10001 for completion-only (all 10000 parts already uploaded)
+                    if (partNumber < 1 or partNumber > 10001) {
                         return globalObject.throwRangeError(partNumber, .{
                             .min = 1,
-                            .max = 10000,
+                            .max = 10001,
                             .field_name = "partNumber",
                         });
                     }
@@ -303,6 +311,10 @@ pub const S3Credentials = struct {
 
                 if (try opts.getTruthyComptime(globalObject, "previousParts")) |js_array| {
                     if (!js_array.isEmptyOrUndefinedOrNull()) {
+                        // Validate previousParts requires uploadId before parsing entries
+                        if (new_credentials.upload_id == null) {
+                            return globalObject.throwInvalidArguments("previousParts requires uploadId to resume an existing multipart upload", .{});
+                        }
                         var iter = try jsc.JSArrayIterator.init(js_array, globalObject);
                         while (try iter.next()) |item| {
                             if (!item.isObject()) {
@@ -320,6 +332,12 @@ pub const S3Credentials = struct {
                             }
                             if (pn >= new_credentials.part_number) {
                                 return globalObject.throwInvalidArguments("each previousParts entry must have a partNumber less than partNumber", .{});
+                            }
+                            // Check for duplicate partNumber
+                            for (new_credentials.previous_parts.items) |existing| {
+                                if (existing.number == @as(u16, @intCast(pn))) {
+                                    return globalObject.throwInvalidArguments("previousParts contains duplicate partNumber", .{});
+                                }
                             }
                             const etag_js = (try item.getTruthyComptime(globalObject, "etag")) orelse {
                                 return globalObject.throwInvalidArguments("each element in previousParts must have an etag", .{});

--- a/src/s3/credentials.zig
+++ b/src/s3/credentials.zig
@@ -318,6 +318,9 @@ pub const S3Credentials = struct {
                                     .field_name = "previousParts[].partNumber",
                                 });
                             }
+                            if (pn >= new_credentials.part_number) {
+                                return globalObject.throwInvalidArguments("each previousParts entry must have a partNumber less than partNumber", .{});
+                            }
                             const etag_js = (try item.getTruthyComptime(globalObject, "etag")) orelse {
                                 return globalObject.throwInvalidArguments("each element in previousParts must have an etag", .{});
                             };
@@ -341,9 +344,9 @@ pub const S3Credentials = struct {
                 if (new_credentials.part_number > 1 and new_credentials.upload_id == null) {
                     return globalObject.throwInvalidArguments("partNumber > 1 requires uploadId to resume an existing multipart upload", .{});
                 }
-                // Validation: previousParts requires uploadId
-                if (new_credentials.previous_parts.items.len > 0 and new_credentials.upload_id == null) {
-                    return globalObject.throwInvalidArguments("previousParts requires uploadId to resume an existing multipart upload", .{});
+                // Validation: partNumber > 1 requires previousParts so CompleteMultipartUpload includes earlier parts
+                if (new_credentials.part_number > 1 and new_credentials.previous_parts.items.len == 0) {
+                    return globalObject.throwInvalidArguments("partNumber > 1 requires previousParts so CompleteMultipartUpload includes the already uploaded parts", .{});
                 }
             }
         }

--- a/src/s3/credentials.zig
+++ b/src/s3/credentials.zig
@@ -274,6 +274,77 @@ pub const S3Credentials = struct {
                 if (try opts.getBooleanStrict(globalObject, "requestPayer")) |request_payer| {
                     new_credentials.request_payer = request_payer;
                 }
+
+                if (try opts.getTruthyComptime(globalObject, "uploadId")) |js_value| {
+                    if (!js_value.isEmptyOrUndefinedOrNull()) {
+                        if (js_value.isString()) {
+                            const str = try bun.String.fromJS(js_value, globalObject);
+                            defer str.deref();
+                            if (str.tag != .Empty and str.tag != .Dead) {
+                                new_credentials._uploadIdSlice = str.toUTF8(bun.default_allocator);
+                                new_credentials.upload_id = new_credentials._uploadIdSlice.?.slice();
+                            }
+                        } else {
+                            return globalObject.throwInvalidArgumentTypeValue("uploadId", "string", js_value);
+                        }
+                    }
+                }
+
+                if (try opts.getOptional(globalObject, "partNumber", i32)) |partNumber| {
+                    if (partNumber < 1 or partNumber > 10000) {
+                        return globalObject.throwRangeError(partNumber, .{
+                            .min = 1,
+                            .max = 10000,
+                            .field_name = "partNumber",
+                        });
+                    }
+                    new_credentials.part_number = @intCast(partNumber);
+                }
+
+                if (try opts.getTruthyComptime(globalObject, "previousParts")) |js_array| {
+                    if (!js_array.isEmptyOrUndefinedOrNull()) {
+                        var iter = try jsc.JSArrayIterator.init(js_array, globalObject);
+                        while (try iter.next()) |item| {
+                            if (!item.isObject()) {
+                                return globalObject.throwInvalidArguments("each element in previousParts must be an object with partNumber and etag", .{});
+                            }
+                            const pn = try item.getOptional(globalObject, "partNumber", i32) orelse {
+                                return globalObject.throwInvalidArguments("each element in previousParts must have a partNumber", .{});
+                            };
+                            if (pn < 1 or pn > 10000) {
+                                return globalObject.throwRangeError(pn, .{
+                                    .min = 1,
+                                    .max = 10000,
+                                    .field_name = "previousParts[].partNumber",
+                                });
+                            }
+                            const etag_js = (try item.getTruthyComptime(globalObject, "etag")) orelse {
+                                return globalObject.throwInvalidArguments("each element in previousParts must have an etag", .{});
+                            };
+                            if (!etag_js.isString()) {
+                                return globalObject.throwInvalidArgumentTypeValue("previousParts[].etag", "string", etag_js);
+                            }
+                            const etag_str = try bun.String.fromJS(etag_js, globalObject);
+                            defer etag_str.deref();
+                            const etag_utf8 = etag_str.toUTF8(bun.default_allocator);
+                            const etag_duped = bun.handleOom(bun.default_allocator.dupe(u8, etag_utf8.slice()));
+                            etag_utf8.deinit();
+                            new_credentials.previous_parts.append(bun.default_allocator, .{
+                                .number = @intCast(pn),
+                                .etag = etag_duped,
+                            }) catch |err| bun.handleOom(err);
+                        }
+                    }
+                }
+
+                // Validation: partNumber > 1 requires uploadId
+                if (new_credentials.part_number > 1 and new_credentials.upload_id == null) {
+                    return globalObject.throwInvalidArguments("partNumber > 1 requires uploadId to resume an existing multipart upload", .{});
+                }
+                // Validation: previousParts requires uploadId
+                if (new_credentials.previous_parts.items.len > 0 and new_credentials.upload_id == null) {
+                    return globalObject.throwInvalidArguments("previousParts requires uploadId to resume an existing multipart upload", .{});
+                }
             }
         }
         return new_credentials;
@@ -1002,6 +1073,12 @@ pub const S3Credentials = struct {
 };
 
 pub const S3CredentialsWithOptions = struct {
+    pub const PreviousPart = struct {
+        number: u16,
+        /// heap-allocated via bun.default_allocator, owned by S3CredentialsWithOptions
+        etag: []const u8,
+    };
+
     credentials: S3Credentials,
     options: MultiPartUploadOptions = .{},
     acl: ?ACL = null,
@@ -1015,6 +1092,14 @@ pub const S3CredentialsWithOptions = struct {
     changed_credentials: bool = false,
     /// indicates if the virtual hosted style is used
     virtual_hosted_style: bool = false,
+
+    /// upload ID from a previous multipart upload to resume
+    upload_id: ?[]const u8 = null,
+    /// starting part number (for resuming uploads, 1-based)
+    part_number: u16 = 1,
+    /// previously uploaded parts to include in CompleteMultipartUpload
+    previous_parts: std.ArrayListUnmanaged(PreviousPart) = .{},
+
     _accessKeyIdSlice: ?jsc.ZigString.Slice = null,
     _secretAccessKeySlice: ?jsc.ZigString.Slice = null,
     _regionSlice: ?jsc.ZigString.Slice = null,
@@ -1024,6 +1109,7 @@ pub const S3CredentialsWithOptions = struct {
     _contentDispositionSlice: ?jsc.ZigString.Slice = null,
     _contentTypeSlice: ?jsc.ZigString.Slice = null,
     _contentEncodingSlice: ?jsc.ZigString.Slice = null,
+    _uploadIdSlice: ?jsc.ZigString.Slice = null,
 
     pub fn deinit(this: *@This()) void {
         if (this._accessKeyIdSlice) |slice| slice.deinit();
@@ -1035,6 +1121,13 @@ pub const S3CredentialsWithOptions = struct {
         if (this._contentDispositionSlice) |slice| slice.deinit();
         if (this._contentTypeSlice) |slice| slice.deinit();
         if (this._contentEncodingSlice) |slice| slice.deinit();
+        if (this._uploadIdSlice) |slice| slice.deinit();
+        for (this.previous_parts.items) |part| {
+            bun.default_allocator.free(part.etag);
+        }
+        if (this.previous_parts.capacity > 0) {
+            this.previous_parts.deinit(bun.default_allocator);
+        }
     }
 };
 

--- a/src/s3/multipart.zig
+++ b/src/s3/multipart.zig
@@ -101,6 +101,8 @@ pub const MultiPartUpload = struct {
     currentPartNumber: u16 = 1,
     ref_count: RefCount,
     ended: bool = false,
+    /// true when upload_id was provided by the user (resume mode) — skip rollback on failure
+    is_resumed: bool = false,
 
     options: MultiPartUploadOptions = .{},
     acl: ?ACL = null,
@@ -437,7 +439,7 @@ pub const MultiPartUpload = struct {
             this.state = .finished;
             try this.callback(.{ .failure = _err }, this.callback_context);
 
-            if (old_state == .multipart_completed) {
+            if (old_state == .multipart_completed and !this.is_resumed) {
                 // we are a multipart upload so we need to rollback
                 // will deref after rollback
                 try this.rollbackMultiPartRequest();

--- a/src/s3/multipart.zig
+++ b/src/s3/multipart.zig
@@ -705,7 +705,8 @@ pub const MultiPartUpload = struct {
 
     pub fn continueStream(this: *@This()) void {
         if (this.state == .wait_stream_check) {
-            this.state = .not_started;
+            // If upload_id is already set (resume), skip directly to multipart_completed
+            this.state = if (this.upload_id.len > 0) .multipart_completed else .not_started;
             if (this.ended) {
                 this.processBuffered(this.partSizeInBytes());
             }

--- a/src/s3/multipart.zig
+++ b/src/s3/multipart.zig
@@ -597,6 +597,13 @@ pub const MultiPartUpload = struct {
         }, .{ .upload = @ptrCast(&onRollbackMultiPartRequest) }, this);
     }
     fn enqueuePart(this: *@This(), chunk: []const u8, allocated_size: usize, needs_clone: bool) bun.JSTerminated!bool {
+        if (this.currentPartNumber > 10000) {
+            try this.fail(.{
+                .code = "InvalidArgument",
+                .message = "Cannot write data: partNumber exceeds S3 maximum of 10000; use end() without write() for completion-only resume",
+            });
+            return false;
+        }
         const part = this.getCreatePart(chunk, allocated_size, needs_clone) orelse return false;
 
         if (this.state == .not_started) {

--- a/test/js/bun/s3/s3-multipart-resume.test.ts
+++ b/test/js/bun/s3/s3-multipart-resume.test.ts
@@ -272,7 +272,7 @@ describe("s3 - Resumable multipart upload", () => {
     }).toThrow("partNumber");
 
     expect(() => {
-      client.file("test").writer({ uploadId: "abc", partNumber: 10001 });
+      client.file("test").writer({ uploadId: "abc", partNumber: 10002 });
     }).toThrow("partNumber");
   });
 

--- a/test/js/bun/s3/s3-multipart-resume.test.ts
+++ b/test/js/bun/s3/s3-multipart-resume.test.ts
@@ -155,11 +155,20 @@ describe("s3 - Resumable multipart upload", () => {
     const uploadId = randomUUID();
     let completionBody = "";
     let completionCalled = false;
+    let uploadedPartCount = 0;
 
     using server = Bun.serve({
       port: 0,
       async fetch(req) {
         const url = new URL(req.url);
+
+        if (req.method === "PUT" && url.search.includes("partNumber=")) {
+          uploadedPartCount++;
+          return new Response(undefined, {
+            status: 200,
+            headers: { ETag: '"unexpected-etag"' },
+          });
+        }
 
         if (req.method === "POST" && url.search.includes("uploadId=")) {
           completionCalled = true;
@@ -199,6 +208,8 @@ describe("s3 - Resumable multipart upload", () => {
     await writer.end();
 
     expect(completionCalled).toBe(true);
+    expect(uploadedPartCount).toBe(0);
+    expect(completionBody).not.toInclude("<PartNumber>4</PartNumber>");
     expect(completionBody).toInclude("<PartNumber>1</PartNumber>");
     expect(completionBody).toInclude("<PartNumber>2</PartNumber>");
     expect(completionBody).toInclude("<PartNumber>3</PartNumber>");
@@ -218,6 +229,20 @@ describe("s3 - Resumable multipart upload", () => {
     }).toThrow("partNumber > 1 requires uploadId");
   });
 
+  it("should throw when previousParts is provided without uploadId", () => {
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: "http://localhost:1",
+    });
+
+    expect(() => {
+      client.file("test").writer({
+        partNumber: 2,
+        previousParts: [{ partNumber: 1, etag: '"etag"' }],
+      });
+    }).toThrow("previousParts requires uploadId");
+  });
+
   it("should throw when previousParts entry has partNumber >= starting partNumber", () => {
     const client = new S3Client({
       ...s3Options,
@@ -230,7 +255,7 @@ describe("s3 - Resumable multipart upload", () => {
         partNumber: 3,
         previousParts: [
           { partNumber: 1, etag: '"e1"' },
-          { partNumber: 3, etag: '"e3"' }, // overlaps with starting partNumber
+          { partNumber: 3, etag: '"e3"' },
         ],
       });
     }).toThrow("previousParts entry must have a partNumber less than partNumber");
@@ -442,7 +467,8 @@ describe("s3 - Resumable multipart upload", () => {
       await writer.end();
       expect.unreachable();
     } catch (e: any) {
-      expect(e).toBeDefined();
+      expect(e).toBeInstanceOf(Error);
+      expect(e.message || e.code || String(e)).not.toBe("");
     }
   });
 });

--- a/test/js/bun/s3/s3-multipart-resume.test.ts
+++ b/test/js/bun/s3/s3-multipart-resume.test.ts
@@ -10,198 +10,210 @@ describe("s3 - Resumable multipart upload", () => {
     bucket: "my_bucket",
   };
 
-  it("should skip CreateMultipartUpload when uploadId is provided", async () => {
-    const uploadId = randomUUID();
-    let createMultipartCalled = false;
-    const partNumbers: number[] = [];
-    let completionBody = "";
+  it(
+    "should skip CreateMultipartUpload when uploadId is provided",
+    async () => {
+      const uploadId = randomUUID();
+      let createMultipartCalled = false;
+      const partNumbers: number[] = [];
+      let completionBody = "";
 
-    using server = Bun.serve({
-      port: 0,
-      async fetch(req) {
-        const url = new URL(req.url);
+      using server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const url = new URL(req.url);
 
-        if (req.method === "POST" && url.search.includes("?uploads=")) {
-          createMultipartCalled = true;
-          return new Response(
-            `<InitiateMultipartUploadResult><UploadId>${randomUUID()}</UploadId></InitiateMultipartUploadResult>`,
-            { status: 200, headers: { "Content-Type": "text/xml" } },
-          );
-        }
+          if (req.method === "POST" && url.search.includes("?uploads=")) {
+            createMultipartCalled = true;
+            return new Response(
+              `<InitiateMultipartUploadResult><UploadId>${randomUUID()}</UploadId></InitiateMultipartUploadResult>`,
+              { status: 200, headers: { "Content-Type": "text/xml" } },
+            );
+          }
 
-        if (req.method === "PUT" && url.search.includes("partNumber=")) {
-          const match = url.search.match(/partNumber=(\d+)/);
-          if (match) partNumbers.push(parseInt(match[1]));
-          return new Response(undefined, {
-            status: 200,
-            headers: { ETag: `"etag-part-${match?.[1]}"` },
-          });
-        }
+          if (req.method === "PUT" && url.search.includes("partNumber=")) {
+            const match = url.search.match(/partNumber=(\d+)/);
+            if (match) partNumbers.push(parseInt(match[1]));
+            return new Response(undefined, {
+              status: 200,
+              headers: { ETag: `"etag-part-${match?.[1]}"` },
+            });
+          }
 
-        if (req.method === "POST" && url.search.includes("uploadId=")) {
-          completionBody = await req.text();
-          return new Response(
-            `<CompleteMultipartUploadResult>
+          if (req.method === "POST" && url.search.includes("uploadId=")) {
+            completionBody = await req.text();
+            return new Response(
+              `<CompleteMultipartUploadResult>
               <Location>http://my_bucket.s3.amazonaws.com/test</Location>
               <Bucket>my_bucket</Bucket>
               <Key>test</Key>
               <ETag>"final-etag"</ETag>
             </CompleteMultipartUploadResult>`,
-            { status: 200, headers: { "Content-Type": "text/xml" } },
-          );
-        }
+              { status: 200, headers: { "Content-Type": "text/xml" } },
+            );
+          }
 
-        return new Response("", { status: 200 });
-      },
-    });
+          return new Response("", { status: 200 });
+        },
+      });
 
-    const client = new S3Client({
-      ...s3Options,
-      endpoint: server.url.href,
-    });
+      const client = new S3Client({
+        ...s3Options,
+        endpoint: server.url.href,
+      });
 
-    const writer = client.file("test_resume").writer({
-      uploadId,
-      partNumber: 3,
-      partSize: 5 * 1024 * 1024,
-      queueSize: 10,
-    });
+      const writer = client.file("test_resume").writer({
+        uploadId,
+        partNumber: 3,
+        partSize: 5 * 1024 * 1024,
+        queueSize: 10,
+      });
 
-    // Write enough data to trigger a part upload (>= partSize)
-    const chunk = Buffer.alloc(5 * 1024 * 1024);
-    writer.write(chunk);
-    await writer.end();
+      // Write enough data to trigger a part upload (>= partSize)
+      const chunk = Buffer.alloc(5 * 1024 * 1024);
+      writer.write(chunk);
+      await writer.end();
 
-    // CreateMultipartUpload should NOT have been called
-    expect(createMultipartCalled).toBe(false);
-    // The part should start from partNumber 3
-    expect(partNumbers).toContain(3);
-    // The completion should include the uploadId
-    expect(completionBody).toInclude("<PartNumber>3</PartNumber>");
-  }, { timeout: 30_000 });
+      // CreateMultipartUpload should NOT have been called
+      expect(createMultipartCalled).toBe(false);
+      // The part should start from partNumber 3
+      expect(partNumbers).toContain(3);
+      // The completion should include the uploadId
+      expect(completionBody).toInclude("<PartNumber>3</PartNumber>");
+    },
+    { timeout: 30_000 },
+  );
 
-  it("should include previousParts in CompleteMultipartUpload XML", async () => {
-    const uploadId = randomUUID();
-    let completionBody = "";
+  it(
+    "should include previousParts in CompleteMultipartUpload XML",
+    async () => {
+      const uploadId = randomUUID();
+      let completionBody = "";
 
-    using server = Bun.serve({
-      port: 0,
-      async fetch(req) {
-        const url = new URL(req.url);
+      using server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const url = new URL(req.url);
 
-        if (req.method === "PUT" && url.search.includes("partNumber=")) {
-          return new Response(undefined, {
-            status: 200,
-            headers: { ETag: `"new-etag"` },
-          });
-        }
+          if (req.method === "PUT" && url.search.includes("partNumber=")) {
+            return new Response(undefined, {
+              status: 200,
+              headers: { ETag: `"new-etag"` },
+            });
+          }
 
-        if (req.method === "POST" && url.search.includes("uploadId=")) {
-          completionBody = await req.text();
-          return new Response(
-            `<CompleteMultipartUploadResult>
+          if (req.method === "POST" && url.search.includes("uploadId=")) {
+            completionBody = await req.text();
+            return new Response(
+              `<CompleteMultipartUploadResult>
               <Location>http://my_bucket.s3.amazonaws.com/test</Location>
               <Bucket>my_bucket</Bucket>
               <Key>test</Key>
               <ETag>"final-etag"</ETag>
             </CompleteMultipartUploadResult>`,
-            { status: 200, headers: { "Content-Type": "text/xml" } },
-          );
-        }
+              { status: 200, headers: { "Content-Type": "text/xml" } },
+            );
+          }
 
-        return new Response("", { status: 200 });
-      },
-    });
+          return new Response("", { status: 200 });
+        },
+      });
 
-    const client = new S3Client({
-      ...s3Options,
-      endpoint: server.url.href,
-    });
+      const client = new S3Client({
+        ...s3Options,
+        endpoint: server.url.href,
+      });
 
-    const writer = client.file("test_resume_parts").writer({
-      uploadId,
-      partNumber: 3,
-      partSize: 5 * 1024 * 1024,
-      queueSize: 10,
-      previousParts: [
-        { partNumber: 1, etag: '"etag-part-1"' },
-        { partNumber: 2, etag: '"etag-part-2"' },
-      ],
-    });
+      const writer = client.file("test_resume_parts").writer({
+        uploadId,
+        partNumber: 3,
+        partSize: 5 * 1024 * 1024,
+        queueSize: 10,
+        previousParts: [
+          { partNumber: 1, etag: '"etag-part-1"' },
+          { partNumber: 2, etag: '"etag-part-2"' },
+        ],
+      });
 
-    const chunk = Buffer.alloc(5 * 1024 * 1024);
-    writer.write(chunk);
-    await writer.end();
+      const chunk = Buffer.alloc(5 * 1024 * 1024);
+      writer.write(chunk);
+      await writer.end();
 
-    // The completion XML should include both previous parts and the new part
-    expect(completionBody).toInclude("<PartNumber>1</PartNumber>");
-    expect(completionBody).toInclude('<ETag>"etag-part-1"</ETag>');
-    expect(completionBody).toInclude("<PartNumber>2</PartNumber>");
-    expect(completionBody).toInclude('<ETag>"etag-part-2"</ETag>');
-    expect(completionBody).toInclude("<PartNumber>3</PartNumber>");
-    // Parts should be sorted by number in the XML
-    const part1Pos = completionBody.indexOf("<PartNumber>1</PartNumber>");
-    const part2Pos = completionBody.indexOf("<PartNumber>2</PartNumber>");
-    const part3Pos = completionBody.indexOf("<PartNumber>3</PartNumber>");
-    expect(part1Pos).toBeLessThan(part2Pos);
-    expect(part2Pos).toBeLessThan(part3Pos);
-  }, { timeout: 30_000 });
+      // The completion XML should include both previous parts and the new part
+      expect(completionBody).toInclude("<PartNumber>1</PartNumber>");
+      expect(completionBody).toInclude('<ETag>"etag-part-1"</ETag>');
+      expect(completionBody).toInclude("<PartNumber>2</PartNumber>");
+      expect(completionBody).toInclude('<ETag>"etag-part-2"</ETag>');
+      expect(completionBody).toInclude("<PartNumber>3</PartNumber>");
+      // Parts should be sorted by number in the XML
+      const part1Pos = completionBody.indexOf("<PartNumber>1</PartNumber>");
+      const part2Pos = completionBody.indexOf("<PartNumber>2</PartNumber>");
+      const part3Pos = completionBody.indexOf("<PartNumber>3</PartNumber>");
+      expect(part1Pos).toBeLessThan(part2Pos);
+      expect(part2Pos).toBeLessThan(part3Pos);
+    },
+    { timeout: 30_000 },
+  );
 
-  it("should complete with only previousParts and no new data", async () => {
-    const uploadId = randomUUID();
-    let completionBody = "";
-    let completionCalled = false;
+  it(
+    "should complete with only previousParts and no new data",
+    async () => {
+      const uploadId = randomUUID();
+      let completionBody = "";
+      let completionCalled = false;
 
-    using server = Bun.serve({
-      port: 0,
-      async fetch(req) {
-        const url = new URL(req.url);
+      using server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const url = new URL(req.url);
 
-        if (req.method === "POST" && url.search.includes("uploadId=")) {
-          completionCalled = true;
-          completionBody = await req.text();
-          return new Response(
-            `<CompleteMultipartUploadResult>
+          if (req.method === "POST" && url.search.includes("uploadId=")) {
+            completionCalled = true;
+            completionBody = await req.text();
+            return new Response(
+              `<CompleteMultipartUploadResult>
               <Location>http://my_bucket.s3.amazonaws.com/test</Location>
               <Bucket>my_bucket</Bucket>
               <Key>test</Key>
               <ETag>"final-etag"</ETag>
             </CompleteMultipartUploadResult>`,
-            { status: 200, headers: { "Content-Type": "text/xml" } },
-          );
-        }
+              { status: 200, headers: { "Content-Type": "text/xml" } },
+            );
+          }
 
-        return new Response("", { status: 200 });
-      },
-    });
+          return new Response("", { status: 200 });
+        },
+      });
 
-    const client = new S3Client({
-      ...s3Options,
-      endpoint: server.url.href,
-    });
+      const client = new S3Client({
+        ...s3Options,
+        endpoint: server.url.href,
+      });
 
-    const writer = client.file("test_complete_only").writer({
-      uploadId,
-      partNumber: 4,
-      partSize: 5 * 1024 * 1024,
-      previousParts: [
-        { partNumber: 1, etag: '"etag-1"' },
-        { partNumber: 2, etag: '"etag-2"' },
-        { partNumber: 3, etag: '"etag-3"' },
-      ],
-    });
+      const writer = client.file("test_complete_only").writer({
+        uploadId,
+        partNumber: 4,
+        partSize: 5 * 1024 * 1024,
+        previousParts: [
+          { partNumber: 1, etag: '"etag-1"' },
+          { partNumber: 2, etag: '"etag-2"' },
+          { partNumber: 3, etag: '"etag-3"' },
+        ],
+      });
 
-    // End immediately without writing any new data
-    await writer.end();
+      // End immediately without writing any new data
+      await writer.end();
 
-    expect(completionCalled).toBe(true);
-    expect(completionBody).toInclude("<PartNumber>1</PartNumber>");
-    expect(completionBody).toInclude("<PartNumber>2</PartNumber>");
-    expect(completionBody).toInclude("<PartNumber>3</PartNumber>");
-    expect(completionBody).toInclude('<ETag>"etag-1"</ETag>');
-    expect(completionBody).toInclude('<ETag>"etag-2"</ETag>');
-    expect(completionBody).toInclude('<ETag>"etag-3"</ETag>');
-  }, { timeout: 30_000 });
+      expect(completionCalled).toBe(true);
+      expect(completionBody).toInclude("<PartNumber>1</PartNumber>");
+      expect(completionBody).toInclude("<PartNumber>2</PartNumber>");
+      expect(completionBody).toInclude("<PartNumber>3</PartNumber>");
+      expect(completionBody).toInclude('<ETag>"etag-1"</ETag>');
+      expect(completionBody).toInclude('<ETag>"etag-2"</ETag>');
+      expect(completionBody).toInclude('<ETag>"etag-3"</ETag>');
+    },
+    { timeout: 30_000 },
+  );
 
   it("should throw when partNumber > 1 without uploadId", () => {
     const client = new S3Client({
@@ -257,128 +269,136 @@ describe("s3 - Resumable multipart upload", () => {
     }).toThrow("etag");
   });
 
-  it("should not use single PUT when resuming with small data", async () => {
-    const uploadId = randomUUID();
-    let putCalled = false;
-    let completionCalled = false;
-    const partNumbers: number[] = [];
+  it(
+    "should not use single PUT when resuming with small data",
+    async () => {
+      const uploadId = randomUUID();
+      let putCalled = false;
+      let completionCalled = false;
+      const partNumbers: number[] = [];
 
-    using server = Bun.serve({
-      port: 0,
-      async fetch(req) {
-        const url = new URL(req.url);
+      using server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const url = new URL(req.url);
 
-        // Detect single PUT (no query params for multipart)
-        if (req.method === "PUT" && !url.search.includes("partNumber=")) {
-          putCalled = true;
+          // Detect single PUT (no query params for multipart)
+          if (req.method === "PUT" && !url.search.includes("partNumber=")) {
+            putCalled = true;
+            return new Response("", { status: 200 });
+          }
+
+          if (req.method === "PUT" && url.search.includes("partNumber=")) {
+            const match = url.search.match(/partNumber=(\d+)/);
+            if (match) partNumbers.push(parseInt(match[1]));
+            return new Response(undefined, {
+              status: 200,
+              headers: { ETag: `"etag-${match?.[1]}"` },
+            });
+          }
+
+          if (req.method === "POST" && url.search.includes("uploadId=")) {
+            completionCalled = true;
+            return new Response(
+              `<CompleteMultipartUploadResult>
+              <Location>http://my_bucket.s3.amazonaws.com/test</Location>
+              <Bucket>my_bucket</Bucket>
+              <Key>test</Key>
+              <ETag>"final-etag"</ETag>
+            </CompleteMultipartUploadResult>`,
+              { status: 200, headers: { "Content-Type": "text/xml" } },
+            );
+          }
+
           return new Response("", { status: 200 });
-        }
+        },
+      });
 
-        if (req.method === "PUT" && url.search.includes("partNumber=")) {
-          const match = url.search.match(/partNumber=(\d+)/);
-          if (match) partNumbers.push(parseInt(match[1]));
-          return new Response(undefined, {
-            status: 200,
-            headers: { ETag: `"etag-${match?.[1]}"` },
-          });
-        }
+      const client = new S3Client({
+        ...s3Options,
+        endpoint: server.url.href,
+      });
 
-        if (req.method === "POST" && url.search.includes("uploadId=")) {
-          completionCalled = true;
-          return new Response(
-            `<CompleteMultipartUploadResult>
+      // Write a small chunk (< partSize) — normally this would trigger single PUT,
+      // but with resume it should stay in multipart mode
+      const writer = client.file("test_no_single_put").writer({
+        uploadId,
+        partNumber: 2,
+        partSize: 5 * 1024 * 1024,
+        previousParts: [{ partNumber: 1, etag: '"etag-1"' }],
+      });
+
+      writer.write(Buffer.alloc(1024)); // Small chunk
+      await writer.end();
+
+      // Should NOT have used single PUT
+      expect(putCalled).toBe(false);
+      // Should have completed the multipart upload
+      expect(completionCalled).toBe(true);
+    },
+    { timeout: 30_000 },
+  );
+
+  it(
+    "should use correct uploadId in part upload and completion requests",
+    async () => {
+      const uploadId = "test-upload-id-12345";
+      const capturedUploadIds: string[] = [];
+
+      using server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const url = new URL(req.url);
+
+          if (url.search.includes("uploadId=")) {
+            const match = url.search.match(/uploadId=([^&]+)/);
+            if (match) capturedUploadIds.push(match[1]);
+          }
+
+          if (req.method === "PUT" && url.search.includes("partNumber=")) {
+            return new Response(undefined, {
+              status: 200,
+              headers: { ETag: '"some-etag"' },
+            });
+          }
+
+          if (req.method === "POST" && url.search.includes("uploadId=")) {
+            return new Response(
+              `<CompleteMultipartUploadResult>
               <Location>http://my_bucket.s3.amazonaws.com/test</Location>
               <Bucket>my_bucket</Bucket>
               <Key>test</Key>
               <ETag>"final-etag"</ETag>
             </CompleteMultipartUploadResult>`,
-            { status: 200, headers: { "Content-Type": "text/xml" } },
-          );
-        }
+              { status: 200, headers: { "Content-Type": "text/xml" } },
+            );
+          }
 
-        return new Response("", { status: 200 });
-      },
-    });
+          return new Response("", { status: 200 });
+        },
+      });
 
-    const client = new S3Client({
-      ...s3Options,
-      endpoint: server.url.href,
-    });
+      const client = new S3Client({
+        ...s3Options,
+        endpoint: server.url.href,
+      });
 
-    // Write a small chunk (< partSize) — normally this would trigger single PUT,
-    // but with resume it should stay in multipart mode
-    const writer = client.file("test_no_single_put").writer({
-      uploadId,
-      partNumber: 2,
-      partSize: 5 * 1024 * 1024,
-      previousParts: [{ partNumber: 1, etag: '"etag-1"' }],
-    });
+      const writer = client.file("test_upload_id").writer({
+        uploadId,
+        partNumber: 1,
+        partSize: 5 * 1024 * 1024,
+        queueSize: 10,
+      });
 
-    writer.write(Buffer.alloc(1024)); // Small chunk
-    await writer.end();
+      writer.write(Buffer.alloc(5 * 1024 * 1024));
+      await writer.end();
 
-    // Should NOT have used single PUT
-    expect(putCalled).toBe(false);
-    // Should have completed the multipart upload
-    expect(completionCalled).toBe(true);
-  }, { timeout: 30_000 });
-
-  it("should use correct uploadId in part upload and completion requests", async () => {
-    const uploadId = "test-upload-id-12345";
-    const capturedUploadIds: string[] = [];
-
-    using server = Bun.serve({
-      port: 0,
-      async fetch(req) {
-        const url = new URL(req.url);
-
-        if (url.search.includes("uploadId=")) {
-          const match = url.search.match(/uploadId=([^&]+)/);
-          if (match) capturedUploadIds.push(match[1]);
-        }
-
-        if (req.method === "PUT" && url.search.includes("partNumber=")) {
-          return new Response(undefined, {
-            status: 200,
-            headers: { ETag: '"some-etag"' },
-          });
-        }
-
-        if (req.method === "POST" && url.search.includes("uploadId=")) {
-          return new Response(
-            `<CompleteMultipartUploadResult>
-              <Location>http://my_bucket.s3.amazonaws.com/test</Location>
-              <Bucket>my_bucket</Bucket>
-              <Key>test</Key>
-              <ETag>"final-etag"</ETag>
-            </CompleteMultipartUploadResult>`,
-            { status: 200, headers: { "Content-Type": "text/xml" } },
-          );
-        }
-
-        return new Response("", { status: 200 });
-      },
-    });
-
-    const client = new S3Client({
-      ...s3Options,
-      endpoint: server.url.href,
-    });
-
-    const writer = client.file("test_upload_id").writer({
-      uploadId,
-      partNumber: 1,
-      partSize: 5 * 1024 * 1024,
-      queueSize: 10,
-    });
-
-    writer.write(Buffer.alloc(5 * 1024 * 1024));
-    await writer.end();
-
-    // All requests with uploadId should use the same provided upload ID
-    expect(capturedUploadIds.length).toBeGreaterThan(0);
-    for (const id of capturedUploadIds) {
-      expect(id).toBe(uploadId);
-    }
-  }, { timeout: 30_000 });
+      // All requests with uploadId should use the same provided upload ID
+      expect(capturedUploadIds.length).toBeGreaterThan(0);
+      for (const id of capturedUploadIds) {
+        expect(id).toBe(uploadId);
+      }
+    },
+    { timeout: 30_000 },
+  );
 });

--- a/test/js/bun/s3/s3-multipart-resume.test.ts
+++ b/test/js/bun/s3/s3-multipart-resume.test.ts
@@ -10,210 +10,202 @@ describe("s3 - Resumable multipart upload", () => {
     bucket: "my_bucket",
   };
 
-  it(
-    "should skip CreateMultipartUpload when uploadId is provided",
-    async () => {
-      const uploadId = randomUUID();
-      let createMultipartCalled = false;
-      const partNumbers: number[] = [];
-      let completionBody = "";
+  it("should skip CreateMultipartUpload when uploadId is provided", async () => {
+    const uploadId = randomUUID();
+    let createMultipartCalled = false;
+    const partNumbers: number[] = [];
+    let completionBody = "";
 
-      using server = Bun.serve({
-        port: 0,
-        async fetch(req) {
-          const url = new URL(req.url);
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
 
-          if (req.method === "POST" && url.search.includes("?uploads=")) {
-            createMultipartCalled = true;
-            return new Response(
-              `<InitiateMultipartUploadResult><UploadId>${randomUUID()}</UploadId></InitiateMultipartUploadResult>`,
-              { status: 200, headers: { "Content-Type": "text/xml" } },
-            );
-          }
+        if (req.method === "POST" && url.search.includes("?uploads=")) {
+          createMultipartCalled = true;
+          return new Response(
+            `<InitiateMultipartUploadResult><UploadId>${randomUUID()}</UploadId></InitiateMultipartUploadResult>`,
+            { status: 200, headers: { "Content-Type": "text/xml" } },
+          );
+        }
 
-          if (req.method === "PUT" && url.search.includes("partNumber=")) {
-            const match = url.search.match(/partNumber=(\d+)/);
-            if (match) partNumbers.push(parseInt(match[1]));
-            return new Response(undefined, {
-              status: 200,
-              headers: { ETag: `"etag-part-${match?.[1]}"` },
-            });
-          }
+        if (req.method === "PUT" && url.search.includes("partNumber=")) {
+          const match = url.search.match(/partNumber=(\d+)/);
+          if (match) partNumbers.push(parseInt(match[1]));
+          return new Response(undefined, {
+            status: 200,
+            headers: { ETag: `"etag-part-${match?.[1]}"` },
+          });
+        }
 
-          if (req.method === "POST" && url.search.includes("uploadId=")) {
-            completionBody = await req.text();
-            return new Response(
-              `<CompleteMultipartUploadResult>
+        if (req.method === "POST" && url.search.includes("uploadId=")) {
+          completionBody = await req.text();
+          return new Response(
+            `<CompleteMultipartUploadResult>
               <Location>http://my_bucket.s3.amazonaws.com/test</Location>
               <Bucket>my_bucket</Bucket>
               <Key>test</Key>
               <ETag>"final-etag"</ETag>
             </CompleteMultipartUploadResult>`,
-              { status: 200, headers: { "Content-Type": "text/xml" } },
-            );
-          }
+            { status: 200, headers: { "Content-Type": "text/xml" } },
+          );
+        }
 
-          return new Response("", { status: 200 });
-        },
-      });
+        return new Response("", { status: 200 });
+      },
+    });
 
-      const client = new S3Client({
-        ...s3Options,
-        endpoint: server.url.href,
-      });
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: server.url.href,
+    });
 
-      const writer = client.file("test_resume").writer({
-        uploadId,
-        partNumber: 3,
-        partSize: 5 * 1024 * 1024,
-        queueSize: 10,
-      });
+    const writer = client.file("test_resume").writer({
+      uploadId,
+      partNumber: 3,
+      partSize: 5 * 1024 * 1024,
+      queueSize: 10,
+      previousParts: [
+        { partNumber: 1, etag: '"prev-1"' },
+        { partNumber: 2, etag: '"prev-2"' },
+      ],
+    });
 
-      // Write enough data to trigger a part upload (>= partSize)
-      const chunk = Buffer.alloc(5 * 1024 * 1024);
-      writer.write(chunk);
-      await writer.end();
+    // With resume, state is already multipart_completed so even small data
+    // goes through the multipart path (no need for >= partSize)
+    writer.write(Buffer.alloc(1024));
+    await writer.end();
 
-      // CreateMultipartUpload should NOT have been called
-      expect(createMultipartCalled).toBe(false);
-      // The part should start from partNumber 3
-      expect(partNumbers).toContain(3);
-      // The completion should include the uploadId
-      expect(completionBody).toInclude("<PartNumber>3</PartNumber>");
-    },
-    { timeout: 30_000 },
-  );
+    // CreateMultipartUpload should NOT have been called
+    expect(createMultipartCalled).toBe(false);
+    // The part should start from partNumber 3
+    expect(partNumbers).toContain(3);
+    // The completion should include the uploadId
+    expect(completionBody).toInclude("<PartNumber>3</PartNumber>");
+  });
 
-  it(
-    "should include previousParts in CompleteMultipartUpload XML",
-    async () => {
-      const uploadId = randomUUID();
-      let completionBody = "";
+  it("should include previousParts in CompleteMultipartUpload XML", async () => {
+    const uploadId = randomUUID();
+    let completionBody = "";
 
-      using server = Bun.serve({
-        port: 0,
-        async fetch(req) {
-          const url = new URL(req.url);
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
 
-          if (req.method === "PUT" && url.search.includes("partNumber=")) {
-            return new Response(undefined, {
-              status: 200,
-              headers: { ETag: `"new-etag"` },
-            });
-          }
+        if (req.method === "PUT" && url.search.includes("partNumber=")) {
+          return new Response(undefined, {
+            status: 200,
+            headers: { ETag: `"new-etag"` },
+          });
+        }
 
-          if (req.method === "POST" && url.search.includes("uploadId=")) {
-            completionBody = await req.text();
-            return new Response(
-              `<CompleteMultipartUploadResult>
+        if (req.method === "POST" && url.search.includes("uploadId=")) {
+          completionBody = await req.text();
+          return new Response(
+            `<CompleteMultipartUploadResult>
               <Location>http://my_bucket.s3.amazonaws.com/test</Location>
               <Bucket>my_bucket</Bucket>
               <Key>test</Key>
               <ETag>"final-etag"</ETag>
             </CompleteMultipartUploadResult>`,
-              { status: 200, headers: { "Content-Type": "text/xml" } },
-            );
-          }
+            { status: 200, headers: { "Content-Type": "text/xml" } },
+          );
+        }
 
-          return new Response("", { status: 200 });
-        },
-      });
+        return new Response("", { status: 200 });
+      },
+    });
 
-      const client = new S3Client({
-        ...s3Options,
-        endpoint: server.url.href,
-      });
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: server.url.href,
+    });
 
-      const writer = client.file("test_resume_parts").writer({
-        uploadId,
-        partNumber: 3,
-        partSize: 5 * 1024 * 1024,
-        queueSize: 10,
-        previousParts: [
-          { partNumber: 1, etag: '"etag-part-1"' },
-          { partNumber: 2, etag: '"etag-part-2"' },
-        ],
-      });
+    const writer = client.file("test_resume_parts").writer({
+      uploadId,
+      partNumber: 3,
+      partSize: 5 * 1024 * 1024,
+      queueSize: 10,
+      previousParts: [
+        { partNumber: 1, etag: '"etag-part-1"' },
+        { partNumber: 2, etag: '"etag-part-2"' },
+      ],
+    });
 
-      const chunk = Buffer.alloc(5 * 1024 * 1024);
-      writer.write(chunk);
-      await writer.end();
+    // Small buffer — resume state bypasses partSize threshold
+    writer.write(Buffer.alloc(1024));
+    await writer.end();
 
-      // The completion XML should include both previous parts and the new part
-      expect(completionBody).toInclude("<PartNumber>1</PartNumber>");
-      expect(completionBody).toInclude('<ETag>"etag-part-1"</ETag>');
-      expect(completionBody).toInclude("<PartNumber>2</PartNumber>");
-      expect(completionBody).toInclude('<ETag>"etag-part-2"</ETag>');
-      expect(completionBody).toInclude("<PartNumber>3</PartNumber>");
-      // Parts should be sorted by number in the XML
-      const part1Pos = completionBody.indexOf("<PartNumber>1</PartNumber>");
-      const part2Pos = completionBody.indexOf("<PartNumber>2</PartNumber>");
-      const part3Pos = completionBody.indexOf("<PartNumber>3</PartNumber>");
-      expect(part1Pos).toBeLessThan(part2Pos);
-      expect(part2Pos).toBeLessThan(part3Pos);
-    },
-    { timeout: 30_000 },
-  );
+    // The completion XML should include both previous parts and the new part
+    expect(completionBody).toInclude("<PartNumber>1</PartNumber>");
+    expect(completionBody).toInclude('<ETag>"etag-part-1"</ETag>');
+    expect(completionBody).toInclude("<PartNumber>2</PartNumber>");
+    expect(completionBody).toInclude('<ETag>"etag-part-2"</ETag>');
+    expect(completionBody).toInclude("<PartNumber>3</PartNumber>");
+    // Parts should be sorted by number in the XML
+    const part1Pos = completionBody.indexOf("<PartNumber>1</PartNumber>");
+    const part2Pos = completionBody.indexOf("<PartNumber>2</PartNumber>");
+    const part3Pos = completionBody.indexOf("<PartNumber>3</PartNumber>");
+    expect(part1Pos).toBeLessThan(part2Pos);
+    expect(part2Pos).toBeLessThan(part3Pos);
+  });
 
-  it(
-    "should complete with only previousParts and no new data",
-    async () => {
-      const uploadId = randomUUID();
-      let completionBody = "";
-      let completionCalled = false;
+  it("should complete with only previousParts and no new data", async () => {
+    const uploadId = randomUUID();
+    let completionBody = "";
+    let completionCalled = false;
 
-      using server = Bun.serve({
-        port: 0,
-        async fetch(req) {
-          const url = new URL(req.url);
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
 
-          if (req.method === "POST" && url.search.includes("uploadId=")) {
-            completionCalled = true;
-            completionBody = await req.text();
-            return new Response(
-              `<CompleteMultipartUploadResult>
+        if (req.method === "POST" && url.search.includes("uploadId=")) {
+          completionCalled = true;
+          completionBody = await req.text();
+          return new Response(
+            `<CompleteMultipartUploadResult>
               <Location>http://my_bucket.s3.amazonaws.com/test</Location>
               <Bucket>my_bucket</Bucket>
               <Key>test</Key>
               <ETag>"final-etag"</ETag>
             </CompleteMultipartUploadResult>`,
-              { status: 200, headers: { "Content-Type": "text/xml" } },
-            );
-          }
+            { status: 200, headers: { "Content-Type": "text/xml" } },
+          );
+        }
 
-          return new Response("", { status: 200 });
-        },
-      });
+        return new Response("", { status: 200 });
+      },
+    });
 
-      const client = new S3Client({
-        ...s3Options,
-        endpoint: server.url.href,
-      });
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: server.url.href,
+    });
 
-      const writer = client.file("test_complete_only").writer({
-        uploadId,
-        partNumber: 4,
-        partSize: 5 * 1024 * 1024,
-        previousParts: [
-          { partNumber: 1, etag: '"etag-1"' },
-          { partNumber: 2, etag: '"etag-2"' },
-          { partNumber: 3, etag: '"etag-3"' },
-        ],
-      });
+    const writer = client.file("test_complete_only").writer({
+      uploadId,
+      partNumber: 4,
+      partSize: 5 * 1024 * 1024,
+      previousParts: [
+        { partNumber: 1, etag: '"etag-1"' },
+        { partNumber: 2, etag: '"etag-2"' },
+        { partNumber: 3, etag: '"etag-3"' },
+      ],
+    });
 
-      // End immediately without writing any new data
-      await writer.end();
+    // End immediately without writing any new data
+    await writer.end();
 
-      expect(completionCalled).toBe(true);
-      expect(completionBody).toInclude("<PartNumber>1</PartNumber>");
-      expect(completionBody).toInclude("<PartNumber>2</PartNumber>");
-      expect(completionBody).toInclude("<PartNumber>3</PartNumber>");
-      expect(completionBody).toInclude('<ETag>"etag-1"</ETag>');
-      expect(completionBody).toInclude('<ETag>"etag-2"</ETag>');
-      expect(completionBody).toInclude('<ETag>"etag-3"</ETag>');
-    },
-    { timeout: 30_000 },
-  );
+    expect(completionCalled).toBe(true);
+    expect(completionBody).toInclude("<PartNumber>1</PartNumber>");
+    expect(completionBody).toInclude("<PartNumber>2</PartNumber>");
+    expect(completionBody).toInclude("<PartNumber>3</PartNumber>");
+    expect(completionBody).toInclude('<ETag>"etag-1"</ETag>');
+    expect(completionBody).toInclude('<ETag>"etag-2"</ETag>');
+    expect(completionBody).toInclude('<ETag>"etag-3"</ETag>');
+  });
 
   it("should throw when partNumber > 1 without uploadId", () => {
     const client = new S3Client({
@@ -226,7 +218,7 @@ describe("s3 - Resumable multipart upload", () => {
     }).toThrow("partNumber > 1 requires uploadId");
   });
 
-  it("should throw when previousParts is provided without uploadId", () => {
+  it("should throw when previousParts entry has partNumber >= starting partNumber", () => {
     const client = new S3Client({
       ...s3Options,
       endpoint: "http://localhost:1",
@@ -234,9 +226,14 @@ describe("s3 - Resumable multipart upload", () => {
 
     expect(() => {
       client.file("test").writer({
-        previousParts: [{ partNumber: 1, etag: '"etag"' }],
+        uploadId: "abc",
+        partNumber: 3,
+        previousParts: [
+          { partNumber: 1, etag: '"e1"' },
+          { partNumber: 3, etag: '"e3"' }, // overlaps with starting partNumber
+        ],
       });
-    }).toThrow("previousParts requires uploadId");
+    }).toThrow("previousParts entry must have a partNumber less than partNumber");
   });
 
   it("should throw for invalid partNumber range", () => {
@@ -247,11 +244,11 @@ describe("s3 - Resumable multipart upload", () => {
 
     expect(() => {
       client.file("test").writer({ uploadId: "abc", partNumber: 0 });
-    }).toThrow();
+    }).toThrow("partNumber");
 
     expect(() => {
       client.file("test").writer({ uploadId: "abc", partNumber: 10001 });
-    }).toThrow();
+    }).toThrow("partNumber");
   });
 
   it("should throw for invalid previousParts entries", () => {
@@ -263,142 +260,189 @@ describe("s3 - Resumable multipart upload", () => {
     expect(() => {
       client.file("test").writer({
         uploadId: "abc",
+        partNumber: 2,
         // @ts-expect-error missing etag
         previousParts: [{ partNumber: 1 }],
       });
     }).toThrow("etag");
   });
 
-  it(
-    "should not use single PUT when resuming with small data",
-    async () => {
-      const uploadId = randomUUID();
-      let putCalled = false;
-      let completionCalled = false;
-      const partNumbers: number[] = [];
+  it("should throw when partNumber > 1 without previousParts", () => {
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: "http://localhost:1",
+    });
 
-      using server = Bun.serve({
-        port: 0,
-        async fetch(req) {
-          const url = new URL(req.url);
+    expect(() => {
+      client.file("test").writer({ uploadId: "abc", partNumber: 2 });
+    }).toThrow("previousParts");
+  });
 
-          // Detect single PUT (no query params for multipart)
-          if (req.method === "PUT" && !url.search.includes("partNumber=")) {
-            putCalled = true;
-            return new Response("", { status: 200 });
-          }
+  it("should not use single PUT when resuming with small data", async () => {
+    const uploadId = randomUUID();
+    let putCalled = false;
+    let completionCalled = false;
 
-          if (req.method === "PUT" && url.search.includes("partNumber=")) {
-            const match = url.search.match(/partNumber=(\d+)/);
-            if (match) partNumbers.push(parseInt(match[1]));
-            return new Response(undefined, {
-              status: 200,
-              headers: { ETag: `"etag-${match?.[1]}"` },
-            });
-          }
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
 
-          if (req.method === "POST" && url.search.includes("uploadId=")) {
-            completionCalled = true;
-            return new Response(
-              `<CompleteMultipartUploadResult>
+        // Detect single PUT (no query params for multipart)
+        if (req.method === "PUT" && !url.search.includes("partNumber=")) {
+          putCalled = true;
+          return new Response("", { status: 200 });
+        }
+
+        if (req.method === "PUT" && url.search.includes("partNumber=")) {
+          return new Response(undefined, {
+            status: 200,
+            headers: { ETag: '"etag-new"' },
+          });
+        }
+
+        if (req.method === "POST" && url.search.includes("uploadId=")) {
+          completionCalled = true;
+          return new Response(
+            `<CompleteMultipartUploadResult>
               <Location>http://my_bucket.s3.amazonaws.com/test</Location>
               <Bucket>my_bucket</Bucket>
               <Key>test</Key>
               <ETag>"final-etag"</ETag>
             </CompleteMultipartUploadResult>`,
-              { status: 200, headers: { "Content-Type": "text/xml" } },
-            );
-          }
+            { status: 200, headers: { "Content-Type": "text/xml" } },
+          );
+        }
 
-          return new Response("", { status: 200 });
-        },
-      });
+        return new Response("", { status: 200 });
+      },
+    });
 
-      const client = new S3Client({
-        ...s3Options,
-        endpoint: server.url.href,
-      });
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: server.url.href,
+    });
 
-      // Write a small chunk (< partSize) — normally this would trigger single PUT,
-      // but with resume it should stay in multipart mode
-      const writer = client.file("test_no_single_put").writer({
-        uploadId,
-        partNumber: 2,
-        partSize: 5 * 1024 * 1024,
-        previousParts: [{ partNumber: 1, etag: '"etag-1"' }],
-      });
+    // Write a small chunk (< partSize) — normally this would trigger single PUT,
+    // but with resume it should stay in multipart mode
+    const writer = client.file("test_no_single_put").writer({
+      uploadId,
+      partNumber: 2,
+      partSize: 5 * 1024 * 1024,
+      previousParts: [{ partNumber: 1, etag: '"etag-1"' }],
+    });
 
-      writer.write(Buffer.alloc(1024)); // Small chunk
-      await writer.end();
+    writer.write(Buffer.alloc(1024)); // Small chunk
+    await writer.end();
 
-      // Should NOT have used single PUT
-      expect(putCalled).toBe(false);
-      // Should have completed the multipart upload
-      expect(completionCalled).toBe(true);
-    },
-    { timeout: 30_000 },
-  );
+    // Should NOT have used single PUT
+    expect(putCalled).toBe(false);
+    // Should have completed the multipart upload
+    expect(completionCalled).toBe(true);
+  });
 
-  it(
-    "should use correct uploadId in part upload and completion requests",
-    async () => {
-      const uploadId = "test-upload-id-12345";
-      const capturedUploadIds: string[] = [];
+  it("should use correct uploadId in part upload and completion requests", async () => {
+    const uploadId = "test-upload-id-12345";
+    const capturedUploadIds: string[] = [];
 
-      using server = Bun.serve({
-        port: 0,
-        async fetch(req) {
-          const url = new URL(req.url);
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
 
-          if (url.search.includes("uploadId=")) {
-            const match = url.search.match(/uploadId=([^&]+)/);
-            if (match) capturedUploadIds.push(match[1]);
-          }
+        if (url.search.includes("uploadId=")) {
+          const match = url.search.match(/uploadId=([^&]+)/);
+          if (match) capturedUploadIds.push(match[1]);
+        }
 
-          if (req.method === "PUT" && url.search.includes("partNumber=")) {
-            return new Response(undefined, {
-              status: 200,
-              headers: { ETag: '"some-etag"' },
-            });
-          }
+        if (req.method === "PUT" && url.search.includes("partNumber=")) {
+          return new Response(undefined, {
+            status: 200,
+            headers: { ETag: '"some-etag"' },
+          });
+        }
 
-          if (req.method === "POST" && url.search.includes("uploadId=")) {
-            return new Response(
-              `<CompleteMultipartUploadResult>
+        if (req.method === "POST" && url.search.includes("uploadId=")) {
+          return new Response(
+            `<CompleteMultipartUploadResult>
               <Location>http://my_bucket.s3.amazonaws.com/test</Location>
               <Bucket>my_bucket</Bucket>
               <Key>test</Key>
               <ETag>"final-etag"</ETag>
             </CompleteMultipartUploadResult>`,
-              { status: 200, headers: { "Content-Type": "text/xml" } },
-            );
-          }
+            { status: 200, headers: { "Content-Type": "text/xml" } },
+          );
+        }
 
-          return new Response("", { status: 200 });
-        },
-      });
+        return new Response("", { status: 200 });
+      },
+    });
 
-      const client = new S3Client({
-        ...s3Options,
-        endpoint: server.url.href,
-      });
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: server.url.href,
+    });
 
-      const writer = client.file("test_upload_id").writer({
-        uploadId,
-        partNumber: 1,
-        partSize: 5 * 1024 * 1024,
-        queueSize: 10,
-      });
+    const writer = client.file("test_upload_id").writer({
+      uploadId,
+      partNumber: 1,
+      partSize: 5 * 1024 * 1024,
+      queueSize: 10,
+    });
 
-      writer.write(Buffer.alloc(5 * 1024 * 1024));
+    // Small buffer — resume state bypasses partSize threshold
+    writer.write(Buffer.alloc(1024));
+    await writer.end();
+
+    // All requests with uploadId should use the same provided upload ID
+    expect(capturedUploadIds.length).toBeGreaterThan(0);
+    for (const id of capturedUploadIds) {
+      expect(id).toBe(uploadId);
+    }
+  });
+
+  it("should propagate server rejection of resumed upload", async () => {
+    const uploadId = randomUUID();
+
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+
+        // Reject all multipart requests with 404
+        if (url.search.includes("uploadId=") || url.search.includes("partNumber=")) {
+          return new Response(
+            `<?xml version="1.0" encoding="UTF-8"?>
+            <Error>
+              <Code>NoSuchUpload</Code>
+              <Message>The specified upload does not exist.</Message>
+            </Error>`,
+            { status: 404, headers: { "Content-Type": "text/xml" } },
+          );
+        }
+
+        return new Response("", { status: 200 });
+      },
+    });
+
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: server.url.href,
+    });
+
+    const writer = client.file("test_rejected").writer({
+      uploadId,
+      partNumber: 2,
+      partSize: 5 * 1024 * 1024,
+      previousParts: [{ partNumber: 1, etag: '"etag-1"' }],
+    });
+
+    writer.write(Buffer.alloc(1024));
+    try {
       await writer.end();
-
-      // All requests with uploadId should use the same provided upload ID
-      expect(capturedUploadIds.length).toBeGreaterThan(0);
-      for (const id of capturedUploadIds) {
-        expect(id).toBe(uploadId);
-      }
-    },
-    { timeout: 30_000 },
-  );
+      expect.unreachable();
+    } catch (e: any) {
+      expect(e).toBeDefined();
+    }
+  });
 });

--- a/test/js/bun/s3/s3-multipart-resume.test.ts
+++ b/test/js/bun/s3/s3-multipart-resume.test.ts
@@ -1,0 +1,384 @@
+import { S3Client, type S3Options } from "bun";
+import { describe, expect, it } from "bun:test";
+import { randomUUID } from "node:crypto";
+
+describe("s3 - Resumable multipart upload", () => {
+  const s3Options: S3Options = {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+    region: "eu-west-3",
+    bucket: "my_bucket",
+  };
+
+  it("should skip CreateMultipartUpload when uploadId is provided", async () => {
+    const uploadId = randomUUID();
+    let createMultipartCalled = false;
+    const partNumbers: number[] = [];
+    let completionBody = "";
+
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+
+        if (req.method === "POST" && url.search.includes("?uploads=")) {
+          createMultipartCalled = true;
+          return new Response(
+            `<InitiateMultipartUploadResult><UploadId>${randomUUID()}</UploadId></InitiateMultipartUploadResult>`,
+            { status: 200, headers: { "Content-Type": "text/xml" } },
+          );
+        }
+
+        if (req.method === "PUT" && url.search.includes("partNumber=")) {
+          const match = url.search.match(/partNumber=(\d+)/);
+          if (match) partNumbers.push(parseInt(match[1]));
+          return new Response(undefined, {
+            status: 200,
+            headers: { ETag: `"etag-part-${match?.[1]}"` },
+          });
+        }
+
+        if (req.method === "POST" && url.search.includes("uploadId=")) {
+          completionBody = await req.text();
+          return new Response(
+            `<CompleteMultipartUploadResult>
+              <Location>http://my_bucket.s3.amazonaws.com/test</Location>
+              <Bucket>my_bucket</Bucket>
+              <Key>test</Key>
+              <ETag>"final-etag"</ETag>
+            </CompleteMultipartUploadResult>`,
+            { status: 200, headers: { "Content-Type": "text/xml" } },
+          );
+        }
+
+        return new Response("", { status: 200 });
+      },
+    });
+
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: server.url.href,
+    });
+
+    const writer = client.file("test_resume").writer({
+      uploadId,
+      partNumber: 3,
+      partSize: 5 * 1024 * 1024,
+      queueSize: 10,
+    });
+
+    // Write enough data to trigger a part upload (>= partSize)
+    const chunk = Buffer.alloc(5 * 1024 * 1024);
+    writer.write(chunk);
+    await writer.end();
+
+    // CreateMultipartUpload should NOT have been called
+    expect(createMultipartCalled).toBe(false);
+    // The part should start from partNumber 3
+    expect(partNumbers).toContain(3);
+    // The completion should include the uploadId
+    expect(completionBody).toInclude("<PartNumber>3</PartNumber>");
+  }, { timeout: 30_000 });
+
+  it("should include previousParts in CompleteMultipartUpload XML", async () => {
+    const uploadId = randomUUID();
+    let completionBody = "";
+
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+
+        if (req.method === "PUT" && url.search.includes("partNumber=")) {
+          return new Response(undefined, {
+            status: 200,
+            headers: { ETag: `"new-etag"` },
+          });
+        }
+
+        if (req.method === "POST" && url.search.includes("uploadId=")) {
+          completionBody = await req.text();
+          return new Response(
+            `<CompleteMultipartUploadResult>
+              <Location>http://my_bucket.s3.amazonaws.com/test</Location>
+              <Bucket>my_bucket</Bucket>
+              <Key>test</Key>
+              <ETag>"final-etag"</ETag>
+            </CompleteMultipartUploadResult>`,
+            { status: 200, headers: { "Content-Type": "text/xml" } },
+          );
+        }
+
+        return new Response("", { status: 200 });
+      },
+    });
+
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: server.url.href,
+    });
+
+    const writer = client.file("test_resume_parts").writer({
+      uploadId,
+      partNumber: 3,
+      partSize: 5 * 1024 * 1024,
+      queueSize: 10,
+      previousParts: [
+        { partNumber: 1, etag: '"etag-part-1"' },
+        { partNumber: 2, etag: '"etag-part-2"' },
+      ],
+    });
+
+    const chunk = Buffer.alloc(5 * 1024 * 1024);
+    writer.write(chunk);
+    await writer.end();
+
+    // The completion XML should include both previous parts and the new part
+    expect(completionBody).toInclude("<PartNumber>1</PartNumber>");
+    expect(completionBody).toInclude('<ETag>"etag-part-1"</ETag>');
+    expect(completionBody).toInclude("<PartNumber>2</PartNumber>");
+    expect(completionBody).toInclude('<ETag>"etag-part-2"</ETag>');
+    expect(completionBody).toInclude("<PartNumber>3</PartNumber>");
+    // Parts should be sorted by number in the XML
+    const part1Pos = completionBody.indexOf("<PartNumber>1</PartNumber>");
+    const part2Pos = completionBody.indexOf("<PartNumber>2</PartNumber>");
+    const part3Pos = completionBody.indexOf("<PartNumber>3</PartNumber>");
+    expect(part1Pos).toBeLessThan(part2Pos);
+    expect(part2Pos).toBeLessThan(part3Pos);
+  }, { timeout: 30_000 });
+
+  it("should complete with only previousParts and no new data", async () => {
+    const uploadId = randomUUID();
+    let completionBody = "";
+    let completionCalled = false;
+
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+
+        if (req.method === "POST" && url.search.includes("uploadId=")) {
+          completionCalled = true;
+          completionBody = await req.text();
+          return new Response(
+            `<CompleteMultipartUploadResult>
+              <Location>http://my_bucket.s3.amazonaws.com/test</Location>
+              <Bucket>my_bucket</Bucket>
+              <Key>test</Key>
+              <ETag>"final-etag"</ETag>
+            </CompleteMultipartUploadResult>`,
+            { status: 200, headers: { "Content-Type": "text/xml" } },
+          );
+        }
+
+        return new Response("", { status: 200 });
+      },
+    });
+
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: server.url.href,
+    });
+
+    const writer = client.file("test_complete_only").writer({
+      uploadId,
+      partNumber: 4,
+      partSize: 5 * 1024 * 1024,
+      previousParts: [
+        { partNumber: 1, etag: '"etag-1"' },
+        { partNumber: 2, etag: '"etag-2"' },
+        { partNumber: 3, etag: '"etag-3"' },
+      ],
+    });
+
+    // End immediately without writing any new data
+    await writer.end();
+
+    expect(completionCalled).toBe(true);
+    expect(completionBody).toInclude("<PartNumber>1</PartNumber>");
+    expect(completionBody).toInclude("<PartNumber>2</PartNumber>");
+    expect(completionBody).toInclude("<PartNumber>3</PartNumber>");
+    expect(completionBody).toInclude('<ETag>"etag-1"</ETag>');
+    expect(completionBody).toInclude('<ETag>"etag-2"</ETag>');
+    expect(completionBody).toInclude('<ETag>"etag-3"</ETag>');
+  }, { timeout: 30_000 });
+
+  it("should throw when partNumber > 1 without uploadId", () => {
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: "http://localhost:1",
+    });
+
+    expect(() => {
+      client.file("test").writer({ partNumber: 5 });
+    }).toThrow("partNumber > 1 requires uploadId");
+  });
+
+  it("should throw when previousParts is provided without uploadId", () => {
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: "http://localhost:1",
+    });
+
+    expect(() => {
+      client.file("test").writer({
+        previousParts: [{ partNumber: 1, etag: '"etag"' }],
+      });
+    }).toThrow("previousParts requires uploadId");
+  });
+
+  it("should throw for invalid partNumber range", () => {
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: "http://localhost:1",
+    });
+
+    expect(() => {
+      client.file("test").writer({ uploadId: "abc", partNumber: 0 });
+    }).toThrow();
+
+    expect(() => {
+      client.file("test").writer({ uploadId: "abc", partNumber: 10001 });
+    }).toThrow();
+  });
+
+  it("should throw for invalid previousParts entries", () => {
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: "http://localhost:1",
+    });
+
+    expect(() => {
+      client.file("test").writer({
+        uploadId: "abc",
+        // @ts-expect-error missing etag
+        previousParts: [{ partNumber: 1 }],
+      });
+    }).toThrow("etag");
+  });
+
+  it("should not use single PUT when resuming with small data", async () => {
+    const uploadId = randomUUID();
+    let putCalled = false;
+    let completionCalled = false;
+    const partNumbers: number[] = [];
+
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+
+        // Detect single PUT (no query params for multipart)
+        if (req.method === "PUT" && !url.search.includes("partNumber=")) {
+          putCalled = true;
+          return new Response("", { status: 200 });
+        }
+
+        if (req.method === "PUT" && url.search.includes("partNumber=")) {
+          const match = url.search.match(/partNumber=(\d+)/);
+          if (match) partNumbers.push(parseInt(match[1]));
+          return new Response(undefined, {
+            status: 200,
+            headers: { ETag: `"etag-${match?.[1]}"` },
+          });
+        }
+
+        if (req.method === "POST" && url.search.includes("uploadId=")) {
+          completionCalled = true;
+          return new Response(
+            `<CompleteMultipartUploadResult>
+              <Location>http://my_bucket.s3.amazonaws.com/test</Location>
+              <Bucket>my_bucket</Bucket>
+              <Key>test</Key>
+              <ETag>"final-etag"</ETag>
+            </CompleteMultipartUploadResult>`,
+            { status: 200, headers: { "Content-Type": "text/xml" } },
+          );
+        }
+
+        return new Response("", { status: 200 });
+      },
+    });
+
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: server.url.href,
+    });
+
+    // Write a small chunk (< partSize) — normally this would trigger single PUT,
+    // but with resume it should stay in multipart mode
+    const writer = client.file("test_no_single_put").writer({
+      uploadId,
+      partNumber: 2,
+      partSize: 5 * 1024 * 1024,
+      previousParts: [{ partNumber: 1, etag: '"etag-1"' }],
+    });
+
+    writer.write(Buffer.alloc(1024)); // Small chunk
+    await writer.end();
+
+    // Should NOT have used single PUT
+    expect(putCalled).toBe(false);
+    // Should have completed the multipart upload
+    expect(completionCalled).toBe(true);
+  }, { timeout: 30_000 });
+
+  it("should use correct uploadId in part upload and completion requests", async () => {
+    const uploadId = "test-upload-id-12345";
+    const capturedUploadIds: string[] = [];
+
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+
+        if (url.search.includes("uploadId=")) {
+          const match = url.search.match(/uploadId=([^&]+)/);
+          if (match) capturedUploadIds.push(match[1]);
+        }
+
+        if (req.method === "PUT" && url.search.includes("partNumber=")) {
+          return new Response(undefined, {
+            status: 200,
+            headers: { ETag: '"some-etag"' },
+          });
+        }
+
+        if (req.method === "POST" && url.search.includes("uploadId=")) {
+          return new Response(
+            `<CompleteMultipartUploadResult>
+              <Location>http://my_bucket.s3.amazonaws.com/test</Location>
+              <Bucket>my_bucket</Bucket>
+              <Key>test</Key>
+              <ETag>"final-etag"</ETag>
+            </CompleteMultipartUploadResult>`,
+            { status: 200, headers: { "Content-Type": "text/xml" } },
+          );
+        }
+
+        return new Response("", { status: 200 });
+      },
+    });
+
+    const client = new S3Client({
+      ...s3Options,
+      endpoint: server.url.href,
+    });
+
+    const writer = client.file("test_upload_id").writer({
+      uploadId,
+      partNumber: 1,
+      partSize: 5 * 1024 * 1024,
+      queueSize: 10,
+    });
+
+    writer.write(Buffer.alloc(5 * 1024 * 1024));
+    await writer.end();
+
+    // All requests with uploadId should use the same provided upload ID
+    expect(capturedUploadIds.length).toBeGreaterThan(0);
+    for (const id of capturedUploadIds) {
+      expect(id).toBe(uploadId);
+    }
+  }, { timeout: 30_000 });
+});


### PR DESCRIPTION
Closes #28503

## Problem
Large S3 uploads can fail due to network drops, app restarts, or system sleep. When that happens, there's no way to resume safely — uploads restart from scratch, wasting time, bandwidth, and cost.

## Solution
Accept `uploadId`, `partNumber`, and `previousParts` options on the S3 writer API to enable resuming interrupted multipart uploads.

### Usage
```js
const writer = s3file.writer({
  uploadId: 'existing-upload-id',
  partNumber: 3,                    // continue from part 3
  previousParts: [
    { partNumber: 1, etag: '"abc"' },
    { partNumber: 2, etag: '"def"' },
  ],
});
writer.write(newData);
await writer.end();
```

### Behavior
When `uploadId` is provided:
- **Skip CreateMultipartUpload** — reuse the existing upload session
- **Start part numbering** from the given `partNumber`
- **Include previousParts** ETags in the CompleteMultipartUpload XML
- **Never fall back to single PUT** — stay in multipart mode even for small data

### Validation
- `partNumber > 1` requires `uploadId`
- `previousParts` requires `uploadId`
- `partNumber` must be 1–10000
- Each `previousParts` entry must have `partNumber` (number) and `etag` (string)

## Changes
- `src/s3/credentials.zig` — Parse `uploadId`, `partNumber`, `previousParts` from JS options with validation
- `src/s3/client.zig` — Accept resume params in `writableStream()` and `uploadStream()`, initialize `MultiPartUpload` with resume state
- `src/s3/multipart.zig` — Handle resume in `continueStream()` (skip to `multipart_completed` state when upload_id is set)
- `src/bun.js/webcore/Blob.zig` — Thread resume data from writer options to S3 upload functions
- `src/bun.js/webcore/fetch.zig` — Pass default (no-resume) params to updated `uploadStream` signature

## Verification
- 9 tests covering: resume without CreateMultipartUpload, previousParts in completion XML, completion with only previous parts, validation errors, no single-PUT fallback, correct uploadId propagation
- All tests fail with system bun (feature doesn't exist) and pass with the build