### PR TITLE
Skip iteration when inspecting WeakMap/WeakSet

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -2747,14 +2747,19 @@ pub const Formatter = struct {
                 writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
             },
             .Map => {
+                const is_weak = value.jsType() == .WeakMap;
+                const map_name = if (is_weak) "WeakMap" else "Map";
+
+                if (is_weak) {
+                    return writer.print("{s} {{ <items unknown> }}", .{map_name});
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
-
-                const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{map_name});
@@ -2854,14 +2859,19 @@ pub const Formatter = struct {
                 writer.writeAll("}");
             },
             .Set => {
+                const is_weak = value.jsType() == .WeakSet;
+                const set_name = if (is_weak) "WeakSet" else "Set";
+
+                if (is_weak) {
+                    return writer.print("{s} {{ <items unknown> }}", .{set_name});
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
-
-                const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{set_name});

--- a/src/bun.js/test/diff_format.zig
+++ b/src/bun.js/test/diff_format.zig
@@ -43,7 +43,9 @@ pub const DiffFormatter = struct {
                 1,
                 &received_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                _ = this.globalThis.clearExceptionExceptTermination();
+            };
 
             JestPrettyFormat.format(
                 .Debug,
@@ -52,7 +54,9 @@ pub const DiffFormatter = struct {
                 1,
                 &expected_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                _ = this.globalThis.clearExceptionExceptTermination();
+            };
         }
 
         var received_slice = received_buf.written();

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -1309,14 +1309,19 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
                 },
                 .Map => {
+                    const is_weak = value.jsType() == .WeakMap;
+                    const map_name = if (is_weak) "WeakMap" else "Map";
+
+                    if (is_weak) {
+                        return writer.print("{s} {{}}", .{map_name});
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
                     const prev_quote_strings = this.quote_strings;
                     this.quote_strings = true;
                     defer this.quote_strings = prev_quote_strings;
-
-                    const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{map_name});
@@ -1337,6 +1342,14 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll("\n");
                 },
                 .Set => {
+                    const is_weak = value.jsType() == .WeakSet;
+                    const set_name = if (is_weak) "WeakSet" else "Set";
+
+                    if (is_weak) {
+                        this.writeIndent(Writer, writer_) catch {};
+                        return writer.print("{s} {{}}", .{set_name});
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
@@ -1345,8 +1358,6 @@ pub const JestPrettyFormat = struct {
                     defer this.quote_strings = prev_quote_strings;
 
                     this.writeIndent(Writer, writer_) catch {};
-
-                    const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{set_name});

--- a/test/js/bun/test/expect-toMatchObject-weakmap-crash.test.ts
+++ b/test/js/bun/test/expect-toMatchObject-weakmap-crash.test.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("toMatchObject with a WeakMap that has a size property does not leak an exception", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const v4 = new WeakMap();
+      v4.size = 2;
+      try { Bun.jest().expect(v4).toMatchObject(new Int16Array(2)); } catch {}
+    `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("");
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(exitCode).toBe(0);
+});
+
+test("toMatchObject with a WeakSet that has a size property does not leak an exception", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const v4 = new WeakSet();
+      v4.size = 2;
+      try { Bun.jest().expect(v4).toMatchObject(new Int16Array(2)); } catch {}
+    `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("");
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(exitCode).toBe(0);
+});
+
+test("console.log does not throw on a WeakMap with a size property", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const v4 = new WeakMap();
+      v4.size = 2;
+      console.log(v4);
+    `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("WeakMap");
+  expect(stderr).not.toContain("TypeError");
+  expect(exitCode).toBe(0);
+});
+
+test("console.log does not throw on a WeakSet with a size property", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const v4 = new WeakSet();
+      v4.size = 2;
+      console.log(v4);
+    `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("WeakSet");
+  expect(stderr).not.toContain("TypeError");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

When inspecting a WeakMap or WeakSet, the formatter read the `size` property and then called `forEach`. Since neither type is iterable, `forEach` (internally `forEachInIterable`) throws a TypeError.

- In the `console.log` path it surfaces as a user-visible `TypeError: Type error`.
- In the `DiffFormatter` path the Zig error is swallowed by `catch {}` in `diff_format.zig` but the JS exception stays on the VM, tripping the `!exception() || hasPendingTerminationException()` assertion in `ExceptionScope::assertNoExceptionExceptTermination` when the outer `throwPretty` tries to throw the diff error.

Normally `size` isn't set on a WeakMap so the formatter hit the `length == 0` fast path and short-circuited. Setting an own `size` property (e.g. `v4.size = 2`) makes it fall through to `forEach` and crash.

Fix by short-circuiting WeakMap/WeakSet in both `pretty_format.zig` and `ConsoleObject.zig` before touching `size`/`forEach`, plus clearing any leaked exception in the `DiffFormatter` catch as a safety net.

Fixes a Fuzzilli-found assertion failure with fingerprint `e29113a2714bbf46`.

### How did you verify your code works?

Added `test/js/bun/test/expect-toMatchObject-weakmap-crash.test.ts` with four regression tests covering both WeakMap and WeakSet for both the `toMatchObject` and `console.log` code paths. The `console.log` tests fail on the baked release bun (visible `TypeError: Type error`) and the `toMatchObject` tests fail on the assertion-enabled debug build; all four pass after the fix.