### PR TITLE
Fix req.socket.bytesRead returning 0 in node:http server

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -743,6 +743,8 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             const promise = $newPromise();
             // Pass the pipelined data (head buffer) if any was received with the CONNECT request
             const head = connectHead ? connectHead : kEmptyBuffer;
+            // Head bytes arrive in the initial parse burst, before #onData is wired.
+            socket[kBytesRead] = (socket[kBytesRead] ?? 0) + head.length;
             // Node.js's parserOnIncoming: req.upgrade is true for CONNECT
             // regardless of shouldUpgradeCallback.
             http_req.upgrade = true;
@@ -972,6 +974,8 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             http_req.once("end", clearUpgradeIncoming.bind(undefined, socket));
           }
           const upgradeHead = !hasBody && connectHead ? connectHead : kEmptyBuffer;
+          // Head bytes arrive in the initial parse burst, before #onData is wired.
+          socket[kBytesRead] = (socket[kBytesRead] ?? 0) + upgradeHead.length;
           let upgradeHandled;
           try {
             upgradeHandled = server.emit("upgrade", http_req, socket, upgradeHead);
@@ -1304,6 +1308,7 @@ function replyMissingHostHeader(socket) {
 }
 
 const kBytesWritten = Symbol("kBytesWritten");
+const kBytesRead = Symbol("kBytesRead");
 const kEnableStreaming = Symbol("kEnableStreaming");
 // Upgrade request whose body is still being parsed: reading the raw socket also
 // resumes this request, like Node.js's UpgradeStream._read, so an unread body
@@ -1475,7 +1480,6 @@ function getNodeHTTPServerSocket() {
   if (NodeHTTPServerSocket) return NodeHTTPServerSocket;
   const { Socket: NetSocket } = require("node:net");
   NodeHTTPServerSocket = class Socket extends NetSocket {
-    bytesRead = 0;
     connecting = false;
     timeout = 0;
     parser = null;
@@ -1483,6 +1487,7 @@ function getNodeHTTPServerSocket() {
     [kBoundOnAbort] = null;
     [kKeepAliveIdleStart] = undefined;
     [kBytesWritten] = 0;
+    [kBytesRead] = 0;
     [kHandle];
     [kUpgradeIncoming] = undefined;
     server: Server;
@@ -1531,6 +1536,14 @@ function getNodeHTTPServerSocket() {
       }
     }
 
+    get bytesRead() {
+      // kBytesRead only ever holds tunnel chunks and close-time folds, so the sum never double-counts.
+      return (this[kHandle]?.response?.getBytesRead?.() ?? 0) + (this[kBytesRead] ?? 0);
+    }
+    set bytesRead(value) {
+      this[kBytesRead] = value;
+    }
+
     get bytesWritten() {
       const handle = this[kHandle];
       return handle
@@ -1573,6 +1586,8 @@ function getNodeHTTPServerSocket() {
     #onData(chunk, last) {
       this._unrefTimer();
       if (chunk) {
+        // Tunnel-mode (CONNECT/Upgrade) chunks bypass the response counter; count them here.
+        this[kBytesRead] = (this[kBytesRead] ?? 0) + chunk.length;
         this.push(chunk);
       }
       if (last) {
@@ -1597,6 +1612,8 @@ function getNodeHTTPServerSocket() {
       }
     }
     #closeHandle(handle, callback, err?: Error) {
+      // Fold the response count into kBytesRead; #onClose then sees kHandle undefined and adds nothing.
+      this[kBytesRead] = (this[kBytesRead] ?? 0) + (handle.response?.getBytesRead?.() ?? 0);
       this[kHandle] = undefined;
       // Capture the in-flight response before detachSocket() can clear it: a
       // synchronous res.destroy() inside the request handler runs detachSocket()
@@ -1611,6 +1628,8 @@ function getNodeHTTPServerSocket() {
       // freeParser equivalent: runs before 'close' listeners so they observe the
       // released parser (free() invoked, kOnTimeout nulled).
       releaseServerParserShim(this);
+      // Fold the response count into kBytesRead so it survives the handle being cleared.
+      this[kBytesRead] = (this[kBytesRead] ?? 0) + (this[kHandle]?.response?.getBytesRead?.() ?? 0);
       this[kHandle] = null;
       this.server?.[kTrackedConnections]?.delete(this);
       const timer = this[kSocketTimeoutTimer];

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -67,6 +67,7 @@ pub struct NodeHTTPResponse {
     /// access.
     pub(crate) raw_request_headers: JsCell<Vec<u8>>,
     pub(crate) bytes_written: Cell<usize>,
+    pub(crate) bytes_read: Cell<usize>,
 
     pending_pinned_write: Cell<PendingPinnedWrite>,
     /// Owns the bytes referenced by `pending_pinned_write`: either a
@@ -1583,6 +1584,8 @@ impl NodeHTTPResponse {
             last
         );
 
+        self.bytes_read
+            .set(self.bytes_read.get().saturating_add(chunk.len()));
         self.buffered_request_body_data_during_pause
             .with_mut(|b| b.append_slice(chunk));
         if last {
@@ -1707,6 +1710,8 @@ impl NodeHTTPResponse {
             last as u8
         );
 
+        self.bytes_read
+            .set(self.bytes_read.get().saturating_add(chunk.len()));
         if last {
             self.capture_request_trailers();
         }
@@ -2437,6 +2442,10 @@ impl NodeHTTPResponse {
     ) -> JSValue {
         JSValue::js_number(self.bytes_written.get() as f64)
     }
+
+    pub(crate) fn get_bytes_read(&self, _global: &JSGlobalObject, _frame: &CallFrame) -> JSValue {
+        JSValue::js_number(self.bytes_read.get() as f64)
+    }
 }
 
 impl NodeHTTPResponse {
@@ -2702,6 +2711,7 @@ pub(crate) unsafe extern "C" fn NodeHTTPResponse__createForJS(
         bytes_written: Cell::new(0),
         pending_pinned_write: Cell::new(PendingPinnedWrite::default()),
         pending_pinned_write_owner: JsCell::new(crate::node::StringOrBuffer::EMPTY),
+        bytes_read: Cell::new(request_ref.headers_byte_length()),
         auto_flusher: JsCell::new(AutoFlusher::default()),
     }));
 

--- a/src/runtime/server/server.classes.ts
+++ b/src/runtime/server/server.classes.ts
@@ -142,6 +142,10 @@ export default [
         fn: "getBytesWritten",
         length: 0,
       },
+      getBytesRead: {
+        fn: "getBytesRead",
+        length: 0,
+      },
       flushHeaders: {
         fn: "flushHeaders",
         length: 0,

--- a/src/uws_sys/Request.rs
+++ b/src/uws_sys/Request.rs
@@ -90,6 +90,9 @@ impl Request {
         // ffi::slice tolerates the (null, 0) shape uWS returns when no parameter is present.
         unsafe { bun_core::ffi::slice(ptr, len) }
     }
+    pub fn headers_byte_length(&self) -> usize {
+        c::uws_req_get_headers_byte_length(self)
+    }
 }
 
 mod c {
@@ -115,5 +118,6 @@ mod c {
             dest: &mut *const u8,
         ) -> usize;
         pub(super) safe fn uws_req_has_transfer_encoding(res: &Request) -> bool;
+        pub(super) safe fn uws_req_get_headers_byte_length(res: &Request) -> usize;
     }
 }

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1455,6 +1455,25 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
     return value.length();
   }
 
+  // Header byte length for socket.bytesRead, reconstructed assuming canonical
+  // "Name: Value\r\n" framing (uWS does not expose the parser's consumed offset).
+  size_t uws_req_get_headers_byte_length(uws_req_t *res)
+  {
+    uWS::HttpRequest *uwsReq = (uWS::HttpRequest *)res;
+    // "METHOD URL HTTP/1.x\r\n" = method + 1 + url + 9 + 2
+    auto method = uwsReq->getMethod();
+    auto url = uwsReq->getFullUrl();
+    size_t size = method.length() + 1 + url.length() + 9 + 2;
+    for (auto header : *uwsReq)
+    {
+      // "Name: Value\r\n"
+      size += header.first.length() + 2 + header.second.length() + 2;
+    }
+    // Trailing "\r\n"
+    size += 2;
+    return size;
+  }
+
   size_t uws_req_get_parameter(uws_req_t *res, unsigned short index,
                                const char **dest)
   {

--- a/test/js/node/http/node-http-socket-bytes-read.test.ts
+++ b/test/js/node/http/node-http-socket-bytes-read.test.ts
@@ -1,0 +1,189 @@
+import { expect, test } from "bun:test";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import net from "node:net";
+
+test("req.socket.bytesRead counts headers and body (#28709)", async () => {
+  const { promise, resolve, reject } = Promise.withResolvers<{
+    atDispatch: number;
+    atEnd: number;
+    atClose: number;
+  }>();
+  const server = http.createServer((req, res) => {
+    // The 'request' event fires after headers are parsed but before any body
+    // chunk is delivered, so this samples the header-seeded value alone.
+    const atDispatch = req.socket.bytesRead;
+    let atEnd = 0;
+    req.socket.once("close", () => {
+      resolve({ atDispatch, atEnd, atClose: req.socket.bytesRead });
+    });
+    req.on("end", () => {
+      atEnd = req.socket.bytesRead;
+      res.end("ok");
+    });
+    req.on("error", reject);
+    req.resume();
+  });
+  try {
+    await new Promise<void>((res, rej) => {
+      server.once("error", rej);
+      server.listen(0, res);
+    });
+    const port = (server.address() as AddressInfo).port;
+    // connection: close makes the server close the socket after responding,
+    // so the 'close' sample exercises the close-time fold in #onClose.
+    const clientReq = http.request({ method: "PUT", port, headers: { connection: "close" } });
+    clientReq.on("error", reject);
+    clientReq.write("hello");
+    clientReq.end();
+    const { atDispatch, atEnd, atClose } = await promise;
+    // Header portion was seeded at request dispatch.
+    expect(atDispatch).toBeGreaterThan(0);
+    // Body bytes were accumulated on top of the header seed.
+    expect(atEnd - atDispatch).toBe("hello".length);
+    // The count survives the native handle being cleared at close.
+    expect(atClose).toBe(atEnd);
+  } finally {
+    await new Promise<void>((res, rej) => server.close(err => (err ? rej(err) : res())));
+  }
+});
+
+test("bytesRead survives a JS-initiated socket.destroy() (#28709)", async () => {
+  const { promise, resolve, reject } = Promise.withResolvers<{ atDispatch: number; atClose: number }>();
+  const server = http.createServer(req => {
+    const atDispatch = req.socket.bytesRead;
+    req.socket.once("close", () => {
+      resolve({ atDispatch, atClose: req.socket.bytesRead });
+    });
+    // destroy() routes through _destroy -> #closeHandle while the handle is
+    // live, exercising that fold rather than #onClose's.
+    req.socket.destroy();
+  });
+  try {
+    await new Promise<void>((res, rej) => {
+      server.once("error", rej);
+      server.listen(0, res);
+    });
+    const port = (server.address() as AddressInfo).port;
+    const clientReq = http.request({ method: "GET", port });
+    // The server destroys the connection without responding; swallow the error.
+    clientReq.on("error", () => {});
+    clientReq.end();
+    const { atDispatch, atClose } = await promise;
+    expect(atDispatch).toBeGreaterThan(0);
+    expect(atClose).toBe(atDispatch);
+  } finally {
+    await new Promise<void>((res, rej) => server.close(err => (err ? rej(err) : res())));
+  }
+});
+
+test("socket.bytesRead counts CONNECT tunnel bytes (#28709)", async () => {
+  const payload = "tunnel-payload";
+  const { promise, resolve, reject } = Promise.withResolvers<{ seed: number; after: number }>();
+  const server = http.createServer();
+  server.on("connect", (req, socket, _head) => {
+    const seed = socket.bytesRead;
+    socket.once("data", () => {
+      resolve({ seed, after: socket.bytesRead });
+      socket.end();
+    });
+    socket.on("error", reject);
+    socket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+  });
+  let client: net.Socket | undefined;
+  try {
+    await new Promise<void>((res, rej) => {
+      server.once("error", rej);
+      server.listen(0, res);
+    });
+    const port = (server.address() as AddressInfo).port;
+    const c = (client = net.connect(port, "127.0.0.1", () => {
+      c.write("CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n");
+    }));
+    c.on("error", reject);
+    // Wait for the 200 before sending payload so it arrives as tunnel data
+    // through #onData, not as pipelined head bytes.
+    c.once("data", () => {
+      c.write(payload);
+    });
+    const { seed, after } = await promise;
+    // CONNECT request line + headers were seeded.
+    expect(seed).toBeGreaterThan(0);
+    // Tunnel bytes were accumulated on top of the seed.
+    expect(after - seed).toBe(payload.length);
+  } finally {
+    client?.destroy();
+    await new Promise<void>((res, rej) => server.close(err => (err ? rej(err) : res())));
+  }
+});
+
+// For the hand-written canonical requests below, the native header
+// reconstruction equals the wire byte length exactly, so the total can be
+// asserted with ===.
+test("socket.bytesRead counts CONNECT head bytes (#28709)", async () => {
+  const request = "CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n";
+  const payload = "head-payload";
+  const target = request.length + payload.length;
+  const { promise, resolve, reject } = Promise.withResolvers<number>();
+  const server = http.createServer();
+  server.on("connect", (req, socket, _head) => {
+    // The payload normally arrives as head bytes (same packet as the request);
+    // if TCP split the write it arrives via 'data' instead. Both paths must
+    // land in the counter.
+    const check = () => {
+      if (socket.bytesRead >= target) resolve(socket.bytesRead);
+    };
+    socket.on("data", check);
+    socket.on("error", reject);
+    check();
+  });
+  let client: net.Socket | undefined;
+  try {
+    await new Promise<void>((res, rej) => {
+      server.once("error", rej);
+      server.listen(0, res);
+    });
+    const port = (server.address() as AddressInfo).port;
+    const c = (client = net.connect(port, "127.0.0.1", () => {
+      // Single write: the payload lands in the request's pipelined head buffer.
+      c.write(request + payload);
+    }));
+    c.on("error", reject);
+    expect(await promise).toBe(target);
+  } finally {
+    client?.destroy();
+    await new Promise<void>((res, rej) => server.close(err => (err ? rej(err) : res())));
+  }
+});
+
+test("socket.bytesRead counts Upgrade head bytes (#28709)", async () => {
+  const request = "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n";
+  const payload = "upgrade-head";
+  const target = request.length + payload.length;
+  const { promise, resolve, reject } = Promise.withResolvers<number>();
+  const server = http.createServer();
+  server.on("upgrade", (req, socket, _head) => {
+    const check = () => {
+      if (socket.bytesRead >= target) resolve(socket.bytesRead);
+    };
+    socket.on("data", check);
+    socket.on("error", reject);
+    check();
+  });
+  let client: net.Socket | undefined;
+  try {
+    await new Promise<void>((res, rej) => {
+      server.once("error", rej);
+      server.listen(0, res);
+    });
+    const port = (server.address() as AddressInfo).port;
+    const c = (client = net.connect(port, "127.0.0.1", () => {
+      c.write(request + payload);
+    }));
+    c.on("error", reject);
+    expect(await promise).toBe(target);
+  } finally {
+    client?.destroy();
+    await new Promise<void>((res, rej) => server.close(err => (err ? rej(err) : res())));
+  }
+});


### PR DESCRIPTION
## Problem

`req.socket.bytesRead` always returns `0` when using `node:http` server because the `bytesRead` property on `NodeHTTPServerSocket` was hardcoded to `0` and never updated.

```javascript
import http from "node:http";
const server = http.createServer((req, res) => {
  req.on("end", () => {
    console.log(req.socket.bytesRead); // Always 0
    res.end("ok");
  });
  req.resume();
});
```

## Root Cause

`NodeHTTPServerSocket` declared `bytesRead = 0` as a plain class field that was never updated. In contrast, `bytesWritten` was properly implemented as a getter reading from the native handle.

## Fix

- Added a `bytes_read` field to `NodeHTTPResponse`, seeded with the raw HTTP header size at request dispatch and incremented with each body chunk in `on_data` / `on_buffer_request_body_while_paused`. Exposed via `getBytesRead()` (registered in `server.classes.ts`).
- Added `uws_req_get_headers_byte_length` to compute the request line + headers size from the parsed request (uWS does not expose the parser's consumed offset, so this reconstructs canonical framing; exact for canonical clients).
- Replaced the hardcoded field with a getter on `NodeHTTPServerSocket` summing the response counter with a socket-level `kBytesRead` cache. The cache collects CONNECT/Upgrade tunnel chunks and head-buffer bytes (which bypass the response counter) and close-time folds, so the value survives reads from a `'close'` handler. A setter stores to the cache since `net.Socket`'s constructor assigns `bytesRead`.

Known limitation, deliberate: on keep-alive connections the counter reflects the current request rather than the socket-lifetime total, matching the existing `bytesWritten` getter on the same class (tracked in an open review thread).

## Verification

- `test/js/node/http/node-http-socket-bytes-read.test.ts` asserts the header seed is non-zero at dispatch and the delta at `'end'` equals the body length.
- Fails on plain main (returns 0), passes with the fix.

Closes #28709

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 15 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-socket-bytes-read.test.ts
bun test v1.4.1 (861e9ae04)

test/js/node/http/node-http-socket-bytes-read.test.ts:
36 |     clientReq.on("error", reject);
37 |     clientReq.write("hello");
38 |     clientReq.end();
39 |     const { atDispatch, atEnd, atClose } = await promise;
40 |     // Header portion was seeded at request dispatch.
41 |     expect(atDispatch).toBeGreaterThan(0);
                            ^
error: expect(received).toBeGreaterThan(expected)

Expected: > 0
Received: 0

      at <anonymous> (/workspace/bun/test/js/node/http/node-http-socket-bytes-read.test.ts:41:24)
(fail) req.socket.bytesRead counts headers and body (#28709) [998.85ms]
68 |     const clientReq = http.request({ method: "GET", port });
69 |     // The server destroys the connection without responding; swallow the error.
70 |     clientReq.on("error", () => {});
71 |     clientReq.end();
72 |     const { atDispatch, atClose } = await promise;
73 |     expect(atDispatch).toBeGreaterThan(0);
                            ^
error: exp
... (truncated)

release without fix: 5 FAILED
bun test v1.4.1-canary.1 (861e9ae04)

test/js/node/http/node-http-socket-bytes-read.test.ts:
36 |     clientReq.on("error", reject);
37 |     clientReq.write("hello");
38 |     clientReq.end();
39 |     const { atDispatch, atEnd, atClose } = await promise;
40 |     // Header portion was seeded at request dispatch.
41 |     expect(atDispatch).toBeGreaterThan(0);
                            ^
error: expect(received).toBeGreaterThan(expected)

Expected: > 0
Received: 0

      at <anonymous> (/workspace/bun/test/js/node/http/node-http-socket-bytes-read.test.ts:41:24)
(fail) req.socket.bytesRead counts headers and body (#28709) [19.65ms]
68 |     const clientReq = http.request({ method: "GET", port });
69 |     // The server destroys the connection without responding; swallow the error.
70 |     clientReq.on("error", () => {});
71 |     clientReq.end();
72 |     const { atDispatch, atClose } = await promise;
73 |     expect(atDispatch).toBeGreaterThan(0);
                            ^
error: expect(received).toBeGreaterThan(expected)

Expected: > 0
Received: 0

      at <anonymous> (/workspace/bun/test/js/node/http/node-http-socket-bytes-read.test.ts:73:24)
(fail) bytesR
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-socket-bytes-read.test.ts
bun test v1.4.1 (861e9ae04)

test/js/node/http/node-http-socket-bytes-read.test.ts:
(pass) req.socket.bytesRead counts headers and body (#28709) [1073.68ms]
(pass) bytesRead survives a JS-initiated socket.destroy() (#28709) [105.15ms]
(pass) socket.bytesRead counts CONNECT tunnel bytes (#28709) [107.13ms]
(pass) socket.bytesRead counts CONNECT head bytes (#28709) [72.90ms]
(pass) socket.bytesRead counts Upgrade head bytes (#28709) [74.76ms]

 5 pass
 0 fail
 9 expect() calls
Ran 5 tests across 1 file. [4.22s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     70771b27b3
  features     baseline

23 deps, 129 codegen, 1172 objects in 717ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (861e9ae04)

Checked 26 installs across 63 packages (no changes) [20.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (861e9ae04)

Checked 1 install across 2 packages (no changes) [6.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (861e9ae04)

Checked 111 installs across 104 packages (no changes) [9.00ms]
[5/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1217] gen node-fallbacks/react-refresh.js
Bundled 1 module in 11ms

  react-refresh.js  4.81 KB  (entry point)

[7/1217] gen bindgenv2
[8/1217] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       34.9kb
  ../../build/release/codegen/bun-error/bun-error.css  12.8kb

⚡ Done in 41ms
[9/1217] gen .bind.ts → Genera
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_server.ts                        |  21 ++-
 src/runtime/server/NodeHTTPResponse.rs             |  10 ++
 src/runtime/server/server.classes.ts               |   4 +
 src/uws_sys/Request.rs                             |   4 +
 src/uws_sys/libuwsockets.cpp                       |  19 +++
 .../node/http/node-http-socket-bytes-read.test.ts  | 189 +++++++++++++++++++++
 6 files changed, 246 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 15

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/js/node/_http_server.ts                               28     32     11
src/runtime/server/NodeHTTPResponse.rs                     7      9     10
src/runtime/server/server.classes.ts                       0      0     11
src/uws_sys/Request.rs                                     2      4     10
src/uws_sys/libuwsockets.cpp                               3      5     11
test/js/node/http/node-http-socket-bytes-read.test.ts      5      8     10
```

</details>

**root cause** · written by the author bot

The `bytesRead` getter on the `node:http` server socket always returned 0 because the native layer never tracked bytes received from the client. The fix adds a `bytes_read` counter to `NodeHTTPResponse`, seeded with the request line and header byte length reconstructed from the parsed request and incremented as body chunks are delivered, exposed to JavaScript through a `getBytesRead()` binding. The socket getter sums this native counter with a socket-level cache that holds tunnel and upgrade head bytes and folds the count at close time so the value survives after the native handle is released.

<!-- robobun:evidence:end -->