### PR TITLE
Fix wikilink rendering out of order with preceding text

### DIFF
--- a/src/md/inlines.zig
+++ b/src/md/inlines.zig
@@ -201,8 +201,12 @@ pub fn processInlineContent(self: *Parser, content: []const u8, base_off: OFF) P
 
         // Wiki links: [[destination]] or [[destination|label]]
         if (c == '[' and self.flags.wiki_links and i + 1 < content.len and content[i + 1] == '[') {
+            // Emit pending text BEFORE processWikiLink, which renders the wikilink
+            // as a side effect. If parsing fails we fall through to the regular link
+            // handler; setting text_start = i prevents it from re-emitting the text.
+            if (i > text_start) try self.emitText(.normal, content[text_start..i]);
+            text_start = i;
             if (try self.processWikiLink(content, i)) |end_pos| {
-                if (i > text_start) try self.emitText(.normal, content[text_start..i]);
                 i = end_pos;
                 text_start = i;
                 continue;

--- a/test/regression/issue/28810.test.ts
+++ b/test/regression/issue/28810.test.ts
@@ -1,29 +1,20 @@
 // https://github.com/oven-sh/bun/issues/28810
 import { expect, test } from "bun:test";
 
-test("wikilink preserves preceding text order", () => {
-  const html = Bun.markdown.html("Hello [[world]], this is a test.", { wikiLinks: true });
-  expect(html).toBe('<p>Hello <x-wikilink data-target="world">world</x-wikilink>, this is a test.</p>\n');
-});
-
-test("wikilink preserves preceding text order with label", () => {
-  const html = Bun.markdown.html("before [[target|label]] after", { wikiLinks: true });
-  expect(html).toBe('<p>before <x-wikilink data-target="target">label</x-wikilink> after</p>\n');
-});
-
-test("wikilink with text on both sides and emphasis", () => {
-  const html = Bun.markdown.html("*prefix* [[foo]] *suffix*", { wikiLinks: true });
-  expect(html).toBe('<p><em>prefix</em> <x-wikilink data-target="foo">foo</x-wikilink> <em>suffix</em></p>\n');
-});
-
-test("multiple wikilinks with interleaved text", () => {
-  const html = Bun.markdown.html("a [[x]] b [[y]] c", { wikiLinks: true });
-  expect(html).toBe(
+test("wikilink preserves preceding text and interleaved content", () => {
+  expect(Bun.markdown.html("Hello [[world]], this is a test.", { wikiLinks: true })).toBe(
+    '<p>Hello <x-wikilink data-target="world">world</x-wikilink>, this is a test.</p>\n',
+  );
+  expect(Bun.markdown.html("before [[target|label]] after", { wikiLinks: true })).toBe(
+    '<p>before <x-wikilink data-target="target">label</x-wikilink> after</p>\n',
+  );
+  expect(Bun.markdown.html("*prefix* [[foo]] *suffix*", { wikiLinks: true })).toBe(
+    '<p><em>prefix</em> <x-wikilink data-target="foo">foo</x-wikilink> <em>suffix</em></p>\n',
+  );
+  expect(Bun.markdown.html("a [[x]] b [[y]] c", { wikiLinks: true })).toBe(
     '<p>a <x-wikilink data-target="x">x</x-wikilink> b <x-wikilink data-target="y">y</x-wikilink> c</p>\n',
   );
-});
-
-test("wikilink parse failure falls back to regular link without duplicating text", () => {
-  const html = Bun.markdown.html("pre [[foo]\n\n[foo]: /url", { wikiLinks: true });
-  expect(html).toBe('<p>pre [<a href="/url">foo</a></p>\n');
+  expect(Bun.markdown.html("pre [[foo]\n\n[foo]: /url", { wikiLinks: true })).toBe(
+    '<p>pre [<a href="/url">foo</a></p>\n',
+  );
 });

--- a/test/regression/issue/28810.test.ts
+++ b/test/regression/issue/28810.test.ts
@@ -4,11 +4,7 @@ import { bunEnv, bunExe } from "harness";
 
 async function renderMarkdown(input: string): Promise<string> {
   await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `process.stdout.write(Bun.markdown.html(${JSON.stringify(input)}, { wikiLinks: true }))`,
-    ],
+    cmd: [bunExe(), "-e", `process.stdout.write(Bun.markdown.html(${JSON.stringify(input)}, { wikiLinks: true }))`],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
@@ -43,7 +39,5 @@ test("multiple wikilinks with interleaved text", async () => {
 });
 
 test("wikilink parse failure falls back to regular link without duplicating text", async () => {
-  expect(await renderMarkdown("pre [[foo]\n\n[foo]: /url")).toBe(
-    '<p>pre [<a href="/url">foo</a></p>\n',
-  );
+  expect(await renderMarkdown("pre [[foo]\n\n[foo]: /url")).toBe('<p>pre [<a href="/url">foo</a></p>\n');
 });

--- a/test/regression/issue/28810.test.ts
+++ b/test/regression/issue/28810.test.ts
@@ -15,9 +15,7 @@ test("wikilink preserves preceding text order with label", () => {
 
 test("wikilink with text on both sides and emphasis", () => {
   const html = Bun.markdown.html("*prefix* [[foo]] *suffix*", { wikiLinks: true });
-  expect(html).toBe(
-    '<p><em>prefix</em> <x-wikilink data-target="foo">foo</x-wikilink> <em>suffix</em></p>\n',
-  );
+  expect(html).toBe('<p><em>prefix</em> <x-wikilink data-target="foo">foo</x-wikilink> <em>suffix</em></p>\n');
 });
 
 test("multiple wikilinks with interleaved text", () => {

--- a/test/regression/issue/28810.test.ts
+++ b/test/regression/issue/28810.test.ts
@@ -1,0 +1,35 @@
+// https://github.com/oven-sh/bun/issues/28810
+// Wikilinks with preceding text were rendered out of order: the wikilink HTML
+// was written before the preceding text rather than after it.
+import { expect, test } from "bun:test";
+
+test("wikilink preserves preceding text order", () => {
+  const html = Bun.markdown.html("Hello [[world]], this is a test.", { wikiLinks: true });
+  expect(html).toBe('<p>Hello <x-wikilink data-target="world">world</x-wikilink>, this is a test.</p>\n');
+});
+
+test("wikilink preserves preceding text order with label", () => {
+  const html = Bun.markdown.html("before [[target|label]] after", { wikiLinks: true });
+  expect(html).toBe('<p>before <x-wikilink data-target="target">label</x-wikilink> after</p>\n');
+});
+
+test("wikilink with text on both sides and emphasis", () => {
+  const html = Bun.markdown.html("*prefix* [[foo]] *suffix*", { wikiLinks: true });
+  expect(html).toBe(
+    '<p><em>prefix</em> <x-wikilink data-target="foo">foo</x-wikilink> <em>suffix</em></p>\n',
+  );
+});
+
+test("multiple wikilinks with interleaved text", () => {
+  const html = Bun.markdown.html("a [[x]] b [[y]] c", { wikiLinks: true });
+  expect(html).toBe(
+    '<p>a <x-wikilink data-target="x">x</x-wikilink> b <x-wikilink data-target="y">y</x-wikilink> c</p>\n',
+  );
+});
+
+test("wikilink parse failure falls back to regular link without duplicating text", () => {
+  // `[[foo]` is not a valid wikilink (single closing bracket) — falls through
+  // to the regular link handler. The preceding text must not be emitted twice.
+  const html = Bun.markdown.html("pre [[foo]\n\n[foo]: /url", { wikiLinks: true });
+  expect(html).toBe('<p>pre [<a href="/url">foo</a></p>\n');
+});

--- a/test/regression/issue/28810.test.ts
+++ b/test/regression/issue/28810.test.ts
@@ -1,29 +1,49 @@
 // https://github.com/oven-sh/bun/issues/28810
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
-test("wikilink preserves preceding text order", () => {
-  const html = Bun.markdown.html("Hello [[world]], this is a test.", { wikiLinks: true });
-  expect(html).toBe('<p>Hello <x-wikilink data-target="world">world</x-wikilink>, this is a test.</p>\n');
+async function renderMarkdown(input: string): Promise<string> {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `process.stdout.write(Bun.markdown.html(${JSON.stringify(input)}, { wikiLinks: true }))`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(exitCode).toBe(0);
+  return stdout;
+}
+
+test("wikilink preserves preceding text order", async () => {
+  expect(await renderMarkdown("Hello [[world]], this is a test.")).toBe(
+    '<p>Hello <x-wikilink data-target="world">world</x-wikilink>, this is a test.</p>\n',
+  );
 });
 
-test("wikilink preserves preceding text order with label", () => {
-  const html = Bun.markdown.html("before [[target|label]] after", { wikiLinks: true });
-  expect(html).toBe('<p>before <x-wikilink data-target="target">label</x-wikilink> after</p>\n');
+test("wikilink preserves preceding text order with label", async () => {
+  expect(await renderMarkdown("before [[target|label]] after")).toBe(
+    '<p>before <x-wikilink data-target="target">label</x-wikilink> after</p>\n',
+  );
 });
 
-test("wikilink with text on both sides and emphasis", () => {
-  const html = Bun.markdown.html("*prefix* [[foo]] *suffix*", { wikiLinks: true });
-  expect(html).toBe('<p><em>prefix</em> <x-wikilink data-target="foo">foo</x-wikilink> <em>suffix</em></p>\n');
+test("wikilink with text on both sides and emphasis", async () => {
+  expect(await renderMarkdown("*prefix* [[foo]] *suffix*")).toBe(
+    '<p><em>prefix</em> <x-wikilink data-target="foo">foo</x-wikilink> <em>suffix</em></p>\n',
+  );
 });
 
-test("multiple wikilinks with interleaved text", () => {
-  const html = Bun.markdown.html("a [[x]] b [[y]] c", { wikiLinks: true });
-  expect(html).toBe(
+test("multiple wikilinks with interleaved text", async () => {
+  expect(await renderMarkdown("a [[x]] b [[y]] c")).toBe(
     '<p>a <x-wikilink data-target="x">x</x-wikilink> b <x-wikilink data-target="y">y</x-wikilink> c</p>\n',
   );
 });
 
-test("wikilink parse failure falls back to regular link without duplicating text", () => {
-  const html = Bun.markdown.html("pre [[foo]\n\n[foo]: /url", { wikiLinks: true });
-  expect(html).toBe('<p>pre [<a href="/url">foo</a></p>\n');
+test("wikilink parse failure falls back to regular link without duplicating text", async () => {
+  expect(await renderMarkdown("pre [[foo]\n\n[foo]: /url")).toBe(
+    '<p>pre [<a href="/url">foo</a></p>\n',
+  );
 });

--- a/test/regression/issue/28810.test.ts
+++ b/test/regression/issue/28810.test.ts
@@ -1,6 +1,4 @@
 // https://github.com/oven-sh/bun/issues/28810
-// Wikilinks with preceding text were rendered out of order: the wikilink HTML
-// was written before the preceding text rather than after it.
 import { expect, test } from "bun:test";
 
 test("wikilink preserves preceding text order", () => {
@@ -26,8 +24,6 @@ test("multiple wikilinks with interleaved text", () => {
 });
 
 test("wikilink parse failure falls back to regular link without duplicating text", () => {
-  // `[[foo]` is not a valid wikilink (single closing bracket) — falls through
-  // to the regular link handler. The preceding text must not be emitted twice.
   const html = Bun.markdown.html("pre [[foo]\n\n[foo]: /url", { wikiLinks: true });
   expect(html).toBe('<p>pre [<a href="/url">foo</a></p>\n');
 });

--- a/test/regression/issue/28810.test.ts
+++ b/test/regression/issue/28810.test.ts
@@ -1,43 +1,29 @@
 // https://github.com/oven-sh/bun/issues/28810
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
 
-async function renderMarkdown(input: string): Promise<string> {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `process.stdout.write(Bun.markdown.html(${JSON.stringify(input)}, { wikiLinks: true }))`],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  expect(exitCode).toBe(0);
-  return stdout;
-}
-
-test("wikilink preserves preceding text order", async () => {
-  expect(await renderMarkdown("Hello [[world]], this is a test.")).toBe(
-    '<p>Hello <x-wikilink data-target="world">world</x-wikilink>, this is a test.</p>\n',
-  );
+test("wikilink preserves preceding text order", () => {
+  const html = Bun.markdown.html("Hello [[world]], this is a test.", { wikiLinks: true });
+  expect(html).toBe('<p>Hello <x-wikilink data-target="world">world</x-wikilink>, this is a test.</p>\n');
 });
 
-test("wikilink preserves preceding text order with label", async () => {
-  expect(await renderMarkdown("before [[target|label]] after")).toBe(
-    '<p>before <x-wikilink data-target="target">label</x-wikilink> after</p>\n',
-  );
+test("wikilink preserves preceding text order with label", () => {
+  const html = Bun.markdown.html("before [[target|label]] after", { wikiLinks: true });
+  expect(html).toBe('<p>before <x-wikilink data-target="target">label</x-wikilink> after</p>\n');
 });
 
-test("wikilink with text on both sides and emphasis", async () => {
-  expect(await renderMarkdown("*prefix* [[foo]] *suffix*")).toBe(
-    '<p><em>prefix</em> <x-wikilink data-target="foo">foo</x-wikilink> <em>suffix</em></p>\n',
-  );
+test("wikilink with text on both sides and emphasis", () => {
+  const html = Bun.markdown.html("*prefix* [[foo]] *suffix*", { wikiLinks: true });
+  expect(html).toBe('<p><em>prefix</em> <x-wikilink data-target="foo">foo</x-wikilink> <em>suffix</em></p>\n');
 });
 
-test("multiple wikilinks with interleaved text", async () => {
-  expect(await renderMarkdown("a [[x]] b [[y]] c")).toBe(
+test("multiple wikilinks with interleaved text", () => {
+  const html = Bun.markdown.html("a [[x]] b [[y]] c", { wikiLinks: true });
+  expect(html).toBe(
     '<p>a <x-wikilink data-target="x">x</x-wikilink> b <x-wikilink data-target="y">y</x-wikilink> c</p>\n',
   );
 });
 
-test("wikilink parse failure falls back to regular link without duplicating text", async () => {
-  expect(await renderMarkdown("pre [[foo]\n\n[foo]: /url")).toBe('<p>pre [<a href="/url">foo</a></p>\n');
+test("wikilink parse failure falls back to regular link without duplicating text", () => {
+  const html = Bun.markdown.html("pre [[foo]\n\n[foo]: /url", { wikiLinks: true });
+  expect(html).toBe('<p>pre [<a href="/url">foo</a></p>\n');
 });


### PR DESCRIPTION
## Repro
```js
Bun.markdown.html(`Hello [[world]], this is a test.`, { wikiLinks: true })
```

**Expected:** `<p>Hello <x-wikilink data-target="world">world</x-wikilink>, this is a test.</p>`
**Actual:** `<p><x-wikilink data-target="world">world</x-wikilink>Hello , this is a test.</p>`

## Cause
In `src/md/inlines.zig`, the wiki-link branch called `processWikiLink` first, then emitted the pending preceding text:

```zig
if (try self.processWikiLink(content, i)) |end_pos| {
    if (i > text_start) try self.emitText(.normal, content[text_start..i]);  // emitted AFTER the wikilink
    ...
}
```

But `processWikiLink` renders the wikilink HTML as a side effect (`enterSpan` + `processInlineContent` + `leaveSpan`) before returning, so the preceding text always landed after the wikilink.

The other inline handlers (HTML tags, autolinks, entities) emit pending text *before* rendering, which is the correct order.

## Fix
Emit pending text before calling `processWikiLink`, and reset `text_start` so that on parse failure (`[[foo]` → returns null) the regular link handler at line 213 does not re-emit the same text.

## Verification
- Added regression test at `test/regression/issue/28810.test.ts` (5 cases: preceding text, labels, emphasis neighbors, multiple wikilinks, parse-failure fallback).
- 4/5 new tests fail without the fix, all 5 pass with it.
- All 792 existing `md-spec` tests pass, all 1021 tests in `test/js/bun/md/` pass.

Fixes #28810