### PR TITLE
fix(http2): accept sockets without alpnProtocol via createConnection

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3497,6 +3497,7 @@ class ClientHttp2Session extends Http2Session {
       if (alpnProtocol === false || (typeof alpnProtocol === "string" && alpnProtocol !== "h2")) {
         socket.end();
         this.emit("error", $ERR_HTTP2_ERROR("h2 is not supported"));
+        return;
       }
       this.#alpnProtocol = alpnProtocol || "h2";
     } else {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3489,15 +3489,8 @@ class ClientHttp2Session extends Http2Session {
     const socket = this[bunHTTP2Socket];
     if (!socket) return;
     this.#connected = true;
-    // check if h2 is supported only for TLSSocket
     if (socket instanceof TLSSocket) {
-      // client must check alpnProtocol
-      if (socket.alpnProtocol !== "h2") {
-        socket.end();
-        const error = $ERR_HTTP2_ERROR("h2 is not supported");
-        this.emit("error", error);
-      }
-      this.#alpnProtocol = "h2";
+      this.#alpnProtocol = socket.alpnProtocol;
     } else {
       this.#alpnProtocol = "h2c";
     }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3490,7 +3490,15 @@ class ClientHttp2Session extends Http2Session {
     if (!socket) return;
     this.#connected = true;
     if (socket instanceof TLSSocket) {
-      this.#alpnProtocol = socket.alpnProtocol;
+      const alpnProtocol = socket.alpnProtocol;
+      // Only reject when ALPN was actually negotiated to something other than h2.
+      // undefined/null means the socket came via createConnection (e.g. http2-wrapper)
+      // where alpnProtocol is not propagated; Node.js does not validate in that case.
+      if (alpnProtocol === false || (typeof alpnProtocol === "string" && alpnProtocol !== "h2")) {
+        socket.end();
+        this.emit("error", $ERR_HTTP2_ERROR("h2 is not supported"));
+      }
+      this.#alpnProtocol = alpnProtocol || "h2";
     } else {
       this.#alpnProtocol = "h2c";
     }

--- a/test/regression/issue/14958.test.ts
+++ b/test/regression/issue/14958.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression test for GitHub Issue #14958
+ *
+ * http2.connect() should accept a TLSSocket supplied via createConnection
+ * even when socket.alpnProtocol is not the string "h2" (e.g. undefined, as
+ * happens with sockets from http2-wrapper). Node.js does not validate
+ * alpnProtocol on the client side; it simply records the value.
+ */
+import { test, expect } from "bun:test";
+import { tls as tlsCert } from "harness";
+import http2 from "node:http2";
+import tls from "node:tls";
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+
+test("http2.connect accepts TLSSocket via createConnection when alpnProtocol is undefined", async () => {
+  const server = http2.createSecureServer({ key: tlsCert.key, cert: tlsCert.cert });
+  server.on("stream", stream => {
+    stream.respond({ ":status": 200 });
+    stream.end("ok");
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const socket = tls.connect({ host: "127.0.0.1", port, ALPNProtocols: ["h2"], rejectUnauthorized: false });
+  await once(socket, "secureConnect");
+  // Simulate http2-wrapper-style sockets where alpnProtocol is not propagated.
+  Object.defineProperty(socket, "alpnProtocol", { value: undefined, configurable: true });
+
+  const client = http2.connect(`https://127.0.0.1:${port}`, { createConnection: () => socket });
+  const errors: Error[] = [];
+  client.on("error", err => errors.push(err));
+  await once(client, "connect");
+  expect(errors).toEqual([]);
+
+  const req = client.request({ ":path": "/" });
+  req.setEncoding("utf8");
+  let body = "";
+  req.on("data", c => (body += c));
+  req.end();
+  const [headers] = await once(req, "response");
+  expect(headers[":status"]).toBe(200);
+  await once(req, "end");
+  expect(body).toBe("ok");
+
+  const closed = new Promise<void>(r => client.close(() => r()));
+  await closed;
+  server.close();
+  await once(server, "close");
+});

--- a/test/regression/issue/14958.test.ts
+++ b/test/regression/issue/14958.test.ts
@@ -6,12 +6,12 @@
  * happens with sockets from http2-wrapper). Node.js does not validate
  * alpnProtocol on the client side; it simply records the value.
  */
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { tls as tlsCert } from "harness";
-import http2 from "node:http2";
-import tls from "node:tls";
 import { once } from "node:events";
+import http2 from "node:http2";
 import type { AddressInfo } from "node:net";
+import tls from "node:tls";
 
 test("http2.connect accepts TLSSocket via createConnection when alpnProtocol is undefined", async () => {
   const server = http2.createSecureServer({ key: tlsCert.key, cert: tlsCert.cert });


### PR DESCRIPTION
When a TLSSocket is supplied to `http2.connect()` via the `createConnection` option (e.g., http2-wrapper), `socket.alpnProtocol` may be undefined since the socket was created outside Bun's control. Bun was rejecting these with `ERR_HTTP2_ERROR: h2 is not supported`.

Node.js does not validate alpnProtocol on the client side ([lib/internal/http2/core.js:1114](https://github.com/nodejs/node/blob/main/lib/internal/http2/core.js)); it simply stores the value. Only the server `connectionListener` rejects non-h2 ALPN. This PR matches that behavior.

Fixes #14958