### PR TITLE
Add IR PGO build support

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -314,6 +314,8 @@ function parseArgs(argv: string[]): CliArgs {
     "nodejsAbiVersion",
     "zigCommit",
     "webkitVersion",
+    "pgoGenerate",
+    "pgoUse",
   ]);
 
   for (let i = 0; i < argv.length; i++) {

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -100,6 +100,10 @@ export interface Config {
 
   // ─── Features (all explicit booleans) ───
   lto: boolean;
+  /** IR PGO: directory for .profraw output (instrumented build). Mutually exclusive with pgoUse. */
+  pgoGenerate: string | undefined;
+  /** IR PGO: .profdata file path (optimized build). Mutually exclusive with pgoGenerate. */
+  pgoUse: string | undefined;
   asan: boolean;
   zigAsan: boolean;
   assertions: boolean;
@@ -207,6 +211,8 @@ export interface PartialConfig {
   buildType?: BuildType;
   mode?: BuildMode;
   lto?: boolean;
+  pgoGenerate?: string;
+  pgoUse?: string;
   asan?: boolean;
   zigAsan?: boolean;
   assertions?: boolean;
@@ -391,6 +397,13 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     lto = false;
   }
 
+  // PGO: paths resolved to absolute. generate/use are mutually exclusive.
+  const pgoGenerate = partial.pgoGenerate ? resolve(partial.pgoGenerate) : undefined;
+  const pgoUse = partial.pgoUse ? resolve(partial.pgoUse) : undefined;
+  if (pgoGenerate && pgoUse) {
+    throw new BuildError("--pgo-generate and --pgo-use are mutually exclusive");
+  }
+
   // Logs: on by default in debug non-test
   const logs = partial.logs ?? debug;
 
@@ -480,6 +493,8 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     release,
     mode: partial.mode ?? "full",
     lto,
+    pgoGenerate,
+    pgoUse,
     asan,
     zigAsan,
     assertions,
@@ -754,6 +769,8 @@ export function formatConfig(cfg: Config, exe: string): string {
   ];
   const features: string[] = [];
   if (cfg.lto) features.push("lto");
+  if (cfg.pgoGenerate) features.push("pgo-gen");
+  if (cfg.pgoUse) features.push("pgo-use");
   if (cfg.asan) features.push("asan");
   if (cfg.assertions) features.push("assertions");
   if (cfg.logs) features.push("logs");

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -182,17 +182,30 @@ export const webkit: Dependency = {
 
     // Local: nested cmake, target=jsc.
     //
-    // CMAKE_C_FLAGS/CMAKE_CXX_FLAGS set to empty: clears the global dep
-    // flags source.ts would otherwise pass. WebKit's cmake sets its own
-    // -O/-march/etc.; ours would conflict. Dep args go LAST so they override.
+    // CMAKE_C_FLAGS/CMAKE_CXX_FLAGS: clears the global dep flags source.ts
+    // would otherwise pass — WebKit's cmake sets its own -O/-march/etc.;
+    // ours would conflict. Dep args go LAST so they override. We DO forward
+    // LTO/PGO since WebKit's cmake doesn't set those itself.
     //
     // Windows: ICU built from source via preBuild before cmake configure.
     // WebKit's cmake finds it via ICU_ROOT. On posix, system ICU is used
     // (macOS: Homebrew headers + system libs; Linux: libicu-dev) — cmake
     // auto-detects.
+    const optFlags: string[] = [];
+    if (cfg.lto) optFlags.push("-flto=full");
+    if (cfg.pgoGenerate) optFlags.push(`-fprofile-generate=${cfg.pgoGenerate}`);
+    if (cfg.pgoUse) {
+      optFlags.push(
+        `-fprofile-use=${cfg.pgoUse}`,
+        "-Wno-profile-instr-out-of-date",
+        "-Wno-profile-instr-unprofiled",
+        "-Wno-backend-plugin",
+      );
+    }
+    const optFlagStr = optFlags.join(" ");
     const args: Record<string, string> = {
-      CMAKE_C_FLAGS: "",
-      CMAKE_CXX_FLAGS: "",
+      CMAKE_C_FLAGS: optFlagStr,
+      CMAKE_CXX_FLAGS: optFlagStr,
       PORT: "JSCOnly",
       ENABLE_STATIC_JSC: "ON",
       USE_THIN_ARCHIVES: "OFF",
@@ -220,8 +233,8 @@ export const webkit: Dependency = {
       args.ICU_INCLUDE_DIR = slash(resolve(icu, "include"));
       // U_STATIC_IMPLEMENTATION: ICU headers default to dllimport; we
       // link statically. Matches what the old cmake's SetupWebKit did.
-      args.CMAKE_C_FLAGS = "/DU_STATIC_IMPLEMENTATION";
-      args.CMAKE_CXX_FLAGS = "/DU_STATIC_IMPLEMENTATION /clang:-fno-c++-static-destructors";
+      args.CMAKE_C_FLAGS = `/DU_STATIC_IMPLEMENTATION ${optFlagStr}`.trim();
+      args.CMAKE_CXX_FLAGS = `/DU_STATIC_IMPLEMENTATION /clang:-fno-c++-static-destructors ${optFlagStr}`.trim();
       // Static CRT to match bun + all other deps (we build everything
       // with /MTd or /MT). Without this, cmake defaults to /MDd →
       // RuntimeLibrary mismatch at link.

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -320,6 +320,23 @@ export const globalFlags: Flag[] = [
     desc: "Enable devirtualization across whole program (LTO only)",
   },
 
+  // ─── PGO (compile-side) ───
+  {
+    flag: c => `-fprofile-generate=${c.pgoGenerate}`,
+    when: c => c.unix && !!c.pgoGenerate,
+    desc: "IR PGO: instrument for profile generation",
+  },
+  {
+    flag: c => [
+      `-fprofile-use=${c.pgoUse}`,
+      "-Wno-profile-instr-out-of-date",
+      "-Wno-profile-instr-unprofiled",
+      "-Wno-backend-plugin",
+    ],
+    when: c => c.unix && !!c.pgoUse,
+    desc: "IR PGO: optimize with profile data",
+  },
+
   // ─── Path remapping (CI reproducibility) ───
   {
     flag: c => [
@@ -606,6 +623,18 @@ export const linkerFlags: Flag[] = [
     flag: "-Os",
     when: c => c.unix && c.lto && c.smol,
     desc: "LTO codegen at -Os (matches compile-side opt level)",
+  },
+
+  // ─── PGO (link-side) ───
+  {
+    flag: c => `-fprofile-generate=${c.pgoGenerate}`,
+    when: c => c.unix && !!c.pgoGenerate,
+    desc: "IR PGO: link profiling runtime",
+  },
+  {
+    flag: c => `-fprofile-use=${c.pgoUse}`,
+    when: c => c.unix && !!c.pgoUse,
+    desc: "IR PGO: LTO+PGO at link time",
   },
 
   // ─── Windows ───


### PR DESCRIPTION
## Summary

Adds IR PGO support to the build system via two new flags:

- `--pgo-generate=<dir>` — produce an instrumented build that writes
  `.profraw` files at runtime
- `--pgo-use=<file.profdata>` — produce an optimized build using merged
  profile data

The flags are forwarded to all C/C++ compilation units via `globalFlags`,
including JSC (WebKit) when built locally. The two flags are mutually
exclusive. Unix only for now (Windows clang-cl needs separate
link-line handling), and Zig code isn't covered (Zig doesn't support
`-fprofile-generate`).

This is a **preparation-stage PR**. It only enables PGO for `release-local`
(local WebKit build) so that developers can experiment with PGO and
measure its effect.

Profile data generation (running an instrumented binary, merging
`.profraw` files via `llvm-profdata merge`) is left to the caller — see
Next Steps below.

## How to use

```sh
# Phase 1: instrumented build
bun scripts/build.ts --profile=release-local --lto=on \
  --pgo-generate=$PWD/build/pgo-raw \
  --build-dir=build/pgo-gen

# Phase 2: training (user-defined workload)
LLVM_PROFILE_FILE="$PWD/build/pgo-raw/bun-%p-%m.profraw" \
  ./build/pgo-gen/bun test test/js/...
llvm-profdata merge build/pgo-raw/*.profraw -o build/pgo-raw/bun.profdata

# Phase 3: optimized build
bun scripts/build.ts --profile=release-local --lto=on \
  --pgo-use=$PWD/build/pgo-raw/bun.profdata \
  --build-dir=build/pgo-use
```

## Next Steps

1. **Profile-data generation in CI** (this repo).
2. **Profile-data distribution.**
3. **`oven-sh/WebKit` PGO matrix entries.**
4. **Switch release builds to PGO prebuilts.**

