### PR TITLE
fix(windows): normalize backslashes in html dev server routes

### DIFF
--- a/src/js/internal/html.ts
+++ b/src/js/internal/html.ts
@@ -140,7 +140,7 @@ yourself with Bun.serve().
     return acc.slice(0, i);
   });
 
-  if (path.platform === "win32") {
+  if (process.platform === "win32") {
     longestCommonPath = longestCommonPath.replaceAll("\\", "/");
   }
 
@@ -165,7 +165,10 @@ yourself with Bun.serve().
     if (servePath.startsWith(longestCommonPath)) {
       servePath = servePath.slice(longestCommonPath.length);
     } else {
-      const relative = path.relative(longestCommonPath, servePath);
+      let relative = path.relative(longestCommonPath, servePath);
+      if (process.platform === "win32") {
+        relative = relative.replaceAll("\\", "/");
+      }
       if (!relative.startsWith("..")) {
         servePath = relative;
       }

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1,6 +1,6 @@
 import type { Server, Subprocess } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 function replaceHash(html: string) {
@@ -908,3 +908,51 @@ for (let development of [true, false, { hmr: false }]) {
     }
   });
 }
+
+test("html cli entry point routes use forward slashes for subdirectories", async () => {
+  using dir = tempDir("html-subdir-routes", {
+    "index.html": `<!DOCTYPE html><html><head><title>Home</title></head><body>Home</body></html>`,
+    demos: {
+      "bubbles.html": `<!DOCTYPE html><html><head><title>Bubbles</title></head><body>Bubbles</body></html>`,
+    },
+  });
+
+  const indexPath = join(String(dir), "index.html");
+  const bubblesPath = join(String(dir), "demos", "bubbles.html");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), indexPath, bubblesPath, "--port=0"],
+    env: { ...bunEnv, NODE_ENV: "production" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const reader = proc.stdout.getReader();
+  const decoder = new TextDecoder();
+  let output = "";
+  let baseUrl: string | undefined;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    output += decoder.decode(value, { stream: true });
+    const match = output.match(/https?:\/\/[^\s\x1b]+/);
+    if (match) {
+      baseUrl = match[0];
+      reader.releaseLock();
+      break;
+    }
+  }
+
+  expect(baseUrl).toBeDefined();
+
+  const response = await fetch(new URL("/demos/bubbles", baseUrl));
+  expect(response.status).toBe(200);
+  const html = await response.text();
+  expect(html).toContain("<title>Bubbles</title>");
+
+  const indexResponse = await fetch(new URL("/", baseUrl));
+  expect(indexResponse.status).toBe(200);
+  const indexHtml = await indexResponse.text();
+  expect(indexHtml).toContain("<title>Home</title>");
+});


### PR DESCRIPTION
Fixes #24031

### What does this PR do?

Fixes HTML dev server routes having backslashes on Windows (e.g. `/demos\test` instead of `/demos/test`).

The root cause is line 143 in `src/js/internal/html.ts` checking `path.platform === "win32"` to decide whether to normalize backslashes. `path.platform` doesn't exist on the `node:path` module, it's always `undefined`, so the normalization never runs. Should be `process.platform`.

Also normalizes the output of `path.relative()` in the fallback branch, since `path.win32.relative` always returns backslashes.

See also #24179 which identified the `path.relative` part of this.

### How did you verify your code works?

Added a test that spawns bun with HTML files in subdirectories and verifies routes use forward slashes. Test passes on the debug build and fails on the current release (1.3.11).

```
bun bd test test/js/bun/http/bun-serve-html.test.ts -t "html cli entry point routes use forward slashes"
```