### PR TITLE
Emit parse error on socket when chunked request body is incomplete

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -47,6 +47,7 @@ const {
   setServerIdleTimeout,
   setServerCustomOptions,
   getMaxHTTPHeaderSize,
+  noBodySymbol,
 } = require("internal/http");
 const NumberIsNaN = Number.isNaN;
 
@@ -751,7 +752,35 @@ function onServerRequestEvent(this: NodeHTTPServerSocket, event: NodeHTTPRespons
   switch (event) {
     case NodeHTTPResponseAbortEvent.abort: {
       if (!socket.destroyed) {
-        socket.destroy();
+        const req = socket._httpMessage?.req;
+        const bodyIncomplete =
+          req &&
+          !req.complete &&
+          !req[noBodySymbol] &&
+          !req[eofInProgress] &&
+          !((req[kHandle]?.hasBody ?? 0) & NodeHTTPBodyReadState.done);
+        if (bodyIncomplete) {
+          // Connection closed while still reading the request body (e.g.
+          // incomplete chunked encoding).  Emit a parse-error so that
+          // listeners see it — matching Node.js HPE_INVALID_EOF_STATE.
+          const err = $HPE_INVALID_EOF_STATE("Parse Error");
+          if (socket.listenerCount("error") > 0) {
+            socket.destroy(err);
+          } else {
+            // Emit on req directly — req.destroy(err) can't be used because
+            // IncomingMessage._destroy forwards err to socket.destroy(err),
+            // which would throw without a socket error listener.
+            if (req.listenerCount("error") > 0) {
+              req.emit("error", err);
+            }
+            // Mark req as destroyed so #onClose won't call
+            // req.destroy(ConnResetException) and emit a second error.
+            req.destroy();
+            socket.destroy();
+          }
+        } else {
+          socket.destroy();
+        }
       }
       break;
     }
@@ -1675,7 +1704,7 @@ function emitServerSocketEOFNT(self, req) {
   if (req) {
     req[eofInProgress] = true;
   }
-  process.nextTick(emitServerSocketEOF, self);
+  process.nextTick(emitServerSocketEOF, self, req);
 }
 
 let OriginalWriteHeadFn, OriginalImplicitHeadFn;

--- a/test/regression/issue/28775.test.ts
+++ b/test/regression/issue/28775.test.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("HTTP server emits error on malformed chunked request (incomplete chunk)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const http = require('http');
+const net = require('net');
+
+const server = http.createServer(function (req, res) {
+  const bufs = [];
+
+  req.on('data', function (chunk) {
+    bufs.push(chunk);
+  });
+
+  req.on('end', function () {
+    // Should NOT fire — the body is incomplete.
+    res.end('OK');
+    server.close();
+  });
+
+  req.socket.on('error', function (e) {
+    console.log('socket error: ' + e.code);
+    req.destroy();
+    server.close();
+  });
+});
+
+server.listen(0, function () {
+  const port = server.address().port;
+  const sock = net.createConnection(port, '127.0.0.1');
+
+  sock.on('connect', function () {
+    sock.write('POST / HTTP/1.1\\r\\n');
+    sock.write('Host: localhost\\r\\n');
+    sock.write('Transfer-Encoding: chunked\\r\\n');
+    sock.write('\\r\\n');
+    sock.write('3\\r\\nfoo\\r\\n');
+    sock.write('3\\r\\nbar\\r\\n');
+    sock.write('ff\\r\\n');   // Declares 255 bytes but sends none
+    sock.end();
+  });
+});
+
+setTimeout(function () {
+  console.log('timeout!');
+  process.exit(1);
+}, 5000).unref();
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("socket error: HPE_INVALID_EOF_STATE");
+  expect(stdout).not.toContain("timeout!");
+  expect(exitCode).toBe(0);
+});
+
+test("incomplete chunked request routes error to req.on('error') when no socket listener", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const http = require('http');
+const net = require('net');
+
+const server = http.createServer(function (req, res) {
+  req.on('data', function () {});
+
+  req.on('error', function (e) {
+    console.log('req error: ' + e.code);
+    server.close();
+  });
+});
+
+server.listen(0, function () {
+  const port = server.address().port;
+  const sock = net.createConnection(port, '127.0.0.1');
+
+  sock.on('connect', function () {
+    sock.write('POST / HTTP/1.1\\r\\n');
+    sock.write('Host: localhost\\r\\n');
+    sock.write('Transfer-Encoding: chunked\\r\\n');
+    sock.write('\\r\\n');
+    sock.write('3\\r\\nfoo\\r\\n');
+    sock.write('ff\\r\\n');
+    sock.end();
+  });
+});
+
+setTimeout(function () {
+  console.log('timeout!');
+  process.exit(1);
+}, 5000).unref();
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("req error: HPE_INVALID_EOF_STATE");
+  expect(stdout).not.toContain("req error: ECONNRESET");
+  expect(stdout).not.toContain("timeout!");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #28775

## Repro

A client sends a chunked POST request, declares a 255-byte chunk via `ff\r\n`, sends no data, and closes the connection. Bun's HTTP server waits indefinitely:

```
request recv 3 bytes
request recv 3 bytes
timeout!
```

Node.js detects the premature close and emits a parse error:
```
request recv 3 bytes
request recv 3 bytes
request error Error: Parse Error
```

## Cause

When the TCP connection closes mid-chunk, uWS correctly fires the abort handler. `onServerRequestEvent` in `_http_server.ts` then calls `socket.destroy()` **without an error argument**. This means:

- `req.on('end')` never fires (a destroyed Readable doesn't emit `end`)
- `req.socket.on('error')` never fires (no error was passed)
- User code waiting for either event hangs indefinitely

## Fix

In `onServerRequestEvent`, when the abort fires and `req.complete` is `false` (body not fully received), pass `$HPE_INVALID_EOF_STATE('Parse Error')` to `socket.destroy()`. This matches Node.js, which raises `HPE_INVALID_EOF_STATE` when the HTTP parser encounters a premature EOF during chunked encoding.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28775.test.ts` → FAIL (hangs, times out)
- `bun bd test test/regression/issue/28775.test.ts` → PASS (error emitted, exits cleanly)