### PR TITLE
compile: normalize /nix/store PT_INTERP to FHS path

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -917,6 +917,8 @@ pub const StandaloneModuleGraph = struct {
                 };
                 defer elf_file.deinit();
 
+                elf_file.normalizeInterpreter();
+
                 elf_file.writeBunSection(bytes) catch |err| {
                     Output.prettyErrorln("Error writing .bun section to ELF: {}", .{err});
                     cleanup(zname, cloned_executable_fd);

--- a/src/elf.zig
+++ b/src/elf.zig
@@ -53,6 +53,11 @@ pub const ElfFile = struct {
         const ehdr = readEhdr(self.data.items);
         const phdr_size = @sizeOf(Elf64_Phdr);
 
+        // Bounds-check the program header table up-front; --compile-executable-path
+        // accepts arbitrary files, so a corrupt e_phoff/e_phnum must not panic.
+        const phdr_table_end = @as(u64, ehdr.e_phoff) +| @as(u64, ehdr.e_phnum) *| @as(u64, phdr_size);
+        if (phdr_table_end > self.data.items.len) return;
+
         for (0..ehdr.e_phnum) |i| {
             const phdr_offset = @as(usize, @intCast(ehdr.e_phoff)) + i * phdr_size;
             const phdr = std.mem.bytesAsValue(Elf64_Phdr, self.data.items[phdr_offset..][0..phdr_size]).*;
@@ -91,6 +96,37 @@ pub const ElfFile = struct {
             // p_filesz @ +32, p_memsz @ +40 in Elf64_Phdr
             std.mem.writeInt(u64, self.data.items[phdr_offset + 32 ..][0..8], new_size, .little);
             std.mem.writeInt(u64, self.data.items[phdr_offset + 40 ..][0..8], new_size, .little);
+
+            self.updateInterpSectionSize(ehdr, new_size);
+            return;
+        }
+    }
+
+    /// Best-effort: keep the `.interp` section header's `sh_size` consistent with
+    /// the rewritten PT_INTERP so `readelf -S` shows accurate metadata. The kernel
+    /// only consults PT_INTERP, so any failure here is silently ignored.
+    fn updateInterpSectionSize(self: *ElfFile, ehdr: Elf64_Ehdr, new_size: u64) void {
+        const shdr_size = @sizeOf(Elf64_Shdr);
+        const shnum = ehdr.e_shnum;
+        if (shnum == 0 or ehdr.e_shstrndx >= shnum) return;
+
+        const shdr_table_end = @as(u64, ehdr.e_shoff) +| @as(u64, shnum) *| @as(u64, shdr_size);
+        if (shdr_table_end > self.data.items.len) return;
+
+        const strtab_shdr = self.readShdr(ehdr.e_shoff, ehdr.e_shstrndx);
+        const strtab_end = strtab_shdr.sh_offset +| strtab_shdr.sh_size;
+        if (strtab_end > self.data.items.len) return;
+        const strtab = self.data.items[@intCast(strtab_shdr.sh_offset)..][0..@intCast(strtab_shdr.sh_size)];
+
+        for (0..shnum) |i| {
+            const shdr = self.readShdr(ehdr.e_shoff, @intCast(i));
+            if (shdr.sh_name >= strtab.len) continue;
+            const name = std.mem.sliceTo(strtab[shdr.sh_name..], 0);
+            if (!bun.strings.eqlComptime(name, ".interp")) continue;
+
+            // sh_size @ +32 in Elf64_Shdr
+            const shdr_offset = @as(usize, @intCast(ehdr.e_shoff)) + i * shdr_size;
+            std.mem.writeInt(u64, self.data.items[shdr_offset + 32 ..][0..8], new_size, .little);
             return;
         }
     }

--- a/src/elf.zig
+++ b/src/elf.zig
@@ -43,6 +43,65 @@ pub const ElfFile = struct {
         self.allocator.destroy(self);
     }
 
+    /// If PT_INTERP points into a Nix/Guix store path, rewrite it to the
+    /// standard FHS path so `bun build --compile` output stays portable when
+    /// the bun binary itself was patchelf'd (NixOS autoPatchelfHook). See #24742.
+    ///
+    /// Store paths are always longer than the FHS path, so this is an in-place
+    /// shrink — no segment moves. No-op for any other interpreter.
+    pub fn normalizeInterpreter(self: *ElfFile) void {
+        const ehdr = readEhdr(self.data.items);
+        const phdr_size = @sizeOf(Elf64_Phdr);
+
+        for (0..ehdr.e_phnum) |i| {
+            const phdr_offset = @as(usize, @intCast(ehdr.e_phoff)) + i * phdr_size;
+            const phdr = std.mem.bytesAsValue(Elf64_Phdr, self.data.items[phdr_offset..][0..phdr_size]).*;
+            if (phdr.p_type != elf.PT_INTERP) continue;
+
+            const interp_offset: usize = @intCast(phdr.p_offset);
+            const interp_filesz: usize = @intCast(phdr.p_filesz);
+            if (interp_offset + interp_filesz > self.data.items.len) return;
+
+            const interp_region = self.data.items[interp_offset..][0..interp_filesz];
+            const current = std.mem.sliceTo(interp_region, 0);
+
+            if (!bun.strings.hasPrefixComptime(current, "/nix/store/") and
+                !bun.strings.hasPrefixComptime(current, "/gnu/store/"))
+            {
+                return;
+            }
+
+            const last_slash = std.mem.lastIndexOfScalar(u8, current, '/') orelse return;
+            const basename = current[last_slash + 1 ..];
+
+            const replacement: []const u8 = inline for (interp_map) |entry| {
+                if (bun.strings.eqlComptime(basename, entry[0])) break entry[1];
+            } else return;
+
+            // FHS path + NUL must fit in the existing segment (always true for
+            // store paths: 32-char hash + pname + "/lib/" alone exceeds any FHS path).
+            if (replacement.len + 1 > interp_filesz) return;
+
+            log("rewriting PT_INTERP {s} -> {s}", .{ current, replacement });
+
+            @memcpy(interp_region[0..replacement.len], replacement);
+            @memset(interp_region[replacement.len..], 0);
+
+            const new_size: u64 = replacement.len + 1;
+            // p_filesz @ +32, p_memsz @ +40 in Elf64_Phdr
+            std.mem.writeInt(u64, self.data.items[phdr_offset + 32 ..][0..8], new_size, .little);
+            std.mem.writeInt(u64, self.data.items[phdr_offset + 40 ..][0..8], new_size, .little);
+            return;
+        }
+    }
+
+    const interp_map = .{
+        .{ "ld-linux-x86-64.so.2", "/lib64/ld-linux-x86-64.so.2" },
+        .{ "ld-linux-aarch64.so.1", "/lib/ld-linux-aarch64.so.1" },
+        .{ "ld-musl-x86_64.so.1", "/lib/ld-musl-x86_64.so.1" },
+        .{ "ld-musl-aarch64.so.1", "/lib/ld-musl-aarch64.so.1" },
+    };
+
     /// Find the `.bun` section and write `payload` to the end of the ELF file,
     /// creating a new PT_LOAD segment (from PT_GNU_STACK) to map it. Stores the
     /// new segment's vaddr at the original BUN_COMPILED location so the runtime
@@ -244,6 +303,7 @@ fn alignUp(value: u64, alignment: u64) u64 {
 }
 
 const bun = @import("bun");
+const log = bun.Output.scoped(.elf, .visible);
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;

--- a/src/elf.zig
+++ b/src/elf.zig
@@ -302,8 +302,9 @@ fn alignUp(value: u64, alignment: u64) u64 {
     return (value + mask) & ~mask;
 }
 
-const bun = @import("bun");
 const log = bun.Output.scoped(.elf, .visible);
+
+const bun = @import("bun");
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;

--- a/test/regression/issue/24742.test.ts
+++ b/test/regression/issue/24742.test.ts
@@ -5,9 +5,9 @@
 //
 // https://github.com/oven-sh/bun/issues/24742
 
-import { test, expect } from "bun:test";
-import { bunEnv, bunExe, tempDir, isLinux, isMusl } from "harness";
-import { cpSync, readFileSync, existsSync, chmodSync } from "fs";
+import { expect, test } from "bun:test";
+import { chmodSync, cpSync, existsSync, readFileSync } from "fs";
+import { bunEnv, bunExe, isLinux, isMusl, tempDir } from "harness";
 import { join } from "path";
 
 const patchelf = Bun.which("patchelf");

--- a/test/regression/issue/24742.test.ts
+++ b/test/regression/issue/24742.test.ts
@@ -1,0 +1,104 @@
+// On NixOS, autoPatchelfHook rewrites bun's PT_INTERP to a /nix/store/... path.
+// `bun build --compile` then copies that patched binary, producing output that
+// only runs on the same Nix generation. We now detect store-path interpreters
+// and rewrite them back to the standard FHS path.
+//
+// https://github.com/oven-sh/bun/issues/24742
+
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir, isLinux, isMusl } from "harness";
+import { cpSync, readFileSync, existsSync, chmodSync } from "fs";
+import { join } from "path";
+
+const patchelf = Bun.which("patchelf");
+
+const ldso =
+  process.arch === "arm64"
+    ? isMusl
+      ? "/lib/ld-musl-aarch64.so.1"
+      : "/lib/ld-linux-aarch64.so.1"
+    : isMusl
+      ? "/lib/ld-musl-x86_64.so.1"
+      : "/lib64/ld-linux-x86-64.so.2";
+
+const ldsoBasename = ldso.split("/").pop()!;
+const fakeNixInterp = `/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-glibc-2.40-1/lib/${ldsoBasename}`;
+
+// Read PT_INTERP path from an ELF64 LE binary.
+function readInterp(buf: Buffer): string | null {
+  if (buf.length < 64 || buf.readUInt32BE(0) !== 0x7f454c46) return null;
+  const e_phoff = Number(buf.readBigUInt64LE(32));
+  const e_phnum = buf.readUInt16LE(56);
+  for (let i = 0; i < e_phnum; i++) {
+    const ph = e_phoff + i * 56;
+    if (buf.readUInt32LE(ph) !== 3 /* PT_INTERP */) continue;
+    const p_offset = Number(buf.readBigUInt64LE(ph + 8));
+    const p_filesz = Number(buf.readBigUInt64LE(ph + 32));
+    const region = buf.subarray(p_offset, p_offset + p_filesz);
+    const nul = region.indexOf(0);
+    return region.subarray(0, nul === -1 ? region.length : nul).toString("utf8");
+  }
+  return null;
+}
+
+test.skipIf(!isLinux || !patchelf || !existsSync(ldso))(
+  "bun build --compile normalizes /nix/store interpreter (#24742)",
+  async () => {
+    using dir = tempDir("nix-interp", {
+      "in.js": `console.log("hello from compiled");`,
+    });
+    const cwd = String(dir);
+
+    // Simulate a NixOS-installed bun: copy the real binary, then patchelf it.
+    const fakeNixBun = join(cwd, "fake-nix-bun");
+    cpSync(bunExe(), fakeNixBun);
+    chmodSync(fakeNixBun, 0o755);
+
+    {
+      const r = Bun.spawnSync({
+        cmd: [patchelf!, "--set-interpreter", fakeNixInterp, fakeNixBun],
+        stderr: "pipe",
+      });
+      expect(r.stderr.toString()).toBe("");
+      expect(r.exitCode).toBe(0);
+    }
+    expect(readInterp(readFileSync(fakeNixBun))).toBe(fakeNixInterp);
+
+    // Build using the patched binary as the template via --compile-executable-path.
+    // (We run the real bunExe(); only the *source* of the copy is the Nix-patched one.)
+    const out = join(cwd, "out");
+    {
+      const r = Bun.spawnSync({
+        cmd: [
+          bunExe(),
+          "build",
+          "--compile",
+          "--compile-executable-path",
+          fakeNixBun,
+          join(cwd, "in.js"),
+          "--outfile",
+          out,
+        ],
+        env: bunEnv,
+        cwd,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const stderr = r.stderr.toString();
+      expect(stderr).not.toContain("error:");
+      expect(r.exitCode).toBe(0);
+    }
+
+    // The compiled output's interpreter must be the standard FHS path,
+    // not the /nix/store path baked into fake-nix-bun.
+    const interp = readInterp(readFileSync(out));
+    expect(interp).toBe(ldso);
+
+    // And it must actually run on a stock system.
+    {
+      const r = Bun.spawnSync({ cmd: [out], env: bunEnv, stderr: "pipe", stdout: "pipe" });
+      expect(r.stdout.toString().trim()).toBe("hello from compiled");
+      expect(r.exitCode).toBe(0);
+    }
+  },
+);


### PR DESCRIPTION
### What does this PR do?

On NixOS, `autoPatchelfHook` rewrites bun's `PT_INTERP` from `/lib64/ld-linux-x86-64.so.2` to a `/nix/store/<hash>-glibc-.../lib/...` path. `bun build --compile` copies the running binary verbatim, so the output inherits that store path and only runs on the exact same Nix generation.

This adds `ElfFile.normalizeInterpreter()`: when injecting the `.bun` section, if `PT_INTERP` starts with `/nix/store/` or `/gnu/store/`, rewrite it to the standard FHS path by mapping the linker basename:

| basename | rewritten to |
|---|---|
| `ld-linux-x86-64.so.2` | `/lib64/ld-linux-x86-64.so.2` |
| `ld-linux-aarch64.so.1` | `/lib/ld-linux-aarch64.so.1` |
| `ld-musl-x86_64.so.1` | `/lib/ld-musl-x86_64.so.1` |
| `ld-musl-aarch64.so.1` | `/lib/ld-musl-aarch64.so.1` |

Store paths are always longer than the FHS path (32-char hash + pname + `/lib/` alone exceeds any of these), so this is an in-place shrink — write the new string, zero-fill, update `p_filesz`/`p_memsz`. No segment moves.

**No effect on non-Nix users** — gated on the store-path prefix; unknown basenames are left untouched.

Fixes #24742

### How did you verify your code works?

- `bun bd` builds, `bun run zig:check-all` passes on all targets
- New `test/regression/issue/24742.test.ts` (Linux-only, requires `patchelf`): copies bun, sets a fake `/nix/store/...` interpreter, runs `bun build --compile --compile-executable-path=<patched>`, asserts output's `PT_INTERP` is the FHS path and the binary executes
- Test correctly skips on macOS locally; Linux CI will exercise the pass case