### PR TITLE
feat: set default minimumReleaseAge to 3 days (259200s)

### DIFF
--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -79,7 +79,8 @@ security_scanner: ?[]const u8 = null,
 
 // Minimum release age in ms (security feature)
 // Only install packages published at least N ms ago
-minimum_release_age_ms: ?f64 = null,
+// Default: 259200000ms (3 days) to protect against supply chain attacks
+minimum_release_age_ms: ?f64 = 259200000.0,
 // Packages to exclude from minimum release age checking
 minimum_release_age_excludes: ?[]const []const u8 = null,
 

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -1805,9 +1805,9 @@ registry = "${mockRegistryUrl}"`,
         ".npmrc": `registry=${mockRegistryUrl}`,
       });
 
-      // First install without minimum-release-age to get latest
+      // First install with minimum-release-age=0 to disable the default 3-day filter and get latest
       let proc = Bun.spawn({
-        cmd: [bunExe(), "install"],
+        cmd: [bunExe(), "install", "--minimum-release-age", "0"],
         cwd: String(dir),
         env: bunEnv,
         stdout: "pipe",
@@ -1818,7 +1818,7 @@ registry = "${mockRegistryUrl}"`,
       expect(exitCode).toBe(0);
 
       const lockfile = await Bun.file(`${dir}/bun.lock`).text();
-      expect(lockfile).toContain("regular-package@3.0.0"); // Latest version
+      expect(lockfile).toContain("regular-package@3.0.0"); // Latest version (age filter disabled)
 
       // Now try with frozen lockfile and minimum-release-age
       // Frozen lockfile means no changes to lockfile - versions stay as-is


### PR DESCRIPTION
## 🛡️ Motivation: Recent Supply Chain Attacks

This change is motivated by a wave of confirmed supply chain attacks in 2025–2026:

| Incident | Date | Impact |
|----------|------|--------|
| [Shai-Hulud npm Worm](https://about.gitlab.com/blog/2025/09/24/shai-hulud-npm-worm/) | Sep 2025 | 200+ npm packages compromised via stolen GitHub tokens; secrets exfiltrated from CI/CD |
| [Trivy GitHub Actions Compromise](https://github.com/aquasecurity/trivy-action/issues/389) | Mar 2026 | Build pipeline of the popular security scanner hijacked; malicious script injection risk |
| [Polyfill.io Domain Hijack](https://www.cisa.gov/news-events/alerts/2024/07/05/cisa-and-partners-release-advisory-polyfillsio-domain-potentially-compromises-100000-websites) | Ongoing | Domain acquisition used to distribute malicious JS to 100,000+ websites |
| [axios npm Compromise](https://socket.dev/blog/axios-npm-package-compromised) | Mar 2026 | Maintainer account takeover; RAT-infected version published |

**Key finding:** According to [Andrew Nesbitt's research](https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html), **8 out of 10 recent supply chain attacks were detected and removed within 1 week of publication**. A 3-day cooldown would have blocked most of them automatically.

## 🔧 What This PR Does

Sets the default `minimumReleaseAge` to `259200` seconds (3 days = 3 × 24 × 60 × 60).

- **Before:** packages are installable immediately after publishing
- **After:** packages must be at least 3 days old before they can be installed by default
- **Opt-out:** users can set `minimumReleaseAge = 0` in `bunfig.toml` to restore the previous behavior

## 📋 Compliance Alignment

- **[NIST Cybersecurity Framework (CSF) 2.0](https://www.nist.gov/cyberframework)** — Emphasizes Supply Chain Risk Management (C-SCRM) as a core function
- **[CISA: Securing the Software Supply Chain](https://www.cisa.gov/resources-tools/resources/securing-software-supply-chain-recommended-practices-guide-developers)** — Official US government roadmap recommending proactive dependency vetting

## 🔗 References

- https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html
- https://zenn.dev/dely_jp/articles/supply-chain-kowai

## ✅ How did you verify your code works?

1. **Unit test update**: Updated `test/cli/install/minimum-release-age.test.ts` — the "frozen lockfile" test now explicitly passes `--minimum-release-age 0` on the initial install to bypass the new default, confirming the flag works as an opt-out mechanism.
2. **Default activation**: Verified that `minimum_release_age_ms` is non-null by default, so the existing guard (`if (options.minimum_release_age_ms) |age_ms|`) in the install path will enforce the cooldown without any user configuration.
3. **Opt-out path**: Confirmed that setting `minimumReleaseAge = 0` in `bunfig.toml` or passing `--minimum-release-age 0` on the CLI correctly overrides the default back to no restriction.
