### PR TITLE
Fix per-query memory leaks in MySQL adapter

### DIFF
--- a/src/sql/mysql/MySQLConnection.zig
+++ b/src/sql/mysql/MySQLConnection.zig
@@ -924,6 +924,7 @@ pub fn handlePreparedStatement(this: *MySQLConnection, comptime Context: type, r
             // Read column definitions if any
             if (ok.num_columns > 0) {
                 statement.columns = try bun.default_allocator.alloc(ColumnDefinition41, ok.num_columns);
+                for (statement.columns) |*col| col.* = .{};
                 statement.columns_received = 0;
             }
 
@@ -1055,6 +1056,7 @@ fn handleResultSet(this: *MySQLConnection, comptime Context: type, reader: NewRe
                         bun.default_allocator.free(statement.columns);
                     }
                     statement.columns = try bun.default_allocator.alloc(ColumnDefinition41, header.field_count);
+                    for (statement.columns) |*col| col.* = .{};
                     statement.columns_received = 0;
                 }
                 statement.execution_flags.needs_duplicate_check = true;

--- a/src/sql/mysql/MySQLStatement.zig
+++ b/src/sql/mysql/MySQLStatement.zig
@@ -83,6 +83,7 @@ pub fn checkForDuplicateFields(this: *@This()) void {
             .name => |*name| {
                 const seen = seen_fields.getOrPut(name.slice()) catch unreachable;
                 if (seen.found_existing) {
+                    field.name_or_index.deinit();
                     field.name_or_index = .duplicate;
                     flags.has_duplicate_columns = true;
                 }

--- a/src/sql/mysql/protocol/ColumnDefinition41.zig
+++ b/src/sql/mysql/protocol/ColumnDefinition41.zig
@@ -48,6 +48,7 @@ pub fn deinit(this: *ColumnDefinition41) void {
     this.org_table.deinit();
     this.name.deinit();
     this.org_name.deinit();
+    this.name_or_index.deinit();
 }
 
 pub fn decodeInternal(this: *ColumnDefinition41, comptime Context: type, reader: NewReader(Context)) !void {
@@ -77,6 +78,7 @@ pub fn decodeInternal(this: *ColumnDefinition41, comptime Context: type, reader:
     this.flags = ColumnFlags.fromInt(try reader.int(u16));
     this.decimals = try reader.int(u8);
 
+    this.name_or_index.deinit();
     this.name_or_index = try ColumnIdentifier.init(this.name);
 
     // https://mariadb.com/kb/en/result-set-packets/#column-definition-packet

--- a/src/sql/mysql/protocol/PreparedStatement.zig
+++ b/src/sql/mysql/protocol/PreparedStatement.zig
@@ -41,6 +41,9 @@ pub const Execute = struct {
         for (this.params) |*param| {
             param.deinit(bun.default_allocator);
         }
+        if (this.params.len > 0) {
+            bun.default_allocator.free(this.params);
+        }
     }
 
     fn writeNullBitmap(this: *const Execute, comptime Context: type, writer: NewWriter(Context)) AnyMySQLError.Error!void {

--- a/test/regression/issue/28632.test.ts
+++ b/test/regression/issue/28632.test.ts
@@ -70,4 +70,4 @@ test("bun:sql MySQL prepared statement should not leak on repeated queries", asy
     await sql`DROP TABLE IF EXISTS leak_test_28632`.catch(() => {});
     await sql.close();
   }
-}, 300_000);
+});

--- a/test/regression/issue/28632.test.ts
+++ b/test/regression/issue/28632.test.ts
@@ -1,73 +1,75 @@
+// https://github.com/oven-sh/bun/issues/28632
 import { SQL } from "bun";
-import { expect, test } from "bun:test";
+import { beforeAll, expect, test } from "bun:test";
+import { describeWithContainer, isDockerEnabled } from "harness";
 
-// This test verifies that repeated MySQL queries don't leak memory per-query.
-// The root cause was ColumnDefinition41.name_or_index (heap-allocated via
-// toOwned()) not being freed on re-decode when a prepared statement is reused,
-// and not being freed in deinit() either. Also Execute.deinit() didn't free
-// the params slice.
-//
-// Uses a 50-column table to amplify the per-query leak signal: each query
-// re-decodes all column definitions, and without the fix, each column's
-// name_or_index allocation leaks.
-test("bun:sql MySQL prepared statement should not leak on repeated queries", async () => {
-  const sql = new SQL({
-    adapter: "mysql",
-    host: "127.0.0.1",
-    port: 3306,
-    username: "root",
-    password: "testpass",
-    database: "testdb",
-  });
+if (isDockerEnabled()) {
+  describeWithContainer(
+    "issue #28632: MySQL adapter should not leak memory on repeated queries",
+    {
+      image: "mysql_plain",
+      concurrent: true,
+    },
+    (container) => {
+      let sql: SQL;
 
-  try {
-    // Create a wide table to amplify the per-column leak
-    await sql`DROP TABLE IF EXISTS leak_test_28632`;
-    await sql`CREATE TABLE leak_test_28632 (
-      primary_id VARCHAR(255) PRIMARY KEY,
-      column_alpha_bravo TEXT, column_charlie_delta TEXT, column_echo_foxtrot TEXT,
-      column_golf_hotel TEXT, column_india_juliet TEXT, column_kilo_lima TEXT,
-      column_mike_november TEXT, column_oscar_papa TEXT, column_quebec_romeo TEXT,
-      column_sierra_tango TEXT, column_uniform_victor TEXT, column_whiskey_xray TEXT,
-      column_yankee_zulu TEXT, column_one_two_three TEXT, column_four_five_six TEXT,
-      column_seven_eight TEXT, column_nine_ten TEXT, column_eleven_twelve TEXT,
-      column_thirteen_fourtn TEXT, column_fifteen_sixtn TEXT, column_seventeen TEXT,
-      column_eighteen TEXT, column_nineteen TEXT, column_twenty_extra TEXT,
-      column_twentyone TEXT, column_twentytwo TEXT, column_twentythree TEXT,
-      column_twentyfour TEXT, column_twentyfive TEXT, column_twentysix TEXT,
-      column_twentyseven TEXT, column_twentyeight TEXT, column_twentynine TEXT,
-      column_thirty_extra TEXT, column_thirtyone TEXT, column_thirtytwo TEXT,
-      column_thirtythree TEXT, column_thirtyfour TEXT, column_thirtyfive TEXT,
-      column_thirtysix TEXT, column_thirtyseven TEXT, column_thirtyeight TEXT,
-      column_thirtynine TEXT, column_forty_extra TEXT, column_fortyone TEXT,
-      column_fortytwo TEXT, column_fortythree TEXT, column_fortyfour TEXT,
-      column_fortyfive TEXT
-    )`;
-    await sql`INSERT INTO leak_test_28632 (primary_id) VALUES ('123')`;
+      beforeAll(async () => {
+        await container.ready;
+        sql = new SQL({
+          url: `mysql://root@${container.host}:${container.port}/bun_sql_test`,
+          max: 1,
+        });
+      });
 
-    // Warm up to stabilize RSS
-    for (let i = 0; i < 500; i++) {
-      await sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`;
-    }
-    Bun.gc(true);
-    await Bun.sleep(50);
-    const rssAfterWarmup = process.memoryUsage.rss();
+      test("prepared statement re-execution should not leak name_or_index", async () => {
+        // Create a wide table to amplify the per-column leak signal
+        await sql`DROP TABLE IF EXISTS leak_test_28632`;
+        await sql`CREATE TABLE leak_test_28632 (
+          primary_id VARCHAR(255) PRIMARY KEY,
+          column_alpha_bravo TEXT, column_charlie_delta TEXT, column_echo_foxtrot TEXT,
+          column_golf_hotel TEXT, column_india_juliet TEXT, column_kilo_lima TEXT,
+          column_mike_november TEXT, column_oscar_papa TEXT, column_quebec_romeo TEXT,
+          column_sierra_tango TEXT, column_uniform_victor TEXT, column_whiskey_xray TEXT,
+          column_yankee_zulu TEXT, column_one_two_three TEXT, column_four_five_six TEXT,
+          column_seven_eight TEXT, column_nine_ten TEXT, column_eleven_twelve TEXT,
+          column_thirteen_fourtn TEXT, column_fifteen_sixtn TEXT, column_seventeen TEXT,
+          column_eighteen TEXT, column_nineteen TEXT, column_twenty_extra TEXT,
+          column_twentyone TEXT, column_twentytwo TEXT, column_twentythree TEXT,
+          column_twentyfour TEXT, column_twentyfive TEXT, column_twentysix TEXT,
+          column_twentyseven TEXT, column_twentyeight TEXT, column_twentynine TEXT,
+          column_thirty_extra TEXT, column_thirtyone TEXT, column_thirtytwo TEXT,
+          column_thirtythree TEXT, column_thirtyfour TEXT, column_thirtyfive TEXT,
+          column_thirtysix TEXT, column_thirtyseven TEXT, column_thirtyeight TEXT,
+          column_thirtynine TEXT, column_forty_extra TEXT, column_fortyone TEXT,
+          column_fortytwo TEXT, column_fortythree TEXT, column_fortyfour TEXT,
+          column_fortyfive TEXT
+        )`;
+        await sql`INSERT INTO leak_test_28632 (primary_id) VALUES ('123')`;
 
-    // Run queries — each re-decodes 50 column definitions
-    for (let i = 0; i < 5000; i++) {
-      await sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`;
-    }
-    Bun.gc(true);
-    await Bun.sleep(50);
-    const rssAfterQueries = process.memoryUsage.rss();
+        // Warm up to stabilize RSS
+        for (let i = 0; i < 500; i++) {
+          await sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`;
+        }
+        Bun.gc(true);
+        await Bun.sleep(50);
+        const rssAfterWarmup = process.memoryUsage.rss();
 
-    const growthMB = (rssAfterQueries - rssAfterWarmup) / 1024 / 1024;
+        // Run queries — each re-decodes 50 column definitions
+        for (let i = 0; i < 5000; i++) {
+          await sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`;
+        }
+        Bun.gc(true);
+        await Bun.sleep(50);
+        const rssAfterQueries = process.memoryUsage.rss();
 
-    // Without the fix, ~17MB growth (50 leaked name_or_index allocs × 5000 queries).
-    // With the fix, ~7MB (allocator noise + ASAN shadow memory).
-    expect(growthMB).toBeLessThan(12);
-  } finally {
-    await sql`DROP TABLE IF EXISTS leak_test_28632`.catch(() => {});
-    await sql.close();
-  }
-});
+        const growthMB = (rssAfterQueries - rssAfterWarmup) / 1024 / 1024;
+
+        // Without the fix, ~17MB growth (50 leaked name_or_index allocs × 5000 queries).
+        // With the fix, ~7MB (allocator noise + ASAN shadow memory).
+        expect(growthMB).toBeLessThan(12);
+
+        await sql`DROP TABLE IF EXISTS leak_test_28632`.catch(() => {});
+      });
+    },
+  );
+}

--- a/test/regression/issue/28632.test.ts
+++ b/test/regression/issue/28632.test.ts
@@ -10,7 +10,7 @@ if (isDockerEnabled()) {
       image: "mysql_plain",
       concurrent: true,
     },
-    (container) => {
+    container => {
       let sql: SQL;
 
       beforeAll(async () => {

--- a/test/regression/issue/28632.test.ts
+++ b/test/regression/issue/28632.test.ts
@@ -1,0 +1,74 @@
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// This test verifies that repeated MySQL queries don't leak memory per-query.
+// The root cause was ColumnDefinition41.name_or_index (heap-allocated via
+// toOwned()) not being freed on re-decode when a prepared statement is reused,
+// and not being freed in deinit() either. Also Execute.deinit() didn't free
+// the params slice.
+//
+// Uses a 50-column table to amplify the per-query leak signal: each query
+// re-decodes all column definitions, and without the fix, each column's
+// name_or_index allocation leaks.
+test("bun:sql MySQL prepared statement should not leak on repeated queries", async () => {
+  const sql = new SQL({
+    adapter: "mysql",
+    host: "127.0.0.1",
+    port: 3306,
+    username: "root",
+    password: "testpass",
+    database: "testdb",
+  });
+
+  try {
+    // Create a wide table to amplify the per-column leak
+    await sql`DROP TABLE IF EXISTS leak_test_28632`;
+    await sql`CREATE TABLE leak_test_28632 (
+      primary_id VARCHAR(255) PRIMARY KEY,
+      column_alpha_bravo TEXT, column_charlie_delta TEXT, column_echo_foxtrot TEXT,
+      column_golf_hotel TEXT, column_india_juliet TEXT, column_kilo_lima TEXT,
+      column_mike_november TEXT, column_oscar_papa TEXT, column_quebec_romeo TEXT,
+      column_sierra_tango TEXT, column_uniform_victor TEXT, column_whiskey_xray TEXT,
+      column_yankee_zulu TEXT, column_one_two_three TEXT, column_four_five_six TEXT,
+      column_seven_eight TEXT, column_nine_ten TEXT, column_eleven_twelve TEXT,
+      column_thirteen_fourtn TEXT, column_fifteen_sixtn TEXT, column_seventeen TEXT,
+      column_eighteen TEXT, column_nineteen TEXT, column_twenty_extra TEXT,
+      column_twentyone TEXT, column_twentytwo TEXT, column_twentythree TEXT,
+      column_twentyfour TEXT, column_twentyfive TEXT, column_twentysix TEXT,
+      column_twentyseven TEXT, column_twentyeight TEXT, column_twentynine TEXT,
+      column_thirty_extra TEXT, column_thirtyone TEXT, column_thirtytwo TEXT,
+      column_thirtythree TEXT, column_thirtyfour TEXT, column_thirtyfive TEXT,
+      column_thirtysix TEXT, column_thirtyseven TEXT, column_thirtyeight TEXT,
+      column_thirtynine TEXT, column_forty_extra TEXT, column_fortyone TEXT,
+      column_fortytwo TEXT, column_fortythree TEXT, column_fortyfour TEXT,
+      column_fortyfive TEXT
+    )`;
+    await sql`INSERT INTO leak_test_28632 (primary_id) VALUES ('123')`;
+
+    // Warm up to stabilize RSS
+    for (let i = 0; i < 500; i++) {
+      await sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`;
+    }
+    Bun.gc(true);
+    await Bun.sleep(50);
+    const rssAfterWarmup = process.memoryUsage.rss();
+
+    // Run queries — each re-decodes 50 column definitions
+    for (let i = 0; i < 5000; i++) {
+      await sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`;
+    }
+    Bun.gc(true);
+    await Bun.sleep(50);
+    const rssAfterQueries = process.memoryUsage.rss();
+
+    const growthMB = (rssAfterQueries - rssAfterWarmup) / 1024 / 1024;
+
+    // Without the fix, ~17MB growth (50 leaked name_or_index allocs × 5000 queries).
+    // With the fix, ~7MB (allocator noise + ASAN shadow memory).
+    expect(growthMB).toBeLessThan(12);
+  } finally {
+    await sql`DROP TABLE IF EXISTS leak_test_28632`.catch(() => {});
+    await sql.close();
+  }
+}, 300_000);

--- a/test/regression/issue/28632.test.ts
+++ b/test/regression/issue/28632.test.ts
@@ -1,6 +1,5 @@
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
 
 // This test verifies that repeated MySQL queries don't leak memory per-query.
 // The root cause was ColumnDefinition41.name_or_index (heap-allocated via


### PR DESCRIPTION
Fixes #28632

## Problem

The `bun:sql` MySQL adapter leaks memory on every query execution, causing RSS to grow monotonically until OOM on Linux. The JS heap stays stable — the leak is in native Zig allocations.

## Root cause

Three separate leaks, all in the MySQL protocol handling:

1. **`ColumnDefinition41.deinit()` did not free `name_or_index`** — The `name_or_index` field holds a heap-allocated copy of the column name (created via `ColumnIdentifier.init()` → `Data.toOwned()`), but `deinit()` only freed the other `Data` fields (catalog, schema, table, etc.), not `name_or_index`. This leaked on every final cleanup.

2. **`ColumnDefinition41.decodeInternal()` overwrote `name_or_index` without freeing the old value** — When a prepared statement is reused (same column count), the MySQL server re-sends column definitions with each COM_STMT_EXECUTE response. `decodeInternal()` assigned a new `name_or_index` on each re-decode without freeing the previous heap allocation. **This leaked one allocation per column per query execution** — the primary cause of the reported unbounded RSS growth.

3. **`PreparedStatement.Execute.deinit()` didn't free the `params` slice** — The `bind()` function allocates a `[]Value` array for query parameters. `Execute.deinit()` freed each individual `Value` but not the slice itself, leaking the array allocation on every parameterized query.

Also fixed `checkForDuplicateFields()` overwriting `name_or_index` to `.duplicate` without freeing the old owned data.

## Fix

- Add `this.name_or_index.deinit()` to `ColumnDefinition41.deinit()`
- Add `this.name_or_index.deinit()` before reassignment in `decodeInternal()`
- Add `bun.default_allocator.free(this.params)` to `Execute.deinit()`
- Add `field.name_or_index.deinit()` before `.duplicate` assignment in `checkForDuplicateFields()`

## Verification

```
# System bun (unfixed), 5000 queries on 50-column table:
Growth: 17.48 MB

# Debug bun (fixed), same test:
Growth: 6.93 MB
```

`bun bd test test/regression/issue/28632.test.ts` — passes with fix, fails without.