### PR TITLE
Enable auto-install for bun build and Bun.build()

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2418,11 +2418,13 @@ pub mod bv2_impl {
             let mut had_busted_dir_cache = false;
             let resolve_result: _resolver::Result = loop {
                 // SAFETY: see `transpiler` note above.
-                match unsafe { &mut *transpiler }.resolver.resolve(
-                    source_dir,
-                    &import_record.specifier,
-                    import_record.kind,
-                ) {
+                match unsafe { &mut *transpiler }
+                    .resolver
+                    .resolve_with_global_cache(
+                        source_dir,
+                        &import_record.specifier,
+                        import_record.kind,
+                    ) {
                     Ok(r) => break r,
                     Err(err) => {
                         // Only perform directory busting when hot-reloading is enabled
@@ -6398,7 +6400,7 @@ pub mod bv2_impl {
 
                 let mut had_busted_dir_cache = false;
                 let resolve_result: _resolver::Result = 'inner: loop {
-                    match transpiler.resolver.resolve_with_framework(
+                    match transpiler.resolver.resolve_with_framework_and_global_cache(
                         source_dir,
                         import_record.path.text,
                         import_record.kind,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -190,6 +190,7 @@ impl<'a> Transpiler<'a> {
         if let Some(ctx) = self.macro_context.take() {
             ctx.deinit();
         }
+        self.resolver.clear_package_manager_handler();
         // SAFETY: `options`, `result`, and `resolver.opts` are init'd and never
         // read past `destroy()` / the `--changed` scan teardown. Caller upholds
         // the no-auto-drop contract above.

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -190,7 +190,6 @@ impl<'a> Transpiler<'a> {
         if let Some(ctx) = self.macro_context.take() {
             ctx.deinit();
         }
-        self.resolver.clear_package_manager_handler();
         // SAFETY: `options`, `result`, and `resolver.opts` are init'd and never
         // read past `destroy()` / the `--changed` scan teardown. Caller upholds
         // the no-auto-drop contract above.

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -714,6 +714,7 @@ impl<'a> Parser<'a> {
             || cmd == CommandTag::RunCommand
             || cmd == CommandTag::AutoCommand
             || cmd == CommandTag::TestCommand
+            || cmd == CommandTag::BuildCommand
         {
             if let Some(install_obj) = json.get_object(b"install") {
                 // Ensure ctx.install is allocated so later passes can write into it

--- a/src/event_loop/AnyEventLoop.rs
+++ b/src/event_loop/AnyEventLoop.rs
@@ -28,6 +28,10 @@ unsafe extern "Rust" {
     /// for the current thread. Kept as a bare extern (no owner). No caller-side
     /// preconditions: panics (not UB) if no VM is bound on this thread.
     pub(crate) safe fn __bun_js_event_loop_current() -> *mut ();
+
+    /// Like `__bun_js_event_loop_current`, but returns null instead of
+    /// panicking when no VM is bound on this thread.
+    pub(crate) safe fn __bun_js_event_loop_current_or_null() -> *mut ();
 }
 
 /// Wrap an erased `*mut jsc::EventLoop` in a
@@ -116,6 +120,17 @@ impl AnyEventLoop {
     pub fn js_current() -> AnyEventLoop {
         AnyEventLoop::Js {
             owner: JsEventLoop::current(),
+        }
+    }
+
+    /// Like `js_current`, but falls back to a fresh `Mini` event loop when
+    /// no VM is bound on the calling thread.
+    pub fn js_current_or_mini() -> AnyEventLoop {
+        let ptr = __bun_js_event_loop_current_or_null();
+        if ptr.is_null() {
+            AnyEventLoop::Mini(Box::new(MiniEventLoop::init()))
+        } else {
+            AnyEventLoop::js(ptr)
         }
     }
 

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -910,6 +910,18 @@ impl PackageManager {
                     err.name(),
                 );
             }
+        } else {
+            // No JS-side handler (bun build CLI): log the failure detail.
+            self.log_mut().add_error_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!(
+                    "{} resolving \"{}@{}\"",
+                    err.name(),
+                    bstr::BStr::new(self.lockfile.str(&dependency.name)),
+                    bstr::BStr::new(self.lockfile.str(&dependency.version.literal)),
+                ),
+            );
         }
     }
 
@@ -2391,6 +2403,7 @@ pub(crate) fn init_with_runtime(
     cli: CommandLineArguments,
     env: &mut dot_env::Loader,
 ) -> crate::Result<*mut PackageManager> {
+    let log_ptr: *mut bun_ast::Log = log;
     // NB: not `bun_core::run_once!` — the body is fallible (reading the root
     // directory hits ENOENT/EACCES at runtime when the cwd was deleted or is
     // unreadable), and the failure must be sticky: `holder::RAW_PTR` stays
@@ -2404,7 +2417,15 @@ pub(crate) fn init_with_runtime(
         }
     });
     match *INIT_ERROR.lock() {
-        None => Ok(get()),
+        None => {
+            let pm = get();
+            // Refresh the log on every call; the first caller's log may
+            // since have been freed.
+            // SAFETY: `pm` is the process-lifetime singleton; `log_ptr`
+            // outlives this call.
+            unsafe { (*pm).log = log_ptr };
+            Ok(pm)
+        }
         Some(code) => Err(code),
     }
 }
@@ -2523,9 +2544,9 @@ fn init_with_runtime_once(
             root_package_json_file,
             bun_sys::File::from_fd(Fd::invalid())
         );
-        // erased *mut () set by tier-6; `js_current()` resolves the per-thread JS
-        // event loop via `bun_io::__bun_get_vm_ctx` (link-time, definer in bun_runtime).
-        wr!(event_loop, AnyEventLoop::js_current());
+        // Falls back to a MiniEventLoop on VM-less threads (bun build CLI,
+        // bundler worker).
+        wr!(event_loop, AnyEventLoop::js_current_or_mini());
         wr!(
             original_package_json_path,
             ZBox::from_vec_with_nul(original_package_json_path)
@@ -2611,6 +2632,21 @@ fn init_with_runtime_once(
     let manager = unsafe { &mut *manager_ptr };
     // The lockfile allocation is folded into the struct literal above
     // (`Box::new(Lockfile::default())`).
+
+    // Mini fallback: wire the parent loop and thread-local global, mirroring
+    // `init()` above.
+    if matches!(manager.event_loop, AnyEventLoop::Mini(_)) {
+        let uws_loop = manager.event_loop.r#loop();
+        // SAFETY: `uws_loop` is the live process-global `uws::Loop` just
+        // returned by `r#loop()`; backref is `manager.event_loop` owned by the
+        // singleton.
+        let uws_loop = unsafe { &mut *uws_loop };
+        EventLoopHandle::from_any(&mut manager.event_loop).set_as_parent_of(uws_loop);
+        if let AnyEventLoop::Mini(mini) = &mut manager.event_loop {
+            let mini_ptr: *mut MiniEventLoop = &raw mut **mini;
+            mini_event_loop::GLOBAL.with(|g| g.set(mini_ptr));
+        }
+    }
 
     if Output::enable_ansi_colors_stderr() {
         manager.progress = Progress::default();

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -899,19 +899,23 @@ impl PackageManager {
         dependency_id: DependencyID,
         err: Error,
     ) {
-        if let Some(ctx) = self.on_wake.context {
-            // SAFETY: `ctx` is the `WakeHandler::context` registered alongside
-            // this callback (a live `*mut Queue`); see `runtime::jsc_hooks`.
+        let handled = if let Some(ctx) = self.on_wake.context {
+            // SAFETY: the callback (`runtime::jsc_hooks`) validates `ctx` by
+            // address against its own thread's context before any deref.
             unsafe {
                 (self.on_wake.get_on_dependency_error())(
                     ctx.as_ptr(),
                     dependency,
                     dependency_id,
                     err.name(),
-                );
+                )
             }
         } else {
-            // No JS-side handler (bun build CLI): log the failure detail.
+            false
+        };
+        if !handled {
+            // No JS-side queue took the error (bun build CLI, or a bundle
+            // thread): log the failure detail.
             self.log_mut().add_error_fmt(
                 None,
                 bun_ast::Loc::EMPTY,

--- a/src/install/auto_installer.rs
+++ b/src/install/auto_installer.rs
@@ -311,6 +311,14 @@ impl hooks::AutoInstaller for PackageManager {
         self.on_wake = handler;
     }
 
+    fn on_wake_context(&self) -> Option<core::ptr::NonNull<core::ffi::c_void>> {
+        self.on_wake.context
+    }
+
+    fn set_log(&mut self, log: *mut bun_ast::Log) {
+        self.log = log;
+    }
+
     fn path_for_resolution<'b>(
         &mut self,
         package_id: PackageID,

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1450,6 +1450,11 @@ pub trait AutoInstaller {
 
     // ── PackageManager ops ────────────────────────────────────────────────
     fn set_on_wake(&mut self, handler: WakeHandler);
+    /// Current `on_wake.context`, so a caller can avoid clobbering a
+    /// registered handler.
+    fn on_wake_context(&self) -> Option<NonNull<c_void>>;
+    /// Repoint the singleton's error log at the caller's live log.
+    fn set_log(&mut self, log: *mut bun_ast::Log);
     fn path_for_resolution<'b>(
         &mut self,
         package_id: PackageID,

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1292,8 +1292,10 @@ pub struct TaskCallbackContext {
 pub struct WakeHandler {
     pub context: Option<NonNull<c_void>>,
     pub handler: Option<fn(*mut c_void, *mut c_void)>,
+    /// Returns true if it dispatched the error to a JS-side queue; false
+    /// tells the caller to report the failure itself.
     pub on_dependency_error:
-        Option<unsafe fn(*mut c_void, &Dependency, DependencyID, &'static str)>,
+        Option<unsafe fn(*mut c_void, &Dependency, DependencyID, &'static str) -> bool>,
 }
 
 impl WakeHandler {
@@ -1310,7 +1312,7 @@ impl WakeHandler {
     #[inline]
     pub fn get_on_dependency_error(
         &self,
-    ) -> unsafe fn(*mut c_void, &Dependency, DependencyID, &'static str) {
+    ) -> unsafe fn(*mut c_void, &Dependency, DependencyID, &'static str) -> bool {
         // Same invariant as `get_handler`: set together with `context` by the
         // sole installer; callers gate on `context.is_some()`.
         self.on_dependency_error.unwrap()

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1502,6 +1502,20 @@ pub(crate) fn __bun_js_event_loop_current() -> *mut () {
     VirtualMachine::get().as_mut().event_loop().cast()
 }
 
+/// Null-returning variant of [`__bun_js_event_loop_current`]: the live
+/// per-thread `*mut jsc::EventLoop`, or null when no VM is bound.
+#[unsafe(no_mangle)]
+pub(crate) fn __bun_js_event_loop_current_or_null() -> *mut () {
+    match VirtualMachine::get_or_null() {
+        Some(vm) => {
+            // SAFETY: `get_or_null` returned `Some`, so the pointer names a
+            // live per-thread VM; `event_loop()` reads the self-pointer.
+            unsafe { (*vm).event_loop().cast() }
+        }
+        None => core::ptr::null_mut(),
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // `bun_event_loop::SpawnSyncEventLoop` extern impls
 //

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -826,23 +826,57 @@ impl<'a> Resolver<'a> {
     /// directory was deleted or is unreadable — callers surface that as a
     /// resolve failure rather than panicking.
     pub fn get_package_manager(&mut self) -> crate::CrateResult<*mut dyn AutoInstaller> {
-        if let Some(pm) = self.package_manager {
-            return Ok(pm.as_ptr());
+        let pm = match self.package_manager {
+            Some(pm) => pm,
+            None => {
+                let env: NonNull<DotEnv::Loader> = self
+                    .env_loader
+                    .expect("Resolver.env_loader must be set before auto-install");
+                // SAFETY: `__bun_resolver_init_package_manager` is defined
+                // `#[no_mangle]` in `bun_install::auto_installer` and linked
+                // into the final binary; `self.log` / `self.opts.install` /
+                // `env` point at process-lifetime storage (Transpiler-owned).
+                // The returned pointer names the `PackageManager` singleton.
+                let pm: NonNull<dyn AutoInstaller> = unsafe {
+                    __bun_resolver_init_package_manager(self.log, self.opts.install, env)
+                }?;
+                self.package_manager = Some(pm);
+                pm
+            }
+        };
+        // Re-point the singleton's log at this resolver's live one before
+        // each wave; an earlier caller's log may have been freed.
+        // SAFETY: `pm` names the process-static singleton; sole `&mut` here.
+        unsafe { (*pm.as_ptr()).set_log(self.log.as_ptr()) };
+        // `wake_raw` reads `on_wake` lock-free from HTTP/task threads, so
+        // leave it untouched unless this resolver has a handler and it is
+        // not the installed one.
+        // SAFETY: as above.
+        let installed = unsafe { (*pm.as_ptr()).on_wake_context() };
+        if self.on_wake_package_manager.context.is_some()
+            && installed != self.on_wake_package_manager.context
+        {
+            // SAFETY: as above.
+            unsafe { (*pm.as_ptr()).set_on_wake(self.on_wake_package_manager) };
         }
-        let env: NonNull<DotEnv::Loader> = self
-            .env_loader
-            .expect("Resolver.env_loader must be set before auto-install");
-        // SAFETY: `__bun_resolver_init_package_manager` is defined
-        // `#[no_mangle]` in `bun_install::auto_installer` and linked into the
-        // final binary; `self.log` / `self.opts.install` / `env` point at
-        // process-lifetime storage (Transpiler-owned). The returned pointer
-        // names the `PackageManager` singleton (`'static`).
-        let pm: NonNull<dyn AutoInstaller> =
-            unsafe { __bun_resolver_init_package_manager(self.log, self.opts.install, env) }?;
-        // SAFETY: `pm` is the just-initialized singleton; sole `&mut` here.
-        unsafe { (*pm.as_ptr()).set_on_wake(self.on_wake_package_manager) };
-        self.package_manager = Some(pm);
         Ok(pm.as_ptr())
+    }
+
+    /// Uninstall this resolver's `WakeHandler` from the singleton (called
+    /// from `Transpiler::deinit`, before the VM's `WakeContext` is freed).
+    pub fn clear_package_manager_handler(&mut self) {
+        let Some(ctx) = self.on_wake_package_manager.context else {
+            return;
+        };
+        let Some(pm) = self.package_manager else {
+            return;
+        };
+        // SAFETY: `pm` names the process-static singleton; sole `&mut` here.
+        unsafe {
+            if (*pm.as_ptr()).on_wake_context() == Some(ctx) {
+                (*pm.as_ptr()).set_on_wake(Install::WakeHandler::default());
+            }
+        }
     }
 
     /// Safe accessor for the optional [`AutoInstaller`] back-reference.
@@ -1489,11 +1523,45 @@ impl<'a> Resolver<'a> {
         import_path: &[u8],
         kind: ast::ImportKind,
     ) -> crate::CrateResult<Result> {
-        match self.resolve_and_auto_install(source_dir, import_path, kind, GlobalCache::disable) {
+        self.resolve_inner(source_dir, import_path, kind, GlobalCache::disable)
+    }
+
+    /// Like `resolve`, but uses the configured `global_cache` setting to
+    /// allow auto-installing packages from the global cache or npm.
+    pub fn resolve_with_global_cache(
+        &mut self,
+        source_dir: &[u8],
+        import_path: &[u8],
+        kind: ast::ImportKind,
+    ) -> crate::CrateResult<Result> {
+        let global_cache = self.opts.global_cache;
+        self.resolve_inner(source_dir, import_path, kind, global_cache)
+    }
+
+    fn resolve_inner(
+        &mut self,
+        source_dir: &[u8],
+        import_path: &[u8],
+        kind: ast::ImportKind,
+        global_cache: GlobalCache,
+    ) -> crate::CrateResult<Result> {
+        match self.resolve_and_auto_install(source_dir, import_path, kind, global_cache) {
             ResultUnion::Success(result) => Ok(result),
             ResultUnion::Pending(_) | ResultUnion::NotFound => Err(crate::Error::ModuleNotFound),
             ResultUnion::Failure(e) => Err(e),
         }
+    }
+
+    /// Like `resolve_with_framework`, but uses the configured `global_cache`
+    /// setting to allow auto-installing packages from the global cache or npm.
+    pub fn resolve_with_framework_and_global_cache(
+        &mut self,
+        source_dir: &[u8],
+        import_path: &[u8],
+        kind: ast::ImportKind,
+    ) -> crate::CrateResult<Result> {
+        let global_cache = self.opts.global_cache;
+        self.resolve_with_framework_inner(source_dir, import_path, kind, global_cache)
     }
 
     /// Runs a resolution but also checking if a Bun Bake framework has an
@@ -1503,6 +1571,16 @@ impl<'a> Resolver<'a> {
         source_dir: &[u8],
         import_path: &[u8],
         kind: ast::ImportKind,
+    ) -> crate::CrateResult<Result> {
+        self.resolve_with_framework_inner(source_dir, import_path, kind, GlobalCache::disable)
+    }
+
+    fn resolve_with_framework_inner(
+        &mut self,
+        source_dir: &[u8],
+        import_path: &[u8],
+        kind: ast::ImportKind,
+        global_cache: GlobalCache,
     ) -> crate::CrateResult<Result> {
         // SAFETY: `import_path` is caller-interned (source text / DirnameStore)
         // and outlives the returned Result. TODO: thread an explicit lifetime.
@@ -1526,18 +1604,23 @@ impl<'a> Resolver<'a> {
                     }
                     bun_options_types::BuiltInModule::Import(path) => {
                         // NOTE: copy out `path` so the `&self.opts.framework` borrow
-                        // ends before `self.resolve(&mut self, ...)`.
+                        // ends before `self.resolve_inner(&mut self, ...)`.
                         // SAFETY: `path` borrows `self.opts.framework`, which lives for the
                         // resolver's lifetime; the `'static` erase only releases the `&self` borrow.
                         let path: &'static [u8] =
                             unsafe { &*std::ptr::from_ref::<[u8]>(path.as_ref()) };
                         let top = self.fs_ref().top_level_dir;
-                        return self.resolve(top, path, ast::ImportKind::EntryPointBuild);
+                        return self.resolve_inner(
+                            top,
+                            path,
+                            ast::ImportKind::EntryPointBuild,
+                            global_cache,
+                        );
                     }
                 }
             }
         }
-        self.resolve(source_dir, import_path, kind)
+        self.resolve_inner(source_dir, import_path, kind, global_cache)
     }
 
     pub(crate) fn finalize_result(

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -862,23 +862,6 @@ impl<'a> Resolver<'a> {
         Ok(pm.as_ptr())
     }
 
-    /// Uninstall this resolver's `WakeHandler` from the singleton (called
-    /// from `Transpiler::deinit`, before the VM's `WakeContext` is freed).
-    pub fn clear_package_manager_handler(&mut self) {
-        let Some(ctx) = self.on_wake_package_manager.context else {
-            return;
-        };
-        let Some(pm) = self.package_manager else {
-            return;
-        };
-        // SAFETY: `pm` names the process-static singleton; sole `&mut` here.
-        unsafe {
-            if (*pm.as_ptr()).on_wake_context() == Some(ctx) {
-                (*pm.as_ptr()).set_on_wake(Install::WakeHandler::default());
-            }
-        }
-    }
-
     /// Safe accessor for the optional [`AutoInstaller`] back-reference.
     ///
     /// Single `unsafe` deref site for the `package_manager:

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -87,6 +87,10 @@ pub struct JSBundleCompletionTask {
     pub(crate) transpiler: *mut BundleV2<'static>,
     pub(crate) plugins: Option<NonNull<Plugin>>,
     pub(crate) started_at_ns: u64,
+    /// Auto-install config captured from the VM's transpiler.
+    pub(crate) global_cache: options::GlobalCache,
+    pub(crate) install: Option<NonNull<api::BunInstall>>,
+    pub(crate) install_preference: options::OfflineMode,
 }
 
 #[repr(u8)]
@@ -143,6 +147,7 @@ impl JSBundleCompletionTask {
         plugins: Option<NonNull<Plugin>>,
         global_this: &JSGlobalObject,
     ) -> JSBundleCompletionTask {
+        let vm_opts = &global_this.bun_vm().transpiler.options;
         JSBundleCompletionTask {
             ref_count: RefCount::init(),
             config,
@@ -161,6 +166,9 @@ impl JSBundleCompletionTask {
             transpiler: ptr::null_mut(),
             plugins,
             started_at_ns: 0,
+            global_cache: vm_opts.global_cache,
+            install: vm_opts.install,
+            install_preference: vm_opts.install_preference,
         }
     }
 
@@ -1080,6 +1088,10 @@ impl CompletionStruct for JSBundleCompletionTask {
             // Emitting DCE annotations is nonsensical in --compile.
             transpiler.options.emit_dce_annotations = false;
         }
+
+        transpiler.options.global_cache = self.global_cache;
+        transpiler.options.install = self.install;
+        transpiler.options.install_preference = self.install_preference;
 
         transpiler.configure_linker();
         transpiler.configure_defines()?;

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -252,6 +252,14 @@ impl BuildCommand {
 
         this_transpiler.options.bytecode = ctx.bundler_options.bytecode;
         this_transpiler.options.bytecode_depth = ctx.bundler_options.bytecode_depth;
+
+        this_transpiler.options.install = ctx.install.as_deref().map(core::ptr::NonNull::from);
+        this_transpiler.options.global_cache = ctx.debug.global_cache;
+        this_transpiler.options.install_preference = ctx
+            .debug
+            .offline_mode_setting
+            .unwrap_or(bun_options_types::offline_mode::OfflineMode::Online);
+
         let mut was_renamed_from_index = false;
 
         if ctx.bundler_options.compile {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -493,30 +493,37 @@ unsafe fn init_runtime_state(
                                 dep: &bun_resolver::install_types::Dependency,
                                 id: bun_resolver::install_types::DependencyID,
                                 err: &'static str,
-                            ) {
-                                // `Queue` is JS-thread-affine: dispatch only on its owning VM's thread.
-                                let Some(vm) = VirtualMachine::get_or_null() else {
-                                    return;
-                                };
-                                // SAFETY: `ctx` is some VM's live `WakeContext` (whichever
-                                // resolver last set the singleton's handler); the check
-                                // below rejects one that is not this thread's VM's.
-                                let queue = unsafe {
-                                    bun_jsc::async_module::Queue::queue_from_wake_context(ctx)
-                                };
-                                // SAFETY: `vm` is this thread's live VM.
-                                if queue != unsafe { &raw mut (*vm).modules } {
-                                    return;
+                            ) -> bool {
+                                // `ctx` may name another VM's (possibly freed)
+                                // `WakeContext`: compare addresses against this
+                                // thread's own before any deref.
+                                let state = runtime_state();
+                                if state.is_null() {
+                                    return false;
                                 }
-                                // SAFETY: queue identity checked above.
+                                // SAFETY: `state` is this thread's live `RuntimeState`.
+                                let Some(my_ctx) = (unsafe { (*state).wake_ctx.as_deref() })
+                                else {
+                                    return false;
+                                };
+                                if !core::ptr::eq(
+                                    ctx.cast_const()
+                                        .cast::<bun_jsc::async_module::WakeContext>(),
+                                    core::ptr::from_ref(my_ctx),
+                                ) {
+                                    return false;
+                                }
+                                // SAFETY: `ctx` is this thread's own live
+                                // `WakeContext`; its queue is this VM's module queue.
                                 unsafe {
                                     bun_jsc::async_module::Queue::on_dependency_error(
-                                        queue.cast(),
+                                        my_ctx.queue.cast(),
                                         dep,
                                         id,
                                         err,
-                                    )
+                                    );
                                 }
+                                true
                             }
                             adapter
                         }),

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -494,11 +494,24 @@ unsafe fn init_runtime_state(
                                 id: bun_resolver::install_types::DependencyID,
                                 err: &'static str,
                             ) {
-                                // SAFETY: `ctx` is the `WakeContext` set just above; its queue is `(*vm).modules`.
+                                // `Queue` is JS-thread-affine: dispatch only on its owning VM's thread.
+                                let Some(vm) = VirtualMachine::get_or_null() else {
+                                    return;
+                                };
+                                // SAFETY: `ctx` is some VM's live `WakeContext` (whichever
+                                // resolver last set the singleton's handler); the check
+                                // below rejects one that is not this thread's VM's.
+                                let queue = unsafe {
+                                    bun_jsc::async_module::Queue::queue_from_wake_context(ctx)
+                                };
+                                // SAFETY: `vm` is this thread's live VM.
+                                if queue != unsafe { &raw mut (*vm).modules } {
+                                    return;
+                                }
+                                // SAFETY: queue identity checked above.
                                 unsafe {
                                     bun_jsc::async_module::Queue::on_dependency_error(
-                                        bun_jsc::async_module::Queue::queue_from_wake_context(ctx)
-                                            .cast(),
+                                        queue.cast(),
                                         dep,
                                         id,
                                         err,

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -502,8 +502,7 @@ unsafe fn init_runtime_state(
                                     return false;
                                 }
                                 // SAFETY: `state` is this thread's live `RuntimeState`.
-                                let Some(my_ctx) = (unsafe { (*state).wake_ctx.as_deref() })
-                                else {
+                                let Some(my_ctx) = (unsafe { (*state).wake_ctx.as_deref() }) else {
                                     return false;
                                 };
                                 if !core::ptr::eq(

--- a/test/regression/issue/28527.test.ts
+++ b/test/regression/issue/28527.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test.concurrent("Bun.build auto-installs dependencies without package.json", { timeout: 30_000 }, async () => {
+  using dir = tempDir("issue-28527", {
+    "entry.ts": `import isOdd from "is-odd"; console.log(isOdd(3));`,
+    "build.ts": `
+const result = await Bun.build({
+  entrypoints: ["./entry.ts"],
+  outdir: "./out",
+});
+if (!result.success) {
+  for (const msg of result.logs) console.error(msg);
+  process.exit(1);
+}
+console.log("BUILD_OK");
+`,
+  });
+
+  const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: `${String(dir)}/cache` };
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build.ts"],
+    env,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("Could not resolve");
+  expect(stdout).toContain("BUILD_OK");
+  expect(exitCode).toBe(0);
+
+  // The bundle must actually contain is-odd and run standalone.
+  await using run = Bun.spawn({
+    cmd: [bunExe(), `${String(dir)}/out/entry.js`],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+  expect(runErr).toBe("");
+  expect(runOut.trim()).toBe("true");
+  expect(runExit).toBe(0);
+});
+
+test.concurrent("bun build CLI auto-installs dependencies without package.json", { timeout: 30_000 }, async () => {
+  using dir = tempDir("issue-28527-cli", {
+    "entry.ts": `import isOdd from "is-odd"; console.log(isOdd(3));`,
+  });
+
+  const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: `${String(dir)}/cache` };
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "entry.ts", "--outdir", "./out"],
+    env,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("Could not resolve");
+  expect(exitCode).toBe(0);
+
+  // The bundle must actually contain is-odd and run standalone.
+  await using run = Bun.spawn({
+    cmd: [bunExe(), `${String(dir)}/out/entry.js`],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+  expect(runErr).toBe("");
+  expect(runOut.trim()).toBe("true");
+  expect(runExit).toBe(0);
+});

--- a/test/regression/issue/28527.test.ts
+++ b/test/regression/issue/28527.test.ts
@@ -1,9 +1,86 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
+// Auto-install for `bun build` / `Bun.build()` (issue #28527), served from a
+// local registry so the test never contacts npm. The package below provides
+// `isOdd`; each test builds an entry that imports it, then runs the bundle
+// with --no-install so runtime auto-install cannot mask a bad bundle.
+
+const pkgName = "pkg-28527";
+const pkgVersion = "1.0.0";
+
+/** One USTAR tar entry (header + zero-padded data blocks). */
+function tarEntry(name: string, content: Buffer): Buffer {
+  const header = Buffer.alloc(512, 0);
+  header.write(name, 0);
+  header.write("0000644\0", 100); // mode
+  header.write("0001000\0", 108); // uid
+  header.write("0001000\0", 116); // gid
+  header.write(content.length.toString(8).padStart(11, "0") + "\0", 124); // size
+  header.write("00000000000\0", 136); // mtime
+  header.write("        ", 148); // checksum placeholder
+  header.write("0", 156); // typeflag: regular file
+  header.write("ustar\0", 257);
+  header.write("00", 263);
+  let checksum = 0;
+  for (let i = 0; i < 512; i++) checksum += header[i];
+  header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148);
+  const data = Buffer.alloc(Math.ceil(content.length / 512) * 512, 0);
+  content.copy(data);
+  return Buffer.concat([header, data]);
+}
+
+function createTarball(files: Record<string, string>): Buffer {
+  const parts = Object.entries(files).map(([name, content]) => tarEntry(name, Buffer.from(content)));
+  parts.push(Buffer.alloc(1024, 0)); // end-of-archive
+  return Buffer.from(Bun.gzipSync(Buffer.concat(parts)));
+}
+
+const tarball = createTarball({
+  "package/package.json": JSON.stringify({ name: pkgName, version: pkgVersion, main: "index.js" }),
+  "package/index.js": "module.exports = function isOdd(n) { return n % 2 === 1; };\n",
+});
+const shasum = new Bun.CryptoHasher("sha1").update(tarball).digest("hex");
+const integrity = "sha512-" + new Bun.CryptoHasher("sha512").update(tarball).digest("base64");
+
+function startRegistry(requests: string[]) {
+  const registry = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const path = new URL(req.url).pathname;
+      requests.push(path);
+      if (path.endsWith(".tgz")) {
+        return new Response(tarball);
+      }
+      if (path === `/${pkgName}`) {
+        return Response.json({
+          name: pkgName,
+          "dist-tags": { latest: pkgVersion },
+          versions: {
+            [pkgVersion]: {
+              name: pkgName,
+              version: pkgVersion,
+              dist: {
+                tarball: `http://127.0.0.1:${registry.port}/${pkgName}/-/${pkgName}-${pkgVersion}.tgz`,
+                shasum,
+                integrity,
+              },
+            },
+          },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  return registry;
+}
+
 test.concurrent("Bun.build auto-installs dependencies without package.json", { timeout: 30_000 }, async () => {
+  const requests: string[] = [];
+  using registry = startRegistry(requests);
+
   using dir = tempDir("issue-28527", {
-    "entry.ts": `import isOdd from "is-odd"; console.log(isOdd(3));`,
+    "entry.ts": `import isOdd from "${pkgName}"; console.log(isOdd(3));`,
     "build.ts": `
 const result = await Bun.build({
   entrypoints: ["./entry.ts"],
@@ -15,6 +92,7 @@ if (!result.success) {
 }
 console.log("BUILD_OK");
 `,
+    "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${registry.port}/"\n`,
   });
 
   const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: `${String(dir)}/cache` };
@@ -31,8 +109,9 @@ console.log("BUILD_OK");
   expect(stderr).not.toContain("Could not resolve");
   expect(stdout).toContain("BUILD_OK");
   expect(exitCode).toBe(0);
+  expect(requests).toContain(`/${pkgName}`);
 
-  // The bundle must actually contain is-odd and run standalone:
+  // The bundle must actually contain the package and run standalone:
   // --no-install keeps runtime auto-install from masking a bad bundle.
   await using run = Bun.spawn({
     cmd: [bunExe(), "--no-install", `${String(dir)}/out/entry.js`],
@@ -46,8 +125,12 @@ console.log("BUILD_OK");
 });
 
 test.concurrent("bun build CLI auto-installs dependencies without package.json", { timeout: 30_000 }, async () => {
+  const requests: string[] = [];
+  using registry = startRegistry(requests);
+
   using dir = tempDir("issue-28527-cli", {
-    "entry.ts": `import isOdd from "is-odd"; console.log(isOdd(3));`,
+    "entry.ts": `import isOdd from "${pkgName}"; console.log(isOdd(3));`,
+    "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${registry.port}/"\n`,
   });
 
   const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: `${String(dir)}/cache` };
@@ -63,8 +146,9 @@ test.concurrent("bun build CLI auto-installs dependencies without package.json",
 
   expect(stderr).not.toContain("Could not resolve");
   expect(exitCode).toBe(0);
+  expect(requests).toContain(`/${pkgName}`);
 
-  // The bundle must actually contain is-odd and run standalone:
+  // The bundle must actually contain the package and run standalone:
   // --no-install keeps runtime auto-install from masking a bad bundle.
   await using run = Bun.spawn({
     cmd: [bunExe(), "--no-install", `${String(dir)}/out/entry.js`],

--- a/test/regression/issue/28527.test.ts
+++ b/test/regression/issue/28527.test.ts
@@ -32,10 +32,11 @@ console.log("BUILD_OK");
   expect(stdout).toContain("BUILD_OK");
   expect(exitCode).toBe(0);
 
-  // The bundle must actually contain is-odd and run standalone.
+  // The bundle must actually contain is-odd and run standalone:
+  // --no-install keeps runtime auto-install from masking a bad bundle.
   await using run = Bun.spawn({
-    cmd: [bunExe(), `${String(dir)}/out/entry.js`],
-    env: bunEnv,
+    cmd: [bunExe(), "--no-install", `${String(dir)}/out/entry.js`],
+    env,
     stderr: "pipe",
   });
   const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
@@ -63,10 +64,11 @@ test.concurrent("bun build CLI auto-installs dependencies without package.json",
   expect(stderr).not.toContain("Could not resolve");
   expect(exitCode).toBe(0);
 
-  // The bundle must actually contain is-odd and run standalone.
+  // The bundle must actually contain is-odd and run standalone:
+  // --no-install keeps runtime auto-install from masking a bad bundle.
   await using run = Bun.spawn({
-    cmd: [bunExe(), `${String(dir)}/out/entry.js`],
-    env: bunEnv,
+    cmd: [bunExe(), "--no-install", `${String(dir)}/out/entry.js`],
+    env,
     stderr: "pipe",
   });
   const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);

--- a/test/regression/issue/28527.test.ts
+++ b/test/regression/issue/28527.test.ts
@@ -75,7 +75,7 @@ function startRegistry(requests: string[]) {
   return registry;
 }
 
-test.concurrent("Bun.build auto-installs dependencies without package.json", { timeout: 30_000 }, async () => {
+test.concurrent("Bun.build auto-installs dependencies without package.json", async () => {
   const requests: string[] = [];
   using registry = startRegistry(requests);
 
@@ -124,7 +124,7 @@ console.log("BUILD_OK");
   expect(runExit).toBe(0);
 });
 
-test.concurrent("bun build CLI auto-installs dependencies without package.json", { timeout: 30_000 }, async () => {
+test.concurrent("bun build CLI auto-installs dependencies without package.json", async () => {
   const requests: string[] = [];
   using registry = startRegistry(requests);
 


### PR DESCRIPTION
Fixes #28527

### Problem
- `bun build` and `Bun.build()` fail with `Could not resolve: "is-odd". Maybe you need to "bun install"?` when no package.json or node_modules exists. The runtime auto-installs from the global cache, the bundler does not.
- Three causes: `BundleOptions.global_cache` is never set from the CLI context or the VM, the bundler resolves through `Resolver::resolve` (src/resolver/resolver.rs), which hardcodes the disabled mode, and `PackageManager::init_with_runtime_once` assumes a VM event loop.

### Fix
- Add `resolve_with_global_cache` and `resolve_with_framework_and_global_cache`, and use them for bundler import records, so the bundler honors the configured install mode.
- Propagate `global_cache`, `install`, and `install_preference` from the CLI context (build_command.rs) and from the VM (JSBundleCompletionTask) into the transpiler options. bunfig's `[install]` section now also applies to `bun build`.
- `init_with_runtime_once` falls back to a `MiniEventLoop` on VM-less threads.
- Harden the singleton backrefs for the new callers: the resolver re-points the manager's log per wave and writes the wake handler only when it differs. The error adapter validates its context by address before any deref and returns whether it dispatched, so CLI and bundle-thread failures are logged instead of dropped.
- Verified: test/regression/issue/28527.test.ts (the build output runs with `--no-install` so runtime auto-install cannot mask a bad bundle), plus run-autoinstall.test.ts and autoinstall-cached-manifest.test.ts.

### Background
- Auto-install: when a bare import misses node_modules, the resolver asks the process-wide `PackageManager` singleton to fetch the package into the global cache and resolves from there. The runtime already does this. This PR extends it to the bundler.
- The singleton keeps two backrefs into its caller: an error log and a `WakeHandler`, a per-VM context that wakes the JS module queue when a download finishes. HTTP threads read the handler lock-free, so the resolver avoids writes to it on the steady path.
- Scope note: the singleton binds one event loop and one wake handler. Lifecycle safety under several VMs or concurrent install waves is a pre-existing design issue, tracked in #31934, and is not changed here.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 30 · 12 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/28527.test.ts"
bun test v1.4.1 (731aa92da)

test/regression/issue/28527.test.ts:
142 |     stderr: "pipe",
143 |   });
144 | 
145 |   const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
146 | 
147 |   expect(stderr).not.toContain("Could not resolve");
                           ^
error: expect(received).not.toContain(expected)

Expected to not contain: "Could not resolve"
Received: "1 | import isOdd from \"pkg-28527\"; console.log(isOdd(3));\n                      ^\nerror: Could not resolve: \"pkg-28527\". Maybe you need to \"bun install\"?\n    at /tmp/issue-28527-cli_LpJKUe/entry.ts:1:19\n"

      at <anonymous> (/workspace/bun/test/regression/issue/28527.test.ts:147:22)
(fail) bun build CLI auto-installs dependencies without package.json [249.03ms]
104 |     stderr: "pipe",
105 |   });
106 | 
107 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
108 | 
109 |   expect(stderr).not.toContain("Could n
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (a5ea9c743)

test/regression/issue/28527.test.ts:
(pass) bun build CLI auto-installs dependencies without package.json [13.32ms]
(pass) Bun.build auto-installs dependencies without package.json [17.61ms]

 2 pass
 0 fail
 13 expect() calls
Ran 2 tests across 1 file. [109.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/28527.test.ts"
bun test v1.4.1 (731aa92da)

test/regression/issue/28527.test.ts:
(pass) bun build CLI auto-installs dependencies without package.json [622.79ms]
(pass) Bun.build auto-installs dependencies without package.json [854.12ms]

 2 pass
 0 fail
 13 expect() calls
Ran 2 tests across 1 file. [2.88s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 583ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_pic
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/bundle_v2.rs                     |  14 ++-
 src/bunfig/bunfig.rs                         |   1 +
 src/event_loop/AnyEventLoop.rs               |  15 +++
 src/install/PackageManager.rs                |  56 +++++++--
 src/install/auto_installer.rs                |   8 ++
 src/install_types/resolver_hooks.rs          |  11 +-
 src/jsc/event_loop.rs                        |  14 +++
 src/resolver/resolver.rs                     | 106 ++++++++++++++----
 src/runtime/api/js_bundle_completion_task.rs |  12 ++
 src/runtime/cli/build_command.rs             |   8 ++
 src/runtime/jsc_hooks.rs                     |  29 ++++-
 test/regression/issue/28527.test.ts          | 162 +++++++++++++++++++++++++++
 12 files changed, 395 insertions(+), 41 deletions(-)
```

</details>

**gate history** · 9 passed · 1 rejected · iteration 30

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/bundler/bundle_v2.rs                          2      2     42
src/bunfig/bunfig.rs                              1      1     42
src/event_loop/AnyEventLoop.rs                    8      8     42
src/install/PackageManager.rs                    17     15     42
src/install/auto_installer.rs                     2      2     42
src/install_types/resolver_hooks.rs               3      3     42
src/jsc/event_loop.rs                             3      2     42
src/resolver/resolver.rs                         15     22     42
src/runtime/api/js_bundle_completion_task.rs      6      9     42
src/runtime/cli/build_command.rs                  6      5     42
src/runtime/jsc_hooks.rs                          6      8     42
test/regression/issue/28527.test.ts               8     15     42
```

</details>

**root cause** · written by the author bot

The root cause was that Bun.build and bun build did not propagate the auto-install and global-cache configuration into the transpiler options, so when no package.json was present the resolver never fell back to fetching missing dependencies into the global cache and instead failed with a module not found error. The fix threads the installation, global-cache, and offline-mode settings from the build command and bundle completion task through to the resolver, and teaches the runtime to initialize a package manager with a mini event loop when no VM event loop exists so auto-install can run dur…

<!-- robobun:evidence:end -->
