### PR TITLE
fix: `bun add --production` installs packages already in devDependencies

### DIFF
--- a/src/install/lockfile/Tree.zig
+++ b/src/install/lockfile/Tree.zig
@@ -388,7 +388,13 @@ pub fn isFilteredDependencyOrWorkspace(
     };
 
     if (!dep.behavior.isEnabled(dep_features)) {
-        return true;
+        // Don't filter out dependencies that the user explicitly requested
+        // on the command line (e.g. `bun add --production jsdom` where
+        // jsdom is in devDependencies should still install jsdom).
+        const is_cli_requested = manager.subcommand == .add and parent_pkg_id == 0 and for (manager.update_requests) |request| {
+            if (request.matches(dep, lockfile.buffers.string_bytes.items)) break true;
+        } else false;
+        if (!is_cli_requested) return true;
     }
 
     // Filtering only applies to the root package dependencies. Also

--- a/test/regression/issue/28627.test.ts
+++ b/test/regression/issue/28627.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { existsSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// https://github.com/oven-sh/bun/issues/28627
+test.concurrent("bun add --production --no-save installs devDependency", async () => {
+  using dir = tempDir("issue-28627", {
+    "package.json": JSON.stringify({
+      name: "test-issue-28627",
+      devDependencies: {
+        "is-number": "^7.0.0",
+      },
+    }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "add", "--production", "--no-save", "is-number"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("installed is-number");
+  expect(existsSync(join(String(dir), "node_modules", "is-number"))).toBeTrue();
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("bun add --production installs devDependency", async () => {
+  using dir = tempDir("issue-28627-save", {
+    "package.json": JSON.stringify({
+      name: "test-issue-28627-save",
+      devDependencies: {
+        "is-number": "^7.0.0",
+      },
+    }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "add", "--production", "is-number"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("installed is-number");
+  expect(existsSync(join(String(dir), "node_modules", "is-number"))).toBeTrue();
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #28627.

## Problem

`bun add --production --no-save <pkg>` (or `bun add --production <pkg>`) reports the package as installed but writes nothing to `node_modules` when the package is already listed in `devDependencies`.

```sh
$ cat package.json | grep -A2 devDep
  "devDependencies": {
    "jsdom": "latest"
  }
$ bun add --production --no-save jsdom
installed jsdom@29.0.1
$ ls node_modules/
(empty)
```

## Cause

The `--production` flag sets `local_package_features.dev_dependencies = false`. During tree building, `isFilteredDependencyOrWorkspace()` in `Tree.zig` checks `dep.behavior.isEnabled(dep_features)` and filters out all dev dependencies — including ones the user explicitly requested on the command line via `bun add`.

The package gets resolved and the success message is printed, but it is never placed into the installation tree and thus never written to `node_modules`.

## Fix

In `isFilteredDependencyOrWorkspace()`, when a dependency would be filtered out by `!isEnabled()`, check whether it matches any of the CLI-specified `update_requests`. If it does, exempt it from the filter — the user explicitly asked for it.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28627.test.ts` → **FAIL** (bug present)
- `bun bd test test/regression/issue/28627.test.ts` → **PASS** (fix works)