### PR TITLE
Validate mock.module() first argument is a string

### DIFF
--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -511,6 +511,11 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         return {};
     }
 
+    if (!callframe->argument(0).isString()) {
+        scope.throwException(lexicalGlobalObject, JSC::createTypeError(lexicalGlobalObject, "mock(module, fn) requires a module name string"_s));
+        return {};
+    }
+
     JSC::JSString* specifierString = callframe->argument(0).toString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     WTF::String specifier = specifierString->value(globalObject);

--- a/test/js/bun/test/mock/mock-module-non-string.test.ts
+++ b/test/js/bun/test/mock/mock-module-non-string.test.ts
@@ -1,0 +1,14 @@
+import { expect, mock, test } from "bun:test";
+
+test("mock.module throws TypeError for non-string first argument", () => {
+  expect(() => mock.module(SharedArrayBuffer, () => ({}))).toThrow("mock(module, fn) requires a module name string");
+  expect(() => mock.module({}, () => ({}))).toThrow("mock(module, fn) requires a module name string");
+  expect(() => mock.module(123, () => ({}))).toThrow("mock(module, fn) requires a module name string");
+  expect(() => mock.module(Symbol("test"), () => ({}))).toThrow("mock(module, fn) requires a module name string");
+});
+
+test("mock.module still works with valid string argument", async () => {
+  mock.module("mock-module-non-string-test-fixture", () => ({ default: 42 }));
+  const m = await import("mock-module-non-string-test-fixture");
+  expect(m.default).toBe(42);
+});

--- a/test/js/bun/test/mock/mock-module-non-string.test.ts
+++ b/test/js/bun/test/mock/mock-module-non-string.test.ts
@@ -1,9 +1,13 @@
 import { expect, mock, test } from "bun:test";
 
 test("mock.module throws TypeError for non-string first argument", () => {
+  // @ts-expect-error
   expect(() => mock.module(SharedArrayBuffer, () => ({}))).toThrow("mock(module, fn) requires a module name string");
+  // @ts-expect-error
   expect(() => mock.module({}, () => ({}))).toThrow("mock(module, fn) requires a module name string");
+  // @ts-expect-error
   expect(() => mock.module(123, () => ({}))).toThrow("mock(module, fn) requires a module name string");
+  // @ts-expect-error
   expect(() => mock.module(Symbol("test"), () => ({}))).toThrow("mock(module, fn) requires a module name string");
 });
 


### PR DESCRIPTION
`mock.module()` calls `toString()` on its first argument before checking its type, then passes the result through the module resolver. When a non-string value like `SharedArrayBuffer` is passed, `toString()` produces `"function SharedArrayBuffer() { [native code] }"` which the resolver tries to auto-install as a package, crashing because the package manager's logger allocator is uninitialized in this context.

Add an `isString()` check before the `toString()` call, matching the validation pattern used by `Jest.call()` and other Bun APIs.

Crash fingerprint: `Address:unknown-crash:bun-debug+0x90074c1`