### PR TITLE
fix: correct typo issues surfaced by typos review

### DIFF
--- a/src/collections/multi_array_list.zig
+++ b/src/collections/multi_array_list.zig
@@ -250,7 +250,7 @@ pub fn MultiArrayList(comptime T: type) type {
 
         /// Extend the list by 1 element, returning the newly reserved
         /// index with uninitialized data.
-        /// Allocates more memory as necesasry.
+        /// Allocates more memory as necessary.
         pub fn addOne(self: *Self, allocator: Allocator) Allocator.Error!usize {
             self.#allocator.set(allocator);
             try self.ensureUnusedCapacity(allocator, 1);

--- a/src/compile_target.zig
+++ b/src/compile_target.zig
@@ -449,7 +449,7 @@ pub fn from(input_: []const u8) CompileTarget {
     };
 }
 
-// Exists for consistentcy with values.
+// Exists for consistency with values.
 pub fn defineKeys(_: *const CompileTarget) []const []const u8 {
     return &.{
         "process.platform",

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -1221,7 +1221,7 @@ pub const WindowsBufferedReader = struct {
             }
         }
 
-        // move cursor foward
+        // move cursor forward
         buf.items.len += amount.result;
 
         _ = this._onReadChunk(slice, hasMore);

--- a/src/io/PipeWriter.zig
+++ b/src/io/PipeWriter.zig
@@ -1303,7 +1303,7 @@ pub fn WindowsStreamingWriter(comptime Parent: type, function_table: anytype) ty
         }
 
         fn isDone(this: *WindowsWriter) bool {
-            // done is flags andd no more data queued? so we are done!
+            // done is flags and no more data queued? so we are done!
             return this.is_done and !this.hasPendingData();
         }
 

--- a/src/s3/credentials.zig
+++ b/src/s3/credentials.zig
@@ -736,7 +736,7 @@ pub const S3Credentials = struct {
                 break :brk_sign result;
             };
             if (signQuery) {
-                var token_encoded_buffer: [2048]u8 = undefined; // token is normaly like 600-700 but can be up to 2k
+                var token_encoded_buffer: [2048]u8 = undefined; // token is normally like 600-700 but can be up to 2k
                 var encoded_session_token: ?[]const u8 = null;
                 if (session_token) |token| {
                     encoded_session_token = encodeURIComponent(token, &token_encoded_buffer, true) catch return error.InvalidSessionToken;

--- a/src/s3/download_stream.zig
+++ b/src/s3/download_stream.zig
@@ -124,7 +124,7 @@ pub const S3HttpDownloadStreamingTask = struct {
                 break :brk buffer;
             }
         };
-        log("reportProgres failed: {} has_more: {} len: {d}", .{ failed, has_more, chunk.list.items.len });
+        log("reportProgress failed: {} has_more: {} len: {d}", .{ failed, has_more, chunk.list.items.len });
         if (failed) {
             if (!has_more) {
                 this.callback(chunk, false, err, this.callback_context);

--- a/src/s3/list_objects.zig
+++ b/src/s3/list_objects.zig
@@ -36,7 +36,7 @@ const S3ListObjectsContents = struct {
     key: []const u8,
     etag: ?bun.ptr.OwnedIn([]const u8, bun.allocators.MaybeOwned(bun.DefaultAllocator)),
     checksum_type: ?[]const u8,
-    checksum_algorithme: ?[]const u8,
+    checksum_algorithm: ?[]const u8,
     last_modified: ?[]const u8,
     object_size: ?i64,
     storage_class: ?[]const u8,
@@ -125,8 +125,8 @@ pub const S3ListObjectsV2Result = struct {
                     objectInfo.put(globalObject, jsc.ZigString.static("eTag"), try bun.String.createUTF8ForJS(globalObject, etag.get()));
                 }
 
-                if (item.checksum_algorithme) |checksum_algorithme| {
-                    objectInfo.put(globalObject, jsc.ZigString.static("checksumAlgorithme"), try bun.String.createUTF8ForJS(globalObject, checksum_algorithme));
+                if (item.checksum_algorithm) |checksum_algorithm| {
+                    objectInfo.put(globalObject, jsc.ZigString.static("checksumAlgorithm"), try bun.String.createUTF8ForJS(globalObject, checksum_algorithm));
                 }
 
                 if (item.checksum_type) |checksum_type| {
@@ -225,7 +225,7 @@ pub fn parseS3ListObjectsResult(xml: []const u8) !S3ListObjectsV2Result {
                     var etag: ?[]const u8 = null;
                     var etag_owned: bool = false;
                     var checksum_type: ?[]const u8 = null;
-                    var checksum_algorithme: ?[]const u8 = null;
+                    var checksum_algorithm: ?[]const u8 = null;
                     var owner_id: ?[]const u8 = null;
                     var owner_display_name: ?[]const u8 = null;
                     var is_restore_in_progress: ?bool = null;
@@ -273,7 +273,7 @@ pub fn parseS3ListObjectsResult(xml: []const u8) !S3ListObjectsV2Result {
                                     }
                                 } else if (strings.eql(inner_tag_name_or_tag_end, "ChecksumAlgorithm")) {
                                     if (strings.indexOf(xml[i..], "</ChecksumAlgorithm>")) |__tag_end| {
-                                        checksum_algorithme = xml[i .. i + __tag_end];
+                                        checksum_algorithm = xml[i .. i + __tag_end];
                                         i = i + __tag_end + 20;
                                     }
                                 } else if (strings.eql(inner_tag_name_or_tag_end, "ETag")) {
@@ -383,7 +383,7 @@ pub fn parseS3ListObjectsResult(xml: []const u8) !S3ListObjectsV2Result {
                             .key = object_key_val,
                             .etag = if (etag) |etag_| if (etag_owned) .fromRawIn(etag_, .init()) else .fromRawIn(etag_, .initBorrowed()) else null,
                             .checksum_type = checksum_type,
-                            .checksum_algorithme = checksum_algorithme,
+                            .checksum_algorithm = checksum_algorithm,
                             .last_modified = last_modified,
                             .object_size = object_size,
                             .storage_class = storage_class,

--- a/test/js/bun/css/files/hint.css
+++ b/test/js/bun/css/files/hint.css
@@ -84,7 +84,7 @@
 /**
  * source: hint-position.scss
  *
- * Defines the positoning logic for the tooltips.
+ * Defines the positioning logic for the tooltips.
  *
  * Classes added:
  * 	1) hint--top

--- a/test/js/third_party/express/express.json.test.ts
+++ b/test/js/third_party/express/express.json.test.ts
@@ -527,7 +527,7 @@ describe("express.json()", function () {
       app = app;
     });
 
-    it("should presist store", function (done) {
+    it("should persist store", function (done) {
       request(app)
         .post("/")
         .set("Content-Type", "application/json")
@@ -549,7 +549,7 @@ describe("express.json()", function () {
         .end(done);
     });
 
-    it("should presist store when inflated", function (done) {
+    it("should persist store when inflated", function (done) {
       var test = request(app).post("/");
       test.set("Content-Encoding", "gzip");
       test.set("Content-Type", "application/json");
@@ -560,7 +560,7 @@ describe("express.json()", function () {
       test.end(done);
     });
 
-    it("should presist store when inflate error", function (done) {
+    it("should persist store when inflate error", function (done) {
       var test = request(app).post("/");
       test.set("Content-Encoding", "gzip");
       test.set("Content-Type", "application/json");
@@ -570,7 +570,7 @@ describe("express.json()", function () {
       test.end(done);
     });
 
-    it("should presist store when parse error", function (done) {
+    it("should persist store when parse error", function (done) {
       request(app)
         .post("/")
         .set("Content-Type", "application/json")
@@ -580,7 +580,7 @@ describe("express.json()", function () {
         .end(done);
     });
 
-    it("should presist store when limit exceeded", function (done) {
+    it("should persist store when limit exceeded", function (done) {
       request(app)
         .post("/")
         .set("Content-Type", "application/json")

--- a/test/js/third_party/express/express.text.test.ts
+++ b/test/js/third_party/express/express.text.test.ts
@@ -360,7 +360,7 @@ describe("express.text()", function () {
       app = app;
     });
 
-    it("should presist store", function (done) {
+    it("should persist store", function (done) {
       request(app)
         .post("/")
         .set("Content-Type", "text/plain")
@@ -371,7 +371,7 @@ describe("express.text()", function () {
         .end(done);
     });
 
-    it("should presist store when unmatched content-type", function (done) {
+    it("should persist store when unmatched content-type", function (done) {
       request(app)
         .post("/")
         .set("Content-Type", "application/fizzbuzz")
@@ -381,7 +381,7 @@ describe("express.text()", function () {
         .end(done);
     });
 
-    it("should presist store when inflated", function (done) {
+    it("should persist store when inflated", function (done) {
       var test = request(app).post("/");
       test.set("Content-Encoding", "gzip");
       test.set("Content-Type", "text/plain");
@@ -392,7 +392,7 @@ describe("express.text()", function () {
       test.end(done);
     });
 
-    it("should presist store when inflate error", function (done) {
+    it("should persist store when inflate error", function (done) {
       var test = request(app).post("/");
       test.set("Content-Encoding", "gzip");
       test.set("Content-Type", "text/plain");
@@ -402,7 +402,7 @@ describe("express.text()", function () {
       test.end(done);
     });
 
-    it("should presist store when limit exceeded", function (done) {
+    it("should persist store when limit exceeded", function (done) {
       request(app)
         .post("/")
         .set("Content-Type", "text/plain")

--- a/test/js/third_party/express/res.sendFile.test.ts
+++ b/test/js/third_party/express/res.sendFile.test.ts
@@ -247,7 +247,7 @@ describe("res", function () {
     });
 
     describe.todo("async local storage", function () {
-      it("should presist store", function (done) {
+      it("should persist store", function (done) {
         var app = express();
         var cb = after(2, done);
         var store = { foo: "bar" };
@@ -271,7 +271,7 @@ describe("res", function () {
         request(app).get("/").expect("Content-Type", "text/plain; charset=utf-8").expect(200, "tobi", cb);
       });
 
-      it("should presist store on error", function (done) {
+      it("should persist store on error", function (done) {
         var app = express();
         var store = { foo: "bar" };
 


### PR DESCRIPTION
### What does this PR do?

- corrects spelling mistakes surfaced by a typos review in comments, logs, CSS comments, and Express test names
- fixes the S3 list-objects checksum field spelling to `checksumAlgorithm` so it matches `packages/bun-types/s3.d.ts`

Closes #28737

### How did you verify your code works?

- `BUN_DEBUG_QUIET_LOGS=1 bun bd test test/js/bun/s3/s3-list-objects.test.ts`
- Result: 34 passed, 3 skipped, 0 failed