### PR TITLE
install: support name@version entries in minimumReleaseAgeExcludes

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -269,8 +269,8 @@ You can also configure this in `bunfig.toml`:
 # Only install package versions published at least 3 days ago
 minimumReleaseAge = 259200 # seconds
 
-# Exclude trusted packages from the age gate
-minimumReleaseAgeExcludes = ["@types/node", "typescript"]
+# Exempt trusted packages; "name@version" whitelists one exact version.
+minimumReleaseAgeExcludes = ["@types/node", "typescript@5.4.5"]
 ```
 
 When the minimum age filter is active:
@@ -282,6 +282,10 @@ When the minimum age filter is active:
   - Searches up to 7 days after the age gate, however if still finding rapid releases it ignores stability check
   - Exact version requests (like `package@1.1.1`) still respect the age gate but bypass the stability check
 - Versions without a `time` field are treated as passing the age check (npm registry should always provide timestamps)
+- `minimumReleaseAgeExcludes` accepts two entry shapes:
+  - Bare package name (e.g. `"typescript"`) — whitelists every current and future version of the package.
+  - Pinned `name@version` (e.g. `"typescript@5.4.5"` or `"@types/node@20.11.0"`) — whitelists exactly that one version. Other versions of the same package continue to respect the age gate, so you can punch a hole for a single vetted release without permanently disabling the gate.
+  - Pinned entries must be an exact semver version. Ranges, dist-tags, and dangling values (e.g. `"typescript@^5"`, `"typescript@latest"`, `"typescript@"`) are silently ignored — they never match, so they can't accidentally widen the whitelist.
 
 For more advanced security scanning, including integration with services & custom filtering, see [Package manager > Security Scanner API](/pm/security-scanner-api).
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -747,13 +747,14 @@ For more details see [Minimum release age](/pm/cli/install#minimum-release-age) 
 
 ### `install.minimumReleaseAgeExcludes`
 
-An array of package names that are exempt from the `minimumReleaseAge` check. Default `[]`.
+An array of package entries that are exempt from the `minimumReleaseAge` check. Default `[]`.
+
+Entries are either a bare package name (whitelists every version) or a pinned `name@version` (whitelists exactly that one version). See [Minimum release age](/pm/cli/install#minimum-release-age) for the full rules.
 
 ```toml title="bunfig.toml" icon="settings"
 [install]
 minimumReleaseAge = 259200
-# These packages will bypass the 3-day minimum age requirement
-minimumReleaseAgeExcludes = ["@types/bun", "typescript"]
+minimumReleaseAgeExcludes = ["@types/bun", "typescript@5.4.5"]
 ```
 
 ## `bun run`

--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -767,7 +767,7 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
                                         if (version.tag == .npm and version.value.npm.version.isExact()) {
                                             if (loaded_manifest.?.findByVersion(version.value.npm.version.head.head.range.left.version)) |find_result| {
                                                 if (this.options.minimum_release_age_ms) |min_age_ms| {
-                                                    if (!loaded_manifest.?.shouldExcludeFromAgeFilter(this.options.minimum_release_age_excludes) and Npm.PackageManifest.isPackageVersionTooRecent(find_result.package, min_age_ms)) {
+                                                    if (!loaded_manifest.?.shouldExcludeFromAgeFilter(this.options.minimum_release_age_excludes) and loaded_manifest.?.isVersionFilteredByAge(find_result.version, find_result.package, min_age_ms, this.options.minimum_release_age_excludes)) {
                                                         const package_name = this.lockfile.str(&name);
                                                         const min_age_seconds = min_age_ms / std.time.ms_per_s;
                                                         this.log.addErrorFmt(null, logger.Loc.Empty, this.allocator, "Version \"{s}@{f}\" was published within minimum release age of {d} seconds", .{ package_name, find_result.version.fmt(this.lockfile.buffers.string_bytes.items), min_age_seconds }) catch {};

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -1355,13 +1355,53 @@ pub const PackageManifest = struct {
         return null;
     }
 
+    /// Split an entry from `minimumReleaseAgeExcludes` into `(name, version)`.
+    /// A null version means a bare entry (whitelists all versions). A dangling
+    /// `@` (e.g. `"foo@"`) is treated as a no-op rather than a bare name, so
+    /// malformed input can't silently widen the whitelist.
+    fn parseAgeFilterExclusion(entry: string) struct { string, ?string } {
+        if (entry.len > 0 and entry[entry.len - 1] == '@') return .{ entry, null };
+        return Dependency.splitNameAndMaybeVersion(entry);
+    }
+
+    /// Whether any bare `"name"` entry in `exclusions` matches this manifest.
+    /// `"name@version"` pins are handled by `isVersionExplicitlyExcluded`.
     pub fn shouldExcludeFromAgeFilter(this: *const PackageManifest, exclusions: ?[]const []const u8) bool {
-        if (exclusions) |excl| {
-            const pkg_name = this.name();
-            for (excl) |excluded| {
-                if (strings.eql(pkg_name, excluded)) {
-                    return true;
-                }
+        const excl = exclusions orelse return false;
+        const pkg_name = this.name();
+        for (excl) |entry| {
+            const entry_name, const entry_version = parseAgeFilterExclusion(entry);
+            if (entry_version != null) continue;
+            if (strings.eql(pkg_name, entry_name)) return true;
+        }
+        return false;
+    }
+
+    /// Whether `exclusions` contains a `"name@version"` pin matching this
+    /// manifest and `version` exactly. Non-exact pins (ranges, dist-tags,
+    /// unparseable values) are silently ignored.
+    pub fn isVersionExplicitlyExcluded(
+        this: *const PackageManifest,
+        version: Semver.Version,
+        exclusions: ?[]const []const u8,
+    ) bool {
+        const excl = exclusions orelse return false;
+        const pkg_name = this.name();
+        for (excl) |entry| {
+            const entry_name, const maybe_version = parseAgeFilterExclusion(entry);
+            const version_str = maybe_version orelse continue;
+            if (!strings.eql(pkg_name, entry_name)) continue;
+            const parsed = Semver.Version.parseUTF8(version_str);
+            // `parseUTF8` stops at the first whitespace/range operator so
+            // `"1.0.0 || 2.0.0"` would otherwise silently match `1.0.0` only.
+            // Require the parser to have consumed the entire pin — anything
+            // short of that is treated as malformed and skipped, failing
+            // closed.
+            if (!parsed.valid or parsed.wildcard != .none or parsed.len != version_str.len) continue;
+            // Build metadata is ignored in semver precedence (§10); match
+            // `findByVersion`'s `eql` semantics by excluding build tags too.
+            if (parsed.version.min().orderWithoutBuild(version, version_str, this.string_buf) == .eq) {
+                return true;
             }
         }
         return false;
@@ -1375,6 +1415,18 @@ pub const PackageManifest = struct {
         return package_version.publish_timestamp_ms > current_timestamp_ms - minimum_release_age_ms;
     }
 
+    /// `isPackageVersionTooRecent` minus versions explicitly pinned in `exclusions`.
+    pub inline fn isVersionFilteredByAge(
+        this: *const PackageManifest,
+        version: Semver.Version,
+        package_version: *const PackageVersion,
+        minimum_release_age_ms: f64,
+        exclusions: ?[]const []const u8,
+    ) bool {
+        if (!isPackageVersionTooRecent(package_version, minimum_release_age_ms)) return false;
+        return !this.isVersionExplicitlyExcluded(version, exclusions);
+    }
+
     fn searchVersionList(
         this: *const PackageManifest,
         versions: []const Semver.Version,
@@ -1382,6 +1434,7 @@ pub const PackageManifest = struct {
         group: Semver.Query.Group,
         group_buf: string,
         minimum_release_age_ms: f64,
+        exclusions: ?[]const []const u8,
         newest_filtered: *?Semver.Version,
     ) ?FindVersionResult {
         var prev_package_blocked_from_age: ?*const PackageVersion = null;
@@ -1397,6 +1450,15 @@ pub const PackageManifest = struct {
             const version = versions[i];
             if (group.satisfies(version, group_buf, this.string_buf)) {
                 const package = &packages[i];
+                // Pinned versions bypass both the age gate and the stability walk.
+                if (this.isVersionExplicitlyExcluded(version, exclusions)) {
+                    const pinned: FindResult = .{ .version = version, .package = package };
+                    if (newest_filtered.*) |nf| {
+                        return .{ .found_with_filter = .{ .result = pinned, .newest_filtered = nf } };
+                    }
+                    return .{ .found = pinned };
+                }
+                // Explicit-exclusion already ruled out above, so a plain age check is enough.
                 if (isPackageVersionTooRecent(package, minimum_release_age_ms)) {
                     if (newest_filtered.* == null) newest_filtered.* = version;
                     prev_package_blocked_from_age = package;
@@ -1500,7 +1562,7 @@ pub const PackageManifest = struct {
         const seven_days_ms: f64 = 7 * std.time.ms_per_day;
         const stability_window_ms = @min(min_age_ms, seven_days_ms);
 
-        const dist_too_recent = isPackageVersionTooRecent(dist_result.package, min_age_ms);
+        const dist_too_recent = this.isVersionFilteredByAge(dist_result.version, dist_result.package, min_age_ms, exclusions);
         if (!dist_too_recent) {
             return .{ .found = dist_result };
         }
@@ -1535,6 +1597,15 @@ pub const PackageManifest = struct {
                 if (!strings.eql(actual_tag, expected_tag)) continue;
             }
 
+            // Pinned versions bypass both the age gate and the stability walk.
+            if (this.isVersionExplicitlyExcluded(version, exclusions)) {
+                return .{ .found_with_filter = .{
+                    .result = .{ .version = version, .package = package },
+                    .newest_filtered = dist_result.version,
+                } };
+            }
+
+            // Explicit-exclusion already ruled out above, so a plain age check is enough.
             if (isPackageVersionTooRecent(package, min_age_ms)) {
                 prev_package_blocked_from_age = package;
                 continue;
@@ -1603,7 +1674,7 @@ pub const PackageManifest = struct {
         if (left.op == .eql) {
             const result = this.findByVersion(left.version);
             if (result) |r| {
-                if (isPackageVersionTooRecent(r.package, min_age_ms)) {
+                if (this.isVersionFilteredByAge(r.version, r.package, min_age_ms, exclusions)) {
                     return .{ .err = .too_recent };
                 }
                 return .{ .found = r };
@@ -1613,7 +1684,7 @@ pub const PackageManifest = struct {
 
         if (this.findByDistTag("latest")) |result| {
             if (group.satisfies(result.version, group_buf, this.string_buf)) {
-                if (isPackageVersionTooRecent(result.package, min_age_ms)) {
+                if (this.isVersionFilteredByAge(result.version, result.package, min_age_ms, exclusions)) {
                     newest_filtered = result.version;
                 }
                 if (newest_filtered == null) {
@@ -1634,6 +1705,7 @@ pub const PackageManifest = struct {
             group,
             group_buf,
             min_age_ms,
+            exclusions,
             &newest_filtered,
         )) |result| {
             return result;
@@ -1646,6 +1718,7 @@ pub const PackageManifest = struct {
                 group,
                 group_buf,
                 min_age_ms,
+                exclusions,
                 &newest_filtered,
             )) |result| {
                 return result;
@@ -2744,6 +2817,7 @@ const ObjectPool = @import("../collections/pool.zig").ObjectPool;
 const URL = @import("../url/url.zig").URL;
 
 const Aligner = @import("./install.zig").Aligner;
+const Dependency = @import("./install.zig").Dependency;
 const ExternalSlice = @import("./install.zig").ExternalSlice;
 const ExternalStringList = @import("./install.zig").ExternalStringList;
 const ExternalStringMap = @import("./install.zig").ExternalStringMap;

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -1233,6 +1233,337 @@ registry = "${mockRegistryUrl}"`,
       expect(lockfile).toContain("regular-package@2.1.0");
       expect(lockfile).not.toContain("regular-package@3.0.0");
     });
+
+    // Regression test for https://github.com/oven-sh/bun/issues/28967 —
+    // `minimumReleaseAgeExcludes` should accept `name@version` entries
+    // that whitelist exactly one version without opening the door to
+    // every future release of the same package.
+    test("name@version exclusion whitelists only the pinned version", async () => {
+      using dir = tempDir("exclusions-version-pinned", {
+        "package.json": JSON.stringify({
+          dependencies: {
+            "excluded-package": "*",
+          },
+        }),
+        "bunfig.toml": `[install]
+minimumReleaseAge = ${5 * SECONDS_PER_DAY}
+minimumReleaseAgeExcludes = ["excluded-package@1.0.1"]
+registry = "${mockRegistryUrl}"`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      // 1.0.1 is 12h old (would normally be filtered) but is explicitly
+      // whitelisted by the `@1.0.1` pin.
+      expect(lockfile).toContain("excluded-package@1.0.1");
+      expect(lockfile).not.toContain("excluded-package@1.0.0");
+      expect(exitCode).toBe(0);
+    });
+
+    test("name@version exclusion does not whitelist other versions of the same package", async () => {
+      using dir = tempDir("exclusions-wrong-version", {
+        "package.json": JSON.stringify({
+          dependencies: {
+            "excluded-package": "*",
+          },
+        }),
+        // Pinning 0.9.0 (which doesn't exist on the mock registry) must
+        // NOT leak the age-gate bypass to the real 1.0.1 release.
+        "bunfig.toml": `[install]
+minimumReleaseAge = ${5 * SECONDS_PER_DAY}
+minimumReleaseAgeExcludes = ["excluded-package@0.9.0"]
+registry = "${mockRegistryUrl}"`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      // The pin is for a version that doesn't exist, so the age gate
+      // stays in effect and we fall back to 1.0.0 (10 days old).
+      expect(lockfile).toContain("excluded-package@1.0.0");
+      expect(lockfile).not.toContain("excluded-package@1.0.1");
+      expect(exitCode).toBe(0);
+    });
+
+    // Malformed entries (dangling '@', dist-tags, ranges, truncated
+    // "range-or" lists) must be treated as no-ops — parser guard that
+    // prevents a future regression from silently widening the whitelist.
+    //
+    // `"excluded-package@1.0.1 || 0.9.0"` is the trickiest: `parseUTF8`
+    // stops at the space, so without a `parsed.len == version_str.len`
+    // check it'd silently pin 1.0.1 (the too-recent version, so a
+    // regression here is detectable — the lockfile would flip from
+    // 1.0.0 to 1.0.1). The test asserts that entry is rejected as
+    // malformed and the age gate stays in force.
+    test("malformed name@... exclusions are silently ignored", async () => {
+      using dir = tempDir("exclusions-malformed", {
+        "package.json": JSON.stringify({
+          dependencies: { "excluded-package": "*" },
+        }),
+        "bunfig.toml": `[install]
+minimumReleaseAge = ${5 * SECONDS_PER_DAY}
+minimumReleaseAgeExcludes = ["excluded-package@", "excluded-package@latest", "excluded-package@^1", "excluded-package@1.0.1 || 0.9.0"]
+registry = "${mockRegistryUrl}"`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      // None of the malformed entries parse as an exact version, so the
+      // age gate stays in force and the install picks the older stable
+      // 1.0.0 rather than the too-recent 1.0.1.
+      expect(lockfile).toContain("excluded-package@1.0.0");
+      expect(lockfile).not.toContain("excluded-package@1.0.1");
+      expect(exitCode).toBe(0);
+    });
+
+    test("scoped name@version exclusion whitelists only the pinned version", async () => {
+      using dir = tempDir("exclusions-scoped-pinned", {
+        "package.json": JSON.stringify({
+          dependencies: {
+            "@scope/scoped-package": "*",
+          },
+        }),
+        "bunfig.toml": `[install]
+minimumReleaseAge = ${5 * SECONDS_PER_DAY}
+minimumReleaseAgeExcludes = ["@scope/scoped-package@2.0.0"]
+registry = "${mockRegistryUrl}"`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      // 2.0.0 is 1 day old (would be filtered) but is explicitly
+      // whitelisted. Without the pin, the install would pick 1.5.0.
+      expect(lockfile).toContain("@scope/scoped-package@2.0.0");
+      expect(lockfile).not.toContain("@scope/scoped-package@1.5.0");
+      expect(exitCode).toBe(0);
+    });
+
+    test("bare scoped name exclusion still whitelists every version", async () => {
+      using dir = tempDir("exclusions-scoped-bare", {
+        "package.json": JSON.stringify({
+          dependencies: {
+            "@scope/scoped-package": "*",
+          },
+        }),
+        "bunfig.toml": `[install]
+minimumReleaseAge = ${5 * SECONDS_PER_DAY}
+minimumReleaseAgeExcludes = ["@scope/scoped-package"]
+registry = "${mockRegistryUrl}"`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      // Bare name bypass — picks the 1-day-old latest.
+      expect(lockfile).toContain("@scope/scoped-package@2.0.0");
+      expect(exitCode).toBe(0);
+    });
+
+    // Regression test for the stability-check leapfrog bug flagged in
+    // #28970 review: pinning a too-recent version must not cause the
+    // install to walk past it to an older naturally-stable version.
+    //
+    // bugfix-package with a 1.8 day age gate:
+    //   1.0.3 (0.5d):       BLOCKED (too recent)
+    //   1.0.2 (1.5d):       BLOCKED (too recent) — PINNED as exclusion
+    //   1.0.1 (2.5d):       would be picked as unstable stability anchor
+    //                       (gap to 1.0.2 = 1d < 1.8d), then...
+    //   1.0.0 (8d):         ...would be picked as the "stable" version
+    //                       since gap to 1.0.1 = 5.5d ≥ 1.8d
+    //
+    // Without the short-circuit, the naive walker leapfrogs all the way
+    // to 1.0.0 instead of returning the pinned 1.0.2.
+    test("name@version exclusion short-circuits the stability check", async () => {
+      using dir = tempDir("exclusions-stability-pinned", {
+        "package.json": JSON.stringify({
+          dependencies: { "bugfix-package": "*" },
+        }),
+        "bunfig.toml": `[install]
+minimumReleaseAge = ${1.8 * SECONDS_PER_DAY}
+minimumReleaseAgeExcludes = ["bugfix-package@1.0.2"]
+registry = "${mockRegistryUrl}"`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      expect(lockfile).toContain("bugfix-package@1.0.2");
+      expect(lockfile).not.toContain("bugfix-package@1.0.0");
+      expect(lockfile).not.toContain("bugfix-package@1.0.1");
+      expect(exitCode).toBe(0);
+    });
+
+    // Regression test for the naturally-old pin case: a pinned version
+    // that has *already passed* the age gate must still be honored even
+    // when newer blocked versions have set prev_package_blocked_from_age
+    // — otherwise the stability check can leapfrog right over it.
+    //
+    // bugfix-package with a 1.8 day age gate, PINNED bugfix-package@1.0.1:
+    //   1.0.3 (0.5d):       BLOCKED (too recent) → prev_blocked = 1.0.3
+    //   1.0.2 (1.5d):       BLOCKED (too recent) → prev_blocked = 1.0.2
+    //   1.0.1 (2.5d, PIN):  naturally passes the age gate. Without the
+    //                       fix, the short-circuit (which required
+    //                       `isPackageVersionTooRecent`) misses it, and
+    //                       the stability check runs — gap to 1.0.2 is
+    //                       1d < 1.8d → unstable → best=1.0.1,
+    //                       prev_blocked=1.0.1.
+    //   1.0.0 (8d):         gap to 1.0.1 = 5.5d ≥ 1.8d → "stable" →
+    //                       best=1.0.0, break. Returns 1.0.0.
+    //
+    // With the fix, `isVersionExplicitlyExcluded` alone short-circuits
+    // to 1.0.1 and the install lands on the pinned version.
+    test("naturally-old pinned version is not leapfrogged", async () => {
+      using dir = tempDir("exclusions-natural-pinned", {
+        "package.json": JSON.stringify({
+          dependencies: { "bugfix-package": "*" },
+        }),
+        "bunfig.toml": `[install]
+minimumReleaseAge = ${1.8 * SECONDS_PER_DAY}
+minimumReleaseAgeExcludes = ["bugfix-package@1.0.1"]
+registry = "${mockRegistryUrl}"`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      expect(lockfile).toContain("bugfix-package@1.0.1");
+      expect(lockfile).not.toContain("bugfix-package@1.0.0");
+      expect(exitCode).toBe(0);
+    });
+
+    // The previous tests all use `"*"` which routes through
+    // `findBestVersionWithFilter` → `searchVersionList`. Dist-tag specs
+    // (e.g. `"latest"`) take a separate path via `findByDistTagWithFilter`
+    // which has its own pinned-exclusion short-circuit — cover that path
+    // explicitly so a refactor can't silently break it.
+    //
+    // Same shape as "name@version exclusion short-circuits the stability
+    // check" (pin 1.0.2, 1.8d gate, 1.0.3 blocks), but the dependency is
+    // the `latest` dist-tag instead of `*`.
+    test("name@version exclusion works on dist-tag dependency", async () => {
+      using dir = tempDir("exclusions-dist-tag-pinned", {
+        "package.json": JSON.stringify({
+          dependencies: { "bugfix-package": "latest" },
+        }),
+        "bunfig.toml": `[install]
+minimumReleaseAge = ${1.8 * SECONDS_PER_DAY}
+minimumReleaseAgeExcludes = ["bugfix-package@1.0.2"]
+registry = "${mockRegistryUrl}"`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      // Dist-tag `latest` = 1.0.3 (too recent). Without the pin, the
+      // walker falls through to 1.0.0. The pin on 1.0.2 short-circuits
+      // the stability walk and lands on 1.0.2.
+      expect(lockfile).toContain("bugfix-package@1.0.2");
+      expect(lockfile).not.toContain("bugfix-package@1.0.0");
+      expect(lockfile).not.toContain("bugfix-package@1.0.1");
+      expect(exitCode).toBe(0);
+    });
+
+    // Exact-version deps (`"excluded-package": "1.0.1"`) take the
+    // `left.op == .eql` branch in `findBestVersionWithFilter` and the
+    // cached-manifest fast-path in `PackageManagerEnqueue`. Both call
+    // `isVersionFilteredByAge` — if either reverts to the raw
+    // `isPackageVersionTooRecent` check, a pin can no longer bypass the
+    // age gate for an exact-version dependency. Without this test a
+    // regression would be silent.
+    test("name@version exclusion bypasses age gate on exact-version dependency", async () => {
+      using dir = tempDir("exclusions-exact-version-pinned", {
+        "package.json": JSON.stringify({
+          dependencies: { "excluded-package": "1.0.1" },
+        }),
+        "bunfig.toml": `[install]
+minimumReleaseAge = ${5 * SECONDS_PER_DAY}
+minimumReleaseAgeExcludes = ["excluded-package@1.0.1"]
+registry = "${mockRegistryUrl}"`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      // 1.0.1 is 12h old — without the pin, the install would fail
+      // with `too_recent`. The pin makes it pass.
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      expect(lockfile).toContain("excluded-package@1.0.1");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("configuration", () => {


### PR DESCRIPTION
## What

Closes #28967.

Lets `minimumReleaseAgeExcludes` whitelist individual versions instead of an entire package.

```toml
[install]
minimumReleaseAge = 86400
minimumReleaseAgeExcludes = [
  "@types/node",                 # (unchanged) bypass every version
  "@types/node@20.11.0",         # (new) bypass exactly one vetted version
  "typescript@5.4.5",            # (new) works for unscoped packages too
]
```

Bare names keep their existing behaviour — full backwards compat. Pinned `name@version` entries let users punch a hole for exactly one version they've audited without permanently disabling the gate for every future release of the package.

## Why

Today, if you whitelist `@types/node` to bypass the age gate, every future version of `@types/node` also slips past the delay. That defeats the point of the feature if the whitelist isn't promptly removed after the patch that triggered it — the original security case for [#28967](https://github.com/oven-sh/bun/issues/28967).

## How

- `shouldExcludeFromAgeFilter` in `src/install/npm.zig` now only matches bare-name entries, so the whole-package bypass short-circuit at the top of `findByDistTagWithFilter` / `findBestVersionWithFilter` still fires for them.
- New `isVersionExplicitlyExcluded(version, exclusions)` parses each entry lazily as `name[@version]` (scoped names start with `@`, so the version separator is the *last* `@`), then semver-compares the pin against the candidate version using the respective string buffers.
- New `isVersionFilteredByAge(version, pkg, min_age_ms, exclusions)` wraps `isPackageVersionTooRecent` so a too-recent-but-pinned version is reported as not filtered. Replaces every per-version age check inside `searchVersionList`, both filter loops, and the exact-version fast path in `PackageManagerEnqueue.zig`.
- Dangling/malformed entries (`foo@`, `foo@^1.0.0`, unparsable strings) are silently no-ops — they never match, so they can't accidentally widen the whitelist.

## Tests

Added four new tests to `test/cli/install/minimum-release-age.test.ts` under the existing `exclusions` describe block:

1. `name@version` whitelists only the pinned version (fails on `main`).
2. Unmatched `name@version` does not leak the bypass to other versions (regression guard).
3. Scoped `@scope/name@version` whitelists only the pinned version (fails on `main`).
4. Bare `@scope/name` continues to whitelist every version (backwards compat).

## Verification

```
bun bd test test/cli/install/minimum-release-age.test.ts
...
 52 pass
 0 fail

USE_SYSTEM_BUN=1 bun test minimum-release-age.test.ts -t exclusions
 3 pass
 2 fail   # ← the two name@version tests fail on the released build, confirming the fix exercises them
```

Docs updated at `docs/pm/cli/install.mdx` and `docs/runtime/bunfig.mdx`.