### PR TITLE
fix(serve): leak when Promise<Response> never settles after abort

### DIFF
--- a/src/bun.js/api.zig
+++ b/src/bun.js/api.zig
@@ -4,6 +4,7 @@
 pub const Bun = @import("./api/BunObject.zig");
 
 pub const server = @import("./api/server.zig");
+pub const NativePromiseContext = @import("./api/NativePromiseContext.zig");
 pub const AnyRequestContext = server.AnyRequestContext;
 pub const AnyServer = server.AnyServer;
 pub const DebugHTTPSServer = server.DebugHTTPSServer;

--- a/src/bun.js/api/NativePromiseContext.zig
+++ b/src/bun.js/api/NativePromiseContext.zig
@@ -62,25 +62,93 @@ pub fn take(comptime T: type, cell: jsc.JSValue) ?*T {
 /// Called from the C++ destructor when a cell is collected with a non-null
 /// pointer (i.e., `take()` was never called — the Promise was GC'd without
 /// settling).
+///
+/// The destructor runs during GC sweep, so it is NOT safe to do anything
+/// that might touch the JSC heap. RequestContext.deref() can trigger
+/// deinit() which detaches responses, unrefs bodies, and calls back into
+/// the server — all of which may unprotect JS values or allocate. We must
+/// defer that work to the event loop.
 pub export fn Bun__NativePromiseContext__destroy(ctx: *anyopaque, tag: u8) callconv(.c) void {
-    switch (@as(Tag, @enumFromInt(tag))) {
-        .HTTPServerRequestContext => @as(*server.HTTPServer.RequestContext, @ptrCast(@alignCast(ctx))).deref(),
-        .HTTPSServerRequestContext => @as(*server.HTTPSServer.RequestContext, @ptrCast(@alignCast(ctx))).deref(),
-        .DebugHTTPServerRequestContext => @as(*server.DebugHTTPServer.RequestContext, @ptrCast(@alignCast(ctx))).deref(),
-        .DebugHTTPSServerRequestContext => @as(*server.DebugHTTPSServer.RequestContext, @ptrCast(@alignCast(ctx))).deref(),
-        .BodyValueBufferer => {
-            // ValueBufferer is embedded by value inside HTMLRewriter's
-            // BufferOutputSink, with the owner pointer stored in .ctx. The
-            // pending-promise ref was taken on the owner, so we release it.
-            const bufferer: *bun.webcore.Body.ValueBufferer = @ptrCast(@alignCast(ctx));
-            @as(*HTMLRewriter.BufferOutputSink, @ptrCast(@alignCast(bufferer.ctx))).deref();
-        },
-    }
+    DeferredDerefTask.schedule(ctx, @enumFromInt(tag));
 }
 
 comptime {
     _ = &Bun__NativePromiseContext__destroy;
 }
+
+/// Defers the GC-triggered deref to the next event-loop tick so it runs
+/// outside the sweep phase.
+///
+/// Zero-allocation: the ctx pointer and our Tag are packed into the task's
+/// `_ptr` slot (pointer in high bits, tag in low 3 bits — the target types
+/// are all >= 8-byte aligned). See PosixSignalTask for the same trick with
+/// signal numbers.
+///
+/// Layout inside jsc.Task's packed u64 after setUintptr:
+///
+///     bits 63..49  bits 48..3           bits 2..0
+///     ┌──────────┬────────────────────┬─────────┐
+///     │ data=u15 │ ctx ptr (aligned)  │ our Tag │
+///     └──────────┴────────────────────┴─────────┘
+///          ▲              ▲                 ▲
+///          │              └─────────┬───────┘
+///      Task union           _ptr (u49) — set by setUintptr
+///      discriminant
+///      (set by init,
+///       untouched)
+///
+/// setUintptr only writes _ptr; the Task discriminant in data that
+/// Task.init(&marker) stamped stays put. @truncate to u49 keeps the low
+/// bits, so both the ctx pointer (bits 3..48) and our Tag (bits 0..2)
+/// survive.
+pub const DeferredDerefTask = struct {
+    const tag_mask: usize = 0b111;
+    comptime {
+        // Low 3 bits hold the tag; verify both capacity and alignment
+        // slack so adding a tag or a packed field can't silently break
+        // the packing.
+        bun.assert(@typeInfo(Tag).@"enum".fields.len <= tag_mask + 1);
+        bun.assert(@alignOf(server.HTTPServer.RequestContext) > tag_mask);
+        bun.assert(@alignOf(server.HTTPSServer.RequestContext) > tag_mask);
+        bun.assert(@alignOf(server.DebugHTTPServer.RequestContext) > tag_mask);
+        bun.assert(@alignOf(server.DebugHTTPSServer.RequestContext) > tag_mask);
+        bun.assert(@alignOf(bun.webcore.Body.ValueBufferer) > tag_mask);
+    }
+
+    pub fn schedule(ctx: *anyopaque, tag: Tag) void {
+        const vm = jsc.VirtualMachine.get();
+        // Process is dying; the leak no longer matters and the task
+        // queue won't drain.
+        if (vm.isShuttingDown()) return;
+
+        const addr = @intFromPtr(ctx);
+        bun.debugAssert(addr & tag_mask == 0);
+
+        var marker: DeferredDerefTask = undefined;
+        var task = jsc.Task.init(&marker);
+        task.setUintptr(@truncate(addr | @intFromEnum(tag)));
+        vm.eventLoop().enqueueTask(task);
+    }
+
+    pub fn runFromJSThread(packed_ptr: usize) void {
+        const tag: Tag = @enumFromInt(packed_ptr & tag_mask);
+        const ctx: *anyopaque = @ptrFromInt(packed_ptr & ~tag_mask);
+        switch (tag) {
+            .HTTPServerRequestContext => @as(*server.HTTPServer.RequestContext, @ptrCast(@alignCast(ctx))).deref(),
+            .HTTPSServerRequestContext => @as(*server.HTTPSServer.RequestContext, @ptrCast(@alignCast(ctx))).deref(),
+            .DebugHTTPServerRequestContext => @as(*server.DebugHTTPServer.RequestContext, @ptrCast(@alignCast(ctx))).deref(),
+            .DebugHTTPSServerRequestContext => @as(*server.DebugHTTPSServer.RequestContext, @ptrCast(@alignCast(ctx))).deref(),
+            .BodyValueBufferer => {
+                // ValueBufferer is embedded by value inside HTMLRewriter's
+                // BufferOutputSink, with the owner pointer stored in .ctx.
+                // The pending-promise ref was taken on the owner, so we
+                // release it there.
+                const bufferer: *bun.webcore.Body.ValueBufferer = @ptrCast(@alignCast(ctx));
+                @as(*HTMLRewriter.BufferOutputSink, @ptrCast(@alignCast(bufferer.ctx))).deref();
+            },
+        }
+    }
+};
 
 const bun = @import("bun");
 const jsc = bun.jsc;

--- a/src/bun.js/api/NativePromiseContext.zig
+++ b/src/bun.js/api/NativePromiseContext.zig
@@ -1,0 +1,89 @@
+//! Zig bindings for the NativePromiseContext JSCell.
+//!
+//! See src/bun.js/bindings/NativePromiseContext.h for the rationale. Short
+//! version: when native code `.then()`s a user Promise and needs a context
+//! pointer, wrap the pointer in this GC-managed cell instead of passing it
+//! raw. If the Promise never settles, GC collects the cell and the destructor
+//! releases the ref — no leak, no use-after-free.
+//!
+//! Usage pattern:
+//!
+//!     ctx.ref();
+//!     const cell = NativePromiseContext.create(global, ctx);
+//!     try promise.thenWithValue(global, cell, onResolve, onReject);
+//!
+//!     // In onResolve/onReject:
+//!     const ctx = NativePromiseContext.take(RequestContext, arguments.ptr[1]) orelse return;
+//!     defer ctx.deref();
+//!     // ... process ...
+
+pub const NativePromiseContext = @This();
+
+/// Must match Bun::NativePromiseContext::Tag in NativePromiseContext.h.
+/// One entry per concrete native type — the tag is packed into the pointer's
+/// upper bits via CompactPointerTuple so the cell stays at one pointer of
+/// storage beyond the JSCell header.
+pub const Tag = enum(u8) {
+    HTTPServerRequestContext,
+    HTTPSServerRequestContext,
+    DebugHTTPServerRequestContext,
+    DebugHTTPSServerRequestContext,
+    BodyValueBufferer,
+
+    pub fn fromType(comptime T: type) Tag {
+        return switch (T) {
+            server.HTTPServer.RequestContext => .HTTPServerRequestContext,
+            server.HTTPSServer.RequestContext => .HTTPSServerRequestContext,
+            server.DebugHTTPServer.RequestContext => .DebugHTTPServerRequestContext,
+            server.DebugHTTPSServer.RequestContext => .DebugHTTPSServerRequestContext,
+            bun.webcore.Body.ValueBufferer => .BodyValueBufferer,
+            else => @compileError("NativePromiseContext.Tag: unsupported type " ++ @typeName(T)),
+        };
+    }
+};
+
+extern fn Bun__NativePromiseContext__create(global: *jsc.JSGlobalObject, ctx: *anyopaque, tag: u8) jsc.JSValue;
+extern fn Bun__NativePromiseContext__take(value: jsc.JSValue) ?*anyopaque;
+
+/// The caller must have already taken a ref on `ctx`. The returned cell owns
+/// that ref until `take()` transfers it back or GC runs the destructor.
+pub fn create(global: *jsc.JSGlobalObject, ctx: anytype) jsc.JSValue {
+    const T = @typeInfo(@TypeOf(ctx)).pointer.child;
+    return Bun__NativePromiseContext__create(global, ctx, @intFromEnum(Tag.fromType(T)));
+}
+
+/// Transfers the ref back to the caller and nulls the cell so the destructor
+/// is a no-op. Returns null if already taken (e.g., the connection aborted
+/// and the ref was released via the destructor on a prior GC cycle).
+pub fn take(comptime T: type, cell: jsc.JSValue) ?*T {
+    return @ptrCast(@alignCast(Bun__NativePromiseContext__take(cell)));
+}
+
+/// Called from the C++ destructor when a cell is collected with a non-null
+/// pointer (i.e., `take()` was never called — the Promise was GC'd without
+/// settling).
+pub export fn Bun__NativePromiseContext__destroy(ctx: *anyopaque, tag: u8) callconv(.c) void {
+    switch (@as(Tag, @enumFromInt(tag))) {
+        .HTTPServerRequestContext => @as(*server.HTTPServer.RequestContext, @ptrCast(@alignCast(ctx))).deref(),
+        .HTTPSServerRequestContext => @as(*server.HTTPSServer.RequestContext, @ptrCast(@alignCast(ctx))).deref(),
+        .DebugHTTPServerRequestContext => @as(*server.DebugHTTPServer.RequestContext, @ptrCast(@alignCast(ctx))).deref(),
+        .DebugHTTPSServerRequestContext => @as(*server.DebugHTTPSServer.RequestContext, @ptrCast(@alignCast(ctx))).deref(),
+        .BodyValueBufferer => {
+            // ValueBufferer is embedded by value inside HTMLRewriter's
+            // BufferOutputSink, with the owner pointer stored in .ctx. The
+            // pending-promise ref was taken on the owner, so we release it.
+            const bufferer: *bun.webcore.Body.ValueBufferer = @ptrCast(@alignCast(ctx));
+            @as(*HTMLRewriter.BufferOutputSink, @ptrCast(@alignCast(bufferer.ctx))).deref();
+        },
+    }
+}
+
+comptime {
+    _ = &Bun__NativePromiseContext__destroy;
+}
+
+const bun = @import("bun");
+const jsc = bun.jsc;
+
+const server = bun.api.server;
+const HTMLRewriter = bun.api.HTMLRewriter.HTMLRewriter;

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -133,7 +133,11 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             ctxLog("onResolve", .{});
 
             const arguments = callframe.arguments_old(2);
-            var ctx = arguments.ptr[1].asPromisePtr(@This());
+            const ctx = NativePromiseContext.take(RequestContext, arguments.ptr[1]) orelse {
+                // The cell's destructor already released the ref (the Promise
+                // was collected before a prior microtask turn reached us).
+                return .js_undefined;
+            };
             defer ctx.deref();
 
             const result = arguments.ptr[0];
@@ -308,9 +312,14 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             ctxLog("onReject", .{});
 
             const arguments = callframe.arguments_old(2);
-            const ctx = arguments.ptr[1].asPromisePtr(@This());
-            const err = arguments.ptr[0];
+            const ctx = NativePromiseContext.take(RequestContext, arguments.ptr[1]) orelse {
+                // The cell's destructor already released the ref (the Promise
+                // was collected before a prior microtask turn reached us).
+                return .js_undefined;
+            };
             defer ctx.deref();
+
+            const err = arguments.ptr[0];
             handleReject(ctx, if (!err.isEmptyOrUndefinedOrNull()) err else .js_undefined);
             return .js_undefined;
         }
@@ -1229,9 +1238,10 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                                 },
                             };
                             this.ref();
-                            assignment_result.then(
+                            const cell = NativePromiseContext.create(globalThis, this);
+                            assignment_result.thenWithValue(
                                 globalThis,
-                                this,
+                                cell,
                                 onResolveStream,
                                 onRejectStream,
                             ) catch {}; // TODO: properly propagate exception upwards
@@ -1595,7 +1605,8 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                 switch (promise.unwrap(vm.global.vm(), .mark_handled)) {
                     .pending => {
                         ctx.ref();
-                        response_value.then(this.globalThis, ctx, RequestContext.onResolve, RequestContext.onReject) catch {}; // TODO: properly propagate exception upwards
+                        const cell = NativePromiseContext.create(this.globalThis, ctx);
+                        response_value.thenWithValue(this.globalThis, cell, RequestContext.onResolve, RequestContext.onReject) catch {}; // TODO: properly propagate exception upwards
                         return;
                     },
                     .fulfilled => |fulfilled_value| {
@@ -1694,8 +1705,8 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
 
         pub fn onResolveStream(_: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
             streamLog("onResolveStream", .{});
-            var args = callframe.arguments_old(2);
-            var req: *@This() = args.ptr[args.len - 1].asPromisePtr(@This());
+            const args = callframe.arguments_old(2);
+            const req = NativePromiseContext.take(RequestContext, args.ptr[args.len - 1]) orelse return .js_undefined;
             defer req.deref();
             req.handleResolveStream();
             return .js_undefined;
@@ -1703,7 +1714,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
         pub fn onRejectStream(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
             streamLog("onRejectStream", .{});
             const args = callframe.arguments_old(2);
-            var req = args.ptr[args.len - 1].asPromisePtr(@This());
+            const req = NativePromiseContext.take(RequestContext, args.ptr[args.len - 1]) orelse return .js_undefined;
             const err = args.ptr[0];
             defer req.deref();
 
@@ -2166,9 +2177,10 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                 .pending => {
                     ctx.flags.is_error_promise_pending = true;
                     ctx.ref();
-                    promise_js.then(
+                    const cell = NativePromiseContext.create(ctx.server.?.globalThis, ctx);
+                    promise_js.thenWithValue(
                         ctx.server.?.globalThis,
-                        ctx,
+                        cell,
                         RequestContext.onResolve,
                         RequestContext.onReject,
                     ) catch {}; // TODO: properly propagate exception upwards
@@ -2695,7 +2707,9 @@ const jsc = bun.jsc;
 const JSGlobalObject = jsc.JSGlobalObject;
 const JSValue = jsc.JSValue;
 const VirtualMachine = jsc.VirtualMachine;
+
 const AnyRequestContext = jsc.API.AnyRequestContext;
+const NativePromiseContext = jsc.API.NativePromiseContext;
 
 const WebCore = jsc.WebCore;
 const Blob = jsc.WebCore.Blob;

--- a/src/bun.js/bindings/BunClientData.cpp
+++ b/src/bun.js/bindings/BunClientData.cpp
@@ -25,6 +25,7 @@
 #include "NodeVM.h"
 #include "../../bake/BakeGlobalObject.h"
 #include "napi_handle_scope.h"
+#include "NativePromiseContext.h"
 
 namespace WebCore {
 using namespace JSC;
@@ -36,6 +37,7 @@ JSHeapData::JSHeapData(Heap& heap)
     , m_heapCellTypeForNodeVMGlobalObject(JSC::IsoHeapCellType::Args<Bun::NodeVMGlobalObject>())
     , m_heapCellTypeForBakeGlobalObject(JSC::IsoHeapCellType::Args<Bake::GlobalObject>())
     , m_heapCellTypeForNapiHandleScopeImpl(JSC::IsoHeapCellType::Args<Bun::NapiHandleScopeImpl>())
+    , m_heapCellTypeForNativePromiseContext(JSC::IsoHeapCellType::Args<Bun::NativePromiseContext>())
     , m_domBuiltinConstructorSpace ISO_SUBSPACE_INIT(heap, heap.cellHeapCellType, JSDOMBuiltinConstructorBase)
     , m_domConstructorSpace ISO_SUBSPACE_INIT(heap, heap.cellHeapCellType, JSDOMConstructorBase)
     , m_domNamespaceObjectSpace ISO_SUBSPACE_INIT(heap, heap.cellHeapCellType, JSDOMObject)

--- a/src/bun.js/bindings/BunClientData.h
+++ b/src/bun.js/bindings/BunClientData.h
@@ -60,6 +60,7 @@ public:
     JSC::IsoHeapCellType m_heapCellTypeForNodeVMGlobalObject;
     JSC::IsoHeapCellType m_heapCellTypeForNapiHandleScopeImpl;
     JSC::IsoHeapCellType m_heapCellTypeForBakeGlobalObject;
+    JSC::IsoHeapCellType m_heapCellTypeForNativePromiseContext;
     // JSC::IsoHeapCellType m_heapCellTypeForGeneratedClass;
 
 private:

--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -1442,6 +1442,18 @@ pub const JSValue = enum(i64) {
         try scope.assertNoExceptionExceptTermination();
     }
 
+    /// Like `then`, but the context is a JSValue instead of a raw pointer.
+    /// Use this when the context should be GC-managed (e.g., a JSCell that
+    /// gets collected with the Promise's reaction if the Promise is GC'd
+    /// without settling).
+    pub fn thenWithValue(this: JSValue, global: *JSGlobalObject, ctx: JSValue, resolve: jsc.JSHostFnZig, reject: jsc.JSHostFnZig) bun.JSTerminated!void {
+        var scope: TopExceptionScope = undefined;
+        scope.init(global, @src());
+        defer scope.deinit();
+        this._then(global, ctx, resolve, reject);
+        try scope.assertNoExceptionExceptTermination();
+    }
+
     pub fn getDescription(this: JSValue, global: *JSGlobalObject) ZigString {
         var zig_str = ZigString.init("");
         getSymbolDescription(this, global, &zig_str);

--- a/src/bun.js/bindings/NativePromiseContext.cpp
+++ b/src/bun.js/bindings/NativePromiseContext.cpp
@@ -1,0 +1,59 @@
+#include "NativePromiseContext.h"
+
+#include "ZigGlobalObject.h"
+
+// Implemented in Zig (src/bun.js/api/NativePromiseContext.zig). Switches on
+// tag to release the ref on the right native type.
+extern "C" void Bun__NativePromiseContext__destroy(void* ctx, uint8_t tag);
+
+namespace Bun {
+
+namespace JSCastingHelpers = JSC::JSCastingHelpers;
+
+const JSC::ClassInfo NativePromiseContext::s_info = {
+    "NativePromiseContext"_s,
+    nullptr,
+    nullptr,
+    nullptr,
+    CREATE_METHOD_TABLE(NativePromiseContext)
+};
+
+NativePromiseContext* NativePromiseContext::create(JSC::VM& vm, JSC::Structure* structure, void* ctx, Tag tag)
+{
+    ASSERT(ctx);
+    NativePromiseContext* cell = new (NotNull, JSC::allocateCell<NativePromiseContext>(vm))
+        NativePromiseContext(vm, structure, ctx, tag);
+    cell->finishCreation(vm);
+    return cell;
+}
+
+NativePromiseContext::~NativePromiseContext()
+{
+    if (void* ctx = pointer()) {
+        Bun__NativePromiseContext__destroy(ctx, static_cast<uint8_t>(tag()));
+    }
+}
+
+void NativePromiseContext::destroy(JSC::JSCell* cell)
+{
+    static_cast<NativePromiseContext*>(cell)->~NativePromiseContext();
+}
+
+} // namespace Bun
+
+extern "C" JSC::EncodedJSValue Bun__NativePromiseContext__create(Zig::GlobalObject* globalObject, void* ctx, uint8_t tag)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto* cell = Bun::NativePromiseContext::create(
+        vm,
+        globalObject->NativePromiseContextStructure(),
+        ctx,
+        static_cast<Bun::NativePromiseContext::Tag>(tag));
+    return JSC::JSValue::encode(cell);
+}
+
+extern "C" void* Bun__NativePromiseContext__take(JSC::EncodedJSValue encodedValue)
+{
+    auto* cell = JSC::jsCast<Bun::NativePromiseContext*>(JSC::JSValue::decode(encodedValue));
+    return cell->take();
+}

--- a/src/bun.js/bindings/NativePromiseContext.h
+++ b/src/bun.js/bindings/NativePromiseContext.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "BunClientData.h"
+#include "root.h"
+#include <wtf/CompactPointerTuple.h>
+
+namespace Bun {
+
+// Opaque marker type so CompactPointerTuple's allowCompactPointers check
+// passes. The actual pointee is one of several Zig-side native types; we
+// cast through void* at the boundary.
+struct NativePromiseContextPointee {
+    WTF_ALLOW_STRUCT_COMPACT_POINTERS;
+};
+
+// A GC-managed cell that owns a reference to a native object for the duration
+// of a pending Promise reaction.
+//
+// Problem: when native code `.then()`s a user Promise and passes a raw pointer
+// as context, it must ref() the native object to keep it alive until the
+// reaction fires. But if the Promise never settles (client aborted, user
+// forgot to resolve), onResolve/onReject never fire and the ref is never
+// balanced — the native object leaks forever.
+//
+// Solution: this cell holds the ref. Creating it increments the native
+// refcount; the destructor decrements it. If the Promise settles normally,
+// onResolve calls take() to transfer ownership and the dtor becomes a no-op.
+// If the Promise is GC'd without settling, the reaction is collected, this
+// cell is collected, and the dtor releases the ref. No leak, no UAF.
+class NativePromiseContext final : public JSC::JSCell {
+public:
+    using Base = JSC::JSCell;
+
+    // One entry per concrete native type. The destructor switches on this to
+    // call the right deref. Packed into the pointer's upper bits via
+    // CompactPointerTuple, so this cell adds only one pointer of storage
+    // beyond the JSCell header.
+    //
+    // Must stay in sync with Tag in src/bun.js/api/NativePromiseContext.zig.
+    enum class Tag : uint8_t {
+        HTTPServerRequestContext,
+        HTTPSServerRequestContext,
+        DebugHTTPServerRequestContext,
+        DebugHTTPSServerRequestContext,
+        BodyValueBufferer,
+    };
+
+    static NativePromiseContext* create(JSC::VM& vm, JSC::Structure* structure, void* ctx, Tag tag);
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+    {
+        return JSC::Structure::create(vm, globalObject, JSC::jsNull(), JSC::TypeInfo(JSC::CellType, StructureFlags), info(), 0, 0);
+    }
+
+    template<typename, JSC::SubspaceAccess mode>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        if constexpr (mode == JSC::SubspaceAccess::Concurrently)
+            return nullptr;
+        return WebCore::subspaceForImpl<NativePromiseContext, WebCore::UseCustomHeapCellType::Yes>(
+            vm,
+            [](auto& spaces) { return spaces.m_clientSubspaceForNativePromiseContext.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNativePromiseContext = std::forward<decltype(space)>(space); },
+            [](auto& spaces) { return spaces.m_subspaceForNativePromiseContext.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_subspaceForNativePromiseContext = std::forward<decltype(space)>(space); },
+            [](auto& server) -> JSC::HeapCellType& { return server.m_heapCellTypeForNativePromiseContext; });
+    }
+
+    DECLARE_INFO;
+
+    static constexpr JSC::DestructionMode needsDestruction = JSC::DestructionMode::NeedsDestruction;
+    static void destroy(JSC::JSCell* cell);
+
+    // Transfer ownership of the ref to the caller. After this, the dtor is a
+    // no-op. Returns null if already taken.
+    void* take()
+    {
+        void* ctx = m_data.pointer();
+        m_data.setPointer(nullptr);
+        return ctx;
+    }
+
+    void* pointer() const { return m_data.pointer(); }
+    Tag tag() const { return m_data.type(); }
+
+private:
+    NativePromiseContext(JSC::VM& vm, JSC::Structure* structure, void* ctx, Tag tag)
+        : Base(vm, structure)
+        , m_data(static_cast<NativePromiseContextPointee*>(ctx), tag)
+    {
+    }
+
+    ~NativePromiseContext();
+
+    WTF::CompactPointerTuple<NativePromiseContextPointee*, Tag> m_data;
+};
+
+} // namespace Bun

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -146,6 +146,7 @@
 #include "napi_external.h"
 #include "napi_handle_scope.h"
 #include "napi_type_tag.h"
+#include "NativePromiseContext.h"
 #include "napi.h"
 #include "NodeHTTP.h"
 #include "NodeVM.h"
@@ -2087,6 +2088,10 @@ void GlobalObject::finishCreation(VM& vm)
 
     m_NapiTypeTagStructure.initLater([](const JSC::LazyProperty<JSC::JSGlobalObject, Structure>::Initializer& init) {
         init.set(Bun::NapiTypeTag::createStructure(init.vm, init.owner));
+    });
+
+    m_NativePromiseContextStructure.initLater([](const JSC::LazyProperty<JSC::JSGlobalObject, Structure>::Initializer& init) {
+        init.set(Bun::NativePromiseContext::createStructure(init.vm, init.owner));
     });
 
     m_napiTypeTags.initLater([](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSWeakMap>::Initializer& init) {

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -317,6 +317,7 @@ public:
     Structure* NapiPrototypeStructure() const { return m_NapiPrototypeStructure.getInitializedOnMainThread(this); }
     Structure* NapiHandleScopeImplStructure() const { return m_NapiHandleScopeImplStructure.getInitializedOnMainThread(this); }
     Structure* NapiTypeTagStructure() const { return m_NapiTypeTagStructure.getInitializedOnMainThread(this); }
+    Structure* NativePromiseContextStructure() const { return m_NativePromiseContextStructure.getInitializedOnMainThread(this); }
 
     Structure* JSSQLStatementStructure() const { return m_JSSQLStatementStructure.getInitializedOnMainThread(this); }
 
@@ -627,6 +628,7 @@ public:
     V(private, LazyPropertyOfGlobalObject<Structure>, m_NapiPrototypeStructure)                              \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_NapiHandleScopeImplStructure)                        \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_NapiTypeTagStructure)                                \
+    V(private, LazyPropertyOfGlobalObject<Structure>, m_NativePromiseContextStructure)                       \
                                                                                                              \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSSQLStatementStructure)                             \
     V(private, LazyPropertyOfGlobalObject<v8::shim::GlobalInternals>, m_V8GlobalInternals)                   \

--- a/src/bun.js/bindings/webcore/DOMClientIsoSubspaces.h
+++ b/src/bun.js/bindings/webcore/DOMClientIsoSubspaces.h
@@ -59,6 +59,7 @@ public:
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForTTYWrapObject;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForNapiHandleScopeImpl;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForNapiTypeTag;
+    std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForNativePromiseContext;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForObjectTemplate;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForInternalFieldObject;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSMIMEType;

--- a/src/bun.js/bindings/webcore/DOMIsoSubspaces.h
+++ b/src/bun.js/bindings/webcore/DOMIsoSubspaces.h
@@ -56,6 +56,7 @@ public:
     std::unique_ptr<IsoSubspace> m_subspaceForTTYWrapObject;
     std::unique_ptr<IsoSubspace> m_subspaceForNapiHandleScopeImpl;
     std::unique_ptr<IsoSubspace> m_subspaceForNapiTypeTag;
+    std::unique_ptr<IsoSubspace> m_subspaceForNativePromiseContext;
     std::unique_ptr<IsoSubspace> m_subspaceForObjectTemplate;
     std::unique_ptr<IsoSubspace> m_subspaceForInternalFieldObject;
     std::unique_ptr<IsoSubspace> m_subspaceForV8GlobalInternals;

--- a/src/bun.js/event_loop/Task.zig
+++ b/src/bun.js/event_loop/Task.zig
@@ -44,6 +44,7 @@ pub const Task = TaggedPointerUnion(.{
     Mkdtemp,
     napi_async_work,
     NapiFinalizerTask,
+    NativePromiseContextDeferredDerefTask,
     NativeBrotli,
     NativeZlib,
     NativeZstd,
@@ -503,6 +504,9 @@ pub fn tickQueueWithCount(this: *EventLoop, virtual_machine: *VirtualMachine, co
                 var any: *NapiFinalizerTask = task.get(NapiFinalizerTask).?;
                 any.runOnJSThread();
             },
+            @field(Task.Tag, @typeName(NativePromiseContextDeferredDerefTask)) => {
+                NativePromiseContextDeferredDerefTask.runFromJSThread(@intCast(task.asUintptr()));
+            },
             @field(Task.Tag, @typeName(StatFS)) => {
                 var any: *StatFS = task.get(StatFS).?;
                 try any.runFromJSThread();
@@ -573,6 +577,7 @@ const S3HttpDownloadStreamingTask = S3.S3HttpDownloadStreamingTask;
 const S3HttpSimpleTask = S3.S3HttpSimpleTask;
 
 const NapiFinalizerTask = bun.api.napi.NapiFinalizerTask;
+const NativePromiseContextDeferredDerefTask = jsc.API.NativePromiseContext.DeferredDerefTask;
 const ThreadSafeFunction = bun.api.napi.ThreadSafeFunction;
 const napi_async_work = bun.api.napi.napi_async_work;
 

--- a/src/bun.js/event_loop/Task.zig
+++ b/src/bun.js/event_loop/Task.zig
@@ -577,7 +577,6 @@ const S3HttpDownloadStreamingTask = S3.S3HttpDownloadStreamingTask;
 const S3HttpSimpleTask = S3.S3HttpSimpleTask;
 
 const NapiFinalizerTask = bun.api.napi.NapiFinalizerTask;
-const NativePromiseContextDeferredDerefTask = jsc.API.NativePromiseContext.DeferredDerefTask;
 const ThreadSafeFunction = bun.api.napi.ThreadSafeFunction;
 const napi_async_work = bun.api.napi.napi_async_work;
 
@@ -638,6 +637,7 @@ const StreamPending = jsc.WebCore.streams.Result.Pending;
 const NativeBrotli = jsc.API.NativeBrotli;
 const NativeZlib = jsc.API.NativeZlib;
 const NativeZstd = jsc.API.NativeZstd;
+const NativePromiseContextDeferredDerefTask = jsc.API.NativePromiseContext.DeferredDerefTask;
 const AsyncGlobWalkTask = jsc.API.Glob.WalkTask.AsyncGlobWalkTask;
 const AsyncTransformTask = jsc.API.JSTranspiler.TransformTask.AsyncTransformTask;
 

--- a/src/bun.js/webcore/Body.zig
+++ b/src/bun.js/webcore/Body.zig
@@ -1567,15 +1567,15 @@ pub const ValueBufferer = struct {
     }
 
     pub fn onResolveStream(_: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
-        var args = callframe.arguments_old(2);
-        var sink: *@This() = args.ptr[args.len - 1].asPromisePtr(@This());
+        const args = callframe.arguments_old(2);
+        const sink = bun.api.NativePromiseContext.take(@This(), args.ptr[args.len - 1]) orelse return .js_undefined;
         sink.handleResolveStream(true);
         return .js_undefined;
     }
 
     pub fn onRejectStream(_: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
         const args = callframe.arguments_old(2);
-        var sink = args.ptr[args.len - 1].asPromisePtr(@This());
+        const sink = bun.api.NativePromiseContext.take(@This(), args.ptr[args.len - 1]) orelse return .js_undefined;
         const err = args.ptr[0];
         sink.handleRejectStream(err, true);
         return .js_undefined;
@@ -1647,12 +1647,13 @@ pub const ValueBufferer = struct {
             if (assignment_result.asAnyPromise()) |promise| {
                 switch (promise.status()) {
                     .Pending => {
-                        assignment_result.then(
+                        const cell = bun.api.NativePromiseContext.create(globalThis, sink);
+                        assignment_result.thenWithValue(
                             globalThis,
-                            sink,
+                            cell,
                             onResolveStream,
                             onRejectStream,
-                        );
+                        ) catch {};
                     },
                     .Fulfilled => {
                         defer stream.value.unprotect();

--- a/test/js/bun/http/serve-pending-promise-abort-leak-fixture.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak-fixture.ts
@@ -1,0 +1,74 @@
+// Fixture: server returns a Promise<Response> that never resolves, then the
+// client disconnects. Previously the RequestContext leaked because the
+// pending-promise ref was only balanced by onResolve/onReject, which never
+// fire when the promise is never settled.
+//
+// We verify the fix by checking server.pendingRequests returns to 0 after
+// aborted requests complete their cleanup cycle.
+import { connect } from "node:net";
+
+let abortCount = 0;
+// Resolved from inside fetch() once the abort listener is installed, so the
+// client knows it's safe to destroy the socket without racing the setup.
+const readySignals: Array<() => void> = [];
+
+const server = Bun.serve({
+  port: 0,
+  idleTimeout: 0,
+  fetch(req) {
+    req.signal.addEventListener("abort", () => abortCount++, { once: true });
+    readySignals.shift()?.();
+    // Never resolves - this is the leak scenario
+    return new Promise<Response>(() => {});
+  },
+});
+
+const port = server.port;
+
+function makeAbortedTcpRequest(): Promise<void> {
+  return new Promise(resolve => {
+    const { promise: ready, resolve: signalReady } = Promise.withResolvers<void>();
+    readySignals.push(signalReady);
+
+    const socket = connect(port, "127.0.0.1", () => {
+      socket.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+      // Wait for the server to reach fetch() and install the abort listener
+      // before destroying. Without this, a slow CI could destroy the socket
+      // before addEventListener runs, and the abort would never be observed.
+      ready.then(() => {
+        socket.destroy();
+        resolve();
+      });
+    });
+    socket.on("error", () => resolve());
+  });
+}
+
+const ITERATIONS = 100;
+for (let i = 0; i < ITERATIONS; i++) {
+  await makeAbortedTcpRequest();
+}
+
+// Force GC to collect the never-settled Promises. The NativePromiseContext
+// cell destructor releases the ref on each RequestContext when the Promise's
+// reaction is collected.
+for (let i = 0; i < 10 && server.pendingRequests > 0; i++) {
+  Bun.gc(true);
+  await Bun.sleep(10);
+}
+
+const pending = server.pendingRequests;
+
+console.log(JSON.stringify({ pending, abortCount, iterations: ITERATIONS }));
+
+server.stop(true);
+
+if (pending !== 0) {
+  console.error(`LEAK: ${pending} RequestContexts were never freed`);
+  process.exit(1);
+}
+if (abortCount !== ITERATIONS) {
+  console.error(`Expected ${ITERATIONS} abort events, got ${abortCount}`);
+  process.exit(1);
+}
+process.exit(0);

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+async function waitForPendingRequests(server: ReturnType<typeof Bun.serve>, expected: number) {
+  for (let i = 0; i < 100; i++) {
+    if (server.pendingRequests === expected) return;
+    Bun.gc(true);
+    await Bun.sleep(10);
+  }
+  throw new Error(`Timed out waiting for pendingRequests === ${expected}; got ${server.pendingRequests}`);
+}
+
+test("RequestContext is freed when client aborts before Promise<Response> settles", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "serve-pending-promise-abort-leak-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout.trim());
+  expect(result.pending).toBe(0);
+  expect(result.abortCount).toBe(result.iterations);
+  expect(exitCode).toBe(0);
+});
+
+test("Promise<Response> still works normally when not aborted", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Promise<Response>(resolve => {
+        queueMicrotask(() => resolve(new Response("hello")));
+      });
+    },
+  });
+
+  const res = await fetch(server.url);
+  expect(await res.text()).toBe("hello");
+  expect(res.status).toBe(200);
+  expect(server.pendingRequests).toBe(0);
+});
+
+test("resolve() inside abort handler is handled safely", async () => {
+  let aborted = false;
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch(req) {
+      return new Promise<Response>(resolve => {
+        req.signal.addEventListener(
+          "abort",
+          () => {
+            aborted = true;
+            // Resolving after abort is safe but the response is dropped
+            // since the client is already gone.
+            resolve(new Response("too late"));
+          },
+          { once: true },
+        );
+      });
+    },
+  });
+
+  const ac = new AbortController();
+  const p = fetch(server.url, { signal: ac.signal }).catch(() => {});
+  await waitForPendingRequests(server, 1);
+  ac.abort();
+  await p;
+  await waitForPendingRequests(server, 0);
+
+  expect(aborted).toBe(true);
+  expect(server.pendingRequests).toBe(0);
+});
+
+test("resolve() after abort does not crash and cleans up", async () => {
+  // UAF safety: while the resolve function is reachable, the Promise stays
+  // alive, the NativePromiseContext cell stays alive, and the RequestContext
+  // stays alive. Calling resolve() after abort triggers onResolve, which sees
+  // the aborted state, bails safely, and derefs.
+  let capturedResolve: ((r: Response) => void) | undefined;
+  const { promise: abortObserved, resolve: signalAbort } = Promise.withResolvers<void>();
+
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch(req) {
+      return new Promise<Response>(resolve => {
+        capturedResolve = resolve;
+        req.signal.addEventListener("abort", () => signalAbort(), { once: true });
+      });
+    },
+  });
+
+  const ac = new AbortController();
+  const p = fetch(server.url, { signal: ac.signal }).catch(() => {});
+  await waitForPendingRequests(server, 1);
+  ac.abort();
+  await p;
+  await abortObserved;
+
+  // While capturedResolve is held, the Promise (and its reaction, and the
+  // cell, and the RequestContext) stay alive. This is the safety guarantee:
+  // no UAF because the ctx outlives any possible resolve() call.
+  Bun.gc(true);
+  await Bun.sleep(0);
+  expect(server.pendingRequests).toBe(1);
+
+  // Resolving after abort: onResolve takes the ctx, handleResolve sees
+  // isAbortedOrEnded() and bails, then derefs. Context is freed.
+  capturedResolve!(new Response("very late"));
+  capturedResolve = undefined;
+  await waitForPendingRequests(server, 0);
+
+  expect(server.pendingRequests).toBe(0);
+});


### PR DESCRIPTION
## Summary

When `Bun.serve()`'s fetch handler returns a pending `Promise<Response>` and the client disconnects before it settles, the `RequestContext` leaked forever. The `ctx.ref()` before `.then()` was only balanced by `onResolve`/`onReject`, which never fire for unsettled promises.

This introduces `NativePromiseContext` — a minimal GC-managed JSCell that owns the ref:

- **`JSC::JSCell`** + `CellType` + custom `IsoHeapCellType` for destructor support
- **`CompactPointerTuple<Pointee*, Tag>`** packs pointer + tag in 8 bytes (cell = JSCell header + 1 word)
- **Tag enum class** with one entry per concrete type (4 RequestContext variants), kept in sync C++↔Zig
- **`take()`** transfers ownership for deterministic cleanup in the normal path
- **Destructor** calls one extern C function that Zig implements with a tag switch — no function pointers, no `Weak<>` overhead

If the Promise settles: `onResolve` calls `take()` → processes → `deref()`. Cell destructor later sees null, no-ops.

If the Promise is GC'd without settling: cell collected with its reaction → destructor → `deref()`. No leak, no UAF.

Applied to all three `.then()` callsites in `RequestContext`: main response promise, error handler promise, and response body stream promise.

## Test plan

- [x] New test: `test/js/bun/http/serve-pending-promise-abort-leak.test.ts` — 4 tests covering the leak fix, normal resolution, resolve-in-abort-handler, and resolve-after-abort-via-setTimeout (UAF safety)
- [x] Test fails on system Bun: `LEAK: 100 RequestContexts were never freed`
- [x] Test passes with fix: `pendingRequests: 0`
- [x] `heapStats().objectTypeCounts.NativePromiseContext` shows 50 for 50 concurrent pending, 0 after resolve+GC
- [x] `serve.test.ts`: 189 pass
- [x] `bun-serve-routes.test.ts` + `bun-serve-headers.test.ts`: 41 pass
- [x] `BUN_JSC_validateExceptionChecks=1`: clean