### PR TITLE
fix: reset socket timeout timer on incoming data

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -746,7 +746,8 @@ function Socket(options?) {
     // when the onread option is specified we use a different handlers object
     this[khandlers] = {
       ...SocketHandlers2,
-      data({ data: self }, buffer) {
+      data(socket, buffer) {
+        const { self } = socket.data;
         if (!self) return;
         self._unrefTimer();
         try {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -156,6 +156,7 @@ const SocketHandlers: SocketHandler = {
     const { data: self } = socket;
     if (!self) return;
 
+    self._unrefTimer();
     self.bytesRead += buffer.length;
     if (!self.push(buffer)) {
       socket.pause();
@@ -302,6 +303,7 @@ const ServerHandlers: SocketHandler<NetSocket> = {
     const { data: self } = socket;
     if (!self) return;
 
+    self._unrefTimer();
     self.bytesRead += buffer.length;
     if (!self.push(buffer)) {
       socket.pause();
@@ -507,6 +509,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
   data(socket, buffer) {
     $debug("Bun.Socket data");
     const { self } = socket.data;
+    self._unrefTimer();
     self.bytesRead += buffer.length;
     if (!self.push(buffer)) socket.pause();
   },
@@ -745,6 +748,7 @@ function Socket(options?) {
       ...SocketHandlers2,
       data({ data: self }, buffer) {
         if (!self) return;
+        self._unrefTimer();
         try {
           onread.callback(buffer.length, buffer);
         } catch (e) {

--- a/test/regression/issue/12306.test.ts
+++ b/test/regression/issue/12306.test.ts
@@ -23,9 +23,13 @@ test("socket.setTimeout resets on incoming data (reads)", async () => {
   let reads = 0;
   let timedOut = false;
 
+  // 10 reads at 200ms intervals ≈ 2s, well past the 1s timeout.
+  // If reads correctly reset the timer, no timeout fires.
+  const READ_THRESHOLD = 10;
+
   const client = new Socket();
   // Set a 1s timeout — server sends data every 200ms, so if reads
-  // reset the timer this should never fire within our 3s window.
+  // reset the timer this should never fire before we hit the threshold.
   client.setTimeout(1000);
   client.on("timeout", () => {
     timedOut = true;
@@ -34,16 +38,14 @@ test("socket.setTimeout resets on incoming data (reads)", async () => {
   });
   client.on("data", () => {
     reads++;
+    if (reads >= READ_THRESHOLD) {
+      client.end();
+      resolve({ reads, timedOut });
+    }
   });
   client.on("error", err => reject(err));
 
-  client.connect(port, "127.0.0.1", () => {
-    // After 3s of receiving data, close gracefully — timeout should not have fired
-    setTimeout(() => {
-      client.end();
-      resolve({ reads, timedOut });
-    }, 3000);
-  });
+  client.connect(port, "127.0.0.1");
 
   const result = await done;
 

--- a/test/regression/issue/12306.test.ts
+++ b/test/regression/issue/12306.test.ts
@@ -12,7 +12,7 @@ test("socket.setTimeout resets on incoming data (reads)", async () => {
   const READ_THRESHOLD = 10;
 
   // Create a server that pushes data every 200ms
-  const server = createServer((socket) => {
+  const server = createServer(socket => {
     const interval = setInterval(() => socket.write("ping\n"), 200);
     socket.on("close", () => clearInterval(interval));
     socket.on("error", () => clearInterval(interval));
@@ -43,7 +43,7 @@ test("socket.setTimeout resets on incoming data (reads)", async () => {
       resolve({ reads, timedOut });
     }
   });
-  client.on("error", (err) => reject(err));
+  client.on("error", err => reject(err));
 
   client.connect(port, "127.0.0.1");
 

--- a/test/regression/issue/12306.test.ts
+++ b/test/regression/issue/12306.test.ts
@@ -1,9 +1,9 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { createServer, Socket } from "node:net";
 
 test("socket.setTimeout resets on incoming data (reads)", async () => {
   // Create a server that pushes data every 200ms
-  await using server = createServer((socket) => {
+  await using server = createServer(socket => {
     const interval = setInterval(() => socket.write("ping\n"), 200);
     socket.on("close", () => clearInterval(interval));
     socket.on("error", () => clearInterval(interval));
@@ -35,7 +35,7 @@ test("socket.setTimeout resets on incoming data (reads)", async () => {
   client.on("data", () => {
     reads++;
   });
-  client.on("error", (err) => reject(err));
+  client.on("error", err => reject(err));
 
   client.connect(port, "127.0.0.1", () => {
     // After 3s of receiving data, close gracefully — timeout should not have fired

--- a/test/regression/issue/12306.test.ts
+++ b/test/regression/issue/12306.test.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "bun:test";
+import { createServer, Socket } from "node:net";
+
+test("socket.setTimeout resets on incoming data (reads)", async () => {
+  // Create a server that pushes data every 200ms
+  await using server = createServer((socket) => {
+    const interval = setInterval(() => socket.write("ping\n"), 200);
+    socket.on("close", () => clearInterval(interval));
+    socket.on("error", () => clearInterval(interval));
+  });
+
+  const { promise: listening, resolve: onListening } = Promise.withResolvers<number>();
+  server.listen(0, () => {
+    const addr = server.address();
+    if (addr && typeof addr === "object") {
+      onListening(addr.port);
+    }
+  });
+  const port = await listening;
+
+  const { promise: done, resolve, reject } = Promise.withResolvers<{ reads: number; timedOut: boolean }>();
+
+  let reads = 0;
+  let timedOut = false;
+
+  const client = new Socket();
+  // Set a 1s timeout — server sends data every 200ms, so if reads
+  // reset the timer this should never fire within our 3s window.
+  client.setTimeout(1000);
+  client.on("timeout", () => {
+    timedOut = true;
+    client.end();
+    resolve({ reads, timedOut });
+  });
+  client.on("data", () => {
+    reads++;
+  });
+  client.on("error", (err) => reject(err));
+
+  client.connect(port, "127.0.0.1", () => {
+    // After 3s of receiving data, close gracefully — timeout should not have fired
+    setTimeout(() => {
+      client.end();
+      resolve({ reads, timedOut });
+    }, 3000);
+  });
+
+  const result = await done;
+
+  // With the fix: reads reset the timer, so no timeout fires.
+  // The client should have received multiple data events and not timed out.
+  expect(result.timedOut).toBe(false);
+  expect(result.reads).toBeGreaterThan(5);
+});

--- a/test/regression/issue/12306.test.ts
+++ b/test/regression/issue/12306.test.ts
@@ -2,8 +2,17 @@ import { expect, test } from "bun:test";
 import { createServer, Socket } from "node:net";
 
 test("socket.setTimeout resets on incoming data (reads)", async () => {
+  const { promise: done, resolve, reject } = Promise.withResolvers<{ reads: number; timedOut: boolean }>();
+
+  let reads = 0;
+  let timedOut = false;
+
+  // 10 reads at 200ms intervals ≈ 2s, well past the 1s timeout.
+  // If reads correctly reset the timer, no timeout fires.
+  const READ_THRESHOLD = 10;
+
   // Create a server that pushes data every 200ms
-  await using server = createServer(socket => {
+  const server = createServer((socket) => {
     const interval = setInterval(() => socket.write("ping\n"), 200);
     socket.on("close", () => clearInterval(interval));
     socket.on("error", () => clearInterval(interval));
@@ -17,15 +26,6 @@ test("socket.setTimeout resets on incoming data (reads)", async () => {
     }
   });
   const port = await listening;
-
-  const { promise: done, resolve, reject } = Promise.withResolvers<{ reads: number; timedOut: boolean }>();
-
-  let reads = 0;
-  let timedOut = false;
-
-  // 10 reads at 200ms intervals ≈ 2s, well past the 1s timeout.
-  // If reads correctly reset the timer, no timeout fires.
-  const READ_THRESHOLD = 10;
 
   const client = new Socket();
   // Set a 1s timeout — server sends data every 200ms, so if reads
@@ -43,11 +43,16 @@ test("socket.setTimeout resets on incoming data (reads)", async () => {
       resolve({ reads, timedOut });
     }
   });
-  client.on("error", err => reject(err));
+  client.on("error", (err) => reject(err));
 
   client.connect(port, "127.0.0.1");
 
   const result = await done;
+
+  // Close server and wait for it
+  const { promise: closed, resolve: onClosed } = Promise.withResolvers<void>();
+  server.close(() => onClosed());
+  await closed;
 
   // With the fix: reads reset the timer, so no timeout fires.
   // The client should have received multiple data events and not timed out.


### PR DESCRIPTION
## Problem

`socket.setTimeout()` in `node:net` should reset on **any** socket activity — both reads and writes — per [Node.js docs](https://nodejs.org/api/net.html#socketsettimeouttimeout-callback). In Bun, the timer was only refreshed in `_write()`, so read-only sockets (or sockets waiting for a response) would incorrectly time out even while actively receiving data.

This caused timeouts with libraries like `mongoose` that send a query (write resets timer) then wait for a database response. If the response takes a while, the timeout fires incorrectly.

Closes #12306

## Root Cause

In `src/js/node/net.ts`, the `_unrefTimer()` call that refreshes the timeout timer was only present in `Socket.prototype._write`. None of the four `data` handlers (`SocketHandlers`, `ServerHandlers`, `SocketHandlers2`, and the `onread` override) called `_unrefTimer()` when incoming data arrived.

## Fix

Add `self._unrefTimer()` to all four data handlers so the timeout resets on both reads and writes, matching Node.js behavior.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/regression/issue/12306.test.ts  → FAIL (timeout fires despite active reads)
bun bd test test/regression/issue/12306.test.ts                → PASS (timeout correctly resets on reads)
```