### PR TITLE
http: support client upgrade event

### DIFF
--- a/src/js/internal/http/UpgradedSocket.ts
+++ b/src/js/internal/http/UpgradedSocket.ts
@@ -1,0 +1,256 @@
+const { Duplex } = require("internal/stream");
+
+const HIGH_WATER_MARK = 64 * 1024;
+
+class UpgradedSocket extends Duplex {
+  #reader;
+  #channel;
+  #abortController;
+  #reading = false;
+  #url;
+  #addressInfo;
+  #timeoutTimer;
+  bytesRead = 0;
+  bytesWritten = 0;
+  connecting = false;
+  timeout = 0;
+  encrypted = false;
+  authorized = false;
+
+  constructor(responseBody, channel, url, rejectUnauthorized = true, abortController?, encrypted = false) {
+    // allowHalfOpen:false matches net.Socket (Duplex defaults to true).
+    // Without this, server EOF ends only the readable side — _final() is
+    // never called, channel.end() never fires, and the body generator leaks.
+    super({
+      allowHalfOpen: false,
+      readableHighWaterMark: HIGH_WATER_MARK,
+      writableHighWaterMark: HIGH_WATER_MARK,
+    });
+    this.#channel = channel;
+    this.#abortController = abortController;
+    this.#url = url;
+    // `encrypted` is passed explicitly (derived from response.url by the
+    // caller) rather than from `url`, because url is undefined for Unix-socket
+    // upgrades — an https:// upgrade over a Unix socket is still encrypted.
+    this.encrypted = encrypted;
+    // A 101 over https:// with rejectUnauthorized=true (fetch's default)
+    // necessarily passed CA verification. When rejectUnauthorized is false,
+    // the TLS handshake may have accepted an unverified cert — authorized
+    // must stay false so consumers (like ws) don't treat the peer as trusted.
+    this.authorized = this.encrypted && rejectUnauthorized !== false;
+    if (responseBody) {
+      this.#reader = responseBody.getReader();
+    }
+  }
+
+  #refreshTimeout() {
+    if (this.timeout <= 0) return;
+    if (this.#timeoutTimer) clearTimeout(this.#timeoutTimer);
+    // Unref the idle timer to match net.Socket — an idle-timeout timer alone
+    // must never keep the process alive (only real I/O does).
+    this.#timeoutTimer = setTimeout(() => {
+      this.#timeoutTimer = undefined;
+      this.emit("timeout");
+    }, this.timeout).unref();
+  }
+
+  async #pump() {
+    const reader = this.#reader;
+    if (!reader) {
+      this.push(null);
+      return;
+    }
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          this.push(null);
+          return;
+        }
+        const buf = Buffer.from(value);
+        this.bytesRead += buf.length;
+        this.#refreshTimeout();
+        if (!this.push(buf)) {
+          return;
+        }
+      }
+    } catch (err) {
+      this.destroy(err);
+    }
+  }
+
+  _read(_size) {
+    if (this.#reading) return;
+    this.#reading = true;
+    this.#pump().finally(() => {
+      this.#reading = false;
+    });
+  }
+
+  _write(chunk, encoding, callback) {
+    let buffer = chunk;
+    if (!Buffer.isBuffer(buffer)) {
+      buffer = Buffer.from(buffer, encoding);
+    }
+    this.bytesWritten += buffer.length;
+    this.#refreshTimeout();
+    this.#channel.pushBuffered(buffer, callback);
+  }
+
+  _final(callback) {
+    this.#channel.end();
+    callback();
+  }
+
+  _destroy(err, callback) {
+    const reader = this.#reader;
+    this.#reader = undefined;
+    if (this.#timeoutTimer) {
+      clearTimeout(this.#timeoutTimer);
+      this.#timeoutTimer = undefined;
+    }
+    if (reader) {
+      try {
+        reader.cancel().catch(() => {});
+      } catch {}
+    }
+    // Forward the destroy error so queued socket.write callbacks see the
+    // failure instead of a silent success. Even without an explicit error
+    // (socket.destroy() with no argument), raise ERR_STREAM_DESTROYED so
+    // waiters aren't falsely signaled as successful.
+    this.#channel.end(err ?? $ERR_STREAM_DESTROYED("write"));
+    // Abort the underlying fetch so the TCP connection is actually torn down.
+    // Cancelling the response-body reader alone leaves the native request
+    // holding an event-loop ref, which keeps the process alive after the
+    // socket is destroyed (the behavior ws/playwright rely on at teardown).
+    const abortController = this.#abortController;
+    this.#abortController = undefined;
+    try {
+      abortController?.abort?.();
+    } catch {}
+    callback(err);
+  }
+
+  #parseAddress() {
+    if (this.#addressInfo) return this.#addressInfo;
+    const url = this.#url;
+    let address: string | undefined;
+    let port: number | undefined;
+    let family: "IPv4" | "IPv6" | undefined;
+    if (typeof url === "string") {
+      try {
+        const parsed = new URL(url);
+        let host = parsed.hostname;
+        if (host.startsWith("[") && host.endsWith("]")) {
+          host = host.slice(1, -1);
+          family = "IPv6";
+        } else if (host.includes(":")) {
+          family = "IPv6";
+        } else {
+          family = "IPv4";
+        }
+        address = host;
+        const portStr = parsed.port;
+        if (portStr) {
+          port = Number(portStr) | 0;
+        } else {
+          port = parsed.protocol === "https:" ? 443 : 80;
+        }
+      } catch {}
+    }
+    return (this.#addressInfo = { address, port, family });
+  }
+
+  address() {
+    // net.Socket.address() returns the LOCAL (bound) endpoint. We don't have
+    // a real bound address, so return an empty object — matches FakeSocket.
+    return {};
+  }
+
+  get remoteAddress() {
+    return this.#parseAddress().address;
+  }
+
+  get remoteFamily() {
+    return this.#parseAddress().family;
+  }
+
+  get remotePort() {
+    return this.#parseAddress().port;
+  }
+
+  get localAddress() {
+    return undefined;
+  }
+
+  get localFamily() {
+    return undefined;
+  }
+
+  get localPort() {
+    return undefined;
+  }
+
+  get bufferSize() {
+    return this.writableLength;
+  }
+
+  get pending() {
+    return this.connecting;
+  }
+
+  get readyState() {
+    if (this.connecting) return "opening";
+    if (this.readable) {
+      return this.writable ? "open" : "readOnly";
+    } else {
+      return this.writable ? "writeOnly" : "closed";
+    }
+  }
+
+  setNoDelay() {
+    return this;
+  }
+
+  setKeepAlive() {
+    return this;
+  }
+
+  setTimeout(timeout, callback) {
+    if (this.#timeoutTimer) {
+      clearTimeout(this.#timeoutTimer);
+      this.#timeoutTimer = undefined;
+    }
+    this.timeout = timeout;
+    if (timeout === 0) {
+      // Node semantics: setTimeout(0, cb) REMOVES the listener instead of adding.
+      if (callback) this.removeListener("timeout", callback);
+    } else {
+      if (callback) this.once("timeout", callback);
+      this.#timeoutTimer = setTimeout(() => {
+        this.#timeoutTimer = undefined;
+        this.emit("timeout");
+      }, timeout).unref();
+    }
+    return this;
+  }
+
+  ref() {
+    return this;
+  }
+
+  unref() {
+    return this;
+  }
+
+  resetAndDestroy() {
+    return this.destroy();
+  }
+}
+
+Object.defineProperty(UpgradedSocket, "name", { value: "Socket" });
+
+export default {
+  UpgradedSocket,
+  HIGH_WATER_MARK,
+};

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -77,6 +77,119 @@ function emitErrorEventNT(self, err) {
   }
 }
 
+const kEmptyBuffer = Buffer.alloc(0);
+let UpgradedSocket;
+const UPGRADE_HIGH_WATER_MARK = 64 * 1024;
+
+async function* upgradeBodyGenerator(channel) {
+  try {
+    while (true) {
+      while (channel.chunks.length > 0) {
+        const wasOverHighWaterMark = channel.queuedBytes >= channel.highWaterMark;
+        const chunk = channel.chunks.shift();
+        channel.queuedBytes -= chunk.length;
+        // Resolve any writers waiting for backpressure to clear.
+        while (channel.waiters.length > 0 && channel.queuedBytes < channel.highWaterMark) {
+          const cb = channel.waiters.shift();
+          try {
+            cb();
+          } catch {}
+        }
+        // Signal the ClientRequest to emit 'drain' once the queue has drained
+        // back below the high-water-mark, so a req.write() caller that paused
+        // on a false return gets a resume signal (matches OutgoingMessage).
+        if (wasOverHighWaterMark && channel.queuedBytes < channel.highWaterMark) {
+          channel.ondrain?.();
+        }
+        yield chunk;
+      }
+      if (channel.ended) {
+        return;
+      }
+      await new Promise(resolve => {
+        channel.resolve = resolve;
+      });
+    }
+  } finally {
+    // Always flush write callbacks — including when the generator is
+    // terminated via .return() (fetch abort/destroy at a yield point).
+    // If end() was called with an error, propagate it to each callback
+    // so callers that rely on the write-callback contract see the failure.
+    const endError = channel.endError;
+    while (channel.waiters.length > 0) {
+      const cb = channel.waiters.shift();
+      try {
+        cb(endError);
+      } catch {}
+    }
+  }
+}
+
+function createUpgradeChannel(initialChunks) {
+  // Own a private copy of the chunks so happy-eyeballs retries (which create
+  // a fresh channel per attempt) don't share state with a prior attempt.
+  const chunks = initialChunks ? initialChunks.slice() : [];
+  let queuedBytes = 0;
+  for (let i = 0; i < chunks.length; i++) queuedBytes += chunks[i].length;
+  return {
+    chunks,
+    queuedBytes,
+    highWaterMark: UPGRADE_HIGH_WATER_MARK,
+    waiters: [] as Array<(err?: Error | null) => void>,
+    ended: false,
+    endError: undefined as Error | undefined,
+    resolve: undefined as undefined | (() => void),
+    // Invoked when queuedBytes drains below highWaterMark so the owning
+    // ClientRequest can emit 'drain' for a paused req.write() caller.
+    ondrain: undefined as undefined | (() => void),
+    // Pre-upgrade body chunk from req.write(). Accounts bytes so that
+    // post-upgrade backpressure checks stay correct.
+    pushChunk(chunk): boolean {
+      if (this.ended) return false;
+      this.chunks.push(chunk);
+      this.queuedBytes += chunk.length;
+      this.notify();
+      return true;
+    },
+    // Post-upgrade writes from socket.write(): apply backpressure.
+    pushBuffered(buffer, callback) {
+      if (this.ended) {
+        callback(this.endError ?? $ERR_STREAM_WRITE_AFTER_END());
+        return;
+      }
+      this.chunks.push(buffer);
+      this.queuedBytes += buffer.length;
+      this.notify();
+      if (this.queuedBytes >= this.highWaterMark) {
+        this.waiters.push(callback);
+      } else {
+        callback();
+      }
+    },
+    notify() {
+      const resolve = this.resolve;
+      if (resolve) {
+        this.resolve = undefined;
+        resolve();
+      }
+    },
+    end(err?: Error) {
+      if (this.ended) return;
+      this.ended = true;
+      if (err) this.endError = err;
+      this.notify();
+      // Flush any waiters so socket.write callbacks don't hang. If we were
+      // ended with an error, forward it to each pending write callback.
+      while (this.waiters.length > 0) {
+        const cb = this.waiters.shift();
+        try {
+          cb(err);
+        } catch {}
+      }
+    },
+  };
+}
+
 function ClientRequest(input, options, cb) {
   if (!(this instanceof ClientRequest)) {
     return new (ClientRequest as any)(input, options, cb);
@@ -100,6 +213,12 @@ function ClientRequest(input, options, cb) {
 
   let writeCount = 0;
   let resolveNextChunk: ((end: boolean) => void) | undefined = _end => {};
+  // Current upgrade channel; replaced by startFetch() on happy-eyeballs retries.
+  let activeUpgradeChannel: any = undefined;
+  // Set when a pre-101 write_() returns false (fake-backpressure threshold
+  // crossed). Node only emits 'drain' after write() returned false, so the
+  // 101 handler uses this to decide whether a 'drain' is actually owed.
+  let preUpgradeBackpressure = false;
 
   // Node sends headers + first chunk immediately on the first write(). We
   // defer by a tick so that `write(chunk); end();` in the same tick still
@@ -113,14 +232,30 @@ function ClientRequest(input, options, cb) {
     }
   }
 
-  const pushChunk = chunk => {
-    this[kBodyChunks].push(chunk);
+  // Returns false when the chunk was rejected because the active upgrade
+  // channel has already been ended (e.g., socket.end() on the upgraded socket).
+  const pushChunk = (chunk): boolean => {
+    // After the upgrade is established we won't retry (happy-eyeballs is
+    // done), so skip kBodyChunks — otherwise post-upgrade req.write()
+    // chunks accumulate and saturate the fake-backpressure counter in
+    // write_() after ~1 MiB, permanently returning false.
+    if (!this[kUpgradeOrConnect]) {
+      this[kBodyChunks].push(chunk);
+    }
+    const hadChannel = activeUpgradeChannel !== undefined;
     if (writeCount > 1) {
       startFetch();
     } else if (writeCount === 1) {
       process.nextTick(startFetchAfterFirstWriteNT, this);
     }
+    let accepted = true;
+    // If startFetch just created the channel, it already captured this chunk
+    // via initialChunks.slice(). Only replay if the channel existed before.
+    if (hadChannel) {
+      accepted = activeUpgradeChannel.pushChunk(chunk);
+    }
     resolveNextChunk?.(false);
+    return accepted;
   };
 
   const write_ = (chunk, encoding, callback) => {
@@ -137,12 +272,29 @@ function ClientRequest(input, options, cb) {
     bodySize = chunk.length;
     writeCount++;
 
+    // After a 101 upgrade, kBodyChunks is kept empty and writes go straight to
+    // the upgrade channel, so the fake-backpressure sum below would never
+    // trip. Use the channel's real queue depth instead so a req.write() caller
+    // that loops until backpressure is signaled still gets a false return
+    // (and a later 'drain' via channel.ondrain). Checked before the
+    // !kBodyChunks branch so the FIRST post-upgrade write (e.g. after
+    // flushHeaders(), where kBodyChunks is still null) also honors backpressure.
+    if (this[kUpgradeOrConnect] && activeUpgradeChannel) {
+      if (!this[kBodyChunks]) this[kBodyChunks] = [];
+      const accepted = pushChunk(chunk);
+      if (!accepted) {
+        if (callback) callback($ERR_STREAM_WRITE_AFTER_END());
+        return false;
+      }
+      if (callback) callback();
+      return activeUpgradeChannel.queuedBytes < activeUpgradeChannel.highWaterMark;
+    }
+
     if (!this[kBodyChunks]) {
       this[kBodyChunks] = [];
-      pushChunk(chunk);
-
-      if (callback) callback();
-      return true;
+      const accepted = pushChunk(chunk);
+      if (callback) callback(accepted ? undefined : $ERR_STREAM_WRITE_AFTER_END());
+      return accepted;
     }
 
     // Signal fake backpressure if the body size is > 1024 * 1024
@@ -155,10 +307,20 @@ function ClientRequest(input, options, cb) {
         break;
       }
     }
-    pushChunk(chunk);
+    const accepted = pushChunk(chunk);
+    if (!accepted) {
+      if (callback) callback($ERR_STREAM_WRITE_AFTER_END());
+      return false;
+    }
 
     if (callback) callback();
-    return bodySize < MAX_FAKE_BACKPRESSURE_SIZE;
+    // Record that we signaled fake backpressure so the 101 handler only emits
+    // 'drain' if a prior write() actually returned false (Node semantics).
+    if (bodySize >= MAX_FAKE_BACKPRESSURE_SIZE) {
+      preUpgradeBackpressure = true;
+      return false;
+    }
+    return true;
   };
 
   const oldEnd = this.end;
@@ -245,6 +407,10 @@ function ClientRequest(input, options, cb) {
     this.destroyed = true;
 
     const res = this.res;
+    // For an upgraded socket (real Duplex), the 'close' event is driven by
+    // the stream's own destroy lifecycle. Calling socket.emit('close')
+    // directly here would fire 'close' twice on the Duplex.
+    const isUpgradedSocket = this[kUpgradeOrConnect] === true;
     if (res) {
       // Socket closed before we emitted 'end' below.
       if (!res.complete) {
@@ -254,16 +420,16 @@ function ClientRequest(input, options, cb) {
         this._closed = true;
         callCloseCallback(this);
         this.emit("close");
-        this.socket?.emit?.("close");
+        if (!isUpgradedSocket) this.socket?.emit?.("close");
       }
-      if (!res.aborted && res.readable) {
+      if (!res.aborted && res.readable && !res.complete) {
         res.push(null);
       }
     } else if (!this._closed) {
       this._closed = true;
       callCloseCallback(this);
       this.emit("close");
-      this.socket?.emit?.("close");
+      if (!isUpgradedSocket) this.socket?.emit?.("close");
     }
   };
 
@@ -345,17 +511,54 @@ function ClientRequest(input, options, cb) {
         keepalive,
       };
       let keepOpen = false;
+      const upgradeHeader = this.getHeader("upgrade");
+      const upgradeHeaderLower = typeof upgradeHeader === "string" ? upgradeHeader.toLowerCase() : "";
+      // HTTP upgrade tokens are case-insensitive (RFC 7230 §6.7). Exclude h2/h2c
+      // since HTTP/2 cleartext upgrade follows a different code path in fetch.
+      const isUpgrade = upgradeHeaderLower.length > 0 && upgradeHeaderLower !== "h2" && upgradeHeaderLower !== "h2c";
       // no body and not finished
-      const isDuplex = customBody === undefined && !this.finished;
+      const isDuplex = isUpgrade || (customBody === undefined && !this.finished);
 
-      if (isDuplex) {
+      let upgradeChannel;
+      if (isUpgrade) {
+        fetchOptions.duplex = "half";
+        // End any prior channel (happy-eyeballs retry) so its generator
+        // can finish instead of blocking forever on channel.resolve().
+        if (activeUpgradeChannel) {
+          activeUpgradeChannel.end();
+        }
+        upgradeChannel = createUpgradeChannel(this[kBodyChunks]);
+        activeUpgradeChannel = upgradeChannel;
+        // Emit 'drain' on the ClientRequest when post-upgrade req.write()
+        // backpressure clears, so a paused writer can resume. Only after the
+        // 101 does req.write() use the channel's 64 KiB high-water-mark
+        // (pre-101 it uses the 1 MiB fake-backpressure threshold), so gate on
+        // kUpgradeOrConnect to avoid a spurious 'drain' for a <1 MiB pre-101
+        // body. Defer via nextTick so a throwing 'drain' listener surfaces as
+        // an uncaught exception instead of propagating out of the body
+        // generator and erroring the fetch write stream (severing the socket).
+        upgradeChannel.ondrain = () => {
+          if (!this[kUpgradeOrConnect]) return;
+          process.nextTick(() => this.emit("drain"));
+        };
+        // pushChunk forwards to the active channel directly; keep
+        // resolveNextChunk as a no-op for the upgrade path (req.end doesn't
+        // close the channel — the upgraded socket reuses it).
+        resolveNextChunk = _end => {};
+        // Keep `fetching` set after the 101 resolves so post-upgrade
+        // req.write() calls don't re-enter startFetch() and issue a
+        // duplicate upgrade handshake.
+        keepOpen = true;
+      } else if (isDuplex) {
         fetchOptions.duplex = "half";
         keepOpen = true;
       }
 
       // Allow body for all methods when explicitly provided via req.write()/req.end()
       // This is needed for Node.js compatibility - Node allows GET requests with bodies
-      if (customBody !== undefined) {
+      if (isUpgrade) {
+        fetchOptions.body = upgradeBodyGenerator(upgradeChannel);
+      } else if (customBody !== undefined) {
         fetchOptions.body = customBody;
       } else if (
         isDuplex &&
@@ -416,8 +619,123 @@ function ClientRequest(input, options, cb) {
       //@ts-ignore
       this[kFetchRequest] = nodeHttpClient(url, fetchOptions).then(response => {
         if (this.aborted) {
+          if (isUpgrade) upgradeChannel.end();
           maybeEmitClose();
           return;
+        }
+
+        if (isUpgrade) {
+          if (response.status === 101) {
+            this[kClearTimeout]();
+            this[kUpgradeOrConnect] = true;
+            // Drain kBodyChunks — happy-eyeballs retries are impossible now
+            // and leaving the pre-upgrade chunks there would trip the
+            // fake-backpressure counter on subsequent req.write() calls.
+            if (this[kBodyChunks]) this[kBodyChunks].length = 0;
+            // Only owe a 'drain' if a pre-101 write() actually returned false
+            // (crossed the fake-backpressure threshold) — Node emits 'drain'
+            // solely after write() returned false, not for every buffered byte.
+            const shouldDrain = preUpgradeBackpressure;
+            const prevIsHTTPS = getIsNextIncomingMessageHTTPS();
+            setIsNextIncomingMessageHTTPS(response.url.startsWith("https:"));
+            const res = (this.res = new IncomingMessage(response, {
+              [typeSymbol]: NodeHTTPIncomingRequestType.FetchResponse,
+              [reqSymbol]: this,
+            }));
+            setIsNextIncomingMessageHTTPS(prevIsHTTPS);
+            res.req = this;
+
+            UpgradedSocket ??= require("internal/http/UpgradedSocket").UpgradedSocket;
+            // For Unix-socket upgrades, response.url is the HTTP URL (e.g.
+            // http://localhost/…) which isn't a real remote address — pass
+            // undefined so the socket doesn't fabricate remoteAddress/Port.
+            const socketURL = this[kSocketPath] ? undefined : response.url;
+            // Derive encrypted from response.url separately (not socketURL) so
+            // an https:// upgrade over a Unix socket still reports encrypted.
+            const encrypted = typeof response.url === "string" && response.url.startsWith("https:");
+            // rejectUnauthorized defaults to true; if the user set it to false,
+            // TLS verification may have been skipped, so authorized must be false.
+            const rejectUnauthorized = this[kTls]?.rejectUnauthorized !== false;
+            // Hand the socket the AbortController so socket.destroy() tears
+            // down the underlying fetch/TCP connection, not just the reader.
+            // Detach it from the request first: once the upgrade succeeds the
+            // socket owns teardown, and leaving the controller on the request
+            // would make a clean socket.destroy() flip the deprecated
+            // req.aborted getter to true (Node keeps it false). req.destroy()
+            // still tears down because it calls this.socket.destroy().
+            const upgradeAbortController = this[kAbortController];
+            if (upgradeAbortController) {
+              upgradeAbortController.signal.removeEventListener("abort", onAbort);
+              this[kAbortController] = null;
+            }
+            const socket = new UpgradedSocket(
+              response.body,
+              upgradeChannel,
+              socketURL,
+              rejectUnauthorized,
+              upgradeAbortController,
+              encrypted,
+            );
+
+            // Replace the pre-upgrade placeholder socket on both request and
+            // response so teardown paths (req.destroy, etc.) operate on the
+            // real upgraded connection.
+            this.socket = socket;
+            this.connection = socket;
+            res.socket = socket;
+
+            // The upgrade response body is consumed by the UpgradedSocket's
+            // reader; mark the IncomingMessage as complete so its own _read()
+            // path doesn't try to re-acquire the locked stream.
+            res.complete = true;
+            res.push(null);
+
+            if (this.listenerCount("upgrade") === 0) {
+              // Match Node: destroy the socket if no 'upgrade' listener attached.
+              // socket.destroy() now aborts the underlying fetch, which tears
+              // down the TCP connection.
+              socket.destroy();
+              maybeEmitClose();
+            } else {
+              // Emit outside the fetch promise chain so listener exceptions
+              // aren't converted into promise rejections that would trigger
+              // spurious happy-eyeballs retries. The 'drain' emit (if any) is
+              // deferred the same way for the same reason.
+              process.nextTick(() => {
+                // If the request was destroyed while waiting for this tick,
+                // 'close' already fired on the ClientRequest — don't then
+                // deliver 'upgrade' afterwards (violates Node event order).
+                if (this.destroyed) {
+                  socket.destroy();
+                  maybeEmitClose();
+                  return;
+                }
+                try {
+                  // Unblock callers that paused after write_() returned false
+                  // from the fake-backpressure threshold. Isolate this emit so
+                  // a throwing 'drain' listener can't short-circuit the
+                  // 'upgrade' delivery below (which hands the socket to the
+                  // consumer). Re-surface the throw as an uncaught exception so
+                  // the user's bug isn't silently swallowed.
+                  if (shouldDrain) {
+                    try {
+                      this.emit("drain");
+                    } catch (err) {
+                      process.nextTick(() => {
+                        throw err;
+                      });
+                    }
+                  }
+                  this.emit("upgrade", res, socket, kEmptyBuffer);
+                } finally {
+                  // ClientRequest emits 'close' after a successful upgrade.
+                  maybeEmitClose();
+                }
+              });
+            }
+            return;
+          }
+          upgradeChannel.end();
         }
 
         handleResponse = () => {
@@ -477,7 +795,9 @@ function ClientRequest(input, options, cb) {
 
         // Emit the response as soon as headers arrive, even when the request
         // body is still being streamed (duplex mode). Node.js emits 'response'
-        // independently of whether req.end() has been called.
+        // independently of whether req.end() has been called. For the upgrade
+        // path the 101 branch returns earlier; a non-101 response falls through
+        // here and is delivered unconditionally.
         handleResponse();
 
         onEnd();
@@ -488,6 +808,7 @@ function ClientRequest(input, options, cb) {
         // This is for the happy eyeballs implementation.
         this[kFetchRequest]
           .catch(err => {
+            if (isUpgrade) upgradeChannel.end();
             if (err.code === "ConnectionRefused") {
               err = new Error("ECONNREFUSED");
               err.code = "ECONNREFUSED";
@@ -752,11 +1073,15 @@ function ClientRequest(input, options, cb) {
 
   const signal = options.signal;
   if (signal) {
-    //We still want to control abort function and timeout so signal call our AbortController
+    // Tear down the request when the user's signal aborts. Destroy (not just
+    // kAbortController.abort()) so this still works after a 101 upgrade, where
+    // the controller is detached from the request — this.destroy() reaches the
+    // UpgradedSocket via this.socket.destroy(). Matches Node's addAbortSignal,
+    // which destroys the request with an AbortError carrying signal.reason.
     signal.addEventListener(
       "abort",
       () => {
-        this[kAbortController]?.abort();
+        this.destroy($makeAbortError(undefined, { cause: signal?.reason }));
       },
       { once: true },
     );

--- a/test/js/node/http/node-http-client-upgrade.test.ts
+++ b/test/js/node/http/node-http-client-upgrade.test.ts
@@ -1,0 +1,1113 @@
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir, tls as tlsCert } from "harness";
+import { once } from "node:events";
+import http from "node:http";
+import https from "node:https";
+import net, { type AddressInfo } from "node:net";
+import path from "node:path";
+import tls from "node:tls";
+
+// Several tests spawn a cold bun process (the upgrade-teardown / drain
+// fixtures) which is slow under CI ASAN. Raise the default timeout for the
+// whole file rather than per-test overrides (test/CLAUDE.md: no per-test
+// timeouts).
+setDefaultTimeout(30_000);
+
+async function listen(server: net.Server | http.Server, arg?: any): Promise<AddressInfo | string> {
+  const { promise, resolve, reject } = Promise.withResolvers<AddressInfo | string>();
+  server.once("error", reject);
+  if (arg !== undefined) {
+    server.listen(arg, () => resolve(server.address() as AddressInfo | string));
+  } else {
+    server.listen(0, "127.0.0.1", () => resolve(server.address() as AddressInfo));
+  }
+  return promise;
+}
+
+describe("http.ClientRequest 'upgrade' event", () => {
+  test("emits 'upgrade' with a usable Duplex socket", async () => {
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: websocket\r\n" + "Connection: Upgrade\r\n" + "\r\n",
+        );
+        conn.on("data", chunk => conn.write(chunk));
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        headers: { Connection: "Upgrade", Upgrade: "websocket" },
+      });
+      req.end();
+
+      const [res, socket, head] = await once(req, "upgrade");
+      expect(res.statusCode).toBe(101);
+      expect(res.headers.upgrade).toBe("websocket");
+      expect(res.headers.connection).toBe("Upgrade");
+      expect(Buffer.isBuffer(head)).toBe(true);
+      expect(head.length).toBe(0);
+
+      const echoed = once(socket, "data");
+      socket.write("hello upgrade");
+      const [chunk] = await echoed;
+      expect(chunk.toString()).toBe("hello upgrade");
+
+      const ended = once(socket, "end");
+      socket.end();
+      server.close();
+      await ended;
+    } finally {
+      server.close();
+    }
+  });
+
+  test.skipIf(isWindows)("upgrade over unix socket", async () => {
+    using dir = tempDir("http-upgrade-unix", {});
+    const sockPath = path.join(String(dir), "upgrade.sock");
+
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.write("HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: tcp\r\n" + "Connection: Upgrade\r\n" + "\r\n");
+        conn.on("data", chunk => conn.write(chunk));
+      });
+    });
+    await listen(server, sockPath);
+
+    try {
+      const req = http.request({
+        socketPath: sockPath,
+        headers: { Connection: "Upgrade", Upgrade: "tcp" },
+      });
+      req.end();
+
+      const [res, socket] = await once(req, "upgrade");
+      expect(res.statusCode).toBe(101);
+
+      const echoed = once(socket, "data");
+      socket.write("unix-hello");
+      const [chunk] = await echoed;
+      expect(chunk.toString()).toBe("unix-hello");
+
+      socket.end();
+    } finally {
+      server.close();
+    }
+  });
+
+  test.skipIf(isWindows)("https upgrade over unix socket reports encrypted", async () => {
+    using dir = tempDir("http-upgrade-unix-tls", {});
+    const sockPath = path.join(String(dir), "upgrade-tls.sock");
+
+    const server = tls.createServer({ cert: tlsCert.cert, key: tlsCert.key }, conn => {
+      conn.on("error", () => {});
+      conn.once("data", () => {
+        conn.write("HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: tcp\r\n" + "Connection: Upgrade\r\n" + "\r\n");
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(sockPath, resolve);
+    });
+
+    try {
+      const req = https.request({
+        socketPath: sockPath,
+        rejectUnauthorized: false,
+        headers: { Connection: "Upgrade", Upgrade: "tcp" },
+      });
+      req.on("error", () => {});
+      req.end();
+
+      const [, socket] = await once(req, "upgrade");
+      // TLS was used even though the address is a unix socket (socketURL is
+      // undefined) — encrypted must still be true, derived from response.url.
+      expect(socket.encrypted).toBe(true);
+      socket.destroy();
+    } finally {
+      server.close();
+    }
+  });
+
+  test("non-101 response to Upgrade request emits 'response'", async () => {
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.end(
+          "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Type: text/plain\r\nContent-Length: 13\r\n\r\nnot upgrading",
+        );
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        headers: { Connection: "Upgrade", Upgrade: "tcp" },
+      });
+      req.on("upgrade", () => {
+        throw new Error("should not emit upgrade");
+      });
+      req.end();
+
+      const [res] = await once(req, "response");
+      expect(res.statusCode).toBe(200);
+      let body = "";
+      for await (const chunk of res) body += chunk.toString();
+      expect(body).toBe("not upgrading");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("non-101 response via flushHeaders emits 'response'", async () => {
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.end(
+          "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Type: text/plain\r\nContent-Length: 3\r\n\r\nnah",
+        );
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        headers: { Connection: "Upgrade", Upgrade: "custom" },
+      });
+      // Use flushHeaders() instead of end() — this is the path that
+      // previously left onEnd as a no-op so handleResponse never fired.
+      req.flushHeaders();
+
+      const [res] = await once(req, "response");
+      expect(res.statusCode).toBe(400);
+      let body = "";
+      for await (const chunk of res) body += chunk.toString();
+      expect(body).toBe("nah");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("non-upgrade requests can reuse keep-alive connections", async () => {
+    let connections = 0;
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    server.on("connection", () => {
+      connections++;
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+    try {
+      for (let i = 0; i < 2; i++) {
+        const req = http.request({ host: "127.0.0.1", port: addr.port, agent });
+        req.end();
+        const [res] = await once(req, "response");
+        let body = "";
+        for await (const chunk of res) body += chunk.toString();
+        expect(body).toBe("ok");
+      }
+      expect(connections).toBe(1);
+    } finally {
+      agent.destroy();
+      server.close();
+    }
+  });
+
+  test("socket exposes address()/remoteAddress/remotePort and replaces req.socket/res.socket", async () => {
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: websocket\r\n" + "Connection: Upgrade\r\n" + "\r\n",
+        );
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        headers: { Connection: "Upgrade", Upgrade: "websocket" },
+      });
+      req.end();
+
+      const [res, socket] = await once(req, "upgrade");
+      // socket.address() must exist (returns local endpoint — empty here).
+      const info = socket.address();
+      expect(info).toBeDefined();
+      // remote* reflect the server we connected to.
+      expect(socket.remoteAddress).toBe("127.0.0.1");
+      expect(socket.remotePort).toBe(addr.port);
+      expect(socket.remoteFamily).toBe("IPv4");
+      // req.socket / res.socket now point at the upgraded socket
+      expect(req.socket).toBe(socket);
+      expect(res.socket).toBe(socket);
+
+      socket.destroy();
+    } finally {
+      server.close();
+    }
+  });
+
+  test("emits 'close' on the ClientRequest after upgrade", async () => {
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: websocket\r\n" + "Connection: Upgrade\r\n" + "\r\n",
+        );
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        headers: { Connection: "Upgrade", Upgrade: "websocket" },
+      });
+      req.end();
+
+      const closed = once(req, "close");
+      const [, socket] = await once(req, "upgrade");
+      await closed;
+      socket.destroy();
+    } finally {
+      server.close();
+    }
+  });
+
+  test("multiple req.write() calls before 101 are all delivered", async () => {
+    const { promise, resolve } = Promise.withResolvers<string>();
+    const server = net.createServer(conn => {
+      let buf = "";
+      let upgraded = false;
+      conn.on("data", chunk => {
+        buf += chunk.toString();
+        if (!upgraded && buf.includes("\r\n\r\n")) {
+          upgraded = true;
+          const headerEnd = buf.indexOf("\r\n\r\n") + 4;
+          const afterHeaders = buf.slice(headerEnd);
+          conn.write(
+            "HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: custom\r\n" + "Connection: Upgrade\r\n" + "\r\n",
+          );
+          // Read 9 bytes of body ("one"+"two"+"3!!")
+          let body = afterHeaders;
+          const check = () => {
+            if (body.length >= 9) resolve(body.slice(0, 9));
+          };
+          check();
+          conn.on("data", more => {
+            body += more.toString();
+            check();
+          });
+        }
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        method: "POST",
+        headers: { Connection: "Upgrade", Upgrade: "custom", "Content-Length": "9" },
+      });
+      req.write("one");
+      req.write("two");
+      // Third write after startFetch fires — previous bug dropped this silently.
+      req.write("3!!");
+      req.end();
+
+      const [, socket] = await once(req, "upgrade");
+      expect(await promise).toBe("onetwo3!!");
+      socket.destroy();
+    } finally {
+      server.close();
+    }
+  });
+
+  test("pre-101 write that does not return false emits no spurious 'drain'", async () => {
+    const serverRead = Promise.withResolvers<void>();
+    const server = net.createServer(conn => {
+      let buf = Buffer.alloc(0);
+      let sent101 = false;
+      let bodyBytes = 0;
+      conn.on("error", () => {});
+      conn.on("data", chunk => {
+        buf = Buffer.concat([buf, chunk]);
+        if (!sent101) {
+          const i = buf.indexOf("\r\n\r\n");
+          if (i === -1) return;
+          sent101 = true;
+          // headers may arrive in their own 'data' event, so body bytes here
+          // can legitimately be 0 — use a boolean sentinel, not the count.
+          bodyBytes = buf.length - (i + 4);
+          conn.write(
+            "HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: custom\r\n" + "Connection: Upgrade\r\n" + "\r\n",
+          );
+          if (bodyBytes >= 70 * 1024) serverRead.resolve();
+          return;
+        }
+        // Drain the pre-101 body so the generator empties the channel.
+        bodyBytes += chunk.length;
+        if (bodyBytes >= 70 * 1024) serverRead.resolve();
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        method: "POST",
+        headers: { Connection: "Upgrade", Upgrade: "custom" },
+      });
+      // Write 70 KiB before the 101: it crosses the channel's 64 KiB
+      // high-water-mark (so the body generator's drain hook fires) but stays
+      // under the 1 MiB fake-backpressure threshold, so write() returns true.
+      // Node emits 'drain' only after write() returned false, so none is owed —
+      // the generator-driven drain must be suppressed until after the upgrade.
+      let drained = false;
+      req.on("drain", () => {
+        drained = true;
+      });
+      expect(req.write(Buffer.alloc(70 * 1024, 0x61))).toBe(true);
+      req.end();
+
+      const [, socket] = await once(req, "upgrade");
+      // Wait until the server has received the full body (generator drained,
+      // so any spurious ondrain would have fired) plus a tick.
+      await serverRead.promise;
+      await new Promise<void>(resolve => process.nextTick(resolve));
+      expect(drained).toBe(false);
+      socket.destroy();
+    } finally {
+      server.close();
+    }
+  });
+
+  test("socket.setTimeout fires a real timer", async () => {
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: websocket\r\n" + "Connection: Upgrade\r\n" + "\r\n",
+        );
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        headers: { Connection: "Upgrade", Upgrade: "websocket" },
+      });
+      req.end();
+      const [, socket] = await once(req, "upgrade");
+
+      const timedOut = once(socket, "timeout");
+      socket.setTimeout(50);
+      expect(socket.timeout).toBe(50);
+      await timedOut;
+      socket.destroy();
+    } finally {
+      server.close();
+    }
+  });
+
+  test("unhandled 101 upgrade destroys the socket", async () => {
+    const { promise: serverConnClosed, resolve: resolveServerClosed } = Promise.withResolvers<void>();
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: websocket\r\n" + "Connection: Upgrade\r\n" + "\r\n",
+        );
+      });
+      conn.once("close", () => resolveServerClosed());
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        headers: { Connection: "Upgrade", Upgrade: "websocket" },
+      });
+      req.end();
+      // No 'upgrade' listener — client socket must be destroyed, which tears
+      // down the TCP connection on the server side.
+      await serverConnClosed;
+    } finally {
+      server.close();
+    }
+  });
+
+  test("req.write() after upgrade does not open a second connection", async () => {
+    let connectionCount = 0;
+    const { promise: gotBytes, resolve: resolveGotBytes } = Promise.withResolvers<void>();
+    const server = net.createServer(conn => {
+      connectionCount++;
+      let buf = "";
+      let upgraded = false;
+      conn.on("data", chunk => {
+        buf += chunk.toString();
+        if (!upgraded && buf.includes("\r\n\r\n")) {
+          upgraded = true;
+          const after = buf.slice(buf.indexOf("\r\n\r\n") + 4);
+          conn.write(
+            "HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: custom\r\n" + "Connection: Upgrade\r\n" + "\r\n",
+          );
+          let body = after;
+          const check = () => {
+            if (body.length >= 3) resolveGotBytes();
+          };
+          check();
+          conn.on("data", more => {
+            body += more.toString();
+            check();
+          });
+        }
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        method: "POST",
+        headers: { Connection: "Upgrade", Upgrade: "custom" },
+      });
+      req.flushHeaders();
+      const [, socket] = await once(req, "upgrade");
+      // After 101, req.write() must not re-enter startFetch() and open a
+      // second TCP connection with a duplicate upgrade handshake.
+      req.write("x");
+      req.write("y");
+      req.write("z");
+      // Await the server actually receiving the bytes instead of sleeping.
+      await gotBytes;
+      expect(connectionCount).toBe(1);
+      socket.destroy();
+    } finally {
+      server.close();
+    }
+  });
+
+  test("req.write() after upgrade doesn't permanently saturate backpressure", async () => {
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.write("HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: custom\r\n" + "Connection: Upgrade\r\n" + "\r\n");
+        conn.on("data", () => {}); // drain
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        method: "POST",
+        headers: { Connection: "Upgrade", Upgrade: "custom" },
+      });
+      req.flushHeaders();
+      const [, socket] = await once(req, "upgrade");
+      // Write >1 MiB post-upgrade. The previous bug left the fake-backpressure
+      // counter stuck at 1 MiB so every subsequent req.write() permanently
+      // returned false with no drain. With the server draining, backpressure
+      // must instead be relievable: after the burst, a write eventually
+      // succeeds again (proving the channel drains and isn't saturated).
+      const chunk = Buffer.alloc(4096, 0x61);
+      for (let i = 0; i < 300; i++) {
+        req.write(chunk);
+      }
+      // Wait until a write returns true again — if backpressure were stuck,
+      // this would loop forever and the test would time out.
+      while (!req.write(chunk)) {
+        await once(req, "drain");
+      }
+      socket.destroy();
+    } finally {
+      server.close();
+    }
+  });
+
+  test("req.write() after upgrade applies backpressure and emits 'drain'", async () => {
+    const serverConn = Promise.withResolvers<net.Socket>();
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.write("HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: custom\r\n" + "Connection: Upgrade\r\n" + "\r\n");
+        // Do NOT read the upgraded body yet — let the client's write queue
+        // fill so req.write() reports backpressure. pause() so the kernel
+        // socket buffer backs up into the fetch body generator.
+        conn.pause();
+        serverConn.resolve(conn);
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        method: "POST",
+        headers: { Connection: "Upgrade", Upgrade: "custom" },
+      });
+      req.flushHeaders();
+      const [, socket] = await once(req, "upgrade");
+      const conn = await serverConn.promise;
+
+      // Write until req.write() signals backpressure (returns false). With the
+      // server not reading, the channel's queued bytes cross the 64 KiB
+      // high-water-mark and write() must return false instead of always-true.
+      const chunk = Buffer.alloc(16 * 1024, 0x61);
+      let sawBackpressure = false;
+      for (let i = 0; i < 256 && !sawBackpressure; i++) {
+        if (!req.write(chunk)) sawBackpressure = true;
+      }
+      expect(sawBackpressure).toBe(true);
+
+      // Now let the server drain the body; the channel empties below the
+      // high-water-mark and the ClientRequest must emit 'drain'.
+      const drained = once(req, "drain");
+      conn.on("data", () => {});
+      conn.resume();
+      await drained;
+
+      socket.destroy();
+    } finally {
+      server.close();
+    }
+  });
+
+  test("first post-upgrade req.write() over the high-water-mark returns false", async () => {
+    const serverConn = Promise.withResolvers<net.Socket>();
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.write("HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: custom\r\n" + "Connection: Upgrade\r\n" + "\r\n");
+        conn.pause(); // don't read the body — keep the channel full
+        serverConn.resolve(conn);
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      // flushHeaders() (no pre-101 body) leaves kBodyChunks uninitialized, so
+      // the very first post-upgrade write hits the first-write branch. A single
+      // write larger than the 64 KiB high-water-mark must still return false —
+      // backpressure has to engage on write #1, not only on write #2.
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        method: "POST",
+        headers: { Connection: "Upgrade", Upgrade: "custom" },
+      });
+      req.flushHeaders();
+      const [, socket] = await once(req, "upgrade");
+      const conn = await serverConn.promise;
+
+      const first = req.write(Buffer.alloc(200 * 1024, 0x61));
+      expect(first).toBe(false);
+
+      conn.on("data", () => {});
+      conn.resume();
+      socket.destroy();
+    } finally {
+      server.close();
+    }
+  });
+
+  test("server-initiated half-close auto-ends the writable side", async () => {
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: websocket\r\n" + "Connection: Upgrade\r\n" + "\r\n",
+        );
+        // Immediately half-close the write side from the server.
+        conn.end();
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        headers: { Connection: "Upgrade", Upgrade: "websocket" },
+      });
+      req.end();
+      const [, socket] = await once(req, "upgrade");
+      // Drain the readable side so the 'end' event fires on EOF.
+      socket.resume();
+      // Server EOF must propagate to close the writable side too
+      // (allowHalfOpen: false on the Duplex).
+      await once(socket, "close");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("pending socket.write callback receives destroy error", async () => {
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.write("HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: custom\r\n" + "Connection: Upgrade\r\n" + "\r\n");
+        // Don't drain — keep the channel backpressured.
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        method: "POST",
+        headers: { Connection: "Upgrade", Upgrade: "custom" },
+      });
+      req.flushHeaders();
+      const [, socket] = await once(req, "upgrade");
+      socket.on("error", () => {});
+
+      const big = Buffer.alloc(96 * 1024, 0x61);
+      const { promise, resolve } = Promise.withResolvers<Error | undefined>();
+      socket.write(big); // pushes past 64KiB highWaterMark
+      socket.write(big, err => resolve(err as Error | undefined));
+
+      socket.destroy(new Error("boom"));
+      const cbErr = await promise;
+      expect(cbErr?.message).toBe("boom");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("aborting options.signal after upgrade delivers AbortError with reason", async () => {
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.write("HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: custom\r\n" + "Connection: Upgrade\r\n" + "\r\n");
+        // Don't drain — keep the channel backpressured so the write callback
+        // is still pending when we abort.
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const ac = new AbortController();
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        method: "POST",
+        signal: ac.signal,
+        headers: { Connection: "Upgrade", Upgrade: "custom" },
+      });
+      req.on("error", () => {});
+      req.flushHeaders();
+      const [, socket] = await once(req, "upgrade");
+      socket.on("error", () => {});
+
+      const big = Buffer.alloc(96 * 1024, 0x61);
+      const { promise, resolve } = Promise.withResolvers<Error | undefined>();
+      socket.write(big); // past the 64 KiB high-water-mark — callback pends
+      socket.write(big, err => resolve(err as Error | undefined));
+
+      // Aborting the user's signal must destroy with an AbortError carrying
+      // the reason (Node's addAbortSignal), not a generic ERR_STREAM_DESTROYED.
+      const reason = new Error("user reason");
+      ac.abort(reason);
+      const cbErr = await promise;
+      expect((cbErr as any)?.code).toBe("ABORT_ERR");
+      expect((cbErr as any)?.cause).toBe(reason);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("req.write() after socket.end() reports write-after-end error", async () => {
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.write("HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: custom\r\n" + "Connection: Upgrade\r\n" + "\r\n");
+        conn.on("data", () => {});
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        method: "POST",
+        headers: { Connection: "Upgrade", Upgrade: "custom" },
+      });
+      req.flushHeaders();
+      const [, socket] = await once(req, "upgrade");
+      socket.on("error", () => {});
+      // End the upgraded socket's writable side, then write more data via
+      // req.write(). It must fail with ERR_STREAM_WRITE_AFTER_END instead
+      // of silently dropping the data.
+      socket.end();
+      const { promise, resolve } = Promise.withResolvers<Error | undefined>();
+      const ok = req.write("late", err => resolve(err as Error | undefined));
+      expect(ok).toBe(false);
+      const err = await promise;
+      expect(err).toBeDefined();
+      expect((err as any)?.code).toBe("ERR_STREAM_WRITE_AFTER_END");
+      socket.destroy();
+    } finally {
+      server.close();
+    }
+  });
+
+  test("res._dump() after upgrade does not throw ReadableStream locked", async () => {
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: websocket\r\n" + "Connection: Upgrade\r\n" + "\r\n",
+        );
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        headers: { Connection: "Upgrade", Upgrade: "websocket" },
+      });
+      req.end();
+
+      const [res, socket] = await once(req, "upgrade");
+      // IncomingMessage body and UpgradedSocket share response.body; the
+      // _read code path must not attempt to re-acquire the locked stream.
+      // Calling _dump() forces resume() -> _read() on the IncomingMessage.
+      expect(res.complete).toBe(true);
+      res._dump();
+      socket.destroy();
+    } finally {
+      server.close();
+    }
+  });
+
+  test("clean socket.destroy() after upgrade leaves req.aborted false", async () => {
+    const server = net.createServer(conn => {
+      conn.once("data", () => {
+        conn.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" + "Upgrade: websocket\r\n" + "Connection: Upgrade\r\n" + "\r\n",
+        );
+      });
+    });
+    const addr = (await listen(server)) as AddressInfo;
+
+    try {
+      const req = http.request({
+        host: "127.0.0.1",
+        port: addr.port,
+        headers: { Connection: "Upgrade", Upgrade: "websocket" },
+      });
+      req.end();
+
+      const [, socket] = await once(req, "upgrade");
+      // Destroying the upgraded socket tears down the underlying fetch, but a
+      // clean destroy (no error) must not flip req.aborted — Node leaves it
+      // false after a successful upgrade. Wait for 'close' so _destroy (and
+      // the abort it performs) has fully run before reading req.aborted.
+      const closed = once(socket, "close");
+      socket.destroy();
+      await closed;
+      expect(req.aborted).toBe(false);
+    } finally {
+      server.close();
+    }
+  });
+
+  // socket.destroy() must tear down the underlying fetch/TCP connection, not
+  // just cancel the response-body reader — otherwise the native request keeps
+  // an event-loop ref and the process never exits. This is what ws/playwright
+  // hit at teardown. Spawn a child that upgrades, destroys the socket, closes
+  // the server, and does nothing else: it must exit on its own.
+  test("socket.destroy() after upgrade lets the process exit", async () => {
+    using dir = tempDir("http-upgrade-exit", {
+      "fixture.mjs": `
+        import http from "node:http";
+        import net from "node:net";
+
+        const server = net.createServer(conn => {
+          let buf = Buffer.alloc(0);
+          let upgraded = false;
+          // socket.destroy() RSTs the peer; swallow the expected post-teardown error.
+          conn.on("error", () => {});
+          conn.on("data", chunk => {
+            if (upgraded) return;
+            buf = Buffer.concat([buf, chunk]);
+            if (buf.indexOf("\\r\\n\\r\\n") === -1) return;
+            upgraded = true;
+            conn.write("HTTP/1.1 101 Switching Protocols\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\n\\r\\n");
+          });
+        }).listen(0, "127.0.0.1");
+        await new Promise(r => server.on("listening", r));
+
+        const req = http.request({
+          host: "127.0.0.1",
+          port: server.address().port,
+          headers: { Connection: "Upgrade", Upgrade: "websocket" },
+        });
+        req.on("upgrade", (res, socket) => {
+          console.log("upgraded");
+          socket.destroy();
+          server.close();
+          // Intentionally nothing else. If the upgrade's fetch isn't aborted,
+          // the event loop stays ref'd here and the process hangs forever.
+        });
+        req.end();
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("upgraded\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // Aborting the options.signal after a 101 must tear down the upgraded
+  // connection (req.destroy() → socket.destroy()), even though the
+  // AbortController is detached from the request post-upgrade. Otherwise the
+  // fetch keeps an event-loop ref and the process hangs. Spawn a child that
+  // upgrades, aborts the signal, and does nothing else: it must exit on its own.
+  test("aborting options.signal after upgrade lets the process exit", async () => {
+    using dir = tempDir("http-upgrade-signal-abort", {
+      "fixture.mjs": `
+        import http from "node:http";
+        import net from "node:net";
+
+        const server = net.createServer(conn => {
+          let buf = Buffer.alloc(0);
+          let upgraded = false;
+          conn.on("error", () => {});
+          conn.on("data", chunk => {
+            if (upgraded) return;
+            buf = Buffer.concat([buf, chunk]);
+            if (buf.indexOf("\\r\\n\\r\\n") === -1) return;
+            upgraded = true;
+            conn.write("HTTP/1.1 101 Switching Protocols\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\n\\r\\n");
+          });
+        }).listen(0, "127.0.0.1");
+        await new Promise(r => server.on("listening", r));
+
+        const ac = new AbortController();
+        const req = http.request({
+          host: "127.0.0.1",
+          port: server.address().port,
+          signal: ac.signal,
+          headers: { Connection: "Upgrade", Upgrade: "websocket" },
+        });
+        req.on("error", () => {});
+        req.on("upgrade", (res, socket) => {
+          console.log("upgraded");
+          socket.on("error", () => {});
+          // Tear down ONLY via the user's signal — not socket.destroy(). If the
+          // signal bridge is broken post-upgrade, the fetch ref keeps the loop
+          // alive and this hangs.
+          ac.abort();
+          server.close();
+        });
+        req.end();
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    if (exitCode !== 0 || stdout !== "upgraded\n") console.error(stderr);
+    expect(stdout).toBe("upgraded\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // A throwing 'drain' listener must not sever the upgraded connection. The
+  // emit is deferred via nextTick so the throw surfaces as an uncaught
+  // exception rather than propagating out of the fetch body generator and
+  // erroring the write side. Spawn a child so the uncaught exception doesn't
+  // fail the test runner; assert the socket still round-trips afterward.
+  test("throwing 'drain' listener does not break the upgraded write side", async () => {
+    using dir = tempDir("http-upgrade-drain-throw", {
+      "fixture.mjs": `
+        import http from "node:http";
+        import net from "node:net";
+
+        const server = net.createServer(conn => {
+          let upgraded = false;
+          let head = Buffer.alloc(0);
+          let body = Buffer.alloc(0);
+          // socket.destroy() RSTs the peer; swallow the expected post-teardown error.
+          conn.on("error", () => {});
+          conn.on("data", chunk => {
+            if (!upgraded) {
+              head = Buffer.concat([head, chunk]);
+              if (head.indexOf("\\r\\n\\r\\n") === -1) return;
+              upgraded = true;
+              conn.write("HTTP/1.1 101 Switching Protocols\\r\\nUpgrade: custom\\r\\nConnection: Upgrade\\r\\n\\r\\n");
+              // Pause so the client's writes back up and trigger backpressure.
+              conn.pause();
+              return;
+            }
+            // Accumulate post-upgrade bytes and echo the PING sentinel only
+            // once it arrives — the filler bytes before it are discarded, so
+            // the test doesn't depend on TCP chunk boundaries.
+            body = Buffer.concat([body, chunk]);
+            if (body.includes("PING")) conn.write("PONG");
+          });
+          server.emit("conn", conn);
+        }).listen(0, "127.0.0.1");
+        await new Promise(r => server.on("listening", r));
+        const connPromise = new Promise(r => server.once("conn", r));
+
+        let resolveUncaught;
+        const uncaughtPromise = new Promise(r => { resolveUncaught = r; });
+        process.on("uncaughtException", err => {
+          if (err && err.message === "drain-oops") { resolveUncaught(); return; }
+          console.error("unexpected: " + (err && err.message));
+          process.exit(3);
+        });
+
+        const req = http.request({
+          method: "POST",
+          host: "127.0.0.1",
+          port: server.address().port,
+          headers: { Connection: "Upgrade", Upgrade: "custom" },
+        });
+        req.on("upgrade", async (res, socket) => {
+          const conn = await connPromise;
+          // Throwing drain listener — must not corrupt the write stream.
+          req.on("drain", () => { throw new Error("drain-oops"); });
+
+          const chunk = Buffer.alloc(16 * 1024, 0x61);
+          while (req.write(chunk)) {}      // write until backpressure engages
+          conn.resume();                    // now let the server drain
+          // Wait for the throwing listener to fire as an uncaught exception.
+          await uncaughtPromise;
+
+          // The connection must still be alive: a PING written to the socket
+          // reaches the server (after the filler drains) and PONG comes back.
+          const echoed = new Promise(r => {
+            let reply = Buffer.alloc(0);
+            socket.on("data", d => {
+              reply = Buffer.concat([reply, d]);
+              if (reply.includes("PONG")) r();
+            });
+          });
+          socket.write("PING");
+          await echoed;
+          console.log("survived");
+          socket.destroy();
+          server.close();
+        });
+        req.end();
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    if (exitCode !== 0 || !stdout.includes("survived")) console.error(stderr);
+    expect(stdout.trim()).toBe("survived");
+    expect(exitCode).toBe(0);
+  });
+
+  // When pre-101 req.write() tripped fake-backpressure, the 101 branch emits
+  // 'drain' right before 'upgrade' in the same tick. A throwing 'drain'
+  // listener must NOT prevent 'upgrade' from firing — otherwise the socket is
+  // orphaned and never delivered. Spawn a child (uncaught exception expected)
+  // and assert 'upgrade' still fired.
+  test("throwing pre-101 'drain' listener still delivers 'upgrade'", async () => {
+    using dir = tempDir("http-upgrade-drain-upgrade", {
+      "fixture.mjs": `
+        import http from "node:http";
+        import net from "node:net";
+
+        const server = net.createServer(conn => {
+          let buf = Buffer.alloc(0);
+          let upgraded = false;
+          // socket.destroy() aborts the fetch mid-stream, so the peer may RST
+          // while the 1.2 MiB body is still in flight — swallow the expected
+          // EPIPE/ECONNRESET instead of letting it become an uncaughtException.
+          conn.on("error", () => {});
+          conn.on("data", chunk => {
+            if (upgraded) return;
+            buf = Buffer.concat([buf, chunk]);
+            if (buf.indexOf("\\r\\n\\r\\n") === -1) return;
+            upgraded = true;
+            conn.write("HTTP/1.1 101 Switching Protocols\\r\\nUpgrade: custom\\r\\nConnection: Upgrade\\r\\n\\r\\n");
+          });
+        }).listen(0, "127.0.0.1");
+        await new Promise(r => server.on("listening", r));
+
+        process.on("uncaughtException", err => {
+          if (err && err.message === "drain-oops") return; // expected
+          console.error("unexpected: " + (err && err.message));
+          process.exit(3);
+        });
+
+        const req = http.request({
+          method: "POST",
+          host: "127.0.0.1",
+          port: server.address().port,
+          headers: { Connection: "Upgrade", Upgrade: "custom" },
+        });
+        // Write >1 MiB before the 101 so the fake-backpressure counter trips
+        // and the 101 branch will emit 'drain' before 'upgrade'.
+        req.write(Buffer.alloc(600 * 1024, 0x61));
+        req.write(Buffer.alloc(600 * 1024, 0x62));
+        req.on("drain", () => { throw new Error("drain-oops"); });
+        req.on("upgrade", (res, socket) => {
+          // Reaching here proves the throwing 'drain' listener did not
+          // short-circuit the 'upgrade' emit.
+          console.log("upgraded");
+          socket.destroy();
+          server.close();
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    if (exitCode !== 0 || !stdout.includes("upgraded")) console.error(stderr);
+    expect(stdout.trim()).toBe("upgraded");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/regression/issue/09911/connectOverCDP.test.ts
+++ b/test/regression/issue/09911/connectOverCDP.test.ts
@@ -1,0 +1,143 @@
+// https://github.com/oven-sh/bun/issues/9911
+//
+// Playwright's connectOverCDP() bundles the real `ws` package, which performs
+// its handshake via http.request() + req.on("upgrade"). This is an end-to-end
+// check against a real Chrome with --remote-debugging-port.
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { accessSync, constants as fsConstants } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// `bun install` of playwright-core and Chrome startup can exceed the 5s
+// default timeout on slow CI workers.
+setDefaultTimeout(60_000);
+
+function findChrome(): string | undefined {
+  const ok = (p: string) => {
+    try {
+      accessSync(p, fsConstants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  if (process.env.BUN_CHROME_PATH) return ok(process.env.BUN_CHROME_PATH) ? process.env.BUN_CHROME_PATH : undefined;
+  for (const n of ["google-chrome-stable", "google-chrome", "chromium-browser", "chromium", "chrome"]) {
+    const found = Bun.which(n);
+    if (found) return found;
+  }
+  if (process.platform === "darwin") {
+    for (const b of ["Google Chrome.app/Contents/MacOS/Google Chrome", "Chromium.app/Contents/MacOS/Chromium"]) {
+      for (const root of ["/Applications", join(homedir(), "Applications")]) {
+        const p = join(root, b);
+        if (ok(p)) return p;
+      }
+    }
+  } else if (process.platform === "linux") {
+    for (const p of ["/usr/bin/google-chrome-stable", "/usr/bin/google-chrome", "/usr/bin/chromium"]) {
+      if (ok(p)) return p;
+    }
+  }
+  return undefined;
+}
+
+const chromePath = findChrome();
+
+describe.todoIf(!chromePath || isWindows)("playwright connectOverCDP via Chrome", () => {
+  async function setup() {
+    const dir = tempDir("issue-09911-cdp", {
+      "package.json": JSON.stringify({ dependencies: { "playwright-core": "1.58.2" } }),
+      "connect.mjs": `
+        const { chromium } = require("playwright-core");
+        const browser = await chromium.connectOverCDP(process.argv[2], { timeout: 15000 });
+        const context = browser.contexts()[0] ?? (await browser.newContext());
+        const page = await context.newPage();
+        await page.goto("data:text/html,<title>cdp-ok</title>");
+        console.log("TITLE", await page.title());
+        await browser.close();
+      `,
+    });
+    let userDataDir: ReturnType<typeof tempDir> | undefined;
+    let chrome: ReturnType<typeof Bun.spawn> | undefined;
+    try {
+      const install = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "ignore",
+        // ignore instead of pipe so large install output can't deadlock on a
+        // full pipe buffer while we await exited.
+        stderr: "ignore",
+      });
+      expect(await install.exited).toBe(0);
+
+      userDataDir = tempDir("issue-09911-chrome-profile", {});
+      chrome = Bun.spawn({
+        cmd: [
+          chromePath!,
+          "--headless=new",
+          "--remote-debugging-port=0",
+          "--no-first-run",
+          "--no-default-browser-check",
+          "--user-data-dir=" + String(userDataDir),
+        ],
+        env: bunEnv,
+        stdout: "ignore",
+        stderr: "pipe",
+      });
+
+      let wsEndpoint = "";
+      // Accumulate stderr — the "DevTools listening on ws://…" line may
+      // straddle a pipe-read boundary, so matching each chunk in isolation
+      // could miss it and hang until the timeout.
+      let stderrBuf = "";
+      for await (const chunk of chrome.stderr) {
+        stderrBuf += Buffer.from(chunk).toString();
+        const m = stderrBuf.match(/DevTools listening on (ws:\/\/[\w.:/-]+)/);
+        if (m) {
+          wsEndpoint = m[1];
+          break;
+        }
+      }
+      expect(wsEndpoint).not.toBe("");
+
+      const capturedUserDataDir = userDataDir;
+      const capturedChrome = chrome;
+      return {
+        dir,
+        chrome,
+        wsEndpoint,
+        [Symbol.dispose]() {
+          capturedChrome.kill();
+          dir[Symbol.dispose]();
+          capturedUserDataDir[Symbol.dispose]();
+        },
+      };
+    } catch (err) {
+      chrome?.kill();
+      userDataDir?.[Symbol.dispose]();
+      dir[Symbol.dispose]();
+      throw err;
+    }
+  }
+
+  async function connect(dir: ReturnType<typeof tempDir>, endpoint: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "connect.mjs", endpoint],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) console.error(stderr);
+    expect(stdout.trim()).toBe("TITLE cdp-ok");
+    expect(exitCode).toBe(0);
+  }
+
+  test("connects with ws:// endpoint", async () => {
+    using ctx = await setup();
+    await connect(ctx.dir, ctx.wsEndpoint);
+  });
+});

--- a/test/regression/issue/09911/real-ws.test.ts
+++ b/test/regression/issue/09911/real-ws.test.ts
@@ -1,0 +1,83 @@
+// https://github.com/oven-sh/bun/issues/9911
+//
+// Playwright bundles the real `ws` npm package. The real package performs its
+// handshake with `http.request({ Upgrade: "websocket" })` and waits for
+// `req.on("upgrade")`, which Bun did not emit. Bun normally intercepts the
+// bare "ws" specifier with a native shim, so this test installs the real
+// package locally and loads it by path to exercise the node:http upgrade path
+// the way Playwright does.
+import { expect, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// `bun install` of the real ws package can exceed the default 5s timeout on
+// slow CI workers.
+setDefaultTimeout(60_000);
+
+test("real ws package (via node:http upgrade) connects and round-trips", async () => {
+  using dir = tempDir("issue-09911-ws", {
+    "package.json": JSON.stringify({ dependencies: { ws: "8.18.3" } }),
+    "client.mjs": `
+      import { createRequire } from "node:module";
+      import net from "node:net";
+      import crypto from "node:crypto";
+      const require = createRequire(import.meta.url);
+      const RealWS = require("./node_modules/ws/index.js");
+      if (RealWS === require("ws")) {
+        console.error("loaded Bun shim instead of real ws");
+        process.exit(2);
+      }
+
+      const server = net.createServer(conn => {
+        let upgraded = false;
+        let buf = Buffer.alloc(0);
+        conn.on("data", chunk => {
+          if (!upgraded) {
+            buf = Buffer.concat([buf, chunk]);
+            const i = buf.indexOf("\\r\\n\\r\\n");
+            if (i === -1) return;
+            upgraded = true;
+            const key = /Sec-WebSocket-Key: (.+)\\r\\n/i.exec(buf.toString())[1];
+            const accept = crypto.createHash("sha1").update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").digest("base64");
+            conn.write("HTTP/1.1 101 Switching Protocols\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\nSec-WebSocket-Accept: " + accept + "\\r\\n\\r\\n");
+            return;
+          }
+          conn.write(Buffer.from([0x81, 0x04, 0x70, 0x6f, 0x6e, 0x67]));
+        });
+      }).listen(0, "127.0.0.1");
+      await new Promise(r => server.on("listening", r));
+
+      const ws = new RealWS("ws://127.0.0.1:" + server.address().port);
+      ws.on("error", err => { console.error("error: " + err.message); process.exit(1); });
+      ws.on("open", () => ws.send("ping"));
+      ws.on("message", data => {
+        console.log("echo: " + data);
+        ws.terminate();
+        server.close();
+      });
+    `,
+  });
+
+  await using install = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const installErr = await install.stderr.text();
+  if ((await install.exited) !== 0) console.error(installErr);
+  expect(await install.exited).toBe(0);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "client.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  if (exitCode !== 0) console.error(stderr);
+  expect(stdout.trim()).toBe("echo: pong");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/18982.test.ts
+++ b/test/regression/issue/18982.test.ts
@@ -1,0 +1,50 @@
+// https://github.com/oven-sh/bun/issues/18982
+// dockerode's container.attach() hangs because http.ClientRequest never emits 'upgrade'.
+import { expect, test } from "bun:test";
+import { once } from "node:events";
+import http from "node:http";
+import net, { type AddressInfo } from "node:net";
+
+test("http.request emits 'upgrade' on 101 Switching Protocols (dockerode attach)", async () => {
+  const server = net.createServer(conn => {
+    conn.once("data", () => {
+      conn.write(
+        "HTTP/1.1 101 UPGRADED\r\n" +
+          "Content-Type: application/vnd.docker.raw-stream\r\n" +
+          "Connection: Upgrade\r\n" +
+          "Upgrade: tcp\r\n" +
+          "\r\n",
+      );
+      conn.on("data", chunk => conn.write(chunk));
+    });
+  });
+
+  const { promise, resolve, reject } = Promise.withResolvers<AddressInfo>();
+  server.once("error", reject);
+  server.listen(0, "127.0.0.1", () => resolve(server.address() as AddressInfo));
+  const addr = await promise;
+
+  try {
+    const req = http.request({
+      host: "127.0.0.1",
+      port: addr.port,
+      method: "POST",
+      path: "/containers/test/attach?stream=1&stdin=1&stdout=1",
+      headers: { Connection: "Upgrade", Upgrade: "tcp" },
+    });
+    req.end();
+
+    const [res, socket] = await once(req, "upgrade");
+    expect(res.statusCode).toBe(101);
+    expect(res.headers.upgrade).toBe("tcp");
+
+    const echoed = once(socket, "data");
+    socket.write('echo "Hello, World!"\n');
+    const [chunk] = await echoed;
+    expect(chunk.toString()).toBe('echo "Hello, World!"\n');
+
+    socket.end();
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
Emit `'upgrade'` on `http.ClientRequest` when the server responds 101, with a usable Duplex socket bridging the underlying fetch streams. Gates `duplex: "half"` on the `Upgrade` header so non-upgrade requests keep their connection-reuse behavior.

This makes the real `ws` npm package work (it does its handshake via `http.request` + `req.on('upgrade')`), which unblocks Playwright's bundled ws — `chromium.connectOverCDP('ws://...')` now connects and round-trips against a real Chrome (#9911). The `http://` form (where Playwright first fetches `/json/version` via the same agent) still hangs at CDP response delivery; that's a separate interaction not addressed here.

Supersedes #22412 and #28629.

Fixes #18982