### PR TITLE
Fix crash in Blob.getWriter when options parsing returns an error

### DIFF
--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -2975,7 +2975,16 @@ pub fn getWriter(
 
     if (arguments.len > 0 and arguments.ptr[0].isObject()) {
         stream_start = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
-        stream_start.FileSink.input_path = input_path;
+        switch (stream_start) {
+            .FileSink => |*file_sink| {
+                file_sink.input_path = input_path;
+            },
+            .err => |err| {
+                sink.deref();
+                return globalThis.throwValue(try err.toJS(globalThis));
+            },
+            else => {},
+        }
     }
 
     switch (sink.start(stream_start)) {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -207,6 +207,14 @@ it("write result is not cumulative", async () => {
   await util.promisify(fs.close)(fd);
 });
 
+if (!isWindows) {
+  it("writer() with invalid fd option throws instead of crashing", () => {
+    const file = Bun.file("/dev/null");
+    expect(() => file.writer({ fd: "not_a_number" })).toThrow();
+    expect(() => file.writer({ fd: -1 })).toThrow();
+  });
+}
+
 if (isWindows) {
   it("ENOENT, Windows", () => {
     expect(() => Bun.file("A:\\this-does-not-exist.txt").writer()).toThrow(


### PR DESCRIPTION
In `Blob.getWriter`, after calling `fromJSWithTag` to parse writer options, the code unconditionally accessed `stream_start.FileSink` to set `input_path`. When `fromJSWithTag` returned `.err` (e.g. passing `{ fd: "not_a_number" }`), accessing the `.FileSink` field of the tagged union panicked with: `access of union field 'FileSink' while field 'err' is active`.

The fix checks the active union variant before accessing `.FileSink`, and properly throws the error to JS when `.err` is active.

**Repro:**
```js
const f = Bun.file("/dev/null");
f.writer({ fd: "not_a_number" }); // panics instead of throwing
```