### PR TITLE
Fix .todoIf() on test.skip chain in webview.test.ts

### DIFF
--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -467,7 +467,7 @@ it("click dispatches native mousedown/mouseup/click with isTrusted", async () =>
 // TODO: times out on CI (90s) — the rAF-driven actionability poll never
 // resolves. Passes locally; likely a headless/offscreen WKWebView rAF
 // scheduling quirk on the CI runner.
-it.todoIf(isCI)("click(selector) waits for actionability, clicks center", async () => {
+(isMacOS ? test.todoIf(isCI) : test.skip)("click(selector) waits for actionability, clicks center", async () => {
   await using view = new Bun.WebView({ width: 300, height: 300 });
   await view.navigate(
     "data:text/html," +


### PR DESCRIPTION
Line 51 aliases `it = isMacOS ? test : test.skip`. On non-macOS platforms, `it.todoIf(isCI)` at line 470 becomes `test.skip.todoIf()` which throws `Cannot call .todoIf() on test.skip` at file load time — the test file fails to load on Linux/Windows CI.

Use the same pattern already established at line 431: `(isMacOS ? test.todoIf(isCI) : test.skip)(...)` — select the modifier chain upfront instead of chaining `.todoIf()` onto the already-skipped `it` alias.