### PR TITLE
Fix memory leak in AbortSignal.timeout() when listeners are removed

### DIFF
--- a/src/bun.js/bindings/AbortSignal.zig
+++ b/src/bun.js/bindings/AbortSignal.zig
@@ -203,8 +203,9 @@ pub const AbortSignal = opaque {
             const loop = vm.eventLoop();
             loop.enter();
             defer loop.exit();
+            // signalAbort() releases the extra ref from timeout() after all
+            // abort work completes, so we must not unref here.
             signal_ptr.signal(vm.global, .Timeout);
-            signal_ptr.unref();
         }
 
         // This may run inside the "signal" call.

--- a/src/bun.js/bindings/webcore/AbortSignal.cpp
+++ b/src/bun.js/bindings/webcore/AbortSignal.cpp
@@ -187,9 +187,17 @@ void AbortSignal::runAbortSteps()
 // https://dom.spec.whatwg.org/#abortsignal-signal-abort
 void AbortSignal::signalAbort(JSC::JSValue reason)
 {
-    // 1. If signal's aborted flag is set, then return.
+    // 1. If signal’s aborted flag is set, then return.
     if (aborted())
         return;
+
+    // signalAbort() is the sole path for releasing the extra ref that
+    // timeout() took — for ALL abort paths, including when the timer fires
+    // naturally (dispatch -> signal -> signalAbort -> deref).
+    // Timeout::dispatch() intentionally does NOT call unref().
+    // Defer the deref until after all abort work is done so `this` stays
+    // alive throughout.
+    bool hadTimeout = m_timeout != nullptr;
 
     // 2. Set signal’s abort reason to reason if it is given; otherwise to a new "AbortError" DOMException.
     markAborted(reason);
@@ -209,6 +217,10 @@ void AbortSignal::signalAbort(JSC::JSValue reason)
     // 6. For each dependentSignal of dependentSignalsToAbort, run the abort steps for dependentSignal.
     for (auto& dependentSignal : dependentSignalsToAbort)
         dependentSignal->runAbortSteps();
+
+    // Release the extra ref from timeout() now that all abort work is done.
+    if (hadTimeout)
+        deref();
 }
 
 void AbortSignal::signalAbort(JSC::JSGlobalObject* globalObject, CommonAbortReason reason)
@@ -255,7 +267,30 @@ void AbortSignal::signalFollow(AbortSignal& signal)
 
 void AbortSignal::eventListenersDidChange()
 {
-    setHasAbortEventListener(hasEventListeners(eventNames().abortEvent) or !m_native_callbacks.isEmpty());
+    bool hasListeners = hasEventListeners(eventNames().abortEvent) or !m_native_callbacks.isEmpty();
+    setHasAbortEventListener(hasListeners);
+
+    // When a timeout signal loses all observers (no JS listeners, no native
+    // callbacks, no algorithms, no dependent signals), there is nothing left
+    // to notify when the timer fires.  Cancel the timer and release the extra
+    // ref that timeout() took to keep the signal alive, so the C++ object can
+    // be destroyed normally.
+    if (!hasListeners && m_timeout && !aborted()
+        && m_algorithms.isEmpty() && !hasPendingActivity()
+        && m_dependentSignals.isEmptyIgnoringNullReferences()) {
+        bool shouldDeref = false;
+        {
+            Locker locker { m_abortAlgorithmsLock };
+            if (m_abortAlgorithms.isEmpty()) {
+                cancelTimer();
+                shouldDeref = true;
+            }
+        }
+        // Release the extra ref after the lock is released, since deref()
+        // may destroy `this` (and m_abortAlgorithmsLock with it).
+        if (shouldDeref)
+            deref(); // balances the ref() in AbortSignal::timeout()
+    }
 }
 
 uint32_t AbortSignal::addAbortAlgorithmToSignal(AbortSignal& signal, Ref<AbortAlgorithm>&& algorithm)

--- a/test/regression/issue/28756.test.ts
+++ b/test/regression/issue/28756.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/28756
+// AbortSignal.timeout() + util.aborted() causes unbounded memory growth
+// because the extra ref() taken in timeout() is never released when all
+// listeners are removed before the timer fires.
+test("AbortSignal.timeout + util.aborted does not leak memory", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const { aborted } = require("util");
+
+      // 10 batches * 8000 = 80k signals.
+      // Without fix: leaks ~0.8 KB/signal => ~60 MB growth.
+      // With fix: stays flat.
+      // Completes in <2s on release, ~120s on ASAN.
+      const iterations = 10;
+      const batchSize = 8000;
+
+      // Warm up so baseline memory is established.
+      for (let i = 0; i < 200; i++) {
+        const sig = AbortSignal.timeout(1_000_000_000);
+        sig.addEventListener("abort", () => {});
+        aborted(sig, {});
+      }
+      await new Promise(r => setTimeout(r, 0));
+      Bun.gc(true);
+      await new Promise(r => setTimeout(r, 50));
+      Bun.gc(true);
+      const baselineRSS = process.memoryUsage().rss;
+
+      for (let iter = 0; iter < iterations; iter++) {
+        for (let i = 0; i < batchSize; i++) {
+          function lis() {}
+          const sig = AbortSignal.timeout(1_000_000_000);
+          sig.addEventListener("abort", lis);
+          aborted(sig, {});
+          sig.removeEventListener("abort", lis);
+        }
+        await new Promise(r => setTimeout(r, 0));
+        Bun.gc(true);
+      }
+
+      await new Promise(r => setTimeout(r, 100));
+      Bun.gc(true);
+      await new Promise(r => setTimeout(r, 100));
+      Bun.gc(true);
+
+      const finalRSS = process.memoryUsage().rss;
+      const growth = finalRSS - baselineRSS;
+      const growthMB = (growth / 1024 / 1024).toFixed(1);
+      console.log(JSON.stringify({ baselineMB: (baselineRSS/1024/1024).toFixed(1), finalMB: (finalRSS/1024/1024).toFixed(1), growthMB }));
+      // Without the fix, 80k signals leak ~60 MB.  With the fix, <50 MB.
+      process.exit(growth < 50 * 1024 * 1024 ? 0 : 1);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  if (exitCode !== 0) {
+    expect().fail(`Memory grew too much. stdout: ${stdout} stderr: ${stderr}`);
+  }
+  expect(exitCode).toBe(0);
+}, 300_000);


### PR DESCRIPTION
## Problem

`AbortSignal.timeout()` + `util.aborted()` causes unbounded memory growth (~50 MB/second in the repro). RSS grows indefinitely until segfault.

Closes #28756

## Root Cause

`AbortSignal::timeout()` takes an extra `ref()` on the C++ signal to keep it alive while the timer is pending. The matching `unref()` only happens in `Timeout::dispatch()` when the timer actually fires. Two paths never released this ref:

1. **All listeners removed before timer fires**: `util.aborted()` uses a `FinalizationRegistry` that removes the event listener when the resource is GC'd. With no listeners left, there's nothing to notify — but the timer + signal stay alive for the full timeout duration (up to 11.5 days in the repro).

2. **Signal aborted via non-timer path**: When a timeout signal is aborted through `AbortSignal.any()` or manual abort, `cancelTimer()` frees the timer struct but never releases the extra ref.

## Fix

- **`eventListenersDidChange()`**: When a timeout signal loses all observers (no JS listeners, no native callbacks, no algorithms), cancel the timer and release the extra ref immediately.
- **`signalAbort()`**: When a timeout signal is aborted via any path, release the extra ref after all abort steps complete.
- **`Timeout.dispatch()`** (Zig): Remove the `unref()` call since `signalAbort()` now handles it for all paths.

## Verification

```
# System bun (unfixed) — FAILS with 128 MB growth:
USE_SYSTEM_BUN=1 bun test test/regression/issue/28756.test.ts

# Debug build (fixed) — PASSES with ~3 MB growth:
bun bd test test/regression/issue/28756.test.ts
```

Also verified: `AbortSignal.timeout()` still fires correctly, `AbortSignal.any()` with timeout works, and `fetch()` with timeout signal aborts properly.