### PR TITLE
Enforce --max-http-header-size limit in native fetch client

### DIFF
--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -1875,6 +1875,12 @@ pub fn handleOnDataHeaders(
         ) catch |err| {
             switch (err) {
                 error.ShortRead => {
+                    // All data received so far is header data (headers aren't
+                    // complete yet). Reject early if it already exceeds the limit.
+                    if (to_read.len > max_http_header_size) {
+                        this.closeAndFail(error.HeaderSizeExceeded, is_ssl, socket);
+                        return;
+                    }
                     this.handleShortRead(is_ssl, incoming_data, socket, needs_move);
                 },
                 else => {
@@ -1883,6 +1889,12 @@ pub fn handleOnDataHeaders(
             }
             return;
         };
+
+        // Enforce the configured max header size limit on the parsed response.
+        if (@as(usize, @intCast(response.bytes_read)) > max_http_header_size) {
+            this.closeAndFail(error.HeaderSizeExceeded, is_ssl, socket);
+            return;
+        }
 
         // we save the successful parsed response
         this.state.pending_response = response;

--- a/src/runtime/webcore/fetch/FetchTasklet.zig
+++ b/src/runtime/webcore/fetch/FetchTasklet.zig
@@ -778,6 +778,7 @@ pub const FetchTasklet = struct {
                 error.TooManyRedirects => bun.String.static("The response redirected too many times. For more information, pass `verbose: true` in the second argument to fetch()"),
                 error.ConnectionRefused => bun.String.static("Unable to connect. Is the computer able to access the url?"),
                 error.RedirectURLInvalid => bun.String.static("Redirect URL in Location header is invalid."),
+                error.HeaderSizeExceeded => bun.String.static("Headers exceeded the configured maximum size. See --max-http-header-size."),
 
                 error.UNABLE_TO_GET_ISSUER_CERT => bun.String.static("unable to get issuer certificate"),
                 error.UNABLE_TO_GET_CRL => bun.String.static("unable to get certificate CRL"),

--- a/test/js/web/fetch/fetch-redirect.test.ts
+++ b/test/js/web/fetch/fetch-redirect.test.ts
@@ -85,7 +85,8 @@ it("fetch() does not leak intermediate redirect URLs in multi-hop chains", async
   `;
 
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
+    // Raise the header size limit since the test deliberately sends ~96 KiB Location headers.
+    cmd: [bunExe(), "--max-http-header-size=131072", "-e", script],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",

--- a/test/regression/issue/20488.test.ts
+++ b/test/regression/issue/20488.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 describe("fetch respects --max-http-header-size", () => {
@@ -34,11 +34,7 @@ describe("fetch respects --max-http-header-size", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toContain("CAUGHT:");
     expect(stdout).toContain("HeaderSizeExceeded");
@@ -78,11 +74,7 @@ describe("fetch respects --max-http-header-size", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toContain("OK: ok");
     expect(exitCode).toBe(0);

--- a/test/regression/issue/20488.test.ts
+++ b/test/regression/issue/20488.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-describe("fetch respects --max-http-header-size", () => {
+describe.concurrent("fetch respects --max-http-header-size", () => {
   test("rejects when response headers exceed the limit", async () => {
     await using proc = Bun.spawn({
       cmd: [
@@ -19,13 +19,13 @@ describe("fetch respects --max-http-header-size", () => {
         });
         try {
           const res = await fetch("http://localhost:" + server.port);
+          server.stop(true);
           console.log("ERROR: fetch should have thrown but got status " + res.status);
           process.exit(1);
         } catch (e) {
+          server.stop(true);
           console.log("CAUGHT: " + e.code);
           process.exit(0);
-        } finally {
-          server.stop(true);
         }
         `,
       ],
@@ -59,13 +59,13 @@ describe("fetch respects --max-http-header-size", () => {
         try {
           const res = await fetch("http://localhost:" + server.port);
           const text = await res.text();
+          server.stop(true);
           console.log("OK: " + text);
           process.exit(0);
         } catch (e) {
+          server.stop(true);
           console.log("ERROR: " + e.message);
           process.exit(1);
-        } finally {
-          server.stop(true);
         }
         `,
       ],

--- a/test/regression/issue/20488.test.ts
+++ b/test/regression/issue/20488.test.ts
@@ -1,0 +1,90 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+describe("fetch respects --max-http-header-size", () => {
+  test("rejects when response headers exceed the limit", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--max-http-header-size=16384",
+        "-e",
+        `
+        const server = Bun.serve({
+          port: 0,
+          fetch(req) {
+            return new Response("ok", {
+              headers: { "Large-Header": Buffer.alloc(1024 * 18, "a").toString() },
+            });
+          },
+        });
+        try {
+          const res = await fetch("http://localhost:" + server.port);
+          console.log("ERROR: fetch should have thrown but got status " + res.status);
+          process.exit(1);
+        } catch (e) {
+          console.log("CAUGHT: " + e.code);
+          process.exit(0);
+        } finally {
+          server.stop(true);
+        }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toContain("CAUGHT:");
+    expect(stdout).toContain("HeaderSizeExceeded");
+    expect(exitCode).toBe(0);
+  }, 30_000);
+
+  test("succeeds when response headers are within the limit", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--max-http-header-size=32768",
+        "-e",
+        `
+        const server = Bun.serve({
+          port: 0,
+          fetch(req) {
+            return new Response("ok", {
+              headers: { "Large-Header": Buffer.alloc(1024 * 18, "a").toString() },
+            });
+          },
+        });
+        try {
+          const res = await fetch("http://localhost:" + server.port);
+          const text = await res.text();
+          console.log("OK: " + text);
+          process.exit(0);
+        } catch (e) {
+          console.log("ERROR: " + e.message);
+          process.exit(1);
+        } finally {
+          server.stop(true);
+        }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toContain("OK: ok");
+    expect(exitCode).toBe(0);
+  }, 30_000);
+});


### PR DESCRIPTION
## Problem

Native `fetch` does not respect the `--max-http-header-size` CLI flag. When a server sends response headers exceeding the configured limit, `fetch` accepts them without error, while Node.js correctly rejects with `UND_ERR_HEADERS_OVERFLOW`.

## Root Cause

`handleOnDataHeaders()` in `src/http.zig` (the fetch HTTP client path) never checked response header sizes against the global `max_http_header_size` setting. The limit was only enforced on the server side (via uWS) and in the Node.js compatibility HTTP parser (llhttp).

## Fix

Add header size checks in two places within `handleOnDataHeaders`:

1. **On `ShortRead`**: When picohttp reports incomplete headers, check if accumulated data already exceeds the limit — rejects early and prevents unbounded buffer growth.
2. **After successful parse**: Check if the parsed header byte count exceeds the limit.

Both paths call `closeAndFail(error.HeaderSizeExceeded)`, which surfaces as a `TypeError` with code `HeaderSizeExceeded` in JavaScript.

## Verification

```
# System bun (no fix) — fetch succeeds with oversized headers:
USE_SYSTEM_BUN=1 bun test test/regression/issue/20488.test.ts  → FAIL

# Debug build (with fix) — fetch rejects oversized headers:
bun bd test test/regression/issue/20488.test.ts  → PASS
```

Closes #20488