### PR TITLE
Fix stack-buffer-overflow from stale PackageManager log pointer in resolveMaybeNeedsTrailingSlash

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1836,10 +1836,16 @@ pub fn resolveMaybeNeedsTrailingSlash(
     jsc_vm.log = &log;
     jsc_vm.transpiler.resolver.log = &log;
     jsc_vm.transpiler.linker.log = &log;
+    if (jsc_vm.transpiler.resolver.package_manager) |pm| {
+        pm.log = &log;
+    }
     defer {
         jsc_vm.log = old_log;
         jsc_vm.transpiler.linker.log = old_log;
         jsc_vm.transpiler.resolver.log = old_log;
+        if (jsc_vm.transpiler.resolver.package_manager) |pm| {
+            pm.log = old_log;
+        }
     }
     jsc_vm._resolve(&result, specifier_utf8.slice(), normalizeSource(source_utf8.slice()), is_esm, is_a_file_path) catch |err_| {
         var err = err_;

--- a/test/js/bun/test/mock/mock-module-resolve-log.test.ts
+++ b/test/js/bun/test/mock/mock-module-resolve-log.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "bun:test";
+import { bunExe, bunEnv } from "harness";
+
+// Regression test: mock.module() with a non-existent specifier must not crash
+// when module resolution triggers auto-install and the package manager uses
+// a stale log pointer from the resolver's stack frame.
+test("mock.module with non-existent specifier does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const { mock } = require("bun:test");
+      try {
+        mock.module("this-package-does-not-exist-abcdef123", () => ({ a: 1 }));
+      } catch (e) {}
+      console.log("ok");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("ok");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/mock/mock-module-resolve-log.test.ts
+++ b/test/js/bun/test/mock/mock-module-resolve-log.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { bunExe, bunEnv } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 // Regression test: mock.module() with a non-existent specifier must not crash
 // when module resolution triggers auto-install and the package manager uses

--- a/test/js/bun/test/mock/mock-module-resolve-log.test.ts
+++ b/test/js/bun/test/mock/mock-module-resolve-log.test.ts
@@ -1,29 +1,8 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { expect, mock, test } from "bun:test";
 
 // Regression test: mock.module() with a non-existent specifier must not crash
 // when module resolution triggers auto-install and the package manager uses
 // a stale log pointer from the resolver's stack frame.
-test("mock.module with non-existent specifier does not crash", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-      const { mock } = require("bun:test");
-      try {
-        mock.module("this-package-does-not-exist-abcdef123", () => ({ a: 1 }));
-      } catch (e) {}
-      console.log("ok");
-      `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stdout).toContain("ok");
-  expect(exitCode).toBe(0);
+test("mock.module with non-existent specifier does not crash", () => {
+  mock.module("this-package-does-not-exist-abcdef123", () => ({ a: 1 }));
 });

--- a/test/js/bun/test/mock/mock-module-resolve-log.test.ts
+++ b/test/js/bun/test/mock/mock-module-resolve-log.test.ts
@@ -1,8 +1,10 @@
-import { mock, test } from "bun:test";
+import { expect, mock, test } from "bun:test";
 
 // Regression test: mock.module() with a non-existent specifier must not crash
 // when module resolution triggers auto-install and the package manager uses
 // a stale log pointer from the resolver's stack frame.
-test("mock.module with non-existent specifier does not crash", () => {
+test("mock.module with non-existent specifier does not crash", async () => {
   mock.module("this-package-does-not-exist-abcdef123", () => ({ a: 1 }));
+  const mod = await import("this-package-does-not-exist-abcdef123");
+  expect(mod.a).toBe(1);
 });

--- a/test/js/bun/test/mock/mock-module-resolve-log.test.ts
+++ b/test/js/bun/test/mock/mock-module-resolve-log.test.ts
@@ -1,4 +1,4 @@
-import { expect, mock, test } from "bun:test";
+import { mock, test } from "bun:test";
 
 // Regression test: mock.module() with a non-existent specifier must not crash
 // when module resolution triggers auto-install and the package manager uses


### PR DESCRIPTION
## Problem

\`resolveMaybeNeedsTrailingSlash\` in \`VirtualMachine.zig\` creates a stack-local \`logger.Log\` and temporarily sets it on the resolver and linker:

\`\`\`zig
var log = logger.Log.init(bun.default_allocator);
defer log.deinit();
jsc_vm.transpiler.resolver.log = &log;
jsc_vm.transpiler.linker.log = &log;
\`\`\`

However, it does **not** update \`PackageManager.log\`. When module resolution triggers auto-install (e.g. via \`mock.module()\` with a non-existent specifier), the package manager calls \`manager.log.addErrorFmt()\` on its stale \`log\` pointer — which may point to a destroyed stack frame from a previous call to \`resolveMaybeNeedsTrailingSlash\`.

This causes a stack-buffer-overflow (ASAN fingerprint: \`Address:stack-buffer-overflow:bun-debug+0xc9f417a\`).

## Fix

Apply the same save/restore pattern already used in \`ModuleLoader.zig\` (lines 188-198) to also update and restore \`pm.log\` in the defer block:

\`\`\`zig
if (jsc_vm.transpiler.resolver.package_manager) |pm| {
    pm.log = &log;
}
defer {
    if (jsc_vm.transpiler.resolver.package_manager) |pm| {
        pm.log = old_log;
    }
}
\`\`\`