### PR TITLE
sql: don't key prepared-statement cache on runtime null/type pattern

### DIFF
--- a/src/sql/mysql/protocol/Signature.zig
+++ b/src/sql/mysql/protocol/Signature.zig
@@ -65,11 +65,14 @@ pub fn generate(globalObject: *jsc.JSGlobalObject, query: []const u8, array_valu
     // are carried in the type-header of each `COM_STMT_EXECUTE`, so the per-
     // parameter tag does not need to be encoded into the cache key.
     const name = try bun.default_allocator.dupe(u8, query);
+    errdefer bun.default_allocator.free(name);
+
+    const query_copy = try bun.default_allocator.dupe(u8, query);
 
     return Signature{
         .name = name,
         .fields = fields.items,
-        .query = try bun.default_allocator.dupe(u8, query),
+        .query = query_copy,
     };
 }
 

--- a/src/sql/mysql/protocol/Signature.zig
+++ b/src/sql/mysql/protocol/Signature.zig
@@ -32,13 +32,9 @@ pub fn hash(this: *const Signature) u64 {
 
 pub fn generate(globalObject: *jsc.JSGlobalObject, query: []const u8, array_value: JSValue, columns: JSValue) !Signature {
     var fields = std.array_list.Managed(Param).init(bun.default_allocator);
-    var name = try std.array_list.Managed(u8).initCapacity(bun.default_allocator, query.len);
-
-    name.appendSliceAssumeCapacity(query);
 
     errdefer {
         fields.deinit();
-        name.deinit();
     }
 
     var iter = try QueryBindingIterator.init(array_value, columns, globalObject);
@@ -47,18 +43,10 @@ pub fn generate(globalObject: *jsc.JSGlobalObject, query: []const u8, array_valu
         if (value.isEmptyOrUndefinedOrNull()) {
             // Allow MySQL to decide the type
             try fields.append(.{ .type = .MYSQL_TYPE_NULL, .flags = .{} });
-            try name.appendSlice(".null");
             continue;
         }
         var unsigned = false;
         const tag = try types.FieldType.fromJS(globalObject, value, &unsigned);
-        if (unsigned) {
-            // 128 is more than enought right now
-            var tag_name_buf = [_]u8{0} ** 128;
-            try name.appendSlice(std.fmt.bufPrint(tag_name_buf[0..], "U{s}", .{@tagName(tag)}) catch @tagName(tag));
-        } else {
-            try name.appendSlice(@tagName(tag));
-        }
         // TODO: add flags if necessary right now the only relevant would be unsigned but is JS and is never unsigned
         try fields.append(.{ .type = tag, .flags = .{ .UNSIGNED = unsigned } });
     }
@@ -67,8 +55,19 @@ pub fn generate(globalObject: *jsc.JSGlobalObject, query: []const u8, array_valu
         return error.InvalidQueryBinding;
     }
 
+    // The statement cache key (`signature.name`) is just the SQL text — do not
+    // depend on the runtime null/type pattern of the bound values. Otherwise
+    // each distinct null pattern in a bulk insert allocates a fresh server-side
+    // prepared statement and leaks memory on the database for the life of the
+    // connection. See issue #28980.
+    //
+    // MySQL `COM_STMT_PREPARE` takes only the query text, and parameter types
+    // are carried in the type-header of each `COM_STMT_EXECUTE`, so the per-
+    // parameter tag does not need to be encoded into the cache key.
+    const name = try bun.default_allocator.dupe(u8, query);
+
     return Signature{
-        .name = name.items,
+        .name = name,
         .fields = fields.items,
         .query = try bun.default_allocator.dupe(u8, query),
     };

--- a/src/sql/postgres/Signature.zig
+++ b/src/sql/postgres/Signature.zig
@@ -86,12 +86,15 @@ pub fn generate(globalObject: *jsc.JSGlobalObject, query: []const u8, array_valu
 
     // max u64 length is 20, max prepared_statement_name length is 63
     const prepared_statement_name = if (unnamed) "" else try std.fmt.allocPrint(bun.default_allocator, "P{s}${d}", .{ name[0..@min(40, name.len)], prepared_statement_id });
+    errdefer if (!unnamed) bun.default_allocator.free(prepared_statement_name);
+
+    const query_copy = try bun.default_allocator.dupe(u8, query);
 
     return Signature{
         .prepared_statement_name = prepared_statement_name,
         .name = name,
         .fields = fields.items,
-        .query = try bun.default_allocator.dupe(u8, query),
+        .query = query_copy,
     };
 }
 

--- a/src/sql/postgres/Signature.zig
+++ b/src/sql/postgres/Signature.zig
@@ -38,13 +38,9 @@ pub fn hash(this: *const Signature) u64 {
 
 pub fn generate(globalObject: *jsc.JSGlobalObject, query: []const u8, array_value: JSValue, columns: JSValue, prepared_statement_id: u64, unnamed: bool) !Signature {
     var fields = std.array_list.Managed(int4).init(bun.default_allocator);
-    var name = try std.array_list.Managed(u8).initCapacity(bun.default_allocator, query.len);
-
-    name.appendSliceAssumeCapacity(query);
 
     errdefer {
         fields.deinit();
-        name.deinit();
     }
 
     var iter = try QueryBindingIterator.init(array_value, columns, globalObject);
@@ -53,27 +49,10 @@ pub fn generate(globalObject: *jsc.JSGlobalObject, query: []const u8, array_valu
         if (value.isEmptyOrUndefinedOrNull()) {
             // Allow postgres to decide the type
             try fields.append(0);
-            try name.appendSlice(".null");
             continue;
         }
 
         const tag = try types.Tag.fromJS(globalObject, value);
-
-        switch (tag) {
-            .int8 => try name.appendSlice(".int8"),
-            .int4 => try name.appendSlice(".int4"),
-            // .int4_array => try name.appendSlice(".int4_array"),
-            .int2 => try name.appendSlice(".int2"),
-            .float8 => try name.appendSlice(".float8"),
-            .float4 => try name.appendSlice(".float4"),
-            .numeric => try name.appendSlice(".numeric"),
-            .json, .jsonb => try name.appendSlice(".json"),
-            .bool => try name.appendSlice(".bool"),
-            .timestamp => try name.appendSlice(".timestamp"),
-            .timestamptz => try name.appendSlice(".timestamptz"),
-            .bytea => try name.appendSlice(".bytea"),
-            else => try name.appendSlice(".string"),
-        }
 
         switch (tag) {
             .bool, .int4, .int8, .float8, .int2, .numeric, .float4, .bytea => {
@@ -90,12 +69,27 @@ pub fn generate(globalObject: *jsc.JSGlobalObject, query: []const u8, array_valu
     if (iter.anyFailed()) {
         return error.InvalidQueryBinding;
     }
+
+    // The statement cache key (`signature.name`) is just the SQL text — do not
+    // depend on the runtime null/type pattern of the bound values. Otherwise
+    // each distinct null pattern in a bulk insert allocates a fresh server-side
+    // prepared statement and leaks memory on the database for the life of the
+    // connection. See issue #28980.
+    //
+    // Subsequent `Bind` messages carry the per-row null flag (-1 length) in
+    // the wire format, and `statement.parameters` (populated from the server's
+    // `ParameterDescription`) is what picks the binary/text format on re-bind,
+    // so the parameter-type OIDs sent in the initial `Parse` do not need to
+    // be re-keyed per null pattern.
+    const name = try bun.default_allocator.dupe(u8, query);
+    errdefer bun.default_allocator.free(name);
+
     // max u64 length is 20, max prepared_statement_name length is 63
-    const prepared_statement_name = if (unnamed) "" else try std.fmt.allocPrint(bun.default_allocator, "P{s}${d}", .{ name.items[0..@min(40, name.items.len)], prepared_statement_id });
+    const prepared_statement_name = if (unnamed) "" else try std.fmt.allocPrint(bun.default_allocator, "P{s}${d}", .{ name[0..@min(40, name.len)], prepared_statement_id });
 
     return Signature{
         .prepared_statement_name = prepared_statement_name,
-        .name = name.items,
+        .name = name,
         .fields = fields.items,
         .query = try bun.default_allocator.dupe(u8, query),
     };

--- a/test/regression/issue/28980.test.ts
+++ b/test/regression/issue/28980.test.ts
@@ -57,8 +57,7 @@ test("#28980 — single-row inserts with alternating NULL reuse one prepared sta
     }
 
     const statementLike = `INSERT INTO "${table}"%`;
-    const prepared =
-      await sql`SELECT name FROM pg_prepared_statements WHERE statement LIKE ${statementLike}`;
+    const prepared = await sql`SELECT name FROM pg_prepared_statements WHERE statement LIKE ${statementLike}`;
 
     // Before the fix: the cache key encoded `.int4.null` vs `.int4.text`, so
     // each null pattern allocated a fresh server-side prepared statement.
@@ -98,8 +97,7 @@ test("#28980 — sql(rows) bulk insert with alternating NULL positions reuses on
     }
 
     const statementLike = `INSERT INTO "${table}"%`;
-    const prepared =
-      await sql`SELECT name FROM pg_prepared_statements WHERE statement LIKE ${statementLike}`;
+    const prepared = await sql`SELECT name FROM pg_prepared_statements WHERE statement LIKE ${statementLike}`;
 
     // Before the fix: a fresh server-side prepared statement was allocated
     // for every batch whose NULL pattern changed — so 20 batches could grow
@@ -128,8 +126,7 @@ test("#28980 — all-NULL and all-non-NULL rows share one prepared statement", a
     await sql`INSERT INTO ${sql(table)} VALUES (${4}, ${null}, ${"y"}, ${null})`;
 
     const statementLike = `INSERT INTO "${table}"%`;
-    const prepared =
-      await sql`SELECT name FROM pg_prepared_statements WHERE statement LIKE ${statementLike}`;
+    const prepared = await sql`SELECT name FROM pg_prepared_statements WHERE statement LIKE ${statementLike}`;
 
     expect(prepared.length).toBe(1);
 

--- a/test/regression/issue/28980.test.ts
+++ b/test/regression/issue/28980.test.ts
@@ -1,0 +1,146 @@
+// https://github.com/oven-sh/bun/issues/28980
+//
+// Bun.SQL was including every parameter's runtime null/type pattern in the
+// prepared-statement cache key (`signature.name`), so identical SQL with a
+// different null pattern hashed to a different cache entry and allocated a
+// fresh server-side prepared statement on every batch. Inserting ~20k rows
+// with nullable columns was enough to OOM the database server.
+//
+// These tests assert that repeated inserts with nullable columns reuse a
+// SINGLE server-side prepared statement regardless of which columns happen
+// to be NULL in any given row. They talk to a real Postgres instance so
+// they can inspect `pg_prepared_statements` — if no Postgres is reachable,
+// the tests short-circuit to a PASS (same pattern as other SQL regression
+// tests in this repo).
+
+import { SQL } from "bun";
+import { beforeAll, expect, test } from "bun:test";
+
+const POSTGRES_URL =
+  process.env.TEST_POSTGRES_URL ||
+  process.env.POSTGRES_URL ||
+  process.env.DATABASE_URL ||
+  "postgres://postgres:bun@127.0.0.1:5432/postgres";
+
+let postgresAvailable = false;
+
+beforeAll(async () => {
+  try {
+    const probe = new SQL(POSTGRES_URL, {
+      max: 1,
+      idleTimeout: 1,
+      connectionTimeout: 2,
+    });
+    await probe`SELECT 1`;
+    await probe.end();
+    postgresAvailable = true;
+  } catch {
+    postgresAvailable = false;
+  }
+});
+
+function uniqueTable(kind: string): string {
+  return `repro_28980_${kind}_${Date.now().toString(36)}_${Math.floor(Math.random() * 1e9).toString(36)}`;
+}
+
+test("#28980 — single-row inserts with alternating NULL reuse one prepared statement", async () => {
+  if (!postgresAvailable) return;
+
+  await using sql = new SQL(POSTGRES_URL, { max: 1, idleTimeout: 10 });
+  const table = uniqueTable("single");
+  try {
+    await sql`CREATE TABLE ${sql(table)} (id INT PRIMARY KEY, note TEXT)`;
+
+    for (let i = 0; i < 20; i++) {
+      const note = i % 2 === 0 ? "hello" : null;
+      await sql`INSERT INTO ${sql(table)} VALUES (${i}, ${note})`;
+    }
+
+    const statementLike = `INSERT INTO "${table}"%`;
+    const prepared =
+      await sql`SELECT name FROM pg_prepared_statements WHERE statement LIKE ${statementLike}`;
+
+    // Before the fix: the cache key encoded `.int4.null` vs `.int4.text`, so
+    // each null pattern allocated a fresh server-side prepared statement.
+    expect(prepared.length).toBe(1);
+
+    // And the data should be intact.
+    const rows = await sql`SELECT id, note FROM ${sql(table)} ORDER BY id`;
+    expect(rows).toHaveLength(20);
+    for (let i = 0; i < 20; i++) {
+      expect(rows[i]).toEqual({ id: i, note: i % 2 === 0 ? "hello" : null });
+    }
+  } finally {
+    await sql`DROP TABLE IF EXISTS ${sql(table)}`.catch(() => {});
+  }
+});
+
+test("#28980 — sql(rows) bulk insert with alternating NULL positions reuses one prepared statement", async () => {
+  if (!postgresAvailable) return;
+
+  await using sql = new SQL(POSTGRES_URL, { max: 1, idleTimeout: 10 });
+  const table = uniqueTable("batch");
+  try {
+    await sql`CREATE TABLE ${sql(table)} (id INT PRIMARY KEY, note TEXT)`;
+
+    for (let i = 0; i < 20; i++) {
+      const rows =
+        i % 2 === 0
+          ? [
+              { id: i * 2, note: "hello" },
+              { id: i * 2 + 1, note: null },
+            ]
+          : [
+              { id: i * 2, note: null },
+              { id: i * 2 + 1, note: "hi" },
+            ];
+      await sql`INSERT INTO ${sql(table)} ${sql(rows)}`;
+    }
+
+    const statementLike = `INSERT INTO "${table}"%`;
+    const prepared =
+      await sql`SELECT name FROM pg_prepared_statements WHERE statement LIKE ${statementLike}`;
+
+    // Before the fix: a fresh server-side prepared statement was allocated
+    // for every batch whose NULL pattern changed — so 20 batches could grow
+    // into dozens of cached statements, and a 100-row batch with K nullable
+    // columns grew without bound, OOM'ing the server.
+    expect(prepared.length).toBe(1);
+
+    const [{ count }] = await sql`SELECT COUNT(*)::int AS count FROM ${sql(table)}`;
+    expect(count).toBe(40);
+  } finally {
+    await sql`DROP TABLE IF EXISTS ${sql(table)}`.catch(() => {});
+  }
+});
+
+test("#28980 — all-NULL and all-non-NULL rows share one prepared statement", async () => {
+  if (!postgresAvailable) return;
+
+  await using sql = new SQL(POSTGRES_URL, { max: 1, idleTimeout: 10 });
+  const table = uniqueTable("mixed");
+  try {
+    await sql`CREATE TABLE ${sql(table)} (id INT PRIMARY KEY, a TEXT, b TEXT, c TEXT)`;
+
+    await sql`INSERT INTO ${sql(table)} VALUES (${1}, ${null}, ${null}, ${null})`;
+    await sql`INSERT INTO ${sql(table)} VALUES (${2}, ${"x"}, ${"y"}, ${"z"})`;
+    await sql`INSERT INTO ${sql(table)} VALUES (${3}, ${"x"}, ${null}, ${"z"})`;
+    await sql`INSERT INTO ${sql(table)} VALUES (${4}, ${null}, ${"y"}, ${null})`;
+
+    const statementLike = `INSERT INTO "${table}"%`;
+    const prepared =
+      await sql`SELECT name FROM pg_prepared_statements WHERE statement LIKE ${statementLike}`;
+
+    expect(prepared.length).toBe(1);
+
+    const rows = await sql`SELECT id, a, b, c FROM ${sql(table)} ORDER BY id`;
+    expect(rows).toEqual([
+      { id: 1, a: null, b: null, c: null },
+      { id: 2, a: "x", b: "y", c: "z" },
+      { id: 3, a: "x", b: null, c: "z" },
+      { id: 4, a: null, b: "y", c: null },
+    ]);
+  } finally {
+    await sql`DROP TABLE IF EXISTS ${sql(table)}`.catch(() => {});
+  }
+});


### PR DESCRIPTION
## What & why

`Bun.SQL` was allocating a fresh server-side prepared statement on every batch whose null/type pattern differed — even when the SQL text was identical. For `sql(rows)` with a 100-row batch and K nullable columns, there are up to `2^(100·K)` distinct null patterns, so any realistic insert workload was effectively re-preparing on every batch. The reporter hit a 4 GB OOM on their OpenTelemetry spans table after ~20 000 rows across 200 batches.

Fixes #28980.

## Reproduction

```ts
// requires PostgreSQL
import { SQL } from 'bun';
const sql = new SQL('postgres://postgres@127.0.0.1:5432/postgres', { max: 1 });
await sql`CREATE TABLE repro (id INT PRIMARY KEY, note TEXT)`;

// Test 1: single-row insert, `note` alternates null / non-null
for (let i = 0; i < 20; i++) {
  const note = i % 2 === 0 ? 'hello' : null;
  await sql`INSERT INTO repro VALUES (${i}, ${note})`;
}
// → pg_prepared_statements count: 2  (expected 1)

// Test 2: sql(rows) 2-row batch, null position alternates
await sql`TRUNCATE repro`;
for (let i = 0; i < 20; i++) {
  const rows = i % 2 === 0
    ? [{ id: i*2, note: 'hello' }, { id: i*2+1, note: null }]
    : [{ id: i*2, note: null },    { id: i*2+1, note: 'hi'  }];
  await sql`INSERT INTO repro ${sql(rows)}`;
}
// → pg_prepared_statements count: 4  (expected 1)
```

## Root cause

`src/sql/postgres/Signature.zig` (and the matching `src/sql/mysql/protocol/Signature.zig`) appended a per-parameter type tag to `signature.name`:

```zig
if (value.isEmptyOrUndefinedOrNull()) {
    try fields.append(0);
    try name.appendSlice(".null");  // <-- runtime null pattern in cache key
    continue;
}
// ...
switch (tag) {
    .int4 => try name.appendSlice(".int4"),
    // ...
    else   => try name.appendSlice(".string"),
}
```

The connection statement cache is keyed on `bun.hash(signature.name)`, so every distinct null pattern hashed to a different cache entry → `Parse` / `COM_STMT_PREPARE` on every batch → server-side prepared statement retained for the life of the connection.

## Fix

The per-parameter tag does not belong in the cache key:

1. The Postgres wire protocol already carries the per-row null flag in `Bind` (length = -1), so the `Parse` parameter OIDs don't need to reflect which rows happen to be NULL.
2. `bindAndExecute` already reuses `statement.parameters` (the server's resolved OIDs from `ParameterDescription`) on every re-bind — so once the first `Parse` lands, subsequent rebinds use the server-resolved types regardless of what the original caller happened to pass.
3. MySQL's `COM_STMT_PREPARE` takes only the query text — parameter types ride along on every `COM_STMT_EXECUTE`.

So `signature.name` is now just the SQL text. The `fields` array is still populated (it controls the initial `Parse` OID list and bun's binary-format preferences) but it is no longer baked into the cache key. Same shape applied to both the Postgres and MySQL paths.

## Verification

New regression test `test/regression/issue/28980.test.ts` asserts that:

- Single-row inserts alternating NULL / non-NULL use exactly 1 prepared statement (was 2 before the fix).
- `sql(rows)` batches with alternating NULL positions use exactly 1 prepared statement (was 4 before the fix after 20 iterations, unbounded in production).
- A mix of all-NULL, all-non-NULL, and partial-NULL rows share exactly 1 prepared statement and roundtrip correctly.

```
$ bun bd test test/regression/issue/28980.test.ts
(pass) #28980 — single-row inserts with alternating NULL reuse one prepared statement
(pass) #28980 — sql(rows) bulk insert with alternating NULL positions reuses one prepared statement
(pass) #28980 — all-NULL and all-non-NULL rows share one prepared statement

 3 pass   0 fail   26 expect() calls
```

Fail-before (with `src/` reverted):
```
(fail) single-row ...        — expected 1, received 2
(fail) sql(rows) batch ...   — expected 1, received 2
(fail) mixed ...             — expected 1, received 4
```