### PR TITLE
fix(http2): add util.inspect.custom to Http2Stream

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -27,7 +27,7 @@
  * Modifications were made to the original code.
  */
 const { isTypedArray } = require("node:util/types");
-const { format: utilFormat } = require("node:util");
+const { inspect: utilInspect } = require("node:util");
 const kInspect = Symbol.for("nodejs.util.inspect.custom");
 const { hideFromStack, throwNotImplemented } = require("internal/shared");
 const { STATUS_CODES } = require("internal/http");
@@ -2088,7 +2088,7 @@ class Http2Stream extends Duplex {
       readableState: this._readableState,
       writableState: this._writableState,
     };
-    return `Http2Stream ${utilFormat(obj)}`;
+    return `Http2Stream ${utilInspect(obj, opts)}`;
   }
 
   priority(options) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -27,6 +27,8 @@
  * Modifications were made to the original code.
  */
 const { isTypedArray } = require("node:util/types");
+const { format: utilFormat } = require("node:util");
+const kInspect = Symbol.for("nodejs.util.inspect.custom");
 const { hideFromStack, throwNotImplemented } = require("internal/shared");
 const { STATUS_CODES } = require("internal/http");
 const tls = require("node:tls");
@@ -2074,6 +2076,19 @@ class Http2Stream extends Duplex {
       return session[bunHTTP2Native]?.getStreamState(this.#id);
     }
     return constants.NGHTTP2_STREAM_STATE_CLOSED;
+  }
+
+  [kInspect](depth, opts) {
+    if (typeof depth === "number" && depth < 0) return this;
+    const obj = {
+      id: this.#id || "<pending>",
+      closed: this.closed,
+      destroyed: this.destroyed,
+      state: this.state,
+      readableState: this._readableState,
+      writableState: this._writableState,
+    };
+    return `Http2Stream ${utilFormat(obj)}`;
   }
 
   priority(options) {

--- a/test/js/node/test/parallel/test-http2-stream-client.js
+++ b/test/js/node/test/parallel/test-http2-stream-client.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+const util = require('util');
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream) => {
+  assert.strictEqual(stream.aborted, false);
+  const insp = util.inspect(stream);
+  assert.match(insp, /Http2Stream {/);
+  assert.match(insp, / {2}state:/);
+  assert.match(insp, / {2}readableState:/);
+  assert.match(insp, / {2}writableState:/);
+  stream.end('ok');
+}));
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request();
+  req.resume();
+  req.on('close', common.mustCall(() => {
+    client.close();
+    server.close();
+  }));
+}));


### PR DESCRIPTION
Node's Http2Stream defines `[util.inspect.custom]` returning `Http2Stream {id, closed, destroyed, state, readableState, writableState}` (lib/internal/http2/core.js:2113). Bun showed raw Duplex internals.

Ports Node's `test/parallel/test-http2-stream-client.js`.