### PR TITLE
Fix crash when .blob() runs on a ByteBlobLoader with detached store

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,8 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    var empty: Blob.Any = .{ .Blob = Blob.initEmpty(globalThis) };
+    return empty.toPromise(globalThis, action);
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/test/js/web/streams/blob-stream-consumed.test.ts
+++ b/test/js/web/streams/blob-stream-consumed.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+
+// Regression test: after Response.bytes() internally detaches the underlying
+// ByteBlobLoader's store via toBlobIfPossible, the JS ReadableStream object
+// returned earlier from .body is still not JS-disturbed. A subsequent call to
+// .blob() on it hits the native fast path, invokes ByteBlobLoader.toBufferedValue
+// with store == null, and used to return an empty JSValue without throwing an
+// exception — crashing the process (segfault in release, assertion in debug).
+test("Response.body .blob() after Response.bytes() does not crash", async () => {
+  const res = new Response("hello world");
+  const body = res.body!;
+  // Internally calls toBlobIfPossible which detaches the ByteBlobLoader store
+  // but leaves the JS stream non-disturbed.
+  res.bytes();
+  // This previously crashed with "Expected an exception to be thrown" (or a
+  // segfault in release). It should now return a promise that settles cleanly.
+  const result = body.blob();
+  expect(result).toBeInstanceOf(Promise);
+  // Either resolves to a Blob or rejects with an error — either is acceptable.
+  // The only unacceptable outcome is a native crash.
+  await result.catch(() => {});
+});
+
+test("body.blob() after body then bytes returns a Blob-valued promise", async () => {
+  const res = new Response("hello world");
+  const body = res.body!;
+  res.bytes();
+  const blob = await body.blob();
+  expect(blob).toBeInstanceOf(Blob);
+});


### PR DESCRIPTION
Fingerprint: `80412156132e55e7`

When `Response.body`'s underlying `ByteBlobLoader` has its store detached (e.g. by `Response.bytes()` calling `toBlobIfPossible`), the JS `ReadableStream` is still not marked as disturbed. A subsequent `body.blob()` call hit the native fast path, invoked `ByteBlobLoader.toBufferedValue` with `store == null`, and returned `.zero` without throwing — tripping `Expected an exception to be thrown` (segfault in release).

Return an empty-blob promise in that case.

### Repro
```js
const res = new Response("hello");
const body = res.body;
res.bytes();
body.blob(); // was crashing
```