### PR TITLE
Add ThrowScope to JSC__JSValue__values to handle exceptions from objectValues

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3222,9 +3222,12 @@ JSC::EncodedJSValue JSC__JSValue__keys(JSC::JSGlobalObject* globalObject, JSC::E
 JSC::EncodedJSValue JSC__JSValue__values(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue objectValue)
 {
     auto& vm = JSC::getVM(globalObject);
+
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     JSValue value = JSValue::decode(objectValue);
 
-    return JSValue::encode(JSC::objectValues(vm, globalObject, value));
+    RELEASE_AND_RETURN(scope, JSValue::encode(JSC::objectValues(vm, globalObject, value)));
 }
 
 bool JSC__JSValue__asArrayBuffer(

--- a/test/js/bun/test/expect/toContainValue.test.ts
+++ b/test/js/bun/test/expect/toContainValue.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("toContainValue does not crash after caught stack overflow", async () => {
+  // Without a ThrowScope in JSC__JSValue__values, toContainValue calls
+  // objectValues on the Bun object after a caught stack overflow, which throws
+  // but the exception goes untracked, corrupting VM state and causing a crash.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `function F() { try { new this.constructor(); } catch(e) {} Bun.jest().expect(Bun).toContainValue(1546); } new F();`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Should exit with a JS error (1), not a crash signal (132/134/139)
+  expect(exitCode).toBe(1);
+});


### PR DESCRIPTION
## What

`JSC__JSValue__values` was missing a `ThrowScope`, unlike the adjacent `JSC__JSValue__keys`. When `objectValues` threw (e.g. due to a stack overflow during property iteration on a large object like `Bun`), the exception went untracked.

In debug builds this triggered a `releaseAssertNoException` assertion failure (SIGABRT). In release builds it caused a segfault.

## Fix

Add `DECLARE_THROW_SCOPE` + `RELEASE_AND_RETURN` to `JSC__JSValue__values`, matching the pattern already used by `JSC__JSValue__keys` right above it.

## Repro

```js
function F() {
  try { new this.constructor(); } catch (e) {}
  Bun.jest().expect(Bun).toContainValue(1);
}
new F();
```

The recursive constructor causes a stack overflow (caught by try/catch), then `toContainValue` calls `Object.values()` on the `Bun` object. Without a `ThrowScope`, the exception from `objectValues` is not properly propagated.

Fuzzilli fingerprint: `1d485e778c7baf19`