### PR TITLE
Fix crash in ReadableStream.blob() when blob store is null

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,8 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    var empty: Blob.Any = .{ .Blob = .{} };
+    return empty.toPromise(globalThis, action);
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/test/js/web/streams/readable-stream-blob-after-cancel.test.ts
+++ b/test/js/web/streams/readable-stream-blob-after-cancel.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("ReadableStream.blob() after stream consumed does not crash", async () => {
   // When a BlobInternalReadableStreamSource has its store detached

--- a/test/js/web/streams/readable-stream-blob-after-cancel.test.ts
+++ b/test/js/web/streams/readable-stream-blob-after-cancel.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "bun:test";
+
+test("ReadableStream.blob() after stream consumed does not crash", async () => {
+  // When a BlobInternalReadableStreamSource has its store detached
+  // (e.g. by fully reading the stream), calling .blob() should return
+  // an empty blob, not crash with "Expected an exception to be thrown".
+  const blob = new Blob(["hello"]);
+  const stream = blob.stream();
+  const reader = stream.getReader();
+  await reader.read();
+  await reader.read();
+  reader.releaseLock();
+  const result = await stream.blob();
+  expect(result).toBeInstanceOf(Blob);
+  expect(result.size).toBe(0);
+});


### PR DESCRIPTION
**Root cause:** `ByteBlobLoader.toBufferedValue` returned `JSValue.zero` without setting a JS exception when the underlying blob store was `null` (e.g. after the stream was fully consumed or cancelled). The host function convention requires that returning `.zero` means an exception is pending on the VM, so the debug assertion in `toJSHostCall` fired:

```
panic(main thread): Internal assertion failure: Expected an exception to be thrown
```

**Fix:** Return a resolved promise with an empty blob instead of `.zero`, which matches the behavior of `toAnyBlob` when the store exists — both paths now go through `Blob.Any.toPromise()`.

**Crash fingerprint:** `6da76b3212b1c532`