### PR TITLE
fix: return empty blob instead of crashing when ByteBlobLoader store is consumed

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,9 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    // Store already consumed/detached — return a resolved promise with an empty value.
+    var empty: Blob.Any = .{ .Blob = Blob.initEmpty(globalThis) };
+    return empty.toPromise(globalThis, action);
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/test/js/web/streams/stream-blob-consumed.test.ts
+++ b/test/js/web/streams/stream-blob-consumed.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 // Regression: ByteBlobLoader.toBufferedValue returned .zero without setting
 // a JS exception when the underlying store was already consumed, causing an

--- a/test/js/web/streams/stream-blob-consumed.test.ts
+++ b/test/js/web/streams/stream-blob-consumed.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from "bun:test";
 // a JS exception when the underlying store was already consumed, causing an
 // assertion failure ("Expected an exception to be thrown") in debug builds.
 
-test("ReadableStream.blob() after Response.clone() does not crash", async () => {
+test("ReadableStream.blob() on original response after clone works correctly", async () => {
   const response = new Response("Hello World");
   const cloned = response.clone();
   const body = response.body!;
@@ -24,6 +24,7 @@ test("ReadableStream.blob() after cancel returns empty blob", async () => {
   // blob() should return an empty blob, not crash.
   const blob = await body.blob();
   expect(blob.size).toBe(0);
+  expect(await blob.text()).toBe("");
 });
 
 test("ReadableStream.blob() on Response body works correctly", async () => {

--- a/test/js/web/streams/stream-blob-consumed.test.ts
+++ b/test/js/web/streams/stream-blob-consumed.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "bun:test";
+
+// Regression: ByteBlobLoader.toBufferedValue returned .zero without setting
+// a JS exception when the underlying store was already consumed, causing an
+// assertion failure ("Expected an exception to be thrown") in debug builds.
+
+test("ReadableStream.blob() after Response.clone() does not crash", async () => {
+  const response = new Response("Hello World");
+  const cloned = response.clone();
+  const body = response.body!;
+  const blob = await body.blob();
+  expect(blob.size).toBe(11);
+  expect(await blob.text()).toBe("Hello World");
+  expect(await cloned.text()).toBe("Hello World");
+});
+
+test("ReadableStream.blob() after cancel returns empty blob", async () => {
+  const response = new Response("Hello World");
+  const body = response.body!;
+  const reader = body.getReader();
+  await reader.cancel();
+  reader.releaseLock();
+  // After cancel, the ByteBlobLoader store is null.
+  // blob() should return an empty blob, not crash.
+  const blob = await body.blob();
+  expect(blob.size).toBe(0);
+});
+
+test("ReadableStream.blob() on Response body works correctly", async () => {
+  const response = new Response("Hello");
+  const body = response.body!;
+  const blob = await body.blob();
+  expect(blob.size).toBe(5);
+  expect(await blob.text()).toBe("Hello");
+});


### PR DESCRIPTION
\`ByteBlobLoader.toBufferedValue\` returned \`.zero\` (null JSValue) without setting a JS exception when the underlying \`Blob.Store\` was already consumed or detached (e.g. after the stream was canceled). This violated the host function contract enforced by \`TopExceptionScope\`, which asserts that \`.zero\` is only returned when a JS exception is pending, causing this panic:

\`\`\`
panic(main thread): Internal assertion failure: Expected an exception to be thrown
\`\`\`

**Root cause:** When \`toAnyBlob()\` returns \`null\` (because \`this.store\` is \`null\`), the function returned \`.zero\` directly — a bare null JSValue with no pending exception.

**Fix:** Return a resolved promise with an empty Blob instead, matching how \`ByteStream.toBufferedValue\` always returns a valid promise value. This is also the semantically correct behavior for a consumed/empty stream source.

Crash fingerprint: \`1058cdc8c8e87135\`