### PR TITLE
Check syntax eagerly in vm.Script constructor

### DIFF
--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -3,6 +3,7 @@
 #include "ErrorCode.h"
 
 #include "JavaScriptCore/Completion.h"
+#include "JavaScriptCore/ParserError.h"
 #include "JavaScriptCore/JIT.h"
 #include "JavaScriptCore/JSWeakMap.h"
 #include "JavaScriptCore/JSWeakMapInlines.h"
@@ -129,6 +130,17 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
 
     SourceCode source = makeSource(sourceString, JSC::SourceOrigin(WTF::URL::fileURLWithFileSystemPath(options.filename), *fetcher), JSC::SourceTaintedOrigin::Untainted, options.filename, TextPosition(options.lineOffset, options.columnOffset));
     RETURN_IF_EXCEPTION(scope, {});
+
+    {
+        JSC::ParserError error;
+        if (!JSC::checkSyntax(vm, source, error)) {
+            ASSERT(error.isValid());
+            auto exception = error.toErrorObject(globalObject, source);
+            RETURN_IF_EXCEPTION(scope, {});
+            JSC::throwException(globalObject, scope, exception);
+            return {};
+        }
+    }
 
     const bool produceCachedData = options.produceCachedData;
     auto filename = options.filename;

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -697,7 +697,7 @@ test("can't use export syntax in vm.Script", () => {
   expect(() => {
     const script = new Script("export default {};");
     script.createCachedData();
-  }).toThrow({ message: "createCachedData failed" });
+  }).toThrow({ name: "SyntaxError", message: "Unexpected keyword 'export'" });
 });
 
 test("rejects invalid bytecode", () => {

--- a/test/regression/issue/28666.test.ts
+++ b/test/regression/issue/28666.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+import { Script } from "node:vm";
+
+test("vm.Script throws SyntaxError for missing closing paren", () => {
+  expect(() => {
+    new Script("Math.max(a, b", { filename: "main" });
+  }).toThrow(SyntaxError);
+});
+
+test("vm.Script throws SyntaxError for unterminated string", () => {
+  expect(() => {
+    new Script('"hello', { filename: "main" });
+  }).toThrow(SyntaxError);
+});
+
+test("vm.Script throws SyntaxError for invalid token", () => {
+  expect(() => {
+    new Script("let @x = 1;", { filename: "main" });
+  }).toThrow(SyntaxError);
+});
+
+test("vm.Script throws SyntaxError at construction, not at run time", () => {
+  let reachedRun = false;
+  try {
+    const script = new Script("Math.max(a, b", { filename: "main" });
+    reachedRun = true;
+    script.runInThisContext();
+  } catch (error: unknown) {
+    expect(error).toBeInstanceOf(SyntaxError);
+  }
+  expect(reachedRun).toBe(false);
+});
+
+test("vm.Script does not throw for valid syntax", () => {
+  expect(() => {
+    new Script("Math.max(1, 2)", { filename: "main" });
+  }).not.toThrow();
+});


### PR DESCRIPTION
Fixes #28666

## Problem

`vm.Script` was not throwing `SyntaxError` at construction time for invalid JavaScript syntax. The source was stored but only parsed at execution time (`runInThisContext`, etc.), deferring the error.

Node.js eagerly compiles in the `Script` constructor, catching syntax errors immediately:

```js
const { Script } = require('vm');
try {
  new Script('Math.max(a, b', { filename: 'main' });
} catch (error) {
  console.log(error.message); // missing ) after argument list
}
```

Bun silently created the Script object and only threw when `runInThisContext()` was called.

## Fix

Call `JSC::checkSyntax()` in `constructScript()` after creating the `SourceCode` but before creating the `NodeVMScript` object. This follows the same pattern already used in `NodeVM.cpp` for `compileFunction`.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28666.test.ts` → 3 fail (bug present)
- `bun bd test test/regression/issue/28666.test.ts` → 5 pass
- `bun bd test test/js/node/vm/vm.test.ts` → 198 pass, 0 fail