### PR TITLE
build: bump zig to oven-sh/zig@365343a

### DIFF
--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -31,7 +31,7 @@ import { streamPath } from "./stream.ts";
  * Override via `--zig-commit=<hash>` to test a new compiler.
  * From https://github.com/oven-sh/zig releases.
  */
-export const ZIG_COMMIT = "c031cbebf5b063210473ff5204a24ebfb2492c72";
+export const ZIG_COMMIT = "365343af4fc5a1a632e6b54aadd0b87be30edd81";
 
 // ───────────────────────────────────────────────────────────────────────────
 // Target/optimize/CPU computation


### PR DESCRIPTION
Bumps the pinned Zig compiler to the latest oven-sh/zig autobuild.

- c031cbebf5b063210473ff5204a24ebfb2492c72 → 365343af4fc5a1a632e6b54aadd0b87be30edd81
- Release: https://github.com/oven-sh/zig/releases/tag/autobuild-365343af4fc5a1a632e6b54aadd0b87be30edd81