### PR TITLE
Fix panic when buffering ReadableStream with detached Blob source

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,8 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    var empty: Blob.Any = .{ .InternalBlob = .{ .bytes = .init(bun.default_allocator) } };
+    return empty.toPromise(globalThis, action);
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,7 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    var empty: Blob.Any = .{ .InternalBlob = .{ .bytes = .init(bun.default_allocator) } };
+    var empty: Blob.Any = .{ .Blob = Blob.initEmpty(globalThis) };
     return empty.toPromise(globalThis, action);
 }
 

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1205,3 +1205,16 @@ it("handles exceptions during empty stream creation", () => {
     throw new Error("not stack overflow");
   }).toThrow("not stack overflow");
 });
+
+it("does not crash when buffering a Response body stream whose underlying source has been consumed", async () => {
+  // Regression: calling text()/bytes()/etc. on a ReadableStream whose
+  // underlying Blob source has been detached must not trigger an assertion.
+  const resp = new Response("Hello World 58");
+  const body = resp.body;
+  expect(await body.text()).toBe("Hello World 58");
+  for (const method of ["text", "bytes", "arrayBuffer", "blob", "json"]) {
+    try {
+      await body[method]();
+    } catch {}
+  }
+});


### PR DESCRIPTION
Fuzzilli found an assertion failure (`Expected an exception to be thrown`) triggered from `BlobInternalReadableStreamSourcePrototype__textCallback` → `ByteBlobLoader.toBufferedValue`.

When the underlying `Blob.Store` of a `ByteBlobLoader` has already been detached (e.g. the stream was fully pulled or `toAnyBlob` was called before), `toAnyBlob` returns `null` and `toBufferedValue` returned `.zero` without throwing an exception. That violates the host-call contract: returning `.zero` from a host function requires a pending exception, which triggers the assertion in `TopExceptionScope.assertExceptionPresenceMatches`.

Return a resolved promise backed by an empty `InternalBlob` in this case so `text()`/`bytes()`/etc. produce a sensible empty value rather than crashing.