### PR TITLE
fix(fetch): accept URL objects in proxy.url

### DIFF
--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -668,14 +668,15 @@ fn fetchImpl(
                         allocator.free(url_proxy_buffer);
                         break :extract_proxy buffer;
                     }
-                    // Handle object format: proxy: { url: "http://proxy.example.com:8080", headers?: Headers }
+                    // Handle object format: proxy: { url: "http://proxy.example.com:8080" | URL, headers?: Headers }
                     // If the proxy object doesn't have a 'url' property, ignore it.
                     // This handles cases like passing a URL object directly as proxy (which has 'href' not 'url').
                     if (proxy_arg.isObject()) {
                         // Get the URL from the proxy object
                         if (try proxy_arg.get(globalThis, "url")) |proxy_url_arg| {
                             if (!proxy_url_arg.isUndefinedOrNull()) {
-                                if (proxy_url_arg.isString() and try proxy_url_arg.getLength(ctx) > 0) {
+                                const proxy_url_is_string = proxy_url_arg.isString() and try proxy_url_arg.getLength(ctx) > 0;
+                                if (proxy_url_is_string or proxy_url_arg.as(jsc.DOMURL) != null) {
                                     var href = try jsc.URL.hrefFromJS(proxy_url_arg, globalThis);
                                     if (href.tag == .Dead) {
                                         const err = ctx.toTypeError(.INVALID_ARG_VALUE, "fetch() proxy URL is invalid", .{});

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -574,6 +574,26 @@ describe("proxy object format with headers", () => {
     expect(response.status).toBe(200);
   });
 
+  test("proxy object with URL url works", async () => {
+    httpProxyServer.log.length = 0;
+
+    const response = await fetch(httpsServer.url, {
+      method: "GET",
+      proxy: {
+        url: new URL(httpProxyServer.url),
+      } as any,
+      keepalive: false,
+      tls: {
+        ca: tlsCert.cert,
+        rejectUnauthorized: false,
+      },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(response.status).toBe(200);
+    expect(httpProxyServer.log).toEqual([`CONNECT localhost:${httpsServer.port}`]);
+  });
+
   test("proxy object with url and headers sends headers to proxy (HTTP proxy)", async () => {
     // Create a proxy server that captures headers
     const capturedHeaders: string[] = [];


### PR DESCRIPTION
Fixes https://github.com/oven-sh/bun/issues/29103

## Summary
- accept `proxy: { url: new URL(...) }` in the fetch proxy object parser
- restore compatibility with nested proxy URLs produced by proxy-agent style stacks
- add a regression test that proves the request actually traverses the proxy

## Testing
- `bun test test/js/bun/http/proxy.test.ts -t "proxy object with URL url works"` on stable Bun 1.3.11 fails with `fetch() proxy.url must be a non-empty string`
- `bun scripts/runner.node.mjs --exec-path ./build/debug/bun-debug.exe js/bun/http/proxy.test.ts`