### PR TITLE
ci: fail loudly when artifact download times out

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1972,11 +1972,17 @@ async function getExecPathFromBuildKite(target, buildId) {
       args.push("--build", buildId);
     }
 
-    await spawnSafe({
+    const { error } = await spawnSafe({
       command: "buildkite-agent",
       args,
-      timeout: 60000,
+      timeout: 120000,
     });
+    if (error === "timeout") {
+      throw new Error(
+        `buildkite-agent artifact download timed out after 120s for step '${target}'. ` +
+          `Refusing to continue with a partial download (would silently fall back to the wrong binary).`,
+      );
+    }
 
     zipPath = readdirSync(releasePath, { recursive: true, encoding: "utf-8" })
       .filter(filename => /^bun.*\.zip$/i.test(filename))


### PR DESCRIPTION
`getExecPathFromBuildKite` runs `buildkite-agent artifact download` via `spawnSafe` with a 60 s timeout. On timeout `spawnSafe` kills the process and returns `{ error: "timeout" }` — it doesn't throw — and the caller doesn't check it. The loop then picks whichever `bun*.zip` made it to disk and continues.

On a slow win-aarch64 VM (build #44517, 38 MiB in 52 s) the 149 MiB `*-profile.zip` never finished, so the runner silently fell back to the release `bun.exe` instead of `bun-profile.exe`. That in turn made `which.test.ts` fail because `basename(process.execPath)` became `"bun.exe"`, which `bootstrap.ps1` bakes into `C:\Windows\System32\` on the v14 image.

Bump the timeout to 120 s and throw if it's hit so the job fails with a clear message instead of running the wrong binary.