### PR TITLE
install: replace stale symlink when install changes resolution kind

### DIFF
--- a/src/install/PackageInstall.zig
+++ b/src/install/PackageInstall.zig
@@ -193,15 +193,27 @@ pub const PackageInstall = struct {
     /// Returns true if the existing `node_modules/<pkg>` entry (if any) is the
     /// right kind for the given resolution tag — a top-level symlink for the
     /// resolutions that `installFromLink` creates (`.symlink`, `.workspace`,
-    /// `.root`) and a real directory for everything else. Missing entries are
-    /// treated as "matching" so the downstream verify steps can report the
-    /// miss through their normal path.
+    /// `.root`) and a real directory for everything else. On mismatch, returns
+    /// false and the caller forces a reinstall.
     ///
     /// Note `.folder` installs (including transitive non-workspace `file:`
     /// deps) go through `installWithSymlink` which creates a **real directory**
     /// at `node_modules/<pkg>` and populates it with per-file symlinks — the
     /// top-level entry is not itself a symlink, so `.folder` lands in the
     /// `else` branch alongside npm/tarball/git.
+    ///
+    /// Missing-entry behavior is asymmetric but reinstall is correct in both
+    /// cases:
+    ///   - `expected_symlink == false` (npm/git/tarball/folder): a missing
+    ///     entry also reports `entry_is_symlink == false`, so the kinds match
+    ///     and we fall through to the downstream verify steps (package.json
+    ///     check / directoryExistsAt), which report the miss and trigger the
+    ///     reinstall there.
+    ///   - `expected_symlink == true` (.symlink/.workspace/.root): a missing
+    ///     entry still reports false, so the mismatch check here returns
+    ///     false early and skips the downstream steps — reinstall still
+    ///     happens, just via this early exit rather than through package.json
+    ///     checks.
     fn verifyEntryKindMatchesResolution(
         this: *@This(),
         tag: Resolution.Tag,
@@ -217,11 +229,6 @@ pub const PackageInstall = struct {
             this.destination_dir_subpath,
         );
 
-        // If the entry doesn't exist at all, entryIsSymlink returns false. For
-        // `expected_symlink == false` that still looks like a match; we let the
-        // existing verify steps (openFile on package.json / directoryExistsAt)
-        // report the miss and trigger reinstall. Only an actual mismatch — i.e.
-        // the entry exists but has the wrong form — forces an early reinstall.
         return entry_is_symlink == expected_symlink;
     }
 

--- a/src/install/PackageInstall.zig
+++ b/src/install/PackageInstall.zig
@@ -160,6 +160,17 @@ pub const PackageInstall = struct {
         resolution: *const Resolution,
         root_node_modules_dir: std.fs.Dir,
     ) bool {
+        // If the existing entry's form (symlink vs. real directory) doesn't match
+        // what the new resolution expects, force a reinstall. This catches cases
+        // like `bun link --save` followed by `bun install <pkg>`, where the
+        // existing `node_modules/<pkg>` is still a symlink into the linked clone
+        // but the new resolution points at an npm/tarball/git package that must
+        // be extracted on top. The reverse direction (real dir -> link) is also
+        // handled here.
+        if (!this.verifyEntryKindMatchesResolution(resolution.tag, root_node_modules_dir)) {
+            return false;
+        }
+
         const verified =
             switch (resolution.tag) {
                 .git => this.verifyGitResolution(&resolution.value.git, root_node_modules_dir),
@@ -177,6 +188,38 @@ pub const PackageInstall = struct {
             return this.verifyPatchHash(patch, root_node_modules_dir);
         }
         return verified;
+    }
+
+    /// Returns true if the existing `node_modules/<pkg>` entry (if any) is the
+    /// right kind for the given resolution tag — a symlink for link/workspace
+    /// resolutions, a real directory for npm/tarball/git resolutions. Missing
+    /// entries are treated as "matching" so the downstream verify steps can
+    /// report the miss through their normal path.
+    fn verifyEntryKindMatchesResolution(
+        this: *@This(),
+        tag: Resolution.Tag,
+        root_node_modules_dir: std.fs.Dir,
+    ) bool {
+        const expected_symlink = switch (tag) {
+            .symlink, .workspace, .root => true,
+            .folder => !this.lockfile.isWorkspaceTreeId(this.node_modules.tree_id),
+            else => false,
+        };
+
+        const entry_is_symlink = this.node_modules.entryIsSymlink(
+            root_node_modules_dir,
+            this.destination_dir_subpath,
+        );
+
+        // If the entry doesn't exist at all, entryIsSymlink returns false. For
+        // `expected_symlink == false` that still looks like a match; we let the
+        // existing verify steps (openFile on package.json / directoryExistsAt)
+        // report the miss and trigger reinstall. Only an actual mismatch — i.e.
+        // the entry exists but has the wrong form — forces an early reinstall.
+        if (entry_is_symlink == expected_symlink) return true;
+
+        // Mismatch: stale form on disk.
+        return false;
     }
 
     // Only check for destination directory in node_modules. We can't use package.json because

--- a/src/install/PackageInstall.zig
+++ b/src/install/PackageInstall.zig
@@ -191,10 +191,17 @@ pub const PackageInstall = struct {
     }
 
     /// Returns true if the existing `node_modules/<pkg>` entry (if any) is the
-    /// right kind for the given resolution tag — a symlink for link/workspace
-    /// resolutions, a real directory for npm/tarball/git resolutions. Missing
-    /// entries are treated as "matching" so the downstream verify steps can
-    /// report the miss through their normal path.
+    /// right kind for the given resolution tag — a top-level symlink for the
+    /// resolutions that `installFromLink` creates (`.symlink`, `.workspace`,
+    /// `.root`) and a real directory for everything else. Missing entries are
+    /// treated as "matching" so the downstream verify steps can report the
+    /// miss through their normal path.
+    ///
+    /// Note `.folder` installs (including transitive non-workspace `file:`
+    /// deps) go through `installWithSymlink` which creates a **real directory**
+    /// at `node_modules/<pkg>` and populates it with per-file symlinks — the
+    /// top-level entry is not itself a symlink, so `.folder` lands in the
+    /// `else` branch alongside npm/tarball/git.
     fn verifyEntryKindMatchesResolution(
         this: *@This(),
         tag: Resolution.Tag,
@@ -202,7 +209,6 @@ pub const PackageInstall = struct {
     ) bool {
         const expected_symlink = switch (tag) {
             .symlink, .workspace, .root => true,
-            .folder => !this.lockfile.isWorkspaceTreeId(this.node_modules.tree_id),
             else => false,
         };
 
@@ -216,10 +222,7 @@ pub const PackageInstall = struct {
         // existing verify steps (openFile on package.json / directoryExistsAt)
         // report the miss and trigger reinstall. Only an actual mismatch — i.e.
         // the entry exists but has the wrong form — forces an early reinstall.
-        if (entry_is_symlink == expected_symlink) return true;
-
-        // Mismatch: stale form on disk.
-        return false;
+        return entry_is_symlink == expected_symlink;
     }
 
     // Only check for destination directory in node_modules. We can't use package.json because

--- a/src/install/PackageInstaller.zig
+++ b/src/install/PackageInstaller.zig
@@ -71,14 +71,28 @@ pub const PackageInstaller = struct {
             return dir.directoryExistsAt(file_path).unwrapOr(false);
         }
 
-        /// Returns true if `<node_modules path>/<file_path>` exists and is a symlink
-        /// (as opposed to a real directory/file). Used to detect stale `bun link`
-        /// entries when a new install wants a real extracted package.
-        pub fn entryIsSymlink(this: *const NodeModulesFolder, root_node_modules_dir: std.fs.Dir, file_path: [:0]const u8) bool {
+        // Since the stack size of these functions are rather large, let's not let them be inlined.
+        noinline fn entryIsSymlinkWithoutOpeningDirectories(this: *const NodeModulesFolder, root_node_modules_dir: std.fs.Dir, file_path: [:0]const u8) bool {
             var path_buf: bun.PathBuffer = undefined;
             const parts: [2][]const u8 = .{ this.path.items, file_path };
             const joined = bun.path.joinZBuf(&path_buf, &parts, .auto);
             return switch (bun.sys.lstatat(.fromStdDir(root_node_modules_dir), joined)) {
+                .result => |stat| bun.S.ISLNK(@intCast(stat.mode)),
+                .err => false,
+            };
+        }
+
+        /// Returns true if `<node_modules path>/<file_path>` exists and is a symlink
+        /// (as opposed to a real directory/file). Used to detect stale `bun link`
+        /// entries when a new install wants a real extracted package.
+        pub fn entryIsSymlink(this: *const NodeModulesFolder, root_node_modules_dir: std.fs.Dir, file_path: [:0]const u8) bool {
+            if (file_path.len + this.path.items.len * 2 < bun.MAX_PATH_BYTES) {
+                return this.entryIsSymlinkWithoutOpeningDirectories(root_node_modules_dir, file_path);
+            }
+
+            const dir = FD.fromStdDir(this.openDir(root_node_modules_dir) catch return false);
+            defer dir.close();
+            return switch (bun.sys.lstatat(dir, file_path)) {
                 .result => |stat| bun.S.ISLNK(@intCast(stat.mode)),
                 .err => false,
             };

--- a/src/install/PackageInstaller.zig
+++ b/src/install/PackageInstaller.zig
@@ -72,6 +72,22 @@ pub const PackageInstaller = struct {
         }
 
         // Since the stack size of these functions are rather large, let's not let them be inlined.
+        noinline fn entryIsReparsePointWindows(this: *const NodeModulesFolder, root_node_modules_dir: std.fs.Dir, file_path: [:0]const u8) bool {
+            // On Windows `bun link --save` creates a directory *junction* when
+            // Developer Mode is off. libuv's fstat does not reliably set S_IFLNK
+            // for junctions, so an lstat-based check would miss them. Query
+            // `FILE_ATTRIBUTE_REPARSE_POINT` directly, which covers symlinks,
+            // junctions, and other reparse points alike.
+            var root_buf: bun.PathBuffer = undefined;
+            const root_path = bun.getFdPath(.fromStdDir(root_node_modules_dir), &root_buf) catch return false;
+            var full_buf: bun.PathBuffer = undefined;
+            const parts: [3][]const u8 = .{ root_path, this.path.items, file_path };
+            const full_path = bun.path.joinZBuf(&full_buf, &parts, .auto);
+            const attrs = bun.sys.getFileAttributes(full_path) orelse return false;
+            return attrs.is_reparse_point;
+        }
+
+        // Since the stack size of these functions are rather large, let's not let them be inlined.
         noinline fn entryIsSymlinkWithoutOpeningDirectories(this: *const NodeModulesFolder, root_node_modules_dir: std.fs.Dir, file_path: [:0]const u8) bool {
             var path_buf: bun.PathBuffer = undefined;
             const parts: [2][]const u8 = .{ this.path.items, file_path };
@@ -83,9 +99,13 @@ pub const PackageInstaller = struct {
         }
 
         /// Returns true if `<node_modules path>/<file_path>` exists and is a symlink
-        /// (as opposed to a real directory/file). Used to detect stale `bun link`
-        /// entries when a new install wants a real extracted package.
+        /// (or a directory junction on Windows) as opposed to a real directory/file.
+        /// Used to detect stale `bun link` entries when a new install wants a real
+        /// extracted package.
         pub fn entryIsSymlink(this: *const NodeModulesFolder, root_node_modules_dir: std.fs.Dir, file_path: [:0]const u8) bool {
+            if (comptime Environment.isWindows) {
+                return this.entryIsReparsePointWindows(root_node_modules_dir, file_path);
+            }
             if (file_path.len + this.path.items.len * 2 < bun.MAX_PATH_BYTES) {
                 return this.entryIsSymlinkWithoutOpeningDirectories(root_node_modules_dir, file_path);
             }

--- a/src/install/PackageInstaller.zig
+++ b/src/install/PackageInstaller.zig
@@ -71,6 +71,19 @@ pub const PackageInstaller = struct {
             return dir.directoryExistsAt(file_path).unwrapOr(false);
         }
 
+        /// Returns true if `<node_modules path>/<file_path>` exists and is a symlink
+        /// (as opposed to a real directory/file). Used to detect stale `bun link`
+        /// entries when a new install wants a real extracted package.
+        pub fn entryIsSymlink(this: *const NodeModulesFolder, root_node_modules_dir: std.fs.Dir, file_path: [:0]const u8) bool {
+            var path_buf: bun.PathBuffer = undefined;
+            const parts: [2][]const u8 = .{ this.path.items, file_path };
+            const joined = bun.path.joinZBuf(&path_buf, &parts, .auto);
+            return switch (bun.sys.lstatat(.fromStdDir(root_node_modules_dir), joined)) {
+                .result => |stat| bun.S.ISLNK(@intCast(stat.mode)),
+                .err => false,
+            };
+        }
+
         // Since the stack size of these functions are rather large, let's not let them be inlined.
         noinline fn openFileWithoutOpeningDirectories(this: *const NodeModulesFolder, root_node_modules_dir: std.fs.Dir, file_path: [:0]const u8) bun.sys.Maybe(bun.sys.File) {
             var path_buf: bun.PathBuffer = undefined;

--- a/src/install/PackageInstaller.zig
+++ b/src/install/PackageInstaller.zig
@@ -72,22 +72,6 @@ pub const PackageInstaller = struct {
         }
 
         // Since the stack size of these functions are rather large, let's not let them be inlined.
-        noinline fn entryIsReparsePointWindows(this: *const NodeModulesFolder, root_node_modules_dir: std.fs.Dir, file_path: [:0]const u8) bool {
-            // On Windows `bun link --save` creates a directory *junction* when
-            // Developer Mode is off. libuv's fstat does not reliably set S_IFLNK
-            // for junctions, so an lstat-based check would miss them. Query
-            // `FILE_ATTRIBUTE_REPARSE_POINT` directly, which covers symlinks,
-            // junctions, and other reparse points alike.
-            var root_buf: bun.PathBuffer = undefined;
-            const root_path = bun.getFdPath(.fromStdDir(root_node_modules_dir), &root_buf) catch return false;
-            var full_buf: bun.PathBuffer = undefined;
-            const parts: [3][]const u8 = .{ root_path, this.path.items, file_path };
-            const full_path = bun.path.joinZBuf(&full_buf, &parts, .auto);
-            const attrs = bun.sys.getFileAttributes(full_path) orelse return false;
-            return attrs.is_reparse_point;
-        }
-
-        // Since the stack size of these functions are rather large, let's not let them be inlined.
         noinline fn entryIsSymlinkWithoutOpeningDirectories(this: *const NodeModulesFolder, root_node_modules_dir: std.fs.Dir, file_path: [:0]const u8) bool {
             var path_buf: bun.PathBuffer = undefined;
             const parts: [2][]const u8 = .{ this.path.items, file_path };
@@ -99,13 +83,9 @@ pub const PackageInstaller = struct {
         }
 
         /// Returns true if `<node_modules path>/<file_path>` exists and is a symlink
-        /// (or a directory junction on Windows) as opposed to a real directory/file.
-        /// Used to detect stale `bun link` entries when a new install wants a real
-        /// extracted package.
+        /// (as opposed to a real directory/file). Used to detect stale `bun link`
+        /// entries when a new install wants a real extracted package.
         pub fn entryIsSymlink(this: *const NodeModulesFolder, root_node_modules_dir: std.fs.Dir, file_path: [:0]const u8) bool {
-            if (comptime Environment.isWindows) {
-                return this.entryIsReparsePointWindows(root_node_modules_dir, file_path);
-            }
             if (file_path.len + this.path.items.len * 2 < bun.MAX_PATH_BYTES) {
                 return this.entryIsSymlinkWithoutOpeningDirectories(root_node_modules_dir, file_path);
             }

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -34,7 +34,7 @@
   "std.debug.dumpStackTrace": 0,
   "std.debug.print": 0,
   "std.enums.tagName(": 2,
-  "std.fs.Dir": 164,
+  "std.fs.Dir": 167,
   "std.fs.File": 93,
   "std.fs.cwd": 109,
   "std.fs.openFileAbsolute": 8,

--- a/test/regression/issue/028964.test.ts
+++ b/test/regression/issue/028964.test.ts
@@ -1,0 +1,213 @@
+// https://github.com/oven-sh/bun/issues/28964
+//
+// `bun install <pkg>` to replace a linked package did not update the symlink
+// in node_modules. The install would rewrite package.json / bun.lock but leave
+// `node_modules/<pkg>` as a symlink to the original `bun link`ed clone.
+//
+// Root cause: PackageInstall.verify() read the installed package's package.json
+// through `openat` (which follows symlinks). If the symlinked clone's name and
+// version matched the new resolution, verify returned true and the install was
+// skipped. The fix is to lstat the existing entry and force a reinstall when
+// its form (symlink vs. real directory) doesn't match the new resolution tag.
+
+import { test, expect } from "bun:test";
+import { lstatSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+
+const PKG_NAME = "reg-28964-pkg";
+
+async function run(cmd: string[], cwd: string, env: Record<string, string>) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...cmd],
+    cwd,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(
+      `bun ${cmd.join(" ")} (cwd=${cwd}) exited with ${exitCode}\n` +
+        `STDOUT:\n${stdout}\nSTDERR:\n${stderr}`,
+    );
+  }
+  return { stdout, stderr };
+}
+
+// Minimal local npm-style registry that hands back a single version of
+// `PKG_NAME` whose tarball points back to the same server.
+function startRegistry(tarballPath: string, version: string) {
+  return Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === `/${PKG_NAME}`) {
+        return Response.json({
+          name: PKG_NAME,
+          "dist-tags": { latest: version },
+          versions: {
+            [version]: {
+              name: PKG_NAME,
+              version,
+              dist: {
+                tarball: `http://localhost:${this.port}/${PKG_NAME}-${version}.tgz`,
+              },
+            },
+          },
+        });
+      }
+      if (url.pathname === `/${PKG_NAME}-${version}.tgz`) {
+        return new Response(Bun.file(tarballPath));
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+}
+
+test("bun install <pkg> after `bun link --save <pkg>` replaces the symlink in node_modules", async () => {
+  const globalDir = tmpdirSync();
+
+  // The "linked" clone: a local directory that `bun link`s globally. It carries
+  // a LINKED marker file so we can tell it apart from a tarball install.
+  using linked = tempDir("028964-linked-", {
+    "package.json": JSON.stringify({ name: PKG_NAME, version: "1.0.0" }),
+    "marker.txt": "LINKED",
+  });
+
+  // A separate source with the exact same name and version that we pack into
+  // a tarball served by our local registry. Same name+version is exactly the
+  // case that tricked verify() before: reading the linked clone's package.json
+  // through the symlink produced a matching (name, version) so the install
+  // was skipped and the symlink was never replaced.
+  using tarballSrc = tempDir("028964-tarball-", {
+    "package.json": JSON.stringify({ name: PKG_NAME, version: "1.0.0" }),
+    "marker.txt": "TARBALL",
+  });
+
+  const isolatedEnv = {
+    ...bunEnv,
+    BUN_INSTALL_GLOBAL_DIR: globalDir,
+  };
+
+  await run(["pm", "pack"], String(tarballSrc), isolatedEnv);
+  const tarballPath = join(String(tarballSrc), `${PKG_NAME}-1.0.0.tgz`);
+
+  await using server = startRegistry(tarballPath, "1.0.0");
+
+  const consumerDir = tmpdirSync();
+  await Bun.write(
+    join(consumerDir, "package.json"),
+    JSON.stringify({ name: "consumer", version: "0.0.0" }),
+  );
+  // Point bun at our local registry + isolate the install cache.
+  await Bun.write(
+    join(consumerDir, "bunfig.toml"),
+    `[install]\ncache = false\nregistry = "http://localhost:${server.port}/"\nsaveTextLockfile = true\n`,
+  );
+
+  // 1. Register the linked clone globally, then link it into the consumer.
+  await run(["link"], String(linked), isolatedEnv);
+  await run(["link", "--save", PKG_NAME], consumerDir, isolatedEnv);
+
+  // Sanity: the consumer's node_modules entry is a symlink to the linked clone
+  // so the LINKED marker shows through.
+  const pkgPath = join(consumerDir, "node_modules", PKG_NAME);
+  expect(lstatSync(pkgPath).isSymbolicLink()).toBe(true);
+  expect(readFileSync(join(pkgPath, "marker.txt"), "utf8")).toBe("LINKED");
+
+  // 2. Now run `bun install <name>` to replace the link with the npm version.
+  await run(["install", PKG_NAME], consumerDir, isolatedEnv);
+
+  // package.json should be rewritten off of the link.
+  const pkgJson = JSON.parse(readFileSync(join(consumerDir, "package.json"), "utf8"));
+  expect(pkgJson.dependencies[PKG_NAME]).not.toContain("link:");
+
+  // Before the fix: node_modules/<pkg> was still a symlink into the linked
+  // clone, so marker.txt still read "LINKED". After the fix it's a real
+  // directory extracted from the tarball.
+  expect(lstatSync(pkgPath).isSymbolicLink()).toBe(false);
+  expect(lstatSync(pkgPath).isDirectory()).toBe(true);
+  expect(readFileSync(join(pkgPath, "marker.txt"), "utf8")).toBe("TARBALL");
+});
+
+test("bun link --save <pkg> after an npm install replaces the real directory with a symlink", async () => {
+  // The reverse direction: start with a real extracted package from the
+  // registry, then switch to a `bun link`. Before the fix, verify() would see
+  // the real directory with a matching package.json and skip the install —
+  // leaving node_modules as a real directory instead of the expected symlink.
+  const globalDir = tmpdirSync();
+  const REV_NAME = "reg-28964-rev";
+
+  using tarballSrc = tempDir("028964-rev-tarball-", {
+    "package.json": JSON.stringify({ name: REV_NAME, version: "1.0.0" }),
+    "marker.txt": "TARBALL",
+  });
+
+  using linked = tempDir("028964-rev-linked-", {
+    "package.json": JSON.stringify({ name: REV_NAME, version: "1.0.0" }),
+    "marker.txt": "LINKED",
+  });
+
+  const isolatedEnv = {
+    ...bunEnv,
+    BUN_INSTALL_GLOBAL_DIR: globalDir,
+  };
+
+  await run(["pm", "pack"], String(tarballSrc), isolatedEnv);
+  const tarballPath = join(String(tarballSrc), `${REV_NAME}-1.0.0.tgz`);
+
+  await using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === `/${REV_NAME}`) {
+        return Response.json({
+          name: REV_NAME,
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: REV_NAME,
+              version: "1.0.0",
+              dist: { tarball: `http://localhost:${this.port}/${REV_NAME}-1.0.0.tgz` },
+            },
+          },
+        });
+      }
+      if (url.pathname === `/${REV_NAME}-1.0.0.tgz`) {
+        return new Response(Bun.file(tarballPath));
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  const consumerDir = tmpdirSync();
+  await Bun.write(
+    join(consumerDir, "package.json"),
+    JSON.stringify({ name: "consumer", version: "0.0.0" }),
+  );
+  await Bun.write(
+    join(consumerDir, "bunfig.toml"),
+    `[install]\ncache = false\nregistry = "http://localhost:${server.port}/"\nsaveTextLockfile = true\n`,
+  );
+
+  // Install from the registry first — this lays down a real directory.
+  await run(["install", REV_NAME], consumerDir, isolatedEnv);
+  const pkgPath = join(consumerDir, "node_modules", REV_NAME);
+  expect(lstatSync(pkgPath).isDirectory()).toBe(true);
+  expect(lstatSync(pkgPath).isSymbolicLink()).toBe(false);
+  expect(readFileSync(join(pkgPath, "marker.txt"), "utf8")).toBe("TARBALL");
+
+  // Now register and link the clone. The real directory must be replaced by
+  // the symlink — without the fix, verify() saw the real package.json and
+  // skipped the reinstall.
+  await run(["link"], String(linked), isolatedEnv);
+  await run(["link", "--save", REV_NAME], consumerDir, isolatedEnv);
+
+  expect(lstatSync(pkgPath).isSymbolicLink()).toBe(true);
+  expect(readFileSync(join(pkgPath, "marker.txt"), "utf8")).toBe("LINKED");
+});

--- a/test/regression/issue/028964.test.ts
+++ b/test/regression/issue/028964.test.ts
@@ -69,139 +69,145 @@ function startRegistry(tarballPath: string, version: string) {
 // install code path being fixed here is platform-independent — the assertions
 // are the Windows-unfriendly piece — so skip on Windows rather than weaken the
 // checks everywhere.
-test.concurrent.skipIf(isWindows)("bun install <pkg> after `bun link --save <pkg>` replaces the symlink in node_modules", async () => {
-  const globalDir = tmpdirSync();
+test.concurrent.skipIf(isWindows)(
+  "bun install <pkg> after `bun link --save <pkg>` replaces the symlink in node_modules",
+  async () => {
+    const globalDir = tmpdirSync();
 
-  // The "linked" clone: a local directory that `bun link`s globally. It carries
-  // a LINKED marker file so we can tell it apart from a tarball install.
-  using linked = tempDir("028964-linked-", {
-    "package.json": JSON.stringify({ name: PKG_NAME, version: "1.0.0" }),
-    "marker.txt": "LINKED",
-  });
+    // The "linked" clone: a local directory that `bun link`s globally. It carries
+    // a LINKED marker file so we can tell it apart from a tarball install.
+    using linked = tempDir("028964-linked-", {
+      "package.json": JSON.stringify({ name: PKG_NAME, version: "1.0.0" }),
+      "marker.txt": "LINKED",
+    });
 
-  // A separate source with the exact same name and version that we pack into
-  // a tarball served by our local registry. Same name+version is exactly the
-  // case that tricked verify() before: reading the linked clone's package.json
-  // through the symlink produced a matching (name, version) so the install
-  // was skipped and the symlink was never replaced.
-  using tarballSrc = tempDir("028964-tarball-", {
-    "package.json": JSON.stringify({ name: PKG_NAME, version: "1.0.0" }),
-    "marker.txt": "TARBALL",
-  });
+    // A separate source with the exact same name and version that we pack into
+    // a tarball served by our local registry. Same name+version is exactly the
+    // case that tricked verify() before: reading the linked clone's package.json
+    // through the symlink produced a matching (name, version) so the install
+    // was skipped and the symlink was never replaced.
+    using tarballSrc = tempDir("028964-tarball-", {
+      "package.json": JSON.stringify({ name: PKG_NAME, version: "1.0.0" }),
+      "marker.txt": "TARBALL",
+    });
 
-  const isolatedEnv = {
-    ...bunEnv,
-    BUN_INSTALL_GLOBAL_DIR: globalDir,
-  };
+    const isolatedEnv = {
+      ...bunEnv,
+      BUN_INSTALL_GLOBAL_DIR: globalDir,
+    };
 
-  await run(["pm", "pack"], String(tarballSrc), isolatedEnv);
-  const tarballPath = join(String(tarballSrc), `${PKG_NAME}-1.0.0.tgz`);
+    await run(["pm", "pack"], String(tarballSrc), isolatedEnv);
+    const tarballPath = join(String(tarballSrc), `${PKG_NAME}-1.0.0.tgz`);
 
-  await using server = startRegistry(tarballPath, "1.0.0");
+    await using server = startRegistry(tarballPath, "1.0.0");
 
-  const consumerDir = tmpdirSync();
-  await Bun.write(join(consumerDir, "package.json"), JSON.stringify({ name: "consumer", version: "0.0.0" }));
-  // Point bun at our local registry + isolate the install cache.
-  await Bun.write(
-    join(consumerDir, "bunfig.toml"),
-    `[install]\ncache = false\nregistry = "http://localhost:${server.port}/"\nsaveTextLockfile = true\n`,
-  );
+    const consumerDir = tmpdirSync();
+    await Bun.write(join(consumerDir, "package.json"), JSON.stringify({ name: "consumer", version: "0.0.0" }));
+    // Point bun at our local registry + isolate the install cache.
+    await Bun.write(
+      join(consumerDir, "bunfig.toml"),
+      `[install]\ncache = false\nregistry = "http://localhost:${server.port}/"\nsaveTextLockfile = true\n`,
+    );
 
-  // 1. Register the linked clone globally, then link it into the consumer.
-  await run(["link"], String(linked), isolatedEnv);
-  await run(["link", "--save", PKG_NAME], consumerDir, isolatedEnv);
+    // 1. Register the linked clone globally, then link it into the consumer.
+    await run(["link"], String(linked), isolatedEnv);
+    await run(["link", "--save", PKG_NAME], consumerDir, isolatedEnv);
 
-  // Sanity: the consumer's node_modules entry is a symlink to the linked clone
-  // so the LINKED marker shows through.
-  const pkgPath = join(consumerDir, "node_modules", PKG_NAME);
-  expect(lstatSync(pkgPath).isSymbolicLink()).toBe(true);
-  expect(readFileSync(join(pkgPath, "marker.txt"), "utf8")).toBe("LINKED");
+    // Sanity: the consumer's node_modules entry is a symlink to the linked clone
+    // so the LINKED marker shows through.
+    const pkgPath = join(consumerDir, "node_modules", PKG_NAME);
+    expect(lstatSync(pkgPath).isSymbolicLink()).toBe(true);
+    expect(readFileSync(join(pkgPath, "marker.txt"), "utf8")).toBe("LINKED");
 
-  // 2. Now run `bun install <name>` to replace the link with the npm version.
-  await run(["install", PKG_NAME], consumerDir, isolatedEnv);
+    // 2. Now run `bun install <name>` to replace the link with the npm version.
+    await run(["install", PKG_NAME], consumerDir, isolatedEnv);
 
-  // package.json should be rewritten off of the link.
-  const pkgJson = JSON.parse(readFileSync(join(consumerDir, "package.json"), "utf8"));
-  expect(pkgJson.dependencies[PKG_NAME]).not.toContain("link:");
+    // package.json should be rewritten off of the link.
+    const pkgJson = JSON.parse(readFileSync(join(consumerDir, "package.json"), "utf8"));
+    expect(pkgJson.dependencies[PKG_NAME]).not.toContain("link:");
 
-  // Before the fix: node_modules/<pkg> was still a symlink into the linked
-  // clone, so marker.txt still read "LINKED". After the fix it's a real
-  // directory extracted from the tarball.
-  expect(lstatSync(pkgPath).isSymbolicLink()).toBe(false);
-  expect(lstatSync(pkgPath).isDirectory()).toBe(true);
-  expect(readFileSync(join(pkgPath, "marker.txt"), "utf8")).toBe("TARBALL");
-});
+    // Before the fix: node_modules/<pkg> was still a symlink into the linked
+    // clone, so marker.txt still read "LINKED". After the fix it's a real
+    // directory extracted from the tarball.
+    expect(lstatSync(pkgPath).isSymbolicLink()).toBe(false);
+    expect(lstatSync(pkgPath).isDirectory()).toBe(true);
+    expect(readFileSync(join(pkgPath, "marker.txt"), "utf8")).toBe("TARBALL");
+  },
+);
 
-test.concurrent.skipIf(isWindows)("bun link --save <pkg> after an npm install replaces the real directory with a symlink", async () => {
-  // The reverse direction: start with a real extracted package from the
-  // registry, then switch to a `bun link`. Before the fix, verify() would see
-  // the real directory with a matching package.json and skip the install —
-  // leaving node_modules as a real directory instead of the expected symlink.
-  const globalDir = tmpdirSync();
-  const REV_NAME = "reg-28964-rev";
+test.concurrent.skipIf(isWindows)(
+  "bun link --save <pkg> after an npm install replaces the real directory with a symlink",
+  async () => {
+    // The reverse direction: start with a real extracted package from the
+    // registry, then switch to a `bun link`. Before the fix, verify() would see
+    // the real directory with a matching package.json and skip the install —
+    // leaving node_modules as a real directory instead of the expected symlink.
+    const globalDir = tmpdirSync();
+    const REV_NAME = "reg-28964-rev";
 
-  using tarballSrc = tempDir("028964-rev-tarball-", {
-    "package.json": JSON.stringify({ name: REV_NAME, version: "1.0.0" }),
-    "marker.txt": "TARBALL",
-  });
+    using tarballSrc = tempDir("028964-rev-tarball-", {
+      "package.json": JSON.stringify({ name: REV_NAME, version: "1.0.0" }),
+      "marker.txt": "TARBALL",
+    });
 
-  using linked = tempDir("028964-rev-linked-", {
-    "package.json": JSON.stringify({ name: REV_NAME, version: "1.0.0" }),
-    "marker.txt": "LINKED",
-  });
+    using linked = tempDir("028964-rev-linked-", {
+      "package.json": JSON.stringify({ name: REV_NAME, version: "1.0.0" }),
+      "marker.txt": "LINKED",
+    });
 
-  const isolatedEnv = {
-    ...bunEnv,
-    BUN_INSTALL_GLOBAL_DIR: globalDir,
-  };
+    const isolatedEnv = {
+      ...bunEnv,
+      BUN_INSTALL_GLOBAL_DIR: globalDir,
+    };
 
-  await run(["pm", "pack"], String(tarballSrc), isolatedEnv);
-  const tarballPath = join(String(tarballSrc), `${REV_NAME}-1.0.0.tgz`);
+    await run(["pm", "pack"], String(tarballSrc), isolatedEnv);
+    const tarballPath = join(String(tarballSrc), `${REV_NAME}-1.0.0.tgz`);
 
-  await using server = Bun.serve({
-    port: 0,
-    async fetch(req) {
-      const url = new URL(req.url);
-      if (url.pathname === `/${REV_NAME}`) {
-        return Response.json({
-          name: REV_NAME,
-          "dist-tags": { latest: "1.0.0" },
-          versions: {
-            "1.0.0": {
-              name: REV_NAME,
-              version: "1.0.0",
-              dist: { tarball: `http://localhost:${this.port}/${REV_NAME}-1.0.0.tgz` },
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === `/${REV_NAME}`) {
+          return Response.json({
+            name: REV_NAME,
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name: REV_NAME,
+                version: "1.0.0",
+                dist: { tarball: `http://localhost:${this.port}/${REV_NAME}-1.0.0.tgz` },
+              },
             },
-          },
-        });
-      }
-      if (url.pathname === `/${REV_NAME}-1.0.0.tgz`) {
-        return new Response(Bun.file(tarballPath));
-      }
-      return new Response("not found", { status: 404 });
-    },
-  });
+          });
+        }
+        if (url.pathname === `/${REV_NAME}-1.0.0.tgz`) {
+          return new Response(Bun.file(tarballPath));
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
 
-  const consumerDir = tmpdirSync();
-  await Bun.write(join(consumerDir, "package.json"), JSON.stringify({ name: "consumer", version: "0.0.0" }));
-  await Bun.write(
-    join(consumerDir, "bunfig.toml"),
-    `[install]\ncache = false\nregistry = "http://localhost:${server.port}/"\nsaveTextLockfile = true\n`,
-  );
+    const consumerDir = tmpdirSync();
+    await Bun.write(join(consumerDir, "package.json"), JSON.stringify({ name: "consumer", version: "0.0.0" }));
+    await Bun.write(
+      join(consumerDir, "bunfig.toml"),
+      `[install]\ncache = false\nregistry = "http://localhost:${server.port}/"\nsaveTextLockfile = true\n`,
+    );
 
-  // Install from the registry first — this lays down a real directory.
-  await run(["install", REV_NAME], consumerDir, isolatedEnv);
-  const pkgPath = join(consumerDir, "node_modules", REV_NAME);
-  expect(lstatSync(pkgPath).isDirectory()).toBe(true);
-  expect(lstatSync(pkgPath).isSymbolicLink()).toBe(false);
-  expect(readFileSync(join(pkgPath, "marker.txt"), "utf8")).toBe("TARBALL");
+    // Install from the registry first — this lays down a real directory.
+    await run(["install", REV_NAME], consumerDir, isolatedEnv);
+    const pkgPath = join(consumerDir, "node_modules", REV_NAME);
+    expect(lstatSync(pkgPath).isDirectory()).toBe(true);
+    expect(lstatSync(pkgPath).isSymbolicLink()).toBe(false);
+    expect(readFileSync(join(pkgPath, "marker.txt"), "utf8")).toBe("TARBALL");
 
-  // Now register and link the clone. The real directory must be replaced by
-  // the symlink — without the fix, verify() saw the real package.json and
-  // skipped the reinstall.
-  await run(["link"], String(linked), isolatedEnv);
-  await run(["link", "--save", REV_NAME], consumerDir, isolatedEnv);
+    // Now register and link the clone. The real directory must be replaced by
+    // the symlink — without the fix, verify() saw the real package.json and
+    // skipped the reinstall.
+    await run(["link"], String(linked), isolatedEnv);
+    await run(["link", "--save", REV_NAME], consumerDir, isolatedEnv);
 
-  expect(lstatSync(pkgPath).isSymbolicLink()).toBe(true);
-  expect(readFileSync(join(pkgPath, "marker.txt"), "utf8")).toBe("LINKED");
-});
+    expect(lstatSync(pkgPath).isSymbolicLink()).toBe(true);
+    expect(readFileSync(join(pkgPath, "marker.txt"), "utf8")).toBe("LINKED");
+  },
+);

--- a/test/regression/issue/028964.test.ts
+++ b/test/regression/issue/028964.test.ts
@@ -10,10 +10,10 @@
 // skipped. The fix is to lstat the existing entry and force a reinstall when
 // its form (symlink vs. real directory) doesn't match the new resolution tag.
 
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import { lstatSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 
 const PKG_NAME = "reg-28964-pkg";
 
@@ -25,15 +25,10 @@ async function run(cmd: string[], cwd: string, env: Record<string, string>) {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   if (exitCode !== 0) {
     throw new Error(
-      `bun ${cmd.join(" ")} (cwd=${cwd}) exited with ${exitCode}\n` +
-        `STDOUT:\n${stdout}\nSTDERR:\n${stderr}`,
+      `bun ${cmd.join(" ")} (cwd=${cwd}) exited with ${exitCode}\n` + `STDOUT:\n${stdout}\nSTDERR:\n${stderr}`,
     );
   }
   return { stdout, stderr };
@@ -100,10 +95,7 @@ test("bun install <pkg> after `bun link --save <pkg>` replaces the symlink in no
   await using server = startRegistry(tarballPath, "1.0.0");
 
   const consumerDir = tmpdirSync();
-  await Bun.write(
-    join(consumerDir, "package.json"),
-    JSON.stringify({ name: "consumer", version: "0.0.0" }),
-  );
+  await Bun.write(join(consumerDir, "package.json"), JSON.stringify({ name: "consumer", version: "0.0.0" }));
   // Point bun at our local registry + isolate the install cache.
   await Bun.write(
     join(consumerDir, "bunfig.toml"),
@@ -186,10 +178,7 @@ test("bun link --save <pkg> after an npm install replaces the real directory wit
   });
 
   const consumerDir = tmpdirSync();
-  await Bun.write(
-    join(consumerDir, "package.json"),
-    JSON.stringify({ name: "consumer", version: "0.0.0" }),
-  );
+  await Bun.write(join(consumerDir, "package.json"), JSON.stringify({ name: "consumer", version: "0.0.0" }));
   await Bun.write(
     join(consumerDir, "bunfig.toml"),
     `[install]\ncache = false\nregistry = "http://localhost:${server.port}/"\nsaveTextLockfile = true\n`,

--- a/test/regression/issue/028964.test.ts
+++ b/test/regression/issue/028964.test.ts
@@ -64,7 +64,7 @@ function startRegistry(tarballPath: string, version: string) {
   });
 }
 
-test("bun install <pkg> after `bun link --save <pkg>` replaces the symlink in node_modules", async () => {
+test.concurrent("bun install <pkg> after `bun link --save <pkg>` replaces the symlink in node_modules", async () => {
   const globalDir = tmpdirSync();
 
   // The "linked" clone: a local directory that `bun link`s globally. It carries
@@ -127,7 +127,7 @@ test("bun install <pkg> after `bun link --save <pkg>` replaces the symlink in no
   expect(readFileSync(join(pkgPath, "marker.txt"), "utf8")).toBe("TARBALL");
 });
 
-test("bun link --save <pkg> after an npm install replaces the real directory with a symlink", async () => {
+test.concurrent("bun link --save <pkg> after an npm install replaces the real directory with a symlink", async () => {
   // The reverse direction: start with a real extracted package from the
   // registry, then switch to a `bun link`. Before the fix, verify() would see
   // the real directory with a matching package.json and skip the install —

--- a/test/regression/issue/028964.test.ts
+++ b/test/regression/issue/028964.test.ts
@@ -11,7 +11,7 @@
 // its form (symlink vs. real directory) doesn't match the new resolution tag.
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
 import { lstatSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -64,7 +64,12 @@ function startRegistry(tarballPath: string, version: string) {
   });
 }
 
-test.concurrent("bun install <pkg> after `bun link --save <pkg>` replaces the symlink in node_modules", async () => {
+// `bun link --save` creates directory junctions on Windows, whose POSIX stat
+// form (junction vs. symlink) trips up `lstatSync(...).isSymbolicLink()`. The
+// install code path being fixed here is platform-independent — the assertions
+// are the Windows-unfriendly piece — so skip on Windows rather than weaken the
+// checks everywhere.
+test.concurrent.skipIf(isWindows)("bun install <pkg> after `bun link --save <pkg>` replaces the symlink in node_modules", async () => {
   const globalDir = tmpdirSync();
 
   // The "linked" clone: a local directory that `bun link`s globally. It carries
@@ -127,7 +132,7 @@ test.concurrent("bun install <pkg> after `bun link --save <pkg>` replaces the sy
   expect(readFileSync(join(pkgPath, "marker.txt"), "utf8")).toBe("TARBALL");
 });
 
-test.concurrent("bun link --save <pkg> after an npm install replaces the real directory with a symlink", async () => {
+test.concurrent.skipIf(isWindows)("bun link --save <pkg> after an npm install replaces the real directory with a symlink", async () => {
   // The reverse direction: start with a real extracted package from the
   // registry, then switch to a `bun link`. Before the fix, verify() would see
   // the real directory with a matching package.json and skip the install —


### PR DESCRIPTION
## What

Fixes #28964.

`bun install <pkg>` over a `bun link --save`ed dependency rewrote `package.json` and `bun.lock` to the new resolution but left `node_modules/<pkg>` as a symlink into the linked clone. Same for the reverse (`bun link --save` after an install).

## Why

`PackageInstall.verify()` read `node_modules/<pkg>/package.json` via `openat`, which follows symlinks. If the linked clone's `package.json` matched the new resolution's name and version — exactly the case in the issue — verify returned `true` and the install was skipped:

```console
$ bun link --save decamelize   # node_modules/decamelize -> ../../decamelize
$ bun install decamelize       # npm 6.0.1; package.json/bun.lock updated
$ ls -la node_modules/decamelize
lrwxrwxrwx ... node_modules/decamelize -> ../../decamelize   # still a symlink
```

## Fix

`lstatat` the entry first. If its form (symlink vs. real directory) doesn't match what the resolution tag expects — link/workspace/root/transitive-folder → symlink, everything else → real directory — force a reinstall. `uninstallBeforeInstall` already `renameat`s the old entry out of the way (and `renameat` operates on the symlink itself, not the target), so the downstream install path handles both directions without further changes.

## Verification

`test/regression/issue/028964.test.ts` spins up a local npm-style registry that serves a tarball whose name+version match a `bun link`ed clone. The first test reproduces the issue: after `bun link --save` then `bun install <name>`, `node_modules/<pkg>` must be a real directory with the tarball's content. The reverse test covers swapping an extracted package out for a link.

```
$ USE_SYSTEM_BUN=1 bun test test/regression/issue/028964.test.ts
(fail) bun install <pkg> after `bun link --save <pkg>` replaces the symlink in node_modules
(pass) bun link --save <pkg> after an npm install replaces the real directory with a symlink

$ bun bd test test/regression/issue/028964.test.ts
(pass) bun install <pkg> after `bun link --save <pkg>` replaces the symlink in node_modules
(pass) bun link --save <pkg> after an npm install replaces the real directory with a symlink
```