### PR TITLE
Fix assertion failure when stack overflow occurs during object construction

### DIFF
--- a/test/js/bun/jsc/stack-overflow-new-target.test.ts
+++ b/test/js/bun/jsc/stack-overflow-new-target.test.ts
@@ -1,12 +1,12 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("recursive new with stack overflow does not crash", async () => {
-    await using proc = Bun.spawn({
-        cmd: [
-            bunExe(),
-            "-e",
-            `
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
             function F(a) {
                 if (!new.target) throw 'must be called with new';
                 try { new a(a); } catch(e) {}
@@ -14,18 +14,14 @@ test("recursive new with stack overflow does not crash", async () => {
             new F(F);
             console.log("done");
             `,
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-    });
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-    ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout).toBe("done\n");
-    expect(exitCode).toBe(0);
+  expect(stdout).toBe("done\n");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/jsc/stack-overflow-new-target.test.ts
+++ b/test/js/bun/jsc/stack-overflow-new-target.test.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("recursive new with stack overflow does not crash", async () => {
+    await using proc = Bun.spawn({
+        cmd: [
+            bunExe(),
+            "-e",
+            `
+            function F(a) {
+                if (!new.target) throw 'must be called with new';
+                try { new a(a); } catch(e) {}
+            }
+            new F(F);
+            console.log("done");
+            `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+    ]);
+
+    expect(stdout).toBe("done\n");
+    expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

Fix a crash (assertion failure) that occurs when a stack overflow exception is thrown during the \`new\` operation's prototype lookup.

## Root Cause

\`JSFunction::prototypeForConstruction\` calls \`get()\` to read the function's \`.prototype\` property and asserts that no exception can occur (\`releaseAssertNoException\`). While the property access is normally non-effectful for functions that can use allocation profiles, a **stack overflow** can happen during any operation — including this \`get()\` call. When it does, the pending exception violates the assertion, crashing the process.

This is triggered by deeply recursive \`new\` calls, e.g.:
```js
function F(a) {
    if (!new.target) throw 'must be called with new';
    try { new a(a); } catch(e) {}
}
new F(F);
```

## Fix

- In \`prototypeForConstruction\`: replace \`DECLARE_TOP_EXCEPTION_SCOPE\` + \`releaseAssertNoException()\` with \`DECLARE_THROW_SCOPE\` + \`RETURN_IF_EXCEPTION\`, returning \`nullptr\` on exception
- In \`allocateAndInitializeRareData\` and \`initializeRareData\`: propagate \`nullptr\` from \`prototypeForConstruction\`
- In \`DFGOperations::operationCreateThis\`: replace \`releaseAssertNoException()\` with \`OPERATION_RETURN_IF_EXCEPTION\`
- In \`CommonSlowPaths::slow_path_create_this\`: move \`CHECK_EXCEPTION()\` before dereferencing the result

Fingerprint: \`8da3d3c095ee4d0f\`