### PR TITLE
Fix assert.partialDeepStrictEqual crashing on array inputs

### DIFF
--- a/src/js/node/assert.ts
+++ b/src/js/node/assert.ts
@@ -380,6 +380,8 @@ const SafeSetPrototypeIterator = SafeSet.prototype[SymbolIterator];
 const SafeMapPrototypeIterator = SafeMap.prototype[SymbolIterator];
 const SafeMapPrototypeHas = SafeMap.prototype.has;
 const SafeMapPrototypeGet = SafeMap.prototype.get;
+const SafeMapPrototypeSet = SafeMap.prototype.set;
+const SafeMapPrototypeDelete = SafeMap.prototype.delete;
 
 /**
  * Compares two objects or values recursively to check if they are equal.
@@ -471,13 +473,13 @@ function compareBranch(actual, expected, comparedObjects?) {
       let found = false;
       for (const { 0: key, 1: count } of expectedCounts) {
         if (isDeepStrictEqual(key, expectedItem)) {
-          expectedCounts.$set(key, count + 1);
+          SafeMapPrototypeSet.$call(expectedCounts, key, count + 1);
           found = true;
           break;
         }
       }
       if (!found) {
-        expectedCounts.$set(expectedItem, 1);
+        SafeMapPrototypeSet.$call(expectedCounts, expectedItem, 1);
       }
     }
 
@@ -486,9 +488,9 @@ function compareBranch(actual, expected, comparedObjects?) {
       for (const { 0: key, 1: count } of expectedCounts) {
         if (isDeepStrictEqual(key, actualItem)) {
           if (count === 1) {
-            expectedCounts.$delete(key);
+            SafeMapPrototypeDelete.$call(expectedCounts, key);
           } else {
-            expectedCounts.$set(key, count - 1);
+            SafeMapPrototypeSet.$call(expectedCounts, key, count - 1);
           }
           break;
         }

--- a/test/regression/issue/28522.test.ts
+++ b/test/regression/issue/28522.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("assert.partialDeepStrictEqual supports arrays", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const assert = require("node:assert/strict");
+
+      // Basic array comparison
+      assert.partialDeepStrictEqual(["foo"], ["foo"]);
+
+      // Subset check
+      assert.partialDeepStrictEqual(["foo", "bar", "baz"], ["foo", "baz"]);
+
+      // Duplicate elements
+      assert.partialDeepStrictEqual(["foo", "foo", "bar"], ["foo", "foo"]);
+
+      // Nested arrays
+      assert.partialDeepStrictEqual([["a", "b"], ["c"]], [["a", "b"]]);
+
+      // Mixed types
+      assert.partialDeepStrictEqual([1, "two", 3], [1, 3]);
+
+      // Should throw when expected is not a subset
+      assert.throws(() => {
+        assert.partialDeepStrictEqual(["foo"], ["bar"]);
+      });
+
+      // Should throw when expected has more elements
+      assert.throws(() => {
+        assert.partialDeepStrictEqual(["foo"], ["foo", "foo"]);
+      });
+
+      console.log("pass");
+      `,
+    ],
+    env: bunEnv,
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toBe("pass\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #28522

**Repro:**
```js
import assert from "node:assert/strict";
assert.partialDeepStrictEqual(["foo"], ["foo"]);
// TypeError: expectedCounts.@set is not a function
```

**Cause:** `SafeMap` instances have their prototype set to `null` by `makeSafe()`, which breaks JSC private method resolution (`.$set`, `.$delete`). The array comparison branch in `compareBranch` used `expectedCounts.$set()` and `expectedCounts.$delete()` directly, which require the prototype chain to be intact.

**Fix:** Extract uncurried `SafeMapPrototypeSet` / `SafeMapPrototypeDelete` references (matching the existing pattern for `SafeMapPrototypeGet` and `SafeMapPrototypeHas`) and call them with `.$call()`.

**Verification:**
- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28522.test.ts` → fails (bug present)
- `bun bd test test/regression/issue/28522.test.ts` → passes (fix works)