### PR TITLE
fix(completions): remove dead branch referencing undefined variable in bash completion

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -55,10 +55,7 @@ _read_scripts_in_package_json() {
 
     # when a script is passed as an option, do not show other scripts as part of the completion anymore
     local re_prev_script="(^| )${prev}($| )";
-    [[
-        ( "${COMPREPLY[*]}" =~ ${re_prev_script} && -n "${COMP_WORDS[2]}" ) || \
-            ( "${COMPREPLY[*]}" =~ ${re_comp_word_script} )
-    ]] && {
+    [[ "${COMPREPLY[*]}" =~ ${re_prev_script} && -n "${COMP_WORDS[2]}" ]] && {
         local re_script=$(echo ${package_json_compreply[@]} | sed 's/[^ ]*/(&)/g');
         local new_reply=$(echo "${COMPREPLY[@]}" | sed -E "s/$re_script//");
         COMPREPLY=( $(compgen -W "${new_reply}" -- "${cur_word}") );


### PR DESCRIPTION
### What does this PR do?

Fixes bash tab completion error: `-bash: [[: invalid regular expression: empty (sub)expression`.

`re_comp_word_script` is referenced on [line 60 of `completions/bun.bash`](https://github.com/oven-sh/bun/blob/main/completions/bun.bash#L60) but was never defined anywhere in the script (since the original PR #403 in 2022). This causes `[[ ... =~ ${re_comp_word_script} ]]` to fail with the above error every time tab completion triggers `_read_scripts_in_package_json` (e.g. `bun run <TAB>` or `bun <TAB>` in a directory with a `package.json`).

Rather than guarding the undefined variable with `-n`, this removes the dead branch entirely. Since `re_comp_word_script` was never defined, the condition always evaluated to false — the branch was unreachable dead code. The first branch already correctly handles filtering scripts from completions once a script has been selected as the previous word.

### How did you verify your code works?

Tested with a bash test suite that simulates completion by setting `COMP_WORDS`/`COMP_CWORD` and calling `_bun_completions` directly — 39 tests covering:

| Scenario | Original (brew 1.3.11) | Fixed |
|---|---|---|
| `bun run <TAB>` no stderr | **FAIL** — `invalid regular expression: empty (sub)expression` | PASS |
| `bun <TAB>` no stderr | **FAIL** — same error | PASS |
| `bun dev <TAB>` no stderr | **FAIL** — same error | PASS |
| `bun run dev <TAB>` no stderr | PASS (first branch matches, dead branch skipped) | PASS |
| Script completion (`bun run <TAB>` shows scripts) | PASS | PASS |
| Prefix filtering (`bun run d<TAB>` → `dev`) | PASS | PASS |
| Script dedup (`bun run dev <TAB>` filters other scripts) | PASS | PASS |
| Subcommands, options, `--cwd`, no package.json, etc. (36 tests) | PASS | PASS |