### PR TITLE
fix(http2): default stream weight to 16 per RFC 9113

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -774,7 +774,7 @@ pub const H2FrameParser = struct {
         rstCode: u32 = 0,
         streamDependency: u32 = 0,
         exclusive: bool = false,
-        weight: u16 = 36,
+        weight: u16 = 16,
         // current window size for the stream
         windowSize: u64 = 65535,
         // used window size for the stream
@@ -1123,7 +1123,7 @@ pub const H2FrameParser = struct {
                 .windowSize = initialWindowSize,
                 .remoteWindowSize = remoteWindowSize,
                 .usedWindowSize = 0,
-                .weight = 36,
+                .weight = 16,
                 .dataFrameQueue = .{},
                 .paddingStrategy = paddingStrategy,
             };

--- a/test/js/node/http2/h2-compat.test.ts
+++ b/test/js/node/http2/h2-compat.test.ts
@@ -30,6 +30,6 @@ test("Http2Stream.state.weight defaults to 16 per RFC 9113", async () => {
   } finally {
     client.close();
     server.close();
-    await once(server, "close");
+    await once(server, "close").catch(() => {});
   }
 });

--- a/test/js/node/http2/h2-compat.test.ts
+++ b/test/js/node/http2/h2-compat.test.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "bun:test";
+import http2 from "node:http2";
+import { once } from "node:events";
+
+test("Http2Stream.state.weight defaults to 16 per RFC 9113", async () => {
+  const server = http2.createServer();
+  const { promise, resolve } = Promise.withResolvers<number>();
+  server.on("stream", stream => {
+    resolve(stream.state.weight);
+    stream.respond({ ":status": 200 });
+    stream.end();
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const client = http2.connect(`http://127.0.0.1:${(server.address() as any).port}`);
+  const req = client.request({ ":path": "/" });
+  req.resume();
+  req.end();
+  const weight = await promise;
+  expect(weight).toBe(16);
+  await once(req, "close");
+  client.close();
+  server.close();
+  await once(server, "close");
+});

--- a/test/js/node/http2/h2-compat.test.ts
+++ b/test/js/node/http2/h2-compat.test.ts
@@ -4,22 +4,32 @@ import http2 from "node:http2";
 
 test("Http2Stream.state.weight defaults to 16 per RFC 9113", async () => {
   const server = http2.createServer();
-  const { promise, resolve } = Promise.withResolvers<number>();
+  const { promise, resolve, reject } = Promise.withResolvers<number>();
   server.on("stream", stream => {
-    resolve(stream.state.weight);
+    try {
+      resolve(stream.state.weight);
+    } catch (e) {
+      reject(e);
+    }
     stream.respond({ ":status": 200 });
     stream.end();
   });
+  server.on("error", reject);
   server.listen(0);
   await once(server, "listening");
   const client = http2.connect(`http://127.0.0.1:${(server.address() as any).port}`);
-  const req = client.request({ ":path": "/" });
-  req.resume();
-  req.end();
-  const weight = await promise;
-  expect(weight).toBe(16);
-  await once(req, "close");
-  client.close();
-  server.close();
-  await once(server, "close");
+  client.on("error", reject);
+  try {
+    const req = client.request({ ":path": "/" });
+    req.on("error", reject);
+    req.resume();
+    req.end();
+    const weight = await promise;
+    expect(weight).toBe(16);
+    await once(req, "close");
+  } finally {
+    client.close();
+    server.close();
+    await once(server, "close");
+  }
 });

--- a/test/js/node/http2/h2-compat.test.ts
+++ b/test/js/node/http2/h2-compat.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "bun:test";
-import http2 from "node:http2";
+import { expect, test } from "bun:test";
 import { once } from "node:events";
+import http2 from "node:http2";
 
 test("Http2Stream.state.weight defaults to 16 per RFC 9113", async () => {
   const server = http2.createServer();


### PR DESCRIPTION
RFC 9113 §5.3.5 default weight is 16 (RFC 7540 carryover). Bun used 36 with no spec basis. Node's `stream.state.weight` returns 16.

Node's `test-http2-client-set-priority.js` is blocked on a separate stream-end ordering bug; included a focused regression test instead.