### PR TITLE
Resolve per-file JSX settings from nearest enclosing tsconfig.json at runtime

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1217,6 +1217,8 @@ pub const JSX = struct {
             hasher.update(this.import_source.production);
             hasher.update(this.classic_import_source);
             hasher.update(this.package_name);
+            hasher.update(std.mem.asBytes(&this.runtime));
+            hasher.update(std.mem.asBytes(&this.development));
         }
 
         pub fn importSource(this: *const Pragma) string {

--- a/src/bundler/transpiler.zig
+++ b/src/bundler/transpiler.zig
@@ -230,6 +230,37 @@ pub const Transpiler = struct {
         this.fs.deinit();
     }
 
+    pub const PerFileFeatures = struct {
+        jsx: options.JSX.Pragma,
+        emit_decorator_metadata: bool,
+        experimental_decorators: bool,
+    };
+
+    /// Resolve per-file JSX and decorator settings from the nearest
+    /// enclosing tsconfig.json, falling back to the root config.
+    pub fn perFileFeatures(t: *Transpiler, path: Fs.Path) PerFileFeatures {
+        var out: PerFileFeatures = .{
+            .jsx = t.options.jsx,
+            .emit_decorator_metadata = t.options.emit_decorator_metadata,
+            .experimental_decorators = t.options.experimental_decorators,
+        };
+        if (path.isFile() and std.fs.path.isAbsolute(path.name.dir)) {
+            if (t.resolver.readDirInfo(path.name.dir) catch null) |dir_info| {
+                if (dir_info.enclosing_tsconfig_json) |tsconfig| {
+                    out.jsx = tsconfig.mergeJSX(out.jsx);
+                    out.jsx.development = switch (t.options.force_node_env) {
+                        .development => true,
+                        .production => false,
+                        .unspecified => t.options.jsx.development,
+                    };
+                    out.emit_decorator_metadata = out.emit_decorator_metadata or tsconfig.emit_decorator_metadata;
+                    out.experimental_decorators = out.experimental_decorators or tsconfig.experimental_decorators;
+                }
+            }
+        }
+        return out;
+    }
+
     pub fn configureLinkerWithAutoJSX(transpiler: *Transpiler, auto_jsx: bool) void {
         transpiler.linker = Linker.init(
             transpiler.allocator,

--- a/src/jsc/ModuleLoader.zig
+++ b/src/jsc/ModuleLoader.zig
@@ -222,6 +222,27 @@ pub fn transpileSourceCode(
             };
 
             var input_file_fd: FD = bun.invalid_fd;
+
+            // Resolve per-file JSX and decorator settings from the nearest
+            // enclosing tsconfig.json instead of using only the root config.
+            var jsx = jsc_vm.transpiler.options.jsx;
+            var emit_decorator_metadata = jsc_vm.transpiler.options.emit_decorator_metadata;
+            var experimental_decorators = jsc_vm.transpiler.options.experimental_decorators;
+            if (path.isFile() and std.fs.path.isAbsolute(path.name.dir)) {
+                if (jsc_vm.transpiler.resolver.readDirInfo(path.name.dir) catch null) |dir_info| {
+                    if (dir_info.enclosing_tsconfig_json) |tsconfig| {
+                        jsx = tsconfig.mergeJSX(jsx);
+                        jsx.development = switch (jsc_vm.transpiler.options.force_node_env) {
+                            .development => true,
+                            .production => false,
+                            .unspecified => jsc_vm.transpiler.options.jsx.development,
+                        };
+                        emit_decorator_metadata = emit_decorator_metadata or tsconfig.emit_decorator_metadata;
+                        experimental_decorators = experimental_decorators or tsconfig.experimental_decorators;
+                    }
+                }
+            }
+
             var parse_options = Transpiler.ParseOptions{
                 .allocator = allocator,
                 .path = path,
@@ -231,9 +252,9 @@ pub fn transpileSourceCode(
                 .file_fd_ptr = &input_file_fd,
                 .file_hash = hash,
                 .macro_remappings = macro_remappings,
-                .jsx = jsc_vm.transpiler.options.jsx,
-                .emit_decorator_metadata = jsc_vm.transpiler.options.emit_decorator_metadata,
-                .experimental_decorators = jsc_vm.transpiler.options.experimental_decorators,
+                .jsx = jsx,
+                .emit_decorator_metadata = emit_decorator_metadata,
+                .experimental_decorators = experimental_decorators,
                 .virtual_source = virtual_source,
                 .dont_bundle_twice = true,
                 .allow_commonjs = true,

--- a/src/jsc/ModuleLoader.zig
+++ b/src/jsc/ModuleLoader.zig
@@ -223,25 +223,8 @@ pub fn transpileSourceCode(
 
             var input_file_fd: FD = bun.invalid_fd;
 
-            // Resolve per-file JSX and decorator settings from the nearest
-            // enclosing tsconfig.json instead of using only the root config.
-            var jsx = jsc_vm.transpiler.options.jsx;
-            var emit_decorator_metadata = jsc_vm.transpiler.options.emit_decorator_metadata;
-            var experimental_decorators = jsc_vm.transpiler.options.experimental_decorators;
-            if (path.isFile() and std.fs.path.isAbsolute(path.name.dir)) {
-                if (jsc_vm.transpiler.resolver.readDirInfo(path.name.dir) catch null) |dir_info| {
-                    if (dir_info.enclosing_tsconfig_json) |tsconfig| {
-                        jsx = tsconfig.mergeJSX(jsx);
-                        jsx.development = switch (jsc_vm.transpiler.options.force_node_env) {
-                            .development => true,
-                            .production => false,
-                            .unspecified => jsc_vm.transpiler.options.jsx.development,
-                        };
-                        emit_decorator_metadata = emit_decorator_metadata or tsconfig.emit_decorator_metadata;
-                        experimental_decorators = experimental_decorators or tsconfig.experimental_decorators;
-                    }
-                }
-            }
+            // Per-file JSX/decorator settings follow the nearest enclosing tsconfig.json, not just the root.
+            const per_file = jsc_vm.transpiler.perFileFeatures(path);
 
             var parse_options = Transpiler.ParseOptions{
                 .allocator = allocator,
@@ -252,9 +235,9 @@ pub fn transpileSourceCode(
                 .file_fd_ptr = &input_file_fd,
                 .file_hash = hash,
                 .macro_remappings = macro_remappings,
-                .jsx = jsx,
-                .emit_decorator_metadata = emit_decorator_metadata,
-                .experimental_decorators = experimental_decorators,
+                .jsx = per_file.jsx,
+                .emit_decorator_metadata = per_file.emit_decorator_metadata,
+                .experimental_decorators = per_file.experimental_decorators,
                 .virtual_source = virtual_source,
                 .dont_bundle_twice = true,
                 .allow_commonjs = true,

--- a/src/jsc/RuntimeTranspilerCache.zig
+++ b/src/jsc/RuntimeTranspilerCache.zig
@@ -17,7 +17,8 @@
 /// Version 18: Include ESM record (module info) with an ES Module, see #15758
 /// Version 19: Sourcemap blob is InternalSourceMap (varint stream + sync points), not VLQ.
 /// Version 20: InternalSourceMap stream is bit-packed windows.
-const expected_version = 20;
+/// Version 21: Include JSX runtime and development flag in feature hashing for per-file JSX cache separation.
+const expected_version = 21;
 
 const debug = Output.scoped(.cache, .visible);
 const MINIMUM_CACHE_SIZE = 50 * 1024;

--- a/src/jsc/RuntimeTranspilerStore.zig
+++ b/src/jsc/RuntimeTranspilerStore.zig
@@ -383,6 +383,26 @@ pub const RuntimeTranspilerStore = struct {
                 else => .unknown,
             };
 
+            // Resolve per-file JSX and decorator settings from the nearest
+            // enclosing tsconfig.json instead of using only the root config.
+            var jsx = transpiler.options.jsx;
+            var emit_decorator_metadata = transpiler.options.emit_decorator_metadata;
+            var experimental_decorators = transpiler.options.experimental_decorators;
+            if (path.isFile() and std.fs.path.isAbsolute(path.name.dir)) {
+                if (transpiler.resolver.readDirInfo(path.name.dir) catch null) |dir_info| {
+                    if (dir_info.enclosing_tsconfig_json) |tsconfig| {
+                        jsx = tsconfig.mergeJSX(jsx);
+                        jsx.development = switch (transpiler.options.force_node_env) {
+                            .development => true,
+                            .production => false,
+                            .unspecified => transpiler.options.jsx.development,
+                        };
+                        emit_decorator_metadata = emit_decorator_metadata or tsconfig.emit_decorator_metadata;
+                        experimental_decorators = experimental_decorators or tsconfig.experimental_decorators;
+                    }
+                }
+            }
+
             var parse_options = Transpiler.ParseOptions{
                 .allocator = allocator,
                 .path = path,
@@ -392,9 +412,9 @@ pub const RuntimeTranspilerStore = struct {
                 .file_fd_ptr = &input_file_fd,
                 .file_hash = hash,
                 .macro_remappings = macro_remappings,
-                .jsx = transpiler.options.jsx,
-                .emit_decorator_metadata = transpiler.options.emit_decorator_metadata,
-                .experimental_decorators = transpiler.options.experimental_decorators,
+                .jsx = jsx,
+                .emit_decorator_metadata = emit_decorator_metadata,
+                .experimental_decorators = experimental_decorators,
                 .virtual_source = null,
                 .dont_bundle_twice = true,
                 .allow_commonjs = true,

--- a/src/jsc/RuntimeTranspilerStore.zig
+++ b/src/jsc/RuntimeTranspilerStore.zig
@@ -383,25 +383,8 @@ pub const RuntimeTranspilerStore = struct {
                 else => .unknown,
             };
 
-            // Resolve per-file JSX and decorator settings from the nearest
-            // enclosing tsconfig.json instead of using only the root config.
-            var jsx = transpiler.options.jsx;
-            var emit_decorator_metadata = transpiler.options.emit_decorator_metadata;
-            var experimental_decorators = transpiler.options.experimental_decorators;
-            if (path.isFile() and std.fs.path.isAbsolute(path.name.dir)) {
-                if (transpiler.resolver.readDirInfo(path.name.dir) catch null) |dir_info| {
-                    if (dir_info.enclosing_tsconfig_json) |tsconfig| {
-                        jsx = tsconfig.mergeJSX(jsx);
-                        jsx.development = switch (transpiler.options.force_node_env) {
-                            .development => true,
-                            .production => false,
-                            .unspecified => transpiler.options.jsx.development,
-                        };
-                        emit_decorator_metadata = emit_decorator_metadata or tsconfig.emit_decorator_metadata;
-                        experimental_decorators = experimental_decorators or tsconfig.experimental_decorators;
-                    }
-                }
-            }
+            // Per-file JSX/decorator settings follow the nearest enclosing tsconfig.json, not just the root.
+            const per_file = transpiler.perFileFeatures(path);
 
             var parse_options = Transpiler.ParseOptions{
                 .allocator = allocator,
@@ -412,9 +395,9 @@ pub const RuntimeTranspilerStore = struct {
                 .file_fd_ptr = &input_file_fd,
                 .file_hash = hash,
                 .macro_remappings = macro_remappings,
-                .jsx = jsx,
-                .emit_decorator_metadata = emit_decorator_metadata,
-                .experimental_decorators = experimental_decorators,
+                .jsx = per_file.jsx,
+                .emit_decorator_metadata = per_file.emit_decorator_metadata,
+                .experimental_decorators = per_file.experimental_decorators,
                 .virtual_source = null,
                 .dont_bundle_twice = true,
                 .allow_commonjs = true,

--- a/test/regression/issue/28605.test.ts
+++ b/test/regression/issue/28605.test.ts
@@ -42,9 +42,10 @@ test.concurrent("jsxImportSource from nested tsconfig is used when running from 
     stderr: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  expect(exitCode).toBe(0);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("Cannot find module");
   expect(stdout).toContain('"type":"div"');
+  expect(exitCode).toBe(0);
 });
 
 test.concurrent("jsxImportSource from deeply nested tsconfig overrides root tsconfig", async () => {
@@ -96,8 +97,9 @@ test.concurrent("jsxImportSource from deeply nested tsconfig overrides root tsco
     stderr: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  expect(exitCode).toBe(0);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("Cannot find module");
   // Both the startup and post-startup paths must pick up the nested tsconfig.
   expect(stdout.match(/"source":"nested"/g)?.length).toBe(2);
+  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/28605.test.ts
+++ b/test/regression/issue/28605.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-test("jsxImportSource from nested tsconfig is used when running from workspace root", async () => {
+test.concurrent("jsxImportSource from nested tsconfig is used when running from workspace root", async () => {
   using dir = tempDir("issue-28605", {
     "package.json": JSON.stringify({
       private: true,
@@ -10,24 +10,12 @@ test("jsxImportSource from nested tsconfig is used when running from workspace r
     "node_modules/chat/package.json": JSON.stringify({
       name: "chat",
       version: "1.0.0",
-      exports: {
-        "./jsx-runtime": "./jsx-runtime.js",
-        "./jsx-dev-runtime": "./jsx-dev-runtime.js",
-      },
+      exports: { "./jsx-dev-runtime": "./jsx-dev-runtime.js" },
     }),
-    "node_modules/chat/jsx-runtime.js": `
-      export function jsx(type, props) { return JSON.stringify({ type, props }); }
-      export function jsxs(type, props) { return JSON.stringify({ type, props }); }
-      export const Fragment = "Fragment";
-    `,
     "node_modules/chat/jsx-dev-runtime.js": `
       export function jsxDEV(type, props) { return JSON.stringify({ type, props }); }
       export const Fragment = "Fragment";
     `,
-    "services/connect/package.json": JSON.stringify({
-      name: "connect",
-      version: "1.0.0",
-    }),
     "services/connect/tsconfig.json": JSON.stringify({
       compilerOptions: {
         jsx: "react-jsx",
@@ -54,16 +42,13 @@ test("jsxImportSource from nested tsconfig is used when running from workspace r
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stderr).not.toContain("Cannot find module");
-  expect(stdout).toContain('"type":"div"');
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
   expect(exitCode).toBe(0);
+  expect(stdout).toContain('"type":"div"');
 });
 
-test("jsxImportSource from deeply nested tsconfig overrides root tsconfig", async () => {
+test.concurrent("jsxImportSource from deeply nested tsconfig overrides root tsconfig", async () => {
   using dir = tempDir("issue-28605-nested", {
-    "package.json": JSON.stringify({ private: true }),
     "tsconfig.json": JSON.stringify({
       compilerOptions: {
         jsx: "react-jsx",
@@ -73,16 +58,8 @@ test("jsxImportSource from deeply nested tsconfig overrides root tsconfig", asyn
     "node_modules/nested-jsx/package.json": JSON.stringify({
       name: "nested-jsx",
       version: "1.0.0",
-      exports: {
-        "./jsx-runtime": "./jsx-runtime.js",
-        "./jsx-dev-runtime": "./jsx-dev-runtime.js",
-      },
+      exports: { "./jsx-dev-runtime": "./jsx-dev-runtime.js" },
     }),
-    "node_modules/nested-jsx/jsx-runtime.js": `
-      export function jsx(type, props) { return JSON.stringify({ source: "nested", type, props }); }
-      export function jsxs(type, props) { return JSON.stringify({ source: "nested", type, props }); }
-      export const Fragment = "Fragment";
-    `,
     "node_modules/nested-jsx/jsx-dev-runtime.js": `
       export function jsxDEV(type, props) { return JSON.stringify({ source: "nested", type, props }); }
       export const Fragment = "Fragment";
@@ -119,9 +96,8 @@ test("jsxImportSource from deeply nested tsconfig overrides root tsconfig", asyn
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stderr).not.toContain("Cannot find module");
-  expect(stdout).toContain('"source":"nested"');
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
   expect(exitCode).toBe(0);
+  // Both the startup and post-startup paths must pick up the nested tsconfig.
+  expect(stdout.match(/"source":"nested"/g)?.length).toBe(2);
 });

--- a/test/regression/issue/28605.test.ts
+++ b/test/regression/issue/28605.test.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("jsxImportSource from nested tsconfig is used when running from workspace root", async () => {
+  using dir = tempDir("issue-28605", {
+    "package.json": JSON.stringify({
+      private: true,
+      workspaces: ["services/connect"],
+    }),
+    "node_modules/chat/package.json": JSON.stringify({
+      name: "chat",
+      version: "1.0.0",
+      exports: {
+        "./jsx-runtime": "./jsx-runtime.js",
+        "./jsx-dev-runtime": "./jsx-dev-runtime.js",
+      },
+    }),
+    "node_modules/chat/jsx-runtime.js": `
+      export function jsx(type, props) { return JSON.stringify({ type, props }); }
+      export function jsxs(type, props) { return JSON.stringify({ type, props }); }
+      export const Fragment = "Fragment";
+    `,
+    "node_modules/chat/jsx-dev-runtime.js": `
+      export function jsxDEV(type, props) { return JSON.stringify({ type, props }); }
+      export const Fragment = "Fragment";
+    `,
+    "services/connect/package.json": JSON.stringify({
+      name: "connect",
+      version: "1.0.0",
+    }),
+    "services/connect/tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        jsx: "react-jsx",
+        jsxImportSource: "chat",
+      },
+      include: ["src/**/*"],
+    }),
+    "services/connect/src/lib/prompt.tsx": `
+      export function Prompt() {
+        return <div>hello</div>;
+      }
+    `,
+    "services/connect/src/app.ts": `
+      import { Prompt } from "./lib/prompt.tsx";
+      console.log(Prompt());
+    `,
+  });
+
+  // Run from the workspace root (no tsconfig.json there)
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "./services/connect/src/app.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("Cannot find module");
+  expect(stdout).toContain('"type":"div"');
+  expect(exitCode).toBe(0);
+});
+
+test("jsxImportSource from deeply nested tsconfig overrides root tsconfig", async () => {
+  using dir = tempDir("issue-28605-nested", {
+    "package.json": JSON.stringify({ private: true }),
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        jsx: "react-jsx",
+        jsxImportSource: "root-jsx",
+      },
+    }),
+    "node_modules/nested-jsx/package.json": JSON.stringify({
+      name: "nested-jsx",
+      version: "1.0.0",
+      exports: {
+        "./jsx-runtime": "./jsx-runtime.js",
+        "./jsx-dev-runtime": "./jsx-dev-runtime.js",
+      },
+    }),
+    "node_modules/nested-jsx/jsx-runtime.js": `
+      export function jsx(type, props) { return JSON.stringify({ source: "nested", type, props }); }
+      export function jsxs(type, props) { return JSON.stringify({ source: "nested", type, props }); }
+      export const Fragment = "Fragment";
+    `,
+    "node_modules/nested-jsx/jsx-dev-runtime.js": `
+      export function jsxDEV(type, props) { return JSON.stringify({ source: "nested", type, props }); }
+      export const Fragment = "Fragment";
+    `,
+    "packages/ui/tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        jsx: "react-jsx",
+        jsxImportSource: "nested-jsx",
+      },
+    }),
+    "packages/ui/component.tsx": `
+      export function Component() {
+        return <span>nested</span>;
+      }
+    `,
+    "packages/ui/dynamic-component.tsx": `
+      export function DynamicComponent() {
+        return <span>dynamic-nested</span>;
+      }
+    `,
+    "entry.ts": `
+      import { Component } from "./packages/ui/component.tsx";
+      console.log(Component());
+      // Dynamic import of a distinct file exercises RuntimeTranspilerStore (post-startup path)
+      const { DynamicComponent } = await import("./packages/ui/dynamic-component.tsx");
+      console.log(DynamicComponent());
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "./entry.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("Cannot find module");
+  expect(stdout).toContain('"source":"nested"');
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #28605

## Problem

When running `bun run ./services/connect/src/app.ts` from a workspace root that has no `tsconfig.json`, Bun ignored `jsxImportSource: "chat"` from the nested `services/connect/tsconfig.json` and fell back to the default `react`, causing:

```
error: Cannot find module 'react/jsx-dev-runtime' from 'services/connect/src/lib/connect-prompt.tsx'
```

## Cause

Runtime transpilation in `ModuleLoader.zig` and `RuntimeTranspilerStore.zig` always used the global `transpiler.options.jsx` settings — derived once at startup from the root directory's tsconfig.json — for **every** file. The per-file tsconfig resolution via `enclosing_tsconfig_json` (which walks up from the file's directory) was only used in the bundler code path, not the runtime `bun run` path.

## Fix

Before transpiling each file at runtime, look up its directory's `DirInfo` via `readDirInfo` and merge the `enclosing_tsconfig_json`'s JSX/decorator settings, matching the behavior the bundler already uses in `finalizeResult`.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28605.test.ts` → 2 fail (bug exists)
- `bun bd test test/regression/issue/28605.test.ts` → 2 pass (fix works)
- Manual repro with workspace root → nested tsconfig now correctly resolves `chat/jsx-dev-runtime`