### PR TITLE
libarchive: skip tar entries with absolute paths on Windows

### DIFF
--- a/src/libarchive/libarchive.zig
+++ b/src/libarchive/libarchive.zig
@@ -417,6 +417,16 @@ pub const Archiver = struct {
                     const path: [:0]bun.OSPathChar = normalized_buf[0..normalized.len :0];
                     if (path.len == 0 or path.len == 1 and path[0] == '.') continue;
 
+                    // Skip entries whose normalized path is absolute on Windows.
+                    // `openatWindows` ignores `dir_fd` for absolute inputs (drive
+                    // letter or UNC), so without this guard a tar entry could
+                    // resolve outside the extraction directory. On POSIX the
+                    // tokenize-on-'/' step already strips any leading separators,
+                    // so `normalizeBufT` cannot produce an absolute output.
+                    if (comptime Environment.isWindows) {
+                        if (std.fs.path.isAbsoluteWindowsWTF16(path)) continue :loop;
+                    }
+
                     if (options.npm and Environment.isWindows) {
                         // When writing files on Windows, translate the characters to their
                         // 0xf000 higher-encoded versions.

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -1,6 +1,38 @@
 import { describe, expect, test } from "bun:test";
-import { tempDir } from "harness";
+import { isWindows, tempDir } from "harness";
+import { existsSync, readdirSync, rmSync } from "node:fs";
 import { join } from "path";
+
+// Minimal ustar tarball builder (pathnames must be <100 bytes).
+function ustarHeader(name: string, size: number): Buffer {
+  if (Buffer.byteLength(name) > 99) throw new Error("ustar name too long: " + name);
+  const h = Buffer.alloc(512);
+  h.write(name, 0, 100, "utf8");
+  h.write("0000644\0", 100);
+  h.write("0000000\0", 108);
+  h.write("0000000\0", 116);
+  h.write(size.toString(8).padStart(11, "0") + "\0", 124);
+  h.write("00000000000\0", 136);
+  h.write("        ", 148);
+  h.write("0", 156);
+  h.write("ustar\0", 257);
+  h.write("00", 263);
+  let sum = 0;
+  for (let i = 0; i < 512; i++) sum += h[i];
+  h.write(sum.toString(8).padStart(6, "0") + "\0 ", 148);
+  return h;
+}
+
+function ustarEntry(name: string, data: Buffer): Buffer {
+  const pad = Buffer.alloc((512 - (data.length % 512)) % 512);
+  return Buffer.concat([ustarHeader(name, data.length), data, pad]);
+}
+
+function buildTarball(entries: Array<{ name: string; data: Buffer | string }>): Uint8Array {
+  const parts = entries.map(e => ustarEntry(e.name, typeof e.data === "string" ? Buffer.from(e.data) : e.data));
+  parts.push(Buffer.alloc(1024));
+  return new Uint8Array(Buffer.concat(parts));
+}
 
 describe("Bun.Archive", () => {
   describe("new Archive()", () => {
@@ -479,6 +511,42 @@ describe("Bun.Archive", () => {
       await expect(async () => {
         await archive.extract(join(String(dir), "existing-file.txt"));
       }).toThrow();
+    });
+
+    test.skipIf(!isWindows)("skips tar entries whose normalized path is absolute", async () => {
+      using dir = tempDir("archive-extract-absolute", {});
+
+      // A tar entry whose name looks like a Windows drive-letter path. After
+      // tokenize + normalize this becomes `C:\...`, which is absolute —
+      // `openatWindows` would ignore the extraction directory and write the
+      // file to the drive root. The extractor must drop the entry.
+      const uniq = `bun-archive-absolute-${crypto.randomUUID()}.txt`;
+      const driveEntry = `C:/${uniq}`;
+      const windowsAbsPath = `C:\\${uniq}`;
+
+      const tarball = buildTarball([
+        { name: "safe.txt", data: "safe contents" },
+        { name: driveEntry, data: "should not escape" },
+      ]);
+
+      try {
+        const archive = new Bun.Archive(tarball);
+        await archive.extract(String(dir));
+
+        // The safe entry must still be extracted.
+        expect(await Bun.file(join(String(dir), "safe.txt")).text()).toBe("safe contents");
+
+        // The absolute entry must not land at its drive-letter target.
+        expect(existsSync(windowsAbsPath)).toBe(false);
+
+        // The absolute entry is skipped entirely, so only `safe.txt` remains
+        // in the extraction directory.
+        expect(readdirSync(String(dir))).toEqual(["safe.txt"]);
+      } finally {
+        if (existsSync(windowsAbsPath)) {
+          rmSync(windowsAbsPath, { force: true });
+        }
+      }
     });
   });
 


### PR DESCRIPTION
`Archiver.extractToDir` normalizes each entry's path with `normalizeBufT(.auto)` and then opens it via `openatWindows`. On Windows `openatWindows` ignores the `dir_fd` argument when the input is absolute (drive letter or UNC), so a tar entry whose normalized form is `C:\...` or `\\host\share\...` would land outside the extraction directory instead of inside it.

## Fix

After normalization in `src/libarchive/libarchive.zig`, check `std.fs.path.isAbsoluteWindowsWTF16` on Windows and `continue :loop` (drop the entry) when it returns true. On POSIX the existing `tokenizeScalar('/', ...)` pass already strips any leading separators before normalization, so the output can never be absolute — the guard is Windows-only and wrapped in `comptime Environment.isWindows`.

## Scope check

The guard only trips for outputs that are Windows-absolute:

- `C:/foo` or `C:\\foo` — drive letter followed by a separator.
- `\\host\\share\\...` — UNC.
- Leading `/` or `\\` — in practice unreachable because the tokenizer either strips leading `/` or bails out on paths that contain no `/`.

It does **not** fire on drive-relative paths like `C:foo` (no separator after the colon) — `isAbsoluteWindowsWTF16` returns false for those, and `openatWindows` at `sys.zig:976-978` already strips the `C:` prefix and resolves them against `dir_fd`. Normal relative entries like `package/lib/foo.js` are unaffected.

## Test

`test/js/bun/archive.test.ts` gets a small ustar tarball builder and a Windows-gated regression test that:

1. Builds a tarball with `safe.txt` and a drive-letter entry `C:/bun-archive-absolute-<uuid>.txt`.
2. Extracts it via `new Bun.Archive(tarball).extract(dir)`.
3. Asserts `safe.txt` is present inside `dir`.
4. Asserts the drive-letter target does **not** exist at `C:\...`.
5. Asserts only `safe.txt` remains in the extraction directory.

Locally on macOS: `bun bd test test/js/bun/archive.test.ts` → 99 pass, 1 skip (the Windows-only test), 0 fail. Windows CI will exercise the regression case.