### PR TITLE
Fix crash in forEachProperty when prototype chain contains a Proxy

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5364,7 +5364,11 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototypeValue = iterating->getPrototype(globalObject);
+            CLEAR_IF_EXCEPTION(scope);
+            if (!prototypeValue || !prototypeValue.isObject())
+                break;
+            iterating = asObject(prototypeValue);
         }
     }
 


### PR DESCRIPTION
## What

Fixes a crash (found by Fuzzilli, fingerprint `b0e67688d5557aff`) in `JSC__JSValue__forEachPropertyImpl` when walking the prototype chain of an object that has a Proxy installed as its prototype.

## Why

`JSObject::getPrototype()` can throw (e.g. via a Proxy's `getPrototypeOf` trap or any trap that runs during prototype resolution). When it does, it returns an empty `JSValue`. Calling `.getObject()` on an empty JSValue then triggers UBSAN (`member call on null pointer of type 'JSC::JSCell'`) because `isCell()` returns true for empty values (their encoded form is 0) but `asCell()` returns nullptr.

Minimal repro:
```js
const v = Bun.jest().expect({});
Object.setPrototypeOf(v, new Proxy(Object.getPrototypeOf(v), {}));
v.toContainKey(v); // throws, formatting the thrown value walks the prototype chain
```

## Fix

Clear any pending exception and check the returned value is a non-empty object before descending.