### PR TITLE
fix(http2): don't emit 'error' for RST_STREAM with NO_ERROR/CANCEL

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2669,10 +2669,17 @@ function emitStreamErrorNT(self, stream, error, destroy, destroy_self) {
   if (stream) {
     let error_instance: Error | number | undefined = undefined;
     if (typeof error === "number") {
-      stream.rstCode = error;
-      // RFC 9113 §8.1: NO_ERROR and CANCEL are non-error closures.
-      if (error !== NGHTTP2_NO_ERROR && error !== NGHTTP2_CANCEL && stream.listenerCount("error") > 0) {
-        error_instance = streamErrorFromCode(error);
+      // RFC 9113 §8.1: NO_ERROR and CANCEL are non-error closures. For those we
+      // always record rstCode so it is observable from 'close'. For real error
+      // codes we only record rstCode (and build an Error) when an 'error'
+      // listener exists; otherwise _destroy would synthesize an unhandled
+      // ERR_HTTP2_STREAM_ERROR and crash the process.
+      const isErrorCode = error !== NGHTTP2_NO_ERROR && error !== NGHTTP2_CANCEL;
+      if (!isErrorCode || stream.listenerCount("error") > 0) {
+        stream.rstCode = error;
+        if (isErrorCode) {
+          error_instance = streamErrorFromCode(error);
+        }
       }
     } else if (stream.listenerCount("error") > 0) {
       error_instance = error;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2668,15 +2668,14 @@ function emitConnectNT(self, socket) {
 function emitStreamErrorNT(self, stream, error, destroy, destroy_self) {
   if (stream) {
     let error_instance: Error | number | undefined = undefined;
-    if (stream.listenerCount("error") > 0) {
-      if (typeof error === "number") {
-        stream.rstCode = error;
-        if (error != 0) {
-          error_instance = streamErrorFromCode(error);
-        }
-      } else {
-        error_instance = error;
+    if (typeof error === "number") {
+      stream.rstCode = error;
+      // RFC 9113 §8.1: NO_ERROR and CANCEL are non-error closures.
+      if (error !== NGHTTP2_NO_ERROR && error !== NGHTTP2_CANCEL && stream.listenerCount("error") > 0) {
+        error_instance = streamErrorFromCode(error);
       }
+    } else if (stream.listenerCount("error") > 0) {
+      error_instance = error;
     }
     if (stream.readable) {
       stream.resume(); // we have a error we consume and close

--- a/test/js/node/test/parallel/test-http2-server-rst-stream.js
+++ b/test/js/node/test/parallel/test-http2-server-rst-stream.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+const Countdown = require('../common/countdown');
+
+const {
+  NGHTTP2_CANCEL,
+  NGHTTP2_NO_ERROR,
+  NGHTTP2_PROTOCOL_ERROR,
+  NGHTTP2_REFUSED_STREAM,
+  NGHTTP2_INTERNAL_ERROR
+} = http2.constants;
+
+const tests = [
+  [NGHTTP2_NO_ERROR, false],
+  [NGHTTP2_NO_ERROR, false],
+  [NGHTTP2_PROTOCOL_ERROR, true, 'NGHTTP2_PROTOCOL_ERROR'],
+  [NGHTTP2_CANCEL, false],
+  [NGHTTP2_REFUSED_STREAM, true, 'NGHTTP2_REFUSED_STREAM'],
+  [NGHTTP2_INTERNAL_ERROR, true, 'NGHTTP2_INTERNAL_ERROR'],
+];
+
+const server = http2.createServer();
+server.on('stream', (stream, headers) => {
+  const test = tests.find((t) => t[0] === Number(headers.rstcode));
+  if (test[1]) {
+    stream.on('error', common.expectsError({
+      name: 'Error',
+      code: 'ERR_HTTP2_STREAM_ERROR',
+      message: `Stream closed with error code ${test[2]}`
+    }));
+  }
+  stream.close(headers.rstcode | 0);
+});
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+
+  const countdown = new Countdown(tests.length, () => {
+    client.close();
+    server.close();
+  });
+
+  tests.forEach((test) => {
+    const req = client.request({
+      ':method': 'POST',
+      'rstcode': test[0]
+    });
+    req.on('close', common.mustCall(() => {
+      assert.strictEqual(req.rstCode, test[0]);
+      countdown.dec();
+    }));
+    req.on('aborted', common.mustCall());
+    if (test[1])
+      req.on('error', common.mustCall());
+    else
+      req.on('error', common.mustNotCall());
+  });
+}));


### PR DESCRIPTION
RFC 9113 §8.1: NO_ERROR(0) and CANCEL(8) are non-error stream closures. Node.js emits 'aborted' + 'close' for these but NOT 'error'. Bun's emitStreamErrorNT generated ERR_HTTP2_STREAM_ERROR for any non-zero code. Now skips it for NO_ERROR and CANCEL while still setting rstCode (now also set when no 'error' listener is attached).

Ports Node's `test/parallel/test-http2-server-rst-stream.js`.