### PR TITLE
Add TypeScript 6 and 7 migration docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -68,6 +68,7 @@
               "/installation",
               "/quickstart",
               "/typescript",
+              "/typescript-6",
               "/runtime/templating/init",
               "/runtime/templating/create"
             ]

--- a/docs/guides/runtime/typescript.mdx
+++ b/docs/guides/runtime/typescript.mdx
@@ -48,4 +48,8 @@ Below is the full set of recommended `compilerOptions` for a Bun project. With t
 
 ---
 
+If you're using TypeScript 6.0 or later, you'll also need to add `"types": ["bun"]` to your `compilerOptions`. See [TypeScript 6 and 7](/typescript-6) for details.
+
+---
+
 Refer to [Ecosystem > TypeScript](/runtime/typescript) for a complete guide to TypeScript support in Bun.

--- a/docs/typescript-6.mdx
+++ b/docs/typescript-6.mdx
@@ -3,19 +3,17 @@ title: TypeScript 6 and 7
 description: "How to configure Bun's type definitions for TypeScript 6.0 and 7.0, which no longer auto-discover @types packages. Fix 'Cannot find name Bun' and other missing type errors after upgrading TypeScript."
 ---
 
-TypeScript 6.0 changed how type definitions are discovered. If you've upgraded TypeScript and your editor no longer recognizes `Bun`, `Request`, or other globals from `@types/bun`, here's why and how to fix it.
+TypeScript 6.0 changed how type definitions are discovered. If you've upgraded TypeScript and your editor no longer recognizes `Bun`, `Request`, or other globals from `@types/bun`, here's how to fix it.
 
 ## What changed
 
-In TypeScript 5 and earlier, the compiler automatically included type definitions from all `@types/*` packages in `node_modules`. Installing `@types/bun` was enough — TypeScript picked it up on its own.
-
-Starting in TypeScript 6.0, the `types` field in `compilerOptions` defaults to an empty array. TypeScript no longer auto-discovers `@types/*` packages, so you need to explicitly list them.
+Starting in TypeScript 6.0, the `types` field in `compilerOptions` defaults to an empty array instead of including all `@types/*` packages. You now need to explicitly list the type packages you use.
 
 ## Add `"types": ["bun"]` to your tsconfig
 
 In your `tsconfig.json`, add `"types": ["bun"]` to `compilerOptions`:
 
-```json tsconfig.json icon="file-json"
+```jsonc tsconfig.json icon="file-json"
 {
   "compilerOptions": {
     "types": ["bun"] // [!code ++]
@@ -23,12 +21,12 @@ In your `tsconfig.json`, add `"types": ["bun"]` to `compilerOptions`:
 }
 ```
 
-This tells TypeScript to load type definitions from `@types/bun`. If you use other `@types/*` packages (like `@types/node` or `@types/react`), include them too:
+This tells TypeScript to load type definitions from `@types/bun`. If you use other `@types/*` packages, include them too:
 
-```json tsconfig.json icon="file-json"
+```jsonc tsconfig.json icon="file-json"
 {
   "compilerOptions": {
-    "types": ["bun", "node", "react"]
+    "types": ["bun", "react"]
   }
 }
 ```
@@ -43,7 +41,7 @@ bun add -d @types/bun
 
 Here's the full recommended `tsconfig.json` for a Bun project using TypeScript 6.0 or later:
 
-```json tsconfig.json icon="file-json"
+```jsonc tsconfig.json icon="file-json"
 {
   "compilerOptions": {
     // Environment setup & latest features

--- a/docs/typescript-6.mdx
+++ b/docs/typescript-6.mdx
@@ -1,0 +1,81 @@
+---
+title: TypeScript 6 and 7
+description: "How to configure Bun's type definitions for TypeScript 6.0 and 7.0, which no longer auto-discover @types packages. Fix 'Cannot find name Bun' and other missing type errors after upgrading TypeScript."
+---
+
+TypeScript 6.0 changed how type definitions are discovered. If you've upgraded TypeScript and your editor no longer recognizes `Bun`, `Request`, or other globals from `@types/bun`, here's why and how to fix it.
+
+## What changed
+
+In TypeScript 5 and earlier, the compiler automatically included type definitions from all `@types/*` packages in `node_modules`. Installing `@types/bun` was enough — TypeScript picked it up on its own.
+
+Starting in TypeScript 6.0, the `types` field in `compilerOptions` defaults to an empty array. TypeScript no longer auto-discovers `@types/*` packages, so you need to explicitly list them.
+
+## Add `"types": ["bun"]` to your tsconfig
+
+In your `tsconfig.json`, add `"types": ["bun"]` to `compilerOptions`:
+
+```json tsconfig.json icon="file-json"
+{
+  "compilerOptions": {
+    "types": ["bun"] // [!code ++]
+  }
+}
+```
+
+This tells TypeScript to load type definitions from `@types/bun`. If you use other `@types/*` packages (like `@types/node` or `@types/react`), include them too:
+
+```json tsconfig.json icon="file-json"
+{
+  "compilerOptions": {
+    "types": ["bun", "node", "react"]
+  }
+}
+```
+
+You still need `@types/bun` installed — the `types` option tells TypeScript _which_ packages to include, but the package itself must exist in `node_modules`:
+
+```sh terminal icon="terminal"
+bun add -d @types/bun
+```
+
+## Full recommended tsconfig.json
+
+Here's the full recommended `tsconfig.json` for a Bun project using TypeScript 6.0 or later:
+
+```json tsconfig.json icon="file-json"
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "types": ["bun"],
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}
+```
+
+## Does this apply to TypeScript 7?
+
+Yes. TypeScript 7 carries forward the same default. If you're upgrading directly from TypeScript 5 to 7, the same fix applies — add `"types": ["bun"]` to your `compilerOptions`.

--- a/docs/typescript-6.mdx
+++ b/docs/typescript-6.mdx
@@ -16,8 +16,8 @@ In your `tsconfig.json`, add `"types": ["bun"]` to `compilerOptions`:
 ```jsonc tsconfig.json icon="file-json"
 {
   "compilerOptions": {
-    "types": ["bun"] // [!code ++]
-  }
+    "types": ["bun"], // [!code ++]
+  },
 }
 ```
 
@@ -26,8 +26,8 @@ This tells TypeScript to load type definitions from `@types/bun`. If you use oth
 ```jsonc tsconfig.json icon="file-json"
 {
   "compilerOptions": {
-    "types": ["bun", "react"]
-  }
+    "types": ["bun", "react"],
+  },
 }
 ```
 
@@ -69,8 +69,8 @@ Here's the full recommended `tsconfig.json` for a Bun project using TypeScript 6
     // Some stricter flags (disabled by default)
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "noPropertyAccessFromIndexSignature": false
-  }
+    "noPropertyAccessFromIndexSignature": false,
+  },
 }
 ```
 

--- a/docs/typescript.mdx
+++ b/docs/typescript.mdx
@@ -52,3 +52,7 @@ If you run `bun init` in a new directory, this `tsconfig.json` will be generated
 ```sh terminal icon="terminal"
 bun init
 ```
+
+## TypeScript 6 and 7
+
+If you're using TypeScript 6.0 or later, you'll also need to add `"types": ["bun"]` to your `compilerOptions`. See [TypeScript 6 and 7](/typescript-6) for details.


### PR DESCRIPTION
TypeScript 6.0 changed the default value of `types` in `compilerOptions` to an empty array. This means `@types/bun` is no longer auto-discovered — projects upgrading to TypeScript 6 (or 7) will see missing type errors like `Cannot find name 'Bun'`.

## Changes

- **New page** (`docs/typescript-6.mdx`): Explains what changed in TypeScript 6.0, the one-line fix (`"types": ["bun"]`), and a full recommended tsconfig for TS 6+.
- **Navigation**: Added to the "Get Started" group in `docs.json`, right after the existing TypeScript page.
- **Cross-links**: Updated `docs/typescript.mdx` and `docs/guides/runtime/typescript.mdx` to link to the new page.

The page is written to be findable via search for terms like "TypeScript 6 Bun", "TypeScript 7 migration", "Cannot find name Bun", "tsconfig types bun", etc.