### PR TITLE
Fix destructured Dirent methods silently returning wrong result

### DIFF
--- a/src/jsc/bindings/NodeDirent.cpp
+++ b/src/jsc/bindings/NodeDirent.cpp
@@ -196,8 +196,6 @@ JSC_DEFINE_HOST_FUNCTION(constructDirent, (JSC::JSGlobalObject * globalObject, J
     return JSValue::encode(object);
 }
 
-// A sloppy-mode host function sees the global object as `this` when the method is
-// called with no receiver. Strict-mode toThis() maps that back to undefined.
 static inline int32_t getType(JSC::ThrowScope& scope, JSC::VM& vm, JSValue thisValue, Zig::GlobalObject* globalObject)
 {
     JSValue value = thisValue.toThis(globalObject, JSC::ECMAMode::strict());

--- a/src/jsc/bindings/NodeDirent.cpp
+++ b/src/jsc/bindings/NodeDirent.cpp
@@ -196,44 +196,34 @@ JSC_DEFINE_HOST_FUNCTION(constructDirent, (JSC::JSGlobalObject * globalObject, J
     return JSValue::encode(object);
 }
 
-static inline int32_t getType(JSC::ThrowScope& scope, JSC::VM& vm, JSValue value, Zig::GlobalObject* globalObject)
+// A sloppy-mode host function sees the global object as `this` when the method is
+// called with no receiver. Strict-mode toThis() maps that back to undefined.
+static inline int32_t getType(JSC::ThrowScope& scope, JSC::VM& vm, JSValue thisValue, Zig::GlobalObject* globalObject)
 {
-    JSObject* object = value.getObject();
-    if (object) [[likely]] {
-        auto* structure = getStructure(globalObject);
-        JSValue type;
-        bool hasType;
-        if (structure->id() == object->structure()->id()) {
-            // Fast path: matching canonical Dirent structure, the @data slot always exists.
-            type = object->getDirect(2);
-            hasType = true;
-        } else {
-            // Slow path: look up @data via the full property machinery so subclass
-            // instances and prototype-delegating wrappers (Object.create(dirent))
-            // still find the inherited type slot. Non-Dirent receivers (e.g. the
-            // global object when the method is destructured) do not have @data
-            // anywhere on their chain, so getPropertySlot returns false.
-            auto propertyName = Bun::builtinNames(vm).dataPrivateName();
-            JSC::PropertySlot slot(object, JSC::PropertySlot::InternalMethodType::Get);
-            hasType = object->getPropertySlot(globalObject, propertyName, slot);
-            RETURN_IF_EXCEPTION(scope, std::numeric_limits<int32_t>::max());
-            if (hasType) {
-                type = slot.getValue(globalObject, propertyName);
-                RETURN_IF_EXCEPTION(scope, std::numeric_limits<int32_t>::max());
-            }
-        }
-
-        if (hasType) {
-            if (type.isAnyInt()) {
-                return JSC::toInt32(type.asNumber());
-            }
-            // Real Dirent instance, but the stored type is not an integer (e.g.
-            // `new Dirent(name)` with no type arg). Match Node.js: is*() returns false.
-            return std::numeric_limits<int32_t>::max();
-        }
+    JSValue value = thisValue.toThis(globalObject, JSC::ECMAMode::strict());
+    RETURN_IF_EXCEPTION(scope, std::numeric_limits<int32_t>::max());
+    if (value.isUndefinedOrNull()) [[unlikely]] {
+        Bun::throwInvalidThisError(globalObject, scope, value, "Dirent"_s);
+        return std::numeric_limits<int32_t>::max();
     }
 
-    Bun::throwError(globalObject, scope, Bun::ErrorCode::ERR_INVALID_THIS, "Value of \"this\" must be of type Dirent"_s);
+    JSObject* object = value.getObject();
+    if (!object) [[unlikely]] {
+        return std::numeric_limits<int32_t>::max();
+    }
+    auto* structure = getStructure(globalObject);
+    JSValue type;
+    if (structure->id() != object->structure()->id()) {
+        type = object->get(globalObject, Bun::builtinNames(vm).dataPrivateName());
+        RETURN_IF_EXCEPTION(scope, std::numeric_limits<int32_t>::max());
+    } else {
+        type = object->getDirect(2);
+    }
+
+    if (type.isAnyInt()) {
+        return JSC::toInt32(type.asNumber());
+    }
+
     return std::numeric_limits<int32_t>::max();
 }
 

--- a/src/jsc/bindings/NodeDirent.cpp
+++ b/src/jsc/bindings/NodeDirent.cpp
@@ -196,27 +196,44 @@ JSC_DEFINE_HOST_FUNCTION(constructDirent, (JSC::JSGlobalObject * globalObject, J
     return JSValue::encode(object);
 }
 
-static inline int32_t getType(JSC::VM& vm, JSValue value, Zig::GlobalObject* globalObject)
+static inline int32_t getType(JSC::ThrowScope& scope, JSC::VM& vm, JSValue value, Zig::GlobalObject* globalObject)
 {
     JSObject* object = value.getObject();
-    if (!object) [[unlikely]] {
-        return std::numeric_limits<int32_t>::max();
-    }
-    auto* structure = getStructure(globalObject);
-    JSValue type;
-    if (structure->id() != object->structure()->id()) {
-        type = object->get(globalObject, Bun::builtinNames(vm).dataPrivateName());
-        if (!type) [[unlikely]] {
+    if (object) [[likely]] {
+        auto* structure = getStructure(globalObject);
+        JSValue type;
+        bool hasType;
+        if (structure->id() == object->structure()->id()) {
+            // Fast path: matching canonical Dirent structure, the @data slot always exists.
+            type = object->getDirect(2);
+            hasType = true;
+        } else {
+            // Slow path: look up @data via the full property machinery so subclass
+            // instances and prototype-delegating wrappers (Object.create(dirent))
+            // still find the inherited type slot. Non-Dirent receivers (e.g. the
+            // global object when the method is destructured) do not have @data
+            // anywhere on their chain, so getPropertySlot returns false.
+            auto propertyName = Bun::builtinNames(vm).dataPrivateName();
+            JSC::PropertySlot slot(object, JSC::PropertySlot::InternalMethodType::Get);
+            hasType = object->getPropertySlot(globalObject, propertyName, slot);
+            RETURN_IF_EXCEPTION(scope, std::numeric_limits<int32_t>::max());
+            if (hasType) {
+                type = slot.getValue(globalObject, propertyName);
+                RETURN_IF_EXCEPTION(scope, std::numeric_limits<int32_t>::max());
+            }
+        }
+
+        if (hasType) {
+            if (type.isAnyInt()) {
+                return JSC::toInt32(type.asNumber());
+            }
+            // Real Dirent instance, but the stored type is not an integer (e.g.
+            // `new Dirent(name)` with no type arg). Match Node.js: is*() returns false.
             return std::numeric_limits<int32_t>::max();
         }
-    } else {
-        type = object->getDirect(2);
     }
 
-    if (type.isAnyInt()) {
-        return JSC::toInt32(type.asNumber());
-    }
-
+    Bun::throwError(globalObject, scope, Bun::ErrorCode::ERR_INVALID_THIS, "Value of \"this\" must be of type Dirent"_s);
     return std::numeric_limits<int32_t>::max();
 }
 
@@ -240,7 +257,7 @@ JSC_DEFINE_HOST_FUNCTION(jsDirentProtoFuncIsBlockDevice, (JSC::JSGlobalObject * 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    int32_t type = getType(vm, callFrame->thisValue(), defaultGlobalObject(globalObject));
+    int32_t type = getType(scope, vm, callFrame->thisValue(), defaultGlobalObject(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
 
     return JSValue::encode(jsBoolean(type == static_cast<int32_t>(DirEntType::BlockDevice)));
@@ -251,7 +268,7 @@ JSC_DEFINE_HOST_FUNCTION(jsDirentProtoFuncIsCharacterDevice, (JSC::JSGlobalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    int32_t type = getType(vm, callFrame->thisValue(), defaultGlobalObject(globalObject));
+    int32_t type = getType(scope, vm, callFrame->thisValue(), defaultGlobalObject(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
 
     return JSValue::encode(jsBoolean(type == static_cast<int32_t>(DirEntType::CharacterDevice)));
@@ -262,7 +279,7 @@ JSC_DEFINE_HOST_FUNCTION(jsDirentProtoFuncIsDirectory, (JSC::JSGlobalObject * gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    int32_t type = getType(vm, callFrame->thisValue(), defaultGlobalObject(globalObject));
+    int32_t type = getType(scope, vm, callFrame->thisValue(), defaultGlobalObject(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
 
     return JSValue::encode(jsBoolean(type == static_cast<int32_t>(DirEntType::Directory)));
@@ -273,7 +290,7 @@ JSC_DEFINE_HOST_FUNCTION(jsDirentProtoFuncIsFIFO, (JSC::JSGlobalObject * globalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    int32_t type = getType(vm, callFrame->thisValue(), defaultGlobalObject(globalObject));
+    int32_t type = getType(scope, vm, callFrame->thisValue(), defaultGlobalObject(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
 
     return JSValue::encode(jsBoolean(type == static_cast<int32_t>(DirEntType::NamedPipe)));
@@ -284,7 +301,7 @@ JSC_DEFINE_HOST_FUNCTION(jsDirentProtoFuncIsFile, (JSC::JSGlobalObject * globalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    int32_t type = getType(vm, callFrame->thisValue(), defaultGlobalObject(globalObject));
+    int32_t type = getType(scope, vm, callFrame->thisValue(), defaultGlobalObject(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
 
     return JSValue::encode(jsBoolean(type == static_cast<int32_t>(DirEntType::File)));
@@ -295,7 +312,7 @@ JSC_DEFINE_HOST_FUNCTION(jsDirentProtoFuncIsSocket, (JSC::JSGlobalObject * globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    int32_t type = getType(vm, callFrame->thisValue(), defaultGlobalObject(globalObject));
+    int32_t type = getType(scope, vm, callFrame->thisValue(), defaultGlobalObject(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
 
     return JSValue::encode(jsBoolean(type == static_cast<int32_t>(DirEntType::UnixDomainSocket)));
@@ -306,7 +323,7 @@ JSC_DEFINE_HOST_FUNCTION(jsDirentProtoFuncIsSymbolicLink, (JSC::JSGlobalObject *
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    int32_t type = getType(vm, callFrame->thisValue(), defaultGlobalObject(globalObject));
+    int32_t type = getType(scope, vm, callFrame->thisValue(), defaultGlobalObject(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
 
     return JSValue::encode(jsBoolean(type == static_cast<int32_t>(DirEntType::SymLink)));

--- a/test/regression/issue/21099.test.ts
+++ b/test/regression/issue/21099.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { Dirent, mkdirSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const invalidThisError = expect.objectContaining({
+  name: "TypeError",
+  code: "ERR_INVALID_THIS",
+});
+
+test("destructured Dirent methods throw TypeError instead of returning wrong result", () => {
+  using dir = tempDir("dirent-destructure", {
+    "file.txt": "hello",
+  });
+  mkdirSync(join(String(dir), "subdir"));
+
+  const entries = readdirSync(String(dir), { withFileTypes: true });
+  const fileEntry = entries.find(e => e.name === "file.txt")!;
+  const dirEntry = entries.find(e => e.name === "subdir")!;
+
+  // Bound calls should work correctly
+  expect(fileEntry.isFile()).toBe(true);
+  expect(fileEntry.isDirectory()).toBe(false);
+  expect(dirEntry.isDirectory()).toBe(true);
+  expect(dirEntry.isFile()).toBe(false);
+
+  // Destructured calls should throw TypeError with ERR_INVALID_THIS (matches Node.js behavior)
+  const { isFile } = fileEntry;
+  expect(() => isFile()).toThrow(invalidThisError);
+
+  const { isDirectory } = dirEntry;
+  expect(() => isDirectory()).toThrow(invalidThisError);
+
+  // All 7 methods should throw when destructured
+  const methods = [
+    "isBlockDevice",
+    "isCharacterDevice",
+    "isDirectory",
+    "isFIFO",
+    "isFile",
+    "isSocket",
+    "isSymbolicLink",
+  ] as const;
+
+  for (const method of methods) {
+    const { [method]: fn } = fileEntry;
+    expect(() => fn()).toThrow(invalidThisError);
+  }
+});
+
+test("Dirent methods called with explicit undefined this throw TypeError", () => {
+  using dir = tempDir("dirent-undefined-this", {
+    "a.txt": "",
+  });
+
+  const [entry] = readdirSync(String(dir), { withFileTypes: true });
+  expect(() => entry.isFile.call(undefined)).toThrow(invalidThisError);
+  expect(() => entry.isDirectory.call(undefined)).toThrow(invalidThisError);
+});
+
+test("Dirent constructed with missing or non-integer type returns false (does not throw)", () => {
+  // `new Dirent(name)` with no type arg — the stored type slot is undefined.
+  // Node.js compares undefined === UV_DIRENT_DIR which is false. Must not throw.
+  // @ts-expect-error — public constructor, testing partial args
+  const noType = new Dirent("foo");
+  expect(noType).toBeInstanceOf(Dirent);
+  expect(noType.isFile()).toBe(false);
+  expect(noType.isDirectory()).toBe(false);
+  expect(noType.isBlockDevice()).toBe(false);
+  expect(noType.isCharacterDevice()).toBe(false);
+  expect(noType.isFIFO()).toBe(false);
+  expect(noType.isSocket()).toBe(false);
+  expect(noType.isSymbolicLink()).toBe(false);
+
+  // Non-integer type argument — also must not throw.
+  // @ts-expect-error — exercising wrong-type input
+  const stringType = new Dirent("bar", "not-a-number", "/path");
+  expect(stringType.isFile()).toBe(false);
+  expect(stringType.isDirectory()).toBe(false);
+
+  // Proper integer type still works.
+  const dirType = new Dirent("baz", 2 /* UV_DIRENT_DIR */, "/path");
+  expect(dirType.isDirectory()).toBe(true);
+  expect(dirType.isFile()).toBe(false);
+
+  const fileType = new Dirent("qux", 1 /* UV_DIRENT_FILE */, "/path");
+  expect(fileType.isFile()).toBe(true);
+  expect(fileType.isDirectory()).toBe(false);
+});
+
+test("Dirent methods work via prototype-chain delegation", () => {
+  // Node.js reads this[kType] via a Symbol, which walks the prototype chain.
+  // Object.create(dirent) and Object.setPrototypeOf({}, dirent) must still
+  // resolve the inherited type slot and return the correct boolean, not throw.
+  const dirent = new Dirent("foo", 1 /* UV_DIRENT_FILE */, "/path");
+
+  const createWrapper = Object.create(dirent);
+  expect(createWrapper.isFile()).toBe(true);
+  expect(createWrapper.isDirectory()).toBe(false);
+
+  const setProtoWrapper = Object.setPrototypeOf({}, dirent);
+  expect(setProtoWrapper.isFile()).toBe(true);
+  expect(setProtoWrapper.isBlockDevice()).toBe(false);
+
+  // Subclass instances still work (they get @data as own property via constructDirent).
+  class MyDirent extends Dirent {}
+  const sub = new MyDirent("sub", 2 /* UV_DIRENT_DIR */, "/path");
+  expect(sub.isDirectory()).toBe(true);
+  expect(sub.isFile()).toBe(false);
+});

--- a/test/regression/issue/21099.test.ts
+++ b/test/regression/issue/21099.test.ts
@@ -48,7 +48,7 @@ test("destructured Dirent methods throw TypeError instead of returning wrong res
   }
 });
 
-test("Dirent methods called with explicit undefined this throw TypeError", () => {
+test("Dirent methods called with explicit undefined or null this throw TypeError", () => {
   using dir = tempDir("dirent-undefined-this", {
     "a.txt": "",
   });
@@ -56,6 +56,22 @@ test("Dirent methods called with explicit undefined this throw TypeError", () =>
   const [entry] = readdirSync(String(dir), { withFileTypes: true });
   expect(() => entry.isFile.call(undefined)).toThrow(invalidThisError);
   expect(() => entry.isDirectory.call(undefined)).toThrow(invalidThisError);
+  expect(() => entry.isFile.call(null)).toThrow(invalidThisError);
+});
+
+test("Dirent methods on a non-Dirent object return false like Node.js", () => {
+  using dir = tempDir("dirent-object-this", {
+    "a.txt": "",
+  });
+
+  const [entry] = readdirSync(String(dir), { withFileTypes: true });
+  expect(entry.isFile.call({})).toBe(false);
+  expect(entry.isDirectory.call({})).toBe(false);
+  expect(entry.isFile.call(42)).toBe(false);
+
+  const bare = Object.create(Dirent.prototype);
+  expect(bare.isFile()).toBe(false);
+  expect(bare.isDirectory()).toBe(false);
 });
 
 test("Dirent constructed with missing or non-integer type returns false (does not throw)", () => {


### PR DESCRIPTION
Fixes #21099

### Problem
- `const { isDirectory } = dirent; isDirectory()` returns `false` for a directory. Node.js throws a `TypeError`. All seven `is*()` methods on `fs.Dirent` have this bug.
- The methods are sloppy-mode host functions. A call with no receiver passes the global object as `this`. `getType()` in `src/jsc/bindings/NodeDirent.cpp:199` finds no type slot on it and returns a sentinel. Every comparison against the sentinel is `false`.
- This is a regression from #16897 (v1.2.2). The generated `Dirent` class before it threw `ERR_INVALID_THIS` for a non-Dirent receiver.

### Fix
- `getType()` takes the caller's `ThrowScope`. It first converts the receiver with `toThis(globalObject, ECMAMode::strict())`. That maps the global object back to `undefined`. The same idiom is in `NodeFSStatBinding.cpp:142`.
- A nullish receiver throws `ERR_INVALID_THIS` through `Bun::throwInvalidThisError`, the helper the generated classes use.
- Any other receiver keeps the old path. An object without the type slot, or with a non-integer slot, still returns the sentinel, so `is*()` returns `false`. Node.js does the same for `isFile.call({})`, `Object.create(Dirent.prototype).isFile()`, and `new Dirent(name).isFile()`.
- Verified: `test/regression/issue/21099.test.ts` (5 tests, 2 fail on stock bun). Also `test/regression/issue/24129.test.ts` and the `Dirent` tests in `test/js/node/fs/fs.test.ts`.

### Background
- A JSC host function is a C++ function registered on a prototype. It is sloppy-mode by default, so a bare call gets the global object as `this`. `toThis()` in strict mode undoes that coercion.
- A `Dirent` is a plain `JSFinalObject` with a fixed structure: `name`, `path`, a private `@data` slot that holds the `uv_dirent_type_t` integer, and `parentPath`. `getType()` reads slot 2 on the fast path and does a full `get()` of `@data` on the slow path, which walks the prototype chain.
- `ERR_INVALID_THIS` is the Node.js error code for a method called on the wrong receiver. `throwInvalidThisError` builds the message and includes the receiver's type.

<details><summary>Notes</summary>

Earlier revisions of this PR threw for every receiver without a type slot. That was stricter than Node.js: `isFile.call({})` and `Object.create(Dirent.prototype).isFile()` return `false` there. Review caught both that and a `getDirect` lookup that broke `Object.create(dirent)` delegation. The current shape throws only for a nullish receiver and leaves the lookup as it was.

The first version of the test file used `toThrow(TypeError)` only. It now asserts `name: "TypeError"` and `code: "ERR_INVALID_THIS"`.

Suites run: `test/regression/issue/21099.test.ts` with `BUN_JSC_validateExceptionChecks=1`, `test/regression/issue/24129.test.ts`, `test/regression/issue/24007.test.ts`, and `bun bd test test/js/node/fs/fs.test.ts -t Dirent`.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 11 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/regression/issue/21099.test.ts"
bun test v1.4.3 (f42e98025)

test/regression/issue/21099.test.ts:
24 |   expect(dirEntry.isDirectory()).toBe(true);
25 |   expect(dirEntry.isFile()).toBe(false);
26 | 
27 |   // Destructured calls should throw TypeError with ERR_INVALID_THIS (matches Node.js behavior)
28 |   const { isFile } = fileEntry;
29 |   expect(() => isFile()).toThrow(invalidThisError);
                              ^
error: expect(received).toThrow(expected)

Expected constructor: ExpectObjectContaining

Received function did not throw
Received value: false

      at <anonymous> (/workspace/bun/test/regression/issue/21099.test.ts:29:26)
(fail) destructured Dirent methods throw TypeError instead of returning wrong result [57.63ms]
52 |   using dir = tempDir("dirent-undefined-this", {
53 |     "a.txt": "",
54 |   });
55 | 
56 |   const [entry] = readdirSync(String(dir), { withFileTypes: true });
57 |   expect(() => entry.isFile.call(undefined)).toThrow(invalidThisError);
                                                  ^
erro
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (a90ed3643)

test/regression/issue/21099.test.ts:
(pass) destructured Dirent methods throw TypeError instead of returning wrong result [4.17ms]
(pass) Dirent methods called with explicit undefined or null this throw TypeError [0.43ms]
(pass) Dirent methods on a non-Dirent object return false like Node.js [0.27ms]
(pass) Dirent constructed with missing or non-integer type returns false (does not throw) [0.13ms]
(pass) Dirent methods work via prototype-chain delegation [0.11ms]

 5 pass
 0 fail
 41 expect() calls
Ran 5 tests across 1 file. [98.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/regression/issue/21099.test.ts"
bun test v1.4.3 (f42e98025)

test/regression/issue/21099.test.ts:
(pass) destructured Dirent methods throw TypeError instead of returning wrong result [66.64ms]
(pass) Dirent methods called with explicit undefined or null this throw TypeError [10.90ms]
(pass) Dirent methods on a non-Dirent object return false like Node.js [8.12ms]
(pass) Dirent constructed with missing or non-integer type returns false (does not throw) [5.65ms]
(pass) Dirent methods work via prototype-chain delegation [6.42ms]

 5 pass
 0 fail
 41 expect() calls
Ran 5 tests across 1 file. [2.21s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 733ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeDirent.cpp     |  27 ++++----
 test/regression/issue/21099.test.ts | 126 ++++++++++++++++++++++++++++++++++++
 2 files changed, 142 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 11

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/bindings/NodeDirent.cpp          9      8     45
test/regression/issue/21099.test.ts      7      9     45
```

</details>

**root cause** · written by the author bot

Destructuring a `Dirent` predicate such as `const { isDirectory } = dirent; isDirectory()` invoked the JSC host function with the global object as `this`, so the lookup for the internal type slot found nothing and the function silently returned `false` instead of signalling the invalid receiver as Node does. The fix threads the caller's `ThrowScope` into the shared `getType()` helper, applies `toThis(..., ECMAMode::strict())` so a global-object receiver is coerced back to `undefined`, and throws `ERR_INVALID_THIS` when the resulting receiver is nullish, while primitives and objects lacking …

<!-- robobun:evidence:end -->