### PR TITLE
bunfig: add [resolve] conditions to configure custom export conditions

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -105,6 +105,31 @@ Bun supports the following loaders:
 - `dataurl`
 - `text`
 
+### `resolve.conditions`
+
+Configure custom [export conditions](https://nodejs.org/api/packages.html#conditional-exports) used when resolving packages. Equivalent to passing `--conditions` on every CLI invocation. Applies to `bun run`, `bun test`, `bun build`, and the dev server.
+
+```toml title="bunfig.toml" icon="settings"
+[resolve]
+conditions = ["source"]
+```
+
+This mirrors TypeScript's `customConditions` in `tsconfig.json`. A common use case is monorepos where workspace packages expose a `"source"` export condition so sibling packages resolve directly to `.ts` source instead of the built output:
+
+```json title="package.json"
+{
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    }
+  }
+}
+```
+
+Conditions from bunfig.toml and the CLI `--conditions` flag are combined — passing `--conditions foo` adds `foo` to the conditions set by bunfig, it does not replace them.
+
 ### `telemetry`
 
 The `telemetry` field is used to enable/disable analytics. By default, telemetry is enabled. This is equivalent to the `DO_NOT_TRACK` environment variable.

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -793,6 +793,7 @@ impl ESMConditions {
             import_condition_map.insert(*condition, ());
             require_condition_map.insert(*condition, ());
             default_condition_amp.insert(*condition, ());
+            style_condition_map.insert(*condition, ());
         }
 
         for default in defaults {

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1054,6 +1054,33 @@ impl<'a> Parser<'a> {
             }
         }
 
+        if let Some(expr) = json.get(b"resolve") {
+            self.expect(&expr, ExprTag::EObject)?;
+
+            if let Some(conds_expr) = expr.get(b"conditions") {
+                self.expect(&conds_expr, ExprTag::EArray)?;
+                let array = conds_expr
+                    .data
+                    .e_array()
+                    .expect("infallible: variant checked");
+                let items = array.items.slice();
+                // Append to any existing conditions (e.g. from a previously
+                // loaded global bunfig) so multiple configs stack rather than
+                // clobber.
+                let mut combined: Vec<Box<[u8]>> =
+                    Vec::with_capacity(self.ctx.args.conditions.len() + items.len());
+                combined.extend(self.ctx.args.conditions.drain(..));
+                for item in items {
+                    self.expect_string(item)?;
+                    let ExprData::EString(s) = &item.data else {
+                        unreachable!("expect_string returned Ok for non-EString")
+                    };
+                    combined.push(estring_to_owned(s, self.bump));
+                }
+                self.ctx.args.conditions = combined;
+            }
+        }
+
         if let Some(expr) = json.get(b"loader") {
             self.expect(&expr, ExprTag::EObject)?;
             let obj = expr.data.e_object().expect("infallible: variant checked");

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1064,20 +1064,21 @@ impl<'a> Parser<'a> {
                     .e_array()
                     .expect("infallible: variant checked");
                 let items = array.items.slice();
-                // Append to any existing conditions (e.g. from a previously
-                // loaded global bunfig) so multiple configs stack rather than
-                // clobber.
-                let mut combined: Vec<Box<[u8]>> =
-                    Vec::with_capacity(self.ctx.args.conditions.len() + items.len());
-                combined.extend(self.ctx.args.conditions.drain(..));
+                // Validate all entries into a local vec first, then append to
+                // any existing conditions so configs stack rather than clobber.
+                // Building first keeps ctx.args.conditions intact if a later
+                // entry is invalid (a bad element must not wipe CLI conditions
+                // already set, especially on the `bun run` deferred-load path
+                // where the parse error is swallowed).
+                let mut parsed: Vec<Box<[u8]>> = Vec::with_capacity(items.len());
                 for item in items {
                     self.expect_string(item)?;
                     let ExprData::EString(s) = &item.data else {
                         unreachable!("expect_string returned Ok for non-EString")
                     };
-                    combined.push(estring_to_owned(s, self.bump));
+                    parsed.push(estring_to_owned(s, self.bump));
                 }
-                self.ctx.args.conditions = combined;
+                self.ctx.args.conditions.extend(parsed);
             }
         }
 

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -908,8 +908,11 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> Result<api::TransformOptions,
             | CommandTag::BuildCommand
             | CommandTag::TestCommand
     ) {
-        if !args.options(b"--conditions").is_empty() {
-            opts.conditions = slice_to_owned(args.options(b"--conditions"));
+        let cli_conditions = args.options(b"--conditions");
+        if !cli_conditions.is_empty() {
+            // Append CLI conditions to any set from bunfig.toml so both sources
+            // stack rather than the CLI clobbering the config.
+            opts.conditions.extend(slice_to_owned(cli_conditions));
         }
     }
 

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1068,8 +1068,16 @@ impl ServerConfig {
                     // map entries with `UserOptions.arena`.
                     for condition in &o.conditions {
                         let key = bb::arena_dupe_z(&user_options.arena, condition).as_bytes();
-                        user_options.bundler_options.client.conditions.insert(key, ());
-                        user_options.bundler_options.server.conditions.insert(key, ());
+                        user_options
+                            .bundler_options
+                            .client
+                            .conditions
+                            .insert(key, ());
+                        user_options
+                            .bundler_options
+                            .server
+                            .conditions
+                            .insert(key, ());
                         user_options.bundler_options.ssr.conditions.insert(key, ());
                     }
 

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1062,6 +1062,17 @@ impl ServerConfig {
                         user_options.bundler_options.ssr.define = define.clone();
                     }
 
+                    // Propagate bunfig/--conditions into each Bake transpiler so
+                    // the dev server honors custom export conditions. Keys are
+                    // arena-duped (like env_prefix above) to back the `&'static`
+                    // map entries with `UserOptions.arena`.
+                    for condition in &o.conditions {
+                        let key = bb::arena_dupe_z(&user_options.arena, condition).as_bytes();
+                        user_options.bundler_options.client.conditions.insert(key, ());
+                        user_options.bundler_options.server.conditions.insert(key, ());
+                        user_options.bundler_options.ssr.conditions.insert(key, ());
+                    }
+
                     args.bake = Some(user_options);
                 } else {
                     if !init_ctx.framework_router_list.is_empty() {

--- a/test/regression/issue/28851-dev-server-fixture.js
+++ b/test/regression/issue/28851-dev-server-fixture.js
@@ -1,0 +1,14 @@
+// Dev server (Bake/HMR) fixture for the bunfig `[resolve] conditions` test.
+// Imports the HTML route and starts Bun.serve with development: true so the
+// Bake bundler runs; conditions must come from the cwd's bunfig.toml.
+import index from "./index.html";
+
+const server = Bun.serve({
+  port: 0,
+  development: true,
+  routes: {
+    "/": index,
+  },
+});
+
+process.send({ port: server.port, hostname: server.hostname });

--- a/test/regression/issue/28851.test.ts
+++ b/test/regression/issue/28851.test.ts
@@ -1,0 +1,152 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/28851
+//
+// Support `[resolve] conditions = [...]` in bunfig.toml so custom export
+// conditions (e.g. "source") don't have to be re-passed as `--conditions`
+// on every CLI invocation.
+
+const packageFiles = {
+  "node_modules/pkg/package.json": JSON.stringify({
+    name: "pkg",
+    type: "module",
+    exports: {
+      ".": {
+        source: "./src.js",
+        import: "./dist.js",
+        default: "./dist.js",
+      },
+    },
+  }),
+  "node_modules/pkg/src.js": "export const value = 'source-file';",
+  "node_modules/pkg/dist.js": "export const value = 'dist-file';",
+  "package.json": JSON.stringify({ name: "host", type: "module" }),
+  "entry.js": "import { value } from 'pkg'; console.log(value);",
+  "entry.test.js":
+    "import { value } from 'pkg';\nimport { test, expect } from 'bun:test';\ntest('t', () => { expect(value).toBe('source-file'); });",
+};
+
+test("bunfig.toml [resolve] conditions applies to bun run", async () => {
+  using dir = tempDir("bunfig-resolve-conditions-run", {
+    ...packageFiles,
+    "bunfig.toml": `[resolve]\nconditions = ["source"]\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("source-file\n");
+  expect(exitCode).toBe(0);
+});
+
+test("without bunfig.toml, the default condition is used", async () => {
+  using dir = tempDir("bunfig-resolve-conditions-no-bunfig", {
+    ...packageFiles,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("dist-file\n");
+  expect(exitCode).toBe(0);
+});
+
+test("bunfig.toml [resolve] conditions applies to bun build", async () => {
+  using dir = tempDir("bunfig-resolve-conditions-build", {
+    ...packageFiles,
+    "bunfig.toml": `[resolve]\nconditions = ["source"]\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "entry.js", "--target", "bun"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("source-file");
+  expect(stdout).not.toContain("dist-file");
+  expect(exitCode).toBe(0);
+});
+
+test("bunfig.toml [resolve] conditions applies to bun test", async () => {
+  using dir = tempDir("bunfig-resolve-conditions-test", {
+    ...packageFiles,
+    "bunfig.toml": `[resolve]\nconditions = ["source"]\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "entry.test.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // bun test prints its summary to stderr; assert both 1 pass and 0 fail.
+  expect(stderr).toContain("1 pass");
+  expect(stderr).toContain("0 fail");
+  expect(exitCode).toBe(0);
+});
+
+test("CLI --conditions appends to bunfig.toml [resolve] conditions", async () => {
+  using dir = tempDir("bunfig-resolve-conditions-cli-append", {
+    "node_modules/pkg/package.json": JSON.stringify({
+      name: "pkg",
+      type: "module",
+      exports: {
+        ".": {
+          source: "./src.js",
+          cli: "./cli.js",
+          import: "./dist.js",
+          default: "./dist.js",
+        },
+      },
+    }),
+    "node_modules/pkg/src.js": "export const value = 'source-file';",
+    "node_modules/pkg/cli.js": "export const value = 'cli-file';",
+    "node_modules/pkg/dist.js": "export const value = 'dist-file';",
+    "package.json": JSON.stringify({ name: "host", type: "module" }),
+    "entry.js": "import { value } from 'pkg'; console.log(value);",
+    "bunfig.toml": `[resolve]\nconditions = ["source"]\n`,
+  });
+
+  // Both "source" (from bunfig) and "cli" (from CLI) are active conditions.
+  // The order of keys in the `exports` object determines which matches first;
+  // since "source" appears before "cli", it wins — proving the CLI flag didn't
+  // clobber the bunfig condition.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "--conditions=cli", "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("source-file\n");
+  expect(exitCode).toBe(0);
+
+  // Drop the "source" option from exports so only "cli" remains — bunfig's
+  // "source" condition isn't hit and CLI's "cli" condition must still work.
+  const pkgPath = String(dir) + "/node_modules/pkg/package.json";
+  const pkg = JSON.parse(await Bun.file(pkgPath).text());
+  delete pkg.exports["."].source;
+  await Bun.write(pkgPath, JSON.stringify(pkg));
+
+  await using proc2 = Bun.spawn({
+    cmd: [bunExe(), "run", "--conditions=cli", "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout2, _stderr2, exitCode2] = await Promise.all([proc2.stdout.text(), proc2.stderr.text(), proc2.exited]);
+  expect(stdout2).toBe("cli-file\n");
+  expect(exitCode2).toBe(0);
+});

--- a/test/regression/issue/28851.test.ts
+++ b/test/regression/issue/28851.test.ts
@@ -150,3 +150,39 @@ test("CLI --conditions appends to bunfig.toml [resolve] conditions", async () =>
   expect(stdout2).toBe("cli-file\n");
   expect(exitCode2).toBe(0);
 });
+
+test("bunfig.toml [resolve] conditions applies to the Bake dev server", async () => {
+  using dir = tempDir("bunfig-resolve-conditions-devserver", {
+    ...packageFiles,
+    "bunfig.toml": `[resolve]\nconditions = ["source"]\n`,
+    "index.html": `<!DOCTYPE html><html><head><script type="module" src="./entry.js"></script></head><body></body></html>`,
+    // Fixture lives next to this test; copy it in so its relative
+    // `./index.html` import resolves and bunfig is loaded from cwd.
+    "dev-server-fixture.js": await Bun.file(new URL("./28851-dev-server-fixture.js", import.meta.url)).text(),
+  });
+
+  const { promise, resolve, reject } = Promise.withResolvers<{ port: number; hostname: string }>();
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "dev-server-fixture.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    ipc(message) {
+      resolve(message);
+    },
+  });
+  proc.exited.then(code => reject(new Error(`dev server exited early with code ${code}`)));
+
+  const { port, hostname } = await promise;
+
+  // Fetch the HTML route, pull the bundled JS chunk URL out of it, then fetch
+  // the chunk and assert it bundled the "source" export (src.js), not dist.js.
+  const html = await (await fetch(`http://${hostname}:${port}/`)).text();
+  const jsPath = html.match(/<script[^>]+src="([^"]+\.js)"/)?.[1];
+  expect(jsPath).toBeTruthy();
+  const chunk = await (await fetch(new URL(jsPath!, `http://${hostname}:${port}/`))).text();
+  expect(chunk).toContain("source-file");
+  expect(chunk).not.toContain("dist-file");
+});

--- a/test/regression/issue/28851.test.ts
+++ b/test/regression/issue/28851.test.ts
@@ -163,12 +163,16 @@ test("bunfig.toml [resolve] conditions applies to the Bake dev server", async ()
 
   const { promise, resolve, reject } = Promise.withResolvers<{ port: number; hostname: string }>();
 
+  // The dev server is long-running and never exits, so we can't drain piped
+  // stdout/stderr via Promise.all([..., proc.exited]) like the other tests.
+  // Inherit both streams instead: no pipe to fill (avoids deadlock) and any
+  // bundler diagnostics surface in the test runner's output.
   await using proc = Bun.spawn({
     cmd: [bunExe(), "dev-server-fixture.js"],
     env: bunEnv,
     cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
+    stdout: "inherit",
+    stderr: "inherit",
     ipc(message) {
       resolve(message);
     },


### PR DESCRIPTION
Closes #28851

## What

Adds support for a `[resolve]` section in `bunfig.toml` with a `conditions` array, so custom export conditions can be set declaratively instead of passing `--conditions` on every CLI invocation.

```toml
[resolve]
conditions = ["source"]
```

Applies to `bun run`, `bun test`, `bun build`, and the dev server — any command that loads bunfig.

## Why

Monorepos commonly expose a `"source"` export condition so workspace siblings resolve to `.ts` source instead of built `.js`, mirroring TypeScript's `customConditions` in `tsconfig.json`. Today that requires remembering `--conditions=source` on every invocation; a declarative config makes the project self-describing.

## Implementation

- **`src/bunfig.zig`**: parse `[resolve] conditions = [...]` into `ctx.args.conditions` next to `loader`/`external`. If a value is already set (e.g. from a previously loaded global bunfig), the new list is appended.
- **`src/cli/Arguments.zig`**: CLI `--conditions` now *appends* to whatever bunfig set rather than replacing it, so both sources compose.
- **`docs/runtime/bunfig.mdx`**: new `resolve.conditions` section.

## Verification

`test/regression/issue/28851.test.ts` — 5 cases covering `bun run`, `bun test`, `bun build`, and CLI-plus-bunfig composition. All pass with the debug build; the bunfig-reliant ones fail under `USE_SYSTEM_BUN=1`, confirming the fix is what makes them green.
