### PR TITLE
glob: fix undeclared component_idx after active-set refactor

### DIFF
--- a/src/glob/GlobWalker.zig
+++ b/src/glob/GlobWalker.zig
@@ -712,7 +712,16 @@ pub fn GlobWalker_(
                 var iterator = Accessor.DirIter.iterate(fd);
                 if (comptime isWindows) {
                     if (@hasDecl(Accessor.DirIter, "setNameFilter")) {
-                        iterator.setNameFilter(this.computeNtFilter(component_idx));
+                        // computeNtFilter operates on a single pattern component.
+                        // When multiple indices are active (e.g. after `**`), the
+                        // kernel filter could hide entries needed by other indices,
+                        // so skip it. The filter is purely an optimization;
+                        // matchPatternImpl still runs for correctness.
+                        const filter: ?[]const u16 = if (active.count() == 1)
+                            this.computeNtFilter(@intCast(active.findFirstSet().?))
+                        else
+                            null;
+                        iterator.setNameFilter(filter);
                     }
                 }
                 this.iter_state.directory.iter = iterator;


### PR DESCRIPTION
## What

Fixes a build error on `main` introduced by the interaction of #28496 and #28489:

```
src/glob/GlobWalker.zig:715:69: error: use of undeclared identifier 'component_idx'
                        iterator.setNameFilter(this.computeNtFilter(component_idx));
                                                                    ^~~~~~~~~~~~~
```

## Why

\#28496 replaced the single `component_idx` variable with an `active` BitSet to track multiple active pattern component indices. \#28489 (merged just before) added a Windows `NtQueryDirectoryFile` filter call that references `component_idx`. After both landed, the variable no longer exists in scope.

## Fix

`computeNtFilter` operates on a single pattern component, so it can only be applied when exactly one index is active. For multi-index states (e.g. after `**`), a single-component kernel filter could hide entries that other active indices need to match, so we skip it.

This is safe because the NT filter is purely a pre-filter optimization — `matchPatternImpl` still runs on every returned entry for correctness (per the existing doc comment on `computeNtFilter`).

## Verification

`bun run zig:check-all` passes on all platforms (macOS/Linux/Windows × x86_64/aarch64 × Debug/Release).