### PR TITLE
Fix crash from stack overflow in JSFunction::prototypeForConstruction

### DIFF
--- a/test/js/bun/jsc/recursive-constructor-stack-overflow.test.ts
+++ b/test/js/bun/jsc/recursive-constructor-stack-overflow.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { bunExe, bunEnv } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 test("recursive constructor call with try/catch does not crash", async () => {
   await using proc = Bun.spawn({
@@ -20,11 +20,7 @@ test("recursive constructor call with try/catch does not crash", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toBe("ok\n");
   expect(exitCode).toBe(0);

--- a/test/js/bun/jsc/recursive-constructor-stack-overflow.test.ts
+++ b/test/js/bun/jsc/recursive-constructor-stack-overflow.test.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "bun:test";
+import { bunExe, bunEnv } from "harness";
+
+test("recursive constructor call with try/catch does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      function F0() {
+        const Ctor = this.constructor;
+        try { new Ctor(); } catch (_e) {}
+      }
+      new F0();
+      console.log("ok");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/jsc/recursive-constructor-stack-overflow.test.ts
+++ b/test/js/bun/jsc/recursive-constructor-stack-overflow.test.ts
@@ -23,5 +23,6 @@ test("recursive constructor call with try/catch does not crash", async () => {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toBe("ok\n");
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/jsc/recursive-constructor-stack-overflow.test.ts
+++ b/test/js/bun/jsc/recursive-constructor-stack-overflow.test.ts
@@ -23,6 +23,5 @@ test("recursive constructor call with try/catch does not crash", async () => {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toBe("ok\n");
-  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
Fixes a crash found by Fuzzilli (fingerprint `2e1891e6328005b7`).

## Root Cause

When a constructor recursively calls itself via `this.constructor` and the stack overflow is caught by `try/catch`, `JSFunction::prototypeForConstruction` can crash with:

```
ASSERTION FAILED: Unexpected exception observed
Error Exception: Maximum call stack size exceeded.
!exception()
ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

The function calls `get(globalObject, vm.propertyNames->prototype)` to look up the constructor's prototype, then asserts `releaseAssertNoException()`. The comment says "This code assumes getting the prototype is not effectful" — but near the stack limit, even a simple property access can throw a stack overflow.

## Fix

In `vendor/WebKit/Source/JavaScriptCore/runtime/JSFunction.cpp`, replace the `releaseAssertNoException()` with an exception check that clears the exception and returns `objectPrototype` as a fallback. This is safe because:

1. The stack is nearly exhausted, so the function body will immediately re-throw the stack overflow
2. The constructed object gets a slightly wrong prototype, but the construction won't complete normally anyway

```diff
     JSValue prototype = get(globalObject, vm.propertyNames->prototype);
-    scope.releaseAssertNoException();
+    if (scope.exception()) [[unlikely]] {
+        scope.clearException();
+        return globalObject->objectPrototype();
+    }
```

This requires a WebKit submodule update — the fix is on branch `farm/1b30348d/fix-stack-overflow-in-prototypeForConstruction` in `vendor/WebKit`.

## Repro

```js
function F0() {
    const v5 = this.constructor;
    try { new v5(); } catch (e) {}
}
new F0();
```