### PR TITLE
fetch: don't deliver empty non-terminal chunk to ByteStream

### DIFF
--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -483,6 +483,35 @@ pub const FetchTasklet = struct {
         }
         // if we already respond the metadata and still need to process the body
         if (this.is_waiting_body) {
+            // `scheduled_response_buffer` has two readers that both drain-and-reset:
+            // this path (onBodyReceived) and `onStartStreamingHTTPResponseBodyCallback`,
+            // which runs once when JS first touches `res.body` and hands any already-
+            // buffered bytes to the new ByteStream synchronously.
+            //
+            // That creates a stale-task race:
+            //   1. HTTP thread `callback()` writes N bytes to the buffer and enqueues
+            //      this onProgressUpdate task (under mutex).
+            //   2. Main thread: JS touches `res.body` -> `onStartStreaming` drains those
+            //      N bytes and resets the buffer (under mutex).
+            //   3. This task runs and finds the buffer empty.
+            //
+            // The task cannot be un-enqueued in step 2, and at schedule time (step 1)
+            // the buffer was non-empty, so the only place the staleness is observable
+            // is here when the task runs.
+            //
+            // Without this guard, `onBodyReceived` would call `ByteStream.onData` with
+            // a zero-length non-terminal chunk. That resolves the reader's pending
+            // pull with `len=0`; `native-readable.ts` `handleNumberResult(0)` does not
+            // `push()`, so node:stream `state.reading` (set before the previous `_read()`
+            // early-returned on `kPendingRead`) is never cleared, `_read()` is never
+            // called again, and `pipeline(Readable.fromWeb(res.body), ...)` stalls
+            // forever — eventually spinning at 100% CPU once `poll_ref` unrefs.
+            if (this.scheduled_response_buffer.list.items.len == 0 and
+                this.result.has_more and
+                this.result.isSuccess())
+            {
+                return;
+            }
             try this.onBodyReceived();
             return;
         }


### PR DESCRIPTION
## What

`pipeline(Readable.fromWeb(res.body), createWriteStream(out))` can permanently stall (and then spin at 100% CPU in `waitForPromise`) when the HTTP thread's first body callback races with JS accessing `res.body`.

Most likely fixes #10066.
Most likely fixes #28703.

## How it happens

1. HTTP thread receives the first body chunk, writes it to `FetchTasklet.scheduled_response_buffer`, and enqueues an `onProgressUpdate` ConcurrentTask.
2. JS reaches `res.body` → `Body.Value.toReadableStream()` → `onStartStreamingHTTPResponseBodyCallback` drains `scheduled_response_buffer` into the new ByteStream's initial buffer and resets it to empty.
3. The already-queued `onProgressUpdate` task runs → `onBodyReceived` → `chunk = scheduled_response_buffer.items` is now empty → calls `ByteStream.onData(.temporary{len=0})`.
4. `ByteStream.onData` sees `pending.state == .pending`, copies 0 bytes, and resolves the pending pull with `.into_array{len=0}`.
5. In `native-readable.ts`, `handleNumberResult(0)` doesn't `push()` (correctly — there's nothing to push). But a prior `_read()` had already early-returned on `kPendingRead`, leaving node:stream's `state.reading = true`. With no push to clear it, `_read()` is never called again.
6. Every subsequent body chunk hits `ByteStream.onData` with no pending pull → appends to the internal buffer forever. The pipeline never completes; once `FetchTasklet` unrefs its `poll_ref`, `waitForPromise` busy-loops on `clock_gettime`.

## Fix

Skip the `onData` call in `onBodyReceived` when the chunk is empty and `has_more` — there is nothing to deliver, and calling `onData` with it consumes the pending pull for nothing. The terminal (`!has_more`) branch is left alone: a zero-length `.temporary_and_done` is valid (means "done, 0 more bytes") and `ByteStream.onData` handles it correctly.

## Repro

The race window is narrow — the HTTP thread's second body callback has to land between `onResolve` firing and JS touching `res.body`. In practice it needs real-network pacing from a remote TLS origin; I couldn't construct a local loopback test (plain HTTP, raw TCP with controlled packet boundaries, or local TLS) that triggers it, so no test is included. It reproduces at ~5-10% per 40-parallel-fetch round against `https://codeload.github.com/google/brotli/tar.gz/v1.1.0` on x64 Linux:

```js
// bun repro.ts — exits 1 when it hits
import { spawn } from "node:child_process";
import { createWriteStream, unlinkSync } from "node:fs";
import { Readable } from "node:stream";
import { pipeline } from "node:stream/promises";
import { tmpdir } from "node:os";
import { join } from "node:path";

const URL = "https://codeload.github.com/google/brotli/tar.gz/v1.1.0";

if (process.argv[2] === "child") {
  const res = await fetch(URL);
  await pipeline(Readable.fromWeb(res.body), createWriteStream(process.argv[3]));
  process.exit(0);
}

for (let round = 1; round <= 15; round++) {
  const kids = Array.from({ length: 40 }, (_, i) => {
    const out = join(tmpdir(), `repro.${process.pid}.${i}`);
    return { out, c: spawn(process.execPath, [import.meta.path, "child", out], { stdio: "ignore" }) };
  });
  await new Promise(r => setTimeout(r, 5000));
  const stuck = kids.filter(k => k.c.exitCode === null && k.c.signalCode === null);
  for (const k of kids) { try { k.c.kill(9); } catch {} try { unlinkSync(k.out); } catch {} }
  console.error(`round ${round}: ${stuck.length}/40 stuck`);
  if (stuck.length) process.exit(1);
}
```
