### PR TITLE
fix Worker SIGABRT on async onmessage rejection

### DIFF
--- a/src/jsc/web_worker.zig
+++ b/src/jsc/web_worker.zig
@@ -806,6 +806,10 @@ fn flushLogs(this: *WebWorker, vm: *jsc.VirtualMachine) void {
         error.JSTerminated => @panic("unhandled exception"),
     };
     defer str.deref();
+    // Reset the log so the subsequent flushLogs() calls in spin() don't
+    // re-dispatch the same messages as duplicate error events when the
+    // worker terminates cooperatively through onUnhandledRejection.
+    vm.log.reset();
     bun.jsc.fromJSHostCallGeneric(vm.global, @src(), WebWorker__dispatchError, .{ vm.global, this.cpp_worker, str, err }) catch |e| {
         _ = vm.global.reportUncaughtException(vm.global.takeException(e).asException(vm.global.vm()).?);
     };
@@ -847,9 +851,34 @@ fn onUnhandledRejection(vm: *jsc.VirtualMachine, globalObject: *jsc.JSGlobalObje
         bun.outOfMemory();
     };
     jsc.markBinding(@src());
-    WebWorker__dispatchError(globalObject, worker.cpp_worker, bun.String.cloneUTF8(array.written()), error_instance);
+    // Wrap in fromJSHostCallGeneric: for Node-kind workers,
+    // WebWorker__dispatchError -> dispatchErrorWithValue -> SerializedScriptValue::create
+    // opens a throw scope. Previously this was called immediately before the
+    // noreturn shutdown() so any pending exception died with the thread.
+    // Now that we return normally, unchecked exception state must be caught
+    // here or JSC's exception-scope validator asserts at the next safepoint.
+    //
+    // DON'T route the exception back through reportUncaughtException: this
+    // handler can be invoked from inside VirtualMachine.uncaughtException()
+    // (e.g. via Bun__reportUnhandledError for a sync throw in a timer),
+    // where is_handling_uncaught_exception is already true. Re-reporting
+    // would hit the re-entry guard that calls process.exit(7) — and in a
+    // worker that returns normally — then @panics. The original error was
+    // already dispatched to the parent; discard the pending exception.
+    bun.jsc.fromJSHostCallGeneric(globalObject, @src(), WebWorker__dispatchError, .{ globalObject, worker.cpp_worker, bun.String.cloneUTF8(array.written()), error_instance }) catch {
+        _ = globalObject.tryTakeException();
+    };
+    // Don't call shutdown() directly here — we're still inside the JS
+    // execution context (entryScope is active from handleRejectedPromises).
+    // Tearing down the VM now triggers a JSC assertion failure
+    // (!vm().entryScope in Heap::lastChanceToFinalize, called via
+    // WebWorker__teardownJSCVM -> collectNow). Set the Zig-level terminate
+    // flag and wake the loop so spin()'s while-loop breaks on its next
+    // hasRequestedTerminate() check and calls shutdown() after the JS call
+    // stack has unwound.
+    if (!worker.exit_called) vm.exit_handler.exit_code = 1;
     _ = worker.setRequestedTerminate();
-    worker.shutdown();
+    vm.eventLoop().wakeup();
 }
 
 /// Resolve a worker entry-point specifier to a path the module loader can

--- a/test/regression/issue/28753.test.ts
+++ b/test/regression/issue/28753.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Regression for https://github.com/oven-sh/bun/issues/28753 — an async
+// `onmessage` handler that throws (or returns a rejected promise) from a
+// Worker used to SIGABRT (or segfault in release) during VM teardown because
+// `onUnhandledRejection` called `shutdown()` while still inside the JS
+// entryScope. The fix defers teardown to `spin()`'s tail via
+// `setRequestedTerminate()` + `eventLoop().wakeup()`.
+//
+// The test asserts both events fire and the child exits cleanly. It does NOT
+// call `process.exit()` in the event handlers — doing that races the worker
+// thread's teardown and causes an unrelated segfault on the child process exit
+// path. Letting the main thread go idle naturally after `close` (no pending
+// timers, no refs) gives the worker thread time to finish its teardown before
+// the process exits, which is what we want to verify.
+test.concurrent.each([
+  ["throw", `throw new Error("test error from async handler");`],
+  ["rejection", `await Promise.reject(new Error("rejected promise in worker"));`],
+])("Worker async onmessage %s does not SIGABRT", async (label, workerBody) => {
+  using dir = tempDir(`issue-28753-${label}`, {
+    "worker.ts": `
+      declare var self: Worker;
+      self.onmessage = async (event: MessageEvent) => {
+        ${workerBody}
+      };
+    `,
+    "main.ts": `
+      // Watchdog: if close never arrives (regression in the dispatch path
+      // itself), exit 1 so the outer test fails cleanly rather than hanging.
+      // Cleared in the close handler so the process can exit naturally.
+      const watchdog = setTimeout(() => { process.exit(1); }, 10_000);
+      const worker = new Worker(new URL("./worker.ts", import.meta.url).href);
+      worker.addEventListener("open", () => { worker.postMessage("go"); });
+      worker.addEventListener("error", () => { console.log("error event received"); });
+      worker.addEventListener("close", () => {
+        clearTimeout(watchdog);
+        console.log("close event received");
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("error event received");
+  expect(stdout).toContain("close event received");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Closes #28753

## Problem

When a Worker's `onmessage` handler is `async` and throws (or has an unhandled promise rejection), the process crashes with SIGABRT instead of dispatching the error to the parent thread's error handler.

```ts
// worker.ts — crashes with SIGABRT
self.onmessage = async (event) => {
  throw new Error("test error");
};
```

Synchronous throws in `onmessage` work correctly.

## Cause

The worker's `onUnhandledRejection` handler called `exitAndDeinit()` directly — a `noreturn` function that tears down the VM including heap finalization. But this handler is invoked from within the JS execution context (`handleRejectedPromises` → `unhandledRejection`), so JSC's `entryScope` is still active on the stack. The assertion `!vm().entryScope` in `Heap::lastChanceToFinalize()` fires, causing SIGABRT.

## Fix

Replace the direct `exitAndDeinit()` call with `notifyNeedTermination()`, which sets the terminate flag and wakes the event loop. The `spin()` loop then breaks out on its next `hasRequestedTerminate()` check and calls `exitAndDeinit()` after the JS call stack has unwound.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28753.test.ts` → **FAIL** (exit code 134)
- `bun bd test test/regression/issue/28753.test.ts` → **PASS**