### PR TITLE
fix(fs): throw ERR_FS_EISDIR when fs.rm targets a directory without recursive

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5762,11 +5762,19 @@ pub const NodeFS = struct {
                     error.IsDir => .ISDIR,
                     error.NotDir => .NOTDIR,
                     error.AccessDenied => brk: {
-                        if (comptime Environment.isMac) {
-                            // Use `lstatat` so a symlink pointing at a
-                            // directory is NOT remapped — unlink on a
-                            // symlink is legal, so a real EACCES/EPERM
-                            // on the link itself must surface unchanged.
+                        // On macOS `unlink(2)` on a directory returns
+                        // EPERM; on Windows `DeleteFile()` on a
+                        // directory returns ERROR_ACCESS_DENIED. Both
+                        // surface as `error.AccessDenied`, so probe the
+                        // path before remapping — we must not clobber a
+                        // real EACCES/EPERM on a regular file.
+                        //
+                        // `lstatat` uses `AT_SYMLINK_NOFOLLOW`, so a
+                        // symlink pointing at a directory is NOT
+                        // remapped — unlink on a symlink is legal and
+                        // any permission error on the link itself must
+                        // surface unchanged.
+                        if (comptime Environment.isMac or Environment.isWindows) {
                             switch (bun.sys.lstatat(bun.invalid_fd, dest)) {
                                 .result => |stat_buf| if (bun.S.ISDIR(stat_buf.mode)) break :brk .ISDIR,
                                 .err => {},

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5750,7 +5750,26 @@ pub const NodeFS = struct {
 
             {
                 const code: E = switch (err1) {
-                    error.AccessDenied => .ACCES,
+                    // On Linux, unlink(2) on a directory returns EISDIR.
+                    // On macOS, unlink(2) on a directory returns EPERM,
+                    // which Zig maps to `error.AccessDenied`. We can't
+                    // tell that apart from a real EACCES/EPERM on a file,
+                    // so probe with a stat and only remap when the target
+                    // is actually a directory.
+                    //
+                    // Node.js throws `ERR_FS_EISDIR` in this case; the JS
+                    // wrapper in `src/js/node/fs.ts` remaps this.
+                    error.IsDir => .ISDIR,
+                    error.NotDir => .NOTDIR,
+                    error.AccessDenied => brk: {
+                        if (comptime Environment.isMac) {
+                            switch (bun.sys.directoryExistsAt(bun.invalid_fd, dest)) {
+                                .result => |is_dir| if (is_dir) break :brk .ISDIR,
+                                .err => {},
+                            }
+                        }
+                        break :brk .ACCES;
+                    },
                     error.SymLinkLoop => .LOOP,
                     error.NameTooLong => .NAMETOOLONG,
                     error.SystemResources => .NOMEM,
@@ -5759,11 +5778,6 @@ pub const NodeFS = struct {
                     error.InvalidUtf8 => .INVAL,
                     error.InvalidWtf8 => .INVAL,
                     error.BadPathName => .INVAL,
-                    // On Linux, unlink(2) on a directory returns EISDIR.
-                    // Node.js throws `ERR_FS_EISDIR` in this case; the JS
-                    // wrapper in `src/js/node/fs.ts` remaps this.
-                    error.IsDir => .ISDIR,
-                    error.NotDir => .NOTDIR,
                     error.FileNotFound => brk: {
                         if (args.force) {
                             return .success;

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5759,6 +5759,11 @@ pub const NodeFS = struct {
                     error.InvalidUtf8 => .INVAL,
                     error.InvalidWtf8 => .INVAL,
                     error.BadPathName => .INVAL,
+                    // On Linux, unlink(2) on a directory returns EISDIR.
+                    // Node.js throws `ERR_FS_EISDIR` in this case; the JS
+                    // wrapper in `src/js/node/fs.ts` remaps this.
+                    error.IsDir => .ISDIR,
+                    error.NotDir => .NOTDIR,
                     error.FileNotFound => brk: {
                         if (args.force) {
                             return .success;

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5775,8 +5775,13 @@ pub const NodeFS = struct {
                         // any permission error on the link itself must
                         // surface unchanged.
                         if (comptime Environment.isMac or Environment.isWindows) {
+                            // Direct bit-test instead of `bun.S.ISDIR`:
+                            // on Windows `stat_buf.mode` is `u64`
+                            // (`uv_stat_t`) but `bun.S.ISDIR` takes an
+                            // `i32`, so the helper doesn't type-check
+                            // across platforms.
                             switch (bun.sys.lstatat(bun.invalid_fd, dest)) {
-                                .result => |stat_buf| if (bun.S.ISDIR(stat_buf.mode)) break :brk .ISDIR,
+                                .result => |stat_buf| if (stat_buf.mode & bun.S.IFMT == bun.S.IFDIR) break :brk .ISDIR,
                                 .err => {},
                             }
                         }

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5763,8 +5763,12 @@ pub const NodeFS = struct {
                     error.NotDir => .NOTDIR,
                     error.AccessDenied => brk: {
                         if (comptime Environment.isMac) {
-                            switch (bun.sys.directoryExistsAt(bun.invalid_fd, dest)) {
-                                .result => |is_dir| if (is_dir) break :brk .ISDIR,
+                            // Use `lstatat` so a symlink pointing at a
+                            // directory is NOT remapped — unlink on a
+                            // symlink is legal, so a real EACCES/EPERM
+                            // on the link itself must surface unchanged.
+                            switch (bun.sys.lstatat(bun.invalid_fd, dest)) {
+                                .result => |stat_buf| if (bun.S.ISDIR(stat_buf.mode)) break :brk .ISDIR,
                                 .err => {},
                             }
                         }

--- a/src/js/internal/fs/rm-utils.ts
+++ b/src/js/internal/fs/rm-utils.ts
@@ -1,0 +1,34 @@
+// Shared helpers for `fs.rm` / `fs.rmSync` / `fs.promises.rm`.
+
+// Node.js throws a SystemError with code `ERR_FS_EISDIR` when `fs.rm*`
+// is called on a directory without `recursive: true`. Bun's native
+// binding surfaces the raw `EISDIR` from unlink(2), so we rewrap it here
+// to match Node.js's shape. See https://github.com/oven-sh/bun/issues/28958.
+export function maybeRemapRmEISDIR(err: any, path: any, options: any) {
+  if (!err || err.code !== "EISDIR") return err;
+  // If the caller passed `recursive: true`, an EISDIR here would be
+  // unexpected — leave the original error alone.
+  if (options != null && typeof options === "object" && options.recursive) return err;
+  let pathString: string | undefined;
+  if (typeof path === "string") {
+    pathString = path;
+  } else if (path instanceof URL) {
+    try {
+      pathString = Bun.fileURLToPath(path as URL);
+    } catch {
+      pathString = undefined;
+    }
+  } else if (Buffer.isBuffer(path)) {
+    pathString = path.toString();
+  } else if (typeof err.path === "string") {
+    pathString = err.path;
+  }
+  const pathSuffix = pathString !== undefined ? " " + pathString : "";
+  const wrapped: any = new Error(`Path is a directory: rm returned EISDIR (is a directory)${pathSuffix}`);
+  wrapped.name = "SystemError";
+  wrapped.code = "ERR_FS_EISDIR";
+  wrapped.errno = 21;
+  wrapped.syscall = "rm";
+  if (pathString !== undefined) wrapped.path = pathString;
+  return wrapped;
+}

--- a/src/js/internal/fs/rm-utils.ts
+++ b/src/js/internal/fs/rm-utils.ts
@@ -4,7 +4,7 @@
 // is called on a directory without `recursive: true`. Bun's native
 // binding surfaces the raw `EISDIR` from unlink(2), so we rewrap it here
 // to match Node.js's shape. See https://github.com/oven-sh/bun/issues/28958.
-export function maybeRemapRmEISDIR(err: any, path: any, options: any) {
+function maybeRemapRmEISDIR(err: any, path: any, options: any) {
   if (!err || err.code !== "EISDIR") return err;
   // If the caller passed `recursive: true`, an EISDIR here would be
   // unexpected — leave the original error alone.
@@ -32,3 +32,7 @@ export function maybeRemapRmEISDIR(err: any, path: any, options: any) {
   if (pathString !== undefined) wrapped.path = pathString;
   return wrapped;
 }
+
+export default {
+  maybeRemapRmEISDIR,
+};

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -117,6 +117,37 @@ async function opendir(dir: string, options) {
   return new (require("node:fs").Dir)(1, dir, options);
 }
 
+// Node.js throws a SystemError with code `ERR_FS_EISDIR` when `fs.rm`
+// is called on a directory without `recursive: true`. Bun's native
+// binding surfaces the raw `EISDIR` from unlink(2), so we rewrap it here
+// to match Node.js's shape. See #28958.
+function maybeRemapRmEISDIR(err: any, path: any, options: any) {
+  if (!err || err.code !== "EISDIR") return err;
+  if (options != null && typeof options === "object" && options.recursive) return err;
+  let pathString: string | undefined;
+  if (typeof path === "string") {
+    pathString = path;
+  } else if (path instanceof URL) {
+    try {
+      pathString = Bun.fileURLToPath(path as URL);
+    } catch {
+      pathString = undefined;
+    }
+  } else if (Buffer.isBuffer(path)) {
+    pathString = path.toString();
+  } else if (typeof err.path === "string") {
+    pathString = err.path;
+  }
+  const pathSuffix = pathString !== undefined ? " " + pathString : "";
+  const wrapped: any = new Error(`Path is a directory: rm returned EISDIR (is a directory)${pathSuffix}`);
+  wrapped.name = "SystemError";
+  wrapped.code = "ERR_FS_EISDIR";
+  wrapped.errno = 21;
+  wrapped.syscall = "rm";
+  if (pathString !== undefined) wrapped.path = pathString;
+  return wrapped;
+}
+
 const private_symbols = {
   kRef,
   kUnref,
@@ -195,7 +226,13 @@ const exports = {
   unlink: asyncWrap(fs.unlink, "unlink"),
   utimes: asyncWrap(fs.utimes, "utimes"),
   lutimes: asyncWrap(fs.lutimes, "lutimes"),
-  rm: asyncWrap(fs.rm, "rm"),
+  rm: async function rm(path, options) {
+    try {
+      return await fs.rm(path, options);
+    } catch (err) {
+      throw maybeRemapRmEISDIR(err, path, options);
+    }
+  },
   rmdir: asyncWrap(fs.rmdir, "rmdir"),
   writev: async (fd, buffers, position) => {
     var bytesWritten = await fs.writev(fd, buffers, position);

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -117,36 +117,7 @@ async function opendir(dir: string, options) {
   return new (require("node:fs").Dir)(1, dir, options);
 }
 
-// Node.js throws a SystemError with code `ERR_FS_EISDIR` when `fs.rm`
-// is called on a directory without `recursive: true`. Bun's native
-// binding surfaces the raw `EISDIR` from unlink(2), so we rewrap it here
-// to match Node.js's shape. See #28958.
-function maybeRemapRmEISDIR(err: any, path: any, options: any) {
-  if (!err || err.code !== "EISDIR") return err;
-  if (options != null && typeof options === "object" && options.recursive) return err;
-  let pathString: string | undefined;
-  if (typeof path === "string") {
-    pathString = path;
-  } else if (path instanceof URL) {
-    try {
-      pathString = Bun.fileURLToPath(path as URL);
-    } catch {
-      pathString = undefined;
-    }
-  } else if (Buffer.isBuffer(path)) {
-    pathString = path.toString();
-  } else if (typeof err.path === "string") {
-    pathString = err.path;
-  }
-  const pathSuffix = pathString !== undefined ? " " + pathString : "";
-  const wrapped: any = new Error(`Path is a directory: rm returned EISDIR (is a directory)${pathSuffix}`);
-  wrapped.name = "SystemError";
-  wrapped.code = "ERR_FS_EISDIR";
-  wrapped.errno = 21;
-  wrapped.syscall = "rm";
-  if (pathString !== undefined) wrapped.path = pathString;
-  return wrapped;
-}
+const { maybeRemapRmEISDIR } = require("internal/fs/rm-utils");
 
 const private_symbols = {
   kRef,

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -193,7 +193,7 @@ var access = function access(path, mode, callback) {
     }
 
     ensureCallback(callback);
-    fs.rm(path, options).then(nullcallback(callback), callback);
+    fs.rm(path, options).then(nullcallback(callback), err => callback(maybeRemapRmEISDIR(err, path, options)));
   },
   rmdir = function rmdir(path, options, callback) {
     if ($isCallable(options)) {
@@ -590,7 +590,13 @@ var access = function access(path, mode, callback) {
   unlinkSync = fs.unlinkSync.bind(fs),
   utimesSync = fs.utimesSync.bind(fs),
   lutimesSync = fs.lutimesSync.bind(fs),
-  rmSync = fs.rmSync.bind(fs),
+  rmSync = function rmSync(path, options) {
+    try {
+      return fs.rmSync(path, options);
+    } catch (err) {
+      throw maybeRemapRmEISDIR(err, path, options);
+    }
+  },
   rmdirSync = fs.rmdirSync.bind(fs),
   writev = function writev(fd, buffers, position, callback) {
     if (typeof position === "function") {
@@ -648,6 +654,39 @@ defineCustomPromisifyArgs(writev, ["bytesWritten", "buffers"]);
 // the reason it's not done right now is because there isnt a great way to have multiple
 // listeners per StatWatcher with the current implementation in native code. the downside
 // of this means we need to do path validation in the js side of things
+// Node.js throws a SystemError with code `ERR_FS_EISDIR` when `fs.rm` /
+// `fs.rmSync` are called on a directory without `recursive: true`. Bun's
+// native binding just surfaces the raw `EISDIR` from unlink(2), so we
+// rewrap it here to match Node.js's shape. See #28958.
+function maybeRemapRmEISDIR(err: any, path: any, options: any) {
+  if (!err || err.code !== "EISDIR") return err;
+  // If the caller passed `recursive: true`, an EISDIR here would be
+  // unexpected — leave the original error alone.
+  if (options != null && typeof options === "object" && options.recursive) return err;
+  let pathString: string | undefined;
+  if (typeof path === "string") {
+    pathString = path;
+  } else if (path instanceof URL) {
+    try {
+      pathString = Bun.fileURLToPath(path as URL);
+    } catch {
+      pathString = undefined;
+    }
+  } else if (Buffer.isBuffer(path)) {
+    pathString = path.toString();
+  } else if (typeof err.path === "string") {
+    pathString = err.path;
+  }
+  const pathSuffix = pathString !== undefined ? " " + pathString : "";
+  const wrapped: any = new Error(`Path is a directory: rm returned EISDIR (is a directory)${pathSuffix}`);
+  wrapped.name = "SystemError";
+  wrapped.code = "ERR_FS_EISDIR";
+  wrapped.errno = 21;
+  wrapped.syscall = "rm";
+  if (pathString !== undefined) wrapped.path = pathString;
+  return wrapped;
+}
+
 const statWatchers = new Map();
 function getValidatedPath(p: any) {
   if (p instanceof URL) return Bun.fileURLToPath(p as URL);

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -654,38 +654,7 @@ defineCustomPromisifyArgs(writev, ["bytesWritten", "buffers"]);
 // the reason it's not done right now is because there isnt a great way to have multiple
 // listeners per StatWatcher with the current implementation in native code. the downside
 // of this means we need to do path validation in the js side of things
-// Node.js throws a SystemError with code `ERR_FS_EISDIR` when `fs.rm` /
-// `fs.rmSync` are called on a directory without `recursive: true`. Bun's
-// native binding just surfaces the raw `EISDIR` from unlink(2), so we
-// rewrap it here to match Node.js's shape. See #28958.
-function maybeRemapRmEISDIR(err: any, path: any, options: any) {
-  if (!err || err.code !== "EISDIR") return err;
-  // If the caller passed `recursive: true`, an EISDIR here would be
-  // unexpected — leave the original error alone.
-  if (options != null && typeof options === "object" && options.recursive) return err;
-  let pathString: string | undefined;
-  if (typeof path === "string") {
-    pathString = path;
-  } else if (path instanceof URL) {
-    try {
-      pathString = Bun.fileURLToPath(path as URL);
-    } catch {
-      pathString = undefined;
-    }
-  } else if (Buffer.isBuffer(path)) {
-    pathString = path.toString();
-  } else if (typeof err.path === "string") {
-    pathString = err.path;
-  }
-  const pathSuffix = pathString !== undefined ? " " + pathString : "";
-  const wrapped: any = new Error(`Path is a directory: rm returned EISDIR (is a directory)${pathSuffix}`);
-  wrapped.name = "SystemError";
-  wrapped.code = "ERR_FS_EISDIR";
-  wrapped.errno = 21;
-  wrapped.syscall = "rm";
-  if (pathString !== undefined) wrapped.path = pathString;
-  return wrapped;
-}
+const { maybeRemapRmEISDIR } = require("internal/fs/rm-utils");
 
 const statWatchers = new Map();
 function getValidatedPath(p: any) {

--- a/test/regression/issue/28958.test.ts
+++ b/test/regression/issue/28958.test.ts
@@ -69,6 +69,50 @@ test("fs.promises.rm on a directory without recursive throws ERR_FS_EISDIR", asy
   expect(fs.existsSync(target)).toBe(true);
 });
 
+test("fs.rmSync with a URL path still throws ERR_FS_EISDIR on a directory", () => {
+  using dir = tempDir("issue-28958-url", { "subdir/.keep": "" });
+  const target = path.join(String(dir), "subdir");
+  const url = new URL(`file://${target}`);
+
+  let err: any;
+  try {
+    fs.rmSync(url, { recursive: false, force: false });
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeDefined();
+  expect(err.name).toBe("SystemError");
+  expect(err.code).toBe("ERR_FS_EISDIR");
+  expect(err.errno).toBe(21);
+  expect(err.syscall).toBe("rm");
+  // The helper resolves URL → path string so consumers get a stable
+  // `path` field regardless of the input type.
+  expect(err.path).toBe(target);
+  expect(err.message).toBe(`Path is a directory: rm returned EISDIR (is a directory) ${target}`);
+  expect(fs.existsSync(target)).toBe(true);
+});
+
+test("fs.promises.rm with a Buffer path still throws ERR_FS_EISDIR on a directory", async () => {
+  using dir = tempDir("issue-28958-buffer", { "subdir/.keep": "" });
+  const target = path.join(String(dir), "subdir");
+  const buf = Buffer.from(target);
+
+  let err: any;
+  try {
+    await fs.promises.rm(buf, { recursive: false, force: false });
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeDefined();
+  expect(err.name).toBe("SystemError");
+  expect(err.code).toBe("ERR_FS_EISDIR");
+  expect(err.errno).toBe(21);
+  expect(err.syscall).toBe("rm");
+  expect(err.path).toBe(target);
+  expect(err.message).toBe(`Path is a directory: rm returned EISDIR (is a directory) ${target}`);
+  expect(fs.existsSync(target)).toBe(true);
+});
+
 test("fs.rmSync with recursive: true still removes a directory", () => {
   using dir = tempDir("issue-28958-recursive", { "subdir/file.txt": "hello" });
   const target = path.join(String(dir), "subdir");

--- a/test/regression/issue/28958.test.ts
+++ b/test/regression/issue/28958.test.ts
@@ -4,14 +4,13 @@
 // `recursive: false` must throw a Node.js-compatible `SystemError`
 // with code `ERR_FS_EISDIR`, not a raw `EFAULT`.
 import { expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 import fs from "node:fs";
 import path from "node:path";
 
 test("fs.rmSync on a directory without recursive throws ERR_FS_EISDIR", () => {
-  const dir = tempDirWithFiles("issue-28958-sync", { ".keep": "" });
-  const target = path.join(dir, "subdir");
-  fs.mkdirSync(target);
+  using dir = tempDir("issue-28958-sync", { "subdir/.keep": "" });
+  const target = path.join(String(dir), "subdir");
 
   let err: any;
   try {
@@ -27,15 +26,13 @@ test("fs.rmSync on a directory without recursive throws ERR_FS_EISDIR", () => {
   expect(err.path).toBe(target);
   expect(err.message).toBe(`Path is a directory: rm returned EISDIR (is a directory) ${target}`);
 
-  // Directory is still there.
+  // Directory is still there — the failing call must not remove it.
   expect(fs.existsSync(target)).toBe(true);
-  fs.rmdirSync(target);
 });
 
 test("fs.rm (callback) on a directory without recursive yields ERR_FS_EISDIR", async () => {
-  const dir = tempDirWithFiles("issue-28958-cb", { ".keep": "" });
-  const target = path.join(dir, "subdir");
-  fs.mkdirSync(target);
+  using dir = tempDir("issue-28958-cb", { "subdir/.keep": "" });
+  const target = path.join(String(dir), "subdir");
 
   const err: any = await new Promise(resolve => {
     fs.rm(target, { recursive: false, force: false }, e => resolve(e));
@@ -49,13 +46,11 @@ test("fs.rm (callback) on a directory without recursive yields ERR_FS_EISDIR", a
   expect(err.message).toBe(`Path is a directory: rm returned EISDIR (is a directory) ${target}`);
 
   expect(fs.existsSync(target)).toBe(true);
-  fs.rmdirSync(target);
 });
 
 test("fs.promises.rm on a directory without recursive throws ERR_FS_EISDIR", async () => {
-  const dir = tempDirWithFiles("issue-28958-promise", { ".keep": "" });
-  const target = path.join(dir, "subdir");
-  fs.mkdirSync(target);
+  using dir = tempDir("issue-28958-promise", { "subdir/.keep": "" });
+  const target = path.join(String(dir), "subdir");
 
   let err: any;
   try {
@@ -72,12 +67,11 @@ test("fs.promises.rm on a directory without recursive throws ERR_FS_EISDIR", asy
   expect(err.message).toBe(`Path is a directory: rm returned EISDIR (is a directory) ${target}`);
 
   expect(fs.existsSync(target)).toBe(true);
-  fs.rmdirSync(target);
 });
 
 test("fs.rmSync with recursive: true still removes a directory", () => {
-  const dir = tempDirWithFiles("issue-28958-recursive", { "subdir/file.txt": "hello" });
-  const target = path.join(dir, "subdir");
+  using dir = tempDir("issue-28958-recursive", { "subdir/file.txt": "hello" });
+  const target = path.join(String(dir), "subdir");
   expect(fs.existsSync(target)).toBe(true);
   fs.rmSync(target, { recursive: true });
   expect(fs.existsSync(target)).toBe(false);

--- a/test/regression/issue/28958.test.ts
+++ b/test/regression/issue/28958.test.ts
@@ -7,6 +7,7 @@ import { expect, test } from "bun:test";
 import { tempDir } from "harness";
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 test("fs.rmSync on a directory without recursive throws ERR_FS_EISDIR", () => {
   using dir = tempDir("issue-28958-sync", { "subdir/.keep": "" });
@@ -72,7 +73,7 @@ test("fs.promises.rm on a directory without recursive throws ERR_FS_EISDIR", asy
 test("fs.rmSync with a URL path still throws ERR_FS_EISDIR on a directory", () => {
   using dir = tempDir("issue-28958-url", { "subdir/.keep": "" });
   const target = path.join(String(dir), "subdir");
-  const url = new URL(`file://${target}`);
+  const url = pathToFileURL(target);
 
   let err: any;
   try {

--- a/test/regression/issue/28958.test.ts
+++ b/test/regression/issue/28958.test.ts
@@ -4,9 +4,9 @@
 // `recursive: false` must throw a Node.js-compatible `SystemError`
 // with code `ERR_FS_EISDIR`, not a raw `EFAULT`.
 import { expect, test } from "bun:test";
+import { tempDirWithFiles } from "harness";
 import fs from "node:fs";
 import path from "node:path";
-import { tempDirWithFiles } from "harness";
 
 test("fs.rmSync on a directory without recursive throws ERR_FS_EISDIR", () => {
   const dir = tempDirWithFiles("issue-28958-sync", { ".keep": "" });

--- a/test/regression/issue/28958.test.ts
+++ b/test/regression/issue/28958.test.ts
@@ -1,0 +1,84 @@
+// https://github.com/oven-sh/bun/issues/28958
+//
+// `fs.rmSync` / `fs.rm` / `fs.promises.rm` on a directory with
+// `recursive: false` must throw a Node.js-compatible `SystemError`
+// with code `ERR_FS_EISDIR`, not a raw `EFAULT`.
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { tempDirWithFiles } from "harness";
+
+test("fs.rmSync on a directory without recursive throws ERR_FS_EISDIR", () => {
+  const dir = tempDirWithFiles("issue-28958-sync", { ".keep": "" });
+  const target = path.join(dir, "subdir");
+  fs.mkdirSync(target);
+
+  let err: any;
+  try {
+    fs.rmSync(target, { recursive: false, force: false });
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeDefined();
+  expect(err.name).toBe("SystemError");
+  expect(err.code).toBe("ERR_FS_EISDIR");
+  expect(err.errno).toBe(21);
+  expect(err.syscall).toBe("rm");
+  expect(err.path).toBe(target);
+  expect(err.message).toBe(`Path is a directory: rm returned EISDIR (is a directory) ${target}`);
+
+  // Directory is still there.
+  expect(fs.existsSync(target)).toBe(true);
+  fs.rmdirSync(target);
+});
+
+test("fs.rm (callback) on a directory without recursive yields ERR_FS_EISDIR", async () => {
+  const dir = tempDirWithFiles("issue-28958-cb", { ".keep": "" });
+  const target = path.join(dir, "subdir");
+  fs.mkdirSync(target);
+
+  const err: any = await new Promise(resolve => {
+    fs.rm(target, { recursive: false, force: false }, e => resolve(e));
+  });
+  expect(err).toBeTruthy();
+  expect(err.name).toBe("SystemError");
+  expect(err.code).toBe("ERR_FS_EISDIR");
+  expect(err.errno).toBe(21);
+  expect(err.syscall).toBe("rm");
+  expect(err.path).toBe(target);
+  expect(err.message).toBe(`Path is a directory: rm returned EISDIR (is a directory) ${target}`);
+
+  expect(fs.existsSync(target)).toBe(true);
+  fs.rmdirSync(target);
+});
+
+test("fs.promises.rm on a directory without recursive throws ERR_FS_EISDIR", async () => {
+  const dir = tempDirWithFiles("issue-28958-promise", { ".keep": "" });
+  const target = path.join(dir, "subdir");
+  fs.mkdirSync(target);
+
+  let err: any;
+  try {
+    await fs.promises.rm(target, { recursive: false, force: false });
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeDefined();
+  expect(err.name).toBe("SystemError");
+  expect(err.code).toBe("ERR_FS_EISDIR");
+  expect(err.errno).toBe(21);
+  expect(err.syscall).toBe("rm");
+  expect(err.path).toBe(target);
+  expect(err.message).toBe(`Path is a directory: rm returned EISDIR (is a directory) ${target}`);
+
+  expect(fs.existsSync(target)).toBe(true);
+  fs.rmdirSync(target);
+});
+
+test("fs.rmSync with recursive: true still removes a directory", () => {
+  const dir = tempDirWithFiles("issue-28958-recursive", { "subdir/file.txt": "hello" });
+  const target = path.join(dir, "subdir");
+  expect(fs.existsSync(target)).toBe(true);
+  fs.rmSync(target, { recursive: true });
+  expect(fs.existsSync(target)).toBe(false);
+});


### PR DESCRIPTION
## Reproduction

```js
import fs from 'node:fs';
fs.mkdirSync('/tmp/repro', { recursive: true });
try {
  fs.rmSync('/tmp/repro', { recursive: false, force: false });
} catch (err) {
  console.log(err);
}
```

Before (Bun):
```
Error: EFAULT: bad address in system call argument, rm '/tmp/repro'
  code: 'EFAULT', errno: -14, syscall: 'rm'
```

After (matches Node.js):
```
SystemError: Path is a directory: rm returned EISDIR (is a directory) /tmp/repro
  code: 'ERR_FS_EISDIR', errno: 21, syscall: 'rm', path: '/tmp/repro'
```

## Root cause

`NodeFS.rm` in `src/bun.js/node/node_fs.zig` has two paths:

- **recursive: true** — uses `zigDeleteTree`; its switch already mapped `error.IsDir → .ISDIR`.
- **recursive: false** — calls `std.posix.unlinkZ`. On Linux, unlinking a directory returns `error.IsDir`. The switch here did **not** list `error.IsDir` / `error.NotDir`, so they fell through to the `else => .FAULT` branch — hence `EFAULT`.

## Fix

1. **Zig** — add `error.IsDir => .ISDIR` and `error.NotDir => .NOTDIR` to the non-recursive switch in `NodeFS.rm` so the errno is correct.
2. **JS** — wrap `rm` / `rmSync` in `src/js/node/fs.ts` and the `rm` in `src/js/node/fs.promises.ts`. When the underlying error is `EISDIR` on a non-recursive call, rewrap it as a `SystemError` with `code: 'ERR_FS_EISDIR'`, `errno: 21`, `syscall: 'rm'`, and the Node.js message format. Node.js itself produces this via its `validateRmOptionsSync` pre-check; rewrapping on the error path gives the same observable shape.

## Verification

`test/regression/issue/28958.test.ts` covers `fs.rmSync`, `fs.rm` (callback), `fs.promises.rm`, and the still-working `recursive: true` path.

```
$ USE_SYSTEM_BUN=1 bun test test/regression/issue/28958.test.ts
 1 pass
 3 fail     ← fails before the fix

$ bun bd test test/regression/issue/28958.test.ts
 4 pass
 0 fail

$ bun bd test test/js/node/fs/fs.test.ts -t rm
 15 pass / 1 skip / 0 fail   ← existing rm/rmdir suite still green
```

Closes #28958