### PR TITLE
fix: CJS errors silently swallowed in bun -e mode

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -3352,12 +3352,6 @@ JSC::EncodedJSValue ZigString__toRangeErrorInstance(const ZigString* str, JSC::J
     return JSC::JSValue::encode(Zig::getRangeErrorInstance(str, globalObject));
 }
 
-static JSC::EncodedJSValue resolverFunctionCallback(JSC::JSGlobalObject* globalObject,
-    JSC::CallFrame* callFrame)
-{
-    return JSC::JSValue::encode(JSC::jsUndefined());
-}
-
 JSC::JSInternalPromise*
 JSC__JSModuleLoader__loadAndEvaluateModule(JSC::JSGlobalObject* globalObject,
     const BunString* arg1)
@@ -3370,12 +3364,17 @@ JSC__JSModuleLoader__loadAndEvaluateModule(JSC::JSGlobalObject* globalObject,
     EXCEPTION_ASSERT(!!promise == !scope.exception());
     if (!promise) return nullptr;
 
-    JSC::JSNativeStdFunction* resolverFunction = JSC::JSNativeStdFunction::create(
-        vm, globalObject, 1, String(), resolverFunctionCallback);
-
-    auto* newPromise = promise->then(globalObject, resolverFunction, globalObject->promiseEmptyOnRejectedFunction());
-    EXCEPTION_ASSERT(!!scope.exception() == !newPromise);
-    return newPromise;
+    // Return the promise directly without chaining .then().
+    // Previously, this used promise->then(resolver, promiseEmptyOnRejectedFunction()),
+    // which converted rejections into fulfilled promises with undefined.
+    // This caused CJS module evaluation errors to be silently swallowed in `bun -e`
+    // mode, because CJS modules are evaluated via SyntheticSourceProvider whose
+    // errors only propagate through the promise chain (unlike ESM errors which also
+    // propagate as synchronous exceptions during microtask draining).
+    // The resolver just returned undefined (result was never used by callers),
+    // and JSInternalPromise rejections are already excluded from the unhandled
+    // rejection tracker, so the .then() chain served no purpose.
+    return promise;
 }
 #pragma mark - JSC::JSPromise
 

--- a/test/js/bun/eval-cjs-error.test.ts
+++ b/test/js/bun/eval-cjs-error.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { join } from "path";
+
+describe("bun -e CJS error propagation", () => {
+  test("throw in CJS mode (require) exits with code 1", () => {
+    const { exitCode, stderr } = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "require('fs'); throw new Error('cjs-error-test')"],
+      env: bunEnv,
+    });
+    expect(stderr.toString()).toInclude("cjs-error-test");
+    expect(exitCode).toBe(1);
+  });
+
+  test("throw in CJS mode (module.exports) exits with code 1", () => {
+    const { exitCode, stderr } = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "module.exports = {}; throw new Error('cjs-module-exports')"],
+      env: bunEnv,
+    });
+    expect(stderr.toString()).toInclude("cjs-module-exports");
+    expect(exitCode).toBe(1);
+  });
+
+  test("throw in CJS mode (exports) exits with code 1", () => {
+    const { exitCode, stderr } = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "exports.foo = 1; throw new Error('cjs-exports')"],
+      env: bunEnv,
+    });
+    expect(stderr.toString()).toInclude("cjs-exports");
+    expect(exitCode).toBe(1);
+  });
+
+  test("throw in CJS mode (__dirname) exits with code 1", () => {
+    const { exitCode, stderr } = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "__dirname; throw new Error('cjs-dirname')"],
+      env: bunEnv,
+    });
+    expect(stderr.toString()).toInclude("cjs-dirname");
+    expect(exitCode).toBe(1);
+  });
+
+  test("throw in CJS mode (__filename) exits with code 1", () => {
+    const { exitCode, stderr } = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "__filename; throw new Error('cjs-filename')"],
+      env: bunEnv,
+    });
+    expect(stderr.toString()).toInclude("cjs-filename");
+    expect(exitCode).toBe(1);
+  });
+
+  test("SyntaxError in new Function with literal string exits with code 1", () => {
+    const { exitCode, stderr } = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "new Function('let a=1,a=2')"],
+      env: bunEnv,
+    });
+    expect(stderr.toString()).toInclude("SyntaxError");
+    expect(exitCode).toBe(1);
+  });
+
+  test("SyntaxError in new Function via readFileSync exits with code 1", () => {
+    const dir = tempDirWithFiles("eval-cjs-syntax", {
+      "bad.js": "let a=1,a=2",
+    });
+    const filePath = join(dir, "bad.js");
+    const { exitCode, stderr } = Bun.spawnSync({
+      cmd: [
+        bunExe(),
+        "-e",
+        `new Function(require('fs').readFileSync(${JSON.stringify(filePath)},'utf8'))`,
+      ],
+      env: bunEnv,
+    });
+    expect(stderr.toString()).toInclude("SyntaxError");
+    expect(exitCode).toBe(1);
+  });
+
+  test("throw in ESM mode still works (regression check)", () => {
+    const { exitCode, stderr } = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "throw new Error('esm-error-test')"],
+      env: bunEnv,
+    });
+    expect(stderr.toString()).toInclude("esm-error-test");
+    expect(exitCode).toBe(1);
+  });
+
+  test("throw in ESM mode with import still works (regression check)", () => {
+    const { exitCode, stderr } = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "import 'fs'; throw new Error('esm-import-error')"],
+      env: bunEnv,
+    });
+    expect(stderr.toString()).toInclude("esm-import-error");
+    expect(exitCode).toBe(1);
+  });
+
+  test("successful CJS eval exits with code 0", () => {
+    const { exitCode, stdout } = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "require('fs'); console.log('ok')"],
+      env: bunEnv,
+    });
+    expect(stdout.toString().trim()).toBe("ok");
+    expect(exitCode).toBe(0);
+  });
+
+  test("successful ESM eval exits with code 0", () => {
+    const { exitCode, stdout } = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "console.log('ok')"],
+      env: bunEnv,
+    });
+    expect(stdout.toString().trim()).toBe("ok");
+    expect(exitCode).toBe(0);
+  });
+
+  test("setTimeout throw in CJS mode works (not affected by this bug)", () => {
+    const { exitCode, stderr } = Bun.spawnSync({
+      cmd: [
+        bunExe(),
+        "-e",
+        "require('fs'); setTimeout(() => { throw new Error('delayed-error') }, 10)",
+      ],
+      env: bunEnv,
+    });
+    expect(stderr.toString()).toInclude("delayed-error");
+    expect(exitCode).toBe(1);
+  });
+
+  test("process.exitCode is respected in CJS mode on success", () => {
+    const { exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "require('fs'); process.exitCode = 42"],
+      env: bunEnv,
+    });
+    expect(exitCode).toBe(42);
+  });
+
+  test("uncaughtException handler is invoked in CJS -e evaluation errors", () => {
+    const { exitCode, stdout } = Bun.spawnSync({
+      cmd: [
+        bunExe(),
+        "-e",
+        "process.on('uncaughtException', e => { console.log('HANDLED'); process.exit(0); }); require('fs'); throw new Error('cjs-uncaught')",
+      ],
+      env: bunEnv,
+    });
+    expect(stdout.toString()).toInclude("HANDLED");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

`bun -e` silently swallows all errors when the code is detected as CommonJS. Exit code is 0, no error output, no event handlers fire. Any use of `require()`, `module.exports`, `exports`, `__dirname`, or `__filename` triggers this.

## Reproduction

```bash
# Works correctly (ESM, no CJS features):
bun -e "throw new Error('test')"
# exit code: 1, error printed

# Bug (CJS mode, require triggers CJS detection):
bun -e "require('fs'); throw new Error('test')"
# exit code: 0, no error output

# Same with other CJS features:
bun -e "module.exports = {}; throw new Error('test')"    # exit 0
bun -e "__dirname; throw new Error('test')"               # exit 0

# new Function() SyntaxError also swallowed:
echo 'let a=1,a=2' > /tmp/bad.js
bun -e "new Function(require('fs').readFileSync('/tmp/bad.js','utf8'))"  # exit 0
```

Node.js handles all of these correctly (exit 1).

## Root cause

`JSC__JSModuleLoader__loadAndEvaluateModule` in `bindings.cpp` chained `.then(resolver, promiseEmptyOnRejectedFunction())` on the module loading promise. The `promiseEmptyOnRejectedFunction` handler converted CJS evaluation rejections into fulfilled promises (returning `undefined`), so the Zig-side error handler (`promise.status() == .rejected`) never saw the error.

ESM errors are unaffected because they propagate as synchronous exceptions during microtask draining (caught by `drainMicrotasks` in `ZigGlobalObject.cpp`), independently of the promise chain. CJS errors only propagate through the promise chain via `SyntheticSourceProvider`, where the rejection handler swallowed them.

## Fix

Return the original promise directly instead of chaining `.then()`. The resolver callback just returned `undefined` (never used by callers), and `JSInternalPromise` rejections are already excluded from the unhandled rejection tracker (`promiseRejectionTracker` in `ZigGlobalObject.cpp` returns early for `JSInternalPromise`).

Deleted the unused `resolverFunctionCallback` function.

Note: `src/bun.js/modules/NodeModuleModule.cpp` line 804 has the same `.then()` pattern in `jsFunctionRunMain` -- separate fix needed for that path.

## Tests

Added `test/js/bun/eval-cjs-error.test.ts` with 12 test cases covering:
- CJS error propagation with require, module.exports, exports, __dirname, __filename
- SyntaxError via new Function + readFileSync
- ESM regression checks (throw, import + throw)
- Successful CJS/ESM eval (exit 0)
- setTimeout throw in CJS mode (already worked, not affected)
- process.exitCode in CJS mode