### PR TITLE
Fix use-after-free in TLS listener .fd getter

### DIFF
--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -527,11 +527,9 @@ pub fn getPort(this: *Listener, _: *jsc.JSGlobalObject) JSValue {
 pub fn getFD(this: *Listener, _: *jsc.JSGlobalObject) JSValue {
     switch (this.listener) {
         .uws => |uws_listener| {
-            switch (this.ssl) {
-                inline else => |ssl| {
-                    return uws_listener.socket(ssl).fd().toJSWithoutMakingLibUVOwned();
-                },
-            }
+            // Listen sockets don't have SSL connections, so always use
+            // the non-SSL path to get the raw fd.
+            return uws_listener.socket(false).fd().toJSWithoutMakingLibUVOwned();
         },
         else => return JSValue.jsNumber(-1),
     }

--- a/test/js/bun/tls-listener-fd.test.ts
+++ b/test/js/bun/tls-listener-fd.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+
+test("TLS listener .fd does not crash", () => {
+  const listener = Bun.listen({
+    hostname: "localhost",
+    port: 0,
+    socket: { data: () => {} },
+    tls: { passphrase: "test" },
+  });
+  try {
+    expect(typeof listener.fd).toBe("number");
+    expect(listener.fd).toBeGreaterThan(0);
+  } finally {
+    listener.stop(true);
+  }
+});

--- a/test/js/bun/tls-listener-fd.test.ts
+++ b/test/js/bun/tls-listener-fd.test.ts
@@ -1,16 +1,12 @@
 import { expect, test } from "bun:test";
 
 test("TLS listener .fd does not crash", () => {
-  const listener = Bun.listen({
+  using listener = Bun.listen({
     hostname: "localhost",
     port: 0,
     socket: { data: () => {} },
     tls: { passphrase: "test" },
   });
-  try {
-    expect(typeof listener.fd).toBe("number");
-    expect(listener.fd).toBeGreaterThan(0);
-  } finally {
-    listener.stop(true);
-  }
+  expect(typeof listener.fd).toBe("number");
+  expect(listener.fd).toBeGreaterThan(0);
 });

--- a/test/js/bun/tls-listener-fd.test.ts
+++ b/test/js/bun/tls-listener-fd.test.ts
@@ -1,11 +1,12 @@
 import { expect, test } from "bun:test";
+import { tls } from "harness";
 
 test("TLS listener .fd does not crash", () => {
   using listener = Bun.listen({
     hostname: "localhost",
     port: 0,
     socket: { data: () => {} },
-    tls: { passphrase: "test" },
+    tls,
   });
   expect(typeof listener.fd).toBe("number");
   expect(listener.fd).toBeGreaterThan(0);


### PR DESCRIPTION
Accessing `.fd` on a TLS listener created by `Bun.listen()` crashes with a segfault (SIGSEGV).

`Listener.getFD()` passed the `ssl` flag when getting the fd from the listen socket. For SSL listeners, this went through `SSL_get_fd()` which dereferences the SSL pointer on the socket. But listen sockets don't have SSL connections — only accepted connections do — so the SSL pointer is invalid, causing a use-after-free.

The fix: always use the non-SSL path (`socket(false)`) to get the raw fd from a listen socket, since the listen socket itself is a plain socket regardless of whether TLS is configured for accepted connections.