### PR TITLE
build: keep zig local cache in buildDir

### DIFF
--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -143,7 +143,7 @@ function zigExecutable(cfg: Config): string {
  */
 function zigCacheDirs(cfg: Config): { local: string; global: string } {
   return {
-    local: resolve(cfg.cacheDir, "zig", "local"),
+    local: resolve(cfg.buildDir, "cache", "zig", "local"),
     global: resolve(cfg.cacheDir, "zig", "global"),
   };
 }


### PR DESCRIPTION
Zig's `--cache-dir` is per-project (default `./.zig-cache`) and holds the compiled `build.zig` runner plus project-specific compilation artifacts. #28846 pointed both local and global at the shared `cfg.cacheDir`; this keeps `local` under `cfg.buildDir` and leaves only `global` (stdlib, compiler_rt) shared.

Verified:
- `bunx tsc --noEmit -p scripts/build/tsconfig.json` clean
- `bun scripts/build.ts --configure-only` → `zig_local_cache` resolves to `build/debug/cache/zig/local`, `zig_global_cache` to `~/.bun/build-cache/zig/global`
- `bun bd --version` builds