### PR TITLE
http: emit 'upgrade' event on 101 and honor chunked body on upgrade

### DIFF
--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -909,6 +909,23 @@ pub fn headerStr(this: *const HTTPClient, ptr: api.StringPointer) string {
     return this.header_buf[ptr.offset..][0..ptr.length];
 }
 
+/// True if the user's request headers explicitly include either
+/// `Transfer-Encoding` or `Content-Length`, meaning they intend to send
+/// a request body with real HTTP framing rather than an empty body (as
+/// with WebSocket-style `Upgrade:` handshakes).
+pub fn hasExplicitBodyFraming(this: *const HTTPClient) bool {
+    const header_entries = this.header_entries.slice();
+    const header_names = header_entries.items(.name);
+    for (header_names) |head| {
+        const name = this.headerStr(head);
+        const hash = hashHeaderName(name);
+        if (hash == hashHeaderConst("Transfer-Encoding") or hash == hashHeaderConst("Content-Length")) {
+            return true;
+        }
+    }
+    return false;
+}
+
 pub const HeaderBuilder = @import("./HeaderBuilder.zig");
 
 pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
@@ -1554,8 +1571,13 @@ pub fn writeToStream(this: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPCo
     }
     var stream = &this.state.original_request_body.stream;
     const stream_buffer = stream.buffer orelse return;
-    if (this.flags.upgrade_state == .pending) {
-        // cannot drain yet, upgrade is waiting for upgrade
+    if (this.flags.upgrade_state == .pending and !this.hasExplicitBodyFraming()) {
+        // For upgrade requests with no explicit body framing (WebSocket-style),
+        // writes represent post-upgrade protocol data and must be held until
+        // the server responds 101. For requests that *do* have explicit framing
+        // (e.g. dockerode sends `Transfer-Encoding: chunked` with an `Upgrade:`
+        // header), the body is part of the HTTP request and must be drained so
+        // the server can parse it before deciding to switch protocols.
         return;
     }
     const buffer = stream_buffer.acquire();

--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -1087,19 +1087,16 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
         header_count += 1;
     }
 
-    // Refresh `request_body_has_framing` from the *finalized* header slice
+    // Compute `request_body_has_framing` from the *finalized* header slice
     // that will hit the wire — not from the raw user headers, which may
     // include entries past `max_user_headers` that have been dropped, or a
-    // `Transfer-Encoding` value that is not `chunked`. The caller may have
-    // already set this flag at setup time based on the same predicates (so
-    // the main thread can safely query it before `buildRequest()` runs); we
-    // recompute here as the source of truth once we know what actually
-    // survived.
+    // `Transfer-Encoding` value that is not `chunked`.
     //
-    // Used by `writeToStream()` to decide whether to drain a streaming body
-    // buffer during the pending-upgrade state, and by
-    // `FetchTasklet.skipChunkedFraming()` to decide whether chunk headers
-    // should wrap body data on the wire.
+    // Used by `writeToStream()` (below) to decide whether to drain a
+    // streaming request body buffer while the upgrade is pending.
+    // `FetchTasklet.skipChunkedFraming()` reads the user headers directly
+    // and does NOT consult this flag — the two code paths deliberately ask
+    // different questions (drain vs. chunk-wrap).
     {
         var has_framing = false;
         for (request_headers_buf[0..header_count]) |h| {

--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -1097,7 +1097,13 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
     // `FetchTasklet.skipChunkedFraming()` reads the user headers directly
     // and does NOT consult this flag — the two code paths deliberately ask
     // different questions (drain vs. chunk-wrap).
-    {
+    //
+    // Only upgrade requests read this flag (the consumer in
+    // `writeToStream()` short-circuits on `upgrade_state == .pending`),
+    // so skip the scan entirely for the >99% non-upgrade case.
+    // `upgrade_state` is set by the first header loop above, so it's
+    // authoritative by the time we get here.
+    if (this.flags.upgrade_state != .none) {
         var has_framing = false;
         for (request_headers_buf[0..header_count]) |h| {
             const hash = hashHeaderName(h.name);

--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -1052,10 +1052,6 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
         header_count += 1;
     }
 
-    // Reset. We recompute this on every buildRequest() because the request
-    // may be rebuilt on retry/redirect and the header set can change.
-    this.flags.request_body_has_framing = false;
-
     if (body_len > 0 or this.method.hasRequestBody()) {
         if (this.flags.is_streaming_request_body) {
             if (original_content_length) |content_length| {
@@ -1072,15 +1068,9 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
                 // If !add_transfer_encoding, the user explicitly set Transfer-Encoding,
                 // which was already added to request_headers_buf. We respect that and
                 // do not add Content-Length (they are mutually exclusive per HTTP/1.1).
-                this.flags.request_body_has_framing = true;
-            } else if (!add_transfer_encoding) {
-                // User explicitly set Transfer-Encoding and it survived truncation
-                // (already in request_headers_buf via the user-headers loop).
-                this.flags.request_body_has_framing = true;
-            } else if (this.flags.upgrade_state == .none) {
+            } else if (add_transfer_encoding and this.flags.upgrade_state == .none) {
                 request_headers_buf[header_count] = chunked_encoded_header;
                 header_count += 1;
-                this.flags.request_body_has_framing = true;
             }
         } else {
             request_headers_buf[header_count] = .{
@@ -1088,7 +1078,6 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
                 .value = std.fmt.bufPrint(&this.request_content_len_buf, "{d}", .{body_len}) catch "0",
             };
             header_count += 1;
-            this.flags.request_body_has_framing = true;
         }
     } else if (original_content_length) |content_length| {
         request_headers_buf[header_count] = .{
@@ -1096,7 +1085,37 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
             .value = content_length,
         };
         header_count += 1;
-        this.flags.request_body_has_framing = true;
+    }
+
+    // Refresh `request_body_has_framing` from the *finalized* header slice
+    // that will hit the wire — not from the raw user headers, which may
+    // include entries past `max_user_headers` that have been dropped, or a
+    // `Transfer-Encoding` value that is not `chunked`. The caller may have
+    // already set this flag at setup time based on the same predicates (so
+    // the main thread can safely query it before `buildRequest()` runs); we
+    // recompute here as the source of truth once we know what actually
+    // survived.
+    //
+    // Used by `writeToStream()` to decide whether to drain a streaming body
+    // buffer during the pending-upgrade state, and by
+    // `FetchTasklet.skipChunkedFraming()` to decide whether chunk headers
+    // should wrap body data on the wire.
+    {
+        var has_framing = false;
+        for (request_headers_buf[0..header_count]) |h| {
+            const hash = hashHeaderName(h.name);
+            if (hash == hashHeaderConst(content_length_header_name)) {
+                has_framing = true;
+                break;
+            }
+            if (hash == hashHeaderConst(chunked_encoded_header.name) and
+                bun.strings.containsCaseInsensitiveASCII(h.value, "chunked"))
+            {
+                has_framing = true;
+                break;
+            }
+        }
+        this.flags.request_body_has_framing = has_framing;
     }
 
     return picohttp.Request{

--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -643,7 +643,12 @@ pub const Flags = packed struct(u32) {
     /// Set after the first H3 retry so a stale-session/GOAWAY race retries
     /// once on a fresh connection but never loops.
     h3_retried: bool = false,
-    _: u13 = 0,
+    /// Set by `buildRequest()` if the request on the wire carries explicit
+    /// body framing (either `Transfer-Encoding: chunked` that survived header
+    /// truncation, or `Content-Length`). Used by `writeToStream()` to decide
+    /// whether to drain the streaming request body before the 101 response.
+    request_body_has_framing: bool = false,
+    _: u12 = 0,
 };
 
 // TODO: reduce the size of this struct
@@ -909,23 +914,6 @@ pub fn headerStr(this: *const HTTPClient, ptr: api.StringPointer) string {
     return this.header_buf[ptr.offset..][0..ptr.length];
 }
 
-/// True if the user's request headers explicitly include either
-/// `Transfer-Encoding` or `Content-Length`, meaning they intend to send
-/// a request body with real HTTP framing rather than an empty body (as
-/// with WebSocket-style `Upgrade:` handshakes).
-pub fn hasExplicitBodyFraming(this: *const HTTPClient) bool {
-    const header_entries = this.header_entries.slice();
-    const header_names = header_entries.items(.name);
-    for (header_names) |head| {
-        const name = this.headerStr(head);
-        const hash = hashHeaderName(name);
-        if (hash == hashHeaderConst("Transfer-Encoding") or hash == hashHeaderConst("Content-Length")) {
-            return true;
-        }
-    }
-    return false;
-}
-
 pub const HeaderBuilder = @import("./HeaderBuilder.zig");
 
 pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
@@ -1064,6 +1052,10 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
         header_count += 1;
     }
 
+    // Reset. We recompute this on every buildRequest() because the request
+    // may be rebuilt on retry/redirect and the header set can change.
+    this.flags.request_body_has_framing = false;
+
     if (body_len > 0 or this.method.hasRequestBody()) {
         if (this.flags.is_streaming_request_body) {
             if (original_content_length) |content_length| {
@@ -1080,9 +1072,15 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
                 // If !add_transfer_encoding, the user explicitly set Transfer-Encoding,
                 // which was already added to request_headers_buf. We respect that and
                 // do not add Content-Length (they are mutually exclusive per HTTP/1.1).
-            } else if (add_transfer_encoding and this.flags.upgrade_state == .none) {
+                this.flags.request_body_has_framing = true;
+            } else if (!add_transfer_encoding) {
+                // User explicitly set Transfer-Encoding and it survived truncation
+                // (already in request_headers_buf via the user-headers loop).
+                this.flags.request_body_has_framing = true;
+            } else if (this.flags.upgrade_state == .none) {
                 request_headers_buf[header_count] = chunked_encoded_header;
                 header_count += 1;
+                this.flags.request_body_has_framing = true;
             }
         } else {
             request_headers_buf[header_count] = .{
@@ -1090,6 +1088,7 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
                 .value = std.fmt.bufPrint(&this.request_content_len_buf, "{d}", .{body_len}) catch "0",
             };
             header_count += 1;
+            this.flags.request_body_has_framing = true;
         }
     } else if (original_content_length) |content_length| {
         request_headers_buf[header_count] = .{
@@ -1097,6 +1096,7 @@ pub fn buildRequest(this: *HTTPClient, body_len: usize) picohttp.Request {
             .value = content_length,
         };
         header_count += 1;
+        this.flags.request_body_has_framing = true;
     }
 
     return picohttp.Request{
@@ -1571,13 +1571,17 @@ pub fn writeToStream(this: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPCo
     }
     var stream = &this.state.original_request_body.stream;
     const stream_buffer = stream.buffer orelse return;
-    if (this.flags.upgrade_state == .pending and !this.hasExplicitBodyFraming()) {
+    if (this.flags.upgrade_state == .pending and !this.flags.request_body_has_framing) {
         // For upgrade requests with no explicit body framing (WebSocket-style),
         // writes represent post-upgrade protocol data and must be held until
         // the server responds 101. For requests that *do* have explicit framing
         // (e.g. dockerode sends `Transfer-Encoding: chunked` with an `Upgrade:`
         // header), the body is part of the HTTP request and must be drained so
         // the server can parse it before deciding to switch protocols.
+        //
+        // `request_body_has_framing` is set by `buildRequest()` from the header
+        // set that actually makes it to the wire, so a late/dropped
+        // `Transfer-Encoding` user header will not falsely enable draining.
         return;
     }
     const buffer = stream_buffer.acquire();

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -156,6 +156,12 @@ function createUpgradeSocket(req, res) {
       // Backpressure: wait for 'drain', but also tear down cleanly if `req`
       // errors or closes before drain fires — otherwise the callback is
       // orphaned and the writable side stays stuck in kWriting.
+      //
+      // A `'close'` before `'drain'` is a failure: the in-flight chunk is
+      // still buffered inside `req` and gets discarded when `req` tears
+      // down. We MUST surface this as an error so the Duplex consumer knows
+      // the write was lost (unlike `_final()` where a clean close after
+      // `req.end()` legitimately signals completion).
       let settled = false;
       const settle = (err?: Error) => {
         if (settled) return;
@@ -167,7 +173,7 @@ function createUpgradeSocket(req, res) {
       };
       const onDrain = () => settle();
       const onError = (err: Error) => settle(err);
-      const onClose = () => settle();
+      const onClose = () => settle(new ConnResetException("socket hang up"));
       req.once("drain", onDrain);
       req.once("error", onError);
       req.once("close", onClose);

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -106,10 +106,10 @@ function createUpgradeSocket(req, res) {
     }
   };
 
-  let bridged = false;
-  const bridgeRes = () => {
-    if (bridged) return;
-    bridged = true;
+  let dataBridged = false;
+  const bridgeResData = () => {
+    if (dataBridged) return;
+    dataBridged = true;
     // Bridge the IncomingMessage's decoded body into the Duplex. The
     // IncomingMessage is the single consumer of the fetch response body
     // reader — avoiding a second `getReader()` call that would otherwise
@@ -121,15 +121,19 @@ function createUpgradeSocket(req, res) {
     res.once("end", () => {
       duplex.push(null);
     });
-    res.once("error", (err: Error) => {
-      duplex.destroy(err);
-    });
   };
 
   const duplex: any = new Duplex({
     allowHalfOpen: true,
     read() {
-      bridgeRes();
+      // If the underlying IncomingMessage was already destroyed (e.g. the
+      // request aborted before the user attached a 'data' listener), push
+      // EOF immediately so the readable side doesn't hang forever.
+      if (res.destroyed || res.readableEnded) {
+        duplex.push(null);
+        return;
+      }
+      bridgeResData();
       res.resume();
     },
     write(chunk, encoding, callback) {
@@ -147,9 +151,26 @@ function createUpgradeSocket(req, res) {
       const ok = req.write(chunk, encoding);
       if (ok) {
         callback();
-      } else {
-        req.once("drain", callback);
+        return;
       }
+      // Backpressure: wait for 'drain', but also tear down cleanly if `req`
+      // errors or closes before drain fires — otherwise the callback is
+      // orphaned and the writable side stays stuck in kWriting.
+      let settled = false;
+      const settle = (err?: Error) => {
+        if (settled) return;
+        settled = true;
+        req.removeListener("drain", onDrain);
+        req.removeListener("error", onError);
+        req.removeListener("close", onClose);
+        callback(err);
+      };
+      const onDrain = () => settle();
+      const onError = (err: Error) => settle(err);
+      const onClose = () => settle();
+      req.once("drain", onDrain);
+      req.once("error", onError);
+      req.once("close", onClose);
     },
     final(callback) {
       if (req.destroyed || req.finished) {
@@ -212,6 +233,28 @@ function createUpgradeSocket(req, res) {
   };
   duplex.ref = () => duplex;
   duplex.unref = () => duplex;
+
+  // Eagerly wire `res` error/close propagation — NOT inside the lazy
+  // `bridgeResData()` closure. Attaching these only on the first `_read()`
+  // leaves a race window between the `'upgrade'` event firing (scheduled on
+  // `process.nextTick`) and the user's handler subscribing to `'data'`: if
+  // the request aborts during that gap, `res` is destroyed with no listener
+  // and the duplex never learns about it. We also hook into req's error
+  // path for the same reason — network errors on the upload half should
+  // surface on the hijacked socket immediately.
+  res.once("error", (err: Error) => {
+    if (!duplex.destroyed) duplex.destroy(err);
+  });
+  res.once("close", () => {
+    if (!duplex.destroyed && !duplex.readableEnded) {
+      // Push EOF if nothing else has — ensures the readable side finishes
+      // even if no 'end' was emitted before the close (abort, reset, etc.).
+      duplex.push(null);
+    }
+  });
+  req.once("error", (err: Error) => {
+    if (!duplex.destroyed) duplex.destroy(err);
+  });
 
   return duplex;
 }

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -162,9 +162,13 @@ function createUpgradeSocket(req, res) {
       // WebSocket/CDP pattern the caller has already called `req.end()`
       // before the 101, which sets `req.finished = true` synchronously.
       // The upgrade-aware body generator stays alive past that point and
-      // still accepts writes until the hijacked socket tears down.
+      // still accepts writes until the hijacked socket tears down. Since
+      // the only way into this branch is destruction, use
+      // `ERR_STREAM_DESTROYED` (matches net.Socket/Writable semantics)
+      // rather than `ERR_STREAM_WRITE_AFTER_END` (reserved for writes
+      // after `.end()` on a stream that ended normally).
       if (req.destroyed) {
-        callback($ERR_STREAM_WRITE_AFTER_END());
+        callback($ERR_STREAM_DESTROYED("write"));
         return;
       }
       armTimeout();

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -682,7 +682,12 @@ function ClientRequest(input, options, cb) {
         // socket regardless of whether the caller ever calls `req.end()` — the
         // upload half of the connection is deliberately left open for the
         // hijacked protocol.
-        const isUpgrade = response.status === 101;
+        //
+        // Named `is101` rather than `isUpgrade` to avoid shadowing the outer
+        // `const isUpgrade = hasUpgradeHeaders(this)` in `go()` (which asks
+        // whether the *request* carried `Upgrade:` headers — a different
+        // question, and the two can diverge when the server rejects).
+        const is101 = response.status === 101;
 
         // Server rejected the upgrade (e.g. 400 Bad Request, 404, auth
         // failure) — release the upgrade-aware body generator so the
@@ -690,7 +695,7 @@ function ClientRequest(input, options, cb) {
         // parks at `yield await new Promise(...)` forever (upgradeBodyEnded
         // is only set by the hijacked socket, which never gets constructed
         // for a non-101 response).
-        if (!isUpgrade && hasUpgradeHeaders(this)) {
+        if (!is101 && hasUpgradeHeaders(this)) {
           this[kEndUpgradeBody]();
         }
 
@@ -709,7 +714,7 @@ function ClientRequest(input, options, cb) {
           res.req = this;
           res.setTimeout = clientResponseSetTimeout;
 
-          if (isUpgrade) {
+          if (is101) {
             this[kUpgradeOrConnect] = true;
             // The hijacked socket reads via the IncomingMessage `res` (the
             // single owner of the fetch response body reader); this avoids

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -209,44 +209,13 @@ function createUpgradeSocket(req, res) {
         callback();
         return;
       }
-      // If ClientRequest installed the upgrade-aware body terminator,
-      // close the upload half through it — this is the WebSocket/CDP
-      // (req.end() before 101) and dockerode (req.write() only) pattern.
-      // Otherwise, wait for the request to finish normally.
-      if (typeof req[kEndUpgradeBody] === "function") {
-        req[kEndUpgradeBody]();
-        callback();
-        return;
-      }
-      if (req.finished) {
-        callback();
-        return;
-      }
-      // Non-upgrade fallback (should not normally be reached on the
-      // hijacked-socket path). Wait until the underlying request body has
-      // actually finished before acknowledging `_final`. `'finish'` fires
-      // after `send()` has completed; `'error'`/`'close'` surface abnormal
-      // termination.
-      let done = false;
-      const finish = (err?: Error) => {
-        if (done) return;
-        done = true;
-        req.removeListener("finish", onFinish);
-        req.removeListener("error", onError);
-        req.removeListener("close", onClose);
-        callback(err);
-      };
-      const onFinish = () => finish();
-      const onError = (err: Error) => finish(err);
-      const onClose = () => finish();
-      req.once("finish", onFinish);
-      req.once("error", onError);
-      req.once("close", onClose);
-      try {
-        req.end();
-      } catch (err) {
-        finish(err as Error);
-      }
+      // The ClientRequest unconditionally installs the upgrade-aware body
+      // terminator, so `kEndUpgradeBody` is always present — close the
+      // upload half through it. This covers both the WebSocket/CDP pattern
+      // (req.end() before 101, req.finished already true) and the
+      // dockerode pattern (only req.write(), never req.end()).
+      req[kEndUpgradeBody]();
+      callback();
     },
     destroy(err, callback) {
       socketDestroyed = true;
@@ -459,9 +428,11 @@ function ClientRequest(input, options, cb) {
     if (!this.finished) {
       send();
       // For upgrade requests the upload half must stay open for post-101
-      // writes (WebSocket/CDP/dockerode all call `req.end()` before the
-      // 101 arrives). The generator keeps running until the hijacked
-      // socket's `_final`/`_destroy` signals via `kEndUpgradeBody`.
+      // writes. WebSocket/CDP clients call `req.end()` before the 101
+      // arrives (and reach this guard); dockerode's hijacked exec never
+      // calls `req.end()` at all (flushHeaders + write only). The
+      // generator keeps running until the hijacked socket's
+      // `_final`/`_destroy` signals via `kEndUpgradeBody`.
       if (!hasUpgradeHeaders(this)) {
         resolveNextChunk?.(true);
       }
@@ -613,18 +584,23 @@ function ClientRequest(input, options, cb) {
       // This covers the dockerode pattern (POST + req.write()) and the
       // WebSocket/CDP pattern (GET + req.end() before the 101).
       const isUpgrade = hasUpgradeHeaders(this);
+
+      // For upgrade requests always funnel the body through the generator
+      // so the write side stays live; any pre-assembled body is already in
+      // kBodyChunks (send() reads from there without clearing it). Clear
+      // it BEFORE computing isDuplex so `keepOpen` goes true — otherwise
+      // the `.finally()` below resets `fetching`, and the first
+      // post-upgrade `socket.write()` would fire a second nodeHttpClient
+      // request to the same URL.
+      if (isUpgrade && customBody !== undefined) {
+        customBody = undefined;
+      }
+
       const isDuplex = customBody === undefined && (!this.finished || isUpgrade);
 
       if (isDuplex) {
         fetchOptions.duplex = "half";
         keepOpen = true;
-      }
-
-      // For upgrade requests always funnel the body through the generator
-      // so the write side stays live; any pre-assembled body is already in
-      // kBodyChunks (send() reads from there without clearing it).
-      if (isUpgrade && customBody !== undefined) {
-        customBody = undefined;
       }
 
       // Allow body for all methods when explicitly provided via req.write()/req.end()
@@ -707,6 +683,16 @@ function ClientRequest(input, options, cb) {
         // upload half of the connection is deliberately left open for the
         // hijacked protocol.
         const isUpgrade = response.status === 101;
+
+        // Server rejected the upgrade (e.g. 400 Bad Request, 404, auth
+        // failure) — release the upgrade-aware body generator so the
+        // ResumableSink/FetchTasklet can finalize. Otherwise the generator
+        // parks at `yield await new Promise(...)` forever (upgradeBodyEnded
+        // is only set by the hijacked socket, which never gets constructed
+        // for a non-101 response).
+        if (!isUpgrade && hasUpgradeHeaders(this)) {
+          this[kEndUpgradeBody]();
+        }
 
         handleResponse = () => {
           this[kFetchRequest] = null;

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -433,7 +433,10 @@ function ClientRequest(input, options, cb) {
       // calls `req.end()` at all (flushHeaders + write only). The
       // generator keeps running until the hijacked socket's
       // `_final`/`_destroy` signals via `kEndUpgradeBody`.
-      if (!hasUpgradeHeaders(this)) {
+      //
+      // Read the cached `isUpgrade` (populated by `send()` → `startFetch`
+      // a few lines above) instead of re-running `hasUpgradeHeaders()`.
+      if (!isUpgrade) {
         resolveNextChunk?.(true);
       }
     }
@@ -512,6 +515,13 @@ function ClientRequest(input, options, cb) {
   };
 
   let fetching = false;
+  // Precomputed once by the first `startFetch()` call so `this.end`, `go()`,
+  // and the `.then` leak-fix guard all share the same answer to "did the
+  // request carry `Connection: Upgrade` + `Upgrade: <proto>`?" — instead of
+  // each re-running `hasUpgradeHeaders()` (two `getHeader()` calls + regex).
+  // `this.end` reads this after `send()` returns, by which point startFetch
+  // has run synchronously and the flag is populated.
+  let isUpgrade = false;
 
   const startFetch = (customBody?) => {
     if (fetching) {
@@ -519,6 +529,7 @@ function ClientRequest(input, options, cb) {
     }
 
     fetching = true;
+    isUpgrade = hasUpgradeHeaders(this);
 
     // Every entry point that dispatches the request (send(), flushHeaders(),
     // and the write() → pushChunk paths) must have an AbortController wired
@@ -579,11 +590,13 @@ function ClientRequest(input, options, cb) {
         keepalive,
       };
       let keepOpen = false;
-      // Upgrade requests need a long-lived streaming body so the upload
-      // half of the hijacked connection stays open for post-101 writes.
-      // This covers the dockerode pattern (POST + req.write()) and the
-      // WebSocket/CDP pattern (GET + req.end() before the 101).
-      const isUpgrade = hasUpgradeHeaders(this);
+      // `isUpgrade` (closure var, set above in `startFetch`) tells us
+      // whether the request carried `Connection: Upgrade` + `Upgrade:
+      // <proto>`. Upgrade requests need a long-lived streaming body so
+      // the upload half of the hijacked connection stays open for
+      // post-101 writes — covers the dockerode pattern (POST +
+      // req.write()) and the WebSocket/CDP pattern (GET + req.end()
+      // before the 101).
 
       // For upgrade requests always funnel the body through the generator
       // so the write side stays live; any pre-assembled body is already in
@@ -683,10 +696,10 @@ function ClientRequest(input, options, cb) {
         // upload half of the connection is deliberately left open for the
         // hijacked protocol.
         //
-        // Named `is101` rather than `isUpgrade` to avoid shadowing the outer
-        // `const isUpgrade = hasUpgradeHeaders(this)` in `go()` (which asks
-        // whether the *request* carried `Upgrade:` headers — a different
-        // question, and the two can diverge when the server rejects).
+        // Named `is101` rather than `isUpgrade` to avoid shadowing the
+        // outer closure `isUpgrade` (set by `startFetch` from the request
+        // headers — a different question; the two diverge when the
+        // server rejects).
         const is101 = response.status === 101;
 
         // Server rejected the upgrade (e.g. 400 Bad Request, 404, auth

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -58,6 +58,27 @@ const { IncomingMessage } = require("node:_http_incoming");
 const { OutgoingMessage } = require("node:_http_outgoing");
 const { Duplex } = require("node:stream");
 
+// Local hook set by `ClientRequest` on itself when it owns an upgrade-aware
+// body generator. `createUpgradeSocket._final()`/`_destroy()` call this to
+// terminate the upload half of a hijacked connection without tripping the
+// normal `req.end()` path (which for the WebSocket/CDP pattern already ran
+// synchronously before the 101 response arrived).
+const kEndUpgradeBody = Symbol("kEndUpgradeBody");
+
+// Matches a `Connection: Upgrade` + `Upgrade: <proto>` pair that turns the
+// request into an HTTP/1.1 upgrade handshake. `h2`/`h2c` are excluded to
+// match `Bun__fetch_` in fetch.zig, which also ignores h2/h2c upgrades.
+function hasUpgradeHeaders(req): boolean {
+  const upgrade = req.getHeader("upgrade");
+  if (!upgrade) return false;
+  const upgradeStr = String(upgrade).toLowerCase();
+  if (upgradeStr === "h2" || upgradeStr === "h2c") return false;
+  const connection = req.getHeader("connection");
+  if (!connection) return false;
+  const cs = Array.isArray(connection) ? connection.join(",") : String(connection);
+  return /(?:^|[\s,])upgrade(?:[\s,]|$)/i.test(cs);
+}
+
 const globalReportError = globalThis.reportError;
 const setTimeout = globalThis.setTimeout;
 const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
@@ -137,7 +158,12 @@ function createUpgradeSocket(req, res) {
       res.resume();
     },
     write(chunk, encoding, callback) {
-      if (req.destroyed || req.finished) {
+      // Only gate on `req.destroyed`, NOT `req.finished` — for the
+      // WebSocket/CDP pattern the caller has already called `req.end()`
+      // before the 101, which sets `req.finished = true` synchronously.
+      // The upgrade-aware body generator stays alive past that point and
+      // still accepts writes until the hijacked socket tears down.
+      if (req.destroyed) {
         callback($ERR_STREAM_WRITE_AFTER_END());
         return;
       }
@@ -179,15 +205,28 @@ function createUpgradeSocket(req, res) {
       req.once("close", onClose);
     },
     final(callback) {
-      if (req.destroyed || req.finished) {
+      if (req.destroyed) {
         callback();
         return;
       }
-      // Wait until the underlying request body has actually finished before
-      // acknowledging `_final`. `'finish'` fires after `send()` has completed;
-      // `'error'`/`'close'` surface abnormal termination. Post-upgrade,
-      // FetchTasklet skips the chunked terminator so `req.end()` just closes
-      // the upload half without injecting framing bytes.
+      // If ClientRequest installed the upgrade-aware body terminator,
+      // close the upload half through it — this is the WebSocket/CDP
+      // (req.end() before 101) and dockerode (req.write() only) pattern.
+      // Otherwise, wait for the request to finish normally.
+      if (typeof req[kEndUpgradeBody] === "function") {
+        req[kEndUpgradeBody]();
+        callback();
+        return;
+      }
+      if (req.finished) {
+        callback();
+        return;
+      }
+      // Non-upgrade fallback (should not normally be reached on the
+      // hijacked-socket path). Wait until the underlying request body has
+      // actually finished before acknowledging `_final`. `'finish'` fires
+      // after `send()` has completed; `'error'`/`'close'` surface abnormal
+      // termination.
       let done = false;
       const finish = (err?: Error) => {
         if (done) return;
@@ -217,6 +256,15 @@ function createUpgradeSocket(req, res) {
       }
       try {
         res.destroy?.(err || undefined);
+      } catch (_err) {
+        void _err;
+      }
+      // Release the upgrade-aware body generator so `fetch` can finalize
+      // the request; otherwise the generator would hang forever waiting
+      // for more chunks (or the `finished` signal that never comes for
+      // the WebSocket pattern).
+      try {
+        req[kEndUpgradeBody]?.();
       } catch (_err) {
         void _err;
       }
@@ -297,6 +345,19 @@ function ClientRequest(input, options, cb) {
 
   let writeCount = 0;
   let resolveNextChunk: ((end: boolean) => void) | undefined = _end => {};
+  // Upgrade-aware body generator's exit flag. For upgrade requests the
+  // generator ignores `self.finished` (which gets set synchronously by
+  // `req.end()` in the WebSocket pattern) and instead waits until the
+  // hijacked duplex socket explicitly closes the upload half via
+  // `this[kEndUpgradeBody]`.
+  let upgradeBodyEnded = false;
+
+  // Exposed on `this` so `createUpgradeSocket`'s `_final`/`_destroy` can
+  // release the upload half. Safe to call multiple times.
+  this[kEndUpgradeBody] = () => {
+    upgradeBodyEnded = true;
+    resolveNextChunk?.(true);
+  };
 
   // Node sends headers + first chunk immediately on the first write(). We
   // defer by a tick so that `write(chunk); end();` in the same tick still
@@ -397,7 +458,13 @@ function ClientRequest(input, options, cb) {
 
     if (!this.finished) {
       send();
-      resolveNextChunk?.(true);
+      // For upgrade requests the upload half must stay open for post-101
+      // writes (WebSocket/CDP/dockerode all call `req.end()` before the
+      // 101 arrives). The generator keeps running until the hijacked
+      // socket's `_final`/`_destroy` signals via `kEndUpgradeBody`.
+      if (!hasUpgradeHeaders(this)) {
+        resolveNextChunk?.(true);
+      }
     }
 
     return this;
@@ -541,12 +608,23 @@ function ClientRequest(input, options, cb) {
         keepalive,
       };
       let keepOpen = false;
-      // no body and not finished
-      const isDuplex = customBody === undefined && !this.finished;
+      // Upgrade requests need a long-lived streaming body so the upload
+      // half of the hijacked connection stays open for post-101 writes.
+      // This covers the dockerode pattern (POST + req.write()) and the
+      // WebSocket/CDP pattern (GET + req.end() before the 101).
+      const isUpgrade = hasUpgradeHeaders(this);
+      const isDuplex = customBody === undefined && (!this.finished || isUpgrade);
 
       if (isDuplex) {
         fetchOptions.duplex = "half";
         keepOpen = true;
+      }
+
+      // For upgrade requests always funnel the body through the generator
+      // so the write side stays live; any pre-assembled body is already in
+      // kBodyChunks (send() reads from there without clearing it).
+      if (isUpgrade && customBody !== undefined) {
+        customBody = undefined;
       }
 
       // Allow body for all methods when explicitly provided via req.write()/req.end()
@@ -554,9 +632,12 @@ function ClientRequest(input, options, cb) {
       if (customBody !== undefined) {
         fetchOptions.body = customBody;
       } else if (
-        isDuplex &&
-        // Normal case: non-GET/HEAD/OPTIONS can use streaming
-        ((method !== "GET" && method !== "HEAD" && method !== "OPTIONS") ||
+        (isDuplex || isUpgrade) &&
+        // Upgrade: always stream — even GET/HEAD/OPTIONS with no pre-body
+        // need a live body channel for post-upgrade socket.write().
+        (isUpgrade ||
+          // Normal case: non-GET/HEAD/OPTIONS can use streaming
+          (method !== "GET" && method !== "HEAD" && method !== "OPTIONS") ||
           // Special case: GET/HEAD/OPTIONS with already-queued chunks should also stream
           this[kBodyChunks]?.length > 0)
       ) {
@@ -570,7 +651,10 @@ function ClientRequest(input, options, cb) {
             self.emit("drain");
           }
 
-          while (!self.finished) {
+          // Exit condition diverges: upgrade requests stay alive until the
+          // hijacked socket calls `req[kEndUpgradeBody]()`; non-upgrade
+          // requests end at `req.end()` as before.
+          while (isUpgrade ? !upgradeBodyEnded : !self.finished) {
             yield await new Promise(resolve => {
               resolveNextChunk = end => {
                 resolveNextChunk = undefined;

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -56,6 +56,7 @@ const {
 const { globalAgent } = require("node:_http_agent");
 const { IncomingMessage } = require("node:_http_incoming");
 const { OutgoingMessage } = require("node:_http_outgoing");
+const { Duplex } = require("node:stream");
 
 const globalReportError = globalThis.reportError;
 const setTimeout = globalThis.setTimeout;
@@ -73,6 +74,91 @@ function emitErrorEventNT(self, err) {
   if (self.listenerCount("error") > 0) {
     self.emit("error", err);
   }
+}
+
+// Creates a Duplex stream that represents the hijacked socket for a
+// `Connection: Upgrade` response. Reads pull from the fetch Response body
+// (the post-upgrade bytes from the server); writes route through the
+// ClientRequest's existing `req.write()` path so that the upload half of
+// the HTTP/1.1 connection keeps flowing. Used for dockerode-style hijacked
+// `docker exec` sessions and similar `Upgrade: tcp` patterns.
+function createUpgradeSocket(req, response) {
+  const reader = response.body?.getReader?.() ?? null;
+  let reading = false;
+  let ended = false;
+
+  const duplex = new Duplex({
+    allowHalfOpen: true,
+    read() {
+      if (reading || ended || !reader) {
+        if (!reader && !ended) {
+          ended = true;
+          this.push(null);
+        }
+        return;
+      }
+      reading = true;
+      reader.read().then(
+        ({ value, done }) => {
+          reading = false;
+          if (done) {
+            ended = true;
+            this.push(null);
+            return;
+          }
+          this.push(Buffer.from(value.buffer, value.byteOffset, value.byteLength));
+        },
+        err => {
+          reading = false;
+          this.destroy(err);
+        },
+      );
+    },
+    write(chunk, encoding, callback) {
+      if (req.destroyed || req.finished) {
+        callback($ERR_STREAM_WRITE_AFTER_END());
+        return;
+      }
+      req.write(chunk, encoding, callback);
+    },
+    final(callback) {
+      if (!req.destroyed && !req.finished) {
+        try {
+          req.end();
+        } catch (_err) {
+          void _err;
+        }
+      }
+      callback();
+    },
+    destroy(err, callback) {
+      ended = true;
+      if (reader) {
+        try {
+          reader.cancel?.();
+        } catch (_err) {
+          void _err;
+        }
+      }
+      if (!req.destroyed) {
+        req.destroy(err || undefined);
+      }
+      callback(err);
+    },
+  });
+
+  // Surface common net.Socket fields so consumers that inspect the socket
+  // (e.g. dockerode-modem) see a sane shape.
+  duplex.setKeepAlive = () => duplex;
+  duplex.setNoDelay = () => duplex;
+  duplex.setTimeout = (msecs, callback) => {
+    if (callback) duplex.once("timeout", callback);
+    return duplex;
+  };
+  duplex.ref = () => duplex;
+  duplex.unref = () => duplex;
+
+  return duplex;
 }
 
 function ClientRequest(input, options, cb) {
@@ -417,6 +503,14 @@ function ClientRequest(input, options, cb) {
           return;
         }
 
+        // A `HTTP/1.1 101 Switching Protocols` response indicates the server
+        // has accepted an `Upgrade:` request (WebSocket, `docker exec` hijack,
+        // etc.). The ClientRequest must dispatch `'upgrade'` with the hijacked
+        // socket regardless of whether the caller ever calls `req.end()` — the
+        // upload half of the connection is deliberately left open for the
+        // hijacked protocol.
+        const isUpgrade = response.status === 101;
+
         handleResponse = () => {
           this[kFetchRequest] = null;
           this[kClearTimeout]();
@@ -431,6 +525,32 @@ function ClientRequest(input, options, cb) {
           setIsNextIncomingMessageHTTPS(prevIsHTTPS);
           res.req = this;
           res.setTimeout = clientResponseSetTimeout;
+
+          if (isUpgrade) {
+            this[kUpgradeOrConnect] = true;
+            const upgradeSocket = createUpgradeSocket(this, response);
+            process.nextTick(
+              (self, res, socket) => {
+                try {
+                  if (self.aborted || self.listenerCount("upgrade") === 0) {
+                    // No handler for 'upgrade' — drop the hijacked socket so
+                    // we don't leak the underlying TCP connection.
+                    socket.destroy();
+                    res._dump?.();
+                  } else {
+                    self.emit("upgrade", res, socket, Buffer.alloc(0));
+                  }
+                } finally {
+                  maybeEmitClose();
+                }
+              },
+              this,
+              res,
+              upgradeSocket,
+            );
+            return;
+          }
+
           process.nextTick(
             (self, res) => {
               // If the user did not listen for the 'response' event, then they

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -763,6 +763,22 @@ function ClientRequest(input, options, cb) {
                   // socket's `_destroy` path calls `req.destroy()` when
                   // the user is done, which emits `'close'` on `req` at
                   // the correct time.
+                  //
+                  // `head` is always `Buffer.alloc(0)` here, diverging from
+                  // Node.js which passes any bytes llhttp read past the 101
+                  // `\r\n\r\n` in the same TCP segment. Bun's fetch-routed
+                  // architecture enqueues those bytes into `response.body`
+                  // before `handleResponse()` runs, so they flow through
+                  // `res` (the `IncomingMessage`) → `createUpgradeSocket`'s
+                  // `res.on('data', …)` bridge and arrive as the first
+                  // `socket.on('data')` chunk instead. Standard upgrade
+                  // consumers (`ws`, dockerode-modem, the `websocket` npm
+                  // package) do `if (head.length) socket.unshift(head)` and
+                  // then read from the socket, so they're unaffected — the
+                  // only code that diverges is code that synchronously
+                  // inspects `head` for protocol bytes before subscribing
+                  // to `'data'`, which is already fragile under Node since
+                  // TCP packet boundaries are not guaranteed.
                   self.emit("upgrade", res, socket, Buffer.alloc(0));
                 }
               },

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -233,7 +233,16 @@ function createUpgradeSocket(req, res) {
   duplex.setNoDelay = () => duplex;
   duplex.setTimeout = (msecs: number, callback?: () => void) => {
     timeoutMs = msecs | 0;
-    if (callback) duplex.once("timeout", callback);
+    if (callback) {
+      // Match `net.Socket.setTimeout(0, cb)` semantics: passing 0 with a
+      // callback de-registers that specific listener rather than adding
+      // another one. Mirrors `ClientRequestPrototype.setTimeout` below.
+      if (timeoutMs === 0) {
+        duplex.removeListener("timeout", callback);
+      } else {
+        duplex.once("timeout", callback);
+      }
+    }
     armTimeout();
     return duplex;
   };
@@ -639,17 +648,26 @@ function ClientRequest(input, options, cb) {
             const upgradeSocket = createUpgradeSocket(this, res);
             process.nextTick(
               (self, res, socket) => {
-                try {
-                  if (self.aborted || self.listenerCount("upgrade") === 0) {
-                    // No handler for 'upgrade' — drop the hijacked socket so
-                    // we don't leak the underlying TCP connection.
-                    socket.destroy();
-                    res._dump?.();
-                  } else {
-                    self.emit("upgrade", res, socket, Buffer.alloc(0));
-                  }
-                } finally {
+                if (self.aborted || self.listenerCount("upgrade") === 0) {
+                  // No handler for 'upgrade' — drop the hijacked socket so
+                  // we don't leak the underlying TCP connection. The close
+                  // notification for `req` will follow from the socket
+                  // destruction path below.
+                  socket.destroy();
+                  res._dump?.();
                   maybeEmitClose();
+                } else {
+                  // Do NOT call `maybeEmitClose()` here. The ClientRequest
+                  // lifecycle is now owned by the hijacked socket — firing
+                  // `req.emit('close')` on the very next tick would race
+                  // the Duplex `_write` backpressure path, which watches
+                  // `req.once('close', …)` to detect real TCP drops and
+                  // would treat a routine lifecycle close as a spurious
+                  // `ConnResetException('socket hang up')`. The hijacked
+                  // socket's `_destroy` path calls `req.destroy()` when
+                  // the user is done, which emits `'close'` on `req` at
+                  // the correct time.
+                  self.emit("upgrade", res, socket, Buffer.alloc(0));
                 }
               },
               this,

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -77,68 +77,121 @@ function emitErrorEventNT(self, err) {
 }
 
 // Creates a Duplex stream that represents the hijacked socket for a
-// `Connection: Upgrade` response. Reads pull from the fetch Response body
-// (the post-upgrade bytes from the server); writes route through the
-// ClientRequest's existing `req.write()` path so that the upload half of
-// the HTTP/1.1 connection keeps flowing. Used for dockerode-style hijacked
-// `docker exec` sessions and similar `Upgrade: tcp` patterns.
-function createUpgradeSocket(req, response) {
-  const reader = response.body?.getReader?.() ?? null;
-  let reading = false;
-  let ended = false;
+// `Connection: Upgrade` response. The readable side is fed from the
+// IncomingMessage `res` (which owns the fetch response body reader); the
+// writable side routes back through `req.write()` so the upload half of
+// the HTTP/1.1 connection keeps flowing. After the server sends `101`,
+// FetchTasklet.skipChunkedFraming() flips on `signals.upgraded`, so any
+// post-upgrade writes bypass chunked framing and the terminating 0-chunk —
+// matching the raw-bytes semantics of a real hijacked TCP socket.
+//
+// Used for dockerode-style hijacked `docker exec` sessions and similar
+// `Upgrade: tcp` patterns.
+function createUpgradeSocket(req, res) {
+  let socketDestroyed = false;
+  let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+  let timeoutMs = 0;
 
-  const duplex = new Duplex({
+  const armTimeout = () => {
+    if (timeoutTimer !== undefined) {
+      clearTimeout(timeoutTimer);
+      timeoutTimer = undefined;
+    }
+    if (timeoutMs > 0 && !socketDestroyed) {
+      timeoutTimer = setTimeout(() => {
+        timeoutTimer = undefined;
+        if (!socketDestroyed) duplex.emit("timeout");
+      }, timeoutMs);
+      (timeoutTimer as any).unref?.();
+    }
+  };
+
+  let bridged = false;
+  const bridgeRes = () => {
+    if (bridged) return;
+    bridged = true;
+    // Bridge the IncomingMessage's decoded body into the Duplex. The
+    // IncomingMessage is the single consumer of the fetch response body
+    // reader — avoiding a second `getReader()` call that would otherwise
+    // throw "ReadableStream is already locked" on the next read.
+    res.on("data", (chunk: Buffer) => {
+      armTimeout();
+      if (!duplex.push(chunk)) res.pause();
+    });
+    res.once("end", () => {
+      duplex.push(null);
+    });
+    res.once("error", (err: Error) => {
+      duplex.destroy(err);
+    });
+  };
+
+  const duplex: any = new Duplex({
     allowHalfOpen: true,
     read() {
-      if (reading || ended || !reader) {
-        if (!reader && !ended) {
-          ended = true;
-          this.push(null);
-        }
-        return;
-      }
-      reading = true;
-      reader.read().then(
-        ({ value, done }) => {
-          reading = false;
-          if (done) {
-            ended = true;
-            this.push(null);
-            return;
-          }
-          this.push(Buffer.from(value.buffer, value.byteOffset, value.byteLength));
-        },
-        err => {
-          reading = false;
-          this.destroy(err);
-        },
-      );
+      bridgeRes();
+      res.resume();
     },
     write(chunk, encoding, callback) {
       if (req.destroyed || req.finished) {
         callback($ERR_STREAM_WRITE_AFTER_END());
         return;
       }
-      req.write(chunk, encoding, callback);
+      armTimeout();
+      // Honor backpressure: only ack this write once `req` reports that it
+      // actually has room for more. `req.write()` returns false when its
+      // internal body queue has crossed the fake-backpressure threshold; the
+      // `'drain'` event fires when the queued chunks have been consumed by
+      // the underlying fetch body generator. Post-upgrade, FetchTasklet
+      // writes the raw bytes directly (no chunk framing).
+      const ok = req.write(chunk, encoding);
+      if (ok) {
+        callback();
+      } else {
+        req.once("drain", callback);
+      }
     },
     final(callback) {
-      if (!req.destroyed && !req.finished) {
-        try {
-          req.end();
-        } catch (_err) {
-          void _err;
-        }
+      if (req.destroyed || req.finished) {
+        callback();
+        return;
       }
-      callback();
+      // Wait until the underlying request body has actually finished before
+      // acknowledging `_final`. `'finish'` fires after `send()` has completed;
+      // `'error'`/`'close'` surface abnormal termination. Post-upgrade,
+      // FetchTasklet skips the chunked terminator so `req.end()` just closes
+      // the upload half without injecting framing bytes.
+      let done = false;
+      const finish = (err?: Error) => {
+        if (done) return;
+        done = true;
+        req.removeListener("finish", onFinish);
+        req.removeListener("error", onError);
+        req.removeListener("close", onClose);
+        callback(err);
+      };
+      const onFinish = () => finish();
+      const onError = (err: Error) => finish(err);
+      const onClose = () => finish();
+      req.once("finish", onFinish);
+      req.once("error", onError);
+      req.once("close", onClose);
+      try {
+        req.end();
+      } catch (err) {
+        finish(err as Error);
+      }
     },
     destroy(err, callback) {
-      ended = true;
-      if (reader) {
-        try {
-          reader.cancel?.();
-        } catch (_err) {
-          void _err;
-        }
+      socketDestroyed = true;
+      if (timeoutTimer !== undefined) {
+        clearTimeout(timeoutTimer);
+        timeoutTimer = undefined;
+      }
+      try {
+        res.destroy?.(err || undefined);
+      } catch (_err) {
+        void _err;
       }
       if (!req.destroyed) {
         req.destroy(err || undefined);
@@ -151,8 +204,10 @@ function createUpgradeSocket(req, response) {
   // (e.g. dockerode-modem) see a sane shape.
   duplex.setKeepAlive = () => duplex;
   duplex.setNoDelay = () => duplex;
-  duplex.setTimeout = (msecs, callback) => {
+  duplex.setTimeout = (msecs: number, callback?: () => void) => {
+    timeoutMs = msecs | 0;
     if (callback) duplex.once("timeout", callback);
+    armTimeout();
     return duplex;
   };
   duplex.ref = () => duplex;
@@ -528,7 +583,11 @@ function ClientRequest(input, options, cb) {
 
           if (isUpgrade) {
             this[kUpgradeOrConnect] = true;
-            const upgradeSocket = createUpgradeSocket(this, response);
+            // The hijacked socket reads via the IncomingMessage `res` (the
+            // single owner of the fetch response body reader); this avoids
+            // the "ReadableStream is already locked" TypeError that would
+            // otherwise occur when the user touches `res`.
+            const upgradeSocket = createUpgradeSocket(this, res);
             process.nextTick(
               (self, res, socket) => {
                 try {

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -695,7 +695,11 @@ function ClientRequest(input, options, cb) {
         // parks at `yield await new Promise(...)` forever (upgradeBodyEnded
         // is only set by the hijacked socket, which never gets constructed
         // for a non-101 response).
-        if (!is101 && hasUpgradeHeaders(this)) {
+        //
+        // Use the captured outer `isUpgrade` (same source of truth the
+        // generator's loop condition closes over) so the guard can't
+        // diverge from the generator if the user mutates headers mid-flight.
+        if (!is101 && isUpgrade) {
           this[kEndUpgradeBody]();
         }
 

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -664,6 +664,19 @@ function ClientRequest(input, options, cb) {
             }
           }
 
+          // Drain chunks queued while `resolveNextChunk` was momentarily
+          // `undefined`. The main loop delivers exactly one chunk per
+          // `resolveNextChunk` wake, so back-to-back synchronous writes
+          // — e.g. `socket.write(A); socket.write(B); socket.end()` on the
+          // hijacked Duplex — leave B in `kBodyChunks`; when `socket.end()`
+          // flushes synchronously, `_final()` → `kEndUpgradeBody()` sets
+          // `upgradeBodyEnded = true` before the generator can re-park,
+          // and the loop check above exits without yielding B. Same shape
+          // applies to `req.end()` on non-upgrade streaming requests.
+          while (self[kBodyChunks]?.length > 0) {
+            yield self[kBodyChunks].shift();
+          }
+
           handleResponse?.();
         };
       }

--- a/src/runtime/webcore/fetch/FetchTasklet.zig
+++ b/src/runtime/webcore/fetch/FetchTasklet.zig
@@ -1262,10 +1262,19 @@ pub const FetchTasklet = struct {
     /// Whether the request body should skip chunked transfer encoding framing.
     /// True for upgraded connections (e.g. WebSocket) or when the user explicitly
     /// set Content-Length without setting Transfer-Encoding.
+    ///
+    /// If the user explicitly set `Transfer-Encoding: chunked`, we honor that
+    /// and use chunked framing even for upgraded connections. This matches
+    /// Node.js behavior and is required by clients like dockerode which send
+    /// a chunked body alongside an `Upgrade` request for hijacked `docker exec`.
     fn skipChunkedFraming(this: *const FetchTasklet) bool {
+        const transfer_encoding = this.request_headers.get("transfer-encoding");
+        if (transfer_encoding) |value| {
+            if (std.ascii.eqlIgnoreCase(value, "chunked")) return false;
+        }
         return this.upgraded_connection or
             this.result.is_http2 or
-            (this.request_headers.get("content-length") != null and this.request_headers.get("transfer-encoding") == null);
+            (this.request_headers.get("content-length") != null and transfer_encoding == null);
     }
 
     pub fn writeRequestData(this: *FetchTasklet, data: []const u8) ResumableSinkBackpressure {

--- a/src/runtime/webcore/fetch/FetchTasklet.zig
+++ b/src/runtime/webcore/fetch/FetchTasklet.zig
@@ -1263,11 +1263,18 @@ pub const FetchTasklet = struct {
     /// True for upgraded connections (e.g. WebSocket) or when the user explicitly
     /// set Content-Length without setting Transfer-Encoding.
     ///
+    /// Once the server has responded `101 Switching Protocols`, the connection
+    /// is in raw mode and all further writes must bypass chunked framing and
+    /// skip the terminating `0\r\n\r\n` — otherwise we'd inject chunk headers
+    /// into the hijacked protocol stream (e.g. corrupting dockerode stdin).
+    ///
     /// If the user explicitly set `Transfer-Encoding: chunked`, we honor that
-    /// and use chunked framing even for upgraded connections. This matches
-    /// Node.js behavior and is required by clients like dockerode which send
-    /// a chunked body alongside an `Upgrade` request for hijacked `docker exec`.
+    /// for the pre-upgrade body. This matches Node.js behavior and is required
+    /// by clients like dockerode which send a chunked body alongside an
+    /// `Upgrade` request for hijacked `docker exec`.
     fn skipChunkedFraming(this: *const FetchTasklet) bool {
+        // Post-upgrade: always raw bytes, no framing and no terminator.
+        if (this.signals.get(.upgraded)) return true;
         const transfer_encoding = this.request_headers.get("transfer-encoding");
         if (transfer_encoding) |value| {
             if (std.ascii.eqlIgnoreCase(value, "chunked")) return false;

--- a/src/runtime/webcore/fetch/FetchTasklet.zig
+++ b/src/runtime/webcore/fetch/FetchTasklet.zig
@@ -1297,6 +1297,7 @@ pub const FetchTasklet = struct {
             if (bun.strings.containsCaseInsensitiveASCII(value, "chunked")) return false;
         }
         return this.upgraded_connection or
+            this.result.is_http2 or
             (this.request_headers.get("content-length") != null and transfer_encoding == null);
     }
 

--- a/src/runtime/webcore/fetch/FetchTasklet.zig
+++ b/src/runtime/webcore/fetch/FetchTasklet.zig
@@ -1192,26 +1192,14 @@ pub const FetchTasklet = struct {
             };
         }
 
-        // Pre-compute `request_body_has_framing` so `skipChunkedFraming()`
-        // has the right answer the moment the first body chunk shows up on
-        // the main thread, before `buildRequest()` runs on the HTTP thread.
-        // `buildRequest()` re-derives this bit from the finalized header
-        // slice as the source of truth, and the two must agree for the
-        // common case — we mirror its logic here.
-        //
-        // Framing is present when:
-        //   - non-streaming body (Content-Length auto-added), or
-        //   - user set `Content-Length`, or
-        //   - user set `Transfer-Encoding: chunked`, or
-        //   - streaming, non-upgrade request (chunked auto-added).
-        fetch_tasklet.http.?.client.flags.request_body_has_framing = compute_framing: {
-            if (!isStream) break :compute_framing true;
-            if (fetch_tasklet.request_headers.get("content-length") != null) break :compute_framing true;
-            if (fetch_tasklet.request_headers.get("transfer-encoding")) |te| {
-                if (bun.strings.containsCaseInsensitiveASCII(te, "chunked")) break :compute_framing true;
-            }
-            break :compute_framing !fetch_tasklet.upgraded_connection;
-        };
+        // Note: `HTTPClient.flags.request_body_has_framing` (read by
+        // `writeToStream()` in http.zig to decide whether to drain the
+        // streaming request body before the 101) is set from
+        // `buildRequest()`, which runs on the HTTP thread during the header
+        // send phase — strictly before the body phase that calls
+        // `writeToStream()`. `FetchTasklet.skipChunkedFraming()` reads the
+        // user headers directly, so it doesn't need the pre-computation here.
+
         // TODO is this necessary? the http client already sets the redirect type,
         // so manually setting it here seems redundant
         if (fetch_options.redirect_type != FetchRedirect.follow) {
@@ -1280,26 +1268,36 @@ pub const FetchTasklet = struct {
         }
     }
 
-    /// Whether the request body should skip chunked transfer encoding framing.
+    /// Whether the request body should skip chunked transfer encoding framing
+    /// (i.e. write bytes raw instead of wrapping them in `{hex}\r\n...\r\n`).
     ///
     /// Once the server has responded `101 Switching Protocols`, the connection
     /// is in raw mode and all further writes must bypass chunked framing and
     /// skip the terminating `0\r\n\r\n` — otherwise we'd inject chunk headers
     /// into the hijacked protocol stream (e.g. corrupting dockerode stdin).
     ///
-    /// Otherwise, the decision comes from the single wire-framing bit on
-    /// `HTTPClient.flags`, which is pre-computed when the fetch tasklet is
-    /// created (main thread, before the HTTP task is scheduled) and then
-    /// re-derived by `buildRequest()` from the finalized header slice as the
-    /// source of truth. Both agree for all practical header configurations.
+    /// Before the upgrade, the decision is made from the user's request
+    /// headers. Chunked framing is ONLY applied when the request body is
+    /// actually chunked-encoded on the wire:
+    ///   - user explicitly set `Transfer-Encoding: chunked`, OR
+    ///   - there is no explicit framing and `buildRequest()` will auto-add
+    ///     chunked (the default streaming path).
+    ///
+    /// `Content-Length`-delimited bodies are raw bytes too — the server reads
+    /// exactly N bytes, no chunk headers. That case lives in the
+    /// `(content-length != null and transfer-encoding == null)` branch below.
     fn skipChunkedFraming(this: *const FetchTasklet) bool {
         // Post-upgrade: always raw bytes, no framing and no terminator.
         if (this.signals.get(.upgraded)) return true;
-        if (this.http) |http_| {
-            return !http_.client.flags.request_body_has_framing;
+        const transfer_encoding = this.request_headers.get("transfer-encoding");
+        if (transfer_encoding) |value| {
+            // User explicitly requested chunked — keep the framing even for
+            // upgrade connections (dockerode's hijacked `docker exec` uses
+            // `Transfer-Encoding: chunked` with `Upgrade: tcp`).
+            if (bun.strings.containsCaseInsensitiveASCII(value, "chunked")) return false;
         }
-        // No HTTP client yet (shouldn't happen — FetchTasklet.get has run).
-        return true;
+        return this.upgraded_connection or
+            (this.request_headers.get("content-length") != null and transfer_encoding == null);
     }
 
     pub fn writeRequestData(this: *FetchTasklet, data: []const u8) ResumableSinkBackpressure {

--- a/src/runtime/webcore/fetch/FetchTasklet.zig
+++ b/src/runtime/webcore/fetch/FetchTasklet.zig
@@ -1191,6 +1191,27 @@ pub const FetchTasklet = struct {
                 },
             };
         }
+
+        // Pre-compute `request_body_has_framing` so `skipChunkedFraming()`
+        // has the right answer the moment the first body chunk shows up on
+        // the main thread, before `buildRequest()` runs on the HTTP thread.
+        // `buildRequest()` re-derives this bit from the finalized header
+        // slice as the source of truth, and the two must agree for the
+        // common case — we mirror its logic here.
+        //
+        // Framing is present when:
+        //   - non-streaming body (Content-Length auto-added), or
+        //   - user set `Content-Length`, or
+        //   - user set `Transfer-Encoding: chunked`, or
+        //   - streaming, non-upgrade request (chunked auto-added).
+        fetch_tasklet.http.?.client.flags.request_body_has_framing = compute_framing: {
+            if (!isStream) break :compute_framing true;
+            if (fetch_tasklet.request_headers.get("content-length") != null) break :compute_framing true;
+            if (fetch_tasklet.request_headers.get("transfer-encoding")) |te| {
+                if (bun.strings.containsCaseInsensitiveASCII(te, "chunked")) break :compute_framing true;
+            }
+            break :compute_framing !fetch_tasklet.upgraded_connection;
+        };
         // TODO is this necessary? the http client already sets the redirect type,
         // so manually setting it here seems redundant
         if (fetch_options.redirect_type != FetchRedirect.follow) {
@@ -1260,28 +1281,25 @@ pub const FetchTasklet = struct {
     }
 
     /// Whether the request body should skip chunked transfer encoding framing.
-    /// True for upgraded connections (e.g. WebSocket) or when the user explicitly
-    /// set Content-Length without setting Transfer-Encoding.
     ///
     /// Once the server has responded `101 Switching Protocols`, the connection
     /// is in raw mode and all further writes must bypass chunked framing and
     /// skip the terminating `0\r\n\r\n` — otherwise we'd inject chunk headers
     /// into the hijacked protocol stream (e.g. corrupting dockerode stdin).
     ///
-    /// If the user explicitly set `Transfer-Encoding: chunked`, we honor that
-    /// for the pre-upgrade body. This matches Node.js behavior and is required
-    /// by clients like dockerode which send a chunked body alongside an
-    /// `Upgrade` request for hijacked `docker exec`.
+    /// Otherwise, the decision comes from the single wire-framing bit on
+    /// `HTTPClient.flags`, which is pre-computed when the fetch tasklet is
+    /// created (main thread, before the HTTP task is scheduled) and then
+    /// re-derived by `buildRequest()` from the finalized header slice as the
+    /// source of truth. Both agree for all practical header configurations.
     fn skipChunkedFraming(this: *const FetchTasklet) bool {
         // Post-upgrade: always raw bytes, no framing and no terminator.
         if (this.signals.get(.upgraded)) return true;
-        const transfer_encoding = this.request_headers.get("transfer-encoding");
-        if (transfer_encoding) |value| {
-            if (std.ascii.eqlIgnoreCase(value, "chunked")) return false;
+        if (this.http) |http_| {
+            return !http_.client.flags.request_body_has_framing;
         }
-        return this.upgraded_connection or
-            this.result.is_http2 or
-            (this.request_headers.get("content-length") != null and transfer_encoding == null);
+        // No HTTP client yet (shouldn't happen — FetchTasklet.get has run).
+        return true;
     }
 
     pub fn writeRequestData(this: *FetchTasklet, data: []const u8) ResumableSinkBackpressure {

--- a/test/regression/issue/29012.test.ts
+++ b/test/regression/issue/29012.test.ts
@@ -293,3 +293,184 @@ test.if(!isWindows)("http.request 'upgrade' (GET + req.end()): socket.write reac
     close();
   }
 });
+
+// Server that rejects every upgrade attempt with a 400 response so we can
+// exercise the "upgrade-headed request gets a non-101 reply" path.
+function spawnRejectUpgradeServer(): Promise<{ socketPath: string; close: () => void }> {
+  return new Promise((resolve, reject) => {
+    const socketPath = path.join(
+      os.tmpdir(),
+      `bun-29012-reject-${process.pid}-${Math.random().toString(36).slice(2)}.sock`,
+    );
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {}
+
+    const server = net.createServer(socket => {
+      let buffer = Buffer.alloc(0);
+      socket.on("data", chunk => {
+        buffer = Buffer.concat([buffer, chunk]);
+        if (buffer.indexOf("\r\n\r\n") === -1) return;
+        const body = "nope";
+        socket.write(
+          "HTTP/1.1 400 Bad Request\r\n" +
+            "Content-Length: " +
+            body.length +
+            "\r\n" +
+            "Connection: close\r\n" +
+            "\r\n" +
+            body,
+        );
+        queueMicrotask(() => socket.end());
+      });
+    });
+
+    server.on("error", reject);
+    server.listen(socketPath, () => {
+      resolve({
+        socketPath,
+        close: () => {
+          server.close();
+          try {
+            fs.unlinkSync(socketPath);
+          } catch {}
+        },
+      });
+    });
+  });
+}
+
+test.if(!isWindows)("http.request upgrade-headed + non-101 response: 'response' fires, no leak", async () => {
+  // Regression: an upgrade-headed request that the server REJECTS (400,
+  // 404, auth failure, etc.) must emit 'response' and release the
+  // upgrade-aware body generator. Otherwise the generator parks at
+  // `yield await new Promise(...)` forever because `upgradeBodyEnded`
+  // is only set from `createUpgradeSocket`, which is only constructed
+  // on a 101 response. If that happens the ResumableSink / FetchTasklet
+  // never finalize and memory leaks per rejected handshake.
+  const { socketPath, close } = await spawnRejectUpgradeServer();
+  try {
+    const req = http.request({
+      socketPath,
+      method: "GET",
+      path: "/",
+      headers: {
+        Connection: "Upgrade",
+        Upgrade: "websocket",
+      },
+    });
+
+    const { promise: responsePromise, resolve, reject } = Promise.withResolvers<http.IncomingMessage>();
+    req.on("response", r => resolve(r));
+    req.on("upgrade", () => reject(new Error("unexpected 'upgrade' event")));
+    req.on("error", reject);
+    req.end();
+
+    const res = await responsePromise;
+    expect(res.statusCode).toBe(400);
+
+    const body = await new Promise<string>((resolveBody, rejectBody) => {
+      const bufs: Buffer[] = [];
+      res.on("data", c => bufs.push(c));
+      res.on("end", () => resolveBody(Buffer.concat(bufs).toString("utf8")));
+      res.on("error", rejectBody);
+    });
+    expect(body).toBe("nope");
+
+    // If the body generator leaks, `req.destroy()` still returns quickly
+    // but the FetchTasklet stays alive. Assert the request is now
+    // considered finished from the caller's perspective.
+    await new Promise<void>(res2 => setImmediate(res2));
+    req.destroy();
+  } finally {
+    close();
+  }
+});
+
+test.if(!isWindows)(
+  "http.request upgrade + req.end(body) without flushHeaders: one nodeHttpClient call",
+  async () => {
+    // Regression: `customBody = undefined` used to run AFTER the isDuplex
+    // computation, so `req.end(body)` on an upgrade request left
+    // `keepOpen = false`, the `.finally()` reset `fetching = false`, and
+    // the first post-upgrade `socket.write()` fired a SECOND nodeHttpClient
+    // request to the same URL.
+    //
+    // We catch this with a server that keeps a connection count: a second
+    // connection would bump it above 1.
+    const { promise: serverReady, resolve: gotPath } = Promise.withResolvers<string>();
+    const socketPath = path.join(
+      os.tmpdir(),
+      `bun-29012-once-${process.pid}-${Math.random().toString(36).slice(2)}.sock`,
+    );
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {}
+
+    let connectionCount = 0;
+    const server = net.createServer(socket => {
+      connectionCount++;
+      let headersSeen = false;
+      let buffer = Buffer.alloc(0);
+      socket.on("data", chunk => {
+        if (!headersSeen) {
+          buffer = Buffer.concat([buffer, chunk]);
+          const headerEnd = buffer.indexOf("\r\n\r\n");
+          if (headerEnd === -1) return;
+          headersSeen = true;
+          socket.write(
+            "HTTP/1.1 101 Switching Protocols\r\n" +
+              "Upgrade: echo\r\n" +
+              "Connection: Upgrade\r\n" +
+              "\r\n",
+          );
+        } else {
+          socket.write(chunk); // echo
+        }
+      });
+    });
+    server.listen(socketPath, () => gotPath(socketPath));
+    await serverReady;
+
+    try {
+      const req = http.request({
+        socketPath,
+        method: "POST",
+        path: "/",
+        headers: {
+          Connection: "Upgrade",
+          Upgrade: "echo",
+          "Content-Length": "4",
+        },
+      });
+
+      const { promise, resolve, reject } = Promise.withResolvers<any>();
+      req.on("upgrade", (_res, socket) => resolve(socket));
+      req.on("error", reject);
+      // Single req.end(body) path — no flushHeaders, no separate write.
+      req.end("init");
+
+      const socket = await promise;
+      const chunks: Buffer[] = [];
+      const got = new Promise<void>(res2 => {
+        socket.on("data", (c: Buffer) => {
+          chunks.push(c);
+          if (Buffer.concat(chunks).toString("utf8") === "post") res2();
+        });
+      });
+      socket.write("post");
+      await got;
+
+      // Give any runaway second-request path time to fire.
+      await new Promise<void>(res2 => setTimeout(res2, 50));
+      expect(connectionCount).toBe(1);
+
+      socket.destroy();
+    } finally {
+      server.close();
+      try {
+        fs.unlinkSync(socketPath);
+      } catch {}
+    }
+  },
+);

--- a/test/regression/issue/29012.test.ts
+++ b/test/regression/issue/29012.test.ts
@@ -189,3 +189,107 @@ test.if(!isWindows)("http.request 'upgrade' delivers hijacked socket with writab
     close();
   }
 });
+
+// Spawns an echo-upgrade server that sends `HTTP/1.1 101` as soon as it
+// sees the request headers (no body required) and echoes raw bytes back
+// once upgraded. This mirrors the `ws` / Playwright CDP pattern: GET with
+// `Upgrade:` headers, `req.end()` before the 101, and `socket.write(…)`
+// inside the `'upgrade'` listener.
+function spawnEchoUpgradeServer(): Promise<{ socketPath: string; close: () => void }> {
+  return new Promise((resolve, reject) => {
+    const socketPath = path.join(
+      os.tmpdir(),
+      `bun-29012-echo-${process.pid}-${Math.random().toString(36).slice(2)}.sock`,
+    );
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {}
+
+    const server = net.createServer(socket => {
+      let headersSeen = false;
+      let buffer = Buffer.alloc(0);
+      socket.on("data", chunk => {
+        if (!headersSeen) {
+          buffer = Buffer.concat([buffer, chunk]);
+          const headerEnd = buffer.indexOf("\r\n\r\n");
+          if (headerEnd === -1) return;
+          headersSeen = true;
+          socket.write(
+            "HTTP/1.1 101 Switching Protocols\r\n" +
+              "Upgrade: echo\r\n" +
+              "Connection: Upgrade\r\n" +
+              "\r\n",
+          );
+          // Anything past the blank line is hijacked-protocol data — echo it.
+          const leftover = buffer.subarray(headerEnd + 4);
+          if (leftover.length > 0) socket.write(leftover);
+        } else {
+          // Hijacked phase: echo raw bytes.
+          socket.write(chunk);
+        }
+      });
+    });
+
+    server.on("error", reject);
+    server.listen(socketPath, () => {
+      resolve({
+        socketPath,
+        close: () => {
+          server.close();
+          try {
+            fs.unlinkSync(socketPath);
+          } catch {}
+        },
+      });
+    });
+  });
+}
+
+test.if(!isWindows)("http.request 'upgrade' (GET + req.end()): socket.write reaches the server", async () => {
+  // Regression for the WebSocket / Playwright CDP / `websocket` npm package
+  // pattern (see #18945, #9911, #20547): GET with `Upgrade:` headers and
+  // `req.end()` called BEFORE the 101 response. The hijacked socket's
+  // writable side must stay live past `req.finished = true`.
+  const { socketPath, close } = await spawnEchoUpgradeServer();
+  try {
+    const req = http.request({
+      socketPath,
+      method: "GET",
+      path: "/",
+      headers: {
+        Connection: "Upgrade",
+        Upgrade: "echo",
+      },
+    });
+
+    const { promise: upgradePromise, resolve, reject } = Promise.withResolvers<{
+      res: http.IncomingMessage;
+      socket: import("node:stream").Duplex;
+      head: Buffer;
+    }>();
+    req.on("upgrade", (res, socket, head) => resolve({ res, socket, head }));
+    req.on("error", reject);
+    // Standard Node WebSocket pattern: end() synchronously BEFORE the 101.
+    req.end();
+
+    const { res, socket } = await upgradePromise;
+    expect(res.statusCode).toBe(101);
+    expect(res.headers.upgrade).toBe("echo");
+
+    const chunks: Buffer[] = [];
+    const gotEcho = new Promise<void>(res2 => {
+      socket.on("data", c => {
+        chunks.push(c);
+        if (Buffer.concat(chunks).toString("utf8") === "ping") res2();
+      });
+    });
+
+    socket.write("ping");
+    await gotEcho;
+    expect(Buffer.concat(chunks).toString("utf8")).toBe("ping");
+
+    socket.destroy();
+  } finally {
+    close();
+  }
+});

--- a/test/regression/issue/29012.test.ts
+++ b/test/regression/issue/29012.test.ts
@@ -408,8 +408,20 @@ test.if(!isWindows)(
     } catch {}
 
     let connectionCount = 0;
+    // If the bug recurred, a second `nodeHttpClient` request would fire
+    // synchronously from `socket.write('post')` and the kernel would
+    // deliver a second `connection` event. We race that against the echo
+    // round-trip so the assertion fails immediately (instead of waiting
+    // for an arbitrary timeout that would be flaky on loaded CI).
+    const { promise: secondConn, reject: secondConnFired } = Promise.withResolvers<never>();
+    secondConn.catch(() => {}); // don't leave this unhandled if it never fires
     const server = net.createServer(socket => {
       connectionCount++;
+      if (connectionCount > 1) {
+        secondConnFired(new Error("regression: a second nodeHttpClient request was fired"));
+        socket.destroy();
+        return;
+      }
       let headersSeen = false;
       let buffer = Buffer.alloc(0);
       socket.on("data", chunk => {
@@ -459,10 +471,10 @@ test.if(!isWindows)(
         });
       });
       socket.write("post");
-      await got;
-
-      // Give any runaway second-request path time to fire.
-      await new Promise<void>(res2 => setTimeout(res2, 50));
+      // `await got` implicitly serializes past the synchronous re-entry
+      // into `startFetch()`, and `secondConn` fails fast if the 2nd
+      // request was actually issued to the kernel. No timer needed.
+      await Promise.race([got, secondConn]);
       expect(connectionCount).toBe(1);
 
       socket.destroy();

--- a/test/regression/issue/29012.test.ts
+++ b/test/regression/issue/29012.test.ts
@@ -422,22 +422,43 @@ test.if(!isWindows)(
         socket.destroy();
         return;
       }
-      let headersSeen = false;
+      // Strict state machine: "headers" → "body" (consume exactly the
+      // Content-Length from the headers) → "upgraded" (echo raw bytes).
+      // This avoids any dependency on whether the kernel coalesces the
+      // request headers and the body into one `'data'` event — we never
+      // accidentally echo the pre-upgrade body.
+      let phase: "headers" | "body" | "upgraded" = "headers";
       let buffer = Buffer.alloc(0);
+      let bodyRemaining = 0;
       socket.on("data", chunk => {
-        if (!headersSeen) {
-          buffer = Buffer.concat([buffer, chunk]);
-          const headerEnd = buffer.indexOf("\r\n\r\n");
-          if (headerEnd === -1) return;
-          headersSeen = true;
-          socket.write(
-            "HTTP/1.1 101 Switching Protocols\r\n" +
-              "Upgrade: echo\r\n" +
-              "Connection: Upgrade\r\n" +
-              "\r\n",
-          );
-        } else {
-          socket.write(chunk); // echo
+        buffer = Buffer.concat([buffer, chunk]);
+        while (buffer.length > 0) {
+          if (phase === "headers") {
+            const headerEnd = buffer.indexOf("\r\n\r\n");
+            if (headerEnd === -1) return;
+            const headerBlock = buffer.subarray(0, headerEnd).toString("binary");
+            const clMatch = headerBlock.match(/^content-length:\s*(\d+)/im);
+            bodyRemaining = clMatch ? parseInt(clMatch[1], 10) : 0;
+            buffer = buffer.subarray(headerEnd + 4);
+            socket.write(
+              "HTTP/1.1 101 Switching Protocols\r\n" +
+                "Upgrade: echo\r\n" +
+                "Connection: Upgrade\r\n" +
+                "\r\n",
+            );
+            phase = bodyRemaining > 0 ? "body" : "upgraded";
+          } else if (phase === "body") {
+            const take = Math.min(bodyRemaining, buffer.length);
+            buffer = buffer.subarray(take);
+            bodyRemaining -= take;
+            if (bodyRemaining === 0) phase = "upgraded";
+            else return;
+          } else {
+            // upgraded: echo the remaining bytes as-is.
+            socket.write(buffer);
+            buffer = Buffer.alloc(0);
+            return;
+          }
         }
       });
     });
@@ -467,7 +488,11 @@ test.if(!isWindows)(
       const got = new Promise<void>(res2 => {
         socket.on("data", (c: Buffer) => {
           chunks.push(c);
-          if (Buffer.concat(chunks).toString("utf8") === "post") res2();
+          // Use endsWith — even though the server is careful not to echo
+          // the pre-upgrade body, be tolerant in case a future refactor
+          // changes that behavior. The regression being tested is
+          // connectionCount, not the echo transcript.
+          if (Buffer.concat(chunks).toString("utf8").endsWith("post")) res2();
         });
       });
       socket.write("post");

--- a/test/regression/issue/29012.test.ts
+++ b/test/regression/issue/29012.test.ts
@@ -1,0 +1,191 @@
+import { test, expect } from "bun:test";
+import { isWindows } from "harness";
+import http from "node:http";
+import net from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// https://github.com/oven-sh/bun/issues/29012
+//
+// `http.request()` with `Connection: Upgrade` must dispatch the `'upgrade'`
+// event when the server answers `HTTP/1.1 101 Switching Protocols`, even if
+// the caller never calls `req.end()`. This is the pattern dockerode uses for
+// hijacked `docker exec` sessions: write the JSON exec config via
+// `req.write(...)`, leave the upload half of the HTTP/1.1 connection open,
+// and hand the hijacked socket back to the user.
+//
+// Regression: Bun used to silently drop the 101, never emitting 'upgrade',
+// 'response', or 'error', so the promise dockerode awaits never settled.
+
+function spawnUpgradeServer(): Promise<{ socketPath: string; close: () => void }> {
+  return new Promise((resolve, reject) => {
+    const socketPath = path.join(os.tmpdir(), `bun-29012-${process.pid}-${Math.random().toString(36).slice(2)}.sock`);
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {}
+
+    const server = net.createServer(socket => {
+      let buffer = Buffer.alloc(0);
+      let phase: "headers" | "chunk-size" | "chunk-data" | "upgraded" = "headers";
+      let chunkSize = -1;
+
+      const sendUpgrade = () => {
+        socket.write(
+          "HTTP/1.1 101 UPGRADED\r\n" +
+            "Content-Type: application/vnd.docker.raw-stream\r\n" +
+            "Connection: Upgrade\r\n" +
+            "Upgrade: tcp\r\n" +
+            "\r\n",
+        );
+        // Docker-style framing: [type=1(stdout), 0,0,0, size32be] + "ready\n"
+        const payload = Buffer.from("ready\n");
+        const hdr = Buffer.alloc(8);
+        hdr[0] = 1;
+        hdr.writeUInt32BE(payload.length, 4);
+        socket.write(Buffer.concat([hdr, payload]));
+        // Give the client a moment to read the frame, then close the socket.
+        queueMicrotask(() => socket.end());
+      };
+
+      socket.on("data", chunk => {
+        buffer = Buffer.concat([buffer, chunk]);
+        while (true) {
+          if (phase === "headers") {
+            const headerEnd = buffer.indexOf("\r\n\r\n");
+            if (headerEnd === -1) return;
+            const headerBlock = buffer.subarray(0, headerEnd).toString("binary");
+            buffer = buffer.subarray(headerEnd + 4);
+            if (!/upgrade/i.test(headerBlock)) {
+              socket.destroy();
+              return;
+            }
+            phase = "chunk-size";
+          } else if (phase === "chunk-size") {
+            const lineEnd = buffer.indexOf("\r\n");
+            if (lineEnd === -1) return;
+            chunkSize = parseInt(buffer.subarray(0, lineEnd).toString("binary"), 16);
+            buffer = buffer.subarray(lineEnd + 2);
+            if (Number.isNaN(chunkSize)) {
+              socket.destroy();
+              return;
+            }
+            phase = chunkSize === 0 ? "upgraded" : "chunk-data";
+            if (phase === "upgraded") sendUpgrade();
+          } else if (phase === "chunk-data") {
+            if (buffer.length < chunkSize + 2) return;
+            buffer = buffer.subarray(chunkSize + 2);
+            phase = "chunk-size";
+            // The hijack protocol expects the server to upgrade as soon as the
+            // exec config chunk is parsed. Do that here.
+            sendUpgrade();
+            phase = "upgraded";
+          } else {
+            // Post-upgrade: ignore any additional client writes.
+            return;
+          }
+        }
+      });
+    });
+
+    server.on("error", reject);
+    server.listen(socketPath, () => {
+      resolve({
+        socketPath,
+        close: () => {
+          server.close();
+          try {
+            fs.unlinkSync(socketPath);
+          } catch {}
+        },
+      });
+    });
+  });
+}
+
+test.if(!isWindows)("http.request emits 'upgrade' on 101 without req.end()", async () => {
+  const { socketPath, close } = await spawnUpgradeServer();
+  try {
+    const req = http.request({
+      socketPath,
+      method: "POST",
+      path: "/exec/fake/start",
+      headers: {
+        "Content-Type": "application/json",
+        "Connection": "Upgrade",
+        "Upgrade": "tcp",
+        "Transfer-Encoding": "chunked",
+      },
+    });
+
+    const { promise, resolve, reject } = Promise.withResolvers<{
+      res: http.IncomingMessage;
+      socket: import("node:stream").Duplex;
+      head: Buffer;
+    }>();
+
+    req.on("upgrade", (res, socket, head) => resolve({ res, socket, head }));
+    req.on("error", reject);
+    req.flushHeaders();
+    // NOTE: req.end() is NOT called — this mirrors dockerode's behavior when
+    // `openStdin` is true. Bun must still dispatch 'upgrade'.
+    req.write('{"Detach":false,"Tty":false}');
+
+    const { res, socket, head } = await promise;
+
+    expect(res.statusCode).toBe(101);
+    expect(res.headers.upgrade).toBe("tcp");
+    expect(Buffer.isBuffer(head)).toBe(true);
+
+    // Read the Docker-framed "ready\n" payload from the hijacked socket.
+    const chunks: Buffer[] = [];
+    const ended = new Promise<void>(res2 => socket.once("end", res2));
+    socket.on("data", (c: Buffer) => chunks.push(c));
+    await ended;
+
+    const body = Buffer.concat(chunks);
+    // type=1 (stdout), 0 0 0, size32be=6, payload="ready\n"
+    expect(body.slice(0, 8)).toEqual(Buffer.from([1, 0, 0, 0, 0, 0, 0, 6]));
+    expect(body.slice(8).toString("utf8")).toBe("ready\n");
+
+    socket.destroy();
+    req.destroy();
+  } finally {
+    close();
+  }
+});
+
+test.if(!isWindows)("http.request 'upgrade' delivers hijacked socket with writable Duplex", async () => {
+  // A lighter-weight variant that just checks the upgrade event shape.
+  const { socketPath, close } = await spawnUpgradeServer();
+  try {
+    const req = http.request({
+      socketPath,
+      method: "POST",
+      path: "/exec/fake/start",
+      headers: {
+        Connection: "Upgrade",
+        Upgrade: "tcp",
+        "Transfer-Encoding": "chunked",
+      },
+    });
+
+    const { promise, resolve, reject } = Promise.withResolvers<any>();
+    req.on("upgrade", (res, socket, head) => resolve({ res, socket, head }));
+    req.on("error", reject);
+    req.flushHeaders();
+    req.write('{"Detach":false,"Tty":false}');
+
+    const { res, socket, head } = await promise;
+    expect(res.statusCode).toBe(101);
+    expect(typeof socket.write).toBe("function");
+    expect(typeof socket.end).toBe("function");
+    expect(typeof socket.on).toBe("function");
+    expect(Buffer.isBuffer(head)).toBe(true);
+
+    socket.destroy();
+    req.destroy();
+  } finally {
+    close();
+  }
+});

--- a/test/regression/issue/29012.test.ts
+++ b/test/regression/issue/29012.test.ts
@@ -511,3 +511,59 @@ test.if(!isWindows)(
     }
   },
 );
+
+test.if(!isWindows)(
+  "http.request upgrade: back-to-back socket.write + socket.end() delivers every chunk",
+  async () => {
+    // Regression: the async-generator request body delivers one chunk per
+    // `resolveNextChunk` wake. Back-to-back synchronous writes followed by
+    // `socket.end()` on the hijacked Duplex — an idiomatic net.Socket
+    // pattern — used to leave later chunks stranded in `kBodyChunks`:
+    // `_final()` → `kEndUpgradeBody()` flipped the exit flag before the
+    // generator could re-park, so the loop exited after yielding only the
+    // first chunk and the rest were silently dropped from the wire.
+    const { socketPath, close } = await spawnEchoUpgradeServer();
+    try {
+      const req = http.request({
+        socketPath,
+        method: "GET",
+        path: "/",
+        headers: { Connection: "Upgrade", Upgrade: "echo" },
+      });
+
+      const { promise: upgradePromise, resolve, reject } = Promise.withResolvers<{
+        socket: import("node:stream").Duplex;
+      }>();
+      req.on("upgrade", (_res, socket) => resolve({ socket }));
+      req.on("error", reject);
+      req.end();
+
+      const { socket } = await upgradePromise;
+
+      // Collect echoed bytes until we see the full concatenated payload.
+      const expected = "AAA" + "BBB" + "CCC";
+      const chunks: Buffer[] = [];
+      const got = new Promise<void>((res2, rej2) => {
+        socket.on("data", (c: Buffer) => {
+          chunks.push(c);
+          if (Buffer.concat(chunks).toString("utf8").endsWith(expected)) res2();
+        });
+        socket.on("error", rej2);
+      });
+
+      // Three back-to-back synchronous writes + end. Under the bug,
+      // the server echoes only the first chunk ("AAA") and the test
+      // hangs waiting for the full string.
+      socket.write("AAA");
+      socket.write("BBB");
+      socket.end("CCC");
+
+      await got;
+      expect(Buffer.concat(chunks).toString("utf8").endsWith(expected)).toBe(true);
+
+      socket.destroy();
+    } finally {
+      close();
+    }
+  },
+);


### PR DESCRIPTION
Fixes #29012

## Reproduction

\`dockerode\`'s \`exec.start({ hijack: true, stdin: true })\` hangs under Bun because \`http.ClientRequest\` never fires the \`'upgrade'\` event when the server answers \`HTTP/1.1 101 Switching Protocols\` on a request that was opened with \`req.flushHeaders(); req.write(body)\` (without \`req.end()\`).

dockerode's pattern:

\`\`\`js
const req = http.request({
  socketPath: "/var/run/docker.sock",
  method: "POST",
  path: "/exec/\${id}/start",
  headers: {
    "Content-Type": "application/json",
    "Connection": "Upgrade",
    "Upgrade": "tcp",
    "Transfer-Encoding": "chunked",
  },
});
req.on("upgrade", (res, sock, head) => { /* hijacked socket */ });
req.flushHeaders();
req.write('{"Detach":false,"Tty":false}');
// req.end() is NOT called — openStdin keeps the upload half open.
\`\`\`

Node fires \`'upgrade'\` immediately after the 101; Bun silently dropped it.

## Root cause

Three layers were missing:

1. **\`FetchTasklet.skipChunkedFraming()\`** unconditionally skipped HTTP/1.1 chunked framing for any request that carried an \`Upgrade:\` header, even when the user had explicitly set \`Transfer-Encoding: chunked\`. The body was written as raw bytes while the headers still advertised chunked, so the server's chunked parser got garbage.

2. **\`HTTPClient.writeToStream()\`** refused to drain the streaming request-body buffer while \`upgrade_state == .pending\`. The buffered chunked body could never reach the server, and the server in turn would never send 101 — a deadlock. The original check was intended to hold back post-upgrade raw bytes for WebSocket-style handshakes.

3. **\`_http_client.ts\` \`ClientRequest\`** never turned a 101 fetch response into an \`'upgrade'\` event. With \`isDuplex: true\` (streaming body), it only called \`handleResponse()\` once the body generator finished — which never happens when the caller deliberately leaves the upload half open.

## Fix

- \`FetchTasklet.skipChunkedFraming\` honors an explicit \`Transfer-Encoding: chunked\` and returns \`false\`, matching Node.
- \`HTTPClient.writeToStream\` drains the buffer in the pending-upgrade state as long as the request has explicit framing (Transfer-Encoding or Content-Length). Requests with no framing (WebSocket-style) still buffer until 101 arrives.
- \`ClientRequest\` detects \`response.status === 101\`, builds a \`Duplex\` socket that reads from the fetch Response body (post-upgrade bytes) and routes writes back through \`req.write\`, and emits \`'upgrade'\` on \`process.nextTick\`. If no handler is attached, the hijacked socket is destroyed.

## Verification

New test: \`test/regression/issue/29012.test.ts\` reproduces the dockerode flow with a Unix-socket server that speaks the same chunked-body → 101 → Docker stream framing sequence. The test hangs (5s timeout) on a binary built without the fix and passes with it; it also verifies the hijacked socket delivers the framed payload.

\`\`\`
$ bun bd test test/regression/issue/29012.test.ts
(pass) http.request emits 'upgrade' on 101 without req.end() [1263ms]
(pass) http.request 'upgrade' delivers hijacked socket with writable Duplex [218ms]

 2 pass
 0 fail
 10 expect() calls
\`\`\`