### PR TITLE
ci: persist build cache across runs, parallelize release upload

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -124,7 +124,7 @@ RUN ARCH=$(if [ "$TARGETARCH" = "arm64" ]; then echo "arm64"; else echo "amd64";
     tar -xzf /tmp/buildkite-agent.tar.gz -C /tmp/buildkite-agent && \
     mv /tmp/buildkite-agent/buildkite-agent /usr/bin/buildkite-agent
 
-RUN mkdir -p /var/cache/buildkite-agent /var/log/buildkite-agent /var/run/buildkite-agent /etc/buildkite-agent /var/lib/buildkite-agent/cache/bun
+RUN mkdir -p /var/cache/buildkite-agent /var/log/buildkite-agent /var/run/buildkite-agent /etc/buildkite-agent /var/lib/buildkite-agent/cache/bun /var/lib/buildkite-agent/cache/build
 
 # The following is necessary to configure buildkite to use a stable
 # checkout directory for ccache to be effective.
@@ -134,6 +134,7 @@ RUN mkdir -p -m 755 /var/lib/buildkite-agent/hooks && \
 set -efu
 
 export BUILDKITE_BUILD_CHECKOUT_PATH=/var/lib/buildkite-agent/build
+export BUN_BUILD_CACHE_PATH=/var/lib/buildkite-agent/cache/build
 EOF
 
 RUN chmod 744 /var/lib/buildkite-agent/hooks/environment

--- a/.buildkite/scripts/upload-release.sh
+++ b/.buildkite/scripts/upload-release.sh
@@ -243,9 +243,14 @@ function create_release() {
     wait
   }
 
+  local max_jobs=6
   for artifact in "${artifacts[@]}"; do
-    upload_artifact "$artifact"
+    while (( $(jobs -rp | wc -l) >= max_jobs )); do
+      wait -n
+    done
+    upload_artifact "$artifact" &
   done
+  wait
 
   update_github_release "$tag"
   create_sentry_release "$tag"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1437,7 +1437,7 @@ create_buildkite_user() {
 		execute_sudo usermod -aG docker "$user"
 	fi
 
-	buildkite_paths="$home /var/cache/buildkite-agent /var/log/buildkite-agent /var/run/buildkite-agent /var/run/buildkite-agent/buildkite-agent.sock"
+	buildkite_paths="$home $home/cache/build /var/cache/buildkite-agent /var/log/buildkite-agent /var/run/buildkite-agent /var/run/buildkite-agent/buildkite-agent.sock"
 	for path in $buildkite_paths; do
 		create_directory "$path"
 	done
@@ -1462,6 +1462,7 @@ create_buildkite_user() {
 set -efu
 
 export BUILDKITE_BUILD_CHECKOUT_PATH=${home}/build
+export BUN_BUILD_CACHE_PATH=${home}/cache/build
 EOF
 	execute_sudo chmod +x "${hook_dir}/environment"
 	execute_sudo chown -R "$user:$group" "$hook_dir"

--- a/scripts/build/ci.ts
+++ b/scripts/build/ci.ts
@@ -9,7 +9,7 @@
 
 import { spawn as nodeSpawn, spawnSync } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
-import { basename, relative, resolve } from "node:path";
+import { basename, relative, resolve, sep } from "node:path";
 // @ts-ignore — utils.mjs has JSDoc types but no .d.ts
 import * as utils from "../utils.mjs";
 import { bunExeName, shouldStrip, type BunOutput } from "./bun.ts";
@@ -261,7 +261,12 @@ export function uploadArtifacts(cfg: Config, output: BunOutput): void {
     console.log("Cleaning intermediate files to free disk...");
     rmSync(cfg.codegenDir, { recursive: true, force: true });
     rmSync(resolve(cfg.buildDir, "obj"), { recursive: true, force: true });
-    rmSync(cfg.cacheDir, { recursive: true, force: true });
+    // Only wipe cacheDir when it's inside buildDir (the local default).
+    // When BUN_BUILD_CACHE_PATH points it elsewhere, it's meant to persist
+    // across builds — deleting it here would defeat the whole point.
+    if (cfg.cacheDir.startsWith(cfg.buildDir + sep)) {
+      rmSync(cfg.cacheDir, { recursive: true, force: true });
+    }
 
     // gzip: posix only (matches cmake — only libbun-*.a are gzipped,
     // Windows .lib archives uploaded uncompressed). gzip isn't a

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -404,12 +404,18 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
         : resolve(cwd, partial.buildDir)
       : resolve(cwd, "build", defaultBuildDirName);
   const codegenDir = resolve(buildDir, "codegen");
+  // CI agents set BUN_BUILD_CACHE_PATH to a directory outside the git
+  // checkout so ccache/zig-cache/tarballs survive `git clean -ffxdq`
+  // between builds. Locally it's under buildDir so `rm -rf build/` is
+  // a full reset.
   const cacheDir =
     partial.cacheDir !== undefined
       ? isAbsolute(partial.cacheDir)
         ? partial.cacheDir
         : resolve(cwd, partial.cacheDir)
-      : resolve(buildDir, "cache");
+      : process.env.BUN_BUILD_CACHE_PATH !== undefined
+        ? resolve(process.env.BUN_BUILD_CACHE_PATH)
+        : resolve(buildDir, "cache");
   const vendorDir = resolve(cwd, "vendor");
 
   // ─── Validation ───


### PR DESCRIPTION
## Summary

Two independent CI speed fixes:

**1. Persist build cache outside the git checkout**

The build cache (ccache, zig cache, WebKit/dep tarballs) defaults to `${buildDir}/cache`, which is inside the git checkout. Buildkite runs `git clean -ffxdq` between builds, wiping it every time — so the caching infrastructure exists but has a 0% hit rate in CI.

- `scripts/build/config.ts` — read `BUN_BUILD_CACHE_PATH` env var as the cacheDir default (falls back to `${buildDir}/cache` when unset, so local builds are unchanged)
- `scripts/build/ci.ts` — skip the post-build `rmSync(cacheDir)` disk cleanup when cacheDir is outside buildDir
- `.buildkite/Dockerfile` + `scripts/bootstrap.sh` — export `BUN_BUILD_CACHE_PATH=/var/lib/buildkite-agent/cache/build` in the buildkite environment hook and create the directory

This should turn cold ccache/zig-cache into warm on persistent agents. The `--cache-dir` CLI flag still takes precedence for manual overrides.

**2. Parallelize release artifact upload**

`upload-release.sh` processed 22 zips sequentially — each iteration downloads the artifact, then runs three parallel uploads (S3 commit path, S3 tag path, GitHub release), then `wait`s before moving to the next. The inner uploads were already parallel; the outer loop wasn't.

Now runs up to 6 artifacts concurrently with a bounded job pool (`wait -n` semaphore). Bounded to avoid hammering the GitHub API and keep peak disk usage reasonable. `wait -n` + `set -e` propagates failures correctly — if any upload fails, the step fails.

## Not in this PR

Left `CCACHE_SLOPPINESS` alone — the `!cfg.ci` guard exists because Ubuntu 20.04 ships ccache 3.7.7 and some sloppiness values (`gcno_cwd`) need 4.5+. That needs version detection or a base image bump, separate PR.

## Test plan

- [x] `bash -n` on both shell scripts
- [x] TypeScript imports verified (`bun -e 'await import(...)'`)
- [x] Verified `BUN_BUILD_CACHE_PATH=/tmp/test-cache` is picked up by `resolveConfig` and the `startsWith(buildDir + sep)` check correctly returns false
- [x] Verified unset env var preserves existing behavior (cacheDir = `${buildDir}/cache`)
- [x] Verified `wait -n` + `set -e` propagates background job failures
- [ ] CI: observe ccache hit rate on second build of same branch
- [ ] CI: observe release step duration on main