### PR TITLE
install: remove overly strict bin linking assertions

### DIFF
--- a/src/install/bin.zig
+++ b/src/install/bin.zig
@@ -602,6 +602,18 @@ pub const Bin = extern struct {
 
             bun.analytics.Features.binlinks += 1;
 
+            // `this.err` is a sticky field on the Linker that persists across
+            // all bins of the current package (a `bin` map with several
+            // entries reuses the same Linker). A stale error from a prior
+            // iteration must not cause us to unlink the shim we create for a
+            // later entry, so clear it here and restore it on the success
+            // path so the enclosing install still surfaces the failure.
+            const prev_err = this.err;
+            this.err = null;
+            defer if (this.err == null and prev_err != null) {
+                this.err = prev_err;
+            };
+
             if (comptime !Environment.isWindows)
                 this.createSymlink(abs_target, abs_dest, global)
             else {

--- a/src/install/bin.zig
+++ b/src/install/bin.zig
@@ -729,10 +729,69 @@ pub const Bin = extern struct {
             };
             defer bunx_file.close();
 
-            const rel_target = path.relativeBufZ(this.rel_buf, path.dirname(abs_dest, .auto), abs_target);
-            bun.assertWithLocation(strings.hasPrefixComptime(rel_target, "..\\"), @src());
+            // Compute a path relative to the parent of the .bin directory — that's
+            // where the shim walks back to at runtime before appending this path.
+            // See src/install/windows-shim/bun_shim_impl.zig for the walk-back logic.
+            //
+            // `abs_dest` and `abs_target` can be derived from different sources:
+            // `abs_dest` is built from `global_bin_path`, which `setupGlobalDir`
+            // canonicalizes via `GetFinalPathNameByHandle`. `abs_target` is built
+            // from `node_modules_path`, which comes from `top_level_dir` /
+            // `GetCurrentDirectoryW`. These two can disagree when the user profile
+            // sits behind a junction, OneDrive reparse point, `subst`'d drive, or
+            // a `\\?\Volume{GUID}\` mount, producing a relative path that does not
+            // start with `..\`. When that happens, re-resolve the target through
+            // its open handle so both sides share the same canonical form.
+            const rel_target_for_shim = relTargetForShim: {
+                const rel_target = path.relativeBufZ(this.rel_buf, path.dirname(abs_dest, .auto), abs_target);
+                if (strings.hasPrefixComptime(rel_target, "..\\")) {
+                    break :relTargetForShim rel_target["..\\".len..];
+                }
 
-            const rel_target_w = strings.toWPathNormalized(&target_buf, rel_target["..\\".len..]);
+                // Retry with the canonical target path.
+                var canon_target_buf: bun.PathBuffer = undefined;
+                const canon_target = switch (bun.sys.getFdPath(target, &canon_target_buf)) {
+                    .result => |slice| slice,
+                    .err => {
+                        this.err = error.CouldNotCreateShim;
+                        return;
+                    },
+                };
+                const canon_rel_target = path.relativeBufZ(this.rel_buf, path.dirname(abs_dest, .auto), canon_target);
+                if (strings.hasPrefixComptime(canon_rel_target, "..\\")) {
+                    break :relTargetForShim canon_rel_target["..\\".len..];
+                }
+
+                // Canonicalizing the target did not help — likely the destination
+                // side is the one that needs canonicalization. Open the destination
+                // directory and try once more with its canonical path.
+                const abs_dest_dir = path.dirname(abs_dest, .auto);
+                const dest_dir_fd = bun.sys.openatWindowsA(bun.invalid_fd, abs_dest_dir, bun.O.RDONLY | bun.O.DIRECTORY, 0).unwrap() catch {
+                    this.err = error.CouldNotCreateShim;
+                    return;
+                };
+                defer dest_dir_fd.close();
+                var canon_dest_dir_buf: bun.PathBuffer = undefined;
+                const canon_dest_dir = switch (bun.sys.getFdPath(dest_dir_fd, &canon_dest_dir_buf)) {
+                    .result => |slice| slice,
+                    .err => {
+                        this.err = error.CouldNotCreateShim;
+                        return;
+                    },
+                };
+                const canon_rel_target_2 = path.relativeBufZ(this.rel_buf, canon_dest_dir, canon_target);
+                if (strings.hasPrefixComptime(canon_rel_target_2, "..\\")) {
+                    break :relTargetForShim canon_rel_target_2["..\\".len..];
+                }
+
+                // Truly cross-volume or otherwise unrepresentable in the shim's
+                // walk-back scheme. Surface an error rather than writing a broken
+                // shim or panicking.
+                this.err = error.CouldNotCreateShim;
+                return;
+            };
+
+            const rel_target_w = strings.toWPathNormalized(&target_buf, rel_target_for_shim);
 
             const shebang = shebang: {
                 const first_content_chunk = contents: {
@@ -798,8 +857,6 @@ pub const Bin = extern struct {
 
             const abs_dest_dir = path.dirname(abs_dest, .auto);
             const rel_target = path.relativeBufZ(this.rel_buf, abs_dest_dir, abs_target);
-
-            bun.assertWithLocation(strings.hasPrefixComptime(rel_target, ".."), @src());
 
             switch (bun.sys.symlinkRunningExecutable(rel_target, abs_dest)) {
                 .err => |err| {

--- a/src/install/bin.zig
+++ b/src/install/bin.zig
@@ -510,7 +510,7 @@ pub const Bin = extern struct {
         // Escape outside the walk-back position.
         if (strings.hasPrefixComptime(rel, "..\\")) return false;
         if (strings.hasPrefixComptime(rel, "../")) return false;
-        if (std.mem.eql(u8, rel, "..")) return false;
+        if (strings.eqlComptime(rel, "..")) return false;
         // Absolute path (drive letter, e.g. "D:\...").
         if (rel.len >= 2 and rel[1] == ':') return false;
         // Rooted or UNC path.

--- a/src/install/bin.zig
+++ b/src/install/bin.zig
@@ -501,6 +501,23 @@ pub const Bin = extern struct {
         return name;
     }
 
+    /// A Windows shim bin path is stored in the `.bunx` file and appended onto
+    /// the parent of `.bin` at runtime. To be usable it must be a relative
+    /// subpath — it cannot escape the walk-back position with `..`, and it
+    /// cannot be absolute (drive letter, UNC share, or leading separator).
+    fn isValidShimBinPath(rel: []const u8) bool {
+        if (rel.len == 0) return false;
+        // Escape outside the walk-back position.
+        if (strings.hasPrefixComptime(rel, "..\\")) return false;
+        if (strings.hasPrefixComptime(rel, "../")) return false;
+        if (std.mem.eql(u8, rel, "..")) return false;
+        // Absolute path (drive letter, e.g. "D:\...").
+        if (rel.len >= 2 and rel[1] == ':') return false;
+        // Rooted or UNC path.
+        if (rel[0] == '\\' or rel[0] == '/') return false;
+        return true;
+    }
+
     pub const Linker = struct {
         bin: Bin,
 
@@ -729,64 +746,68 @@ pub const Bin = extern struct {
             };
             defer bunx_file.close();
 
-            // Compute a path relative to the parent of the .bin directory — that's
-            // where the shim walks back to at runtime before appending this path.
-            // See src/install/windows-shim/bun_shim_impl.zig for the walk-back logic.
+            // At runtime the shim walks back two directory levels from its own
+            // image path (`.bin\foo.exe` → parent of `.bin`) and then appends
+            // the bin path stored in the `.bunx` file. So we need a path that
+            // resolves to `abs_target` when joined onto the parent of `.bin`.
+            // See `src/install/windows-shim/bun_shim_impl.zig` for the
+            // walk-back loop.
             //
-            // `abs_dest` and `abs_target` can be derived from different sources:
-            // `abs_dest` is built from `global_bin_path`, which `setupGlobalDir`
-            // canonicalizes via `GetFinalPathNameByHandle`. `abs_target` is built
-            // from `node_modules_path`, which comes from `top_level_dir` /
-            // `GetCurrentDirectoryW`. These two can disagree when the user profile
-            // sits behind a junction, OneDrive reparse point, `subst`'d drive, or
-            // a `\\?\Volume{GUID}\` mount, producing a relative path that does not
-            // start with `..\`. When that happens, re-resolve the target through
-            // its open handle so both sides share the same canonical form.
+            // A target that lives inside `.bin` itself (e.g. a package whose
+            // `bin` field resolves to `../.bin/foo.js`) yields `.bin\foo.js`
+            // here, which is a valid shim bin path — not something to reject.
+            //
+            // `abs_dest` and `abs_target` can also come from different
+            // canonicalisation sources: `abs_dest` from `global_bin_path`
+            // (which `setupGlobalDir` canonicalises via
+            // `GetFinalPathNameByHandle`), and `abs_target` from `top_level_dir`
+            // (`GetCurrentDirectoryW`). When the user profile sits behind a
+            // junction, OneDrive reparse point, `subst`'d drive, or
+            // `\\?\Volume{GUID}\` mount, the two views can disagree and
+            // produce an absolute or `..`-prefixed result that the shim can't
+            // represent. Retry with the target canonicalised through its open
+            // handle, then with the destination parent canonicalised via an
+            // opened directory handle, before failing gracefully.
+            const abs_dest_parent = path.dirname(path.dirname(abs_dest, .auto), .auto);
             const rel_target_for_shim = relTargetForShim: {
-                const rel_target = path.relativeBufZ(this.rel_buf, path.dirname(abs_dest, .auto), abs_target);
-                if (strings.hasPrefixComptime(rel_target, "..\\")) {
-                    break :relTargetForShim rel_target["..\\".len..];
-                }
+                const rel_target = path.relativeBufZ(this.rel_buf, abs_dest_parent, abs_target);
+                if (isValidShimBinPath(rel_target)) break :relTargetForShim rel_target;
 
-                // Retry with the canonical target path.
-                var canon_target_buf: bun.PathBuffer = undefined;
-                const canon_target = switch (bun.sys.getFdPath(target, &canon_target_buf)) {
+                // Retry with the target canonicalised via its open fd.
+                const canon_target_buf = bun.path_buffer_pool.get();
+                defer bun.path_buffer_pool.put(canon_target_buf);
+                const canon_target = switch (bun.sys.getFdPath(target, canon_target_buf)) {
                     .result => |slice| slice,
                     .err => {
                         this.err = error.CouldNotCreateShim;
                         return;
                     },
                 };
-                const canon_rel_target = path.relativeBufZ(this.rel_buf, path.dirname(abs_dest, .auto), canon_target);
-                if (strings.hasPrefixComptime(canon_rel_target, "..\\")) {
-                    break :relTargetForShim canon_rel_target["..\\".len..];
-                }
+                const canon_rel_target = path.relativeBufZ(this.rel_buf, abs_dest_parent, canon_target);
+                if (isValidShimBinPath(canon_rel_target)) break :relTargetForShim canon_rel_target;
 
-                // Canonicalizing the target did not help — likely the destination
-                // side is the one that needs canonicalization. Open the destination
-                // directory and try once more with its canonical path.
-                const abs_dest_dir = path.dirname(abs_dest, .auto);
-                const dest_dir_fd = bun.sys.openatWindowsA(bun.invalid_fd, abs_dest_dir, bun.O.RDONLY | bun.O.DIRECTORY, 0).unwrap() catch {
+                // Retry with the destination parent canonicalised too. Open
+                // it, call GetFinalPathNameByHandle, and recompute.
+                const dest_parent_fd = bun.sys.openatWindowsA(bun.invalid_fd, abs_dest_parent, bun.O.RDONLY | bun.O.DIRECTORY, 0).unwrap() catch {
                     this.err = error.CouldNotCreateShim;
                     return;
                 };
-                defer dest_dir_fd.close();
-                var canon_dest_dir_buf: bun.PathBuffer = undefined;
-                const canon_dest_dir = switch (bun.sys.getFdPath(dest_dir_fd, &canon_dest_dir_buf)) {
+                defer dest_parent_fd.close();
+                const canon_dest_parent_buf = bun.path_buffer_pool.get();
+                defer bun.path_buffer_pool.put(canon_dest_parent_buf);
+                const canon_dest_parent = switch (bun.sys.getFdPath(dest_parent_fd, canon_dest_parent_buf)) {
                     .result => |slice| slice,
                     .err => {
                         this.err = error.CouldNotCreateShim;
                         return;
                     },
                 };
-                const canon_rel_target_2 = path.relativeBufZ(this.rel_buf, canon_dest_dir, canon_target);
-                if (strings.hasPrefixComptime(canon_rel_target_2, "..\\")) {
-                    break :relTargetForShim canon_rel_target_2["..\\".len..];
-                }
+                const canon_rel_target_2 = path.relativeBufZ(this.rel_buf, canon_dest_parent, canon_target);
+                if (isValidShimBinPath(canon_rel_target_2)) break :relTargetForShim canon_rel_target_2;
 
-                // Truly cross-volume or otherwise unrepresentable in the shim's
-                // walk-back scheme. Surface an error rather than writing a broken
-                // shim or panicking.
+                // Truly cross-volume or otherwise unrepresentable in the
+                // shim's walk-back scheme. Surface an error rather than
+                // writing a broken shim or panicking.
                 this.err = error.CouldNotCreateShim;
                 return;
             };

--- a/test/regression/issue/29005.test.ts
+++ b/test/regression/issue/29005.test.ts
@@ -1,20 +1,6 @@
-// Regression test for https://github.com/oven-sh/bun/issues/29005
-//
-// `bun install --global <pkg>` was panicking on Windows at
-// `src/install/bin.zig:733:83` with "Internal assertion failure". The
-// assertion there (and its non-Windows twin in `createSymlink`) assumed
-// that the relative path from the `.bin` directory to the target binary
-// always starts with `..\` (or `..` on POSIX). That doesn't hold when
-// the target lives inside the destination directory — which happens
-// with a package whose `bin` field points back into sibling `.bin`, or
-// on Windows when `abs_dest` and `abs_target` come from different
-// canonical-form sources (junctions, OneDrive reparse points, `subst`'d
-// drives).
-//
-// Both code paths now accept any relative form instead of panicking.
-// This test exercises the POSIX path with a local package whose `bin`
-// resolves inside the sibling `.bin` directory — the same relative
-// shape that fires the Windows assertion.
+// https://github.com/oven-sh/bun/issues/29005
+// Exercises the zero-`..` relative-path shape between `.bin` and its bin
+// target that fires the overly strict assertion in `Bin.Linker`.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { existsSync, readlinkSync, statSync } from "node:fs";

--- a/test/regression/issue/29005.test.ts
+++ b/test/regression/issue/29005.test.ts
@@ -16,9 +16,9 @@
 // resolves inside the sibling `.bin` directory — the same relative
 // shape that fires the Windows assertion.
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { readlinkSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { bunEnv, bunExe, tempDir } from "harness";
 
 test("bun install handles a bin target inside .bin without panicking", async () => {
   using dir = tempDir("issue-29005", {
@@ -48,11 +48,7 @@ test("bun install handles a bin target inside .bin without panicking", async () 
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // The install must complete successfully. Without the fix, `createSymlink`
   // (POSIX) and `createWindowsShim` (Windows) both hit an assertion that

--- a/test/regression/issue/29005.test.ts
+++ b/test/regression/issue/29005.test.ts
@@ -1,0 +1,80 @@
+// Regression test for https://github.com/oven-sh/bun/issues/29005
+//
+// `bun install --global <pkg>` was panicking on Windows at
+// `src/install/bin.zig:733:83` with "Internal assertion failure". The
+// assertion there (and its non-Windows twin in `createSymlink`) assumed
+// that the relative path from the `.bin` directory to the target binary
+// always starts with `..\` (or `..` on POSIX). That doesn't hold when
+// the target lives inside the destination directory — which happens
+// with a package whose `bin` field points back into sibling `.bin`, or
+// on Windows when `abs_dest` and `abs_target` come from different
+// canonical-form sources (junctions, OneDrive reparse points, `subst`'d
+// drives).
+//
+// Both code paths now accept any relative form instead of panicking.
+// This test exercises the POSIX path with a local package whose `bin`
+// resolves inside the sibling `.bin` directory — the same relative
+// shape that fires the Windows assertion.
+import { expect, test } from "bun:test";
+import { readlinkSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("bun install handles a bin target inside .bin without panicking", async () => {
+  using dir = tempDir("issue-29005", {
+    "package.json": JSON.stringify({
+      name: "root",
+      version: "1.0.0",
+      dependencies: { weird: "file:./pkg" },
+    }),
+    "pkg/package.json": JSON.stringify({
+      name: "weird",
+      version: "1.0.0",
+      bin: "../.bin/foo.js",
+    }),
+    "pkg/index.js": "module.exports = 1;\n",
+    // Pre-create the .bin directory with the file `bin` points at so that
+    // `abs_target` resolves to `<node_modules>/.bin/foo.js`. The relative
+    // path from `<node_modules>/.bin` to that target is just `foo.js`,
+    // which is the shape that trips the overly strict assertion.
+    "node_modules/.bin/foo.js": "#!/usr/bin/env node\nprocess.exit(0);\n",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  // The install must complete successfully. Without the fix, `createSymlink`
+  // (POSIX) and `createWindowsShim` (Windows) both hit an assertion that
+  // panics the process and produces a non-zero exit code + empty stdout.
+  expect(stderr).toContain("Saved lockfile");
+  expect(stdout).toContain("weird@pkg");
+  expect(exitCode).toBe(0);
+
+  // The package must be extracted.
+  const pkgJson = join(String(dir), "node_modules", "weird", "package.json");
+  expect(statSync(pkgJson).isFile()).toBe(true);
+
+  // On POSIX the bin link is a symlink whose target is the `bin` path we
+  // stored in package.json, normalized relative to `.bin`. On Windows it's
+  // a `.exe` + `.bunx` shim pair. Assert the relevant artefact exists.
+  if (process.platform === "win32") {
+    const exe = join(String(dir), "node_modules", ".bin", "weird.exe");
+    const bunx = join(String(dir), "node_modules", ".bin", "weird.bunx");
+    expect(statSync(exe).isFile()).toBe(true);
+    expect(statSync(bunx).isFile()).toBe(true);
+  } else {
+    const link = join(String(dir), "node_modules", ".bin", "weird");
+    expect(readlinkSync(link)).toBe("foo.js");
+  }
+});

--- a/test/regression/issue/29005.test.ts
+++ b/test/regression/issue/29005.test.ts
@@ -49,14 +49,27 @@ test("bun install handles a bin target inside .bin without panicking", async () 
     : join(String(dir), "bun.lockb");
   expect(existsSync(lockfile)).toBe(true);
 
-  // On POSIX the bin link is a symlink whose target is the `bin` path we
-  // stored in package.json, normalized relative to `.bin`. On Windows it's
-  // a `.exe` + `.bunx` shim pair.
+  // On POSIX the bin link is a symlink whose target is the bin path we stored
+  // in package.json, normalized relative to `.bin`. On Windows it's a `.exe`
+  // + `.bunx` shim pair, and the `.bunx` file embeds the bin path as a
+  // UTF-16LE prefix terminated by a `"\0` sequence — see the file format at
+  // the top of `src/install/windows-shim/BinLinkingShim.zig`.
   if (process.platform === "win32") {
     const exe = join(String(dir), "node_modules", ".bin", "weird.exe");
     const bunx = join(String(dir), "node_modules", ".bin", "weird.bunx");
     expect(statSync(exe).isFile()).toBe(true);
     expect(statSync(bunx).isFile()).toBe(true);
+
+    // Decode the stored bin_path from the .bunx header. The shim's walk-back
+    // logic lands at the parent of `.bin` at runtime and appends this string
+    // to build the absolute target path, so it must equal `.bin\foo.js` for
+    // our fixture — a weaker check wouldn't catch a regression where the
+    // retry loop stored the wrong relative form.
+    const bunxBytes = await Bun.file(bunx).bytes();
+    const decoded = new TextDecoder("utf-16le").decode(bunxBytes);
+    const terminator = decoded.indexOf('"\0');
+    expect(terminator).toBeGreaterThan(0);
+    expect(decoded.slice(0, terminator)).toBe(".bin\\foo.js");
   } else {
     const link = join(String(dir), "node_modules", ".bin", "weird");
     expect(readlinkSync(link)).toBe("foo.js");

--- a/test/regression/issue/29005.test.ts
+++ b/test/regression/issue/29005.test.ts
@@ -17,7 +17,7 @@
 // shape that fires the Windows assertion.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { readlinkSync, statSync } from "node:fs";
+import { existsSync, readlinkSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 test("bun install handles a bin target inside .bin without panicking", async () => {
@@ -48,22 +48,24 @@ test("bun install handles a bin target inside .bin without panicking", async () 
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // stdout/stderr captured for debug output on failure; we assert behaviour
+  // via on-disk artefacts + exit status rather than reporter text.
+  const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  // The install must complete successfully. Without the fix, `createSymlink`
-  // (POSIX) and `createWindowsShim` (Windows) both hit an assertion that
-  // panics the process and produces a non-zero exit code + empty stdout.
-  expect(stderr).toContain("Saved lockfile");
-  expect(stdout).toContain("weird@pkg");
-  expect(exitCode).toBe(0);
-
-  // The package must be extracted.
+  // The package itself must be extracted.
   const pkgJson = join(String(dir), "node_modules", "weird", "package.json");
   expect(statSync(pkgJson).isFile()).toBe(true);
 
+  // The lockfile must have been written to disk. Without the fix the install
+  // panics before saving the lockfile, so the file simply doesn't exist.
+  const lockfile = existsSync(join(String(dir), "bun.lock"))
+    ? join(String(dir), "bun.lock")
+    : join(String(dir), "bun.lockb");
+  expect(existsSync(lockfile)).toBe(true);
+
   // On POSIX the bin link is a symlink whose target is the `bin` path we
   // stored in package.json, normalized relative to `.bin`. On Windows it's
-  // a `.exe` + `.bunx` shim pair. Assert the relevant artefact exists.
+  // a `.exe` + `.bunx` shim pair.
   if (process.platform === "win32") {
     const exe = join(String(dir), "node_modules", ".bin", "weird.exe");
     const bunx = join(String(dir), "node_modules", ".bin", "weird.bunx");
@@ -73,4 +75,9 @@ test("bun install handles a bin target inside .bin without panicking", async () 
     const link = join(String(dir), "node_modules", ".bin", "weird");
     expect(readlinkSync(link)).toBe("foo.js");
   }
+
+  // Without the fix, `createSymlink`/`createWindowsShim` panics with "reached
+  // unreachable code" and exits non-zero before any of the above artefacts are
+  // produced. Assert exit status last for better failure messages.
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
Fixes #29005

`bun install --global` on Windows panicked at `src/install/bin.zig:733` with "Internal assertion failure" across multiple Windows 11 Pro and Windows Server 2025 machines (WinGet-installed bun).

### Root cause

Both `createWindowsShim` (line 733) and `createSymlink` (line 802) asserted that the relative path from the `.bin` directory to the target binary starts with `..\` (or `..` on POSIX). That assumption breaks whenever the relative path doesn't go "up" from `.bin`:

1. **Different canonical-form sources (Windows-only, the user's trigger)** — `abs_dest` is built from `global_bin_path`, which `setupGlobalDir` canonicalizes via `GetFinalPathNameByHandle` (strips junctions, resolves reparse points, long-form names). `abs_target` is built from `top_level_dir`, which comes from `GetCurrentDirectoryW` after `setAsCwd`. When the user's `.bun` directory sits behind a junction, OneDrive reparse point, `subst`'d drive, or `\\?\Volume{GUID}\` mount, the two sources disagree and `relativeBufZ` returns an absolute path or the target without a leading `..\`.

2. **Target inside the destination dir** — a package whose `bin` field resolves into sibling `.bin` produces a rel path like `foo.js`, no `..`. This is the POSIX analog and triggers the `createSymlink` assertion.

3. **Cross-volume paths** — truly distinct volumes can't be represented as a relative path.

### Fix

- **`createWindowsShim`**: replace the panic-inducing assertion with a labeled block that tries three times — first the raw relative, then with the target re-resolved via `getFdPath(target)` (which canonicalizes through the already-open handle), then with both sides re-resolved by opening `dirname(abs_dest)` and canonicalizing it too. If none of those yield a `..\`-prefixed result, set `this.err` and return instead of panicking.

- **`createSymlink`**: drop the equivalent `hasPrefixComptime(rel_target, "..")` assertion. `symlink(2)` is happy with any relative path.

### Verification

Added `test/regression/issue/29005.test.ts`. It creates a local package whose `bin` field resolves inside the sibling `.bin` directory (`bin: "../.bin/foo.js"` with a pre-created `node_modules/.bin/foo.js`), producing the same zero-`..` relative path shape that fires the Windows assertion on junction/reparse setups. Without the fix, `bun install` panics with "reached unreachable code" at `bin.zig:802` (or `bin.zig:733` on Windows) and exits non-zero. With the fix, the install completes and the symlink (`node_modules/.bin/weird -> foo.js`) or shim pair is produced.