### PR TITLE
lint: remove no-undef-init from oxlint.json

### DIFF
--- a/oxlint.json
+++ b/oxlint.json
@@ -26,8 +26,6 @@
     // We have custom thenables. This is not a bug.
     "no-thenable": "off",
 
-    "no-undef-init": "error",
-
     // We use this in some cases. The ordering is deliberate.
     "no-unsafe-finally": "off",
 


### PR DESCRIPTION
CI's **Lint JavaScript** check fails on every PR with:

```
Failed to parse oxlint configuration file.
× Rule 'no-undef-init' not found in plugin 'eslint'
```

The workflow runs `bunx oxlint` (unpinned, `BUN_VERSION: 1.2.10` on the runner), which resolves to an oxlint build where this rule name is not recognized under the eslint plugin namespace. Local oxlint 1.56.0 handles it fine.

Main's lint runs are stuck in `action_required` so this breakage was invisible on main but hits every PR.

The rule itself is minor (`let x = undefined` being redundant). Removed to unblock CI.