### PR TITLE
bunx: don't fall through to system commands for scoped packages

### DIFF
--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -651,8 +651,13 @@ pub const BunxCommand = struct {
                 // `package.json`, not the bin-name basename — otherwise for scoped packages
                 // we'd look up `node_modules/name/package.json`, which doesn't exist.
                 if (getBinName(&this_transpiler, root_dir_fd, bunx_cache_dir, result_package_name)) |package_name_for_bin| {
-                    // if we check the bin name and its actually the same, we don't need to check $PATH here again
-                    if (!strings.eqlLong(package_name_for_bin, initial_bin_name, true)) {
+                    // If we already searched $PATH for `initial_bin_name` above and the resolved
+                    // bin name is the same, there's nothing new to look up. But for scoped packages
+                    // we skip that first $PATH probe (see `initial_bin_name_is_reliable_path_match`),
+                    // so an `@scope/foo` package that publishes a bin literally named `foo` still
+                    // needs this second probe — otherwise `bunx @scope/foo` would miss an already
+                    // installed `node_modules/.bin/foo`.
+                    if (!strings.eqlLong(package_name_for_bin, initial_bin_name, true) or !initial_bin_name_is_reliable_path_match) {
                         absolute_in_cache_dir = std.fmt.bufPrint(&absolute_in_cache_dir_buf, bun.pathLiteral("{s}/node_modules/.bin/{s}{s}"), .{ bunx_cache_dir, package_name_for_bin, bun.exe_suffix }) catch unreachable;
 
                         // Only use the system-installed version if there is no version specified.

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -374,6 +374,14 @@ pub const BunxCommand = struct {
             update_request.name;
         debug("initial_bin_name: {s}", .{initial_bin_name});
 
+        // For scoped packages like `@scope/name`, the portion after `/` is not a reliable bin name —
+        // many scoped packages publish a bin with a completely different name (e.g. `@paretools/git`
+        // publishes `pare-git`). If we blindly search $PATH for that basename we can accidentally run
+        // an unrelated system command that happens to share the name (e.g. `bun x @paretools/git`
+        // running `/usr/bin/git`). Only trust the basename as a PATH-searchable bin name when the
+        // user explicitly specified the bin via `--package` or when the package isn't scoped.
+        const initial_bin_name_is_reliable_path_match = opts.binary_name != null or !strings.hasPrefixComptime(update_request.name, "@");
+
         // fast path: they're actually using this interchangeably with `bun run`
         // so we use Bun.which to check
         // SAFETY: initialized by Run.configureEnvForRun
@@ -551,8 +559,11 @@ pub const BunxCommand = struct {
         if (look_for_existing_bin) try_run_existing: {
             var destination_: ?[:0]const u8 = null;
 
-            // Only use the system-installed version if there is no version specified
-            if (update_request.version.literal.isEmpty()) {
+            // Only use the system-installed version if there is no version specified.
+            // For scoped packages whose bin name we derived from the basename, we skip
+            // this $PATH fast-path because the basename may collide with an unrelated
+            // system command (see `initial_bin_name_is_reliable_path_match` above).
+            if (initial_bin_name_is_reliable_path_match and update_request.version.literal.isEmpty()) {
                 destination_ = bun.which(
                     &path_buf,
                     PATH_FOR_BIN_DIRS,
@@ -636,16 +647,22 @@ pub const BunxCommand = struct {
             const root_dir_fd = root_dir_info.getFileDescriptor();
             bun.assert(root_dir_fd.isValid());
             if (opts.binary_name == null) {
-                if (getBinName(&this_transpiler, root_dir_fd, bunx_cache_dir, initial_bin_name)) |package_name_for_bin| {
+                // Use the full package name (e.g. `@scope/name`) to locate the installed
+                // `package.json`, not the bin-name basename — otherwise for scoped packages
+                // we'd look up `node_modules/name/package.json`, which doesn't exist.
+                if (getBinName(&this_transpiler, root_dir_fd, bunx_cache_dir, result_package_name)) |package_name_for_bin| {
                     // if we check the bin name and its actually the same, we don't need to check $PATH here again
                     if (!strings.eqlLong(package_name_for_bin, initial_bin_name, true)) {
                         absolute_in_cache_dir = std.fmt.bufPrint(&absolute_in_cache_dir_buf, bun.pathLiteral("{s}/node_modules/.bin/{s}{s}"), .{ bunx_cache_dir, package_name_for_bin, bun.exe_suffix }) catch unreachable;
 
-                        // Only use the system-installed version if there is no version specified
+                        // Only use the system-installed version if there is no version specified.
+                        // This is safe to search $PATH with now because `package_name_for_bin`
+                        // comes from the target package's own `package.json`, so local node_modules
+                        // entries will point at the right binary (not an unrelated system command).
                         if (update_request.version.literal.isEmpty()) {
                             destination_ = bun.which(
                                 &path_buf,
-                                bunx_cache_dir,
+                                PATH_FOR_BIN_DIRS,
                                 if (ignore_cwd.len > 0) "" else this_transpiler.fs.top_level_dir,
                                 package_name_for_bin,
                             );

--- a/test/regression/issue/28950.test.ts
+++ b/test/regression/issue/28950.test.ts
@@ -1,0 +1,74 @@
+// https://github.com/oven-sh/bun/issues/28950
+//
+// `bun x @scope/name` must not fall through to a same-named system command
+// when the scoped package publishes a bin with a different name. Previously
+// we would derive `initial_bin_name` from the basename after `/` and
+// happily resolve it against $PATH, so e.g. `bun x @paretools/git` ran
+// `/usr/bin/git` instead of `pare-git`.
+import { test, expect } from "bun:test";
+import { chmodSync } from "node:fs";
+import { join } from "node:path";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+test("bun x @scope/name runs the package's real bin, not a colliding system command", async () => {
+  // The scoped package's "basename" (`collide`) intentionally matches the
+  // decoy binary we'll put on PATH. The real bin is `real-bin`.
+  //
+  // Pre-install it under the scoped path and populate `node_modules/.bin`
+  // manually — `--no-install` makes `bun x` use what's already on disk, so
+  // this is enough to exercise the code path without talking to a registry.
+  using dir = tempDir("bunx-28950-", {
+    "node_modules/@myscope/collide/package.json": JSON.stringify({
+      name: "@myscope/collide",
+      version: "1.0.0",
+      bin: { "real-bin": "./real.js" },
+    }),
+    "node_modules/@myscope/collide/real.js": `#!/usr/bin/env node
+console.log("REAL_BIN_RAN");
+`,
+    "node_modules/.bin/real-bin": `#!/usr/bin/env node
+require("../@myscope/collide/real.js");
+`,
+    // Decoy that matches the basename of the scoped package. If the fast
+    // path of bunx searches PATH for "collide" it will find this and run it.
+    "decoy/collide": `#!/bin/sh
+echo "DECOY_RAN"
+`,
+    // Windows .cmd equivalent for the decoy — on Windows bun.which looks up
+    // common extensions when searching PATH.
+    "decoy/collide.cmd": `@echo off\r\necho DECOY_RAN\r\n`,
+  });
+
+  const root = String(dir);
+  const realJs = join(root, "node_modules/@myscope/collide/real.js");
+  const realBin = join(root, "node_modules/.bin/real-bin");
+  const decoy = join(root, "decoy/collide");
+
+  if (!isWindows) {
+    chmodSync(realJs, 0o755);
+    chmodSync(realBin, 0o755);
+    chmodSync(decoy, 0o755);
+  }
+
+  // Prepend the decoy dir to PATH so `bun.which("collide")` would hit it
+  // before any real system command.
+  const PATH = join(root, "decoy") + (isWindows ? ";" : ":") + (bunEnv.PATH ?? "");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "x", "--no-install", "@myscope/collide"],
+    cwd: root,
+    env: { ...bunEnv, PATH },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The fix: `bun x @myscope/collide` must NOT run the decoy named "collide"
+  // on PATH — it must resolve through the scoped package's package.json to
+  // the real bin "real-bin".
+  expect({ stdout: stdout.trim(), stderr: stderr.trim(), exitCode }).toEqual({
+    stdout: "REAL_BIN_RAN",
+    stderr: "",
+    exitCode: 0,
+  });
+});

--- a/test/regression/issue/28950.test.ts
+++ b/test/regression/issue/28950.test.ts
@@ -29,25 +29,25 @@ console.log("REAL_BIN_RAN");
     "node_modules/.bin/real-bin": `#!/usr/bin/env node
 require("../@myscope/collide/real.js");
 `,
+    // Windows .cmd shim for the real bin — on Windows `bun.which` only matches
+    // files with .exe/.cmd/.bat extensions, so the extension-less shebang script
+    // above is invisible to it.
+    "node_modules/.bin/real-bin.cmd": `@echo off\r\nnode "%~dp0..\\@myscope\\collide\\real.js" %*\r\n`,
     // Decoy that matches the basename of the scoped package. If the fast
     // path of bunx searches PATH for "collide" it will find this and run it.
     "decoy/collide": `#!/bin/sh
 echo "DECOY_RAN"
 `,
-    // Windows .cmd equivalent for the decoy — on Windows bun.which looks up
-    // common extensions when searching PATH.
+    // Windows .cmd equivalent for the decoy.
     "decoy/collide.cmd": `@echo off\r\necho DECOY_RAN\r\n`,
   });
 
   const root = String(dir);
-  const realJs = join(root, "node_modules/@myscope/collide/real.js");
-  const realBin = join(root, "node_modules/.bin/real-bin");
-  const decoy = join(root, "decoy/collide");
 
   if (!isWindows) {
-    chmodSync(realJs, 0o755);
-    chmodSync(realBin, 0o755);
-    chmodSync(decoy, 0o755);
+    chmodSync(join(root, "node_modules/@myscope/collide/real.js"), 0o755);
+    chmodSync(join(root, "node_modules/.bin/real-bin"), 0o755);
+    chmodSync(join(root, "decoy/collide"), 0o755);
   }
 
   // Prepend the decoy dir to PATH so `bun.which("collide")` would hit it
@@ -61,14 +61,55 @@ echo "DECOY_RAN"
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // The fix: `bun x @myscope/collide` must NOT run the decoy named "collide"
   // on PATH — it must resolve through the scoped package's package.json to
-  // the real bin "real-bin".
-  expect({ stdout: stdout.trim(), stderr: stderr.trim(), exitCode }).toEqual({
-    stdout: "REAL_BIN_RAN",
-    stderr: "",
-    exitCode: 0,
+  // the real bin "real-bin". (Don't assert stderr is empty — ASAN builds
+  // emit warnings there even on success.)
+  expect(stdout.trim()).toBe("REAL_BIN_RAN");
+  expect(exitCode).toBe(0);
+});
+
+test("bun x @scope/name runs an already-installed bin whose name matches the basename", async () => {
+  // Regression for the double-skip case: if `@scope/foo` publishes a bin
+  // literally named `foo` (bin name == package basename), the fix for the
+  // main issue still needs to re-probe $PATH for the resolved bin name,
+  // even though it matches `initial_bin_name`. Otherwise the first probe
+  // is skipped (because the package is scoped) *and* the second probe is
+  // skipped (because the names match) — leaving a locally-installed bin
+  // undiscoverable under `--no-install`.
+  using dir = tempDir("bunx-28950-match-", {
+    "node_modules/@myscope/samebin/package.json": JSON.stringify({
+      name: "@myscope/samebin",
+      version: "1.0.0",
+      bin: { samebin: "./real.js" },
+    }),
+    "node_modules/@myscope/samebin/real.js": `#!/usr/bin/env node
+console.log("SAMEBIN_RAN");
+`,
+    "node_modules/.bin/samebin": `#!/usr/bin/env node
+require("../@myscope/samebin/real.js");
+`,
+    "node_modules/.bin/samebin.cmd": `@echo off\r\nnode "%~dp0..\\@myscope\\samebin\\real.js" %*\r\n`,
   });
+
+  const root = String(dir);
+
+  if (!isWindows) {
+    chmodSync(join(root, "node_modules/@myscope/samebin/real.js"), 0o755);
+    chmodSync(join(root, "node_modules/.bin/samebin"), 0o755);
+  }
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "x", "--no-install", "@myscope/samebin"],
+    cwd: root,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("SAMEBIN_RAN");
+  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/28950.test.ts
+++ b/test/regression/issue/28950.test.ts
@@ -5,10 +5,10 @@
 // we would derive `initial_bin_name` from the basename after `/` and
 // happily resolve it against $PATH, so e.g. `bun x @paretools/git` ran
 // `/usr/bin/git` instead of `pare-git`.
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { chmodSync } from "node:fs";
 import { join } from "node:path";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 test("bun x @scope/name runs the package's real bin, not a colliding system command", async () => {
   // The scoped package's "basename" (`collide`) intentionally matches the


### PR DESCRIPTION
Fixes #28950

## Repro

`@paretools/git` publishes a single bin named `pare-git` (different
from the package basename `git`):

```console
$ npm view @paretools/git bin --json
{ "pare-git": "dist/index.js" }
$ bun x @paretools/git
usage: git [-v | --version] [-h | --help] ...
```

Instead of installing `@paretools/git` and executing `pare-git`,
`bun x` runs `/usr/bin/git`. The scoped package is never touched.

## Root cause

In `src/cli/bunx_command.zig`, `exec()` derives `initial_bin_name`
from the package name by taking everything after the last `/`, so
`@paretools/git` → `initial_bin_name = "git"`. The fast path then
calls `bun.which` against $PATH with that name and happily resolves
to `/usr/bin/git`.

There was also a second, latent bug in the same block: when the
fast-path $PATH lookup fails and we fall through to read the target
package's `package.json` to discover its real bin name, the code
calls `getBinName(..., initial_bin_name)` — which looks for
`node_modules/name/package.json` instead of
`node_modules/@scope/name/package.json`. For scoped packages this
always missed the installed `package.json`.

## Fix

In `bunx_command.zig`:

1. For scoped packages without an explicit `--package` binary name,
   skip the basename-based $PATH fast-path. The basename isn't a
   reliable bin name.
2. When reading `package.json` to discover the real bin name, pass
   the full `@scope/name` (`result_package_name`) so we actually
   find the installed `package.json`.
3. Once we know the real bin name, search $PATH with *that* instead
   of just the `bunx` cache dir. It's safe now because the name
   came from the target package's own `package.json`, so a
   `node_modules/.bin` entry with that name is the right binary.

Unscoped packages and `--package <pkg> <bin>` are unchanged.

## Verification

Added `test/regression/issue/28950.test.ts`. It pre-installs a
`@myscope/collide` package into `node_modules/` with bin
`real-bin`, plants a decoy script named `collide` on `$PATH`,
and asserts that `bun x --no-install @myscope/collide` runs
`real-bin` rather than the decoy.

- `bun bd test test/regression/issue/28950.test.ts` → **pass**
- `USE_SYSTEM_BUN=1 bun test test/regression/issue/28950.test.ts` → **fails** on current `main` with `DECOY_RAN`, confirming the bug

Existing `bunx.test.ts` scoped-package test still passes.