### PR TITLE
fix(fuzzilli): save Buffer/console refs before eval to prevent REPRL crash

### DIFF
--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -86,7 +86,7 @@ while (true) {
   // Read size as little-endian uint64 using raw byte access (avoids
   // Buffer.prototype.readBigUInt64LE and its internal dependencies).
   let script_size = 0;
-  for (let i = 0; i < 8; i++) script_size += size_bytes[i] * (2 ** (i * 8));
+  for (let i = 0; i < 8; i++) script_size += size_bytes[i] * 2 ** (i * 8);
 
   // Read script data from REPRL_DRFD
   const script_data = _BufferAlloc(script_size);

--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -8,6 +8,12 @@ const REPRL_DRFD = 102; // Data read FD
 
 const fs = require("node:fs");
 
+// Save references to globals before any fuzzed code can corrupt them.
+// Fuzzed scripts may do things like `Buffer++` which replaces the global
+// Buffer with NaN, breaking the REPRL protocol loop.
+const _Buffer = Buffer;
+const _console = console;
+
 // Make common Node modules available
 globalThis.require = require;
 globalThis.__dirname = "/";
@@ -29,10 +35,10 @@ try {
 }
 
 // Send HELO handshake
-fs.writeSync(REPRL_CWFD, Buffer.from("HELO"));
+fs.writeSync(REPRL_CWFD, _Buffer.from("HELO"));
 
 // Read HELO response
-const response = Buffer.alloc(4);
+const response = _Buffer.alloc(4);
 const responseBytes = fs.readSync(REPRL_CRFD, response, 0, 4, null);
 if (responseBytes !== 4) {
   throw new Error(`REPRL handshake failed: expected 4 bytes, got ${responseBytes}`);
@@ -41,7 +47,7 @@ if (responseBytes !== 4) {
 // Main REPRL loop
 while (true) {
   // Read command
-  const cmd = Buffer.alloc(4);
+  const cmd = _Buffer.alloc(4);
   const cmd_n = fs.readSync(REPRL_CRFD, cmd, 0, 4, null);
 
   if (cmd_n === 0) {
@@ -54,12 +60,12 @@ while (true) {
   }
 
   // Read script size (8 bytes, little-endian)
-  const size_bytes = Buffer.alloc(8);
+  const size_bytes = _Buffer.alloc(8);
   fs.readSync(REPRL_CRFD, size_bytes, 0, 8, null);
   const script_size = Number(size_bytes.readBigUInt64LE(0));
 
   // Read script data from REPRL_DRFD
-  const script_data = Buffer.alloc(script_size);
+  const script_data = _Buffer.alloc(script_size);
   let total_read = 0;
   while (total_read < script_size) {
     const n = fs.readSync(REPRL_DRFD, script_data, total_read, script_size - total_read, null);
@@ -76,14 +82,14 @@ while (true) {
     (0, eval)(script);
   } catch (_e) {
     // Print uncaught exception like workerd does
-    console.log(`uncaught:${_e}`);
+    _console.log(`uncaught:${_e}`);
     exit_code = 1;
   }
 
   // Send status back (4 bytes: exit code in REPRL format)
   // Format: lower 8 bits = signal number, next 8 bits = exit code
   const status = exit_code << 8;
-  const status_bytes = Buffer.alloc(4);
+  const status_bytes = _Buffer.alloc(4);
   status_bytes.writeUInt32LE(status, 0);
   fs.writeSync(REPRL_CWFD, status_bytes);
 

--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -95,7 +95,9 @@ while (true) {
     (0, eval)(script);
   } catch (_e) {
     // Print uncaught exception like workerd does
-    try { _console_log(`uncaught:${_e}`); } catch {}
+    try {
+      _console_log(`uncaught:${_e}`);
+    } catch {}
     exit_code = 1;
   }
 

--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -22,9 +22,10 @@ const _resetCoverage = resetCoverage;
 const _fsReadSync = fs.readSync.bind(fs);
 const _fsWriteSync = fs.writeSync.bind(fs);
 const _fstatSync = fs.fstatSync.bind(fs);
-const _writeUInt32LE = Buffer.prototype.writeUInt32LE;
-const _readBigUInt64LE = Buffer.prototype.readBigUInt64LE;
-const _bufToString = Buffer.prototype.toString;
+const _call = Function.prototype.call;
+const _writeUInt32LE = _call.bind(Buffer.prototype.writeUInt32LE);
+const _readBigUInt64LE = _call.bind(Buffer.prototype.readBigUInt64LE);
+const _bufToString = _call.bind(Buffer.prototype.toString);
 
 // Make common Node modules available
 globalThis.require = require;
@@ -67,14 +68,14 @@ while (true) {
     break;
   }
 
-  if (cmd_n !== 4 || _bufToString.call(cmd) !== "exec") {
-    throw new Error(`Invalid REPRL command: expected 'exec', got ${_bufToString.call(cmd)}`);
+  if (cmd_n !== 4 || _bufToString(cmd) !== "exec") {
+    throw new Error(`Invalid REPRL command: expected 'exec', got ${_bufToString(cmd)}`);
   }
 
   // Read script size (8 bytes, little-endian)
   const size_bytes = _BufferAlloc(8);
   _fsReadSync(REPRL_CRFD, size_bytes, 0, 8, null);
-  const script_size = _Number(_readBigUInt64LE.call(size_bytes, 0));
+  const script_size = _Number(_readBigUInt64LE(size_bytes, 0));
 
   // Read script data from REPRL_DRFD
   const script_data = _BufferAlloc(script_size);
@@ -85,7 +86,7 @@ while (true) {
     total_read += n;
   }
 
-  const script = _bufToString.call(script_data, "utf8");
+  const script = _bufToString(script_data, "utf8");
 
   // Execute script
   let exit_code = 0;
@@ -94,7 +95,7 @@ while (true) {
     (0, eval)(script);
   } catch (_e) {
     // Print uncaught exception like workerd does
-    _console_log(`uncaught:${_e}`);
+    try { _console_log(`uncaught:${_e}`); } catch {}
     exit_code = 1;
   }
 
@@ -102,7 +103,7 @@ while (true) {
   // Format: lower 8 bits = signal number, next 8 bits = exit code
   const status = exit_code << 8;
   const status_bytes = _BufferAlloc(4);
-  _writeUInt32LE.call(status_bytes, status, 0);
+  _writeUInt32LE(status_bytes, status, 0);
   _fsWriteSync(REPRL_CWFD, status_bytes);
 
   _resetCoverage();

--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -8,11 +8,23 @@ const REPRL_DRFD = 102; // Data read FD
 
 const fs = require("node:fs");
 
-// Save references to globals before any fuzzed code can corrupt them.
-// Fuzzed scripts may do things like `Buffer++` which replaces the global
-// Buffer with NaN, breaking the REPRL protocol loop.
-const _Buffer = Buffer;
-const _console = console;
+// Save bound method references before any fuzzed code can corrupt them.
+// Fuzzed scripts run via eval in global scope and can corrupt any global
+// variable (Buffer++), object property (Buffer.alloc = null), prototype
+// method (Buffer.prototype.writeUInt32LE = null), or cached module export
+// (require("node:fs").readSync = null). All of these break the REPRL
+// protocol loop if they affect methods used outside the try/catch.
+const _BufferAlloc = Buffer.alloc.bind(Buffer);
+const _BufferFrom = Buffer.from.bind(Buffer);
+const _Number = Number;
+const _console_log = console.log.bind(console);
+const _resetCoverage = resetCoverage;
+const _fsReadSync = fs.readSync.bind(fs);
+const _fsWriteSync = fs.writeSync.bind(fs);
+const _fstatSync = fs.fstatSync.bind(fs);
+const _writeUInt32LE = Buffer.prototype.writeUInt32LE;
+const _readBigUInt64LE = Buffer.prototype.readBigUInt64LE;
+const _bufToString = Buffer.prototype.toString;
 
 // Make common Node modules available
 globalThis.require = require;
@@ -27,7 +39,7 @@ globalThis.__filename = "/fuzzilli.js";
 // The Zig code should have already checked, but double-check here
 try {
   // Try to stat fd 100 to see if it exists
-  fs.fstatSync(REPRL_CRFD);
+  _fstatSync(REPRL_CRFD);
 } catch {
   // FD doesn't exist - not running under Fuzzilli
   console.error("ERROR: REPRL file descriptors not available. Must run under Fuzzilli.");
@@ -35,11 +47,11 @@ try {
 }
 
 // Send HELO handshake
-fs.writeSync(REPRL_CWFD, _Buffer.from("HELO"));
+_fsWriteSync(REPRL_CWFD, _BufferFrom("HELO"));
 
 // Read HELO response
-const response = _Buffer.alloc(4);
-const responseBytes = fs.readSync(REPRL_CRFD, response, 0, 4, null);
+const response = _BufferAlloc(4);
+const responseBytes = _fsReadSync(REPRL_CRFD, response, 0, 4, null);
 if (responseBytes !== 4) {
   throw new Error(`REPRL handshake failed: expected 4 bytes, got ${responseBytes}`);
 }
@@ -47,33 +59,33 @@ if (responseBytes !== 4) {
 // Main REPRL loop
 while (true) {
   // Read command
-  const cmd = _Buffer.alloc(4);
-  const cmd_n = fs.readSync(REPRL_CRFD, cmd, 0, 4, null);
+  const cmd = _BufferAlloc(4);
+  const cmd_n = _fsReadSync(REPRL_CRFD, cmd, 0, 4, null);
 
   if (cmd_n === 0) {
     // EOF
     break;
   }
 
-  if (cmd_n !== 4 || cmd.toString() !== "exec") {
-    throw new Error(`Invalid REPRL command: expected 'exec', got ${cmd.toString()}`);
+  if (cmd_n !== 4 || _bufToString.call(cmd) !== "exec") {
+    throw new Error(`Invalid REPRL command: expected 'exec', got ${_bufToString.call(cmd)}`);
   }
 
   // Read script size (8 bytes, little-endian)
-  const size_bytes = _Buffer.alloc(8);
-  fs.readSync(REPRL_CRFD, size_bytes, 0, 8, null);
-  const script_size = Number(size_bytes.readBigUInt64LE(0));
+  const size_bytes = _BufferAlloc(8);
+  _fsReadSync(REPRL_CRFD, size_bytes, 0, 8, null);
+  const script_size = _Number(_readBigUInt64LE.call(size_bytes, 0));
 
   // Read script data from REPRL_DRFD
-  const script_data = _Buffer.alloc(script_size);
+  const script_data = _BufferAlloc(script_size);
   let total_read = 0;
   while (total_read < script_size) {
-    const n = fs.readSync(REPRL_DRFD, script_data, total_read, script_size - total_read, null);
+    const n = _fsReadSync(REPRL_DRFD, script_data, total_read, script_size - total_read, null);
     if (n === 0) break;
     total_read += n;
   }
 
-  const script = script_data.toString("utf8");
+  const script = _bufToString.call(script_data, "utf8");
 
   // Execute script
   let exit_code = 0;
@@ -82,16 +94,16 @@ while (true) {
     (0, eval)(script);
   } catch (_e) {
     // Print uncaught exception like workerd does
-    _console.log(`uncaught:${_e}`);
+    _console_log(`uncaught:${_e}`);
     exit_code = 1;
   }
 
   // Send status back (4 bytes: exit code in REPRL format)
   // Format: lower 8 bits = signal number, next 8 bits = exit code
   const status = exit_code << 8;
-  const status_bytes = _Buffer.alloc(4);
-  status_bytes.writeUInt32LE(status, 0);
-  fs.writeSync(REPRL_CWFD, status_bytes);
+  const status_bytes = _BufferAlloc(4);
+  _writeUInt32LE.call(status_bytes, status, 0);
+  _fsWriteSync(REPRL_CWFD, status_bytes);
 
-  resetCoverage();
+  _resetCoverage();
 }

--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -16,7 +16,6 @@ const fs = require("node:fs");
 // protocol loop if they affect methods used outside the try/catch.
 const _BufferAlloc = Buffer.alloc.bind(Buffer);
 const _BufferFrom = Buffer.from.bind(Buffer);
-const _Number = Number;
 const _console_log = console.log.bind(console);
 const _fsReadSync = fs.readSync.bind(fs);
 const _fsWriteSync = fs.writeSync.bind(fs);

--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -18,13 +18,10 @@ const _BufferAlloc = Buffer.alloc.bind(Buffer);
 const _BufferFrom = Buffer.from.bind(Buffer);
 const _Number = Number;
 const _console_log = console.log.bind(console);
-const _resetCoverage = resetCoverage;
 const _fsReadSync = fs.readSync.bind(fs);
 const _fsWriteSync = fs.writeSync.bind(fs);
 const _fstatSync = fs.fstatSync.bind(fs);
 const _call = Function.prototype.call;
-const _writeUInt32LE = _call.bind(Buffer.prototype.writeUInt32LE);
-const _readBigUInt64LE = _call.bind(Buffer.prototype.readBigUInt64LE);
 const _bufToString = _call.bind(Buffer.prototype.toString);
 
 // Make common Node modules available
@@ -46,6 +43,16 @@ try {
   console.error("ERROR: REPRL file descriptors not available. Must run under Fuzzilli.");
   process.exit(1);
 }
+
+// Save resetCoverage after the FD check so a missing global (in non-Fuzzilli
+// builds) doesn't mask the diagnostic error message above.
+const _resetCoverage = resetCoverage;
+
+// Pre-allocate buffers for the REPRL protocol status response. Using a raw
+// Uint8Array with manual byte writes avoids all Buffer prototype methods and
+// their internal dependencies (e.g. DataView), making the status write immune
+// to any global/prototype corruption by fuzzed scripts.
+const status_bytes = new Uint8Array(4);
 
 // Send HELO handshake
 _fsWriteSync(REPRL_CWFD, _BufferFrom("HELO"));
@@ -75,7 +82,11 @@ while (true) {
   // Read script size (8 bytes, little-endian)
   const size_bytes = _BufferAlloc(8);
   _fsReadSync(REPRL_CRFD, size_bytes, 0, 8, null);
-  const script_size = _Number(_readBigUInt64LE(size_bytes, 0));
+
+  // Read size as little-endian uint64 using raw byte access (avoids
+  // Buffer.prototype.readBigUInt64LE and its internal dependencies).
+  let script_size = 0;
+  for (let i = 0; i < 8; i++) script_size += size_bytes[i] * (2 ** (i * 8));
 
   // Read script data from REPRL_DRFD
   const script_data = _BufferAlloc(script_size);
@@ -103,9 +114,13 @@ while (true) {
 
   // Send status back (4 bytes: exit code in REPRL format)
   // Format: lower 8 bits = signal number, next 8 bits = exit code
+  // Write as little-endian uint32 using raw byte access to avoid all
+  // Buffer prototype methods and their internal globals (DataView etc).
   const status = exit_code << 8;
-  const status_bytes = _BufferAlloc(4);
-  _writeUInt32LE(status_bytes, status, 0);
+  status_bytes[0] = status & 0xff;
+  status_bytes[1] = (status >> 8) & 0xff;
+  status_bytes[2] = (status >> 16) & 0xff;
+  status_bytes[3] = (status >> 24) & 0xff;
   _fsWriteSync(REPRL_CWFD, status_bytes);
 
   _resetCoverage();

--- a/test/js/bun/buffer/buffer-global-corruption.test.ts
+++ b/test/js/bun/buffer/buffer-global-corruption.test.ts
@@ -21,6 +21,7 @@ test("Buffer++ followed by SharedArrayBuffer operations should not crash", async
       new SharedArrayBuffer();
       new Int8Array(v36);
       Bun.gc(true);
+      console.log("__reached_end__");
     `,
     ],
     env: bunEnv,
@@ -30,8 +31,7 @@ test("Buffer++ followed by SharedArrayBuffer operations should not crash", async
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  // Should exit with an error (Buffer.byteLength on NaN), not a crash/signal
-  expect(exitCode).not.toBe(null);
+  expect(stdout).toContain("__reached_end__");
   // Exit code should not be a signal (signals are typically > 128)
   expect(exitCode).toBeLessThan(128);
 });

--- a/test/js/bun/buffer/buffer-global-corruption.test.ts
+++ b/test/js/bun/buffer/buffer-global-corruption.test.ts
@@ -5,7 +5,7 @@ import { bunEnv, bunExe } from "harness";
 // should not crash the process. This pattern caused SIGSEGV in the Fuzzilli REPRL
 // loop because the protocol code used the corrupted global Buffer reference.
 
-test("Buffer++ followed by SharedArrayBuffer operations should not crash", async () => {
+test.concurrent("Buffer++ followed by SharedArrayBuffer operations should not crash", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -36,7 +36,7 @@ test("Buffer++ followed by SharedArrayBuffer operations should not crash", async
   expect(exitCode).toBeLessThan(128);
 });
 
-test("saved Buffer reference survives global corruption via eval", async () => {
+test.concurrent("saved Buffer reference survives global corruption via eval", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/bun/buffer/buffer-global-corruption.test.ts
+++ b/test/js/bun/buffer/buffer-global-corruption.test.ts
@@ -7,7 +7,10 @@ import { bunEnv, bunExe } from "harness";
 
 test("Buffer++ followed by SharedArrayBuffer operations should not crash", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       function f4() { return f4; }
       const v6 = Buffer(f4);
       try { v6.writeBigInt64LE(f4); } catch (e) {}
@@ -18,17 +21,14 @@ test("Buffer++ followed by SharedArrayBuffer operations should not crash", async
       new SharedArrayBuffer();
       new Int8Array(v36);
       Bun.gc(true);
-    `],
+    `,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // Should exit with an error (Buffer.byteLength on NaN), not a crash/signal
   expect(exitCode).not.toBe(null);
@@ -38,7 +38,10 @@ test("Buffer++ followed by SharedArrayBuffer operations should not crash", async
 
 test("saved Buffer reference survives global corruption via eval", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       const _Buffer = Buffer;
       // Simulate what fuzzed scripts do
       (0, eval)("Buffer++");
@@ -46,17 +49,14 @@ test("saved Buffer reference survives global corruption via eval", async () => {
       const buf = _Buffer.alloc(4);
       buf.writeUInt32LE(42, 0);
       console.log(buf.readUInt32LE(0));
-    `],
+    `,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout.trim()).toBe("42");
   expect(exitCode).toBe(0);

--- a/test/js/bun/buffer/buffer-global-corruption.test.ts
+++ b/test/js/bun/buffer/buffer-global-corruption.test.ts
@@ -59,5 +59,6 @@ test("saved Buffer reference survives global corruption via eval", async () => {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout.trim()).toBe("42");
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/buffer/buffer-global-corruption.test.ts
+++ b/test/js/bun/buffer/buffer-global-corruption.test.ts
@@ -32,8 +32,7 @@ test.concurrent("Buffer++ followed by SharedArrayBuffer operations should not cr
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toContain("__reached_end__");
-  // Exit code should not be a signal (signals are typically > 128)
-  expect(exitCode).toBeLessThan(128);
+  expect(exitCode).toBe(0);
 });
 
 test.concurrent("saved Buffer reference survives global corruption via eval", async () => {

--- a/test/js/bun/buffer/buffer-global-corruption.test.ts
+++ b/test/js/bun/buffer/buffer-global-corruption.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test: fuzzed scripts that corrupt the Buffer global (e.g. Buffer++)
+// should not crash the process. This pattern caused SIGSEGV in the Fuzzilli REPRL
+// loop because the protocol code used the corrupted global Buffer reference.
+
+test("Buffer++ followed by SharedArrayBuffer operations should not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `
+      function f4() { return f4; }
+      const v6 = Buffer(f4);
+      try { v6.writeBigInt64LE(f4); } catch (e) {}
+      Buffer++;
+      new Response();
+      try { const v15 = new SharedArrayBuffer(); Buffer.byteLength(v15); } catch(e) {}
+      const v36 = new SharedArrayBuffer(6, { maxByteLength: 1024 });
+      new SharedArrayBuffer();
+      new Int8Array(v36);
+      Bun.gc(true);
+    `],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  // Should exit with an error (Buffer.byteLength on NaN), not a crash/signal
+  expect(exitCode).not.toBe(null);
+  // Exit code should not be a signal (signals are typically > 128)
+  expect(exitCode).toBeLessThan(128);
+});
+
+test("saved Buffer reference survives global corruption via eval", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `
+      const _Buffer = Buffer;
+      // Simulate what fuzzed scripts do
+      (0, eval)("Buffer++");
+      // The saved reference should still work
+      const buf = _Buffer.alloc(4);
+      buf.writeUInt32LE(42, 0);
+      console.log(buf.readUInt32LE(0));
+    `],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout.trim()).toBe("42");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
The Fuzzilli REPRL loop in `fuzzilli-reprl.ts` used `Buffer` and `console` directly from the global scope. Fuzzed scripts can corrupt these globals (e.g. `Buffer++` converts Buffer to NaN), causing the REPRL protocol code to throw **outside** its try/catch when it calls `Buffer.alloc()` to send the status response back to Fuzzilli.

This breaks the REPRL protocol synchronization — Fuzzilli expects a 4-byte status response but the loop crashes instead. The resulting abnormal process exit during cleanup can trigger a SIGSEGV, especially when growable SharedArrayBuffers with large `maxByteLength` values are in play.

**Fix:** Save references to `Buffer` and `console` at module scope before any fuzzed code runs via `eval`, then use those saved references throughout the REPRL loop. This mirrors the existing pattern where `fs` is already saved via `require('node:fs')`.

**Repro pattern (in REPRL mode):**
```js
// Script 1: corrupts Buffer global
Buffer++;
// REPRL loop then tries Buffer.alloc(4) to send status → TypeError outside try/catch → crash
```

Crash fingerprint: `ab5a7cc8c96e7a66`