### PR TITLE
fix: drain accumulated chunks in http ClientRequest streaming body

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -363,6 +363,15 @@ function ClientRequest(input, options, cb) {
               };
             });
 
+            // Drain any chunks that accumulated while the generator was suspended.
+            // Multiple synchronous write() calls between iterations each push to
+            // kBodyChunks, but only the first resolves the Promise above — the rest
+            // are buffered. Yield them all before checking the loop condition,
+            // otherwise they are abandoned when finished becomes true.
+            while (self[kBodyChunks]?.length > 0) {
+              yield self[kBodyChunks].shift();
+            }
+
             if (self[kBodyChunks]?.length === 0) {
               self.emit("drain");
             }

--- a/test/regression/issue/012292.test.ts
+++ b/test/regression/issue/012292.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { Readable } from "node:stream";
+
+// https://github.com/oven-sh/bun/issues/12292
+// When a Readable with no backpressure (like the AWS SDK's aws-chunked wrapper)
+// is piped to http.ClientRequest, multiple synchronous push() calls can accumulate
+// chunks in the internal buffer faster than the async generator body can yield them.
+// When end() fires, the generator exits its loop before draining the remaining chunks,
+// causing truncated request bodies and SignatureDoesNotMatch errors with S3.
+test("#12292 - backpressure-free Readable piped to http.request sends complete body", async () => {
+  using dir = tempDir("12292", {});
+  const filePath = path.join(String(dir), "testfile.bin");
+
+  // 1 MB deterministic file
+  const fileSize = 1024 * 1024;
+  const content = Buffer.alloc(fileSize);
+  for (let i = 0; i < fileSize; i++) {
+    content[i] = i & 0xff;
+  }
+  fs.writeFileSync(filePath, content);
+
+  const { promise: bodyPromise, resolve: resolveBody } = Promise.withResolvers<Buffer>();
+
+  await using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const body = Buffer.from(await req.arrayBuffer());
+      resolveBody(body);
+      return new Response("OK");
+    },
+  });
+
+  await new Promise<void>((resolveReq, rejectReq) => {
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: server.port,
+        path: "/upload",
+        method: "PUT",
+      },
+      (res) => {
+        res.resume();
+        res.on("end", resolveReq);
+      },
+    );
+    req.on("error", rejectReq);
+
+    // Simulate the AWS SDK's aws-chunked encoding wrapper:
+    // a Readable with read:()=>{} that pushes data via "data" event
+    // listeners on the source, with NO backpressure management.
+    // This pattern causes many synchronous push() calls that overwhelm
+    // the async generator in ClientRequest.
+    const source = fs.createReadStream(filePath);
+    const wrapper = new Readable({ read() {} });
+
+    source.on("data", (chunk: Buffer) => {
+      // Push framing + data synchronously, just like aws-chunked does
+      wrapper.push(chunk.length.toString(16) + "\r\n");
+      wrapper.push(chunk);
+      wrapper.push("\r\n");
+    });
+    source.on("end", () => {
+      wrapper.push("0\r\n");
+      wrapper.push("trailer:value\r\n");
+      wrapper.push("\r\n");
+      wrapper.push(null);
+    });
+    source.on("error", (err) => wrapper.destroy(err));
+
+    wrapper.pipe(req);
+  });
+
+  const result = await bodyPromise;
+
+  // The received body must contain ALL the framed data plus the trailer
+  const resultStr = result.toString("utf8");
+  expect(resultStr).toContain("trailer:value");
+  expect(result.length).toBeGreaterThan(fileSize);
+});

--- a/test/regression/issue/012292.test.ts
+++ b/test/regression/issue/012292.test.ts
@@ -42,7 +42,7 @@ test("#12292 - backpressure-free Readable piped to http.request sends complete b
         path: "/upload",
         method: "PUT",
       },
-      (res) => {
+      res => {
         res.resume();
         res.on("end", resolveReq);
       },
@@ -69,7 +69,7 @@ test("#12292 - backpressure-free Readable piped to http.request sends complete b
       wrapper.push("\r\n");
       wrapper.push(null);
     });
-    source.on("error", (err) => wrapper.destroy(err));
+    source.on("error", err => wrapper.destroy(err));
 
     wrapper.pipe(req);
   });


### PR DESCRIPTION
## Problem

When using `fs.createReadStream` with the AWS SDK S3 client (`PutObjectCommand`), the request body is truncated non-deterministically (e.g. 786KB instead of 1MB), causing `SignatureDoesNotMatch` errors from S3.

Fixes #12292.

## Root Cause

The `ClientRequest` in `_http_client.ts` uses an async generator to stream request body chunks to `fetch()`. The generator awaits a Promise that is resolved by the next `write()` call via `resolveNextChunk`. However, `resolveNextChunk` sets itself to `undefined` after being called once:

```js
resolveNextChunk = end => {
    resolveNextChunk = undefined;  // <-- cleared after first call
    resolve(self[kBodyChunks].shift());
};
```

When multiple `write()` calls happen synchronously between generator iterations (common with the AWS SDK's aws-chunked encoding wrapper, which uses `new Readable({read(){}}).push()` with no backpressure), only the first `write()` resolves the Promise. The remaining chunks accumulate in `kBodyChunks`.

When `end()` sets `this.finished = true`, the generator's `while (!self.finished)` loop exits before draining those buffered chunks, truncating the body.

## Fix

Add an inner drain loop after each `yield await` to flush all buffered chunks before re-checking the loop condition:

```js
while (self[kBodyChunks]?.length > 0) {
    yield self[kBodyChunks].shift();
}
```

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/012292.test.ts` → **fails** (body truncated)
- `bun bd test test/regression/issue/012292.test.ts` → **passes** (body complete)
- AWS SDK S3 reproduction from the issue now sends consistent 1,048,756 bytes across all runs