### PR TITLE
ci: run binary-size on a Linux EC2 agent with auto-retry

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -831,11 +831,16 @@ function getBinarySizeStep(releasePlatforms, options, { recordOnly = false } = {
   return {
     key: "binary-size",
     label: `${getBuildkiteEmoji("package")} binary-size`,
-    agents: { queue: "test-darwin" },
+    agents: getEc2Agent({ os: "linux", arch: "aarch64", distro: "amazonlinux", release: "2023" }, options, {
+      instanceType: "c8g.large",
+    }),
     depends_on: releasePlatforms.map(p => `${getTargetKey(p)}-build-bun`),
     allow_dependency_failure: true,
     soft_fail: !!options.skipSizeCheck,
-    retry: getRetry(),
+    retry: {
+      manual: { permit_on_passed: true },
+      automatic: [{ exit_status: "*", limit: 2 }],
+    },
     cancel_on_build_failing: isMergeQueue(),
     command: `bun scripts/binary-size.ts ${args.join(" ")}`,
   };


### PR DESCRIPTION
The `binary-size` step was running on `queue: test-darwin`, which is the same pool as every darwin `test-bun` shard. It becomes runnable at the exact moment all those shards do, so it was routinely losing the race and expiring after 20–60 minutes with no agent ever assigned (builds 44312, 44322, 44328, 44418). A separate one-off on build 44124 hit `bun: command not found` on a misconfigured darwin runner.

Move the step to a small `c8g.large` EC2 instance on the `linux-aarch64` amazonlinux build image — provisioned on demand so there's no queue to contend, and the build image guarantees `bun` in PATH. Also add `automatic: [{exit_status: "*", limit: 2}]` so any transient failure self-heals; the step is ~15 s and idempotent.