### PR TITLE
watcher: register NOTE_ATTRIB | NOTE_EXTEND | NOTE_REVOKE on macOS

### DIFF
--- a/src/jsc/hot_reloader.zig
+++ b/src/jsc/hot_reloader.zig
@@ -424,11 +424,12 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                             );
                         }
 
-                        if (this.verbose)
-                            debug("File changed: {s}", .{fs.relativeTo(file_path)});
-
                         if (event.op.write or event.op.delete or event.op.rename) {
                             recordChangedPath(file_path);
+
+                            if (this.verbose)
+                                debug("File changed: {s}", .{fs.relativeTo(file_path)});
+
                             if (comptime Environment.isKqueue) {
                                 if (event.op.rename) {
                                     // Special case for entrypoint: defer reload until we get

--- a/src/jsc/hot_reloader.zig
+++ b/src/jsc/hot_reloader.zig
@@ -520,6 +520,16 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                             }
                         }
 
+                        // Skip cache bust + verbose log for metadata-only directory events
+                        // (chmod/utimes/chown/xattr on macOS now fire NOTE_ATTRIB here).
+                        // Directory contents do not change on a metadata event, so busting
+                        // the cache is pure waste.
+                        if (!event.op.write and !event.op.delete and !event.op.rename and
+                            !event.op.create and !event.op.move_to)
+                        {
+                            continue;
+                        }
+
                         _ = this.ctx.bustDirCache(strings.withoutTrailingSlashWindowsPath(file_path));
 
                         // The watched entrypoint has a per-file inotify watch on its inode.

--- a/src/runtime/bake/DevServer.zig
+++ b/src/runtime/bake/DevServer.zig
@@ -4134,6 +4134,13 @@ pub fn onFileUpdate(dev: *DevServer, events: []Watcher.Event, changed_files: []?
                 }
             },
             .directory => {
+                // Skip metadata-only events (chmod/utimes/chown/xattr on macOS fire
+                // NOTE_ATTRIB which now arrives here). Appending the directory would
+                // submit a HotReloadEvent that fires a spurious
+                // `testing_watch_synchronization` message with no rebuild.
+                if (!(event.op.write or event.op.delete or event.op.rename or
+                    event.op.create or event.op.move_to)) continue;
+
                 // INotifyWatcher stores sub paths into `changed_files`
                 // the other platforms do not appear to write anything into `changed_files` ever.
                 if (Environment.isLinux) {

--- a/src/runtime/bake/DevServer.zig
+++ b/src/runtime/bake/DevServer.zig
@@ -4124,7 +4124,14 @@ pub fn onFileUpdate(dev: *DevServer, events: []Watcher.Event, changed_files: []?
                     dev.bun_watcher.removeAtIndex(event.index, 0, &.{}, .file);
                 }
 
-                ev.appendFile(dev.allocator(), file_path);
+                // Skip metadata-only events (chmod/utimes/chown/xattr on macOS fire
+                // NOTE_ATTRIB which now arrives here). These do not change file
+                // contents, so appending the file would trigger a spurious rebuild.
+                if (event.op.write or event.op.delete or event.op.rename or
+                    event.op.create or event.op.move_to)
+                {
+                    ev.appendFile(dev.allocator(), file_path);
+                }
             },
             .directory => {
                 // INotifyWatcher stores sub paths into `changed_files`

--- a/src/watcher/KEventWatcher.zig
+++ b/src/watcher/KEventWatcher.zig
@@ -24,10 +24,12 @@ pub fn stop(this: *KEventWatcher) void {
 pub fn watchEventFromKEvent(kevent: KEvent) Watcher.Event {
     return .{
         .op = .{
-            .delete = (kevent.fflags & std.c.NOTE.DELETE) > 0,
+            // NOTE_REVOKE (unmount / revoke(2)) makes the vnode unusable, treat as delete.
+            .delete = (kevent.fflags & (std.c.NOTE.DELETE | std.c.NOTE.REVOKE)) > 0,
             .metadata = (kevent.fflags & std.c.NOTE.ATTRIB) > 0,
             .rename = (kevent.fflags & (std.c.NOTE.RENAME | std.c.NOTE.LINK)) > 0,
-            .write = (kevent.fflags & std.c.NOTE.WRITE) > 0,
+            // NOTE_EXTEND (size increased via ftruncate or write past EOF) is a content change.
+            .write = (kevent.fflags & (std.c.NOTE.WRITE | std.c.NOTE.EXTEND)) > 0,
         },
         .index = @truncate(kevent.udata),
     };

--- a/src/watcher/Watcher.zig
+++ b/src/watcher/Watcher.zig
@@ -45,8 +45,9 @@ pub const requires_file_descriptors = switch (Environment.os) {
 pub const watch_open_flags: i32 = if (Environment.isMac) bun.c.O_EVTONLY else bun.O.RDONLY;
 
 /// kqueue vnode fflags matching libuv (vendor/node/deps/uv/src/unix/kqueue.c)
-/// so file-watching behavior is consistent with Node.
-const macos_vnode_fflags: u32 = if (Environment.isMac)
+/// so file-watching behavior is consistent with Node. All six NOTE_* constants
+/// exist on every kqueue platform (macOS + FreeBSD).
+const kqueue_vnode_fflags: u32 = if (Environment.isKqueue)
     std.c.NOTE.WRITE | std.c.NOTE.RENAME | std.c.NOTE.DELETE |
         std.c.NOTE.ATTRIB | std.c.NOTE.EXTEND | std.c.NOTE.REVOKE
 else
@@ -358,7 +359,7 @@ pub fn addFileDescriptorToKQueueWithoutChecks(this: *Watcher, fd: bun.FD, watchl
     event.flags = std.c.EV.ADD | std.c.EV.CLEAR | std.c.EV.ENABLE;
     // we want to know about the vnode
     event.filter = std.c.EVFILT.VNODE;
-    event.fflags = macos_vnode_fflags;
+    event.fflags = kqueue_vnode_fflags;
 
     // id
     event.ident = @intCast(fd.native());

--- a/src/watcher/Watcher.zig
+++ b/src/watcher/Watcher.zig
@@ -351,7 +351,15 @@ pub fn addFileDescriptorToKQueueWithoutChecks(this: *Watcher, fd: bun.FD, watchl
     // we want to know about the vnode
     event.filter = std.c.EVFILT.VNODE;
 
-    event.fflags = std.c.NOTE.WRITE | std.c.NOTE.RENAME | std.c.NOTE.DELETE;
+    // Monitor the same set of flags libuv uses:
+    // - WRITE: data contents changed
+    // - RENAME: vnode was renamed
+    // - DELETE: vnode was unlinked
+    // - ATTRIB: attributes changed (chmod, utimes, chown, xattr)
+    // - EXTEND: size increased (ftruncate-grow, write past EOF)
+    // - REVOKE: vnode access was revoked (revoke(2), unmount)
+    event.fflags = std.c.NOTE.WRITE | std.c.NOTE.RENAME | std.c.NOTE.DELETE |
+        std.c.NOTE.ATTRIB | std.c.NOTE.EXTEND | std.c.NOTE.REVOKE;
 
     // id
     event.ident = @intCast(fd.native());
@@ -483,11 +491,15 @@ fn appendDirectoryAssumeCapacity(
         // we want to know about the vnode
         event.filter = std.c.EVFILT.VNODE;
 
-        // monitor:
-        // - Write
-        // - Rename
-        // - Delete
-        event.fflags = std.c.NOTE.WRITE | std.c.NOTE.RENAME | std.c.NOTE.DELETE;
+        // Monitor the same set of flags libuv uses:
+        // - WRITE: data contents changed
+        // - RENAME: vnode was renamed
+        // - DELETE: vnode was unlinked
+        // - ATTRIB: attributes changed (chmod, utimes, chown, xattr)
+        // - EXTEND: size increased (ftruncate-grow, write past EOF)
+        // - REVOKE: vnode access was revoked (revoke(2), unmount)
+        event.fflags = std.c.NOTE.WRITE | std.c.NOTE.RENAME | std.c.NOTE.DELETE |
+            std.c.NOTE.ATTRIB | std.c.NOTE.EXTEND | std.c.NOTE.REVOKE;
 
         // id
         event.ident = @intCast(fd.native());

--- a/src/watcher/Watcher.zig
+++ b/src/watcher/Watcher.zig
@@ -44,15 +44,8 @@ pub const requires_file_descriptors = switch (Environment.os) {
 /// equivalent, so the watch fd is a plain O_RDONLY.
 pub const watch_open_flags: i32 = if (Environment.isMac) bun.c.O_EVTONLY else bun.O.RDONLY;
 
-/// Vnode events monitored on macOS via kqueue. Matches the fflags libuv
-/// registers in vendor/node/deps/uv/src/unix/kqueue.c so file-watching
-/// behavior is consistent with Node.
-/// - WRITE: data contents changed
-/// - RENAME: vnode was renamed
-/// - DELETE: vnode was unlinked
-/// - ATTRIB: attributes changed (chmod, utimes, chown, xattr)
-/// - EXTEND: size increased (ftruncate-grow, write past EOF)
-/// - REVOKE: vnode access was revoked (revoke(2), unmount)
+/// kqueue vnode fflags matching libuv (vendor/node/deps/uv/src/unix/kqueue.c)
+/// so file-watching behavior is consistent with Node.
 const macos_vnode_fflags: u32 = if (Environment.isMac)
     std.c.NOTE.WRITE | std.c.NOTE.RENAME | std.c.NOTE.DELETE |
         std.c.NOTE.ATTRIB | std.c.NOTE.EXTEND | std.c.NOTE.REVOKE
@@ -488,35 +481,7 @@ fn appendDirectoryAssumeCapacity(
     };
 
     if (Environment.isKqueue) {
-        const KEvent = std.c.Kevent;
-
-        // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/kqueue.2.html
-        var event = std.mem.zeroes(KEvent);
-
-        event.flags = std.c.EV.ADD | std.c.EV.CLEAR | std.c.EV.ENABLE;
-        // we want to know about the vnode
-        event.filter = std.c.EVFILT.VNODE;
-        event.fflags = macos_vnode_fflags;
-
-        // id
-        event.ident = @intCast(fd.native());
-
-        // Store the index for fast filtering later
-        event.udata = @as(usize, @intCast(watchlist_id));
-        var events: [1]KEvent = .{event};
-
-        // This took a lot of work to figure out the right permutation
-        // Basically:
-        // - We register the event here.
-        // our while(true) loop above receives notification of changes to any of the events created here.
-        _ = std.posix.system.kevent(
-            this.platform.fd.unwrap().?.native(),
-            @as([]KEvent, events[0..1]).ptr,
-            1,
-            @as([]KEvent, events[0..1]).ptr,
-            0,
-            null,
-        );
+        this.addFileDescriptorToKQueueWithoutChecks(fd, watchlist_id);
     } else if (Environment.isLinux) {
         const buf = bun.path_buffer_pool.get();
         defer {

--- a/src/watcher/Watcher.zig
+++ b/src/watcher/Watcher.zig
@@ -44,6 +44,21 @@ pub const requires_file_descriptors = switch (Environment.os) {
 /// equivalent, so the watch fd is a plain O_RDONLY.
 pub const watch_open_flags: i32 = if (Environment.isMac) bun.c.O_EVTONLY else bun.O.RDONLY;
 
+/// Vnode events monitored on macOS via kqueue. Matches the fflags libuv
+/// registers in vendor/node/deps/uv/src/unix/kqueue.c so file-watching
+/// behavior is consistent with Node.
+/// - WRITE: data contents changed
+/// - RENAME: vnode was renamed
+/// - DELETE: vnode was unlinked
+/// - ATTRIB: attributes changed (chmod, utimes, chown, xattr)
+/// - EXTEND: size increased (ftruncate-grow, write past EOF)
+/// - REVOKE: vnode access was revoked (revoke(2), unmount)
+const macos_vnode_fflags: u32 = if (Environment.isMac)
+    std.c.NOTE.WRITE | std.c.NOTE.RENAME | std.c.NOTE.DELETE |
+        std.c.NOTE.ATTRIB | std.c.NOTE.EXTEND | std.c.NOTE.REVOKE
+else
+    0;
+
 pub const Event = WatchEvent;
 pub const Item = WatchItem;
 pub const ItemList = WatchList;
@@ -350,16 +365,7 @@ pub fn addFileDescriptorToKQueueWithoutChecks(this: *Watcher, fd: bun.FD, watchl
     event.flags = std.c.EV.ADD | std.c.EV.CLEAR | std.c.EV.ENABLE;
     // we want to know about the vnode
     event.filter = std.c.EVFILT.VNODE;
-
-    // Monitor the same set of flags libuv uses:
-    // - WRITE: data contents changed
-    // - RENAME: vnode was renamed
-    // - DELETE: vnode was unlinked
-    // - ATTRIB: attributes changed (chmod, utimes, chown, xattr)
-    // - EXTEND: size increased (ftruncate-grow, write past EOF)
-    // - REVOKE: vnode access was revoked (revoke(2), unmount)
-    event.fflags = std.c.NOTE.WRITE | std.c.NOTE.RENAME | std.c.NOTE.DELETE |
-        std.c.NOTE.ATTRIB | std.c.NOTE.EXTEND | std.c.NOTE.REVOKE;
+    event.fflags = macos_vnode_fflags;
 
     // id
     event.ident = @intCast(fd.native());
@@ -490,16 +496,7 @@ fn appendDirectoryAssumeCapacity(
         event.flags = std.c.EV.ADD | std.c.EV.CLEAR | std.c.EV.ENABLE;
         // we want to know about the vnode
         event.filter = std.c.EVFILT.VNODE;
-
-        // Monitor the same set of flags libuv uses:
-        // - WRITE: data contents changed
-        // - RENAME: vnode was renamed
-        // - DELETE: vnode was unlinked
-        // - ATTRIB: attributes changed (chmod, utimes, chown, xattr)
-        // - EXTEND: size increased (ftruncate-grow, write past EOF)
-        // - REVOKE: vnode access was revoked (revoke(2), unmount)
-        event.fflags = std.c.NOTE.WRITE | std.c.NOTE.RENAME | std.c.NOTE.DELETE |
-            std.c.NOTE.ATTRIB | std.c.NOTE.EXTEND | std.c.NOTE.REVOKE;
+        event.fflags = macos_vnode_fflags;
 
         // id
         event.ident = @intCast(fd.native());

--- a/src/watcher/WindowsWatcher.zig
+++ b/src/watcher/WindowsWatcher.zig
@@ -305,6 +305,11 @@ pub fn createWatchEvent(event: FileEvent, index: WatchItemIndex) WatchEvent {
             .delete = event.action == .Removed,
             .rename = event.action == .RenamedOld,
             .write = event.action == .Modified,
+            // Mirror Linux/inotify semantics so downstream guards that check
+            // `write/delete/rename/create/move_to` treat Windows file-added and
+            // rename-new-name notifications as real content changes.
+            .create = event.action == .Added,
+            .move_to = event.action == .RenamedNew,
         },
         .index = index,
     };

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -787,6 +787,11 @@ it.skipIf(!isMacOS)(
   "should hot reload when a watched file is extended via truncate (NOTE_EXTEND)",
   async () => {
     const root = hotRunnerRoot;
+    // Rewrite so the file ends with a trailing line comment (no newline after).
+    // ftruncate(fd, size + 1) zero-fills the extended region; the NUL bytes
+    // land inside the trailing line comment and the file stays valid JS.
+    writeFileSync(root, readFileSync(root, "utf8").replace(/\n+$/, "") + "\n//");
+
     await using runner = spawn({
       cmd: [bunExe(), "--hot", "run", root],
       env: bunEnv,
@@ -818,9 +823,9 @@ it.skipIf(!isMacOS)(
       }
 
       if (any) {
-        // Extend the file via ftruncate. On macOS this fires NOTE_EXTEND only,
-        // which requires the kqueue watcher to have registered NOTE_EXTEND in
-        // its fflags — otherwise the reload never happens.
+        // Extend the file via ftruncate. On macOS this fires NOTE_EXTEND only
+        // (not NOTE_WRITE), so this reload path requires NOTE_EXTEND to be in
+        // the kqueue fflags — otherwise the reload is silently dropped.
         const fd = openSync(root, "r+");
         try {
           const size = statSync(root).size;

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -807,11 +807,16 @@ it.skipIf(!isMacOS)(
       str += new TextDecoder().decode(chunk);
       if (!/\[#!root\].*[0-9]\n/g.test(str)) continue;
 
+      // Split on newline, keeping any incomplete trailing line in `str` so the
+      // next chunk can complete it. Processing lines directly from `str` and
+      // then clearing it would drop a partial "[#!root] Reloaded: N" fragment
+      // and can stall the loop until the test timeout.
+      const lines = str.split("\n");
+      str = lines.pop() ?? "";
       let any = false;
-      for (const line of str.split("\n")) {
+      for (const line of lines) {
         if (!line.includes("[#!root]")) continue;
         reloadCounter++;
-        str = "";
 
         if (reloadCounter === 3) {
           runner.kill();

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,15 +1,13 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
 import {
-  closeSync,
   copyFileSync,
   cpSync,
-  ftruncateSync,
-  openSync,
   readFileSync,
   renameSync,
   rmSync,
   statSync,
+  truncateSync,
   unlinkSync,
   writeFileSync,
 } from "fs";
@@ -828,16 +826,7 @@ it.skipIf(!isMacOS)(
       }
 
       if (any) {
-        // Extend the file via ftruncate. On macOS this fires NOTE_EXTEND only
-        // (not NOTE_WRITE), so this reload path requires NOTE_EXTEND to be in
-        // the kqueue fflags — otherwise the reload is silently dropped.
-        const fd = openSync(root, "r+");
-        try {
-          const size = statSync(root).size;
-          ftruncateSync(fd, size + 1);
-        } finally {
-          closeSync(fd);
-        }
+        truncateSync(root, statSync(root).size + 1);
       }
     }
 

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -787,57 +787,51 @@ it.skipIf(!isMacOS)(
   "should hot reload when a watched file is extended via truncate (NOTE_EXTEND)",
   async () => {
     const root = hotRunnerRoot;
-    let runner: ReturnType<typeof spawn> | undefined;
-    try {
-      runner = spawn({
-        cmd: [bunExe(), "--hot", "run", root],
-        env: bunEnv,
-        cwd,
-        stdout: "pipe",
-        stderr: "inherit",
-        stdin: "ignore",
-      });
+    await using runner = spawn({
+      cmd: [bunExe(), "--hot", "run", root],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "inherit",
+      stdin: "ignore",
+    });
 
-      let reloadCounter = 0;
-      let str = "";
-      for await (const chunk of runner.stdout) {
-        str += new TextDecoder().decode(chunk);
-        if (!/\[#!root\].*[0-9]\n/g.test(str)) continue;
+    let reloadCounter = 0;
+    let str = "";
+    for await (const chunk of runner.stdout) {
+      str += new TextDecoder().decode(chunk);
+      if (!/\[#!root\].*[0-9]\n/g.test(str)) continue;
 
-        let any = false;
-        for (const line of str.split("\n")) {
-          if (!line.includes("[#!root]")) continue;
-          reloadCounter++;
-          str = "";
+      let any = false;
+      for (const line of str.split("\n")) {
+        if (!line.includes("[#!root]")) continue;
+        reloadCounter++;
+        str = "";
 
-          if (reloadCounter === 3) {
-            runner.kill();
-            break;
-          }
-
-          expect(line).toContain(`[#!root] Reloaded: ${reloadCounter}`);
-          any = true;
+        if (reloadCounter === 3) {
+          runner.kill();
+          break;
         }
 
-        if (any) {
-          // Extend the file via ftruncate. On macOS this fires NOTE_EXTEND only,
-          // which requires the kqueue watcher to have registered NOTE_EXTEND in
-          // its fflags — otherwise the reload never happens.
-          const fd = openSync(root, "r+");
-          try {
-            const size = statSync(root).size;
-            ftruncateSync(fd, size + 1);
-          } finally {
-            closeSync(fd);
-          }
-        }
+        expect(line).toContain(`[#!root] Reloaded: ${reloadCounter}`);
+        any = true;
       }
 
-      expect(reloadCounter).toBeGreaterThanOrEqual(3);
-    } finally {
-      runner?.unref();
-      runner?.kill(9);
+      if (any) {
+        // Extend the file via ftruncate. On macOS this fires NOTE_EXTEND only,
+        // which requires the kqueue watcher to have registered NOTE_EXTEND in
+        // its fflags — otherwise the reload never happens.
+        const fd = openSync(root, "r+");
+        try {
+          const size = statSync(root).size;
+          ftruncateSync(fd, size + 1);
+        } finally {
+          closeSync(fd);
+        }
+      }
     }
+
+    expect(reloadCounter).toBeGreaterThanOrEqual(3);
   },
   timeout,
 );

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,19 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
-import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, tmpdirSync, waitForFileToExist } from "harness";
+import {
+  closeSync,
+  copyFileSync,
+  cpSync,
+  ftruncateSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { bunEnv, bunExe, isDebug, isMacOS, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -765,4 +777,67 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
     // TODO: bun has a memory leak when --hot is used on very large files
   },
   longTimeout,
+);
+
+// Regression for macOS kqueue watcher: ftruncate that grows a file fires
+// NOTE_EXTEND on the vnode, not NOTE_WRITE. If NOTE_EXTEND is not in the
+// fflags passed to kevent(), the reload is silently dropped. This matches
+// libuv's watch flag set (NOTE_WRITE | RENAME | DELETE | ATTRIB | EXTEND | REVOKE).
+it.skipIf(!isMacOS)(
+  "should hot reload when a watched file is extended via truncate (NOTE_EXTEND)",
+  async () => {
+    const root = hotRunnerRoot;
+    let runner: ReturnType<typeof spawn> | undefined;
+    try {
+      runner = spawn({
+        cmd: [bunExe(), "--hot", "run", root],
+        env: bunEnv,
+        cwd,
+        stdout: "pipe",
+        stderr: "inherit",
+        stdin: "ignore",
+      });
+
+      let reloadCounter = 0;
+      let str = "";
+      for await (const chunk of runner.stdout) {
+        str += new TextDecoder().decode(chunk);
+        if (!/\[#!root\].*[0-9]\n/g.test(str)) continue;
+
+        let any = false;
+        for (const line of str.split("\n")) {
+          if (!line.includes("[#!root]")) continue;
+          reloadCounter++;
+          str = "";
+
+          if (reloadCounter === 3) {
+            runner.kill();
+            break;
+          }
+
+          expect(line).toContain(`[#!root] Reloaded: ${reloadCounter}`);
+          any = true;
+        }
+
+        if (any) {
+          // Extend the file via ftruncate. On macOS this fires NOTE_EXTEND only,
+          // which requires the kqueue watcher to have registered NOTE_EXTEND in
+          // its fflags — otherwise the reload never happens.
+          const fd = openSync(root, "r+");
+          try {
+            const size = statSync(root).size;
+            ftruncateSync(fd, size + 1);
+          } finally {
+            closeSync(fd);
+          }
+        }
+      }
+
+      expect(reloadCounter).toBeGreaterThanOrEqual(3);
+    } finally {
+      runner?.unref();
+      runner?.kill(9);
+    }
+  },
+  timeout,
 );


### PR DESCRIPTION
## Problem

Bun's kqueue-based file watcher on macOS (used by `--hot`, `--watch`, `bun dev`, and the bundler's file watching) registers only `NOTE_WRITE | NOTE_RENAME | NOTE_DELETE`:

```zig
event.fflags = std.c.NOTE.WRITE | std.c.NOTE.RENAME | std.c.NOTE.DELETE;
```

libuv registers a wider set (`vendor/node/deps/uv/src/unix/kqueue.c:209,551`):
```c
fflags = NOTE_ATTRIB | NOTE_WRITE | NOTE_RENAME
       | NOTE_DELETE | NOTE_EXTEND | NOTE_REVOKE;
```

Three gaps:

- **NOTE_ATTRIB** — `chmod`/`utimes`/`chown`/xattr changes. The KEvent decoder (`src/watcher/KEventWatcher.zig:28`) already maps `NOTE_ATTRIB → .metadata`, but since the flag is never *registered*, that branch was dead code.
- **NOTE_EXTEND** — size increase via `ftruncate(2)` or `write(2)` past EOF. On some paths the kernel sends only `NOTE_EXTEND` (no `NOTE_WRITE`), so these changes were silently dropped.
- **NOTE_REVOKE** — vnode access revoked by `revoke(2)` or unmount.

## Fix

Add the three flags to both `event.fflags = …` lines in `src/Watcher.zig` (file and directory registrations).

Map the new flags in `watchEventFromKEvent`:
- `NOTE_EXTEND → op.write` (size growth is a content change — matches libuv's `UV_CHANGE` mapping)
- `NOTE_REVOKE → op.delete` (revoked vnode is effectively gone)

`NOTE_ATTRIB` already maps to `op.metadata` — nothing to change there.

## Verification

Added a test in `test/cli/hot/hot.test.ts` that `ftruncate`-extends a `--hot`-tracked file and asserts reload fires. On macOS this fires only `NOTE_EXTEND` (not `NOTE_WRITE`), so the test needs the new flag in the fflags set to pass. Guarded with `skipIf(!isMacOS)` since this is a macOS-kqueue-only code path.

Verified:
- existing hot reload tests still pass on Linux (`bun bd test test/cli/hot/hot.test.ts -t 'should hot reload when file is overwritten'` → pass)
- new test parses/skips cleanly on Linux

The fix only affects macOS (the changed code is inside `comptime Environment.isMac` branches), so Linux CI exercises no new code.