### PR TITLE
Fix global bin path warnings: double backslashes on Windows and trailing slash PATH detection

### DIFF
--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -889,6 +889,11 @@ struct ShellPathFormatter<'a> {
 
 impl fmt::Display for ShellPathFormatter<'_> {
     fn fmt(&self, writer: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // On Windows, backslashes are native path separators and should not be
+        // escaped/doubled in display output. Spaces inside quoted strings are
+        // literal on Windows shells (cmd/PowerShell) so no backslash-space
+        // escape is needed there either.
+        let escape_backslashes = !cfg!(windows);
         let mut remaining = self.folder;
         while let Some(space) = strings::index_of_char(remaining, b' ') {
             write!(
@@ -897,7 +902,7 @@ impl fmt::Display for ShellPathFormatter<'_> {
                 bun_core::fmt::fmt_path_u8(
                     &remaining[..space as usize],
                     bun_core::fmt::PathFormatOptions {
-                        escape_backslashes: true,
+                        escape_backslashes,
                         path_sep: if cfg!(windows) {
                             bun_core::fmt::PathSep::Windows
                         } else {
@@ -906,7 +911,7 @@ impl fmt::Display for ShellPathFormatter<'_> {
                     },
                 ),
             )?;
-            writer.write_str("\\ ")?;
+            writer.write_str(if cfg!(windows) { " " } else { "\\ " })?;
             remaining = &remaining[(space as usize + 1).min(remaining.len())..];
         }
 
@@ -916,7 +921,7 @@ impl fmt::Display for ShellPathFormatter<'_> {
             bun_core::fmt::fmt_path_u8(
                 remaining,
                 bun_core::fmt::PathFormatOptions {
-                    escape_backslashes: true,
+                    escape_backslashes,
                     path_sep: if cfg!(windows) {
                         bun_core::fmt::PathSep::Windows
                     } else {

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -310,12 +310,15 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 'warner: {
                     if Output::enable_ansi_colors_stderr() {
                         if let Some(path) = env_var::PATH.get() {
-                            // skip empty segments
+                            // Compare path entries tolerantly: trailing `/` and
+                            // `\` are ignored on every platform, and on Windows
+                            // slashes and ASCII case are normalized too.
+                            // Skip empty segments.
                             let mut path_iter = path
                                 .split(|b| *b == bun_paths::DELIMITER)
                                 .filter(|s| !s.is_empty());
                             for entry in &mut path_iter {
-                                if strings::eql(entry, output_path) {
+                                if path_entries_equal(entry, output_path) {
                                     break 'warner;
                                 }
                             }
@@ -690,6 +693,42 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
         } else {
             Global::exit(0);
         }
+    }
+}
+
+/// Trim trailing `/` and `\` characters from a PATH entry so that e.g.
+/// "/home/user/.bun/bin/" matches "/home/user/.bun/bin".
+fn trim_trailing_path_separators(s: &[u8]) -> &[u8] {
+    let mut end = s.len();
+    while end > 0 && (s[end - 1] == b'/' || s[end - 1] == b'\\') {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+/// Compare two path slices for equality, tolerant of the differences that
+/// show up between a canonical `output_path` and a raw `$PATH` entry:
+/// - trailing `/` and `\` are ignored;
+/// - on Windows, `/` and `\` are interchangeable and ASCII case is ignored.
+///
+/// We deliberately do *not* fall back to `std::fs::canonicalize` here: every
+/// PATH entry gets compared on every `bun pm bin -g`, and canonicalize on
+/// Windows issues `CreateFileW` + `GetFinalPathNameByHandleW` — which blocks
+/// for the SMB timeout (~20–60s) on a disconnected mapped drive or
+/// unreachable UNC share. The byte-level fast path (plus the case/slash
+/// normalization on Windows) covers the case #28771 actually reported.
+fn path_entries_equal(a: &[u8], b: &[u8]) -> bool {
+    let a = trim_trailing_path_separators(a);
+    let b = trim_trailing_path_separators(b);
+    if cfg!(windows) {
+        a.len() == b.len()
+            && a.iter().zip(b.iter()).all(|(&x, &y)| {
+                let nx = if x == b'/' { b'\\' } else { x.to_ascii_lowercase() };
+                let ny = if y == b'/' { b'\\' } else { y.to_ascii_lowercase() };
+                nx == ny
+            })
+    } else {
+        strings::eql(a, b)
     }
 }
 

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -723,8 +723,16 @@ fn path_entries_equal(a: &[u8], b: &[u8]) -> bool {
     if cfg!(windows) {
         a.len() == b.len()
             && a.iter().zip(b.iter()).all(|(&x, &y)| {
-                let nx = if x == b'/' { b'\\' } else { x.to_ascii_lowercase() };
-                let ny = if y == b'/' { b'\\' } else { y.to_ascii_lowercase() };
+                let nx = if x == b'/' {
+                    b'\\'
+                } else {
+                    x.to_ascii_lowercase()
+                };
+                let ny = if y == b'/' {
+                    b'\\'
+                } else {
+                    y.to_ascii_lowercase()
+                };
                 nx == ny
             })
     } else {

--- a/test/regression/issue/28771.test.ts
+++ b/test/regression/issue/28771.test.ts
@@ -1,0 +1,104 @@
+// https://github.com/oven-sh/bun/issues/28771
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, mergeWindowEnvs, tempDir } from "harness";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { delimiter, join } from "node:path";
+
+// FORCE_COLOR=1 is needed because the "not in $PATH" warning is gated
+// on enable_ansi_colors_stderr, which is false when stderr is piped.
+const baseEnv = { ...bunEnv, FORCE_COLOR: "1" };
+
+function setupGlobalDirs(dirStr: string) {
+  const binDir = join(dirStr, "bin");
+  const globalDir = join(dirStr, "global");
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(globalDir, { recursive: true });
+  writeFileSync(join(globalDir, "package.json"), "{}");
+  return { binDir, globalDir };
+}
+
+describe.concurrent("global bin path warnings", () => {
+  test("bun pm bin -g does not warn when PATH entry has trailing slash", async () => {
+    using dir = tempDir("global-bin-28771", { "placeholder": "" });
+    const { binDir, globalDir } = setupGlobalDirs(String(dir));
+
+    // PATH entry with trailing separator — should still match the bin dir.
+    const pathWithTrailing = binDir + "/";
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pm", "bin", "-g"],
+      stdout: "pipe",
+      stderr: "pipe",
+      // `mergeWindowEnvs` folds case-insensitive dupes (Windows treats `Path`
+      // and `PATH` as the same var, but JS object keys are case-sensitive —
+      // a plain spread leaves both entries and the child picks the wrong one).
+      env: mergeWindowEnvs([
+        baseEnv,
+        {
+          BUN_INSTALL_BIN: binDir,
+          BUN_INSTALL_GLOBAL_DIR: globalDir,
+          PATH: pathWithTrailing + delimiter + (process.env.PATH ?? ""),
+        },
+      ]),
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain(binDir);
+    expect(stderr).not.toContain("not in $PATH");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun pm bin -g does not warn when PATH entry matches exactly", async () => {
+    using dir = tempDir("global-bin-28771", { "placeholder": "" });
+    const { binDir, globalDir } = setupGlobalDirs(String(dir));
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pm", "bin", "-g"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: mergeWindowEnvs([
+        baseEnv,
+        {
+          BUN_INSTALL_BIN: binDir,
+          BUN_INSTALL_GLOBAL_DIR: globalDir,
+          PATH: binDir + delimiter + (process.env.PATH ?? ""),
+        },
+      ]),
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain(binDir);
+    expect(stderr).not.toContain("not in $PATH");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun pm bin -g warns when global bin dir is not in PATH", async () => {
+    using dir = tempDir("global-bin-28771", { "placeholder": "" });
+    const { binDir, globalDir } = setupGlobalDirs(String(dir));
+
+    // Use a PATH that does NOT contain the bin dir.
+    const fakePath = ["/usr/bin", "/usr/local/bin"].join(delimiter);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pm", "bin", "-g"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: mergeWindowEnvs([
+        baseEnv,
+        {
+          BUN_INSTALL_BIN: binDir,
+          BUN_INSTALL_GLOBAL_DIR: globalDir,
+          PATH: fakePath,
+        },
+      ]),
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain(binDir);
+    expect(stderr).toContain("not in $PATH");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

When running `bun i -g prettier` on Windows, the warning message displays double backslashes:

```
warn: To run "prettier", add the global bin folder to $PATH:

L:\\Software\\bun\\bin
```

instead of `L:\Software\bun\bin`. Additionally, `bun pm bin -g` fails to detect the global bin dir in `$PATH` when the PATH entry has a trailing separator (e.g. `/home/user/.bun/bin/` or `C:\...\bin\`).

Fixes #28771.

## Root Cause

1. **Double backslashes**: `ShellPathFormatter` unconditionally uses `escape_backslashes = true` when formatting the path via `fmt_path_u8`. On Windows, backslashes are the native path separator. The `escape_backslashes` option doubles every `\` to `\\`, which was designed for POSIX shells where `\` is an escape character — not for Windows display output.

2. **Trailing slash + Windows path quirks**: `bun pm bin -g` compares each `$PATH` entry against the resolved bin dir using strict byte equality. Two problems:
   - A PATH entry like `/home/user/.bun/bin/` does not match `/home/user/.bun/bin` due to the trailing separator.
   - On Windows, `output_path` is derived from a canonical path returned by `get_fd_path_z` (which normalizes case/slashes), while `$PATH` entries are the raw strings the user set — so they can disagree on case (`C:\Users` vs `C:\USERS`) and slash direction (`\` vs `/`).

## Fix

1. Changed `escape_backslashes` to `!cfg!(windows)` in `ShellPathFormatter`, and emit a literal space instead of `\ ` between space-separated path segments on Windows.

2. Introduced `path_entries_equal` which trims trailing `/` and `\` on both sides universally, and on Windows additionally treats `/` and `\` as equivalent and ignores ASCII case. Use it in the `bun pm bin -g` warner loop.

## Unrelated build fix cherry-picked

The debug build on a clean checkout after the Rust rewrite (#30412) fails with:

```
error: Unsupported syntax: Operators are not allowed in JSON
    at defines.json:1:1
```

because `src/codegen/bake-codegen.ts` passed minified CSS (which starts with `*{...}`) as a raw `define` value; the other defines in the same call all go through `JSON.stringify`. Cherry-picked `bf8bd90154` which wraps `OVERLAY_CSS` in `JSON.stringify` — a one-line fix that unblocks `bun bd` on main and therefore gates this PR.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28771.test.ts` — **fails** on the trailing-slash test (1 fail)
- `bun bd test test/regression/issue/28771.test.ts` — **passes** (3/3)