### PR TITLE
Fix assertion failure in Bun.dns.setServers with non-int32 values

### DIFF
--- a/src/bun.js/api/bun/dns.zig
+++ b/src/bun.js/api/bun/dns.zig
@@ -3290,8 +3290,8 @@ pub const Resolver = struct {
                 return globalThis.throwInvalidArgumentType("setServers", "triple", "array");
             }
 
-            const family = (try triple.getIndex(globalThis, 0)).toInt32();
-            const port = (try triple.getIndex(globalThis, 2)).toInt32();
+            const family = try (try triple.getIndex(globalThis, 0)).coerceToInt32(globalThis);
+            const port = try (try triple.getIndex(globalThis, 2)).coerceToInt32(globalThis);
 
             if (family != 4 and family != 6) {
                 return globalThis.throwInvalidArguments("Invalid address family", .{});

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -121,4 +121,26 @@ describe("dns", () => {
     expect(result.length).toBeGreaterThan(0);
     expect(isIP(result[0].address)).toBeGreaterThan(0);
   });
+
+  describe("setServers", () => {
+    test("triple with non-int32 family (double) should not crash", () => {
+      // @ts-expect-error
+      expect(() => dns.setServers([[-9007199254740991, "8.8.8.8", 53]])).toThrow();
+    });
+
+    test("triple with missing port (undefined) should not crash", () => {
+      // undefined port coerces to 0, which is a valid int32
+      // @ts-expect-error
+      expect(() => dns.setServers([[4, "8.8.8.8"]])).not.toThrow();
+    });
+
+    test("triple with missing family (undefined) should not crash", () => {
+      // @ts-expect-error
+      expect(() => dns.setServers([["8.8.8.8"]])).toThrow();
+    });
+
+    test("valid triple should succeed", () => {
+      expect(() => dns.setServers([[4, "8.8.8.8", 53]])).not.toThrow();
+    });
+  });
 });

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -123,9 +123,9 @@ describe("dns", () => {
   });
 
   describe("setServers", () => {
-    test("triple with non-int32 family (double) should not crash", () => {
+    test("triple with non-int32 family (double) throws TypeError", () => {
       // @ts-expect-error
-      expect(() => dns.setServers([[-9007199254740991, "8.8.8.8", 53]])).toThrow();
+      expect(() => dns.setServers([[-9007199254740991, "8.8.8.8", 53]])).toThrow(TypeError);
     });
 
     test("triple with missing port (undefined) should not crash", () => {
@@ -134,9 +134,9 @@ describe("dns", () => {
       expect(() => dns.setServers([[4, "8.8.8.8"]])).not.toThrow();
     });
 
-    test("triple with missing family (undefined) should not crash", () => {
+    test("triple with missing family (undefined) throws TypeError", () => {
       // @ts-expect-error
-      expect(() => dns.setServers([["8.8.8.8"]])).toThrow();
+      expect(() => dns.setServers([["8.8.8.8"]])).toThrow(TypeError);
     });
 
     test("valid triple should succeed", () => {


### PR DESCRIPTION
`Bun.dns.setServers` called `toInt32()` on the family and port elements of each server triple. The internal `toInt32()` helper falls through to `JSC__JSValue__toInt32`, which calls `JSValue::asInt32()` and asserts `isInt32()`. Passing a double (e.g. `-9007199254740991`) or leaving the port out (so the index returns `undefined`) tripped the assertion:

```
ASSERTION FAILED: isInt32()
JavaScriptCore/JSCJSValue.h(994) : int32_t JSC::JSValue::asInt32() const
```

Repro:

```js
Bun.dns.setServers([[-9007199254740991, 15473]]);
```

Switch to `coerceToInt32`, which uses JSC's full numeric coercion. The existing `family != 4 and family != 6` check still rejects invalid families with a proper `TypeError`.

Found by Fuzzilli.