### PR TITLE
Fix unchecked exception after isInstanceOf in expect matchers

### DIFF
--- a/src/runtime/test_runner/expect/toBeInstanceOf.zig
+++ b/src/runtime/test_runner/expect/toBeInstanceOf.zig
@@ -22,7 +22,14 @@ pub fn toBeInstanceOf(this: *Expect, globalThis: *JSGlobalObject, callFrame: *Ca
     const value: JSValue = try this.getValue(globalThis, thisValue, "toBeInstanceOf", "<green>expected<r>");
 
     const not = this.flags.not;
-    var pass = value.isInstanceOf(globalThis, expected_value);
+    var pass = blk: {
+        var scope: jsc.TopExceptionScope = undefined;
+        scope.init(globalThis, @src());
+        defer scope.deinit();
+        const result = value.isInstanceOf(globalThis, expected_value);
+        try scope.returnIfException();
+        break :blk result;
+    };
     if (not) pass = !pass;
     if (pass) return .js_undefined;
 

--- a/src/runtime/test_runner/expect/toThrow.zig
+++ b/src/runtime/test_runner/expect/toThrow.zig
@@ -117,7 +117,15 @@ pub fn toThrow(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFrame
             return this.throw(globalThis, signature, "\n\nExpected message: not <green>{f}<r>\n", .{expected_message.toFmt(&formatter)});
         }
 
-        if (!result.isInstanceOf(globalThis, expected_value)) return .js_undefined;
+        const is_instance = blk: {
+            var scope: jsc.TopExceptionScope = undefined;
+            scope.init(globalThis, @src());
+            defer scope.deinit();
+            const r = result.isInstanceOf(globalThis, expected_value);
+            try scope.returnIfException();
+            break :blk r;
+        };
+        if (!is_instance) return .js_undefined;
 
         var expected_class = ZigString.Empty;
         try expected_value.getClassName(globalThis, &expected_class);
@@ -237,7 +245,15 @@ pub fn toThrow(this: *Expect, globalThis: *JSGlobalObject, callFrame: *CallFrame
             return this.throw(globalThis, signature, "\n\nExpected message: <green>{f}<r>\nReceived value: <red>{f}<r>\n", .{ expected_fmt, received_fmt });
         }
 
-        if (result.isInstanceOf(globalThis, expected_value)) return .js_undefined;
+        const is_instance = blk: {
+            var scope: jsc.TopExceptionScope = undefined;
+            scope.init(globalThis, @src());
+            defer scope.deinit();
+            const r = result.isInstanceOf(globalThis, expected_value);
+            try scope.returnIfException();
+            break :blk r;
+        };
+        if (is_instance) return .js_undefined;
 
         // error: received error not instance of received error constructor
         var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis, .quote_strings = true };

--- a/test/js/bun/test/expect/toBeInstanceOf.test.ts
+++ b/test/js/bun/test/expect/toBeInstanceOf.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+
+// When Symbol.hasInstance throws during isInstanceOf, the original exception
+// must be propagated (not swallowed into a corrupted matcher error message).
+
+test("toBeInstanceOf propagates hasInstance exception", () => {
+  class Foo {
+    static [Symbol.hasInstance](): boolean {
+      throw new Error("boom");
+    }
+  }
+  expect(() => {
+    expect({}).toBeInstanceOf(Foo);
+  }).toThrow("boom");
+});
+
+test("toThrow propagates hasInstance exception", () => {
+  class Foo {
+    static [Symbol.hasInstance](): boolean {
+      throw new Error("boom");
+    }
+  }
+  expect(() => {
+    expect(() => {
+      throw new TypeError("x");
+    }).toThrow(Foo);
+  }).toThrow("boom");
+});
+
+test("not.toThrow propagates hasInstance exception", () => {
+  class Foo {
+    static [Symbol.hasInstance](): boolean {
+      throw new Error("boom");
+    }
+  }
+  expect(() => {
+    expect(() => {
+      throw new TypeError("x");
+    }).not.toThrow(Foo);
+  }).toThrow("boom");
+});


### PR DESCRIPTION
When `isInstanceOf` (via JSC's `hasInstance`) throws an exception like "Maximum call stack size exceeded", the C++ implementation catches it via `RETURN_IF_EXCEPTION` and returns `false`, but leaves the exception pending on the VM. The Zig callers in `toBeInstanceOf` and `toThrow` never checked for this pending exception, causing subsequent formatting operations to hit `releaseAssertNoException` assertions.

**Root cause:** `JSC__JSValue__isInstanceOf` in `bindings.cpp` uses `DECLARE_TOP_EXCEPTION_SCOPE` and `RETURN_IF_EXCEPTION(scope, {})` which returns `false` on exception but doesn't clear it. The Zig `isInstanceOf` binding returns only `bool`, giving callers no way to detect the error. When the Zig code then tries to format error messages (since `pass` is `false`), the new exception scopes find the pending exception and crash.

**Fix:** Check `globalThis.hasException()` after every `isInstanceOf` call and propagate the error at all three call sites:
- `toBeInstanceOf.zig` (line 25)
- `toThrow.zig` (lines 120 and 240)

---

Crash fingerprint: `6b5f88dc9ccf8931`