### PR TITLE
os: cgroup-aware availableParallelism / hardwareConcurrency on Linux

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "7da058f2ad4432ec5547dbfc3a5b6d544bb05d1d";
+export const WEBKIT_VERSION = "c2010c47d12c525d36adabe3a17b2eb6ec850960";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/bun.js/bindings/WTF.zig
+++ b/src/bun.js/bindings/WTF.zig
@@ -1,6 +1,15 @@
 pub const WTF = struct {
     extern fn WTF__parseDouble(bytes: [*]const u8, length: usize, counted: *usize) f64;
 
+    extern fn WTF__numberOfProcessorCores() c_int;
+
+    /// On Linux, this is min(sysconf(_SC_NPROCESSORS_ONLN), sched_getaffinity count, cgroup cpu.max quota).
+    /// Result is cached after the first call.
+    pub fn numberOfProcessorCores() u32 {
+        jsc.markBinding(@src());
+        return @intCast(@max(1, WTF__numberOfProcessorCores()));
+    }
+
     extern fn WTF__releaseFastMallocFreeMemoryForThisThread() void;
 
     pub fn releaseFastMallocFreeMemoryForThisThread() void {

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -215,12 +215,7 @@
 #include <dlfcn.h>
 #endif
 
-#ifdef __APPLE__
-#include <sys/sysctl.h>
-#elif defined(__linux__)
-// for sysconf
-#include <unistd.h>
-#endif
+#include <wtf/NumberOfCores.h>
 
 using namespace Bun;
 
@@ -1967,18 +1962,7 @@ void GlobalObject::finishCreation(VM& vm)
 
     m_navigatorObject.initLater(
         [](const Initializer<JSObject>& init) {
-            int cpuCount = 0;
-#ifdef __APPLE__
-            size_t count_len = sizeof(cpuCount);
-            sysctlbyname("hw.logicalcpu", &cpuCount, &count_len, NULL, 0);
-#elif OS(WINDOWS)
-            SYSTEM_INFO sysinfo;
-            GetSystemInfo(&sysinfo);
-            cpuCount = sysinfo.dwNumberOfProcessors;
-#else
-            // TODO: windows
-            cpuCount = sysconf(_SC_NPROCESSORS_ONLN);
-#endif
+            int cpuCount = WTF::numberOfProcessorCores();
 
             auto str = WTF::String::fromUTF8(Bun__userAgent);
             JSC::Identifier userAgentIdentifier = JSC::Identifier::fromString(init.vm, "userAgent"_s);

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -105,6 +105,19 @@ extern "C" ssize_t bun_sysconf__SC_CLK_TCK()
 #endif
 }
 
+// Host CPU count, ignoring sched_getaffinity and cgroup cpu.max.
+// Used to size os.cpus() so it matches the native cpus() result count.
+extern "C" int32_t bun_sysconf__SC_NPROCESSORS_ONLN()
+{
+#if OS(WINDOWS)
+    SYSTEM_INFO sysinfo;
+    GetSystemInfo(&sysinfo);
+    return sysinfo.dwNumberOfProcessors;
+#else
+    return sysconf(_SC_NPROCESSORS_ONLN);
+#endif
+}
+
 #if OS(DARWIN) && BUN_DEBUG
 #include <malloc/malloc.h>
 

--- a/src/bun.js/bindings/wtf-bindings.cpp
+++ b/src/bun.js/bindings/wtf-bindings.cpp
@@ -4,6 +4,7 @@
 #include <wtf/StackCheck.h>
 #include <wtf/StackTrace.h>
 #include <wtf/dtoa.h>
+#include <wtf/NumberOfCores.h>
 #include <atomic>
 
 #include "wtf/SIMDUTF.h"
@@ -254,6 +255,11 @@ extern "C" [[ZIG_EXPORT(nothrow)]] void* Bun__StackCheck__getMaxStack()
 extern "C" void WTF__DumpStackTrace(void** stack, size_t stack_count)
 {
     WTFPrintBacktrace({ stack, stack_count });
+}
+
+extern "C" int WTF__numberOfProcessorCores()
+{
+    return WTF::numberOfProcessorCores();
 }
 
 extern "C" void WTF__releaseFastMallocFreeMemoryForThisThread()

--- a/src/bun.js/node/node_os.zig
+++ b/src/bun.js/node/node_os.zig
@@ -1,5 +1,8 @@
+extern fn bun_sysconf__SC_NPROCESSORS_ONLN() i32;
+
 pub fn createNodeOsBinding(global: *jsc.JSGlobalObject) bun.JSError!jsc.JSValue {
     return (try jsc.JSObject.create(.{
+        .hostCpuCount = @max(1, bun_sysconf__SC_NPROCESSORS_ONLN()),
         .cpus = gen.createCpusCallback(global),
         .freemem = gen.createFreememCallback(global),
         .getPriority = gen.createGetPriorityCallback(global),

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -3599,7 +3599,7 @@ pub fn getThreadCount() u16 {
             return null;
         }
         fn getThreadCountOnce() void {
-            cached_thread_count = @min(max_threads, @max(min_threads, getThreadCountFromUser() orelse std.Thread.getCpuCount() catch 0));
+            cached_thread_count = @min(max_threads, @max(min_threads, getThreadCountFromUser() orelse jsc.wtf.numberOfProcessorCores()));
         }
     };
     ThreadCount.cached_thread_count_once.call();

--- a/src/js/node/os.ts
+++ b/src/js/node/os.ts
@@ -28,9 +28,9 @@ var tmpdir = function () {
 // Some packages like FastGlob only bother to read the length of the array
 // so instead of actually populating the entire object
 // we turn them into getters
-function lazyCpus({ cpus }) {
+function lazyCpus({ cpus, hostCpuCount }) {
   return () => {
-    const array = new Array(navigator.hardwareConcurrency);
+    const array = new Array(hostCpuCount);
     function populate() {
       const results = cpus();
       const length = results.length;


### PR DESCRIPTION
Routes `navigator.hardwareConcurrency`, `os.availableParallelism()`, and `bun.getThreadCount()` through `WTF::numberOfProcessorCores()`, which is now `min(sysconf(_SC_NPROCESSORS_ONLN), sched_getaffinity count, cgroup CPU quota)` on Linux.

### Why

Under `docker run --cpus=2` (or k8s `resources.limits.cpu`), the kernel sets a CFS bandwidth quota rather than a cpuset mask. `sysconf` and `sched_getaffinity` both still report the host core count, so on a 96-core host Bun spawns ~96 threads for the thread pool, JSC parallel GC markers, and JIT workers. Those threads exhaust the 200ms/100ms quota in a few ms of wall time and the entire cgroup is descheduled for the rest of the period — sawtooth latency, `nr_throttled` climbing, GC stalls mid-collection.

Node returns 2 here (libuv reads `cpu.max`); Bun returned 96.

### What

- `WTF::numberOfProcessorCores()` (WebKit side, separate PR): on Linux, also consults `sched_getaffinity` and a new `uv_get_constrained_cpu()` that parses `/proc/self/cgroup`, dispatches v1/v2, and for v2 walks the hierarchy taking the tightest `ceil(quota/period)`. Same file now also walks the v2 hierarchy for `memory.max` (previously read leaf only). Result is cached after first call.
- `ZigGlobalObject.cpp`: `navigator.hardwareConcurrency` uses `WTF::numberOfProcessorCores()` instead of inline `sysctl`/`sysconf`.
- `wtf-bindings.cpp` / `WTF.zig`: expose `WTF__numberOfProcessorCores()` to Zig.
- `bun.zig`: `getThreadCount()` uses it instead of `std.Thread.getCpuCount()`.

One function now feeds JSC GC/JIT sizing, `navigator.hardwareConcurrency`, `os.availableParallelism()`, and Bun's internal thread pool.

### Notes

- Runtime cgroup resize (k8s in-place vertical scaling) is not picked up; same as Node.