### PR TITLE
bunx: fix git dependency parsing and SCP-like URL handling

### DIFF
--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -457,6 +457,14 @@ pub const BunxCommand = struct {
                 }),
                 update_request.name,
             }
+        else if (update_request.version.tag == .git)
+            // For git URLs with no alias (e.g. git@host:org/repo.git), pass the
+            // URL directly so that `bun add` re-parses it as a git dependency
+            // instead of mangling it into "binName@gitUrl".
+            .{
+                display_version,
+                initial_bin_name,
+            }
         else
             // When there is not a clear package name (URL/GitHub/etc), we force the package name
             // to be the same as the calculated initial bin name. This allows us to have a predictable

--- a/src/install/PackageManager/UpdateRequest.zig
+++ b/src/install/PackageManager/UpdateRequest.zig
@@ -144,7 +144,7 @@ fn parseWithError(
         if (!Dependency.isTarball(input) and strings.isNPMPackageName(input)) {
             alias = input;
             value = input[input.len..];
-        } else if (input.len > 1) {
+        } else if (input.len > 1 and !Dependency.isSCPLikePath(input)) {
             if (strings.indexOfChar(input[1..], '@')) |at| {
                 const name = input[0 .. at + 1];
                 if (strings.isNPMPackageName(name)) {


### PR DESCRIPTION

Fixes #28813

### What does this PR do?

- Prevent SCP-like git URLs (e.g., git@github.com:org/repo) from being misidentified as npm package aliases in UpdateRequest.
- Ensure git dependencies in bunx are passed to the installer without mangling the URL when no alias is provided.

### How did you verify your code works?

```
$ bun run build --asan=off
$ ./build/debug/bun-debug x --package=git@git-private.com:organization/repo.git command
# command run successfully
```
