### PR TITLE
patch.zig: add --no-ext-diff to git invocation

### DIFF
--- a/src/patch.zig
+++ b/src/patch.zig
@@ -1249,6 +1249,7 @@ pub fn spawnOpts(
             "--irreversible-delete",
             "--full-index",
             "--no-index",
+            "--no-ext-diff",
         };
         const argv_buf = bun.handleOom(bun.default_allocator.alloc([]const u8, ARGV.len + 2));
         argv_buf[0] = git;
@@ -1381,6 +1382,7 @@ pub fn gitDiffInternal(
             "--irreversible-delete",
             "--full-index",
             "--no-index",
+            "--no-ext-diff",
             old_folder,
             new_folder,
         },


### PR DESCRIPTION
Necessary to get a sensible patch file for users with `diff.external` configured in Git, i.e. Difftastic.

This is a pretty minor change, but very necessary to make `bun patch --commit` work properly in the described case. Otherwise, you get a heavily malformed patch file from the diff tool unexpectedly being piped into a file. Difftastic could, and probably should, handle that case better, but Bun should also ensure it is getting a raw diff from Git.

### What does this PR do?

Add `--no-ext-diff` to all invocations of `git diff`

### How did you verify your code works?

I will admit I do not have the patience to locally build Bun, but this is a change that is of such small scope and clear action that I don't think it's necessary to do that.

`git diff | cat` produces (uncolored) Difftastic-style output, whereas `git diff --no-ext-diff | cat` produces a patch. That should be good enough.