### PR TITLE
fix(http2): honor maxSettings option per RFC 9113 §6.5

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -2423,18 +2423,23 @@ pub const H2FrameParser = struct {
             this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Settings frame on connection stream", this.lastStreamID, true);
             return data.len;
         }
-        defer if (!isACK) this.sendSettingsACK();
+        // RFC 9113 §6.5: a SETTINGS_ACK confirms the settings were received
+        // and applied, so it must only be sent once the frame is accepted.
+        var needs_ack = !isACK;
+        defer if (needs_ack) this.sendSettingsACK();
 
         const settingByteSize = SettingsPayloadUnit.byteSize;
         if (frame.length > 0) {
             if (isACK or frame.length % settingByteSize != 0) {
                 log("invalid settings frame size", .{});
+                needs_ack = false;
                 this.sendGoAway(frame.streamIdentifier, ErrorCode.FRAME_SIZE_ERROR, "Invalid settings frame size", this.lastStreamID, true);
                 return data.len;
             }
             const entry_count: u32 = @intCast(@divTrunc(frame.length, settingByteSize));
             if (entry_count > this.maxSettings) {
                 log("settings frame exceeds maxSettings ({} > {})", .{ entry_count, this.maxSettings });
+                needs_ack = false;
                 this.sendGoAway(frame.streamIdentifier, ErrorCode.ENHANCE_YOUR_CALM, "SETTINGS frame exceeded maxSettings", this.lastStreamID, true);
                 return data.len;
             }

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -667,6 +667,9 @@ pub const H2FrameParser = struct {
     maxHeaderListPairs: u32 = 128,
     maxRejectedStreams: u32 = 100,
     maxOutstandingSettings: u32 = 10,
+    /// RFC 9113 §6.5: limits the number of settings entries accepted in a
+    /// single received SETTINGS frame. Node.js defaults to 32.
+    maxSettings: u32 = 32,
     outstandingSettings: u32 = 0,
     rejectedStreams: u32 = 0,
     maxSessionMemory: u32 = 10, //this limit is in MB
@@ -2427,6 +2430,12 @@ pub const H2FrameParser = struct {
             if (isACK or frame.length % settingByteSize != 0) {
                 log("invalid settings frame size", .{});
                 this.sendGoAway(frame.streamIdentifier, ErrorCode.FRAME_SIZE_ERROR, "Invalid settings frame size", this.lastStreamID, true);
+                return data.len;
+            }
+            const entry_count: u32 = @intCast(@divTrunc(frame.length, settingByteSize));
+            if (entry_count > this.maxSettings) {
+                log("settings frame exceeds maxSettings ({} > {})", .{ entry_count, this.maxSettings });
+                this.sendGoAway(frame.streamIdentifier, ErrorCode.ENHANCE_YOUR_CALM, "SETTINGS frame exceeded maxSettings", this.lastStreamID, true);
                 return data.len;
             }
         } else {
@@ -4718,6 +4727,11 @@ pub const H2FrameParser = struct {
                 if (try settings_js.get(globalObject, "maxOutstandingSettings")) |max_outstanding_settings| {
                     if (max_outstanding_settings.isNumber()) {
                         this.maxOutstandingSettings = @max(1, @as(u32, @truncate(max_outstanding_settings.to(u64))));
+                    }
+                }
+                if (try settings_js.get(globalObject, "maxSettings")) |max_settings| {
+                    if (max_settings.isNumber()) {
+                        this.maxSettings = @max(1, @as(u32, @truncate(max_settings.to(u64))));
                     }
                 }
                 if (try settings_js.get(globalObject, "maxSendHeaderBlockLength")) |max_send_header_block_length| {

--- a/test/js/node/test/parallel/test-http2-max-settings.js
+++ b/test/js/node/test/parallel/test-http2-max-settings.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const http2 = require('http2');
+
+const server = http2.createServer({ maxSettings: 1 });
+
+// TODO(@jasnell): There is still a session event
+// emitted on the server side but it will be destroyed
+// immediately after creation and there will be no
+// stream created.
+server.on('session', common.mustCall((session) => {
+  session.on('stream', common.mustNotCall());
+  session.on('remoteSettings', common.mustNotCall());
+}, 2));
+server.on('stream', common.mustNotCall());
+
+server.listen(0, common.mustCall(() => {
+  // Specify two settings entries when a max of 1 is allowed.
+  // Connection should error immediately.
+  const client = http2.connect(
+    `http://localhost:${server.address().port}`, {
+      settings: {
+        // The actual settings values do not matter.
+        headerTableSize: 1000,
+        enablePush: false,
+      },
+    });
+
+  client.on('error', common.mustCall((err) => {
+    // The same but with custom settings
+    const client2 = http2.connect(
+      `http://localhost:${server.address().port}`, {
+        settings: {
+        // The actual settings values do not matter.
+          headerTableSize: 1000,
+          customSettings: {
+            0x14: 45
+          }
+        },
+      });
+
+    client2.on('error', common.mustCall(() => {
+      server.close();
+    }));
+  }));
+
+
+}));


### PR DESCRIPTION
Node.js supports `{maxSettings: N}` (default 32) to bound entries in a received SETTINGS frame; exceeding it tears down the session with ENHANCE_YOUR_CALM. Bun ignored the option.

Adds `maxSettings: u32 = 32` field, reads it from JS options, and rejects frames with too many entries before applying any setting.

Ports Node's `test/parallel/test-http2-max-settings.js`.