### PR TITLE
Strip .esm.preflight suffix in module resolution for Playwright compat

### DIFF
--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -1717,13 +1717,15 @@ fn normalizeSpecifierForResolution(specifier_: []const u8, query_string: *[]cons
         specifier = specifier[0..i];
     }
 
-    // Playwright appends ".esm.preflight" to file URLs for ESM preflight
+    // Playwright appends ".esm.preflight" to file:// URLs for ESM preflight
     // checks that rely on Node.js ESM loader hooks (module.register()).
     // Under Node, the loader intercepts this synthetic import and returns
     // an empty module. Since Bun handles TypeScript/ESM natively and does
     // not support loader hooks, strip the suffix so the underlying file
-    // resolves directly.
-    if (strings.hasSuffixComptime(specifier, ".esm.preflight")) {
+    // resolves directly. Scoped to absolute paths because file:// URLs are
+    // converted to absolute filesystem paths by the C++ layer before
+    // reaching here.
+    if (std.fs.path.isAbsolute(specifier) and strings.hasSuffixComptime(specifier, ".esm.preflight")) {
         specifier = specifier[0 .. specifier.len - ".esm.preflight".len];
     }
 

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -1717,6 +1717,16 @@ fn normalizeSpecifierForResolution(specifier_: []const u8, query_string: *[]cons
         specifier = specifier[0..i];
     }
 
+    // Playwright appends ".esm.preflight" to file URLs for ESM preflight
+    // checks that rely on Node.js ESM loader hooks (module.register()).
+    // Under Node, the loader intercepts this synthetic import and returns
+    // an empty module. Since Bun handles TypeScript/ESM natively and does
+    // not support loader hooks, strip the suffix so the underlying file
+    // resolves directly.
+    if (strings.hasSuffixComptime(specifier, ".esm.preflight")) {
+        specifier = specifier[0 .. specifier.len - ".esm.preflight".len];
+    }
+
     return specifier;
 }
 

--- a/test/regression/issue/28609.test.ts
+++ b/test/regression/issue/28609.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 

--- a/test/regression/issue/28609.test.ts
+++ b/test/regression/issue/28609.test.ts
@@ -2,11 +2,6 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 
-// https://github.com/oven-sh/bun/issues/28609
-// Playwright appends ".esm.preflight" to file URLs for ESM preflight checks
-// via Node.js ESM loader hooks. Bun should strip this suffix and resolve
-// the underlying file.
-
 test("dynamic import with .esm.preflight suffix resolves to base file", async () => {
   using dir = tempDir("esm-preflight", {
     "package.json": JSON.stringify({ type: "module" }),
@@ -15,8 +10,6 @@ test("dynamic import with .esm.preflight suffix resolves to base file", async ()
       import { pathToFileURL } from 'url';
       const configPath = process.argv[2];
       const fileName = pathToFileURL(configPath);
-      // Playwright does this in transform.js requireOrImport():
-      //   await eval(\\\`import(\\\${JSON.stringify(fileName + ".esm.preflight")})\\\`)
       await eval(\`import(\${JSON.stringify(fileName + ".esm.preflight")})\`);
       const mod = await eval(\`import(\${JSON.stringify(fileName)})\`);
       console.log(JSON.stringify(mod.default));

--- a/test/regression/issue/28609.test.ts
+++ b/test/regression/issue/28609.test.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "path";
+
+// https://github.com/oven-sh/bun/issues/28609
+// Playwright appends ".esm.preflight" to file URLs for ESM preflight checks
+// via Node.js ESM loader hooks. Bun should strip this suffix and resolve
+// the underlying file.
+
+test("dynamic import with .esm.preflight suffix resolves to base file", async () => {
+  using dir = tempDir("esm-preflight", {
+    "package.json": JSON.stringify({ type: "module" }),
+    "config.ts": `export default { value: 42 };`,
+    "main.mjs": `
+      import { pathToFileURL } from 'url';
+      const configPath = process.argv[2];
+      const fileName = pathToFileURL(configPath);
+      // Playwright does this in transform.js requireOrImport():
+      //   await eval(\\\`import(\\\${JSON.stringify(fileName + ".esm.preflight")})\\\`)
+      await eval(\`import(\${JSON.stringify(fileName + ".esm.preflight")})\`);
+      const mod = await eval(\`import(\${JSON.stringify(fileName)})\`);
+      console.log(JSON.stringify(mod.default));
+    `,
+  });
+
+  const configPath = path.join(String(dir), "config.ts");
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs", configPath],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("Cannot find module");
+  expect(stdout).toBe('{"value":42}\n');
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Problem

Playwright appends `.esm.preflight` to file URLs for ESM preflight checks via Node.js ESM loader hooks (`module.register()`). Under Node, the registered loader intercepts this synthetic import and returns an empty module. Playwright detects Bun and skips loader registration (`esmLoaderHost.js`), but the `.esm.preflight` import in `requireOrImport()` still runs unconditionally for ESM files.

```
error: Cannot find module '/path/to/playwright.config.ts.esm.preflight'
  from '/path/to/node_modules/playwright/lib/transform/transform.js'
```

## Root Cause

In `transform.js`, Playwright does:
```js
await eval(`import(${JSON.stringify(fileName + ".esm.preflight")})`)
```

Bun tries to resolve `playwright.config.ts.esm.preflight` as a literal file path, which does not exist.

## Fix

Strip the `.esm.preflight` suffix in `normalizeSpecifierForResolution()` in `VirtualMachine.zig`, the same function that already strips query strings from specifiers. This lets the underlying file (e.g. `config.ts`) resolve directly.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28609.test.ts` → **FAIL** (reproduces the bug)
- `bun bd test test/regression/issue/28609.test.ts` → **PASS** (fix works)

Closes #28609