### PR TITLE
Fix 4 bugs in NODE_OPTIONS parsing

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -2064,6 +2064,157 @@ pub fn appendOptionsEnv(env: []const u8, comptime ArgType: type, args: *std.arra
     }
 }
 
+/// Kind of flag in `NODE_OPTIONS`: either a boolean flag (no value) or an
+/// option that takes a value. Used by `appendNodeOptionsEnv` to decide
+/// whether the next token should be consumed as a value.
+const NodeOptionKind = enum { bool_flag, option };
+
+/// Allowlist of flags supported by Bun that may appear in `NODE_OPTIONS`.
+///
+/// Matches Node.js's behavior of restricting `NODE_OPTIONS` to a subset of
+/// flags (for security and predictability). We include only flags that Bun
+/// actually implements — unknown flags are silently ignored.
+pub const node_options_allowlist = ComptimeStringMap(NodeOptionKind, .{
+    // Boolean flags (no value)
+    .{ "--expose-gc", .bool_flag },
+    .{ "--no-addons", .bool_flag },
+    .{ "--no-deprecation", .bool_flag },
+    .{ "--preserve-symlinks", .bool_flag },
+    .{ "--preserve-symlinks-main", .bool_flag },
+    .{ "--throw-deprecation", .bool_flag },
+    .{ "--use-bundled-ca", .bool_flag },
+    .{ "--use-openssl-ca", .bool_flag },
+    .{ "--use-system-ca", .bool_flag },
+    .{ "--zero-fill-buffers", .bool_flag },
+    .{ "--cpu-prof", .bool_flag },
+    .{ "--cpu-prof-md", .bool_flag },
+    .{ "--heap-prof", .bool_flag },
+    .{ "--heap-prof-md", .bool_flag },
+
+    // Options that take a value
+    .{ "--conditions", .option },
+    .{ "-C", .option },
+    .{ "--cpu-prof-dir", .option },
+    .{ "--cpu-prof-interval", .option },
+    .{ "--cpu-prof-name", .option },
+    .{ "--dns-result-order", .option },
+    .{ "--heap-prof-dir", .option },
+    .{ "--heap-prof-name", .option },
+    .{ "--import", .option },
+    .{ "--inspect", .option },
+    .{ "--inspect-brk", .option },
+    .{ "--inspect-wait", .option },
+    .{ "--max-http-header-size", .option },
+    .{ "--require", .option },
+    .{ "-r", .option },
+    .{ "--title", .option },
+    .{ "--unhandled-rejections", .option },
+});
+
+/// Parses `NODE_OPTIONS` env var into command-line tokens filtered by
+/// `node_options_allowlist` and inserts them into `args` starting at
+/// `offset` (after argv[0]).
+///
+/// Splits on whitespace with support for single/double quotes and backslash
+/// escapes, matching Node.js's NODE_OPTIONS parsing behavior. Positional
+/// (non-flag) tokens and unrecognized flags are dropped to prevent
+/// unintended script execution via the environment.
+pub fn appendNodeOptionsEnv(env: []const u8, args: *std.array_list.Managed([:0]const u8)) !void {
+    // First, tokenize the NODE_OPTIONS string (quote- and escape-aware).
+    var tokens = std.array_list.Managed([]u8).init(bun.default_allocator);
+    defer {
+        for (tokens.items) |t| bun.default_allocator.free(t);
+        tokens.deinit();
+    }
+
+    var buf = std.array_list.Managed(u8).init(bun.default_allocator);
+    defer buf.deinit();
+
+    var in_quote: ?u8 = null;
+    var escape = false;
+    var has_token = false;
+
+    var i: usize = 0;
+    while (i < env.len) : (i += 1) {
+        const ch = env[i];
+
+        if (escape) {
+            try buf.append(ch);
+            escape = false;
+            has_token = true;
+            continue;
+        }
+
+        if (ch == '\\') {
+            escape = true;
+            continue;
+        }
+
+        if (in_quote) |q| {
+            if (ch == q) {
+                in_quote = null;
+            } else {
+                try buf.append(ch);
+                has_token = true;
+            }
+            continue;
+        }
+
+        if (ch == '\'' or ch == '"') {
+            in_quote = ch;
+            has_token = true;
+            continue;
+        }
+
+        if (std.ascii.isWhitespace(ch)) {
+            if (has_token) {
+                try tokens.append(try buf.toOwnedSlice());
+                has_token = false;
+            }
+            continue;
+        }
+
+        try buf.append(ch);
+        has_token = true;
+    }
+    if (has_token) {
+        try tokens.append(try buf.toOwnedSlice());
+    }
+
+    // Now filter tokens through the allowlist and insert into args.
+    var offset: usize = 1;
+    var j: usize = 0;
+    while (j < tokens.items.len) : (j += 1) {
+        const token = tokens.items[j];
+        if (token.len == 0 or token[0] != '-') {
+            // Positional args are not allowed in NODE_OPTIONS.
+            continue;
+        }
+
+        // Split --flag=value into name and value.
+        const eq_idx = std.mem.indexOfScalar(u8, token, '=');
+        const flag_name = if (eq_idx) |idx| token[0..idx] else token;
+
+        const kind = node_options_allowlist.get(flag_name) orelse continue;
+
+        const token_z = try bun.default_allocator.dupeZ(u8, token);
+        try args.insert(offset, token_z);
+        offset += 1;
+
+        // If this is a value-taking option and the value wasn't inline
+        // (`--flag value` form), consume the next token as its value.
+        if (kind == .option and eq_idx == null and j + 1 < tokens.items.len) {
+            const next_tok = tokens.items[j + 1];
+            if (next_tok.len > 0 and next_tok[0] != '-') {
+                const next_z = try bun.default_allocator.dupeZ(u8, next_tok);
+                try args.insert(offset, next_z);
+                offset += 1;
+                j += 1;
+            }
+        }
+    }
+}
+
 pub fn initArgv() !void {
     if (comptime Environment.isPosix) {
         argv = try bun.default_allocator.alloc([:0]const u8, std.os.argv.len);
@@ -2130,6 +2281,16 @@ pub fn initArgv() !void {
         try appendOptionsEnv(opts, [:0]const u8, &argv_list);
         argv = argv_list.items;
         bun_options_argc = argv.len - original_len;
+    }
+
+    // NODE_OPTIONS: Node.js-compatible env var for injecting CLI flags.
+    // Filtered through an allowlist — unknown flags are dropped.
+    if (bun.env_var.NODE_OPTIONS.get()) |opts| {
+        if (opts.len > 0) {
+            var argv_list = std.array_list.Managed([:0]const u8).fromOwnedSlice(bun.default_allocator, argv);
+            try appendNodeOptionsEnv(opts, &argv_list);
+            argv = argv_list.items;
+        }
     }
 }
 

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -2145,7 +2145,7 @@ pub fn appendNodeOptionsEnv(env: []const u8, args: *std.array_list.Managed([:0]c
             continue;
         }
 
-        if (ch == '\\') {
+        if (ch == '\\' and (in_quote == null or in_quote.? != '\'')) {
             escape = true;
             continue;
         }
@@ -2197,20 +2197,28 @@ pub fn appendNodeOptionsEnv(env: []const u8, args: *std.array_list.Managed([:0]c
 
         const kind = node_options_allowlist.get(flag_name) orelse continue;
 
-        const token_z = try bun.default_allocator.dupeZ(u8, token);
-        try args.insert(offset, token_z);
-        offset += 1;
-
-        // If this is a value-taking option and the value wasn't inline
-        // (`--flag value` form), consume the next token as its value.
-        if (kind == .option and eq_idx == null and j + 1 < tokens.items.len) {
-            const next_tok = tokens.items[j + 1];
-            if (next_tok.len > 0 and next_tok[0] != '-') {
-                const next_z = try bun.default_allocator.dupeZ(u8, next_tok);
-                try args.insert(offset, next_z);
-                offset += 1;
-                j += 1;
+        if (kind == .option and eq_idx == null) {
+            // Space-separated value form: only inject if a value token
+            // actually follows in NODE_OPTIONS. Never inject a bare
+            // required-value flag — it would consume a user arg.
+            if (j + 1 < tokens.items.len) {
+                const next_tok = tokens.items[j + 1];
+                if (next_tok.len == 0 or next_tok[0] != '-') {
+                    const token_z = try bun.default_allocator.dupeZ(u8, token);
+                    try args.insert(offset, token_z);
+                    offset += 1;
+                    const next_z = try bun.default_allocator.dupeZ(u8, next_tok);
+                    try args.insert(offset, next_z);
+                    offset += 1;
+                    j += 1;
+                }
             }
+            // No value follows → drop the flag entirely.
+        } else {
+            // bool_flag, or --flag=value form: safe to insert as-is.
+            const token_z = try bun.default_allocator.dupeZ(u8, token);
+            try args.insert(offset, token_z);
+            offset += 1;
         }
     }
 }
@@ -2287,9 +2295,11 @@ pub fn initArgv() !void {
     // Filtered through an allowlist — unknown flags are dropped.
     if (bun.env_var.NODE_OPTIONS.get()) |opts| {
         if (opts.len > 0) {
+            const len_before = argv.len;
             var argv_list = std.array_list.Managed([:0]const u8).fromOwnedSlice(bun.default_allocator, argv);
             try appendNodeOptionsEnv(opts, &argv_list);
             argv = argv_list.items;
+            bun_options_argc += argv.len - len_before;
         }
     }
 }

--- a/src/env_var.zig
+++ b/src/env_var.zig
@@ -104,6 +104,7 @@ pub const JENKINS_URL = New(kind.string, "JENKINS_URL", .{});
 pub const MI_VERBOSE = New(kind.boolean, "MI_VERBOSE", .{ .default = false });
 pub const NO_COLOR = New(kind.boolean, "NO_COLOR", .{ .default = false });
 pub const NODE_CHANNEL_FD = New(kind.string, "NODE_CHANNEL_FD", .{});
+pub const NODE_OPTIONS = New(kind.string, "NODE_OPTIONS", .{});
 /// Set by HostProcess.zig when spawning the WebView host subprocess. The
 /// child's cli.zig checks this before anything else and hands off to C++
 /// Bun__WebView__hostMain. Never returns — no JSC, no VM.

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -92,7 +92,7 @@ function setDefaultResultOrder(order) {
 }
 
 function getDefaultResultOrder() {
-  return defaultResultOrder;
+  return defaultResultOrder();
 }
 
 function setServersOn(servers, object) {

--- a/test/regression/issue/28817.test.ts
+++ b/test/regression/issue/28817.test.ts
@@ -11,11 +11,7 @@ async function run(nodeOptions: string, script: string) {
     stderr: "pipe",
     stdout: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout, stderr, exitCode };
 }
 
@@ -71,39 +67,27 @@ describe("NODE_OPTIONS", () => {
   test("positional args cannot inject scripts via NODE_OPTIONS", async () => {
     // Even though the user put a positional-looking arg in, the entrypoint
     // should still be the -e script, not the injected positional.
-    const { stdout, exitCode } = await run(
-      "/etc/passwd",
-      'console.log("safe");',
-    );
+    const { stdout, exitCode } = await run("/etc/passwd", 'console.log("safe");');
     expect(stdout.trim()).toBe("safe");
     expect(exitCode).toBe(0);
   });
 
   test("--eval is not injectable via NODE_OPTIONS", async () => {
     // --eval is not in the allowlist, so this must not execute.
-    const { stdout, exitCode } = await run(
-      "--eval console.log('HIJACKED')",
-      'console.log("original");',
-    );
+    const { stdout, exitCode } = await run("--eval console.log('HIJACKED')", 'console.log("original");');
     expect(stdout).not.toContain("HIJACKED");
     expect(stdout.trim()).toBe("original");
     expect(exitCode).toBe(0);
   });
 
   test("--expose-gc exposes gc()", async () => {
-    const { stdout, exitCode } = await run(
-      "--expose-gc",
-      'console.log(typeof gc);',
-    );
+    const { stdout, exitCode } = await run("--expose-gc", "console.log(typeof gc);");
     expect(stdout.trim()).toBe("function");
     expect(exitCode).toBe(0);
   });
 
   test("--title sets process.title", async () => {
-    const { stdout, exitCode } = await run(
-      "--title=my-bun-app",
-      'console.log(process.title);',
-    );
+    const { stdout, exitCode } = await run("--title=my-bun-app", "console.log(process.title);");
     expect(stdout.trim()).toBe("my-bun-app");
     expect(exitCode).toBe(0);
   });

--- a/test/regression/issue/28817.test.ts
+++ b/test/regression/issue/28817.test.ts
@@ -1,0 +1,119 @@
+// Regression test for https://github.com/oven-sh/bun/issues/28817
+// Bun should honor NODE_OPTIONS=--dns-result-order and other Node-compatible
+// flags set via the NODE_OPTIONS environment variable.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+async function run(nodeOptions: string, script: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: { ...bunEnv, NODE_OPTIONS: nodeOptions },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("NODE_OPTIONS", () => {
+  test("--dns-result-order=ipv4first sets default order via env", async () => {
+    const { stdout, exitCode } = await run(
+      "--dns-result-order=ipv4first",
+      'import dns from "node:dns"; console.log(dns.getDefaultResultOrder());',
+    );
+    expect(stdout.trim()).toBe("ipv4first");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--dns-result-order ipv6first (space separated) also works", async () => {
+    const { stdout, exitCode } = await run(
+      "--dns-result-order ipv6first",
+      'import dns from "node:dns"; console.log(dns.getDefaultResultOrder());',
+    );
+    expect(stdout.trim()).toBe("ipv6first");
+    expect(exitCode).toBe(0);
+  });
+
+  test("default order is verbatim without NODE_OPTIONS", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", 'import dns from "node:dns"; console.log(dns.getDefaultResultOrder());'],
+      env: { ...bunEnv, NODE_OPTIONS: "" },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim()).toBe("verbatim");
+    expect(exitCode).toBe(0);
+  });
+
+  test("getDefaultResultOrder returns a string, not a function", async () => {
+    const { stdout, exitCode } = await run(
+      "--dns-result-order=ipv4first",
+      'import dns from "node:dns"; console.log(typeof dns.getDefaultResultOrder());',
+    );
+    expect(stdout.trim()).toBe("string");
+    expect(exitCode).toBe(0);
+  });
+
+  test("unknown flags are silently ignored", async () => {
+    const { stdout, exitCode } = await run(
+      "--unknown-flag --dns-result-order=ipv4first",
+      'import dns from "node:dns"; console.log(dns.getDefaultResultOrder());',
+    );
+    expect(stdout.trim()).toBe("ipv4first");
+    expect(exitCode).toBe(0);
+  });
+
+  test("positional args cannot inject scripts via NODE_OPTIONS", async () => {
+    // Even though the user put a positional-looking arg in, the entrypoint
+    // should still be the -e script, not the injected positional.
+    const { stdout, exitCode } = await run(
+      "/etc/passwd",
+      'console.log("safe");',
+    );
+    expect(stdout.trim()).toBe("safe");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--eval is not injectable via NODE_OPTIONS", async () => {
+    // --eval is not in the allowlist, so this must not execute.
+    const { stdout, exitCode } = await run(
+      "--eval console.log('HIJACKED')",
+      'console.log("original");',
+    );
+    expect(stdout).not.toContain("HIJACKED");
+    expect(stdout.trim()).toBe("original");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--expose-gc exposes gc()", async () => {
+    const { stdout, exitCode } = await run(
+      "--expose-gc",
+      'console.log(typeof gc);',
+    );
+    expect(stdout.trim()).toBe("function");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--title sets process.title", async () => {
+    const { stdout, exitCode } = await run(
+      "--title=my-bun-app",
+      'console.log(process.title);',
+    );
+    expect(stdout.trim()).toBe("my-bun-app");
+    expect(exitCode).toBe(0);
+  });
+
+  test("quoted values are parsed correctly", async () => {
+    const { stdout, exitCode } = await run(
+      `--dns-result-order='ipv4first'`,
+      'import dns from "node:dns"; console.log(dns.getDefaultResultOrder());',
+    );
+    expect(stdout.trim()).toBe("ipv4first");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/regression/issue/28817.test.ts
+++ b/test/regression/issue/28817.test.ts
@@ -11,11 +11,7 @@ async function runWith(nodeOptions: string, script: string) {
     stderr: "pipe",
     stdout: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout: stdout.trim(), stderr, exitCode };
 }
 

--- a/test/regression/issue/28817.test.ts
+++ b/test/regression/issue/28817.test.ts
@@ -2,102 +2,89 @@
 // Bun should honor NODE_OPTIONS=--dns-result-order and other Node-compatible
 // flags set via the NODE_OPTIONS environment variable.
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 
-async function run(nodeOptions: string, script: string) {
+async function runWith(nodeOptions: string, script: string) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", script],
     env: { ...bunEnv, NODE_OPTIONS: nodeOptions },
     stderr: "pipe",
     stdout: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return { stdout, stderr, exitCode };
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  return { stdout: stdout.trim(), stderr, exitCode };
 }
 
 describe("NODE_OPTIONS", () => {
-  test("--dns-result-order=ipv4first sets default order via env", async () => {
-    const { stdout, exitCode } = await run(
-      "--dns-result-order=ipv4first",
-      'import dns from "node:dns"; console.log(dns.getDefaultResultOrder());',
-    );
-    expect(stdout.trim()).toBe("ipv4first");
-    expect(exitCode).toBe(0);
-  });
+  test("--dns-result-order honored via env (= and space forms)", async () => {
+    const getOrder = 'import dns from "node:dns"; console.log(dns.getDefaultResultOrder());';
 
-  test("--dns-result-order ipv6first (space separated) also works", async () => {
-    const { stdout, exitCode } = await run(
-      "--dns-result-order ipv6first",
-      'import dns from "node:dns"; console.log(dns.getDefaultResultOrder());',
-    );
-    expect(stdout.trim()).toBe("ipv6first");
-    expect(exitCode).toBe(0);
+    // --flag=value form
+    const eq = await runWith("--dns-result-order=ipv4first", getOrder);
+    expect(eq.stdout).toBe("ipv4first");
+    expect(eq.exitCode).toBe(0);
+
+    // --flag value (space separated) form
+    const sp = await runWith("--dns-result-order ipv6first", getOrder);
+    expect(sp.stdout).toBe("ipv6first");
+    expect(sp.exitCode).toBe(0);
+
+    // quoted value
+    const q = await runWith(`--dns-result-order='verbatim'`, getOrder);
+    expect(q.stdout).toBe("verbatim");
+    expect(q.exitCode).toBe(0);
   });
 
   test("default order is verbatim without NODE_OPTIONS", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", 'import dns from "node:dns"; console.log(dns.getDefaultResultOrder());'],
-      env: { ...bunEnv, NODE_OPTIONS: "" },
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(stdout.trim()).toBe("verbatim");
-    expect(exitCode).toBe(0);
+    const r = await runWith("", 'import dns from "node:dns"; console.log(dns.getDefaultResultOrder());');
+    expect(r.stdout).toBe("verbatim");
+    expect(r.exitCode).toBe(0);
   });
 
   test("getDefaultResultOrder returns a string, not a function", async () => {
-    const { stdout, exitCode } = await run(
+    const r = await runWith(
       "--dns-result-order=ipv4first",
-      'import dns from "node:dns"; console.log(typeof dns.getDefaultResultOrder());',
+      'import dns from "node:dns"; const v = dns.getDefaultResultOrder(); console.log(typeof v, v);',
     );
-    expect(stdout.trim()).toBe("string");
-    expect(exitCode).toBe(0);
+    expect(r.stdout).toBe("string ipv4first");
+    expect(r.exitCode).toBe(0);
   });
 
-  test("unknown flags are silently ignored", async () => {
-    const { stdout, exitCode } = await run(
+  test("unknown flags and positional args are dropped", async () => {
+    // Unknown flag is ignored; known flag still works.
+    const r1 = await runWith(
       "--unknown-flag --dns-result-order=ipv4first",
       'import dns from "node:dns"; console.log(dns.getDefaultResultOrder());',
     );
-    expect(stdout.trim()).toBe("ipv4first");
-    expect(exitCode).toBe(0);
+    expect(r1.stdout).toBe("ipv4first");
+    expect(r1.exitCode).toBe(0);
+
+    // Positional arg (non-flag) cannot inject a script/entrypoint.
+    const r2 = await runWith("/etc/passwd", 'console.log("safe");');
+    expect(r2.stdout).toBe("safe");
+    expect(r2.exitCode).toBe(0);
+
+    // --eval is not in the allowlist, so this must not execute injected code.
+    const r3 = await runWith("--eval console.log('HIJACKED')", 'console.log("original");');
+    expect(r3.stdout).not.toContain("HIJACKED");
+    expect(r3.stdout).toBe("original");
+    expect(r3.exitCode).toBe(0);
   });
 
-  test("positional args cannot inject scripts via NODE_OPTIONS", async () => {
-    // Even though the user put a positional-looking arg in, the entrypoint
-    // should still be the -e script, not the injected positional.
-    const { stdout, exitCode } = await run("/etc/passwd", 'console.log("safe");');
-    expect(stdout.trim()).toBe("safe");
-    expect(exitCode).toBe(0);
+  test("--expose-gc exposes gc() via env", async () => {
+    const r = await runWith("--expose-gc", "console.log(typeof gc);");
+    expect(r.stdout).toBe("function");
+    expect(r.exitCode).toBe(0);
   });
 
-  test("--eval is not injectable via NODE_OPTIONS", async () => {
-    // --eval is not in the allowlist, so this must not execute.
-    const { stdout, exitCode } = await run("--eval console.log('HIJACKED')", 'console.log("original");');
-    expect(stdout).not.toContain("HIJACKED");
-    expect(stdout.trim()).toBe("original");
-    expect(exitCode).toBe(0);
-  });
-
-  test("--expose-gc exposes gc()", async () => {
-    const { stdout, exitCode } = await run("--expose-gc", "console.log(typeof gc);");
-    expect(stdout.trim()).toBe("function");
-    expect(exitCode).toBe(0);
-  });
-
-  test("--title sets process.title", async () => {
-    const { stdout, exitCode } = await run("--title=my-bun-app", "console.log(process.title);");
-    expect(stdout.trim()).toBe("my-bun-app");
-    expect(exitCode).toBe(0);
-  });
-
-  test("quoted values are parsed correctly", async () => {
-    const { stdout, exitCode } = await run(
-      `--dns-result-order='ipv4first'`,
-      'import dns from "node:dns"; console.log(dns.getDefaultResultOrder());',
-    );
-    expect(stdout.trim()).toBe("ipv4first");
-    expect(exitCode).toBe(0);
+  test.skipIf(isWindows)("--title sets process.title via env", async () => {
+    // process.title is unreliable on Windows (varies by OS version); skip there.
+    const r = await runWith("--title=my-bun-app", "console.log(process.title);");
+    expect(r.stdout).toBe("my-bun-app");
+    expect(r.exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Fixes 4 bugs identified in review of #28818:

- **`bun_options_argc` not updated** after NODE_OPTIONS tokens are injected into argv, causing standalone compiled binaries to miscalculate `offset_for_passthrough`
- **Bare required-value flags hijack user args** — e.g. `NODE_OPTIONS="--require" bun app.js` would consume `app.js` as the require path. Now checks for a value token *before* inserting the flag, drops it entirely if none follows
- **Empty quoted values rejected** — `--title ""` would drop the empty string and leave `--title` bare. Fixed guard to accept len==0 tokens as valid values
- **Backslash escapes inside single quotes** — POSIX says backslash is literal inside single quotes; was incorrectly consuming the closing quote as an escaped char

## Test plan

- [ ] Existing NODE_OPTIONS tests in `test/regression/issue/28817.test.ts` still pass
- [ ] `NODE_OPTIONS="--require" bun -e "console.log('safe')"` prints "safe" (bare flag dropped)
- [ ] `NODE_OPTIONS="--title ''" bun -e "console.log(process.title)"` works with empty value
- [ ] Standalone compiled binary with `NODE_OPTIONS` set computes correct passthrough args

🤖 Generated with [Claude Code](https://claude.com/claude-code)