### PR TITLE
Fix global bin shims not created when bin targets point into hoisted node_modules

### DIFF
--- a/src/install/bin.zig
+++ b/src/install/bin.zig
@@ -861,43 +861,54 @@ pub const Bin = extern struct {
 
         /// Resolve the absolute target for a bin entry inside `package_dir`.
         ///
-        /// When redirected into a platform-specific optional dependency (native
-        /// binlink optimization), the platform package may lay the binary out
-        /// differently than the root package's `bin` field expects. esbuild
-        /// mirrors the path exactly (`bin/esbuild` in both) but other packages
-        /// ship the binary at the package root under the bin name (e.g.
-        /// `@anthropic-ai/claude-code` has `bin/claude.exe` in the root package
-        /// but `claude` at the root of `@anthropic-ai/claude-code-linux-x64`,
-        /// which has no `bin` field of its own).
+        /// Two orthogonal fallbacks are applied when the primary path does not
+        /// exist on disk:
         ///
-        /// Both candidates come from the root package's `bin` entry - its
-        /// value (`target`) and its key (`bin_name`):
-        ///   1. `<package_dir>/<target>` - the path from the root `bin` field
-        ///   2. `<package_dir>/<bin_name>` - the bin name at package root
+        /// 1. Native binlink redirect: when redirected into a platform-specific
+        ///    optional dependency (e.g. `@anthropic-ai/claude-code` ->
+        ///    `@anthropic-ai/claude-code-linux-x64`), the platform package may
+        ///    lay the binary out differently than the root package's `bin`
+        ///    field expects. Try `<package_dir>/<bin_name>`.
         ///
-        /// Falls through to (1) when nothing exists so the existing
-        /// `skipped_due_to_missing_bin` retry-without-redirect path still fires.
+        /// 2. Hoisted `node_modules/...` target: when a package has bin entries
+        ///    pointing into its own `node_modules/` (e.g.
+        ///    `"bin": {"foo": "node_modules/@x/y/bin.js"}`), the dependency
+        ///    may be hoisted to the parent `node_modules` directory, so the
+        ///    nested path doesn't exist. Resolve relative to the parent
+        ///    `node_modules` where hoisted packages live.
+        ///
+        /// Falls through to the primary `<package_dir>/<target>` path when
+        /// nothing exists so the existing `skipped_due_to_missing_bin`
+        /// retry-without-redirect path still fires.
         fn resolveBinTarget(this: *const Linker, package_dir: []const u8, target: []const u8, bin_name: []const u8) [:0]const u8 {
-            const primary = path.joinAbsStringZ(package_dir, &.{target}, .auto);
+            if (this.isNativeBinlinkRedirect()) {
+                const primary = path.joinAbsStringZ(package_dir, &.{target}, .auto);
+                if (bun.sys.exists(primary)) return primary;
 
-            if (!this.isNativeBinlinkRedirect()) {
-                return primary;
-            }
-
-            if (bun.sys.exists(primary)) {
-                return primary;
-            }
-
-            if (bin_name.len > 0) {
-                const at_root = path.joinAbsStringZ(package_dir, &.{bin_name}, .auto);
-                if (bun.sys.exists(at_root)) {
-                    return at_root;
+                if (bin_name.len > 0) {
+                    const at_root = path.joinAbsStringZ(package_dir, &.{bin_name}, .auto);
+                    if (bun.sys.exists(at_root)) return at_root;
                 }
             }
 
-            // Nothing found; return the primary so `linkBinOrCreateShim` sets
-            // `skipped_due_to_missing_bin` and the caller retries without the
-            // redirect.
+            // Hoisting fallback: bin target like "node_modules/@x/y/bin.js"
+            // resolves against the parent `node_modules` directory where
+            // hoisted packages live. Accept both separators and a leading `./`.
+            const hoisted_rel = strings.withoutPrefixIfPossibleComptime(target, "node_modules/") orelse
+                strings.withoutPrefixIfPossibleComptime(target, "./node_modules/") orelse
+                strings.withoutPrefixIfPossibleComptime(target, "node_modules\\") orelse
+                strings.withoutPrefixIfPossibleComptime(target, ".\\node_modules\\");
+
+            if (hoisted_rel) |rel| if (rel.len > 0) {
+                const primary = path.joinAbsStringZ(package_dir, &.{target}, .auto);
+                if (bun.sys.exists(primary)) return primary;
+                const nm_path = strings.withoutTrailingSlash(this.target_node_modules_path.slice());
+                const hoisted = path.joinAbsStringZ(nm_path, &.{rel}, .auto);
+                if (bun.sys.exists(hoisted)) return hoisted;
+            };
+
+            // Nothing matched; recompute so the caller gets a stable path
+            // after prior exists()/join calls clobbered the threadlocal buffer.
             return path.joinAbsStringZ(package_dir, &.{target}, .auto);
         }
 
@@ -1014,7 +1025,7 @@ pub const Bin = extern struct {
                     if (target.len == 0) return;
 
                     // for normalizing `target`
-                    const abs_target_dir = path.joinAbsStringZ(package_dir, &.{target}, .auto);
+                    const abs_target_dir = this.resolveBinTarget(package_dir, target, "");
 
                     var target_dir = bun.openDirAbsolute(abs_target_dir) catch |err| {
                         if (err == error.ENOENT) {
@@ -1108,9 +1119,14 @@ pub const Bin = extern struct {
                     const target = this.bin.value.dir.slice(this.string_buf);
                     if (target.len == 0) return;
 
-                    const abs_target_dir = path.joinAbsStringZ(package_dir, &.{target}, .auto);
+                    const abs_target_dir = this.resolveBinTarget(package_dir, target, "");
 
                     var target_dir = bun.openDirAbsolute(abs_target_dir) catch |err| {
+                        if (err == error.ENOENT) {
+                            // mirror link() .dir: a missing bin directory is
+                            // benign during uninstall too (nothing to remove).
+                            return;
+                        }
                         this.err = err;
                         return;
                     };

--- a/test/regression/issue/28597.test.ts
+++ b/test/regression/issue/28597.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "bun:test";
+import { chmodSync, existsSync, mkdirSync, readlinkSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// Regression test for https://github.com/oven-sh/bun/issues/28597
+// When a package has bin entries pointing into node_modules/ (e.g. a wrapper
+// package), and the dependency gets hoisted, global bin shims must still be created.
+
+test("global bin shims are created when bin target points into hoisted node_modules", async () => {
+  using dir = tempDir("issue-28597", {});
+  const dirStr = String(dir);
+
+  // Create inner package tarball content
+  const innerPkgJson = JSON.stringify({
+    name: "@inner-scope/inner-bin",
+    version: "1.0.0",
+    bin: { "inner-bin": "bin.js" },
+  });
+
+  // Create wrapper package tarball content
+  // Key: bin entries point into node_modules/ subdirectory
+  const wrapperPkgJson = JSON.stringify({
+    name: "wrapper-bin",
+    version: "1.0.0",
+    dependencies: { "@inner-scope/inner-bin": "1.0.0" },
+    bin: { "wrapper-tool": "node_modules/@inner-scope/inner-bin/bin.js" },
+  });
+
+  // Build tarballs in-memory using Bun.spawn + tar
+  const innerTarDir = join(dirStr, "inner-tar", "package");
+  const wrapperTarDir = join(dirStr, "wrapper-tar", "package");
+
+  mkdirSync(innerTarDir, { recursive: true });
+  writeFileSync(join(innerTarDir, "package.json"), innerPkgJson);
+  writeFileSync(join(innerTarDir, "bin.js"), "");
+  chmodSync(join(innerTarDir, "bin.js"), 0o755);
+
+  mkdirSync(wrapperTarDir, { recursive: true });
+  writeFileSync(join(wrapperTarDir, "package.json"), wrapperPkgJson);
+
+  // Create tarballs
+  {
+    await using proc = Bun.spawn({
+      cmd: ["tar", "czf", join(dirStr, "inner-bin-1.0.0.tgz"), "-C", join(dirStr, "inner-tar"), "package"],
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    expect(await proc.exited).toBe(0);
+  }
+  {
+    await using proc = Bun.spawn({
+      cmd: ["tar", "czf", join(dirStr, "wrapper-bin-1.0.0.tgz"), "-C", join(dirStr, "wrapper-tar"), "package"],
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    expect(await proc.exited).toBe(0);
+  }
+
+  // Serve packages via a simple HTTP registry
+  await using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const pathname = url.pathname;
+
+      if (pathname === "/wrapper-bin") {
+        return Response.json({
+          name: "wrapper-bin",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: "wrapper-bin",
+              version: "1.0.0",
+              dependencies: { "@inner-scope/inner-bin": "1.0.0" },
+              bin: { "wrapper-tool": "node_modules/@inner-scope/inner-bin/bin.js" },
+              dist: { tarball: `http://localhost:${server.port}/wrapper-bin-1.0.0.tgz` },
+            },
+          },
+        });
+      }
+
+      if (pathname === "/@inner-scope%2finner-bin" || pathname === "/@inner-scope/inner-bin") {
+        return Response.json({
+          name: "@inner-scope/inner-bin",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: "@inner-scope/inner-bin",
+              version: "1.0.0",
+              bin: { "inner-bin": "bin.js" },
+              dist: { tarball: `http://localhost:${server.port}/inner-bin-1.0.0.tgz` },
+            },
+          },
+        });
+      }
+
+      if (pathname.endsWith(".tgz")) {
+        const filepath = join(dirStr, pathname.slice(1));
+        if (existsSync(filepath)) return new Response(Bun.file(filepath));
+      }
+
+      return new Response("Not found", { status: 404 });
+    },
+  });
+
+  const globalDir = join(dirStr, "global-install");
+  const globalBinDir = join(dirStr, "global-bin");
+  mkdirSync(globalBinDir, { recursive: true });
+
+  const bunfig = join(dirStr, "bunfig.toml");
+  writeFileSync(
+    bunfig,
+    `[install]\ncache = false\nregistry = "http://localhost:${server.port}/"\nglobalBinDir = "${globalBinDir.replace(/\\/g, "\\\\")}"\n`,
+  );
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", "-g", `--config=${bunfig}`, "wrapper-bin"],
+    cwd: dirStr,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...bunEnv, BUN_INSTALL: globalDir },
+  });
+
+  const exitCode = await proc.exited;
+
+  // The global bin shim should exist despite the bin target pointing
+  // into node_modules/ (hoisted dependency)
+  if (process.platform === "win32") {
+    expect(existsSync(join(globalBinDir, "wrapper-tool.exe"))).toBeTrue();
+  } else {
+    expect(existsSync(join(globalBinDir, "wrapper-tool"))).toBeTrue();
+    // Verify symlink resolves to the hoisted location
+    const target = readlinkSync(join(globalBinDir, "wrapper-tool"));
+    expect(target).toContain(join("@inner-scope", "inner-bin", "bin.js"));
+  }
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Problem

When a package has `bin` entries pointing into `node_modules/` subdirectories (like `sudocode` does):

```json
"bin": {
    "sudocode": "node_modules/@sudocode-ai/cli/dist/cli.js",
    "sdc": "node_modules/@sudocode-ai/cli/dist/cli.js"
}
```

...and the dependency (`@sudocode-ai/cli`) gets hoisted to the parent `node_modules` directory during global install, the constructed target path does not exist on disk. `linkBinOrCreateShim` checks `bun.sys.exists(abs_target)` and silently skips, so no global shims are created in `~/.bun/bin/`.

## Root Cause

The bin linker constructs the target path as `<node_modules>/<package>/node_modules/@dep/pkg/bin.js`, but because the dependency was hoisted, the file actually lives at `<node_modules>/@dep/pkg/bin.js`.

## Fix

Fold the hoisting fallback into `resolveBinTarget` (which already handles native binlink redirects). When the bin target starts with `node_modules/` (or `node_modules\` on Windows, optionally prefixed by `./` / `.\`) and the primary path does not exist, resolve it against the parent `node_modules` directory where hoisted packages live.

Applied in `resolveBinTarget`, which is called from all four bin tag cases (`.file`, `.named_file`, `.map`, `.dir`) in both `link()` and `unlink()` so install/uninstall stay symmetric.

## Rebase note

Rebased onto main (PR #29489 refactored bin linking, introducing `resolveBinTarget`). Resolved by merging the hoisting logic as an additional fallback alongside the native binlink redirect logic in the same function. Conflicts in `src/install/bin.zig` only.

## Verification

- `bun bd test test/regression/issue/28597.test.ts` — **passes** with fix
- `git stash push -- src/ && bun bd test test/regression/issue/28597.test.ts` — **fails** without fix (shims not created)

Fixes #28597