### PR TITLE
Fix crash in Error.captureStackTrace when stackTraceLimit is non-number

### DIFF
--- a/src/bun.js/bindings/FormatStackTraceForJS.cpp
+++ b/src/bun.js/bindings/FormatStackTraceForJS.cpp
@@ -682,7 +682,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
     JSC::JSObject* errorObject = objectArg.asCell()->getObject();
     JSC::JSValue caller = callFrame->argument(1);
 
-    size_t stackTraceLimit = globalObject->stackTraceLimit().value();
+    size_t stackTraceLimit = globalObject->stackTraceLimit().value_or(0);
     if (stackTraceLimit == 0) {
         stackTraceLimit = DEFAULT_ERROR_STACK_TRACE_LIMIT;
     }

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -169,20 +169,6 @@ test("capture stack trace limit", () => {
   }
 });
 
-test("captureStackTrace with non-number stackTraceLimit does not crash", () => {
-  const originalLimit = Error.stackTraceLimit;
-  try {
-    for (const bad of [{}, "hello", null, undefined, Symbol("x"), [], Error]) {
-      Error.stackTraceLimit = bad;
-      const e = {};
-      Error.captureStackTrace(e);
-      expect(typeof e.stack).toBe("string");
-    }
-  } finally {
-    Error.stackTraceLimit = originalLimit;
-  }
-});
-
 test("prepare stack trace", () => {
   function f1() {
     f2();
@@ -537,8 +523,8 @@ test("err.stack should invoke prepareStackTrace", () => {
   functionWithAName();
 
   expect(functionName).toBe("functionWithAName");
-  expect(lineNumber).toBe(532);
-  expect(parentLineNumber).toBe(537);
+  expect(lineNumber).toBe(518);
+  expect(parentLineNumber).toBe(523);
 });
 
 test("Error.prepareStackTrace inside a node:vm works", () => {
@@ -802,5 +788,19 @@ test("captureStackTrace with constructor function not in stack returns error str
     const e = new TypeError("bad type");
     Error.captureStackTrace(e, notInStack);
     expect(e.stack).toBe("TypeError: bad type");
+  }
+});
+
+test("captureStackTrace with non-number stackTraceLimit does not crash", () => {
+  const originalLimit = Error.stackTraceLimit;
+  try {
+    for (const bad of [{}, "hello", null, undefined, Symbol("x"), [], Error]) {
+      Error.stackTraceLimit = bad;
+      const e = {};
+      Error.captureStackTrace(e);
+      expect(typeof e.stack).toBe("string");
+    }
+  } finally {
+    Error.stackTraceLimit = originalLimit;
   }
 });

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -169,6 +169,20 @@ test("capture stack trace limit", () => {
   }
 });
 
+test("captureStackTrace with non-number stackTraceLimit does not crash", () => {
+  const originalLimit = Error.stackTraceLimit;
+  try {
+    for (const bad of [{}, "hello", null, undefined, Symbol("x"), [], Error]) {
+      Error.stackTraceLimit = bad;
+      const e = {};
+      Error.captureStackTrace(e);
+      expect(typeof e.stack).toBe("string");
+    }
+  } finally {
+    Error.stackTraceLimit = originalLimit;
+  }
+});
+
 test("prepare stack trace", () => {
   function f1() {
     f2();
@@ -523,8 +537,8 @@ test("err.stack should invoke prepareStackTrace", () => {
   functionWithAName();
 
   expect(functionName).toBe("functionWithAName");
-  expect(lineNumber).toBe(518);
-  expect(parentLineNumber).toBe(523);
+  expect(lineNumber).toBe(532);
+  expect(parentLineNumber).toBe(537);
 });
 
 test("Error.prepareStackTrace inside a node:vm works", () => {


### PR DESCRIPTION
## What

`Error.captureStackTrace({})` aborts the process if `Error.stackTraceLimit` was previously assigned a non-number value.

```js
Error.stackTraceLimit = {};
Error.captureStackTrace({}); // SIGABRT
```

## Why

`ErrorConstructor::put` stores `std::nullopt` into `JSGlobalObject::m_stackTraceLimit` when the assigned value `!isNumber()`. `errorConstructorFuncCaptureStackTrace` then called `.value()` on that empty `std::optional`, which aborts.

## Fix

Use `.value_or(0)` — the next line already substitutes `DEFAULT_ERROR_STACK_TRACE_LIMIT` for zero.

Found by Fuzzilli.