### PR TITLE
fix(inspect): serve /json and /json/list for CDP target discovery

### DIFF
--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -339,7 +339,7 @@ class Debugger {
         return Response.json(versionInfo());
       case "/json":
       case "/json/list":
-      // TODO?
+        return Response.json(targetList(request, this.#url));
     }
 
     if (!this.#url!.protocol.includes("unix") && this.#url!.pathname !== pathname) {
@@ -516,6 +516,57 @@ function versionInfo(): unknown {
     "Bun-Version": Bun.version,
     "Bun-Revision": Bun.revision,
   };
+}
+
+// GET /json and /json/list — CDP target discovery. Node.js, Chrome DevTools
+// and JetBrains IDEs (WebStorm "Coding assistance for Node.js") hit this
+// endpoint to find the webSocketDebuggerUrl. Returning 404 here made those
+// integrations fail with "Cannot connect to VM". See #28984.
+function targetList(request: Request, inspectorUrl: URL | undefined): unknown[] {
+  if (!inspectorUrl) return [];
+
+  // Unix sockets don't have a useful ws:// URL for remote clients; JetBrains
+  // / Chrome DevTools only consume TCP inspector endpoints via /json anyway.
+  if (inspectorUrl.protocol.includes("unix")) return [];
+
+  // Echo whatever Host: header the client connected to so the returned
+  // webSocketDebuggerUrl works even when the inspector is listening on
+  // 0.0.0.0 or ::. Fall back to the URL's own host if no Host header.
+  const hostHeader = request.headers.get("Host");
+  const host = hostHeader || inspectorUrl.host || "localhost";
+  const wsPath = inspectorUrl.pathname || "/";
+  const id = wsPath.length > 1 ? wsPath.slice(1) : "bun";
+
+  // process.argv[1] is the script path if the user ran a file, empty for
+  // `bun -e`/REPL. Fall back to something sensible in both cases.
+  const script = typeof process.argv[1] === "string" && process.argv[1].length > 0 ? process.argv[1] : "";
+  const title = script || "bun";
+  const fileUrl = script ? pathToFileURL(script) : `file://${process.cwd()}/`;
+
+  return [
+    {
+      description: "bun instance",
+      devtoolsFrontendUrl: `https://debug.bun.sh/#${host}${wsPath}`,
+      faviconUrl: "https://bun.com/favicon.ico",
+      id,
+      title,
+      // JetBrains/Chrome DevTools match on type === "node". Anything else and
+      // they skip the entry, so we mirror what Node.js returns here.
+      type: "node",
+      url: fileUrl,
+      webSocketDebuggerUrl: `ws://${host}${wsPath}`,
+    },
+  ];
+}
+
+function pathToFileURL(path: string): string {
+  if (path.startsWith("file://")) return path;
+  // Windows: absolute path like C:\foo\bar → file:///C:/foo/bar
+  if (process.platform === "win32") {
+    const normalized = path.replace(/\\/g, "/");
+    return `file:///${normalized.startsWith("/") ? normalized.slice(1) : normalized}`;
+  }
+  return `file://${path.startsWith("/") ? path : `/${path}`}`;
 }
 
 function webSocketWriter(ws: ServerWebSocket<unknown>): Writer {

--- a/test/regression/issue/28984.test.ts
+++ b/test/regression/issue/28984.test.ts
@@ -1,0 +1,145 @@
+// https://github.com/oven-sh/bun/issues/28984
+//
+// WebStorm's "Coding assistance for Node.js" configures the debugger by
+// hitting GET /json and /json/list on the inspector HTTP server to discover
+// the webSocketDebuggerUrl. Bun used to 404 those endpoints, so the IDE
+// failed with "Cannot connect to VM localhost/127.0.0.1:<port>".
+//
+// Make sure both endpoints now return a CDP-compatible array describing the
+// current target and that its webSocketDebuggerUrl actually accepts an
+// upgrade.
+import { spawn } from "bun";
+import { afterEach, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+let inspectee: ReturnType<typeof spawn> | undefined;
+
+afterEach(() => {
+  inspectee?.kill();
+  inspectee = undefined;
+});
+
+async function startInspector(extraArgs: string[] = []): Promise<URL> {
+  inspectee = spawn({
+    cmd: [bunExe(), "--inspect=127.0.0.1:0", ...extraArgs, "-e", "setInterval(() => {}, 1000)"],
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+
+  const decoder = new TextDecoder();
+  let stderr = "";
+  for await (const chunk of inspectee.stderr as ReadableStream) {
+    stderr += decoder.decode(chunk);
+    for (const line of stderr.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("ws:")) continue;
+      try {
+        return new URL(trimmed);
+      } catch {
+        // keep looking
+      }
+    }
+    if (stderr.includes("Listening:") && stderr.includes("Inspect in browser")) {
+      break;
+    }
+  }
+
+  throw new Error(`Unable to find inspector URL in stderr: ${stderr}`);
+}
+
+async function fetchJson(wsUrl: URL, pathname: string): Promise<Response> {
+  const httpUrl = new URL(pathname, `http://${wsUrl.host}/`);
+  return await fetch(httpUrl);
+}
+
+function assertTarget(entry: unknown, wsUrl: URL) {
+  expect(typeof entry).toBe("object");
+  const e = entry as Record<string, unknown>;
+
+  // Capture the scalar fields BEFORE any matcher mutation and assert them
+  // with primitive checks — JetBrains's Node.js coding assistance matches
+  // on type === "node" so that's the field that matters most for #28984.
+  expect(typeof e.description).toBe("string");
+  expect(typeof e.faviconUrl).toBe("string");
+  expect(typeof e.id).toBe("string");
+  expect((e.id as string).length).toBeTruthy();
+  expect(typeof e.title).toBe("string");
+  expect((e.title as string).length).toBeTruthy();
+  expect(e.type).toBe("node");
+  expect(e.devtoolsFrontendUrl as string).toContain("debug.bun.sh");
+  expect(e.url as string).toMatch(/^file:\/\//);
+
+  // The websocket URL must point back at the same host:port the HTTP
+  // request landed on, with the inspector's pathname preserved.
+  expect(typeof e.webSocketDebuggerUrl).toBe("string");
+  const wsDebugger = new URL(e.webSocketDebuggerUrl as string);
+  expect(wsDebugger.protocol).toBe("ws:");
+  expect(wsDebugger.host).toBe(wsUrl.host);
+  expect(wsDebugger.pathname).toBe(wsUrl.pathname);
+}
+
+describe("issue #28984 — inspector /json discovery endpoints", () => {
+  test("GET /json returns a non-empty CDP target list", async () => {
+    const wsUrl = await startInspector();
+    const res = await fetchJson(wsUrl, "/json");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+
+    const list = await res.json();
+    expect(Array.isArray(list)).toBe(true);
+    expect(list).toHaveLength(1);
+    assertTarget(list[0], wsUrl);
+  });
+
+  test("GET /json/list matches GET /json", async () => {
+    const wsUrl = await startInspector();
+    const [a, b] = await Promise.all([fetchJson(wsUrl, "/json"), fetchJson(wsUrl, "/json/list")]);
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+
+    const [listA, listB] = await Promise.all([a.json(), b.json()]);
+    expect(listA).toEqual(listB);
+    expect(listA).toHaveLength(1);
+    assertTarget(listA[0], wsUrl);
+  });
+
+  test("webSocketDebuggerUrl from /json/list actually upgrades", async () => {
+    const wsUrl = await startInspector();
+    const res = await fetchJson(wsUrl, "/json/list");
+    const [target] = await res.json();
+
+    const ws = new WebSocket(target.webSocketDebuggerUrl);
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    ws.addEventListener("open", () => resolve());
+    ws.addEventListener("error", e => reject(new Error("websocket error", { cause: e })));
+    ws.addEventListener("close", e => reject(new Error("websocket closed", { cause: e })));
+
+    try {
+      await promise;
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("GET /json/version still works alongside /json", async () => {
+    const wsUrl = await startInspector();
+    const res = await fetchJson(wsUrl, "/json/version");
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      "Protocol-Version": expect.any(String),
+      "Browser": "Bun",
+      "Bun-Version": expect.any(String),
+    });
+  });
+
+  test("POST /json is rejected with 405", async () => {
+    const wsUrl = await startInspector();
+    const res = await fetch(new URL("/json", `http://${wsUrl.host}/`), { method: "POST" });
+    expect(res.status).toBe(405);
+  });
+});


### PR DESCRIPTION
Fixes #28984.

## Problem

JetBrains IDEs (WebStorm "Coding assistance for Node.js"), Chrome DevTools, and any other Node.js-compatible debugger client discover the debug target by hitting `GET /json` (or `GET /json/list`) on the inspector HTTP server and reading `webSocketDebuggerUrl` from the first entry. Bun was 404-ing both paths, so WebStorm failed with:

> Cannot connect to VM localhost/127.0.0.1:50xxx

Reproduction:

```console
$ bun --inspect=127.0.0.1:9231 -e "setInterval(()=>{}, 1000)" &
$ curl -sv http://127.0.0.1:9231/json
< HTTP/1.1 404 Not Found
$ curl -sv http://127.0.0.1:9231/json/list
< HTTP/1.1 404 Not Found
```

Root cause: `src/js/internal/debugger.ts` had the `/json` and `/json/list` cases stubbed out with a `// TODO?` comment, falling through to the 404 branch.

## Fix

Implement the endpoints in `src/js/internal/debugger.ts`. The handler returns a single-element array describing the current target in the shape Node.js emits, including:

- `type: "node"` — JetBrains matches on this literal string; anything else is skipped.
- `webSocketDebuggerUrl` — built from the incoming request `Host` header so the returned URL is reachable even when the inspector is listening on `0.0.0.0` or `::`.
- WS path taken from the inspector URL so it matches the random token bun generated for `--inspect`.
- `devtoolsFrontendUrl` pointed at `https://debug.bun.sh/#...`.
- Unix-socket inspectors return an empty array (no routable `ws://` URL exists for a remote client over a unix socket).

## Verification

```console
$ curl -s http://127.0.0.1:40053/json
[{"description":"bun instance","devtoolsFrontendUrl":"https://debug.bun.sh/#127.0.0.1:40053/l3ye6j3371d","faviconUrl":"https://bun.com/favicon.ico","id":"l3ye6j3371d","title":"bun","type":"node","url":"file:///workspace/bun/","webSocketDebuggerUrl":"ws://127.0.0.1:40053/l3ye6j3371d"}]
```

Regression test: `test/regression/issue/28984.test.ts` covers:

1. `GET /json` → 200 with a CDP target entry.
2. `GET /json/list` → same body as `/json`.
3. `new WebSocket(target.webSocketDebuggerUrl)` actually upgrades.
4. `GET /json/version` still works (no regression).
5. `POST /json` → 405 Method Not Allowed (no regression).

```
$ bun bd test test/regression/issue/28984.test.ts
 5 pass
 0 fail

$ USE_SYSTEM_BUN=1 bun test test/regression/issue/28984.test.ts   # unpatched
 2 pass
 3 fail
```