### PR TITLE
fix(http2): propagate enableConnectProtocol setting to SETTINGS frame

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -2791,6 +2791,14 @@ pub const H2FrameParser = struct {
             }
         }
 
+        if (try options.get(globalObject, "enableConnectProtocol")) |enableConnectProtocol| {
+            if (enableConnectProtocol.isBoolean()) {
+                this.localSettings.enableConnectProtocol = if (enableConnectProtocol.asBoolean()) 1 else 0;
+            } else if (!enableConnectProtocol.isUndefined()) {
+                return globalObject.ERR(.HTTP2_INVALID_SETTING_VALUE, "Expected enableConnectProtocol to be a boolean", .{}).throw();
+            }
+        }
+
         // Validate customSettings
         if (try options.get(globalObject, "customSettings")) |customSettings| {
             if (!customSettings.isUndefined()) {


### PR DESCRIPTION
## Summary

`session.settings({ enableConnectProtocol: true })` and `createSecureServer({ settings: { enableConnectProtocol: true } })` are silently ignored — the `SETTINGS_ENABLE_CONNECT_PROTOCOL` (0x8) value is never sent to the peer.

`loadSettingsFromJSValue()` in `h2_frame_parser.zig` handles every HTTP/2 setting (`headerTableSize`, `enablePush`, `initialWindowSize`, `maxFrameSize`, `maxConcurrentStreams`, `maxHeaderListSize`, `maxHeaderSize`, `customSettings`) but has no handler for `enableConnectProtocol`. The JS layer validates it correctly, `getPackedSettings`/`getUnpackedSettings` serialize it correctly, and the Zig `FullSettingsPayload` struct has the field — the only missing piece is reading it from the JS settings object in `loadSettingsFromJSValue()`.

This blocks RFC 8441 (Bootstrapping WebSockets with HTTP/2) because browsers (Chrome 121+, Firefox) require `SETTINGS_ENABLE_CONNECT_PROTOCOL=1` before attempting Extended CONNECT for WebSocket over HTTP/2.

## Fix

Add the missing handler in `loadSettingsFromJSValue()`, following the same pattern as `enablePush` (lines 2725-2731):

```zig
if (try options.get(globalObject, "enableConnectProtocol")) |enableConnectProtocol| {
    if (enableConnectProtocol.isBoolean()) {
        this.localSettings.enableConnectProtocol = if (enableConnectProtocol.asBoolean()) 1 else 0;
    } else if (!enableConnectProtocol.isUndefined()) {
        return globalObject.ERR(.HTTP2_INVALID_SETTING_VALUE, "Expected enableConnectProtocol to be a boolean", .{}).throw();
    }
}
```

1 file changed, 8 insertions.

## How we tested

**Reproduction script** — creates an h2 server with `enableConnectProtocol: true`, then connects a client and reads `remoteSettings`:

```typescript
import http2 from 'node:http2';
import { readFileSync } from 'node:fs';

const server = http2.createSecureServer({
  cert: readFileSync('cert.pem', 'utf-8'),
  key: readFileSync('key.pem', 'utf-8'),
  settings: { enableConnectProtocol: true },
});
server.on('stream', (s) => { s.respond({ ':status': 200 }); s.end('ok'); });
server.listen(4480, () => {
  const client = http2.connect('https://localhost:4480', { rejectUnauthorized: false });
  client.on('remoteSettings', (rs) => {
    console.log('enableConnectProtocol:', rs.enableConnectProtocol);
    client.close();
    server.close();
  });
});
```

**Before (stock Bun 1.3.11):**
```
enableConnectProtocol: false
```

**After (patched):**
```
enableConnectProtocol: true
```

**Browser verification** — with the patched binary, started an h2 server with `enableConnectProtocol: true` and opened a page in Chromium (via Playwright) that creates `new WebSocket('wss://...')`. Chrome sent an Extended CONNECT stream (`:method: CONNECT`, `:protocol: websocket`) which the server received on the `stream` event. The WebSocket connected successfully over HTTP/2 — confirmed bidirectional message exchange (ping/pong). Without the patch, Chrome falls back to HTTP/1.1 upgrade which fails because `allowHTTP1` is not yet implemented (#26721).