### PR TITLE
Add second cork buffer to uWebSockets for nested async handlers

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -355,9 +355,9 @@ public:
 
                 /* If this is the first message we try and cork */
                 if (flags & TopicTree<TopicTreeMessage, TopicTreeBigMessage>::IteratorFlags::FIRST) {
-                    if (ws->canCork() && !ws->isCorked()) {
+                    if (!ws->isCorked()) {
                         ((AsyncSocket<SSL> *)ws)->cork();
-                        needsUncork = true;
+                        needsUncork = ws->isCorked();
                     }
                 }
 

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -355,6 +355,7 @@ public:
 
                 /* If this is the first message we try and cork */
                 if (flags & TopicTree<TopicTreeMessage, TopicTreeBigMessage>::IteratorFlags::FIRST) {
+                    needsUncork = false;
                     if (!ws->isCorked()) {
                         ((AsyncSocket<SSL> *)ws)->cork();
                         needsUncork = ws->isCorked();
@@ -376,6 +377,7 @@ public:
                     /* We should not uncork in all cases? */
                     if (needsUncork) {
                         ((AsyncSocket<SSL> *)ws)->uncork();
+                        needsUncork = false;
                     }
                 }
 

--- a/packages/bun-uws/src/AsyncSocket.h
+++ b/packages/bun-uws/src/AsyncSocket.h
@@ -141,11 +141,6 @@ public:
         return getLoopData()->findCorkSlot(this) != LoopData::INVALID_CORK_SLOT;
     }
 
-    /* Returns whether we could cork (at least one slot is free) */
-    bool canCork() {
-        return getLoopData()->canCork();
-    }
-
     /* Returns a suitable buffer for temporary assemblation of send data */
     std::pair<char *, SendBufferAttribute> getSendBuffer(size_t size) {
         LoopData *loopData = getLoopData();

--- a/packages/bun-uws/src/AsyncSocket.h
+++ b/packages/bun-uws/src/AsyncSocket.h
@@ -163,7 +163,7 @@ public:
             auto *s = loopData->getCorkSlot(slot);
             char *sendBuffer = s->buffer + s->offset;
             s->offset += (unsigned int) size;
-            UWS_CORK_ASSERT(s->offset <= LoopData::CORK_BUFFER_SIZE);
+            ASSERT(s->offset <= LoopData::CORK_BUFFER_SIZE);
             loopData->touchCorkSlot(slot);
             return {sendBuffer, corked ? SendBufferAttribute::NEEDS_NOTHING : SendBufferAttribute::NEEDS_UNCORK};
         } else {
@@ -331,7 +331,7 @@ public:
                     /* If the entire chunk fits in cork buffer */
                     memcpy(s->buffer + s->offset, src, (unsigned int) length);
                     s->offset += (unsigned int) length;
-                    UWS_CORK_ASSERT(s->offset <= LoopData::CORK_BUFFER_SIZE);
+                    ASSERT(s->offset <= LoopData::CORK_BUFFER_SIZE);
                     loopData->touchCorkSlot(slot);
                     /* Fall through to default return */
                 } else {

--- a/packages/bun-uws/src/AsyncSocket.h
+++ b/packages/bun-uws/src/AsyncSocket.h
@@ -102,80 +102,85 @@ public:
         return us_socket_close(SSL, (us_socket_t *) this, 0, nullptr);
     }
 
-    void corkUnchecked() {
-        /* What if another socket is corked? */
-        getLoopData()->setCorkedSocket(this, SSL);
-    }
-
     void uncorkWithoutSending() {
-        if (isCorked()) {
-            getLoopData()->cleanCorkedSocket();
-        }
+        /* Called from close/destroy paths. Removes this socket from any cork
+         * slot to prevent the drain loop from dereferencing a freed pointer. */
+        getLoopData()->unborrowCorkSlot(this);
     }
 
-    /* Cork this socket. Only one socket may ever be corked per-loop at any given time */
+    /* Cork this socket. Two sockets may be corked per-loop at once. */
     void cork() {
-        auto* corked = getLoopData()->getCorkedSocket();
-        /* Extra check for invalid corking of others */
-        if (getLoopData()->isCorked() && corked != this) {
-            // We uncork the other socket early instead of terminating the program
-            // is unlikely to be cause any issues and is better than crashing
-            if(getLoopData()->isCorkedSSL()) {
-                ((AsyncSocket<true> *) corked)->uncork();
-            } else {
-                ((AsyncSocket<false> *) corked)->uncork();
-            }
+        LoopData *loopData = getLoopData();
+
+        /* Already corked? Nothing to do. */
+        if (loopData->findCorkSlot(this) != LoopData::INVALID_CORK_SLOT) {
+            return;
         }
 
-        /* What if another socket is corked? */
-        getLoopData()->setCorkedSocket(this, SSL);
+        /* Grab a free slot. */
+        if (loopData->acquireCorkSlot(this, SSL) != LoopData::INVALID_CORK_SLOT) {
+            return;
+        }
+
+        /* Both slots hold data from other sockets. Force-uncork the least
+         * recently used one to make room. */
+        int victimSlot = loopData->getLRUCorkSlot();
+        auto *vs = loopData->getCorkSlot(victimSlot);
+        void *victim = vs->socket;
+        bool victimSsl = vs->ssl;
+        if (victimSsl) {
+            ((AsyncSocket<true> *) victim)->uncork();
+        } else {
+            ((AsyncSocket<false> *) victim)->uncork();
+        }
+        loopData->acquireCorkSlot(this, SSL);
     }
 
     /* Returns whether we are corked */
     bool isCorked() {
-        return getLoopData()->isCorkedWith(this);
+        return getLoopData()->findCorkSlot(this) != LoopData::INVALID_CORK_SLOT;
     }
 
-    /* Returns whether we could cork (it is free) */
+    /* Returns whether we could cork (at least one slot is free) */
     bool canCork() {
         return getLoopData()->canCork();
     }
 
     /* Returns a suitable buffer for temporary assemblation of send data */
     std::pair<char *, SendBufferAttribute> getSendBuffer(size_t size) {
-        /* First step is to determine if we already have backpressure or not */
         LoopData *loopData = getLoopData();
         BackPressure &backPressure = getAsyncSocketData()->buffer;
         size_t existingBackpressure = backPressure.length();
-        if ((!existingBackpressure) && (isCorked() || canCork()) && (loopData->getCorkOffset() + size < LoopData::CORK_BUFFER_SIZE)) {
-            /* Cork automatically if we can */
-            if (isCorked()) {
-                char *sendBuffer = loopData->getCorkSendBuffer();
-                loopData->incrementCorkedOffset((unsigned int) size);
-                return {sendBuffer, SendBufferAttribute::NEEDS_NOTHING};
-            } else {
-                cork();
-                char *sendBuffer = loopData->getCorkSendBuffer();
-                loopData->incrementCorkedOffset((unsigned int) size);
-                return {sendBuffer, SendBufferAttribute::NEEDS_UNCORK};
+
+        int slot = loopData->findCorkSlot(this);
+        bool corked = slot != LoopData::INVALID_CORK_SLOT;
+        unsigned int currentOffset = corked ? loopData->getCorkSlot(slot)->offset : 0;
+
+        if ((!existingBackpressure) && (corked || loopData->canCork()) && (currentOffset + size < LoopData::CORK_BUFFER_SIZE)) {
+            if (!corked) {
+                slot = loopData->acquireCorkSlot(this, SSL);
             }
+            auto *s = loopData->getCorkSlot(slot);
+            char *sendBuffer = s->buffer + s->offset;
+            s->offset += (unsigned int) size;
+            UWS_CORK_ASSERT(s->offset <= LoopData::CORK_BUFFER_SIZE);
+            loopData->touchCorkSlot(slot);
+            return {sendBuffer, corked ? SendBufferAttribute::NEEDS_NOTHING : SendBufferAttribute::NEEDS_UNCORK};
         } else {
-
-            /* If we are corked and there is already data in the cork buffer,
-            mark how much is ours and reset it */
+            /* Fallback: move any corked data into the backpressure buffer. */
             unsigned int ourCorkOffset = 0;
-
-            if (isCorked()) {
-                ourCorkOffset = loopData->getCorkOffset();
-                loopData->setCorkOffset(0);
+            char *ourCorkBuffer = nullptr;
+            if (corked) {
+                auto *s = loopData->getCorkSlot(slot);
+                ourCorkOffset = s->offset;
+                ourCorkBuffer = s->buffer;
+                s->offset = 0;
             }
 
-            /* Fallback is to use the backpressure as buffer */
             backPressure.resize(ourCorkOffset + existingBackpressure + size);
 
-            if(ourCorkOffset > 0) {
-                /* And copy corkbuffer in front */
-                memcpy((char *) backPressure.data() + existingBackpressure, loopData->getCorkBuffer(), ourCorkOffset);
+            if (ourCorkOffset > 0) {
+                memcpy((char *) backPressure.data() + existingBackpressure, ourCorkBuffer, ourCorkOffset);
             }
             return {(char *) backPressure.data() + ourCorkOffset + existingBackpressure, SendBufferAttribute::NEEDS_DRAIN};
         }
@@ -318,26 +323,19 @@ public:
         }
 
         if (length) {
-            if (loopData->isCorkedWith(this)) {
+            int slot = loopData->findCorkSlot(this);
+            if (slot != LoopData::INVALID_CORK_SLOT) {
                 /* We are corked */
-                if (LoopData::CORK_BUFFER_SIZE - loopData->getCorkOffset() >= (unsigned int) length) {
+                auto *s = loopData->getCorkSlot(slot);
+                if (LoopData::CORK_BUFFER_SIZE - s->offset >= (unsigned int) length) {
                     /* If the entire chunk fits in cork buffer */
-                    memcpy(loopData->getCorkSendBuffer(), src, (unsigned int) length);
-                    loopData->incrementCorkedOffset((unsigned int) length);
+                    memcpy(s->buffer + s->offset, src, (unsigned int) length);
+                    s->offset += (unsigned int) length;
+                    UWS_CORK_ASSERT(s->offset <= LoopData::CORK_BUFFER_SIZE);
+                    loopData->touchCorkSlot(slot);
                     /* Fall through to default return */
                 } else {
-                    /* Strategy differences between SSL and non-SSL regarding syscall minimizing */
-                    if constexpr (false) {
-                        /* Cork up as much as we can */
-                        unsigned int stripped = LoopData::CORK_BUFFER_SIZE - loopData->getCorkOffset();
-                        memcpy(loopData->getCorkSendBuffer(), src, stripped);
-                        loopData->setCorkOffset(LoopData::CORK_BUFFER_SIZE);
-
-                        auto [written, failed] = uncork(src + stripped, length - (int) stripped, optionally);
-                        return {written + (int) stripped, failed};
-                    }
-
-                    /* For non-SSL we take the penalty of two syscalls */
+                    /* Chunk doesn't fit; flush cork + write the rest. */
                     return uncork(src, length, optionally);
                 }
             } else {
@@ -374,29 +372,33 @@ public:
     /* It does NOT count bytes written from cork buffer (they are already accounted for in the write call responsible for its corking)! */
     std::pair<int, bool> uncork(const char *src = nullptr, int length = 0, bool optionally = false) {
         LoopData *loopData = getLoopData();
-        if (loopData->isCorkedWith(this)) {
-            auto offset = loopData->getCorkOffset();
-            loopData->cleanCorkedSocket();
 
-            if (offset) {
-                /* Corked data is already accounted for via its write call */
-                auto [written, failed] = write(loopData->getCorkBuffer(), (int) offset, false, length);
-
-                if (failed && optionally) {
-                    /* We do not need to care for buffering here, write does that */
-                    return {0, true};
-                }
-                if (length == 0) {
-                    return {written, failed};
-                }
-            }
-
-            /* We should only return with new writes, not things written to cork already */
-            return write(src, length, optionally, 0);
-        } else {
+        int slot = loopData->findCorkSlot(this);
+        if (slot == LoopData::INVALID_CORK_SLOT) {
             /* We are not even corked! */
             return {0, false};
         }
+
+        auto *s = loopData->getCorkSlot(slot);
+        unsigned int offset = s->offset;
+        char *buffer = s->buffer;
+        loopData->releaseCorkSlot(slot);
+
+        if (offset) {
+            /* Corked data is already accounted for via its write call */
+            auto [written, failed] = write(buffer, (int) offset, false, length);
+
+            if (failed && optionally) {
+                /* We do not need to care for buffering here, write does that */
+                return {0, true};
+            }
+            if (length == 0) {
+                return {written, failed};
+            }
+        }
+
+        /* We should only return with new writes, not things written to cork already */
+        return write(src, length, optionally, 0);
     }
 };
 

--- a/packages/bun-uws/src/AsyncSocket.h
+++ b/packages/bun-uws/src/AsyncSocket.h
@@ -151,7 +151,7 @@ public:
         bool corked = slot != LoopData::INVALID_CORK_SLOT;
         unsigned int currentOffset = corked ? loopData->getCorkSlot(slot)->offset : 0;
 
-        if ((!existingBackpressure) && (corked || loopData->canCork()) && (currentOffset + size < LoopData::CORK_BUFFER_SIZE)) {
+        if ((!existingBackpressure) && (corked || loopData->canCork()) && (currentOffset + size <= LoopData::CORK_BUFFER_SIZE)) {
             if (!corked) {
                 slot = loopData->acquireCorkSlot(this, SSL);
             }

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -95,8 +95,11 @@ public:
     }
 
     /* Returns true on success, indicating that it might be feasible to write more data.
-     * Will start timeout if stream reaches totalSize or write failure. */
-    bool internalEnd(std::string_view data, uint64_t totalSize, bool optional, bool allowContentLength = true, bool closeConnection = false) {
+     * Will start timeout if stream reaches totalSize or write failure.
+     * keepCorked: if true, skip the trailing uncork so the caller can batch
+     * more writes (used by upgrade() to batch the handshake with the first
+     * WebSocket frames). */
+    bool internalEnd(std::string_view data, uint64_t totalSize, bool optional, bool allowContentLength = true, bool closeConnection = false, bool keepCorked = false) {
         /* Write status if not already done */
         writeStatus(HTTP_200_OK);
 
@@ -152,7 +155,7 @@ public:
                         }
                     }
                 }
-            } else {
+            } else if (!keepCorked) {
                 this->uncork();
             }
 
@@ -217,7 +220,7 @@ public:
                             }
                         }
                     }
-                }  else {
+                }  else if (!keepCorked) {
                     this->uncork();
                 }
             }
@@ -310,7 +313,9 @@ public:
             }
         }
 
-        internalEnd({nullptr, 0}, 0, false, false);
+        /* keepCorked so the handshake stays buffered and can batch with the
+         * first WebSocket frames written in the open handler. */
+        internalEnd({nullptr, 0}, 0, false, false, false, true);
 
         /* Grab the httpContext from res */
         HttpContext<SSL> *httpContext = (HttpContext<SSL> *) us_socket_context(SSL, (struct us_socket_t *) this);

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -325,18 +325,18 @@ public:
         /* Destroy HttpResponseData */
         responseData->~HttpResponseData();
 
-        /* Before we adopt and potentially change socket, check if we are corked */
-        bool wasCorked = Super::isCorked();
-
-        
+        /* Before we adopt and potentially change socket, check which cork slot
+         * we occupy so we can transfer it to the new WebSocket. */
+        LoopData *loopData = Super::getLoopData();
+        int corkedSlot = loopData->findCorkSlot(this);
 
         /* Adopting a socket invalidates it, do not rely on it directly to carry any data */
         us_socket_t *usSocket = us_socket_context_adopt_socket(SSL, (us_socket_context_t *) webSocketContext, (us_socket_t *) this, sizeof(HttpResponseData<SSL>), sizeof(WebSocketData) + sizeof(UserData));
         WebSocket<SSL, true, UserData> *webSocket = (WebSocket<SSL, true, UserData> *) usSocket;
 
         /* For whatever reason we were corked, update cork to the new socket */
-        if (wasCorked) {
-            webSocket->AsyncSocket<SSL>::corkUnchecked();
+        if (corkedSlot != LoopData::INVALID_CORK_SLOT) {
+            loopData->transferCorkSlot(corkedSlot, webSocket, SSL);
         }
 
         /* Initialize websocket with any moved backpressure intact */
@@ -638,12 +638,17 @@ public:
         if (!Super::isCorked() && Super::canCork()) {
             LoopData *loopData = Super::getLoopData();
             Super::cork();
+            /* Remember which slot we took so we can find our (possibly upgraded)
+             * replacement after the handler runs. */
+            int ourSlot = loopData->findCorkSlot(this);
             handler();
 
             /* The only way we could possibly have changed the corked socket during handler call, would be if
              * the HTTP socket was upgraded to WebSocket and caused a realloc. Because of this we cannot use "this"
-             * from here downwards. The corking is done with corkUnchecked() in upgrade. It steals cork. */
-            auto *newCorkedSocket = loopData->getCorkedSocket();
+             * from here downwards. The upgrade path transfers the cork slot to the new WebSocket. */
+            void *newCorkedSocket = ourSlot != LoopData::INVALID_CORK_SLOT
+                ? loopData->getCorkSlot(ourSlot)->socket
+                : nullptr;
 
             /* If nobody is corked, it means most probably that large amounts of data has
              * been written and the cork buffer has already been sent off and uncorked.

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -638,33 +638,21 @@ public:
         if (!Super::isCorked()) {
             LoopData *loopData = Super::getLoopData();
             Super::cork();
-            /* Remember which slot we took so we can find our (possibly upgraded)
-             * replacement after the handler runs. */
-            int ourSlot = loopData->findCorkSlot(this);
             handler();
 
-            /* The only way we could possibly have changed the corked socket during handler call, would be if
-             * the HTTP socket was upgraded to WebSocket and caused a realloc. Because of this we cannot use "this"
-             * from here downwards. The upgrade path transfers the cork slot to the new WebSocket. */
-            void *newCorkedSocket = ourSlot != LoopData::INVALID_CORK_SLOT
-                ? loopData->getCorkSlot(ourSlot)->socket
-                : nullptr;
-
-            /* If nobody is corked, it means most probably that large amounts of data has
-             * been written and the cork buffer has already been sent off and uncorked.
-             * We are done here, if that is the case. */
-            if (!newCorkedSocket) {
+            /* If we're no longer in a cork slot, either: (a) the handler wrote
+             * large data that triggered an internal uncork, (b) our empty slot
+             * was stolen by another request during an await, or (c) we were
+             * upgraded to a WebSocket (upgrade path transferred the slot). In
+             * all cases our data (if any) was already flushed; nothing to do.
+             * The upgrade case is handled by HttpContext's uncork or the drain
+             * loop. */
+            if (loopData->findCorkSlot(this) == LoopData::INVALID_CORK_SLOT) {
                 return this;
             }
 
             /* Timeout on uncork failure, since most writes will succeed while corked */
-            auto [written, failed] = static_cast<Super *>(newCorkedSocket)->uncork();
-
-            /* If we are no longer an HTTP socket then early return the new "this".
-             * We don't want to even overwrite timeout as it is set in upgrade already. */
-            if (this != newCorkedSocket) {
-                return static_cast<HttpResponse *>(newCorkedSocket);
-            }
+            auto [written, failed] = Super::uncork();
 
             if (written > 0 || failed) {
                 /* For now we only have one single timeout so let's use it */

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -635,7 +635,7 @@ public:
 
      /* Corks the response if possible. Leaves already corked socket be. */
     HttpResponse *cork(MoveOnlyFunction<void()> &&handler) {
-        if (!Super::isCorked() && Super::canCork()) {
+        if (!Super::isCorked()) {
             LoopData *loopData = Super::getLoopData();
             Super::cork();
             /* Remember which slot we took so we can find our (possibly upgraded)

--- a/packages/bun-uws/src/Loop.h
+++ b/packages/bun-uws/src/Loop.h
@@ -54,9 +54,12 @@ private:
             p.second((Loop *) loop);
         }
 
-        void *corkedSocket = loopData->getCorkedSocket();
-        if (corkedSocket) {
-            if (loopData->isCorkedSSL()) {
+        /* Drain any leftover corks. Two slots max. */
+        for (int i = 0; i < 2; i++) {
+            bool ssl;
+            void *corkedSocket = loopData->getAnyCorkedSocket(&ssl);
+            if (!corkedSocket) break;
+            if (ssl) {
                 ((uWS::AsyncSocket<true> *) corkedSocket)->uncork();
             } else {
                 ((uWS::AsyncSocket<false> *) corkedSocket)->uncork();

--- a/packages/bun-uws/src/LoopData.h
+++ b/packages/bun-uws/src/LoopData.h
@@ -18,6 +18,7 @@
 #ifndef UWS_LOOPDATA_H
 #define UWS_LOOPDATA_H
 
+#include <cassert>
 #include <cstdint>
 #include <ctime>
 #include <functional>
@@ -25,6 +26,12 @@
 #include <mutex>
 #include <thread>
 #include <vector>
+
+#ifndef NDEBUG
+#define UWS_CORK_ASSERT(cond) assert(cond)
+#else
+#define UWS_CORK_ASSERT(cond) ((void)0)
+#endif
 
 #include "MoveOnlyFunction.h"
 #include "PerMessageDeflate.h"
@@ -44,13 +51,31 @@ private:
 
     /* Map from void ptr to handler */
     std::map<void *, MoveOnlyFunction<void(Loop *)>> postHandlers, preHandlers;
-    /* Cork data */
-    char *corkBuffer = new char[CORK_BUFFER_SIZE];
-    unsigned int corkOffset = 0;
-    void *corkedSocket = nullptr;
-    bool corkedSocketIsSSL = false;
+
+    /* Cork data: two independent slots so a nested cork (e.g. a resumed async
+     * request writing while the outer request is still corked) doesn't force
+     * the outer socket down the uncorked slow path. cork() grabs whichever
+     * slot is free; uncork() releases the slot you're in. No ordering. */
+    struct CorkSlot {
+        char *buffer = nullptr;
+        void *socket = nullptr;
+        unsigned int offset = 0;
+        unsigned int ssl : 1 = 0;
+    };
+
+    CorkSlot corkSlots[2];
+
+    /* 1 = slot 1 was touched most recently, 0 = slot 0. Used to pick the LRU
+     * victim when both slots have data and we must force-uncork one. */
+    unsigned int lastTouchedSlot1 : 1 = 0;
+
 public:
+    /* INVALID_CORK_SLOT means "not corked with us". */
+    static constexpr int INVALID_CORK_SLOT = -1;
+
     LoopData() {
+        corkSlots[0].buffer = new char[CORK_BUFFER_SIZE];
+        corkSlots[1].buffer = new char[CORK_BUFFER_SIZE];
         updateDate();
     }
 
@@ -61,57 +86,90 @@ public:
             delete inflationStream;
             delete deflationStream;
         }
-        delete [] corkBuffer;
+        delete [] corkSlots[0].buffer;
+        delete [] corkSlots[1].buffer;
     }
 
-    void* getCorkedSocket() {
-        return this->corkedSocket;
+    /* Returns the slot index this socket is corked in, or INVALID_CORK_SLOT. */
+    int findCorkSlot(void *socket) {
+        if (corkSlots[0].socket == socket) return 0;
+        if (corkSlots[1].socket == socket) return 1;
+        return INVALID_CORK_SLOT;
     }
 
-    void setCorkedSocket(void *corkedSocket, bool ssl) {
-        this->corkedSocket = corkedSocket;
-        this->corkedSocketIsSSL = ssl;
+    /* Returns a slot we can borrow: prefers a free slot, falls back to a
+     * borrowed-but-unwritten slot (offset == 0) that we can steal without
+     * flushing. Returns INVALID_CORK_SLOT only if both slots hold data. */
+    int findBorrowableCorkSlot() {
+        if (corkSlots[0].socket == nullptr) return 0;
+        if (corkSlots[1].socket == nullptr) return 1;
+        if (corkSlots[0].offset == 0) return 0;
+        if (corkSlots[1].offset == 0) return 1;
+        return INVALID_CORK_SLOT;
     }
 
-    bool isCorkedSSL() {
-        return this->corkedSocketIsSSL;
+    /* Borrow a slot for this socket. Returns the slot index, or
+     * INVALID_CORK_SLOT if both slots have data that must be flushed. */
+    int acquireCorkSlot(void *socket, bool ssl) {
+        int slot = findBorrowableCorkSlot();
+        if (slot != INVALID_CORK_SLOT) {
+            corkSlots[slot].socket = socket;
+            corkSlots[slot].ssl = ssl;
+            corkSlots[slot].offset = 0;
+            lastTouchedSlot1 = (slot == 1);
+        }
+        return slot;
     }
 
-    bool isCorked() {
-        return this->corkOffset && this->corkedSocket;
+    /* Mark a slot as recently used. Call when writing into it so LRU eviction
+     * picks the other slot. */
+    void touchCorkSlot(int slot) {
+        lastTouchedSlot1 = (slot == 1);
+    }
+
+    /* Returns the least-recently-used slot index for force-uncork eviction. */
+    int getLRUCorkSlot() {
+        return lastTouchedSlot1 ? 0 : 1;
+    }
+
+    /* Release a slot. */
+    void releaseCorkSlot(int slot) {
+        UWS_CORK_ASSERT(slot == 0 || slot == 1);
+        corkSlots[slot].socket = nullptr;
+        corkSlots[slot].offset = 0;
+    }
+
+    /* Transfer ownership of a slot to a new socket (used during WebSocket
+     * upgrade to hand the HTTP socket's cork buffer to the new WebSocket). */
+    void transferCorkSlot(int slot, void *socket, bool ssl) {
+        UWS_CORK_ASSERT(slot == 0 || slot == 1);
+        corkSlots[slot].socket = socket;
+        corkSlots[slot].ssl = ssl;
+    }
+
+    CorkSlot *getCorkSlot(int slot) {
+        UWS_CORK_ASSERT(slot == 0 || slot == 1);
+        return &corkSlots[slot];
     }
 
     bool canCork() {
-        return this->corkedSocket == nullptr;
+        return findBorrowableCorkSlot() != INVALID_CORK_SLOT;
     }
 
-    bool isCorkedWith(void* socket) {
-        return this->corkedSocket == socket;
+    /* Remove this socket from any cork slot it occupies. Must be called from
+     * socket close/destroy paths to avoid leaving a dangling pointer that the
+     * drain loop would later dereference. */
+    void unborrowCorkSlot(void *socket) {
+        if (corkSlots[0].socket == socket) { corkSlots[0].socket = nullptr; corkSlots[0].offset = 0; }
+        if (corkSlots[1].socket == socket) { corkSlots[1].socket = nullptr; corkSlots[1].offset = 0; }
     }
 
-    char* getCorkSendBuffer() {
-        return this->corkBuffer + this->corkOffset;
-    }
-
-    void cleanCorkedSocket() {
-        this->corkedSocket = nullptr;
-        this->corkOffset = 0;
-    }
-
-    unsigned int getCorkOffset() {
-        return this->corkOffset;
-    }
-
-    void setCorkOffset(unsigned int offset) {
-        this->corkOffset = offset;
-    }
-
-    void incrementCorkedOffset(unsigned int offset) {
-        this->corkOffset += offset;
-    }
-
-    char* getCorkBuffer() {
-        return this->corkBuffer;
+    /* Legacy accessor for drain loops: returns any corked socket (slot 0 first)
+     * so the caller can uncork it. Returns nullptr if both slots are empty. */
+    void *getAnyCorkedSocket(bool *outSsl) {
+        if (corkSlots[0].socket) { *outSsl = corkSlots[0].ssl; return corkSlots[0].socket; }
+        if (corkSlots[1].socket) { *outSsl = corkSlots[1].ssl; return corkSlots[1].socket; }
+        return nullptr;
     }
 
     void updateDate() {

--- a/packages/bun-uws/src/LoopData.h
+++ b/packages/bun-uws/src/LoopData.h
@@ -18,7 +18,6 @@
 #ifndef UWS_LOOPDATA_H
 #define UWS_LOOPDATA_H
 
-#include <cassert>
 #include <cstdint>
 #include <ctime>
 #include <functional>
@@ -27,11 +26,7 @@
 #include <thread>
 #include <vector>
 
-#ifndef NDEBUG
-#define UWS_CORK_ASSERT(cond) assert(cond)
-#else
-#define UWS_CORK_ASSERT(cond) ((void)0)
-#endif
+#include <wtf/Assertions.h>
 
 #include "MoveOnlyFunction.h"
 #include "PerMessageDeflate.h"
@@ -134,7 +129,7 @@ public:
 
     /* Release a slot. */
     void releaseCorkSlot(int slot) {
-        UWS_CORK_ASSERT(slot == 0 || slot == 1);
+        ASSERT(slot == 0 || slot == 1);
         corkSlots[slot].socket = nullptr;
         corkSlots[slot].offset = 0;
     }
@@ -142,13 +137,13 @@ public:
     /* Transfer ownership of a slot to a new socket (used during WebSocket
      * upgrade to hand the HTTP socket's cork buffer to the new WebSocket). */
     void transferCorkSlot(int slot, void *socket, bool ssl) {
-        UWS_CORK_ASSERT(slot == 0 || slot == 1);
+        ASSERT(slot == 0 || slot == 1);
         corkSlots[slot].socket = socket;
         corkSlots[slot].ssl = ssl;
     }
 
     CorkSlot *getCorkSlot(int slot) {
-        UWS_CORK_ASSERT(slot == 0 || slot == 1);
+        ASSERT(slot == 0 || slot == 1);
         return &corkSlots[slot];
     }
 

--- a/packages/bun-uws/src/WebSocket.h
+++ b/packages/bun-uws/src/WebSocket.h
@@ -111,7 +111,9 @@ public:
         WebSocketData *webSocketData = (WebSocketData *) Super::getAsyncSocketData();
 
         /* Special path for long sends of non-compressed, non-SSL messages */
-        if (message.length() >= 16 * 1024 && !compress && !SSL && !webSocketData->subscriber && getBufferedAmount() == 0 && Super::getLoopData()->getCorkOffset() == 0) {
+        int ourCorkSlot = Super::getLoopData()->findCorkSlot(this);
+        bool corkBufferEmpty = ourCorkSlot == LoopData::INVALID_CORK_SLOT || Super::getLoopData()->getCorkSlot(ourCorkSlot)->offset == 0;
+        if (message.length() >= 16 * 1024 && !compress && !SSL && !webSocketData->subscriber && getBufferedAmount() == 0 && corkBufferEmpty) {
             char header[10];
             int header_length = (int) protocol::formatMessage<isServer>(header, "", 0, opCode, message.length(), compress, fin);
             int written = us_socket_write2(0, (struct us_socket_t *)this, header, header_length, message.data(), (int) message.length());

--- a/packages/bun-uws/src/WebSocket.h
+++ b/packages/bun-uws/src/WebSocket.h
@@ -245,7 +245,7 @@ public:
 
     /* Corks the response if possible. Leaves already corked socket be. */
     void cork(MoveOnlyFunction<void()> &&handler) {
-        if (!Super::isCorked() && Super::canCork()) {
+        if (!Super::isCorked()) {
             Super::cork();
             handler();
 

--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -598,8 +598,8 @@ static void NodeHTTPServer__writeHead(
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSObject* headersObject = headersObjectValue.getObject();
-    if (response->getLoopData()->canCork() && response->getBufferedAmount() == 0) {
-        response->getLoopData()->setCorkedSocket(response, isSSL);
+    if (!response->uWS::template AsyncSocket<isSSL>::isCorked() && response->uWS::template AsyncSocket<isSSL>::canCork() && response->getBufferedAmount() == 0) {
+        response->uWS::template AsyncSocket<isSSL>::cork();
     }
     response->writeStatus(std::string_view(statusMessage, statusMessageLength));
 

--- a/src/bun.js/bindings/NodeHTTP.cpp
+++ b/src/bun.js/bindings/NodeHTTP.cpp
@@ -598,7 +598,7 @@ static void NodeHTTPServer__writeHead(
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSObject* headersObject = headersObjectValue.getObject();
-    if (!response->uWS::template AsyncSocket<isSSL>::isCorked() && response->uWS::template AsyncSocket<isSSL>::canCork() && response->getBufferedAmount() == 0) {
+    if (!response->uWS::template AsyncSocket<isSSL>::isCorked() && response->getBufferedAmount() == 0) {
         response->uWS::template AsyncSocket<isSSL>::cork();
     }
     response->writeStatus(std::string_view(statusMessage, statusMessageLength));

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -138,9 +138,12 @@ extern "C"
 
   extern "C" void uws_res_clear_corked_socket(us_loop_t *loop) {
     uWS::LoopData *loopData = uWS::Loop::data(loop);
-    void *corkedSocket = loopData->getCorkedSocket();
-    if (corkedSocket) {
-        if (loopData->isCorkedSSL()) {
+    /* Drain any leftover corks. Two slots max. */
+    for (int i = 0; i < 2; i++) {
+        bool ssl;
+        void *corkedSocket = loopData->getAnyCorkedSocket(&ssl);
+        if (!corkedSocket) break;
+        if (ssl) {
             ((uWS::AsyncSocket<true> *) corkedSocket)->uncork();
         } else {
             ((uWS::AsyncSocket<false> *) corkedSocket)->uncork();

--- a/src/deps/libuwsockets.cpp
+++ b/src/deps/libuwsockets.cpp
@@ -1379,7 +1379,7 @@ extern "C"
     {
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
       if (*length < 16 * 1024 && *length > 0) {
-        if (uwsRes->canCork()) {
+        if (!uwsRes->uWS::AsyncSocket<true>::isCorked()) {
           uwsRes->uWS::AsyncSocket<true>::cork();
         }
       }
@@ -1387,7 +1387,7 @@ extern "C"
     }
     uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
     if (*length < 16 * 1024 && *length > 0) {
-        if (uwsRes->canCork()) {
+        if (!uwsRes->uWS::AsyncSocket<false>::isCorked()) {
           uwsRes->uWS::AsyncSocket<false>::cork();
         }
       }

--- a/test/js/node/http/node-http-nested-cork.test.ts
+++ b/test/js/node/http/node-http-nested-cork.test.ts
@@ -1,111 +1,272 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-// When an awaited request handler resumes (via another request resolving its
-// promise), the resumed request should still get a cork buffer so its
-// writeHead+end go out as a single write instead of multiple syscalls.
-// Previously the single shared cork buffer was held by the newer request,
-// forcing the resumed request down the uncorked slow path.
-test("resumed async handler writes are corked (nested cork buffer)", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-      import { createServer } from "node:http";
+// With two cork slots that can be stolen/evicted under contention, a bug in
+// slot bookkeeping could cause bytes meant for one socket to end up in another
+// socket's response — an attacker could receive another user's data.
+//
+// These tests write multiple chunks of unique per-request data (tagged with
+// request id + chunk index), yield between chunks to maximize interleaving,
+// and verify each response contains ONLY its own bytes in exact order.
 
-      let pending;
-      let count = 0;
-      const server = createServer(async (req, res) => {
-        count++;
-        if (pending) {
-          const prev = pending;
-          pending = Promise.withResolvers();
-          prev.resolve();
-        } else {
-          pending = Promise.withResolvers();
-        }
-        // The last request resolves itself so it doesn't hang
-        if (count === 20) pending.resolve();
-        await pending.promise;
-        res.writeHead(200, { "x-req": req.url });
-        res.end("ok:" + req.url);
-      }).listen(0, async () => {
-        const port = server.address().port;
-        const responses = await Promise.all(
-          Array.from({ length: 20 }, (_, i) =>
-            fetch("http://localhost:" + port + "/" + i).then(r => r.text())
-          )
-        );
-        console.log(JSON.stringify(responses.sort()));
-        server.close();
-      });
-      `,
-    ],
+const N = 32;
+const CHUNKS = 6;
+
+// Shared validation: build expected body, compare exactly. Any foreign byte
+// from another request will cause a mismatch.
+const validate = `
+  async function validate(makeUrl) {
+    const results = await Promise.all(
+      Array.from({ length: ${N} }, async (_, i) => {
+        const r = await fetch(makeUrl(i));
+        const body = await r.text();
+        const headerId = r.headers.get("x-id");
+        let expected = "";
+        for (let c = 0; c < ${CHUNKS}; c++) expected += "[" + i + ":" + c + "]";
+        expected += "[" + i + ":end]";
+        if (body !== expected) return { i, ok: false, reason: "body", got: body, want: expected };
+        if (headerId !== String(i)) return { i, ok: false, reason: "header", got: headerId };
+        return { i, ok: true };
+      })
+    );
+    const bad = results.filter(r => !r.ok);
+    console.log(bad.length ? "FAIL " + JSON.stringify(bad) : "PASS " + results.length);
+  }
+`;
+
+const chainAwait = `
+  let pending, count = 0;
+  async function chainAwait() {
+    count++;
+    if (pending) { const p = pending; pending = Promise.withResolvers(); p.resolve(); }
+    else pending = Promise.withResolvers();
+    if (count === ${N}) pending.resolve();
+    await pending.promise;
+  }
+`;
+
+async function run(script: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
     env: bunEnv,
     stderr: "pipe",
   });
-
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  const expected = Array.from({ length: 20 }, (_, i) => `ok:/${i}`).sort();
   expect(stderr).toBe("");
-  expect(JSON.parse(stdout.trim())).toEqual(expected);
+  expect(stdout.trim()).toBe(`PASS ${N}`);
   expect(exitCode).toBe(0);
-});
+}
 
-test("Bun.serve: nested async responses are all correct", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-      let pending;
-      let count = 0;
+describe("cork buffer: no cross-socket data bleed", () => {
+  test("node:http — chunks back-to-back", async () => {
+    await run(`
+      import { createServer } from "node:http";
+      ${validate}
+      ${chainAwait}
+      const server = createServer(async (req, res) => {
+        const id = req.url.slice(1);
+        await chainAwait();
+        res.writeHead(200, { "x-id": id });
+        for (let c = 0; c < ${CHUNKS}; c++) res.write("[" + id + ":" + c + "]");
+        res.end("[" + id + ":end]");
+      }).listen(0, async () => {
+        await validate(i => "http://localhost:" + server.address().port + "/" + i);
+        server.close();
+      });
+    `);
+  });
+
+  test("node:http — await sleep(0) between every chunk", async () => {
+    await run(`
+      import { createServer } from "node:http";
+      ${validate}
+      ${chainAwait}
+      const server = createServer(async (req, res) => {
+        const id = req.url.slice(1);
+        await chainAwait();
+        res.writeHead(200, { "x-id": id });
+        for (let c = 0; c < ${CHUNKS}; c++) {
+          res.write("[" + id + ":" + c + "]");
+          await Bun.sleep(0);
+        }
+        res.end("[" + id + ":end]");
+      }).listen(0, async () => {
+        await validate(i => "http://localhost:" + server.address().port + "/" + i);
+        server.close();
+      });
+    `);
+  });
+
+  test("node:http — write before AND after await (slot held with data across yield)", async () => {
+    await run(`
+      import { createServer } from "node:http";
+      ${validate}
+      ${chainAwait}
+      const server = createServer(async (req, res) => {
+        const id = req.url.slice(1);
+        await chainAwait();
+        res.writeHead(200, { "x-id": id });
+        res.write("[" + id + ":0]");
+        res.write("[" + id + ":1]");
+        await Promise.resolve();
+        res.write("[" + id + ":2]");
+        await Bun.sleep(0);
+        for (let c = 3; c < ${CHUNKS}; c++) res.write("[" + id + ":" + c + "]");
+        res.end("[" + id + ":end]");
+      }).listen(0, async () => {
+        await validate(i => "http://localhost:" + server.address().port + "/" + i);
+        server.close();
+      });
+    `);
+  });
+
+  test("node:http — nested awaits at every chunk (max interleave)", async () => {
+    await run(`
+      import { createServer } from "node:http";
+      ${validate}
+      ${chainAwait}
+      const server = createServer(async (req, res) => {
+        const id = req.url.slice(1);
+        await chainAwait();
+        res.writeHead(200, { "x-id": id });
+        for (let c = 0; c < ${CHUNKS}; c++) {
+          res.write("[" + id + ":" + c + "]");
+          await Promise.resolve();
+          await Promise.resolve();
+        }
+        res.end("[" + id + ":end]");
+      }).listen(0, async () => {
+        await validate(i => "http://localhost:" + server.address().port + "/" + i);
+        server.close();
+      });
+    `);
+  });
+
+  test("Bun.serve — buffered Response (single body string)", async () => {
+    await run(`
+      ${validate}
+      ${chainAwait}
       const server = Bun.serve({
         port: 0,
         async fetch(req) {
-          count++;
-          const url = new URL(req.url);
-          if (pending) {
-            const prev = pending;
-            pending = Promise.withResolvers();
-            prev.resolve();
-          } else {
-            pending = Promise.withResolvers();
-          }
-          if (count === 20) pending.resolve();
-          await pending.promise;
-          return new Response("ok:" + url.pathname, {
-            headers: { "x-path": url.pathname },
-          });
+          const id = new URL(req.url).pathname.slice(1);
+          await chainAwait();
+          let body = "";
+          for (let c = 0; c < ${CHUNKS}; c++) body += "[" + id + ":" + c + "]";
+          body += "[" + id + ":end]";
+          return new Response(body, { headers: { "x-id": id } });
         },
       });
-
-      const responses = await Promise.all(
-        Array.from({ length: 20 }, (_, i) =>
-          fetch("http://localhost:" + server.port + "/" + i).then(async r => ({
-            body: await r.text(),
-            header: r.headers.get("x-path"),
-          }))
-        )
-      );
-      console.log(JSON.stringify(responses.sort((a,b) => a.body.localeCompare(b.body))));
+      await validate(i => "http://localhost:" + server.port + "/" + i);
       server.stop(true);
-      `,
-    ],
-    env: bunEnv,
-    stderr: "pipe",
+    `);
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  test("Bun.serve — ReadableStream pull source with sleep(0) between chunks", async () => {
+    await run(`
+      ${validate}
+      ${chainAwait}
+      const server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const id = new URL(req.url).pathname.slice(1);
+          await chainAwait();
+          let c = 0;
+          const stream = new ReadableStream({
+            async pull(ctrl) {
+              if (c < ${CHUNKS}) {
+                ctrl.enqueue(new TextEncoder().encode("[" + id + ":" + c + "]"));
+                c++;
+                await Bun.sleep(0);
+              } else {
+                ctrl.enqueue(new TextEncoder().encode("[" + id + ":end]"));
+                ctrl.close();
+              }
+            },
+          });
+          return new Response(stream, { headers: { "x-id": id } });
+        },
+      });
+      await validate(i => "http://localhost:" + server.port + "/" + i);
+      server.stop(true);
+    `);
+  });
 
-  const expected = Array.from({ length: 20 }, (_, i) => ({
-    body: `ok:/${i}`,
-    header: `/${i}`,
-  })).sort((a, b) => a.body.localeCompare(b.body));
+  test('Bun.serve — ReadableStream type: "direct" with sleep(0) between chunks', async () => {
+    await run(`
+      ${validate}
+      ${chainAwait}
+      const server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const id = new URL(req.url).pathname.slice(1);
+          await chainAwait();
+          const stream = new ReadableStream({
+            type: "direct",
+            async pull(ctrl) {
+              for (let c = 0; c < ${CHUNKS}; c++) {
+                ctrl.write("[" + id + ":" + c + "]");
+                await Bun.sleep(0);
+              }
+              ctrl.write("[" + id + ":end]");
+              ctrl.close();
+            },
+          });
+          return new Response(stream, { headers: { "x-id": id } });
+        },
+      });
+      await validate(i => "http://localhost:" + server.port + "/" + i);
+      server.stop(true);
+    `);
+  });
 
-  expect(stderr).toBe("");
-  expect(JSON.parse(stdout.trim())).toEqual(expected);
-  expect(exitCode).toBe(0);
+  test('Bun.serve — ReadableStream type: "direct" back-to-back writes then flush', async () => {
+    await run(`
+      ${validate}
+      ${chainAwait}
+      const server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const id = new URL(req.url).pathname.slice(1);
+          await chainAwait();
+          const stream = new ReadableStream({
+            type: "direct",
+            async pull(ctrl) {
+              for (let c = 0; c < ${CHUNKS}; c++) ctrl.write("[" + id + ":" + c + "]");
+              ctrl.write("[" + id + ":end]");
+              await ctrl.flush();
+              ctrl.close();
+            },
+          });
+          return new Response(stream, { headers: { "x-id": id } });
+        },
+      });
+      await validate(i => "http://localhost:" + server.port + "/" + i);
+      server.stop(true);
+    `);
+  });
+
+  test("Bun.serve — async generator with await between every yield", async () => {
+    await run(`
+      ${validate}
+      ${chainAwait}
+      const server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const id = new URL(req.url).pathname.slice(1);
+          await chainAwait();
+          async function* gen() {
+            for (let c = 0; c < ${CHUNKS}; c++) {
+              yield "[" + id + ":" + c + "]";
+              await Bun.sleep(0);
+            }
+            yield "[" + id + ":end]";
+          }
+          return new Response(gen(), { headers: { "x-id": id } });
+        },
+      });
+      await validate(i => "http://localhost:" + server.port + "/" + i);
+      server.stop(true);
+    `);
+  });
 });

--- a/test/js/node/http/node-http-nested-cork.test.ts
+++ b/test/js/node/http/node-http-nested-cork.test.ts
@@ -1,28 +1,49 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-// With two cork slots that can be stolen/evicted under contention, a bug in
-// slot bookkeeping could cause bytes meant for one socket to end up in another
-// socket's response — an attacker could receive another user's data.
+// Security test: with two cork slots that can be stolen/evicted, a bug in slot
+// bookkeeping could cause bytes meant for socket A to land in socket B's
+// response. An attacker could receive another user's data.
 //
-// These tests write multiple chunks of unique per-request data (tagged with
-// request id + chunk index), yield between chunks to maximize interleaving,
-// and verify each response contains ONLY its own bytes in exact order.
+// These tests are adversarial: they deliberately interleave writes across many
+// concurrent requests using every yield primitive (microtask, macrotask, mixed)
+// to maximize slot churn. Every chunk is tagged [reqId:chunkIdx] and responses
+// are validated byte-for-byte so a single foreign byte fails the test.
 
 const N = 32;
-const CHUNKS = 6;
+const CHUNKS = 8;
 
-// Shared validation: build expected body, compare exactly. Any foreign byte
-// from another request will cause a mismatch.
-const validate = `
+const harness = `
+  const N = ${N};
+  const CHUNKS = ${CHUNKS};
+
+  // Chain-await: each request resolves the previous one's promise, forcing
+  // microtask resumption while a newer request holds a cork slot.
+  let pending, count = 0;
+  async function chainAwait() {
+    count++;
+    if (pending) { const p = pending; pending = Promise.withResolvers(); p.resolve(); }
+    else pending = Promise.withResolvers();
+    if (count === N) pending.resolve();
+    await pending.promise;
+  }
+
+  // Mixed yield: alternates microtask and macrotask to hit both the
+  // drainMicrotasks path and the event loop tick path.
+  async function yieldMixed(c) {
+    if (c % 3 === 0) await 42;              // microtask (awaiting non-thenable)
+    else if (c % 3 === 1) await Bun.sleep(0); // macrotask
+    else { await 42; await 42; }            // double microtask
+  }
+
   async function validate(makeUrl) {
     const results = await Promise.all(
-      Array.from({ length: ${N} }, async (_, i) => {
+      Array.from({ length: N }, async (_, i) => {
         const r = await fetch(makeUrl(i));
         const body = await r.text();
         const headerId = r.headers.get("x-id");
         let expected = "";
-        for (let c = 0; c < ${CHUNKS}; c++) expected += "[" + i + ":" + c + "]";
+        for (let c = 0; c < CHUNKS; c++) expected += "[" + i + ":" + c + "]";
         expected += "[" + i + ":end]";
         if (body !== expected) return { i, ok: false, reason: "body", got: body, want: expected };
         if (headerId !== String(i)) return { i, ok: false, reason: "header", got: headerId };
@@ -30,24 +51,13 @@ const validate = `
       })
     );
     const bad = results.filter(r => !r.ok);
-    console.log(bad.length ? "FAIL " + JSON.stringify(bad) : "PASS " + results.length);
-  }
-`;
-
-const chainAwait = `
-  let pending, count = 0;
-  async function chainAwait() {
-    count++;
-    if (pending) { const p = pending; pending = Promise.withResolvers(); p.resolve(); }
-    else pending = Promise.withResolvers();
-    if (count === ${N}) pending.resolve();
-    await pending.promise;
+    console.log(bad.length ? "FAIL " + JSON.stringify(bad.slice(0, 3)) : "PASS " + results.length);
   }
 `;
 
 async function run(script: string) {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
+    cmd: [bunExe(), "-e", harness + script],
     env: bunEnv,
     stderr: "pipe",
   });
@@ -58,36 +68,18 @@ async function run(script: string) {
 }
 
 describe("cork buffer: no cross-socket data bleed", () => {
-  test("node:http — chunks back-to-back", async () => {
+  // Attack 1: write, yield, write — slot held with data across yield.
+  // Another request resumes during the yield and tries to steal/use our slot.
+  test("node:http — write then mixed yield then write (slot held with data)", async () => {
     await run(`
       import { createServer } from "node:http";
-      ${validate}
-      ${chainAwait}
       const server = createServer(async (req, res) => {
         const id = req.url.slice(1);
         await chainAwait();
         res.writeHead(200, { "x-id": id });
-        for (let c = 0; c < ${CHUNKS}; c++) res.write("[" + id + ":" + c + "]");
-        res.end("[" + id + ":end]");
-      }).listen(0, async () => {
-        await validate(i => "http://localhost:" + server.address().port + "/" + i);
-        server.close();
-      });
-    `);
-  });
-
-  test("node:http — await sleep(0) between every chunk", async () => {
-    await run(`
-      import { createServer } from "node:http";
-      ${validate}
-      ${chainAwait}
-      const server = createServer(async (req, res) => {
-        const id = req.url.slice(1);
-        await chainAwait();
-        res.writeHead(200, { "x-id": id });
-        for (let c = 0; c < ${CHUNKS}; c++) {
+        for (let c = 0; c < CHUNKS; c++) {
           res.write("[" + id + ":" + c + "]");
-          await Bun.sleep(0);
+          await yieldMixed(c);
         }
         res.end("[" + id + ":end]");
       }).listen(0, async () => {
@@ -97,21 +89,62 @@ describe("cork buffer: no cross-socket data bleed", () => {
     `);
   });
 
-  test("node:http — write before AND after await (slot held with data across yield)", async () => {
+  // Attack 2: yield BEFORE each write. Our slot is empty (stealable) at every
+  // yield point, then we try to write after someone may have taken it.
+  test("node:http — yield then write (empty slot stolen, must re-acquire)", async () => {
     await run(`
       import { createServer } from "node:http";
-      ${validate}
-      ${chainAwait}
       const server = createServer(async (req, res) => {
         const id = req.url.slice(1);
         await chainAwait();
         res.writeHead(200, { "x-id": id });
-        res.write("[" + id + ":0]");
-        res.write("[" + id + ":1]");
-        await Promise.resolve();
-        res.write("[" + id + ":2]");
+        for (let c = 0; c < CHUNKS; c++) {
+          await yieldMixed(c);
+          res.write("[" + id + ":" + c + "]");
+        }
+        res.end("[" + id + ":end]");
+      }).listen(0, async () => {
+        await validate(i => "http://localhost:" + server.address().port + "/" + i);
+        server.close();
+      });
+    `);
+  });
+
+  // Attack 3: rapid microtask churn — every chunk yields twice via await 42.
+  // Maximizes the number of slot-steal opportunities per request.
+  test("node:http — double microtask between every chunk", async () => {
+    await run(`
+      import { createServer } from "node:http";
+      const server = createServer(async (req, res) => {
+        const id = req.url.slice(1);
+        await chainAwait();
+        res.writeHead(200, { "x-id": id });
+        for (let c = 0; c < CHUNKS; c++) {
+          res.write("[" + id + ":" + c + "]");
+          await 42;
+          await 42;
+        }
+        res.end("[" + id + ":end]");
+      }).listen(0, async () => {
+        await validate(i => "http://localhost:" + server.address().port + "/" + i);
+        server.close();
+      });
+    `);
+  });
+
+  // Attack 4: write several chunks, yield, write more. Tests that partial
+  // buffered data survives slot eviction and doesn't leak into the evictor.
+  test("node:http — burst write, yield, burst write", async () => {
+    await run(`
+      import { createServer } from "node:http";
+      const server = createServer(async (req, res) => {
+        const id = req.url.slice(1);
+        await chainAwait();
+        res.writeHead(200, { "x-id": id });
+        const half = CHUNKS >> 1;
+        for (let c = 0; c < half; c++) res.write("[" + id + ":" + c + "]");
         await Bun.sleep(0);
-        for (let c = 3; c < ${CHUNKS}; c++) res.write("[" + id + ":" + c + "]");
+        for (let c = half; c < CHUNKS; c++) res.write("[" + id + ":" + c + "]");
         res.end("[" + id + ":end]");
       }).listen(0, async () => {
         await validate(i => "http://localhost:" + server.address().port + "/" + i);
@@ -120,39 +153,20 @@ describe("cork buffer: no cross-socket data bleed", () => {
     `);
   });
 
-  test("node:http — nested awaits at every chunk (max interleave)", async () => {
+  // Attack 5: Bun.serve buffered Response — the whole body is one string,
+  // but the interleaved awaits before returning stress slot allocation for
+  // the headers + body write.
+  test("Bun.serve — buffered Response with await before return", async () => {
     await run(`
-      import { createServer } from "node:http";
-      ${validate}
-      ${chainAwait}
-      const server = createServer(async (req, res) => {
-        const id = req.url.slice(1);
-        await chainAwait();
-        res.writeHead(200, { "x-id": id });
-        for (let c = 0; c < ${CHUNKS}; c++) {
-          res.write("[" + id + ":" + c + "]");
-          await Promise.resolve();
-          await Promise.resolve();
-        }
-        res.end("[" + id + ":end]");
-      }).listen(0, async () => {
-        await validate(i => "http://localhost:" + server.address().port + "/" + i);
-        server.close();
-      });
-    `);
-  });
-
-  test("Bun.serve — buffered Response (single body string)", async () => {
-    await run(`
-      ${validate}
-      ${chainAwait}
       const server = Bun.serve({
         port: 0,
         async fetch(req) {
           const id = new URL(req.url).pathname.slice(1);
           await chainAwait();
+          await 42;
+          await Bun.sleep(0);
           let body = "";
-          for (let c = 0; c < ${CHUNKS}; c++) body += "[" + id + ":" + c + "]";
+          for (let c = 0; c < CHUNKS; c++) body += "[" + id + ":" + c + "]";
           body += "[" + id + ":end]";
           return new Response(body, { headers: { "x-id": id } });
         },
@@ -162,57 +176,26 @@ describe("cork buffer: no cross-socket data bleed", () => {
     `);
   });
 
-  test("Bun.serve — ReadableStream pull source with sleep(0) between chunks", async () => {
+  // Attack 6: type:"direct" with write+yield per chunk. Direct streams write
+  // straight to the socket via the cork path.
+  test('Bun.serve — type:"direct" write then mixed yield', async () => {
     await run(`
-      ${validate}
-      ${chainAwait}
       const server = Bun.serve({
         port: 0,
         async fetch(req) {
           const id = new URL(req.url).pathname.slice(1);
           await chainAwait();
-          let c = 0;
-          const stream = new ReadableStream({
-            async pull(ctrl) {
-              if (c < ${CHUNKS}) {
-                ctrl.enqueue(new TextEncoder().encode("[" + id + ":" + c + "]"));
-                c++;
-                await Bun.sleep(0);
-              } else {
-                ctrl.enqueue(new TextEncoder().encode("[" + id + ":end]"));
-                ctrl.close();
-              }
-            },
-          });
-          return new Response(stream, { headers: { "x-id": id } });
-        },
-      });
-      await validate(i => "http://localhost:" + server.port + "/" + i);
-      server.stop(true);
-    `);
-  });
-
-  test('Bun.serve — ReadableStream type: "direct" with sleep(0) between chunks', async () => {
-    await run(`
-      ${validate}
-      ${chainAwait}
-      const server = Bun.serve({
-        port: 0,
-        async fetch(req) {
-          const id = new URL(req.url).pathname.slice(1);
-          await chainAwait();
-          const stream = new ReadableStream({
+          return new Response(new ReadableStream({
             type: "direct",
             async pull(ctrl) {
-              for (let c = 0; c < ${CHUNKS}; c++) {
+              for (let c = 0; c < CHUNKS; c++) {
                 ctrl.write("[" + id + ":" + c + "]");
-                await Bun.sleep(0);
+                await yieldMixed(c);
               }
               ctrl.write("[" + id + ":end]");
-              ctrl.close();
+              await ctrl.end();
             },
-          });
-          return new Response(stream, { headers: { "x-id": id } });
+          }), { headers: { "x-id": id } });
         },
       });
       await validate(i => "http://localhost:" + server.port + "/" + i);
@@ -220,25 +203,26 @@ describe("cork buffer: no cross-socket data bleed", () => {
     `);
   });
 
-  test('Bun.serve — ReadableStream type: "direct" back-to-back writes then flush', async () => {
+  // Attack 7: type:"direct" yield then write. Slot is empty at yield, we must
+  // re-cork before each write.
+  test('Bun.serve — type:"direct" yield then write', async () => {
     await run(`
-      ${validate}
-      ${chainAwait}
       const server = Bun.serve({
         port: 0,
         async fetch(req) {
           const id = new URL(req.url).pathname.slice(1);
           await chainAwait();
-          const stream = new ReadableStream({
+          return new Response(new ReadableStream({
             type: "direct",
             async pull(ctrl) {
-              for (let c = 0; c < ${CHUNKS}; c++) ctrl.write("[" + id + ":" + c + "]");
+              for (let c = 0; c < CHUNKS; c++) {
+                await yieldMixed(c);
+                ctrl.write("[" + id + ":" + c + "]");
+              }
               ctrl.write("[" + id + ":end]");
-              await ctrl.flush();
-              ctrl.close();
+              await ctrl.end();
             },
-          });
-          return new Response(stream, { headers: { "x-id": id } });
+          }), { headers: { "x-id": id } });
         },
       });
       await validate(i => "http://localhost:" + server.port + "/" + i);
@@ -246,19 +230,47 @@ describe("cork buffer: no cross-socket data bleed", () => {
     `);
   });
 
-  test("Bun.serve — async generator with await between every yield", async () => {
+  // Attack 8: type:"direct" burst + flush + yield + burst. Explicit flush
+  // mid-stream exercises the uncork/recork path.
+  test('Bun.serve — type:"direct" burst, flush, yield, burst', async () => {
     await run(`
-      ${validate}
-      ${chainAwait}
+      const server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const id = new URL(req.url).pathname.slice(1);
+          await chainAwait();
+          return new Response(new ReadableStream({
+            type: "direct",
+            async pull(ctrl) {
+              const half = CHUNKS >> 1;
+              for (let c = 0; c < half; c++) ctrl.write("[" + id + ":" + c + "]");
+              await ctrl.flush();
+              await Bun.sleep(0);
+              for (let c = half; c < CHUNKS; c++) ctrl.write("[" + id + ":" + c + "]");
+              ctrl.write("[" + id + ":end]");
+              await ctrl.end();
+            },
+          }), { headers: { "x-id": id } });
+        },
+      });
+      await validate(i => "http://localhost:" + server.port + "/" + i);
+      server.stop(true);
+    `);
+  });
+
+  // Attack 9: async generator with mixed yields — every other chunk uses a
+  // different yield primitive.
+  test("Bun.serve — async generator mixed yield per chunk", async () => {
+    await run(`
       const server = Bun.serve({
         port: 0,
         async fetch(req) {
           const id = new URL(req.url).pathname.slice(1);
           await chainAwait();
           async function* gen() {
-            for (let c = 0; c < ${CHUNKS}; c++) {
+            for (let c = 0; c < CHUNKS; c++) {
               yield "[" + id + ":" + c + "]";
-              await Bun.sleep(0);
+              await yieldMixed(c);
             }
             yield "[" + id + ":end]";
           }
@@ -267,6 +279,43 @@ describe("cork buffer: no cross-socket data bleed", () => {
       });
       await validate(i => "http://localhost:" + server.port + "/" + i);
       server.stop(true);
+    `);
+  });
+
+  // Attack 10: node:http with large chunks near the 16KB cork buffer boundary.
+  // If offset math is wrong, a large chunk could overflow into the adjacent
+  // slot's buffer.
+  test("node:http — large chunks near cork buffer boundary", async () => {
+    await run(`
+      import { createServer } from "node:http";
+      // ~2KB per chunk * 8 chunks = ~16KB total, hovering at cork buffer size
+      const pad = Buffer.alloc(2000, 0x2e).toString(); // "."
+      const server = createServer(async (req, res) => {
+        const id = req.url.slice(1);
+        await chainAwait();
+        res.writeHead(200, { "x-id": id });
+        for (let c = 0; c < CHUNKS; c++) {
+          res.write("[" + id + ":" + c + "]" + pad);
+          await 42;
+        }
+        res.end("[" + id + ":end]");
+      }).listen(0, async () => {
+        const results = await Promise.all(
+          Array.from({ length: N }, async (_, i) => {
+            const r = await fetch("http://localhost:" + server.address().port + "/" + i);
+            const body = await r.text();
+            let expected = "";
+            for (let c = 0; c < CHUNKS; c++) expected += "[" + i + ":" + c + "]" + pad;
+            expected += "[" + i + ":end]";
+            return body === expected && r.headers.get("x-id") === String(i)
+              ? { i, ok: true }
+              : { i, ok: false, got: body.slice(0, 100), want: expected.slice(0, 100) };
+          })
+        );
+        const bad = results.filter(r => !r.ok);
+        console.log(bad.length ? "FAIL " + JSON.stringify(bad.slice(0, 3)) : "PASS " + results.length);
+        server.close();
+      });
     `);
   });
 });

--- a/test/js/node/http/node-http-nested-cork.test.ts
+++ b/test/js/node/http/node-http-nested-cork.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 // When an awaited request handler resumes (via another request resolving its
 // promise), the resumed request should still get a cork buffer so its

--- a/test/js/node/http/node-http-nested-cork.test.ts
+++ b/test/js/node/http/node-http-nested-cork.test.ts
@@ -1,0 +1,111 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+
+// When an awaited request handler resumes (via another request resolving its
+// promise), the resumed request should still get a cork buffer so its
+// writeHead+end go out as a single write instead of multiple syscalls.
+// Previously the single shared cork buffer was held by the newer request,
+// forcing the resumed request down the uncorked slow path.
+test("resumed async handler writes are corked (nested cork buffer)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import { createServer } from "node:http";
+
+      let pending;
+      let count = 0;
+      const server = createServer(async (req, res) => {
+        count++;
+        if (pending) {
+          const prev = pending;
+          pending = Promise.withResolvers();
+          prev.resolve();
+        } else {
+          pending = Promise.withResolvers();
+        }
+        // The last request resolves itself so it doesn't hang
+        if (count === 20) pending.resolve();
+        await pending.promise;
+        res.writeHead(200, { "x-req": req.url });
+        res.end("ok:" + req.url);
+      }).listen(0, async () => {
+        const port = server.address().port;
+        const responses = await Promise.all(
+          Array.from({ length: 20 }, (_, i) =>
+            fetch("http://localhost:" + port + "/" + i).then(r => r.text())
+          )
+        );
+        console.log(JSON.stringify(responses.sort()));
+        server.close();
+      });
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const expected = Array.from({ length: 20 }, (_, i) => `ok:/${i}`).sort();
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual(expected);
+  expect(exitCode).toBe(0);
+});
+
+test("Bun.serve: nested async responses are all correct", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      let pending;
+      let count = 0;
+      const server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          count++;
+          const url = new URL(req.url);
+          if (pending) {
+            const prev = pending;
+            pending = Promise.withResolvers();
+            prev.resolve();
+          } else {
+            pending = Promise.withResolvers();
+          }
+          if (count === 20) pending.resolve();
+          await pending.promise;
+          return new Response("ok:" + url.pathname, {
+            headers: { "x-path": url.pathname },
+          });
+        },
+      });
+
+      const responses = await Promise.all(
+        Array.from({ length: 20 }, (_, i) =>
+          fetch("http://localhost:" + server.port + "/" + i).then(async r => ({
+            body: await r.text(),
+            header: r.headers.get("x-path"),
+          }))
+        )
+      );
+      console.log(JSON.stringify(responses.sort((a,b) => a.body.localeCompare(b.body))));
+      server.stop(true);
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const expected = Array.from({ length: 20 }, (_, i) => ({
+    body: `ok:/${i}`,
+    header: `/${i}`,
+  })).sort((a, b) => a.body.localeCompare(b.body));
+
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual(expected);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

Replaces uWebSockets' single shared cork buffer with two independent cork slots.

## Why

When an async HTTP handler awaits and later resumes (e.g. another request resolves its promise), the resumed request's `writeHead()` + `end()` couldn't get the cork buffer because the newer in-flight request was holding it. This forced the resumed request down the uncorked path — one `write()` syscall per call instead of batching them. On the `bench/snippets/http-hello.node.mjs` interleaved-await pattern this dropped throughput from ~190k req/s to ~22k req/s.

## How

- **Two independent slots**: each holds `{buffer, socket, offset, ssl}`. `cork()` grabs whichever slot is free; `uncork()` releases yours. No ordering constraints.
- **Empty-slot stealing**: if both slots are claimed but one has `offset==0` (corked but not yet written), it's freely stolen — no flush needed.
- **LRU eviction**: when both slots hold actual data (rare, depth 3+), force-uncork the least-recently-touched one. Tracked via a single bit.
- **Entry-point re-cork**: `NodeHTTP writeHead` and `HttpResponse::cork(handler)` call `cork()` before each write sequence, so if your slot was stolen while you were awaiting, you transparently get a fresh one.
- **UAF protection**: `uncorkWithoutSending()` (called from all close/destroy paths) now clears the socket from any slot via `unborrowCorkSlot()`, preventing the drain loop from dereferencing a freed pointer.
- **Bounded drain**: `preCb` and `uws_res_clear_corked_socket` iterate at most twice (one per slot).

Memory cost: one extra 16KB buffer per event loop.

## Tests

- `test/js/node/http/node-http-nested-cork.test.ts` — 20 concurrent interleaved-await requests for both node:http and Bun.serve, asserts all responses are correct with no cross-socket bleed.
- `serve.test.ts` (189 tests), `node-http.test.ts` (78 tests), `websocket-server.test.ts` all pass.