### PR TITLE
Fix expect.extend crash with numeric index property names

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -957,9 +957,9 @@ pub const Expect = struct {
 
                 const wrapper_fn = Bun__JSWrappingFunction__create(globalThis, matcher_name, jsc.toJSHostFn(Expect.applyCustomMatcher), matcher_fn, true);
 
-                expect_proto.put(globalThis, matcher_name, wrapper_fn);
-                expect_constructor.put(globalThis, matcher_name, wrapper_fn);
-                expect_static_proto.put(globalThis, matcher_name, wrapper_fn);
+                try expect_proto.putMayBeIndex(globalThis, matcher_name, wrapper_fn);
+                try expect_constructor.putMayBeIndex(globalThis, matcher_name, wrapper_fn);
+                try expect_static_proto.putMayBeIndex(globalThis, matcher_name, wrapper_fn);
             }
         }
 

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -392,4 +392,14 @@ describe("MatcherContext", () => {
       expect(123).toBeCustomColor(456);
     });
   });
+
+  if (isBun) {
+    test("does not crash when matchers object has numeric index properties", () => {
+      // Numeric index properties should be silently skipped, not crash with
+      // an assertion failure in putDirectInternal.
+      expect(() => {
+        expect.extend({ 0: () => ({ pass: true }) });
+      }).not.toThrow();
+    });
+  }
 });


### PR DESCRIPTION
When `expect.extend()` receives an object with numeric index properties (e.g. `{ 0: fn }` or a constructor with indexed entries), the property iterator yields those numeric keys. These were then passed to `putDirect`, which asserts `!parseIndex(propertyName)` — only named (non-index) properties are valid there.

**Root cause:** `expect.extend` iterates properties with `own_properties_only: false` to support prototype chains. The iterator can yield numeric index properties, which `put()` → `putDirect()` cannot handle.

**Fix:** Use `putMayBeIndex` instead of `put` when registering matchers on the Expect prototype/constructor. This safely handles both named and numeric property keys via the correct JSC API (`putDirectMayBeIndex`).

**Crash:**
```
ASSERTION FAILED: !parseIndex(propertyName)
JSObjectInlines.h(451) : JSC::JSObject::putDirectInternal(VM &, PropertyName, JSValue, unsigned int, PutPropertySlot &)
```