### PR TITLE
install: add blockDeprecatedDependencies bunfig option

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -669,6 +669,20 @@ minimumReleaseAgeExcludes = ["@types/bun", "typescript"]
 
 For more details see [Minimum release age](/pm/cli/install#minimum-release-age) in the install documentation.
 
+### `install.blockDeprecatedDependencies`
+
+When `true`, skip any npm package version whose manifest has a non-empty `deprecated` field. During resolution, the highest-numbered non-deprecated version matching the requested range is picked instead. If every matching version is deprecated (or a pinned exact version is deprecated), installation fails with an error. Default is `false`.
+
+```toml title="bunfig.toml" icon="settings"
+[install]
+# Never install a version whose manifest is marked deprecated
+blockDeprecatedDependencies = true
+# ...unless the package is on this exempt list
+blockDeprecatedDependenciesExcludes = ["request", "left-pad"]
+```
+
+This pairs well with `minimumReleaseAge`: when a just-patched replacement is too young to be picked, the filter falls back to the previous non-deprecated release instead of the broken one the maintainer pulled.
+
 ## `bun run`
 
 The `bun run` command can be configured under the `[run]` section. These apply to the `bun run` command and the `bun` command when running a file or executable or script.

--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -3073,6 +3073,9 @@ pub const api = struct {
         minimum_release_age_ms: ?f64 = null,
         minimum_release_age_excludes: ?[]const []const u8 = null,
 
+        block_deprecated_dependencies: ?bool = null,
+        block_deprecated_dependencies_excludes: ?[]const []const u8 = null,
+
         public_hoist_pattern: ?install.PnpmMatcher = null,
         hoist_pattern: ?install.PnpmMatcher = null,
     };

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -817,6 +817,36 @@ pub const Bunfig = struct {
                         }
                     }
 
+                    if (install_obj.get("blockDeprecatedDependencies")) |block_deprecated| {
+                        switch (block_deprecated.data) {
+                            .e_boolean => |val| {
+                                install.block_deprecated_dependencies = val.value;
+                            },
+                            else => {
+                                try this.addError(block_deprecated.loc, "Expected boolean for blockDeprecatedDependencies");
+                            },
+                        }
+                    }
+
+                    if (install_obj.get("blockDeprecatedDependenciesExcludes")) |exclusions| {
+                        switch (exclusions.data) {
+                            .e_array => |arr| brk: {
+                                const raw_exclusions = arr.items.slice();
+                                if (raw_exclusions.len == 0) break :brk;
+
+                                const exclusions_list = try this.allocator.alloc(string, raw_exclusions.len);
+                                for (raw_exclusions, 0..) |p, i| {
+                                    try this.expectString(p);
+                                    exclusions_list[i] = try p.data.e_string.string(allocator);
+                                }
+                                install.block_deprecated_dependencies_excludes = exclusions_list;
+                            },
+                            else => {
+                                try this.addError(exclusions.loc, "Expected array for blockDeprecatedDependenciesExcludes");
+                            },
+                        }
+                    }
+
                     if (install_obj.get("publicHoistPattern")) |public_hoist_pattern_expr| {
                         install.public_hoist_pattern = bun.install.PnpmMatcher.fromExpr(
                             allocator,

--- a/src/cli/outdated_command.zig
+++ b/src/cli/outdated_command.zig
@@ -427,17 +427,18 @@ pub const OutdatedCommand = struct {
                     package_name,
                     &expired,
                     .load_from_memory_fallback_to_disk,
-                    manager.options.minimum_release_age_ms != null,
+                    manager.options.needsExtendedManifest(),
                 ) orelse continue;
 
                 const actual_latest = manifest.findByDistTag("latest") orelse continue;
 
-                const latest = manifest.findByDistTagWithFilter("latest", manager.options.minimum_release_age_ms, manager.options.minimum_release_age_excludes);
+                const filter = manager.options.manifestFilterOptions();
+                const latest = manifest.findByDistTagWithFilter("latest", filter);
 
                 const update_version = if (resolved_version.tag == .npm)
-                    manifest.findBestVersionWithFilter(resolved_version.value.npm.version, string_buf, manager.options.minimum_release_age_ms, manager.options.minimum_release_age_excludes)
+                    manifest.findBestVersionWithFilter(resolved_version.value.npm.version, string_buf, filter)
                 else
-                    manifest.findByDistTagWithFilter(resolved_version.value.dist_tag.tag.slice(string_buf), manager.options.minimum_release_age_ms, manager.options.minimum_release_age_excludes);
+                    manifest.findByDistTagWithFilter(resolved_version.value.dist_tag.tag.slice(string_buf), filter);
 
                 if (resolution.value.npm.version.order(actual_latest.version, string_buf, manifest.string_buf) != .lt) continue;
 
@@ -582,15 +583,16 @@ pub const OutdatedCommand = struct {
                     package_name,
                     &expired,
                     .load_from_memory_fallback_to_disk,
-                    manager.options.minimum_release_age_ms != null,
+                    manager.options.needsExtendedManifest(),
                 ) orelse continue;
 
-                const latest = manifest.findByDistTagWithFilter("latest", manager.options.minimum_release_age_ms, manager.options.minimum_release_age_excludes);
+                const filter = manager.options.manifestFilterOptions();
+                const latest = manifest.findByDistTagWithFilter("latest", filter);
                 const resolved_version = manager.lockfile.resolveCatalogDependency(dep) orelse continue;
                 const update = if (resolved_version.tag == .npm)
-                    manifest.findBestVersionWithFilter(resolved_version.value.npm.version, string_buf, manager.options.minimum_release_age_ms, manager.options.minimum_release_age_excludes)
+                    manifest.findBestVersionWithFilter(resolved_version.value.npm.version, string_buf, filter)
                 else
-                    manifest.findByDistTagWithFilter(resolved_version.value.dist_tag.tag.slice(string_buf), manager.options.minimum_release_age_ms, manager.options.minimum_release_age_excludes);
+                    manifest.findByDistTagWithFilter(resolved_version.value.dist_tag.tag.slice(string_buf), filter);
 
                 table.printLineSeparator();
 

--- a/src/cli/outdated_command.zig
+++ b/src/cli/outdated_command.zig
@@ -685,7 +685,7 @@ pub const OutdatedCommand = struct {
         table.printBottomLineSeparator();
 
         if (has_filtered_versions) {
-            Output.prettyln("<d><b>Note:<r> <d>The <r><blue>*<r><d> indicates that version isn't true latest due to minimum release age<r>", .{});
+            Output.prettyln("<d><b>Note:<r> <d>The <r><blue>*<r><d> indicates the displayed version isn't true latest due to an active install filter (minimum release age or blockDeprecatedDependencies)<r>", .{});
         }
     }
 };

--- a/src/cli/update_interactive_command.zig
+++ b/src/cli/update_interactive_command.zig
@@ -758,14 +758,26 @@ pub const UpdateInteractiveCommand = struct {
                 ) orelse continue;
 
                 const filter = manager.options.manifestFilterOptions();
-                const latest = manifest.findByDistTagWithFilter("latest", filter).unwrap() orelse continue;
+                const latest_result = manifest.findByDistTagWithFilter("latest", filter);
+                // If even `latest` is wholly deprecated under the active filter,
+                // the package has nothing installable to show. Same for age.
+                if (latest_result == .err) continue;
+                const latest = latest_result.unwrap() orelse continue;
 
                 // In interactive mode, show the constrained update version as "Target"
-                // but always include packages (don't filter out breaking changes)
-                const update_version = if (resolved_version.tag == .npm)
-                    manifest.findBestVersionWithFilter(resolved_version.value.npm.version, string_buf, filter).unwrap() orelse latest
+                // but always include packages (don't filter out breaking changes).
+                // Exception: when `blockDeprecatedDependencies` has blocked every
+                // version matching the user's range, skip the package — selecting
+                // `latest` would offer a version outside the user's constraint with
+                // no path to a non-deprecated in-range alternative.
+                const update_result: Install.Npm.PackageManifest.FindVersionResult = if (resolved_version.tag == .npm)
+                    manifest.findBestVersionWithFilter(resolved_version.value.npm.version, string_buf, filter)
                 else
-                    manifest.findByDistTagWithFilter(resolved_version.value.dist_tag.tag.slice(string_buf), filter).unwrap() orelse latest;
+                    manifest.findByDistTagWithFilter(resolved_version.value.dist_tag.tag.slice(string_buf), filter);
+                if (update_result == .err and (update_result.err == .deprecated or update_result.err == .all_versions_deprecated)) {
+                    continue;
+                }
+                const update_version = update_result.unwrap() orelse latest;
 
                 // Skip only if both the constrained update AND the latest version are the same as current
                 // This ensures we show packages where latest is newer even if constrained update isn't

--- a/src/cli/update_interactive_command.zig
+++ b/src/cli/update_interactive_command.zig
@@ -754,17 +754,18 @@ pub const UpdateInteractiveCommand = struct {
                     package_name,
                     &expired,
                     .load_from_memory_fallback_to_disk,
-                    manager.options.minimum_release_age_ms != null,
+                    manager.options.needsExtendedManifest(),
                 ) orelse continue;
 
-                const latest = manifest.findByDistTagWithFilter("latest", manager.options.minimum_release_age_ms, manager.options.minimum_release_age_excludes).unwrap() orelse continue;
+                const filter = manager.options.manifestFilterOptions();
+                const latest = manifest.findByDistTagWithFilter("latest", filter).unwrap() orelse continue;
 
                 // In interactive mode, show the constrained update version as "Target"
                 // but always include packages (don't filter out breaking changes)
                 const update_version = if (resolved_version.tag == .npm)
-                    manifest.findBestVersionWithFilter(resolved_version.value.npm.version, string_buf, manager.options.minimum_release_age_ms, manager.options.minimum_release_age_excludes).unwrap() orelse latest
+                    manifest.findBestVersionWithFilter(resolved_version.value.npm.version, string_buf, filter).unwrap() orelse latest
                 else
-                    manifest.findByDistTagWithFilter(resolved_version.value.dist_tag.tag.slice(string_buf), manager.options.minimum_release_age_ms, manager.options.minimum_release_age_excludes).unwrap() orelse latest;
+                    manifest.findByDistTagWithFilter(resolved_version.value.dist_tag.tag.slice(string_buf), filter).unwrap() orelse latest;
 
                 // Skip only if both the constrained update AND the latest version are the same as current
                 // This ensures we show packages where latest is newer even if constrained update isn't

--- a/src/cli/update_interactive_command.zig
+++ b/src/cli/update_interactive_command.zig
@@ -762,7 +762,7 @@ pub const UpdateInteractiveCommand = struct {
                 // If even `latest` is wholly deprecated under the active filter,
                 // the package has nothing installable to show. Same for age.
                 if (latest_result == .err) continue;
-                const latest = latest_result.unwrap() orelse continue;
+                const latest = latest_result.unwrap().?;
 
                 // In interactive mode, show the constrained update version as "Target"
                 // but always include packages (don't filter out breaking changes).

--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -653,8 +653,8 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
                                                 this.allocator,
                                                 "No non-deprecated version matching \"{s}\" found for specifier \"{s}\"<r> <d>(blocked by blockDeprecatedDependencies)<r>",
                                                 .{
-                                                    this.lockfile.str(&name),
                                                     this.lockfile.str(&version.literal),
+                                                    this.lockfile.str(&name),
                                                 },
                                             ) catch unreachable;
                                         }
@@ -807,12 +807,13 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
                                                         return;
                                                     }
                                                 }
-                                                if (this.options.block_deprecated_dependencies) {
-                                                    if (!loaded_manifest.?.shouldExcludeFromDeprecatedFilter(this.options.block_deprecated_dependencies_excludes) and Npm.PackageManifest.isPackageVersionDeprecated(find_result.package)) {
-                                                        const package_name = this.lockfile.str(&name);
-                                                        this.log.addErrorFmt(null, logger.Loc.Empty, this.allocator, "Version \"{s}@{f}\" is deprecated and blocked by blockDeprecatedDependencies: {s}", .{ package_name, find_result.version.fmt(this.lockfile.buffers.string_bytes.items), find_result.package.deprecated.slice(loaded_manifest.?.string_buf) }) catch {};
-                                                        return;
-                                                    }
+                                                if (this.options.block_deprecated_dependencies and
+                                                    !loaded_manifest.?.shouldExcludeFromDeprecatedFilter(this.options.block_deprecated_dependencies_excludes) and
+                                                    Npm.PackageManifest.isPackageVersionDeprecated(find_result.package))
+                                                {
+                                                    _ = this.network_dedupe_map.remove(task_id);
+                                                    resolve_result_ = error.DeprecatedVersion;
+                                                    continue :retry_with_new_resolve_result;
                                                 }
                                                 if (getOrPutResolvedPackageWithFindResult(
                                                     this,
@@ -1759,7 +1760,7 @@ fn getOrPutResolvedPackage(
                                     });
                                 },
                                 .npm => {
-                                    const version_str = version.value.npm.version.fmt(manifest.string_buf);
+                                    const version_str = version.value.npm.version.fmt(this.lockfile.buffers.string_bytes.items);
                                     Output.prettyErrorln("<d>[block-deprecated]<r> <b>{s}<r>@{f}<r> selected <green>{f}<r> instead of <yellow>{f}<r> because it is deprecated", .{
                                         package_name,
                                         version_str,

--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -646,6 +646,17 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
                                                     this.lockfile.str(&version.value.dist_tag.tag),
                                                 },
                                             ) catch unreachable;
+                                        } else if (version.tag == .npm and version.value.npm.version.isExact()) {
+                                            this.log.addErrorFmt(
+                                                null,
+                                                logger.Loc.Empty,
+                                                this.allocator,
+                                                "Version \"{s}@{s}\" is deprecated<r> <d>(blocked by blockDeprecatedDependencies)<r>",
+                                                .{
+                                                    this.lockfile.str(&name),
+                                                    this.lockfile.str(&version.literal),
+                                                },
+                                            ) catch unreachable;
                                         } else {
                                             this.log.addErrorFmt(
                                                 null,

--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -625,6 +625,43 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
                                 }
                                 return;
                             },
+                            error.DeprecatedVersion => {
+                                if (dependency.behavior.isRequired()) {
+                                    if (failFn) |fail| {
+                                        fail(
+                                            this,
+                                            dependency,
+                                            id,
+                                            err,
+                                        );
+                                    } else {
+                                        if (version.tag == .dist_tag) {
+                                            this.log.addErrorFmt(
+                                                null,
+                                                logger.Loc.Empty,
+                                                this.allocator,
+                                                "Package \"{s}\" with tag \"{s}\" not found<r> <d>(all matching versions blocked by blockDeprecatedDependencies)<r>",
+                                                .{
+                                                    this.lockfile.str(&name),
+                                                    this.lockfile.str(&version.value.dist_tag.tag),
+                                                },
+                                            ) catch unreachable;
+                                        } else {
+                                            this.log.addErrorFmt(
+                                                null,
+                                                logger.Loc.Empty,
+                                                this.allocator,
+                                                "No non-deprecated version matching \"{s}\" found for specifier \"{s}\"<r> <d>(blocked by blockDeprecatedDependencies)<r>",
+                                                .{
+                                                    this.lockfile.str(&name),
+                                                    this.lockfile.str(&version.literal),
+                                                },
+                                            ) catch unreachable;
+                                        }
+                                    }
+                                }
+                                return;
+                            },
                             error.MissingPackageJSON => {
                                 if (dependency.behavior.isRequired()) {
                                     if (failFn) |fail| {
@@ -745,7 +782,7 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
 
                         if (!dependency.behavior.isPeer() or install_peer) {
                             if (!this.hasCreatedNetworkTask(task_id, dependency.behavior.isRequired())) {
-                                const needs_extended_manifest = this.options.minimum_release_age_ms != null;
+                                const needs_extended_manifest = this.options.needsExtendedManifest();
                                 if (this.options.enable.manifest_cache) {
                                     var expired = false;
                                     if (this.manifests.byNameHashAllowExpired(
@@ -767,6 +804,13 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
                                                         const package_name = this.lockfile.str(&name);
                                                         const min_age_seconds = min_age_ms / std.time.ms_per_s;
                                                         this.log.addErrorFmt(null, logger.Loc.Empty, this.allocator, "Version \"{s}@{f}\" was published within minimum release age of {d} seconds", .{ package_name, find_result.version.fmt(this.lockfile.buffers.string_bytes.items), min_age_seconds }) catch {};
+                                                        return;
+                                                    }
+                                                }
+                                                if (this.options.block_deprecated_dependencies) {
+                                                    if (!loaded_manifest.?.shouldExcludeFromDeprecatedFilter(this.options.block_deprecated_dependencies_excludes) and Npm.PackageManifest.isPackageVersionDeprecated(find_result.package)) {
+                                                        const package_name = this.lockfile.str(&name);
+                                                        this.log.addErrorFmt(null, logger.Loc.Empty, this.allocator, "Version \"{s}@{f}\" is deprecated and blocked by blockDeprecatedDependencies: {s}", .{ package_name, find_result.version.fmt(this.lockfile.buffers.string_bytes.items), find_result.package.deprecated.slice(loaded_manifest.?.string_buf) }) catch {};
                                                         return;
                                                     }
                                                 }
@@ -1663,12 +1707,12 @@ fn getOrPutResolvedPackage(
                 this.scopeForPackageName(name_str),
                 name_hash,
                 .load_from_memory_fallback_to_disk,
-                this.options.minimum_release_age_ms != null,
+                this.options.needsExtendedManifest(),
             ) orelse return null; // manifest might still be downloading. This feels unreliable.
 
             const version_result: Npm.PackageManifest.FindVersionResult = switch (version.tag) {
-                .dist_tag => manifest.findByDistTagWithFilter(this.lockfile.str(&version.value.dist_tag.tag), this.options.minimum_release_age_ms, this.options.minimum_release_age_excludes),
-                .npm => manifest.findBestVersionWithFilter(version.value.npm.version, this.lockfile.buffers.string_bytes.items, this.options.minimum_release_age_ms, this.options.minimum_release_age_excludes),
+                .dist_tag => manifest.findByDistTagWithFilter(this.lockfile.str(&version.value.dist_tag.tag), this.options.manifestFilterOptions()),
+                .npm => manifest.findBestVersionWithFilter(version.value.npm.version, this.lockfile.buffers.string_bytes.items, this.options.manifestFilterOptions()),
                 else => unreachable,
             };
 
@@ -1703,12 +1747,36 @@ fn getOrPutResolvedPackage(
                                 else => unreachable,
                             }
                         }
+                        if (filtered.newest_deprecated) |newest| {
+                            switch (version.tag) {
+                                .dist_tag => {
+                                    const tag_str = this.lockfile.str(&version.value.dist_tag.tag);
+                                    Output.prettyErrorln("<d>[block-deprecated]<r> <b>{s}@{s}<r> selected <green>{f}<r> instead of <yellow>{f}<r> because it is deprecated", .{
+                                        package_name,
+                                        tag_str,
+                                        filtered.result.version.fmt(manifest.string_buf),
+                                        newest.fmt(manifest.string_buf),
+                                    });
+                                },
+                                .npm => {
+                                    const version_str = version.value.npm.version.fmt(manifest.string_buf);
+                                    Output.prettyErrorln("<d>[block-deprecated]<r> <b>{s}<r>@{f}<r> selected <green>{f}<r> instead of <yellow>{f}<r> because it is deprecated", .{
+                                        package_name,
+                                        version_str,
+                                        filtered.result.version.fmt(manifest.string_buf),
+                                        newest.fmt(manifest.string_buf),
+                                    });
+                                },
+                                else => unreachable,
+                            }
+                        }
                     }
 
                     break :blk filtered.result;
                 },
                 .err => |err_type| switch (err_type) {
                     .too_recent, .all_versions_too_recent => return error.TooRecentVersion,
+                    .deprecated, .all_versions_deprecated => return error.DeprecatedVersion,
                     .not_found => null, // Handle below with existing logic
                 },
             } orelse {

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -83,6 +83,11 @@ minimum_release_age_ms: ?f64 = null,
 // Packages to exclude from minimum release age checking
 minimum_release_age_excludes: ?[]const []const u8 = null,
 
+// Block installing npm versions whose manifest has a non-empty `deprecated` field
+block_deprecated_dependencies: bool = false,
+// Packages to exclude from the deprecated-version filter
+block_deprecated_dependencies_excludes: ?[]const []const u8 = null,
+
 /// Override CPU architecture for optional dependencies filtering
 cpu: Npm.Architecture = Npm.Architecture.current,
 /// Override OS for optional dependencies filtering
@@ -122,6 +127,20 @@ pub const AuthType = enum {
 
 pub fn shouldPrintCommandName(this: *const Options) bool {
     return this.log_level != .silent and this.do.summary;
+}
+
+pub fn manifestFilterOptions(this: *const Options) Npm.PackageManifest.FilterOptions {
+    return .{
+        .minimum_release_age_ms = this.minimum_release_age_ms,
+        .minimum_release_age_excludes = this.minimum_release_age_excludes,
+        .block_deprecated = this.block_deprecated_dependencies,
+        .block_deprecated_excludes = this.block_deprecated_dependencies_excludes,
+    };
+}
+
+pub fn needsExtendedManifest(this: *const Options) bool {
+    // Age filtering needs publish times, which are only in the extended manifest.
+    return this.minimum_release_age_ms != null;
 }
 
 pub const LogLevel = enum {
@@ -381,6 +400,14 @@ pub fn load(
 
         if (config.minimum_release_age_excludes) |exclusions| {
             this.minimum_release_age_excludes = exclusions;
+        }
+
+        if (config.block_deprecated_dependencies) |block_deprecated| {
+            this.block_deprecated_dependencies = block_deprecated;
+        }
+
+        if (config.block_deprecated_dependencies_excludes) |exclusions| {
+            this.block_deprecated_dependencies_excludes = exclusions;
         }
 
         if (config.public_hoist_pattern) |public_hoist_pattern| {

--- a/src/install/PackageManager/PackageManagerResolution.zig
+++ b/src/install/PackageManager/PackageManagerResolution.zig
@@ -15,10 +15,10 @@ pub fn formatLaterVersionInCache(
                 this.scopeForPackageName(package_name),
                 name_hash,
                 .load_from_memory,
-                this.options.minimum_release_age_ms != null,
+                this.options.needsExtendedManifest(),
             ) orelse return null;
 
-            if (manifest.findByDistTagWithFilter("latest", this.options.minimum_release_age_ms, this.options.minimum_release_age_excludes).unwrap()) |*latest_version| {
+            if (manifest.findByDistTagWithFilter("latest", this.options.manifestFilterOptions()).unwrap()) |*latest_version| {
                 if (latest_version.version.order(
                     resolution.value.npm.version,
                     manifest.string_buf,

--- a/src/install/PackageManager/PopulateManifestCache.zig
+++ b/src/install/PackageManager/PopulateManifestCache.zig
@@ -58,7 +58,7 @@ pub fn populateManifestCache(manager: *PackageManager, packages: Packages) !void
                 }
 
                 const pkg_name = pkg_names[pkg_id];
-                const needs_extended_manifest = manager.options.minimum_release_age_ms != null;
+                const needs_extended_manifest = manager.options.needsExtendedManifest();
 
                 _ = manager.manifests.byName(
                     manager,
@@ -86,7 +86,7 @@ pub fn populateManifestCache(manager: *PackageManager, packages: Packages) !void
                     const resolution: Resolution = pkg_resolutions[pkg_id];
                     if (resolution.tag != .npm) continue;
 
-                    const needs_extended_manifest = manager.options.minimum_release_age_ms != null;
+                    const needs_extended_manifest = manager.options.needsExtendedManifest();
                     const package_name = pkg_names[pkg_id].slice(string_buf);
                     _ = manager.manifests.byName(
                         manager,

--- a/src/install/PackageManager/PopulateManifestCache.zig
+++ b/src/install/PackageManager/PopulateManifestCache.zig
@@ -26,6 +26,7 @@ const Packages = union(enum) {
 /// all packages in the lockfile will have their manifests fetched if necessary.
 pub fn populateManifestCache(manager: *PackageManager, packages: Packages) !void {
     const log_level = manager.options.log_level;
+    const needs_extended_manifest = manager.options.needsExtendedManifest();
     const lockfile = manager.lockfile;
     const resolutions = lockfile.buffers.resolutions.items;
     const dependencies = lockfile.buffers.dependencies.items;
@@ -58,7 +59,6 @@ pub fn populateManifestCache(manager: *PackageManager, packages: Packages) !void
                 }
 
                 const pkg_name = pkg_names[pkg_id];
-                const needs_extended_manifest = manager.options.needsExtendedManifest();
 
                 _ = manager.manifests.byName(
                     manager,
@@ -86,7 +86,6 @@ pub fn populateManifestCache(manager: *PackageManager, packages: Packages) !void
                     const resolution: Resolution = pkg_resolutions[pkg_id];
                     if (resolution.tag != .npm) continue;
 
-                    const needs_extended_manifest = manager.options.needsExtendedManifest();
                     const package_name = pkg_names[pkg_id].slice(string_buf);
                     _ = manager.manifests.byName(
                         manager,

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -1522,14 +1522,6 @@ pub const PackageManifest = struct {
         block_deprecated: bool = false,
         block_deprecated_excludes: ?[]const []const u8 = null,
 
-        pub inline fn none() FilterOptions {
-            return .{};
-        }
-
-        pub inline fn hasAnyFilter(self: FilterOptions) bool {
-            return self.minimum_release_age_ms != null or self.block_deprecated;
-        }
-
         /// Returns the minimum age to apply for this manifest, or null when
         /// age filtering is inactive (disabled or excluded by name).
         pub fn effectiveAgeMs(self: FilterOptions, manifest: *const PackageManifest) ?f64 {

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -1619,6 +1619,13 @@ pub const PackageManifest = struct {
                 }
             }
 
+            if (newest_filtered.* != null or newest_deprecated.* != null) {
+                return .{ .found_with_filter = .{
+                    .result = .{ .version = version, .package = package },
+                    .newest_filtered = newest_filtered.*,
+                    .newest_deprecated = newest_deprecated.*,
+                } };
+            }
             return .{
                 .found = .{
                     .version = version,

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -1842,15 +1842,14 @@ pub const PackageManifest = struct {
 
         if (this.findByDistTag("latest")) |result| {
             if (group.satisfies(result.version, group_buf, this.string_buf)) {
-                if (block_deprecated and isPackageVersionDeprecated(result.package)) {
-                    newest_deprecated = result.version;
-                }
-                if (min_age_ms) |age| {
-                    if (isPackageVersionTooRecent(result.package, age)) {
-                        newest_filtered = result.version;
-                    }
-                }
-                if (newest_filtered == null and newest_deprecated == null) {
+                // Check whether latest is currently blocked so we can decide
+                // whether to short-circuit, but don't seed newest_filtered /
+                // newest_deprecated — `searchVersionList` walks newest-first
+                // and will record the true newest blocked version naturally.
+                // (The `latest` dist-tag isn't always the highest semver.)
+                const latest_too_recent = if (min_age_ms) |age| isPackageVersionTooRecent(result.package, age) else false;
+                const latest_deprecated_now = block_deprecated and isPackageVersionDeprecated(result.package);
+                if (!latest_too_recent and !latest_deprecated_now) {
                     if (group.flags.isSet(Semver.Query.Group.Flags.pre)) {
                         if (left.version.order(result.version, group_buf, this.string_buf) == .eq) {
                             return .{ .found = result };

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -872,13 +872,21 @@ pub const PackageVersion = extern struct {
     /// Unix timestamp when this version was published (0 if unknown)
     publish_timestamp_ms: f64 = 0,
 
+    /// `"deprecated"` field in the npm manifest (empty if not deprecated).
+    /// This is included in the abbreviated manifest, so no extended fetch is required.
+    deprecated: ExternalString = ExternalString{},
+
     pub fn allDependenciesBundled(this: *const PackageVersion) bool {
         return this.bundled_dependencies.isInvalid();
+    }
+
+    pub fn isDeprecated(this: *const PackageVersion) bool {
+        return !this.deprecated.isEmpty();
     }
 };
 
 comptime {
-    if (@sizeOf(Npm.PackageVersion) != 240) {
+    if (@sizeOf(Npm.PackageVersion) != 256) {
         @compileError(std.fmt.comptimePrint("Npm.PackageVersion has unexpected size {d}", .{@sizeOf(Npm.PackageVersion)}));
     }
 }
@@ -935,7 +943,8 @@ pub const PackageManifest = struct {
         // - v0.0.5: added bundled dependencies
         // - v0.0.6: changed semver major/minor/patch to each use u64 instead of u32
         // - v0.0.7: added version publish times and extended manifest flag for minimum release age
-        pub const version = "bun-npm-manifest-cache-v0.0.7\n";
+        // - v0.0.8: added per-version `deprecated` message for blockDeprecatedDependencies
+        pub const version = "bun-npm-manifest-cache-v0.0.8\n";
         const header_bytes: string = "#!/usr/bin/env bun\n" ++ version;
 
         pub const sizes = blk: {
@@ -1479,6 +1488,18 @@ pub const PackageManifest = struct {
         return false;
     }
 
+    pub fn shouldExcludeFromDeprecatedFilter(this: *const PackageManifest, exclusions: ?[]const []const u8) bool {
+        if (exclusions) |excl| {
+            const pkg_name = this.name();
+            for (excl) |excluded| {
+                if (strings.eql(pkg_name, excluded)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     pub inline fn isPackageVersionTooRecent(
         package_version: *const PackageVersion,
         minimum_release_age_ms: f64,
@@ -1487,78 +1508,131 @@ pub const PackageManifest = struct {
         return package_version.publish_timestamp_ms > current_timestamp_ms - minimum_release_age_ms;
     }
 
+    pub inline fn isPackageVersionDeprecated(package_version: *const PackageVersion) bool {
+        return package_version.isDeprecated();
+    }
+
+    /// Combined filter options passed through package resolution.
+    /// Each sub-filter is independent — age blocks versions that are too
+    /// young, deprecation blocks versions with a non-empty `deprecated`
+    /// message in the npm manifest.
+    pub const FilterOptions = struct {
+        minimum_release_age_ms: ?f64 = null,
+        minimum_release_age_excludes: ?[]const []const u8 = null,
+        block_deprecated: bool = false,
+        block_deprecated_excludes: ?[]const []const u8 = null,
+
+        pub inline fn none() FilterOptions {
+            return .{};
+        }
+
+        pub inline fn hasAnyFilter(self: FilterOptions) bool {
+            return self.minimum_release_age_ms != null or self.block_deprecated;
+        }
+
+        /// Returns the minimum age to apply for this manifest, or null when
+        /// age filtering is inactive (disabled or excluded by name).
+        pub fn effectiveAgeMs(self: FilterOptions, manifest: *const PackageManifest) ?f64 {
+            const ms = self.minimum_release_age_ms orelse return null;
+            if (manifest.shouldExcludeFromAgeFilter(self.minimum_release_age_excludes)) return null;
+            return ms;
+        }
+
+        /// Whether the deprecation filter applies to this manifest.
+        pub fn deprecationActive(self: FilterOptions, manifest: *const PackageManifest) bool {
+            if (!self.block_deprecated) return false;
+            if (manifest.shouldExcludeFromDeprecatedFilter(self.block_deprecated_excludes)) return false;
+            return true;
+        }
+    };
+
     fn searchVersionList(
         this: *const PackageManifest,
         versions: []const Semver.Version,
         packages: []const PackageVersion,
         group: Semver.Query.Group,
         group_buf: string,
-        minimum_release_age_ms: f64,
+        minimum_release_age_ms: ?f64,
+        block_deprecated: bool,
         newest_filtered: *?Semver.Version,
+        newest_deprecated: *?Semver.Version,
     ) ?FindVersionResult {
         var prev_package_blocked_from_age: ?*const PackageVersion = null;
         var best_version: ?FindResult = null;
 
         const current_timestamp_ms: f64 = @floatFromInt(@divTrunc(bun.start_time, std.time.ns_per_ms));
         const seven_days_ms: f64 = 7 * std.time.ms_per_day;
-        const stability_window_ms: f64 = @min(minimum_release_age_ms, seven_days_ms);
+        const age_ms_for_window: f64 = minimum_release_age_ms orelse 0;
+        const stability_window_ms: f64 = @min(age_ms_for_window, seven_days_ms);
 
         var i = versions.len;
         while (i > 0) {
             i -= 1;
             const version = versions[i];
-            if (group.satisfies(version, group_buf, this.string_buf)) {
-                const package = &packages[i];
-                if (isPackageVersionTooRecent(package, minimum_release_age_ms)) {
+            if (!group.satisfies(version, group_buf, this.string_buf)) continue;
+            const package = &packages[i];
+
+            if (block_deprecated and isPackageVersionDeprecated(package)) {
+                if (newest_deprecated.* == null) newest_deprecated.* = version;
+                // Deprecation is permanent — no stability window. Skip without
+                // affecting the age-based stability state.
+                continue;
+            }
+
+            if (minimum_release_age_ms) |age_ms| {
+                if (isPackageVersionTooRecent(package, age_ms)) {
                     if (newest_filtered.* == null) newest_filtered.* = version;
                     prev_package_blocked_from_age = package;
+                    continue;
                 }
-                // stability check - if the previous package is blocked from age, we need to check if the current package wasn't the cause
-                else if (prev_package_blocked_from_age) |prev_package| {
-                    // only try to go backwards for a max of 7 days on top of existing minimum age
-                    if (package.publish_timestamp_ms < current_timestamp_ms - (minimum_release_age_ms + seven_days_ms)) {
-                        if (best_version == null) {
-                            best_version = .{
-                                .version = version,
-                                .package = package,
-                            };
-                        }
-                        break;
-                    }
+            }
 
-                    const is_stable = prev_package.publish_timestamp_ms - package.publish_timestamp_ms >= stability_window_ms;
-                    if (is_stable) {
+            // stability check - if the previous package is blocked from age, we need to check if the current package wasn't the cause
+            if (prev_package_blocked_from_age) |prev_package| {
+                // only try to go backwards for a max of 7 days on top of existing minimum age
+                if (package.publish_timestamp_ms < current_timestamp_ms - (age_ms_for_window + seven_days_ms)) {
+                    if (best_version == null) {
                         best_version = .{
                             .version = version,
                             .package = package,
                         };
-                        break;
-                    } else {
-                        if (best_version == null) {
-                            best_version = .{
-                                .version = version,
-                                .package = package,
-                            };
-                        }
-                        prev_package_blocked_from_age = package;
-                        continue;
                     }
+                    break;
+                }
+
+                const is_stable = prev_package.publish_timestamp_ms - package.publish_timestamp_ms >= stability_window_ms;
+                if (is_stable) {
+                    best_version = .{
+                        .version = version,
+                        .package = package,
+                    };
+                    break;
                 } else {
-                    return .{
-                        .found = .{
+                    if (best_version == null) {
+                        best_version = .{
                             .version = version,
                             .package = package,
-                        },
-                    };
+                        };
+                    }
+                    prev_package_blocked_from_age = package;
+                    continue;
                 }
             }
+
+            return .{
+                .found = .{
+                    .version = version,
+                    .package = package,
+                },
+            };
         }
 
         if (best_version) |result| {
-            if (newest_filtered.*) |nf| {
+            if (newest_filtered.* != null or newest_deprecated.* != null) {
                 return .{ .found_with_filter = .{
                     .result = result,
-                    .newest_filtered = nf,
+                    .newest_filtered = newest_filtered.*,
+                    .newest_deprecated = newest_deprecated.*,
                 } };
             } else {
                 return .{ .found = result };
@@ -1572,11 +1646,14 @@ pub const PackageManifest = struct {
         found_with_filter: struct {
             result: FindResult,
             newest_filtered: ?Semver.Version = null,
+            newest_deprecated: ?Semver.Version = null,
         },
         err: enum {
             not_found,
             too_recent,
             all_versions_too_recent,
+            deprecated,
+            all_versions_deprecated,
         },
 
         pub fn unwrap(self: FindVersionResult) ?FindResult {
@@ -1589,9 +1666,9 @@ pub const PackageManifest = struct {
 
         pub fn latestIsFiltered(self: FindVersionResult) bool {
             return switch (self) {
-                .found_with_filter => |filtered| filtered.newest_filtered != null,
-                .err => |err| err == .all_versions_too_recent,
-                // .err.too_recent is only for direct version checks which doesn't prove there was a later version that could have been chosen
+                .found_with_filter => |filtered| filtered.newest_filtered != null or filtered.newest_deprecated != null,
+                .err => |err| err == .all_versions_too_recent or err == .all_versions_deprecated,
+                // .err.too_recent / .err.deprecated are only for direct version checks which doesn't prove there was a later version that could have been chosen
                 else => false,
             };
         }
@@ -1600,20 +1677,22 @@ pub const PackageManifest = struct {
     pub fn findByDistTagWithFilter(
         this: *const PackageManifest,
         tag: string,
-        minimum_release_age_ms: ?f64,
-        exclusions: ?[]const []const u8,
+        filter: FilterOptions,
     ) FindVersionResult {
         const dist_result = this.findByDistTag(tag) orelse return .{ .err = .not_found };
-        const min_age_gate_ms = if (minimum_release_age_ms) |min_age_ms| if (!this.shouldExcludeFromAgeFilter(exclusions)) min_age_ms else null else null;
-        const min_age_ms = min_age_gate_ms orelse {
+        const min_age_ms = filter.effectiveAgeMs(this);
+        const block_deprecated = filter.deprecationActive(this);
+        if (min_age_ms == null and !block_deprecated) {
             return .{ .found = dist_result };
-        };
+        }
         const current_timestamp_ms: f64 = @floatFromInt(@divTrunc(bun.start_time, std.time.ns_per_ms));
         const seven_days_ms: f64 = 7 * std.time.ms_per_day;
-        const stability_window_ms = @min(min_age_ms, seven_days_ms);
+        const age_ms_for_window = min_age_ms orelse 0;
+        const stability_window_ms = @min(age_ms_for_window, seven_days_ms);
 
-        const dist_too_recent = isPackageVersionTooRecent(dist_result.package, min_age_ms);
-        if (!dist_too_recent) {
+        const dist_too_recent = if (min_age_ms) |age| isPackageVersionTooRecent(dist_result.package, age) else false;
+        const dist_deprecated = block_deprecated and isPackageVersionDeprecated(dist_result.package);
+        if (!dist_too_recent and !dist_deprecated) {
             return .{ .found = dist_result };
         }
 
@@ -1630,7 +1709,12 @@ pub const PackageManifest = struct {
         const packages = list.values.get(this.package_versions);
 
         var best_version: ?FindResult = null;
-        var prev_package_blocked_from_age: ?*const PackageVersion = dist_result.package;
+        // If the dist-tag was too-recent, seed the stability tracker with it.
+        // If it was only deprecated, we don't affect age stability — but we
+        // still need to surface it as "the thing we skipped".
+        var prev_package_blocked_from_age: ?*const PackageVersion = if (dist_too_recent) dist_result.package else null;
+        const newest_filtered: ?Semver.Version = if (dist_too_recent) dist_result.version else null;
+        const newest_deprecated: ?Semver.Version = if (dist_deprecated) dist_result.version else null;
 
         var i: usize = versions.len;
         while (i > 0) : (i -= 1) {
@@ -1647,18 +1731,25 @@ pub const PackageManifest = struct {
                 if (!strings.eql(actual_tag, expected_tag)) continue;
             }
 
-            if (isPackageVersionTooRecent(package, min_age_ms)) {
-                prev_package_blocked_from_age = package;
+            if (block_deprecated and isPackageVersionDeprecated(package)) {
                 continue;
+            }
+
+            if (min_age_ms) |age| {
+                if (isPackageVersionTooRecent(package, age)) {
+                    prev_package_blocked_from_age = package;
+                    continue;
+                }
             }
 
             // stability check - if the previous package is blocked from age, we need to check if the current package wasn't the cause
             if (prev_package_blocked_from_age) |prev_package| {
                 // only try to go backwards for a max of 7 days on top of existing minimum age
-                if (package.publish_timestamp_ms < current_timestamp_ms - (min_age_ms + seven_days_ms)) {
+                if (package.publish_timestamp_ms < current_timestamp_ms - (age_ms_for_window + seven_days_ms)) {
                     return .{ .found_with_filter = .{
                         .result = best_version orelse .{ .version = version, .package = package },
-                        .newest_filtered = dist_result.version,
+                        .newest_filtered = newest_filtered,
+                        .newest_deprecated = newest_deprecated,
                     } };
                 }
 
@@ -1666,7 +1757,8 @@ pub const PackageManifest = struct {
                 if (is_stable) {
                     return .{ .found_with_filter = .{
                         .result = .{ .version = version, .package = package },
-                        .newest_filtered = dist_result.version,
+                        .newest_filtered = newest_filtered,
+                        .newest_deprecated = newest_deprecated,
                     } };
                 } else {
                     if (best_version == null) {
@@ -1687,36 +1779,49 @@ pub const PackageManifest = struct {
         if (best_version) |result| {
             return .{ .found_with_filter = .{
                 .result = result,
-                .newest_filtered = dist_result.version,
+                .newest_filtered = newest_filtered,
+                .newest_deprecated = newest_deprecated,
             } };
         }
 
-        return .{ .err = .all_versions_too_recent };
+        if (dist_too_recent) {
+            return .{ .err = .all_versions_too_recent };
+        }
+        return .{ .err = .all_versions_deprecated };
     }
 
     pub fn findBestVersionWithFilter(
         this: *const PackageManifest,
         group: Semver.Query.Group,
         group_buf: string,
-        minimum_release_age_ms: ?f64,
-        exclusions: ?[]const []const u8,
+        filter: FilterOptions,
     ) FindVersionResult {
-        const min_age_gate_ms = if (minimum_release_age_ms) |min_age_ms| if (!this.shouldExcludeFromAgeFilter(exclusions)) min_age_ms else null else null;
-        const min_age_ms = min_age_gate_ms orelse {
+        const min_age_ms = filter.effectiveAgeMs(this);
+        const block_deprecated = filter.deprecationActive(this);
+        if (min_age_ms == null and !block_deprecated) {
             const result = this.findBestVersion(group, group_buf);
             if (result) |r| return .{ .found = r };
             return .{ .err = .not_found };
-        };
-        bun.debugAssert(this.pkg.has_extended_manifest);
+        }
+        // The extended manifest is required for age filtering (publish times).
+        // Deprecation is in the abbreviated manifest, so no assert here when
+        // only block_deprecated is active.
+        if (min_age_ms != null) bun.debugAssert(this.pkg.has_extended_manifest);
 
         const left = group.head.head.range.left;
         var newest_filtered: ?Semver.Version = null;
+        var newest_deprecated: ?Semver.Version = null;
 
         if (left.op == .eql) {
             const result = this.findByVersion(left.version);
             if (result) |r| {
-                if (isPackageVersionTooRecent(r.package, min_age_ms)) {
-                    return .{ .err = .too_recent };
+                if (block_deprecated and isPackageVersionDeprecated(r.package)) {
+                    return .{ .err = .deprecated };
+                }
+                if (min_age_ms) |age| {
+                    if (isPackageVersionTooRecent(r.package, age)) {
+                        return .{ .err = .too_recent };
+                    }
                 }
                 return .{ .found = r };
             }
@@ -1725,10 +1830,15 @@ pub const PackageManifest = struct {
 
         if (this.findByDistTag("latest")) |result| {
             if (group.satisfies(result.version, group_buf, this.string_buf)) {
-                if (isPackageVersionTooRecent(result.package, min_age_ms)) {
-                    newest_filtered = result.version;
+                if (block_deprecated and isPackageVersionDeprecated(result.package)) {
+                    newest_deprecated = result.version;
                 }
-                if (newest_filtered == null) {
+                if (min_age_ms) |age| {
+                    if (isPackageVersionTooRecent(result.package, age)) {
+                        newest_filtered = result.version;
+                    }
+                }
+                if (newest_filtered == null and newest_deprecated == null) {
                     if (group.flags.isSet(Semver.Query.Group.Flags.pre)) {
                         if (left.version.order(result.version, group_buf, this.string_buf) == .eq) {
                             return .{ .found = result };
@@ -1746,7 +1856,9 @@ pub const PackageManifest = struct {
             group,
             group_buf,
             min_age_ms,
+            block_deprecated,
             &newest_filtered,
+            &newest_deprecated,
         )) |result| {
             return result;
         }
@@ -1758,7 +1870,9 @@ pub const PackageManifest = struct {
                 group,
                 group_buf,
                 min_age_ms,
+                block_deprecated,
                 &newest_filtered,
+                &newest_deprecated,
             )) |result| {
                 return result;
             }
@@ -1766,6 +1880,9 @@ pub const PackageManifest = struct {
 
         if (newest_filtered != null) {
             return .{ .err = .all_versions_too_recent };
+        }
+        if (newest_deprecated != null) {
+            return .{ .err = .all_versions_deprecated };
         }
 
         return .{ .err = .not_found };
@@ -1953,6 +2070,14 @@ pub const PackageManifest = struct {
                                 const tarball = tarball_prop.data.e_string.slice(allocator);
                                 string_builder.count(tarball);
                                 tarball_urls_count += @as(usize, @intFromBool(tarball.len > 0));
+                            }
+                        }
+                    }
+
+                    if (prop.value.?.asProperty("deprecated")) |deprecated_q| {
+                        if (deprecated_q.expr.asString(allocator)) |deprecated_str| {
+                            if (deprecated_str.len > 0) {
+                                string_builder.count(deprecated_str);
                             }
                         }
                     }
@@ -2344,6 +2469,14 @@ pub const PackageManifest = struct {
                                         package_version.integrity = Integrity.parseSHASum(shasum_str) catch Integrity{};
                                     }
                                 }
+                            }
+                        }
+                    }
+
+                    if (prop.value.?.asProperty("deprecated")) |deprecated_q| {
+                        if (deprecated_q.expr.asString(allocator)) |deprecated_str| {
+                            if (deprecated_str.len > 0) {
+                                package_version.deprecated = string_builder.append(ExternalString, deprecated_str);
                             }
                         }
                     }

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -1720,8 +1720,8 @@ pub const PackageManifest = struct {
         // If it was only deprecated, we don't affect age stability — but we
         // still need to surface it as "the thing we skipped".
         var prev_package_blocked_from_age: ?*const PackageVersion = if (dist_too_recent) dist_result.package else null;
-        const newest_filtered: ?Semver.Version = if (dist_too_recent) dist_result.version else null;
-        const newest_deprecated: ?Semver.Version = if (dist_deprecated) dist_result.version else null;
+        var newest_filtered: ?Semver.Version = if (dist_too_recent) dist_result.version else null;
+        var newest_deprecated: ?Semver.Version = if (dist_deprecated) dist_result.version else null;
 
         var i: usize = versions.len;
         while (i > 0) : (i -= 1) {
@@ -1739,11 +1739,13 @@ pub const PackageManifest = struct {
             }
 
             if (block_deprecated and isPackageVersionDeprecated(package)) {
+                if (newest_deprecated == null) newest_deprecated = version;
                 continue;
             }
 
             if (min_age_ms) |age| {
                 if (isPackageVersionTooRecent(package, age)) {
+                    if (newest_filtered == null) newest_filtered = version;
                     prev_package_blocked_from_age = package;
                     continue;
                 }
@@ -1791,7 +1793,10 @@ pub const PackageManifest = struct {
             } };
         }
 
-        if (dist_too_recent) {
+        // Report the filter that actually blocked the last hope of a fallback:
+        // if any non-deprecated candidate was rejected by age, attribute the
+        // failure to age; otherwise it was all deprecation.
+        if (newest_filtered != null) {
             return .{ .err = .all_versions_too_recent };
         }
         return .{ .err = .all_versions_deprecated };

--- a/test/regression/issue/28822.test.ts
+++ b/test/regression/issue/28822.test.ts
@@ -5,9 +5,9 @@ import { bunEnv, bunExe, tempDir } from "harness";
 /**
  * Regression test for https://github.com/oven-sh/bun/issues/28822
  *
- * `blockDeprecatedDependencies` (bunfig) / `--block-deprecated-dependencies`
- * (CLI flag) / per-package excludes. A version with a non-empty `deprecated`
- * string in its npm manifest entry is skipped during resolution.
+ * `blockDeprecatedDependencies` (bunfig, with per-package excludes). A
+ * version with a non-empty `deprecated` string in its npm manifest entry
+ * is skipped during resolution.
  */
 describe.concurrent("issue #28822 - blockDeprecatedDependencies", () => {
   let mockRegistryServer: Server;
@@ -229,7 +229,7 @@ describe.concurrent("issue #28822 - blockDeprecatedDependencies", () => {
     });
 
     const [_stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(exitCode).not.toBe(0);
     expect(stderr.toLowerCase()).toMatch(/blockdeprecateddependencies|boolean/);
+    expect(exitCode).not.toBe(0);
   });
 });

--- a/test/regression/issue/28822.test.ts
+++ b/test/regression/issue/28822.test.ts
@@ -193,6 +193,26 @@ describe("issue #28822 - blockDeprecatedDependencies", () => {
     expect({ stdout, exitCode }).not.toMatchObject({ exitCode: 0 });
   });
 
+  test("fails when an exact pinned version is itself deprecated", async () => {
+    using dir = tempDir("issue28822-exact-pin", {
+      "package.json": JSON.stringify({ name: "app", dependencies: { lodashlike: "4.18.0" } }),
+      ".npmrc": `registry=${mockRegistryUrl}`,
+      "bunfig.toml": `[install]\nblockDeprecatedDependencies = true\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--lockfile-only"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [_stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("blockDeprecatedDependencies");
+    expect(exitCode).not.toBe(0);
+  });
+
   test("bunfig rejects non-boolean blockDeprecatedDependencies", async () => {
     using dir = tempDir("issue28822-bad-config", {
       "package.json": JSON.stringify({ name: "app", dependencies: { "clean-pkg": "1.0.0" } }),

--- a/test/regression/issue/28822.test.ts
+++ b/test/regression/issue/28822.test.ts
@@ -9,7 +9,7 @@ import { bunEnv, bunExe, tempDir } from "harness";
  * (CLI flag) / per-package excludes. A version with a non-empty `deprecated`
  * string in its npm manifest entry is skipped during resolution.
  */
-describe("issue #28822 - blockDeprecatedDependencies", () => {
+describe.concurrent("issue #28822 - blockDeprecatedDependencies", () => {
   let mockRegistryServer: Server;
   let mockRegistryUrl = "";
 

--- a/test/regression/issue/28822.test.ts
+++ b/test/regression/issue/28822.test.ts
@@ -1,0 +1,215 @@
+import type { Server } from "bun";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+/**
+ * Regression test for https://github.com/oven-sh/bun/issues/28822
+ *
+ * `blockDeprecatedDependencies` (bunfig) / `--block-deprecated-dependencies`
+ * (CLI flag) / per-package excludes. A version with a non-empty `deprecated`
+ * string in its npm manifest entry is skipped during resolution.
+ */
+describe("issue #28822 - blockDeprecatedDependencies", () => {
+  let mockRegistryServer: Server;
+  let mockRegistryUrl = "";
+
+  beforeAll(() => {
+    mockRegistryServer = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+
+        // PACKAGE A: latest version is deprecated → should pick prior one
+        if (url.pathname === "/lodashlike") {
+          return Response.json({
+            name: "lodashlike",
+            "dist-tags": { latest: "4.18.0" },
+            versions: {
+              "4.17.23": {
+                name: "lodashlike",
+                version: "4.17.23",
+                dist: {
+                  tarball: `${mockRegistryUrl}/lodashlike/-/lodashlike-4.17.23.tgz`,
+                  integrity: "sha512-fake-a1==",
+                },
+              },
+              "4.18.0": {
+                name: "lodashlike",
+                version: "4.18.0",
+                deprecated: "broken — use 4.17.23 or newer",
+                dist: {
+                  tarball: `${mockRegistryUrl}/lodashlike/-/lodashlike-4.18.0.tgz`,
+                  integrity: "sha512-fake-a2==",
+                },
+              },
+            },
+          });
+        }
+
+        // PACKAGE B: every matching version is deprecated
+        if (url.pathname === "/all-deprecated") {
+          return Response.json({
+            name: "all-deprecated",
+            "dist-tags": { latest: "2.0.0" },
+            versions: {
+              "1.0.0": {
+                name: "all-deprecated",
+                version: "1.0.0",
+                deprecated: "don't use",
+                dist: {
+                  tarball: `${mockRegistryUrl}/all-deprecated/-/all-deprecated-1.0.0.tgz`,
+                  integrity: "sha512-fake-b1==",
+                },
+              },
+              "2.0.0": {
+                name: "all-deprecated",
+                version: "2.0.0",
+                deprecated: "don't use",
+                dist: {
+                  tarball: `${mockRegistryUrl}/all-deprecated/-/all-deprecated-2.0.0.tgz`,
+                  integrity: "sha512-fake-b2==",
+                },
+              },
+            },
+          });
+        }
+
+        // PACKAGE C: clean versions only
+        if (url.pathname === "/clean-pkg") {
+          return Response.json({
+            name: "clean-pkg",
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name: "clean-pkg",
+                version: "1.0.0",
+                dist: {
+                  tarball: `${mockRegistryUrl}/clean-pkg/-/clean-pkg-1.0.0.tgz`,
+                  integrity: "sha512-fake-c==",
+                },
+              },
+            },
+          });
+        }
+
+        return new Response("not found", { status: 404 });
+      },
+    });
+    mockRegistryUrl = `http://localhost:${mockRegistryServer.port}`;
+  });
+
+  afterAll(() => {
+    mockRegistryServer?.stop(true);
+  });
+
+  test("when blocked, deprecated latest version is skipped and prior version is chosen", async () => {
+    using dir = tempDir("issue28822-skip-deprecated", {
+      "package.json": JSON.stringify({ name: "app", dependencies: { lodashlike: "^4.17.0" } }),
+      ".npmrc": `registry=${mockRegistryUrl}`,
+      "bunfig.toml": `[install]\nblockDeprecatedDependencies = true\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--lockfile-only"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+
+    const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+    expect(lockfile).toContain("lodashlike@4.17.23");
+    expect(lockfile).not.toContain("lodashlike@4.18.0");
+  });
+
+  test("without the option set, deprecated latest is still selected (default behaviour)", async () => {
+    using dir = tempDir("issue28822-default-behaviour", {
+      "package.json": JSON.stringify({ name: "app", dependencies: { lodashlike: "^4.17.0" } }),
+      ".npmrc": `registry=${mockRegistryUrl}`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--lockfile-only"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+
+    const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+    expect(lockfile).toContain("lodashlike@4.18.0");
+  });
+
+  test("blockDeprecatedDependenciesExcludes lets a specific package keep its deprecated version", async () => {
+    using dir = tempDir("issue28822-excludes", {
+      "package.json": JSON.stringify({ name: "app", dependencies: { lodashlike: "^4.17.0" } }),
+      ".npmrc": `registry=${mockRegistryUrl}`,
+      "bunfig.toml": `[install]\nblockDeprecatedDependencies = true\nblockDeprecatedDependenciesExcludes = ["lodashlike"]\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--lockfile-only"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+
+    const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+    // Excluded package keeps its normally-picked latest version, deprecated and all.
+    expect(lockfile).toContain("lodashlike@4.18.0");
+  });
+
+  test("fails when every semver-matching version is deprecated", async () => {
+    using dir = tempDir("issue28822-all-deprecated", {
+      "package.json": JSON.stringify({
+        name: "app",
+        dependencies: { "all-deprecated": "^1.0.0", "clean-pkg": "1.0.0" },
+      }),
+      ".npmrc": `registry=${mockRegistryUrl}`,
+      "bunfig.toml": `[install]\nblockDeprecatedDependencies = true\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--lockfile-only"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Installation must fail and the error must cite the new option by name.
+    expect(stderr).toContain("blockDeprecatedDependencies");
+    expect({ stdout, exitCode }).not.toMatchObject({ exitCode: 0 });
+  });
+
+  test("bunfig rejects non-boolean blockDeprecatedDependencies", async () => {
+    using dir = tempDir("issue28822-bad-config", {
+      "package.json": JSON.stringify({ name: "app", dependencies: { "clean-pkg": "1.0.0" } }),
+      ".npmrc": `registry=${mockRegistryUrl}`,
+      "bunfig.toml": `[install]\nblockDeprecatedDependencies = "yes"\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--lockfile-only"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [_stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr.toLowerCase()).toMatch(/blockdeprecateddependencies|boolean/);
+  });
+});


### PR DESCRIPTION
Closes #28822
Relates to #25314

## Why

A package ecosystem gotcha: a maintainer publishes a broken version, then deprecates it and pushes a patch release. With Bun's existing `minimumReleaseAge` setting, the patched version can be too young to pick, so the resolver happily installs the deprecated broken one. The reporter hit this with lodash 4.18.0.

## What

Two new options under `[install]` in `bunfig.toml`:

```toml
[install]
blockDeprecatedDependencies = true
blockDeprecatedDependenciesExcludes = ["request", "left-pad"]
```

When `blockDeprecatedDependencies` is true, any npm version whose manifest entry has a non-empty `deprecated` field is skipped during resolution. The resolver walks versions newest → oldest and picks the highest non-deprecated one that matches the requested range. If every matching version is deprecated — or if an exact pin points at a deprecated version — the install fails with an error that names the option.

The `blockDeprecatedDependenciesExcludes` list takes package names that are allowed to keep their deprecated versions (mirroring `minimumReleaseAgeExcludes`).

Both filters compose cleanly: age and deprecation are checked independently against each candidate version. Deprecation has no "stability window" (unlike age) because deprecation is permanent.

## Implementation

- `PackageVersion` in `src/install/npm.zig` gains a `deprecated: ExternalString` field parsed out of the abbreviated manifest. No extended manifest fetch is needed — deprecated ships in the abbreviated registry response.
- The npm manifest cache format version bumps from v0.0.7 → v0.0.8 to account for the added field.
- Filter state is bundled into a new `FilterOptions` struct on `PackageManifest` and threaded through `findByDistTagWithFilter` / `findBestVersionWithFilter` / `searchVersionList`. Callers in `PackageManagerEnqueue`, `PackageManagerResolution`, `outdated_command`, `update_interactive_command`, and `PopulateManifestCache` now build this struct via `options.manifestFilterOptions()`.
- `options.needsExtendedManifest()` replaces the scattered `minimum_release_age_ms != null` checks.
- `FindVersionResult` gains two new error variants (`deprecated`, `all_versions_deprecated`) and its `found_with_filter` arm carries both `newest_filtered` (age) and `newest_deprecated` (deprecation) for the verbose-log output.

## Verification

```
bun bd test test/regression/issue/28822.test.ts
```

5 tests pass on the debug build with the patch applied; 3 of them fail on system bun, which confirms they exercise the new code path.

Docs updated at `docs/runtime/bunfig.mdx`.