### PR TITLE
usockets: work around long unix socket paths on macOS

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1071,7 +1071,13 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int
 #include <sys/stat.h>
 #include <stddef.h>
 
-static LIBUS_SOCKET_DESCRIPTOR bsd_create_unix_socket_address(const char *path, size_t path_len, int* dirfd_linux_workaround_for_unix_path_len, struct sockaddr_un *server_address, size_t* addrlen) {
+#if defined(__APPLE__)
+// Per-thread chdir. Not declared in any public header, but a stable syscall since macOS 10.5.
+// Passing -1 clears the per-thread cwd override.
+extern int __pthread_fchdir(int fd);
+#endif
+
+static LIBUS_SOCKET_DESCRIPTOR bsd_create_unix_socket_address(const char *path, size_t path_len, int* dirfd_workaround_for_unix_path_len, struct sockaddr_un *server_address, size_t* addrlen) {
     memset(server_address, 0, sizeof(struct sockaddr_un));
     server_address->sun_family = AF_UNIX;
 
@@ -1125,7 +1131,7 @@ static LIBUS_SOCKET_DESCRIPTOR bsd_create_unix_socket_address(const char *path, 
                 return LIBUS_SOCKET_ERROR;
             }
 
-            *dirfd_linux_workaround_for_unix_path_len = socket_dir_fd;
+            *dirfd_workaround_for_unix_path_len = socket_dir_fd;
             return 0;
         } else if (path_len < sizeof(server_address->sun_path)) {
             memcpy(server_address->sun_path, path, path_len);
@@ -1135,6 +1141,45 @@ static LIBUS_SOCKET_DESCRIPTOR bsd_create_unix_socket_address(const char *path, 
                 *addrlen = offsetof(struct sockaddr_un, sun_path) + path_len;
             }
 
+            return 0;
+        }
+    #endif
+
+    #if defined(__APPLE__)
+        // sun_path is 104 bytes on macOS. /dev/fd/N/ is not traversable like /proc/self/fd/N/ on Linux,
+        // so instead we open the parent directory and let the caller __pthread_fchdir() into it and
+        // bind/connect with a relative basename.
+        if (path_len >= sizeof(server_address->sun_path)) {
+            size_t dirname_len = path_len;
+            while (dirname_len > 1 && path[dirname_len - 1] != '/') {
+                dirname_len--;
+            }
+
+            size_t basename_len = path_len - dirname_len;
+            if (dirname_len < 2 || basename_len + 1 >= sizeof(server_address->sun_path)) {
+                errno = ENAMETOOLONG;
+                return LIBUS_SOCKET_ERROR;
+            }
+
+            char dirname_buf[4096];
+            if (dirname_len + 1 > sizeof(dirname_buf)) {
+                errno = ENAMETOOLONG;
+                return LIBUS_SOCKET_ERROR;
+            }
+
+            memcpy(dirname_buf, path, dirname_len);
+            dirname_buf[dirname_len] = 0;
+
+            int socket_dir_fd = open(dirname_buf, O_CLOEXEC | O_RDONLY | O_DIRECTORY);
+            if (socket_dir_fd == -1) {
+                errno = ENAMETOOLONG;
+                return LIBUS_SOCKET_ERROR;
+            }
+
+            memcpy(server_address->sun_path, path + dirname_len, basename_len);
+            server_address->sun_path[basename_len] = 0;
+
+            *dirfd_workaround_for_unix_path_len = socket_dir_fd;
             return 0;
         }
     #endif
@@ -1186,18 +1231,35 @@ static LIBUS_SOCKET_DESCRIPTOR internal_bsd_create_listen_socket_unix(const char
 }
 
 LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket_unix(const char *path, size_t len, int options, int* error) {
-    int dirfd_linux_workaround_for_unix_path_len = -1;
+    int dirfd_workaround_for_unix_path_len = -1;
     struct sockaddr_un server_address;
     size_t addrlen = 0;
-    if (bsd_create_unix_socket_address(path, len, &dirfd_linux_workaround_for_unix_path_len, &server_address, &addrlen)) {
+    if (bsd_create_unix_socket_address(path, len, &dirfd_workaround_for_unix_path_len, &server_address, &addrlen)) {
         return LIBUS_SOCKET_ERROR;
     }
 
+#if defined(__APPLE__)
+    if (dirfd_workaround_for_unix_path_len != -1) {
+        if (__pthread_fchdir(dirfd_workaround_for_unix_path_len) != 0) {
+            close(dirfd_workaround_for_unix_path_len);
+            errno = ENAMETOOLONG;
+            return LIBUS_SOCKET_ERROR;
+        }
+    }
+#endif
+
     LIBUS_SOCKET_DESCRIPTOR listenFd = internal_bsd_create_listen_socket_unix(path, options, &server_address, addrlen, error);
 
-#if defined(__linux__)
-    if (dirfd_linux_workaround_for_unix_path_len != -1) {
-        close(dirfd_linux_workaround_for_unix_path_len);
+#if defined(__APPLE__)
+    if (dirfd_workaround_for_unix_path_len != -1) {
+        int saved_errno = errno;
+        __pthread_fchdir(-1);
+        close(dirfd_workaround_for_unix_path_len);
+        errno = saved_errno;
+    }
+#elif defined(__linux__)
+    if (dirfd_workaround_for_unix_path_len != -1) {
+        close(dirfd_workaround_for_unix_path_len);
     }
 #endif
 
@@ -1545,18 +1607,35 @@ static LIBUS_SOCKET_DESCRIPTOR internal_bsd_create_connect_socket_unix(const cha
 LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket_unix(const char *server_path, size_t len, int options) {
     struct sockaddr_un server_address;
     size_t addrlen = 0;
-    int dirfd_linux_workaround_for_unix_path_len = -1;
-    if (bsd_create_unix_socket_address(server_path, len, &dirfd_linux_workaround_for_unix_path_len, &server_address, &addrlen)) {
+    int dirfd_workaround_for_unix_path_len = -1;
+    if (bsd_create_unix_socket_address(server_path, len, &dirfd_workaround_for_unix_path_len, &server_address, &addrlen)) {
         return LIBUS_SOCKET_ERROR;
     }
 
+#if defined(__APPLE__)
+    if (dirfd_workaround_for_unix_path_len != -1) {
+        if (__pthread_fchdir(dirfd_workaround_for_unix_path_len) != 0) {
+            close(dirfd_workaround_for_unix_path_len);
+            errno = ENAMETOOLONG;
+            return LIBUS_SOCKET_ERROR;
+        }
+    }
+#endif
+
     LIBUS_SOCKET_DESCRIPTOR fd = internal_bsd_create_connect_socket_unix(server_path, len, options, &server_address, addrlen);
 
-    #if defined(__linux__)
-    if (dirfd_linux_workaround_for_unix_path_len != -1) {
-        close(dirfd_linux_workaround_for_unix_path_len);
+#if defined(__APPLE__)
+    if (dirfd_workaround_for_unix_path_len != -1) {
+        int saved_errno = errno;
+        __pthread_fchdir(-1);
+        close(dirfd_workaround_for_unix_path_len);
+        errno = saved_errno;
     }
-    #endif
+#elif defined(__linux__)
+    if (dirfd_workaround_for_unix_path_len != -1) {
+        close(dirfd_workaround_for_unix_path_len);
+    }
+#endif
 
     return fd;
 }

--- a/test/js/web/fetch/fetch.unix.test.ts
+++ b/test/js/web/fetch/fetch.unix.test.ts
@@ -1,6 +1,6 @@
 import { serve, ServeOptions, Server } from "bun";
 import { afterAll, expect, it } from "bun:test";
-import { rmSync } from "fs";
+import { mkdirSync, rmSync } from "fs";
 import { isWindows, tmpdirSync } from "harness";
 import { request } from "http";
 import { join } from "path";
@@ -92,6 +92,37 @@ if (process.platform === "linux") {
     server.stop(true);
     try {
       rmSync(unix, {});
+    } catch (e) {}
+  });
+}
+
+if (process.platform === "linux" || process.platform === "darwin") {
+  it("can workaround socket path length limit when only the directory is long", async () => {
+    const base = tmpdirSync();
+    let dir = base;
+    while (dir.length + "/fetch-unix.sock".length < 130) {
+      dir = join(dir, Buffer.alloc(40, "a").toString());
+    }
+    mkdirSync(dir, { recursive: true });
+    const unix = join(dir, "fetch-unix.sock");
+    expect(unix.length).toBeGreaterThanOrEqual(108);
+
+    using server = Bun.serve({
+      unix,
+      fetch(req) {
+        return new Response(req.body);
+      },
+    });
+
+    for (let i = 0; i < 5; i++) {
+      const response = await fetch("http://localhost/hello", { method: "POST", body: String(i), unix });
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe(String(i));
+    }
+
+    server.stop(true);
+    try {
+      rmSync(base, { recursive: true, force: true });
     } catch (e) {}
   });
 }


### PR DESCRIPTION
## Summary
- On macOS, when a unix socket path exceeds `sun_path` (104 bytes), open the parent directory and use `__pthread_fchdir()` (per-thread cwd, stable since 10.5) to bind/connect with a relative basename, then revert with `__pthread_fchdir(-1)`.
- Mirrors the existing Linux `/proc/self/fd/N/` workaround. `/dev/fd/N/` on macOS is not traversable, so the Linux trick doesn't apply directly.
- Renamed `dirfd_linux_workaround_for_unix_path_len` → `dirfd_workaround_for_unix_path_len` since it's no longer Linux-only.

## Test plan
- [x] New test in `test/js/web/fetch/fetch.unix.test.ts` creates a socket path >108 bytes and verifies `Bun.serve({ unix })` + `fetch({ unix })` round-trip on both Linux and macOS.
- [x] `bun bd test test/js/web/fetch/fetch.unix.test.ts` — 6 pass, 0 fail
- [x] `USE_SYSTEM_BUN=1 bun test ... -t "only the directory is long"` fails with `ENAMETOOLONG` on macOS (confirms test exercises the new path)