### PR TITLE
Read and execute JavaScript from stdin when piped with no arguments

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -995,6 +995,13 @@ pub const Command = struct {
                     return;
                 }
 
+                // If stdin is piped (not a TTY), read and execute JavaScript
+                // from stdin, matching Node.js behavior.
+                if (!Output.isStdinTTY()) {
+                    try RunCommand.bootFromStdin(ctx);
+                    return;
+                }
+
                 Output.flush();
                 try HelpCommand.exec(allocator);
             },

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -578,6 +578,9 @@ pub const Command = struct {
 
         var next_arg = ((args_iter.next()) orelse return .AutoCommand);
         while (next_arg.len > 0 and next_arg[0] == '-' and !(next_arg.len > 1 and next_arg[1] == 'e')) {
+            if (strings.eqlComptime(next_arg, "-i") or strings.eqlComptime(next_arg, "--interactive")) {
+                return .ReplCommand;
+            }
             next_arg = ((args_iter.next()) orelse return .AutoCommand);
         }
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -550,6 +550,18 @@ pub const Command = struct {
         return strings.endsWithComptime(argv0, "node");
     }
 
+    /// Returns true if the user passed `--interactive` or `-i` on the
+    /// command line. Used by AutoCommand to distinguish interactive/REPL
+    /// intent from piped-stdin script execution.
+    fn hasInteractiveFlag() bool {
+        for (bun.argv[1..]) |arg| {
+            if (strings.eqlComptime(arg, "--interactive") or strings.eqlComptime(arg, "-i")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     pub fn which() Tag {
         var args_iter = ArgsIterator{ .buf = bun.argv };
 
@@ -578,9 +590,6 @@ pub const Command = struct {
 
         var next_arg = ((args_iter.next()) orelse return .AutoCommand);
         while (next_arg.len > 0 and next_arg[0] == '-' and !(next_arg.len > 1 and next_arg[1] == 'e')) {
-            if (strings.eqlComptime(next_arg, "-i") or strings.eqlComptime(next_arg, "--interactive")) {
-                return .ReplCommand;
-            }
             next_arg = ((args_iter.next()) orelse return .AutoCommand);
         }
 
@@ -999,8 +1008,11 @@ pub const Command = struct {
                 }
 
                 // If stdin is piped (not a TTY), read and execute JavaScript
-                // from stdin, matching Node.js behavior.
-                if (!Output.isStdinTTY()) {
+                // from stdin, matching Node.js behavior. Skip when the user
+                // requested interactive mode — `-i` is also Bun's auto-install
+                // short flag but when used alone (no positional) it's meant
+                // to signal interactive/REPL mode per Node.js semantics.
+                if (!Output.isStdinTTY() and !hasInteractiveFlag()) {
                     try RunCommand.bootFromStdin(ctx, false);
                     return;
                 }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -998,7 +998,7 @@ pub const Command = struct {
                 // If stdin is piped (not a TTY), read and execute JavaScript
                 // from stdin, matching Node.js behavior.
                 if (!Output.isStdinTTY()) {
-                    try RunCommand.bootFromStdin(ctx);
+                    try RunCommand.bootFromStdin(ctx, false);
                     return;
                 }
 

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1395,7 +1395,7 @@ pub const RunCommand = struct {
         // check for stdin
 
         if (target_name.len == 1 and target_name[0] == '-') {
-            try bootFromStdin(ctx);
+            try bootFromStdin(ctx, true);
             return true;
         }
 
@@ -1596,8 +1596,10 @@ pub const RunCommand = struct {
 
     /// Read JavaScript from stdin and execute it. Used when bun is invoked
     /// with no arguments and stdin is piped (not a TTY), matching Node.js
-    /// behavior.
-    pub fn bootFromStdin(ctx: Command.Context) !void {
+    /// behavior. When `is_explicit_dash` is true (explicit `bun run -`),
+    /// prepends "-" to argv so scripts can distinguish it from implicit
+    /// piped stdin.
+    pub fn bootFromStdin(ctx: Command.Context, is_explicit_dash: bool) !void {
         log("Executing from stdin", .{});
 
         var stack_fallback = std.heap.stackFallback(2048, bun.default_allocator);
@@ -1620,14 +1622,18 @@ pub const RunCommand = struct {
 
         const trigger = bun.pathLiteral("/[stdin]");
         var entry_point_buf: [bun.MAX_PATH_BYTES + trigger.len]u8 = undefined;
-        const cwd = try std.posix.getcwd(&entry_point_buf);
+        const cwd = try bun.getcwd(&entry_point_buf);
         @memcpy(entry_point_buf[cwd.len..][0..trigger.len], trigger);
         const entry_path = entry_point_buf[0 .. cwd.len + trigger.len];
 
-        var passthrough_list = try std.array_list.Managed(string).initCapacity(ctx.allocator, ctx.passthrough.len + 1);
-        passthrough_list.appendAssumeCapacity("-");
-        passthrough_list.appendSliceAssumeCapacity(ctx.passthrough);
-        ctx.passthrough = passthrough_list.items;
+        // Only prepend "-" to argv for explicit `bun run -`. Implicit
+        // piped stdin (e.g. `echo code | bun`) should not add it.
+        if (is_explicit_dash) {
+            var passthrough_list = try std.array_list.Managed(string).initCapacity(ctx.allocator, ctx.passthrough.len + 1);
+            passthrough_list.appendAssumeCapacity("-");
+            passthrough_list.appendSliceAssumeCapacity(ctx.passthrough);
+            ctx.passthrough = passthrough_list.items;
+        }
 
         Run.boot(ctx, ctx.allocator.dupe(u8, entry_path) catch return error.OutOfMemory, null) catch |err| {
             ctx.log.print(Output.errorWriter()) catch {};

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1604,7 +1604,6 @@ pub const RunCommand = struct {
 
         var stack_fallback = std.heap.stackFallback(2048, bun.default_allocator);
         var list = std.Io.Writer.Allocating.init(stack_fallback.get());
-        errdefer list.deinit();
 
         var file_reader = std.fs.File.stdin().readerStreaming(&.{});
         _ = file_reader.interface.streamRemaining(&list.writer) catch {

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1395,38 +1395,7 @@ pub const RunCommand = struct {
         // check for stdin
 
         if (target_name.len == 1 and target_name[0] == '-') {
-            log("Executing from stdin", .{});
-
-            // read from stdin
-            var stack_fallback = std.heap.stackFallback(2048, bun.default_allocator);
-            var list = std.Io.Writer.Allocating.init(stack_fallback.get());
-            errdefer list.deinit();
-
-            var file_reader = std.fs.File.stdin().readerStreaming(&.{});
-            _ = file_reader.interface.streamRemaining(&list.writer) catch return false;
-            ctx.runtime_options.eval.script = list.written();
-
-            const trigger = bun.pathLiteral("/[stdin]");
-            var entry_point_buf: [bun.MAX_PATH_BYTES + trigger.len]u8 = undefined;
-            const cwd = try std.posix.getcwd(&entry_point_buf);
-            @memcpy(entry_point_buf[cwd.len..][0..trigger.len], trigger);
-            const entry_path = entry_point_buf[0 .. cwd.len + trigger.len];
-
-            var passthrough_list = try std.array_list.Managed(string).initCapacity(ctx.allocator, ctx.passthrough.len + 1);
-            passthrough_list.appendAssumeCapacity("-");
-            passthrough_list.appendSliceAssumeCapacity(ctx.passthrough);
-            ctx.passthrough = passthrough_list.items;
-
-            Run.boot(ctx, ctx.allocator.dupe(u8, entry_path) catch return false, null) catch |err| {
-                ctx.log.print(Output.errorWriter()) catch {};
-
-                Output.prettyErrorln("<r><red>error<r>: Failed to run <b>{s}<r> due to error <b>{s}<r>", .{
-                    std.fs.path.basename(target_name),
-                    @errorName(err),
-                });
-                bun.handleErrorReturnTrace(err, @errorReturnTrace());
-                Global.exit(1);
-            };
+            try bootFromStdin(ctx);
             return true;
         }
 
@@ -1625,6 +1594,51 @@ pub const RunCommand = struct {
         return false;
     }
 
+    /// Read JavaScript from stdin and execute it. Used when bun is invoked
+    /// with no arguments and stdin is piped (not a TTY), matching Node.js
+    /// behavior.
+    pub fn bootFromStdin(ctx: Command.Context) !void {
+        log("Executing from stdin", .{});
+
+        var stack_fallback = std.heap.stackFallback(2048, bun.default_allocator);
+        var list = std.Io.Writer.Allocating.init(stack_fallback.get());
+        errdefer list.deinit();
+
+        var file_reader = std.fs.File.stdin().readerStreaming(&.{});
+        _ = file_reader.interface.streamRemaining(&list.writer) catch {
+            Output.errGeneric("Failed to read from stdin", .{});
+            Global.exit(1);
+        };
+        const script = list.written();
+
+        // Empty stdin — exit successfully, matching Node.js behavior.
+        if (script.len == 0) {
+            Global.exit(0);
+        }
+
+        ctx.runtime_options.eval.script = script;
+
+        const trigger = bun.pathLiteral("/[stdin]");
+        var entry_point_buf: [bun.MAX_PATH_BYTES + trigger.len]u8 = undefined;
+        const cwd = try std.posix.getcwd(&entry_point_buf);
+        @memcpy(entry_point_buf[cwd.len..][0..trigger.len], trigger);
+        const entry_path = entry_point_buf[0 .. cwd.len + trigger.len];
+
+        var passthrough_list = try std.array_list.Managed(string).initCapacity(ctx.allocator, ctx.passthrough.len + 1);
+        passthrough_list.appendAssumeCapacity("-");
+        passthrough_list.appendSliceAssumeCapacity(ctx.passthrough);
+        ctx.passthrough = passthrough_list.items;
+
+        Run.boot(ctx, ctx.allocator.dupe(u8, entry_path) catch bun.outOfMemory(), null) catch |err| {
+            ctx.log.print(Output.errorWriter()) catch {};
+            Output.prettyErrorln("<r><red>error<r>: Failed to run <b>stdin<r> due to error <b>{s}<r>", .{
+                @errorName(err),
+            });
+            bun.handleErrorReturnTrace(err, @errorReturnTrace());
+            Global.exit(1);
+        };
+    }
+
     pub fn execAsIfNode(ctx: Command.Context) !void {
         bun.assert(CLI.pretend_to_be_node);
 
@@ -1638,6 +1652,10 @@ pub const RunCommand = struct {
         }
 
         if (ctx.positionals.len == 0) {
+            if (!Output.isStdinTTY()) {
+                try bootFromStdin(ctx);
+                return;
+            }
             Output.errGeneric("Missing script to execute. Bun's provided 'node' cli wrapper does not support a repl.", .{});
             Global.exit(1);
         }

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1629,7 +1629,7 @@ pub const RunCommand = struct {
         passthrough_list.appendSliceAssumeCapacity(ctx.passthrough);
         ctx.passthrough = passthrough_list.items;
 
-        Run.boot(ctx, ctx.allocator.dupe(u8, entry_path) catch bun.outOfMemory(), null) catch |err| {
+        Run.boot(ctx, ctx.allocator.dupe(u8, entry_path) catch return error.OutOfMemory, null) catch |err| {
             ctx.log.print(Output.errorWriter()) catch {};
             Output.prettyErrorln("<r><red>error<r>: Failed to run <b>stdin<r> due to error <b>{s}<r>", .{
                 @errorName(err),
@@ -1652,10 +1652,6 @@ pub const RunCommand = struct {
         }
 
         if (ctx.positionals.len == 0) {
-            if (!Output.isStdinTTY()) {
-                try bootFromStdin(ctx);
-                return;
-            }
             Output.errGeneric("Missing script to execute. Bun's provided 'node' cli wrapper does not support a repl.", .{});
             Global.exit(1);
         }

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1617,8 +1617,6 @@ pub const RunCommand = struct {
             Global.exit(0);
         }
 
-        ctx.runtime_options.eval.script = script;
-
         const trigger = bun.pathLiteral("/[stdin]");
         var entry_point_buf: [bun.MAX_PATH_BYTES + trigger.len]u8 = undefined;
         const cwd = try bun.getcwd(&entry_point_buf);
@@ -1633,6 +1631,13 @@ pub const RunCommand = struct {
             passthrough_list.appendSliceAssumeCapacity(ctx.passthrough);
             ctx.passthrough = passthrough_list.items;
         }
+
+        // Assign eval.script only after all failable operations. The
+        // script slice may point into stack-allocated memory (scripts
+        // ≤2048 bytes live in stack_fallback's on-stack buffer), so
+        // storing it in the global ctx before a potential error return
+        // would leave a dangling pointer.
+        ctx.runtime_options.eval.script = script;
 
         Run.boot(ctx, ctx.allocator.dupe(u8, entry_path) catch return error.OutOfMemory, null) catch |err| {
             ctx.log.print(Output.errorWriter()) catch {};

--- a/test/regression/issue/28747.test.ts
+++ b/test/regression/issue/28747.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 describe("piping JavaScript to bun via stdin", () => {
@@ -11,10 +11,7 @@ describe("piping JavaScript to bun via stdin", () => {
       env: bunEnv,
     });
 
-    const [stdout, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.exited,
-    ]);
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
     expect(stdout).toBe("hello from stdin\n");
     expect(exitCode).toBe(0);
@@ -22,23 +19,24 @@ describe("piping JavaScript to bun via stdin", () => {
 
   test("child_process.spawn with piped stdin executes code", async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", `
+      cmd: [
+        bunExe(),
+        "-e",
+        `
         const { execFileSync } = require('child_process');
         const result = execFileSync(process.execPath, [], {
           input: 'console.log("hello from child");\\n',
           encoding: 'utf8',
         });
         process.stdout.write(result);
-      `],
+      `,
+      ],
       stdout: "pipe",
       stderr: "pipe",
       env: bunEnv,
     });
 
-    const [stdout, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.exited,
-    ]);
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
     expect(stdout).toBe("hello from child\n");
     expect(exitCode).toBe(0);
@@ -55,21 +53,14 @@ describe("piping JavaScript to bun via stdin", () => {
 
     proc.stdin.end();
 
-    const [stdout, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.exited,
-    ]);
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
     expect(stdout).toBe("");
     expect(exitCode).toBe(0);
   });
 
   test("multiline script from stdin", async () => {
-    const script = [
-      "const x = 42;",
-      "const y = 58;",
-      "console.log(x + y);",
-    ].join("\n");
+    const script = ["const x = 42;", "const y = 58;", "console.log(x + y);"].join("\n");
 
     await using proc = Bun.spawn({
       cmd: [bunExe()],
@@ -79,10 +70,7 @@ describe("piping JavaScript to bun via stdin", () => {
       env: bunEnv,
     });
 
-    const [stdout, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.exited,
-    ]);
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
     expect(stdout).toBe("100\n");
     expect(exitCode).toBe(0);

--- a/test/regression/issue/28747.test.ts
+++ b/test/regression/issue/28747.test.ts
@@ -1,0 +1,90 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+describe("piping JavaScript to bun via stdin", () => {
+  test("executes code piped to stdin with no arguments", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe()],
+      stdin: new TextEncoder().encode('console.log("hello from stdin");\n'),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    const [stdout, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toBe("hello from stdin\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("child_process.spawn with piped stdin executes code", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `
+        const { execFileSync } = require('child_process');
+        const result = execFileSync(process.execPath, [], {
+          input: 'console.log("hello from child");\\n',
+          encoding: 'utf8',
+        });
+        process.stdout.write(result);
+      `],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    const [stdout, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toBe("hello from child\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("empty stdin exits with code 0", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe()],
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    proc.stdin.end();
+
+    const [stdout, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("multiline script from stdin", async () => {
+    const script = [
+      "const x = 42;",
+      "const y = 58;",
+      "console.log(x + y);",
+    ].join("\n");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe()],
+      stdin: new TextEncoder().encode(script),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    const [stdout, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.exited,
+    ]);
+
+    expect(stdout).toBe("100\n");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

When `bun` is invoked with no arguments and stdin is piped (not a TTY), it prints help text instead of reading and executing JavaScript from stdin. This breaks the common Node.js pattern:

```javascript
const { spawn } = require('child_process');
const child = spawn(process.execPath, [], {
  stdio: ['pipe', 'inherit', 'inherit']
});
child.stdin.write('console.log("hello");');
child.stdin.end();
```

Also broken: `echo 'console.log(42)' | bun`

## Root Cause

In `src/cli.zig`, the `AutoCommand` handler unconditionally falls through to `HelpCommand.exec()` when there are no positional arguments, without checking whether stdin is piped. Similarly, `execAsIfNode()` errors with "Missing script to execute" without checking stdin.

## Fix

- Extract the existing stdin-reading logic (from `bun run -`) into a reusable `RunCommand.bootFromStdin()` function
- In `AutoCommand`: check `Output.isStdinTTY()` before falling through to help — if stdin is piped, read and execute it
- In `execAsIfNode()`: same check before erroring on missing script
- Handle empty stdin by exiting cleanly (exit code 0), matching Node.js behavior

## Verification

```
# Before fix:
echo 'console.log(42)' | bun    # prints help text

# After fix:
echo 'console.log(42)' | bun    # prints 42
true | bun                       # exits 0 (empty stdin)
bun                              # still prints help (TTY stdin)
```

`bun bd test test/regression/issue/28747.test.ts` — 4/4 pass
`USE_SYSTEM_BUN=1 bun test test/regression/issue/28747.test.ts` — 4/4 fail

Fixes #28747