### PR TITLE
fs: fix Stats() slot scramble and instanceof Stats returning false

### DIFF
--- a/src/bun.js/bindings/NodeFSStatBinding.cpp
+++ b/src/bun.js/bindings/NodeFSStatBinding.cpp
@@ -784,14 +784,14 @@ inline JSValue callJSStatsFunction(JSC::JSGlobalObject* globalObject, JSC::CallF
     auto* object = JSC::JSFinalObject::create(vm, structure);
 
     object->putDirectOffset(vm, 0, dev);
-    object->putDirectOffset(vm, 1, mode);
-    object->putDirectOffset(vm, 2, nlink);
-    object->putDirectOffset(vm, 3, uid);
-    object->putDirectOffset(vm, 4, gid);
-    object->putDirectOffset(vm, 5, rdev);
-    object->putDirectOffset(vm, 6, blksize);
-    object->putDirectOffset(vm, 7, ino);
-    object->putDirectOffset(vm, 8, size);
+    object->putDirectOffset(vm, 1, ino);
+    object->putDirectOffset(vm, 2, mode);
+    object->putDirectOffset(vm, 3, nlink);
+    object->putDirectOffset(vm, 4, uid);
+    object->putDirectOffset(vm, 5, gid);
+    object->putDirectOffset(vm, 6, rdev);
+    object->putDirectOffset(vm, 7, size);
+    object->putDirectOffset(vm, 8, blksize);
     object->putDirectOffset(vm, 9, blocks);
 
     object->putDirectOffset(vm, static_cast<unsigned>(DateFieldType::atime), atimeMs);

--- a/src/bun.js/bindings/NodeFSStatBinding.cpp
+++ b/src/bun.js/bindings/NodeFSStatBinding.cpp
@@ -532,9 +532,8 @@ private:
     }
 };
 
-JSC::Structure* createJSStatsObjectStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+JSC::Structure* createJSStatsObjectStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSObject* prototype)
 {
-    auto* prototype = JSStatsPrototype::create(vm, globalObject, JSStatsPrototype::createStructure(vm, globalObject, globalObject->objectPrototype()));
     auto structure = JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::FinalObjectType, 0), JSFinalObject::info(), NonArray,
         14);
 
@@ -562,9 +561,8 @@ JSC::Structure* createJSStatsObjectStructure(JSC::VM& vm, JSC::JSGlobalObject* g
     return structure;
 }
 
-JSC::Structure* createJSBigIntStatsObjectStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+JSC::Structure* createJSBigIntStatsObjectStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSObject* prototype)
 {
-    auto prototype = JSBigIntStatsPrototype::create(vm, globalObject, JSBigIntStatsPrototype::createStructure(vm, globalObject, globalObject->objectPrototype()));
     auto structure = JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::FinalObjectType, 0), JSFinalObject::info(), NonArray,
         18);
 
@@ -925,7 +923,7 @@ extern "C" JSC::EncodedJSValue Bun__JSStatsObjectConstructor(Zig::GlobalObject* 
 void initJSStatsClassStructure(JSC::LazyClassStructure::Initializer& init)
 {
     auto* prototype = JSStatsPrototype::create(init.vm, init.global, JSStatsPrototype::createStructure(init.vm, init.global, init.global->objectPrototype()));
-    auto* structure = createJSStatsObjectStructure(init.vm, init.global);
+    auto* structure = createJSStatsObjectStructure(init.vm, init.global, prototype);
     auto* constructor = JSStatsConstructor::create(init.vm, JSStatsConstructor::createStructure(init.vm, init.global, init.global->functionPrototype()), prototype);
     init.setPrototype(prototype);
     init.setStructure(structure);
@@ -935,7 +933,7 @@ void initJSStatsClassStructure(JSC::LazyClassStructure::Initializer& init)
 void initJSBigIntStatsClassStructure(JSC::LazyClassStructure::Initializer& init)
 {
     auto* prototype = JSBigIntStatsPrototype::create(init.vm, init.global, JSBigIntStatsPrototype::createStructure(init.vm, init.global, init.global->objectPrototype()));
-    auto* structure = createJSBigIntStatsObjectStructure(init.vm, init.global);
+    auto* structure = createJSBigIntStatsObjectStructure(init.vm, init.global, prototype);
     auto* constructor = JSBigIntStatsConstructor::create(init.vm, JSBigIntStatsConstructor::createStructure(init.vm, init.global, init.global->functionPrototype()), prototype);
     init.setPrototype(prototype);
     init.setStructure(structure);

--- a/test/js/node/fs/fs-stats-constructor.test.ts
+++ b/test/js/node/fs/fs-stats-constructor.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+import { Stats } from "node:fs";
+
+// Node.js's Stats constructor signature (deprecated, DEP0180):
+//   Stats(dev, mode, nlink, uid, gid, rdev, blksize, ino, size, blocks, atimeMs, mtimeMs, ctimeMs, birthtimeMs)
+const args = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+const expected = {
+  dev: 0,
+  mode: 1,
+  nlink: 2,
+  uid: 3,
+  gid: 4,
+  rdev: 5,
+  blksize: 6,
+  ino: 7,
+  size: 8,
+  blocks: 9,
+  atimeMs: 10,
+  mtimeMs: 11,
+  ctimeMs: 12,
+  birthtimeMs: 13,
+};
+
+test("new Stats(...) assigns fields in Node's order", () => {
+  // @ts-expect-error DEP0180
+  expect({ ...new Stats(...args) }).toMatchObject(expected);
+});
+
+test("Stats(...) without new assigns fields in Node's order", () => {
+  // Regression: callJSStatsFunction used to write putDirectOffset slots in
+  // argument order, but the structure's slot layout differs, so .ino returned
+  // the mode argument etc.
+  // @ts-expect-error DEP0180
+  expect({ ...Stats(...args) }).toMatchObject(expected);
+});

--- a/test/js/node/fs/fs-stats-constructor.test.ts
+++ b/test/js/node/fs/fs-stats-constructor.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { Stats } from "node:fs";
+import { Stats, statSync } from "node:fs";
 
 // Node.js's Stats constructor signature (deprecated, DEP0180):
 //   Stats(dev, mode, nlink, uid, gid, rdev, blksize, ino, size, blocks, atimeMs, mtimeMs, ctimeMs, birthtimeMs)
@@ -32,4 +32,25 @@ test("Stats(...) without new assigns fields in Node's order", () => {
   // the mode argument etc.
   // @ts-expect-error DEP0180
   expect({ ...Stats(...args) }).toMatchObject(expected);
+});
+
+test("Stats instances share Stats.prototype", () => {
+  // Regression: initJSStatsClassStructure created two JSStatsPrototype objects,
+  // so Object.getPrototypeOf(instance) !== Stats.prototype and instanceof failed.
+  const fromSync = statSync(import.meta.path);
+  // @ts-expect-error DEP0180
+  const fromNew = new Stats(...args);
+  // @ts-expect-error DEP0180
+  const fromCall = Stats(...args);
+
+  expect(fromSync instanceof Stats).toBe(true);
+  expect(fromNew instanceof Stats).toBe(true);
+  expect(fromCall instanceof Stats).toBe(true);
+  expect(Object.getPrototypeOf(fromSync)).toBe(Stats.prototype);
+  expect(Object.getPrototypeOf(fromNew)).toBe(Stats.prototype);
+  expect(Object.getPrototypeOf(fromCall)).toBe(Stats.prototype);
+
+  const bigint = statSync(import.meta.path, { bigint: true });
+  expect(Object.getPrototypeOf(bigint).constructor.name).toBe("BigIntStats");
+  expect(bigint instanceof Object.getPrototypeOf(bigint).constructor).toBe(true);
 });


### PR DESCRIPTION
Two pre-existing `fs.Stats` constructor bugs in `NodeFSStatBinding.cpp`, both found by the review bot on #28989 (no overlap with that diff).

## 1. `Stats(...)` without `new` scrambles fields

`callJSStatsFunction` wrote `putDirectOffset` slots 0–9 in Node's constructor-argument order (`dev, mode, nlink, uid, gid, rdev, blksize, ino, size, blocks`), but the structure's slot layout (`createJSStatsObjectStructure`) is `dev, ino, mode, nlink, uid, gid, rdev, size, blksize, blocks` — so 8 of 10 integer fields landed under the wrong property:

```js
const s = require("fs").Stats(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
s.ino   // 1 (the "mode" argument)
s.size  // 7 (the "ino" argument)
```

`new Stats(...)` was already correct (uses `putDirect` by name), as was `fs.statSync` (`Bun__createJSStatsObject` uses the right offsets). Fix: reorder the ten `putDirectOffset` calls to match the structure.

## 2. `statSync(p) instanceof Stats` returns `false`

`initJSStatsClassStructure` created one `JSStatsPrototype` for `Stats.prototype` / the constructor, and `createJSStatsObjectStructure` created a **second** one baked into the instance structure. So every instance's `[[Prototype]]` was a different object than `Stats.prototype`:

```js
statSync(".") instanceof Stats                       // bun: false, node: true
Object.getPrototypeOf(statSync(".")) === Stats.prototype  // bun: false, node: true
```

Methods like `.isFile()` still worked because both prototypes were real `JSStatsPrototype` instances — just not the same one. Same issue for `BigIntStats`. Fix: `createJS{,BigInt}StatsObjectStructure` now take the prototype as a parameter instead of creating their own.

## Tests

`test/js/node/fs/fs-stats-constructor.test.ts` covers both: field ordering for `new Stats(...)` and `Stats(...)`, and `instanceof` / prototype identity for `statSync`, `new Stats`, `Stats()`, and `statSync({bigint:true})`. All fail on released bun, pass on this branch.