### PR TITLE
fix(tls): pass ALPN protocols to SNI server name contexts

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -752,6 +752,13 @@ void free_ssl_context(SSL_CTX *ssl_context) {
   /* OpenSSL returns NULL if we have no set password */
   us_free(password);
 
+  /* Free ALPN data if set (includes copied protos) */
+  struct alpn_data *alpn = (struct alpn_data *)SSL_CTX_get_ex_data(ssl_context, 1);
+  if (alpn) {
+    us_free((void *)alpn->protos);
+    us_free(alpn);
+  }
+
   SSL_CTX_free(ssl_context);
 }
 
@@ -1136,6 +1143,28 @@ int us_verify_callback(int preverify_ok, X509_STORE_CTX *ctx) {
   return 1;
 }
 
+/* ALPN select callback for SNI contexts — protos stored in SSL_CTX ex_data slot 1 */
+struct alpn_data {
+  const unsigned char *protos;
+  unsigned int protos_len;
+};
+
+static int sni_alpn_select_cb(SSL *ssl, const unsigned char **out,
+                               unsigned char *outlen,
+                               const unsigned char *in, unsigned int inlen,
+                               void *arg) {
+  struct alpn_data *data = (struct alpn_data *)arg;
+  if (!data || !data->protos || data->protos_len == 0) {
+    return SSL_TLSEXT_ERR_NOACK;
+  }
+  if (SSL_select_next_proto((unsigned char **)out, outlen,
+                            data->protos, data->protos_len,
+                            in, inlen) == OPENSSL_NPN_NEGOTIATED) {
+    return SSL_TLSEXT_ERR_OK;
+  }
+  return SSL_TLSEXT_ERR_ALERT_FATAL;
+}
+
 SSL_CTX *create_ssl_context_from_bun_options(
     struct us_bun_socket_context_options_t options,
     enum create_bun_socket_error_t *err) {
@@ -1331,6 +1360,25 @@ SSL_CTX *create_ssl_context_from_bun_options(
 
   if (options.secure_options) {
     SSL_CTX_set_options(ssl_context, options.secure_options);
+  }
+
+  /* Set ALPN select callback if protocols were provided.
+   * The protos are copied so the SSL_CTX does not depend on the caller's
+   * memory lifetime.  The alpn_data (including its copy of the protos) is
+   * stored in ex_data slot 1 and freed in free_ssl_context. */
+  if (options.protos && options.protos_len > 0) {
+    unsigned char *protos_copy = (unsigned char *)us_malloc(options.protos_len);
+    struct alpn_data *data = (struct alpn_data *)us_malloc(sizeof(struct alpn_data));
+    if (protos_copy && data) {
+      memcpy(protos_copy, options.protos, options.protos_len);
+      data->protos = protos_copy;
+      data->protos_len = options.protos_len;
+      SSL_CTX_set_ex_data(ssl_context, 1, data);
+      SSL_CTX_set_alpn_select_cb(ssl_context, sni_alpn_select_cb, data);
+    } else {
+      us_free(protos_copy);
+      us_free(data);
+    }
   }
 
   /* This must be free'd with free_ssl_context, not SSL_CTX_free */

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -742,6 +742,12 @@ us_internal_create_child_ssl_socket_context(
 
 /* Common function for creating a context from options.
  * We must NOT free a SSL_CTX with only SSL_CTX_free! Also free any password */
+/* ALPN data attached to SNI SSL_CTX instances via ex_data slot 1 */
+struct alpn_data {
+  const unsigned char *protos;
+  unsigned int protos_len;
+};
+
 void free_ssl_context(SSL_CTX *ssl_context) {
   if (!ssl_context) {
     return;
@@ -1143,12 +1149,7 @@ int us_verify_callback(int preverify_ok, X509_STORE_CTX *ctx) {
   return 1;
 }
 
-/* ALPN select callback for SNI contexts — protos stored in SSL_CTX ex_data slot 1 */
-struct alpn_data {
-  const unsigned char *protos;
-  unsigned int protos_len;
-};
-
+/* ALPN select callback for SNI contexts */
 static int sni_alpn_select_cb(SSL *ssl, const unsigned char **out,
                                unsigned char *outlen,
                                const unsigned char *in, unsigned int inlen,

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -237,6 +237,8 @@ struct us_bun_socket_context_options_t {
     int request_cert;
     unsigned int client_renegotiation_limit;
     unsigned int client_renegotiation_window;
+    const unsigned char *protos;
+    unsigned int protos_len;
 };
 
 /* Return 15-bit timestamp for this context */

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -78,6 +78,8 @@ namespace uWS {
         int request_cert = 0;
         unsigned int client_renegotiation_limit = 3;
         unsigned int client_renegotiation_window = 600;
+        const unsigned char *protos = nullptr;
+        unsigned int protos_len = 0;
 
         /* Conversion operator used internally */
         operator struct us_bun_socket_context_options_t() const {

--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -410,7 +410,13 @@ pub fn addServerName(this: *Listener, global: *jsc.JSGlobalObject, hostname: JSV
     if (try SSLConfig.fromJS(jsc.VirtualMachine.get(), global, tls)) |ssl_config| {
         // to keep nodejs compatibility, we allow to replace the server name
         this.socket_context.?.removeServerName(true, server_name);
-        this.socket_context.?.addServerName(true, server_name, ssl_config.asUSockets());
+        var opts = ssl_config.asUSockets();
+        // Pass ALPN protocols so the SNI context can negotiate ALPN
+        if (this.protos) |protos| {
+            opts.protos = protos.ptr;
+            opts.protos_len = @intCast(protos.len);
+        }
+        this.socket_context.?.addServerName(true, server_name, opts);
         var ssl_config_mut = ssl_config;
         ssl_config_mut.deinit();
     }

--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -171,7 +171,7 @@ pub fn listen(globalObject: *jsc.JSGlobalObject, opts: JSValue) bun.JSError!JSVa
         }
     }
 
-    const ctx_opts: uws.SocketContext.BunSocketContextOptions = if (ssl) |some_ssl|
+    var ctx_opts: uws.SocketContext.BunSocketContextOptions = if (ssl) |some_ssl|
         some_ssl.asUSockets()
     else
         .{};
@@ -304,6 +304,12 @@ pub fn listen(globalObject: *jsc.JSGlobalObject, opts: JSValue) bun.JSError!JSVa
         if (ssl_config.server_name) |server_name| {
             const slice = std.mem.span(server_name);
             if (slice.len > 0) {
+                // Pass ALPN protocols to the SNI context so it can
+                // negotiate ALPN during the TLS handshake
+                if (socket.protos) |protos| {
+                    ctx_opts.protos = protos.ptr;
+                    ctx_opts.protos_len = @intCast(protos.len);
+                }
                 socket.socket_context.?.addServerName(true, server_name, ctx_opts);
             }
         }

--- a/src/deps/uws/SocketContext.zig
+++ b/src/deps/uws/SocketContext.zig
@@ -240,6 +240,8 @@ pub const SocketContext = opaque {
         request_cert: i32 = 0,
         client_renegotiation_limit: u32 = 3,
         client_renegotiation_window: u32 = 600,
+        protos: ?[*]const u8 = null,
+        protos_len: u32 = 0,
 
         pub fn createSSLContext(options: BunSocketContextOptions, err: *uws.create_bun_socket_error_t) ?*BoringSSL.SSL_CTX {
             return c.create_ssl_context_from_bun_options(options, err);


### PR DESCRIPTION
## Summary

`tls.Server` ALPN negotiation fails when `server.listen()` is called with hostname `'localhost'`. Both client and server report `alpnProtocol: false`. Direct IPs (`'127.0.0.1'`, `'0.0.0.0'`, `'::1'`) and omitting the hostname all work correctly. Node.js v22 handles all variants correctly.

## Root cause

When `server.listen(port, 'localhost')` is called, `tls.ts` sets `serverName: 'localhost'` in the TLS config. `Listener.zig` then calls `addServerName()` which creates a **new** `SSL_CTX` via `create_ssl_context_from_bun_options()`. The `us_bun_socket_context_options_t` struct has no ALPN/protos fields, so the new SSL context has no ALPN callback. When a client connects with SNI hostname `'localhost'`, BoringSSL selects this ALPN-less context for the handshake.

## Fix

Add `protos`/`protos_len` fields to `us_bun_socket_context_options_t` (C), `SocketContextOptions` (C++), and `BunSocketContextOptions` (Zig) so that `create_ssl_context_from_bun_options()` can register an ALPN select callback on the new SSL context. `Listener.zig` passes the protos through `ctx_opts` when calling `addServerName()`. The ALPN data is stored in `SSL_CTX` ex_data slot 1 and freed in `free_ssl_context()`.

5 files changed, ~51 insertions.

## Reproduction

```typescript
import tls from 'node:tls';
import fs from 'node:fs';

const server = tls.createServer({
  cert: fs.readFileSync('cert.pem', 'utf-8'),
  key: fs.readFileSync('key.pem', 'utf-8'),
  ALPNProtocols: ['h2'],
}, (socket) => {
  console.log('server alpn:', socket.alpnProtocol);
  socket.end();
  server.close();
});

server.listen(4500, 'localhost', () => {
  const client = tls.connect(4500, 'localhost', {
    rejectUnauthorized: false,
    ALPNProtocols: ['h2'],
  }, () => {
    console.log('client alpn:', client.alpnProtocol);
    client.end();
  });
});
```

**Before:** `alpnProtocol: false` / **After:** `alpnProtocol: h2`

## How we tested

All hostname variants verified on the patched build:

| hostname | Before | After |
|---|---|---|
| _(omitted)_ | h2 | h2 |
| `'127.0.0.1'` | h2 | h2 |
| `'0.0.0.0'` | h2 | h2 |
| `'::1'` | h2 | h2 |
| `'localhost'` | **false** | **h2** |

Also verified `http2.createSecureServer()` with `listen(port, 'localhost')` — HTTP/2 ALPN negotiation works correctly with the patch applied.