### PR TITLE
Add markdown ANSI pretty-printer for `bun ./file.md`

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1312,6 +1312,70 @@ declare module "bun" {
     ): string;
 
     /**
+     * Theme for ANSI terminal rendering.
+     */
+    export interface AnsiTheme {
+      /**
+       * Emit ANSI color + styling escape sequences. When `false`, the
+       * renderer falls back to plain ASCII chrome (no box drawing,
+       * no emoji, no escape codes).
+       * @default true
+       */
+      colors?: boolean;
+      /**
+       * Emit OSC 8 hyperlinks (clickable links in modern terminals).
+       * When `false`, links render as `text (url)`.
+       * @default false
+       */
+      hyperlinks?: boolean;
+      /**
+       * True when the terminal background is light. Affects the color
+       * palette chosen for inline code backgrounds. Defaults to
+       * detecting from the `COLORFGBG` environment variable.
+       */
+      light?: boolean;
+      /**
+       * Line width used for word-wrapping paragraphs and headings and
+       * for the horizontal rule. Pass `0` to disable wrapping.
+       * @default 80
+       */
+      columns?: number;
+    }
+
+    /**
+     * Render markdown to an ANSI-colored terminal string.
+     *
+     * Supports headings, lists, tables, inline styles, syntax-highlighted
+     * code blocks, links, images, and blockquotes. By default, enables all
+     * GFM extensions plus wikilinks, underline, and LaTeX math.
+     *
+     * @param input The markdown string or buffer to render
+     * @param theme Optional theme overrides
+     * @returns An ANSI-colored string
+     *
+     * @example
+     * ```ts
+     * const out = Bun.markdown.ansi("# Hello\n\n**bold** and *italic*\n");
+     * process.stdout.write(out);
+     *
+     * // Plain text, no escape codes
+     * const plain = Bun.markdown.ansi("# Hello", { colors: false });
+     *
+     * // Enable clickable OSC 8 hyperlinks
+     * const html = Bun.markdown.ansi("[docs](https://bun.com)", {
+     *   hyperlinks: true,
+     * });
+     *
+     * // Custom width
+     * const wrapped = Bun.markdown.ansi(longText, { columns: 60 });
+     * ```
+     */
+    export function ansi(
+      input: string | NodeJS.TypedArray | DataView<ArrayBuffer> | ArrayBufferLike,
+      theme?: AnsiTheme,
+    ): string;
+
+    /**
      * Render markdown with custom JavaScript callbacks for each element.
      *
      * Each callback receives the accumulated children as a string and optional

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1340,6 +1340,13 @@ declare module "bun" {
        * @default 80
        */
       columns?: number;
+      /**
+       * Inline images using the Kitty Graphics Protocol when the `src`
+       * resolves to a local file on disk. Falls through to the text alt
+       * for remote URLs. Supported by Kitty, WezTerm, and Ghostty.
+       * @default false
+       */
+      kittyGraphics?: boolean;
     }
 
     /**
@@ -1362,8 +1369,13 @@ declare module "bun" {
      * const plain = Bun.markdown.ansi("# Hello", { colors: false });
      *
      * // Enable clickable OSC 8 hyperlinks
-     * const html = Bun.markdown.ansi("[docs](https://bun.com)", {
+     * const linked = Bun.markdown.ansi("[docs](https://bun.com)", {
      *   hyperlinks: true,
+     * });
+     *
+     * // Inline images via Kitty Graphics Protocol
+     * const withImg = Bun.markdown.ansi("![alt](./logo.png)", {
+     *   kittyGraphics: true,
      * });
      *
      * // Custom width

--- a/src/bun.js/api/MarkdownObject.zig
+++ b/src/bun.js/api/MarkdownObject.zig
@@ -49,12 +49,14 @@ pub fn renderToAnsi(
     var theme: md.AnsiTheme = .{
         .colors = true,
         .hyperlinks = false,
+        .kitty_graphics = false,
         .light = md.detectLightBackground(),
         .columns = 80,
     };
     if (theme_value.isObject()) {
         if (try theme_value.getBooleanLoose(globalThis, "colors")) |v| theme.colors = v;
         if (try theme_value.getBooleanLoose(globalThis, "hyperlinks")) |v| theme.hyperlinks = v;
+        if (try theme_value.getBooleanLoose(globalThis, "kittyGraphics")) |v| theme.kitty_graphics = v;
         if (try theme_value.getBooleanLoose(globalThis, "light")) |v| theme.light = v;
         if (try theme_value.get(globalThis, "columns")) |cols| {
             if (cols.isNumber()) {
@@ -77,9 +79,13 @@ pub fn renderToAnsi(
         .latex_math = true,
     };
 
-    const result = md.renderToAnsi(input, arena.allocator(), opts, theme) catch {
-        return globalThis.throwOutOfMemory();
+    const result = md.renderToAnsi(input, arena.allocator(), opts, theme) catch |err| switch (err) {
+        error.OutOfMemory => return globalThis.throwOutOfMemory(),
+        error.StackOverflow => return globalThis.throwStackOverflow(),
     } orelse {
+        // The parser can only return null via JSError / JSTerminated
+        // from a renderer callback; the ANSI renderer has none, so this
+        // path is unreachable but handle it safely.
         return globalThis.throwOutOfMemory();
     };
 

--- a/src/bun.js/api/MarkdownObject.zig
+++ b/src/bun.js/api/MarkdownObject.zig
@@ -1,9 +1,14 @@
 pub fn create(globalThis: *jsc.JSGlobalObject) jsc.JSValue {
-    const object = JSValue.createEmptyObject(globalThis, 3);
+    const object = JSValue.createEmptyObject(globalThis, 4);
     object.put(
         globalThis,
         ZigString.static("html"),
         jsc.JSFunction.create(globalThis, "html", renderToHTML, 1, .{}),
+    );
+    object.put(
+        globalThis,
+        ZigString.static("ansi"),
+        jsc.JSFunction.create(globalThis, "ansi", renderToAnsi, 2, .{}),
     );
     object.put(
         globalThis,
@@ -16,6 +21,69 @@ pub fn create(globalThis: *jsc.JSGlobalObject) jsc.JSValue {
         jsc.JSFunction.create(globalThis, "react", renderReact, 3, .{}),
     );
     return object;
+}
+
+/// `Bun.markdown.ansi(text, theme?)` — render markdown to an ANSI-colored
+/// terminal string. `theme` is an optional object: `{ colors?, hyperlinks?,
+/// light?, columns? }`. By default colors are enabled, hyperlinks are
+/// disabled (the caller doesn't know if stdout is a TTY), and columns is 80.
+pub fn renderToAnsi(
+    globalThis: *jsc.JSGlobalObject,
+    callframe: *jsc.CallFrame,
+) bun.JSError!jsc.JSValue {
+    const input_value, const theme_value = callframe.argumentsAsArray(2);
+
+    if (input_value.isEmptyOrUndefinedOrNull()) {
+        return globalThis.throwInvalidArguments("Expected a string or buffer to render", .{});
+    }
+
+    var arena: bun.ArenaAllocator = .init(bun.default_allocator);
+    defer arena.deinit();
+
+    const buffer = try jsc.Node.StringOrBuffer.fromJS(globalThis, arena.allocator(), input_value) orelse {
+        return globalThis.throwInvalidArguments("Expected a string or buffer to render", .{});
+    };
+
+    const input = buffer.slice();
+
+    var theme: md.AnsiTheme = .{
+        .colors = true,
+        .hyperlinks = false,
+        .light = md.detectLightBackground(),
+        .columns = 80,
+    };
+    if (theme_value.isObject()) {
+        if (try theme_value.getBooleanLoose(globalThis, "colors")) |v| theme.colors = v;
+        if (try theme_value.getBooleanLoose(globalThis, "hyperlinks")) |v| theme.hyperlinks = v;
+        if (try theme_value.getBooleanLoose(globalThis, "light")) |v| theme.light = v;
+        if (try theme_value.get(globalThis, "columns")) |cols| {
+            if (cols.isNumber()) {
+                const n = cols.toInt32();
+                theme.columns = if (n <= 0) 0 else @intCast(@min(n, std.math.maxInt(u16)));
+            }
+        }
+    }
+
+    // Terminal rendering needs all the markdown syntax enabled by default.
+    const opts: md.Options = .{
+        .tables = true,
+        .strikethrough = true,
+        .tasklists = true,
+        .permissive_url_autolinks = true,
+        .permissive_www_autolinks = true,
+        .permissive_email_autolinks = true,
+        .wiki_links = true,
+        .underline = true,
+        .latex_math = true,
+    };
+
+    const result = md.renderToAnsi(input, arena.allocator(), opts, theme) catch {
+        return globalThis.throwOutOfMemory();
+    } orelse {
+        return globalThis.throwOutOfMemory();
+    };
+
+    return bun.String.createUTF8ForJS(globalThis, result);
 }
 
 pub fn renderToHTML(

--- a/src/bun.js/api/MarkdownObject.zig
+++ b/src/bun.js/api/MarkdownObject.zig
@@ -66,20 +66,7 @@ pub fn renderToAnsi(
         }
     }
 
-    // Terminal rendering needs all the markdown syntax enabled by default.
-    const opts: md.Options = .{
-        .tables = true,
-        .strikethrough = true,
-        .tasklists = true,
-        .permissive_url_autolinks = true,
-        .permissive_www_autolinks = true,
-        .permissive_email_autolinks = true,
-        .wiki_links = true,
-        .underline = true,
-        .latex_math = true,
-    };
-
-    const result = md.renderToAnsi(input, arena.allocator(), opts, theme) catch |err| switch (err) {
+    const result = md.renderToAnsi(input, arena.allocator(), .terminal, theme) catch |err| switch (err) {
         error.OutOfMemory => return globalThis.throwOutOfMemory(),
         error.StackOverflow => return globalThis.throwStackOverflow(),
     } orelse {

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1289,7 +1289,7 @@ pub const RunCommand = struct {
 
             // Extension is best-effort from the URL path; Kitty inspects
             // the file's magic bytes regardless.
-            const ext: []const u8 = if (bun.strings.endsWithAny(raw_url, ".png")) ".png" else if (bun.strings.endsWithAny(raw_url, ".jpg") or bun.strings.endsWithAny(raw_url, ".jpeg")) ".jpg" else if (bun.strings.endsWithAny(raw_url, ".gif")) ".gif" else if (bun.strings.endsWithAny(raw_url, ".webp")) ".webp" else ".bin";
+            const ext: []const u8 = if (bun.strings.endsWith(raw_url, ".png")) ".png" else if (bun.strings.endsWith(raw_url, ".jpg") or bun.strings.endsWith(raw_url, ".jpeg")) ".jpg" else if (bun.strings.endsWith(raw_url, ".gif")) ".gif" else if (bun.strings.endsWith(raw_url, ".webp")) ".webp" else ".bin";
             var name_buf: [64]u8 = undefined;
             const name = std.fmt.bufPrint(&name_buf, "bun-md-{x}{s}", .{ bun.fastRandom(), ext }) catch continue;
             const path = std.fmt.allocPrint(allocator, "{s}/{s}", .{ tmpdir, name }) catch continue;
@@ -1407,6 +1407,19 @@ pub const RunCommand = struct {
 
         Output.writer().writeAll(rendered) catch {};
         Output.flush();
+        // Unlink the temp files prefetchRemoteImages() wrote. Flush
+        // above guarantees the APC sequences referencing these paths
+        // have left this process for the terminal; Kitty reads the
+        // file synchronously when it receives the APC, so an unlink
+        // now is safe.
+        if (remote_map.count() > 0) {
+            var it = remote_map.valueIterator();
+            while (it.next()) |tmp_path| {
+                const z = bun.default_allocator.dupeZ(u8, tmp_path.*) catch continue;
+                _ = bun.sys.unlink(z);
+                bun.default_allocator.free(z);
+            }
+        }
         Global.exit(0);
     }
 

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1246,7 +1246,11 @@ pub const RunCommand = struct {
     /// address — HTTPThread.schedule does @fieldParentPtr on that task,
     /// so moving the struct would break the worker's callback.
     const RemoteImageDownload = struct {
-        async_http: bun.http.AsyncHTTP = undefined,
+        // Assigned immediately after the struct literal in
+        // prefetchRemoteImages (can't be set in the literal because
+        // AsyncHTTP.init needs a pointer to response_buffer, which only
+        // has a stable address once the owning struct is live).
+        async_http: bun.http.AsyncHTTP,
         response_buffer: bun.MutableString,
         url: []const u8,
         done: *DoneChannel,
@@ -1317,6 +1321,7 @@ pub const RunCommand = struct {
         for (remote_urls.items) |raw_url| {
             const d = allocator.create(RemoteImageDownload) catch continue;
             d.* = .{
+                .async_http = undefined,
                 .response_buffer = bun.MutableString.init(allocator, 8 * 1024) catch {
                     allocator.destroy(d);
                     continue;

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1584,7 +1584,8 @@ pub const RunCommand = struct {
         if (resolution) |resolved| {
             var resolved_mutable = resolved;
             const path = resolved_mutable.path().?;
-            const loader: bun.options.Loader = this_transpiler.options.loaders.get(path.name.ext) orelse .tsx;
+            const loader: bun.options.Loader = this_transpiler.options.loaders.get(path.name.ext) orelse
+                bun.options.defaultLoaders.get(path.name.ext) orelse .tsx;
             if (loader.canBeRunByBun() or loader == .html or loader == .md) {
                 log("Resolved to: `{s}`", .{path.text});
                 return _bootAndHandleError(ctx, path.text, loader);

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1284,10 +1284,13 @@ pub const RunCommand = struct {
             bun.default_allocator,
             md_opts,
             theme,
-        ) catch {
-            Output.prettyErrorln("<r><red>error<r>: failed to render markdown", .{});
-            Output.flush();
-            Global.exit(1);
+        ) catch |err| switch (err) {
+            error.OutOfMemory => bun.outOfMemory(),
+            error.StackOverflow => {
+                Output.prettyErrorln("<r><red>error<r>: markdown rendering exceeded the stack — input is too deeply nested", .{});
+                Output.flush();
+                Global.exit(1);
+            },
         } orelse {
             Output.prettyErrorln("<r><red>error<r>: failed to render markdown", .{});
             Output.flush();

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1395,6 +1395,23 @@ pub const RunCommand = struct {
             prefetchRemoteImages(contents, md_opts, &remote_map);
         }
 
+        // Relative image paths in the markdown should resolve against
+        // the document's directory, not the process cwd — otherwise
+        // `bun ./docs/README.md` from `/home/user` can't find `./img.png`
+        // that sits next to README.md. Resolve to an absolute dir first
+        // so joinAbsString downstream doesn't double-apply cwd.
+        var base_buf: bun.PathBuffer = undefined;
+        var cwd_buf: bun.PathBuffer = undefined;
+        const abs_md_path: []const u8 = blk: {
+            if (std.fs.path.isAbsolute(path)) break :blk path;
+            const cwd = switch (bun.sys.getcwd(&cwd_buf)) {
+                .result => |c| c,
+                .err => break :blk path,
+            };
+            break :blk bun.path.joinAbsStringBuf(cwd, &base_buf, &.{path}, .auto);
+        };
+        const image_base_dir = std.fs.path.dirname(abs_md_path) orelse abs_md_path;
+
         const theme: bun.md.AnsiTheme = .{
             .light = bun.md.detectLightBackground(),
             .columns = columns,
@@ -1402,6 +1419,7 @@ pub const RunCommand = struct {
             .hyperlinks = colors and is_tty,
             .kitty_graphics = kitty_graphics,
             .remote_image_paths = if (remote_map.count() > 0) &remote_map else null,
+            .image_base_dir = image_base_dir,
         };
 
         const rendered = bun.md.renderToAnsi(

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1252,6 +1252,19 @@ pub const RunCommand = struct {
         bun.md.renderWithRenderer(contents, allocator, md_opts, collector.renderer()) catch return;
         if (collector.urls.items.len == 0) return;
 
+        // Only spawn the HTTP worker thread if at least one URL is remote.
+        // A doc with only local images (`![logo](./logo.png)`) would hit
+        // the scheme filter inside the loop and skip everything — no point
+        // paying thread-startup cost for that case.
+        var has_remote = false;
+        for (collector.urls.items) |u| {
+            if (bun.strings.startsWith(u, "http://") or bun.strings.startsWith(u, "https://")) {
+                has_remote = true;
+                break;
+            }
+        }
+        if (!has_remote) return;
+
         const HTTP = bun.http;
         HTTP.HTTPThread.init(&.{});
 

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1416,14 +1416,15 @@ pub const RunCommand = struct {
         var base_buf: bun.PathBuffer = undefined;
         var cwd_buf: bun.PathBuffer = undefined;
         const abs_md_path: []const u8 = blk: {
-            if (std.fs.path.isAbsolute(path)) break :blk path;
+            if (bun.path.isAbsolute(.auto, path)) break :blk path;
             const cwd = switch (bun.sys.getcwd(&cwd_buf)) {
                 .result => |c| c,
                 .err => break :blk path,
             };
             break :blk bun.path.joinAbsStringBuf(cwd, &base_buf, &.{path}, .auto);
         };
-        const image_base_dir = std.fs.path.dirname(abs_md_path) orelse abs_md_path;
+        const dir = bun.path.dirname(abs_md_path, .auto);
+        const image_base_dir = if (dir.len > 0) dir else abs_md_path;
 
         const theme: bun.md.AnsiTheme = .{
             .light = bun.md.detectLightBackground(),

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1345,15 +1345,31 @@ pub const RunCommand = struct {
                 allocator.free(path);
                 continue;
             }
-            out_map.put(allocator, raw_url, path) catch {
-                // Map insert OOM'd after a successful write — unlink
-                // the now-orphaned temp file so it doesn't leak.
+            // Dupe raw_url for the map key — `collector.urls.items`
+            // owns raw_url, and `defer collector.deinit()` frees it
+            // when this function returns, leaving out_map with dangling
+            // keys that emitImage() would later hash-compare.
+            const key = allocator.dupe(u8, raw_url) catch {
                 const z = allocator.dupeZ(u8, path) catch {
                     allocator.free(path);
                     continue;
                 };
                 _ = bun.sys.unlink(z);
                 allocator.free(z);
+                allocator.free(path);
+                continue;
+            };
+            out_map.put(allocator, key, path) catch {
+                // Map insert OOM'd after a successful write — unlink
+                // the now-orphaned temp file so it doesn't leak.
+                const z = allocator.dupeZ(u8, path) catch {
+                    allocator.free(key);
+                    allocator.free(path);
+                    continue;
+                };
+                _ = bun.sys.unlink(z);
+                allocator.free(z);
+                allocator.free(key);
                 allocator.free(path);
                 continue;
             };

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1244,7 +1244,7 @@ pub const RunCommand = struct {
     fn prefetchRemoteImages(
         contents: []const u8,
         md_opts: bun.md.Options,
-        out_map: *std.StringHashMapUnmanaged([]const u8),
+        out_map: *bun.StringHashMapUnmanaged([]const u8),
     ) void {
         const allocator = bun.default_allocator;
         var collector = bun.md.ImageUrlCollector.init(allocator);
@@ -1270,7 +1270,7 @@ pub const RunCommand = struct {
 
         const tmpdir = bun.fs.FileSystem.RealFS.tmpdirPath();
         // Guard against the same URL appearing twice: only download once.
-        var seen = std.StringHashMapUnmanaged(void){};
+        var seen = bun.StringHashMapUnmanaged(void){};
         defer seen.deinit(allocator);
 
         for (collector.urls.items) |raw_url| {
@@ -1403,7 +1403,7 @@ pub const RunCommand = struct {
         // inline. Only runs when kitty_graphics is on and the document
         // actually contains an image marker — otherwise the whole block
         // is a no-op.
-        var remote_map: std.StringHashMapUnmanaged([]const u8) = .{};
+        var remote_map: bun.StringHashMapUnmanaged([]const u8) = .{};
         if (kitty_graphics and bun.strings.contains(contents, "![")) {
             prefetchRemoteImages(contents, md_opts, &remote_map);
         }

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1459,19 +1459,14 @@ pub const RunCommand = struct {
 
         Output.writer().writeAll(rendered) catch {};
         Output.flush();
-        // Unlink the temp files prefetchRemoteImages() wrote. Flush
-        // above guarantees the APC sequences referencing these paths
-        // have left this process for the terminal; Kitty reads the
-        // file synchronously when it receives the APC, so an unlink
-        // now is safe.
-        if (remote_map.count() > 0) {
-            var it = remote_map.valueIterator();
-            while (it.next()) |tmp_path| {
-                const z = bun.default_allocator.dupeZ(u8, tmp_path.*) catch continue;
-                _ = bun.sys.unlink(z);
-                bun.default_allocator.free(z);
-            }
-        }
+        // Temp files prefetchRemoteImages() wrote are deliberately NOT
+        // unlinked here. Output.flush() only guarantees the APC bytes
+        // reached the terminal's PTY ring buffer — Kitty reads the file
+        // asynchronously from its own event loop, so unlinking inside
+        // this process races Kitty's open() and typically drops images
+        // silently (q=2 suppresses the error). System tmp cleanup
+        // (systemd-tmpfiles, /tmp reboot wipe) eventually removes the
+        // bun-md-*.png files, which are small (~100KB each) and rare.
         Global.exit(0);
     }
 

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1416,7 +1416,7 @@ pub const RunCommand = struct {
         var base_buf: bun.PathBuffer = undefined;
         var cwd_buf: bun.PathBuffer = undefined;
         const abs_md_path: []const u8 = blk: {
-            if (bun.path.isAbsolute(.auto, path)) break :blk path;
+            if (std.fs.path.isAbsolute(path)) break :blk path;
             const cwd = switch (bun.sys.getcwd(&cwd_buf)) {
                 .result => |c| c,
                 .err => break :blk path,

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1237,7 +1237,73 @@ pub const RunCommand = struct {
         Output.flush();
     }
 
+    /// Read a markdown file, render it to ANSI, print to stdout, and exit.
+    /// Runs without a JavaScript VM — much faster than booting JSC.
+    fn renderMarkdownFileAndExit(path: string) noreturn {
+        const contents = switch (bun.sys.File.readFrom(bun.FD.cwd(), path, bun.default_allocator)) {
+            .result => |bytes| bytes,
+            .err => |err| {
+                Output.prettyErrorln("<r><red>error<r>: {f}", .{err});
+                Output.flush();
+                Global.exit(1);
+            },
+        };
+        defer bun.default_allocator.free(contents);
+
+        // Theme selection: colors when stdout is a TTY (or forced on),
+        // hyperlinks when colors are on. Light/dark detected from env.
+        const colors = Output.enable_ansi_colors_stdout;
+        const columns: u16 = brk: {
+            const c = Output.terminal_size.col;
+            if (c == 0) break :brk 80;
+            break :brk @min(c, 120);
+        };
+        const theme: bun.md.AnsiTheme = .{
+            .light = bun.md.detectLightBackground(),
+            .columns = columns,
+            .colors = colors,
+            .hyperlinks = colors and Output.isStdoutTTY(),
+        };
+
+        // Terminal rendering enables every syntax we can display nicely —
+        // GFM baseline plus wikilinks, underline, and LaTeX math passthrough.
+        const md_opts: bun.md.Options = .{
+            .tables = true,
+            .strikethrough = true,
+            .tasklists = true,
+            .permissive_url_autolinks = true,
+            .permissive_www_autolinks = true,
+            .permissive_email_autolinks = true,
+            .wiki_links = true,
+            .underline = true,
+            .latex_math = true,
+        };
+        const rendered = bun.md.renderToAnsi(
+            contents,
+            bun.default_allocator,
+            md_opts,
+            theme,
+        ) catch {
+            Output.prettyErrorln("<r><red>error<r>: failed to render markdown", .{});
+            Output.flush();
+            Global.exit(1);
+        } orelse {
+            Output.prettyErrorln("<r><red>error<r>: failed to render markdown", .{});
+            Output.flush();
+            Global.exit(1);
+        };
+        defer bun.default_allocator.free(rendered);
+
+        Output.writer().writeAll(rendered) catch {};
+        Output.flush();
+        Global.exit(0);
+    }
+
     fn _bootAndHandleError(ctx: Command.Context, path: string, loader: ?bun.options.Loader) bool {
+        const resolved_loader: ?bun.options.Loader = loader orelse bun.options.defaultLoaders.get(std.fs.path.extension(path));
+        if (resolved_loader) |l| {
+            if (l == .md) renderMarkdownFileAndExit(path);
+        }
         Global.configureAllocator(.{ .long_running = true });
         Run.boot(ctx, ctx.allocator.dupe(u8, path) catch return false, loader) catch |err| {
             ctx.log.print(Output.errorWriter()) catch {};
@@ -1358,7 +1424,7 @@ pub const RunCommand = struct {
         } else if (cfg.allow_fast_run_for_extensions) {
             const ext = std.fs.path.extension(target_name);
             const default_loader = options.defaultLoaders.get(ext);
-            if (default_loader != null and default_loader.?.canBeRunByBun()) {
+            if (default_loader != null and (default_loader.?.canBeRunByBun() or default_loader.? == .md)) {
                 try_fast_run = true;
             }
         }
@@ -1519,7 +1585,7 @@ pub const RunCommand = struct {
             var resolved_mutable = resolved;
             const path = resolved_mutable.path().?;
             const loader: bun.options.Loader = this_transpiler.options.loaders.get(path.name.ext) orelse .tsx;
-            if (loader.canBeRunByBun() or loader == .html) {
+            if (loader.canBeRunByBun() or loader == .html or loader == .md) {
                 log("Resolved to: `{s}`", .{path.text});
                 return _bootAndHandleError(ctx, path.text, loader);
             } else {

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1335,13 +1335,10 @@ pub const RunCommand = struct {
             if (!ok) {
                 // The file was created by openA + TRUNC, so even a
                 // zero-byte write leaves an orphan on disk. Unlink
-                // before dropping the path string.
-                const z = allocator.dupeZ(u8, path) catch {
-                    allocator.free(path);
-                    continue;
-                };
-                _ = bun.sys.unlink(z);
-                allocator.free(z);
+                // before dropping the path string. Uses a stack buffer
+                // for the null-terminated path so the unlink doesn't
+                // depend on a second allocation (which could also OOM).
+                unlinkStagedPath(path);
                 allocator.free(path);
                 continue;
             }
@@ -1350,30 +1347,32 @@ pub const RunCommand = struct {
             // when this function returns, leaving out_map with dangling
             // keys that emitImage() would later hash-compare.
             const key = allocator.dupe(u8, raw_url) catch {
-                const z = allocator.dupeZ(u8, path) catch {
-                    allocator.free(path);
-                    continue;
-                };
-                _ = bun.sys.unlink(z);
-                allocator.free(z);
+                unlinkStagedPath(path);
                 allocator.free(path);
                 continue;
             };
             out_map.put(allocator, key, path) catch {
                 // Map insert OOM'd after a successful write — unlink
                 // the now-orphaned temp file so it doesn't leak.
-                const z = allocator.dupeZ(u8, path) catch {
-                    allocator.free(key);
-                    allocator.free(path);
-                    continue;
-                };
-                _ = bun.sys.unlink(z);
-                allocator.free(z);
+                unlinkStagedPath(path);
                 allocator.free(key);
                 allocator.free(path);
                 continue;
             };
         }
+    }
+
+    /// Null-terminate `path` on the stack and unlink it. Never allocates,
+    /// so temp-file cleanup can't fail for OOM reasons. Silently skips
+    /// paths too long to fit in PathBuffer — `prefetchRemoteImages`
+    /// generates paths of the form `{tmpdir}/bun-md-{hex8}{ext}` so this
+    /// bound is never hit in practice.
+    fn unlinkStagedPath(path: []const u8) void {
+        var buf: bun.PathBuffer = undefined;
+        if (path.len + 1 > buf.len) return;
+        @memcpy(buf[0..path.len], path);
+        buf[path.len] = 0;
+        _ = bun.sys.unlink(buf[0..path.len :0]);
     }
 
     /// Read a markdown file, render it to ANSI, print to stdout, and exit.

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1241,6 +1241,31 @@ pub const RunCommand = struct {
     /// http(s) image URL it finds to a temp file, and populate `out_map`
     /// with url → temp-path entries. Failures are silent — an image that
     /// can't be downloaded just falls back to alt-text rendering.
+    /// One pending remote-image download. Lives on the heap so its
+    /// `async_http.task` (embedded in ThreadPool.Task) has a stable
+    /// address — HTTPThread.schedule does @fieldParentPtr on that task,
+    /// so moving the struct would break the worker's callback.
+    const RemoteImageDownload = struct {
+        async_http: bun.http.AsyncHTTP = undefined,
+        response_buffer: bun.MutableString,
+        url: []const u8,
+        done: *DoneChannel,
+
+        const DoneChannel = bun.threading.Channel(u32, .{ .Static = 256 });
+
+        fn onDone(self: *RemoteImageDownload, async_http: *bun.http.AsyncHTTP, _: bun.http.HTTPClientResult) void {
+            // Mirror sendSyncCallback from AsyncHTTP.zig: the worker's
+            // ThreadlocalAsyncHTTP is about to be freed, so copy its
+            // mutated state back into our owned AsyncHTTP before writing
+            // to the channel.
+            async_http.real.?.* = async_http.*;
+            async_http.real.?.response_buffer = async_http.response_buffer;
+            // Channel payload is a placeholder tick — the main thread
+            // walks `downloads[]` to read per-task state after N wakeups.
+            self.done.writeItem(0) catch {};
+        }
+    };
+
     fn prefetchRemoteImages(
         contents: []const u8,
         md_opts: bun.md.Options,
@@ -1252,57 +1277,98 @@ pub const RunCommand = struct {
         bun.md.renderWithRenderer(contents, allocator, md_opts, collector.renderer()) catch return;
         if (collector.urls.items.len == 0) return;
 
-        // Only spawn the HTTP worker thread if at least one URL is remote.
-        // A doc with only local images (`![logo](./logo.png)`) would hit
-        // the scheme filter inside the loop and skip everything — no point
-        // paying thread-startup cost for that case.
-        var has_remote = false;
+        // Walk the collected URLs once, deduping and picking out the
+        // http(s) ones. If there are no remote URLs we never spawn the
+        // HTTP worker or allocate any Download structs.
+        var seen = bun.StringHashMapUnmanaged(void){};
+        defer seen.deinit(allocator);
+        var remote_urls = std.ArrayListUnmanaged([]const u8){};
+        defer remote_urls.deinit(allocator);
         for (collector.urls.items) |u| {
-            if (bun.strings.startsWith(u, "http://") or bun.strings.startsWith(u, "https://")) {
-                has_remote = true;
-                break;
-            }
+            if (!bun.strings.startsWith(u, "http://") and
+                !bun.strings.startsWith(u, "https://")) continue;
+            const gop = seen.getOrPut(allocator, u) catch continue;
+            if (gop.found_existing) continue;
+            remote_urls.append(allocator, u) catch continue;
         }
-        if (!has_remote) return;
+        if (remote_urls.items.len == 0) return;
 
         const HTTP = bun.http;
         HTTP.HTTPThread.init(&.{});
 
-        const tmpdir = bun.fs.FileSystem.RealFS.tmpdirPath();
-        // Guard against the same URL appearing twice: only download once.
-        var seen = bun.StringHashMapUnmanaged(void){};
-        defer seen.deinit(allocator);
+        // Heap-allocate each Download so AsyncHTTP.task has a stable
+        // address (see RemoteImageDownload doc comment).
+        var downloads = std.ArrayListUnmanaged(*RemoteImageDownload){};
+        defer {
+            for (downloads.items) |d| {
+                d.response_buffer.deinit();
+                allocator.destroy(d);
+            }
+            downloads.deinit(allocator);
+        }
 
-        for (collector.urls.items) |raw_url| {
-            if (!bun.strings.startsWith(raw_url, "http://") and
-                !bun.strings.startsWith(raw_url, "https://")) continue;
-            const gop = seen.getOrPut(allocator, raw_url) catch continue;
-            if (gop.found_existing) continue;
+        var done_channel = RemoteImageDownload.DoneChannel.init();
 
-            const parsed_url = bun.URL.parse(raw_url);
-            var response_buffer = bun.MutableString.init(allocator, 8 * 1024) catch continue;
-            defer response_buffer.deinit();
-
-            var async_http = HTTP.AsyncHTTP.initSync(
+        // Kick off every download in parallel. Accumulate tasks into a
+        // single ThreadPool.Batch, then ship the whole batch to the
+        // HTTP thread in one schedule() call — worker picks up and runs
+        // them concurrently.
+        var batch = bun.ThreadPool.Batch{};
+        for (remote_urls.items) |raw_url| {
+            const d = allocator.create(RemoteImageDownload) catch continue;
+            d.* = .{
+                .response_buffer = bun.MutableString.init(allocator, 8 * 1024) catch {
+                    allocator.destroy(d);
+                    continue;
+                },
+                .url = raw_url,
+                .done = &done_channel,
+            };
+            d.async_http = HTTP.AsyncHTTP.init(
                 allocator,
                 .GET,
-                parsed_url,
+                bun.URL.parse(raw_url),
                 .{},
                 "",
-                &response_buffer,
+                &d.response_buffer,
                 "",
-                null,
-                null,
+                HTTP.HTTPClientResult.Callback.New(*RemoteImageDownload, RemoteImageDownload.onDone).init(d),
                 HTTP.FetchRedirect.follow,
+                .{},
             );
-            const resp = async_http.sendSync() catch continue;
-            if (resp.status_code != 200) continue;
-            const bytes = response_buffer.slice();
+            downloads.append(allocator, d) catch {
+                d.response_buffer.deinit();
+                allocator.destroy(d);
+                continue;
+            };
+            d.async_http.schedule(allocator, &batch);
+        }
+        if (downloads.items.len == 0) return;
+        HTTP.http_thread.schedule(batch);
+
+        // Block the main thread on the channel until every scheduled
+        // download has reported back. readItem() uses a mutex+condvar,
+        // no busy loop. The payload value is unused — each wakeup just
+        // means "one more task finished".
+        var completed: usize = 0;
+        while (completed < downloads.items.len) : (completed += 1) {
+            _ = done_channel.readItem() catch break;
+        }
+
+        // Second pass: walk completed downloads, write successful
+        // bodies to temp files, populate out_map. All disk I/O is done
+        // AFTER every network request has settled.
+        const tmpdir = bun.fs.FileSystem.RealFS.tmpdirPath();
+        for (downloads.items) |d| {
+            if (d.async_http.err != null) continue;
+            const status = if (d.async_http.response) |r| r.status_code else 0;
+            if (status != 200) continue;
+            const bytes = d.response_buffer.slice();
             if (bytes.len == 0) continue;
 
             // Extension is best-effort from the URL path; Kitty inspects
             // the file's magic bytes regardless.
-            const ext: []const u8 = if (bun.strings.endsWith(raw_url, ".png")) ".png" else if (bun.strings.endsWith(raw_url, ".jpg") or bun.strings.endsWith(raw_url, ".jpeg")) ".jpg" else if (bun.strings.endsWith(raw_url, ".gif")) ".gif" else if (bun.strings.endsWith(raw_url, ".webp")) ".webp" else ".bin";
+            const ext: []const u8 = if (bun.strings.endsWith(d.url, ".png")) ".png" else if (bun.strings.endsWith(d.url, ".jpg") or bun.strings.endsWith(d.url, ".jpeg")) ".jpg" else if (bun.strings.endsWith(d.url, ".gif")) ".gif" else if (bun.strings.endsWith(d.url, ".webp")) ".webp" else ".bin";
             var name_buf: [64]u8 = undefined;
             const name = std.fmt.bufPrint(&name_buf, "bun-md-{x}{s}", .{ bun.fastRandom(), ext }) catch continue;
             const path = std.fmt.allocPrint(allocator, "{s}/{s}", .{ tmpdir, name }) catch continue;
@@ -1333,27 +1399,23 @@ pub const RunCommand = struct {
             }
             fd.close();
             if (!ok) {
-                // The file was created by openA + TRUNC, so even a
-                // zero-byte write leaves an orphan on disk. Unlink
-                // before dropping the path string. Uses a stack buffer
-                // for the null-terminated path so the unlink doesn't
-                // depend on a second allocation (which could also OOM).
+                // openA + TRUNC leaves an orphan even on zero-byte
+                // write failure. Unlink via stack buffer so cleanup
+                // can't fail for OOM reasons.
                 unlinkStagedPath(path);
                 allocator.free(path);
                 continue;
             }
-            // Dupe raw_url for the map key — `collector.urls.items`
-            // owns raw_url, and `defer collector.deinit()` frees it
-            // when this function returns, leaving out_map with dangling
-            // keys that emitImage() would later hash-compare.
-            const key = allocator.dupe(u8, raw_url) catch {
+            // Dupe d.url for the map key — `collector.urls.items` owns
+            // the backing bytes and gets freed by `defer collector.deinit()`
+            // when this function returns, which would leave out_map with
+            // dangling keys that emitImage() would later hash-compare.
+            const key = allocator.dupe(u8, d.url) catch {
                 unlinkStagedPath(path);
                 allocator.free(path);
                 continue;
             };
             out_map.put(allocator, key, path) catch {
-                // Map insert OOM'd after a successful write — unlink
-                // the now-orphaned temp file so it doesn't leak.
                 unlinkStagedPath(path);
                 allocator.free(key);
                 allocator.free(path);

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1240,6 +1240,9 @@ pub const RunCommand = struct {
     /// Read a markdown file, render it to ANSI, print to stdout, and exit.
     /// Runs without a JavaScript VM — much faster than booting JSC.
     fn renderMarkdownFileAndExit(path: string) noreturn {
+        // No explicit free() on contents / rendered below: every path out
+        // of this function calls Global.exit() or bun.outOfMemory() (both
+        // noreturn), so the OS reclaims the allocations on process exit.
         const contents = switch (bun.sys.File.readFrom(bun.FD.cwd(), path, bun.default_allocator)) {
             .result => |bytes| bytes,
             .err => |err| {
@@ -1248,7 +1251,6 @@ pub const RunCommand = struct {
                 Global.exit(1);
             },
         };
-        defer bun.default_allocator.free(contents);
 
         // Theme selection: colors when stdout is a TTY (or forced on),
         // hyperlinks when colors are on. Light/dark detected from env.
@@ -1296,7 +1298,6 @@ pub const RunCommand = struct {
             Output.flush();
             Global.exit(1);
         };
-        defer bun.default_allocator.free(rendered);
 
         Output.writer().writeAll(rendered) catch {};
         Output.flush();

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1255,8 +1255,7 @@ pub const RunCommand = struct {
         const colors = Output.enable_ansi_colors_stdout;
         const columns: u16 = brk: {
             const c = Output.terminal_size.col;
-            if (c == 0) break :brk 80;
-            break :brk @min(c, 120);
+            break :brk if (c == 0) 80 else c;
         };
         const theme: bun.md.AnsiTheme = .{
             .light = bun.md.detectLightBackground(),

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1257,11 +1257,13 @@ pub const RunCommand = struct {
             const c = Output.terminal_size.col;
             break :brk if (c == 0) 80 else c;
         };
+        const is_tty = Output.isStdoutTTY();
         const theme: bun.md.AnsiTheme = .{
             .light = bun.md.detectLightBackground(),
             .columns = columns,
             .colors = colors,
-            .hyperlinks = colors and Output.isStdoutTTY(),
+            .hyperlinks = colors and is_tty,
+            .kitty_graphics = colors and is_tty and bun.md.detectKittyGraphics(),
         };
 
         // Terminal rendering enables every syntax we can display nicely —

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1237,6 +1237,99 @@ pub const RunCommand = struct {
         Output.flush();
     }
 
+    /// Parse `contents` once with an ImageUrlCollector, download every
+    /// http(s) image URL it finds to a temp file, and populate `out_map`
+    /// with url → temp-path entries. Failures are silent — an image that
+    /// can't be downloaded just falls back to alt-text rendering.
+    fn prefetchRemoteImages(
+        contents: []const u8,
+        md_opts: bun.md.Options,
+        out_map: *std.StringHashMapUnmanaged([]const u8),
+    ) void {
+        const allocator = bun.default_allocator;
+        var collector = bun.md.ImageUrlCollector.init(allocator);
+        defer collector.deinit();
+        bun.md.renderWithRenderer(contents, allocator, md_opts, collector.renderer()) catch return;
+        if (collector.urls.items.len == 0) return;
+
+        const HTTP = bun.http;
+        HTTP.HTTPThread.init(&.{});
+
+        const tmpdir = bun.fs.FileSystem.RealFS.tmpdirPath();
+        // Guard against the same URL appearing twice: only download once.
+        var seen = std.StringHashMapUnmanaged(void){};
+        defer seen.deinit(allocator);
+
+        for (collector.urls.items) |raw_url| {
+            if (!bun.strings.startsWith(raw_url, "http://") and
+                !bun.strings.startsWith(raw_url, "https://")) continue;
+            const gop = seen.getOrPut(allocator, raw_url) catch continue;
+            if (gop.found_existing) continue;
+
+            const parsed_url = bun.URL.parse(raw_url);
+            var response_buffer = bun.MutableString.init(allocator, 8 * 1024) catch continue;
+            defer response_buffer.deinit();
+
+            var async_http = HTTP.AsyncHTTP.initSync(
+                allocator,
+                .GET,
+                parsed_url,
+                .{},
+                "",
+                &response_buffer,
+                "",
+                null,
+                null,
+                HTTP.FetchRedirect.follow,
+            );
+            const resp = async_http.sendSync() catch continue;
+            if (resp.status_code != 200) continue;
+            const bytes = response_buffer.slice();
+            if (bytes.len == 0) continue;
+
+            // Extension is best-effort from the URL path; Kitty inspects
+            // the file's magic bytes regardless.
+            const ext: []const u8 = if (bun.strings.endsWithAny(raw_url, ".png")) ".png" else if (bun.strings.endsWithAny(raw_url, ".jpg") or bun.strings.endsWithAny(raw_url, ".jpeg")) ".jpg" else if (bun.strings.endsWithAny(raw_url, ".gif")) ".gif" else if (bun.strings.endsWithAny(raw_url, ".webp")) ".webp" else ".bin";
+            var name_buf: [64]u8 = undefined;
+            const name = std.fmt.bufPrint(&name_buf, "bun-md-{x}{s}", .{ bun.fastRandom(), ext }) catch continue;
+            const path = std.fmt.allocPrint(allocator, "{s}/{s}", .{ tmpdir, name }) catch continue;
+
+            const fd = switch (bun.sys.openA(path, bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o600)) {
+                .result => |f| f,
+                .err => {
+                    allocator.free(path);
+                    continue;
+                },
+            };
+            var written: usize = 0;
+            var ok = true;
+            while (written < bytes.len) {
+                switch (bun.sys.write(fd, bytes[written..])) {
+                    .result => |n| {
+                        if (n == 0) {
+                            ok = false;
+                            break;
+                        }
+                        written += n;
+                    },
+                    .err => {
+                        ok = false;
+                        break;
+                    },
+                }
+            }
+            fd.close();
+            if (!ok) {
+                allocator.free(path);
+                continue;
+            }
+            out_map.put(allocator, raw_url, path) catch {
+                allocator.free(path);
+                continue;
+            };
+        }
+    }
+
     /// Read a markdown file, render it to ANSI, print to stdout, and exit.
     /// Runs without a JavaScript VM — much faster than booting JSC.
     fn renderMarkdownFileAndExit(path: string) noreturn {
@@ -1260,13 +1353,7 @@ pub const RunCommand = struct {
             break :brk if (c == 0) 80 else c;
         };
         const is_tty = Output.isStdoutTTY();
-        const theme: bun.md.AnsiTheme = .{
-            .light = bun.md.detectLightBackground(),
-            .columns = columns,
-            .colors = colors,
-            .hyperlinks = colors and is_tty,
-            .kitty_graphics = colors and is_tty and bun.md.detectKittyGraphics(),
-        };
+        const kitty_graphics = colors and is_tty and bun.md.detectKittyGraphics();
 
         // Terminal rendering enables every syntax we can display nicely —
         // GFM baseline plus wikilinks, underline, and LaTeX math passthrough.
@@ -1281,6 +1368,25 @@ pub const RunCommand = struct {
             .underline = true,
             .latex_math = true,
         };
+
+        // Pre-scan for http(s) image URLs so Kitty can display them
+        // inline. Only runs when kitty_graphics is on and the document
+        // actually contains an image marker — otherwise the whole block
+        // is a no-op.
+        var remote_map: std.StringHashMapUnmanaged([]const u8) = .{};
+        if (kitty_graphics and bun.strings.contains(contents, "![")) {
+            prefetchRemoteImages(contents, md_opts, &remote_map);
+        }
+
+        const theme: bun.md.AnsiTheme = .{
+            .light = bun.md.detectLightBackground(),
+            .columns = columns,
+            .colors = colors,
+            .hyperlinks = colors and is_tty,
+            .kitty_graphics = kitty_graphics,
+            .remote_image_paths = if (remote_map.count() > 0) &remote_map else null,
+        };
+
         const rendered = bun.md.renderToAnsi(
             contents,
             bun.default_allocator,

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1320,10 +1320,27 @@ pub const RunCommand = struct {
             }
             fd.close();
             if (!ok) {
+                // The file was created by openA + TRUNC, so even a
+                // zero-byte write leaves an orphan on disk. Unlink
+                // before dropping the path string.
+                const z = allocator.dupeZ(u8, path) catch {
+                    allocator.free(path);
+                    continue;
+                };
+                _ = bun.sys.unlink(z);
+                allocator.free(z);
                 allocator.free(path);
                 continue;
             }
             out_map.put(allocator, raw_url, path) catch {
+                // Map insert OOM'd after a successful write — unlink
+                // the now-orphaned temp file so it doesn't leak.
+                const z = allocator.dupeZ(u8, path) catch {
+                    allocator.free(path);
+                    continue;
+                };
+                _ = bun.sys.unlink(z);
+                allocator.free(z);
                 allocator.free(path);
                 continue;
             };

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1424,7 +1424,10 @@ pub const RunCommand = struct {
             break :blk bun.path.joinAbsStringBuf(cwd, &base_buf, &.{path}, .auto);
         };
         const dir = bun.path.dirname(abs_md_path, .auto);
-        const image_base_dir = if (dir.len > 0) dir else abs_md_path;
+        // When dirname returns empty (bare filename + getcwd failed), fall
+        // back to "." instead of abs_md_path — otherwise joinAbsString
+        // downstream would treat the file path itself as a directory.
+        const image_base_dir = if (dir.len > 0) dir else ".";
 
         const theme: bun.md.AnsiTheme = .{
             .light = bun.md.detectLightBackground(),

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1456,8 +1456,29 @@ pub const RunCommand = struct {
         // hyperlinks when colors are on. Light/dark detected from env.
         const colors = Output.enable_ansi_colors_stdout;
         const columns: u16 = brk: {
-            const c = Output.terminal_size.col;
-            break :brk if (c == 0) 80 else c;
+            // Output.terminal_size is never populated; query stdout
+            // directly. Honor COLUMNS so piped output and tests can
+            // pin a width.
+            if (bun.getenvZ("COLUMNS")) |env| {
+                if (std.fmt.parseInt(u16, env, 10) catch null) |n| {
+                    if (n > 0) break :brk n;
+                }
+            }
+            if (comptime bun.Environment.isPosix) {
+                var size: std.posix.winsize = undefined;
+                if (std.posix.system.ioctl(std.posix.STDOUT_FILENO, std.posix.T.IOCGWINSZ, @intFromPtr(&size)) == 0) {
+                    if (size.col > 0) break :brk size.col;
+                }
+            } else if (comptime bun.Environment.isWindows) {
+                if (windows.GetStdHandle(windows.STD_OUTPUT_HANDLE) catch null) |handle| {
+                    var csbi: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
+                    if (windows.kernel32.GetConsoleScreenBufferInfo(handle, &csbi) != windows.FALSE) {
+                        const w = csbi.srWindow.Right - csbi.srWindow.Left + 1;
+                        if (w > 0) break :brk @intCast(w);
+                    }
+                }
+            }
+            break :brk 80;
         };
         const is_tty = Output.isStdoutTTY();
         const kitty_graphics = colors and is_tty and bun.md.detectKittyGraphics();

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1237,10 +1237,6 @@ pub const RunCommand = struct {
         Output.flush();
     }
 
-    /// Parse `contents` once with an ImageUrlCollector, download every
-    /// http(s) image URL it finds to a temp file, and populate `out_map`
-    /// with url → temp-path entries. Failures are silent — an image that
-    /// can't be downloaded just falls back to alt-text rendering.
     /// One pending remote-image download. Lives on the heap so its
     /// `async_http.task` (embedded in ThreadPool.Task) has a stable
     /// address — HTTPThread.schedule does @fieldParentPtr on that task,
@@ -1270,6 +1266,10 @@ pub const RunCommand = struct {
         }
     };
 
+    /// Parse `contents` once with an ImageUrlCollector, download every
+    /// http(s) image URL it finds to a temp file, and populate `out_map`
+    /// with url → temp-path entries. Failures are silent — an image that
+    /// can't be downloaded just falls back to alt-text rendering.
     fn prefetchRemoteImages(
         contents: []const u8,
         md_opts: bun.md.Options,
@@ -1289,8 +1289,8 @@ pub const RunCommand = struct {
         var remote_urls = std.ArrayListUnmanaged([]const u8){};
         defer remote_urls.deinit(allocator);
         for (collector.urls.items) |u| {
-            if (!bun.strings.startsWith(u, "http://") and
-                !bun.strings.startsWith(u, "https://")) continue;
+            if (!bun.strings.hasPrefixComptime(u, "http://") and
+                !bun.strings.hasPrefixComptime(u, "https://")) continue;
             const gop = seen.getOrPut(allocator, u) catch continue;
             if (gop.found_existing) continue;
             remote_urls.append(allocator, u) catch continue;
@@ -1385,23 +1385,7 @@ pub const RunCommand = struct {
                     continue;
                 },
             };
-            var written: usize = 0;
-            var ok = true;
-            while (written < bytes.len) {
-                switch (bun.sys.write(fd, bytes[written..])) {
-                    .result => |n| {
-                        if (n == 0) {
-                            ok = false;
-                            break;
-                        }
-                        written += n;
-                    },
-                    .err => {
-                        ok = false;
-                        break;
-                    },
-                }
-            }
+            const ok = (bun.sys.File{ .handle = fd }).writeAll(bytes) == .result;
             fd.close();
             if (!ok) {
                 // openA + TRUNC leaves an orphan even on zero-byte
@@ -1429,17 +1413,10 @@ pub const RunCommand = struct {
         }
     }
 
-    /// Null-terminate `path` on the stack and unlink it. Never allocates,
-    /// so temp-file cleanup can't fail for OOM reasons. Silently skips
-    /// paths too long to fit in PathBuffer — `prefetchRemoteImages`
-    /// generates paths of the form `{tmpdir}/bun-md-{hex8}{ext}` so this
-    /// bound is never hit in practice.
+    /// Null-terminate `path` on the stack and unlink it. Never allocates.
     fn unlinkStagedPath(path: []const u8) void {
         var buf: bun.PathBuffer = undefined;
-        if (path.len + 1 > buf.len) return;
-        @memcpy(buf[0..path.len], path);
-        buf[path.len] = 0;
-        _ = bun.sys.unlink(buf[0..path.len :0]);
+        _ = bun.sys.unlink(bun.path.z(path, &buf));
     }
 
     /// Read a markdown file, render it to ANSI, print to stdout, and exit.
@@ -1488,19 +1465,7 @@ pub const RunCommand = struct {
         const is_tty = Output.isStdoutTTY();
         const kitty_graphics = colors and is_tty and bun.md.detectKittyGraphics();
 
-        // Terminal rendering enables every syntax we can display nicely —
-        // GFM baseline plus wikilinks, underline, and LaTeX math passthrough.
-        const md_opts: bun.md.Options = .{
-            .tables = true,
-            .strikethrough = true,
-            .tasklists = true,
-            .permissive_url_autolinks = true,
-            .permissive_www_autolinks = true,
-            .permissive_email_autolinks = true,
-            .wiki_links = true,
-            .underline = true,
-            .latex_math = true,
-        };
+        const md_opts: bun.md.Options = .terminal;
 
         // Pre-scan for http(s) image URLs so Kitty can display them
         // inline. Only runs when kitty_graphics is on and the document

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1410,6 +1410,162 @@ pub const AnsiRenderer = struct {
         self.table_rows.clearRetainingCapacity();
     }
 
+    /// ANSI state active at a given byte offset inside a cell's buffer.
+    /// Tracked so a cell that wraps mid-span can re-emit the same opens
+    /// on the continuation segment AND close any open OSC 8 link before
+    /// the border character — `\x1b[0m` doesn't terminate OSC 8.
+    const CellAnsiState = struct {
+        flags: u8 = 0,
+        fg: ?[]const u8 = null,
+        bg: ?[]const u8 = null,
+        link: ?[]const u8 = null,
+
+        const BOLD: u8 = 1 << 0;
+        const ITALIC: u8 = 1 << 1;
+        const UNDERLINE: u8 = 1 << 2;
+        const STRIKE: u8 = 1 << 3;
+
+        fn hasAny(self: CellAnsiState) bool {
+            return self.flags != 0 or self.fg != null or self.bg != null or self.link != null;
+        }
+
+        fn emitOpens(self: CellAnsiState, out: *OutputBuffer) void {
+            if (self.flags & BOLD != 0) out.write("\x1b[1m");
+            if (self.flags & ITALIC != 0) out.write("\x1b[3m");
+            if (self.flags & UNDERLINE != 0) out.write("\x1b[4m");
+            if (self.flags & STRIKE != 0) out.write("\x1b[9m");
+            if (self.fg) |f| out.write(f);
+            if (self.bg) |b| out.write(b);
+            if (self.link) |l| out.write(l);
+        }
+
+        fn emitCloses(self: CellAnsiState, out: *OutputBuffer) void {
+            if (self.hasAny()) out.write("\x1b[0m");
+            if (self.link != null) out.write("\x1b]8;;\x1b\\");
+        }
+
+        /// Walk `bytes` forward, updating `self` to reflect any SGR and
+        /// OSC 8 toggles encountered. Unrecognized escapes are skipped.
+        fn scan(self: *CellAnsiState, bytes: []const u8) void {
+            var i: usize = 0;
+            while (i < bytes.len) {
+                if (bytes[i] != 0x1b) {
+                    i += 1;
+                    continue;
+                }
+                if (i + 1 >= bytes.len) return;
+                if (bytes[i + 1] == '[') {
+                    // CSI ... m (SGR). Scan until final byte.
+                    const seq_start = i;
+                    var j = i + 2;
+                    while (j < bytes.len) : (j += 1) {
+                        const c = bytes[j];
+                        if ((c >= 0x40 and c <= 0x7e) and c != ';') break;
+                    }
+                    if (j >= bytes.len) return;
+                    if (bytes[j] == 'm') {
+                        const seq = bytes[seq_start .. j + 1];
+                        const params = bytes[seq_start + 2 .. j];
+                        self.applySgr(seq, params);
+                    }
+                    i = j + 1;
+                    continue;
+                }
+                if (bytes[i + 1] == ']') {
+                    // OSC. Scan until ST (\x1b\\) or BEL (\x07).
+                    const seq_start = i;
+                    var j = i + 2;
+                    while (j < bytes.len) : (j += 1) {
+                        if (bytes[j] == 0x07) {
+                            j += 1;
+                            break;
+                        }
+                        if (bytes[j] == 0x1b and j + 1 < bytes.len and bytes[j + 1] == '\\') {
+                            j += 2;
+                            break;
+                        }
+                    }
+                    const seq = bytes[seq_start..j];
+                    if (seq.len >= 5 and std.mem.startsWith(u8, seq, "\x1b]8;")) {
+                        // "\x1b]8;<params>;<URL>\x1b\\" — a close has an
+                        // empty URL component.
+                        const body = seq[4..]; // after "\x1b]8;"
+                        // Strip terminator off the end for URL extraction.
+                        const body_end: usize = blk: {
+                            if (body.len >= 2 and body[body.len - 2] == 0x1b and body[body.len - 1] == '\\') {
+                                break :blk body.len - 2;
+                            }
+                            if (body.len >= 1 and body[body.len - 1] == 0x07) break :blk body.len - 1;
+                            break :blk body.len;
+                        };
+                        const body_stripped = body[0..body_end];
+                        if (std.mem.indexOfScalar(u8, body_stripped, ';')) |semi| {
+                            const url = body_stripped[semi + 1 ..];
+                            if (url.len == 0) {
+                                self.link = null;
+                            } else {
+                                self.link = seq;
+                            }
+                        }
+                    }
+                    i = j;
+                    continue;
+                }
+                i += 1;
+            }
+        }
+
+        fn applySgr(self: *CellAnsiState, seq: []const u8, params: []const u8) void {
+            // Empty param ("\x1b[m") is equivalent to "\x1b[0m".
+            if (params.len == 0) {
+                self.flags = 0;
+                self.fg = null;
+                self.bg = null;
+                return;
+            }
+            // Stateful parse: 38/48 consume 2 extra params for `5;N` or
+            // 4 extra for `2;R;G;B`. Snapshot the whole seq for fg/bg
+            // since we don't need to recompute it — just replay it.
+            var iter = std.mem.splitScalar(u8, params, ';');
+            while (iter.next()) |p| {
+                const n = std.fmt.parseInt(u32, p, 10) catch continue;
+                switch (n) {
+                    0 => {
+                        self.flags = 0;
+                        self.fg = null;
+                        self.bg = null;
+                    },
+                    1 => self.flags |= BOLD,
+                    3 => self.flags |= ITALIC,
+                    4 => self.flags |= UNDERLINE,
+                    9 => self.flags |= STRIKE,
+                    22 => self.flags &= ~BOLD,
+                    23 => self.flags &= ~ITALIC,
+                    24 => self.flags &= ~UNDERLINE,
+                    29 => self.flags &= ~STRIKE,
+                    30...37, 90...97 => self.fg = seq,
+                    38 => {
+                        self.fg = seq;
+                        // Consume remaining params since they're part of
+                        // the 38 encoding — don't misinterpret them as
+                        // standalone SGRs.
+                        while (iter.next()) |_| {}
+                        return;
+                    },
+                    39 => self.fg = null,
+                    40...47, 100...107 => self.bg = seq,
+                    48 => {
+                        self.bg = seq;
+                        while (iter.next()) |_| {}
+                        return;
+                    },
+                    49 => self.bg = null,
+                    else => {},
+                }
+            }
+        }
+    };
+
     fn writeRowCells(
         self: *AnsiRenderer,
         row: TableRow,
@@ -1431,10 +1587,26 @@ pub const AnsiRenderer = struct {
         }
         @memset(segments, .{});
 
+        // Per-cell ANSI state snapshotted at the START of each segment.
+        // `state_at[col][line]` is the SGR/OSC 8 state that was active
+        // when rendering reached the beginning of that segment. Needed
+        // so a cell that wraps mid-span can re-open the style on the
+        // continuation line.
+        var state_at = self.allocator.alloc(std.ArrayListUnmanaged(CellAnsiState), widths.len) catch {
+            self.out.oom = true;
+            return;
+        };
+        defer {
+            for (state_at) |*s| s.deinit(self.allocator);
+            self.allocator.free(state_at);
+        }
+        @memset(state_at, .{});
+
         var lines: usize = 1;
         for (widths, 0..) |w, i| {
             const content = if (i < row.cells.len) row.cells[i].content else "";
             var rest = content;
+            var state = CellAnsiState{};
             while (rest.len > 0) {
                 var cut = visibleIndexAt(rest, w);
                 if (cut < rest.len) {
@@ -1445,12 +1617,25 @@ pub const AnsiRenderer = struct {
                     }
                 }
                 if (cut == 0) cut = @min(rest.len, @as(usize, bun.strings.wtf8ByteSequenceLengthWithInvalid(rest[0])));
+                state_at[i].append(self.allocator, state) catch {
+                    self.out.oom = true;
+                    return;
+                };
                 segments[i].append(self.allocator, rest[0..cut]) catch {
                     self.out.oom = true;
                     return;
                 };
+                state.scan(rest[0..cut]);
                 rest = rest[cut..];
-                while (rest.len > 0 and rest[0] == ' ') rest = rest[1..];
+                // Skip spaces that led to the wrap so they don't start
+                // the continuation line; scan them too in case a padded
+                // ANSI sequence hides inside.
+                var skipped_start: usize = 0;
+                while (skipped_start < rest.len and rest[skipped_start] == ' ') skipped_start += 1;
+                if (skipped_start > 0) {
+                    state.scan(rest[0..skipped_start]);
+                    rest = rest[skipped_start..];
+                }
             }
             lines = @max(lines, segments[i].items.len);
         }
@@ -1463,8 +1648,13 @@ pub const AnsiRenderer = struct {
             if (self.theme.colors) self.out.write("\x1b[0m");
             for (widths, 0..) |w, i| {
                 const seg: []const u8 = if (line < segments[i].items.len) segments[i].items[line] else "";
+                const opens: CellAnsiState = if (line < state_at[i].items.len) state_at[i].items[line] else .{};
                 self.out.writeByte(' ');
                 if (row.is_header and self.theme.colors) self.out.write("\x1b[1m");
+                // Re-emit any SGR + OSC 8 that was active at the start
+                // of this segment (no-op on the first line because the
+                // opens are already embedded in `seg`).
+                if (self.theme.colors and line > 0) opens.emitOpens(&self.out);
                 const cw = visibleWidth(seg);
                 const cell_align = if (i < row.cells.len) row.cells[i].alignment else .default;
                 const alignment = if (cell_align != .default) cell_align else aligns[i];
@@ -1476,10 +1666,16 @@ pub const AnsiRenderer = struct {
                 };
                 self.writePadding(left);
                 self.out.write(seg);
-                // Clear any inline style from the segment so it doesn't
-                // bleed into the padding / border on this or the next
-                // physical line.
-                if (self.theme.colors) self.out.write("\x1b[0m");
+                // Close everything still open at the end of this segment
+                // — `\x1b[0m` for SGR and `\x1b]8;;\x1b\\` for OSC 8 so
+                // the padding, trailing space, and border are not part
+                // of an active hyperlink.
+                if (self.theme.colors) {
+                    var end_state = opens;
+                    end_state.scan(seg);
+                    end_state.emitCloses(&self.out);
+                    if (row.is_header) self.out.write("\x1b[0m");
+                }
                 self.writePadding(right);
                 self.out.writeByte(' ');
                 if (self.theme.colors) self.out.write(color(.dim));

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -13,6 +13,10 @@ pub const Theme = struct {
     colors: bool = true,
     /// Emit OSC 8 hyperlinks. When false links are shown as "text (url)".
     hyperlinks: bool = true,
+    /// Inline images using the Kitty Graphics Protocol when the `src`
+    /// refers to a local file (absolute or ./relative path, or file://).
+    /// Falls through to the text alt for remote URLs.
+    kitty_graphics: bool = false,
 };
 
 pub const AnsiRenderer = struct {
@@ -233,7 +237,10 @@ pub const AnsiRenderer = struct {
                 var marker_width: u32 = 0;
                 if (task_mark != 0) {
                     const checked = types.isTaskChecked(task_mark);
-                    const glyph = if (checked) "☒ " else "☐ ";
+                    const glyph = if (self.theme.colors)
+                        (if (checked) "☒ " else "☐ ")
+                    else
+                        (if (checked) "[x] " else "[ ] ");
                     const c = if (checked) color(.green) else color(.dim);
                     self.writeStyled(c, glyph);
                     self.writeStyled(reset(), "");
@@ -262,7 +269,9 @@ pub const AnsiRenderer = struct {
             .hr => {
                 self.ensureBlankLine();
                 self.writeIndent();
-                const width: u32 = @min(self.theme.columns, 60);
+                // columns == 0 is the "disable wrapping" sentinel, not a
+                // zero-width rule — fall back to 60 in that case.
+                const width: u32 = if (self.theme.columns == 0) 60 else @min(self.theme.columns, 60);
                 var i: u32 = 0;
                 const dash = if (self.theme.colors) "─" else "-";
                 self.writeStyled(color(.dim), "");
@@ -484,18 +493,24 @@ pub const AnsiRenderer = struct {
             .em => {
                 self.span_flags &= ~SPAN_EM;
                 self.writeStyled("\x1b[23m", "");
+                // An off-code can turn off a heading's own bold/italic —
+                // reapply if we're inside a heading buffer.
+                if (self.heading_level > 0) self.reapplyStyles();
             },
             .strong => {
                 self.span_flags &= ~SPAN_STRONG;
                 self.writeStyled("\x1b[22m", "");
+                if (self.heading_level > 0) self.reapplyStyles();
             },
             .u => {
                 self.span_flags &= ~SPAN_U;
                 self.writeStyled("\x1b[24m", "");
+                if (self.heading_level > 0) self.reapplyStyles();
             },
             .del => {
                 self.span_flags &= ~SPAN_DEL;
                 self.writeStyled("\x1b[29m", "");
+                if (self.heading_level > 0) self.reapplyStyles();
             },
             .code => {
                 self.span_flags &= ~SPAN_CODE;
@@ -565,10 +580,13 @@ pub const AnsiRenderer = struct {
             .br => self.writeContent("\n"),
             .softbr => self.writeContent(" "),
             .html => {
-                // Render raw HTML dimmed.
+                // Render raw HTML dimmed. Close with the targeted dim-off
+                // (\x1b[22m) rather than a full reset, then reapply any
+                // outer span/link styles.
                 self.writeStyled(color(.dim), "");
                 self.writeContent(content);
-                self.writeStyled(reset(), "");
+                self.writeStyled("\x1b[22m", "");
+                self.reapplyStyles();
             },
             .entity => {
                 var buf: [8]u8 = undefined;
@@ -778,11 +796,18 @@ pub const AnsiRenderer = struct {
         self.out.write(data);
     }
 
-    /// Re-emit the currently active inline styles from span_flags and the
-    /// link-styling state. Used after a nested span closes so the outer
+    /// Re-emit the currently active inline styles from span_flags, the
+    /// link-styling state, and — when buffering a heading — the heading's
+    /// bold + color wrapper. Used after a nested span closes so the outer
     /// style doesn't get wiped, and after writeIndent emits its own reset.
     fn reapplyStyles(self: *AnsiRenderer) void {
         if (!self.theme.colors) return;
+        // If we're inside a heading's buffered content, the outer bold +
+        // color wrapper must also be reapplied.
+        if (self.heading_level > 0) {
+            self.emitInline(style(.bold));
+            self.emitInline(headingColor(self.heading_level));
+        }
         if (self.span_flags & SPAN_STRONG != 0) self.emitInline(style(.bold));
         if (self.span_flags & SPAN_EM != 0) self.emitInline(style(.italic));
         if (self.span_flags & SPAN_U != 0) self.emitInline(style(.underline));
@@ -893,16 +918,38 @@ pub const AnsiRenderer = struct {
         const level = self.heading_level;
         const content = self.heading_buf.items;
         self.writeIndent();
-        const prefix = switch (level) {
-            1 => "",
-            2 => "",
-            3 => "",
-            4 => "",
-            5 => "",
-            else => "",
-        };
-        _ = prefix;
-        const heading_color = switch (level) {
+        if (self.theme.colors) {
+            self.out.write("\x1b[1m"); // bold
+            self.out.write(headingColor(level));
+        }
+        self.out.write(content);
+        if (self.theme.colors) self.out.write("\x1b[0m");
+        self.out.writeByte('\n');
+        self.last_was_newline = true;
+        self.col = 0;
+        // Add underline for h1/h2. Indent matches the heading text so
+        // headings inside blockquotes / list items stay aligned.
+        if (level == 1 or level == 2) {
+            self.writeIndent();
+            const text_w = @max(visibleWidth(content), 3);
+            const width = if (self.theme.columns == 0)
+                text_w
+            else
+                @min(text_w, @as(usize, @intCast(self.theme.columns)));
+            if (self.theme.colors) self.out.write(color(.dim));
+            const char = if (self.theme.colors) (if (level == 1) "═" else "─") else (if (level == 1) "=" else "-");
+            var i: usize = 0;
+            while (i < width) : (i += 1) self.out.write(char);
+            if (self.theme.colors) self.out.write("\x1b[0m");
+            self.out.writeByte('\n');
+            self.last_was_newline = true;
+            self.col = 0;
+        }
+    }
+
+    /// ANSI color for a given heading level.
+    fn headingColor(level: u8) []const u8 {
+        return switch (level) {
             1 => color(.magenta),
             2 => color(.cyan),
             3 => color(.yellow),
@@ -910,28 +957,6 @@ pub const AnsiRenderer = struct {
             5 => color(.blue),
             else => color(.white),
         };
-        if (self.theme.colors) {
-            self.out.write("\x1b[1m"); // bold
-            self.out.write(heading_color);
-        }
-        self.out.write(content);
-        if (self.theme.colors) self.out.write("\x1b[0m");
-        self.out.writeByte('\n');
-        self.last_was_newline = true;
-        self.col = 0;
-        // Add underline for h1/h2
-        if (level == 1 or level == 2) {
-            const width = @min(
-                @max(visibleWidth(content), 3),
-                @as(usize, @intCast(self.theme.columns)),
-            );
-            if (self.theme.colors) self.out.write(color(.dim));
-            const char = if (self.theme.colors) (if (level == 1) "═" else "─") else (if (level == 1) "=" else "-");
-            var i: usize = 0;
-            while (i < width) : (i += 1) self.out.write(char);
-            if (self.theme.colors) self.out.write("\x1b[0m");
-            self.out.writeByte('\n');
-        }
     }
 
     // ========================================
@@ -1212,13 +1237,35 @@ pub const AnsiRenderer = struct {
         defer self.image_depth = saved_depth;
 
         const has_src = src != null and src.?.len > 0;
+
+        // Kitty Graphics Protocol path: for local files, emit an APC
+        // sequence that tells the terminal to read the file directly
+        // and display it inline. Only attempts this when:
+        //   1. colors + kitty_graphics are enabled (needs ESC support)
+        //   2. src is a file: URI or a non-URL path
+        //   3. the file exists on disk
+        // On success we also emit an OSC 8 hyperlink so the text alt
+        // remains clickable below the image, and still write the alt
+        // text as a visible caption for non-Kitty terminals that ignore
+        // the APC sequence.
+        var kitty_sent = false;
+        if (self.theme.colors and self.theme.kitty_graphics and has_src) {
+            if (resolveLocalImagePath(src.?, self.allocator)) |abs_path| {
+                defer self.allocator.free(abs_path);
+                self.emitKittyImage(abs_path);
+                kitty_sent = true;
+            }
+        }
+
         if (self.theme.colors and self.theme.hyperlinks and has_src) {
             self.writeRawNoColor("\x1b]8;;");
             self.writeRawNoColor(src.?);
             self.writeRawNoColor("\x1b\\");
         }
-        const img_marker = if (self.theme.colors) "🖼 " else "[img] ";
-        self.writeStyled(color(.magenta), img_marker);
+        const img_marker = if (kitty_sent) "" else if (self.theme.colors) "🖼 " else "[img] ";
+        if (img_marker.len > 0) {
+            self.writeStyled(color(.magenta), img_marker);
+        }
         if (alt.len > 0) {
             self.writeStyled("", alt);
         } else if (self.image_title) |title| if (title.len > 0) {
@@ -1233,6 +1280,35 @@ pub const AnsiRenderer = struct {
         if (self.theme.colors and self.theme.hyperlinks and has_src) {
             self.writeRawNoColor("\x1b]8;;\x1b\\");
         }
+    }
+
+    /// Emit a Kitty Graphics Protocol transmit-and-display sequence for
+    /// the absolute file `path`. Uses `t=f` (transmission medium = regular
+    /// file by path) so the terminal reads the file directly — no need
+    /// to base64 the pixels. Terminals that don't understand the APC
+    /// sequence will silently drop it.
+    fn emitKittyImage(self: *AnsiRenderer, path: []const u8) void {
+        // Base64-encode the file path (Kitty expects payload to be b64).
+        // Path is expected to be ASCII in most cases; use std.base64.
+        const enc = std.base64.standard.Encoder;
+        const encoded_len = enc.calcSize(path.len);
+        const encoded = self.allocator.alloc(u8, encoded_len) catch return;
+        defer self.allocator.free(encoded);
+        _ = enc.encode(encoded, path);
+
+        // APC sequence: \x1b_G<control>;<payload>\x1b\
+        //   a=T  : transmit and display
+        //   t=f  : transmission medium = regular file (by path)
+        //   f=100: format = file (kitty auto-detects PNG/JPEG/etc.)
+        //   q=2  : suppress OK + error responses (don't pollute stdin)
+        self.writeRawNoColor("\x1b_Ga=T,t=f,f=100,q=2;");
+        self.writeRawNoColor(encoded);
+        self.writeRawNoColor("\x1b\\");
+        // End with a newline so the following caption/alt text lands
+        // on its own line under the image.
+        self.out.writeByte('\n');
+        self.col = 0;
+        self.last_was_newline = true;
     }
 };
 
@@ -1343,18 +1419,84 @@ fn resolveHref(detail: SpanDetail, allocator: Allocator) ![]u8 {
 /// 2. Dark mode (default)
 pub fn detectLightBackground() bool {
     if (bun.getenvZ("COLORFGBG")) |value| {
-        // Format: "fg;bg" or "fg;default;bg" — bg index < 8 is dark, >=8 light
+        // Format: "fg;bg" or "fg;default;bg" — only 7 (white) and 15
+        // (bright white) are light terminal backgrounds. Bright colors
+        // 9-14 are high-intensity foreground codes, not light backgrounds.
         var iter = std.mem.splitScalar(u8, value, ';');
         var last: []const u8 = "";
         while (iter.next()) |part| last = part;
         if (last.len > 0) {
             const bg = std.fmt.parseInt(u8, last, 10) catch return false;
-            // Terminals using this convention treat 0-6 and 8 as dark, 7/15 as light.
-            // A higher threshold is safer.
-            return bg >= 7 and bg != 8;
+            return bg == 7 or bg == 15;
         }
     }
     return false;
+}
+
+/// Detect whether the current terminal likely supports the Kitty
+/// Graphics Protocol. Checked heuristics:
+///   - `KITTY_WINDOW_ID` set (native Kitty)
+///   - `TERM` contains "kitty"
+///   - `TERM_PROGRAM=WezTerm` or `ghostty` (compatible terminals)
+///   - `TERM_PROGRAM=ghostty`
+pub fn detectKittyGraphics() bool {
+    if (bun.getenvZ("KITTY_WINDOW_ID")) |_| return true;
+    if (bun.getenvZ("GHOSTTY_RESOURCES_DIR")) |_| return true;
+    if (bun.getenvZ("TERM")) |term| {
+        if (bun.strings.contains(term, "kitty")) return true;
+        if (bun.strings.contains(term, "ghostty")) return true;
+    }
+    if (bun.getenvZ("TERM_PROGRAM")) |tp| {
+        if (bun.strings.eqlCaseInsensitiveASCII(tp, "wezterm", true)) return true;
+        if (bun.strings.eqlCaseInsensitiveASCII(tp, "ghostty", true)) return true;
+    }
+    return false;
+}
+
+/// Resolve an image `src` from markdown to an absolute file path on
+/// disk if it refers to a local file, otherwise return null. Handles
+/// `file://` URIs and relative paths (resolved against the CWD). The
+/// returned slice is owned by the caller.
+fn resolveLocalImagePath(src: []const u8, allocator: Allocator) ?[]u8 {
+    // Reject clearly remote schemes.
+    if (bun.strings.startsWith(src, "http://") or
+        bun.strings.startsWith(src, "https://") or
+        bun.strings.startsWith(src, "data:"))
+    {
+        return null;
+    }
+
+    var path: []const u8 = src;
+    // Strip file:// prefix if present.
+    if (bun.strings.startsWith(src, "file://")) {
+        path = src["file://".len..];
+    }
+
+    // If already absolute, use it.
+    if (std.fs.path.isAbsolute(path)) {
+        const abs = allocator.dupe(u8, path) catch return null;
+        std.fs.accessAbsolute(abs, .{}) catch {
+            allocator.free(abs);
+            return null;
+        };
+        return abs;
+    }
+
+    // Relative path — resolve against CWD.
+    var cwd_buf: bun.PathBuffer = undefined;
+    const cwd = bun.getcwd(&cwd_buf) catch return null;
+    var joined = std.ArrayListUnmanaged(u8){};
+    errdefer joined.deinit(allocator);
+    joined.appendSlice(allocator, cwd) catch return null;
+    joined.append(allocator, std.fs.path.sep) catch return null;
+    joined.appendSlice(allocator, path) catch return null;
+
+    const abs = joined.toOwnedSlice(allocator) catch return null;
+    std.fs.accessAbsolute(abs, .{}) catch {
+        allocator.free(abs);
+        return null;
+    };
+    return abs;
 }
 
 // ========================================

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -24,6 +24,11 @@ pub const Theme = struct {
     /// send remote images through Kitty's `t=f` path. When null, http
     /// and https URLs fall through to the alt-text fallback.
     remote_image_paths: ?*const std.StringHashMapUnmanaged([]const u8) = null,
+    /// Base directory used to resolve relative image `src` paths. When
+    /// null, falls back to the process cwd. The CLI entry point sets
+    /// this to the markdown file's directory so `![](./img.png)` works
+    /// regardless of where `bun ./some/dir/file.md` is invoked from.
+    image_base_dir: ?[]const u8 = null,
 };
 
 /// Renderer that only collects image URLs — no output. Used by the CLI
@@ -118,6 +123,10 @@ pub const AnsiRenderer = struct {
     cell_align: types.Align = .default,
     /// Track whether we just emitted a newline, to collapse extra blanks.
     last_was_newline: bool = true,
+    /// True after ensureBlankLine emitted its blank-line separator and
+    /// no content has been written since. Used to dedup back-to-back
+    /// ensureBlankLine() calls (e.g. enter-quote followed by enter-para).
+    blank_emitted: bool = false,
 
     const BlockContext = struct {
         kind: Kind,
@@ -883,6 +892,10 @@ pub const AnsiRenderer = struct {
     }
 
     fn writeIndent(self: *AnsiRenderer) void {
+        // writeIndent is called at the start of every content line, so
+        // this is the right place to clear the "blank line just emitted"
+        // flag ensureBlankLine uses for dedup.
+        self.blank_emitted = false;
         var quote_bars: u32 = 0;
         var other_indent: u32 = 0;
         for (self.block_stack.items) |entry| {
@@ -934,6 +947,25 @@ pub const AnsiRenderer = struct {
         }
     }
 
+    /// Emit just the blockquote `│` bars (no list indent) for the
+    /// current block_stack. Used by ensureBlankLine so the inter-block
+    /// gap inside a blockquote keeps its visual border.
+    fn writeQuoteBars(self: *AnsiRenderer) void {
+        var quote_bars: u32 = 0;
+        for (self.block_stack.items) |entry| {
+            if (entry.kind == .quote) quote_bars += 1;
+        }
+        if (quote_bars == 0) return;
+        const bar = if (self.theme.colors) "│" else "|";
+        if (self.theme.colors) self.out.write("\x1b[38;5;242m");
+        var i: u32 = 0;
+        while (i < quote_bars) : (i += 1) {
+            self.out.write(bar);
+            self.col += 1;
+        }
+        if (self.theme.colors) self.out.write("\x1b[39m");
+    }
+
     fn ensureNewline(self: *AnsiRenderer) void {
         if (!self.last_was_newline) {
             self.out.writeByte('\n');
@@ -944,18 +976,24 @@ pub const AnsiRenderer = struct {
 
     fn ensureBlankLine(self: *AnsiRenderer) void {
         self.ensureNewline();
+        // Already on a fresh blank line? Don't stack another.
+        if (self.blank_emitted) return;
         // Add an extra blank line only if we already produced output.
         if (self.out.list.items.len > 0) {
             // Check if last two chars are newlines
             const items = self.out.list.items;
             if (items.len >= 2 and items[items.len - 1] == '\n' and items[items.len - 2] != '\n') {
+                self.writeQuoteBars();
                 self.out.writeByte('\n');
                 self.col = 0;
+                self.blank_emitted = true;
             } else if (items.len == 1 and items[0] == '\n') {
                 // single newline — don't add another
             } else if (items.len >= 1 and items[items.len - 1] != '\n') {
+                self.writeQuoteBars();
                 self.out.writeByte('\n');
                 self.col = 0;
+                self.blank_emitted = true;
             }
         }
     }
@@ -1347,7 +1385,7 @@ pub const AnsiRenderer = struct {
                     }
                 }
             }
-            if (resolveLocalImagePath(src.?, self.allocator)) |abs_path| {
+            if (resolveLocalImagePath(src.?, self.allocator, self.theme.image_base_dir)) |abs_path| {
                 defer self.allocator.free(abs_path);
                 self.emitKittyImageFile(abs_path);
                 return;
@@ -1388,7 +1426,10 @@ pub const AnsiRenderer = struct {
     fn emitKittyImageFile(self: *AnsiRenderer, path: []const u8) void {
         // Base64-encode the file path (Kitty expects the payload to be b64).
         const encoded_len = bun.base64.encodeLen(path);
-        const encoded = self.allocator.alloc(u8, encoded_len) catch return;
+        const encoded = self.allocator.alloc(u8, encoded_len) catch {
+            self.out.oom = true;
+            return;
+        };
         defer self.allocator.free(encoded);
         _ = bun.base64.encode(encoded, path);
         self.writeRawNoColor("\x1b_Ga=T,t=f,f=100,q=2;");
@@ -1622,9 +1663,11 @@ fn probeKittyGraphics() bool {
 
 /// Resolve an image `src` from markdown to an absolute file path on
 /// disk if it refers to a local file, otherwise return null. Handles
-/// `file://` URIs and relative paths (resolved against the CWD). The
-/// returned slice is owned by the caller.
-fn resolveLocalImagePath(src: []const u8, allocator: Allocator) ?[]u8 {
+/// `file://` URIs and relative paths. Relative paths resolve against
+/// `base_dir` when non-null (typically the markdown file's directory),
+/// falling back to the process cwd. The returned slice is owned by the
+/// caller.
+fn resolveLocalImagePath(src: []const u8, allocator: Allocator, base_dir: ?[]const u8) ?[]u8 {
     // Reject remote schemes. A renderer-level prefetch pass can feed
     // http(s) URLs into the renderer via a lookup table as local paths.
     // data: URIs are handled separately in emitImage via direct Kitty
@@ -1657,12 +1700,15 @@ fn resolveLocalImagePath(src: []const u8, allocator: Allocator) ?[]u8 {
 
     // Resolve to an absolute path. bun.path.joinAbsString returns a
     // slice in a threadlocal buffer — dupe it before leaving this fn.
+    // Prefer the markdown file's directory when provided; otherwise fall
+    // back to cwd so `Bun.markdown.ansi()` callers without a source path
+    // still work.
     var cwd_buf: bun.PathBuffer = undefined;
-    const cwd = switch (bun.sys.getcwd(&cwd_buf)) {
+    const base: []const u8 = if (base_dir) |d| d else switch (bun.sys.getcwd(&cwd_buf)) {
         .result => |c| c,
         .err => return null,
     };
-    const joined = bun.path.joinAbsString(cwd, &.{decoded}, .auto);
+    const joined = bun.path.joinAbsString(base, &.{decoded}, .auto);
     const abs = allocator.dupe(u8, joined) catch return null;
     if (!bun.sys.exists(abs)) {
         allocator.free(abs);

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -329,7 +329,13 @@ pub const AnsiRenderer = struct {
                 self.writeIndent();
                 // columns == 0 is the "disable wrapping" sentinel, not a
                 // zero-width rule — fall back to 60 in that case.
-                const width: u32 = if (self.theme.columns == 0) 60 else @min(self.theme.columns, 60);
+                // Subtract the indent that writeIndent() just emitted so
+                // a rule inside a blockquote / list item doesn't overflow.
+                const indent_cols = self.currentIndent();
+                const width: u32 = if (self.theme.columns == 0)
+                    60 -| indent_cols
+                else
+                    @min(self.theme.columns, 60) -| indent_cols;
                 var i: u32 = 0;
                 const dash = if (self.theme.colors) "─" else "-";
                 self.writeStyled(color(.dim), "");
@@ -1181,10 +1187,14 @@ pub const AnsiRenderer = struct {
         if (level == 1 or level == 2) {
             self.writeIndent();
             const text_w = @max(visibleWidth(content), 3);
+            // Subtract the indent that writeIndent() just emitted so
+            // an underlined heading inside a blockquote / list item
+            // doesn't overflow the terminal width.
+            const indent_cols = self.currentIndent();
             const width = if (self.theme.columns == 0)
                 text_w
             else
-                @min(text_w, @as(usize, @intCast(self.theme.columns)));
+                @min(text_w, (@as(usize, @intCast(self.theme.columns))) -| @as(usize, indent_cols));
             if (self.theme.colors) self.out.write(color(.dim));
             const char = if (self.theme.colors) (if (level == 1) "═" else "─") else (if (level == 1) "=" else "-");
             var i: usize = 0;

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1408,7 +1408,13 @@ pub const AnsiRenderer = struct {
         // of U+1F5BC "FRAME WITH PICTURE" because 1F5BC is classified
         // Narrow in EastAsianWidth.txt — visibleWidth would undercount
         // it as 1 column and wrapping would fire one column too late.)
-        if (self.theme.colors and self.theme.hyperlinks and has_src) {
+        // Skip the OSC 8 wrapper when src is a `data:` URI — those
+        // payloads are megabytes of base64 and would exceed typical
+        // terminal OSC parameter limits (64KB–1MB), causing rendering
+        // artifacts, hangs, or garbage output.
+        const link_ok = self.theme.colors and self.theme.hyperlinks and has_src and
+            !bun.strings.startsWith(src.?, "data:");
+        if (link_ok) {
             self.writeRawNoColor("\x1b]8;;");
             self.writeRawNoColor(src.?);
             self.writeRawNoColor("\x1b\\");
@@ -1426,7 +1432,7 @@ pub const AnsiRenderer = struct {
         }
         self.writeStyled(reset(), "");
         self.reapplyStyles();
-        if (self.theme.colors and self.theme.hyperlinks and has_src) {
+        if (link_ok) {
             self.writeRawNoColor("\x1b]8;;\x1b\\");
         }
     }
@@ -1722,9 +1728,25 @@ fn resolveLocalImagePath(src: []const u8, allocator: Allocator, base_dir: ?[]con
     };
     const joined = bun.path.joinAbsString(base, &.{decoded}, .auto);
     const abs = allocator.dupe(u8, joined) catch return null;
-    if (!bun.sys.exists(abs)) {
+    // Stat instead of plain exists() so a directory like `./assets/` gets
+    // rejected. bun.sys.exists wraps access(path, F_OK) which returns true
+    // for any entry, including directories — and emitKittyImageFile sets
+    // q=2 so the terminal silently drops directory paths without falling
+    // through to alt text.
+    const abs_z = allocator.dupeZ(u8, abs) catch {
         allocator.free(abs);
         return null;
+    };
+    defer allocator.free(abs_z);
+    switch (bun.sys.stat(abs_z)) {
+        .result => |s| if ((s.mode & bun.S.IFMT) != bun.S.IFREG) {
+            allocator.free(abs);
+            return null;
+        },
+        .err => {
+            allocator.free(abs);
+            return null;
+        },
     }
     return abs;
 }

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -661,7 +661,9 @@ pub const AnsiRenderer = struct {
             // the content through the active buffer + updates col in one
             // pass, without the paragraph word-wrap logic.
             .code => self.writeStyled("", content),
-            .latexmath => self.writeContent(content),
+            // LaTeX math spans are atomic like .code — don't let
+            // writeWrapped split `$E = mc^2$` at internal spaces.
+            .latexmath => self.writeStyled("", content),
             else => self.writeContent(content),
         }
     }
@@ -1444,14 +1446,18 @@ pub const AnsiRenderer = struct {
         }
         const img_marker = if (self.theme.colors) "📷 " else "[img] ";
         self.writeStyled(color(.magenta), img_marker);
+        // Route alt/title through writeContent so word-wrap applies and
+        // any hard breaks (`\n` captured from .br events) get a proper
+        // writeIndent() afterwards — otherwise long alts overflow and
+        // continuation lines inside blockquotes lose the `│ ` prefix.
         if (alt.len > 0) {
-            self.writeStyled("", alt);
+            self.writeContent(alt);
         } else if (self.image_title) |title| if (title.len > 0) {
-            self.writeStyled("", title);
+            self.writeContent(title);
         } else {
-            self.writeStyled("", "(image)");
+            self.writeContent("(image)");
         } else {
-            self.writeStyled("", "(image)");
+            self.writeContent("(image)");
         }
         self.writeStyled(reset(), "");
         self.reapplyStyles();

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -18,6 +18,51 @@ pub const Theme = struct {
     /// refers to a local file (absolute or ./relative path, or file://).
     /// Falls through to the text alt for remote URLs.
     kitty_graphics: bool = false,
+    /// Optional lookup table mapping http(s) image URLs to already-
+    /// downloaded local file paths. Populated by a pre-scan pass (see
+    /// `collectImageUrls` + the CLI entry point) so `emitImage` can
+    /// send remote images through Kitty's `t=f` path. When null, http
+    /// and https URLs fall through to the alt-text fallback.
+    remote_image_paths: ?*const std.StringHashMapUnmanaged([]const u8) = null,
+};
+
+/// Renderer that only collects image URLs — no output. Used by the CLI
+/// pre-scan pass to decide which remote images to download.
+pub const ImageUrlCollector = struct {
+    urls: std.ArrayListUnmanaged([]const u8) = .{},
+    allocator: Allocator,
+
+    pub fn init(allocator: Allocator) ImageUrlCollector {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *ImageUrlCollector) void {
+        self.urls.deinit(self.allocator);
+    }
+
+    pub fn renderer(self: *ImageUrlCollector) Renderer {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable: Renderer.VTable = .{
+        .enterBlock = noopEnterBlock,
+        .leaveBlock = noopLeaveBlock,
+        .enterSpan = enterSpanImpl,
+        .leaveSpan = noopLeaveSpan,
+        .text = noopText,
+    };
+
+    fn noopEnterBlock(_: *anyopaque, _: BlockType, _: u32, _: u32) bun.JSError!void {}
+    fn noopLeaveBlock(_: *anyopaque, _: BlockType, _: u32) bun.JSError!void {}
+    fn noopLeaveSpan(_: *anyopaque, _: SpanType) bun.JSError!void {}
+    fn noopText(_: *anyopaque, _: TextType, _: []const u8) bun.JSError!void {}
+
+    fn enterSpanImpl(ptr: *anyopaque, span_type: SpanType, detail: SpanDetail) bun.JSError!void {
+        if (span_type != .img) return;
+        const self: *ImageUrlCollector = @ptrCast(@alignCast(ptr));
+        if (detail.href.len == 0) return;
+        self.urls.append(self.allocator, detail.href) catch return error.OutOfMemory;
+    }
 };
 
 pub const AnsiRenderer = struct {
@@ -1273,6 +1318,18 @@ pub const AnsiRenderer = struct {
             if (extractPngDataUrlBase64(src.?)) |payload| {
                 self.emitKittyImageDirect(payload);
                 return;
+            }
+            // http(s) URL that the CLI pre-scan pass already downloaded
+            // to a temp file → send via Kitty's t=f against that path.
+            if (self.theme.remote_image_paths) |map| {
+                if ((bun.strings.startsWith(src.?, "http://") or
+                    bun.strings.startsWith(src.?, "https://")))
+                {
+                    if (map.get(src.?)) |local_path| {
+                        self.emitKittyImageFile(local_path);
+                        return;
+                    }
+                }
             }
             if (resolveLocalImagePath(src.?, self.allocator)) |abs_path| {
                 defer self.allocator.free(abs_path);

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1,0 +1,1201 @@
+//! Markdown → ANSI renderer. Used by `bun ./file.md` to pretty-print
+//! markdown documents to the terminal with colors, hyperlinks, syntax
+//! highlighting, and Unicode box drawing.
+
+pub const Theme = struct {
+    /// True when the terminal background is light. Controls color choices
+    /// so text stays readable.
+    light: bool = false,
+    /// Terminal column count. Used for word-wrapping paragraphs and sizing
+    /// horizontal rules. 0 disables wrapping.
+    columns: u16 = 80,
+    /// Emit colors and styles. When false the renderer emits plain text.
+    colors: bool = true,
+    /// Emit OSC 8 hyperlinks. When false links are shown as "text (url)".
+    hyperlinks: bool = true,
+};
+
+pub const AnsiRenderer = struct {
+    out: OutputBuffer,
+    allocator: Allocator,
+    src_text: []const u8,
+    theme: Theme,
+    /// Stack of active block contexts (li/quote) for indentation.
+    block_stack: std.ArrayListUnmanaged(BlockContext) = .{},
+    /// Currently open span styles (bit flags).
+    span_flags: u32 = 0,
+    /// Non-empty when we're inside a link span; the href to emit in OSC 8.
+    link_href: []const u8 = "",
+    /// Depth of enclosing link spans (brackets can nest in markdown parsers).
+    link_depth: u32 = 0,
+    /// Depth of enclosing image spans — text inside images becomes alt text
+    /// rather than normal output.
+    image_depth: u32 = 0,
+    /// Buffered alt text for the innermost image.
+    image_alt: std.ArrayListUnmanaged(u8) = .{},
+    /// Saved image src URL for when the image span closes.
+    image_src: []const u8 = "",
+    /// Saved image title (rendered after alt).
+    image_title: []const u8 = "",
+    /// Active paragraph-level wrapping column usage. Tracks visible chars
+    /// written on the current line so word wrapping works inside headings
+    /// and paragraphs.
+    col: u32 = 0,
+    /// True when we're collecting a code block body (fenced or indented).
+    in_code_block: bool = false,
+    /// Language extracted from the fenced code block info string.
+    code_lang: []const u8 = "",
+    /// Whether the current code block is fenced (not indented).
+    code_fenced: bool = false,
+    /// Buffer of the current code block body, flushed on leaveBlock(.code).
+    code_buf: std.ArrayListUnmanaged(u8) = .{},
+    /// Heading level currently being rendered (0 = none).
+    heading_level: u8 = 0,
+    /// Buffer of the current heading text, flushed on leaveBlock(.h).
+    heading_buf: std.ArrayListUnmanaged(u8) = .{},
+    /// Table state: cells of the current row with their alignment + width.
+    table_cells: std.ArrayListUnmanaged(TableCell) = .{},
+    /// Buffered rows for the current table, flushed on leaveBlock(.table).
+    table_rows: std.ArrayListUnmanaged(TableRow) = .{},
+    /// Buffer for the current table cell being rendered.
+    table_cell_buf: std.ArrayListUnmanaged(u8) = .{},
+    /// True when inside a table header row.
+    in_thead: bool = false,
+    /// True when inside a table cell (th/td) to capture output.
+    in_cell: bool = false,
+    /// Current cell alignment being captured.
+    cell_align: types.Align = .default,
+    /// Track whether we just emitted a newline, to collapse extra blanks.
+    last_was_newline: bool = true,
+    /// Depth of blockquote nesting for left bar rendering.
+    quote_depth: u32 = 0,
+
+    const BlockContext = struct {
+        kind: Kind,
+        /// ordered-list start number or ul marker char
+        data: u32 = 0,
+        /// 0-based index of the current child (for numbered lists)
+        index: u32 = 0,
+        /// Indent (in characters) added by this block.
+        indent: u32 = 0,
+
+        const Kind = enum { quote, ul, ol, li };
+    };
+
+    const TableCell = struct {
+        content: []const u8,
+        alignment: types.Align,
+    };
+
+    const TableRow = struct {
+        cells: []TableCell,
+        is_header: bool,
+    };
+
+    // Span flags
+    const SPAN_EM: u32 = 1 << 0;
+    const SPAN_STRONG: u32 = 1 << 1;
+    const SPAN_DEL: u32 = 1 << 2;
+    const SPAN_U: u32 = 1 << 3;
+    const SPAN_CODE: u32 = 1 << 4;
+
+    pub const OutputBuffer = struct {
+        list: std.ArrayListUnmanaged(u8),
+        allocator: Allocator,
+        oom: bool,
+
+        fn write(self: *OutputBuffer, data: []const u8) void {
+            if (self.oom) return;
+            self.list.appendSlice(self.allocator, data) catch {
+                self.oom = true;
+            };
+        }
+
+        fn writeByte(self: *OutputBuffer, b: u8) void {
+            if (self.oom) return;
+            self.list.append(self.allocator, b) catch {
+                self.oom = true;
+            };
+        }
+    };
+
+    pub fn init(allocator: Allocator, src_text: []const u8, theme: Theme) AnsiRenderer {
+        return .{
+            .out = .{ .list = .{}, .allocator = allocator, .oom = false },
+            .allocator = allocator,
+            .src_text = src_text,
+            .theme = theme,
+        };
+    }
+
+    pub fn deinit(self: *AnsiRenderer) void {
+        self.out.list.deinit(self.allocator);
+        self.block_stack.deinit(self.allocator);
+        self.image_alt.deinit(self.allocator);
+        self.code_buf.deinit(self.allocator);
+        self.heading_buf.deinit(self.allocator);
+        for (self.table_rows.items) |row| {
+            for (row.cells) |cell| self.allocator.free(cell.content);
+            self.allocator.free(row.cells);
+        }
+        self.table_rows.deinit(self.allocator);
+        self.table_cells.deinit(self.allocator);
+        self.table_cell_buf.deinit(self.allocator);
+    }
+
+    pub fn toOwnedSlice(self: *AnsiRenderer) error{OutOfMemory}![]u8 {
+        if (self.out.oom) return error.OutOfMemory;
+        return self.out.list.toOwnedSlice(self.allocator);
+    }
+
+    pub fn renderer(self: *AnsiRenderer) Renderer {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    pub const vtable: Renderer.VTable = .{
+        .enterBlock = enterBlockImpl,
+        .leaveBlock = leaveBlockImpl,
+        .enterSpan = enterSpanImpl,
+        .leaveSpan = leaveSpanImpl,
+        .text = textImpl,
+    };
+
+    fn enterBlockImpl(ptr: *anyopaque, block_type: BlockType, data: u32, flags: u32) bun.JSError!void {
+        const self: *AnsiRenderer = @ptrCast(@alignCast(ptr));
+        self.enterBlock(block_type, data, flags);
+    }
+
+    fn leaveBlockImpl(ptr: *anyopaque, block_type: BlockType, data: u32) bun.JSError!void {
+        const self: *AnsiRenderer = @ptrCast(@alignCast(ptr));
+        self.leaveBlock(block_type, data);
+    }
+
+    fn enterSpanImpl(ptr: *anyopaque, span_type: SpanType, detail: SpanDetail) bun.JSError!void {
+        const self: *AnsiRenderer = @ptrCast(@alignCast(ptr));
+        self.enterSpan(span_type, detail);
+    }
+
+    fn leaveSpanImpl(ptr: *anyopaque, span_type: SpanType) bun.JSError!void {
+        const self: *AnsiRenderer = @ptrCast(@alignCast(ptr));
+        self.leaveSpan(span_type);
+    }
+
+    fn textImpl(ptr: *anyopaque, text_type: TextType, content: []const u8) bun.JSError!void {
+        const self: *AnsiRenderer = @ptrCast(@alignCast(ptr));
+        self.text(text_type, content);
+    }
+
+    // ========================================
+    // Block rendering
+    // ========================================
+
+    pub fn enterBlock(self: *AnsiRenderer, block_type: BlockType, data: u32, flags: u32) void {
+        switch (block_type) {
+            .doc => {},
+            .quote => {
+                self.ensureBlankLine();
+                self.quote_depth += 1;
+                self.block_stack.append(self.allocator, .{ .kind = .quote, .indent = 2 }) catch {
+                    self.out.oom = true;
+                };
+            },
+            .ul => {
+                self.ensureNewline();
+                self.block_stack.append(self.allocator, .{ .kind = .ul, .data = data, .indent = 2 }) catch {
+                    self.out.oom = true;
+                };
+            },
+            .ol => {
+                self.ensureNewline();
+                self.block_stack.append(self.allocator, .{ .kind = .ol, .data = data, .indent = 3 }) catch {
+                    self.out.oom = true;
+                };
+            },
+            .li => {
+                self.ensureNewline();
+                self.writeIndent();
+                var entry: BlockContext = .{ .kind = .li };
+                const parent_list = self.findParentList();
+                const task_mark = types.taskMarkFromData(data);
+                if (parent_list) |list| {
+                    entry.index = list.index;
+                    list.index += 1;
+                }
+                if (task_mark != 0) {
+                    const checked = types.isTaskChecked(task_mark);
+                    const glyph = if (checked) "☒ " else "☐ ";
+                    const c = if (checked) color(.green) else color(.dim);
+                    self.writeStyled(c, glyph);
+                    self.writeStyled(reset(), "");
+                } else if (parent_list != null and parent_list.?.kind == .ol) {
+                    const start = parent_list.?.data;
+                    const num = start + entry.index;
+                    var buf: [12]u8 = undefined;
+                    const s = std.fmt.bufPrint(&buf, "{d}.", .{num}) catch "?";
+                    self.writeStyled(color(.cyan), s);
+                    self.writeRaw(" ");
+                    self.col += @intCast(s.len + 1);
+                } else {
+                    self.writeStyled(color(.cyan), "• ");
+                    self.col += 2;
+                }
+                self.block_stack.append(self.allocator, entry) catch {
+                    self.out.oom = true;
+                };
+            },
+            .hr => {
+                self.ensureBlankLine();
+                self.writeIndent();
+                const width: u32 = @min(self.theme.columns, 60);
+                var i: u32 = 0;
+                const dash = "─";
+                self.writeStyled(color(.dim), "");
+                while (i < width) : (i += 1) self.writeRaw(dash);
+                self.writeStyled(reset(), "");
+                self.writeRaw("\n");
+                self.last_was_newline = true;
+                self.col = 0;
+            },
+            .h => {
+                self.ensureBlankLine();
+                self.heading_level = @intCast(data);
+                self.heading_buf.clearRetainingCapacity();
+                // heading content is buffered; on leaveBlock we print with
+                // full styling + underline.
+            },
+            .code => {
+                self.ensureBlankLine();
+                self.in_code_block = true;
+                self.code_fenced = (flags & types.BLOCK_FENCED_CODE) != 0;
+                self.code_buf.clearRetainingCapacity();
+                if (self.code_fenced) {
+                    self.code_lang = extractLanguage(self.src_text, data);
+                } else {
+                    self.code_lang = "";
+                }
+            },
+            .html => {
+                self.ensureNewline();
+            },
+            .p => {
+                // When a paragraph sits directly inside a list item, the li
+                // marker has already emitted the indent + bullet; don't add
+                // a blank line or re-indent.
+                const top = if (self.block_stack.items.len > 0)
+                    self.block_stack.items[self.block_stack.items.len - 1].kind
+                else
+                    null;
+                if (top != null and top.? == .li and self.col > 0) {
+                    // continue on the same line
+                } else {
+                    self.ensureBlankLine();
+                    self.writeIndent();
+                }
+            },
+            .table => {
+                self.ensureBlankLine();
+                self.in_thead = false;
+                // Free any leftover rows from a previous invocation.
+                for (self.table_rows.items) |row| {
+                    for (row.cells) |cell| self.allocator.free(cell.content);
+                    self.allocator.free(row.cells);
+                }
+                self.table_rows.clearRetainingCapacity();
+                self.table_cells.clearRetainingCapacity();
+            },
+            .thead => {
+                self.in_thead = true;
+            },
+            .tbody => {
+                self.in_thead = false;
+            },
+            .tr => {
+                self.table_cells.clearRetainingCapacity();
+            },
+            .th, .td => {
+                self.in_cell = true;
+                self.cell_align = types.alignmentFromData(data);
+                self.table_cell_buf.clearRetainingCapacity();
+            },
+        }
+    }
+
+    pub fn leaveBlock(self: *AnsiRenderer, block_type: BlockType, data: u32) void {
+        switch (block_type) {
+            .doc => {},
+            .quote => {
+                self.quote_depth -= 1;
+                _ = self.block_stack.pop();
+                self.ensureNewline();
+            },
+            .ul, .ol => {
+                _ = self.block_stack.pop();
+                self.ensureNewline();
+            },
+            .li => {
+                _ = self.block_stack.pop();
+                self.ensureNewline();
+            },
+            .hr => {},
+            .h => {
+                self.flushHeading();
+                self.heading_level = 0;
+            },
+            .code => {
+                self.flushCodeBlock();
+                self.in_code_block = false;
+                self.code_lang = "";
+            },
+            .html => {
+                self.ensureNewline();
+            },
+            .p => {
+                self.writeStyled(reset(), "");
+                self.ensureNewline();
+                self.col = 0;
+            },
+            .table => {
+                self.flushTable();
+                self.ensureNewline();
+            },
+            .thead, .tbody => {},
+            .tr => {
+                // Move the collected cells into a table row; widths will be
+                // normalized once the table finishes.
+                const cells = self.allocator.dupe(TableCell, self.table_cells.items) catch {
+                    self.out.oom = true;
+                    return;
+                };
+                self.table_rows.append(self.allocator, .{
+                    .cells = cells,
+                    .is_header = self.in_thead,
+                }) catch {
+                    self.out.oom = true;
+                    return;
+                };
+                self.table_cells.clearRetainingCapacity();
+            },
+            .th, .td => {
+                self.in_cell = false;
+                const owned = self.allocator.dupe(u8, self.table_cell_buf.items) catch {
+                    self.out.oom = true;
+                    return;
+                };
+                self.table_cells.append(self.allocator, .{
+                    .content = owned,
+                    .alignment = self.cell_align,
+                }) catch {
+                    self.out.oom = true;
+                };
+            },
+        }
+        _ = data;
+    }
+
+    // ========================================
+    // Span rendering
+    // ========================================
+
+    pub fn enterSpan(self: *AnsiRenderer, span_type: SpanType, detail: SpanDetail) void {
+        switch (span_type) {
+            .em => {
+                self.span_flags |= SPAN_EM;
+                self.writeStyled(style(.italic), "");
+            },
+            .strong => {
+                self.span_flags |= SPAN_STRONG;
+                self.writeStyled(style(.bold), "");
+            },
+            .u => {
+                self.span_flags |= SPAN_U;
+                self.writeStyled(style(.underline), "");
+            },
+            .del => {
+                self.span_flags |= SPAN_DEL;
+                self.writeStyled(style(.strikethrough), "");
+            },
+            .code => {
+                self.span_flags |= SPAN_CODE;
+                // Inline code: faint background + surround padding.
+                self.writeStyled(codeSpanOpen(self.theme.light), "");
+            },
+            .a => {
+                self.link_depth += 1;
+                if (self.link_depth == 1) {
+                    // Resolve final href (prefixes for autolinks)
+                    const href = resolveHref(detail, self.allocator) catch "";
+                    self.link_href = href;
+                    if (self.theme.colors and self.theme.hyperlinks) {
+                        // OSC 8 hyperlink start
+                        self.writeRawNoColor("\x1b]8;;");
+                        self.writeRawNoColor(href);
+                        self.writeRawNoColor("\x1b\\");
+                    }
+                    self.writeStyled(color(.blue), "");
+                    self.writeStyled(style(.underline), "");
+                }
+            },
+            .img => {
+                self.image_depth += 1;
+                if (self.image_depth == 1) {
+                    self.image_src = self.allocator.dupe(u8, detail.href) catch "";
+                    self.image_title = self.allocator.dupe(u8, detail.title) catch "";
+                    self.image_alt.clearRetainingCapacity();
+                }
+            },
+            .wikilink => {
+                self.writeStyled(color(.blue), "[[");
+                self.col += 2;
+            },
+            .latexmath, .latexmath_display => {
+                self.writeStyled(color(.magenta), "$");
+                self.col += 1;
+            },
+        }
+    }
+
+    pub fn leaveSpan(self: *AnsiRenderer, span_type: SpanType) void {
+        switch (span_type) {
+            .em => {
+                self.span_flags &= ~SPAN_EM;
+                self.writeStyled("\x1b[23m", "");
+            },
+            .strong => {
+                self.span_flags &= ~SPAN_STRONG;
+                self.writeStyled("\x1b[22m", "");
+            },
+            .u => {
+                self.span_flags &= ~SPAN_U;
+                self.writeStyled("\x1b[24m", "");
+            },
+            .del => {
+                self.span_flags &= ~SPAN_DEL;
+                self.writeStyled("\x1b[29m", "");
+            },
+            .code => {
+                self.span_flags &= ~SPAN_CODE;
+                self.writeStyled(codeSpanClose(), "");
+            },
+            .a => {
+                if (self.link_depth == 1) {
+                    self.writeStyled("\x1b[24m", ""); // stop underline
+                    self.writeStyled(reset(), "");
+                    if (self.theme.colors and self.theme.hyperlinks) {
+                        self.writeRawNoColor("\x1b]8;;\x1b\\");
+                    } else if (self.link_href.len > 0) {
+                        // Show URL in parens for non-hyperlink terminals
+                        self.writeStyled(color(.dim), " (");
+                        self.writeRaw(self.link_href);
+                        self.writeStyled(color(.dim), ")");
+                        self.writeStyled(reset(), "");
+                        self.col += @intCast(self.link_href.len + 3);
+                    }
+                    self.allocator.free(self.link_href);
+                    self.link_href = "";
+                }
+                if (self.link_depth > 0) self.link_depth -= 1;
+            },
+            .img => {
+                if (self.image_depth == 1) {
+                    self.emitImage();
+                    self.allocator.free(self.image_src);
+                    self.allocator.free(self.image_title);
+                    self.image_src = "";
+                    self.image_title = "";
+                    self.image_alt.clearRetainingCapacity();
+                }
+                if (self.image_depth > 0) self.image_depth -= 1;
+            },
+            .wikilink => {
+                self.writeRaw("]]");
+                self.writeStyled(reset(), "");
+                self.col += 2;
+            },
+            .latexmath, .latexmath_display => {
+                self.writeRaw("$");
+                self.writeStyled(reset(), "");
+                self.col += 1;
+            },
+        }
+    }
+
+    // ========================================
+    // Text rendering
+    // ========================================
+
+    pub fn text(self: *AnsiRenderer, text_type: TextType, content: []const u8) void {
+        switch (text_type) {
+            .null_char => self.writeContent("\xEF\xBF\xBD"),
+            .br => self.writeContent("\n"),
+            .softbr => self.writeContent(" "),
+            .html => {
+                // Render raw HTML dimmed.
+                self.writeStyled(color(.dim), "");
+                self.writeContent(content);
+                self.writeStyled(reset(), "");
+            },
+            .entity => {
+                var buf: [8]u8 = undefined;
+                const decoded = helpers.decodeEntityToUtf8(content, &buf) orelse content;
+                self.writeContent(decoded);
+            },
+            .code => self.writeContent(content),
+            .latexmath => self.writeContent(content),
+            else => self.writeContent(content),
+        }
+    }
+
+    // ========================================
+    // Writing helpers
+    // ========================================
+
+    /// Route a chunk of rendered text to the appropriate sink (code buffer,
+    /// heading buffer, table cell, image alt, or directly to output).
+    fn writeContent(self: *AnsiRenderer, data: []const u8) void {
+        if (self.image_depth > 0) {
+            self.image_alt.appendSlice(self.allocator, data) catch {
+                self.out.oom = true;
+            };
+            return;
+        }
+        if (self.in_code_block) {
+            self.code_buf.appendSlice(self.allocator, data) catch {
+                self.out.oom = true;
+            };
+            return;
+        }
+        if (self.heading_level > 0) {
+            self.heading_buf.appendSlice(self.allocator, data) catch {
+                self.out.oom = true;
+            };
+            return;
+        }
+        if (self.in_cell) {
+            self.table_cell_buf.appendSlice(self.allocator, data) catch {
+                self.out.oom = true;
+            };
+            return;
+        }
+        // Normal paragraph flow: respect wrapping + indent.
+        self.writeWrapped(data);
+    }
+
+    /// Emit a chunk to output, wrapping at word boundaries when the column
+    /// exceeds `theme.columns`.
+    fn writeWrapped(self: *AnsiRenderer, data: []const u8) void {
+        if (self.theme.columns == 0) {
+            self.writeRaw(data);
+            self.updateColFromText(data);
+            return;
+        }
+        const indent = self.currentIndent();
+        const max = self.theme.columns;
+        var i: usize = 0;
+        while (i < data.len) {
+            const c = data[i];
+            if (c == '\n') {
+                self.writeRaw("\n");
+                self.last_was_newline = true;
+                self.col = 0;
+                i += 1;
+                if (i < data.len) {
+                    self.writeIndent();
+                }
+                continue;
+            }
+            if (c == ' ' and self.col >= max) {
+                self.writeRaw("\n");
+                self.last_was_newline = true;
+                self.col = 0;
+                self.writeIndent();
+                i += 1;
+                // collapse repeated spaces
+                while (i < data.len and data[i] == ' ') i += 1;
+                continue;
+            }
+            // find next break boundary
+            var j = i;
+            while (j < data.len and data[j] != ' ' and data[j] != '\n') : (j += 1) {}
+            const word = data[i..j];
+            const word_width = visibleWidth(word);
+            if (self.col != 0 and self.col + word_width > max and self.col > indent) {
+                self.writeRaw("\n");
+                self.last_was_newline = true;
+                self.col = 0;
+                self.writeIndent();
+            }
+            self.writeRaw(word);
+            self.col += @intCast(word_width);
+            self.last_was_newline = (word.len == 0);
+            i = j;
+            if (i < data.len and data[i] == ' ') {
+                self.writeRaw(" ");
+                self.col += 1;
+                i += 1;
+                while (i < data.len and data[i] == ' ') i += 1;
+            }
+        }
+    }
+
+    /// Emit a styled sequence + text, respecting color settings.
+    fn writeStyled(self: *AnsiRenderer, prefix: []const u8, text_: []const u8) void {
+        if (self.theme.colors) {
+            self.out.write(prefix);
+        }
+        if (text_.len > 0) {
+            self.out.write(text_);
+            self.col += @intCast(visibleWidth(text_));
+            self.last_was_newline = false;
+        }
+    }
+
+    /// Return the visible length of a styled sequence — the prefix adds
+    /// zero visible chars but advances `col` by the text length.
+    fn styledLen(self: *AnsiRenderer, s: []const u8) usize {
+        _ = self;
+        return visibleWidth(s);
+    }
+
+    /// Emit raw text (bypassing styling). Does not track the column.
+    fn writeRaw(self: *AnsiRenderer, data: []const u8) void {
+        self.out.write(data);
+        if (data.len > 0) self.last_was_newline = (data[data.len - 1] == '\n');
+    }
+
+    /// Emit raw bytes even when colors are off (for OSC sequences).
+    fn writeRawNoColor(self: *AnsiRenderer, data: []const u8) void {
+        if (!self.theme.colors) return;
+        self.out.write(data);
+    }
+
+    fn writeIndent(self: *AnsiRenderer) void {
+        var quote_bars: u32 = 0;
+        var other_indent: u32 = 0;
+        for (self.block_stack.items) |entry| {
+            switch (entry.kind) {
+                .quote => quote_bars += 1,
+                else => other_indent += entry.indent,
+            }
+        }
+        if (self.theme.colors and quote_bars > 0) {
+            self.out.write("\x1b[38;5;242m");
+        }
+        var i: u32 = 0;
+        while (i < quote_bars) : (i += 1) {
+            self.out.write("│ ");
+            self.col += 2;
+        }
+        if (self.theme.colors and quote_bars > 0) {
+            self.out.write("\x1b[0m");
+        }
+        var j: u32 = 0;
+        while (j < other_indent) : (j += 1) {
+            self.out.write(" ");
+            self.col += 1;
+        }
+    }
+
+    fn currentIndent(self: *AnsiRenderer) u32 {
+        var total: u32 = 0;
+        for (self.block_stack.items) |entry| {
+            total += if (entry.kind == .quote) 2 else entry.indent;
+        }
+        return total;
+    }
+
+    fn updateColFromText(self: *AnsiRenderer, data: []const u8) void {
+        var i: usize = 0;
+        while (i < data.len) : (i += 1) {
+            if (data[i] == '\n') {
+                self.col = 0;
+                self.last_was_newline = true;
+            } else {
+                self.col += 1;
+                self.last_was_newline = false;
+            }
+        }
+    }
+
+    fn ensureNewline(self: *AnsiRenderer) void {
+        if (!self.last_was_newline) {
+            self.out.writeByte('\n');
+            self.col = 0;
+            self.last_was_newline = true;
+        }
+    }
+
+    fn ensureBlankLine(self: *AnsiRenderer) void {
+        self.ensureNewline();
+        // Add an extra blank line only if we already produced output.
+        if (self.out.list.items.len > 0) {
+            // Check if last two chars are newlines
+            const items = self.out.list.items;
+            if (items.len >= 2 and items[items.len - 1] == '\n' and items[items.len - 2] != '\n') {
+                self.out.writeByte('\n');
+                self.col = 0;
+            } else if (items.len == 1 and items[0] == '\n') {
+                // single newline — don't add another
+            } else if (items.len >= 1 and items[items.len - 1] != '\n') {
+                self.out.writeByte('\n');
+                self.col = 0;
+            }
+        }
+    }
+
+    /// Find the nearest enclosing ul/ol in the block stack (walking
+    /// from innermost outward, skipping the current li at the top).
+    fn findParentList(self: *AnsiRenderer) ?*BlockContext {
+        const len = self.block_stack.items.len;
+        if (len == 0) return null;
+        var i: usize = len;
+        while (i > 0) {
+            i -= 1;
+            const entry = &self.block_stack.items[i];
+            if (entry.kind == .ul or entry.kind == .ol) return entry;
+        }
+        return null;
+    }
+
+    // ========================================
+    // Heading flush
+    // ========================================
+
+    fn flushHeading(self: *AnsiRenderer) void {
+        const level = self.heading_level;
+        const content = self.heading_buf.items;
+        self.writeIndent();
+        const prefix = switch (level) {
+            1 => "",
+            2 => "",
+            3 => "",
+            4 => "",
+            5 => "",
+            else => "",
+        };
+        _ = prefix;
+        const heading_color = switch (level) {
+            1 => color(.magenta),
+            2 => color(.cyan),
+            3 => color(.yellow),
+            4 => color(.green),
+            5 => color(.blue),
+            else => color(.white),
+        };
+        if (self.theme.colors) {
+            self.out.write("\x1b[1m"); // bold
+            self.out.write(heading_color);
+        }
+        self.out.write(content);
+        if (self.theme.colors) self.out.write("\x1b[0m");
+        self.out.writeByte('\n');
+        self.last_was_newline = true;
+        self.col = 0;
+        // Add underline for h1/h2
+        if (level == 1 or level == 2) {
+            const width = @min(
+                @max(visibleWidth(content), 3),
+                @as(usize, @intCast(self.theme.columns)),
+            );
+            if (self.theme.colors) self.out.write(color(.dim));
+            const char = if (level == 1) "═" else "─";
+            var i: usize = 0;
+            while (i < width) : (i += 1) self.out.write(char);
+            if (self.theme.colors) self.out.write("\x1b[0m");
+            self.out.writeByte('\n');
+        }
+    }
+
+    // ========================================
+    // Code block flush with syntax highlighting
+    // ========================================
+
+    fn flushCodeBlock(self: *AnsiRenderer) void {
+        const src = self.code_buf.items;
+        // Strip exactly one trailing newline (parser adds one).
+        const body = if (src.len > 0 and src[src.len - 1] == '\n') src[0 .. src.len - 1] else src;
+
+        // Language badge
+        if (self.theme.colors) self.out.write(color(.dim));
+        self.writeIndent();
+        const badge = if (self.code_lang.len > 0) self.code_lang else "";
+        if (badge.len > 0) {
+            self.out.write("┌─ ");
+            if (self.theme.colors) self.out.write("\x1b[0m");
+            if (self.theme.colors) self.out.write("\x1b[2m\x1b[3m");
+            self.out.write(badge);
+            if (self.theme.colors) self.out.write("\x1b[0m");
+        } else {
+            if (self.theme.colors) self.out.write(color(.dim));
+            self.out.write("┌─");
+            if (self.theme.colors) self.out.write("\x1b[0m");
+        }
+        self.out.writeByte('\n');
+        self.last_was_newline = true;
+
+        // Highlight body for JS/TS/JSX/TSX; otherwise print as-is.
+        const is_js = isJsLang(self.code_lang);
+        var line_start: usize = 0;
+        var i: usize = 0;
+        while (i <= body.len) : (i += 1) {
+            if (i == body.len or body[i] == '\n') {
+                const line = body[line_start..i];
+                self.writeIndent();
+                if (self.theme.colors) self.out.write(color(.dim));
+                self.out.write("│ ");
+                if (self.theme.colors) self.out.write("\x1b[0m");
+                if (is_js and self.theme.colors) {
+                    self.writeHighlightedJs(line);
+                } else {
+                    self.out.write(line);
+                }
+                self.out.writeByte('\n');
+                self.last_was_newline = true;
+                line_start = i + 1;
+            }
+        }
+        // Closing border
+        self.writeIndent();
+        if (self.theme.colors) self.out.write(color(.dim));
+        self.out.write("└─");
+        if (self.theme.colors) self.out.write("\x1b[0m");
+        self.out.writeByte('\n');
+        self.col = 0;
+        self.last_was_newline = true;
+    }
+
+    fn writeHighlightedJs(self: *AnsiRenderer, line: []const u8) void {
+        const highlighter = bun.fmt.QuickAndDirtyJavaScriptSyntaxHighlighter{
+            .text = line,
+            .opts = .{ .enable_colors = true, .check_for_unhighlighted_write = false },
+        };
+        var aw: std.Io.Writer.Allocating = .init(self.allocator);
+        defer aw.deinit();
+        highlighter.format(&aw.writer) catch {
+            self.out.write(line);
+            return;
+        };
+        self.out.write(aw.written());
+    }
+
+    // ========================================
+    // Table flush
+    // ========================================
+
+    fn flushTable(self: *AnsiRenderer) void {
+        if (self.table_rows.items.len == 0) return;
+
+        // Compute max column widths across all rows.
+        var col_count: usize = 0;
+        for (self.table_rows.items) |row| col_count = @max(col_count, row.cells.len);
+        if (col_count == 0) return;
+
+        var widths = self.allocator.alloc(usize, col_count) catch {
+            self.out.oom = true;
+            return;
+        };
+        defer self.allocator.free(widths);
+        @memset(widths, 3);
+        // Track alignment per column (first seen wins, headers precede body).
+        var aligns = self.allocator.alloc(types.Align, col_count) catch {
+            self.out.oom = true;
+            return;
+        };
+        defer self.allocator.free(aligns);
+        @memset(aligns, .default);
+        for (self.table_rows.items) |row| {
+            for (row.cells, 0..) |cell, i| {
+                widths[i] = @max(widths[i], visibleWidth(cell.content));
+                if (aligns[i] == .default) aligns[i] = cell.alignment;
+            }
+        }
+
+        // Top border
+        self.writeIndent();
+        if (self.theme.colors) self.out.write(color(.dim));
+        self.out.write("┌");
+        for (widths, 0..) |w, i| {
+            var j: usize = 0;
+            while (j < w + 2) : (j += 1) self.out.write("─");
+            self.out.write(if (i == widths.len - 1) "┐" else "┬");
+        }
+        if (self.theme.colors) self.out.write("\x1b[0m");
+        self.out.writeByte('\n');
+        self.last_was_newline = true;
+
+        // Rows
+        var has_separated_header = false;
+        for (self.table_rows.items) |row| {
+            self.writeRowCells(row, widths, aligns);
+            if (row.is_header and !has_separated_header) {
+                self.writeTableSeparator(widths);
+                has_separated_header = true;
+            }
+        }
+
+        // Bottom border
+        self.writeIndent();
+        if (self.theme.colors) self.out.write(color(.dim));
+        self.out.write("└");
+        for (widths, 0..) |w, i| {
+            var j: usize = 0;
+            while (j < w + 2) : (j += 1) self.out.write("─");
+            self.out.write(if (i == widths.len - 1) "┘" else "┴");
+        }
+        if (self.theme.colors) self.out.write("\x1b[0m");
+        self.out.writeByte('\n');
+        self.last_was_newline = true;
+
+        // Free rows
+        for (self.table_rows.items) |row| {
+            for (row.cells) |cell| self.allocator.free(cell.content);
+            self.allocator.free(row.cells);
+        }
+        self.table_rows.clearRetainingCapacity();
+    }
+
+    fn writeRowCells(
+        self: *AnsiRenderer,
+        row: TableRow,
+        widths: []const usize,
+        aligns: []const types.Align,
+    ) void {
+        self.writeIndent();
+        if (self.theme.colors) self.out.write(color(.dim));
+        self.out.write("│");
+        if (self.theme.colors) self.out.write("\x1b[0m");
+        for (widths, 0..) |w, i| {
+            const cell: TableCell = if (i < row.cells.len) row.cells[i] else .{ .content = "", .alignment = .default };
+            self.out.writeByte(' ');
+            if (row.is_header and self.theme.colors) self.out.write("\x1b[1m");
+            const cw = visibleWidth(cell.content);
+            const alignment = if (cell.alignment != .default) cell.alignment else aligns[i];
+            switch (alignment) {
+                .right => {
+                    self.writePadding(w - cw);
+                    self.out.write(cell.content);
+                },
+                .center => {
+                    const pad = w - cw;
+                    self.writePadding(pad / 2);
+                    self.out.write(cell.content);
+                    self.writePadding(pad - pad / 2);
+                },
+                else => {
+                    self.out.write(cell.content);
+                    self.writePadding(w - cw);
+                },
+            }
+            if (row.is_header and self.theme.colors) self.out.write("\x1b[0m");
+            self.out.writeByte(' ');
+            if (self.theme.colors) self.out.write(color(.dim));
+            self.out.write("│");
+            if (self.theme.colors) self.out.write("\x1b[0m");
+        }
+        self.out.writeByte('\n');
+        self.last_was_newline = true;
+    }
+
+    fn writeTableSeparator(self: *AnsiRenderer, widths: []const usize) void {
+        self.writeIndent();
+        if (self.theme.colors) self.out.write(color(.dim));
+        self.out.write("├");
+        for (widths, 0..) |w, i| {
+            var j: usize = 0;
+            while (j < w + 2) : (j += 1) self.out.write("─");
+            self.out.write(if (i == widths.len - 1) "┤" else "┼");
+        }
+        if (self.theme.colors) self.out.write("\x1b[0m");
+        self.out.writeByte('\n');
+        self.last_was_newline = true;
+    }
+
+    fn writePadding(self: *AnsiRenderer, n: usize) void {
+        var i: usize = 0;
+        while (i < n) : (i += 1) self.out.writeByte(' ');
+    }
+
+    // ========================================
+    // Image emission (alt text, with optional Kitty graphics)
+    // ========================================
+
+    fn emitImage(self: *AnsiRenderer) void {
+        const alt = self.image_alt.items;
+        // Display as: [alt text] (src)  with OSC 8 hyperlink
+        if (self.theme.colors and self.theme.hyperlinks and self.image_src.len > 0) {
+            self.writeRawNoColor("\x1b]8;;");
+            self.writeRawNoColor(self.image_src);
+            self.writeRawNoColor("\x1b\\");
+        }
+        self.writeStyled(color(.magenta), "🖼 ");
+        if (alt.len > 0) {
+            self.writeRaw(alt);
+            self.col += @intCast(visibleWidth(alt));
+        } else if (self.image_title.len > 0) {
+            self.writeRaw(self.image_title);
+            self.col += @intCast(visibleWidth(self.image_title));
+        } else {
+            self.writeRaw("(image)");
+            self.col += 7;
+        }
+        self.writeStyled(reset(), "");
+        if (self.theme.colors and self.theme.hyperlinks and self.image_src.len > 0) {
+            self.writeRawNoColor("\x1b]8;;\x1b\\");
+        }
+    }
+};
+
+// ========================================
+// Module-level helpers
+// ========================================
+
+const AnsiColor = enum {
+    black,
+    red,
+    green,
+    yellow,
+    blue,
+    magenta,
+    cyan,
+    white,
+    dim,
+};
+
+fn color(c: AnsiColor) []const u8 {
+    return switch (c) {
+        .black => "\x1b[30m",
+        .red => "\x1b[31m",
+        .green => "\x1b[32m",
+        .yellow => "\x1b[33m",
+        .blue => "\x1b[34m",
+        .magenta => "\x1b[35m",
+        .cyan => "\x1b[36m",
+        .white => "\x1b[37m",
+        .dim => "\x1b[2m",
+    };
+}
+
+const AnsiStyle = enum {
+    bold,
+    italic,
+    underline,
+    strikethrough,
+};
+
+fn style(s: AnsiStyle) []const u8 {
+    return switch (s) {
+        .bold => "\x1b[1m",
+        .italic => "\x1b[3m",
+        .underline => "\x1b[4m",
+        .strikethrough => "\x1b[9m",
+    };
+}
+
+fn reset() []const u8 {
+    return "\x1b[0m";
+}
+
+fn codeSpanOpen(light: bool) []const u8 {
+    // Distinct inline-code look: soft background tint + yellow text.
+    return if (light) "\x1b[48;5;254m\x1b[38;5;124m" else "\x1b[48;5;236m\x1b[38;5;215m";
+}
+
+fn codeSpanClose() []const u8 {
+    return "\x1b[0m";
+}
+
+/// Visible printable width of a UTF-8 byte slice, excluding ANSI escape
+/// sequences. Correctly handles multi-width graphemes (CJK, emoji).
+fn visibleWidth(s: []const u8) usize {
+    return bun.strings.visible.width.exclude_ansi_colors.utf8(s);
+}
+
+fn isJsLang(lang: []const u8) bool {
+    const names = [_][]const u8{
+        "js", "javascript", "jsx", "mjs", "cjs",
+        "ts", "typescript", "tsx", "mts", "cts",
+    };
+    for (names) |n| {
+        if (bun.strings.eqlCaseInsensitiveASCII(lang, n, true)) return true;
+    }
+    return false;
+}
+
+fn extractLanguage(src_text: []const u8, info_beg: u32) []const u8 {
+    var lang_end: u32 = info_beg;
+    while (lang_end < src_text.len) {
+        const c = src_text[lang_end];
+        if (c == ' ' or c == '\t' or c == '\n' or c == '\r') break;
+        lang_end += 1;
+    }
+    if (lang_end > info_beg) return src_text[info_beg..lang_end];
+    return "";
+}
+
+/// Build the final href string with autolink prefixes (mailto:, http://).
+/// Caller owns the returned memory.
+fn resolveHref(detail: SpanDetail, allocator: Allocator) ![]u8 {
+    var buf: std.ArrayListUnmanaged(u8) = .{};
+    errdefer buf.deinit(allocator);
+    if (detail.autolink_email) try buf.appendSlice(allocator, "mailto:");
+    if (detail.autolink_www) try buf.appendSlice(allocator, "http://");
+    try buf.appendSlice(allocator, detail.href);
+    return try buf.toOwnedSlice(allocator);
+}
+
+// ========================================
+// Theme detection helpers (callable from the runner)
+// ========================================
+
+/// Detect whether the terminal background is light. Preference order:
+/// 1. `COLORFGBG` env var (set by rxvt, xterm, Konsole, iTerm2 in some modes)
+/// 2. Dark mode (default)
+pub fn detectLightBackground() bool {
+    if (std.posix.getenv("COLORFGBG")) |value| {
+        // Format: "fg;bg" or "fg;default;bg" — bg index < 8 is dark, >=8 light
+        var iter = std.mem.splitScalar(u8, value, ';');
+        var last: []const u8 = "";
+        while (iter.next()) |part| last = part;
+        if (last.len > 0) {
+            const bg = std.fmt.parseInt(u8, last, 10) catch return false;
+            // Terminals using this convention treat 0-6 and 8 as dark, 7/15 as light.
+            // A higher threshold is safer.
+            return bg >= 7 and bg != 8;
+        }
+    }
+    return false;
+}
+
+// ========================================
+// Public entry point
+// ========================================
+
+/// Render markdown text to ANSI. Caller owns the returned bytes.
+pub fn renderToAnsi(
+    text: []const u8,
+    allocator: Allocator,
+    options: root.Options,
+    theme: Theme,
+) !?[]u8 {
+    var renderer = AnsiRenderer.init(allocator, text, theme);
+    defer renderer.deinit();
+    root.renderWithRenderer(text, allocator, options, renderer.renderer()) catch |err| switch (err) {
+        error.JSError, error.JSTerminated => return null,
+        error.OutOfMemory => return error.OutOfMemory,
+        error.StackOverflow => return error.StackOverflow,
+    };
+    if (renderer.out.oom) return error.OutOfMemory;
+    return try renderer.out.list.toOwnedSlice(allocator);
+}
+
+const bun = @import("bun");
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const root = @import("./root.zig");
+const helpers = @import("./helpers.zig");
+const types = @import("./types.zig");
+const BlockType = types.BlockType;
+const SpanType = types.SpanType;
+const TextType = types.TextType;
+const SpanDetail = types.SpanDetail;
+const Renderer = types.Renderer;

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -684,8 +684,24 @@ pub const AnsiRenderer = struct {
     /// exceeds `theme.columns`.
     fn writeWrapped(self: *AnsiRenderer, data: []const u8) void {
         if (self.theme.columns == 0) {
-            self.writeRaw(data);
-            self.updateColFromText(data);
+            // No-wrap path: still emit the indent after each embedded
+            // newline so continuation lines inside blockquotes / list
+            // items keep their `│ ` / hanging prefix.
+            var start: usize = 0;
+            var i: usize = 0;
+            while (i < data.len) : (i += 1) {
+                if (data[i] == '\n') {
+                    self.writeRaw(data[start .. i + 1]);
+                    self.col = 0;
+                    self.last_was_newline = true;
+                    self.writeIndent();
+                    start = i + 1;
+                }
+            }
+            if (start < data.len) {
+                self.writeRaw(data[start..]);
+                self.updateColFromText(data[start..]);
+            }
             return;
         }
         const indent = self.currentIndent();

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -588,8 +588,10 @@ pub const AnsiRenderer = struct {
                         // Only emit the OSC 8 terminator if we emitted the
                         // opening sequence (which required link_href).
                         if (had_href) self.writeRawNoColor("\x1b]8;;\x1b\\");
-                    } else if (self.link_href) |href| if (href.len > 0) {
-                        // Show URL in parens for non-hyperlink terminals
+                    } else if (self.link_href) |href| if (href.len > 0 and self.image_depth == 0) {
+                        // Show URL in parens for non-hyperlink terminals.
+                        // image_depth==0 keeps " (url)" out of image alt
+                        // text when a link sits inside an image span.
                         self.writeStyled(color(.dim), " (");
                         self.writeStyled("", href);
                         self.writeStyled(color(.dim), ")");
@@ -654,7 +656,11 @@ pub const AnsiRenderer = struct {
                 const decoded = helpers.decodeEntityToUtf8(content, &buf) orelse content;
                 self.writeContent(decoded);
             },
-            .code => self.writeContent(content),
+            // Inline code spans are atomic — don't let writeWrapped split
+            // them at internal spaces. writeStyled with empty prefix routes
+            // the content through the active buffer + updates col in one
+            // pass, without the paragraph word-wrap logic.
+            .code => self.writeStyled("", content),
             .latexmath => self.writeContent(content),
             else => self.writeContent(content),
         }
@@ -905,6 +911,7 @@ pub const AnsiRenderer = struct {
         if (self.span_flags & SPAN_EM != 0) self.emitInline(style(.italic));
         if (self.span_flags & SPAN_U != 0) self.emitInline(style(.underline));
         if (self.span_flags & SPAN_DEL != 0) self.emitInline(style(.strikethrough));
+        if (self.span_flags & SPAN_CODE != 0) self.emitInline(codeSpanOpen(self.theme.light));
         if (self.link_depth > 0) {
             self.emitInline(color(.blue));
             self.emitInline(style(.underline));

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1424,7 +1424,11 @@ pub const AnsiRenderer = struct {
         // payloads are megabytes of base64 and would exceed typical
         // terminal OSC parameter limits (64KB–1MB), causing rendering
         // artifacts, hangs, or garbage output.
+        // Also skip when we're inside an enclosing link span
+        // (`[![alt](img)](url)`) — emitting our own OSC 8 would overwrite
+        // the outer link destination for subsequent text on that line.
         const link_ok = self.theme.colors and self.theme.hyperlinks and has_src and
+            self.link_depth == 0 and
             !bun.strings.startsWith(src.?, "data:");
         if (link_ok) {
             self.writeRawNoColor("\x1b]8;;");

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1568,7 +1568,7 @@ pub fn detectKittyGraphics() bool {
 /// the reply with a short timeout. Raw mode is applied + restored
 /// around the read so the bytes don't echo to the user's terminal.
 fn probeKittyGraphics() bool {
-    if (!bun.Environment.isPosix) return false;
+    if (comptime !bun.Environment.isPosix) return false;
     if (bun.Output.bun_stdio_tty[0] == 0 or bun.Output.bun_stdio_tty[1] == 0) return false;
     // Honor an explicit opt-out.
     if (bun.getenvZ("BUN_DISABLE_KITTY_PROBE")) |_| return false;
@@ -1577,22 +1577,12 @@ fn probeKittyGraphics() bool {
     // parent (a TUI, tmux/Zellij pane, etc.) already had raw mode on,
     // restoring to a fixed .normal would corrupt it — instead reapply
     // exactly what we read. tcgetattr failing means stdin isn't a real
-    // TTY in a way we can snapshot; fall back to forcing .normal.
-    var saved_termios: std.posix.termios = undefined;
-    const have_saved = if (std.posix.tcgetattr(0)) |t| blk: {
-        saved_termios = t;
-        break :blk true;
-    } else |_| false;
+    // TTY in a way we can snapshot; skip probing entirely.
+    const saved_termios = std.posix.tcgetattr(0) catch return false;
     _ = bun.tty.setMode(0, .raw);
-    defer {
-        if (have_saved) {
-            std.posix.tcsetattr(0, .NOW, saved_termios) catch {
-                _ = bun.tty.setMode(0, .normal);
-            };
-        } else {
-            _ = bun.tty.setMode(0, .normal);
-        }
-    }
+    defer std.posix.tcsetattr(0, .NOW, saved_termios) catch {
+        _ = bun.tty.setMode(0, .normal);
+    };
 
     // Query: transmit a 1×1 RGB image (3 zero bytes = "AAAA" b64),
     // id=31. The terminal replies with `\x1b_Gi=31;OK\x1b\\`

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1397,6 +1397,9 @@ pub const AnsiRenderer = struct {
         self.writeRaw("\n");
         self.col = 0;
         self.last_was_newline = true;
+        // Re-emit the active block indent so text that follows the image
+        // inside a blockquote / list item keeps its `│ ` / hanging prefix.
+        self.writeIndent();
     }
 
     /// Emit a Kitty Graphics Protocol transmit-and-display sequence with
@@ -1410,6 +1413,7 @@ pub const AnsiRenderer = struct {
         self.writeRaw("\n");
         self.col = 0;
         self.last_was_newline = true;
+        self.writeIndent();
     }
 };
 

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -222,12 +222,14 @@ pub const AnsiRenderer = struct {
                     entry.index = list.index;
                     list.index += 1;
                 }
+                var marker_width: u32 = 0;
                 if (task_mark != 0) {
                     const checked = types.isTaskChecked(task_mark);
                     const glyph = if (checked) "☒ " else "☐ ";
                     const c = if (checked) color(.green) else color(.dim);
                     self.writeStyled(c, glyph);
                     self.writeStyled(reset(), "");
+                    marker_width = @intCast(visibleWidth(glyph));
                 } else if (parent_list != null and parent_list.?.kind == .ol) {
                     const start = parent_list.?.data;
                     const num = start + entry.index;
@@ -235,10 +237,16 @@ pub const AnsiRenderer = struct {
                     const s = std.fmt.bufPrint(&buf, "{d}. ", .{num}) catch "? ";
                     self.writeStyled(color(.cyan), s);
                     self.writeStyled(reset(), "");
+                    marker_width = @intCast(visibleWidth(s));
                 } else {
-                    self.writeStyled(color(.cyan), "• ");
+                    const bullet = if (self.theme.colors) "• " else "* ";
+                    self.writeStyled(color(.cyan), bullet);
                     self.writeStyled(reset(), "");
+                    marker_width = @intCast(visibleWidth(bullet));
                 }
+                // Wrapped continuation lines need to land under the item's
+                // content (past the marker), so record the marker width.
+                entry.indent = marker_width;
                 self.block_stack.append(self.allocator, entry) catch {
                     self.out.oom = true;
                 };
@@ -248,7 +256,7 @@ pub const AnsiRenderer = struct {
                 self.writeIndent();
                 const width: u32 = @min(self.theme.columns, 60);
                 var i: u32 = 0;
-                const dash = "─";
+                const dash = if (self.theme.colors) "─" else "-";
                 self.writeStyled(color(.dim), "");
                 while (i < width) : (i += 1) self.writeRaw(dash);
                 self.writeStyled(reset(), "");
@@ -715,8 +723,13 @@ pub const AnsiRenderer = struct {
         }
         if (text_.len > 0) {
             self.emitInline(text_);
-            self.col += @intCast(visibleWidth(text_));
-            self.last_was_newline = false;
+            // `col` tracks the visible cursor on the main output only —
+            // bytes buffered into a cell / heading / image-alt / code
+            // block don't move the current line's cursor.
+            if (!self.in_cell and self.heading_level == 0 and !self.in_code_block and self.image_depth == 0) {
+                self.col += @intCast(visibleWidth(text_));
+                self.last_was_newline = false;
+            }
         }
     }
 
@@ -750,14 +763,19 @@ pub const AnsiRenderer = struct {
         self.out.write(data);
     }
 
-    /// Re-emit the currently active inline styles from span_flags. Used
-    /// after a nested span closes to avoid wiping the outer styles.
+    /// Re-emit the currently active inline styles from span_flags and the
+    /// link-styling state. Used after a nested span closes so the outer
+    /// style doesn't get wiped, and after writeIndent emits its own reset.
     fn reapplyStyles(self: *AnsiRenderer) void {
         if (!self.theme.colors) return;
         if (self.span_flags & SPAN_STRONG != 0) self.emitInline(style(.bold));
         if (self.span_flags & SPAN_EM != 0) self.emitInline(style(.italic));
         if (self.span_flags & SPAN_U != 0) self.emitInline(style(.underline));
         if (self.span_flags & SPAN_DEL != 0) self.emitInline(style(.strikethrough));
+        if (self.link_depth > 0) {
+            self.emitInline(color(.blue));
+            self.emitInline(style(.underline));
+        }
     }
 
     fn writeIndent(self: *AnsiRenderer) void {
@@ -769,16 +787,20 @@ pub const AnsiRenderer = struct {
                 else => other_indent += entry.indent,
             }
         }
+        const bar = if (self.theme.colors) "│ " else "| ";
         if (self.theme.colors and quote_bars > 0) {
             self.out.write("\x1b[38;5;242m");
         }
         var i: u32 = 0;
         while (i < quote_bars) : (i += 1) {
-            self.out.write("│ ");
+            self.out.write(bar);
             self.col += 2;
         }
         if (self.theme.colors and quote_bars > 0) {
-            self.out.write("\x1b[0m");
+            // Clear only the indent's fg color; keep any active inline
+            // styles intact by re-applying them after the targeted off.
+            self.out.write("\x1b[39m");
+            self.reapplyStyles();
         }
         var j: u32 = 0;
         while (j < other_indent) : (j += 1) {
@@ -889,7 +911,7 @@ pub const AnsiRenderer = struct {
                 @as(usize, @intCast(self.theme.columns)),
             );
             if (self.theme.colors) self.out.write(color(.dim));
-            const char = if (level == 1) "═" else "─";
+            const char = if (self.theme.colors) (if (level == 1) "═" else "─") else (if (level == 1) "=" else "-");
             var i: usize = 0;
             while (i < width) : (i += 1) self.out.write(char);
             if (self.theme.colors) self.out.write("\x1b[0m");
@@ -906,19 +928,24 @@ pub const AnsiRenderer = struct {
         // Strip exactly one trailing newline (parser adds one).
         const body = if (src.len > 0 and src[src.len - 1] == '\n') src[0 .. src.len - 1] else src;
 
+        const top_border = if (self.theme.colors) "┌─ " else "+- ";
+        const top_bare = if (self.theme.colors) "┌─" else "+-";
+        const side = if (self.theme.colors) "│ " else "| ";
+        const bottom = if (self.theme.colors) "└─" else "+-";
+
         // Language badge
         if (self.theme.colors) self.out.write(color(.dim));
         self.writeIndent();
         const badge = if (self.code_lang.len > 0) self.code_lang else "";
         if (badge.len > 0) {
-            self.out.write("┌─ ");
+            self.out.write(top_border);
             if (self.theme.colors) self.out.write("\x1b[0m");
             if (self.theme.colors) self.out.write("\x1b[2m\x1b[3m");
             self.out.write(badge);
             if (self.theme.colors) self.out.write("\x1b[0m");
         } else {
             if (self.theme.colors) self.out.write(color(.dim));
-            self.out.write("┌─");
+            self.out.write(top_bare);
             if (self.theme.colors) self.out.write("\x1b[0m");
         }
         self.out.writeByte('\n');
@@ -933,7 +960,7 @@ pub const AnsiRenderer = struct {
                 const line = body[line_start..i];
                 self.writeIndent();
                 if (self.theme.colors) self.out.write(color(.dim));
-                self.out.write("│ ");
+                self.out.write(side);
                 if (self.theme.colors) self.out.write("\x1b[0m");
                 if (is_js and self.theme.colors) {
                     self.writeHighlightedJs(line);
@@ -948,7 +975,7 @@ pub const AnsiRenderer = struct {
         // Closing border
         self.writeIndent();
         if (self.theme.colors) self.out.write(color(.dim));
-        self.out.write("└─");
+        self.out.write(bottom);
         if (self.theme.colors) self.out.write("\x1b[0m");
         self.out.writeByte('\n');
         self.col = 0;
@@ -1001,14 +1028,16 @@ pub const AnsiRenderer = struct {
             }
         }
 
+        const chars = self.boxChars();
+
         // Top border
         self.writeIndent();
         if (self.theme.colors) self.out.write(color(.dim));
-        self.out.write("┌");
+        self.out.write(chars.tl);
         for (widths, 0..) |w, i| {
             var j: usize = 0;
-            while (j < w + 2) : (j += 1) self.out.write("─");
-            self.out.write(if (i == widths.len - 1) "┐" else "┬");
+            while (j < w + 2) : (j += 1) self.out.write(chars.h);
+            self.out.write(if (i == widths.len - 1) chars.tr else chars.t);
         }
         if (self.theme.colors) self.out.write("\x1b[0m");
         self.out.writeByte('\n');
@@ -1027,11 +1056,11 @@ pub const AnsiRenderer = struct {
         // Bottom border
         self.writeIndent();
         if (self.theme.colors) self.out.write(color(.dim));
-        self.out.write("└");
+        self.out.write(chars.bl);
         for (widths, 0..) |w, i| {
             var j: usize = 0;
-            while (j < w + 2) : (j += 1) self.out.write("─");
-            self.out.write(if (i == widths.len - 1) "┘" else "┴");
+            while (j < w + 2) : (j += 1) self.out.write(chars.h);
+            self.out.write(if (i == widths.len - 1) chars.br else chars.b);
         }
         if (self.theme.colors) self.out.write("\x1b[0m");
         self.out.writeByte('\n');
@@ -1051,9 +1080,10 @@ pub const AnsiRenderer = struct {
         widths: []const usize,
         aligns: []const types.Align,
     ) void {
+        const chars = self.boxChars();
         self.writeIndent();
         if (self.theme.colors) self.out.write(color(.dim));
-        self.out.write("│");
+        self.out.write(chars.v);
         if (self.theme.colors) self.out.write("\x1b[0m");
         for (widths, 0..) |w, i| {
             const cell: TableCell = if (i < row.cells.len) row.cells[i] else .{ .content = "", .alignment = .default };
@@ -1080,7 +1110,7 @@ pub const AnsiRenderer = struct {
             if (row.is_header and self.theme.colors) self.out.write("\x1b[0m");
             self.out.writeByte(' ');
             if (self.theme.colors) self.out.write(color(.dim));
-            self.out.write("│");
+            self.out.write(chars.v);
             if (self.theme.colors) self.out.write("\x1b[0m");
         }
         self.out.writeByte('\n');
@@ -1088,17 +1118,50 @@ pub const AnsiRenderer = struct {
     }
 
     fn writeTableSeparator(self: *AnsiRenderer, widths: []const usize) void {
+        const chars = self.boxChars();
         self.writeIndent();
         if (self.theme.colors) self.out.write(color(.dim));
-        self.out.write("├");
+        self.out.write(chars.ml);
         for (widths, 0..) |w, i| {
             var j: usize = 0;
-            while (j < w + 2) : (j += 1) self.out.write("─");
-            self.out.write(if (i == widths.len - 1) "┤" else "┼");
+            while (j < w + 2) : (j += 1) self.out.write(chars.h);
+            self.out.write(if (i == widths.len - 1) chars.mr else chars.x);
         }
         if (self.theme.colors) self.out.write("\x1b[0m");
         self.out.writeByte('\n');
         self.last_was_newline = true;
+    }
+
+    const BoxChars = struct {
+        h: []const u8,
+        v: []const u8,
+        tl: []const u8,
+        tr: []const u8,
+        bl: []const u8,
+        br: []const u8,
+        t: []const u8,
+        b: []const u8,
+        ml: []const u8,
+        mr: []const u8,
+        x: []const u8,
+    };
+
+    fn boxChars(self: *AnsiRenderer) BoxChars {
+        return if (self.theme.colors) .{
+            .h = "─", .v = "│",
+            .tl = "┌", .tr = "┐",
+            .bl = "└", .br = "┘",
+            .t = "┬", .b = "┴",
+            .ml = "├", .mr = "┤",
+            .x = "┼",
+        } else .{
+            .h = "-", .v = "|",
+            .tl = "+", .tr = "+",
+            .bl = "+", .br = "+",
+            .t = "+", .b = "+",
+            .ml = "+", .mr = "+",
+            .x = "+",
+        };
     }
 
     fn writePadding(self: *AnsiRenderer, n: usize) void {
@@ -1128,7 +1191,8 @@ pub const AnsiRenderer = struct {
             self.writeRawNoColor(src.?);
             self.writeRawNoColor("\x1b\\");
         }
-        self.writeStyled(color(.magenta), "🖼 ");
+        const img_marker = if (self.theme.colors) "🖼 " else "[img] ";
+        self.writeStyled(color(.magenta), img_marker);
         if (alt.len > 0) {
             self.writeStyled("", alt);
         } else if (self.image_title) |title| if (title.len > 0) {

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -622,17 +622,20 @@ pub const AnsiRenderer = struct {
                 if (self.image_depth > 0) self.image_depth -= 1;
             },
             .wikilink => {
-                self.writeStyled("", "]]");
+                // Use writeNoWrap so the closing delimiter stays attached
+                // to the content it closes — writeStyled would wrap `]]`
+                // to a new line when the inner text fills up to col-max.
+                self.writeNoWrap("]]");
                 self.writeStyled("\x1b[39m", "");
                 self.reapplyStyles();
             },
             .latexmath => {
-                self.writeStyled("", "$");
+                self.writeNoWrap("$");
                 self.writeStyled("\x1b[39m", "");
                 self.reapplyStyles();
             },
             .latexmath_display => {
-                self.writeStyled("", "$$");
+                self.writeNoWrap("$$");
                 self.writeStyled("\x1b[39m", "");
                 self.reapplyStyles();
             },
@@ -986,6 +989,20 @@ pub const AnsiRenderer = struct {
         if (data.len == 0) return;
         self.emitInline(data);
         self.last_was_newline = (data[data.len - 1] == '\n');
+    }
+
+    /// Emit a short text chunk through the active buffer and update col
+    /// WITHOUT the pre-wrap guard that writeStyled uses. This is the
+    /// right path for closing delimiters (`]]`, `$`, `$$`) that must
+    /// stay attached to whatever they close — otherwise a wrap can push
+    /// the closer onto a new line and orphan it.
+    fn writeNoWrap(self: *AnsiRenderer, text_: []const u8) void {
+        if (text_.len == 0) return;
+        self.emitInline(text_);
+        if (!self.in_cell and self.heading_level == 0 and !self.in_code_block and self.image_depth == 0) {
+            self.col += @intCast(visibleWidth(text_));
+            self.last_was_newline = false;
+        }
     }
 
     /// Emit raw bytes that must not appear in `image_alt`. Goes through

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1444,6 +1444,11 @@ pub fn detectLightBackground() bool {
 ///   - `TERM_PROGRAM=WezTerm` or `ghostty` (compatible terminals)
 ///   - `TERM_PROGRAM=ghostty`
 pub fn detectKittyGraphics() bool {
+    // TERM=dumb is the standard opt-out for any ESC handling — bail
+    // before any env match or probe runs.
+    if (bun.getenvZ("TERM")) |term| {
+        if (bun.strings.eqlCaseInsensitiveASCII(term, "dumb", true)) return false;
+    }
     // Fast path: env vars set by known-compatible terminals.
     if (bun.getenvZ("KITTY_WINDOW_ID")) |_| return true;
     if (bun.getenvZ("GHOSTTY_RESOURCES_DIR")) |_| return true;
@@ -1472,7 +1477,6 @@ pub fn detectKittyGraphics() bool {
 fn probeKittyGraphics() bool {
     if (!bun.Environment.isPosix) return false;
     if (bun.Output.bun_stdio_tty[0] == 0 or bun.Output.bun_stdio_tty[1] == 0) return false;
-    if (bun.getenvZ("DUMB")) |_| return false;
     // Honor an explicit opt-out.
     if (bun.getenvZ("BUN_DISABLE_KITTY_PROBE")) |_| return false;
 
@@ -1482,14 +1486,17 @@ fn probeKittyGraphics() bool {
     defer _ = bun.tty.setMode(0, .normal);
 
     // Query: transmit a 1×1 RGB image (3 zero bytes = "AAAA" b64),
-    // id=31, suppress OK so we only see errors → no: we NEED the OK
-    // so q is unset. The terminal replies with `\x1b_Gi=31;OK\x1b\\`
+    // id=31. The terminal replies with `\x1b_Gi=31;OK\x1b\\`
     // (or `ENOTSUPPORTED:...`) within a frame.
     const query = "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\";
-    _ = std.posix.write(1, query) catch return false;
+    switch (bun.sys.write(bun.FD.stdout(), query)) {
+        .result => {},
+        .err => return false,
+    }
 
     // Wait up to ~80ms for a response. Kitty/Ghostty/WezTerm reply
     // in < 10ms; anything longer is noise from an unrelated terminal.
+    // poll() stays on std.posix — bun.sys has no TTY poll wrapper.
     var pfd = [_]std.posix.pollfd{.{
         .fd = 0,
         .events = std.posix.POLL.IN,
@@ -1499,7 +1506,10 @@ fn probeKittyGraphics() bool {
     if (ready <= 0) return false;
 
     var buf: [128]u8 = undefined;
-    const n = std.posix.read(0, &buf) catch return false;
+    const n = switch (bun.sys.read(bun.FD.stdin(), &buf)) {
+        .result => |r| r,
+        .err => return false,
+    };
     if (n == 0) return false;
     const reply = buf[0..n];
     // A successful reply looks like: \x1b_G<...>;OK\x1b\
@@ -1520,24 +1530,33 @@ fn resolveLocalImagePath(src: []const u8, allocator: Allocator) ?[]u8 {
         return null;
     }
 
-    // Strip file:// prefix if present. Other places in bun do the same
-    // prefix-strip (VirtualMachine, node_fs_watcher, etc.) — use the
-    // WTF URL parser only when we need percent-decoding / UNC handling.
+    // Strip file:// prefix + optional `localhost` authority, then
+    // percent-decode. RFC 8089 allows `file://localhost/path`
+    // (equivalent to `file:///path`) and real-world file URLs
+    // contain %XX escapes for spaces and other reserved chars.
     var path: []const u8 = src;
     if (bun.strings.startsWith(src, "file://")) {
         path = src["file://".len..];
+        // Drop `localhost` authority — RFC 8089 treats it as identity.
+        if (bun.strings.startsWith(path, "localhost/")) {
+            path = path["localhost".len..];
+        } else if (bun.strings.eqlComptime(path, "localhost")) {
+            return null;
+        }
     }
+
+    // Percent-decode the path so file:///foo/bar%20baz works.
+    const decoded = PercentEncoding.decodeAlloc(allocator, path) catch return null;
+    defer allocator.free(decoded);
 
     // Resolve to an absolute path. bun.path.joinAbsString returns a
     // slice in a threadlocal buffer — dupe it before leaving this fn.
-    // Use bun's cached cwd when available (fs.FileSystem.instance),
-    // otherwise look it up with bun.sys.getcwd (Windows-aware).
     var cwd_buf: bun.PathBuffer = undefined;
     const cwd = switch (bun.sys.getcwd(&cwd_buf)) {
         .result => |c| c,
         .err => return null,
     };
-    const joined = bun.path.joinAbsString(cwd, &.{path}, .auto);
+    const joined = bun.path.joinAbsString(cwd, &.{decoded}, .auto);
     const abs = allocator.dupe(u8, joined) catch return null;
     if (!bun.sys.exists(abs)) {
         allocator.free(abs);
@@ -1573,6 +1592,7 @@ const helpers = @import("./helpers.zig");
 const root = @import("./root.zig");
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const PercentEncoding = @import("../url.zig").PercentEncoding;
 
 const types = @import("./types.zig");
 const BlockType = types.BlockType;

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -42,6 +42,7 @@ pub const ImageUrlCollector = struct {
     }
 
     pub fn deinit(self: *ImageUrlCollector) void {
+        for (self.urls.items) |u| self.allocator.free(u);
         self.urls.deinit(self.allocator);
     }
 
@@ -66,7 +67,12 @@ pub const ImageUrlCollector = struct {
         if (span_type != .img) return;
         const self: *ImageUrlCollector = @ptrCast(@alignCast(ptr));
         if (detail.href.len == 0) return;
-        self.urls.append(self.allocator, detail.href) catch return error.OutOfMemory;
+        // detail.href is a slice into the parser's reusable buffer, which
+        // is freed when renderWithRenderer returns (p.deinit). Dupe it so
+        // callers can safely read collector.urls after rendering finishes.
+        const owned = self.allocator.dupe(u8, detail.href) catch return error.OutOfMemory;
+        errdefer self.allocator.free(owned);
+        self.urls.append(self.allocator, owned) catch return error.OutOfMemory;
     }
 };
 
@@ -949,15 +955,21 @@ pub const AnsiRenderer = struct {
     }
 
     fn updateColFromText(self: *AnsiRenderer, data: []const u8) void {
+        // Advance col by visible width per-segment (between newlines) so
+        // multi-byte UTF-8 content stays consistent with every other
+        // col-update site (they all use visibleWidth()).
+        var start: usize = 0;
         var i: usize = 0;
         while (i < data.len) : (i += 1) {
             if (data[i] == '\n') {
                 self.col = 0;
                 self.last_was_newline = true;
-            } else {
-                self.col += 1;
-                self.last_was_newline = false;
+                start = i + 1;
             }
+        }
+        if (start < data.len) {
+            self.col += @intCast(visibleWidth(data[start..]));
+            self.last_was_newline = false;
         }
     }
 

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1258,7 +1258,12 @@ pub const AnsiRenderer = struct {
         // Try to render inline via Kitty Graphics. If the image is
         // actually displayed, we're done — the image itself is the
         // content, no caption/alt text needed.
-        if (self.theme.colors and self.theme.kitty_graphics and has_src) {
+        // Skip Kitty inside table cells / headings: the APC payload
+        // would be counted as visible width by flushTable/flushHeading,
+        // blowing up the column / underline size. Images in cells
+        // always fall back to alt-text rendering.
+        const kitty_allowed = !self.in_cell and self.heading_level == 0;
+        if (kitty_allowed and self.theme.colors and self.theme.kitty_graphics and has_src) {
             if (resolveLocalImagePath(src.?, self.allocator)) |abs_path| {
                 defer self.allocator.free(abs_path);
                 self.emitKittyImage(abs_path);
@@ -1299,13 +1304,11 @@ pub const AnsiRenderer = struct {
     /// to base64 the pixels. Terminals that don't understand the APC
     /// sequence will silently drop it.
     fn emitKittyImage(self: *AnsiRenderer, path: []const u8) void {
-        // Base64-encode the file path (Kitty expects payload to be b64).
-        // Path is expected to be ASCII in most cases; use std.base64.
-        const enc = std.base64.standard.Encoder;
-        const encoded_len = enc.calcSize(path.len);
+        // Base64-encode the file path (Kitty expects the payload to be b64).
+        const encoded_len = bun.base64.encodeLen(path);
         const encoded = self.allocator.alloc(u8, encoded_len) catch return;
         defer self.allocator.free(encoded);
-        _ = enc.encode(encoded, path);
+        _ = bun.base64.encode(encoded, path);
 
         // APC sequence: \x1b_G<control>;<payload>\x1b\
         //   a=T  : transmit and display

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -653,9 +653,11 @@ pub const AnsiRenderer = struct {
                 self.last_was_newline = true;
                 self.col = 0;
                 i += 1;
-                if (i < data.len) {
-                    self.writeIndent();
-                }
+                // Always re-emit the indent after a newline, even when
+                // this is the final byte of `data` — a hard break
+                // (`text(.br)`) arrives as a lone "\n" and the next
+                // text() call starts at col=0 with no indent pushed.
+                self.writeIndent();
                 continue;
             }
             if (c == ' ' and self.col >= max) {
@@ -1264,9 +1266,17 @@ pub const AnsiRenderer = struct {
         // always fall back to alt-text rendering.
         const kitty_allowed = !self.in_cell and self.heading_level == 0;
         if (kitty_allowed and self.theme.colors and self.theme.kitty_graphics and has_src) {
+            // data:image/png;base64,... → transmit payload directly via
+            // t=d so no temp file needs to live on disk. Other data:
+            // formats (jpeg/gif/webp) don't map to a Kitty format code
+            // for direct transmission, so fall through to alt text.
+            if (extractPngDataUrlBase64(src.?)) |payload| {
+                self.emitKittyImageDirect(payload);
+                return;
+            }
             if (resolveLocalImagePath(src.?, self.allocator)) |abs_path| {
                 defer self.allocator.free(abs_path);
-                self.emitKittyImage(abs_path);
+                self.emitKittyImageFile(abs_path);
                 return;
             }
         }
@@ -1300,28 +1310,30 @@ pub const AnsiRenderer = struct {
 
     /// Emit a Kitty Graphics Protocol transmit-and-display sequence for
     /// the absolute file `path`. Uses `t=f` (transmission medium = regular
-    /// file by path) so the terminal reads the file directly — no need
-    /// to base64 the pixels. Terminals that don't understand the APC
-    /// sequence will silently drop it.
-    fn emitKittyImage(self: *AnsiRenderer, path: []const u8) void {
+    /// file by path) so the terminal reads the file directly. Terminals
+    /// that don't understand the APC sequence silently drop it.
+    fn emitKittyImageFile(self: *AnsiRenderer, path: []const u8) void {
         // Base64-encode the file path (Kitty expects the payload to be b64).
         const encoded_len = bun.base64.encodeLen(path);
         const encoded = self.allocator.alloc(u8, encoded_len) catch return;
         defer self.allocator.free(encoded);
         _ = bun.base64.encode(encoded, path);
-
-        // APC sequence: \x1b_G<control>;<payload>\x1b\
-        //   a=T  : transmit and display
-        //   t=f  : transmission medium = regular file (by path)
-        //   f=100: format = file (kitty auto-detects PNG/JPEG/etc.)
-        //   q=2  : suppress OK + error responses (don't pollute stdin)
         self.writeRawNoColor("\x1b_Ga=T,t=f,f=100,q=2;");
         self.writeRawNoColor(encoded);
         self.writeRawNoColor("\x1b\\");
-        // End with a newline so the following caption/alt text lands
-        // on its own line under the image. Route through writeRaw so
-        // the byte lands in the active buffer (cell/heading) when the
-        // image is rendered inside a table or heading.
+        self.writeRaw("\n");
+        self.col = 0;
+        self.last_was_newline = true;
+    }
+
+    /// Emit a Kitty Graphics Protocol transmit-and-display sequence with
+    /// the PNG bytes encoded directly in the APC payload via `t=d`. The
+    /// `base64_payload` is already the base64 body of a `data:image/png`
+    /// URL, so we forward it as-is — no temp file, no re-encoding.
+    fn emitKittyImageDirect(self: *AnsiRenderer, base64_payload: []const u8) void {
+        self.writeRawNoColor("\x1b_Ga=T,t=d,f=100,q=2;");
+        self.writeRawNoColor(base64_payload);
+        self.writeRawNoColor("\x1b\\");
         self.writeRaw("\n");
         self.col = 0;
         self.last_was_newline = true;
@@ -1532,16 +1544,13 @@ fn probeKittyGraphics() bool {
 fn resolveLocalImagePath(src: []const u8, allocator: Allocator) ?[]u8 {
     // Reject remote schemes. A renderer-level prefetch pass can feed
     // http(s) URLs into the renderer via a lookup table as local paths.
+    // data: URIs are handled separately in emitImage via direct Kitty
+    // transmission (t=d) to avoid creating temp files.
     if (bun.strings.startsWith(src, "http://") or
-        bun.strings.startsWith(src, "https://"))
+        bun.strings.startsWith(src, "https://") or
+        bun.strings.startsWith(src, "data:"))
     {
         return null;
-    }
-
-    // data: URIs — decode the base64 payload and write it to a
-    // temp file so Kitty's t=f (file path) transmission can load it.
-    if (bun.strings.startsWith(src, "data:")) {
-        return decodeDataUrlToTempFile(src, allocator);
     }
 
     // Strip file:// prefix + optional `localhost` authority, then
@@ -1583,57 +1592,20 @@ fn resolveLocalImagePath(src: []const u8, allocator: Allocator) ?[]u8 {
 // Public entry point
 // ========================================
 
-/// Decode a `data:` URI's base64 payload and write it to a uniquely-
-/// named temp file. Returns the temp file path (owned by caller) so
-/// Kitty's `t=f` (file path) transmission can display it. Falls back
-/// to null on any parse/decode/write error.
-fn decodeDataUrlToTempFile(src: []const u8, allocator: Allocator) ?[]u8 {
-    // Format: `data:<mediatype>[;base64],<data>` — only base64 payloads
-    // support binary image bytes.
+/// Extract the base64 body of a `data:image/png;base64,...` URI. Returns
+/// a slice into `src` (no allocation) that's the direct payload Kitty
+/// can consume via `t=d,f=100`. Non-PNG data URIs return null because
+/// Kitty's format codes (`f=100` PNG, `f=24` RGB, `f=32` RGBA) don't
+/// cover JPEG/GIF/WebP binary input.
+fn extractPngDataUrlBase64(src: []const u8) ?[]const u8 {
+    if (!bun.strings.startsWith(src, "data:")) return null;
     const comma = bun.strings.indexOfChar(src, ',') orelse return null;
     const header = src[0..comma];
     const payload = src[comma + 1 ..];
     if (!bun.strings.endsWith(header, ";base64")) return null;
-
-    const decoded = bun.base64.decodeAlloc(allocator, payload) catch return null;
-    defer allocator.free(decoded);
-
-    // Pick a short unique filename inside the OS tmpdir so Kitty can
-    // `t=f` open it. The extension is best-effort from the mediatype —
-    // Kitty auto-detects from magic bytes either way.
-    const ext: []const u8 = if (bun.strings.contains(header, "image/png")) ".png" else if (bun.strings.contains(header, "image/jpeg") or bun.strings.contains(header, "image/jpg")) ".jpg" else if (bun.strings.contains(header, "image/gif")) ".gif" else if (bun.strings.contains(header, "image/webp")) ".webp" else ".bin";
-    var name_buf: [64]u8 = undefined;
-    const name = std.fmt.bufPrint(&name_buf, "bun-md-{x}{s}", .{ bun.fastRandom(), ext }) catch return null;
-    const tmpdir = bun.fs.FileSystem.RealFS.tmpdirPath();
-    const path = std.fmt.allocPrint(allocator, "{s}/{s}", .{ tmpdir, name }) catch return null;
-
-    // Write the bytes. Any error → free the path + drop the fd.
-    // Function returns ?[]u8 (not error union), so errdefer is dead.
-    const fd = switch (bun.sys.openA(path, bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o600)) {
-        .result => |f| f,
-        .err => {
-            allocator.free(path);
-            return null;
-        },
-    };
-    defer fd.close();
-    var written: usize = 0;
-    while (written < decoded.len) {
-        switch (bun.sys.write(fd, decoded[written..])) {
-            .result => |n| {
-                if (n == 0) {
-                    allocator.free(path);
-                    return null;
-                }
-                written += n;
-            },
-            .err => {
-                allocator.free(path);
-                return null;
-            },
-        }
-    }
-    return path;
+    // Only PNG is losslessly transmittable via t=d,f=100.
+    if (!bun.strings.contains(header, "image/png")) return null;
+    return payload;
 }
 
 /// Render markdown text to ANSI. Caller owns the returned bytes.

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1188,14 +1188,14 @@ pub fn renderToAnsi(
 }
 
 const bun = @import("bun");
+const helpers = @import("./helpers.zig");
+const root = @import("./root.zig");
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
-const root = @import("./root.zig");
-const helpers = @import("./helpers.zig");
 const types = @import("./types.zig");
 const BlockType = types.BlockType;
+const Renderer = types.Renderer;
+const SpanDetail = types.SpanDetail;
 const SpanType = types.SpanType;
 const TextType = types.TextType;
-const SpanDetail = types.SpanDetail;
-const Renderer = types.Renderer;

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1148,18 +1148,28 @@ pub const AnsiRenderer = struct {
 
     fn boxChars(self: *AnsiRenderer) BoxChars {
         return if (self.theme.colors) .{
-            .h = "─", .v = "│",
-            .tl = "┌", .tr = "┐",
-            .bl = "└", .br = "┘",
-            .t = "┬", .b = "┴",
-            .ml = "├", .mr = "┤",
+            .h = "─",
+            .v = "│",
+            .tl = "┌",
+            .tr = "┐",
+            .bl = "└",
+            .br = "┘",
+            .t = "┬",
+            .b = "┴",
+            .ml = "├",
+            .mr = "┤",
             .x = "┼",
         } else .{
-            .h = "-", .v = "|",
-            .tl = "+", .tr = "+",
-            .bl = "+", .br = "+",
-            .t = "+", .b = "+",
-            .ml = "+", .mr = "+",
+            .h = "-",
+            .v = "|",
+            .tl = "+",
+            .tr = "+",
+            .bl = "+",
+            .br = "+",
+            .t = "+",
+            .b = "+",
+            .ml = "+",
+            .mr = "+",
             .x = "+",
         };
     }

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -135,11 +135,19 @@ pub const AnsiRenderer = struct {
         self.image_alt.deinit(self.allocator);
         self.code_buf.deinit(self.allocator);
         self.heading_buf.deinit(self.allocator);
+        // Normally freed by leaveSpan, but rendering can be interrupted
+        // mid-span by an OOM — free defensively here.
+        if (self.link_href) |s| self.allocator.free(s);
+        if (self.image_src) |s| self.allocator.free(s);
+        if (self.image_title) |s| self.allocator.free(s);
         for (self.table_rows.items) |row| {
             for (row.cells) |cell| self.allocator.free(cell.content);
             self.allocator.free(row.cells);
         }
         self.table_rows.deinit(self.allocator);
+        // Same for orphaned cells left in table_cells when interrupted
+        // mid-row.
+        for (self.table_cells.items) |cell| self.allocator.free(cell.content);
         self.table_cells.deinit(self.allocator);
         self.table_cell_buf.deinit(self.allocator);
     }
@@ -497,12 +505,18 @@ pub const AnsiRenderer = struct {
             },
             .a => {
                 if (self.link_depth == 1) {
+                    // Decrement BEFORE reapplyStyles so it doesn't re-emit
+                    // blue+underline for text after the link.
+                    self.link_depth = 0;
+                    const had_href = self.link_href != null;
                     // Underline off, default fg; reapply outer styles so a
                     // link inside **bold** doesn't drop the bold.
                     self.writeStyled("\x1b[24m\x1b[39m", "");
                     self.reapplyStyles();
                     if (self.theme.colors and self.theme.hyperlinks) {
-                        self.writeRawNoColor("\x1b]8;;\x1b\\");
+                        // Only emit the OSC 8 terminator if we emitted the
+                        // opening sequence (which required link_href).
+                        if (had_href) self.writeRawNoColor("\x1b]8;;\x1b\\");
                     } else if (self.link_href) |href| if (href.len > 0) {
                         // Show URL in parens for non-hyperlink terminals
                         self.writeStyled(color(.dim), " (");
@@ -513,8 +527,9 @@ pub const AnsiRenderer = struct {
                     };
                     if (self.link_href) |href| self.allocator.free(href);
                     self.link_href = null;
+                } else if (self.link_depth > 0) {
+                    self.link_depth -= 1;
                 }
-                if (self.link_depth > 0) self.link_depth -= 1;
             },
             .img => {
                 if (self.image_depth == 1) {
@@ -1065,6 +1080,7 @@ pub const AnsiRenderer = struct {
         if (self.theme.colors) self.out.write("\x1b[0m");
         self.out.writeByte('\n');
         self.last_was_newline = true;
+        self.col = 0;
 
         // Free rows
         for (self.table_rows.items) |row| {

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -12,7 +12,8 @@ pub const Theme = struct {
     /// Emit colors and styles. When false the renderer emits plain text.
     colors: bool = true,
     /// Emit OSC 8 hyperlinks. When false links are shown as "text (url)".
-    hyperlinks: bool = true,
+    /// Default false to match the documented Bun.markdown.ansi() API.
+    hyperlinks: bool = false,
     /// Inline images using the Kitty Graphics Protocol when the `src`
     /// refers to a local file (absolute or ./relative path, or file://).
     /// Falls through to the text alt for remote URLs.

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1458,11 +1458,14 @@ pub const AnsiRenderer = struct {
                 if (i + 1 >= bytes.len) return;
                 if (bytes[i + 1] == '[') {
                     // CSI ... m (SGR). Scan until final byte.
+                    // ECMA-48 final bytes are 0x40–0x7E; the parameter
+                    // separator ';' is 0x3B and is already excluded by
+                    // the range check.
                     const seq_start = i;
                     var j = i + 2;
                     while (j < bytes.len) : (j += 1) {
                         const c = bytes[j];
-                        if ((c >= 0x40 and c <= 0x7e) and c != ';') break;
+                        if (c >= 0x40 and c <= 0x7e) break;
                     }
                     if (j >= bytes.len) return;
                     if (bytes[j] == 'm') {

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -916,6 +916,12 @@ pub const AnsiRenderer = struct {
 
     fn flushHeading(self: *AnsiRenderer) void {
         const level = self.heading_level;
+        // Temporarily zero heading_level so writeIndent()'s reapplyStyles()
+        // routes emitInline() to self.out instead of heading_buf. Otherwise
+        // inside a blockquote the bold+color writes reach heading_buf and
+        // may realloc its backing array, dangling the `content` slice below.
+        self.heading_level = 0;
+        defer self.heading_level = level;
         const content = self.heading_buf.items;
         self.writeIndent();
         if (self.theme.colors) {
@@ -1440,6 +1446,7 @@ pub fn detectLightBackground() bool {
 ///   - `TERM_PROGRAM=WezTerm` or `ghostty` (compatible terminals)
 ///   - `TERM_PROGRAM=ghostty`
 pub fn detectKittyGraphics() bool {
+    // Fast path: env vars set by known-compatible terminals.
     if (bun.getenvZ("KITTY_WINDOW_ID")) |_| return true;
     if (bun.getenvZ("GHOSTTY_RESOURCES_DIR")) |_| return true;
     if (bun.getenvZ("TERM")) |term| {
@@ -1450,7 +1457,56 @@ pub fn detectKittyGraphics() bool {
         if (bun.strings.eqlCaseInsensitiveASCII(tp, "wezterm", true)) return true;
         if (bun.strings.eqlCaseInsensitiveASCII(tp, "ghostty", true)) return true;
     }
-    return false;
+    // Runtime probe: send a Kitty query to the terminal and wait for a
+    // response. Compatible terminals reply within a few ms; others stay
+    // silent because they ignore the APC sequence entirely.
+    return probeKittyGraphics();
+}
+
+/// Write a Kitty Graphics Protocol query to stdout and wait briefly
+/// for a response on stdin. Returns true only when the terminal
+/// answers with an OK. stdin and stdout must both be TTYs for the
+/// probe to run.
+///
+/// The query transmits a 1×1 placeholder image with id=31 and reads
+/// the reply with a short timeout. Raw mode is applied + restored
+/// around the read so the bytes don't echo to the user's terminal.
+fn probeKittyGraphics() bool {
+    if (!bun.Environment.isPosix) return false;
+    if (bun.Output.bun_stdio_tty[0] == 0 or bun.Output.bun_stdio_tty[1] == 0) return false;
+    if (bun.getenvZ("DUMB")) |_| return false;
+    // Honor an explicit opt-out.
+    if (bun.getenvZ("BUN_DISABLE_KITTY_PROBE")) |_| return false;
+
+    // Save original mode + switch stdin to raw so the reply bytes
+    // arrive immediately and don't echo.
+    _ = bun.tty.setMode(0, .raw);
+    defer _ = bun.tty.setMode(0, .normal);
+
+    // Query: transmit a 1×1 RGB image (3 zero bytes = "AAAA" b64),
+    // id=31, suppress OK so we only see errors → no: we NEED the OK
+    // so q is unset. The terminal replies with `\x1b_Gi=31;OK\x1b\\`
+    // (or `ENOTSUPPORTED:...`) within a frame.
+    const query = "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\";
+    _ = std.posix.write(1, query) catch return false;
+
+    // Wait up to ~80ms for a response. Kitty/Ghostty/WezTerm reply
+    // in < 10ms; anything longer is noise from an unrelated terminal.
+    var pfd = [_]std.posix.pollfd{.{
+        .fd = 0,
+        .events = std.posix.POLL.IN,
+        .revents = 0,
+    }};
+    const ready = std.posix.poll(&pfd, 80) catch return false;
+    if (ready <= 0) return false;
+
+    var buf: [128]u8 = undefined;
+    const n = std.posix.read(0, &buf) catch return false;
+    if (n == 0) return false;
+    const reply = buf[0..n];
+    // A successful reply looks like: \x1b_G<...>;OK\x1b\
+    // Failure (but-understood): \x1b_G<...>;ENOTSUPPORTED:...\x1b\
+    return bun.strings.contains(reply, ";OK\x1b\\");
 }
 
 /// Resolve an image `src` from markdown to an absolute file path on
@@ -1486,7 +1542,10 @@ fn resolveLocalImagePath(src: []const u8, allocator: Allocator) ?[]u8 {
     var cwd_buf: bun.PathBuffer = undefined;
     const cwd = bun.getcwd(&cwd_buf) catch return null;
     var joined = std.ArrayListUnmanaged(u8){};
-    errdefer joined.deinit(allocator);
+    // Function returns ?[]u8 (not error union), so errdefer would be dead.
+    // Use defer — after toOwnedSlice() succeeds the list is empty so deinit
+    // is a no-op; on any catch-return-null path we still free the buffer.
+    defer joined.deinit(allocator);
     joined.appendSlice(allocator, cwd) catch return null;
     joined.append(allocator, std.fs.path.sep) catch return null;
     joined.appendSlice(allocator, path) catch return null;

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1591,8 +1591,8 @@ const bun = @import("bun");
 const helpers = @import("./helpers.zig");
 const root = @import("./root.zig");
 const std = @import("std");
-const Allocator = std.mem.Allocator;
 const PercentEncoding = @import("../url.zig").PercentEncoding;
+const Allocator = std.mem.Allocator;
 
 const types = @import("./types.zig");
 const BlockType = types.BlockType;

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1521,11 +1521,9 @@ fn probeKittyGraphics() bool {
         .events = std.posix.POLL.IN,
         .revents = 0,
     }};
-    const ready = switch (bun.sys.poll(&pfd, 80)) {
-        .result => |n| n,
-        .err => return false,
-    };
-    if (ready == 0) return false;
+    // bun.sys.poll has a Maybe variant Zig flags as incomplete — keep std.posix.poll.
+    const ready = std.posix.poll(&pfd, 80) catch return false;
+    if (ready <= 0) return false;
 
     var buf: [128]u8 = undefined;
     const n = switch (bun.sys.read(bun.FD.stdin(), &buf)) {

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1255,24 +1255,28 @@ pub const AnsiRenderer = struct {
         // remains clickable below the image, and still write the alt
         // text as a visible caption for non-Kitty terminals that ignore
         // the APC sequence.
-        var kitty_sent = false;
+        // Try to render inline via Kitty Graphics. If the image is
+        // actually displayed, we're done — the image itself is the
+        // content, no caption/alt text needed.
         if (self.theme.colors and self.theme.kitty_graphics and has_src) {
             if (resolveLocalImagePath(src.?, self.allocator)) |abs_path| {
                 defer self.allocator.free(abs_path);
                 self.emitKittyImage(abs_path);
-                kitty_sent = true;
+                return;
             }
         }
 
+        // Fallback: image can't be rendered inline. Show the alt text
+        // (or title, or "(image)") wrapped in the OSC 8 hyperlink so
+        // the src URL stays clickable. A magenta 🖼 marker makes it
+        // obvious this is a missing/unrendered image.
         if (self.theme.colors and self.theme.hyperlinks and has_src) {
             self.writeRawNoColor("\x1b]8;;");
             self.writeRawNoColor(src.?);
             self.writeRawNoColor("\x1b\\");
         }
-        const img_marker = if (kitty_sent) "" else if (self.theme.colors) "🖼 " else "[img] ";
-        if (img_marker.len > 0) {
-            self.writeStyled(color(.magenta), img_marker);
-        }
+        const img_marker = if (self.theme.colors) "🖼 " else "[img] ";
+        self.writeStyled(color(.magenta), img_marker);
         if (alt.len > 0) {
             self.writeStyled("", alt);
         } else if (self.image_title) |title| if (title.len > 0) {
@@ -1523,12 +1527,18 @@ fn probeKittyGraphics() bool {
 /// `file://` URIs and relative paths (resolved against the CWD). The
 /// returned slice is owned by the caller.
 fn resolveLocalImagePath(src: []const u8, allocator: Allocator) ?[]u8 {
-    // Reject clearly remote schemes. `data:` is intentionally allowed to
-    // fall through — callers that know how to decode data URIs can.
+    // Reject remote schemes. A renderer-level prefetch pass can feed
+    // http(s) URLs into the renderer via a lookup table as local paths.
     if (bun.strings.startsWith(src, "http://") or
         bun.strings.startsWith(src, "https://"))
     {
         return null;
+    }
+
+    // data: URIs — decode the base64 payload and write it to a
+    // temp file so Kitty's t=f (file path) transmission can load it.
+    if (bun.strings.startsWith(src, "data:")) {
+        return decodeDataUrlToTempFile(src, allocator);
     }
 
     // Strip file:// prefix + optional `localhost` authority, then
@@ -1569,6 +1579,59 @@ fn resolveLocalImagePath(src: []const u8, allocator: Allocator) ?[]u8 {
 // ========================================
 // Public entry point
 // ========================================
+
+/// Decode a `data:` URI's base64 payload and write it to a uniquely-
+/// named temp file. Returns the temp file path (owned by caller) so
+/// Kitty's `t=f` (file path) transmission can display it. Falls back
+/// to null on any parse/decode/write error.
+fn decodeDataUrlToTempFile(src: []const u8, allocator: Allocator) ?[]u8 {
+    // Format: `data:<mediatype>[;base64],<data>` — only base64 payloads
+    // support binary image bytes.
+    const comma = bun.strings.indexOfChar(src, ',') orelse return null;
+    const header = src[0..comma];
+    const payload = src[comma + 1 ..];
+    if (!bun.strings.endsWith(header, ";base64")) return null;
+
+    const decoded = bun.base64.decodeAlloc(allocator, payload) catch return null;
+    defer allocator.free(decoded);
+
+    // Pick a short unique filename inside the OS tmpdir so Kitty can
+    // `t=f` open it. The extension is best-effort from the mediatype —
+    // Kitty auto-detects from magic bytes either way.
+    const ext: []const u8 = if (bun.strings.contains(header, "image/png")) ".png" else if (bun.strings.contains(header, "image/jpeg") or bun.strings.contains(header, "image/jpg")) ".jpg" else if (bun.strings.contains(header, "image/gif")) ".gif" else if (bun.strings.contains(header, "image/webp")) ".webp" else ".bin";
+    var name_buf: [64]u8 = undefined;
+    const name = std.fmt.bufPrint(&name_buf, "bun-md-{x}{s}", .{ bun.fastRandom(), ext }) catch return null;
+    const tmpdir = bun.fs.FileSystem.RealFS.tmpdirPath();
+    const path = std.fmt.allocPrint(allocator, "{s}/{s}", .{ tmpdir, name }) catch return null;
+
+    // Write the bytes. Any error → free the path + drop the fd.
+    // Function returns ?[]u8 (not error union), so errdefer is dead.
+    const fd = switch (bun.sys.openA(path, bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o600)) {
+        .result => |f| f,
+        .err => {
+            allocator.free(path);
+            return null;
+        },
+    };
+    defer fd.close();
+    var written: usize = 0;
+    while (written < decoded.len) {
+        switch (bun.sys.write(fd, decoded[written..])) {
+            .result => |n| {
+                if (n == 0) {
+                    allocator.free(path);
+                    return null;
+                }
+                written += n;
+            },
+            .err => {
+                allocator.free(path);
+                return null;
+            },
+        }
+    }
+    return path;
+}
 
 /// Render markdown text to ANSI. Caller owns the returned bytes.
 pub fn renderToAnsi(

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1574,6 +1574,56 @@ pub const AnsiRenderer = struct {
         }
     };
 
+    /// Find the last space byte in `bytes` that lies OUTSIDE any ANSI
+    /// escape sequence (CSI or OSC). The table wrapper uses this to pick
+    /// a word-break point without splitting an OSC 8 opener mid-URL —
+    /// `[text](<url with space>)` is valid CommonMark and produces an
+    /// OSC 8 href that literally contains a space byte, so a naive
+    /// byte scan would break the sequence in half and leave the
+    /// terminal stuck in persistent hyperlink mode.
+    fn lastWordBreakOutsideEscapes(bytes: []const u8) ?usize {
+        var last: ?usize = null;
+        var i: usize = 0;
+        while (i < bytes.len) {
+            const c = bytes[i];
+            if (c == 0x1b and i + 1 < bytes.len) {
+                const next = bytes[i + 1];
+                if (next == '[') {
+                    // CSI — skip to a final byte in 0x40–0x7E.
+                    i += 2;
+                    while (i < bytes.len) : (i += 1) {
+                        if (bytes[i] >= 0x40 and bytes[i] <= 0x7e) {
+                            i += 1;
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                if (next == ']') {
+                    // OSC — skip to ST (ESC \) or BEL.
+                    i += 2;
+                    while (i < bytes.len) : (i += 1) {
+                        if (bytes[i] == 0x07) {
+                            i += 1;
+                            break;
+                        }
+                        if (bytes[i] == 0x1b and i + 1 < bytes.len and bytes[i + 1] == '\\') {
+                            i += 2;
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                // Other ESC-<byte> two-byte sequences: skip the pair.
+                i += 2;
+                continue;
+            }
+            if (c == ' ') last = i;
+            i += 1;
+        }
+        return last;
+    }
+
     fn writeRowCells(
         self: *AnsiRenderer,
         row: TableRow,
@@ -1618,9 +1668,14 @@ pub const AnsiRenderer = struct {
             while (rest.len > 0) {
                 var cut = visibleIndexAt(rest, w);
                 if (cut < rest.len) {
-                    // Prefer breaking at the last space inside the cut so
-                    // words stay intact when there's room.
-                    if (bun.strings.lastIndexOfChar(rest[0..cut], ' ')) |sp| {
+                    // Prefer breaking at the last word boundary inside the
+                    // cut so words stay intact when there's room. Must use
+                    // an escape-aware scanner — a raw lastIndexOfChar(' ')
+                    // would find spaces inside an OSC 8 URL (valid via the
+                    // `[text](<url with space>)` angle-bracket syntax) and
+                    // truncate mid-sequence, leaving a never-terminated
+                    // hyperlink opener that corrupts the rest of the row.
+                    if (lastWordBreakOutsideEscapes(rest[0..cut])) |sp| {
                         if (sp > 0) cut = sp;
                     }
                 }

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -73,8 +73,6 @@ pub const AnsiRenderer = struct {
     cell_align: types.Align = .default,
     /// Track whether we just emitted a newline, to collapse extra blanks.
     last_was_newline: bool = true,
-    /// Depth of blockquote nesting for left bar rendering.
-    quote_depth: u32 = 0,
 
     const BlockContext = struct {
         kind: Kind,
@@ -208,7 +206,6 @@ pub const AnsiRenderer = struct {
             .doc => {},
             .quote => {
                 self.ensureBlankLine();
-                self.quote_depth += 1;
                 self.block_stack.append(self.allocator, .{ .kind = .quote, .indent = 2 }) catch {
                     self.out.oom = true;
                 };
@@ -350,7 +347,6 @@ pub const AnsiRenderer = struct {
         switch (block_type) {
             .doc => {},
             .quote => {
-                self.quote_depth -= 1;
                 _ = self.block_stack.pop();
                 self.ensureNewline();
             },
@@ -483,9 +479,8 @@ pub const AnsiRenderer = struct {
             .wikilink => {
                 self.writeStyled(color(.blue), "[[");
             },
-            .latexmath, .latexmath_display => {
-                self.writeStyled(color(.magenta), "$");
-            },
+            .latexmath => self.writeStyled(color(.magenta), "$"),
+            .latexmath_display => self.writeStyled(color(.magenta), "$$"),
         }
     }
 
@@ -563,8 +558,13 @@ pub const AnsiRenderer = struct {
                 self.writeStyled("\x1b[39m", "");
                 self.reapplyStyles();
             },
-            .latexmath, .latexmath_display => {
+            .latexmath => {
                 self.writeStyled("", "$");
+                self.writeStyled("\x1b[39m", "");
+                self.reapplyStyles();
+            },
+            .latexmath_display => {
+                self.writeStyled("", "$$");
                 self.writeStyled("\x1b[39m", "");
                 self.reapplyStyles();
             },
@@ -1516,14 +1516,16 @@ fn probeKittyGraphics() bool {
 
     // Wait up to ~80ms for a response. Kitty/Ghostty/WezTerm reply
     // in < 10ms; anything longer is noise from an unrelated terminal.
-    // poll() stays on std.posix — bun.sys has no TTY poll wrapper.
     var pfd = [_]std.posix.pollfd{.{
         .fd = 0,
         .events = std.posix.POLL.IN,
         .revents = 0,
     }};
-    const ready = std.posix.poll(&pfd, 80) catch return false;
-    if (ready <= 0) return false;
+    const ready = switch (bun.sys.poll(&pfd, 80)) {
+        .result => |n| n,
+        .err => return false,
+    };
+    if (ready == 0) return false;
 
     var buf: [128]u8 = undefined;
     const n = switch (bun.sys.read(bun.FD.stdin(), &buf)) {

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1311,8 +1311,10 @@ pub const AnsiRenderer = struct {
         self.writeRawNoColor(encoded);
         self.writeRawNoColor("\x1b\\");
         // End with a newline so the following caption/alt text lands
-        // on its own line under the image.
-        self.out.writeByte('\n');
+        // on its own line under the image. Route through writeRaw so
+        // the byte lands in the active buffer (cell/heading) when the
+        // image is rendered inside a table or heading.
+        self.writeRaw("\n");
         self.col = 0;
         self.last_was_newline = true;
     }
@@ -1371,10 +1373,6 @@ fn reset() []const u8 {
 fn codeSpanOpen(light: bool) []const u8 {
     // Distinct inline-code look: soft background tint + yellow text.
     return if (light) "\x1b[48;5;254m\x1b[38;5;124m" else "\x1b[48;5;236m\x1b[38;5;215m";
-}
-
-fn codeSpanClose() []const u8 {
-    return "\x1b[0m";
 }
 
 /// Visible printable width of a UTF-8 byte slice, excluding ANSI escape
@@ -1514,47 +1512,37 @@ fn probeKittyGraphics() bool {
 /// `file://` URIs and relative paths (resolved against the CWD). The
 /// returned slice is owned by the caller.
 fn resolveLocalImagePath(src: []const u8, allocator: Allocator) ?[]u8 {
-    // Reject clearly remote schemes.
+    // Reject clearly remote schemes. `data:` is intentionally allowed to
+    // fall through — callers that know how to decode data URIs can.
     if (bun.strings.startsWith(src, "http://") or
-        bun.strings.startsWith(src, "https://") or
-        bun.strings.startsWith(src, "data:"))
+        bun.strings.startsWith(src, "https://"))
     {
         return null;
     }
 
+    // Strip file:// prefix if present. Other places in bun do the same
+    // prefix-strip (VirtualMachine, node_fs_watcher, etc.) — use the
+    // WTF URL parser only when we need percent-decoding / UNC handling.
     var path: []const u8 = src;
-    // Strip file:// prefix if present.
     if (bun.strings.startsWith(src, "file://")) {
         path = src["file://".len..];
     }
 
-    // If already absolute, use it.
-    if (std.fs.path.isAbsolute(path)) {
-        const abs = allocator.dupe(u8, path) catch return null;
-        std.fs.accessAbsolute(abs, .{}) catch {
-            allocator.free(abs);
-            return null;
-        };
-        return abs;
-    }
-
-    // Relative path — resolve against CWD.
+    // Resolve to an absolute path. bun.path.joinAbsString returns a
+    // slice in a threadlocal buffer — dupe it before leaving this fn.
+    // Use bun's cached cwd when available (fs.FileSystem.instance),
+    // otherwise look it up with bun.sys.getcwd (Windows-aware).
     var cwd_buf: bun.PathBuffer = undefined;
-    const cwd = bun.getcwd(&cwd_buf) catch return null;
-    var joined = std.ArrayListUnmanaged(u8){};
-    // Function returns ?[]u8 (not error union), so errdefer would be dead.
-    // Use defer — after toOwnedSlice() succeeds the list is empty so deinit
-    // is a no-op; on any catch-return-null path we still free the buffer.
-    defer joined.deinit(allocator);
-    joined.appendSlice(allocator, cwd) catch return null;
-    joined.append(allocator, std.fs.path.sep) catch return null;
-    joined.appendSlice(allocator, path) catch return null;
-
-    const abs = joined.toOwnedSlice(allocator) catch return null;
-    std.fs.accessAbsolute(abs, .{}) catch {
+    const cwd = switch (bun.sys.getcwd(&cwd_buf)) {
+        .result => |c| c,
+        .err => return null,
+    };
+    const joined = bun.path.joinAbsString(cwd, &.{path}, .auto);
+    const abs = allocator.dupe(u8, joined) catch return null;
+    if (!bun.sys.exists(abs)) {
         allocator.free(abs);
         return null;
-    };
+    }
     return abs;
 }
 

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -156,12 +156,26 @@ pub const AnsiRenderer = struct {
         is_header: bool,
     };
 
-    // Span flags
     const SPAN_EM: u32 = 1 << 0;
     const SPAN_STRONG: u32 = 1 << 1;
     const SPAN_DEL: u32 = 1 << 2;
     const SPAN_U: u32 = 1 << 3;
     const SPAN_CODE: u32 = 1 << 4;
+
+    const InlineStyle = struct {
+        flag: u32,
+        on: []const u8,
+        off: []const u8,
+        fn of(span_type: SpanType) ?InlineStyle {
+            return switch (span_type) {
+                .em => .{ .flag = SPAN_EM, .on = style(.italic), .off = "\x1b[23m" },
+                .strong => .{ .flag = SPAN_STRONG, .on = style(.bold), .off = "\x1b[22m" },
+                .u => .{ .flag = SPAN_U, .on = style(.underline), .off = "\x1b[24m" },
+                .del => .{ .flag = SPAN_DEL, .on = style(.strikethrough), .off = "\x1b[29m" },
+                else => null,
+            };
+        }
+    };
 
     pub const OutputBuffer = struct {
         list: std.ArrayListUnmanaged(u8),
@@ -184,12 +198,14 @@ pub const AnsiRenderer = struct {
     };
 
     pub fn init(allocator: Allocator, src_text: []const u8, theme: Theme) AnsiRenderer {
-        return .{
+        var r: AnsiRenderer = .{
             .out = .{ .list = .{}, .allocator = allocator, .oom = false },
             .allocator = allocator,
             .src_text = src_text,
             .theme = theme,
         };
+        r.out.list.ensureTotalCapacity(allocator, src_text.len + src_text.len / 2) catch {};
+        return r;
     }
 
     pub fn deinit(self: *AnsiRenderer) void {
@@ -292,34 +308,27 @@ pub const AnsiRenderer = struct {
                     entry.index = list.index;
                     list.index += 1;
                 }
-                var marker_width: u32 = 0;
-                if (task_mark != 0) {
-                    const checked = types.isTaskChecked(task_mark);
-                    const glyph = if (self.theme.colors)
-                        (if (checked) "☒ " else "☐ ")
-                    else
-                        (if (checked) "[x] " else "[ ] ");
-                    const c = if (checked) color(.green) else color(.dim);
-                    self.writeStyled(c, glyph);
-                    self.writeStyled(reset(), "");
-                    marker_width = @intCast(visibleWidth(glyph));
-                } else if (parent_list != null and parent_list.?.kind == .ol) {
-                    const start = parent_list.?.data;
-                    const num = start + entry.index;
-                    var buf: [12]u8 = undefined;
-                    const s = std.fmt.bufPrint(&buf, "{d}. ", .{num}) catch "? ";
-                    self.writeStyled(color(.cyan), s);
-                    self.writeStyled(reset(), "");
-                    marker_width = @intCast(visibleWidth(s));
-                } else {
-                    const bullet = if (self.theme.colors) "• " else "* ";
-                    self.writeStyled(color(.cyan), bullet);
-                    self.writeStyled(reset(), "");
-                    marker_width = @intCast(visibleWidth(bullet));
-                }
+                var num_buf: [12]u8 = undefined;
+                const glyph: []const u8, const glyph_color: []const u8 = blk: {
+                    if (task_mark != 0) {
+                        const checked = types.isTaskChecked(task_mark);
+                        const g = if (self.theme.colors)
+                            (if (checked) "☒ " else "☐ ")
+                        else
+                            (if (checked) "[x] " else "[ ] ");
+                        break :blk .{ g, if (checked) color(.green) else color(.dim) };
+                    }
+                    if (parent_list != null and parent_list.?.kind == .ol) {
+                        const num = parent_list.?.data + entry.index;
+                        break :blk .{ std.fmt.bufPrint(&num_buf, "{d}. ", .{num}) catch "? ", color(.cyan) };
+                    }
+                    break :blk .{ if (self.theme.colors) "• " else "* ", color(.cyan) };
+                };
+                self.writeStyled(glyph_color, glyph);
+                self.writeStyled(reset(), "");
                 // Wrapped continuation lines need to land under the item's
                 // content (past the marker), so record the marker width.
-                entry.indent = marker_width;
+                entry.indent = @intCast(visibleWidth(glyph));
                 self.block_stack.append(self.allocator, entry) catch {
                     self.out.oom = true;
                 };
@@ -409,18 +418,10 @@ pub const AnsiRenderer = struct {
         }
     }
 
-    pub fn leaveBlock(self: *AnsiRenderer, block_type: BlockType, data: u32) void {
+    pub fn leaveBlock(self: *AnsiRenderer, block_type: BlockType, _: u32) void {
         switch (block_type) {
             .doc => {},
-            .quote => {
-                _ = self.block_stack.pop();
-                self.ensureNewline();
-            },
-            .ul, .ol => {
-                _ = self.block_stack.pop();
-                self.ensureNewline();
-            },
-            .li => {
+            .quote, .ul, .ol, .li => {
                 _ = self.block_stack.pop();
                 self.ensureNewline();
             },
@@ -485,7 +486,6 @@ pub const AnsiRenderer = struct {
                 };
             },
         }
-        _ = data;
     }
 
     // ========================================
@@ -494,21 +494,10 @@ pub const AnsiRenderer = struct {
 
     pub fn enterSpan(self: *AnsiRenderer, span_type: SpanType, detail: SpanDetail) void {
         switch (span_type) {
-            .em => {
-                self.span_flags |= SPAN_EM;
-                self.writeStyled(style(.italic), "");
-            },
-            .strong => {
-                self.span_flags |= SPAN_STRONG;
-                self.writeStyled(style(.bold), "");
-            },
-            .u => {
-                self.span_flags |= SPAN_U;
-                self.writeStyled(style(.underline), "");
-            },
-            .del => {
-                self.span_flags |= SPAN_DEL;
-                self.writeStyled(style(.strikethrough), "");
+            .em, .strong, .u, .del => {
+                const s = InlineStyle.of(span_type).?;
+                self.span_flags |= s.flag;
+                self.writeStyled(s.on, "");
             },
             .code => {
                 self.span_flags |= SPAN_CODE;
@@ -552,26 +541,12 @@ pub const AnsiRenderer = struct {
 
     pub fn leaveSpan(self: *AnsiRenderer, span_type: SpanType) void {
         switch (span_type) {
-            .em => {
-                self.span_flags &= ~SPAN_EM;
-                self.writeStyled("\x1b[23m", "");
+            .em, .strong, .u, .del => {
+                const s = InlineStyle.of(span_type).?;
+                self.span_flags &= ~s.flag;
+                self.writeStyled(s.off, "");
                 // An off-code can turn off a heading's own bold/italic —
                 // reapply if we're inside a heading buffer.
-                if (self.heading_level > 0) self.reapplyStyles();
-            },
-            .strong => {
-                self.span_flags &= ~SPAN_STRONG;
-                self.writeStyled("\x1b[22m", "");
-                if (self.heading_level > 0) self.reapplyStyles();
-            },
-            .u => {
-                self.span_flags &= ~SPAN_U;
-                self.writeStyled("\x1b[24m", "");
-                if (self.heading_level > 0) self.reapplyStyles();
-            },
-            .del => {
-                self.span_flags &= ~SPAN_DEL;
-                self.writeStyled("\x1b[29m", "");
                 if (self.heading_level > 0) self.reapplyStyles();
             },
             .code => {
@@ -621,21 +596,13 @@ pub const AnsiRenderer = struct {
                 }
                 if (self.image_depth > 0) self.image_depth -= 1;
             },
-            .wikilink => {
-                // Use writeNoWrap so the closing delimiter stays attached
-                // to the content it closes — writeStyled would wrap `]]`
-                // to a new line when the inner text fills up to col-max.
-                self.writeNoWrap("]]");
-                self.writeStyled("\x1b[39m", "");
-                self.reapplyStyles();
-            },
-            .latexmath => {
-                self.writeNoWrap("$");
-                self.writeStyled("\x1b[39m", "");
-                self.reapplyStyles();
-            },
-            .latexmath_display => {
-                self.writeNoWrap("$$");
+            .wikilink, .latexmath, .latexmath_display => {
+                self.writeNoWrap(switch (span_type) {
+                    .wikilink => "]]",
+                    .latexmath => "$",
+                    .latexmath_display => "$$",
+                    else => unreachable,
+                });
                 self.writeStyled("\x1b[39m", "");
                 self.reapplyStyles();
             },
@@ -759,11 +726,9 @@ pub const AnsiRenderer = struct {
                 self.col = 0;
                 self.writeIndent();
                 i += 1;
-                // collapse repeated spaces
                 while (i < data.len and data[i] == ' ') i += 1;
                 continue;
             }
-            // find next break boundary
             var j = i;
             while (j < data.len and data[j] != ' ' and data[j] != '\n') : (j += 1) {}
             const word = data[i..j];
@@ -1365,7 +1330,6 @@ pub const AnsiRenderer = struct {
 
         const chars = self.boxChars();
 
-        // Top border
         self.writeIndent();
         if (self.theme.colors) self.out.write(color(.dim));
         self.out.write(chars.tl);
@@ -1378,7 +1342,6 @@ pub const AnsiRenderer = struct {
         self.out.writeByte('\n');
         self.last_was_newline = true;
 
-        // Rows
         var has_separated_header = false;
         for (self.table_rows.items) |row| {
             self.writeRowCells(row, widths, aligns);
@@ -1388,7 +1351,6 @@ pub const AnsiRenderer = struct {
             }
         }
 
-        // Bottom border
         self.writeIndent();
         if (self.theme.colors) self.out.write(color(.dim));
         self.out.write(chars.bl);
@@ -1402,7 +1364,6 @@ pub const AnsiRenderer = struct {
         self.last_was_newline = true;
         self.col = 0;
 
-        // Free rows
         for (self.table_rows.items) |row| {
             for (row.cells) |cell| self.allocator.free(cell.content);
             self.allocator.free(row.cells);

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -759,15 +759,34 @@ pub const AnsiRenderer = struct {
             while (j < data.len and data[j] != ' ' and data[j] != '\n') : (j += 1) {}
             const word = data[i..j];
             const word_width = visibleWidth(word);
-            if (self.col != 0 and self.col + word_width > max and self.col > indent) {
-                self.writeRaw("\n");
-                self.last_was_newline = true;
-                self.col = 0;
-                self.writeIndent();
+            const avail = max -| indent;
+            if (avail > 0 and word_width > avail) {
+                // Word can never fit on a fresh line — hard-break from
+                // wherever the cursor is so we don't waste the tail of
+                // the current line.
+                var rest = word;
+                while (rest.len > 0) {
+                    const r = max -| self.col;
+                    if (r == 0) {
+                        self.wrapBreak();
+                        continue;
+                    }
+                    var cut = visibleIndexAt(rest, r);
+                    if (cut == 0) cut = @min(rest.len, @as(usize, bun.strings.wtf8ByteSequenceLengthWithInvalid(rest[0])));
+                    self.writeRaw(rest[0..cut]);
+                    self.col += @intCast(visibleWidth(rest[0..cut]));
+                    self.last_was_newline = false;
+                    rest = rest[cut..];
+                    if (rest.len > 0) self.wrapBreak();
+                }
+            } else {
+                if (self.col != 0 and self.col + word_width > max and self.col > indent) {
+                    self.wrapBreak();
+                }
+                self.writeRaw(word);
+                self.col += @intCast(word_width);
+                self.last_was_newline = (word.len == 0);
             }
-            self.writeRaw(word);
-            self.col += @intCast(word_width);
-            self.last_was_newline = (word.len == 0);
             i = j;
             if (i < data.len and data[i] == ' ') {
                 // Look ahead to the next word: if the space + next word
@@ -778,7 +797,11 @@ pub const AnsiRenderer = struct {
                 var m = k;
                 while (m < data.len and data[m] != ' ' and data[m] != '\n') : (m += 1) {}
                 const next_word_width = visibleWidth(data[k..m]);
-                if (self.col != 0 and self.col + 1 + next_word_width > max and self.col > indent) {
+                const next_avail = max -| indent;
+                // Only soft-wrap when the next word would fit on a fresh
+                // line; if it's wider than that it will hard-break, so
+                // emit the space and let the break start mid-line.
+                if (self.col != 0 and self.col + 1 + next_word_width > max and self.col > indent and next_word_width <= next_avail) {
                     self.writeRaw("\n");
                     self.last_was_newline = true;
                     self.col = 0;
@@ -852,19 +875,102 @@ pub const AnsiRenderer = struct {
     /// both the escape prefix and the text through the active buffer so
     /// spans inside cells/headings flush correctly.
     fn writeStyled(self: *AnsiRenderer, prefix: []const u8, text_: []const u8) void {
+        const in_main_flow = !self.in_cell and self.heading_level == 0 and
+            !self.in_code_block and self.image_depth == 0;
+
+        // Pre-wrap before opening the style: an atomic span (`.code`,
+        // `.latexmath`, link href fallback) is emitted in one piece via
+        // emitInline, so if it would overflow we must break to a fresh
+        // line first — otherwise the terminal hard-wraps mid-span.
+        if (in_main_flow and self.theme.columns > 0 and text_.len > 0) {
+            const tw = visibleWidth(text_);
+            if (tw > 0) {
+                const max = self.theme.columns;
+                const indent = self.currentIndent();
+                if (self.col > indent and self.col + tw > max) {
+                    self.wrapBreak();
+                }
+            }
+        }
+
         if (self.theme.colors and prefix.len > 0) {
             self.emitInline(prefix);
         }
-        if (text_.len > 0) {
+        if (text_.len == 0) return;
+
+        if (!in_main_flow) {
             self.emitInline(text_);
-            // `col` tracks the visible cursor on the main output only —
-            // bytes buffered into a cell / heading / image-alt / code
-            // block don't move the current line's cursor.
-            if (!self.in_cell and self.heading_level == 0 and !self.in_code_block and self.image_depth == 0) {
-                self.col += @intCast(visibleWidth(text_));
-                self.last_was_newline = false;
-            }
+            return;
         }
+
+        const max = self.theme.columns;
+        if (max == 0) {
+            self.emitInline(text_);
+            self.col += @intCast(visibleWidth(text_));
+            self.last_was_newline = false;
+            return;
+        }
+
+        var rest = text_;
+        while (rest.len > 0) {
+            const room = max -| self.col;
+            if (room == 0) {
+                if (self.col <= self.currentIndent()) {
+                    // Pathological: indent >= columns. Emit as-is to
+                    // avoid an infinite loop.
+                    self.emitInline(rest);
+                    self.col += @intCast(visibleWidth(rest));
+                    self.last_was_newline = false;
+                    return;
+                }
+                self.wrapBreak();
+                continue;
+            }
+            const cut = visibleIndexAt(rest, room);
+            if (cut == rest.len) {
+                self.emitInline(rest);
+                self.col += @intCast(visibleWidth(rest));
+                self.last_was_newline = false;
+                return;
+            }
+            // cut == 0 happens when the first codepoint is wider than
+            // `room` (e.g. one column left, next char is width-2 CJK).
+            // Wrap to a fresh line; the next iteration has full room.
+            if (cut == 0) {
+                if (self.col <= self.currentIndent()) {
+                    // Even a fresh line can't hold one codepoint —
+                    // emit one codepoint to make progress.
+                    const adv = visibleIndexAt(rest, 2);
+                    const one = if (adv == 0) @min(rest.len, @as(usize, bun.strings.wtf8ByteSequenceLengthWithInvalid(rest[0]))) else adv;
+                    self.emitInline(rest[0..one]);
+                    self.col += @intCast(visibleWidth(rest[0..one]));
+                    self.last_was_newline = false;
+                    rest = rest[one..];
+                    if (rest.len > 0) self.wrapBreak();
+                    continue;
+                }
+                self.wrapBreak();
+                continue;
+            }
+            self.emitInline(rest[0..cut]);
+            self.col += @intCast(visibleWidth(rest[0..cut]));
+            self.last_was_newline = false;
+            rest = rest[cut..];
+            self.wrapBreak();
+        }
+    }
+
+    /// Soft-wrap inside a styled span: clear bg/fg so the line tail and
+    /// indent stay clean, newline, re-emit indent, then reapply the
+    /// active span styles so the continuation keeps its color.
+    fn wrapBreak(self: *AnsiRenderer) void {
+        const has_style = self.span_flags != 0 or self.link_depth > 0;
+        if (self.theme.colors and has_style) self.out.write("\x1b[39m\x1b[49m");
+        self.out.writeByte('\n');
+        self.last_was_newline = true;
+        self.col = 0;
+        self.writeIndent();
+        if (has_style) self.reapplyStyles();
     }
 
     /// Emit raw text (typically a single char or newline). Routes through
@@ -1211,6 +1317,25 @@ pub const AnsiRenderer = struct {
             }
         }
 
+        // Clamp column widths so the rendered table fits the terminal.
+        // Each column contributes ` content │` = width+3; plus one
+        // leading `│` and the current indent.
+        if (self.theme.columns > 0) {
+            const indent = self.currentIndent();
+            var total: usize = indent + 1;
+            for (widths) |w| total += w + 3;
+            const budget = self.theme.columns;
+            while (total > budget) {
+                var widest: usize = 0;
+                for (widths, 0..) |w, i| {
+                    if (w > widths[widest]) widest = i;
+                }
+                if (widths[widest] <= 3) break;
+                widths[widest] -= 1;
+                total -= 1;
+            }
+        }
+
         const chars = self.boxChars();
 
         // Top border
@@ -1265,39 +1390,77 @@ pub const AnsiRenderer = struct {
         aligns: []const types.Align,
     ) void {
         const chars = self.boxChars();
-        self.writeIndent();
-        if (self.theme.colors) self.out.write(color(.dim));
-        self.out.write(chars.v);
-        if (self.theme.colors) self.out.write("\x1b[0m");
+
+        // Split each cell into visible-width-bounded segments so a wide
+        // cell wraps WITHIN its column instead of letting the terminal
+        // hard-wrap the whole row and shred the borders.
+        var segments = self.allocator.alloc(std.ArrayListUnmanaged([]const u8), widths.len) catch {
+            self.out.oom = true;
+            return;
+        };
+        defer {
+            for (segments) |*s| s.deinit(self.allocator);
+            self.allocator.free(segments);
+        }
+        @memset(segments, .{});
+
+        var lines: usize = 1;
         for (widths, 0..) |w, i| {
-            const cell: TableCell = if (i < row.cells.len) row.cells[i] else .{ .content = "", .alignment = .default };
-            self.out.writeByte(' ');
-            if (row.is_header and self.theme.colors) self.out.write("\x1b[1m");
-            const cw = visibleWidth(cell.content);
-            const alignment = if (cell.alignment != .default) cell.alignment else aligns[i];
-            switch (alignment) {
-                .right => {
-                    self.writePadding(w - cw);
-                    self.out.write(cell.content);
-                },
-                .center => {
-                    const pad = w - cw;
-                    self.writePadding(pad / 2);
-                    self.out.write(cell.content);
-                    self.writePadding(pad - pad / 2);
-                },
-                else => {
-                    self.out.write(cell.content);
-                    self.writePadding(w - cw);
-                },
+            const content = if (i < row.cells.len) row.cells[i].content else "";
+            var rest = content;
+            while (rest.len > 0) {
+                var cut = visibleIndexAt(rest, w);
+                if (cut < rest.len) {
+                    // Prefer breaking at the last space inside the cut so
+                    // words stay intact when there's room.
+                    if (bun.strings.lastIndexOfChar(rest[0..cut], ' ')) |sp| {
+                        if (sp > 0) cut = sp;
+                    }
+                }
+                if (cut == 0) cut = @min(rest.len, @as(usize, bun.strings.wtf8ByteSequenceLengthWithInvalid(rest[0])));
+                segments[i].append(self.allocator, rest[0..cut]) catch {
+                    self.out.oom = true;
+                    return;
+                };
+                rest = rest[cut..];
+                while (rest.len > 0 and rest[0] == ' ') rest = rest[1..];
             }
-            if (row.is_header and self.theme.colors) self.out.write("\x1b[0m");
-            self.out.writeByte(' ');
+            lines = @max(lines, segments[i].items.len);
+        }
+
+        var line: usize = 0;
+        while (line < lines) : (line += 1) {
+            self.writeIndent();
             if (self.theme.colors) self.out.write(color(.dim));
             self.out.write(chars.v);
             if (self.theme.colors) self.out.write("\x1b[0m");
+            for (widths, 0..) |w, i| {
+                const seg: []const u8 = if (line < segments[i].items.len) segments[i].items[line] else "";
+                self.out.writeByte(' ');
+                if (row.is_header and self.theme.colors) self.out.write("\x1b[1m");
+                const cw = visibleWidth(seg);
+                const cell_align = if (i < row.cells.len) row.cells[i].alignment else .default;
+                const alignment = if (cell_align != .default) cell_align else aligns[i];
+                const pad = w -| cw;
+                const left: usize, const right: usize = switch (alignment) {
+                    .right => .{ pad, 0 },
+                    .center => .{ pad / 2, pad - pad / 2 },
+                    else => .{ 0, pad },
+                };
+                self.writePadding(left);
+                self.out.write(seg);
+                // Clear any inline style from the segment so it doesn't
+                // bleed into the padding / border on this or the next
+                // physical line.
+                if (self.theme.colors) self.out.write("\x1b[0m");
+                self.writePadding(right);
+                self.out.writeByte(' ');
+                if (self.theme.colors) self.out.write(color(.dim));
+                self.out.write(chars.v);
+                if (self.theme.colors) self.out.write("\x1b[0m");
+            }
+            self.out.writeByte('\n');
         }
-        self.out.writeByte('\n');
         self.last_was_newline = true;
     }
 
@@ -1564,6 +1727,12 @@ fn codeSpanOpen(light: bool) []const u8 {
 /// sequences. Correctly handles multi-width graphemes (CJK, emoji).
 fn visibleWidth(s: []const u8) usize {
     return bun.strings.visible.width.exclude_ansi_colors.utf8(s);
+}
+
+/// Byte index of the longest prefix of `s` whose visible width is <=
+/// `max_cols`. ANSI escapes are zero-width and always included.
+fn visibleIndexAt(s: []const u8, max_cols: usize) usize {
+    return bun.strings.visible.width.exclude_ansi_colors.utf8IndexAtWidth(s, max_cols);
 }
 
 fn isJsLang(lang: []const u8) bool {

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1573,10 +1573,26 @@ fn probeKittyGraphics() bool {
     // Honor an explicit opt-out.
     if (bun.getenvZ("BUN_DISABLE_KITTY_PROBE")) |_| return false;
 
-    // Save original mode + switch stdin to raw so the reply bytes
-    // arrive immediately and don't echo.
+    // Save the parent's termios before flipping stdin to raw. If the
+    // parent (a TUI, tmux/Zellij pane, etc.) already had raw mode on,
+    // restoring to a fixed .normal would corrupt it — instead reapply
+    // exactly what we read. tcgetattr failing means stdin isn't a real
+    // TTY in a way we can snapshot; fall back to forcing .normal.
+    var saved_termios: std.posix.termios = undefined;
+    const have_saved = if (std.posix.tcgetattr(0)) |t| blk: {
+        saved_termios = t;
+        break :blk true;
+    } else |_| false;
     _ = bun.tty.setMode(0, .raw);
-    defer _ = bun.tty.setMode(0, .normal);
+    defer {
+        if (have_saved) {
+            std.posix.tcsetattr(0, .NOW, saved_termios) catch {
+                _ = bun.tty.setMode(0, .normal);
+            };
+        } else {
+            _ = bun.tty.setMode(0, .normal);
+        }
+    }
 
     // Query: transmit a 1×1 RGB image (3 zero bytes = "AAAA" b64),
     // id=31. The terminal replies with `\x1b_Gi=31;OK\x1b\\`

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -1424,6 +1424,7 @@ pub const AnsiRenderer = struct {
         const ITALIC: u8 = 1 << 1;
         const UNDERLINE: u8 = 1 << 2;
         const STRIKE: u8 = 1 << 3;
+        const DIM: u8 = 1 << 4;
 
         fn hasAny(self: CellAnsiState) bool {
             return self.flags != 0 or self.fg != null or self.bg != null or self.link != null;
@@ -1431,6 +1432,7 @@ pub const AnsiRenderer = struct {
 
         fn emitOpens(self: CellAnsiState, out: *OutputBuffer) void {
             if (self.flags & BOLD != 0) out.write("\x1b[1m");
+            if (self.flags & DIM != 0) out.write("\x1b[2m");
             if (self.flags & ITALIC != 0) out.write("\x1b[3m");
             if (self.flags & UNDERLINE != 0) out.write("\x1b[4m");
             if (self.flags & STRIKE != 0) out.write("\x1b[9m");
@@ -1486,7 +1488,7 @@ pub const AnsiRenderer = struct {
                         }
                     }
                     const seq = bytes[seq_start..j];
-                    if (seq.len >= 5 and std.mem.startsWith(u8, seq, "\x1b]8;")) {
+                    if (seq.len >= 5 and bun.strings.hasPrefixComptime(seq, "\x1b]8;")) {
                         // "\x1b]8;<params>;<URL>\x1b\\" — a close has an
                         // empty URL component.
                         const body = seq[4..]; // after "\x1b]8;"
@@ -1499,7 +1501,7 @@ pub const AnsiRenderer = struct {
                             break :blk body.len;
                         };
                         const body_stripped = body[0..body_end];
-                        if (std.mem.indexOfScalar(u8, body_stripped, ';')) |semi| {
+                        if (bun.strings.indexOfChar(body_stripped, ';')) |semi| {
                             const url = body_stripped[semi + 1 ..];
                             if (url.len == 0) {
                                 self.link = null;
@@ -1536,10 +1538,13 @@ pub const AnsiRenderer = struct {
                         self.bg = null;
                     },
                     1 => self.flags |= BOLD,
+                    2 => self.flags |= DIM,
                     3 => self.flags |= ITALIC,
                     4 => self.flags |= UNDERLINE,
                     9 => self.flags |= STRIKE,
-                    22 => self.flags &= ~BOLD,
+                    // ECMA-48 §8.3.117: SGR 22 = "normal intensity" —
+                    // clears BOTH bold (SGR 1) and faint/dim (SGR 2).
+                    22 => self.flags &= ~(BOLD | DIM),
                     23 => self.flags &= ~ITALIC,
                     24 => self.flags &= ~UNDERLINE,
                     29 => self.flags &= ~STRIKE,

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -24,8 +24,9 @@ pub const AnsiRenderer = struct {
     block_stack: std.ArrayListUnmanaged(BlockContext) = .{},
     /// Currently open span styles (bit flags).
     span_flags: u32 = 0,
-    /// Non-empty when we're inside a link span; the href to emit in OSC 8.
-    link_href: []const u8 = "",
+    /// Non-null when we're inside a link span; the href to emit in OSC 8.
+    /// Always allocator-owned when non-null (freed in leaveSpan).
+    link_href: ?[]const u8 = null,
     /// Depth of enclosing link spans (brackets can nest in markdown parsers).
     link_depth: u32 = 0,
     /// Depth of enclosing image spans — text inside images becomes alt text
@@ -33,10 +34,10 @@ pub const AnsiRenderer = struct {
     image_depth: u32 = 0,
     /// Buffered alt text for the innermost image.
     image_alt: std.ArrayListUnmanaged(u8) = .{},
-    /// Saved image src URL for when the image span closes.
-    image_src: []const u8 = "",
-    /// Saved image title (rendered after alt).
-    image_title: []const u8 = "",
+    /// Saved image src URL for when the image span closes (owned).
+    image_src: ?[]const u8 = null,
+    /// Saved image title (rendered after alt, owned).
+    image_title: ?[]const u8 = null,
     /// Active paragraph-level wrapping column usage. Tracks visible chars
     /// written on the current line so word wrapping works inside headings
     /// and paragraphs.
@@ -231,13 +232,12 @@ pub const AnsiRenderer = struct {
                     const start = parent_list.?.data;
                     const num = start + entry.index;
                     var buf: [12]u8 = undefined;
-                    const s = std.fmt.bufPrint(&buf, "{d}.", .{num}) catch "?";
+                    const s = std.fmt.bufPrint(&buf, "{d}. ", .{num}) catch "? ";
                     self.writeStyled(color(.cyan), s);
-                    self.writeRaw(" ");
-                    self.col += @intCast(s.len + 1);
+                    self.writeStyled(reset(), "");
                 } else {
                     self.writeStyled(color(.cyan), "• ");
-                    self.col += 2;
+                    self.writeStyled(reset(), "");
                 }
                 self.block_stack.append(self.allocator, entry) catch {
                     self.out.oom = true;
@@ -363,6 +363,10 @@ pub const AnsiRenderer = struct {
                 // Move the collected cells into a table row; widths will be
                 // normalized once the table finishes.
                 const cells = self.allocator.dupe(TableCell, self.table_cells.items) catch {
+                    // Cell content slices in table_cells become orphaned
+                    // if we can't move them into a row; free them here.
+                    for (self.table_cells.items) |c| self.allocator.free(c.content);
+                    self.table_cells.clearRetainingCapacity();
                     self.out.oom = true;
                     return;
                 };
@@ -370,6 +374,9 @@ pub const AnsiRenderer = struct {
                     .cells = cells,
                     .is_header = self.in_thead,
                 }) catch {
+                    for (cells) |c| self.allocator.free(c.content);
+                    self.allocator.free(cells);
+                    self.table_cells.clearRetainingCapacity();
                     self.out.oom = true;
                     return;
                 };
@@ -385,6 +392,7 @@ pub const AnsiRenderer = struct {
                     .content = owned,
                     .alignment = self.cell_align,
                 }) catch {
+                    self.allocator.free(owned);
                     self.out.oom = true;
                 };
             },
@@ -422,14 +430,17 @@ pub const AnsiRenderer = struct {
             .a => {
                 self.link_depth += 1;
                 if (self.link_depth == 1) {
-                    // Resolve final href (prefixes for autolinks)
-                    const href = resolveHref(detail, self.allocator) catch "";
-                    self.link_href = href;
+                    // Resolve final href (prefixes for autolinks). On OOM
+                    // we leave link_href null so leaveSpan doesn't try to
+                    // free a literal.
+                    self.link_href = resolveHref(detail, self.allocator) catch null;
                     if (self.theme.colors and self.theme.hyperlinks) {
-                        // OSC 8 hyperlink start
-                        self.writeRawNoColor("\x1b]8;;");
-                        self.writeRawNoColor(href);
-                        self.writeRawNoColor("\x1b\\");
+                        if (self.link_href) |href| {
+                            // OSC 8 hyperlink start
+                            self.writeRawNoColor("\x1b]8;;");
+                            self.writeRawNoColor(href);
+                            self.writeRawNoColor("\x1b\\");
+                        }
                     }
                     self.writeStyled(color(.blue), "");
                     self.writeStyled(style(.underline), "");
@@ -438,18 +449,16 @@ pub const AnsiRenderer = struct {
             .img => {
                 self.image_depth += 1;
                 if (self.image_depth == 1) {
-                    self.image_src = self.allocator.dupe(u8, detail.href) catch "";
-                    self.image_title = self.allocator.dupe(u8, detail.title) catch "";
+                    self.image_src = self.allocator.dupe(u8, detail.href) catch null;
+                    self.image_title = self.allocator.dupe(u8, detail.title) catch null;
                     self.image_alt.clearRetainingCapacity();
                 }
             },
             .wikilink => {
                 self.writeStyled(color(.blue), "[[");
-                self.col += 2;
             },
             .latexmath, .latexmath_display => {
                 self.writeStyled(color(.magenta), "$");
-                self.col += 1;
             },
         }
     }
@@ -474,47 +483,51 @@ pub const AnsiRenderer = struct {
             },
             .code => {
                 self.span_flags &= ~SPAN_CODE;
-                self.writeStyled(codeSpanClose(), "");
+                // Restore default fg+bg without touching bold/italic/etc.
+                self.writeStyled("\x1b[39m\x1b[49m", "");
+                self.reapplyStyles();
             },
             .a => {
                 if (self.link_depth == 1) {
-                    self.writeStyled("\x1b[24m", ""); // stop underline
-                    self.writeStyled(reset(), "");
+                    // Underline off, default fg; reapply outer styles so a
+                    // link inside **bold** doesn't drop the bold.
+                    self.writeStyled("\x1b[24m\x1b[39m", "");
+                    self.reapplyStyles();
                     if (self.theme.colors and self.theme.hyperlinks) {
                         self.writeRawNoColor("\x1b]8;;\x1b\\");
-                    } else if (self.link_href.len > 0) {
+                    } else if (self.link_href) |href| if (href.len > 0) {
                         // Show URL in parens for non-hyperlink terminals
                         self.writeStyled(color(.dim), " (");
-                        self.writeRaw(self.link_href);
+                        self.writeStyled("", href);
                         self.writeStyled(color(.dim), ")");
-                        self.writeStyled(reset(), "");
-                        self.col += @intCast(self.link_href.len + 3);
-                    }
-                    self.allocator.free(self.link_href);
-                    self.link_href = "";
+                        self.writeStyled("\x1b[39m\x1b[22m", "");
+                        self.reapplyStyles();
+                    };
+                    if (self.link_href) |href| self.allocator.free(href);
+                    self.link_href = null;
                 }
                 if (self.link_depth > 0) self.link_depth -= 1;
             },
             .img => {
                 if (self.image_depth == 1) {
                     self.emitImage();
-                    self.allocator.free(self.image_src);
-                    self.allocator.free(self.image_title);
-                    self.image_src = "";
-                    self.image_title = "";
+                    if (self.image_src) |src| self.allocator.free(src);
+                    if (self.image_title) |title| self.allocator.free(title);
+                    self.image_src = null;
+                    self.image_title = null;
                     self.image_alt.clearRetainingCapacity();
                 }
                 if (self.image_depth > 0) self.image_depth -= 1;
             },
             .wikilink => {
-                self.writeRaw("]]");
-                self.writeStyled(reset(), "");
-                self.col += 2;
+                self.writeStyled("", "]]");
+                self.writeStyled("\x1b[39m", "");
+                self.reapplyStyles();
             },
             .latexmath, .latexmath_display => {
-                self.writeRaw("$");
-                self.writeStyled(reset(), "");
-                self.col += 1;
+                self.writeStyled("", "$");
+                self.writeStyled("\x1b[39m", "");
+                self.reapplyStyles();
             },
         }
     }
@@ -637,35 +650,114 @@ pub const AnsiRenderer = struct {
         }
     }
 
-    /// Emit a styled sequence + text, respecting color settings.
+    /// Route bytes to the active inline sink. Spans inside a table cell,
+    /// heading, or image must write to that buffer so structural code
+    /// (flushTable/flushHeading/emitImage) emits them at the right spot.
+    /// ANSI escape bytes are dropped inside image alt text since alt text
+    /// is plain.
+    fn emitInline(self: *AnsiRenderer, bytes: []const u8) void {
+        if (bytes.len == 0) return;
+        if (self.image_depth > 0) {
+            // Image alt is plain text — strip escape sequences.
+            var i: usize = 0;
+            while (i < bytes.len) {
+                if (bytes[i] == 0x1b) {
+                    i += 1;
+                    if (i < bytes.len and bytes[i] == '[') {
+                        i += 1;
+                        while (i < bytes.len and (bytes[i] < 0x40 or bytes[i] > 0x7e)) : (i += 1) {}
+                        if (i < bytes.len) i += 1;
+                    } else if (i < bytes.len and bytes[i] == ']') {
+                        i += 1;
+                        while (i < bytes.len) : (i += 1) {
+                            if (bytes[i] == 0x07) {
+                                i += 1;
+                                break;
+                            }
+                            if (bytes[i] == 0x1b and i + 1 < bytes.len and bytes[i + 1] == '\\') {
+                                i += 2;
+                                break;
+                            }
+                        }
+                    }
+                    continue;
+                }
+                const start = i;
+                while (i < bytes.len and bytes[i] != 0x1b) : (i += 1) {}
+                self.image_alt.appendSlice(self.allocator, bytes[start..i]) catch {
+                    self.out.oom = true;
+                    return;
+                };
+            }
+            return;
+        }
+        if (self.in_cell) {
+            self.table_cell_buf.appendSlice(self.allocator, bytes) catch {
+                self.out.oom = true;
+            };
+            return;
+        }
+        if (self.heading_level > 0) {
+            self.heading_buf.appendSlice(self.allocator, bytes) catch {
+                self.out.oom = true;
+            };
+            return;
+        }
+        self.out.write(bytes);
+    }
+
+    /// Emit a styled sequence + text, respecting color settings. Routes
+    /// both the escape prefix and the text through the active buffer so
+    /// spans inside cells/headings flush correctly.
     fn writeStyled(self: *AnsiRenderer, prefix: []const u8, text_: []const u8) void {
-        if (self.theme.colors) {
-            self.out.write(prefix);
+        if (self.theme.colors and prefix.len > 0) {
+            self.emitInline(prefix);
         }
         if (text_.len > 0) {
-            self.out.write(text_);
+            self.emitInline(text_);
             self.col += @intCast(visibleWidth(text_));
             self.last_was_newline = false;
         }
     }
 
-    /// Return the visible length of a styled sequence — the prefix adds
-    /// zero visible chars but advances `col` by the text length.
-    fn styledLen(self: *AnsiRenderer, s: []const u8) usize {
-        _ = self;
-        return visibleWidth(s);
-    }
-
-    /// Emit raw text (bypassing styling). Does not track the column.
+    /// Emit raw text (typically a single char or newline). Routes through
+    /// the active inline buffer and keeps last_was_newline current. Does
+    /// not track column width — callers that need it use writeStyled.
     fn writeRaw(self: *AnsiRenderer, data: []const u8) void {
-        self.out.write(data);
-        if (data.len > 0) self.last_was_newline = (data[data.len - 1] == '\n');
+        if (data.len == 0) return;
+        self.emitInline(data);
+        self.last_was_newline = (data[data.len - 1] == '\n');
     }
 
-    /// Emit raw bytes even when colors are off (for OSC sequences).
+    /// Emit raw bytes that must not appear in `image_alt`. Goes through
+    /// the active buffer for cells/headings, but never into image alt.
     fn writeRawNoColor(self: *AnsiRenderer, data: []const u8) void {
         if (!self.theme.colors) return;
+        if (data.len == 0) return;
+        if (self.image_depth > 0) return;
+        if (self.in_cell) {
+            self.table_cell_buf.appendSlice(self.allocator, data) catch {
+                self.out.oom = true;
+            };
+            return;
+        }
+        if (self.heading_level > 0) {
+            self.heading_buf.appendSlice(self.allocator, data) catch {
+                self.out.oom = true;
+            };
+            return;
+        }
         self.out.write(data);
+    }
+
+    /// Re-emit the currently active inline styles from span_flags. Used
+    /// after a nested span closes to avoid wiping the outer styles.
+    fn reapplyStyles(self: *AnsiRenderer) void {
+        if (!self.theme.colors) return;
+        if (self.span_flags & SPAN_STRONG != 0) self.emitInline(style(.bold));
+        if (self.span_flags & SPAN_EM != 0) self.emitInline(style(.italic));
+        if (self.span_flags & SPAN_U != 0) self.emitInline(style(.underline));
+        if (self.span_flags & SPAN_DEL != 0) self.emitInline(style(.strikethrough));
     }
 
     fn writeIndent(self: *AnsiRenderer) void {
@@ -1019,26 +1111,36 @@ pub const AnsiRenderer = struct {
     // ========================================
 
     fn emitImage(self: *AnsiRenderer) void {
+        // Snapshot alt + link fields now — emitImage drops out of the
+        // image context before writing, so image_alt / image_depth checks
+        // in emitInline would otherwise still divert output.
         const alt = self.image_alt.items;
-        // Display as: [alt text] (src)  with OSC 8 hyperlink
-        if (self.theme.colors and self.theme.hyperlinks and self.image_src.len > 0) {
+        const src = self.image_src;
+        // Drop image context so writeStyled/writeRaw flow through the
+        // normal inline path (paragraph, cell, etc.).
+        const saved_depth = self.image_depth;
+        self.image_depth = 0;
+        defer self.image_depth = saved_depth;
+
+        const has_src = src != null and src.?.len > 0;
+        if (self.theme.colors and self.theme.hyperlinks and has_src) {
             self.writeRawNoColor("\x1b]8;;");
-            self.writeRawNoColor(self.image_src);
+            self.writeRawNoColor(src.?);
             self.writeRawNoColor("\x1b\\");
         }
         self.writeStyled(color(.magenta), "🖼 ");
         if (alt.len > 0) {
-            self.writeRaw(alt);
-            self.col += @intCast(visibleWidth(alt));
-        } else if (self.image_title.len > 0) {
-            self.writeRaw(self.image_title);
-            self.col += @intCast(visibleWidth(self.image_title));
+            self.writeStyled("", alt);
+        } else if (self.image_title) |title| if (title.len > 0) {
+            self.writeStyled("", title);
         } else {
-            self.writeRaw("(image)");
-            self.col += 7;
+            self.writeStyled("", "(image)");
+        } else {
+            self.writeStyled("", "(image)");
         }
         self.writeStyled(reset(), "");
-        if (self.theme.colors and self.theme.hyperlinks and self.image_src.len > 0) {
+        self.reapplyStyles();
+        if (self.theme.colors and self.theme.hyperlinks and has_src) {
             self.writeRawNoColor("\x1b]8;;\x1b\\");
         }
     }
@@ -1150,7 +1252,7 @@ fn resolveHref(detail: SpanDetail, allocator: Allocator) ![]u8 {
 /// 1. `COLORFGBG` env var (set by rxvt, xterm, Konsole, iTerm2 in some modes)
 /// 2. Dark mode (default)
 pub fn detectLightBackground() bool {
-    if (std.posix.getenv("COLORFGBG")) |value| {
+    if (bun.getenvZ("COLORFGBG")) |value| {
         // Format: "fg;bg" or "fg;default;bg" — bg index < 8 is dark, >=8 light
         var iter = std.mem.splitScalar(u8, value, ';');
         var last: []const u8 = "";

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -23,7 +23,7 @@ pub const Theme = struct {
     /// `collectImageUrls` + the CLI entry point) so `emitImage` can
     /// send remote images through Kitty's `t=f` path. When null, http
     /// and https URLs fall through to the alt-text fallback.
-    remote_image_paths: ?*const std.StringHashMapUnmanaged([]const u8) = null,
+    remote_image_paths: ?*const bun.StringHashMapUnmanaged([]const u8) = null,
     /// Base directory used to resolve relative image `src` paths. When
     /// null, falls back to the process cwd. The CLI entry point sets
     /// this to the markdown file's directory so `![](./img.png)` works

--- a/src/md/ansi_renderer.zig
+++ b/src/md/ansi_renderer.zig
@@ -756,10 +756,24 @@ pub const AnsiRenderer = struct {
             self.last_was_newline = (word.len == 0);
             i = j;
             if (i < data.len and data[i] == ' ') {
-                self.writeRaw(" ");
-                self.col += 1;
-                i += 1;
-                while (i < data.len and data[i] == ' ') i += 1;
+                // Look ahead to the next word: if the space + next word
+                // would overflow, wrap here and drop the space instead of
+                // leaving a trailing space at the end of the wrapped line.
+                var k = i;
+                while (k < data.len and data[k] == ' ') k += 1;
+                var m = k;
+                while (m < data.len and data[m] != ' ' and data[m] != '\n') : (m += 1) {}
+                const next_word_width = visibleWidth(data[k..m]);
+                if (self.col != 0 and self.col + 1 + next_word_width > max and self.col > indent) {
+                    self.writeRaw("\n");
+                    self.last_was_newline = true;
+                    self.col = 0;
+                    self.writeIndent();
+                } else {
+                    self.writeRaw(" ");
+                    self.col += 1;
+                }
+                i = k;
             }
         }
     }
@@ -1352,13 +1366,8 @@ pub const AnsiRenderer = struct {
         //   1. colors + kitty_graphics are enabled (needs ESC support)
         //   2. src is a file: URI or a non-URL path
         //   3. the file exists on disk
-        // On success we also emit an OSC 8 hyperlink so the text alt
-        // remains clickable below the image, and still write the alt
-        // text as a visible caption for non-Kitty terminals that ignore
-        // the APC sequence.
-        // Try to render inline via Kitty Graphics. If the image is
-        // actually displayed, we're done — the image itself is the
-        // content, no caption/alt text needed.
+        // If the image is actually displayed, we're done — the image
+        // itself is the content, no caption/alt text needed.
         // Skip Kitty inside table cells / headings: the APC payload
         // would be counted as visible width by flushTable/flushHeading,
         // blowing up the column / underline size. Images in cells
@@ -1394,14 +1403,17 @@ pub const AnsiRenderer = struct {
 
         // Fallback: image can't be rendered inline. Show the alt text
         // (or title, or "(image)") wrapped in the OSC 8 hyperlink so
-        // the src URL stays clickable. A magenta 🖼 marker makes it
-        // obvious this is a missing/unrendered image.
+        // the src URL stays clickable. A magenta camera marker makes it
+        // obvious this is a missing/unrendered image. (U+1F4F7 instead
+        // of U+1F5BC "FRAME WITH PICTURE" because 1F5BC is classified
+        // Narrow in EastAsianWidth.txt — visibleWidth would undercount
+        // it as 1 column and wrapping would fire one column too late.)
         if (self.theme.colors and self.theme.hyperlinks and has_src) {
             self.writeRawNoColor("\x1b]8;;");
             self.writeRawNoColor(src.?);
             self.writeRawNoColor("\x1b\\");
         }
-        const img_marker = if (self.theme.colors) "🖼 " else "[img] ";
+        const img_marker = if (self.theme.colors) "📷 " else "[img] ";
         self.writeStyled(color(.magenta), img_marker);
         if (alt.len > 0) {
             self.writeStyled("", alt);

--- a/src/md/inlines.zig
+++ b/src/md/inlines.zig
@@ -201,12 +201,15 @@ pub fn processInlineContent(self: *Parser, content: []const u8, base_off: OFF) P
 
         // Wiki links: [[destination]] or [[destination|label]]
         if (c == '[' and self.flags.wiki_links and i + 1 < content.len and content[i + 1] == '[') {
+            if (i > text_start) try self.emitText(.normal, content[text_start..i]);
             if (try self.processWikiLink(content, i)) |end_pos| {
-                if (i > text_start) try self.emitText(.normal, content[text_start..i]);
                 i = end_pos;
                 text_start = i;
                 continue;
             }
+            // No wikilink matched: restore text_start so preceding text
+            // isn't double-emitted by the next span branch.
+            text_start = i;
         }
 
         // Links: [text](url) or [text][ref]

--- a/src/md/root.zig
+++ b/src/md/root.zig
@@ -52,6 +52,18 @@ pub const Options = struct {
         .tag_filter = true,
     };
 
+    pub const terminal: Options = .{
+        .tables = true,
+        .strikethrough = true,
+        .tasklists = true,
+        .permissive_url_autolinks = true,
+        .permissive_www_autolinks = true,
+        .permissive_email_autolinks = true,
+        .wiki_links = true,
+        .underline = true,
+        .latex_math = true,
+    };
+
     pub fn toFlags(self: Options) Flags {
         return .{
             .tables = self.tables,

--- a/src/md/root.zig
+++ b/src/md/root.zig
@@ -103,6 +103,7 @@ pub const helpers = @import("./helpers.zig");
 pub const ansi = @import("./ansi_renderer.zig");
 pub const AnsiRenderer = ansi.AnsiRenderer;
 pub const AnsiTheme = ansi.Theme;
+pub const ImageUrlCollector = ansi.ImageUrlCollector;
 pub const renderToAnsi = ansi.renderToAnsi;
 pub const detectLightBackground = ansi.detectLightBackground;
 pub const detectKittyGraphics = ansi.detectKittyGraphics;

--- a/src/md/root.zig
+++ b/src/md/root.zig
@@ -100,5 +100,11 @@ const Flags = types.Flags;
 pub const entity = @import("./entity.zig");
 pub const helpers = @import("./helpers.zig");
 
+pub const ansi = @import("./ansi_renderer.zig");
+pub const AnsiRenderer = ansi.AnsiRenderer;
+pub const AnsiTheme = ansi.Theme;
+pub const renderToAnsi = ansi.renderToAnsi;
+pub const detectLightBackground = ansi.detectLightBackground;
+
 const parser = @import("./parser.zig");
 const std = @import("std");

--- a/src/md/root.zig
+++ b/src/md/root.zig
@@ -105,6 +105,7 @@ pub const AnsiRenderer = ansi.AnsiRenderer;
 pub const AnsiTheme = ansi.Theme;
 pub const renderToAnsi = ansi.renderToAnsi;
 pub const detectLightBackground = ansi.detectLightBackground;
+pub const detectKittyGraphics = ansi.detectKittyGraphics;
 
 const parser = @import("./parser.zig");
 const std = @import("std");

--- a/src/options.zig
+++ b/src/options.zig
@@ -1156,6 +1156,8 @@ const default_loaders_posix = .{
     .{ ".html", .html },
     .{ ".jsonc", .jsonc },
     .{ ".json5", .json5 },
+    .{ ".md", .md },
+    .{ ".markdown", .md },
 };
 const default_loaders_win32 = default_loaders_posix ++ .{
     .{ ".sh", .bunsh },

--- a/src/string/immutable/visible.zig
+++ b/src/string/immutable/visible.zig
@@ -1275,8 +1275,102 @@ pub const visible = struct {
             pub fn utf16(input: []const u16, ambiguousAsWide: bool) usize {
                 return visibleUTF16WidthFn(input, true, ambiguousAsWide);
             }
+
+            /// Byte index of the longest prefix of `input` whose visible
+            /// width is <= `max_width`. ANSI escapes count as zero-width
+            /// and are always included in the prefix. Never splits a
+            /// multi-byte UTF-8 codepoint.
+            pub fn utf8IndexAtWidth(input: []const u8, max_width: usize) usize {
+                return utf8IndexAtWidthExcludeANSI(input, max_width);
+            }
         };
     };
+
+    fn utf8IndexAtWidthExcludeANSI(input_: []const u8, max_width: usize) usize {
+        var input = input_;
+        var w: usize = 0;
+        while (strings.indexOfCharUsize(input, '\x1b')) |esc| {
+            // Walk the visible run before ESC.
+            const run_start = @intFromPtr(input.ptr) - @intFromPtr(input_.ptr);
+            if (utf8WalkRun(input_, run_start, esc, max_width, &w)) |stop| return stop;
+            input = input[esc..];
+            // Same CSI/OSC skip as visibleLatin1WidthExcludeANSIColors.
+            if (input.len < 2) return input_.len;
+            if (input[1] == '[') {
+                if (input.len < 3) return input_.len;
+                input = input[2..];
+                if (scanLaneInRange(u8, 0x40, 0x7E, input)) |t| {
+                    input = input[t + 1 ..];
+                } else return input_.len;
+            } else if (input[1] == ']') {
+                input = input[2..];
+                while (scanLaneAnyOf(u8, &.{ 0x07, 0x9c, 0x1b }, input)) |t| {
+                    const term = input[t];
+                    if (term == 0x07 or term == 0x9c) {
+                        input = input[t + 1 ..];
+                        break;
+                    }
+                    if (t + 1 < input.len and input[t + 1] == '\\') {
+                        input = input[t + 2 ..];
+                        break;
+                    }
+                    input = input[t + 1 ..];
+                } else input = input[input.len..];
+            } else {
+                input = input[1..];
+            }
+        }
+        const run_start = @intFromPtr(input.ptr) - @intFromPtr(input_.ptr);
+        if (utf8WalkRun(input_, run_start, input.len, max_width, &w)) |stop| return stop;
+        return input_.len;
+    }
+
+    /// Walk `len` bytes of `input` starting at absolute offset `start`,
+    /// accumulating visible width. Returns the absolute byte index at
+    /// which adding the next codepoint would exceed `max_width`, or null
+    /// if the whole run fits. Mirrors visibleUTF8WidthFn's decode loop.
+    fn utf8WalkRun(input: []const u8, start: usize, len: usize, max_width: usize, w: *usize) ?usize {
+        var bytes = input[start .. start + len];
+        while (firstNonASCII(bytes)) |i| {
+            // ASCII run: each printable char is width 1.
+            var k: usize = 0;
+            while (k < i) : (k += 1) {
+                const cw = visibleLatin1WidthScalar(bytes[k]);
+                if (w.* + cw > max_width) {
+                    return (@intFromPtr(bytes.ptr) - @intFromPtr(input.ptr)) + k;
+                }
+                w.* += cw;
+            }
+            const this_chunk = bytes[i..];
+            const byte = this_chunk[0];
+            const skip = bun.strings.wtf8ByteSequenceLengthWithInvalid(byte);
+            const cp_bytes: [4]u8 = switch (@min(@as(usize, skip), this_chunk.len)) {
+                inline 1, 2, 3, 4 => |cp_len| .{
+                    byte,
+                    if (comptime cp_len > 1) this_chunk[1] else 0,
+                    if (comptime cp_len > 2) this_chunk[2] else 0,
+                    if (comptime cp_len > 3) this_chunk[3] else 0,
+                },
+                else => unreachable,
+            };
+            const cp = decodeWTF8RuneTMultibyte(&cp_bytes, skip, u32, unicode_replacement);
+            const cw = visibleCodepointWidth(cp, false);
+            if (w.* + cw > max_width) {
+                return (@intFromPtr(bytes.ptr) - @intFromPtr(input.ptr)) + i;
+            }
+            w.* += cw;
+            bytes = bytes[@min(i + skip, bytes.len)..];
+        }
+        var k: usize = 0;
+        while (k < bytes.len) : (k += 1) {
+            const cw = visibleLatin1WidthScalar(bytes[k]);
+            if (w.* + cw > max_width) {
+                return (@intFromPtr(bytes.ptr) - @intFromPtr(input.ptr)) + k;
+            }
+            w.* += cw;
+        }
+        return null;
+    }
 };
 
 // extern "C" bool icu_hasBinaryProperty(UChar32 cp, unsigned int prop)

--- a/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
+++ b/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
@@ -31,9 +31,9 @@ exports[`bun <file.md> renders ordered, unordered, and task lists 1`] = `
 `;
 
 exports[`bun <file.md> renders blockquotes and nested blockquotes 1`] = `
-"\x1B[38;5;242m│ \x1B[0mA quote\x1B[0m
+"\x1B[38;5;242m│ \x1B[39mA quote\x1B[0m
 
-\x1B[38;5;242m│ │ \x1B[0mNested quote\x1B[0m
+\x1B[38;5;242m│ │ \x1B[39mNested quote\x1B[0m
 "
 `;
 
@@ -62,13 +62,13 @@ exports[`bun <file.md> renders fenced code block without language 1`] = `
 "
 `;
 
-exports[`bun <file.md> renders hyperlinks with OSC 8 escape sequence 1`] = `
-"Visit \x1B[34m\x1B[4mBun\x1B[24m\x1B[39m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m today.\x1B[0m
+exports[`bun <file.md> renders link text with url fallback when no TTY 1`] = `
+"Visit \x1B[34m\x1B[4mBun\x1B[24m\x1B[39m\x1B[34m\x1B[4m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[34m\x1B[4m today.\x1B[0m
 "
 `;
 
-exports[`bun <file.md> renders hyperlinks without OSC 8 when no TTY 1`] = `
-"see \x1B[34m\x1B[4mBun\x1B[24m\x1B[39m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[0m
+exports[`bun <file.md> renders multiple links as text + url pairs 1`] = `
+"see \x1B[34m\x1B[4mBun\x1B[24m\x1B[39m\x1B[34m\x1B[4m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[34m\x1B[4m\x1B[0m
 "
 `;
 
@@ -78,7 +78,7 @@ exports[`bun <file.md> renders images as alt text with link 1`] = `
 `;
 
 exports[`bun <file.md> renders wikilinks 1`] = `
-"\x1B[34m[[SomePage]]\x1B[39msee  for more\x1B[0m
+"see \x1B[34m[[SomePage]]\x1B[39m for more\x1B[0m
 "
 `;
 
@@ -128,7 +128,7 @@ exports[`bun <file.md> renders inline formatting inside table cells 1`] = `
 \x1B[2m│\x1B[0m \x1B[1mName \x1B[0m \x1B[2m│\x1B[0m \x1B[1mStyle                 \x1B[0m \x1B[2m│\x1B[0m
 \x1B[2m├───────┼────────────────────────┤\x1B[0m
 \x1B[2m│\x1B[0m \x1B[1mAlice\x1B[22m \x1B[2m│\x1B[0m \x1B[3meditor\x1B[23m                 \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215mbob\x1B[39m\x1B[49m   \x1B[2m│\x1B[0m \x1B[34m\x1B[4mlink\x1B[24m\x1B[39m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215mbob\x1B[39m\x1B[49m   \x1B[2m│\x1B[0m \x1B[34m\x1B[4mlink\x1B[24m\x1B[39m\x1B[34m\x1B[4m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[34m\x1B[4m \x1B[2m│\x1B[0m
 \x1B[2m└───────┴────────────────────────┘\x1B[0m
 "
 `;
@@ -145,23 +145,23 @@ exports[`bun <file.md> nested code span inside bold keeps outer bold 1`] = `
 `;
 
 exports[`bun <file.md> renders mixed inline styles with autolinks 1`] = `
-"Check \x1B[1m\x1B[34m\x1B[4mhttps://bun.com\x1B[24m\x1B[39m\x1B[1m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[1m\x1B[22m and \x1B[34m\x1B[4mme@example.com\x1B[24m\x1B[39m\x1B[2m (mailto:me@example.com\x1B[2m)\x1B[39m\x1B[22m
+"Check \x1B[1m\x1B[34m\x1B[4mhttps://bun.com\x1B[24m\x1B[39m\x1B[1m\x1B[34m\x1B[4m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[1m\x1B[34m\x1B[4m\x1B[22m and \x1B[34m\x1B[4mme@example.com\x1B[24m\x1B[39m\x1B[34m\x1B[4m\x1B[2m (mailto:me@example.com\x1B[2m)\x1B[39m\x1B[22m\x1B[34m\x1B[4m
 !\x1B[0m
 "
 `;
 
 exports[`bun <file.md> renders nested lists 1`] = `
 "  \x1B[36m• \x1B[0mouter
-    \x1B[36m• \x1B[0minner 1
-    \x1B[36m• \x1B[0minner 2
-      \x1B[36m• \x1B[0mdeep
+      \x1B[36m• \x1B[0minner 1
+      \x1B[36m• \x1B[0minner 2
+          \x1B[36m• \x1B[0mdeep
   \x1B[36m• \x1B[0msecond outer
 "
 `;
 
 exports[`bun <file.md> runs without colors when NO_COLOR is set 1`] = `
 "Hello
-═════
+=====
 
 world
 "

--- a/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
+++ b/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
@@ -1,5 +1,10 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
+exports[`bun <file.md> falls back to literal text when \`[[\` never closes 1`] = `
+"foo [[bar baz\x1B[0m
+"
+`;
+
 exports[`bun <file.md> renders headings with underlines 1`] = `
 "\x1B[1m\x1B[35mHeading 1\x1B[0m
 \x1B[2m═════════\x1B[0m

--- a/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
+++ b/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
@@ -37,7 +37,7 @@ exports[`bun <file.md> renders ordered, unordered, and task lists 1`] = `
 
 exports[`bun <file.md> renders blockquotes and nested blockquotes 1`] = `
 "\x1B[38;5;242m│ \x1B[39mA quote\x1B[0m
-
+\x1B[38;5;242m│\x1B[39m
 \x1B[38;5;242m│ │ \x1B[39mNested quote\x1B[0m
 "
 `;

--- a/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
+++ b/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
@@ -63,12 +63,12 @@ exports[`bun <file.md> renders fenced code block without language 1`] = `
 `;
 
 exports[`bun <file.md> renders link text with url fallback when no TTY 1`] = `
-"Visit \x1B[34m\x1B[4mBun\x1B[24m\x1B[39m\x1B[34m\x1B[4m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[34m\x1B[4m today.\x1B[0m
+"Visit \x1B[34m\x1B[4mBun\x1B[24m\x1B[39m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m today.\x1B[0m
 "
 `;
 
 exports[`bun <file.md> renders multiple links as text + url pairs 1`] = `
-"see \x1B[34m\x1B[4mBun\x1B[24m\x1B[39m\x1B[34m\x1B[4m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[34m\x1B[4m\x1B[0m
+"see \x1B[34m\x1B[4mBun\x1B[24m\x1B[39m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[0m
 "
 `;
 
@@ -128,7 +128,7 @@ exports[`bun <file.md> renders inline formatting inside table cells 1`] = `
 \x1B[2m│\x1B[0m \x1B[1mName \x1B[0m \x1B[2m│\x1B[0m \x1B[1mStyle                 \x1B[0m \x1B[2m│\x1B[0m
 \x1B[2m├───────┼────────────────────────┤\x1B[0m
 \x1B[2m│\x1B[0m \x1B[1mAlice\x1B[22m \x1B[2m│\x1B[0m \x1B[3meditor\x1B[23m                 \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215mbob\x1B[39m\x1B[49m   \x1B[2m│\x1B[0m \x1B[34m\x1B[4mlink\x1B[24m\x1B[39m\x1B[34m\x1B[4m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[34m\x1B[4m \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215mbob\x1B[39m\x1B[49m   \x1B[2m│\x1B[0m \x1B[34m\x1B[4mlink\x1B[24m\x1B[39m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m \x1B[2m│\x1B[0m
 \x1B[2m└───────┴────────────────────────┘\x1B[0m
 "
 `;
@@ -145,7 +145,7 @@ exports[`bun <file.md> nested code span inside bold keeps outer bold 1`] = `
 `;
 
 exports[`bun <file.md> renders mixed inline styles with autolinks 1`] = `
-"Check \x1B[1m\x1B[34m\x1B[4mhttps://bun.com\x1B[24m\x1B[39m\x1B[1m\x1B[34m\x1B[4m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[1m\x1B[34m\x1B[4m\x1B[22m and \x1B[34m\x1B[4mme@example.com\x1B[24m\x1B[39m\x1B[34m\x1B[4m\x1B[2m (mailto:me@example.com\x1B[2m)\x1B[39m\x1B[22m\x1B[34m\x1B[4m
+"Check \x1B[1m\x1B[34m\x1B[4mhttps://bun.com\x1B[24m\x1B[39m\x1B[1m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[1m\x1B[22m and \x1B[34m\x1B[4mme@example.com\x1B[24m\x1B[39m\x1B[2m (mailto:me@example.com\x1B[2m)\x1B[39m\x1B[22m
 !\x1B[0m
 "
 `;

--- a/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
+++ b/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
@@ -1,0 +1,161 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`bun <file.md> renders headings with underlines 1`] = `
+"\x1B[1m\x1B[35mHeading 1\x1B[0m
+\x1B[2m═════════\x1B[0m
+
+\x1B[1m\x1B[36mHeading 2\x1B[0m
+\x1B[2m─────────\x1B[0m
+
+\x1B[1m\x1B[33mHeading 3\x1B[0m
+
+body\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders bold, italic, strikethrough, inline code 1`] = `
+"\x1B[1mbold\x1B[22m \x1B[3mitalic\x1B[23m \x1B[9mstrike\x1B[29m \x1B[48;5;236m\x1B[38;5;215mcode\x1B[0m regular\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders ordered, unordered, and task lists 1`] = `
+"   \x1B[36m1. first
+   \x1B[36m2. second
+   \x1B[36m3. third
+  \x1B[36m• apple\x1B[0m
+  \x1B[36m• banana\x1B[0m
+  \x1B[36m• cherry\x1B[0m
+  \x1B[2m☐ \x1B[0mtodo\x1B[0m
+  \x1B[32m☒ \x1B[0mdone\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders blockquotes and nested blockquotes 1`] = `
+"\x1B[38;5;242m│ \x1B[0mA quote\x1B[0m
+
+\x1B[38;5;242m│ │ \x1B[0mNested quote\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders horizontal rules 1`] = `
+"above\x1B[0m
+
+\x1B[2m────────────────────────────────────────────────────────────\x1B[0m
+
+below\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders fenced code block with JS syntax highlighting 1`] = `
+"\x1B[2m┌─ \x1B[0m\x1B[2m\x1B[3mjs\x1B[0m
+\x1B[2m│ \x1B[0m\x1B[0m\x1B[35mconst\x1B[0m name = \x1B[0m\x1B[32m"world"\x1B[0m\x1B[0m\x1B[2m;\x1B[0m
+\x1B[2m│ \x1B[0mconsole\x1B[0m\x1B[3m\x1B[1m.log\x1B[0m(\x1B[0m\x1B[32m\`hello \x1B[0m\${name}\x1B[0m\x1B[32m\`\x1B[0m)\x1B[0m\x1B[2m;\x1B[0m
+\x1B[2m└─\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders fenced code block without language 1`] = `
+"\x1B[2m\x1B[2m┌─\x1B[0m
+\x1B[2m│ \x1B[0mplain text
+\x1B[2m│ \x1B[0mno highlighting
+\x1B[2m└─\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders hyperlinks with OSC 8 escape sequence 1`] = `
+"Visit \x1B[34m\x1B[4mBun\x1B[24m\x1B[0m\x1B[2m (https://bun.com\x1B[2m)\x1B[0m today.\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders hyperlinks without OSC 8 when no TTY 1`] = `
+"see \x1B[34m\x1B[4mBun\x1B[24m\x1B[0m\x1B[2m (https://bun.com\x1B[2m)\x1B[0m\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders images as alt text with link 1`] = `
+"\x1B[35m🖼 an image\x1B[0m\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders wikilinks 1`] = `
+"\x1B[34m[[SomePage]]\x1B[0msee  for more\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders simple table with alignment 1`] = `
+"\x1B[2m┌───────┬─────┬──────┐\x1B[0m
+\x1B[2m│\x1B[0m \x1B[1mName \x1B[0m \x1B[2m│\x1B[0m \x1B[1mAge\x1B[0m \x1B[2m│\x1B[0m \x1B[1mCity\x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m├───────┼─────┼──────┤\x1B[0m
+\x1B[2m│\x1B[0m Alice \x1B[2m│\x1B[0m 30  \x1B[2m│\x1B[0m  NYC \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m Bob   \x1B[2m│\x1B[0m 25  \x1B[2m│\x1B[0m   LA \x1B[2m│\x1B[0m
+\x1B[2m└───────┴─────┴──────┘\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders table with CJK multi-width graphemes 1`] = `
+"\x1B[2m┌───────┬─────────┬──────┐\x1B[0m
+\x1B[2m│\x1B[0m \x1B[1m名前 \x1B[0m \x1B[2m│\x1B[0m \x1B[1m 言語  \x1B[0m \x1B[2m│\x1B[0m \x1B[1m都市\x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m├───────┼─────────┼──────┤\x1B[0m
+\x1B[2m│\x1B[0m 山田  \x1B[2m│\x1B[0m 日本語  \x1B[2m│\x1B[0m 東京 \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m Alice \x1B[2m│\x1B[0m English \x1B[2m│\x1B[0m  NYC \x1B[2m│\x1B[0m
+\x1B[2m└───────┴─────────┴──────┘\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders table with emoji graphemes 1`] = `
+"\x1B[2m┌────────┬────────┐\x1B[0m
+\x1B[2m│\x1B[0m \x1B[1mStatus\x1B[0m \x1B[2m│\x1B[0m \x1B[1mLabel \x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m├────────┼────────┤\x1B[0m
+\x1B[2m│\x1B[0m   ✅   \x1B[2m│\x1B[0m pass   \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m   ❌   \x1B[2m│\x1B[0m fail   \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m   🚀   \x1B[2m│\x1B[0m launch \x1B[2m│\x1B[0m
+\x1B[2m└────────┴────────┘\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders combining characters without breaking alignment 1`] = `
+"\x1B[2m┌───────┬──────┐\x1B[0m
+\x1B[2m│\x1B[0m \x1B[1mName \x1B[0m \x1B[2m│\x1B[0m \x1B[1mNote\x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m├───────┼──────┤\x1B[0m
+\x1B[2m│\x1B[0m café  \x1B[2m│\x1B[0m hot  \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m naïve \x1B[2m│\x1B[0m ok   \x1B[2m│\x1B[0m
+\x1B[2m└───────┴──────┘\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders mixed inline styles with autolinks 1`] = `
+"Check \x1B[1m\x1B[34m\x1B[4mhttps://bun.com\x1B[24m\x1B[0m\x1B[2m (https://bun.com\x1B[2m)\x1B[0m\x1B[22m and \x1B[34m\x1B[4mme@example.com\x1B[24m\x1B[0m\x1B[2m (mailto:me@example.com\x1B[2m)\x1B[0m
+!\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders nested lists 1`] = `
+"  \x1B[36m• outer
+    \x1B[36m• inner 1
+    \x1B[36m• inner 2
+      \x1B[36m• deep
+  \x1B[36m• second outer
+"
+`;
+
+exports[`bun <file.md> runs without colors when NO_COLOR is set 1`] = `
+"Hello
+═════
+
+world
+"
+`;
+
+exports[`bun <file.md> renders via \`bun run ./file.md\` 1`] = `
+"\x1B[1m\x1B[35mTitle\x1B[0m
+\x1B[2m═════\x1B[0m
+
+body\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders .markdown extension too 1`] = `
+"\x1B[1m\x1B[35myep\x1B[0m
+\x1B[2m═══\x1B[0m
+"
+`;

--- a/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
+++ b/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
@@ -134,7 +134,7 @@ exports[`bun <file.md> renders inline formatting inside table cells 1`] = `
 `;
 
 exports[`bun <file.md> renders inline formatting inside headings 1`] = `
-"\x1B[1m\x1B[35mHello \x1B[1mbold\x1B[22m and \x1B[3mitalic\x1B[23m heading\x1B[0m
+"\x1B[1m\x1B[35mHello \x1B[1mbold\x1B[22m\x1B[1m\x1B[35m and \x1B[3mitalic\x1B[23m\x1B[1m\x1B[35m heading\x1B[0m
 \x1B[2m═════════════════════════════\x1B[0m
 "
 `;

--- a/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
+++ b/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
@@ -1,10 +1,5 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`bun <file.md> falls back to literal text when \`[[\` never closes 1`] = `
-"foo [[bar baz\x1B[0m
-"
-`;
-
 exports[`bun <file.md> renders headings with underlines 1`] = `
 "\x1B[1m\x1B[35mHeading 1\x1B[0m
 \x1B[2m═════════\x1B[0m
@@ -87,53 +82,58 @@ exports[`bun <file.md> renders wikilinks 1`] = `
 "
 `;
 
+exports[`bun <file.md> falls back to literal text when \`[[\` never closes 1`] = `
+"foo [[bar baz\x1B[0m
+"
+`;
+
 exports[`bun <file.md> renders simple table with alignment 1`] = `
 "\x1B[2m┌───────┬─────┬──────┐\x1B[0m
-\x1B[2m│\x1B[0m \x1B[1mName \x1B[0m \x1B[2m│\x1B[0m \x1B[1mAge\x1B[0m \x1B[2m│\x1B[0m \x1B[1mCity\x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[1mName\x1B[0m  \x1B[2m│\x1B[0m \x1B[1mAge\x1B[0m \x1B[2m│\x1B[0m \x1B[1mCity\x1B[0m \x1B[2m│\x1B[0m
 \x1B[2m├───────┼─────┼──────┤\x1B[0m
-\x1B[2m│\x1B[0m Alice \x1B[2m│\x1B[0m 30  \x1B[2m│\x1B[0m  NYC \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m Bob   \x1B[2m│\x1B[0m 25  \x1B[2m│\x1B[0m   LA \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m Alice\x1B[0m \x1B[2m│\x1B[0m 30\x1B[0m  \x1B[2m│\x1B[0m  NYC\x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m Bob\x1B[0m   \x1B[2m│\x1B[0m 25\x1B[0m  \x1B[2m│\x1B[0m   LA\x1B[0m \x1B[2m│\x1B[0m
 \x1B[2m└───────┴─────┴──────┘\x1B[0m
 "
 `;
 
 exports[`bun <file.md> renders table with CJK multi-width graphemes 1`] = `
 "\x1B[2m┌───────┬─────────┬──────┐\x1B[0m
-\x1B[2m│\x1B[0m \x1B[1m名前 \x1B[0m \x1B[2m│\x1B[0m \x1B[1m 言語  \x1B[0m \x1B[2m│\x1B[0m \x1B[1m都市\x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[1m名前\x1B[0m  \x1B[2m│\x1B[0m \x1B[1m 言語\x1B[0m   \x1B[2m│\x1B[0m \x1B[1m都市\x1B[0m \x1B[2m│\x1B[0m
 \x1B[2m├───────┼─────────┼──────┤\x1B[0m
-\x1B[2m│\x1B[0m 山田  \x1B[2m│\x1B[0m 日本語  \x1B[2m│\x1B[0m 東京 \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m Alice \x1B[2m│\x1B[0m English \x1B[2m│\x1B[0m  NYC \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m 山田\x1B[0m  \x1B[2m│\x1B[0m 日本語\x1B[0m  \x1B[2m│\x1B[0m 東京\x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m Alice\x1B[0m \x1B[2m│\x1B[0m English\x1B[0m \x1B[2m│\x1B[0m  NYC\x1B[0m \x1B[2m│\x1B[0m
 \x1B[2m└───────┴─────────┴──────┘\x1B[0m
 "
 `;
 
 exports[`bun <file.md> renders table with emoji graphemes 1`] = `
 "\x1B[2m┌────────┬────────┐\x1B[0m
-\x1B[2m│\x1B[0m \x1B[1mStatus\x1B[0m \x1B[2m│\x1B[0m \x1B[1mLabel \x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[1mStatus\x1B[0m \x1B[2m│\x1B[0m \x1B[1mLabel\x1B[0m  \x1B[2m│\x1B[0m
 \x1B[2m├────────┼────────┤\x1B[0m
-\x1B[2m│\x1B[0m   ✅   \x1B[2m│\x1B[0m pass   \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m   ❌   \x1B[2m│\x1B[0m fail   \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m   🚀   \x1B[2m│\x1B[0m launch \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m   ✅\x1B[0m   \x1B[2m│\x1B[0m pass\x1B[0m   \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m   ❌\x1B[0m   \x1B[2m│\x1B[0m fail\x1B[0m   \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m   🚀\x1B[0m   \x1B[2m│\x1B[0m launch\x1B[0m \x1B[2m│\x1B[0m
 \x1B[2m└────────┴────────┘\x1B[0m
 "
 `;
 
 exports[`bun <file.md> renders combining characters without breaking alignment 1`] = `
 "\x1B[2m┌───────┬──────┐\x1B[0m
-\x1B[2m│\x1B[0m \x1B[1mName \x1B[0m \x1B[2m│\x1B[0m \x1B[1mNote\x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[1mName\x1B[0m  \x1B[2m│\x1B[0m \x1B[1mNote\x1B[0m \x1B[2m│\x1B[0m
 \x1B[2m├───────┼──────┤\x1B[0m
-\x1B[2m│\x1B[0m café  \x1B[2m│\x1B[0m hot  \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m naïve \x1B[2m│\x1B[0m ok   \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m café\x1B[0m  \x1B[2m│\x1B[0m hot\x1B[0m  \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m naïve\x1B[0m \x1B[2m│\x1B[0m ok\x1B[0m   \x1B[2m│\x1B[0m
 \x1B[2m└───────┴──────┘\x1B[0m
 "
 `;
 
 exports[`bun <file.md> renders inline formatting inside table cells 1`] = `
 "\x1B[2m┌───────┬────────────────────────┐\x1B[0m
-\x1B[2m│\x1B[0m \x1B[1mName \x1B[0m \x1B[2m│\x1B[0m \x1B[1mStyle                 \x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[1mName\x1B[0m  \x1B[2m│\x1B[0m \x1B[1mStyle\x1B[0m                  \x1B[2m│\x1B[0m
 \x1B[2m├───────┼────────────────────────┤\x1B[0m
-\x1B[2m│\x1B[0m \x1B[1mAlice\x1B[22m \x1B[2m│\x1B[0m \x1B[3meditor\x1B[23m                 \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215mbob\x1B[39m\x1B[49m   \x1B[2m│\x1B[0m \x1B[34m\x1B[4mlink\x1B[24m\x1B[39m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[1mAlice\x1B[22m\x1B[0m \x1B[2m│\x1B[0m \x1B[3meditor\x1B[23m\x1B[0m                 \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215mbob\x1B[39m\x1B[49m\x1B[0m   \x1B[2m│\x1B[0m \x1B[34m\x1B[4mlink\x1B[24m\x1B[39m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[0m \x1B[2m│\x1B[0m
 \x1B[2m└───────┴────────────────────────┘\x1B[0m
 "
 `;
@@ -150,8 +150,8 @@ exports[`bun <file.md> nested code span inside bold keeps outer bold 1`] = `
 `;
 
 exports[`bun <file.md> renders mixed inline styles with autolinks 1`] = `
-"Check \x1B[1m\x1B[34m\x1B[4mhttps://bun.com\x1B[24m\x1B[39m\x1B[1m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[1m\x1B[22m and \x1B[34m\x1B[4mme@example.com\x1B[24m\x1B[39m\x1B[2m (mailto:me@example.com\x1B[2m)\x1B[39m\x1B[22m
-!\x1B[0m
+"Check \x1B[1m\x1B[34m\x1B[4mhttps://bun.com\x1B[24m\x1B[39m\x1B[1m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[1m\x1B[22m and \x1B[34m\x1B[4mme@example.com\x1B[24m\x1B[39m\x1B[2m (
+mailto:me@example.com\x1B[2m)\x1B[39m\x1B[22m!\x1B[0m
 "
 `;
 
@@ -183,5 +183,34 @@ body\x1B[0m
 exports[`bun <file.md> renders .markdown extension too 1`] = `
 "\x1B[1m\x1B[35myep\x1B[0m
 \x1B[2m═══\x1B[0m
+"
+`;
+
+exports[`bun <file.md> wraps inline code spans within COLUMNS, never mid-word 1`] = `
+"After modifying \x1B[48;5;236m\x1B[38;5;215mcoreBeeps.ts\x1B[39m\x1B[49m, \x1B[48;5;236m\x1B[38;5;215mcontrolBoops.ts\x1B[39m\x1B[49m
+, or \x1B[48;5;236m\x1B[38;5;215mtoolBoops.ts\x1B[39m\x1B[49m, run \x1B[48;5;236m\x1B[38;5;215mbun run build:boop\x1B[39m\x1B[49m to
+regenerate. \x1B[1mDo not edit \x1B[48;5;236m\x1B[38;5;215m*.generated.ts\x1B[39m\x1B[49m\x1B[1m files
+directly.\x1B[22m\x1B[0m
+"
+`;
+
+exports[`bun <file.md> hard-breaks an overlong CJK word at the visible-width boundary 1`] = `
+"A 测试测试测试测试测试测试测试
+测试测试测试 wide.\x1B[0m
+"
+`;
+
+exports[`bun <file.md> shrinks table columns to fit COLUMNS and wraps cell content 1`] = `
+"\x1B[2m┌───────────────────────┬────────────────────────┐\x1B[0m
+\x1B[2m│\x1B[0m \x1B[1mPath\x1B[0m                  \x1B[2m│\x1B[0m \x1B[1mScope\x1B[0m                  \x1B[2m│\x1B[0m
+\x1B[2m├───────────────────────┼────────────────────────┤\x1B[0m
+\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215msrc/CLAUDE.md\x1B[39m\x1B[49m\x1B[0m         \x1B[2m│\x1B[0m Source architecture:\x1B[0m   \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[0m                      \x1B[2m│\x1B[0m module map, startup\x1B[0m    \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[0m                      \x1B[2m│\x1B[0m flow, state management\x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215msrc/components/design\x1B[0m \x1B[2m│\x1B[0m Design system\x1B[0m          \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m -system/CLAUDE.md\x1B[39m\x1B[49m\x1B[0m     \x1B[2m│\x1B[0m component API\x1B[0m          \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[0m                      \x1B[2m│\x1B[0m (Dialog, Tabs,\x1B[0m         \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[0m                      \x1B[2m│\x1B[0m StatusIcon, etc.)\x1B[0m      \x1B[2m│\x1B[0m
+\x1B[2m└───────────────────────┴────────────────────────┘\x1B[0m
 "
 `;

--- a/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
+++ b/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
@@ -14,17 +14,17 @@ body\x1B[0m
 `;
 
 exports[`bun <file.md> renders bold, italic, strikethrough, inline code 1`] = `
-"\x1B[1mbold\x1B[22m \x1B[3mitalic\x1B[23m \x1B[9mstrike\x1B[29m \x1B[48;5;236m\x1B[38;5;215mcode\x1B[0m regular\x1B[0m
+"\x1B[1mbold\x1B[22m \x1B[3mitalic\x1B[23m \x1B[9mstrike\x1B[29m \x1B[48;5;236m\x1B[38;5;215mcode\x1B[39m\x1B[49m regular\x1B[0m
 "
 `;
 
 exports[`bun <file.md> renders ordered, unordered, and task lists 1`] = `
-"   \x1B[36m1. first
-   \x1B[36m2. second
-   \x1B[36m3. third
-  \x1B[36m• apple\x1B[0m
-  \x1B[36m• banana\x1B[0m
-  \x1B[36m• cherry\x1B[0m
+"   \x1B[36m1. \x1B[0mfirst
+   \x1B[36m2. \x1B[0msecond
+   \x1B[36m3. \x1B[0mthird
+  \x1B[36m• \x1B[0mapple\x1B[0m
+  \x1B[36m• \x1B[0mbanana\x1B[0m
+  \x1B[36m• \x1B[0mcherry\x1B[0m
   \x1B[2m☐ \x1B[0mtodo\x1B[0m
   \x1B[32m☒ \x1B[0mdone\x1B[0m
 "
@@ -63,12 +63,12 @@ exports[`bun <file.md> renders fenced code block without language 1`] = `
 `;
 
 exports[`bun <file.md> renders hyperlinks with OSC 8 escape sequence 1`] = `
-"Visit \x1B[34m\x1B[4mBun\x1B[24m\x1B[0m\x1B[2m (https://bun.com\x1B[2m)\x1B[0m today.\x1B[0m
+"Visit \x1B[34m\x1B[4mBun\x1B[24m\x1B[39m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m today.\x1B[0m
 "
 `;
 
 exports[`bun <file.md> renders hyperlinks without OSC 8 when no TTY 1`] = `
-"see \x1B[34m\x1B[4mBun\x1B[24m\x1B[0m\x1B[2m (https://bun.com\x1B[2m)\x1B[0m\x1B[0m
+"see \x1B[34m\x1B[4mBun\x1B[24m\x1B[39m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[0m
 "
 `;
 
@@ -78,7 +78,7 @@ exports[`bun <file.md> renders images as alt text with link 1`] = `
 `;
 
 exports[`bun <file.md> renders wikilinks 1`] = `
-"\x1B[34m[[SomePage]]\x1B[0msee  for more\x1B[0m
+"\x1B[34m[[SomePage]]\x1B[39msee  for more\x1B[0m
 "
 `;
 
@@ -117,24 +117,45 @@ exports[`bun <file.md> renders combining characters without breaking alignment 1
 "\x1B[2m┌───────┬──────┐\x1B[0m
 \x1B[2m│\x1B[0m \x1B[1mName \x1B[0m \x1B[2m│\x1B[0m \x1B[1mNote\x1B[0m \x1B[2m│\x1B[0m
 \x1B[2m├───────┼──────┤\x1B[0m
-\x1B[2m│\x1B[0m café  \x1B[2m│\x1B[0m hot  \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m naïve \x1B[2m│\x1B[0m ok   \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m café  \x1B[2m│\x1B[0m hot  \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m naïve \x1B[2m│\x1B[0m ok   \x1B[2m│\x1B[0m
 \x1B[2m└───────┴──────┘\x1B[0m
 "
 `;
 
+exports[`bun <file.md> renders inline formatting inside table cells 1`] = `
+"\x1B[2m┌───────┬────────────────────────┐\x1B[0m
+\x1B[2m│\x1B[0m \x1B[1mName \x1B[0m \x1B[2m│\x1B[0m \x1B[1mStyle                 \x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m├───────┼────────────────────────┤\x1B[0m
+\x1B[2m│\x1B[0m \x1B[1mAlice\x1B[22m \x1B[2m│\x1B[0m \x1B[3meditor\x1B[23m                 \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215mbob\x1B[39m\x1B[49m   \x1B[2m│\x1B[0m \x1B[34m\x1B[4mlink\x1B[24m\x1B[39m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m \x1B[2m│\x1B[0m
+\x1B[2m└───────┴────────────────────────┘\x1B[0m
+"
+`;
+
+exports[`bun <file.md> renders inline formatting inside headings 1`] = `
+"\x1B[1m\x1B[35mHello \x1B[1mbold\x1B[22m and \x1B[3mitalic\x1B[23m heading\x1B[0m
+\x1B[2m═════════════════════════════\x1B[0m
+"
+`;
+
+exports[`bun <file.md> nested code span inside bold keeps outer bold 1`] = `
+"\x1B[1mbefore \x1B[48;5;236m\x1B[38;5;215mcode\x1B[39m\x1B[49m\x1B[1m after\x1B[22m tail\x1B[0m
+"
+`;
+
 exports[`bun <file.md> renders mixed inline styles with autolinks 1`] = `
-"Check \x1B[1m\x1B[34m\x1B[4mhttps://bun.com\x1B[24m\x1B[0m\x1B[2m (https://bun.com\x1B[2m)\x1B[0m\x1B[22m and \x1B[34m\x1B[4mme@example.com\x1B[24m\x1B[0m\x1B[2m (mailto:me@example.com\x1B[2m)\x1B[0m
+"Check \x1B[1m\x1B[34m\x1B[4mhttps://bun.com\x1B[24m\x1B[39m\x1B[1m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[1m\x1B[22m and \x1B[34m\x1B[4mme@example.com\x1B[24m\x1B[39m\x1B[2m (mailto:me@example.com\x1B[2m)\x1B[39m\x1B[22m
 !\x1B[0m
 "
 `;
 
 exports[`bun <file.md> renders nested lists 1`] = `
-"  \x1B[36m• outer
-    \x1B[36m• inner 1
-    \x1B[36m• inner 2
-      \x1B[36m• deep
-  \x1B[36m• second outer
+"  \x1B[36m• \x1B[0mouter
+    \x1B[36m• \x1B[0minner 1
+    \x1B[36m• \x1B[0minner 2
+      \x1B[36m• \x1B[0mdeep
+  \x1B[36m• \x1B[0msecond outer
 "
 `;
 

--- a/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
+++ b/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
@@ -72,7 +72,7 @@ exports[`bun <file.md> renders link text with url fallback when no TTY 1`] = `
 "
 `;
 
-exports[`bun <file.md> renders multiple links as text + url pairs 1`] = `
+exports[`bun <file.md> renders link with text + url pair fallback 1`] = `
 "see \x1B[34m\x1B[4mBun\x1B[24m\x1B[39m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[0m
 "
 `;

--- a/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
+++ b/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
@@ -204,11 +204,12 @@ exports[`bun <file.md> shrinks table columns to fit COLUMNS and wraps cell conte
 "\x1B[2m┌───────────────────────┬────────────────────────┐\x1B[0m
 \x1B[2m│\x1B[0m \x1B[1mPath\x1B[0m                  \x1B[2m│\x1B[0m \x1B[1mScope\x1B[0m                  \x1B[2m│\x1B[0m
 \x1B[2m├───────────────────────┼────────────────────────┤\x1B[0m
-\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215msrc/CLAUDE.md\x1B[39m\x1B[49m\x1B[0m         \x1B[2m│\x1B[0m Source architecture:\x1B[0m   \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m \x1B[0m                      \x1B[2m│\x1B[0m module map, startup\x1B[0m    \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m \x1B[0m                      \x1B[2m│\x1B[0m flow, state management\x1B[0m \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215msrc/components/design\x1B[0m \x1B[2m│\x1B[0m Design system\x1B[0m          \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m -system/CLAUDE.md\x1B[39m\x1B[49m\x1B[0m     \x1B[2m│\x1B[0m component API\x1B[0m          \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215mdocs/guide.md\x1B[39m\x1B[49m\x1B[0m         \x1B[2m│\x1B[0m Top-level\x1B[0m              \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[0m                      \x1B[2m│\x1B[0m architecture: module\x1B[0m   \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[0m                      \x1B[2m│\x1B[0m map, startup flow,\x1B[0m     \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[0m                      \x1B[2m│\x1B[0m state management\x1B[0m       \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215mdocs/components/desig\x1B[0m \x1B[2m│\x1B[0m Design system\x1B[0m          \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m n-system/guide.md\x1B[39m\x1B[49m\x1B[0m     \x1B[2m│\x1B[0m component API\x1B[0m          \x1B[2m│\x1B[0m
 \x1B[2m│\x1B[0m \x1B[0m                      \x1B[2m│\x1B[0m (Dialog, Tabs,\x1B[0m         \x1B[2m│\x1B[0m
 \x1B[2m│\x1B[0m \x1B[0m                      \x1B[2m│\x1B[0m StatusIcon, etc.)\x1B[0m      \x1B[2m│\x1B[0m
 \x1B[2m└───────────────────────┴────────────────────────┘\x1B[0m

--- a/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
+++ b/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
@@ -78,7 +78,7 @@ exports[`bun <file.md> renders multiple links as text + url pairs 1`] = `
 `;
 
 exports[`bun <file.md> renders images as alt text with link 1`] = `
-"\x1B[35m🖼 an image\x1B[0m\x1B[0m
+"\x1B[35m📷 an image\x1B[0m\x1B[0m
 "
 `;
 

--- a/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
+++ b/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
@@ -91,8 +91,8 @@ exports[`bun <file.md> renders simple table with alignment 1`] = `
 "\x1B[2m┌───────┬─────┬──────┐\x1B[0m
 \x1B[2m│\x1B[0m \x1B[1mName\x1B[0m  \x1B[2m│\x1B[0m \x1B[1mAge\x1B[0m \x1B[2m│\x1B[0m \x1B[1mCity\x1B[0m \x1B[2m│\x1B[0m
 \x1B[2m├───────┼─────┼──────┤\x1B[0m
-\x1B[2m│\x1B[0m Alice\x1B[0m \x1B[2m│\x1B[0m 30\x1B[0m  \x1B[2m│\x1B[0m  NYC\x1B[0m \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m Bob\x1B[0m   \x1B[2m│\x1B[0m 25\x1B[0m  \x1B[2m│\x1B[0m   LA\x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m Alice \x1B[2m│\x1B[0m 30  \x1B[2m│\x1B[0m  NYC \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m Bob   \x1B[2m│\x1B[0m 25  \x1B[2m│\x1B[0m   LA \x1B[2m│\x1B[0m
 \x1B[2m└───────┴─────┴──────┘\x1B[0m
 "
 `;
@@ -101,8 +101,8 @@ exports[`bun <file.md> renders table with CJK multi-width graphemes 1`] = `
 "\x1B[2m┌───────┬─────────┬──────┐\x1B[0m
 \x1B[2m│\x1B[0m \x1B[1m名前\x1B[0m  \x1B[2m│\x1B[0m \x1B[1m 言語\x1B[0m   \x1B[2m│\x1B[0m \x1B[1m都市\x1B[0m \x1B[2m│\x1B[0m
 \x1B[2m├───────┼─────────┼──────┤\x1B[0m
-\x1B[2m│\x1B[0m 山田\x1B[0m  \x1B[2m│\x1B[0m 日本語\x1B[0m  \x1B[2m│\x1B[0m 東京\x1B[0m \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m Alice\x1B[0m \x1B[2m│\x1B[0m English\x1B[0m \x1B[2m│\x1B[0m  NYC\x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m 山田  \x1B[2m│\x1B[0m 日本語  \x1B[2m│\x1B[0m 東京 \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m Alice \x1B[2m│\x1B[0m English \x1B[2m│\x1B[0m  NYC \x1B[2m│\x1B[0m
 \x1B[2m└───────┴─────────┴──────┘\x1B[0m
 "
 `;
@@ -111,9 +111,9 @@ exports[`bun <file.md> renders table with emoji graphemes 1`] = `
 "\x1B[2m┌────────┬────────┐\x1B[0m
 \x1B[2m│\x1B[0m \x1B[1mStatus\x1B[0m \x1B[2m│\x1B[0m \x1B[1mLabel\x1B[0m  \x1B[2m│\x1B[0m
 \x1B[2m├────────┼────────┤\x1B[0m
-\x1B[2m│\x1B[0m   ✅\x1B[0m   \x1B[2m│\x1B[0m pass\x1B[0m   \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m   ❌\x1B[0m   \x1B[2m│\x1B[0m fail\x1B[0m   \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m   🚀\x1B[0m   \x1B[2m│\x1B[0m launch\x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m   ✅   \x1B[2m│\x1B[0m pass   \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m   ❌   \x1B[2m│\x1B[0m fail   \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m   🚀   \x1B[2m│\x1B[0m launch \x1B[2m│\x1B[0m
 \x1B[2m└────────┴────────┘\x1B[0m
 "
 `;
@@ -122,8 +122,8 @@ exports[`bun <file.md> renders combining characters without breaking alignment 1
 "\x1B[2m┌───────┬──────┐\x1B[0m
 \x1B[2m│\x1B[0m \x1B[1mName\x1B[0m  \x1B[2m│\x1B[0m \x1B[1mNote\x1B[0m \x1B[2m│\x1B[0m
 \x1B[2m├───────┼──────┤\x1B[0m
-\x1B[2m│\x1B[0m café\x1B[0m  \x1B[2m│\x1B[0m hot\x1B[0m  \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m naïve\x1B[0m \x1B[2m│\x1B[0m ok\x1B[0m   \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m café  \x1B[2m│\x1B[0m hot  \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m naïve \x1B[2m│\x1B[0m ok   \x1B[2m│\x1B[0m
 \x1B[2m└───────┴──────┘\x1B[0m
 "
 `;
@@ -132,8 +132,8 @@ exports[`bun <file.md> renders inline formatting inside table cells 1`] = `
 "\x1B[2m┌───────┬────────────────────────┐\x1B[0m
 \x1B[2m│\x1B[0m \x1B[1mName\x1B[0m  \x1B[2m│\x1B[0m \x1B[1mStyle\x1B[0m                  \x1B[2m│\x1B[0m
 \x1B[2m├───────┼────────────────────────┤\x1B[0m
-\x1B[2m│\x1B[0m \x1B[1mAlice\x1B[22m\x1B[0m \x1B[2m│\x1B[0m \x1B[3meditor\x1B[23m\x1B[0m                 \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215mbob\x1B[39m\x1B[49m\x1B[0m   \x1B[2m│\x1B[0m \x1B[34m\x1B[4mlink\x1B[24m\x1B[39m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m\x1B[0m \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[1mAlice\x1B[22m \x1B[2m│\x1B[0m \x1B[3meditor\x1B[23m                 \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215mbob\x1B[39m\x1B[49m   \x1B[2m│\x1B[0m \x1B[34m\x1B[4mlink\x1B[24m\x1B[39m\x1B[2m (https://bun.com\x1B[2m)\x1B[39m\x1B[22m \x1B[2m│\x1B[0m
 \x1B[2m└───────┴────────────────────────┘\x1B[0m
 "
 `;
@@ -204,14 +204,14 @@ exports[`bun <file.md> shrinks table columns to fit COLUMNS and wraps cell conte
 "\x1B[2m┌───────────────────────┬────────────────────────┐\x1B[0m
 \x1B[2m│\x1B[0m \x1B[1mPath\x1B[0m                  \x1B[2m│\x1B[0m \x1B[1mScope\x1B[0m                  \x1B[2m│\x1B[0m
 \x1B[2m├───────────────────────┼────────────────────────┤\x1B[0m
-\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215mdocs/guide.md\x1B[39m\x1B[49m\x1B[0m         \x1B[2m│\x1B[0m Top-level\x1B[0m              \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m \x1B[0m                      \x1B[2m│\x1B[0m architecture: module\x1B[0m   \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m \x1B[0m                      \x1B[2m│\x1B[0m map, startup flow,\x1B[0m     \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m \x1B[0m                      \x1B[2m│\x1B[0m state management\x1B[0m       \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215mdocs/components/desig\x1B[0m \x1B[2m│\x1B[0m Design system\x1B[0m          \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m n-system/guide.md\x1B[39m\x1B[49m\x1B[0m     \x1B[2m│\x1B[0m component API\x1B[0m          \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m \x1B[0m                      \x1B[2m│\x1B[0m (Dialog, Tabs,\x1B[0m         \x1B[2m│\x1B[0m
-\x1B[2m│\x1B[0m \x1B[0m                      \x1B[2m│\x1B[0m StatusIcon, etc.)\x1B[0m      \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215mdocs/guide.md\x1B[39m\x1B[49m         \x1B[2m│\x1B[0m Top-level              \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m                       \x1B[2m│\x1B[0m architecture: module   \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m                       \x1B[2m│\x1B[0m map, startup flow,     \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m                       \x1B[2m│\x1B[0m state management       \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[48;5;236m\x1B[38;5;215mdocs/components/desig\x1B[0m \x1B[2m│\x1B[0m Design system          \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m \x1B[38;5;215m\x1B[48;5;236mn-system/guide.md\x1B[39m\x1B[49m     \x1B[2m│\x1B[0m component API          \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m                       \x1B[2m│\x1B[0m (Dialog, Tabs,         \x1B[2m│\x1B[0m
+\x1B[2m│\x1B[0m                       \x1B[2m│\x1B[0m StatusIcon, etc.)      \x1B[2m│\x1B[0m
 \x1B[2m└───────────────────────┴────────────────────────┘\x1B[0m
 "
 `;

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -142,13 +142,7 @@ describe("bun <file.md>", () => {
     // Decomposed NFD: 'e' + U+0301 combining acute, 'i' + U+0308 combining diaeresis.
     // These must be zero-width in the grapheme counter for the table to line up.
     const stdout = await runMd(
-      [
-        "| Name   | Note |",
-        "|:-------|:-----|",
-        "| cafe\u0301   | hot  |",
-        "| nai\u0308ve  | ok   |",
-        "",
-      ].join("\n"),
+      ["| Name   | Note |", "|:-------|:-----|", "| cafe\u0301   | hot  |", "| nai\u0308ve  | ok   |", ""].join("\n"),
     );
     expect(stdout).toMatchSnapshot();
     expect(lastExitCode).toBe(0);

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -10,11 +10,7 @@ async function runMd(source: string, env: Record<string, string> = {}) {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
   return stdout;
@@ -23,27 +19,12 @@ async function runMd(source: string, env: Record<string, string> = {}) {
 describe("bun <file.md>", () => {
   test("renders headings with underlines", async () => {
     expect(
-      await runMd(
-        [
-          "# Heading 1",
-          "",
-          "## Heading 2",
-          "",
-          "### Heading 3",
-          "",
-          "body",
-          "",
-        ].join("\n"),
-      ),
+      await runMd(["# Heading 1", "", "## Heading 2", "", "### Heading 3", "", "body", ""].join("\n")),
     ).toMatchSnapshot();
   });
 
   test("renders bold, italic, strikethrough, inline code", async () => {
-    expect(
-      await runMd(
-        "**bold** *italic* ~~strike~~ `code` regular\n",
-      ),
-    ).toMatchSnapshot();
+    expect(await runMd("**bold** *italic* ~~strike~~ `code` regular\n")).toMatchSnapshot();
   });
 
   test("renders ordered, unordered, and task lists", async () => {
@@ -67,93 +48,39 @@ describe("bun <file.md>", () => {
   });
 
   test("renders blockquotes and nested blockquotes", async () => {
-    expect(
-      await runMd(
-        [
-          "> A quote",
-          ">",
-          "> > Nested quote",
-          "",
-        ].join("\n"),
-      ),
-    ).toMatchSnapshot();
+    expect(await runMd(["> A quote", ">", "> > Nested quote", ""].join("\n"))).toMatchSnapshot();
   });
 
   test("renders horizontal rules", async () => {
-    expect(
-      await runMd(
-        [
-          "above",
-          "",
-          "---",
-          "",
-          "below",
-          "",
-        ].join("\n"),
-      ),
-    ).toMatchSnapshot();
+    expect(await runMd(["above", "", "---", "", "below", ""].join("\n"))).toMatchSnapshot();
   });
 
   test("renders fenced code block with JS syntax highlighting", async () => {
     expect(
-      await runMd(
-        [
-          "```js",
-          'const name = "world";',
-          "console.log(`hello ${name}`);",
-          "```",
-          "",
-        ].join("\n"),
-      ),
+      await runMd(["```js", 'const name = "world";', "console.log(`hello ${name}`);", "```", ""].join("\n")),
     ).toMatchSnapshot();
   });
 
   test("renders fenced code block without language", async () => {
-    expect(
-      await runMd(
-        [
-          "```",
-          "plain text",
-          "no highlighting",
-          "```",
-          "",
-        ].join("\n"),
-      ),
-    ).toMatchSnapshot();
+    expect(await runMd(["```", "plain text", "no highlighting", "```", ""].join("\n"))).toMatchSnapshot();
   });
 
   test("renders hyperlinks with OSC 8 escape sequence", async () => {
-    expect(
-      await runMd(
-        "Visit [Bun](https://bun.com) today.\n",
-      ),
-    ).toMatchSnapshot();
+    expect(await runMd("Visit [Bun](https://bun.com) today.\n")).toMatchSnapshot();
   });
 
   test("renders hyperlinks without OSC 8 when no TTY", async () => {
     // The spawned process doesn't have a TTY on stdout so hyperlinks fall
     // back to "text (url)" format. This is the default for runMd().
-    expect(
-      await runMd(
-        "see [Bun](https://bun.com)\n",
-      ),
-    ).toMatchSnapshot();
+    expect(await runMd("see [Bun](https://bun.com)\n")).toMatchSnapshot();
   });
 
   test("renders images as alt text with link", async () => {
-    expect(
-      await runMd(
-        "![an image](https://bun.com/logo.png)\n",
-      ),
-    ).toMatchSnapshot();
+    expect(await runMd("![an image](https://bun.com/logo.png)\n")).toMatchSnapshot();
   });
 
   test("renders wikilinks", async () => {
-    expect(
-      await runMd(
-        "see [[SomePage]] for more\n",
-      ),
-    ).toMatchSnapshot();
+    expect(await runMd("see [[SomePage]] for more\n")).toMatchSnapshot();
   });
 
   test("renders simple table with alignment", async () => {
@@ -201,38 +128,17 @@ describe("bun <file.md>", () => {
 
   test("renders combining characters without breaking alignment", async () => {
     expect(
-      await runMd(
-        [
-          "| Name   | Note |",
-          "|:-------|:-----|",
-          "| café   | hot  |",
-          "| naïve  | ok   |",
-          "",
-        ].join("\n"),
-      ),
+      await runMd(["| Name   | Note |", "|:-------|:-----|", "| café   | hot  |", "| naïve  | ok   |", ""].join("\n")),
     ).toMatchSnapshot();
   });
 
   test("renders mixed inline styles with autolinks", async () => {
-    expect(
-      await runMd(
-        "Check **https://bun.com** and <me@example.com>!\n",
-      ),
-    ).toMatchSnapshot();
+    expect(await runMd("Check **https://bun.com** and <me@example.com>!\n")).toMatchSnapshot();
   });
 
   test("renders nested lists", async () => {
     expect(
-      await runMd(
-        [
-          "- outer",
-          "  - inner 1",
-          "  - inner 2",
-          "    - deep",
-          "- second outer",
-          "",
-        ].join("\n"),
-      ),
+      await runMd(["- outer", "  - inner 1", "  - inner 2", "    - deep", "- second outer", ""].join("\n")),
     ).toMatchSnapshot();
   });
 
@@ -250,11 +156,7 @@ describe("bun <file.md>", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
     // No escape characters expected
@@ -271,11 +173,7 @@ describe("bun <file.md>", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
     expect(stdout).toMatchSnapshot();
@@ -290,11 +188,7 @@ describe("bun <file.md>", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
     expect(stdout).toMatchSnapshot();

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -298,12 +298,16 @@ describe("bun <file.md>", () => {
       { COLUMNS: "50" },
     );
     expect(maxLineWidth(out)).toBeLessThanOrEqual(50);
-    // Borders stay aligned: every non-blank line starts and ends with `│`.
+    // Borders stay aligned: every non-blank line starts and ends with `│`
+    // (or the matching corner/junction char for the top/bottom/separator).
     for (const line of out.split("\n")) {
       if (line.trim().length === 0) continue;
       const stripped = Bun.stripANSI(line);
       expect(
         stripped.startsWith("│") || stripped.startsWith("┌") || stripped.startsWith("├") || stripped.startsWith("└"),
+      ).toBe(true);
+      expect(
+        stripped.endsWith("│") || stripped.endsWith("┐") || stripped.endsWith("┤") || stripped.endsWith("┘"),
       ).toBe(true);
     }
     expect(out).toMatchSnapshot();

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -84,6 +84,30 @@ describe("bun <file.md>", () => {
     expect(await runMd("Visit [Bun](https://bun.com) today.\n")).toMatchSnapshot();
   });
 
+  test("emits OSC 8 escape for links when hyperlinks are enabled", async () => {
+    // runMd() pipes stdout so the CLI path can't see a TTY; drive the
+    // JS API directly with hyperlinks:true to cover the OSC 8 branch.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.stdout.write(Bun.markdown.ansi("see [Bun](https://bun.com)\\n", { hyperlinks: true }))`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, _stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    // Output must contain the OSC 8 opener + closer around the link.
+    expect(stdout).toContain("\x1b]8;;https://bun.com\x1b\\");
+    expect(stdout).toContain("\x1b]8;;\x1b\\");
+    expect(exitCode).toBe(0);
+  });
+
   test("renders multiple links as text + url pairs", async () => {
     expect(await runMd("see [Bun](https://bun.com)\n")).toMatchSnapshot();
   });
@@ -94,6 +118,13 @@ describe("bun <file.md>", () => {
 
   test("renders wikilinks", async () => {
     expect(await runMd("see [[SomePage]] for more\n")).toMatchSnapshot();
+  });
+
+  // Regression: the parser's `[[` fast-path used to skip emitting the
+  // preceding text when the wikilink failed to close. `foo [[bar baz`
+  // should render the full text literally, not drop the `foo ` prefix.
+  test("falls back to literal text when `[[` never closes", async () => {
+    expect(await runMd("foo [[bar baz\n")).toMatchSnapshot();
   });
 
   test("renders simple table with alignment", async () => {

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -306,9 +306,9 @@ describe("bun <file.md>", () => {
       expect(
         stripped.startsWith("│") || stripped.startsWith("┌") || stripped.startsWith("├") || stripped.startsWith("└"),
       ).toBe(true);
-      expect(
-        stripped.endsWith("│") || stripped.endsWith("┐") || stripped.endsWith("┤") || stripped.endsWith("┘"),
-      ).toBe(true);
+      expect(stripped.endsWith("│") || stripped.endsWith("┐") || stripped.endsWith("┤") || stripped.endsWith("┘")).toBe(
+        true,
+      );
     }
     expect(out).toMatchSnapshot();
   });

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -260,4 +260,52 @@ describe("bun <file.md>", () => {
     expect(stdout).toMatchSnapshot();
     expect(exitCode).toBe(0);
   });
+
+  // Every emitted line must fit the terminal — checked via Bun.stringWidth
+  // (visible width, ANSI-stripped) so escape sequences don't inflate the
+  // count.
+  function maxLineWidth(out: string): number {
+    return Math.max(0, ...out.split("\n").map(l => Bun.stringWidth(l)));
+  }
+
+  test("wraps inline code spans within COLUMNS, never mid-word", async () => {
+    const out = await runMd(
+      "After modifying `coreBeeps.ts`, `controlBoops.ts`, or `toolBoops.ts`, run " +
+        "`bun run build:boop` to regenerate. **Do not edit `*.generated.ts` files directly.**\n",
+      { COLUMNS: "45" },
+    );
+    expect(maxLineWidth(out)).toBeLessThanOrEqual(45);
+    expect(out).toMatchSnapshot();
+  });
+
+  test("hard-breaks an overlong CJK word at the visible-width boundary", async () => {
+    // 60 bytes = 20 CJK chars = 40 visible columns; must wrap at 30.
+    const out = await runMd("A " + Buffer.alloc(60, "测试").toString() + " wide.\n", { COLUMNS: "30" });
+    expect(out).not.toContain("\uFFFD");
+    expect(maxLineWidth(out)).toBeLessThanOrEqual(30);
+    expect(out).toMatchSnapshot();
+  });
+
+  test("shrinks table columns to fit COLUMNS and wraps cell content", async () => {
+    const out = await runMd(
+      [
+        "| Path | Scope |",
+        "| --- | --- |",
+        "| `src/CLAUDE.md` | Source architecture: module map, startup flow, state management |",
+        "| `src/components/design-system/CLAUDE.md` | Design system component API (Dialog, Tabs, StatusIcon, etc.) |",
+        "",
+      ].join("\n"),
+      { COLUMNS: "50" },
+    );
+    expect(maxLineWidth(out)).toBeLessThanOrEqual(50);
+    // Borders stay aligned: every non-blank line starts and ends with `│`.
+    for (const line of out.split("\n")) {
+      if (line.trim().length === 0) continue;
+      const stripped = Bun.stripANSI(line);
+      expect(
+        stripped.startsWith("│") || stripped.startsWith("┌") || stripped.startsWith("├") || stripped.startsWith("└"),
+      ).toBe(true);
+    }
+    expect(out).toMatchSnapshot();
+  });
 });

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+async function runMd(source: string, env: Record<string, string> = {}) {
+  using dir = tempDir("md-entry-", { "doc.md": source });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "./doc.md"],
+    env: { ...bunEnv, FORCE_COLOR: "1", TERM: "xterm-256color", ...env },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return stdout;
+}
+
+describe("bun <file.md>", () => {
+  test("renders headings with underlines", async () => {
+    expect(
+      await runMd(
+        [
+          "# Heading 1",
+          "",
+          "## Heading 2",
+          "",
+          "### Heading 3",
+          "",
+          "body",
+          "",
+        ].join("\n"),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("renders bold, italic, strikethrough, inline code", async () => {
+    expect(
+      await runMd(
+        "**bold** *italic* ~~strike~~ `code` regular\n",
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("renders ordered, unordered, and task lists", async () => {
+    expect(
+      await runMd(
+        [
+          "1. first",
+          "2. second",
+          "3. third",
+          "",
+          "- apple",
+          "- banana",
+          "- cherry",
+          "",
+          "- [ ] todo",
+          "- [x] done",
+          "",
+        ].join("\n"),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("renders blockquotes and nested blockquotes", async () => {
+    expect(
+      await runMd(
+        [
+          "> A quote",
+          ">",
+          "> > Nested quote",
+          "",
+        ].join("\n"),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("renders horizontal rules", async () => {
+    expect(
+      await runMd(
+        [
+          "above",
+          "",
+          "---",
+          "",
+          "below",
+          "",
+        ].join("\n"),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("renders fenced code block with JS syntax highlighting", async () => {
+    expect(
+      await runMd(
+        [
+          "```js",
+          'const name = "world";',
+          "console.log(`hello ${name}`);",
+          "```",
+          "",
+        ].join("\n"),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("renders fenced code block without language", async () => {
+    expect(
+      await runMd(
+        [
+          "```",
+          "plain text",
+          "no highlighting",
+          "```",
+          "",
+        ].join("\n"),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("renders hyperlinks with OSC 8 escape sequence", async () => {
+    expect(
+      await runMd(
+        "Visit [Bun](https://bun.com) today.\n",
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("renders hyperlinks without OSC 8 when no TTY", async () => {
+    // The spawned process doesn't have a TTY on stdout so hyperlinks fall
+    // back to "text (url)" format. This is the default for runMd().
+    expect(
+      await runMd(
+        "see [Bun](https://bun.com)\n",
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("renders images as alt text with link", async () => {
+    expect(
+      await runMd(
+        "![an image](https://bun.com/logo.png)\n",
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("renders wikilinks", async () => {
+    expect(
+      await runMd(
+        "see [[SomePage]] for more\n",
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("renders simple table with alignment", async () => {
+    expect(
+      await runMd(
+        [
+          "| Name  | Age | City |",
+          "|:------|:---:|-----:|",
+          "| Alice |  30 |  NYC |",
+          "| Bob   |  25 |   LA |",
+          "",
+        ].join("\n"),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("renders table with CJK multi-width graphemes", async () => {
+    expect(
+      await runMd(
+        [
+          "| 名前   | 言語       | 都市       |",
+          "|:-------|:----------:|-----------:|",
+          "| 山田   | 日本語     | 東京       |",
+          "| Alice  | English    | NYC        |",
+          "",
+        ].join("\n"),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("renders table with emoji graphemes", async () => {
+    expect(
+      await runMd(
+        [
+          "| Status | Label  |",
+          "|:------:|:-------|",
+          "| ✅     | pass   |",
+          "| ❌     | fail   |",
+          "| 🚀     | launch |",
+          "",
+        ].join("\n"),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("renders combining characters without breaking alignment", async () => {
+    expect(
+      await runMd(
+        [
+          "| Name   | Note |",
+          "|:-------|:-----|",
+          "| café   | hot  |",
+          "| naïve  | ok   |",
+          "",
+        ].join("\n"),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("renders mixed inline styles with autolinks", async () => {
+    expect(
+      await runMd(
+        "Check **https://bun.com** and <me@example.com>!\n",
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("renders nested lists", async () => {
+    expect(
+      await runMd(
+        [
+          "- outer",
+          "  - inner 1",
+          "  - inner 2",
+          "    - deep",
+          "- second outer",
+          "",
+        ].join("\n"),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test("runs without colors when NO_COLOR is set", async () => {
+    using dir = tempDir("md-no-color-", {
+      "doc.md": "# Hello\n\n**world**\n",
+    });
+    const env = { ...bunEnv, NO_COLOR: "1" };
+    // FORCE_COLOR set to anything (even "") forces colors on, so drop it.
+    delete env.FORCE_COLOR;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "./doc.md"],
+      env,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    // No escape characters expected
+    expect(stdout).not.toContain("\x1b[");
+    expect(stdout).toMatchSnapshot();
+  });
+
+  test("renders via `bun run ./file.md`", async () => {
+    using dir = tempDir("md-run-", { "doc.md": "# Title\n\nbody\n" });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "./doc.md"],
+      env: { ...bunEnv, FORCE_COLOR: "1", TERM: "xterm-256color" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatchSnapshot();
+  });
+
+  test("renders .markdown extension too", async () => {
+    using dir = tempDir("md-ext-", { "doc.markdown": "# yep\n" });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "./doc.markdown"],
+      env: { ...bunEnv, FORCE_COLOR: "1", TERM: "xterm-256color" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatchSnapshot();
+  });
+});

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -77,13 +77,14 @@ describe("bun <file.md>", () => {
     expect(await runMd(["```", "plain text", "no highlighting", "```", ""].join("\n"))).toMatchSnapshot();
   });
 
-  test("renders hyperlinks with OSC 8 escape sequence", async () => {
+  test("renders link text with url fallback when no TTY", async () => {
+    // runMd() spawns Bun with stdout:"pipe", so Output.isStdoutTTY() is
+    // false and hyperlinks fall back to `text (url)`. The OSC 8 path fires
+    // when stdout really is a TTY.
     expect(await runMd("Visit [Bun](https://bun.com) today.\n")).toMatchSnapshot();
   });
 
-  test("renders hyperlinks without OSC 8 when no TTY", async () => {
-    // The spawned process doesn't have a TTY on stdout so hyperlinks fall
-    // back to "text (url)" format. This is the default for runMd().
+  test("renders multiple links as text + url pairs", async () => {
     expect(await runMd("see [Bun](https://bun.com)\n")).toMatchSnapshot();
   });
 

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -312,4 +312,39 @@ describe("bun <file.md>", () => {
     }
     expect(out).toMatchSnapshot();
   });
+
+  // Regression: the row-wrapper's word-break refinement used a raw byte
+  // scan for the last space inside the cut, which found spaces inside an
+  // OSC 8 URL (e.g. `[text](<https://host/my file.png>)`) and truncated
+  // the escape sequence mid-URL, corrupting every subsequent row.
+  //
+  // Triggering this needs the URL space to be the ONLY space in the
+  // refinement window: the link is the first content in the cell and is
+  // followed by unbreakable text (no literal spaces) that forces a wrap
+  // BEFORE any external space appears — so lastIndexOfChar(' ') has
+  // nothing else to return.
+  test("table link with space in URL keeps OSC 8 sequences intact", () => {
+    const source =
+      "| Col |\n" +
+      "|---|\n" +
+      "| [c](<https://host/my file.png>)longunbreakabletailtextxx |\n";
+    const out = Bun.markdown.ansi(source, { hyperlinks: true, columns: 25 });
+    // Full URL (including the space) must survive inside the opener.
+    expect(out).toContain("\x1b]8;;https://host/my file.png\x1b\\");
+    // Every OSC 8 opener must have its own ST before the next one starts
+    // — a truncation would leave an opener dangling.
+    let i = 0;
+    let openers = 0;
+    while (true) {
+      const open = out.indexOf("\x1b]8;;", i);
+      if (open === -1) break;
+      openers++;
+      const close = out.indexOf("\x1b\\", open);
+      expect(close).not.toBe(-1);
+      const nextOpen = out.indexOf("\x1b]8;;", open + 5);
+      if (nextOpen !== -1) expect(close).toBeLessThan(nextOpen);
+      i = close + 2;
+    }
+    expect(openers).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -97,11 +97,7 @@ describe("bun <file.md>", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, _stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // Output must contain the OSC 8 opener + closer around the link.
     expect(stdout).toContain("\x1b]8;;https://bun.com\x1b\\");
     expect(stdout).toContain("\x1b]8;;\x1b\\");

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -291,8 +291,8 @@ describe("bun <file.md>", () => {
       [
         "| Path | Scope |",
         "| --- | --- |",
-        "| `src/CLAUDE.md` | Source architecture: module map, startup flow, state management |",
-        "| `src/components/design-system/CLAUDE.md` | Design system component API (Dialog, Tabs, StatusIcon, etc.) |",
+        "| `docs/guide.md` | Top-level architecture: module map, startup flow, state management |",
+        "| `docs/components/design-system/guide.md` | Design system component API (Dialog, Tabs, StatusIcon, etc.) |",
         "",
       ].join("\n"),
       { COLUMNS: "50" },

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -324,10 +324,7 @@ describe("bun <file.md>", () => {
   // BEFORE any external space appears — so lastIndexOfChar(' ') has
   // nothing else to return.
   test("table link with space in URL keeps OSC 8 sequences intact", () => {
-    const source =
-      "| Col |\n" +
-      "|---|\n" +
-      "| [c](<https://host/my file.png>)longunbreakabletailtextxx |\n";
+    const source = "| Col |\n" + "|---|\n" + "| [c](<https://host/my file.png>)longunbreakabletailtextxx |\n";
     const out = Bun.markdown.ansi(source, { hyperlinks: true, columns: 25 });
     // Full URL (including the space) must survive inside the opener.
     expect(out).toContain("\x1b]8;;https://host/my file.png\x1b\\");

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+
+// Tracks exit code from the last runMd() call so individual tests can
+// assert it after snapshotting stdout (giving a readable diff on failure).
+let lastExitCode: number | null = null;
 
 async function runMd(source: string, env: Record<string, string> = {}) {
   using dir = tempDir("md-entry-", { "doc.md": source });
@@ -10,13 +14,21 @@ async function runMd(source: string, env: Record<string, string> = {}) {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
+  // stderr intentionally not asserted: ASAN builds emit a warning there.
+  const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  lastExitCode = exitCode;
   return stdout;
 }
 
 describe("bun <file.md>", () => {
+  afterEach(() => {
+    // Implicit exit-code assertion for every test that relies on runMd().
+    if (lastExitCode !== null) {
+      expect(lastExitCode).toBe(0);
+      lastExitCode = null;
+    }
+  });
+
   test("renders headings with underlines", async () => {
     expect(
       await runMd(["# Heading 1", "", "## Heading 2", "", "### Heading 3", "", "body", ""].join("\n")),
@@ -127,9 +139,45 @@ describe("bun <file.md>", () => {
   });
 
   test("renders combining characters without breaking alignment", async () => {
-    expect(
-      await runMd(["| Name   | Note |", "|:-------|:-----|", "| café   | hot  |", "| naïve  | ok   |", ""].join("\n")),
-    ).toMatchSnapshot();
+    // Decomposed NFD: 'e' + U+0301 combining acute, 'i' + U+0308 combining diaeresis.
+    // These must be zero-width in the grapheme counter for the table to line up.
+    const stdout = await runMd(
+      [
+        "| Name   | Note |",
+        "|:-------|:-----|",
+        "| cafe\u0301   | hot  |",
+        "| nai\u0308ve  | ok   |",
+        "",
+      ].join("\n"),
+    );
+    expect(stdout).toMatchSnapshot();
+    expect(lastExitCode).toBe(0);
+  });
+
+  test("renders inline formatting inside table cells", async () => {
+    const stdout = await runMd(
+      [
+        "| Name  | Style     |",
+        "|:------|:----------|",
+        "| **Alice** | *editor* |",
+        "| `bob` | [link](https://bun.com) |",
+        "",
+      ].join("\n"),
+    );
+    expect(stdout).toMatchSnapshot();
+    expect(lastExitCode).toBe(0);
+  });
+
+  test("renders inline formatting inside headings", async () => {
+    const stdout = await runMd("# Hello **bold** and *italic* heading\n");
+    expect(stdout).toMatchSnapshot();
+    expect(lastExitCode).toBe(0);
+  });
+
+  test("nested code span inside bold keeps outer bold", async () => {
+    const stdout = await runMd("**before `code` after** tail\n");
+    expect(stdout).toMatchSnapshot();
+    expect(lastExitCode).toBe(0);
   });
 
   test("renders mixed inline styles with autolinks", async () => {
@@ -156,12 +204,11 @@ describe("bun <file.md>", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
+    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // No escape characters expected
     expect(stdout).not.toContain("\x1b[");
     expect(stdout).toMatchSnapshot();
+    expect(exitCode).toBe(0);
   });
 
   test("renders via `bun run ./file.md`", async () => {
@@ -173,10 +220,9 @@ describe("bun <file.md>", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
+    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toMatchSnapshot();
+    expect(exitCode).toBe(0);
   });
 
   test("renders .markdown extension too", async () => {
@@ -188,9 +234,8 @@ describe("bun <file.md>", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
+    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toMatchSnapshot();
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -104,7 +104,7 @@ describe("bun <file.md>", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("renders multiple links as text + url pairs", async () => {
+  test("renders link with text + url pair fallback", async () => {
     expect(await runMd("see [Bun](https://bun.com)\n")).toMatchSnapshot();
   });
 


### PR DESCRIPTION
When the entrypoint loader is `.md`, bun now reads the file, renders it
to ANSI, prints to stdout, and exits — no JavaScript VM spin-up.

### Supported

- Headings (h1-h6) with colored underlines
- **Bold**, *italic*, ~~strikethrough~~, underline, \`inline code\`
- Ordered / unordered / task lists (with nesting)
- Blockquotes (nested)
- Horizontal rules
- Fenced code blocks with syntax highlighting for JS/TS/JSX/TSX via
  \`QuickAndDirtyJavaScriptSyntaxHighlighter\`
- Tables with per-column alignment + box-drawing borders. Column widths
  are computed globally so **CJK, emoji, and combining characters align
  correctly** (uses \`bun.strings.visible.width.exclude_ansi_colors.utf8\`)
- OSC 8 hyperlinks (with \"text (url)\" fallback when stdout isn't a TTY)
- Images as alt text with the src as an OSC 8 link
- Wikilinks
- Autolinks (url, www, email)
- Word-wrapping respecting COLUMNS
- Light / dark theme selection via \`COLORFGBG\`, \`NO_COLOR\`, \`FORCE_COLOR\`

### Wiring

- \`.md\` added to \`default_loaders\` so \`bun ./file.md\` resolves it.
- \`_bootAndHandleError\` short-circuits when the loader resolves to
  \`.md\`, calls the renderer, flushes, and exits.
- No VM boot, no JSC init — much faster than spinning up a runtime.

### Tests

\`test/cli/run/markdown-entrypoint.test.ts\` — 20 snapshot tests covering
every feature above plus NO_COLOR mode and the \`.markdown\` extension.
Tables specifically include CJK, emoji, and combining-character rows to
verify multi-width grapheme alignment.