### PR TITLE
test: run proxy/syntax test blocks concurrently

### DIFF
--- a/test/cli/run/syntax.test.ts
+++ b/test/cli/run/syntax.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
-import { join } from "path";
 
 const exitCode0 = [
   " ",
@@ -301,21 +300,20 @@ const exitCode0 = [
   "(()=>{let{a=b,b=1}={}})",
 ];
 
-describe("exit code 0", () => {
+describe.concurrent("exit code 0", () => {
   const fixturePath = tempDirWithFiles("fixture", {
     [`package.json`]: `{
       "name": "test",
 
     }`,
-    "fixture.js": "export default 1",
+    ...Object.fromEntries(exitCode0.map((source, i) => [`fixture-${i}.js`, source])),
   });
 
   for (let i = 0; i < exitCode0.length; i++) {
     const source = exitCode0[i];
 
     test(`file #${i}: ${JSON.stringify(source)}`, async () => {
-      await Bun.write(join(fixturePath, "fixture.js"), source);
-      await using proc = Bun.spawn([bunExe(), "./fixture.js"], {
+      await using proc = Bun.spawn([bunExe(), `./fixture-${i}.js`], {
         stdout: "inherit",
         env: bunEnv,
         cwd: fixturePath,

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -113,33 +113,36 @@ afterAll(() => {
 for (const proxy_tls of [false, true]) {
   for (const target_tls of [false, true]) {
     for (const body of [undefined, "Hello, World"]) {
-      test(`${body === undefined ? "GET" : "POST"} ${proxy_tls ? "TLS" : "non-TLS"} proxy -> ${target_tls ? "TLS" : "non-TLS"} body type ${typeof body}`, async () => {
-        const response = await fetch(target_tls ? httpsServer.url : httpServer.url, {
-          method: body === undefined ? "GET" : "POST",
-          proxy: proxy_tls ? httpsProxyServer.url : httpProxyServer.url,
-          headers: {
-            "Content-Type": "plain/text",
-          },
-          keepalive: false,
-          body: body,
-          tls: {
-            ca: tlsCert.cert,
-            rejectUnauthorized: false,
-          },
-        });
-        expect(response.ok).toBe(true);
-        expect(response.status).toBe(200);
-        expect(response.statusText).toBe("OK");
-        const result = await response.text();
+      test.concurrent(
+        `${body === undefined ? "GET" : "POST"} ${proxy_tls ? "TLS" : "non-TLS"} proxy -> ${target_tls ? "TLS" : "non-TLS"} body type ${typeof body}`,
+        async () => {
+          const response = await fetch(target_tls ? httpsServer.url : httpServer.url, {
+            method: body === undefined ? "GET" : "POST",
+            proxy: proxy_tls ? httpsProxyServer.url : httpProxyServer.url,
+            headers: {
+              "Content-Type": "plain/text",
+            },
+            keepalive: false,
+            body: body,
+            tls: {
+              ca: tlsCert.cert,
+              rejectUnauthorized: false,
+            },
+          });
+          expect(response.ok).toBe(true);
+          expect(response.status).toBe(200);
+          expect(response.statusText).toBe("OK");
+          const result = await response.text();
 
-        expect(result).toBe(body || "");
-      });
+          expect(result).toBe(body || "");
+        },
+      );
     }
   }
 }
 
 for (const server_tls of [false, true]) {
-  describe(`proxy can handle redirects with ${server_tls ? "TLS" : "non-TLS"} server`, () => {
+  describe.concurrent(`proxy can handle redirects with ${server_tls ? "TLS" : "non-TLS"} server`, () => {
     test("with empty body #12007", async () => {
       using server = Bun.serve({
         tls: server_tls ? tlsCert : undefined,
@@ -561,7 +564,7 @@ test("HTTPS origin close-delimited body via HTTP proxy does not ECONNRESET", asy
   }
 });
 
-describe("proxy object format with headers", () => {
+describe.concurrent("proxy object format with headers", () => {
   test("proxy object with url string works same as string proxy", async () => {
     const response = await fetch(httpServer.url, {
       method: "GET",


### PR DESCRIPTION
Part of a sweep to reduce per-platform test wall-clock by adding `.concurrent` where tests are already isolated.

**`test/js/bun/http/proxy.test.ts`** — mark three stateless blocks concurrent:
- the 2×2×2 proxy/target/body matrix (each test is a single fetch against the shared stateless proxy/origin servers with `keepalive: false`)
- both `proxy can handle redirects` describes (each test owns its server via `using server = Bun.serve(...)`)
- the `proxy object format with headers` describe (independent servers or stateless use of the shared proxy; no `.log` assertions)

The keep-alive ordering tests (which assert on `httpProxyServer.log`) and the large-body TLS-order test stay serial.

**`test/cli/run/syntax.test.ts`** — the `exit code 0` describe previously overwrote a single `fixture.js` per test, which forced serial execution. Write each source to its own `fixture-${i}.js` up front so nothing shares a path, then run the whole describe concurrently.

Measured locally (release bun, darwin-aarch64): proxy 20.2s → 6.5s, syntax 8.3s → 4.5s. Identical pass/fail counts on both release and debug builds.