### PR TITLE
fix(node:http2): implement HTTP/1.1 fallback for secure servers

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -34,6 +34,7 @@ const net = require("node:net");
 const fs = require("node:fs");
 const { $data } = require("node:fs/promises");
 const FileHandle = $data.FileHandle;
+const { HTTPParser, allMethods } = process.binding("http_parser");
 const bunTLSConnectOptions = Symbol.for("::buntlsconnectoptions::");
 const bunSocketServerOptions = Symbol.for("::bunnetserveroptions::");
 const kInfoHeaders = Symbol("sent-info-headers");
@@ -4068,76 +4069,93 @@ function connectionListener(socket: Socket) {
         }
       }
 
-      let buffer = Buffer.alloc(0);
-      let parsed = false;
+      // Initialize native HTTP parser
+      const parser = new HTTPParser();
+      // 0 = REQUEST type, 16384 = max header size, 0 = strict parsing flags
+      parser.initialize(0, 16384, 0);
+
       let req: any = null;
 
-      socket.on("data", chunk => {
-        if (parsed) {
-          req.push(chunk);
-          return;
-        }
-        buffer = Buffer.concat([buffer, chunk]);
-        const headerEnd = buffer.indexOf("\r\n\r\n");
-        if (headerEnd !== -1) {
-          parsed = true;
-          const headerStr = buffer.subarray(0, headerEnd).toString("utf-8");
-          const lines = headerStr.split("\r\n");
-          const [method, url, version] = lines[0].split(" ");
+      parser[HTTPParser.kOnHeadersComplete] = (
+        versionMajor,
+        versionMinor,
+        headers,
+        method,
+        url,
+        statusCode,
+        statusMessage,
+        upgrade,
+        shouldKeepAlive,
+      ) => {
+        // Initialize the request stream here so it's fresh for every request
+        req = new Readable({ read() {} });
+        req.httpVersionMajor = versionMajor;
+        req.httpVersionMinor = versionMinor;
+        req.httpVersion = `${versionMajor}.${versionMinor}`;
 
-          const headers = {};
-          const rawHeaders = [];
-          for (let i = 1; i < lines.length; i++) {
-            const colon = lines[i].indexOf(":");
-            if (colon !== -1) {
-              const key = lines[i].slice(0, colon).trim();
-              const val = lines[i].slice(colon + 1).trim();
-              const lowerKey = key.toLowerCase();
-              if (headers[lowerKey]) {
-                headers[lowerKey] += `, ${val}`;
-              } else {
-                headers[lowerKey] = val;
-              }
-              rawHeaders.push(key, val);
+        // Use allMethods from process.binding to get the correct HTTP method
+        req.method = typeof method === "number" ? allMethods[method] : method;
+        req.url = url;
+
+        // 'headers' comes as a flat array from C++: [key1, val1, key2, val2, ...]
+        const headersObj = {};
+        const rawHeaders = [];
+        if (headers) {
+          for (let i = 0; i < headers.length; i += 2) {
+            const key = headers[i];
+            const val = headers[i + 1];
+            rawHeaders.push(key, val);
+
+            const lowerKey = key.toLowerCase();
+            if (headersObj[lowerKey]) {
+              headersObj[lowerKey] += `, ${val}`;
+            } else {
+              headersObj[lowerKey] = val;
             }
           }
+        }
 
-          req = new Readable({ read() {} });
-          req.method = method;
-          req.url = url;
+        req.headers = headersObj;
+        req.rawHeaders = rawHeaders;
+        req.socket = socket;
+        req.connection = socket;
 
-          const httpVer = version ? version.split("/")[1] : "1.1";
-          req.httpVersion = httpVer;
+        const res = new FallbackServerResponse(req);
 
-          const [major, minor] = httpVer.split(".");
-          req.httpVersionMajor = parseInt(major, 10) || 1;
-          req.httpVersionMinor = parseInt(minor, 10) || 1;
-
-          req.headers = headers;
-          req.rawHeaders = rawHeaders;
-          req.socket = socket;
-          req.connection = socket;
-
-          const res = new FallbackServerResponse(req);
-
-          if (headers.expect === "100-continue") {
-            if (this.listenerCount("checkContinue") > 0) {
-              this.emit("checkContinue", req, res);
-            } else {
-              socket.write("HTTP/1.1 100 Continue\r\n\r\n");
-              this.emit("request", req, res);
-            }
+        if (headersObj.expect === "100-continue") {
+          if (this.listenerCount("checkContinue") > 0) {
+            this.emit("checkContinue", req, res);
           } else {
+            socket.write("HTTP/1.1 100 Continue\r\n\r\n");
             this.emit("request", req, res);
           }
+        } else {
+          this.emit("request", req, res);
+        }
 
-          const body = buffer.subarray(headerEnd + 4);
-          if (body.length > 0) req.push(body);
+        return 0; // 0 tells the parser to continue processing
+      };
+
+      parser[HTTPParser.kOnBody] = chunk => {
+        if (req) req.push(chunk);
+        return 0;
+      };
+
+      parser[HTTPParser.kOnMessageComplete] = () => {
+        if (req) req.push(null);
+        return 0;
+      };
+
+      // Feed the raw socket data directly into the C++ parser
+      socket.on("data", chunk => {
+        const ret = parser.execute(chunk);
+        if (ret instanceof Error) {
+          socket.destroy(ret); // Destroy socket on parse error (e.g. invalid headers)
         }
       });
 
       socket.on("end", () => {
-        if (req) req.push(null);
+        if (req && !req.readableEnded) req.push(null);
       });
 
       socket.resume();

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3949,6 +3949,114 @@ function closeAllSessions(server: Http2Server | Http2SecureServer) {
   }
 }
 
+class FallbackServerResponse extends EventEmitter {
+  req: any;
+  socket: Socket;
+  statusCode: number;
+  statusMessage: string;
+  headers: Map<string, [string, any]>;
+  headersSent: boolean;
+  finished: boolean;
+  chunkedEncoding: boolean;
+  constructor(req) {
+    super();
+    this.req = req;
+    this.socket = req.socket;
+    this.statusCode = 200;
+    this.statusMessage = "OK";
+    this.headers = new Map();
+    this.headersSent = false;
+    this.finished = false;
+    this.chunkedEncoding = false;
+  }
+  setHeader(name, value) {
+    this.headers.set(name.toLowerCase(), [name, value]);
+    return this;
+  }
+  getHeader(name) {
+    return this.headers.get(name.toLowerCase())?.[1];
+  }
+  getHeaders() {
+    const out = {};
+    for (const [k, v] of this.headers) out[k] = v[1];
+    return out;
+  }
+  hasHeader(name) {
+    return this.headers.has(name.toLowerCase());
+  }
+  removeHeader(name) {
+    this.headers.delete(name.toLowerCase());
+  }
+  writeHead(statusCode: number, statusMessage?: any, headers?: any) {
+    if (this.headersSent) return this;
+    this.statusCode = statusCode;
+    if (typeof statusMessage === "object") {
+      headers = statusMessage;
+      statusMessage = "OK";
+    }
+    if (statusMessage) this.statusMessage = statusMessage;
+    if (headers) {
+      for (const k in headers) this.setHeader(k, headers[k]);
+    }
+    let head = `HTTP/1.1 ${this.statusCode} ${this.statusMessage}\r\n`;
+    if (!this.headers.has("date")) this.setHeader("Date", new Date().toUTCString());
+
+    let hasConnection = this.headers.has("connection");
+    let hasContentLength = this.headers.has("content-length");
+    let hasTransferEncoding = this.headers.has("transfer-encoding");
+
+    if (!hasConnection) {
+      this.setHeader("Connection", "close");
+    }
+    if (!hasContentLength && !hasTransferEncoding) {
+      this.setHeader("Transfer-Encoding", "chunked");
+      this.chunkedEncoding = true;
+    }
+
+    for (const [_, [name, value]] of this.headers) {
+      if (Array.isArray(value)) {
+        for (const v of value) head += `${name}: ${v}\r\n`;
+      } else {
+        head += `${name}: ${value}\r\n`;
+      }
+    }
+    head += "\r\n";
+    this.socket.write(head);
+    this.headersSent = true;
+    return this;
+  }
+  write(chunk: any, encoding?: any, cb?: any) {
+    if (!this.headersSent) this.writeHead(this.statusCode);
+    if (this.chunkedEncoding) {
+      const len = Buffer.byteLength(chunk, encoding);
+      this.socket.write(`${len.toString(16)}\r\n`);
+      this.socket.write(chunk, encoding);
+      return this.socket.write("\r\n", cb);
+    }
+    return this.socket.write(chunk, encoding, cb);
+  }
+  end(chunk?: any, encoding?: any, cb?: any) {
+    if (typeof chunk === "function") {
+      cb = chunk;
+      chunk = null;
+      encoding = null;
+    } else if (typeof encoding === "function") {
+      cb = encoding;
+      encoding = null;
+    }
+    if (chunk) this.write(chunk, encoding);
+    if (!this.headersSent) this.writeHead(this.statusCode);
+    if (this.chunkedEncoding) {
+      this.socket.write("0\r\n\r\n");
+    }
+    this.finished = true;
+    this.socket.end();
+    if (cb) cb();
+    this.emit("finish");
+    return this;
+  }
+}
+
 function connectionListener(socket: Socket) {
   const options = this[bunSocketServerOptions] || {};
   if (socket.alpnProtocol === false || socket.alpnProtocol === "http/1.1") {
@@ -3957,118 +4065,11 @@ function connectionListener(socket: Socket) {
     // Bun's native ServerResponse is heavily optimized and tightly coupled to the
     // internal `Bun.serve` native handle (`kHandle`). Because this connection is
     // intercepted from a raw TLSSocket, that native HTTP handle does not exist.
-    // To bridge this gap without crashing the native bindings, we implement a
-    // lightweight, pure-JS HTTP/1.1 header parser and a `FallbackServerResponse`
-    // to manually frame the payload and fulfill the standard `node:http` API contract.
+    // To bridge this gap without triggering infinite timeouts in the native state
+    // machine, we use the built-in `http_parser` binding to safely parse the
+    // request, and a custom `FallbackServerResponse` to manually frame the
+    // outbound payload, fulfilling the standard `node:http` API contract.
     if (options.allowHTTP1 === true) {
-      class FallbackServerResponse extends EventEmitter {
-        req: any;
-        socket: Socket;
-        statusCode: number;
-        statusMessage: string;
-        headers: Map<string, [string, any]>;
-        headersSent: boolean;
-        finished: boolean;
-        chunkedEncoding: boolean;
-        constructor(req) {
-          super();
-          this.req = req;
-          this.socket = req.socket;
-          this.statusCode = 200;
-          this.statusMessage = "OK";
-          this.headers = new Map();
-          this.headersSent = false;
-          this.finished = false;
-          this.chunkedEncoding = false;
-        }
-        setHeader(name, value) {
-          this.headers.set(name.toLowerCase(), [name, value]);
-          return this;
-        }
-        getHeader(name) {
-          return this.headers.get(name.toLowerCase())?.[1];
-        }
-        getHeaders() {
-          const out = {};
-          for (const [k, v] of this.headers) out[k] = v[1];
-          return out;
-        }
-        hasHeader(name) {
-          return this.headers.has(name.toLowerCase());
-        }
-        removeHeader(name) {
-          this.headers.delete(name.toLowerCase());
-        }
-        writeHead(statusCode: number, statusMessage?: any, headers?: any) {
-          if (this.headersSent) return this;
-          this.statusCode = statusCode;
-          if (typeof statusMessage === "object") {
-            headers = statusMessage;
-            statusMessage = "OK";
-          }
-          if (statusMessage) this.statusMessage = statusMessage;
-          if (headers) {
-            for (const k in headers) this.setHeader(k, headers[k]);
-          }
-          let head = `HTTP/1.1 ${this.statusCode} ${this.statusMessage}\r\n`;
-          if (!this.headers.has("date")) this.setHeader("Date", new Date().toUTCString());
-
-          let hasConnection = this.headers.has("connection");
-          let hasContentLength = this.headers.has("content-length");
-          let hasTransferEncoding = this.headers.has("transfer-encoding");
-
-          if (!hasConnection) {
-            this.setHeader("Connection", "close");
-          }
-          if (!hasContentLength && !hasTransferEncoding) {
-            this.setHeader("Transfer-Encoding", "chunked");
-            this.chunkedEncoding = true;
-          }
-
-          for (const [_, [name, value]] of this.headers) {
-            if (Array.isArray(value)) {
-              for (const v of value) head += `${name}: ${v}\r\n`;
-            } else {
-              head += `${name}: ${value}\r\n`;
-            }
-          }
-          head += "\r\n";
-          this.socket.write(head);
-          this.headersSent = true;
-          return this;
-        }
-        write(chunk: any, encoding?: any, cb?: any) {
-          if (!this.headersSent) this.writeHead(this.statusCode);
-          if (this.chunkedEncoding) {
-            const len = Buffer.byteLength(chunk, encoding);
-            this.socket.write(`${len.toString(16)}\r\n`);
-            this.socket.write(chunk, encoding);
-            return this.socket.write("\r\n", cb);
-          }
-          return this.socket.write(chunk, encoding, cb);
-        }
-        end(chunk?: any, encoding?: any, cb?: any) {
-          if (typeof chunk === "function") {
-            cb = chunk;
-            chunk = null;
-            encoding = null;
-          } else if (typeof encoding === "function") {
-            cb = encoding;
-            encoding = null;
-          }
-          if (chunk) this.write(chunk, encoding);
-          if (!this.headersSent) this.writeHead(this.statusCode);
-          if (this.chunkedEncoding) {
-            this.socket.write("0\r\n\r\n");
-          }
-          this.finished = true;
-          this.socket.end();
-          if (cb) cb();
-          this.emit("finish");
-          return this;
-        }
-      }
-
       // Initialize native HTTP parser
       const parser = new HTTPParser();
       // 0 = REQUEST type, 16384 = max header size, 0 = strict parsing flags

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3951,10 +3951,199 @@ function closeAllSessions(server: Http2Server | Http2SecureServer) {
 function connectionListener(socket: Socket) {
   const options = this[bunSocketServerOptions] || {};
   if (socket.alpnProtocol === false || socket.alpnProtocol === "http/1.1") {
-    // TODO: Fallback to HTTP/1.1
-    // if (options.allowHTTP1 === true) {
+    // Handle HTTP/1.1 fallback via ALPN when `allowHTTP1` is enabled.
+    // Note: We cannot use the standard `node:_http_server` ServerResponse here.
+    // Bun's native ServerResponse is heavily optimized and tightly coupled to the
+    // internal `Bun.serve` native handle (`kHandle`). Because this connection is
+    // intercepted from a raw TLSSocket, that native HTTP handle does not exist.
+    // To bridge this gap without crashing the native bindings, we implement a
+    // lightweight, pure-JS HTTP/1.1 header parser and a `FallbackServerResponse`
+    // to manually frame the payload and fulfill the standard `node:http` API contract.
+    if (options.allowHTTP1 === true) {
+      class FallbackServerResponse extends EventEmitter {
+        req: any;
+        socket: Socket;
+        statusCode: number;
+        statusMessage: string;
+        headers: Map<string, [string, any]>;
+        headersSent: boolean;
+        finished: boolean;
+        chunkedEncoding: boolean;
+        constructor(req) {
+          super();
+          this.req = req;
+          this.socket = req.socket;
+          this.statusCode = 200;
+          this.statusMessage = "OK";
+          this.headers = new Map();
+          this.headersSent = false;
+          this.finished = false;
+          this.chunkedEncoding = false;
+        }
+        setHeader(name, value) {
+          this.headers.set(name.toLowerCase(), [name, value]);
+          return this;
+        }
+        getHeader(name) {
+          return this.headers.get(name.toLowerCase())?.[1];
+        }
+        getHeaders() {
+          const out = {};
+          for (const [k, v] of this.headers) out[k] = v[1];
+          return out;
+        }
+        hasHeader(name) {
+          return this.headers.has(name.toLowerCase());
+        }
+        removeHeader(name) {
+          this.headers.delete(name.toLowerCase());
+        }
+        writeHead(statusCode: number, statusMessage?: any, headers?: any) {
+          if (this.headersSent) return this;
+          this.statusCode = statusCode;
+          if (typeof statusMessage === "object") {
+            headers = statusMessage;
+            statusMessage = "OK";
+          }
+          if (statusMessage) this.statusMessage = statusMessage;
+          if (headers) {
+            for (const k in headers) this.setHeader(k, headers[k]);
+          }
+          let head = `HTTP/1.1 ${this.statusCode} ${this.statusMessage}\r\n`;
+          if (!this.headers.has("date")) this.setHeader("Date", new Date().toUTCString());
 
-    // }
+          let hasConnection = this.headers.has("connection");
+          let hasContentLength = this.headers.has("content-length");
+          let hasTransferEncoding = this.headers.has("transfer-encoding");
+
+          if (!hasConnection) {
+            this.setHeader("Connection", "close");
+          }
+          if (!hasContentLength && !hasTransferEncoding) {
+            this.setHeader("Transfer-Encoding", "chunked");
+            this.chunkedEncoding = true;
+          }
+
+          for (const [_, [name, value]] of this.headers) {
+            if (Array.isArray(value)) {
+              for (const v of value) head += `${name}: ${v}\r\n`;
+            } else {
+              head += `${name}: ${value}\r\n`;
+            }
+          }
+          head += "\r\n";
+          this.socket.write(head);
+          this.headersSent = true;
+          return this;
+        }
+        write(chunk: any, encoding?: any, cb?: any) {
+          if (!this.headersSent) this.writeHead(this.statusCode);
+          if (this.chunkedEncoding) {
+            const len = Buffer.byteLength(chunk, encoding);
+            this.socket.write(`${len.toString(16)}\r\n`);
+            this.socket.write(chunk, encoding);
+            return this.socket.write("\r\n", cb);
+          }
+          return this.socket.write(chunk, encoding, cb);
+        }
+        end(chunk?: any, encoding?: any, cb?: any) {
+          if (typeof chunk === "function") {
+            cb = chunk;
+            chunk = null;
+            encoding = null;
+          } else if (typeof encoding === "function") {
+            cb = encoding;
+            encoding = null;
+          }
+          if (chunk) this.write(chunk, encoding);
+          if (!this.headersSent) this.writeHead(this.statusCode);
+          if (this.chunkedEncoding) {
+            this.socket.write("0\r\n\r\n");
+          }
+          this.finished = true;
+          this.socket.end();
+          if (cb) cb();
+          this.emit("finish");
+          return this;
+        }
+      }
+
+      let buffer = Buffer.alloc(0);
+      let parsed = false;
+      let req: any = null;
+
+      socket.on("data", chunk => {
+        if (parsed) {
+          req.push(chunk);
+          return;
+        }
+        buffer = Buffer.concat([buffer, chunk]);
+        const headerEnd = buffer.indexOf("\r\n\r\n");
+        if (headerEnd !== -1) {
+          parsed = true;
+          const headerStr = buffer.subarray(0, headerEnd).toString("utf-8");
+          const lines = headerStr.split("\r\n");
+          const [method, url, version] = lines[0].split(" ");
+
+          const headers = {};
+          const rawHeaders = [];
+          for (let i = 1; i < lines.length; i++) {
+            const colon = lines[i].indexOf(":");
+            if (colon !== -1) {
+              const key = lines[i].slice(0, colon).trim();
+              const val = lines[i].slice(colon + 1).trim();
+              const lowerKey = key.toLowerCase();
+              if (headers[lowerKey]) {
+                headers[lowerKey] += `, ${val}`;
+              } else {
+                headers[lowerKey] = val;
+              }
+              rawHeaders.push(key, val);
+            }
+          }
+
+          req = new Readable({ read() {} });
+          req.method = method;
+          req.url = url;
+
+          const httpVer = version ? version.split("/")[1] : "1.1";
+          req.httpVersion = httpVer;
+
+          const [major, minor] = httpVer.split(".");
+          req.httpVersionMajor = parseInt(major, 10) || 1;
+          req.httpVersionMinor = parseInt(minor, 10) || 1;
+
+          req.headers = headers;
+          req.rawHeaders = rawHeaders;
+          req.socket = socket;
+          req.connection = socket;
+
+          const res = new FallbackServerResponse(req);
+
+          if (headers.expect === "100-continue") {
+            if (this.listenerCount("checkContinue") > 0) {
+              this.emit("checkContinue", req, res);
+            } else {
+              socket.write("HTTP/1.1 100 Continue\r\n\r\n");
+              this.emit("request", req, res);
+            }
+          } else {
+            this.emit("request", req, res);
+          }
+
+          const body = buffer.subarray(headerEnd + 4);
+          if (body.length > 0) req.push(body);
+        }
+      });
+
+      socket.on("end", () => {
+        if (req) req.push(null);
+      });
+
+      socket.resume();
+      return;
+    }
+
     // Let event handler deal with the socket
 
     if (!this.emit("unknownProtocol", socket)) {
@@ -4126,10 +4315,9 @@ class Http2SecureServer extends tls.Server {
   timeout = 0;
   [kSessions] = new SafeSet();
   constructor(options, onRequestHandler) {
-    //TODO: add 'http/1.1' on ALPNProtocols list after allowHTTP1 support
     if (typeof options !== "undefined") {
       if (options && typeof options === "object") {
-        options = { ...options, ALPNProtocols: ["h2"] };
+        options = { ...options, ALPNProtocols: options.allowHTTP1 ? ["h2", "http/1.1"] : ["h2"] };
       } else {
         throw $ERR_INVALID_ARG_TYPE("options", "object", options);
       }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4146,17 +4146,44 @@ function connectionListener(socket: Socket) {
         return 0;
       };
 
-      // Feed the raw socket data directly into the C++ parser
-      socket.on("data", chunk => {
+      let isParserClosed = false;
+
+      const cleanupParser = () => {
+        if (isParserClosed) return;
+        isParserClosed = true;
+
+        // Safely free the native C++ memory
+        if (typeof parser.close === "function") {
+          parser.close();
+        } else if (typeof parser.free === "function") {
+          parser.free();
+        }
+
+        // Prevent memory leaks by detaching closures from the socket
+        socket.removeListener("data", onData);
+        socket.removeListener("end", onEnd);
+        socket.removeListener("close", cleanupParser);
+        socket.removeListener("error", cleanupParser);
+      };
+
+      const onData = chunk => {
         const ret = parser.execute(chunk);
         if (ret instanceof Error) {
+          cleanupParser();
           socket.destroy(ret); // Destroy socket on parse error (e.g. invalid headers)
         }
-      });
+      };
 
-      socket.on("end", () => {
+      const onEnd = () => {
         if (req && !req.readableEnded) req.push(null);
-      });
+        cleanupParser();
+      };
+
+      // Attach the named listeners to the socket
+      socket.on("data", onData);
+      socket.on("end", onEnd);
+      socket.on("close", cleanupParser);
+      socket.on("error", cleanupParser);
 
       socket.resume();
       return;

--- a/test/js/node/http2/http1-fallback.test.ts
+++ b/test/js/node/http2/http1-fallback.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import http2 from "node:http2";
+import https from "node:https";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+
+let tempDir: string;
+let KEY: Buffer;
+let CERT: Buffer;
+
+beforeAll(() => {
+  // Dynamically generate a valid RSA key and self-signed certificate
+  // so BoringSSL doesn't reject the server creation.
+  tempDir = mkdtempSync(join(tmpdir(), "bun-http2-test-"));
+  const keyPath = join(tempDir, "key.pem");
+  const certPath = join(tempDir, "cert.pem");
+
+  const result = spawnSync("openssl", [
+    "req",
+    "-x509",
+    "-newkey",
+    "rsa:2048",
+    "-nodes",
+    "-keyout",
+    keyPath,
+    "-out",
+    certPath,
+    "-days",
+    "1",
+    "-subj",
+    "/CN=localhost",
+  ]);
+
+  if (result.status !== 0) {
+    throw new Error(`Failed to generate test certificates: ${result.stderr.toString()}`);
+  }
+
+  KEY = readFileSync(keyPath);
+  CERT = readFileSync(certPath);
+});
+
+afterAll(() => {
+  // Clean up the temporary certificates
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("http2.createSecureServer", () => {
+  test("allowHTTP1: true falls back to HTTP/1.1 correctly", async () => {
+    const server = http2.createSecureServer({
+      allowHTTP1: true,
+      key: KEY,
+      cert: CERT,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      // 1. Verify the server emits the standard 'request' event
+      server.on("request", (req, res) => {
+        try {
+          expect(req.httpVersionMajor).toBe(1);
+          expect(req.httpVersionMinor).toBe(1);
+          expect(req.method).toBe("GET");
+          expect(req.url).toBe("/fallback-test");
+
+          res.writeHead(200, { "X-Custom-Header": "bun-test" });
+          res.end("HTTP/1.1 fallback successful");
+        } catch (e) {
+          reject(e);
+        }
+      });
+
+      // 2. Bind to an ephemeral port explicitly on IPv4
+      server.listen(0, "127.0.0.1", () => {
+        const port = (server.address() as any).port;
+
+        // 3. Make an HTTPS request forcing HTTP/1.1 via ALPN
+        const req = https.request(
+          {
+            hostname: "127.0.0.1",
+            port: port,
+            path: "/fallback-test",
+            method: "GET",
+            rejectUnauthorized: false, // Bypass self-signed cert warning
+            ALPNProtocols: ["http/1.1"], // Explicitly demand HTTP/1.1
+          },
+          res => {
+            try {
+              expect(res.statusCode).toBe(200);
+              expect(res.headers["x-custom-header"]).toBe("bun-test");
+
+              let data = "";
+              res.on("data", chunk => {
+                data += chunk;
+              });
+
+              res.on("end", () => {
+                expect(data).toBe("HTTP/1.1 fallback successful");
+                server.close(() => resolve());
+              });
+            } catch (e) {
+              reject(e);
+            }
+          },
+        );
+
+        req.on("error", err => {
+          server.close();
+          reject(err);
+        });
+
+        req.end();
+      });
+    });
+  });
+});

--- a/test/js/node/http2/http1-fallback.test.ts
+++ b/test/js/node/http2/http1-fallback.test.ts
@@ -2,20 +2,18 @@ import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import http2 from "node:http2";
 import https from "node:https";
 import { spawnSync } from "node:child_process";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join, basename } from "node:path";
+import { readFileSync } from "node:fs";
+import { tempDir } from "harness";
 
-let tempDir: string;
 let KEY: Buffer;
 let CERT: Buffer;
 
 beforeAll(() => {
-  // Dynamically generate a valid RSA key and self-signed certificate
-  // so BoringSSL doesn't reject the server creation.
-  tempDir = mkdtempSync(join(tmpdir(), "bun-http2-test-"));
-  const keyPath = join(tempDir, "key.pem");
-  const certPath = join(tempDir, "cert.pem");
+  const tmp = tempDir(basename(import.meta.path), {});
+
+  const keyPath = join(tmp, "key.pem");
+  const certPath = join(tmp, "cert.pem");
 
   const result = spawnSync("openssl", [
     "req",
@@ -39,13 +37,6 @@ beforeAll(() => {
 
   KEY = readFileSync(keyPath);
   CERT = readFileSync(certPath);
-});
-
-afterAll(() => {
-  // Clean up the temporary certificates
-  if (tempDir) {
-    rmSync(tempDir, { recursive: true, force: true });
-  }
 });
 
 describe("http2.createSecureServer", () => {


### PR DESCRIPTION
### What does this PR do?

Resolves #26721 and #15419

When creating a secure HTTP/2 server with `allowHTTP1: true`, the server previously failed to negotiate HTTP/1.1 connections because it only advertised `h2` via ALPN. This caused clients explicitly requesting HTTP/1.1 to fail with an application protocol negotiation error.

Furthermore, attempting to bridge the raw `TLSSocket` directly into the standard `node:_http_server` `ServerResponse` resulted in and infinite timeouts, as Bun's native response object strictly expects an underlying `Bun.serve` C++/Zig handle.

This commit resolves the issue by:
1. Conditionally advertising `http/1.1` in the ALPN protocols list when `allowHTTP1` is enabled.
2. Intercepting `http/1.1` connections in `connectionListener` and delegating the byte-level protocol parsing to the native C++ `HTTPParser` (via `process.binding('http_parser')`).
3. Implementing a custom `FallbackServerResponse` to manually frame HTTP/1.1 response payloads. This acts as a safe bridge between the native parser callbacks and userland, bypassing the native `kHandle` requirement while emitting standard `request` events.

### How did you verify your code works?

I added a new test under `test/js/node/http2/http1-fallback.test.ts`. Because BoringSSL strictly validates certificates, I couldn't just use hardcoded dummy strings. Instead, the test shells out to openssl via child_process to generate a real self-signed cert in a temp directory. It then binds the secure server explicitly to 127.0.0.1 (to dodge any IPv6-disabled CI flakiness) and hits it with an https.request that demands http/1.1 via ALPN. The test asserts that the standard request event fires and properly exposes req.httpVersion === '1.1'.

I also verified this locally by compiling `bun-debug`, running the original reproduction script from the issue, and hitting it with `curl -vk --http1.1 https://localhost:8443/`. It successfully negotiates the fallback, streams the 200 OK response, and closes cleanly.