### PR TITLE
Fix bunx with private git SCP-like package URLs

### DIFF
--- a/src/install/PackageManager/UpdateRequest.zig
+++ b/src/install/PackageManager/UpdateRequest.zig
@@ -188,8 +188,14 @@ fn parseWithError(
                 log,
                 pm,
             )) |ver| {
-                alias = null;
-                version = ver;
+                // Only strip the alias when the full input also parses as a
+                // git/github URL. Otherwise the initial alias was legitimate
+                // (e.g. `alias@git@host:path` where `alias` is a real alias
+                // and `git@host:path` is the SCP URL).
+                if (ver.tag == .git or ver.tag == .github) {
+                    alias = null;
+                    version = ver;
+                }
             }
         }
         if (switch (version.tag) {

--- a/src/install/dependency.zig
+++ b/src/install/dependency.zig
@@ -159,7 +159,11 @@ pub inline fn isSCPLikePath(dependency: string) bool {
     for (dependency, 0..) |c, i| {
         switch (c) {
             '@' => {
-                if (at_index == null) at_index = i;
+                // SCP format is `[user@]host:path` — only one `@` is allowed
+                // before the colon. A second `@` means this is actually an
+                // alias like `alias@git@host:path`, not a valid SCP path.
+                if (at_index != null) return false;
+                at_index = i;
             },
             ':' => {
                 if (strings.hasPrefixComptime(dependency[i..], "://")) return false;

--- a/src/install/repository.zig
+++ b/src/install/repository.zig
@@ -444,7 +444,7 @@ pub const Repository = extern struct {
 
             bun.copy(u8, rest, url);
             if (colon_index) |colon| rest[colon] = '/';
-            const final = ssh_path_buf[0 .. url.len + "ssh://".len];
+            const final = ssh_path_buf[0 .. url.len + "ssh://git@".len];
             return final;
         }
 

--- a/test/regression/issue/28813.test.ts
+++ b/test/regression/issue/28813.test.ts
@@ -28,7 +28,7 @@ test.skipIf(isWindows)("bunx --package=<scp-url> does not mangle the git URL", a
     env,
     cwd: join(String(dir), "cwd"),
     stderr: "pipe",
-    stdout: "pipe",
+    stdout: "ignore",
   });
 
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);

--- a/test/regression/issue/28813.test.ts
+++ b/test/regression/issue/28813.test.ts
@@ -1,0 +1,70 @@
+// https://github.com/oven-sh/bun/issues/28813
+//
+// `bunx --package=<scp-style-git-url> <binary>` was constructing a malformed
+// URL by prefixing `<binary>@` to the SCP URL. The resulting
+// `<binary>@git@host:org/repo.git` got re-detected as an SCP-like path,
+// yielding `https://<binary>@git@host/org/repo.git` passed to `git clone`.
+import { expect, test } from "bun:test";
+import { chmodSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+test.skipIf(isWindows)("bunx --package=<scp-url> does not mangle the git URL", async () => {
+  // A fake `git` that logs its arguments to a file, then exits non-zero so
+  // the package manager bails out of the resolve step with the error we
+  // need to inspect.
+  using dir = tempDir("bunx-28813-", {
+    "fakegit/git": `#!/bin/sh\nprintf '%s\\n' "$*" >> "$GIT_LOG_FILE"\nexit 128\n`,
+    "cwd/package.json": "{}\n",
+  });
+
+  const gitLogFile = join(String(dir), "git-cmds.log");
+  writeFileSync(gitLogFile, "");
+  chmodSync(join(String(dir), "fakegit", "git"), 0o755);
+
+  const env = {
+    ...bunEnv,
+    GIT_LOG_FILE: gitLogFile,
+    PATH: `${join(String(dir), "fakegit")}:${bunEnv.PATH}`,
+  };
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "x",
+      "--package=git@private-repo.example:organization/repo.git",
+      "somebin",
+    ],
+    env,
+    cwd: join(String(dir), "cwd"),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // Expected to fail (our fake git exits 128), but the URL passed to git must
+  // be well-formed — no `somebin@git@...` double-userinfo splice.
+  expect(exitCode).not.toBe(0);
+
+  const gitLog = await Bun.file(gitLogFile).text();
+  expect(gitLog.length).toBeGreaterThan(0);
+
+  // Every `git clone` attempt must target the real host, not the binary name.
+  const cloneLines = gitLog.split("\n").filter(line => line.startsWith("clone"));
+  expect(cloneLines.length).toBeGreaterThan(0);
+  for (const line of cloneLines) {
+    // The URL is the second-to-last token in the `git clone … <url> <target>` line.
+    const tokens = line.split(/\s+/);
+    const url = tokens[tokens.length - 2];
+    expect(url).not.toContain("somebin@git@");
+    expect(url).toContain("private-repo.example");
+    // Sanity: the user portion (if any) is just `git`, not `somebin@git`.
+    expect(url).not.toMatch(/somebin@/);
+  }
+
+  // And the install failure itself must reference the real URL, not a
+  // binary-prefixed mangled form pointing at a different host.
+  expect(stderr).not.toContain("https://somebin@git@");
+  expect(stderr).not.toContain("ssh://git@somebin@git@");
+});

--- a/test/regression/issue/28813.test.ts
+++ b/test/regression/issue/28813.test.ts
@@ -5,9 +5,9 @@
 // `<binary>@git@host:org/repo.git` got re-detected as an SCP-like path,
 // yielding `https://<binary>@git@host/org/repo.git` passed to `git clone`.
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { chmodSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 test.skipIf(isWindows)("bunx --package=<scp-url> does not mangle the git URL", async () => {
   // A fake `git` that logs its arguments to a file, then exits non-zero so
@@ -29,12 +29,7 @@ test.skipIf(isWindows)("bunx --package=<scp-url> does not mangle the git URL", a
   };
 
   await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "x",
-      "--package=git@private-repo.example:organization/repo.git",
-      "somebin",
-    ],
+    cmd: [bunExe(), "x", "--package=git@private-repo.example:organization/repo.git", "somebin"],
     env,
     cwd: join(String(dir), "cwd"),
     stderr: "pipe",

--- a/test/regression/issue/28813.test.ts
+++ b/test/regression/issue/28813.test.ts
@@ -1,9 +1,4 @@
 // https://github.com/oven-sh/bun/issues/28813
-//
-// `bunx --package=<scp-style-git-url> <binary>` was constructing a malformed
-// URL by prefixing `<binary>@` to the SCP URL. The resulting
-// `<binary>@git@host:org/repo.git` got re-detected as an SCP-like path,
-// yielding `https://<binary>@git@host/org/repo.git` passed to `git clone`.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { chmodSync, writeFileSync } from "node:fs";
@@ -38,10 +33,6 @@ test.skipIf(isWindows)("bunx --package=<scp-url> does not mangle the git URL", a
 
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-  // Expected to fail (our fake git exits 128), but the URL passed to git must
-  // be well-formed — no `somebin@git@...` double-userinfo splice.
-  expect(exitCode).not.toBe(0);
-
   const gitLog = await Bun.file(gitLogFile).text();
   expect(gitLog.length).toBeGreaterThan(0);
 
@@ -62,4 +53,7 @@ test.skipIf(isWindows)("bunx --package=<scp-url> does not mangle the git URL", a
   // binary-prefixed mangled form pointing at a different host.
   expect(stderr).not.toContain("https://somebin@git@");
   expect(stderr).not.toContain("ssh://git@somebin@git@");
+
+  // Expected to fail because our fake git exits 128.
+  expect(exitCode).not.toBe(0);
 });

--- a/test/regression/issue/28813.test.ts
+++ b/test/regression/issue/28813.test.ts
@@ -4,11 +4,8 @@ import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { chmodSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-test.skipIf(isWindows)("bunx --package=<scp-url> does not mangle the git URL", async () => {
-  // A fake `git` that logs its arguments to a file, then exits non-zero so
-  // the package manager bails out of the resolve step with the error we
-  // need to inspect.
-  using dir = tempDir("bunx-28813-", {
+async function runBunxWithFakeGit(pkg: string) {
+  using dir = tempDir(`bunx-28813-${Math.random().toString(36).slice(2, 8)}-`, {
     "fakegit/git": `#!/bin/sh\nprintf '%s\\n' "$*" >> "$GIT_LOG_FILE"\nexit 128\n`,
     "cwd/package.json": "{}\n",
   });
@@ -24,7 +21,7 @@ test.skipIf(isWindows)("bunx --package=<scp-url> does not mangle the git URL", a
   };
 
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "x", "--package=git@private-repo.example:organization/repo.git", "somebin"],
+    cmd: [bunExe(), "x", `--package=${pkg}`, "somebin"],
     env,
     cwd: join(String(dir), "cwd"),
     stderr: "pipe",
@@ -34,26 +31,50 @@ test.skipIf(isWindows)("bunx --package=<scp-url> does not mangle the git URL", a
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
   const gitLog = await Bun.file(gitLogFile).text();
-  expect(gitLog.length).toBeGreaterThan(0);
+  const cloneUrls = gitLog
+    .split("\n")
+    .filter(line => line.startsWith("clone"))
+    .map(line => {
+      // `clone … <url> <target>` — URL is the second-to-last token.
+      const tokens = line.split(/\s+/);
+      return tokens[tokens.length - 2];
+    });
 
-  // Every `git clone` attempt must target the real host, not the binary name.
-  const cloneLines = gitLog.split("\n").filter(line => line.startsWith("clone"));
-  expect(cloneLines.length).toBeGreaterThan(0);
-  for (const line of cloneLines) {
-    // The URL is the second-to-last token in the `git clone … <url> <target>` line.
-    const tokens = line.split(/\s+/);
-    const url = tokens[tokens.length - 2];
+  return { stderr, exitCode, cloneUrls };
+}
+
+test.skipIf(isWindows)("bunx --package=<scp-url> does not mangle the git URL", async () => {
+  // A fake `git` logs its arguments to a file, then exits non-zero so the
+  // package manager bails out of the resolve step with the error to inspect.
+  const { stderr, exitCode, cloneUrls } = await runBunxWithFakeGit("git@private-repo.example:organization/repo.git");
+
+  expect(cloneUrls.length).toBeGreaterThan(0);
+  for (const url of cloneUrls) {
+    // No `somebin@git@…` double-userinfo splice, and the real host must survive.
     expect(url).not.toContain("somebin@git@");
     expect(url).toContain("private-repo.example");
-    // Sanity: the user portion (if any) is just `git`, not `somebin@git`.
     expect(url).not.toMatch(/somebin@/);
   }
 
-  // And the install failure itself must reference the real URL, not a
-  // binary-prefixed mangled form pointing at a different host.
   expect(stderr).not.toContain("https://somebin@git@");
   expect(stderr).not.toContain("ssh://git@somebin@git@");
 
   // Expected to fail because our fake git exits 128.
+  expect(exitCode).not.toBe(0);
+});
+
+test.skipIf(isWindows)("trySSH does not truncate the last 4 bytes of unrecognised SCP hosts", async () => {
+  // Bare SCP-style URL with a host not in the known-hosts table routes
+  // through trySSH's fallback branch, which previously returned a slice
+  // that was 4 bytes short of the actual `ssh://git@host/path.git`
+  // buffer, silently dropping `.git`.
+  const { exitCode, cloneUrls } = await runBunxWithFakeGit("myhost.example:org/repo.git");
+
+  expect(cloneUrls.length).toBeGreaterThan(0);
+  // Every logged URL should still end with `.git` — nothing chopped off.
+  for (const url of cloneUrls) {
+    expect(url).toMatch(/\.git$/);
+  }
+
   expect(exitCode).not.toBe(0);
 });


### PR DESCRIPTION
Fixes #28813.

## Reproduction

```console
$ bunx --package=git@private-repo.example:organization/repo.git somebin
error: "git clone" for "somebin@git@private-repo.example:organization/repo.git" failed
```

Intercepting `git`, the URL passed was:

```
clone … --bare https://somebin@git@private-repo.example/organization/repo.git …
```

— malformed: `somebin@git@…` is not a valid userinfo segment.

## Cause

bunx built `install_param = "<binary>@<scp-url>"` and passed it to `bun add`. The add-time parser:

1. Split on the first `@` → alias = `<binary>`, value = `<scp-url>`.
2. Value parsed as `.git` (valid SCP path).
3. Because it saw `alias + git`, it reparsed the full input with no alias. That reparse hit `isSCPLikePath`, which only required any `@` before any `:` — so `<binary>@git@host:path` was (incorrectly) accepted as an SCP path.
4. The reparse's literal (`<binary>@git@host:path`) then went straight into `Repository.repo`, and `tryHTTPS` prefixed `https://` producing the malformed URL.

## Fix

- **`isSCPLikePath`**: reject strings with more than one `@` before the `:`. SCP format is `[user@]host:path` and the user field cannot contain `@`, so a second `@` means this is really `alias@git@host:path`, not a valid SCP URL.
- **`UpdateRequest` reparse**: only strip the alias when the full input also re-parses as `.git` / `.github`. A legitimate `alias@git-url` pairing stays intact even if the reparse returns something else.

## Verification

Regression test `test/regression/issue/28813.test.ts` intercepts `git` with a shim and asserts every `git clone` URL bunx emits:
- contains the real host, and
- does NOT contain the `<binary>@git@` double-userinfo splice.

```
bun bd test test/regression/issue/28813.test.ts   → pass
USE_SYSTEM_BUN=1 bun test …                       → fail (bug still present)
```

Other `test/cli/install/bunx.test.ts` cases that exercise `--package` against a mock registry continue to pass.