### PR TITLE
Check for pending exceptions after Bun__Jest__testModuleObject

### DIFF
--- a/src/test_runner/jest.zig
+++ b/src/test_runner/jest.zig
@@ -293,7 +293,12 @@ pub const Jest = struct {
             }
         }
 
-        return Bun__Jest__testModuleObject(globalObject);
+        var scope: jsc.TopExceptionScope = undefined;
+        scope.init(globalObject, @src());
+        defer scope.deinit();
+        const result = Bun__Jest__testModuleObject(globalObject);
+        try scope.returnIfException();
+        return result;
     }
 
     fn jsSetDefaultTimeout(globalObject: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {

--- a/test/js/bun/test/jest-stack-overflow.test.ts
+++ b/test/js/bun/test/jest-stack-overflow.test.ts
@@ -8,27 +8,27 @@ import { bunEnv, bunExe } from "harness";
 // release builds the exception is silently consumed, so this test only
 // observably regresses under ASAN — which is what `bun bd test` uses.
 test("Bun.jest() after stack overflow does not crash", async () => {
-    await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", `
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
             function cause_overflow() { cause_overflow(); }
             try { cause_overflow(); } catch (e) {}
             try {
                 const j = Bun.jest();
                 j.expect(j).toBeValidDate();
             } catch(e) {}
-        `],
-        env: bunEnv,
-        stderr: "pipe",
-        stdout: "pipe",
-    });
+        `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-    ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toBe("");
-    expect(stdout).toBe("");
-    expect(exitCode).toBe(0);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/jest-stack-overflow.test.ts
+++ b/test/js/bun/test/jest-stack-overflow.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression for a Fuzzilli-discovered crash where Bun__Jest__testModuleObject
+// could leave a pending JSC exception on the VM after a deep stack overflow
+// during lazy module initialization. In debug/ASAN builds this tripped a
+// releaseAssertNoException on the next host-function entry (SIGABRT). In
+// release builds the exception is silently consumed, so this test only
+// observably regresses under ASAN — which is what `bun bd test` uses.
+test("Bun.jest() after stack overflow does not crash", async () => {
+    await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", `
+            function cause_overflow() { cause_overflow(); }
+            try { cause_overflow(); } catch (e) {}
+            try {
+                const j = Bun.jest();
+                j.expect(j).toBeValidDate();
+            } catch(e) {}
+        `],
+        env: bunEnv,
+        stderr: "pipe",
+        stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+    ]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Bun.jest() calls `Bun__Jest__testModuleObject` (a C++ extern) which lazily initializes the test module object. If initialization triggers a stack overflow or other exception, the exception was left pending on the VM without being propagated. This caused a `releaseAssertNoException` assertion failure when a subsequent call (like `expect().toBeValidDate()`) entered an `ExceptionValidationScope`.

Fingerprint: `9903e8ad7d0190ee`