### PR TITLE
ci: retry buildkite-agent annotate instead of posting 'annotation error'

### DIFF
--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -2745,30 +2745,21 @@ export function reportAnnotationToBuildKite({ context, label, content, style = "
       input: content,
       stdio: ["pipe", "ignore", "pipe"],
       encoding: "utf-8",
-      timeout: 5_000,
+      timeout: 30_000,
     },
   );
   if (status === 0) {
     return;
   }
-  if (attempt > 0) {
-    const cause = error ?? signal ?? `code ${status}`;
-    throw new Error(`Failed to create annotation: ${label}`, { cause });
+  const cause = error?.message || signal || (status == null ? "timed out" : `exit code ${status}`);
+  if (attempt === 0) {
+    console.error(`buildkite-agent annotate failed for '${label}' (${cause}), retrying...`);
+    return reportAnnotationToBuildKite({ context, label, content, style, priority, attempt: attempt + 1 });
   }
-  const errorContent = formatAnnotationToHtml({
-    title: "annotation error",
-    content: stderr || "",
-    source: "buildkite",
-    level: "error",
-  });
-  reportAnnotationToBuildKite({
-    context,
-    label: `${label}-error`,
-    content: errorContent,
-    style,
-    priority,
-    attempt: attempt + 1,
-  });
+  // Annotations are best-effort: log and move on rather than throwing, which
+  // would abort the test runner mid-suite over a cosmetic failure.
+  console.error(`buildkite-agent annotate failed for '${label}' after retry (${cause}), giving up`);
+  if (stderr) console.error(stderr);
 }
 
 /**


### PR DESCRIPTION
Recent builds have been showing flaky `annotation error on <target>` entries (e.g. builds #44422, #44397). These come from `reportAnnotationToBuildKite` in `scripts/utils.mjs`, which spawns `buildkite-agent annotate` with a 5-second `spawnSync` timeout. When the agent doesn't finish in 5s, Node SIGTERMs it, `status` comes back `null`, and the old fallback posted a second annotation titled "annotation error" whose body was whatever stderr had been captured so far — in every observed case just `INFO   Reading annotation body from STDIN`, which is useless.

The Buildkite status page being green doesn't protect against this: `buildkite-agent`'s HTTP client has its own retry loop with exponential backoff, so a single transient failure on one request (TCP reset, TLS hiccup, a lone 5xx, or per-build rate limiting when many parallel test jobs append to the shared `flaky` context at once) makes the agent sleep several seconds before retrying internally — already past our 5s kill. None of that registers as a service outage.

This change raises the timeout to 30s (enough for one internal agent retry cycle), retries the original annotation once on failure instead of posting a content-free "annotation error", and logs-and-continues rather than `throw`ing if the retry also fails — the throw path could abort `runner.node.mjs` mid-suite over what is ultimately a cosmetic reporting step.