### PR TITLE
Lower import.meta.env to process.env when bundling

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2560,6 +2560,11 @@ pub mod parse_worker {
             opts.lower_import_meta_main_for_node_js = true;
         }
 
+        // Lower import.meta.env to process.env for targets where process.env is available
+        if target != options::Target::Browser {
+            opts.lower_import_meta_env_to_process_env = true;
+        }
+
         opts.tree_shaking = if task.source_index.is_runtime() {
             true
         } else {

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1596,6 +1596,7 @@ impl<'a> Transpiler<'a> {
                     transform_only: self.options.transform_only,
                     import_meta_main_value: None,
                     lower_import_meta_main_for_node_js: false,
+                    lower_import_meta_env_to_process_env: false,
                     framework: None,
                     repl_mode: self.options.repl_mode,
                 };

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -512,6 +512,47 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         });
                     }
 
+                    // Lower import.meta.env to process.env when bundling for bun/node targets.
+                    // Skip for assignment/delete targets to avoid destructive semantics on
+                    // `delete import.meta.env` or `import.meta.env = x` becoming operations
+                    // on the real `process.env`. Also skip if `process` is shadowed by a
+                    // local binding in the current scope chain — leaving `import.meta.env`
+                    // as-is lets Bun's runtime resolve it correctly.
+                    if p.options.lower_import_meta_env_to_process_env
+                        && name == b"env"
+                        && identifier_opts.assign_target() == js_ast::AssignTarget::None
+                        && !identifier_opts.is_delete_target()
+                    {
+                        let process_ref = p
+                            .find_symbol(target.loc, b"process")
+                            .expect("unreachable")
+                            .r#ref;
+                        if p.symbols[process_ref.inner_index() as usize].kind
+                            == js_ast::symbol::Kind::Unbound
+                        {
+                            let process_target = p.new_expr(
+                                E::Identifier {
+                                    ref_: process_ref,
+                                    ..Default::default()
+                                },
+                                target.loc,
+                            );
+                            return Some(p.new_expr(
+                                E::Dot {
+                                    target: process_target,
+                                    name: b"env".into(),
+                                    name_loc,
+                                    can_be_removed_if_unused: true,
+                                    ..Default::default()
+                                },
+                                loc,
+                            ));
+                        }
+                        // find_symbol recorded a usage on the local `process` binding; undo it
+                        // since we're not actually emitting a reference to it.
+                        p.ignore_usage(process_ref);
+                    }
+
                     // Inline import.meta properties for Bake
                     if p.options.framework.is_some()
                         || (p.options.bundle

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -100,6 +100,10 @@ pub struct Options<'a> {
     pub import_meta_main_value: Option<bool>,
     pub lower_import_meta_main_for_node_js: bool,
 
+    /// When true, import.meta.env is lowered to process.env during bundling.
+    /// Set for bun/node targets where process.env is available.
+    pub lower_import_meta_env_to_process_env: bool,
+
     /// When using react fast refresh or server components, the framework is
     /// able to customize what import sources are used.
     pub framework: Option<&'a options::Framework>, // TYPE_ONLY: was bun_runtime::bake::Framework
@@ -140,6 +144,7 @@ impl<'a> Default for Options<'a> {
             transform_only: false,
             import_meta_main_value: None,
             lower_import_meta_main_for_node_js: false,
+            lower_import_meta_env_to_process_env: false,
             framework: None,
             repl_mode: false,
         }
@@ -227,6 +232,7 @@ impl<'a> Options<'a> {
             transform_only: self.transform_only,
             import_meta_main_value: self.import_meta_main_value,
             lower_import_meta_main_for_node_js: self.lower_import_meta_main_for_node_js,
+            lower_import_meta_env_to_process_env: self.lower_import_meta_env_to_process_env,
             framework: self.framework,
             repl_mode: self.repl_mode,
         }
@@ -295,6 +301,7 @@ impl<'a> Options<'a> {
             transform_only: false,
             import_meta_main_value: None,
             lower_import_meta_main_for_node_js: false,
+            lower_import_meta_env_to_process_env: false,
             framework: None,
             repl_mode: false,
         };

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -823,6 +823,13 @@ impl BuildCommand {
             }
 
             if ctx.bundler_options.compile {
+                if log_ref.errors > 0 {
+                    log_ref.print(std::ptr::from_mut::<bun_core::io::Writer>(
+                        Output::error_writer(),
+                    ))?;
+                    Global::exit(1);
+                }
+
                 print_summary(
                     bundled_end,
                     minify_duration,

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -827,7 +827,7 @@ impl BuildCommand {
                     log_ref.print(std::ptr::from_mut::<bun_core::io::Writer>(
                         Output::error_writer(),
                     ))?;
-                    Global::exit(1);
+                    exit_or_watch(1, ctx.debug.hot_reload == HotReload::Watch);
                 }
 
                 print_summary(

--- a/test/regression/issue/21097.test.ts
+++ b/test/regression/issue/21097.test.ts
@@ -1,0 +1,101 @@
+import { expect, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+setDefaultTimeout(30_000);
+
+test("import.meta.env is lowered to process.env in bun build", async () => {
+  using dir = tempDir("issue-21097-bundle", {
+    "index.ts": "console.log(import.meta.env.FOO)",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--target=bun", join(String(dir), "index.ts")],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("process.env.FOO");
+  expect(stdout).not.toContain("import.meta.env");
+  expect(exitCode).toBe(0);
+});
+
+test("import.meta.env lowering does not shadow a local process binding", async () => {
+  // When `process` is shadowed by a local parameter, the rewrite must not
+  // silently reference the local. Leave import.meta.env as-is so Bun's
+  // runtime resolves it to the real global.
+  using dir = tempDir("issue-21097-shadow", {
+    "index.ts": `
+function handler(process: any) {
+  return import.meta.env.FOO;
+}
+console.log(handler.toString());
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--target=bun", join(String(dir), "index.ts")],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The shadowed scope must NOT be rewritten to `process.env.FOO`,
+  // which would reference the parameter instead of the global.
+  expect(stdout).toContain("import.meta.env.FOO");
+  expect(stdout).not.toContain("process.env.FOO");
+  expect(exitCode).toBe(0);
+});
+
+test("import.meta.env works in bun build --compile --bytecode", async () => {
+  using dir = tempDir("issue-21097-bc", {
+    "index.ts": `
+const val = import.meta.env.TEST_VAR_21097_BC;
+if (val) {
+  console.log("found:" + val);
+} else {
+  console.log("not-found");
+}
+`,
+  });
+
+  const outfile = join(String(dir), isWindows ? "test-binary-bc.exe" : "test-binary-bc");
+
+  // Compile with bytecode - previously failed with "Failed to generate bytecode"
+  await using compile = Bun.spawn({
+    cmd: [bunExe(), "build", "--compile", "--bytecode", join(String(dir), "index.ts"), "--outfile", outfile],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [compileStdout, compileStderr, compileExit] = await Promise.all([
+    compile.stdout.text(),
+    compile.stderr.text(),
+    compile.exited,
+  ]);
+
+  expect(compileStderr).not.toContain("Failed to generate bytecode");
+  expect(compileExit).toBe(0);
+
+  // Run with env var - previously crashed with TypeError
+  await using withEnv = Bun.spawn({
+    cmd: [outfile],
+    env: { ...bunEnv, TEST_VAR_21097_BC: "bytecode-works" },
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [withEnvStdout, withEnvStderr, withEnvExit] = await Promise.all([
+    withEnv.stdout.text(),
+    withEnv.stderr.text(),
+    withEnv.exited,
+  ]);
+
+  expect(withEnvStderr).not.toContain("TypeError: Expected CommonJS module to have a function wrapper");
+  expect(withEnvStdout).toBe("found:bytecode-works\n");
+  expect(withEnvExit).toBe(0);
+});


### PR DESCRIPTION
Closes #21097

## Problem

`import.meta.env` in `bun build --compile --bytecode` causes:
1. **Bytecode generation failure**: `import.meta.env` passes through the bundler unchanged, but JSC's bytecode generator can't handle `import.meta` in this context, printing `Failed to generate bytecode`
2. **Silent broken binary**: The build exits 0 and produces a binary that crashes at runtime with `TypeError: Expected CommonJS module to have a function wrapper`

## Root Cause

`import.meta.env` was not being lowered during bundling. Other `import.meta` properties (`main`, `hot`, `dir`, etc.) are already handled in `maybeRewritePropertyAccess`, but `env` was falling through to the generic passthrough case, leaving `import.meta.env` as-is in the bundled output.

## Fix

1. **Lower `import.meta.env` → `process.env` when bundling** (`src/ast/maybe.zig`): These are semantically equivalent in Bun's runtime. This follows the existing pattern for other `import.meta` property lowerings.

2. **Exit with code 1 on `--compile` log errors** (`src/cli/build_command.zig`): The `--compile` code path was not checking for accumulated log errors before producing the executable. Now it exits early with code 1 if there are any errors.

## Verification

```
# Before: import.meta.env passes through
bun build -e 'console.log(import.meta.env.FOO)'
# → console.log(import.meta.env.FOO)

# After: lowered to process.env
bun build -e 'console.log(import.meta.env.FOO)'
# → console.log(process.env.FOO)

# --compile --bytecode now works
bun build --compile --bytecode ./index.ts --outfile server  # no error
DATABASE_URL=something ./server  # works correctly
```

`bun bd test test/regression/issue/21097.test.ts` passes, `USE_SYSTEM_BUN=1` fails.