### PR TITLE
fix(dns): use isObject() instead of isCell() for lookup options check

### DIFF
--- a/src/bun.js/api/bun/dns.zig
+++ b/src/bun.js/api/bun/dns.zig
@@ -2719,7 +2719,7 @@ pub const Resolver = struct {
         var options = GetAddrInfo.Options{};
         var port: u16 = 0;
 
-        if (arguments.len > 1 and arguments.ptr[1].isCell()) {
+        if (arguments.len > 1 and arguments.ptr[1].isObject()) {
             const optionsObject = arguments.ptr[1];
 
             if (try optionsObject.getTruthy(globalThis, "port")) |port_value| {

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -112,4 +112,11 @@ describe("dns", () => {
       });
     });
   });
+
+  test("lookup does not crash when options is a non-object cell", async () => {
+    // Passing a string as the options argument should not crash.
+    // Strings are cells but not objects, so property access must be guarded.
+    const result = await dns.lookup("localhost", "notAnObject" as any);
+    expect(result).toBeDefined();
+  });
 });


### PR DESCRIPTION
\`dns.lookup()\` crashes when the second argument is a non-object cell (e.g. a string). 

**Root cause:** \`globalLookup\` used \`isCell()\` to guard entry into the options-parsing block. \`isCell()\` returns true for any heap-allocated JS value — including strings, arrays, and functions. When a string is passed as the options argument, it enters the block and \`getTruthy()\` calls \`get()\`, which asserts \`target.isObject()\`. A string is not an object, so the assertion fails and panics.

**Fix:** Change \`isCell()\` to \`isObject()\`, consistent with \`newResolver\` and \`Options.fromJS\` in the same file. Non-object values are now treated as if no options were provided (default options used).

**Crash fingerprint:** \`ded3068752e0b874\`