### PR TITLE
stripANSI: preserve unterminated sequences and reject non-ASCII in CSI/ESC

### DIFF
--- a/src/bun.js/bindings/ANSIHelpers.h
+++ b/src/bun.js/bindings/ANSIHelpers.h
@@ -256,6 +256,10 @@ static const Char* consumeANSI(const Char* start, const Char* end)
                 state = State::needSt;
                 break;
             default:
+                // Non-ASCII can't be a valid ESC continuation; bail so the
+                // caller leaves the bytes literal (matches npm strip-ansi).
+                if (static_cast<unsigned>(c) >= 0x80)
+                    return start;
                 // Otherwise, assume this is a one-byte sequence
                 state = State::start;
             }
@@ -271,7 +275,18 @@ static const Char* consumeANSI(const Char* start, const Char* end)
             // CSI parameters can be 1-15+ bytes (e.g. \x1b[1;31;48;2;255;0;0m).
             const auto* term = scanForByteInRange<0x40, 0x7e>(it, end);
             if (!term)
-                return end;
+                return start;
+            // Bytes between the introducer and the terminator must be CSI
+            // parameter or intermediate bytes (0x20-0x3F per ECMA-48 §5.4).
+            // Anything else (control chars, non-ASCII text, surrogates) means
+            // the SIMD scan jumped over invalid content to land on a stray
+            // letter — bail out and leave the bytes literal. Common case is
+            // CJK text after `\x1b[` with a downstream ASCII letter.
+            for (const auto* p = it; p < term; ++p) {
+                const auto cc = static_cast<unsigned>(*p);
+                if (cc < 0x20 || cc > 0x3f)
+                    return start;
+            }
             it = term; // ++it on next loop iteration steps past terminator
             state = State::start;
             break;
@@ -283,7 +298,7 @@ static const Char* consumeANSI(const Char* start, const Char* end)
             // (filenames, titles, hyperlinks), so SIMD-scan for those 3 bytes.
             const auto* term = scanForAnyByte<0x07, 0x9c, 0x1b>(it, end);
             if (!term)
-                return end;
+                return start;
             it = term;
             state = (*term == static_cast<Char>(0x1b)) ? State::inOscGotEsc : State::start;
             break;
@@ -300,7 +315,7 @@ static const Char* consumeANSI(const Char* start, const Char* end)
             // ST-terminated payload: scan for ESC or C1 ST.
             const auto* term = scanForAnyByte<0x1b, 0x9c>(it, end);
             if (!term)
-                return end;
+                return start;
             it = term;
             state = (*term == static_cast<Char>(0x1b)) ? State::needStGotEsc : State::start;
             break;
@@ -313,6 +328,22 @@ static const Char* consumeANSI(const Char* start, const Char* end)
                 state = State::needSt;
             break;
         }
+    }
+
+    // Input exhausted. If we're still mid-sequence in a multi-byte state,
+    // the sequence is unterminated and matches no strip-ansi pattern, so
+    // bail out so the caller leaves the bytes literal. `gotEsc` and
+    // `ignoreNextChar` fall through to `return end` to preserve the
+    // existing trailing-ESC and two-byte-ESC consumption behavior.
+    switch (state) {
+    case State::inCsi:
+    case State::inOsc:
+    case State::inOscGotEsc:
+    case State::needSt:
+    case State::needStGotEsc:
+        return start;
+    default:
+        break;
     }
     return end;
 }

--- a/src/bun.js/bindings/ANSIHelpers.h
+++ b/src/bun.js/bindings/ANSIHelpers.h
@@ -201,10 +201,16 @@ static const Char* consumeANSI(const Char* start, const Char* end)
     };
 
     auto state = State::start;
+    // Start of the *current* sub-sequence in the chain. consumeANSI greedily
+    // chains adjacent escapes; when a later sub-sequence turns out to be
+    // invalid/unterminated we must report progress up to *its* introducer,
+    // not rewind to the very first one (which would un-strip valid prefixes).
+    auto seqStart = start;
     for (auto it = start; it != end; ++it) {
         const auto c = *it;
         switch (state) {
         case State::start:
+            seqStart = it;
             switch (c) {
             case 0x1b:
                 state = State::gotEsc;
@@ -259,7 +265,7 @@ static const Char* consumeANSI(const Char* start, const Char* end)
                 // Non-ASCII can't be a valid ESC continuation; bail so the
                 // caller leaves the bytes literal (matches npm strip-ansi).
                 if (static_cast<unsigned>(c) >= 0x80)
-                    return start;
+                    return seqStart;
                 // Otherwise, assume this is a one-byte sequence
                 state = State::start;
             }
@@ -275,7 +281,7 @@ static const Char* consumeANSI(const Char* start, const Char* end)
             // CSI parameters can be 1-15+ bytes (e.g. \x1b[1;31;48;2;255;0;0m).
             const auto* term = scanForByteInRange<0x40, 0x7e>(it, end);
             if (!term)
-                return start;
+                return seqStart;
             // Bytes between the introducer and the terminator must be CSI
             // parameter or intermediate bytes (0x20-0x3F per ECMA-48 §5.4).
             // Anything else (control chars, non-ASCII text, surrogates) means
@@ -285,7 +291,7 @@ static const Char* consumeANSI(const Char* start, const Char* end)
             for (const auto* p = it; p < term; ++p) {
                 const auto cc = static_cast<unsigned>(*p);
                 if (cc < 0x20 || cc > 0x3f)
-                    return start;
+                    return seqStart;
             }
             it = term; // ++it on next loop iteration steps past terminator
             state = State::start;
@@ -298,7 +304,7 @@ static const Char* consumeANSI(const Char* start, const Char* end)
             // (filenames, titles, hyperlinks), so SIMD-scan for those 3 bytes.
             const auto* term = scanForAnyByte<0x07, 0x9c, 0x1b>(it, end);
             if (!term)
-                return start;
+                return seqStart;
             it = term;
             state = (*term == static_cast<Char>(0x1b)) ? State::inOscGotEsc : State::start;
             break;
@@ -315,7 +321,7 @@ static const Char* consumeANSI(const Char* start, const Char* end)
             // ST-terminated payload: scan for ESC or C1 ST.
             const auto* term = scanForAnyByte<0x1b, 0x9c>(it, end);
             if (!term)
-                return start;
+                return seqStart;
             it = term;
             state = (*term == static_cast<Char>(0x1b)) ? State::needStGotEsc : State::start;
             break;
@@ -341,7 +347,7 @@ static const Char* consumeANSI(const Char* start, const Char* end)
     case State::inOscGotEsc:
     case State::needSt:
     case State::needStGotEsc:
-        return start;
+        return seqStart;
     default:
         break;
     }

--- a/src/bun.js/bindings/sliceAnsi.cpp
+++ b/src/bun.js/bindings/sliceAnsi.cpp
@@ -476,8 +476,12 @@ static const Char* parseCsi(const Char* start, const Char* end, bool& isSgr, boo
         return it; // Return pointer to the malformed byte (treated as control up to here)
     }
 
-    // Unterminated CSI - consume everything
-    return end;
+    // Unterminated CSI — DO NOT consume to EOF. Match parseControlString and
+    // ANSIHelpers.h consumeANSI: return nullptr so the caller treats the
+    // introducer as a single width-0 char and the rest as literal text.
+    // Otherwise Bun.sliceAnsi("\x1b[31", 0, 5) silently drops "[31" while
+    // Bun.stripANSI("\x1b[31") preserves it.
+    return nullptr;
 }
 
 // Parse hyperlink: ESC]8;...;url TERMINATOR

--- a/src/bun.js/bindings/stripANSI.cpp
+++ b/src/bun.js/bindings/stripANSI.cpp
@@ -104,8 +104,15 @@ extern "C" bool Bun__ANSI__next(BunANSIIterator* it)
         if (escPos != start) break;
         const auto after = ANSI::consumeANSI(start, end);
         if (after == start) {
-            start++;
-            break;
+            // consumeANSI didn't advance — the ESC begins an unterminated or
+            // invalid sequence that consumeANSI left literal (it returns
+            // seqStart in that case). Yield this byte as a 1-char text slice
+            // so callers see it; `start++; break;` here would silently drop
+            // the ESC and corrupt e.g. OSC 52 clipboard payloads in the REPL.
+            it->slice_ptr = start;
+            it->slice_len = 1;
+            it->cursor = static_cast<size_t>(start - it->input) + 1;
+            return true;
         }
         start = after;
     }

--- a/test/js/bun/util/sliceAnsi-fuzz.test.ts
+++ b/test/js/bun/util/sliceAnsi-fuzz.test.ts
@@ -436,8 +436,13 @@ function randomString(rng: () => number, minLen: number, maxLen: number): string
       // Control char
       pieces.push(String.fromCharCode(Math.floor(rng() * 0x20)));
     } else if (r < 0.96) {
-      // C1 control
-      pieces.push(String.fromCharCode(0x80 + Math.floor(rng() * 0x20)));
+      // C1 control — restricted to 0x80-0x8F. The upper half includes
+      // sequence introducers (CSI 0x9B, OSC 0x9D, DCS 0x90, etc.) which,
+      // emitted standalone, start unterminated sequences whose visible
+      // width depends on whether a stray terminator byte happens to follow.
+      // sliceAnsi's appended close codes (e.g. `\x1b]8;;\x07`) can supply
+      // such a terminator and make stripANSI(sliced) ≠ stripANSI(original).
+      pieces.push(String.fromCharCode(0x80 + Math.floor(rng() * 0x10)));
     } else {
       // Truecolor SGR
       pieces.push(`\x1b[38;2;${Math.floor(rng() * 256)};${Math.floor(rng() * 256)};${Math.floor(rng() * 256)}m`);

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -560,9 +560,18 @@ describe("Bun.sliceAnsi", () => {
       expect(Bun.sliceAnsi(input, 0, 1)).toBe("A");
     });
 
-    test("treats truncated CSI tails as non-visible control codes", () => {
-      expect(Bun.sliceAnsi("\u001B[31", 0, 1)).toBe("");
-      expect(Bun.sliceAnsi("\u009B31", 0, 1)).toBe("");
+    test("preserves unterminated CSI as literal text (matches Bun.stripANSI)", () => {
+      // parseCsi returns nullptr for unterminated CSI (same as
+      // parseControlString does for unterminated OSC/DCS), so the introducer
+      // becomes a width-0 char and the rest is visible text — not silently
+      // swallowed as a zero-width control token.
+      expect(Bun.sliceAnsi("\u001B[31", 0, 1)).toBe("\u001B[");
+      expect(Bun.sliceAnsi("\u001B[31", 0, 3)).toBe("\u001B[31");
+      expect(Bun.sliceAnsi("\u009B31", 0, 1)).toBe("\u009B3");
+      expect(Bun.sliceAnsi("\u009B31", 0, 2)).toBe("\u009B31");
+      // Consistency: stripANSI on the slice == stripANSI on the original
+      // (both preserve the unterminated bytes literal).
+      expect(Bun.stripANSI(Bun.sliceAnsi("\u001B[31", 0, 5))).toBe(Bun.stripANSI("\u001B[31"));
     });
 
     test("does not swallow visible text after malformed CSI bytes", () => {

--- a/test/js/bun/util/stripANSI.test.ts
+++ b/test/js/bun/util/stripANSI.test.ts
@@ -272,6 +272,15 @@ describe("Bun.stripANSI", () => {
     ["\x1b]8;;url本文末尾", "\x1b]8;;url本文末尾"], // unterminated OSC8 with JP payload: keep verbatim
     ["\x1b]0;ウィンドウ", "\x1b]0;ウィンドウ"], // unterminated OSC with JP title: keep verbatim
     ["\x1bあ\x1b[31mred\x1b[39m", "\x1bあred"], // partial-escape splice followed by valid CSI
+    ["\x1b[あm", "\x1b[あm"], // ESC[ + non-ASCII + downstream final byte: bail, keep verbatim
+    ["\x1b[31m\x1b[あm", "\x1b[あm"], // valid CSI chained into invalid CSI: strip the valid prefix only
+    ["\x1b[31m\x1b]0;noend", "\x1b]0;noend"], // valid CSI chained into unterminated OSC: same
+    ["\x1bPunterminated", "\x1bPunterminated"], // unterminated DCS (needSt EOF branch)
+    ["\x1b_unterminated", "\x1b_unterminated"], // unterminated APC (needSt EOF branch)
+    // Unterminated OSC whose payload contains an ESC. Preserved literal, but
+    // when the outer loop resumes after the leading ESC it re-tokenizes the
+    // inner `\x1bo` as a one-byte ESC sequence (SS3) — pre-existing behavior.
+    ["\x1b]2;test\x1bother", "\x1b]2;testther"],
 
     // Complex prefix combinations
     ["\x1b[[[31mtext", "[31mtext"], // [ terminates CSI

--- a/test/js/bun/util/stripANSI.test.ts
+++ b/test/js/bun/util/stripANSI.test.ts
@@ -105,10 +105,12 @@ describe("Bun.stripANSI", () => {
     "",
     "hello world",
 
-    // Partial sequences
+    // Partial sequences. Bun preserves unterminated sequences literal.
+    // strip-ansi's regex treats trailing digits as CSI terminators via
+    // backtracking, which we deliberately diverge from.
     ["text\x1b", "text"],
-    ["text\x1b[", "text"],
-    "text\x1b[3",
+    ["text\x1b[", "text\x1b["],
+    ["text\x1b[3", "text\x1b[3"],
 
     // Real world examples
     "\x1b[2K\x1b[1G\x1b[36m?\x1b[39m Installing...",
@@ -134,11 +136,13 @@ describe("Bun.stripANSI", () => {
     // Malformed sequences
     "\x1b[31text",
     "\x1b[moretext",
-    ["\x1b]incomplete", ""],
-    ["\x1b]", ""],
-    "\x1b]i",
-    ["\x1b]in", ""],
-    ["\x1b]inc", ""],
+    // Unterminated OSC: Bun preserves literal; strip-ansi's regex
+    // backtracks and treats letters as CSI fallback terminators.
+    ["\x1b]incomplete", "\x1b]incomplete"],
+    ["\x1b]", "\x1b]"],
+    ["\x1b]i", "\x1b]i"],
+    ["\x1b]in", "\x1b]in"],
+    ["\x1b]inc", "\x1b]inc"],
 
     // Preserves whitespace
     "\x1b[31m  text  \x1b[39m",
@@ -195,7 +199,7 @@ describe("Bun.stripANSI", () => {
 
     // Prefix characters in sequences
     "\x1b[?1049htext",
-    ["\x1b]#text", ""], // missing ST
+    ["\x1b]#text", "\x1b]#text"], // unterminated OSC — Bun keeps literal
     "\x1b[(text",
     "\x1b[)text",
     "\x1b[;text",
@@ -256,9 +260,18 @@ describe("Bun.stripANSI", () => {
     ["\x1b]2;Both\x9ctext", "text"], // ST terminator
     ["\x1b]8;;http://example.com\x07", ""], // Hyperlink OSC
 
-    // Invalid OSC sequences (missing terminator)
-    ["\x1b]0;title", ""], // No terminator, consumes rest
-    ["\x1b]2;test\x1bother", ""], // Incomplete ESC terminator
+    // Invalid OSC sequences (missing terminator). Bun preserves literal;
+    // strip-ansi's regex backtracks into a CSI fallback that consumes
+    // through the first ASCII letter — we deliberately diverge.
+    ["\x1b]0;title", "\x1b]0;title"],
+
+    // CJK (and other non-ASCII) following partial/invalid escape introducers
+    // must not be eaten. The original regression report flagged each of these.
+    ["\x1bあいう", "\x1bあいう"], // bare ESC + non-ASCII: keep verbatim
+    ["\x1b[あいう", "\x1b[あいう"], // ESC[ then non-ASCII with no terminator: keep verbatim
+    ["\x1b]8;;url本文末尾", "\x1b]8;;url本文末尾"], // unterminated OSC8 with JP payload: keep verbatim
+    ["\x1b]0;ウィンドウ", "\x1b]0;ウィンドウ"], // unterminated OSC with JP title: keep verbatim
+    ["\x1bあ\x1b[31mred\x1b[39m", "\x1bあred"], // partial-escape splice followed by valid CSI
 
     // Complex prefix combinations
     ["\x1b[[[31mtext", "[31mtext"], // [ terminates CSI
@@ -348,12 +361,12 @@ describe("Bun.stripANSI", () => {
     ["\x1b#5text", "text"], // Single-width line
     ["\x1b#6text", "text"], // Double-width line
 
-    // Malformed sequences that should partially match
-    "\x1b[31", // Incomplete CSI (no final byte)
-    ["\x1b[31;", ""], // Incomplete parameters
-    "\x1b[31;4", // Incomplete parameters
-    ["\x1b]0;title", ""], // Incomplete OSC
-    ["\x1b]0;title\x1b", ""], // Incomplete OSC terminator
+    // Malformed sequences. Bun preserves unterminated sequences literal
+    // (rather than strip-ansi's regex backtracking into a CSI fallback).
+    ["\x1b[31", "\x1b[31"], // Incomplete CSI (no final byte)
+    ["\x1b[31;", "\x1b[31;"], // Incomplete parameters
+    ["\x1b[31;4", "\x1b[31;4"], // Incomplete parameters
+    ["\x1b]0;title\x1b", "\x1b]0;title"], // Incomplete OSC terminator (trailing ESC stripped)
 
     // Sequences with invalid parameters
     ["\x1b[99999mtext", "text"], // Parameter too long (>4 digits), but strip anyway


### PR DESCRIPTION
### What does this PR do?

Fixes `Bun.stripANSI` eating CJK and other non-ASCII content in three cases:

1. **ESC + non-ASCII** — `"\x1bあいう"` was returning `"いう"`. The `gotEsc` default branch treated any byte after ESC as the second byte of a 2-byte escape, swallowing the first non-ASCII character.
2. **ESC[ + non-ASCII** — `"\x1b[あいう"` was returning `""`. The CSI terminator SIMD scan ([0x40, 0x7e]) skipped over non-ASCII bytes entirely; with no terminator anywhere in the string, `consumeANSI` returned `end` and ate the rest. Even worse, `"\x1b[あm"` returned `""` because the scan jumped over `あ` (0x3042) and landed on the literal `m` downstream.
3. **Unterminated OSC with non-ASCII payload** — `"\x1b]8;;url本文末尾"` was returning `""`. OSC sequences without BEL / ST / `ESC \` ate everything to end-of-input.

The fix updates `consumeANSI` in `src/bun.js/bindings/ANSIHelpers.h`:

- In `gotEsc`, bail when the next byte is `>= 0x80`. Non-ASCII bytes can never be a valid ANSI escape continuation, so the caller leaves them literal.
- In `inCsi`, after the SIMD terminator scan finds a candidate, validate that every byte between the introducer and the candidate is a valid CSI parameter or intermediate (`0x20-0x3F` per ECMA-48 §5.4). Anything else means the SIMD scan jumped over invalid content to land on a stray ASCII letter — bail and leave the bytes literal.
- In `inCsi` / `inOsc` / `needSt`, return `start` (not `end`) when the terminator scan reaches end-of-input. The caller already handles `newPos == start` by copying the byte literally and continuing, so no caller change is needed.
- After the for loop, return `start` when still mid-sequence in a multi-byte state (`inCsi` / `inOsc` / `inOscGotEsc` / `needSt` / `needStGotEsc`). This catches cases like `"\x1b]"` where `++it` reaches `end` before the inner state's body ever runs.

`gotEsc` and `ignoreNextChar` still fall through to `return end` to preserve trailing-ESC and two-byte-ESC consumption.

The new behavior diverges from npm `strip-ansi` for some pathological inputs: `strip-ansi`'s regex backtracks and treats trailing digits as CSI terminators, and falls into a CSI fallback for OSC introducers that consumes through the next ASCII letter (e.g. `"\x1b]0;title"` → `"itle"`). Bun now preserves unterminated sequences literal, which is a more accurate interpretation of the input. The test file marks these divergences explicitly via the `[input, expected]` tuple form.

### How did you verify your code works?

`bun bd test test/js/bun/util/stripANSI.test.ts` — 268 pass, 0 fail.

The test file already had a parity loop comparing `Bun.stripANSI(input)` against npm `strip-ansi(input)`. New plain-string entries (parity-checked) cover the original bug-report cases and adversarial probes:

- `"\x1bあいう"`, `"\x1b[あいう"`, `"\x1b]8;;url本文末尾"` — original report
- `"\x1b]"`, `"\x1b[あm"` — regressions surfaced during verification
- `"\x1b]0;ウィンドウ"`, `"\x1bあ\x1b[31mred\x1b[39m"` — additional CJK / partial-escape coverage

Pre-existing entries that previously asserted `[..., ""]` for unterminated CSI / OSC have been converted to tuples reflecting the new literal-preservation behavior.
