### PR TITLE
Fix Map and Set deep equality for structurally-equal, non-identical entries

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1260,33 +1260,103 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
             return false;
         }
 
-        auto iter1 = JSSetIterator::create(vm, globalObject->setIteratorStructure(), set1, IterationKind::Keys);
-        RETURN_IF_EXCEPTION(scope, {});
-        JSValue key1;
-        while (iter1->next(globalObject, key1)) {
-            bool has = set2->has(globalObject, key1);
+        // Fast path: sizes match, so the sets are equal if set2 contains every element of set1 by reference.
+        bool allFastPath = true;
+        {
+            auto iter1 = JSSetIterator::create(vm, globalObject->setIteratorStructure(), set1, IterationKind::Keys);
             RETURN_IF_EXCEPTION(scope, {});
-            if (has) {
-                continue;
-            }
-
-            // We couldn't find the key in the second set. This may be a false positive due to how
-            // JSValues are represented in JSC, so we need to fall back to a linear search to be sure.
-            auto iter2 = JSSetIterator::create(vm, globalObject->setIteratorStructure(), set2, IterationKind::Keys);
-            RETURN_IF_EXCEPTION(scope, {});
-            JSValue key2;
-            bool foundMatchingKey = false;
-            while (iter2->next(globalObject, key2)) {
-                bool equal = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, key1, key2, gcBuffer, stack, scope, false);
+            JSValue key1;
+            while (iter1->next(globalObject, key1)) {
+                bool has = set2->has(globalObject, key1);
                 RETURN_IF_EXCEPTION(scope, {});
-                if (equal) {
-                    foundMatchingKey = true;
+                if (!has) {
+                    allFastPath = false;
                     break;
                 }
             }
+        }
 
-            if (!foundMatchingKey) {
-                return false;
+        if (!allFastPath) {
+            // addToStack=true below keeps nested self-referential collections on the cycle stack.
+            if constexpr (enableAsymmetricMatchers) {
+                // Asymmetric matchers break transitivity, so use Jest's two-way subset check instead of a bijection.
+                // Forward: every element in set1 has a deep-equal match in set2.
+                {
+                    auto iter1 = JSSetIterator::create(vm, globalObject->setIteratorStructure(), set1, IterationKind::Keys);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    JSValue key1;
+                    while (iter1->next(globalObject, key1)) {
+                        auto iter2 = JSSetIterator::create(vm, globalObject->setIteratorStructure(), set2, IterationKind::Keys);
+                        RETURN_IF_EXCEPTION(scope, {});
+                        JSValue key2;
+                        bool found = false;
+                        while (iter2->next(globalObject, key2)) {
+                            bool equal = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, key1, key2, gcBuffer, stack, scope, true);
+                            RETURN_IF_EXCEPTION(scope, {});
+                            if (equal) {
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (!found) {
+                            return false;
+                        }
+                    }
+                }
+                // Backward pass; keep the forward (key1, key2) argument order because the cycle stack records pairs positionally.
+                {
+                    auto iter2 = JSSetIterator::create(vm, globalObject->setIteratorStructure(), set2, IterationKind::Keys);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    JSValue key2;
+                    while (iter2->next(globalObject, key2)) {
+                        auto iter1 = JSSetIterator::create(vm, globalObject->setIteratorStructure(), set1, IterationKind::Keys);
+                        RETURN_IF_EXCEPTION(scope, {});
+                        JSValue key1;
+                        bool found = false;
+                        while (iter1->next(globalObject, key1)) {
+                            bool equal = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, key1, key2, gcBuffer, stack, scope, true);
+                            RETURN_IF_EXCEPTION(scope, {});
+                            if (equal) {
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (!found) {
+                            return false;
+                        }
+                    }
+                }
+            } else {
+                // Plain deep equality is an equivalence, so a first-fit bijection over a consumed-slot bitset is exact.
+                WTF::BitVector matchedIndices;
+                matchedIndices.ensureSize(set2->size());
+
+                auto iter1 = JSSetIterator::create(vm, globalObject->setIteratorStructure(), set1, IterationKind::Keys);
+                RETURN_IF_EXCEPTION(scope, {});
+                JSValue key1;
+                while (iter1->next(globalObject, key1)) {
+                    auto iter2 = JSSetIterator::create(vm, globalObject->setIteratorStructure(), set2, IterationKind::Keys);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    JSValue key2;
+                    bool found = false;
+                    size_t idx2 = 0;
+                    while (iter2->next(globalObject, key2)) {
+                        if (!matchedIndices.get(idx2)) {
+                            bool equal = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, key1, key2, gcBuffer, stack, scope, true);
+                            RETURN_IF_EXCEPTION(scope, {});
+                            if (equal) {
+                                matchedIndices.set(idx2);
+                                found = true;
+                                break;
+                            }
+                        }
+                        idx2++;
+                    }
+
+                    if (!found) {
+                        return false;
+                    }
+                }
             }
         }
 
@@ -1309,40 +1379,120 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
             return false;
         }
 
-        auto iter1 = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map1, IterationKind::Entries);
-        RETURN_IF_EXCEPTION(scope, {});
-        JSValue key1, value1;
-        while (iter1->nextKeyValue(globalObject, key1, value1)) {
-            JSValue value2 = map2->get(globalObject, key1);
+        // Fast path: every key of map1 found in map2 by reference, with deep-equal values.
+        bool allFastPath = true;
+        {
+            auto iter1 = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map1, IterationKind::Entries);
             RETURN_IF_EXCEPTION(scope, {});
-            if (value2.isUndefined()) {
-                // We couldn't find the key in the second map. This may be a false positive due to
-                // how JSValues are represented in JSC, so we need to fall back to a linear search
-                // to be sure.
-                auto iter2 = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map2, IterationKind::Entries);
+            JSValue key1, value1;
+            while (iter1->nextKeyValue(globalObject, key1, value1)) {
+                JSValue value2 = map2->get(globalObject, key1);
                 RETURN_IF_EXCEPTION(scope, {});
-                JSValue key2;
-                bool foundMatchingKey = false;
-                while (iter2->nextKeyValue(globalObject, key2, value2)) {
-                    bool keysEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, key1, key2, gcBuffer, stack, scope, false);
+                if (value2.isUndefined()) {
+                    allFastPath = false;
+                    break;
+                }
+                bool valuesEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, value1, value2, gcBuffer, stack, scope, true);
+                RETURN_IF_EXCEPTION(scope, {});
+                if (!valuesEqual) {
+                    allFastPath = false;
+                    break;
+                }
+            }
+        }
+
+        if (!allFastPath) {
+            // A hash-matched key with an unequal value may still pair with a structurally-equal key elsewhere; same branches as the Set slow path.
+            if constexpr (enableAsymmetricMatchers) {
+                // Forward: every (k1, v1) in map1 has a deep-equal entry in map2.
+                {
+                    auto iter1 = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map1, IterationKind::Entries);
                     RETURN_IF_EXCEPTION(scope, {});
-                    if (keysEqual) {
-                        foundMatchingKey = true;
-                        break;
+                    JSValue key1, value1;
+                    while (iter1->nextKeyValue(globalObject, key1, value1)) {
+                        auto iter2 = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map2, IterationKind::Entries);
+                        RETURN_IF_EXCEPTION(scope, {});
+                        JSValue key2, value2;
+                        bool found = false;
+                        while (iter2->nextKeyValue(globalObject, key2, value2)) {
+                            bool keysEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, key1, key2, gcBuffer, stack, scope, true);
+                            RETURN_IF_EXCEPTION(scope, {});
+                            if (keysEqual) {
+                                bool valuesEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, value1, value2, gcBuffer, stack, scope, true);
+                                RETURN_IF_EXCEPTION(scope, {});
+                                if (valuesEqual) {
+                                    found = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (!found) {
+                            return false;
+                        }
                     }
                 }
-
-                if (!foundMatchingKey) {
-                    return false;
+                // Backward pass, same argument order as forward for the cycle stack.
+                {
+                    auto iter2 = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map2, IterationKind::Entries);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    JSValue key2, value2;
+                    while (iter2->nextKeyValue(globalObject, key2, value2)) {
+                        auto iter1 = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map1, IterationKind::Entries);
+                        RETURN_IF_EXCEPTION(scope, {});
+                        JSValue key1, value1;
+                        bool found = false;
+                        while (iter1->nextKeyValue(globalObject, key1, value1)) {
+                            bool keysEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, key1, key2, gcBuffer, stack, scope, true);
+                            RETURN_IF_EXCEPTION(scope, {});
+                            if (keysEqual) {
+                                bool valuesEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, value1, value2, gcBuffer, stack, scope, true);
+                                RETURN_IF_EXCEPTION(scope, {});
+                                if (valuesEqual) {
+                                    found = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (!found) {
+                            return false;
+                        }
+                    }
                 }
+            } else {
+                // First-fit bijection; an entry is only consumed when both key and value match.
+                WTF::BitVector matchedIndices;
+                matchedIndices.ensureSize(leftSize);
 
-                // Compare both values below.
-            }
+                auto iter1 = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map1, IterationKind::Entries);
+                RETURN_IF_EXCEPTION(scope, {});
+                JSValue key1, value1;
+                while (iter1->nextKeyValue(globalObject, key1, value1)) {
+                    auto iter2 = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map2, IterationKind::Entries);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    JSValue key2, value2;
+                    bool found = false;
+                    size_t idx2 = 0;
+                    while (iter2->nextKeyValue(globalObject, key2, value2)) {
+                        if (!matchedIndices.get(idx2)) {
+                            bool keysEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, key1, key2, gcBuffer, stack, scope, true);
+                            RETURN_IF_EXCEPTION(scope, {});
+                            if (keysEqual) {
+                                bool valuesEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, value1, value2, gcBuffer, stack, scope, true);
+                                RETURN_IF_EXCEPTION(scope, {});
+                                if (valuesEqual) {
+                                    matchedIndices.set(idx2);
+                                    found = true;
+                                    break;
+                                }
+                            }
+                        }
+                        idx2++;
+                    }
 
-            bool valuesEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, value1, value2, gcBuffer, stack, scope, false);
-            RETURN_IF_EXCEPTION(scope, {});
-            if (!valuesEqual) {
-                return false;
+                    if (!found) {
+                        return false;
+                    }
+                }
             }
         }
 

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -49,6 +49,136 @@ describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
     expect(deepEquals(b, a)).toBe(false);
   });
 
+  // Map/Set equality is defined over the unordered entry multiset. Structurally-equal
+  // (non-identical) keys must be matched one-to-one against the other side, on both
+  // key and value, regardless of insertion order.
+  describe("Map/Set with structurally-equal object keys", () => {
+    it("Map: same (key, value) multiset in different insertion order is equal", () => {
+      const m1 = new Map<object, string>([
+        [{ k: 1 }, "x"],
+        [{ k: 1 }, "y"],
+      ]);
+      const m2 = new Map<object, string>([
+        [{ k: 1 }, "y"],
+        [{ k: 1 }, "x"],
+      ]);
+      expect(deepEquals(m1, m2)).toBe(true);
+      expect(deepEquals(m2, m1)).toBe(true);
+    });
+
+    it("Map: shared-reference key matched by identity must not pin a wrong value", () => {
+      const shared = { k: 1 };
+      const m1 = new Map<object, number>([
+        [shared, 1],
+        [{ k: 1 }, 2],
+      ]);
+      const m2 = new Map<object, number>([
+        [shared, 2],
+        [{ k: 1 }, 1],
+      ]);
+      expect(deepEquals(m1, m2)).toBe(true);
+      expect(deepEquals(m2, m1)).toBe(true);
+    });
+
+    it("Map: three structurally-equal keys with permuted values", () => {
+      const m1 = new Map<object, number>([
+        [{ k: 1 }, 1],
+        [{ k: 1 }, 2],
+        [{ k: 1 }, 3],
+      ]);
+      const m2 = new Map<object, number>([
+        [{ k: 1 }, 3],
+        [{ k: 1 }, 1],
+        [{ k: 1 }, 2],
+      ]);
+      const m3 = new Map<object, number>([
+        [{ k: 1 }, 1],
+        [{ k: 1 }, 2],
+        [{ k: 1 }, 4],
+      ]);
+      expect(deepEquals(m1, m2)).toBe(true);
+      expect(deepEquals(m2, m1)).toBe(true);
+      expect(deepEquals(m1, m3)).toBe(false);
+      expect(deepEquals(m3, m1)).toBe(false);
+    });
+
+    it("Map: duplicate structurally-equal keys with differing value multisets are not equal", () => {
+      const m1 = new Map<object, number>([
+        [{ k: 1 }, 1],
+        [{ k: 1 }, 1],
+        [{ k: 1 }, 2],
+      ]);
+      const m2 = new Map<object, number>([
+        [{ k: 1 }, 1],
+        [{ k: 1 }, 2],
+        [{ k: 1 }, 2],
+      ]);
+      expect(deepEquals(m1, m2)).toBe(false);
+      expect(deepEquals(m2, m1)).toBe(false);
+    });
+
+    it("Map: object keys mixed with primitive keys", () => {
+      const m1 = new Map<unknown, string>([
+        ["p", "same"],
+        [{ k: 1 }, "x"],
+        [{ k: 1 }, "y"],
+      ]);
+      const m2 = new Map<unknown, string>([
+        [{ k: 1 }, "y"],
+        ["p", "same"],
+        [{ k: 1 }, "x"],
+      ]);
+      const m3 = new Map<unknown, string>([
+        ["p", "same"],
+        ["q", "extra"],
+        [{ k: 1 }, "x"],
+      ]);
+      expect(deepEquals(m1, m2)).toBe(true);
+      expect(deepEquals(m2, m1)).toBe(true);
+      expect(deepEquals(m1, m3)).toBe(false);
+      expect(deepEquals(m3, m1)).toBe(false);
+    });
+
+    it("Map: entries whose value is undefined are not treated as missing keys", () => {
+      const m1 = new Map<string, unknown>([
+        ["a", undefined],
+        ["b", 1],
+      ]);
+      const m2 = new Map<string, unknown>([
+        ["b", 1],
+        ["a", undefined],
+      ]);
+      const m3 = new Map<string, unknown>([
+        ["c", undefined],
+        ["b", 1],
+      ]);
+      expect(deepEquals(m1, m2)).toBe(true);
+      expect(deepEquals(m1, m3)).toBe(false);
+      expect(deepEquals(m3, m1)).toBe(false);
+    });
+
+    it("Set: structurally-equal elements in different order are equal", () => {
+      const s1 = new Set<object>([{ a: 1 }, { a: 2 }, { a: 3 }]);
+      const s2 = new Set<object>([{ a: 3 }, { a: 1 }, { a: 2 }]);
+      expect(deepEquals(s1, s2)).toBe(true);
+      expect(deepEquals(s2, s1)).toBe(true);
+    });
+
+    it("Set: duplicate structurally-equal elements on both sides are equal", () => {
+      const s1 = new Set<object>([{ a: 1 }, { a: 1 }, { a: 2 }]);
+      const s2 = new Set<object>([{ a: 2 }, { a: 1 }, { a: 1 }]);
+      expect(deepEquals(s1, s2)).toBe(true);
+      expect(deepEquals(s2, s1)).toBe(true);
+    });
+
+    it("Set: multisets with different duplicate counts are not equal", () => {
+      const s1 = new Set<object>([{ a: 1 }, { a: 1 }, { a: 2 }]);
+      const s2 = new Set<object>([{ a: 1 }, { a: 2 }, { a: 2 }]);
+      expect(deepEquals(s1, s2)).toBe(false);
+      expect(deepEquals(s2, s1)).toBe(false);
+    });
+  });
+
   // we may change this in the future
   it("functions that are not reference-equal are never equal", () => {
     function foo() {}

--- a/test/regression/issue/28760.test.ts
+++ b/test/regression/issue/28760.test.ts
@@ -1,0 +1,215 @@
+import { expect, test } from "bun:test";
+import assert from "node:assert";
+
+test("assert.deepEqual throws for unequal Sets with duplicate-by-value objects", () => {
+  expect(() => {
+    assert.deepEqual(new Set([{ a: 1 }, { a: 1 }]), new Set([{ a: 1 }, { a: 2 }]));
+  }).toThrow(assert.AssertionError);
+});
+
+test("assert.deepStrictEqual throws for unequal Sets with duplicate-by-value objects", () => {
+  expect(() => {
+    assert.deepStrictEqual(new Set([{ a: 1 }, { a: 1 }]), new Set([{ a: 1 }, { a: 2 }]));
+  }).toThrow(assert.AssertionError);
+});
+
+test("assert.deepStrictEqual does not throw for equal Sets with objects", () => {
+  expect(() => {
+    assert.deepStrictEqual(new Set([{ a: 1 }, { a: 2 }]), new Set([{ a: 1 }, { a: 2 }]));
+  }).not.toThrow();
+});
+
+test("assert.deepStrictEqual does not throw for equal Sets with duplicate-by-value objects", () => {
+  expect(() => {
+    assert.deepStrictEqual(new Set([{ a: 1 }, { a: 1 }]), new Set([{ a: 1 }, { a: 1 }]));
+  }).not.toThrow();
+});
+
+test("assert.deepEqual throws for unequal Sets with nested objects", () => {
+  expect(() => {
+    assert.deepEqual(new Set([{ a: { b: 1 } }, { a: { b: 1 } }]), new Set([{ a: { b: 1 } }, { a: { b: 2 } }]));
+  }).toThrow(assert.AssertionError);
+});
+
+test("assert.deepStrictEqual throws for unequal Maps with duplicate-by-value keys", () => {
+  expect(() => {
+    assert.deepStrictEqual(
+      new Map([
+        [{ a: 1 }, "x"],
+        [{ a: 1 }, "y"],
+      ]),
+      new Map([
+        [{ a: 1 }, "x"],
+        [{ a: 2 }, "y"],
+      ]),
+    );
+  }).toThrow(assert.AssertionError);
+});
+
+test("Bun.deepEquals returns false for unequal Sets with duplicate-by-value objects", () => {
+  expect(Bun.deepEquals(new Set([{ a: 1 }, { a: 1 }]), new Set([{ a: 1 }, { a: 2 }]))).toBe(false);
+});
+
+test("Bun.deepEquals returns true for equal Sets with duplicate-by-value objects", () => {
+  expect(Bun.deepEquals(new Set([{ a: 1 }, { a: 1 }]), new Set([{ a: 1 }, { a: 1 }]))).toBe(true);
+});
+
+test("expect().toEqual fails for unequal Sets with duplicate-by-value objects", () => {
+  expect(new Set([{ a: 1 }, { a: 1 }])).not.toEqual(new Set([{ a: 1 }, { a: 2 }]));
+});
+
+test("Set with shared reference and deep-equal duplicate is not equal", () => {
+  // Fast-path match for `shared` must not let fallback reuse same rhs slot
+  const shared = { a: 1 };
+  expect(Bun.deepEquals(new Set([shared, { a: 1 }]), new Set([shared, { a: 2 }]))).toBe(false);
+});
+
+test("Map with duplicate-by-value keys and different values in opposite order", () => {
+  // Must check both key AND value before consuming an entry
+  expect(
+    Bun.deepEquals(
+      new Map([
+        [{ a: 1 }, "x"],
+        [{ a: 1 }, "y"],
+      ]),
+      new Map([
+        [{ a: 1 }, "y"],
+        [{ a: 1 }, "x"],
+      ]),
+    ),
+  ).toBe(true);
+});
+
+test("Map with duplicate-by-value keys rejects when values differ", () => {
+  expect(
+    Bun.deepEquals(
+      new Map([
+        [{ a: 1 }, "x"],
+        [{ a: 1 }, "y"],
+      ]),
+      new Map([
+        [{ a: 1 }, "x"],
+        [{ a: 1 }, "z"],
+      ]),
+    ),
+  ).toBe(false);
+});
+
+// Asymmetric matchers (expect.anything, etc.) make the match relation non-transitive,
+// so bijection-via-greedy matching misses valid pairings that exist. For expect().toEqual,
+// we use Jest-compatible two-way subset semantics.
+test("expect().toEqual with expect.anything mixed with concrete values in Set", () => {
+  // Valid 1:1 pairing: {a:1}↔{a:1}, {a:2}↔anything()
+  expect(new Set([{ a: 1 }, { a: 2 }])).toEqual(new Set([expect.anything(), { a: 1 }]));
+});
+
+test("expect().toEqual with expect.anything in Set - reverse order", () => {
+  expect(new Set([expect.anything(), { a: 1 }])).toEqual(new Set([{ a: 1 }, { a: 2 }]));
+});
+
+test("expect().toEqual with expect.anything in Map", () => {
+  // Valid 1:1 pairing: ({a:1},"x")↔({a:1},"x"), ({a:2},"y")↔(anything(),"y")
+  expect(
+    new Map<object, string>([
+      [{ a: 1 }, "x"],
+      [{ a: 2 }, "y"],
+    ]),
+  ).toEqual(
+    new Map<object, string>([
+      [expect.anything(), "y"],
+      [{ a: 1 }, "x"],
+    ]),
+  );
+});
+
+test("expect().toEqual with self-referential Sets does not stack overflow", () => {
+  // Both passes of the two-way subset check must preserve cycle detection
+  // (consistent argument order to Bun__deepEquals).
+  const a = new Set<unknown>();
+  a.add(89);
+  a.add("hello");
+  a.add({ a: 1 });
+  a.add([1, 2, 3]);
+  a.add(a);
+  const b = new Set<unknown>();
+  b.add(89);
+  b.add("hello");
+  b.add(b);
+  b.add({ a: 1 });
+  b.add([1, 2, 3]);
+  expect(a).toEqual(b);
+  expect(b).toEqual(a);
+});
+
+test("expect().toEqual with self-referential Maps does not stack overflow", () => {
+  // The object key is deep-equal but not reference-equal, so the hash-lookup fast
+  // path misses and the comparison actually reaches the two-way subset slow path.
+  const a = new Map<unknown, unknown>();
+  a.set("self", a);
+  a.set({ k: 1 }, 0);
+  const b = new Map<unknown, unknown>();
+  b.set({ k: 1 }, 0);
+  b.set("self", b);
+  expect(a).toEqual(b);
+  expect(b).toEqual(a);
+});
+
+test("Bun.deepEquals with self-referential Maps and object keys does not stack overflow", () => {
+  const a = new Map<unknown, unknown>();
+  a.set("self", a);
+  a.set({ k: 1 }, 0);
+  const b = new Map<unknown, unknown>();
+  b.set({ k: 1 }, 0);
+  b.set("self", b);
+  expect(Bun.deepEquals(a, b)).toBe(true);
+  expect(Bun.deepEquals(b, a)).toBe(true);
+  expect(Bun.deepEquals(a, b, true)).toBe(true);
+});
+
+// Depth-2 cycles: a Set/Map that contains ANOTHER self-referential Set/Map.
+// The cycle closes through a nested pair, so element comparison must record
+// nested pairs on the cycle stack (addToStack=true), matching Node.
+test("Bun.deepEquals with nested self-referential Sets does not stack overflow", () => {
+  const inner1 = new Set<unknown>();
+  inner1.add(inner1);
+  const inner2 = new Set<unknown>();
+  inner2.add(inner2);
+  expect(Bun.deepEquals(new Set([inner1]), new Set([inner2]))).toBe(true);
+  expect(Bun.deepEquals(new Set([inner1]), new Set([inner2]), true)).toBe(true);
+});
+
+test("Bun.deepEquals with nested self-referential Maps (object keys) does not stack overflow", () => {
+  const inner1 = new Map<unknown, unknown>();
+  inner1.set("x", inner1);
+  const inner2 = new Map<unknown, unknown>();
+  inner2.set("x", inner2);
+  expect(
+    Bun.deepEquals(new Map<unknown, unknown>([[{ k: 1 }, inner1]]), new Map<unknown, unknown>([[{ k: 1 }, inner2]])),
+  ).toBe(true);
+});
+
+test("Bun.deepEquals with nested self-referential Maps (string keys, fast path) does not stack overflow", () => {
+  // String keys hash-match, so this exercises the fast-path value comparison.
+  const inner1 = new Map<unknown, unknown>();
+  inner1.set("x", inner1);
+  const inner2 = new Map<unknown, unknown>();
+  inner2.set("x", inner2);
+  expect(Bun.deepEquals(new Map([["y", inner1]]), new Map([["y", inner2]]))).toBe(true);
+});
+
+test("expect().toEqual with nested self-referential Sets does not stack overflow", () => {
+  const inner1 = new Set<unknown>();
+  inner1.add(inner1);
+  const inner2 = new Set<unknown>();
+  inner2.add(inner2);
+  expect(new Set([inner1])).toEqual(new Set([inner2]));
+});
+
+test("Bun.deepEquals rejects nested self-referential Sets with differing siblings", () => {
+  // Cycle handling must not mask a real inequality elsewhere in the structure.
+  const inner1 = new Set<unknown>();
+  inner1.add(inner1);
+  const inner2 = new Set<unknown>();
+  inner2.add(inner2);
+  expect(Bun.deepEquals(new Set([inner1, { a: 1 }]), new Set([inner2, { a: 2 }]))).toBe(false);
+});


### PR DESCRIPTION
Fixes #28760
Fixes #34830

## Problem

`Bun.deepEquals`, `expect().toEqual`, and `assert.deepEqual`/`deepStrictEqual` mishandle Maps and Sets whose keys or elements are structurally equal but not reference equal. The same bug produces both a false negative and a false positive:

```js
// False negative: same (key, value) multiset, different insertion order.
// Node's util.isDeepStrictEqual and Jest's toEqual both report true.
Bun.deepEquals(
  new Map([[{ k: 1 }, "x"], [{ k: 1 }, "y"]]),
  new Map([[{ k: 1 }, "y"], [{ k: 1 }, "x"]]),
); // false

// False positive: different duplicate-by-value multisets. Node throws here.
assert.deepStrictEqual(
  new Set([{ a: 1 }, { a: 1 }]),
  new Set([{ a: 1 }, { a: 2 }]),
); // does not throw
```

## Cause

In `specialObjectsDequal` (bindings.cpp), when a key misses the hash lookup, the fallback linear scan pairs it with the first structurally-equal key on the other side. It never marks that entry as consumed, and for Maps it matches on the key alone. So `{k:1} -> "x"` greedily grabs the right-hand `{k:1} -> "y"`, the values mismatch, and two equal Maps compare unequal. In the other direction, a single right-hand `{a:1}` satisfies both left-hand `{a:1}` entries, so `{a:2}` is never accounted for.

## Fix

Split the comparison into a hash-lookup fast path and a slow path.

For plain deep equality (`Bun.deepEquals`, `assert.*`) the slow path enforces a one-to-one pairing with a `WTF::BitVector`, and a Map entry only consumes a slot when both key and value match. Structural deep equality is an equivalence relation, so a first-fit bijection is exact.

For `expect().toEqual`, asymmetric matchers like `expect.anything()` make the relation non-transitive, so a first-fit bijection can reject valid pairings (for example `new Set([{a:1},{a:2}])` vs `new Set([expect.anything(), {a:1}])`). That path uses Jest's two-way subset check instead.

Recursive element comparisons pass `addToStack=true` so nested pairs land on the cycle-detection stack; a collection containing another self-referential collection previously recursed until `RangeError: Maximum call stack size exceeded` (Node returns true for those). Both passes use a consistent (left, right) argument order because the cycle stack records pairs positionally.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28760.test.ts` -> 13 of 23 fail (bug present)
- `USE_SYSTEM_BUN=1 bun test test/js/bun/bun-object/deep-equals.test.ts` -> 10 of 65 fail
- `bun bd test` on both files -> all pass
- No regressions in `test/js/node/assert/deep-equal.test.ts` (305 tests, exercises the node `checkPrototypes` entry points), `assert-typedarray-deepequal.test.ts`, or the `expect.test.js` isEqual/deepEquals groups (including the cyclic-Set case and the Set/Map stress test)

## Rebase notes

Resolved against the restructured main:

- `Bun__deepEquals` gained two template parameters (`checkPrototypes`, `skipPrototypeIdentity`), and content-equal Sets/Maps now `break` to own-enumerable-property comparison for the node entry points instead of returning. The new Set/Map paths funnel every self-equal outcome through that shared exit so those semantics are preserved.
- `test/js/bun/bun-object/deep-equals.spec.ts` was replaced by `deep-equals.test.ts` on main (#37168); the structurally-equal-keys test block moved into the new file.
- The use-after-free fix from #37168 and the spec-driven matrix from #33323 are unaffected; their suites pass with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 18 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/bun-object/deep-equals.test.ts

<!-- robobun:evidence:end -->