### PR TITLE
ci: use cmake -E tar to re-zip signed Windows artifacts

### DIFF
--- a/.buildkite/scripts/sign-windows-artifacts.ps1
+++ b/.buildkite/scripts/sign-windows-artifacts.ps1
@@ -232,7 +232,14 @@ function Sign-Artifact {
 
     Log-Info "Re-packing $ZipName"
     Remove-Item $ZipName -Force
-    Compress-Archive -Path $extractDir -DestinationPath $ZipName -CompressionLevel Optimal
+    # Use the same zip command as the build-bun step (scripts/build/ci.ts makeZip)
+    # so the signed archive's entry layout matches the original: forward-slash
+    # paths and a directory entry. Compress-Archive writes backslash separators,
+    # which violates the ZIP spec and triggers warnings in non-Windows unzip.
+    & cmake -E tar cfv $ZipName --format=zip $extractDir
+    if ($LASTEXITCODE -ne 0) {
+        throw "cmake -E tar failed for $ZipName"
+    }
     Remove-Item $extractDir -Recurse -Force
 
     Log-Info "Uploading signed $ZipName"


### PR DESCRIPTION
PowerShell's `Compress-Archive` writes zip entries with backslash path separators (`bun-windows-x64\bun.exe`) and omits the directory entry. This violates APPNOTE 4.4.17 and makes non-Windows `unzip` print a warning; strict extractors can produce a flat file with a literal backslash in the name.

Switch the re-pack step to `cmake -E tar cfv <zip> --format=zip <dir>`, which is exactly what the build-bun step uses (`scripts/build/ci.ts` `makeZip`), so the signed archive's entry layout is identical to the unsigned one it replaces. cmake is already a required tool on the Windows build agents.

The commit includes `[sign windows]` so the `windows-sign` step runs on this branch for verification.