### PR TITLE
Fix use-after-poison in forEachProperty prototype chain walk

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5264,9 +5264,16 @@ restart:
 
     {
 
-        JSObject* iterating = prototypeObject.getObject();
+        JSValue iteratingValue = prototypeObject;
 
-        while (iterating && !(iterating == globalObject->objectPrototype() || iterating == globalObject->functionPrototype() || (iterating->inherits<JSGlobalProxy>() && jsCast<JSGlobalProxy*>(iterating)->target() != globalObject)) && prototypeCount++ < 5) {
+        while (JSObject* iterating = iteratingValue.getObject()) {
+            if (iterating == globalObject->objectPrototype() || iterating == globalObject->functionPrototype() || (iterating->inherits<JSGlobalProxy>() && jsCast<JSGlobalProxy*>(iterating)->target() != globalObject))
+                break;
+            if (prototypeCount++ >= 5)
+                break;
+
+            JSC::EnsureStillAliveScope ensureIteratingStillAlive(iteratingValue);
+
             if constexpr (nonIndexedOnly) {
                 iterating->getOwnNonIndexPropertyNames(globalObject, properties, DontEnumPropertiesMode::Include);
             } else {
@@ -5364,7 +5371,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            iteratingValue = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            if (scope.exception()) [[unlikely]] {
+                (void)scope.tryClearException();
+                break;
+            }
         }
     }
 

--- a/test/js/bun/test/expect-proxy-prototype-crash.test.ts
+++ b/test/js/bun/test/expect-proxy-prototype-crash.test.ts
@@ -16,9 +16,11 @@ test("expect does not crash when expect value has a Proxy in its prototype chain
     `,
     ],
     env: bunEnv,
+    stdout: "pipe",
   });
 
-  const exitCode = await proc.exited;
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
+  expect(stdout).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/expect-proxy-prototype-crash.test.ts
+++ b/test/js/bun/test/expect-proxy-prototype-crash.test.ts
@@ -16,10 +16,11 @@ test("expect does not crash when expect value has a Proxy in its prototype chain
     `,
     ],
     env: bunEnv,
+    stderr: "pipe",
     stdout: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toBe("");
   expect(exitCode).toBe(0);

--- a/test/js/bun/test/expect-proxy-prototype-crash.test.ts
+++ b/test/js/bun/test/expect-proxy-prototype-crash.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("expect does not crash when expect value has a Proxy in its prototype chain", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const obj = Bun.jest().expect(Bun);
+      const newProto = new Proxy(Object.getPrototypeOf(obj), {
+        get(target, key, receiver) { return Reflect.get(target, key, receiver); },
+      });
+      Object.setPrototypeOf(obj, newProto);
+      try { obj.toContainKey(obj); } catch {}
+    `,
+    ],
+    env: bunEnv,
+  });
+
+  const exitCode = await proc.exited;
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

A use-after-poison (ASan) / null pointer UBSan error in `JSC__JSValue__forEachPropertyImpl` when the iterated object has a `Proxy` in its prototype chain.

## Repro

```js
const obj = Bun.jest().expect(Bun);
const newProto = new Proxy(Object.getPrototypeOf(obj), {
  get(target, key, receiver) { return Reflect.get(target, key, receiver); },
});
Object.setPrototypeOf(obj, newProto);
try { obj.toContainKey(obj); } catch {}
```

With the `expect` object's prototype chain routed through a `Proxy`, triggering the error formatter calls `forEachProperty` which walks the prototype chain. The `get` trap runs JS for each property access, creating GC opportunities. The raw `JSObject* iterating` held across those calls gets freed and the next iteration dereferences poisoned memory inside `iterating->getPrototype(globalObject).getObject()`.

## Fix

Hold the current prototype as a `JSValue` protected by `EnsureStillAliveScope`, matching the pattern already used elsewhere in the file (e.g. line 5044 and line 5121). Also clear any exception thrown from the Proxy `getPrototypeOf` trap, matching the fast-path treatment a few lines above.

Found by Fuzzilli — fingerprint `Address:use-after-poison:bun-debug+0xc4fd94a`.