### PR TITLE
Return a regular Promise from Response body consumers for async-iterable bodies

### DIFF
--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -112,7 +112,7 @@ export function readableStreamToArray(stream: ReadableStream): Promise<unknown[]
   // this is a direct stream
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
   if (underlyingSource != null) {
-    return $readableStreamToArrayDirect(stream, underlyingSource);
+    return Promise.$resolve($readableStreamToArrayDirect(stream, underlyingSource));
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
   return $readableStreamIntoArray(stream);
@@ -124,7 +124,7 @@ export function readableStreamToText(stream: ReadableStream): Promise<string> {
   // this is a direct stream
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
   if (underlyingSource != null) {
-    return $readableStreamToTextDirect(stream, underlyingSource);
+    return Promise.$resolve($readableStreamToTextDirect(stream, underlyingSource));
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
 
@@ -143,7 +143,7 @@ export function readableStreamToArrayBuffer(stream: ReadableStream<ArrayBuffer>)
   // this is a direct stream
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
   if (underlyingSource != null) {
-    return $readableStreamToArrayBufferDirect(stream, underlyingSource, false);
+    return Promise.$resolve($readableStreamToArrayBufferDirect(stream, underlyingSource, false));
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
 
@@ -224,7 +224,7 @@ export function readableStreamToBytes(stream: ReadableStream<ArrayBuffer>): Prom
   var underlyingSource = $getByIdDirectPrivate(stream, "underlyingSource");
 
   if (underlyingSource != null) {
-    return $readableStreamToArrayBufferDirect(stream, underlyingSource, true);
+    return Promise.$resolve($readableStreamToArrayBufferDirect(stream, underlyingSource, true));
   }
   if ($isReadableStreamLocked(stream)) return Promise.$reject($ERR_INVALID_STATE_TypeError("ReadableStream is locked"));
 

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2321,7 +2321,7 @@ export function readableStreamToArrayBufferDirect(
   }
 
   $assert($isPromise(firstPull));
-  return firstPull.then(
+  return Promise.$resolve(firstPull).$then(
     () => {
       if (!didError && stream) {
         $putByIdDirectPrivate(stream, "reader", undefined);

--- a/test/js/web/fetch/response-body-promise-type.test.ts
+++ b/test/js/web/fetch/response-body-promise-type.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+
+// Regression: Response body from an async-iterable source used to return an
+// InternalPromise from .bytes()/.text()/.json()/.arrayBuffer(), leaking JSC's
+// internal promise to user space.
+function makeAsyncIterableBody() {
+  async function* gen() {
+    yield new Uint8Array([104, 105]); // "hi"
+  }
+  return gen();
+}
+
+for (const method of ["bytes", "text", "json", "arrayBuffer"] as const) {
+  test(`Response.${method}() returns a regular Promise for async-iterable body`, async () => {
+    const res = new Response(makeAsyncIterableBody() as any);
+    const p = res[method]();
+    expect(p.constructor).toBe(Promise);
+    try {
+      await p;
+    } catch {}
+  });
+}
+
+for (const method of ["bytes", "text", "json"] as const) {
+  test(`ReadableStream.${method}() returns a regular Promise for async-iterable body`, async () => {
+    const res = new Response(makeAsyncIterableBody() as any);
+    const p = (res.body as any)[method]();
+    expect(p.constructor).toBe(Promise);
+    try {
+      await p;
+    } catch {}
+  });
+}


### PR DESCRIPTION
Fixes a crash where `Response.bytes()` (and `.arrayBuffer()`) returned an `InternalPromise` — a JSC-internal class that must not leak to user code — when the body was constructed from an async iterable.

Fuzzilli reached this via:

```js
function* gen() { return 1; }
gen[Symbol.asyncIterator] = gen;
const promise = new Response(gen).bytes();
promise.constructor.internalAll(1); // ASSERTION FAILED: array
```

The leak was in `readableStreamToArrayBufferDirect`: `firstPull.then(...)` carried the constructor of `firstPull` through. Wrapping the pull result in `Promise.$resolve` ensures the returned promise is always a regular `Promise`.

Fingerprint: `JSInternalPromiseConstructor.cpp(100)`