### PR TITLE
fix: improve misleading fetch() error for non-string URL inputs

### DIFF
--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -1,5 +1,6 @@
 pub const fetch_error_no_args = "fetch() expects a string but received no arguments.";
 pub const fetch_error_blank_url = "fetch() URL must not be a blank string.";
+pub const fetch_error_no_hostname = "fetch() URL must have a hostname.";
 pub const fetch_error_unexpected_body = "fetch() request with GET/HEAD/OPTIONS method cannot have body.";
 pub const fetch_error_proxy_unix = "fetch() cannot use a proxy with a unix socket.";
 const JSTypeErrorEnum = std.enums.EnumArray(JSType, string);
@@ -132,7 +133,7 @@ pub fn Bun__fetchPreconnect_(
 
     if (url.hostname.len == 0) {
         bun.default_allocator.free(url.href);
-        return globalObject.ERR(.INVALID_ARG_TYPE, fetch_error_blank_url, .{}).throw();
+        return globalObject.ERR(.INVALID_ARG_TYPE, fetch_error_no_hostname, .{}).throw();
     }
 
     if (!url.hasValidPort()) {
@@ -311,6 +312,7 @@ fn fetchImpl(
         break :brk null;
     };
 
+    var url_was_from_input = true;
     var url_str = extract_url: {
         if (url_str_optional) |str| break :extract_url str;
 
@@ -327,6 +329,7 @@ fn fetchImpl(
             }
         }
 
+        url_was_from_input = false;
         break :extract_url bun.String.empty;
     };
     defer url_str.deref();
@@ -338,7 +341,10 @@ fn fetchImpl(
 
     if (url_str.isEmpty()) {
         is_error = true;
-        const err = ctx.toTypeError(.INVALID_URL, fetch_error_blank_url, .{});
+        const err = if (url_was_from_input)
+            ctx.toTypeError(.INVALID_URL, fetch_error_blank_url, .{})
+        else
+            ctx.toTypeError(.INVALID_URL, "fetch() URL could not be parsed; received a non-string value that is not a URL object.", .{});
         return JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, err);
     }
 


### PR DESCRIPTION
## Summary

Fixes #21361

When `fetch()` receives a non-string, non-URL value like `undefined`, `123`, or an object whose `toString()` returns a relative path, Bun currently reports:

> `fetch() URL must not be a blank string.`

This is misleading because the user did provide a value — it just wasn't a valid URL.

### Changes

All changes are in `src/bun.js/webcore/fetch.zig`:

1. **`fetchImpl`**: Track whether the empty URL string came from actual user input (e.g. `fetch("")`) vs a failed type conversion (e.g. `fetch(undefined)`). When the input was a non-string/non-URL value that couldn't be converted, the error now reads:
   > `fetch() URL could not be parsed; received a non-string value that is not a URL object.`
   
   The original "must not be a blank string" message is preserved for `fetch("")` where it is accurate.

2. **`Bun__fetchPreconnect_`**: When a URL parses successfully but has no hostname (e.g. a path like `/some_path` that made it past the empty check), the error now reads:
   > `fetch() URL must have a hostname.`
   
   Previously this also used the "blank string" message, which was incorrect — the string wasn't blank, it just lacked a hostname.

### Before / After

| Input | Before | After |
|---|---|---|
| `fetch(undefined)` | `URL must not be a blank string` | `URL could not be parsed; received a non-string value that is not a URL object` |
| `fetch(123)` | `URL must not be a blank string` | `URL could not be parsed; received a non-string value that is not a URL object` |
| `fetch("")` | `URL must not be a blank string` | `URL must not be a blank string` (unchanged) |
| `preconnect("/path")` | `URL must not be a blank string` | `URL must have a hostname` |

### Test plan

- Verify `fetch(undefined)` no longer reports "blank string"
- Verify `fetch(123)` no longer reports "blank string"
- Verify `fetch("")` still reports "blank string" (correct case)
- Verify `fetch({toString() { return '/path' }})` no longer reports "blank string"
- Verify `fetch.preconnect('/path')` reports "must have a hostname"
- Verify normal `fetch('https://example.com')` is unaffected

---

🇺🇸 Reid Wiseman — Commander
🇺🇸 Victor Glover — Pilot
🇺🇸 Christina Koch — Mission Specialist
🇨🇦 Jeremy Hansen — Mission Specialist

Artemis II. Open source for all — on this planet and beyond it.