### PR TITLE
Fix crash in ByteBlobLoader.toBufferedValue when store is null

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,8 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    var empty: Blob.Any = .{ .Blob = Blob.initEmpty(globalThis) };
+    return empty.toPromise(globalThis, action);
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/test/js/web/streams/blob-stream-bytes.test.ts
+++ b/test/js/web/streams/blob-stream-bytes.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "bun:test";
+
+test("calling bytes() on body stream after Response.bytes() detaches the store should not crash", async () => {
+  const response = new Response("hello");
+  // Capture a reference to the body stream BEFORE consuming the response
+  const body = response.body!;
+
+  // Response.bytes() detaches the blob store from the underlying
+  // BlobInternalReadableStreamSource without closing the JS ReadableStream
+  await response.bytes();
+
+  // Calling bytes() on the body stream should not crash with
+  // "Expected an exception to be thrown" assertion failure
+  const result = await body.bytes();
+  expect(result).toBeInstanceOf(Uint8Array);
+});

--- a/test/js/web/streams/blob-stream-bytes.test.ts
+++ b/test/js/web/streams/blob-stream-bytes.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("calling bytes() on body stream after Response.bytes() detaches the store should not crash", async () => {
   const response = new Response("hello");


### PR DESCRIPTION
When `Response.bytes()` is called, it detaches the blob store from the underlying `BlobInternalReadableStreamSource` via a fast path without closing the JS-visible ReadableStream. If `body.bytes()` is subsequently called on the same stream, `toBufferedValue` finds a null store and returned `.zero` without setting a JS exception, violating the host function contract and triggering an assertion failure:

```
panic(main thread): Internal assertion failure: Expected an exception to be thrown
```

`Response.bytes()` calls `toBlobIfPossible()` → `ByteBlobLoader.toAnyBlob()`, which detaches the store (`this.store = null`). However, the JS ReadableStream is never properly closed/disturbed — `detachIfPossible()` is a no-op and `ReadableStream__detach` is commented out in `Strong.deinit()`. So subsequent calls to `body.bytes()` enter the native fast path and reach `toBufferedValue` with a null store.

The fix returns a resolved promise for an empty blob instead of `.zero` when the store has already been consumed.