### PR TITLE
Clear pending JSC exception in DiffFormatter catch blocks

### DIFF
--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -44,6 +44,10 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 flush: false,
                 quote_strings: true,
             };
+            // A thrown/non-primitive `toString` leaves a pending JS exception.
+            // Clear it (termination excepted, which stays pending to tear the VM
+            // down) so the next format and the caller's throw don't trip
+            // assertNoException. Mirrors `JSGlobalObject::throw_pretty`.
             if JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
@@ -53,9 +57,8 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 fmt_options,
             )
             .is_err()
-                && !global_this.clear_exception_except_termination()
             {
-                return Err(fmt::Error);
+                let _ = global_this.clear_exception_except_termination();
             }
 
             if JestPrettyFormat::format(
@@ -67,9 +70,8 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 fmt_options,
             )
             .is_err()
-                && !global_this.clear_exception_except_termination()
             {
-                return Err(fmt::Error);
+                let _ = global_this.clear_exception_except_termination();
             }
         }
 

--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -44,23 +44,33 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 flush: false,
                 quote_strings: true,
             };
-            let _ = JestPrettyFormat::format(
+            if JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
                 core::slice::from_ref(&received),
                 1,
                 &mut received_buf,
                 fmt_options,
-            ); // TODO:
+            )
+            .is_err()
+                && !global_this.clear_exception_except_termination()
+            {
+                return Err(fmt::Error);
+            }
 
-            let _ = JestPrettyFormat::format(
+            if JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
                 core::slice::from_ref(&expected),
                 1,
                 &mut expected_buf,
                 fmt_options,
-            ); // TODO:
+            )
+            .is_err()
+                && !global_this.clear_exception_except_termination()
+            {
+                return Err(fmt::Error);
+            }
         }
 
         let mut received_slice: &[u8] = received_buf.as_slice();

--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -44,9 +44,8 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 flush: false,
                 quote_strings: true,
             };
-            // A thrown/non-primitive `toString` leaves a pending JS exception.
-            // Clear it (termination excepted, which stays pending to tear the VM
-            // down) so the next format and the caller's throw don't trip
+            // A thrown/non-primitive `toString` leaves a pending JS exception. Clear it
+            // (termination stays pending) so the caller's throw doesn't trip
             // assertNoException. Mirrors `JSGlobalObject::throw_pretty`.
             if JestPrettyFormat::format(
                 MessageLevel::Debug,

--- a/test/js/bun/test/expect-toEqual-regex-toString-crash.test.ts
+++ b/test/js/bun/test/expect-toEqual-regex-toString-crash.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("expect.toEqual does not crash when regex has overridden toString", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const re = /abc/;
+      Object.defineProperty(re, "toString", { value: () => { throw new Error("nope"); } });
+      let threw = false;
+      try { Bun.jest().expect(re).toEqual({}); } catch (e) {
+        threw = true;
+        if (!e.message.includes("Expected: {}")) process.exit(1);
+      }
+      if (!threw) process.exit(1);
+    `,
+    ],
+    env: bunEnv,
+  });
+
+  const exitCode = await proc.exited;
+
+  expect(exitCode).toBe(0);
+});
+
+test("expect.toEqual does not crash when regex toString returns non-primitive", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const re = /abc/;
+      Object.defineProperty(re, "toString", { value: () => Array });
+      let threw = false;
+      try { Bun.jest().expect(re).toEqual({}); } catch (e) {
+        threw = true;
+        if (!e.message.includes("Expected: {}")) process.exit(1);
+      }
+      if (!threw) process.exit(1);
+    `,
+    ],
+    env: bunEnv,
+  });
+
+  const exitCode = await proc.exited;
+
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/expect-toEqual-regex-toString-crash.test.ts
+++ b/test/js/bun/test/expect-toEqual-regex-toString-crash.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-test("expect.toEqual does not crash when regex has overridden toString", async () => {
+test.concurrent("expect.toEqual does not crash when regex has overridden toString", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -18,14 +18,15 @@ test("expect.toEqual does not crash when regex has overridden toString", async (
     `,
     ],
     env: bunEnv,
+    stderr: "pipe",
   });
 
-  const exitCode = await proc.exited;
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-  expect(exitCode).toBe(0);
+  expect({ stderr, exitCode }).toMatchObject({ exitCode: 0 });
 });
 
-test("expect.toEqual does not crash when regex toString returns non-primitive", async () => {
+test.concurrent("expect.toEqual does not crash when regex toString returns non-primitive", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -42,9 +43,10 @@ test("expect.toEqual does not crash when regex toString returns non-primitive", 
     `,
     ],
     env: bunEnv,
+    stderr: "pipe",
   });
 
-  const exitCode = await proc.exited;
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-  expect(exitCode).toBe(0);
+  expect({ stderr, exitCode }).toMatchObject({ exitCode: 0 });
 });


### PR DESCRIPTION
When `toEqual` fails and formats a diff message, `JestPrettyFormat` calls `toZigString` on values to stringify them for the diff output. For a RegExp with an overridden `toString` that throws or returns a non-primitive (like a constructor), JSC sets a pending exception on the VM. The `catch {}` blocks in `DiffFormatter.format` swallowed the Zig error but left the JSC exception pending, causing an assertion failure when the code proceeded to create the matcher error.

Fix: call `clearExceptionExceptTermination()` in the catch blocks so the pending JSC exception is properly cleared before continuing to format the matcher error message.

**Repro:**
```js
const re = /abc/;
Object.defineProperty(re, "toString", { value: () => { throw new Error("nope"); } });
Bun.jest().expect(re).toEqual({});
```