### PR TITLE
ReadFile: avoid integer overflow when computing buffer capacity

### DIFF
--- a/src/bun.js/webcore/blob/read_file.zig
+++ b/src/bun.js/webcore/blob/read_file.zig
@@ -386,6 +386,7 @@ pub const ReadFile = struct {
         if (!this.could_block or (this.size > 0 and this.size != Blob.max_size))
             this.buffer = std.ArrayListUnmanaged(u8).initCapacity(bun.default_allocator, @as(usize, this.size) + 16) catch |err| {
                 this.errno = err;
+                this.system_error = bun.sys.Error.fromCode(bun.sys.E.NOMEM, .read).toSystemError();
                 this.onFinish();
                 return;
             };

--- a/src/bun.js/webcore/blob/read_file.zig
+++ b/src/bun.js/webcore/blob/read_file.zig
@@ -384,7 +384,7 @@ pub const ReadFile = struct {
 
         // add an extra 16 bytes to the buffer to avoid having to resize it for trailing extra data
         if (!this.could_block or (this.size > 0 and this.size != Blob.max_size))
-            this.buffer = std.ArrayListUnmanaged(u8).initCapacity(bun.default_allocator, this.size + 16) catch |err| {
+            this.buffer = std.ArrayListUnmanaged(u8).initCapacity(bun.default_allocator, @as(usize, this.size) + 16) catch |err| {
                 this.errno = err;
                 this.onFinish();
                 return;

--- a/test/js/web/fetch/blob-oom.test.ts
+++ b/test/js/web/fetch/blob-oom.test.ts
@@ -144,13 +144,12 @@ describe("Bun.file", () => {
 });
 
 describe.if(!isWindows)("Bun.file on character devices", () => {
-  test("slice() with a very large max length does not crash", async () => {
+  test("slice() with a very large max length throws OOM without crashing", async () => {
     // Regression test: reading a character device (e.g. /dev/null) with a
     // max_length close to u52 max used to overflow `this.size + 16` in
-    // ReadFile.runAsyncWithFD and panic in debug builds.
-    const bytes = await Bun.file("/dev/null")
-      .slice(0, 2 ** 52 - 15)
-      .bytes();
-    expect(bytes.length).toBe(0);
+    // ReadFile.runAsyncWithFD and panic in debug builds. Also verifies that
+    // OOM from the buffer allocation is propagated to JS rather than
+    // silently returning an empty result.
+    expect(async () => await Bun.file("/dev/null").slice(0, 2 ** 52 - 15).bytes()).toThrow();
   });
 });

--- a/test/js/web/fetch/blob-oom.test.ts
+++ b/test/js/web/fetch/blob-oom.test.ts
@@ -150,6 +150,11 @@ describe.if(!isWindows)("Bun.file on character devices", () => {
     // ReadFile.runAsyncWithFD and panic in debug builds. Also verifies that
     // OOM from the buffer allocation is propagated to JS rather than
     // silently returning an empty result.
-    expect(async () => await Bun.file("/dev/null").slice(0, 2 ** 52 - 15).bytes()).toThrow();
+    expect(
+      async () =>
+        await Bun.file("/dev/null")
+          .slice(0, 2 ** 52 - 15)
+          .bytes(),
+    ).toThrow();
   });
 });

--- a/test/js/web/fetch/blob-oom.test.ts
+++ b/test/js/web/fetch/blob-oom.test.ts
@@ -1,7 +1,7 @@
 import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { unlinkSync } from "fs";
-import { tempDirWithFiles } from "harness";
+import { isWindows, tempDirWithFiles } from "harness";
 import path from "path";
 describe("Memory", () => {
   beforeAll(() => {
@@ -140,5 +140,17 @@ describe("Bun.file", () => {
 
   test("arrayBuffer() should NOT throw an OOM.", () => {
     expect(async () => await Bun.file(tmpFile).arrayBuffer()).not.toThrow();
+  });
+});
+
+describe.if(!isWindows)("Bun.file on character devices", () => {
+  test("slice() with a very large max length does not crash", async () => {
+    // Regression test: reading a character device (e.g. /dev/null) with a
+    // max_length close to u52 max used to overflow `this.size + 16` in
+    // ReadFile.runAsyncWithFD and panic in debug builds.
+    const bytes = await Bun.file("/dev/null")
+      .slice(0, 2 ** 52 - 15)
+      .bytes();
+    expect(bytes.length).toBe(0);
   });
 });


### PR DESCRIPTION
`this.size` is a `u52` (`Blob.SizeType`). In `ReadFile.runAsyncWithFD`, `this.size + 16` is evaluated in `u52` arithmetic, and overflows when `this.size` is close to `u52` max. In debug builds this traps as SIGILL and looks like a thread-pool crash:

```
bun.js.webcore.blob.read_file.ReadFile.runAsyncWithFD
/workspace/bun/src/bun.js/webcore/blob/read_file.zig:387:100

bun.js.webcore.Blob.FileOpener(bun.js.webcore.blob.read_file.ReadFile).getFd
/workspace/bun/src/bun.js/webcore/Blob.zig:4810:25
```

The existing guard `this.size != Blob.max_size` only excludes the exact max value, so any `size` in `[max_u52 - 15, max_u52 - 1]` still overflows.

Reachable today via e.g. `Bun.file('/dev/null').slice(0, 2**52 - 15).bytes()`: for a character device `resolveSizeAndLastModified` sets `this.size = max_length`, which is passed through from the blob slice.

Fix: widen to `usize` before adding. The allocator's existing catch handler gracefully handles the subsequent `OutOfMemory`.