### PR TITLE
fix(linux): widen statx fallback to match libuv (EPERM/EINVAL/rc>0)

### DIFF
--- a/src/sys.zig
+++ b/src/sys.zig
@@ -587,6 +587,22 @@ inline fn makedev(major: u32, minor: u32) u64 {
     return (maj << 8) | (min & 0xFF) | ((min & 0xFFF00) << 12);
 }
 
+fn statxFallback(fd: bun.FileDescriptor, path: ?[*:0]const u8, flags: u32) Maybe(PosixStat) {
+    if (path) |p| {
+        const path_span = bun.span(p);
+        const fallback = if (flags & linux.AT.SYMLINK_NOFOLLOW != 0) lstat(path_span) else stat(path_span);
+        return switch (fallback) {
+            .result => |s| .{ .result = PosixStat.init(&s) },
+            .err => |e| .{ .err = e },
+        };
+    } else {
+        return switch (fstat(fd)) {
+            .result => |s| .{ .result = PosixStat.init(&s) },
+            .err => |e| .{ .err = e },
+        };
+    }
+}
+
 fn statxImpl(fd: bun.FileDescriptor, path: ?[*:0]const u8, flags: u32, mask: u32) Maybe(PosixStat) {
     if (comptime !Environment.isLinux) {
         @compileError("statx is only supported on Linux");
@@ -597,29 +613,33 @@ fn statxImpl(fd: bun.FileDescriptor, path: ?[*:0]const u8, flags: u32, mask: u32
     while (true) {
         const rc = linux.statx(@intCast(fd.cast()), if (path) |p| p else "", flags, mask, &buf);
 
+        // On some setups (QEMU user-mode, S390 RHEL docker), statx returns a
+        // positive value other than 0 with errno unset — neither a normal
+        // success (0) nor a kernel -errno. Treat as "not implemented".
+        // See nodejs/node#27275 and libuv/libuv src/unix/fs.c.
+        if (@as(isize, @bitCast(rc)) > 0) {
+            supports_statx_on_linux.store(false, .monotonic);
+            return statxFallback(fd, path, flags);
+        }
+
         if (Maybe(PosixStat).errnoSys(rc, .statx)) |err| {
             // Retry on EINTR
             if (err.getErrno() == .INTR) continue;
 
-            // Handle unsupported statx by setting flag and falling back
-            if (err.getErrno() == .NOSYS or err.getErrno() == .OPNOTSUPP) {
-                supports_statx_on_linux.store(false, .monotonic);
-                if (path) |p| {
-                    const path_span = bun.span(p);
-                    const fallback = if (flags & linux.AT.SYMLINK_NOFOLLOW != 0) lstat(path_span) else stat(path_span);
-                    return switch (fallback) {
-                        .result => |s| .{ .result = PosixStat.init(&s) },
-                        .err => |e| .{ .err = e },
-                    };
-                } else {
-                    return switch (fstat(fd)) {
-                        .result => |s| .{ .result = PosixStat.init(&s) },
-                        .err => |e| .{ .err = e },
-                    };
-                }
+            // Handle unsupported statx by setting the flag and falling back.
+            // Fall back on the same errnos libuv does (deps/uv/src/unix/fs.c):
+            //   ENOSYS:     kernel < 4.11
+            //   EOPNOTSUPP: filesystem doesn't support it
+            //   EPERM:      seccomp filter rejects statx (libseccomp < 2.3.3,
+            //               docker < 18.04, various CI sandboxes)
+            //   EINVAL:     old Android builds
+            switch (err.getErrno()) {
+                .NOSYS, .OPNOTSUPP, .PERM, .INVAL => {
+                    supports_statx_on_linux.store(false, .monotonic);
+                    return statxFallback(fd, path, flags);
+                },
+                else => return err,
             }
-
-            return err;
         }
 
         // Convert statx buffer to PosixStat structure

--- a/test/js/node/fs/fs-stat-seccomp-linux.test.ts
+++ b/test/js/node/fs/fs-stat-seccomp-linux.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDirWithFiles } from "harness";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+// Reproduces the seccomp class of failures documented in libuv's
+// deps/uv/src/unix/fs.c: statx under a seccomp filter that does not
+// whitelist it returns EPERM (libseccomp < 2.3.3, docker < 18.04, various
+// CI sandboxes). Before the fix, fs.stat would throw EPERM here.
+// After the fix, statxImpl falls back to fstatat.
+describe.skipIf(!isLinux)("fs.stat seccomp statx fallback", () => {
+  const helperSrc = `
+#define _GNU_SOURCE
+#include <errno.h>
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#if defined(__x86_64__)
+  #define MY_AUDIT_ARCH AUDIT_ARCH_X86_64
+#elif defined(__aarch64__)
+  #define MY_AUDIT_ARCH AUDIT_ARCH_AARCH64
+#else
+  #define MY_AUDIT_ARCH 0
+#endif
+
+int main(int argc, char **argv) {
+  if (argc < 2) return 2;
+  if (MY_AUDIT_ARCH == 0) return 77; /* unsupported arch, skip */
+
+  struct sock_filter filter[] = {
+    /* arch check */
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, arch)),
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, MY_AUDIT_ARCH, 1, 0),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    /* load syscall nr */
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+    /* if nr == __NR_statx → return EPERM */
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_statx, 0, 1),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (EPERM & SECCOMP_RET_DATA)),
+    /* else → allow */
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+  };
+  struct sock_fprog prog = {
+    .len = (unsigned short)(sizeof(filter) / sizeof(filter[0])),
+    .filter = filter,
+  };
+
+  if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) {
+    perror("prctl(PR_SET_NO_NEW_PRIVS)");
+    return 77; /* cannot install filter, skip */
+  }
+  if (syscall(__NR_seccomp, SECCOMP_SET_MODE_FILTER, 0, &prog) != 0) {
+    perror("seccomp");
+    return 77; /* cannot install filter, skip */
+  }
+
+  execvp(argv[1], &argv[1]);
+  perror("execvp");
+  return 127;
+}
+`;
+
+  const tryBuild = () => {
+    const dir = tempDirWithFiles("stat-seccomp", {
+      "block_statx.c": helperSrc,
+    });
+    const src = join(dir, "block_statx.c");
+    const bin = join(dir, "block_statx");
+    const compile = spawnSync("cc", ["-O0", "-o", bin, src], { stdio: "pipe" });
+    if (compile.status !== 0 || !existsSync(bin)) {
+      return null;
+    }
+    return { dir, bin };
+  };
+
+  test("fs.statSync succeeds when statx is blocked by seccomp", async () => {
+    const built = tryBuild();
+    if (!built) return; // no compiler / seccomp headers available — skip
+
+    const targetDir = tempDirWithFiles("stat-seccomp-target", {
+      "file.txt": "hello",
+    });
+    const target = join(targetDir, "file.txt");
+
+    // Sanity check: the blocker itself must actually block statx. If the
+    // environment doesn't permit seccomp (exit 77), skip.
+    await using proc = Bun.spawn({
+      cmd: [
+        built.bin,
+        bunExe(),
+        "-e",
+        `
+          const fs = require("node:fs");
+          const s = fs.statSync(${JSON.stringify(target)});
+          const l = fs.lstatSync(${JSON.stringify(target)});
+          const fd = fs.openSync(${JSON.stringify(target)}, "r");
+          const f = fs.fstatSync(fd);
+          fs.closeSync(fd);
+          console.log(JSON.stringify({ size: s.size, lsize: l.size, fsize: f.size, isFile: s.isFile() }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    if (exitCode === 77) {
+      // Helper couldn't install seccomp in this environment — skip.
+      console.log("skip: seccomp not permitted in this environment:", stderr.trim());
+      return;
+    }
+
+    expect(stdout.trim()).toBe(JSON.stringify({ size: 5, lsize: 5, fsize: 5, isFile: true }));
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/fs/fs-stat-seccomp-linux.test.ts
+++ b/test/js/node/fs/fs-stat-seccomp-linux.test.ts
@@ -111,11 +111,7 @@ int main(int argc, char **argv) {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     if (exitCode === 77) {
       // Helper couldn't install seccomp in this environment — skip.

--- a/test/js/node/fs/fs-stat-seccomp-linux.test.ts
+++ b/test/js/node/fs/fs-stat-seccomp-linux.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, tempDirWithFiles } from "harness";
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 
 // Reproduces the seccomp class of failures documented in libuv's
@@ -117,39 +117,49 @@ int main(int argc, char **argv) {
     return { stdout, stderr, exitCode };
   }
 
-  const cases: Array<{ name: string; snippet: (target: string) => string; expected: string }> = [
+  // `lstatSync` targets a symlink so the SYMLINK_NOFOLLOW branch of
+  // statxFallback is actually distinguishable from the stat() branch: if
+  // the condition were inverted the subprocess would follow the link and
+  // report isSymbolicLink:false / isFile:true.
+  const cases: Array<{
+    name: string;
+    target: (dir: string) => string;
+    snippet: (target: string) => string;
+    expected: string;
+  }> = [
     {
-      // exercises statxFallback path branch (no SYMLINK_NOFOLLOW)
       name: "statSync",
+      target: dir => join(dir, "file.txt"),
       snippet: target => `
         const fs = require("node:fs");
         const s = fs.statSync(${JSON.stringify(target)});
-        console.log(JSON.stringify({ size: s.size, isFile: s.isFile() }));
+        console.log(JSON.stringify({ size: s.size, isFile: s.isFile(), isSymbolicLink: s.isSymbolicLink() }));
       `,
-      expected: JSON.stringify({ size: 5, isFile: true }),
+      expected: JSON.stringify({ size: 5, isFile: true, isSymbolicLink: false }),
     },
     {
-      // exercises statxFallback path branch (SYMLINK_NOFOLLOW)
       name: "lstatSync",
+      target: dir => join(dir, "link.txt"),
       snippet: target => `
         const fs = require("node:fs");
         const s = fs.lstatSync(${JSON.stringify(target)});
-        console.log(JSON.stringify({ size: s.size, isFile: s.isFile() }));
+        console.log(JSON.stringify({ isFile: s.isFile(), isSymbolicLink: s.isSymbolicLink() }));
       `,
-      expected: JSON.stringify({ size: 5, isFile: true }),
+      // isFile:false + isSymbolicLink:true proves we used lstat, not stat.
+      expected: JSON.stringify({ isFile: false, isSymbolicLink: true }),
     },
     {
-      // exercises statxFallback fd branch (path == null)
       name: "fstatSync",
+      target: dir => join(dir, "file.txt"),
       snippet: target => `
         const fs = require("node:fs");
         const fd = fs.openSync(${JSON.stringify(target)}, "r");
         try {
           const s = fs.fstatSync(fd);
-          console.log(JSON.stringify({ size: s.size, isFile: s.isFile() }));
+          console.log(JSON.stringify({ size: s.size, isFile: s.isFile(), isSymbolicLink: s.isSymbolicLink() }));
         } finally { fs.closeSync(fd); }
       `,
-      expected: JSON.stringify({ size: 5, isFile: true }),
+      expected: JSON.stringify({ size: 5, isFile: true, isSymbolicLink: false }),
     },
   ];
 
@@ -164,18 +174,18 @@ int main(int argc, char **argv) {
       }
 
       const targetDir = tempDirWithFiles("stat-seccomp-target", { "file.txt": "hello" });
-      const target = join(targetDir, "file.txt");
+      // symlink created here rather than via tempDirWithFiles (which only
+      // supports regular files).
+      symlinkSync("file.txt", join(targetDir, "link.txt"));
 
-      const out = await runUnderSeccomp(helperBin, c.snippet(target));
+      const out = await runUnderSeccomp(helperBin, c.snippet(c.target(targetDir)));
       if (out == null) {
         console.warn(`SKIP fs.${c.name} seccomp: seccomp not permitted in this environment`);
         return;
       }
 
-      // Strip the one known ASAN warning that debug builds print on startup;
-      // anything else on stderr is a real regression.
-      const stderr = out.stderr.replace(/^WARNING: ASAN interferes with JSC signal handlers;.*\n?/m, "").trim();
-      expect(stderr).toBe("");
+      // Don't assert empty stderr — ASAN builds emit a startup warning
+      // there. exitCode is the crash/failure signal.
       expect(out.stdout.trim()).toBe(c.expected);
       expect(out.exitCode).toBe(0);
     });

--- a/test/js/node/fs/fs-stat-seccomp-linux.test.ts
+++ b/test/js/node/fs/fs-stat-seccomp-linux.test.ts
@@ -8,7 +8,12 @@ import { join } from "node:path";
 // deps/uv/src/unix/fs.c: statx under a seccomp filter that does not
 // whitelist it returns EPERM (libseccomp < 2.3.3, docker < 18.04, various
 // CI sandboxes). Before the fix, fs.stat would throw EPERM here.
-// After the fix, statxImpl falls back to fstatat.
+// After the fix, statxImpl falls back to fstat/lstat/stat.
+//
+// Each stat variant runs in its OWN subprocess so the per-process
+// `supports_statx_on_linux` flag is still `true` on entry — otherwise the
+// first call would flip the flag and subsequent calls would bypass
+// statxImpl/statxFallback entirely and go straight to Syscall.lstat/fstat.
 describe.skipIf(!isLinux)("fs.stat seccomp statx fallback", () => {
   const helperSrc = `
 #define _GNU_SOURCE
@@ -81,49 +86,79 @@ int main(int argc, char **argv) {
     return { dir, bin };
   };
 
-  test("fs.statSync succeeds when statx is blocked by seccomp", async () => {
-    const built = tryBuild();
-    if (!built) {
-      // bun:test has no runtime-skip; log loudly so CI output distinguishes
-      // this from a real pass. Happens when cc or the seccomp headers are
-      // missing on the test host.
-      console.warn("SKIP fs.stat seccomp: compiling the seccomp helper failed (cc/headers missing)");
-      return;
-    }
-
-    const targetDir = tempDirWithFiles("stat-seccomp-target", {
-      "file.txt": "hello",
-    });
-    const target = join(targetDir, "file.txt");
-
+  // Run `snippet` in a bun subprocess guarded by the seccomp helper.
+  // Returns { stdout, stderr, exitCode } on success, or null if the
+  // environment refused to install the seccomp filter (skip).
+  async function runUnderSeccomp(bin: string, snippet: string) {
     await using proc = Bun.spawn({
-      cmd: [
-        built.bin,
-        bunExe(),
-        "-e",
-        `
-          const fs = require("node:fs");
-          const s = fs.statSync(${JSON.stringify(target)});
-          const l = fs.lstatSync(${JSON.stringify(target)});
-          const fd = fs.openSync(${JSON.stringify(target)}, "r");
-          const f = fs.fstatSync(fd);
-          fs.closeSync(fd);
-          console.log(JSON.stringify({ size: s.size, lsize: l.size, fsize: f.size, isFile: s.isFile() }));
-        `,
-      ],
+      cmd: [bin, bunExe(), "-e", snippet],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode === 77) return null;
+    return { stdout, stderr, exitCode };
+  }
 
-    if (exitCode === 77) {
-      // Helper couldn't install seccomp in this environment — skip loudly.
-      console.warn("SKIP fs.stat seccomp: seccomp not permitted in this environment:", stderr.trim());
-      return;
-    }
+  const cases: Array<{ name: string; snippet: (target: string) => string; expected: string }> = [
+    {
+      // exercises statxFallback path branch (no SYMLINK_NOFOLLOW)
+      name: "statSync",
+      snippet: target => `
+        const fs = require("node:fs");
+        const s = fs.statSync(${JSON.stringify(target)});
+        console.log(JSON.stringify({ size: s.size, isFile: s.isFile() }));
+      `,
+      expected: JSON.stringify({ size: 5, isFile: true }),
+    },
+    {
+      // exercises statxFallback path branch (SYMLINK_NOFOLLOW)
+      name: "lstatSync",
+      snippet: target => `
+        const fs = require("node:fs");
+        const s = fs.lstatSync(${JSON.stringify(target)});
+        console.log(JSON.stringify({ size: s.size, isFile: s.isFile() }));
+      `,
+      expected: JSON.stringify({ size: 5, isFile: true }),
+    },
+    {
+      // exercises statxFallback fd branch (path == null)
+      name: "fstatSync",
+      snippet: target => `
+        const fs = require("node:fs");
+        const fd = fs.openSync(${JSON.stringify(target)}, "r");
+        try {
+          const s = fs.fstatSync(fd);
+          console.log(JSON.stringify({ size: s.size, isFile: s.isFile() }));
+        } finally { fs.closeSync(fd); }
+      `,
+      expected: JSON.stringify({ size: 5, isFile: true }),
+    },
+  ];
 
-    expect(stdout.trim()).toBe(JSON.stringify({ size: 5, lsize: 5, fsize: 5, isFile: true }));
-    expect(exitCode).toBe(0);
-  });
+  for (const c of cases) {
+    test(`${c.name} succeeds when statx is blocked by seccomp`, async () => {
+      const built = tryBuild();
+      if (!built) {
+        // bun:test has no runtime-skip; log loudly so CI output distinguishes
+        // this from a real pass. Happens when cc or the seccomp headers are
+        // missing on the test host.
+        console.warn(`SKIP fs.${c.name} seccomp: compiling the seccomp helper failed (cc/headers missing)`);
+        return;
+      }
+
+      const targetDir = tempDirWithFiles("stat-seccomp-target", { "file.txt": "hello" });
+      const target = join(targetDir, "file.txt");
+
+      const out = await runUnderSeccomp(built.bin, c.snippet(target));
+      if (out == null) {
+        console.warn(`SKIP fs.${c.name} seccomp: seccomp not permitted in this environment`);
+        return;
+      }
+
+      expect(out.stdout.trim()).toBe(c.expected);
+      expect(out.exitCode).toBe(0);
+    });
+  }
 });

--- a/test/js/node/fs/fs-stat-seccomp-linux.test.ts
+++ b/test/js/node/fs/fs-stat-seccomp-linux.test.ts
@@ -83,15 +83,19 @@ int main(int argc, char **argv) {
 
   test("fs.statSync succeeds when statx is blocked by seccomp", async () => {
     const built = tryBuild();
-    if (!built) return; // no compiler / seccomp headers available — skip
+    if (!built) {
+      // bun:test has no runtime-skip; log loudly so CI output distinguishes
+      // this from a real pass. Happens when cc or the seccomp headers are
+      // missing on the test host.
+      console.warn("SKIP fs.stat seccomp: compiling the seccomp helper failed (cc/headers missing)");
+      return;
+    }
 
     const targetDir = tempDirWithFiles("stat-seccomp-target", {
       "file.txt": "hello",
     });
     const target = join(targetDir, "file.txt");
 
-    // Sanity check: the blocker itself must actually block statx. If the
-    // environment doesn't permit seccomp (exit 77), skip.
     await using proc = Bun.spawn({
       cmd: [
         built.bin,
@@ -114,8 +118,8 @@ int main(int argc, char **argv) {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     if (exitCode === 77) {
-      // Helper couldn't install seccomp in this environment — skip.
-      console.log("skip: seccomp not permitted in this environment:", stderr.trim());
+      // Helper couldn't install seccomp in this environment — skip loudly.
+      console.warn("SKIP fs.stat seccomp: seccomp not permitted in this environment:", stderr.trim());
       return;
     }
 

--- a/test/js/node/fs/fs-stat-seccomp-linux.test.ts
+++ b/test/js/node/fs/fs-stat-seccomp-linux.test.ts
@@ -73,18 +73,34 @@ int main(int argc, char **argv) {
 }
 `;
 
-  const tryBuild = () => {
+  // Compile the seccomp helper once. Returns the binary path, or null if
+  // the host genuinely can't build it (no cc, missing kernel headers).
+  // Any other compile failure throws so a source regression isn't silently
+  // hidden as a skip.
+  const tryBuild = (): string | null => {
     const dir = tempDirWithFiles("stat-seccomp", {
       "block_statx.c": helperSrc,
     });
     const src = join(dir, "block_statx.c");
     const bin = join(dir, "block_statx");
     const compile = spawnSync("cc", ["-O0", "-o", bin, src], { stdio: "pipe" });
-    if (compile.status !== 0 || !existsSync(bin)) {
-      return null;
+
+    // compiler not on PATH — expected skip
+    if ((compile.error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") return null;
+
+    if (compile.status !== 0) {
+      const stderr = compile.stderr?.toString() ?? "";
+      // missing linux/*.h on the host — expected skip
+      if (/linux\/(seccomp|filter|audit)\.h|sys\/prctl\.h/.test(stderr)) return null;
+      throw new Error(`failed to compile seccomp helper:\n${stderr}`);
     }
-    return { dir, bin };
+    if (!existsSync(bin)) {
+      throw new Error("seccomp helper compiled successfully but output binary is missing");
+    }
+    return bin;
   };
+
+  const helperBin = tryBuild();
 
   // Run `snippet` in a bun subprocess guarded by the seccomp helper.
   // Returns { stdout, stderr, exitCode } on success, or null if the
@@ -139,24 +155,27 @@ int main(int argc, char **argv) {
 
   for (const c of cases) {
     test(`${c.name} succeeds when statx is blocked by seccomp`, async () => {
-      const built = tryBuild();
-      if (!built) {
+      if (helperBin == null) {
         // bun:test has no runtime-skip; log loudly so CI output distinguishes
         // this from a real pass. Happens when cc or the seccomp headers are
         // missing on the test host.
-        console.warn(`SKIP fs.${c.name} seccomp: compiling the seccomp helper failed (cc/headers missing)`);
+        console.warn(`SKIP fs.${c.name} seccomp: cc or seccomp headers not available`);
         return;
       }
 
       const targetDir = tempDirWithFiles("stat-seccomp-target", { "file.txt": "hello" });
       const target = join(targetDir, "file.txt");
 
-      const out = await runUnderSeccomp(built.bin, c.snippet(target));
+      const out = await runUnderSeccomp(helperBin, c.snippet(target));
       if (out == null) {
         console.warn(`SKIP fs.${c.name} seccomp: seccomp not permitted in this environment`);
         return;
       }
 
+      // Strip the one known ASAN warning that debug builds print on startup;
+      // anything else on stderr is a real regression.
+      const stderr = out.stderr.replace(/^WARNING: ASAN interferes with JSC signal handlers;.*\n?/m, "").trim();
+      expect(stderr).toBe("");
       expect(out.stdout.trim()).toBe(c.expected);
       expect(out.exitCode).toBe(0);
     });


### PR DESCRIPTION
## Problem

Bun uses `statx(2)` on Linux for `fs.stat`/`lstat`/`fstat` and falls back to `fstatat` when statx is unavailable. The fallback currently only triggers on `ENOSYS` and `EOPNOTSUPP`:

```zig
if (err.getErrno() == .NOSYS or err.getErrno() == .OPNOTSUPP) {
    supports_statx_on_linux.store(false, .monotonic);
    // fall through to fstatat
}
```

Seccomp filters that don't whitelist `statx` return **`EPERM`**, not `ENOSYS`. This happens with:
- libseccomp < 2.3.3
- Docker < 18.04 (default seccomp profile)
- Various CI sandboxes and minimal container runtimes

Under those, `fs.stat()` in Bun throws `EPERM` while Node.js succeeds (libuv falls back).

There's also a separate failure mode: some QEMU user-mode / S390 RHEL Docker setups make `statx` return a **positive value** with `errno == 0` — neither a normal success (0) nor a normal `-errno`.

## What libuv does

`deps/uv/src/unix/fs.c` (1518-1560) falls back on **four** errnos: `EINVAL`, `EPERM`, `ENOSYS`, `EOPNOTSUPP`, and treats `rc > 0` as "not implemented".

## Fix

In `src/sys.zig` `statxImpl`:

1. Widen the errno switch to include `.PERM` and `.INVAL` alongside `.NOSYS` and `.OPNOTSUPP`.
2. Detect the abnormal `rc > 0` case by bit-casting the raw `usize` return to `isize` and checking `> 0` — success is `0` and `-errno` values bit-cast to large usize, so only the positive-non-errno case matches.
3. Factor the stat/lstat/fstat fallback into a `statxFallback` helper.

## Verification

- Fail-before: `USE_SYSTEM_BUN=1 bun test test/js/node/fs/fs-stat-seccomp-linux.test.ts` → `fail (Received: "")` because the subprocess throws EPERM on `fs.statSync`.
- Pass-after: `bun bd test test/js/node/fs/fs-stat-seccomp-linux.test.ts` → pass; stat/lstat/fstat all fall back successfully.
- Existing Linux stat tests still pass (fs-birthtime-linux, fs-stats-truncate).

## Test

`test/js/node/fs/fs-stat-seccomp-linux.test.ts` compiles a small C helper at test time that installs a seccomp BPF filter returning `EPERM` for the `statx` syscall, then `execvp`s bun-debug to run a script that `statSync`/`lstatSync`/`fstatSync`s a file. The test skips if the environment doesn't permit seccomp filter installation (exit 77).

## Related

`copy_file_range` has a similar class of problem (doesn't fall back on EPERM for CIFS/SMB, EACCES for CephFS, etc.) — not addressed here since those paths are in different files and the CIFS/CephFS cases are niche.