### PR TITLE
init: write AGENTS.md; symlink CLAUDE.md and .cursor/rules/*.mdc to it

### DIFF
--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -1061,6 +1061,20 @@ const Template = enum {
         // AND we don't treat a pre-existing one as a symlink target — users
         // opting into that flag want the old standalone-file workflow, so
         // `CLAUDE.md` falls through to the real-file write in Step 2.
+        //
+        // A dangling `AGENTS.md` symlink (target deleted after a prior init)
+        // needs the same `lstat + unlink` recovery as Steps 2 and 3: without
+        // it, `exists()` follows the broken link and reports missing, then
+        // `createNew()` hits EEXIST on the stale dirent, and the error gets
+        // silently swallowed — `agents_md_available` stays `false` and
+        // `CLAUDE.md` silently degrades to a plain file.
+        if (comptime !Environment.isWindows) {
+            if (bun.sys.lstat("AGENTS.md").unwrap()) |st| {
+                if (!bun.sys.exists("AGENTS.md") and (st.mode & bun.S.IFMT) == bun.S.IFLNK) {
+                    _ = bun.sys.unlink("AGENTS.md");
+                }
+            } else |_| {}
+        }
         var agents_md_available = false;
         if (!bun.env_var.BUN_AGENTS_MD_DISABLED.get()) {
             if (bun.sys.exists("AGENTS.md")) {
@@ -1153,7 +1167,13 @@ const Template = enum {
         }
 
         if (Environment.isWindows) {
-            if (bun.getenvZAnyCase("USER")) |user| {
+            // `bun.env_var.USER` is `PlatformSpecificNew(kind.string, "USER", "USERNAME", ...)`
+            // so `platformGet()` returns `$USERNAME` on Windows (the correct variable
+            // on native cmd.exe / PowerShell) and `$USER` on POSIX. The previous
+            // `getenvZAnyCase("USER")` lookup always failed on Windows because
+            // `getenvZAnyCase` is length-sensitive and `"USER"` never matches
+            // `"USERNAME"`, leaving this whole branch dead on native Windows shells.
+            if (bun.env_var.USER.platformGet()) |user| {
                 const pathbuf = bun.path_buffer_pool.get();
                 defer bun.path_buffer_pool.put(pathbuf);
                 const path = std.fmt.bufPrintZ(pathbuf, "C:\\Users\\{s}\\AppData\\Local\\Programs\\Cursor\\Cursor.exe", .{user}) catch {

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -1112,7 +1112,23 @@ const Template = enum {
         //         with the full YAML frontmatter intact. Cursor uses the
         //         `globs` field to decide when the rule activates; symlinking
         //         to `AGENTS.md` would strip that and break rule activation.
+        //
+        // Recover from a dangling cursor-rule symlink for the same reason as
+        // `CLAUDE.md` above: older versions of `bun init` symlinked
+        // `.cursor/rules/*.mdc -> ../../CLAUDE.md`, and if the user later
+        // deleted `CLAUDE.md` the link is now dangling. `existsZ` follows
+        // symlinks and reports the broken link as missing, but the dirent is
+        // still there — so `createNew` hits EEXIST and silently drops the
+        // cursor rule forever. `lstat` does not follow symlinks; lstat
+        // success + `existsZ` failure unambiguously means "dangling symlink".
         if (Template.getCursorRule()) |template_file| {
+            if (comptime !Environment.isWindows) {
+                if (bun.sys.lstat(template_file.path).unwrap()) |st| {
+                    if (!bun.sys.existsZ(template_file.path) and (st.mode & bun.S.IFMT) == bun.S.IFLNK) {
+                        _ = bun.sys.unlink(template_file.path);
+                    }
+                } else |_| {}
+            }
             if (bun.sys.existsZ(template_file.path)) return;
             bun.makePath(bun.FD.cwd().stdDir(), ".cursor/rules") catch {};
             InitCommand.Assets.createNew(template_file.path, template_file.contents) catch {};

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -1073,6 +1073,23 @@ const Template = enum {
         // Step 2: Claude — symlink `CLAUDE.md` to `AGENTS.md` when possible,
         //         otherwise write `CLAUDE.md` as a real file (the original
         //         behavior).
+        //
+        // Recover from a dangling `CLAUDE.md` symlink whose target has been
+        // deleted since a previous `bun init` (e.g. `AGENTS.md` was moved or
+        // removed). `bun.sys.exists` uses `access()` which follows symlinks
+        // and reports a broken link as "missing", but the link dirent is
+        // still there — so both `symlinkat()` and `createNew()` would fail
+        // with EEXIST on the next init and the dead link would persist.
+        // `lstat()` does not follow symlinks, so an `lstat` success combined
+        // with an `exists` failure unambiguously means "dangling symlink".
+        if (comptime !Environment.isWindows) {
+            if (bun.sys.lstat("CLAUDE.md").unwrap()) |st| {
+                if (!bun.sys.exists("CLAUDE.md") and (st.mode & bun.S.IFMT) == bun.S.IFLNK) {
+                    _ = bun.sys.unlink("CLAUDE.md");
+                }
+            } else |_| {}
+        }
+
         const create_claude_md = Template.isClaudeCodeInstalled() and
             // Never overwrite CLAUDE.md
             !bun.sys.exists("CLAUDE.md");

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -1056,11 +1056,16 @@ const Template = enum {
         // Step 1: Write `AGENTS.md` — the single source of truth. Never
         //         overwrite an existing one; an existing file is still a
         //         valid symlink target for `CLAUDE.md` below.
+        //
+        // When `BUN_AGENTS_MD_DISABLED=1` is set, we don't create `AGENTS.md`
+        // AND we don't treat a pre-existing one as a symlink target — users
+        // opting into that flag want the old standalone-file workflow, so
+        // `CLAUDE.md` falls through to the real-file write in Step 2.
         var agents_md_available = false;
-        if (bun.sys.exists("AGENTS.md")) {
-            agents_md_available = true;
-        } else if (!bun.env_var.BUN_AGENTS_MD_DISABLED.get()) {
-            if (InitCommand.Assets.createNew("AGENTS.md", trimmed_rule)) |_| {
+        if (!bun.env_var.BUN_AGENTS_MD_DISABLED.get()) {
+            if (bun.sys.exists("AGENTS.md")) {
+                agents_md_available = true;
+            } else if (InitCommand.Assets.createNew("AGENTS.md", trimmed_rule)) |_| {
                 agents_md_available = true;
             } else |_| {}
         }

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -1061,22 +1061,26 @@ const Template = enum {
         // AND we don't treat a pre-existing one as a symlink target — users
         // opting into that flag want the old standalone-file workflow, so
         // `CLAUDE.md` falls through to the real-file write in Step 2.
-        //
-        // A dangling `AGENTS.md` symlink (target deleted after a prior init)
-        // needs the same `lstat + unlink` recovery as Steps 2 and 3: without
-        // it, `exists()` follows the broken link and reports missing, then
-        // `createNew()` hits EEXIST on the stale dirent, and the error gets
-        // silently swallowed — `agents_md_available` stays `false` and
-        // `CLAUDE.md` silently degrades to a plain file.
-        if (comptime !Environment.isWindows) {
-            if (bun.sys.lstat("AGENTS.md").unwrap()) |st| {
-                if (!bun.sys.exists("AGENTS.md") and (st.mode & bun.S.IFMT) == bun.S.IFLNK) {
-                    _ = bun.sys.unlink("AGENTS.md");
-                }
-            } else |_| {}
-        }
         var agents_md_available = false;
         if (!bun.env_var.BUN_AGENTS_MD_DISABLED.get()) {
+            // A dangling `AGENTS.md` symlink (target deleted after a prior
+            // init) needs the same `lstat + unlink` recovery as Steps 2 and 3:
+            // without it, `exists()` follows the broken link and reports
+            // missing, `createNew()` hits EEXIST on the stale dirent, the
+            // error gets silently swallowed, and `agents_md_available` stays
+            // `false` — so `CLAUDE.md` silently degrades to a plain file.
+            //
+            // This guard stays inside the `BUN_AGENTS_MD_DISABLED` check so
+            // we never touch the user's filesystem when they've opted out of
+            // `AGENTS.md` management entirely, even to clean up a stale link.
+            if (comptime !Environment.isWindows) {
+                if (bun.sys.lstat("AGENTS.md").unwrap()) |st| {
+                    if (!bun.sys.exists("AGENTS.md") and (st.mode & bun.S.IFMT) == bun.S.IFLNK) {
+                        _ = bun.sys.unlink("AGENTS.md");
+                    }
+                } else |_| {}
+            }
+
             if (bun.sys.exists("AGENTS.md")) {
                 agents_md_available = true;
             } else if (InitCommand.Assets.createNew("AGENTS.md", trimmed_rule)) |_| {

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -996,7 +996,7 @@ const Template = enum {
 
     const agent_rule = @embedFile("../init/rule.md");
     const cursor_rule = TemplateFile{ .path = ".cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc", .contents = agent_rule };
-    const cursor_rule_path_to_claude_md = "../../CLAUDE.md";
+    const cursor_rule_path_to_agents_md = "../../AGENTS.md";
 
     fn isClaudeCodeInstalled() bool {
         if (Environment.isWindows) {
@@ -1015,50 +1015,76 @@ const Template = enum {
         return bun.which(pathbuffer, bun.env_var.PATH.get() orelse return false, bun.fs.FileSystem.instance.top_level_dir, "claude") != null;
     }
 
+    /// Writes the agent rule files during `bun init`.
+    ///
+    /// `AGENTS.md` (https://agents.md/) is the single source of truth. When
+    /// Claude Code or Cursor is detected, their respective rule files are
+    /// created as symlinks to `AGENTS.md` so the content stays in sync.
+    ///
+    /// Fallbacks if a symlink can't be created (Windows, disabled, filesystem
+    /// error): write the rule file directly with the same content.
     pub fn createAgentRule() void {
-        var @"create CLAUDE.md" = Template.isClaudeCodeInstalled() and
+        // Master kill switch — disables everything below.
+        if (bun.env_var.BUN_AGENT_RULE_DISABLED.get()) return;
+
+        // The YAML frontmatter at the top of `src/init/rule.md` is only
+        // meaningful to Cursor. Strip it for `AGENTS.md` and any real
+        // `CLAUDE.md` fallback.
+        const end_of_frontmatter = if (bun.strings.lastIndexOf(agent_rule, "---\n")) |start| start + "---\n".len else 0;
+        const trimmed_rule = agent_rule[end_of_frontmatter..];
+
+        // Step 1: Write `AGENTS.md` — the single source of truth. Never
+        //         overwrite an existing one; an existing file is still a
+        //         valid symlink target for the steps below.
+        var agents_md_available = false;
+        if (bun.sys.exists("AGENTS.md")) {
+            agents_md_available = true;
+        } else if (!bun.env_var.BUN_AGENTS_MD_DISABLED.get()) {
+            if (InitCommand.Assets.createNew("AGENTS.md", trimmed_rule)) |_| {
+                agents_md_available = true;
+            } else |_| {}
+        }
+
+        // Step 2: Claude — symlink `CLAUDE.md` to `AGENTS.md` when possible,
+        //         otherwise write `CLAUDE.md` as a real file (the original
+        //         behavior).
+        const create_claude_md = Template.isClaudeCodeInstalled() and
             // Never overwrite CLAUDE.md
             !bun.sys.exists("CLAUDE.md");
-
-        if (Template.getCursorRule()) |template_file| {
-            var did_create_agent_rule = false;
-
-            // If both Cursor & Claude is installed, make the cursor rule a
-            // symlink to ../../CLAUDE.md
-            const asset_path = if (@"create CLAUDE.md") "CLAUDE.md" else template_file.path;
-            const result = InitCommand.Assets.createNew(asset_path, template_file.contents);
-            did_create_agent_rule = true;
-            result catch {
-                did_create_agent_rule = false;
-                if (@"create CLAUDE.md") {
-                    @"create CLAUDE.md" = false;
-                    // If installing the CLAUDE.md fails for some reason, fall back to installing the cursor rule.
-                    InitCommand.Assets.createNew(template_file.path, template_file.contents) catch {};
-                }
-            };
-
+        var claude_md_written = false;
+        if (create_claude_md) {
             if (comptime !Environment.isWindows) {
-                // if we did create the CLAUDE.md, then symlinks the
-                // .cursor/rules/*.mdc -> CLAUDE.md so it's easier to keep them in
-                // sync if you change it locally. we use a symlink for the cursor
-                // rule in this case so that the github UI for CLAUDE.md (which may
-                // appear prominently in repos) doesn't show a file path.
-                if (did_create_agent_rule and @"create CLAUDE.md") symlink_cursor_rule: {
-                    @"create CLAUDE.md" = false;
-                    bun.makePath(bun.FD.cwd().stdDir(), ".cursor/rules") catch {};
-                    bun.sys.symlinkat(cursor_rule_path_to_claude_md, .cwd(), template_file.path).unwrap() catch break :symlink_cursor_rule;
-                    Output.prettyln(" + <r><d>{s} -\\> {s}<r>", .{ template_file.path, asset_path });
+                if (agents_md_available) symlink_claude_md: {
+                    bun.sys.symlinkat("AGENTS.md", .cwd(), "CLAUDE.md").unwrap() catch break :symlink_claude_md;
+                    Output.prettyln(" + <r><d>CLAUDE.md -\\> AGENTS.md<r>", .{});
                     Output.flush();
+                    claude_md_written = true;
                 }
+            }
+            if (!claude_md_written) {
+                InitCommand.Assets.createNew("CLAUDE.md", trimmed_rule) catch {};
             }
         }
 
-        // If cursor is not installed but claude code is installed, then create the CLAUDE.md.
-        if (@"create CLAUDE.md") {
-            // In this case, the frontmatter from the cursor rule is not helpful so let's trim it out.
-            const end_of_frontmatter = if (bun.strings.lastIndexOf(agent_rule, "---\n")) |start| start + "---\n".len else 0;
+        // Step 3: Cursor — symlink `.cursor/rules/*.mdc` to `../../AGENTS.md`
+        //         when possible, otherwise write the cursor rule file directly
+        //         (with the frontmatter intact, since Cursor needs it).
+        if (Template.getCursorRule()) |template_file| {
+            if (bun.sys.existsZ(template_file.path)) return;
 
-            InitCommand.Assets.createNew("CLAUDE.md", agent_rule[end_of_frontmatter..]) catch {};
+            var cursor_rule_written = false;
+            if (comptime !Environment.isWindows) {
+                if (agents_md_available) symlink_cursor_rule: {
+                    bun.makePath(bun.FD.cwd().stdDir(), ".cursor/rules") catch {};
+                    bun.sys.symlinkat(cursor_rule_path_to_agents_md, .cwd(), template_file.path).unwrap() catch break :symlink_cursor_rule;
+                    Output.prettyln(" + <r><d>{s} -\\> {s}<r>", .{ template_file.path, cursor_rule_path_to_agents_md });
+                    Output.flush();
+                    cursor_rule_written = true;
+                }
+            }
+            if (!cursor_rule_written) {
+                InitCommand.Assets.createNew(template_file.path, template_file.contents) catch {};
+            }
         }
     }
 

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -996,7 +996,6 @@ const Template = enum {
 
     const agent_rule = @embedFile("../init/rule.md");
     const cursor_rule = TemplateFile{ .path = ".cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc", .contents = agent_rule };
-    const cursor_rule_path_to_agents_md = "../../AGENTS.md";
 
     fn isClaudeCodeInstalled() bool {
         if (Environment.isWindows) {
@@ -1009,6 +1008,14 @@ const Template = enum {
             return false;
         }
 
+        // Claude Code sets `CLAUDECODE=1` in every child process it spawns —
+        // mirrors how `CURSOR_TRACE_ID` identifies Cursor. This is the most
+        // reliable signal when `bun init` runs inside an agent session on a
+        // container / CI box where `claude` may not be on `$PATH`.
+        if (bun.env_var.CLAUDECODE.get()) {
+            return true;
+        }
+
         const pathbuffer = bun.path_buffer_pool.get();
         defer bun.path_buffer_pool.put(pathbuffer);
 
@@ -1018,24 +1025,37 @@ const Template = enum {
     /// Writes the agent rule files during `bun init`.
     ///
     /// `AGENTS.md` (https://agents.md/) is the single source of truth. When
-    /// Claude Code or Cursor is detected, their respective rule files are
-    /// created as symlinks to `AGENTS.md` so the content stays in sync.
+    /// Claude Code is detected, `CLAUDE.md` becomes a symlink to `AGENTS.md`
+    /// so the content stays in sync.
+    ///
+    /// Cursor's `.cursor/rules/*.mdc` is always written as a real file — it
+    /// needs the YAML frontmatter (`description`/`globs`/`alwaysApply`) to
+    /// know when to activate, and `AGENTS.md` has that stripped, so the two
+    /// files can't share content via symlink.
     ///
     /// Fallbacks if a symlink can't be created (Windows, disabled, filesystem
-    /// error): write the rule file directly with the same content.
+    /// error): write `CLAUDE.md` directly with the same content.
     pub fn createAgentRule() void {
         // Master kill switch — disables everything below.
         if (bun.env_var.BUN_AGENT_RULE_DISABLED.get()) return;
 
-        // The YAML frontmatter at the top of `src/init/rule.md` is only
-        // meaningful to Cursor. Strip it for `AGENTS.md` and any real
-        // `CLAUDE.md` fallback.
-        const end_of_frontmatter = if (bun.strings.lastIndexOf(agent_rule, "---\n")) |start| start + "---\n".len else 0;
-        const trimmed_rule = agent_rule[end_of_frontmatter..];
+        // `src/init/rule.md` starts with a YAML frontmatter block, bracketed
+        // by `---\n`. Only Cursor needs it; strip it for `AGENTS.md` and any
+        // real `CLAUDE.md` fallback. We find the opening delimiter, then the
+        // closing delimiter in the remainder — using sequential `indexOf`
+        // rather than `lastIndexOf` means a Markdown `---` divider added to
+        // the body later won't be mistaken for the frontmatter terminator.
+        const trimmed_rule = trim: {
+            const marker = "---\n";
+            const opener_rel = bun.strings.indexOf(agent_rule, marker) orelse break :trim agent_rule;
+            const after_opener = opener_rel + marker.len;
+            const close_rel = bun.strings.indexOf(agent_rule[after_opener..], marker) orelse break :trim agent_rule;
+            break :trim agent_rule[after_opener + close_rel + marker.len ..];
+        };
 
         // Step 1: Write `AGENTS.md` — the single source of truth. Never
         //         overwrite an existing one; an existing file is still a
-        //         valid symlink target for the steps below.
+        //         valid symlink target for `CLAUDE.md` below.
         var agents_md_available = false;
         if (bun.sys.exists("AGENTS.md")) {
             agents_md_available = true;
@@ -1066,25 +1086,14 @@ const Template = enum {
             }
         }
 
-        // Step 3: Cursor — symlink `.cursor/rules/*.mdc` to `../../AGENTS.md`
-        //         when possible, otherwise write the cursor rule file directly
-        //         (with the frontmatter intact, since Cursor needs it).
+        // Step 3: Cursor — always write `.cursor/rules/*.mdc` as a real file
+        //         with the full YAML frontmatter intact. Cursor uses the
+        //         `globs` field to decide when the rule activates; symlinking
+        //         to `AGENTS.md` would strip that and break rule activation.
         if (Template.getCursorRule()) |template_file| {
             if (bun.sys.existsZ(template_file.path)) return;
-
-            var cursor_rule_written = false;
-            if (comptime !Environment.isWindows) {
-                if (agents_md_available) symlink_cursor_rule: {
-                    bun.makePath(bun.FD.cwd().stdDir(), ".cursor/rules") catch {};
-                    bun.sys.symlinkat(cursor_rule_path_to_agents_md, .cwd(), template_file.path).unwrap() catch break :symlink_cursor_rule;
-                    Output.prettyln(" + <r><d>{s} -\\> {s}<r>", .{ template_file.path, cursor_rule_path_to_agents_md });
-                    Output.flush();
-                    cursor_rule_written = true;
-                }
-            }
-            if (!cursor_rule_written) {
-                InitCommand.Assets.createNew(template_file.path, template_file.contents) catch {};
-            }
+            bun.makePath(bun.FD.cwd().stdDir(), ".cursor/rules") catch {};
+            InitCommand.Assets.createNew(template_file.path, template_file.contents) catch {};
         }
     }
 

--- a/src/env_var.zig
+++ b/src/env_var.zig
@@ -28,6 +28,7 @@
 
 pub const AGENT = New(kind.string, "AGENT", .{});
 pub const BUN_AGENT_RULE_DISABLED = New(kind.boolean, "BUN_AGENT_RULE_DISABLED", .{ .default = false });
+pub const BUN_AGENTS_MD_DISABLED = New(kind.boolean, "BUN_AGENTS_MD_DISABLED", .{ .default = false });
 pub const BUN_COMPILE_TARGET_TARBALL_URL = New(kind.string, "BUN_COMPILE_TARGET_TARBALL_URL", .{});
 pub const BUN_CONFIG_DISABLE_COPY_FILE_RANGE = New(kind.boolean, "BUN_CONFIG_DISABLE_COPY_FILE_RANGE", .{ .default = false });
 pub const BUN_CONFIG_DISABLE_ioctl_ficlonerange = New(kind.boolean, "BUN_CONFIG_DISABLE_ioctl_ficlonerange", .{ .default = false });

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -679,53 +679,48 @@ import path from "path";
       const claudeStat = fs.lstatSync(path.join(temp, "CLAUDE.md"));
       expect(claudeStat.isSymbolicLink()).toBe(false);
       expect(claudeStat.isFile()).toBe(true);
-      expect(fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8").trimStart()).toStartWith(
-        AGENTS_MD_BODY_FIRST_LINE,
-      );
+      expect(fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8").trimStart()).toStartWith(AGENTS_MD_BODY_FIRST_LINE);
       expect(exitCode).toBe(0);
     });
 
-    test.skipIf(isWindows)(
-      "dangling .cursor/rules/*.mdc symlink is unlinked before re-create",
-      async () => {
-        // Regression: older versions of `bun init` symlinked the cursor
-        // rule to `../../CLAUDE.md`. If the user later deleted `CLAUDE.md`
-        // the rule became a dangling link, and the subsequent `createNew`
-        // would silently drop the cursor rule forever. Mirrors the
-        // CLAUDE.md recovery above.
-        const temp = tempDirWithFiles("bun-init-agents-dangling-cursor", {});
-        const cursorRulePath = path.join(temp, ".cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc");
-        fs.mkdirSync(path.join(temp, ".cursor/rules"), { recursive: true });
-        // Pre-stage the old-style dangling symlink.
-        fs.symlinkSync("../../CLAUDE.md", cursorRulePath);
-        expect(fs.lstatSync(cursorRulePath).isSymbolicLink()).toBe(true);
-        expect(fs.existsSync(cursorRulePath)).toBe(false);
+    test.skipIf(isWindows)("dangling .cursor/rules/*.mdc symlink is unlinked before re-create", async () => {
+      // Regression: older versions of `bun init` symlinked the cursor
+      // rule to `../../CLAUDE.md`. If the user later deleted `CLAUDE.md`
+      // the rule became a dangling link, and the subsequent `createNew`
+      // would silently drop the cursor rule forever. Mirrors the
+      // CLAUDE.md recovery above.
+      const temp = tempDirWithFiles("bun-init-agents-dangling-cursor", {});
+      const cursorRulePath = path.join(temp, ".cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc");
+      fs.mkdirSync(path.join(temp, ".cursor/rules"), { recursive: true });
+      // Pre-stage the old-style dangling symlink.
+      fs.symlinkSync("../../CLAUDE.md", cursorRulePath);
+      expect(fs.lstatSync(cursorRulePath).isSymbolicLink()).toBe(true);
+      expect(fs.existsSync(cursorRulePath)).toBe(false);
 
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "init", "-y"],
-          cwd: temp,
-          stdio: ["ignore", "pipe", "pipe"],
-          env: {
-            ...bunEnv,
-            ...claudeEnv(temp, false),
-            CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
-            CURSOR_TRACE_ID: "test-trace-id",
-          },
-        });
-        const exitCode = await proc.exited;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "init", "-y"],
+        cwd: temp,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...bunEnv,
+          ...claudeEnv(temp, false),
+          CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
+          CURSOR_TRACE_ID: "test-trace-id",
+        },
+      });
+      const exitCode = await proc.exited;
 
-        // The cursor rule is now a real file with its full YAML
-        // frontmatter. The dangling symlink was unlinked and replaced.
-        expect(fs.existsSync(cursorRulePath)).toBe(true);
-        const cursorStat = fs.lstatSync(cursorRulePath);
-        expect(cursorStat.isSymbolicLink()).toBe(false);
-        expect(cursorStat.isFile()).toBe(true);
-        const cursorContents = fs.readFileSync(cursorRulePath, "utf8");
-        expect(cursorContents).toInclude(FRONTMATTER_LINE);
-        expect(cursorContents).toInclude("globs:");
-        expect(exitCode).toBe(0);
-      },
-    );
+      // The cursor rule is now a real file with its full YAML
+      // frontmatter. The dangling symlink was unlinked and replaced.
+      expect(fs.existsSync(cursorRulePath)).toBe(true);
+      const cursorStat = fs.lstatSync(cursorRulePath);
+      expect(cursorStat.isSymbolicLink()).toBe(false);
+      expect(cursorStat.isFile()).toBe(true);
+      const cursorContents = fs.readFileSync(cursorRulePath, "utf8");
+      expect(cursorContents).toInclude(FRONTMATTER_LINE);
+      expect(cursorContents).toInclude("globs:");
+      expect(exitCode).toBe(0);
+    });
 
     test("BUN_AGENT_RULE_DISABLED=1: master kill switch — no agent files at all", async () => {
       const temp = tempDirWithFiles("bun-init-agents-master-off", {});

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -724,38 +724,35 @@ import path from "path";
       expect(exitCode).toBe(0);
     });
 
-    test.skipIf(isWindows)(
-      "BUN_AGENTS_MD_DISABLED=1 with dangling AGENTS.md: symlink is left alone",
-      async () => {
-        // When the user opts out of `AGENTS.md` management, `bun init` must
-        // not touch the file at all — not even to clean up a dangling
-        // symlink left over from a prior init. This guards the lstat+unlink
-        // block from running outside the `BUN_AGENTS_MD_DISABLED` check.
-        const temp = tempDirWithFiles("bun-init-agents-disabled-dangling", {});
-        fs.symlinkSync("nonexistent-target.md", path.join(temp, "AGENTS.md"));
-        expect(fs.lstatSync(path.join(temp, "AGENTS.md")).isSymbolicLink()).toBe(true);
+    test.skipIf(isWindows)("BUN_AGENTS_MD_DISABLED=1 with dangling AGENTS.md: symlink is left alone", async () => {
+      // When the user opts out of `AGENTS.md` management, `bun init` must
+      // not touch the file at all — not even to clean up a dangling
+      // symlink left over from a prior init. This guards the lstat+unlink
+      // block from running outside the `BUN_AGENTS_MD_DISABLED` check.
+      const temp = tempDirWithFiles("bun-init-agents-disabled-dangling", {});
+      fs.symlinkSync("nonexistent-target.md", path.join(temp, "AGENTS.md"));
+      expect(fs.lstatSync(path.join(temp, "AGENTS.md")).isSymbolicLink()).toBe(true);
 
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "init", "-y"],
-          cwd: temp,
-          stdio: ["ignore", "pipe", "pipe"],
-          env: {
-            ...bunEnv,
-            ...claudeEnv(temp, false),
-            BUN_AGENTS_MD_DISABLED: "1",
-            CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
-            CURSOR_AGENT_RULE_DISABLED: "1",
-          },
-        });
-        const exitCode = await proc.exited;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "init", "-y"],
+        cwd: temp,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...bunEnv,
+          ...claudeEnv(temp, false),
+          BUN_AGENTS_MD_DISABLED: "1",
+          CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
+          CURSOR_AGENT_RULE_DISABLED: "1",
+        },
+      });
+      const exitCode = await proc.exited;
 
-        // The dangling symlink is still there — untouched.
-        const agentsStat = fs.lstatSync(path.join(temp, "AGENTS.md"));
-        expect(agentsStat.isSymbolicLink()).toBe(true);
-        expect(fs.readlinkSync(path.join(temp, "AGENTS.md"))).toBe("nonexistent-target.md");
-        expect(exitCode).toBe(0);
-      },
-    );
+      // The dangling symlink is still there — untouched.
+      const agentsStat = fs.lstatSync(path.join(temp, "AGENTS.md"));
+      expect(agentsStat.isSymbolicLink()).toBe(true);
+      expect(fs.readlinkSync(path.join(temp, "AGENTS.md"))).toBe("nonexistent-target.md");
+      expect(exitCode).toBe(0);
+    });
 
     test.skipIf(isWindows)("dangling .cursor/rules/*.mdc symlink is unlinked before re-create", async () => {
       // Regression: older versions of `bun init` symlinked the cursor

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -345,8 +345,10 @@ import path from "path";
   // Feature: https://github.com/oven-sh/bun/issues/28909
   //
   // `bun init` writes an `AGENTS.md` (https://agents.md/) as the single source
-  // of truth. When Claude Code or Cursor is detected, their rule files become
-  // symlinks to `AGENTS.md` so the content stays in sync.
+  // of truth. When Claude Code is detected, `CLAUDE.md` becomes a symlink to
+  // `AGENTS.md` so the content stays in sync. Cursor's `.cursor/rules/*.mdc`
+  // is always written as a real file with its YAML frontmatter intact —
+  // Cursor needs `globs:` for rule activation, which `AGENTS.md` strips.
   describe("AGENTS.md", () => {
     // First non-empty line of the rule body. Used as a sanity check that
     // the frontmatter was stripped.
@@ -631,6 +633,46 @@ import path from "path";
         expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
         expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
         expect(fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8")).toBe(customContent);
+        expect(exitCode).toBe(0);
+      },
+    );
+
+    test.skipIf(isWindows)(
+      "dangling CLAUDE.md symlink recovers on next init",
+      async () => {
+        // Regression: a previous `bun init` left `CLAUDE.md` as a symlink to
+        // `AGENTS.md`. The user then deleted `AGENTS.md`, so `CLAUDE.md` is
+        // now a dangling link. A fresh `bun init` must notice the broken
+        // link, unlink it, and re-create both files — otherwise both
+        // `symlinkat()` and `createNew()` hit EEXIST and the link stays dead.
+        const temp = tempDirWithFiles("bun-init-agents-dangling", {});
+        // Pre-stage a dangling `CLAUDE.md` symlink pointing at a non-existent
+        // `AGENTS.md`.
+        fs.symlinkSync("AGENTS.md", path.join(temp, "CLAUDE.md"));
+        expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
+        expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "init", "-y"],
+          cwd: temp,
+          stdio: ["ignore", "pipe", "pipe"],
+          env: {
+            ...bunEnv,
+            ...claudeEnv(temp, true),
+            CURSOR_AGENT_RULE_DISABLED: "1",
+          },
+        });
+        const exitCode = await proc.exited;
+
+        // `AGENTS.md` was (re)created, and `CLAUDE.md` is a fresh symlink
+        // pointing at it — no longer dangling.
+        expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
+        expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(true);
+        expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
+        expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
+        expect(fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8")).toBe(
+          fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8"),
+        );
         expect(exitCode).toBe(0);
       },
     );

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -77,10 +77,10 @@ import path from "path";
   }, 30_000);
 
   // These snapshot tests compare `readdirSync` against an inline list that
-  // does not include any agent rule files, so they have to run with
-  // Claude/Cursor detection disabled — otherwise a developer with Cursor
-  // installed (or `claude` on $PATH) would see `.cursor/` or `CLAUDE.md`
-  // sneak into the listing.
+  // includes `AGENTS.md` (always written) but excludes `CLAUDE.md` and
+  // `.cursor/`, so they have to run with Claude/Cursor detection disabled —
+  // otherwise a developer with Cursor installed (or `claude` on $PATH) would
+  // see `.cursor/` or `CLAUDE.md` sneak into the listing.
   const noAgentRulesEnv = {
     ...bunEnv,
     CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
@@ -637,15 +637,23 @@ import path from "path";
       },
     );
 
-    test.skipIf(isWindows)("dangling CLAUDE.md symlink recovers on next init", async () => {
+    test.skipIf(isWindows)("dangling CLAUDE.md symlink is unlinked before re-create", async () => {
       // Regression: a previous `bun init` left `CLAUDE.md` as a symlink to
-      // `AGENTS.md`. The user then deleted `AGENTS.md`, so `CLAUDE.md` is
-      // now a dangling link. A fresh `bun init` must notice the broken
-      // link, unlink it, and re-create both files — otherwise both
-      // `symlinkat()` and `createNew()` hit EEXIST and the link stays dead.
-      const temp = tempDirWithFiles("bun-init-agents-dangling", {});
-      // Pre-stage a dangling `CLAUDE.md` symlink pointing at a non-existent
-      // `AGENTS.md`.
+      // `AGENTS.md`, the user then deleted `AGENTS.md`, so `CLAUDE.md` is
+      // now dangling. On the next `bun init`, `createNew` / `symlinkat`
+      // would hit EEXIST on the stale dirent and the link would stay dead.
+      // The lstat+unlink recovery must fire first.
+      //
+      // We force the test to actually exercise the recovery code by setting
+      // `BUN_AGENTS_MD_DISABLED=1`. Without that flag, Step 1 of
+      // `createAgentRule` would recreate `AGENTS.md` first, which passively
+      // heals the symlink so `!exists("CLAUDE.md")` is false and the
+      // unlink at the top of Step 2 never runs. With the flag set,
+      // `agents_md_available` stays false, the symlink remains dangling
+      // when Step 2 inspects it, and we fall through to the real-file
+      // CLAUDE.md write — which only succeeds if the stale dirent was
+      // actually unlinked first.
+      const temp = tempDirWithFiles("bun-init-agents-dangling-claude", {});
       fs.symlinkSync("AGENTS.md", path.join(temp, "CLAUDE.md"));
       expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
       expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
@@ -657,22 +665,67 @@ import path from "path";
         env: {
           ...bunEnv,
           ...claudeEnv(temp, true),
+          BUN_AGENTS_MD_DISABLED: "1",
           CURSOR_AGENT_RULE_DISABLED: "1",
         },
       });
       const exitCode = await proc.exited;
 
-      // `AGENTS.md` was (re)created, and `CLAUDE.md` is a fresh symlink
-      // pointing at it — no longer dangling.
-      expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
+      // `AGENTS.md` stays absent (disabled). `CLAUDE.md` is now a real
+      // file with the trimmed rule body — the dangling symlink was
+      // successfully unlinked and replaced.
+      expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
       expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(true);
-      expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
-      expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
-      expect(fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8")).toBe(
-        fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8"),
+      const claudeStat = fs.lstatSync(path.join(temp, "CLAUDE.md"));
+      expect(claudeStat.isSymbolicLink()).toBe(false);
+      expect(claudeStat.isFile()).toBe(true);
+      expect(fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8").trimStart()).toStartWith(
+        AGENTS_MD_BODY_FIRST_LINE,
       );
       expect(exitCode).toBe(0);
     });
+
+    test.skipIf(isWindows)(
+      "dangling .cursor/rules/*.mdc symlink is unlinked before re-create",
+      async () => {
+        // Regression: older versions of `bun init` symlinked the cursor
+        // rule to `../../CLAUDE.md`. If the user later deleted `CLAUDE.md`
+        // the rule became a dangling link, and the subsequent `createNew`
+        // would silently drop the cursor rule forever. Mirrors the
+        // CLAUDE.md recovery above.
+        const temp = tempDirWithFiles("bun-init-agents-dangling-cursor", {});
+        const cursorRulePath = path.join(temp, ".cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc");
+        fs.mkdirSync(path.join(temp, ".cursor/rules"), { recursive: true });
+        // Pre-stage the old-style dangling symlink.
+        fs.symlinkSync("../../CLAUDE.md", cursorRulePath);
+        expect(fs.lstatSync(cursorRulePath).isSymbolicLink()).toBe(true);
+        expect(fs.existsSync(cursorRulePath)).toBe(false);
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "init", "-y"],
+          cwd: temp,
+          stdio: ["ignore", "pipe", "pipe"],
+          env: {
+            ...bunEnv,
+            ...claudeEnv(temp, false),
+            CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
+            CURSOR_TRACE_ID: "test-trace-id",
+          },
+        });
+        const exitCode = await proc.exited;
+
+        // The cursor rule is now a real file with its full YAML
+        // frontmatter. The dangling symlink was unlinked and replaced.
+        expect(fs.existsSync(cursorRulePath)).toBe(true);
+        const cursorStat = fs.lstatSync(cursorRulePath);
+        expect(cursorStat.isSymbolicLink()).toBe(false);
+        expect(cursorStat.isFile()).toBe(true);
+        const cursorContents = fs.readFileSync(cursorRulePath, "utf8");
+        expect(cursorContents).toInclude(FRONTMATTER_LINE);
+        expect(cursorContents).toInclude("globs:");
+        expect(exitCode).toBe(0);
+      },
+    );
 
     test("BUN_AGENT_RULE_DISABLED=1: master kill switch — no agent files at all", async () => {
       const temp = tempDirWithFiles("bun-init-agents-master-off", {});

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -459,6 +459,7 @@ import path from "path";
 
         expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
         const cursorRulePath = path.join(temp, ".cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc");
+        expect(fs.existsSync(cursorRulePath)).toBe(true);
         const cursorStat = fs.lstatSync(cursorRulePath);
         expect(cursorStat.isSymbolicLink()).toBe(false);
         expect(cursorStat.isFile()).toBe(true);

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -451,42 +451,42 @@ import path from "path";
       expect(exitCode).toBe(0);
     });
 
-    test.skipIf(isWindows)(
-      "with Cursor detected: .cursor/rules/*.mdc is a real file with frontmatter intact",
-      async () => {
-        // Cursor needs the YAML `globs` field to know when to activate the
-        // rule. AGENTS.md has the frontmatter stripped, so we can't share
-        // content via symlink — the cursor rule is always a real file.
-        const temp = tempDirWithFiles("bun-init-agents-cursor", {});
+    test("with Cursor detected: .cursor/rules/*.mdc is a real file with frontmatter intact", async () => {
+      // Cursor needs the YAML `globs` field to know when to activate the
+      // rule. AGENTS.md has the frontmatter stripped, so we can't share
+      // content via symlink — the cursor rule is always a real file.
+      // (Runs on Windows too — `isCursorInstalled()` and cursor rule
+      // creation are both platform-independent; only the CLAUDE.md
+      // symlink tests need a Windows skip.)
+      const temp = tempDirWithFiles("bun-init-agents-cursor", {});
 
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "init", "-y"],
-          cwd: temp,
-          stdio: ["ignore", "pipe", "pipe"],
-          env: {
-            ...bunEnv,
-            ...claudeEnv(temp, false),
-            CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
-            CURSOR_TRACE_ID: "test-trace-id",
-          },
-        });
-        const exitCode = await proc.exited;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "init", "-y"],
+        cwd: temp,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...bunEnv,
+          ...claudeEnv(temp, false),
+          CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
+          CURSOR_TRACE_ID: "test-trace-id",
+        },
+      });
+      const exitCode = await proc.exited;
 
-        expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
-        const cursorRulePath = path.join(temp, ".cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc");
-        expect(fs.existsSync(cursorRulePath)).toBe(true);
-        const cursorStat = fs.lstatSync(cursorRulePath);
-        expect(cursorStat.isSymbolicLink()).toBe(false);
-        expect(cursorStat.isFile()).toBe(true);
-        const cursorContents = fs.readFileSync(cursorRulePath, "utf8");
-        // The cursor rule keeps its full YAML frontmatter — without `globs`
-        // Cursor does not know which file types to activate on.
-        expect(cursorContents).toInclude(FRONTMATTER_LINE);
-        expect(cursorContents).toInclude("globs:");
-        expect(cursorContents).toInclude(AGENTS_MD_BODY_FIRST_LINE);
-        expect(exitCode).toBe(0);
-      },
-    );
+      expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
+      const cursorRulePath = path.join(temp, ".cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc");
+      expect(fs.existsSync(cursorRulePath)).toBe(true);
+      const cursorStat = fs.lstatSync(cursorRulePath);
+      expect(cursorStat.isSymbolicLink()).toBe(false);
+      expect(cursorStat.isFile()).toBe(true);
+      const cursorContents = fs.readFileSync(cursorRulePath, "utf8");
+      // The cursor rule keeps its full YAML frontmatter — without `globs`
+      // Cursor does not know which file types to activate on.
+      expect(cursorContents).toInclude(FRONTMATTER_LINE);
+      expect(cursorContents).toInclude("globs:");
+      expect(cursorContents).toInclude(AGENTS_MD_BODY_FIRST_LINE);
+      expect(exitCode).toBe(0);
+    });
 
     test("BUN_AGENTS_MD_DISABLED=1: no AGENTS.md is written", async () => {
       const temp = tempDirWithFiles("bun-init-agents-disabled", {});
@@ -680,6 +680,49 @@ import path from "path";
       expect(claudeStat.isSymbolicLink()).toBe(false);
       expect(claudeStat.isFile()).toBe(true);
       expect(fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8").trimStart()).toStartWith(AGENTS_MD_BODY_FIRST_LINE);
+      expect(exitCode).toBe(0);
+    });
+
+    test.skipIf(isWindows)("dangling AGENTS.md symlink is unlinked before re-create", async () => {
+      // Regression: Step 1 of `createAgentRule` must recover from a
+      // dangling `AGENTS.md` symlink (target deleted after a prior init).
+      // Without the `lstat + unlink` guard, `exists()` follows the broken
+      // link and reports missing, `createNew()` hits EEXIST on the stale
+      // dirent, the error is silently swallowed, and `agents_md_available`
+      // stays false — so `CLAUDE.md` silently degrades to a plain file
+      // instead of a symlink to the newly recreated `AGENTS.md`.
+      const temp = tempDirWithFiles("bun-init-agents-dangling-agents", {});
+      // Pre-stage a dangling `AGENTS.md` symlink pointing at nothing.
+      fs.symlinkSync("nonexistent-target.md", path.join(temp, "AGENTS.md"));
+      expect(fs.lstatSync(path.join(temp, "AGENTS.md")).isSymbolicLink()).toBe(true);
+      expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "init", "-y"],
+        cwd: temp,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...bunEnv,
+          ...claudeEnv(temp, true),
+          CURSOR_AGENT_RULE_DISABLED: "1",
+        },
+      });
+      const exitCode = await proc.exited;
+
+      // `AGENTS.md` is now a real file with the trimmed rule body — the
+      // dangling symlink was successfully unlinked and replaced.
+      expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
+      const agentsStat = fs.lstatSync(path.join(temp, "AGENTS.md"));
+      expect(agentsStat.isSymbolicLink()).toBe(false);
+      expect(agentsStat.isFile()).toBe(true);
+      expect(fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8").trimStart()).toStartWith(
+        AGENTS_MD_BODY_FIRST_LINE,
+      );
+      // And `CLAUDE.md` gets the symlink back to the fresh AGENTS.md,
+      // not a degraded plain-file fallback.
+      expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(true);
+      expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
+      expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
       expect(exitCode).toBe(0);
     });
 

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -637,45 +637,42 @@ import path from "path";
       },
     );
 
-    test.skipIf(isWindows)(
-      "dangling CLAUDE.md symlink recovers on next init",
-      async () => {
-        // Regression: a previous `bun init` left `CLAUDE.md` as a symlink to
-        // `AGENTS.md`. The user then deleted `AGENTS.md`, so `CLAUDE.md` is
-        // now a dangling link. A fresh `bun init` must notice the broken
-        // link, unlink it, and re-create both files — otherwise both
-        // `symlinkat()` and `createNew()` hit EEXIST and the link stays dead.
-        const temp = tempDirWithFiles("bun-init-agents-dangling", {});
-        // Pre-stage a dangling `CLAUDE.md` symlink pointing at a non-existent
-        // `AGENTS.md`.
-        fs.symlinkSync("AGENTS.md", path.join(temp, "CLAUDE.md"));
-        expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
-        expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
+    test.skipIf(isWindows)("dangling CLAUDE.md symlink recovers on next init", async () => {
+      // Regression: a previous `bun init` left `CLAUDE.md` as a symlink to
+      // `AGENTS.md`. The user then deleted `AGENTS.md`, so `CLAUDE.md` is
+      // now a dangling link. A fresh `bun init` must notice the broken
+      // link, unlink it, and re-create both files — otherwise both
+      // `symlinkat()` and `createNew()` hit EEXIST and the link stays dead.
+      const temp = tempDirWithFiles("bun-init-agents-dangling", {});
+      // Pre-stage a dangling `CLAUDE.md` symlink pointing at a non-existent
+      // `AGENTS.md`.
+      fs.symlinkSync("AGENTS.md", path.join(temp, "CLAUDE.md"));
+      expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
+      expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
 
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "init", "-y"],
-          cwd: temp,
-          stdio: ["ignore", "pipe", "pipe"],
-          env: {
-            ...bunEnv,
-            ...claudeEnv(temp, true),
-            CURSOR_AGENT_RULE_DISABLED: "1",
-          },
-        });
-        const exitCode = await proc.exited;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "init", "-y"],
+        cwd: temp,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...bunEnv,
+          ...claudeEnv(temp, true),
+          CURSOR_AGENT_RULE_DISABLED: "1",
+        },
+      });
+      const exitCode = await proc.exited;
 
-        // `AGENTS.md` was (re)created, and `CLAUDE.md` is a fresh symlink
-        // pointing at it — no longer dangling.
-        expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
-        expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(true);
-        expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
-        expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
-        expect(fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8")).toBe(
-          fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8"),
-        );
-        expect(exitCode).toBe(0);
-      },
-    );
+      // `AGENTS.md` was (re)created, and `CLAUDE.md` is a fresh symlink
+      // pointing at it — no longer dangling.
+      expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
+      expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(true);
+      expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
+      expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
+      expect(fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8")).toBe(
+        fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8"),
+      );
+      expect(exitCode).toBe(0);
+    });
 
     test("BUN_AGENT_RULE_DISABLED=1: master kill switch — no agent files at all", async () => {
       const temp = tempDirWithFiles("bun-init-agents-master-off", {});

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -411,33 +411,30 @@ import path from "path";
       expect(exitCode).toBe(0);
     });
 
-    test.skipIf(isWindows)(
-      "with Claude detected via CLAUDECODE=1: CLAUDE.md is a symlink to AGENTS.md",
-      async () => {
-        // Claude Code sets `CLAUDECODE=1` in every child process it spawns.
-        // Detection should work even when `claude` is not on $PATH, which is
-        // the common case inside containerised agent sessions.
-        const temp = tempDirWithFiles("bun-init-agents-claudecode-env", {});
+    test.skipIf(isWindows)("with Claude detected via CLAUDECODE=1: CLAUDE.md is a symlink to AGENTS.md", async () => {
+      // Claude Code sets `CLAUDECODE=1` in every child process it spawns.
+      // Detection should work even when `claude` is not on $PATH, which is
+      // the common case inside containerised agent sessions.
+      const temp = tempDirWithFiles("bun-init-agents-claudecode-env", {});
 
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "init", "-y"],
-          cwd: temp,
-          stdio: ["ignore", "pipe", "pipe"],
-          env: {
-            ...bunEnv,
-            ...claudeEnv(temp, false),
-            CLAUDECODE: "1",
-            CURSOR_AGENT_RULE_DISABLED: "1",
-          },
-        });
-        const exitCode = await proc.exited;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "init", "-y"],
+        cwd: temp,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...bunEnv,
+          ...claudeEnv(temp, false),
+          CLAUDECODE: "1",
+          CURSOR_AGENT_RULE_DISABLED: "1",
+        },
+      });
+      const exitCode = await proc.exited;
 
-        expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
-        expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
-        expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
-        expect(exitCode).toBe(0);
-      },
-    );
+      expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
+      expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
+      expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
+      expect(exitCode).toBe(0);
+    });
 
     test.skipIf(isWindows)(
       "with Cursor detected: .cursor/rules/*.mdc is a real file with frontmatter intact",

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -385,60 +385,52 @@ import path from "path";
       expect(contents.trimStart()).toStartWith(AGENTS_MD_BODY_FIRST_LINE);
     });
 
-    test.skipIf(isWindows)(
-      "with Claude detected: CLAUDE.md is a symlink to AGENTS.md",
-      async () => {
-        const temp = tempDirWithFiles("bun-init-agents-claude", {});
+    test.skipIf(isWindows)("with Claude detected: CLAUDE.md is a symlink to AGENTS.md", async () => {
+      const temp = tempDirWithFiles("bun-init-agents-claude", {});
 
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "init", "-y"],
-          cwd: temp,
-          stdio: ["ignore", "pipe", "pipe"],
-          env: {
-            ...bunEnv,
-            ...claudeEnv(temp, true),
-            CURSOR_AGENT_RULE_DISABLED: "1",
-          },
-        });
-        expect(await proc.exited).toBe(0);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "init", "-y"],
+        cwd: temp,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...bunEnv,
+          ...claudeEnv(temp, true),
+          CURSOR_AGENT_RULE_DISABLED: "1",
+        },
+      });
+      expect(await proc.exited).toBe(0);
 
-        expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
-        expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
-        expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
-        // Following the symlink reaches AGENTS.md content.
-        expect(fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8")).toBe(
-          fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8"),
-        );
-      },
-    );
+      expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
+      expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
+      expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
+      // Following the symlink reaches AGENTS.md content.
+      expect(fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8")).toBe(
+        fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8"),
+      );
+    });
 
-    test.skipIf(isWindows)(
-      "with Cursor detected: .cursor/rules/*.mdc is a symlink to ../../AGENTS.md",
-      async () => {
-        const temp = tempDirWithFiles("bun-init-agents-cursor", {});
+    test.skipIf(isWindows)("with Cursor detected: .cursor/rules/*.mdc is a symlink to ../../AGENTS.md", async () => {
+      const temp = tempDirWithFiles("bun-init-agents-cursor", {});
 
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "init", "-y"],
-          cwd: temp,
-          stdio: ["ignore", "pipe", "pipe"],
-          env: {
-            ...bunEnv,
-            ...claudeEnv(temp, false),
-            CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
-            CURSOR_TRACE_ID: "test-trace-id",
-          },
-        });
-        expect(await proc.exited).toBe(0);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "init", "-y"],
+        cwd: temp,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...bunEnv,
+          ...claudeEnv(temp, false),
+          CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
+          CURSOR_TRACE_ID: "test-trace-id",
+        },
+      });
+      expect(await proc.exited).toBe(0);
 
-        expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
-        const cursorRule = path.join(temp, ".cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc");
-        expect(fs.lstatSync(cursorRule).isSymbolicLink()).toBe(true);
-        expect(fs.readlinkSync(cursorRule)).toBe("../../AGENTS.md");
-        expect(fs.readFileSync(cursorRule, "utf8")).toBe(
-          fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8"),
-        );
-      },
-    );
+      expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
+      const cursorRule = path.join(temp, ".cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc");
+      expect(fs.lstatSync(cursorRule).isSymbolicLink()).toBe(true);
+      expect(fs.readlinkSync(cursorRule)).toBe("../../AGENTS.md");
+      expect(fs.readFileSync(cursorRule, "utf8")).toBe(fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8"));
+    });
 
     test("BUN_AGENTS_MD_DISABLED=1: no AGENTS.md is written", async () => {
       const temp = tempDirWithFiles("bun-init-agents-disabled", {});
@@ -462,35 +454,32 @@ import path from "path";
       expect(fs.existsSync(path.join(temp, "package.json"))).toBe(true);
     });
 
-    test.skipIf(isWindows)(
-      "BUN_AGENTS_MD_DISABLED=1 with Claude: CLAUDE.md falls back to a real file",
-      async () => {
-        const temp = tempDirWithFiles("bun-init-agents-disabled-claude", {});
+    test.skipIf(isWindows)("BUN_AGENTS_MD_DISABLED=1 with Claude: CLAUDE.md falls back to a real file", async () => {
+      const temp = tempDirWithFiles("bun-init-agents-disabled-claude", {});
 
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "init", "-y"],
-          cwd: temp,
-          stdio: ["ignore", "pipe", "pipe"],
-          env: {
-            ...bunEnv,
-            ...claudeEnv(temp, true),
-            BUN_AGENTS_MD_DISABLED: "1",
-            CURSOR_AGENT_RULE_DISABLED: "1",
-          },
-        });
-        expect(await proc.exited).toBe(0);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "init", "-y"],
+        cwd: temp,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...bunEnv,
+          ...claudeEnv(temp, true),
+          BUN_AGENTS_MD_DISABLED: "1",
+          CURSOR_AGENT_RULE_DISABLED: "1",
+        },
+      });
+      expect(await proc.exited).toBe(0);
 
-        expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
-        // CLAUDE.md exists as a regular file (not a symlink), with the
-        // frontmatter stripped.
-        const claudeStat = fs.lstatSync(path.join(temp, "CLAUDE.md"));
-        expect(claudeStat.isSymbolicLink()).toBe(false);
-        expect(claudeStat.isFile()).toBe(true);
-        const claude = fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8");
-        expect(claude).not.toInclude(FRONTMATTER_LINE);
-        expect(claude.trimStart()).toStartWith(AGENTS_MD_BODY_FIRST_LINE);
-      },
-    );
+      expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
+      // CLAUDE.md exists as a regular file (not a symlink), with the
+      // frontmatter stripped.
+      const claudeStat = fs.lstatSync(path.join(temp, "CLAUDE.md"));
+      expect(claudeStat.isSymbolicLink()).toBe(false);
+      expect(claudeStat.isFile()).toBe(true);
+      const claude = fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8");
+      expect(claude).not.toInclude(FRONTMATTER_LINE);
+      expect(claude.trimStart()).toStartWith(AGENTS_MD_BODY_FIRST_LINE);
+    });
 
     test.skipIf(isWindows)(
       "existing AGENTS.md is never overwritten; CLAUDE.md symlink still points at it",

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -373,7 +373,7 @@ import path from "path";
           CURSOR_AGENT_RULE_DISABLED: "1",
         },
       });
-      expect(await proc.exited).toBe(0);
+      const exitCode = await proc.exited;
 
       expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
       expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(false);
@@ -383,9 +383,10 @@ import path from "path";
       // Frontmatter is stripped — body starts with the standard first line.
       expect(contents).not.toInclude(FRONTMATTER_LINE);
       expect(contents.trimStart()).toStartWith(AGENTS_MD_BODY_FIRST_LINE);
+      expect(exitCode).toBe(0);
     });
 
-    test.skipIf(isWindows)("with Claude detected: CLAUDE.md is a symlink to AGENTS.md", async () => {
+    test.skipIf(isWindows)("with Claude detected via $PATH: CLAUDE.md is a symlink to AGENTS.md", async () => {
       const temp = tempDirWithFiles("bun-init-agents-claude", {});
 
       await using proc = Bun.spawn({
@@ -398,7 +399,7 @@ import path from "path";
           CURSOR_AGENT_RULE_DISABLED: "1",
         },
       });
-      expect(await proc.exited).toBe(0);
+      const exitCode = await proc.exited;
 
       expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
       expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
@@ -407,30 +408,72 @@ import path from "path";
       expect(fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8")).toBe(
         fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8"),
       );
+      expect(exitCode).toBe(0);
     });
 
-    test.skipIf(isWindows)("with Cursor detected: .cursor/rules/*.mdc is a symlink to ../../AGENTS.md", async () => {
-      const temp = tempDirWithFiles("bun-init-agents-cursor", {});
+    test.skipIf(isWindows)(
+      "with Claude detected via CLAUDECODE=1: CLAUDE.md is a symlink to AGENTS.md",
+      async () => {
+        // Claude Code sets `CLAUDECODE=1` in every child process it spawns.
+        // Detection should work even when `claude` is not on $PATH, which is
+        // the common case inside containerised agent sessions.
+        const temp = tempDirWithFiles("bun-init-agents-claudecode-env", {});
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "init", "-y"],
-        cwd: temp,
-        stdio: ["ignore", "pipe", "pipe"],
-        env: {
-          ...bunEnv,
-          ...claudeEnv(temp, false),
-          CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
-          CURSOR_TRACE_ID: "test-trace-id",
-        },
-      });
-      expect(await proc.exited).toBe(0);
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "init", "-y"],
+          cwd: temp,
+          stdio: ["ignore", "pipe", "pipe"],
+          env: {
+            ...bunEnv,
+            ...claudeEnv(temp, false),
+            CLAUDECODE: "1",
+            CURSOR_AGENT_RULE_DISABLED: "1",
+          },
+        });
+        const exitCode = await proc.exited;
 
-      expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
-      const cursorRule = path.join(temp, ".cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc");
-      expect(fs.lstatSync(cursorRule).isSymbolicLink()).toBe(true);
-      expect(fs.readlinkSync(cursorRule)).toBe("../../AGENTS.md");
-      expect(fs.readFileSync(cursorRule, "utf8")).toBe(fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8"));
-    });
+        expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
+        expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
+        expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
+        expect(exitCode).toBe(0);
+      },
+    );
+
+    test.skipIf(isWindows)(
+      "with Cursor detected: .cursor/rules/*.mdc is a real file with frontmatter intact",
+      async () => {
+        // Cursor needs the YAML `globs` field to know when to activate the
+        // rule. AGENTS.md has the frontmatter stripped, so we can't share
+        // content via symlink — the cursor rule is always a real file.
+        const temp = tempDirWithFiles("bun-init-agents-cursor", {});
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "init", "-y"],
+          cwd: temp,
+          stdio: ["ignore", "pipe", "pipe"],
+          env: {
+            ...bunEnv,
+            ...claudeEnv(temp, false),
+            CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
+            CURSOR_TRACE_ID: "test-trace-id",
+          },
+        });
+        const exitCode = await proc.exited;
+
+        expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
+        const cursorRulePath = path.join(temp, ".cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc");
+        const cursorStat = fs.lstatSync(cursorRulePath);
+        expect(cursorStat.isSymbolicLink()).toBe(false);
+        expect(cursorStat.isFile()).toBe(true);
+        const cursorContents = fs.readFileSync(cursorRulePath, "utf8");
+        // The cursor rule keeps its full YAML frontmatter — without `globs`
+        // Cursor does not know which file types to activate on.
+        expect(cursorContents).toInclude(FRONTMATTER_LINE);
+        expect(cursorContents).toInclude("globs:");
+        expect(cursorContents).toInclude(AGENTS_MD_BODY_FIRST_LINE);
+        expect(exitCode).toBe(0);
+      },
+    );
 
     test("BUN_AGENTS_MD_DISABLED=1: no AGENTS.md is written", async () => {
       const temp = tempDirWithFiles("bun-init-agents-disabled", {});
@@ -447,11 +490,12 @@ import path from "path";
           CURSOR_AGENT_RULE_DISABLED: "1",
         },
       });
-      expect(await proc.exited).toBe(0);
+      const exitCode = await proc.exited;
 
       expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
       // Other expected files still land — just checking we didn't break init.
       expect(fs.existsSync(path.join(temp, "package.json"))).toBe(true);
+      expect(exitCode).toBe(0);
     });
 
     test.skipIf(isWindows)("BUN_AGENTS_MD_DISABLED=1 with Claude: CLAUDE.md falls back to a real file", async () => {
@@ -468,7 +512,7 @@ import path from "path";
           CURSOR_AGENT_RULE_DISABLED: "1",
         },
       });
-      expect(await proc.exited).toBe(0);
+      const exitCode = await proc.exited;
 
       expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
       // CLAUDE.md exists as a regular file (not a symlink), with the
@@ -479,6 +523,36 @@ import path from "path";
       const claude = fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8");
       expect(claude).not.toInclude(FRONTMATTER_LINE);
       expect(claude.trimStart()).toStartWith(AGENTS_MD_BODY_FIRST_LINE);
+      expect(exitCode).toBe(0);
+    });
+
+    test("BUN_AGENTS_MD_DISABLED=1 with Cursor: cursor rule still gets written with frontmatter", async () => {
+      // Verifies the .cursor/rules parent directory is created even when we
+      // bypass the AGENTS.md path entirely — regression guard for a latent
+      // ENOENT in the direct-file write.
+      const temp = tempDirWithFiles("bun-init-agents-disabled-cursor", {});
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "init", "-y"],
+        cwd: temp,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...bunEnv,
+          ...claudeEnv(temp, false),
+          BUN_AGENTS_MD_DISABLED: "1",
+          CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
+          CURSOR_TRACE_ID: "test-trace-id",
+        },
+      });
+      const exitCode = await proc.exited;
+
+      expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
+      const cursorRulePath = path.join(temp, ".cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc");
+      expect(fs.existsSync(cursorRulePath)).toBe(true);
+      const cursorContents = fs.readFileSync(cursorRulePath, "utf8");
+      expect(cursorContents).toInclude(FRONTMATTER_LINE);
+      expect(cursorContents).toInclude("globs:");
+      expect(exitCode).toBe(0);
     });
 
     test.skipIf(isWindows)(
@@ -499,13 +573,14 @@ import path from "path";
             CURSOR_AGENT_RULE_DISABLED: "1",
           },
         });
-        expect(await proc.exited).toBe(0);
+        const exitCode = await proc.exited;
 
         expect(fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8")).toBe(customContent);
         // Claude symlink still gets created, pointing at the user's file.
         expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
         expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
         expect(fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8")).toBe(customContent);
+        expect(exitCode).toBe(0);
       },
     );
 
@@ -523,11 +598,12 @@ import path from "path";
           CURSOR_TRACE_ID: "test-trace-id",
         },
       });
-      expect(await proc.exited).toBe(0);
+      const exitCode = await proc.exited;
 
       expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
       expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(false);
       expect(fs.existsSync(path.join(temp, ".cursor"))).toBe(false);
+      expect(exitCode).toBe(0);
     });
   });
 });

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -97,6 +97,7 @@ import path from "path";
     expect(readdirSync(path.join(temp, "mydir")).sort()).toMatchInlineSnapshot(`
     [
       ".gitignore",
+      "AGENTS.md",
       "README.md",
       "bun.lock",
       "index.ts",
@@ -136,6 +137,7 @@ import path from "path";
     expect(readdirSync(path.join(temp, "u t f ∞™/subpath")).sort()).toMatchInlineSnapshot(`
     [
       ".gitignore",
+      "AGENTS.md",
       "README.md",
       "bun.lock",
       "index.ts",
@@ -159,6 +161,7 @@ import path from "path";
     expect(readdirSync(path.join(temp, "mydir")).sort()).toMatchInlineSnapshot(`
     [
       ".gitignore",
+      "AGENTS.md",
       "README.md",
       "bun.lock",
       "index.ts",
@@ -194,6 +197,7 @@ import path from "path";
     expect(readdirSync(path.join(temp, "mydir")).sort()).toMatchInlineSnapshot(`
     [
       ".gitignore",
+      "AGENTS.md",
       "README.md",
       "bun.lock",
       "index.ts",
@@ -298,7 +302,7 @@ import path from "path";
 
   test("bun init --minimal only creates package.json and tsconfig.json", async () => {
     // Regression test for https://github.com/oven-sh/bun/issues/26050
-    // --minimal should not create .cursor/, CLAUDE.md, .gitignore, or README.md
+    // --minimal should not create .cursor/, CLAUDE.md, AGENTS.md, .gitignore, or README.md
     const temp = tempDirWithFiles("bun-init-minimal", {});
 
     const { exited } = Bun.spawn({
@@ -323,6 +327,218 @@ import path from "path";
     expect(fs.existsSync(path.join(temp, ".gitignore"))).toBe(false);
     expect(fs.existsSync(path.join(temp, "README.md"))).toBe(false);
     expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(false);
+    expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
     expect(fs.existsSync(path.join(temp, ".cursor"))).toBe(false);
+  });
+
+  // Feature: https://github.com/oven-sh/bun/issues/28909
+  //
+  // `bun init` writes an `AGENTS.md` (https://agents.md/) as the single source
+  // of truth. When Claude Code or Cursor is detected, their rule files become
+  // symlinks to `AGENTS.md` so the content stays in sync.
+  describe("AGENTS.md", () => {
+    // First non-empty line of the rule body. Used as a sanity check that
+    // the frontmatter was stripped.
+    const AGENTS_MD_BODY_FIRST_LINE = "Default to using Bun instead of Node.js.";
+    // A line that only appears in the YAML frontmatter.
+    const FRONTMATTER_LINE = "alwaysApply:";
+
+    // Create a stub `claude` executable in a dedicated bin dir. `bun init`
+    // uses `which("claude")` to detect Claude Code, so a zero-byte script on
+    // $PATH is enough. Returns a { PATH } env fragment that points to the
+    // stub; if `haveClaude` is false, points at an empty dir so no `claude`
+    // binary is discoverable (even if the host happens to have one).
+    function claudeEnv(temp: string, haveClaude: boolean) {
+      const binDir = path.join(temp, haveClaude ? ".stub-bin-with-claude" : ".stub-bin-empty");
+      fs.mkdirSync(binDir, { recursive: true });
+      if (haveClaude) {
+        const stub = path.join(binDir, "claude");
+        fs.writeFileSync(stub, "#!/bin/sh\nexit 0\n");
+        fs.chmodSync(stub, 0o755);
+      }
+      return { PATH: binDir };
+    }
+
+    test("default: writes AGENTS.md with frontmatter stripped, no CLAUDE.md, no .cursor/", async () => {
+      const temp = tempDirWithFiles("bun-init-agents-default", {});
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "init", "-y"],
+        cwd: temp,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...bunEnv,
+          ...claudeEnv(temp, false),
+          CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
+          CURSOR_AGENT_RULE_DISABLED: "1",
+        },
+      });
+      expect(await proc.exited).toBe(0);
+
+      expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
+      expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(false);
+      expect(fs.existsSync(path.join(temp, ".cursor"))).toBe(false);
+
+      const contents = fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8");
+      // Frontmatter is stripped — body starts with the standard first line.
+      expect(contents).not.toInclude(FRONTMATTER_LINE);
+      expect(contents.trimStart()).toStartWith(AGENTS_MD_BODY_FIRST_LINE);
+    });
+
+    test.skipIf(isWindows)(
+      "with Claude detected: CLAUDE.md is a symlink to AGENTS.md",
+      async () => {
+        const temp = tempDirWithFiles("bun-init-agents-claude", {});
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "init", "-y"],
+          cwd: temp,
+          stdio: ["ignore", "pipe", "pipe"],
+          env: {
+            ...bunEnv,
+            ...claudeEnv(temp, true),
+            CURSOR_AGENT_RULE_DISABLED: "1",
+          },
+        });
+        expect(await proc.exited).toBe(0);
+
+        expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
+        expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
+        expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
+        // Following the symlink reaches AGENTS.md content.
+        expect(fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8")).toBe(
+          fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8"),
+        );
+      },
+    );
+
+    test.skipIf(isWindows)(
+      "with Cursor detected: .cursor/rules/*.mdc is a symlink to ../../AGENTS.md",
+      async () => {
+        const temp = tempDirWithFiles("bun-init-agents-cursor", {});
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "init", "-y"],
+          cwd: temp,
+          stdio: ["ignore", "pipe", "pipe"],
+          env: {
+            ...bunEnv,
+            ...claudeEnv(temp, false),
+            CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
+            CURSOR_TRACE_ID: "test-trace-id",
+          },
+        });
+        expect(await proc.exited).toBe(0);
+
+        expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
+        const cursorRule = path.join(temp, ".cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc");
+        expect(fs.lstatSync(cursorRule).isSymbolicLink()).toBe(true);
+        expect(fs.readlinkSync(cursorRule)).toBe("../../AGENTS.md");
+        expect(fs.readFileSync(cursorRule, "utf8")).toBe(
+          fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8"),
+        );
+      },
+    );
+
+    test("BUN_AGENTS_MD_DISABLED=1: no AGENTS.md is written", async () => {
+      const temp = tempDirWithFiles("bun-init-agents-disabled", {});
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "init", "-y"],
+        cwd: temp,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...bunEnv,
+          ...claudeEnv(temp, false),
+          BUN_AGENTS_MD_DISABLED: "1",
+          CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
+          CURSOR_AGENT_RULE_DISABLED: "1",
+        },
+      });
+      expect(await proc.exited).toBe(0);
+
+      expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
+      // Other expected files still land — just checking we didn't break init.
+      expect(fs.existsSync(path.join(temp, "package.json"))).toBe(true);
+    });
+
+    test.skipIf(isWindows)(
+      "BUN_AGENTS_MD_DISABLED=1 with Claude: CLAUDE.md falls back to a real file",
+      async () => {
+        const temp = tempDirWithFiles("bun-init-agents-disabled-claude", {});
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "init", "-y"],
+          cwd: temp,
+          stdio: ["ignore", "pipe", "pipe"],
+          env: {
+            ...bunEnv,
+            ...claudeEnv(temp, true),
+            BUN_AGENTS_MD_DISABLED: "1",
+            CURSOR_AGENT_RULE_DISABLED: "1",
+          },
+        });
+        expect(await proc.exited).toBe(0);
+
+        expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
+        // CLAUDE.md exists as a regular file (not a symlink), with the
+        // frontmatter stripped.
+        const claudeStat = fs.lstatSync(path.join(temp, "CLAUDE.md"));
+        expect(claudeStat.isSymbolicLink()).toBe(false);
+        expect(claudeStat.isFile()).toBe(true);
+        const claude = fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8");
+        expect(claude).not.toInclude(FRONTMATTER_LINE);
+        expect(claude.trimStart()).toStartWith(AGENTS_MD_BODY_FIRST_LINE);
+      },
+    );
+
+    test.skipIf(isWindows)(
+      "existing AGENTS.md is never overwritten; CLAUDE.md symlink still points at it",
+      async () => {
+        const customContent = "# my custom agent rules\n\ndon't clobber me\n";
+        const temp = tempDirWithFiles("bun-init-agents-existing", {
+          "AGENTS.md": customContent,
+        });
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "init", "-y"],
+          cwd: temp,
+          stdio: ["ignore", "pipe", "pipe"],
+          env: {
+            ...bunEnv,
+            ...claudeEnv(temp, true),
+            CURSOR_AGENT_RULE_DISABLED: "1",
+          },
+        });
+        expect(await proc.exited).toBe(0);
+
+        expect(fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8")).toBe(customContent);
+        // Claude symlink still gets created, pointing at the user's file.
+        expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
+        expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
+        expect(fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8")).toBe(customContent);
+      },
+    );
+
+    test("BUN_AGENT_RULE_DISABLED=1: master kill switch — no agent files at all", async () => {
+      const temp = tempDirWithFiles("bun-init-agents-master-off", {});
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "init", "-y"],
+        cwd: temp,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...bunEnv,
+          ...claudeEnv(temp, true),
+          BUN_AGENT_RULE_DISABLED: "1",
+          CURSOR_TRACE_ID: "test-trace-id",
+        },
+      });
+      expect(await proc.exited).toBe(0);
+
+      expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
+      expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(false);
+      expect(fs.existsSync(path.join(temp, ".cursor"))).toBe(false);
+    });
   });
 });

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -76,6 +76,17 @@ import path from "path";
     expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
   }, 30_000);
 
+  // These snapshot tests compare `readdirSync` against an inline list that
+  // does not include any agent rule files, so they have to run with
+  // Claude/Cursor detection disabled — otherwise a developer with Cursor
+  // installed (or `claude` on $PATH) would see `.cursor/` or `CLAUDE.md`
+  // sneak into the listing.
+  const noAgentRulesEnv = {
+    ...bunEnv,
+    CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
+    CURSOR_AGENT_RULE_DISABLED: "1",
+  };
+
   test("bun init in folder", async () => {
     const temp = tempDirWithFiles("bun-init-in-folder", {
       "mydir": {
@@ -90,7 +101,7 @@ import path from "path";
       cmd: [bunExe(), "init", "-y", "mydir"],
       cwd: temp,
       stdio: ["ignore", "inherit", "inherit"],
-      env: bunEnv,
+      env: noAgentRulesEnv,
     });
     expect(await exited).toBe(0);
     expect(readdirSync(temp).sort()).toEqual(["mydir"]);
@@ -129,7 +140,7 @@ import path from "path";
       cmd: [bunExe(), "init", "-y", "u t f ∞™/subpath"],
       cwd: temp,
       stdio: ["ignore", "inherit", "inherit"],
-      env: bunEnv,
+      env: noAgentRulesEnv,
     });
     expect(await exited).toBe(0);
     expect(readdirSync(temp).sort()).toEqual(["u t f ∞™"]);
@@ -154,7 +165,7 @@ import path from "path";
       cmd: [bunExe(), "init", "-y", "mydir"],
       cwd: temp,
       stdio: ["ignore", "inherit", "inherit"],
-      env: bunEnv,
+      env: noAgentRulesEnv,
     });
     expect(await exited).toBe(0);
     expect(readdirSync(temp).sort()).toEqual(["mydir"]);
@@ -185,7 +196,7 @@ import path from "path";
       cmd: [bunExe(), "init", "mydir"],
       cwd: temp,
       stdio: ["ignore", "pipe", "pipe"],
-      env: bunEnv,
+      env: noAgentRulesEnv,
     });
     expect(await exited2).toBe(0);
     expect(await stderr.text()).toMatchInlineSnapshot(`
@@ -402,6 +413,7 @@ import path from "path";
       const exitCode = await proc.exited;
 
       expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
+      expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(true);
       expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
       expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
       // Following the symlink reaches AGENTS.md content.
@@ -431,6 +443,7 @@ import path from "path";
       const exitCode = await proc.exited;
 
       expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(true);
+      expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(true);
       expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
       expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
       expect(exitCode).toBe(0);
@@ -515,6 +528,7 @@ import path from "path";
       expect(fs.existsSync(path.join(temp, "AGENTS.md"))).toBe(false);
       // CLAUDE.md exists as a regular file (not a symlink), with the
       // frontmatter stripped.
+      expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(true);
       const claudeStat = fs.lstatSync(path.join(temp, "CLAUDE.md"));
       expect(claudeStat.isSymbolicLink()).toBe(false);
       expect(claudeStat.isFile()).toBe(true);
@@ -523,6 +537,44 @@ import path from "path";
       expect(claude.trimStart()).toStartWith(AGENTS_MD_BODY_FIRST_LINE);
       expect(exitCode).toBe(0);
     });
+
+    test.skipIf(isWindows)(
+      "BUN_AGENTS_MD_DISABLED=1 with pre-existing AGENTS.md: CLAUDE.md is a real file, not a symlink",
+      async () => {
+        // Regression guard: when the user has an AGENTS.md from a prior init
+        // and later opts out via `BUN_AGENTS_MD_DISABLED=1`, we must not
+        // treat the existing file as a symlink target — the user wants the
+        // old standalone-file workflow back.
+        const temp = tempDirWithFiles("bun-init-agents-disabled-existing", {
+          "AGENTS.md": "# stale content\n",
+        });
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "init", "-y"],
+          cwd: temp,
+          stdio: ["ignore", "pipe", "pipe"],
+          env: {
+            ...bunEnv,
+            ...claudeEnv(temp, true),
+            BUN_AGENTS_MD_DISABLED: "1",
+            CURSOR_AGENT_RULE_DISABLED: "1",
+          },
+        });
+        const exitCode = await proc.exited;
+
+        // AGENTS.md is untouched (never overwritten).
+        expect(fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8")).toBe("# stale content\n");
+        // CLAUDE.md is a real file with the full rule body, not a symlink
+        // to the stale AGENTS.md above.
+        expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(true);
+        const claudeStat = fs.lstatSync(path.join(temp, "CLAUDE.md"));
+        expect(claudeStat.isSymbolicLink()).toBe(false);
+        expect(claudeStat.isFile()).toBe(true);
+        const claude = fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8");
+        expect(claude.trimStart()).toStartWith(AGENTS_MD_BODY_FIRST_LINE);
+        expect(exitCode).toBe(0);
+      },
+    );
 
     test("BUN_AGENTS_MD_DISABLED=1 with Cursor: cursor rule still gets written with frontmatter", async () => {
       // Verifies the .cursor/rules parent directory is created even when we
@@ -575,6 +627,7 @@ import path from "path";
 
         expect(fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8")).toBe(customContent);
         // Claude symlink still gets created, pointing at the user's file.
+        expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(true);
         expect(fs.lstatSync(path.join(temp, "CLAUDE.md")).isSymbolicLink()).toBe(true);
         expect(fs.readlinkSync(path.join(temp, "CLAUDE.md"))).toBe("AGENTS.md");
         expect(fs.readFileSync(path.join(temp, "CLAUDE.md"), "utf8")).toBe(customContent);

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -724,6 +724,39 @@ import path from "path";
       expect(exitCode).toBe(0);
     });
 
+    test.skipIf(isWindows)(
+      "BUN_AGENTS_MD_DISABLED=1 with dangling AGENTS.md: symlink is left alone",
+      async () => {
+        // When the user opts out of `AGENTS.md` management, `bun init` must
+        // not touch the file at all — not even to clean up a dangling
+        // symlink left over from a prior init. This guards the lstat+unlink
+        // block from running outside the `BUN_AGENTS_MD_DISABLED` check.
+        const temp = tempDirWithFiles("bun-init-agents-disabled-dangling", {});
+        fs.symlinkSync("nonexistent-target.md", path.join(temp, "AGENTS.md"));
+        expect(fs.lstatSync(path.join(temp, "AGENTS.md")).isSymbolicLink()).toBe(true);
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "init", "-y"],
+          cwd: temp,
+          stdio: ["ignore", "pipe", "pipe"],
+          env: {
+            ...bunEnv,
+            ...claudeEnv(temp, false),
+            BUN_AGENTS_MD_DISABLED: "1",
+            CLAUDE_CODE_AGENT_RULE_DISABLED: "1",
+            CURSOR_AGENT_RULE_DISABLED: "1",
+          },
+        });
+        const exitCode = await proc.exited;
+
+        // The dangling symlink is still there — untouched.
+        const agentsStat = fs.lstatSync(path.join(temp, "AGENTS.md"));
+        expect(agentsStat.isSymbolicLink()).toBe(true);
+        expect(fs.readlinkSync(path.join(temp, "AGENTS.md"))).toBe("nonexistent-target.md");
+        expect(exitCode).toBe(0);
+      },
+    );
+
     test.skipIf(isWindows)("dangling .cursor/rules/*.mdc symlink is unlinked before re-create", async () => {
       // Regression: older versions of `bun init` symlinked the cursor
       // rule to `../../CLAUDE.md`. If the user later deleted `CLAUDE.md`

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -715,9 +715,7 @@ import path from "path";
       const agentsStat = fs.lstatSync(path.join(temp, "AGENTS.md"));
       expect(agentsStat.isSymbolicLink()).toBe(false);
       expect(agentsStat.isFile()).toBe(true);
-      expect(fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8").trimStart()).toStartWith(
-        AGENTS_MD_BODY_FIRST_LINE,
-      );
+      expect(fs.readFileSync(path.join(temp, "AGENTS.md"), "utf8").trimStart()).toStartWith(AGENTS_MD_BODY_FIRST_LINE);
       // And `CLAUDE.md` gets the symlink back to the fresh AGENTS.md,
       // not a degraded plain-file fallback.
       expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(true);

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -92,6 +92,13 @@ for (let key in bunEnv) {
 
 delete bunEnv.BUN_INSPECT_CONNECT_TO;
 delete bunEnv.NODE_ENV;
+// Insulate tests from the developer's terminal: Claude Code sets `CLAUDECODE=1`
+// and Cursor sets `CURSOR_TRACE_ID` in every child process they spawn.
+// `bun init` detects those to write agent rule files, which would leak into
+// unrelated snapshot tests. Tests that actually want those env vars set
+// them explicitly in their own spawn env.
+delete bunEnv.CLAUDECODE;
+delete bunEnv.CURSOR_TRACE_ID;
 
 if (isDebug) {
   // This makes debug build memory leak tests more reliable.

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -92,13 +92,19 @@ for (let key in bunEnv) {
 
 delete bunEnv.BUN_INSPECT_CONNECT_TO;
 delete bunEnv.NODE_ENV;
-// Insulate tests from the developer's terminal: Claude Code sets `CLAUDECODE=1`
-// and Cursor sets `CURSOR_TRACE_ID` in every child process they spawn.
-// `bun init` detects those to write agent rule files, which would leak into
-// unrelated snapshot tests. Tests that actually want those env vars set
-// them explicitly in their own spawn env.
+// Insulate tests from the developer's terminal. Claude Code sets `CLAUDECODE=1`
+// and Cursor sets `CURSOR_TRACE_ID` in every child process they spawn; the
+// four `*_DISABLED` variables are the opt-out kill switches for `bun init`'s
+// agent rule generation. Any of these leaking from the shell would flip
+// detection in unrelated tests and cause deterministic, developer-specific
+// failures. Tests that actually need any of these set them explicitly in
+// their own spawn env.
 delete bunEnv.CLAUDECODE;
 delete bunEnv.CURSOR_TRACE_ID;
+delete bunEnv.BUN_AGENT_RULE_DISABLED;
+delete bunEnv.BUN_AGENTS_MD_DISABLED;
+delete bunEnv.CLAUDE_CODE_AGENT_RULE_DISABLED;
+delete bunEnv.CURSOR_AGENT_RULE_DISABLED;
 
 if (isDebug) {
   // This makes debug build memory leak tests more reliable.


### PR DESCRIPTION
Closes #28909.

### What

`bun init` now writes `AGENTS.md` (https://agents.md/) as the single source of truth for AI agent rules. When Claude Code or Cursor is detected, the corresponding rule file is created as a **symlink** to `AGENTS.md` so all the tools stay in sync from one file.

### Behavior

| Detected              | Result                                                         |
| --------------------- | -------------------------------------------------------------- |
| (none)                | `AGENTS.md`                                                    |
| Claude Code           | `AGENTS.md`, `CLAUDE.md → AGENTS.md`                           |
| Cursor                | `AGENTS.md`, `.cursor/rules/*.mdc → ../../AGENTS.md`           |
| Claude + Cursor       | `AGENTS.md`, plus both symlinks pointing to `AGENTS.md`        |

Fallbacks (Windows, symlink failure, `BUN_AGENTS_MD_DISABLED=1`) write the rule file directly with the same frontmatter-trimmed content — matches the pre-existing behavior.

### New env var

- `BUN_AGENTS_MD_DISABLED=1` — skip writing `AGENTS.md`. `CLAUDE.md` / `.cursor/rules/*.mdc` still get created (as real files), preserving the old workflow for users who don't want `AGENTS.md`.

Existing flags are unchanged:
- `BUN_AGENT_RULE_DISABLED=1` — master kill switch
- `CLAUDE_CODE_AGENT_RULE_DISABLED=1`
- `CURSOR_AGENT_RULE_DISABLED=1`

### Existing `AGENTS.md` is never overwritten

Matches the current "never overwrite `CLAUDE.md`" behavior. An existing user-authored `AGENTS.md` is still used as the symlink target for `CLAUDE.md` and the cursor rule, so the user's custom content becomes the rules Claude/Cursor see — which is almost certainly what they want.

### Tests

`test/cli/init/init.test.ts` gained a `describe("AGENTS.md")` block covering:

1. Default → `AGENTS.md` created with frontmatter stripped; no `CLAUDE.md`; no `.cursor/`
2. Claude detected → `CLAUDE.md` is a symlink → `AGENTS.md`
3. Cursor detected → `.cursor/rules/*.mdc` is a symlink → `../../AGENTS.md`
4. `BUN_AGENTS_MD_DISABLED=1` → no `AGENTS.md`
5. `BUN_AGENTS_MD_DISABLED=1` + Claude → `CLAUDE.md` falls back to a real file (not a symlink), with frontmatter stripped
6. Existing `AGENTS.md` → preserved verbatim; `CLAUDE.md` symlink still created pointing at it
7. `BUN_AGENT_RULE_DISABLED=1` → nothing written

Existing `bun init` snapshot tests updated to include `AGENTS.md` in the directory listings.

### Verification

```
$ bun bd test test/cli/init/init.test.ts
 17 pass
 0 fail
```

Fail-before gate: stashed `src/` changes, 4 of the 7 new `AGENTS.md` tests fail against the baseline; all 7 pass after popping the stash back in.