### PR TITLE
fix crash in ByteBlobLoader.toBufferedValue when source drained

### DIFF
--- a/src/bun.js/webcore/ByteBlobLoader.zig
+++ b/src/bun.js/webcore/ByteBlobLoader.zig
@@ -180,7 +180,8 @@ pub fn toBufferedValue(this: *ByteBlobLoader, globalThis: *JSGlobalObject, actio
         return blob.toPromise(globalThis, action);
     }
 
-    return .zero;
+    var empty: Blob.Any = .{ .Blob = .{} };
+    return empty.toPromise(globalThis, action);
 }
 
 pub fn memoryCost(this: *const ByteBlobLoader) usize {

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -906,6 +906,28 @@ it("new Response(stream).bytes() (direct)", async () => {
   expect(new TextDecoder().decode(buffer)).toBe("abdefgh");
 });
 
+it("Blob stream .bytes() called after being drained does not crash", async () => {
+  const blob = new Blob(["hello"]);
+  const stream = blob.stream();
+  const first = await stream.bytes();
+  expect(new TextDecoder().decode(first)).toBe("hello");
+  // After the underlying source is drained/detached, a second bytes() call
+  // must not trigger an assertion failure ("Expected an exception to be thrown").
+  const second = await stream.bytes();
+  expect(second).toBeInstanceOf(Uint8Array);
+  expect(second.byteLength).toBe(0);
+});
+
+it("Response body .bytes() called after being drained does not crash", async () => {
+  const response = new Response("hello");
+  const body = response.body;
+  const first = await body.bytes();
+  expect(new TextDecoder().decode(first)).toBe("hello");
+  const second = await body.bytes();
+  expect(second).toBeInstanceOf(Uint8Array);
+  expect(second.byteLength).toBe(0);
+});
+
 it("new Response(stream).text() (bytes)", async () => {
   var queue = [Buffer.from("abdefgh")];
   var stream = new ReadableStream({


### PR DESCRIPTION
`ByteBlobLoader.toBufferedValue` returned `.zero` without throwing an exception when `toAnyBlob` returned null (the underlying store was already detached). That violates the `toJSHostCall` contract (empty value must correspond to a thrown exception) and tripped the `assertExceptionPresenceMatches` assertion:

```
panic(main thread): Internal assertion failure: Expected an exception to be thrown
BlobInternalReadableStreamSourcePrototype__bytesFromJS
```

Return an empty `Blob.Any` wrapped in a promise instead, matching the shape the caller expects for an already-drained source.

Fingerprint: `4caaea6b9d6f1990`