### PR TITLE
Fix out-of-bounds write in pathToFileURL with long relative paths

### DIFF
--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -2048,13 +2048,18 @@ export fn ResolvePath__joinAbsStringBufCurrentPlatformBunString(
     const str = in.toUTF8WithoutRef(bun.default_allocator);
     defer str.deinit();
 
-    const out_slice = joinAbsStringBuf(
-        globalObject.bunVM().transpiler.fs.top_level_dir,
-        &join_buf,
-        &.{str.slice()},
-        .auto,
-    );
+    const cwd = globalObject.bunVM().transpiler.fs.top_level_dir;
+    const parts: [1][]const u8 = .{str.slice()};
 
+    if (joinAbsStringBufChecked(cwd, &join_buf, &parts, .auto)) |out_slice| {
+        return bun.String.cloneUTF8(out_slice);
+    }
+
+    // Normalized result exceeds fixed buffer; use a heap allocation.
+    const total = cwd.len + str.slice().len + 2;
+    const heap_buf = bun.handleOom(bun.default_allocator.alloc(u8, total));
+    defer bun.default_allocator.free(heap_buf);
+    const out_slice = joinAbsStringBuf(cwd, heap_buf, &parts, .auto);
     return bun.String.cloneUTF8(out_slice);
 }
 

--- a/test/js/node/url/pathToFileURL.test.ts
+++ b/test/js/node/url/pathToFileURL.test.ts
@@ -10,9 +10,13 @@ test("pathToFileURL with long relative path does not crash", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", `Bun.pathToFileURL(Buffer.alloc(5000, "a").toString())`],
     env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
   });
 
-  expect(await proc.exited).toBe(0);
+  const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });
 
 test("pathToFileURL escapes special characters", () => {

--- a/test/js/node/url/pathToFileURL.test.ts
+++ b/test/js/node/url/pathToFileURL.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import path from "path";
 
 test("pathToFileURL doesn't leak memory", () => {
@@ -7,8 +8,8 @@ test("pathToFileURL doesn't leak memory", () => {
 
 test("pathToFileURL with long relative path does not crash", async () => {
   await using proc = Bun.spawn({
-    cmd: [process.execPath, "-e", `Bun.pathToFileURL(Buffer.alloc(5000, "a").toString())`],
-    env: { ...process.env, BUN_DEBUG_QUIET_LOGS: "1" },
+    cmd: [bunExe(), "-e", `Bun.pathToFileURL(Buffer.alloc(5000, "a").toString())`],
+    env: bunEnv,
   });
 
   expect(await proc.exited).toBe(0);

--- a/test/js/node/url/pathToFileURL.test.ts
+++ b/test/js/node/url/pathToFileURL.test.ts
@@ -5,6 +5,15 @@ test("pathToFileURL doesn't leak memory", () => {
   expect([path.join(import.meta.dir, "pathToFileURL-leak-fixture.js")]).toRun();
 });
 
+test("pathToFileURL with long relative path does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [process.execPath, "-e", `Bun.pathToFileURL(Buffer.alloc(5000, "a").toString())`],
+    env: { ...process.env, BUN_DEBUG_QUIET_LOGS: "1" },
+  });
+
+  expect(await proc.exited).toBe(0);
+});
+
 test("pathToFileURL escapes special characters", () => {
   const cases = [
     ["\0", "%00"], // '\0' == 0x00


### PR DESCRIPTION
\`ResolvePath__joinAbsStringBufCurrentPlatformBunString\` used the unchecked \`joinAbsStringBuf\` with a fixed 4096-byte threadlocal buffer (\`join_buf\`). When a relative path longer than ~4KB was passed (e.g. through \`Bun.pathToFileURL\`), \`normalizeStringGenericTZ\` would \`@memcpy\` past the end of the output buffer, causing a panic in debug builds and undefined behavior in release builds.

The fix switches to \`joinAbsStringBufChecked\`, which safely detects when the normalized result exceeds the fixed buffer. When that happens, a heap-allocated buffer is used as fallback.

**Repro:**
\`\`\`js
Bun.pathToFileURL("a".repeat(5000));
\`\`\`

**Crash output (debug):**
\`\`\`
panic(main thread): index out of bounds: index 5014, len 4095
resolver.resolve_path.normalizeStringGenericTZ
\`\`\`