### PR TITLE
Fix null deref in esmRegistryMap when globalThis.Loader is non-object

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2195,12 +2195,12 @@ void GlobalObject::finishCreation(VM& vm)
             auto loaderValue = global->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "Loader"_s));
             scope.assertNoExceptionExceptTermination();
             RETURN_IF_EXCEPTION(scope, setEmpty());
-            if (loaderValue) {
+            if (loaderValue && loaderValue.isObject()) {
                 auto registryValue = loaderValue.getObject()->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "registry"_s));
                 scope.assertNoExceptionExceptTermination();
                 RETURN_IF_EXCEPTION(scope, setEmpty());
-                if (registryValue) {
-                    registry = jsCast<JSC::JSMap*>(registryValue);
+                if (auto* map = jsDynamicCast<JSC::JSMap*>(registryValue)) {
+                    registry = map;
                 }
             }
 

--- a/test/js/bun/test/mock/mock-module-loader-tamper.test.ts
+++ b/test/js/bun/test/mock/mock-module-loader-tamper.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("mock.module does not crash when globalThis.Loader is overwritten with non-object", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `
+      globalThis.Loader = 42;
+      const v2 = Bun.jest(import.meta.path).mock;
+      try { v2.module("test", () => ({ default: 1 })); } catch(e) {}
+      Bun.gc(true);
+      console.log("ok");
+    `],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});
+
+test("mock.module does not crash when globalThis.Loader is deleted", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `
+      delete globalThis.Loader;
+      const v2 = Bun.jest(import.meta.path).mock;
+      try { v2.module("test", () => ({ default: 1 })); } catch(e) {}
+      Bun.gc(true);
+      console.log("ok");
+    `],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/mock/mock-module-loader-tamper.test.ts
+++ b/test/js/bun/test/mock/mock-module-loader-tamper.test.ts
@@ -3,13 +3,17 @@ import { bunEnv, bunExe } from "harness";
 
 test("mock.module does not crash when globalThis.Loader is overwritten with non-object", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       globalThis.Loader = 42;
       const v2 = Bun.jest(import.meta.path).mock;
       try { v2.module("test", () => ({ default: 1 })); } catch(e) {}
       Bun.gc(true);
       console.log("ok");
-    `],
+    `,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
@@ -23,13 +27,17 @@ test("mock.module does not crash when globalThis.Loader is overwritten with non-
 
 test("mock.module does not crash when globalThis.Loader is deleted", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       delete globalThis.Loader;
       const v2 = Bun.jest(import.meta.path).mock;
       try { v2.module("test", () => ({ default: 1 })); } catch(e) {}
       Bun.gc(true);
       console.log("ok");
-    `],
+    `,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",


### PR DESCRIPTION
The `esmRegistryMap` lazy initializer reads `globalThis.Loader` (exposed by JSC when `exposeInternalModuleLoader` is true) and calls `getObject()` on it without checking that the value is actually an object. If user code overwrites `globalThis.Loader` with a non-object value (e.g. a number or boolean), `getObject()` returns `nullptr`, causing a null pointer dereference on the subsequent `getIfPropertyExists()` call.

Adds an `isObject()` guard before calling `getObject()`.

Crash fingerprint: `2b977ab1504fe1e0`