### PR TITLE
Emit 'upgrade' event on http.ClientRequest for 101 responses

### DIFF
--- a/src/js/internal/http/UpgradeSocket.ts
+++ b/src/js/internal/http/UpgradeSocket.ts
@@ -2,6 +2,8 @@ const { Duplex } = require("internal/stream");
 
 const kReader = Symbol("reader");
 const kWriter = Symbol("writer");
+const kReading = Symbol("reading");
+const kWriterEnded = Symbol("writerEnded");
 
 interface UpgradeSocketWriter {
   push(chunk: Buffer): void;
@@ -12,11 +14,15 @@ type UpgradeSocket = InstanceType<typeof UpgradeSocket>;
 var UpgradeSocket = class UpgradeSocket extends Duplex {
   [kReader]: ReadableStreamDefaultReader | null;
   [kWriter]: UpgradeSocketWriter;
+  [kReading]: boolean;
+  [kWriterEnded]: boolean;
 
   constructor(responseBody: ReadableStream | null, writer: UpgradeSocketWriter) {
     super();
     this[kReader] = responseBody ? responseBody.getReader() : null;
     this[kWriter] = writer;
+    this[kReading] = false;
+    this[kWriterEnded] = false;
 
     if (this[kReader]) {
       this.#pump();
@@ -25,11 +31,13 @@ var UpgradeSocket = class UpgradeSocket extends Duplex {
 
   #pump() {
     const reader = this[kReader];
-    if (!reader) return;
+    if (!reader || this[kReading]) return;
+    this[kReading] = true;
 
     reader
       .read()
       .then(({ done, value }: { done: boolean; value?: Uint8Array }) => {
+        this[kReading] = false;
         if (done) {
           this.push(null);
           return;
@@ -41,9 +49,10 @@ var UpgradeSocket = class UpgradeSocket extends Duplex {
         }
         this.#pump();
       })
-      .catch(() => {
+      .catch((err: Error) => {
+        this[kReading] = false;
         if (!this.destroyed) {
-          this.push(null);
+          this.destroy(err);
         }
       });
   }
@@ -60,8 +69,14 @@ var UpgradeSocket = class UpgradeSocket extends Duplex {
     callback();
   }
 
-  _final(callback: (err?: Error | null) => void) {
+  #endWriter() {
+    if (this[kWriterEnded]) return;
+    this[kWriterEnded] = true;
     this[kWriter].end();
+  }
+
+  _final(callback: (err?: Error | null) => void) {
+    this.#endWriter();
     callback();
   }
 
@@ -71,7 +86,7 @@ var UpgradeSocket = class UpgradeSocket extends Duplex {
       this[kReader] = null;
       reader.cancel().catch(() => {});
     }
-    this[kWriter].end();
+    this.#endWriter();
     callback(err);
   }
 

--- a/src/js/internal/http/UpgradeSocket.ts
+++ b/src/js/internal/http/UpgradeSocket.ts
@@ -43,7 +43,6 @@ var UpgradeSocket = class UpgradeSocket extends Duplex {
           return;
         }
         if (!this.push(value)) {
-          // Backpressure: consumer buffer is full, wait for _read()
           return;
         }
         this.#pump();
@@ -87,6 +86,41 @@ var UpgradeSocket = class UpgradeSocket extends Duplex {
     }
     this.#endWriter();
     callback(err);
+  }
+
+  setTimeout(timeout: number, callback?: () => void) {
+    if (callback) {
+      if (timeout === 0) {
+        this.removeListener("timeout", callback);
+      } else {
+        this.once("timeout", callback);
+      }
+    }
+    return this;
+  }
+
+  address() {
+    return {};
+  }
+
+  get remoteAddress() {
+    return undefined;
+  }
+
+  get remotePort() {
+    return undefined;
+  }
+
+  get remoteFamily() {
+    return undefined;
+  }
+
+  get localAddress() {
+    return undefined;
+  }
+
+  get localPort() {
+    return undefined;
   }
 
   setKeepAlive(_enable = false, _initialDelay = 0) {

--- a/src/js/internal/http/UpgradeSocket.ts
+++ b/src/js/internal/http/UpgradeSocket.ts
@@ -106,7 +106,10 @@ var UpgradeSocket = class UpgradeSocket extends Duplex {
     return this;
   }
 
-  resetAndDestroy() {}
+  resetAndDestroy() {
+    this.destroy();
+    return this;
+  }
 };
 
 Object.defineProperty(UpgradeSocket, "name", { value: "Socket" });

--- a/src/js/internal/http/UpgradeSocket.ts
+++ b/src/js/internal/http/UpgradeSocket.ts
@@ -38,11 +38,10 @@ var UpgradeSocket = class UpgradeSocket extends Duplex {
       .read()
       .then(({ done, value }: { done: boolean; value?: Uint8Array }) => {
         this[kReading] = false;
-        if (done) {
-          this.push(null);
+        if (done || this.destroyed) {
+          if (!this.destroyed) this.push(null);
           return;
         }
-        if (this.destroyed) return;
         if (!this.push(value)) {
           // Backpressure: consumer buffer is full, wait for _read()
           return;

--- a/src/js/internal/http/UpgradeSocket.ts
+++ b/src/js/internal/http/UpgradeSocket.ts
@@ -34,8 +34,10 @@ var UpgradeSocket = class UpgradeSocket extends Duplex {
           this.push(null);
           return;
         }
-        if (!this.destroyed) {
-          this.push(value);
+        if (this.destroyed) return;
+        if (!this.push(value)) {
+          // Backpressure: consumer buffer is full, wait for _read()
+          return;
         }
         this.#pump();
       })
@@ -46,7 +48,9 @@ var UpgradeSocket = class UpgradeSocket extends Duplex {
       });
   }
 
-  _read(_size: number) {}
+  _read(_size: number) {
+    this.#pump();
+  }
 
   _write(chunk: any, encoding: string, callback: (err?: Error | null) => void) {
     if (typeof chunk === "string") {

--- a/src/js/internal/http/UpgradeSocket.ts
+++ b/src/js/internal/http/UpgradeSocket.ts
@@ -1,0 +1,97 @@
+const { Duplex } = require("internal/stream");
+
+const kReader = Symbol("reader");
+const kWriter = Symbol("writer");
+
+type WriterCallback = (chunk: Buffer | undefined) => void;
+
+interface UpgradeSocketWriter {
+  push(chunk: Buffer): void;
+  end(): void;
+}
+
+type UpgradeSocket = InstanceType<typeof UpgradeSocket>;
+var UpgradeSocket = class UpgradeSocket extends Duplex {
+  [kReader]: ReadableStreamDefaultReader | null;
+  [kWriter]: UpgradeSocketWriter;
+
+  constructor(responseBody: ReadableStream | null, writer: UpgradeSocketWriter) {
+    super();
+    this[kReader] = responseBody ? responseBody.getReader() : null;
+    this[kWriter] = writer;
+
+    if (this[kReader]) {
+      this.#pump();
+    }
+  }
+
+  #pump() {
+    const reader = this[kReader];
+    if (!reader) return;
+
+    reader
+      .read()
+      .then(({ done, value }: { done: boolean; value?: Uint8Array }) => {
+        if (done) {
+          this.push(null);
+          return;
+        }
+        if (!this.destroyed) {
+          this.push(value);
+        }
+        this.#pump();
+      })
+      .catch(() => {
+        if (!this.destroyed) {
+          this.push(null);
+        }
+      });
+  }
+
+  _read(_size: number) {}
+
+  _write(chunk: any, encoding: string, callback: (err?: Error | null) => void) {
+    if (typeof chunk === "string") {
+      chunk = Buffer.from(chunk, encoding);
+    }
+    this[kWriter].push(chunk);
+    callback();
+  }
+
+  _final(callback: (err?: Error | null) => void) {
+    this[kWriter].end();
+    callback();
+  }
+
+  _destroy(err: Error | null, callback: (err?: Error | null) => void) {
+    const reader = this[kReader];
+    if (reader) {
+      this[kReader] = null;
+      reader.cancel().catch(() => {});
+    }
+    this[kWriter].end();
+    callback(err);
+  }
+
+  setKeepAlive(_enable = false, _initialDelay = 0) {}
+
+  setNoDelay(_noDelay = true) {
+    return this;
+  }
+
+  ref() {
+    return this;
+  }
+
+  unref() {
+    return this;
+  }
+
+  resetAndDestroy() {}
+};
+
+Object.defineProperty(UpgradeSocket, "name", { value: "Socket" });
+
+export default {
+  UpgradeSocket,
+};

--- a/src/js/internal/http/UpgradeSocket.ts
+++ b/src/js/internal/http/UpgradeSocket.ts
@@ -3,8 +3,6 @@ const { Duplex } = require("internal/stream");
 const kReader = Symbol("reader");
 const kWriter = Symbol("writer");
 
-type WriterCallback = (chunk: Buffer | undefined) => void;
-
 interface UpgradeSocketWriter {
   push(chunk: Buffer): void;
   end(): void;
@@ -73,7 +71,9 @@ var UpgradeSocket = class UpgradeSocket extends Duplex {
     callback(err);
   }
 
-  setKeepAlive(_enable = false, _initialDelay = 0) {}
+  setKeepAlive(_enable = false, _initialDelay = 0) {
+    return this;
+  }
 
   setNoDelay(_noDelay = true) {
     return this;

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -429,10 +429,13 @@ function ClientRequest(input, options, cb) {
           });
 
           upgradeRes.socket = upgradeSocket;
+          upgradeSocket.once("close", maybeEmitClose);
 
           process.nextTick(
             (self, res, socket) => {
-              self.emit("upgrade", res, socket, Buffer.alloc(0));
+              if (!self.emit("upgrade", res, socket, Buffer.alloc(0))) {
+                socket.destroy();
+              }
             },
             this,
             upgradeRes,

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -413,54 +413,22 @@ function ClientRequest(input, options, cb) {
           setIsNextIncomingMessageHTTPS(prevIsHTTPS);
           upgradeRes.req = this;
 
-          // Create a duplex socket that bridges the response body (read side)
-          // and the request body generator (write side).
-          const self = this;
-          const { Duplex } = require("internal/stream");
-          const upgradeSocket = new Duplex({
-            read() {},
-            write(chunk, encoding, callback) {
-              if (typeof chunk === "string") {
-                chunk = Buffer.from(chunk, encoding);
+          const { UpgradeSocket } = require("internal/http/UpgradeSocket");
+          const upgradeSocket = new UpgradeSocket(response.body, {
+            push: (chunk) => {
+              if (!this[kBodyChunks]) {
+                this[kBodyChunks] = [];
               }
-              if (!self[kBodyChunks]) {
-                self[kBodyChunks] = [];
-              }
-              self[kBodyChunks].push(chunk);
+              this[kBodyChunks].push(chunk);
               resolveNextChunk?.(false);
-              callback();
             },
-            final(callback) {
-              self.finished = true;
+            end: () => {
+              this.finished = true;
               resolveNextChunk?.(true);
-              callback();
             },
           });
 
-          // Pump response body into the readable side of the duplex socket.
-          if (response.body) {
-            const reader = response.body.getReader();
-            const pump = () => {
-              reader
-                .read()
-                .then(({ done, value }) => {
-                  if (done) {
-                    upgradeSocket.push(null);
-                    return;
-                  }
-                  if (!upgradeSocket.destroyed) {
-                    upgradeSocket.push(value);
-                  }
-                  pump();
-                })
-                .catch(() => {
-                  if (!upgradeSocket.destroyed) {
-                    upgradeSocket.push(null);
-                  }
-                });
-            };
-            pump();
-          }
+          upgradeRes.socket = upgradeSocket;
 
           process.nextTick(
             (self, res, socket) => {

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -397,6 +397,82 @@ function ClientRequest(input, options, cb) {
           return;
         }
 
+        // Handle HTTP 101 Switching Protocols (upgrade)
+        if (response.status === 101) {
+          this[kFetchRequest] = null;
+          this[kClearTimeout]();
+          this[kUpgradeOrConnect] = true;
+          handleResponse = undefined;
+
+          const prevIsHTTPS = getIsNextIncomingMessageHTTPS();
+          setIsNextIncomingMessageHTTPS(response.url.startsWith("https:"));
+          var upgradeRes = (this.res = new IncomingMessage(response, {
+            [typeSymbol]: NodeHTTPIncomingRequestType.FetchResponse,
+            [reqSymbol]: this,
+          }));
+          setIsNextIncomingMessageHTTPS(prevIsHTTPS);
+          upgradeRes.req = this;
+
+          // Create a duplex socket that bridges the response body (read side)
+          // and the request body generator (write side).
+          const self = this;
+          const { Duplex } = require("internal/stream");
+          const upgradeSocket = new Duplex({
+            read() {},
+            write(chunk, encoding, callback) {
+              if (typeof chunk === "string") {
+                chunk = Buffer.from(chunk, encoding);
+              }
+              if (!self[kBodyChunks]) {
+                self[kBodyChunks] = [];
+              }
+              self[kBodyChunks].push(chunk);
+              resolveNextChunk?.(false);
+              callback();
+            },
+            final(callback) {
+              self.finished = true;
+              resolveNextChunk?.(true);
+              callback();
+            },
+          });
+
+          // Pump response body into the readable side of the duplex socket.
+          if (response.body) {
+            const reader = response.body.getReader();
+            const pump = () => {
+              reader
+                .read()
+                .then(({ done, value }) => {
+                  if (done) {
+                    upgradeSocket.push(null);
+                    return;
+                  }
+                  if (!upgradeSocket.destroyed) {
+                    upgradeSocket.push(value);
+                  }
+                  pump();
+                })
+                .catch(() => {
+                  if (!upgradeSocket.destroyed) {
+                    upgradeSocket.push(null);
+                  }
+                });
+            };
+            pump();
+          }
+
+          process.nextTick(
+            (self, res, socket) => {
+              self.emit("upgrade", res, socket, Buffer.alloc(0));
+            },
+            this,
+            upgradeRes,
+            upgradeSocket,
+          );
+          return;
+        }
+
         handleResponse = () => {
           this[kFetchRequest] = null;
           this[kClearTimeout]();

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -352,7 +352,13 @@ function ClientRequest(input, options, cb) {
           }
 
           while (!self.finished) {
-            yield await new Promise(resolve => {
+            // Drain any chunks queued while resolveNextChunk was undefined
+            while (self[kBodyChunks]?.length > 0 && !self.finished) {
+              yield self[kBodyChunks].shift();
+            }
+            if (self.finished) break;
+
+            const chunk = await new Promise(resolve => {
               resolveNextChunk = end => {
                 resolveNextChunk = undefined;
                 if (end) {
@@ -362,6 +368,9 @@ function ClientRequest(input, options, cb) {
                 }
               };
             });
+            if (chunk !== undefined) {
+              yield chunk;
+            }
 
             if (self[kBodyChunks]?.length === 0) {
               self.emit("drain");
@@ -429,6 +438,8 @@ function ClientRequest(input, options, cb) {
           });
 
           upgradeRes.socket = upgradeSocket;
+          upgradeRes.complete = true;
+          upgradeRes.push(null);
           upgradeSocket.once("close", maybeEmitClose);
 
           process.nextTick(

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -415,7 +415,7 @@ function ClientRequest(input, options, cb) {
 
           const { UpgradeSocket } = require("internal/http/UpgradeSocket");
           const upgradeSocket = new UpgradeSocket(response.body, {
-            push: (chunk) => {
+            push: chunk => {
               if (!this[kBodyChunks]) {
                 this[kBodyChunks] = [];
               }

--- a/test/regression/issue/18982.test.ts
+++ b/test/regression/issue/18982.test.ts
@@ -1,0 +1,303 @@
+import { test, expect, describe } from "bun:test";
+import http from "node:http";
+import net from "node:net";
+
+describe("http.ClientRequest upgrade event", () => {
+  test("emits 'upgrade' event on 101 Switching Protocols", async () => {
+    const { promise: serverReady, resolve: resolveServerReady } = Promise.withResolvers<number>();
+    const { promise: done, resolve: resolveDone, reject: rejectDone } = Promise.withResolvers<void>();
+
+    // Raw TCP server that responds with 101 Switching Protocols
+    const server = net.createServer((socket) => {
+      socket.once("data", () => {
+        socket.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: tcp\r\n" +
+            "Connection: Upgrade\r\n" +
+            "\r\n",
+        );
+
+        // Echo back data
+        socket.on("data", (chunk) => {
+          socket.write("echo:" + chunk.toString());
+        });
+      });
+    });
+
+    server.listen(0, () => {
+      resolveServerReady((server.address() as net.AddressInfo).port);
+    });
+
+    try {
+      const port = await serverReady;
+
+      const req = http.request({
+        host: "127.0.0.1",
+        port,
+        method: "POST",
+        path: "/attach",
+        headers: {
+          Connection: "Upgrade",
+          Upgrade: "tcp",
+        },
+      });
+
+      req.on("upgrade", (res, socket, head) => {
+        try {
+          expect(res.statusCode).toBe(101);
+          expect(res.headers["upgrade"]).toBe("tcp");
+          expect(head).toBeInstanceOf(Buffer);
+
+          socket.write("hello");
+          socket.on("data", (chunk: Buffer) => {
+            try {
+              expect(chunk.toString()).toBe("echo:hello");
+              socket.destroy();
+              resolveDone();
+            } catch (e) {
+              rejectDone(e);
+            }
+          });
+        } catch (e) {
+          rejectDone(e);
+        }
+      });
+
+      req.on("response", () => {
+        rejectDone(new Error("'response' event should not fire for 101"));
+      });
+
+      req.on("error", (err) => {
+        rejectDone(err);
+      });
+
+      req.flushHeaders();
+
+      await done;
+    } finally {
+      server.close();
+    }
+  });
+
+  test("upgrade socket supports bidirectional streaming", async () => {
+    const { promise: serverReady, resolve: resolveServerReady } = Promise.withResolvers<number>();
+    const { promise: done, resolve: resolveDone, reject: rejectDone } = Promise.withResolvers<void>();
+
+    const server = net.createServer((socket) => {
+      socket.once("data", () => {
+        socket.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: tcp\r\n" +
+            "Connection: Upgrade\r\n" +
+            "\r\n",
+        );
+
+        // Server sends first, then echoes
+        socket.write("server-hello\n");
+
+        socket.on("data", (chunk) => {
+          const msg = chunk.toString().trim();
+          socket.write("reply:" + msg + "\n");
+          if (msg === "done") {
+            socket.end();
+          }
+        });
+      });
+    });
+
+    server.listen(0, () => {
+      resolveServerReady((server.address() as net.AddressInfo).port);
+    });
+
+    try {
+      const port = await serverReady;
+
+      const req = http.request({
+        host: "127.0.0.1",
+        port,
+        method: "POST",
+        path: "/exec",
+        headers: {
+          Connection: "Upgrade",
+          Upgrade: "tcp",
+        },
+      });
+
+      req.on("upgrade", (_res, socket) => {
+        const received: string[] = [];
+
+        socket.setEncoding("utf-8");
+        socket.on("data", (chunk: string) => {
+          for (const line of chunk.split("\n").filter(Boolean)) {
+            received.push(line);
+            if (line === "server-hello") {
+              socket.write("ping\n");
+            } else if (line === "reply:ping") {
+              socket.write("done\n");
+            } else if (line === "reply:done") {
+              // Server will close the connection
+            }
+          }
+        });
+
+        socket.on("end", () => {
+          try {
+            expect(received).toEqual(["server-hello", "reply:ping", "reply:done"]);
+            resolveDone();
+          } catch (e) {
+            rejectDone(e);
+          }
+        });
+
+        socket.on("error", rejectDone);
+      });
+
+      req.on("error", rejectDone);
+      req.flushHeaders();
+
+      await done;
+    } finally {
+      server.close();
+    }
+  });
+
+  test("upgrade over unix socket", async () => {
+    const fs = await import("node:fs");
+    const os = await import("node:os");
+    const path = await import("node:path");
+
+    const socketPath = path.join(os.tmpdir(), `bun-test-upgrade-${Date.now()}.sock`);
+
+    const { promise: serverReady, resolve: resolveServerReady } = Promise.withResolvers<void>();
+    const { promise: done, resolve: resolveDone, reject: rejectDone } = Promise.withResolvers<void>();
+
+    const server = net.createServer((socket) => {
+      socket.once("data", () => {
+        socket.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: tcp\r\n" +
+            "Connection: Upgrade\r\n" +
+            "\r\n",
+        );
+
+        socket.on("data", (chunk) => {
+          socket.write("echo:" + chunk.toString());
+        });
+      });
+    });
+
+    server.listen(socketPath, () => {
+      resolveServerReady();
+    });
+
+    try {
+      await serverReady;
+
+      const req = http.request({
+        socketPath,
+        method: "POST",
+        path: "/v1.45/containers/test/attach?stdin=1&stdout=1&stream=1",
+        headers: {
+          Connection: "Upgrade",
+          Upgrade: "tcp",
+          "Content-Type": "application/json",
+        },
+      });
+
+      req.on("upgrade", (res, socket) => {
+        try {
+          expect(res.statusCode).toBe(101);
+
+          socket.write("test-data");
+          socket.on("data", (chunk: Buffer) => {
+            try {
+              expect(chunk.toString()).toBe("echo:test-data");
+              socket.destroy();
+              resolveDone();
+            } catch (e) {
+              rejectDone(e);
+            }
+          });
+        } catch (e) {
+          rejectDone(e);
+        }
+      });
+
+      req.on("error", rejectDone);
+      req.flushHeaders();
+
+      await done;
+    } finally {
+      server.close();
+      try {
+        fs.unlinkSync(socketPath);
+      } catch {}
+    }
+  });
+
+  test("req.end() with body before upgrade still works", async () => {
+    const { promise: serverReady, resolve: resolveServerReady } = Promise.withResolvers<number>();
+    const { promise: done, resolve: resolveDone, reject: rejectDone } = Promise.withResolvers<void>();
+
+    const server = net.createServer((socket) => {
+      let buf = "";
+      socket.on("data", (data) => {
+        buf += data.toString();
+        // Wait until we get the full HTTP request with body
+        if (buf.includes("\r\n\r\n")) {
+          socket.write(
+            "HTTP/1.1 101 Switching Protocols\r\n" +
+              "Upgrade: tcp\r\n" +
+              "Connection: Upgrade\r\n" +
+              "\r\n" +
+              "welcome",
+          );
+        }
+      });
+    });
+
+    server.listen(0, () => {
+      resolveServerReady((server.address() as net.AddressInfo).port);
+    });
+
+    try {
+      const port = await serverReady;
+
+      const req = http.request({
+        host: "127.0.0.1",
+        port,
+        method: "POST",
+        path: "/start",
+        headers: {
+          Connection: "Upgrade",
+          Upgrade: "tcp",
+        },
+      });
+
+      req.on("upgrade", (res, socket) => {
+        try {
+          expect(res.statusCode).toBe(101);
+
+          socket.on("data", (chunk: Buffer) => {
+            try {
+              expect(chunk.toString()).toBe("welcome");
+              socket.destroy();
+              resolveDone();
+            } catch (e) {
+              rejectDone(e);
+            }
+          });
+        } catch (e) {
+          rejectDone(e);
+        }
+      });
+
+      req.on("error", rejectDone);
+      req.end('{"Tty":true}');
+
+      await done;
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/test/regression/issue/18982.test.ts
+++ b/test/regression/issue/18982.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import http from "node:http";
 import net from "node:net";
 
@@ -8,17 +8,12 @@ describe("http.ClientRequest upgrade event", () => {
     const { promise: done, resolve: resolveDone, reject: rejectDone } = Promise.withResolvers<void>();
 
     // Raw TCP server that responds with 101 Switching Protocols
-    const server = net.createServer((socket) => {
+    const server = net.createServer(socket => {
       socket.once("data", () => {
-        socket.write(
-          "HTTP/1.1 101 Switching Protocols\r\n" +
-            "Upgrade: tcp\r\n" +
-            "Connection: Upgrade\r\n" +
-            "\r\n",
-        );
+        socket.write("HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: tcp\r\n" + "Connection: Upgrade\r\n" + "\r\n");
 
         // Echo back data
-        socket.on("data", (chunk) => {
+        socket.on("data", chunk => {
           socket.write("echo:" + chunk.toString());
         });
       });
@@ -67,7 +62,7 @@ describe("http.ClientRequest upgrade event", () => {
         rejectDone(new Error("'response' event should not fire for 101"));
       });
 
-      req.on("error", (err) => {
+      req.on("error", err => {
         rejectDone(err);
       });
 
@@ -83,19 +78,14 @@ describe("http.ClientRequest upgrade event", () => {
     const { promise: serverReady, resolve: resolveServerReady } = Promise.withResolvers<number>();
     const { promise: done, resolve: resolveDone, reject: rejectDone } = Promise.withResolvers<void>();
 
-    const server = net.createServer((socket) => {
+    const server = net.createServer(socket => {
       socket.once("data", () => {
-        socket.write(
-          "HTTP/1.1 101 Switching Protocols\r\n" +
-            "Upgrade: tcp\r\n" +
-            "Connection: Upgrade\r\n" +
-            "\r\n",
-        );
+        socket.write("HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: tcp\r\n" + "Connection: Upgrade\r\n" + "\r\n");
 
         // Server sends first, then echoes
         socket.write("server-hello\n");
 
-        socket.on("data", (chunk) => {
+        socket.on("data", chunk => {
           const msg = chunk.toString().trim();
           socket.write("reply:" + msg + "\n");
           if (msg === "done") {
@@ -171,16 +161,11 @@ describe("http.ClientRequest upgrade event", () => {
     const { promise: serverReady, resolve: resolveServerReady } = Promise.withResolvers<void>();
     const { promise: done, resolve: resolveDone, reject: rejectDone } = Promise.withResolvers<void>();
 
-    const server = net.createServer((socket) => {
+    const server = net.createServer(socket => {
       socket.once("data", () => {
-        socket.write(
-          "HTTP/1.1 101 Switching Protocols\r\n" +
-            "Upgrade: tcp\r\n" +
-            "Connection: Upgrade\r\n" +
-            "\r\n",
-        );
+        socket.write("HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: tcp\r\n" + "Connection: Upgrade\r\n" + "\r\n");
 
-        socket.on("data", (chunk) => {
+        socket.on("data", chunk => {
           socket.write("echo:" + chunk.toString());
         });
       });
@@ -239,9 +224,9 @@ describe("http.ClientRequest upgrade event", () => {
     const { promise: serverReady, resolve: resolveServerReady } = Promise.withResolvers<number>();
     const { promise: done, resolve: resolveDone, reject: rejectDone } = Promise.withResolvers<void>();
 
-    const server = net.createServer((socket) => {
+    const server = net.createServer(socket => {
       let buf = "";
-      socket.on("data", (data) => {
+      socket.on("data", data => {
         buf += data.toString();
         // Wait until we get the full HTTP request with body
         if (buf.includes("\r\n\r\n")) {

--- a/test/regression/issue/18982.test.ts
+++ b/test/regression/issue/18982.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
 import http from "node:http";
 import net from "node:net";
+import os from "node:os";
+import path from "node:path";
 
 describe("http.ClientRequest upgrade event", () => {
   test("emits 'upgrade' event on 101 Switching Protocols", async () => {
@@ -152,10 +155,6 @@ describe("http.ClientRequest upgrade event", () => {
   });
 
   test("upgrade over unix socket", async () => {
-    const fs = await import("node:fs");
-    const os = await import("node:os");
-    const path = await import("node:path");
-
     const socketPath = path.join(os.tmpdir(), `bun-test-upgrade-${Date.now()}.sock`);
 
     const { promise: serverReady, resolve: resolveServerReady } = Promise.withResolvers<void>();
@@ -228,8 +227,8 @@ describe("http.ClientRequest upgrade event", () => {
       let buf = "";
       socket.on("data", data => {
         buf += data.toString();
-        // Wait until we get the full HTTP request with body
-        if (buf.includes("\r\n\r\n")) {
+        // Wait until we get the full HTTP request including body
+        if (buf.includes('{"Tty":true}')) {
           socket.write(
             "HTTP/1.1 101 Switching Protocols\r\n" +
               "Upgrade: tcp\r\n" +

--- a/test/regression/issue/18982.test.ts
+++ b/test/regression/issue/18982.test.ts
@@ -5,7 +5,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
-describe("http.ClientRequest upgrade event", () => {
+describe.concurrent("http.ClientRequest upgrade event", () => {
   test("emits 'upgrade' event on 101 Switching Protocols", async () => {
     const { promise: serverReady, resolve: resolveServerReady } = Promise.withResolvers<number>();
     const { promise: done, resolve: resolveDone, reject: rejectDone } = Promise.withResolvers<void>();


### PR DESCRIPTION
## Problem

`http.ClientRequest` never emits the `'upgrade'` event when the server responds with `101 Switching Protocols`. Instead, the 101 response is dispatched as a regular `'response'` event (or swallowed entirely for streaming requests), causing any code that relies on HTTP upgrades to hang indefinitely.

This breaks all Docker SDK packages on npm (`dockerode`, `docker-modem`, etc.) which use HTTP upgrades over unix sockets for `container.attach()`, `exec.start()`, and similar operations.

Fixes #18982

## Root cause

In `_http_client.ts`, the `handleResponse` callback unconditionally emits `'response'` for all status codes. There was no check for status code 101 and no code path to emit `'upgrade'`. The `kUpgradeOrConnect` symbol was imported but never set to `true`.

## Fix

When the fetch response has status 101:
1. Skip the normal `'response'` emission path
2. Create a `Duplex` stream that bridges the fetch response body (read side) with the request body async generator (write side)
3. Emit `'upgrade'` event with `(res, socket, head)` matching Node.js behavior

The duplex socket supports full bidirectional streaming — writes feed into the existing request body channel, reads come from the response body ReadableStream.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/regression/issue/18982.test.ts  → 4 fail (all timeout)
bun bd test test/regression/issue/18982.test.ts                → 4 pass
```

Tests cover: basic upgrade event, bidirectional streaming, unix socket path, and req.end() with body before upgrade.