### PR TITLE
Fix http request hang after 100-continue response

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -920,7 +920,24 @@ function ClientRequest(input, options, cb) {
 
   this._httpMessage = this;
 
-  process.nextTick(emitContinueAndSocketNT, this);
+  const expectsContinue = this.getHeader("expect") === "100-continue";
+  process.nextTick(emitContinueAndSocketNT, this, expectsContinue ? () => {
+    // For 100-continue, start the fetch immediately after emitting "continue".
+    // The underlying HTTP client handles 100-continue internally, so we need to
+    // initiate the connection. Without this, the fetch only starts when end()
+    // is called, causing a deadlock when code awaits "response" before calling end().
+    if (!fetching && !this.destroyed) {
+      this[kAbortController] ??= new AbortController();
+      this[kAbortController].signal.addEventListener("abort", onAbort, { once: true });
+      this.finished = true;
+      var body = this[kBodyChunks] && this[kBodyChunks].length > 1 ? new Blob(this[kBodyChunks]) : this[kBodyChunks]?.[0];
+      startFetch(body);
+      onEnd = () => {
+        handleResponse?.();
+      };
+      process.nextTick(maybeEmitFinish.bind(this));
+    }
+  } : undefined);
 
   this[kEmitState] = 0;
 
@@ -1031,7 +1048,7 @@ function validateHost(host, name) {
   return host;
 }
 
-function emitContinueAndSocketNT(self) {
+function emitContinueAndSocketNT(self, startFetchCb?) {
   if (self.destroyed) return;
   // Ref: https://github.com/nodejs/node/blob/f63e8b7fa7a4b5e041ddec67307609ec8837154f/lib/_http_client.js#L803-L839
   if (!(self[kEmitState] & (1 << ClientRequestEmitState.socket))) {
@@ -1040,8 +1057,10 @@ function emitContinueAndSocketNT(self) {
   }
 
   // Emit continue event for the client (internally we auto handle it)
-  if (!self._closed && self.getHeader("expect") === "100-continue") {
+  if (!self._closed && startFetchCb) {
     self.emit("continue");
+    // Start the fetch so the response event can fire without waiting for end()
+    startFetchCb();
   }
 }
 

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -920,31 +920,21 @@ function ClientRequest(input, options, cb) {
 
   this._httpMessage = this;
 
-  const expectsContinue = this.getHeader("expect") === "100-continue";
-  process.nextTick(
-    emitContinueAndSocketNT,
-    this,
-    expectsContinue
-      ? () => {
-          // For 100-continue, start the fetch immediately after emitting "continue".
-          // The underlying HTTP client handles 100-continue internally, so we need to
-          // initiate the connection. Without this, the fetch only starts when end()
-          // is called, causing a deadlock when code awaits "response" before calling end().
-          if (!fetching && !this.destroyed) {
-            this[kAbortController] ??= new AbortController();
-            this[kAbortController].signal.addEventListener("abort", onAbort, { once: true });
-            this.finished = true;
-            var body =
-              this[kBodyChunks] && this[kBodyChunks].length > 1 ? new Blob(this[kBodyChunks]) : this[kBodyChunks]?.[0];
-            startFetch(body);
-            onEnd = () => {
-              handleResponse?.();
-            };
-            process.nextTick(maybeEmitFinish.bind(this));
-          }
-        }
-      : undefined,
-  );
+  process.nextTick(emitContinueAndSocketNT, this, () => {
+    // For 100-continue, start the fetch immediately after emitting "continue".
+    // The underlying HTTP client handles 100-continue internally, so we need
+    // to initiate the connection. Without this, the fetch only starts when
+    // end() is called, causing a deadlock when code awaits "response" before
+    // calling end().
+    // Use flushHeaders() which starts the fetch in duplex mode, keeping the
+    // request writable so late write()/end(chunk) still work.
+    this.flushHeaders();
+    // Set onEnd so that when the fetch resolves (with keepOpen=true in duplex
+    // mode), calling onEnd() delivers the response.
+    onEnd = () => {
+      handleResponse?.();
+    };
+  });
 
   this[kEmitState] = 0;
 
@@ -1055,7 +1045,7 @@ function validateHost(host, name) {
   return host;
 }
 
-function emitContinueAndSocketNT(self, startFetchCb?) {
+function emitContinueAndSocketNT(self, onContinue?) {
   if (self.destroyed) return;
   // Ref: https://github.com/nodejs/node/blob/f63e8b7fa7a4b5e041ddec67307609ec8837154f/lib/_http_client.js#L803-L839
   if (!(self[kEmitState] & (1 << ClientRequestEmitState.socket))) {
@@ -1063,11 +1053,12 @@ function emitContinueAndSocketNT(self, startFetchCb?) {
     self.emit("socket", self.socket);
   }
 
-  // Emit continue event for the client (internally we auto handle it)
-  if (!self._closed && startFetchCb) {
+  // Emit continue event and start the fetch for 100-continue requests.
+  // Re-evaluate the header at call time so late setHeader() calls are respected.
+  if (!self._closed && self.getHeader("expect") === "100-continue") {
     self.emit("continue");
     // Start the fetch so the response event can fire without waiting for end()
-    startFetchCb();
+    onContinue?.();
   }
 }
 

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -1055,10 +1055,14 @@ function emitContinueAndSocketNT(self, onContinue?) {
 
   // Emit continue event and start the fetch for 100-continue requests.
   // Re-evaluate the header at call time so late setHeader() calls are respected.
-  if (!self._closed && self.getHeader("expect") === "100-continue") {
+  const expectHeader = self.getHeader("expect");
+  if (!self._closed && expectHeader && expectHeader.toLowerCase() === "100-continue") {
     self.emit("continue");
-    // Start the fetch so the response event can fire without waiting for end()
-    onContinue?.();
+    // A "continue" listener may call req.abort()/req.destroy() — don't start the
+    // fetch if the request was cancelled during the event.
+    if (!self.destroyed && !self._closed && !self.aborted) {
+      onContinue?.();
+    }
   }
 }
 

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -921,23 +921,30 @@ function ClientRequest(input, options, cb) {
   this._httpMessage = this;
 
   const expectsContinue = this.getHeader("expect") === "100-continue";
-  process.nextTick(emitContinueAndSocketNT, this, expectsContinue ? () => {
-    // For 100-continue, start the fetch immediately after emitting "continue".
-    // The underlying HTTP client handles 100-continue internally, so we need to
-    // initiate the connection. Without this, the fetch only starts when end()
-    // is called, causing a deadlock when code awaits "response" before calling end().
-    if (!fetching && !this.destroyed) {
-      this[kAbortController] ??= new AbortController();
-      this[kAbortController].signal.addEventListener("abort", onAbort, { once: true });
-      this.finished = true;
-      var body = this[kBodyChunks] && this[kBodyChunks].length > 1 ? new Blob(this[kBodyChunks]) : this[kBodyChunks]?.[0];
-      startFetch(body);
-      onEnd = () => {
-        handleResponse?.();
-      };
-      process.nextTick(maybeEmitFinish.bind(this));
-    }
-  } : undefined);
+  process.nextTick(
+    emitContinueAndSocketNT,
+    this,
+    expectsContinue
+      ? () => {
+          // For 100-continue, start the fetch immediately after emitting "continue".
+          // The underlying HTTP client handles 100-continue internally, so we need to
+          // initiate the connection. Without this, the fetch only starts when end()
+          // is called, causing a deadlock when code awaits "response" before calling end().
+          if (!fetching && !this.destroyed) {
+            this[kAbortController] ??= new AbortController();
+            this[kAbortController].signal.addEventListener("abort", onAbort, { once: true });
+            this.finished = true;
+            var body =
+              this[kBodyChunks] && this[kBodyChunks].length > 1 ? new Blob(this[kBodyChunks]) : this[kBodyChunks]?.[0];
+            startFetch(body);
+            onEnd = () => {
+              handleResponse?.();
+            };
+            process.nextTick(maybeEmitFinish.bind(this));
+          }
+        }
+      : undefined,
+  );
 
   this[kEmitState] = 0;
 

--- a/test/regression/issue/28749.test.ts
+++ b/test/regression/issue/28749.test.ts
@@ -1,0 +1,103 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("http request with expect: 100-continue does not hang", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const http = require("http");
+
+async function main() {
+  const server = http.createServer((request, response) => response.end());
+  await new Promise(resolve => server.listen(0, resolve));
+  const port = server.address().port;
+
+  const stream = http.request(
+    "http://localhost:" + port + "/",
+    { headers: { "expect": "100-continue" } }
+  );
+
+  const errorPromise = new Promise((resolve, reject) => stream.addListener("error", reject));
+  const continuePromise = new Promise(resolve => stream.addListener("continue", resolve));
+  const responsePromise = new Promise(resolve => stream.addListener("response", resolve));
+
+  await Promise.race([errorPromise, continuePromise]);
+  console.log("continue");
+
+  await Promise.race([errorPromise, responsePromise]);
+  console.log("response");
+
+  await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+  console.log("done");
+}
+
+main().catch(e => { console.error(e); process.exit(1); });
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("continue\nresponse\ndone\n");
+  expect(exitCode).toBe(0);
+});
+
+test("http POST with expect: 100-continue and body works", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const http = require("http");
+
+async function main() {
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", chunk => body += chunk);
+    req.on("end", () => { res.end("got:" + body); });
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  const port = server.address().port;
+
+  const req = http.request("http://localhost:" + port + "/", {
+    method: "POST",
+    headers: { "expect": "100-continue" },
+  });
+
+  req.on("continue", () => {
+    req.end("hello");
+  });
+
+  const res = await new Promise((resolve, reject) => {
+    req.on("response", resolve);
+    req.on("error", reject);
+  });
+
+  const data = await new Promise(resolve => {
+    let d = "";
+    res.on("data", chunk => d += chunk);
+    res.on("end", () => resolve(d));
+  });
+
+  console.log(data);
+  server.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("got:hello\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/28749.test.ts
+++ b/test/regression/issue/28749.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("http request with expect: 100-continue does not hang", async () => {


### PR DESCRIPTION
Fixes #28749

## Problem

When an HTTP request is made with the `expect: 100-continue` header, the request hangs and the `response` event never fires. The `continue` event fires correctly, but code that awaits the `response` event before calling `end()` deadlocks.

```js
const stream = http.request(url, { headers: { expect: '100-continue' } });
stream.on('continue', () => console.log('continue')); // fires
stream.on('response', () => console.log('response')); // never fires
```

## Cause

The underlying fetch is only started when `end()` is called (via `send()`). With `100-continue`, users typically wait for the `continue` event before proceeding, but if they await the `response` event next (without calling `end()` first), the fetch never starts and the response never arrives — a deadlock.

## Fix

When the `expect: 100-continue` header is present, after emitting the `continue` event in `emitContinueAndSocketNT`, automatically start the fetch. This ensures the server receives the request and the `response` event fires without requiring `end()` to be called first.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28749.test.ts` → first test fails (bug exists)
- `bun bd test test/regression/issue/28749.test.ts` → both tests pass (fix works)