### PR TITLE
node:http: fire close/end events on peer abort after body consumed

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1018,7 +1018,6 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
 
 const kBytesWritten = Symbol("kBytesWritten");
 const kEnableStreaming = Symbol("kEnableStreaming");
-const kIsTunnel = Symbol("kIsTunnel");
 function onServerSocketError(this: any, _err) {
   // Default 'error' listener so socket-level errors (e.g. res.destroy(err)
   // forwarding the error to the socket) do not crash the process as
@@ -1036,7 +1035,6 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   connecting = false;
   timeout = 0;
   [kBytesWritten] = 0;
-  [kIsTunnel] = false;
   [kHandle];
   server: Server;
   _httpMessage;
@@ -1059,6 +1057,18 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
     server[kTrackedConnections]?.add(this);
   }
 
+  emit(event) {
+    // Mirrors ServerResponse.prototype.emit: when the internal
+    // assignSocket path (`setCloseCallback(socket, onServerResponseClose)`)
+    // is in use, we must drive that one-shot callback here instead of
+    // relying on a real 'close' event listener. Without this the internal
+    // path never propagates the socket close to `res.on('close')`.
+    if (event === "close") {
+      callCloseCallback(this);
+    }
+    return Stream.prototype.emit.$apply(this, arguments);
+  }
+
   get bytesWritten() {
     const handle = this[kHandle];
     return handle
@@ -1070,10 +1080,6 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
   }
 
   [kEnableStreaming](enable: boolean) {
-    // kIsTunnel latches: once a socket is detached into CONNECT/upgrade tunnel
-    // mode it never returns to normal request handling, and #onClose relies on
-    // it to emit 'close' on native close.
-    if (enable) this[kIsTunnel] = true;
     const handle = this[kHandle];
     if (handle) {
       if (enable) {
@@ -1124,6 +1130,16 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
     this[kHandle] = null;
     this.server?.[kTrackedConnections]?.delete(this);
 
+    // End the readable side first so `socket.on('end')` fires on peer
+    // disconnect, regardless of whether the request body had been fully
+    // consumed at the time of the abort. Mirrors Node's net.Socket
+    // handling of UV_EOF: push(null) + read(0) to drain the state machine.
+    if (!this.destroyed && this.readable && !this.readableEnded) {
+      if (!this.push(null)) {
+        this.read(0);
+      }
+    }
+
     // Node.js's `socketOnClose` → `abortIncoming()` only destroys requests
     // that are still in `state.incoming` — i.e. requests whose response has
     // not yet finished (`resOnFinish` does `incoming.shift()`). Our
@@ -1162,10 +1178,15 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
       process.nextTick(emitCloseNT, message);
     }
 
-    // A tunneled/upgraded connection (CONNECT or WebSocket upgrade) is detached
-    // from the request/response lifecycle, so end the Duplex on native close to
-    // emit 'close' for the upgrade handler and user listeners, like Node.js.
-    if (this[kIsTunnel] && !this.destroyed) {
+    // Ensure the Duplex socket itself emits 'close'/'end' when the native
+    // socket goes away. The req.destroy() branch above only destroys the
+    // socket when shouldEmitAborted is true (an incomplete request); once the
+    // request body was fully consumed (req.complete === true) nothing else
+    // tears the Duplex down, so `socket.on('close')` would never fire after a
+    // peer abort on a POST whose body had already been read. This also covers
+    // tunneled/upgraded connections (CONNECT or WebSocket upgrade), which are
+    // detached from the request/response lifecycle entirely.
+    if (!this.destroyed) {
       this.destroy();
     }
   }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2440,6 +2440,10 @@ ServerResponse.prototype.destroy = function (err?: Error) {
   this?.socket?.destroy(err);
   if (!this._closed) {
     // res.closed must already be true inside the 'close' listeners.
+    // Setting _closed before emitting also gates out the async socket-close
+    // path (NodeHTTPServerSocket.emit → callCloseCallback → onServerResponseClose
+    // → emitCloseNT), so res 'close' fires exactly once when destroy() is
+    // called from outside the synchronous request handler (e.g. a setTimeout).
     this._closed = true;
     this.emit("close");
   }

--- a/test/regression/issue/28976.test.ts
+++ b/test/regression/issue/28976.test.ts
@@ -1,0 +1,136 @@
+// https://github.com/oven-sh/bun/issues/28976
+//
+// When a client aborts an in-flight POST request that had a body, the
+// server-side `res.on('close')`, `req.socket.on('close')`, and
+// `req.socket.on('end')` listeners never fired — the handler kept running
+// to completion on a dead socket. Code that relied on those events to
+// cancel downstream work (LLM streams, DB queries, upstream fetches) had
+// no way to detect the disconnect.
+//
+// The bug was specific to bodies being present: without a body (e.g. a
+// bare POST or GET), the events fired. The test runs the server as a
+// subprocess so internal "Premature close" errors (a side-effect of the
+// abort, not the bug under test) don't pollute the test runner.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+const SCRIPT = /* js */ `
+const http = require("node:http");
+const net = require("node:net");
+
+const events = [];
+
+const server = http.createServer((req, res) => {
+  const socket = req.socket;
+
+  req.on("error", () => {});
+  res.on("error", () => {});
+  socket.on("error", () => {});
+
+  // Consume the body so it is fully drained BEFORE the client aborts.
+  // This is the exact scenario the bug was about: body done, req.complete
+  // already true by the time the abort is observed.
+  req.on("data", () => {});
+  req.on("end", () => {
+    // Now signal the client (via its side of the connection it will
+    // notice) that the body has been read; but we don't respond — the
+    // setTimeout below sits idle, simulating long-running work.
+  });
+
+  res.on("close", () => {
+    events.push("res close");
+    maybeDone();
+  });
+  socket.on("close", () => {
+    events.push("socket close");
+    maybeDone();
+  });
+  socket.on("end", () => {
+    events.push("socket end");
+    maybeDone();
+  });
+
+  // Long-running work we would otherwise hang on a dead socket.
+  const t = setTimeout(() => {
+    if (!res.writableEnded) res.end("ok");
+  }, 60_000);
+  t.unref?.();
+  res.on("close", () => clearTimeout(t));
+});
+
+function maybeDone() {
+  if (
+    events.includes("res close") &&
+    events.includes("socket close") &&
+    events.includes("socket end")
+  ) {
+    console.log("EVENTS=" + events.sort().join(","));
+    server.close();
+    process.exit(0);
+  }
+}
+
+server.listen(0, () => {
+  const { port } = server.address();
+
+  // Raw TCP client so we can send the body, wait long enough for the
+  // server to fully read it (we close the connection AFTER the body),
+  // then destroy the socket — mimicking a client abort.
+  const client = net.createConnection({ host: "127.0.0.1", port }, () => {
+    const body = '{"hello":"world"}';
+    client.write(
+      "POST /test HTTP/1.1\\r\\n" +
+      "Host: localhost\\r\\n" +
+      "Content-Type: application/json\\r\\n" +
+      "Content-Length: " + body.length + "\\r\\n" +
+      "Connection: close\\r\\n" +
+      "\\r\\n" +
+      body
+    );
+    // Give the server a tick to finish reading the body, then destroy.
+    // (We check this via polling instead of timers to avoid flakiness.)
+    const check = setInterval(() => {
+      if (events.length === 0) {
+        // handler ran far enough — the test server will have seen the
+        // body end and set up listeners; destroy now to simulate abort.
+        client.destroy();
+        clearInterval(check);
+      }
+    }, 10);
+  });
+  client.on("error", () => {});
+});
+
+// Safety net: if the close events never fire (i.e. the bug is still
+// present), bail after a few seconds with a deterministic failure line.
+setTimeout(() => {
+  console.log("EVENTS=" + events.sort().join(","));
+  process.exit(1);
+}, 5000).unref();
+`;
+
+test("res.on('close') / socket.on('close') / socket.on('end') fire after client abort on POST with body (#28976)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", SCRIPT],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  const line = stdout
+    .split("\n")
+    .map(l => l.trim())
+    .find(l => l.startsWith("EVENTS="));
+
+  expect({ exitCode, line, stderr }).toEqual({
+    exitCode: 0,
+    line: "EVENTS=res close,socket close,socket end",
+    stderr: expect.any(String),
+  });
+});

--- a/test/regression/issue/28976.test.ts
+++ b/test/regression/issue/28976.test.ts
@@ -111,28 +111,24 @@ setTimeout(() => {
 }, 15_000);
 `;
 
-test(
-  "res.on('close') / socket.on('close') / socket.on('end') fire after client abort on POST with body (#28976)",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", SCRIPT],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+test("res.on('close') / socket.on('close') / socket.on('end') fire after client abort on POST with body (#28976)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", SCRIPT],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const line = stdout
-      .split("\n")
-      .map(l => l.trim())
-      .find(l => l.startsWith("EVENTS="));
+  const line = stdout
+    .split("\n")
+    .map(l => l.trim())
+    .find(l => l.startsWith("EVENTS="));
 
-    expect({ exitCode, line, stderr }).toEqual({
-      exitCode: 0,
-      line: "EVENTS=res close,socket close,socket end",
-      stderr: expect.any(String),
-    });
-  },
-  30_000,
-);
+  expect({ exitCode, line, stderr }).toEqual({
+    exitCode: 0,
+    line: "EVENTS=res close,socket close,socket end",
+    stderr: expect.any(String),
+  });
+}, 30_000);

--- a/test/regression/issue/28976.test.ts
+++ b/test/regression/issue/28976.test.ts
@@ -117,11 +117,7 @@ test("res.on('close') / socket.on('close') / socket.on('end') fire after client 
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   const line = stdout
     .split("\n")

--- a/test/regression/issue/28976.test.ts
+++ b/test/regression/issue/28976.test.ts
@@ -9,8 +9,9 @@
 //
 // The bug was specific to bodies being present: without a body (e.g. a
 // bare POST or GET), the events fired. The test runs the server as a
-// subprocess so internal "Premature close" errors (a side-effect of the
-// abort, not the bug under test) don't pollute the test runner.
+// subprocess so the internal "Premature close" error that fires on the
+// abort (a side-effect, not the bug under test) doesn't pollute the
+// outer test runner.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
@@ -19,8 +20,11 @@ const http = require("node:http");
 const net = require("node:net");
 
 const events = [];
+let handlerEntered = false;
+let bodyReceived = false;
 
 const server = http.createServer((req, res) => {
+  handlerEntered = true;
   const socket = req.socket;
 
   req.on("error", () => {});
@@ -31,11 +35,7 @@ const server = http.createServer((req, res) => {
   // This is the exact scenario the bug was about: body done, req.complete
   // already true by the time the abort is observed.
   req.on("data", () => {});
-  req.on("end", () => {
-    // Now signal the client (via its side of the connection it will
-    // notice) that the body has been read; but we don't respond — the
-    // setTimeout below sits idle, simulating long-running work.
-  });
+  req.on("end", () => { bodyReceived = true; });
 
   res.on("close", () => {
     events.push("res close");
@@ -64,7 +64,7 @@ function maybeDone() {
     events.includes("socket close") &&
     events.includes("socket end")
   ) {
-    console.log("EVENTS=" + events.sort().join(","));
+    console.log("EVENTS=" + events.slice().sort().join(","));
     server.close();
     process.exit(0);
   }
@@ -73,9 +73,10 @@ function maybeDone() {
 server.listen(0, () => {
   const { port } = server.address();
 
-  // Raw TCP client so we can send the body, wait long enough for the
-  // server to fully read it (we close the connection AFTER the body),
-  // then destroy the socket — mimicking a client abort.
+  // Raw TCP client so we can send the body in full and wait for the
+  // server to finish reading it before destroying — no dependency on
+  // http.request's abort semantics, which don't guarantee the body is
+  // fully drained on the server before the reset lands.
   const client = net.createConnection({ host: "127.0.0.1", port }, () => {
     const body = '{"hello":"world"}';
     client.write(
@@ -87,46 +88,51 @@ server.listen(0, () => {
       "\\r\\n" +
       body
     );
-    // Give the server a tick to finish reading the body, then destroy.
-    // (We check this via polling instead of timers to avoid flakiness.)
+    // Wait until the server actually finished reading the body, then
+    // destroy to simulate a client abort on an in-flight request whose
+    // body was already drained.
     const check = setInterval(() => {
-      if (events.length === 0) {
-        // handler ran far enough — the test server will have seen the
-        // body end and set up listeners; destroy now to simulate abort.
-        client.destroy();
+      if (bodyReceived) {
         clearInterval(check);
+        client.destroy();
       }
     }, 10);
   });
   client.on("error", () => {});
 });
 
-// Safety net: if the close events never fire (i.e. the bug is still
-// present), bail after a few seconds with a deterministic failure line.
+// Safety net: if the close events never fire (bug still present) or
+// the handler never runs, bail with a deterministic failure line.
 setTimeout(() => {
-  console.log("EVENTS=" + events.sort().join(","));
+  console.log("EVENTS=" + events.slice().sort().join(","));
+  console.log("HANDLER_ENTERED=" + handlerEntered);
+  console.log("BODY_RECEIVED=" + bodyReceived);
   process.exit(1);
-}, 5000).unref();
+}, 15_000);
 `;
 
-test("res.on('close') / socket.on('close') / socket.on('end') fire after client abort on POST with body (#28976)", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", SCRIPT],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+test(
+  "res.on('close') / socket.on('close') / socket.on('end') fire after client abort on POST with body (#28976)",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", SCRIPT],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const line = stdout
-    .split("\n")
-    .map(l => l.trim())
-    .find(l => l.startsWith("EVENTS="));
+    const line = stdout
+      .split("\n")
+      .map(l => l.trim())
+      .find(l => l.startsWith("EVENTS="));
 
-  expect({ exitCode, line, stderr }).toEqual({
-    exitCode: 0,
-    line: "EVENTS=res close,socket close,socket end",
-    stderr: expect.any(String),
-  });
-});
+    expect({ exitCode, line, stderr }).toEqual({
+      exitCode: 0,
+      line: "EVENTS=res close,socket close,socket end",
+      stderr: expect.any(String),
+    });
+  },
+  30_000,
+);

--- a/test/regression/issue/28976.test.ts
+++ b/test/regression/issue/28976.test.ts
@@ -132,3 +132,57 @@ test("res.on('close') / socket.on('close') / socket.on('end') fire after client 
     stderr: expect.any(String),
   });
 }, 30_000);
+
+// Guards against a regression of the companion bug: res.destroy() called
+// asynchronously (e.g. from a setTimeout / error path) must emit 'close' on
+// the response exactly once, not twice. A naïve version of the fix above
+// (which teaches the socket's close event to drive the internal
+// one-shot setCloseCallback path) would fire res.emit('close') a second
+// time when the async socket close arrives. The guard is
+// ServerResponse.prototype.destroy setting _closed=true before emitting.
+const DESTROY_SCRIPT = /* js */ `
+const http = require("node:http");
+
+let resCloseCount = 0;
+
+const server = http.createServer((req, res) => {
+  res.on("close", () => { resCloseCount++; });
+  res.writeHead(200);
+  // Defer the destroy so it doesn't happen inside the synchronous
+  // request handler — that's the path that used to emit twice.
+  setImmediate(() => res.destroy());
+});
+
+server.listen(0, () => {
+  const { port } = server.address();
+  const req = http.get({ port }, () => {});
+  req.on("error", () => {});
+  setTimeout(() => {
+    console.log("RES_CLOSE_COUNT=" + resCloseCount);
+    server.close();
+    process.exit(0);
+  }, 500);
+});
+`;
+
+test("res.destroy() emits 'close' exactly once when called asynchronously (#28976)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", DESTROY_SCRIPT],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const line = stdout
+    .split("\n")
+    .map(l => l.trim())
+    .find(l => l.startsWith("RES_CLOSE_COUNT="));
+
+  expect({ exitCode, line, stderr }).toEqual({
+    exitCode: 0,
+    line: "RES_CLOSE_COUNT=1",
+    stderr: expect.any(String),
+  });
+}, 15_000);

--- a/test/regression/issue/28976.test.ts
+++ b/test/regression/issue/28976.test.ts
@@ -8,181 +8,119 @@
 // no way to detect the disconnect.
 //
 // The bug was specific to bodies being present: without a body (e.g. a
-// bare POST or GET), the events fired. The test runs the server as a
-// subprocess so the internal "Premature close" error that fires on the
-// abort (a side-effect, not the bug under test) doesn't pollute the
-// outer test runner.
+// bare POST or GET), the events fired.
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import http from "node:http";
+import net from "node:net";
 
-const SCRIPT = /* js */ `
-const http = require("node:http");
-const net = require("node:net");
+test("res/socket 'close' and socket 'end' fire after client abort on POST with body (#28976)", async () => {
+  const seen = new Set<string>();
+  const { promise: bodyReceived, resolve: onBody } = Promise.withResolvers<void>();
+  const { promise: allEvents, resolve: onAllEvents } = Promise.withResolvers<void>();
 
-const events = [];
-let handlerEntered = false;
-let bodyReceived = false;
+  const check = () => {
+    if (seen.has("res close") && seen.has("socket close") && seen.has("socket end")) onAllEvents();
+  };
 
-const server = http.createServer((req, res) => {
-  handlerEntered = true;
-  const socket = req.socket;
+  await using server = http.createServer((req, res) => {
+    const socket = req.socket!;
 
-  req.on("error", () => {});
-  res.on("error", () => {});
-  socket.on("error", () => {});
+    // Swallow the benign "aborted"/premature-close errors that the abort
+    // produces; they are a side effect, not the behavior under test.
+    req.on("error", () => {});
+    res.on("error", () => {});
+    socket.on("error", () => {});
 
-  // Consume the body so it is fully drained BEFORE the client aborts.
-  // This is the exact scenario the bug was about: body done, req.complete
-  // already true by the time the abort is observed.
-  req.on("data", () => {});
-  req.on("end", () => { bodyReceived = true; });
+    // Consume the body so it is fully drained BEFORE the client aborts.
+    // This is the exact scenario the bug was about: body done, req.complete
+    // already true by the time the abort is observed.
+    req.on("data", () => {});
+    req.on("end", () => onBody());
 
-  res.on("close", () => {
-    events.push("res close");
-    maybeDone();
+    res.on("close", () => {
+      seen.add("res close");
+      check();
+    });
+    socket.on("close", () => {
+      seen.add("socket close");
+      check();
+    });
+    socket.on("end", () => {
+      seen.add("socket end");
+      check();
+    });
+
+    // Never respond: the test asserts the close events fire from the abort,
+    // not from a completed response.
   });
-  socket.on("close", () => {
-    events.push("socket close");
-    maybeDone();
-  });
-  socket.on("end", () => {
-    events.push("socket end");
-    maybeDone();
-  });
 
-  // Long-running work we would otherwise hang on a dead socket.
-  const t = setTimeout(() => {
-    if (!res.writableEnded) res.end("ok");
-  }, 60_000);
-  t.unref?.();
-  res.on("close", () => clearTimeout(t));
-});
+  await new Promise<void>(resolve => server.listen(0, () => resolve()));
+  const { port } = server.address() as net.AddressInfo;
 
-function maybeDone() {
-  if (
-    events.includes("res close") &&
-    events.includes("socket close") &&
-    events.includes("socket end")
-  ) {
-    console.log("EVENTS=" + events.slice().sort().join(","));
-    server.close();
-    process.exit(0);
-  }
-}
-
-server.listen(0, () => {
-  const { port } = server.address();
-
-  // Raw TCP client so we can send the body in full and wait for the
-  // server to finish reading it before destroying — no dependency on
-  // http.request's abort semantics, which don't guarantee the body is
-  // fully drained on the server before the reset lands.
-  const client = net.createConnection({ host: "127.0.0.1", port }, () => {
-    const body = '{"hello":"world"}';
-    client.write(
-      "POST /test HTTP/1.1\\r\\n" +
-      "Host: localhost\\r\\n" +
-      "Content-Type: application/json\\r\\n" +
-      "Content-Length: " + body.length + "\\r\\n" +
-      "Connection: close\\r\\n" +
-      "\\r\\n" +
-      body
-    );
-    // Wait until the server actually finished reading the body, then
-    // destroy to simulate a client abort on an in-flight request whose
-    // body was already drained.
-    const check = setInterval(() => {
-      if (bodyReceived) {
-        clearInterval(check);
-        client.destroy();
-      }
-    }, 10);
-  });
+  // Raw TCP client so we can send the body in full and wait for the server
+  // to finish reading it before aborting — no dependency on http.request's
+  // abort semantics, which don't guarantee the body is drained server-side
+  // before the reset lands.
+  const client = net.connect(port);
   client.on("error", () => {});
+  const body = '{"hello":"world"}';
+  client.write(
+    "POST /test HTTP/1.1\r\n" +
+      "Host: localhost\r\n" +
+      "Content-Type: application/json\r\n" +
+      `Content-Length: ${body.length}\r\n` +
+      "Connection: close\r\n" +
+      "\r\n" +
+      body,
+  );
+
+  // Wait for the server to fully read the body, then abort. If the fix is
+  // absent the close events never fire and the test times out (the default
+  // bun:test timeout is the failure signal here).
+  await bodyReceived;
+  client.destroy();
+  await allEvents;
+
+  expect([...seen].sort()).toEqual(["res close", "socket close", "socket end"]);
 });
 
-// Safety net: if the close events never fire (bug still present) or
-// the handler never runs, bail with a deterministic failure line.
-setTimeout(() => {
-  console.log("EVENTS=" + events.slice().sort().join(","));
-  console.log("HANDLER_ENTERED=" + handlerEntered);
-  console.log("BODY_RECEIVED=" + bodyReceived);
-  process.exit(1);
-}, 15_000);
-`;
+// Companion guard for the fix above: teaching the socket's 'close' event to
+// drive the internal one-shot setCloseCallback path (so res.on('close') fires
+// on a peer abort) must not make res emit 'close' twice when res.destroy() is
+// called asynchronously — e.g. from a timer or error handler — while the
+// socket is still attached. ServerResponse.prototype.destroy marks the
+// response closed before emitting, so emitCloseNT's `!_closed` guard gates out
+// the later socket-close path.
+test("res.destroy() from a later tick emits 'close' exactly once (#28976)", async () => {
+  let resCloseCount = 0;
+  const { promise: socketClosed, resolve: onSocketClose } = Promise.withResolvers<void>();
 
-test("res.on('close') / socket.on('close') / socket.on('end') fire after client abort on POST with body (#28976)", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", SCRIPT],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
+  await using server = http.createServer((req, res) => {
+    req.on("error", () => {});
+    res.on("error", () => {});
+    req.socket!.on("error", () => {});
+
+    res.on("close", () => {
+      resCloseCount++;
+    });
+    // The emit() override drives any second res-'close' during the socket's
+    // own close emission, which runs before the socket's 'close' listeners,
+    // so resCloseCount is final by the time this resolves. No timer needed.
+    req.socket!.on("close", () => onSocketClose());
+
+    res.writeHead(200);
+    // Defer the destroy out of the synchronous request handler — that's the
+    // path that used to emit 'close' twice.
+    setImmediate(() => res.destroy());
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  await new Promise<void>(resolve => server.listen(0, () => resolve()));
+  const { port } = server.address() as net.AddressInfo;
 
-  const line = stdout
-    .split("\n")
-    .map(l => l.trim())
-    .find(l => l.startsWith("EVENTS="));
+  const client = net.connect(port);
+  client.on("error", () => {});
+  client.write("GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n");
 
-  expect({ exitCode, line, stderr }).toEqual({
-    exitCode: 0,
-    line: "EVENTS=res close,socket close,socket end",
-    stderr: expect.any(String),
-  });
-}, 30_000);
-
-// Guards against a regression of the companion bug: res.destroy() called
-// asynchronously (e.g. from a setTimeout / error path) must emit 'close' on
-// the response exactly once, not twice. A naïve version of the fix above
-// (which teaches the socket's close event to drive the internal
-// one-shot setCloseCallback path) would fire res.emit('close') a second
-// time when the async socket close arrives. The guard is
-// ServerResponse.prototype.destroy setting _closed=true before emitting.
-const DESTROY_SCRIPT = /* js */ `
-const http = require("node:http");
-
-let resCloseCount = 0;
-
-const server = http.createServer((req, res) => {
-  res.on("close", () => { resCloseCount++; });
-  res.writeHead(200);
-  // Defer the destroy so it doesn't happen inside the synchronous
-  // request handler — that's the path that used to emit twice.
-  setImmediate(() => res.destroy());
+  await socketClosed;
+  expect(resCloseCount).toBe(1);
 });
-
-server.listen(0, () => {
-  const { port } = server.address();
-  const req = http.get({ port }, () => {});
-  req.on("error", () => {});
-  setTimeout(() => {
-    console.log("RES_CLOSE_COUNT=" + resCloseCount);
-    server.close();
-    process.exit(0);
-  }, 500);
-});
-`;
-
-test("res.destroy() emits 'close' exactly once when called asynchronously (#28976)", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", DESTROY_SCRIPT],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  const line = stdout
-    .split("\n")
-    .map(l => l.trim())
-    .find(l => l.startsWith("RES_CLOSE_COUNT="));
-
-  expect({ exitCode, line, stderr }).toEqual({
-    exitCode: 0,
-    line: "RES_CLOSE_COUNT=1",
-    stderr: expect.any(String),
-  });
-}, 15_000);

--- a/test/regression/issue/28976.test.ts
+++ b/test/regression/issue/28976.test.ts
@@ -1,14 +1,4 @@
 // https://github.com/oven-sh/bun/issues/28976
-//
-// When a client aborts an in-flight POST request that had a body, the
-// server-side `res.on('close')`, `req.socket.on('close')`, and
-// `req.socket.on('end')` listeners never fired — the handler kept running
-// to completion on a dead socket. Code that relied on those events to
-// cancel downstream work (LLM streams, DB queries, upstream fetches) had
-// no way to detect the disconnect.
-//
-// The bug was specific to bodies being present: without a body (e.g. a
-// bare POST or GET), the events fired.
 import { expect, test } from "bun:test";
 import http from "node:http";
 import net from "node:net";


### PR DESCRIPTION
## What

Fixes #28976.

When a client aborts an in-flight POST that has a body, the server-side
`res.on('close')`, `req.socket.on('close')`, and `req.socket.on('end')`
listeners never fire. The handler keeps running to completion on a dead
socket, and application code that relies on those events to cancel
downstream work (LLM streams, DB queries, upstream HTTP calls) has no
way to detect the disconnect.

## Reproduction

```ts
import express from "express";
const app = express();
app.use(express.json());
app.post("/test", (req, res) => {
  const t0 = Date.now();
  req.on("close",  () => console.log("req close  " + (Date.now() - t0)));
  res.on("close",  () => console.log("res close  " + (Date.now() - t0)));
  req.socket?.on("close", () => console.log("socket close " + (Date.now() - t0)));
  req.socket?.on("end",   () => console.log("socket end   " + (Date.now() - t0)));
  setTimeout(() => res.writableEnded || res.json({ ok: true }), 30_000);
});
app.listen(8090);
```

`curl -X POST http://localhost:8090/test -H 'content-type: application/json' --data '{"hello":"world"}' --max-time 2`

**Before:** only `req close` fires (from express.json ending the readable
when the body is fully received). None of `res close`, `socket close`,
or `socket end` ever fire after the abort.

**After:** all four fire shortly after the curl timeout, matching Node.

## Cause

`NodeHTTPServerSocket.#onClose` only destroys the `IncomingMessage` —
and only when `req.complete` is still false. For a POST whose body was
already fully drained (`express.json()` is one way to get there),
`req.complete` is already `true` by the time the peer aborts, so
`#onClose` does nothing at all. The Duplex socket is never destroyed,
so `'close'` / `'end'` never propagate.

Separately, the internal `assignSocketInternal` path wires the
`ServerResponse` to the socket via a one-shot
`setCloseCallback(socket, onServerResponseClose)` — `~10% faster` than
`socket.once('close', …)`, per the comment. But nothing drives
`callCloseCallback` on the socket, so the internal path never
propagates the socket close to the response either.

## Fix

1. In `#onClose`, always destroy the Duplex socket. `push(null)` +
   `read(0)` first (matches Node's `net.Socket` handling of `UV_EOF`)
   so `'end'` fires, then `this.destroy()` so `'close'` fires.
2. Override `emit` on `NodeHTTPServerSocket` to call
   `callCloseCallback(this)` when a `'close'` event is emitted — same
   pattern `ServerResponse.prototype.emit` already uses for its own
   close event. That lets the internal `setCloseCallback` path drive
   `onServerResponseClose` into the response on peer disconnect.

## Verification

New regression test at `test/regression/issue/28976.test.ts` spawns a
`node:http` server, opens a raw TCP connection, sends the POST body in
full, waits for the server to finish reading it, destroys the client
socket, and asserts that `res.on('close')`, `socket.on('close')`, and
`socket.on('end')` all fire on the server within a few seconds. Test
fails without the fix (5s timeout waiting for events), passes with it.