### PR TITLE
Fix deepEquals strict mode for Proxy-wrapped arrays and objects

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -734,12 +734,25 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     if (v1Array != v2Array)
         return false;
 
-    if (v1Array && v2Array && !(o1->isProxy() || o2->isProxy())) {
-        JSC::JSArray* array1 = JSC::jsCast<JSC::JSArray*>(v1);
-        JSC::JSArray* array2 = JSC::jsCast<JSC::JSArray*>(v2);
+    if (v1Array && v2Array) {
+        size_t array1Length;
+        size_t array2Length;
 
-        size_t array1Length = array1->length();
-        size_t array2Length = array2->length();
+        bool eitherIsProxy = o1->isProxy() || o2->isProxy();
+        if (!eitherIsProxy) {
+            array1Length = JSC::jsCast<JSC::JSArray*>(v1)->length();
+            array2Length = JSC::jsCast<JSC::JSArray*>(v2)->length();
+        } else {
+            JSValue len1 = o1->get(globalObject, vm.propertyNames->length);
+            RETURN_IF_EXCEPTION(scope, false);
+            array1Length = len1.toLength(globalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+
+            JSValue len2 = o2->get(globalObject, vm.propertyNames->length);
+            RETURN_IF_EXCEPTION(scope, false);
+            array2Length = len2.toLength(globalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+        }
         if constexpr (isStrict) {
             if (array1Length != array2Length) {
                 return false;
@@ -834,7 +847,15 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     }
 
     if constexpr (isStrict) {
-        if (!equal(JSObject::calculatedClassName(o1), JSObject::calculatedClassName(o2))) {
+        // Look through proxies to compare the target's class name rather than
+        // the proxy wrapper's, so that e.g. new Proxy({}, {}) equals {}.
+        JSObject* cn1 = o1;
+        JSObject* cn2 = o2;
+        if (cn1->type() == JSC::ProxyObjectType)
+            cn1 = jsCast<ProxyObject*>(cn1)->target();
+        if (cn2->type() == JSC::ProxyObjectType)
+            cn2 = jsCast<ProxyObject*>(cn2)->target();
+        if (!equal(JSObject::calculatedClassName(cn1), JSObject::calculatedClassName(cn2))) {
             return false;
         }
     }

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -851,6 +851,23 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             cn1 = jsCast<ProxyObject*>(cn1)->target();
         while (cn2->type() == JSC::ProxyObjectType)
             cn2 = jsCast<ProxyObject*>(cn2)->target();
+
+        // If unwrapping revealed a DOM wrapper or special type (URL, Headers,
+        // etc.), re-dispatch through specialObjectsDequal so semantic equality
+        // is used instead of generic property enumeration.
+        uint8_t cn1Type = cn1->type();
+        uint8_t cn2Type = cn2->type();
+        if (cn1Type == JSDOMWrapperType || cn1Type == JSAsJSONType
+            || cn2Type == JSDOMWrapperType || cn2Type == JSAsJSONType) {
+            std::optional<bool> result = specialObjectsDequal<isStrict, enableAsymmetricMatchers>(globalObject, gcBuffer, stack, scope, cn1, cn2);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (result.has_value()) return *result;
+            result = specialObjectsDequal<isStrict, enableAsymmetricMatchers>(globalObject, gcBuffer, stack, scope, cn2, cn1);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (result.has_value()) return *result;
+            return false;
+        }
+
         if (!equal(JSObject::calculatedClassName(cn1), JSObject::calculatedClassName(cn2))) {
             return false;
         }

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -753,6 +753,11 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             if (array1Length != array2Length) {
                 return false;
             }
+            // Check class names on the unwrapped targets so Array subclasses
+            // (e.g. class MyArr extends Array) are distinguished from Array.
+            if (!equal(JSObject::calculatedClassName(a1Obj), JSObject::calculatedClassName(a2Obj))) {
+                return false;
+            }
         }
 
         uint64_t i = 0;
@@ -865,7 +870,8 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             result = specialObjectsDequal<isStrict, enableAsymmetricMatchers>(globalObject, gcBuffer, stack, scope, cn2, cn1);
             RETURN_IF_EXCEPTION(scope, false);
             if (result.has_value()) return *result;
-            return false;
+            // nullopt means semantic check passed but own-property comparison
+            // is still needed — fall through to normal path.
         }
 
         if (!equal(JSObject::calculatedClassName(cn1), JSObject::calculatedClassName(cn2))) {

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -760,11 +760,14 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             }
         }
 
+        // Use unwrapped targets for element access so that sparse array holes
+        // are correctly detected as JSValue() (isEmpty), not as jsUndefined()
+        // which the proxy [[Get]] trap would return for missing indices.
         uint64_t i = 0;
         for (; i < array1Length; i++) {
-            JSValue left = getIndexWithoutAccessors(globalObject, o1, i);
+            JSValue left = getIndexWithoutAccessors(globalObject, a1Obj, i);
             RETURN_IF_EXCEPTION(scope, false);
-            JSValue right = getIndexWithoutAccessors(globalObject, o2, i);
+            JSValue right = getIndexWithoutAccessors(globalObject, a2Obj, i);
             RETURN_IF_EXCEPTION(scope, false);
 
             if constexpr (isStrict) {
@@ -788,7 +791,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         }
 
         for (; i < array2Length; i++) {
-            JSValue right = getIndexWithoutAccessors(globalObject, o2, i);
+            JSValue right = getIndexWithoutAccessors(globalObject, a2Obj, i);
             RETURN_IF_EXCEPTION(scope, false);
 
             if (((right.isEmpty() || right.isUndefined()))) {

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -738,21 +738,17 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         size_t array1Length;
         size_t array2Length;
 
-        bool eitherIsProxy = o1->isProxy() || o2->isProxy();
-        if (!eitherIsProxy) {
-            array1Length = JSC::jsCast<JSC::JSArray*>(v1)->length();
-            array2Length = JSC::jsCast<JSC::JSArray*>(v2)->length();
-        } else {
-            JSValue len1 = o1->get(globalObject, vm.propertyNames->length);
-            RETURN_IF_EXCEPTION(scope, false);
-            array1Length = len1.toLength(globalObject);
-            RETURN_IF_EXCEPTION(scope, false);
-
-            JSValue len2 = o2->get(globalObject, vm.propertyNames->length);
-            RETURN_IF_EXCEPTION(scope, false);
-            array2Length = len2.toLength(globalObject);
-            RETURN_IF_EXCEPTION(scope, false);
-        }
+        // For proxies wrapping arrays, unwrap to get the target JSArray's
+        // actual length rather than trusting the get trap, which could return
+        // an arbitrarily large value and cause a near-infinite loop.
+        JSObject* a1Obj = o1;
+        JSObject* a2Obj = o2;
+        while (a1Obj->type() == JSC::ProxyObjectType)
+            a1Obj = jsCast<ProxyObject*>(a1Obj)->target();
+        while (a2Obj->type() == JSC::ProxyObjectType)
+            a2Obj = jsCast<ProxyObject*>(a2Obj)->target();
+        array1Length = JSC::jsCast<JSC::JSArray*>(a1Obj)->length();
+        array2Length = JSC::jsCast<JSC::JSArray*>(a2Obj)->length();
         if constexpr (isStrict) {
             if (array1Length != array2Length) {
                 return false;
@@ -799,9 +795,9 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
 
         JSC::PropertyNameArrayBuilder a1(vm, PropertyNameMode::Symbols, PrivateSymbolMode::Exclude);
         JSC::PropertyNameArrayBuilder a2(vm, PropertyNameMode::Symbols, PrivateSymbolMode::Exclude);
-        JSObject::getOwnPropertyNames(o1, globalObject, a1, DontEnumPropertiesMode::Exclude);
+        o1->methodTable()->getOwnPropertyNames(o1, globalObject, a1, DontEnumPropertiesMode::Exclude);
         RETURN_IF_EXCEPTION(scope, false);
-        JSObject::getOwnPropertyNames(o2, globalObject, a2, DontEnumPropertiesMode::Exclude);
+        o2->methodTable()->getOwnPropertyNames(o2, globalObject, a2, DontEnumPropertiesMode::Exclude);
         RETURN_IF_EXCEPTION(scope, false);
 
         size_t propertyLength = a1.size();
@@ -851,9 +847,9 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         // the proxy wrapper's, so that e.g. new Proxy({}, {}) equals {}.
         JSObject* cn1 = o1;
         JSObject* cn2 = o2;
-        if (cn1->type() == JSC::ProxyObjectType)
+        while (cn1->type() == JSC::ProxyObjectType)
             cn1 = jsCast<ProxyObject*>(cn1)->target();
-        if (cn2->type() == JSC::ProxyObjectType)
+        while (cn2->type() == JSC::ProxyObjectType)
             cn2 = jsCast<ProxyObject*>(cn2)->target();
         if (!equal(JSObject::calculatedClassName(cn1), JSObject::calculatedClassName(cn2))) {
             return false;

--- a/test/regression/issue/28647.test.ts
+++ b/test/regression/issue/28647.test.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import assert from "node:assert";
 import { expect, test } from "bun:test";
 
 // https://github.com/oven-sh/bun/issues/28647

--- a/test/regression/issue/28647.test.ts
+++ b/test/regression/issue/28647.test.ts
@@ -96,6 +96,12 @@ test("nested Proxy chains compare correctly", () => {
   expect(Bun.deepEquals(tripleProxy, { x: "y" }, true)).toBe(true);
 });
 
+test("Proxy-wrapped Array subclass is not equal to plain Array in strict mode", () => {
+  class MyArr extends Array {}
+  expect(Bun.deepEquals(new Proxy(new MyArr(1, 2, 3), {}), [1, 2, 3], true)).toBe(false);
+  expect(Bun.deepEquals(new Proxy(new MyArr(1, 2, 3), {}), new MyArr(1, 2, 3), true)).toBe(true);
+});
+
 test("expect().toStrictEqual works with Proxy-wrapped values", () => {
   expect(new Proxy(["foo"], {})).toStrictEqual(["foo"]);
   expect(new Proxy({ a: 1 }, {})).toStrictEqual({ a: 1 });

--- a/test/regression/issue/28647.test.ts
+++ b/test/regression/issue/28647.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import assert from "assert";
 
 // https://github.com/oven-sh/bun/issues/28647
 // assert.deepStrictEqual incorrectly fails for Proxy-wrapped arrays/objects
@@ -44,12 +45,10 @@ test("Bun.deepEquals non-strict mode still works with proxies", () => {
 });
 
 test("assert.deepStrictEqual works with Proxy-wrapped arrays", () => {
-  const assert = require("assert");
   assert.deepStrictEqual(new Proxy(["foo"], {}), ["foo"]);
 });
 
 test("assert.deepStrictEqual works with Proxy-wrapped objects", () => {
-  const assert = require("assert");
   assert.deepStrictEqual(new Proxy({ a: 1 }, {}), { a: 1 });
 });
 
@@ -70,6 +69,21 @@ test("Proxy-wrapped nested structures compare correctly", () => {
   const nested = { arr: [1, 2], obj: { x: "y" } };
   const proxy = new Proxy(nested, {});
   expect(Bun.deepEquals(proxy, { arr: [1, 2], obj: { x: "y" } }, true)).toBe(true);
+});
+
+test("nested Proxy chains compare correctly", () => {
+  // Doubly-nested proxy around object
+  const nestedProxy = new Proxy(new Proxy({ a: 1 }, {}), {});
+  expect(Bun.deepEquals(nestedProxy, { a: 1 }, true)).toBe(true);
+  expect(Bun.deepEquals({ a: 1 }, nestedProxy, true)).toBe(true);
+
+  // Doubly-nested proxy around array
+  const nestedArrProxy = new Proxy(new Proxy([1, 2], {}), {});
+  expect(Bun.deepEquals(nestedArrProxy, [1, 2], true)).toBe(true);
+
+  // Triple-nested
+  const tripleProxy = new Proxy(new Proxy(new Proxy({ x: "y" }, {}), {}), {});
+  expect(Bun.deepEquals(tripleProxy, { x: "y" }, true)).toBe(true);
 });
 
 test("expect().toStrictEqual works with Proxy-wrapped values", () => {

--- a/test/regression/issue/28647.test.ts
+++ b/test/regression/issue/28647.test.ts
@@ -103,6 +103,9 @@ test("Proxy-wrapped Array subclass is not equal to plain Array in strict mode", 
 });
 
 test("expect().toStrictEqual works with Proxy-wrapped values", () => {
-  expect(new Proxy(["foo"], {})).toStrictEqual(["foo"]);
-  expect(new Proxy({ a: 1 }, {})).toStrictEqual({ a: 1 });
+  // Use variables to keep the proxy alive during comparison
+  const proxyArr = new Proxy(["foo"], {});
+  const proxyObj = new Proxy({ a: 1 }, {});
+  expect(proxyArr).toStrictEqual(["foo"]);
+  expect(proxyObj).toStrictEqual({ a: 1 });
 });

--- a/test/regression/issue/28647.test.ts
+++ b/test/regression/issue/28647.test.ts
@@ -65,6 +65,16 @@ test("Proxy with trapping handler is compared correctly", () => {
   expect(Bun.deepEquals(proxyObj, { key: "value" }, true)).toBe(true);
 });
 
+test("deepEquals uses target array length, not spoofed proxy length", () => {
+  const spoofedLengthProxy = new Proxy([1, 2, 3], {
+    get(target: any, prop: string | symbol, receiver: any) {
+      if (prop === "length") return 1_000_000;
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+  expect(Bun.deepEquals(spoofedLengthProxy, [1, 2, 3], true)).toBe(true);
+});
+
 test("Proxy-wrapped nested structures compare correctly", () => {
   const nested = { arr: [1, 2], obj: { x: "y" } };
   const proxy = new Proxy(nested, {});

--- a/test/regression/issue/28647.test.ts
+++ b/test/regression/issue/28647.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "bun:test";
 import assert from "assert";
+import { expect, test } from "bun:test";
 
 // https://github.com/oven-sh/bun/issues/28647
 // assert.deepStrictEqual incorrectly fails for Proxy-wrapped arrays/objects

--- a/test/regression/issue/28647.test.ts
+++ b/test/regression/issue/28647.test.ts
@@ -1,5 +1,5 @@
-import assert from "node:assert";
 import { expect, test } from "bun:test";
+import assert from "node:assert";
 
 // https://github.com/oven-sh/bun/issues/28647
 // assert.deepStrictEqual incorrectly fails for Proxy-wrapped arrays/objects

--- a/test/regression/issue/28647.test.ts
+++ b/test/regression/issue/28647.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 // https://github.com/oven-sh/bun/issues/28647
 // assert.deepStrictEqual incorrectly fails for Proxy-wrapped arrays/objects

--- a/test/regression/issue/28647.test.ts
+++ b/test/regression/issue/28647.test.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/28647
+// assert.deepStrictEqual incorrectly fails for Proxy-wrapped arrays/objects
+
+test("Bun.deepEquals strict mode works with Proxy-wrapped arrays", () => {
+  const proxy = new Proxy(["foo"], {});
+  expect(Bun.deepEquals(proxy, ["foo"], true)).toBe(true);
+  expect(Bun.deepEquals(["foo"], proxy, true)).toBe(true);
+});
+
+test("Bun.deepEquals strict mode works with Proxy-wrapped objects", () => {
+  const proxy = new Proxy({ a: 1 }, {});
+  expect(Bun.deepEquals(proxy, { a: 1 }, true)).toBe(true);
+  expect(Bun.deepEquals({ a: 1 }, proxy, true)).toBe(true);
+});
+
+test("Bun.deepEquals strict mode works with both sides being proxies", () => {
+  const proxy1 = new Proxy(["foo", "bar"], {});
+  const proxy2 = new Proxy(["foo", "bar"], {});
+  expect(Bun.deepEquals(proxy1, proxy2, true)).toBe(true);
+
+  const proxyObj1 = new Proxy({ x: 1 }, {});
+  const proxyObj2 = new Proxy({ x: 1 }, {});
+  expect(Bun.deepEquals(proxyObj1, proxyObj2, true)).toBe(true);
+});
+
+test("Bun.deepEquals strict mode detects differences through proxies", () => {
+  // Different array contents
+  expect(Bun.deepEquals(new Proxy(["foo"], {}), ["bar"], true)).toBe(false);
+  // Different array lengths
+  expect(Bun.deepEquals(new Proxy(["foo", "bar"], {}), ["foo"], true)).toBe(false);
+  // Different object values
+  expect(Bun.deepEquals(new Proxy({ a: 1 }, {}), { a: 2 }, true)).toBe(false);
+  // Different object keys
+  expect(Bun.deepEquals(new Proxy({ a: 1 }, {}), { b: 1 }, true)).toBe(false);
+  // Array vs non-array
+  expect(Bun.deepEquals(new Proxy(["foo"], {}), { 0: "foo" }, true)).toBe(false);
+});
+
+test("Bun.deepEquals non-strict mode still works with proxies", () => {
+  expect(Bun.deepEquals(new Proxy(["foo"], {}), ["foo"], false)).toBe(true);
+  expect(Bun.deepEquals(new Proxy({ a: 1 }, {}), { a: 1 }, false)).toBe(true);
+});
+
+test("assert.deepStrictEqual works with Proxy-wrapped arrays", () => {
+  const assert = require("assert");
+  assert.deepStrictEqual(new Proxy(["foo"], {}), ["foo"]);
+});
+
+test("assert.deepStrictEqual works with Proxy-wrapped objects", () => {
+  const assert = require("assert");
+  assert.deepStrictEqual(new Proxy({ a: 1 }, {}), { a: 1 });
+});
+
+test("Proxy with trapping handler is compared correctly", () => {
+  const handler = {
+    get(target: any, prop: string | symbol, receiver: any) {
+      return Reflect.get(target, prop, receiver);
+    },
+  };
+  const proxy = new Proxy([1, 2, 3], handler);
+  expect(Bun.deepEquals(proxy, [1, 2, 3], true)).toBe(true);
+
+  const proxyObj = new Proxy({ key: "value" }, handler);
+  expect(Bun.deepEquals(proxyObj, { key: "value" }, true)).toBe(true);
+});
+
+test("Proxy-wrapped nested structures compare correctly", () => {
+  const nested = { arr: [1, 2], obj: { x: "y" } };
+  const proxy = new Proxy(nested, {});
+  expect(Bun.deepEquals(proxy, { arr: [1, 2], obj: { x: "y" } }, true)).toBe(true);
+});
+
+test("expect().toStrictEqual works with Proxy-wrapped values", () => {
+  expect(new Proxy(["foo"], {})).toStrictEqual(["foo"]);
+  expect(new Proxy({ a: 1 }, {})).toStrictEqual({ a: 1 });
+});


### PR DESCRIPTION
## Problem

`assert.deepStrictEqual` and `Bun.deepEquals(a, b, true)` incorrectly return `false` when comparing a Proxy-wrapped array or object to a structurally identical plain array or object.

```js
const assert = require("assert");
assert.deepStrictEqual(new Proxy(["foo"], {}), ["foo"]); // throws AssertionError
Bun.deepEquals(new Proxy({a: 1}, {}), {a: 1}, true);     // returns false
```

Node.js handles both cases correctly.

Closes #28647

## Root Cause

Two issues in `Bun__deepEquals` (`bindings.cpp`):

1. **Array path skipped for proxies**: The array comparison path required neither operand to be a proxy (`!(o1->isProxy() || o2->isProxy())`), since `jsCast<JSArray*>` is unsafe on proxy objects. When skipped, the code fell through to the generic object path which fails on the class name check.

2. **`calculatedClassName` mismatch**: In strict mode, the generic object path compares `calculatedClassName` of both objects. A `ProxyObject` wrapper has a different class name than `"Array"` or `"Object"`, so the comparison returned `false`.

## Fix

1. **Array path**: Remove the proxy exclusion. When either operand is a proxy, get `length` through property access (`o->get(globalObject, vm.propertyNames->length)`) instead of the `JSArray::length()` fast path. The rest of the array comparison already works through `JSObject*`.

2. **Class name check**: Look through `ProxyObject` to compare the *target*'s class name, so `new Proxy({}, {})` matches `{}` and `new Proxy([], {})` matches `[]`.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28647.test.ts` → 7 fail (bug exists)
- `bun bd test test/regression/issue/28647.test.ts` → 10 pass (fix works)
- `bun bd test test/js/bun/bun-object/deep-equals.spec.ts` → 36 pass, 0 fail (no regression)