### PR TITLE
Never iterate WeakMap/WeakSet when formatting

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -2757,14 +2757,20 @@ pub const Formatter = struct {
                 writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
             },
             .Map => {
+                const is_weak = value.jsType() == .WeakMap;
+                const map_name = if (is_weak) "WeakMap" else "Map";
+
+                // WeakMap is not iterable and has no size; always print empty.
+                if (is_weak) {
+                    return writer.print("{s} {{}}", .{map_name});
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
-
-                const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{map_name});
@@ -2864,14 +2870,20 @@ pub const Formatter = struct {
                 writer.writeAll("}");
             },
             .Set => {
+                const is_weak = value.jsType() == .WeakSet;
+                const set_name = if (is_weak) "WeakSet" else "Set";
+
+                // WeakSet is not iterable and has no size; always print empty.
+                if (is_weak) {
+                    return writer.print("{s} {{}}", .{set_name});
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
-
-                const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{set_name});

--- a/src/test_runner/diff_format.zig
+++ b/src/test_runner/diff_format.zig
@@ -43,7 +43,9 @@ pub const DiffFormatter = struct {
                 1,
                 &received_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                _ = this.globalThis.clearExceptionExceptTermination();
+            };
 
             JestPrettyFormat.format(
                 .Debug,
@@ -52,7 +54,9 @@ pub const DiffFormatter = struct {
                 1,
                 &expected_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                _ = this.globalThis.clearExceptionExceptTermination();
+            };
         }
 
         var received_slice = received_buf.written();

--- a/src/test_runner/pretty_format.zig
+++ b/src/test_runner/pretty_format.zig
@@ -1307,14 +1307,20 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
                 },
                 .Map => {
+                    const is_weak = value.jsType() == .WeakMap;
+                    const map_name = if (is_weak) "WeakMap" else "Map";
+
+                    // WeakMap is not iterable and has no size; always print empty.
+                    if (is_weak) {
+                        return writer.print("{s} {{}}", .{map_name});
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
                     const prev_quote_strings = this.quote_strings;
                     this.quote_strings = true;
                     defer this.quote_strings = prev_quote_strings;
-
-                    const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{map_name});
@@ -1335,6 +1341,15 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll("\n");
                 },
                 .Set => {
+                    const is_weak = value.jsType() == .WeakSet;
+                    const set_name = if (is_weak) "WeakSet" else "Set";
+
+                    // WeakSet is not iterable and has no size; always print empty.
+                    if (is_weak) {
+                        this.writeIndent(Writer, writer_) catch {};
+                        return writer.print("{s} {{}}", .{set_name});
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
@@ -1343,8 +1358,6 @@ pub const JestPrettyFormat = struct {
                     defer this.quote_strings = prev_quote_strings;
 
                     this.writeIndent(Writer, writer_) catch {};
-
-                    const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{set_name});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -734,6 +734,26 @@ it("MessageEvent", () => {
   `);
 });
 
+it("WeakMap/WeakSet with fake size property does not crash", () => {
+  // Regression: WeakMap/WeakSet are not iterable and have no `size` getter,
+  // but user code can assign a `size` data property. Previously, formatting
+  // such an object tried to iterate it when `size > 0`, which threw a
+  // TypeError and left a pending JSC exception, causing an
+  // `Unexpected exception observed` assertion in debug builds.
+  const wm = new WeakMap();
+  wm.size = 1728;
+  expect(Bun.inspect(wm)).toBe("WeakMap {}");
+
+  const ws = new WeakSet();
+  ws.size = 42;
+  expect(Bun.inspect(ws)).toBe("WeakSet {}");
+
+  // Also make sure the jest diff formatter does not crash on these.
+  const ta = new Int16Array(2);
+  expect(() => expect(wm).toMatchObject(ta)).toThrow();
+  expect(() => expect(ta).toMatchObject(wm)).toThrow();
+});
+
 it("CustomEvent", () => {
   const customEvent = new CustomEvent("custom", {
     detail: { value: 42, name: "test" },


### PR DESCRIPTION
Fuzzilli fingerprint: `c523fc74dc21960c`

```js
const v3 = new Int16Array(2);
const v5 = new WeakMap();
v5.size = 1728;
Bun.jest().expect(v5).toMatchObject(v3);
```

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: Type error
!exception() || m_vm.hasPendingTerminationException()
ExceptionScope.h(63) : JSC::ExceptionScope::assertNoExceptionExceptTermination()
```

`WeakMap`/`WeakSet` are not iterable and have no `size` getter, but user code can assign `size` as an own data property. Both the console formatter (`ConsoleObject.zig`) and the jest pretty formatter (`pretty_format.zig`) read that property and, if nonzero, fell through to `forEachInIterable`, which threw a `TypeError`. In the jest diff path the error was swallowed with a bare `catch {}`, leaving a pending JSC exception and tripping the `Unexpected exception observed` assertion in debug builds.

- Always print `WeakMap {}` / `WeakSet {}` regardless of the fake `.size` property, since they cannot be iterated.
- Clear any pending exception in `DiffFormatter` when a format error is swallowed.