### PR TITLE
Show empty coverage table when all files are test files

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1433,25 +1433,37 @@ impl CommandLineReporter {
             return Ok(());
         }
 
-        let Some(map) = ByteRangeMapping::map() else {
-            return Ok(());
+        let mut byte_ranges: Vec<&mut ByteRangeMapping> = if let Some(map) = ByteRangeMapping::map()
+        {
+            // SAFETY: thread-local Box pinned for the thread; sole `&mut` for the
+            // collection loop below (single-threaded CLI report path).
+            let map = unsafe { &mut *map.as_ptr() };
+            // PORT NOTE: Zig bitwise-copied each `ByteRangeMapping` out of the map
+            // (`entry.*`). The Rust struct owns a `MultiArrayList` and is not
+            // `Copy`, so collect mutable borrows into the thread-local map instead
+            // — same observable behaviour, no double-free risk.
+            let mut ranges: Vec<&mut ByteRangeMapping> = Vec::with_capacity(map.len());
+            for entry in map.values_mut() {
+                ranges.push(entry);
+            }
+            ranges
+        } else {
+            Vec::new()
         };
-        // SAFETY: thread-local Box pinned for the thread; sole `&mut` for the
-        // collection loop below (single-threaded CLI report path).
-        let map = unsafe { &mut *map.as_ptr() };
-        // `ByteRangeMapping` owns a `MultiArrayList` and is not `Copy`, so
-        // collect mutable borrows into the thread-local map instead — no
-        // double-free risk.
-        let mut byte_ranges: Vec<&mut ByteRangeMapping> = Vec::with_capacity(map.len());
-        for entry in map.values_mut() {
-            byte_ranges.push(entry);
-        }
-
-        if byte_ranges.is_empty() {
-            return Ok(());
-        }
 
         byte_ranges.sort_by(coverage::is_less_than_cmp);
+
+        if byte_ranges.is_empty() {
+            // No files to report — show empty text table but skip LCOV file creation
+            if REPORTERS_TEXT {
+                return self.print_code_coverage::<true, false, ENABLE_ANSI_COLORS>(
+                    vm,
+                    opts,
+                    &mut byte_ranges,
+                );
+            }
+            return Ok(());
+        }
 
         self.print_code_coverage::<REPORTERS_TEXT, REPORTERS_LCOV, ENABLE_ANSI_COLORS>(
             vm,
@@ -1924,6 +1936,15 @@ pub(crate) extern "C" fn BunTest__shouldGenerateCodeCoverage(
 
     // always ignore node_modules.
     if strings::contains(slice, b"/node_modules/") || strings::contains(slice, b"\\node_modules\\")
+    {
+        return false;
+    }
+
+    // Ignore built-in modules. ZigSourceProvider.cpp already filters these
+    // via !isBuiltin, but InternalModuleRegistry.cpp does not in debug builds.
+    if strings::has_prefix_comptime(slice, b"internal:")
+        || strings::has_prefix_comptime(slice, b"node:")
+        || strings::has_prefix_comptime(slice, b"bun:")
     {
         return false;
     }

--- a/test/regression/issue/28620.test.ts
+++ b/test/regression/issue/28620.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+test("coverage table shown when only test files exist", () => {
+  const dir = tempDirWithFiles("cov-28620", {
+    "bunfig.toml": `
+[test]
+coverageSkipTestFiles = true
+`,
+    "i.test.mjs": `
+import { test } from 'bun:test';
+
+test('foo', () => {
+  if (false) {
+    throw new Error('Failed');
+  } else {
+    // pass
+  }
+});
+`,
+  });
+
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage"], {
+    cwd: dir,
+    env: bunEnv,
+    stdio: [null, null, "pipe"],
+  });
+
+  const stderr = result.stderr.toString("utf-8");
+
+  // The coverage table should be present even when all files are skipped
+  expect(stderr).toContain("All files");
+  expect(stderr).toContain("% Funcs");
+  expect(stderr).toContain("% Lines");
+  // Built-in modules should not appear in the coverage table
+  expect(stderr).not.toContain("internal:");
+  expect(result.exitCode).toBe(0);
+});
+
+test("coverage table shown with node:test and only test files", () => {
+  const dir = tempDirWithFiles("cov-28620-node", {
+    "bunfig.toml": `
+[test]
+coverageSkipTestFiles = true
+`,
+    "i.test.mjs": `
+import { test } from 'node:test';
+
+test('foo', () => {
+  if (false) {
+    throw new Error('Failed');
+  } else {
+    // pass
+  }
+});
+`,
+  });
+
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage"], {
+    cwd: dir,
+    env: bunEnv,
+    stdio: [null, null, "pipe"],
+  });
+
+  const stderr = result.stderr.toString("utf-8");
+
+  // The coverage table should be present even when using node:test
+  expect(stderr).toContain("All files");
+  expect(stderr).toContain("% Funcs");
+  expect(stderr).toContain("% Lines");
+  // Built-in modules should not appear in the coverage table
+  expect(stderr).not.toContain("internal:");
+  expect(result.exitCode).toBe(0);
+});

--- a/test/regression/issue/28620.test.ts
+++ b/test/regression/issue/28620.test.ts
@@ -34,6 +34,7 @@ test('foo', () => {
   expect(stderr).toContain("% Lines");
   // Built-in modules should not appear in the coverage table
   expect(stderr).not.toContain("internal:");
+  expect(stderr).not.toContain("bun:");
   expect(result.exitCode).toBe(0);
 });
 
@@ -70,5 +71,6 @@ test('foo', () => {
   expect(stderr).toContain("% Lines");
   // Built-in modules should not appear in the coverage table
   expect(stderr).not.toContain("internal:");
+  expect(stderr).not.toContain("node:");
   expect(result.exitCode).toBe(0);
 });


### PR DESCRIPTION
Closes #28620

## Problem

Running `bun test --coverage` with only test files (e.g. `i.test.mjs`) produces no coverage table at all. This happens regardless of whether `bun:test` or `node:test` is used.

```
$ bun test --coverage
bun test v1.3.11

i.test.mjs:
✓ foo

 1 pass
 0 fail
Ran 1 test across 1 file.
```

Node.js shows an empty coverage table in this case.

## Cause

In release builds, `coverageSkipTestFiles` defaults to `true`, which filters out files ending in `.test`, `_test`, `.spec`, `_spec` from coverage collection. When a project has only test files, every file gets filtered out, leaving the coverage map null or empty. `generate_code_coverage` then returned early without printing anything.

A second, related issue: in debug builds `InternalModuleRegistry.cpp` tracks coverage for built-in modules without the `!isBuiltin` guard that `ZigSourceProvider.cpp` has, so `internal:*` / `node:*` / `bun:*` shims pollute the table.

## Fix

- When the coverage map is null or empty, proceed to `print_code_coverage` with an empty byte-ranges slice (text reporter only) so the table header, "All files" 0.00% row, and footer still render. LCOV file creation is skipped entirely when empty (no stray empty `lcov.info`).
- Filter built-in module URLs (`internal:`, `node:`, `bun:`) out of coverage collection in `BunTest__shouldGenerateCodeCoverage`.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28620.test.ts` → **FAIL** (no coverage table)
- `bun bd test test/regression/issue/28620.test.ts` → **PASS** (coverage table shown, 12 expects)

## Rebase note

Rebased onto main after #32621 removed the `.zig` porting-reference sources. The change originally touched both `test_command.zig` and `test_command.rs`; since the Zig file is gone from the build, only the live Rust implementation (`src/runtime/cli/test_command.rs`) carries the fix now.
