### PR TITLE
node:url: match node's authority assembly in legacy url.format()

### DIFF
--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -490,7 +490,7 @@ Url.prototype.format = function format() {
   var auth: string = this.auth || "";
   if (auth) {
     auth = encodeURIComponent(auth);
-    auth = auth.replace(/%3A/i, ":");
+    auth = auth.replace(/%3A/gi, ":");
     auth += "@";
   }
 

--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -505,7 +505,9 @@ Url.prototype.format = function format() {
   if (thisHost) {
     host = auth + thisHost;
   } else if ((thisHostname = this.hostname)) {
-    host = auth + (thisHostname.indexOf(":") === -1 ? thisHostname : "[" + thisHostname + "]");
+    host =
+      auth +
+      (thisHostname.indexOf(":") !== -1 && !isIpv6Hostname(thisHostname) ? "[" + thisHostname + "]" : thisHostname);
     const thisPort = this.port;
     if (thisPort) {
       host += ":" + thisPort;
@@ -527,13 +529,16 @@ Url.prototype.format = function format() {
    * only the slashedProtocols get the //.  Not mailto:, xmpp:, etc.
    * unless they had them to begin with.
    */
-  if (this.slashes || ((!protocol || slashedProtocol[protocol]) && host.length > 0)) {
-    host = "//" + (host || "");
-    if (pathname && pathname.charAt(0) !== "/") {
-      pathname = "/" + pathname;
+  if (this.slashes || slashedProtocol[protocol]) {
+    if (this.slashes || host) {
+      if (pathname && pathname.charAt(0) !== "/") {
+        pathname = "/" + pathname;
+      }
+      host = "//" + host;
+    } else if (protocol === "file:") {
+      // file: keeps the empty authority: "file:///x", never "file:/x".
+      host = "//";
     }
-  } else if (!host) {
-    host = "";
   }
 
   if (hash && hash.charAt(0) !== "#") {

--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -529,8 +529,9 @@ Url.prototype.format = function format() {
    * only the slashedProtocols get the //.  Not mailto:, xmpp:, etc.
    * unless they had them to begin with.
    */
-  if (this.slashes || slashedProtocol[protocol]) {
-    if (this.slashes || host) {
+  const thisSlashes = this.slashes;
+  if (thisSlashes || slashedProtocol[protocol]) {
+    if (thisSlashes || host) {
       if (pathname && pathname.charAt(0) !== "/") {
         pathname = "/" + pathname;
       }

--- a/src/node-fallbacks/url.js
+++ b/src/node-fallbacks/url.js
@@ -406,7 +406,7 @@ Url.prototype.format = function () {
   var auth = this.auth || "";
   if (auth) {
     auth = encodeURIComponent(auth);
-    auth = auth.replace(/%3A/i, ":");
+    auth = auth.replace(/%3A/gi, ":");
     auth += "@";
   }
 
@@ -448,7 +448,7 @@ Url.prototype.format = function () {
   pathname = pathname.replace(/[?#]/g, function (match) {
     return encodeURIComponent(match);
   });
-  search = search.replace("#", "%23");
+  search = search.replace(/#/g, "%23");
 
   return protocol + host + pathname + search + hash;
 };

--- a/src/node-fallbacks/url.js
+++ b/src/node-fallbacks/url.js
@@ -402,6 +402,10 @@ function urlFormat(obj) {
   return obj.format();
 }
 
+function isIpv6Hostname(hostname) {
+  return hostname.charCodeAt(0) === 91 /* [ */ && hostname.charCodeAt(hostname.length - 1) === 93 /* ] */;
+}
+
 Url.prototype.format = function () {
   var auth = this.auth || "";
   if (auth) {
@@ -413,13 +417,15 @@ Url.prototype.format = function () {
   var protocol = this.protocol || "",
     pathname = this.pathname || "",
     hash = this.hash || "",
-    host = false,
+    host = "",
     query = "";
 
   if (this.host) {
     host = auth + this.host;
   } else if (this.hostname) {
-    host = auth + (this.hostname.indexOf(":") === -1 ? this.hostname : "[" + this.hostname + "]");
+    host =
+      auth +
+      (this.hostname.indexOf(":") !== -1 && !isIpv6Hostname(this.hostname) ? "[" + this.hostname + "]" : this.hostname);
     if (this.port) {
       host += ":" + this.port;
     }
@@ -435,11 +441,14 @@ Url.prototype.format = function () {
 
   // only the slashedProtocols get the //.  Not mailto:, xmpp:, etc.
   // unless they had them to begin with.
-  if (this.slashes || ((!protocol || slashedProtocol[protocol]) && host !== false)) {
-    host = "//" + (host || "");
-    if (pathname && pathname.charAt(0) !== "/") pathname = "/" + pathname;
-  } else if (!host) {
-    host = "";
+  if (this.slashes || slashedProtocol[protocol]) {
+    if (this.slashes || host) {
+      if (pathname && pathname.charAt(0) !== "/") pathname = "/" + pathname;
+      host = "//" + host;
+    } else if (protocol === "file:") {
+      // file: keeps the empty authority: "file:///x", never "file:/x".
+      host = "//";
+    }
   }
 
   if (hash && hash.charAt(0) !== "#") hash = "#" + hash;

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -413,6 +413,23 @@ describe("bundler", () => {
     },
   });
 
+  itBundled("browser/NodeUrlFormatAuthority", {
+    files: {
+      "/entry.js": /* js */ `
+        import { format } from "node:url";
+        console.log(format({ auth: "u", hostname: "h" }));
+        console.log(format({ host: "h", pathname: "p" }));
+        console.log(format({ protocol: "file:", pathname: "/x/y" }));
+        console.log(format({ protocol: "file", pathname: "//srv/x" }));
+        console.log(format({ protocol: "http", hostname: "[::1]", port: 8 }));
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "u@h\nhp\nfile:///x/y\nfile:////srv/x\nhttp://[::1]:8",
+    },
+  });
+
   itBundled("browser/NodeUrlFormatSearchHash", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -397,4 +397,32 @@ describe("bundler", () => {
       stdout: "Before!\nThe dispose function was called\n",
     },
   });
+
+  itBundled("browser/NodeUrlFormatAuthColons#28751", {
+    files: {
+      "/entry.js": /* js */ `
+        import { parse, format } from "node:url";
+        const user = encodeURIComponent("us:er");
+        const pass = encodeURIComponent("pass:word");
+        console.log(format(parse("http://" + user + ":" + pass + "@localhost/")));
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "http://us:er:pass:word@localhost/",
+    },
+  });
+
+  itBundled("browser/NodeUrlFormatSearchHash", {
+    files: {
+      "/entry.js": /* js */ `
+        import { format } from "node:url";
+        console.log(format({ protocol: "http:", host: "localhost", pathname: "/", search: "?a#b#c" }));
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "http://localhost/?a%23b%23c",
+    },
+  });
 });

--- a/test/js/node/url/url-format.test.js
+++ b/test/js/node/url/url-format.test.js
@@ -279,6 +279,84 @@ describe("url.format", () => {
     }
   });
 
+  test("only slashed protocols get the // authority separator", () => {
+    // A protocol-less object never gains a "//", and a non-slashed protocol
+    // only gets one when the object was parsed with `slashes`.
+    const cases = [
+      [{ auth: "u", hostname: "h" }, "u@h"],
+      [{ host: "h", pathname: "p" }, "hp"],
+      [{ hostname: "h" }, "h"],
+      [{ host: "h", pathname: "/p", search: "?q", hash: "#f" }, "h/p?q#f"],
+      [{ protocol: "mailto:", host: "h", pathname: "x" }, "mailto:hx"],
+      [{ slashes: true, host: "h", pathname: "p" }, "//h/p"],
+      [{ slashes: true, pathname: "x/y" }, "///x/y"],
+      [{ protocol: "http:", host: "h", pathname: "p" }, "http://h/p"],
+      [{ protocol: "http:", pathname: "x/y" }, "http:x/y"],
+      [{ protocol: "ftp:", pathname: "/x" }, "ftp:/x"],
+      [{ protocol: "gopher:", pathname: "/x" }, "gopher:/x"],
+    ];
+    for (const [urlObject, expected] of cases) {
+      assert.strictEqual(url.format(urlObject), expected, `format(${JSON.stringify(urlObject)})`);
+    }
+  });
+
+  test("file: keeps its empty authority and never swallows a // pathname", () => {
+    // "file:/x/y" and "file://srv/x" mean different things than what was asked
+    // for: the latter would name a remote host `srv`.
+    const cases = [
+      [{ protocol: "file:" }, "file://"],
+      [{ protocol: "file:", pathname: "/x/y" }, "file:///x/y"],
+      [{ protocol: "file", pathname: "//srv/x" }, "file:////srv/x"],
+      [{ protocol: "file:", pathname: "x/y" }, "file://x/y"],
+      [{ protocol: "file:", slashes: true, pathname: "x/y" }, "file:///x/y"],
+      [{ protocol: "file:", slashes: false, pathname: "/x" }, "file:///x"],
+      [{ protocol: "file:", host: "h", pathname: "/x" }, "file://h/x"],
+      [{ protocol: "file:", hostname: "h", pathname: "/x" }, "file://h/x"],
+    ];
+    for (const [urlObject, expected] of cases) {
+      assert.strictEqual(url.format(urlObject), expected, `format(${JSON.stringify(urlObject)})`);
+    }
+
+    // The host of a formatted file: URL is still empty after re-parsing.
+    assert.strictEqual(url.parse(url.format({ protocol: "file", pathname: "//srv/x" })).host, "");
+  });
+
+  test("auth is escaped like node: every colon is preserved", () => {
+    const cases = [
+      [{ auth: "u:p:q", host: "h" }, "u:p:q@h"],
+      [{ auth: "u:p:q", hostname: "h", port: 9 }, "u:p:q@h:9"],
+      [{ auth: ":::", host: "h" }, ":::@h"],
+      // A literal "%3A" in auth is escaped to "%253A", not decoded back to ":".
+      [{ auth: "a%3Ab", host: "h" }, "a%253Ab@h"],
+      [{ auth: "atslash/@:/@", hostname: "foo", protocol: "http:", pathname: "/" }, "http://atslash%2F%40:%2F%40@foo/"],
+    ];
+    for (const [urlObject, expected] of cases) {
+      assert.strictEqual(url.format(urlObject), expected, `format(${JSON.stringify(urlObject)})`);
+    }
+
+    // url.format(url.parse(x)) === x is documented for these.
+    for (const href of ["http://u:p:q@h/", "coap:u:p:q@[::1]:61616/a", "http://a:b:c:d@h/x?y#z"]) {
+      const parsed = url.parse(href);
+      assert.strictEqual(url.format(parsed), href);
+      assert.strictEqual(parsed.href, href);
+    }
+    assert.strictEqual(url.format(url.parse("http://u:p%3Aq@h/")), "http://u:p:q@h/");
+  });
+
+  test("an already bracketed IPv6 hostname is not bracketed again", () => {
+    const cases = [
+      [{ protocol: "http", hostname: "[::1]", port: 8 }, "http://[::1]:8"],
+      [{ protocol: "http:", hostname: "[::1]" }, "http://[::1]"],
+      [{ protocol: "http:", hostname: "::1", port: 8 }, "http://[::1]:8"],
+      [{ hostname: "[::1]" }, "[::1]"],
+      [{ hostname: "::1", port: 1 }, "[::1]:1"],
+      [{ protocol: "http:", slashes: true, host: "[::1]:8", pathname: "/" }, "http://[::1]:8/"],
+    ];
+    for (const [urlObject, expected] of cases) {
+      assert.strictEqual(url.format(urlObject), expected, `format(${JSON.stringify(urlObject)})`);
+    }
+  });
+
   test("format encodes every hash character in the search component", () => {
     // A search string containing more than one "#" must have all of them
     // percent-encoded; otherwise re-parsing the formatted URL truncates the

--- a/test/regression/issue/28751.test.ts
+++ b/test/regression/issue/28751.test.ts
@@ -14,3 +14,12 @@ test("url.format preserves all decoded colons in auth credentials", () => {
   const formatted = format(parsed);
   expect(formatted).toBe("http://us:er:pass:word@localhost/");
 });
+
+test("url.format leaves ordinary user:password credentials unchanged", () => {
+  expect(format(parse("http://user:pass@localhost/"))).toBe("http://user:pass@localhost/");
+});
+
+test("url.format decodes an encoded colon in only the username", () => {
+  const uri = "http://" + encodeURIComponent("a:b") + ":pw@localhost/";
+  expect(format(parse(uri))).toBe("http://a:b:pw@localhost/");
+});

--- a/test/regression/issue/28751.test.ts
+++ b/test/regression/issue/28751.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+import { format, parse } from "node:url";
+
+// https://github.com/oven-sh/bun/issues/28751
+
+test("url.format preserves all decoded colons in auth credentials", () => {
+  const user = encodeURIComponent("us:er");
+  const password = encodeURIComponent("pass:word");
+  const uri = "http://" + user + ":" + password + "@localhost/";
+
+  const parsed = parse(uri);
+  expect(parsed.auth).toBe("us:er:pass:word");
+
+  const formatted = format(parsed);
+  expect(formatted).toBe("http://us:er:pass:word@localhost/");
+});


### PR DESCRIPTION
Closes #28751

Legacy `url.format(urlObject)` assembles the authority differently from node in four independent ways, all inside `Url.prototype.format`.

**Repro:**

```js
import * as nurl from "node:url";
console.log(
  JSON.stringify([
    nurl.format({ auth: "u", hostname: "h" }),
    nurl.format({ host: "h", pathname: "p" }),
    nurl.format({ protocol: "file:", pathname: "/x/y" }),
    nurl.format({ protocol: "file", pathname: "//srv/x" }),
    nurl.format({ auth: "u:p:q", host: "h" }),
    nurl.format({ protocol: "http", hostname: "[::1]", port: 8 }),
    nurl.format(nurl.parse("http://u:p:q@h/")), // documented round-trip
  ]),
);
```

```
node v26.3.0: ["u@h",   "hp",    "file:///x/y", "file:////srv/x", "u:p:q@h",     "http://[::1]:8",   "http://u:p:q@h/"]
bun 1.4.0:    ["//u@h", "//h/p", "file:/x/y",   "file://srv/x",   "//u:p%3Aq@h", "http://[[::1]]:8", "http://u:p%3Aq@h/"]
```

**Cause:**

- The `//` is gated on `(!protocol || slashedProtocol[protocol]) && host.length > 0`. Node gates it on `slashes || slashedProtocol.has(protocol)`, so a protocol-less object gains a separator it should not have.
- Node gives a hostless `file:` URL an empty authority (`host = "//"`), bun gives it nothing. `file:/x/y` and `file:////srv/x` are not the same URL: the latter, written as `file://srv/x`, names a remote host `srv`.
- `auth` is run through `encodeURIComponent` and then colons are restored with `.replace(/%3A/i, ":")`. The regex is missing the `g` flag, so only the first `%3A` comes back, breaking the documented `url.format(url.parse(x)) === x` round-trip (and `.href`, which is built via `format`).
- A hostname containing `:` is wrapped in brackets unconditionally, so an already-bracketed `[::1]` becomes `[[::1]]`.

**Fix:** mirror node's `Url.prototype.format` for each: gate the separator on `slashes || slashedProtocol[protocol]`, keep `file:`'s empty authority, add the `g` flag, and skip re-bracketing a hostname that already passes `isIpv6Hostname`.

`src/node-fallbacks/url.js` (the `bun build --target=browser` polyfill) is a copy of the same function and carried all four bugs plus an analogous missing `g` flag on `search.replace("#", "%23")`. It gets the same fixes so bundled output no longer diverges from the runtime.

**Verification:**

- `test/js/node/url/url-format.test.js`: four new cases, one per divergence. They fail under `USE_SYSTEM_BUN=1 bun test` and pass under `bun bd test`.
- `test/regression/issue/28751.test.ts` covers the auth round-trip.
- `test/bundler/bundler_browser.test.ts`: `NodeUrlFormatAuthority`, `NodeUrlFormatAuthColons#28751`, `NodeUrlFormatSearchHash` cover the polyfill copy.
- Exhaustive differential against node v26.3.0 over 99,792 combinations of `protocol` × `host` × `hostname` × `auth` × `pathname` × `slashes` × `port`: 17,136 outputs differed before, 0 after, for both the runtime module and the polyfill.
- `test/js/node/url/` and the `test/js/node/test/parallel/test-url-*` ports are unchanged (`test-url-parse-format.js`, which round-trips `format(parse(x))` over a large table, still passes).

<details>
<summary>Out of scope</summary>

`url.format(whatwgURL, options)` still ignores `options` and drops `auth` (already tracked as a TODO in `test/js/node/url/url-format-whatwg.test.js`, and separately in #32424). This PR only touches the legacy `Url.prototype.format` path. The `file:` fix does improve `url.format(new URL("file:///x/y"))`, which previously returned `file:/x/y`.

</details>
