### PR TITLE
fix use-after-free when terminating a worker after it exited

### DIFF
--- a/src/bun.js/bindings/webcore/Worker.cpp
+++ b/src/bun.js/bindings/webcore/Worker.cpp
@@ -133,12 +133,25 @@ extern "C" void WebWorker__setRef(
 
 void Worker::setKeepAlive(bool keepAlive)
 {
-    WebWorker__setRef(impl_, keepAlive);
+    Locker lock { m_implLock };
+    if (impl_)
+        WebWorker__setRef(impl_, keepAlive);
+}
+
+void Worker::clearImpl()
+{
+    Locker lock { m_implLock };
+    impl_ = nullptr;
 }
 
 bool Worker::updatePtr()
 {
-    if (!WebWorker__updatePtr(impl_, this)) {
+    void* impl;
+    {
+        Locker lock { m_implLock };
+        impl = impl_;
+    }
+    if (!impl || !WebWorker__updatePtr(impl, this)) {
         m_onlineClosingFlags = ClosingFlag;
         m_terminationFlags.fetch_or(TerminatedFlag);
         return false;
@@ -216,7 +229,10 @@ ExceptionOr<Ref<Worker>> Worker::create(ScriptExecutionContext& context, const S
         return Exception { TypeError, errorMessage.toWTFString(BunString::ZeroCopy) };
     }
 
-    worker->impl_ = impl;
+    {
+        Locker lock { worker->m_implLock };
+        worker->impl_ = impl;
+    }
     worker->m_workerCreationTime = MonotonicTime::now();
 
     return worker;
@@ -263,7 +279,9 @@ void Worker::terminate()
 {
     // m_contextProxy.terminateWorkerGlobalScope();
     m_terminationFlags.fetch_or(TerminateRequestedFlag);
-    WebWorker__notifyNeedTermination(impl_);
+    Locker lock { m_implLock };
+    if (impl_)
+        WebWorker__notifyNeedTermination(impl_);
 }
 
 // const char* Worker::activeDOMObjectName() const
@@ -463,6 +481,11 @@ void Worker::forEachWorker(const Function<Function<void(ScriptExecutionContext&)
     Locker locker { allWorkersLock };
     for (auto& contextIdentifier : allWorkers().keys())
         ScriptExecutionContext::postTaskTo(contextIdentifier, callback());
+}
+
+extern "C" void WebWorker__clearImpl(Worker* worker)
+{
+    worker->clearImpl();
 }
 
 extern "C" void WebWorker__dispatchExit(Zig::GlobalObject* globalObject, Worker* worker, int32_t exitCode)

--- a/src/bun.js/bindings/webcore/Worker.h
+++ b/src/bun.js/bindings/webcore/Worker.h
@@ -76,6 +76,9 @@ public:
     void dispatchEvent(Event&);
     void dispatchCloseEvent(Event&);
     void setKeepAlive(bool);
+    // Called from the worker thread just before its WebWorker is freed, so
+    // that the main thread never calls into a freed impl_.
+    void clearImpl();
 
     void postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>&&);
 
@@ -119,6 +122,9 @@ private:
     // Tracks TerminateRequestedFlag and TerminatedFlag
     std::atomic<uint8_t> m_terminationFlags { 0 };
     const ScriptExecutionContextIdentifier m_clientIdentifier;
+    // Protects impl_ from being used by the main thread after the worker
+    // thread has freed it in WebWorker.exitAndDeinit.
+    Lock m_implLock;
     void* impl_ { nullptr };
 };
 

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -51,6 +51,7 @@ extern fn WebWorker__dispatchExit(?*jsc.JSGlobalObject, *anyopaque, i32) void;
 extern fn WebWorker__dispatchOnline(cpp_worker: *anyopaque, *jsc.JSGlobalObject) void;
 extern fn WebWorker__fireEarlyMessages(cpp_worker: *anyopaque, *jsc.JSGlobalObject) void;
 extern fn WebWorker__dispatchError(*jsc.JSGlobalObject, *anyopaque, bun.String, JSValue) void;
+extern fn WebWorker__clearImpl(cpp_worker: *anyopaque) void;
 
 export fn WebWorker__getParentWorker(vm: *jsc.VirtualMachine) ?*anyopaque {
     const worker = vm.worker orelse return null;
@@ -643,6 +644,12 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
         vm_to_deinit = vm;
     }
     var arena = this.arena;
+
+    // Clear the WebWorker pointer on the C++ side before freeing it here,
+    // so the main thread can't call into freed memory via terminate() or
+    // ref()/unref(). This must happen before WebWorker__dispatchExit, which
+    // may release the last reference to the C++ Worker.
+    WebWorker__clearImpl(cpp_worker);
 
     WebWorker__dispatchExit(globalObject, cpp_worker, exit_code);
     if (loop) |loop_| {

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -410,4 +410,19 @@ describe("worker_threads", () => {
     await p;
     expect(message).toEqual("hello");
   });
+
+  test("calling terminate() after the worker thread fails to start does not use-after-free", async () => {
+    // The worker thread frees its WebWorker struct when startup fails (e.g.
+    // module not found). If the main thread then calls terminate() afterwards
+    // it races with that free and reads freed memory. See fuzzilli crash
+    // Address:use-after-poison in WebWorker__notifyNeedTermination.
+    for (let i = 0; i < 10; i++) {
+      const w = new wt.Worker("does-not-exist-" + i);
+      // Wait for the worker to fail startup and run exitAndDeinit, then
+      // terminate() on the main thread exercises the freed-impl_ path.
+      await once(w, "error");
+      w.terminate();
+      w.terminate();
+    }
+  });
 });


### PR DESCRIPTION
Found by Fuzzilli with ASAN: `Address:use-after-poison` inside `WebWorker__notifyNeedTermination`.

### Repro

```js
for (let i = 0; i < 100; i++) {
  const w = new Worker("does-not-exist-" + i);
  w.onerror = () => {};
  w.terminate();
  w.terminate();
}
```

### What happens

`Worker::terminate()` in C++ calls `WebWorker__notifyNeedTermination(impl_)` unconditionally. When the worker thread's `exitAndDeinit` has already run, `impl_` points to freed memory, so the call is a use-after-free. `setKeepAlive` and `updatePtr` read `impl_` the same way.

The worker thread's `exitAndDeinit` posts a close task to the main thread, then calls `this.deinit()` which frees the `WebWorker`. The close task — which is what marks the Worker terminated on the main thread — runs later, so there is a window where the main thread still sees the worker as alive while `impl_` is already freed.

### Fix

Protect `impl_` with a lock in `Worker`. The worker thread calls a new `WebWorker__clearImpl` before `deinit()` to null it out under the lock. Callers on the main thread (`terminate`, `setKeepAlive`, `updatePtr`) check for nullptr while holding the lock before dereferencing.

### Stack (before fix)

```
atomic.Value(bun.js.web_worker.Status).load
WebWorker__notifyNeedTermination        src/bun.js/web_worker.zig:571
WebCore::Worker::terminate()            src/bun.js/bindings/webcore/Worker.cpp:266
jsWorkerPrototypeFunction_terminate     src/bun.js/bindings/webcore/JSWorker.cpp:554
```