### PR TITLE
valkey: deliver pub/sub messages under RESP2

### DIFF
--- a/src/valkey/valkey.zig
+++ b/src/valkey/valkey.zig
@@ -650,19 +650,18 @@ pub const ValkeyClient = struct {
         // If the loop finishes, the entire 'data' was processed without needing the buffer.
     }
 
-    /// Try handling this response as a subscriber-state response.
-    /// Returns `handled` if we handled it, `fallthrough` if we did not.
+    /// Handle a response that has already been classified as a subscription
+    /// frame by the caller (via `SubscriptionPushMessage.asFrame`).
     ///
-    /// `frame` is the parsed subscription frame, extracted by the caller so
-    /// that we don't have to re-discriminate on `.Push` vs. `.Array`. It works
-    /// uniformly for RESP3 push frames and RESP2 inline-array pub/sub frames.
+    /// `frame` is the parsed subscription frame. This abstracts over the two
+    /// wire shapes: RESP3 `.Push` frames and RESP2 inline-array pub/sub
+    /// frames; both reach this function via the same dispatch.
     fn handleSubscribeResponse(
         this: *ValkeyClient,
         value: *protocol.RESPValue,
         frame: protocol.SubscriptionPushMessage.Frame,
         pair: ?*ValkeyCommand.PromisePair,
-    ) bun.JSError!enum { handled, fallthrough } {
-        // Resolve the promise with the potentially transformed value
+    ) bun.JSError!void {
         const globalThis = this.globalObject();
         const loop = this.vm.eventLoop();
 
@@ -671,14 +670,17 @@ pub const ValkeyClient = struct {
         defer loop.exit();
 
         const p = this.parent();
-        const sub_count = try p._subscription_ctx.channelsSubscribedToCount(globalThis);
 
         switch (frame.kind) {
             .message => {
+                // Hot path during active pub/sub: skip the JS-side channel-count
+                // lookup entirely, since message frames don't resolve a promise.
                 this.onValkeyMessage(frame.data);
-                return .handled;
             },
             .subscribe => {
+                // `channelsSubscribedToCount` reads from a JSMap via the JS
+                // getter, so only touch it on the path that actually needs it.
+                const sub_count = try p._subscription_ctx.channelsSubscribedToCount(globalThis);
                 p.addSubscription();
                 this.onValkeySubscribe(value);
 
@@ -687,7 +689,6 @@ pub const ValkeyClient = struct {
                 if (pair) |req_pair| {
                     try req_pair.promise.promise.resolve(globalThis, .jsNumber(sub_count));
                 }
-                return .handled;
             },
             .unsubscribe => {
                 try this.onValkeyUnsubscribe();
@@ -698,7 +699,6 @@ pub const ValkeyClient = struct {
                 if (pair) |req_pair| {
                     try req_pair.promise.promise.resolve(globalThis, .js_undefined);
                 }
-                return .handled;
             },
         }
     }
@@ -847,9 +847,8 @@ pub const ValkeyClient = struct {
             }
 
             if (subscription_frame) |frame| {
-                if ((try this.handleSubscribeResponse(value, frame, if (pair_maybe) |*pm| pm else null)) == .handled) {
-                    return;
-                }
+                try this.handleSubscribeResponse(value, frame, if (pair_maybe) |*pm| pm else null);
+                return;
             }
             // Fall through to the regular command handler. Subscribers can receive non-subscription
             // responses (RESP3 push commands, or regular command replies on RESP2 subscribe-only

--- a/src/valkey/valkey.zig
+++ b/src/valkey/valkey.zig
@@ -809,6 +809,17 @@ pub const ValkeyClient = struct {
         // reply IS a subscription frame and we have to route it through `handleSubscribeResponse`.
         const subscription_frame: ?protocol.SubscriptionPushMessage.Frame = protocol.SubscriptionPushMessage.asFrame(value);
 
+        // A RESP3 `.Push` frame that is not a recognized pub/sub kind (e.g. a keyspace
+        // notification, a CLIENT TRACKING `invalidate`, or a sharded/pattern push kind
+        // the client doesn't route yet) is a server-initiated async notification — it is
+        // NOT a reply to any in-flight command. Drop it without consuming a promise pair,
+        // otherwise we'd corrupt an unrelated command's result.
+        if (value.* == .Push and subscription_frame == null) {
+            @branchHint(.cold);
+            debug("Dropping unrouted server push frame (kind={s})", .{value.Push.kind});
+            return;
+        }
+
         if (this.parent().isSubscriber()) {
             if (subscription_frame) |frame| {
                 switch (frame.kind) {
@@ -842,6 +853,18 @@ pub const ValkeyClient = struct {
             debug("This client is a subscriber. Handling as subscriber...", .{});
 
             if (value.* == .Error) {
+                // If we already popped a pair for this reply, reject ITS promise — otherwise
+                // `fail()` would reject everything else in the queue and orphan the caller that
+                // actually issued this command. Only call `fail()` when the error is
+                // unattributed (no in-flight pair to blame).
+                if (pair_maybe) |*pm| {
+                    const globalThis = this.globalObject();
+                    const loop = this.vm.eventLoop();
+                    loop.enter();
+                    defer loop.exit();
+                    try pm.promise.reject(globalThis, value.toJS(globalThis) catch |err| globalThis.takeError(err));
+                    return;
+                }
                 try this.fail(value.Error, protocol.RedisError.InvalidResponse);
                 return;
             }
@@ -850,9 +873,9 @@ pub const ValkeyClient = struct {
                 try this.handleSubscribeResponse(value, frame, if (pair_maybe) |*pm| pm else null);
                 return;
             }
-            // Fall through to the regular command handler. Subscribers can receive non-subscription
-            // responses (RESP3 push commands, or regular command replies on RESP2 subscribe-only
-            // connections that the user has sent outside the SUBSCRIBE workflow).
+            // Fall through to the regular command handler. Subscribers can receive regular
+            // command replies (for example a `+PONG\r\n` reply to `PING` issued outside the
+            // subscription workflow on a RESP2 subscribe-only connection).
 
             debug("Treating subscriber response as a regular command...", .{});
         }

--- a/src/valkey/valkey.zig
+++ b/src/valkey/valkey.zig
@@ -652,9 +652,14 @@ pub const ValkeyClient = struct {
 
     /// Try handling this response as a subscriber-state response.
     /// Returns `handled` if we handled it, `fallthrough` if we did not.
+    ///
+    /// `frame` is the parsed subscription frame, extracted by the caller so
+    /// that we don't have to re-discriminate on `.Push` vs. `.Array`. It works
+    /// uniformly for RESP3 push frames and RESP2 inline-array pub/sub frames.
     fn handleSubscribeResponse(
         this: *ValkeyClient,
         value: *protocol.RESPValue,
+        frame: protocol.SubscriptionPushMessage.Frame,
         pair: ?*ValkeyCommand.PromisePair,
     ) bun.JSError!enum { handled, fallthrough } {
         // Resolve the promise with the potentially transformed value
@@ -665,63 +670,37 @@ pub const ValkeyClient = struct {
         loop.enter();
         defer loop.exit();
 
-        return switch (value.*) {
-            .Error => {
-                if (pair) |p| {
-                    try p.promise.reject(globalThis, value.toJS(globalThis));
+        const p = this.parent();
+        const sub_count = try p._subscription_ctx.channelsSubscribedToCount(globalThis);
+
+        switch (frame.kind) {
+            .message => {
+                this.onValkeyMessage(frame.data);
+                return .handled;
+            },
+            .subscribe => {
+                p.addSubscription();
+                this.onValkeySubscribe(value);
+
+                // For SUBSCRIBE responses, only resolve the promise for the first channel confirmation
+                // Additional channel confirmations from multi-channel SUBSCRIBE commands don't need promise pairs
+                if (pair) |req_pair| {
+                    try req_pair.promise.promise.resolve(globalThis, .jsNumber(sub_count));
                 }
                 return .handled;
             },
-            .Push => |push| {
-                const p = this.parent();
-                const sub_count = try p._subscription_ctx.channelsSubscribedToCount(globalThis);
+            .unsubscribe => {
+                try this.onValkeyUnsubscribe();
+                p.removeSubscription();
 
-                if (protocol.SubscriptionPushMessage.map.get(push.kind)) |msg_type| {
-                    switch (msg_type) {
-                        .message => {
-                            this.onValkeyMessage(push.data);
-                            return .handled;
-                        },
-                        .subscribe => {
-                            p.addSubscription();
-                            this.onValkeySubscribe(value);
-
-                            // For SUBSCRIBE responses, only resolve the promise for the first channel confirmation
-                            // Additional channel confirmations from multi-channel SUBSCRIBE commands don't need promise pairs
-                            if (pair) |req_pair| {
-                                try req_pair.promise.promise.resolve(globalThis, .jsNumber(sub_count));
-                            }
-                            return .handled;
-                        },
-                        .unsubscribe => {
-                            try this.onValkeyUnsubscribe();
-                            p.removeSubscription();
-
-                            // For UNSUBSCRIBE responses, only resolve the promise if we have one
-                            // Additional channel confirmations from multi-channel UNSUBSCRIBE commands don't need promise pairs
-                            if (pair) |req_pair| {
-                                try req_pair.promise.promise.resolve(globalThis, .js_undefined);
-                            }
-                            return .handled;
-                        },
-                    }
-                } else {
-                    // We should rarely reach this point. If we're guaranteed to be handling a subscribe/unsubscribe,
-                    // then this is an unexpected path.
-                    @branchHint(.cold);
-                    try this.fail(
-                        "Push message is not a subscription message.",
-                        protocol.RedisError.InvalidResponseType,
-                    );
-                    return .handled;
+                // For UNSUBSCRIBE responses, only resolve the promise if we have one
+                // Additional channel confirmations from multi-channel UNSUBSCRIBE commands don't need promise pairs
+                if (pair) |req_pair| {
+                    try req_pair.promise.promise.resolve(globalThis, .js_undefined);
                 }
+                return .handled;
             },
-            else => {
-                // This may be a regular command response. Let's pass it down
-                // to the next handler.
-                return .fallthrough;
-            },
-        };
+        }
     }
 
     fn handleHelloResponse(this: *ValkeyClient, value: *protocol.RESPValue) bun.JSTerminated!void {
@@ -819,26 +798,31 @@ pub const ValkeyClient = struct {
         var should_consume_promise_pair = true;
         var pair_maybe: ?ValkeyCommand.PromisePair = null;
 
-        // For subscription clients, check if this is a push message that doesn't need a promise pair
+        // Check whether this response is a pub/sub notification frame.
+        //
+        // Under RESP3, subscription frames arrive as `.Push` values (`>`).
+        // Under RESP2, the same frames arrive as regular `.Array` values whose first element is a
+        // `SimpleString`/`BulkString` tag (for example `["message", "chan", "payload"]`).
+        //
+        // `SubscriptionPushMessage.asFrame` accepts either shape. We check this even before the first
+        // SUBSCRIBE confirmation promotes the client into subscriber state, because that very first
+        // reply IS a subscription frame and we have to route it through `handleSubscribeResponse`.
+        const subscription_frame: ?protocol.SubscriptionPushMessage.Frame = protocol.SubscriptionPushMessage.asFrame(value);
+
         if (this.parent().isSubscriber()) {
-            switch (value.*) {
-                .Push => |push| {
-                    if (protocol.SubscriptionPushMessage.map.get(push.kind)) |msg_type| {
-                        switch (msg_type) {
-                            .message => {
-                                // Message pushes never need promise pairs
-                                should_consume_promise_pair = false;
-                            },
-                            .subscribe, .unsubscribe => {
-                                // Subscribe/unsubscribe pushes only need promise pairs if we have pending commands
-                                if (this.in_flight.readableLength() == 0) {
-                                    should_consume_promise_pair = false;
-                                }
-                            },
+            if (subscription_frame) |frame| {
+                switch (frame.kind) {
+                    .message => {
+                        // Message frames never need promise pairs
+                        should_consume_promise_pair = false;
+                    },
+                    .subscribe, .unsubscribe => {
+                        // Subscribe/unsubscribe frames only need promise pairs if we have pending commands
+                        if (this.in_flight.readableLength() == 0) {
+                            should_consume_promise_pair = false;
                         }
-                    }
-                },
-                else => {},
+                    },
+                }
             }
         }
 
@@ -857,31 +841,19 @@ pub const ValkeyClient = struct {
         if (this.parent().isSubscriber() or request_is_subscribe) {
             debug("This client is a subscriber. Handling as subscriber...", .{});
 
-            switch (value.*) {
-                .Error => |err| {
-                    try this.fail(err, protocol.RedisError.InvalidResponse);
-                    return;
-                },
-                .Push => |push| {
-                    if (protocol.SubscriptionPushMessage.map.get(push.kind)) |_| {
-                        if ((try this.handleSubscribeResponse(value, if (pair_maybe) |*pm| pm else null)) == .handled) {
-                            return;
-                        }
-                    } else {
-                        @branchHint(.cold);
-                        try this.fail(
-                            "Unexpected push message kind without promise",
-                            protocol.RedisError.InvalidResponseType,
-                        );
-                        return;
-                    }
-                },
-                else => {
-                    // In the else case, we fall through to the regular
-                    // handler. Subscribers can send .Push commands which have
-                    // the same semantics as regular commands.
-                },
+            if (value.* == .Error) {
+                try this.fail(value.Error, protocol.RedisError.InvalidResponse);
+                return;
             }
+
+            if (subscription_frame) |frame| {
+                if ((try this.handleSubscribeResponse(value, frame, if (pair_maybe) |*pm| pm else null)) == .handled) {
+                    return;
+                }
+            }
+            // Fall through to the regular command handler. Subscribers can receive non-subscription
+            // responses (RESP3 push commands, or regular command replies on RESP2 subscribe-only
+            // connections that the user has sent outside the SUBSCRIBE workflow).
 
             debug("Treating subscriber response as a regular command...", .{});
         }

--- a/src/valkey/valkey.zig
+++ b/src/valkey/valkey.zig
@@ -809,12 +809,15 @@ pub const ValkeyClient = struct {
         // reply IS a subscription frame and we have to route it through `handleSubscribeResponse`.
         const subscription_frame: ?protocol.SubscriptionPushMessage.Frame = protocol.SubscriptionPushMessage.asFrame(value);
 
-        // A RESP3 `.Push` frame that is not a recognized pub/sub kind (e.g. a keyspace
-        // notification, a CLIENT TRACKING `invalidate`, or a sharded/pattern push kind
-        // the client doesn't route yet) is a server-initiated async notification — it is
-        // NOT a reply to any in-flight command. Drop it without consuming a promise pair,
-        // otherwise we'd corrupt an unrelated command's result.
-        if (value.* == .Push and subscription_frame == null) {
+        // A RESP3 `.Push` frame with an unrecognized kind (keyspace notification,
+        // CLIENT TRACKING `invalidate`, sharded/pattern push, etc.) is a server-initiated
+        // async notification ONLY when nothing is in flight. If a command is pending,
+        // the push is actually its reply (for example `psubscribe`/`pmessage` arrive as
+        // `.Push` on RESP3 and are the reply to a user-issued `PSUBSCRIBE`). Dropping
+        // those would leave the caller's promise hanging — fall through to the regular
+        // handler in that case and resolve the pair with the raw value, matching the
+        // pre-refactor behavior for unrouted kinds.
+        if (value.* == .Push and subscription_frame == null and this.in_flight.readableLength() == 0) {
             @branchHint(.cold);
             debug("Dropping unrouted server push frame (kind={s})", .{value.Push.kind});
             return;

--- a/src/valkey/valkey_protocol.zig
+++ b/src/valkey/valkey_protocol.zig
@@ -687,6 +687,49 @@ pub const SubscriptionPushMessage = enum(u2) {
         .{ "subscribe", .subscribe },
         .{ "unsubscribe", .unsubscribe },
     });
+
+    /// A subscription frame as it is presented to the rest of the client.
+    ///
+    /// Under RESP3 these frames arrive as `.Push` values; under RESP2 (after a
+    /// client sends `HELLO 2`) the same frames arrive as ordinary `.Array`
+    /// values whose first element is a `SimpleString`/`BulkString` tag.
+    /// This struct abstracts over both so callers don't have to branch on the
+    /// wire-level representation.
+    pub const Frame = struct {
+        kind: SubscriptionPushMessage,
+        /// The elements after the kind tag. For `message` this is
+        /// `[channel, payload]`; for `subscribe`/`unsubscribe` this is
+        /// `[channel, subscription_count]`.
+        data: []RESPValue,
+    };
+
+    /// Try to interpret `value` as a subscription frame. Returns `null` if it
+    /// is not a recognized subscription frame — regular command replies on a
+    /// subscriber connection (for example a `PONG` reply to `PING`) fall into
+    /// that bucket and must be routed through the normal command path.
+    pub fn asFrame(value: *RESPValue) ?Frame {
+        switch (value.*) {
+            .Push => |push| {
+                if (map.get(push.kind)) |kind| {
+                    return .{ .kind = kind, .data = push.data };
+                }
+                return null;
+            },
+            .Array => |array| {
+                if (array.len == 0) return null;
+                const kind_str: []const u8 = switch (array[0]) {
+                    .SimpleString => |s| s,
+                    .BulkString => |maybe| maybe orelse return null,
+                    else => return null,
+                };
+                if (map.get(kind_str)) |kind| {
+                    return .{ .kind = kind, .data = array[1..] };
+                }
+                return null;
+            },
+            else => return null,
+        }
+    }
 };
 
 const std = @import("std");

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -6324,6 +6324,70 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
         expect(counter.count()).toBe(TEST_MESSAGE_COUNT);
       });
 
+      // https://github.com/oven-sh/bun/issues/29042
+      // Under RESP2 (after sending `HELLO 2` on the subscriber connection),
+      // Redis delivers `message` / `subscribe` / `unsubscribe` notifications as
+      // ordinary `*3\r\n$7\r\nmessage\r\n...` arrays rather than RESP3 push
+      // frames. Bun used to only match the RESP3 `.Push` variant, so the
+      // subscriber counted as subscribed on the server (PUBLISH returned 1)
+      // but the JS handler silently never fired.
+      test("subscribing after HELLO 2 (RESP2) still receives messages (#29042)", async () => {
+        const TEST_MESSAGE_COUNT = 16;
+        const subscriber = await ctx.newSubscriberClient(connectionType);
+        const channel = testChannel();
+        const message = testMessage();
+
+        // Force the subscriber connection into RESP2 mode. This used to make
+        // every subsequent pub/sub notification be silently dropped.
+        await subscriber.send("HELLO", ["2"]);
+
+        const counter = awaitableCounter();
+        const received: string[] = [];
+        await subscriber.subscribe(channel, (msg, ch) => {
+          received.push(msg);
+          expect(ch).toBe(channel);
+          counter.increment();
+        });
+
+        for (let i = 0; i < TEST_MESSAGE_COUNT; i++) {
+          expect(await ctx.redis.publish(channel, message)).toBe(1);
+        }
+
+        await counter.untilValue(TEST_MESSAGE_COUNT);
+        expect(received).toEqual(Array.from({ length: TEST_MESSAGE_COUNT }, () => message));
+
+        await subscriber.unsubscribe(channel);
+      });
+
+      // https://github.com/oven-sh/bun/issues/29042 — combine multi-channel
+      // subscribe with a RESP2-negotiated connection. Exercises both the
+      // subscribe-confirmation path (which is pair-resolved) and the
+      // message-delivery path on the same RESP2 connection.
+      test("multi-channel subscribe works after HELLO 2 (RESP2) (#29042)", async () => {
+        const subscriber = await ctx.newSubscriberClient(connectionType);
+        await subscriber.send("HELLO", ["2"]);
+
+        const channels = [testChannel(), testChannel()];
+        const counter = awaitableCounter();
+        const received: Record<string, string[]> = {};
+
+        await subscriber.subscribe(channels, (msg, ch) => {
+          (received[ch] ??= []).push(msg);
+          counter.increment();
+        });
+
+        expect(await ctx.redis.publish(channels[0], "a")).toBe(1);
+        expect(await ctx.redis.publish(channels[1], "b")).toBe(1);
+
+        await counter.untilValue(2);
+        expect(received).toEqual({
+          [channels[0]]: ["a"],
+          [channels[1]]: ["b"],
+        });
+
+        await subscriber.unsubscribe(channels);
+      });
+
       test("messages are received in order", async () => {
         const channel = testChannel();
 

--- a/test/regression/issue/29042.test.ts
+++ b/test/regression/issue/29042.test.ts
@@ -135,7 +135,10 @@ t("unsubscribe after HELLO 2 resolves its promise", async () => {
   await sub.send("HELLO", ["2"]);
 
   const channel = `bun-29042-${crypto.randomUUID()}`;
-  await withTimeout(sub.subscribe(channel, () => {}), "SUBSCRIBE confirmation (RESP2)");
+  await withTimeout(
+    sub.subscribe(channel, () => {}),
+    "SUBSCRIBE confirmation (RESP2)",
+  );
 
   // Without the fix the UNSUBSCRIBE confirmation frame (a RESP2 array) was
   // never matched in the subscriber dispatch, so this promise would hang.

--- a/test/regression/issue/29042.test.ts
+++ b/test/regression/issue/29042.test.ts
@@ -54,96 +54,105 @@ function withTimeout<T>(promise: Promise<T>, label: string, ms = REGRESSION_TIME
   });
 }
 
+// RedisClient doesn't implement Symbol.dispose yet, so scope cleanup with
+// explicit try/finally — a timeout/assert failure in the body must still
+// close both sockets so the next test isn't poisoned by a stale subscriber.
 t("subscribe() after HELLO 2 delivers messages to the JS handler", async () => {
   const pub = new RedisClient("redis://localhost:6379");
-  await pub.connect();
-
   const sub = new RedisClient("redis://localhost:6379");
-  await sub.connect();
+  try {
+    await pub.connect();
+    await sub.connect();
 
-  // Force the subscriber connection into RESP2.
-  await sub.send("HELLO", ["2"]);
+    // Force the subscriber connection into RESP2.
+    await sub.send("HELLO", ["2"]);
 
-  const channel = `bun-29042-${crypto.randomUUID()}`;
-  const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const channel = `bun-29042-${crypto.randomUUID()}`;
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
 
-  await withTimeout(
-    sub.subscribe(channel, (message, ch) => {
-      if (ch !== channel) reject(new Error(`wrong channel: ${ch}`));
-      resolve(message);
-    }),
-    "SUBSCRIBE confirmation (RESP2)",
-  );
+    await withTimeout(
+      sub.subscribe(channel, (message, ch) => {
+        if (ch !== channel) reject(new Error(`wrong channel: ${ch}`));
+        resolve(message);
+      }),
+      "SUBSCRIBE confirmation (RESP2)",
+    );
 
-  const numSubs = await withTimeout(pub.send("PUBLISH", [channel, "hello"]), "PUBLISH");
-  // Sanity-check the regression shape: the server MUST see the subscriber,
-  // otherwise the test is not exercising the bug.
-  expect(numSubs).toBe(1);
+    const numSubs = await withTimeout(pub.send("PUBLISH", [channel, "hello"]), "PUBLISH");
+    // Sanity-check the regression shape: the server MUST see the subscriber,
+    // otherwise the test is not exercising the bug.
+    expect(numSubs).toBe(1);
 
-  const received = await withTimeout(promise, "subscribe() handler invocation (RESP2)");
-  expect(received).toBe("hello");
+    const received = await withTimeout(promise, "subscribe() handler invocation (RESP2)");
+    expect(received).toBe("hello");
 
-  await withTimeout(sub.unsubscribe(channel), "UNSUBSCRIBE confirmation (RESP2)");
-  sub.close();
-  pub.close();
+    await withTimeout(sub.unsubscribe(channel), "UNSUBSCRIBE confirmation (RESP2)");
+  } finally {
+    sub.close();
+    pub.close();
+  }
 });
 
 t("multi-channel subscribe after HELLO 2 delivers every message", async () => {
   const pub = new RedisClient("redis://localhost:6379");
-  await pub.connect();
-
   const sub = new RedisClient("redis://localhost:6379");
-  await sub.connect();
+  try {
+    await pub.connect();
+    await sub.connect();
 
-  await sub.send("HELLO", ["2"]);
+    await sub.send("HELLO", ["2"]);
 
-  const prefix = `bun-29042-${crypto.randomUUID()}`;
-  const channels = [`${prefix}:a`, `${prefix}:b`];
+    const prefix = `bun-29042-${crypto.randomUUID()}`;
+    const channels = [`${prefix}:a`, `${prefix}:b`];
 
-  const received: Array<{ channel: string; message: string }> = [];
-  const { promise, resolve } = Promise.withResolvers<void>();
+    const received: Array<{ channel: string; message: string }> = [];
+    const { promise, resolve } = Promise.withResolvers<void>();
 
-  await withTimeout(
-    sub.subscribe(channels, (message, channel) => {
-      received.push({ channel, message });
-      if (received.length === 2) resolve();
-    }),
-    "multi-channel SUBSCRIBE confirmation (RESP2)",
-  );
+    await withTimeout(
+      sub.subscribe(channels, (message, channel) => {
+        received.push({ channel, message });
+        if (received.length === 2) resolve();
+      }),
+      "multi-channel SUBSCRIBE confirmation (RESP2)",
+    );
 
-  expect(await withTimeout(pub.send("PUBLISH", [channels[0], "hello-a"]), "PUBLISH channel 0")).toBe(1);
-  expect(await withTimeout(pub.send("PUBLISH", [channels[1], "hello-b"]), "PUBLISH channel 1")).toBe(1);
+    expect(await withTimeout(pub.send("PUBLISH", [channels[0], "hello-a"]), "PUBLISH channel 0")).toBe(1);
+    expect(await withTimeout(pub.send("PUBLISH", [channels[1], "hello-b"]), "PUBLISH channel 1")).toBe(1);
 
-  await withTimeout(promise, "both multi-channel messages delivered (RESP2)");
+    await withTimeout(promise, "both multi-channel messages delivered (RESP2)");
 
-  // Order between channels is not guaranteed, sort for stable comparison.
-  received.sort((x, y) => x.channel.localeCompare(y.channel));
-  expect(received).toEqual([
-    { channel: channels[0], message: "hello-a" },
-    { channel: channels[1], message: "hello-b" },
-  ]);
+    // Order between channels is not guaranteed, sort for stable comparison.
+    received.sort((x, y) => x.channel.localeCompare(y.channel));
+    expect(received).toEqual([
+      { channel: channels[0], message: "hello-a" },
+      { channel: channels[1], message: "hello-b" },
+    ]);
 
-  await withTimeout(sub.unsubscribe(channels), "multi-channel UNSUBSCRIBE (RESP2)");
-  sub.close();
-  pub.close();
+    await withTimeout(sub.unsubscribe(channels), "multi-channel UNSUBSCRIBE (RESP2)");
+  } finally {
+    sub.close();
+    pub.close();
+  }
 });
 
 t("unsubscribe after HELLO 2 resolves its promise", async () => {
   const sub = new RedisClient("redis://localhost:6379");
-  await sub.connect();
+  try {
+    await sub.connect();
 
-  await sub.send("HELLO", ["2"]);
+    await sub.send("HELLO", ["2"]);
 
-  const channel = `bun-29042-${crypto.randomUUID()}`;
-  await withTimeout(
-    sub.subscribe(channel, () => {}),
-    "SUBSCRIBE confirmation (RESP2)",
-  );
+    const channel = `bun-29042-${crypto.randomUUID()}`;
+    await withTimeout(
+      sub.subscribe(channel, () => {}),
+      "SUBSCRIBE confirmation (RESP2)",
+    );
 
-  // Without the fix the UNSUBSCRIBE confirmation frame (a RESP2 array) was
-  // never matched in the subscriber dispatch, so this promise would hang.
-  // withTimeout turns that hang into a clear regression message.
-  await withTimeout(sub.unsubscribe(channel), "UNSUBSCRIBE confirmation (RESP2)");
-
-  sub.close();
+    // Without the fix the UNSUBSCRIBE confirmation frame (a RESP2 array) was
+    // never matched in the subscriber dispatch, so this promise would hang.
+    // withTimeout turns that hang into a clear regression message.
+    await withTimeout(sub.unsubscribe(channel), "UNSUBSCRIBE confirmation (RESP2)");
+  } finally {
+    sub.close();
+  }
 });

--- a/test/regression/issue/29042.test.ts
+++ b/test/regression/issue/29042.test.ts
@@ -17,13 +17,15 @@ import { RedisClient } from "bun";
 import { expect, test } from "bun:test";
 
 async function redisReachable() {
+  let c: RedisClient | undefined;
   try {
-    const c = new RedisClient("redis://localhost:6379");
+    c = new RedisClient("redis://localhost:6379");
     await c.connect();
-    c.close();
     return true;
   } catch {
     return false;
+  } finally {
+    c?.close();
   }
 }
 

--- a/test/regression/issue/29042.test.ts
+++ b/test/regression/issue/29042.test.ts
@@ -1,0 +1,119 @@
+// https://github.com/oven-sh/bun/issues/29042
+//
+// Bun.RedisClient: `subscribe()` handler silently dropped messages after
+// `HELLO 2` on the subscriber connection.
+//
+// Under RESP3 (Bun's default) a pub/sub notification arrives as a `.Push`
+// frame (type byte `>`). Under RESP2 (after the user sends `HELLO 2` on the
+// subscriber connection) Redis sends the *same* notification as an ordinary
+// `*3\r\n$7\r\nmessage\r\n...` array. Bun's client used to match only `.Push`
+// frames in the subscriber dispatch path, so after `HELLO 2` every incoming
+// message was silently swallowed even though PUBLISH on the server side still
+// reported the subscriber was present.
+//
+// The fix parses both shapes uniformly in `SubscriptionPushMessage.asFrame`
+// and routes them through the same subscriber handler.
+import { RedisClient } from "bun";
+import { expect, test } from "bun:test";
+
+// We spawn a sub-process for each test so a dropped message can't poison a
+// shared connection pool.
+
+async function redisReachable() {
+  try {
+    const c = new RedisClient("redis://localhost:6379");
+    await c.connect();
+    c.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const isReachable = await redisReachable();
+const t = isReachable ? test : test.skip;
+
+t("subscribe() after HELLO 2 delivers messages to the JS handler", async () => {
+  const pub = new RedisClient("redis://localhost:6379");
+  await pub.connect();
+
+  const sub = new RedisClient("redis://localhost:6379");
+  await sub.connect();
+
+  // Force the subscriber connection into RESP2.
+  await sub.send("HELLO", ["2"]);
+
+  const channel = `bun-29042-${crypto.randomUUID()}`;
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
+
+  await sub.subscribe(channel, (message, ch) => {
+    if (ch !== channel) reject(new Error(`wrong channel: ${ch}`));
+    resolve(message);
+  });
+
+  const numSubs = await pub.send("PUBLISH", [channel, "hello"]);
+  // Sanity-check the regression shape: the server MUST see the subscriber,
+  // otherwise the test is not exercising the bug.
+  expect(numSubs).toBe(1);
+
+  const received = await promise;
+  expect(received).toBe("hello");
+
+  await sub.unsubscribe(channel);
+  sub.close();
+  pub.close();
+});
+
+t("multi-channel subscribe after HELLO 2 delivers every message", async () => {
+  const pub = new RedisClient("redis://localhost:6379");
+  await pub.connect();
+
+  const sub = new RedisClient("redis://localhost:6379");
+  await sub.connect();
+
+  await sub.send("HELLO", ["2"]);
+
+  const prefix = `bun-29042-${crypto.randomUUID()}`;
+  const channels = [`${prefix}:a`, `${prefix}:b`];
+
+  const received: Array<{ channel: string; message: string }> = [];
+  const { promise, resolve } = Promise.withResolvers<void>();
+
+  await sub.subscribe(channels, (message, channel) => {
+    received.push({ channel, message });
+    if (received.length === 2) resolve();
+  });
+
+  expect(await pub.send("PUBLISH", [channels[0], "hello-a"])).toBe(1);
+  expect(await pub.send("PUBLISH", [channels[1], "hello-b"])).toBe(1);
+
+  await promise;
+
+  // Order between channels is not guaranteed, sort for stable comparison.
+  received.sort((x, y) => x.channel.localeCompare(y.channel));
+  expect(received).toEqual([
+    { channel: channels[0], message: "hello-a" },
+    { channel: channels[1], message: "hello-b" },
+  ]);
+
+  await sub.unsubscribe(channels);
+  sub.close();
+  pub.close();
+});
+
+t("unsubscribe after HELLO 2 resolves its promise", async () => {
+  const sub = new RedisClient("redis://localhost:6379");
+  await sub.connect();
+
+  await sub.send("HELLO", ["2"]);
+
+  const channel = `bun-29042-${crypto.randomUUID()}`;
+  await sub.subscribe(channel, () => {});
+
+  // If RESP2 unsubscribe confirmations are dropped, this promise hangs
+  // forever — the test harness will time it out rather than report a
+  // meaningful failure. So just call it and make sure we reach the next line.
+  await sub.unsubscribe(channel);
+
+  sub.close();
+});

--- a/test/regression/issue/29042.test.ts
+++ b/test/regression/issue/29042.test.ts
@@ -16,9 +16,6 @@
 import { RedisClient } from "bun";
 import { expect, test } from "bun:test";
 
-// We spawn a sub-process for each test so a dropped message can't poison a
-// shared connection pool.
-
 async function redisReachable() {
   try {
     const c = new RedisClient("redis://localhost:6379");
@@ -33,6 +30,30 @@ async function redisReachable() {
 const isReachable = await redisReachable();
 const t = isReachable ? test : test.skip;
 
+// If the regression returns, the RESP2 subscribe path hangs forever rather
+// than throwing. Race every network-dependent await against an explicit
+// bounded timeout so failures are reported with a useful message instead of
+// an opaque 5s global-test-timeout.
+const REGRESSION_TIMEOUT_MS = 2_000;
+
+function withTimeout<T>(promise: Promise<T>, label: string, ms = REGRESSION_TIMEOUT_MS): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`#29042 regression? Timed out after ${ms}ms waiting for: ${label}`));
+    }, ms);
+    promise.then(
+      value => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      err => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
 t("subscribe() after HELLO 2 delivers messages to the JS handler", async () => {
   const pub = new RedisClient("redis://localhost:6379");
   await pub.connect();
@@ -46,20 +67,23 @@ t("subscribe() after HELLO 2 delivers messages to the JS handler", async () => {
   const channel = `bun-29042-${crypto.randomUUID()}`;
   const { promise, resolve, reject } = Promise.withResolvers<string>();
 
-  await sub.subscribe(channel, (message, ch) => {
-    if (ch !== channel) reject(new Error(`wrong channel: ${ch}`));
-    resolve(message);
-  });
+  await withTimeout(
+    sub.subscribe(channel, (message, ch) => {
+      if (ch !== channel) reject(new Error(`wrong channel: ${ch}`));
+      resolve(message);
+    }),
+    "SUBSCRIBE confirmation (RESP2)",
+  );
 
-  const numSubs = await pub.send("PUBLISH", [channel, "hello"]);
+  const numSubs = await withTimeout(pub.send("PUBLISH", [channel, "hello"]), "PUBLISH");
   // Sanity-check the regression shape: the server MUST see the subscriber,
   // otherwise the test is not exercising the bug.
   expect(numSubs).toBe(1);
 
-  const received = await promise;
+  const received = await withTimeout(promise, "subscribe() handler invocation (RESP2)");
   expect(received).toBe("hello");
 
-  await sub.unsubscribe(channel);
+  await withTimeout(sub.unsubscribe(channel), "UNSUBSCRIBE confirmation (RESP2)");
   sub.close();
   pub.close();
 });
@@ -79,15 +103,18 @@ t("multi-channel subscribe after HELLO 2 delivers every message", async () => {
   const received: Array<{ channel: string; message: string }> = [];
   const { promise, resolve } = Promise.withResolvers<void>();
 
-  await sub.subscribe(channels, (message, channel) => {
-    received.push({ channel, message });
-    if (received.length === 2) resolve();
-  });
+  await withTimeout(
+    sub.subscribe(channels, (message, channel) => {
+      received.push({ channel, message });
+      if (received.length === 2) resolve();
+    }),
+    "multi-channel SUBSCRIBE confirmation (RESP2)",
+  );
 
-  expect(await pub.send("PUBLISH", [channels[0], "hello-a"])).toBe(1);
-  expect(await pub.send("PUBLISH", [channels[1], "hello-b"])).toBe(1);
+  expect(await withTimeout(pub.send("PUBLISH", [channels[0], "hello-a"]), "PUBLISH channel 0")).toBe(1);
+  expect(await withTimeout(pub.send("PUBLISH", [channels[1], "hello-b"]), "PUBLISH channel 1")).toBe(1);
 
-  await promise;
+  await withTimeout(promise, "both multi-channel messages delivered (RESP2)");
 
   // Order between channels is not guaranteed, sort for stable comparison.
   received.sort((x, y) => x.channel.localeCompare(y.channel));
@@ -96,7 +123,7 @@ t("multi-channel subscribe after HELLO 2 delivers every message", async () => {
     { channel: channels[1], message: "hello-b" },
   ]);
 
-  await sub.unsubscribe(channels);
+  await withTimeout(sub.unsubscribe(channels), "multi-channel UNSUBSCRIBE (RESP2)");
   sub.close();
   pub.close();
 });
@@ -108,12 +135,12 @@ t("unsubscribe after HELLO 2 resolves its promise", async () => {
   await sub.send("HELLO", ["2"]);
 
   const channel = `bun-29042-${crypto.randomUUID()}`;
-  await sub.subscribe(channel, () => {});
+  await withTimeout(sub.subscribe(channel, () => {}), "SUBSCRIBE confirmation (RESP2)");
 
-  // If RESP2 unsubscribe confirmations are dropped, this promise hangs
-  // forever — the test harness will time it out rather than report a
-  // meaningful failure. So just call it and make sure we reach the next line.
-  await sub.unsubscribe(channel);
+  // Without the fix the UNSUBSCRIBE confirmation frame (a RESP2 array) was
+  // never matched in the subscriber dispatch, so this promise would hang.
+  // withTimeout turns that hang into a clear regression message.
+  await withTimeout(sub.unsubscribe(channel), "UNSUBSCRIBE confirmation (RESP2)");
 
   sub.close();
 });


### PR DESCRIPTION
Fixes #29042.

## Repro

```ts
const pub = new Bun.RedisClient("redis://localhost:6379");
await pub.connect();

const sub = new Bun.RedisClient("redis://localhost:6379");
await sub.connect();
await sub.send("HELLO", ["2"]); // force RESP2 on the subscriber

const received: string[] = [];
await sub.subscribe("bun-repro:chan", (message) => received.push(message));

console.log(await pub.send("PUBLISH", ["bun-repro:chan", "hello"]));
// → 1    (server counts the subscriber)
await new Promise((r) => setTimeout(r, 500));
console.log(received);
// before: []
// after:  [ "hello" ]
```

## Cause

`ValkeyClient.handleResponse` / `handleSubscribeResponse` in `src/valkey/valkey.zig` dispatch subscriber notifications by pattern-matching on the RESP3 `.Push` (`>`) wire type. When the user switches the subscriber connection into RESP2 mode via `HELLO 2`, Redis keeps delivering `message` / `subscribe` / `unsubscribe` notifications on the wire but now encodes them as ordinary `.Array` values (`*3\r\n$7\r\nmessage\r\n$...\r\n...`). Those never matched `.Push`, so they fell through the subscriber block and were silently dropped — no error, no rejection, no handler call. The server-side count from `PUBLISH` was correct because Redis still considered the client subscribed.

## Fix

Added `SubscriptionPushMessage.asFrame(value)` in `src/valkey/valkey_protocol.zig` that recognizes a subscription frame whether it arrives as a RESP3 `.Push` or as a RESP2 `.Array` whose first element is a matching kind tag. Both entry points in `valkey.zig` (the promise-pair gating and the subscribe dispatch) now use that helper, so:

- RESP2 `message` frames reach `onValkeyMessage` and fire the JS handler.
- RESP2 `subscribe` / `unsubscribe` confirmations resolve their promises instead of hanging.
- Non-subscription replies (e.g. RESP3 subscribers receiving a `PING` response) still fall through to the regular command handler.

## Verification

New regression test `test/regression/issue/29042.test.ts`:

- `bun bd test test/regression/issue/29042.test.ts` → **pass**
- `USE_SYSTEM_BUN=1 bun test test/regression/issue/29042.test.ts` → **fail** (two tests time out because the handler never fires, one throws `can only be called while in subscriber mode` because the SUBSCRIBE confirmation was dropped)

Also added two RESP2 cases to the existing `PUB/SUB` describe block in `test/js/valkey/valkey.test.ts` so the Docker-backed pipeline exercises the fix too.