### PR TITLE
Fix assert.deepStrictEqual with Proxy-wrapped arrays and objects

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -834,7 +834,10 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     }
 
     if constexpr (isStrict) {
-        if (!equal(JSObject::calculatedClassName(o1), JSObject::calculatedClassName(o2))) {
+        // Skip the class name check when either side is a Proxy.
+        // Node.js treats Proxies as transparent for deep equality.
+        // https://github.com/oven-sh/bun/issues/28647
+        if (!(o1->isProxy() || o2->isProxy()) && !equal(JSObject::calculatedClassName(o1), JSObject::calculatedClassName(o2))) {
             return false;
         }
     }

--- a/test/regression/issue/28647.test.ts
+++ b/test/regression/issue/28647.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/28647
+// assert.deepStrictEqual(new Proxy(['foo'], {}), ['foo']) should pass
+// Node.js treats Proxies as transparent for deep equality
+
+test("assert.deepStrictEqual with Proxy<Array> and Proxy<Object>", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const assert = require("node:assert");
+
+      // Proxy<Array> vs Array
+      assert.deepStrictEqual(new Proxy(["foo"], {}), ["foo"]);
+      assert.deepStrictEqual(["foo"], new Proxy(["foo"], {}));
+      assert.deepStrictEqual(new Proxy([1, 2, 3], {}), [1, 2, 3]);
+
+      // Proxy<Object> vs Object
+      assert.deepStrictEqual(new Proxy({ a: 1 }, {}), { a: 1 });
+      assert.deepStrictEqual({ a: 1 }, new Proxy({ a: 1 }, {}));
+      assert.deepStrictEqual(new Proxy({ a: 1, b: 2 }, {}), { a: 1, b: 2 });
+
+      // Proxy vs Proxy
+      assert.deepStrictEqual(new Proxy([1, 2], {}), new Proxy([1, 2], {}));
+      assert.deepStrictEqual(new Proxy({ x: 1 }, {}), new Proxy({ x: 1 }, {}));
+
+      // Proxy<Array> vs different Array should still fail
+      assert.throws(() => {
+        assert.deepStrictEqual(new Proxy([1, 2], {}), [1, 2, 3]);
+      });
+
+      // Proxy<Object> vs different Object should still fail
+      assert.throws(() => {
+        assert.deepStrictEqual(new Proxy({ a: 1 }, {}), { a: 2 });
+      });
+
+      // Proxy<Object> vs Object with different keys should still fail
+      assert.throws(() => {
+        assert.deepStrictEqual(new Proxy({ a: 1 }, {}), { b: 1 });
+      });
+
+      console.log("pass");
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("pass\n");
+  expect(exitCode).toBe(0);
+});
+
+test("Bun.deepEquals with Proxy (strict mode)", () => {
+  // Proxy<Array>
+  expect(Bun.deepEquals(new Proxy([1, 2, 3], {}), [1, 2, 3], true)).toBe(true);
+  expect(Bun.deepEquals([1, 2, 3], new Proxy([1, 2, 3], {}), true)).toBe(true);
+
+  // Proxy<Object>
+  expect(Bun.deepEquals(new Proxy({ a: 1 }, {}), { a: 1 }, true)).toBe(true);
+  expect(Bun.deepEquals({ a: 1 }, new Proxy({ a: 1 }, {}), true)).toBe(true);
+
+  // Different values should still fail
+  expect(Bun.deepEquals(new Proxy([1, 2], {}), [1, 2, 3], true)).toBe(false);
+  expect(Bun.deepEquals(new Proxy({ a: 1 }, {}), { a: 2 }, true)).toBe(false);
+  expect(Bun.deepEquals(new Proxy({ a: 1 }, {}), { b: 1 }, true)).toBe(false);
+});


### PR DESCRIPTION
## What does this PR do?

Fixes `assert.deepStrictEqual` and `Bun.deepEquals(..., ..., true)` (strict mode) to treat Proxy-wrapped arrays and objects as transparent, matching Node.js behavior.

## How did you verify your code works?

- Added regression test `test/regression/issue/28647.test.ts` covering Proxy<Array>, Proxy<Object>, both directions, and negative cases
- Verified `bun bd test test/regression/issue/28647.test.ts` passes (2/2)
- Verified `USE_SYSTEM_BUN=1 bun test test/regression/issue/28647.test.ts` fails (validates test catches the bug)
- Ran `test/js/bun/bun-object/deep-equals.spec.ts` — 36 pass, 0 fail
- Ran `test/js/node/assert/` — 92 pass, 0 fail

Fixes #28647