### PR TITLE
Include async frames in Error.captureStackTrace

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "fc9f2fa7272fec64905df6a9c78e15d7912f14ca";
+export const WEBKIT_VERSION = "7da058f2ad4432ec5547dbfc3a5b6d544bb05d1d";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/bun.js/bindings/ErrorStackTrace.cpp
+++ b/src/bun.js/bindings/ErrorStackTrace.cpp
@@ -126,8 +126,14 @@ void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, J
     // built-in caller filtering skips entry-frame tracking during the skip phase,
     // which loses async frames when the caller is the innermost sync frame.
     // Instead we filter out frames up to and including the caller afterwards.
+    //
+    // Collect without a limit: stackTraceLimit must apply to visible frames
+    // AFTER Bun's post-filter and AFTER caller removal, not to raw frames from
+    // JSC. If the caller is deep, capping at stackTraceLimit here would collect
+    // only frames that get removed, leaving an empty trace. Stack depth is
+    // bounded by native stack size so this walk is still O(actual depth).
     WTF::Vector<JSC::StackFrame> rawFrames;
-    vm.interpreter.getStackTrace(owner, rawFrames, 1, stackTraceLimit);
+    vm.interpreter.getStackTrace(owner, rawFrames, 1, std::numeric_limits<size_t>::max());
 
     // JSC's getStackTrace uses StackVisitor::isImplementationVisibilityPrivate
     // which differs from Bun's helper — post-filter to keep behavior consistent
@@ -138,8 +144,11 @@ void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, J
             stackTrace.append(WTF::move(frame));
     }
 
-    if (!caller.isObject())
+    if (!caller.isObject()) {
+        if (stackTrace.size() > stackTraceLimit)
+            stackTrace.shrink(stackTraceLimit);
         return;
+    }
 
     JSC::JSObject* callerObject = caller.getObject();
     auto* globalObject = callerObject->globalObject();
@@ -168,6 +177,9 @@ void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, J
 
     if (removeCount > 0)
         stackTrace.removeAt(0, removeCount);
+
+    if (stackTrace.size() > stackTraceLimit)
+        stackTrace.shrink(stackTraceLimit);
 }
 
 JSCStackTrace JSCStackTrace::getStackTraceForThrownValue(JSC::VM& vm, JSC::JSValue thrownValue)

--- a/src/bun.js/bindings/ErrorStackTrace.cpp
+++ b/src/bun.js/bindings/ErrorStackTrace.cpp
@@ -19,6 +19,7 @@
 #include <JavaScriptCore/ErrorInstance.h>
 #include <JavaScriptCore/StackVisitor.h>
 #include <JavaScriptCore/NativeCallee.h>
+#include <JavaScriptCore/Interpreter.h>
 #include <wtf/IterationStatus.h>
 #include <JavaScriptCore/CodeBlock.h>
 #include <JavaScriptCore/FunctionCodeBlock.h>
@@ -114,144 +115,59 @@ JSCStackTrace JSCStackTrace::fromExisting(JSC::VM& vm, const WTF::Vector<JSC::St
 
 void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, JSC::JSCell* owner, JSC::JSValue caller, WTF::Vector<JSC::StackFrame>& stackTrace, size_t stackTraceLimit)
 {
-    size_t framesCount = 0;
+    UNUSED_PARAM(callFrame);
 
-    bool belowCaller = false;
-    int32_t skipFrames = 0;
+    // Delegate to Interpreter::getStackTrace which includes async stack frames
+    // (from the await chain via getAsyncStackTrace). The previous hand-rolled
+    // StackVisitor::visit walk only collected synchronous frames.
+    //
+    // We always collect with framesToSkip=1 (to drop Error.captureStackTrace
+    // itself) and without the caller argument, because Interpreter::getStackTrace's
+    // built-in caller filtering skips entry-frame tracking during the skip phase,
+    // which loses async frames when the caller is the innermost sync frame.
+    // Instead we filter out frames up to and including the caller afterwards.
+    WTF::Vector<JSC::StackFrame> rawFrames;
+    vm.interpreter.getStackTrace(owner, rawFrames, 1, stackTraceLimit);
 
-    WTF::String callerName {};
-    if (JSC::JSFunction* callerFunction = JSC::jsDynamicCast<JSC::JSFunction*>(caller)) {
-        callerName = callerFunction->name(vm);
-        if (callerName.isEmpty() && !callerFunction->isHostFunction() && callerFunction->jsExecutable()) {
-            callerName = callerFunction->jsExecutable()->name().string();
-        }
-    } else if (JSC::InternalFunction* callerFunctionInternal = JSC::jsDynamicCast<JSC::InternalFunction*>(caller)) {
-        callerName = callerFunctionInternal->name();
+    // JSC's getStackTrace uses StackVisitor::isImplementationVisibilityPrivate
+    // which differs from Bun's helper — post-filter to keep behavior consistent
+    // with new Error() stack formatting.
+    stackTrace.reserveInitialCapacity(rawFrames.size());
+    for (auto& frame : rawFrames) {
+        if (!isImplementationVisibilityPrivate(frame))
+            stackTrace.append(WTF::move(frame));
     }
 
-    size_t totalFrames = 0;
+    if (!caller.isObject())
+        return;
 
-    if (!callerName.isEmpty()) {
-        JSC::StackVisitor::visit(callFrame, vm, [&](JSC::StackVisitor& visitor) -> WTF::IterationStatus {
-            if (isImplementationVisibilityPrivate(visitor)) {
-                return WTF::IterationStatus::Continue;
-            }
+    JSC::JSObject* callerObject = caller.getObject();
+    auto* globalObject = callerObject->globalObject();
+    WTF::String callerName = Zig::functionName(vm, globalObject, callerObject);
 
-            framesCount += 1;
-
-            // skip caller frame and all frames above it
-            if (!belowCaller) {
-                skipFrames += 1;
-
-                if (visitor->functionName() == callerName) {
-                    belowCaller = true;
-                    return WTF::IterationStatus::Continue;
-                }
-            }
-
-            totalFrames += 1;
-
-            if (totalFrames > stackTraceLimit) {
-                return WTF::IterationStatus::Done;
-            }
-
-            return WTF::IterationStatus::Continue;
-        });
-    } else if (caller && caller.isCell()) {
-        JSC::StackVisitor::visit(callFrame, vm, [&](JSC::StackVisitor& visitor) -> WTF::IterationStatus {
-            if (isImplementationVisibilityPrivate(visitor)) {
-                return WTF::IterationStatus::Continue;
-            }
-
-            framesCount += 1;
-
-            // skip caller frame and all frames above it
-            if (!belowCaller) {
-                auto callee = visitor->callee();
-                skipFrames += 1;
-                if (callee.isCell() && callee.asCell() == caller) {
-                    belowCaller = true;
-                    return WTF::IterationStatus::Continue;
-                }
-            }
-
-            totalFrames += 1;
-
-            if (totalFrames > stackTraceLimit) {
-                return WTF::IterationStatus::Done;
-            }
-
-            return WTF::IterationStatus::Continue;
-        });
-    } else if (caller.isEmpty() || caller.isUndefined()) {
-        // Skip the first frame.
-        JSC::StackVisitor::visit(callFrame, vm, [&](JSC::StackVisitor& visitor) -> WTF::IterationStatus {
-            if (isImplementationVisibilityPrivate(visitor)) {
-                return WTF::IterationStatus::Continue;
-            }
-
-            framesCount += 1;
-
-            if (!belowCaller) {
-                skipFrames += 1;
-                belowCaller = true;
-            }
-
-            totalFrames += 1;
-
-            if (totalFrames > stackTraceLimit) {
-                return WTF::IterationStatus::Done;
-            }
-
-            return WTF::IterationStatus::Continue;
-        });
+    // Match V8: remove all frames up to and including the caller. If the caller
+    // is not found anywhere in the sync portion of the stack, remove everything.
+    // We match by cell identity first, then by name — name matching is needed
+    // because a resumed async function's frame callee is the generator's `next`
+    // function (a different cell) but Zig::functionName still reports the
+    // original async function's name.
+    size_t removeCount = stackTrace.size();
+    for (size_t i = 0; i < stackTrace.size(); i++) {
+        const auto& frame = stackTrace.at(i);
+        if (frame.isAsyncFrame())
+            break;
+        if (frame.callee() == callerObject) {
+            removeCount = i + 1;
+            break;
+        }
+        if (!callerName.isEmpty() && Zig::functionName(vm, globalObject, frame, FinalizerSafety::NotInFinalizer, nullptr) == callerName) {
+            removeCount = i + 1;
+            break;
+        }
     }
-    size_t i = 0;
-    totalFrames = 0;
-    stackTrace.reserveInitialCapacity(framesCount);
-    JSC::StackVisitor::visit(callFrame, vm, [&](JSC::StackVisitor& visitor) -> WTF::IterationStatus {
-        // Skip native frames
-        if (isImplementationVisibilityPrivate(visitor)) {
-            return WTF::IterationStatus::Continue;
-        }
 
-        // Skip frames if needed
-        if (skipFrames > 0) {
-            skipFrames--;
-            return WTF::IterationStatus::Continue;
-        }
-
-        totalFrames += 1;
-
-        if (totalFrames > stackTraceLimit) {
-            return WTF::IterationStatus::Done;
-        }
-
-        if (visitor->isNativeCalleeFrame()) {
-
-            auto* nativeCallee = visitor->callee().asNativeCallee();
-            switch (nativeCallee->category()) {
-            case NativeCallee::Category::Wasm: {
-                stackTrace.append(StackFrame(visitor->wasmFunctionIndexOrName()));
-                break;
-            }
-            case NativeCallee::Category::InlineCache: {
-                break;
-            }
-            }
-#if USE(ALLOW_LINE_AND_COLUMN_NUMBER_IN_BUILTINS)
-        } else if (!!visitor->codeBlock())
-#else
-            } else if (!!visitor->codeBlock() && !visitor->codeBlock()->unlinkedCodeBlock()->isBuiltinFunction())
-#endif
-            stackTrace.append(StackFrame(vm, owner, visitor->callee().asCell(), visitor->codeBlock(), visitor->bytecodeIndex()));
-        else
-            stackTrace.append(StackFrame(vm, owner, visitor->callee().asCell()));
-
-        i++;
-
-        return (i == framesCount) ? WTF::IterationStatus::Done : WTF::IterationStatus::Continue;
-    });
+    if (removeCount > 0)
+        stackTrace.removeAt(0, removeCount);
 }
 
 JSCStackTrace JSCStackTrace::getStackTraceForThrownValue(JSC::VM& vm, JSC::JSValue thrownValue)

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -790,3 +790,69 @@ test("captureStackTrace with constructor function not in stack returns error str
     expect(e.stack).toBe("TypeError: bad type");
   }
 });
+
+test("Error.captureStackTrace includes async frames from the await chain", async () => {
+  async function innerAsync() {
+    await new Promise(r => setImmediate(r));
+    const err = new Error("async test");
+    Error.captureStackTrace(err);
+    return err;
+  }
+  noInline(innerAsync);
+
+  async function outerAsync() {
+    return await innerAsync();
+  }
+  noInline(outerAsync);
+
+  const err = await outerAsync();
+  expect(err.stack).toContain("at innerAsync");
+  expect(err.stack).toContain("at async outerAsync");
+});
+
+test("Error.captureStackTrace with caller argument preserves async frames", async () => {
+  async function innerAsync() {
+    await new Promise(r => setImmediate(r));
+    const err = new Error("async test");
+    Error.captureStackTrace(err, innerAsync);
+    return err;
+  }
+  noInline(innerAsync);
+
+  async function middleAsync() {
+    return await innerAsync();
+  }
+  noInline(middleAsync);
+
+  async function outerAsync() {
+    return await middleAsync();
+  }
+  noInline(outerAsync);
+
+  const err = await outerAsync();
+  // innerAsync should be filtered out, but async parents should remain
+  expect(err.stack).not.toContain("at innerAsync");
+  expect(err.stack).toContain("at async middleAsync");
+  expect(err.stack).toContain("at async outerAsync");
+});
+
+test("Error.captureStackTrace with caller not in stack clears async frames too", async () => {
+  function notInStack() {}
+
+  async function innerAsync() {
+    await new Promise(r => setImmediate(r));
+    const err = new Error("async test");
+    Error.captureStackTrace(err, notInStack);
+    return err;
+  }
+  noInline(innerAsync);
+
+  async function outerAsync() {
+    return await innerAsync();
+  }
+  noInline(outerAsync);
+
+  const err = await outerAsync();
+  // When caller is not found, V8 clears everything
+  expect(err.stack).toBe("Error: async test");
+});

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -856,3 +856,36 @@ test("Error.captureStackTrace with caller not in stack clears async frames too",
   // When caller is not found, V8 clears everything
   expect(err.stack).toBe("Error: async test");
 });
+
+test("Error.captureStackTrace applies stackTraceLimit after caller removal", () => {
+  // Build a deep call chain so the caller sits beyond stackTraceLimit.
+  // If the limit were applied before removal, all collected frames would
+  // be above the caller and get removed, yielding an empty trace.
+  const origLimit = Error.stackTraceLimit;
+  Error.stackTraceLimit = 3;
+  try {
+    function target() {
+      const err = {};
+      Error.captureStackTrace(err, target);
+      return err;
+    }
+    noInline(target);
+
+    function recurse(depth) {
+      if (depth === 0) return target();
+      // Not a tail call — keeps each frame on the stack.
+      const r = recurse(depth - 1);
+      return { ...r };
+    }
+    noInline(recurse);
+
+    const err = recurse(20);
+    const frames = err.stack.split("\n").filter(l => l.includes("    at "));
+    // Should have exactly 3 frames (the limit), all below target()
+    expect(frames.length).toBe(3);
+    expect(err.stack).not.toContain("at target");
+    expect(err.stack).toContain("at recurse");
+  } finally {
+    Error.stackTraceLimit = origLimit;
+  }
+});


### PR DESCRIPTION
## Summary

`Error.captureStackTrace` was using a hand-rolled `StackVisitor::visit` walk that only collected synchronous frames, missing `at async <fn>` frames from the await chain. `new Error()` included them but `Error.captureStackTrace(err)` did not.

This rewrites `getFramesForCaller` to delegate to `Interpreter::getStackTrace` (which includes async frames via `getAsyncStackTrace`), then applies caller filtering afterward:

- Post-filters with Bun's `isImplementationVisibilityPrivate` to match `new Error()` visibility rules
- Matches caller by cell identity first, then by name via `Zig::functionName` — name matching is needed because a resumed async function's frame callee is the generator's `next` function (a different cell), but the function name still matches
- If caller isn't found in the sync portion, removes all frames (matches V8)

Also removes the double stack walk (count + collect) since `getStackTrace` does it in one pass.

## Test plan

- [x] `bun bd test test/js/node/v8/capture-stack-trace.test.js` — 36 pass (33 existing + 3 new)
- [x] New tests fail on system Bun (verified with `USE_SYSTEM_BUN=1`)
- [x] `BUN_JSC_validateExceptionChecks=1` — no exception scope errors