### PR TITLE
Fix crash in ReadableStream.text() when blob store is already consumed

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,7 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    return globalThis.throw("Body already consumed", .{});
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/test/js/web/streams/stream-body-consumed.test.ts
+++ b/test/js/web/streams/stream-body-consumed.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test.concurrent("ReadableStream.text() after body consumed does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const response = new Response("hello");
+      const body = response.body;
+      try { await response.json(); } catch(e) {}
+      try { await body.text(); } catch(e) {}
+      console.log("OK");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("ReadableStream.blob() after body consumed does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const response = new Response("hello");
+      const body = response.body;
+      try { await response.text(); } catch(e) {}
+      try { await body.blob(); } catch(e) {}
+      console.log("OK");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`ByteBlobLoader.toBufferedValue()` returned `.zero` without throwing a JS exception when the underlying blob store was null (already consumed by a prior `response.json()` / `response.text()` call). This violated the host function contract that `.zero` means an exception was thrown.

- **Debug builds**: assertion failure — `Expected an exception to be thrown`
- **Release builds**: segfault at address `0x5`

## Fix

When the blob store is already consumed, throw a proper `"Body already consumed"` JS error instead of returning `.zero`. This follows the same pattern used in `ByteStream.toBufferedValue`.

## Repro

```js
const response = new Response("hello");
const body = response.body;
try { await response.json(); } catch(e) {}
// Crashes — blob store was consumed by json() above
await body.text();
```

Crash fingerprint: `15871b1a535cef35`