### PR TITLE
dns: use stackFallback allocator for name_buf in LibInfo.lookup

### DIFF
--- a/src/bun.js/api/bun/dns.zig
+++ b/src/bun.js/api/bun/dns.zig
@@ -68,11 +68,10 @@ const LibInfo = struct {
             return dns_lookup.promise.value();
         }
 
-        var name_buf: [1024]u8 = undefined;
-        _ = strings.copy(name_buf[0..], query.name);
-
-        name_buf[query.name.len] = 0;
-        const name_z = name_buf[0..query.name.len :0];
+        var stack_fallback = std.heap.stackFallback(1024, bun.default_allocator);
+        const name_allocator = stack_fallback.get();
+        const name_z = bun.handleOom(name_allocator.dupeZ(u8, query.name));
+        defer name_allocator.free(name_z);
 
         var request = GetAddrInfoRequest.init(
             cache,


### PR DESCRIPTION
## Summary
- Replace the fixed 1024-byte stack buffer in `LibInfo.lookup` (macOS `getaddrinfo_async_start` path) with `std.heap.stackFallback(1024, bun.default_allocator)` + `dupeZ`.
- Hostnames up to 1024 bytes stay on the stack; longer names spill to the heap instead of overrunning the buffer.

## Test plan
- [x] Debug build compiles (`bun bd --version`).
- [x] `Bun.dns.lookup` with a 2008-character hostname returns `DNS_ENOTFOUND` instead of crashing / truncating.