### PR TITLE
fix(http2): null-guard socket ref in compat proxySocketHandler

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -1164,7 +1164,8 @@ function onServerStream(Http2ServerRequest, Http2ServerResponse, stream, headers
 
 const proxyCompatSocketHandler = {
   has(stream, prop) {
-    const ref = stream.session !== undefined ? stream.session[bunHTTP2Socket] : stream;
+    const session = stream.session;
+    const ref = (session != null ? session[bunHTTP2Socket] : undefined) ?? stream;
     return prop in stream || prop in ref;
   },
 
@@ -1195,15 +1196,17 @@ const proxyCompatSocketHandler = {
       case "resume":
         throw $ERR_HTTP2_NO_SOCKET_MANIPULATION();
       default: {
-        const ref = stream.session !== undefined ? stream.session[bunHTTP2Socket] : stream;
+        const session = stream.session;
+    const ref = (session != null ? session[bunHTTP2Socket] : undefined) ?? stream;
         const value = ref[prop];
         return typeof value === "function" ? value.bind(ref) : value;
       }
     }
   },
   getPrototypeOf(stream) {
-    if (stream.session !== undefined) return ReflectGetPrototypeOf(stream.session[bunHTTP2Socket]);
-    return ReflectGetPrototypeOf(stream);
+    const session = stream.session;
+    const ref = (session != null ? session[bunHTTP2Socket] : undefined) ?? stream;
+    return ReflectGetPrototypeOf(ref);
   },
   set(stream, prop, value) {
     switch (prop) {
@@ -1229,7 +1232,8 @@ const proxyCompatSocketHandler = {
       case "resume":
         throw $ERR_HTTP2_NO_SOCKET_MANIPULATION();
       default: {
-        const ref = stream.session !== undefined ? stream.session[bunHTTP2Socket] : stream;
+        const session = stream.session;
+    const ref = (session != null ? session[bunHTTP2Socket] : undefined) ?? stream;
         ref[prop] = value;
         return true;
       }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -1197,7 +1197,7 @@ const proxyCompatSocketHandler = {
         throw $ERR_HTTP2_NO_SOCKET_MANIPULATION();
       default: {
         const session = stream.session;
-    const ref = (session != null ? session[bunHTTP2Socket] : undefined) ?? stream;
+        const ref = (session != null ? session[bunHTTP2Socket] : undefined) ?? stream;
         const value = ref[prop];
         return typeof value === "function" ? value.bind(ref) : value;
       }
@@ -1233,7 +1233,7 @@ const proxyCompatSocketHandler = {
         throw $ERR_HTTP2_NO_SOCKET_MANIPULATION();
       default: {
         const session = stream.session;
-    const ref = (session != null ? session[bunHTTP2Socket] : undefined) ?? stream;
+        const ref = (session != null ? session[bunHTTP2Socket] : undefined) ?? stream;
         ref[prop] = value;
         return true;
       }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -1165,7 +1165,7 @@ function onServerStream(Http2ServerRequest, Http2ServerResponse, stream, headers
 const proxyCompatSocketHandler = {
   has(stream, prop) {
     const session = stream.session;
-        const ref = (session != null ? session[bunHTTP2Socket] : undefined) ?? stream;
+    const ref = (session != null ? session[bunHTTP2Socket] : undefined) ?? stream;
     return prop in stream || prop in ref;
   },
 
@@ -1205,7 +1205,7 @@ const proxyCompatSocketHandler = {
   },
   getPrototypeOf(stream) {
     const session = stream.session;
-        const ref = (session != null ? session[bunHTTP2Socket] : undefined) ?? stream;
+    const ref = (session != null ? session[bunHTTP2Socket] : undefined) ?? stream;
     return ReflectGetPrototypeOf(ref);
   },
   set(stream, prop, value) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -1165,7 +1165,7 @@ function onServerStream(Http2ServerRequest, Http2ServerResponse, stream, headers
 const proxyCompatSocketHandler = {
   has(stream, prop) {
     const session = stream.session;
-    const ref = (session != null ? session[bunHTTP2Socket] : undefined) ?? stream;
+        const ref = (session != null ? session[bunHTTP2Socket] : undefined) ?? stream;
     return prop in stream || prop in ref;
   },
 
@@ -1187,7 +1187,7 @@ const proxyCompatSocketHandler = {
       }
       case "setTimeout": {
         const session = stream.session;
-        if (session !== undefined) return session.setTimeout.bind(session);
+        if (session != null) return session.setTimeout.bind(session);
         return stream.setTimeout.bind(stream);
       }
       case "write":
@@ -1205,7 +1205,7 @@ const proxyCompatSocketHandler = {
   },
   getPrototypeOf(stream) {
     const session = stream.session;
-    const ref = (session != null ? session[bunHTTP2Socket] : undefined) ?? stream;
+        const ref = (session != null ? session[bunHTTP2Socket] : undefined) ?? stream;
     return ReflectGetPrototypeOf(ref);
   },
   set(stream, prop, value) {
@@ -1222,7 +1222,7 @@ const proxyCompatSocketHandler = {
         return true;
       case "setTimeout": {
         const session = stream.session;
-        if (session !== undefined) session.setTimeout = value;
+        if (session != null) session.setTimeout = value;
         else stream.setTimeout = value;
         return true;
       }

--- a/test/js/node/http2/h2-compat-socket-null.test.ts
+++ b/test/js/node/http2/h2-compat-socket-null.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "bun:test";
-import http2 from "node:http2";
+import { expect, test } from "bun:test";
 import { once } from "node:events";
+import http2 from "node:http2";
 
 test("compat req.socket access after stream finish does not throw", async () => {
   let captured: { bw: unknown; has: boolean; proto: unknown } | undefined;

--- a/test/js/node/http2/h2-compat-socket-null.test.ts
+++ b/test/js/node/http2/h2-compat-socket-null.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "bun:test";
+import http2 from "node:http2";
+import { once } from "node:events";
+
+test("compat req.socket access after stream finish does not throw", async () => {
+  let captured: { bw: unknown; has: boolean; proto: unknown } | undefined;
+  const server = http2.createServer((req, res) => {
+    res.on("finish", () => {
+      captured = {
+        bw: req.socket.bytesWritten,
+        has: "bytesWritten" in req.socket,
+        proto: Object.getPrototypeOf(req.socket),
+      };
+    });
+    res.end("x");
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as any).port;
+  const client = http2.connect("http://127.0.0.1:" + port);
+  const req = client.request({ ":path": "/" });
+  req.resume();
+  await once(req, "close");
+  await new Promise<void>(r => client.close(() => r()));
+  server.close();
+  await once(server, "close");
+  expect(captured).toBeDefined();
+  expect(typeof captured!.has).toBe("boolean");
+  expect(captured!.proto).toBeDefined();
+});

--- a/test/js/node/http2/h2-compat-socket-null.test.ts
+++ b/test/js/node/http2/h2-compat-socket-null.test.ts
@@ -21,7 +21,9 @@ test("compat req.socket access after stream finish does not throw", async () => 
   const req = client.request({ ":path": "/" });
   req.resume();
   await once(req, "close");
-  await new Promise<void>(r => client.close(() => r()));
+  const { promise, resolve } = Promise.withResolvers<void>();
+  client.close(() => resolve());
+  await promise;
   server.close();
   await once(server, "close");
   expect(captured).toBeDefined();


### PR DESCRIPTION
After a stream finishes, `stream.session` may be null; the compat socket proxy then evaluated `null[bunHTTP2Socket]`, throwing `TypeError` on access patterns like `req.socket.bytesWritten`, `'x' in req.socket`, or `Object.getPrototypeOf(req.socket)`.

Fall back to the stream itself when the session or its socket is gone, matching Node's [compat.js kSocket fallback](https://github.com/nodejs/node/blob/main/lib/internal/http2/compat.js).

Prerequisite for porting Node's `test-http2-byteswritten-server.js` (which has a separate bytesWritten-tracking gap).