### PR TITLE
Fix null deref in forEachProperty when Proxy prototype throws

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5238,7 +5238,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototype" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = proto ? proto.getObject() : nullptr;
         }
     }
 

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -1834,6 +1834,7 @@ extern "C" napi_status napi_get_all_property_names(
                 // Climb up the prototype chain to find inherited properties
                 JSObject* current_object = object;
                 while (!current_object->getOwnPropertyDescriptor(globalObject, key.toPropertyKey(globalObject), desc)) {
+                    NAPI_RETURN_IF_EXCEPTION(env);
                     JSValue protoVal = current_object->getPrototype(globalObject);
                     // Ignore exceptions from Proxy "getPrototype" trap.
                     CLEAR_IF_EXCEPTION(napi_preamble_throw_scope__);

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -1834,7 +1834,10 @@ extern "C" napi_status napi_get_all_property_names(
                 // Climb up the prototype chain to find inherited properties
                 JSObject* current_object = object;
                 while (!current_object->getOwnPropertyDescriptor(globalObject, key.toPropertyKey(globalObject), desc)) {
-                    JSObject* proto = current_object->getPrototype(globalObject).getObject();
+                    JSValue protoVal = current_object->getPrototype(globalObject);
+                    // Ignore exceptions from Proxy "getPrototype" trap.
+                    CLEAR_IF_EXCEPTION(napi_preamble_throw_scope__);
+                    JSObject* proto = protoVal ? protoVal.getObject() : nullptr;
                     if (!proto) {
                         break;
                     }

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -451,6 +451,17 @@ const fixture = [
         },
       },
     ),
+  () => {
+    const obj = { a: 1 };
+    Object.setPrototypeOf(obj, new Proxy(Object.getPrototypeOf(obj), {}));
+    return obj;
+  },
+  () => {
+    const v1 = Bun.jest();
+    const v2 = v1.expect(v1);
+    Object.setPrototypeOf(v2, new Proxy(Object.getPrototypeOf(v2), {}));
+    return v2;
+  },
 ];
 
 describe("crash testing", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -456,12 +456,6 @@ const fixture = [
     Object.setPrototypeOf(obj, new Proxy(Object.getPrototypeOf(obj), {}));
     return obj;
   },
-  () => {
-    const v1 = Bun.jest(Bun.fileURLToPath(import.meta.url));
-    const v2 = v1.expect(v1);
-    Object.setPrototypeOf(v2, new Proxy(Object.getPrototypeOf(v2), {}));
-    return v2;
-  },
 ];
 
 describe("crash testing", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -457,7 +457,7 @@ const fixture = [
     return obj;
   },
   () => {
-    const v1 = Bun.jest();
+    const v1 = Bun.jest(Bun.fileURLToPath(import.meta.url));
     const v2 = v1.expect(v1);
     Object.setPrototypeOf(v2, new Proxy(Object.getPrototypeOf(v2), {}));
     return v2;

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -453,7 +453,14 @@ const fixture = [
     ),
   () => {
     const obj = { a: 1 };
-    Object.setPrototypeOf(obj, new Proxy(Object.getPrototypeOf(obj), {}));
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(Object.getPrototypeOf(obj), {
+        getPrototypeOf() {
+          throw new Error("boom");
+        },
+      }),
+    );
     return obj;
   },
 ];


### PR DESCRIPTION
When iterating prototypes in \`JSC__JSValue__forEachPropertyImpl\`, calling \`getPrototype()\` on an object with a Proxy in the chain can throw, returning an empty \`JSValue\`. Calling \`.getObject()\` on that empty value hits UBSan as a member call on a null \`JSCell*\` (the tag bits of an empty JSValue match \`isCell()\` but the pointer is null).

The fast path above (~line 5121) already guards against this with the same pattern. Mirror it in the slow path: clear the exception, and treat an empty prototype as "no more prototypes to visit".

Repro:
\`\`\`js
const v1 = Bun.jest();
const v2 = v1.expect(v1);
Object.setPrototypeOf(v2, new Proxy(Object.getPrototypeOf(v2), {}));
Bun.inspect(v2);
\`\`\`

Fixes a Fuzzilli-found crash (fingerprint \`147521e6b763081c\`).