### PR TITLE
mock.module: skip resolve for specifiers with control characters

### DIFF
--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -546,6 +546,16 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         }
 
         if (url.isValid() && url.protocolIsFile()) {
+            // Skip module resolution for specifiers that contain characters never
+            // valid in real module names/paths. Running the resolver on arbitrary
+            // text would otherwise fall through to the auto-install code path.
+            for (unsigned i = 0; i < specifier.length(); ++i) {
+                auto c = specifier[i];
+                if (c == '\0' || c == '\n' || c == '\r') {
+                    return;
+                }
+            }
+
             auto fromString = url.fileSystemPath();
             BunString from = Bun::toString(fromString);
             auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);

--- a/test/js/bun/test/mock/mock-module-control-chars.test.ts
+++ b/test/js/bun/test/mock/mock-module-control-chars.test.ts
@@ -1,0 +1,8 @@
+import { expect, mock, test } from "bun:test";
+
+test("mock.module does not crash on specifiers containing control characters", () => {
+  const specifiers = ["function f() {}\nfunction g() {}", "foo\rbar", "foo\u0000bar", "line1\nline2\nline3"];
+  for (const specifier of specifiers) {
+    expect(() => mock.module(specifier, () => ({ default: 1 }))).not.toThrow();
+  }
+});


### PR DESCRIPTION
Fuzzilli found a flaky use-after-poison in `UnboundedQueue.popBatch` reached from the JS event loop during `vi.mock()` of a garbage specifier:

```
#0 ConcurrentTask.PackedNextPtr.atomicLoadPtr (event_loop/ConcurrentTask.zig:46)
#1 UnboundedQueue(ConcurrentTask).atomicLoadNext (threading/unbounded_queue.zig:44)
#2 UnboundedQueue(ConcurrentTask).popBatch (threading/unbounded_queue.zig:156)
#3 event_loop.tickConcurrentWithCount (bun.js/event_loop.zig:315)
…
#7 AnyEventLoop.tick (bun.js/event_loop/AnyEventLoop.zig:62)
#8 PackageManager.sleepUntil (install/PackageManager.zig:426)
#9 PackageManager.enqueueDependencyToRoot (install/PackageManager/PackageManagerEnqueue.zig:378)
#10 Resolver.resolveAndAutoInstall (resolver/resolver.zig:857)
…
#16 Bun__resolveSyncWithSource (bun.js/api/BunObject.zig:946)
#17 JSMock__jsModuleMock (bindings/BunPlugin.cpp:552)
```

The repro called `Bun.jest().vi.mock(s)` where `s` was a 1 KB string of concatenated function source code containing newlines. `resolveSpecifier()` in `JSMock__jsModuleMock` always calls `Bun__resolveSyncWithSource` when the caller has a `file://` source URL, which then falls through to `resolveAndAutoInstall → PackageManager.sleepUntil`, reentrantly ticking the JS event loop from inside the running `vi.mock` call.

Real module names/paths never contain `\0`, `\n`, or `\r`, so we can just skip the resolve step for such specifiers and let `vi.mock` use the literal key, which is what it already falls back to on resolve failure anyway.

Minimal, targeted fix:

```cpp
for (unsigned i = 0; i < specifier.length(); ++i) {
    auto c = specifier[i];
    if (c == '\0' || c == '\n' || c == '\r') {
        return;
    }
}
```

Adds a regression test in `test/js/bun/test/mock/mock-module-non-string.test.ts` covering specifiers with newlines, carriage returns, and null bytes.