### PR TITLE
fix: throw proper error in ByteBlobLoader when stream store is already consumed

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,7 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return globalThis.ERR(.BODY_ALREADY_USED, "Body already used", .{}).throw();
+    return globalThis.ERR(.BODY_ALREADY_USED, "Body already used", .{}).reject();
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,7 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    return globalThis.throw("Body already consumed", .{});
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,7 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return globalThis.throw("Body already consumed", .{});
+    return globalThis.ERR(.BODY_ALREADY_USED, "Body already used", .{}).throw();
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/test/js/web/streams/readable-stream-blob-consumed.test.ts
+++ b/test/js/web/streams/readable-stream-blob-consumed.test.ts
@@ -5,9 +5,12 @@ test("ReadableStream.blob() after body consumed does not crash", async () => {
   const body = r.body!;
   // Consume the body through the Response API, detaching the blob store
   await r.arrayBuffer();
-  // Calling blob() on the stream whose store is now null should throw, not crash
+  // Calling blob() on the stream whose store is now null should return a
+  // rejected promise (not crash or throw synchronously)
+  const promise = body.blob();
+  expect(promise).toBeInstanceOf(Promise);
   try {
-    await body.blob();
+    await promise;
     expect.unreachable();
   } catch (e: any) {
     expect(e.code).toBe("ERR_BODY_ALREADY_USED");

--- a/test/js/web/streams/readable-stream-blob-consumed.test.ts
+++ b/test/js/web/streams/readable-stream-blob-consumed.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("ReadableStream.blob() after body consumed does not crash", async () => {
   const r = new Response("Hello World");

--- a/test/js/web/streams/readable-stream-blob-consumed.test.ts
+++ b/test/js/web/streams/readable-stream-blob-consumed.test.ts
@@ -6,5 +6,10 @@ test("ReadableStream.blob() after body consumed does not crash", async () => {
   // Consume the body through the Response API, detaching the blob store
   await r.arrayBuffer();
   // Calling blob() on the stream whose store is now null should throw, not crash
-  expect(async () => await body.blob()).toThrow();
+  try {
+    await body.blob();
+    expect.unreachable();
+  } catch (e: any) {
+    expect(e.code).toBe("ERR_BODY_ALREADY_USED");
+  }
 });

--- a/test/js/web/streams/readable-stream-blob-consumed.test.ts
+++ b/test/js/web/streams/readable-stream-blob-consumed.test.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "bun:test";
+
+test("ReadableStream.blob() after body consumed does not crash", async () => {
+  const r = new Response("Hello World");
+  const body = r.body!;
+  // Consume the body through the Response API, detaching the blob store
+  await r.arrayBuffer();
+  // Calling blob() on the stream whose store is now null should throw, not crash
+  expect(async () => await body.blob()).toThrow();
+});


### PR DESCRIPTION
When a Response body is consumed via `Response.arrayBuffer()` and then `ReadableStream.blob()` is called on the body stream, the `ByteBlobLoader`'s store is already detached (null). `toBufferedValue` was returning `.zero` without throwing an exception, which violated the host function calling convention that treats `.zero` as "exception was thrown." This caused an assertion failure: `Expected an exception to be thrown`.

**Root cause:** `ByteBlobLoader.toBufferedValue()` returned `.zero` (a sentinel meaning "error pending") when `toAnyBlob()` returned null, but never actually threw an exception on the JS VM.

**Fix:** Return `globalThis.throw("Body already consumed")` — a proper `bun.JSError` — instead of bare `.zero`.

**Repro:**
```js
const r = new Response("Hello World");
const body = r.body;
r.arrayBuffer(); // consumes the blob store
body.blob();     // store is null → was crash, now throws
```

Crash fingerprint: `62250fa827848dda`