### PR TITLE
fix crash formatting WeakMap/WeakSet with custom size property

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -2747,14 +2747,20 @@ pub const Formatter = struct {
                 writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
             },
             .Map => {
+                const is_weak = value.jsType() == .WeakMap;
+                const map_name = if (is_weak) "WeakMap" else "Map";
+
+                // WeakMap is not iterable and has no `size`, so always print as empty.
+                if (is_weak) {
+                    return writer.print("{s} {{}}", .{map_name});
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
-
-                const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{map_name});
@@ -2854,14 +2860,20 @@ pub const Formatter = struct {
                 writer.writeAll("}");
             },
             .Set => {
+                const is_weak = value.jsType() == .WeakSet;
+                const set_name = if (is_weak) "WeakSet" else "Set";
+
+                // WeakSet is not iterable and has no `size`, so always print as empty.
+                if (is_weak) {
+                    return writer.print("{s} {{}}", .{set_name});
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
-
-                const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{set_name});

--- a/src/bun.js/test/diff_format.zig
+++ b/src/bun.js/test/diff_format.zig
@@ -43,7 +43,9 @@ pub const DiffFormatter = struct {
                 1,
                 &received_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                if (!this.globalThis.clearExceptionExceptTermination()) return;
+            };
 
             JestPrettyFormat.format(
                 .Debug,
@@ -52,7 +54,9 @@ pub const DiffFormatter = struct {
                 1,
                 &expected_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                if (!this.globalThis.clearExceptionExceptTermination()) return;
+            };
         }
 
         var received_slice = received_buf.written();

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -1309,14 +1309,20 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
                 },
                 .Map => {
+                    const is_weak = value.jsType() == .WeakMap;
+                    const map_name = if (is_weak) "WeakMap" else "Map";
+
+                    // WeakMap is not iterable and has no `size`, so always print as empty.
+                    if (is_weak) {
+                        return writer.print("{s} {{}}", .{map_name});
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
                     const prev_quote_strings = this.quote_strings;
                     this.quote_strings = true;
                     defer this.quote_strings = prev_quote_strings;
-
-                    const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{map_name});
@@ -1337,6 +1343,14 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll("\n");
                 },
                 .Set => {
+                    const is_weak = value.jsType() == .WeakSet;
+                    const set_name = if (is_weak) "WeakSet" else "Set";
+
+                    // WeakSet is not iterable and has no `size`, so always print as empty.
+                    if (is_weak) {
+                        return writer.print("{s} {{}}", .{set_name});
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
@@ -1345,8 +1359,6 @@ pub const JestPrettyFormat = struct {
                     defer this.quote_strings = prev_quote_strings;
 
                     this.writeIndent(Writer, writer_) catch {};
-
-                    const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{set_name});

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3528,6 +3528,24 @@ describe("expect()", () => {
       expect(a1).not.toMatchObject({ 1: 1 });
       expect(a1).toMatchObject(a1);
     });
+
+    if (isBun) {
+      test("WeakMap/WeakSet with fake 'size' property does not crash diff formatting", () => {
+        // Regression: pretty formatting read the own `size` property of a
+        // WeakMap/WeakSet and then called forEach on it, which throws TypeError
+        // because weak collections are not iterable. In debug this tripped an
+        // ExceptionScope assertion; in release it produced broken diff output.
+        const wm = new WeakMap();
+        /** @type {any} */ (wm).size = 2836;
+        expect(Bun.inspect(wm)).toBe("WeakMap {}");
+        expect(() => expect(wm).toMatchObject(new Int16Array(2))).toThrow();
+
+        const ws = new WeakSet();
+        /** @type {any} */ (ws).size = 2836;
+        expect(Bun.inspect(ws)).toBe("WeakSet {}");
+        expect(() => expect(ws).toMatchObject(new Int16Array(2))).toThrow();
+      });
+    }
   });
 
   describe("toMatch()", () => {


### PR DESCRIPTION
Fuzzilli found that this crashes:

```js
const wm = new WeakMap();
wm.size = 2836;
expect(wm).toMatchObject(new Int16Array(2));
// ASSERTION FAILED: Unexpected exception observed on thread ...
// Error Exception: Type error
// cache/webkit-fc9f2fa7272fec64/include/JavaScriptCore/ExceptionScope.h(63)
// : void JSC::ExceptionScope::assertNoExceptionExceptTermination()
```

The pretty formatter used for jest diffs and `console.log` treats a WeakMap/WeakSet like a Map/Set: it reads `value.get("size")`, and when that returns a non-zero number (e.g. from `wm.size = 2836`), it goes on to call `value.forEach` which throws a TypeError because WeakMap/WeakSet aren't iterable. `DiffFormatter.format` then swallows the Zig error with `catch {}` but the JSC exception remains pending, tripping the next `ExceptionScope` assertion.

Fix: WeakMap/WeakSet are always printed as `WeakMap {}` / `WeakSet {}` (matching Jest), so no `size` lookup or `forEach` is attempted. Also clear the pending exception when `DiffFormatter.format` swallows a pretty-format failure so other unprintable values don't wedge the VM.

Fingerprint: `0d83200cd7d6cc55`