### PR TITLE
fix(sql): gracefully retire connections on maxLifetime instead of killing in-flight queries

### DIFF
--- a/src/sql/mysql/js/JSMySQLConnection.zig
+++ b/src/sql/mysql/js/JSMySQLConnection.zig
@@ -135,7 +135,16 @@ pub fn onConnectionTimeout(this: *@This()) void {
 pub fn onMaxLifetimeTimeout(this: *@This()) void {
     this.max_lifetime_timer.state = .FIRED;
     if (this.#connection.status == .failed) return;
-    this.failFmt(error.LifetimeTimeout, "Max lifetime timeout reached after {f}", .{bun.fmt.fmtDurationOneDecimal(@as(u64, this.max_lifetime_interval_ms) *| std.time.ns_per_ms)});
+
+    if (this.#connection.isIdle()) {
+        // Connection is idle, close it gracefully without erroring in-flight queries.
+        this.close();
+    } else {
+        // Connection has in-flight queries. Reschedule to check again in 1 second
+        // so we don't kill active queries.
+        this.max_lifetime_timer.next = bun.timespec.msFromNow(.allow_mocked_time, 1000);
+        this.#vm.timer.insert(&this.max_lifetime_timer);
+    }
 }
 fn setupMaxLifetimeTimerIfNecessary(this: *@This()) void {
     if (this.max_lifetime_interval_ms == 0) return;

--- a/src/sql/postgres/PostgresSQLConnection.zig
+++ b/src/sql/postgres/PostgresSQLConnection.zig
@@ -222,7 +222,16 @@ pub fn onMaxLifetimeTimeout(this: *PostgresSQLConnection) void {
     debug("onMaxLifetimeTimeout", .{});
     this.max_lifetime_timer.state = .FIRED;
     if (this.status == .failed) return;
-    this.failFmt("ERR_POSTGRES_LIFETIME_TIMEOUT", "Max lifetime timeout reached after {f}", .{bun.fmt.fmtDurationOneDecimal(@as(u64, this.max_lifetime_interval_ms) *| std.time.ns_per_ms)});
+
+    if (this.requests.readableLength() == 0) {
+        // Connection is idle, close it gracefully without erroring in-flight queries.
+        this.disconnect();
+    } else {
+        // Connection has in-flight queries. Reschedule to check again in 1 second
+        // so we don't kill active queries.
+        this.max_lifetime_timer.next = bun.timespec.msFromNow(.allow_mocked_time, 1000);
+        this.vm.timer.insert(&this.max_lifetime_timer);
+    }
 }
 
 fn start(this: *PostgresSQLConnection) void {

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -167,7 +167,7 @@ if (isDockerEnabled()) {
           expect((err as SQL.MySQLError).code).toBe(`ERR_MYSQL_IDLE_TIMEOUT`);
         });
 
-        test("Max lifetime works", async () => {
+        test("Max lifetime closes idle connection gracefully", async () => {
           const onClosePromise = Promise.withResolvers();
           const onclose = mock(err => {
             onClosePromise.resolve(err);
@@ -180,26 +180,49 @@ if (isDockerEnabled()) {
             onclose,
             max: 1,
           });
-          let error: unknown;
 
-          try {
-            expect<[{ x: number }]>(await sql`select 1 as x`).toEqual([{ x: 1 }]);
+          // Get the server-side connection ID before maxLifetime fires
+          const [{ id: connBefore }] = await sql`select CONNECTION_ID() as id`;
 
-            while (true) {
-              for (let i = 0; i < 100; i++) {
-                await sql`select SLEEP(1)`;
-              }
-            }
-          } catch (e) {
-            error = e;
-          }
-
+          // Wait for maxLifetime to fire and close the idle connection
+          await onClosePromise.promise;
           expect(onclose).toHaveBeenCalledTimes(1);
           expect(onconnect).toHaveBeenCalledTimes(1);
 
-          expect(error).toBeInstanceOf(SQL.SQLError);
-          expect(error).toBeInstanceOf(SQL.MySQLError);
-          expect((error as SQL.MySQLError).code).toBe(`ERR_MYSQL_LIFETIME_TIMEOUT`);
+          // The pool should reconnect — verify via a different connection ID
+          const [{ id: connAfter }] = await sql`select CONNECTION_ID() as id`;
+          expect(connAfter).not.toBe(connBefore);
+        });
+
+        test("Max lifetime does not kill in-flight queries", async () => {
+          const onClosePromise = Promise.withResolvers();
+          const onclose = mock(err => {
+            onClosePromise.resolve(err);
+          });
+          const onconnect = mock();
+          await using sql = new SQL({
+            ...getOptions(),
+            max_lifetime: 1,
+            onconnect,
+            onclose,
+            max: 1,
+          });
+
+          // Get connection ID before the long query
+          const [{ id: connBefore }] = await sql`select CONNECTION_ID() as id`;
+
+          // Start a query that takes longer than maxLifetime (3s > 1s).
+          // Previously this would throw ERR_MYSQL_LIFETIME_TIMEOUT.
+          const result = await sql`select SLEEP(3) as s, 42 as x`;
+          expect(result[0].x).toBe(42);
+
+          // Wait for the connection to be closed after the query finishes
+          await onClosePromise.promise;
+          expect(onclose).toHaveBeenCalledTimes(1);
+
+          // Verify the pool reconnected with a different connection ID
+          const [{ id: connAfter }] = await sql`select CONNECTION_ID() as id`;
+          expect(connAfter).not.toBe(connBefore);
         });
 
         // Last one wins.
@@ -483,9 +506,7 @@ if (isDockerEnabled()) {
         test("Binary", async () => {
           const random_name = ("t_" + Bun.randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
           await sql`CREATE TEMPORARY TABLE ${sql(random_name)} (a binary(1), b varbinary(1), c blob)`;
-          const values = [
-            { a: Buffer.from([1]), b: Buffer.from([2]), c: Buffer.from([3]) },
-          ];
+          const values = [{ a: Buffer.from([1]), b: Buffer.from([2]), c: Buffer.from([3]) }];
           await sql`INSERT INTO ${sql(random_name)} ${sql(values)}`;
           const results = await sql`select * from ${sql(random_name)}`;
           // return buffers
@@ -497,7 +518,7 @@ if (isDockerEnabled()) {
           expect(results2[0].a).toEqual(Buffer.from([1]));
           expect(results2[0].b).toEqual(Buffer.from([2]));
           expect(results2[0].c).toEqual(Buffer.from([3]));
-        })
+        });
 
         test("bulk insert nested sql()", async () => {
           await using sql = new SQL({ ...getOptions(), max: 1 });

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -772,7 +772,7 @@ if (isDockerEnabled()) {
       expect(err.code).toBe(`ERR_POSTGRES_IDLE_TIMEOUT`);
     });
 
-    test("Max lifetime works", async () => {
+    test("Max lifetime closes idle connection gracefully", async () => {
       const onClosePromise = Promise.withResolvers();
       const onclose = mock(err => {
         onClosePromise.resolve(err);
@@ -784,24 +784,53 @@ if (isDockerEnabled()) {
         onconnect,
         onclose,
       });
-      let error: any;
-      expect(await sql`select 1 as x`).toEqual([{ x: 1 }]);
-      expect(onconnect).toHaveBeenCalledTimes(1);
-      try {
-        while (true) {
-          for (let i = 0; i < 100; i++) {
-            await sql`select pg_sleep(1)`;
-          }
-        }
-      } catch (e) {
-        error = e;
-      }
 
+      // Get the server-side backend PID before maxLifetime fires
+      const [{ pid: pidBefore }] = await sql`select pg_backend_pid() as pid`;
+      expect(onconnect).toHaveBeenCalledTimes(1);
+
+      // Wait for maxLifetime to fire and close the idle connection
+      await onClosePromise.promise;
       expect(onclose).toHaveBeenCalledTimes(1);
 
-      expect(error).toBeInstanceOf(SQL.SQLError);
-      expect(error).toBeInstanceOf(SQL.PostgresError);
-      expect(error.code).toBe(`ERR_POSTGRES_LIFETIME_TIMEOUT`);
+      // The pool should reconnect — verify via a different backend PID
+      const [{ pid: pidAfter }] = await sql`select pg_backend_pid() as pid`;
+      expect(pidAfter).not.toBe(pidBefore);
+
+      await sql.close();
+    });
+
+    test("Max lifetime does not kill in-flight queries", async () => {
+      const onClosePromise = Promise.withResolvers();
+      const onclose = mock(err => {
+        onClosePromise.resolve(err);
+      });
+      const onconnect = mock();
+      const sql = postgres({
+        ...options,
+        max_lifetime: 1,
+        onconnect,
+        onclose,
+        max: 1,
+      });
+
+      // Get backend PID before the long query
+      const [{ pid: pidBefore }] = await sql`select pg_backend_pid() as pid`;
+
+      // Start a query that takes longer than maxLifetime (3s > 1s).
+      // Previously this would throw ERR_POSTGRES_LIFETIME_TIMEOUT.
+      const result = await sql`select pg_sleep(3), 42 as x`;
+      expect(result[0].x).toBe(42);
+
+      // Wait for the connection to be closed after the query finishes
+      await onClosePromise.promise;
+      expect(onclose).toHaveBeenCalledTimes(1);
+
+      // Verify the pool reconnected with a different backend PID
+      const [{ pid: pidAfter }] = await sql`select pg_backend_pid() as pid`;
+      expect(pidAfter).not.toBe(pidBefore);
+
+      await sql.close();
     });
 
     // Last one wins.


### PR DESCRIPTION
## Problem

When `maxLifetime` expires on a MySQL or Postgres connection, `onMaxLifetimeTimeout` calls `failFmt()`, which immediately:

1. Sets the connection status to **failed**
2. **Rejects all in-flight queries** with `ERR_MYSQL_LIFETIME_TIMEOUT` / `ERR_POSTGRES_LIFETIME_TIMEOUT`
3. Closes the connection

This means any query that happens to be running when the timer fires is killed — even though the query itself is perfectly healthy. In long-running processes that continuously query the database, this makes `maxLifetime` effectively unusable.

Reported in #25405 (MySQL) and confirmed for Postgres in the comments.

## Solution

Instead of hard-failing the connection, `onMaxLifetimeTimeout` now checks whether the connection is idle:

- **Idle** (no in-flight queries) → close the connection gracefully via `close()` / `disconnect()`. No queries are affected, and the pool's existing retry logic creates a replacement on the next query.
- **Busy** (queries in-flight) → reschedule the timer to check again in **1 second**. This repeats until the connection becomes idle between queries, then closes it.

### Why this is safe

- We only close when idle — no queries are ever interrupted
- The pool already handles closed connections: `retry()` reconnects automatically when a query needs the connection
- If the connection fails for another reason before our timer fires, the `if (status == .failed) return` guard prevents double-close
- The `insert()` call on the timer queue correctly sets the state back to `.ACTIVE`

## Changes

| File | Change |
|------|--------|
| `src/sql/mysql/js/JSMySQLConnection.zig` | Check `isIdle()` before closing; reschedule if busy |
| `src/sql/postgres/PostgresSQLConnection.zig` | Check `requests.readableLength() == 0` before closing; reschedule if busy |
| `test/js/sql/sql-mysql.test.ts` | Two tests: idle close + busy query survives (verified via `CONNECTION_ID()`) |
| `test/js/sql/sql.test.ts` | Two tests: idle close + busy query survives (verified via `pg_backend_pid()`) |

## Test plan

Each database (MySQL and Postgres) has two tests:

1. **Idle path** — run a query, wait for `maxLifetime` to fire while idle, verify `onclose` is called, run another query, assert the server-side connection ID changed (proving the pool recycled the connection)
2. **Busy path** — start a `SLEEP(3)` / `pg_sleep(3)` query with `maxLifetime: 1s`, verify the query completes without error (previously threw `LIFETIME_TIMEOUT`), wait for `onclose`, run another query, assert the connection ID changed

All 4 tests verified locally against real MySQL 8.4 and Postgres 16 instances.
