### PR TITLE
Implement net.Socket handle passing over IPC

### DIFF
--- a/src/bun.js/ipc.zig
+++ b/src/bun.js/ipc.zig
@@ -1025,8 +1025,18 @@ pub fn doSend(ipc: ?*SendQueue, globalObject: *jsc.JSGlobalObject, callFrame: *j
                 },
                 .none => {},
             }
-        } else {
-            //
+        } else if (handle.as(bun.api.TCPSocket)) |tcp_socket| {
+            log("got tcp socket", .{});
+            const fd = tcp_socket.socket.fd();
+            if (fd != bun.invalid_fd) {
+                zig_handle = .init(fd, handle);
+            }
+        } else if (handle.as(bun.api.TLSSocket)) |tls_socket| {
+            log("got tls socket", .{});
+            const fd = tls_socket.socket.fd();
+            if (fd != bun.invalid_fd) {
+                zig_handle = .init(fd, handle);
+            }
         }
     }
 

--- a/src/bun.js/node/node_net_binding.zig
+++ b/src/bun.js/node/node_net_binding.zig
@@ -134,6 +134,10 @@ pub fn socketFromFd(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) 
     });
 
     const native_socket = bun.api.TCPSocket.Socket.fromFd(context, fd, bun.api.TCPSocket, tcp_socket, null, false) orelse {
+        // Free handlers before deref — deinit() won't reach Handlers.markInactive()
+        // because onOpen() never fired so is_active stays false.
+        tcp_socket.handlers = null;
+        globalThis.bunVM().allocator.destroy(handlers_ptr);
         tcp_socket.deref();
         return globalThis.throw("Failed to create socket from fd", .{});
     };

--- a/src/bun.js/node/node_net_binding.zig
+++ b/src/bun.js/node/node_net_binding.zig
@@ -132,7 +132,6 @@ pub fn socketFromFd(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) 
         .protos = null,
         .handlers = handlers_ptr,
     });
-    tcp_socket.ref();
 
     const native_socket = bun.api.TCPSocket.Socket.fromFd(context, fd, bun.api.TCPSocket, tcp_socket, null, false) orelse {
         tcp_socket.deref();

--- a/src/bun.js/node/node_net_binding.zig
+++ b/src/bun.js/node/node_net_binding.zig
@@ -139,10 +139,14 @@ pub fn socketFromFd(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) 
         tcp_socket.handlers = null;
         globalThis.bunVM().allocator.destroy(handlers_ptr);
         tcp_socket.deref();
+        fd.close();
         return globalThis.throw("Failed to create socket from fd", .{});
     };
 
     tcp_socket.socket = native_socket;
+    // Call onOpen so markActive() fires — without this, handlers_ptr leaks
+    // when the socket closes because markInactive() is guarded by is_active.
+    tcp_socket.onOpen(native_socket);
     return tcp_socket.getThisValue(globalThis);
 }
 

--- a/src/bun.js/node/node_net_binding.zig
+++ b/src/bun.js/node/node_net_binding.zig
@@ -102,7 +102,49 @@ pub fn doConnect(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun
     return bun.api.Listener.connectInner(globalThis, maybe_tcp, maybe_tls, opts);
 }
 
+/// Create a connected TCPSocket from an existing file descriptor.
+/// Used by IPC parseHandle to reconstruct a net.Socket from a received fd.
+/// The socket is created in a paused state so no events fire until the JS
+/// side has attached handlers via net.Socket.
+pub fn socketFromFd(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+    const args = callframe.argumentsAsArray(1);
+    const fd_value = args[0];
+    if (!fd_value.isNumber()) {
+        return globalThis.throw("Expected a number for fd", .{});
+    }
+    const fd = fd_value.asFileDescriptor();
+
+    const context = uws.SocketContext.createNoSSLContext(uws.Loop.get(), @sizeOf(usize)) orelse {
+        return globalThis.throw("Failed to create socket context", .{});
+    };
+    uws.NewSocketHandler(false).configure(context, true, *bun.api.TCPSocket, bun.api.TCPSocket);
+
+    const handlers_ptr = bun.handleOom(globalThis.bunVM().allocator.create(bun.api.SocketHandlers));
+    handlers_ptr.* = .{
+        .vm = globalThis.bunVM(),
+        .globalObject = globalThis,
+    };
+
+    const tcp_socket = bun.api.TCPSocket.new(.{
+        .socket = .detached,
+        .socket_context = context,
+        .ref_count = .init(),
+        .protos = null,
+        .handlers = handlers_ptr,
+    });
+    tcp_socket.ref();
+
+    const native_socket = bun.api.TCPSocket.Socket.fromFd(context, fd, bun.api.TCPSocket, tcp_socket, null, false) orelse {
+        tcp_socket.deref();
+        return globalThis.throw("Failed to create socket from fd", .{});
+    };
+
+    tcp_socket.socket = native_socket;
+    return tcp_socket.getThisValue(globalThis);
+}
+
 const validators = @import("./util/validators.zig");
 
 const bun = @import("bun");
 const jsc = bun.jsc;
+const uws = bun.uws;

--- a/src/js/builtins/Ipc.ts
+++ b/src/js/builtins/Ipc.ts
@@ -145,65 +145,15 @@
  * @param {{ keepOpen?: boolean } | undefined} options
  * @returns {[unknown, Serialized] | null}
  */
-export function serialize(_message, _handle, _options) {
-  // sending file descriptors is not supported yet
-  return null; // send the message without the file descriptor
-
-  /*
+export function serialize(message, handle, _options) {
   const net = require("node:net");
-  const dgram = require("node:dgram");
   if (handle instanceof net.Server) {
-    // this one doesn't need a close function, but the fd needs to be kept alive until it is sent
-    const server = handle as unknown as (typeof net)["Server"] & { _handle: Bun.TCPSocketListener<unknown> };
-    return [server._handle, { cmd: "NODE_HANDLE", message, type: "net.Server" }];
+    return [handle._handle, { cmd: "NODE_HANDLE", message, type: "net.Server" }];
   } else if (handle instanceof net.Socket) {
-    const new_message: { cmd: "NODE_HANDLE"; message: unknown; type: "net.Socket"; key?: string } = {
-      cmd: "NODE_HANDLE",
-      message,
-      type: "net.Socket",
-    };
-    const socket = handle as unknown as (typeof net)["Socket"] & {
-      _handle: Bun.Socket;
-      server: (typeof net)["Server"] | null;
-      setTimeout(timeout: number): void;
-    };
-    if (!socket._handle) return null; // failed
-
-    // If the socket was created by net.Server
-    if (socket.server) {
-      // The worker should keep track of the socket
-      new_message.key = socket.server._connectionKey;
-
-      const firstTime = !this[kChannelHandle].sockets.send[message.key];
-      const socketList = getSocketList("send", this, message.key);
-
-      // The server should no longer expose a .connection property
-      // and when asked to close it should query the socket status from
-      // the workers
-      if (firstTime) socket.server._setupWorker(socketList);
-
-      // Act like socket is detached
-      if (!options?.keepOpen) socket.server._connections--;
-    }
-
-    const internal_handle = socket._handle;
-
-    // Remove handle from socket object, it will be closed when the socket
-    // will be sent
-    if (!options?.keepOpen) {
-      // we can use a $newZigFunction to have it unset the callback
-      internal_handle.onread = nop;
-      socket._handle = null;
-      socket.setTimeout(0);
-    }
-    return [internal_handle, new_message];
-  } else if (handle instanceof dgram.Socket) {
-    // this one doesn't need a close function, but the fd needs to be kept alive until it is sent
-    throw new Error("todo serialize dgram.Socket");
-  } else {
-    throw $ERR_INVALID_HANDLE_TYPE();
+    if (!handle._handle) return null;
+    return [handle._handle, { cmd: "NODE_HANDLE", message, type: "net.Socket" }];
   }
-  */
+  return null;
 }
 /**
  * @param {Serialized} serialized
@@ -224,7 +174,19 @@ export function parseHandle(target, serialized, fd) {
       return;
     }
     case "net.Socket": {
-      throw new Error("TODO case net.Socket");
+      const socketFromFd = $newZigFunction("node_net_binding.zig", "socketFromFd", 1);
+      try {
+        const nativeHandle = socketFromFd(fd);
+        const socket = new net.Socket({ readable: true, writable: true });
+        socket._handle = nativeHandle;
+        nativeHandle.data = socket;
+        socket.connecting = false;
+        socket._readableState && (socket._readableState.reading = false);
+        emit(target, serialized.message, socket);
+      } catch {
+        emit(target, serialized.message, undefined);
+      }
+      return;
     }
     case "dgram.Socket": {
       throw new Error("TODO case dgram.Socket");

--- a/src/js/builtins/Ipc.ts
+++ b/src/js/builtins/Ipc.ts
@@ -148,10 +148,19 @@
 export function serialize(message, handle, _options) {
   const net = require("node:net");
   if (handle instanceof net.Server) {
+    if (!handle._handle) return null;
     return [handle._handle, { cmd: "NODE_HANDLE", message, type: "net.Server" }];
   } else if (handle instanceof net.Socket) {
     if (!handle._handle) return null;
-    return [handle._handle, { cmd: "NODE_HANDLE", message, type: "net.Socket" }];
+    // TLS sockets cannot be transferred — TLS state is in-process only
+    const tls = require("node:tls");
+    if (handle instanceof tls.TLSSocket) return null;
+    const internal_handle = handle._handle;
+    // Detach the socket from the sender so both sides don't read from the
+    // same underlying fd after SCM_RIGHTS duplicates it to the receiver.
+    handle._handle = null;
+    handle.setTimeout(0);
+    return [internal_handle, { cmd: "NODE_HANDLE", message, type: "net.Socket" }];
   }
   return null;
 }

--- a/test/regression/issue/28759.test.ts
+++ b/test/regression/issue/28759.test.ts
@@ -14,14 +14,18 @@ if (cluster.isMaster) {
     const isSocket = h instanceof net.Socket;
     console.log('master recv: cmd=' + m.cmd + ', isSocket=' + isSocket);
     worker.kill();
+    server.close();
     process.exit(0);
   });
 
-  worker.on('online', function() {
-    const sock = new net.Socket();
-    sock.connect(443, 'google.com', function() {
-      console.log('master sending socket');
-      worker.send({ cmd: 'syn', data: 'hello' }, sock);
+  const server = net.createServer();
+  server.listen(0, '127.0.0.1', function() {
+    worker.on('online', function() {
+      const sock = new net.Socket();
+      sock.connect(server.address().port, '127.0.0.1', function() {
+        console.log('master sending socket');
+        worker.send({ cmd: 'syn', data: 'hello' }, sock);
+      });
     });
   });
 } else {
@@ -63,18 +67,22 @@ if (cluster.isMaster) {
     const isSocket = h instanceof net.Socket;
     console.log('master recv: cmd=' + m.cmd + ', dataLen=' + m.data.length + ', isSocket=' + isSocket);
     worker.kill();
+    server.close();
     process.exit(0);
   });
 
-  worker.on('online', function() {
-    const sock = new net.Socket();
-    sock.connect(443, 'google.com', function() {
-      const data = [];
-      for (var i = 0; i < 30000; i++) {
-        data[i] = '1';
-      }
-      console.log('master sending socket with large payload');
-      worker.send({ cmd: 'syn', data: data }, sock);
+  const server = net.createServer();
+  server.listen(0, '127.0.0.1', function() {
+    worker.on('online', function() {
+      const sock = new net.Socket();
+      sock.connect(server.address().port, '127.0.0.1', function() {
+        const data = [];
+        for (var i = 0; i < 30000; i++) {
+          data[i] = '1';
+        }
+        console.log('master sending socket with large payload');
+        worker.send({ cmd: 'syn', data: data }, sock);
+      });
     });
   });
 } else {

--- a/test/regression/issue/28759.test.ts
+++ b/test/regression/issue/28759.test.ts
@@ -2,9 +2,11 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 // IPC socket handle passing uses SCM_RIGHTS which is POSIX-only
-test.skipIf(isWindows)("cluster.send() preserves socket handle", async () => {
-  using dir = tempDir("issue-28759", {
-    "index.cjs": `
+test.skipIf(isWindows)(
+  "cluster.send() preserves socket handle",
+  async () => {
+    using dir = tempDir("issue-28759", {
+      "index.cjs": `
 const cluster = require('cluster');
 const net = require('net');
 
@@ -37,27 +39,31 @@ if (cluster.isMaster) {
   });
 }
 `,
-  });
+    });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "index.cjs"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout).toContain("master sending socket");
-  expect(stdout).toContain("worker recv: cmd=syn, isSocket=true");
-  expect(stdout).toContain("master recv: cmd=ack, isSocket=true");
-  expect(exitCode).toBe(0);
-}, 30_000);
+    expect(stdout).toContain("master sending socket");
+    expect(stdout).toContain("worker recv: cmd=syn, isSocket=true");
+    expect(stdout).toContain("master recv: cmd=ack, isSocket=true");
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
 
-test.skipIf(isWindows)("process.send() preserves socket handle with large payload", async () => {
-  using dir = tempDir("issue-28759-large", {
-    "index.cjs": `
+test.skipIf(isWindows)(
+  "process.send() preserves socket handle with large payload",
+  async () => {
+    using dir = tempDir("issue-28759-large", {
+      "index.cjs": `
 const cluster = require('cluster');
 const net = require('net');
 
@@ -94,20 +100,22 @@ if (cluster.isMaster) {
   });
 }
 `,
-  });
+    });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "index.cjs"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout).toContain("master sending socket with large payload");
-  expect(stdout).toContain("worker recv: cmd=syn, dataLen=30000, isSocket=true");
-  expect(stdout).toContain("master recv: cmd=ack, dataLen=30000, isSocket=true");
-  expect(exitCode).toBe(0);
-}, 30_000);
+    expect(stdout).toContain("master sending socket with large payload");
+    expect(stdout).toContain("worker recv: cmd=syn, dataLen=30000, isSocket=true");
+    expect(stdout).toContain("master recv: cmd=ack, dataLen=30000, isSocket=true");
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);

--- a/test/regression/issue/28759.test.ts
+++ b/test/regression/issue/28759.test.ts
@@ -1,0 +1,112 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("cluster.send() preserves socket handle", async () => {
+  using dir = tempDir("issue-28759", {
+    "index.cjs": `
+const cluster = require('cluster');
+const net = require('net');
+
+if (cluster.isMaster) {
+  const worker = cluster.fork();
+
+  worker.on('message', function(m, h) {
+    const isSocket = h instanceof net.Socket;
+    console.log('master recv: cmd=' + m.cmd + ', isSocket=' + isSocket);
+    worker.kill();
+    process.exit(0);
+  });
+
+  worker.on('online', function() {
+    const sock = new net.Socket();
+    sock.connect(443, 'google.com', function() {
+      console.log('master sending socket');
+      worker.send({ cmd: 'syn', data: 'hello' }, sock);
+    });
+  });
+} else {
+  process.on('message', function(m, h) {
+    const isSocket = h instanceof net.Socket;
+    console.log('worker recv: cmd=' + m.cmd + ', isSocket=' + isSocket);
+    process.send({ cmd: 'ack' }, h);
+  });
+}
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout).toContain("master sending socket");
+  expect(stdout).toContain("worker recv: cmd=syn, isSocket=true");
+  expect(stdout).toContain("master recv: cmd=ack, isSocket=true");
+  expect(exitCode).toBe(0);
+}, 30_000);
+
+test("process.send() preserves socket handle with large payload", async () => {
+  using dir = tempDir("issue-28759-large", {
+    "index.cjs": `
+const cluster = require('cluster');
+const net = require('net');
+
+if (cluster.isMaster) {
+  const worker = cluster.fork();
+
+  worker.on('message', function(m, h) {
+    const isSocket = h instanceof net.Socket;
+    console.log('master recv: cmd=' + m.cmd + ', dataLen=' + m.data.length + ', isSocket=' + isSocket);
+    worker.kill();
+    process.exit(0);
+  });
+
+  worker.on('online', function() {
+    const sock = new net.Socket();
+    sock.connect(443, 'google.com', function() {
+      const data = [];
+      for (var i = 0; i < 30000; i++) {
+        data[i] = '1';
+      }
+      console.log('master sending socket with large payload');
+      worker.send({ cmd: 'syn', data: data }, sock);
+    });
+  });
+} else {
+  process.on('message', function(m, h) {
+    const isSocket = h instanceof net.Socket;
+    console.log('worker recv: cmd=' + m.cmd + ', dataLen=' + m.data.length + ', isSocket=' + isSocket);
+    process.send({ cmd: 'ack', data: m.data }, h);
+  });
+}
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout).toContain("master sending socket with large payload");
+  expect(stdout).toContain("worker recv: cmd=syn, dataLen=30000, isSocket=true");
+  expect(stdout).toContain("master recv: cmd=ack, dataLen=30000, isSocket=true");
+  expect(exitCode).toBe(0);
+}, 30_000);

--- a/test/regression/issue/28759.test.ts
+++ b/test/regression/issue/28759.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
-test("cluster.send() preserves socket handle", async () => {
+// IPC socket handle passing uses SCM_RIGHTS which is POSIX-only
+test.skipIf(isWindows)("cluster.send() preserves socket handle", async () => {
   using dir = tempDir("issue-28759", {
     "index.cjs": `
 const cluster = require('cluster');
@@ -54,7 +55,7 @@ if (cluster.isMaster) {
   expect(exitCode).toBe(0);
 }, 30_000);
 
-test("process.send() preserves socket handle with large payload", async () => {
+test.skipIf(isWindows)("process.send() preserves socket handle with large payload", async () => {
   using dir = tempDir("issue-28759-large", {
     "index.cjs": `
 const cluster = require('cluster');

--- a/test/regression/issue/28759.test.ts
+++ b/test/regression/issue/28759.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 test("cluster.send() preserves socket handle", async () => {
@@ -42,11 +42,7 @@ if (cluster.isMaster) {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toContain("master sending socket");
   expect(stdout).toContain("worker recv: cmd=syn, isSocket=true");
@@ -99,11 +95,7 @@ if (cluster.isMaster) {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toContain("master sending socket with large payload");
   expect(stdout).toContain("worker recv: cmd=syn, dataLen=30000, isSocket=true");


### PR DESCRIPTION
## Problem

`cluster.send()` / `worker.send()` / `process.send()` silently drops `net.Socket` handles when sending messages over IPC. The socket handle argument is always received as `undefined` on the other side.

## Root Cause

Three gaps prevented socket handle passing:

1. **`serialize()` in `Ipc.ts`** — returned `null` immediately, never extracting the native handle from the socket
2. **`doSend()` in `ipc.zig`** — had an empty `else` branch for non-Listener handles, so file descriptors were never extracted from `TCPSocket`/`TLSSocket` objects
3. **`parseHandle()` in `Ipc.ts`** — threw `"TODO case net.Socket"` when receiving a socket handle

## Fix

- **`Ipc.ts` `serialize()`**: Implement for `net.Server` and `net.Socket`, extracting `_handle` and wrapping the message in a `NODE_HANDLE` envelope
- **`ipc.zig` `doSend()`**: Extract file descriptors from `TCPSocket` and `TLSSocket` handles, enabling fd transmission via `SCM_RIGHTS`
- **`node_net_binding.zig`**: Add `socketFromFd()` that creates a connected `TCPSocket` from a received file descriptor with a proper socket context and handlers
- **`Ipc.ts` `parseHandle()`**: Reconstruct a `net.Socket` from the received fd using the new `socketFromFd()`

## Verification

```
USE_SYSTEM_BUN=1 bun test test/regression/issue/28759.test.ts  →  2 fail (handle is undefined)
bun bd test test/regression/issue/28759.test.ts                 →  2 pass (handle is net.Socket)
```

Closes #28759