### PR TITLE
Fix crash in S3Client.presign() with missing credentials

### DIFF
--- a/src/bun.js/webcore/S3Client.zig
+++ b/src/bun.js/webcore/S3Client.zig
@@ -143,6 +143,16 @@ pub const S3Client = struct {
 
     pub fn presign(ptr: *@This(), globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
         const arguments = callframe.arguments_old(2).slice();
+
+        // Validate credentials early, before PathLike.fromJS and blob
+        // construction which involve C++ / JSC operations that can leave
+        // internal exception-scope state preventing subsequent throws from
+        // succeeding in debug builds. Determine whether the merged
+        // credentials (base from client + overrides from options) will
+        // satisfy signRequest's requirement for both accessKeyId and
+        // secretAccessKey.
+        try validatePresignCredentials(ptr.credentials.accessKeyId, ptr.credentials.secretAccessKey, arguments, globalThis);
+
         var args = jsc.CallFrame.ArgumentsSlice.init(globalThis.bunVM(), arguments);
         defer args.deinit();
         const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
@@ -276,6 +286,15 @@ pub const S3Client = struct {
     }
 
     pub fn staticPresign(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+        const arguments = callframe.arguments_old(3).slice();
+        // Validate env credentials for path-like inputs (string, Buffer, URL,
+        // etc.). Skip only when the first argument is an S3 blob which carries
+        // its own credentials — detected by checking for the Blob native type.
+        const is_blob = arguments.len > 0 and arguments[0].as(Blob) != null;
+        if (!is_blob) {
+            const env_creds = globalThis.bunVM().transpiler.env.getS3Credentials();
+            try validatePresignCredentials(env_creds.accessKeyId, env_creds.secretAccessKey, arguments, globalThis);
+        }
         return S3File.presign(globalThis, callframe);
     }
 
@@ -319,9 +338,41 @@ pub const S3Client = struct {
         defer blob.detach();
         return blob.store.?.data.s3.listObjects(blob.store.?, globalThis, object_keys, options);
     }
+
+    /// Validate that S3 credentials will be available before entering
+    /// PathLike.fromJS / blob construction which involve C++ / JSC
+    /// operations that leave internal exception-scope state preventing
+    /// subsequent throws from succeeding in debug builds.
+    fn validatePresignCredentials(base_key: []const u8, base_secret: []const u8, arguments: []const jsc.JSValue, globalThis: *jsc.JSGlobalObject) bun.JSError!void {
+        var has_access_key = base_key.len > 0;
+        var has_secret_key = base_secret.len > 0;
+
+        if (arguments.len > 1 and arguments[1].isObject()) {
+            const opts = arguments[1];
+            // Type-check all string credential/option fields that
+            // getCredentialsWithOptions would reject with
+            // throwInvalidArgumentTypeValue. This mirrors its checks so
+            // the type error is thrown before PathLike.fromJS runs.
+            const string_fields = .{ "accessKeyId", "secretAccessKey", "region", "endpoint", "bucket", "sessionToken", "contentDisposition", "type", "contentEncoding" };
+            inline for (string_fields) |field| {
+                if (try opts.getTruthyComptime(globalThis, field)) |v| {
+                    if (v.isString()) {
+                        if (comptime std.mem.eql(u8, field, "accessKeyId")) has_access_key = true;
+                        if (comptime std.mem.eql(u8, field, "secretAccessKey")) has_secret_key = true;
+                    } else if (!v.isEmptyOrUndefinedOrNull()) {
+                        return globalThis.throwInvalidArgumentTypeValue(field, "string", v);
+                    }
+                }
+            }
+        }
+        if (!has_access_key or !has_secret_key) {
+            return globalThis.ERR(.S3_MISSING_CREDENTIALS, "Missing S3 credentials. 'accessKeyId' and 'secretAccessKey' are required", .{}).throw();
+        }
+    }
 };
 
 const S3File = @import("./S3File.zig");
+const std = @import("std");
 
 const bun = @import("bun");
 const S3Credentials = bun.S3.S3Credentials;

--- a/test/js/bun/s3/s3-presign-missing-credentials.test.ts
+++ b/test/js/bun/s3/s3-presign-missing-credentials.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+
+// Regression: S3Client.presign("path") with missing credentials crashed in
+// debug builds due to stale JSC exception-scope state from PathLike.fromJS.
+// The fix validates credentials before PathLike parsing, and the error
+// message now correctly lists only the fields that are checked.
+
+test("S3Client.presign(path) throws accurate ERR_S3_MISSING_CREDENTIALS", () => {
+  const client = new Bun.S3Client();
+  try {
+    client.presign("test.txt");
+    expect.unreachable();
+  } catch (e: any) {
+    expect(e.code).toBe("ERR_S3_MISSING_CREDENTIALS");
+    // The early validation only checks accessKeyId and secretAccessKey,
+    // so the message should not mention bucket or endpoint.
+    expect(e.message).not.toContain("bucket");
+  }
+});
+
+test("S3Client.presign(path) throws with non-string credential type", () => {
+  const client = new Bun.S3Client();
+  expect(() => client.presign("test.txt", { accessKeyId: 123 as any })).toThrow();
+});


### PR DESCRIPTION
\`S3Client.presign()\` crashed when called without credentials (e.g. \`new Bun.S3Client().presign("test.txt")\`).

The crash occurred because \`PathLike.fromJS\` and \`constructS3FileWithS3CredentialsAndOptions\` (which involve C++ string conversion and JSC property access) leave internal exception-scope state on the JSC VM. When \`signRequest\` then returned \`error.MissingCredentials\` and \`throwSignError\` tried to create and throw a JS error, the \`ErrorInstance::create\` stack trace capture interacted with this stale state, triggering a debug assertion in \`VM.throwError\`.

**Fix**: Validate credentials early in \`S3Client.presign()\`, before \`PathLike.fromJS\` and blob construction. When the S3Client has no credentials and the options argument doesn't provide an \`accessKeyId\` override, throw \`ERR_S3_MISSING_CREDENTIALS\` immediately — before any JSC state accumulates.

**Repro**:
\`\`\`js
const client = new Bun.S3Client();
client.presign("test.txt"); // crashed, now throws ERR_S3_MISSING_CREDENTIALS
\`\`\`

Crash fingerprint: \`57c3d7a3187f8a94\`