### PR TITLE
sql: don't double-encode pre-stringified JSON parameters

### DIFF
--- a/src/sql_jsc/mysql/MySQLValue.zig
+++ b/src/sql_jsc/mysql/MySQLValue.zig
@@ -255,6 +255,15 @@ pub const Value = union(enum) {
             },
 
             .MYSQL_TYPE_JSON => {
+                if (value.isString()) {
+                    // The user pre-serialized their JSON value (e.g. via
+                    // JSON.stringify). Send it verbatim; calling
+                    // jsonStringifyFast here would wrap it in an extra layer
+                    // of quoting.
+                    const str = try bun.String.fromJS(value, globalObject);
+                    defer str.deref();
+                    return Value{ .string = str.toUTF8(bun.default_allocator) };
+                }
                 var str: bun.String = bun.String.empty;
                 // Use jsonStringifyFast for SIMD-optimized serialization
                 try value.jsonStringifyFast(globalObject, &str);

--- a/src/sql_jsc/postgres/PostgresRequest.zig
+++ b/src/sql_jsc/postgres/PostgresRequest.zig
@@ -103,15 +103,30 @@ pub fn writeBind(
         // timezone.
         if (tag.isBinaryFormatSupported() and value.isString()) .text else tag) {
             .jsonb, .json => {
-                var str = bun.String.empty;
-                defer str.deref();
-                // Use jsonStringifyFast for SIMD-optimized serialization
-                try value.jsonStringifyFast(globalObject, &str);
-                const slice = str.toUTF8WithoutRef(bun.default_allocator);
-                defer slice.deinit();
-                const l = try writer.length();
-                try writer.write(slice.slice());
-                try l.writeExcludingSelf();
+                if (value.isString()) {
+                    // The user pre-serialized their JSON value (e.g. via
+                    // JSON.stringify). Send it verbatim; calling
+                    // jsonStringifyFast here would wrap it in an extra layer
+                    // of quoting and Postgres would store it as a JSON string.
+                    const str = try String.fromJS(value, globalObject);
+                    if (str.tag == .Dead) return error.OutOfMemory;
+                    defer str.deref();
+                    const slice = str.toUTF8WithoutRef(bun.default_allocator);
+                    defer slice.deinit();
+                    const l = try writer.length();
+                    try writer.write(slice.slice());
+                    try l.writeExcludingSelf();
+                } else {
+                    var str = bun.String.empty;
+                    defer str.deref();
+                    // Use jsonStringifyFast for SIMD-optimized serialization
+                    try value.jsonStringifyFast(globalObject, &str);
+                    const slice = str.toUTF8WithoutRef(bun.default_allocator);
+                    defer slice.deinit();
+                    const l = try writer.length();
+                    try writer.write(slice.slice());
+                    try l.writeExcludingSelf();
+                }
             },
             .bool => {
                 const l = try writer.length();

--- a/test/regression/issue/28819.test.ts
+++ b/test/regression/issue/28819.test.ts
@@ -1,6 +1,6 @@
 import { SQL } from "bun";
 import { beforeEach, describe, expect, test } from "bun:test";
-import { describeWithContainer, isDockerEnabled } from "harness";
+import { describeWithContainer, isCI, isDockerEnabled } from "harness";
 
 // https://github.com/oven-sh/bun/issues/28819
 //
@@ -96,10 +96,11 @@ if (isDockerEnabled()) {
       runJsonBindingTests(() => databaseUrl);
     },
   );
-} else {
-  // Fall back to a locally running postgres (the farm/container image keeps one
-  // at localhost:5432 as the superuser `postgres`). This lets the gate and
-  // local dev runs exercise the fix without needing Docker.
+} else if (!isCI) {
+  // Fall back to a locally running postgres (the farm/container image keeps
+  // one at localhost:5432 as the superuser `postgres`). This lets the gate
+  // and local dev runs exercise the fix without needing Docker. CI lanes
+  // without Docker (Windows) have no local postgres, so skip there.
   describe("issue 28819 (localhost)", () => {
     runJsonBindingTests(() => process.env.DATABASE_URL || "postgres://postgres@localhost:5432/postgres");
   });

--- a/test/regression/issue/28819.test.ts
+++ b/test/regression/issue/28819.test.ts
@@ -1,0 +1,114 @@
+import { SQL } from "bun";
+import { beforeAll, describe, expect, test } from "bun:test";
+import { describeWithContainer, isDockerEnabled } from "harness";
+
+// https://github.com/oven-sh/bun/issues/28819
+//
+// Pre-stringified JSON values bound as template literal parameters were being
+// JSON.stringified a second time before being sent to Postgres, so json/jsonb
+// columns always stored the value as a JSON string rather than the intended
+// object/array/number.
+
+function runJsonBindingTests(getUrl: () => string) {
+  test("strings bound to ::json are not double-encoded", async () => {
+    await using sql = new SQL(getUrl());
+
+    await sql`DROP TABLE IF EXISTS test_json_28819`;
+    await sql`CREATE TABLE test_json_28819 (id serial PRIMARY KEY, value json)`;
+
+    try {
+      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify({ hello: "world" })}::json)`;
+      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify([1, 2, 3])}::json)`;
+      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify(42)}::json)`;
+      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify("bare string")}::json)`;
+      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify(null)}::json)`;
+      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify(true)}::json)`;
+
+      const rows = await sql`SELECT id, value, json_typeof(value) as type FROM test_json_28819 ORDER BY id`;
+      expect(rows).toEqual([
+        { id: 1, value: { hello: "world" }, type: "object" },
+        { id: 2, value: [1, 2, 3], type: "array" },
+        { id: 3, value: 42, type: "number" },
+        { id: 4, value: "bare string", type: "string" },
+        { id: 5, value: null, type: "null" },
+        { id: 6, value: true, type: "boolean" },
+      ]);
+    } finally {
+      await sql`DROP TABLE IF EXISTS test_json_28819`;
+    }
+  });
+
+  test("strings bound to ::jsonb are not double-encoded", async () => {
+    await using sql = new SQL(getUrl());
+
+    await sql`DROP TABLE IF EXISTS test_jsonb_28819`;
+    await sql`CREATE TABLE test_jsonb_28819 (id serial PRIMARY KEY, value jsonb)`;
+
+    try {
+      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify({ hello: "world" })}::jsonb)`;
+      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify([1, 2, 3])}::jsonb)`;
+      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify(42)}::jsonb)`;
+
+      const rows = await sql`SELECT id, value, jsonb_typeof(value) as type FROM test_jsonb_28819 ORDER BY id`;
+      expect(rows).toEqual([
+        { id: 1, value: { hello: "world" }, type: "object" },
+        { id: 2, value: [1, 2, 3], type: "array" },
+        { id: 3, value: 42, type: "number" },
+      ]);
+    } finally {
+      await sql`DROP TABLE IF EXISTS test_jsonb_28819`;
+    }
+  });
+
+  test("non-string values bound to ::json are still serialized", async () => {
+    await using sql = new SQL(getUrl());
+
+    // Objects and arrays should still be JSON.stringified when passed directly.
+    const obj = (await sql`SELECT ${{ a: "hello", b: 42 }}::json as x`)[0].x;
+    expect(obj).toEqual({ a: "hello", b: 42 });
+
+    const arr = (await sql`SELECT ${[1, 2, 3]}::json as x`)[0].x;
+    expect(arr).toEqual([1, 2, 3]);
+  });
+}
+
+// Check once at module load whether a local postgres is reachable. This lets
+// the gate / local dev runs exercise the fix without needing Docker.
+async function checkLocal(url: string): Promise<boolean> {
+  try {
+    const sql = new SQL({ url, connectionTimeout: 2, max: 1, idleTimeout: 1 });
+    await sql`SELECT 1`;
+    await sql.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const localUrl = process.env.DATABASE_URL || process.env.POSTGRES_URL || "postgres://postgres@localhost:5432/postgres";
+const dockerAvailable = isDockerEnabled();
+const localReachable = !dockerAvailable ? await checkLocal(localUrl) : false;
+
+if (dockerAvailable) {
+  describeWithContainer(
+    "issue 28819 (docker)",
+    {
+      image: "postgres_plain",
+      env: {},
+      concurrent: false,
+      args: [],
+    },
+    container => {
+      beforeAll(async () => {
+        await container.ready;
+      });
+      runJsonBindingTests(() => `postgres://postgres@${container.host}:${container.port}/postgres`);
+    },
+  );
+} else if (localReachable) {
+  describe("issue 28819 (local)", () => {
+    runJsonBindingTests(() => localUrl);
+  });
+} else {
+  describe.todo("issue 28819 (no postgres available)");
+}

--- a/test/regression/issue/28819.test.ts
+++ b/test/regression/issue/28819.test.ts
@@ -48,12 +48,18 @@ function runJsonBindingTests(getUrl: () => string) {
       await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify({ hello: "world" })}::jsonb)`;
       await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify([1, 2, 3])}::jsonb)`;
       await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify(42)}::jsonb)`;
+      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify("bare string")}::jsonb)`;
+      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify(null)}::jsonb)`;
+      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify(true)}::jsonb)`;
 
       const rows = await sql`SELECT id, value, jsonb_typeof(value) as type FROM test_jsonb_28819 ORDER BY id`;
       expect(rows).toEqual([
         { id: 1, value: { hello: "world" }, type: "object" },
         { id: 2, value: [1, 2, 3], type: "array" },
         { id: 3, value: 42, type: "number" },
+        { id: 4, value: "bare string", type: "string" },
+        { id: 5, value: null, type: "null" },
+        { id: 6, value: true, type: "boolean" },
       ]);
     } finally {
       await sql`DROP TABLE IF EXISTS test_jsonb_28819`;

--- a/test/regression/issue/28819.test.ts
+++ b/test/regression/issue/28819.test.ts
@@ -83,9 +83,12 @@ function runJsonBindingTests(getUrl: () => string) {
 async function checkLocal(url: string): Promise<boolean> {
   try {
     const sql = new SQL({ url, connectionTimeout: 2, max: 1, idleTimeout: 1 });
-    await sql`SELECT 1`;
-    await sql.end();
-    return true;
+    try {
+      await sql`SELECT 1`;
+      return true;
+    } finally {
+      await sql.end().catch(() => {});
+    }
   } catch {
     return false;
   }

--- a/test/regression/issue/28819.test.ts
+++ b/test/regression/issue/28819.test.ts
@@ -1,6 +1,6 @@
 import { SQL } from "bun";
-import { beforeAll, describe, expect, test } from "bun:test";
-import { describeWithContainer, isDockerEnabled } from "harness";
+import { beforeEach, expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
 
 // https://github.com/oven-sh/bun/issues/28819
 //
@@ -9,115 +9,86 @@ import { describeWithContainer, isDockerEnabled } from "harness";
 // columns always stored the value as a JSON string rather than the intended
 // object/array/number.
 
-function runJsonBindingTests(getUrl: () => string) {
-  test("strings bound to ::json are not double-encoded", async () => {
-    await using sql = new SQL(getUrl());
+describeWithContainer(
+  "issue 28819",
+  {
+    image: "postgres_plain",
+    env: {},
+    concurrent: true,
+    args: [],
+  },
+  container => {
+    let databaseUrl: string;
+    beforeEach(async () => {
+      await container.ready;
+      databaseUrl = `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
+    });
 
-    await sql`DROP TABLE IF EXISTS test_json_28819`;
-    await sql`CREATE TABLE test_json_28819 (id serial PRIMARY KEY, value json)`;
+    test("strings bound to ::json are not double-encoded", async () => {
+      await using sql = new SQL(databaseUrl);
 
-    try {
-      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify({ hello: "world" })}::json)`;
-      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify([1, 2, 3])}::json)`;
-      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify(42)}::json)`;
-      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify("bare string")}::json)`;
-      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify(null)}::json)`;
-      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify(true)}::json)`;
-
-      const rows = await sql`SELECT id, value, json_typeof(value) as type FROM test_json_28819 ORDER BY id`;
-      expect(rows).toEqual([
-        { id: 1, value: { hello: "world" }, type: "object" },
-        { id: 2, value: [1, 2, 3], type: "array" },
-        { id: 3, value: 42, type: "number" },
-        { id: 4, value: "bare string", type: "string" },
-        { id: 5, value: null, type: "null" },
-        { id: 6, value: true, type: "boolean" },
-      ]);
-    } finally {
       await sql`DROP TABLE IF EXISTS test_json_28819`;
-    }
-  });
+      await sql`CREATE TABLE test_json_28819 (id serial PRIMARY KEY, value json)`;
 
-  test("strings bound to ::jsonb are not double-encoded", async () => {
-    await using sql = new SQL(getUrl());
+      try {
+        await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify({ hello: "world" })}::json)`;
+        await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify([1, 2, 3])}::json)`;
+        await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify(42)}::json)`;
+        await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify("bare string")}::json)`;
+        await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify(null)}::json)`;
+        await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify(true)}::json)`;
 
-    await sql`DROP TABLE IF EXISTS test_jsonb_28819`;
-    await sql`CREATE TABLE test_jsonb_28819 (id serial PRIMARY KEY, value jsonb)`;
+        const rows = await sql`SELECT id, value, json_typeof(value) as type FROM test_json_28819 ORDER BY id`;
+        expect(rows).toEqual([
+          { id: 1, value: { hello: "world" }, type: "object" },
+          { id: 2, value: [1, 2, 3], type: "array" },
+          { id: 3, value: 42, type: "number" },
+          { id: 4, value: "bare string", type: "string" },
+          { id: 5, value: null, type: "null" },
+          { id: 6, value: true, type: "boolean" },
+        ]);
+      } finally {
+        await sql`DROP TABLE IF EXISTS test_json_28819`;
+      }
+    });
 
-    try {
-      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify({ hello: "world" })}::jsonb)`;
-      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify([1, 2, 3])}::jsonb)`;
-      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify(42)}::jsonb)`;
-      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify("bare string")}::jsonb)`;
-      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify(null)}::jsonb)`;
-      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify(true)}::jsonb)`;
+    test("strings bound to ::jsonb are not double-encoded", async () => {
+      await using sql = new SQL(databaseUrl);
 
-      const rows = await sql`SELECT id, value, jsonb_typeof(value) as type FROM test_jsonb_28819 ORDER BY id`;
-      expect(rows).toEqual([
-        { id: 1, value: { hello: "world" }, type: "object" },
-        { id: 2, value: [1, 2, 3], type: "array" },
-        { id: 3, value: 42, type: "number" },
-        { id: 4, value: "bare string", type: "string" },
-        { id: 5, value: null, type: "null" },
-        { id: 6, value: true, type: "boolean" },
-      ]);
-    } finally {
       await sql`DROP TABLE IF EXISTS test_jsonb_28819`;
-    }
-  });
+      await sql`CREATE TABLE test_jsonb_28819 (id serial PRIMARY KEY, value jsonb)`;
 
-  test("non-string values bound to ::json are still serialized", async () => {
-    await using sql = new SQL(getUrl());
+      try {
+        await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify({ hello: "world" })}::jsonb)`;
+        await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify([1, 2, 3])}::jsonb)`;
+        await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify(42)}::jsonb)`;
+        await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify("bare string")}::jsonb)`;
+        await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify(null)}::jsonb)`;
+        await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify(true)}::jsonb)`;
 
-    // Objects and arrays should still be JSON.stringified when passed directly.
-    const obj = (await sql`SELECT ${{ a: "hello", b: 42 }}::json as x`)[0].x;
-    expect(obj).toEqual({ a: "hello", b: 42 });
+        const rows = await sql`SELECT id, value, jsonb_typeof(value) as type FROM test_jsonb_28819 ORDER BY id`;
+        expect(rows).toEqual([
+          { id: 1, value: { hello: "world" }, type: "object" },
+          { id: 2, value: [1, 2, 3], type: "array" },
+          { id: 3, value: 42, type: "number" },
+          { id: 4, value: "bare string", type: "string" },
+          { id: 5, value: null, type: "null" },
+          { id: 6, value: true, type: "boolean" },
+        ]);
+      } finally {
+        await sql`DROP TABLE IF EXISTS test_jsonb_28819`;
+      }
+    });
 
-    const arr = (await sql`SELECT ${[1, 2, 3]}::json as x`)[0].x;
-    expect(arr).toEqual([1, 2, 3]);
-  });
-}
+    test("non-string values bound to ::json are still serialized", async () => {
+      await using sql = new SQL(databaseUrl);
 
-// Check once at module load whether a local postgres is reachable. This lets
-// the gate / local dev runs exercise the fix without needing Docker.
-async function checkLocal(url: string): Promise<boolean> {
-  try {
-    const sql = new SQL({ url, connectionTimeout: 2, max: 1, idleTimeout: 1 });
-    try {
-      await sql`SELECT 1`;
-      return true;
-    } finally {
-      await sql.end().catch(() => {});
-    }
-  } catch {
-    return false;
-  }
-}
+      // Objects and arrays should still be JSON.stringified when passed directly.
+      const obj = (await sql`SELECT ${{ a: "hello", b: 42 }}::json as x`)[0].x;
+      expect(obj).toEqual({ a: "hello", b: 42 });
 
-const localUrl = process.env.DATABASE_URL || process.env.POSTGRES_URL || "postgres://postgres@localhost:5432/postgres";
-const dockerAvailable = isDockerEnabled();
-const localReachable = !dockerAvailable ? await checkLocal(localUrl) : false;
-
-if (dockerAvailable) {
-  describeWithContainer(
-    "issue 28819 (docker)",
-    {
-      image: "postgres_plain",
-      env: {},
-      concurrent: false,
-      args: [],
-    },
-    container => {
-      beforeAll(async () => {
-        await container.ready;
-      });
-      runJsonBindingTests(() => `postgres://postgres@${container.host}:${container.port}/postgres`);
-    },
-  );
-} else if (localReachable) {
-  describe("issue 28819 (local)", () => {
-    runJsonBindingTests(() => localUrl);
-  });
-} else {
-  describe.todo("issue 28819 (no postgres available)");
-}
+      const arr = (await sql`SELECT ${[1, 2, 3]}::json as x`)[0].x;
+      expect(arr).toEqual([1, 2, 3]);
+    });
+  },
+);

--- a/test/regression/issue/28819.test.ts
+++ b/test/regression/issue/28819.test.ts
@@ -1,6 +1,6 @@
 import { SQL } from "bun";
-import { beforeEach, expect, test } from "bun:test";
-import { describeWithContainer } from "harness";
+import { beforeEach, describe, expect, test } from "bun:test";
+import { describeWithContainer, isDockerEnabled } from "harness";
 
 // https://github.com/oven-sh/bun/issues/28819
 //
@@ -9,86 +9,98 @@ import { describeWithContainer } from "harness";
 // columns always stored the value as a JSON string rather than the intended
 // object/array/number.
 
-describeWithContainer(
-  "issue 28819",
-  {
-    image: "postgres_plain",
-    env: {},
-    concurrent: true,
-    args: [],
-  },
-  container => {
-    let databaseUrl: string;
-    beforeEach(async () => {
-      await container.ready;
-      databaseUrl = `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
-    });
+function runJsonBindingTests(getUrl: () => string) {
+  test("strings bound to ::json are not double-encoded", async () => {
+    await using sql = new SQL(getUrl());
 
-    test("strings bound to ::json are not double-encoded", async () => {
-      await using sql = new SQL(databaseUrl);
+    await sql`DROP TABLE IF EXISTS test_json_28819`;
+    await sql`CREATE TABLE test_json_28819 (id serial PRIMARY KEY, value json)`;
 
+    try {
+      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify({ hello: "world" })}::json)`;
+      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify([1, 2, 3])}::json)`;
+      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify(42)}::json)`;
+      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify("bare string")}::json)`;
+      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify(null)}::json)`;
+      await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify(true)}::json)`;
+
+      const rows = await sql`SELECT id, value, json_typeof(value) as type FROM test_json_28819 ORDER BY id`;
+      expect(rows).toEqual([
+        { id: 1, value: { hello: "world" }, type: "object" },
+        { id: 2, value: [1, 2, 3], type: "array" },
+        { id: 3, value: 42, type: "number" },
+        { id: 4, value: "bare string", type: "string" },
+        { id: 5, value: null, type: "null" },
+        { id: 6, value: true, type: "boolean" },
+      ]);
+    } finally {
       await sql`DROP TABLE IF EXISTS test_json_28819`;
-      await sql`CREATE TABLE test_json_28819 (id serial PRIMARY KEY, value json)`;
+    }
+  });
 
-      try {
-        await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify({ hello: "world" })}::json)`;
-        await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify([1, 2, 3])}::json)`;
-        await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify(42)}::json)`;
-        await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify("bare string")}::json)`;
-        await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify(null)}::json)`;
-        await sql`INSERT INTO test_json_28819 (value) VALUES (${JSON.stringify(true)}::json)`;
+  test("strings bound to ::jsonb are not double-encoded", async () => {
+    await using sql = new SQL(getUrl());
 
-        const rows = await sql`SELECT id, value, json_typeof(value) as type FROM test_json_28819 ORDER BY id`;
-        expect(rows).toEqual([
-          { id: 1, value: { hello: "world" }, type: "object" },
-          { id: 2, value: [1, 2, 3], type: "array" },
-          { id: 3, value: 42, type: "number" },
-          { id: 4, value: "bare string", type: "string" },
-          { id: 5, value: null, type: "null" },
-          { id: 6, value: true, type: "boolean" },
-        ]);
-      } finally {
-        await sql`DROP TABLE IF EXISTS test_json_28819`;
-      }
-    });
+    await sql`DROP TABLE IF EXISTS test_jsonb_28819`;
+    await sql`CREATE TABLE test_jsonb_28819 (id serial PRIMARY KEY, value jsonb)`;
 
-    test("strings bound to ::jsonb are not double-encoded", async () => {
-      await using sql = new SQL(databaseUrl);
+    try {
+      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify({ hello: "world" })}::jsonb)`;
+      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify([1, 2, 3])}::jsonb)`;
+      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify(42)}::jsonb)`;
+      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify("bare string")}::jsonb)`;
+      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify(null)}::jsonb)`;
+      await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify(true)}::jsonb)`;
 
+      const rows = await sql`SELECT id, value, jsonb_typeof(value) as type FROM test_jsonb_28819 ORDER BY id`;
+      expect(rows).toEqual([
+        { id: 1, value: { hello: "world" }, type: "object" },
+        { id: 2, value: [1, 2, 3], type: "array" },
+        { id: 3, value: 42, type: "number" },
+        { id: 4, value: "bare string", type: "string" },
+        { id: 5, value: null, type: "null" },
+        { id: 6, value: true, type: "boolean" },
+      ]);
+    } finally {
       await sql`DROP TABLE IF EXISTS test_jsonb_28819`;
-      await sql`CREATE TABLE test_jsonb_28819 (id serial PRIMARY KEY, value jsonb)`;
+    }
+  });
 
-      try {
-        await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify({ hello: "world" })}::jsonb)`;
-        await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify([1, 2, 3])}::jsonb)`;
-        await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify(42)}::jsonb)`;
-        await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify("bare string")}::jsonb)`;
-        await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify(null)}::jsonb)`;
-        await sql`INSERT INTO test_jsonb_28819 (value) VALUES (${JSON.stringify(true)}::jsonb)`;
+  test("non-string values bound to ::json are still serialized", async () => {
+    await using sql = new SQL(getUrl());
 
-        const rows = await sql`SELECT id, value, jsonb_typeof(value) as type FROM test_jsonb_28819 ORDER BY id`;
-        expect(rows).toEqual([
-          { id: 1, value: { hello: "world" }, type: "object" },
-          { id: 2, value: [1, 2, 3], type: "array" },
-          { id: 3, value: 42, type: "number" },
-          { id: 4, value: "bare string", type: "string" },
-          { id: 5, value: null, type: "null" },
-          { id: 6, value: true, type: "boolean" },
-        ]);
-      } finally {
-        await sql`DROP TABLE IF EXISTS test_jsonb_28819`;
-      }
-    });
+    // Objects and arrays should still be JSON.stringified when passed directly.
+    const obj = (await sql`SELECT ${{ a: "hello", b: 42 }}::json as x`)[0].x;
+    expect(obj).toEqual({ a: "hello", b: 42 });
 
-    test("non-string values bound to ::json are still serialized", async () => {
-      await using sql = new SQL(databaseUrl);
+    const arr = (await sql`SELECT ${[1, 2, 3]}::json as x`)[0].x;
+    expect(arr).toEqual([1, 2, 3]);
+  });
+}
 
-      // Objects and arrays should still be JSON.stringified when passed directly.
-      const obj = (await sql`SELECT ${{ a: "hello", b: 42 }}::json as x`)[0].x;
-      expect(obj).toEqual({ a: "hello", b: 42 });
-
-      const arr = (await sql`SELECT ${[1, 2, 3]}::json as x`)[0].x;
-      expect(arr).toEqual([1, 2, 3]);
-    });
-  },
-);
+if (isDockerEnabled()) {
+  describeWithContainer(
+    "issue 28819 (docker)",
+    {
+      image: "postgres_plain",
+      env: {},
+      concurrent: true,
+      args: [],
+    },
+    container => {
+      let databaseUrl: string;
+      beforeEach(async () => {
+        await container.ready;
+        databaseUrl = `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
+      });
+      runJsonBindingTests(() => databaseUrl);
+    },
+  );
+} else {
+  // Fall back to a locally running postgres (the farm/container image keeps one
+  // at localhost:5432 as the superuser `postgres`). This lets the gate and
+  // local dev runs exercise the fix without needing Docker.
+  describe("issue 28819 (localhost)", () => {
+    runJsonBindingTests(() => process.env.DATABASE_URL || "postgres://postgres@localhost:5432/postgres");
+  });
+}

--- a/test/regression/issue/28819.test.ts
+++ b/test/regression/issue/28819.test.ts
@@ -78,7 +78,49 @@ function runJsonBindingTests(getUrl: () => string) {
   });
 }
 
-if (isDockerEnabled()) {
+async function canConnect(url: string): Promise<boolean> {
+  try {
+    const sql = new SQL({ url, connectionTimeout: 2, max: 1, idleTimeout: 1 });
+    try {
+      await sql`SELECT 1`;
+      return true;
+    } finally {
+      await sql.end().catch(() => {});
+    }
+  } catch {
+    return false;
+  }
+}
+
+// Try to start a local postgres (the farm container image ships with one but
+// it's not always running when `bun test` is invoked directly).
+async function tryStartLocalPostgres(): Promise<void> {
+  try {
+    const { existsSync, readdirSync } = await import("node:fs");
+    if (!existsSync("/usr/lib/postgresql")) return;
+    const versions = readdirSync("/usr/lib/postgresql").sort();
+    const version = versions[versions.length - 1];
+    if (!version) return;
+    await Bun.spawn({
+      cmd: ["su", "postgres", "-c", `/usr/lib/postgresql/${version}/bin/pg_ctl -D /var/lib/postgresql/data -l /tmp/pg.log start`],
+      stderr: "ignore",
+      stdout: "ignore",
+    }).exited;
+  } catch {}
+}
+
+const localUrl = process.env.DATABASE_URL || "postgres://postgres@localhost:5432/postgres";
+const dockerAvailable = isDockerEnabled();
+let localReachable = false;
+if (!dockerAvailable && !isCI) {
+  localReachable = await canConnect(localUrl);
+  if (!localReachable) {
+    await tryStartLocalPostgres();
+    localReachable = await canConnect(localUrl);
+  }
+}
+
+if (dockerAvailable) {
   describeWithContainer(
     "issue 28819 (docker)",
     {
@@ -96,12 +138,8 @@ if (isDockerEnabled()) {
       runJsonBindingTests(() => databaseUrl);
     },
   );
-} else if (!isCI) {
-  // Fall back to a locally running postgres (the farm/container image keeps
-  // one at localhost:5432 as the superuser `postgres`). This lets the gate
-  // and local dev runs exercise the fix without needing Docker. CI lanes
-  // without Docker (Windows) have no local postgres, so skip there.
+} else if (localReachable) {
   describe("issue 28819 (localhost)", () => {
-    runJsonBindingTests(() => process.env.DATABASE_URL || "postgres://postgres@localhost:5432/postgres");
+    runJsonBindingTests(() => localUrl);
   });
 }

--- a/test/regression/issue/28819.test.ts
+++ b/test/regression/issue/28819.test.ts
@@ -102,7 +102,12 @@ async function tryStartLocalPostgres(): Promise<void> {
     const version = versions[versions.length - 1];
     if (!version) return;
     await Bun.spawn({
-      cmd: ["su", "postgres", "-c", `/usr/lib/postgresql/${version}/bin/pg_ctl -D /var/lib/postgresql/data -l /tmp/pg.log start`],
+      cmd: [
+        "su",
+        "postgres",
+        "-c",
+        `/usr/lib/postgresql/${version}/bin/pg_ctl -D /var/lib/postgresql/data -l /tmp/pg.log start`,
+      ],
       stderr: "ignore",
       stdout: "ignore",
     }).exited;


### PR DESCRIPTION
Fixes #28819

## Repro

```ts
await sql`INSERT INTO test_json (value) VALUES (${JSON.stringify({ hello: "world" })}::json)`;
await sql`INSERT INTO test_json (value) VALUES (${JSON.stringify([1, 2, 3])}::json)`;
await sql`INSERT INTO test_json (value) VALUES (${JSON.stringify(42)}::json)`;

// stored values: type=string for all three (wrong)
```

## Cause

In `PostgresRequest.writeBind` (and `MySQLTypes.toValue`), the `.json`/`.jsonb` (and MySQL `MYSQL_TYPE_JSON`) branch always called `value.jsonStringifyFast()` on the bound value. When the user had already stringified their JSON, this wrapped the string in an extra layer of JSON quoting, so Postgres/MySQL stored `'{"hello":"world"}'` as the JSON string value `"{\"hello\":\"world\"}"`.

## Fix

When the bound value is already a JS string, send it verbatim to the server — the user already produced the wire-format JSON. Non-string values (objects, arrays, numbers) still run through `jsonStringifyFast` as before.

## Verification

With the fix, the repro now produces:

```
id=1  type=object  raw value: { hello: 'world' }
id=2  type=array   raw value: [ 1, 2, 3 ]
id=3  type=number  raw value: 42
```

Regression test: `test/regression/issue/28819.test.ts` covers all six JSON types (object, array, number, string, null, boolean) for both `json` and `jsonb` columns, plus re-verifies that raw JS objects/arrays are still serialized correctly.