### PR TITLE
fix(http2): validate :status range in respond()

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2619,7 +2619,13 @@ class ServerHttp2Stream extends Http2Stream {
     if (headers[HTTP2_HEADER_STATUS] === undefined) {
       headers[HTTP2_HEADER_STATUS] = 200;
     }
-    const statusCode = headers[HTTP2_HEADER_STATUS];
+    const statusCode = (headers[HTTP2_HEADER_STATUS] |= 0);
+    if (statusCode < 200 || statusCode > 599) {
+      throw $ERR_HTTP2_STATUS_INVALID(headers[HTTP2_HEADER_STATUS]);
+    }
+    if (statusCode === HTTP_STATUS_SWITCHING_PROTOCOLS) {
+      throw $ERR_HTTP2_STATUS_101();
+    }
     let endStream = !!options?.endStream;
     if (
       endStream ||

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2620,11 +2620,12 @@ class ServerHttp2Stream extends Http2Stream {
       headers[HTTP2_HEADER_STATUS] = 200;
     }
     const statusCode = (headers[HTTP2_HEADER_STATUS] |= 0);
+    // This is intentionally stricter than the HTTP/1 implementation, which
+    // allows values between 100 and 999 (inclusive) in order to allow for
+    // backwards compatibility with non-spec compliant code. With HTTP/2,
+    // we have the opportunity to start fresh with stricter spec compliance.
     if (statusCode < 200 || statusCode > 599) {
       throw $ERR_HTTP2_STATUS_INVALID(headers[HTTP2_HEADER_STATUS]);
-    }
-    if (statusCode === HTTP_STATUS_SWITCHING_PROTOCOLS) {
-      throw $ERR_HTTP2_STATUS_101();
     }
     let endStream = !!options?.endStream;
     if (

--- a/test/js/node/test/parallel/test-http2-status-code-invalid.js
+++ b/test/js/node/test/parallel/test-http2-status-code-invalid.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+const server = http2.createServer();
+
+function expectsError(code) {
+  return common.expectsError({
+    code: 'ERR_HTTP2_STATUS_INVALID',
+    name: 'RangeError',
+    message: `Invalid status code: ${code}`
+  });
+}
+
+server.on('stream', common.mustCall((stream) => {
+
+  // Anything lower than 100 and greater than 599 is rejected
+  [ 99, 700, 1000 ].forEach((i) => {
+    assert.throws(() => stream.respond({ ':status': i }), expectsError(i));
+  });
+
+  stream.respond();
+  stream.end();
+}));
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request();
+  req.on('response', common.mustCall((headers) => {
+    assert.strictEqual(headers[':status'], 200);
+  }));
+  req.resume();
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.close();
+  }));
+}));


### PR DESCRIPTION
RFC 9113 §8.3.2 requires `:status` to be a valid 3-digit code. Node throws `ERR_HTTP2_STATUS_INVALID` for codes outside 100-599 and `ERR_HTTP2_STATUS_101` for 101 (switching protocols is meaningless in HTTP/2). Bun's `respond()` did not validate.

Ports `test/parallel/test-http2-status-code-invalid.js` from Node.js.