### PR TITLE
Handle missing exception when BunString__fromJS fails

### DIFF
--- a/src/string.zig
+++ b/src/string.zig
@@ -536,11 +536,17 @@ pub const String = extern struct {
         const has_exception = scope.hasExceptionOrFalseWhenAssertionsAreDisabled();
         if (ok) {
             bun.debugAssert(out.tag != .Dead);
-        } else {
-            bun.debugAssert(has_exception);
+            return out;
         }
 
-        return if (ok) out else error.JSError;
+        // BunString__fromJS returning false without an exception can happen when
+        // a Proxy trap's try/catch clears a pending exception during toString().
+        // Throw a TypeError so callers always see a proper JS error.
+        if (!has_exception and !globalObject.hasException()) {
+            return globalObject.throwTypeError("Failed to convert value to string", .{});
+        }
+
+        return error.JSError;
     }
 
     pub fn toJS(this: *const String, globalObject: *bun.jsc.JSGlobalObject) bun.JSError!jsc.JSValue {

--- a/test/js/bun/io/bun-write-proxy-prototype.test.ts
+++ b/test/js/bun/io/bun-write-proxy-prototype.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "bun:test";
+import { tempDir } from "harness";
+import path from "path";
+
+test("Bun.write with proxy-prototyped constructor does not crash", async () => {
+  using dir = tempDir("bun-write-proxy", {});
+  const origProto = Object.getPrototypeOf(Buffer);
+  try {
+    Object.setPrototypeOf(
+      Buffer,
+      new Proxy(origProto, {
+        get(target, key, receiver) {
+          try {
+            void Reflect.has(target, key);
+          } catch (_) {}
+          return Reflect.get(target, key, receiver);
+        },
+      }),
+    );
+    // Buffer is a constructor (InternalFunction). Writing it as data should
+    // convert via toString(), not crash.
+    const result = await Bun.write(path.join(String(dir), "out.txt"), Buffer);
+    expect(result).toBeGreaterThan(0);
+  } finally {
+    Object.setPrototypeOf(Buffer, origProto);
+  }
+});

--- a/test/js/bun/io/bun-write-proxy-prototype.test.ts
+++ b/test/js/bun/io/bun-write-proxy-prototype.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { tempDir } from "harness";
 import path from "path";
 


### PR DESCRIPTION
When `BunString__fromJS` returns false (toString conversion failed) but no JS exception is pending — which can happen when a Proxy trap's try/catch clears the exception during the `toString()` call — `String.fromJS` hit `unreachable` via `debugAssert(has_exception)`.

**Fix:** Check `globalObject.hasException()` directly (independent of `ci_assert`) and throw a `TypeError` when the conversion fails without a pending exception, instead of crashing.

Fingerprint: cb01d84a4d6c4080