### PR TITLE
fix(stream): return empty blob when ByteBlobLoader store is detached

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,8 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    var empty: Blob.Any = .{ .Blob = Blob.initEmpty(globalThis) };
+    return empty.toPromise(globalThis, action);
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/test/js/web/fetch/stream-fast-path.test.ts
+++ b/test/js/web/fetch/stream-fast-path.test.ts
@@ -53,4 +53,16 @@ describe("ByteBlobLoader", () => {
     expect(result.then).toBeFunction();
     expect(async () => await result).toThrow();
   });
+
+  test("does not crash when the body's store was already detached", async () => {
+    // Consuming the Response drains the underlying blob store
+    // out from under the saved ReadableStream reference.
+    for (const method of ["text", "bytes", "blob"] as const) {
+      const resp = new Response("Hello World");
+      const body = resp.body!;
+      await resp.arrayBuffer();
+      // Should not crash, just return empty content.
+      await body[method]();
+    }
+  });
 });

--- a/test/js/web/fetch/stream-fast-path.test.ts
+++ b/test/js/web/fetch/stream-fast-path.test.ts
@@ -62,7 +62,10 @@ describe("ByteBlobLoader", () => {
       const body = resp.body!;
       await resp.arrayBuffer();
       // Should not crash, just return empty content.
-      await body[method]();
+      const value = await body[method]();
+      if (method === "text") expect(value).toBe("");
+      if (method === "bytes") expect((value as Uint8Array).byteLength).toBe(0);
+      if (method === "blob") expect((value as Blob).size).toBe(0);
     }
   });
 });


### PR DESCRIPTION
`BlobInternalReadableStreamSource`'s `textFromJS`/`arrayBufferFromJS`/`bytesFromJS`/`blobFromJS`/`jsonFromJS` call `ByteBlobLoader.toBufferedValue`. When the underlying blob store was already detached (e.g. because the Response was consumed via another path), `toAnyBlob` returns `null` and `toBufferedValue` returned `.zero` without throwing, tripping the `Expected an exception to be thrown` debug assertion.

Return an empty blob's promise instead, matching the behavior when reading a disturbed stream via a reader.

Repro:

```js
const resp = new Response("Hello World");
const body = resp.body;
await resp.arrayBuffer();
await body.text(); // used to crash in debug
```