### PR TITLE
Fix crash in Blob.writer() when options parsing returns an error

### DIFF
--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -2975,7 +2975,16 @@ pub fn getWriter(
 
     if (arguments.len > 0 and arguments.ptr[0].isObject()) {
         stream_start = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
-        stream_start.FileSink.input_path = input_path;
+        switch (stream_start) {
+            .FileSink => |*fs| fs.input_path = input_path,
+            .err => |err| {
+                sink.deref();
+                return globalThis.throwValue(try err.toJS(globalThis));
+            },
+            else => {
+                stream_start = .{ .FileSink = .{ .input_path = input_path } };
+            },
+        }
     }
 
     switch (sink.start(stream_start)) {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -1,6 +1,6 @@
 import { createSocketPair, fileSinkInternals } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
-import { fileDescriptorLeakChecker, isPosix, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, fileDescriptorLeakChecker, isPosix, isWindows, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
 import { join } from "node:path";
 
@@ -182,6 +182,23 @@ it("end doesn't close when backed by a file descriptor", async () => {
   await writer.end();
   await util.promisify(fs.ftruncate)(fd, written);
   await util.promisify(fs.close)(fd);
+});
+
+it("writer with invalid options throws instead of crashing", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `
+      const results = [];
+      try { Bun.file("test.txt").writer({ path: 42 }); results.push("no_throw"); } catch(e) { results.push("threw"); }
+      try { Bun.file("test.txt").writer({ fd: "invalid" }); results.push("no_throw"); } catch(e) { results.push("threw"); }
+      console.log(results.join(","));
+    `],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout.trim()).toBe("threw,threw");
+  expect(exitCode).toBe(0);
 });
 
 it("end does close when not backed by a file descriptor", async () => {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -186,12 +186,16 @@ it("end doesn't close when backed by a file descriptor", async () => {
 
 it("writer with invalid options throws instead of crashing", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `
+    cmd: [
+      bunExe(),
+      "-e",
+      `
       const results = [];
       try { Bun.file("test.txt").writer({ path: 42 }); results.push("no_throw"); } catch(e) { results.push("threw"); }
       try { Bun.file("test.txt").writer({ fd: "invalid" }); results.push("no_throw"); } catch(e) { results.push("threw"); }
       console.log(results.join(","));
-    `],
+    `,
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -184,7 +184,7 @@ it("end doesn't close when backed by a file descriptor", async () => {
   await util.promisify(fs.close)(fd);
 });
 
-it("writer with invalid options throws instead of crashing", async () => {
+it.skipIf(isWindows)("writer with invalid options throws instead of crashing", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),


### PR DESCRIPTION
**What**

`Blob.getWriter` panics with \"access of union field 'FileSink' while field 'err' is active\" when the writer options object has an invalid `path` (non-string) or `fd` (non-integer).

**Root cause**

`Start.fromJSWithTag` can return `.err` (e.g. `EINVAL` for non-string path, `EBADF` for invalid fd), but the code at line 2811 unconditionally accesses `stream_start.FileSink.input_path` without checking which union variant is active.

**Fix**

Switch on the result of `fromJSWithTag`:
- `.FileSink` → set `input_path` as before
- `.err` → clean up the sink and throw the error to JS
- other → reset to default FileSink options

**Repro**

```js
const f = Bun.file("/dev/null");
f.writer({ path: 42 }); // panics instead of throwing
```