### PR TITLE
Fix null butterfly dereference in DFG graph dump

### DIFF
--- a/patches/webkit/fix-null-butterfly-dump.patch
+++ b/patches/webkit/fix-null-butterfly-dump.patch
@@ -1,0 +1,13 @@
+--- a/Source/JavaScriptCore/runtime/JSCJSValue.cpp
++++ b/Source/JavaScriptCore/runtime/JSCJSValue.cpp
+@@ -311,7 +311,11 @@ void JSValue::dumpInContextAssumingStructure(PrintStream& out, DumpContext* cont
+         else if (structure->classInfoForCells()->isSubClassOf(JSObject::info())) {
+             out.print("Object: ", RawPointer(asCell()));
+-            out.print(" with butterfly ", RawPointer(asObject(asCell())->butterfly()), "(base=", RawPointer(asObject(asCell())->butterfly()->base(structure)), ")");
++            auto* butterfly = asObject(asCell())->butterfly();
++            if (butterfly)
++                out.print(" with butterfly ", RawPointer(butterfly), "(base=", RawPointer(butterfly->base(structure)), ")");
++            else
++                out.print(" with butterfly ", RawPointer(butterfly));
+             out.print(" (Structure ", inContext(*structure, context), ")");
+         } else {

--- a/test/js/bun/jsc/dfg-null-butterfly-dump.test.ts
+++ b/test/js/bun/jsc/dfg-null-butterfly-dump.test.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test: DFG graph dump should not crash when printing
+// JSConstant objects that have a null butterfly (objects with only
+// inline properties and no indexed storage).
+test("DFG dump handles objects with null butterfly", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      function f() {
+        const sab = new SharedArrayBuffer(0, { maxByteLength: 248 });
+        const ta = new Float32Array(sab);
+        const arr = [ta, Float32Array];
+        const w = arr * 0;
+        try { sab.grow(sab.byteLength + 100); } catch(e) {}
+        const ab = new ArrayBuffer(64, { maxByteLength: 1024 });
+        new Uint8ClampedArray(ab);
+        +sab;
+      }
+      for (let i = 0; i < 100; i++) f();
+      `,
+    ],
+    env: {
+      ...bunEnv,
+      BUN_JSC_validateGraph: "1",
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("null pointer");
+  expect(stderr).not.toContain("runtime error");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/jsc/dfg-null-butterfly-dump.test.ts
+++ b/test/js/bun/jsc/dfg-null-butterfly-dump.test.ts
@@ -21,6 +21,7 @@ test("DFG dump handles objects with null butterfly", async () => {
         +sab;
       }
       for (let i = 0; i < 100; i++) f();
+      console.log("ok");
       `,
     ],
     env: {
@@ -31,9 +32,8 @@ test("DFG dump handles objects with null butterfly", async () => {
     stdout: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
-  expect(stderr).not.toContain("null pointer");
-  expect(stderr).not.toContain("runtime error");
+  expect(stdout).toBe("ok\n");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/jsc/dfg-null-butterfly-dump.test.ts
+++ b/test/js/bun/jsc/dfg-null-butterfly-dump.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // Regression test: DFG graph dump should not crash when printing

--- a/test/js/bun/jsc/dfg-null-butterfly-dump.test.ts
+++ b/test/js/bun/jsc/dfg-null-butterfly-dump.test.ts
@@ -28,7 +28,7 @@ test("DFG dump handles objects with null butterfly", async () => {
       ...bunEnv,
       BUN_JSC_validateGraph: "1",
     },
-    stderr: "pipe",
+    stderr: "ignore",
     stdout: "pipe",
   });
 


### PR DESCRIPTION
## What

Fix undefined behavior in `JSCJSValue::dumpInContextAssumingStructure` where `butterfly()->base(structure)` is called without checking if `butterfly()` returns null.

## Why

When the DFG compiler dumps its graph (e.g. during validation failures), it prints JSConstant nodes that reference heap objects. For objects with only inline properties (no indexed storage, no out-of-line properties), `butterfly()` returns `nullptr`. The dump code unconditionally dereferences this null pointer to call `->base(structure)`, triggering undefined behavior caught by UBSAN:

```
Butterfly.h:182:21: runtime error: member call on null pointer of type 'JSC::Butterfly *'
```

The call chain is:
```
DFGGraph::dump → FrozenValue::dumpInContext → JSValue::dumpInContextAssumingStructure
  → butterfly()->base(structure)  // butterfly() is null
    → indexingHeader()            // this is null → UB
```

## Fix

Add a null check on the butterfly pointer before calling `->base()`. When null, just print the pointer value without the base offset.

This is an upstream WebKit fix (the patch is in `patches/webkit/`). The change is in `vendor/WebKit/Source/JavaScriptCore/runtime/JSCJSValue.cpp`.

Fuzzilli fingerprint: `Butterfly.h:182:21:member call on null pointer of type 'JSC::Butterfl`