### PR TITLE
Fix division by zero in BlockList.estimatedSize and PackedMap.memoryCost

### DIFF
--- a/src/bake/DevServer/PackedMap.zig
+++ b/src/bake/DevServer/PackedMap.zig
@@ -106,7 +106,7 @@ pub const Shared = union(enum) {
     /// Amortized memory cost across all references to the same `PackedMap`
     pub fn memoryCost(self: Shared) usize {
         return switch (self) {
-            .some => |ptr| ptr.get().memoryCost() / ptr.strongCount(),
+            .some => |ptr| ptr.get().memoryCost() / @max(ptr.strongCount(), 1),
             else => 0,
         };
     }


### PR DESCRIPTION
\`BlockList.estimatedSize\` divides by \`ref_count.get()\` which can return 0 when called from JSC's GC (\`visitChildren\`/\`estimatedSize\`) after the ref count has been decremented to zero. On x86-64, integer division by zero raises SIGFPE (signal 8).

The same pattern exists in \`PackedMap.Shared.memoryCost\` which divides by \`strongCount()\`.

Both are fixed by using \`@max(count, 1)\` to prevent division by zero.

The crash is flaky and depends on GC timing — it was found by Fuzzilli with a script that creates a \`RedisClient\`, calls \`rpop()\`, and then forces \`Bun.gc(true)\`.

---

Crash fingerprint: \`b246ff98ec6d10e8\`