### PR TITLE
usockets: drain epoll/kqueue when ready_polls buffer saturates

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -285,6 +285,30 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
 #endif
 }
 
+/* If the kernel filled our entire buffer, more events are likely already queued.
+ * Re-poll non-blocking and dispatch again before running pre/post callbacks, so a
+ * single tick covers all pending I/O instead of one 1024-event slice per roundtrip.
+ * Conditioned on saturation and capped at 48 iterations — matches libuv's uv__io_poll
+ * (vendor/libuv/src/unix/linux.c:1387,1590 and kqueue.c:253,451). */
+static void us_internal_drain_ready_polls(struct us_loop_t *loop) {
+    int drain_count = 48;
+    while (UNLIKELY(loop->num_ready_polls == LIBUS_MAX_READY_POLLS) && --drain_count != 0 && loop->num_polls > 0) {
+#ifdef LIBUS_USE_EPOLL
+        static const struct timespec zero = {0, 0};
+        loop->num_ready_polls = bun_epoll_pwait2(loop->fd, loop->ready_polls, LIBUS_MAX_READY_POLLS, &zero);
+#else
+        do {
+            loop->num_ready_polls = kevent64(loop->fd, NULL, 0, loop->ready_polls, LIBUS_MAX_READY_POLLS, KEVENT_FLAG_IMMEDIATE, NULL);
+        } while (IS_EINTR(loop->num_ready_polls));
+#endif
+        if (loop->num_ready_polls <= 0) {
+            loop->num_ready_polls = 0;
+            break;
+        }
+        us_internal_dispatch_ready_polls(loop);
+    }
+}
+
 void us_loop_run(struct us_loop_t *loop) {
     us_loop_integrate(loop);
 
@@ -295,14 +319,15 @@ void us_loop_run(struct us_loop_t *loop) {
 
         /* Fetch ready polls */
 #ifdef LIBUS_USE_EPOLL
-        loop->num_ready_polls = bun_epoll_pwait2(loop->fd, loop->ready_polls, 1024, NULL);
+        loop->num_ready_polls = bun_epoll_pwait2(loop->fd, loop->ready_polls, LIBUS_MAX_READY_POLLS, NULL);
 #else
         do {
-            loop->num_ready_polls = kevent64(loop->fd, NULL, 0, loop->ready_polls, 1024, 0, NULL);
+            loop->num_ready_polls = kevent64(loop->fd, NULL, 0, loop->ready_polls, LIBUS_MAX_READY_POLLS, 0, NULL);
         } while (IS_EINTR(loop->num_ready_polls));
 #endif
 
         us_internal_dispatch_ready_polls(loop);
+        us_internal_drain_ready_polls(loop);
 
         /* Emit post callback */
         us_internal_loop_post(loop);
@@ -352,28 +377,7 @@ void us_loop_run_bun_tick(struct us_loop_t *loop, const struct timespec* timeout
 #endif
 
     us_internal_dispatch_ready_polls(loop);
-
-    /* If the kernel filled our entire buffer, more events are likely already queued.
-     * Re-poll non-blocking and dispatch again before returning to JS, so a single tick
-     * covers all pending I/O instead of one 1024-event slice per JS roundtrip.
-     * Conditioned on saturation and capped at 48 iterations — matches libuv's uv__io_poll
-     * (vendor/libuv/src/unix/linux.c:1387,1590 and kqueue.c:253,451). */
-    int drain_count = 48;
-    while (UNLIKELY(loop->num_ready_polls == LIBUS_MAX_READY_POLLS) && --drain_count != 0 && loop->num_polls > 0) {
-#ifdef LIBUS_USE_EPOLL
-        static const struct timespec zero = {0, 0};
-        loop->num_ready_polls = bun_epoll_pwait2(loop->fd, loop->ready_polls, LIBUS_MAX_READY_POLLS, &zero);
-#else
-        do {
-            loop->num_ready_polls = kevent64(loop->fd, NULL, 0, loop->ready_polls, LIBUS_MAX_READY_POLLS, KEVENT_FLAG_IMMEDIATE, NULL);
-        } while (IS_EINTR(loop->num_ready_polls));
-#endif
-        if (loop->num_ready_polls <= 0) {
-            loop->num_ready_polls = 0;
-            break;
-        }
-        us_internal_dispatch_ready_polls(loop);
-    }
+    us_internal_drain_ready_polls(loop);
 
     /* Emit post callback */
     us_internal_loop_post(loop);

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -336,10 +336,10 @@ void us_loop_run_bun_tick(struct us_loop_t *loop, const struct timespec* timeout
     /* A zero timespec already has a fast path in ep_poll (fs/eventpoll.c):
      * it sets timed_out=1 (line 1952) and returns before any scheduler
      * interaction (line 1975). No equivalent of KEVENT_FLAG_IMMEDIATE needed. */
-    loop->num_ready_polls = bun_epoll_pwait2(loop->fd, loop->ready_polls, 1024, timeout);
+    loop->num_ready_polls = bun_epoll_pwait2(loop->fd, loop->ready_polls, LIBUS_MAX_READY_POLLS, timeout);
 #else
     do {
-        loop->num_ready_polls = kevent64(loop->fd, NULL, 0, loop->ready_polls, 1024,
+        loop->num_ready_polls = kevent64(loop->fd, NULL, 0, loop->ready_polls, LIBUS_MAX_READY_POLLS,
             /* When we won't idle (pending wakeups or zero timeout), use KEVENT_FLAG_IMMEDIATE.
              * In XNU's kqueue_scan (bsd/kern/kern_event.c):
              *  - KEVENT_FLAG_IMMEDIATE: returns immediately after kqueue_process() (line 8031)
@@ -351,8 +351,29 @@ void us_loop_run_bun_tick(struct us_loop_t *loop, const struct timespec* timeout
     } while (IS_EINTR(loop->num_ready_polls));
 #endif
 
-
     us_internal_dispatch_ready_polls(loop);
+
+    /* If the kernel filled our entire buffer, more events are likely already queued.
+     * Re-poll non-blocking and dispatch again before returning to JS, so a single tick
+     * covers all pending I/O instead of one 1024-event slice per JS roundtrip.
+     * Conditioned on saturation and capped at 48 iterations — matches libuv's uv__io_poll
+     * (vendor/libuv/src/unix/linux.c:1387,1590 and kqueue.c:253,451). */
+    int drain_count = 48;
+    while (UNLIKELY(loop->num_ready_polls == LIBUS_MAX_READY_POLLS) && --drain_count != 0 && loop->num_polls > 0) {
+#ifdef LIBUS_USE_EPOLL
+        static const struct timespec zero = {0, 0};
+        loop->num_ready_polls = bun_epoll_pwait2(loop->fd, loop->ready_polls, LIBUS_MAX_READY_POLLS, &zero);
+#else
+        do {
+            loop->num_ready_polls = kevent64(loop->fd, NULL, 0, loop->ready_polls, LIBUS_MAX_READY_POLLS, KEVENT_FLAG_IMMEDIATE, NULL);
+        } while (IS_EINTR(loop->num_ready_polls));
+#endif
+        if (loop->num_ready_polls <= 0) {
+            loop->num_ready_polls = 0;
+            break;
+        }
+        us_internal_dispatch_ready_polls(loop);
+    }
 
     /* Emit post callback */
     us_internal_loop_post(loop);


### PR DESCRIPTION
## What

After `us_internal_dispatch_ready_polls`, if `num_ready_polls == LIBUS_MAX_READY_POLLS` (kernel filled the entire 1024-slot buffer), re-poll with a zero timeout and dispatch again before running pre/post callbacks. Capped at 48 iterations. Applied to both `us_loop_run` and `us_loop_run_bun_tick`.

## Why

When >1024 fds are ready at once, we previously processed exactly 1024, ran the post callback (and in the bun_tick case, returned to the JS event loop for microtask drain + GC safepoint), then came back for the next 1024 on the following tick. The drain loop lets one tick service the whole backlog.

This mirrors libuv's `uv__io_poll`:
- `vendor/libuv/src/unix/linux.c:1387,1590` — `count = 48`, `if (nfds == ARRAY_SIZE(events) && --count != 0) { timeout = 0; continue; }`
- `vendor/libuv/src/unix/kqueue.c:253,451` — same pattern

A previous unconditional drain experiment cut wake count 280k→98k but didn't move throughput on a 70%-idle server. This version is gated on buffer saturation, so it's a no-op (one untaken branch) unless there's evidence of more queued work — the only case where draining pays.

## Safety

- Re-polling after dispatch is safe: closed/stopped polls are removed from the kernel set via `epoll_ctl(DEL)` / `EV_DELETE` during the callback, so the next `epoll_wait`/`kevent64` won't return them. No stale userspace pointers carry across batches.
- `num_ready_polls` is not mutated by dispatch (only `current_ready_poll` is), so the saturation check is valid post-dispatch.
- `loop->num_polls > 0` guards against re-polling after everything was torn down mid-batch.

## Test plan

- [x] `bun bd test test/js/bun/http/serve.test.ts` — 189 pass
- [x] release build, `oha -c {256,1024,2048,4096}` keepalive against `Bun.serve`: no regression vs baseline (~170k req/s on M-series macOS; loopback load doesn't reliably fill the buffer so the drain branch stays cold)
- [ ] CI on Linux