### PR TITLE
Fix crash when Bun.jest() is called during stack overflow

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1943,6 +1943,12 @@ void GlobalObject::finishCreation(VM& vm)
             JSC::JSGlobalObject* globalObject = init.owner;
 
             JSValue result = JSValue::decode(Bun__Jest__createTestModuleObject(globalObject));
+            if (result.isEmpty()) [[unlikely]] {
+                auto scope = DECLARE_TOP_EXCEPTION_SCOPE(init.vm);
+                scope.clearException();
+                init.set(JSC::constructEmptyObject(globalObject));
+                return;
+            }
             init.set(result.toObject(globalObject));
         });
 

--- a/src/test_runner/jest.zig
+++ b/src/test_runner/jest.zig
@@ -293,7 +293,9 @@ pub const Jest = struct {
             }
         }
 
-        return Bun__Jest__testModuleObject(globalObject);
+        const result = Bun__Jest__testModuleObject(globalObject);
+        if (result == .zero) return error.JSError;
+        return result;
     }
 
     fn jsSetDefaultTimeout(globalObject: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {

--- a/test/js/bun/test/jest-stack-overflow.test.ts
+++ b/test/js/bun/test/jest-stack-overflow.test.ts
@@ -1,9 +1,12 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("Bun.jest() during stack overflow does not crash", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       function recurse() { try { recurse(); } catch(e) {} }
       recurse();
       // After recovering from stack overflow, Bun.jest() should not crash
@@ -12,17 +15,14 @@ test("Bun.jest() during stack overflow does not crash", async () => {
       } catch(e) {
         console.log("OK");
       }
-    `],
+    `,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toContain("OK");
   // Should exit cleanly, not crash with a signal

--- a/test/js/bun/test/jest-stack-overflow.test.ts
+++ b/test/js/bun/test/jest-stack-overflow.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("Bun.jest() during stack overflow does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `
+      function recurse() { try { recurse(); } catch(e) {} }
+      recurse();
+      // After recovering from stack overflow, Bun.jest() should not crash
+      try {
+        Bun.jest().expect(1).toBeFalse();
+      } catch(e) {
+        console.log("OK");
+      }
+    `],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout).toContain("OK");
+  // Should exit cleanly, not crash with a signal
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
When `Bun.jest()` is called near the stack limit (e.g. after recovering from a stack overflow in a try/catch), `createTestModuleObject` can itself fail with a stack overflow exception. The lazy initializer for `m_lazyTestModuleObject` did not handle this case — it called `result.toObject()` on an empty JSValue with a pending exception. Later, any code trying to throw a new JS error would hit the `assertNoException` check in `VM.throwError` and abort.

**Fix:** Check for empty result in the lazy initializer, clear the pending exception, and set an empty fallback object. Also check for `.zero` return in `Jest.call` to properly propagate the error to JavaScript.

**Crash fingerprint:** `b0b1208bee49bf07`