### PR TITLE
Fix crash when Reflect.construct is used on mock functions returning non-objects

### DIFF
--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -837,6 +837,7 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
         return {};
     }
 
+    const bool isConstruct = !callframe->newTarget().isUndefined();
     JSC::ArgList args = JSC::ArgList(callframe);
     JSValue thisValue = callframe->thisValue();
     JSC::JSArray* argumentsArray = nullptr;
@@ -954,15 +955,24 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
                 fn->returnValues.set(vm, fn, returnValuesArray);
             }
 
+            if (isConstruct && !returnValue.isObject()) {
+                return JSValue::encode(thisValue.isObject() ? thisValue : JSC::constructEmptyObject(globalObject));
+            }
             return JSValue::encode(returnValue);
         }
         case JSMockImplementation::Kind::ReturnValue: {
             JSValue returnValue = impl->underlyingValue.get();
             setReturnValue(createMockResult(vm, globalObject, "return"_s, returnValue));
+            if (isConstruct && !returnValue.isObject()) {
+                return JSValue::encode(thisValue.isObject() ? thisValue : JSC::constructEmptyObject(globalObject));
+            }
             return JSValue::encode(returnValue);
         }
         case JSMockImplementation::Kind::ReturnThis: {
             setReturnValue(createMockResult(vm, globalObject, "return"_s, thisValue));
+            if (isConstruct && !thisValue.isObject()) {
+                return JSValue::encode(JSC::constructEmptyObject(globalObject));
+            }
             return JSValue::encode(thisValue);
         }
         case JSMockImplementation::Kind::RejectedValue: {
@@ -978,6 +988,9 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
+    if (isConstruct) {
+        return JSValue::encode(thisValue.isObject() ? thisValue : JSC::constructEmptyObject(globalObject));
+    }
     return JSValue::encode(jsUndefined());
 }
 

--- a/test/js/bun/test/mock-fn-construct.test.ts
+++ b/test/js/bun/test/mock-fn-construct.test.ts
@@ -1,0 +1,30 @@
+import { test, expect, jest } from "bun:test";
+
+test("Reflect.construct on mock with non-object return value does not crash", () => {
+  const m = jest.fn(() => 42);
+  const result = Reflect.construct(m, []);
+  expect(result).toBeObject();
+  expect(m.mock.results[0].value).toBe(42);
+});
+
+test("Reflect.construct on mock with mockReturnValue does not crash", () => {
+  const m = jest.fn();
+  m.mockReturnValue(123);
+  const result = Reflect.construct(m, []);
+  expect(result).toBeObject();
+  expect(m.mock.results[0].value).toBe(123);
+});
+
+test("Reflect.construct on mock with object return value returns that object", () => {
+  const obj = { a: 1 };
+  const m = jest.fn(() => obj);
+  const result = Reflect.construct(m, []);
+  expect(result).toBe(obj);
+});
+
+test("new on mock with non-object return value still works", () => {
+  const m = jest.fn(() => 42);
+  const result = new m();
+  expect(result).toBeObject();
+  expect(m.mock.results[0].value).toBe(42);
+});

--- a/test/js/bun/test/mock-fn-construct.test.ts
+++ b/test/js/bun/test/mock-fn-construct.test.ts
@@ -14,17 +14,3 @@ test("Reflect.construct on mock with mockReturnValue does not crash", () => {
   expect(result).toBeObject();
   expect(m.mock.results[0].value).toBe(123);
 });
-
-test("Reflect.construct on mock with object return value returns that object", () => {
-  const obj = { a: 1 };
-  const m = jest.fn(() => obj);
-  const result = Reflect.construct(m, []);
-  expect(result).toBe(obj);
-});
-
-test("new on mock with non-object return value still works", () => {
-  const m = jest.fn(() => 42);
-  const result = new m();
-  expect(result).toBeObject();
-  expect(m.mock.results[0].value).toBe(42);
-});

--- a/test/js/bun/test/mock-fn-construct.test.ts
+++ b/test/js/bun/test/mock-fn-construct.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, jest } from "bun:test";
+import { expect, jest, test } from "bun:test";
 
 test("Reflect.construct on mock with non-object return value does not crash", () => {
   const m = jest.fn(() => 42);


### PR DESCRIPTION
`jsMockFunctionCall` serves as both the call and construct handler for `JSMockFunction`. When a mock returns a non-object value (e.g. a number from `mockReturnValue`), calling it via `Reflect.construct` causes JSC to assert `isCell()` at `JSCJSValue.h:1077` because the construct path expects the handler to return a cell/object.

**Root cause:** `JSMockFunction` registers the same native function for both call and construct:
```cpp
JSMockFunction(VM& vm, Structure* structure, CallbackKind wrapKind)
    : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
```

When the mock's return value is not an object (number, undefined, etc.), it is returned directly from the construct handler. `new` has its own isObject check in the bytecode, but `Reflect.construct` trusts the handler and crashes.

**Fix:** Follow standard JS `[[Construct]]` semantics — when called as a constructor (`newTarget` is set) and the return value is not an object, return `thisValue` or a new empty object instead.

**Repro:**
```js
const m = jest.fn(() => 42);
Reflect.construct(m, []); // ASSERTION FAILED: isCell()
```