### PR TITLE
fix: return rejected promise in ByteBlobLoader.toBufferedValue when store is null

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,7 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    return globalThis.ERR(.BODY_ALREADY_USED, "Body already used", .{}).reject();
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/test/js/web/streams/readable-stream-bytes-after-consume.test.ts
+++ b/test/js/web/streams/readable-stream-bytes-after-consume.test.ts
@@ -6,5 +6,5 @@ test("ReadableStream .bytes() after body consumed via Response.bytes() does not 
   // Consume body through Response (drains ByteBlobLoader store via toBlobIfPossible)
   await resp.bytes();
   // Calling .bytes() on the now-drained ReadableStream should reject, not crash
-  expect(async () => await body.bytes()).toThrow("Body already used");
+  await expect(body.bytes()).rejects.toThrow("Body already used");
 });

--- a/test/js/web/streams/readable-stream-bytes-after-consume.test.ts
+++ b/test/js/web/streams/readable-stream-bytes-after-consume.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("ReadableStream .bytes() after body consumed via Response.bytes() does not crash", async () => {
   const resp = new Response("Hello World");

--- a/test/js/web/streams/readable-stream-bytes-after-consume.test.ts
+++ b/test/js/web/streams/readable-stream-bytes-after-consume.test.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "bun:test";
+
+test("ReadableStream .bytes() after body consumed via Response.bytes() does not crash", async () => {
+  const resp = new Response("Hello World");
+  const body = resp.body!;
+  // Consume body through Response (drains ByteBlobLoader store via toBlobIfPossible)
+  await resp.bytes();
+  // Calling .bytes() on the now-drained ReadableStream should reject, not crash
+  expect(async () => await body.bytes()).toThrow("Body already used");
+});


### PR DESCRIPTION
When `Response.bytes()` consumes a body that has an active ReadableStream, `toBlobIfPossible` drains the `ByteBlobLoader`'s store without marking the JS-side stream as disturbed. A subsequent call to `ReadableStream.prototype.bytes()` enters the buffered fast path (stream undisturbed, native ptr present) and calls `toBufferedValue`, which finds a null store and returns `.zero` without setting a JS exception — violating the host function contract and causing an assertion failure (debug) or segfault (release).

**Fix:** Return a rejected promise with `ERR_BODY_ALREADY_USED` instead, matching the existing pattern in `Body.handleBodyAlreadyUsed`.

**Repro:**
```js
const resp = new Response("Hello World");
const body = resp.body;
resp.bytes();
body.bytes(); // crash
```

Crash fingerprint: `61e1737779e6cfeb`