### PR TITLE
fix(child_process): kill() returns false once the child has exited

### DIFF
--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -559,7 +559,7 @@ interface Subprocess extends AsyncDisposable {
   readonly signalCode: NodeJS.Signals | null;
   readonly killed: boolean;
 
-  kill(exitCode?: number | NodeJS.Signals): void;
+  kill(signal?: number | NodeJS.Signals): boolean;
   ref(): void;
   unref(): void;
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7251,8 +7251,10 @@ declare module "bun" {
     /**
      * Kill the process
      * @param exitCode The exitCode to send to the process
+     * @returns `true` if the signal was delivered, `false` if the process
+     * had already exited (the OS reported `ESRCH`).
      */
-    kill(exitCode?: number | NodeJS.Signals): void;
+    kill(exitCode?: number | NodeJS.Signals): boolean;
 
     /**
      * This method will tell Bun to wait for this process to exit after you already

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7249,12 +7249,12 @@ declare module "bun" {
     readonly killed: boolean;
 
     /**
-     * Kill the process
-     * @param exitCode The exitCode to send to the process
+     * Kill the process by sending it a signal.
+     * @param signal The signal to send to the process. Defaults to `"SIGTERM"`.
      * @returns `true` if the signal was delivered, `false` if the process
      * had already exited (the OS reported `ESRCH`).
      */
-    kill(exitCode?: number | NodeJS.Signals): boolean;
+    kill(signal?: number | NodeJS.Signals): boolean;
 
     /**
      * This method will tell Bun to wait for this process to exit after you already

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7249,16 +7249,11 @@ declare module "bun" {
     readonly killed: boolean;
 
     /**
-     * Send a signal to the process, or probe for its existence with `0`.
-     *
-     * When `signal` is `0` no signal is actually delivered; the call only
-     * reports whether the process is still reachable. This is the standard
-     * POSIX existence probe and does not terminate the child.
+     * Send a signal to the process, or probe for its existence with `0`
+     * (POSIX-style existence check that does not terminate the child).
      * @param signal The signal to send to the process. Defaults to `"SIGTERM"`.
      * @returns `true` if the signal was sent (or, for `signal === 0`, the
-     * process is still alive); `false` if the child process could not be
-     * reached — either Bun already observed its exit on our side or the
-     * OS reported `ESRCH`.
+     * process is still alive); `false` if the process has already exited.
      */
     kill(signal?: number | NodeJS.Signals): boolean;
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7249,10 +7249,15 @@ declare module "bun" {
     readonly killed: boolean;
 
     /**
-     * Kill the process by sending it a signal.
+     * Send a signal to the process, or probe for its existence with `0`.
+     *
+     * When `signal` is `0` no signal is actually delivered; the call only
+     * reports whether the process is still reachable. This is the standard
+     * POSIX existence probe and does not terminate the child.
      * @param signal The signal to send to the process. Defaults to `"SIGTERM"`.
-     * @returns `true` if the signal was delivered, `false` if the process
-     * had already exited (the OS reported `ESRCH`).
+     * @returns `true` if the signal was sent (or, for `signal === 0`, the
+     * process is still alive); `false` if the process had already exited
+     * (the OS reported `ESRCH`).
      */
     kill(signal?: number | NodeJS.Signals): boolean;
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7256,8 +7256,9 @@ declare module "bun" {
      * POSIX existence probe and does not terminate the child.
      * @param signal The signal to send to the process. Defaults to `"SIGTERM"`.
      * @returns `true` if the signal was sent (or, for `signal === 0`, the
-     * process is still alive); `false` if the process had already exited
-     * (the OS reported `ESRCH`).
+     * process is still alive); `false` if the child process could not be
+     * reached — either Bun already observed its exit on our side or the
+     * OS reported `ESRCH`.
      */
     kill(signal?: number | NodeJS.Signals): boolean;
 

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1485,19 +1485,9 @@ class ChildProcess extends EventEmitter {
     const handle = this.#handle;
     if (handle) {
       try {
-        // `handle.kill` returns `true` if the signal was delivered and
-        // `false` if the process was already gone (Bun observed the exit
-        // on our side or the OS reported ESRCH). Mirror Node, which
-        // returns `false` in the latter case so callers can tell them
-        // apart. Note that `handle.killed` is not useful here: Bun's
-        // Subprocess marks itself "killed" whenever the process has
-        // exited — even when it exited on its own without any signal.
+        // Don't gate on handle.killed: Bun flips it on any exit, signalled or not.
         const delivered = handle.kill(signal);
-        // `this.killed` tracks whether the user has asked us to kill
-        // (Node semantics). Only flip it when an actual signal was sent:
-        // `kill(0)` is just an existence probe and never terminates the
-        // child, so it must not mark the process as killed even when
-        // the probe succeeds.
+        // kill(0) is a POSIX existence probe, not a kill — don't mark killed.
         if (delivered && signal !== 0) this.killed = true;
         return delivered;
       } catch (e) {

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1484,15 +1484,20 @@ class ChildProcess extends EventEmitter {
 
     const handle = this.#handle;
     if (handle) {
-      if (handle.killed) {
-        this.killed = true;
-        return true;
-      }
-
       try {
-        handle.kill(signal);
-        this.killed = true;
-        return true;
+        // `handle.kill` returns `true` if the signal was delivered and
+        // `false` if the process was already gone (Bun observed the exit
+        // on our side or the OS reported ESRCH). Mirror Node, which
+        // returns `false` in the latter case so callers can tell them
+        // apart. Note that `handle.killed` is not useful here: Bun's
+        // Subprocess marks itself "killed" whenever the process has
+        // exited — even when it exited on its own without any signal.
+        const delivered = handle.kill(signal);
+        // `this.killed` tracks whether the user has asked us to kill
+        // (Node semantics). Only flip it when the signal was actually
+        // delivered; an already-dead process was never killed by *us*.
+        if (delivered) this.killed = true;
+        return delivered;
       } catch (e) {
         this.emit("error", e);
       }

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1494,9 +1494,11 @@ class ChildProcess extends EventEmitter {
         // exited — even when it exited on its own without any signal.
         const delivered = handle.kill(signal);
         // `this.killed` tracks whether the user has asked us to kill
-        // (Node semantics). Only flip it when the signal was actually
-        // delivered; an already-dead process was never killed by *us*.
-        if (delivered) this.killed = true;
+        // (Node semantics). Only flip it when an actual signal was sent:
+        // `kill(0)` is just an existence probe and never terminates the
+        // child, so it must not mark the process as killed even when
+        // the probe succeeds.
+        if (delivered && signal !== 0) this.killed = true;
         return delivered;
       } catch (e) {
         this.emit("error", e);

--- a/src/jsc/ProcessAutoKiller.rs
+++ b/src/jsc/ProcessAutoKiller.rs
@@ -40,7 +40,12 @@ impl ProcessAutoKiller {
                 let p: &mut Process = unsafe { &mut *entry.key };
                 if !p.has_exited() {
                     bun_core::scoped_log!(AutoKiller, "process.kill {}", p.pid);
-                    count += p.kill(SignalCode::DEFAULT.0).is_ok() as u32;
+                    // Count only processes where the signal was actually
+                    // delivered — a `.detached` poller or OS-reported ESRCH
+                    // returns `Ok(false)` from `kill` and should not count.
+                    if let Ok(true) = p.kill(SignalCode::DEFAULT.0) {
+                        count += 1;
+                    }
                 }
             }
             // SAFETY: key live until this releases the ref taken on insert.

--- a/src/jsc/ProcessAutoKiller.zig
+++ b/src/jsc/ProcessAutoKiller.zig
@@ -31,10 +31,7 @@ fn killProcesses(this: *ProcessAutoKiller) u32 {
         defer process.key.deref();
         if (!process.key.hasExited()) {
             log("process.kill {d}", .{process.key.pid});
-            switch (process.key.kill(@intFromEnum(bun.SignalCode.default))) {
-                .result => |delivered| count += @intFromBool(delivered),
-                .err => {},
-            }
+            count += @intFromBool(process.key.kill(@intFromEnum(bun.SignalCode.default)).isTrue());
         }
     }
     return count;

--- a/src/jsc/ProcessAutoKiller.zig
+++ b/src/jsc/ProcessAutoKiller.zig
@@ -31,7 +31,10 @@ fn killProcesses(this: *ProcessAutoKiller) u32 {
         defer process.key.deref();
         if (!process.key.hasExited()) {
             log("process.kill {d}", .{process.key.pid});
-            count += @as(u32, @intFromBool(process.key.kill(@intFromEnum(bun.SignalCode.default)) == .result));
+            switch (process.key.kill(@intFromEnum(bun.SignalCode.default))) {
+                .result => |delivered| count += @intFromBool(delivered),
+                .err => {},
+            }
         }
     }
     return count;

--- a/src/runtime/api/bun/process.zig
+++ b/src/runtime/api/bun/process.zig
@@ -573,7 +573,16 @@ pub const Process = struct {
         bun.destroy(this);
     }
 
-    pub fn kill(this: *Process, signal: u8) Maybe(void) {
+    /// Sends `signal` to the process.
+    ///
+    /// Returns:
+    /// - `.result = true` if the signal was delivered.
+    /// - `.result = false` if the OS reported `ESRCH` (the process is already
+    ///   gone). Callers that just want best-effort termination can ignore this,
+    ///   but anything JS-visible (e.g. `subprocess.kill()`) needs to propagate
+    ///   it so Node's `ChildProcess.kill()` can return `false`.
+    /// - `.err` for any other error.
+    pub fn kill(this: *Process, signal: u8) Maybe(bool) {
         if (comptime Environment.isPosix) {
             switch (this.poller) {
                 .waiter_thread, .fd => {
@@ -584,6 +593,8 @@ pub const Process = struct {
                         // if the process was already killed don't throw
                         if (errno_ != .SRCH)
                             return .{ .err = bun.sys.Error.fromCode(errno_, .kill) };
+
+                        return .{ .result = false };
                     }
                 },
                 else => {},
@@ -596,19 +607,17 @@ pub const Process = struct {
                         if (err.errno != @intFromEnum(bun.sys.E.SRCH)) {
                             return .{ .err = err };
                         }
+
+                        return .{ .result = false };
                     }
 
-                    return .{
-                        .result = {},
-                    };
+                    return .{ .result = true };
                 },
                 else => {},
             }
         }
 
-        return .{
-            .result = {},
-        };
+        return .{ .result = true };
     }
 };
 

--- a/src/runtime/api/bun/process.zig
+++ b/src/runtime/api/bun/process.zig
@@ -577,10 +577,12 @@ pub const Process = struct {
     ///
     /// Returns:
     /// - `.result = true` if the signal was delivered.
-    /// - `.result = false` if the OS reported `ESRCH` (the process is already
-    ///   gone). Callers that just want best-effort termination can ignore this,
-    ///   but anything JS-visible (e.g. `subprocess.kill()`) needs to propagate
-    ///   it so Node's `ChildProcess.kill()` can return `false`.
+    /// - `.result = false` if the child could not be reached — either the
+    ///   poller is already `.detached` (we observed the exit on our side)
+    ///   or the OS reported `ESRCH`. Callers that just want best-effort
+    ///   termination can ignore this, but anything JS-visible (e.g.
+    ///   `subprocess.kill()`) needs to propagate it so Node's
+    ///   `ChildProcess.kill()` can return `false`.
     /// - `.err` for any other error.
     pub fn kill(this: *Process, signal: u8) Maybe(bool) {
         if (comptime Environment.isPosix) {

--- a/src/runtime/api/bun/process.zig
+++ b/src/runtime/api/bun/process.zig
@@ -596,8 +596,14 @@ pub const Process = struct {
 
                         return .{ .result = false };
                     }
+
+                    return .{ .result = true };
                 },
-                else => {},
+                // `.detached` means we never armed the poller or we already
+                // called `detach()` from `onExit`. Either way there is no
+                // live child to signal — report "not delivered" rather than
+                // claiming success we didn't attempt.
+                .detached => return .{ .result = false },
             }
         } else if (comptime Environment.isWindows) {
             switch (this.poller) {
@@ -613,11 +619,11 @@ pub const Process = struct {
 
                     return .{ .result = true };
                 },
-                else => {},
+                .detached => return .{ .result = false },
             }
         }
 
-        return .{ .result = true };
+        return .{ .result = false };
     }
 };
 

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -651,7 +651,10 @@ impl Subprocess<'_> {
         this.stderr.with_mut(|s| s.unref());
 
         match this.try_kill(this.kill_signal) {
-            bun_sys::Result::Ok(()) => {}
+            // Delivered or not doesn't matter for asyncDispose — the caller
+            // just wants the child dead; falling through to `getExited`
+            // below handles both the "already gone" and "just killed" cases.
+            bun_sys::Result::Ok(_) => {}
             bun_sys::Result::Err(err) => {
                 // Signal 9 should always be fine, but just in case that somehow fails.
                 return Err(global.throw_value(err.to_js(global)));
@@ -717,23 +720,27 @@ impl Subprocess<'_> {
         }
 
         match this.try_kill(sig) {
-            bun_sys::Result::Ok(()) => {}
+            // `true` when the signal was sent, `false` when the process had
+            // already exited (nothing to signal). Node's `ChildProcess.kill()`
+            // needs to see `false` to return `false` to user code.
+            bun_sys::Result::Ok(delivered) => Ok(JSValue::js_boolean(delivered)),
             bun_sys::Result::Err(err) => {
                 // EINVAL or ENOSYS means the signal is not supported in the current platform (most likely unsupported on windows)
-                return Err(global_this.throw_value(err.to_js(global_this)));
+                Err(global_this.throw_value(err.to_js(global_this)))
             }
         }
-
-        Ok(JSValue::UNDEFINED)
     }
 
     pub fn has_killed(&self) -> bool {
         self.process().has_killed()
     }
 
-    pub fn try_kill(&self, sig: SignalCode) -> bun_sys::Result<()> {
+    /// Returns `Ok(true)` if `sig` was delivered to the child, or
+    /// `Ok(false)` if the child had already exited (either because we
+    /// already saw the exit on our side or the OS reported `ESRCH`).
+    pub fn try_kill(&self, sig: SignalCode) -> bun_sys::Result<bool> {
         if self.has_exited() {
-            return bun_sys::Result::Ok(());
+            return bun_sys::Result::Ok(false);
         }
         self.process_mut().kill(sig.0)
     }

--- a/src/runtime/api/bun/subprocess.zig
+++ b/src/runtime/api/bun/subprocess.zig
@@ -395,23 +395,27 @@ pub fn kill(
     if (globalThis.hasException()) return .zero;
 
     switch (this.tryKill(sig)) {
-        .result => {},
+        // `true` when the signal was sent, `false` when the process had
+        // already exited (nothing to signal). Node's `ChildProcess.kill()`
+        // needs to see `false` to return `false` to user code.
+        .result => |delivered| return JSValue.jsBoolean(delivered),
         .err => |err| {
             // EINVAL or ENOSYS means the signal is not supported in the current platform (most likely unsupported on windows)
             return globalThis.throwValue(try err.toJS(globalThis));
         },
     }
-
-    return .js_undefined;
 }
 
 pub fn hasKilled(this: *const Subprocess) bool {
     return this.process.hasKilled();
 }
 
-pub fn tryKill(this: *Subprocess, sig: SignalCode) bun.sys.Maybe(void) {
+/// Returns `.result = true` if `sig` was delivered to the child, or
+/// `.result = false` if the child had already exited (either because we
+/// already saw the exit on our side or the OS reported `ESRCH`).
+pub fn tryKill(this: *Subprocess, sig: SignalCode) bun.sys.Maybe(bool) {
     if (this.hasExited()) {
-        return .success;
+        return .{ .result = false };
     }
     return this.process.kill(@intFromEnum(sig));
 }

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -403,7 +403,11 @@ impl ShellSubprocess {
             return Ok(());
         }
 
-        self.proc().kill(u8::try_from(sig).expect("int cast"))
+        // Shell subprocess kill is best-effort — drop the "delivered?" bool
+        // from process.kill's Maybe<bool>, keep errors.
+        self.proc()
+            .kill(u8::try_from(sig).expect("int cast"))
+            .map(|_delivered| ())
     }
 
     // fn has_called_getter(self: &Subprocess, comptime getter: @Type(.enum_literal)) -> bool {

--- a/src/runtime/shell/subproc.zig
+++ b/src/runtime/shell/subproc.zig
@@ -498,7 +498,13 @@ pub const ShellSubprocess = struct {
             return .success;
         }
 
-        return this.process.kill(@intCast(sig));
+        return switch (this.process.kill(@intCast(sig))) {
+            // The shell's subprocess doesn't distinguish "signal delivered"
+            // from "process was already gone" — both are a no-op success
+            // for the shell's best-effort termination flow.
+            .result => .success,
+            .err => |err| .{ .err = err },
+        };
     }
 
     // fn hasCalledGetter(this: *Subprocess, comptime getter: @Type(.enum_literal)) bool {

--- a/src/runtime/shell/subproc.zig
+++ b/src/runtime/shell/subproc.zig
@@ -498,13 +498,9 @@ pub const ShellSubprocess = struct {
             return .success;
         }
 
-        return switch (this.process.kill(@intCast(sig))) {
-            // The shell's subprocess doesn't distinguish "signal delivered"
-            // from "process was already gone" — both are a no-op success
-            // for the shell's best-effort termination flow.
-            .result => .success,
-            .err => |err| .{ .err = err },
-        };
+        // Shell kill is best-effort — drop the "delivered?" bool, keep errors.
+        if (this.process.kill(@intCast(sig)).asErr()) |err| return .{ .err = err };
+        return .success;
     }
 
     // fn hasCalledGetter(this: *Subprocess, comptime getter: @Type(.enum_literal)) bool {

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -654,7 +654,14 @@ impl Process {
         self.exit_handler = ProcessExitHandler::default();
     }
 
-    pub fn kill(&mut self, signal: u8) -> Maybe<()> {
+    /// Sends `signal` to the process.
+    ///
+    /// Returns `Ok(true)` if the signal was delivered, `Ok(false)` if the
+    /// child could not be reached — either the poller is detached (we
+    /// observed the exit on our side) or the OS reported `ESRCH`. Anything
+    /// JS-visible (e.g. `subprocess.kill()`) needs to propagate this so
+    /// Node's `ChildProcess.kill()` can return `false`.
+    pub fn kill(&mut self, signal: u8) -> Maybe<bool> {
         #[cfg(unix)]
         {
             // Spec process.zig:550 — `.waiter_thread, .fd => kill(); else => {}`.
@@ -683,9 +690,12 @@ impl Process {
                         if errno_ != bun_sys::E::ESRCH {
                             return Err(bun_sys::Error::from_code(errno_, bun_sys::Tag::kill));
                         }
+                        return Ok(false);
                     }
+                    return Ok(true);
                 }
-                _ => {}
+                // Detached: no live child to signal.
+                _ => return Ok(false),
             }
         }
         #[cfg(windows)]
@@ -700,14 +710,16 @@ impl Process {
                         if err.errno != bun_sys::E::ESRCH as u16 {
                             return Err(err);
                         }
+                        return Ok(false);
                     }
-                    return Ok(());
+                    return Ok(true);
                 }
-                _ => {}
+                _ => return Ok(false),
             }
         }
 
-        Ok(())
+        #[cfg(not(any(unix, windows)))]
+        Ok(false)
     }
 }
 

--- a/test/integration/bun-types/fixture/spawn.ts
+++ b/test/integration/bun-types/fixture/spawn.ts
@@ -119,10 +119,10 @@ function depromise<T>(_promise: Promise<T>): T {
   proc.killed; // boolean — was the process killed?
   proc.exitCode; // null | number
   proc.signalCode; // null | "SIGABRT" | "SIGALRM" | ...
-  proc.kill();
+  tsd.expectType(proc.kill()).is<boolean>();
   proc.killed; // true
 
-  proc.kill(); // specify an exit code
+  tsd.expectType(proc.kill(9)).is<boolean>(); // specify a signal
   proc.unref();
 }
 

--- a/test/regression/issue/29001.test.ts
+++ b/test/regression/issue/29001.test.ts
@@ -55,9 +55,11 @@ describe.concurrent("issue #29001 — kill() reports failure after exit", () => 
   });
 
   // The Bun.spawn exit-path tests exercise the platform-agnostic
-  // `hasExited()` fast path inside `Subprocess.tryKill` and the
-  // Windows-specific `ESRCH` branch in `Process.kill`, so they run on
-  // every platform.
+  // `hasExited()` fast path inside `Subprocess.tryKill` — by the time
+  // `await proc.exited` resolves, `tryKill` short-circuits before ever
+  // reaching `Process.kill`, so the OS-level `ESRCH` branch is *not*
+  // covered here. These tests still run on every platform because the
+  // fast path itself is cross-platform.
   test("Bun.spawn subprocess.kill() returns false after exit", async () => {
     await using proc = bunSpawn({
       cmd: [bunExe(), "-e", "process.exit(0)"],

--- a/test/regression/issue/29001.test.ts
+++ b/test/regression/issue/29001.test.ts
@@ -4,13 +4,8 @@ import { bunEnv, bunExe, isPosix } from "harness";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
 
-// https://github.com/oven-sh/bun/issues/29001
-//
-// `ChildProcess.kill()` must return `false` once the child has exited,
-// matching Node.js. Before the fix the JS binding for `Subprocess.kill()`
-// always returned `undefined`, so the `node:child_process` wrapper could
-// never tell the difference between "signal delivered" and "process was
-// already gone" and ended up returning `true` in both cases.
+// https://github.com/oven-sh/bun/issues/29001 — kill() must return false
+// once the child has exited, matching Node.
 describe.concurrent("issue #29001 — kill() reports failure after exit", () => {
   test.if(isPosix)("node:child_process ChildProcess.kill() returns false after exit", async () => {
     const proc = spawn(bunExe(), ["-e", "process.exit(0)"], {
@@ -18,35 +13,25 @@ describe.concurrent("issue #29001 — kill() reports failure after exit", () => 
       stdio: "ignore",
     });
 
-    // Wait for the child to actually exit cleanly. We check the exit
-    // code/signal before the kill assertions so a fixture crash surfaces
-    // as a meaningful failure instead of a misleading "kill returned true".
+    // Assert the clean exit first so a fixture crash surfaces clearly.
     const [code, signal] = await once(proc, "close");
     expect(code).toBe(0);
     expect(signal).toBe(null);
 
-    // Every kill attempt must now report failure — the process is gone.
     expect(proc.kill("SIGTERM")).toBe(false);
     expect(proc.kill("SIGQUIT")).toBe(false);
-    // Signal 0 is the existence probe; it must also report failure.
     expect(proc.kill(0)).toBe(false);
 
-    // `proc.killed` only flips when *we* successfully delivered a signal.
-    // The child exited on its own, so it must still be false — matching
-    // Node's documented semantics.
+    // Child exited on its own — proc.killed only flips on our signal.
     expect(proc.killed).toBe(false);
   });
 
   test.if(isPosix)("node:child_process ChildProcess.kill() returns true while alive", async () => {
-    // `cat` with no stdin sits around until we kill it.
     const proc = spawn("cat", [], { stdio: ["pipe", "ignore", "ignore"] });
 
     try {
-      // Signal 0 does not terminate but should report success.
+      // Signal 0 is an existence probe — succeeds but must not mark killed.
       expect(proc.kill(0)).toBe(true);
-      // A successful existence probe must NOT mark the child as killed;
-      // only a real signal delivery flips `proc.killed`. Mirrors Node,
-      // which guards this with `signal > 0`.
       expect(proc.killed).toBe(false);
     } finally {
       proc.kill("SIGKILL");
@@ -54,12 +39,9 @@ describe.concurrent("issue #29001 — kill() reports failure after exit", () => 
     }
   });
 
-  // The Bun.spawn exit-path tests exercise the platform-agnostic
-  // `hasExited()` fast path inside `Subprocess.tryKill` — by the time
-  // `await proc.exited` resolves, `tryKill` short-circuits before ever
-  // reaching `Process.kill`, so the OS-level `ESRCH` branch is *not*
-  // covered here. These tests still run on every platform because the
-  // fast path itself is cross-platform.
+  // These Bun.spawn tests cover the cross-platform hasExited() fast path
+  // in Subprocess.tryKill (short-circuits before Process.kill), so they
+  // don't exercise the OS-level ESRCH branch.
   test("Bun.spawn subprocess.kill() returns false after exit", async () => {
     await using proc = bunSpawn({
       cmd: [bunExe(), "-e", "process.exit(0)"],
@@ -78,7 +60,6 @@ describe.concurrent("issue #29001 — kill() reports failure after exit", () => 
   test.if(isPosix)("Bun.spawn subprocess.kill() returns true while alive", async () => {
     await using proc = bunSpawn({
       cmd: ["cat"],
-      env: bunEnv,
       stdio: ["pipe", "ignore", "ignore"],
     });
 

--- a/test/regression/issue/29001.test.ts
+++ b/test/regression/issue/29001.test.ts
@@ -18,14 +18,23 @@ describe.concurrent("issue #29001 — kill() reports failure after exit", () => 
       stdio: "ignore",
     });
 
-    // Wait for the child to actually exit.
-    await once(proc, "close");
+    // Wait for the child to actually exit cleanly. We check the exit
+    // code/signal before the kill assertions so a fixture crash surfaces
+    // as a meaningful failure instead of a misleading "kill returned true".
+    const [code, signal] = await once(proc, "close");
+    expect(code).toBe(0);
+    expect(signal).toBe(null);
 
     // Every kill attempt must now report failure — the process is gone.
     expect(proc.kill("SIGTERM")).toBe(false);
     expect(proc.kill("SIGQUIT")).toBe(false);
     // Signal 0 is the existence probe; it must also report failure.
     expect(proc.kill(0)).toBe(false);
+
+    // `proc.killed` only flips when *we* successfully delivered a signal.
+    // The child exited on its own, so it must still be false — matching
+    // Node's documented semantics.
+    expect(proc.killed).toBe(false);
   });
 
   test.if(isPosix)("node:child_process ChildProcess.kill() returns true while alive", async () => {
@@ -35,20 +44,30 @@ describe.concurrent("issue #29001 — kill() reports failure after exit", () => 
     try {
       // Signal 0 does not terminate but should report success.
       expect(proc.kill(0)).toBe(true);
+      // A successful existence probe must NOT mark the child as killed;
+      // only a real signal delivery flips `proc.killed`. Mirrors Node,
+      // which guards this with `signal > 0`.
+      expect(proc.killed).toBe(false);
     } finally {
       proc.kill("SIGKILL");
       await once(proc, "close");
     }
   });
 
-  test.if(isPosix)("Bun.spawn subprocess.kill() returns false after exit", async () => {
+  // The Bun.spawn exit-path tests exercise the platform-agnostic
+  // `hasExited()` fast path inside `Subprocess.tryKill` and the
+  // Windows-specific `ESRCH` branch in `Process.kill`, so they run on
+  // every platform.
+  test("Bun.spawn subprocess.kill() returns false after exit", async () => {
     await using proc = bunSpawn({
       cmd: [bunExe(), "-e", "process.exit(0)"],
       env: bunEnv,
       stdio: ["ignore", "ignore", "ignore"],
     });
 
-    await proc.exited;
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+    expect(proc.signalCode).toBe(null);
 
     expect(proc.kill("SIGTERM")).toBe(false);
     expect(proc.kill(0)).toBe(false);

--- a/test/regression/issue/29001.test.ts
+++ b/test/regression/issue/29001.test.ts
@@ -1,7 +1,7 @@
-import { spawn } from "node:child_process";
 import { spawn as bunSpawn } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isPosix } from "harness";
+import { spawn } from "node:child_process";
 import { once } from "node:events";
 
 // https://github.com/oven-sh/bun/issues/29001

--- a/test/regression/issue/29001.test.ts
+++ b/test/regression/issue/29001.test.ts
@@ -1,0 +1,71 @@
+import { spawn } from "node:child_process";
+import { spawn as bunSpawn } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix } from "harness";
+import { once } from "node:events";
+
+// https://github.com/oven-sh/bun/issues/29001
+//
+// `ChildProcess.kill()` must return `false` once the child has exited,
+// matching Node.js. Before the fix the JS binding for `Subprocess.kill()`
+// always returned `undefined`, so the `node:child_process` wrapper could
+// never tell the difference between "signal delivered" and "process was
+// already gone" and ended up returning `true` in both cases.
+describe.concurrent("issue #29001 — kill() reports failure after exit", () => {
+  test.if(isPosix)("node:child_process ChildProcess.kill() returns false after exit", async () => {
+    const proc = spawn(bunExe(), ["-e", "process.exit(0)"], {
+      env: bunEnv,
+      stdio: "ignore",
+    });
+
+    // Wait for the child to actually exit.
+    await once(proc, "close");
+
+    // Every kill attempt must now report failure — the process is gone.
+    expect(proc.kill("SIGTERM")).toBe(false);
+    expect(proc.kill("SIGQUIT")).toBe(false);
+    // Signal 0 is the existence probe; it must also report failure.
+    expect(proc.kill(0)).toBe(false);
+  });
+
+  test.if(isPosix)("node:child_process ChildProcess.kill() returns true while alive", async () => {
+    // `cat` with no stdin sits around until we kill it.
+    const proc = spawn("cat", [], { stdio: ["pipe", "ignore", "ignore"] });
+
+    try {
+      // Signal 0 does not terminate but should report success.
+      expect(proc.kill(0)).toBe(true);
+    } finally {
+      proc.kill("SIGKILL");
+      await once(proc, "close");
+    }
+  });
+
+  test.if(isPosix)("Bun.spawn subprocess.kill() returns false after exit", async () => {
+    await using proc = bunSpawn({
+      cmd: [bunExe(), "-e", "process.exit(0)"],
+      env: bunEnv,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+
+    await proc.exited;
+
+    expect(proc.kill("SIGTERM")).toBe(false);
+    expect(proc.kill(0)).toBe(false);
+  });
+
+  test.if(isPosix)("Bun.spawn subprocess.kill() returns true while alive", async () => {
+    await using proc = bunSpawn({
+      cmd: ["cat"],
+      env: bunEnv,
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+
+    try {
+      expect(proc.kill(0)).toBe(true);
+    } finally {
+      proc.kill("SIGKILL");
+      await proc.exited;
+    }
+  });
+});


### PR DESCRIPTION
## What

Before: `ChildProcess.kill()` always returned `true`, even after awaiting the child's `close` event. Node returns `false` in that case so callers can distinguish "signal delivered" from "process was already gone".

```js
import { spawn } from 'node:child_process';
const proc = spawn('echo', ['hi'], { stdio: 'inherit' });
await new Promise(r => proc.on('close', r));
console.log(proc.kill('SIGQUIT')); // Node: false, Bun (old): true
```

## Why

Two bugs cooperated to hide the `ESRCH` signal:

1. `src/bun.js/api/bun/subprocess.zig` `tryKill` returned `.success` whenever `hasExited()` was true, and the `kill` JS binding threw the result away and returned `undefined`.
2. `src/js/node/child_process.ts` `ChildProcess.prototype.kill` then short-circuited on `handle.killed` (which Bun's Subprocess flips to `true` for *any* exited process, even one that exited on its own) and returned `true` from the happy path.

## How

- `Process.kill` now returns `Maybe(bool)` — `.result = true` if the signal was delivered, `.result = false` if `kill(2)` / `uv_process_kill` reported `ESRCH`.
- `Subprocess.tryKill` propagates that and also reports `false` when the Subprocess already observed the exit on its side.
- The `Subprocess.kill` JS binding returns a boolean (the public `Bun.Subprocess#kill()` API signature is updated accordingly).
- `ChildProcess.prototype.kill` returns that boolean and only sets `this.killed = true` when the signal was actually delivered — matching Node, which documents `childprocess.killed` as "set to true after subprocess.kill() is used to successfully send a signal."
- Bun's internal shell subprocess keeps its existing "best-effort success" contract; only the JS-visible path changed.

## Tests

`test/regression/issue/29001.test.ts` covers both `node:child_process` and `Bun.spawn`:

- `kill()` returns `false` for `SIGTERM` / `SIGQUIT` / signal 0 after `close`.
- `kill(0)` returns `true` while the child is alive.

Fail-before / pass-after confirmed with `USE_SYSTEM_BUN=1`. Official Node parallel tests `test-child-process-kill.js` and `test-child-process-destroy.js` still pass, as do `test/js/bun/spawn/spawn-kill-signal.test.ts`.

Fixes #29001