### PR TITLE
ci: show binary-size deltas under 1 MB in KB

### DIFF
--- a/scripts/binary-size.ts
+++ b/scripts/binary-size.ts
@@ -267,5 +267,7 @@ function fmtBytes(n: number): string {
   return `${(n / 1024 / 1024).toFixed(2)} MB`;
 }
 function fmtDelta(n: number): string {
-  return `${n >= 0 ? "+" : "-"}${(Math.abs(n) / 1024 / 1024).toFixed(2)} MB`;
+  const sign = n >= 0 ? "+" : "-";
+  const abs = Math.abs(n);
+  return abs >= 1024 * 1024 ? `${sign}${(abs / 1024 / 1024).toFixed(2)} MB` : `${sign}${(abs / 1024).toFixed(1)} KB`;
 }


### PR DESCRIPTION
Deltas below 1 MB now render as `+138.2 KB` instead of `+0.13 MB` so small per-commit drift stays readable. Absolute size columns remain in MB.