### PR TITLE
Validate first argument to mock.module() is a string

### DIFF
--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -511,6 +511,11 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         return {};
     }
 
+    if (!callframe->argument(0).isString()) {
+        scope.throwException(lexicalGlobalObject, JSC::createTypeError(lexicalGlobalObject, "mock.module() expects a string as the first argument"_s));
+        return {};
+    }
+
     JSC::JSString* specifierString = callframe->argument(0).toString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     WTF::String specifier = specifierString->value(globalObject);

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -156,6 +156,13 @@ test("mocking a package", async () => {
   expect(require("ha-ha-ha").wow()).toBe(43);
 });
 
+test("mock.module throws TypeError for non-string first argument", () => {
+  expect(() => mock.module(123 as any, () => ({}))).toThrow(TypeError);
+  expect(() => mock.module({} as any, () => ({}))).toThrow(TypeError);
+  expect(() => mock.module(null as any, () => ({}))).toThrow(TypeError);
+  expect(() => mock.module(undefined as any, () => ({}))).toThrow(TypeError);
+});
+
 test("mocking a builtin", async () => {
   mock.module("fs/promises", () => {
     return {


### PR DESCRIPTION
\`mock.module()\` called \`.toString()\` on its first argument without checking the type, allowing non-string values (objects, numbers, etc.) to be coerced into nonsensical module specifiers like \`"[object Object]"\`. These would then enter the module resolver and trigger auto-install, crashing in the package manager's allocator with a corrupted length (SIGSEGV in \`mem.Allocator.rawRemap\`).

**Fix:** Add a string type check before coercion so non-string arguments throw a \`TypeError\` instead of crashing.

**Root cause:** \`BunPlugin.cpp:514\` — \`callframe->argument(0).toString(globalObject)\` was called unconditionally. When fuzzilli passed \`Intl\` (an object) as the first argument, it was coerced to \`"[object Object]"\`, which then went through the full module resolution path including package auto-install, leading to a segfault.

---

Crash fingerprint: \`08c481bb726878bb\`