### PR TITLE
sqlite: bound query cache by SQL byte size

### DIFF
--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -180,7 +180,7 @@ const query = db.query(`select "Hello world" as message`);
 <Note>
 **What does "cached" mean?**
 
-The caching refers to the **compiled prepared statement** (the SQL bytecode), not the query results. When you call `db.query()` with the same SQL string multiple times, Bun returns the same cached `Statement` object instead of recompiling the SQL. The cache holds the `Database.MAX_QUERY_CACHE_SIZE` (default 20) most recently used SQL strings. Evicted statements keep working, but a later `db.query()` with the same string compiles a new one.
+The caching refers to the **compiled prepared statement** (the SQL bytecode), not the query results. When you call `db.query()` with the same SQL string multiple times, Bun returns the same cached `Statement` object instead of recompiling the SQL. The cache holds the `Database.MAX_QUERY_CACHE_SIZE` (default 20) most recently used SQL strings, subject to a `Database.MAX_QUERY_CACHE_BYTES` (default 2 MB) budget on the total cached SQL text. A single query whose SQL text exceeds `Database.MAX_QUERY_CACHE_ENTRY_BYTES` (default 64 KB) is never cached. Evicted statements keep working, but a later `db.query()` with the same string compiles a new one.
 
 It is safe to reuse a cached statement with different parameter values:
 

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -143,6 +143,32 @@ declare module "bun:sqlite" {
     static MAX_QUERY_CACHE_SIZE: number;
 
     /**
+     * Soft cap on the total SQL text size the {@link Database.query} cache
+     * may pin across all entries, measured in UTF-16 code units
+     * (`String#length` — equal to UTF-8 bytes for ASCII SQL, up to 3× smaller
+     * for non-ASCII). Least-recently-used entries are evicted until a new
+     * entry fits.
+     *
+     * Writable at runtime; changes apply to subsequent `db.query()` calls.
+     *
+     * @default 2 * 1024 * 1024
+     */
+    static MAX_QUERY_CACHE_BYTES: number;
+
+    /**
+     * A single query whose SQL text exceeds this (measured in UTF-16 code
+     * units; see {@link Database.MAX_QUERY_CACHE_BYTES}) is never cached by
+     * `db.query()`. Large dynamic SQL (for example a multi-megabyte
+     * `IN (...)` list) gets little reuse value from caching, and one cached
+     * prepared statement can pin many MB.
+     *
+     * Writable at runtime; changes apply to subsequent `db.query()` calls.
+     *
+     * @default 64 * 1024
+     */
+    static MAX_QUERY_CACHE_ENTRY_BYTES: number;
+
+    /**
      * Execute a SQL query **without returning any results**.
      *
      * This does not cache the query. To run a query multiple times, use {@link prepare} instead.

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -431,6 +431,7 @@ class Database implements SqliteTypes.Database {
   #internalFlags = 0;
   #handle;
   #queryCache: Map<string, Statement> = new Map();
+  #queryCacheBytes = 0;
   filename;
   get handle() {
     return this.#handle;
@@ -499,12 +500,14 @@ class Database implements SqliteTypes.Database {
   close(throwOnError = false) {
     // native close finalizes every kOwnedByDatabaseFlag statement (query cache + transaction controller)
     this.#queryCache.$clear();
+    this.#queryCacheBytes = 0;
     controllers?.delete(this);
     return SQL.close(this.#handle, throwOnError);
   }
   clearQueryCache() {
     this.#queryCache.$forEach(stmt => stmt.finalize());
     this.#queryCache.$clear();
+    this.#queryCacheBytes = 0;
   }
 
   run(query, ...params) {
@@ -534,6 +537,8 @@ class Database implements SqliteTypes.Database {
   }
 
   static MAX_QUERY_CACHE_SIZE = 20;
+  static MAX_QUERY_CACHE_BYTES = 2 * 1024 * 1024;
+  static MAX_QUERY_CACHE_ENTRY_BYTES = 64 * 1024;
 
   get [cachedCount]() {
     return this.#queryCache.$size;
@@ -544,7 +549,8 @@ class Database implements SqliteTypes.Database {
       throw new TypeError(`Expected 'query' to be a string, got '${typeof query}'`);
     }
 
-    if (query.length === 0) {
+    const queryLength = query.length;
+    if (queryLength === 0) {
       throw new Error("SQL query cannot be empty.");
     }
 
@@ -553,17 +559,27 @@ class Database implements SqliteTypes.Database {
     if (stmt !== undefined) {
       // LRU: re-insert so the most recently used key is last
       cache.$delete(query);
+      this.#queryCacheBytes -= queryLength;
       if (stmt.isFinalized) stmt = this[kPrepareOwned](query, constants.SQLITE_PREPARE_PERSISTENT);
-      cache.$set(query, stmt);
+      if (Database.MAX_QUERY_CACHE_SIZE > 0) {
+        cache.$set(query, stmt);
+        this.#queryCacheBytes += queryLength;
+      }
       return stmt;
     }
 
     stmt = this[kPrepareOwned](query, constants.SQLITE_PREPARE_PERSISTENT);
     const max = Database.MAX_QUERY_CACHE_SIZE;
-    if (max > 0) {
+    if (max > 0 && queryLength <= Database.MAX_QUERY_CACHE_ENTRY_BYTES) {
+      const maxBytes = Database.MAX_QUERY_CACHE_BYTES;
       // evicted statements stay usable; close() still finalizes them via kOwnedByDatabaseFlag
-      if (cache.$size >= max) cache.$delete(cache.$keys().next().value);
+      while (cache.$size > 0 && (cache.$size >= max || this.#queryCacheBytes + queryLength > maxBytes)) {
+        const oldest = cache.$keys().next().value;
+        cache.$delete(oldest);
+        this.#queryCacheBytes -= oldest.length;
+      }
       cache.$set(query, stmt);
+      this.#queryCacheBytes += queryLength;
     }
     return stmt;
   }

--- a/src/jsc/bindings/NodeFSStatBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatBinding.cpp
@@ -41,6 +41,23 @@ using namespace WebCore;
 #define mode_t int32_t
 #endif
 
+// file-local: sibling TUs in a unified-source bundle gate fs.constants on #ifdef
+#pragma push_macro("S_IFMT")
+#pragma push_macro("S_IFDIR")
+#pragma push_macro("S_IFCHR")
+#pragma push_macro("S_IFBLK")
+#pragma push_macro("S_IFREG")
+#pragma push_macro("S_IFIFO")
+#pragma push_macro("S_IFLNK")
+#pragma push_macro("S_IFSOCK")
+#pragma push_macro("S_ISBLK")
+#pragma push_macro("S_ISCHR")
+#pragma push_macro("S_ISDIR")
+#pragma push_macro("S_ISFIFO")
+#pragma push_macro("S_ISREG")
+#pragma push_macro("S_ISLNK")
+#pragma push_macro("S_ISSOCK")
+
 #ifndef S_IFMT
 #define S_IFMT 0170000
 #endif
@@ -966,4 +983,23 @@ void initJSBigIntStatsClassStructure(JSC::LazyClassStructure::Initializer& init)
 #ifdef BUN_PUSHED_MODE_T
 #pragma pop_macro("mode_t")
 #undef BUN_PUSHED_MODE_T
+#endif
+
+#if OS(WINDOWS)
+// Mirror the push_macro block at the top.
+#pragma pop_macro("S_ISSOCK")
+#pragma pop_macro("S_ISLNK")
+#pragma pop_macro("S_ISREG")
+#pragma pop_macro("S_ISFIFO")
+#pragma pop_macro("S_ISDIR")
+#pragma pop_macro("S_ISCHR")
+#pragma pop_macro("S_ISBLK")
+#pragma pop_macro("S_IFSOCK")
+#pragma pop_macro("S_IFLNK")
+#pragma pop_macro("S_IFIFO")
+#pragma pop_macro("S_IFREG")
+#pragma pop_macro("S_IFBLK")
+#pragma pop_macro("S_IFCHR")
+#pragma pop_macro("S_IFDIR")
+#pragma pop_macro("S_IFMT")
 #endif

--- a/test/regression/issue/28911.test.ts
+++ b/test/regression/issue/28911.test.ts
@@ -1,0 +1,252 @@
+// https://github.com/oven-sh/bun/issues/28911
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+import { isASAN } from "harness";
+
+const cacheCountSymbol = Symbol.for("Bun.Database.cache.count");
+
+// Build a SELECT ... IN (...) large enough to exceed the per-entry cap.
+// Each literal is 19 bytes; 10k literals ≈ 190 KB of SQL text.
+const buildBigInClause = (n: number) =>
+  Array.from({ length: n }, (_, i) => `'${i.toString(16).padStart(16, "0")}'`).join(",");
+
+test("large dynamic queries do not fill the query cache (#28911)", () => {
+  using db = new Database(":memory:");
+  db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, template_id TEXT)");
+
+  const baseSql = `SELECT id FROM t WHERE template_id IN (${buildBigInClause(10_000)}) LIMIT 1`;
+  expect(baseSql.length).toBeGreaterThan(Database.MAX_QUERY_CACHE_ENTRY_BYTES);
+
+  // Each iteration differs only in a trailing comment, so the cache key never matches.
+  for (let i = 0; i < 25; i++) {
+    const stmt = db.query(`${baseSql} /*iter=${i}*/`);
+    stmt.all();
+    stmt.finalize();
+  }
+
+  expect(db[cacheCountSymbol]).toBe(0);
+});
+
+test("small queries still populate the query cache", () => {
+  using db = new Database(":memory:");
+  db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)");
+  db.exec("INSERT INTO t (name) VALUES ('a'), ('b'), ('c')");
+
+  // Same SQL text reuses one slot, regardless of call count.
+  for (let i = 0; i < 5; i++) {
+    expect(db.query("SELECT * FROM t WHERE name = ?").all("a")).toEqual([{ id: 1, name: "a" }]);
+  }
+  expect(db[cacheCountSymbol]).toBe(1);
+
+  for (let i = 0; i < 5; i++) {
+    db.query(`SELECT ${i} AS x, id FROM t WHERE id = ?`).all(1);
+  }
+  expect(db[cacheCountSymbol]).toBe(6);
+});
+
+test("query cache evicts the least recently used entry once the count cap is reached (#28911)", () => {
+  using db = new Database(":memory:");
+  db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+  db.exec("INSERT INTO t (id) VALUES (0), (1), (2)");
+  const max = Database.MAX_QUERY_CACHE_SIZE;
+
+  // Fill the cache, keeping a reference to the oldest entry.
+  const oldestStmt = db.query(`SELECT 0 AS x, id FROM t`);
+  oldestStmt.all();
+  for (let i = 1; i < max; i++) {
+    db.query(`SELECT ${i} AS x, id FROM t`).all();
+  }
+  expect(db[cacheCountSymbol]).toBe(max);
+
+  // Insert more distinct queries than the cap — the oldest entries are evicted.
+  for (let i = max; i < max + 10; i++) {
+    db.query(`SELECT ${i} AS x, id FROM t`).all();
+  }
+  expect(db[cacheCountSymbol]).toBe(max);
+
+  // Evicted Statement stays usable via the held caller reference.
+  expect(oldestStmt.isFinalized).toBe(false);
+  expect(oldestStmt.all()).toEqual([
+    { x: 0, id: 0 },
+    { x: 0, id: 1 },
+    { x: 0, id: 2 },
+  ]);
+
+  // Re-querying the oldest SQL prepares a fresh Statement.
+  const afterEviction = db.query(`SELECT 0 AS x, id FROM t`);
+  expect(afterEviction).not.toBe(oldestStmt);
+  expect(oldestStmt.isFinalized).toBe(false);
+  expect(oldestStmt.all()).toHaveLength(3);
+});
+
+test("synchronous loop of large dynamic queries does not pin memory (#28911)", async () => {
+  // The exact repro from the issue: a synchronous loop that throws away
+  // each Statement without finalize(). Inside one JS job, queries above
+  // MAX_QUERY_CACHE_ENTRY_BYTES must NOT be retained by the database —
+  // neither by the cache (excluded by the byte cap) nor by any weak-ref
+  // book-keeping (WeakRef targets are KeptAlive until the next job
+  // boundary, so tracking uncached Statements would pin them all for the
+  // entire loop and re-create the OOM in a different shape).
+  using db = new Database(":memory:");
+  db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, template_id TEXT)");
+  // ~190 KB of SQL text per iteration, similar shape to the repro.
+  const baseSql = `SELECT id FROM t WHERE template_id IN (${buildBigInClause(10_000)}) LIMIT 1`;
+  expect(baseSql.length).toBeGreaterThan(Database.MAX_QUERY_CACHE_ENTRY_BYTES);
+
+  Bun.gc(true);
+  const startRss = process.memoryUsage.rss();
+  for (let i = 0; i < 30; i++) {
+    db.query(`${baseSql} /*iter=${i}*/`).all();
+  }
+  // Without the per-entry cap the count-only cache would pin the 20 newest
+  // of these statements; with it the cache must stay empty.
+  expect(db[cacheCountSymbol]).toBe(0);
+
+  // Yield so JSC's WeakRef [[KeptAlive]] list clears, then GC.
+  await Promise.resolve();
+  Bun.gc(true);
+  const endRss = process.memoryUsage.rss();
+
+  // Coarse OOM backstop only; the discriminating check is the cache count
+  // above. Measured fixed-path growth is ~191 MB under ASAN (quarantine
+  // pins the loop's churn) and far lower on release.
+  const growthMB = (endRss - startRss) / 1024 / 1024;
+  expect(growthMB).toBeLessThan(isASAN ? 400 : 200);
+});
+
+test("evicted cache entry that is re-queried moves to newest slot (#28911)", () => {
+  using db = new Database(":memory:");
+  db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+  const max = Database.MAX_QUERY_CACHE_SIZE;
+
+  for (let i = 0; i < max; i++) {
+    db.query(`SELECT ${i} AS x FROM t`).all();
+  }
+  expect(db[cacheCountSymbol]).toBe(max);
+
+  // Externally-finalize the oldest entry, then re-query. The hit path
+  // must move the refreshed entry to the NEWEST slot; otherwise the next
+  // distinct query would immediately evict it.
+  const oldestSql = `SELECT 0 AS x FROM t`;
+  db.query(oldestSql).finalize();
+  const refreshed = db.query(oldestSql);
+  expect(refreshed.isFinalized).toBe(false);
+
+  for (let i = max; i < max + max - 1; i++) {
+    db.query(`SELECT ${i} AS x FROM t`).all();
+  }
+  expect(db[cacheCountSymbol]).toBe(max);
+
+  // If the slot move worked, this is a cache hit on the same instance.
+  const stillCached = db.query(oldestSql);
+  expect(stillCached).toBe(refreshed);
+});
+
+test("disabling the cache at runtime drains entries on the hit path (#28911)", () => {
+  // Setting MAX_QUERY_CACHE_SIZE = 0 at runtime must fully disable caching
+  // even on the hit path that replaces a finalized entry.
+  const prevCount = Database.MAX_QUERY_CACHE_SIZE;
+  using db = new Database(":memory:");
+  try {
+    db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+    const sql = "SELECT 1 AS x FROM t";
+
+    const first = db.query(sql);
+    first.all();
+    expect(db[cacheCountSymbol]).toBe(1);
+
+    Database.MAX_QUERY_CACHE_SIZE = 0;
+    first.finalize();
+
+    const replacement = db.query(sql);
+    expect(replacement).not.toBe(first);
+    expect(replacement.isFinalized).toBe(false);
+    expect(replacement.all()).toEqual([]);
+    expect(db[cacheCountSymbol]).toBe(0);
+  } finally {
+    Database.MAX_QUERY_CACHE_SIZE = prevCount;
+  }
+});
+
+test("standalone clearQueryCache() preserves held uncached and evicted statements (#28911)", () => {
+  using db = new Database(":memory:");
+  db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+  db.exec("INSERT INTO t (id) VALUES (1), (2), (3)");
+  const max = Database.MAX_QUERY_CACHE_SIZE;
+
+  // Grab one evicted statement and one that was never cacheable
+  // (SQL > per-entry cap).
+  const evictable = db.query(`SELECT 0 AS x, id FROM t`);
+  evictable.all();
+  for (let i = 1; i < max + 5; i++) {
+    db.query(`SELECT ${i} AS x, id FROM t`).all();
+  }
+  expect(evictable.isFinalized).toBe(false);
+
+  const bigSql = `SELECT id FROM t WHERE id IN (${buildBigInClause(10_000)})`;
+  expect(bigSql.length).toBeGreaterThan(Database.MAX_QUERY_CACHE_ENTRY_BYTES);
+  const transient = db.query(bigSql);
+  transient.all();
+  expect(transient.isFinalized).toBe(false);
+
+  // Standalone clearQueryCache() drops the cache but must NOT destroy
+  // statements the caller still holds — that's only close()'s job.
+  db.clearQueryCache();
+  expect(db[cacheCountSymbol]).toBe(0);
+  expect(evictable.isFinalized).toBe(false);
+  expect(transient.isFinalized).toBe(false);
+  expect(() => evictable.all()).not.toThrow();
+  expect(() => transient.all()).not.toThrow();
+  expect(evictable.all()).toHaveLength(3);
+});
+
+test("query cache total SQL bytes are bounded (#28911)", () => {
+  // Raise per-entry cap and count cap so the total byte cap is what binds.
+  const prevCount = Database.MAX_QUERY_CACHE_SIZE;
+  const prevEntryBytes = Database.MAX_QUERY_CACHE_ENTRY_BYTES;
+  Database.MAX_QUERY_CACHE_SIZE = 1000;
+  Database.MAX_QUERY_CACHE_ENTRY_BYTES = 512 * 1024;
+  try {
+    using db = new Database(":memory:");
+    db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+
+    // ~120 KB each, under the raised per-entry cap but enough to exceed 2 MB total.
+    const baseSql = `SELECT id FROM t WHERE id IN (${buildBigInClause(6_000)})`;
+    expect(baseSql.length).toBeLessThan(Database.MAX_QUERY_CACHE_ENTRY_BYTES);
+
+    for (let i = 0; i < 50; i++) {
+      const stmt = db.query(`${baseSql} /*iter=${i}*/`);
+      stmt.all();
+      stmt.finalize();
+    }
+
+    const maxEntries = Math.floor(Database.MAX_QUERY_CACHE_BYTES / baseSql.length) + 1;
+    const count = db[cacheCountSymbol] as number;
+    expect(count).toBeLessThanOrEqual(maxEntries);
+    expect(count).toBeGreaterThan(0);
+    expect(count).toBeLessThan(50);
+  } finally {
+    Database.MAX_QUERY_CACHE_SIZE = prevCount;
+    Database.MAX_QUERY_CACHE_ENTRY_BYTES = prevEntryBytes;
+  }
+});
+
+test("cache stays consistent when re-preparing a finalized hit throws (#28911)", () => {
+  using db = new Database(":memory:");
+  db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+  const sql = "SELECT id FROM t";
+
+  db.query(sql).finalize();
+  expect(db[cacheCountSymbol]).toBe(1);
+
+  // A hit on the finalized entry re-prepares; make that prepare fail.
+  db.exec("DROP TABLE t");
+  expect(() => db.query(sql)).toThrow(/no such table/);
+  expect(db[cacheCountSymbol]).toBe(0);
+
+  // The failed hit must not corrupt the cache: re-creating the table makes
+  // the same SQL cacheable again.
+  db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+  expect(db.query(sql).all()).toEqual([]);
+  expect(db[cacheCountSymbol]).toBe(1);
+});


### PR DESCRIPTION
Fixes #28911

### Problem

- Running `db.query()` in a loop with large dynamic SQL — a `SELECT … IN (…)` with 300k inlined literals is ~5.7 MB of SQL text per call, with a unique trailing comment per iteration — OOMs a 1 GB container after ~20 iterations (RSS plateaus ~1.3 GB).
- The query cache is bounded only by entry count (`MAX_QUERY_CACHE_SIZE = 20`), so a single 5.7 MB query counts the same as a 30-byte one; 20 huge entries pin ~1 GB of SQL text + prepared-statement state until `close()`.
- Reproduced on 1.3.13 linux-x64 (repro + numbers: https://github.com/oven-sh/bun/issues/28911#issuecomment-4445149682). The LRU cache rework in #36793 did not change this: the cache is still count-bounded, so the 20 most recent huge statements stay pinned.

### Fix

Byte caps layered on the existing LRU Map cache (`src/js/bun/sqlite.ts`), as two writable statics on `Database`:

- `MAX_QUERY_CACHE_ENTRY_BYTES` (64 KB): a query whose SQL exceeds this is never cached. This alone fixes the reported case — each 5.7 MB statement runs transient and is released by GC / at close, instead of being pinned by the cache.
- `MAX_QUERY_CACHE_BYTES` (2 MB): soft total budget across entries; inserting a new entry evicts LRU entries until the new one fits. Defends configurations that raise the count or per-entry caps.
- The hit path now honors a runtime `MAX_QUERY_CACHE_SIZE = 0`: it drains the hit entry instead of re-inserting it, so disabling the cache actually empties it (previously hit entries were re-inserted forever).
- Evicted statements keep working via caller-held references; native close still finalizes them through `kOwnedByDatabaseFlag` (unchanged from #36793).
- Types for the two new statics in `packages/bun-types/sqlite.d.ts`.
- Verified: `test/regression/issue/28911.test.ts` (8 tests — entry-cap exclusion, cache population, LRU eviction with usable evicted statements, the issue's 30-iteration loop staying RSS-bounded, LRU slot refresh, runtime disable draining, `clearQueryCache()` preserving held statements, byte cap binding when count cap is raised). 8/8 pass with the fix; 5/8 fail without it. Full `test/js/bun/sqlite/sqlite.test.js` suite: 115/115 pass.

Also includes a Windows-only fix in `src/jsc/bindings/NodeFSStatBinding.cpp`: the POSIX file-type fallback defines (`S_IFBLK`, `S_IFSOCK`, …) are now bracketed with `push_macro`/`pop_macro`, mirroring the existing `mode_t` pattern. Unbracketed, they leak into sibling `.cpp` files in a unified-source bundle; `ProcessBindingConstants.cpp` and `NodeConstantsModule.h` gate `fs.constants.S_IFBLK`/`S_IFSOCK` exports on `#ifdef`, so the leak spuriously exports them on Windows and breaks the `fs.constants` allowlist test.

### Background

- `db.query()` caches prepared statements keyed by exact SQL text so repeated identical queries skip `sqlite3_prepare_v3`. Since #36793 that cache is an insertion-ordered `Map` with LRU eviction, and statements created by `query()` are marked database-owned so native `close()` finalizes them.
- A prepared statement for a multi-megabyte `IN (...)` list pins far more than its SQL text (parse tree + program), which is why 20 of them exceed 1 GB.
- Byte caps measure `String#length` (UTF-16 code units): equal to UTF-8 bytes for ASCII SQL, up to 3× smaller for non-ASCII. They are soft caps.
- Unified-source builds concatenate sibling `.cpp` files into one translation unit, so file-scope `#define`s in one file are visible to the next unless explicitly scoped.

<details>
<summary>Rebase history: conflict resolution against #36793, and the superseded pre-rebase design</summary>

This PR originally replaced the then-current parallel-array cache with an insertion-ordered `Map`, FIFO eviction, and the same two byte caps. Main's #36793 later landed its own `Map`-based LRU cache with native statement ownership (`kOwnedByDatabaseFlag`), overlapping most of that refactor.

Resolution when rebasing: adopted main's #36793 implementation as the base and re-applied only the remaining delta — the two byte-cap statics, the per-entry eligibility check and byte-budget eviction loop on the miss path, the hit-path drain for runtime `MAX_QUERY_CACHE_SIZE = 0`, byte-count resets in `close()`/`clearQueryCache()`, the `.d.ts` docs, and the regression test (re-validated against #36793 semantics; FIFO naming updated to LRU). The old design's JS-side eviction-finalization and weak tracking are superseded by #36793's native ownership and were dropped.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 20 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/28911.test.ts"
bun test v1.4.0 (459233d90)

test/regression/issue/28911.test.ts:
13 | test("large dynamic queries do not fill the query cache (#28911)", () => {
14 |   using db = new Database(":memory:");
15 |   db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, template_id TEXT)");
16 | 
17 |   const baseSql = `SELECT id FROM t WHERE template_id IN (${buildBigInClause(10_000)}) LIMIT 1`;
18 |   expect(baseSql.length).toBeGreaterThan(Database.MAX_QUERY_CACHE_ENTRY_BYTES);
                              ^
error: Expected and actual values must be numbers or bigints
      at <anonymous> (/workspace/bun/test/regression/issue/28911.test.ts:18:26)
(fail) large dynamic queries do not fill the query cache (#28911) [878.86ms]
(pass) small queries still populate the query cache [26.26ms]
(pass) query cache evicts the least recently used entry once the count cap is reached (#28911) [26.33ms]
89 |   // entire loop and re-create the OOM in a different shape).
90 |   using db = new Database(":memory:");
91 |   db.exec("CREATE TA
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (6b92dc836)

test/regression/issue/28911.test.ts:
(pass) large dynamic queries do not fill the query cache (#28911) [128.60ms]
(pass) small queries still populate the query cache [0.83ms]
(pass) query cache evicts the least recently used entry once the count cap is reached (#28911) [1.01ms]
(pass) synchronous loop of large dynamic queries does not pin memory (#28911) [169.40ms]
(pass) evicted cache entry that is re-queried moves to newest slot (#28911) [1.17ms]
(pass) disabling the cache at runtime drains entries on the hit path (#28911) [0.41ms]
(pass) standalone clearQueryCache() preserves held uncached and evicted statements (#28911) [17.21ms]
(pass) query cache total SQL bytes are bounded (#28911) [170.29ms]
(pass) cache stays consistent when re-preparing a finalized hit throws (#28911) [0.61ms]

 9 pass
 0 fail
 46 expect() calls
Ran 9 tests across 1 file. [713.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/28911.test.ts"
bun test v1.4.0 (459233d90)

test/regression/issue/28911.test.ts:
(pass) large dynamic queries do not fill the query cache (#28911) [1314.16ms]
(pass) small queries still populate the query cache [13.93ms]
(pass) query cache evicts the least recently used entry once the count cap is reached (#28911) [25.42ms]
(pass) synchronous loop of large dynamic queries does not pin memory (#28911) [1808.59ms]
(pass) evicted cache entry that is re-queried moves to newest slot (#28911) [19.79ms]
(pass) disabling the cache at runtime drains entries on the hit path (#28911) [7.48ms]
(pass) standalone clearQueryCache() preserves held uncached and evicted statements (#28911) [851.67ms]
(pass) query cache total SQL bytes are bounded (#28911) [2126.86ms]
(pass) cache stays consistent when re-preparing a finalized hit throws (#28911) [12.05ms]

 9 pass
 0 fail
 46 expect() calls
Ran 9 tests across 1 file. [9.06s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 773ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[2/23] gen cpp.rs (cppbind)
[3/23] gen JS modules (bundle-modules)
Preprocess modules (9172ms)
Bundle modules (65ms)
Postprocesss modules (199ms)
Bundle Functions (800ms)
Generate Code (30ms)

[10.29s] Bundled "src/js" for production
  2633 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/sqlite.mdx                |   2 +-
 packages/bun-types/sqlite.d.ts         |  26 ++++
 src/js/bun/sqlite.ts                   |  24 +++-
 src/jsc/bindings/NodeFSStatBinding.cpp |  36 +++++
 test/regression/issue/28911.test.ts    | 252 +++++++++++++++++++++++++++++++++
 5 files changed, 335 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 7 passed · 1 rejected · iteration 20

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
docs/runtime/sqlite.mdx                     2      3    108
packages/bun-types/sqlite.d.ts              5      4    108
src/js/bun/sqlite.ts                       19     27    109
src/jsc/bindings/NodeFSStatBinding.cpp      1      3    108
test/regression/issue/28911.test.ts        14     25    108
```

</details>

**root cause** · written by the author bot

The query cache in bun:sqlite keyed prepared statements by their full SQL text and never evicted entries, so workloads issuing large queries with unique text each call accumulated every statement and its multi-megabyte SQL string indefinitely, growing RSS until the process was OOM-killed. The fix replaces the cache with an insertion-ordered map governed by byte budgets, declining to cache any single query exceeding MAX_QUERY_CACHE_ENTRY_BYTES and evicting the oldest entries once total cached SQL bytes pass MAX_QUERY_CACHE_BYTES. Statements that bypass or leave the cache are tracked with wea…

<!-- robobun:evidence:end -->