### PR TITLE
Improve dangling process diagnostics in test runner

### DIFF
--- a/src/bun.js/ProcessAutoKiller.zig
+++ b/src/bun.js/ProcessAutoKiller.zig
@@ -2,9 +2,20 @@ const ProcessAutoKiller = @This();
 
 const log = bun.Output.scoped(.AutoKiller, .hidden);
 
-processes: std.AutoArrayHashMapUnmanaged(*bun.spawn.Process, void) = .{},
+processes: std.AutoArrayHashMapUnmanaged(*bun.spawn.Process, ProcessInfo) = .{},
 enabled: bool = false,
 ever_enabled: bool = false,
+
+pub const ProcessInfo = struct {
+    command: ?[]const u8 = null,
+
+    fn deinit(this: *ProcessInfo) void {
+        if (this.command) |cmd| {
+            bun.default_allocator.free(cmd);
+            this.command = null;
+        }
+    }
+};
 
 pub fn enable(this: *ProcessAutoKiller) void {
     this.enabled = true;
@@ -15,31 +26,72 @@ pub fn disable(this: *ProcessAutoKiller) void {
     this.enabled = false;
 }
 
+pub const KilledProcess = struct {
+    pid: if (bun.Environment.isPosix) std.posix.pid_t else bun.windows.libuv.uv_pid_t,
+    command: ?[]const u8,
+};
+
 pub const Result = struct {
     processes: u32 = 0,
+    killed: bun.BoundedArray(KilledProcess, max_reported) = .{},
+
+    const max_reported = 8;
+
+    pub fn printError(this: *const Result) void {
+        if (this.processes == 0) return;
+        if (this.killed.len == 1) {
+            const info = this.killed.constSlice()[0];
+            if (info.command) |cmd| {
+                bun.Output.prettyErrorln("<yellow>killed 1 dangling process<r> <d>(pid {d}: {s})<r>", .{ info.pid, cmd });
+            } else {
+                bun.Output.prettyErrorln("<yellow>killed 1 dangling process<r> <d>(pid {d})<r>", .{info.pid});
+            }
+        } else {
+            bun.Output.prettyErrorln("<yellow>killed {d} dangling processes:<r>", .{this.processes});
+            for (this.killed.constSlice()) |info| {
+                if (info.command) |cmd| {
+                    bun.Output.prettyErrorln("<d>  pid {d}: {s}<r>", .{ info.pid, cmd });
+                } else {
+                    bun.Output.prettyErrorln("<d>  pid {d}<r>", .{info.pid});
+                }
+            }
+            if (this.processes > this.killed.len) {
+                bun.Output.prettyErrorln("<d>  ... and {d} more<r>", .{this.processes - this.killed.len});
+            }
+        }
+    }
 };
 
 pub fn kill(this: *ProcessAutoKiller) Result {
-    return .{
-        .processes = this.killProcesses(),
-    };
+    return this.killProcesses();
 }
 
-fn killProcesses(this: *ProcessAutoKiller) u32 {
-    var count: u32 = 0;
-    while (this.processes.pop()) |process| {
-        defer process.key.deref();
-        if (!process.key.hasExited()) {
-            log("process.kill {d}", .{process.key.pid});
-            count += @as(u32, @intFromBool(process.key.kill(@intFromEnum(bun.SignalCode.default)) == .result));
+fn killProcesses(this: *ProcessAutoKiller) Result {
+    var result = Result{};
+    while (this.processes.pop()) |entry| {
+        defer entry.key.deref();
+        if (!entry.key.hasExited()) {
+            log("process.kill {d}", .{entry.key.pid});
+            if (entry.key.kill(@intFromEnum(bun.SignalCode.default)) == .result) {
+                result.processes += 1;
+                result.killed.append(.{
+                    .pid = entry.key.pid,
+                    .command = entry.value.command,
+                }) catch {};
+            }
+        } else {
+            // Process already exited, free its info
+            var info = entry.value;
+            info.deinit();
         }
     }
-    return count;
+    return result;
 }
 
 pub fn clear(this: *ProcessAutoKiller) void {
-    for (this.processes.keys()) |process| {
+    for (this.processes.keys(), this.processes.values()) |process, *info| {
         process.deref();
+        info.deinit();
     }
 
     if (this.processes.capacity() > 256) {
@@ -49,24 +101,34 @@ pub fn clear(this: *ProcessAutoKiller) void {
     this.processes.clearRetainingCapacity();
 }
 
-pub fn onSubprocessSpawn(this: *ProcessAutoKiller, process: *bun.spawn.Process) void {
+pub fn onSubprocessSpawn(this: *ProcessAutoKiller, process: *bun.spawn.Process, command: ?[]const u8) void {
     if (this.enabled) {
-        this.processes.put(bun.default_allocator, process, {}) catch return;
+        const duped_command: ?[]const u8 = if (command) |cmd|
+            bun.default_allocator.dupe(u8, cmd) catch null
+        else
+            null;
+        this.processes.put(bun.default_allocator, process, .{ .command = duped_command }) catch {
+            if (duped_command) |cmd| bun.default_allocator.free(cmd);
+            return;
+        };
         process.ref();
     }
 }
 
 pub fn onSubprocessExit(this: *ProcessAutoKiller, process: *bun.spawn.Process) void {
     if (this.ever_enabled) {
-        if (this.processes.swapRemove(process)) {
+        if (this.processes.fetchSwapRemove(process)) |entry| {
+            var info = entry.value;
+            info.deinit();
             process.deref();
         }
     }
 }
 
 pub fn deinit(this: *ProcessAutoKiller) void {
-    for (this.processes.keys()) |process| {
+    for (this.processes.keys(), this.processes.values()) |process, *info| {
         process.deref();
+        info.deinit();
     }
     this.processes.deinit(bun.default_allocator);
 }

--- a/src/bun.js/ProcessAutoKiller.zig
+++ b/src/bun.js/ProcessAutoKiller.zig
@@ -37,6 +37,16 @@ pub const Result = struct {
 
     const max_reported = 8;
 
+    /// Free command strings owned by this result.
+    pub fn deinit(this: *Result) void {
+        for (this.killed.slice()) |*info| {
+            if (info.command) |cmd| {
+                bun.default_allocator.free(cmd);
+                info.command = null;
+            }
+        }
+    }
+
     pub fn printError(this: *const Result) void {
         if (this.processes == 0) return;
         if (this.killed.len == 1) {
@@ -70,20 +80,21 @@ fn killProcesses(this: *ProcessAutoKiller) Result {
     var result = Result{};
     while (this.processes.pop()) |entry| {
         defer entry.key.deref();
+        var info = entry.value;
         if (!entry.key.hasExited()) {
             log("process.kill {d}", .{entry.key.pid});
             if (entry.key.kill(@intFromEnum(bun.SignalCode.default)) == .result) {
                 result.processes += 1;
-                result.killed.append(.{
-                    .pid = entry.key.pid,
-                    .command = entry.value.command,
-                }) catch {};
+                if (result.killed.len < Result.max_reported) {
+                    result.killed.appendAssumeCapacity(.{
+                        .pid = entry.key.pid,
+                        .command = info.command,
+                    });
+                    info.command = null; // ownership moved into result
+                }
             }
-        } else {
-            // Process already exited, free its info
-            var info = entry.value;
-            info.deinit();
         }
+        info.deinit(); // free command if ownership was not transferred
     }
     return result;
 }
@@ -104,7 +115,7 @@ pub fn clear(this: *ProcessAutoKiller) void {
 pub fn onSubprocessSpawn(this: *ProcessAutoKiller, process: *bun.spawn.Process, command: ?[]const u8) void {
     if (this.enabled) {
         const duped_command: ?[]const u8 = if (command) |cmd|
-            bun.default_allocator.dupe(u8, cmd) catch null
+            bun.handleOom(bun.default_allocator.dupe(u8, cmd))
         else
             null;
         this.processes.put(bun.default_allocator, process, .{ .command = duped_command }) catch {
@@ -123,6 +134,11 @@ pub fn onSubprocessExit(this: *ProcessAutoKiller, process: *bun.spawn.Process) v
             process.deref();
         }
     }
+}
+
+/// Returns the number of tracked (not-yet-exited) child processes.
+pub fn trackedCount(this: *const ProcessAutoKiller) u32 {
+    return @intCast(this.processes.count());
 }
 
 pub fn deinit(this: *ProcessAutoKiller) void {

--- a/src/bun.js/ProcessAutoKiller.zig
+++ b/src/bun.js/ProcessAutoKiller.zig
@@ -136,11 +136,6 @@ pub fn onSubprocessExit(this: *ProcessAutoKiller, process: *bun.spawn.Process) v
     }
 }
 
-/// Returns the number of tracked (not-yet-exited) child processes.
-pub fn trackedCount(this: *const ProcessAutoKiller) u32 {
-    return @intCast(this.processes.count());
-}
-
 pub fn deinit(this: *ProcessAutoKiller) void {
     for (this.processes.keys(), this.processes.values()) |process, *info| {
         process.deref();

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -269,8 +269,8 @@ pub fn getTLSRejectUnauthorized(this: *const VirtualMachine) bool {
     return this.default_tls_reject_unauthorized orelse this.transpiler.env.getTLSRejectUnauthorized();
 }
 
-pub fn onSubprocessSpawn(this: *VirtualMachine, process: *bun.spawn.Process) void {
-    this.auto_killer.onSubprocessSpawn(process);
+pub fn onSubprocessSpawn(this: *VirtualMachine, process: *bun.spawn.Process, command: ?[]const u8) void {
+    this.auto_killer.onSubprocessSpawn(process, command);
 }
 
 pub fn onSubprocessExit(this: *VirtualMachine, process: *bun.spawn.Process) void {

--- a/src/bun.js/api/bun/js_bun_spawn_bindings.zig
+++ b/src/bun.js/api/bun/js_bun_spawn_bindings.zig
@@ -891,7 +891,11 @@ pub fn spawnMaybeSync(
 
     if (comptime !is_sync) {
         if (!subprocess.process.hasExited()) {
-            jsc_vm.onSubprocessSpawn(subprocess.process);
+            const spawn_cmd: ?[]const u8 = if (argv.items.len > 0 and argv.items[0] != null)
+                bun.sliceTo(argv.items[0].?, 0)
+            else
+                null;
+            jsc_vm.onSubprocessSpawn(subprocess.process, spawn_cmd);
         }
         return out;
     }
@@ -924,7 +928,11 @@ pub fn spawnMaybeSync(
     }
 
     if (!subprocess.process.hasExited()) {
-        jsc_vm.onSubprocessSpawn(subprocess.process);
+        const spawn_cmd: ?[]const u8 = if (argv.items.len > 0 and argv.items[0] != null)
+            bun.sliceTo(argv.items[0].?, 0)
+        else
+            null;
+        jsc_vm.onSubprocessSpawn(subprocess.process, spawn_cmd);
     }
 
     var did_timeout = false;

--- a/src/bun.js/test/Execution.zig
+++ b/src/bun.js/test/Execution.zig
@@ -230,8 +230,9 @@ pub fn handleTimeout(this: *Execution, globalThis: *jsc.JSGlobalObject) bun.JSEr
 }
 
 /// Print a diagnostic hint explaining why a test may be hanging.
-/// Only called for non-concurrent groups (sequences.len == 1) where
-/// VM-wide counters can be safely attributed to the active test.
+/// Only called for non-concurrent groups (sequences.len == 1).
+/// Note: active_timer_count is VM-wide and may include timers from
+/// earlier tests or internal subsystems — the hint is best-effort.
 fn printTimeoutHint(vm: *jsc.VirtualMachine, killed_processes: u32) void {
     const timer_count: u32 = if (vm.timer.active_timer_count > 0) @intCast(vm.timer.active_timer_count) else 0;
 

--- a/src/bun.js/test/Execution.zig
+++ b/src/bun.js/test/Execution.zig
@@ -207,9 +207,13 @@ pub fn handleTimeout(this: *Execution, globalThis: *jsc.JSGlobalObject) bun.JSEr
             if (sequence.active_entry) |entry| {
                 const now = bun.timespec.now(.force_real_time);
                 if (entry.timespec.order(&now) == .lt) {
-                    const kill_count = globalThis.bunVM().auto_killer.kill();
-                    if (kill_count.processes > 0) {
-                        bun.Output.prettyErrorln("<d>killed {d} dangling process{s}<r>", .{ kill_count.processes, if (kill_count.processes != 1) "es" else "" });
+                    const kill_result = globalThis.bunVM().auto_killer.kill();
+                    if (kill_result.processes > 0) {
+                        // Track total dangling processes across the run
+                        if (jsc.Jest.Jest.runner) |runner| {
+                            runner.summary.dangling_processes +|= kill_result.processes;
+                        }
+                        kill_result.printError();
                         bun.Output.flush();
                     }
                 }

--- a/src/bun.js/test/Execution.zig
+++ b/src/bun.js/test/Execution.zig
@@ -83,6 +83,9 @@ pub const ExecutionSequence = struct {
     result: Result = .pending,
     executing: bool = false,
     started_at: bun.timespec = .epoch,
+    /// Snapshot of VM timer count at sequence start, used by printTimeoutHint
+    /// to report only timers created during this test (not leaked from prior tests).
+    timer_count_at_start: i32 = 0,
     /// Number of expect() calls observed in this sequence.
     expect_call_count: u32 = 0,
     /// Expectation set by expect.hasAssertions() or expect.assertions(n).
@@ -219,7 +222,7 @@ pub fn handleTimeout(this: *Execution, globalThis: *jsc.JSGlobalObject) bun.JSEr
                         }
                         kill_result.printError();
                     }
-                    printTimeoutHint(vm, kill_result.processes);
+                    printTimeoutHint(vm, kill_result.processes, sequence.timer_count_at_start);
                     bun.Output.flush();
                 }
             }
@@ -231,10 +234,12 @@ pub fn handleTimeout(this: *Execution, globalThis: *jsc.JSGlobalObject) bun.JSEr
 
 /// Print a diagnostic hint explaining why a test may be hanging.
 /// Only called for non-concurrent groups (sequences.len == 1).
-/// Note: active_timer_count is VM-wide and may include timers from
-/// earlier tests or internal subsystems — the hint is best-effort.
-fn printTimeoutHint(vm: *jsc.VirtualMachine, killed_processes: u32) void {
-    const timer_count: u32 = if (vm.timer.active_timer_count > 0) @intCast(vm.timer.active_timer_count) else 0;
+/// Uses a snapshot of active_timer_count from sequence start to report
+/// only timers created during this test, not leaked from prior tests.
+fn printTimeoutHint(vm: *jsc.VirtualMachine, killed_processes: u32, timer_count_at_start: i32) void {
+    // Report only timers added since this test started.
+    const delta = vm.timer.active_timer_count - timer_count_at_start;
+    const timer_count: u32 = if (delta > 0) @intCast(delta) else 0;
 
     if (killed_processes == 0 and timer_count == 0) return;
 
@@ -567,6 +572,7 @@ fn onSequenceStarted(_: *Execution, sequence: *ExecutionSequence) void {
     if (sequence.test_entry) |entry| if (entry.callback == null) return;
 
     sequence.started_at = bun.timespec.now(.force_real_time);
+    sequence.timer_count_at_start = jsc.VirtualMachine.get().timer.active_timer_count;
 
     if (sequence.test_entry) |entry| {
         log("Running test: \"{f}\"", .{std.zig.fmtString(entry.base.name orelse "(unnamed)")});

--- a/src/bun.js/test/Execution.zig
+++ b/src/bun.js/test/Execution.zig
@@ -200,50 +200,47 @@ pub fn handleTimeout(this: *Execution, globalThis: *jsc.JSGlobalObject) bun.JSEr
     // if the concurrent group has one sequence and the sequence has an active entry that has timed out,
     //   kill any dangling processes
     // when using test.concurrent(), we can't do this because it could kill multiple tests at once.
-    const vm = globalThis.bunVM();
-    var killed_count: u32 = 0;
     if (this.activeGroup()) |current_group| {
         const sequences = current_group.sequences(this);
+        // Only kill processes and print hints for non-concurrent groups
+        // (sequences.len == 1). For test.concurrent(), we can't safely
+        // attribute VM-wide resources to a specific test.
         if (sequences.len == 1) {
             const sequence = sequences[0];
             if (sequence.active_entry) |entry| {
                 const now = bun.timespec.now(.force_real_time);
                 if (entry.timespec.order(&now) == .lt) {
+                    const vm = globalThis.bunVM();
                     var kill_result = vm.auto_killer.kill();
                     defer kill_result.deinit();
-                    killed_count = kill_result.processes;
                     if (kill_result.processes > 0) {
                         if (jsc.Jest.Jest.runner) |runner| {
                             runner.summary.dangling_processes +|= kill_result.processes;
                         }
                         kill_result.printError();
                     }
+                    printTimeoutHint(vm, kill_result.processes);
+                    bun.Output.flush();
                 }
             }
         }
     }
-    printTimeoutHint(vm, killed_count);
-    bun.Output.flush();
 
     this.bunTest().addResult(.start);
 }
 
 /// Print a diagnostic hint explaining why a test may be hanging.
+/// Only called for non-concurrent groups (sequences.len == 1) where
+/// VM-wide counters can be safely attributed to the active test.
 fn printTimeoutHint(vm: *jsc.VirtualMachine, killed_processes: u32) void {
     const timer_count: u32 = if (vm.timer.active_timer_count > 0) @intCast(vm.timer.active_timer_count) else 0;
-    const process_count = vm.auto_killer.trackedCount();
 
-    if (killed_processes == 0 and timer_count == 0 and process_count == 0) return;
+    if (killed_processes == 0 and timer_count == 0) return;
 
     bun.Output.prettyError("<d>hint: this test timed out because", .{});
     var first = true;
     if (killed_processes > 0) {
         bun.Output.prettyError(" {d} child process{s} did not exit", .{ killed_processes, if (killed_processes != 1) "es" else "" });
-        first = false;
-    }
-    if (process_count > 0) {
-        if (!first) bun.Output.prettyError(",", .{});
-        bun.Output.prettyError(" {d} child process{s} still running", .{ process_count, if (process_count != 1) "es are" else " is" });
         first = false;
     }
     if (timer_count > 0) {

--- a/src/bun.js/test/Execution.zig
+++ b/src/bun.js/test/Execution.zig
@@ -200,6 +200,8 @@ pub fn handleTimeout(this: *Execution, globalThis: *jsc.JSGlobalObject) bun.JSEr
     // if the concurrent group has one sequence and the sequence has an active entry that has timed out,
     //   kill any dangling processes
     // when using test.concurrent(), we can't do this because it could kill multiple tests at once.
+    const vm = globalThis.bunVM();
+    var killed_count: u32 = 0;
     if (this.activeGroup()) |current_group| {
         const sequences = current_group.sequences(this);
         if (sequences.len == 1) {
@@ -207,21 +209,48 @@ pub fn handleTimeout(this: *Execution, globalThis: *jsc.JSGlobalObject) bun.JSEr
             if (sequence.active_entry) |entry| {
                 const now = bun.timespec.now(.force_real_time);
                 if (entry.timespec.order(&now) == .lt) {
-                    const kill_result = globalThis.bunVM().auto_killer.kill();
+                    var kill_result = vm.auto_killer.kill();
+                    defer kill_result.deinit();
+                    killed_count = kill_result.processes;
                     if (kill_result.processes > 0) {
-                        // Track total dangling processes across the run
                         if (jsc.Jest.Jest.runner) |runner| {
                             runner.summary.dangling_processes +|= kill_result.processes;
                         }
                         kill_result.printError();
-                        bun.Output.flush();
                     }
                 }
             }
         }
     }
+    printTimeoutHint(vm, killed_count);
+    bun.Output.flush();
 
     this.bunTest().addResult(.start);
+}
+
+/// Print a diagnostic hint explaining why a test may be hanging.
+fn printTimeoutHint(vm: *jsc.VirtualMachine, killed_processes: u32) void {
+    const timer_count: u32 = if (vm.timer.active_timer_count > 0) @intCast(vm.timer.active_timer_count) else 0;
+    const process_count = vm.auto_killer.trackedCount();
+
+    if (killed_processes == 0 and timer_count == 0 and process_count == 0) return;
+
+    bun.Output.prettyError("<d>hint: this test timed out because", .{});
+    var first = true;
+    if (killed_processes > 0) {
+        bun.Output.prettyError(" {d} child process{s} did not exit", .{ killed_processes, if (killed_processes != 1) "es" else "" });
+        first = false;
+    }
+    if (process_count > 0) {
+        if (!first) bun.Output.prettyError(",", .{});
+        bun.Output.prettyError(" {d} child process{s} still running", .{ process_count, if (process_count != 1) "es are" else " is" });
+        first = false;
+    }
+    if (timer_count > 0) {
+        if (!first) bun.Output.prettyError(",", .{});
+        bun.Output.prettyError(" {d} active timer{s}", .{ timer_count, if (timer_count != 1) "s" else "" });
+    }
+    bun.Output.prettyErrorln("<r>", .{});
 }
 
 pub fn step(buntest_strong: bun_test.BunTestPtr, globalThis: *jsc.JSGlobalObject, data: bun_test.BunTest.RefDataValue) bun.JSError!bun_test.StepResult {

--- a/src/bun.js/test/jest.zig
+++ b/src/bun.js/test/jest.zig
@@ -121,6 +121,7 @@ pub const TestRunner = struct {
         fail: u32 = 0,
         files: u32 = 0,
         skipped_because_label: u32 = 0,
+        dangling_processes: u32 = 0,
 
         pub fn didLabelFilterOutAllTests(this: *const Summary) bool {
             return this.skipped_because_label > 0 and (this.pass + this.skip + this.todo + this.fail + this.expectations) == 0;

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1727,6 +1727,9 @@ pub const TestCommand = struct {
                 if (reporter.jest.unhandled_errors_between_tests > 0) {
                     Output.prettyError("{f}<r><red>{d:5>} error{s}<r>\n", .{ indenter, reporter.jest.unhandled_errors_between_tests, if (reporter.jest.unhandled_errors_between_tests > 1) "s" else "" });
                 }
+                if (summary.dangling_processes > 0) {
+                    Output.prettyError("{f}<r><yellow>{d:5>} dangling process{s} killed<r>\n", .{ indenter, summary.dangling_processes, if (summary.dangling_processes > 1) "es" else "" });
+                }
 
                 var print_expect_calls = reporter.summary().expectations > 0;
                 if (reporter.jest.snapshots.total > 0) {

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -710,8 +710,8 @@ pub const CommandLineReporter = struct {
                     .fail_because_todo_passed => writer.writeAll(comptime Output.prettyFmt("  <d>^<r> <red>this test is marked as todo but passes.<r> <d>Remove `.todo` if tested behavior now works<r>\n", colors)) catch {},
                     .fail_because_expected_assertion_count, .fail_because_expected_has_assertions => {}, // printed above
                     .fail_because_timeout => writer.print(comptime Output.prettyFmt("  <d>^<r> <red>this test timed out after {d}ms.<r>\n", colors), .{test_entry.timeout}) catch {},
-                    .fail_because_hook_timeout => writer.writeAll(comptime Output.prettyFmt("  <d>^<r> <red>a beforeEach/afterEach hook timed out for this test.<r>\n", colors)) catch {},
                     .fail_because_timeout_with_done_callback => writer.print(comptime Output.prettyFmt("  <d>^<r> <red>this test timed out after {d}ms, before its done callback was called.<r> <d>If a done callback was not intended, remove the last parameter from the test callback function<r>\n", colors), .{test_entry.timeout}) catch {},
+                    .fail_because_hook_timeout => writer.writeAll(comptime Output.prettyFmt("  <d>^<r> <red>a beforeEach/afterEach hook timed out for this test.<r>\n", colors)) catch {},
                     .fail_because_hook_timeout_with_done_callback => writer.writeAll(comptime Output.prettyFmt("  <d>^<r> <red>a beforeEach/afterEach hook timed out before its done callback was called.<r> <d>If a done callback was not intended, remove the last parameter from the hook callback function<r>\n", colors)) catch {},
                 },
             }
@@ -958,6 +958,11 @@ pub const CommandLineReporter = struct {
 
     pub fn printSummary(this: *CommandLineReporter) void {
         const summary_ = this.summary();
+
+        if (summary_.dangling_processes > 0) {
+            Output.prettyError("<r><yellow>{d:5>} dangling process{s} killed<r>\n", .{ summary_.dangling_processes, if (summary_.dangling_processes > 1) "es" else "" });
+        }
+
         const tests = summary_.fail + summary_.pass + summary_.skip + summary_.todo;
         const files = summary_.files;
 
@@ -1726,9 +1731,6 @@ pub const TestCommand = struct {
                 Output.prettyError("{f}{d:5>} fail<r>\n", .{ indenter, summary.fail });
                 if (reporter.jest.unhandled_errors_between_tests > 0) {
                     Output.prettyError("{f}<r><red>{d:5>} error{s}<r>\n", .{ indenter, reporter.jest.unhandled_errors_between_tests, if (reporter.jest.unhandled_errors_between_tests > 1) "s" else "" });
-                }
-                if (summary.dangling_processes > 0) {
-                    Output.prettyError("{f}<r><yellow>{d:5>} dangling process{s} killed<r>\n", .{ indenter, summary.dangling_processes, if (summary.dangling_processes > 1) "es" else "" });
                 }
 
                 var print_expect_calls = reporter.summary().expectations > 0;

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -960,7 +960,7 @@ pub const CommandLineReporter = struct {
         const summary_ = this.summary();
 
         if (summary_.dangling_processes > 0) {
-            Output.prettyError("<r><yellow>{d:5>} dangling process{s} killed<r>\n", .{ summary_.dangling_processes, if (summary_.dangling_processes > 1) "es" else "" });
+            Output.prettyError("<r><yellow> {d:5>} dangling process{s} killed<r>\n", .{ summary_.dangling_processes, if (summary_.dangling_processes > 1) "es" else "" });
         }
 
         const tests = summary_.fail + summary_.pass + summary_.skip + summary_.todo;

--- a/test/cli/test/dangling-process-diagnostics.test.ts
+++ b/test/cli/test/dangling-process-diagnostics.test.ts
@@ -73,11 +73,9 @@ test("spawns multiple processes that outlive the test", async () => {
     60_000,
   );
 
-  test(
-    "shows timeout hint for active timers",
-    async () => {
-      using dir = tempDir("dangling-timer", {
-        "timer.test.ts": `
+  test("shows timeout hint for active timers", async () => {
+    using dir = tempDir("dangling-timer", {
+      "timer.test.ts": `
 import { test } from "bun:test";
 
 test("has an active timer that prevents exit", async () => {
@@ -85,24 +83,22 @@ test("has an active timer that prevents exit", async () => {
   await new Promise(() => {});
 }, { timeout: 1000 });
 `,
-      });
+    });
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "test", "timer.test.ts"],
-        env: bunEnv,
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "timer.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      expect(stderr).toContain("hint: this test timed out because");
-      expect(stderr).toContain("active timer");
-      expect(exitCode).toBe(1);
-    },
-    60_000,
-  );
+    expect(stderr).toContain("hint: this test timed out because");
+    expect(stderr).toContain("active timer");
+    expect(exitCode).toBe(1);
+  }, 60_000);
 
   test.skipIf(isWindows)(
     "summary shows total dangling processes killed",

--- a/test/cli/test/dangling-process-diagnostics.test.ts
+++ b/test/cli/test/dangling-process-diagnostics.test.ts
@@ -1,0 +1,117 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("dangling process diagnostics", () => {
+  test("reports PID and command name for dangling processes on timeout", async () => {
+    using dir = tempDir("dangling-diag", {
+      "dangling.test.ts": `
+import { test } from "bun:test";
+
+test("spawns a process that outlives the test", async () => {
+  // Spawn a long-running process that won't exit before the test times out
+  Bun.spawn({ cmd: ["sleep", "30"] });
+  // Wait forever so the test times out
+  await new Promise(() => {});
+}, { timeout: 300 });
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "dangling.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    // Should show the command name and PID in the dangling process message
+    expect(stderr).toContain("killed 1 dangling process");
+    expect(stderr).toMatch(/pid \d+: sleep/);
+    // Should show the timeout message
+    expect(stderr).toContain("timed out after 300ms");
+    // Should show dangling process count in summary
+    expect(stderr).toContain("dangling process");
+    expect(stderr).toContain("killed");
+    expect(exitCode).toBe(1);
+  });
+
+  test("reports multiple dangling processes with individual details", async () => {
+    using dir = tempDir("dangling-multi", {
+      "multi-dangling.test.ts": `
+import { test } from "bun:test";
+
+test("spawns multiple processes that outlive the test", async () => {
+  Bun.spawn({ cmd: ["sleep", "30"] });
+  Bun.spawn({ cmd: ["sleep", "31"] });
+  Bun.spawn({ cmd: ["sleep", "32"] });
+  await new Promise(() => {});
+}, { timeout: 300 });
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "multi-dangling.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    // Should show count of dangling processes
+    expect(stderr).toContain("killed 3 dangling processes:");
+    // Should list each with pid and command
+    const pidMatches = stderr.match(/pid \d+: sleep/g);
+    expect(pidMatches).not.toBeNull();
+    expect(pidMatches!.length).toBe(3);
+    expect(exitCode).toBe(1);
+  });
+
+  test("summary shows total dangling processes killed", async () => {
+    using dir = tempDir("dangling-summary", {
+      "summary.test.ts": `
+import { test, expect } from "bun:test";
+
+test("clean test", () => {
+  expect(1 + 1).toBe(2);
+});
+
+test("leaky test", async () => {
+  Bun.spawn({ cmd: ["sleep", "30"] });
+  await new Promise(() => {});
+}, { timeout: 300 });
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "summary.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    // Summary should show pass, fail, and dangling process counts
+    expect(stderr).toContain("1 pass");
+    expect(stderr).toContain("1 fail");
+    expect(stderr).toContain("1 dangling process killed");
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/cli/test/dangling-process-diagnostics.test.ts
+++ b/test/cli/test/dangling-process-diagnostics.test.ts
@@ -25,7 +25,7 @@ test("spawns a process that outlives the test", async () => {
         stderr: "pipe",
       });
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stderr).toContain("killed 1 dangling process");
       expect(stderr).toMatch(/pid \d+: sleep/);
@@ -62,7 +62,7 @@ test("spawns multiple processes that outlive the test", async () => {
         stderr: "pipe",
       });
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stderr).toContain("killed 3 dangling processes:");
       const pidMatches = stderr.match(/pid \d+: sleep/g);
@@ -73,7 +73,7 @@ test("spawns multiple processes that outlive the test", async () => {
     60_000,
   );
 
-  test.skipIf(isWindows)(
+  test(
     "shows timeout hint for active timers",
     async () => {
       using dir = tempDir("dangling-timer", {
@@ -95,7 +95,7 @@ test("has an active timer that prevents exit", async () => {
         stderr: "pipe",
       });
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stderr).toContain("hint: this test timed out because");
       expect(stderr).toContain("active timer");
@@ -130,7 +130,7 @@ test("leaky test", async () => {
         stderr: "pipe",
       });
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stderr).toContain("1 pass");
       expect(stderr).toContain("1 fail");

--- a/test/cli/test/dangling-process-diagnostics.test.ts
+++ b/test/cli/test/dangling-process-diagnostics.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
-describe("dangling process diagnostics", () => {
+describe.skipIf(isWindows)("dangling process diagnostics", () => {
   test("reports PID, command name, and timeout hint for dangling processes", async () => {
     using dir = tempDir("dangling-diag", {
       "dangling.test.ts": `

--- a/test/cli/test/dangling-process-diagnostics.test.ts
+++ b/test/cli/test/dangling-process-diagnostics.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
-describe.skipIf(isWindows)("dangling process diagnostics", () => {
-  test("reports PID, command name, and timeout hint for dangling processes", async () => {
+// These tests use "sleep" which is not available on Windows.
+describe("dangling process diagnostics", () => {
+  test.skipIf(isWindows)("reports PID, command name, and timeout hint for dangling processes", async () => {
     using dir = tempDir("dangling-diag", {
       "dangling.test.ts": `
 import { test } from "bun:test";
@@ -33,7 +34,7 @@ test("spawns a process that outlives the test", async () => {
     expect(exitCode).toBe(1);
   }, 60_000);
 
-  test("reports multiple dangling processes with individual details", async () => {
+  test.skipIf(isWindows)("reports multiple dangling processes with individual details", async () => {
     using dir = tempDir("dangling-multi", {
       "multi-dangling.test.ts": `
 import { test } from "bun:test";
@@ -64,7 +65,7 @@ test("spawns multiple processes that outlive the test", async () => {
     expect(exitCode).toBe(1);
   }, 60_000);
 
-  test("shows timeout hint for active timers", async () => {
+  test.skipIf(isWindows)("shows timeout hint for active timers", async () => {
     using dir = tempDir("dangling-timer", {
       "timer.test.ts": `
 import { test } from "bun:test";
@@ -91,7 +92,7 @@ test("has an active timer that prevents exit", async () => {
     expect(exitCode).toBe(1);
   }, 60_000);
 
-  test("summary shows total dangling processes killed", async () => {
+  test.skipIf(isWindows)("summary shows total dangling processes killed", async () => {
     using dir = tempDir("dangling-summary", {
       "summary.test.ts": `
 import { test, expect } from "bun:test";

--- a/test/cli/test/dangling-process-diagnostics.test.ts
+++ b/test/cli/test/dangling-process-diagnostics.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("dangling process diagnostics", () => {
@@ -24,11 +24,7 @@ test("spawns a process that outlives the test", async () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // Should show the command name and PID in the dangling process message
     expect(stderr).toContain("killed 1 dangling process");
@@ -63,11 +59,7 @@ test("spawns multiple processes that outlive the test", async () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // Should show count of dangling processes
     expect(stderr).toContain("killed 3 dangling processes:");
@@ -102,11 +94,7 @@ test("leaky test", async () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // Summary should show pass, fail, and dangling process counts
     expect(stderr).toContain("1 pass");

--- a/test/cli/test/dangling-process-diagnostics.test.ts
+++ b/test/cli/test/dangling-process-diagnostics.test.ts
@@ -2,15 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("dangling process diagnostics", () => {
-  test("reports PID and command name for dangling processes on timeout", async () => {
+  test("reports PID, command name, and timeout hint for dangling processes", async () => {
     using dir = tempDir("dangling-diag", {
       "dangling.test.ts": `
 import { test } from "bun:test";
 
 test("spawns a process that outlives the test", async () => {
-  // Spawn a long-running process that won't exit before the test times out
   Bun.spawn({ cmd: ["sleep", "30"] });
-  // Wait forever so the test times out
   await new Promise(() => {});
 }, { timeout: 300 });
 `,
@@ -31,11 +29,13 @@ test("spawns a process that outlives the test", async () => {
     expect(stderr).toMatch(/pid \d+: sleep/);
     // Should show the timeout message
     expect(stderr).toContain("timed out after 300ms");
+    // Should show a hint explaining why the test timed out
+    expect(stderr).toContain("hint: this test timed out because");
+    expect(stderr).toContain("child process");
     // Should show dangling process count in summary
-    expect(stderr).toContain("dangling process");
-    expect(stderr).toContain("killed");
+    expect(stderr).toContain("1 dangling process killed");
     expect(exitCode).toBe(1);
-  });
+  }, 30_000);
 
   test("reports multiple dangling processes with individual details", async () => {
     using dir = tempDir("dangling-multi", {
@@ -68,7 +68,35 @@ test("spawns multiple processes that outlive the test", async () => {
     expect(pidMatches).not.toBeNull();
     expect(pidMatches!.length).toBe(3);
     expect(exitCode).toBe(1);
-  });
+  }, 30_000);
+
+  test("shows timeout hint for active timers", async () => {
+    using dir = tempDir("dangling-timer", {
+      "timer.test.ts": `
+import { test } from "bun:test";
+
+test("has an active timer that prevents exit", async () => {
+  setInterval(() => {}, 1000);
+  await new Promise(() => {});
+}, { timeout: 300 });
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "timer.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Should show a hint about active timers
+    expect(stderr).toContain("hint: this test timed out because");
+    expect(stderr).toContain("active timer");
+    expect(exitCode).toBe(1);
+  }, 30_000);
 
   test("summary shows total dangling processes killed", async () => {
     using dir = tempDir("dangling-summary", {
@@ -101,5 +129,5 @@ test("leaky test", async () => {
     expect(stderr).toContain("1 fail");
     expect(stderr).toContain("1 dangling process killed");
     expect(exitCode).toBe(1);
-  });
+  }, 30_000);
 });

--- a/test/cli/test/dangling-process-diagnostics.test.ts
+++ b/test/cli/test/dangling-process-diagnostics.test.ts
@@ -3,9 +3,11 @@ import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 // These tests use "sleep" which is not available on Windows.
 describe("dangling process diagnostics", () => {
-  test.skipIf(isWindows)("reports PID, command name, and timeout hint for dangling processes", async () => {
-    using dir = tempDir("dangling-diag", {
-      "dangling.test.ts": `
+  test.skipIf(isWindows)(
+    "reports PID, command name, and timeout hint for dangling processes",
+    async () => {
+      using dir = tempDir("dangling-diag", {
+        "dangling.test.ts": `
 import { test } from "bun:test";
 
 test("spawns a process that outlives the test", async () => {
@@ -13,30 +15,34 @@ test("spawns a process that outlives the test", async () => {
   await new Promise(() => {});
 }, { timeout: 1000 });
 `,
-    });
+      });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "dangling.test.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "dangling.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toContain("killed 1 dangling process");
-    expect(stderr).toMatch(/pid \d+: sleep/);
-    expect(stderr).toContain("timed out after 1000ms");
-    expect(stderr).toContain("hint: this test timed out because");
-    expect(stderr).toContain("child process");
-    expect(stderr).toContain("1 dangling process killed");
-    expect(exitCode).toBe(1);
-  }, 60_000);
+      expect(stderr).toContain("killed 1 dangling process");
+      expect(stderr).toMatch(/pid \d+: sleep/);
+      expect(stderr).toContain("timed out after 1000ms");
+      expect(stderr).toContain("hint: this test timed out because");
+      expect(stderr).toContain("child process");
+      expect(stderr).toContain("1 dangling process killed");
+      expect(exitCode).toBe(1);
+    },
+    60_000,
+  );
 
-  test.skipIf(isWindows)("reports multiple dangling processes with individual details", async () => {
-    using dir = tempDir("dangling-multi", {
-      "multi-dangling.test.ts": `
+  test.skipIf(isWindows)(
+    "reports multiple dangling processes with individual details",
+    async () => {
+      using dir = tempDir("dangling-multi", {
+        "multi-dangling.test.ts": `
 import { test } from "bun:test";
 
 test("spawns multiple processes that outlive the test", async () => {
@@ -46,28 +52,32 @@ test("spawns multiple processes that outlive the test", async () => {
   await new Promise(() => {});
 }, { timeout: 1000 });
 `,
-    });
+      });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "multi-dangling.test.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "multi-dangling.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toContain("killed 3 dangling processes:");
-    const pidMatches = stderr.match(/pid \d+: sleep/g);
-    expect(pidMatches).not.toBeNull();
-    expect(pidMatches!.length).toBe(3);
-    expect(exitCode).toBe(1);
-  }, 60_000);
+      expect(stderr).toContain("killed 3 dangling processes:");
+      const pidMatches = stderr.match(/pid \d+: sleep/g);
+      expect(pidMatches).not.toBeNull();
+      expect(pidMatches!.length).toBe(3);
+      expect(exitCode).toBe(1);
+    },
+    60_000,
+  );
 
-  test.skipIf(isWindows)("shows timeout hint for active timers", async () => {
-    using dir = tempDir("dangling-timer", {
-      "timer.test.ts": `
+  test.skipIf(isWindows)(
+    "shows timeout hint for active timers",
+    async () => {
+      using dir = tempDir("dangling-timer", {
+        "timer.test.ts": `
 import { test } from "bun:test";
 
 test("has an active timer that prevents exit", async () => {
@@ -75,26 +85,30 @@ test("has an active timer that prevents exit", async () => {
   await new Promise(() => {});
 }, { timeout: 1000 });
 `,
-    });
+      });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "timer.test.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "timer.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toContain("hint: this test timed out because");
-    expect(stderr).toContain("active timer");
-    expect(exitCode).toBe(1);
-  }, 60_000);
+      expect(stderr).toContain("hint: this test timed out because");
+      expect(stderr).toContain("active timer");
+      expect(exitCode).toBe(1);
+    },
+    60_000,
+  );
 
-  test.skipIf(isWindows)("summary shows total dangling processes killed", async () => {
-    using dir = tempDir("dangling-summary", {
-      "summary.test.ts": `
+  test.skipIf(isWindows)(
+    "summary shows total dangling processes killed",
+    async () => {
+      using dir = tempDir("dangling-summary", {
+        "summary.test.ts": `
 import { test, expect } from "bun:test";
 
 test("clean test", () => {
@@ -106,21 +120,23 @@ test("leaky test", async () => {
   await new Promise(() => {});
 }, { timeout: 1000 });
 `,
-    });
+      });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "summary.test.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "summary.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toContain("1 pass");
-    expect(stderr).toContain("1 fail");
-    expect(stderr).toContain("1 dangling process killed");
-    expect(exitCode).toBe(1);
-  }, 60_000);
+      expect(stderr).toContain("1 pass");
+      expect(stderr).toContain("1 fail");
+      expect(stderr).toContain("1 dangling process killed");
+      expect(exitCode).toBe(1);
+    },
+    60_000,
+  );
 });

--- a/test/cli/test/dangling-process-diagnostics.test.ts
+++ b/test/cli/test/dangling-process-diagnostics.test.ts
@@ -10,7 +10,7 @@ import { test } from "bun:test";
 test("spawns a process that outlives the test", async () => {
   Bun.spawn({ cmd: ["sleep", "30"] });
   await new Promise(() => {});
-}, { timeout: 300 });
+}, { timeout: 1000 });
 `,
     });
 
@@ -24,18 +24,14 @@ test("spawns a process that outlives the test", async () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // Should show the command name and PID in the dangling process message
     expect(stderr).toContain("killed 1 dangling process");
     expect(stderr).toMatch(/pid \d+: sleep/);
-    // Should show the timeout message
-    expect(stderr).toContain("timed out after 300ms");
-    // Should show a hint explaining why the test timed out
+    expect(stderr).toContain("timed out after 1000ms");
     expect(stderr).toContain("hint: this test timed out because");
     expect(stderr).toContain("child process");
-    // Should show dangling process count in summary
     expect(stderr).toContain("1 dangling process killed");
     expect(exitCode).toBe(1);
-  }, 30_000);
+  }, 60_000);
 
   test("reports multiple dangling processes with individual details", async () => {
     using dir = tempDir("dangling-multi", {
@@ -47,7 +43,7 @@ test("spawns multiple processes that outlive the test", async () => {
   Bun.spawn({ cmd: ["sleep", "31"] });
   Bun.spawn({ cmd: ["sleep", "32"] });
   await new Promise(() => {});
-}, { timeout: 300 });
+}, { timeout: 1000 });
 `,
     });
 
@@ -61,14 +57,12 @@ test("spawns multiple processes that outlive the test", async () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // Should show count of dangling processes
     expect(stderr).toContain("killed 3 dangling processes:");
-    // Should list each with pid and command
     const pidMatches = stderr.match(/pid \d+: sleep/g);
     expect(pidMatches).not.toBeNull();
     expect(pidMatches!.length).toBe(3);
     expect(exitCode).toBe(1);
-  }, 30_000);
+  }, 60_000);
 
   test("shows timeout hint for active timers", async () => {
     using dir = tempDir("dangling-timer", {
@@ -78,7 +72,7 @@ import { test } from "bun:test";
 test("has an active timer that prevents exit", async () => {
   setInterval(() => {}, 1000);
   await new Promise(() => {});
-}, { timeout: 300 });
+}, { timeout: 1000 });
 `,
     });
 
@@ -92,11 +86,10 @@ test("has an active timer that prevents exit", async () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // Should show a hint about active timers
     expect(stderr).toContain("hint: this test timed out because");
     expect(stderr).toContain("active timer");
     expect(exitCode).toBe(1);
-  }, 30_000);
+  }, 60_000);
 
   test("summary shows total dangling processes killed", async () => {
     using dir = tempDir("dangling-summary", {
@@ -110,7 +103,7 @@ test("clean test", () => {
 test("leaky test", async () => {
   Bun.spawn({ cmd: ["sleep", "30"] });
   await new Promise(() => {});
-}, { timeout: 300 });
+}, { timeout: 1000 });
 `,
     });
 
@@ -124,10 +117,9 @@ test("leaky test", async () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // Summary should show pass, fail, and dangling process counts
     expect(stderr).toContain("1 pass");
     expect(stderr).toContain("1 fail");
     expect(stderr).toContain("1 dangling process killed");
     expect(exitCode).toBe(1);
-  }, 30_000);
+  }, 60_000);
 });


### PR DESCRIPTION
## Context

Based on feedback from a user who migrated from `bun test` to Vitest ([gist](https://gist.githubusercontent.com/kody-bot/888c66c3c9c01f9a39029171dce26bb7/raw/2659021c693cdbfdeb55cc3bdfacef86e757b35c/why-i-migrated-from-bun-test-to-vitest.md)). Their top pain points were:
- Process-heavy tests hang with minimal diagnostics
- No way to tell *why* a test is hanging
- No distinction between test timeout and resource leaks

## Changes

### 1. Dangling process diagnostics with PID and command name

Previously: `killed 1 dangling process`

Now: `killed 1 dangling process (pid 12345: sleep)`

For multiple:
```
killed 3 dangling processes:
  pid 12345: sleep
  pid 12346: node
  pid 12347: wrangler
```

### 2. Timeout diagnostic hints — tells you WHY the test is hanging

`hint: this test timed out because 1 child process did not exit, 1 active timer`

Checks for child processes (killed or still running) and active setTimeout/setInterval timers.

### 3. Summary line at end of test run

Shows `1 dangling process killed` in summary, on both normal completion and --bail early exit.

## Implementation

- ProcessAutoKiller stores argv0 alongside each tracked process
- Result.deinit() for proper ownership cleanup of command strings
- bun.handleOom for command string duplication (not silent null)
- printTimeoutHint checks active_timer_count and auto_killer.trackedCount()
- Dangling process summary moved into printSummary() for bail path coverage

## Verification

```
bun bd test test/cli/test/dangling-process-diagnostics.test.ts  → 4 pass
USE_SYSTEM_BUN=1 bun test test/cli/test/dangling-process-diagnostics.test.ts → 4 fail
```