### PR TITLE
Fix crash in dns.lookup when second argument is a non-object cell

### DIFF
--- a/src/bun.js/api/bun/dns.zig
+++ b/src/bun.js/api/bun/dns.zig
@@ -2719,7 +2719,7 @@ pub const Resolver = struct {
         var options = GetAddrInfo.Options{};
         var port: u16 = 0;
 
-        if (arguments.len > 1 and arguments.ptr[1].isCell()) {
+        if (arguments.len > 1 and arguments.ptr[1].isObject()) {
             const optionsObject = arguments.ptr[1];
 
             if (try optionsObject.getTruthy(globalThis, "port")) |port_value| {

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -112,4 +112,18 @@ describe("dns", () => {
       });
     });
   });
+
+  test("lookup does not crash with non-object second argument", async () => {
+    // Non-object cells like strings should be ignored as options, not crash.
+    const results = await Promise.all([
+      dns.lookup("localhost", "string" as any),
+      dns.lookup("localhost", 42 as any),
+      dns.lookup("localhost", true as any),
+      dns.lookup("localhost", null as any),
+    ]);
+    for (const result of results) {
+      expect(result).toBeArray();
+      expect(result.length).toBeGreaterThanOrEqual(1);
+    }
+  });
 });


### PR DESCRIPTION
Fixes a crash in `Bun.dns.lookup()` when the second argument is a non-object cell type (e.g., a string).

## Root Cause

`globalLookup` in `dns.zig` used `isCell()` to check whether the second argument should be treated as an options object. In JSC, strings are cells (`JSString` is a `JSCell` subclass), so passing a string like `Bun.dns.lookup("127.0.0.1", "printf")` would enter the options-parsing block. Inside that block, `getTruthy()` calls `get()` which asserts `target.isObject()`, triggering a panic on non-object cells.

## Fix

Change the check from `isCell()` to `isObject()` so that non-object cells (strings, numbers, booleans) are properly skipped as the options parameter.

## Test

Added a test that passes non-object values as the second argument to `dns.lookup()` and verifies they don't crash.