### PR TITLE
Fix UDP socket closing when sending to unreachable destination

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -57,6 +57,13 @@ static void init_debug_logging() {
 #include <errno.h>
 #else /* _WIN32 */
 #include <mstcpip.h>
+#include <mswsock.h>
+/* SIO_UDP_CONNRESET disables Windows ICMP port-unreachable errors from
+ * surfacing as WSAECONNRESET on UDP sockets. Without this, sending to an
+ * unreachable destination closes the socket on the next recvfrom(). */
+#ifndef SIO_UDP_CONNRESET
+#define SIO_UDP_CONNRESET _WSAIOW(IOC_VENDOR, 12)
+#endif
 #endif
 
 #if defined(__APPLE__)
@@ -132,7 +139,12 @@ int bsd_recvmmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct udp_recvbuf *recvbuf, int fl
     while (1) {
         ssize_t ret = recvfrom(fd, recvbuf->buf, LIBUS_RECV_BUFFER_LENGTH, flags, (struct sockaddr *)&recvbuf->addr, &addr_len);
         if (ret < 0) {
-            if (WSAGetLastError() == WSAEINTR) continue;
+            int err = WSAGetLastError();
+            if (err == WSAEINTR) continue;
+            /* WSAECONNRESET/WSAENETRESET indicate a previous sendto() to an
+             * unreachable destination triggered an ICMP error. Treat as
+             * non-fatal to match libuv/Node.js behavior. */
+            if (err == WSAECONNRESET || err == WSAENETRESET) return 0;
             return ret;
         }
         recvbuf->recvlen = ret;
@@ -142,6 +154,10 @@ int bsd_recvmmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct udp_recvbuf *recvbuf, int fl
     if (Bun__doesMacOSVersionSupportSendRecvMsgX()) {
         while (1) {
             int ret = recvmsg_x(fd, recvbuf->msgvec, LIBUS_UDP_RECV_COUNT, flags);
+            if (ret < 0 && errno != EINTR) {
+                /* ICMP errors from a previous sendto() are non-fatal for UDP. */
+                if (errno == ECONNREFUSED || errno == ECONNRESET || errno == ENETRESET) return 0;
+            }
             if (ret >= 0 || errno != EINTR) return ret;
         }
     }
@@ -152,6 +168,8 @@ int bsd_recvmmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct udp_recvbuf *recvbuf, int fl
             if (ret < 0) {
                 if (errno == EINTR) continue;
                 if (errno == EAGAIN || errno == EWOULDBLOCK) return i;
+                /* ICMP errors from a previous sendto() are non-fatal for UDP. */
+                if (errno == ECONNREFUSED || errno == ECONNRESET || errno == ENETRESET) return i;
                 return ret;
             }
             recvbuf->msgvec[i].msg_len = ret;
@@ -162,6 +180,10 @@ int bsd_recvmmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct udp_recvbuf *recvbuf, int fl
 #else
     while (1) {
         int ret = recvmmsg(fd, (struct mmsghdr *)&recvbuf->msgvec, LIBUS_UDP_RECV_COUNT, flags, 0);
+        if (ret < 0 && errno != EINTR) {
+            /* ICMP errors from a previous sendto() are non-fatal for UDP. */
+            if (errno == ECONNREFUSED || errno == ECONNRESET || errno == ENETRESET) return 0;
+        }
         if (ret >= 0 || errno != EINTR) return ret;
     }
 #endif
@@ -1247,6 +1269,16 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
         freeaddrinfo(result);
         return LIBUS_SOCKET_ERROR;
     }
+
+#ifdef _WIN32
+    /* Prevent ICMP port-unreachable errors from closing the socket.
+     * This matches libuv/Node.js behavior for UDP sockets. */
+    {
+        DWORD no = 0;
+        DWORD bytes;
+        WSAIoctl(listenFd, SIO_UDP_CONNRESET, &no, sizeof(no), NULL, 0, &bytes, NULL, NULL);
+    }
+#endif
 
     if (bsd_set_reuse(listenFd, options) != 0) {
         if (err != NULL) {

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -588,6 +588,24 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                 break;
             }
 
+            /* For UDP, EPOLLERR/EPOLLHUP from ICMP errors (e.g. port unreachable
+             * after sendto to an unreachable destination) are non-fatal. Unlike TCP,
+             * these don't indicate the socket is broken — they just report that a
+             * previous send didn't reach its destination. When EPOLLERR fires
+             * without EPOLLIN, we must call bsd_recvmmsg to drain sk_err from the
+             * kernel socket (otherwise epoll re-fires EPOLLERR in a tight loop).
+             * When EPOLLIN is also set, the readable block below handles draining.
+             * This matches libuv/Node.js behavior. */
+            if (error && !(events & LIBUS_SOCKET_READABLE)) {
+                struct udp_recvbuf recvbuf;
+                bsd_udp_setup_recvbuf(&recvbuf, u->loop->data.recv_buf, LIBUS_RECV_BUFFER_LENGTH);
+                int npackets = bsd_recvmmsg(us_poll_fd(p), &recvbuf, MSG_DONTWAIT);
+                if (npackets > 0) {
+                    u->on_data(u, &recvbuf, npackets);
+                }
+                error = 0;
+            }
+
             if (events & LIBUS_SOCKET_READABLE) {
                 do {
                     struct udp_recvbuf recvbuf;

--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -642,7 +642,9 @@ function doSend(ex, self, ip, list, address, port, callback) {
     if (err) {
       err.address = ip;
       err.port = port;
-      err.message = `send ${err.code} ${ip}:${port}`;
+      if (err.code) {
+        err.message = `send ${err.code} ${ip}:${port}`;
+      }
       process.nextTick(callback, err);
     } else {
       const sent = success ? data.byteLength : 0;

--- a/test/regression/issue/18029.test.ts
+++ b/test/regression/issue/18029.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import dgram from "node:dgram";
+
+async function getUnreachablePort(): Promise<number> {
+  const probe = dgram.createSocket("udp4");
+  await new Promise<void>(resolve => probe.bind(0, resolve));
+  const port = probe.address().port;
+  await new Promise<void>(resolve => probe.close(resolve));
+  return port;
+}
+
+describe("UDP socket stays open after sending to unreachable destination", () => {
+  test("Bun.udpSocket connected to unreachable port does not close", async () => {
+    const unreachablePort = await getUnreachablePort();
+
+    const s = await Bun.udpSocket({
+      connect: { hostname: "127.0.0.1", port: unreachablePort },
+      socket: {
+        data() {},
+      },
+    });
+
+    try {
+      expect(() => s.send("hey")).not.toThrow();
+
+      // Wait for kernel to deliver ICMP port-unreachable
+      await Bun.sleep(200);
+
+      // Socket must remain open — the ICMP error is non-fatal for UDP
+      expect(s.closed).toBe(false);
+    } finally {
+      if (!s.closed) s.close();
+    }
+  });
+
+  test("Bun.udpSocket unconnected send to unreachable port does not close", async () => {
+    const unreachablePort = await getUnreachablePort();
+    const s = await Bun.udpSocket({});
+
+    try {
+      s.send("hey", unreachablePort, "127.0.0.1");
+      await Bun.sleep(200);
+
+      expect(s.closed).toBe(false);
+      // Should still be able to send
+      s.send("hey2", unreachablePort, "127.0.0.1");
+    } finally {
+      if (!s.closed) s.close();
+    }
+  });
+
+  test("dgram socket stays open after sending to unreachable port", async () => {
+    const unreachablePort = await getUnreachablePort();
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+    const server = dgram.createSocket("udp4");
+    server.once("error", reject);
+    server.bind(0, () => {
+      let count = 0;
+      const sendNext = () => {
+        server.send("hey", unreachablePort, "127.0.0.1", error => {
+          if (error) {
+            server.close();
+            reject(error);
+            return;
+          }
+          count++;
+          if (count < 3) {
+            sendNext();
+          } else {
+            server.close();
+            resolve();
+          }
+        });
+      };
+      sendNext();
+    });
+
+    // Should complete all 3 sends without the socket closing
+    await promise;
+  });
+
+  test("dgram error message contains error code, not 'undefined'", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const dgram = require("node:dgram");
+        const server = dgram.createSocket("udp4");
+        server.bind(0, () => {
+          const huge = Buffer.alloc(256 * 1024);
+          server.send(huge, 0, huge.length, server.address().port, "127.0.0.1", (err) => {
+            if (err) {
+              console.log(JSON.stringify({ message: err.message, code: err.code }));
+            }
+            server.close();
+          });
+        });
+        `,
+      ],
+      env: bunEnv,
+    });
+
+    const stdout = await proc.stdout.text();
+    const exitCode = await proc.exited;
+
+    // The error message should contain the error code, never "undefined"
+    const result = JSON.parse(stdout.trim());
+    expect(result.code).toBe("EMSGSIZE");
+    expect(result.message).toContain("EMSGSIZE");
+    expect(result.message).not.toContain("undefined");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

Sending UDP data to an unreachable destination (port with no listener) causes the entire UDP socket to close. This affects both `Bun.udpSocket` and `node:dgram`, and does not match Node.js behavior where the socket stays open.

**Repro** (from #18029):
```typescript
const s = await Bun.udpSocket({
  connect: { hostname: '127.0.0.1', port: 21213 },
  socket: { data() {} },
});
s.send('hey');
await Bun.sleep(200);
console.log(s.closed); // true — socket was killed
```

Also affects `node:dgram` with error message `send undefined 127.0.0.1:21213` (undefined because the caught error has no `.code`).

## Root Cause

Three issues in the UDP error handling chain:

1. **Event loop (loop.c)**: `EPOLLERR`/`EPOLLHUP` from ICMP port-unreachable responses were passed into the UDP handler as the `error` parameter, which unconditionally closed the socket. Unlike TCP, these are non-fatal for UDP — they just mean a previous send didn't reach its destination.

2. **Recv path (bsd.c)**: `bsd_recvmmsg()` treated `ECONNREFUSED`/`WSAECONNRESET` as fatal errors, returning `LIBUS_SOCKET_ERROR`. These ICMP-derived errors should be silently consumed.

3. **Windows-specific**: Unconnected UDP sockets on Windows receive `WSAECONNRESET` on the next `recvfrom()` after sending to an unreachable destination. Node.js/libuv prevents this with `SIO_UDP_CONNRESET` ioctl.

## Fix

- **loop.c**: Clear the epoll/kqueue error flag for `POLL_TYPE_UDP` before processing events, since ICMP errors are non-fatal for connectionless protocols.
- **bsd.c recvmmsg**: Treat `ECONNREFUSED`/`ECONNRESET`/`ENETRESET` (and Windows `WSAECONNRESET`/`WSAENETRESET`) as non-fatal, returning 0 (no packets) instead of an error.
- **bsd.c create**: Add `WSAIoctl(SIO_UDP_CONNRESET)` on Windows to prevent ICMP errors from surfacing on unconnected UDP sockets (matches libuv).
- **dgram.ts**: Preserve the original error message when `err.code` is not set, instead of interpolating `'undefined'`.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/regression/issue/18029.test.ts → 1 FAIL (connected socket closes)
bun bd test test/regression/issue/18029.test.ts → 4 PASS
```

Existing UDP/dgram tests all pass (167 + 29 tests).

Closes #18029