### PR TITLE
Fix crash in Error.captureStackTrace when stackTraceLimit is nullopt

### DIFF
--- a/src/bun.js/bindings/FormatStackTraceForJS.cpp
+++ b/src/bun.js/bindings/FormatStackTraceForJS.cpp
@@ -682,7 +682,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
     JSC::JSObject* errorObject = objectArg.asCell()->getObject();
     JSC::JSValue caller = callFrame->argument(1);
 
-    size_t stackTraceLimit = globalObject->stackTraceLimit().value();
+    size_t stackTraceLimit = globalObject->stackTraceLimit().value_or(DEFAULT_ERROR_STACK_TRACE_LIMIT);
     if (stackTraceLimit == 0) {
         stackTraceLimit = DEFAULT_ERROR_STACK_TRACE_LIMIT;
     }

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -790,3 +790,22 @@ test("captureStackTrace with constructor function not in stack returns error str
     expect(e.stack).toBe("TypeError: bad type");
   }
 });
+
+test("captureStackTrace does not crash when stackTraceLimit is deleted or non-numeric", () => {
+  const origLimit = Error.stackTraceLimit;
+  try {
+    // Setting to non-number makes the internal optional nullopt
+    Error.stackTraceLimit = "not a number";
+    expect(() => Error.captureStackTrace({})).not.toThrow();
+
+    // Deleting also makes it nullopt
+    delete Error.stackTraceLimit;
+    expect(() => Error.captureStackTrace({})).not.toThrow();
+
+    // undefined
+    Error.stackTraceLimit = undefined;
+    expect(() => Error.captureStackTrace({})).not.toThrow();
+  } finally {
+    Error.stackTraceLimit = origLimit;
+  }
+});


### PR DESCRIPTION
Fixes a crash (SIGABRT) in `Error.captureStackTrace` when `Error.stackTraceLimit` has been deleted or set to a non-number value.

## Root Cause

In `FormatStackTraceForJS.cpp`, line 685 calls `.value()` on the `std::optional<unsigned>` returned by `globalObject->stackTraceLimit()`:

```cpp
size_t stackTraceLimit = globalObject->stackTraceLimit().value();
```

When `Error.stackTraceLimit` is set to a non-number (e.g. a string, undefined) or deleted, `ErrorConstructor::put` / `ErrorConstructor::deleteProperty` in WebKit sets the internal optional to `std::nullopt`. Calling `.value()` on an empty optional throws `std::bad_optional_access`, which terminates the process with SIGABRT.

## Fix

Use `.value_or(DEFAULT_ERROR_STACK_TRACE_LIMIT)` instead of `.value()`, matching the pattern used in WebKit's own `ErrorConstructor.cpp` and other call sites in Bun.

## Repro

```js
delete Error.stackTraceLimit;
Error.captureStackTrace({}); // SIGABRT
```