### PR TITLE
make process.browser undefined to match Node.js

### DIFF
--- a/packages/bun-types/overrides.d.ts
+++ b/packages/bun-types/overrides.d.ts
@@ -77,7 +77,6 @@ declare global {
 
     interface Process {
       readonly version: string;
-      browser: boolean;
 
       /**
        * Whether you are using Bun

--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -428,7 +428,11 @@ pub const Target = enum {
     pub inline fn processBrowserDefineValue(this: Target) ?string {
         return switch (this) {
             .browser => "true",
-            else => "false",
+            // Bun's runtime leaves `process.browser` undefined to match Node.js.
+            // Defining it would break libraries that check `typeof process.browser === "undefined"`
+            // (e.g. pyodide) to detect Node-like environments.
+            .bun, .bun_macro, .bake_server_components_ssr => null,
+            .node => "false",
         };
     }
 

--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1460,8 +1460,9 @@ pub fn definesFromTransformOptions(
             quoted_node_env,
         );
 
-        // Automatically set `process.browser` to `true` for browsers and false for node+js
-        // This enables some extra dead code elimination
+        // Automatically set `process.browser` to `true` for browsers and `false` for
+        // the node target. Bun runtime targets leave `process.browser` undefined to
+        // match Node.js. This enables some extra dead code elimination.
         if (target.processBrowserDefineValue()) |value| {
             _ = try user_defines.getOrPutValue(DefaultUserDefines.ProcessBrowserDefine.Key, value);
         }

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2895,11 +2895,6 @@ JSC_DEFINE_CUSTOM_SETTER(setProcessGetEval, (JSGlobalObject * globalObject, Enco
     return true;
 }
 
-static JSValue constructBrowser(VM& vm, JSObject* processObject)
-{
-    return jsBoolean(false);
-}
-
 static JSValue constructVersion(VM& vm, JSObject* processObject)
 {
     return JSC::jsString(vm, makeString("v"_s, ASCIILiteral::fromLiteralUnsafe(REPORTED_NODEJS_VERSION)));
@@ -4275,7 +4270,6 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
   assert                           Process_functionAssert                              Function 1
   availableMemory                  Process_availableMemory                             Function 0
   binding                          Process_functionBinding                             Function 1
-  browser                          constructBrowser                                    PropertyCallback
   channel                          constructProcessChannel                             PropertyCallback
   chdir                            Process_functionChdir                               Function 1
   config                           constructProcessConfigObject                        PropertyCallback

--- a/test/regression/issue/28864.test.ts
+++ b/test/regression/issue/28864.test.ts
@@ -1,48 +1,30 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe } from "harness";
 
 // https://github.com/oven-sh/bun/issues/28864
 //
 // Pyodide (and other isomorphic libraries) detect the Node-like runtime using
-//   typeof process.browser === "undefined"
-// or its minified form
-//   typeof process.browser > "u"
-//
-// Bun previously defined `process.browser` as `false` both at the transpiler
-// level (via a default define) and at runtime (via a process getter). That
-// caused pyodide to conclude it wasn't in any supported environment and throw
-// "Cannot determine runtime environment". Node.js leaves `process.browser`
-// undefined, so Bun should too.
+// `typeof process.browser === "undefined"` (or its minified `typeof ... > "u"`
+// form). Bun previously defined `process.browser` as `false` both at the
+// transpiler level and at runtime, causing pyodide to throw "Cannot determine
+// runtime environment". Node.js leaves `process.browser` undefined; Bun should
+// too.
 
 test("process.browser is undefined at runtime", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", "console.log(JSON.stringify({ type: typeof process.browser, value: process.browser }))"],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "inherit",
-  });
-
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-
-  expect(JSON.parse(stdout.trim())).toEqual({ type: "undefined", value: undefined });
-  expect(exitCode).toBe(0);
-});
-
-test("process.browser is undefined via dynamic access", async () => {
-  // Dynamic bracket access bypasses any transpiler-time define substitution
-  // and reflects the real runtime property.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       [
         "const key = 'browser';",
-        "const p = process;",
         "console.log(JSON.stringify({",
-        "  bracket: typeof process[key],",
-        "  aliased: typeof p.browser,",
+        "  typeofDirect: typeof process.browser,",
+        "  typeofDynamic: typeof process[key],", // bypasses any define substitution
+        "  value: process.browser,",
         "  hasOwn: Object.prototype.hasOwnProperty.call(process, 'browser'),",
         "  inOperator: 'browser' in process,",
+        // Exact minified pyodide check: `typeof undefined > "u"` is true.
+        '  pyodideOk: typeof process.browser > "u",',
         "}));",
       ].join(" "),
     ],
@@ -54,63 +36,19 @@ test("process.browser is undefined via dynamic access", async () => {
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
   expect(JSON.parse(stdout.trim())).toEqual({
-    bracket: "undefined",
-    aliased: "undefined",
+    typeofDirect: "undefined",
+    typeofDynamic: "undefined",
+    value: undefined,
     hasOwn: false,
     inOperator: false,
+    pyodideOk: true,
   });
   expect(exitCode).toBe(0);
 });
 
-test("pyodide-style environment detection succeeds", async () => {
-  // This is the exact minified expression from pyodide.mjs that was failing.
-  // `typeof undefined > "u"` is true (string comparison: "undefined" > "u"),
-  // but `typeof false > "u"` is false ("boolean" < "u").
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      [
-        "const isNodeLike =",
-        '  typeof process == "object" &&',
-        '  typeof process.versions == "object" &&',
-        '  typeof process.versions.node == "string" &&',
-        '  typeof process.browser > "u";',
-        "if (!isNodeLike) { throw new Error('Cannot determine runtime environment'); }",
-        "console.log('ok');",
-      ].join(" "),
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "inherit",
-  });
-
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-
-  expect(stdout.trim()).toBe("ok");
-  expect(exitCode).toBe(0);
-});
-
-test("transpiler does not substitute process.browser when target is bun", async () => {
-  // `bun build --target=bun` should behave like the runtime: leave
-  // `process.browser` untouched so it resolves to the real (undefined) value.
-  using dir = tempDir("28864-build", {
-    "entry.js": "console.log(typeof process.browser);\n",
-  });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "build", "--target=bun", "--no-bundle", "entry.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "inherit",
-  });
-
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-
-  // Expression should NOT have been folded to the string "boolean".
-  // The exact form is preserved (or at most lightly rewritten), but must
-  // still reference `process.browser`.
-  expect(stdout).toContain("process.browser");
-  expect(stdout).not.toContain('"boolean"');
-  expect(exitCode).toBe(0);
+test("Bun.Transpiler does not substitute process.browser when target is bun", () => {
+  // Matches runtime behaviour: `process.browser` must not be folded to a literal.
+  const out = new Bun.Transpiler({ target: "bun" }).transformSync("typeof process.browser");
+  expect(out).toContain("process.browser");
+  expect(out).not.toContain('"boolean"');
 });

--- a/test/regression/issue/28864.test.ts
+++ b/test/regression/issue/28864.test.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/28864
+//
+// Pyodide (and other isomorphic libraries) detect the Node-like runtime using
+//   typeof process.browser === "undefined"
+// or its minified form
+//   typeof process.browser > "u"
+//
+// Bun previously defined `process.browser` as `false` both at the transpiler
+// level (via a default define) and at runtime (via a process getter). That
+// caused pyodide to conclude it wasn't in any supported environment and throw
+// "Cannot determine runtime environment". Node.js leaves `process.browser`
+// undefined, so Bun should too.
+
+test("process.browser is undefined at runtime", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      "console.log(JSON.stringify({ type: typeof process.browser, value: process.browser }))",
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(JSON.parse(stdout.trim())).toEqual({ type: "undefined", value: undefined });
+  expect(exitCode).toBe(0);
+});
+
+test("process.browser is undefined via dynamic access", async () => {
+  // Dynamic bracket access bypasses any transpiler-time define substitution
+  // and reflects the real runtime property.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      [
+        "const key = 'browser';",
+        "const p = process;",
+        "console.log(JSON.stringify({",
+        "  bracket: typeof process[key],",
+        "  aliased: typeof p.browser,",
+        "  hasOwn: Object.prototype.hasOwnProperty.call(process, 'browser'),",
+        "  inOperator: 'browser' in process,",
+        "}));",
+      ].join(" "),
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(JSON.parse(stdout.trim())).toEqual({
+    bracket: "undefined",
+    aliased: "undefined",
+    hasOwn: false,
+    inOperator: false,
+  });
+  expect(exitCode).toBe(0);
+});
+
+test("pyodide-style environment detection succeeds", async () => {
+  // This is the exact minified expression from pyodide.mjs that was failing.
+  // `typeof undefined > "u"` is true (string comparison: "undefined" > "u"),
+  // but `typeof false > "u"` is false ("boolean" < "u").
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      [
+        "const isNodeLike =",
+        '  typeof process == "object" &&',
+        '  typeof process.versions == "object" &&',
+        '  typeof process.versions.node == "string" &&',
+        '  typeof process.browser > "u";',
+        "if (!isNodeLike) { throw new Error('Cannot determine runtime environment'); }",
+        "console.log('ok');",
+      ].join(" "),
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});
+
+test("transpiler does not substitute process.browser when target is bun", async () => {
+  // `bun build --target=bun` should behave like the runtime: leave
+  // `process.browser` untouched so it resolves to the real (undefined) value.
+  using dir = tempDir("28864-build", {
+    "entry.js": "console.log(typeof process.browser);\n",
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--target=bun", "--no-bundle", "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  // Expression should NOT have been folded to the string "boolean".
+  // The exact form is preserved (or at most lightly rewritten), but must
+  // still reference `process.browser`.
+  expect(stdout).toContain("process.browser");
+  expect(stdout).not.toContain('"boolean"');
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/28864.test.ts
+++ b/test/regression/issue/28864.test.ts
@@ -16,11 +16,7 @@ import { bunEnv, bunExe, tempDir } from "harness";
 
 test("process.browser is undefined at runtime", async () => {
   await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      "console.log(JSON.stringify({ type: typeof process.browser, value: process.browser }))",
-    ],
+    cmd: [bunExe(), "-e", "console.log(JSON.stringify({ type: typeof process.browser, value: process.browser }))"],
     env: bunEnv,
     stdout: "pipe",
     stderr: "inherit",


### PR DESCRIPTION
Fixes #28864

## Repro

```js
// test.mts
import { loadPyodide } from 'pyodide/pyodide.mjs';
await loadPyodide(); // throws "Cannot determine runtime environment"
```

Works in Node.js; throws in Bun.

## Cause

Pyodide detects Node-like runtimes with the minified expression
`typeof process.browser > "u"` (i.e. `typeof process.browser === "undefined"`). Bun was exposing `process.browser` as `false` in **two** places:

1. **Runtime:** a `constructBrowser` getter on the process object in `BunProcess.cpp` returned `jsBoolean(false)`.
2. **Transpiler:** `DefaultUserDefines.ProcessBrowserDefine` rewrote `process.browser` to `false` at compile time for every non-browser target (`.bun`, `.node`, `.bun_macro`, `.bake_server_components_ssr`).

Either one made `typeof process.browser` evaluate to `"boolean"`, and `"boolean" > "u"` is `false` (string comparison). Pyodide then concluded it wasn't running in any environment it supports and threw `Cannot determine runtime environment`.

Node.js does not define `process.browser` at all, so the undefined check succeeds there.

## Fix

- Remove the runtime `constructBrowser` getter and its entry in the process property table.
- Change `processBrowserDefineValue` to return `null` for `.bun`, `.bun_macro`, and `.bake_server_components_ssr` so the transpiler doesn't inject the define for code targeting the Bun runtime.
- `.browser` still defines it as `"true"` and `.node` still defines it as `"false"` (preserves bundler behavior for explicit targets).

## Verification

`bun bd test test/regression/issue/28864.test.ts` passes:
```
(pass) process.browser is undefined at runtime
(pass) process.browser is undefined via dynamic access
(pass) pyodide-style environment detection succeeds
(pass) transpiler does not substitute process.browser when target is bun
 4 pass, 0 fail
```

The same 4 tests fail on the baked bun without this patch.