### PR TITLE
Fix TLS/HTTP2 connection failure with IP addresses

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1521,6 +1521,7 @@ function lookupAndConnect(self, options) {
   // If host is an IP, skip performing a lookup
   const addressType = isIP(host);
   if (addressType) {
+    self._host = host;
     process.nextTick(() => {
       if (self.connecting) {
         internalConnect(self, options, host, port, addressType, localAddress, localPort);

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -688,7 +688,7 @@ TLSSocket.prototype[buntls] = function (port, host) {
   return {
     socket: this._handle,
     ALPNProtocols: this.ALPNProtocols,
-    serverName: this.servername || host || "localhost",
+    serverName: this.servername === "" ? "" : (this.servername || (net.isIP(host) ? "" : (host || "localhost"))),
     checkServerIdentity: this[kcheckServerIdentity],
     session: this[ksession],
     rejectUnauthorized: this._rejectUnauthorized,
@@ -816,7 +816,7 @@ function Server(options, secureConnectionListener): void {
   this[buntls] = function (port, host, isClient) {
     return [
       {
-        serverName: this.servername || host || "localhost",
+        serverName: this.servername === "" ? "" : (this.servername || (net.isIP(host) ? "" : (host || "localhost"))),
         key: this.key,
         cert: this.cert,
         ca: this.ca,

--- a/test/regression/issue/28716.test.ts
+++ b/test/regression/issue/28716.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/28716
+// http2.connect with an IP address and servername: '' should not fail with
+// UNABLE_TO_VERIFY_LEAF_SIGNATURE. Per RFC 6066, IP addresses must not be
+// sent as SNI; an empty servername should suppress SNI entirely.
+
+test.concurrent("http2.connect with IP address and servername: '' connects successfully", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const http2 = require('http2');
+      const session = http2.connect('https://1.1.1.1', { servername: '' });
+      session.once('error', (err) => {
+        console.error(err.code);
+        session.close();
+        process.exit(1);
+      });
+      session.once('remoteSettings', () => {
+        console.log(JSON.stringify(session.originSet));
+        session.close();
+      });
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("UNABLE_TO_VERIFY_LEAF_SIGNATURE");
+  const origins = JSON.parse(stdout.trim());
+  expect(origins).toBeArrayOfSize(1);
+  expect(origins[0]).toStartWith("https://1.1.1.1");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("tls.connect with IP address and servername: '' connects successfully", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const tls = require('tls');
+      const socket = tls.connect({ host: '1.1.1.1', port: 443, servername: '' }, () => {
+        console.log('authorized:' + socket.authorized);
+        socket.destroy();
+      });
+      socket.once('error', (err) => {
+        console.error(err.code);
+        process.exit(1);
+      });
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("UNABLE_TO_VERIFY_LEAF_SIGNATURE");
+  expect(stdout.trim()).toBe("authorized:true");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("tls.connect with IP address and no servername connects successfully", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const tls = require('tls');
+      const socket = tls.connect({ host: '1.1.1.1', port: 443 }, () => {
+        console.log('authorized:' + socket.authorized);
+        socket.destroy();
+      });
+      socket.once('error', (err) => {
+        console.error(err.code);
+        process.exit(1);
+      });
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("UNABLE_TO_VERIFY_LEAF_SIGNATURE");
+  expect(stdout.trim()).toBe("authorized:true");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Problem

`http2.connect` and `tls.connect` fail with `UNABLE_TO_VERIFY_LEAF_SIGNATURE` when connecting to an IP address with `servername: ''` or without an explicit `servername`. Node.js handles both cases correctly.

```js
const http2 = require('http2');
const session = http2.connect('https://1.1.1.1', { servername: '' });
// Bun: UNABLE_TO_VERIFY_LEAF_SIGNATURE
// Node: connects successfully
```

## Root Cause

Two bugs:

1. **`tls.ts`**: The `[buntls]` method used `||` to compute `serverName`:
   ```js
   serverName: this.servername || host || "localhost"
   ```
   `||` treats `''` as falsy, so an explicit `servername: ''` falls through to the host IP. Per RFC 6066, IP addresses must not be sent as SNI. Changed to `??` with a `net.isIP()` guard so `''` is preserved and IP hosts default to `''` (no SNI).

2. **`net.ts`**: `lookupAndConnect` returns early for IP hosts without setting `self._host`. A second `[buntls]` call in `internalConnect` then uses `self._host` (undefined), overriding the correct `serverName` with `'localhost'`.

## Fix

- `tls.ts`: `serverName: this.servername ?? (net.isIP(host) ? "" : (host || "localhost"))` — preserves empty string, auto-detects IP hosts
- `net.ts`: Set `self._host = host` before the early return for IP addresses

Fixes #28716