### PR TITLE
Fix swapped \t and \f escape values in TOML parser

### DIFF
--- a/src/parsers/toml/lexer.rs
+++ b/src/parsers/toml/lexer.rs
@@ -912,7 +912,7 @@ impl<'a> Lexer<'a> {
                             continue;
                         }
                         c if c == 'f' as CodePoint => {
-                            buf.push(9);
+                            buf.push(0x0C);
                             continue;
                         }
                         c if c == 'n' as CodePoint => {
@@ -930,7 +930,7 @@ impl<'a> Lexer<'a> {
                             continue;
                         }
                         c if c == 't' as CodePoint => {
-                            buf.push(12);
+                            buf.push(0x09);
                             continue;
                         }
                         c if c == 'r' as CodePoint => {

--- a/src/parsers/toml/lexer.zig
+++ b/src/parsers/toml/lexer.zig
@@ -843,7 +843,7 @@ pub const Lexer = struct {
                             continue;
                         },
                         'f' => {
-                            buf.append(9) catch unreachable;
+                            buf.append(0x0C) catch unreachable;
                             continue;
                         },
                         'n' => {
@@ -861,7 +861,7 @@ pub const Lexer = struct {
                             continue;
                         },
                         't' => {
-                            buf.append(12) catch unreachable;
+                            buf.append(0x09) catch unreachable;
                             continue;
                         },
                         'r' => {

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -5,3 +5,22 @@ test("Bun.TOML.parse with non-string input throws", () => {
   expect(() => Bun.TOML.parse(undefined as any)).toThrow();
   expect(() => Bun.TOML.parse(null as any)).toThrow();
 });
+
+// https://github.com/oven-sh/bun/issues/28681
+test("Bun.TOML.parse handles \\t and \\f escapes correctly", () => {
+  const toml = String.raw`str = "Name\tJos\u00E9\nLoc\tSF."`;
+  const { str } = Bun.TOML.parse(toml) as { str: string };
+  expect(str).toBe("Name\tJosé\nLoc\tSF.");
+});
+
+test("Bun.TOML.parse \\f escape produces formfeed (0x0C)", () => {
+  const { str } = Bun.TOML.parse(String.raw`str = "a\fb"`) as { str: string };
+  expect(str).toBe("a\fb");
+  expect(str.charCodeAt(1)).toBe(0x0c);
+});
+
+test("Bun.TOML.parse \\t escape produces tab (0x09)", () => {
+  const { str } = Bun.TOML.parse(String.raw`str = "a\tb"`) as { str: string };
+  expect(str).toBe("a\tb");
+  expect(str.charCodeAt(1)).toBe(0x09);
+});


### PR DESCRIPTION
Closes #28681

## Problem

The TOML lexer had the escape character values for `\t` and `\f` swapped:
- `'f'` produced 9 (tab, 0x09) instead of 12 (formfeed, 0x0C)
- `'t'` produced 12 (formfeed, 0x0C) instead of 9 (tab, 0x09)

This caused `\t` in TOML strings to be parsed as formfeed characters and vice versa.

## Reproduction

```ts
const toml = String.raw`str = "Name\tJos\u00E9\nLoc\tSF."`;
const { str } = Bun.TOML.parse(toml);
// Actual:   "Name\fJosé\nLoc\fSF."  (tabs became formfeeds)
// Expected: "Name\tJosé\nLoc\tSF."
```

## Fix

Swapped the values in `src/parsers/toml/lexer.rs`:
- `'f'` now correctly produces `0x0C` (formfeed)
- `'t'` now correctly produces `0x09` (tab)

Also synced the `.zig` porting reference in `src/parsers/toml/lexer.zig` so the two don't diverge.

## Test

`test/js/bun/resolve/toml/toml-parse.test.ts` — three cases pinning the expected char codes for `\\t`, `\\f`, and the combined repro from the issue.