### PR TITLE
fix(http2): stream.session/state return undefined/{} after session.destroy()

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2071,9 +2071,10 @@ class Http2Stream extends Duplex {
   get state() {
     const session = this[bunHTTP2Session];
     if (session) {
-      return session[bunHTTP2Native]?.getStreamState(this.#id);
+      const native = session[bunHTTP2Native];
+      if (native) return native.getStreamState(this.#id) ?? {};
     }
-    return constants.NGHTTP2_STREAM_STATE_CLOSED;
+    return {};
   }
 
   priority(options) {
@@ -2098,7 +2099,9 @@ class Http2Stream extends Duplex {
   }
 
   get session() {
-    return this[bunHTTP2Session];
+    const session = this[bunHTTP2Session];
+    if (session == null || session.destroyed) return undefined;
+    return session;
   }
 
   get pushAllowed() {

--- a/test/js/node/http2/h2-stream-after-destroy.test.ts
+++ b/test/js/node/http2/h2-stream-after-destroy.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "bun:test";
+import http2 from "node:http2";
+import { once } from "node:events";
+
+test("stream.session is undefined and stream.state is {} after session.destroy()", async () => {
+  const server = http2.createServer();
+  let resolveStream: (s: any) => void;
+  const streamP = new Promise<any>(r => (resolveStream = r));
+  server.on("stream", s => {
+    s.respond({ ":status": 200 });
+    s.end();
+    resolveStream(s);
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as any).port;
+  const client = http2.connect(`http://127.0.0.1:${port}`);
+  const req = client.request({ ":path": "/" });
+  req.resume();
+  req.end();
+  const serverStream = await streamP;
+  await once(req, "end");
+  serverStream.session?.destroy();
+  await Bun.sleep(50);
+  expect(serverStream.session).toBeUndefined();
+  expect(serverStream.state).toEqual({});
+  client.close();
+  server.close();
+});

--- a/test/js/node/http2/h2-stream-after-destroy.test.ts
+++ b/test/js/node/http2/h2-stream-after-destroy.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "bun:test";
-import http2 from "node:http2";
+import { expect, test } from "bun:test";
 import { once } from "node:events";
+import http2 from "node:http2";
 
 test("stream.session is undefined and stream.state is {} after session.destroy()", async () => {
   const server = http2.createServer();

--- a/test/js/node/http2/h2-stream-after-destroy.test.ts
+++ b/test/js/node/http2/h2-stream-after-destroy.test.ts
@@ -7,23 +7,27 @@ test("stream.session is undefined and stream.state is {} after session.destroy()
   let resolveStream: (s: any) => void;
   const streamP = new Promise<any>(r => (resolveStream = r));
   server.on("stream", s => {
-    s.respond({ ":status": 200 });
-    s.end();
     resolveStream(s);
   });
   server.listen(0);
   await once(server, "listening");
   const port = (server.address() as any).port;
   const client = http2.connect(`http://127.0.0.1:${port}`);
-  const req = client.request({ ":path": "/" });
-  req.resume();
-  req.end();
-  const serverStream = await streamP;
-  await once(req, "end");
-  serverStream.session?.destroy();
-  await Bun.sleep(50);
-  expect(serverStream.session).toBeUndefined();
-  expect(serverStream.state).toEqual({});
-  client.close();
-  server.close();
+  try {
+    const req = client.request({ ":path": "/" });
+    req.on("error", () => {});
+    req.resume();
+    req.end();
+    const serverStream = await streamP;
+    const session = serverStream.session;
+    expect(session).toBeDefined();
+    const closeP = once(session, "close");
+    session.destroy();
+    await closeP;
+    expect(serverStream.session).toBeUndefined();
+    expect(serverStream.state).toEqual({});
+  } finally {
+    client.close();
+    server.close();
+  }
 });


### PR DESCRIPTION
Node's `Http2Stream` `session` getter returns `undefined` once the session is destroyed (`kSession` is cleared), and `state` returns `{}` when there is no native handle (lib/internal/http2/core.js:2113, 2178). Bun returned the destroyed session object and the numeric constant `NGHTTP2_STREAM_STATE_CLOSED`.

Prerequisite for porting `test/parallel/test-http2-server-stream-session-destroy.js`.