### PR TITLE
Update nodejs-compat.mdx: fix link target for node:util

### DIFF
--- a/docs/runtime/nodejs-compat.mdx
+++ b/docs/runtime/nodejs-compat.mdx
@@ -137,7 +137,7 @@ This page is updated regularly to reflect compatibility status of the latest ver
 
 ### [`node:sys`](https://nodejs.org/api/util.html)
 
-🟡 See [`node:util`](#node-util).
+🟡 See [`node:util`](#nodeutil).
 
 ### [`node:tls`](https://nodejs.org/api/tls.html)
 


### PR DESCRIPTION
The link target for `node:util` (on the same page) had a dash in it incorrectly.

### What does this PR do?

Fixes the link target (a minor change)

### How did you verify your code works?

Tested the proposed fix using in-browser tools