### PR TITLE
Warn when hardlink fallback to copy occurs during install

### DIFF
--- a/src/install/PackageInstall.zig
+++ b/src/install/PackageInstall.zig
@@ -374,6 +374,26 @@ pub const PackageInstall = struct {
     else
         Method.hardlink;
 
+    /// Set to true when the user explicitly chose a backend via `--backend` CLI flag.
+    /// When true, we suppress the hardlink-to-copy fallback warning.
+    pub var backend_explicitly_set: bool = false;
+
+    pub fn warnFallbackToFileCopy(from_method: []const u8) void {
+        const warned = struct {
+            var once = false;
+        };
+        if (warned.once) return;
+        warned.once = true;
+        if (backend_explicitly_set) return;
+
+        Output.warn(
+            "Failed to {s} files; falling back to full copy. This may lead to degraded performance.\n" ++
+                "         If the cache and target directories are on different filesystems, {s} may not be supported.\n" ++
+                "         If this is intentional, set --backend=copyfile to suppress this warning.\n",
+            .{ from_method, from_method },
+        );
+    }
+
     fn installWithClonefileEachDir(this: *@This(), destination_dir: std.fs.Dir) !Result {
         var cached_package_dir = bun.openDir(this.cache_dir, this.cache_dir_subpath) catch |err| return Result.fail(err, .opening_cache_dir, @errorReturnTrace());
         defer cached_package_dir.close();
@@ -834,24 +854,7 @@ pub const PackageInstall = struct {
                 return null;
             }
 
-            if (PackageManager.verbose_install) {
-                const once_log = struct {
-                    var once = false;
-
-                    pub fn get() bool {
-                        const prev = once;
-                        once = true;
-                        return !prev;
-                    }
-                }.get();
-
-                if (once_log) {
-                    Output.warn("CreateHardLinkW failed, falling back to CopyFileW: {f} -> {f}\n", .{
-                        bun.fmt.fmtOSPath(src, .{}),
-                        bun.fmt.fmtOSPath(dest, .{}),
-                    });
-                }
-            }
+            warnFallbackToFileCopy("hardlink");
 
             if (bun.windows.CopyFileW(src.ptr, dest.ptr, 0) != 0) {
                 return null;
@@ -1417,6 +1420,7 @@ pub const PackageInstall = struct {
                             error.NotSupported => {
                                 supported_method = .copyfile;
                                 supported_method_to_use = .copyfile;
+                                warnFallbackToFileCopy("clonefile");
                             },
                             error.FileNotFound => return Result.fail(error.FileNotFound, .opening_cache_dir, @errorReturnTrace()),
                             else => return Result.fail(err, .copying_files, @errorReturnTrace()),
@@ -1433,6 +1437,7 @@ pub const PackageInstall = struct {
                             error.NotSupported => {
                                 supported_method = .copyfile;
                                 supported_method_to_use = .copyfile;
+                                warnFallbackToFileCopy("clonefile");
                             },
                             error.FileNotFound => return Result.fail(error.FileNotFound, .opening_cache_dir, @errorReturnTrace()),
                             else => return Result.fail(err, .copying_files, @errorReturnTrace()),
@@ -1448,6 +1453,7 @@ pub const PackageInstall = struct {
                         if (err == error.NotSameFileSystem) {
                             supported_method = .copyfile;
                             supported_method_to_use = .copyfile;
+                            warnFallbackToFileCopy("hardlink");
                             break :outer;
                         }
                     }

--- a/src/install/PackageInstall.zig
+++ b/src/install/PackageInstall.zig
@@ -435,14 +435,8 @@ pub const PackageInstall = struct {
                             )) {
                                 0 => {},
                                 else => |errno| switch (std.posix.errno(errno)) {
-                                    .XDEV => {
-                                        warnFallbackToFileCopy("clone");
-                                        return error.NotSupported; // not same file system
-                                    },
-                                    .OPNOTSUPP => {
-                                        warnFallbackToFileCopy("clone");
-                                        return error.NotSupported;
-                                    },
+                                    .XDEV => return error.NotSupported, // not same file system
+                                    .OPNOTSUPP => return error.NotSupported,
                                     .NOENT => return error.FileNotFound,
                                     // sometimes the downloaded npm package has already node_modules with it, so just ignore exist error here
                                     .EXIST => {},
@@ -467,7 +461,10 @@ pub const PackageInstall = struct {
         this.file_count = FileCopier.copy(
             subdir,
             &walker_,
-        ) catch |err| return Result.fail(err, .copying_files, @errorReturnTrace());
+        ) catch |err| switch (err) {
+            error.NotSupported => return err,
+            else => return Result.fail(err, .copying_files, @errorReturnTrace()),
+        };
 
         return .{ .success = {} };
     }
@@ -1446,6 +1443,7 @@ pub const PackageInstall = struct {
                             error.NotSupported => {
                                 supported_method = .copyfile;
                                 supported_method_to_use = .copyfile;
+                                warnFallbackToFileCopy("clone");
                             },
                             error.FileNotFound => return Result.fail(error.FileNotFound, .opening_cache_dir, @errorReturnTrace()),
                             else => return Result.fail(err, .copying_files, @errorReturnTrace()),

--- a/src/install/PackageInstall.zig
+++ b/src/install/PackageInstall.zig
@@ -435,8 +435,14 @@ pub const PackageInstall = struct {
                             )) {
                                 0 => {},
                                 else => |errno| switch (std.posix.errno(errno)) {
-                                    .XDEV => return error.NotSupported, // not same file system
-                                    .OPNOTSUPP => return error.NotSupported,
+                                    .XDEV => {
+                                        warnFallbackToFileCopy("clone");
+                                        return error.NotSupported; // not same file system
+                                    },
+                                    .OPNOTSUPP => {
+                                        warnFallbackToFileCopy("clone");
+                                        return error.NotSupported;
+                                    },
                                     .NOENT => return error.FileNotFound,
                                     // sometimes the downloaded npm package has already node_modules with it, so just ignore exist error here
                                     .EXIST => {},
@@ -461,10 +467,7 @@ pub const PackageInstall = struct {
         this.file_count = FileCopier.copy(
             subdir,
             &walker_,
-        ) catch |err| switch (err) {
-            error.NotSupported => return err,
-            else => return Result.fail(err, .copying_files, @errorReturnTrace()),
-        };
+        ) catch |err| return Result.fail(err, .copying_files, @errorReturnTrace());
 
         return .{ .success = {} };
     }
@@ -1443,7 +1446,6 @@ pub const PackageInstall = struct {
                             error.NotSupported => {
                                 supported_method = .copyfile;
                                 supported_method_to_use = .copyfile;
-                                warnFallbackToFileCopy("clone");
                             },
                             error.FileNotFound => return Result.fail(error.FileNotFound, .opening_cache_dir, @errorReturnTrace()),
                             else => return Result.fail(err, .copying_files, @errorReturnTrace()),

--- a/src/install/PackageInstall.zig
+++ b/src/install/PackageInstall.zig
@@ -392,7 +392,7 @@ pub const PackageInstall = struct {
         Output.warn(
             "Failed to {s} files; falling back to full copy. This may lead to degraded performance.\n" ++
                 "         If the cache and target directories are on different filesystems, {s} may not be supported.\n" ++
-                "         If this is intentional, set --backend=copyfile to suppress this warning.\n",
+                "         If this is intentional, pass --backend explicitly (e.g. --backend=copyfile) to suppress this warning.\n",
             .{ from_method, from_method },
         );
     }

--- a/src/install/PackageInstall.zig
+++ b/src/install/PackageInstall.zig
@@ -461,12 +461,7 @@ pub const PackageInstall = struct {
         this.file_count = FileCopier.copy(
             subdir,
             &walker_,
-        ) catch |err| {
-            if (err == error.NotSupported) {
-                warnFallbackToFileCopy("clone");
-            }
-            return Result.fail(err, .copying_files, @errorReturnTrace());
-        };
+        ) catch |err| return Result.fail(err, .copying_files, @errorReturnTrace());
 
         return .{ .success = {} };
     }

--- a/src/install/PackageInstall.zig
+++ b/src/install/PackageInstall.zig
@@ -461,9 +461,11 @@ pub const PackageInstall = struct {
         this.file_count = FileCopier.copy(
             subdir,
             &walker_,
-        ) catch |err| switch (err) {
-            error.NotSupported => return err,
-            else => return Result.fail(err, .copying_files, @errorReturnTrace()),
+        ) catch |err| {
+            if (err == error.NotSupported) {
+                warnFallbackToFileCopy("clone");
+            }
+            return Result.fail(err, .copying_files, @errorReturnTrace());
         };
 
         return .{ .success = {} };
@@ -1443,7 +1445,6 @@ pub const PackageInstall = struct {
                             error.NotSupported => {
                                 supported_method = .copyfile;
                                 supported_method_to_use = .copyfile;
-                                warnFallbackToFileCopy("clone");
                             },
                             error.FileNotFound => return Result.fail(error.FileNotFound, .opening_cache_dir, @errorReturnTrace()),
                             else => return Result.fail(err, .copying_files, @errorReturnTrace()),

--- a/src/install/PackageInstall.zig
+++ b/src/install/PackageInstall.zig
@@ -379,12 +379,15 @@ pub const PackageInstall = struct {
     pub var backend_explicitly_set: bool = false;
 
     pub fn warnFallbackToFileCopy(from_method: []const u8) void {
-        const warned = struct {
-            var once = false;
-        };
-        if (warned.once) return;
-        warned.once = true;
         if (backend_explicitly_set) return;
+
+        const warned = struct {
+            var once = std.atomic.Value(bool).init(false);
+        };
+        // .monotonic is okay because we only ever set this to true, and
+        // we don't rely on any side effects from a thread that
+        // previously set this to true.
+        if (warned.once.swap(true, .monotonic)) return;
 
         Output.warn(
             "Failed to {s} files; falling back to full copy. This may lead to degraded performance.\n" ++
@@ -1420,7 +1423,7 @@ pub const PackageInstall = struct {
                             error.NotSupported => {
                                 supported_method = .copyfile;
                                 supported_method_to_use = .copyfile;
-                                warnFallbackToFileCopy("clonefile");
+                                warnFallbackToFileCopy("clone");
                             },
                             error.FileNotFound => return Result.fail(error.FileNotFound, .opening_cache_dir, @errorReturnTrace()),
                             else => return Result.fail(err, .copying_files, @errorReturnTrace()),
@@ -1437,7 +1440,7 @@ pub const PackageInstall = struct {
                             error.NotSupported => {
                                 supported_method = .copyfile;
                                 supported_method_to_use = .copyfile;
-                                warnFallbackToFileCopy("clonefile");
+                                warnFallbackToFileCopy("clone");
                             },
                             error.FileNotFound => return Result.fail(error.FileNotFound, .opening_cache_dir, @errorReturnTrace()),
                             else => return Result.fail(err, .copying_files, @errorReturnTrace()),

--- a/src/install/PackageInstall.zig
+++ b/src/install/PackageInstall.zig
@@ -461,7 +461,10 @@ pub const PackageInstall = struct {
         this.file_count = FileCopier.copy(
             subdir,
             &walker_,
-        ) catch |err| return Result.fail(err, .copying_files, @errorReturnTrace());
+        ) catch |err| switch (err) {
+            error.NotSupported => return err,
+            else => return Result.fail(err, .copying_files, @errorReturnTrace()),
+        };
 
         return .{ .success = {} };
     }

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -606,6 +606,7 @@ pub fn load(
 
         if (cli.backend) |backend| {
             PackageInstall.supported_method = backend;
+            PackageInstall.backend_explicitly_set = true;
         }
 
         // CPU and OS are now parsed as enums in CommandLineArguments, just copy them

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -524,6 +524,7 @@ pub const Installer = struct {
                                         .result => {},
                                         .err => |err| {
                                             if (err.getErrno() == .XDEV) {
+                                                PackageInstall.warnFallbackToFileCopy("hardlink");
                                                 continue :backend .copyfile;
                                             }
 
@@ -660,6 +661,7 @@ pub const Installer = struct {
                                 .err => |err| {
                                     switch (err.getErrno()) {
                                         .XDEV => {
+                                            PackageInstall.warnFallbackToFileCopy("clone");
                                             installer.supported_backend.store(.copyfile, .monotonic);
                                             continue :backend .copyfile;
                                         },
@@ -710,6 +712,7 @@ pub const Installer = struct {
                                 .result => {},
                                 .err => |err| {
                                     if (err.getErrno() == .XDEV) {
+                                        PackageInstall.warnFallbackToFileCopy("hardlink");
                                         installer.supported_backend.store(.copyfile, .monotonic);
                                         continue :backend .copyfile;
                                     }

--- a/test/regression/issue/28768.test.ts
+++ b/test/regression/issue/28768.test.ts
@@ -93,7 +93,7 @@ test.skipIf(!isLinux || !isCrossDevice)("warns when hardlink falls back to copy 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr.match(/falling back to full copy/g)?.length ?? 0).toBe(1);
-    expect(stderr).toContain("--backend=copyfile");
+    expect(stderr).toContain("--backend");
     expect(exitCode).toBe(0);
   } finally {
     rmSync(cacheDir, { recursive: true, force: true });

--- a/test/regression/issue/28768.test.ts
+++ b/test/regression/issue/28768.test.ts
@@ -1,10 +1,20 @@
-import { test, expect, beforeAll, afterAll } from "bun:test";
-import { mkdirSync, rmSync, readFileSync, writeFileSync } from "fs";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import { join } from "path";
-import { bunExe, bunEnv, isLinux, tempDir } from "harness";
 
 // Serve a minimal registry with a single package (no-deps@1.0.0)
-const tgzPath = join(import.meta.dir, "..", "..", "cli", "install", "registry", "packages", "no-deps", "no-deps-1.0.0.tgz");
+const tgzPath = join(
+  import.meta.dir,
+  "..",
+  "..",
+  "cli",
+  "install",
+  "registry",
+  "packages",
+  "no-deps",
+  "no-deps-1.0.0.tgz",
+);
 const tgzData = readFileSync(tgzPath);
 
 let server: ReturnType<typeof Bun.serve>;

--- a/test/regression/issue/28768.test.ts
+++ b/test/regression/issue/28768.test.ts
@@ -92,7 +92,7 @@ test.skipIf(!isLinux || !isCrossDevice)("warns when hardlink falls back to copy 
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toContain("falling back to full copy");
+    expect(stderr.match(/falling back to full copy/g)?.length ?? 0).toBe(1);
     expect(stderr).toContain("--backend=copyfile");
     expect(exitCode).toBe(0);
   } finally {

--- a/test/regression/issue/28768.test.ts
+++ b/test/regression/issue/28768.test.ts
@@ -1,0 +1,105 @@
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdirSync, rmSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { bunExe, bunEnv, isLinux, tempDir } from "harness";
+
+// Serve a minimal registry with a single package (no-deps@1.0.0)
+const tgzPath = join(import.meta.dir, "..", "..", "cli", "install", "registry", "packages", "no-deps", "no-deps-1.0.0.tgz");
+const tgzData = readFileSync(tgzPath);
+
+let server: ReturnType<typeof Bun.serve>;
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/no-deps") {
+        return Response.json({
+          name: "no-deps",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: "no-deps",
+              version: "1.0.0",
+              dist: {
+                tarball: `http://localhost:${server.port}/no-deps/-/no-deps-1.0.0.tgz`,
+              },
+            },
+          },
+        });
+      }
+      if (url.pathname === "/no-deps/-/no-deps-1.0.0.tgz") {
+        return new Response(tgzData);
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+function writeBunfig(dir: string, cacheDir: string) {
+  const bunfig = `[install]\ncache = "${cacheDir.replaceAll("\\", "\\\\")}"\nregistry = "http://localhost:${server.port}/"\n`;
+  writeFileSync(join(dir, "bunfig.toml"), bunfig);
+}
+
+test.skipIf(!isLinux)("warns when hardlink falls back to copy on cross-filesystem", async () => {
+  using dir = tempDir("crossfs-warn", {
+    "package.json": JSON.stringify({ name: "cross-fs-test", dependencies: { "no-deps": "1.0.0" } }),
+  });
+  const packageDir = String(dir);
+  // Cache on tmpfs (/dev/shm) — different filesystem from overlay /tmp
+  const cacheDir = join("/dev/shm", `bun-cache-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(cacheDir, { recursive: true });
+
+  try {
+    writeBunfig(packageDir, cacheDir);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir, BUN_CONFIG_NO_VERIFY: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("falling back to full copy");
+    expect(stderr).toContain("--backend=copyfile");
+    expect(exitCode).toBe(0);
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+test.skipIf(!isLinux)("no warning when --backend=copyfile is explicitly set", async () => {
+  using dir = tempDir("crossfs-nowarn", {
+    "package.json": JSON.stringify({ name: "cross-fs-nowarn", dependencies: { "no-deps": "1.0.0" } }),
+  });
+  const packageDir = String(dir);
+  const cacheDir = join("/dev/shm", `bun-cache-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(cacheDir, { recursive: true });
+
+  try {
+    writeBunfig(packageDir, cacheDir);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--backend", "copyfile"],
+      cwd: packageDir,
+      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir, BUN_CONFIG_NO_VERIFY: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("falling back to full copy");
+    expect(exitCode).toBe(0);
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+});

--- a/test/regression/issue/28768.test.ts
+++ b/test/regression/issue/28768.test.ts
@@ -1,7 +1,8 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import { join } from "path";
+import { tmpdir } from "os";
 
 // Serve a minimal registry with a single package (no-deps@1.0.0)
 const tgzPath = join(
@@ -16,6 +17,19 @@ const tgzPath = join(
   "no-deps-1.0.0.tgz",
 );
 const tgzData = readFileSync(tgzPath);
+
+// Check that /dev/shm and the temp directory are on different devices.
+// If they're on the same device, hardlinks would succeed and the warning
+// wouldn't trigger, making the test meaningless.
+const isCrossDevice = (() => {
+  try {
+    const shmDev = statSync("/dev/shm").dev;
+    const tmpDev = statSync(tmpdir()).dev;
+    return shmDev !== tmpDev;
+  } catch {
+    return false;
+  }
+})();
 
 let server: ReturnType<typeof Bun.serve>;
 
@@ -56,12 +70,12 @@ function writeBunfig(dir: string, cacheDir: string) {
   writeFileSync(join(dir, "bunfig.toml"), bunfig);
 }
 
-test.skipIf(!isLinux)("warns when hardlink falls back to copy on cross-filesystem", async () => {
+test.skipIf(!isLinux || !isCrossDevice)("warns when hardlink falls back to copy on cross-filesystem", async () => {
   using dir = tempDir("crossfs-warn", {
     "package.json": JSON.stringify({ name: "cross-fs-test", dependencies: { "no-deps": "1.0.0" } }),
   });
   const packageDir = String(dir);
-  // Cache on tmpfs (/dev/shm) — different filesystem from overlay /tmp
+  // Cache on tmpfs (/dev/shm) — different filesystem from the temp directory
   const cacheDir = join("/dev/shm", `bun-cache-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   mkdirSync(cacheDir, { recursive: true });
 
@@ -71,7 +85,7 @@ test.skipIf(!isLinux)("warns when hardlink falls back to copy on cross-filesyste
     await using proc = Bun.spawn({
       cmd: [bunExe(), "install"],
       cwd: packageDir,
-      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir, BUN_CONFIG_NO_VERIFY: "1" },
+      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -86,7 +100,7 @@ test.skipIf(!isLinux)("warns when hardlink falls back to copy on cross-filesyste
   }
 });
 
-test.skipIf(!isLinux)("no warning when --backend=copyfile is explicitly set", async () => {
+test.skipIf(!isLinux || !isCrossDevice)("no warning when --backend is explicitly set", async () => {
   using dir = tempDir("crossfs-nowarn", {
     "package.json": JSON.stringify({ name: "cross-fs-nowarn", dependencies: { "no-deps": "1.0.0" } }),
   });
@@ -97,10 +111,13 @@ test.skipIf(!isLinux)("no warning when --backend=copyfile is explicitly set", as
   try {
     writeBunfig(packageDir, cacheDir);
 
+    // Use --backend hardlink so the install still attempts hardlinking,
+    // hits the cross-filesystem error, but suppresses the warning because
+    // the backend was explicitly chosen.
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "install", "--backend", "copyfile"],
+      cmd: [bunExe(), "install", "--backend", "hardlink"],
       cwd: packageDir,
-      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir, BUN_CONFIG_NO_VERIFY: "1" },
+      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/regression/issue/28768.test.ts
+++ b/test/regression/issue/28768.test.ts
@@ -1,8 +1,8 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
-import { join } from "path";
 import { tmpdir } from "os";
+import { join } from "path";
 
 // Serve a minimal registry with a single package (no-deps@1.0.0)
 const tgzPath = join(


### PR DESCRIPTION
Closes #28768

## Problem

When `bun install` fails to hardlink dependencies (e.g., project on `D:\`, cache on `C:\` on Windows, or cache and project on different Linux filesystems), bun silently falls back to a full file copy. Users have no idea they're losing the disk-space and performance benefits of hardlinks.

## Cause

The fallback paths in `PackageInstall.zig` (Windows `CreateHardLinkW` → `CopyFileW`, POSIX `NotSameFileSystem` → copyfile, macOS `clonefile` → copyfile) had no user-visible warning — only a verbose-mode debug message on Windows.

## Fix

Added a warning that prints once per install when a fallback occurs:

```
warn: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.
         If the cache and target directories are on different filesystems, hardlinking may not be supported.
         If this is intentional, set --backend=copyfile to suppress this warning.
```

The warning is:
- Printed **once per install** (not per file)
- **Suppressed** when `--backend` is explicitly set (user chose the method intentionally)
- Applied on **all platforms**: Windows (`CreateHardLinkW` failure), Linux (`NotSameFileSystem`), macOS (`clonefile NotSupported`)

## Verification

- `bun bd test test/regression/issue/28768.test.ts` — 2 pass
- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28768.test.ts` — first test fails (warning absent in old bun)