### PR TITLE
install: preserve resolution.tarball when migrating pnpm-lock.yaml

### DIFF
--- a/src/install/pnpm.zig
+++ b/src/install/pnpm.zig
@@ -614,6 +614,19 @@ pub fn migratePnpmLockfile(
 
                         pkg.meta.integrity = Integrity.parse(integrity_str);
                     }
+
+                    // If pnpm recorded an explicit tarball URL (e.g. GitHub Packages uses
+                    // `/download/...` instead of the npm `/-/` layout), prefer it over the
+                    // URL we synthesized from the registry scope above.
+                    if (res.tag == .npm) {
+                        if (res_expr.get("tarball")) |tarball_expr| {
+                            if (tarball_expr.asString(allocator)) |tarball_str| {
+                                if (tarball_str.len > 0) {
+                                    res.value.npm.url = try string_buf.append(tarball_str);
+                                }
+                            }
+                        }
+                    }
                 }
 
                 if (package_obj.get("os")) |os_expr| {

--- a/test/cli/install/migration/__snapshots__/pnpm-migration-complete.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/pnpm-migration-complete.test.ts.snap
@@ -171,7 +171,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
     },
   },
   "packages": {
-    "@company/private-pkg": ["@company/private-pkg@1.0.5", "", {}, ""],
+    "@company/private-pkg": ["@company/private-pkg@1.0.5", "https://npm.company.com/@company/private-pkg/-/private-pkg-1.0.5.tgz", {}, ""],
 
     "lodash": ["lodash@4.17.21", "", {}, ""],
   }

--- a/test/regression/issue/28959.test.ts
+++ b/test/regression/issue/28959.test.ts
@@ -7,13 +7,12 @@
 // install eventually hangs.
 
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import fs from "node:fs";
 import { join } from "node:path";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 
 test("pnpm migration preserves resolution.tarball for GitHub Packages URLs", async () => {
-  const githubTarball =
-    "https://npm.pkg.github.com/download/@scope/pkg/0.2.0/0123456789abcdef0123456789abcdef01234567";
+  const githubTarball = "https://npm.pkg.github.com/download/@scope/pkg/0.2.0/0123456789abcdef0123456789abcdef01234567";
 
   const dir = tempDirWithFiles("issue-28959-pnpm-tarball", {
     "package.json": JSON.stringify({

--- a/test/regression/issue/28959.test.ts
+++ b/test/regression/issue/28959.test.ts
@@ -1,0 +1,73 @@
+// https://github.com/oven-sh/bun/issues/28959
+//
+// pnpm records the registry-specific tarball URL inside `resolution.tarball`
+// (GitHub Packages serves `/download/...` rather than the npm `/-/<name>-<ver>.tgz`
+// layout). The migration from `pnpm-lock.yaml` to `bun.lock` must preserve that
+// URL; otherwise bun tries to fetch a non-existent npm-shaped path and the
+// install eventually hangs.
+
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import { join } from "node:path";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+test("pnpm migration preserves resolution.tarball for GitHub Packages URLs", async () => {
+  const githubTarball =
+    "https://npm.pkg.github.com/download/@scope/pkg/0.2.0/0123456789abcdef0123456789abcdef01234567";
+
+  const dir = tempDirWithFiles("issue-28959-pnpm-tarball", {
+    "package.json": JSON.stringify({
+      name: "issue-28959",
+      version: "0.0.0",
+      dependencies: {
+        "@scope/pkg": "^0.2.0",
+      },
+    }),
+    "pnpm-lock.yaml": `lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@scope/pkg':
+        specifier: ^0.2.0
+        version: 0.2.0
+
+packages:
+
+  '@scope/pkg@0.2.0':
+    resolution: {integrity: sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==, tarball: ${githubTarball}}
+
+snapshots:
+
+  '@scope/pkg@0.2.0': {}
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "migrate"],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
+  expect(exitCode).toBe(0);
+
+  const bunLock = fs.readFileSync(join(String(dir), "bun.lock"), "utf8");
+
+  // The tarball URL from pnpm's resolution must appear verbatim in the
+  // migrated bun.lock (second field of the package entry).
+  expect(bunLock).toContain(githubTarball);
+
+  // And bun must NOT have fabricated an npm-shaped URL that GitHub Packages
+  // doesn't recognize.
+  expect(bunLock).not.toContain("@scope/pkg/-/pkg-0.2.0.tgz");
+});

--- a/test/regression/issue/28959.test.ts
+++ b/test/regression/issue/28959.test.ts
@@ -7,14 +7,14 @@
 // install eventually hangs.
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import fs from "node:fs";
 import { join } from "node:path";
 
 test("pnpm migration preserves resolution.tarball for GitHub Packages URLs", async () => {
   const githubTarball = "https://npm.pkg.github.com/download/@scope/pkg/0.2.0/0123456789abcdef0123456789abcdef01234567";
 
-  const dir = tempDirWithFiles("issue-28959-pnpm-tarball", {
+  using dir = tempDir("issue-28959-pnpm-tarball", {
     "package.json": JSON.stringify({
       name: "issue-28959",
       version: "0.0.0",
@@ -39,7 +39,7 @@ importers:
 packages:
 
   '@scope/pkg@0.2.0':
-    resolution: {integrity: sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==, tarball: ${githubTarball}}
+    resolution: {integrity: sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==, tarball: ${githubTarball}}
 
 snapshots:
 
@@ -57,6 +57,7 @@ snapshots:
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect(stdout).toBe("");
   expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
 
   const bunLock = fs.readFileSync(join(String(dir), "bun.lock"), "utf8");
@@ -65,9 +66,10 @@ snapshots:
   // migrated bun.lock (second field of the package entry).
   expect(bunLock).toContain(githubTarball);
 
-  // And bun must NOT have fabricated an npm-shaped URL that GitHub Packages
-  // doesn't recognize.
-  expect(bunLock).not.toContain("@scope/pkg/-/pkg-0.2.0.tgz");
+  // And the URL field of the package entry must not be the empty string
+  // (which is how the serializer writes a default-registry URL — the exact
+  // broken state this PR fixes, where the tarball URL got silently dropped).
+  expect(bunLock).not.toContain(`"@scope/pkg@0.2.0", ""`);
 
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/28959.test.ts
+++ b/test/regression/issue/28959.test.ts
@@ -58,7 +58,6 @@ snapshots:
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
-  expect(exitCode).toBe(0);
 
   const bunLock = fs.readFileSync(join(String(dir), "bun.lock"), "utf8");
 
@@ -69,4 +68,6 @@ snapshots:
   // And bun must NOT have fabricated an npm-shaped URL that GitHub Packages
   // doesn't recognize.
   expect(bunLock).not.toContain("@scope/pkg/-/pkg-0.2.0.tgz");
+
+  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/28959.test.ts
+++ b/test/regression/issue/28959.test.ts
@@ -49,7 +49,7 @@ snapshots:
 
   await using proc = Bun.spawn({
     cmd: [bunExe(), "pm", "migrate"],
-    cwd: dir,
+    cwd: String(dir),
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",


### PR DESCRIPTION
## Reproduction

A pnpm monorepo has a scoped package hosted on GitHub Packages. pnpm records the real download URL in the `resolution` object:

```yaml
packages:
  '@scope/pkg@0.2.0':
    resolution:
      integrity: sha512-…
      tarball: https://npm.pkg.github.com/download/@scope/pkg/0.2.0/<sha>
```

Running `bun install` against that project triggers the pnpm lockfile migration and the install then hangs indefinitely.

## Root cause

In `src/install/pnpm.zig`, the packages loop built the tarball URL unconditionally from the registry scope + name + version:

```zig
if (res.tag == .npm) {
    const scope = manager.scopeForPackageName(name_str);
    const url = try ExtractTarball.buildURL(scope.url.href, …);
    res.value.npm.url = try string_buf.append(url);
}
```

The later `resolution` block only extracted `integrity`; the `tarball` field was dropped. Bun then tried to fetch `https://npm.pkg.github.com/@scope/pkg/-/pkg-0.2.0.tgz`, which GitHub Packages doesn't serve — it 302s off to `registry.npmjs.com`, the extract fails and the install stalls (compounded by #26341).

A fresh install without a pnpm lockfile works because `src/install/npm.zig` reads `dist.tarball` from the registry metadata; only the migration path hardcoded the URL shape.

## Fix

After the integrity branch, if the resolution is `npm` and a non-empty `tarball` string is present, overwrite `res.value.npm.url` with it. `res.copy()` further down already captures the updated URL, and `bun.lock.zig` writes it as the second field of the package entry when it doesn't match the default registry.

## Verification

`test/regression/issue/28959.test.ts` writes a `pnpm-lock.yaml` with a GitHub-Packages-style `resolution.tarball`, runs `bun pm migrate`, and asserts the resulting `bun.lock` contains the original URL and does NOT contain the npm-shaped path.

- Before (USE_SYSTEM_BUN=1): fails — the package entry is written as `["@scope/pkg@0.2.0", "", {}, ""]`.
- After (bun bd): passes — the entry preserves the `https://npm.pkg.github.com/download/...` URL.

The existing `pnpm-migration-complete.test.ts` snapshot for `custom-registries` previously masked the bug by only checking that an entry exists; it now pins the preserved URL (`https://npm.company.com/@company/private-pkg/-/private-pkg-1.0.5.tgz`). Full `pnpm-migration-complete.test.ts`, `pnpm-lock-migration.test.ts`, and `pnpm-comprehensive.test.ts` suites all pass.

Fixes #28959