### PR TITLE
fix(websocket): decode upgrade request inputs as UTF-8

### DIFF
--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -583,13 +583,13 @@ BUN_DECLARE_HOST_FUNCTION(NetworkSink__write);
 ZIG_DECL void Bun__WebSocketHTTPClient__cancel(WebSocketHTTPClient* arg0);
 ZIG_DECL WebSocketHTTPClient* Bun__WebSocketHTTPClient__connect(
     JSC::JSGlobalObject* globalObject, void* socketContext, CppWebSocket* websocket,
-    const ZigString* host, uint16_t port, const ZigString* path, const ZigString* protocols,
-    ZigString* headerNames, ZigString* headerValues, size_t headerCount,
-    const ZigString* proxyHost, uint16_t proxyPort,
-    const ZigString* proxyAuthorization,
-    ZigString* proxyHeaderNames, ZigString* proxyHeaderValues, size_t proxyHeaderCount,
+    const BunString* host, uint16_t port, const BunString* path, const BunString* protocols,
+    BunString* headerNames, BunString* headerValues, size_t headerCount,
+    const BunString* proxyHost, uint16_t proxyPort,
+    const BunString* proxyAuthorization,
+    BunString* proxyHeaderNames, BunString* proxyHeaderValues, size_t proxyHeaderCount,
     void* sslConfig, bool targetIsSecure,
-    const ZigString* targetAuthorization);
+    const BunString* targetAuthorization);
 ZIG_DECL void Bun__WebSocketHTTPClient__register(JSC::JSGlobalObject* arg0, void* arg1, void* arg2);
 ZIG_DECL size_t Bun__WebSocketHTTPClient__memoryCost(WebSocketHTTPClient* arg0);
 #endif
@@ -599,13 +599,13 @@ ZIG_DECL size_t Bun__WebSocketHTTPClient__memoryCost(WebSocketHTTPClient* arg0);
 ZIG_DECL void Bun__WebSocketHTTPSClient__cancel(WebSocketHTTPSClient* arg0);
 ZIG_DECL WebSocketHTTPSClient* Bun__WebSocketHTTPSClient__connect(
     JSC::JSGlobalObject* globalObject, void* socketContext, CppWebSocket* websocket,
-    const ZigString* host, uint16_t port, const ZigString* path, const ZigString* protocols,
-    ZigString* headerNames, ZigString* headerValues, size_t headerCount,
-    const ZigString* proxyHost, uint16_t proxyPort,
-    const ZigString* proxyAuthorization,
-    ZigString* proxyHeaderNames, ZigString* proxyHeaderValues, size_t proxyHeaderCount,
+    const BunString* host, uint16_t port, const BunString* path, const BunString* protocols,
+    BunString* headerNames, BunString* headerValues, size_t headerCount,
+    const BunString* proxyHost, uint16_t proxyPort,
+    const BunString* proxyAuthorization,
+    BunString* proxyHeaderNames, BunString* proxyHeaderValues, size_t proxyHeaderCount,
     void* sslConfig, bool targetIsSecure,
-    const ZigString* targetAuthorization);
+    const BunString* targetAuthorization);
 ZIG_DECL void Bun__WebSocketHTTPSClient__register(JSC::JSGlobalObject* arg0, void* arg1, void* arg2);
 ZIG_DECL size_t Bun__WebSocketHTTPSClient__memoryCost(WebSocketHTTPSClient* arg0);
 

--- a/src/bun.js/bindings/webcore/WebSocket.cpp
+++ b/src/bun.js/bindings/webcore/WebSocket.cpp
@@ -544,17 +544,25 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
     if (!protocols.isEmpty())
         protocolString = joinStrings(protocols, subprotocolSeparator());
 
-    ZigString host = Zig::toZigString(m_url.host());
+    // Materialize host/path as WTF::String so the BunString wrappers hold a
+    // stable WTFStringImpl backing (preserving 8-bit vs UTF-16 encoding).
+    // ZigString wrappers over non-ASCII Latin1/UTF-16 data lose the encoding
+    // tag and corrupt the HTTP upgrade request build in Zig.
+    String hostString = m_url.host().toString();
     auto resource = resourceName(m_url);
-    ZigString path = Zig::toZigString(resource);
-    ZigString clientProtocolString = Zig::toZigString(protocolString);
+    BunString host = Bun::toString(hostString);
+    BunString path = Bun::toString(resource);
+    BunString clientProtocolString = Bun::toString(protocolString);
     uint16_t port = is_secure ? 443 : 80;
     if (auto userPort = m_url.port()) {
         port = userPort.value();
     }
 
-    Vector<ZigString, 8> headerNames;
-    Vector<ZigString, 8> headerValues;
+    // Hold WTF::Strings so the BunString wrappers stay valid for the Zig call.
+    Vector<String, 8> headerNameStrings;
+    Vector<String, 8> headerValueStrings;
+    Vector<BunString, 8> headerNames;
+    Vector<BunString, 8> headerValues;
 
     auto headersOrException = FetchHeaders::create(WTF::move(headersInit));
     if (headersOrException.hasException()) [[unlikely]] {
@@ -564,13 +572,19 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
     }
 
     auto headers = headersOrException.releaseReturnValue();
+    headerNameStrings.reserveInitialCapacity(headers.get().internalHeaders().size());
+    headerValueStrings.reserveInitialCapacity(headers.get().internalHeaders().size());
     headerNames.reserveInitialCapacity(headers.get().internalHeaders().size());
     headerValues.reserveInitialCapacity(headers.get().internalHeaders().size());
     // lowerCaseKeys = false so we dont touch the keys casing
     auto iterator = headers.get().createIterator(false);
     while (auto value = iterator.next()) {
-        headerNames.unsafeAppendWithoutCapacityCheck(Zig::toZigString(value->key));
-        headerValues.unsafeAppendWithoutCapacityCheck(Zig::toZigString(value->value));
+        headerNameStrings.append(value->key);
+        headerValueStrings.append(value->value);
+    }
+    for (size_t i = 0; i < headerNameStrings.size(); ++i) {
+        headerNames.unsafeAppendWithoutCapacityCheck(Bun::toString(headerNameStrings[i]));
+        headerValues.unsafeAppendWithoutCapacityCheck(Bun::toString(headerValueStrings[i]));
     }
 
     // Determine connection type based on proxy usage and TLS requirements
@@ -601,19 +615,21 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
 
     this->incPendingActivityCount();
 
-    // Prepare proxy parameters (use local variables, not member fields)
-    ZigString proxyHost = hasProxy ? Zig::toZigString(proxyConfig->host) : ZigString {};
-    ZigString proxyAuth = hasProxy ? Zig::toZigString(proxyConfig->authorization) : ZigString {};
+    // Prepare proxy parameters (use local variables, not member fields).
+    // The BunString wrappers reference the underlying WTF::Strings in proxyConfig
+    // and remain valid for the duration of the connect() call.
+    BunString proxyHost = hasProxy ? Bun::toString(proxyConfig->host) : BunString { BunStringTag::Empty };
+    BunString proxyAuth = hasProxy ? Bun::toString(proxyConfig->authorization) : BunString { BunStringTag::Empty };
     uint16_t proxyPort = hasProxy ? proxyConfig->port : 0;
 
-    Vector<ZigString, 8> proxyHeaderNames;
-    Vector<ZigString, 8> proxyHeaderValues;
+    Vector<BunString, 8> proxyHeaderNames;
+    Vector<BunString, 8> proxyHeaderValues;
     if (hasProxy) {
         proxyHeaderNames.reserveInitialCapacity(proxyConfig->headers.size());
         proxyHeaderValues.reserveInitialCapacity(proxyConfig->headers.size());
         for (const auto& header : proxyConfig->headers) {
-            proxyHeaderNames.unsafeAppendWithoutCapacityCheck(Zig::toZigString(header.first));
-            proxyHeaderValues.unsafeAppendWithoutCapacityCheck(Zig::toZigString(header.second));
+            proxyHeaderNames.unsafeAppendWithoutCapacityCheck(Bun::toString(header.first));
+            proxyHeaderValues.unsafeAppendWithoutCapacityCheck(Bun::toString(header.second));
         }
     }
 
@@ -625,7 +641,7 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
         auto encoded = base64EncodeToString(std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length()));
         targetAuthorization = makeString("Basic "_s, encoded);
     }
-    ZigString targetAuth = Zig::toZigString(targetAuthorization);
+    BunString targetAuth = Bun::toString(targetAuthorization);
 
     // Pass SSLConfig pointer to Zig (ownership transferred - Zig will deinit when connection closes)
     // After this call, m_sslConfig should not be used by C++ anymore

--- a/src/http/websocket_client/WebSocketUpgradeClient.zig
+++ b/src/http/websocket_client/WebSocketUpgradeClient.zig
@@ -100,38 +100,67 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
             global: *jsc.JSGlobalObject,
             socket_ctx: *uws.SocketContext,
             websocket: *CppWebSocket,
-            host: *const jsc.ZigString,
+            host: *const bun.String,
             port: u16,
-            pathname: *const jsc.ZigString,
-            client_protocol: *const jsc.ZigString,
-            header_names: ?[*]const jsc.ZigString,
-            header_values: ?[*]const jsc.ZigString,
+            pathname: *const bun.String,
+            client_protocol: *const bun.String,
+            header_names: ?[*]const bun.String,
+            header_values: ?[*]const bun.String,
             header_count: usize,
             // Proxy parameters
-            proxy_host: ?*const jsc.ZigString,
+            proxy_host: ?*const bun.String,
             proxy_port: u16,
-            proxy_authorization: ?*const jsc.ZigString,
-            proxy_header_names: ?[*]const jsc.ZigString,
-            proxy_header_values: ?[*]const jsc.ZigString,
+            proxy_authorization: ?*const bun.String,
+            proxy_header_names: ?[*]const bun.String,
+            proxy_header_values: ?[*]const bun.String,
             proxy_header_count: usize,
             // TLS options (full SSLConfig for complete TLS customization)
             ssl_config: ?*SSLConfig,
             // Whether the target URL is wss:// (separate from ssl template parameter)
             target_is_secure: bool,
             // Target URL authorization (Basic auth from ws://user:pass@host)
-            target_authorization: ?*const jsc.ZigString,
+            target_authorization: ?*const bun.String,
         ) callconv(.c) ?*HTTPClient {
             const vm = global.bunVM();
 
             bun.assert(vm.event_loop_handle != null);
 
-            const extra_headers = NonUTF8Headers.init(header_names, header_values, header_count);
+            // Decode all BunString inputs into UTF-8 slices. The underlying
+            // JavaScript strings may be Latin1 or UTF-16; `String.toUTF8()` either
+            // borrows the 8-bit ASCII backing (no allocation) or allocates a
+            // UTF-8 copy. All slices live until `deinit_slices()` below.
+            const allocator = bun.default_allocator;
+
+            var host_slice = host.toUTF8(allocator);
+            var pathname_slice = pathname.toUTF8(allocator);
+            var client_protocol_slice = client_protocol.toUTF8(allocator);
+
+            const extra_headers = Headers8Bit.init(allocator, header_names, header_values, header_count) catch {
+                host_slice.deinit();
+                pathname_slice.deinit();
+                client_protocol_slice.deinit();
+                return null;
+            };
+            defer extra_headers.deinit();
+
+            defer host_slice.deinit();
+            defer pathname_slice.deinit();
+            defer client_protocol_slice.deinit();
+
+            var proxy_host_slice: ?jsc.ZigString.Slice = null;
+            defer if (proxy_host_slice) |s| s.deinit();
+            if (proxy_host) |ph| proxy_host_slice = ph.toUTF8(allocator);
+
+            var target_authorization_slice: ?jsc.ZigString.Slice = null;
+            defer if (target_authorization_slice) |s| s.deinit();
+            if (target_authorization) |ta| target_authorization_slice = ta.toUTF8(allocator);
+
             const using_proxy = proxy_host != null;
 
             // Check if user provided a custom protocol for subprotocols validation
-            var protocol_for_subprotocols = client_protocol.*;
-            for (extra_headers.names, extra_headers.values) |name, value| {
-                if (strings.eqlCaseInsensitiveASCII(name.slice(), "sec-websocket-protocol", true)) {
+            var protocol_for_subprotocols: []const u8 = client_protocol_slice.slice();
+            for (extra_headers.names(), extra_headers.values()) |name, value| {
+                if (strings.eqlCaseInsensitiveASCII(name, "sec-websocket-protocol", true)) {
                     protocol_for_subprotocols = value;
                     break;
                 }
@@ -139,13 +168,13 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
 
             const request_result = buildRequestBody(
                 vm,
-                pathname,
+                pathname_slice.slice(),
                 ssl,
-                host,
+                host_slice.slice(),
                 port,
-                client_protocol,
+                client_protocol_slice.slice(),
                 extra_headers,
-                if (target_authorization) |auth| auth.slice() else null,
+                if (target_authorization_slice) |s| s.slice() else null,
             ) catch return null;
             const body = request_result.body;
 
@@ -157,44 +186,46 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
             if (using_proxy) {
                 // Parse proxy authorization (temporary, freed after building CONNECT request)
                 var proxy_auth_slice: ?[]const u8 = null;
-                var proxy_auth_owned: ?[]u8 = null;
-                defer if (proxy_auth_owned) |auth| bun.default_allocator.free(auth);
+                var proxy_auth_decoded: ?jsc.ZigString.Slice = null;
+                defer if (proxy_auth_decoded) |s| s.deinit();
 
                 if (proxy_authorization) |auth| {
-                    proxy_auth_owned = bun.default_allocator.dupe(u8, auth.slice()) catch {
-                        bun.default_allocator.free(body);
-                        return null;
-                    };
-                    proxy_auth_slice = proxy_auth_owned;
+                    proxy_auth_decoded = auth.toUTF8(allocator);
+                    proxy_auth_slice = proxy_auth_decoded.?.slice();
                 }
 
                 // Parse proxy headers (temporary, freed after building CONNECT request)
                 var proxy_hdrs: ?Headers = null;
                 defer if (proxy_hdrs) |*hdrs| hdrs.deinit();
 
+                const proxy_extra_headers = Headers8Bit.init(allocator, proxy_header_names, proxy_header_values, proxy_header_count) catch {
+                    allocator.free(body);
+                    return null;
+                };
+                defer proxy_extra_headers.deinit();
+
                 if (proxy_header_count > 0) {
-                    const non_utf8_hdrs = NonUTF8Headers.init(proxy_header_names, proxy_header_values, proxy_header_count);
-                    proxy_hdrs = non_utf8_hdrs.toHeaders(bun.default_allocator) catch {
-                        bun.default_allocator.free(body);
+                    proxy_hdrs = proxy_extra_headers.toHeaders(allocator) catch {
+                        allocator.free(body);
                         return null;
                     };
                 }
 
                 // Build CONNECT request (proxy_auth and proxy_hdrs are freed by defer after this)
                 connect_request = buildConnectRequest(
-                    host.slice(),
+                    host_slice.slice(),
                     port,
                     proxy_auth_slice,
                     proxy_hdrs,
                 ) catch {
-                    bun.default_allocator.free(body);
+                    allocator.free(body);
                     return null;
                 };
 
                 // Duplicate target_host (needed for SNI during TLS handshake)
-                const target_host_dup = bun.default_allocator.dupe(u8, host.slice()) catch {
-                    bun.default_allocator.free(body);
-                    bun.default_allocator.free(connect_request);
+                const target_host_dup = allocator.dupe(u8, host_slice.slice()) catch {
+                    allocator.free(body);
+                    allocator.free(connect_request);
                     return null;
                 };
 
@@ -217,7 +248,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 .expected_accept = request_result.expected_accept,
                 .subprotocols = brk: {
                     var subprotocols = bun.StringSet.init(bun.default_allocator);
-                    var it = bun.http.HeaderValueIterator.init(protocol_for_subprotocols.slice());
+                    var it = bun.http.HeaderValueIterator.init(protocol_for_subprotocols);
                     while (it.next()) |protocol| {
                         subprotocols.insert(protocol) catch |e| bun.handleOom(e);
                     }
@@ -228,13 +259,10 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
             // Store TLS config if provided (ownership transferred to client)
             client.ssl_config = ssl_config;
 
-            var host_ = if (using_proxy) proxy_host.?.toSlice(bun.default_allocator) else host.toSlice(bun.default_allocator);
-            defer host_.deinit();
-
+            const display_host_ = if (using_proxy) proxy_host_slice.?.slice() else host_slice.slice();
             const connect_port = if (using_proxy) proxy_port else port;
 
             client.poll_ref.ref(vm);
-            const display_host_ = host_.slice();
             const display_host = if (bun.FeatureFlags.hardcode_localhost_to_127_0_0_1 and strings.eqlComptime(display_host_, "localhost"))
                 "127.0.0.1"
             else
@@ -307,8 +335,8 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 bun.analytics.Features.WebSocket += 1;
 
                 if (comptime ssl) {
-                    if (!strings.isIPAddress(host_.slice())) {
-                        out.hostname = bun.default_allocator.dupeZ(u8, host_.slice()) catch "";
+                    if (!strings.isIPAddress(host_slice.slice())) {
+                        out.hostname = bun.default_allocator.dupeZ(u8, host_slice.slice()) catch "";
                     }
                 }
 
@@ -1098,41 +1126,97 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
     };
 }
 
-const NonUTF8Headers = struct {
-    names: []const jsc.ZigString,
-    values: []const jsc.ZigString,
+/// Decodes an array of BunString header name/value pairs to UTF-8 up front.
+///
+/// The BunString values may be backed by 8-bit Latin1 or 16-bit UTF-16
+/// `WTFStringImpl`s. Calling `.slice()` on a ZigString wrapper that was built
+/// from a non-ASCII WTFStringImpl returns raw Latin1 or UTF-16 code units,
+/// which then corrupts the HTTP upgrade request and can cause heap corruption.
+///
+/// Using `bun.String.toUTF8(allocator)` either borrows the 8-bit ASCII backing
+/// (no allocation) or allocates a UTF-8 copy. The resulting slices are stored
+/// here so buildRequestBody / buildConnectRequest can index them by []const u8.
+const Headers8Bit = struct {
+    slices: []jsc.ZigString.Slice,
+    name_slices: [][]const u8,
+    value_slices: [][]const u8,
+    allocator: std.mem.Allocator,
 
-    pub fn format(self: NonUTF8Headers, writer: *std.Io.Writer) !void {
-        const count = self.names.len;
-        var i: usize = 0;
-        while (i < count) : (i += 1) {
-            try writer.print("{f}: {f}\r\n", .{ self.names[i], self.values[i] });
-        }
-    }
-
-    pub fn init(names: ?[*]const jsc.ZigString, values: ?[*]const jsc.ZigString, len: usize) NonUTF8Headers {
+    pub fn init(
+        allocator: std.mem.Allocator,
+        names_ptr: ?[*]const bun.String,
+        values_ptr: ?[*]const bun.String,
+        len: usize,
+    ) std.mem.Allocator.Error!Headers8Bit {
         if (len == 0) {
             return .{
-                .names = &[_]jsc.ZigString{},
-                .values = &[_]jsc.ZigString{},
+                .slices = &.{},
+                .name_slices = &.{},
+                .value_slices = &.{},
+                .allocator = allocator,
             };
+        }
+        const names_in = names_ptr.?[0..len];
+        const values_in = values_ptr.?[0..len];
+
+        const slices = try allocator.alloc(jsc.ZigString.Slice, len * 2);
+        errdefer allocator.free(slices);
+
+        const name_slices = try allocator.alloc([]const u8, len);
+        errdefer allocator.free(name_slices);
+
+        const value_slices = try allocator.alloc([]const u8, len);
+        errdefer allocator.free(value_slices);
+
+        var decoded: usize = 0;
+        errdefer {
+            var j: usize = 0;
+            while (j < decoded) : (j += 1) slices[j].deinit();
+        }
+        var i: usize = 0;
+        while (i < len) : (i += 1) {
+            slices[i * 2] = names_in[i].toUTF8(allocator);
+            decoded += 1;
+            slices[i * 2 + 1] = values_in[i].toUTF8(allocator);
+            decoded += 1;
+            name_slices[i] = slices[i * 2].slice();
+            value_slices[i] = slices[i * 2 + 1].slice();
         }
 
         return .{
-            .names = names.?[0..len],
-            .values = values.?[0..len],
+            .slices = slices,
+            .name_slices = name_slices,
+            .value_slices = value_slices,
+            .allocator = allocator,
         };
     }
 
-    /// Convert NonUTF8Headers to bun.http.Headers
-    pub fn toHeaders(self: NonUTF8Headers, allocator: std.mem.Allocator) !Headers {
+    pub fn deinit(self: Headers8Bit) void {
+        for (self.slices) |*s| s.deinit();
+        if (self.slices.len > 0) {
+            self.allocator.free(self.slices);
+            self.allocator.free(self.name_slices);
+            self.allocator.free(self.value_slices);
+        }
+    }
+
+    pub fn names(self: Headers8Bit) []const []const u8 {
+        return self.name_slices;
+    }
+
+    pub fn values(self: Headers8Bit) []const []const u8 {
+        return self.value_slices;
+    }
+
+    /// Convert Headers8Bit to bun.http.Headers
+    pub fn toHeaders(self: Headers8Bit, allocator: std.mem.Allocator) !Headers {
         var headers = Headers{
             .allocator = allocator,
         };
         errdefer headers.deinit();
 
-        for (self.names, self.values) |name, value| {
-            try headers.append(name.slice(), value.slice());
+        for (self.name_slices, self.value_slices) |name, value| {
+            try headers.append(name, value);
         }
 
         return headers;
@@ -1195,24 +1279,23 @@ const BuildRequestResult = struct {
 
 fn buildRequestBody(
     vm: *jsc.VirtualMachine,
-    pathname: *const jsc.ZigString,
+    pathname: []const u8,
     is_https: bool,
-    host: *const jsc.ZigString,
+    host: []const u8,
     port: u16,
-    client_protocol: *const jsc.ZigString,
-    extra_headers: NonUTF8Headers,
+    client_protocol: []const u8,
+    extra_headers: Headers8Bit,
     target_authorization: ?[]const u8,
 ) std.mem.Allocator.Error!BuildRequestResult {
-    const allocator = vm.allocator;
+    const allocator = bun.default_allocator;
 
     // Check for user overrides
-    var user_host: ?jsc.ZigString = null;
-    var user_key: ?jsc.ZigString = null;
-    var user_protocol: ?jsc.ZigString = null;
+    var user_host: ?[]const u8 = null;
+    var user_key: ?[]const u8 = null;
+    var user_protocol: ?[]const u8 = null;
     var user_authorization: bool = false;
 
-    for (extra_headers.names, extra_headers.values) |name, value| {
-        const name_slice = name.slice();
+    for (extra_headers.names(), extra_headers.values()) |name_slice, value| {
         if (user_host == null and strings.eqlCaseInsensitiveASCII(name_slice, "host", true)) {
             user_host = value;
         } else if (user_key == null and strings.eqlCaseInsensitiveASCII(name_slice, "sec-websocket-key", true)) {
@@ -1227,8 +1310,7 @@ fn buildRequestBody(
     // Validate and use user key, or generate a new one
     var encoded_buf: [24]u8 = undefined;
     const key = blk: {
-        if (user_key) |k| {
-            const k_slice = k.slice();
+        if (user_key) |k_slice| {
             // Validate that it's a valid base64-encoded 16-byte value
             var decoded_buf: [24]u8 = undefined; // Max possible decoded size
             const decoded_len = std.base64.standard.Decoder.calcSizeForSlice(k_slice) catch {
@@ -1254,18 +1336,11 @@ fn buildRequestBody(
     // base64(SHA-1(Sec-WebSocket-Key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
     const expected_accept = computeAcceptValue(key);
 
-    const protocol = if (user_protocol) |p| p.slice() else client_protocol.slice();
-
-    const pathname_ = pathname.toSlice(allocator);
-    const host_ = host.toSlice(allocator);
-    defer {
-        pathname_.deinit();
-        host_.deinit();
-    }
+    const protocol = if (user_protocol) |p| p else client_protocol;
 
     const host_fmt = bun.fmt.HostFormatter{
         .is_https = is_https,
-        .host = host_.slice(),
+        .host = host,
         .port = port,
     };
 
@@ -1289,8 +1364,7 @@ fn buildRequestBody(
         }
     }
 
-    for (extra_headers.names, extra_headers.values) |name, value| {
-        const name_slice = name.slice();
+    for (extra_headers.names(), extra_headers.values()) |name_slice, value| {
         if (strings.eqlCaseInsensitiveASCII(name_slice, "host", true) or
             strings.eqlCaseInsensitiveASCII(name_slice, "connection", true) or
             strings.eqlCaseInsensitiveASCII(name_slice, "upgrade", true) or
@@ -1301,7 +1375,7 @@ fn buildRequestBody(
         {
             continue;
         }
-        try writer.print("{f}: {f}\r\n", .{ name, value });
+        try writer.print("{s}: {s}\r\n", .{ name_slice, value });
     }
 
     // Build request with user overrides
@@ -1310,7 +1384,7 @@ fn buildRequestBody(
             .body = try std.fmt.allocPrint(
                 allocator,
                 "GET {s} HTTP/1.1\r\n" ++
-                    "Host: {f}\r\n" ++
+                    "Host: {s}\r\n" ++
                     "Connection: Upgrade\r\n" ++
                     "Upgrade: websocket\r\n" ++
                     "Sec-WebSocket-Version: 13\r\n" ++
@@ -1318,7 +1392,7 @@ fn buildRequestBody(
                     "{f}" ++
                     "{s}" ++
                     "\r\n",
-                .{ pathname_.slice(), h, pico_headers, extra_headers_buf.items },
+                .{ pathname, h, pico_headers, extra_headers_buf.items },
             ),
             .expected_accept = expected_accept,
         };
@@ -1336,7 +1410,7 @@ fn buildRequestBody(
                 "{f}" ++
                 "{s}" ++
                 "\r\n",
-            .{ pathname_.slice(), host_fmt, pico_headers, extra_headers_buf.items },
+            .{ pathname, host_fmt, pico_headers, extra_headers_buf.items },
         ),
         .expected_accept = expected_accept,
     };

--- a/src/http/websocket_client/WebSocketUpgradeClient.zig
+++ b/src/http/websocket_client/WebSocketUpgradeClient.zig
@@ -164,6 +164,9 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 }
             }
 
+            // buildRequestBody only returns Allocator.Error; crash on OOM per
+            // the contract, consistent with the other allocator-only catches
+            // in this function.
             const request_result = buildRequestBody(
                 vm,
                 pathname_slice.slice(),
@@ -173,7 +176,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 client_protocol_slice.slice(),
                 extra_headers,
                 if (target_authorization_slice) |s| s.slice() else null,
-            ) catch return null;
+            ) catch |err| bun.handleOom(err);
             const body = request_result.body;
 
             // Build proxy state if using proxy

--- a/src/http/websocket_client/WebSocketUpgradeClient.zig
+++ b/src/http/websocket_client/WebSocketUpgradeClient.zig
@@ -1160,14 +1160,17 @@ const Headers8Bit = struct {
         const value_slices = try allocator.alloc([]const u8, len);
         errdefer allocator.free(value_slices);
 
-        // `bun.String.toUTF8` never returns an error — it panics on OOM via
-        // `bun.handleOom()` — so the loop body is infallible and no partial
-        // cleanup is needed. The three `try allocator.alloc()` calls above are
-        // the only error sites, and each has its own errdefer.
+        var decoded: usize = 0;
+        errdefer {
+            var j: usize = 0;
+            while (j < decoded) : (j += 1) slices[j].deinit();
+        }
         var i: usize = 0;
         while (i < len) : (i += 1) {
             slices[i * 2] = names_in[i].toUTF8(allocator);
+            decoded += 1;
             slices[i * 2 + 1] = values_in[i].toUTF8(allocator);
+            decoded += 1;
             name_slices[i] = slices[i * 2].slice();
             value_slices[i] = slices[i * 2 + 1].slice();
         }

--- a/src/http/websocket_client/WebSocketUpgradeClient.zig
+++ b/src/http/websocket_client/WebSocketUpgradeClient.zig
@@ -167,7 +167,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
             const request_result = buildRequestBody(
                 vm,
                 pathname_slice.slice(),
-                ssl,
+                target_is_secure,
                 host_slice.slice(),
                 port,
                 client_protocol_slice.slice(),
@@ -354,6 +354,11 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
             this.subprotocols.clearAndFree();
             this.clearInput();
             this.body.clearAndFree(bun.default_allocator);
+
+            if (this.hostname.len > 0) {
+                bun.default_allocator.free(this.hostname);
+                this.hostname = "";
+            }
 
             // Clean up proxy state
             if (this.proxy) |*p| {

--- a/src/http/websocket_client/WebSocketUpgradeClient.zig
+++ b/src/http/websocket_client/WebSocketUpgradeClient.zig
@@ -135,12 +135,10 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
             var pathname_slice = pathname.toUTF8(allocator);
             var client_protocol_slice = client_protocol.toUTF8(allocator);
 
-            const extra_headers = Headers8Bit.init(allocator, header_names, header_values, header_count) catch {
-                host_slice.deinit();
-                pathname_slice.deinit();
-                client_protocol_slice.deinit();
-                return null;
-            };
+            // Headers8Bit.init only returns Allocator.Error; handle OOM as a
+            // crash per the OOM contract instead of masking it as a connection
+            // failure.
+            const extra_headers = Headers8Bit.init(allocator, header_names, header_values, header_count) catch |err| bun.handleOom(err);
             defer extra_headers.deinit();
 
             defer host_slice.deinit();
@@ -198,36 +196,27 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 var proxy_hdrs: ?Headers = null;
                 defer if (proxy_hdrs) |*hdrs| hdrs.deinit();
 
-                const proxy_extra_headers = Headers8Bit.init(allocator, proxy_header_names, proxy_header_values, proxy_header_count) catch {
-                    allocator.free(body);
-                    return null;
-                };
+                // Headers8Bit.init / toHeaders only return Allocator.Error;
+                // OOM should crash, not silently become a connection failure.
+                const proxy_extra_headers = Headers8Bit.init(allocator, proxy_header_names, proxy_header_values, proxy_header_count) catch |err| bun.handleOom(err);
                 defer proxy_extra_headers.deinit();
 
                 if (proxy_header_count > 0) {
-                    proxy_hdrs = proxy_extra_headers.toHeaders(allocator) catch {
-                        allocator.free(body);
-                        return null;
-                    };
+                    proxy_hdrs = proxy_extra_headers.toHeaders(allocator) catch |err| bun.handleOom(err);
                 }
 
-                // Build CONNECT request (proxy_auth and proxy_hdrs are freed by defer after this)
+                // Build CONNECT request (proxy_auth and proxy_hdrs are freed by defer after this).
+                // buildConnectRequest only returns Allocator.Error; crash on OOM.
                 connect_request = buildConnectRequest(
                     host_slice.slice(),
                     port,
                     proxy_auth_slice,
                     proxy_hdrs,
-                ) catch {
-                    allocator.free(body);
-                    return null;
-                };
+                ) catch |err| bun.handleOom(err);
 
-                // Duplicate target_host (needed for SNI during TLS handshake)
-                const target_host_dup = allocator.dupe(u8, host_slice.slice()) catch {
-                    allocator.free(body);
-                    allocator.free(connect_request);
-                    return null;
-                };
+                // Duplicate target_host (needed for SNI during TLS handshake).
+                // allocator.dupe only returns Allocator.Error; crash on OOM.
+                const target_host_dup = allocator.dupe(u8, host_slice.slice()) catch |err| bun.handleOom(err);
 
                 proxy_state = WebSocketProxy.init(
                     target_host_dup,

--- a/src/http/websocket_client/WebSocketUpgradeClient.zig
+++ b/src/http/websocket_client/WebSocketUpgradeClient.zig
@@ -335,8 +335,11 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 bun.analytics.Features.WebSocket += 1;
 
                 if (comptime ssl) {
-                    if (!strings.isIPAddress(host_slice.slice())) {
-                        out.hostname = bun.default_allocator.dupeZ(u8, host_slice.slice()) catch "";
+                    // SNI for the outer TLS socket must use the host we actually
+                    // dialed. For HTTPS proxy connections, that's the proxy host,
+                    // not the wss:// target.
+                    if (!strings.isIPAddress(display_host_)) {
+                        out.hostname = bun.default_allocator.dupeZ(u8, display_host_) catch "";
                     }
                 }
 

--- a/src/http/websocket_client/WebSocketUpgradeClient.zig
+++ b/src/http/websocket_client/WebSocketUpgradeClient.zig
@@ -164,9 +164,6 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 }
             }
 
-            // buildRequestBody only returns Allocator.Error; crash on OOM per
-            // the contract, consistent with the other allocator-only catches
-            // in this function.
             const request_result = buildRequestBody(
                 vm,
                 pathname_slice.slice(),
@@ -176,7 +173,7 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
                 client_protocol_slice.slice(),
                 extra_headers,
                 if (target_authorization_slice) |s| s.slice() else null,
-            ) catch |err| bun.handleOom(err);
+            ) catch return null;
             const body = request_result.body;
 
             // Build proxy state if using proxy

--- a/src/http/websocket_client/WebSocketUpgradeClient.zig
+++ b/src/http/websocket_client/WebSocketUpgradeClient.zig
@@ -1160,17 +1160,14 @@ const Headers8Bit = struct {
         const value_slices = try allocator.alloc([]const u8, len);
         errdefer allocator.free(value_slices);
 
-        var decoded: usize = 0;
-        errdefer {
-            var j: usize = 0;
-            while (j < decoded) : (j += 1) slices[j].deinit();
-        }
+        // `bun.String.toUTF8` never returns an error — it panics on OOM via
+        // `bun.handleOom()` — so the loop body is infallible and no partial
+        // cleanup is needed. The three `try allocator.alloc()` calls above are
+        // the only error sites, and each has its own errdefer.
         var i: usize = 0;
         while (i < len) : (i += 1) {
             slices[i * 2] = names_in[i].toUTF8(allocator);
-            decoded += 1;
             slices[i * 2 + 1] = values_in[i].toUTF8(allocator);
-            decoded += 1;
             name_slices[i] = slices[i * 2].slice();
             value_slices[i] = slices[i * 2 + 1].slice();
         }

--- a/test/js/web/websocket/websocket-utf16-headers.test.ts
+++ b/test/js/web/websocket/websocket-utf16-headers.test.ts
@@ -40,14 +40,12 @@ async function listenEphemeral(
   return { port: (server.address() as net.AddressInfo).port, server };
 }
 
-// Returns an ephemeral port that is bound and then immediately released so
-// connections to it will be refused. We never use a hardcoded "reserved" port
-// like 127.0.0.1:1 because it is not guaranteed free on shared CI hosts.
+// Returns an ephemeral port whose server stays bound for the duration of the
+// test and immediately destroys any incoming connection. This avoids the
+// TOCTOU race of "bind → close → hope nothing else grabs the port" — the port
+// is held until afterEach() tears the server down.
 async function deadPort(): Promise<number> {
-  const probe = net.createServer();
-  await once(probe.listen(0, "127.0.0.1"), "listening");
-  const port = (probe.address() as net.AddressInfo).port;
-  await new Promise<void>(resolve => probe.close(() => resolve()));
+  const { port } = await listenEphemeral(socket => socket.destroy());
   return port;
 }
 
@@ -133,7 +131,7 @@ describe("WebSocket upgrade with non-ASCII inputs", () => {
     // `new URL(...)` with a non-Latin1 path produces a 16-bit-backed
     // WTFStringImpl for the parsed URL. Before the fix, the Zig side called
     // `.slice()` on that and wrote raw UTF-16 bytes into the upgrade request.
-    // Target port is allocated and immediately released so the connect()
+    // The target port immediately destroys any connection so the WebSocket
     // fails quickly — we only care that the upgrade request build doesn't
     // crash.
     const port = await deadPort();

--- a/test/js/web/websocket/websocket-utf16-headers.test.ts
+++ b/test/js/web/websocket/websocket-utf16-headers.test.ts
@@ -13,7 +13,6 @@
 // BunString and decodes every input with `bun.String.toUTF8(allocator)`.
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { createHash } from "node:crypto";
 import { once } from "node:events";
 import net from "node:net";
 
@@ -64,65 +63,42 @@ afterEach(async () => {
 describe("WebSocket upgrade with non-ASCII inputs", () => {
   test("Latin1 header value with high bytes is sent as UTF-8 without crashing", async () => {
     // Spin up a trivial TCP listener that captures the raw upgrade request
-    // bytes and responds with a valid 101 Switching Protocols handshake.
-    const receivedRequests: Buffer[] = [];
-    const { port, server } = await listenEphemeral(socket => {
+    // bytes. We only need to inspect what the client *sent*; we don't need
+    // the WebSocket handshake to complete, so the server destroys the socket
+    // as soon as it has the full request headers.
+    const gotRequest = Promise.withResolvers<Buffer>();
+    const { port } = await listenEphemeral(socket => {
       const chunks: Buffer[] = [];
-      let sawUpgrade = false;
       socket.on("data", chunk => {
-        if (sawUpgrade) return;
         chunks.push(chunk);
         const joined = Buffer.concat(chunks);
         if (joined.includes("\r\n\r\n")) {
-          sawUpgrade = true;
-          receivedRequests.push(joined);
-          // Extract Sec-WebSocket-Key and compute Sec-WebSocket-Accept.
-          const text = joined.toString("latin1");
-          const match = text.match(/sec-websocket-key:\s*([^\r\n]+)/i);
-          if (!match) {
-            socket.destroy();
-            return;
-          }
-          const key = match[1];
-          const accept = createHash("sha1")
-            .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
-            .digest("base64");
-          socket.write(
-            "HTTP/1.1 101 Switching Protocols\r\n" +
-              "Upgrade: websocket\r\n" +
-              "Connection: Upgrade\r\n" +
-              `Sec-WebSocket-Accept: ${accept}\r\n` +
-              "\r\n",
-          );
+          gotRequest.resolve(joined);
+          socket.destroy();
         }
       });
+      socket.on("error", () => {});
     });
 
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
     // "vàlüé-ñ" contains U+00E0, U+00FC, U+00E9, U+00F1 — all in Latin1
     // range, so the underlying WTFStringImpl stays 8-bit.
     const latin1Value = "vàlüé-ñ";
-    try {
-      const ws = new WebSocket(`ws://127.0.0.1:${port}/`, {
-        headers: {
-          "X-Latin1": latin1Value,
-        },
-      });
-      ws.onopen = () => {
-        ws.close();
-        resolve();
-      };
-      ws.onerror = e => reject(new Error(String((e as any).message ?? "error")));
-      await promise;
-    } finally {
-      await new Promise<void>(r => server.close(() => r()));
-    }
+    const wsDone = Promise.withResolvers<void>();
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/`, {
+      headers: {
+        "X-Latin1": latin1Value,
+      },
+    });
+    ws.onerror = () => wsDone.resolve();
+    ws.onclose = () => wsDone.resolve();
 
-    expect(receivedRequests.length).toBe(1);
+    const request = await gotRequest.promise;
+    await wsDone.promise;
+
     // Before the fix, the upgrade request buffer would either contain raw
     // Latin1 bytes (0xE0, 0xFC, 0xE9, 0xF1) or be completely corrupted and
     // crash the runtime. With the fix, the header is emitted as proper UTF-8.
-    const body = receivedRequests[0].toString("utf8");
+    const body = request.toString("utf8");
     expect(body).toContain("X-Latin1:");
     expect(body).toContain(latin1Value);
   });

--- a/test/js/web/websocket/websocket-utf16-headers.test.ts
+++ b/test/js/web/websocket/websocket-utf16-headers.test.ts
@@ -13,8 +13,14 @@
 // BunString and decodes every input with `bun.String.toUTF8(allocator)`.
 
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { once } from "node:events";
 import net from "node:net";
+
+// "path-\u{1F525}" forces JSC to materialize the backing StringImpl as
+// 16-bit UTF-16, which is the other half of the regression path.
+const UTF16_PATH_SEGMENT = "path-\u{1F525}";
+const UTF16_SUBPROTOCOL_SENTINEL = "proto-\u{1F525}";
 
 describe("WebSocket upgrade with non-ASCII inputs", () => {
   test("Latin1 header value with high bytes is sent as UTF-8 without crashing", async () => {
@@ -24,10 +30,13 @@ describe("WebSocket upgrade with non-ASCII inputs", () => {
     const receivedRequests: Buffer[] = [];
     server.on("connection", socket => {
       const chunks: Buffer[] = [];
+      let sawUpgrade = false;
       socket.on("data", chunk => {
+        if (sawUpgrade) return;
         chunks.push(chunk);
         const joined = Buffer.concat(chunks);
         if (joined.includes("\r\n\r\n")) {
+          sawUpgrade = true;
           receivedRequests.push(joined);
           // Extract Sec-WebSocket-Key and compute Sec-WebSocket-Accept.
           const text = joined.toString("latin1");
@@ -37,9 +46,7 @@ describe("WebSocket upgrade with non-ASCII inputs", () => {
             return;
           }
           const key = match[1];
-          const crypto = require("node:crypto");
-          const accept = crypto
-            .createHash("sha1")
+          const accept = createHash("sha1")
             .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
             .digest("base64");
           socket.write(
@@ -81,6 +88,33 @@ describe("WebSocket upgrade with non-ASCII inputs", () => {
     const body = receivedRequests[0].toString("utf8");
     expect(body).toContain("X-Latin1:");
     expect(body).toContain(latin1Value);
+  });
+
+  test("UTF-16 URL path is decoded to UTF-8 without crashing", async () => {
+    // `new URL(...)` with a non-Latin1 path produces a 16-bit-backed
+    // WTFStringImpl for the parsed URL. Before the fix, the Zig side called
+    // `.slice()` on that and wrote raw UTF-16 bytes into the upgrade request.
+    // The URL parser percent-encodes non-ASCII, but the internal path
+    // traverses the 16-bit WTFStringImpl branch regardless.
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const ws = new WebSocket(`ws://127.0.0.1:1/${UTF16_PATH_SEGMENT}`);
+    ws.onerror = () => resolve();
+    ws.onclose = () => resolve();
+    await promise;
+    expect(true).toBe(true);
+  });
+
+  test("UTF-16 subprotocol is decoded to UTF-8 without crashing", () => {
+    // A subprotocol containing codepoints > U+00FF is rejected by the
+    // WebSocket spec validator (which only allows HTTP tokens), so the
+    // constructor throws a SyntaxError. The important thing is that the
+    // validator runs before the Zig side sees the string and crashes.
+    expect(
+      () =>
+        new WebSocket("ws://127.0.0.1:1/", {
+          protocols: [UTF16_SUBPROTOCOL_SENTINEL],
+        }),
+    ).toThrow();
   });
 
   test("does not crash when target URL path contains non-ASCII characters", async () => {

--- a/test/js/web/websocket/websocket-utf16-headers.test.ts
+++ b/test/js/web/websocket/websocket-utf16-headers.test.ts
@@ -1,0 +1,153 @@
+// Regression test for WebSocket upgrade request crash on non-ASCII inputs.
+//
+// The HTTP upgrade request is built in Zig. Before the fix, header values,
+// host, path, client protocol and proxy parameters were passed from C++ as
+// `ZigString` wrappers over the underlying `WTF::StringImpl`. When a
+// WTFStringImpl was not 8-bit ASCII (either Latin1 with high bytes, or UTF-16),
+// calling `.slice()` on the ZigString returned raw Latin1 / UTF-16 code units.
+// Those bytes were then substituted into a printf-like format string and the
+// resulting garbage length could cause heap corruption in mimalloc
+// (`_mi_heap_realloc_zero`) during `std.fmt.allocPrint`.
+//
+// The fix migrates the WebSocket upgrade client FFI from ZigString to
+// BunString and decodes every input with `bun.String.toUTF8(allocator)`.
+
+import { describe, expect, test } from "bun:test";
+import net from "node:net";
+import { once } from "node:events";
+
+describe("WebSocket upgrade with non-ASCII inputs", () => {
+  test("Latin1 header value with high bytes is sent as UTF-8 without crashing", async () => {
+    // Spin up a trivial HTTP listener that captures the raw upgrade request
+    // bytes and responds with a valid 101 Switching Protocols handshake.
+    const server = net.createServer();
+    const receivedRequests: Buffer[] = [];
+    server.on("connection", socket => {
+      const chunks: Buffer[] = [];
+      socket.on("data", chunk => {
+        chunks.push(chunk);
+        const joined = Buffer.concat(chunks);
+        if (joined.includes("\r\n\r\n")) {
+          receivedRequests.push(joined);
+          // Extract Sec-WebSocket-Key and compute Sec-WebSocket-Accept.
+          const text = joined.toString("latin1");
+          const match = text.match(/sec-websocket-key:\s*([^\r\n]+)/i);
+          if (!match) {
+            socket.destroy();
+            return;
+          }
+          const key = match[1];
+          const crypto = require("node:crypto");
+          const accept = crypto
+            .createHash("sha1")
+            .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+            .digest("base64");
+          socket.write(
+            "HTTP/1.1 101 Switching Protocols\r\n" +
+              "Upgrade: websocket\r\n" +
+              "Connection: Upgrade\r\n" +
+              `Sec-WebSocket-Accept: ${accept}\r\n` +
+              "\r\n",
+          );
+        }
+      });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const port = (server.address() as net.AddressInfo).port;
+
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+    // "vàlüé-ñ" contains U+00E0, U+00FC, U+00E9, U+00F1 — all in Latin1
+    // range, so the underlying WTFStringImpl stays 8-bit.
+    const latin1Value = "vàlüé-ñ";
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/`, {
+      headers: {
+        "X-Latin1": latin1Value,
+      },
+    });
+    ws.onopen = () => {
+      ws.close();
+      resolve();
+    };
+    ws.onerror = e => reject(new Error(String((e as any).message ?? "error")));
+    await promise;
+    server.close();
+
+    expect(receivedRequests.length).toBe(1);
+    // Before the fix, the upgrade request buffer would either contain raw
+    // Latin1 bytes (0xE0, 0xFC, 0xE9, 0xF1) or be completely corrupted and
+    // crash the runtime. With the fix, the header is emitted as proper UTF-8.
+    const body = receivedRequests[0].toString("utf8");
+    expect(body).toContain("X-Latin1:");
+    expect(body).toContain(latin1Value);
+  });
+
+  test("does not crash when target URL path contains non-ASCII characters", async () => {
+    // Target port 1 is reserved — connection will fail quickly. The point is
+    // that the upgrade request build step must not crash regardless of what
+    // the URL parser produces for non-ASCII path segments.
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const ws = new WebSocket("ws://127.0.0.1:1/pâth/ünîcôdé");
+    ws.onerror = () => resolve();
+    ws.onclose = () => resolve();
+    await promise;
+    expect(true).toBe(true);
+  });
+
+  test("does not crash when proxy target with Latin1 header + tls is unreachable", async () => {
+    // Proxy + custom TLS config + non-ASCII headers — this is the combination
+    // that matched the original crash backtrace. Construct, let it fail to
+    // connect, and make sure nothing heap-corrupts along the way.
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const ws = new WebSocket("wss://127.0.0.1:1/", {
+      headers: {
+        "X-Latin1": "vàlüé-ñ",
+        Authorization: "Bearer tökën",
+      },
+      proxy: "http://127.0.0.1:2",
+      tls: {
+        cert: "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----",
+        key: "-----BEGIN PRIVATE KEY-----\nMIIE\n-----END PRIVATE KEY-----",
+        rejectUnauthorized: false,
+      },
+    });
+    ws.onerror = () => resolve();
+    ws.onclose = () => resolve();
+    await promise;
+    expect(true).toBe(true);
+  });
+
+  test("does not crash with many Latin1 headers through proxy", async () => {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const headers: Record<string, string> = {};
+    for (let i = 0; i < 16; i++) {
+      headers[`X-Hdr-${i}`] = `vàlüé-${i}-ñ`.repeat(4);
+    }
+    const ws = new WebSocket("wss://127.0.0.1:1/", {
+      headers,
+      proxy: "http://127.0.0.1:2",
+      tls: { rejectUnauthorized: false },
+    });
+    ws.onerror = () => resolve();
+    ws.onclose = () => resolve();
+    await promise;
+    expect(true).toBe(true);
+  });
+
+  test("does not crash with Latin1 proxy header values", async () => {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const ws = new WebSocket("ws://127.0.0.1:1/", {
+      proxy: {
+        url: "http://127.0.0.1:2",
+        headers: {
+          "X-Proxy": "prôxy-vàlüé",
+        },
+      },
+    });
+    ws.onerror = () => resolve();
+    ws.onclose = () => resolve();
+    await promise;
+    expect(true).toBe(true);
+  });
+});

--- a/test/js/web/websocket/websocket-utf16-headers.test.ts
+++ b/test/js/web/websocket/websocket-utf16-headers.test.ts
@@ -12,7 +12,7 @@
 // The fix migrates the WebSocket upgrade client FFI from ZigString to
 // BunString and decodes every input with `bun.String.toUTF8(allocator)`.
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { once } from "node:events";
 import net from "node:net";
@@ -22,13 +22,51 @@ import net from "node:net";
 const UTF16_PATH_SEGMENT = "path-\u{1F525}";
 const UTF16_SUBPROTOCOL_SENTINEL = "proto-\u{1F525}";
 
+// Track every server we spin up so afterEach cleans them up even if a test
+// throws before closing its own fixtures.
+const servers: net.Server[] = [];
+
+function track(server: net.Server) {
+  servers.push(server);
+  return server;
+}
+
+async function listenEphemeral(onConnection?: (socket: net.Socket) => void): Promise<{ port: number; server: net.Server }> {
+  const server = net.createServer(onConnection);
+  track(server);
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  return { port: (server.address() as net.AddressInfo).port, server };
+}
+
+// Returns an ephemeral port that is bound and then immediately released so
+// connections to it will be refused. We never use a hardcoded "reserved" port
+// like 127.0.0.1:1 because it is not guaranteed free on shared CI hosts.
+async function deadPort(): Promise<number> {
+  const probe = net.createServer();
+  await once(probe.listen(0, "127.0.0.1"), "listening");
+  const port = (probe.address() as net.AddressInfo).port;
+  await new Promise<void>(resolve => probe.close(() => resolve()));
+  return port;
+}
+
+beforeEach(() => {
+  servers.length = 0;
+});
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) {
+    try {
+      if (server.listening) await new Promise<void>(r => server.close(() => r()));
+    } catch {}
+  }
+});
+
 describe("WebSocket upgrade with non-ASCII inputs", () => {
   test("Latin1 header value with high bytes is sent as UTF-8 without crashing", async () => {
-    // Spin up a trivial HTTP listener that captures the raw upgrade request
+    // Spin up a trivial TCP listener that captures the raw upgrade request
     // bytes and responds with a valid 101 Switching Protocols handshake.
-    const server = net.createServer();
     const receivedRequests: Buffer[] = [];
-    server.on("connection", socket => {
+    const { port, server } = await listenEphemeral(socket => {
       const chunks: Buffer[] = [];
       let sawUpgrade = false;
       socket.on("data", chunk => {
@@ -59,27 +97,26 @@ describe("WebSocket upgrade with non-ASCII inputs", () => {
         }
       });
     });
-    await once(server.listen(0, "127.0.0.1"), "listening");
-    const port = (server.address() as net.AddressInfo).port;
 
     const { promise, resolve, reject } = Promise.withResolvers<void>();
-
     // "vàlüé-ñ" contains U+00E0, U+00FC, U+00E9, U+00F1 — all in Latin1
     // range, so the underlying WTFStringImpl stays 8-bit.
     const latin1Value = "vàlüé-ñ";
-
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/`, {
-      headers: {
-        "X-Latin1": latin1Value,
-      },
-    });
-    ws.onopen = () => {
-      ws.close();
-      resolve();
-    };
-    ws.onerror = e => reject(new Error(String((e as any).message ?? "error")));
-    await promise;
-    server.close();
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/`, {
+        headers: {
+          "X-Latin1": latin1Value,
+        },
+      });
+      ws.onopen = () => {
+        ws.close();
+        resolve();
+      };
+      ws.onerror = e => reject(new Error(String((e as any).message ?? "error")));
+      await promise;
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
 
     expect(receivedRequests.length).toBe(1);
     // Before the fix, the upgrade request buffer would either contain raw
@@ -94,35 +131,36 @@ describe("WebSocket upgrade with non-ASCII inputs", () => {
     // `new URL(...)` with a non-Latin1 path produces a 16-bit-backed
     // WTFStringImpl for the parsed URL. Before the fix, the Zig side called
     // `.slice()` on that and wrote raw UTF-16 bytes into the upgrade request.
-    // The URL parser percent-encodes non-ASCII, but the internal path
-    // traverses the 16-bit WTFStringImpl branch regardless.
+    // Target port is allocated and immediately released so the connect()
+    // fails quickly — we only care that the upgrade request build doesn't
+    // crash.
+    const port = await deadPort();
     const { promise, resolve } = Promise.withResolvers<void>();
-    const ws = new WebSocket(`ws://127.0.0.1:1/${UTF16_PATH_SEGMENT}`);
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/${UTF16_PATH_SEGMENT}`);
     ws.onerror = () => resolve();
     ws.onclose = () => resolve();
     await promise;
     expect(true).toBe(true);
   });
 
-  test("UTF-16 subprotocol is decoded to UTF-8 without crashing", () => {
+  test("UTF-16 subprotocol is rejected by the spec validator without crashing", async () => {
     // A subprotocol containing codepoints > U+00FF is rejected by the
     // WebSocket spec validator (which only allows HTTP tokens), so the
     // constructor throws a SyntaxError. The important thing is that the
     // validator runs before the Zig side sees the string and crashes.
+    const port = await deadPort();
     expect(
       () =>
-        new WebSocket("ws://127.0.0.1:1/", {
+        new WebSocket(`ws://127.0.0.1:${port}/`, {
           protocols: [UTF16_SUBPROTOCOL_SENTINEL],
         }),
     ).toThrow();
   });
 
-  test("does not crash when target URL path contains non-ASCII characters", async () => {
-    // Target port 1 is reserved — connection will fail quickly. The point is
-    // that the upgrade request build step must not crash regardless of what
-    // the URL parser produces for non-ASCII path segments.
+  test("does not crash when target URL path contains non-ASCII Latin1 characters", async () => {
+    const port = await deadPort();
     const { promise, resolve } = Promise.withResolvers<void>();
-    const ws = new WebSocket("ws://127.0.0.1:1/pâth/ünîcôdé");
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/pâth/ünîcôdé`);
     ws.onerror = () => resolve();
     ws.onclose = () => resolve();
     await promise;
@@ -133,13 +171,14 @@ describe("WebSocket upgrade with non-ASCII inputs", () => {
     // Proxy + custom TLS config + non-ASCII headers — this is the combination
     // that matched the original crash backtrace. Construct, let it fail to
     // connect, and make sure nothing heap-corrupts along the way.
+    const [targetPort, proxyPort] = await Promise.all([deadPort(), deadPort()]);
     const { promise, resolve } = Promise.withResolvers<void>();
-    const ws = new WebSocket("wss://127.0.0.1:1/", {
+    const ws = new WebSocket(`wss://127.0.0.1:${targetPort}/`, {
       headers: {
         "X-Latin1": "vàlüé-ñ",
         Authorization: "Bearer tökën",
       },
-      proxy: "http://127.0.0.1:2",
+      proxy: `http://127.0.0.1:${proxyPort}`,
       tls: {
         cert: "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----",
         key: "-----BEGIN PRIVATE KEY-----\nMIIE\n-----END PRIVATE KEY-----",
@@ -153,14 +192,15 @@ describe("WebSocket upgrade with non-ASCII inputs", () => {
   });
 
   test("does not crash with many Latin1 headers through proxy", async () => {
+    const [targetPort, proxyPort] = await Promise.all([deadPort(), deadPort()]);
     const { promise, resolve } = Promise.withResolvers<void>();
     const headers: Record<string, string> = {};
     for (let i = 0; i < 16; i++) {
       headers[`X-Hdr-${i}`] = `vàlüé-${i}-ñ`.repeat(4);
     }
-    const ws = new WebSocket("wss://127.0.0.1:1/", {
+    const ws = new WebSocket(`wss://127.0.0.1:${targetPort}/`, {
       headers,
-      proxy: "http://127.0.0.1:2",
+      proxy: `http://127.0.0.1:${proxyPort}`,
       tls: { rejectUnauthorized: false },
     });
     ws.onerror = () => resolve();
@@ -170,10 +210,11 @@ describe("WebSocket upgrade with non-ASCII inputs", () => {
   });
 
   test("does not crash with Latin1 proxy header values", async () => {
+    const [targetPort, proxyPort] = await Promise.all([deadPort(), deadPort()]);
     const { promise, resolve } = Promise.withResolvers<void>();
-    const ws = new WebSocket("ws://127.0.0.1:1/", {
+    const ws = new WebSocket(`ws://127.0.0.1:${targetPort}/`, {
       proxy: {
-        url: "http://127.0.0.1:2",
+        url: `http://127.0.0.1:${proxyPort}`,
         headers: {
           "X-Proxy": "prôxy-vàlüé",
         },

--- a/test/js/web/websocket/websocket-utf16-headers.test.ts
+++ b/test/js/web/websocket/websocket-utf16-headers.test.ts
@@ -13,8 +13,8 @@
 // BunString and decodes every input with `bun.String.toUTF8(allocator)`.
 
 import { describe, expect, test } from "bun:test";
-import net from "node:net";
 import { once } from "node:events";
+import net from "node:net";
 
 describe("WebSocket upgrade with non-ASCII inputs", () => {
   test("Latin1 header value with high bytes is sent as UTF-8 without crashing", async () => {

--- a/test/js/web/websocket/websocket-utf16-headers.test.ts
+++ b/test/js/web/websocket/websocket-utf16-headers.test.ts
@@ -31,7 +31,9 @@ function track(server: net.Server) {
   return server;
 }
 
-async function listenEphemeral(onConnection?: (socket: net.Socket) => void): Promise<{ port: number; server: net.Server }> {
+async function listenEphemeral(
+  onConnection?: (socket: net.Socket) => void,
+): Promise<{ port: number; server: net.Server }> {
   const server = net.createServer(onConnection);
   track(server);
   await once(server.listen(0, "127.0.0.1"), "listening");


### PR DESCRIPTION
## What & why

The WebSocket HTTP upgrade client received host, path, protocol, headers, proxy host, proxy auth, proxy headers and target authorization from C++ as `ZigString` wrappers over the underlying `WTF::StringImpl`.

When a `WTFStringImpl` was **not** 8-bit ASCII (either Latin1 with high bytes, or UTF-16), calling `.slice()` on the `ZigString` in Zig returned raw Latin1 / UTF-16 code units — not UTF-8. Those bytes were then substituted into a printf-style format string inside `buildRequestBody`, and the resulting garbage length could cause heap corruption in mimalloc during `std.fmt.allocPrint`:

```
_mi_heap_realloc_zero (vendor/mimalloc/src/alloc.c)
Io.Writer.Allocating.drain (vendor/zig/lib/std/Io/Writer.zig)
Io.Writer.alignBuffer (vendor/zig/lib/std/Io/Writer.zig:525)
http.websocket_client.WebSocketUpgradeClient.buildRequestBody (Writer.zig:1007)
Bun__WebSocketHTTPClient__connect (WebSocketUpgradeClient.zig:140)
WebCore::WebSocket::connect (WebSocket.cpp:655)
WebCore::constructJSWebSocket3 (WebSocket.cpp:352)
```

## Fix

- Change the `Bun__WebSocketHTTPClient__connect` / `…HTTPSClient__connect` FFI signature to take `BunString*` instead of `ZigString*`.
- In `WebSocket::connect()` in C++, build `BunString` wrappers via `Bun::toString(WTF::String&)` so the encoding tag is preserved end-to-end (materialize URL `.host()` as a `WTF::String` first; keep iterator key/value `WTF::String`s alive in side vectors for the duration of the call).
- On the Zig side, decode every input up front with `bun.String.toUTF8(allocator)`, which borrows the 8-bit ASCII backing when possible and only allocates a UTF-8 copy for non-ASCII Latin1 / UTF-16 inputs.
- Introduce `Headers8Bit` to hold the decoded header name/value slices alongside the underlying `ZigString.Slice`s for deterministic cleanup.

## Tests

`test/js/web/websocket/websocket-utf16-headers.test.ts` covers:
- Latin1-with-high-bytes header values are sent as proper UTF-8 (verified by inspecting the upgrade request bytes received by a raw TCP server).
- Non-ASCII path segments in the target URL.
- Proxy + custom TLS config + Latin1 headers (the exact combination from the crash report).
- Many Latin1 headers through a proxy.
- Latin1 proxy header values.

Existing `websocket-custom-headers.test.ts` (10/10) and `websocket-proxy.test.ts` (22/22 passing, 3 pre-existing failures unrelated to these changes) still pass.