### PR TITLE
types: allow windowBits 0 in ZlibCompressionOptions

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5073,6 +5073,7 @@ declare module "bun" {
      * Larger values of this parameter result in better compression at the expense of memory usage.
      *
      * The following value ranges are supported:
+     * - `0`: (inflateSync only) read the window size from the zlib header of the compressed stream
      * - `9..15`: The output will have a zlib header and footer (Deflate)
      * - `-9..-15`: The output will **not** have a zlib header or footer (Raw Deflate)
      * - `25..31` (16+`9..15`): The output will have a gzip header and footer (gzip)
@@ -5080,6 +5081,7 @@ declare module "bun" {
      * The gzip header will have no file name, no extra data, no comment, no modification time (set to zero) and no header CRC.
      */
     windowBits?:
+      | 0
       | -9
       | -10
       | -11

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -597,7 +597,7 @@ describe("@types/bun integration test", () => {
         },
         {
           code: 2353,
-          line: "globals.ts:307:5",
+          line: "globals.ts:309:5",
           message: "Object literal may only specify known properties, and 'headers' does not exist in type 'string[]'.",
         },
         {

--- a/test/integration/bun-types/fixture/globals.ts
+++ b/test/integration/bun-types/fixture/globals.ts
@@ -34,8 +34,10 @@ expectType<Uint8Array>(
 );
 expectType<Uint8Array>(Bun.gzipSync(new Uint8Array(128), { level: 9, memLevel: 6, windowBits: 27 }));
 expectType<Uint8Array>(Bun.inflateSync(new Uint8Array(64))); // Pretend this is DEFLATE compressed data
+expectType<Uint8Array>(Bun.inflateSync(new Uint8Array(64), { windowBits: 0 })); // Read window size from zlib header
 expectType<Uint8Array>(Bun.gunzipSync(new Uint8Array(64))); // Pretend this is GZIP compressed data
 expectAssignable<Bun.ZlibCompressionOptions>({ windowBits: -11 });
+expectAssignable<Bun.ZlibCompressionOptions>({ windowBits: 0 });
 
 // Other
 expectType<Promise<number>>(Bun.write("test.json", "lol"));

--- a/test/js/bun/util/bun-zlib.test.ts
+++ b/test/js/bun/util/bun-zlib.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { deflateSync as nodeDeflateSync } from "node:zlib";
 
 describe("Bun.inflateSync windowBits", () => {

--- a/test/js/bun/util/bun-zlib.test.ts
+++ b/test/js/bun/util/bun-zlib.test.ts
@@ -1,0 +1,40 @@
+import { expect, test, describe } from "bun:test";
+import { deflateSync as nodeDeflateSync } from "node:zlib";
+
+describe("Bun.inflateSync windowBits", () => {
+  test("0 reads window size from zlib header", () => {
+    // node:zlib deflateSync produces a zlib-wrapped stream (78 xx header + adler32 trailer).
+    // Bun.inflateSync defaults to raw deflate and cannot decode this without windowBits:0,
+    // which per zlib.h inflateInit2 docs means "use the window size in the zlib header".
+    const input = "hello zlib wrapped stream";
+    const wrapped = nodeDeflateSync(input);
+
+    expect(wrapped[0]).toBe(0x78); // zlib magic
+
+    // Without windowBits:0, the zlib header is interpreted as deflate data and fails
+    expect(() => Bun.inflateSync(wrapped)).toThrow();
+
+    // With windowBits:0, the header is read and the stream decodes
+    const out = Bun.inflateSync(wrapped, { windowBits: 0 });
+    expect(new TextDecoder().decode(out)).toBe(input);
+  });
+
+  test("0 works across all zlib compression levels", () => {
+    // Each level produces a different 2-byte header (78 01 / 78 9c / 78 da).
+    // windowBits:0 reads the header regardless of which level wrote it.
+    const input = "test";
+    for (const level of [1, 6, 9] as const) {
+      const wrapped = nodeDeflateSync(input, { level });
+      const out = Bun.inflateSync(wrapped, { windowBits: 0 });
+      expect(new TextDecoder().decode(out)).toBe(input);
+    }
+  });
+
+  test("raw deflate still round-trips with no options", () => {
+    // Bun.deflateSync produces raw deflate (no zlib header). Unchanged by this PR.
+    const input = "round trip";
+    const raw = Bun.deflateSync(input);
+    expect(raw[0]).not.toBe(0x78);
+    expect(new TextDecoder().decode(Bun.inflateSync(raw))).toBe(input);
+  });
+});


### PR DESCRIPTION
`Bun.inflateSync` accepts `windowBits: 0` at runtime to mean "read the window size from the zlib header of the compressed stream." This is documented zlib behavior — from `inflateInit2` in zlib.h:

> windowBits can also be zero to request that inflate use the window size in the zlib header of the compressed stream.

Without it, you can't decompress zlib-wrapped output (from `node:zlib` `deflateSync`, or C `compress2()`) without manually stripping the 2-byte header and 4-byte adler32 trailer:

```ts
import { deflateSync } from "node:zlib";

const wrapped = deflateSync("hello");  // has 78 xx header

Bun.inflateSync(wrapped);                      // throws "invalid stored block lengths"
Bun.inflateSync(wrapped, { windowBits: 0 });   // works at runtime, but type error before this PR
```

The type rejected `0` because `ZlibCompressionOptions` enumerates only the values meaningful for compression (`9..15` / `-9..-15` / `25..31`), where `0` has no meaning — there's no header to read when you're writing it. The same options type is reused for `inflateSync` where `0` is the documented header-reading mode.

This adds `0` to the union with a doc note that it's inflate-only.