### PR TITLE
worker_threads: give MessagePort node's EventEmitter surface

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -106,13 +106,22 @@ function injectFakeEmitter(Class) {
     return this;
   };
 
+  function removeAny(target, event, listener) {
+    const wrapper = existingWrapperFor(event, listener);
+    target.removeEventListener(event, wrapper);
+    // A listener registered raw via addEventListener has no cached wrapper, but
+    // a stale cache entry from an earlier on() would shadow it, so also remove
+    // the listener itself (a no-op when it isn't registered).
+    if (wrapper !== listener) target.removeEventListener(event, listener);
+  }
+
   Class.prototype.off = function off(event, listener) {
-    this.removeEventListener(event, existingWrapperFor(event, listener));
+    removeAny(this, event, listener);
     return this;
   };
 
   Class.prototype.removeListener = function removeListener(event, listener) {
-    this.removeEventListener(event, existingWrapperFor(event, listener));
+    removeAny(this, event, listener);
     return this;
   };
 

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -79,8 +79,12 @@ function injectFakeEmitter(Class) {
     let wrapper = byEvent.$get(event);
     if (wrapper === undefined) {
       const unwrap = event === "error" || event === "messageerror" ? errorEventHandler : messageEventHandler;
+      // Node's NodeEventTarget binds `this` to the target for emitter-style
+      // listeners; the wrapper is dispatched with `this` === the port, so
+      // forward it so `port.on('message', function () { this.postMessage(...) })`
+      // works like it does in node.
       wrapper = function (e) {
-        return listener(unwrap(e));
+        return listener.$call(this, unwrap(e));
       };
       byEvent.$set(event, wrapper);
     }
@@ -495,7 +499,17 @@ function fakeParentPort() {
 
   Object.defineProperty(fake, "removeAllListeners", {
     value(event) {
-      eventTargetRemoveAllListeners(self, event);
+      if (event === undefined) {
+        // This port is a facade over the worker's global scope, which can also
+        // hold the user's own error / unhandledrejection / message handlers.
+        // A no-arg clear must only drop the events a MessagePort delivers, not
+        // wipe every listener on `self`.
+        eventTargetRemoveAllListeners(self, "message");
+        eventTargetRemoveAllListeners(self, "messageerror");
+        eventTargetRemoveAllListeners(self, "close");
+      } else {
+        eventTargetRemoveAllListeners(self, event);
+      }
       return this;
     },
     enumerable: false,

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -6,6 +6,17 @@ type WebWorker = InstanceType<typeof globalThis.Worker>;
 const EventEmitter = require("node:events");
 const Readable = require("internal/streams/readable");
 const { throwNotImplemented, warnNotImplementedOnce } = require("internal/shared");
+const { SafeWeakMap } = require("internal/primordials");
+const { validateNumber } = require("internal/validators");
+
+const { kMaxEventTargetListeners, kMaxEventTargetListenersWarned } = EventEmitter;
+
+// Introspection of an EventTarget's listener map, used to back node's
+// EventEmitter methods on MessagePort. Each accepts the target as the first
+// argument, and returns undefined/false when it is not an EventTarget.
+const eventTargetListenerCount = $newCppFunction("JSEventTarget.cpp", "jsEventTargetGetEventListenersCount", 2);
+const eventTargetEventNames = $newCppFunction("JSEventTarget.cpp", "jsEventTargetGetEventNames", 1);
+const eventTargetRemoveAllListeners = $newCppFunction("JSEventTarget.cpp", "jsEventTargetRemoveAllEventListeners", 2);
 
 const {
   MessageChannel,
@@ -38,6 +49,10 @@ type NodeWorkerOptions = import("node:worker_threads").WorkerOptions;
 // after their Worker exits
 let urlRevokeRegistry: FinalizationRegistry<string> | undefined = undefined;
 
+// node's MessagePort is an EventEmitter/EventTarget hybrid: its prototype chain
+// runs through NodeEventTarget, which layers the emitter methods on top of the
+// EventTarget listener map. Bun's MessagePort is a plain EventTarget, so mix the
+// same methods in here, backed by that same listener map.
 function injectFakeEmitter(Class) {
   function messageEventHandler(event: MessageEvent) {
     return event.data;
@@ -47,65 +62,98 @@ function injectFakeEmitter(Class) {
     return event.error;
   }
 
-  const wrappedListener = Symbol("wrappedListener");
+  // An emitter listener receives the event's payload, not the event, so it has
+  // to be registered through a wrapper. Keep one wrapper per (listener, event)
+  // pair so addEventListener still dedupes, and off() finds the right wrapper.
+  const wrappers = new SafeWeakMap();
 
-  function wrapped(run, listener) {
-    const callback = function (event) {
-      return listener(run(event));
-    };
-    listener[wrappedListener] = callback;
-    return callback;
-  }
+  function wrapperFor(event, listener) {
+    if (!$isCallable(listener)) return listener;
 
-  function functionForEventType(event, listener) {
-    switch (event) {
-      case "error":
-      case "messageerror": {
-        return wrapped(errorEventHandler, listener);
-      }
-
-      default: {
-        return wrapped(messageEventHandler, listener);
-      }
+    let byEvent = wrappers.get(listener);
+    if (byEvent === undefined) {
+      byEvent = new Map();
+      wrappers.set(listener, byEvent);
     }
+
+    let wrapper = byEvent.$get(event);
+    if (wrapper === undefined) {
+      const unwrap = event === "error" || event === "messageerror" ? errorEventHandler : messageEventHandler;
+      wrapper = function (e) {
+        return listener(unwrap(e));
+      };
+      byEvent.$set(event, wrapper);
+    }
+    return wrapper;
   }
 
-  Class.prototype.on = function (event, listener) {
-    this.addEventListener(event, functionForEventType(event, listener));
+  function existingWrapperFor(event, listener) {
+    if (!$isCallable(listener)) return listener;
+    return wrappers.get(listener)?.$get(event) ?? listener;
+  }
 
+  Class.prototype.on = function on(event, listener) {
+    this.addEventListener(event, wrapperFor(event, listener));
     return this;
   };
 
-  Class.prototype.off = function (event, listener) {
-    if (listener) {
-      this.removeEventListener(event, listener[wrappedListener] || listener);
-    } else {
-      this.removeEventListener(event);
-    }
-
+  Class.prototype.addListener = function addListener(event, listener) {
+    this.addEventListener(event, wrapperFor(event, listener));
     return this;
   };
 
-  Class.prototype.once = function (event, listener) {
-    this.addEventListener(event, functionForEventType(event, listener), {
+  Class.prototype.off = function off(event, listener) {
+    this.removeEventListener(event, existingWrapperFor(event, listener));
+    return this;
+  };
+
+  Class.prototype.removeListener = function removeListener(event, listener) {
+    this.removeEventListener(event, existingWrapperFor(event, listener));
+    return this;
+  };
+
+  Class.prototype.once = function once(event, listener) {
+    this.addEventListener(event, wrapperFor(event, listener), {
       once: true,
     });
 
     return this;
   };
 
-  function EventClass(eventName) {
-    if (eventName === "error" || eventName === "messageerror") {
-      return ErrorEvent;
-    }
-
-    return MessageEvent;
-  }
-
-  Class.prototype.emit = function (event, ...args) {
-    this.dispatchEvent(new (EventClass(event))(event, ...args));
-
+  Class.prototype.removeAllListeners = function removeAllListeners(event) {
+    eventTargetRemoveAllListeners(this, event);
     return this;
+  };
+
+  Class.prototype.listenerCount = function listenerCount(event) {
+    return eventTargetListenerCount(this, event) ?? 0;
+  };
+
+  Class.prototype.eventNames = function eventNames() {
+    return eventTargetEventNames(this) ?? [];
+  };
+
+  // Same storage node's EventTarget uses, so events.setMaxListeners(n, port) and
+  // port.setMaxListeners(n) stay in sync. Like node, neither returns the port.
+  Class.prototype.setMaxListeners = function setMaxListeners(n) {
+    validateNumber(n, "setMaxListeners", 0);
+    this[kMaxEventTargetListeners] = n;
+    this[kMaxEventTargetListenersWarned] = false;
+  };
+
+  Class.prototype.getMaxListeners = function getMaxListeners() {
+    this[kMaxEventTargetListeners] ??= EventEmitter.defaultMaxListeners;
+    return this[kMaxEventTargetListeners];
+  };
+
+  Class.prototype.emit = function emit(event, arg) {
+    const hadListeners = this.listenerCount(event) > 0;
+    const e =
+      event === "error" || event === "messageerror"
+        ? new ErrorEvent(event, { error: arg })
+        : new MessageEvent(event, { data: arg });
+    this.dispatchEvent(e);
+    return hadListeners;
   };
 
   Class.prototype.prependListener = Class.prototype.on;
@@ -425,13 +473,31 @@ function fakeParentPort() {
     value: self.removeEventListener.bind(self),
   });
 
-  Object.defineProperty(fake, "removeListener", {
-    value: self.removeEventListener.bind(self),
+  Object.defineProperty(fake, "dispatchEvent", {
+    value: self.dispatchEvent.bind(self),
+  });
+
+  // The worker's global scope is this port's other half, so it owns the listener
+  // map that the inherited emitter methods read from and write to.
+  Object.defineProperty(fake, "listenerCount", {
+    value(event) {
+      return eventTargetListenerCount(self, event) ?? 0;
+    },
     enumerable: false,
   });
 
-  Object.defineProperty(fake, "addListener", {
-    value: self.addEventListener.bind(self),
+  Object.defineProperty(fake, "eventNames", {
+    value() {
+      return eventTargetEventNames(self) ?? [];
+    },
+    enumerable: false,
+  });
+
+  Object.defineProperty(fake, "removeAllListeners", {
+    value(event) {
+      eventTargetRemoveAllListeners(self, event);
+      return this;
+    },
     enumerable: false,
   });
 

--- a/src/jsc/bindings/webcore/JSEventTarget.cpp
+++ b/src/jsc/bindings/webcore/JSEventTarget.cpp
@@ -43,12 +43,17 @@
 #include "JSEvent.h"
 #include "JSEventListener.h"
 #include "JSEventListenerOptions.h"
+#include "RegisteredEventListener.h"
 #include "ScriptExecutionContext.h"
 #include "WebCoreJSClientData.h"
+#include <JavaScriptCore/ArgList.h>
+#include <JavaScriptCore/ExceptionHelpers.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/HeapAnalyzer.h>
+#include <JavaScriptCore/JSArray.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
+#include <JavaScriptCore/JSGlobalObjectInlines.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <variant>
@@ -370,12 +375,60 @@ JSC_DEFINE_HOST_FUNCTION(jsEventTargetGetEventListenersCount, (JSC::JSGlobalObje
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    auto* thisValue = dynamicDowncast<WebCore::JSEventTarget>(callFrame->argument(0));
-    if (!thisValue) return JSC::JSValue::encode(JSC::jsUndefined());
+    auto thisValue = WebCore::jsEventTargetCast(vm, callFrame->argument(0));
+    if (thisValue.isNull()) return JSC::JSValue::encode(JSC::jsUndefined());
     JSC::JSString* eventName = callFrame->argument(1).toString(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(throwScope, {});
     String str = eventName->value(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(throwScope, {});
-    auto size = thisValue->wrapped().eventListeners(makeAtomString(str)).size();
+    auto size = thisValue.wrapped().eventListeners(makeAtomString(str)).size();
     return JSC::JSValue::encode(JSC::jsNumber(size));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsEventTargetGetEventNames, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    auto thisValue = WebCore::jsEventTargetCast(vm, callFrame->argument(0));
+    if (thisValue.isNull()) return JSC::JSValue::encode(JSC::jsUndefined());
+
+    auto eventTypes = thisValue.wrapped().eventTypes();
+    JSC::MarkedArgumentBuffer names;
+    names.ensureCapacity(eventTypes.size());
+    for (auto& eventType : eventTypes)
+        names.append(JSC::jsString(vm, eventType.string()));
+    if (names.hasOverflowed()) [[unlikely]] {
+        JSC::throwOutOfMemoryError(lexicalGlobalObject, throwScope);
+        return {};
+    }
+
+    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(JSC::constructArray(lexicalGlobalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), names)));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsEventTargetRemoveAllEventListeners, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    auto thisValue = WebCore::jsEventTargetCast(vm, callFrame->argument(0));
+    if (thisValue.isNull()) return JSC::JSValue::encode(JSC::jsBoolean(false));
+
+    auto& impl = thisValue.wrapped();
+    JSC::JSValue eventName = callFrame->argument(1);
+    if (eventName.isUndefined()) {
+        impl.removeAllEventListeners();
+        return JSC::JSValue::encode(JSC::jsBoolean(true));
+    }
+
+    String str = eventName.toWTFString(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    auto eventType = makeAtomString(str);
+
+    // removeEventListener() mutates the target's listener vector, so walk a copy of it.
+    WebCore::EventListenerVector listeners = impl.eventListeners(eventType);
+    for (auto& registeredListener : listeners) {
+        if (registeredListener->wasRemoved())
+            continue;
+        impl.removeEventListener(eventType, registeredListener->callback(), WebCore::EventListenerOptions { registeredListener->useCapture() });
+    }
+    return JSC::JSValue::encode(JSC::jsBoolean(true));
 }

--- a/src/jsc/bindings/webcore/JSEventTarget.h
+++ b/src/jsc/bindings/webcore/JSEventTarget.h
@@ -103,5 +103,7 @@ template<> struct JSDOMWrapperConverterTraits<EventTarget> {
 } // namespace WebCore
 
 JSC_DECLARE_HOST_FUNCTION(jsEventTargetGetEventListenersCount);
+JSC_DECLARE_HOST_FUNCTION(jsEventTargetGetEventNames);
+JSC_DECLARE_HOST_FUNCTION(jsEventTargetRemoveAllEventListeners);
 
 #include "JSEventTargetCustom.h"

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -137,7 +137,6 @@ TransferredMessagePort MessagePort::disentangle()
     // this port is still attached to its context; after observeContext(null)
     // there would be nothing to unref.
     removeAllEventListeners();
-    m_hasMessageEventListener = false;
 
     // Release the self-reference taken by jsRef() on the sending side. After
     // transfer this object is inert (the receiving side gets a fresh
@@ -322,6 +321,12 @@ bool MessagePort::removeEventListener(const AtomString& eventType, EventListener
     if (!hasEventListeners(eventNames().messageEvent))
         m_hasMessageEventListener = false;
     return result;
+}
+
+void MessagePort::removeAllEventListeners()
+{
+    EventTarget::removeAllEventListeners();
+    m_hasMessageEventListener = false;
 }
 
 WebCoreOpaqueRoot root(MessagePort* port)

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -114,6 +114,7 @@ private:
 
     bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) final;
     bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions&) final;
+    void removeAllEventListeners() final;
 
     void contextDestroyed() final;
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -866,4 +866,44 @@ describe("MessagePort EventEmitter interface", () => {
       port1.close();
     }
   });
+
+  test("on()/once() bind this to the port, like node's NodeEventTarget", async () => {
+    const { port1, port2 } = new MessageChannel();
+    try {
+      const onThis = Promise.withResolvers();
+      const onceThis = Promise.withResolvers();
+      port1.on("message", function (this: unknown) {
+        onThis.resolve(this);
+      });
+      port1.once("message", function (this: unknown) {
+        onceThis.resolve(this);
+      });
+      port2.postMessage("a");
+      expect(await onThis.promise).toBe(port1);
+      expect(await onceThis.promise).toBe(port1);
+    } finally {
+      port1.close();
+      port2.close();
+    }
+  });
+
+  test("parentPort.removeAllListeners() leaves unrelated global listeners intact", async () => {
+    const worker = new Worker(
+      `const { parentPort } = require("node:worker_threads");
+       let errorFired = false;
+       self.addEventListener("error", () => { errorFired = true; });
+       parentPort.on("message", () => {});
+       parentPort.removeAllListeners();
+       // If the user's global 'error' listener survived, this dispatch flips the flag.
+       self.dispatchEvent(new ErrorEvent("error", {}));
+       parentPort.postMessage({
+         messageCleared: parentPort.listenerCount("message") === 0,
+         errorHandlerKept: errorFired,
+       });`,
+      { eval: true },
+    );
+    const [message] = await once(worker, "message");
+    await worker.terminate();
+    expect(message).toEqual({ messageCleared: true, errorHandlerKept: true });
+  });
 });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -906,4 +906,25 @@ describe("MessagePort EventEmitter interface", () => {
     await worker.terminate();
     expect(message).toEqual({ messageCleared: true, errorHandlerKept: true });
   });
+
+  test("off() removes a raw addEventListener registration even after on() cached a wrapper", () => {
+    const { port1, port2 } = new MessageChannel();
+    try {
+      const h = () => {};
+      // Seed the wrapper cache for (h, "message") and tear it back down.
+      port1.on("message", h);
+      port1.off("message", h);
+      expect(port1.listenerCount("message")).toBe(0);
+
+      // Now register the same function raw. A stale cached wrapper must not
+      // shadow it: off() has to find and remove the raw registration too.
+      port1.addEventListener("message", h);
+      expect(port1.listenerCount("message")).toBe(1);
+      port1.off("message", h);
+      expect(port1.listenerCount("message")).toBe(0);
+    } finally {
+      port1.close();
+      port2.close();
+    }
+  });
 });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,5 +1,5 @@
 import { bunEnv, bunExe, tmpdirSync } from "harness";
-import { once } from "node:events";
+import events, { once, setMaxListeners } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { Readable } from "node:stream";
@@ -627,4 +627,243 @@ test("FileHandles nested in Map and Set workerData are transferred", async () =>
   // and Set entries deserialized to the same single instance
   expect(fh.fd).toBe(-1);
   expect(message).toEqual({ sameInstance: true, text: "hello" });
+});
+
+describe("MessagePort EventEmitter interface", () => {
+  // In node, MessagePort's prototype chain runs through NodeEventTarget, so a port
+  // is an EventEmitter/EventTarget hybrid. Worker pools (piscina, tinypool,
+  // jest-worker) lean on the EventEmitter half when tearing a worker down.
+  const nodeEventTargetMethods = [
+    "addListener",
+    "emit",
+    "eventNames",
+    "getMaxListeners",
+    "listenerCount",
+    "off",
+    "on",
+    "once",
+    "removeAllListeners",
+    "removeListener",
+    "setMaxListeners",
+  ];
+
+  function openChannel() {
+    const channel = new MessageChannel();
+    return {
+      port1: channel.port1,
+      port2: channel.port2,
+      [Symbol.dispose]() {
+        channel.port1.close();
+        channel.port2.close();
+      },
+    };
+  }
+
+  test("a port exposes every NodeEventTarget method", () => {
+    using ports = openChannel();
+    const missing = nodeEventTargetMethods.filter(name => typeof ports.port1[name] !== "function");
+    expect(missing).toEqual([]);
+  });
+
+  test("listenerCount and eventNames see every kind of listener", () => {
+    using ports = openChannel();
+    const { port1 } = ports;
+
+    expect(port1.listenerCount("message")).toBe(0);
+    expect(port1.eventNames()).toEqual([]);
+
+    port1.on("message", () => {});
+    port1.addEventListener("message", () => {});
+    port1.onmessage = () => {};
+    port1.on("messageerror", () => {});
+
+    expect(port1.listenerCount("message")).toBe(3);
+    expect(port1.listenerCount("messageerror")).toBe(1);
+    expect(port1.listenerCount("nope")).toBe(0);
+    expect(port1.eventNames().sort()).toEqual(["message", "messageerror"]);
+  });
+
+  test("removeAllListeners(type) drops every listener for that type", async () => {
+    using ports = openChannel();
+    const { port1, port2 } = ports;
+
+    const calls: string[] = [];
+    port1.on("message", () => calls.push("on"));
+    port1.addEventListener("message", () => calls.push("addEventListener"));
+    port1.onmessage = () => calls.push("onmessage");
+    port1.on("messageerror", () => calls.push("messageerror"));
+
+    expect(port1.removeAllListeners("message")).toBe(port1);
+    expect(port1.listenerCount("message")).toBe(0);
+    expect(port1.eventNames()).toEqual(["messageerror"]);
+
+    const received = new Promise(resolve => port1.once("message", resolve));
+    port2.postMessage("after");
+    expect(await received).toBe("after");
+    expect(calls).toEqual([]);
+  });
+
+  test("removeAllListeners() with no type clears every event", () => {
+    using ports = openChannel();
+    const { port1 } = ports;
+
+    port1.on("message", () => {});
+    port1.on("messageerror", () => {});
+    port1.onmessage = () => {};
+
+    expect(port1.removeAllListeners()).toBe(port1);
+    expect(port1.eventNames()).toEqual([]);
+    expect(port1.listenerCount("message")).toBe(0);
+    expect(port1.listenerCount("messageerror")).toBe(0);
+  });
+
+  test("off()/removeListener() only remove the listener for the event they were given", () => {
+    using ports = openChannel();
+    const { port1 } = ports;
+    const handler = () => {};
+
+    port1.on("message", handler);
+    port1.on("messageerror", handler);
+
+    expect(port1.off("message", handler)).toBe(port1);
+    expect(port1.listenerCount("message")).toBe(0);
+    expect(port1.listenerCount("messageerror")).toBe(1);
+
+    expect(port1.removeListener("messageerror", handler)).toBe(port1);
+    expect(port1.listenerCount("messageerror")).toBe(0);
+  });
+
+  test("addListener() delivers the payload and registering twice is a no-op", async () => {
+    using ports = openChannel();
+    const { port1, port2 } = ports;
+
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const seen: unknown[] = [];
+    const handler = (value: unknown) => {
+      seen.push(value);
+      resolve();
+    };
+    port1.addListener("message", handler);
+    port1.addListener("message", handler);
+    expect(port1.listenerCount("message")).toBe(1);
+
+    port2.postMessage({ hello: "world" });
+    await promise;
+    expect(seen).toEqual([{ hello: "world" }]);
+  });
+
+  // https://github.com/oven-sh/bun/issues/20169
+  test("registering the same listener repeatedly adds it once, and one off() removes it", async () => {
+    using ports = openChannel();
+    const { port1, port2 } = ports;
+
+    const received: unknown[] = [];
+    const { promise: firstDelivery, resolve: delivered } = Promise.withResolvers<void>();
+    const onMessage = (message: unknown) => {
+      received.push(message);
+      delivered();
+    };
+    port1.on("message", onMessage);
+    port1.on("message", onMessage);
+    port1.on("message", onMessage);
+    expect(port1.listenerCount("message")).toBe(1);
+
+    port2.postMessage("Hi");
+    await firstDelivery;
+    expect(received).toEqual(["Hi"]);
+
+    // One off() is enough, because the duplicate registrations never happened.
+    port1.off("message", onMessage);
+    expect(port1.listenerCount("message")).toBe(0);
+
+    const drained = new Promise(resolve => port1.once("message", resolve));
+    port2.postMessage("Hi Again...");
+    expect(await drained).toBe("Hi Again...");
+    expect(received).toEqual(["Hi"]);
+  });
+
+  test("off() with no listener is a no-op", () => {
+    using ports = openChannel();
+    const { port1 } = ports;
+    port1.on("message", () => {});
+    expect(port1.off("message")).toBe(port1);
+    expect(port1.listenerCount("message")).toBe(1);
+  });
+
+  test("emit() delivers the payload and reports whether there were listeners", () => {
+    using ports = openChannel();
+    const { port1 } = ports;
+
+    expect(port1.emit("message", 1)).toBe(false);
+
+    const seen: unknown[] = [];
+    port1.on("message", value => seen.push(value));
+    expect(port1.emit("message", 42)).toBe(true);
+    expect(seen).toEqual([42]);
+  });
+
+  test("get/setMaxListeners round-trip and share storage with events.setMaxListeners", () => {
+    using ports = openChannel();
+    const { port1 } = ports;
+
+    expect(port1.getMaxListeners()).toBe(events.defaultMaxListeners);
+    expect(port1.setMaxListeners(42)).toBeUndefined();
+    expect(port1.getMaxListeners()).toBe(42);
+
+    setMaxListeners(7, port1);
+    expect(port1.getMaxListeners()).toBe(7);
+
+    expect(() => port1.setMaxListeners(-1)).toThrow(
+      'The value of "setMaxListeners" is out of range. It must be >= 0. Received -1',
+    );
+    expect(() => port1.setMaxListeners("nope" as any)).toThrow(
+      "The \"setMaxListeners\" argument must be of type number. Received type string ('nope')",
+    );
+    expect(port1.getMaxListeners()).toBe(7);
+  });
+
+  test("parentPort exposes the same methods inside a worker", async () => {
+    const worker = new Worker(
+      `const { parentPort } = require("node:worker_threads");
+       const missing = ${JSON.stringify(nodeEventTargetMethods)}.filter(m => typeof parentPort[m] !== "function");
+       parentPort.on("message", () => {});
+       const before = parentPort.listenerCount("message");
+       const names = parentPort.eventNames();
+       parentPort.removeAllListeners("message");
+       parentPort.postMessage({ missing, before, names, after: parentPort.listenerCount("message") });`,
+      { eval: true },
+    );
+    const [message] = await once(worker, "message");
+    await worker.terminate();
+    expect(message).toEqual({ missing: [], before: 1, names: ["message"], after: 0 });
+  });
+
+  test("removeAllListeners releases the event-loop ref a transferred port holds", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const worker = new Worker(
+      `const { workerData: port } = require("node:worker_threads");
+       port.on("message", () => {
+         port.postMessage("ack");
+         // Without this the message listener keeps the worker's event loop
+         // referenced forever, which is how pools leak a worker on teardown.
+         try {
+           port.removeAllListeners();
+         } catch {
+           process.exit(7);
+         }
+       });`,
+      { eval: true, workerData: port2, transferList: [port2] },
+    );
+
+    try {
+      const acked = new Promise(resolve => port1.once("message", resolve));
+      port1.postMessage("go");
+      expect(await acked).toBe("ack");
+
+      const [code] = await once(worker, "exit");
+      expect(code).toBe(0);
+    } finally {
+      port1.close();
+    }
+  });
 });


### PR DESCRIPTION
Closes #29022
Closes #20169
Closes #32232

## Repro

```js
import { MessageChannel } from "node:worker_threads";

const { port1 } = new MessageChannel();
const handler = () => {};

port1.on("message", handler);
port1.removeAllListeners("message"); // node: fine        bun: TypeError
port1.listenerCount("message");      // node: 0           bun: TypeError
```

Pool libraries (`piscina`, `tinypool`, jest workers) and anything generic over
`EventEmitter` call exactly these methods on ports while tearing a worker down,
so the `TypeError` lands mid-teardown.

Two more shapes of the same gap:

```js
// #20169: node dedupes identical (event, listener) pairs; bun registered three
port1.on("message", onMessage);
port1.on("message", onMessage);
port1.on("message", onMessage);
port1.off("message", onMessage);   // node: 0 left, bun: 2 left

// off() kept one wrapper slot per listener function, not per (listener, event)
port1.on("message", handler);
port1.on("messageerror", handler); // overwrites the slot
port1.off("message", handler);     // removes nothing
```

## Cause

In node, `MessagePort.prototype`'s chain runs through `NodeEventTarget`, which
layers `addListener`, `removeListener`, `removeAllListeners`, `listenerCount`,
`eventNames`, `getMaxListeners` and `setMaxListeners` on top of the EventTarget
listener map. A port is an `EventEmitter`/`EventTarget` hybrid.

Bun's `MessagePort` is a plain WebCore `EventTarget`, and
`injectFakeEmitter` in `src/js/node/worker_threads.ts` only grafted on
`on`/`off`/`once`/`emit`. The rest of the surface did not exist.

`injectFakeEmitter` also registered each emitter listener through a wrapper (an
emitter listener receives the payload, not the event) and stashed that wrapper
on the listener function under a single symbol slot, so a listener attached to
two events lost the first wrapper and `off()` removed the wrong registration.
A fresh wrapper per call also defeated EventTarget's own dedupe.

## Fix

`injectFakeEmitter` installs the full `NodeEventTarget` method set, backed by
the port's actual EventTarget listener map rather than a side table, so
`listenerCount`/`eventNames` also see `addEventListener` and `onmessage`
registrations the way node's do. Three host functions on `JSEventTarget`
provide the introspection (`jsEventTargetGetEventListenersCount` already
existed and now resolves the global scope too, via `jsEventTargetCast`):

- `jsEventTargetGetEventNames`
- `jsEventTargetRemoveAllEventListeners`

Wrappers are now keyed per `(listener, event)` pair in a `WeakMap`, so
`addEventListener` dedupes repeat registrations (node's behavior, #20169) and
`off()`/`removeListener()` look up the wrapper for the event they were given.

`MessagePort::removeAllEventListeners()` now resets `m_hasMessageEventListener`,
so `removeAllListeners()` releases the event-loop ref a transferred port takes
while it has a message listener. That is the "leaks the worker" half of the bug:
without it the worker's loop stays referenced after a pool drops its listeners.
`disentangle()` used to reset that flag by hand; it no longer has to.

`emit()` follows node: the second argument is the payload (`port.emit("message", 42)`
delivered `42`, bun threw, because it was passed through as a `MessageEvent`
init dict), and the return value is whether there were listeners.

`parentPort` is an object with `MessagePort.prototype`, delegating to the worker
global scope, so it inherits the new methods; the three that introspect the
listener map get overrides pointing at that scope, and it gains `dispatchEvent`
so `emit()` works there too. Its hand-rolled `addListener`/`removeListener`
overrides are gone: they aliased `addEventListener`/`removeEventListener`
directly, so the listener received an `Event` instead of the payload. The
inherited versions do the right thing.

## Verification

`test/js/node/worker_threads/worker_threads.test.ts` gains 12 tests covering the
method set, `listenerCount`/`eventNames` over every kind of registration,
`removeAllListeners` with and without a type, cross-event `off()` bookkeeping,
duplicate-registration dedupe, `emit()` payload and return value, max-listener
round-tripping with `events.setMaxListeners`, `parentPort` inside a worker, and
a transferred port whose worker exits on its own once `removeAllListeners()`
releases the event-loop ref.

```
USE_SYSTEM_BUN=1 bun test test/js/node/worker_threads/worker_threads.test.ts -t "MessagePort EventEmitter"
 0 pass, 12 fail

bun bd test test/js/node/worker_threads/worker_threads.test.ts -t "MessagePort EventEmitter"
 12 pass, 0 fail
```

<details>
<summary>Output of a 20-case differential against node v26.3.0 is byte-identical</summary>

```
proto methods = []
dedupe = 1
cross-event off = [0,1]
mixed count = 3
events.listenerCount = 3
eventNames = ["message"]
after removeAll(type) = 0
emit no listeners = false
emit with listener = true
emit payload = [42]
default max = 10
setMaxListeners returns = undefined
after set = 42
after events.setMaxListeners = 7
setMaxListeners(-1) = ["ERR_OUT_OF_RANGE","The value of \"setMaxListeners\" is out of range. It must be >= 0. Received -1"]
once payload = "hi"
once cleared = 0
addListener payload = {"a":1}
events.once = ["viaOnce"]
off no listener is noop = 1
```

</details>

The three linked issues' repros now print what node prints. Existing coverage
stays green: `test/js/node/events/event-emitter.test.ts`, `test/js/bun/worker/`,
`test/js/web/broadcastchannel`, and the `test-worker*` / `test-eventtarget*` /
`test-messagechannel*` node-compat tests.
