### PR TITLE
fix: return empty resolved promise when ByteBlobLoader store is null

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,8 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    var empty: Blob.Any = .{ .Blob = Blob.initEmpty(globalThis) };
+    return empty.toPromise(globalThis, action);
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {


### PR DESCRIPTION
When `toBufferedValue` was called on a `ByteBlobLoader` whose store had already been consumed (null), it returned `.zero` without setting a JavaScript exception. This violated the host function contract that returning `.zero` means an exception was thrown, triggering a debug assertion crash: `Expected an exception to be thrown`.

The fix returns a resolved promise from an empty Blob instead of `.zero`, matching how `ByteStream` handles the equivalent case.

**Reproduction:**
```js
const resp = Response.json({ a: 1 });
const body = resp.body;
await body.text();   // consumes the store
await body.text();   // crashed: .zero returned without exception
```

Crash fingerprint: `a136028432ab06ee`