### PR TITLE
fix(http2): guard ref/unref when socket is generic Duplex

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3151,7 +3151,8 @@ class ServerHttp2Session extends Http2Session {
     if (socket && typeof socket.ref === "function") return socket.ref();
   }
   setTimeout(msecs, callback) {
-    return this[bunHTTP2Socket]?.setTimeout(msecs, callback);
+    const socket = this[bunHTTP2Socket];
+    if (socket && typeof socket.setTimeout === "function") return socket.setTimeout(msecs, callback);
   }
 
   ping(payload, callback) {
@@ -3594,7 +3595,8 @@ class ClientHttp2Session extends Http2Session {
     this.#parser?.setNextStreamID(id);
   }
   setTimeout(msecs, callback) {
-    return this[bunHTTP2Socket]?.setTimeout(msecs, callback);
+    const socket = this[bunHTTP2Socket];
+    if (socket && typeof socket.setTimeout === "function") return socket.setTimeout(msecs, callback);
   }
   ping(payload, callback) {
     if (typeof payload === "function") {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3143,10 +3143,12 @@ class ServerHttp2Session extends Http2Session {
   }
 
   unref() {
-    return this[bunHTTP2Socket]?.unref();
+    const socket = this[bunHTTP2Socket];
+    if (socket && typeof socket.unref === "function") return socket.unref();
   }
   ref() {
-    return this[bunHTTP2Socket]?.ref();
+    const socket = this[bunHTTP2Socket];
+    if (socket && typeof socket.ref === "function") return socket.ref();
   }
   setTimeout(msecs, callback) {
     return this[bunHTTP2Socket]?.setTimeout(msecs, callback);
@@ -3577,10 +3579,12 @@ class ClientHttp2Session extends Http2Session {
     return 1;
   }
   unref() {
-    return this[bunHTTP2Socket]?.unref();
+    const socket = this[bunHTTP2Socket];
+    if (socket && typeof socket.unref === "function") return socket.unref();
   }
   ref() {
-    return this[bunHTTP2Socket]?.ref();
+    const socket = this[bunHTTP2Socket];
+    if (socket && typeof socket.ref === "function") return socket.ref();
   }
   setNextStreamID(id) {
     if (this.destroyed) throw $ERR_HTTP2_INVALID_SESSION();

--- a/test/js/node/test/parallel/test-http2-session-unref.js
+++ b/test/js/node/test/parallel/test-http2-session-unref.js
@@ -1,0 +1,58 @@
+'use strict';
+// Tests that calling unref() on Http2Session:
+// (1) Prevents it from keeping the process alive
+// (2) Doesn't crash
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+const Countdown = require('../common/countdown');
+const { duplexPair } = require('stream');
+
+const server = http2.createServer();
+const [ clientSide, serverSide ] = duplexPair();
+
+const counter = new Countdown(3, () => server.unref());
+
+// 'session' event should be emitted 3 times:
+// - the vanilla client
+// - the destroyed client
+// - manual 'connection' event emission with generic Duplex stream
+server.on('session', common.mustCallAtLeast((session) => {
+  counter.dec();
+  session.unref();
+}, 3));
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+
+  // unref new client
+  {
+    const client = http2.connect(`http://localhost:${port}`);
+    client.unref();
+  }
+
+  // Unref destroyed client
+  {
+    const client = http2.connect(`http://localhost:${port}`);
+
+    client.on('connect', common.mustCall(() => {
+      client.destroy();
+      client.unref();
+    }));
+  }
+
+  // Unref destroyed client
+  {
+    const client = http2.connect(`http://localhost:${port}`, {
+      createConnection: common.mustCall(() => clientSide)
+    });
+
+    client.on('connect', common.mustCall(() => {
+      client.destroy();
+      client.unref();
+    }));
+  }
+}));
+server.emit('connection', serverSide);


### PR DESCRIPTION
session.ref()/unref() forwarded to socket.unref() unconditionally. When the socket is a generic Duplex (e.g. server.emit('connection', duplexPair)), these don't exist and threw. Now check typeof, matching Node.

Ports Node's `test/parallel/test-http2-session-unref.js`.