### PR TITLE
Handle exception from getPrototype in forEachProperty

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5048,6 +5048,8 @@ static void JSC__JSValue__forEachPropertyImpl(JSC::EncodedJSValue JSValue0, JSC:
                     prototypeCount = 1;
                 }
             }
+            // Ignore exceptions from Proxy "getPrototype" trap.
+            CLEAR_IF_EXCEPTION(scope);
         }
     }
     auto* propertyNames = vm.propertyNames;
@@ -5238,7 +5240,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            if (scope.exception()) [[unlikely]] {
+                (void)scope.tryClearException();
+                break;
+            }
+            iterating = proto.getObject();
         }
     }
 

--- a/test/js/bun/test/expect-proxy-prototype-crash.test.ts
+++ b/test/js/bun/test/expect-proxy-prototype-crash.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test: formatting an Expect object whose prototype has been
+// replaced with a Proxy should not crash when toBe() fails and the error
+// message formatter walks the prototype chain.
+test("expect error formatting does not crash with Proxy prototype", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const v1 = Bun.jest();
+const v2 = v1.expect(v1);
+Object.setPrototypeOf(v2, new Proxy(Object.getPrototypeOf(v2), {}));
+try { v2.toBe(v2); } catch (e) {}
+console.log("OK");`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("OK\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fuzzilli found a null deref in `JSC__JSValue__forEachPropertyImpl` when formatting an object whose prototype chain contains a Proxy.

When walking the prototype chain, `iterating->getPrototype(globalObject)` can throw (e.g. from a Proxy `getPrototypeOf` trap or from side-effects of the walk), and returns an empty `JSValue`. Calling `.getObject()` on that empty value invokes `asCell()` which returns null, then dereferences it — UBSan catches the null member call.

The fast path at line 5121 already handles this correctly with `if (JSValue proto = ...)` which is false for empty values, followed by `CLEAR_IF_EXCEPTION`. The slow path at line 5241 did not — check the exception and bail out of the walk.

Fuzzilli repro (minimized):

```js
const v1 = Bun.jest(Bun);
const v2 = v1.expect(v1);
Object.setPrototypeOf(v2, new Proxy(Object.getPrototypeOf(v2), {}));
v2.toBe(v2); // triggers toBe failure → formats v2 → walks prototype chain
```

Fingerprint: `9e09c9e7bd37325a`