### PR TITLE
fix(http2): preserve AsyncLocalStorage context across client request callbacks

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -1916,9 +1916,28 @@ function assertSession(session) {
 }
 hideFromStack(assertSession);
 
-function emitResponseNT(self, stream, headers, flags, rawheaders) {
-  self.emit("stream", stream, headers, flags, rawheaders);
-  stream.emit("response", headers, flags, rawheaders);
+function emitClientStreamHeaders(self, stream, headers, flags, rawheaders) {
+  const status = stream[bunHTTP2StreamStatus];
+  const header_status = headers[HTTP2_HEADER_STATUS];
+  if (header_status === HTTP_STATUS_CONTINUE) {
+    stream.emit("continue");
+  }
+
+  if ((status & StreamState.StreamResponded) !== 0) {
+    stream.emit("trailers", headers, flags, rawheaders);
+  } else {
+    if (header_status >= 100 && header_status < 200) {
+      stream.emit("headers", headers, flags, rawheaders);
+    } else {
+      stream[bunHTTP2StreamStatus] = status | StreamState.StreamResponded;
+      if (header_status === 421) {
+        // 421 Misdirected Request
+        removeOriginFromSet(self, stream);
+      }
+      self.emit("stream", stream, headers, flags, rawheaders);
+      stream.emit("response", headers, flags, rawheaders);
+    }
+  }
 }
 function pushToStreamInScope(stream, data) {
   const reqAsync = stream[kRequestAsyncResource];
@@ -3379,31 +3398,11 @@ class ClientHttp2Session extends Http2Session {
     ) {
       if (!self || typeof stream !== "object" || stream.rstCode) return;
       const headers = toHeaderObject(rawheaders, sensitiveHeadersValue || []);
-      const status = stream[bunHTTP2StreamStatus];
-      const header_status = headers[HTTP2_HEADER_STATUS];
-      if (header_status === HTTP_STATUS_CONTINUE) {
-        stream.emit("continue");
-      }
-
-      if ((status & StreamState.StreamResponded) !== 0) {
-        stream.emit("trailers", headers, flags, rawheaders);
+      const reqAsync = stream[kRequestAsyncResource];
+      if (reqAsync) {
+        reqAsync.runInAsyncScope(emitClientStreamHeaders, null, self, stream, headers, flags, rawheaders);
       } else {
-        if (header_status >= 100 && header_status < 200) {
-          stream.emit("headers", headers, flags, rawheaders);
-        } else {
-          stream[bunHTTP2StreamStatus] = status | StreamState.StreamResponded;
-          if (header_status === 421) {
-            // 421 Misdirected Request
-            removeOriginFromSet(self, stream);
-          }
-          const reqAsync = stream[kRequestAsyncResource];
-          if (reqAsync) {
-            reqAsync.runInAsyncScope(process.nextTick, null, emitResponseNT, self, stream, headers, flags, rawheaders);
-          } else {
-            self.emit("stream", stream, headers, flags, rawheaders);
-            stream.emit("response", headers, flags, rawheaders);
-          }
-        }
+        emitClientStreamHeaders(self, stream, headers, flags, rawheaders);
       }
     },
     localSettings(self: ClientHttp2Session, settings: Settings) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -1902,7 +1902,6 @@ function streamErrorFromCode(code: number) {
 }
 hideFromStack(streamErrorFromCode);
 function sessionErrorFromCode(code: number) {
-  if (code === -2) return $ERR_HTTP2_TOO_MANY_INVALID_FRAMES("Too many invalid HTTP/2 frames");
   if (code === 0xe) {
     return $ERR_HTTP2_MAX_PENDING_SETTINGS_ACK();
   }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -54,6 +54,8 @@ const Socket = net.Socket;
 const EventEmitter = require("node:events");
 const { Duplex } = Stream;
 const { SafeArrayIterator, SafeSet } = require("internal/primordials");
+const { AsyncResource } = require("node:async_hooks");
+const kRequestAsyncResource = Symbol("kRequestAsyncResource");
 const { promisify } = require("internal/promisify");
 
 const RegExpPrototypeExec = RegExp.prototype.exec;
@@ -1900,6 +1902,7 @@ function streamErrorFromCode(code: number) {
 }
 hideFromStack(streamErrorFromCode);
 function sessionErrorFromCode(code: number) {
+  if (code === -2) return $ERR_HTTP2_TOO_MANY_INVALID_FRAMES("Too many invalid HTTP/2 frames");
   if (code === 0xe) {
     return $ERR_HTTP2_MAX_PENDING_SETTINGS_ACK();
   }
@@ -1914,6 +1917,15 @@ function assertSession(session) {
 }
 hideFromStack(assertSession);
 
+function emitResponseNT(self, stream, headers, flags, rawheaders) {
+  self.emit("stream", stream, headers, flags, rawheaders);
+  stream.emit("response", headers, flags, rawheaders);
+}
+function pushToStreamInScope(stream, data) {
+  const reqAsync = stream[kRequestAsyncResource];
+  if (reqAsync) reqAsync.runInAsyncScope(pushToStream, null, stream, data);
+  else pushToStream(stream, data);
+}
 function pushToStream(stream, data) {
   if (data && stream[bunHTTP2StreamStatus] & StreamState.Closed) {
     if (!stream._readableState.ended) {
@@ -3337,7 +3349,7 @@ class ClientHttp2Session extends Http2Session {
           }
           // Push a null so the stream can end whenever the client consumes
           // it completely.
-          pushToStream(stream, null);
+          pushToStreamInScope(stream, null);
           stream.read(0);
         }
       }
@@ -3357,7 +3369,7 @@ class ClientHttp2Session extends Http2Session {
     },
     streamData(self: ClientHttp2Session, stream: ClientHttp2Stream, data: Buffer) {
       if (!self || typeof stream !== "object" || !data) return;
-      pushToStream(stream, data);
+      pushToStreamInScope(stream, data);
     },
     streamHeaders(
       self: ClientHttp2Session,
@@ -3385,8 +3397,13 @@ class ClientHttp2Session extends Http2Session {
             // 421 Misdirected Request
             removeOriginFromSet(self, stream);
           }
-          self.emit("stream", stream, headers, flags, rawheaders);
-          stream.emit("response", headers, flags, rawheaders);
+          const reqAsync = stream[kRequestAsyncResource];
+          if (reqAsync) {
+            reqAsync.runInAsyncScope(process.nextTick, null, emitResponseNT, self, stream, headers, flags, rawheaders);
+          } else {
+            self.emit("stream", stream, headers, flags, rawheaders);
+            stream.emit("response", headers, flags, rawheaders);
+          }
         }
       }
     },
@@ -3887,6 +3904,7 @@ class ClientHttp2Session extends Http2Session {
         return req;
       }
       const req = new ClientHttp2Stream(stream_id, this, headers);
+      req[kRequestAsyncResource] = new AsyncResource("PendingRequest");
       req.authority = authority;
       req[kHeadRequest] = method === HTTP2_METHOD_HEAD;
       if (typeof options === "undefined") {

--- a/test/js/node/test/parallel/test-http2-async-local-storage.js
+++ b/test/js/node/test/parallel/test-http2-async-local-storage.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+const async_hooks = require('async_hooks');
+
+const storage = new async_hooks.AsyncLocalStorage();
+
+const {
+  HTTP2_HEADER_CONTENT_TYPE,
+  HTTP2_HEADER_PATH,
+  HTTP2_HEADER_STATUS,
+} = http2.constants;
+
+const server = http2.createServer();
+server.on('stream', (stream) => {
+  stream.respond({
+    [HTTP2_HEADER_CONTENT_TYPE]: 'text/plain; charset=utf-8',
+    [HTTP2_HEADER_STATUS]: 200
+  });
+  stream.on('error', common.mustNotCall());
+  stream.end('data');
+});
+
+server.listen(0, common.mustCall(async () => {
+  const client = storage.run({ id: 0 }, () => http2.connect(`http://localhost:${server.address().port}`));
+
+  async function doReq(id) {
+    const req = client.request({ [HTTP2_HEADER_PATH]: '/' });
+
+    req.on('response', common.mustCall((headers) => {
+      assert.strictEqual(headers[HTTP2_HEADER_STATUS], 200);
+      assert.strictEqual(id, storage.getStore().id);
+    }));
+    req.on('data', common.mustCall((data) => {
+      assert.strictEqual(data.toString(), 'data');
+      assert.strictEqual(id, storage.getStore().id);
+    }));
+    req.on('end', common.mustCall(() => {
+      assert.strictEqual(id, storage.getStore().id);
+      server.close();
+      client.close();
+    }));
+  }
+
+  function doReqWith(id) {
+    storage.run({ id }, () => doReq(id));
+  }
+
+  doReqWith(1);
+  doReqWith(2);
+}));


### PR DESCRIPTION
Node captures an `AsyncResource('PendingRequest')` at `client.request()` time and runs the stream's `'response'`/`'data'`/`'end'` emits inside that scope (lib/internal/http2/core.js). Bun's native handler callbacks were bound at `connect()` time, so all stream events ran in the connect-time ALS context, not the per-request one.

Now `request()` captures the resource on the stream and the client-side event handlers wrap emits in `runInAsyncScope`.

Ports Node's `test/parallel/test-http2-async-local-storage.js`.