### PR TITLE
fix(node:http): emit close event on ServerResponse when client disconnects

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -908,6 +908,11 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
         req.destroy();
       }
     }
+
+    // Ensure ServerResponse gets its close event when socket closes (#14697)
+    if (message && !message._closed && !message.destroyed) {
+      process.nextTick(emitCloseNT, message);
+    }
   }
   #onCloseForDestroy(closeCallback) {
     this.#onClose();

--- a/test/regression/issue/14697.test.ts
+++ b/test/regression/issue/14697.test.ts
@@ -29,8 +29,7 @@ test("ServerResponse emits close event when client disconnects", async () => {
   try {
     const controller = new AbortController();
     const fetchPromise = fetch(`http://localhost:${port}`, { signal: controller.signal });
-    // Give the server a moment to receive the request, then abort
-    await Bun.sleep(50);
+    await requestStartedPromise;
     controller.abort();
     await fetchPromise.catch(() => {});
   } catch {

--- a/test/regression/issue/14697.test.ts
+++ b/test/regression/issue/14697.test.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "bun:test";
+import { createServer } from "node:http";
+
+// https://github.com/oven-sh/bun/issues/14697
+test("ServerResponse emits close event when client disconnects", async () => {
+  const { promise: reqClosePromise, resolve: reqCloseResolve } = Promise.withResolvers<void>();
+  const { promise: resClosePromise, resolve: resCloseResolve } = Promise.withResolvers<void>();
+
+  const server = createServer((req, res) => {
+    req.once("close", () => {
+      reqCloseResolve();
+    });
+
+    res.once("close", () => {
+      resCloseResolve();
+    });
+  });
+
+  const { promise: listeningPromise, resolve: listeningResolve } = Promise.withResolvers<void>();
+  server.listen(0, () => {
+    listeningResolve();
+  });
+  await listeningPromise;
+
+  const addr = server.address()!;
+  const port = typeof addr === "string" ? 0 : addr.port;
+
+  // Connect and immediately abort to simulate client disconnect
+  try {
+    const controller = new AbortController();
+    const fetchPromise = fetch(`http://localhost:${port}`, { signal: controller.signal });
+    // Give the server a moment to receive the request, then abort
+    await Bun.sleep(50);
+    controller.abort();
+    await fetchPromise.catch(() => {});
+  } catch {
+    // Expected - abort causes an error
+  }
+
+  // Both close events should fire
+  await Promise.all([
+    reqClosePromise,
+    resClosePromise,
+  ]);
+
+  server.close();
+});


### PR DESCRIPTION
## Summary
- Fix `ServerResponse` not emitting `close` event when client disconnects before `response.end()` is called
- In `NodeHTTPServerSocket.#onClose()`, the socket close handler was destroying the `IncomingMessage` (request) but not scheduling the `close` event on the `ServerResponse`
- Added `process.nextTick(emitCloseNT, message)` with guards (`!message._closed && !message.destroyed`) to prevent double-emit

Closes #14697

## Repro (from issue)
```js
import { createServer } from "node:http";

createServer((req, res) => {
  req.once("close", () => console.log("Request closed"));
  res.once("close", () => console.log("Response closed"));
}).listen(3000);
```
```sh
curl --request GET --no-buffer http://localhost:3000
# Ctrl+C
```

**Before:** Only "Request closed" printed  
**After:** Both "Response closed" and "Request closed" printed (matches Node.js)