### PR TITLE
Print mimalloc stats before quick_exit on Linux

### DIFF
--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -802,6 +802,18 @@ pub(crate) extern "C" fn Bun__onExit() {
         callback();
     }
     run_exit_callbacks();
+
+    // Bun builds mimalloc with MI_NO_PROCESS_DETACH, disabling its automatic
+    // stats output on exit. Print them when MIMALLOC_SHOW_STATS=1 or
+    // MIMALLOC_VERBOSE=1 is set.
+    if bun_alloc::mimalloc::mi_option_is_enabled(bun_alloc::mimalloc::Option::show_stats)
+        || bun_alloc::mimalloc::mi_option_is_enabled(bun_alloc::mimalloc::Option::verbose)
+    {
+        // SAFETY: reads global mimalloc counters and writes to stderr; a null
+        // `out` selects the default stream. No pointer preconditions.
+        unsafe { bun_alloc::mimalloc::mi_stats_print(core::ptr::null_mut()) };
+    }
+
     Output::flush();
     crate::keep_symbols!(Bun__atexit);
 

--- a/test/regression/issue/28630.test.ts
+++ b/test/regression/issue/28630.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Bun builds mimalloc with MI_NO_PROCESS_DETACH, which disables mimalloc's
+// automatic stats print on exit. Bun prints them manually in Bun__onExit,
+// which runs on all platforms (atexit on macOS/ASAN, at_quick_exit on
+// Linux, explicit call before ExitProcess on Windows).
+test("MIMALLOC_SHOW_STATS=1 prints memory statistics on exit", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "console.log('hello')"],
+    env: { ...bunEnv, MIMALLOC_SHOW_STATS: "1" },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // trim() because Windows writes CRLF
+  expect(stdout.trim()).toBe("hello");
+  // mimalloc stats include arenas and process sections
+  expect(stderr).toContain("arenas");
+  expect(stderr).toContain("process");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #28630

## Problem

`MIMALLOC_SHOW_STATS=1` / `MIMALLOC_VERBOSE=1` do not print memory statistics on exit. The program runs and exits with no output.

## Cause

Bun builds mimalloc with `MI_NO_PROCESS_DETACH=1` (see `scripts/build/deps/mimalloc.ts`), which disables mimalloc's automatic stats output on exit. As a result, no platform produced stats.

## Fix

Print stats manually in `Bun__onExit` (which runs on all platforms: via `atexit` on macOS/ASAN, via `at_quick_exit` on Linux, called explicitly before `ExitProcess` on Windows) when `show_stats` or `verbose` is enabled. Mirrors what mimalloc's own `mi_process_done` would have done.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/regression/issue/28630.test.ts  -> FAIL (no stats printed)
bun bd test test/regression/issue/28630.test.ts                -> PASS (stats printed)
```

## Rebase note

Rebased onto current main, which ported the runtime from Zig to Rust. The original fix in `src/Global.zig` moved to `src/bun_core/Global.rs` (`Bun__onExit`), using the `bun_alloc::mimalloc` bindings (`mi_option_is_enabled`, `mi_stats_print`). The call is intentionally not gated on `USE_MIMALLOC` (which is false under ASAN): mimalloc is always linked (built with `MI_TRACK_ASAN` under ASAN), so the stats still print in debug/ASAN builds, and the regression test passes under `bun bd`.