### PR TITLE
build: fix permanent cpp rebuild on Windows (host exe suffix)

### DIFF
--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -39,6 +39,8 @@ export type WebKitMode = "prebuilt" | "local";
 export interface Host {
   os: OS;
   arch: Arch;
+  /** ".exe" on a Windows host, "" elsewhere. Mirrors Config.exeSuffix (target). */
+  exeSuffix: string;
 }
 
 /**
@@ -315,7 +317,7 @@ export function detectHost(): Host {
             throw new BuildError(`Unsupported host architecture: ${a}`, { hint: "Bun builds on x64 or arm64" });
           })();
 
-  return { os, arch };
+  return { os, arch, exeSuffix: os === "windows" ? ".exe" : "" };
 }
 
 /**

--- a/scripts/build/download.ts
+++ b/scripts/build/download.ts
@@ -19,19 +19,23 @@
  * interrupted (ctrl-c, network drop, OOM), no partial file claims to be
  * complete. Next build retries from scratch.
  *
- * ## Why not stream to disk
+ * ## Streaming to disk
  *
- * We buffer the whole response in memory (`arrayBuffer()`) before writing.
- * For zig (~50MB) and dep tarballs (~few MB) this is fine. For WebKit
- * (~200MB) it's ~200MB peak memory. If that's ever a problem, switch to
- * `Bun.write(dest, res)` which streams. Haven't bothered because CI
- * machines have GBs of RAM and the whole download is a few seconds.
+ * Response body is piped to the temp file via `pipeline()` rather than
+ * buffered through `res.arrayBuffer()`. Under node on Windows arm64,
+ * `arrayBuffer()` on multi-MB responses intermittently fastfails the
+ * process (0xC0000409) — no exception, just gone. Streaming avoids the
+ * large native allocation and keeps peak memory flat regardless of
+ * tarball size (WebKit is ~200MB).
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { createWriteStream, existsSync, readFileSync } from "node:fs";
 import { mkdir, readdir, rename, rm, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { ReadableStream as NodeWebReadable } from "node:stream/web";
 import { BuildError, assert } from "./error.ts";
 
 /**
@@ -50,20 +54,22 @@ export async function downloadWithRetry(url: string, dest: string, logPrefix: st
       await new Promise(r => setTimeout(r, backoffMs));
     }
 
+    const tmpPath = `${dest}.${process.pid}.partial`;
     try {
       const res = await fetch(url, { headers: { "User-Agent": "bun-build-system" } });
-      if (!res.ok) {
+      if (!res.ok || res.body === null) {
         lastError = new BuildError(`HTTP ${res.status} ${res.statusText} for ${url}`);
         continue;
       }
 
-      const tmpPath = `${dest}.${process.pid}.partial`;
-      const buf = await res.arrayBuffer();
-      await writeFile(tmpPath, new Uint8Array(buf));
+      // Cast: DOM ReadableStream vs node:stream/web ReadableStream — same
+      // shape at runtime, different TS lib declarations.
+      await pipeline(Readable.fromWeb(res.body as unknown as NodeWebReadable), createWriteStream(tmpPath));
       await rename(tmpPath, dest);
       return;
     } catch (err) {
       lastError = err;
+      await rm(tmpPath, { force: true });
     }
   }
 

--- a/scripts/build/download.ts
+++ b/scripts/build/download.ts
@@ -69,7 +69,10 @@ export async function downloadWithRetry(url: string, dest: string, logPrefix: st
       return;
     } catch (err) {
       lastError = err;
-      await rm(tmpPath, { force: true });
+      // Swallow cleanup errors: on Windows, AV/indexer can briefly lock the
+      // partial; a failed unlink must not abort the retry loop. Next attempt's
+      // createWriteStream truncates anyway.
+      await rm(tmpPath, { force: true }).catch(() => {});
     }
   }
 

--- a/scripts/build/source.ts
+++ b/scripts/build/source.ts
@@ -1343,7 +1343,9 @@ function emitDirect(
   if (spec.codegen !== undefined) {
     const cg = spec.codegen;
     const toolSrc = resolve(srcDir, cg.tool);
-    const toolOut = resolve(buildDir, "codegen-tool");
+    // Host exe suffix: clang on Windows auto-appends .exe to `-o foo`, so
+    // the ninja output name must match or the edge is permanently dirty.
+    const toolOut = resolve(buildDir, `codegen-tool${cfg.host.exeSuffix}`);
 
     // Host tool: runs at build time to generate headers, so it must target
     // the BUILD host, not the bun target. cc()/link() add cfg's target/arch

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -132,10 +132,7 @@ function zigPath(cfg: Config): string {
 }
 
 function zigExecutable(cfg: Config): string {
-  // Host suffix — zig runs on the host. cfg.exeSuffix is target
-  // (windows target → .exe), wrong for cross-compile from linux.
-  const suffix = cfg.host.os === "windows" ? ".exe" : "";
-  return resolve(zigPath(cfg), "zig" + suffix);
+  return resolve(zigPath(cfg), "zig" + cfg.host.exeSuffix);
 }
 
 /**


### PR DESCRIPTION
## Summary
- On Windows, `bun run build` recompiled all ~570 cpp objects every run. Root cause: the DirectBuild codegen host-tool edge declared output `deps/tinycc/codegen-tool`, but clang writes `codegen-tool.exe`, so ninja saw the output as permanently missing and cascaded through `tccdefs_.h` → `tinycc.lib` → all cpp (implicit dep since #28858).
- Adds `Host.exeSuffix` (mirrors target-side `Config.exeSuffix`) and uses it for the codegen tool path and `zigExecutable()`.
- Streams dep tarball downloads to disk via `pipeline()` instead of buffering through `res.arrayBuffer()`. Under node on Windows arm64, `arrayBuffer()` on multi-MB responses was intermittently fastfailing the process (0xC0000409), killing the `dep_fetch` edge for a random dep. Streaming avoids the large native allocation and keeps peak memory flat (WebKit is ~200MB).

## Test plan
- [x] `bunx tsc --noEmit -p scripts/build/tsconfig.json`
- [x] Windows: `bun run build` twice → second run is `ninja: no work to do.`
- [x] `bun scripts/build.ts --configure-only` → `build.ninja` byte-identical on second configure
- [x] `downloadWithRetry` smoke test (highway tarball) under both `bun` and `node --experimental-strip-types` → identical 3,635,379-byte output, no `.partial` left behind