### PR TITLE
Stop file watcher thread before Global.exit tears down memory

### DIFF
--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -657,12 +657,8 @@ pub fn add_pre_exit_callback(function: ExitFn) {
     }
 }
 
-/// Callbacks run at the very top of `exit()` — BEFORE any heap teardown or the
-/// ASAN `libc_exit` that poisons freed memory. Used by `bun_watcher` to stop
-/// its background threads so they can't touch process-global singletons (the
-/// resolver's `BSSMap` dir cache) after the exit path frees/poisons them.
-/// `bun_watcher` sits above `bun_core`, so it registers its hook here rather
-/// than us calling into it (layering).
+/// Run at the very top of `exit()`, before any heap teardown. `bun_watcher`
+/// registers its `stop_all_for_exit` here (it sits above `bun_core`).
 static EARLY_EXIT_CALLBACKS: crate::Mutex<Vec<ExitFn>> = crate::Mutex::new(Vec::new());
 
 pub fn add_early_exit_callback(function: ExitFn) {
@@ -673,10 +669,7 @@ pub fn add_early_exit_callback(function: ExitFn) {
 }
 
 fn run_early_exit_callbacks() {
-    // Snapshot under lock, run outside it — same pattern as
-    // `run_exit_callbacks`. Callbacks can block (e.g. `stop_all_for_exit`
-    // waits on each watcher's mutex); don't hold a non-recursive lock across
-    // them.
+    // Snapshot under lock, run outside it; callbacks can block.
     let cbs: Vec<ExitFn> = EARLY_EXIT_CALLBACKS.lock().clone();
     for callback in &cbs {
         callback();
@@ -730,18 +723,12 @@ pub fn exit(code: u32) -> ! {
     // MOVE_DOWN: bun_crash_handler::sleep_forever_if_another_thread_is_crashing → bun_core.
     crate::sleep_forever_if_another_thread_is_crashing();
 
-    // Stop background threads (e.g. the file watcher) before tearing the heap
-    // down. Under ASAN, `libc_exit` below runs the leak/teardown pass which
-    // poisons freed memory; a live watcher thread would then touch the
-    // resolver's BSSMap singleton and trip use-after-poison. No-op when no
-    // watcher is active. `bun_watcher` registers its `stop_all_for_exit` hook
-    // here because it sits above `bun_core`.
+    // Stop background threads (the file watcher) before the heap teardown /
+    // ASAN poison below can pull memory out from under them.
     run_early_exit_callbacks();
 
-    // Test-only (debug builds): linger after stopping watchers but before the
-    // heap teardown/poison so the `hot-reload-exit-race` regression test's
-    // delayed `bust_dir_cache` has time to land — on freed memory when the fix
-    // is absent, harmlessly when it's present (watchers already stopped above).
+    // Test-only linger so the hot-reload-exit-race test's delayed
+    // bust_dir_cache lands before the process dies.
     #[cfg(debug_assertions)]
     if let Some(ms) = crate::env_var::BUN_INTERNAL_GLOBALEXIT_LINGER_MS.get() {
         if ms != 0 {

--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -657,6 +657,32 @@ pub fn add_pre_exit_callback(function: ExitFn) {
     }
 }
 
+/// Callbacks run at the very top of `exit()` — BEFORE any heap teardown or the
+/// ASAN `libc_exit` that poisons freed memory. Used by `bun_watcher` to stop
+/// its background threads so they can't touch process-global singletons (the
+/// resolver's `BSSMap` dir cache) after the exit path frees/poisons them.
+/// `bun_watcher` sits above `bun_core`, so it registers its hook here rather
+/// than us calling into it (layering).
+static EARLY_EXIT_CALLBACKS: crate::Mutex<Vec<ExitFn>> = crate::Mutex::new(Vec::new());
+
+pub fn add_early_exit_callback(function: ExitFn) {
+    let mut cbs = EARLY_EXIT_CALLBACKS.lock();
+    if !cbs.iter().any(|f| *f as usize == function as usize) {
+        cbs.push(function);
+    }
+}
+
+fn run_early_exit_callbacks() {
+    // Snapshot under lock, run outside it — same pattern as
+    // `run_exit_callbacks`. Callbacks can block (e.g. `stop_all_for_exit`
+    // waits on each watcher's mutex); don't hold a non-recursive lock across
+    // them.
+    let cbs: Vec<ExitFn> = EARLY_EXIT_CALLBACKS.lock().clone();
+    for callback in &cbs {
+        callback();
+    }
+}
+
 fn run_exit_callbacks() {
     // Drain under lock, run outside it (callbacks may call `Bun__atexit`).
     let cbs: Vec<ExitFn> = core::mem::take(&mut *ON_EXIT_CALLBACKS.lock());
@@ -672,7 +698,7 @@ extern "C" fn bun_is_exiting() -> c_int {
     is_exiting() as c_int
 }
 
-fn is_exiting() -> bool {
+pub fn is_exiting() -> bool {
     IS_EXITING.load(Ordering::Relaxed)
 }
 
@@ -703,6 +729,25 @@ pub fn exit(code: u32) -> ! {
     // If we are crashing, allow the crash handler to finish it's work.
     // MOVE_DOWN: bun_crash_handler::sleep_forever_if_another_thread_is_crashing → bun_core.
     crate::sleep_forever_if_another_thread_is_crashing();
+
+    // Stop background threads (e.g. the file watcher) before tearing the heap
+    // down. Under ASAN, `libc_exit` below runs the leak/teardown pass which
+    // poisons freed memory; a live watcher thread would then touch the
+    // resolver's BSSMap singleton and trip use-after-poison. No-op when no
+    // watcher is active. `bun_watcher` registers its `stop_all_for_exit` hook
+    // here because it sits above `bun_core`.
+    run_early_exit_callbacks();
+
+    // Test-only (debug builds): linger after stopping watchers but before the
+    // heap teardown/poison so the `hot-reload-exit-race` regression test's
+    // delayed `bust_dir_cache` has time to land — on freed memory when the fix
+    // is absent, harmlessly when it's present (watchers already stopped above).
+    #[cfg(debug_assertions)]
+    if let Some(ms) = crate::env_var::BUN_INTERNAL_GLOBALEXIT_LINGER_MS.get() {
+        if ms != 0 {
+            std::thread::sleep(std::time::Duration::from_millis(ms));
+        }
+    }
 
     #[cfg(debug_assertions)]
     {

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -165,6 +165,21 @@ new!(pub NODE_DISABLE_COMPILE_CACHE: string, "NODE_DISABLE_COMPILE_CACHE", {});
 // child's CLI entrypoint checks this before anything else and hands off to
 // C++ Bun__WebView__hostMain. Never returns — no JSC, no VM.
 new!(pub BUN_INTERNAL_WEBVIEW_HOST: string, "BUN_INTERNAL_WEBVIEW_HOST", {});
+// Test-only (debug builds only; call sites are gated on `cfg(debug_assertions)`).
+// These three widen the otherwise-microsecond race between the file-watcher
+// thread and process exit so the `hot-reload-exit-race` regression test can
+// trigger it deterministically:
+//  - `..._BUSTDIRCACHE_DELAY_MS`: make `VirtualMachine::bust_dir_cache` sleep
+//    this many ms while holding the watcher mutex, so the main thread can race
+//    ahead and free the resolver BSSMap singleton.
+//  - `..._GLOBALEXIT_FAST_PATH_TO_TRANSPILER_DEINIT`: cut `global_exit`
+//    straight to freeing the BSSMap (skipping the phased teardown), so the
+//    free happens while the watcher is still sleeping.
+//  - `..._GLOBALEXIT_LINGER_MS`: linger in `Global::exit` after the teardown so
+//    the watcher's delayed `bust_dir_cache` lands on the freed memory.
+new!(pub BUN_INTERNAL_WATCHER_BUSTDIRCACHE_DELAY_MS: unsigned, "BUN_INTERNAL_WATCHER_BUSTDIRCACHE_DELAY_MS", { deser: { error_handling: NotSet } });
+new!(pub BUN_INTERNAL_GLOBALEXIT_FAST_PATH_TO_TRANSPILER_DEINIT: boolean, "BUN_INTERNAL_GLOBALEXIT_FAST_PATH_TO_TRANSPILER_DEINIT", { default: false });
+new!(pub BUN_INTERNAL_GLOBALEXIT_LINGER_MS: unsigned, "BUN_INTERNAL_GLOBALEXIT_LINGER_MS", { deser: { error_handling: NotSet } });
 new!(pub NODE_PENDING_DEPRECATION: string, "NODE_PENDING_DEPRECATION", {});
 new!(pub NODE_PRESERVE_SYMLINKS_MAIN: boolean, "NODE_PRESERVE_SYMLINKS_MAIN", { default: false });
 new!(pub NODE_USE_SYSTEM_CA: boolean, "NODE_USE_SYSTEM_CA", { default: false });

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -165,18 +165,9 @@ new!(pub NODE_DISABLE_COMPILE_CACHE: string, "NODE_DISABLE_COMPILE_CACHE", {});
 // child's CLI entrypoint checks this before anything else and hands off to
 // C++ Bun__WebView__hostMain. Never returns — no JSC, no VM.
 new!(pub BUN_INTERNAL_WEBVIEW_HOST: string, "BUN_INTERNAL_WEBVIEW_HOST", {});
-// Test-only (debug builds only; call sites are gated on `cfg(debug_assertions)`).
-// These three widen the otherwise-microsecond race between the file-watcher
-// thread and process exit so the `hot-reload-exit-race` regression test can
-// trigger it deterministically:
-//  - `..._BUSTDIRCACHE_DELAY_MS`: make `VirtualMachine::bust_dir_cache` sleep
-//    this many ms while holding the watcher mutex, so the main thread can race
-//    ahead and free the resolver BSSMap singleton.
-//  - `..._GLOBALEXIT_FAST_PATH_TO_TRANSPILER_DEINIT`: cut `global_exit`
-//    straight to freeing the BSSMap (skipping the phased teardown), so the
-//    free happens while the watcher is still sleeping.
-//  - `..._GLOBALEXIT_LINGER_MS`: linger in `Global::exit` after the teardown so
-//    the watcher's delayed `bust_dir_cache` lands on the freed memory.
+// Test-only hooks (call sites are `cfg(debug_assertions)`): widen the
+// microsecond-wide watcher-vs-exit race so the `hot-reload-exit-race`
+// regression test can trigger it deterministically.
 new!(pub BUN_INTERNAL_WATCHER_BUSTDIRCACHE_DELAY_MS: unsigned, "BUN_INTERNAL_WATCHER_BUSTDIRCACHE_DELAY_MS", { deser: { error_handling: NotSet } });
 new!(pub BUN_INTERNAL_GLOBALEXIT_FAST_PATH_TO_TRANSPILER_DEINIT: boolean, "BUN_INTERNAL_GLOBALEXIT_FAST_PATH_TO_TRANSPILER_DEINIT", { default: false });
 new!(pub BUN_INTERNAL_GLOBALEXIT_LINGER_MS: unsigned, "BUN_INTERNAL_GLOBALEXIT_LINGER_MS", { deser: { error_handling: NotSet } });

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1682,6 +1682,27 @@ impl VirtualMachine {
         // self.event_loop().tick();
 
         if self.should_destruct_main_thread_on_exit() {
+            // File-watcher threads dispatch through the process-global resolver
+            // BSSMap singletons (dir_cache, etc.) that `teardown` →
+            // `destroy()` → `transpiler.deinit()` below frees. Stop them
+            // first, under each watcher's own mutex, so any in-flight
+            // `bust_dir_cache` completes before the freeing starts.
+            // `Global::exit` re-stops via its early-exit hook on the
+            // non-destruct path; `stop_all_for_exit` is idempotent.
+            bun_watcher::stop_all_for_exit();
+            // Test-only (debug builds): skip the phased teardown and free the
+            // BSSMap singletons immediately, so the `hot-reload-exit-race`
+            // regression test frees them while a watcher thread's
+            // `bust_dir_cache` is still sleeping in its delay hook.
+            #[cfg(debug_assertions)]
+            if bun_core::env_var::BUN_INTERNAL_GLOBALEXIT_FAST_PATH_TO_TRANSPILER_DEINIT.get()
+                == Some(true)
+            {
+                // SAFETY: main-thread VM on the main thread; the process exits
+                // immediately below, so nothing observes the skipped phases.
+                unsafe { self.transpiler.deinit() };
+                bun_core::Global::exit(u32::from(self.exit_handler.exit_code));
+            }
             // SAFETY: main-thread VM on the main thread; exit handlers have run.
             unsafe { Self::teardown(core::ptr::from_mut(self), Teardown::MainThreadExit) };
         } else {
@@ -6708,6 +6729,17 @@ impl VirtualMachine {
 
     /// To satisfy the interface from NewHotReloader().
     pub(crate) fn bust_dir_cache(&mut self, path: &[u8]) -> bool {
+        // Test-only (debug builds): sleep here, on the watcher thread, while it
+        // holds the watcher mutex, so the main thread's `global_exit` can race
+        // ahead and free the resolver BSSMap singleton this call is about to
+        // touch. Widens the otherwise-microsecond watcher-vs-exit race for the
+        // `hot-reload-exit-race` regression test.
+        #[cfg(debug_assertions)]
+        if let Some(ms) = bun_core::env_var::BUN_INTERNAL_WATCHER_BUSTDIRCACHE_DELAY_MS.get() {
+            if ms != 0 {
+                std::thread::sleep(std::time::Duration::from_millis(ms));
+            }
+        }
         self.transpiler.resolver.bust_dir_cache(path)
     }
 }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1682,24 +1682,17 @@ impl VirtualMachine {
         // self.event_loop().tick();
 
         if self.should_destruct_main_thread_on_exit() {
-            // File-watcher threads dispatch through the process-global resolver
-            // BSSMap singletons (dir_cache, etc.) that `teardown` →
-            // `destroy()` → `transpiler.deinit()` below frees. Stop them
-            // first, under each watcher's own mutex, so any in-flight
-            // `bust_dir_cache` completes before the freeing starts.
-            // `Global::exit` re-stops via its early-exit hook on the
-            // non-destruct path; `stop_all_for_exit` is idempotent.
+            // Stop watcher threads before `teardown` frees the resolver BSSMap
+            // singletons they dispatch through (any in-flight `bust_dir_cache`
+            // completes under the watcher mutex first).
             bun_watcher::stop_all_for_exit();
-            // Test-only (debug builds): skip the phased teardown and free the
-            // BSSMap singletons immediately, so the `hot-reload-exit-race`
-            // regression test frees them while a watcher thread's
-            // `bust_dir_cache` is still sleeping in its delay hook.
+            // Test-only fast path for the hot-reload-exit-race test: free the
+            // BSSMap immediately instead of running the phased teardown.
             #[cfg(debug_assertions)]
             if bun_core::env_var::BUN_INTERNAL_GLOBALEXIT_FAST_PATH_TO_TRANSPILER_DEINIT.get()
                 == Some(true)
             {
-                // SAFETY: main-thread VM on the main thread; the process exits
-                // immediately below, so nothing observes the skipped phases.
+                // SAFETY: main-thread VM; the process exits immediately below.
                 unsafe { self.transpiler.deinit() };
                 bun_core::Global::exit(u32::from(self.exit_handler.exit_code));
             }
@@ -6729,11 +6722,8 @@ impl VirtualMachine {
 
     /// To satisfy the interface from NewHotReloader().
     pub(crate) fn bust_dir_cache(&mut self, path: &[u8]) -> bool {
-        // Test-only (debug builds): sleep here, on the watcher thread, while it
-        // holds the watcher mutex, so the main thread's `global_exit` can race
-        // ahead and free the resolver BSSMap singleton this call is about to
-        // touch. Widens the otherwise-microsecond watcher-vs-exit race for the
-        // `hot-reload-exit-race` regression test.
+        // Test-only delay (watcher thread, under the watcher mutex) so the
+        // hot-reload-exit-race test can widen the watcher-vs-exit race.
         #[cfg(debug_assertions)]
         if let Some(ms) = bun_core::env_var::BUN_INTERNAL_WATCHER_BUSTDIRCACHE_DELAY_MS.get() {
             if ms != 0 {

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -158,8 +158,7 @@ static ACTIVE_WATCHERS: bun_core::Mutex<Vec<usize>> = bun_core::Mutex::new(Vec::
 /// Set by `stop_all_for_exit`. `VirtualMachine::global_exit` stops watchers and
 /// tears the heap down before `Global::exit` sets `IS_EXITING`, so that flag
 /// alone can't gate the exit paths below.
-static STOPPING_FOR_EXIT: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+static STOPPING_FOR_EXIT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 extern "C" fn stop_all_for_exit_hook() {
     stop_all_for_exit();

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -151,6 +151,92 @@ pub trait WatcherContext {
     }
 }
 
+// ─── exit coordination ──────────────────────────────────────────────────────
+//
+// Global list of running watchers so that `stop_all_for_exit` can signal them
+// before the process tears down heap memory. The watcher thread accesses
+// globals like the resolver's directory cache (a process-global `BSSMap`
+// singleton) whose storage is freed by `transpiler.deinit()` on the
+// `BUN_DESTRUCT_VM_ON_EXIT` path and poisoned by ASAN's `libc_exit` teardown
+// otherwise. Without stopping the thread first those accesses become
+// use-after-free / use-after-poison (observed on the x64-asan CI lane as a
+// crash in `bustDirCache` on the "File Watcher" thread).
+//
+// Pointers are stored as `usize` because a raw `*mut Watcher` is not `Send`;
+// every access below reconstitutes the pointer under `ACTIVE_WATCHERS` and the
+// watcher's own `mutex`, matching the alias-allowed `*Watcher` model the rest
+// of the port uses (see `VirtualMachine::bun_watcher_ptr`).
+static ACTIVE_WATCHERS: bun_core::Mutex<Vec<usize>> = bun_core::Mutex::new(Vec::new());
+
+/// Set once `stop_all_for_exit` runs. `Global::is_exiting()` covers the plain
+/// `Global::exit` path, but `VirtualMachine::global_exit` calls
+/// `stop_all_for_exit` directly and tears the heap down *before* it reaches
+/// `Global::exit` (which is what sets `IS_EXITING`). Read by `register_active`
+/// (refuse new watchers) and the `thread_main` teardown guard (skip reclaiming
+/// the Box) so both cover both exit paths.
+static STOPPING_FOR_EXIT: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// `extern "C"` thunk matching `bun_core::Global::ExitFn`, registered once so
+/// `Global::exit` stops every watcher before the heap teardown / ASAN poison.
+extern "C" fn stop_all_for_exit_hook() {
+    stop_all_for_exit();
+}
+
+/// Returns `false` if the process is already exiting, in which case the caller
+/// must not spawn a watcher thread — it would race the exit-time teardown.
+/// The check runs under the same lock `stop_all_for_exit` holds, so a watcher
+/// that wins the register race is already in the list when the stop sweep
+/// iterates.
+fn register_active(this: *mut Watcher) -> bool {
+    // Install the `Global::exit` hook on first use. `add_early_exit_callback`
+    // dedups, but a `Once` keeps the lock traffic off the common path.
+    static HOOK: std::sync::Once = std::sync::Once::new();
+    HOOK.call_once(|| bun_core::Global::add_early_exit_callback(stop_all_for_exit_hook));
+
+    let mut list = ACTIVE_WATCHERS.lock();
+    if STOPPING_FOR_EXIT.load(std::sync::atomic::Ordering::Acquire)
+        || bun_core::Global::is_exiting()
+    {
+        return false;
+    }
+    list.push(this as usize);
+    true
+}
+
+fn unregister_active(this: *mut Watcher) {
+    let addr = this as usize;
+    let mut list = ACTIVE_WATCHERS.lock();
+    if let Some(idx) = list.iter().position(|&p| p == addr) {
+        list.swap_remove(idx);
+    }
+}
+
+/// Called from the exit path (main thread) before tearing down heap memory.
+/// Acquires each watcher's `mutex` — which serialises with the watcher
+/// thread's `dispatch_file_updates` (it holds `mutex` across `on_file_update`)
+/// — then sets `running = false` and closes the platform handle so the next
+/// loop iteration exits. Any `bust_dir_cache` already in flight completes
+/// before this returns. Callers are serialised by `ACTIVE_WATCHERS`; the
+/// platform `stop()` implementations are idempotent, so a second sequential
+/// call is a no-op.
+pub fn stop_all_for_exit() {
+    STOPPING_FOR_EXIT.store(true, std::sync::atomic::Ordering::Release);
+    let list = ACTIVE_WATCHERS.lock();
+    for &addr in list.iter() {
+        // SAFETY: pointers in the list are live `Box<Watcher>` allocations
+        // (removed in `thread_main`/`shutdown` before the Box is reclaimed,
+        // both of which also take `ACTIVE_WATCHERS`). We hold that lock here,
+        // so no entry can be freed concurrently. The watcher's own `mutex`
+        // serialises the `running`/`platform` writes with the watcher thread.
+        let w = unsafe { &mut *(addr as *mut Watcher) };
+        w.mutex.lock();
+        w.running.store(false);
+        w.platform.stop();
+        w.mutex.unlock();
+    }
+}
+
 impl Watcher {
     /// Initializes a watcher. Each watcher is tied to some context type, which
     /// receives watch callbacks on the watcher thread. This function does not
@@ -233,10 +319,19 @@ impl Watcher {
 
     pub fn start(&mut self) -> Result<(), crate::Error> {
         debug_assert!(!self.watchloop_handle.load());
-        self.watchloop_handle.store(true);
         // Watcher must be Send across the spawned thread boundary; we pass a
         // raw pointer (as usize) and uphold the safety contract manually.
-        let this = std::ptr::from_mut::<Watcher>(self) as usize;
+        let this_ptr = std::ptr::from_mut::<Watcher>(self);
+        // If the process is already exiting, don't spawn — the watcher would
+        // race the exit-time teardown of the resolver's BSSMap singletons (and
+        // ASAN's `libc_exit` heap poisoning). Callers can't usefully recover
+        // and the process is about to die anyway. `register_active` also adds
+        // `self` to the global list so `stop_all_for_exit` can signal it.
+        if !register_active(this_ptr) {
+            return Ok(());
+        }
+        self.watchloop_handle.store(true);
+        let this = this_ptr as usize;
         let spawn = || {
             std::thread::Builder::new()
                 .name("FileWatcher".into())
@@ -256,6 +351,9 @@ impl Watcher {
         });
         self.thread = Some(handle.map_err(|e| {
             self.watchloop_handle.store(false);
+            // Spawn failed: drop the registration so the global list doesn't
+            // retain a pointer to a thread that never started.
+            unregister_active(this_ptr);
             // Windows: raw_os_error() is a Win32 GetLastError() code, so
             // route it through the u32 (Win32Error) mapper rather than
             // from_errno's i64 discriminant-cast path.
@@ -306,6 +404,9 @@ impl Watcher {
             }
         };
         if free {
+            // No thread ever ran, so drop any registration before the Box is
+            // reclaimed (idempotent — usually a no-op on this path).
+            unregister_active(this);
             // watchlist freed by Drop on Box
             // SAFETY: this was heap-allocated by caller of init(); no borrow of it
             // is live here.
@@ -337,6 +438,21 @@ impl Watcher {
 
         Output::flush();
 
+        // Drop out of the active list before the allocation can go away so a
+        // later `stop_all_for_exit` can't observe a dangling pointer.
+        unregister_active(this);
+
+        // If we were stopped for process exit, the main thread is now tearing
+        // the heap down (`transpiler.deinit()` on the destruct path, and under
+        // ASAN `libc_exit` poisoning it on the plain path). Don't reclaim the
+        // Box here: freeing on this thread would race that teardown. The
+        // process is about to die; let it reclaim everything.
+        if STOPPING_FOR_EXIT.load(std::sync::atomic::Ordering::Acquire)
+            || bun_core::Global::is_exiting()
+        {
+            return Ok(());
+        }
+
         if !owner_still_alive {
             // SAFETY: `this` is the heap allocation from init(); the watcher thread
             // owns it now and no `&`/`&mut` borrow of it remains live (the scoped
@@ -356,8 +472,16 @@ impl Watcher {
         let owner_still_alive = match self.watch_loop() {
             Err(err) => {
                 self.watchloop_handle.store(false);
+                // Take `mutex` around `platform.stop()` and the `running`
+                // read: `stop_all_for_exit` on the main thread holds the same
+                // mutex while it calls `platform.stop()`, so without this the
+                // two `stop()` calls race (a double-`CloseHandle` on Windows).
+                // `running` is also written under `mutex` by
+                // `stop_all_for_exit`/`shutdown`, so read it here too.
+                self.mutex.lock();
                 self.platform.stop();
                 let running = self.running.load();
+                self.mutex.unlock();
                 if running {
                     (self.on_error)(self.ctx, err);
                 }

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -174,8 +174,7 @@ static ACTIVE_WATCHERS: bun_core::Mutex<Vec<usize>> = bun_core::Mutex::new(Vec::
 /// `Global::exit` (which is what sets `IS_EXITING`). Read by `register_active`
 /// (refuse new watchers) and the `thread_main` teardown guard (skip reclaiming
 /// the Box) so both cover both exit paths.
-static STOPPING_FOR_EXIT: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+static STOPPING_FOR_EXIT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 /// `extern "C"` thunk matching `bun_core::Global::ExitFn`, registered once so
 /// `Global::exit` stops every watcher before the heap teardown / ASAN poison.

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -197,13 +197,18 @@ pub fn stop_all_for_exit() {
     STOPPING_FOR_EXIT.store(true, std::sync::atomic::Ordering::Release);
     let list = ACTIVE_WATCHERS.lock();
     for &addr in list.iter() {
+        let ptr = addr as *mut Watcher;
         // SAFETY: entries are live `Box<Watcher>` allocations; they are removed
-        // (under `ACTIVE_WATCHERS`, held here) before the Box is reclaimed.
-        let w = unsafe { &mut *(addr as *mut Watcher) };
-        w.mutex.lock();
-        w.running.store(false);
-        w.platform.stop();
-        w.mutex.unlock();
+        // (under `ACTIVE_WATCHERS`, held here) before the Box is reclaimed. No
+        // `&mut Watcher` is formed (the watcher thread holds one in
+        // `thread_body`); these are raw-place projections, and every `platform`
+        // mutator takes `mutex` first, so the two `stop()`s cannot race.
+        unsafe {
+            (*ptr).mutex.lock();
+            (*ptr).running.store(false);
+            (*ptr).platform.stop();
+            (*ptr).mutex.unlock();
+        }
     }
 }
 
@@ -401,15 +406,17 @@ impl Watcher {
 
         Output::flush();
 
-        unregister_active(this);
-
         // Stopped for process exit: the main thread is tearing the heap down,
         // so don't race it by freeing the Box here — the process reclaims it.
+        // Stay registered so the abandoned Box remains reachable from
+        // `ACTIVE_WATCHERS` (keeps LeakSanitizer from reporting it).
         if STOPPING_FOR_EXIT.load(std::sync::atomic::Ordering::Acquire)
             || bun_core::Global::is_exiting()
         {
             return Ok(());
         }
+
+        unregister_active(this);
 
         if !owner_still_alive {
             // SAFETY: `this` is the heap allocation from init(); the watcher thread

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -197,18 +197,18 @@ pub fn stop_all_for_exit() {
     STOPPING_FOR_EXIT.store(true, std::sync::atomic::Ordering::Release);
     let list = ACTIVE_WATCHERS.lock();
     for &addr in list.iter() {
-        let ptr = addr as *mut Watcher;
         // SAFETY: entries are live `Box<Watcher>` allocations; they are removed
-        // (under `ACTIVE_WATCHERS`, held here) before the Box is reclaimed. No
-        // `&mut Watcher` is formed (the watcher thread holds one in
-        // `thread_body`); these are raw-place projections, and every `platform`
-        // mutator takes `mutex` first, so the two `stop()`s cannot race.
-        unsafe {
-            (*ptr).mutex.lock();
-            (*ptr).running.store(false);
-            (*ptr).platform.stop();
-            (*ptr).mutex.unlock();
-        }
+        // (under `ACTIVE_WATCHERS`, held here) before the Box is reclaimed.
+        // Shared access suffices, matching `shutdown()`: only the mutex and the
+        // `running` atomic are touched. `platform` is left alone; a thread
+        // still blocked in its platform wait never dispatches, and one that
+        // wakes sees `running == false` (checked under `mutex` in
+        // `dispatch_file_updates` and in `watch_loop`'s condition) and exits
+        // without touching the freed resolver state.
+        let me = unsafe { &*(addr as *const Watcher) };
+        me.mutex.lock();
+        me.running.store(false);
+        me.mutex.unlock();
     }
 }
 
@@ -437,8 +437,8 @@ impl Watcher {
         let owner_still_alive = match self.watch_loop() {
             Err(err) => {
                 self.watchloop_handle.store(false);
-                // `stop_all_for_exit` stops the platform and writes `running`
-                // under `mutex`; hold it here so the two `stop()`s can't race.
+                // `stop_all_for_exit` and `shutdown` write `running` under
+                // `mutex`; hold it so the stop and the read are one step.
                 self.mutex.lock();
                 self.platform.stop();
                 let running = self.running.load();

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -197,18 +197,21 @@ pub fn stop_all_for_exit() {
     STOPPING_FOR_EXIT.store(true, std::sync::atomic::Ordering::Release);
     let list = ACTIVE_WATCHERS.lock();
     for &addr in list.iter() {
+        let ptr = addr as *const Watcher;
         // SAFETY: entries are live `Box<Watcher>` allocations; they are removed
         // (under `ACTIVE_WATCHERS`, held here) before the Box is reclaimed.
-        // Shared access suffices, matching `shutdown()`: only the mutex and the
-        // `running` atomic are touched. `platform` is left alone; a thread
-        // still blocked in its platform wait never dispatches, and one that
-        // wakes sees `running == false` (checked under `mutex` in
-        // `dispatch_file_updates` and in `watch_loop`'s condition) and exits
-        // without touching the freed resolver state.
-        let me = unsafe { &*(addr as *const Watcher) };
-        me.mutex.lock();
-        me.running.store(false);
-        me.mutex.unlock();
+        // Raw-place projections so no `&Watcher` is retagged while the watcher
+        // thread holds a protected `&mut self` in `thread_body`; only the
+        // interior-mutable `mutex` and `running` are touched. `platform` is
+        // left alone: a thread still blocked in its platform wait never
+        // dispatches, and one that wakes sees `running == false` (checked
+        // under `mutex` in `dispatch_file_updates` and in `watch_loop`'s
+        // condition) and exits without touching the freed resolver state.
+        unsafe {
+            (*ptr).mutex.lock();
+            (*ptr).running.store(false);
+            (*ptr).mutex.unlock();
+        }
     }
 }
 
@@ -438,14 +441,16 @@ impl Watcher {
             Err(err) => {
                 self.watchloop_handle.store(false);
                 // `stop_all_for_exit` and `shutdown` write `running` under
-                // `mutex`; hold it so the stop and the read are one step.
+                // `mutex`; hold it across the callback, like
+                // `dispatch_file_updates`, so `ctx` can't be torn down between
+                // the `running` read and the `on_error` call.
                 self.mutex.lock();
                 self.platform.stop();
                 let running = self.running.load();
-                self.mutex.unlock();
                 if running {
                     (self.on_error)(self.ctx, err);
                 }
+                self.mutex.unlock();
                 running
             }
             Ok(()) => false,

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -151,45 +151,24 @@ pub trait WatcherContext {
     }
 }
 
-// ─── exit coordination ──────────────────────────────────────────────────────
-//
-// Global list of running watchers so that `stop_all_for_exit` can signal them
-// before the process tears down heap memory. The watcher thread accesses
-// globals like the resolver's directory cache (a process-global `BSSMap`
-// singleton) whose storage is freed by `transpiler.deinit()` on the
-// `BUN_DESTRUCT_VM_ON_EXIT` path and poisoned by ASAN's `libc_exit` teardown
-// otherwise. Without stopping the thread first those accesses become
-// use-after-free / use-after-poison (observed on the x64-asan CI lane as a
-// crash in `bustDirCache` on the "File Watcher" thread).
-//
-// Pointers are stored as `usize` because a raw `*mut Watcher` is not `Send`;
-// every access below reconstitutes the pointer under `ACTIVE_WATCHERS` and the
-// watcher's own `mutex`, matching the alias-allowed `*Watcher` model the rest
-// of the port uses (see `VirtualMachine::bun_watcher_ptr`).
+/// Running watchers, stored as `usize` (`*mut Watcher` is not `Send`). Every
+/// access reconstitutes the pointer under this lock plus the watcher's `mutex`.
 static ACTIVE_WATCHERS: bun_core::Mutex<Vec<usize>> = bun_core::Mutex::new(Vec::new());
 
-/// Set once `stop_all_for_exit` runs. `Global::is_exiting()` covers the plain
-/// `Global::exit` path, but `VirtualMachine::global_exit` calls
-/// `stop_all_for_exit` directly and tears the heap down *before* it reaches
-/// `Global::exit` (which is what sets `IS_EXITING`). Read by `register_active`
-/// (refuse new watchers) and the `thread_main` teardown guard (skip reclaiming
-/// the Box) so both cover both exit paths.
-static STOPPING_FOR_EXIT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+/// Set by `stop_all_for_exit`. `VirtualMachine::global_exit` stops watchers and
+/// tears the heap down before `Global::exit` sets `IS_EXITING`, so that flag
+/// alone can't gate the exit paths below.
+static STOPPING_FOR_EXIT: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
-/// `extern "C"` thunk matching `bun_core::Global::ExitFn`, registered once so
-/// `Global::exit` stops every watcher before the heap teardown / ASAN poison.
 extern "C" fn stop_all_for_exit_hook() {
     stop_all_for_exit();
 }
 
-/// Returns `false` if the process is already exiting, in which case the caller
-/// must not spawn a watcher thread — it would race the exit-time teardown.
-/// The check runs under the same lock `stop_all_for_exit` holds, so a watcher
-/// that wins the register race is already in the list when the stop sweep
-/// iterates.
+/// Returns `false` if the process is exiting; the caller must not spawn. Runs
+/// under the same lock as `stop_all_for_exit`, so a registered watcher is
+/// always seen by the stop sweep.
 fn register_active(this: *mut Watcher) -> bool {
-    // Install the `Global::exit` hook on first use. `add_early_exit_callback`
-    // dedups, but a `Once` keeps the lock traffic off the common path.
     static HOOK: std::sync::Once = std::sync::Once::new();
     HOOK.call_once(|| bun_core::Global::add_early_exit_callback(stop_all_for_exit_hook));
 
@@ -211,23 +190,16 @@ fn unregister_active(this: *mut Watcher) {
     }
 }
 
-/// Called from the exit path (main thread) before tearing down heap memory.
-/// Acquires each watcher's `mutex` — which serialises with the watcher
-/// thread's `dispatch_file_updates` (it holds `mutex` across `on_file_update`)
-/// — then sets `running = false` and closes the platform handle so the next
-/// loop iteration exits. Any `bust_dir_cache` already in flight completes
-/// before this returns. Callers are serialised by `ACTIVE_WATCHERS`; the
-/// platform `stop()` implementations are idempotent, so a second sequential
-/// call is a no-op.
+/// Stop every watcher before exit tears down heap memory the watcher thread
+/// dispatches through (the resolver's process-global `BSSMap` dir cache).
+/// Taking each watcher's `mutex` serialises with `dispatch_file_updates`, so
+/// any in-flight `bust_dir_cache` completes before this returns.
 pub fn stop_all_for_exit() {
     STOPPING_FOR_EXIT.store(true, std::sync::atomic::Ordering::Release);
     let list = ACTIVE_WATCHERS.lock();
     for &addr in list.iter() {
-        // SAFETY: pointers in the list are live `Box<Watcher>` allocations
-        // (removed in `thread_main`/`shutdown` before the Box is reclaimed,
-        // both of which also take `ACTIVE_WATCHERS`). We hold that lock here,
-        // so no entry can be freed concurrently. The watcher's own `mutex`
-        // serialises the `running`/`platform` writes with the watcher thread.
+        // SAFETY: entries are live `Box<Watcher>` allocations; they are removed
+        // (under `ACTIVE_WATCHERS`, held here) before the Box is reclaimed.
         let w = unsafe { &mut *(addr as *mut Watcher) };
         w.mutex.lock();
         w.running.store(false);
@@ -321,11 +293,8 @@ impl Watcher {
         // Watcher must be Send across the spawned thread boundary; we pass a
         // raw pointer (as usize) and uphold the safety contract manually.
         let this_ptr = std::ptr::from_mut::<Watcher>(self);
-        // If the process is already exiting, don't spawn — the watcher would
-        // race the exit-time teardown of the resolver's BSSMap singletons (and
-        // ASAN's `libc_exit` heap poisoning). Callers can't usefully recover
-        // and the process is about to die anyway. `register_active` also adds
-        // `self` to the global list so `stop_all_for_exit` can signal it.
+        // Don't spawn while the process is exiting — the thread would race the
+        // exit-time heap teardown.
         if !register_active(this_ptr) {
             return Ok(());
         }
@@ -350,8 +319,6 @@ impl Watcher {
         });
         self.thread = Some(handle.map_err(|e| {
             self.watchloop_handle.store(false);
-            // Spawn failed: drop the registration so the global list doesn't
-            // retain a pointer to a thread that never started.
             unregister_active(this_ptr);
             // Windows: raw_os_error() is a Win32 GetLastError() code, so
             // route it through the u32 (Win32Error) mapper rather than
@@ -403,8 +370,6 @@ impl Watcher {
             }
         };
         if free {
-            // No thread ever ran, so drop any registration before the Box is
-            // reclaimed (idempotent — usually a no-op on this path).
             unregister_active(this);
             // watchlist freed by Drop on Box
             // SAFETY: this was heap-allocated by caller of init(); no borrow of it
@@ -437,15 +402,10 @@ impl Watcher {
 
         Output::flush();
 
-        // Drop out of the active list before the allocation can go away so a
-        // later `stop_all_for_exit` can't observe a dangling pointer.
         unregister_active(this);
 
-        // If we were stopped for process exit, the main thread is now tearing
-        // the heap down (`transpiler.deinit()` on the destruct path, and under
-        // ASAN `libc_exit` poisoning it on the plain path). Don't reclaim the
-        // Box here: freeing on this thread would race that teardown. The
-        // process is about to die; let it reclaim everything.
+        // Stopped for process exit: the main thread is tearing the heap down,
+        // so don't race it by freeing the Box here — the process reclaims it.
         if STOPPING_FOR_EXIT.load(std::sync::atomic::Ordering::Acquire)
             || bun_core::Global::is_exiting()
         {
@@ -471,12 +431,8 @@ impl Watcher {
         let owner_still_alive = match self.watch_loop() {
             Err(err) => {
                 self.watchloop_handle.store(false);
-                // Take `mutex` around `platform.stop()` and the `running`
-                // read: `stop_all_for_exit` on the main thread holds the same
-                // mutex while it calls `platform.stop()`, so without this the
-                // two `stop()` calls race (a double-`CloseHandle` on Windows).
-                // `running` is also written under `mutex` by
-                // `stop_all_for_exit`/`shutdown`, so read it here too.
+                // `stop_all_for_exit` stops the platform and writes `running`
+                // under `mutex`; hold it here so the two `stop()`s can't race.
                 self.mutex.lock();
                 self.platform.stop();
                 let running = self.running.load();

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -380,18 +380,12 @@ impl WindowsWatcher {
     }
 
     pub(crate) fn stop(&mut self) {
-        // `stop()` can run twice in sequence at exit: once by
-        // `Watcher::stop_all_for_exit` on the main thread, then by the watcher
-        // thread's own error arm once its IOCP wait unblocks. Both callers
-        // hold `Watcher.mutex` around `platform.stop()`, so they're serialised
-        // — this isn't a concurrent race (`mem::replace` is not atomic and
-        // couldn't guard one). Snapshot-and-clear each handle so the second,
-        // serialised call sees `INVALID_HANDLE_VALUE` and skips the close — no
-        // double-`CloseHandle`.
+        // Idempotent: `stop_all_for_exit` and the watcher thread's error arm
+        // both call this (serialised by `Watcher.mutex`); clear the fields so
+        // the second call skips the close.
         let dir_handle = std::mem::replace(&mut self.watcher.dir_handle, w::INVALID_HANDLE_VALUE);
         let iocp = std::mem::replace(&mut self.iocp, w::INVALID_HANDLE_VALUE);
-        // SAFETY: each handle was opened in init() and is closed at most once
-        // (the replace above leaves INVALID_HANDLE_VALUE for a later call).
+        // SAFETY: each handle was opened in init() and is closed at most once.
         unsafe {
             if dir_handle != w::INVALID_HANDLE_VALUE {
                 w::CloseHandle(dir_handle);

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -380,10 +380,25 @@ impl WindowsWatcher {
     }
 
     pub(crate) fn stop(&mut self) {
-        // SAFETY: handles were opened in init() and are valid until stop() is called once.
+        // `stop()` can run twice in sequence at exit: once by
+        // `Watcher::stop_all_for_exit` on the main thread, then by the watcher
+        // thread's own error arm once its IOCP wait unblocks. Both callers
+        // hold `Watcher.mutex` around `platform.stop()`, so they're serialised
+        // — this isn't a concurrent race (`mem::replace` is not atomic and
+        // couldn't guard one). Snapshot-and-clear each handle so the second,
+        // serialised call sees `INVALID_HANDLE_VALUE` and skips the close — no
+        // double-`CloseHandle`.
+        let dir_handle = std::mem::replace(&mut self.watcher.dir_handle, w::INVALID_HANDLE_VALUE);
+        let iocp = std::mem::replace(&mut self.iocp, w::INVALID_HANDLE_VALUE);
+        // SAFETY: each handle was opened in init() and is closed at most once
+        // (the replace above leaves INVALID_HANDLE_VALUE for a later call).
         unsafe {
-            w::CloseHandle(self.watcher.dir_handle);
-            w::CloseHandle(self.iocp);
+            if dir_handle != w::INVALID_HANDLE_VALUE {
+                w::CloseHandle(dir_handle);
+            }
+            if iocp != w::INVALID_HANDLE_VALUE {
+                w::CloseHandle(iocp);
+            }
         }
     }
 }

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -380,9 +380,7 @@ impl WindowsWatcher {
     }
 
     pub(crate) fn stop(&mut self) {
-        // Idempotent: `stop_all_for_exit` and the watcher thread's error arm
-        // both call this (serialised by `Watcher.mutex`); clear the fields so
-        // the second call skips the close.
+        // Idempotent: clear the fields so a repeated call skips the close.
         let dir_handle = std::mem::replace(&mut self.watcher.dir_handle, w::INVALID_HANDLE_VALUE);
         let iocp = std::mem::replace(&mut self.iocp, w::INVALID_HANDLE_VALUE);
         // SAFETY: each handle was opened in init() and is closed at most once.

--- a/src/watcher/lib.rs
+++ b/src/watcher/lib.rs
@@ -38,6 +38,7 @@ pub use watcher_impl::{
     AnyResolveWatcher, ChangedFilePath, Event, FdOwnership, HashType, MAX_COUNT,
     MAX_EVICTION_COUNT, Op, PackageJSON, REQUIRES_FILE_DESCRIPTORS, WATCH_OPEN_FLAGS, WatchEvent,
     WatchItem, WatchItemColumns, WatchItemIndex, WatchItemKind, WatchList, Watcher, WatcherContext,
+    stop_all_for_exit,
 };
 
 // ─── upward-crate placeholders (CYCLEBREAK) ───────────────────────────────

--- a/test/cli/hot/hot-reload-exit-race.test.ts
+++ b/test/cli/hot/hot-reload-exit-race.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
+
+// Regression for the watcher-vs-exit race observed on the x64-asan CI lane.
+// A file-watcher thread dispatching through the resolver's BSSMap singletons
+// (the module-resolution dir cache, etc.) can touch that memory after the
+// exit path frees it — `transpiler.deinit()` on the BUN_DESTRUCT_VM_ON_EXIT
+// path, ASAN's `libc_exit` teardown otherwise — aborting with use-after-poison
+// from the "File Watcher" thread:
+//
+//   bust_dir_cache                (resolver BSSMap::remove)
+//   VirtualMachine::bust_dir_cache
+//   NewHotReloader::on_file_update
+//   process_inotify_event_batch   (File Watcher thread)
+//
+// The fix stops every watcher (under its own mutex, which serialises with the
+// thread's on_file_update dispatch) before the teardown frees that memory:
+// `Watcher::stop_all_for_exit`, called from `VirtualMachine::global_exit`
+// before `destroy()` and from `Global::exit` via an early-exit hook.
+//
+// The race is microseconds wide in production and can't be hit from user-space
+// alone, so this test uses three debug-build internal env vars to force it:
+//
+//  - BUN_INTERNAL_WATCHER_BUSTDIRCACHE_DELAY_MS: make
+//    `VirtualMachine::bust_dir_cache` sleep under the watcher's mutex, so the
+//    main thread has time to race ahead and free the singleton.
+//  - BUN_INTERNAL_GLOBALEXIT_FAST_PATH_TO_TRANSPILER_DEINIT: cut
+//    `global_exit` straight to `destroy()` (frees the BSSMap), skipping the
+//    worker/socket drains, so the free happens while the watcher still sleeps.
+//  - BUN_INTERNAL_GLOBALEXIT_LINGER_MS: linger in `Global::exit` after the
+//    teardown so the watcher's delayed bust_dir_cache lands on freed memory.
+//
+// All three are gated on `cfg(debug_assertions)` so they do nothing in
+// canary/release. The entrypoint's own directory is watched by --hot (the
+// parent-directory auto-watch in `append_file_maybe_lock`), so writing sibling
+// files in it fires the `.directory` branch of `on_file_update` →
+// `bust_dir_cache` — no extra hook needed to reach the crash site.
+//
+// Requires BOTH ASAN (to catch the use-after-free) and a debug-assertions
+// build (for the hooks above): `bun-debug` / any debug-ASAN build. The CI
+// release-ASAN binary (`bun-asan`) has `debug_assertions` off — the hooks
+// compile out there — so skip rather than pass vacuously.
+test.skipIf(!isASAN || !isDebug)(
+  "--hot exits cleanly while watcher is dispatching bust_dir_cache",
+  async () => {
+    using dir = tempDir("hot-exit-race", {
+      "script.ts":
+        `import { writeFileSync } from "node:fs";\n` +
+        `console.log("READY");\n` +
+        // Keep directory events flowing at the watcher throughout, so when the
+        // exit fires the watcher is almost certainly sleeping inside
+        // bust_dir_cache's delay hook. Writes land in the entrypoint's own
+        // (watched) directory.
+        `setInterval(() => { try { writeFileSync("./x" + ((Math.random() * 16) | 0), "x"); } catch {} }, 1);\n` +
+        `setTimeout(() => process.exit(0), 300);\n` +
+        `setInterval(() => {}, 10_000);\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--hot", "run", "script.ts"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        BUN_INTERNAL_WATCHER_BUSTDIRCACHE_DELAY_MS: "50",
+        BUN_INTERNAL_GLOBALEXIT_FAST_PATH_TO_TRANSPILER_DEINIT: "1",
+        BUN_INTERNAL_GLOBALEXIT_LINGER_MS: "200",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    // The script prints READY, churns the watched directory for ~300ms, then
+    // exits. Collect everything and wait for exit — without the fix the File
+    // Watcher thread aborts (SIGABRT) mid-bust_dir_cache, so `exited` resolves
+    // with the signal and stderr carries the AddressSanitizer report.
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    if (exitCode !== 0 || proc.signalCode !== null) {
+      console.error(`exitCode=${exitCode}, signal=${proc.signalCode}, stderr:\n${stderr}`);
+    }
+    expect(stdout).toContain("READY");
+    expect(stderr).not.toContain("AddressSanitizer");
+    expect(stderr).not.toContain("use-after-poison");
+    expect(proc.signalCode).not.toBe("SIGABRT");
+    expect(exitCode).toBe(0);
+  },
+  20_000,
+);
+// ^ explicit timeout: when the fix is absent the child reports the
+// use-after-free on the File Watcher thread but the crashed thread keeps the
+// stderr pipe's write end open, so the parent's `stderr` read only EOFs once
+// the process is fully reaped (~7s). The assertion must win before the test
+// times out, so the budget is set above that. With the fix the child exits
+// cleanly in ~2s.


### PR DESCRIPTION
## What

Stops every file-watcher thread before the process exit path tears down heap memory, fixing a use-after-free on the "File Watcher" thread observed on the x64-asan CI lane.

## Why

The file-watcher thread dispatches module-reload events through the resolver's process-global `BSSMap` singletons (the directory cache, etc.) via `bust_dir_cache`. On exit those singletons are freed — by `transpiler.deinit()` on the `BUN_DESTRUCT_VM_ON_EXIT` path, and poisoned by ASAN's `libc_exit` teardown otherwise — while the watcher thread may still be inside `bust_dir_cache`. The result is a heap-use-after-free / use-after-poison reported from thread T2 (File Watcher):

```
==…==ERROR: AddressSanitizer: heap-use-after-free … thread T2 (File Watcher)
  bust_dir_cache                (resolver BSSMap::remove)
  VirtualMachine::bust_dir_cache
  NewHotReloader::on_file_update
  process_inotify_event_batch   (File Watcher thread)
```

## How

`Watcher::stop_all_for_exit()` — a process-global registry of running watchers plus a stop sweep that, for each watcher, takes the watcher's own `mutex`, sets `running = false`, and calls `platform.stop()` to close the inotify/kqueue/RDCW handle so the loop exits. Taking the watcher's mutex serialises with the platform backend's own `mutex` + `if running` guard around `on_file_update` (INotify/KEvent/Windows all hold it across dispatch), so any in-flight `bust_dir_cache` finishes before the sweep returns.

It's called from:
- `VirtualMachine::global_exit` before `destroy()` (the `BUN_DESTRUCT_VM_ON_EXIT` path — CI forces this on the sanitizer lanes), and
- `Global::exit` via a new `bun_core` early-exit hook (`bun_watcher` sits above `bun_core`, so it registers the hook rather than `bun_core` calling up).

`start()` also refuses to spawn once the process is already exiting, and the watcher thread skips reclaiming its own `Box` when exiting so it can't race the heap teardown.

## Test

`test/cli/hot/hot-reload-exit-race.test.ts`, gated on `isASAN`. The race is microseconds wide in production and can't be hit from user-space alone, so the test drives it with three debug-only (`cfg(debug_assertions)`) internal env-var hooks that widen the window (a `bust_dir_cache` delay on the watcher thread, a fast-path to `destroy()` in `global_exit`, and a post-teardown linger in `Global::exit`). Verified:

- **without the fix:** the child reports `AddressSanitizer: heap-use-after-free … thread T2 (File Watcher)` and the test fails on the `not.toContain("AddressSanitizer")` assertion.
- **with the fix:** the child exits cleanly (exit 0, no ASAN report) in ~2s.

## Note

An earlier revision of this PR put the fix in the `.zig` reference files, which are no longer compiled (the runtime is built from the `.rs` siblings). That revision was dead code and the test passed vacuously. This revision implements the fix entirely in the compiled Rust sources.


## Rebase note (June 2026)

Rebased onto current main across a large upstream refactor of the watcher and VM teardown. This was a re-port rather than a mechanical rebase:

- `VirtualMachine::global_exit` now runs a phased `teardown()`; `stop_all_for_exit()` is called right before it on the destruct path (the BSSMap free moved into teardown's free-owners phase via `destroy()` → `transpiler.deinit()`).
- Upstream rewrote `KEventWatcher` around the safe `bun_sys::kevent` wrapper with `fd: Fd` and an idempotent `stop()`, which makes this PR's earlier macOS guards (`Option<Fd>` unwraps, raw `kevent` errno discrimination) unnecessary — they were dropped.
- Upstream's `Watcher` now has `thread_body()`/`dispatch_file_updates()` (the latter already mutex+`running`-guarded); the registry, the spawn-refusal in `start()`, the exit guard in `thread_main`, and the mutex around the error-arm `platform.stop()` were re-applied onto that structure. `WindowsWatcher::stop()` idempotency re-applied unchanged.

Re-verified on the new base: without the fix (the two `stop_all_for_exit` call sites reverted, hooks kept) the child reports `AddressSanitizer: heap-use-after-free … (File Watcher)` and the test fails; with the fix it exits clean. All 17 hot/watch tests pass; `cargo check --target aarch64-apple-darwin` clean.
