### PR TITLE
fix: clear exception before continue in property enumeration slow path

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5163,8 +5163,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
+                if (!object->getPropertySlot(globalObject, property, slot)) {
+                    // Ignore exceptions from "Get" proxy traps.
+                    CLEAR_IF_EXCEPTION(scope);
                     continue;
+                }
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
 

--- a/test/js/bun/util/inspect-proxy-prototype.test.ts
+++ b/test/js/bun/util/inspect-proxy-prototype.test.ts
@@ -49,6 +49,6 @@ test("formatting object with Proxy prototype and multiple getters where later on
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
-  expect(stdout).toContain("a:");
+  expect(stdout).toBe('{\n  a: "A",\n}\n');
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/util/inspect-proxy-prototype.test.ts
+++ b/test/js/bun/util/inspect-proxy-prototype.test.ts
@@ -1,24 +1,24 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("console.log with throwing getter behind Proxy prototype does not crash", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       const proto = { get x() { throw new Error('boom'); } };
       const obj = {};
       Object.setPrototypeOf(obj, new Proxy(proto, {}));
       console.log(obj);
-    `],
+    `,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
   expect(stdout).toBe("{}\n");
@@ -27,7 +27,10 @@ test("console.log with throwing getter behind Proxy prototype does not crash", a
 
 test("formatting object with Proxy prototype and multiple getters where later ones throw", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       let state = 0;
       const proto = {
         get a() { state = 1; return 'A'; },
@@ -36,17 +39,14 @@ test("formatting object with Proxy prototype and multiple getters where later on
       const obj = {};
       Object.setPrototypeOf(obj, new Proxy(proto, {}));
       console.log(obj);
-    `],
+    `,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
   expect(stdout).toContain("a:");

--- a/test/js/bun/util/inspect-proxy-prototype.test.ts
+++ b/test/js/bun/util/inspect-proxy-prototype.test.ts
@@ -1,24 +1,24 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("console.log with throwing getter behind Proxy prototype does not crash", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       const proto = { get x() { throw new Error('boom'); } };
       const obj = {};
       Object.setPrototypeOf(obj, new Proxy(proto, {}));
       console.log(obj);
-    `],
+    `,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toBe("{}\n");
   expect(exitCode).toBe(0);
@@ -26,7 +26,10 @@ test("console.log with throwing getter behind Proxy prototype does not crash", a
 
 test("formatting object with Proxy prototype and multiple getters where later ones throw", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       let state = 0;
       const proto = {
         get a() { state = 1; return 'A'; },
@@ -35,17 +38,14 @@ test("formatting object with Proxy prototype and multiple getters where later on
       const obj = {};
       Object.setPrototypeOf(obj, new Proxy(proto, {}));
       console.log(obj);
-    `],
+    `,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/util/inspect-proxy-prototype.test.ts
+++ b/test/js/bun/util/inspect-proxy-prototype.test.ts
@@ -1,35 +1,33 @@
-import { expect, test } from "bun:test";
+import { test, expect } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("console.log with throwing getter behind Proxy prototype does not crash", async () => {
   await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
+    cmd: [bunExe(), "-e", `
       const proto = { get x() { throw new Error('boom'); } };
       const obj = {};
       Object.setPrototypeOf(obj, new Proxy(proto, {}));
       console.log(obj);
-    `,
-    ],
+    `],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
 
+  expect(stderr).toBe("");
   expect(stdout).toBe("{}\n");
   expect(exitCode).toBe(0);
 });
 
 test("formatting object with Proxy prototype and multiple getters where later ones throw", async () => {
   await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
+    cmd: [bunExe(), "-e", `
       let state = 0;
       const proto = {
         get a() { state = 1; return 'A'; },
@@ -38,14 +36,19 @@ test("formatting object with Proxy prototype and multiple getters where later on
       const obj = {};
       Object.setPrototypeOf(obj, new Proxy(proto, {}));
       console.log(obj);
-    `,
-    ],
+    `],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
 
+  expect(stderr).toBe("");
+  expect(stdout).toContain("a:");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/util/inspect-proxy-prototype.test.ts
+++ b/test/js/bun/util/inspect-proxy-prototype.test.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("console.log with throwing getter behind Proxy prototype does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `
+      const proto = { get x() { throw new Error('boom'); } };
+      const obj = {};
+      Object.setPrototypeOf(obj, new Proxy(proto, {}));
+      console.log(obj);
+    `],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout).toBe("{}\n");
+  expect(exitCode).toBe(0);
+});
+
+test("formatting object with Proxy prototype and multiple getters where later ones throw", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `
+      let state = 0;
+      const proto = {
+        get a() { state = 1; return 'A'; },
+        get b() { if (state === 1) throw new Error('boom'); return 'B'; }
+      };
+      const obj = {};
+      Object.setPrototypeOf(obj, new Proxy(proto, {}));
+      console.log(obj);
+    `],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
When `forEachPropertyImpl` enumerates properties through a Proxy prototype, `getPropertySlot` can throw (e.g. a getter on the Proxy target throws during the Proxy's `performGet`). The code had `CLEAR_IF_EXCEPTION` **after** the `continue`, so the exception was never cleared when `getPropertySlot` returned false. The pending exception then caused `getPrototype()` on the next prototype-chain step to return a null JSValue, and `getObject()` dereferenced the null cell pointer.

Moves `CLEAR_IF_EXCEPTION` before the `continue` so exceptions from Proxy get traps are always cleared.

**Minimal repro:**
```js
const proto = { get x() { throw new Error("boom"); } };
const obj = {};
Object.setPrototypeOf(obj, new Proxy(proto, {}));
console.log(obj); // crash: member call on null pointer of type 'JSC::JSCell'
```

Crash fingerprint: `JSCJSValueCellInlines.h:92:33:member call on null pointer of type 'JSC::JSCell'`