### PR TITLE
fix(install): remove incorrect npm alias resolving that corrupts package names

### DIFF
--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -340,7 +340,6 @@ pub const BunxCommand = struct {
         defer requests_buf.deinit(ctx.allocator);
         const update_requests = UpdateRequest.parse(
             ctx.allocator,
-            null,
             ctx.log,
             &.{opts.package_name},
             &requests_buf,

--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -100,9 +100,6 @@ ci_mode: bun.LazyBool(computeIsContinuousIntegration, @This(), "ci_mode") = .{},
 
 peer_dependencies: bun.LinearFifo(DependencyID, .Dynamic) = .init(default_allocator),
 
-// name hash from alias package name -> aliased package dependency version info
-known_npm_aliases: NpmAliasMap = .{},
-
 event_loop: jsc.AnyEventLoop,
 
 // During `installPackages` we learn exactly what dependencies from --trust
@@ -1140,8 +1137,6 @@ const PreallocatedNetworkTasks = bun.HiveArray(NetworkTask, 128).Fallback;
 const ResolveTaskQueue = bun.UnboundedQueue(Task, .next);
 
 const RepositoryMap = std.HashMapUnmanaged(Task.Id, bun.FileDescriptor, IdentityContext(Task.Id), 80);
-const NpmAliasMap = std.HashMapUnmanaged(PackageNameHash, Dependency.Version, IdentityContext(u64), 80);
-
 const NetworkQueue = bun.LinearFifo(*NetworkTask, .{ .Static = 32 });
 const PatchTaskFifo = bun.LinearFifo(*PatchTask, .{ .Static = 32 });
 

--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -308,7 +308,7 @@ pub fn enqueueDependencyToRoot(
 
         builder.allocate() catch |err| return .{ .failure = err };
 
-        const dep = dummy.cloneWithDifferentBuffers(this, name, version_buf, @TypeOf(&builder), &builder) catch unreachable;
+        const dep = dummy.cloneWithDifferentBuffers(name, version_buf, @TypeOf(&builder), &builder) catch unreachable;
         builder.clamp();
         const index = this.lockfile.buffers.dependencies.items.len;
         this.lockfile.buffers.dependencies.append(this.allocator, dep) catch unreachable;
@@ -456,29 +456,6 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
     };
 
     const version = version: {
-        if (dependency.version.tag == .npm) {
-            if (this.known_npm_aliases.get(name_hash)) |aliased| {
-                const group = dependency.version.value.npm.version;
-                const buf = this.lockfile.buffers.string_bytes.items;
-                var curr_list: ?*const Semver.Query.List = &aliased.value.npm.version.head;
-                while (curr_list) |queries| {
-                    var curr: ?*const Semver.Query = &queries.head;
-                    while (curr) |query| {
-                        if (group.satisfies(query.range.left.version, buf, buf) or group.satisfies(query.range.right.version, buf, buf)) {
-                            name = aliased.value.npm.name;
-                            name_hash = String.Builder.stringHash(this.lockfile.str(&name));
-                            break :version aliased;
-                        }
-                        curr = query.next;
-                    }
-                    curr_list = queries.next;
-                }
-
-                // fallthrough. a package that matches the name of an alias but does not match
-                // the version should be enqueued as a normal npm dependency, overrides allowed
-            }
-        }
-
         // allow overriding all dependencies unless the dependency is coming directly from an alias, "npm:<this dep>" or
         // if it's a workspaceOnly dependency
         if (!dependency.behavior.isWorkspace() and (dependency.version.tag != .npm or !dependency.version.value.npm.is_alias)) {
@@ -1445,7 +1422,6 @@ fn getOrPutResolvedPackageWithFindResult(
 
     // appendPackage sets the PackageID on the package
     const package = try this.lockfile.appendPackage(try Lockfile.Package.fromNPM(
-        this,
         this.allocator,
         this.lockfile,
         this.log,

--- a/src/install/PackageManager/UpdateRequest.zig
+++ b/src/install/PackageManager/UpdateRequest.zig
@@ -79,7 +79,7 @@ pub fn fromJS(globalThis: *jsc.JSGlobalObject, input: jsc.JSValue) bun.JSError!j
 
     var array = Array{};
 
-    const update_requests = parseWithError(allocator, null, &log, all_positionals.items, &array, .add, false) catch {
+    const update_requests = parseWithError(allocator, &log, all_positionals.items, &array, .add, false) catch {
         return globalThis.throwValue(try log.toJS(globalThis, bun.default_allocator, "Failed to parse dependencies"));
     };
     if (update_requests.len == 0) return .js_undefined;
@@ -101,18 +101,16 @@ pub fn fromJS(globalThis: *jsc.JSGlobalObject, input: jsc.JSValue) bun.JSError!j
 
 pub fn parse(
     allocator: std.mem.Allocator,
-    pm: ?*PackageManager,
     log: *logger.Log,
     positionals: []const string,
     update_requests: *Array,
     subcommand: Subcommand,
 ) []UpdateRequest {
-    return parseWithError(allocator, pm, log, positionals, update_requests, subcommand, true) catch Global.crash();
+    return parseWithError(allocator, log, positionals, update_requests, subcommand, true) catch Global.crash();
 }
 
 fn parseWithError(
     allocator: std.mem.Allocator,
-    pm: ?*PackageManager,
     log: *logger.Log,
     positionals: []const string,
     update_requests: *Array,
@@ -163,7 +161,6 @@ fn parseWithError(
             null,
             &SlicedString.init(input, value),
             log,
-            pm,
         ) orelse {
             if (fatal) {
                 Output.errGeneric("unrecognised dependency format: {s}", .{
@@ -186,7 +183,6 @@ fn parseWithError(
                 null,
                 &SlicedString.init(input, input),
                 log,
-                pm,
             )) |ver| {
                 alias = null;
                 version = ver;

--- a/src/install/PackageManager/install_with_manager.zig
+++ b/src/install/PackageManager/install_with_manager.zig
@@ -254,8 +254,8 @@ pub fn installWithManager(
                         break :brk all_name_hashes;
                     };
 
-                    manager.lockfile.overrides = try lockfile.overrides.clone(manager, &lockfile, manager.lockfile, builder);
-                    manager.lockfile.catalogs = try lockfile.catalogs.clone(manager, &lockfile, manager.lockfile, builder);
+                    manager.lockfile.overrides = try lockfile.overrides.clone(&lockfile, manager.lockfile, builder);
+                    manager.lockfile.catalogs = try lockfile.catalogs.clone(&lockfile, manager.lockfile, builder);
 
                     manager.lockfile.trusted_dependencies = if (lockfile.trusted_dependencies) |trusted_dependencies|
                         try trusted_dependencies.clone(manager.lockfile.allocator)
@@ -278,7 +278,7 @@ pub fn installWithManager(
                     manager.lockfile.buffers.resolutions.items = manager.lockfile.buffers.resolutions.items.ptr[0 .. off + len];
 
                     for (new_dependencies, 0..) |new_dep, i| {
-                        dependencies[i] = try new_dep.clone(manager, lockfile.buffers.string_bytes.items, *Lockfile.StringBuilder, builder);
+                        dependencies[i] = try new_dep.clone(lockfile.buffers.string_bytes.items, *Lockfile.StringBuilder, builder);
                         if (mapping[i] != invalid_package_id) {
                             resolutions[i] = old_resolutions[mapping[i]];
                         }

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -46,7 +46,7 @@ fn updatePackageJSONAndInstallWithManagerWithUpdatesAndUpdateRequests(
     var updates: []UpdateRequest = if (manager.subcommand == .@"patch-commit" or manager.subcommand == .patch)
         &[_]UpdateRequest{}
     else
-        UpdateRequest.parse(ctx.allocator, manager, ctx.log, positionals, update_requests, manager.subcommand);
+        UpdateRequest.parse(ctx.allocator, ctx.log, positionals, update_requests, manager.subcommand);
     try updatePackageJSONAndInstallWithManagerWithUpdates(
         manager,
         ctx,

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -61,11 +61,11 @@ pub fn count(this: *const Dependency, buf: []const u8, comptime StringBuilder: t
     this.countWithDifferentBuffers(buf, buf, StringBuilder, builder);
 }
 
-pub fn clone(this: *const Dependency, package_manager: *PackageManager, buf: []const u8, comptime StringBuilder: type, builder: StringBuilder) !Dependency {
-    return this.cloneWithDifferentBuffers(package_manager, buf, buf, StringBuilder, builder);
+pub fn clone(this: *const Dependency, buf: []const u8, comptime StringBuilder: type, builder: StringBuilder) !Dependency {
+    return this.cloneWithDifferentBuffers(buf, buf, StringBuilder, builder);
 }
 
-pub fn cloneWithDifferentBuffers(this: *const Dependency, package_manager: *PackageManager, name_buf: []const u8, version_buf: []const u8, comptime StringBuilder: type, builder: StringBuilder) !Dependency {
+pub fn cloneWithDifferentBuffers(this: *const Dependency, name_buf: []const u8, version_buf: []const u8, comptime StringBuilder: type, builder: StringBuilder) !Dependency {
     const out_slice = builder.lockfile.buffers.string_bytes.items;
     const new_literal = builder.append(String, this.version.literal.slice(version_buf));
     const sliced = new_literal.sliced(out_slice);
@@ -82,7 +82,6 @@ pub fn cloneWithDifferentBuffers(this: *const Dependency, package_manager: *Pack
             this.version.tag,
             &sliced,
             null,
-            package_manager,
         ) orelse Dependency.Version{},
         .behavior = this.behavior,
     };
@@ -99,7 +98,6 @@ pub const Context = struct {
     allocator: std.mem.Allocator,
     log: *logger.Log,
     buffer: []const u8,
-    package_manager: ?*PackageManager,
 };
 
 /// Get the name of the package as it should appear in a remote registry.
@@ -396,7 +394,6 @@ pub const Version = struct {
             tag,
             sliced,
             ctx.log,
-            ctx.package_manager,
         ) orelse Dependency.Version.zeroed;
     }
 
@@ -872,10 +869,9 @@ pub inline fn parse(
     dependency: string,
     sliced: *const SlicedString,
     log: ?*logger.Log,
-    manager: ?*PackageManager,
 ) ?Version {
     const dep = std.mem.trimLeft(u8, dependency, " \t\n\r");
-    return parseWithTag(allocator, alias, alias_hash, dep, Version.Tag.infer(dep), sliced, log, manager);
+    return parseWithTag(allocator, alias, alias_hash, dep, Version.Tag.infer(dep), sliced, log);
 }
 
 pub fn parseWithOptionalTag(
@@ -886,7 +882,6 @@ pub fn parseWithOptionalTag(
     tag: ?Dependency.Version.Tag,
     sliced: *const SlicedString,
     log: ?*logger.Log,
-    package_manager: ?*PackageManager,
 ) ?Version {
     const dep = std.mem.trimLeft(u8, dependency, " \t\n\r");
     return parseWithTag(
@@ -897,7 +892,6 @@ pub fn parseWithOptionalTag(
         tag orelse Version.Tag.infer(dep),
         sliced,
         log,
-        package_manager,
     );
 }
 
@@ -909,7 +903,6 @@ pub fn parseWithTag(
     tag: Dependency.Version.Tag,
     sliced: *const SlicedString,
     log_: ?*logger.Log,
-    package_manager: ?*PackageManager,
 ) ?Version {
     switch (tag) {
         .npm => {
@@ -967,16 +960,6 @@ pub fn parseWithTag(
                 },
                 .tag = .npm,
             };
-
-            if (is_alias) {
-                if (package_manager) |pm| {
-                    pm.known_npm_aliases.put(
-                        allocator,
-                        alias_hash.?,
-                        result,
-                    ) catch unreachable;
-                }
-            }
 
             return result;
         },
@@ -1294,7 +1277,7 @@ pub fn fromJS(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
     var log = logger.Log.init(allocator);
     const sliced = SlicedString.init(buf, name);
 
-    const dep: Version = Dependency.parse(allocator, SlicedString.init(buf, alias).value(), null, buf, &sliced, &log, null) orelse {
+    const dep: Version = Dependency.parse(allocator, SlicedString.init(buf, alias).value(), null, buf, &sliced, &log) orelse {
         if (log.msgs.items.len > 0) {
             return globalThis.throwValue(try log.toJS(globalThis, bun.default_allocator, "Failed to parse dependency"));
         }

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -541,7 +541,6 @@ fn preprocessUpdateRequests(old: *Lockfile, manager: *PackageManager, updates: [
                                 sliced.slice,
                                 &sliced,
                                 null,
-                                manager,
                             ) orelse Dependency.Version{};
                         }
                     }
@@ -683,8 +682,8 @@ pub fn cleanWithLogger(
         old.overrides.count(old, &builder);
         old.catalogs.count(old, &builder);
         try builder.allocate();
-        new.overrides = try old.overrides.clone(manager, old, new, &builder);
-        new.catalogs = try old.catalogs.clone(manager, old, new, &builder);
+        new.overrides = try old.overrides.clone(old, new, &builder);
+        new.catalogs = try old.catalogs.clone(old, new, &builder);
     }
 
     // Step 1. Recreate the lockfile with only the packages that are still alive
@@ -707,7 +706,7 @@ pub fn cleanWithLogger(
     };
 
     // try clone_queue.ensureUnusedCapacity(root.dependencies.len);
-    _ = try root.clone(manager, old, new, package_id_mapping, &cloner);
+    _ = try root.clone(old, new, package_id_mapping, &cloner);
 
     // Clone workspace_paths and workspace_versions at the end.
     if (old.workspace_paths.count() > 0 or old.workspace_versions.count() > 0) {
@@ -878,7 +877,6 @@ pub const Cloner = struct {
             const old_package = this.old.packages.get(to_clone.old_resolution);
 
             this.lockfile.buffers.resolutions.items[to_clone.resolve_id] = try old_package.clone(
-                this.manager,
                 this.old,
                 this.lockfile,
                 this.mapping,

--- a/src/install/lockfile/Buffers.zig
+++ b/src/install/lockfile/Buffers.zig
@@ -338,7 +338,6 @@ pub fn load(stream: *Stream, allocator: Allocator, log: *logger.Log, pm_: ?*Pack
         .log = log,
         .allocator = allocator,
         .buffer = string_buf,
-        .package_manager = pm_,
     };
 
     this.dependencies.expandToCapacity();

--- a/src/install/lockfile/CatalogMap.zig
+++ b/src/install/lockfile/CatalogMap.zig
@@ -109,7 +109,6 @@ pub fn parseCount(_: *CatalogMap, lockfile: *Lockfile, expr: Expr, builder: *Loc
 
 pub fn parseAppend(
     this: *CatalogMap,
-    pm: *PackageManager,
     lockfile: *Lockfile,
     log: *logger.Log,
     source: *const logger.Source,
@@ -141,7 +140,6 @@ pub fn parseAppend(
                                 version_sliced.slice,
                                 &version_sliced,
                                 log,
-                                pm,
                             ) orelse {
                                 try log.addError(source, item.value.?.loc, "Invalid dependency version");
                                 continue;
@@ -202,7 +200,6 @@ pub fn parseAppend(
                                             version_sliced.slice,
                                             &version_sliced,
                                             log,
-                                            pm,
                                         ) orelse {
                                             try log.addError(source, item.value.?.loc, "Invalid dependency version");
                                             continue;
@@ -305,7 +302,6 @@ fn putEntriesFromPnpmLockfile(
                 version_sliced.slice,
                 &version_sliced,
                 log,
-                null,
             ) orelse {
                 return error.InvalidPnpmLockfile;
             },
@@ -407,7 +403,7 @@ pub fn count(this: *CatalogMap, lockfile: *Lockfile, builder: *Lockfile.StringBu
     }
 }
 
-pub fn clone(this: *CatalogMap, pm: *PackageManager, old: *Lockfile, new: *Lockfile, builder: *Lockfile.StringBuilder) OOM!CatalogMap {
+pub fn clone(this: *CatalogMap, old: *Lockfile, new: *Lockfile, builder: *Lockfile.StringBuilder) OOM!CatalogMap {
     var new_catalog: CatalogMap = .{};
 
     try new_catalog.default.ensureTotalCapacity(new.allocator, this.default.count());
@@ -418,7 +414,7 @@ pub fn clone(this: *CatalogMap, pm: *PackageManager, old: *Lockfile, new: *Lockf
         const dep = entry.value_ptr;
         new_catalog.default.putAssumeCapacityContext(
             builder.append(String, dep_name.slice(old.buffers.string_bytes.items)),
-            try dep.clone(pm, old.buffers.string_bytes.items, @TypeOf(builder), builder),
+            try dep.clone(old.buffers.string_bytes.items, @TypeOf(builder), builder),
             String.arrayHashContext(new, null),
         );
     }
@@ -439,7 +435,7 @@ pub fn clone(this: *CatalogMap, pm: *PackageManager, old: *Lockfile, new: *Lockf
             const dep = entry.value_ptr;
             new_group.putAssumeCapacityContext(
                 builder.append(String, dep_name.slice(old.buffers.string_bytes.items)),
-                try dep.clone(pm, old.buffers.string_bytes.items, @TypeOf(builder), builder),
+                try dep.clone(old.buffers.string_bytes.items, @TypeOf(builder), builder),
                 String.arrayHashContext(new, null),
             );
         }

--- a/src/install/lockfile/CatalogMap.zig
+++ b/src/install/lockfile/CatalogMap.zig
@@ -464,4 +464,3 @@ const String = bun.Semver.String;
 
 const Dependency = bun.install.Dependency;
 const Lockfile = bun.install.Lockfile;
-const PackageManager = bun.install.PackageManager;

--- a/src/install/lockfile/OverrideMap.zig
+++ b/src/install/lockfile/OverrideMap.zig
@@ -349,5 +349,4 @@ const String = bun.Semver.String;
 
 const Dependency = bun.install.Dependency;
 const Lockfile = bun.install.Lockfile;
-const PackageManager = bun.install.PackageManager;
 const PackageNameHash = bun.install.PackageNameHash;

--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -79,7 +79,6 @@ pub fn Package(comptime SemverIntType: type) type {
 
         pub fn clone(
             this: *const @This(),
-            pm: *PackageManager,
             old: *Lockfile,
             new: *Lockfile,
             package_id_mapping: []PackageID,
@@ -176,7 +175,6 @@ pub fn Package(comptime SemverIntType: type) type {
 
             for (old_dependencies, dependencies) |old_dep, *new_dep| {
                 new_dep.* = try old_dep.clone(
-                    pm,
                     old_string_buf,
                     *Lockfile.StringBuilder,
                     builder,
@@ -210,7 +208,6 @@ pub fn Package(comptime SemverIntType: type) type {
 
         pub fn fromPackageJSON(
             lockfile: *Lockfile,
-            pm: *PackageManager,
             package_json: *PackageJSON,
             comptime features: Features,
         ) !@This() {
@@ -270,7 +267,7 @@ pub fn Package(comptime SemverIntType: type) type {
                 for (package_dependencies) |dep| {
                     if (!dep.behavior.isEnabled(features)) continue;
 
-                    dependencies[0] = try dep.clone(pm, source_buf, @TypeOf(&string_builder), &string_builder);
+                    dependencies[0] = try dep.clone(source_buf, @TypeOf(&string_builder), &string_builder);
                     dependencies = dependencies[1..];
                     if (dependencies.len == 0) break;
                 }
@@ -300,7 +297,6 @@ pub fn Package(comptime SemverIntType: type) type {
         }
 
         pub fn fromNPM(
-            pm: *PackageManager,
             allocator: Allocator,
             lockfile: *Lockfile,
             log: *logger.Log,
@@ -463,7 +459,6 @@ pub fn Package(comptime SemverIntType: type) type {
                                 sliced.slice,
                                 &sliced,
                                 log,
-                                pm,
                             ) orelse Dependency.Version{},
                         };
 
@@ -1031,7 +1026,6 @@ pub fn Package(comptime SemverIntType: type) type {
                 tag,
                 &sliced,
                 log,
-                pm,
             ) orelse Dependency.Version{};
             var workspace_range: ?Semver.Query.Group = null;
             const name_hash = switch (dependency_version.tag) {
@@ -1100,7 +1094,6 @@ pub fn Package(comptime SemverIntType: type) type {
                                 .workspace,
                                 &path,
                                 log,
-                                pm,
                             )) |dep| {
                                 dependency_version.tag = dep.tag;
                                 dependency_version.value = dep.value;
@@ -1943,12 +1936,12 @@ pub fn Package(comptime SemverIntType: type) type {
 
             // This function depends on package.dependencies being set, so it is done at the very end.
             if (comptime features.is_main) {
-                try lockfile.overrides.parseAppend(pm, lockfile, package, log, source, json, &string_builder);
+                try lockfile.overrides.parseAppend(lockfile, package, log, source, json, &string_builder);
 
                 var found_any_catalog_or_catalog_object = false;
                 var has_workspaces = false;
                 if (json.get("workspaces")) |workspaces_expr| {
-                    found_any_catalog_or_catalog_object = try lockfile.catalogs.parseAppend(pm, lockfile, log, source, workspaces_expr, &string_builder);
+                    found_any_catalog_or_catalog_object = try lockfile.catalogs.parseAppend(lockfile, log, source, workspaces_expr, &string_builder);
                     has_workspaces = true;
                 }
 
@@ -1957,7 +1950,7 @@ pub fn Package(comptime SemverIntType: type) type {
                 // allow "catalog" and "catalogs" in top-level "package.json"
                 // so it's easier to guess.
                 if (!found_any_catalog_or_catalog_object and has_workspaces) {
-                    _ = try lockfile.catalogs.parseAppend(pm, lockfile, log, source, json, &string_builder);
+                    _ = try lockfile.catalogs.parseAppend(lockfile, log, source, json, &string_builder);
                 }
             }
 

--- a/src/install/lockfile/bun.lock.zig
+++ b/src/install/lockfile/bun.lock.zig
@@ -1276,7 +1276,6 @@ pub fn parseIntoBinaryLockfile(
                     version_sliced.slice,
                     &version_sliced,
                     log,
-                    manager,
                 ) orelse {
                     try log.addError(source, value.loc, "Invalid override version");
                     return error.InvalidOverridesObject;
@@ -1326,7 +1325,6 @@ pub fn parseIntoBinaryLockfile(
                     version_sliced.slice,
                     &version_sliced,
                     log,
-                    manager,
                 ) orelse {
                     try log.addError(source, value.loc, "Invalid catalog version");
                     return error.InvalidCatalogObject;
@@ -1406,7 +1404,6 @@ pub fn parseIntoBinaryLockfile(
                         version_sliced.slice,
                         &version_sliced,
                         log,
-                        manager,
                     ) orelse {
                         try log.addError(source, value.loc, "Invalid catalog version");
                         return error.InvalidCatalogsObject;
@@ -2191,7 +2188,6 @@ fn parseAppendDependencies(
                         version_sliced.slice,
                         &version_sliced,
                         log,
-                        null,
                     ) orelse {
                         try log.addError(source, value.loc, "Invalid dependency version");
                         return error.InvalidDependencyVersion;

--- a/src/install/lockfile/bun.lockb.zig
+++ b/src/install/lockfile/bun.lockb.zig
@@ -464,7 +464,6 @@ pub fn load(
                     .allocator = allocator,
                     .log = log,
                     .buffer = lockfile.buffers.string_bytes.items,
-                    .package_manager = manager,
                 };
                 for (overrides_name_hashes.items, override_versions_external.items) |name, value| {
                     map.putAssumeCapacity(name, Dependency.toDependency(value, context));
@@ -528,7 +527,6 @@ pub fn load(
                     .allocator = allocator,
                     .log = log,
                     .buffer = lockfile.buffers.string_bytes.items,
-                    .package_manager = manager,
                 };
 
                 for (default_dep_names.items, default_deps.items) |dep_name, dep| {

--- a/src/install/migration.zig
+++ b/src/install/migration.zig
@@ -769,7 +769,6 @@ pub fn migrateNPMLockfile(
                         sliced.slice,
                         &sliced,
                         log,
-                        manager,
                     ) orelse {
                         return error.InvalidNPMLockfile;
                     };
@@ -850,7 +849,6 @@ pub fn migrateNPMLockfile(
                                                         tag,
                                                         &dep_resolved_sliced,
                                                         log,
-                                                        manager,
                                                     ) orelse return error.InvalidNPMLockfile;
 
                                                     break :dep_resolved dep_resolved;

--- a/src/install/pnpm.zig
+++ b/src/install/pnpm.zig
@@ -174,7 +174,6 @@ pub fn migratePnpmLockfile(
                         version_sliced.slice,
                         &version_sliced,
                         log,
-                        manager,
                     ) orelse {
                         return invalidPnpmLockfile();
                     },
@@ -908,7 +907,6 @@ fn parseAppendPackageDependencies(
                         version_sliced.slice,
                         &version_sliced,
                         log,
-                        null,
                     ) orelse {
                         return invalidPnpmLockfile();
                     },
@@ -1015,7 +1013,6 @@ fn parseAppendPackageDependencies(
                                 version_sliced.slice,
                                 &version_sliced,
                                 log,
-                                null,
                             ) orelse {
                                 return invalidPnpmLockfile();
                             },
@@ -1038,7 +1035,6 @@ fn parseAppendPackageDependencies(
                     version_sliced.slice,
                     &version_sliced,
                     log,
-                    null,
                 ) orelse {
                     return invalidPnpmLockfile();
                 },
@@ -1157,7 +1153,6 @@ fn parseAppendImporterDependencies(
                         specifier_sliced.slice,
                         &specifier_sliced,
                         log,
-                        null,
                     ) orelse {
                         return invalidPnpmLockfile();
                     },

--- a/src/install/yarn.zig
+++ b/src/install/yarn.zig
@@ -483,7 +483,6 @@ fn processDeps(
     deps_buf: []Dependency,
     res_buf: []Install.PackageID,
     log: *logger.Log,
-    manager: *Install.PackageManager,
     yarn_entry_to_package_id: []const Install.PackageID,
 ) ![]Install.PackageID {
     var deps_it = deps.iterator();
@@ -520,7 +519,6 @@ fn processDeps(
                     parsed_version,
                     &Semver.SlicedString.init(parsed_version, parsed_version),
                     log,
-                    manager,
                 ) orelse Dependency.Version{},
                 .behavior = .{
                     .prod = dep_type == .production,
@@ -714,7 +712,7 @@ pub fn migrateYarnLockfile(
             if (string_builder.cap > 0) {
                 try string_builder.allocate();
             }
-            try this.overrides.parseAppend(manager, this, &root_package, log, &package_json_source, package_json, &string_builder);
+            try this.overrides.parseAppend(this, &root_package, log, &package_json_source, package_json, &string_builder);
             this.packages.set(0, root_package);
         }
     }
@@ -1043,7 +1041,6 @@ pub fn migrateYarnLockfile(
                         version_string.slice(this.buffers.string_bytes.items),
                         &version_string.sliced(this.buffers.string_bytes.items),
                         log,
-                        manager,
                     ) orelse Dependency.Version{},
                     .behavior = .{
                         .prod = dep.dep_type == .production,
@@ -1079,25 +1076,25 @@ pub fn migrateYarnLockfile(
         const dependencies_start = dependencies_buf.ptr;
         const resolutions_start = resolutions_buf.ptr;
         if (entry.dependencies) |deps| {
-            const processed = try processDeps(deps, .production, &yarn_lock, &string_buf, dependencies_buf, resolutions_buf, log, manager, yarn_entry_to_package_id);
+            const processed = try processDeps(deps, .production, &yarn_lock, &string_buf, dependencies_buf, resolutions_buf, log, yarn_entry_to_package_id);
             dependencies_buf = dependencies_buf[processed.len..];
             resolutions_buf = resolutions_buf[processed.len..];
         }
 
         if (entry.optionalDependencies) |deps| {
-            const processed = try processDeps(deps, .optional, &yarn_lock, &string_buf, dependencies_buf, resolutions_buf, log, manager, yarn_entry_to_package_id);
+            const processed = try processDeps(deps, .optional, &yarn_lock, &string_buf, dependencies_buf, resolutions_buf, log, yarn_entry_to_package_id);
             dependencies_buf = dependencies_buf[processed.len..];
             resolutions_buf = resolutions_buf[processed.len..];
         }
 
         if (entry.peerDependencies) |deps| {
-            const processed = try processDeps(deps, .peer, &yarn_lock, &string_buf, dependencies_buf, resolutions_buf, log, manager, yarn_entry_to_package_id);
+            const processed = try processDeps(deps, .peer, &yarn_lock, &string_buf, dependencies_buf, resolutions_buf, log, yarn_entry_to_package_id);
             dependencies_buf = dependencies_buf[processed.len..];
             resolutions_buf = resolutions_buf[processed.len..];
         }
 
         if (entry.devDependencies) |deps| {
-            const processed = try processDeps(deps, .development, &yarn_lock, &string_buf, dependencies_buf, resolutions_buf, log, manager, yarn_entry_to_package_id);
+            const processed = try processDeps(deps, .development, &yarn_lock, &string_buf, dependencies_buf, resolutions_buf, log, yarn_entry_to_package_id);
             dependencies_buf = dependencies_buf[processed.len..];
             resolutions_buf = resolutions_buf[processed.len..];
         }
@@ -1435,7 +1432,6 @@ pub fn migrateYarnLockfile(
                 dep_version_string.slice(this.buffers.string_bytes.items),
                 &sliced_string,
                 log,
-                manager,
             ) orelse Dependency.Version{};
 
             parsed_version.literal = dep_version_string;
@@ -1501,7 +1497,6 @@ pub fn migrateYarnLockfile(
                     dep_version_string.slice(this.buffers.string_bytes.items),
                     &sliced_string,
                     log,
-                    manager,
                 ) orelse Dependency.Version{};
 
                 parsed_version.literal = dep_version_string;
@@ -1545,7 +1540,6 @@ pub fn migrateYarnLockfile(
                     dep_version_string.slice(this.buffers.string_bytes.items),
                     &sliced_string,
                     log,
-                    manager,
                 ) orelse Dependency.Version{};
 
                 parsed_version.literal = dep_version_string;
@@ -1589,7 +1583,6 @@ pub fn migrateYarnLockfile(
                     dep_version_string.slice(this.buffers.string_bytes.items),
                     &sliced_string,
                     log,
-                    manager,
                 ) orelse Dependency.Version{};
 
                 parsed_version.literal = dep_version_string;
@@ -1633,7 +1626,6 @@ pub fn migrateYarnLockfile(
                     dep_version_string.slice(this.buffers.string_bytes.items),
                     &sliced_string,
                     log,
-                    manager,
                 ) orelse Dependency.Version{};
 
                 parsed_version.literal = dep_version_string;

--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -921,7 +921,6 @@ pub const PackageJSON = struct {
                                 .npm,
                                 &sliced,
                                 r.log,
-                                pm,
                             )) |dependency_version| {
                                 if (dependency_version.value.npm.version.isExact()) {
                                     if (pm.lockfile.resolvePackageFromNameAndVersion(package_json.name, dependency_version)) |resolved| {
@@ -1043,7 +1042,6 @@ pub const PackageJSON = struct {
                                         version_str,
                                         &sliced_str,
                                         r.log,
-                                        r.package_manager,
                                     )) |dependency_version| {
                                         const dependency = Dependency{
                                             .name = name,

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1987,7 +1987,6 @@ pub const Resolver = struct {
                                 esm.version,
                                 &sliced_string,
                                 r.log,
-                                manager,
                             ) orelse break :load_module_from_cache;
                         }
 
@@ -2309,7 +2308,6 @@ pub const Resolver = struct {
             if (package_json_) |package_json| {
                 package = Package.fromPackageJSON(
                     pm.lockfile,
-                    pm,
                     package_json,
                     Install.Features{
                         .dev_dependencies = true,

--- a/test/regression/issue/28674.test.ts
+++ b/test/regression/issue/28674.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { execSync } from "child_process";
+import { spawnSync } from "bun";
 import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
@@ -10,7 +10,8 @@ function createTarball(baseDir: string, pkgName: string, version: string): strin
   writeFileSync(join(tmpPkg, "package", "package.json"), JSON.stringify({ name: pkgName, version }));
   writeFileSync(join(tmpPkg, "package", "index.js"), `module.exports = '${pkgName}';`);
   const tgzPath = join(baseDir, "_tarballs", `${pkgName}-${version}.tgz`);
-  execSync(`tar czf "${tgzPath}" package`, { cwd: tmpPkg });
+  const result = spawnSync(["tar", "czf", tgzPath, "package"], { cwd: tmpPkg });
+  if (result.exitCode !== 0) throw new Error(`tar failed: ${result.stderr.toString()}`);
   return tgzPath;
 }
 

--- a/test/regression/issue/28674.test.ts
+++ b/test/regression/issue/28674.test.ts
@@ -1,0 +1,167 @@
+import { expect, test } from "bun:test";
+import { bunExe, bunEnv, tempDir } from "harness";
+import { join } from "path";
+import { mkdirSync, writeFileSync, readFileSync } from "fs";
+import { execSync } from "child_process";
+
+function createTarball(baseDir: string, pkgName: string, version: string): string {
+  const tmpPkg = join(baseDir, "_tarballs", `${pkgName}-${version}`);
+  mkdirSync(join(tmpPkg, "package"), { recursive: true });
+  writeFileSync(
+    join(tmpPkg, "package", "package.json"),
+    JSON.stringify({ name: pkgName, version })
+  );
+  writeFileSync(join(tmpPkg, "package", "index.js"), `module.exports = '${pkgName}';`);
+  const tgzPath = join(baseDir, "_tarballs", `${pkgName}-${version}.tgz`);
+  execSync(`tar czf "${tgzPath}" package`, { cwd: tmpPkg });
+  return tgzPath;
+}
+
+test("bun install does not corrupt package names when workspace uses npm alias", async () => {
+  using dir = tempDir("28674", {});
+  const cwd = String(dir);
+
+  // Create tarballs for mock packages
+  const realPkgTgz = createTarball(cwd, "real-pkg", "1.0.0");
+  const myPkgTgz = createTarball(cwd, "my-pkg", "1.0.0");
+  const extraDepTgz = createTarball(cwd, "extra-dep", "1.0.0");
+
+  // Mock registry server - runs in this process so we need concurrent I/O
+  await using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      const path = url.pathname;
+
+      const packages: Record<string, string> = {
+        "real-pkg": realPkgTgz,
+        "my-pkg": myPkgTgz,
+        "extra-dep": extraDepTgz,
+      };
+
+      // Serve package manifests
+      for (const [name, tgzPath] of Object.entries(packages)) {
+        if (path === `/${name}`) {
+          return Response.json({
+            name,
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name,
+                version: "1.0.0",
+                dist: {
+                  tarball: `http://127.0.0.1:${server.port}/${name}/-/${name}-1.0.0.tgz`,
+                  integrity: "",
+                },
+              },
+            },
+          });
+        }
+        if (path === `/${name}/-/${name}-1.0.0.tgz`) {
+          return new Response(Bun.file(tgzPath));
+        }
+      }
+
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  const registryUrl = `http://127.0.0.1:${server.port}/`;
+
+  // Write bunfig to point to mock registry
+  writeFileSync(join(cwd, "bunfig.toml"), `[install]\nregistry = "${registryUrl}"\n`);
+
+  // Create workspace structure
+  mkdirSync(join(cwd, "packages", "workspace-a"), { recursive: true });
+  mkdirSync(join(cwd, "packages", "workspace-b"), { recursive: true });
+
+  writeFileSync(
+    join(cwd, "package.json"),
+    JSON.stringify({
+      name: "monorepo",
+      private: true,
+      workspaces: ["packages/*"],
+    })
+  );
+  writeFileSync(
+    join(cwd, "packages", "workspace-a", "package.json"),
+    JSON.stringify({
+      name: "workspace-a",
+      dependencies: {
+        // npm alias: "my-pkg" resolves to "real-pkg@1.0.0"
+        "my-pkg": "npm:real-pkg@1.0.0",
+      },
+    })
+  );
+  writeFileSync(
+    join(cwd, "packages", "workspace-b", "package.json"),
+    JSON.stringify({
+      name: "workspace-b",
+      dependencies: {
+        "my-pkg": "1.0.0",
+      },
+    })
+  );
+
+  const spawnEnv = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(cwd, ".bun-cache") };
+
+  // First install
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd,
+      env: spawnEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+
+  // Add a new dependency to workspace-b
+  writeFileSync(
+    join(cwd, "packages", "workspace-b", "package.json"),
+    JSON.stringify({
+      name: "workspace-b",
+      dependencies: {
+        "my-pkg": "1.0.0",
+        "extra-dep": "1.0.0",
+      },
+    })
+  );
+
+  // Second install — this previously caused corrupted package names due to
+  // stale string buffer offsets in known_npm_aliases
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd,
+      env: spawnEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).not.toContain("error:");
+    expect(stderr).not.toContain("405");
+    expect(exitCode).toBe(0);
+  }
+
+  // Read the lockfile and verify workspace-b's "my-pkg" resolved to the
+  // actual "my-pkg" package, not "real-pkg" (the alias target).
+  // The old code's known_npm_aliases incorrectly substituted the name.
+  const lockContent = readFileSync(join(cwd, "bun.lock"), "utf8");
+
+  // bun.lock contains both "my-pkg" and "real-pkg" as separate packages.
+  // With the old buggy code, "my-pkg" was incorrectly resolved as "real-pkg".
+  expect(lockContent).toContain('"my-pkg@');
+  expect(lockContent).toContain('"real-pkg@');
+});

--- a/test/regression/issue/28674.test.ts
+++ b/test/regression/issue/28674.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "bun:test";
 import { spawnSync } from "bun";
+import { expect, test } from "bun:test";
 import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";

--- a/test/regression/issue/28674.test.ts
+++ b/test/regression/issue/28674.test.ts
@@ -149,8 +149,9 @@ test("bun install does not corrupt package names when workspace uses npm alias",
   // The old code's known_npm_aliases incorrectly substituted the name.
   const lockContent = readFileSync(join(cwd, "bun.lock"), "utf8");
 
-  // bun.lock contains both "my-pkg" and "real-pkg" as separate packages.
-  // With the old buggy code, "my-pkg" was incorrectly resolved as "real-pkg".
-  expect(lockContent).toContain('"my-pkg@');
-  expect(lockContent).toContain('"real-pkg@');
+  // The packages section must contain a resolution "my-pkg@1.0.0" (the real
+  // package), not just "real-pkg@1.0.0". With the old buggy code, my-pkg was
+  // incorrectly resolved as real-pkg so "my-pkg@1.0.0" never appeared.
+  expect(lockContent).toContain('"my-pkg@1.0.0"');
+  expect(lockContent).toContain('"real-pkg@1.0.0"');
 });

--- a/test/regression/issue/28674.test.ts
+++ b/test/regression/issue/28674.test.ts
@@ -1,16 +1,13 @@
 import { expect, test } from "bun:test";
-import { bunExe, bunEnv, tempDir } from "harness";
-import { join } from "path";
-import { mkdirSync, writeFileSync, readFileSync } from "fs";
 import { execSync } from "child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
 
 function createTarball(baseDir: string, pkgName: string, version: string): string {
   const tmpPkg = join(baseDir, "_tarballs", `${pkgName}-${version}`);
   mkdirSync(join(tmpPkg, "package"), { recursive: true });
-  writeFileSync(
-    join(tmpPkg, "package", "package.json"),
-    JSON.stringify({ name: pkgName, version })
-  );
+  writeFileSync(join(tmpPkg, "package", "package.json"), JSON.stringify({ name: pkgName, version }));
   writeFileSync(join(tmpPkg, "package", "index.js"), `module.exports = '${pkgName}';`);
   const tgzPath = join(baseDir, "_tarballs", `${pkgName}-${version}.tgz`);
   execSync(`tar czf "${tgzPath}" package`, { cwd: tmpPkg });
@@ -81,7 +78,7 @@ test("bun install does not corrupt package names when workspace uses npm alias",
       name: "monorepo",
       private: true,
       workspaces: ["packages/*"],
-    })
+    }),
   );
   writeFileSync(
     join(cwd, "packages", "workspace-a", "package.json"),
@@ -91,7 +88,7 @@ test("bun install does not corrupt package names when workspace uses npm alias",
         // npm alias: "my-pkg" resolves to "real-pkg@1.0.0"
         "my-pkg": "npm:real-pkg@1.0.0",
       },
-    })
+    }),
   );
   writeFileSync(
     join(cwd, "packages", "workspace-b", "package.json"),
@@ -100,7 +97,7 @@ test("bun install does not corrupt package names when workspace uses npm alias",
       dependencies: {
         "my-pkg": "1.0.0",
       },
-    })
+    }),
   );
 
   const spawnEnv = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(cwd, ".bun-cache") };
@@ -114,11 +111,7 @@ test("bun install does not corrupt package names when workspace uses npm alias",
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("error:");
     expect(exitCode).toBe(0);
   }
@@ -132,7 +125,7 @@ test("bun install does not corrupt package names when workspace uses npm alias",
         "my-pkg": "1.0.0",
         "extra-dep": "1.0.0",
       },
-    })
+    }),
   );
 
   // Second install — this previously caused corrupted package names due to
@@ -145,11 +138,7 @@ test("bun install does not corrupt package names when workspace uses npm alias",
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("error:");
     expect(stderr).not.toContain("405");
     expect(exitCode).toBe(0);

--- a/test/regression/issue/28674.test.ts
+++ b/test/regression/issue/28674.test.ts
@@ -150,6 +150,9 @@ test("bun install does not corrupt package names when workspace uses npm alias",
   // The old code's known_npm_aliases incorrectly substituted the name.
   const lockContent = readFileSync(join(cwd, "bun.lock"), "utf8");
 
+  // Prove the second install picked up the new dependency from workspace-b.
+  expect(lockContent).toContain('"extra-dep@1.0.0"');
+
   // The packages section must contain a resolution "my-pkg@1.0.0" (the real
   // package), not just "real-pkg@1.0.0". With the old buggy code, my-pkg was
   // incorrectly resolved as real-pkg so "my-pkg@1.0.0" never appeared.


### PR DESCRIPTION
## Problem

When a workspace uses an npm alias (e.g., `"react-native": "npm:react-native-tvos@0.79.3-0"`) and another workspace depends on the same package name normally (`"react-native": "0.79.4"`), running `bun install` after adding a new dependency produces corrupted package names like `9.3-0@babel%2fcode-`, resulting in 405/404 errors from the registry.

## Root cause

The `known_npm_aliases` map stored `Dependency.Version` objects containing `String` offsets into the lockfile's string buffer. On subsequent installs when a new dependency was added, these offsets became stale as the string buffer changed during lockfile reload and diff processing. The stale offsets then pointed to garbage data, producing corrupted package names in registry URLs.

Even without buffer corruption, the alias lookup was semantically incorrect: it would substitute a normal dependency's package name with the alias target when the version ranges happened to satisfy each other, causing the wrong package to be resolved (e.g., `my-pkg` would silently resolve to `real-pkg`).

## Fix

Remove the `known_npm_aliases` mechanism entirely, along with the `package_manager` parameter that was threaded through all `Dependency` parse/clone functions solely to populate this map.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/regression/issue/28674.test.ts  → FAILS (system bun incorrectly resolves my-pkg as real-pkg)
bun bd test test/regression/issue/28674.test.ts                 → PASSES (fix correctly keeps packages separate)
```

Closes #28674