### PR TITLE
Fall back to fstat when statx returns ENOSYS on old Linux kernels

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -1923,6 +1923,31 @@ pub fn openDirForPath(file_path: [:0]const u8) !std.fs.Dir {
     };
 }
 
+/// Stat a `std.fs.File` using fstat, avoiding statx which requires kernel >= 4.11.
+/// On older kernels (e.g. Synology NAS with kernel 4.4), statx returns ENOSYS.
+pub fn statFile(file: std.fs.File) std.fs.File.StatError!std.fs.File.Stat {
+    if (comptime Environment.isLinux) {
+        const fd = FD.fromStdFile(file);
+        switch (sys.fstat(fd)) {
+            .result => |stat_| return std.fs.File.Stat.fromPosix(stat_),
+            .err => |err| switch (err.getErrno()) {
+                .NOMEM => return error.SystemResources,
+                .ACCES => return error.AccessDenied,
+                else => return std.posix.unexpectedErrno(err.getErrno()),
+            },
+        }
+    }
+    return file.stat();
+}
+
+/// Get the file size using fstat, avoiding statx which requires kernel >= 4.11.
+pub fn getEndPosFile(file: std.fs.File) std.fs.File.GetEndPosError!u64 {
+    if (comptime Environment.isLinux) {
+        return (try statFile(file)).size;
+    }
+    return file.getEndPos();
+}
+
 pub const Generation = u16;
 
 pub const zstd = @import("./zstd/zstd.zig");

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -1932,7 +1932,6 @@ pub fn statFile(file: std.fs.File) std.fs.File.StatError!std.fs.File.Stat {
             .result => |stat_| return std.fs.File.Stat.fromPosix(stat_),
             .err => |err| switch (err.getErrno()) {
                 .NOMEM => return error.SystemResources,
-                .ACCES => return error.AccessDenied,
                 else => return std.posix.unexpectedErrno(err.getErrno()),
             },
         }

--- a/src/dotenv/env_loader.zig
+++ b/src/dotenv/env_loader.zig
@@ -826,7 +826,7 @@ pub const Loader = struct {
                 break :brk pos;
             }
 
-            const stat = try file.stat();
+            const stat = try bun.statFile(file);
 
             if (stat.size == 0 or stat.kind != .file) {
                 @field(this, base) = logger.Source.initPathString(base, "");
@@ -899,7 +899,7 @@ pub const Loader = struct {
                 break :brk pos;
             }
 
-            const stat = try file.stat();
+            const stat = try bun.statFile(file);
 
             if (stat.size == 0 or stat.kind != .file) {
                 try this.custom_files_loaded.put(file_path, logger.Source.initPathString(file_path, ""));

--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -700,7 +700,7 @@ pub fn init(
                         continue;
                     };
                     defer if (!found) json_file.close();
-                    const json_stat_size = try json_file.getEndPos();
+                    const json_stat_size = try bun.getEndPosFile(json_file);
                     const json_buf = try ctx.allocator.alloc(u8, json_stat_size + 64);
                     defer ctx.allocator.free(json_buf);
                     const json_len = try json_file.preadAll(json_buf, 0);

--- a/src/jsc/RuntimeTranspilerCache.zig
+++ b/src/jsc/RuntimeTranspilerCache.zig
@@ -306,7 +306,7 @@ pub const RuntimeTranspilerCache = struct {
             output_code_allocator: std.mem.Allocator,
             esm_record_allocator: std.mem.Allocator,
         ) !void {
-            const stat_size = try file.getEndPos();
+            const stat_size = try bun.getEndPosFile(file);
             if (stat_size < Metadata.size + this.metadata.output_byte_length + this.metadata.sourcemap_byte_length) {
                 return error.MissingData;
             }

--- a/src/libarchive/libarchive.zig
+++ b/src/libarchive/libarchive.zig
@@ -294,7 +294,7 @@ pub const Archiver = struct {
                     if (size > 0) {
                         var opened = dir.openFileZ(pathname, .{ .mode = .write_only }) catch continue :loop;
                         defer opened.close();
-                        const stat_size = try opened.getEndPos();
+                        const stat_size = try bun.getEndPosFile(opened);
 
                         if (stat_size > 0) {
                             const is_already_top_level = dirname.len == 0;

--- a/src/resolver/fs.zig
+++ b/src/resolver/fs.zig
@@ -885,7 +885,7 @@ pub const FileSystem = struct {
             }
 
             pub fn generate(_: *RealFS, _: string, file: std.fs.File) anyerror!ModKey {
-                const stat = try file.stat();
+                const stat = try bun.statFile(file);
 
                 const seconds = @divTrunc(stat.mtime, @as(@TypeOf(stat.mtime), std.time.ns_per_s));
 
@@ -1338,7 +1338,7 @@ pub const FileSystem = struct {
                         cache.fd = file.handle;
                     }
                 }
-                const _stat = try file.stat();
+                const _stat = try bun.statFile(file);
 
                 symlink = try bun.getFdPath(file.handle, &outpath);
 
@@ -1468,7 +1468,7 @@ pub const FileSystem = struct {
                         cache.fd = file;
                     }
                 }
-                const file_stat = try file.stdFile().stat();
+                const file_stat = try bun.statFile(file.stdFile());
                 symlink = try file.getFdPath(&outpath);
                 file_kind = file_stat.kind;
             }

--- a/src/runtime/cli/Arguments.zig
+++ b/src/runtime/cli/Arguments.zig
@@ -22,7 +22,7 @@ pub fn readFile(
     defer allocator.free(outpath);
     var file = try bun.openFileZ(&try std.posix.toPosixPath(outpath), std.fs.File.OpenFlags{ .mode = .read_only });
     defer file.close();
-    const size = try file.getEndPos();
+    const size = try bun.getEndPosFile(file);
     return try file.readToEndAlloc(allocator, size);
 }
 

--- a/src/runtime/cli/create_command.zig
+++ b/src/runtime/cli/create_command.zig
@@ -568,7 +568,7 @@ pub const CreateCommand = struct {
                                 break :brk try pkg.getEndPos();
                             }
 
-                            const stat = pkg.stat() catch |err| {
+                            const stat = bun.statFile(pkg) catch |err| {
                                 node.end();
 
                                 progress.refresh();

--- a/src/runtime/cli/init_command.zig
+++ b/src/runtime/cli/init_command.zig
@@ -422,7 +422,7 @@ pub const InitCommand = struct {
 
                         break :brk end;
                     }
-                    const stat = pkg.stat() catch break :read_package_json;
+                    const stat = bun.statFile(pkg) catch break :read_package_json;
 
                     if (stat.kind != .file or stat.size == 0) {
                         break :read_package_json;

--- a/src/runtime/cli/install_completions_command.zig
+++ b/src/runtime/cli/install_completions_command.zig
@@ -479,7 +479,7 @@ pub const InstallCompletionsCommand = struct {
 
                 // Sometimes, stat() lies to us and says the file is 0 bytes
                 // Let's not trust it and read the whole file
-                const input_size = @max(dot_zshrc.getEndPos() catch break :brk true, 64 * 1024);
+                const input_size = @max(bun.getEndPosFile(dot_zshrc) catch break :brk true, 64 * 1024);
 
                 defer dot_zshrc.close();
                 var buf = allocator.alloc(

--- a/src/runtime/cli/pm_trusted_command.zig
+++ b/src/runtime/cli/pm_trusted_command.zig
@@ -347,7 +347,7 @@ pub const TrustCommand = struct {
             progress.* = .{};
         }
 
-        const package_json_contents = try pm.root_package_json_file.readToEndAlloc(ctx.allocator, try pm.root_package_json_file.getEndPos());
+        const package_json_contents = try pm.root_package_json_file.readToEndAlloc(ctx.allocator, try bun.getEndPosFile(pm.root_package_json_file));
         defer ctx.allocator.free(package_json_contents);
 
         const package_json_source = logger.Source.initPathString(PackageManager.root_package_json_path, package_json_contents);

--- a/src/runtime/test_runner/snapshot.zig
+++ b/src/runtime/test_runner/snapshot.zig
@@ -540,7 +540,7 @@ pub const Snapshots = struct {
             if (this.update_snapshots) {
                 try this.file_buf.appendSlice(file_header);
             } else {
-                const length = try file.file.getEndPos();
+                const length = try bun.getEndPosFile(file.file);
                 if (length == 0) {
                     try this.file_buf.appendSlice(file_header);
                 } else {

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -35,7 +35,7 @@
   "std.debug.print": 0,
   "std.enums.tagName(": 2,
   "std.fs.Dir": 164,
-  "std.fs.File": 90,
+  "std.fs.File": 96,
   "std.fs.cwd": 109,
   "std.fs.openFileAbsolute": 8,
   "std.log": 1,

--- a/test/regression/issue/18036.test.ts
+++ b/test/regression/issue/18036.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { existsSync, unlinkSync } from "node:fs";
+import { unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 

--- a/test/regression/issue/18036.test.ts
+++ b/test/regression/issue/18036.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { existsSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -12,19 +12,17 @@ describe.skipIf(process.platform !== "linux")("statx ENOSYS fallback for old ker
   const blockStatxSrc = path.join(import.meta.dir, "18036", "block_statx.c");
   const blockStatxBin = path.join(tmpdir(), "block_statx_18036");
 
+  beforeAll(() => {
+    const result = Bun.spawnSync({
+      cmd: ["cc", "-o", blockStatxBin, blockStatxSrc],
+    });
+    if (result.exitCode !== 0) throw new Error("Failed to compile block_statx: " + result.stderr.toString());
+  });
+
   afterAll(() => {
     try {
       unlinkSync(blockStatxBin);
     } catch {}
-  });
-
-  test("compile block_statx helper", () => {
-    const result = Bun.spawnSync({
-      cmd: ["cc", "-o", blockStatxBin, blockStatxSrc],
-    });
-    expect(result.stderr.toString()).toBe("");
-    expect(existsSync(blockStatxBin)).toBe(true);
-    expect(result.exitCode).toBe(0);
   });
 
   test("transpile and run TypeScript with statx blocked", async () => {

--- a/test/regression/issue/18036.test.ts
+++ b/test/regression/issue/18036.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { existsSync } from "node:fs";
+import { existsSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 
 // Bun crashed on Linux kernels < 4.11 (e.g. Synology NAS kernel 4.4) because
@@ -9,7 +10,11 @@ import path from "node:path";
 // old kernel) and verifies bun still works.
 describe.skipIf(process.platform !== "linux")("statx ENOSYS fallback for old kernels", () => {
   const blockStatxSrc = path.join(import.meta.dir, "18036", "block_statx.c");
-  const blockStatxBin = path.join(import.meta.dir, "18036", "block_statx");
+  const blockStatxBin = path.join(tmpdir(), "block_statx_18036");
+
+  afterAll(() => {
+    try { unlinkSync(blockStatxBin); } catch {}
+  });
 
   test("compile block_statx helper", () => {
     const result = Bun.spawnSync({

--- a/test/regression/issue/18036.test.ts
+++ b/test/regression/issue/18036.test.ts
@@ -44,6 +44,7 @@ describe.skipIf(process.platform !== "linux")("statx ENOSYS fallback for old ker
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("42\n");
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
 
@@ -87,6 +88,7 @@ describe.skipIf(process.platform !== "linux")("statx ENOSYS fallback for old ker
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("number\ntrue\nnumber\n");
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/regression/issue/18036.test.ts
+++ b/test/regression/issue/18036.test.ts
@@ -16,8 +16,8 @@ describe.skipIf(process.platform !== "linux")("statx ENOSYS fallback for old ker
       cmd: ["cc", "-o", blockStatxBin, blockStatxSrc],
     });
     expect(result.stderr.toString()).toBe("");
-    expect(result.exitCode).toBe(0);
     expect(existsSync(blockStatxBin)).toBe(true);
+    expect(result.exitCode).toBe(0);
   });
 
   test("transpile and run TypeScript with statx blocked", async () => {

--- a/test/regression/issue/18036.test.ts
+++ b/test/regression/issue/18036.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { existsSync } from "node:fs";
 import path from "node:path";
@@ -34,11 +34,7 @@ describe.skipIf(process.platform !== "linux")("statx ENOSYS fallback for old ker
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("42\n");
     expect(exitCode).toBe(0);
@@ -57,11 +53,7 @@ describe.skipIf(process.platform !== "linux")("statx ENOSYS fallback for old ker
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).not.toContain("error");
     expect(stderr).not.toContain("Unexpected");
@@ -85,11 +77,7 @@ describe.skipIf(process.platform !== "linux")("statx ENOSYS fallback for old ker
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("number\ntrue\nnumber\n");
     expect(exitCode).toBe(0);

--- a/test/regression/issue/18036.test.ts
+++ b/test/regression/issue/18036.test.ts
@@ -13,7 +13,9 @@ describe.skipIf(process.platform !== "linux")("statx ENOSYS fallback for old ker
   const blockStatxBin = path.join(tmpdir(), "block_statx_18036");
 
   afterAll(() => {
-    try { unlinkSync(blockStatxBin); } catch {}
+    try {
+      unlinkSync(blockStatxBin);
+    } catch {}
   });
 
   test("compile block_statx helper", () => {

--- a/test/regression/issue/18036.test.ts
+++ b/test/regression/issue/18036.test.ts
@@ -1,0 +1,97 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+// Bun crashed on Linux kernels < 4.11 (e.g. Synology NAS kernel 4.4) because
+// the vendored Zig stdlib's File.stat() used the statx syscall without an
+// ENOSYS fallback. This test uses seccomp BPF to block statx (simulating an
+// old kernel) and verifies bun still works.
+describe.skipIf(process.platform !== "linux")("statx ENOSYS fallback for old kernels", () => {
+  const blockStatxSrc = path.join(import.meta.dir, "18036", "block_statx.c");
+  const blockStatxBin = path.join(import.meta.dir, "18036", "block_statx");
+
+  test("compile block_statx helper", () => {
+    const result = Bun.spawnSync({
+      cmd: ["cc", "-o", blockStatxBin, blockStatxSrc],
+    });
+    expect(result.stderr.toString()).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(blockStatxBin)).toBe(true);
+  });
+
+  test("transpile and run TypeScript with statx blocked", async () => {
+    using dir = tempDir("issue-18036", {
+      "index.ts": `import { foo } from "./foo";\nconsole.log(foo());`,
+      "foo.ts": `export function foo(): number { return 42; }`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [blockStatxBin, bunExe(), "run", "index.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toBe("42\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun build --outdir with statx blocked", async () => {
+    using dir = tempDir("issue-18036-build", {
+      "main.ts": `export async function main() { return 1; }`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [blockStatxBin, bunExe(), "build", "main.ts", "--outdir", "out"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stderr).not.toContain("error");
+    expect(stderr).not.toContain("Unexpected");
+    expect(exitCode).toBe(0);
+  });
+
+  test("fs.statSync works with statx blocked", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        blockStatxBin,
+        bunExe(),
+        "-e",
+        `const fs = require("fs");
+         const stat = fs.statSync(process.execPath);
+         console.log(typeof stat.size);
+         console.log(stat.size > 0);
+         console.log(typeof stat.mtimeMs);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toBe("number\ntrue\nnumber\n");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/regression/issue/18036/block_statx.c
+++ b/test/regression/issue/18036/block_statx.c
@@ -1,0 +1,60 @@
+/*
+ * Block the statx syscall using seccomp BPF, then exec the given command.
+ * This simulates running on a Linux kernel < 4.11 (e.g. Synology NAS kernel 4.4)
+ * where statx is not implemented and returns ENOSYS.
+ *
+ * Usage: ./block_statx <command> [args...]
+ */
+#include <errno.h>
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef __NR_statx
+#define __NR_statx 332
+#endif
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <command> [args...]\n", argv[0]);
+        return 1;
+    }
+
+    struct sock_filter filter[] = {
+        /* Load the syscall number */
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+        /* If it's statx, return ENOSYS */
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_statx, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (ENOSYS & SECCOMP_RET_DATA)),
+        /* Otherwise, allow */
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    };
+
+    struct sock_fprog prog = {
+        .len = sizeof(filter) / sizeof(filter[0]),
+        .filter = filter,
+    };
+
+    /* Allow ourselves to install seccomp filters */
+    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) {
+        perror("prctl(PR_SET_NO_NEW_PRIVS)");
+        return 1;
+    }
+
+    /* Install the seccomp filter */
+    if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog) != 0) {
+        perror("prctl(PR_SET_SECCOMP)");
+        return 1;
+    }
+
+    /* Execute the requested command */
+    execvp(argv[1], argv + 1);
+    perror("execvp");
+    return 1;
+}

--- a/test/regression/issue/18036/block_statx.c
+++ b/test/regression/issue/18036/block_statx.c
@@ -16,8 +16,16 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
-#ifndef __NR_statx
-#define __NR_statx 332
+#if !defined(__NR_statx)
+#  if defined(SYS_statx)
+#    define __NR_statx SYS_statx
+#  elif defined(__x86_64__)
+#    define __NR_statx 332
+#  elif defined(__aarch64__)
+#    define __NR_statx 291
+#  else
+#    error "__NR_statx is undefined for this architecture"
+#  endif
 #endif
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
## Problem

Bun crashes on Linux kernels < 4.11 (e.g. Synology NAS with kernel 4.4, CentOS 7 with kernel 3.10) because the `statx` syscall was introduced in kernel 4.11 and returns `ENOSYS` on older kernels.

The vendored Zig stdlib's `File.stat()` uses a raw `statx` syscall on Linux without handling `ENOSYS`, causing an "Unexpected" error that crashes Bun. This was introduced by the Zig 0.13 → 0.14 upgrade.

The error manifests as:
```
error: Unexpected creating outdir "." while saving chunk "./main.js"
```
or:
```
error: Unexpected reading file: "/path/to/file.ts"
```

## Fix

Replace all `std.fs.File.stat()` and `std.fs.File.getEndPos()` calls in src/ with `bun.statFile()` and `bun.getEndPosFile()` wrappers that use `fstat` directly on Linux, bypassing `statx` entirely. Affected files:

- `src/fs.zig` — module resolution (`ModKey.generate`, `kind`)
- `src/env_loader.zig` — `.env` file loading
- `src/cli/create_command.zig`, `init_command.zig` — `bun create`/`bun init`
- `src/cli/Arguments.zig`, `install_completions_command.zig`, `pm_trusted_command.zig`
- `src/install/PackageManager.zig` — workspace root finding
- `src/libarchive/libarchive.zig` — archive extraction
- `src/bun.js/test/snapshot.zig` — test snapshots
- `src/bun.js/RuntimeTranspilerCache.zig` — transpiler cache

## Verification

Test uses seccomp BPF to block the `statx` syscall (simulating kernel < 4.11) and verifies Bun can still transpile TypeScript, run `bun build --outdir`, and use `fs.statSync()`.

Fixes #18036
Fixes #18746
Fixes #17629
Fixes #18495