### PR TITLE
fix: let clientError handler send response before closing socket

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -409,6 +409,14 @@ private:
         if (httpErrorStatusCode) {
             if(httpContextData->onClientError) {
                 httpContextData->onClientError(SSL, s, result.parserError, data, length);
+                /* The handler takes responsibility for the socket lifecycle.
+                 * Unref so the socket doesn't keep the event loop alive
+                 * (balances the us_socket_ref at the top of on_data).
+                 * Uncork so any data written by the handler gets flushed.
+                 * uncork() is safe on a closed socket. */
+                us_socket_unref(s);
+                ((AsyncSocket<SSL> *) s)->uncork();
+                return s;
             }
             /* For errors, we only deliver them "at most once". We don't care if they get halfways delivered or not. */
             us_socket_write(s, httpErrorResponses[httpErrorStatusCode].data(), (int) httpErrorResponses[httpErrorStatusCode].length());

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -408,14 +408,17 @@ private:
         /* If we got fullptr that means the parser wants us to close the socket from error (same as calling the errorHandler) */
         if (httpErrorStatusCode) {
             if(httpContextData->onClientError) {
+                /* Uncork BEFORE calling onClientError so any corked responses
+                 * from prior pipelined requests in the same packet are flushed
+                 * to the kernel first — the JS handler's response goes through
+                 * the raw socket write path (not the cork buffer), so without
+                 * this the responses would be delivered out of order. */
+                ((AsyncSocket<SSL> *) s)->uncork();
                 httpContextData->onClientError(SSL, s, result.parserError, data, length);
                 /* The handler takes responsibility for the socket lifecycle.
                  * Unref so the socket doesn't keep the event loop alive
-                 * (balances the us_socket_ref at the top of on_data).
-                 * Uncork so any data written by the handler gets flushed.
-                 * uncork() is safe on a closed socket. */
+                 * (balances the us_socket_ref at the top of on_data). */
                 us_socket_unref(s);
-                ((AsyncSocket<SSL> *) s)->uncork();
                 return s;
             }
             /* For errors, we only deliver them "at most once". We don't care if they get halfways delivered or not. */

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -819,11 +819,42 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
       break;
   }
   err.rawPacket = rawPacket;
-  const nodeSocket = new NodeHTTPServerSocket(self, socket, ssl);
-  self.emit("connection", nodeSocket);
+  const handle = socket as any;
+  const existingSocket = handle?.duplex;
+  const nodeSocket = existingSocket ?? new NodeHTTPServerSocket(self, handle, ssl);
+  nodeSocket[kEnableStreaming](true);
+  if (!existingSocket) {
+    self.emit("connection", nodeSocket);
+  } else {
+    // Clear stale reference from a prior request so the old IncomingMessage
+    // can be GC'd (test-http-server-keepalive-req-gc relies on this).
+    nodeSocket[kRequest] = null;
+  }
+  // Use handle.bytesWritten (stream buffer counter) directly — the getter on
+  // nodeSocket goes through handle.response.getBytesWritten() which points to
+  // a stale response object on keep-alive connections.
+  const bytesBeforeEmit = handle?.bytesWritten ?? 0;
   self.emit("clientError", err, nodeSocket);
+  // Mirror Node.js: deliver the parse error to listeners attached via
+  // `server.on('connection', sock => sock.on('error', ...))`.
   if (nodeSocket.listenerCount("error") > 0) {
     nodeSocket.emit("error", err);
+  }
+  // If the socket is still writable and no response was sent, send a default error response.
+  if (!nodeSocket.writableEnded && !nodeSocket.destroyed) {
+    const bytesAfterEmit = handle?.bytesWritten ?? 0;
+    if (nodeSocket.writable && bytesAfterEmit === bytesBeforeEmit) {
+      // Match the status codes that uWS used to send directly (see packages/bun-uws/src/HttpErrors.h)
+      const response =
+        errorCode === HttpParserError.HTTP_PARSER_ERROR_INVALID_HTTP_VERSION
+          ? "HTTP/1.1 505 HTTP Version Not Supported\r\nConnection: close\r\n\r\n"
+          : errorCode === HttpParserError.HTTP_PARSER_ERROR_REQUEST_HEADER_FIELDS_TOO_LARGE
+            ? "HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n"
+            : "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n";
+      nodeSocket.end(response);
+    } else {
+      nodeSocket.end();
+    }
   }
 }
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -841,6 +841,9 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
     nodeSocket.emit("error", err);
   }
   // If the socket is still writable and no response was sent, send a default error response.
+  // Match Node.js `socketOnError`: write then destroy, which triggers us_socket_close()
+  // (graceful TCP close) rather than a half-close. This avoids FIN_WAIT_2 linger on
+  // keep-alive connections where the previous request set idleTimeout=0.
   if (!nodeSocket.writableEnded && !nodeSocket.destroyed) {
     const bytesAfterEmit = handle?.bytesWritten ?? 0;
     if (nodeSocket.writable && bytesAfterEmit === bytesBeforeEmit) {
@@ -851,10 +854,10 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
           : errorCode === HttpParserError.HTTP_PARSER_ERROR_REQUEST_HEADER_FIELDS_TOO_LARGE
             ? "HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n"
             : "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n";
-      nodeSocket.end(response);
-    } else {
-      nodeSocket.end();
+      nodeSocket.write(response);
     }
+    // No error arg: avoid an unhandled 'error' event if no listener is attached.
+    nodeSocket.destroy();
   }
 }
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -841,9 +841,10 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
     nodeSocket.emit("error", err);
   }
   // If the socket is still writable and no response was sent, send a default error response.
-  // Match Node.js `socketOnError`: write then destroy, which triggers us_socket_close()
-  // (graceful TCP close) rather than a half-close. This avoids FIN_WAIT_2 linger on
-  // keep-alive connections where the previous request set idleTimeout=0.
+  // Use end() so _final() → handle.end() → us_socket_shutdown() sends a graceful FIN.
+  // On Windows, us_socket_close() alone does not call shutdown() first, so using destroy()
+  // here would produce an abortive close (RST) on the client side on Windows libuv builds,
+  // breaking tests that assert `client.on('end')` fires.
   if (!nodeSocket.writableEnded && !nodeSocket.destroyed) {
     const bytesAfterEmit = handle?.bytesWritten ?? 0;
     if (nodeSocket.writable && bytesAfterEmit === bytesBeforeEmit) {
@@ -854,10 +855,10 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
           : errorCode === HttpParserError.HTTP_PARSER_ERROR_REQUEST_HEADER_FIELDS_TOO_LARGE
             ? "HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n"
             : "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n";
-      nodeSocket.write(response);
+      nodeSocket.end(response);
+    } else {
+      nodeSocket.end();
     }
-    // No error arg: avoid an unhandled 'error' event if no listener is attached.
-    nodeSocket.destroy();
   }
 }
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -841,12 +841,16 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
     nodeSocket.emit("error", err);
   }
   // If the socket is still writable and no response was sent, send a default error response.
-  // Use end() so _final() → handle.end() → us_socket_shutdown() sends a graceful FIN.
-  // On Windows, us_socket_close() alone does not call shutdown() first, so using destroy()
-  // here would produce an abortive close (RST) on the client side on Windows libuv builds,
-  // breaking tests that assert `client.on('end')` fires.
+  // Use end() first so _final() → handle.end() → us_socket_shutdown() sends a graceful FIN
+  // (required on Windows libuv where us_socket_close() alone does not call shutdown() and
+  // would produce an abortive close), then destroy() in the end callback to free the FD
+  // immediately — avoids FIN_WAIT_2 linger on keep-alive connections where idleTimeout=0.
+  // This mirrors pre-PR C++ behavior: write → shutdown → close.
   if (!nodeSocket.writableEnded && !nodeSocket.destroyed) {
     const bytesAfterEmit = handle?.bytesWritten ?? 0;
+    const destroyAfterFlush = () => {
+      if (!nodeSocket.destroyed) nodeSocket.destroy();
+    };
     if (nodeSocket.writable && bytesAfterEmit === bytesBeforeEmit) {
       // Match the status codes that uWS used to send directly (see packages/bun-uws/src/HttpErrors.h)
       const response =
@@ -855,9 +859,9 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
           : errorCode === HttpParserError.HTTP_PARSER_ERROR_REQUEST_HEADER_FIELDS_TOO_LARGE
             ? "HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n"
             : "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n";
-      nodeSocket.end(response);
+      nodeSocket.end(response, destroyAfterFlush);
     } else {
-      nodeSocket.end();
+      nodeSocket.end(undefined, destroyAfterFlush);
     }
   }
 }

--- a/test/regression/issue/28641.test.ts
+++ b/test/regression/issue/28641.test.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("http.createServer clientError handler can send 431 response", async () => {
+  await using server = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const http = require("http");
+const net = require("net");
+
+const server = http.createServer((req, res) => {
+  res.end("ok");
+});
+
+server.on("clientError", (err, socket) => {
+  if (!socket.destroyed) {
+    socket.end("HTTP/1.1 431 Header Too Large\\r\\nConnection: close\\r\\n\\r\\nHeader too large");
+  }
+});
+
+server.listen(0, () => {
+  const port = server.address().port;
+
+  const client = net.createConnection({ port, host: "127.0.0.1" }, () => {
+    const hugeHeader = Buffer.alloc(128 * 1024, 97).toString(); // 128KB of 'a'
+    client.write("GET / HTTP/1.1\\r\\nHost: localhost\\r\\nX-Huge: " + hugeHeader + "\\r\\n\\r\\n");
+  });
+
+  let data = "";
+  let finished = false;
+  const finish = (output) => {
+    if (finished) return;
+    finished = true;
+    process.stdout.write(output || data);
+    server.close();
+  };
+  client.on("data", (chunk) => { data += chunk.toString(); });
+  client.on("end", () => finish());
+  client.on("close", () => finish());
+  client.on("error", (err) => finish("ERROR:" + err.message));
+});
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+
+  const [stdout, exitCode] = await Promise.all([server.stdout.text(), server.exited]);
+
+  expect(stdout).toContain("431");
+  expect(stdout).toContain("Header too large");
+  expect(exitCode).toBe(0);
+});
+
+test("http.createServer sends default 431 for header overflow when no clientError listener", async () => {
+  await using server = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const http = require("http");
+const net = require("net");
+
+const server = http.createServer((req, res) => {
+  res.end("ok");
+});
+
+// No clientError listener — should get default 431 for header overflow
+
+server.listen(0, () => {
+  const port = server.address().port;
+
+  const client = net.createConnection({ port, host: "127.0.0.1" }, () => {
+    const hugeHeader = Buffer.alloc(128 * 1024, 97).toString();
+    client.write("GET / HTTP/1.1\\r\\nHost: localhost\\r\\nX-Huge: " + hugeHeader + "\\r\\n\\r\\n");
+  });
+
+  let data = "";
+  let finished = false;
+  const finish = (output) => {
+    if (finished) return;
+    finished = true;
+    process.stdout.write(output || data);
+    server.close();
+  };
+  client.on("data", (chunk) => { data += chunk.toString(); });
+  client.on("end", () => finish());
+  client.on("close", () => finish());
+  client.on("error", (err) => finish("ERROR:" + err.message));
+});
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+
+  const [stdout, exitCode] = await Promise.all([server.stdout.text(), server.exited]);
+
+  expect(stdout).toContain("431");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/28641.test.ts
+++ b/test/regression/issue/28641.test.ts
@@ -39,7 +39,7 @@ server.listen(0, () => {
   client.on("data", (chunk) => { data += chunk.toString(); });
   client.on("end", () => finish());
   client.on("close", () => finish());
-  client.on("error", (err) => finish("ERROR:" + err.message));
+  client.on("error", (err) => finish(data + "ERROR:" + err.message));
 });
 `,
     ],
@@ -89,7 +89,7 @@ server.listen(0, () => {
   client.on("data", (chunk) => { data += chunk.toString(); });
   client.on("end", () => finish());
   client.on("close", () => finish());
-  client.on("error", (err) => finish("ERROR:" + err.message));
+  client.on("error", (err) => finish(data + "ERROR:" + err.message));
 });
 `,
     ],


### PR DESCRIPTION
Fixes #28641

## Problem

When `http.createServer` receives a request with headers exceeding the size limit, the `clientError` event fires but uWebSockets immediately writes a default error response, shuts down the socket, and closes it. This prevents user code from sending a custom response (e.g. 431 Header Too Large).

**Expected (Node.js):** The `clientError` handler receives a writable socket, sends a custom response, and closes the socket itself.

**Actual (Bun):** The socket is destroyed before the handler's `socket.end(...)` can deliver data.

## Root Cause

In `packages/bun-uws/src/HttpContext.h`, after calling the `onClientError` callback, the code unconditionally:
1. Writes a default error response
2. Shuts down the socket
3. Closes the socket

Additionally, the `NodeHTTPServerSocket` created in the error path never had streaming enabled, so its `_write()` method was a no-op (it checks `handle.ondrain` before writing).

## Fix

1. **HttpContext.h**: When an `onClientError` handler is registered, call it and skip the automatic write/shutdown/close. The handler takes responsibility for the socket lifecycle. Uncork the socket so any data written by the handler gets flushed.

2. **_http_server.ts**: Enable streaming on the `NodeHTTPServerSocket` created in the error path so `_write()` can send data. When no `clientError` listener is attached, send a default 400 response matching Node.js behavior.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/regression/issue/28641.test.ts  → 2 FAIL
bun bd test test/regression/issue/28641.test.ts                → 2 PASS
```