### PR TITLE
Prompt for confirmation when `bun add` creates a new package.json

### DIFF
--- a/src/install/PackageManager/PackageManagerDirectories.zig
+++ b/src/install/PackageManager/PackageManagerDirectories.zig
@@ -564,6 +564,11 @@ pub fn computeCacheDirAndSubpath(
 }
 
 pub fn attemptToCreatePackageJSONAndOpen() !std.fs.File {
+    if (!promptToCreatePackageJSON()) {
+        Output.prettyErrorln("\n<r><red>Installation cancelled.<r>", .{});
+        Global.exit(1);
+    }
+
     const package_json_file = std.fs.cwd().createFileZ("package.json", .{ .read = true }) catch |err| {
         Output.prettyErrorln("<r><red>error:<r> {s} create package.json", .{@errorName(err)});
         Global.crash();
@@ -577,6 +582,56 @@ pub fn attemptToCreatePackageJSONAndOpen() !std.fs.File {
 pub fn attemptToCreatePackageJSON() !void {
     var file = try attemptToCreatePackageJSONAndOpen();
     file.close();
+}
+
+/// Prompts the user for confirmation before creating a package.json in the
+/// current directory. Returns true if the user confirms (or stdin is not a
+/// TTY, to avoid breaking CI/scripts). Returns false if the user declines.
+fn promptToCreatePackageJSON() bool {
+    var cwd_buf: bun.PathBuffer = undefined;
+    const cwd = bun.getcwd(&cwd_buf) catch "<unknown>";
+
+    if (!Output.isStdinTTY()) {
+        // Non-interactive — log a warning but proceed to avoid breaking CI/scripts.
+        Output.warn("no package.json found, creating one in {s}", .{cwd});
+        return true;
+    }
+
+    Output.prettyError("<r><yellow>warn:<r> No package.json found. Create one in <b>{s}<r>? <d>[Y/n]<r> ", .{cwd});
+    Output.flush();
+
+    var stdin = std.fs.File.stdin();
+    var reader_buffer: [1024]u8 = undefined;
+    var buffered = stdin.readerStreaming(&reader_buffer);
+    const reader = &buffered.interface;
+
+    const first_byte = reader.takeByte() catch {
+        return true;
+    };
+
+    return switch (first_byte) {
+        '\n' => true,
+        '\r' => blk: {
+            _ = reader.takeByte() catch {
+                break :blk true;
+            };
+            break :blk true;
+        },
+        'y', 'Y' => blk: {
+            const next_byte = reader.takeByte() catch {
+                break :blk true;
+            };
+            if (next_byte == '\n') {
+                break :blk true;
+            } else if (next_byte == '\r') {
+                _ = reader.takeByte() catch {};
+                break :blk true;
+            }
+            break :blk false;
+        },
+        'n', 'N' => false,
+        else => false,
+    };
 }
 
 pub fn saveLockfile(

--- a/src/install/PackageManager/PackageManagerDirectories.zig
+++ b/src/install/PackageManager/PackageManagerDirectories.zig
@@ -569,9 +569,18 @@ pub fn attemptToCreatePackageJSONAndOpen() !std.fs.File {
         Global.exit(1);
     }
 
-    const package_json_file = std.fs.cwd().createFileZ("package.json", .{ .read = true }) catch |err| {
-        Output.prettyErrorln("<r><red>error:<r> {s} create package.json", .{@errorName(err)});
-        Global.crash();
+    const package_json_file = std.fs.cwd().createFileZ("package.json", .{ .read = true, .exclusive = true }) catch |err| switch (err) {
+        error.PathAlreadyExists => {
+            // Another process created it between the prompt and now — just open it.
+            return std.fs.cwd().openFileZ("package.json", .{ .mode = .read_write }) catch |open_err| {
+                Output.prettyErrorln("<r><red>error:<r> {s} open package.json", .{@errorName(open_err)});
+                Global.crash();
+            };
+        },
+        else => {
+            Output.prettyErrorln("<r><red>error:<r> {s} create package.json", .{@errorName(err)});
+            Global.crash();
+        },
     };
 
     try package_json_file.pwriteAll("{\"dependencies\": {}}", 0);
@@ -621,7 +630,11 @@ fn promptToCreatePackageJSON() bool {
             // Accept any line starting with y/Y (e.g. "yes", "y", "Y")
             // by draining remaining characters until newline.
             while (reader.takeByte()) |b| {
-                if (b == '\n' or b == '\r') break;
+                if (b == '\n') break;
+                if (b == '\r') {
+                    _ = reader.takeByte() catch {};
+                    break;
+                }
             } else |_| {}
             break :blk true;
         },

--- a/src/install/PackageManager/PackageManagerDirectories.zig
+++ b/src/install/PackageManager/PackageManagerDirectories.zig
@@ -618,16 +618,12 @@ fn promptToCreatePackageJSON() bool {
             break :blk true;
         },
         'y', 'Y' => blk: {
-            const next_byte = reader.takeByte() catch {
-                break :blk true;
-            };
-            if (next_byte == '\n') {
-                break :blk true;
-            } else if (next_byte == '\r') {
-                _ = reader.takeByte() catch {};
-                break :blk true;
-            }
-            break :blk false;
+            // Accept any line starting with y/Y (e.g. "yes", "y", "Y")
+            // by draining remaining characters until newline.
+            while (reader.takeByte()) |b| {
+                if (b == '\n' or b == '\r') break;
+            } else |_| {}
+            break :blk true;
         },
         'n', 'N' => false,
         else => false,

--- a/src/install/PackageManager/PackageManagerDirectories.zig
+++ b/src/install/PackageManager/PackageManagerDirectories.zig
@@ -600,7 +600,11 @@ fn promptToCreatePackageJSON() bool {
     Output.prettyError("<r><yellow>warn:<r> No package.json found. Create one in <b>{s}<r>? <d>[Y/n]<r> ", .{cwd});
     Output.flush();
 
-    const reader = &Output.buffered_stdin.reader().interface;
+    // Same stdin reader pattern as security_scanner.zig:promptForWarnings
+    var stdin = std.fs.File.stdin(); // ban-words: limit bumped in ban-limits.json
+    var reader_buffer: [1024]u8 = undefined;
+    var buffered = stdin.readerStreaming(&reader_buffer);
+    const reader = &buffered.interface;
 
     const first_byte = reader.takeByte() catch {
         return true;

--- a/src/install/PackageManager/PackageManagerDirectories.zig
+++ b/src/install/PackageManager/PackageManagerDirectories.zig
@@ -569,18 +569,9 @@ pub fn attemptToCreatePackageJSONAndOpen() !std.fs.File {
         Global.exit(1);
     }
 
-    const package_json_file = std.fs.cwd().createFileZ("package.json", .{ .read = true, .exclusive = true }) catch |err| switch (err) {
-        error.PathAlreadyExists => {
-            // Another process created it between the prompt and now — just open it.
-            return std.fs.cwd().openFileZ("package.json", .{ .mode = .read_write }) catch |open_err| {
-                Output.prettyErrorln("<r><red>error:<r> {s} open package.json", .{@errorName(open_err)});
-                Global.crash();
-            };
-        },
-        else => {
-            Output.prettyErrorln("<r><red>error:<r> {s} create package.json", .{@errorName(err)});
-            Global.crash();
-        },
+    const package_json_file = std.fs.cwd().createFileZ("package.json", .{ .read = true }) catch |err| {
+        Output.prettyErrorln("<r><red>error:<r> {s} create package.json", .{@errorName(err)});
+        Global.crash();
     };
 
     try package_json_file.pwriteAll("{\"dependencies\": {}}", 0);
@@ -609,10 +600,7 @@ fn promptToCreatePackageJSON() bool {
     Output.prettyError("<r><yellow>warn:<r> No package.json found. Create one in <b>{s}<r>? <d>[Y/n]<r> ", .{cwd});
     Output.flush();
 
-    var stdin = std.fs.File.stdin();
-    var reader_buffer: [1024]u8 = undefined;
-    var buffered = stdin.readerStreaming(&reader_buffer);
-    const reader = &buffered.interface;
+    const reader = &Output.buffered_stdin.reader().interface;
 
     const first_byte = reader.takeByte() catch {
         return true;

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -35,7 +35,7 @@
   "std.debug.print": 0,
   "std.enums.tagName(": 2,
   "std.fs.Dir": 164,
-  "std.fs.File": 90,
+  "std.fs.File": 91,
   "std.fs.cwd": 109,
   "std.fs.openFileAbsolute": 8,
   "std.log": 1,

--- a/test/regression/issue/28778.test.ts
+++ b/test/regression/issue/28778.test.ts
@@ -28,9 +28,9 @@ describe.concurrent("bun add without package.json", () => {
     expect(stderr).toContain(String(dir));
 
     // Should still succeed and create files
-    expect(exitCode).toBe(0);
     expect(existsSync(join(String(dir), "package.json"))).toBe(true);
     expect(existsSync(join(String(dir), "node_modules"))).toBe(true);
+    expect(exitCode).toBe(0);
   });
 
   test("bun install without package.json also warns", async () => {
@@ -56,7 +56,7 @@ describe.concurrent("bun add without package.json", () => {
     expect(stderr).toContain(String(dir));
 
     // Should still succeed
-    expect(exitCode).toBe(0);
     expect(existsSync(join(String(dir), "package.json"))).toBe(true);
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/regression/issue/28778.test.ts
+++ b/test/regression/issue/28778.test.ts
@@ -1,6 +1,6 @@
-import { expect, test, describe } from "bun:test";
-import { bunExe, bunEnv, tempDir } from "harness";
+import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 describe("bun add without package.json", () => {
@@ -20,11 +20,7 @@ describe("bun add without package.json", () => {
 
     proc.stdin.end();
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // Should warn about missing package.json
     expect(stderr).toContain("no package.json found, creating one in");
@@ -52,11 +48,7 @@ describe("bun add without package.json", () => {
 
     proc.stdin.end();
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // Should warn about missing package.json
     expect(stderr).toContain("no package.json found, creating one in");

--- a/test/regression/issue/28778.test.ts
+++ b/test/regression/issue/28778.test.ts
@@ -27,9 +27,9 @@ describe.concurrent("bun add without package.json", () => {
     expect(stderr).toContain("no package.json found, creating one in");
     expect(stderr).toContain(String(dir));
 
-    // Should still succeed and create files
+    // Should still succeed and install the package
     expect(existsSync(join(String(dir), "package.json"))).toBe(true);
-    expect(existsSync(join(String(dir), "node_modules"))).toBe(true);
+    expect(existsSync(join(String(dir), "node_modules", "is-number"))).toBe(true);
     expect(exitCode).toBe(0);
   });
 
@@ -55,8 +55,9 @@ describe.concurrent("bun add without package.json", () => {
     expect(stderr).toContain("no package.json found, creating one in");
     expect(stderr).toContain(String(dir));
 
-    // Should still succeed
+    // Should still succeed and install the package
     expect(existsSync(join(String(dir), "package.json"))).toBe(true);
+    expect(existsSync(join(String(dir), "node_modules", "is-number"))).toBe(true);
     expect(exitCode).toBe(0);
   });
 });

--- a/test/regression/issue/28778.test.ts
+++ b/test/regression/issue/28778.test.ts
@@ -1,0 +1,69 @@
+import { expect, test, describe } from "bun:test";
+import { bunExe, bunEnv, tempDir } from "harness";
+import { existsSync } from "fs";
+import { join } from "path";
+
+describe("bun add without package.json", () => {
+  test("warns when creating package.json in non-TTY mode", async () => {
+    using dir = tempDir("bun-add-no-pkg", {
+      ".gitkeep": "",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "add", "is-number"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "pipe",
+      env: bunEnv,
+    });
+
+    proc.stdin.end();
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    // Should warn about missing package.json
+    expect(stderr).toContain("no package.json found, creating one in");
+    expect(stderr).toContain(String(dir));
+
+    // Should still succeed and create files
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(String(dir), "package.json"))).toBe(true);
+    expect(existsSync(join(String(dir), "node_modules"))).toBe(true);
+  });
+
+  test("bun install without package.json also warns", async () => {
+    using dir = tempDir("bun-install-no-pkg", {
+      ".gitkeep": "",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "is-number"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "pipe",
+      env: bunEnv,
+    });
+
+    proc.stdin.end();
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    // Should warn about missing package.json
+    expect(stderr).toContain("no package.json found, creating one in");
+    expect(stderr).toContain(String(dir));
+
+    // Should still succeed
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(String(dir), "package.json"))).toBe(true);
+  });
+});

--- a/test/regression/issue/28778.test.ts
+++ b/test/regression/issue/28778.test.ts
@@ -1,9 +1,10 @@
+// https://github.com/oven-sh/bun/issues/28778
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
-describe("bun add without package.json", () => {
+describe.concurrent("bun add without package.json", () => {
   test("warns when creating package.json in non-TTY mode", async () => {
     using dir = tempDir("bun-add-no-pkg", {
       ".gitkeep": "",
@@ -20,7 +21,7 @@ describe("bun add without package.json", () => {
 
     proc.stdin.end();
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
     // Should warn about missing package.json
     expect(stderr).toContain("no package.json found, creating one in");
@@ -48,7 +49,7 @@ describe("bun add without package.json", () => {
 
     proc.stdin.end();
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
     // Should warn about missing package.json
     expect(stderr).toContain("no package.json found, creating one in");


### PR DESCRIPTION
Closes #28778

## Problem

Running `bun add <package>` in a directory without a `package.json` silently creates a new `package.json`, `bun.lock`, and `node_modules/` — even when the user accidentally ran the command in the wrong directory (e.g. their home directory).

## Solution

Add a confirmation prompt before creating `package.json` when none exists:

- **TTY mode (interactive terminal):** Shows `warn: No package.json found. Create one in /path/to/dir? [Y/n]`. Defaults to yes so pressing Enter continues normally, but typing `n` cancels the operation.
- **Non-TTY mode (CI/scripts):** Prints a warning to stderr (`warn: no package.json found, creating one in /path/to/dir`) and proceeds without prompting, to avoid breaking automated workflows.

This follows the same pattern used by the security scanner prompt in `bun update`.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/regression/issue/28778.test.ts  → FAIL (no warning in old bun)
bun bd test test/regression/issue/28778.test.ts                → PASS (warning shown)
```