### PR TITLE
fix(bundler): inline `Bun.env` the same as `process.env` with `--env`

### DIFF
--- a/src/bun.js/api/server/HTMLBundle.zig
+++ b/src/bun.js/api/server/HTMLBundle.zig
@@ -281,6 +281,7 @@ pub const Route = struct {
 
         if (!is_development) {
             bun.handleOom(config.define.put("process.env.NODE_ENV", "\"production\""));
+            bun.handleOom(config.define.put("Bun.env.NODE_ENV", "\"production\""));
             config.jsx.development = false;
         } else {
             config.force_node_env = .development;

--- a/src/env_loader.zig
+++ b/src/env_loader.zig
@@ -409,7 +409,7 @@ pub const Loader = struct {
             }
         }
 
-        // We have to copy all the keys to prepend "process.env" :/
+        // We have to copy all the keys to prepend "process.env" and "Bun.env"
         var key_buf_len: usize = 0;
         var e_strings_to_allocate: usize = 0;
 
@@ -439,11 +439,11 @@ pub const Loader = struct {
 
             if (key_buf_len > 0) {
                 iter.reset();
-                key_buf = try allocator.alloc(u8, key_buf_len + key_count * "process.env.".len);
+                key_buf = try allocator.alloc(u8, key_buf_len * 2 + key_count * ("process.env.".len + "Bun.env.".len));
                 var key_writer = std.Io.Writer.fixed(key_buf);
                 const js_ast = bun.ast;
 
-                var e_strings = try allocator.alloc(js_ast.E.String, e_strings_to_allocate * 2);
+                var e_strings = try allocator.alloc(js_ast.E.String, e_strings_to_allocate * 2 + framework_defaults.keys.len);
                 errdefer allocator.free(e_strings);
                 errdefer allocator.free(key_buf);
 
@@ -452,29 +452,30 @@ pub const Loader = struct {
                         const value: string = entry.value_ptr.value;
 
                         if (strings.startsWith(entry.key_ptr.*, prefix)) {
-                            key_writer.print("process.env.{s}", .{entry.key_ptr.*}) catch |err| switch (err) {
-                                error.WriteFailed => unreachable, // miscalculated length of key_buf above
-                            };
-                            const key_str = key_writer.buffered();
-                            key_writer = std.Io.Writer.fixed(key_writer.unusedCapacitySlice());
+                            inline for (.{ "process.env.", "Bun.env." }) |env_prefix| {
+                                key_writer.print(env_prefix ++ "{s}", .{entry.key_ptr.*}) catch |err| switch (err) {
+                                    error.WriteFailed => unreachable, // miscalculated length of key_buf above
+                                };
+                                const key_str = key_writer.buffered();
+                                key_writer = std.Io.Writer.fixed(key_writer.unusedCapacitySlice());
 
-                            e_strings[0] = js_ast.E.String{
-                                .data = if (value.len > 0)
-                                    @as([*]u8, @ptrFromInt(@intFromPtr(value.ptr)))[0..value.len]
-                                else
-                                    &[_]u8{},
-                            };
-                            const expr_data = js_ast.Expr.Data{ .e_string = &e_strings[0] };
+                                e_strings[0] = js_ast.E.String{
+                                    .data = if (value.len > 0)
+                                        @as([*]u8, @ptrFromInt(@intFromPtr(value.ptr)))[0..value.len]
+                                    else
+                                        &[_]u8{},
+                                };
 
-                            _ = try to_string.getOrPutValue(
-                                key_str,
-                                .init(.{
-                                    .can_be_removed_if_unused = true,
-                                    .call_can_be_unwrapped_if_unused = .if_unused,
-                                    .value = expr_data,
-                                }),
-                            );
-                            e_strings = e_strings[1..];
+                                _ = try to_string.getOrPutValue(
+                                    key_str,
+                                    .init(.{
+                                        .can_be_removed_if_unused = true,
+                                        .call_can_be_unwrapped_if_unused = .if_unused,
+                                        .value = js_ast.Expr.Data{ .e_string = &e_strings[0] },
+                                    }),
+                                );
+                                e_strings = e_strings[1..];
+                            }
                         } else {
                             const hash = bun.hash(entry.key_ptr.*);
 
@@ -506,30 +507,30 @@ pub const Loader = struct {
                     while (iter.next()) |entry| {
                         const value: string = entry.value_ptr.value;
 
-                        key_writer.print("process.env.{s}", .{entry.key_ptr.*}) catch |err| switch (err) {
-                            error.WriteFailed => unreachable, // miscalculated length of key_buf above
-                        };
-                        const key_str = key_writer.buffered();
-                        key_writer = std.Io.Writer.fixed(key_writer.unusedCapacitySlice());
+                        inline for (.{ "process.env.", "Bun.env." }) |env_prefix| {
+                            key_writer.print(env_prefix ++ "{s}", .{entry.key_ptr.*}) catch |err| switch (err) {
+                                error.WriteFailed => unreachable, // miscalculated length of key_buf above
+                            };
+                            const key_str = key_writer.buffered();
+                            key_writer = std.Io.Writer.fixed(key_writer.unusedCapacitySlice());
 
-                        e_strings[0] = js_ast.E.String{
-                            .data = if (entry.value_ptr.value.len > 0)
-                                @as([*]u8, @ptrFromInt(@intFromPtr(entry.value_ptr.value.ptr)))[0..value.len]
-                            else
-                                &[_]u8{},
-                        };
+                            e_strings[0] = js_ast.E.String{
+                                .data = if (value.len > 0)
+                                    @as([*]u8, @ptrFromInt(@intFromPtr(value.ptr)))[0..value.len]
+                                else
+                                    &[_]u8{},
+                            };
 
-                        const expr_data = js_ast.Expr.Data{ .e_string = &e_strings[0] };
-
-                        _ = try to_string.getOrPutValue(
-                            key_str,
-                            .init(.{
-                                .can_be_removed_if_unused = true,
-                                .call_can_be_unwrapped_if_unused = .if_unused,
-                                .value = expr_data,
-                            }),
-                        );
-                        e_strings = e_strings[1..];
+                            _ = try to_string.getOrPutValue(
+                                key_str,
+                                .init(.{
+                                    .can_be_removed_if_unused = true,
+                                    .call_can_be_unwrapped_if_unused = .if_unused,
+                                    .value = js_ast.Expr.Data{ .e_string = &e_strings[0] },
+                                }),
+                            );
+                            e_strings = e_strings[1..];
+                        }
                     }
                 }
             }

--- a/src/options.zig
+++ b/src/options.zig
@@ -1543,7 +1543,15 @@ pub fn definesFromTransformOptions(
             quoted_node_env,
         );
         _ = try user_defines.getOrPutValue(
+            "Bun.env.NODE_ENV",
+            quoted_node_env,
+        );
+        _ = try user_defines.getOrPutValue(
             "process.env.BUN_ENV",
+            quoted_node_env,
+        );
+        _ = try user_defines.getOrPutValue(
+            "Bun.env.BUN_ENV",
             quoted_node_env,
         );
 
@@ -2228,9 +2236,10 @@ pub const TransformOptions = struct {
         }
 
         var define = bun.StringHashMap(string).init(allocator);
-        try define.ensureTotalCapacity(1);
+        try define.ensureTotalCapacity(2);
 
         define.putAssumeCapacity("process.env.NODE_ENV", "development");
+        define.putAssumeCapacity("Bun.env.NODE_ENV", "development");
 
         var loader = Loader.file;
         if (defaultLoaders.get(entryPoint.path.name.ext)) |defaultLoader| {

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -92,6 +92,56 @@ for (let backend of ["api", "cli"] as const) {
         },
       });
 
+    // Test that Bun.env works the same as process.env with inline mode
+    if (backend === "cli")
+      itBundled("env/inline-bun-env", {
+        env: {
+          FOO: "bar",
+          BAZ: "123",
+        },
+        backend: backend,
+        dotenv: "inline",
+        files: {
+          "/a.js": `
+        console.log(Bun.env.FOO);
+        console.log(Bun.env.BAZ);
+      `,
+        },
+        run: {
+          env: {
+            FOO: "barz",
+            BAZ: "123z",
+          },
+          stdout: "bar\n123\n",
+        },
+      });
+
+    // Test that Bun.env works with pattern matching
+    if (backend === "cli")
+      itBundled("env/pattern-matching-bun-env", {
+        env: {
+          PUBLIC_FOO: "public_value",
+          PUBLIC_BAR: "another_public",
+          PRIVATE_SECRET: "secret_value",
+        },
+        dotenv: "PUBLIC_*",
+        backend: backend,
+        files: {
+          "/a.js": `
+        console.log(Bun.env.PUBLIC_FOO);
+        console.log(Bun.env.PUBLIC_BAR);
+        console.log(Bun.env.PRIVATE_SECRET);
+      `,
+        },
+        run: {
+          env: {
+            PUBLIC_FOO: "BAD_FOO",
+            PUBLIC_BAR: "BAD_BAR",
+          },
+          stdout: "public_value\nanother_public\nundefined\n",
+        },
+      });
+
     if (backend === "cli")
       // Test nested environment variable references
       itBundled("nested-refs", {


### PR DESCRIPTION
Fixes #20430

`bun build --env=inline` and `bun build --env='PREFIX_*'` inline `process.env.<KEY>` but leave `Bun.env.<KEY>` untouched. Since `Bun.env` is equivalent to `process.env`, both should be inlined.

The bundler's define system only registered `process.env.<KEY>` entries. This PR adds `Bun.env.<KEY>` defines alongside them in:

- **`env_loader.zig`** — `copyForDefine`, both `prefix` and `load_all` paths. Uses `inline for` over both prefixes to avoid duplication. Also tightened the `e_strings` allocation to the exact worst-case bound.
- **`options.zig`** — default `NODE_ENV` / `BUN_ENV` defines.
- **`HTMLBundle.zig`** — production `NODE_ENV` define in the Bake path.

## Example

**test.js**

```
console.log(Bun.env.FOO)
```

**Before:**
```
$ FOO=hello bun build --env=inline test.js
console.log(Bun.env.FOO);
```

**After:**
```
$ FOO=hello bun build --env=inline test.js
console.log("hello");
```