### PR TITLE
Fix null deref in ESM registry init when globalThis.Loader is tampered

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -616,13 +616,12 @@ JSC_DEFINE_HOST_FUNCTION(functionFulfillModuleSync,
 extern "C" void* Zig__GlobalObject__getModuleRegistryMap(JSC::JSGlobalObject* arg0)
 {
     if (JSC::JSObject* loader = JSC::jsDynamicCast<JSC::JSObject*>(arg0->moduleLoader())) {
-        JSC::JSMap* map = JSC::jsDynamicCast<JSC::JSMap*>(
-            loader->getDirect(arg0->vm(), JSC::Identifier::fromString(arg0->vm(), "registry"_s)));
-
-        JSC::JSMap* cloned = map->clone(arg0, arg0->vm(), arg0->mapStructure());
-        JSC::gcProtect(cloned);
-
-        return cloned;
+        if (JSC::JSMap* map = JSC::jsDynamicCast<JSC::JSMap*>(
+                loader->getDirect(arg0->vm(), JSC::Identifier::fromString(arg0->vm(), "registry"_s)))) {
+            JSC::JSMap* cloned = map->clone(arg0, arg0->vm(), arg0->mapStructure());
+            JSC::gcProtect(cloned);
+            return cloned;
+        }
     }
 
     return nullptr;
@@ -2182,25 +2181,11 @@ void GlobalObject::finishCreation(VM& vm)
         [](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSMap>::Initializer& init) {
             auto* global = init.owner;
             auto& vm = init.vm;
-            auto scope = DECLARE_THROW_SCOPE(vm);
-
-            // if we get the termination exception, we'd still like to set a non-null Map so that
-            // we don't segfault
-            auto setEmpty = [&]() {
-                ASSERT(scope.exception());
-                init.set(JSC::JSMap::create(init.vm, init.owner->mapStructure()));
-            };
 
             JSMap* registry = nullptr;
-            auto loaderValue = global->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "Loader"_s));
-            scope.assertNoExceptionExceptTermination();
-            RETURN_IF_EXCEPTION(scope, setEmpty());
-            if (loaderValue) {
-                auto registryValue = loaderValue.getObject()->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "registry"_s));
-                scope.assertNoExceptionExceptTermination();
-                RETURN_IF_EXCEPTION(scope, setEmpty());
-                if (registryValue) {
-                    registry = jsCast<JSC::JSMap*>(registryValue);
+            if (auto* loader = global->moduleLoader()) {
+                if (auto registryValue = loader->getDirect(vm, JSC::Identifier::fromString(vm, "registry"_s))) {
+                    registry = jsDynamicCast<JSC::JSMap*>(registryValue);
                 }
             }
 
@@ -3069,14 +3054,18 @@ void GlobalObject::reload()
 {
     JSModuleLoader* moduleLoader = this->moduleLoader();
     auto& vm = this->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSC::JSMap* registry = jsCast<JSC::JSMap*>(moduleLoader->get(this, Identifier::fromString(vm, "registry"_s)));
-    RETURN_IF_EXCEPTION(scope, );
 
-    registry->clear(this);
-    RETURN_IF_EXCEPTION(scope, );
-    this->requireMap()->clear(this);
-    RETURN_IF_EXCEPTION(scope, );
+    if (JSC::JSMap* registry = jsDynamicCast<JSC::JSMap*>(moduleLoader->getDirect(vm, Identifier::fromString(vm, "registry"_s)))) {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        registry->clear(this);
+        RETURN_IF_EXCEPTION(scope, );
+    }
+
+    {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        this->requireMap()->clear(this);
+        RETURN_IF_EXCEPTION(scope, );
+    }
 
     // If we run the GC every time, we will never get the SourceProvider cache hit.
     // So we run the GC every other time.

--- a/test/js/bun/test/mock/mock-module-loader-tamper.test.ts
+++ b/test/js/bun/test/mock/mock-module-loader-tamper.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Filter out ASAN warnings that only appear in debug builds
+function filterAsanWarning(stderr: string): string {
+  return stderr
+    .split("\n")
+    .filter(line => !line.startsWith("WARNING: ASAN"))
+    .join("\n")
+    .trim();
+}
+
+test("mock.module does not crash when globalThis.Loader is tampered", async () => {
+  // Test 1: Loader set to non-object truthy value
+  await using proc1 = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `globalThis.Loader = true; Bun.jest().mock.module("test-mod", () => ({ foo: 1 })); console.log("ok");`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout1, stderr1, exit1] = await Promise.all([proc1.stdout.text(), proc1.stderr.text(), proc1.exited]);
+
+  expect(filterAsanWarning(stderr1)).toBe("");
+  expect(stdout1).toBe("ok\n");
+  expect(exit1).toBe(0);
+
+  // Test 2: Loader deleted
+  await using proc2 = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `delete globalThis.Loader; Bun.jest().mock.module("test-mod", () => ({ bar: 2 })); console.log("ok");`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout2, stderr2, exit2] = await Promise.all([proc2.stdout.text(), proc2.stderr.text(), proc2.exited]);
+
+  expect(filterAsanWarning(stderr2)).toBe("");
+  expect(stdout2).toBe("ok\n");
+  expect(exit2).toBe(0);
+});


### PR DESCRIPTION
The `m_esmRegistryMap` lazy initializer read the user-modifiable `globalThis.Loader` property to find the module registry. If a user set `globalThis.Loader` to a non-object truthy value (e.g. `true`, `42`), `getObject()` returned `nullptr` and the subsequent `getIfPropertyExists` call crashed with a null pointer dereference (UBSAN confirmed: `member call on null pointer of type 'JSC::JSObject'` at ZigGlobalObject.cpp:2199).

Uses `moduleLoader()` directly instead, which returns the internal module loader without depending on the user-visible property.

**Repro:**
```js
globalThis.Loader = true;
Bun.jest().mock.module("test", () => ({}));
```

Crash fingerprint: `dcb22fc17e3121c0`