### PR TITLE
install: fix explosion of peers in isolated install resolution

### DIFF
--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -43,11 +43,49 @@ pub fn installIsolatedPackages(
         var dep_ids_sort_buf: std.ArrayListUnmanaged(DependencyID) = .empty;
         defer dep_ids_sort_buf.deinit(lockfile.allocator);
 
-        // Used by leaves and linked dependencies. They can be deduplicated early
-        // because peers won't change them.
-        //
-        // In the pnpm repo without this map: 772,471 nodes
-        //                 and with this map: 314,022 nodes
+        // Pre-compute which packages have peer dependencies anywhere in their
+        // transitive dependency closure. Packages without transitive peers will
+        // produce identical subtrees regardless of where they appear in the tree,
+        // so they can be safely deduplicated in the first pass.
+        var has_transitive_peers = try bun.bit_set.DynamicBitSetUnmanaged.initEmpty(lockfile.allocator, lockfile.packages.len);
+        defer has_transitive_peers.deinit(lockfile.allocator);
+
+        // Mark packages that directly have peer deps
+        for (0..lockfile.packages.len) |pkg_idx| {
+            const pkg_id: PackageID = @intCast(pkg_idx);
+            const deps = pkg_dependency_slices[pkg_id];
+            for (deps.begin()..deps.end()) |dep_idx| {
+                if (dependencies[dep_idx].behavior.isPeer()) {
+                    has_transitive_peers.set(pkg_id);
+                    break;
+                }
+            }
+        }
+
+        // Propagate: if any resolved dep has transitive peers, mark the parent too
+        {
+            var changed = true;
+            while (changed) {
+                changed = false;
+                for (0..lockfile.packages.len) |pkg_idx| {
+                    const pkg_id: PackageID = @intCast(pkg_idx);
+                    if (has_transitive_peers.isSet(pkg_id)) continue;
+                    const deps = pkg_dependency_slices[pkg_id];
+                    for (deps.begin()..deps.end()) |dep_idx| {
+                        const res_pkg = resolutions[dep_idx];
+                        if (res_pkg != invalid_package_id and has_transitive_peers.isSet(res_pkg)) {
+                            has_transitive_peers.set(pkg_id);
+                            changed = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Packages that are peer-free (no peers in transitive closure) can be
+        // deduplicated early because their subtrees are identical regardless of
+        // position in the tree.
         var early_dedupe: std.AutoHashMap(PackageID, Store.Node.Id) = .init(lockfile.allocator);
         defer early_dedupe.deinit();
 
@@ -113,7 +151,7 @@ pub fn installIsolatedPackages(
 
             if (entry.dep_id != invalid_dependency_id) {
                 const entry_dep = dependencies[entry.dep_id];
-                if (pkg_deps.len == 0 or entry_dep.version.tag == .workspace) dont_dedupe: {
+                if (pkg_deps.len == 0 or entry_dep.version.tag == .workspace or !has_transitive_peers.isSet(entry.pkg_id)) dont_dedupe: {
                     const dedupe_entry = try early_dedupe.getOrPut(entry.pkg_id);
                     if (dedupe_entry.found_existing) {
                         const dedupe_node_id = dedupe_entry.value_ptr.*;


### PR DESCRIPTION
### What does this PR do?
Pre-compute which packages have peer dependencies in their transitive closure. Packages without transitive peers produce identical subtrees regardless of position in the tree, so they can be safely deduplicated during the first pass instead of waiting for the second pass.

Previously, only leaf packages (no dependencies) were eligible for early deduplication. Non-leaf peer-free packages like @babel/types would create millions of redundant nodes — e.g. 27M nodes / 2min collapsing to just 3,356 entries in the second pass. With this change, the same lockfile produces ~1.4M nodes in ~9s (in debug build).


I haven't verified the code here too closely (mostly generated by Opus 4.6), but the idea seems sane to me and the results to speak for themselves, but please do modify or change the implementation if it's not up to par😄 

## Benchmark

On my device:
> MacBook Pro M2 pro 32GB
> MacOS 26.3.1

**Previously**: 
```sh
$ bun i
bun install v1.3.11 (af24e281)

Checked 3356 installs across 3538 packages (no changes) [33.51s]
```

**Now**:
```sh
$ bun-new i
bun install v1.3.12-canary.1 (5b782c9c)

Checked 3356 installs across 3538 packages (no changes) [720.00ms]
```

I suspect my lockfile hit an especially egregious case of this (looks like `@babel/types` was one of the worst offenders in my case), but I would assume this change would cause massive speedups for many other lockfiles using isolated installs. 
My own repo was not even close to this fast even before I had the updates that hit this issue especially bad, around 5s with no changes on my machine if my memory serves right).

This should fix #22846 

### How did you verify your code works?

I ran tests and `bun i` on my own repo.
