### PR TITLE
Throw Body already used when ByteBlobLoader store is detached

### DIFF
--- a/test/js/web/fetch/body-mixin-errors.test.ts
+++ b/test/js/web/fetch/body-mixin-errors.test.ts
@@ -28,7 +28,14 @@ describe("body-mixin-errors", () => {
       const response = new Response("<html><body><h1>Test</h1></body></html>");
       const body = response.body!;
       response.bytes();
-      await expect((body as any)[method]()).rejects.toThrow("Body already used");
+      try {
+        await (body as any)[method]();
+        expect.unreachable("body is already used");
+      } catch (err: any) {
+        expect(err.name).toBe("TypeError");
+        expect(err.message).toBe("Body already used");
+        expect(err instanceof TypeError).toBe(true);
+      }
     },
   );
 });

--- a/test/js/web/fetch/body-mixin-errors.test.ts
+++ b/test/js/web/fetch/body-mixin-errors.test.ts
@@ -21,4 +21,14 @@ describe("body-mixin-errors", () => {
       expect(err instanceof TypeError).toBe(true);
     }
   });
+
+  it.concurrent.each(["json", "text", "bytes", "blob"])(
+    "should reject ReadableStream.%s() after underlying body blob was consumed",
+    async method => {
+      const response = new Response("<html><body><h1>Test</h1></body></html>");
+      const body = response.body!;
+      response.bytes();
+      await expect((body as any)[method]()).rejects.toThrow("Body already used");
+    },
+  );
 });


### PR DESCRIPTION
Calling `ReadableStream.prototype.json()` (and `text()`/`bytes()`/`blob()`) on the body of a `Response` backed by a Blob after the Response body has already been consumed via another API (e.g. `response.bytes()`) would hit `toBufferedValue` in `ByteBlobLoader.zig` where the store was already detached. The function returned `.zero` without throwing, triggering the 'Expected an exception to be thrown' panic.

The Response's consumer methods swap the body to a Blob via `toBlobIfPossible` which detaches the store on the underlying stream source, but the ReadableStream itself wasn't yet marked as disturbed by that JS-side path, so the buffered fast path in `tryUseReadableStreamBufferedFastPath` ended up calling the native `BlobInternalReadableStreamSource.prototype.json()` on a store-less source.

Now returns a rejected promise with `ERR_BODY_ALREADY_USED` to match the behavior of `Body.handleBodyAlreadyUsed`.

Repro:
```js
const r = new Response('hello');
const body = r.body;
r.bytes();
await body.json();  // used to panic, now rejects with TypeError: Body already used
```