### PR TITLE
net: match Node.js unix socket unlink semantics

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1163,12 +1163,6 @@ static LIBUS_SOCKET_DESCRIPTOR internal_bsd_create_listen_socket_unix(const char
         return LIBUS_SOCKET_ERROR;
     }
 
-#ifdef _WIN32
-    _unlink(path);
-#else
-    unlink(path);
-#endif
-
     if (us_internal_bind_and_listen(listenFd, (struct sockaddr *) server_address, (socklen_t) addrlen, 512, error)) {
         #if defined(_WIN32)
           int shouldSimulateENOENT = WSAGetLastError() == WSAENETDOWN;

--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -430,11 +430,11 @@ fn doStop(this: *Listener, force_close: bool) void {
     if (this.listener == .none) return;
     const listener = this.listener;
 
+    // Unlink before any close path (including ctx.deinit below) can release the fd.
+    if (listener == .uws) this.unlinkUnixSocketPath();
+
     defer switch (listener) {
-        .uws => |socket| {
-            this.unlinkUnixSocketPath();
-            socket.close(this.ssl);
-        },
+        .uws => |socket| socket.close(this.ssl),
         .namedPipe => |namedPipe| if (Environment.isWindows) namedPipe.closePipeAndDeinit(),
         .none => {},
     };

--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -431,7 +431,10 @@ fn doStop(this: *Listener, force_close: bool) void {
     const listener = this.listener;
 
     defer switch (listener) {
-        .uws => |socket| socket.close(this.ssl),
+        .uws => |socket| {
+            this.unlinkUnixSocketPath();
+            socket.close(this.ssl);
+        },
         .namedPipe => |namedPipe| if (Environment.isWindows) namedPipe.closePipeAndDeinit(),
         .none => {},
     };
@@ -463,11 +466,25 @@ pub fn finalize(this: *Listener) callconv(.c) void {
     const listener = this.listener;
     this.listener = .none;
     switch (listener) {
-        .uws => |socket| socket.close(this.ssl),
+        .uws => |socket| {
+            this.unlinkUnixSocketPath();
+            socket.close(this.ssl);
+        },
         .namedPipe => |namedPipe| if (Environment.isWindows) namedPipe.closePipeAndDeinit(),
         .none => {},
     }
     this.deinit();
+}
+
+/// Match Node.js/libuv: unlink the unix socket file before closing the listening fd.
+/// Unlinking after close would race with another process creating a socket at the same path.
+fn unlinkUnixSocketPath(this: *const Listener) void {
+    if (this.connection != .unix) return;
+    const path = this.connection.unix;
+    // Abstract sockets (Linux) start with a NUL byte and have no filesystem entry.
+    if (path.len == 0 or path[0] == 0) return;
+    var buf: bun.PathBuffer = undefined;
+    _ = bun.sys.unlink(bun.path.z(path, &buf));
 }
 
 pub fn deinit(this: *Listener) void {

--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -483,8 +483,9 @@ fn unlinkUnixSocketPath(this: *const Listener) void {
     const path = this.connection.unix;
     // Abstract sockets (Linux) start with a NUL byte and have no filesystem entry.
     if (path.len == 0 or path[0] == 0) return;
-    var buf: bun.PathBuffer = undefined;
-    _ = bun.sys.unlink(bun.path.z(path, &buf));
+    const buf = bun.path_buffer_pool.get();
+    defer bun.path_buffer_pool.put(buf);
+    _ = bun.sys.unlink(bun.path.z(path, buf));
 }
 
 pub fn deinit(this: *Listener) void {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1550,6 +1550,13 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
             this.notifyInspectorServerStopped();
 
+            if (this.config.address == .unix) {
+                const path = this.config.address.unix;
+                if (path.len > 0 and path[0] != 0) {
+                    _ = bun.sys.unlink(path);
+                }
+            }
+
             if (!abrupt) {
                 listener.close();
             } else if (!this.flags.terminated) {

--- a/test/js/bun/http/server-url-invalid.test.ts
+++ b/test/js/bun/http/server-url-invalid.test.ts
@@ -1,15 +1,26 @@
 import { expect, test } from "bun:test";
+import { tempDir } from "harness";
 
 test("server.url does not crash when unix socket path produces invalid URL", () => {
   // Passing an object as the unix socket path causes the URL formatter to produce
   // a string like "unix://[object Bun]" which is not a valid URL. Accessing
   // server.url should throw a proper JS error instead of crashing.
-  using server = Bun.serve({
-    // @ts-expect-error: intentionally passing invalid type
-    unix: Bun,
-    fetch() {
-      return new Response("ok");
-    },
-  });
-  expect(() => server.url).toThrow();
+  //
+  // The socket path is relative, so run inside a fresh temp dir to avoid
+  // EADDRINUSE from a stale socket file left in cwd by an earlier run.
+  using dir = tempDir("server-url-invalid", {});
+  const prev = process.cwd();
+  process.chdir(String(dir));
+  try {
+    using server = Bun.serve({
+      // @ts-expect-error: intentionally passing invalid type
+      unix: Bun,
+      fetch() {
+        return new Response("ok");
+      },
+    });
+    expect(() => server.url).toThrow();
+  } finally {
+    process.chdir(prev);
+  }
 });

--- a/test/js/bun/net/unix-socket-unlink.test.ts
+++ b/test/js/bun/net/unix-socket-unlink.test.ts
@@ -1,0 +1,139 @@
+import { test, expect, describe } from "bun:test";
+import { tempDir, isWindows, isLinux } from "harness";
+import { existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createServer, connect } from "node:net";
+import { once } from "node:events";
+
+// Node.js/libuv behavior for unix domain sockets:
+// - bind() does NOT unlink an existing socket file (returns EADDRINUSE)
+// - close() DOES unlink the socket file it created
+// Bun previously had this inverted (unlinked before bind, leaked on close).
+
+describe.skipIf(isWindows)("unix domain socket unlink", () => {
+  test("Bun.listen removes the socket file on stop()", () => {
+    using dir = tempDir("uds-unlink-listen", {});
+    const sock = join(String(dir), "a.sock");
+
+    const listener = Bun.listen({
+      unix: sock,
+      socket: { data() {}, open() {} },
+    });
+    expect(existsSync(sock)).toBe(true);
+    listener.stop();
+    expect(existsSync(sock)).toBe(false);
+  });
+
+  test("Bun.listen removes the socket file on stop(true)", () => {
+    using dir = tempDir("uds-unlink-listen-force", {});
+    const sock = join(String(dir), "a.sock");
+
+    const listener = Bun.listen({
+      unix: sock,
+      socket: { data() {}, open() {} },
+    });
+    expect(existsSync(sock)).toBe(true);
+    listener.stop(true);
+    expect(existsSync(sock)).toBe(false);
+  });
+
+  test("Bun.serve removes the socket file on stop()", async () => {
+    using dir = tempDir("uds-unlink-serve", {});
+    const sock = join(String(dir), "a.sock");
+
+    const server = Bun.serve({
+      unix: sock,
+      fetch: () => new Response("ok"),
+    });
+    expect(existsSync(sock)).toBe(true);
+    await server.stop();
+    expect(existsSync(sock)).toBe(false);
+  });
+
+  test("Bun.serve removes the socket file on stop(true)", async () => {
+    using dir = tempDir("uds-unlink-serve-force", {});
+    const sock = join(String(dir), "a.sock");
+
+    const server = Bun.serve({
+      unix: sock,
+      fetch: () => new Response("ok"),
+    });
+    expect(existsSync(sock)).toBe(true);
+    await server.stop(true);
+    expect(existsSync(sock)).toBe(false);
+  });
+
+  test("net.Server removes the socket file on close()", async () => {
+    using dir = tempDir("uds-unlink-net", {});
+    const sock = join(String(dir), "a.sock");
+
+    const server = createServer();
+    server.listen(sock);
+    await once(server, "listening");
+    expect(existsSync(sock)).toBe(true);
+
+    server.close();
+    await once(server, "close");
+    expect(existsSync(sock)).toBe(false);
+  });
+
+  test("Bun.listen does not unlink an existing file before bind", () => {
+    using dir = tempDir("uds-no-prebind-unlink", {});
+    const sock = join(String(dir), "a.sock");
+
+    const first = Bun.listen({
+      unix: sock,
+      socket: { data() {}, open() {} },
+    });
+
+    // A second listener at the same path must fail; it must not silently
+    // unlink the live socket out from under the first listener.
+    expect(() => {
+      Bun.listen({
+        unix: sock,
+        socket: { data() {}, open() {} },
+      });
+    }).toThrow();
+
+    // The original socket file is untouched.
+    expect(existsSync(sock)).toBe(true);
+
+    first.stop();
+    expect(existsSync(sock)).toBe(false);
+  });
+
+  test("net.Server fails with EADDRINUSE on a stale socket file", async () => {
+    using dir = tempDir("uds-eaddrinuse", {});
+    const sock = join(String(dir), "a.sock");
+    // Node.js leaves stale socket files alone and returns EADDRINUSE.
+    writeFileSync(sock, "");
+
+    const server = createServer();
+    server.listen(sock);
+    const [err] = await once(server, "error");
+    expect(err.code).toBe("EADDRINUSE");
+  });
+
+  test("can re-listen on the same path after stop()", async () => {
+    using dir = tempDir("uds-relisten", {});
+    const sock = join(String(dir), "a.sock");
+
+    const a = Bun.listen({ unix: sock, socket: { data() {}, open() {} } });
+    a.stop();
+    expect(existsSync(sock)).toBe(false);
+
+    const b = Bun.listen({ unix: sock, socket: { data() {}, open() {} } });
+    expect(existsSync(sock)).toBe(true);
+    b.stop();
+    expect(existsSync(sock)).toBe(false);
+  });
+
+  test.skipIf(!isLinux)("abstract sockets are not unlinked", () => {
+    const listener = Bun.listen({
+      unix: "\0bun-uds-unlink-test-" + Math.random().toString(36).slice(2),
+      socket: { data() {}, open() {} },
+    });
+    // Just verify stop() doesn't crash or throw on abstract sockets.
+    listener.stop();
+  });
+});

--- a/test/js/bun/net/unix-socket-unlink.test.ts
+++ b/test/js/bun/net/unix-socket-unlink.test.ts
@@ -1,9 +1,9 @@
-import { test, expect, describe } from "bun:test";
-import { tempDir, isWindows, isLinux } from "harness";
-import { existsSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
-import { createServer, connect } from "node:net";
+import { describe, expect, test } from "bun:test";
+import { isLinux, isWindows, tempDir } from "harness";
 import { once } from "node:events";
+import { existsSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { join } from "node:path";
 
 // Node.js/libuv behavior for unix domain sockets:
 // - bind() does NOT unlink an existing socket file (returns EADDRINUSE)

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -8,7 +8,7 @@
 import { bunEnv, bunExe, exampleSite, randomPort, tls as tlsCert } from "harness";
 import { createTest } from "node-harness";
 import { EventEmitter, once } from "node:events";
-import nodefs, { unlinkSync } from "node:fs";
+import nodefs from "node:fs";
 import http, {
   Agent,
   createServer,
@@ -1253,7 +1253,6 @@ describe("server.address should be valid IP", () => {
         done(err);
       } finally {
         server.close();
-        unlinkSync(socketPath);
       }
     });
   });


### PR DESCRIPTION
## What

Bun's unix domain socket lifecycle was inverted from Node.js/libuv:

|  | Node.js / libuv | Bun (before) |
|---|---|---|
| Existing file at bind time | `EADDRINUSE` | Silently `unlink()`s it and binds anyway |
| Socket file after `close()` | Removed | Left on disk |

This meant Bun could silently steal a live socket out from under another process on `listen()`, and leaked `.sock` files on `stop()`/`close()`.

## How

- `packages/bun-usockets/src/bsd.c` — drop the unconditional pre-bind `unlink()`
- `src/bun.js/api/bun/socket/Listener.zig` — unlink the path in `doStop()`/`finalize()` immediately before closing the listening fd (same ordering as `uv__pipe_close` to avoid the rebind race). Skips abstract sockets and Windows named pipes.
- `src/bun.js/api/server.zig` — same for `Bun.serve` in `stopListening()`

This revisits #22401, which was closed by stale-bot. That PR coupled the fix with a `UnixOrHost` ownership refactor that introduced a use-after-clear in the error path. This change keeps `connection.unix` as the existing owned `[]const u8` and just null-terminates into a stack buffer for `bun.sys.unlink`, so none of that refactor is needed.

## Tests

New `test/js/bun/net/unix-socket-unlink.test.ts` covers `Bun.listen`, `Bun.serve`, `net.Server`, EADDRINUSE on a stale file, re-listening after stop, and abstract sockets. Removed a now-redundant manual `unlinkSync` from the issue #6413 test in `node-http.test.ts`.