### PR TITLE
Fix null pointer crash in lazy property reification during deepEquals

### DIFF
--- a/src/jsc/bindings/BunObject+exports.h
+++ b/src/jsc/bindings/BunObject+exports.h
@@ -94,7 +94,9 @@ FOR_EACH_GETTER(DECLARE_ZIG_BUN_OBJECT_GETTER);
 
 // definition of the C++ wrapper to call the Zig function
 #define DEFINE_ZIG_BUN_OBJECT_GETTER_WRAPPER(name) static JSC::JSValue BunObject_lazyPropCb_wrap_##name(JSC::VM &vm, JSC::JSObject *object) { \
-    return JSC::JSValue::decode(BunObject_lazyPropCb_##name(object->globalObject(), object)); \
+    JSC::JSValue result = JSC::JSValue::decode(BunObject_lazyPropCb_##name(object->globalObject(), object)); \
+    if (!result) [[unlikely]] return JSC::jsUndefined(); \
+    return result; \
 } \
 
 FOR_EACH_GETTER(DEFINE_ZIG_BUN_OBJECT_GETTER_WRAPPER);

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -319,7 +319,7 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
 #if BUN_DEBUG
     if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
 #endif
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
 
@@ -331,7 +331,7 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
 #if BUN_DEBUG
     if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
 #endif
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));
 }
@@ -366,20 +366,20 @@ static JSValue constructBunShell(VM& vm, JSObject* bunObject)
     args.append(createShellInterpreterFunction);
     args.append(createParsedShellScript);
     JSC::JSValue shell = JSC::call(globalObject, createShellFn, args, "BunShell"_s);
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
 
     if (!shell.isObject()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Internal error: BunShell constructor did not return an object"_s);
-        return {};
+        return jsUndefined();
     }
 
     auto* bunShell = shell.getObject();
 
     auto ShellError = bunShell->get(globalObject, JSC::Identifier::fromString(vm, "ShellError"_s));
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
     if (!ShellError.isObject()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Internal error: BunShell.ShellError is not an object"_s);
-        return {};
+        return jsUndefined();
     }
 
     bunShell->putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "braces"_s), 1, Generated::BunObject::jsBraces, ImplementationVisibility::Public, NoIntrinsic, JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | 0);

--- a/test/js/bun/deep-equals-lazy-property-crash.test.ts
+++ b/test/js/bun/deep-equals-lazy-property-crash.test.ts
@@ -7,11 +7,12 @@ test("deepEquals does not crash when lazy property callback fails after stack ov
       bunExe(),
       "-e",
       `
-      function F4() {
-        try { new F4(); } catch (e) {}
+      function F4(n) {
+        if (n <= 0) { throw new RangeError("stack"); }
+        try { new F4(n - 1); } catch (e) {}
         Bun.deepEquals(Uint8Array, Bun);
       }
-      new F4();
+      new F4(1000);
       console.log("ok");
       `,
     ],

--- a/test/js/bun/deep-equals-lazy-property-crash.test.ts
+++ b/test/js/bun/deep-equals-lazy-property-crash.test.ts
@@ -7,13 +7,12 @@ test("deepEquals does not crash when lazy property callback fails after stack ov
       bunExe(),
       "-e",
       `
-      var depth = 0;
       function F4() {
-        if (depth++ > 100) throw new Error("too deep");
         try { new F4(); } catch (e) {}
         Bun.deepEquals(Uint8Array, Bun);
       }
       new F4();
+      console.log("ok");
       `,
     ],
     env: bunEnv,
@@ -21,8 +20,8 @@ test("deepEquals does not crash when lazy property callback fails after stack ov
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
-  expect(stderr).not.toContain("null pointer");
+  expect(stdout.trim()).toBe("ok");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/deep-equals-lazy-property-crash.test.ts
+++ b/test/js/bun/deep-equals-lazy-property-crash.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test";
+import { bunExe, bunEnv } from "harness";
+
+test("deepEquals does not crash when lazy property callback fails after stack overflow", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      var depth = 0;
+      function F4() {
+        if (depth++ > 100) throw new Error("too deep");
+        try { new F4(); } catch (e) {}
+        Bun.deepEquals(Uint8Array, Bun);
+      }
+      new F4();
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("null pointer");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/deep-equals-lazy-property-crash.test.ts
+++ b/test/js/bun/deep-equals-lazy-property-crash.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { bunExe, bunEnv } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 test("deepEquals does not crash when lazy property callback fails after stack overflow", async () => {
   await using proc = Bun.spawn({

--- a/test/js/bun/deep-equals-lazy-property-crash.test.ts
+++ b/test/js/bun/deep-equals-lazy-property-crash.test.ts
@@ -7,18 +7,17 @@ test("deepEquals does not crash when lazy property callback fails after stack ov
       bunExe(),
       "-e",
       `
-      function F4(n) {
-        if (n <= 0) { throw new RangeError("stack"); }
-        try { new F4(n - 1); } catch (e) {}
+      function F4() {
+        try { new F4(); } catch (e) {}
         Bun.deepEquals(Uint8Array, Bun);
       }
-      new F4(1000);
+      new F4();
       console.log("ok");
       `,
     ],
     env: bunEnv,
     stdout: "pipe",
-    stderr: "pipe",
+    stderr: "inherit",
   });
 
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);

--- a/test/js/bun/deep-equals-lazy-property-crash.test.ts
+++ b/test/js/bun/deep-equals-lazy-property-crash.test.ts
@@ -7,9 +7,10 @@ test("deepEquals does not crash when lazy property callback fails after stack ov
       bunExe(),
       "-e",
       `
+      var count = 0;
       function F4() {
         try { new F4(); } catch (e) {}
-        Bun.deepEquals(Uint8Array, Bun);
+        if (count++ < 5) Bun.deepEquals(Uint8Array, Bun);
       }
       new F4();
       console.log("ok");


### PR DESCRIPTION
After a caught stack overflow, calling `Bun.deepEquals()` with the `Bun` namespace object as an argument could crash with a null pointer dereference in `isGetterSetter()`.

## Root cause

When `deepEquals` iterates the properties of the `Bun` object, it triggers lazy property reification via `getIfPropertyExists` → `setUpStaticFunctionSlot` → `reifyStaticProperty`. The lazy property callbacks (both Zig-backed and C++) can return an empty `JSValue` (`.zero` / `{}`) when they encounter an exception (like a stack overflow propagating through). This empty value was passed directly to `putDirect()`, which called `isGetterSetter()` on a null cell pointer.

## Fix

- **Zig callback wrapper** (`BunObject+exports.h`): Return `jsUndefined()` instead of an empty JSValue when the callback fails. The pending exception is still on the VM and will be caught by `RETURN_IF_EXCEPTION` in the caller.
- **C++ callbacks** (`BunObject.cpp`): Change `constructBunShell`, `defaultBunSQLObject`, and `constructBunSQLObject` to return `jsUndefined()` instead of `{}` on exception.

## Repro

```js
function F4() {
    try { new F4(); } catch (e) {}
    Bun.deepEquals(Uint8Array, Bun);
}
new F4();
```

Crash: `JSCJSValueCellInlines.h:67:34: member call on null pointer of type 'JSC::JSCell'`