### PR TITLE
Skip env flags (-S, --split-string) in Windows shebang parser

### DIFF
--- a/src/install/windows-shim/BinLinkingShim.zig
+++ b/src/install/windows-shim/BinLinkingShim.zig
@@ -195,8 +195,21 @@ pub const Shebang = struct {
         var tokenizer = std.mem.tokenizeScalar(u8, line, ' ');
         const first = tokenizer.next() orelse return parseFromBinPath(bin_path);
         if (eqlComptime(first, "/usr/bin/env") or eqlComptime(first, "/bin/env")) {
-            const rest = tokenizer.rest();
-            const program = tokenizer.next() orelse return parseFromBinPath(bin_path);
+            // Skip env flags (e.g. -S/--split-string, -i, -v) to find the
+            // actual interpreter program. These flags are consumed by env
+            // itself and should not appear in the launcher command line.
+            var rest = tokenizer.rest();
+            var program = tokenizer.next() orelse return parseFromBinPath(bin_path);
+            while (program.len > 0 and program[0] == '-') {
+                if (eqlComptime(program, "--")) {
+                    // "--" signals end of env options; next token is the program.
+                    rest = tokenizer.rest();
+                    program = tokenizer.next() orelse return parseFromBinPath(bin_path);
+                    break;
+                }
+                rest = tokenizer.rest();
+                program = tokenizer.next() orelse return parseFromBinPath(bin_path);
+            }
             const is_node_or_bun = eqlComptime(program, "bun") or eqlComptime(program, "node");
             return try Shebang.init(rest, is_node_or_bun);
         }

--- a/test/regression/issue/28594.test.ts
+++ b/test/regression/issue/28594.test.ts
@@ -1,0 +1,195 @@
+import { test, expect, describe } from "bun:test";
+import { bunExe, bunEnv, tempDir, isWindows } from "harness";
+import { join } from "path";
+
+// https://github.com/oven-sh/bun/issues/28594
+// Shebangs like #!/usr/bin/env -S node should skip the env flags (-S)
+// and use "node" as the interpreter, not "-S".
+describe("env -S flag in shebang", () => {
+  test.skipIf(!isWindows)("package with env -S shebang can be installed and run", async () => {
+    using dir = tempDir("issue-28594", {
+      "package.json": JSON.stringify({
+        name: "test-env-s-flag",
+        version: "1.0.0",
+        dependencies: {
+          "env-s-pkg": "file:./env-s-pkg",
+        },
+      }),
+      "env-s-pkg/package.json": JSON.stringify({
+        name: "env-s-pkg",
+        version: "1.0.0",
+        bin: {
+          "env-s-test": "./bin.js",
+        },
+      }),
+      "env-s-pkg/bin.js": '#!/usr/bin/env -S node --no-warnings=DEP0040\nconsole.log("env-s-works");\n',
+    });
+
+    // Install the package
+    await using installProc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [installStdout, installStderr, installExit] = await Promise.all([
+      installProc.stdout.text(),
+      installProc.stderr.text(),
+      installProc.exited,
+    ]);
+
+    expect(installStderr).not.toContain("error:");
+    expect(installExit).toBe(0);
+
+    // Run the binary through bun run
+    await using runProc = Bun.spawn({
+      cmd: [bunExe(), "run", "env-s-test"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      runProc.stdout.text(),
+      runProc.stderr.text(),
+      runProc.exited,
+    ]);
+
+    expect(stderr).not.toContain('interpreter executable "-S" not found');
+    expect(stdout).toContain("env-s-works");
+    expect(exitCode).toBe(0);
+
+    // Also test running the .exe shim directly
+    await using shimProc = Bun.spawn({
+      cmd: [join(String(dir), "node_modules", ".bin", "env-s-test.exe")],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [shimStdout, shimStderr, shimExit] = await Promise.all([
+      shimProc.stdout.text(),
+      shimProc.stderr.text(),
+      shimProc.exited,
+    ]);
+
+    expect(shimStderr).not.toContain('interpreter executable "-S" not found');
+    expect(shimStdout).toContain("env-s-works");
+    expect(shimExit).toBe(0);
+  });
+
+  test.skipIf(!isWindows)("package with env --split-string shebang can be installed and run", async () => {
+    using dir = tempDir("issue-28594-long", {
+      "package.json": JSON.stringify({
+        name: "test-env-split-string",
+        version: "1.0.0",
+        dependencies: {
+          "split-string-pkg": "file:./split-string-pkg",
+        },
+      }),
+      "split-string-pkg/package.json": JSON.stringify({
+        name: "split-string-pkg",
+        version: "1.0.0",
+        bin: {
+          "split-string-test": "./bin.js",
+        },
+      }),
+      "split-string-pkg/bin.js":
+        '#!/usr/bin/env --split-string node --no-warnings=DEP0040\nconsole.log("split-string-works");\n',
+    });
+
+    await using installProc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, installStderr, installExit] = await Promise.all([
+      installProc.stdout.text(),
+      installProc.stderr.text(),
+      installProc.exited,
+    ]);
+
+    expect(installStderr).not.toContain("error:");
+    expect(installExit).toBe(0);
+
+    await using runProc = Bun.spawn({
+      cmd: [bunExe(), "run", "split-string-test"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      runProc.stdout.text(),
+      runProc.stderr.text(),
+      runProc.exited,
+    ]);
+
+    expect(stderr).not.toContain("not found");
+    expect(stdout).toContain("split-string-works");
+    expect(exitCode).toBe(0);
+  });
+
+  test.skipIf(!isWindows)("package with env -- separator shebang can be installed and run", async () => {
+    using dir = tempDir("issue-28594-sep", {
+      "package.json": JSON.stringify({
+        name: "test-env-separator",
+        version: "1.0.0",
+        dependencies: {
+          "separator-pkg": "file:./separator-pkg",
+        },
+      }),
+      "separator-pkg/package.json": JSON.stringify({
+        name: "separator-pkg",
+        version: "1.0.0",
+        bin: {
+          "separator-test": "./bin.js",
+        },
+      }),
+      "separator-pkg/bin.js": '#!/usr/bin/env -- node\nconsole.log("separator-works");\n',
+    });
+
+    await using installProc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, installStderr, installExit] = await Promise.all([
+      installProc.stdout.text(),
+      installProc.stderr.text(),
+      installProc.exited,
+    ]);
+
+    expect(installStderr).not.toContain("error:");
+    expect(installExit).toBe(0);
+
+    await using runProc = Bun.spawn({
+      cmd: [bunExe(), "run", "separator-test"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      runProc.stdout.text(),
+      runProc.stderr.text(),
+      runProc.exited,
+    ]);
+
+    expect(stderr).not.toContain("not found");
+    expect(stdout).toContain("separator-works");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/regression/issue/28594.test.ts
+++ b/test/regression/issue/28594.test.ts
@@ -1,5 +1,5 @@
-import { test, expect, describe } from "bun:test";
-import { bunExe, bunEnv, tempDir, isWindows } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 // https://github.com/oven-sh/bun/issues/28594


### PR DESCRIPTION
Fixes #28594

## Problem

When a package like `@google/gemini-cli` uses the shebang `#!/usr/bin/env -S node --no-warnings=DEP0040`, Bun's Windows shebang parser treats `-S` as the interpreter program name instead of recognizing it as a flag to `env`. This causes the Windows shim to fail with:

```
error: interpreter executable "-S" not found in %PATH%
```

## Root Cause

In `BinLinkingShim.zig`, `Shebang.parse()` tokenizes the shebang line and after identifying `/usr/bin/env`, takes the very next token as the program name. For `#!/usr/bin/env -S node --no-warnings=DEP0040`, that next token is `-S` — an `env` flag, not the interpreter.

The resulting launcher command line becomes `-S node --no-warnings=DEP0040`, causing the shim to try to spawn `-S` as an executable.

## Fix

After identifying `/usr/bin/env` or `/bin/env`, skip any tokens that start with `-` (env flags like `-S`, `--split-string`, `-i`, `-v`, etc.) to find the actual interpreter program. Handle `--` as the standard end-of-options separator.

This correctly resolves the launcher to `node --no-warnings=DEP0040` with `is_node_or_bun=true`.

## Verification

- Test covers `-S`, `--split-string`, and `--` separator variants
- Tests are Windows-only (`test.skipIf(!isWindows)`) since the Windows shim code path is only exercised on Windows (Linux/macOS use kernel shebang handling via symlinks)