### PR TITLE
test(http,websocket): regression guards for proxied WebSocket from Bun.connect callback and HTTP_PROXY reassign mid-fetch

### DIFF
--- a/test/js/bun/http/proxy-env-reassign.test.ts
+++ b/test/js/bun/http/proxy-env-reassign.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Stress test for the env-derived proxy URL lifecycle: getHttpProxy() returns a
+ * URL whose fields borrow from a RefCountedEnvValue's bytes. Reassigning
+ * process.env.HTTP_PROXY derefs/frees those bytes. Any async caller that stored
+ * the borrowed URL would then read freed memory; if the freed block is reused
+ * for heap metadata, a later realloc segfaults at NULL (observed in
+ * WebSocketUpgradeClient.buildRequestBody → _mi_heap_realloc_zero @ 0x0).
+ *
+ * FetchTasklet already dupes into url_proxy_buffer; this test guards that
+ * behavior end-to-end and exercises the WebSocket-from-socket-callback
+ * realloc path under the same heap pressure.
+ */
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("fetch through env HTTP_PROXY survives mid-flight reassignment, then WebSocket allocPrint does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        import net from "node:net";
+
+        // Target HTTP+WS server.
+        let httpHits = 0;
+        using server = Bun.serve({
+          port: 0,
+          fetch(req, srv) {
+            if (srv.upgrade(req)) return;
+            httpHits++;
+            return new Response("ok");
+          },
+          websocket: {
+            open(ws) { ws.send("connected"); },
+            message(ws, m) { ws.send(m); },
+          },
+        });
+        const targetUrl = "http://127.0.0.1:" + server.port + "/";
+        const wsUrl = "ws://127.0.0.1:" + server.port + "/";
+
+        // Minimal forwarding HTTP proxy that handles both absolute-URI GET
+        // (fetch over plain HTTP) and CONNECT (WebSocket).
+        let proxyHttpHits = 0;
+        let proxyConnectHits = 0;
+        const proxy = net.createServer(client => {
+          let buf = Buffer.alloc(0);
+          client.once("data", data => {
+            buf = Buffer.concat([buf, data]);
+            const text = buf.toString();
+            const eoh = text.indexOf("\\r\\n\\r\\n");
+            const firstLine = text.slice(0, text.indexOf("\\r\\n"));
+            const [method, target, ver] = firstLine.split(" ");
+            if (method === "CONNECT") {
+              proxyConnectHits++;
+              const [host, port] = target.split(":");
+              const upstream = net.connect(+port, host, () => {
+                client.write("HTTP/1.1 200 Connection Established\\r\\n\\r\\n");
+                const rest = buf.subarray(eoh + 4);
+                if (rest.length) upstream.write(rest);
+                client.pipe(upstream);
+                upstream.pipe(client);
+              });
+              upstream.on("error", () => client.destroy());
+              return;
+            }
+            proxyHttpHits++;
+            const u = new URL(target);
+            const upstream = net.connect(+u.port, u.hostname, () => {
+              upstream.write(method + " " + (u.pathname || "/") + (u.search || "") + " " + ver + "\\r\\n");
+              upstream.write(text.slice(text.indexOf("\\r\\n") + 2));
+              client.pipe(upstream);
+              upstream.pipe(client);
+            });
+            upstream.on("error", () => client.destroy());
+          });
+        });
+        await new Promise(r => proxy.listen(0, "127.0.0.1", r));
+        const proxyPort = proxy.address().port;
+        const proxyUrl = "http://127.0.0.1:" + proxyPort;
+
+        // TCP echo server so we can run code inside a Bun.connect data callback
+        // (the exact reentrancy from the crash report's stack trace).
+        const echo = Bun.listen({
+          hostname: "127.0.0.1",
+          port: 0,
+          socket: { data(s, d) { s.write(d); } },
+        });
+
+        process.env.HTTP_PROXY = proxyUrl;
+
+        // Fire fetches that resolve their proxy from env (not the explicit
+        // {proxy} option). FetchTasklet dupes the env URL before queuing on
+        // the HTTP thread; the thrash below would UAF if it didn't.
+        const FETCHES = 24;
+        const fetches = Array.from({ length: FETCHES }, () => fetch(targetUrl).then(r => r.text()));
+
+        // Thrash HTTP_PROXY so the original RefCountedEnvValue is freed and
+        // its bytes reused before the HTTP thread reads them.
+        for (let i = 0; i < 128; i++) {
+          process.env.HTTP_PROXY = "http://" + Buffer.alloc(32 + (i & 31), "z").toString() + ".invalid:1/";
+        }
+        Bun.gc(true);
+        process.env.HTTP_PROXY = proxyUrl;
+
+        // Now create WebSockets through the proxy from inside a Bun.connect
+        // data callback — buildRequestBody runs allocPrint on vm.allocator.
+        const wsResults = [];
+        for (let i = 0; i < 4; i++) {
+          const created = Promise.withResolvers();
+          wsResults.push(created.promise);
+          Bun.connect({
+            hostname: "127.0.0.1",
+            port: echo.port,
+            socket: {
+              open(s) { s.write("ping"); },
+              data(s) {
+                try {
+                  const ws = new WebSocket(wsUrl, { proxy: proxyUrl });
+                  ws.onmessage = ev => { if (ev.data === "connected") { ws.close(); created.resolve("ok"); } };
+                  ws.onerror = ev => created.reject(new Error("ws error: " + (ev.message ?? ev.type)));
+                } catch (e) { created.reject(e); }
+                s.end();
+              },
+              error(_s, e) { created.reject(e); },
+            },
+          }).catch(e => created.reject(e));
+        }
+
+        const fr = await Promise.all(fetches);
+        const wr = await Promise.all(wsResults);
+
+        echo.stop(true);
+        proxy.close();
+
+        if (fr.some(t => t !== "ok")) { console.error("fetch body mismatch"); process.exit(1); }
+        if (wr.some(t => t !== "ok")) { console.error("ws result mismatch"); process.exit(1); }
+        if (httpHits < FETCHES) { console.error("endpoint missed fetches: " + httpHits); process.exit(1); }
+        if (proxyHttpHits < FETCHES) { console.error("proxy missed fetches: " + proxyHttpHits); process.exit(1); }
+        if (proxyConnectHits < 4) { console.error("proxy missed CONNECTs: " + proxyConnectHits); process.exit(1); }
+
+        console.log("PASS " + httpHits + " " + proxyHttpHits + " " + proxyConnectHits);
+        process.exit(0);
+      `,
+    ],
+    env: (() => {
+      const e: Record<string, string | undefined> = { ...bunEnv };
+      delete e.HTTP_PROXY;
+      delete e.http_proxy;
+      delete e.HTTPS_PROXY;
+      delete e.https_proxy;
+      delete e.NO_PROXY;
+      delete e.no_proxy;
+      return e;
+    })(),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toMatch(/^PASS \d+ \d+ \d+\n$/);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/websocket/websocket-from-socket-callback.test.ts
+++ b/test/js/web/websocket/websocket-from-socket-callback.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Regression test for a segfault in _mi_heap_realloc_zero during
+ * WebSocketUpgradeClient.buildRequestBody when `new WebSocket()` is created
+ * from inside a Bun.connect (uSockets) data callback with an HTTP proxy.
+ *
+ * Stack trace shape:
+ *   us_loop_run_bun_tick → us_internal_dispatch_ready_poll → NewSocketHandler
+ *   → Bun.connect data handler → JS → new WebSocket() → WebSocket::connect
+ *   → Bun__WebSocketHTTPClient__connect → buildRequestBody → allocPrint
+ *   → Allocating.drain → mi_heap_realloc_aligned → segfault @ 0x0
+ */
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import type net from "net";
+import { createConnectProxy, startProxy } from "./proxy-test-utils";
+
+let wsServer: ReturnType<typeof Bun.serve>;
+let tcpServer: ReturnType<typeof Bun.listen>;
+let proxy: net.Server;
+let wsPort: number;
+let tcpPort: number;
+let proxyPort: number;
+
+beforeAll(async () => {
+  wsServer = Bun.serve({
+    port: 0,
+    fetch(req, server) {
+      if (server.upgrade(req)) return;
+      return new Response("Expected WebSocket", { status: 400 });
+    },
+    websocket: {
+      open(ws) {
+        ws.send("connected");
+      },
+      message(ws, message) {
+        ws.send(message);
+      },
+    },
+  });
+  wsPort = wsServer.port;
+
+  tcpServer = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      data(socket, data) {
+        socket.write(data);
+      },
+    },
+  });
+  tcpPort = tcpServer.port;
+
+  proxy = createConnectProxy();
+  proxyPort = await startProxy(proxy);
+});
+
+afterAll(() => {
+  wsServer?.stop(true);
+  tcpServer?.stop(true);
+  proxy?.close();
+});
+
+function openWebSocketViaProxy(): Promise<void> {
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, {
+    // @ts-expect-error Bun-specific option
+    proxy: `http://127.0.0.1:${proxyPort}`,
+  });
+  ws.onmessage = ev => {
+    if (ev.data === "connected") {
+      ws.close();
+      resolve();
+    }
+  };
+  ws.onerror = ev => reject(new Error(`WebSocket error: ${(ev as ErrorEvent).message ?? ev.type}`));
+  ws.onclose = ev => {
+    if (ev.code !== 1000 && ev.code !== 1005) {
+      reject(new Error(`WebSocket closed unexpectedly: code=${ev.code} reason=${ev.reason}`));
+    }
+  };
+  return promise;
+}
+
+test("creating a proxied WebSocket inside a Bun.connect data callback does not crash", async () => {
+  const ITERATIONS = 16;
+  const results: Promise<void>[] = [];
+
+  for (let i = 0; i < ITERATIONS; i++) {
+    const wsCreated = Promise.withResolvers<Promise<void>>();
+    results.push(wsCreated.promise.then(p => p));
+
+    const sock = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: tcpPort,
+      socket: {
+        open(socket) {
+          socket.write("ping");
+        },
+        data(socket) {
+          try {
+            wsCreated.resolve(openWebSocketViaProxy());
+          } catch (e) {
+            wsCreated.reject(e);
+          }
+          socket.end();
+        },
+        error(_socket, error) {
+          wsCreated.reject(error);
+        },
+      },
+    });
+    void sock;
+  }
+
+  const settled = await Promise.allSettled(results);
+  const failures = settled.filter(r => r.status === "rejected");
+  expect(failures).toEqual([]);
+  expect(settled.length).toBe(ITERATIONS);
+});
+
+test("creating many proxied WebSockets concurrently inside socket callbacks does not crash", async () => {
+  const SOCKETS = 8;
+  const WS_PER_CALLBACK = 4;
+  const allWs: Promise<void>[] = [];
+  const sockReady: Promise<void>[] = [];
+
+  for (let i = 0; i < SOCKETS; i++) {
+    const done = Promise.withResolvers<void>();
+    sockReady.push(done.promise);
+
+    Bun.connect({
+      hostname: "127.0.0.1",
+      port: tcpPort,
+      socket: {
+        open(socket) {
+          socket.write("ping");
+        },
+        data(socket) {
+          for (let j = 0; j < WS_PER_CALLBACK; j++) {
+            allWs.push(openWebSocketViaProxy());
+          }
+          socket.end();
+          done.resolve();
+        },
+        error(_socket, error) {
+          done.reject(error);
+        },
+      },
+    }).catch(done.reject);
+  }
+
+  await Promise.all(sockReady);
+  const settled = await Promise.allSettled(allWs);
+  const failures = settled.filter(r => r.status === "rejected");
+  expect(failures).toEqual([]);
+  expect(settled.length).toBe(SOCKETS * WS_PER_CALLBACK);
+});


### PR DESCRIPTION
test(http,websocket): regression guards for proxied WebSocket from Bun.connect callback and HTTP_PROXY reassignment mid-fetch

Guards two scenarios surfaced while investigating a _mi_heap_realloc_zero
segfault report:

- websocket-from-socket-callback: creates proxied WebSockets from inside
  Bun.connect data handlers (the crash report's stack shape).
- proxy-env-reassign: thrashes process.env.HTTP_PROXY while env-proxied
  fetches are in flight, then creates proxied WebSockets from a socket
  callback. Guards FetchTasklet's url_proxy_buffer dupe end-to-end.
