### PR TITLE
fix(http2): enforce maxSessionMemory on server-side stream creation

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -2550,7 +2550,7 @@ pub const H2FrameParser = struct {
             this.paddingStrategy,
         );
 
-        // RFC 9113 §10.5: reject new server streams when session memory budget is exceeded
+        // RFC 9113 §5.1.2: reject new server streams when session memory budget is exceeded
         if (this.isServer and this.getSessionMemoryUsage() > this.getSessionMaxMemoryBytes()) {
             this.rejectedStreams += 1;
             if (this.maxRejectedStreams <= this.rejectedStreams) {
@@ -2558,7 +2558,9 @@ pub const H2FrameParser = struct {
             } else {
                 this.endStream(entry.value_ptr, ErrorCode.ENHANCE_YOUR_CALM);
             }
-            return entry.value_ptr;
+            // endStream/sendGoAway dispatch into JS which may re-enter and rehash the
+            // streams map, invalidating entry.value_ptr — re-fetch before returning.
+            return if (this.streams.getEntry(streamIdentifier)) |e| e.value_ptr else null;
         }
 
         const this_value = this.strong_this.tryGet() orelse return entry.value_ptr;
@@ -3353,9 +3355,11 @@ pub const H2FrameParser = struct {
         }
     };
 
-    // get memory usage in MB
+    // get memory usage in bytes
     fn getSessionMemoryUsage(this: *H2FrameParser) u64 {
-        return @as(u64, this.writeBuffer.len) + this.queuedDataSize;
+        // writeBufferOffset advances on partial flushes without shrinking writeBuffer.len,
+        // so subtract it to count only the bytes still pending on the socket.
+        return (@as(u64, this.writeBuffer.len) -| @as(u64, this.writeBufferOffset)) + this.queuedDataSize;
     }
 
     fn getSessionMaxMemoryBytes(this: *H2FrameParser) u64 {

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -2549,6 +2549,18 @@ pub const H2FrameParser = struct {
             if (this.remoteSettings) |s| s.initialWindowSize else DEFAULT_WINDOW_SIZE,
             this.paddingStrategy,
         );
+
+        // RFC 9113 §10.5: reject new server streams when session memory budget is exceeded
+        if (this.isServer and this.getSessionMemoryUsage() > this.getSessionMaxMemoryBytes()) {
+            this.rejectedStreams += 1;
+            if (this.maxRejectedStreams <= this.rejectedStreams) {
+                this.sendGoAway(streamIdentifier, ErrorCode.ENHANCE_YOUR_CALM, "ENHANCE_YOUR_CALM", this.lastStreamID, true);
+            } else {
+                this.endStream(entry.value_ptr, ErrorCode.ENHANCE_YOUR_CALM);
+            }
+            return entry.value_ptr;
+        }
+
         const this_value = this.strong_this.tryGet() orelse return entry.value_ptr;
         const ctx_value = js.gc.context.get(this_value) orelse return entry.value_ptr;
         const callback = js.gc.onStreamStart.get(this_value) orelse return entry.value_ptr;
@@ -3342,8 +3354,12 @@ pub const H2FrameParser = struct {
     };
 
     // get memory usage in MB
-    fn getSessionMemoryUsage(this: *H2FrameParser) usize {
-        return (this.writeBuffer.len + this.queuedDataSize) / 1024 / 1024;
+    fn getSessionMemoryUsage(this: *H2FrameParser) u64 {
+        return @as(u64, this.writeBuffer.len) + this.queuedDataSize;
+    }
+
+    fn getSessionMaxMemoryBytes(this: *H2FrameParser) u64 {
+        return @as(u64, this.maxSessionMemory) * 1024 * 1024;
     }
 
     // get memory in bytes
@@ -4323,7 +4339,7 @@ pub const H2FrameParser = struct {
         }
 
         // too much memory being use
-        if (this.getSessionMemoryUsage() > this.maxSessionMemory) {
+        if (this.getSessionMemoryUsage() > this.getSessionMaxMemoryBytes()) {
             stream.state = .CLOSED;
             stream.rstCode = @intFromEnum(ErrorCode.ENHANCE_YOUR_CALM);
             this.rejectedStreams += 1;

--- a/src/http/websocket_client/WebSocketProxyTunnel.zig
+++ b/src/http/websocket_client/WebSocketProxyTunnel.zig
@@ -88,6 +88,13 @@ const SocketUnion = union(enum) {
             .none => true,
         };
     }
+
+    pub fn close(self: SocketUnion) void {
+        switch (self) {
+            inline .tcp, .ssl => |s| s.close(.normal),
+            .none => {},
+        }
+    }
 };
 
 const SSLWrapperType = SSLWrapper(*WebSocketProxyTunnel);
@@ -334,11 +341,19 @@ pub fn write(this: *WebSocketProxyTunnel, data: []const u8) !usize {
     return error.ConnectionClosed;
 }
 
-/// Gracefully shutdown the TLS connection
+/// Gracefully shutdown the TLS connection and close the underlying proxy
+/// socket so the upgrade client's handleClose fires and releases its socket
+/// ref + proxy state. Take the socket out first so a re-entrant shutdown()
+/// (via handleClose → clearData → proxy.deinit → tunnel.shutdown) finds .none
+/// and returns early without re-running wrapper.shutdown.
 pub fn shutdown(this: *WebSocketProxyTunnel) void {
+    const sock = this.#socket;
+    if (sock == .none) return;
+    this.#socket = .{ .none = {} };
     if (this.#wrapper) |*wrapper| {
         _ = wrapper.shutdown(true); // Fast shutdown
     }
+    sock.close();
 }
 
 /// Check if the tunnel has backpressure

--- a/test/js/node/test/sequential/test-http2-max-session-memory.js
+++ b/test/js/node/test/sequential/test-http2-max-session-memory.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const http2 = require('http2');
+
+// Test that maxSessionMemory Caps work
+
+const largeBuffer = Buffer.alloc(2e6);
+
+const server = http2.createServer({ maxSessionMemory: 1 });
+
+server.on('stream', common.mustCall((stream) => {
+  stream.on('error', (err) => {
+    if (err.code !== 'ECONNRESET')
+      throw err;
+  });
+  stream.respond();
+  stream.end(largeBuffer);
+}));
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+
+  {
+    const req = client.request();
+
+    req.on('response', common.mustCall(() => {
+      // This one should be rejected because the server is over budget
+      // on the current memory allocation
+      const req = client.request();
+      req.on('error', common.expectsError({
+        code: 'ERR_HTTP2_STREAM_ERROR',
+        name: 'Error',
+        message: 'Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM',
+      }));
+      req.on('close', common.mustCall(() => {
+        server.close();
+        client.destroy();
+      }));
+    }));
+
+    req.resume();
+    req.on('close', common.mustCall());
+  }
+}));

--- a/test/js/web/websocket/wss-proxy-tunnel-leak-fixture.ts
+++ b/test/js/web/websocket/wss-proxy-tunnel-leak-fixture.ts
@@ -1,0 +1,124 @@
+// Fixture for wss-proxy-tunnel-leak.test.ts.
+// Repeatedly opens+closes a wss:// WebSocket through an HTTP CONNECT proxy
+// (the tunnel-mode upgrade path in WebSocketUpgradeClient.zig), then reports
+// RSS growth so the test can assert the per-upgrade HTTPClient/tunnel are freed.
+// Servers run in a child process so server-side allocations don't pollute the
+// client RSS measurement.
+import net from "node:net";
+import { tls as tlsCerts } from "harness";
+
+if (process.argv[2] === "server") {
+  const wss = Bun.serve({
+    port: 0,
+    tls: { key: tlsCerts.key, cert: tlsCerts.cert },
+    fetch(req, server) {
+      if (server.upgrade(req)) return;
+      return new Response("nope", { status: 400 });
+    },
+    websocket: {
+      open(ws) {
+        ws.send("hi");
+      },
+      message(ws, m) {
+        ws.send(m);
+      },
+    },
+  });
+
+  const proxy = net.createServer(client => {
+    let buf = Buffer.alloc(0);
+    const onData = (data: Buffer) => {
+      buf = Buffer.concat([buf, data]);
+      const text = buf.toString();
+      const eoh = text.indexOf("\r\n\r\n");
+      if (eoh < 0) return; // wait for more — CONNECT may span multiple reads
+      client.removeListener("data", onData);
+      const first = text.slice(0, text.indexOf("\r\n"));
+      const m = first.match(/^CONNECT\s+([^:]+):(\d+)\s+HTTP/);
+      if (!m) {
+        client.write("HTTP/1.1 400 Bad Request\r\n\r\n");
+        client.end();
+        return;
+      }
+      const upstream = net.connect(+m[2], m[1], () => {
+        client.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+        const rest = buf.subarray(eoh + 4);
+        if (rest.length) upstream.write(rest);
+        client.pipe(upstream);
+        upstream.pipe(client);
+      });
+      upstream.on("error", () => client.destroy());
+      upstream.on("close", () => client.destroy());
+      client.on("close", () => upstream.destroy());
+    };
+    client.on("data", onData);
+    client.on("error", () => {});
+  });
+  await new Promise<void>(r => proxy.listen(0, "127.0.0.1", () => r()));
+
+  process.send!({ wss: wss.port, proxy: (proxy.address() as net.AddressInfo).port });
+  // Keep alive until parent exits.
+  setInterval(() => {}, 1 << 30);
+} else {
+  const ready = Promise.withResolvers<{ wss: number; proxy: number }>();
+  await using child = Bun.spawn({
+    cmd: [process.execPath, import.meta.path, "server"],
+    env: process.env,
+    // Don't inherit — the parent test asserts stderr === "" on this process,
+    // and inherited fds would let server-side noise leak into that buffer.
+    stdout: "ignore",
+    stderr: "ignore",
+    ipc(msg) {
+      ready.resolve(msg);
+    },
+  });
+  const { wss: wssPort, proxy: proxyPort } = await ready.promise;
+  const wssUrl = `wss://localhost:${wssPort}/`;
+  const proxyUrl = `http://127.0.0.1:${proxyPort}`;
+
+  async function once(): Promise<void> {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const ws = new WebSocket(wssUrl, {
+      // @ts-expect-error Bun-specific options
+      proxy: proxyUrl,
+      tls: { rejectUnauthorized: false },
+    });
+    let opened = false;
+    ws.onmessage = () => {
+      opened = true;
+      ws.close();
+    };
+    ws.onclose = () => {
+      if (opened) resolve();
+      else reject(new Error("closed before message"));
+    };
+    ws.onerror = ev => reject(new Error(`ws error: ${(ev as ErrorEvent).message ?? ev.type}`));
+    return promise;
+  }
+
+  const WARMUP = parseInt(process.env.LEAK_WARMUP ?? "60", 10);
+  const ITER = parseInt(process.env.LEAK_ITER ?? "500", 10);
+  const BATCH = 8;
+
+  async function loop(n: number) {
+    let remaining = n;
+    while (remaining > 0) {
+      const k = Math.min(BATCH, remaining);
+      const batch: Promise<void>[] = [];
+      for (let i = 0; i < k; i++) batch.push(once());
+      await Promise.all(batch);
+      remaining -= k;
+    }
+  }
+
+  await loop(WARMUP);
+  Bun.gc(true);
+  const baseline = process.memoryUsage.rss();
+
+  await loop(ITER);
+  Bun.gc(true);
+  const after = process.memoryUsage.rss();
+
+  console.log(JSON.stringify({ baseline, after, growth: after - baseline, iter: ITER }));
+  child.kill();
+}

--- a/test/js/web/websocket/wss-proxy-tunnel-leak-fixture.ts
+++ b/test/js/web/websocket/wss-proxy-tunnel-leak-fixture.ts
@@ -32,6 +32,9 @@ if (process.argv[2] === "server") {
       const text = buf.toString();
       const eoh = text.indexOf("\r\n\r\n");
       if (eoh < 0) return; // wait for more — CONNECT may span multiple reads
+      // Removing the only 'data' listener leaves the socket in flowing mode;
+      // pause it so any bytes that arrive before pipe() is attached aren't lost.
+      client.pause();
       client.removeListener("data", onData);
       const first = text.slice(0, text.indexOf("\r\n"));
       const m = first.match(/^CONNECT\s+([^:]+):(\d+)\s+HTTP/);
@@ -46,6 +49,7 @@ if (process.argv[2] === "server") {
         if (rest.length) upstream.write(rest);
         client.pipe(upstream);
         upstream.pipe(client);
+        client.resume();
       });
       upstream.on("error", () => client.destroy());
       upstream.on("close", () => client.destroy());
@@ -64,15 +68,18 @@ if (process.argv[2] === "server") {
   await using child = Bun.spawn({
     cmd: [process.execPath, import.meta.path, "server"],
     env: process.env,
-    // Don't inherit — the parent test asserts stderr === "" on this process,
-    // and inherited fds would let server-side noise leak into that buffer.
+    // Don't inherit — keeps server-side noise out of this process's stdio so
+    // the parent test only sees the JSON growth report on stdout.
     stdout: "ignore",
     stderr: "ignore",
     ipc(msg) {
       ready.resolve(msg);
     },
   });
-  const { wss: wssPort, proxy: proxyPort } = await ready.promise;
+  const { wss: wssPort, proxy: proxyPort } = await Promise.race([
+    ready.promise,
+    child.exited.then(code => Promise.reject(new Error(`server fixture exited before sending ports (code ${code})`))),
+  ]);
   const wssUrl = `wss://localhost:${wssPort}/`;
   const proxyUrl = `http://127.0.0.1:${proxyPort}`;
 

--- a/test/js/web/websocket/wss-proxy-tunnel-leak.test.ts
+++ b/test/js/web/websocket/wss-proxy-tunnel-leak.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression test for the wss://-through-HTTP-proxy tunnel leak in
+ * WebSocketProxyTunnel.zig: shutdown() only sent TLS close_notify and never
+ * closed the underlying socket, so the upgrade client's handleClose never
+ * fired, proxy.deinit never ran, and the tunnel + per-connection SSL_CTX +
+ * upgrade client all leaked (~2.5MB per connection). After the fix the socket
+ * closes on shutdown and the tunnel reaches refcount=0.
+ */
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug } from "harness";
+import { join } from "node:path";
+
+test(
+  "wss-via-http-proxy upgrade does not leak the HTTPClient",
+  async () => {
+    const ITER = isDebug ? 200 : 500;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", join(import.meta.dirname, "wss-proxy-tunnel-leak-fixture.ts")],
+      env: { ...bunEnv, LEAK_ITER: String(ITER), LEAK_WARMUP: "60" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const { baseline, after, growth, iter } = JSON.parse(stdout.trim());
+    expect(iter).toBe(ITER);
+
+    // Without the fix, the upgrade client + tunnel + SSLWrapper never free
+    // and growth is ~2.5MB/iter. With the fix the tunnel reaches refcount=0;
+    // a residual ~1MB/iter remains (per-connection SSL_CTX cost — separate
+    // from this leak). Threshold sits between the two so the test fails
+    // before the fix and passes after.
+    const threshold = iter * 1536 * 1024;
+    if (growth >= threshold) {
+      throw new Error(
+        `RSS grew ${growth} bytes (${(growth / iter).toFixed(0)} B/iter) over ${iter} wss-via-proxy upgrades ` +
+          `(baseline=${baseline}, after=${after}, threshold=${threshold})`,
+      );
+    }
+  },
+  isDebug ? 120_000 : 60_000,
+);

--- a/test/js/web/websocket/wss-proxy-tunnel-leak.test.ts
+++ b/test/js/web/websocket/wss-proxy-tunnel-leak.test.ts
@@ -23,10 +23,13 @@ test(
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
-
-    const { baseline, after, growth, iter } = JSON.parse(stdout.trim());
+    let parsed: { baseline: number; after: number; growth: number; iter: number };
+    try {
+      parsed = JSON.parse(stdout.trim());
+    } catch {
+      throw new Error(`fixture did not emit JSON (exit ${exitCode}): stdout=${stdout} stderr=${stderr}`);
+    }
+    const { baseline, after, growth, iter } = parsed;
     expect(iter).toBe(ITER);
 
     // Without the fix, the upgrade client + tunnel + SSLWrapper never free
@@ -41,6 +44,7 @@ test(
           `(baseline=${baseline}, after=${after}, threshold=${threshold})`,
       );
     }
+    expect(exitCode).toBe(0);
   },
   isDebug ? 120_000 : 60_000,
 );


### PR DESCRIPTION
Two bugs:
1. `maxSessionMemory` was only checked on the client `request()` path, never on server-side `handleReceivedStreamID`.
2. The comparison used floored MB so 2MB usage vs 1MB limit compared as `1>1==false`.

Now compares in bytes and rejects new server streams with `ENHANCE_YOUR_CALM` per RFC 9113 §5.1.2 when the limit is exceeded.

Ports `test/sequential/test-http2-max-session-memory.js` from Node.js.