### PR TITLE
fix(css): preserve leading @layer statements when bundling

### DIFF
--- a/src/bundler/linker_context/prepareCssAstsForChunk.zig
+++ b/src/bundler/linker_context/prepareCssAstsForChunk.zig
@@ -152,20 +152,67 @@ fn prepareCssAstsForChunkImpl(c: *LinkerContext, chunk: *Chunk, allocator: std.m
                         break :ast &chunk.content.css.asts[i];
                     };
 
-                    filter: {
-                        // Filter out "@charset", "@import", and leading "@layer" rules
-                        for (ast.rules.v.items, 0..) |*rule, ruleidx| {
-                            if (rule.* == .import or rule.* == .ignored or rule.* == .layer_statement) {} else {
-                                // It's okay to do this because AST is allocated into arena
-                                const reslice = ast.rules.v.items[ruleidx..];
-                                ast.rules.v = .{
-                                    .items = reslice,
-                                    .capacity = ast.rules.v.capacity - (ast.rules.v.items.len - reslice.len),
-                                };
-                                break :filter;
+                    {
+                        // Strip leading "@import" and ".ignored" rules. Any
+                        // "@layer" statement rules interleaved with them are
+                        // preserved, because they carry layer ordering
+                        // information that is not re-emitted elsewhere by
+                        // the bundler (e.g. Tailwind's
+                        // `@layer theme, base, components, utilities;`).
+                        //
+                        // IMPORTANT: `ast` is only a shallow copy of the
+                        // per-source stylesheet, so `ast.rules.v.items` still
+                        // points at the backing array owned by
+                        // `c.graph.ast.items(.css)`. We MUST NOT mutate that
+                        // buffer in place — a second import of the same
+                        // source_index would observe the compacted prefix and
+                        // drop rules. Instead we either reslice the copied
+                        // header (fast path) or build a fresh rules list.
+                        //
+                        // Regression: #28914
+                        const original_rules = ast.rules.v.items;
+                        var layer_count: usize = 0;
+                        var prefix_end: usize = original_rules.len;
+                        prefix_scan: for (original_rules, 0..) |rule, idx| {
+                            switch (rule) {
+                                .import, .ignored => {},
+                                .layer_statement => layer_count += 1,
+                                else => {
+                                    prefix_end = idx;
+                                    break :prefix_scan;
+                                },
                             }
                         }
-                        ast.rules.v.items.len = 0;
+                        const dropped = prefix_end - layer_count;
+
+                        if (dropped == 0) {
+                            // Prefix is all "@layer" (or empty). Nothing to
+                            // strip — leave `ast.rules.v` untouched.
+                        } else if (layer_count == 0) {
+                            // Fast path: no "@layer" statements to preserve,
+                            // reslice the copied header forward. This does
+                            // not touch the backing array.
+                            const tail = original_rules[prefix_end..];
+                            ast.rules.v = .{
+                                .items = tail,
+                                .capacity = ast.rules.v.capacity - (original_rules.len - tail.len),
+                            };
+                        } else {
+                            // Interleaved case: allocate a fresh rules list
+                            // so we don't mutate the shared backing array.
+                            // Preserve the "@layer" statements from the
+                            // prefix and append the remaining tail.
+                            var new_rules = bun.css.BundlerCssRuleList{};
+                            for (original_rules[0..prefix_end]) |rule| {
+                                if (rule == .layer_statement) {
+                                    new_rules.v.append(allocator, rule) catch |err| bun.handleOom(err);
+                                }
+                            }
+                            for (original_rules[prefix_end..]) |rule| {
+                                new_rules.v.append(allocator, rule) catch |err| bun.handleOom(err);
+                            }
+                            ast.rules = new_rules;
+                        }
                     }
 
                     wrapRulesWithConditions(ast, allocator, &entry.conditions);

--- a/test/regression/issue/28914.test.ts
+++ b/test/regression/issue/28914.test.ts
@@ -1,0 +1,174 @@
+// https://github.com/oven-sh/bun/issues/28914
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe.concurrent("issue #28914 - bundler preserves top-level @layer statements", () => {
+  test("Tailwind-style @layer statement with a @layer block", async () => {
+    using dir = tempDir("css-layer-28914-tailwind", {
+      "entry.css": /* css */ `
+@layer theme, base, components, utilities;
+
+@layer base {
+  body {
+    color: red;
+  }
+}
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./entry.css", "--outdir=out"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const out = await Bun.file(`${dir}/out/entry.css`).text();
+
+    // The statement carrying layer ordering must survive the bundle.
+    expect(out).toContain("@layer theme, base, components, utilities;");
+    // The block content must also be present.
+    expect(out).toContain("@layer base");
+    expect(out).toContain("color: red");
+    expect(stdout).toContain("Bundled");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bare @layer statement survives the bundle", async () => {
+    using dir = tempDir("css-layer-28914-bare", {
+      "entry.css": /* css */ `@layer theme, base, components, utilities;`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./entry.css", "--outdir=out"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const out = await Bun.file(`${dir}/out/entry.css`).text();
+    expect(out).toContain("@layer theme, base, components, utilities;");
+    expect(stdout).toContain("Bundled");
+    expect(exitCode).toBe(0);
+  });
+
+  test("@layer statement followed by an unlayered rule", async () => {
+    using dir = tempDir("css-layer-28914-mixed", {
+      "entry.css": /* css */ `
+@layer reset, base, components, utilities;
+
+.foo { color: blue; }
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./entry.css", "--outdir=out"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const out = await Bun.file(`${dir}/out/entry.css`).text();
+    expect(out).toContain("@layer reset, base, components, utilities;");
+    expect(out).toContain(".foo");
+    expect(stdout).toContain("Bundled");
+    expect(exitCode).toBe(0);
+  });
+
+  test("multiple individual @layer statements are all preserved", async () => {
+    using dir = tempDir("css-layer-28914-multi", {
+      "entry.css": /* css */ `
+@layer theme;
+@layer base;
+@layer components;
+
+.foo { color: red; }
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./entry.css", "--outdir=out"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const out = await Bun.file(`${dir}/out/entry.css`).text();
+    expect(out).toContain("@layer theme;");
+    expect(out).toContain("@layer base;");
+    expect(out).toContain("@layer components;");
+    expect(out).toContain(".foo");
+    expect(stdout).toContain("Bundled");
+    expect(exitCode).toBe(0);
+  });
+
+  // The `.source_index` branch of `prepareCssAstsForChunk` only shallow-copies
+  // the stylesheet, so its `rules.v.items` still points at the AST owned by
+  // the parse graph. If the same source is imported from multiple chunks the
+  // filter must not mutate that shared backing buffer. This test imports the
+  // same file twice with two different layer conditions so both copies go
+  // through the filter, and then checks every layer's rule still shows up.
+  test("duplicate imports of a layered source don't corrupt the shared AST", async () => {
+    using dir = tempDir("css-layer-28914-dup", {
+      "entry.css": /* css */ `
+@layer one, two;
+@import url('./shared.css') layer(one);
+@import url('./shared.css') layer(two);
+`,
+      // `shared.css` deliberately mixes an `.import` rule with an
+      // `.layer_statement` in its prefix so the filter's interleaved
+      // `else` branch (dropped=1, layer_count=1) is exercised, not the
+      // no-op fast path.
+      "shared.css": /* css */ `
+@import url('./nested.css');
+@layer base;
+.shared { color: rebeccapurple; }
+`,
+      "nested.css": /* css */ `.nested { color: green; }`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./entry.css", "--outdir=out"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const out = await Bun.file(`${dir}/out/entry.css`).text();
+
+    // Both layer-wrapped copies of shared.css must emit the rule. An
+    // in-place compaction of the shared backing array would leave a stale
+    // slot that the second visit re-reads, producing three matches
+    // instead of two (the duplicated rule falls through to the wrap step).
+    const sharedMatches = out.match(/\.shared\s*\{/g) ?? [];
+    expect(sharedMatches.length).toBe(2);
+    // The shared `@layer base;` declaration must also survive in both
+    // copies — it's part of the prefix the filter scans over.
+    const baseMatches = out.match(/@layer base;/g) ?? [];
+    expect(baseMatches.length).toBe(2);
+    // The entry file's comma-separated ordering statement must survive.
+    // `toContain("@layer one")` alone would be satisfied by the
+    // `@layer one { ... }` wrapper, so assert the exact statement form.
+    expect(out).toContain("@layer one, two;");
+    // The per-condition block wrappers must also be present.
+    expect(out).toContain("@layer one {");
+    expect(out).toContain("@layer two {");
+    expect(stdout).toContain("Bundled");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Closes #28914.

The CSS bundler's leading-rule filter in `prepareCssAstsForChunk` was unconditionally stripping every leading `.layer_statement` rule, which deleted the top-level `@layer` ordering declarations that Tailwind CSS (and anyone using cascade layers) depends on.

## Repro

```css
/* entry.css */
@layer theme, base, components, utilities;

@layer base {
  body { color: red; }
}
```

```console
$ bun build ./entry.css
/* entry.css */
@layer base {
  body {
    color: red;
  }
}
```

The `@layer theme, base, components, utilities;` line is gone. Without it the cascade order is whatever happens to be emitted first, which is exactly the Tailwind breakage reported in #28914.

## Cause

Regression from #27131 (`e7cf4b77ba`), which added `.layer_statement` to the leading-rule filter in `src/bundler/linker_context/prepareCssAstsForChunk.zig`:

```zig
if (rule.* == .import or rule.* == .ignored or rule.* == .layer_statement) {} else {
    // slice off [0..ruleidx]
}
```

That fix wanted the filter to skip **past** leading `@layer` statements so it could reach and strip the interleaved `@import` rules underneath them (the target of #20546). But the filter mechanism is "drop everything up to the first non-match", so skipping past `@layer` also dropped it. For files with no `@import layer(...)` (Tailwind's shape), nothing else re-emits those layer names and the ordering information is lost.

## Fix

Rewrite the filter as an in-place compaction:

- Drop leading `.import` and `.ignored` rules.
- Keep `.layer_statement` rules, compacting them forward.
- Stop at the first rule of any other kind, then shift the tail to close the gap.

This keeps the #20546 behavior (interleaved `@import` rules are still stripped) while preserving the layer ordering declarations that Tailwind needs.

## Verification

- New regression test: `test/regression/issue/28914.test.ts` (4 cases — Tailwind-style statement + block, bare statement, statement + unlayered rule, multiple individual statements). All pass on the patched build, all fail on system bun.
- Existing `test/regression/issue/20546.test.ts` still passes (2/2).
- Full CSS bundler suite `test/bundler/esbuild/css.test.ts` passes (53/53).
- Broader CSS parser suite `test/js/bun/css/css.test.ts` passes (1028/1028).