### PR TITLE
ci: fix binary-size agent image name

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -831,9 +831,11 @@ function getBinarySizeStep(releasePlatforms, options, { recordOnly = false } = {
   return {
     key: "binary-size",
     label: `${getBuildkiteEmoji("package")} binary-size`,
-    agents: getEc2Agent({ os: "linux", arch: "aarch64", distro: "amazonlinux", release: "2023" }, options, {
-      instanceType: "c8g.large",
-    }),
+    agents: getEc2Agent(
+      buildPlatforms.find(p => p.os === "linux" && p.arch === "aarch64" && p.distro === "amazonlinux"),
+      options,
+      { instanceType: "c8g.large" },
+    ),
     depends_on: releasePlatforms.map(p => `${getTargetKey(p)}-build-bun`),
     allow_dependency_failure: true,
     soft_fail: !!options.skipSizeCheck,


### PR DESCRIPTION
Follow-up to #28992. The hand-built platform object omitted `features: ["docker"]`, so `getImageKey()` produced `linux-aarch64-2023-amazonlinux-v29` — an AMI that doesn't exist (robobun: `Image not found`). Reuse the actual `buildPlatforms` linux-aarch64 entry so the image name stays identical to what `linux-aarch64-build-cpp` requests (`linux-aarch64-2023-amazonlinux-with-docker-v29`).