### PR TITLE
Fix null deref in esmRegistryMap init when Loader is not an object

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3075,11 +3075,13 @@ void GlobalObject::reload()
     JSModuleLoader* moduleLoader = this->moduleLoader();
     auto& vm = this->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSC::JSMap* registry = jsCast<JSC::JSMap*>(moduleLoader->get(this, Identifier::fromString(vm, "registry"_s)));
+    JSC::JSMap* registry = jsDynamicCast<JSC::JSMap*>(moduleLoader->get(this, Identifier::fromString(vm, "registry"_s)));
     RETURN_IF_EXCEPTION(scope, );
 
-    registry->clear(this);
-    RETURN_IF_EXCEPTION(scope, );
+    if (registry) {
+        registry->clear(this);
+        RETURN_IF_EXCEPTION(scope, );
+    }
     this->requireMap()->clear(this);
     RETURN_IF_EXCEPTION(scope, );
 

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2200,12 +2200,12 @@ void GlobalObject::finishCreation(VM& vm)
             auto loaderValue = global->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "Loader"_s));
             scope.assertNoExceptionExceptTermination();
             RETURN_IF_EXCEPTION(scope, setEmpty());
-            if (loaderValue) {
-                auto registryValue = loaderValue.getObject()->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "registry"_s));
+            if (auto* loaderObject = loaderValue.getObject()) {
+                auto registryValue = loaderObject->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "registry"_s));
                 scope.assertNoExceptionExceptTermination();
                 RETURN_IF_EXCEPTION(scope, setEmpty());
                 if (registryValue) {
-                    registry = jsCast<JSC::JSMap*>(registryValue);
+                    registry = jsDynamicCast<JSC::JSMap*>(registryValue);
                 }
             }
 

--- a/test/js/bun/resolve/loader-not-an-object.test.ts
+++ b/test/js/bun/resolve/loader-not-an-object.test.ts
@@ -23,11 +23,7 @@ test("setting globalThis.Loader to a non-object does not crash", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toContain("ok");
   expect(exitCode).toBe(0);

--- a/test/js/bun/resolve/loader-not-an-object.test.ts
+++ b/test/js/bun/resolve/loader-not-an-object.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test: setting `globalThis.Loader` to a non-object before the
+// ESM registry map is lazily initialized used to crash in
+// ZigGlobalObject.cpp because `loaderValue.getObject()` returned nullptr
+// and was dereferenced unconditionally.
+test("setting globalThis.Loader to a non-object does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        delete globalThis.Loader;
+        globalThis.Loader = 3n;
+        try { require("/proc/self/status"); } catch (e) {}
+        try { await import("data:text/javascript,export default 1"); } catch (e) {}
+        console.log("ok");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout).toContain("ok");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`m_esmRegistryMap`'s lazy initializer in `ZigGlobalObject` reads `globalThis.Loader.registry` and casts it to a JSMap to reuse an existing loader state. The existing object check only guarded against `loaderValue` being the empty JSValue — if user code sets `globalThis.Loader` to a primitive (BigInt, number, string, etc.), `loaderValue.getObject()` returns `nullptr` and the subsequent `->getIfPropertyExists(...)` call dereferences null.

Fuzzilli found this with:

```js
delete globalThis.Loader;
globalThis.Loader = 3n;
try { require("/proc/self/status"); } catch (e) {}
```

```
ZigGlobalObject.cpp:2204:63: runtime error: member call on null pointer of type 'JSC::JSObject'
```

## Fix

Check the result of `getObject()` directly instead of only guarding against the empty value, and use `jsDynamicCast` for the registry slot so a non-`JSMap` value falls through to creating a fresh map rather than being cast unsafely.