### PR TITLE
fix: remove unused mode argument from open() without O_CREAT in bsd.c

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1132,7 +1132,7 @@ static LIBUS_SOCKET_DESCRIPTOR bsd_create_unix_socket_address(const char *path, 
             memcpy(dirname_buf, path, dirname_len);
             dirname_buf[dirname_len] = 0;
 
-            int socket_dir_fd = open(dirname_buf, O_CLOEXEC | O_PATH | O_DIRECTORY, 0700);
+            int socket_dir_fd = open(dirname_buf, O_CLOEXEC | O_PATH | O_DIRECTORY);
             if (socket_dir_fd == -1) {
                 errno = ENAMETOOLONG;
                 return LIBUS_SOCKET_ERROR;


### PR DESCRIPTION
The `open()` call in `bsd_create_unix_socket_address` passes a mode argument (`0700`) but the flags don't include `O_CREAT` or `O_TMPFILE`. Per POSIX, the mode argument is only meaningful when `O_CREAT` or `O_TMPFILE` is specified.

On most platforms this is harmless (the argument is ignored), but it is technically undefined behavior for variadic function calls and causes issues on Android/Bionic where the extra variadic argument is handled more strictly.

### What does this PR do?

Removes the unused `0700` mode argument from the `open()` call in `bsd_create_unix_socket_address()` that only uses `O_CLOEXEC | O_PATH | O_DIRECTORY` flags.

### How did you verify your code works?

Discovered while cross-compiling Bun for Android/aarch64 (Termux). The extra variadic argument caused issues on Bionic's stricter `open()` implementation. After removing it, the Unix socket path-length workaround works correctly on Android. The fix is also correct on all other platforms since the mode was already being ignored.