### PR TITLE
Fix exception leak in JSC__JSValue__keys

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2846,7 +2846,9 @@ bool JSC__JSValue__isStrictEqual(JSC::EncodedJSValue l, JSC::EncodedJSValue r, J
 {
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    RELEASE_AND_RETURN(scope, JSC::JSValue::strictEqual(globalObject, JSC::JSValue::decode(l), JSC::JSValue::decode(r)));
+    auto result = JSC::JSValue::strictEqual(globalObject, JSC::JSValue::decode(l), JSC::JSValue::decode(r));
+    RETURN_IF_EXCEPTION(scope, false);
+    return result;
 }
 
 bool JSC__JSValue__isSameValue(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1,
@@ -2889,7 +2891,9 @@ bool JSC__JSValue__jestDeepMatch(JSC::EncodedJSValue JSValue0, JSC::EncodedJSVal
     std::set<EncodedJSValue> objVisited;
     std::set<EncodedJSValue> subsetVisited;
     MarkedArgumentBuffer gcBuffer;
-    RELEASE_AND_RETURN(scope, Bun__deepMatch<true>(obj, &objVisited, subset, &subsetVisited, globalObject, scope, &gcBuffer, replacePropsWithAsymmetricMatchers, false));
+    auto result = Bun__deepMatch<true>(obj, &objVisited, subset, &subsetVisited, globalObject, scope, &gcBuffer, replacePropsWithAsymmetricMatchers, false);
+    RETURN_IF_EXCEPTION(scope, false);
+    return result;
 }
 
 extern "C" bool Bun__JSValue__isAsyncContextFrame(JSC::EncodedJSValue value)
@@ -3216,7 +3220,9 @@ JSC::EncodedJSValue JSC__JSValue__keys(JSC::JSGlobalObject* globalObject, JSC::E
     JSC::JSObject* object = JSC::JSValue::decode(objectValue).toObject(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(ownPropertyKeys(globalObject, object, PropertyNameMode::Strings, DontEnumPropertiesMode::Exclude)));
+    auto result = ownPropertyKeys(globalObject, object, PropertyNameMode::Strings, DontEnumPropertiesMode::Exclude);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(result);
 }
 
 JSC::EncodedJSValue JSC__JSValue__values(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue objectValue)

--- a/test/js/bun/test/expect-toBeEmptyObject-crash.test.ts
+++ b/test/js/bun/test/expect-toBeEmptyObject-crash.test.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "bun:test";
+import { bunExe, bunEnv } from "harness";
+
+test("expect().toBeEmptyObject() does not crash when called on non-empty objects", async () => {
+  // Regression test: ownPropertyKeys on certain objects could leak exceptions
+  // through RELEASE_AND_RETURN, causing a releaseAssertNoException crash.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `
+      const mod = Bun.jest(import.meta.path);
+      const e = mod.expect(mod);
+      try { e.toBeEmptyObject(); } catch (err) {}
+      console.log("ok");
+    `],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+
+  const [stdout, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout).toContain("ok");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/expect-toBeEmptyObject-crash.test.ts
+++ b/test/js/bun/test/expect-toBeEmptyObject-crash.test.ts
@@ -1,25 +1,26 @@
-import { test, expect } from "bun:test";
-import { bunExe, bunEnv } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 test("expect().toBeEmptyObject() does not crash when called on non-empty objects", async () => {
   // Regression test: ownPropertyKeys on certain objects could leak exceptions
   // through RELEASE_AND_RETURN, causing a releaseAssertNoException crash.
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       const mod = Bun.jest(import.meta.path);
       const e = mod.expect(mod);
       try { e.toBeEmptyObject(); } catch (err) {}
       console.log("ok");
-    `],
+    `,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "inherit",
   });
 
-  const [stdout, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.exited,
-  ]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
   expect(stdout).toContain("ok");
   expect(exitCode).toBe(0);


### PR DESCRIPTION
**Fingerprint:** `2ba803a8c2f7782d`

Fixes a flaky `releaseAssertNoException` crash found by Fuzzilli.

### Root cause

`JSC__JSValue__keys` used `RELEASE_AND_RETURN(scope, JSValue::encode(ownPropertyKeys(...)))`. The `RELEASE_AND_RETURN` macro calls `scope.release()` **before** evaluating the expression. If `ownPropertyKeys` throws an exception, the throw scope has already been released, so the exception leaks out. The Zig wrapper (`fromJSHostCall`) then sees a non-zero return value with a pending exception and hits the `releaseAssertNoException` assertion.

### Fix

Replace `RELEASE_AND_RETURN` with an explicit `RETURN_IF_EXCEPTION` check after `ownPropertyKeys`, so any exception is properly propagated as a zero return value.