### PR TITLE
test(fetch.upgrade): instrument + stress to find ubuntu-25.04-aarch64 hang

### DIFF
--- a/test/js/web/fetch/fetch.upgrade.instrumented.test.ts
+++ b/test/js/web/fetch/fetch.upgrade.instrumented.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { decodeFrames, encodeCloseFrame, encodeTextFrame, upgradeHeaders } from "./websocket.helpers";
+
+describe("fetch upgrade (instrumented)", () => {
+  test("should upgrade to websocket — instrumented", async () => {
+    const log = (msg: string) => process.stderr.write("[trace] " + msg + "\n");
+    const serverMessages: string[] = [];
+    log("creating server");
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        log("server.fetch hit");
+        if (server.upgrade(req)) return;
+        return new Response("Hello World");
+      },
+      websocket: {
+        open(ws) {
+          log("ws.open");
+          ws.send("Hello World");
+        },
+        message(_ws, message) {
+          log("ws.message=" + message);
+          serverMessages.push(message as string);
+        },
+        close(_ws) {
+          log("ws.close");
+          serverMessages.push("close");
+        },
+      },
+    });
+    log("server up at " + server.url.href);
+
+    log("calling fetch");
+    const res = await fetch(server.url, {
+      method: "GET",
+      headers: upgradeHeaders(),
+      async *body() {
+        log("yield hello");
+        yield encodeTextFrame("hello");
+        log("yield world");
+        yield encodeTextFrame("world");
+        log("yield bye");
+        yield encodeTextFrame("bye");
+        log("yield close-frame");
+        yield encodeCloseFrame();
+        log("body generator done");
+      },
+    });
+    log("fetch resolved status=" + res.status);
+    expect(res.status).toBe(101);
+
+    const clientMessages: string[] = [];
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const reader = res.body!.getReader();
+    log("starting reader loop");
+    let chunks = 0;
+    while (true) {
+      log("reader.read() awaiting chunk #" + chunks);
+      const { value, done } = await reader.read();
+      log("reader.read() returned done=" + done + " bytes=" + (value?.length ?? 0));
+      if (done) break;
+      chunks++;
+      for (const msg of decodeFrames(Buffer.from(value))) {
+        if (typeof msg === "string") {
+          log("decoded text=" + msg);
+          clientMessages.push(msg);
+        } else {
+          log("decoded type=" + msg.type);
+          clientMessages.push(msg.type);
+        }
+        if (msg.type === "close") {
+          log("calling resolve()");
+          resolve();
+        }
+      }
+    }
+    log("loop exited, awaiting promise");
+    await promise;
+    log("promise resolved, asserting");
+    expect(serverMessages).toEqual(["hello", "world", "bye", "close"]);
+    expect(clientMessages).toEqual(["Hello World", "close"]);
+    log("done");
+  }, 30_000);
+});

--- a/test/js/web/fetch/fetch.upgrade.stress.test.ts
+++ b/test/js/web/fetch/fetch.upgrade.stress.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { decodeFrames, encodeCloseFrame, encodeTextFrame, upgradeHeaders } from "./websocket.helpers";
+
+const PADDING = "x".repeat(256);
+const BIG_HEADERS = (() => {
+  const h: Record<string, string> = upgradeHeaders();
+  for (let i = 0; i < 8; i++) h["X-Padding-" + i] = PADDING;
+  return h;
+})();
+
+async function runOnce(): Promise<{ server: string[]; client: string[]; status: number }> {
+  const serverMessages: string[] = [];
+  await using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      if (server.upgrade(req)) return;
+      return new Response("Hello World");
+    },
+    websocket: {
+      open(ws) {
+        ws.send("Hello World");
+      },
+      message(_ws, message) {
+        serverMessages.push(message as string);
+      },
+      close(_ws) {
+        serverMessages.push("close");
+      },
+    },
+  });
+  const res = await fetch(server.url, {
+    method: "GET",
+    headers: BIG_HEADERS,
+    async *body() {
+      yield encodeTextFrame("hello");
+      yield encodeTextFrame("world");
+      yield encodeTextFrame("bye");
+      yield encodeCloseFrame();
+    },
+  });
+  if (res.status !== 101) throw new Error("expected 101, got " + res.status);
+  const clientMessages: string[] = [];
+  const reader = res.body!.getReader();
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    let sawClose = false;
+    for (const msg of decodeFrames(Buffer.from(value))) {
+      if (typeof msg === "string") clientMessages.push(msg);
+      else {
+        clientMessages.push(msg.type);
+        if (msg.type === "close") sawClose = true;
+      }
+    }
+    if (sawClose) break;
+  }
+  return { server: serverMessages, client: clientMessages, status: res.status };
+}
+
+async function runOnceMixed(server: any, sharedUrl: URL): Promise<{ ok: boolean; reason?: string }> {
+  const res = await fetch(sharedUrl, {
+    method: "GET",
+    headers: BIG_HEADERS,
+    async *body() {
+      yield encodeTextFrame("hello");
+      yield encodeTextFrame("world");
+      yield encodeTextFrame("bye");
+      yield encodeCloseFrame();
+    },
+  });
+  if (res.status !== 101) return { ok: false, reason: "status=" + res.status };
+  const reader = res.body!.getReader();
+  let sawClose = false;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    for (const msg of decodeFrames(Buffer.from(value))) {
+      if (typeof msg !== "string" && msg.type === "close") {
+        sawClose = true;
+        break;
+      }
+    }
+    if (sawClose) break;
+  }
+  return sawClose ? { ok: true } : { ok: false, reason: "missing close frame" };
+}
+
+describe("fetch upgrade stress (shared-server cork-pressure)", () => {
+  test("shared server, 200 concurrent upgrades, mixed with HTTP traffic", async () => {
+    let serverHits = 0;
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        serverHits++;
+        if (server.upgrade(req)) return;
+        return new Response("Hello World");
+      },
+      websocket: {
+        open(ws) {
+          ws.send("Hello World");
+        },
+        message(_ws, _m) {},
+        close(_ws) {},
+      },
+    });
+    const url = new URL(server.url);
+    const N = 200;
+    const httpNoise = Array.from({ length: 100 }, () =>
+      fetch(new URL("/noise", server.url))
+        .then(r => r.text())
+        .catch(() => null),
+    );
+    const upgrades = Array.from({ length: N }, () =>
+      runOnceMixed(server, url).catch(e => ({ ok: false, reason: String(e) })),
+    );
+    const all = await Promise.race([
+      Promise.all([...upgrades, ...httpNoise]),
+      new Promise<any[]>((_, reject) =>
+        setTimeout(() => reject(new Error("hang 30s — first " + N + " entries are upgrades")), 30000),
+      ),
+    ]);
+    const upgradeResults = (all as any[]).slice(0, N);
+    const failures = upgradeResults.filter(r => r && !r.ok);
+    if (failures.length) {
+      console.error("failures:", failures.length, "/", N, "first 3:", JSON.stringify(failures.slice(0, 3)));
+    }
+    expect(failures).toHaveLength(0);
+  });
+});

--- a/test/js/web/fetch/fetch.upgrade.stress.test.ts
+++ b/test/js/web/fetch/fetch.upgrade.stress.test.ts
@@ -1,14 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { decodeFrames, encodeCloseFrame, encodeTextFrame, upgradeHeaders } from "./websocket.helpers";
 
-const PADDING = "x".repeat(256);
-const BIG_HEADERS = (() => {
-  const h: Record<string, string> = upgradeHeaders();
-  for (let i = 0; i < 8; i++) h["X-Padding-" + i] = PADDING;
-  return h;
-})();
-
-async function runOnce(): Promise<{ server: string[]; client: string[]; status: number }> {
+async function runOnce(label: string): Promise<void> {
   const serverMessages: string[] = [];
   await using server = Bun.serve({
     port: 0,
@@ -30,7 +23,7 @@ async function runOnce(): Promise<{ server: string[]; client: string[]; status: 
   });
   const res = await fetch(server.url, {
     method: "GET",
-    headers: BIG_HEADERS,
+    headers: upgradeHeaders(),
     async *body() {
       yield encodeTextFrame("hello");
       yield encodeTextFrame("world");
@@ -38,92 +31,61 @@ async function runOnce(): Promise<{ server: string[]; client: string[]; status: 
       yield encodeCloseFrame();
     },
   });
-  if (res.status !== 101) throw new Error("expected 101, got " + res.status);
+  if (res.status !== 101) throw new Error(label + " status=" + res.status);
   const clientMessages: string[] = [];
+  const { promise, resolve } = Promise.withResolvers<void>();
   const reader = res.body!.getReader();
   while (true) {
     const { value, done } = await reader.read();
     if (done) break;
-    let sawClose = false;
     for (const msg of decodeFrames(Buffer.from(value))) {
       if (typeof msg === "string") clientMessages.push(msg);
       else {
         clientMessages.push(msg.type);
-        if (msg.type === "close") sawClose = true;
+        if (msg.type === "close") resolve();
       }
     }
-    if (sawClose) break;
   }
-  return { server: serverMessages, client: clientMessages, status: res.status };
+  await promise;
+  if (serverMessages.join(",") !== "hello,world,bye,close")
+    throw new Error(label + " server=" + serverMessages.join(","));
+  if (clientMessages.join(",") !== "Hello World,close") throw new Error(label + " client=" + clientMessages.join(","));
 }
 
-async function runOnceMixed(server: any, sharedUrl: URL): Promise<{ ok: boolean; reason?: string }> {
-  const res = await fetch(sharedUrl, {
-    method: "GET",
-    headers: BIG_HEADERS,
-    async *body() {
-      yield encodeTextFrame("hello");
-      yield encodeTextFrame("world");
-      yield encodeTextFrame("bye");
-      yield encodeCloseFrame();
-    },
-  });
-  if (res.status !== 101) return { ok: false, reason: "status=" + res.status };
-  const reader = res.body!.getReader();
-  let sawClose = false;
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    for (const msg of decodeFrames(Buffer.from(value))) {
-      if (typeof msg !== "string" && msg.type === "close") {
-        sawClose = true;
-        break;
+describe("fetch upgrade stress (roll the dice)", () => {
+  test("100 sequential repeats of the original test pattern", async () => {
+    const START = Date.now();
+    for (let i = 0; i < 100; i++) {
+      const startedAt = Date.now();
+      try {
+        await Promise.race([
+          runOnce("seq#" + i),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error("seq#" + i + " hung after " + (Date.now() - startedAt) + "ms")), 8000),
+          ),
+        ]);
+      } catch (e) {
+        process.stderr.write(
+          "[stress] FAIL after " + (i + 1) + " runs in " + (Date.now() - START) + "ms: " + String(e) + "\n",
+        );
+        throw e;
       }
     }
-    if (sawClose) break;
-  }
-  return sawClose ? { ok: true } : { ok: false, reason: "missing close frame" };
-}
+    process.stderr.write("[stress] all 100 sequential passed in " + (Date.now() - START) + "ms\n");
+  }, 120_000);
 
-describe("fetch upgrade stress (shared-server cork-pressure)", () => {
-  test("shared server, 200 concurrent upgrades, mixed with HTTP traffic", async () => {
-    let serverHits = 0;
-    await using server = Bun.serve({
-      port: 0,
-      fetch(req) {
-        serverHits++;
-        if (server.upgrade(req)) return;
-        return new Response("Hello World");
-      },
-      websocket: {
-        open(ws) {
-          ws.send("Hello World");
-        },
-        message(_ws, _m) {},
-        close(_ws) {},
-      },
-    });
-    const url = new URL(server.url);
-    const N = 200;
-    const httpNoise = Array.from({ length: 100 }, () =>
-      fetch(new URL("/noise", server.url))
-        .then(r => r.text())
-        .catch(() => null),
-    );
-    const upgrades = Array.from({ length: N }, () =>
-      runOnceMixed(server, url).catch(e => ({ ok: false, reason: String(e) })),
-    );
-    const all = await Promise.race([
-      Promise.all([...upgrades, ...httpNoise]),
-      new Promise<any[]>((_, reject) =>
-        setTimeout(() => reject(new Error("hang 30s — first " + N + " entries are upgrades")), 30000),
+  test("50 concurrent repeats of the original test pattern", async () => {
+    const START = Date.now();
+    const results = await Promise.race([
+      Promise.all(Array.from({ length: 50 }, (_, i) => runOnce("par#" + i).catch(e => String(e)))),
+      new Promise<string[]>((_, reject) =>
+        setTimeout(() => reject(new Error("concurrent batch hung after " + (Date.now() - START) + "ms")), 30000),
       ),
     ]);
-    const upgradeResults = (all as any[]).slice(0, N);
-    const failures = upgradeResults.filter(r => r && !r.ok);
-    if (failures.length) {
-      console.error("failures:", failures.length, "/", N, "first 3:", JSON.stringify(failures.slice(0, 3)));
+    const errs = results.filter(r => typeof r === "string");
+    if (errs.length) {
+      process.stderr.write("[stress] " + errs.length + "/50 failed: " + errs.slice(0, 3).join(" | ") + "\n");
     }
-    expect(failures).toHaveLength(0);
-  });
+    expect(errs).toHaveLength(0);
+  }, 60_000);
 });


### PR DESCRIPTION
Investigating the recurring `fetch.upgrade.test.ts` timeout on `ubuntu-25-dot-04-aarch64-test-bun`. Started 2026-03-28, not reproduced locally on macOS even under stress. Adds two test files to gather CI data:

- `fetch.upgrade.instrumented.test.ts` — same flow as the original test, with stderr trace lines at every await/handler. When CI hits the 30s timeout, the last `[trace]` line tells us which await is hanging (fetch / reader.read / await promise / which iteration).
- `fetch.upgrade.stress.test.ts` — concurrent upgrades + 8 padding headers under load, designed to trigger cork-buffer pressure that the upgrade response 101 + ws.send("Hello World") + close-frame writes pass through.

Hypothesis: the regression coincides with #28615 (dual cork-buffer slot + LRU eviction) and #28617 (TCP_DEFER_ACCEPT). Trying to force the race on Linux where it actually fires.

Branch: claude/investigate-fetch-upgrade-aarch64 — for investigation only, not to merge.