### PR TITLE
fix(http2): validate CONNECT pseudo-headers per RFC 9113 §8.5

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3856,7 +3856,7 @@ class ClientHttp2Session extends Http2Session {
             headers[":authority"] = authority;
           }
         }
-        if (headers[":scheme"] === undefined) {
+        if (!headers[":scheme"]) {
           let protocol: string = url.protocol || options?.protocol || "https:";
           switch (protocol) {
             case "https:":

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3839,38 +3839,43 @@ class ClientHttp2Session extends Http2Session {
       }
       const url = this.#url;
 
-      let authority = headers[":authority"];
-      if (!authority) {
-        // Use precomputed authority (like Node.js's session[kAuthority])
-        authority = this.#authority;
-        if (!headers["host"]) {
-          headers[":authority"] = authority;
-        }
-      }
       let method = headers[":method"];
       if (!method) {
         method = "GET";
         headers[":method"] = method;
       }
 
-      let scheme = headers[":scheme"];
-      if (!scheme) {
-        let protocol: string = url.protocol || options?.protocol || "https:";
-        switch (protocol) {
-          case "https:":
-            scheme = "https";
-            break;
-          case "http:":
-            scheme = "http";
-            break;
-          default:
-            scheme = protocol;
-        }
-        headers[":scheme"] = scheme;
-      }
+      const isConnect = method === HTTP2_METHOD_CONNECT;
+      let authority = headers[":authority"];
 
-      if (headers[":path"] == undefined) {
-        headers[":path"] = "/";
+      if (!isConnect || headers[":protocol"] !== undefined) {
+        if (!authority) {
+          // Use precomputed authority (like Node.js's session[kAuthority])
+          authority = this.#authority;
+          if (!headers["host"]) {
+            headers[":authority"] = authority;
+          }
+        }
+        if (headers[":scheme"] === undefined) {
+          let protocol: string = url.protocol || options?.protocol || "https:";
+          switch (protocol) {
+            case "https:":
+              headers[":scheme"] = "https";
+              break;
+            case "http:":
+              headers[":scheme"] = "http";
+              break;
+            default:
+              headers[":scheme"] = protocol;
+          }
+        }
+        if (headers[":path"] == undefined) {
+          headers[":path"] = "/";
+        }
+      } else {
+        if (authority === undefined) throw $ERR_HTTP2_CONNECT_AUTHORITY();
+        if (headers[":scheme"] !== undefined) throw $ERR_HTTP2_CONNECT_SCHEME();
+        if (headers[":path"] !== undefined) throw $ERR_HTTP2_CONNECT_PATH();
       }
 
       if (NoPayloadMethods.has(method.toUpperCase())) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3873,7 +3873,7 @@ class ClientHttp2Session extends Http2Session {
           headers[":path"] = "/";
         }
       } else {
-        if (authority === undefined) throw $ERR_HTTP2_CONNECT_AUTHORITY();
+        if (!authority) throw $ERR_HTTP2_CONNECT_AUTHORITY();
         if (headers[":scheme"] !== undefined) throw $ERR_HTTP2_CONNECT_SCHEME();
         if (headers[":path"] !== undefined) throw $ERR_HTTP2_CONNECT_PATH();
       }

--- a/test/js/node/http2/h2-connect-validation.test.ts
+++ b/test/js/node/http2/h2-connect-validation.test.ts
@@ -11,17 +11,22 @@ test("CONNECT method pseudo-header validation per RFC 9113 §8.5", async () => {
   const client = http2.connect("http://127.0.0.1:" + port);
   await once(client, "connect");
 
-  expect(() => client.request({ ":method": "CONNECT" })).toThrow(
-    expect.objectContaining({ code: "ERR_HTTP2_CONNECT_AUTHORITY" }),
-  );
-  expect(() => client.request({ ":method": "CONNECT", ":authority": "example.com:443", ":scheme": "https" })).toThrow(
-    expect.objectContaining({ code: "ERR_HTTP2_CONNECT_SCHEME" }),
-  );
-  expect(() => client.request({ ":method": "CONNECT", ":authority": "example.com:443", ":path": "/" })).toThrow(
-    expect.objectContaining({ code: "ERR_HTTP2_CONNECT_PATH" }),
-  );
-
-  client.destroy();
-  server.close();
-  await once(server, "close");
+  try {
+    expect(() => client.request({ ":method": "CONNECT" })).toThrow(
+      expect.objectContaining({ code: "ERR_HTTP2_CONNECT_AUTHORITY" }),
+    );
+    expect(() => client.request({ ":method": "CONNECT", ":authority": "" })).toThrow(
+      expect.objectContaining({ code: "ERR_HTTP2_CONNECT_AUTHORITY" }),
+    );
+    expect(() => client.request({ ":method": "CONNECT", ":authority": "example.com:443", ":scheme": "https" })).toThrow(
+      expect.objectContaining({ code: "ERR_HTTP2_CONNECT_SCHEME" }),
+    );
+    expect(() => client.request({ ":method": "CONNECT", ":authority": "example.com:443", ":path": "/" })).toThrow(
+      expect.objectContaining({ code: "ERR_HTTP2_CONNECT_PATH" }),
+    );
+  } finally {
+    client.destroy();
+    server.close();
+    await once(server, "close");
+  }
 });

--- a/test/js/node/http2/h2-connect-validation.test.ts
+++ b/test/js/node/http2/h2-connect-validation.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "bun:test";
+import http2 from "node:http2";
+import { once } from "node:events";
+
+test("CONNECT method pseudo-header validation per RFC 9113 §8.5", async () => {
+  const server = http2.createServer();
+  server.on("stream", s => s.close());
+  server.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as any).port;
+  const client = http2.connect("http://127.0.0.1:" + port);
+  await once(client, "connect");
+
+  expect(() => client.request({ ":method": "CONNECT" })).toThrow(
+    expect.objectContaining({ code: "ERR_HTTP2_CONNECT_AUTHORITY" }),
+  );
+  expect(() => client.request({ ":method": "CONNECT", ":authority": "example.com:443", ":scheme": "https" })).toThrow(
+    expect.objectContaining({ code: "ERR_HTTP2_CONNECT_SCHEME" }),
+  );
+  expect(() => client.request({ ":method": "CONNECT", ":authority": "example.com:443", ":path": "/" })).toThrow(
+    expect.objectContaining({ code: "ERR_HTTP2_CONNECT_PATH" }),
+  );
+
+  client.destroy();
+  server.close();
+  await once(server, "close");
+});

--- a/test/js/node/http2/h2-connect-validation.test.ts
+++ b/test/js/node/http2/h2-connect-validation.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "bun:test";
-import http2 from "node:http2";
+import { expect, test } from "bun:test";
 import { once } from "node:events";
+import http2 from "node:http2";
 
 test("CONNECT method pseudo-header validation per RFC 9113 §8.5", async () => {
   const server = http2.createServer();


### PR DESCRIPTION
RFC 9113 §8.5: CONNECT requests MUST include `:authority` and MUST NOT include `:scheme` or `:path` (unless extended CONNECT with `:protocol`). Node throws `ERR_HTTP2_CONNECT_AUTHORITY`/`ERR_HTTP2_CONNECT_SCHEME`/`ERR_HTTP2_CONNECT_PATH` respectively.

Bun's `request()` set defaults for `:authority`/`:scheme`/`:path` before checking the method, so these validations never fired. Now checks method first and skips defaults for plain CONNECT, throwing the appropriate error.

Node's `test-http2-connect-method.js` validation assertions (lines 58-80) now pass; the data-tunneling portion of that test depends on a separate CONNECT proxying gap.