### PR TITLE
Return empty blob promise when ByteBlobLoader store is detached

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -181,6 +181,13 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
     }
 
     var empty: Blob.Any = .{ .Blob = Blob.initEmpty(globalThis) };
+    if (this.content_type.len > 0) {
+        empty.Blob.content_type = this.content_type;
+        empty.Blob.content_type_was_set = true;
+        empty.Blob.content_type_allocated = this.content_type_allocated;
+        this.content_type = "";
+        this.content_type_allocated = false;
+    }
     return empty.toPromise(globalThis, action);
 }
 

--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,8 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    var empty: Blob.Any = .{ .Blob = Blob.initEmpty(globalThis) };
+    return empty.toPromise(globalThis, action);
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/test/js/web/fetch/blob-stream-consume.test.ts
+++ b/test/js/web/fetch/blob-stream-consume.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test";
+
+// Regression test for a Fuzzilli-found crash in ByteBlobLoader.toBufferedValue:
+// calling a buffered consumer (text/bytes/blob/json) on a blob-backed
+// ReadableStream after the underlying store has been detached used to return
+// an empty JSValue without throwing, tripping the
+// "Expected an exception to be thrown" assertion.
+test("blob stream buffered consumers do not crash on empty blob", async () => {
+  expect(await new Blob([]).stream().text()).toBe("");
+  expect((await new Blob([]).stream().bytes()).byteLength).toBe(0);
+  expect((await new Blob([]).stream().blob()).size).toBe(0);
+  await expect(new Blob([]).stream().json()).rejects.toThrow();
+});
+
+test("blob stream buffered consumers return data for non-empty blob", async () => {
+  expect(await new Blob(["hello"]).stream().text()).toBe("hello");
+  expect(Array.from(await new Blob(["hi"]).stream().bytes())).toEqual([104, 105]);
+  expect((await new Blob(["x"]).stream().blob()).size).toBe(1);
+  expect(await new Blob(['{"a":1}']).stream().json()).toEqual({ a: 1 });
+});


### PR DESCRIPTION
Fixes a `panic: Expected an exception to be thrown` in `BlobInternalReadableStreamSourcePrototype__textFromJS` reported by Fuzzilli.

`ByteBlobLoader.toBufferedValue` returned an empty JSValue (`.zero`) when its internal blob store had been detached, without throwing a JS exception. This violates the `toJSHostCall` contract (empty JSValue ⇔ exception thrown) and triggers the assertion in ASAN builds.

Treat the detached-store case as an empty blob and return a resolved promise for the requested action, matching what an empty input would produce.