### PR TITLE
sys: add /dev/fd fallback to getFdPath for FreeBSD Linuxulator

### DIFF
--- a/src/sys.zig
+++ b/src/sys.zig
@@ -2748,13 +2748,27 @@ pub fn getFdPath(fd: bun.FileDescriptor, out_buffer: *bun.PathBuffer) Maybe([]u8
             return .{ .result = bun.sliceTo(out_buffer, 0) };
         },
         .linux => {
-            // TODO: alpine linux may not have /proc/self
             var procfs_buf: ["/proc/self/fd/-2147483648".len + 1:0]u8 = undefined;
             const proc_path = std.fmt.bufPrintZ(&procfs_buf, "/proc/self/fd/{d}", .{fd.cast()}) catch unreachable;
-            return switch (readlink(proc_path, out_buffer)) {
-                .err => |err| return .{ .err = err },
-                .result => |result| .{ .result = result },
-            };
+            switch (readlink(proc_path, out_buffer)) {
+                .result => |result| return .{ .result = result },
+                .err => |err| switch (err.getErrno()) {
+                    // /proc/self/fd/N unreadable: /proc not mounted (minimal
+                    // containers), or FreeBSD linprocfs where /proc/<pid>/fd is
+                    // a symlink to /dev/fd that escapes emul_path and lands on
+                    // host devfs. Retry via /dev/fd directly — that goes through
+                    // emul_path → /compat/linux/dev/fd (fdescfs, readlink works).
+                    // On real Linux /dev/fd → /proc/self/fd so this is a no-op.
+                    .NOENT, .INVAL, .NOTDIR => {
+                        const dev_path = std.fmt.bufPrintZ(&procfs_buf, "/dev/fd/{d}", .{fd.cast()}) catch unreachable;
+                        return switch (readlink(dev_path, out_buffer)) {
+                            .err => |_| .{ .err = err }, // report original error
+                            .result => |result| .{ .result = result },
+                        };
+                    },
+                    else => return .{ .err = err },
+                },
+            }
         },
         .wasm => @compileError("querying for canonical path of a handle is unsupported on this host"),
     }

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -575,6 +575,10 @@ pub const StatxField = enum(comptime_int) {
 // Linux Kernel v4.11
 pub var supports_statx_on_linux = std.atomic.Value(bool).init(true);
 
+/// Memoize whether /proc/self/fd is usable for getFdPath.
+/// 0 = untested, 1 = use /dev/fd (FreeBSD Linuxulator / no /proc).
+pub var use_devfd_fallback = std.atomic.Value(u8).init(0);
+
 /// Linux kernel makedev encoding for device numbers
 /// From glibc sys/sysmacros.h and Linux kernel <linux/kdev_t.h>
 /// dev_t layout (64 bits):
@@ -2749,28 +2753,30 @@ pub fn getFdPath(fd: bun.FileDescriptor, out_buffer: *bun.PathBuffer) Maybe([]u8
         },
         .linux => {
             var procfs_buf: ["/proc/self/fd/-2147483648".len + 1:0]u8 = undefined;
-            const proc_path = std.fmt.bufPrintZ(&procfs_buf, "/proc/self/fd/{d}", .{fd.cast()}) catch unreachable;
-            switch (readlink(proc_path, out_buffer)) {
-                .result => |result| return .{ .result = result },
-                .err => |err| switch (err.getErrno()) {
-                    // /proc/self/fd/N unreadable: /proc not mounted (minimal
-                    // containers), or FreeBSD linprocfs where /proc/<pid>/fd is
-                    // a symlink to /dev/fd that escapes emul_path and lands on
-                    // host devfs. Retry via /dev/fd directly — that goes through
-                    // emul_path → /compat/linux/dev/fd (fdescfs, readlink works).
-                    // On real Linux /dev/fd → /proc/self/fd so this is a no-op.
-                    .NOENT, .INVAL, .NOTDIR => {
-                        // separate buffer: err.path borrows from procfs_buf
-                        var devfd_buf: ["/dev/fd/-2147483648".len + 1:0]u8 = undefined;
-                        const dev_path = std.fmt.bufPrintZ(&devfd_buf, "/dev/fd/{d}", .{fd.cast()}) catch unreachable;
-                        return switch (readlink(dev_path, out_buffer)) {
-                            .err => |_| .{ .err = err }, // report original error
-                            .result => |result| .{ .result = result },
-                        };
+
+            if (use_devfd_fallback.load(.acquire) == 0) {
+                const proc_path = std.fmt.bufPrintZ(&procfs_buf, "/proc/self/fd/{d}", .{fd.cast()}) catch unreachable;
+                switch (readlink(proc_path, out_buffer)) {
+                    .result => |result| return .{ .result = result },
+                    .err => |err| switch (err.getErrno()) {
+                        // /proc/self/fd/N unreadable: /proc not mounted (minimal
+                        // containers), or FreeBSD linprocfs where /proc/<pid>/fd
+                        // escapes emul_path and lands on host devfs.
+                        .NOENT, .INVAL, .NOTDIR => {
+                            use_devfd_fallback.store(1, .release);
+                        },
+                        else => return .{ .err = err },
                     },
-                    else => return .{ .err = err },
-                },
+                }
             }
+
+            // Either we just discovered /proc doesn't work, or a previous
+            // call already flipped the flag. Use /dev/fd directly.
+            const dev_path = std.fmt.bufPrintZ(&procfs_buf, "/dev/fd/{d}", .{fd.cast()}) catch unreachable;
+            return switch (readlink(dev_path, out_buffer)) {
+                .err => |err| .{ .err = err },
+                .result => |result| .{ .result = result },
+            };
         },
         .wasm => @compileError("querying for canonical path of a handle is unsupported on this host"),
     }

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -2758,20 +2758,27 @@ pub fn getFdPath(fd: bun.FileDescriptor, out_buffer: *bun.PathBuffer) Maybe([]u8
                 const proc_path = std.fmt.bufPrintZ(&procfs_buf, "/proc/self/fd/{d}", .{fd.cast()}) catch unreachable;
                 switch (readlink(proc_path, out_buffer)) {
                     .result => |result| return .{ .result = result },
-                    .err => |err| switch (err.getErrno()) {
+                    .err => |proc_err| switch (proc_err.getErrno()) {
                         // /proc/self/fd/N unreadable: /proc not mounted (minimal
                         // containers), or FreeBSD linprocfs where /proc/<pid>/fd
                         // escapes emul_path and lands on host devfs.
                         .NOENT, .INVAL, .NOTDIR => {
-                            use_devfd_fallback.store(1, .release);
+                            var devfd_buf: ["/dev/fd/-2147483648".len + 1:0]u8 = undefined;
+                            const dev_path = std.fmt.bufPrintZ(&devfd_buf, "/dev/fd/{d}", .{fd.cast()}) catch unreachable;
+                            return switch (readlink(dev_path, out_buffer)) {
+                                .result => |result| {
+                                    use_devfd_fallback.store(1, .release);
+                                    return .{ .result = result };
+                                },
+                                .err => |_| .{ .err = proc_err },
+                            };
                         },
-                        else => return .{ .err = err },
+                        else => return .{ .err = proc_err },
                     },
                 }
             }
 
-            // Either we just discovered /proc doesn't work, or a previous
-            // call already flipped the flag. Use /dev/fd directly.
+            // Previous call confirmed /dev/fd works on this host.
             const dev_path = std.fmt.bufPrintZ(&procfs_buf, "/dev/fd/{d}", .{fd.cast()}) catch unreachable;
             return switch (readlink(dev_path, out_buffer)) {
                 .err => |err| .{ .err = err },

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -575,9 +575,41 @@ pub const StatxField = enum(comptime_int) {
 // Linux Kernel v4.11
 pub var supports_statx_on_linux = std.atomic.Value(bool).init(true);
 
-/// Memoize whether /proc/self/fd is usable for getFdPath.
-/// 0 = untested, 1 = use /dev/fd (FreeBSD Linuxulator / no /proc).
-pub var use_devfd_fallback = std.atomic.Value(u8).init(0);
+const LinuxKernel = enum(u8) {
+    unknown,
+    linux,
+    /// FreeBSD Linuxulator (linprocfs).
+    freebsd,
+
+    var cached = std.atomic.Value(LinuxKernel).init(.unknown);
+
+    /// Reads /proc/version to determine if we're under FreeBSD's Linuxulator.
+    /// linprocfs hardcodes "des@freebsd.org" in the version string.
+    fn detect() LinuxKernel {
+        var buf: [512]u8 = undefined;
+        const fd = switch (open("/proc/version", bun.O.RDONLY | bun.O.NOCTTY, 0)) {
+            .result => |fd| fd,
+            .err => return .linux,
+        };
+        defer fd.close();
+        const n = switch (read(fd, &buf)) {
+            .result => |n| n,
+            .err => return .linux,
+        };
+        if (bun.strings.containsCaseInsensitiveASCII(buf[0..n], "freebsd")) {
+            return .freebsd;
+        }
+        return .linux;
+    }
+
+    fn get() LinuxKernel {
+        const v = cached.load(.acquire);
+        if (v != .unknown) return v;
+        const detected = detect();
+        cached.store(detected, .release);
+        return detected;
+    }
+};
 
 /// Linux kernel makedev encoding for device numbers
 /// From glibc sys/sysmacros.h and Linux kernel <linux/kdev_t.h>
@@ -2729,6 +2761,17 @@ pub fn unlinkat(dirfd: bun.FileDescriptor, to: anytype) Maybe(void) {
     }
 }
 
+/// FreeBSD Linuxulator: linprocfs's /proc/<pid>/fd escapes emul_path and lands
+/// on host devfs, so readlink fails. Use fdescfs at /dev/fd instead.
+fn getFdPathFreeBSDLinuxulator(fd: bun.FileDescriptor, out_buffer: *bun.PathBuffer) Maybe([]u8) {
+    var buf: ["/dev/fd/-2147483648".len + 1:0]u8 = undefined;
+    const path = std.fmt.bufPrintZ(&buf, "/dev/fd/{d}", .{fd.cast()}) catch unreachable;
+    return switch (readlink(path, out_buffer)) {
+        .result => |r| .{ .result = r },
+        .err => |err| .{ .err = err },
+    };
+}
+
 pub fn getFdPath(fd: bun.FileDescriptor, out_buffer: *bun.PathBuffer) Maybe([]u8) {
     switch (Environment.os) {
         .windows => {
@@ -2752,37 +2795,26 @@ pub fn getFdPath(fd: bun.FileDescriptor, out_buffer: *bun.PathBuffer) Maybe([]u8
             return .{ .result = bun.sliceTo(out_buffer, 0) };
         },
         .linux => {
-            var procfs_buf: ["/proc/self/fd/-2147483648".len + 1:0]u8 = undefined;
-
-            if (use_devfd_fallback.load(.acquire) == 0) {
-                const proc_path = std.fmt.bufPrintZ(&procfs_buf, "/proc/self/fd/{d}", .{fd.cast()}) catch unreachable;
-                switch (readlink(proc_path, out_buffer)) {
-                    .result => |result| return .{ .result = result },
-                    .err => |proc_err| switch (proc_err.getErrno()) {
-                        // /proc/self/fd/N unreadable: /proc not mounted (minimal
-                        // containers), or FreeBSD linprocfs where /proc/<pid>/fd
-                        // escapes emul_path and lands on host devfs.
-                        .NOENT, .INVAL, .NOTDIR => {
-                            var devfd_buf: ["/dev/fd/-2147483648".len + 1:0]u8 = undefined;
-                            const dev_path = std.fmt.bufPrintZ(&devfd_buf, "/dev/fd/{d}", .{fd.cast()}) catch unreachable;
-                            return switch (readlink(dev_path, out_buffer)) {
-                                .result => |result| {
-                                    use_devfd_fallback.store(1, .release);
-                                    return .{ .result = result };
-                                },
-                                .err => |_| .{ .err = proc_err },
-                            };
-                        },
-                        else => return .{ .err = proc_err },
-                    },
-                }
+            // Fast path: a previous call already proved this is FreeBSD's Linuxulator.
+            if (LinuxKernel.cached.load(.acquire) == .freebsd) {
+                return getFdPathFreeBSDLinuxulator(fd, out_buffer);
             }
-
-            // Previous call confirmed /dev/fd works on this host.
-            const dev_path = std.fmt.bufPrintZ(&procfs_buf, "/dev/fd/{d}", .{fd.cast()}) catch unreachable;
-            return switch (readlink(dev_path, out_buffer)) {
-                .err => |err| .{ .err = err },
-                .result => |result| .{ .result = result },
+            var buf: ["/proc/self/fd/-2147483648".len + 1:0]u8 = undefined;
+            const path = std.fmt.bufPrintZ(&buf, "/proc/self/fd/{d}", .{fd.cast()}) catch unreachable;
+            return switch (readlink(path, out_buffer)) {
+                .result => |r| .{ .result = r },
+                .err => |err| {
+                    // readlink on /proc/self/fd/N basically never fails on real
+                    // Linux. We don't want to guess based on errno -- ENOENT etc.
+                    // could mean any number of things. Instead, pay one syscall
+                    // (memoized) to read /proc/version and only take the /dev/fd
+                    // path when we've positively identified FreeBSD's Linuxulator.
+                    // Otherwise, surface the original error unchanged.
+                    if (LinuxKernel.get() == .freebsd) {
+                        return getFdPathFreeBSDLinuxulator(fd, out_buffer);
+                    }
+                    return .{ .err = err };
+                },
             };
         },
         .wasm => @compileError("querying for canonical path of a handle is unsupported on this host"),

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -2760,7 +2760,9 @@ pub fn getFdPath(fd: bun.FileDescriptor, out_buffer: *bun.PathBuffer) Maybe([]u8
                     // emul_path → /compat/linux/dev/fd (fdescfs, readlink works).
                     // On real Linux /dev/fd → /proc/self/fd so this is a no-op.
                     .NOENT, .INVAL, .NOTDIR => {
-                        const dev_path = std.fmt.bufPrintZ(&procfs_buf, "/dev/fd/{d}", .{fd.cast()}) catch unreachable;
+                        // separate buffer: err.path borrows from procfs_buf
+                        var devfd_buf: ["/dev/fd/-2147483648".len + 1:0]u8 = undefined;
+                        const dev_path = std.fmt.bufPrintZ(&devfd_buf, "/dev/fd/{d}", .{fd.cast()}) catch unreachable;
                         return switch (readlink(dev_path, out_buffer)) {
                             .err => |_| .{ .err = err }, // report original error
                             .result => |result| .{ .result = result },

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1560,6 +1560,27 @@ it.if(isPosix)("realpathSync doesn't block on FIFO", () => {
   unlinkSync(path);
 });
 
+// Regression guard: getFdPath on Linux uses readlink(/proc/self/fd/N) with
+// a /dev/fd/N fallback for environments where /proc is unavailable or broken
+// (minimal containers, FreeBSD Linuxulator). This test ensures the primary
+// path still works on a normal POSIX host.
+it.if(isPosix)("realpathSync resolves root, regular files, and symlinks", () => {
+  // Root directory — the original Linuxulator bug manifested here as
+  // ENOENT: no such file or directory, lstat '/'
+  expect(realpathSync("/")).toBe("/");
+
+  // Regular file — should resolve to a canonical absolute path
+  const self = realpathSync(import.meta.path);
+  expect(self).toStartWith("/");
+  expect(existsSync(self)).toBe(true);
+
+  // Symlink — should follow through to the target
+  const linkPath = join(tmpdirSync(), "fs-realpath-getfdpath.link");
+  symlinkSync(import.meta.path, linkPath);
+  expect(realpathSync(linkPath)).toBe(self);
+  unlinkSync(linkPath);
+});
+
 it("readlink", () => {
   const actual = join(tmpdirSync(), "fs-readlink.txt");
   try {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1560,10 +1560,9 @@ it.if(isPosix)("realpathSync doesn't block on FIFO", () => {
   unlinkSync(path);
 });
 
-// Regression guard: getFdPath on Linux uses readlink(/proc/self/fd/N) with
-// a /dev/fd/N fallback for environments where /proc is unavailable or broken
-// (minimal containers, FreeBSD Linuxulator). This test ensures the primary
-// path still works on a normal POSIX host.
+// Regression guard for realpathSync on POSIX hosts. On Linux, getFdPath has
+// a /dev/fd fallback for environments where /proc is broken (FreeBSD
+// Linuxulator) or absent (minimal containers).
 it.if(isPosix)("realpathSync resolves root, regular files, and symlinks", () => {
   expect(realpathSync("/")).toBe("/");
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1565,20 +1565,16 @@ it.if(isPosix)("realpathSync doesn't block on FIFO", () => {
 // (minimal containers, FreeBSD Linuxulator). This test ensures the primary
 // path still works on a normal POSIX host.
 it.if(isPosix)("realpathSync resolves root, regular files, and symlinks", () => {
-  // Root directory — the original Linuxulator bug manifested here as
-  // ENOENT: no such file or directory, lstat '/'
   expect(realpathSync("/")).toBe("/");
 
-  // Regular file — should resolve to a canonical absolute path
   const self = realpathSync(import.meta.path);
   expect(self).toStartWith("/");
   expect(existsSync(self)).toBe(true);
 
-  // Symlink — should follow through to the target
-  const linkPath = join(tmpdirSync(), "fs-realpath-getfdpath.link");
+  using dir = tempDir("fs-realpath-getfdpath", {});
+  const linkPath = join(String(dir), "link");
   symlinkSync(import.meta.path, linkPath);
   expect(realpathSync(linkPath)).toBe(self);
-  unlinkSync(linkPath);
 });
 
 it("readlink", () => {


### PR DESCRIPTION
## Problem

`fs.realpathSync("/")` throws `ENOENT: no such file or directory, lstat '/'` when running under FreeBSD's Linuxulator (Linux binary compatibility layer).

`bun.sys.getFdPath` calls `readlink("/proc/self/fd/N")` to resolve file descriptors to paths. Under Linuxulator, `/proc` is linprocfs which symlinks `/proc/<pid>/fd` → `/dev/fd`, but symlink resolution escapes `emul_path` and lands on FreeBSD's native `/dev/fd` (devfs, char-device nodes, not readlinkable for arbitrary fds).

## Fix

When `readlink("/proc/self/fd/N")` fails with `ENOENT`/`EINVAL`/`ENOTDIR`, retry with `/dev/fd/N`. That path goes through `emul_path` → `/compat/linux/dev/fd` which is `fdescfs` and readlink-able.

- On real Linux `/dev/fd` is a symlink to `/proc/self/fd`, so the fallback is a no-op
- Also helps minimal containers where `/proc` is not mounted
- Preserves the original error if both fail

## Verification

Verified on FreeBSD 15.0-RELEASE-p4 aarch64 with glibc 2.34 in `/compat/linux/`:

```sh
# Stock Bun 1.3.11 (without fix)
$ bun -e 'require("fs").realpathSync("/")'
ENOENT: no such file or directory, lstat '/'

# With fix
$ bun -e 'require("fs").realpathSync("/")'
/
```