### PR TITLE
fix(http2): defer Http2Stream _write callback so write() returns false at highWaterMark

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2260,7 +2260,13 @@ class Http2Stream extends Duplex {
           }
         }
         const chunk = Buffer.concat(chunks || []);
-        native.writeStream(this.#id, chunk, undefined, false, callback);
+        let invoked = false;
+        const cb = err => {
+          if (invoked) return;
+          invoked = true;
+          process.nextTick(callback, err);
+        };
+        native.writeStream(this.#id, chunk, undefined, false, cb);
         return;
       }
     }
@@ -2273,7 +2279,13 @@ class Http2Stream extends Duplex {
     if (session) {
       const native = session[bunHTTP2Native];
       if (native) {
-        native.writeStream(this.#id, chunk, encoding, false, callback);
+        let invoked = false;
+        const cb = err => {
+          if (invoked) return;
+          invoked = true;
+          process.nextTick(callback, err);
+        };
+        native.writeStream(this.#id, chunk, encoding, false, cb);
         return;
       }
     }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -1958,6 +1958,25 @@ function rstNextTick(id: number, rstCode: number) {
   const session = this as Http2Session;
   session[bunHTTP2Native]?.rstStream(id, rstCode);
 }
+
+// In Node.js, Http2Stream.prototype._write/_writev call writeGeneric/writevGeneric which write
+// through a native WriteWrap; the onwrite callback fires from libuv and is therefore always
+// asynchronous. See:
+// https://github.com/nodejs/node/blob/v22.14.0/lib/internal/http2/core.js#L2143-L2222
+// https://github.com/nodejs/node/blob/v22.14.0/lib/internal/stream_base_commons.js#L146-L163
+// Bun's native.writeStream may invoke the callback synchronously when the socket buffer accepts
+// the data immediately. If onwrite runs synchronously, Writable's writeOrBuffer decrements
+// state.length before computing its return value, so write() never returns false at highWaterMark
+// and 'drain' never fires. Defer to nextTick to match Node.js timing semantics.
+function deferWriteCallback(callback) {
+  let invoked = false;
+  return function (err) {
+    if (invoked) return;
+    invoked = true;
+    process.nextTick(callback, err);
+  };
+}
+
 class Http2Stream extends Duplex {
   #id: number;
   [bunHTTP2Session]: ClientHttp2Session | ServerHttp2Session | null = null;
@@ -2260,13 +2279,7 @@ class Http2Stream extends Duplex {
           }
         }
         const chunk = Buffer.concat(chunks || []);
-        let invoked = false;
-        const cb = err => {
-          if (invoked) return;
-          invoked = true;
-          process.nextTick(callback, err);
-        };
-        native.writeStream(this.#id, chunk, undefined, false, cb);
+        native.writeStream(this.#id, chunk, undefined, false, deferWriteCallback(callback));
         return;
       }
     }
@@ -2279,13 +2292,7 @@ class Http2Stream extends Duplex {
     if (session) {
       const native = session[bunHTTP2Native];
       if (native) {
-        let invoked = false;
-        const cb = err => {
-          if (invoked) return;
-          invoked = true;
-          process.nextTick(callback, err);
-        };
-        native.writeStream(this.#id, chunk, encoding, false, cb);
+        native.writeStream(this.#id, chunk, encoding, false, deferWriteCallback(callback));
         return;
       }
     }

--- a/test/js/node/test/parallel/test-http2-compat-serverresponse-drain.js
+++ b/test/js/node/test/parallel/test-http2-compat-serverresponse-drain.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const h2 = require('http2');
+
+// Check that drain event is passed from Http2Stream
+
+const testString = 'tests';
+
+const server = h2.createServer();
+
+server.on('request', common.mustCall((req, res) => {
+  res.stream._writableState.highWaterMark = testString.length;
+  assert.strictEqual(res.write(testString), false);
+  res.on('drain', common.mustCall(() => res.end(testString)));
+}));
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+
+  const client = h2.connect(`http://localhost:${port}`);
+  const request = client.request({
+    ':path': '/foobar',
+    ':method': 'POST',
+    ':scheme': 'http',
+    ':authority': `localhost:${port}`
+  });
+  request.resume();
+  request.end();
+
+  let data = '';
+  request.setEncoding('utf8');
+  request.on('data', (chunk) => (data += chunk));
+
+  request.on('end', common.mustCall(function() {
+    assert.strictEqual(data, testString.repeat(2));
+    client.close();
+    server.close();
+  }));
+}));


### PR DESCRIPTION
`native.writeStream()` invokes its callback synchronously, so Duplex's `writableLength` is decremented before `write()` computes its return value — `write()` always returned `true` and `'drain'` never fired.

Wrap the callback in `process.nextTick` (with a re-entrancy guard) in `_write` and `_writev` so the chunk stays counted in `writableLength` for the synchronous `write()` call. Also fixes `Http2ServerResponse.writableLength`.

Ports Node's `test/parallel/test-http2-compat-serverresponse-drain.js`.