### PR TITLE
fix(http2): make Http2Stream.priority() a no-op with DEP0194 per RFC 9113

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -57,6 +57,16 @@ const { SafeArrayIterator, SafeSet } = require("internal/primordials");
 const { promisify } = require("internal/promisify");
 
 const RegExpPrototypeExec = RegExp.prototype.exec;
+let priorityDeprecationWarned = false;
+function emitPriorityDeprecation() {
+  if (priorityDeprecationWarned) return;
+  priorityDeprecationWarned = true;
+  process.emitWarning(
+    "http2Stream.priority is longer supported after priority signalling was deprecated in RFC 9113",
+    "DeprecationWarning",
+    "DEP0194",
+  );
+}
 const ObjectAssign = Object.assign;
 const ArrayIsArray = Array.isArray;
 const ObjectKeys = Object.keys;
@@ -2076,13 +2086,11 @@ class Http2Stream extends Duplex {
     return constants.NGHTTP2_STREAM_STATE_CLOSED;
   }
 
-  priority(options) {
-    if (!options) return false;
-    if (options.silent) return false;
-    const session = this[bunHTTP2Session];
-    assertSession(session);
-
-    session[bunHTTP2Native]?.setStreamPriority(this.#id, options);
+  priority(_options) {
+    emitPriorityDeprecation();
+    if (this.destroyed || this[bunHTTP2Session]?.destroyed) {
+      throw $ERR_HTTP2_INVALID_STREAM();
+    }
   }
 
   get endAfterHeaders() {

--- a/test/js/node/test/parallel/test-http2-priority-event.js
+++ b/test/js/node/test/parallel/test-http2-priority-event.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const h2 = require('http2');
+
+common.expectWarning(
+  'DeprecationWarning',
+  'http2Stream.priority is longer supported after priority signalling was deprecated in RFC 9113',
+  'DEP0194');
+
+const server = h2.createServer();
+
+// We use the lower-level API here
+server.on('stream', common.mustCall(onStream));
+
+function onStream(stream, headers, flags) {
+  stream.priority({
+    parent: 0,
+    weight: 1,
+    exclusive: false
+  });
+  stream.respond({
+    'content-type': 'text/html',
+    ':status': 200
+  });
+  stream.end('hello world');
+}
+
+server.listen(0);
+
+server.on('priority', common.mustNotCall());
+
+server.on('listening', common.mustCall(() => {
+
+  const client = h2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request({ ':path': '/' });
+
+  client.on('connect', () => {
+    req.priority({
+      parent: 0,
+      weight: 1,
+      exclusive: false
+    });
+  });
+
+  // The priority event is not supported anymore by nghttp2
+  // since 1.65.0.
+  req.on('priority', common.mustNotCall());
+
+  req.on('response', common.mustCall());
+  req.resume();
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.close();
+  }));
+  req.end();
+
+}));


### PR DESCRIPTION
RFC 9113 §5.3 deprecates priority signalling. Node's `Http2Stream.prototype.priority` now only emits DEP0194 and throws `ERR_HTTP2_INVALID_STREAM` if destroyed (lib/internal/http2/core.js:2526). Bun was calling native `setStreamPriority` which threw 'Invalid stream id' for streams not yet assigned an ID.

Ports Node's `test/parallel/test-http2-priority-event.js`.