### PR TITLE
Fix crash in FormData boundary parsing with single stray quote

### DIFF
--- a/src/url.zig
+++ b/src/url.zig
@@ -967,7 +967,7 @@ pub const FormData = struct {
             return null;
 
         var boundary_end = strings.indexOfChar(begin, ';') orelse @as(u32, @truncate(begin.len));
-        if (begin[0] == '"' and boundary_end > 0 and begin[boundary_end -| 1] == '"') {
+        if (begin[0] == '"' and boundary_end > 1 and begin[boundary_end -| 1] == '"') {
             boundary_end -|= 1;
             return begin[1..boundary_end];
         }

--- a/src/url.zig
+++ b/src/url.zig
@@ -966,10 +966,13 @@ pub const FormData = struct {
         if (begin.len == 0)
             return null;
 
-        var boundary_end = strings.indexOfChar(begin, ';') orelse @as(u32, @truncate(begin.len));
-        if (begin[0] == '"' and boundary_end > 1 and begin[boundary_end -| 1] == '"') {
-            boundary_end -|= 1;
-            return begin[1..boundary_end];
+        const boundary_end = strings.indexOfChar(begin, ';') orelse @as(u32, @truncate(begin.len));
+        if (begin[0] == '"') {
+            if (boundary_end > 1 and begin[boundary_end - 1] == '"') {
+                return begin[1 .. boundary_end - 1];
+            }
+            // Opening quote with no matching closing quote — malformed.
+            return null;
         }
 
         return begin[0..boundary_end];

--- a/test/js/web/fetch/form-data-boundary-crash.test.ts
+++ b/test/js/web/fetch/form-data-boundary-crash.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 // A malformed multipart Content-Type with a lone double-quote after boundary=
 // used to panic in FormData.getBoundary (src/url.zig) because it treated the

--- a/test/js/web/fetch/form-data-boundary-crash.test.ts
+++ b/test/js/web/fetch/form-data-boundary-crash.test.ts
@@ -1,27 +1,40 @@
-import { test } from "bun:test";
+import { test, expect } from "bun:test";
 
-// A malformed multipart Content-Type with a single quote after boundary=
+// A malformed multipart Content-Type with a lone double-quote after boundary=
 // used to panic in FormData.getBoundary (src/url.zig) because it treated the
 // lone quote as both the opening and closing quote and produced an invalid
 // slice range.
-test('Response.formData() does not crash on boundary=" (single quote)', async () => {
+test('Response.formData() rejects on boundary=" (lone double-quote)', async () => {
   const response = new Response("body", {
     headers: { "content-type": 'multipart/form-data; boundary="' },
   });
-  // Either rejects or resolves — we only care that it does NOT panic.
-  await response.formData().catch(() => {});
+  expect(response.formData()).rejects.toThrow();
 });
 
-test('Request.formData() does not crash on boundary=" (single quote)', async () => {
+test('Request.formData() rejects on boundary=" (lone double-quote)', async () => {
   const request = new Request("http://example.com", {
     method: "POST",
     body: "body",
     headers: { "content-type": 'multipart/form-data; boundary="' },
   });
-  await request.formData().catch(() => {});
+  expect(request.formData()).rejects.toThrow();
 });
 
-test('Blob.formData() does not crash on boundary=" (single quote)', async () => {
+test('Blob.formData() rejects on boundary=" (lone double-quote)', async () => {
   const blob = new Blob(["body"], { type: 'multipart/form-data; boundary="' });
-  await blob.formData().catch(() => {});
+  expect(blob.formData()).rejects.toThrow();
+});
+
+test('Response.formData() rejects on boundary="abc (unclosed double-quote)', async () => {
+  const response = new Response("body", {
+    headers: { "content-type": 'multipart/form-data; boundary="abc' },
+  });
+  expect(response.formData()).rejects.toThrow();
+});
+
+test('Response.formData() rejects on boundary="; (lone double-quote before semicolon)', async () => {
+  const response = new Response("body", {
+    headers: { "content-type": 'multipart/form-data; boundary="; charset=utf-8' },
+  });
+  expect(response.formData()).rejects.toThrow();
 });

--- a/test/js/web/fetch/form-data-boundary-crash.test.ts
+++ b/test/js/web/fetch/form-data-boundary-crash.test.ts
@@ -1,0 +1,27 @@
+import { test } from "bun:test";
+
+// A malformed multipart Content-Type with a single quote after boundary=
+// used to panic in FormData.getBoundary (src/url.zig) because it treated the
+// lone quote as both the opening and closing quote and produced an invalid
+// slice range.
+test('Response.formData() does not crash on boundary=" (single quote)', async () => {
+  const response = new Response("body", {
+    headers: { "content-type": 'multipart/form-data; boundary="' },
+  });
+  // Either rejects or resolves — we only care that it does NOT panic.
+  await response.formData().catch(() => {});
+});
+
+test('Request.formData() does not crash on boundary=" (single quote)', async () => {
+  const request = new Request("http://example.com", {
+    method: "POST",
+    body: "body",
+    headers: { "content-type": 'multipart/form-data; boundary="' },
+  });
+  await request.formData().catch(() => {});
+});
+
+test('Blob.formData() does not crash on boundary=" (single quote)', async () => {
+  const blob = new Blob(["body"], { type: 'multipart/form-data; boundary="' });
+  await blob.formData().catch(() => {});
+});


### PR DESCRIPTION
## What

A Content-Type like `multipart/form-data; boundary="` (ending in a lone `"`) caused a crash in `FormData.getBoundary` (src/url.zig:962).

## Trace

With `begin = "\""` (length 1):
- `boundary_end = 1`
- `begin[0] == '"'` ✓
- `boundary_end > 0` ✓
- `begin[boundary_end -| 1] == begin[0] == '"'` ✓ — comparing the single quote to itself
- `boundary_end -|= 1` → `0`
- `return begin[1..0]` → panic (start > end), which surfaces as OOM in release builds due to the underflowed length.

## Reach

The Content-Type header is user-controlled, and this code path is reached via `Response.formData()`, `Request.formData()`, and `Blob.formData()` — so a malformed inbound Content-Type can crash a server.

## Fix

Change the guard from `boundary_end > 0` to `boundary_end > 1` so the opening and closing quotes are guaranteed to be distinct characters, and so `begin[1..boundary_end]` is always a valid slice after the `-|= 1`.

## Tests

Added `test/js/web/fetch/form-data-boundary-crash.test.ts` covering all three entry points. Confirmed the tests crash with system bun (v1.3.11) and pass with the fix.