### PR TITLE
install: `bun update <pkg>@latest` now overrides pinned exact versions

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.zig
+++ b/src/install/PackageManager/PackageJSONEditor.zig
@@ -683,7 +683,14 @@ pub fn edit(
                         break :uninitialized try allocator.dupe(u8, "latest");
                     }
 
-                    if (manager.subcommand != .update or !options.before_install or e_string.isBlank() or request.version.tag == .npm) {
+                    // If the user explicitly typed a dist-tag (e.g. `bun update pkg@latest`),
+                    // treat it like an npm spec: overwrite the existing package.json entry so
+                    // install re-resolves against that dist-tag. A bare `bun update pkg` (no spec)
+                    // parses to `.dist_tag` with an empty literal and should keep the existing pin.
+                    const user_typed_dist_tag = request.version.tag == .dist_tag and
+                        request.version.literal.slice(request.version_buf).len > 0;
+
+                    if (manager.subcommand != .update or !options.before_install or e_string.isBlank() or request.version.tag == .npm or user_typed_dist_tag) {
                         break :uninitialized switch (request.version.tag) {
                             .uninitialized => try allocator.dupe(u8, "latest"),
                             else => try allocator.dupe(u8, request.version.literal.slice(request.version_buf)),

--- a/test/regression/issue/28808.test.ts
+++ b/test/regression/issue/28808.test.ts
@@ -1,17 +1,5 @@
-// Regression test for https://github.com/oven-sh/bun/issues/28808
-//
-// Bug: `bun update <pkg>@latest` ignores the @latest dist-tag when package.json
-// has a pinned exact version (e.g. `"pkg": "1.0.0"` instead of `"^1.0.0"`).
-// The package stays at the pinned version instead of updating to latest.
-//
-// Cause: PackageJSONEditor.edit() kept the existing pinned literal in the
-// in-memory package.json for `bun update` with an existing non-blank range,
-// unless the user typed an explicit npm semver spec. A CLI-supplied `@latest`
-// (Dependency.Version.tag == .dist_tag) was dropped, so install saw no diff
-// and never re-resolved the package.
-//
-// Fix: treat an explicit dist-tag on the CLI like an explicit npm spec —
-// write it into the in-memory package.json so install re-resolves.
+// https://github.com/oven-sh/bun/issues/28808
+// `bun update <pkg>@latest` should override a pinned exact version in package.json.
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";

--- a/test/regression/issue/28808.test.ts
+++ b/test/regression/issue/28808.test.ts
@@ -100,6 +100,7 @@ test("bun update <pkg>@latest updates past a pinned exact version", async () => 
   };
 
   // Install the pinned version first.
+  let installExitCode: number;
   {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "install"],
@@ -108,16 +109,18 @@ test("bun update <pkg>@latest updates past a pinned exact version", async () => 
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("error:");
-    expect(exitCode).toBe(0);
+    installExitCode = exitCode;
   }
 
   // Sanity: installed version is the pinned one.
   const installedBefore = await Bun.file(join(String(dir), "node_modules", pkgName, "package.json")).json();
   expect(installedBefore.version).toBe(oldVersion);
+  expect(installExitCode).toBe(0);
 
   // Run `bun update <pkg>@latest` — should bump past the pinned version.
+  let updateExitCode: number;
   {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "update", `${pkgName}@latest`],
@@ -126,9 +129,9 @@ test("bun update <pkg>@latest updates past a pinned exact version", async () => 
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("error:");
-    expect(exitCode).toBe(0);
+    updateExitCode = exitCode;
   }
 
   // Installed version on disk should now be the new one.
@@ -138,4 +141,5 @@ test("bun update <pkg>@latest updates past a pinned exact version", async () => 
   // package.json should have been rewritten to the new version, preserving the exact pinning style.
   const editedPkg = await Bun.file(join(String(dir), "package.json")).json();
   expect(editedPkg.dependencies[pkgName]).toBe(newVersion);
+  expect(updateExitCode).toBe(0);
 });

--- a/test/regression/issue/28808.test.ts
+++ b/test/regression/issue/28808.test.ts
@@ -15,7 +15,6 @@
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { once } from "node:events";
 import { join } from "node:path";
 
 /**

--- a/test/regression/issue/28808.test.ts
+++ b/test/regression/issue/28808.test.ts
@@ -1,0 +1,154 @@
+// Regression test for https://github.com/oven-sh/bun/issues/28808
+//
+// Bug: `bun update <pkg>@latest` ignores the @latest dist-tag when package.json
+// has a pinned exact version (e.g. `"pkg": "1.0.0"` instead of `"^1.0.0"`).
+// The package stays at the pinned version instead of updating to latest.
+//
+// Cause: PackageJSONEditor.edit() kept the existing pinned literal in the
+// in-memory package.json for `bun update` with an existing non-blank range,
+// unless the user typed an explicit npm semver spec. A CLI-supplied `@latest`
+// (Dependency.Version.tag == .dist_tag) was dropped, so install saw no diff
+// and never re-resolved the package.
+//
+// Fix: treat an explicit dist-tag on the CLI like an explicit npm spec —
+// write it into the in-memory package.json so install re-resolves.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { once } from "node:events";
+import { join } from "node:path";
+
+/**
+ * Creates a minimal valid npm tarball (.tgz) containing only package/package.json.
+ */
+function createMinimalTarball(pkgJson: object): Buffer {
+  const content = Buffer.from(JSON.stringify(pkgJson));
+  const filename = "package/package.json";
+
+  const header = Buffer.alloc(512, 0);
+  header.write(filename, 0);
+  header.write("0000644\0", 100);
+  header.write("0001000\0", 108);
+  header.write("0001000\0", 116);
+  header.write(content.length.toString(8).padStart(11, "0") + "\0", 124);
+  header.write(
+    Math.floor(Date.now() / 1000)
+      .toString(8)
+      .padStart(11, "0") + "\0",
+    136,
+  );
+  header.write("        ", 148);
+  header.write("0", 156);
+  header.write("ustar\0", 257);
+  header.write("00", 263);
+
+  let checksum = 0;
+  for (let i = 0; i < 512; i++) checksum += header[i];
+  header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148);
+
+  const dataBlocks = Buffer.alloc(Math.ceil(content.length / 512) * 512, 0);
+  content.copy(dataBlocks);
+
+  return Buffer.from(Bun.gzipSync(Buffer.concat([header, dataBlocks, Buffer.alloc(1024, 0)])));
+}
+
+test("bun update <pkg>@latest updates past a pinned exact version", async () => {
+  const pkgName = "test-pinned-update";
+  const oldVersion = "1.0.0";
+  const newVersion = "1.0.1";
+
+  const oldTarball = createMinimalTarball({ name: pkgName, version: oldVersion });
+  const newTarball = createMinimalTarball({ name: pkgName, version: newVersion });
+
+  const oldShasum = new Bun.CryptoHasher("sha1").update(oldTarball).digest("hex");
+  const oldIntegrity = "sha512-" + new Bun.CryptoHasher("sha512").update(oldTarball).digest("base64");
+  const newShasum = new Bun.CryptoHasher("sha1").update(newTarball).digest("hex");
+  const newIntegrity = "sha512-" + new Bun.CryptoHasher("sha512").update(newTarball).digest("base64");
+
+  await using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname.endsWith(`${pkgName}-${oldVersion}.tgz`)) {
+        return new Response(oldTarball, { headers: { "Content-Type": "application/octet-stream" } });
+      }
+      if (url.pathname.endsWith(`${pkgName}-${newVersion}.tgz`)) {
+        return new Response(newTarball, { headers: { "Content-Type": "application/octet-stream" } });
+      }
+      if (url.pathname === `/${pkgName}`) {
+        const base = `http://localhost:${server.port}/${pkgName}/-/`;
+        return Response.json({
+          name: pkgName,
+          "dist-tags": { latest: newVersion },
+          versions: {
+            [oldVersion]: {
+              name: pkgName,
+              version: oldVersion,
+              dist: { tarball: `${base}${pkgName}-${oldVersion}.tgz`, shasum: oldShasum, integrity: oldIntegrity },
+            },
+            [newVersion]: {
+              name: pkgName,
+              version: newVersion,
+              dist: { tarball: `${base}${pkgName}-${newVersion}.tgz`, shasum: newShasum, integrity: newIntegrity },
+            },
+          },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  using dir = tempDir("issue-28808", {
+    "package.json": JSON.stringify({
+      name: "test-project",
+      version: "1.0.0",
+      dependencies: { [pkgName]: oldVersion }, // pinned exact version
+    }),
+    "bunfig.toml": `[install]\nregistry = "http://localhost:${server.port}/"\ncache = false\n`,
+  });
+
+  const installEnv = {
+    ...bunEnv,
+    BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+  };
+
+  // Install the pinned version first.
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: installEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+
+  // Sanity: installed version is the pinned one.
+  const installedBefore = await Bun.file(join(String(dir), "node_modules", pkgName, "package.json")).json();
+  expect(installedBefore.version).toBe(oldVersion);
+
+  // Run `bun update <pkg>@latest` — should bump past the pinned version.
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "update", `${pkgName}@latest`],
+      cwd: String(dir),
+      env: installEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+
+  // Installed version on disk should now be the new one.
+  const installedAfter = await Bun.file(join(String(dir), "node_modules", pkgName, "package.json")).json();
+  expect(installedAfter.version).toBe(newVersion);
+
+  // package.json should have been rewritten to the new version, preserving the exact pinning style.
+  const editedPkg = await Bun.file(join(String(dir), "package.json")).json();
+  expect(editedPkg.dependencies[pkgName]).toBe(newVersion);
+});


### PR DESCRIPTION
Fixes #28808

## Repro

```bash
mkdir /tmp/test && cd /tmp/test
echo '{"name":"x","version":"1.0.0","dependencies":{"is-odd":"3.0.0"}}' > package.json
bun install
# + is-odd@3.0.0 (v3.0.1 available)
bun update is-odd@latest
# installed is-odd@3.0.0   <- bug: stays at 3.0.0
```

## Cause

`PackageJSONEditor.edit()` (src/install/PackageManager/PackageJSONEditor.zig) kept the existing pinned literal in the in-memory `package.json` for `bun update` with an existing non-blank range, unless the user typed an explicit npm semver spec. A CLI-supplied `@latest` (`Dependency.Version.Tag.dist_tag`) was dropped, so install saw no diff and never re-resolved the package.

## Fix

Treat an explicit dist-tag on the CLI the same way we already treat an explicit npm semver spec — write it into the in-memory `package.json` so install re-resolves. A bare `bun update pkg` (no spec) still parses to `.dist_tag` with an empty literal and keeps the existing pin, so pins are only overridden when the user explicitly asks.

## Verification

Regression test `test/regression/issue/28808.test.ts` passes on debug build with the fix and fails against 1.3.11 without it (with a mock registry so it doesn't depend on the real npm). Existing `test/cli/install/bun-update.test.ts` tests all pass. Manually verified:

| Command | package.json spec | Result |
|---|---|---|
| `bun update pkg@latest` | `"1.0.0"` (pinned) | ✅ updates to latest (was stuck) |
| `bun update pkg@latest` | `"^1.0.0"` | ✅ updates to latest (unchanged) |
| `bun update pkg` (no spec) | `"1.0.0"` (pinned) | ✅ stays at 1.0.0 (pin respected) |
| `bun update pkg@^1.0.1` | `"1.0.0"` (pinned) | ✅ updates to 1.0.1 (unchanged) |
| `bun update --latest pkg` | `"1.0.0"` (pinned) | ✅ updates to latest (unchanged) |
| `bun add pkg@latest` | `"1.0.0"` (pinned) | ✅ updates to latest (unchanged) |