### PR TITLE
mock.module: validate callback before running resolver

### DIFF
--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -526,6 +526,12 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         return {};
     }
 
+    JSC::JSValue callbackValue = callframe->argument(1);
+    if (!callbackValue.isCell() || !callbackValue.isCallable()) {
+        scope.throwException(lexicalGlobalObject, JSC::createTypeError(lexicalGlobalObject, "mock(module, fn) requires a function"_s));
+        return {};
+    }
+
     auto resolveSpecifier = [&]() -> void {
         JSC::SourceOrigin sourceOrigin = callframe->callerSourceOrigin(vm);
         if (sourceOrigin.isNull())
@@ -580,12 +586,6 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
 
     resolveSpecifier();
     RETURN_IF_EXCEPTION(scope, {});
-
-    JSC::JSValue callbackValue = callframe->argument(1);
-    if (!callbackValue.isCell() || !callbackValue.isCallable()) {
-        scope.throwException(lexicalGlobalObject, JSC::createTypeError(lexicalGlobalObject, "mock(module, fn) requires a function"_s));
-        return {};
-    }
 
     JSC::JSObject* callback = callbackValue.getObject();
 

--- a/test/js/bun/test/mock/mock-module-non-string.test.ts
+++ b/test/js/bun/test/mock/mock-module-non-string.test.ts
@@ -16,3 +16,20 @@ test("mock.module still works with valid string argument", async () => {
   const m = await import("mock-module-non-string-test-fixture");
   expect(m.default).toBe(42);
 });
+
+test("mock.module throws TypeError without resolving when callback is missing", () => {
+  // Running the resolver on an arbitrary user-provided string can enter the
+  // package-manager auto-install code path and crash. When the caller didn't
+  // pass a callable second argument, we must fail fast before touching the
+  // resolver.
+  const specifiers = [
+    "function f3() {}",
+    "function foo(a, b) { return a + b; }",
+    "() => 1",
+    "some bogus package name {with braces}",
+  ];
+  for (const specifier of specifiers) {
+    // @ts-expect-error missing callback on purpose
+    expect(() => mock.module(specifier)).toThrow("mock(module, fn) requires a function");
+  }
+});


### PR DESCRIPTION
## Crash

Fuzzilli hit a flaky SIGSEGV (fingerprint `ac324f57f10d95ce`) from this body:

```js
delete globalThis.Loader;
Bun.generateHeapSnapshot = console.profile = console.profileEnd = process.abort = () => {};
Bun.FFI = undefined;
try {
  Bun.parse();
} catch (e2) {
  function f3() {}
  const v4 = f3.toLocaleString();
  const v7 = Bun.jest().vi;
  try { v7.mock(v4); } catch (e) {}
}
```

`v4` ends up as the string `"function f3() {}"`. It is then passed as the first (and only) argument to `vi.mock`. The function is going to throw `TypeError: mock(module, fn) requires a function` regardless — but before it gets there, `JSMock__jsModuleMock` runs `resolveSpecifier()`, which feeds that junk string into the module resolver. The resolver in turn can reach the package manager auto-install path, which has a history of crashing on inputs it doesn't expect (see #28511, #28518, #28945).

## Fix

Move the callable check for the second argument in front of `resolveSpecifier()`. When a caller forgets the callback (or passes something non-callable), we throw `TypeError: mock(module, fn) requires a function` without ever touching the resolver. That avoids the entire auto-install re-entry for the 1-arg misuse and matches how `jest.fn`/`vi.mock` consumers actually use the API.

The error message and behavior for valid 2-arg calls are unchanged.

## Test

Adds a regression test to `test/js/bun/test/mock/mock-module-non-string.test.ts` that exercises a few specifiers that could previously reach the resolver (a function source, an arrow function, a bogus package-name-with-braces), verifying each throws `TypeError` cleanly.

```
test/js/bun/test/mock/mock-module-non-string.test.ts:
(pass) mock.module throws TypeError for non-string first argument
(pass) mock.module still works with valid string argument
(pass) mock.module throws TypeError without resolving when callback is missing
```

Fingerprint: `ac324f57f10d95ce`