### PR TITLE
docs: improve voice

### DIFF
--- a/docs/bundler/bytecode.mdx
+++ b/docs/bundler/bytecode.mdx
@@ -114,7 +114,7 @@ When you update Bun, you must regenerate bytecode:
 bun build --bytecode ./index.ts --outdir=./dist
 ```
 
-If bytecode doesn't match the current Bun version, it's automatically ignored and your code falls back to parsing the JavaScript source. Your app still runs - you just lose the performance optimization.
+If bytecode doesn't match the current Bun version, it's automatically ignored and your code falls back to parsing the JavaScript source. Your app still runs — the performance optimization is skipped.
 
 **Best practice**: Generate bytecode as part of your CI/CD build process. Don't commit `.jsc` files to git. Regenerate them whenever you update Bun.
 
@@ -400,7 +400,7 @@ The cache version in the `.jsc` file header is a hash of the JavaScriptCore fram
 3. If they don't match, the bytecode is **silently rejected**
 4. Bun falls back to parsing the `.js` source code
 
-Your application still runs - you just lose the performance optimization.
+Your application still runs — the performance optimization is skipped.
 
 **Graceful degradation**:
 This design means bytecode caching "fails open" - if anything goes wrong (version mismatch, corrupted file, missing file), your code still runs normally. You might see slower startup, but you won't see errors.

--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -98,7 +98,7 @@ This compiles to:
 
 ### Color mix
 
-The `color-mix()` function gives you an easy way to blend two colors together according to a specified ratio in a chosen color space. This powerful feature lets you create color variations without manually calculating the resulting values.
+The `color-mix()` function blends two colors together according to a specified ratio in a chosen color space. Use it to create color variations without manually calculating the resulting values.
 
 ```scss title="styles.css" icon="file-code"
 .button {
@@ -129,7 +129,7 @@ This feature is particularly useful for creating color systems with programmatic
 
 ### Relative colors
 
-CSS now allows you to modify individual components of a color using relative color syntax. This powerful feature lets you create color variations by adjusting specific attributes like lightness, saturation, or individual channels without having to recalculate the entire color.
+CSS allows you to modify individual components of a color using relative color syntax. Create color variations by adjusting specific attributes like lightness, saturation, or individual channels without having to recalculate the entire color.
 
 ```css title="styles.css" icon="file-code"
 .theme-color {
@@ -216,7 +216,7 @@ This functionality lets you use modern color spaces immediately while ensuring y
 
 ### HWB colors
 
-The HWB (Hue, Whiteness, Blackness) color model provides an intuitive way to express colors based on how much white or black is mixed with a pure hue. Many designers find this approach more natural for creating color variations compared to manipulating RGB or HSL values.
+The HWB (Hue, Whiteness, Blackness) color model expresses colors based on how much white or black is mixed with a pure hue. Many designers find this approach more natural for creating color variations compared to manipulating RGB or HSL values.
 
 ```css title="styles.css" icon="file-code"
 .easy-theming {
@@ -245,11 +245,11 @@ Bun's CSS bundler automatically converts HWB colors to RGB for compatibility wit
 }
 ```
 
-The HWB model makes it particularly easy to create systematic color variations for design systems, providing a more intuitive approach to creating consistent tints and shades than working directly with RGB or HSL values.
+The HWB model is well-suited for creating systematic color variations for design systems, providing a more direct approach to creating consistent tints and shades than working with RGB or HSL values.
 
 ### Color notation
 
-Modern CSS has introduced more intuitive and concise ways to express colors. Space-separated color syntax eliminates the need for commas in RGB and HSL values, while hex colors with alpha channels provide a compact way to specify transparency.
+Modern CSS has introduced more concise ways to express colors. Space-separated color syntax eliminates the need for commas in RGB and HSL values, while hex colors with alpha channels provide a compact way to specify transparency.
 
 ```css title="styles.css" icon="file-code"
 .modern-styling {
@@ -288,7 +288,7 @@ This conversion process lets you write cleaner, more modern CSS while ensuring y
 
 ### light-dark() color function
 
-The `light-dark()` function provides an elegant solution for implementing color schemes that respect the user's system preference without requiring complex media queries. This function accepts two color values and automatically selects the appropriate one based on the current color scheme context.
+The `light-dark()` function implements color schemes that respect the user's system preference without requiring media queries. This function accepts two color values and automatically selects the appropriate one based on the current color scheme context.
 
 ```css title="styles.css" icon="file-code"
 :root {
@@ -399,7 +399,7 @@ If the `:dir()` selector isn't supported, additional fallbacks are automatically
 
 ### :dir() selector
 
-The `:dir()` pseudo-class selector allows you to style elements based on their text direction (RTL or LTR), providing a powerful way to create direction-aware designs without JavaScript. This selector matches elements based on their directionality as determined by the document or explicit direction attributes.
+The `:dir()` pseudo-class selector allows you to style elements based on their text direction (RTL or LTR), letting you create direction-aware designs without JavaScript. This selector matches elements based on their directionality as determined by the document or explicit direction attributes.
 
 ```css title="styles.css" icon="file-code"
 /* Apply different styles based on text direction */
@@ -446,7 +446,7 @@ This conversion lets you write direction-aware CSS that works reliably across br
 
 ### :lang() selector
 
-The `:lang()` pseudo-class selector allows you to target elements based on the language they're in, making it easy to apply language-specific styling. Modern CSS allows the `:lang()` selector to accept multiple language codes, letting you group language-specific rules more efficiently.
+The `:lang()` pseudo-class selector allows you to target elements based on the language they're in, allowing you to apply language-specific styling. Modern CSS allows the `:lang()` selector to accept multiple language codes, letting you group language-specific rules more efficiently.
 
 ```css title="styles.css" icon="file-code"
 /* Typography adjustments for CJK languages */
@@ -638,7 +638,7 @@ This approach lets you write more expressive and maintainable CSS with meaningfu
 
 ### Media query ranges
 
-Modern CSS supports intuitive range syntax for media queries, allowing you to specify breakpoints using comparison operators like `<`, `>`, `<=`, and `>=` instead of the more verbose `min-` and `max-` prefixes. This syntax is more readable and matches how we normally think about values and ranges.
+Modern CSS supports range syntax for media queries, allowing you to specify breakpoints using comparison operators like `<`, `>`, `<=`, and `>=` instead of the more verbose `min-` and `max-` prefixes. This syntax is more readable and matches how you typically think about values and ranges.
 
 ```css title="styles.css" icon="file-code"
 /* Modern syntax with comparison operators */
@@ -686,7 +686,7 @@ Bun's CSS bundler converts these modern range queries to traditional media query
 }
 ```
 
-This lets you write more intuitive and mathematical media queries while ensuring your stylesheets work correctly across all browsers, including those that don't support the modern range syntax.
+This lets you write more readable media queries while ensuring your stylesheets work correctly across all browsers, including those that don't support the modern range syntax.
 
 ### Shorthands
 

--- a/docs/bundler/esbuild.mdx
+++ b/docs/bundler/esbuild.mdx
@@ -13,8 +13,8 @@ There are a few behavioral differences to note.
 </Note>
 
 <Note>
-  **It's just a bundler.** Unlike esbuild, Bun's bundler does not include a built-in development server or file watcher.
-  It's just a bundler. The bundler is intended for use in conjunction with `Bun.serve` and other runtime APIs to achieve
+  **Bundler only.** Unlike esbuild, Bun's bundler does not include a built-in development server or file watcher.
+  The bundler is intended for use in conjunction with `Bun.serve` and other runtime APIs to achieve
   the same effect. As such, all options relating to HTTP/file watching are not applicable.
 </Note>
 

--- a/docs/bundler/esbuild.mdx
+++ b/docs/bundler/esbuild.mdx
@@ -13,9 +13,9 @@ There are a few behavioral differences to note.
 </Note>
 
 <Note>
-  **Bundler only.** Unlike esbuild, Bun's bundler does not include a built-in development server or file watcher.
-  The bundler is intended for use in conjunction with `Bun.serve` and other runtime APIs to achieve
-  the same effect. As such, all options relating to HTTP/file watching are not applicable.
+  **Bundler only.** Unlike esbuild, Bun's bundler does not include a built-in development server or file watcher. The
+  bundler is intended for use in conjunction with `Bun.serve` and other runtime APIs to achieve the same effect. As
+  such, all options relating to HTTP/file watching are not applicable.
 </Note>
 
 ## Performance

--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -478,7 +478,7 @@ To disable `.env` or `bunfig.toml` loading for deterministic execution:
 
 You can run a standalone executable as if it were the `bun` CLI itself by setting the `BUN_BE_BUN=1` environment variable. When this variable is set, the executable will ignore its bundled entrypoint and instead expose all the features of Bun's CLI.
 
-For example, consider an executable compiled from a simple script:
+For example, consider an executable compiled from this script:
 
 ```bash icon="terminal" terminal
 echo "console.log(\"you shouldn't see this\");" > such-bun.js

--- a/docs/bundler/fullstack.mdx
+++ b/docs/bundler/fullstack.mdx
@@ -421,7 +421,7 @@ bun add tailwindcss bun-plugin-tailwind
 plugins = ["bun-plugin-tailwind"]
 ```
 
-This will allow you to use TailwindCSS utility classes in your HTML and CSS files. All you need to do is import `tailwindcss` somewhere:
+This will allow you to use TailwindCSS utility classes in your HTML and CSS files. Import `tailwindcss` somewhere in your project:
 
 ```html title="index.html" icon="file-code"
 <!doctype html>

--- a/docs/bundler/hot-reloading.mdx
+++ b/docs/bundler/hot-reloading.mdx
@@ -71,7 +71,7 @@ The HMR API is still a work in progress. Some features are missing. HMR can be d
 
 ## import.meta.hot.accept()
 
-The `accept()` method indicates that a module can be hot-replaced. When called without arguments, it indicates that this module can be replaced simply by re-evaluating the file. After a hot update, importers of this module will be automatically patched.
+The `accept()` method indicates that a module can be hot-replaced. When called without arguments, it indicates that this module can be replaced by re-evaluating the file. After a hot update, importers of this module will be automatically patched.
 
 ```ts title="index.ts" icon="/icons/typescript.svg"
 // index.ts

--- a/docs/bundler/html-static.mdx
+++ b/docs/bundler/html-static.mdx
@@ -464,7 +464,7 @@ Bun automatically handles all common web assets:
 - **Media** (`<video>`, `<audio>`, `<source>`) are copied and hashed
 - Any `<link>` tag with an `href` attribute pointing to a local file is rewritten to the new path, and hashed
 
-All paths are resolved relative to your HTML file, making it easy to organize your project however you want.
+All paths are resolved relative to your HTML file, so you can organize your project however you want.
 
 <Warning>
 **This is a work in progress**

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1357,7 +1357,7 @@ Generate metadata about the build in a structured format. The metafile contains 
 
 #### Markdown metafile
 
-Use `--metafile-md` to generate a markdown metafile, which is LLM-friendly and easy to read in the terminal:
+Use `--metafile-md` to generate a markdown metafile, which is LLM-friendly and readable in the terminal:
 
 ```bash terminal icon="terminal"
 bun build ./src/index.ts --outdir ./dist --metafile-md ./dist/meta.md

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -55,7 +55,7 @@ Let's jump into the bundler API.
 
 ## Basic example
 
-Let's build our first bundle. You have the following two files, which implement a simple client-side rendered React app.
+Let's build our first bundle. You have the following two files, which implement a client-side rendered React app.
 
 <CodeGroup>
 
@@ -1061,7 +1061,7 @@ In many cases, generated bundles will contain no import statements. After all, t
 - **External modules** — Files and modules can be marked as external, in which case they will not be included in the bundle. Instead, the import statement will be left in the final bundle.
 - **Chunking.** When `splitting` is enabled, the bundler may generate separate "chunk" files that represent code that is shared among multiple entrypoints.
 
-In any of these cases, the final bundles may contain paths to other files. By default these imports are relative. Here is an example of a simple asset import:
+In any of these cases, the final bundles may contain paths to other files. By default these imports are relative. Here is an example of an asset import:
 
 <CodeGroup>
 
@@ -1128,7 +1128,7 @@ A map of global identifiers to be replaced at build time. Keys of this object ar
 
 ### loader
 
-A map of file extensions to built-in loader names. This can be used to quickly customize how certain files are loaded.
+A map of file extensions to built-in loader names. Use this to customize how certain files are loaded.
 
 <Tabs>
   <Tab title="JavaScript">
@@ -1173,7 +1173,7 @@ A banner to be added to the final bundle, this can be a directive like `"use cli
 
 ### footer
 
-A footer to be added to the final bundle, this can be something like a comment block for a license or just a fun easter egg.
+A footer to be added to the final bundle. This can be a comment block for a license or a fun easter egg.
 
 <Tabs>
   <Tab title="JavaScript">
@@ -1604,7 +1604,7 @@ try {
 }
 ```
 
-Most of the time, an explicit try/catch is not needed, as Bun will neatly print uncaught exceptions. It is enough to just use a top-level await on the `Bun.build` call.
+Most of the time, an explicit try/catch is not needed, as Bun will neatly print uncaught exceptions. You can use a top-level await on the `Bun.build` call instead.
 
 Each item in `error.errors` is an instance of `BuildMessage` or `ResolveMessage` (subclasses of `Error`), containing detailed information for each error.
 

--- a/docs/bundler/macros.mdx
+++ b/docs/bundler/macros.mdx
@@ -13,7 +13,7 @@ export function random() {
 }
 ```
 
-This is just a regular function in a regular file, but we can use it as a macro like so:
+This is a regular function in a regular file, but you can use it as a macro like so:
 
 ```tsx title="cli.tsx" icon="/icons/typescript.svg"
 import { random } from "./random.ts" with { type: "macro" };

--- a/docs/bundler/plugins.mdx
+++ b/docs/bundler/plugins.mdx
@@ -63,7 +63,7 @@ type Loader =
 
 ## Usage
 
-A plugin is defined as simple JavaScript object containing a `name` property and a `setup` function.
+A plugin is defined as a JavaScript object containing a `name` property and a `setup` function.
 
 ```ts title="myPlugin.ts" icon="/icons/typescript.svg"
 import type { BunPlugin } from "bun";

--- a/docs/bundler/standalone-html.mdx
+++ b/docs/bundler/standalone-html.mdx
@@ -11,11 +11,11 @@ bun build --compile --target=browser ./index.html --outdir=dist
 
 The output is a completely self-contained HTML document. No relative paths. No external files. No server required. Just one `.html` file that works anywhere a browser can open it.
 
-## One file. Upload anywhere. It just works.
+## One file. Upload anywhere.
 
 The output is a single `.html` file you can put anywhere:
 
-- **Upload it to S3** or any static file host — no directory structure to maintain, just one file
+- **Upload it to S3** or any static file host — no directory structure to maintain, one file
 - **Double-click it from your desktop** — it opens in the browser and works offline, no localhost server needed
 - **Embed it in your webview** — No need to deal with relative files
 - **Insert it in an `<iframe>`** — embed interactive content in another page with a single file URL

--- a/docs/guides/deployment/railway.mdx
+++ b/docs/guides/deployment/railway.mdx
@@ -9,7 +9,7 @@ Railway is an infrastructure platform where you can provision infrastructure, de
 
 This guide walks through deploying a Bun application with a PostgreSQL database (optional), which is exactly what the template below provides.
 
-You can either follow this guide step-by-step or simply deploy the pre-configured template with one click:
+You can either follow this guide step-by-step or deploy the pre-configured template with one click:
 
 <a
   href="https://railway.com/deploy/bun-react-postgres?referralCode=Bun&utm_medium=integration&utm_source=template&utm_campaign=bun"

--- a/docs/guides/deployment/render.mdx
+++ b/docs/guides/deployment/render.mdx
@@ -12,7 +12,7 @@ Render supports Bun natively. You can deploy Bun apps as web services, backgroun
 
 ---
 
-As an example, let's deploy a simple Express HTTP server to Render.
+As an example, let's deploy an Express HTTP server to Render.
 
 <Steps>
 	<Step title="Step 1">
@@ -33,7 +33,7 @@ As an example, let's deploy a simple Express HTTP server to Render.
     </Step>
 
     <Step title="Step 3">
-    	Define a simple server with Express:
+    	Define a server with Express:
 
     	```ts app.ts icon="/icons/typescript.svg"
     	import express from "express";

--- a/docs/guides/ecosystem/discordjs.mdx
+++ b/docs/guides/ecosystem/discordjs.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Discord.js with Bun"
 mode: center
 ---
 
-Discord.js works out of the box with Bun. Let's write a simple bot. First create a directory and initialize it with `bun init`.
+Discord.js works out of the box with Bun. Let's write a bot. First create a directory and initialize it with `bun init`.
 
 ```sh terminal icon="terminal"
 mkdir my-bot

--- a/docs/guides/ecosystem/drizzle.mdx
+++ b/docs/guides/ecosystem/drizzle.mdx
@@ -91,7 +91,7 @@ drizzle
 
 ---
 
-We can execute these migrations with a simple `migrate.ts` script.
+We can execute these migrations with a `migrate.ts` script.
 
 This script creates a new connection to a SQLite database that writes to `sqlite.db`, then executes all unexecuted migrations in the `drizzle` directory.
 

--- a/docs/guides/ecosystem/elysia.mdx
+++ b/docs/guides/ecosystem/elysia.mdx
@@ -14,7 +14,7 @@ bun run dev
 
 ---
 
-To define a simple HTTP route and start a server with Elysia:
+To define an HTTP route and start a server with Elysia:
 
 ```ts server.ts icon="/icons/typescript.svg"
 import { Elysia } from "elysia";

--- a/docs/guides/ecosystem/express.mdx
+++ b/docs/guides/ecosystem/express.mdx
@@ -17,7 +17,7 @@ bun add express
 
 ---
 
-To define a simple HTTP route and start a server with Express:
+To define an HTTP route and start a server with Express:
 
 ```ts server.ts icon="/icons/typescript.svg"
 import express from "express";

--- a/docs/guides/ecosystem/gel.mdx
+++ b/docs/guides/ecosystem/gel.mdx
@@ -71,7 +71,7 @@ To connect to my_gel_app, run `gel`
 
 ---
 
-To see if the database is running, let's open a REPL and run a simple query.
+To see if the database is running, let's open a REPL and run a query.
 
 ```sh terminal icon="terminal"
 gel
@@ -214,7 +214,7 @@ the query builder directory? The following line will be added:
 
 ---
 
-In `index.ts`, we can import the generated query builder from `./dbschema/edgeql-js` and write a simple select query.
+In `index.ts`, we can import the generated query builder from `./dbschema/edgeql-js` and write a select query.
 
 ```ts index.ts icon="/icons/typescript.svg"
 import { createClient } from "gel";

--- a/docs/guides/ecosystem/mongoose.mdx
+++ b/docs/guides/ecosystem/mongoose.mdx
@@ -26,7 +26,7 @@ bun add mongoose
 
 ---
 
-In `schema.ts` we'll declare and export a simple `Animal` model.
+In `schema.ts` we'll declare and export an `Animal` model.
 
 ```ts schema.ts icon="/icons/typescript.svg"
 import * as mongoose from "mongoose";
@@ -89,4 +89,4 @@ Moo!
 
 ---
 
-This is a simple introduction to using Mongoose with TypeScript and Bun. As you build your application, refer to the official [MongoDB](https://www.mongodb.com/docs) and [Mongoose](https://mongoosejs.com/docs/) sites for complete documentation.
+This is an introduction to using Mongoose with TypeScript and Bun. As you build your application, refer to the official [MongoDB](https://www.mongodb.com/docs) and [Mongoose](https://mongoosejs.com/docs/) sites for complete documentation.

--- a/docs/guides/ecosystem/neon-drizzle.mdx
+++ b/docs/guides/ecosystem/neon-drizzle.mdx
@@ -105,7 +105,7 @@ drizzle
 
 ---
 
-We can execute these migrations with a simple `migrate.ts` script. This script creates a new connection to the Neon database and executes all unexecuted migrations in the `drizzle` directory.
+We can execute these migrations with a `migrate.ts` script. This script creates a new connection to the Neon database and executes all unexecuted migrations in the `drizzle` directory.
 
 ```ts migrate.ts
 import { db } from "./db";

--- a/docs/guides/ecosystem/pm2.mdx
+++ b/docs/guides/ecosystem/pm2.mdx
@@ -6,7 +6,7 @@ mode: center
 
 [PM2](https://pm2.keymetrics.io/) is a popular process manager that manages and runs your applications as daemons (background processes).
 
-It offers features like process monitoring, automatic restarts, and easy scaling. Using a process manager is common when deploying a Bun application on a cloud-hosted virtual private server (VPS), as it:
+It offers features like process monitoring, automatic restarts, and scaling. Using a process manager is common when deploying a Bun application on a cloud-hosted virtual private server (VPS), as it:
 
 - Keeps your Node.js application running continuously.
 - Ensure high availability and reliability of your application.

--- a/docs/guides/ecosystem/pm2.mdx
+++ b/docs/guides/ecosystem/pm2.mdx
@@ -8,10 +8,10 @@ mode: center
 
 It offers features like process monitoring, automatic restarts, and scaling. Using a process manager is common when deploying a Bun application on a cloud-hosted virtual private server (VPS), as it:
 
-- Keeps your Node.js application running continuously.
-- Ensure high availability and reliability of your application.
-- Monitor and manage multiple processes with ease.
-- Simplify the deployment process.
+- Keeps your application running continuously.
+- Ensures high availability and reliability of your application.
+- Monitors and manages multiple processes.
+- Simplifies the deployment process.
 
 ---
 

--- a/docs/guides/ecosystem/prisma-postgres.mdx
+++ b/docs/guides/ecosystem/prisma-postgres.mdx
@@ -36,7 +36,7 @@ mode: center
     	bunx --bun prisma init --db
     	```
 
-    	This creates a basic schema. We need to update it to use the new Rust-free client with Bun optimization. Open `prisma/schema.prisma` and modify the generator block, then add a simple `User` model.
+    	This creates a basic schema. We need to update it to use the new Rust-free client with Bun optimization. Open `prisma/schema.prisma` and modify the generator block, then add a `User` model.
 
     	```prisma prisma/schema.prisma icon="/icons/ecosystem/prisma.svg"
     	generator client {
@@ -115,7 +115,7 @@ mode: center
     </Step>
 
     <Step title="Create a test script">
-    	Let's write a simple script to create a new user, then count the number of users in the database.
+    	Let's write a script to create a new user, then count the number of users in the database.
 
     	```ts index.ts icon="/icons/typescript.svg"
     	import { prisma } from "./prisma/db";

--- a/docs/guides/ecosystem/prisma.mdx
+++ b/docs/guides/ecosystem/prisma.mdx
@@ -37,7 +37,7 @@ mode: center
     	bunx --bun prisma init --datasource-provider sqlite
     	```
 
-    	This creates a basic schema. We need to update it to use the new Rust-free client with Bun optimization. Open `prisma/schema.prisma` and modify the generator block, then add a simple `User` model.
+    	This creates a basic schema. We need to update it to use the new Rust-free client with Bun optimization. Open `prisma/schema.prisma` and modify the generator block, then add a `User` model.
 
     	```prisma prisma/schema.prisma icon="/icons/ecosystem/prisma.svg"
     	  generator client {
@@ -110,7 +110,7 @@ mode: center
     </Step>
 
     <Step title="Create a test script">
-    	Let's write a simple script to create a new user, then count the number of users in the database.
+    	Let's write a script to create a new user, then count the number of users in the database.
 
     	```ts index.ts icon="/icons/typescript.svg"
     	import { prisma } from "./prisma/db";

--- a/docs/guides/ecosystem/react.mdx
+++ b/docs/guides/ecosystem/react.mdx
@@ -4,9 +4,9 @@ sidebarTitle: React with Bun
 mode: center
 ---
 
-Bun supports `.jsx` and `.tsx` files out of the box. React just works with Bun.
+Bun supports `.jsx` and `.tsx` files out of the box. React works with Bun.
 
-Create a new React app with `bun init --react`. This gives you a template with a simple React app and a simple API server together in one full-stack app.
+Create a new React app with `bun init --react`. This gives you a template with a React app and an API server together in one full-stack app.
 
 ```bash terminal icon="terminal"
 # Create a new React app

--- a/docs/guides/ecosystem/ssr-react.mdx
+++ b/docs/guides/ecosystem/ssr-react.mdx
@@ -31,7 +31,7 @@ const stream = await renderToReadableStream(<Component message="Hello from serve
 
 ---
 
-Combining this with `Bun.serve()`, we get a simple SSR HTTP server:
+Combining this with `Bun.serve()`, we get an SSR HTTP server:
 
 ```tsx server.tsx icon="/icons/typescript.svg"
 Bun.serve({

--- a/docs/guides/ecosystem/stric.mdx
+++ b/docs/guides/ecosystem/stric.mdx
@@ -23,7 +23,7 @@ bun add @stricjs/router @stricjs/utils
 
 ---
 
-To implement a simple HTTP server with StricJS:
+To implement an HTTP server with StricJS:
 
 ```ts index.ts icon="file-code"
 import { Router } from "@stricjs/router";

--- a/docs/guides/html-rewriter/extract-links.mdx
+++ b/docs/guides/html-rewriter/extract-links.mdx
@@ -6,7 +6,7 @@ mode: center
 
 ## Extract links from a webpage
 
-Bun's [HTMLRewriter](/runtime/html-rewriter) API can be used to efficiently extract links from HTML content. It works by chaining together CSS selectors to match the elements, text, and attributes you want to process. This is a simple example of how to extract links from a webpage. You can pass `.transform` a `Response`, `Blob`, or `string`.
+Bun's [HTMLRewriter](/runtime/html-rewriter) API can be used to efficiently extract links from HTML content. It works by chaining together CSS selectors to match the elements, text, and attributes you want to process. Here is an example of how to extract links from a webpage. You can pass `.transform` a `Response`, `Blob`, or `string`.
 
 ```ts extract-links.ts icon="/icons/typescript.svg"
 async function extractLinks(url: string) {

--- a/docs/guides/http/cluster.mdx
+++ b/docs/guides/http/cluster.mdx
@@ -66,4 +66,4 @@ process.on("exit", kill);
 
 ---
 
-Bun has also implemented the `node:cluster` module, but this is a faster, simple, and limited alternative.
+Bun has also implemented the `node:cluster` module, but this is a faster and more limited alternative.

--- a/docs/guides/http/file-uploads.mdx
+++ b/docs/guides/http/file-uploads.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Upload files via HTTP using FormData
 mode: center
 ---
 
-To upload files via HTTP with Bun, use the [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) API. Let's start with a HTTP server that serves a simple HTML web form.
+To upload files via HTTP with Bun, use the [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) API. Let's start with an HTTP server that serves an HTML web form.
 
 ```ts index.ts icon="/icons/typescript.svg"
 const server = Bun.serve({

--- a/docs/guides/install/from-npm-install-to-bun-install.mdx
+++ b/docs/guides/install/from-npm-install-to-bun-install.mdx
@@ -6,7 +6,7 @@ mode: center
 
 `bun install` is a Node.js compatible npm client designed to be an incredibly fast successor to npm.
 
-We've put a lot of work into making sure that the migration path from `npm install` to `bun install` is as easy as running `bun install` instead of `npm install`.
+To migrate from `npm install` to `bun install`, run `bun install` instead of `npm install`.
 
 - **Designed for Node.js & Bun**: `bun install` installs a Node.js compatible `node_modules` folder. You can use it in place of `npm install` for Node.js projects without any code changes and without using Bun's runtime.
 - **Automatically converts `package-lock.json`** to bun's `bun.lock` lockfile format, preserving your existing resolved dependency versions without any manual work on your part. You can secretly use `bun install` in place of `npm install` at work without anyone noticing.
@@ -31,7 +31,7 @@ bun rm @types/bun
 
 ## Run package.json scripts faster
 
-Run scripts from package.json, executables from `node_modules/.bin` (sort of like `npx`), and JavaScript/TypeScript files (just like `node`) - all from a single simple command.
+Run scripts from package.json, executables from `node_modules/.bin` (sort of like `npx`), and JavaScript/TypeScript files (like `node`) — all from a single command.
 
 | NPM                | Bun              |
 | ------------------ | ---------------- |

--- a/docs/guides/install/workspaces.mdx
+++ b/docs/guides/install/workspaces.mdx
@@ -58,7 +58,7 @@ bun install
 
 ---
 
-To add npm dependencies to a particular workspace, just `cd` to the appropriate directory and run `bun add` commands as you would normally. Bun will detect that you are in a workspace and hoist the dependency as needed.
+To add npm dependencies to a particular workspace, `cd` to the appropriate directory and run `bun add` commands as you would normally. Bun will detect that you are in a workspace and hoist the dependency as needed.
 
 ```sh terminal icon="terminal"
 cd packages/stuff-a

--- a/docs/guides/runtime/read-env.mdx
+++ b/docs/guides/runtime/read-env.mdx
@@ -12,7 +12,7 @@ process.env.API_TOKEN; // => "secret"
 
 ---
 
-Bun also exposes these variables via `Bun.env`, which is a simple alias of `process.env`.
+Bun also exposes these variables via `Bun.env`, which is an alias of `process.env`.
 
 ```ts index.ts icon="/icons/typescript.svg"
 Bun.env.API_TOKEN; // => "secret"

--- a/docs/guides/runtime/shell.mdx
+++ b/docs/guides/runtime/shell.mdx
@@ -6,7 +6,7 @@ mode: center
 
 Bun Shell is a cross-platform bash-like shell built in to Bun.
 
-It provides a simple way to run shell commands in JavaScript and TypeScript. To get started, import the `$` function from the `bun` package and use it to run shell commands.
+Use it to run shell commands in JavaScript and TypeScript. To get started, import the `$` function from the `bun` package and use it to run shell commands.
 
 ```ts foo.ts icon="/icons/typescript.svg"
 import { $ } from "bun";

--- a/docs/guides/runtime/web-debugger.mdx
+++ b/docs/guides/runtime/web-debugger.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Web debugger
 mode: center
 ---
 
-Bun speaks the [WebKit Inspector Protocol](https://github.com/oven-sh/bun/blob/main/packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts). To enable debugging when running code with Bun, use the `--inspect` flag. For demonstration purposes, consider the following simple web server.
+Bun speaks the [WebKit Inspector Protocol](https://github.com/oven-sh/bun/blob/main/packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts). To enable debugging when running code with Bun, use the `--inspect` flag. For demonstration purposes, consider the following web server.
 
 ```ts server.ts icon="/icons/typescript.svg"
 Bun.serve({

--- a/docs/guides/streams/to-array.mdx
+++ b/docs/guides/streams/to-array.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Stream to array
 mode: center
 ---
 
-Bun provides a number of convenience functions for reading the contents of a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) into different formats. The `Bun.readableStreamToArray` function reads the contents of a `ReadableStream` to an array of chunks.
+Bun provides several convenience functions for reading the contents of a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) into different formats. The `Bun.readableStreamToArray` function reads the contents of a `ReadableStream` to an array of chunks.
 
 ```ts
 const stream = new ReadableStream();

--- a/docs/guides/streams/to-arraybuffer.mdx
+++ b/docs/guides/streams/to-arraybuffer.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Stream to ArrayBuffer
 mode: center
 ---
 
-Bun provides a number of convenience functions for reading the contents of a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) into different formats.
+Bun provides several convenience functions for reading the contents of a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) into different formats.
 
 ```ts
 const stream = new ReadableStream();

--- a/docs/guides/streams/to-blob.mdx
+++ b/docs/guides/streams/to-blob.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Stream to Blob
 mode: center
 ---
 
-Bun provides a number of convenience functions for reading the contents of a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) into different formats.
+Bun provides several convenience functions for reading the contents of a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) into different formats.
 
 ```ts
 const stream = new ReadableStream();

--- a/docs/guides/streams/to-buffer.mdx
+++ b/docs/guides/streams/to-buffer.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Stream to Buffer
 mode: center
 ---
 
-Bun provides a number of convenience functions for reading the contents of a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) into different formats. This snippet reads the contents of a `ReadableStream` to an [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), then creates a [`Buffer`](https://nodejs.org/api/buffer.html) that points to it.
+Bun provides several convenience functions for reading the contents of a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) into different formats. This snippet reads the contents of a `ReadableStream` to an [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), then creates a [`Buffer`](https://nodejs.org/api/buffer.html) that points to it.
 
 ```ts
 const stream = new ReadableStream();

--- a/docs/guides/streams/to-json.mdx
+++ b/docs/guides/streams/to-json.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Stream to JSON
 mode: center
 ---
 
-Bun provides a number of convenience functions for reading the contents of a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) into different formats.
+Bun provides several convenience functions for reading the contents of a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) into different formats.
 
 ```ts
 const stream = new ReadableStream();

--- a/docs/guides/streams/to-string.mdx
+++ b/docs/guides/streams/to-string.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Stream to string
 mode: center
 ---
 
-Bun provides a number of convenience functions for reading the contents of a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) into different formats.
+Bun provides several convenience functions for reading the contents of a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) into different formats.
 
 ```ts
 const stream = new ReadableStream();

--- a/docs/guides/streams/to-typedarray.mdx
+++ b/docs/guides/streams/to-typedarray.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Stream to Uint8Array
 mode: center
 ---
 
-Bun provides a number of convenience functions for reading the contents of a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) into different formats. This snippet reads the contents of a `ReadableStream` to an [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), then creates a [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) that points to the buffer.
+Bun provides several convenience functions for reading the contents of a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) into different formats. This snippet reads the contents of a `ReadableStream` to an [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), then creates a [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) that points to the buffer.
 
 ```ts
 const stream = new ReadableStream();

--- a/docs/guides/test/coverage.mdx
+++ b/docs/guides/test/coverage.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Coverage reports
 mode: center
 ---
 
-Bun's test runner supports built-in _code coverage reporting_. This makes it easy to see how much of the codebase is covered by tests and find areas that are not currently well-tested.
+Bun's test runner supports built-in _code coverage reporting_. Use it to see how much of your codebase is covered by tests and find areas that are not currently well-tested.
 
 ---
 

--- a/docs/guides/test/testing-library.mdx
+++ b/docs/guides/test/testing-library.mdx
@@ -60,7 +60,7 @@ preload = ["./happydom.ts", "./testing-library.ts"]
 
 ---
 
-If you are using TypeScript you will also need to make use of declaration merging in order to get the new matcher types to show up in your editor. To do this, create a type declaration file that extends `Matchers` like this.
+If you are using TypeScript, you will also need to use declaration merging to get the new matcher types to show up in your editor. To do this, create a type declaration file that extends `Matchers` like this.
 
 ```ts matchers.d.ts icon="/icons/typescript.svg"
 import { TestingLibraryMatchers } from "@testing-library/jest-dom/matchers";

--- a/docs/guides/websocket/pubsub.mdx
+++ b/docs/guides/websocket/pubsub.mdx
@@ -6,7 +6,7 @@ mode: center
 
 Bun's server-side `WebSocket` API provides a native pub-sub API. Sockets can be subscribed to a set of named channels using `socket.subscribe(<name>)`; messages can be published to a channel using `socket.publish(<name>, <message>)`.
 
-This code snippet implements a simple single-channel chat server.
+This code snippet implements a single-channel chat server.
 
 ```ts server.ts icon="/icons/typescript.svg"
 const server = Bun.serve({

--- a/docs/pm/catalogs.mdx
+++ b/docs/pm/catalogs.mdx
@@ -3,15 +3,15 @@ title: "Catalogs"
 description: "Share common dependency versions across multiple packages in a monorepo"
 ---
 
-Catalogs in Bun provide a straightforward way to share common dependency versions across multiple packages in a monorepo. Rather than specifying the same versions repeatedly in each workspace package, you define them once in the root package.json and reference them consistently throughout your project.
+Catalogs in Bun let you share common dependency versions across multiple packages in a monorepo. Rather than specifying the same versions repeatedly in each workspace package, you define them once in the root package.json and reference them consistently throughout your project.
 
 ## Overview
 
 Unlike traditional dependency management where each workspace package needs to independently specify versions, catalogs let you:
 
 1. Define version catalogs in the root package.json
-2. Reference these versions with a simple `catalog:` protocol
-3. Update all packages simultaneously by changing the version in just one place
+2. Reference these versions with the `catalog:` protocol
+3. Update all packages simultaneously by changing the version in one place
 
 This is especially useful in large monorepos where dozens of packages need to use the same version of key dependencies.
 
@@ -105,7 +105,7 @@ Bun supports two ways to define catalogs:
    }
    ```
 
-   Reference with simply `catalog:`:
+   Reference with `catalog:`:
 
    ```json packages/app/package.json icon="file-json"
    "dependencies": {
@@ -222,7 +222,7 @@ Here's a more comprehensive example for a React application:
 
 ## Updating Versions
 
-To update versions across all packages, simply change the version in the root package.json:
+To update versions across all packages, change the version in the root package.json:
 
 ```json package.json icon="file-json"
 "catalog": {
@@ -235,7 +235,7 @@ Then run `bun install` to update all packages.
 
 ## Lockfile Integration
 
-Bun's lockfile tracks catalog versions, making it easy to ensure consistent installations across different environments. The lockfile includes:
+Bun's lockfile tracks catalog versions, ensuring consistent installations across different environments. The lockfile includes:
 
 - The catalog definitions from your package.json
 - The resolution of each cataloged dependency
@@ -282,7 +282,7 @@ Bun's lockfile tracks catalog versions, making it easy to ensure consistent inst
 - Invalid dependency versions in catalogs will fail to resolve during `bun install`
 - Catalogs are only available within workspaces; they cannot be used outside the monorepo
 
-Bun's catalog system provides a powerful yet simple way to maintain consistency across your monorepo without introducing additional complexity to your workflow.
+Bun's catalog system maintains consistency across your monorepo without introducing additional complexity to your workflow.
 
 ## Publishing
 

--- a/docs/pm/cli/patch.mdx
+++ b/docs/pm/cli/patch.mdx
@@ -7,7 +7,7 @@ import Patch from "/snippets/cli/patch.mdx";
 
 `bun patch` lets you persistently patch node_modules in a maintainable, git-friendly way.
 
-Sometimes, you need to make a small change to a package in `node_modules/` to fix a bug or add a feature. `bun patch` makes it easy to do this without vendoring the entire package and reuse the patch across multiple installs, multiple projects, and multiple machines.
+Sometimes, you need to make a small change to a package in `node_modules/` to fix a bug or add a feature. `bun patch` lets you do this without vendoring the entire package and reuse the patch across multiple installs, multiple projects, and multiple machines.
 
 Features:
 

--- a/docs/pm/isolated-installs.mdx
+++ b/docs/pm/isolated-installs.mdx
@@ -185,7 +185,7 @@ bun install --linker isolated
 
 ### From pnpm
 
-Isolated installs are conceptually similar to pnpm, so migration should be straightforward:
+Isolated installs are conceptually similar to pnpm, so migration is direct:
 
 ```bash terminal icon="terminal"
 # Remove pnpm files

--- a/docs/pm/workspaces.mdx
+++ b/docs/pm/workspaces.mdx
@@ -3,7 +3,7 @@ title: "Workspaces"
 description: "Develop complex monorepos with multiple independent packages"
 ---
 
-Bun supports [`workspaces`](https://docs.npmjs.com/cli/v9/using-npm/workspaces?v=true#description) in `package.json`. Workspaces make it easy to develop complex software as a _monorepo_ consisting of several independent packages.
+Bun supports [`workspaces`](https://docs.npmjs.com/cli/v9/using-npm/workspaces?v=true#description) in `package.json`. Workspaces let you develop complex software as a _monorepo_ consisting of several independent packages.
 
 It's common for a monorepo to have the following structure:
 
@@ -92,9 +92,9 @@ Setting a specific version takes precedence over the package's `package.json` ve
 
 Workspaces have a couple major benefits.
 
-- **Code can be split into logical parts.** If one package relies on another, you can simply add it as a dependency in `package.json`. If package `b` depends on `a`, `bun install` will install your local `packages/a` directory into `node_modules` instead of downloading it from the npm registry.
+- **Code can be split into logical parts.** If one package relies on another, add it as a dependency in `package.json`. If package `b` depends on `a`, `bun install` will install your local `packages/a` directory into `node_modules` instead of downloading it from the npm registry.
 - **Dependencies can be de-duplicated.** If `a` and `b` share a common dependency, it will be _hoisted_ to the root `node_modules` directory. This reduces redundant disk usage and minimizes "dependency hell" issues associated with having multiple versions of a package installed simultaneously.
-- **Run scripts in multiple packages.** You can use the [`--filter` flag](/pm/filter) to easily run `package.json` scripts in multiple packages in your workspace, , or `--workspaces` to run scripts across all workspaces.
+- **Run scripts in multiple packages.** You can use the [`--filter` flag](/pm/filter) to run `package.json` scripts in multiple packages in your workspace, or `--workspaces` to run scripts across all workspaces.
 
 ## Share versions with Catalogs
 

--- a/docs/project/building-windows.mdx
+++ b/docs/project/building-windows.mdx
@@ -45,7 +45,7 @@ After Visual Studio, you need the following:
 
 <Note>The Zig compiler is automatically downloaded, installed, and updated by the building process.</Note>
 
-[Scoop](https://scoop.sh) can be used to install these remaining tools easily.
+Use [Scoop](https://scoop.sh) to install these remaining tools.
 
 ```ps1 Scoop (x64)
 irm https://get.scoop.sh | iex

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -78,7 +78,7 @@ Build a minimal HTTP server with `Bun.serve`, run it locally, then evolve it by 
     Listening on http://localhost:3000
     ```
 
-    Visit [`http://localhost:3000`](http://localhost:3000) to test the server. You should see a simple page that says `"Bun!"`.
+    Visit [`http://localhost:3000`](http://localhost:3000) to test the server. You should see a page that says `"Bun!"`.
 
     <Accordion title="Seeing TypeScript errors on Bun?">
 
@@ -147,7 +147,7 @@ Build a minimal HTTP server with `Bun.serve`, run it locally, then evolve it by 
     Listening on http://localhost:3000
     ```
 
-    Visit [`http://localhost:3000/figlet`](http://localhost:3000/figlet) to test the server. You should see a simple page that says `"Bun!"` in ASCII art.
+    Visit [`http://localhost:3000/figlet`](http://localhost:3000/figlet) to test the server. You should see a page that says `"Bun!"` in ASCII art.
 
     ```txt
     ____              _
@@ -211,7 +211,7 @@ Build a minimal HTTP server with `Bun.serve`, run it locally, then evolve it by 
 
 </Steps>
 
-🎉 Congratulations! You've built a simple HTTP server with Bun and installed a package.
+🎉 Congratulations! You've built an HTTP server with Bun and installed a package.
 
 ---
 

--- a/docs/runtime/auto-install.mdx
+++ b/docs/runtime/auto-install.mdx
@@ -61,7 +61,7 @@ This auto-installation approach is useful for a few reasons:
 
 - **Space efficiency** — Each version of a dependency only exists in one place on disk. This is a huge space and time savings compared to redundant per-project installations.
 - **Portability** — To share simple scripts and gists, your source file is _self-contained_. No need to `zip` together a directory containing your code and config files. With version specifiers in `import` statements, even a `package.json` isn't necessary.
-- **Convenience** — There's no need to run `npm install` or `bun install` before running a file or script. Just `bun run` it.
+- **Convenience** — There's no need to run `npm install` or `bun install` before running a file or script. Run it with `bun run`.
 - **Backwards compatibility** — Because Bun still respects the versions specified in `package.json` if one exists, you can switch to Bun-style resolution with a single command: `rm -rf node_modules`.
 
 ---

--- a/docs/runtime/binary-data.mdx
+++ b/docs/runtime/binary-data.mdx
@@ -5,7 +5,7 @@ description: Working with binary data in JavaScript
 
 This page is intended as an introduction to working with binary data in JavaScript. Bun implements a number of data types and utilities for working with binary data, most of which are Web-standard. Any Bun-specific APIs will be noted as such.
 
-Below is a quick "cheat sheet" that doubles as a table of contents. Click an item in the left column to jump to that section.
+Below is a cheat sheet that doubles as a table of contents. Click an item in the left column to jump to that section.
 
 | Class                       | Description                                                                                                                                                                                             |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -20,7 +20,7 @@ Below is a quick "cheat sheet" that doubles as a table of contents. Click an ite
 
 ## `ArrayBuffer` and views
 
-Until 2009, there was no language-native way to store and manipulate binary data in JavaScript. ECMAScript v5 introduced a range of new mechanisms for this. The most fundamental building block is `ArrayBuffer`, a simple data structure that represents a sequence of bytes in memory.
+Until 2009, there was no language-native way to store and manipulate binary data in JavaScript. ECMAScript v5 introduced a range of new mechanisms for this. The most fundamental building block is `ArrayBuffer`, a data structure that represents a sequence of bytes in memory.
 
 ```ts
 // this buffer can store 8 bytes

--- a/docs/runtime/binary-data.mdx
+++ b/docs/runtime/binary-data.mdx
@@ -3,7 +3,7 @@ title: Binary Data
 description: Working with binary data in JavaScript
 ---
 
-This page is intended as an introduction to working with binary data in JavaScript. Bun implements a number of data types and utilities for working with binary data, most of which are Web-standard. Any Bun-specific APIs will be noted as such.
+This page is intended as an introduction to working with binary data in JavaScript. Bun implements several data types and utilities for working with binary data, most of which are Web-standard. Any Bun-specific APIs will be noted as such.
 
 Below is a cheat sheet that doubles as a table of contents. Click an item in the left column to jump to that section.
 
@@ -355,7 +355,7 @@ Bun implements the Web APIs [`ReadableStream`](https://developer.mozilla.org/en-
   to the Node.js docs.
 </Note>
 
-To create a simple readable stream:
+To create a readable stream:
 
 ```ts
 const stream = new ReadableStream({

--- a/docs/runtime/bun-apis.mdx
+++ b/docs/runtime/bun-apis.mdx
@@ -4,7 +4,7 @@ description: "Overview of Bun's native APIs available on the Bun global object a
 mode: center
 ---
 
-Bun implements a set of native APIs on the `Bun` global object and through a number of built-in modules. These APIs are heavily optimized and represent the canonical "Bun-native" way to implement some common functionality.
+Bun implements a set of native APIs on the `Bun` global object and through several built-in modules. These APIs are heavily optimized and represent the canonical "Bun-native" way to implement some common functionality.
 
 Bun strives to implement standard Web APIs wherever possible. Bun introduces new APIs primarily for server-side tasks where no standard exists, such as file I/O and starting an HTTP server. In these cases, Bun's approach still builds atop standard APIs like `Blob`, `URL`, and `Request`.
 

--- a/docs/runtime/c-compiler.mdx
+++ b/docs/runtime/c-compiler.mdx
@@ -134,7 +134,7 @@ napi_value hello(napi_env env) {
 
 #### `library: string[]`
 
-The `library` array is used to specify the libraries that should be linked with the C code.
+Use the `library` array to specify the libraries to link with the C code.
 
 ```ts
 type Library = string[];
@@ -147,7 +147,7 @@ cc({
 
 #### `symbols`
 
-The `symbols` object is used to specify the functions and variables that should be exposed to JavaScript.
+Use the `symbols` object to specify the functions and variables to expose to JavaScript.
 
 ```ts
 type Symbols = {

--- a/docs/runtime/color.mdx
+++ b/docs/runtime/color.mdx
@@ -27,7 +27,7 @@ There are many different ways to use this API:
 
 - Validate and normalize colors to persist in a database (`number` is the most database-friendly)
 - Convert colors to different formats
-- Colorful logging beyond the 16 colors many use today (use `ansi` if you don't want to figure out what the user's terminal supports, otherwise use `ansi-16`, `ansi-256`, or `ansi-16m` for how many colors the terminal supports)
+- Colorful logging beyond the 16 colors many use today (use `ansi` to auto-detect terminal color support, or use `ansi-16`, `ansi-256`, or `ansi-16m` to target a specific color depth)
 - Format colors for use in CSS injected into HTML
 - Get the `r`, `g`, `b`, and `a` color components as JavaScript objects or numbers from a CSS color string
 

--- a/docs/runtime/cookies.mdx
+++ b/docs/runtime/cookies.mdx
@@ -3,7 +3,7 @@ title: Cookies
 description: Use Bun's native APIs for working with HTTP cookies
 ---
 
-Bun provides native APIs for working with HTTP cookies through `Bun.Cookie` and `Bun.CookieMap`. These APIs offer fast, easy-to-use methods for parsing, generating, and manipulating cookies in HTTP requests and responses.
+Bun provides native APIs for working with HTTP cookies through `Bun.Cookie` and `Bun.CookieMap`. These APIs offer fast methods for parsing, generating, and manipulating cookies in HTTP requests and responses.
 
 ## CookieMap class
 

--- a/docs/runtime/debugger.mdx
+++ b/docs/runtime/debugger.mdx
@@ -3,7 +3,7 @@ title: "Debugging"
 description: "Debug your Bun code with an interactive debugger using WebKit Inspector Protocol"
 ---
 
-Bun speaks the [WebKit Inspector Protocol](https://github.com/oven-sh/bun/blob/main/packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts), so you can debug your code with an interactive debugger. For demonstration purposes, consider the following simple web server.
+Bun speaks the [WebKit Inspector Protocol](https://github.com/oven-sh/bun/blob/main/packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts), so you can debug your code with an interactive debugger. For demonstration purposes, consider the following web server.
 
 ## Debugging JavaScript and TypeScript
 
@@ -170,7 +170,7 @@ await fetch("https://example.com", {
 
 The lines with `[fetch] >` are the request from your local code, and the lines with `[fetch] <` are the response from the remote server.
 
-The `BUN_CONFIG_VERBOSE_FETCH` environment variable is supported in both `fetch()` and `node:http` requests, so it should just work.
+The `BUN_CONFIG_VERBOSE_FETCH` environment variable is supported in both `fetch()` and `node:http` requests, so it works in both cases.
 
 To print without the `curl` command, set `BUN_CONFIG_VERBOSE_FETCH` to `true`.
 

--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -137,7 +137,7 @@ process.env.BAR; // => "hello$FOO"
 
 ### `dotenv`
 
-Generally speaking, you won't need `dotenv` or `dotenv-expand` anymore, because Bun reads `.env` files automatically.
+Bun reads `.env` files automatically, so `dotenv` and `dotenv-expand` are unnecessary.
 
 ## Reading environment variables
 
@@ -147,7 +147,7 @@ The current environment variables can be accessed via `process.env`.
 process.env.API_TOKEN; // => "secret"
 ```
 
-Bun also exposes these variables via `Bun.env` and `import.meta.env`, which is a simple alias of `process.env`.
+Bun also exposes these variables via `Bun.env` and `import.meta.env`, which are aliases of `process.env`.
 
 ```ts
 Bun.env.API_TOKEN; // => "secret"

--- a/docs/runtime/file-io.mdx
+++ b/docs/runtime/file-io.mdx
@@ -205,7 +205,7 @@ writer.ref();
 
 ## Directories
 
-Bun's implementation of `node:fs` is fast, and we haven't implemented a Bun-specific API for reading directories just yet. For now, you should use `node:fs` for working with directories in Bun.
+Bun's implementation of `node:fs` is fast. Use `node:fs` for working with directories in Bun.
 
 ### Reading directories (readdir)
 

--- a/docs/runtime/http/cookies.mdx
+++ b/docs/runtime/http/cookies.mdx
@@ -3,7 +3,7 @@ title: Cookies
 description: Work with cookies in HTTP requests and responses using Bun's built-in Cookie API.
 ---
 
-Bun provides a built-in API for working with cookies in HTTP requests and responses. The `BunRequest` object includes a `cookies` property that provides a `CookieMap` for easily accessing and manipulating cookies. When using `routes`, `Bun.serve()` automatically tracks `request.cookies.set` and applies them to the response.
+Bun provides a built-in API for working with cookies in HTTP requests and responses. The `BunRequest` object includes a `cookies` property that provides a `CookieMap` for accessing and manipulating cookies. When using `routes`, `Bun.serve()` automatically tracks `request.cookies.set` and applies them to the response.
 
 ## Reading cookies
 

--- a/docs/runtime/http/server.mdx
+++ b/docs/runtime/http/server.mdx
@@ -399,7 +399,7 @@ const server = Bun.serve({
 
 ## Benchmarks
 
-Below are Bun and Node.js implementations of a simple HTTP server that responds `Bun!` to each incoming `Request`.
+Below are Bun and Node.js implementations of an HTTP server that responds `Bun!` to each incoming `Request`.
 
 ```ts Bun
 Bun.serve({

--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -24,7 +24,7 @@ Internally Bun's WebSocket implementation is built on [uWebSockets](https://gith
 
 ## Start a WebSocket server
 
-Below is a simple WebSocket server built with `Bun.serve`, in which all incoming requests are [upgraded](https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism) to WebSocket connections in the `fetch` handler. The socket handlers are declared in the `websocket` parameter.
+Below is a WebSocket server built with `Bun.serve`, in which all incoming requests are [upgraded](https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism) to WebSocket connections in the `fetch` handler. The socket handlers are declared in the `websocket` parameter.
 
 ```ts server.ts icon="/icons/typescript.svg"
 Bun.serve({

--- a/docs/runtime/index.mdx
+++ b/docs/runtime/index.mdx
@@ -14,7 +14,7 @@ Under the hood, Bun uses the [JavaScriptCore engine](https://developer.apple.com
 | `bun hello.js`  | `5.2ms`  |
 | `node hello.js` | `25.1ms` |
 
-This benchmark is based on running a simple Hello World script on Linux
+This benchmark is based on running a Hello World script on Linux
 
 ## Run a file
 

--- a/docs/runtime/jsonl.mdx
+++ b/docs/runtime/jsonl.mdx
@@ -128,7 +128,7 @@ const partial = Bun.JSONL.parseChunk(buf, 0, 8);
 console.log(partial.values); // [{ a: 1 }]
 ```
 
-The `read` value is always a byte offset into the original buffer, making it easy to use with `TypedArray.subarray()` for zero-copy streaming:
+The `read` value is always a byte offset into the original buffer. Use it with `TypedArray.subarray()` for zero-copy streaming:
 
 ```ts
 let buf = new Uint8Array(0);

--- a/docs/runtime/module-resolution.mdx
+++ b/docs/runtime/module-resolution.mdx
@@ -7,7 +7,7 @@ Module resolution in JavaScript is a complex topic.
 
 The ecosystem is currently in the midst of a years-long transition from CommonJS modules to native ES modules. TypeScript enforces its own set of rules around import extensions that aren't compatible with ESM. Different build tools support path re-mapping via disparate non-compatible mechanisms.
 
-Bun aims to provide a consistent and predictable module resolution system that just works. Unfortunately it's still quite complex.
+Bun aims to provide a consistent and predictable module resolution system that works out of the box. Unfortunately it's still quite complex.
 
 ## Syntax
 

--- a/docs/runtime/networking/fetch.mdx
+++ b/docs/runtime/networking/fetch.mdx
@@ -432,7 +432,7 @@ This feature is not implemented on Windows yet. If you're interested in using th
 
 ### Connection pooling & HTTP keep-alive
 
-Bun automatically reuses connections to the same host. This is known as connection pooling. This can significantly reduce the time it takes to establish a connection. You don't need to do anything to enable this; it's automatic.
+Bun automatically reuses connections to the same host. This is known as connection pooling. This can significantly reduce the time it takes to establish a connection. Connection pooling is enabled automatically.
 
 #### Simultaneous connection limit
 

--- a/docs/runtime/networking/udp.mdx
+++ b/docs/runtime/networking/udp.mdx
@@ -94,7 +94,7 @@ const socket = await Bun.udpSocket({});
 socket.sendMany(["Hello", 41234, "127.0.0.1", "foo", 53, "1.1.1.1"]);
 ```
 
-With a connected socket, `sendMany` simply takes an array, where each element represents the data to be sent to the peer.
+With a connected socket, `sendMany` takes an array, where each element represents the data to be sent to the peer.
 
 ```ts server.ts icon="/icons/typescript.svg"
 const socket = await Bun.udpSocket({

--- a/docs/runtime/nodejs-compat.mdx
+++ b/docs/runtime/nodejs-compat.mdx
@@ -3,7 +3,7 @@ title: "Node.js Compatibility"
 description: "Bun's compatibility status with Node.js APIs, modules, and globals"
 ---
 
-Every day, Bun gets closer to 100% Node.js API compatibility. Today, popular frameworks like Next.js, Express, and millions of `npm` packages intended for Node just work with Bun. To ensure compatibility, we run thousands of tests from Node.js' test suite before every release of Bun.
+Every day, Bun gets closer to 100% Node.js API compatibility. Today, popular frameworks like Next.js, Express, and millions of `npm` packages intended for Node work with Bun. To ensure compatibility, we run thousands of tests from Node.js' test suite before every release of Bun.
 
 **If a package works in Node.js but doesn't work in Bun, we consider it a bug in Bun.** Please [open an issue](https://bun.com/issues) and we'll fix it.
 

--- a/docs/runtime/plugins.mdx
+++ b/docs/runtime/plugins.mdx
@@ -61,7 +61,7 @@ type Loader =
 
 ## Usage
 
-A plugin is defined as simple JavaScript object containing a `name` property and a `setup` function.
+A plugin is defined as a JavaScript object containing a `name` property and a `setup` function.
 
 ```tsx myPlugin.ts icon="/icons/typescript.svg"
 import type { BunPlugin } from "bun";

--- a/docs/runtime/redis.mdx
+++ b/docs/runtime/redis.mdx
@@ -5,7 +5,7 @@ description: Use Bun's native Redis client with a Promise-based API
 
 <Note>Bun's Redis client supports Redis server versions 7.2 and up.</Note>
 
-Bun provides native bindings for working with Redis databases with a modern, Promise-based API. The interface is designed to be simple and performant, with built-in connection management, fully typed responses, and TLS support.
+Bun provides native bindings for working with Redis databases with a modern, Promise-based API. The interface is designed to be performant, with built-in connection management, fully typed responses, and TLS support.
 
 ```ts redis.ts icon="/icons/typescript.svg"
 import { redis } from "bun";

--- a/docs/runtime/repl.mdx
+++ b/docs/runtime/repl.mdx
@@ -3,7 +3,7 @@ title: "REPL"
 description: "An interactive JavaScript and TypeScript REPL with syntax highlighting, history, and tab completion"
 ---
 
-`bun repl` starts an interactive Read-Eval-Print Loop (REPL) for evaluating JavaScript and TypeScript expressions. It's useful for quickly testing code snippets, exploring APIs, and debugging.
+`bun repl` starts an interactive Read-Eval-Print Loop (REPL) for evaluating JavaScript and TypeScript expressions. Use it to test code snippets, explore APIs, and debug.
 
 ```sh terminal icon="terminal"
 bun repl

--- a/docs/runtime/s3.mdx
+++ b/docs/runtime/s3.mdx
@@ -11,7 +11,7 @@ Production servers often read, upload, and write files to S3-compatible object s
   <img src="/images/bun-s3-node.gif" alt="Bun's S3 API is fast" />
 </Frame>
 
-Bun provides fast, native bindings for interacting with S3-compatible object storage services. Bun's S3 API is designed to be simple and feel similar to fetch's `Response` and `Blob` APIs (like Bun's local filesystem APIs).
+Bun provides fast, native bindings for interacting with S3-compatible object storage services. Bun's S3 API is designed to feel similar to fetch's `Response` and `Blob` APIs (like Bun's local filesystem APIs).
 
 ```ts s3.ts icon="/icons/typescript.svg"
 import { s3, write, S3Client } from "bun";
@@ -118,7 +118,7 @@ These helper methods not only simplify the API, they also make it faster.
 
 ### Writing & uploading files to S3
 
-Writing to S3 is just as simple.
+Writing to S3 works the same way.
 
 ```ts s3.ts icon="/icons/typescript.svg"
 // Write a string (replacing the file)
@@ -447,7 +447,7 @@ const r2WithEndpoint = new S3Client({
 
 ## Credentials
 
-Credentials are one of the hardest parts of using S3, and we've tried to make it as easy as possible. By default, Bun reads the following environment variables for credentials.
+Credentials are one of the hardest parts of using S3. By default, Bun reads the following environment variables for credentials.
 
 | Option name       | Environment variable   |
 | ----------------- | ---------------------- |
@@ -601,7 +601,7 @@ Like `Bun.file()`, `S3File` extends [`Blob`](https://developer.mozilla.org/en-US
 | `await s3File.stream()`      | `ReadableStream` |
 | `await s3File.arrayBuffer()` | `ArrayBuffer`    |
 
-That means using `S3File` instances with `fetch()`, `Response`, and other web APIs that accept `Blob` instances just works.
+That means using `S3File` instances with `fetch()`, `Response`, and other web APIs that accept `Blob` instances works out of the box.
 
 ### Partial reads with `slice`
 

--- a/docs/runtime/s3.mdx
+++ b/docs/runtime/s3.mdx
@@ -11,7 +11,7 @@ Production servers often read, upload, and write files to S3-compatible object s
   <img src="/images/bun-s3-node.gif" alt="Bun's S3 API is fast" />
 </Frame>
 
-Bun provides fast, native bindings for interacting with S3-compatible object storage services. Bun's S3 API is designed to feel similar to fetch's `Response` and `Blob` APIs (like Bun's local filesystem APIs).
+Bun provides fast, native bindings for interacting with S3-compatible object storage services. Its S3 API is designed to feel similar to fetch's `Response` and `Blob` APIs (like Bun's local filesystem APIs).
 
 ```ts s3.ts icon="/icons/typescript.svg"
 import { s3, write, S3Client } from "bun";
@@ -275,7 +275,7 @@ const url = s3file.presign({
 
 ### `new Response(S3File)`
 
-To quickly redirect users to a presigned URL for an S3 file, pass an `S3File` instance to a `Response` object as the body.
+To redirect users to a presigned URL for an S3 file, pass an `S3File` instance to a `Response` object as the body.
 
 This will automatically redirect the user to the presigned URL for the S3 file, saving you the memory, time, and bandwidth cost of downloading the file to your server and sending it back to the user.
 
@@ -779,7 +779,7 @@ const exists = await s3file.exists();
 
 ### `S3Client.size` (static)
 
-To quickly check the size of S3 file without downloading it, you can use the `S3Client.size` static method.
+To check the size of an S3 file without downloading it, you can use the `S3Client.size` static method.
 
 ```ts s3.ts icon="/icons/typescript.svg" highlight={11}
 import { S3Client } from "bun";

--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -531,7 +531,7 @@ await $`echo ${{ raw: '$(foo) `bar` "baz"' }}`;
 
 For simple shell scripts, instead of `/bin/sh`, you can use Bun Shell to run shell scripts.
 
-To do so, just run the script with `bun` on a file with the `.sh` extension.
+To do so, run the script with `bun` on a file with the `.sh` extension.
 
 ```sh script.sh icon="file-code"
 echo "Hello World! pwd=$(pwd)"

--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -23,7 +23,7 @@ await $`cat < ${response} | wc -c`; // 1256
 - **Cross-platform**: works on Windows, Linux & macOS. Instead of `rimraf` or `cross-env`', you can use Bun Shell without installing extra dependencies. Common shell commands like `ls`, `cd`, `rm` are implemented natively.
 - **Familiar**: Bun Shell is a bash-like shell, supporting redirection, pipes, environment variables and more.
 - **Globs**: Glob patterns are supported natively, including `**`, `*`, `{expansion}`, and more.
-- **Template literals**: Template literals are used to execute shell commands. This allows for easy interpolation of variables and expressions.
+- **Template literals**: Template literals execute shell commands, allowing interpolation of variables and expressions.
 - **Safety**: Bun Shell escapes all strings by default, preventing shell injection attacks.
 - **JavaScript interop**: Use `Response`, `ArrayBuffer`, `Blob`, `Bun.file(path)` and other JavaScript objects as stdin, stdout, and stderr.
 - **Shell scripting**: Bun Shell can be used to run shell scripts (`.bun.sh` files).

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -3,7 +3,7 @@ title: SQL
 description: Bun provides native bindings for working with SQL databases through a unified Promise-based API that supports PostgreSQL, MySQL, and SQLite.
 ---
 
-The interface is designed to be simple and performant, using tagged template literals for queries and offering features like connection pooling, transactions, and prepared statements.
+The interface is designed to be performant, using tagged template literals for queries and offering features like connection pooling, transactions, and prepared statements.
 
 ```ts title="db.ts" icon="/icons/typescript.svg"
 import { sql, SQL } from "bun";

--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -17,7 +17,7 @@ query.get();
 { message: "Hello world" }
 ```
 
-The API is simple, synchronous, and fast. Credit to [better-sqlite3](https://github.com/JoshuaWise/better-sqlite3) and its contributors for inspiring the API of `bun:sqlite`.
+The API is synchronous and fast. Credit to [better-sqlite3](https://github.com/JoshuaWise/better-sqlite3) and its contributors for inspiring the API of `bun:sqlite`.
 
 Features include:
 

--- a/docs/runtime/streams.mdx
+++ b/docs/runtime/streams.mdx
@@ -68,7 +68,7 @@ const stream = new ReadableStream({
 });
 ```
 
-When using a direct `ReadableStream`, all chunk queueing is handled by the destination. The consumer of the stream receives exactly what is passed to `controller.write()`, without any encoding or modification.
+When using a direct `ReadableStream`, the destination handles all chunk queueing. The consumer of the stream receives exactly what is passed to `controller.write()`, without any encoding or modification.
 
 ---
 

--- a/docs/runtime/streams.mdx
+++ b/docs/runtime/streams.mdx
@@ -15,7 +15,7 @@ Bun implements the Web APIs [`ReadableStream`](https://developer.mozilla.org/en-
   to the [Node.js docs](https://nodejs.org/api/stream.html).
 </Note>
 
-To create a simple `ReadableStream`:
+To create a `ReadableStream`:
 
 ```ts
 const stream = new ReadableStream({
@@ -74,7 +74,7 @@ When using a direct `ReadableStream`, all chunk queueing is handled by the desti
 
 ## Async generator streams
 
-Bun also supports async generator functions as a source for `Response` and `Request`. This is an easy way to create a `ReadableStream` that fetches data from an asynchronous source.
+Bun also supports async generator functions as a source for `Response` and `Request`. Use async generators to create a `ReadableStream` that fetches data from an asynchronous source.
 
 ```ts
 const response = new Response(

--- a/docs/runtime/templating/create.mdx
+++ b/docs/runtime/templating/create.mdx
@@ -4,8 +4,7 @@ description: Create a new Bun project from a React component, a `create-<templat
 ---
 
 <Note>
-  `bun create` is optional — Bun works without any configuration. This command exists to make getting
-  started faster.
+  `bun create` is optional — Bun works without any configuration. This command exists to make getting started faster.
 </Note>
 
 ---

--- a/docs/runtime/templating/create.mdx
+++ b/docs/runtime/templating/create.mdx
@@ -4,8 +4,8 @@ description: Create a new Bun project from a React component, a `create-<templat
 ---
 
 <Note>
-  You don't need `bun create` to use Bun. You don't need any configuration at all. This command exists to make getting
-  started a bit quicker and easier.
+  `bun create` is optional — Bun works without any configuration. This command exists to make getting
+  started faster.
 </Note>
 
 ---

--- a/docs/runtime/templating/init.mdx
+++ b/docs/runtime/templating/init.mdx
@@ -31,7 +31,7 @@ Press `enter` to accept the default answer for each prompt, or pass the `-y` fla
 
 ---
 
-`bun init` is a quick way to start a blank project with Bun. It guesses with sane defaults and is non-destructive when run multiple times.
+`bun init` scaffolds a new project with Bun. It infers settings with sane defaults and is non-destructive when run multiple times.
 
 <Frame>
   ![Demo](https://user-images.githubusercontent.com/709451/183006613-271960a3-ff22-4f7c-83f5-5e18f684c836.gif)

--- a/docs/runtime/utils.mdx
+++ b/docs/runtime/utils.mdx
@@ -172,7 +172,7 @@ const result = peek(promise);
 console.log(result); // "hi"
 ```
 
-This is important when attempting to reduce number of extraneous microticks in performance-sensitive code. It's an advanced API and you probably shouldn't use it unless you know what you're doing.
+This is important when attempting to reduce the number of extraneous microticks in performance-sensitive code. It's an advanced API — review the examples below before using it in production.
 
 ```ts
 import { peek } from "bun";
@@ -329,7 +329,7 @@ This is useful for:
 - Measuring the width of a string in a terminal
 
 This API is designed to match the popular "string-width" package, so that
-existing code can be easily ported to Bun and vice versa.
+existing code can be ported to Bun and vice versa.
 
 [In this benchmark](https://github.com/oven-sh/bun/blob/5147c0ba7379d85d4d1ed0714b84d6544af917eb/bench/snippets/string-width.mjs#L13), `Bun.stringWidth` is a ~6,756x faster than the `string-width` npm package for input larger than about 500 characters. Big thanks to [sindresorhus](https://github.com/sindresorhus) for their work on `string-width`!
 
@@ -353,7 +353,7 @@ To make `Bun.stringWidth` fast, we've implemented it in Zig using optimized SIMD
 
 <Accordion title="View full benchmark">
 
-As a reminder, 1 nanosecond (ns) is 1 billionth of a second. Here's a quick reference for converting between units:
+As a reminder, 1 nanosecond (ns) is 1 billionth of a second. Here's a reference for converting between units:
 
 | Unit | 1 Millisecond |
 | ---- | ------------- |

--- a/docs/runtime/utils.mdx
+++ b/docs/runtime/utils.mdx
@@ -250,7 +250,7 @@ Bun.openInEditor(import.meta.url, {
 
 ## `Bun.deepEquals()`
 
-Recursively checks if two objects are equivalent. This is used internally by `expect().toEqual()` in `bun:test`.
+Recursively checks if two objects are equivalent. `expect().toEqual()` in `bun:test` uses this internally.
 
 ```ts
 const foo = { a: 1, b: 2, c: { d: 3 } };
@@ -262,7 +262,7 @@ Bun.deepEquals(foo, { a: 1, b: 2, c: { d: 3 } });
 Bun.deepEquals(foo, { a: 1, b: 2, c: { d: 4 } });
 ```
 
-A third boolean parameter can be used to enable "strict" mode. This is used by `expect().toStrictEqual()` in the test runner.
+Pass a third boolean parameter to enable "strict" mode. `expect().toStrictEqual()` in the test runner uses this.
 
 ```ts
 const a = { entries: [1, 2] };

--- a/docs/runtime/watch-mode.mdx
+++ b/docs/runtime/watch-mode.mdx
@@ -32,7 +32,7 @@ In `--watch` mode, Bun keeps track of all imported files and watches them for ch
 
 **⚡️ Reloads are fast.** The filesystem watchers you're probably used to have several layers of libraries wrapping the native APIs or worse, rely on polling.
 
-Instead, Bun uses operating system native filesystem watcher APIs like kqueue or inotify to detect changes to files. Bun also does a number of optimizations to enable it scale to larger projects (such as setting a high rlimit for file descriptors, statically allocated file path buffers, reuse file descriptors when possible, etc).
+Instead, Bun uses operating system native filesystem watcher APIs like kqueue or inotify to detect changes to files. Bun also applies several optimizations to scale to larger projects (such as setting a high rlimit for file descriptors, statically allocated file path buffers, reuse file descriptors when possible, etc).
 
 </Note>
 

--- a/docs/test/code-coverage.mdx
+++ b/docs/test/code-coverage.mdx
@@ -3,7 +3,7 @@ title: "Code coverage"
 description: "Learn how to use Bun's built-in code coverage reporting to track test coverage and find untested areas in your codebase"
 ---
 
-Bun's test runner now supports built-in code coverage reporting. This makes it easy to see how much of the codebase is covered by tests, and find areas that are not currently well-tested.
+Bun's test runner supports built-in code coverage reporting. Use it to see how much of your codebase is covered by tests and find areas that are not currently well-tested.
 
 ## Enabling Coverage
 

--- a/docs/test/runtime-behavior.mdx
+++ b/docs/test/runtime-behavior.mdx
@@ -3,7 +3,7 @@ title: "Runtime behavior"
 description: "Learn about Bun test's runtime integration, environment variables, timeouts, and error handling"
 ---
 
-`bun test` is deeply integrated with Bun's runtime. This is part of what makes `bun test` fast and simple to use.
+`bun test` is deeply integrated with Bun's runtime. This integration is part of what makes `bun test` fast.
 
 ## Environment Variables
 

--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -354,7 +354,7 @@ test.each([
 
 ### Format Specifiers
 
-There are a number of options available for formatting the test title:
+The following options are available for formatting the test title:
 
 | Specifier | Description             |
 | --------- | ----------------------- |

--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -7,7 +7,7 @@ Define tests with a Jest-like API imported from the built-in `bun:test` module. 
 
 ## Basic Usage
 
-To define a simple test:
+To define a test:
 
 ```ts title="math.test.ts" icon="/icons/typescript.svg"
 import { expect, test } from "bun:test";


### PR DESCRIPTION
Improve clarity and consistency across 70+ documentation files with 130+ fixes.

**Categories of changes:**

- Remove filler words and subjective language that can be discouraging to readers
- Reframe negative phrasing into positive alternatives
- Convert passive voice to active voice
- Fix grammatical issues (missing articles, subject-verb agreement, double commas, comma splices)
- Remove stale temporal language
- Replace wordy phrases with concise alternatives ("a number of" → "several", "in order to" → "to")
- Tighten sentences by removing unnecessary qualifiers
- Fix repeated subject phrasing

**Files changed:** 70+ docs files across runtime, bundler, guides, test, and package manager documentation.