### PR TITLE
Dispatch worker online before waiting for top-level await

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4593,7 +4593,6 @@ impl VirtualMachine {
         Ok(promise)
     }
 
-
     /// Loads a test-file entry point and waits for the load promise to settle.
     pub fn load_entry_point_for_test_runner(
         &mut self,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4593,22 +4593,6 @@ impl VirtualMachine {
         Ok(promise)
     }
 
-    /// Loads the worker entry point and waits for it, honoring termination requests.
-    pub fn load_entry_point_for_web_worker(
-        &mut self,
-        entry_path: &[u8],
-    ) -> crate::CrateResult<*mut JSInternalPromise> {
-        let promise = self.reload_entry_point(entry_path)?;
-        self.event_loop_mut().perform_gc();
-        self.event_loop_mut()
-            .wait_for_promise_with_termination(jsc::AnyPromise::Internal(promise));
-        if let Some(worker) = self.worker_ref() {
-            if worker.has_requested_terminate() {
-                return Err(crate::CrateError::WorkerTerminated);
-            }
-        }
-        Ok(self.pending_internal_promise.unwrap())
-    }
 
     /// Loads a test-file entry point and waits for the load promise to settle.
     pub fn load_entry_point_for_test_runner(

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -726,9 +726,8 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapSnapshotBody(
     // Pending. postTaskToWorkerGlobalScope queues into m_pendingTasks for
     // Pending and returns false only for Closing/Closed, which the !accepted
     // reject below handles. If the worker never reaches Running (entry threw,
-    // failed to load, unsettled TLA), dispatchExit clears m_pendingTasks on
-    // the parent thread and rejectAllCrossVMRequests() rejects + frees the
-    // Strong<>.
+    // failed to load), dispatchExit clears m_pendingTasks on the parent
+    // thread and rejectAllCrossVMRequests() rejects + frees the Strong<>.
     auto* promise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
 
     // The promise is registered in a parent-side map keyed by reqId; only the id

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -721,8 +721,8 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapSnapshotBody(
     }
 
     // No up-front isOnline() gate: a worker can post to its parent (e.g. from
-    // a microtask the entry module scheduled, drained inside
-    // wait_for_promise_with_termination's tick()) while m_state is still
+    // a microtask the entry module scheduled, drained during the worker's
+    // pre-online startup ticks) while m_state is still
     // Pending. postTaskToWorkerGlobalScope queues into m_pendingTasks for
     // Pending and returns false only for Closing/Closed, which the !accepted
     // reject below handles. If the worker never reaches Running (entry threw,

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -719,6 +719,15 @@ extern "C" void WebWorker__fireEarlyMessages(Worker* worker, Zig::GlobalObject* 
     worker->fireEarlyMessages(globalObject);
 }
 
+// Returns true if a 'message' event listener has been registered on the
+// worker's global event scope. Used by the worker startup sequence to
+// decide whether the module body has progressed past its
+// listener-registration point before firing buffered messages.
+extern "C" bool WebWorker__hasMessageListener(Zig::GlobalObject* globalObject)
+{
+    return globalObject->globalEventScope->hasActiveEventListeners(eventNames().messageEvent);
+}
+
 extern "C" void WebWorker__dispatchError(Zig::GlobalObject* globalObject, Worker* worker, BunString* message, JSC::EncodedJSValue errorValue)
 {
     JSValue error = JSC::JSValue::decode(errorValue);

--- a/src/jsc/error.rs
+++ b/src/jsc/error.rs
@@ -42,8 +42,6 @@ pub enum Error {
     ServerEntryPointGenerate,
     #[error("UnexpectedPendingResolution")]
     UnexpectedPendingResolution,
-    #[error("WorkerTerminated")]
-    WorkerTerminated,
     #[error("JSErrorObject")]
     JSErrorObject,
     #[error("ThreadSpawnFailed")]
@@ -113,7 +111,6 @@ impl Error {
             Self::TarballFailedToExtract => "TarballFailedToExtract",
             Self::ServerEntryPointGenerate => "ServerEntryPointGenerate",
             Self::UnexpectedPendingResolution => "UnexpectedPendingResolution",
-            Self::WorkerTerminated => "WorkerTerminated",
             Self::JSErrorObject => "JSErrorObject",
             Self::ThreadSpawnFailed => "ThreadSpawnFailed",
             Self::MissingDebugInfo => "MissingDebugInfo",

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1130,37 +1130,6 @@ impl EventLoop {
         self.tick();
     }
 
-    pub fn wait_for_promise_with_termination(&mut self, promise: jsc::AnyPromise) {
-        // BACKREF — `WebWorker` is owned by C++ and outlives this VM (see
-        // [`VirtualMachine::worker_ref`]); route through the safe accessor
-        // instead of open-coding the raw `*const c_void` cast + deref.
-        let worker = self
-            .vm_ref()
-            .worker_ref()
-            .expect("worker is not initialized");
-        match promise.status() {
-            PromiseStatus::Pending => {
-                while !worker.has_requested_terminate()
-                    && promise.status() == PromiseStatus::Pending
-                {
-                    self.tick();
-                    if !worker.has_requested_terminate()
-                        && promise.status() == PromiseStatus::Pending
-                    {
-                        // Unsettled top-level await: the loop has drained but the
-                        // entry module's evaluation promise is still pending. Stop
-                        // waiting so the worker can exit (node uses exit code 13).
-                        if !self.vm_ref().is_event_loop_alive() {
-                            break;
-                        }
-                        self.auto_tick();
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-
     pub fn enqueue_task_concurrent_batch(
         &self,
         batch: bun_threading::unbounded_queue::Batch<ConcurrentTaskItem>,

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -216,6 +216,7 @@ unsafe extern "C" {
     safe fn WebWorker__dispatchOnline(cpp_worker: *mut c_void, global: &JSGlobalObject);
     safe fn WebWorker__fireEarlyMessages(cpp_worker: *mut c_void, global: &JSGlobalObject);
     safe fn WebWorker__entrySettled(global: &JSGlobalObject);
+    safe fn WebWorker__hasMessageListener(global: &JSGlobalObject) -> bool;
     safe fn WebWorker__dispatchError(
         global: &JSGlobalObject,
         cpp_worker: *mut c_void,
@@ -1086,11 +1087,14 @@ impl WebWorker {
             return self.shutdown();
         }
 
+        // Start loading the entry point module. This kicks off module
+        // resolution and evaluation but does not wait for top-level await.
+        //
         // `path` borrows the resolver's process-lifetime string store, the
         // standalone module graph, or `self.unresolved_specifier` — all of
         // which outlive the worker VM. `vm.main` stores it as a raw BACKREF
         // (see `VirtualMachine::set_main`); no lifetime extension needed.
-        let promise = match vm.as_mut().load_entry_point_for_web_worker(path) {
+        let initial_promise = match vm.as_mut().reload_entry_point(path) {
             Ok(p) => p,
             Err(_) => {
                 // process.exit() may have run during load; don't clobber its code.
@@ -1102,16 +1106,168 @@ impl WebWorker {
                 return self.shutdown();
             }
         };
+        vm.event_loop_mut().perform_gc();
 
-        // Fire (and clear) the entryEvaluated hook on EVERY post-evaluation path
-        // so buffered postMessageToThread deliveries drain and the sender's
-        // Atomics.waitAsync settles. dispatchOnline re-calls it as a no-op.
-        WebWorker__entrySettled(vm.global());
+        // Spin the event loop until the module has progressed far enough to
+        // register a 'message' listener, the module promise settles (normal
+        // completion or synchronous module with no TLA), or termination is
+        // requested. Without this, a worker whose entry point imports a
+        // userland module would dispatch 'online' and fire buffered messages
+        // before the module body has had a chance to run its listener
+        // registration — messages would be dropped into an empty event scope.
+        //
+        // Once a listener exists (or the module finishes), the buffered
+        // inbox drain will reach live handlers. If the loop drains while
+        // the TLA is still pending and no listener exists, fall through —
+        // the post-online wait below exits the worker with code 13.
+        //
+        // Drain microtasks once unconditionally first: hasMessageListener
+        // is satisfied by ANY listener on the global event scope, and
+        // load_preloads inside reload_entry_point already ran any preload
+        // bodies to completion. A preload that registers a 'message'
+        // listener would otherwise short-circuit the loop before the main
+        // module body runs, and buffered messages would dispatch to the
+        // preload's listener instead of the main module's.
+        vm.as_mut().event_loop_mut().tick();
+        // SAFETY: `initial_promise` is a live JSC heap cell stored on the VM.
+        while !self.has_requested_terminate()
+            && unsafe { (*initial_promise).status() } == jsc::js_promise::Status::Pending
+            && !WebWorker__hasMessageListener(vm.global())
+        {
+            vm.as_mut().event_loop_mut().tick();
+            if self.has_requested_terminate()
+                || unsafe { (*initial_promise).status() } != jsc::js_promise::Status::Pending
+                || WebWorker__hasMessageListener(vm.global())
+                || !vm.is_event_loop_alive()
+            {
+                break;
+            }
+            vm.as_mut().event_loop_mut().auto_tick();
+        }
 
-        // SAFETY: `promise` is a live JSC heap cell.
+        if self.has_requested_terminate() {
+            // Terminate arrived after the module started running — exit
+            // code 1 because evaluation was forcibly interrupted (matches
+            // Node.js worker.terminate() semantics, and makes CloseEvent
+            // report wasClean:false on the parent). Don't clobber a
+            // user-chosen exit code from process.exit(N) inside the module
+            // body.
+            if !self.exit_called.load(Ordering::Relaxed) {
+                vm.as_mut().exit_handler.exit_code = 1;
+            }
+            self.flush_logs(vm);
+            WebWorker__entrySettled(vm.global());
+            return self.shutdown();
+        }
+
+        // If the module already rejected synchronously, handle the rejection
+        // before dispatchOnline. Unhandled rejection terminates the worker
+        // (via uncaught_exception → shutdown(), noreturn). A handled
+        // rejection falls through to dispatchOnline — matching Node.js
+        // semantics where process.on('uncaughtException') can keep the
+        // worker alive. This mirrors the post-TLA rejection path below, so
+        // a worker whose module throws behaves the same way whether the
+        // throw is synchronous or after an await.
+        //
+        // Track whether we already dispatched a rejection so the post-TLA
+        // check below doesn't double-fire. Re-reading the promise status
+        // isn't sufficient — `fireEarlyMessages` can synchronously run JS
+        // (drainInbox) which may resolve an awaited promise, run the TLA
+        // continuation, and transition `initial_promise` `Pending → Rejected`
+        // in between. Using a flag ensures: the sync-rejection dispatched
+        // here isn't re-dispatched later, and a rejection that happens during
+        // or after `fireEarlyMessages` still gets reported.
+        let mut rejection_dispatched = false;
+        // SAFETY: `initial_promise` is a live JSC heap cell.
+        if unsafe { (*initial_promise).status() } == jsc::js_promise::Status::Rejected {
+            rejection_dispatched = true;
+            let handled = unsafe {
+                vm.as_mut().uncaught_exception(
+                    vm.global(),
+                    (*initial_promise).result(vm.jsc_vm()),
+                    true,
+                )
+            };
+            if !handled {
+                // exit_code is already 1 from uncaught_exception; re-setting it
+                // here would clobber a process.on('exit') change to
+                // process.exitCode.
+                self.flush_logs(vm);
+                WebWorker__entrySettled(vm.global());
+                return self.shutdown();
+            }
+        }
+
+        self.flush_logs(vm);
+        log!("[{}] event loop start", self.execution_context_id);
+        // Dispatch 'online' and fire buffered messages BEFORE (potentially
+        // still) waiting for top-level await. The event loop spins during
+        // the TLA wait below, so messages posted to the worker are
+        // processed even while TLA is pending. This matches Node.js
+        // and browser semantics (issue #21101).
+        WebWorker__dispatchOnline(self.cpp_worker, vm.global());
+        WebWorker__fireEarlyMessages(self.cpp_worker, vm.global());
+        self.set_status(Status::Running);
+
+        // Wait for the module's top-level await to settle (or termination).
+        // No-op on an already-settled promise, so this is safe to run
+        // unconditionally; the rejection_dispatched flag prevents the
+        // post-TLA check from firing twice on sync-rejection.
+        //
+        // Tick/auto_tick until settled or terminated, except for the
+        // drained-loop case: the worker is online here, so a registered
+        // 'message' listener is a live wake source (the parent can post at
+        // any time — incoming messages enqueue a drain task that wakes the
+        // loop). Park on it instead of breaking, matching Node where
+        // parentPort.on('message') keeps a TLA worker alive. With no
+        // listener and a dead loop, the await can never settle — break so
+        // the worker exits with code 13 below (Node semantics).
+        //
+        // SAFETY: `initial_promise` is a live JSC heap cell stored on the VM.
+        while !self.has_requested_terminate()
+            && unsafe { (*initial_promise).status() } == jsc::js_promise::Status::Pending
+        {
+            vm.as_mut().event_loop_mut().tick();
+            if self.has_requested_terminate()
+                || unsafe { (*initial_promise).status() } != jsc::js_promise::Status::Pending
+            {
+                break;
+            }
+            if !vm.is_event_loop_alive() {
+                if WebWorker__hasMessageListener(vm.global()) {
+                    vm.event_loop_mut().tick_possibly_forever();
+                    continue;
+                }
+                break;
+            }
+            vm.as_mut().event_loop_mut().auto_tick();
+        }
+
+        if self.has_requested_terminate() {
+            // Terminate arrived while TLA was pending — exit code 1, same
+            // reasoning as the pre-online check above.
+            if !self.exit_called.load(Ordering::Relaxed) {
+                vm.as_mut().exit_handler.exit_code = 1;
+            }
+            // Drain any CppTask fireEarlyMessages posted (else-branch of
+            // the no-listener case) before shutdown() runs — otherwise
+            // the heap-allocated EventLoopTask and the Ref<Worker> it
+            // captures would leak, since shutdown() is noreturn and
+            // EventLoop.deinit frees only the fifo buffer.
+            vm.as_mut().tick();
+            self.flush_logs(vm);
+            return self.shutdown();
+        }
+
+        let promise = vm.pending_internal_promise.unwrap();
+
+        // Handle rejection from TLA (or from JS run during
+        // fireEarlyMessages) — but only if we didn't already dispatch it
+        // above.
+        // SAFETY: `promise` is a live JSC heap cell on the VM.
         unsafe {
             let status = (*promise).status();
-            if status == jsc::js_promise::Status::Rejected {
+            if status == jsc::js_promise::Status::Rejected && !rejection_dispatched {
                 let handled = vm.as_mut().uncaught_exception(
                     vm.global(),
                     (*promise).result(vm.jsc_vm()),
@@ -1120,34 +1276,25 @@ impl WebWorker {
                 if !handled {
                     // exit_code is already 1 from uncaught_exception; re-setting it here
                     // would clobber a process.on('exit') change to process.exitCode.
+                    self.flush_logs(vm);
                     return self.shutdown();
                 }
             } else if status == jsc::js_promise::Status::Pending {
                 // Unsettled top-level await (loop drained, entry promise still
-                // pending): node exits the worker with code 13, but only if the
-                // user hasn't set a nonzero process.exitCode.
+                // pending, no message listener to wake us): node exits the
+                // worker with code 13, but only if the user hasn't set a
+                // nonzero process.exitCode.
                 if vm.exit_handler.exit_code == 0 {
                     vm.as_mut().exit_handler.exit_code = 13;
                 }
                 self.flush_logs(vm);
                 return self.shutdown();
-            } else {
+            } else if status == jsc::js_promise::Status::Fulfilled {
                 let _ = (*promise).result(vm.jsc_vm());
             }
         }
 
         self.flush_logs(vm);
-        log!("[{}] event loop start", self.execution_context_id);
-        // dispatchOnline fires the parent-side 'open' event and flips the C++
-        // state to Running (which routes postMessage directly instead of
-        // queuing). It is placed after the entry point has loaded so the parent
-        // observes 'online' only once the worker's top-level code has completed;
-        // moving it earlier would change that observable ordering.
-        // `cpp_worker` is the opaque C++-owned handle round-tripped via `safe fn`;
-        // `vm.global()` yields the live `&JSGlobalObject` published in start_vm.
-        WebWorker__dispatchOnline(self.cpp_worker, vm.global());
-        WebWorker__fireEarlyMessages(self.cpp_worker, vm.global());
-        self.set_status(Status::Running);
 
         // don't run the GC if we don't actually need to
         if vm.is_event_loop_alive() || vm.event_loop_mut().tick_concurrent_with_count() > 0 {
@@ -1157,8 +1304,10 @@ impl WebWorker {
             let _ = vm.global().vm().run_gc(false);
         }
 
-        // Always do a first tick so we call CppTask without delay after
-        // dispatchOnline.
+        // Tick once so the drain CppTask that fireEarlyMessages may have
+        // posted (synchronous module with no message listener) runs even
+        // when the TLA wait above was a no-op because the module promise
+        // was already settled.
         vm.as_mut().tick();
 
         while vm.is_event_loop_alive() {

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -176,11 +176,14 @@ pub struct WebWorker {
     /// first, then map — `Loader<'static>` borrows `*map`).
     worker_env_map: Cell<*mut bun_dotenv::Map>,
     worker_env_loader: Cell<*mut bun_dotenv::Loader<'static>>,
-    /// Set by `exit()` so that `spin()`'s error paths don't clobber an explicit
-    /// `process.exit(code)`. Atomic so `exit()` can take `&self` (the struct is
+    /// The exit code is already settled — `exit()` saw an explicit
+    /// `process.exit(code)`, or `on_unhandled_rejection` ran the process
+    /// 'exit' handlers (which may amend `process.exitCode`) — so `spin()`'s
+    /// terminate checkpoints must not overwrite it with the default
+    /// terminate code 1. Atomic so setters can take `&self` (the struct is
     /// observed concurrently by `terminate_all_and_wait` / parent-thread FFI;
     /// producing `&mut WebWorker` while another thread holds `&WebWorker` is UB).
-    exit_called: AtomicBool,
+    exit_code_decided: AtomicBool,
 }
 
 #[repr(u8)]
@@ -566,7 +569,7 @@ impl WebWorker {
             arena: JsCell::new(None),
             worker_env_map: Cell::new(core::ptr::null_mut()),
             worker_env_loader: Cell::new(core::ptr::null_mut()),
-            exit_called: AtomicBool::new(false),
+            exit_code_decided: AtomicBool::new(false),
         }));
         // `worker` is non-null (just heap-allocated). Wrap once for the safe
         // shared reborrows below; the raw `worker` is still used for
@@ -1098,7 +1101,7 @@ impl WebWorker {
             Ok(p) => p,
             Err(_) => {
                 // process.exit() may have run during load; don't clobber its code.
-                if !self.exit_called.load(Ordering::Relaxed) {
+                if !self.exit_code_decided.load(Ordering::Relaxed) {
                     vm.as_mut().exit_handler.exit_code = 1;
                 }
                 self.flush_logs(vm);
@@ -1149,10 +1152,10 @@ impl WebWorker {
             // Terminate arrived after the module started running — exit
             // code 1 because evaluation was forcibly interrupted (matches
             // Node.js worker.terminate() semantics, and makes CloseEvent
-            // report wasClean:false on the parent). Don't clobber a
-            // user-chosen exit code from process.exit(N) inside the module
-            // body.
-            if !self.exit_called.load(Ordering::Relaxed) {
+            // report wasClean:false on the parent). Skip when the code is
+            // already settled (process.exit(N), or an unhandled error whose
+            // 'exit' handlers may have amended process.exitCode).
+            if !self.exit_code_decided.load(Ordering::Relaxed) {
                 vm.as_mut().exit_handler.exit_code = 1;
             }
             self.flush_logs(vm);
@@ -1214,14 +1217,13 @@ impl WebWorker {
         // unconditionally; the rejection_dispatched flag prevents the
         // post-TLA check from firing twice on sync-rejection.
         //
-        // Tick/auto_tick until settled or terminated, except for the
-        // drained-loop case: the worker is online here, so a registered
-        // 'message' listener is a live wake source (the parent can post at
-        // any time — incoming messages enqueue a drain task that wakes the
-        // loop). Park on it instead of breaking, matching Node where
-        // parentPort.on('message') keeps a TLA worker alive. With no
-        // listener and a dead loop, the await can never settle — break so
-        // the worker exits with code 13 below (Node semantics).
+        // Tick/auto_tick until settled or terminated. A registered 'message'
+        // listener refs the event loop (WorkerGlobalScope::
+        // onDidChangeListenerImpl), keeping it alive so auto_tick() parks and
+        // a message posted by the parent wakes the loop — matching Node where
+        // parentPort.on('message') keeps a TLA worker alive. With no listener
+        // the loop drains and the await can never settle — break so the
+        // worker exits with code 13 below (Node semantics).
         //
         // SAFETY: `initial_promise` is a live JSC heap cell stored on the VM.
         while !self.has_requested_terminate()
@@ -1234,10 +1236,6 @@ impl WebWorker {
                 break;
             }
             if !vm.is_event_loop_alive() {
-                if WebWorker__hasMessageListener(vm.global()) {
-                    vm.event_loop_mut().tick_possibly_forever();
-                    continue;
-                }
                 break;
             }
             vm.as_mut().event_loop_mut().auto_tick();
@@ -1246,7 +1244,7 @@ impl WebWorker {
         if self.has_requested_terminate() {
             // Terminate arrived while TLA was pending — exit code 1, same
             // reasoning as the pre-online check above.
-            if !self.exit_called.load(Ordering::Relaxed) {
+            if !self.exit_code_decided.load(Ordering::Relaxed) {
                 vm.as_mut().exit_handler.exit_code = 1;
             }
             // Drain any CppTask fireEarlyMessages posted (else-branch of
@@ -1538,7 +1536,7 @@ impl WebWorker {
     /// `notify_need_termination` may concurrently hold `&WebWorker` on another
     /// thread; producing `&mut` here would be aliased-&mut UB.
     pub fn exit(&self) {
-        self.exit_called.store(true, Ordering::Relaxed);
+        self.exit_code_decided.store(true, Ordering::Relaxed);
         let _ = self.set_requested_terminate();
         // Stop subsequent JS at the next safepoint. `this.vm` is null during
         // `vm.onExit()` (shutdown nulls it first), so a re-entrant
@@ -1689,6 +1687,9 @@ fn on_unhandled_rejection(
     // termination exception makes dispatchExitInternal skip 'exit' (as terminate() should),
     // and its processIsExiting guard stops shutdown() from running them twice.
     virtual_machine::ExitHandler::dispatch_on_exit(vm);
+    // The 'exit' handlers just observed (and may have amended) the final
+    // exit code; spin()'s terminate checkpoints must not overwrite it.
+    worker.exit_code_decided.store(true, Ordering::Relaxed);
     let _ = worker.set_requested_terminate();
     // Do NOT call `worker.shutdown()` here —
     // `shutdown()` RETURNS, so calling it here would destroy

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,4 +1,5 @@
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -21,6 +22,12 @@ import wt, {
   Worker,
   workerData,
 } from "worker_threads";
+
+// Worker spawn/teardown is 10-100x slower in debug/ASAN builds; the
+// multi-worker tests here overrun the 5s default.
+if (isDebug) {
+  setDefaultTimeout(90_000);
+}
 
 test("support eval in worker", async () => {
   const worker = new Worker(`postMessage(1 + 1)`, {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -577,14 +577,13 @@ describe("getHeapSnapshot", () => {
   // uncaught_exception return handled=true so spin() continues to
   // fireEarlyMessages (the call resolves with real data). Under `bun -e`
   // it rejects — see the test-worker-heapdump-failure.js vendored test for
-  // subprocess coverage. The two cases below take the shutdown() path
-  // directly so they exercise the m_pendingTasks abandon drain regardless.
-  test.each([
-    ["entry not found", undefined],
-    ["unsettled top-level await", "await new Promise(() => {})"],
-  ])("rejects ERR_WORKER_NOT_RUNNING when called before a worker that fails to start (%s)", async (_, src) => {
-    const worker =
-      src === undefined ? new Worker("/nonexistent/__bun_worker_path__.js") : new Worker(src, { eval: true });
+  // subprocess coverage. "Unsettled top-level await" is also omitted: the
+  // worker goes online before TLA settles (queued calls are delivered by
+  // fireEarlyMessages and resolve) — covered by the next test. The
+  // entry-not-found case takes the shutdown() path directly so it
+  // exercises the m_pendingTasks abandon drain.
+  test("rejects ERR_WORKER_NOT_RUNNING when called before a worker that fails to start (entry not found)", async () => {
+    const worker = new Worker("/nonexistent/__bun_worker_path__.js");
     worker.on("error", () => {});
     // Called immediately (m_state still Pending) so the task queues into
     // m_pendingTasks; dispatchExit drains it on the parent thread when the
@@ -613,6 +612,22 @@ describe("getHeapSnapshot", () => {
     for (const p of captured) {
       expect(await p).toMatchObject({ code: "ERR_WORKER_NOT_RUNNING" });
     }
+  });
+
+  test("resolves when called before a worker whose top-level await never settles", async () => {
+    // The worker goes online once its entry body has had a chance to run,
+    // even while TLA is still pending, so calls queued while m_state was
+    // Pending are delivered by fireEarlyMessages and resolve; with no
+    // listener or live handles the worker then exits with code 13.
+    const worker = new Worker("await new Promise(() => {})", { eval: true });
+    worker.on("error", () => {});
+    const snapshot = worker.getHeapSnapshot().then(
+      v => ({ resolved: !!v }),
+      e => e,
+    );
+    const exitCode = new Promise(resolve => worker.on("exit", resolve));
+    expect(await snapshot).toEqual({ resolved: true });
+    expect(await exitCode).toBe(13);
   });
 
   test("queues while the worker is starting and rejects once it has exited", async () => {

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -459,3 +459,8 @@ test/js/node/tls/node-tls-connect.test.ts
 # ("TODO: think about the finalizer here"), so the meta is never freed. All 18
 # tests pass; only the exit check fails. Remove once that TODO is resolved.
 test/bundler/native-plugin.test.ts
+
+# Worker with preload exposes pre-existing async-transpile leak
+# (RuntimeTranspilerStore::TranspilerJob::run → sourcemap::Builder::finalize).
+# The existing transpiler suppressions only cover the sync path.
+test/regression/issue/21101.test.ts

--- a/test/regression/issue/21101.test.ts
+++ b/test/regression/issue/21101.test.ts
@@ -1,0 +1,266 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("worker receives messages during top-level await", async () => {
+  using dir = tempDir("issue-21101", {
+    "main.js": `
+      import { Worker } from "node:worker_threads";
+
+      const worker = new Worker(new URL("./worker.js", import.meta.url), {
+        type: "module",
+      });
+
+      let watchdog;
+      worker.on("message", (msg) => {
+        console.log(msg);
+        if (msg === "done") {
+          clearInterval(interval);
+          clearTimeout(watchdog);
+          // Drop the parent-side ref so the parent's event loop drains
+          // and the process exits. terminateAllAndWait() then forcibly
+          // tears down the worker (parked in its never-resolving TLA)
+          // during parent process shutdown. Using terminate()+process.exit()
+          // here races the worker's dispatchExit and exposes a separate
+          // pre-existing teardown crash.
+          worker.unref();
+        }
+      });
+
+      let count = 0;
+      const interval = setInterval(() => {
+        worker.postMessage("ping");
+        count++;
+        if (count >= 5) {
+          clearInterval(interval);
+          // If we sent 5 messages and never got "done", the bug is present.
+          watchdog = setTimeout(() => process.exit(1), 2000);
+        }
+      }, 500);
+    `,
+    "worker.js": `
+      import { parentPort } from "node:worker_threads";
+
+      let received = 0;
+      parentPort.on("message", (msg) => {
+        received++;
+        if (received === 3) {
+          parentPort.postMessage("done");
+        }
+      });
+
+      // Top-level await that never resolves — messages should still
+      // be delivered while this is pending.
+      await new Promise(() => {});
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The worker received at least 3 messages during TLA and sent "done"
+  expect(stdout.trim()).toBe("done");
+  expect(exitCode).toBe(0);
+}, 15000);
+
+test("worker receives messages during finite top-level await", async () => {
+  using dir = tempDir("issue-21101-finite", {
+    "main.js": `
+      import { Worker } from "node:worker_threads";
+
+      const worker = new Worker(new URL("./worker.js", import.meta.url), {
+        type: "module",
+      });
+
+      let count = 0;
+      const interval = setInterval(() => {
+        worker.postMessage("hello");
+        count++;
+        if (count >= 10) clearInterval(interval);
+      }, 100);
+
+      worker.on("message", (msg) => {
+        if (typeof msg === "string" && msg.startsWith("count:")) {
+          console.log(msg);
+          clearInterval(interval);
+          // Drop the parent-side ref: see "during top-level await" test
+          // for rationale. Parent drains, process exits, worker is
+          // torn down via terminateAllAndWait().
+          worker.unref();
+        }
+      });
+    `,
+    "worker.js": `
+      import { parentPort } from "node:worker_threads";
+
+      const received = [];
+      parentPort.on("message", (msg) => {
+        received.push(msg);
+      });
+
+      // TLA that resolves after 2s — messages sent during
+      // the await should be delivered in real time, not queued.
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      parentPort.postMessage("count:" + received.length);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The worker should have received messages DURING the await
+  const countLine = stdout
+    .trim()
+    .split("\n")
+    .find((l: string) => l.startsWith("count:"));
+  expect(countLine).toBeDefined();
+  const count = parseInt(countLine!.split(":")[1]);
+  expect(count).toBeGreaterThanOrEqual(1);
+  expect(exitCode).toBe(0);
+}, 15000);
+
+test("worker receives messages posted synchronously before startup", async () => {
+  // Regression guard: when the main thread posts messages synchronously
+  // right after `new Worker(...)`, they are buffered in the inbox before
+  // the worker's VM starts. The worker must drain the module body to
+  // register its listener before firing the buffered messages, otherwise
+  // they are dispatched with no listener and silently dropped.
+  using dir = tempDir("issue-21101-sync", {
+    "main.js": `
+      import { Worker } from "node:worker_threads";
+
+      const worker = new Worker(new URL("./worker.js", import.meta.url), {
+        type: "module",
+      });
+
+      // Post BEFORE worker is online — these go into the pre-online inbox.
+      worker.postMessage("m1");
+      worker.postMessage("m2");
+      worker.postMessage("m3");
+
+      let timer = setTimeout(() => {
+        console.error("timeout — buffered messages were dropped");
+        process.exit(1);
+      }, 3000);
+
+      worker.on("message", (msg) => {
+        if (msg === "done") {
+          clearTimeout(timer);
+          // Drop the parent-side ref: see "during top-level await" test
+          // for rationale (pre-existing teardown crash with terminate()).
+          worker.unref();
+        }
+      });
+    `,
+    "worker.js": `
+      import { parentPort } from "node:worker_threads";
+
+      const received = [];
+      parentPort.on("message", (msg) => {
+        received.push(msg);
+        if (received.length === 3) {
+          parentPort.postMessage("done");
+        }
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("timeout");
+  expect(exitCode).toBe(0);
+}, 15000);
+
+test("worker with preload that registers message listener still delivers to main module", async () => {
+  // Regression guard for the pre-online loop: hasMessageListener is
+  // satisfied by ANY listener on globalEventScope, including one
+  // registered by a preload module that runs synchronously inside
+  // reloadEntryPoint. If the loop short-circuits on the preload's
+  // listener before the main module body runs, fireEarlyMessages
+  // would dispatch buffered messages to the preload's listener only
+  // and the main module's parentPort.on('message', ...) would never
+  // see them.
+  using dir = tempDir("issue-21101-preload", {
+    "main.js": `
+      import { Worker } from "node:worker_threads";
+      import { fileURLToPath } from "node:url";
+
+      const worker = new Worker(new URL("./worker.js", import.meta.url), {
+        type: "module",
+        preload: [fileURLToPath(new URL("./preload.js", import.meta.url))],
+      });
+
+      // Post BEFORE worker is online so the message is buffered and
+      // drained by fireEarlyMessages on the worker thread.
+      worker.postMessage("hello");
+
+      let watchdog = setTimeout(() => {
+        console.error("timeout");
+        process.exit(1);
+      }, 5000);
+
+      worker.on("message", (msg) => {
+        if (msg === "main-got") {
+          clearTimeout(watchdog);
+          worker.unref();
+        }
+      });
+    `,
+    "preload.js": `
+      // Preload registers a 'message' listener on globalEventScope. Both
+      // preload and main-module listeners share that scope, so on the
+      // passing path both fire for every delivered message. We detect a
+      // regression of the pre-online race not by exclusivity but by the
+      // presence of 'main-got' in the parent's messages — which only
+      // arrives if the main-module listener was registered before
+      // fireEarlyMessages drained the buffered inbox.
+      self.addEventListener("message", () => {
+        self.postMessage("preload-got");
+      });
+    `,
+    "worker.js": `
+      import { parentPort } from "node:worker_threads";
+
+      parentPort.on("message", (msg) => {
+        if (msg === "hello") {
+          parentPort.postMessage("main-got");
+        }
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("timeout");
+  expect(exitCode).toBe(0);
+}, 15000);


### PR DESCRIPTION
## What does this PR do?

Workers with top-level await (TLA) never receive messages while the await is pending. In Node.js and browsers, messages are delivered in real time even during TLA.

```js
// worker.js
import { parentPort } from "node:worker_threads";
parentPort.on("message", (msg) => console.log(msg));
await new Promise(() => {}); // messages never delivered in Bun
```

## Root cause

In `src/jsc/web_worker.rs`, the worker's `spin()` called `dispatchOnline` and `fireEarlyMessages` only after the module's top-level await settled. Since `dispatchOnline` flips the C++ state that controls whether messages are dispatched or buffered, messages were stuck in `m_pendingTasks` for the entire duration of TLA. There was even a TODO comment acknowledging this (`// TODO(@190n) call dispatchOnline earlier`).

## Fix

- `spin()` first ticks the event loop until the module has registered a 'message' listener or its promise settles (so buffered messages are not dropped into an empty event scope, and a preload's listener cannot steal them), then dispatches `online`, fires buffered messages, and only then waits for the TLA to settle. The wait spins the event loop, so messages arrive during TLA. A new `WebWorker__hasMessageListener` C++ hook backs the listener check.
- Workers whose TLA never settles still exit with code 13 once the loop drains (a registered 'message' listener refs the loop via `WorkerGlobalScope::onDidChangeListenerImpl`, keeping such workers alive).
- The worker's unhandled-error path runs the process 'exit' handlers itself, which may amend `process.exitCode`; `spin()`'s terminate checkpoints no longer overwrite that with the default terminate code 1 (`exit_called` renamed to `exit_code_decided`, also set by `on_unhandled_rejection`). This keeps `test-worker-exit-code.js` green.

Deleted as a result: `VirtualMachine::load_entry_point_for_web_worker` (inlined into `spin()`), `EventLoop::wait_for_promise_with_termination` (lost its last caller), and `CrateError::WorkerTerminated` (lost its only producer).

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/21101.test.ts` fails (bug present)
- `bun bd test test/regression/issue/21101.test.ts` passes (4 tests)
- `test/js/node/worker_threads/` (89 tests), `worker-top-level-await.test.ts` (6 exit-13 tests), `test/js/web/workers/` (370 tests), and the worker exit/terminate tests in `test/js/node/test/parallel/` (including `test-worker-exit-code.js`) all pass with the fix.

Fixes #21101

[skip size check]

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 102 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts "test/regression/issue/21101.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3be1ecb4f)

test/regression/issue/21101.test.ts:
63 |   });
64 | 
65 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
66 | 
67 |   // The worker received at least 3 messages during TLA and sent "done"
68 |   expect(stdout.trim()).toBe("done");
                             ^
error: expect(received).toBe(expected)

Expected: "done"
Received: ""

      at <anonymous> (/workspace/bun/test/regression/issue/21101.test.ts:68:25)
(fail) worker receives messages during top-level await [5675.47ms]
127 |     .trim()
128 |     .split("\n")
129 |     .find((l: string) => l.startsWith("count:"));
130 |   expect(countLine).toBeDef
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (f59da15b3)

test/regression/issue/21101.test.ts:
(pass) worker receives messages during top-level await [1526.85ms]
(pass) worker receives messages during finite top-level await [2047.40ms]
(pass) worker receives messages posted synchronously before startup [47.24ms]
(pass) worker with preload that registers message listener still delivers to main module [47.41ms]

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [31.71ms]
(pass) all worker_threads module properties are present [0.54ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [0.47ms]
(pass) all worker_threads worker instance properties are present [3.15ms]
(pass) threadId module and worker property is consistent [4.36ms]
(pass) receiveMessageOnPort works across threads [27.26ms]
(pass) receiveMessageOnPort works as FIFO [0.27ms]
(pass) you can override globalThis.postMessage [27.76ms]
(pass) support require in eval [27.81ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [28.28ms]
(pass) support require in eval for a file that doesnt 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts "test/regression/issue/21101.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3be1ecb4f)

test/regression/issue/21101.test.ts:
(pass) worker receives messages during top-level await [2676.66ms]
(pass) worker receives messages during finite top-level await [4434.74ms]
(pass) worker receives messages posted synchronously before startup [2458.54ms]
(pass) worker with preload that registers message listener still delivers to main module [2475.83ms]

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1736.93ms]
(pass) all worker_threads module properties are present [27.10ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [24.75ms]
(pass) all worker_threads worker instance prope
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 707ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/12] cc obj/packages/bun-usockets/src/bsd.c.o
[2/12] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[3/12] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-1.cpp.o
[4/12] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-0.cpp.o
[5/12] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[6/12] gen cpp.rs (cppbind)
[6/12] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs                          |  17 --
 src/jsc/bindings/webcore/JSWorker.cpp              |   9 +-
 src/jsc/bindings/webcore/Worker.cpp                |   9 +
 src/jsc/error.rs                                   |   3 -
 src/jsc/event_loop.rs                              |  31 ---
 src/jsc/web_worker.rs                              | 208 +++++++++++++---
 test/js/node/worker_threads/worker_threads.test.ts |  40 +++-
 test/no-validate-leaksan.txt                       |   5 +
 test/regression/issue/21101.test.ts                | 266 +++++++++++++++++++++
 9 files changed, 494 insertions(+), 94 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 102

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/VirtualMachine.rs                               6      3    157
src/jsc/bindings/webcore/JSWorker.cpp                   2      3    156
src/jsc/bindings/webcore/Worker.cpp                     3      3    156
src/jsc/error.rs                                        2      2    156
src/jsc/event_loop.rs                                   2      1    156
src/jsc/web_worker.rs                                  20     20    157
test/js/node/worker_threads/worker_threads.test.ts      3      6      4
test/no-validate-leaksan.txt                            2      3    158
test/regression/issue/21101.test.ts                    26     34    152
```

</details>

<!-- robobun:evidence:end -->