### PR TITLE
docs: fix various typos in documentation

### DIFF
--- a/docs/bundler/hot-reloading.mdx
+++ b/docs/bundler/hot-reloading.mdx
@@ -149,7 +149,7 @@ import { createRoot } from "react-dom/client";
 import { App } from "./app";
 
 const root = (import.meta.hot.data.root ??= createRoot(elem));
-root.render(<App />); // re-use an existing root
+root.render(<App />); // reuse an existing root
 ```
 
 In production, `data` is inlined to be `{}`, meaning it cannot be used as a state holder.
@@ -187,7 +187,7 @@ This can be used to clean up resources that were created when the module was loa
 ```ts title="index.ts" icon="/icons/typescript.svg"
 import { something } from "./something";
 
-// Initialize or re-use a WebSocket connection
+// Initialize or reuse a WebSocket connection
 export const ws = (import.meta.hot.data.ws ??= new WebSocket(location.origin));
 
 // If the module's import is removed, clean up the WebSocket connection.

--- a/docs/guides/process/ipc.mdx
+++ b/docs/guides/process/ipc.mdx
@@ -54,7 +54,7 @@ process.on("message", message => {
 
 ---
 
-All messages are serialized using the JSC `serialize` API, which allows for the same set of [transferrable types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) supported by `postMessage` and `structuredClone`, including strings, typed arrays, streams, and objects.
+All messages are serialized using the JSC `serialize` API, which allows for the same set of [transferable types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) supported by `postMessage` and `structuredClone`, including strings, typed arrays, streams, and objects.
 
 ```ts child.ts icon="/icons/typescript.svg"
 // send a string


### PR DESCRIPTION
Fixes typos in documentation files: 'transferrable' -> 'transferable', 're-use' -> 'reuse'.