### PR TITLE
fix(node:fs): validate readSync position when length is 0

### DIFF
--- a/src/runtime/node/node_fs.zig
+++ b/src/runtime/node/node_fs.zig
@@ -2599,47 +2599,55 @@ pub const Arguments = struct {
             else
                 0;
 
-            // The `length === 0` short-circuit must not skip the `position`
-            // type check below — bun is stricter than Node here on purpose
-            // (see https://github.com/nodejs/node/issues/62638). We still
-            // need to validate `length` and `position` even when no bytes
-            // will be read.
-            var length_int: i64 = 0;
-            var length: u64 = 0;
-            if (length_float != 0) {
-                const buf_len = buffer.slice().len;
-                if (buf_len == 0) {
-                    return ctx.ERR(.INVALID_ARG_VALUE, "The argument 'buffer' is empty and cannot be written.", .{}).throw();
-                }
-                // validateOffsetLengthRead(offset, length, buffer.byteLength);
-                if (@mod(length_float, 1) != 0) {
-                    return ctx.throwRangeError(length_float, .{ .field_name = "length", .msg = "an integer" });
-                }
-                length_int = @intFromFloat(length_float);
-                if (length_int > buf_len) {
-                    return ctx.throwRangeError(
-                        length_float,
-                        .{ .field_name = "length", .max = @intCast(@min(buf_len, std.math.maxInt(i64))) },
-                    );
-                }
-                if (@as(i64, @intCast(offset)) +| length_int > buf_len) {
-                    return ctx.throwRangeError(
-                        length_float,
-                        .{ .field_name = "length", .max = @intCast(buf_len -| offset) },
-                    );
-                }
-                if (length_int < 0) {
-                    return ctx.throwRangeError(length_float, .{ .field_name = "length", .min = 0 });
-                }
-                length = @intCast(length_int);
+            // Peek the position argument so we can validate it even when
+            // `length == 0` short-circuits below. See
+            // https://github.com/oven-sh/bun/issues/29016 — bun used to
+            // skip this type check whenever no bytes would be read.
+            const position_value: jsc.JSValue = arguments.nextEat() orelse .null;
+            if (!position_value.isUndefinedOrNull() and !position_value.isNumber() and jsc.JSBigInt.fromJS(position_value) == null) {
+                return ctx.throwInvalidArgumentTypeValue("position", "number or bigint", position_value);
             }
+
+            //   if (length === 0) {
+            //     return process.nextTick(function tick() {
+            //       callback(null, 0, buffer);
+            //     });
+            //   }
+            if (length_float == 0) {
+                return .{ .fd = fd, .buffer = buffer, .length = 0, .offset = 0 };
+            }
+
+            const buf_len = buffer.slice().len;
+            if (buf_len == 0) {
+                return ctx.ERR(.INVALID_ARG_VALUE, "The argument 'buffer' is empty and cannot be written.", .{}).throw();
+            }
+            // validateOffsetLengthRead(offset, length, buffer.byteLength);
+            if (@mod(length_float, 1) != 0) {
+                return ctx.throwRangeError(length_float, .{ .field_name = "length", .msg = "an integer" });
+            }
+            const length_int: i64 = @intFromFloat(length_float);
+            if (length_int > buf_len) {
+                return ctx.throwRangeError(
+                    length_float,
+                    .{ .field_name = "length", .max = @intCast(@min(buf_len, std.math.maxInt(i64))) },
+                );
+            }
+            if (@as(i64, @intCast(offset)) +| length_int > buf_len) {
+                return ctx.throwRangeError(
+                    length_float,
+                    .{ .field_name = "length", .max = @intCast(buf_len -| offset) },
+                );
+            }
+            if (length_int < 0) {
+                return ctx.throwRangeError(length_float, .{ .field_name = "length", .min = 0 });
+            }
+            const length: u64 = @intCast(length_int);
 
             // if (position == null) {
             //   position = -1;
             // } else {
             //   validatePosition(position, 'position', length);
             // }
-            const position_value: jsc.JSValue = arguments.nextEat() orelse .null;
             const position_int: i64 = if (position_value.isUndefinedOrNull())
                 -1
             else if (position_value.isNumber())

--- a/src/runtime/node/node_fs.zig
+++ b/src/runtime/node/node_fs.zig
@@ -2599,40 +2599,40 @@ pub const Arguments = struct {
             else
                 0;
 
-            //   if (length === 0) {
-            //     return process.nextTick(function tick() {
-            //       callback(null, 0, buffer);
-            //     });
-            //   }
-            if (length_float == 0) {
-                return .{ .fd = fd, .buffer = buffer, .length = 0, .offset = 0 };
+            // The `length === 0` short-circuit must not skip the `position`
+            // type check below — bun is stricter than Node here on purpose
+            // (see https://github.com/nodejs/node/issues/62638). We still
+            // need to validate `length` and `position` even when no bytes
+            // will be read.
+            var length_int: i64 = 0;
+            var length: u64 = 0;
+            if (length_float != 0) {
+                const buf_len = buffer.slice().len;
+                if (buf_len == 0) {
+                    return ctx.ERR(.INVALID_ARG_VALUE, "The argument 'buffer' is empty and cannot be written.", .{}).throw();
+                }
+                // validateOffsetLengthRead(offset, length, buffer.byteLength);
+                if (@mod(length_float, 1) != 0) {
+                    return ctx.throwRangeError(length_float, .{ .field_name = "length", .msg = "an integer" });
+                }
+                length_int = @intFromFloat(length_float);
+                if (length_int > buf_len) {
+                    return ctx.throwRangeError(
+                        length_float,
+                        .{ .field_name = "length", .max = @intCast(@min(buf_len, std.math.maxInt(i64))) },
+                    );
+                }
+                if (@as(i64, @intCast(offset)) +| length_int > buf_len) {
+                    return ctx.throwRangeError(
+                        length_float,
+                        .{ .field_name = "length", .max = @intCast(buf_len -| offset) },
+                    );
+                }
+                if (length_int < 0) {
+                    return ctx.throwRangeError(length_float, .{ .field_name = "length", .min = 0 });
+                }
+                length = @intCast(length_int);
             }
-
-            const buf_len = buffer.slice().len;
-            if (buf_len == 0) {
-                return ctx.ERR(.INVALID_ARG_VALUE, "The argument 'buffer' is empty and cannot be written.", .{}).throw();
-            }
-            // validateOffsetLengthRead(offset, length, buffer.byteLength);
-            if (@mod(length_float, 1) != 0) {
-                return ctx.throwRangeError(length_float, .{ .field_name = "length", .msg = "an integer" });
-            }
-            const length_int: i64 = @intFromFloat(length_float);
-            if (length_int > buf_len) {
-                return ctx.throwRangeError(
-                    length_float,
-                    .{ .field_name = "length", .max = @intCast(@min(buf_len, std.math.maxInt(i64))) },
-                );
-            }
-            if (@as(i64, @intCast(offset)) +| length_int > buf_len) {
-                return ctx.throwRangeError(
-                    length_float,
-                    .{ .field_name = "length", .max = @intCast(buf_len -| offset) },
-                );
-            }
-            if (length_int < 0) {
-                return ctx.throwRangeError(length_float, .{ .field_name = "length", .min = 0 });
-            }
-            const length: u64 = @intCast(length_int);
 
             // if (position == null) {
             //   position = -1;

--- a/test/regression/issue/29016.test.ts
+++ b/test/regression/issue/29016.test.ts
@@ -1,8 +1,4 @@
 // https://github.com/oven-sh/bun/issues/29016
-//
-// `fs.readSync` (and `fs.read`) used to skip `position` type validation
-// when the `length` argument was 0, because `Arguments.Read.fromJS`
-// short-circuited on `length === 0` before reaching the position check.
 import { describe, expect, test } from "bun:test";
 import { tempDirWithFiles } from "harness";
 import fs from "node:fs";
@@ -13,7 +9,7 @@ function openEmptyTempFile() {
   return fs.openSync(path.join(dir, "tempfile"), "r+");
 }
 
-describe("fs.readSync position validation (issue #29016)", () => {
+describe.concurrent("fs.readSync position validation (issue #29016)", () => {
   test("throws TypeError on object position with zero-length buffer", () => {
     const fd = openEmptyTempFile();
     try {
@@ -90,7 +86,7 @@ describe("fs.readSync position validation (issue #29016)", () => {
   });
 });
 
-describe("fs.read position validation (issue #29016)", () => {
+describe.concurrent("fs.read position validation (issue #29016)", () => {
   test("rejects object position with zero-length buffer (callback form)", async () => {
     const fd = openEmptyTempFile();
     try {
@@ -98,7 +94,8 @@ describe("fs.read position validation (issue #29016)", () => {
       await new Promise<void>((resolve, reject) => {
         try {
           fs.read(fd, empty, 0, empty.length, { not: "a number" } as any, err => {
-            if (err) resolve();
+            if (err?.code === "ERR_INVALID_ARG_TYPE") resolve();
+            else if (err) reject(err);
             else reject(new Error("expected fs.read to error out"));
           });
         } catch (err: any) {

--- a/test/regression/issue/29016.test.ts
+++ b/test/regression/issue/29016.test.ts
@@ -4,9 +4,9 @@
 // when the `length` argument was 0, because `Arguments.Read.fromJS`
 // short-circuited on `length === 0` before reaching the position check.
 import { describe, expect, test } from "bun:test";
+import { tempDirWithFiles } from "harness";
 import fs from "node:fs";
 import path from "node:path";
-import { tempDirWithFiles } from "harness";
 
 function openEmptyTempFile() {
   const dir = tempDirWithFiles("issue-29016", { tempfile: "" });

--- a/test/regression/issue/29016.test.ts
+++ b/test/regression/issue/29016.test.ts
@@ -91,19 +91,19 @@ describe.concurrent("fs.read position validation (issue #29016)", () => {
     const fd = openEmptyTempFile();
     try {
       const empty = new Uint8Array(0);
-      await new Promise<void>((resolve, reject) => {
-        try {
-          fs.read(fd, empty, 0, empty.length, { not: "a number" } as any, err => {
-            if (err?.code === "ERR_INVALID_ARG_TYPE") resolve();
-            else if (err) reject(err);
-            else reject(new Error("expected fs.read to error out"));
-          });
-        } catch (err: any) {
-          // Synchronously-thrown TypeError is also acceptable.
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      try {
+        fs.read(fd, empty, 0, empty.length, { not: "a number" } as any, err => {
           if (err?.code === "ERR_INVALID_ARG_TYPE") resolve();
-          else reject(err);
-        }
-      });
+          else if (err) reject(err);
+          else reject(new Error("expected fs.read to error out"));
+        });
+      } catch (err: any) {
+        // Synchronously-thrown TypeError is also acceptable.
+        if (err?.code === "ERR_INVALID_ARG_TYPE") resolve();
+        else reject(err);
+      }
+      await promise;
     } finally {
       fs.closeSync(fd);
     }

--- a/test/regression/issue/29016.test.ts
+++ b/test/regression/issue/29016.test.ts
@@ -1,0 +1,114 @@
+// https://github.com/oven-sh/bun/issues/29016
+//
+// `fs.readSync` (and `fs.read`) used to skip `position` type validation
+// when the `length` argument was 0, because `Arguments.Read.fromJS`
+// short-circuited on `length === 0` before reaching the position check.
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { tempDirWithFiles } from "harness";
+
+function openEmptyTempFile() {
+  const dir = tempDirWithFiles("issue-29016", { tempfile: "" });
+  return fs.openSync(path.join(dir, "tempfile"), "r+");
+}
+
+describe("fs.readSync position validation (issue #29016)", () => {
+  test("throws TypeError on object position with zero-length buffer", () => {
+    const fd = openEmptyTempFile();
+    try {
+      const empty = new Uint8Array(0);
+      expect(() => fs.readSync(fd, empty, 0, empty.length, { not: "a number" } as any)).toThrow(
+        expect.objectContaining({
+          name: "TypeError",
+          code: "ERR_INVALID_ARG_TYPE",
+        }),
+      );
+    } finally {
+      fs.closeSync(fd);
+    }
+  });
+
+  test("throws TypeError on object position with non-zero-length buffer", () => {
+    const fd = openEmptyTempFile();
+    try {
+      const buf = new Uint8Array(5);
+      expect(() => fs.readSync(fd, buf, 0, buf.length, { not: "a number" } as any)).toThrow(
+        expect.objectContaining({
+          name: "TypeError",
+          code: "ERR_INVALID_ARG_TYPE",
+        }),
+      );
+    } finally {
+      fs.closeSync(fd);
+    }
+  });
+
+  test("throws TypeError on string position with zero-length buffer", () => {
+    const fd = openEmptyTempFile();
+    try {
+      const empty = new Uint8Array(0);
+      expect(() => fs.readSync(fd, empty, 0, empty.length, "nope" as any)).toThrow(
+        expect.objectContaining({
+          name: "TypeError",
+          code: "ERR_INVALID_ARG_TYPE",
+        }),
+      );
+    } finally {
+      fs.closeSync(fd);
+    }
+  });
+
+  test("accepts null position with zero-length buffer", () => {
+    const fd = openEmptyTempFile();
+    try {
+      const empty = new Uint8Array(0);
+      expect(fs.readSync(fd, empty, 0, empty.length, null)).toBe(0);
+    } finally {
+      fs.closeSync(fd);
+    }
+  });
+
+  test("accepts integer position with zero-length buffer", () => {
+    const fd = openEmptyTempFile();
+    try {
+      const empty = new Uint8Array(0);
+      expect(fs.readSync(fd, empty, 0, empty.length, 0)).toBe(0);
+    } finally {
+      fs.closeSync(fd);
+    }
+  });
+
+  test("accepts bigint position with zero-length buffer", () => {
+    const fd = openEmptyTempFile();
+    try {
+      const empty = new Uint8Array(0);
+      expect(fs.readSync(fd, empty, 0, empty.length, 0n)).toBe(0);
+    } finally {
+      fs.closeSync(fd);
+    }
+  });
+});
+
+describe("fs.read position validation (issue #29016)", () => {
+  test("rejects object position with zero-length buffer (callback form)", async () => {
+    const fd = openEmptyTempFile();
+    try {
+      const empty = new Uint8Array(0);
+      await new Promise<void>((resolve, reject) => {
+        try {
+          fs.read(fd, empty, 0, empty.length, { not: "a number" } as any, err => {
+            if (err) resolve();
+            else reject(new Error("expected fs.read to error out"));
+          });
+        } catch (err: any) {
+          // Synchronously-thrown TypeError is also acceptable.
+          if (err?.code === "ERR_INVALID_ARG_TYPE") resolve();
+          else reject(err);
+        }
+      });
+    } finally {
+      fs.closeSync(fd);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`fs.readSync` (and `fs.read`) silently accepted an invalid `position` argument whenever the read `length` was zero.

### Reproduction

```js
import fs from 'node:fs';
import os from 'node:os';
import path from 'node:path';

const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repro-'));
const file = path.join(dir, 'tempfile');
fs.writeFileSync(file, '');
const fd = fs.openSync(file, 'r+');

const empty = new TextEncoder().encode('');
try {
  fs.readSync(fd, empty, 0, empty.length, { not: 'a number' });
  console.log('did not throw'); // bun before the fix
} catch (err) {
  console.log(err.name, '-', err.message);
}
fs.closeSync(fd);
```

Before: `did not throw`
After: `TypeError - The "position" argument must be of type number or bigint. Received an instance of Object`

### Root cause

`Arguments.Read.fromJS` in `src/bun.js/node/node_fs.zig` parsed `length` before `position` and returned early when `length == 0`:

```zig
if (length_float == 0) {
    return .{ .fd = fd, .buffer = buffer, .length = 0, .offset = 0 };
}
// ... position parsing and validation lived below this short-circuit
```

Because the early return ran before the position block, an invalid `position` (non-number, non-bigint, non-null) slipped through whenever the read length was zero. With a non-zero length the validation already threw correctly.

### Fix

Gate the length bounds checks behind `length_float != 0` but let the position parsing/validation block run unconditionally. The early-return path now still validates `position`, and the returned `length` is `0` in that case. Behaviour for non-zero lengths is unchanged.

### Verification

```
bun bd test test/regression/issue/29016.test.ts      → 7 pass, 0 fail
USE_SYSTEM_BUN=1 bun test test/regression/issue/29016.test.ts → 4 pass, 3 fail (bug)
```

Fixes #29016