### PR TITLE
Flush FileSink in process.stdout._final before end() callback fires

### DIFF
--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -87,7 +87,10 @@ export function getStdioWriteStream(
       if (sink && sink !== true) {
         const result = sink.flush();
         if ($isPromise(result)) {
-          result.then(() => cb(null), (err) => cb(err));
+          result.then(
+            () => cb(null),
+            err => cb(err),
+          );
           return;
         }
       }

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -80,6 +80,19 @@ export function getStdioWriteStream(
         });
       }
     };
+
+    const kFastPath = require("internal/fs/streams").kWriteStreamFastPath;
+    stream._final = function (cb) {
+      const sink = this[kFastPath];
+      if (sink && sink !== true) {
+        const result = sink.flush();
+        if ($isPromise(result)) {
+          result.then(() => cb(null), (err) => cb(err));
+          return;
+        }
+      }
+      cb(null);
+    };
   }
 
   stream._isStdio = true;

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -83,18 +83,22 @@ export function getStdioWriteStream(
 
     const kFastPath = require("internal/fs/streams").kWriteStreamFastPath;
     stream._final = function (cb) {
-      const sink = this[kFastPath];
-      if (sink && sink !== true) {
-        const result = sink.flush();
-        if ($isPromise(result)) {
-          result.then(
-            () => cb(null),
-            err => cb(err),
-          );
-          return;
+      try {
+        const sink = this[kFastPath];
+        if (sink && sink !== true) {
+          const result = sink.flush();
+          if ($isPromise(result)) {
+            result.then(
+              () => cb(null),
+              err => cb(err),
+            );
+            return;
+          }
         }
+        cb(null);
+      } catch (err) {
+        cb(err);
       }
-      cb(null);
     };
   }
 

--- a/test/regression/issue/25432.test.ts
+++ b/test/regression/issue/25432.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import path from "node:path";
 

--- a/test/regression/issue/25432.test.ts
+++ b/test/regression/issue/25432.test.ts
@@ -1,0 +1,60 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
+
+describe("process.stdout.end() flushes pending writes before callback", () => {
+  test("large write followed by end() with process.exit in callback", async () => {
+    using dir = tempDir("issue-25432", {
+      "test.js": `
+        const output = Buffer.alloc(200000, 120).toString() + "\\n";
+        process.stdout.write(output);
+        process.stdout.end(() => { process.exit(0); });
+      `,
+    });
+
+    // Use a shell pipe to detect truncation — Bun.spawn's own pipe reader
+    // doesn't reproduce the issue because it drains fully after child exit.
+    const result = Bun.spawnSync({
+      cmd: ["sh", "-c", `"${bunExe()}" "${path.join(String(dir), "test.js")}" 2>/dev/null | wc -c`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const byteCount = parseInt(result.stdout.toString().trim(), 10);
+    expect(byteCount).toBe(200001);
+  });
+
+  test("overridden write with .bind() pattern from issue", async () => {
+    using dir = tempDir("issue-25432-bind", {
+      "test.js": `
+        const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+        process.stdout.write = function(chunk, ...args) {
+          return process.stderr.write(chunk, ...args);
+        };
+        const output = JSON.stringify({
+          items: Array.from({ length: 1000 }, (_, i) => ({
+            id: i,
+            name: "Item " + i,
+            description: "Description for item " + i + " with extra padding text to increase total size.",
+            metadata: { index: i, category: "Cat " + (i % 10) }
+          }))
+        }, null, 2);
+        originalStdoutWrite(output);
+        originalStdoutWrite("\\n");
+        process.stdout.end(() => { process.exit(0); });
+      `,
+    });
+
+    const result = Bun.spawnSync({
+      cmd: ["sh", "-c", `"${bunExe()}" "${path.join(String(dir), "test.js")}" 2>/dev/null | wc -c`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const byteCount = parseInt(result.stdout.toString().trim(), 10);
+    // The JSON output should be ~216KB, not truncated at 64KB/128KB
+    expect(byteCount).toBeGreaterThan(200000);
+  });
+});

--- a/test/regression/issue/25432.test.ts
+++ b/test/regression/issue/25432.test.ts
@@ -23,6 +23,7 @@ describe("process.stdout.end() flushes pending writes before callback", () => {
 
     const byteCount = parseInt(result.stdout.toString().trim(), 10);
     expect(byteCount).toBe(200001);
+    expect(result.exitCode).toBe(0);
   });
 
   test("overridden write with .bind() pattern from issue", async () => {
@@ -56,5 +57,6 @@ describe("process.stdout.end() flushes pending writes before callback", () => {
     const byteCount = parseInt(result.stdout.toString().trim(), 10);
     // The JSON output should be ~216KB, not truncated at 64KB/128KB
     expect(byteCount).toBeGreaterThan(200000);
+    expect(result.exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Problem

`process.stdout.end(callback)` fires `callback` before all data has been flushed through the pipe, causing truncation at power-of-2 boundaries (64KB, 128KB, etc.) when the callback calls `process.exit(0)`.

**Repro:**
```js
const output = "x".repeat(200000) + "\n";
process.stdout.write(output);
process.stdout.end(() => { process.exit(0); });
```
```
$ bun repro.js | wc -c
65536          # expected: 200001
```

Node.js outputs all 200001 bytes correctly.

## Root Cause

`process.stdout` uses a fast-path `writeFast()` that bypasses `Writable._writableState` tracking (never updates `pendingcb`). When `end()` is called, `finishMaybe()` sees `pendingcb === 0` and immediately schedules the finish callback — even though the underlying `FileSink` may still have buffered data waiting to be flushed through the pipe.

Additionally, `process.stdout` had no `_final` method defined. The `_final` hook is specifically designed for this purpose: it runs before the stream transitions to "finished" state, giving an opportunity to flush pending data.

## Fix

Add a `_final` method to `process.stdout` and `process.stderr` that calls `sink.flush()` on the underlying `FileSink`. If `flush()` returns a Promise (data still pending in the pipe buffer), the callback waits for it to resolve before the stream finishes.

Closes #25432