### PR TITLE
fix: set .stack on system errors created without JS frames

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -2327,6 +2327,16 @@ JSC::EncodedJSValue SystemError__toErrorInstanceWithInfoObject(const SystemError
     info->putDirect(vm, clientData->builtinNames().errnoPublicName(), jsNumber(err.errno_), JSC::PropertyAttribute::DontDelete | 0);
     result->putDirect(vm, clientData->builtinNames().errnoPublicName(), jsNumber(err.errno_), JSC::PropertyAttribute::DontDelete | 0);
 
+    // ErrorInstance::create with {} always produces an empty stack trace, so
+    // .stack is never materialized by JSC. Set it explicitly to match Node.js.
+    if (auto* errorInstance = jsDynamicCast<JSC::ErrorInstance*>(result)) {
+        auto* stackTrace = errorInstance->stackTrace();
+        if (!stackTrace || stackTrace->isEmpty()) {
+            WTF::String stackString = message.isEmpty() ? "SystemError"_s : makeString("SystemError: "_s, message);
+            errorInstance->putDirect(vm, vm.propertyNames->stack, jsString(vm, stackString), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
+        }
+    }
+
     return JSC::JSValue::encode(result);
 }
 

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -2279,6 +2279,17 @@ JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::J
 
     result->putDirect(vm, names.errnoPublicName(), jsNumber(err.errno_), JSC::PropertyAttribute::DontDelete | 0);
 
+    // When this error is created from native async code (e.g. fs.readFile callback),
+    // there are no JS frames on the stack, so JSC's lazy stack materialization skips
+    // setting .stack entirely. Explicitly set it to "Error: <message>" to match Node.js.
+    if (auto* errorInstance = jsDynamicCast<JSC::ErrorInstance*>(result)) {
+        auto* stackTrace = errorInstance->stackTrace();
+        if (!stackTrace || stackTrace->isEmpty()) {
+            WTF::String stackString = message.isEmpty() ? "Error"_s : makeString("Error: "_s, message);
+            errorInstance->putDirect(vm, vm.propertyNames->stack, jsString(vm, stackString), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
+        }
+    }
+
     return JSC::JSValue::encode(result);
 }
 

--- a/test/regression/issue/28644.test.ts
+++ b/test/regression/issue/28644.test.ts
@@ -1,18 +1,24 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
 
 test("fs.readFile async error has .stack property", async () => {
+  using dir = tempDir("issue-28644", {});
+  const missingPath = join(String(dir), "no-such-file");
+
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `
       const fs = require('fs');
-      fs.readFile('nonexistentfile', (err) => {
+      fs.readFile(${JSON.stringify(missingPath)}, (err) => {
         if (!err) { process.exit(1); }
-        console.log(typeof err.stack);
-        console.log(err.stack);
-        console.log(err instanceof Error);
+        console.log(JSON.stringify({
+          type: typeof err.stack,
+          stack: err.stack,
+          isError: err instanceof Error,
+        }));
       });
       `,
     ],
@@ -23,25 +29,30 @@ test("fs.readFile async error has .stack property", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const lines = stdout.trim().split("\n");
-  expect(lines[0]).toBe("string");
-  expect(lines[1]).toContain("ENOENT");
-  expect(lines[1]).toContain("nonexistentfile");
-  expect(lines[2]).toBe("true");
+  const { type, stack, isError } = JSON.parse(stdout.trim());
+  expect(type).toBe("string");
+  expect(stack).toMatch(/^Error: /);
+  expect(stack).toContain("ENOENT");
+  expect(isError).toBe(true);
   expect(exitCode).toBe(0);
 });
 
 test("fs.stat async error has .stack property", async () => {
+  using dir = tempDir("issue-28644", {});
+  const missingPath = join(String(dir), "no-such-file");
+
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `
       const fs = require('fs');
-      fs.stat('nonexistentfile', (err) => {
+      fs.stat(${JSON.stringify(missingPath)}, (err) => {
         if (!err) { process.exit(1); }
-        console.log(typeof err.stack);
-        console.log(err.stack);
+        console.log(JSON.stringify({
+          type: typeof err.stack,
+          stack: err.stack,
+        }));
       });
       `,
     ],
@@ -52,22 +63,28 @@ test("fs.stat async error has .stack property", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const lines = stdout.trim().split("\n");
-  expect(lines[0]).toBe("string");
-  expect(lines[1]).toContain("ENOENT");
+  const { type, stack } = JSON.parse(stdout.trim());
+  expect(type).toBe("string");
+  expect(stack).toMatch(/^Error: /);
+  expect(stack).toContain("ENOENT");
   expect(exitCode).toBe(0);
 });
 
 test("fs.promises.readFile rejected error has .stack property", async () => {
+  using dir = tempDir("issue-28644", {});
+  const missingPath = join(String(dir), "no-such-file");
+
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `
       const fs = require('fs').promises;
-      fs.readFile('nonexistentfile').catch((err) => {
-        console.log(typeof err.stack);
-        console.log(err.stack);
+      fs.readFile(${JSON.stringify(missingPath)}).catch((err) => {
+        console.log(JSON.stringify({
+          type: typeof err.stack,
+          stack: err.stack,
+        }));
       });
       `,
     ],
@@ -78,23 +95,29 @@ test("fs.promises.readFile rejected error has .stack property", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const lines = stdout.trim().split("\n");
-  expect(lines[0]).toBe("string");
-  expect(lines[1]).toContain("ENOENT");
+  const { type, stack } = JSON.parse(stdout.trim());
+  expect(type).toBe("string");
+  expect(stack).toMatch(/^Error: /);
+  expect(stack).toContain("ENOENT");
   expect(exitCode).toBe(0);
 });
 
 test("fs.access async error has .stack property", async () => {
+  using dir = tempDir("issue-28644", {});
+  const missingPath = join(String(dir), "no-such-file");
+
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `
       const fs = require('fs');
-      fs.access('nonexistentfile', (err) => {
+      fs.access(${JSON.stringify(missingPath)}, (err) => {
         if (!err) { process.exit(1); }
-        console.log(typeof err.stack);
-        console.log(err.stack);
+        console.log(JSON.stringify({
+          type: typeof err.stack,
+          stack: err.stack,
+        }));
       });
       `,
     ],
@@ -105,8 +128,9 @@ test("fs.access async error has .stack property", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const lines = stdout.trim().split("\n");
-  expect(lines[0]).toBe("string");
-  expect(lines[1]).toContain("ENOENT");
+  const { type, stack } = JSON.parse(stdout.trim());
+  expect(type).toBe("string");
+  expect(stack).toMatch(/^Error: /);
+  expect(stack).toContain("ENOENT");
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/28644.test.ts
+++ b/test/regression/issue/28644.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("fs.readFile async error has .stack property", async () => {

--- a/test/regression/issue/28644.test.ts
+++ b/test/regression/issue/28644.test.ts
@@ -1,0 +1,112 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("fs.readFile async error has .stack property", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const fs = require('fs');
+      fs.readFile('nonexistentfile', (err) => {
+        if (!err) { process.exit(1); }
+        console.log(typeof err.stack);
+        console.log(err.stack);
+        console.log(err instanceof Error);
+      });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const lines = stdout.trim().split("\n");
+  expect(lines[0]).toBe("string");
+  expect(lines[1]).toContain("ENOENT");
+  expect(lines[1]).toContain("nonexistentfile");
+  expect(lines[2]).toBe("true");
+  expect(exitCode).toBe(0);
+});
+
+test("fs.stat async error has .stack property", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const fs = require('fs');
+      fs.stat('nonexistentfile', (err) => {
+        if (!err) { process.exit(1); }
+        console.log(typeof err.stack);
+        console.log(err.stack);
+      });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const lines = stdout.trim().split("\n");
+  expect(lines[0]).toBe("string");
+  expect(lines[1]).toContain("ENOENT");
+  expect(exitCode).toBe(0);
+});
+
+test("fs.promises.readFile rejected error has .stack property", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const fs = require('fs').promises;
+      fs.readFile('nonexistentfile').catch((err) => {
+        console.log(typeof err.stack);
+        console.log(err.stack);
+      });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const lines = stdout.trim().split("\n");
+  expect(lines[0]).toBe("string");
+  expect(lines[1]).toContain("ENOENT");
+  expect(exitCode).toBe(0);
+});
+
+test("fs.access async error has .stack property", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const fs = require('fs');
+      fs.access('nonexistentfile', (err) => {
+        if (!err) { process.exit(1); }
+        console.log(typeof err.stack);
+        console.log(err.stack);
+      });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const lines = stdout.trim().split("\n");
+  expect(lines[0]).toBe("string");
+  expect(lines[1]).toContain("ENOENT");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Closes #28644

## Problem

`fs.readFile` (and other async fs APIs like `stat`, `access`, `promises.readFile`) invoke callbacks with an Error that has `undefined` for its `.stack` property, while Node.js always includes at least `"Error: <message>"`.

```js
fs.readFile('nonexistentfile', (err) => {
  console.log(err.stack); // undefined in Bun, string in Node.js
});
```

## Cause

`SystemError__toErrorInstance` creates errors via `JSC::createError()`, which captures the current JS call stack. When called from native async code (event loop task processing), there are no JS frames on the stack. JSC's `ErrorInstance::materializeErrorInfoIfNeeded` then skips setting `.stack` entirely when the captured trace is empty — the property is never put on the object.

## Fix

After creating the `ErrorInstance` in `SystemError__toErrorInstance`, check if the captured stack trace is empty. If so, explicitly set `.stack` to `"Error: <message>"` via `putDirect`, matching Node.js behavior where `.stack` always contains at least the error name and message.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28644.test.ts` → 4 fail (bug present)
- `bun bd test test/regression/issue/28644.test.ts` → 4 pass (fix works)

Tests cover: `fs.readFile`, `fs.stat`, `fs.access`, `fs.promises.readFile`