### PR TITLE
fix(http2): validate setTimeout callback and bind session timeout listener correctly

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3149,7 +3149,13 @@ class ServerHttp2Session extends Http2Session {
     return this[bunHTTP2Socket]?.ref();
   }
   setTimeout(msecs, callback) {
-    return this[bunHTTP2Socket]?.setTimeout(msecs, callback);
+    const socket = this[bunHTTP2Socket];
+    if (socket && typeof socket.setTimeout === "function") socket.setTimeout(msecs);
+    if (callback !== undefined) {
+      validateFunction(callback, "callback");
+      this.once("timeout", callback);
+    }
+    return this;
   }
 
   ping(payload, callback) {
@@ -3590,7 +3596,13 @@ class ClientHttp2Session extends Http2Session {
     this.#parser?.setNextStreamID(id);
   }
   setTimeout(msecs, callback) {
-    return this[bunHTTP2Socket]?.setTimeout(msecs, callback);
+    const socket = this[bunHTTP2Socket];
+    if (socket && typeof socket.setTimeout === "function") socket.setTimeout(msecs);
+    if (callback !== undefined) {
+      validateFunction(callback, "callback");
+      this.once("timeout", callback);
+    }
+    return this;
   }
   ping(payload, callback) {
     if (typeof payload === "function") {
@@ -4062,7 +4074,8 @@ class Http2Server extends net.Server {
   }
   setTimeout(ms, callback) {
     this.timeout = ms;
-    if (typeof callback === "function") {
+    if (callback !== undefined) {
+      validateFunction(callback, "callback");
       this.on("timeout", callback);
     }
     return this;
@@ -4168,7 +4181,8 @@ class Http2SecureServer extends tls.Server {
   }
   setTimeout(ms, callback) {
     this.timeout = ms;
-    if (typeof callback === "function") {
+    if (callback !== undefined) {
+      validateFunction(callback, "callback");
       this.on("timeout", callback);
     }
     return this;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3149,10 +3149,13 @@ class ServerHttp2Session extends Http2Session {
     return this[bunHTTP2Socket]?.ref();
   }
   setTimeout(msecs, callback) {
+    if (this.destroyed) return this;
+    if (callback !== undefined) {
+      validateFunction(callback, "callback");
+    }
     const socket = this[bunHTTP2Socket];
     if (socket && typeof socket.setTimeout === "function") socket.setTimeout(msecs);
     if (callback !== undefined) {
-      validateFunction(callback, "callback");
       this.once("timeout", callback);
     }
     return this;
@@ -3596,10 +3599,13 @@ class ClientHttp2Session extends Http2Session {
     this.#parser?.setNextStreamID(id);
   }
   setTimeout(msecs, callback) {
+    if (this.destroyed) return this;
+    if (callback !== undefined) {
+      validateFunction(callback, "callback");
+    }
     const socket = this[bunHTTP2Socket];
     if (socket && typeof socket.setTimeout === "function") socket.setTimeout(msecs);
     if (callback !== undefined) {
-      validateFunction(callback, "callback");
       this.once("timeout", callback);
     }
     return this;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4073,9 +4073,11 @@ class Http2Server extends net.Server {
     return super.emit(event, ...args);
   }
   setTimeout(ms, callback) {
-    this.timeout = ms;
     if (callback !== undefined) {
       validateFunction(callback, "callback");
+    }
+    this.timeout = ms;
+    if (callback !== undefined) {
       this.on("timeout", callback);
     }
     return this;
@@ -4180,9 +4182,11 @@ class Http2SecureServer extends tls.Server {
     return super.emit(event, ...args);
   }
   setTimeout(ms, callback) {
-    this.timeout = ms;
     if (callback !== undefined) {
       validateFunction(callback, "callback");
+    }
+    this.timeout = ms;
+    if (callback !== undefined) {
       this.on("timeout", callback);
     }
     return this;

--- a/test/js/node/test/parallel/test-http2-server-settimeout-no-callback.js
+++ b/test/js/node/test/parallel/test-http2-server-settimeout-no-callback.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const http2 = require('http2');
+
+// Verify that setTimeout callback verifications work correctly
+const verifyCallbacks = common.mustCall((server) => {
+  const testTimeout = 10;
+
+  [true, 1, {}, [], null, 'test'].forEach((notFunction) => {
+    assert.throws(
+      () => server.setTimeout(testTimeout, notFunction),
+      {
+        name: 'TypeError',
+        code: 'ERR_INVALID_ARG_TYPE',
+      }
+    );
+  });
+
+  // No callback
+  const returnedVal = server.setTimeout(testTimeout);
+  assert.strictEqual(returnedVal.timeout, testTimeout);
+}, 2);
+
+// Test with server
+{
+  const server = http2.createServer();
+  verifyCallbacks(server);
+}
+
+// Test with secure server
+{
+  const secureServer = http2.createSecureServer({});
+  verifyCallbacks(secureServer);
+}

--- a/test/js/node/test/parallel/test-http2-server-timeout.js
+++ b/test/js/node/test/parallel/test-http2-server-timeout.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+
+function testServerTimeout(setTimeoutFn) {
+  const server = http2.createServer();
+  setTimeoutFn(server);
+
+  const onServerTimeout = common.mustCall((session) => {
+    session.close();
+  });
+
+  server.on('stream', common.mustNotCall());
+  server.once('timeout', onServerTimeout);
+
+  server.listen(0, common.mustCall(() => {
+    const url = `http://localhost:${server.address().port}`;
+    const client = http2.connect(url);
+    client.on('close', common.mustCall(() => {
+      const client2 = http2.connect(url);
+      client2.on('close', common.mustCall(() => server.close()));
+    }));
+  }));
+}
+
+const timeout = common.platformTimeout(50);
+testServerTimeout((server) => server.setTimeout(timeout));
+testServerTimeout((server) => server.timeout = timeout);


### PR DESCRIPTION
Two bugs: (1) `Http2Server.setTimeout(ms, cb)` silently ignored non-function callbacks; Node throws `ERR_INVALID_ARG_TYPE`. (2) `Http2Session.setTimeout(ms, cb)` delegated to `socket.setTimeout(ms, cb)`, so the listener was attached to the *socket* and `sessionOnTimeout` ran with `this === socket`, never reaching the server's 'timeout' listener.

Now: server `setTimeout` validates the callback; session `setTimeout` calls `socket.setTimeout(ms)` for the timer only and attaches the callback to the *session* (which already re-emits the socket's 'timeout' via `#onTimeout`). Also guards `typeof socket.setTimeout` for generic Duplex sockets.

Ports Node's `test-http2-server-settimeout-no-callback.js` and `test-http2-server-timeout.js`.