### PR TITLE
docs: fix repeated phrases in shell and css docs

### DIFF
--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -446,7 +446,7 @@ This conversion lets you write direction-aware CSS that works reliably across br
 
 ### :lang() selector
 
-The `:lang()` pseudo-class selector allows you to target elements based on the language they're in, allowing you to apply language-specific styling. Modern CSS allows the `:lang()` selector to accept multiple language codes, letting you group language-specific rules more efficiently.
+The `:lang()` pseudo-class selector targets elements based on the language they're in, enabling language-specific styling. Modern CSS supports passing multiple language codes to `:lang()`, letting you group language-specific rules more efficiently.
 
 ```css title="styles.css" icon="file-code"
 /* Typography adjustments for CJK languages */

--- a/docs/guides/runtime/shell.mdx
+++ b/docs/guides/runtime/shell.mdx
@@ -6,7 +6,7 @@ mode: center
 
 Bun Shell is a cross-platform bash-like shell built in to Bun.
 
-Use it to run shell commands in JavaScript and TypeScript. To get started, import the `$` function from the `bun` package and use it to run shell commands.
+It runs shell commands in JavaScript and TypeScript. To get started, import the `$` function from the `bun` package and use it to run shell commands.
 
 ```ts foo.ts icon="/icons/typescript.svg"
 import { $ } from "bun";


### PR DESCRIPTION
Follow-up to #28788 addressing unresolved review comments.

## Changes

**`docs/guides/runtime/shell.mdx` (line 9)** — removed repeated "use it to run shell commands" in adjacent sentences:

```diff
-Use it to run shell commands in JavaScript and TypeScript. To get started, import the `$` function from the `bun` package and use it to run shell commands.
+It runs shell commands in JavaScript and TypeScript. To get started, import the `$` function from the `bun` package and use it to run shell commands.
```

**`docs/bundler/css.mdx` (line 449)** — broke up triple "allow" root repetition ("allows/allowing/allows") in the `:lang()` selector section:

```diff
-The `:lang()` pseudo-class selector allows you to target elements based on the language they're in, allowing you to apply language-specific styling. Modern CSS allows the `:lang()` selector to accept multiple language codes, letting you group language-specific rules more efficiently.
+The `:lang()` pseudo-class selector targets elements based on the language they're in, enabling language-specific styling. Modern CSS supports passing multiple language codes to `:lang()`, letting you group language-specific rules more efficiently.
```

Docs-only change. No functional impact.