### PR TITLE
Fix crash when calling text() on consumed ReadableStream body

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,7 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    return globalThis.ERR(.BODY_ALREADY_USED, "Body already used", .{}).reject();
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/test/js/web/streams/body-already-consumed.test.ts
+++ b/test/js/web/streams/body-already-consumed.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test";
+
+test("ReadableStream.text() on consumed Response body rejects instead of crashing", async () => {
+  const resp = new Response("Hello");
+  const body = resp.body!;
+  // Consume the body via Response.bytes()
+  await resp.bytes();
+  // Calling text() on the now-consumed stream should return a rejected promise, not crash
+  await expect(body.text()).rejects.toThrow("Body already used");
+});


### PR DESCRIPTION
**What:** `ByteBlobLoader.toBufferedValue` returned `.zero` (null JSValue) without throwing a JS exception when the blob store had already been detached, violating the host function contract and triggering an assertion failure.

**How to reproduce:**
```js
const resp = new Response("Hello");
const body = resp.body;
resp.bytes();
body.text(); // crash: "Expected an exception to be thrown"
```

When `Response.bytes()` is called, it detaches the underlying blob store from the `ByteBlobLoader`. A subsequent `body.text()` call on the already-obtained `ReadableStream` reference reaches `toBufferedValue` where `toAnyBlob()` returns `null`. The function then returned `.zero` — but the `toJSHostCall` wrapper asserts that `.zero` means a JS exception was set, which it wasn't.

**Fix:** Throw a proper JS error (`"Body already consumed"`) instead of returning `.zero`, matching the pattern used by `ByteStream.toBufferedValue` for similar error cases.

---
Crash fingerprint: `8528c32f3d75dc9f`