### PR TITLE
Fix crash when onResolve plugin appends query string to file path

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -2644,12 +2644,18 @@ pub const BundleV2 = struct {
                     // (mirroring the fallback approach in resolver.zig for CSS).
                     // Search only the filename portion so that ? or # in
                     // directory names (e.g. /projects/C#/main.js) are preserved.
-                    // Prefer '?' over '#' so a file literally named C#.ts with an
-                    // appended ?query strips at the query, not inside the name.
+                    // Prefer the first '?' (essentially never a real filename
+                    // char), else the last '#' so files literally named C#.ts
+                    // with an appended ?query or #fragment strip at the suffix,
+                    // not inside the name.
                     const path_to_use = if (is_file_namespace) blk: {
                         const basename_start = if (bun.path.lastIndexOfSep(result.path)) |sep| sep + 1 else 0;
                         const basename = result.path[basename_start..];
-                        if (bun.strings.indexOfChar(basename, '?') orelse bun.strings.indexOfChar(basename, '#')) |offset| {
+                        const suffix_at: ?usize = if (bun.strings.indexOfChar(basename, '?')) |q|
+                            @intCast(q)
+                        else
+                            bun.strings.lastIndexOfChar(basename, '#');
+                        if (suffix_at) |offset| {
                             break :blk if (bun.sys.exists(result.path))
                                 result.path
                             else

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -2636,8 +2636,22 @@ pub const BundleV2 = struct {
             .success => |result| {
                 var out_source_index: ?Index = null;
                 if (!result.external) {
-                    var path = Fs.Path.init(result.path);
-                    if (result.namespace.len == 0 or strings.eqlComptime(result.namespace, "file")) {
+                    const is_file_namespace = result.namespace.len == 0 or strings.eqlComptime(result.namespace, "file");
+
+                    // Strip query string and fragment from file namespace paths so
+                    // the bundler can find the file on disk. Plugins may append
+                    // ?query or #fragment to the resolved path for identification
+                    // purposes, but the filesystem lookup must use the clean path.
+                    const path_to_use = if (is_file_namespace)
+                        if (bun.strings.indexOfAny(result.path, "?#")) |suffix|
+                            result.path[0..suffix]
+                        else
+                            result.path
+                    else
+                        result.path;
+
+                    var path = Fs.Path.init(path_to_use);
+                    if (is_file_namespace) {
                         path.namespace = "file";
                     } else {
                         path.namespace = result.namespace;

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -2638,13 +2638,16 @@ pub const BundleV2 = struct {
                 if (!result.external) {
                     const is_file_namespace = result.namespace.len == 0 or strings.eqlComptime(result.namespace, "file");
 
-                    // Strip query string and fragment from file namespace paths so
-                    // the bundler can find the file on disk. Plugins may append
-                    // ?query or #fragment to the resolved path for identification
-                    // purposes, but the filesystem lookup must use the clean path.
+                    // Plugins may append ?query or #fragment to resolved paths.
+                    // Since ? and # are valid filename characters on Unix, only
+                    // strip the suffix when the full path doesn't exist on disk
+                    // (mirroring the fallback approach in resolver.zig for CSS).
                     const path_to_use = if (is_file_namespace)
                         if (bun.strings.indexOfAny(result.path, "?#")) |suffix|
-                            result.path[0..suffix]
+                            if (bun.sys.exists(result.path))
+                                result.path
+                            else
+                                result.path[0..suffix]
                         else
                             result.path
                     else

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -2642,8 +2642,10 @@ pub const BundleV2 = struct {
                     // Since ? and # are valid filename characters on Unix, only
                     // strip the suffix when the full path doesn't exist on disk
                     // (mirroring the fallback approach in resolver.zig for CSS).
+                    // Use lastIndexOfAny so that ? or # in directory names
+                    // (e.g. /projects/C#/main.js) are preserved.
                     const path_to_use = if (is_file_namespace)
-                        if (bun.strings.indexOfAny(result.path, "?#")) |suffix|
+                        if (std.mem.lastIndexOfAny(u8, result.path, "?#")) |suffix|
                             if (bun.sys.exists(result.path))
                                 result.path
                             else

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -2642,18 +2642,18 @@ pub const BundleV2 = struct {
                     // Since ? and # are valid filename characters on Unix, only
                     // strip the suffix when the full path doesn't exist on disk
                     // (mirroring the fallback approach in resolver.zig for CSS).
-                    // Use lastIndexOfAny so that ? or # in directory names
-                    // (e.g. /projects/C#/main.js) are preserved.
-                    const path_to_use = if (is_file_namespace)
-                        if (std.mem.lastIndexOfAny(u8, result.path, "?#")) |suffix|
-                            if (bun.sys.exists(result.path))
+                    // Search only the filename portion so that ? or # in
+                    // directory names (e.g. /projects/C#/main.js) are preserved.
+                    const path_to_use = if (is_file_namespace) blk: {
+                        const basename_start = if (bun.path.lastIndexOfSep(result.path)) |sep| sep + 1 else 0;
+                        if (bun.strings.indexOfAny(result.path[basename_start..], "?#")) |offset| {
+                            break :blk if (bun.sys.exists(result.path))
                                 result.path
                             else
-                                result.path[0..suffix]
-                        else
-                            result.path
-                    else
-                        result.path;
+                                result.path[0 .. basename_start + offset];
+                        }
+                        break :blk result.path;
+                    } else result.path;
 
                     var path = Fs.Path.init(path_to_use);
                     if (is_file_namespace) {

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -2644,9 +2644,12 @@ pub const BundleV2 = struct {
                     // (mirroring the fallback approach in resolver.zig for CSS).
                     // Search only the filename portion so that ? or # in
                     // directory names (e.g. /projects/C#/main.js) are preserved.
+                    // Prefer '?' over '#' so a file literally named C#.ts with an
+                    // appended ?query strips at the query, not inside the name.
                     const path_to_use = if (is_file_namespace) blk: {
                         const basename_start = if (bun.path.lastIndexOfSep(result.path)) |sep| sep + 1 else 0;
-                        if (bun.strings.indexOfAny(result.path[basename_start..], "?#")) |offset| {
+                        const basename = result.path[basename_start..];
+                        if (bun.strings.indexOfChar(basename, '?') orelse bun.strings.indexOfChar(basename, '#')) |offset| {
                             break :blk if (bun.sys.exists(result.path))
                                 result.path
                             else

--- a/test/regression/issue/28625.test.ts
+++ b/test/regression/issue/28625.test.ts
@@ -101,6 +101,53 @@ test.concurrent.skipIf(isWindows)("onResolve plugin can append query string when
   expect(exitCode).toBe(0);
 });
 
+// Same, but the plugin appends a '#fragment' — the strip must cut at the
+// last '#' (the appended suffix), not the first one inside the filename.
+test.concurrent.skipIf(isWindows)("onResolve plugin can append hash fragment when filename contains '#'", async () => {
+  using dir = tempDir("issue-28625-sharp-hash", {
+    "entry.js": `import txt from './C#.txt'; console.log(txt);`,
+    "C#.txt": `hello sharp`,
+    "build.js": `
+      import path from 'path';
+
+      const result = await Bun.build({
+        entrypoints: ['./entry.js'],
+        outdir: './out',
+        loader: { '.txt': 'text' },
+        plugins: [{
+          name: 'txt-hash-plugin',
+          setup(build) {
+            build.onResolve({filter: /\\.txt$/}, args => {
+              const resolvedPath = path.resolve(args.resolveDir, args.path) + '#section';
+              return { path: resolvedPath };
+            });
+          }
+        }]
+      });
+
+      if (!result.success) {
+        for (const msg of result.logs) console.error(msg);
+        process.exit(1);
+      }
+      console.log("BUILD_OK");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(filterAsanWarning(stderr)).toBe("");
+  expect(stdout).toContain("BUILD_OK");
+  expect(exitCode).toBe(0);
+});
+
 test.concurrent("onResolve plugin can append hash fragment to file namespace path", async () => {
   using dir = tempDir("issue-28625-hash", {
     "entry.js": `import txt from './data.txt'; console.log(txt);`,

--- a/test/regression/issue/28625.test.ts
+++ b/test/regression/issue/28625.test.ts
@@ -1,7 +1,15 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-test("onResolve plugin can append query string to file namespace path", async () => {
+function filterAsanWarning(stderr: string): string {
+  return stderr
+    .split("\n")
+    .filter((line) => !line.startsWith("WARNING: ASAN"))
+    .join("\n")
+    .trim();
+}
+
+test.concurrent("onResolve plugin can append query string to file namespace path", async () => {
   using dir = tempDir("issue-28625-query", {
     "entry.js": `import txt from './data.txt'; console.log(txt);`,
     "data.txt": `hello world`,
@@ -41,11 +49,12 @@ test("onResolve plugin can append query string to file namespace path", async ()
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect(filterAsanWarning(stderr)).toBe("");
   expect(stdout).toContain("BUILD_OK");
   expect(exitCode).toBe(0);
 });
 
-test("onResolve plugin can append hash fragment to file namespace path", async () => {
+test.concurrent("onResolve plugin can append hash fragment to file namespace path", async () => {
   using dir = tempDir("issue-28625-hash", {
     "entry.js": `import txt from './data.txt'; console.log(txt);`,
     "data.txt": `hello world`,
@@ -85,6 +94,7 @@ test("onResolve plugin can append hash fragment to file namespace path", async (
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect(filterAsanWarning(stderr)).toBe("");
   expect(stdout).toContain("BUILD_OK");
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/28625.test.ts
+++ b/test/regression/issue/28625.test.ts
@@ -56,13 +56,11 @@ test.concurrent("onResolve plugin can append query string to file namespace path
 
 // '#' is a valid filename character on POSIX; stripping a plugin-appended
 // '?query' must not truncate inside the basename when it contains '#'.
-test.concurrent.skipIf(isWindows)(
-  "onResolve plugin can append query string when filename contains '#'",
-  async () => {
-    using dir = tempDir("issue-28625-sharp", {
-      "entry.js": `import txt from './C#.txt'; console.log(txt);`,
-      "C#.txt": `hello sharp`,
-      "build.js": `
+test.concurrent.skipIf(isWindows)("onResolve plugin can append query string when filename contains '#'", async () => {
+  using dir = tempDir("issue-28625-sharp", {
+    "entry.js": `import txt from './C#.txt'; console.log(txt);`,
+    "C#.txt": `hello sharp`,
+    "build.js": `
       import path from 'path';
 
       const result = await Bun.build({
@@ -86,23 +84,22 @@ test.concurrent.skipIf(isWindows)(
       }
       console.log("BUILD_OK");
     `,
-    });
+  });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build.js"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(filterAsanWarning(stderr)).toBe("");
-    expect(stdout).toContain("BUILD_OK");
-    expect(exitCode).toBe(0);
-  },
-);
+  expect(filterAsanWarning(stderr)).toBe("");
+  expect(stdout).toContain("BUILD_OK");
+  expect(exitCode).toBe(0);
+});
 
 test.concurrent("onResolve plugin can append hash fragment to file namespace path", async () => {
   using dir = tempDir("issue-28625-hash", {

--- a/test/regression/issue/28625.test.ts
+++ b/test/regression/issue/28625.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 function filterAsanWarning(stderr: string): string {
   return stderr
@@ -53,6 +53,56 @@ test.concurrent("onResolve plugin can append query string to file namespace path
   expect(stdout).toContain("BUILD_OK");
   expect(exitCode).toBe(0);
 });
+
+// '#' is a valid filename character on POSIX; stripping a plugin-appended
+// '?query' must not truncate inside the basename when it contains '#'.
+test.concurrent.skipIf(isWindows)(
+  "onResolve plugin can append query string when filename contains '#'",
+  async () => {
+    using dir = tempDir("issue-28625-sharp", {
+      "entry.js": `import txt from './C#.txt'; console.log(txt);`,
+      "C#.txt": `hello sharp`,
+      "build.js": `
+      import path from 'path';
+
+      const result = await Bun.build({
+        entrypoints: ['./entry.js'],
+        outdir: './out',
+        loader: { '.txt': 'text' },
+        plugins: [{
+          name: 'txt-query-plugin',
+          setup(build) {
+            build.onResolve({filter: /\\.txt$/}, args => {
+              const resolvedPath = path.resolve(args.resolveDir, args.path) + '?version=1';
+              return { path: resolvedPath };
+            });
+          }
+        }]
+      });
+
+      if (!result.success) {
+        for (const msg of result.logs) console.error(msg);
+        process.exit(1);
+      }
+      console.log("BUILD_OK");
+    `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(filterAsanWarning(stderr)).toBe("");
+    expect(stdout).toContain("BUILD_OK");
+    expect(exitCode).toBe(0);
+  },
+);
 
 test.concurrent("onResolve plugin can append hash fragment to file namespace path", async () => {
   using dir = tempDir("issue-28625-hash", {

--- a/test/regression/issue/28625.test.ts
+++ b/test/regression/issue/28625.test.ts
@@ -1,0 +1,98 @@
+import { test, expect } from "bun:test";
+import { tempDir, bunExe, bunEnv } from "harness";
+
+test("onResolve plugin can append query string to file namespace path", async () => {
+  using dir = tempDir("issue-28625-query", {
+    "entry.js": `import txt from './data.txt'; console.log(txt);`,
+    "data.txt": `hello world`,
+    "build.js": `
+      import path from 'path';
+
+      const result = await Bun.build({
+        entrypoints: ['./entry.js'],
+        outdir: './out',
+        loader: { '.txt': 'text' },
+        plugins: [{
+          name: 'txt-query-plugin',
+          setup(build) {
+            build.onResolve({filter: /\\.txt$/}, args => {
+              const resolvedPath = path.resolve(args.resolveDir, args.path) + '?version=1';
+              return { path: resolvedPath };
+            });
+          }
+        }]
+      });
+
+      if (!result.success) {
+        for (const msg of result.logs) console.error(msg);
+        process.exit(1);
+      }
+      console.log("BUILD_OK");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout).toContain("BUILD_OK");
+  expect(exitCode).toBe(0);
+});
+
+test("onResolve plugin can append hash fragment to file namespace path", async () => {
+  using dir = tempDir("issue-28625-hash", {
+    "entry.js": `import txt from './data.txt'; console.log(txt);`,
+    "data.txt": `hello world`,
+    "build.js": `
+      import path from 'path';
+
+      const result = await Bun.build({
+        entrypoints: ['./entry.js'],
+        outdir: './out',
+        loader: { '.txt': 'text' },
+        plugins: [{
+          name: 'txt-hash-plugin',
+          setup(build) {
+            build.onResolve({filter: /\\.txt$/}, args => {
+              const resolvedPath = path.resolve(args.resolveDir, args.path) + '#section';
+              return { path: resolvedPath };
+            });
+          }
+        }]
+      });
+
+      if (!result.success) {
+        for (const msg of result.logs) console.error(msg);
+        process.exit(1);
+      }
+      console.log("BUILD_OK");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout).toContain("BUILD_OK");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/28625.test.ts
+++ b/test/regression/issue/28625.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { tempDir, bunExe, bunEnv } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("onResolve plugin can append query string to file namespace path", async () => {
   using dir = tempDir("issue-28625-query", {
@@ -39,11 +39,7 @@ test("onResolve plugin can append query string to file namespace path", async ()
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toContain("BUILD_OK");
   expect(exitCode).toBe(0);
@@ -87,11 +83,7 @@ test("onResolve plugin can append hash fragment to file namespace path", async (
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toContain("BUILD_OK");
   expect(exitCode).toBe(0);

--- a/test/regression/issue/28625.test.ts
+++ b/test/regression/issue/28625.test.ts
@@ -4,7 +4,7 @@ import { bunEnv, bunExe, tempDir } from "harness";
 function filterAsanWarning(stderr: string): string {
   return stderr
     .split("\n")
-    .filter((line) => !line.startsWith("WARNING: ASAN"))
+    .filter(line => !line.startsWith("WARNING: ASAN"))
     .join("\n")
     .trim();
 }


### PR DESCRIPTION
Closes #28625

## Problem

When a bundler plugin's `build.onResolve` hook returns a path with a query string (e.g., `/path/to/file.html?env=browser`) or hash fragment in the `file` namespace, the bundler tries to open the literal filename including the suffix, causing a "File not found" error or crash.

```js
build.onResolve({filter: /\.html$/}, args => {
  return { path: args.path + '?env=browser' };
});
```

## Cause

In `BundleV2.onResolve`, plugin-resolved paths are passed directly to `Fs.Path.init` without stripping query/fragment suffixes. The resolver already handles this for CSS imports (`kind.isFromCSS()`), but plugin-resolved paths in the `file` namespace bypass the resolver entirely and never get stripped.

## Fix

Strip `?` and `#` suffixes from plugin-resolved paths in the `file` namespace before constructing the `Fs.Path`, so the filesystem lookup uses the clean path.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28625.test.ts` → 2 fail
- `bun bd test test/regression/issue/28625.test.ts` → 2 pass