### PR TITLE
fs: create parent dirs when cpSync copies a symlink

### DIFF
--- a/src/runtime/node/node_fs.zig
+++ b/src/runtime/node/node_fs.zig
@@ -6484,7 +6484,12 @@ pub const NodeFS = struct {
                             mode_ |= c.COPYFILE_EXCL;
                         }
 
-                        return ret.errnoSysP(c.copyfile(src, dest, null, mode_), .copyfile, src) orelse ret.success;
+                        const first_try = ret.errnoSysP(c.copyfile(src, dest, null, mode_), .copyfile, src) orelse return ret.success;
+                        if (first_try == .err and first_try.err.errno == @intFromEnum(Syscall.E.NOENT)) {
+                            bun.makePath(std.fs.cwd(), bun.path.dirname(dest, .auto)) catch {};
+                            return ret.errnoSysP(c.copyfile(src, dest, null, mode_), .copyfile, src) orelse ret.success;
+                        }
+                        return first_try;
                     }
                     @memcpy(this.sync_error_buf[0..src.len], src);
                     return Maybe(Return.CopyFile){ .err = .{
@@ -6591,7 +6596,14 @@ pub const NodeFS = struct {
                     if (err.getErrno() == .LOOP) {
                         // ELOOP is returned when you open a symlink with NOFOLLOW.
                         // as in, it does not actually let you open it.
-                        return this._cpSymlink(src, dest);
+                        const first_try = this._cpSymlink(src, dest);
+                        if (first_try == .err and first_try.err.getErrno() == .NOENT) {
+                            // Create the parent directory if it doesn't exist and retry,
+                            // matching the regular-file fallback below.
+                            bun.makePath(std.fs.cwd(), bun.path.dirname(dest, .auto)) catch {};
+                            return this._cpSymlink(src, dest);
+                        }
+                        return first_try;
                     }
 
                     return .{ .err = err };
@@ -6742,7 +6754,14 @@ pub const NodeFS = struct {
                     // open(2) returns EMLINK for this case, though POSIX
                     // specifies ELOOP; accept either.
                     if (err.getErrno() == .MLINK or err.getErrno() == .LOOP) {
-                        return this._cpSymlink(src, dest);
+                        const first_try = this._cpSymlink(src, dest);
+                        if (first_try == .err and first_try.err.getErrno() == .NOENT) {
+                            // Create the parent directory if it doesn't exist and retry,
+                            // matching the regular-file fallback below.
+                            bun.makePath(std.fs.cwd(), bun.path.dirname(dest, .auto)) catch {};
+                            return this._cpSymlink(src, dest);
+                        }
+                        return first_try;
                     }
                     return .{ .err = err };
                 },
@@ -6877,6 +6896,14 @@ pub const NodeFS = struct {
                 else
                     0;
                 if (windows.CreateSymbolicLinkW(dest, wbuf[0..len :0], flags) == 0) {
+                    // If the destination's parent directory doesn't exist, create it and retry,
+                    // matching the regular-file fallback above.
+                    if (windows.GetLastError() == .PATH_NOT_FOUND) {
+                        bun.makePathW(std.fs.cwd(), bun.path.dirnameW(dest)) catch {};
+                        if (windows.CreateSymbolicLinkW(dest, wbuf[0..len :0], flags) != 0) {
+                            return ret.success;
+                        }
+                    }
                     return ret.errnoSysP(0, .copyfile, this.osPathIntoSyncErrorBuf(dest)) orelse dst_enoent_maybe;
                 }
                 return ret.success;

--- a/test/regression/issue/28997.test.ts
+++ b/test/regression/issue/28997.test.ts
@@ -1,0 +1,41 @@
+// https://github.com/oven-sh/bun/issues/28997
+//
+// cpSync should create missing parent directories for symlinks, matching its
+// behavior for regular files and matching Node.js.
+import { expect, test } from "bun:test";
+import { cpSync, lstatSync, readFileSync, symlinkSync } from "fs";
+import { tempDir } from "harness";
+import { join } from "path";
+
+test("cpSync copies a symlink into a missing parent directory", () => {
+  using dir = tempDir("cp-sync-symlink-28997", {
+    "target.md": "# Hello",
+  });
+  const root = String(dir);
+
+  // Absolute target so the test works on Windows too.
+  symlinkSync(join(root, "target.md"), join(root, "link.md"));
+
+  // Regular file into a missing parent directory still works (baseline).
+  cpSync(join(root, "target.md"), join(root, "out/target.md"), { recursive: true });
+  expect(lstatSync(join(root, "out/target.md")).isFile()).toBe(true);
+
+  // The bug: symlink into a missing parent directory threw ENOENT.
+  // After the fix, the parent directory is created and the symlink is copied.
+  cpSync(join(root, "link.md"), join(root, "out2/link.md"), { recursive: true });
+  expect(lstatSync(join(root, "out2/link.md")).isSymbolicLink()).toBe(true);
+  expect(readFileSync(join(root, "out2/link.md"), "utf8")).toBe("# Hello");
+});
+
+test("cpSync copies a symlink into a deeply nested missing parent directory", () => {
+  using dir = tempDir("cp-sync-symlink-28997-nested", {
+    "target.md": "# Hello",
+  });
+  const root = String(dir);
+
+  symlinkSync(join(root, "target.md"), join(root, "link.md"));
+
+  cpSync(join(root, "link.md"), join(root, "a/b/c/link.md"), { recursive: true });
+  expect(lstatSync(join(root, "a/b/c/link.md")).isSymbolicLink()).toBe(true);
+  expect(readFileSync(join(root, "a/b/c/link.md"), "utf8")).toBe("# Hello");
+});


### PR DESCRIPTION
## What

`cpSync`'s regular-file path already retries `copyfile()` after creating the destination's parent directory when it fails with `ENOENT`. The symlink branches in `_copySingleFileSync` did not, so

```js
cpSync('link.md', 'out/link.md', { recursive: true });
```

threw `ENOENT: no such file or directory, symlink` when `out/` did not exist. Regular files in the same scenario worked fine, and Node and Bun's JS fallback (used with `dereference: true`) both create the parent directory first.

## Repro

```js
const { cpSync, symlinkSync, writeFileSync, mkdirSync } = require('fs');
mkdirSync('/tmp/x', { recursive: true });
process.chdir('/tmp/x');
writeFileSync('target.md', '# Hello');
symlinkSync('target.md', 'link.md');

cpSync('target.md', 'out/target.md', { recursive: true });   // ok
cpSync('link.md', 'out2/link.md', { recursive: true });      // ENOENT
```

## Cause

`src/bun.js/node/node_fs.zig::_copySingleFileSync`:

- **macOS symlink branch (~L6296):** called `copyfile(src, dest, COPYFILE_NOFOLLOW_SRC)` and returned the result directly. The regular-file branch a few lines below does `makePath` + retry on `ENOENT`; the symlink branch didn't.
- **Linux ELOOP fallback (~L6410):** when `open(src, O_NOFOLLOW)` returned `ELOOP`, the code called `Syscall.symlink(src, dest)` and returned unchanged. The regular-file path right below catches `ENOENT` on `open(dest, …)` and runs `mkdirRecursive` before retrying; the symlink fallback didn't.
- **Windows `CreateSymbolicLinkW` branch (~L6591):** same pattern — any failure propagated, including `PATH_NOT_FOUND`.

## Fix

Apply the existing "ENOENT → makePath → retry" fallback to all three symlink paths, mirroring the regular-file code in each platform branch.

## Test

`test/regression/issue/28997.test.ts` — creates a symlink and runs `cpSync` with a missing parent dir (one-level and three-level deep). Uses absolute symlink targets so the test passes on every platform.

```
# gate verification
USE_SYSTEM_BUN=1 bun test test/regression/issue/28997.test.ts  → 0 pass / 2 fail (ENOENT)
bun bd test test/regression/issue/28997.test.ts                → 2 pass / 0 fail
```

Fixes #28997