### PR TITLE
Fix lab/lch/oklab/oklch color parsing to accept both numbers and percentages

### DIFF
--- a/src/css/values/color.zig
+++ b/src/css/values/color.zig
@@ -905,20 +905,34 @@ pub fn parseLab(
 
         pub fn innerfn(i: *css.Parser, p: *ComponentParser) Result(CssColor) {
             // f32::max() does not propagate NaN, so use clamp for now until f32::maximum() is stable.
+            // CSS Color 4: l accepts <number> or <percentage>.
+            // lab/oklab: percentage is unit value; number is divided by range max (100 for lab, 1 for oklab).
             const l = bun.clamp(
-                switch (p.parsePercentage(i)) {
-                    .result => |v| v,
+                switch (p.parseNumberOrPercentage(i)) {
+                    .result => |vv| switch (vv) {
+                        .number => |v| v.value / comptime (if (T == OKLAB) @as(f32, 1.0) else @as(f32, 100.0)),
+                        .percentage => |v| v.unit_value,
+                    },
                     .err => |e| return .{ .err = e },
                 },
                 0.0,
                 std.math.floatMax(f32),
             );
-            const a = switch (p.parseNumber(i)) {
-                .result => |vv| vv,
+            // CSS Color 4: a and b accept <number> or <percentage>.
+            // Percentage maps to number range: -125..125 for lab, -0.4..0.4 for oklab.
+            const ab_pct_basis: f32 = comptime if (T == OKLAB) 0.4 else 125.0;
+            const a = switch (p.parseNumberOrPercentage(i)) {
+                .result => |vv| switch (vv) {
+                    .number => |v| v.value,
+                    .percentage => |v| v.unit_value * ab_pct_basis,
+                },
                 .err => |e| return .{ .err = e },
             };
-            const b = switch (p.parseNumber(i)) {
-                .result => |vv| vv,
+            const b = switch (p.parseNumberOrPercentage(i)) {
+                .result => |vv| switch (vv) {
+                    .number => |v| v.value,
+                    .percentage => |v| v.unit_value * ab_pct_basis,
+                },
                 .err => |e| return .{ .err = e },
             };
             const alpha = switch (parseAlpha(i, p)) {
@@ -972,17 +986,27 @@ pub fn parseLch(
                 }
             }
 
+            // CSS Color 4: l accepts <number> or <percentage>.
+            // lch/oklch: percentage is unit value; number is divided by range max (100 for lch, 1 for oklch).
             const l = bun.clamp(
-                switch (p.parsePercentage(i)) {
-                    .result => |vv| vv,
+                switch (p.parseNumberOrPercentage(i)) {
+                    .result => |vv| switch (vv) {
+                        .number => |v| v.value / comptime (if (T == OKLCH) @as(f32, 1.0) else @as(f32, 100.0)),
+                        .percentage => |v| v.unit_value,
+                    },
                     .err => |e| return .{ .err = e },
                 },
                 0.0,
                 std.math.floatMax(f32),
             );
+            // CSS Color 4: c accepts <number> or <percentage>.
+            // Percentage maps to number range: 0..150 for lch, 0..0.4 for oklch.
             const c = bun.clamp(
-                switch (p.parseNumber(i)) {
-                    .result => |vv| vv,
+                switch (p.parseNumberOrPercentage(i)) {
+                    .result => |vv| switch (vv) {
+                        .number => |v| v.value,
+                        .percentage => |v| v.unit_value * comptime (if (T == OKLCH) @as(f32, 0.4) else @as(f32, 150.0)),
+                    },
                     .err => |e| return .{ .err = e },
                 },
                 0.0,

--- a/test/regression/issue/16727.test.ts
+++ b/test/regression/issue/16727.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 // https://github.com/oven-sh/bun/issues/16727
 // Bun.color should accept both <number> and <percentage> for all

--- a/test/regression/issue/16727.test.ts
+++ b/test/regression/issue/16727.test.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/16727
+// Bun.color should accept both <number> and <percentage> for all
+// lab/lch/oklab/oklch components per CSS Color 4 spec.
+
+test("lab() accepts number and percentage for all components", () => {
+  // All percentages
+  expect(Bun.color("lab(50% 50% 50%)", "css")).not.toBeNull();
+  // All numbers
+  expect(Bun.color("lab(50 50 50)", "css")).not.toBeNull();
+  // Mixed: number L, percentage a/b
+  expect(Bun.color("lab(50 50% 50%)", "css")).not.toBeNull();
+  // Mixed: percentage L, number a/b (this was the only combo that worked before)
+  expect(Bun.color("lab(50% 50 50)", "css")).not.toBeNull();
+
+  // Verify number and percentage produce equivalent results.
+  // lab(50% 50 50) should equal lab(50 50 50) since L number 50 = 50%.
+  expect(Bun.color("lab(50% 50 50)", "css")).toBe(Bun.color("lab(50 50 50)", "css"));
+
+  // lab(50% 40% 40%): 40% of 125 = 50 → should equal lab(50% 50 50)
+  expect(Bun.color("lab(50% 40% 40%)", "css")).toBe(Bun.color("lab(50% 50 50)", "css"));
+});
+
+test("lch() accepts number and percentage for l and c components", () => {
+  // All numbers
+  expect(Bun.color("lch(50 50 50)", "css")).not.toBeNull();
+  // Percentage L, number c
+  expect(Bun.color("lch(50% 50 50)", "css")).not.toBeNull();
+  // Number L, percentage c
+  expect(Bun.color("lch(50 50% 50)", "css")).not.toBeNull();
+  // Percentage L, percentage c
+  expect(Bun.color("lch(50% 50% 50)", "css")).not.toBeNull();
+  // With deg suffix on hue
+  expect(Bun.color("lch(50% 50% 50deg)", "css")).not.toBeNull();
+
+  // Verify equivalence: lch(50% ...) = lch(50 ...)
+  expect(Bun.color("lch(50% 50 180)", "css")).toBe(Bun.color("lch(50 50 180)", "css"));
+});
+
+test("oklab() accepts number and percentage for all components", () => {
+  // All percentages
+  expect(Bun.color("oklab(50% 50% 50%)", "css")).not.toBeNull();
+  // All numbers
+  expect(Bun.color("oklab(0.5 0.1 0.1)", "css")).not.toBeNull();
+  // Mixed
+  expect(Bun.color("oklab(50% 0.1 0.1)", "css")).not.toBeNull();
+  expect(Bun.color("oklab(0.5 50% 50%)", "css")).not.toBeNull();
+
+  // oklab L: number 0.5 = 50%
+  expect(Bun.color("oklab(50% 0.1 0.1)", "css")).toBe(Bun.color("oklab(0.5 0.1 0.1)", "css"));
+
+  // oklab a/b: 25% of 0.4 = 0.1
+  expect(Bun.color("oklab(50% 25% 25%)", "css")).toBe(Bun.color("oklab(0.5 0.1 0.1)", "css"));
+});
+
+test("oklch() accepts number and percentage for l and c components", () => {
+  // All numbers
+  expect(Bun.color("oklch(0.5 0.1 180)", "css")).not.toBeNull();
+  // Percentage L
+  expect(Bun.color("oklch(50% 0.1 180)", "css")).not.toBeNull();
+  // Percentage c
+  expect(Bun.color("oklch(0.5 50% 180)", "css")).not.toBeNull();
+  // Both percentages
+  expect(Bun.color("oklch(50% 50% 180)", "css")).not.toBeNull();
+
+  // oklch L: number 0.5 = 50%
+  expect(Bun.color("oklch(50% 0.1 180)", "css")).toBe(Bun.color("oklch(0.5 0.1 180)", "css"));
+
+  // oklch c: 25% of 0.4 = 0.1
+  expect(Bun.color("oklch(50% 25% 180)", "css")).toBe(Bun.color("oklch(0.5 0.1 180)", "css"));
+});
+
+test("original issue: lab(50% 50% 50%) should not return null", () => {
+  const result = Bun.color("lab(50% 50% 50%)", "css");
+  expect(result).not.toBeNull();
+  expect(typeof result).toBe("string");
+});


### PR DESCRIPTION
## Problem

`Bun.color("lab(50% 50% 50%)")` returns `null` despite the [CSS Color 4 spec](https://www.w3.org/TR/css-color-4/#funcdef-lab) allowing both `<number>` and `<percentage>` for all `lab()`/`lch()`/`oklab()`/`oklch()` components.

The only combination that worked was `lab(L% a b)` — percentage for lightness, numbers for a/b.

```js
Bun.color("lab(50% 50% 50%)", "css")  // null (should work)
Bun.color("lab(50 50 50)", "css")     // null (should work)
Bun.color("lab(50% 50 50)", "css")    // worked (only valid combo before)
```

## Root Cause

In `src/css/values/color.zig`, `parseLab` used `parsePercentage()` for lightness and `parseNumber()` for a/b channels. `parseLch` did the same for lightness and chroma. These reject the other format.

CSS Color 4 says all components accept both `<number>` and `<percentage>` with defined scaling:

| Component | Number range | Percentage range | Scaling |
|-----------|-------------|-----------------|---------|
| lab L     | 0–100       | 0%–100%         | num/100 = unit |
| oklab L   | 0–1         | 0%–100%         | num/1 = unit |
| lab a,b   | -125–125    | -100%–100%      | pct×125 = num |
| oklab a,b | -0.4–0.4    | -100%–100%      | pct×0.4 = num |
| lch c     | 0–150       | 0%–100%         | pct×150 = num |
| oklch c   | 0–0.4       | 0%–100%         | pct×0.4 = num |

## Fix

Replaced `parsePercentage`/`parseNumber` calls with `parseNumberOrPercentage` and apply the correct CSS Color 4 scaling factors based on the color space type (comptime `T`).

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/16727.test.ts` → 5 fail (bug present)
- `bun bd test test/regression/issue/16727.test.ts` → 5 pass (fix works)
- Existing `test/js/bun/css/color.test.ts` → all pass (no regressions)

Fixes #16727