### PR TITLE
Return empty promise from ByteBlobLoader.toBufferedValue when store is null

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,8 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    var empty: Blob.Any = .{ .InternalBlob = .{ .bytes = .init(bun.default_allocator), .was_string = action == .text } };
+    return empty.toPromise(globalThis, action);
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -254,3 +254,12 @@ test("#12894", () => {
   const bunFile = Bun.file("foo.txt");
   expect(new File([bunFile], "bar.txt").name).toBe("bar.txt");
 });
+
+test("Blob.prototype.stream().text() called twice does not crash", async () => {
+  const blob = new Blob(["hello"]);
+  const stream = blob.stream();
+  const first = stream.text();
+  const second = stream.text();
+  expect(await first).toBe("hello");
+  expect(await second).toBe("");
+});


### PR DESCRIPTION
Fixes a Fuzzilli-found crash where `ByteBlobLoader.toBufferedValue` returned `.zero` without setting an exception when the underlying store had already been cleared.

This failed the `toJSHostCall` assertion (`Expected an exception to be thrown`) because the host-call ABI requires an empty return value to be paired with a pending exception.

When the store is `null` (i.e. the Blob-backed stream has already been drained via `onPull` or detached by a previous `toAnyBlob` call) and `text()`/`arrayBuffer()`/`blob()`/`bytes()`/`json()` is invoked on the native source, return a resolved promise with an empty value via an empty `InternalBlob` instead of an empty JS value.

Fingerprint: `0ac4a46ca78f2d41`