### PR TITLE
trim contextual code block options in docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -44,7 +44,7 @@
     ]
   },
   "contextual": {
-    "options": ["copy", "view", "chatgpt", "claude", "perplexity", "mcp", "cursor", "vscode"]
+    "options": ["copy", "view", "claude", "mcp", "vscode"]
   },
   "styling": {
     "codeblocks": {


### PR DESCRIPTION
Remove unused contextual options from the docs Mintlify config.