### PR TITLE
Clear pending exceptions after error message formatting

### DIFF
--- a/src/jsc/JSGlobalObject.zig
+++ b/src/jsc/JSGlobalObject.zig
@@ -296,6 +296,7 @@ pub const JSGlobalObject = opaque {
                 _ = this.clearExceptionExceptTermination();
                 return ZigString.static(fmt).toErrorInstance(this);
             };
+            _ = this.clearExceptionExceptTermination();
 
             // Ensure we clone it.
             var str = ZigString.initUTF8(buf.written());
@@ -320,6 +321,7 @@ pub const JSGlobalObject = opaque {
                 _ = this.clearExceptionExceptTermination();
                 return ZigString.static(fmt).toTypeErrorInstance(this);
             };
+            _ = this.clearExceptionExceptTermination();
             var str = ZigString.fromUTF8(buf.slice());
             return str.toTypeErrorInstance(this);
         } else {
@@ -351,6 +353,7 @@ pub const JSGlobalObject = opaque {
                 _ = this.clearExceptionExceptTermination();
                 return ZigString.static(fmt).toSyntaxErrorInstance(this);
             };
+            _ = this.clearExceptionExceptTermination();
             var str = ZigString.fromUTF8(buf.slice());
             return str.toSyntaxErrorInstance(this);
         } else {
@@ -368,6 +371,7 @@ pub const JSGlobalObject = opaque {
                 _ = this.clearExceptionExceptTermination();
                 return ZigString.static(fmt).toRangeErrorInstance(this);
             };
+            _ = this.clearExceptionExceptTermination();
             var str = ZigString.fromUTF8(buf.slice());
             return str.toRangeErrorInstance(this);
         } else {

--- a/test/js/bun/test/stack-overflow-error-format.test.ts
+++ b/test/js/bun/test/stack-overflow-error-format.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "bun:test";
+
+test("toHaveReturnedWith on non-mock formats error without crash", () => {
+  const obj = { nested: { value: 42 }, fn: () => {} };
+  expect(() => {
+    expect(obj).toHaveReturnedWith();
+  }).toThrow("Expected value must be a mock function");
+});


### PR DESCRIPTION
When `createErrorInstance` formats an error message containing `{f}` format args, the `ConsoleObject` formatter may call into JSC to inspect object properties. Near the stack limit (e.g. after catching a stack overflow), this can trigger a secondary stack overflow exception that gets silently set on the VM without being propagated as a Zig error. The subsequent `throwValue` call then hits `assertNoException` because the pending exception was never cleared.

The catch block in `createErrorInstance` already handles the case where `writer.print` returns an error, but the formatter can also set an exception without propagating it. Fix by clearing any pending exceptions after formatting completes, matching the existing catch-block behavior.

Also moves `DECLARE_THROW_SCOPE` inside the mock-function branch in `JSMockFunction__getCalls` and `JSMockFunction__getReturns` since the ThrowScope is only needed where `getReturnValues()`/`getCalls()` can throw.

Crash fingerprint: `cb109bc4537116d5`