### PR TITLE
node:http2: honor res.sendDate/removeHeader and emit Keep-Alive on the allowHTTP1 fallback

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -5354,8 +5354,6 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
     let out = `HTTP/1.1 ${statusCode} ${statusMessage}\r\n`;
     let hasContentLength = false;
     let hasTransferEncoding = false;
-    let hasDate = false;
-    let hasConnection = false;
     const headers = head?.headers;
     if (headers) {
       for (let i = 0, end = headers.length - 1; i < end; i += 2) {
@@ -5376,12 +5374,6 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
             hasTransferEncoding = true;
             if (String(value).toLowerCase().includes("chunked")) chunked = true;
             break;
-          case "date":
-            hasDate = true;
-            break;
-          case "connection":
-            hasConnection = true;
-            break;
         }
         out += `${name}: ${value}\r\n`;
       }
@@ -5394,13 +5386,11 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
         out += `Content-Length: ${contentLength}\r\n`;
       }
     }
-    if (!hasDate) {
+    // renderNativeHeaders() is the source of truth for the Date and Connection
+    // response headers (it honors res.sendDate and res.removeHeader("connection")),
+    // so only synthesize them when no rendered header array was provided.
+    if (!headers) {
       out += `Date: ${new Date().toUTCString()}\r\n`;
-    }
-    // A close-delimited response with no Connection pair means the user removed
-    // it (Node's _removedConnection): write none rather than inventing
-    // keep-alive on a connection that ends with the body.
-    if (!hasConnection && !closeDelimited) {
       if (shouldKeepAlive) {
         out += `Connection: keep-alive\r\nKeep-Alive: timeout=${Math.floor((keepAliveTimeout || 5000) / 1000)}\r\n`;
       } else {
@@ -5562,6 +5552,9 @@ function connectionListenerHTTP1(server, socket, options) {
     };
 
     const res = new ServerResponseClass(req);
+    // Mirror the native node:http path (_http_server.ts) so renderNativeHeaders()
+    // emits the Keep-Alive: timeout header on persistent connections.
+    res._keepAliveTimeout = keepAliveTimeout;
     const handle = createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTimeout);
     handle.onfinished = function () {
       socket[kHttp1ActiveRequests] = Math.max(0, (socket[kHttp1ActiveRequests] || 1) - 1);

--- a/test/regression/issue/28656.test.ts
+++ b/test/regression/issue/28656.test.ts
@@ -1,0 +1,385 @@
+import { expect, test } from "bun:test";
+import { tls } from "harness";
+import http2 from "node:http2";
+import https from "node:https";
+
+test("http2.createSecureServer with allowHTTP1 handles HTTP/1.1 requests", async () => {
+  const { promise: listening, resolve: onListening } = Promise.withResolvers<number>();
+  const {
+    promise: done,
+    resolve: onDone,
+    reject: onError,
+  } = Promise.withResolvers<{
+    status: number;
+    body: string;
+    httpVersion: string;
+    contentType: string | undefined;
+    custom: string | undefined;
+  }>();
+
+  const server = http2.createSecureServer(
+    {
+      allowHTTP1: true,
+      ...tls,
+    },
+    (req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain", "X-Custom-Header": "custom-value" });
+      res.end("ok");
+    },
+  );
+
+  server.listen(0, () => {
+    onListening((server.address() as any).port);
+  });
+
+  const port = await listening;
+
+  const req = https.get(`https://localhost:${port}`, { rejectUnauthorized: false }, res => {
+    let data = "";
+    res.on("data", (chunk: any) => (data += chunk));
+    res.on("end", () => {
+      onDone({
+        status: res.statusCode!,
+        body: data,
+        httpVersion: res.httpVersion,
+        // The response headers set via writeHead must survive the HTTP/1.1
+        // fallback intact (the fallback previously mangled the flat header
+        // array, emitting "c: o" instead of "content-type: text/plain").
+        contentType: res.headers["content-type"],
+        custom: res.headers["x-custom-header"],
+      });
+    });
+  });
+  req.on("error", onError);
+
+  const result = await done;
+  expect(result).toEqual({
+    status: 200,
+    body: "ok",
+    httpVersion: "1.1",
+    contentType: "text/plain",
+    custom: "custom-value",
+  });
+
+  server.close();
+});
+
+test("http2.createSecureServer with allowHTTP1 honors res.sendDate = false", async () => {
+  const { promise: listening, resolve: onListening } = Promise.withResolvers<number>();
+  const {
+    promise: done,
+    resolve: onDone,
+    reject: onError,
+  } = Promise.withResolvers<{
+    date: string | undefined;
+    contentType: string | undefined;
+    body: string;
+  }>();
+
+  const server = http2.createSecureServer(
+    {
+      allowHTTP1: true,
+      ...tls,
+    },
+    (req, res) => {
+      // renderNativeHeaders() omits Date when sendDate is false, so the
+      // fallback must not re-synthesize it (it used to add Date unconditionally).
+      res.sendDate = false;
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("ok");
+    },
+  );
+
+  server.listen(0, () => {
+    onListening((server.address() as any).port);
+  });
+
+  const port = await listening;
+
+  const req = https.get(`https://localhost:${port}`, { rejectUnauthorized: false }, res => {
+    let data = "";
+    res.on("data", (chunk: any) => (data += chunk));
+    res.on("end", () => {
+      onDone({
+        date: res.headers["date"],
+        contentType: res.headers["content-type"],
+        body: data,
+      });
+    });
+  });
+  req.on("error", onError);
+
+  const result = await done;
+  expect(result).toEqual({
+    date: undefined,
+    contentType: "text/plain",
+    body: "ok",
+  });
+
+  server.close();
+});
+
+test("http2.createSecureServer with allowHTTP1 sends Keep-Alive on persistent connections", async () => {
+  const { promise: listening, resolve: onListening } = Promise.withResolvers<number>();
+  const {
+    promise: done,
+    resolve: onDone,
+    reject: onError,
+  } = Promise.withResolvers<{
+    connection: string | undefined;
+    keepAlive: string | undefined;
+    body: string;
+  }>();
+
+  const server = http2.createSecureServer(
+    {
+      allowHTTP1: true,
+      ...tls,
+    },
+    (req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("ok");
+    },
+  );
+
+  server.listen(0, () => {
+    onListening((server.address() as any).port);
+  });
+
+  const port = await listening;
+
+  // keepAlive advertises a persistent connection, which is what makes the
+  // server emit Connection: keep-alive together with Keep-Alive: timeout=N.
+  const agent = new https.Agent({ keepAlive: true });
+  const req = https.get(`https://localhost:${port}`, { rejectUnauthorized: false, agent }, res => {
+    let data = "";
+    res.on("data", (chunk: any) => (data += chunk));
+    res.on("end", () => {
+      onDone({
+        connection: res.headers["connection"],
+        // renderNativeHeaders() only emits Keep-Alive when res._keepAliveTimeout
+        // is set, so connectionListenerHTTP1 must set it like the node:http path.
+        keepAlive: res.headers["keep-alive"],
+        body: data,
+      });
+    });
+  });
+  req.on("error", onError);
+
+  const result = await done;
+  expect(result).toEqual({
+    connection: "keep-alive",
+    keepAlive: "timeout=5",
+    body: "ok",
+  });
+
+  agent.destroy();
+  server.close();
+});
+
+test("http2.createSecureServer with allowHTTP1 still handles HTTP/2 requests", async () => {
+  const { promise: listening, resolve: onListening } = Promise.withResolvers<number>();
+
+  const server = http2.createSecureServer(
+    {
+      allowHTTP1: true,
+      ...tls,
+    },
+    (req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("ok-h2");
+    },
+  );
+
+  server.listen(0, () => {
+    onListening((server.address() as any).port);
+  });
+
+  const port = await listening;
+
+  const {
+    promise: done,
+    resolve: onDone,
+    reject: onError,
+  } = Promise.withResolvers<{
+    status: number;
+    body: string;
+  }>();
+
+  const client = http2.connect(`https://localhost:${port}`, { rejectUnauthorized: false });
+  client.on("error", onError);
+
+  const h2req = client.request({ ":path": "/" });
+  let data = "";
+  let status = 0;
+  h2req.on("response", headers => {
+    status = headers[":status"] as number;
+  });
+  h2req.on("data", (chunk: any) => (data += chunk));
+  h2req.on("end", () => {
+    onDone({ status, body: data });
+  });
+  h2req.end();
+
+  const result = await done;
+  expect(result).toEqual({
+    status: 200,
+    body: "ok-h2",
+  });
+
+  client.close();
+  server.close();
+});
+
+test("http2.createSecureServer without allowHTTP1 rejects HTTP/1.1", async () => {
+  const { promise: listening, resolve: onListening } = Promise.withResolvers<number>();
+
+  const server = http2.createSecureServer(
+    {
+      allowHTTP1: false,
+      ...tls,
+    },
+    (_req, res) => {
+      res.end("should not reach");
+    },
+  );
+
+  server.listen(0, () => {
+    onListening((server.address() as any).port);
+  });
+
+  const port = await listening;
+
+  const { promise: done, resolve: onDone } = Promise.withResolvers<{
+    status?: number;
+    body?: string;
+    error?: string;
+  }>();
+
+  const req = https.get(`https://localhost:${port}`, { rejectUnauthorized: false }, res => {
+    let data = "";
+    res.on("data", (chunk: any) => (data += chunk));
+    res.on("end", () => onDone({ status: res.statusCode!, body: data }));
+  });
+  req.on("error", (e: any) => onDone({ error: e.code }));
+
+  const result = await done;
+  // The HTTP/1.1 request must be rejected: the request handler is never reached.
+  // Node sends a 403 "Missing ALPN Protocol" response (or the connection errors out);
+  // either way the application's "should not reach" body is never delivered.
+  expect(result.body ?? "").not.toContain("should not reach");
+  if (result.error === undefined) {
+    expect(result.status).toBe(403);
+  }
+
+  server.close();
+});
+
+test("http2.createSecureServer allowHTTP1 handles request with body", async () => {
+  const { promise: listening, resolve: onListening } = Promise.withResolvers<number>();
+
+  const server = http2.createSecureServer(
+    {
+      allowHTTP1: true,
+      ...tls,
+    },
+    (req, res) => {
+      let body = "";
+      req.on("data", (chunk: any) => (body += chunk));
+      req.on("end", () => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ received: body }));
+      });
+    },
+  );
+
+  server.listen(0, () => {
+    onListening((server.address() as any).port);
+  });
+
+  const port = await listening;
+
+  const {
+    promise: done,
+    resolve: onDone,
+    reject: onError,
+  } = Promise.withResolvers<{
+    status: number;
+    body: string;
+  }>();
+
+  const options = {
+    hostname: "localhost",
+    port,
+    path: "/test",
+    method: "POST",
+    rejectUnauthorized: false,
+    headers: { "Content-Type": "text/plain" },
+  };
+
+  const req = https.request(options, res => {
+    let data = "";
+    res.on("data", (chunk: any) => (data += chunk));
+    res.on("end", () => {
+      onDone({ status: res.statusCode!, body: data });
+    });
+  });
+  req.on("error", onError);
+  req.write("hello world");
+  req.end();
+
+  const result = await done;
+  expect(result.status).toBe(200);
+  expect(JSON.parse(result.body)).toEqual({ received: "hello world" });
+
+  server.close();
+});
+
+test("http2.createSecureServer allowHTTP1 streaming write() then end()", async () => {
+  const { promise: listening, resolve: onListening } = Promise.withResolvers<number>();
+
+  const server = http2.createSecureServer(
+    {
+      allowHTTP1: true,
+      ...tls,
+    },
+    (_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.write("part1-");
+      res.write("part2-");
+      res.end("part3");
+    },
+  );
+
+  server.listen(0, () => {
+    onListening((server.address() as any).port);
+  });
+
+  const port = await listening;
+
+  const {
+    promise: done,
+    resolve: onDone,
+    reject: onError,
+  } = Promise.withResolvers<{
+    status: number;
+    body: string;
+  }>();
+
+  const req = https.get(`https://localhost:${port}`, { rejectUnauthorized: false }, res => {
+    let data = "";
+    res.on("data", (chunk: any) => (data += chunk));
+    res.on("end", () => {
+      onDone({ status: res.statusCode!, body: data });
+    });
+  });
+  req.on("error", onError);
+
+  const result = await done;
+  expect(result).toEqual({
+    status: 200,
+    body: "part1-part2-part3",
+  });
+
+  server.close();
+});

--- a/test/regression/issue/28656.test.ts
+++ b/test/regression/issue/28656.test.ts
@@ -34,34 +34,36 @@ test("http2.createSecureServer with allowHTTP1 handles HTTP/1.1 requests", async
 
   const port = await listening;
 
-  const req = https.get(`https://localhost:${port}`, { rejectUnauthorized: false }, res => {
-    let data = "";
-    res.on("data", (chunk: any) => (data += chunk));
-    res.on("end", () => {
-      onDone({
-        status: res.statusCode!,
-        body: data,
-        httpVersion: res.httpVersion,
-        // The response headers set via writeHead must survive the HTTP/1.1
-        // fallback intact (the fallback previously mangled the flat header
-        // array, emitting "c: o" instead of "content-type: text/plain").
-        contentType: res.headers["content-type"],
-        custom: res.headers["x-custom-header"],
+  try {
+    const req = https.get(`https://localhost:${port}`, { rejectUnauthorized: false }, res => {
+      let data = "";
+      res.on("data", (chunk: any) => (data += chunk));
+      res.on("end", () => {
+        onDone({
+          status: res.statusCode!,
+          body: data,
+          httpVersion: res.httpVersion,
+          // The response headers set via writeHead must survive the HTTP/1.1
+          // fallback intact (the fallback previously mangled the flat header
+          // array, emitting "c: o" instead of "content-type: text/plain").
+          contentType: res.headers["content-type"],
+          custom: res.headers["x-custom-header"],
+        });
       });
     });
-  });
-  req.on("error", onError);
+    req.on("error", onError);
 
-  const result = await done;
-  expect(result).toEqual({
-    status: 200,
-    body: "ok",
-    httpVersion: "1.1",
-    contentType: "text/plain",
-    custom: "custom-value",
-  });
-
-  server.close();
+    const result = await done;
+    expect(result).toEqual({
+      status: 200,
+      body: "ok",
+      httpVersion: "1.1",
+      contentType: "text/plain",
+      custom: "custom-value",
+    });
+  } finally {
+    server.close();
+  }
 });
 
 test("http2.createSecureServer with allowHTTP1 honors res.sendDate = false", async () => {
@@ -96,27 +98,29 @@ test("http2.createSecureServer with allowHTTP1 honors res.sendDate = false", asy
 
   const port = await listening;
 
-  const req = https.get(`https://localhost:${port}`, { rejectUnauthorized: false }, res => {
-    let data = "";
-    res.on("data", (chunk: any) => (data += chunk));
-    res.on("end", () => {
-      onDone({
-        date: res.headers["date"],
-        contentType: res.headers["content-type"],
-        body: data,
+  try {
+    const req = https.get(`https://localhost:${port}`, { rejectUnauthorized: false }, res => {
+      let data = "";
+      res.on("data", (chunk: any) => (data += chunk));
+      res.on("end", () => {
+        onDone({
+          date: res.headers["date"],
+          contentType: res.headers["content-type"],
+          body: data,
+        });
       });
     });
-  });
-  req.on("error", onError);
+    req.on("error", onError);
 
-  const result = await done;
-  expect(result).toEqual({
-    date: undefined,
-    contentType: "text/plain",
-    body: "ok",
-  });
-
-  server.close();
+    const result = await done;
+    expect(result).toEqual({
+      date: undefined,
+      contentType: "text/plain",
+      body: "ok",
+    });
+  } finally {
+    server.close();
+  }
 });
 
 test("http2.createSecureServer with allowHTTP1 sends Keep-Alive on persistent connections", async () => {
@@ -151,30 +155,32 @@ test("http2.createSecureServer with allowHTTP1 sends Keep-Alive on persistent co
   // keepAlive advertises a persistent connection, which is what makes the
   // server emit Connection: keep-alive together with Keep-Alive: timeout=N.
   const agent = new https.Agent({ keepAlive: true });
-  const req = https.get(`https://localhost:${port}`, { rejectUnauthorized: false, agent }, res => {
-    let data = "";
-    res.on("data", (chunk: any) => (data += chunk));
-    res.on("end", () => {
-      onDone({
-        connection: res.headers["connection"],
-        // renderNativeHeaders() only emits Keep-Alive when res._keepAliveTimeout
-        // is set, so connectionListenerHTTP1 must set it like the node:http path.
-        keepAlive: res.headers["keep-alive"],
-        body: data,
+  try {
+    const req = https.get(`https://localhost:${port}`, { rejectUnauthorized: false, agent }, res => {
+      let data = "";
+      res.on("data", (chunk: any) => (data += chunk));
+      res.on("end", () => {
+        onDone({
+          connection: res.headers["connection"],
+          // renderNativeHeaders() only emits Keep-Alive when res._keepAliveTimeout
+          // is set, so connectionListenerHTTP1 must set it like the node:http path.
+          keepAlive: res.headers["keep-alive"],
+          body: data,
+        });
       });
     });
-  });
-  req.on("error", onError);
+    req.on("error", onError);
 
-  const result = await done;
-  expect(result).toEqual({
-    connection: "keep-alive",
-    keepAlive: "timeout=5",
-    body: "ok",
-  });
-
-  agent.destroy();
-  server.close();
+    const result = await done;
+    expect(result).toEqual({
+      connection: "keep-alive",
+      keepAlive: "timeout=5",
+      body: "ok",
+    });
+  } finally {
+    agent.destroy();
+    server.close();
+  }
 });
 
 test("http2.createSecureServer with allowHTTP1 still handles HTTP/2 requests", async () => {
@@ -207,28 +213,30 @@ test("http2.createSecureServer with allowHTTP1 still handles HTTP/2 requests", a
   }>();
 
   const client = http2.connect(`https://localhost:${port}`, { rejectUnauthorized: false });
-  client.on("error", onError);
+  try {
+    client.on("error", onError);
 
-  const h2req = client.request({ ":path": "/" });
-  let data = "";
-  let status = 0;
-  h2req.on("response", headers => {
-    status = headers[":status"] as number;
-  });
-  h2req.on("data", (chunk: any) => (data += chunk));
-  h2req.on("end", () => {
-    onDone({ status, body: data });
-  });
-  h2req.end();
+    const h2req = client.request({ ":path": "/" });
+    let data = "";
+    let status = 0;
+    h2req.on("response", headers => {
+      status = headers[":status"] as number;
+    });
+    h2req.on("data", (chunk: any) => (data += chunk));
+    h2req.on("end", () => {
+      onDone({ status, body: data });
+    });
+    h2req.end();
 
-  const result = await done;
-  expect(result).toEqual({
-    status: 200,
-    body: "ok-h2",
-  });
-
-  client.close();
-  server.close();
+    const result = await done;
+    expect(result).toEqual({
+      status: 200,
+      body: "ok-h2",
+    });
+  } finally {
+    client.close();
+    server.close();
+  }
 });
 
 test("http2.createSecureServer without allowHTTP1 rejects HTTP/1.1", async () => {
@@ -256,23 +264,25 @@ test("http2.createSecureServer without allowHTTP1 rejects HTTP/1.1", async () =>
     error?: string;
   }>();
 
-  const req = https.get(`https://localhost:${port}`, { rejectUnauthorized: false }, res => {
-    let data = "";
-    res.on("data", (chunk: any) => (data += chunk));
-    res.on("end", () => onDone({ status: res.statusCode!, body: data }));
-  });
-  req.on("error", (e: any) => onDone({ error: e.code }));
+  try {
+    const req = https.get(`https://localhost:${port}`, { rejectUnauthorized: false }, res => {
+      let data = "";
+      res.on("data", (chunk: any) => (data += chunk));
+      res.on("end", () => onDone({ status: res.statusCode!, body: data }));
+    });
+    req.on("error", (e: any) => onDone({ error: e.code }));
 
-  const result = await done;
-  // The HTTP/1.1 request must be rejected: the request handler is never reached.
-  // Node sends a 403 "Missing ALPN Protocol" response (or the connection errors out);
-  // either way the application's "should not reach" body is never delivered.
-  expect(result.body ?? "").not.toContain("should not reach");
-  if (result.error === undefined) {
-    expect(result.status).toBe(403);
+    const result = await done;
+    // The HTTP/1.1 request must be rejected: the request handler is never reached.
+    // Node sends a 403 "Missing ALPN Protocol" response (or the connection errors out);
+    // either way the application's "should not reach" body is never delivered.
+    expect(result.body ?? "").not.toContain("should not reach");
+    if (result.error === undefined) {
+      expect(result.status).toBe(403);
+    }
+  } finally {
+    server.close();
   }
-
-  server.close();
 });
 
 test("http2.createSecureServer allowHTTP1 handles request with body", async () => {
@@ -308,31 +318,33 @@ test("http2.createSecureServer allowHTTP1 handles request with body", async () =
     body: string;
   }>();
 
-  const options = {
-    hostname: "localhost",
-    port,
-    path: "/test",
-    method: "POST",
-    rejectUnauthorized: false,
-    headers: { "Content-Type": "text/plain" },
-  };
+  try {
+    const options = {
+      hostname: "localhost",
+      port,
+      path: "/test",
+      method: "POST",
+      rejectUnauthorized: false,
+      headers: { "Content-Type": "text/plain" },
+    };
 
-  const req = https.request(options, res => {
-    let data = "";
-    res.on("data", (chunk: any) => (data += chunk));
-    res.on("end", () => {
-      onDone({ status: res.statusCode!, body: data });
+    const req = https.request(options, res => {
+      let data = "";
+      res.on("data", (chunk: any) => (data += chunk));
+      res.on("end", () => {
+        onDone({ status: res.statusCode!, body: data });
+      });
     });
-  });
-  req.on("error", onError);
-  req.write("hello world");
-  req.end();
+    req.on("error", onError);
+    req.write("hello world");
+    req.end();
 
-  const result = await done;
-  expect(result.status).toBe(200);
-  expect(JSON.parse(result.body)).toEqual({ received: "hello world" });
-
-  server.close();
+    const result = await done;
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({ received: "hello world" });
+  } finally {
+    server.close();
+  }
 });
 
 test("http2.createSecureServer allowHTTP1 streaming write() then end()", async () => {
@@ -366,20 +378,22 @@ test("http2.createSecureServer allowHTTP1 streaming write() then end()", async (
     body: string;
   }>();
 
-  const req = https.get(`https://localhost:${port}`, { rejectUnauthorized: false }, res => {
-    let data = "";
-    res.on("data", (chunk: any) => (data += chunk));
-    res.on("end", () => {
-      onDone({ status: res.statusCode!, body: data });
+  try {
+    const req = https.get(`https://localhost:${port}`, { rejectUnauthorized: false }, res => {
+      let data = "";
+      res.on("data", (chunk: any) => (data += chunk));
+      res.on("end", () => {
+        onDone({ status: res.statusCode!, body: data });
+      });
     });
-  });
-  req.on("error", onError);
+    req.on("error", onError);
 
-  const result = await done;
-  expect(result).toEqual({
-    status: 200,
-    body: "part1-part2-part3",
-  });
-
-  server.close();
+    const result = await done;
+    expect(result).toEqual({
+      status: 200,
+      body: "part1-part2-part3",
+    });
+  } finally {
+    server.close();
+  }
 });


### PR DESCRIPTION
## Summary

The HTTP/1.1 fallback for `http2.createSecureServer({ allowHTTP1: true })` mangled response headers (the flat `[name, value, ...]` array from `renderNativeHeaders()` was iterated as pairs-of-pairs, so `content-type` went out as `c: o`). That core fix landed independently in #33072 (Hardening round 11), so this PR has been rebased down to the two refinements #33072 does not cover:

1. **`res.sendDate = false` / `res.removeHeader("connection")` were ignored.** The fallback synthesized its own `Date`/`Connection` headers via `!hasDate`/`!hasConnection`, which re-adds a header the user deliberately suppressed. `renderNativeHeaders()` already owns those (it honors `sendDate`/`removeHeader`), so the synthesis is now gated on `!headers` (the head-unset defensive path only), and the dead `hasDate`/`hasConnection` tracking is removed.

2. **`Keep-Alive: timeout=N` was never emitted.** `renderNativeHeaders()` only appends it when `res._keepAliveTimeout` is set. The native `node:http` path sets it (`_http_server.ts`), but `connectionListenerHTTP1` did not, so the fallback advertised `Connection: keep-alive` without the accompanying header. It is now set from the server's `keepAliveTimeout`.

## Rebase note

The merge conflict was in `src/js/node/http2.ts`: #33072 rewrote `createHttp1FallbackResponseHandle` with the same header-parsing fix this PR originally carried (plus header/status validation). Rather than replay the now-redundant header-mangling commit, the branch was reset onto `main` and only the two remaining refinements were re-applied on top of #33072's structure. No behavior from #33072 is reverted.

## Verification

```
$ bun bd test test/regression/issue/28656.test.ts
 7 pass  0 fail
```

The `res.sendDate = false` and `Keep-Alive` tests fail against current `main` (they require these changes); the others guard the allowHTTP1 fallback end to end.

Refs #28656