### PR TITLE
Handle throwing custom inspect functions in ConsoleObject formatter

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -1006,6 +1006,10 @@ pub const Formatter = struct {
     ordered_properties: bool = false,
     custom_formatted_object: CustomFormattedObject = .{},
     disable_inspect_custom: bool = false,
+    /// When true, exceptions from custom inspect functions are caught and the value
+    /// is formatted with default formatting. Used in error message construction paths
+    /// where exceptions must not leak (e.g. createErrorInstance).
+    suppress_custom_inspect_exceptions: bool = false,
     stack_check: bun.StackCheck = .{ .cached_stack_end = std.math.maxInt(usize) },
     can_throw_stack_overflow: bool = false,
     error_display_level: FormatOptions.ErrorDisplayLevel = .full,
@@ -2278,14 +2282,23 @@ pub const Formatter = struct {
             .CustomFormattedObject => {
                 // Call custom inspect function. Will return the error if there is one
                 // we'll need to pass the callback through to the "this" value in here
-                const result = try bun.jsc.fromJSHostCall(this.globalThis, @src(), JSC__JSValue__callCustomInspectFunction, .{
+                const result = bun.jsc.fromJSHostCall(this.globalThis, @src(), JSC__JSValue__callCustomInspectFunction, .{
                     this.globalThis,
                     this.custom_formatted_object.function,
                     this.custom_formatted_object.this,
                     this.max_depth -| this.depth,
                     this.max_depth,
                     enable_ansi_colors,
-                });
+                }) catch {
+                    if (!this.suppress_custom_inspect_exceptions) return error.JSError;
+                    // In error-formatting contexts, catch the exception and fall back to
+                    // type-aware formatting to avoid assertion failures from leaked exceptions.
+                    if (!this.globalThis.clearExceptionExceptTermination()) return error.JSError;
+                    const fallback_value = this.custom_formatted_object.this;
+                    const fallback_tag = try ConsoleObject.Formatter.Tag.getAdvanced(fallback_value, this.globalThis, .{ .disable_inspect_custom = true });
+                    try this.format(fallback_tag, Writer, writer_, fallback_value, this.globalThis, enable_ansi_colors);
+                    return;
+                };
                 // Strings are printed directly, otherwise we recurse. It is possible to end up in an infinite loop.
                 if (result.isString()) {
                     writer.print("{f}", .{result.fmtString(this.globalThis)});

--- a/src/jsc/JSValue.zig
+++ b/src/jsc/JSValue.zig
@@ -2043,6 +2043,9 @@ pub const JSValue = enum(i64) {
             formatter.deinit();
         }
         formatter.stack_check.update();
+        // toFmt is used for {f} formatting in error messages and similar contexts
+        // where exceptions from custom inspect must not leak.
+        formatter.suppress_custom_inspect_exceptions = true;
 
         return jsc.ConsoleObject.Formatter.ZigFormatter{
             .formatter = formatter,

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -24,6 +24,27 @@ it("prototype", () => {
   Bun.gc(true);
 });
 
+it("throwing custom inspect in error formatting does not crash", () => {
+  // Direct Bun.inspect() should still throw (Node.js compat).
+  const obj = Object.create({
+    [Symbol.for("nodejs.util.inspect.custom")]() {
+      throw new Error("inspect failed");
+    },
+  });
+  expect(() => Bun.inspect(obj)).toThrow("inspect failed");
+
+  // But the {f} formatter used in error messages should suppress and fall back,
+  // not crash or leak raw format strings.
+  expect(() => expect({}).toHaveLength(obj)).toThrow(/Expected value must be a non-negative integer/);
+
+  // TypedArray with throwing inspect should use type-aware fallback, not plain object
+  const arr = new Uint8Array([1, 2, 3]);
+  arr[Symbol.for("nodejs.util.inspect.custom")] = () => {
+    throw new Error("nope");
+  };
+  expect(() => expect({}).toHaveLength(arr)).toThrow(/Uint8Array/);
+});
+
 it("getters", () => {
   const obj = {
     get foo() {


### PR DESCRIPTION
When a custom inspect function (e.g. `Buffer.prototype[Symbol.for('nodejs.util.inspect.custom')]`) throws during value formatting, catch the exception and fall back to default object formatting instead of propagating the error.

**Root cause:** `Buffer.prototype` has a custom inspect function that throws `"Can only call Buffer.inspect on instances of Buffer"` when called on `Buffer.prototype` itself (which is not a Buffer instance). When the `ConsoleObject` formatter encounters this during error message construction (e.g. in `toHaveLength` formatting the expected value with `{f}`), the uncaught exception triggers a `releaseAssertNoException` assertion failure.

**Fix:** In the `.CustomFormattedObject` handler in `ConsoleObject.zig`, catch errors from calling custom inspect functions, clear the pending JS exception, and fall back to default object formatting. This also fixes the visible symptom where error messages would show the raw format string `{f}` instead of the formatted value.