### PR TITLE
fix null deref in forEachProperty prototype walk

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5364,7 +5364,9 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = proto ? proto.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { normalizeBunSnapshot, tmpdirSync } from "harness";
+import { writeFileSync } from "fs";
+import { bunEnv, bunExe, normalizeBunSnapshot, tmpdirSync } from "harness";
 import { join } from "path";
 import util from "util";
 it("prototype", () => {
@@ -739,4 +740,33 @@ it("CustomEvent", () => {
       BUBBLING_PHASE: 3,
     }"
   `);
+});
+
+it("formatting object with Proxy prototype does not crash", () => {
+  // Regression test for a crash in JSC__JSValue__forEachPropertyImpl's slow
+  // path: walking the prototype chain must not call .getObject() on an empty
+  // JSValue. Run in a child process so a segfault doesn't tear down the
+  // test runner.
+  const dir = tmpdirSync();
+  const script = join(dir, "repro.js");
+  writeFileSync(
+    script,
+    `import { expect } from "bun:test";
+const v = expect();
+Object.setPrototypeOf(v, new Proxy(Object.getPrototypeOf(v), {}));
+try { v.toBe(v); } catch {}
+Bun.inspect(v);
+`,
+  );
+  const result = Bun.spawnSync({
+    cmd: [bunExe(), script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stderr = result.stderr?.toString() ?? "";
+  expect(result.signalCode).toBeUndefined();
+  expect(stderr).not.toContain("Segmentation fault");
+  expect(stderr).not.toContain("runtime error");
+  expect(stderr).not.toContain("panic");
 });


### PR DESCRIPTION
Fixes a crash found by Fuzzilli (fingerprint `6b65dd404623d6cd`).

The slow path of `JSC__JSValue__forEachPropertyImpl` called `.getObject()` directly on the return value of `iterating->getPrototype()`:

```cpp
iterating = iterating->getPrototype(globalObject).getObject();
```

If `getPrototype()` returns an empty `JSValue` (e.g. because a Proxy `getPrototypeOf` trap threw), `getObject()` crashes: an empty `JSValue` is all zeros, so `isCell()` returns `true` while `asCell()` returns `nullptr`, which UBSAN/ASAN catches as a member call on a null `JSCell`.

Use the same pattern the fast path (lines 5121–5131) already uses: check truthiness of the returned `JSValue` and clear any pending exception from the Proxy trap.

### Repro
```js
const v = Bun.jest().expect();
Object.setPrototypeOf(v, new Proxy(Object.getPrototypeOf(v), {}));
v.toBe(v);
```

Before the fix this segfaults while formatting `v` for the `toBe` error message. After, it throws a normal `expect(...).toBe(...)` failure.

Regression test added in `test/js/bun/util/inspect.test.js`.