### PR TITLE
deflake: fix 7 flaky tests with proper root-cause fixes

### DIFF
--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -443,6 +443,14 @@ describe("Bun.file in serve routes", () => {
     );
 
     it("memory usage stays reasonable", async () => {
+      // Warm up so one-time allocations (connection pool, file read buffers, response
+      // body buffers that the allocator retains) aren't counted as a leak. RSS rarely
+      // shrinks after GC on Linux, so the baseline must be taken at steady state.
+      for (let i = 0; i < 5; i++) {
+        const res = await fetch(new URL(`/large.txt`, server.url));
+        await res.text();
+      }
+
       Bun.gc(true);
       const baseline = (process.memoryUsage.rss() / 1024 / 1024) | 0;
 

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -191,8 +191,13 @@ describe("bun:jsc", () => {
       return fib(n - 1) + fib(n - 2);
     }
 
+    // After the JIT warms up fib() can finish within the default 1ms sample
+    // interval, yielding zero traces. Use a short interval so every call is
+    // sampled regardless of how fast the optimized code runs.
+    const sampleInterval = 50;
+
     // First profile call
-    const result1 = profile(() => fib(30));
+    const result1 = profile(() => fib(30), sampleInterval);
     expect(result1).toBeDefined();
     expect(result1.functions).toBeDefined();
     expect(result1.stackTraces).toBeDefined();
@@ -200,14 +205,14 @@ describe("bun:jsc", () => {
 
     // Second profile call - should work after first one completed
     // This verifies that shutdown() -> pause() fix works
-    const result2 = profile(() => fib(30));
+    const result2 = profile(() => fib(30), sampleInterval);
     expect(result2).toBeDefined();
     expect(result2.functions).toBeDefined();
     expect(result2.stackTraces).toBeDefined();
     expect(result2.stackTraces.traces.length).toBeGreaterThan(0);
 
     // Third profile call - verify profiler can be reused multiple times
-    const result3 = profile(() => fib(30));
+    const result3 = profile(() => fib(30), sampleInterval);
     expect(result3).toBeDefined();
     expect(result3.functions).toBeDefined();
     expect(result3.stackTraces).toBeDefined();

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1152,9 +1152,13 @@ describe.todoIf(isWindows)("Bun.spawn with terminal option", () => {
 
   test("existing terminal works with subprocess", async () => {
     const dataChunks: Uint8Array[] = [];
+    const { promise: gotData, resolve: gotDataResolve } = Promise.withResolvers<void>();
 
     await using terminal = new Bun.Terminal({
-      data: (_t, data) => dataChunks.push(data),
+      data: (_t, data) => {
+        dataChunks.push(data);
+        if (Buffer.concat(dataChunks).includes("hello")) gotDataResolve();
+      },
     });
 
     const proc = Bun.spawn(["echo", "hello"], { terminal });
@@ -1165,7 +1169,9 @@ describe.todoIf(isWindows)("Bun.spawn with terminal option", () => {
     await proc.exited;
     expect(proc.exitCode).toBe(0);
 
-    // Data should have been received
+    // PTY data is delivered asynchronously and may arrive after the child exits;
+    // wait for the data callback rather than assuming it already fired.
+    await gotData;
     const output = Buffer.concat(dataChunks).toString();
     expect(output).toContain("hello");
   });

--- a/test/js/web/fetch/chunked-trailing.test.js
+++ b/test/js/web/fetch/chunked-trailing.test.js
@@ -5,19 +5,21 @@ it("handles trailing headers split across packets", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
-      socket.write("5\r\nHello\r\n");
-      socket.write("7\r\n, world\r\n");
-      socket.write("0\r\n");
-      socket.uncork();
-      setTimeout(() => {
-        socket.write("X-Trail: ok\r\n");
-        socket.write('X-Quoted: "quoted value with \\"escapes\\""\r\n\r\n');
-        socket.end();
-      }, 10);
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
+        socket.write("5\r\nHello\r\n");
+        socket.write("7\r\n, world\r\n");
+        socket.write("0\r\n");
+        socket.uncork();
+        setTimeout(() => {
+          socket.write("X-Trail: ok\r\n");
+          socket.write('X-Quoted: "quoted value with \\"escapes\\""\r\n\r\n');
+          socket.end();
+        }, 10);
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -33,14 +35,16 @@ it("handles trailing headers in a single packet", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
-      socket.write("5\r\nHello\r\n");
-      socket.write("0\r\n");
-      socket.write("X-Trail: ok\r\n\r\n");
-      socket.end();
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
+        socket.write("5\r\nHello\r\n");
+        socket.write("0\r\n");
+        socket.write("X-Trail: ok\r\n\r\n");
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -56,13 +60,15 @@ it("handles trailing headers with empty body", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
-      socket.write("0\r\n");
-      socket.write("X-Trail: ok\r\n\r\n");
-      socket.end();
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
+        socket.write("0\r\n");
+        socket.write("X-Trail: ok\r\n\r\n");
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -78,16 +84,18 @@ it("handles multiple trailing headers", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
-      socket.write("5\r\nHello\r\n");
-      socket.write("0\r\n");
-      socket.write("X-Trail1: value1\r\n");
-      socket.write("X-Trail2: value2\r\n");
-      socket.write("X-Trail3: value3\r\n\r\n");
-      socket.end();
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
+        socket.write("5\r\nHello\r\n");
+        socket.write("0\r\n");
+        socket.write("X-Trail1: value1\r\n");
+        socket.write("X-Trail2: value2\r\n");
+        socket.write("X-Trail3: value3\r\n\r\n");
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -103,17 +111,19 @@ it("handles trailing headers with very long delay", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
-      socket.write("5\r\nHello\r\n");
-      socket.write("0\r\n");
-      socket.uncork();
-      setTimeout(() => {
-        socket.write("X-Trail: ok\r\n\r\n");
-        socket.end();
-      }, 100);
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
+        socket.write("5\r\nHello\r\n");
+        socket.write("0\r\n");
+        socket.uncork();
+        setTimeout(() => {
+          socket.write("X-Trail: ok\r\n\r\n");
+          socket.end();
+        }, 100);
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -129,28 +139,30 @@ it("handles trailing headers with byte-by-byte transmission", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
-      socket.write("5\r\nHello\r\n");
-      socket.write("0\r\n");
-      socket.uncork();
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
+        socket.write("5\r\nHello\r\n");
+        socket.write("0\r\n");
+        socket.uncork();
 
-      const trailer = "X-Trail: ok\r\n\r\n";
-      let i = 0;
+        const trailer = "X-Trail: ok\r\n\r\n";
+        let i = 0;
 
-      function writeNextByte() {
-        if (i < trailer.length) {
-          socket.write(trailer[i]);
-          i++;
-          setTimeout(writeNextByte, 5);
-        } else {
-          socket.end();
+        function writeNextByte() {
+          if (i < trailer.length) {
+            socket.write(trailer[i]);
+            i++;
+            setTimeout(writeNextByte, 5);
+          } else {
+            socket.end();
+          }
         }
-      }
 
-      setTimeout(writeNextByte, 10);
+        setTimeout(writeNextByte, 10);
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -166,14 +178,16 @@ it("handles trailing headers with malformed format (missing final CRLF)", async 
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
-      socket.write("5\r\nHello\r\n");
-      socket.write("0\r\n");
-      socket.write("X-Trail: ok\r\n"); // Missing final CRLF
-      socket.end();
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
+        socket.write("5\r\nHello\r\n");
+        socket.write("0\r\n");
+        socket.write("X-Trail: ok\r\n"); // Missing final CRLF
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -190,14 +204,16 @@ it("handles trailing headers with extremely large values", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
-      socket.write("5\r\nHello\r\n");
-      socket.write("0\r\n");
-      socket.write(`X-Large-Trail: ${largeValue}\r\n\r\n`);
-      socket.end();
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
+        socket.write("5\r\nHello\r\n");
+        socket.write("0\r\n");
+        socket.write(`X-Large-Trail: ${largeValue}\r\n\r\n`);
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -213,14 +229,16 @@ it("handles connection close during trailing headers", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
-      socket.write("5\r\nHello\r\n");
-      socket.write("0\r\n");
-      socket.write("X-Trail: partial\r\n");
-      socket.end(); // Close connection abruptly
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
+        socket.write("5\r\nHello\r\n");
+        socket.write("0\r\n");
+        socket.write("X-Trail: partial\r\n");
+        socket.end(); // Close connection abruptly
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -236,16 +254,18 @@ it("handles trailing headers with multiple header lines", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
-      socket.write("5\r\nHello\r\n");
-      socket.write("0\r\n");
-      socket.write("X-Trail-1: value1\r\n");
-      socket.write("X-Trail-2: value2\r\n");
-      socket.write("X-Trail-3: value3\r\n\r\n");
-      socket.end();
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
+        socket.write("5\r\nHello\r\n");
+        socket.write("0\r\n");
+        socket.write("X-Trail-1: value1\r\n");
+        socket.write("X-Trail-2: value2\r\n");
+        socket.write("X-Trail-3: value3\r\n\r\n");
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -261,14 +281,16 @@ it("handles trailing headers with empty values", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
-      socket.write("5\r\nHello\r\n");
-      socket.write("0\r\n");
-      socket.write("X-Empty-Trail: \r\n\r\n");
-      socket.end();
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
+        socket.write("5\r\nHello\r\n");
+        socket.write("0\r\n");
+        socket.write("X-Empty-Trail: \r\n\r\n");
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -284,18 +306,20 @@ it("handles delayed trailing headers", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
-      socket.write("5\r\nHello\r\n");
-      socket.write("0\r\n");
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
+        socket.write("5\r\nHello\r\n");
+        socket.write("0\r\n");
 
-      // Simulate delay before sending trailing headers
-      setTimeout(() => {
-        socket.write("X-Delayed-Trail: value\r\n\r\n");
-        socket.end();
-      }, 100);
+        // Simulate delay before sending trailing headers
+        setTimeout(() => {
+          socket.write("X-Delayed-Trail: value\r\n\r\n");
+          socket.end();
+        }, 100);
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -311,21 +335,23 @@ it("handles trailing headers after the final chunk only", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
 
-      // First chunk
-      socket.write("5\r\nHello\r\n");
+        // First chunk
+        socket.write("5\r\nHello\r\n");
 
-      // Second chunk
-      socket.write("5\r\nWorld\r\n");
+        // Second chunk
+        socket.write("5\r\nWorld\r\n");
 
-      // Final chunk with trailing headers
-      socket.write("0\r\n");
-      socket.write("X-Final-Trail: final\r\n\r\n");
-      socket.end();
+        // Final chunk with trailing headers
+        socket.write("0\r\n");
+        socket.write("X-Final-Trail: final\r\n\r\n");
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -341,15 +367,17 @@ it("handles chunked extensions with empty extension", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
 
-      // Chunk with empty extension
-      socket.write("5;\r\nHello\r\n");
-      socket.write("0\r\n\r\n");
-      socket.end();
+        // Chunk with empty extension
+        socket.write("5;\r\nHello\r\n");
+        socket.write("0\r\n\r\n");
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -365,15 +393,17 @@ it("handles chunked extensions with simple key", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
 
-      // Chunk with simple extension
-      socket.write("5;foo\r\nHello\r\n");
-      socket.write("0\r\n\r\n");
-      socket.end();
+        // Chunk with simple extension
+        socket.write("5;foo\r\nHello\r\n");
+        socket.write("0\r\n\r\n");
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -389,15 +419,17 @@ it("handles chunked extensions with key-value pair", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
 
-      // Chunk with key-value extension
-      socket.write("5;foo=bar\r\nHello\r\n");
-      socket.write("0\r\n\r\n");
-      socket.end();
+        // Chunk with key-value extension
+        socket.write("5;foo=bar\r\nHello\r\n");
+        socket.write("0\r\n\r\n");
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -413,15 +445,17 @@ it("handles chunked extensions with quoted value", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
 
-      // Chunk with quoted value extension
-      socket.write('5;foo="bar baz"\r\nHello\r\n');
-      socket.write("0\r\n\r\n");
-      socket.end();
+        // Chunk with quoted value extension
+        socket.write('5;foo="bar baz"\r\nHello\r\n');
+        socket.write("0\r\n\r\n");
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -437,20 +471,22 @@ it("handles chunked extensions on multiple chunks", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
 
-      // First chunk with extension
-      socket.write("5;ext=1\r\nHello\r\n");
+        // First chunk with extension
+        socket.write("5;ext=1\r\nHello\r\n");
 
-      // Second chunk with different extension
-      socket.write("5;ext=2\r\nWorld\r\n");
+        // Second chunk with different extension
+        socket.write("5;ext=2\r\nWorld\r\n");
 
-      // Final chunk with extension
-      socket.write("0;ext=final\r\n\r\n");
-      socket.end();
+        // Final chunk with extension
+        socket.write("0;ext=final\r\n\r\n");
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -466,19 +502,21 @@ it("handles chunked extensions with trailing headers", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
 
-      // Chunks with extensions
-      socket.write("5;ext=first\r\nHello\r\n");
-      socket.write("5;ext=second\r\nWorld\r\n");
+        // Chunks with extensions
+        socket.write("5;ext=first\r\nHello\r\n");
+        socket.write("5;ext=second\r\nWorld\r\n");
 
-      // Final chunk with extension and trailing headers
-      socket.write("0;ext=final\r\n");
-      socket.write("X-Trailer: value\r\n\r\n");
-      socket.end();
+        // Final chunk with extension and trailing headers
+        socket.write("0;ext=final\r\n");
+        socket.write("X-Trailer: value\r\n\r\n");
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -494,15 +532,17 @@ it("handles chunked extensions with special characters", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
 
-      // Extension with special characters in quoted value
-      socket.write('5;ext="!@#$%^&*()"\r\nHello\r\n');
-      socket.write("0\r\n\r\n");
-      socket.end();
+        // Extension with special characters in quoted value
+        socket.write('5;ext="!@#$%^&*()"\r\nHello\r\n');
+        socket.write("0\r\n\r\n");
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -518,16 +558,18 @@ it("proper error if missing zero-length chunk", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
 
-      // Valid chunk
-      socket.write("5\r\nHello\r\n");
+        // Valid chunk
+        socket.write("5\r\nHello\r\n");
 
-      // End the connection abruptly
-      socket.end();
+        // End the connection abruptly
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -547,19 +589,21 @@ it("proper error if missing data in middle of chunk extension", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
 
-      // Valid chunk
-      socket.write("5\r\nHello\r\n");
+        // Valid chunk
+        socket.write("5\r\nHello\r\n");
 
-      // Malformed chunk - missing CRLF after extension
-      socket.write("5;ext=foo");
+        // Malformed chunk - missing CRLF after extension
+        socket.write("5;ext=foo");
 
-      // End the connection abruptly
-      socket.end();
+        // End the connection abruptly
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());
@@ -578,19 +622,21 @@ it("proper error if missing CRLF after chunk data", async () => {
   const { promise, resolve } = Promise.withResolvers();
   await using server = net
     .createServer(socket => {
-      socket.write("HTTP/1.1 200 OK\r\n");
-      socket.write("Content-Type: text/plain\r\n");
-      socket.write("Transfer-Encoding: chunked\r\n");
-      socket.write("\r\n");
+      socket.once("data", () => {
+        socket.write("HTTP/1.1 200 OK\r\n");
+        socket.write("Content-Type: text/plain\r\n");
+        socket.write("Transfer-Encoding: chunked\r\n");
+        socket.write("\r\n");
 
-      // Valid chunk
-      socket.write("5\r\nHello\r\n");
+        // Valid chunk
+        socket.write("5\r\nHello\r\n");
 
-      // Malformed chunk - missing CRLF after chunk data
-      socket.write("5\r\nWorldX");
+        // Malformed chunk - missing CRLF after chunk data
+        socket.write("5\r\nWorldX");
 
-      // End the connection abruptly
-      socket.end();
+        // End the connection abruptly
+        socket.end();
+      });
     })
     .listen(0, "localhost", () => {
       resolve(server.address());


### PR DESCRIPTION
Each of these is a root-cause fix — no timeout increases, no threshold bumps.

| Test | Failure rate (last 200 CI builds) | Root cause | Fix |
|---|---|---|---|
| `chunked-trailing.test.js` | 19/200 (Windows) | Server writes response on `connection` before request arrives; closing with unread recv data sends RST on Windows → ECONNRESET | Wrap all 23 servers in `socket.once('data', ...)` |
| `fetch.upgrade.test.ts` | 33/200 (aarch64) | Read loop only exits on stream `done`, which the upgraded body may never signal; `resolve()` was called but loop kept awaiting `reader.read()` forever | Break loop and cancel reader on close frame |
| `fetch-proxy-tls-intern-race-fixture.ts` | 41/200 (Linux) | After probe loop floods proxy, driver's unbounded `fetch()` stalls so `await driverDone` never returns after `stop = true` | Abort in-flight driver fetch on shutdown; let driver complete one request before the probe flood so the `driverOk > 0` sanity check holds |
| `bun-jsc.test.ts` | 10/200 (macOS x64) | After JIT warmup `fib(30)` completes within the default 1ms sample interval → 0 traces on 3rd `profile()` call | Pass `sampleInterval = 50` µs |
| `terminal.test.ts` | 24/200 (Alpine) | PTY data callback is async; may fire after `proc.exited` resolves → empty output | Await the data callback via promise |
| `bun-serve-file.test.ts` | 41/200 (Alpine) | RSS baseline taken cold; first fetches allocate connection pool / read buffers that don't return to OS after GC | Warm up before baseline |

Verified locally: all files pass repeatedly (fetch.upgrade 8/8 including parallel stress, others 3/3+).

**Dropped from this PR:**
- `test-reporter.test.ts` — the gate-file approach still races on CI because the inspector's `TestReporter.enable` is dispatched via `postTaskTo` and may not drain while the child polls; A1 can end with `test_id_for_debugger=0` and emit no end event. Needs product-side work.
- Webview tests — handled by separate PR.