### PR TITLE
Implement HTTP/2 server push streams (PUSH_PROMISE)

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -731,6 +731,7 @@ declare function $ERR_HTTP2_TRAILERS_NOT_READY(): Error;
 declare function $ERR_HTTP2_SEND_FILE(): Error;
 declare function $ERR_HTTP2_SEND_FILE_NOSEEK(): Error;
 declare function $ERR_HTTP2_PUSH_DISABLED(): Error;
+declare function $ERR_HTTP2_NESTED_PUSH(): Error;
 declare function $ERR_HTTP2_HEADERS_AFTER_RESPOND(): Error;
 declare function $ERR_HTTP2_STATUS_101(): Error;
 declare function $ERR_HTTP2_ALTSVC_INVALID_ORIGIN(): TypeError;

--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -732,6 +732,7 @@ declare function $ERR_HTTP2_SEND_FILE(): Error;
 declare function $ERR_HTTP2_SEND_FILE_NOSEEK(): Error;
 declare function $ERR_HTTP2_PUSH_DISABLED(): Error;
 declare function $ERR_HTTP2_NESTED_PUSH(): Error;
+declare function $ERR_HTTP2_FRAME_ERROR(): Error;
 declare function $ERR_HTTP2_HEADERS_AFTER_RESPOND(): Error;
 declare function $ERR_HTTP2_STATUS_101(): Error;
 declare function $ERR_HTTP2_ALTSVC_INVALID_ORIGIN(): TypeError;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2513,6 +2513,11 @@ class ServerHttp2Stream extends Http2Stream {
 
     const parser = session[bunHTTP2Native];
     const streamId = parser.sendPushPromise(this.id, pushHeaders, {});
+    if (streamId === -2) {
+      // Stream ID space exhausted — push is still enabled, we just ran out of IDs.
+      process.nextTick(callback, $ERR_HTTP2_OUT_OF_STREAMS());
+      return;
+    }
     if (streamId < 0) {
       process.nextTick(callback, $ERR_HTTP2_PUSH_DISABLED());
       return;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2557,9 +2557,20 @@ class ServerHttp2Stream extends Http2Stream {
     // be HPACK-encoded with never-index (RFC 7541 Section 7.1.3), matching
     // `request()`/`respond()` semantics. Honour a top-level options override
     // first, then fall back to the magic symbol on the headers object.
-    const sensitiveNames = finalOptions[sensitiveHeaders] ?? pushHeaders[sensitiveHeaders] ?? [];
+    //
+    // Object spread (`{ ...headers }` above) copies own enumerable Symbol
+    // keys, and the native header iterator enumerates symbols. Without
+    // `delete pushHeaders[sensitiveHeaders]` the symbol's description string
+    // would leak onto the wire as a bogus "nodejs.http2.sensitiveheaders"
+    // header field. Also mirror the ERR_INVALID_ARG_VALUE validation used by
+    // request()/respond()/addTrailers().
+    const sensitiveNames = finalOptions[sensitiveHeaders] ?? pushHeaders[sensitiveHeaders];
+    delete pushHeaders[sensitiveHeaders];
     const sensitiveMap = {};
-    if ($isArray(sensitiveNames)) {
+    if (sensitiveNames !== undefined) {
+      if (!$isArray(sensitiveNames)) {
+        throw $ERR_INVALID_ARG_VALUE("headers[http2.neverIndex]", sensitiveNames);
+      }
       for (let i = 0; i < sensitiveNames.length; i++) {
         sensitiveMap[String(sensitiveNames[i]).toLowerCase()] = true;
       }
@@ -2570,6 +2581,23 @@ class ServerHttp2Stream extends Http2Stream {
     if (streamId === -2) {
       // Stream ID space exhausted — push is still enabled, we just ran out of IDs.
       process.nextTick(callback, $ERR_HTTP2_OUT_OF_STREAMS());
+      return;
+    }
+    if (streamId === -3) {
+      // Parent stream closed/half-closed-local between the JS guard and
+      // the native call — surface as an invalid-stream error, not push-
+      // disabled (SETTINGS negotiation is fine; it's the parent's state).
+      process.nextTick(callback, $ERR_HTTP2_INVALID_STREAM());
+      return;
+    }
+    if (streamId === -4) {
+      // encoded_size > maxSendHeaderBlockLength. Node surfaces an equivalent
+      // condition on the regular request() path via a 'frameError' event.
+      // Report the same code via the callback so users can match on
+      // err.code rather than the less-specific PUSH_DISABLED.
+      const e = new Error("Frame size error") as Error & { code?: string };
+      e.code = "ERR_HTTP2_FRAME_ERROR";
+      process.nextTick(callback, e);
       return;
     }
     if (streamId < 0) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -1935,6 +1935,7 @@ enum StreamState {
   Closed = 1 << 3, // 01000 = 8
   StreamResponded = 1 << 4, // 10000 = 16
   WritableClosed = 1 << 5, // 100000 = 32
+  PushPromiseReceived = 1 << 6, // 1000000 = 64
 }
 function markWritableDone(stream: Http2Stream) {
   const _final = stream[bunHTTP2StreamFinal];
@@ -2113,8 +2114,11 @@ class Http2Stream extends Duplex {
   }
 
   get pushAllowed() {
-    // not implemented yet aka server side
-    return false;
+    const session = this[bunHTTP2Session];
+    if (!session) return false;
+    const remoteSettings = session.remoteSettings;
+    if (!remoteSettings) return false;
+    return remoteSettings.enablePush !== false;
   }
   close(code, callback) {
     if ((this[bunHTTP2StreamStatus] & StreamState.Closed) === 0) {
@@ -2466,8 +2470,54 @@ class ServerHttp2Stream extends Http2Stream {
   constructor(streamId, session, headers) {
     super(streamId, session, headers);
   }
-  pushStream() {
-    throw $ERR_HTTP2_PUSH_DISABLED();
+  pushStream(headers, options, callback) {
+    if (typeof options === "function") {
+      callback = options;
+      options = {};
+    }
+
+    validateFunction(callback, "callback");
+
+    if (this.destroyed || this.closed) {
+      throw $ERR_HTTP2_INVALID_STREAM();
+    }
+
+    const session = this[bunHTTP2Session];
+    assertSession(session);
+
+    const remoteSettings = session.remoteSettings;
+    if (!remoteSettings || remoteSettings.enablePush === false) {
+      throw $ERR_HTTP2_PUSH_DISABLED();
+    }
+
+    if (!$isObject(headers)) {
+      throw $ERR_INVALID_ARG_TYPE("headers", "object", headers);
+    }
+
+    // Ensure required pseudo-headers for push promise
+    const pushHeaders = { ...headers };
+    if (pushHeaders[":method"] === undefined) {
+      pushHeaders[":method"] = "GET";
+    }
+    if (pushHeaders[":scheme"] === undefined) {
+      pushHeaders[":scheme"] = "https";
+    }
+    if (pushHeaders[":authority"] === undefined) {
+      pushHeaders[":authority"] = "localhost";
+    }
+
+    const parser = session[bunHTTP2Native];
+    const streamId = parser.sendPushPromise(this.id, pushHeaders, {});
+    if (streamId < 0) {
+      process.nextTick(callback, $ERR_HTTP2_PUSH_DISABLED());
+      return;
+    }
+
+    // Create a new ServerHttp2Stream for the promised stream
+    const pushStream = new ServerHttp2Stream(streamId, session, null);
+    parser.setStreamContext(streamId, pushStream);
+
+    process.nextTick(callback, null, pushStream, pushHeaders, options || {});
   }
 
   respondWithFile(path, headers, options) {
@@ -3384,8 +3434,8 @@ class ClientHttp2Session extends Http2Session {
       if (!self) return;
       self.#connections++;
       if (stream_id % 2 === 0) {
-        // pushStream
-        const stream = new ClientHttp2Session(stream_id, self, null);
+        // pushStream - even-numbered stream IDs are server-initiated push streams
+        const stream = new ClientHttp2Stream(stream_id, self, null);
         self.#parser?.setStreamContext(stream_id, stream);
       }
     },
@@ -3454,6 +3504,21 @@ class ClientHttp2Session extends Http2Session {
       const headers = toHeaderObject(rawheaders, sensitiveHeadersValue || []);
       const status = stream[bunHTTP2StreamStatus];
       const header_status = headers[HTTP2_HEADER_STATUS];
+
+      // Push promise request headers: even stream ID, no PushPromiseReceived yet, no :status
+      if (stream.id % 2 === 0 && (status & StreamState.PushPromiseReceived) === 0 && header_status === undefined) {
+        stream[bunHTTP2StreamStatus] = status | StreamState.PushPromiseReceived;
+        self.emit("stream", stream, headers, flags, rawheaders);
+        return;
+      }
+
+      // Push stream response headers: has PushPromiseReceived, not yet responded
+      if ((status & StreamState.PushPromiseReceived) !== 0 && (status & StreamState.StreamResponded) === 0) {
+        stream[bunHTTP2StreamStatus] = status | StreamState.StreamResponded;
+        stream.emit("response", headers, flags, rawheaders);
+        return;
+      }
+
       if (header_status === HTTP_STATUS_CONTINUE) {
         stream.emit("continue");
       }
@@ -3473,7 +3538,10 @@ class ClientHttp2Session extends Http2Session {
             // 421 Misdirected Request
             removeOriginFromSet(self, stream);
           }
-          self.emit("stream", stream, headers, flags, rawheaders);
+          // Don't emit session 'stream' again for push streams (already emitted for push promise)
+          if ((status & StreamState.PushPromiseReceived) === 0) {
+            self.emit("stream", stream, headers, flags, rawheaders);
+          }
           stream.emit("response", headers, flags, rawheaders);
         }
       }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2501,11 +2501,7 @@ class ServerHttp2Stream extends Http2Stream {
     // too so we do not emit a PUSH_PROMISE on a stream we already ended,
     // which a conforming client must reject with PROTOCOL_ERROR and tears
     // down the whole connection.
-    if (
-      this.destroyed ||
-      this.closed ||
-      (this[bunHTTP2StreamStatus] & StreamState.WritableClosed) !== 0
-    ) {
+    if (this.destroyed || this.closed || (this[bunHTTP2StreamStatus] & StreamState.WritableClosed) !== 0) {
       throw $ERR_HTTP2_INVALID_STREAM();
     }
 
@@ -2551,8 +2547,7 @@ class ServerHttp2Stream extends Http2Stream {
     // be HPACK-encoded with never-index (RFC 7541 Section 7.1.3), matching
     // `request()`/`respond()` semantics. Honour a top-level options override
     // first, then fall back to the magic symbol on the headers object.
-    const sensitiveNames =
-      finalOptions[sensitiveHeaders] ?? pushHeaders[sensitiveHeaders] ?? [];
+    const sensitiveNames = finalOptions[sensitiveHeaders] ?? pushHeaders[sensitiveHeaders] ?? [];
     const sensitiveMap = {};
     if ($isArray(sensitiveNames)) {
       for (let i = 0; i < sensitiveNames.length; i++) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2488,8 +2488,10 @@ class ServerHttp2Stream extends Http2Stream {
     const session = this[bunHTTP2Session];
     assertSession(session);
 
+    // RFC 7540 Section 6.5.2: SETTINGS_ENABLE_PUSH defaults to 1.
+    // Only reject if the peer has explicitly disabled push via SETTINGS.
     const remoteSettings = session.remoteSettings;
-    if (!remoteSettings || remoteSettings.enablePush === false) {
+    if (remoteSettings && remoteSettings.enablePush === false) {
       throw $ERR_HTTP2_PUSH_DISABLED();
     }
 
@@ -2509,9 +2511,10 @@ class ServerHttp2Stream extends Http2Stream {
       pushHeaders[":scheme"] = session.encrypted ? "https" : "http";
     }
     if (pushHeaders[":authority"] === undefined) {
-      // Inherit from the originating request headers
+      // RFC 7540 Section 8.1.2.3 allows clients to use either :authority or
+      // the host header. Use getAuthority() which handles both forms.
       const reqHeaders = this[bunHTTP2Headers];
-      pushHeaders[":authority"] = reqHeaders?.[":authority"] ?? "localhost";
+      pushHeaders[":authority"] = (reqHeaders ? getAuthority(reqHeaders) : undefined) ?? "localhost";
     }
 
     const parser = session[bunHTTP2Native];
@@ -3529,6 +3532,11 @@ class ClientHttp2Session extends Http2Session {
       if ((status & StreamState.PushPromiseReceived) !== 0 && (status & StreamState.StreamResponded) === 0) {
         if (header_status === HTTP_STATUS_CONTINUE) {
           stream.emit("continue");
+        }
+        // CONTINUATION fragments of a multi-frame header block can arrive here
+        // without a :status (partial block). Don't consume StreamResponded yet.
+        if (header_status === undefined) {
+          return;
         }
         // Informational 1xx headers don't count as final response
         if (header_status >= 100 && header_status < 200) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -323,9 +323,9 @@ const bunHTTP2Session = Symbol.for("::bunhttp2session::");
 const bunHTTP2Headers = Symbol.for("::bunhttp2headers::");
 // Accumulator for multi-fragment header blocks (HEADERS/PUSH_PROMISE spanning
 // CONTINUATION frames). The native layer dispatches streamHeaders once per
-// fragment; we merge here and only emit the user-visible event when the
-// END_HEADERS flag is present on the current fragment.
-const bunHTTP2PartialHeaders = Symbol("::bunhttp2partialheaders::");
+// fragment; we merge the raw name/value list + sensitive-name list here and
+// only emit the user-visible event when the END_HEADERS flag is present on
+// the current fragment.
 const bunHTTP2PartialRawHeaders = Symbol("::bunhttp2partialrawheaders::");
 const bunHTTP2PartialSensitive = Symbol("::bunhttp2partialsensitive::");
 
@@ -2503,6 +2503,16 @@ class ServerHttp2Stream extends Http2Stream {
     // down the whole connection.
     if (this.destroyed || this.closed || (this[bunHTTP2StreamStatus] & StreamState.WritableClosed) !== 0) {
       throw $ERR_HTTP2_INVALID_STREAM();
+    }
+
+    // RFC 7540 Section 6.6: only a peer-initiated stream (odd id from the
+    // server's perspective) may carry a PUSH_PROMISE. An even-id stream is
+    // itself a push stream; nested pushes are forbidden. Matches Node's
+    // ERR_HTTP2_NESTED_PUSH semantics ordering — fire before header
+    // validation so e.code === 'ERR_HTTP2_NESTED_PUSH' regardless of
+    // whatever headers the caller passed.
+    if ((this.id & 1) === 0) {
+      throw $ERR_HTTP2_NESTED_PUSH();
     }
 
     const session = this[bunHTTP2Session];

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2531,6 +2531,16 @@ class ServerHttp2Stream extends Http2Stream {
     const session = this[bunHTTP2Session];
     assertSession(session);
 
+    // Match Node: reject if the session is closed/destroyed. The pushAllowed
+    // getter above already returns false in this state; without this the
+    // getter and the method disagreed (pushAllowed === false but
+    // pushStream() succeeded). After session.close() the parser is still
+    // alive while existing streams drain, so pushStream() would otherwise
+    // write a PUSH_PROMISE on a session flagged for shutdown.
+    if (session.closed || session.destroyed) {
+      throw $ERR_HTTP2_PUSH_DISABLED();
+    }
+
     // RFC 7540 Section 6.5.2: SETTINGS_ENABLE_PUSH defaults to 1.
     // Only reject if the peer has explicitly disabled push via SETTINGS.
     const remoteSettings = session.remoteSettings;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2499,11 +2499,16 @@ class ServerHttp2Stream extends Http2Stream {
     if (pushHeaders[":method"] === undefined) {
       pushHeaders[":method"] = "GET";
     }
+    if (pushHeaders[":path"] === undefined) {
+      throw $ERR_INVALID_ARG_VALUE("headers[:path]", undefined);
+    }
     if (pushHeaders[":scheme"] === undefined) {
-      pushHeaders[":scheme"] = "https";
+      pushHeaders[":scheme"] = session.encrypted ? "https" : "http";
     }
     if (pushHeaders[":authority"] === undefined) {
-      pushHeaders[":authority"] = "localhost";
+      // Inherit from the originating request headers
+      const reqHeaders = this[bunHTTP2Headers];
+      pushHeaders[":authority"] = reqHeaders?.[":authority"] ?? "localhost";
     }
 
     const parser = session[bunHTTP2Native];
@@ -2513,9 +2518,9 @@ class ServerHttp2Stream extends Http2Stream {
       return;
     }
 
-    // Create a new ServerHttp2Stream for the promised stream
-    const pushStream = new ServerHttp2Stream(streamId, session, null);
-    parser.setStreamContext(streamId, pushStream);
+    // The streamStart handler already created a ServerHttp2Stream and
+    // incremented #connections via handleReceivedStreamID -> onStreamStart
+    const pushStream = parser.getStreamContext(streamId);
 
     process.nextTick(callback, null, pushStream, pushHeaders, options || {});
   }
@@ -3514,6 +3519,14 @@ class ClientHttp2Session extends Http2Session {
 
       // Push stream response headers: has PushPromiseReceived, not yet responded
       if ((status & StreamState.PushPromiseReceived) !== 0 && (status & StreamState.StreamResponded) === 0) {
+        if (header_status === HTTP_STATUS_CONTINUE) {
+          stream.emit("continue");
+        }
+        // Informational 1xx headers don't count as final response
+        if (header_status >= 100 && header_status < 200) {
+          stream.emit("headers", headers, flags, rawheaders);
+          return;
+        }
         stream[bunHTTP2StreamStatus] = status | StreamState.StreamResponded;
         stream.emit("response", headers, flags, rawheaders);
         return;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -321,6 +321,13 @@ const bunHTTP2StreamStatus = Symbol.for("::bunhttp2StreamStatus::");
 
 const bunHTTP2Session = Symbol.for("::bunhttp2session::");
 const bunHTTP2Headers = Symbol.for("::bunhttp2headers::");
+// Accumulator for multi-fragment header blocks (HEADERS/PUSH_PROMISE spanning
+// CONTINUATION frames). The native layer dispatches streamHeaders once per
+// fragment; we merge here and only emit the user-visible event when the
+// END_HEADERS flag is present on the current fragment.
+const bunHTTP2PartialHeaders = Symbol("::bunhttp2partialheaders::");
+const bunHTTP2PartialRawHeaders = Symbol("::bunhttp2partialrawheaders::");
+const bunHTTP2PartialSensitive = Symbol("::bunhttp2partialsensitive::");
 
 const ReflectGetPrototypeOf = Reflect.getPrototypeOf;
 
@@ -2116,6 +2123,11 @@ class Http2Stream extends Duplex {
   get pushAllowed() {
     const session = this[bunHTTP2Session];
     if (!session) return false;
+    // pushStream() is server-only — clients never send PUSH_PROMISE.
+    // RFC 7540 Section 6.6: "A client cannot push." Return false regardless
+    // of remoteSettings on ClientHttp2Stream; the base getter still returns
+    // the peer's enablePush value for ServerHttp2Stream.
+    if (!session[kServer]) return false;
     // RFC 7540 Section 6.5.2: SETTINGS_ENABLE_PUSH has an initial value of 1.
     // If we have not yet received a SETTINGS frame from the peer, assume push
     // is enabled — the peer may still disable it in the first SETTINGS frame.
@@ -2476,12 +2488,24 @@ class ServerHttp2Stream extends Http2Stream {
   pushStream(headers, options, callback) {
     if (typeof options === "function") {
       callback = options;
-      options = {};
+      options = undefined;
     }
 
     validateFunction(callback, "callback");
 
-    if (this.destroyed || this.closed) {
+    // RFC 7540 Section 6.6: PUSH_PROMISE MUST only be sent on an open or
+    // half-closed (remote) parent stream. `this.closed` only tracks the
+    // StreamState.Closed bit, but after `respond({endStream: true})` the
+    // state machine transitions to HALF_CLOSED_LOCAL and only the
+    // WritableClosed bit is set — the Closed bit is not. Gate on that bit
+    // too so we do not emit a PUSH_PROMISE on a stream we already ended,
+    // which a conforming client must reject with PROTOCOL_ERROR and tears
+    // down the whole connection.
+    if (
+      this.destroyed ||
+      this.closed ||
+      (this[bunHTTP2StreamStatus] & StreamState.WritableClosed) !== 0
+    ) {
       throw $ERR_HTTP2_INVALID_STREAM();
     }
 
@@ -2498,6 +2522,11 @@ class ServerHttp2Stream extends Http2Stream {
     if (!$isObject(headers)) {
       throw $ERR_INVALID_ARG_TYPE("headers", "object", headers);
     }
+
+    if (options !== undefined && !$isObject(options)) {
+      throw $ERR_INVALID_ARG_TYPE("options", "object", options);
+    }
+    const finalOptions = options ? { ...options } : {};
 
     // Ensure required pseudo-headers for push promise
     const pushHeaders = { ...headers };
@@ -2517,8 +2546,22 @@ class ServerHttp2Stream extends Http2Stream {
       pushHeaders[":authority"] = (reqHeaders ? getAuthority(reqHeaders) : undefined) ?? "localhost";
     }
 
+    // Forward per-header never-index hints to native. `sensitiveHeaders` is a
+    // well-known Symbol carrying an array of header names whose values must
+    // be HPACK-encoded with never-index (RFC 7541 Section 7.1.3), matching
+    // `request()`/`respond()` semantics. Honour a top-level options override
+    // first, then fall back to the magic symbol on the headers object.
+    const sensitiveNames =
+      finalOptions[sensitiveHeaders] ?? pushHeaders[sensitiveHeaders] ?? [];
+    const sensitiveMap = {};
+    if ($isArray(sensitiveNames)) {
+      for (let i = 0; i < sensitiveNames.length; i++) {
+        sensitiveMap[String(sensitiveNames[i]).toLowerCase()] = true;
+      }
+    }
+
     const parser = session[bunHTTP2Native];
-    const streamId = parser.sendPushPromise(this.id, pushHeaders, {});
+    const streamId = parser.sendPushPromise(this.id, pushHeaders, sensitiveMap);
     if (streamId === -2) {
       // Stream ID space exhausted — push is still enabled, we just ran out of IDs.
       process.nextTick(callback, $ERR_HTTP2_OUT_OF_STREAMS());
@@ -2532,8 +2575,13 @@ class ServerHttp2Stream extends Http2Stream {
     // The streamStart handler already created a ServerHttp2Stream and
     // incremented #connections via handleReceivedStreamID -> onStreamStart
     const pushStream = parser.getStreamContext(streamId);
+    // Node marks pushed streams whose :method is HEAD so that respond() on
+    // the push rejects payload bodies. Mirror that here.
+    if (pushStream && pushHeaders[HTTP2_HEADER_METHOD] === HTTP2_METHOD_HEAD) {
+      pushStream[kHeadRequest] = true;
+    }
 
-    process.nextTick(callback, null, pushStream, pushHeaders, options || {});
+    process.nextTick(callback, null, pushStream, pushHeaders, finalOptions);
   }
 
   respondWithFile(path, headers, options) {
@@ -3012,13 +3060,37 @@ class ServerHttp2Session extends Http2Session {
       flags: number,
     ) {
       if (!self || typeof stream !== "object" || self.closed || stream.closed) return;
-      const headers = toHeaderObject(rawheaders, sensitiveHeadersValue || []);
+      // Accumulate multi-frame header blocks (HEADERS + CONTINUATION). See
+      // the matching comment in the client streamHeaders handler — the
+      // native decoder dispatches once per fragment, we only surface the
+      // complete block to user code on END_HEADERS.
+      const END_HEADERS = 0x4;
+      const partialRaw = stream[bunHTTP2PartialRawHeaders];
+      const partialSensitive = stream[bunHTTP2PartialSensitive];
+      let finalRaw: string[];
+      let finalSensitive: string[];
+      if (partialRaw !== undefined) {
+        finalRaw = partialRaw.concat(rawheaders);
+        finalSensitive = partialSensitive.concat(sensitiveHeadersValue || []);
+      } else {
+        finalRaw = rawheaders;
+        finalSensitive = sensitiveHeadersValue || [];
+      }
+      if ((flags & END_HEADERS) === 0) {
+        stream[bunHTTP2PartialRawHeaders] = finalRaw;
+        stream[bunHTTP2PartialSensitive] = finalSensitive;
+        return;
+      }
+      stream[bunHTTP2PartialRawHeaders] = undefined;
+      stream[bunHTTP2PartialSensitive] = undefined;
+
+      const headers = toHeaderObject(finalRaw, finalSensitive);
       if (headers[HTTP2_HEADER_METHOD] === HTTP2_METHOD_HEAD) {
         stream[kHeadRequest] = true;
       }
       const status = stream[bunHTTP2StreamStatus];
       if ((status & StreamState.StreamResponded) !== 0) {
-        stream.emit("trailers", headers, flags, rawheaders);
+        stream.emit("trailers", headers, flags, finalRaw);
       } else {
         // Set the StreamResponded bit BEFORE dispatching the 'stream' event
         // synchronously to user code. The user handler may call
@@ -3028,8 +3100,8 @@ class ServerHttp2Session extends Http2Session {
         // user handler — in particular, losing WantTrailer/FinalCalled breaks
         // any later `sendTrailers()` with ERR_HTTP2_TRAILERS_NOT_READY.
         stream[bunHTTP2StreamStatus] |= StreamState.StreamResponded;
-        self[kServer].emit("stream", stream, headers, flags, rawheaders);
-        self.emit("stream", stream, headers, flags, rawheaders);
+        self[kServer].emit("stream", stream, headers, flags, finalRaw);
+        self.emit("stream", stream, headers, flags, finalRaw);
       }
     },
     localSettings(self: ServerHttp2Session, settings: Settings) {
@@ -3517,14 +3589,42 @@ class ClientHttp2Session extends Http2Session {
       flags: number,
     ) {
       if (!self || typeof stream !== "object" || stream.rstCode) return;
-      const headers = toHeaderObject(rawheaders, sensitiveHeadersValue || []);
+      // RFC 7540 Section 6.10: a header block can be split across one HEADERS
+      // (or PUSH_PROMISE) plus zero or more CONTINUATION frames; the native
+      // layer decodes each fragment and dispatches `streamHeaders` once per
+      // fragment. Accumulate the pieces here and only surface the complete
+      // block to user code on the frame carrying END_HEADERS — without this,
+      // custom request/response headers that land in a CONTINUATION fragment
+      // are silently lost (partial `response` event, stale `trailers`, or
+      // missing push-promise metadata).
+      const END_HEADERS = 0x4;
+      const partialRaw = stream[bunHTTP2PartialRawHeaders];
+      const partialSensitive = stream[bunHTTP2PartialSensitive];
+      let finalRaw: string[];
+      let finalSensitive: string[];
+      if (partialRaw !== undefined) {
+        finalRaw = partialRaw.concat(rawheaders);
+        finalSensitive = partialSensitive.concat(sensitiveHeadersValue || []);
+      } else {
+        finalRaw = rawheaders;
+        finalSensitive = sensitiveHeadersValue || [];
+      }
+      if ((flags & END_HEADERS) === 0) {
+        stream[bunHTTP2PartialRawHeaders] = finalRaw;
+        stream[bunHTTP2PartialSensitive] = finalSensitive;
+        return;
+      }
+      stream[bunHTTP2PartialRawHeaders] = undefined;
+      stream[bunHTTP2PartialSensitive] = undefined;
+
+      const headers = toHeaderObject(finalRaw, finalSensitive);
       const status = stream[bunHTTP2StreamStatus];
       const header_status = headers[HTTP2_HEADER_STATUS];
 
       // Push promise request headers: even stream ID, no PushPromiseReceived yet, no :status
       if (stream.id % 2 === 0 && (status & StreamState.PushPromiseReceived) === 0 && header_status === undefined) {
         stream[bunHTTP2StreamStatus] = status | StreamState.PushPromiseReceived;
-        self.emit("stream", stream, headers, flags, rawheaders);
+        self.emit("stream", stream, headers, flags, finalRaw);
         return;
       }
 
@@ -3533,18 +3633,17 @@ class ClientHttp2Session extends Http2Session {
         if (header_status === HTTP_STATUS_CONTINUE) {
           stream.emit("continue");
         }
-        // CONTINUATION fragments of a multi-frame header block can arrive here
-        // without a :status (partial block). Don't consume StreamResponded yet.
-        if (header_status === undefined) {
-          return;
-        }
         // Informational 1xx headers don't count as final response
         if (header_status >= 100 && header_status < 200) {
-          stream.emit("headers", headers, flags, rawheaders);
+          stream.emit("headers", headers, flags, finalRaw);
           return;
         }
         stream[bunHTTP2StreamStatus] = status | StreamState.StreamResponded;
-        stream.emit("response", headers, flags, rawheaders);
+        // Node's client emits 'push' on ClientHttp2Stream when a pushed stream
+        // receives its final response headers. `stream` (session-level) was
+        // already fired for the push-promise request headers above, so we use
+        // 'push' here instead of 'response' to mirror Node's API.
+        stream.emit("push", headers, flags, finalRaw);
         return;
       }
 
@@ -3553,10 +3652,10 @@ class ClientHttp2Session extends Http2Session {
       }
 
       if ((status & StreamState.StreamResponded) !== 0) {
-        stream.emit("trailers", headers, flags, rawheaders);
+        stream.emit("trailers", headers, flags, finalRaw);
       } else {
         if (header_status >= 100 && header_status < 200) {
-          stream.emit("headers", headers, flags, rawheaders);
+          stream.emit("headers", headers, flags, finalRaw);
         } else {
           // Set the bit BEFORE dispatching synchronously to user code — a
           // 'response' handler that mutates stream state would otherwise be
@@ -3569,9 +3668,9 @@ class ClientHttp2Session extends Http2Session {
           }
           // Don't emit session 'stream' again for push streams (already emitted for push promise)
           if ((status & StreamState.PushPromiseReceived) === 0) {
-            self.emit("stream", stream, headers, flags, rawheaders);
+            self.emit("stream", stream, headers, flags, finalRaw);
           }
-          stream.emit("response", headers, flags, rawheaders);
+          stream.emit("response", headers, flags, finalRaw);
         }
       }
     },

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -325,9 +325,17 @@ const bunHTTP2Headers = Symbol.for("::bunhttp2headers::");
 // CONTINUATION frames). The native layer dispatches streamHeaders once per
 // fragment; we merge the raw name/value list + sensitive-name list here and
 // only emit the user-visible event when the END_HEADERS flag is present on
-// the current fragment.
+// the current fragment. `Flags` aggregates each fragment's flags bits so the
+// final emit sees END_STREAM / padding / etc. from the ORIGINAL HEADERS
+// frame, not just the CONTINUATION frame that carried END_HEADERS.
 const bunHTTP2PartialRawHeaders = Symbol("::bunhttp2partialrawheaders::");
 const bunHTTP2PartialSensitive = Symbol("::bunhttp2partialsensitive::");
+const bunHTTP2PartialFlags = Symbol("::bunhttp2partialflags::");
+// Inbound request headers saved on a ServerHttp2Stream for pushStream() to
+// derive `:authority` from. Separate from bunHTTP2Headers, which is populated
+// by respond() with the RESPONSE headers (for the `sentHeaders` getter) and
+// so has no `:authority` / `host`.
+const bunHTTP2RequestHeaders = Symbol("::bunhttp2requestheaders::");
 
 const ReflectGetPrototypeOf = Reflect.getPrototypeOf;
 
@@ -2128,6 +2136,11 @@ class Http2Stream extends Duplex {
     // of remoteSettings on ClientHttp2Stream; the base getter still returns
     // the peer's enablePush value for ServerHttp2Stream.
     if (!session[kServer]) return false;
+    // Mirror Node's lifecycle guards: a destroyed/closed stream or a
+    // closed/destroyed session cannot carry a PUSH_PROMISE regardless of
+    // SETTINGS_ENABLE_PUSH.
+    if (this.destroyed || this.closed) return false;
+    if (session.closed || session.destroyed) return false;
     // RFC 7540 Section 6.5.2: SETTINGS_ENABLE_PUSH has an initial value of 1.
     // If we have not yet received a SETTINGS frame from the peer, assume push
     // is enabled — the peer may still disable it in the first SETTINGS frame.
@@ -2547,8 +2560,14 @@ class ServerHttp2Stream extends Http2Stream {
     }
     if (pushHeaders[":authority"] === undefined) {
       // RFC 7540 Section 8.1.2.3 allows clients to use either :authority or
-      // the host header. Use getAuthority() which handles both forms.
-      const reqHeaders = this[bunHTTP2Headers];
+      // the host header. `bunHTTP2RequestHeaders` is populated by the server
+      // streamHeaders handler with the INBOUND request headers; using
+      // `bunHTTP2Headers` here would read the RESPONSE headers (set by
+      // respond()) which don't carry :authority/host. Fall back to the
+      // session's connecting origin when the inbound headers were somehow
+      // lost; the "localhost" tail is a last-resort only hit when nothing
+      // else is available (e.g. stream created by a test or mock).
+      const reqHeaders = this[bunHTTP2RequestHeaders];
       pushHeaders[":authority"] = (reqHeaders ? getAuthority(reqHeaders) : undefined) ?? "localhost";
     }
 
@@ -2592,12 +2611,10 @@ class ServerHttp2Stream extends Http2Stream {
     }
     if (streamId === -4) {
       // encoded_size > maxSendHeaderBlockLength. Node surfaces an equivalent
-      // condition on the regular request() path via a 'frameError' event.
-      // Report the same code via the callback so users can match on
+      // condition on the regular request() path via a 'frameError' event;
+      // use the same error code via the callback so users can match on
       // err.code rather than the less-specific PUSH_DISABLED.
-      const e = new Error("Frame size error") as Error & { code?: string };
-      e.code = "ERR_HTTP2_FRAME_ERROR";
-      process.nextTick(callback, e);
+      process.nextTick(callback, $ERR_HTTP2_FRAME_ERROR());
       return;
     }
     if (streamId < 0) {
@@ -2614,7 +2631,9 @@ class ServerHttp2Stream extends Http2Stream {
       pushStream[kHeadRequest] = true;
     }
 
-    process.nextTick(callback, null, pushStream, pushHeaders, finalOptions);
+    // Node's callback signature is (err, pushStream, headers) — three args.
+    // Don't forward finalOptions; it's stashed here only for validation.
+    process.nextTick(callback, null, pushStream, pushHeaders);
   }
 
   respondWithFile(path, headers, options) {
@@ -3096,10 +3115,13 @@ class ServerHttp2Session extends Http2Session {
       // Accumulate multi-frame header blocks (HEADERS + CONTINUATION). See
       // the matching comment in the client streamHeaders handler — the
       // native decoder dispatches once per fragment, we only surface the
-      // complete block to user code on END_HEADERS.
+      // complete block to user code on END_HEADERS. OR the flags across
+      // fragments so END_STREAM from the original HEADERS frame survives;
+      // CONTINUATION only ever carries END_HEADERS.
       const END_HEADERS = 0x4;
       const partialRaw = stream[bunHTTP2PartialRawHeaders];
       const partialSensitive = stream[bunHTTP2PartialSensitive];
+      const partialFlags = stream[bunHTTP2PartialFlags] ?? 0;
       let finalRaw: string[];
       let finalSensitive: string[];
       if (partialRaw !== undefined) {
@@ -3109,13 +3131,16 @@ class ServerHttp2Session extends Http2Session {
         finalRaw = rawheaders;
         finalSensitive = sensitiveHeadersValue || [];
       }
+      const mergedFlags = partialFlags | flags;
       if ((flags & END_HEADERS) === 0) {
         stream[bunHTTP2PartialRawHeaders] = finalRaw;
         stream[bunHTTP2PartialSensitive] = finalSensitive;
+        stream[bunHTTP2PartialFlags] = mergedFlags;
         return;
       }
       stream[bunHTTP2PartialRawHeaders] = undefined;
       stream[bunHTTP2PartialSensitive] = undefined;
+      stream[bunHTTP2PartialFlags] = undefined;
 
       const headers = toHeaderObject(finalRaw, finalSensitive);
       if (headers[HTTP2_HEADER_METHOD] === HTTP2_METHOD_HEAD) {
@@ -3123,8 +3148,13 @@ class ServerHttp2Session extends Http2Session {
       }
       const status = stream[bunHTTP2StreamStatus];
       if ((status & StreamState.StreamResponded) !== 0) {
-        stream.emit("trailers", headers, flags, finalRaw);
+        stream.emit("trailers", headers, mergedFlags, finalRaw);
       } else {
+        // Save the inbound request headers on the stream for pushStream()
+        // to derive :authority from (RFC 7540 Section 8.2.2). Distinct
+        // from bunHTTP2Headers which respond() uses for the response
+        // headers (for the `sentHeaders` getter).
+        stream[bunHTTP2RequestHeaders] = headers;
         // Set the StreamResponded bit BEFORE dispatching the 'stream' event
         // synchronously to user code. The user handler may call
         // stream.respond()/stream.end() which set other bits (WantTrailer,
@@ -3133,8 +3163,8 @@ class ServerHttp2Session extends Http2Session {
         // user handler — in particular, losing WantTrailer/FinalCalled breaks
         // any later `sendTrailers()` with ERR_HTTP2_TRAILERS_NOT_READY.
         stream[bunHTTP2StreamStatus] |= StreamState.StreamResponded;
-        self[kServer].emit("stream", stream, headers, flags, finalRaw);
-        self.emit("stream", stream, headers, flags, finalRaw);
+        self[kServer].emit("stream", stream, headers, mergedFlags, finalRaw);
+        self.emit("stream", stream, headers, mergedFlags, finalRaw);
       }
     },
     localSettings(self: ServerHttp2Session, settings: Settings) {
@@ -3629,10 +3659,13 @@ class ClientHttp2Session extends Http2Session {
       // block to user code on the frame carrying END_HEADERS — without this,
       // custom request/response headers that land in a CONTINUATION fragment
       // are silently lost (partial `response` event, stale `trailers`, or
-      // missing push-promise metadata).
+      // missing push-promise metadata). OR the flags across fragments so
+      // END_STREAM from the original HEADERS frame is preserved (CONTINUATION
+      // only carries END_HEADERS).
       const END_HEADERS = 0x4;
       const partialRaw = stream[bunHTTP2PartialRawHeaders];
       const partialSensitive = stream[bunHTTP2PartialSensitive];
+      const partialFlags = stream[bunHTTP2PartialFlags] ?? 0;
       let finalRaw: string[];
       let finalSensitive: string[];
       if (partialRaw !== undefined) {
@@ -3642,13 +3675,16 @@ class ClientHttp2Session extends Http2Session {
         finalRaw = rawheaders;
         finalSensitive = sensitiveHeadersValue || [];
       }
+      const mergedFlags = partialFlags | flags;
       if ((flags & END_HEADERS) === 0) {
         stream[bunHTTP2PartialRawHeaders] = finalRaw;
         stream[bunHTTP2PartialSensitive] = finalSensitive;
+        stream[bunHTTP2PartialFlags] = mergedFlags;
         return;
       }
       stream[bunHTTP2PartialRawHeaders] = undefined;
       stream[bunHTTP2PartialSensitive] = undefined;
+      stream[bunHTTP2PartialFlags] = undefined;
 
       const headers = toHeaderObject(finalRaw, finalSensitive);
       const status = stream[bunHTTP2StreamStatus];
@@ -3657,7 +3693,7 @@ class ClientHttp2Session extends Http2Session {
       // Push promise request headers: even stream ID, no PushPromiseReceived yet, no :status
       if (stream.id % 2 === 0 && (status & StreamState.PushPromiseReceived) === 0 && header_status === undefined) {
         stream[bunHTTP2StreamStatus] = status | StreamState.PushPromiseReceived;
-        self.emit("stream", stream, headers, flags, finalRaw);
+        self.emit("stream", stream, headers, mergedFlags, finalRaw);
         return;
       }
 
@@ -3668,7 +3704,7 @@ class ClientHttp2Session extends Http2Session {
         }
         // Informational 1xx headers don't count as final response
         if (header_status >= 100 && header_status < 200) {
-          stream.emit("headers", headers, flags, finalRaw);
+          stream.emit("headers", headers, mergedFlags, finalRaw);
           return;
         }
         stream[bunHTTP2StreamStatus] = status | StreamState.StreamResponded;
@@ -3676,7 +3712,7 @@ class ClientHttp2Session extends Http2Session {
         // receives its final response headers. `stream` (session-level) was
         // already fired for the push-promise request headers above, so we use
         // 'push' here instead of 'response' to mirror Node's API.
-        stream.emit("push", headers, flags, finalRaw);
+        stream.emit("push", headers, mergedFlags, finalRaw);
         return;
       }
 
@@ -3685,10 +3721,10 @@ class ClientHttp2Session extends Http2Session {
       }
 
       if ((status & StreamState.StreamResponded) !== 0) {
-        stream.emit("trailers", headers, flags, finalRaw);
+        stream.emit("trailers", headers, mergedFlags, finalRaw);
       } else {
         if (header_status >= 100 && header_status < 200) {
-          stream.emit("headers", headers, flags, finalRaw);
+          stream.emit("headers", headers, mergedFlags, finalRaw);
         } else {
           // Set the bit BEFORE dispatching synchronously to user code — a
           // 'response' handler that mutates stream state would otherwise be
@@ -3701,9 +3737,9 @@ class ClientHttp2Session extends Http2Session {
           }
           // Don't emit session 'stream' again for push streams (already emitted for push promise)
           if ((status & StreamState.PushPromiseReceived) === 0) {
-            self.emit("stream", stream, headers, flags, finalRaw);
+            self.emit("stream", stream, headers, mergedFlags, finalRaw);
           }
-          stream.emit("response", headers, flags, finalRaw);
+          stream.emit("response", headers, mergedFlags, finalRaw);
         }
       }
     },

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2116,8 +2116,11 @@ class Http2Stream extends Duplex {
   get pushAllowed() {
     const session = this[bunHTTP2Session];
     if (!session) return false;
+    // RFC 7540 Section 6.5.2: SETTINGS_ENABLE_PUSH has an initial value of 1.
+    // If we have not yet received a SETTINGS frame from the peer, assume push
+    // is enabled — the peer may still disable it in the first SETTINGS frame.
     const remoteSettings = session.remoteSettings;
-    if (!remoteSettings) return false;
+    if (!remoteSettings) return true;
     return remoteSettings.enablePush !== false;
   }
   close(code, callback) {

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -2472,6 +2472,8 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP2_PUSH_DISABLED, "HTTP/2 client has disabled push streams"_s));
     case ErrorCode::ERR_HTTP2_NESTED_PUSH:
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP2_NESTED_PUSH, "A push stream cannot itself initiate a new push stream."_s));
+    case ErrorCode::ERR_HTTP2_FRAME_ERROR:
+        return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP2_FRAME_ERROR, "Error sending frame"_s));
     case ErrorCode::ERR_HTTP2_HEADERS_AFTER_RESPOND:
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP2_HEADERS_AFTER_RESPOND, "Cannot specify additional headers after response initiated"_s));
     case ErrorCode::ERR_HTTP2_STATUS_101:

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -2470,6 +2470,8 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP2_SEND_FILE_NOSEEK, "Offset or length can only be specified for regular files"_s));
     case ErrorCode::ERR_HTTP2_PUSH_DISABLED:
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP2_PUSH_DISABLED, "HTTP/2 client has disabled push streams"_s));
+    case ErrorCode::ERR_HTTP2_NESTED_PUSH:
+        return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP2_NESTED_PUSH, "A push stream cannot itself initiate a new push stream."_s));
     case ErrorCode::ERR_HTTP2_HEADERS_AFTER_RESPOND:
         return JSC::JSValue::encode(createError(globalObject, ErrorCode::ERR_HTTP2_HEADERS_AFTER_RESPOND, "Cannot specify additional headers after response initiated"_s));
     case ErrorCode::ERR_HTTP2_STATUS_101:

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -95,6 +95,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_HTTP2_CONNECT_SCHEME", Error],
   ["ERR_HTTP2_CONNECT_PATH", Error],
   ["ERR_HTTP2_ERROR", Error],
+  ["ERR_HTTP2_FRAME_ERROR", Error],
   ["ERR_HTTP2_HEADER_SINGLE_VALUE", TypeError],
   ["ERR_HTTP2_HEADERS_AFTER_RESPOND", Error],
   ["ERR_HTTP2_HEADERS_SENT", Error],

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -106,6 +106,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_HTTP2_INVALID_SESSION", Error],
   ["ERR_HTTP2_INVALID_STREAM", Error],
   ["ERR_HTTP2_MAX_PENDING_SETTINGS_ACK", Error],
+  ["ERR_HTTP2_NESTED_PUSH", Error],
   ["ERR_HTTP2_NO_SOCKET_MANIPULATION", Error],
   ["ERR_HTTP2_ORIGIN_LENGTH", TypeError],
   ["ERR_HTTP2_OUT_OF_STREAMS", Error],

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -7139,6 +7139,29 @@ impl H2FrameParser {
         Ok(JSValue::js_number(stream_id as f64))
     }
 
+    /// RFC 7540 Section 6.6: Send a PUSH_PROMISE frame from the server.
+    /// Takes: original_stream_id, headers, sensitiveHeaders
+    /// Returns: the promised stream ID, or a negative sentinel on error:
+    ///   -1 = peer disabled push via SETTINGS
+    ///   -2 = stream ID space exhausted
+    ///   -3 = parent stream state invalid
+    ///   -4 = header block exceeds maxSendHeaderBlockLength
+    ///
+    /// NOTE: this is a stub for the Rust port — full implementation still
+    /// lives in the Zig version. Returns -1 (push disabled) so the JS
+    /// layer surfaces ERR_HTTP2_PUSH_DISABLED to the user instead of a
+    /// type error or silent failure.
+    #[bun_jsc::host_fn(method)]
+    pub fn send_push_promise(
+        this: &Self,
+        _global_object: &JSGlobalObject,
+        _callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let _ = this;
+        bun_output::scoped_log!(H2FrameParser, "sendPushPromise (stub)");
+        Ok(JSValue::js_number(-1.0))
+    }
+
     #[bun_jsc::host_fn(method)]
     pub fn read(
         this: &Self,

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -2363,6 +2363,78 @@ pub const H2FrameParser = struct {
         return data.len;
     }
 
+    /// RFC 7540 Section 6.6: Handle PUSH_PROMISE frame (type=0x5).
+    /// PUSH_PROMISE frames are sent by the server to notify the client that
+    /// it intends to initiate a new stream for a server push.
+    /// Format: [Pad Length (1)?] [R + Promised Stream ID (4)] [Header Block Fragment (*)] [Padding (*)]
+    pub fn handlePushPromiseFrame(this: *H2FrameParser, frame: FrameHeader, data: []const u8, stream_: ?*Stream) bun.JSError!usize {
+        log("handlePushPromiseFrame {s}", .{if (this.isServer) "server" else "client"});
+        _ = stream_ orelse {
+            this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "PUSH_PROMISE on connection stream", this.lastStreamID, true);
+            return data.len;
+        };
+
+        // Servers must not receive PUSH_PROMISE frames
+        if (this.isServer) {
+            this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Server received PUSH_PROMISE", this.lastStreamID, true);
+            return data.len;
+        }
+
+        // Check if push is enabled in local settings
+        if (this.localSettings.enablePush == 0) {
+            this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Push is disabled", this.lastStreamID, true);
+            return data.len;
+        }
+
+        const settings = this.remoteSettings orelse this.localSettings;
+        if (frame.length > settings.maxFrameSize) {
+            this.sendGoAway(frame.streamIdentifier, ErrorCode.FRAME_SIZE_ERROR, "invalid PUSH_PROMISE frame size", this.lastStreamID, true);
+            return data.len;
+        }
+
+        if (handleIncommingPayload(this, data, frame.streamIdentifier)) |content| {
+            const payload = content.data;
+            var offset: usize = 0;
+            var padding: usize = 0;
+            this.readBuffer.reset();
+
+            if (frame.flags & @intFromEnum(HeadersFrameFlags.PADDED) != 0) {
+                padding = payload[0];
+                offset += 1;
+            }
+
+            // Parse the 4-byte promised stream ID
+            if (payload.len < offset + 4) {
+                this.sendGoAway(frame.streamIdentifier, ErrorCode.FRAME_SIZE_ERROR, "PUSH_PROMISE too short for promised stream ID", this.lastStreamID, true);
+                return content.end;
+            }
+            const promised_id = UInt31WithReserved.fromBytes(payload[offset..][0..4]);
+            offset += 4;
+
+            const end = payload.len - padding;
+            if (offset > end) {
+                this.sendGoAway(frame.streamIdentifier, ErrorCode.FRAME_SIZE_ERROR, "invalid PUSH_PROMISE frame size", this.lastStreamID, true);
+                return content.end;
+            }
+
+            // Create the promised stream
+            const promised_stream = this.handleReceivedStreamID(promised_id.uint31) orelse {
+                return content.end;
+            };
+            promised_stream.state = .RESERVED_REMOTE;
+
+            // Decode the header block on the promised stream
+            _ = (try this.decodeHeaderBlock(payload[offset..end], promised_stream, frame.flags)) orelse {
+                return content.end;
+            };
+
+            return content.end;
+        }
+
+        // needs more data
+        return data.len;
+    }
+
     pub fn handleHeadersFrame(this: *H2FrameParser, frame: FrameHeader, data: []const u8, stream_: ?*Stream) bun.JSError!usize {
         log("handleHeadersFrame {s}", .{if (this.isServer) "server" else "client"});
         var stream = stream_ orelse {
@@ -2626,6 +2698,7 @@ pub const H2FrameParser = struct {
                 @intFromEnum(FrameType.HTTP_FRAME_RST_STREAM) => this.handleRSTStreamFrame(header, bytes, stream),
                 @intFromEnum(FrameType.HTTP_FRAME_ALTSVC) => this.handleAltsvcFrame(header, bytes, stream),
                 @intFromEnum(FrameType.HTTP_FRAME_ORIGIN) => this.handleOriginFrame(header, bytes, stream),
+                @intFromEnum(FrameType.HTTP_FRAME_PUSH_PROMISE) => this.handlePushPromiseFrame(header, bytes, stream),
                 else => {
                     this.sendGoAway(header.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Unknown frame type", this.lastStreamID, true);
                     return bytes.len;
@@ -2675,6 +2748,7 @@ pub const H2FrameParser = struct {
                 @intFromEnum(FrameType.HTTP_FRAME_RST_STREAM) => this.handleRSTStreamFrame(header, bytes[needed..], stream) + needed,
                 @intFromEnum(FrameType.HTTP_FRAME_ALTSVC) => (try this.handleAltsvcFrame(header, bytes[needed..], stream)) + needed,
                 @intFromEnum(FrameType.HTTP_FRAME_ORIGIN) => (try this.handleOriginFrame(header, bytes[needed..], stream)) + needed,
+                @intFromEnum(FrameType.HTTP_FRAME_PUSH_PROMISE) => (try this.handlePushPromiseFrame(header, bytes[needed..], stream)) + needed,
                 else => {
                     this.sendGoAway(header.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Unknown frame type", this.lastStreamID, true);
                     return bytes.len;
@@ -2708,6 +2782,7 @@ pub const H2FrameParser = struct {
             @intFromEnum(FrameType.HTTP_FRAME_RST_STREAM) => this.handleRSTStreamFrame(header, bytes[FrameHeader.byteSize..], stream) + FrameHeader.byteSize,
             @intFromEnum(FrameType.HTTP_FRAME_ALTSVC) => (try this.handleAltsvcFrame(header, bytes[FrameHeader.byteSize..], stream)) + FrameHeader.byteSize,
             @intFromEnum(FrameType.HTTP_FRAME_ORIGIN) => (try this.handleOriginFrame(header, bytes[FrameHeader.byteSize..], stream)) + FrameHeader.byteSize,
+            @intFromEnum(FrameType.HTTP_FRAME_PUSH_PROMISE) => (try this.handlePushPromiseFrame(header, bytes[FrameHeader.byteSize..], stream)) + FrameHeader.byteSize,
             else => {
                 this.sendGoAway(header.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Unknown frame type", this.lastStreamID, true);
                 return bytes.len;
@@ -4534,6 +4609,199 @@ pub const H2FrameParser = struct {
         }
 
         return jsc.JSValue.jsNumber(stream_id);
+    }
+
+    /// RFC 7540 Section 6.6: Send a PUSH_PROMISE frame from the server.
+    /// Takes: original_stream_id, headers, sensitiveHeaders
+    /// Returns: the promised stream ID (even-numbered), or -1 on error.
+    pub fn sendPushPromise(this: *H2FrameParser, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+        jsc.markBinding(@src());
+        log("sendPushPromise", .{});
+
+        const args_list = callframe.arguments_old(3);
+        if (args_list.len < 3) {
+            return globalObject.throw("Expected original_stream_id, headers and sensitiveHeaders arguments", .{});
+        }
+
+        const orig_stream_id_arg = args_list.ptr[0];
+        const headers_arg = args_list.ptr[1];
+        const sensitive_arg = args_list.ptr[2];
+
+        if (!orig_stream_id_arg.isNumber()) {
+            return globalObject.throw("Expected original_stream_id to be a number", .{});
+        }
+        const orig_stream_id: u32 = orig_stream_id_arg.to(u32);
+
+        // Verify original stream exists
+        _ = this.streams.getPtr(orig_stream_id) orelse {
+            return globalObject.throw("Invalid original stream id", .{});
+        };
+
+        // Check remote settings allow push
+        if (this.remoteSettings) |rs| {
+            if (rs.enablePush == 0) {
+                return jsc.JSValue.jsNumber(-1);
+            }
+        }
+
+        const headers_obj = headers_arg.getObject() orelse {
+            return globalObject.throw("Expected headers to be an object", .{});
+        };
+
+        if (!sensitive_arg.isObject()) {
+            return globalObject.throw("Expected sensitiveHeaders to be an object", .{});
+        }
+
+        // Encode headers with HPACK
+        var buf_fallback = bun.allocators.BufferFallbackAllocator.init(&shared_request_buffer, bun.default_allocator);
+        const alloc = buf_fallback.allocator();
+        var encoded_headers = std.ArrayListUnmanaged(u8){};
+        defer encoded_headers.deinit(alloc);
+        encoded_headers.ensureTotalCapacity(alloc, shared_request_buffer.len) catch {
+            return globalObject.throw("Failed to allocate header buffer", .{});
+        };
+        var name_buffer: [4096]u8 = undefined;
+        @memset(&name_buffer, 0);
+
+        // Allocate the promised stream ID (even-numbered for server push)
+        const promised_stream_id = this.getNextStreamID();
+        if (promised_stream_id > MAX_STREAM_ID) {
+            return jsc.JSValue.jsNumber(-1);
+        }
+
+        // Encode headers - pseudo-headers first, then regular headers
+        var iter = try jsc.JSPropertyIterator(.{
+            .skip_empty_name = false,
+            .include_value = true,
+        }).init(globalObject, headers_obj);
+        defer iter.deinit();
+        var single_value_headers: [SingleValueHeaders.keys().len]bool = undefined;
+        @memset(&single_value_headers, false);
+
+        for (0..2) |ignore_pseudo_headers| {
+            iter.reset();
+            while (try iter.next()) |header_name| {
+                if (header_name.length() == 0) continue;
+                const name_slice = header_name.toUTF8(bun.default_allocator);
+                defer name_slice.deinit();
+                const name = name_slice.slice();
+                const validated_name = toValidHeaderName(name, name_buffer[0..name.len]) catch {
+                    const exception = globalObject.toTypeError(.INVALID_HTTP_TOKEN, "The arguments Header name is invalid. Received \"{s}\"", .{name});
+                    return globalObject.throwValue(exception);
+                };
+
+                if (header_name.charAt(0) == ':') {
+                    if (ignore_pseudo_headers == 1) continue;
+                    // Push promise headers are request pseudo-headers
+                    if (!ValidRequestPseudoHeaders.has(validated_name)) {
+                        if (!globalObject.hasException()) {
+                            return globalObject.ERR(.HTTP2_INVALID_PSEUDOHEADER, "\"{s}\" is an invalid pseudoheader or is used incorrectly", .{name}).throw();
+                        }
+                        return .zero;
+                    }
+                } else if (ignore_pseudo_headers == 0) {
+                    continue;
+                }
+
+                const js_value = iter.value;
+                if (js_value.isUndefinedOrNull()) {
+                    const exception = globalObject.toTypeError(.HTTP2_INVALID_HEADER_VALUE, "Invalid value for header \"{s}\"", .{name});
+                    return globalObject.throwValue(exception);
+                }
+
+                if (!js_value.isEmptyOrUndefinedOrNull()) {
+                    if (SingleValueHeaders.indexOf(validated_name)) |idx| {
+                        if (single_value_headers[idx]) {
+                            const exception = globalObject.toTypeError(.HTTP2_HEADER_SINGLE_VALUE, "Header field \"{s}\" must only have a single value", .{validated_name});
+                            return globalObject.throwValue(exception);
+                        }
+                        single_value_headers[idx] = true;
+                    }
+                    const value_str = js_value.toJSString(globalObject) catch {
+                        globalObject.clearException();
+                        return globalObject.ERR(.HTTP2_INVALID_HEADER_VALUE, "Invalid value for header \"{s}\"", .{name}).throw();
+                    };
+                    const never_index = (try sensitive_arg.getTruthyPropertyValue(globalObject, validated_name) orelse try sensitive_arg.getTruthyPropertyValue(globalObject, name)) != null;
+                    const value_slice = value_str.toSlice(globalObject, bun.default_allocator);
+                    defer value_slice.deinit();
+                    const value = value_slice.slice();
+
+                    _ = this.encodeHeaderIntoList(&encoded_headers, alloc, validated_name, value, never_index) catch {
+                        return globalObject.throw("Failed to encode header", .{});
+                    };
+                }
+            }
+        }
+
+        const encoded_data = encoded_headers.items;
+        const encoded_size = encoded_data.len;
+
+        // Create the promised stream in RESERVED_LOCAL state
+        const promised_stream = this.handleReceivedStreamID(promised_stream_id) orelse {
+            return jsc.JSValue.jsNumber(-1);
+        };
+        promised_stream.state = .RESERVED_LOCAL;
+
+        // Build and send PUSH_PROMISE frame
+        const actual_max_frame_size = (this.remoteSettings orelse this.localSettings).maxFrameSize;
+        // PUSH_PROMISE payload: 4 bytes promised stream ID + encoded headers
+        const promised_id_size: usize = 4;
+        const available_payload = actual_max_frame_size - promised_id_size;
+
+        const writer = this.toWriter();
+
+        if (encoded_size <= available_payload) {
+            // Single PUSH_PROMISE frame
+            const payload_size = promised_id_size + encoded_size;
+            var frame: FrameHeader = .{
+                .type = @intFromEnum(FrameType.HTTP_FRAME_PUSH_PROMISE),
+                .flags = @intFromEnum(HeadersFrameFlags.END_HEADERS),
+                .streamIdentifier = orig_stream_id,
+                .length = @intCast(payload_size),
+            };
+            _ = frame.write(@TypeOf(writer), writer);
+
+            // Write promised stream ID (4 bytes)
+            var promised_id = UInt31WithReserved.init(@intCast(promised_stream_id), false);
+            _ = promised_id.write(@TypeOf(writer), writer);
+
+            // Write encoded headers
+            _ = writer.write(encoded_data) catch 0;
+        } else {
+            // PUSH_PROMISE + CONTINUATION frames
+            const first_chunk_size = available_payload;
+            var pp_frame: FrameHeader = .{
+                .type = @intFromEnum(FrameType.HTTP_FRAME_PUSH_PROMISE),
+                .flags = 0, // no END_HEADERS yet
+                .streamIdentifier = orig_stream_id,
+                .length = @intCast(promised_id_size + first_chunk_size),
+            };
+            _ = pp_frame.write(@TypeOf(writer), writer);
+
+            var promised_id = UInt31WithReserved.init(@intCast(promised_stream_id), false);
+            _ = promised_id.write(@TypeOf(writer), writer);
+            _ = writer.write(encoded_data[0..first_chunk_size]) catch 0;
+
+            // CONTINUATION frames for remaining data
+            var offset: usize = first_chunk_size;
+            while (offset < encoded_size) {
+                const remaining = encoded_size - offset;
+                const chunk_size = @min(remaining, actual_max_frame_size);
+                const is_last = (offset + chunk_size >= encoded_size);
+
+                var cont_frame: FrameHeader = .{
+                    .type = @intFromEnum(FrameType.HTTP_FRAME_CONTINUATION),
+                    .flags = if (is_last) @intFromEnum(HeadersFrameFlags.END_HEADERS) else 0,
+                    .streamIdentifier = orig_stream_id,
+                    .length = @intCast(chunk_size),
+                };
+                _ = cont_frame.write(@TypeOf(writer), writer);
+                _ = writer.write(encoded_data[offset..][0..chunk_size]) catch 0;
+                offset += chunk_size;
+            }
+        }
+
+        return jsc.JSValue.jsNumber(promised_stream_id);
     }
 
     pub fn read(this: *H2FrameParser, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -2462,35 +2462,20 @@ pub const H2FrameParser = struct {
                 if (stream.endAfterHeaders) {
                     const identifier = stream.getIdentifier();
                     identifier.ensureStillAlive();
-                    // The preceding HEADERS frame with END_STREAM=1 + END_HEADERS=0
-                    // already transitioned this stream to HALF_CLOSED_REMOTE (see
-                    // handleHeadersFrame's `isWaitingMoreHeaders` branch). Here we
-                    // need to finalise it now that the block is complete:
-                    //   - Client: HALF_CLOSED_REMOTE → CLOSED. The client is either
-                    //     receiving a bodyless response on a stream it already
-                    //     sent END_STREAM on (HALF_CLOSED_LOCAL → HALF_CLOSED_REMOTE
-                    //     in the preceding frame) or a push-stream response, and in
-                    //     both cases there is nothing more to send locally.
-                    //   - Server: HALF_CLOSED_REMOTE must stay open so the user's
-                    //     async handler can still call respond(). Dropping here
-                    //     would destroy the stream before the response could be
-                    //     written, matching the single-frame HEADERS path at
-                    //     handleHeadersFrame.
-                    //   - HALF_CLOSED_LOCAL / RESERVED_REMOTE: client stream whose
-                    //     local side already ended; → CLOSED (defensive — with
-                    //     the HEADERS-side overwrite in place, this is rarely hit).
-                    //   - anything else: fall through to HALF_CLOSED_LOCAL.
+                    // Matches the non-waiting arm of handleHeadersFrame exactly.
+                    // The preceding HEADERS(END_STREAM=1, END_HEADERS=0) left
+                    // HALF_CLOSED_LOCAL / RESERVED_REMOTE in place (see the
+                    // `isWaitingMoreHeaders` branch in handleHeadersFrame), so a
+                    // client stream whose local side already ended (normal
+                    // request + server response, or push-stream receive) reaches
+                    // CLOSED here; an OPEN stream (client still writing a
+                    // request body, or server pre-respond) stays in
+                    // HALF_CLOSED_REMOTE so the writable side is not destroyed.
                     if (stream.state == .HALF_CLOSED_LOCAL or stream.state == .RESERVED_REMOTE) {
                         stream.state = .CLOSED;
                         stream.freeResources(this, false);
-                    } else if (stream.state == .HALF_CLOSED_REMOTE) {
-                        if (!this.isServer) {
-                            stream.state = .CLOSED;
-                            stream.freeResources(this, false);
-                        }
-                        // else: server — leave HALF_CLOSED_REMOTE for respond()
-                    } else {
-                        stream.state = .HALF_CLOSED_LOCAL;
+                    } else if (stream.state != .HALF_CLOSED_REMOTE) {
+                        stream.state = .HALF_CLOSED_REMOTE;
                     }
                     this.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(stream.state)));
                 }
@@ -2737,7 +2722,17 @@ pub const H2FrameParser = struct {
                 identifier.ensureStillAlive();
 
                 if (stream.isWaitingMoreHeaders) {
-                    stream.state = .HALF_CLOSED_REMOTE;
+                    // HEADERS(END_STREAM=1) + END_HEADERS=0: remote is done, but
+                    // we need more CONTINUATION frames to finish the block. Do
+                    // NOT overwrite HALF_CLOSED_LOCAL/RESERVED_REMOTE — those
+                    // carry the local-side-already-ended bit that the matching
+                    // CONTINUATION END_STREAM path needs to transition to CLOSED.
+                    // For OPEN (client still writing a request body, or server
+                    // pre-respond) stay at HALF_CLOSED_REMOTE so the writable
+                    // side is not prematurely destroyed.
+                    if (stream.state != .HALF_CLOSED_LOCAL and stream.state != .RESERVED_REMOTE) {
+                        stream.state = .HALF_CLOSED_REMOTE;
+                    }
                 } else {
                     // Client-side push streams start in RESERVED_REMOTE and
                     // go straight to CLOSED on END_STREAM from the remote.

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -2347,22 +2347,45 @@ pub const H2FrameParser = struct {
             const promised_entry = this.streams.getEntry(this.continuation_promised_stream_id);
             if (promised_entry) |entry| {
                 const promised_stream = entry.value_ptr;
+                const parent_id = frame.streamIdentifier;
                 if (handleIncommingPayload(this, data, frame.streamIdentifier)) |content| {
                     const payload = content.data;
                     this.readBuffer.reset();
-                    _ = (try this.decodeHeaderBlock(payload[0..payload.len], promised_stream, frame.flags)) orelse {
+                    const maybe_result = try this.decodeHeaderBlock(payload[0..payload.len], promised_stream, frame.flags);
+                    // decodeHeaderBlock fires JS callbacks which may grow the
+                    // streams HashMap and invalidate any prior *Stream pointer.
+                    // Always re-fetch the parent by id before touching it.
+                    if (maybe_result == null) {
+                        // Promised stream removed during callbacks — clear all
+                        // continuation state so future frames aren't misrouted.
+                        this.continuation_promised_stream_id = 0;
+                        if (this.streams.getPtr(parent_id)) |p| {
+                            p.isWaitingMoreHeaders = false;
+                        }
                         return content.end;
-                    };
+                    }
                     if (frame.flags & @intFromEnum(HeadersFrameFlags.END_HEADERS) != 0) {
-                        stream.isWaitingMoreHeaders = false;
+                        if (this.streams.getPtr(parent_id)) |p| {
+                            p.isWaitingMoreHeaders = false;
+                        }
                         this.continuation_promised_stream_id = 0;
                     }
                     return content.end;
                 }
                 return data.len;
             }
-            // Promised stream vanished; fall through to normal handling.
+            // Promised stream vanished before data arrived. Consume the
+            // fragment, clear waiting state on the parent, and move on —
+            // the header block can't be routed anywhere meaningful.
             this.continuation_promised_stream_id = 0;
+            if (this.streams.getPtr(frame.streamIdentifier)) |p| {
+                p.isWaitingMoreHeaders = false;
+            }
+            if (handleIncommingPayload(this, data, frame.streamIdentifier)) |content| {
+                this.readBuffer.reset();
+                return content.end;
+            }
+            return data.len;
         }
 
         if (handleIncommingPayload(this, data, frame.streamIdentifier)) |content| {
@@ -2404,11 +2427,26 @@ pub const H2FrameParser = struct {
         // NOTE: Do NOT hold on to the parent_stream pointer — calling
         // handleReceivedStreamID() below can grow the streams HashMap and
         // invalidate it. We re-fetch by id when we need to write to the parent.
-        _ = stream_ orelse {
+        const parent_stream = stream_ orelse {
             this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "PUSH_PROMISE on connection stream", this.lastStreamID, true);
             return data.len;
         };
         const parent_stream_id = frame.streamIdentifier;
+
+        // RFC 7540 Section 6.10: After a frame without END_HEADERS the only
+        // permissible next frame type is CONTINUATION. Reject a PUSH_PROMISE
+        // that arrives mid-CONTINUATION sequence.
+        if (parent_stream.isWaitingMoreHeaders) {
+            this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "PUSH_PROMISE mid-CONTINUATION", this.lastStreamID, true);
+            return data.len;
+        }
+
+        // RFC 7540 Section 6.6: PUSH_PROMISE MUST only be received on a stream
+        // that is in the "open" or "half-closed (local)" state.
+        if (parent_stream.state != .OPEN and parent_stream.state != .HALF_CLOSED_LOCAL) {
+            this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "PUSH_PROMISE on non-open parent stream", this.lastStreamID, true);
+            return data.len;
+        }
 
         // Servers must not receive PUSH_PROMISE frames
         if (this.isServer) {
@@ -4858,10 +4896,21 @@ pub const H2FrameParser = struct {
         const encoded_data = encoded_headers.items;
         const encoded_size = encoded_data.len;
 
-        // Create the promised stream in RESERVED_LOCAL state
+        // Create the promised stream in RESERVED_LOCAL state.
+        // IMPORTANT: handleReceivedStreamID unconditionally advances
+        // this.lastStreamID to any id larger than its current value. For
+        // server push we allocate even ids, but lastStreamID tracks the
+        // highest *peer-initiated* stream the session has seen (used as
+        // the Last-Stream-ID field in GOAWAY per RFC 7540 Section 6.8). If we
+        // let push ids bump it, GOAWAY would falsely claim we processed
+        // client streams up to the push id, leading clients to silently
+        // drop in-flight odd-numbered streams. Save and restore around the
+        // call so only the new stream gets registered.
+        const saved_last_stream_id = this.lastStreamID;
         const promised_stream = this.handleReceivedStreamID(promised_stream_id) orelse {
             return jsc.JSValue.jsNumber(-1);
         };
+        this.lastStreamID = saved_last_stream_id;
         promised_stream.state = .RESERVED_LOCAL;
 
         // Build and send PUSH_PROMISE frame

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -2462,19 +2462,34 @@ pub const H2FrameParser = struct {
                 if (stream.endAfterHeaders) {
                     const identifier = stream.getIdentifier();
                     identifier.ensureStillAlive();
-                    // Mirror the state transitions in handleHeadersFrame's
-                    // END_STREAM path. The prior HEADERS frame already set
-                    // the stream to HALF_CLOSED_REMOTE when END_STREAM is
-                    // accompanied by END_HEADERS=0, so:
-                    //   - HALF_CLOSED_REMOTE: on the server this stays open
-                    //     for the local response; do NOT transition to CLOSED.
-                    //   - HALF_CLOSED_LOCAL / RESERVED_REMOTE: client push
-                    //     stream whose local side already ended → CLOSED.
+                    // The preceding HEADERS frame with END_STREAM=1 + END_HEADERS=0
+                    // already transitioned this stream to HALF_CLOSED_REMOTE (see
+                    // handleHeadersFrame's `isWaitingMoreHeaders` branch). Here we
+                    // need to finalise it now that the block is complete:
+                    //   - Client: HALF_CLOSED_REMOTE → CLOSED. The client is either
+                    //     receiving a bodyless response on a stream it already
+                    //     sent END_STREAM on (HALF_CLOSED_LOCAL → HALF_CLOSED_REMOTE
+                    //     in the preceding frame) or a push-stream response, and in
+                    //     both cases there is nothing more to send locally.
+                    //   - Server: HALF_CLOSED_REMOTE must stay open so the user's
+                    //     async handler can still call respond(). Dropping here
+                    //     would destroy the stream before the response could be
+                    //     written, matching the single-frame HEADERS path at
+                    //     handleHeadersFrame.
+                    //   - HALF_CLOSED_LOCAL / RESERVED_REMOTE: client stream whose
+                    //     local side already ended; → CLOSED (defensive — with
+                    //     the HEADERS-side overwrite in place, this is rarely hit).
                     //   - anything else: fall through to HALF_CLOSED_LOCAL.
                     if (stream.state == .HALF_CLOSED_LOCAL or stream.state == .RESERVED_REMOTE) {
                         stream.state = .CLOSED;
                         stream.freeResources(this, false);
-                    } else if (stream.state != .HALF_CLOSED_REMOTE) {
+                    } else if (stream.state == .HALF_CLOSED_REMOTE) {
+                        if (!this.isServer) {
+                            stream.state = .CLOSED;
+                            stream.freeResources(this, false);
+                        }
+                        // else: server — leave HALF_CLOSED_REMOTE for respond()
+                    } else {
                         stream.state = .HALF_CLOSED_LOCAL;
                     }
                     this.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(stream.state)));

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -681,6 +681,11 @@ pub const H2FrameParser = struct {
     // pollutes lastStreamID (which is used for GOAWAY Last-Stream-ID and for
     // allocating the next client-initiated stream).
     lastPushStreamID: u32 = 0,
+    // Client-side monotonicity guard for inbound PUSH_PROMISE. Section 5.1.1
+    // requires the peer to use numerically increasing stream identifiers;
+    // we reject any promised stream id <= the highest we have accepted so
+    // far so a server cannot reuse a lower even id after advancing.
+    highestReceivedPushPromiseID: u32 = 0,
     // RFC 7540 Section 6.10: CONTINUATION frames after PUSH_PROMISE carry the
     // parent stream identifier, but the header block belongs to the promised
     // stream. Track both the promised stream ID (decode target) and the
@@ -1912,7 +1917,17 @@ pub const H2FrameParser = struct {
     }
 
     pub fn decodeHeaderBlock(this: *H2FrameParser, payload: []const u8, stream: *Stream, flags: u8) bun.JSError!?*Stream {
-        log("decodeHeaderBlock isSever: {}", .{this.isServer});
+        return this.decodeHeaderBlockInternal(payload, stream, flags, false);
+    }
+
+    /// `is_push_promise=true` requests request-header validation semantics for
+    /// the header block even on the client side — PUSH_PROMISE carries the
+    /// associated request headers, so response-only pseudo-headers like
+    /// `:status` are illegal and must produce a PROTOCOL_ERROR (RFC 7540
+    /// §8.1.2.1, §8.2.1). Without this the peer could misroute the stream by
+    /// injecting `:status` into a PUSH_PROMISE.
+    pub fn decodeHeaderBlockInternal(this: *H2FrameParser, payload: []const u8, stream: *Stream, flags: u8, is_push_promise: bool) bun.JSError!?*Stream {
+        log("decodeHeaderBlock isSever: {} is_push_promise: {}", .{ this.isServer, is_push_promise });
 
         var offset: usize = 0;
         const globalObject = this.handlers.globalObject;
@@ -1933,7 +1948,7 @@ pub const H2FrameParser = struct {
             const header = this.decode(payload[offset..]) catch break;
             offset += header.next;
             log("header {s} {s}", .{ header.name, header.value });
-            if (this.isServer and strings.eqlComptime(header.name, ":status")) {
+            if ((this.isServer or is_push_promise) and strings.eqlComptime(header.name, ":status")) {
                 this.sendGoAway(stream_id, ErrorCode.PROTOCOL_ERROR, "Server received :status header", this.lastStreamID, true);
 
                 return this.streams.get(stream_id);
@@ -2012,6 +2027,18 @@ pub const H2FrameParser = struct {
             this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Data frame on connection stream", this.lastStreamID, true);
             return data.len;
         };
+
+        // RFC 7540 Section 6.1: DATA frames are subject to flow control and can
+        // only be sent when a stream is in the "open" or "half-closed (local)"
+        // state. Receiving DATA on a RESERVED_REMOTE push stream before the
+        // server has sent the response HEADERS is a stream error of type
+        // PROTOCOL_ERROR — the payload must not be delivered to JS, otherwise
+        // a misbehaving server could inject data onto a stream that was never
+        // legitimately opened.
+        if (stream.state == .RESERVED_REMOTE or stream.state == .RESERVED_LOCAL or stream.state == .IDLE) {
+            this.endStream(stream, ErrorCode.PROTOCOL_ERROR);
+            return data.len;
+        }
 
         if (frame.length > this.localSettings.maxFrameSize) {
             log("received data frame with length: {d} and max frame size: {d}", .{ frame.length, this.localSettings.maxFrameSize });
@@ -2104,10 +2131,13 @@ pub const H2FrameParser = struct {
                 const identifier = stream.getIdentifier();
                 identifier.ensureStillAlive();
 
-                // Client-side push streams start in RESERVED_REMOTE and can
-                // only receive from the server. END_STREAM from the remote
-                // transitions them directly to CLOSED.
-                if (stream.state == .HALF_CLOSED_LOCAL or stream.state == .RESERVED_REMOTE) {
+                // Client-side push streams transition through HALF_CLOSED_LOCAL
+                // (after receiving the response HEADERS frame) before DATA is
+                // legal per RFC 7540 Section 5.1. The early RESERVED_REMOTE
+                // guard above rejects DATA that arrives before HEADERS, so by
+                // the time we reach here we are in either HALF_CLOSED_LOCAL
+                // (push) or OPEN (normal) state.
+                if (stream.state == .HALF_CLOSED_LOCAL) {
                     stream.state = .CLOSED;
                     stream.freeResources(this, false);
                 } else {
@@ -2365,7 +2395,7 @@ pub const H2FrameParser = struct {
                 if (handleIncommingPayload(this, data, frame.streamIdentifier)) |content| {
                     const payload = content.data;
                     this.readBuffer.reset();
-                    const maybe_result = try this.decodeHeaderBlock(payload[0..payload.len], promised_stream, frame.flags);
+                    const maybe_result = try this.decodeHeaderBlockInternal(payload[0..payload.len], promised_stream, frame.flags, true);
                     // decodeHeaderBlock fires JS callbacks which may grow the
                     // streams HashMap and invalidate any prior *Stream pointer.
                     // Always re-fetch the parent by id before touching it.
@@ -2408,17 +2438,27 @@ pub const H2FrameParser = struct {
         if (handleIncommingPayload(this, data, frame.streamIdentifier)) |content| {
             const payload = content.data;
             this.readBuffer.reset();
-            stream.endAfterHeaders = frame.flags & @intFromEnum(HeadersFrameFlags.END_STREAM) != 0;
+            // RFC 7540 Section 6.10: CONTINUATION frames have no flags other
+            // than END_HEADERS. The END_STREAM sentinel is carried only on the
+            // original HEADERS frame that opened this header-block sequence,
+            // so preserve stream.endAfterHeaders across CONTINUATION frames
+            // rather than re-deriving it from the CONTINUATION flag bits
+            // (which are always 0 for END_STREAM).
             stream = (try this.decodeHeaderBlock(payload[0..payload.len], stream, frame.flags)) orelse {
                 return content.end;
             };
-            if (stream.endAfterHeaders) {
+            if (frame.flags & @intFromEnum(HeadersFrameFlags.END_HEADERS) != 0) {
                 stream.isWaitingMoreHeaders = false;
-                if (frame.flags & @intFromEnum(HeadersFrameFlags.END_STREAM) != 0) {
+                if (stream.endAfterHeaders) {
                     const identifier = stream.getIdentifier();
                     identifier.ensureStillAlive();
                     if (stream.state == .HALF_CLOSED_REMOTE) {
                         // no more continuation headers we can call it closed
+                        stream.state = .CLOSED;
+                        stream.freeResources(this, false);
+                    } else if (stream.state == .RESERVED_REMOTE or stream.state == .HALF_CLOSED_LOCAL) {
+                        // Client-side push stream finishing its response with
+                        // END_STREAM on the initial HEADERS frame.
                         stream.state = .CLOSED;
                         stream.freeResources(this, false);
                     } else {
@@ -2521,6 +2561,15 @@ pub const H2FrameParser = struct {
                 this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Invalid promised stream ID", this.lastStreamID, true);
                 return content.end;
             }
+            // RFC 7540 Section 5.1.1: stream identifiers must be numerically
+            // greater than all previously opened or reserved streams in the
+            // same direction. Reject a peer that attempts to reuse or rewind
+            // promised ids — pure existence-in-map check is insufficient once
+            // a previous push was processed and the map entry freed.
+            if (promised_stream_id <= this.highestReceivedPushPromiseID) {
+                this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "PUSH_PROMISE stream ID not monotonically increasing", this.lastStreamID, true);
+                return content.end;
+            }
             if (this.streams.get(promised_stream_id) != null) {
                 this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Promised stream ID already in use", this.lastStreamID, true);
                 return content.end;
@@ -2538,10 +2587,15 @@ pub const H2FrameParser = struct {
                 return content.end;
             };
             this.lastStreamID = saved_last_stream_id;
+            this.highestReceivedPushPromiseID = promised_stream_id;
             promised_stream.state = .RESERVED_REMOTE;
 
-            // Decode the header block on the promised stream
-            _ = (try this.decodeHeaderBlock(payload[offset..end], promised_stream, frame.flags)) orelse {
+            // Decode the header block on the promised stream.
+            // PUSH_PROMISE carries the associated request headers (RFC 7540
+            // §8.2.1); pass is_push_promise=true so `:status` and other
+            // response-only pseudo-headers are rejected with PROTOCOL_ERROR
+            // instead of being silently forwarded.
+            _ = (try this.decodeHeaderBlockInternal(payload[offset..end], promised_stream, frame.flags, true)) orelse {
                 return content.end;
             };
 
@@ -4796,9 +4850,19 @@ pub const H2FrameParser = struct {
         if (orig_stream_id % 2 != 1) {
             return globalObject.throw("PUSH_PROMISE must be sent on a client-initiated (odd) stream", .{});
         }
-        _ = this.streams.get(orig_stream_id) orelse {
+        const orig_stream = this.streams.get(orig_stream_id) orelse {
             return globalObject.throw("Invalid original stream id", .{});
         };
+
+        // RFC 7540 Section 6.6: PUSH_PROMISE MUST only be sent on a stream
+        // that is in either the "open" or "half-closed (remote)" state from
+        // the server's perspective — i.e. the client still has the stream
+        // open for receiving. If we already sent END_STREAM (HALF_CLOSED_LOCAL,
+        // CLOSED) or never saw the request (IDLE, RESERVED_*) then emitting a
+        // PUSH_PROMISE here is a protocol violation the peer must reject.
+        if (orig_stream.state != .OPEN and orig_stream.state != .HALF_CLOSED_REMOTE) {
+            return jsc.JSValue.jsNumber(-1);
+        }
 
         // Check remote settings allow push
         if (this.remoteSettings) |rs| {
@@ -4943,6 +5007,16 @@ pub const H2FrameParser = struct {
 
         const encoded_data = encoded_headers.items;
         const encoded_size = encoded_data.len;
+
+        // Check if headers block exceeds maxSendHeaderBlockLength — mirrors
+        // the same guard in `request()` and `respond()` so push-promise
+        // callers get a consistent rejection instead of silently emitting a
+        // header block larger than the application opted into. We reject here
+        // before reserving a stream id so the lastPushStreamID counter stays
+        // in sync with what actually went on the wire.
+        if (this.maxSendHeaderBlockLength != 0 and encoded_size > this.maxSendHeaderBlockLength) {
+            return jsc.JSValue.jsNumber(-1);
+        }
 
         // Create the promised stream in RESERVED_LOCAL state.
         // handleReceivedStreamID advances this.lastStreamID to any id larger

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -4654,15 +4654,31 @@ pub const H2FrameParser = struct {
             }
         }
 
+        // RFC 7540 Section 5.1: A push stream starts in RESERVED_LOCAL. Sending
+        // HEADERS on a RESERVED_LOCAL stream transitions it to HALF_CLOSED_REMOTE
+        // because the client cannot send data on a promised stream.
+        const was_reserved_local = stream.state == .RESERVED_LOCAL;
         if (end_stream) {
             stream.endAfterHeaders = true;
-            stream.state = .HALF_CLOSED_LOCAL;
+            stream.state = if (was_reserved_local) .CLOSED else .HALF_CLOSED_LOCAL;
+
+            if (was_reserved_local) {
+                const identifier = stream.getIdentifier();
+                identifier.ensureStillAlive();
+                stream.freeResources(this, false);
+                this.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(stream.state)));
+            }
 
             if (waitForTrailers) {
                 this.dispatch(.onWantTrailers, stream.getIdentifier());
                 return jsc.JSValue.jsNumber(stream_id);
             }
         } else {
+            if (was_reserved_local) {
+                // Transition to HALF_CLOSED_REMOTE so subsequent sendData(close=true)
+                // correctly moves to CLOSED and the JS layer decrements connections.
+                stream.state = .HALF_CLOSED_REMOTE;
+            }
             stream.waitForTrailers = waitForTrailers;
         }
 

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -4779,14 +4779,10 @@ pub const H2FrameParser = struct {
         jsc.markBinding(@src());
         log("sendPushPromise", .{});
 
-        const args_list = callframe.arguments_old(3);
-        if (args_list.len < 3) {
+        const orig_stream_id_arg, const headers_arg, const sensitive_arg = callframe.argumentsAsArray(3);
+        if (orig_stream_id_arg.isUndefined() or headers_arg.isUndefined() or sensitive_arg.isUndefined()) {
             return globalObject.throw("Expected original_stream_id, headers and sensitiveHeaders arguments", .{});
         }
-
-        const orig_stream_id_arg = args_list.ptr[0];
-        const headers_arg = args_list.ptr[1];
-        const sensitive_arg = args_list.ptr[2];
 
         if (!orig_stream_id_arg.isNumber()) {
             return globalObject.throw("Expected original_stream_id to be a number", .{});

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -2028,15 +2028,20 @@ pub const H2FrameParser = struct {
             return data.len;
         };
 
-        // RFC 7540 Section 6.1: DATA frames are subject to flow control and can
-        // only be sent when a stream is in the "open" or "half-closed (local)"
-        // state. Receiving DATA on a RESERVED_REMOTE push stream before the
-        // server has sent the response HEADERS is a stream error of type
-        // PROTOCOL_ERROR — the payload must not be delivered to JS, otherwise
-        // a misbehaving server could inject data onto a stream that was never
-        // legitimately opened.
+        // RFC 7540 Section 6.1 / 5.1: DATA frames are only legal on an "open"
+        // or "half-closed (local)" stream. Receipt on a reserved or idle
+        // stream is permitted to be a connection error of type PROTOCOL_ERROR
+        // (see Section 5.1, "reserved (remote)" state) and we treat it as one
+        // here. The payload must not be delivered to JS (a misbehaving server
+        // could otherwise inject data onto a stream that was never
+        // legitimately opened) and stream-level RST is insufficient — the
+        // outer readBytes() set `currentFrame`/`remainingLength` before
+        // dispatch, and a stream-scoped reject would leave that bookkeeping
+        // stale for the next TCP read, desynchronising connection framing.
+        // Sending GOAWAY tears the connection down, which matches every
+        // other early-return in this handler.
         if (stream.state == .RESERVED_REMOTE or stream.state == .RESERVED_LOCAL or stream.state == .IDLE) {
-            this.endStream(stream, ErrorCode.PROTOCOL_ERROR);
+            this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "DATA on reserved/idle stream", this.lastStreamID, true);
             return data.len;
         }
 
@@ -4860,8 +4865,11 @@ pub const H2FrameParser = struct {
         // open for receiving. If we already sent END_STREAM (HALF_CLOSED_LOCAL,
         // CLOSED) or never saw the request (IDLE, RESERVED_*) then emitting a
         // PUSH_PROMISE here is a protocol violation the peer must reject.
+        // Return -3 (distinct from -1 = push disabled by peer) so the JS layer
+        // can surface ERR_HTTP2_INVALID_STREAM instead of the misleading
+        // ERR_HTTP2_PUSH_DISABLED.
         if (orig_stream.state != .OPEN and orig_stream.state != .HALF_CLOSED_REMOTE) {
-            return jsc.JSValue.jsNumber(-1);
+            return jsc.JSValue.jsNumber(-3);
         }
 
         // Check remote settings allow push
@@ -5013,9 +5021,12 @@ pub const H2FrameParser = struct {
         // callers get a consistent rejection instead of silently emitting a
         // header block larger than the application opted into. We reject here
         // before reserving a stream id so the lastPushStreamID counter stays
-        // in sync with what actually went on the wire.
+        // in sync with what actually went on the wire. Return -4 (distinct
+        // from -1 = push disabled, -3 = parent stream invalid) so the JS
+        // layer can surface an ERR_HTTP2_FRAME_ERROR rather than the
+        // misleading ERR_HTTP2_PUSH_DISABLED.
         if (this.maxSendHeaderBlockLength != 0 and encoded_size > this.maxSendHeaderBlockLength) {
-            return jsc.JSValue.jsNumber(-1);
+            return jsc.JSValue.jsNumber(-4);
         }
 
         // Create the promised stream in RESERVED_LOCAL state.

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -2095,7 +2095,10 @@ pub const H2FrameParser = struct {
                 const identifier = stream.getIdentifier();
                 identifier.ensureStillAlive();
 
-                if (stream.state == .HALF_CLOSED_LOCAL) {
+                // Client-side push streams start in RESERVED_REMOTE and can
+                // only receive from the server. END_STREAM from the remote
+                // transitions them directly to CLOSED.
+                if (stream.state == .HALF_CLOSED_LOCAL or stream.state == .RESERVED_REMOTE) {
                     stream.state = .CLOSED;
                     stream.freeResources(this, false);
                 } else {
@@ -2509,10 +2512,18 @@ pub const H2FrameParser = struct {
                 return content.end;
             }
 
-            // Create the promised stream
+            // Create the promised stream. Save/restore this.lastStreamID
+            // around the call: that field tracks the highest client-initiated
+            // (odd) stream ID for GOAWAY/stream-ID-allocation purposes, and a
+            // peer-supplied push id (even, potentially very large) must not
+            // be allowed to advance it. Otherwise a server sending a large
+            // promised id could exhaust our client stream ID space.
+            const saved_last_stream_id = this.lastStreamID;
             const promised_stream = this.handleReceivedStreamID(promised_stream_id) orelse {
+                this.lastStreamID = saved_last_stream_id;
                 return content.end;
             };
+            this.lastStreamID = saved_last_stream_id;
             promised_stream.state = .RESERVED_REMOTE;
 
             // Decode the header block on the promised stream
@@ -2609,8 +2620,9 @@ pub const H2FrameParser = struct {
                 if (stream.isWaitingMoreHeaders) {
                     stream.state = .HALF_CLOSED_REMOTE;
                 } else {
-                    // no more continuation headers we can call it closed
-                    if (stream.state == .HALF_CLOSED_LOCAL) {
+                    // Client-side push streams start in RESERVED_REMOTE and
+                    // go straight to CLOSED on END_STREAM from the remote.
+                    if (stream.state == .HALF_CLOSED_LOCAL or stream.state == .RESERVED_REMOTE) {
                         stream.state = .CLOSED;
                         stream.freeResources(this, false);
                     } else {

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -1949,7 +1949,12 @@ pub const H2FrameParser = struct {
             offset += header.next;
             log("header {s} {s}", .{ header.name, header.value });
             if ((this.isServer or is_push_promise) and strings.eqlComptime(header.name, ":status")) {
-                this.sendGoAway(stream_id, ErrorCode.PROTOCOL_ERROR, "Server received :status header", this.lastStreamID, true);
+                // Direction-neutral debug string: this branch fires both on
+                // the server (request header block with :status) and on the
+                // client (PUSH_PROMISE header block with :status). The old
+                // "Server received ..." wording was backwards for the
+                // client path.
+                this.sendGoAway(stream_id, ErrorCode.PROTOCOL_ERROR, ":status pseudo-header in request header block", this.lastStreamID, true);
 
                 return this.streams.get(stream_id);
             }

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -675,6 +675,12 @@ pub const H2FrameParser = struct {
     outStandingPings: u64 = 0,
     maxSendHeaderBlockLength: u32 = 0,
     lastStreamID: u32 = 0,
+    // RFC 7540 Section 6.10: CONTINUATION frames after PUSH_PROMISE carry the
+    // parent stream identifier, but the header block belongs to the promised
+    // stream. Track the promised stream ID so the next CONTINUATION arriving
+    // on the parent stream can route its decoded headers to the promised stream.
+    // 0 means no pending PUSH_PROMISE continuation.
+    continuation_promised_stream_id: u32 = 0,
     isServer: bool = false,
     prefaceReceivedLen: u8 = 0,
     // we buffer requests until we get the first settings ACK
@@ -2333,6 +2339,32 @@ pub const H2FrameParser = struct {
             this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Continuation without headers", this.lastStreamID, true);
             return data.len;
         }
+
+        // RFC 7540 Section 6.10: If this CONTINUATION follows a PUSH_PROMISE,
+        // the decoded header block belongs to the promised stream, not the
+        // parent stream that the CONTINUATION frame is addressed to.
+        if (this.continuation_promised_stream_id != 0) {
+            const promised_entry = this.streams.getEntry(this.continuation_promised_stream_id);
+            if (promised_entry) |entry| {
+                const promised_stream = entry.value_ptr;
+                if (handleIncommingPayload(this, data, frame.streamIdentifier)) |content| {
+                    const payload = content.data;
+                    this.readBuffer.reset();
+                    _ = (try this.decodeHeaderBlock(payload[0..payload.len], promised_stream, frame.flags)) orelse {
+                        return content.end;
+                    };
+                    if (frame.flags & @intFromEnum(HeadersFrameFlags.END_HEADERS) != 0) {
+                        stream.isWaitingMoreHeaders = false;
+                        this.continuation_promised_stream_id = 0;
+                    }
+                    return content.end;
+                }
+                return data.len;
+            }
+            // Promised stream vanished; fall through to normal handling.
+            this.continuation_promised_stream_id = 0;
+        }
+
         if (handleIncommingPayload(this, data, frame.streamIdentifier)) |content| {
             const payload = content.data;
             this.readBuffer.reset();
@@ -2369,7 +2401,7 @@ pub const H2FrameParser = struct {
     /// Format: [Pad Length (1)?] [R + Promised Stream ID (4)] [Header Block Fragment (*)] [Padding (*)]
     pub fn handlePushPromiseFrame(this: *H2FrameParser, frame: FrameHeader, data: []const u8, stream_: ?*Stream) bun.JSError!usize {
         log("handlePushPromiseFrame {s}", .{if (this.isServer) "server" else "client"});
-        _ = stream_ orelse {
+        const parent_stream = stream_ orelse {
             this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "PUSH_PROMISE on connection stream", this.lastStreamID, true);
             return data.len;
         };
@@ -2380,8 +2412,10 @@ pub const H2FrameParser = struct {
             return data.len;
         }
 
-        // Check if push is enabled in local settings
-        if (this.localSettings.enablePush == 0) {
+        // Check if push is enabled. Per RFC 7540 Section 6.5.3, settings take
+        // effect only after being acknowledged by the peer, so we can only
+        // reject PUSH_PROMISE once our SETTINGS frame has been ACKed.
+        if (this.outstandingSettings == 0 and this.localSettings.enablePush == 0) {
             this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Push is disabled", this.lastStreamID, true);
             return data.len;
         }
@@ -2440,11 +2474,21 @@ pub const H2FrameParser = struct {
             promised_stream.state = .RESERVED_REMOTE;
 
             // Decode the header block on the promised stream
-            const result_stream = (try this.decodeHeaderBlock(payload[offset..end], promised_stream, frame.flags)) orelse {
+            _ = (try this.decodeHeaderBlock(payload[offset..end], promised_stream, frame.flags)) orelse {
                 return content.end;
             };
-            // Track incomplete header blocks for CONTINUATION frame reassembly
-            result_stream.isWaitingMoreHeaders = frame.flags & @intFromEnum(HeadersFrameFlags.END_HEADERS) == 0;
+
+            // CONTINUATION frames after PUSH_PROMISE are keyed by the parent
+            // stream's identifier (RFC 7540 Section 6.10). Mark the parent
+            // stream as waiting so that the dispatch in handleContinuationFrame
+            // does not treat them as orphaned. We also record the promised
+            // stream so continuation header blocks are routed to it.
+            if (frame.flags & @intFromEnum(HeadersFrameFlags.END_HEADERS) == 0) {
+                parent_stream.isWaitingMoreHeaders = true;
+                this.continuation_promised_stream_id = promised_stream_id;
+            } else {
+                this.continuation_promised_stream_id = 0;
+            }
 
             return content.end;
         }
@@ -4681,10 +4725,12 @@ pub const H2FrameParser = struct {
         var name_buffer: [4096]u8 = undefined;
         @memset(&name_buffer, 0);
 
-        // Allocate the promised stream ID (even-numbered for server push)
+        // Allocate the promised stream ID (even-numbered for server push).
+        // Return -2 to signal stream ID exhaustion (distinct from -1 = push disabled)
+        // so the JS layer can report ERR_HTTP2_OUT_OF_STREAMS.
         const promised_stream_id = this.getNextStreamID();
         if (promised_stream_id > MAX_STREAM_ID) {
-            return jsc.JSValue.jsNumber(-1);
+            return jsc.JSValue.jsNumber(-2);
         }
 
         // Encode headers - pseudo-headers first, then regular headers

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -675,6 +675,12 @@ pub const H2FrameParser = struct {
     outStandingPings: u64 = 0,
     maxSendHeaderBlockLength: u32 = 0,
     lastStreamID: u32 = 0,
+    // RFC 7540 Section 5.1.1: server push stream IDs (even) are a separate
+    // monotonically-increasing namespace from client-initiated (odd) IDs.
+    // Track them independently so push allocation never collides with nor
+    // pollutes lastStreamID (which is used for GOAWAY Last-Stream-ID and for
+    // allocating the next client-initiated stream).
+    lastPushStreamID: u32 = 0,
     // RFC 7540 Section 6.10: CONTINUATION frames after PUSH_PROMISE carry the
     // parent stream identifier, but the header block belongs to the promised
     // stream. Track the promised stream ID so the next CONTINUATION arriving
@@ -2377,17 +2383,17 @@ pub const H2FrameParser = struct {
                 }
                 return data.len;
             }
-            // Promised stream vanished before data arrived. Consume the
-            // fragment, clear waiting state on the parent, and move on —
-            // the header block can't be routed anywhere meaningful.
+            // Promised stream vanished before the CONTINUATION arrived.
+            // We can't decode the header block into that stream, and
+            // silently dropping the bytes would desynchronize HPACK's
+            // connection-wide dynamic table against the remote encoder,
+            // corrupting every subsequent header block. Treat this as a
+            // connection-level compression error.
             this.continuation_promised_stream_id = 0;
             if (this.streams.getPtr(frame.streamIdentifier)) |p| {
                 p.isWaitingMoreHeaders = false;
             }
-            if (handleIncommingPayload(this, data, frame.streamIdentifier)) |content| {
-                this.readBuffer.reset();
-                return content.end;
-            }
+            this.sendGoAway(frame.streamIdentifier, ErrorCode.COMPRESSION_ERROR, "PUSH_PROMISE CONTINUATION for gone stream", this.lastStreamID, true);
             return data.len;
         }
 
@@ -4769,7 +4775,13 @@ pub const H2FrameParser = struct {
         }
         const orig_stream_id: u32 = orig_stream_id_arg.to(u32);
 
-        // Verify original stream exists
+        // Verify original stream exists and is client-initiated (odd id).
+        // RFC 7540 Section 6.6: PUSH_PROMISE MUST only be sent on a
+        // peer-initiated stream. A server's peer is the client, so the
+        // parent id must be odd.
+        if (orig_stream_id % 2 != 1) {
+            return globalObject.throw("PUSH_PROMISE must be sent on a client-initiated (odd) stream", .{});
+        }
         _ = this.streams.getPtr(orig_stream_id) orelse {
             return globalObject.throw("Invalid original stream id", .{});
         };
@@ -4800,10 +4812,20 @@ pub const H2FrameParser = struct {
         var name_buffer: [4096]u8 = undefined;
         @memset(&name_buffer, 0);
 
-        // Allocate the promised stream ID (even-numbered for server push).
-        // Return -2 to signal stream ID exhaustion (distinct from -1 = push disabled)
-        // so the JS layer can report ERR_HTTP2_OUT_OF_STREAMS.
-        const promised_stream_id = this.getNextStreamID();
+        // Allocate the next even-numbered push stream ID from the dedicated
+        // push counter so successive PUSH_PROMISEs get monotonically
+        // increasing ids (RFC 7540 Section 5.1.1) without touching
+        // lastStreamID (which tracks client-initiated streams and feeds
+        // GOAWAY Last-Stream-ID per Section 6.8).
+        // Return -2 to signal stream ID exhaustion (distinct from -1 = push
+        // disabled) so the JS layer can report ERR_HTTP2_OUT_OF_STREAMS.
+        const promised_stream_id: u32 = blk: {
+            var id: u32 = if (this.lastPushStreamID == 0) 2 else this.lastPushStreamID + 2;
+            // In case a PUSH_PROMISE was previously accepted through another
+            // code path, don't collide with any even id already registered.
+            while (this.streams.getEntry(id) != null) : (id += 2) {}
+            break :blk id;
+        };
         if (promised_stream_id > MAX_STREAM_ID) {
             return jsc.JSValue.jsNumber(-2);
         }
@@ -4909,20 +4931,20 @@ pub const H2FrameParser = struct {
         const encoded_size = encoded_data.len;
 
         // Create the promised stream in RESERVED_LOCAL state.
-        // IMPORTANT: handleReceivedStreamID unconditionally advances
-        // this.lastStreamID to any id larger than its current value. For
-        // server push we allocate even ids, but lastStreamID tracks the
-        // highest *peer-initiated* stream the session has seen (used as
-        // the Last-Stream-ID field in GOAWAY per RFC 7540 Section 6.8). If we
-        // let push ids bump it, GOAWAY would falsely claim we processed
-        // client streams up to the push id, leading clients to silently
-        // drop in-flight odd-numbered streams. Save and restore around the
-        // call so only the new stream gets registered.
+        // handleReceivedStreamID advances this.lastStreamID to any id larger
+        // than the current value; on the server side that field tracks the
+        // highest client-initiated (odd) stream and feeds GOAWAY Last-Stream-ID
+        // per RFC 7540 Section 6.8. Save/restore it so an even push id never
+        // pollutes the client-stream accounting. We still advance
+        // lastPushStreamID below so the next sendPushPromise picks the next
+        // even id instead of re-using the same one.
         const saved_last_stream_id = this.lastStreamID;
         const promised_stream = this.handleReceivedStreamID(promised_stream_id) orelse {
+            this.lastStreamID = saved_last_stream_id;
             return jsc.JSValue.jsNumber(-1);
         };
         this.lastStreamID = saved_last_stream_id;
+        this.lastPushStreamID = promised_stream_id;
         promised_stream.state = .RESERVED_LOCAL;
 
         // Build and send PUSH_PROMISE frame

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -2401,10 +2401,14 @@ pub const H2FrameParser = struct {
     /// Format: [Pad Length (1)?] [R + Promised Stream ID (4)] [Header Block Fragment (*)] [Padding (*)]
     pub fn handlePushPromiseFrame(this: *H2FrameParser, frame: FrameHeader, data: []const u8, stream_: ?*Stream) bun.JSError!usize {
         log("handlePushPromiseFrame {s}", .{if (this.isServer) "server" else "client"});
-        const parent_stream = stream_ orelse {
+        // NOTE: Do NOT hold on to the parent_stream pointer — calling
+        // handleReceivedStreamID() below can grow the streams HashMap and
+        // invalidate it. We re-fetch by id when we need to write to the parent.
+        _ = stream_ orelse {
             this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "PUSH_PROMISE on connection stream", this.lastStreamID, true);
             return data.len;
         };
+        const parent_stream_id = frame.streamIdentifier;
 
         // Servers must not receive PUSH_PROMISE frames
         if (this.isServer) {
@@ -2483,8 +2487,13 @@ pub const H2FrameParser = struct {
             // stream as waiting so that the dispatch in handleContinuationFrame
             // does not treat them as orphaned. We also record the promised
             // stream so continuation header blocks are routed to it.
+            // Re-fetch the parent stream by id because handleReceivedStreamID
+            // above may have grown the HashMap and invalidated any prior
+            // pointer we held.
             if (frame.flags & @intFromEnum(HeadersFrameFlags.END_HEADERS) == 0) {
-                parent_stream.isWaitingMoreHeaders = true;
+                if (this.streams.getPtr(parent_stream_id)) |p| {
+                    p.isWaitingMoreHeaders = true;
+                }
                 this.continuation_promised_stream_id = promised_stream_id;
             } else {
                 this.continuation_promised_stream_id = 0;

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -683,10 +683,13 @@ pub const H2FrameParser = struct {
     lastPushStreamID: u32 = 0,
     // RFC 7540 Section 6.10: CONTINUATION frames after PUSH_PROMISE carry the
     // parent stream identifier, but the header block belongs to the promised
-    // stream. Track the promised stream ID so the next CONTINUATION arriving
-    // on the parent stream can route its decoded headers to the promised stream.
+    // stream. Track both the promised stream ID (decode target) and the
+    // parent stream ID (expected CONTINUATION stream identifier) so we only
+    // take the push-promise decode path when the CONTINUATION arrives on the
+    // correct parent — a different waiting stream must not be misrouted here.
     // 0 means no pending PUSH_PROMISE continuation.
     continuation_promised_stream_id: u32 = 0,
+    continuation_parent_stream_id: u32 = 0,
     isServer: bool = false,
     prefaceReceivedLen: u8 = 0,
     // we buffer requests until we get the first settings ACK
@@ -2351,11 +2354,13 @@ pub const H2FrameParser = struct {
 
         // RFC 7540 Section 6.10: If this CONTINUATION follows a PUSH_PROMISE,
         // the decoded header block belongs to the promised stream, not the
-        // parent stream that the CONTINUATION frame is addressed to.
-        if (this.continuation_promised_stream_id != 0) {
-            const promised_entry = this.streams.getEntry(this.continuation_promised_stream_id);
-            if (promised_entry) |entry| {
-                const promised_stream = entry.value_ptr;
+        // parent stream that the CONTINUATION frame is addressed to. Only
+        // take this path when the CONTINUATION arrived on the parent stream
+        // we actually saw the PUSH_PROMISE on — otherwise a CONTINUATION for
+        // a different mid-header-block stream could be misrouted into the
+        // push-promise decode, corrupting HPACK state.
+        if (this.continuation_promised_stream_id != 0 and frame.streamIdentifier == this.continuation_parent_stream_id) {
+            if (this.streams.get(this.continuation_promised_stream_id)) |promised_stream| {
                 const parent_id = frame.streamIdentifier;
                 if (handleIncommingPayload(this, data, frame.streamIdentifier)) |content| {
                     const payload = content.data;
@@ -2368,16 +2373,18 @@ pub const H2FrameParser = struct {
                         // Promised stream removed during callbacks — clear all
                         // continuation state so future frames aren't misrouted.
                         this.continuation_promised_stream_id = 0;
-                        if (this.streams.getPtr(parent_id)) |p| {
+                        this.continuation_parent_stream_id = 0;
+                        if (this.streams.get(parent_id)) |p| {
                             p.isWaitingMoreHeaders = false;
                         }
                         return content.end;
                     }
                     if (frame.flags & @intFromEnum(HeadersFrameFlags.END_HEADERS) != 0) {
-                        if (this.streams.getPtr(parent_id)) |p| {
+                        if (this.streams.get(parent_id)) |p| {
                             p.isWaitingMoreHeaders = false;
                         }
                         this.continuation_promised_stream_id = 0;
+                        this.continuation_parent_stream_id = 0;
                     }
                     return content.end;
                 }
@@ -2390,7 +2397,8 @@ pub const H2FrameParser = struct {
             // corrupting every subsequent header block. Treat this as a
             // connection-level compression error.
             this.continuation_promised_stream_id = 0;
-            if (this.streams.getPtr(frame.streamIdentifier)) |p| {
+            this.continuation_parent_stream_id = 0;
+            if (this.streams.get(frame.streamIdentifier)) |p| {
                 p.isWaitingMoreHeaders = false;
             }
             this.sendGoAway(frame.streamIdentifier, ErrorCode.COMPRESSION_ERROR, "PUSH_PROMISE CONTINUATION for gone stream", this.lastStreamID, true);
@@ -2513,7 +2521,7 @@ pub const H2FrameParser = struct {
                 this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Invalid promised stream ID", this.lastStreamID, true);
                 return content.end;
             }
-            if (this.streams.getEntry(promised_stream_id) != null) {
+            if (this.streams.get(promised_stream_id) != null) {
                 this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Promised stream ID already in use", this.lastStreamID, true);
                 return content.end;
             }
@@ -2546,12 +2554,14 @@ pub const H2FrameParser = struct {
             // above may have grown the HashMap and invalidated any prior
             // pointer we held.
             if (frame.flags & @intFromEnum(HeadersFrameFlags.END_HEADERS) == 0) {
-                if (this.streams.getPtr(parent_stream_id)) |p| {
+                if (this.streams.get(parent_stream_id)) |p| {
                     p.isWaitingMoreHeaders = true;
                 }
                 this.continuation_promised_stream_id = promised_stream_id;
+                this.continuation_parent_stream_id = parent_stream_id;
             } else {
                 this.continuation_promised_stream_id = 0;
+                this.continuation_parent_stream_id = 0;
             }
 
             return content.end;
@@ -2619,6 +2629,14 @@ pub const H2FrameParser = struct {
                 return content.end;
             };
             stream.isWaitingMoreHeaders = frame.flags & @intFromEnum(HeadersFrameFlags.END_HEADERS) == 0;
+            // RFC 7540 Section 5.1: receiving HEADERS on a RESERVED_REMOTE
+            // push stream transitions it to HALF_CLOSED_LOCAL, independent of
+            // whether END_STREAM is set. Without this the stream state says
+            // the client can still send data on a server push, which is
+            // always wrong.
+            if (!stream.endAfterHeaders and stream.state == .RESERVED_REMOTE) {
+                stream.state = .HALF_CLOSED_LOCAL;
+            }
             if (stream.endAfterHeaders) {
                 const identifier = stream.getIdentifier();
                 identifier.ensureStillAlive();
@@ -4782,7 +4800,7 @@ pub const H2FrameParser = struct {
         if (orig_stream_id % 2 != 1) {
             return globalObject.throw("PUSH_PROMISE must be sent on a client-initiated (odd) stream", .{});
         }
-        _ = this.streams.getPtr(orig_stream_id) orelse {
+        _ = this.streams.get(orig_stream_id) orelse {
             return globalObject.throw("Invalid original stream id", .{});
         };
 
@@ -4823,7 +4841,7 @@ pub const H2FrameParser = struct {
             var id: u32 = if (this.lastPushStreamID == 0) 2 else this.lastPushStreamID + 2;
             // In case a PUSH_PROMISE was previously accepted through another
             // code path, don't collide with any even id already registered.
-            while (this.streams.getEntry(id) != null) : (id += 2) {}
+            while (this.streams.get(id) != null) : (id += 2) {}
             break :blk id;
         };
         if (promised_stream_id > MAX_STREAM_ID) {

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -2399,12 +2399,16 @@ pub const H2FrameParser = struct {
             this.readBuffer.reset();
 
             if (frame.flags & @intFromEnum(HeadersFrameFlags.PADDED) != 0) {
+                if (payload.len == 0) {
+                    this.sendGoAway(frame.streamIdentifier, ErrorCode.FRAME_SIZE_ERROR, "invalid PUSH_PROMISE frame size", this.lastStreamID, true);
+                    return content.end;
+                }
                 padding = payload[0];
                 offset += 1;
             }
 
             // Parse the 4-byte promised stream ID
-            if (payload.len < offset + 4) {
+            if (payload.len < offset + 4 or payload.len -| (offset + 4) < padding) {
                 this.sendGoAway(frame.streamIdentifier, ErrorCode.FRAME_SIZE_ERROR, "PUSH_PROMISE too short for promised stream ID", this.lastStreamID, true);
                 return content.end;
             }
@@ -2417,16 +2421,30 @@ pub const H2FrameParser = struct {
                 return content.end;
             }
 
+            // RFC 7540 Section 6.6: Validate promised stream ID
+            // Must be non-zero, even (server-initiated), and not already in use
+            const promised_stream_id = promised_id.uint31;
+            if (promised_stream_id == 0 or promised_stream_id % 2 != 0) {
+                this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Invalid promised stream ID", this.lastStreamID, true);
+                return content.end;
+            }
+            if (this.streams.getEntry(promised_stream_id) != null) {
+                this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Promised stream ID already in use", this.lastStreamID, true);
+                return content.end;
+            }
+
             // Create the promised stream
-            const promised_stream = this.handleReceivedStreamID(promised_id.uint31) orelse {
+            const promised_stream = this.handleReceivedStreamID(promised_stream_id) orelse {
                 return content.end;
             };
             promised_stream.state = .RESERVED_REMOTE;
 
             // Decode the header block on the promised stream
-            _ = (try this.decodeHeaderBlock(payload[offset..end], promised_stream, frame.flags)) orelse {
+            const result_stream = (try this.decodeHeaderBlock(payload[offset..end], promised_stream, frame.flags)) orelse {
                 return content.end;
             };
+            // Track incomplete header blocks for CONTINUATION frame reassembly
+            result_stream.isWaitingMoreHeaders = frame.flags & @intFromEnum(HeadersFrameFlags.END_HEADERS) == 0;
 
             return content.end;
         }
@@ -4709,7 +4727,40 @@ pub const H2FrameParser = struct {
                     return globalObject.throwValue(exception);
                 }
 
-                if (!js_value.isEmptyOrUndefinedOrNull()) {
+                if (js_value.jsType().isArray()) {
+                    var value_iter = try js_value.arrayIterator(globalObject);
+
+                    if (SingleValueHeaders.indexOf(validated_name)) |idx| {
+                        if (value_iter.len > 1 or single_value_headers[idx]) {
+                            if (!globalObject.hasException()) {
+                                const exception = globalObject.toTypeError(.HTTP2_HEADER_SINGLE_VALUE, "Header field \"{s}\" must only have a single value", .{validated_name});
+                                return globalObject.throwValue(exception);
+                            }
+                            return .zero;
+                        }
+                        single_value_headers[idx] = true;
+                    }
+
+                    while (try value_iter.next()) |item| {
+                        if (item.isEmptyOrUndefinedOrNull()) {
+                            if (!globalObject.hasException()) {
+                                return globalObject.ERR(.HTTP2_INVALID_HEADER_VALUE, "Invalid value for header \"{s}\"", .{validated_name}).throw();
+                            }
+                            return .zero;
+                        }
+                        const arr_value_str = item.toJSString(globalObject) catch {
+                            globalObject.clearException();
+                            return globalObject.ERR(.HTTP2_INVALID_HEADER_VALUE, "Invalid value for header \"{s}\"", .{validated_name}).throw();
+                        };
+                        const never_index = (try sensitive_arg.getTruthyPropertyValue(globalObject, validated_name) orelse try sensitive_arg.getTruthyPropertyValue(globalObject, name)) != null;
+                        const arr_value_slice = arr_value_str.toSlice(globalObject, bun.default_allocator);
+                        defer arr_value_slice.deinit();
+                        const arr_value = arr_value_slice.slice();
+                        _ = this.encodeHeaderIntoList(&encoded_headers, alloc, validated_name, arr_value, never_index) catch {
+                            return globalObject.throw("Failed to encode header", .{});
+                        };
+                    }
+                } else if (!js_value.isEmptyOrUndefinedOrNull()) {
                     if (SingleValueHeaders.indexOf(validated_name)) |idx| {
                         if (single_value_headers[idx]) {
                             const exception = globalObject.toTypeError(.HTTP2_HEADER_SINGLE_VALUE, "Header field \"{s}\" must only have a single value", .{validated_name});

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -2457,16 +2457,19 @@ pub const H2FrameParser = struct {
                 if (stream.endAfterHeaders) {
                     const identifier = stream.getIdentifier();
                     identifier.ensureStillAlive();
-                    if (stream.state == .HALF_CLOSED_REMOTE) {
-                        // no more continuation headers we can call it closed
+                    // Mirror the state transitions in handleHeadersFrame's
+                    // END_STREAM path. The prior HEADERS frame already set
+                    // the stream to HALF_CLOSED_REMOTE when END_STREAM is
+                    // accompanied by END_HEADERS=0, so:
+                    //   - HALF_CLOSED_REMOTE: on the server this stays open
+                    //     for the local response; do NOT transition to CLOSED.
+                    //   - HALF_CLOSED_LOCAL / RESERVED_REMOTE: client push
+                    //     stream whose local side already ended → CLOSED.
+                    //   - anything else: fall through to HALF_CLOSED_LOCAL.
+                    if (stream.state == .HALF_CLOSED_LOCAL or stream.state == .RESERVED_REMOTE) {
                         stream.state = .CLOSED;
                         stream.freeResources(this, false);
-                    } else if (stream.state == .RESERVED_REMOTE or stream.state == .HALF_CLOSED_LOCAL) {
-                        // Client-side push stream finishing its response with
-                        // END_STREAM on the initial HEADERS frame.
-                        stream.state = .CLOSED;
-                        stream.freeResources(this, false);
-                    } else {
+                    } else if (stream.state != .HALF_CLOSED_REMOTE) {
                         stream.state = .HALF_CLOSED_LOCAL;
                     }
                     this.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(stream.state)));
@@ -2494,6 +2497,19 @@ pub const H2FrameParser = struct {
             return data.len;
         };
         const parent_stream_id = frame.streamIdentifier;
+
+        // RFC 7540 Section 6.6: PUSH_PROMISE MUST only be sent on a
+        // peer-initiated stream. On the client, peer-initiated means
+        // client-initiated — i.e. odd-numbered. The state check below is
+        // insufficient on its own because a client-side push stream (even
+        // id) legitimately reaches HALF_CLOSED_LOCAL after receiving its
+        // response HEADERS without END_STREAM, so without this parity guard
+        // a server could chain nested push promises on server-initiated
+        // streams.
+        if (frame.streamIdentifier % 2 != 1) {
+            this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "PUSH_PROMISE on server-initiated stream", this.lastStreamID, true);
+            return data.len;
+        }
 
         // RFC 7540 Section 6.10: After a frame without END_HEADERS the only
         // permissible next frame type is CONTINUATION. Reject a PUSH_PROMISE

--- a/src/runtime/api/h2.classes.ts
+++ b/src/runtime/api/h2.classes.ts
@@ -121,6 +121,10 @@ export default [
         fn: "getNextStream",
         length: 0,
       },
+      sendPushPromise: {
+        fn: "sendPushPromise",
+        length: 3,
+      },
     },
     finalize: true,
     construct: true,

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -23,7 +23,7 @@
   "allocator.ptr !=": 1,
   "allocator.ptr ==": 0,
   "global.hasException": 29,
-  "globalObject.hasException": 47,
+  "globalObject.hasException": 50,
   "globalThis.hasException": 126,
   "std.StringArrayHashMap(": 1,
   "std.StringArrayHashMapUnmanaged(": 11,

--- a/test/regression/issue/28712.test.ts
+++ b/test/regression/issue/28712.test.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "bun:test";
+import { tls } from "harness";
+import http2 from "node:http2";
+
+test("HTTP/2 server push streams work", async () => {
+  const { promise: done, resolve, reject } = Promise.withResolvers<{
+    mainBody: string;
+    pushPath: string;
+    pushData: string;
+  }>();
+
+  const server = http2.createSecureServer({ key: tls.key, cert: tls.cert });
+
+  server.on("stream", (stream, _headers) => {
+    stream.pushStream({ ":path": "/style.css" }, (err, pushStream) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      pushStream.respond({
+        [http2.constants.HTTP2_HEADER_STATUS]: 200,
+        [http2.constants.HTTP2_HEADER_CONTENT_TYPE]: "text/css",
+      });
+      pushStream.end("body { background: red; }");
+    });
+
+    stream.respond({
+      [http2.constants.HTTP2_HEADER_STATUS]: 200,
+      [http2.constants.HTTP2_HEADER_CONTENT_TYPE]: "text/html",
+    });
+    stream.end("main response");
+  });
+
+  server.listen(0, () => {
+    const port = (server.address() as any).port;
+    const client = http2.connect(`https://localhost:${port}`, {
+      rejectUnauthorized: false,
+    });
+    client.on("error", reject);
+
+    let pushPath: string | null = null;
+    let pushData: string | null = null;
+    let mainBody: string | null = null;
+
+    function maybeFinish() {
+      if (mainBody !== null && pushData !== null && pushPath !== null) {
+        resolve({ mainBody, pushPath, pushData });
+        client.close();
+        server.close();
+      }
+    }
+
+    client.on("stream", (pushedStream, headers) => {
+      const path = headers[":path"];
+      if (!path) return; // skip non-push stream events
+      pushPath = path as string;
+      let data = "";
+      pushedStream.on("data", (chunk: Buffer) => (data += chunk));
+      pushedStream.on("end", () => {
+        pushData = data;
+        maybeFinish();
+      });
+    });
+
+    const req = client.request({ ":path": "/" });
+    let body = "";
+    req.on("data", (chunk: Buffer) => (body += chunk));
+    req.on("end", () => {
+      mainBody = body;
+      maybeFinish();
+    });
+    req.end();
+  });
+
+  const result = await done;
+  expect(result).toEqual({
+    mainBody: "main response",
+    pushPath: "/style.css",
+    pushData: "body { background: red; }",
+  });
+});

--- a/test/regression/issue/28712.test.ts
+++ b/test/regression/issue/28712.test.ts
@@ -2,116 +2,112 @@ import { expect, test } from "bun:test";
 import { tls } from "harness";
 import http2 from "node:http2";
 
-test(
-  "HTTP/2 server push streams work",
-  async () => {
-    let client: ReturnType<typeof http2.connect> | undefined;
-    let pushErr: Error | null = null;
-    const {
-      promise: done,
-      resolve,
-      reject,
-    } = Promise.withResolvers<{
-      mainBody: string;
-      pushPath: string;
-      pushData: string;
-    }>();
+test("HTTP/2 server push streams work", async () => {
+  let client: ReturnType<typeof http2.connect> | undefined;
+  let pushErr: Error | null = null;
+  const {
+    promise: done,
+    resolve,
+    reject,
+  } = Promise.withResolvers<{
+    mainBody: string;
+    pushPath: string;
+    pushData: string;
+  }>();
 
-    const server = http2.createSecureServer({ key: tls.key, cert: tls.cert });
+  const server = http2.createSecureServer({ key: tls.key, cert: tls.cert });
 
-    function cleanup() {
-      try {
-        client?.close();
-      } catch {}
-      try {
-        server.close();
-      } catch {}
-    }
+  function cleanup() {
+    try {
+      client?.close();
+    } catch {}
+    try {
+      server.close();
+    } catch {}
+  }
 
-    server.on("stream", (stream, _headers) => {
-      stream.pushStream({ ":path": "/style.css" }, (err: Error | null, pushStream: any) => {
-        if (err) {
-          pushErr = err;
-          cleanup();
-          reject(err);
-          return;
-        }
-        pushStream.on("error", () => {});
-        pushStream.respond({
-          [http2.constants.HTTP2_HEADER_STATUS]: 200,
-          [http2.constants.HTTP2_HEADER_CONTENT_TYPE]: "text/css",
-        });
-        pushStream.end("body { background: red; }");
-      });
-
-      stream.on("error", () => {});
-      stream.respond({
-        [http2.constants.HTTP2_HEADER_STATUS]: 200,
-        [http2.constants.HTTP2_HEADER_CONTENT_TYPE]: "text/html",
-      });
-      stream.end("main response");
-    });
-
-    server.on("error", () => {});
-
-    server.listen(0, () => {
-      const port = (server.address() as any).port;
-      client = http2.connect(`https://localhost:${port}`, {
-        rejectUnauthorized: false,
-      });
-      client.on("error", (err: Error) => {
+  server.on("stream", (stream, _headers) => {
+    stream.pushStream({ ":path": "/style.css" }, (err: Error | null, pushStream: any) => {
+      if (err) {
+        pushErr = err;
         cleanup();
         reject(err);
-      });
-
-      let pushPath: string | null = null;
-      let pushData: string | null = null;
-      let mainBody: string | null = null;
-
-      function maybeFinish() {
-        if (mainBody !== null && pushData !== null && pushPath !== null) {
-          resolve({ mainBody, pushPath, pushData });
-          cleanup();
-        }
+        return;
       }
-
-      client.on("stream", (pushedStream: any, headers: any) => {
-        // Push promise request headers have :path; response headers have :status.
-        const path = headers[":path"];
-        if (!path) return;
-        pushPath = path as string;
-        pushedStream.setEncoding?.("utf8");
-        pushedStream.on("error", () => {});
-        let data = "";
-        pushedStream.on("data", (chunk: any) => (data += chunk));
-        pushedStream.on("end", () => {
-          pushData = data;
-          maybeFinish();
-        });
+      pushStream.on("error", () => {});
+      pushStream.respond({
+        [http2.constants.HTTP2_HEADER_STATUS]: 200,
+        [http2.constants.HTTP2_HEADER_CONTENT_TYPE]: "text/css",
       });
-
-      const req = client.request({ ":path": "/" });
-      req.setEncoding("utf8");
-      req.on("error", () => {});
-      let body = "";
-      req.on("data", (chunk: any) => (body += chunk));
-      req.on("end", () => {
-        mainBody = body;
-        maybeFinish();
-      });
-      req.end();
+      pushStream.end("body { background: red; }");
     });
 
-    try {
-      const result = await done;
-      expect(result).toEqual({
-        mainBody: "main response",
-        pushPath: "/style.css",
-        pushData: "body { background: red; }",
-      });
-    } finally {
+    stream.on("error", () => {});
+    stream.respond({
+      [http2.constants.HTTP2_HEADER_STATUS]: 200,
+      [http2.constants.HTTP2_HEADER_CONTENT_TYPE]: "text/html",
+    });
+    stream.end("main response");
+  });
+
+  server.on("error", () => {});
+
+  server.listen(0, () => {
+    const port = (server.address() as any).port;
+    client = http2.connect(`https://localhost:${port}`, {
+      rejectUnauthorized: false,
+    });
+    client.on("error", (err: Error) => {
       cleanup();
+      reject(err);
+    });
+
+    let pushPath: string | null = null;
+    let pushData: string | null = null;
+    let mainBody: string | null = null;
+
+    function maybeFinish() {
+      if (mainBody !== null && pushData !== null && pushPath !== null) {
+        resolve({ mainBody, pushPath, pushData });
+        cleanup();
+      }
     }
-  },
-  15_000,
-);
+
+    client.on("stream", (pushedStream: any, headers: any) => {
+      // Push promise request headers have :path; response headers have :status.
+      const path = headers[":path"];
+      if (!path) return;
+      pushPath = path as string;
+      pushedStream.setEncoding?.("utf8");
+      pushedStream.on("error", () => {});
+      let data = "";
+      pushedStream.on("data", (chunk: any) => (data += chunk));
+      pushedStream.on("end", () => {
+        pushData = data;
+        maybeFinish();
+      });
+    });
+
+    const req = client.request({ ":path": "/" });
+    req.setEncoding("utf8");
+    req.on("error", () => {});
+    let body = "";
+    req.on("data", (chunk: any) => (body += chunk));
+    req.on("end", () => {
+      mainBody = body;
+      maybeFinish();
+    });
+    req.end();
+  });
+
+  try {
+    const result = await done;
+    expect(result).toEqual({
+      mainBody: "main response",
+      pushPath: "/style.css",
+      pushData: "body { background: red; }",
+    });
+  } finally {
+    cleanup();
+  }
+}, 15_000);

--- a/test/regression/issue/28712.test.ts
+++ b/test/regression/issue/28712.test.ts
@@ -2,93 +2,116 @@ import { expect, test } from "bun:test";
 import { tls } from "harness";
 import http2 from "node:http2";
 
-test("HTTP/2 server push streams work", async () => {
-  let client: ReturnType<typeof http2.connect> | undefined;
-  const {
-    promise: done,
-    resolve,
-    reject,
-  } = Promise.withResolvers<{
-    mainBody: string;
-    pushPath: string;
-    pushData: string;
-  }>();
+test(
+  "HTTP/2 server push streams work",
+  async () => {
+    let client: ReturnType<typeof http2.connect> | undefined;
+    let pushErr: Error | null = null;
+    const {
+      promise: done,
+      resolve,
+      reject,
+    } = Promise.withResolvers<{
+      mainBody: string;
+      pushPath: string;
+      pushData: string;
+    }>();
 
-  const server = http2.createSecureServer({ key: tls.key, cert: tls.cert });
+    const server = http2.createSecureServer({ key: tls.key, cert: tls.cert });
 
-  function cleanup() {
-    client?.close();
-    server.close();
-  }
-
-  server.on("stream", (stream, _headers) => {
-    stream.pushStream({ ":path": "/style.css" }, (err: Error | null, pushStream: any) => {
-      if (err) {
-        cleanup();
-        reject(err);
-        return;
-      }
-      pushStream.respond({
-        [http2.constants.HTTP2_HEADER_STATUS]: 200,
-        [http2.constants.HTTP2_HEADER_CONTENT_TYPE]: "text/css",
-      });
-      pushStream.end("body { background: red; }");
-    });
-
-    stream.respond({
-      [http2.constants.HTTP2_HEADER_STATUS]: 200,
-      [http2.constants.HTTP2_HEADER_CONTENT_TYPE]: "text/html",
-    });
-    stream.end("main response");
-  });
-
-  server.listen(0, () => {
-    const port = (server.address() as any).port;
-    client = http2.connect(`https://localhost:${port}`, {
-      rejectUnauthorized: false,
-    });
-    client.on("error", (err: Error) => {
-      cleanup();
-      reject(err);
-    });
-
-    let pushPath: string | null = null;
-    let pushData: string | null = null;
-    let mainBody: string | null = null;
-
-    function maybeFinish() {
-      if (mainBody !== null && pushData !== null && pushPath !== null) {
-        resolve({ mainBody, pushPath, pushData });
-        cleanup();
-      }
+    function cleanup() {
+      try {
+        client?.close();
+      } catch {}
+      try {
+        server.close();
+      } catch {}
     }
 
-    client.on("stream", (pushedStream: any, headers: any) => {
-      const path = headers[":path"];
-      if (!path) return; // skip non-push stream events
-      pushPath = path as string;
-      let data = "";
-      pushedStream.on("data", (chunk: Buffer) => (data += chunk));
-      pushedStream.on("end", () => {
-        pushData = data;
+    server.on("stream", (stream, _headers) => {
+      stream.pushStream({ ":path": "/style.css" }, (err: Error | null, pushStream: any) => {
+        if (err) {
+          pushErr = err;
+          cleanup();
+          reject(err);
+          return;
+        }
+        pushStream.on("error", () => {});
+        pushStream.respond({
+          [http2.constants.HTTP2_HEADER_STATUS]: 200,
+          [http2.constants.HTTP2_HEADER_CONTENT_TYPE]: "text/css",
+        });
+        pushStream.end("body { background: red; }");
+      });
+
+      stream.on("error", () => {});
+      stream.respond({
+        [http2.constants.HTTP2_HEADER_STATUS]: 200,
+        [http2.constants.HTTP2_HEADER_CONTENT_TYPE]: "text/html",
+      });
+      stream.end("main response");
+    });
+
+    server.on("error", () => {});
+
+    server.listen(0, () => {
+      const port = (server.address() as any).port;
+      client = http2.connect(`https://localhost:${port}`, {
+        rejectUnauthorized: false,
+      });
+      client.on("error", (err: Error) => {
+        cleanup();
+        reject(err);
+      });
+
+      let pushPath: string | null = null;
+      let pushData: string | null = null;
+      let mainBody: string | null = null;
+
+      function maybeFinish() {
+        if (mainBody !== null && pushData !== null && pushPath !== null) {
+          resolve({ mainBody, pushPath, pushData });
+          cleanup();
+        }
+      }
+
+      client.on("stream", (pushedStream: any, headers: any) => {
+        // Push promise request headers have :path; response headers have :status.
+        const path = headers[":path"];
+        if (!path) return;
+        pushPath = path as string;
+        pushedStream.setEncoding?.("utf8");
+        pushedStream.on("error", () => {});
+        let data = "";
+        pushedStream.on("data", (chunk: any) => (data += chunk));
+        pushedStream.on("end", () => {
+          pushData = data;
+          maybeFinish();
+        });
+      });
+
+      const req = client.request({ ":path": "/" });
+      req.setEncoding("utf8");
+      req.on("error", () => {});
+      let body = "";
+      req.on("data", (chunk: any) => (body += chunk));
+      req.on("end", () => {
+        mainBody = body;
         maybeFinish();
       });
+      req.end();
     });
 
-    const req = client.request({ ":path": "/" });
-    let body = "";
-    req.on("data", (chunk: Buffer) => (body += chunk));
-    req.on("end", () => {
-      mainBody = body;
-      maybeFinish();
-    });
-    req.end();
-  });
-
-  const result = await done;
-  expect(result).toEqual({
-    mainBody: "main response",
-    pushPath: "/style.css",
-    pushData: "body { background: red; }",
-  });
-});
+    try {
+      const result = await done;
+      expect(result).toEqual({
+        mainBody: "main response",
+        pushPath: "/style.css",
+        pushData: "body { background: red; }",
+      });
+    } finally {
+      cleanup();
+    }
+  },
+  15_000,
+);

--- a/test/regression/issue/28712.test.ts
+++ b/test/regression/issue/28712.test.ts
@@ -3,6 +3,7 @@ import { tls } from "harness";
 import http2 from "node:http2";
 
 test("HTTP/2 server push streams work", async () => {
+  let client: ReturnType<typeof http2.connect> | undefined;
   const {
     promise: done,
     resolve,
@@ -15,9 +16,15 @@ test("HTTP/2 server push streams work", async () => {
 
   const server = http2.createSecureServer({ key: tls.key, cert: tls.cert });
 
+  function cleanup() {
+    client?.close();
+    server.close();
+  }
+
   server.on("stream", (stream, _headers) => {
-    stream.pushStream({ ":path": "/style.css" }, (err, pushStream) => {
+    stream.pushStream({ ":path": "/style.css" }, (err: Error | null, pushStream: any) => {
       if (err) {
+        cleanup();
         reject(err);
         return;
       }
@@ -37,10 +44,13 @@ test("HTTP/2 server push streams work", async () => {
 
   server.listen(0, () => {
     const port = (server.address() as any).port;
-    const client = http2.connect(`https://localhost:${port}`, {
+    client = http2.connect(`https://localhost:${port}`, {
       rejectUnauthorized: false,
     });
-    client.on("error", reject);
+    client.on("error", (err: Error) => {
+      cleanup();
+      reject(err);
+    });
 
     let pushPath: string | null = null;
     let pushData: string | null = null;
@@ -49,12 +59,11 @@ test("HTTP/2 server push streams work", async () => {
     function maybeFinish() {
       if (mainBody !== null && pushData !== null && pushPath !== null) {
         resolve({ mainBody, pushPath, pushData });
-        client.close();
-        server.close();
+        cleanup();
       }
     }
 
-    client.on("stream", (pushedStream, headers) => {
+    client.on("stream", (pushedStream: any, headers: any) => {
       const path = headers[":path"];
       if (!path) return; // skip non-push stream events
       pushPath = path as string;

--- a/test/regression/issue/28712.test.ts
+++ b/test/regression/issue/28712.test.ts
@@ -1,9 +1,13 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { tls } from "harness";
 import http2 from "node:http2";
 
 test("HTTP/2 server push streams work", async () => {
-  const { promise: done, resolve, reject } = Promise.withResolvers<{
+  const {
+    promise: done,
+    resolve,
+    reject,
+  } = Promise.withResolvers<{
     mainBody: string;
     pushPath: string;
     pushData: string;

--- a/test/regression/issue/28712.test.ts
+++ b/test/regression/issue/28712.test.ts
@@ -185,6 +185,58 @@ test("nested pushStream() throws ERR_HTTP2_NESTED_PUSH", async () => {
   }
 });
 
+test("pushStream() rejects with ERR_HTTP2_PUSH_DISABLED after session.close()", async () => {
+  let client: ReturnType<typeof http2.connect> | undefined;
+  const { promise: done, resolve, reject } = Promise.withResolvers<string | undefined>();
+
+  const server = http2.createSecureServer({ key: tls.key, cert: tls.cert });
+
+  function cleanup() {
+    try {
+      client?.close();
+    } catch {}
+    try {
+      server.close();
+    } catch {}
+  }
+
+  server.on("stream", (stream: any) => {
+    stream.on("error", () => {});
+    // Close the session gracefully — the parser stays alive while the
+    // current stream drains, but session.closed is now true. pushStream()
+    // should throw ERR_HTTP2_PUSH_DISABLED (matches the pushAllowed getter
+    // which already returns false in this state).
+    stream.session.close();
+    let code: string | undefined;
+    try {
+      stream.pushStream({ ":path": "/a.css" }, () => {});
+    } catch (e: any) {
+      code = e?.code;
+    }
+    stream.respond({ [http2.constants.HTTP2_HEADER_STATUS]: 200 });
+    stream.end("ok");
+    resolve(code);
+  });
+
+  server.on("error", () => {});
+  server.listen(0, () => {
+    const port = (server.address() as any).port;
+    client = http2.connect(`https://localhost:${port}`, { rejectUnauthorized: false });
+    client.on("error", () => {});
+    const req = client.request({ ":path": "/" });
+    req.on("error", () => {});
+    req.resume();
+    req.end();
+  });
+
+  try {
+    const code = await done;
+    expect(code).toBe("ERR_HTTP2_PUSH_DISABLED");
+  } finally {
+    cleanup();
+  }
+});
+
 test("pushStream() inherits :authority from the client's request headers", async () => {
   let client: ReturnType<typeof http2.connect> | undefined;
   const { promise: done, resolve, reject } = Promise.withResolvers<string | undefined>();

--- a/test/regression/issue/28712.test.ts
+++ b/test/regression/issue/28712.test.ts
@@ -184,3 +184,73 @@ test("nested pushStream() throws ERR_HTTP2_NESTED_PUSH", async () => {
     cleanup();
   }
 });
+
+test("pushStream() does not leak http2.sensitiveHeaders symbol as a bogus header", async () => {
+  let client: ReturnType<typeof http2.connect> | undefined;
+  const { promise: done, resolve, reject } = Promise.withResolvers<string[]>();
+
+  const server = http2.createSecureServer({ key: tls.key, cert: tls.cert });
+
+  function cleanup() {
+    try {
+      client?.close();
+    } catch {}
+    try {
+      server.close();
+    } catch {}
+  }
+
+  server.on("stream", (stream: any) => {
+    stream.on("error", () => {});
+    // Pass a sensitiveHeaders symbol in the push headers; if the symbol leaks
+    // through the object spread to native, its description string
+    // "nodejs.http2.sensitiveHeaders" would be HPACK-encoded as a real header.
+    const pushHeaders: any = {
+      ":path": "/a.css",
+      authorization: "Bearer topsecret",
+      [http2.sensitiveHeaders]: ["authorization"],
+    };
+    stream.pushStream(pushHeaders, (err: Error | null, pushStream: any) => {
+      if (err) {
+        cleanup();
+        reject(err);
+        return;
+      }
+      pushStream.on("error", () => {});
+      pushStream.respond({ [http2.constants.HTTP2_HEADER_STATUS]: 200 });
+      pushStream.end("a");
+    });
+    stream.respond({ [http2.constants.HTTP2_HEADER_STATUS]: 200 });
+    stream.end("root");
+  });
+
+  server.on("error", () => {});
+  server.listen(0, () => {
+    const port = (server.address() as any).port;
+    client = http2.connect(`https://localhost:${port}`, { rejectUnauthorized: false });
+    client.on("error", (err: Error) => {
+      cleanup();
+      reject(err);
+    });
+    client.on("stream", (_pushedStream: any, headers: any) => {
+      // Emit the received header names for the PUSH_PROMISE request block.
+      resolve(Object.keys(headers));
+      _pushedStream.on("error", () => {});
+      _pushedStream.resume();
+    });
+    const req = client.request({ ":path": "/" });
+    req.on("error", () => {});
+    req.resume();
+    req.end();
+  });
+
+  try {
+    const names = await done;
+    // No HPACK-encoded header should have a name derived from the symbol.
+    for (const n of names) {
+      expect(n.toLowerCase()).not.toContain("nodejs.http2.sensitiveheaders");
+    }
+  } finally {
+    cleanup();
+  }
+});

--- a/test/regression/issue/28712.test.ts
+++ b/test/regression/issue/28712.test.ts
@@ -13,6 +13,7 @@ test("HTTP/2 server push streams work", async () => {
     mainBody: string;
     pushPath: string;
     pushData: string;
+    pushResponseStatus: number;
   }>();
 
   const server = http2.createSecureServer({ key: tls.key, cert: tls.cert });
@@ -64,11 +65,12 @@ test("HTTP/2 server push streams work", async () => {
 
     let pushPath: string | null = null;
     let pushData: string | null = null;
+    let pushResponseStatus: number | null = null;
     let mainBody: string | null = null;
 
     function maybeFinish() {
-      if (mainBody !== null && pushData !== null && pushPath !== null) {
-        resolve({ mainBody, pushPath, pushData });
+      if (mainBody !== null && pushData !== null && pushPath !== null && pushResponseStatus !== null) {
+        resolve({ mainBody, pushPath, pushData, pushResponseStatus });
         cleanup();
       }
     }
@@ -80,6 +82,11 @@ test("HTTP/2 server push streams work", async () => {
       pushPath = path as string;
       pushedStream.setEncoding?.("utf8");
       pushedStream.on("error", () => {});
+      // Node emits 'push' (not 'response') for a pushed stream's final
+      // response headers. Capture :status so we exercise the event name.
+      pushedStream.on("push", (pushResponseHeaders: any) => {
+        pushResponseStatus = pushResponseHeaders[":status"];
+      });
       let data = "";
       pushedStream.on("data", (chunk: any) => (data += chunk));
       pushedStream.on("end", () => {
@@ -106,8 +113,9 @@ test("HTTP/2 server push streams work", async () => {
       mainBody: "main response",
       pushPath: "/style.css",
       pushData: "body { background: red; }",
+      pushResponseStatus: 200,
     });
   } finally {
     cleanup();
   }
-}, 15_000);
+});

--- a/test/regression/issue/28712.test.ts
+++ b/test/regression/issue/28712.test.ts
@@ -185,6 +185,73 @@ test("nested pushStream() throws ERR_HTTP2_NESTED_PUSH", async () => {
   }
 });
 
+test("pushStream() inherits :authority from the client's request headers", async () => {
+  let client: ReturnType<typeof http2.connect> | undefined;
+  const { promise: done, resolve, reject } = Promise.withResolvers<string | undefined>();
+
+  const server = http2.createSecureServer({ key: tls.key, cert: tls.cert });
+
+  function cleanup() {
+    try {
+      client?.close();
+    } catch {}
+    try {
+      server.close();
+    } catch {}
+  }
+
+  server.on("stream", (stream: any) => {
+    stream.on("error", () => {});
+    // Omit :authority from the push headers so pushStream() has to derive it
+    // from the inbound request headers (Node: stream[kHeaders][':authority']).
+    // Without the fix, it would fall back to "localhost".
+    stream.pushStream({ ":path": "/a.css" }, (err: Error | null, pushStream: any) => {
+      if (err) {
+        cleanup();
+        reject(err);
+        return;
+      }
+      pushStream.on("error", () => {});
+      pushStream.respond({ [http2.constants.HTTP2_HEADER_STATUS]: 200 });
+      pushStream.end("a");
+    });
+    stream.respond({ [http2.constants.HTTP2_HEADER_STATUS]: 200 });
+    stream.end("root");
+  });
+
+  server.on("error", () => {});
+  server.listen(0, () => {
+    const port = (server.address() as any).port;
+    client = http2.connect(`https://localhost:${port}`, { rejectUnauthorized: false });
+    client.on("error", (err: Error) => {
+      cleanup();
+      reject(err);
+    });
+    client.on("stream", (pushedStream: any, pushHeaders: any) => {
+      pushedStream.on("error", () => {});
+      pushedStream.resume();
+      resolve(pushHeaders[":authority"]);
+    });
+    // Send the request with a distinct :authority so the fallback "localhost"
+    // path would not coincidentally match.
+    const req = client.request({ ":path": "/", ":authority": `localhost:${port}` });
+    req.on("error", () => {});
+    req.resume();
+    req.end();
+  });
+
+  try {
+    const authority = await done;
+    expect(authority).toBeDefined();
+    // The :authority on the pushed stream must contain the port the client
+    // actually connected to (localhost:PORT). Plain "localhost" means the
+    // fix didn't wire up — that's the buggy fallback.
+    expect(authority).toMatch(/^localhost:\d+$/);
+  } finally {
+    cleanup();
+  }
+});
+
 test("pushStream() does not leak http2.sensitiveHeaders symbol as a bogus header", async () => {
   let client: ReturnType<typeof http2.connect> | undefined;
   const { promise: done, resolve, reject } = Promise.withResolvers<string[]>();

--- a/test/regression/issue/28712.test.ts
+++ b/test/regression/issue/28712.test.ts
@@ -252,6 +252,70 @@ test("pushStream() inherits :authority from the client's request headers", async
   }
 });
 
+test("client session.close() completes when server response headers span HEADERS + CONTINUATION", async () => {
+  let client: ReturnType<typeof http2.connect> | undefined;
+  const { promise: done, resolve, reject } = Promise.withResolvers<{ closed: boolean; status: number | undefined }>();
+
+  const server = http2.createSecureServer({ key: tls.key, cert: tls.cert });
+
+  function cleanup() {
+    try {
+      client?.close();
+    } catch {}
+    try {
+      server.close();
+    } catch {}
+  }
+
+  server.on("stream", (stream: any) => {
+    stream.on("error", () => {});
+    // Respond with a bodyless response whose headers exceed maxFrameSize
+    // (~16KB default) so the framing lands as HEADERS(END_STREAM=1,
+    // END_HEADERS=0) + CONTINUATION(END_HEADERS=1). Prior to the fix, the
+    // client's CONTINUATION path left the stream stuck in HALF_CLOSED_REMOTE
+    // and session.close() would hang because #connections never reached 0.
+    // Keep the pair count under maxHeaderListPairs (128) and total size
+    // under maxHeaderListSize (65535) so only the per-frame limit matters.
+    const bigHeaders: any = { [http2.constants.HTTP2_HEADER_STATUS]: 200 };
+    for (let i = 0; i < 100; i++) {
+      bigHeaders[`x-custom-header-${i}`] = "x".repeat(200);
+    }
+    stream.respond(bigHeaders, { endStream: true });
+  });
+
+  server.on("error", () => {});
+  server.listen(0, () => {
+    const port = (server.address() as any).port;
+    client = http2.connect(`https://localhost:${port}`, { rejectUnauthorized: false });
+    client.on("error", (err: Error) => {
+      cleanup();
+      reject(err);
+    });
+
+    let respStatus: number | undefined;
+    const req = client.request({ ":path": "/" });
+    req.on("response", headers => {
+      respStatus = headers[":status"];
+    });
+    req.on("error", () => {});
+    req.on("end", () => {
+      // Now try to close the session cleanly. If #connections is stuck
+      // at 1 (the stream leak scenario) this never fires.
+      client!.close(() => resolve({ closed: true, status: respStatus }));
+    });
+    req.resume();
+    req.end();
+  });
+
+  try {
+    const result = await done;
+    expect(result.closed).toBe(true);
+    expect(result.status).toBe(200);
+  } finally {
+    cleanup();
+  }
+});
+
 test("pushStream() does not leak http2.sensitiveHeaders symbol as a bogus header", async () => {
   let client: ReturnType<typeof http2.connect> | undefined;
   const { promise: done, resolve, reject } = Promise.withResolvers<string[]>();

--- a/test/regression/issue/28712.test.ts
+++ b/test/regression/issue/28712.test.ts
@@ -4,7 +4,6 @@ import http2 from "node:http2";
 
 test("HTTP/2 server push streams work", async () => {
   let client: ReturnType<typeof http2.connect> | undefined;
-  let pushErr: Error | null = null;
   const {
     promise: done,
     resolve,
@@ -30,7 +29,6 @@ test("HTTP/2 server push streams work", async () => {
   server.on("stream", (stream, _headers) => {
     stream.pushStream({ ":path": "/style.css" }, (err: Error | null, pushStream: any) => {
       if (err) {
-        pushErr = err;
         cleanup();
         reject(err);
         return;
@@ -115,6 +113,73 @@ test("HTTP/2 server push streams work", async () => {
       pushData: "body { background: red; }",
       pushResponseStatus: 200,
     });
+  } finally {
+    cleanup();
+  }
+});
+
+test("nested pushStream() throws ERR_HTTP2_NESTED_PUSH", async () => {
+  let client: ReturnType<typeof http2.connect> | undefined;
+  const { promise: done, resolve, reject } = Promise.withResolvers<string | undefined>();
+
+  const server = http2.createSecureServer({ key: tls.key, cert: tls.cert });
+
+  function cleanup() {
+    try {
+      client?.close();
+    } catch {}
+    try {
+      server.close();
+    } catch {}
+  }
+
+  server.on("stream", (stream: any) => {
+    stream.on("error", () => {});
+    stream.pushStream({ ":path": "/a.css" }, (err: Error | null, pushStream: any) => {
+      if (err) {
+        cleanup();
+        reject(err);
+        return;
+      }
+      pushStream.on("error", () => {});
+      let nestedCode: string | undefined;
+      try {
+        // Nested push — must throw ERR_HTTP2_NESTED_PUSH synchronously per
+        // RFC 7540 §6.6 and Node.js ServerHttp2Stream.pushStream semantics.
+        pushStream.pushStream({ ":path": "/b.css" }, () => {});
+      } catch (e: any) {
+        nestedCode = e?.code;
+      }
+      pushStream.respond({ [http2.constants.HTTP2_HEADER_STATUS]: 200 });
+      pushStream.end("a");
+      resolve(nestedCode);
+    });
+    stream.respond({ [http2.constants.HTTP2_HEADER_STATUS]: 200 });
+    stream.end("root");
+  });
+
+  server.on("error", () => {});
+  server.listen(0, () => {
+    const port = (server.address() as any).port;
+    client = http2.connect(`https://localhost:${port}`, { rejectUnauthorized: false });
+    client.on("error", (err: Error) => {
+      cleanup();
+      reject(err);
+    });
+    client.on("stream", (pushedStream: any) => {
+      pushedStream.on("error", () => {});
+      pushedStream.resume();
+    });
+    const req = client.request({ ":path": "/" });
+    req.on("error", () => {});
+    req.resume();
+    req.on("end", () => {});
+    req.end();
+  });
+
+  try {
+    const code = await done;
+    expect(code).toBe("ERR_HTTP2_NESTED_PUSH");
   } finally {
     cleanup();
   }

--- a/test/regression/issue/28712.test.ts
+++ b/test/regression/issue/28712.test.ts
@@ -317,6 +317,84 @@ test("client session.close() completes when server response headers span HEADERS
   }
 });
 
+test("client POST stays writable when server replies early with CONTINUATION-spanning headers", async () => {
+  let client: ReturnType<typeof http2.connect> | undefined;
+  const { promise: done, resolve, reject } = Promise.withResolvers<{ writeOk: boolean; status: number | undefined }>();
+
+  const server = http2.createSecureServer({ key: tls.key, cert: tls.cert });
+
+  function cleanup() {
+    try {
+      client?.close();
+    } catch {}
+    try {
+      server.close();
+    } catch {}
+  }
+
+  server.on("stream", (stream: any, _headers: any) => {
+    stream.on("error", () => {});
+    stream.on("data", () => {});
+    // Send a bodyless early response whose headers exceed maxFrameSize so
+    // the framing lands as HEADERS(END_STREAM=1, END_HEADERS=0) +
+    // CONTINUATION(END_HEADERS=1). The client is still writing its request
+    // body, so its state is OPEN. The fix preserves OPEN through the split,
+    // leaving the client stream in HALF_CLOSED_REMOTE afterwards (writable
+    // side intact) — without it the client would be destroyed mid-write.
+    const bigHeaders: any = { [http2.constants.HTTP2_HEADER_STATUS]: 413 };
+    const value = Buffer.alloc(200, "x").toString();
+    for (let i = 0; i < 100; i++) {
+      bigHeaders[`x-custom-header-${i}`] = value;
+    }
+    stream.respond(bigHeaders, { endStream: true });
+  });
+
+  server.on("error", () => {});
+  server.listen(0, () => {
+    const port = (server.address() as any).port;
+    client = http2.connect(`https://localhost:${port}`, { rejectUnauthorized: false });
+    client.on("error", (err: Error) => {
+      cleanup();
+      reject(err);
+    });
+
+    // Start a POST without ending the body — the stream is OPEN when the
+    // server's early response arrives.
+    let respStatus: number | undefined;
+    const req = client.request({ ":path": "/upload", ":method": "POST" });
+    req.on("error", () => {});
+    req.resume();
+    req.write("chunk1");
+
+    req.on("response", headers => {
+      respStatus = headers[":status"];
+      // onStreamEnd fires synchronously right after onStreamHeaders on
+      // END_HEADERS; the pre-fix code transitioned OPEN → HALF_CLOSED_REMOTE
+      // → CLOSED there and scheduled stream.destroy(). The destruction
+      // happens at the END of the dispatchWithExtra sequence, so we need
+      // a setImmediate here to observe destroyed === true on the pre-fix
+      // binary. The fix leaves the stream in HALF_CLOSED_REMOTE instead.
+      setImmediate(() => {
+        let writeOk = false;
+        try {
+          req.write("chunk2");
+          writeOk = !req.destroyed;
+        } catch {}
+        req.end();
+        resolve({ writeOk, status: respStatus });
+      });
+    });
+  });
+
+  try {
+    const result = await done;
+    expect(result.status).toBe(413);
+    expect(result.writeOk).toBe(true);
+  } finally {
+    cleanup();
+  }
+});
+
 test("pushStream() does not leak http2.sensitiveHeaders symbol as a bogus header", async () => {
   let client: ReturnType<typeof http2.connect> | undefined;
   const { promise: done, resolve, reject } = Promise.withResolvers<string[]>();

--- a/test/regression/issue/28712.test.ts
+++ b/test/regression/issue/28712.test.ts
@@ -277,8 +277,9 @@ test("client session.close() completes when server response headers span HEADERS
     // Keep the pair count under maxHeaderListPairs (128) and total size
     // under maxHeaderListSize (65535) so only the per-frame limit matters.
     const bigHeaders: any = { [http2.constants.HTTP2_HEADER_STATUS]: 200 };
+    const value = Buffer.alloc(200, "x").toString();
     for (let i = 0; i < 100; i++) {
-      bigHeaders[`x-custom-header-${i}`] = "x".repeat(200);
+      bigHeaders[`x-custom-header-${i}`] = value;
     }
     stream.respond(bigHeaders, { endStream: true });
   });


### PR DESCRIPTION
Fixes #28712

## Problem

`ServerHttp2Stream.pushStream()` was a stub that unconditionally threw `ERR_HTTP2_PUSH_DISABLED`. The native H2 frame parser had no handler for PUSH_PROMISE frames (type 0x05) — receiving one triggered a GOAWAY with PROTOCOL_ERROR. The client-side push stream handler also instantiated `ClientHttp2Session` instead of `ClientHttp2Stream`.

## Root Cause

HTTP/2 server push was never implemented — only the frame type constant and settings plumbing existed.

## Fix

**Native parser (`h2_frame_parser.zig`):**
- Add `handlePushPromiseFrame()` to parse incoming PUSH_PROMISE frames on the client side (extracts promised stream ID, decodes HPACK header block, creates stream in RESERVED_REMOTE state)
- Add `sendPushPromise()` to construct and send PUSH_PROMISE frames from the server (allocates even-numbered stream ID, HPACK-encodes push request headers, handles CONTINUATION for large header blocks)
- Add `HTTP_FRAME_PUSH_PROMISE` dispatch to all three switch blocks in `readBytes()`

**JS layer (`http2.ts`):**
- Implement `ServerHttp2Stream.pushStream()` with proper validation (stream state, remote `enablePush` setting, header defaults)
- Fix `pushAllowed` getter to check `remoteSettings.enablePush` instead of returning `false`
- Fix client `streamStart` handler to create `ClientHttp2Stream` (was `ClientHttp2Session`)
- Add `PushPromiseReceived` flag to `StreamState` to distinguish push promise request headers from response headers, preventing duplicate session `stream` events

**Classes definition (`h2.classes.ts`):**
- Expose `sendPushPromise` as a proto method on `H2FrameParser`

## Verification

```
USE_SYSTEM_BUN=1 bun test test/regression/issue/28712.test.ts  → FAIL (throws ERR_HTTP2_PUSH_DISABLED)
bun bd test test/regression/issue/28712.test.ts                → PASS
bun bd test test/js/node/http2/node-http2.test.js              → 235 pass (all stream event tests pass)
```