### PR TITLE
fix crash reading fd of a TLS listener

### DIFF
--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -527,11 +527,7 @@ pub fn getPort(this: *Listener, _: *jsc.JSGlobalObject) JSValue {
 pub fn getFD(this: *Listener, _: *jsc.JSGlobalObject) JSValue {
     switch (this.listener) {
         .uws => |uws_listener| {
-            switch (this.ssl) {
-                inline else => |ssl| {
-                    return uws_listener.socket(ssl).fd().toJSWithoutMakingLibUVOwned();
-                },
-            }
+            return uws_listener.socket(false).fd().toJSWithoutMakingLibUVOwned();
         },
         else => return JSValue.jsNumber(-1),
     }

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -801,3 +801,14 @@ it("should throw on empty unix path from truthy non-string value", () => {
   expect(() => Bun.listen({ unix: [] as any, socket })).toThrow("SocketOptions.unix must be a string");
   expect(() => Bun.connect({ unix: [] as any, socket })).toThrow("SocketOptions.unix must be a string");
 });
+
+it("reading fd of a TLS listener should not crash", () => {
+  using listener = Bun.listen({
+    hostname: "localhost",
+    port: 0,
+    socket: { data() {}, open() {}, close() {} },
+    tls: { passphrase: "abc" },
+  });
+  expect(typeof listener.fd).toBe("number");
+  expect(listener.fd).toBeGreaterThanOrEqual(0);
+});


### PR DESCRIPTION
Fixes a segfault when reading `.fd` on the result of `Bun.listen({ tls: { ... } })`.

`Listener.getFD` was calling `uws_listener.socket(true).fd()` for TLS listeners. For `is_ssl=true`, the uSockets wrapper `us_internal_ssl_socket_get_native_handle` returns `s->ssl`, and `fd()` then calls `SSL_get_fd()` on it. But a listen socket has no SSL object — SSL is per-connection — so `s->ssl` is uninitialized memory (ASAN poison `0xbebebe...`) and the call segfaults.

Listen sockets always have a plain poll fd regardless of TLS, so get it via the non-SSL path.

```
#3 SSL_get_rfd (ssl=0xbebebe0000000018)
#4 SSL_get_fd  (ssl=0xbebebe0000000018)
#5 deps.uws.socket.NewSocketHandler(true).fd () at src/deps/uws/socket.zig:283
   bun.js.api.bun.socket.Listener.getFD at src/bun.js/api/bun/socket/Listener.zig:532
```

Repro (also triggered when `console.log()` introspects the listener):

```js
const s = Bun.listen({
  hostname: "localhost", port: 0,
  socket: { data(){}, open(){}, close(){} },
  tls: { passphrase: "abc" },
});
console.log(s.fd);
```

Found by Fuzzilli.