### PR TITLE
fix(http2): add captureRejectionSymbol handler to Http2SecureServer

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4186,7 +4186,8 @@ class Http2SecureServer extends tls.Server {
     closeAllSessions(this);
   }
 }
-Http2SecureServer.prototype[EventEmitter.captureRejectionSymbol] = Http2Server.prototype[EventEmitter.captureRejectionSymbol];
+Http2SecureServer.prototype[EventEmitter.captureRejectionSymbol] =
+  Http2Server.prototype[EventEmitter.captureRejectionSymbol];
 function createServer(options, onRequestHandler) {
   return new Http2Server(options, onRequestHandler);
 }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4186,6 +4186,7 @@ class Http2SecureServer extends tls.Server {
     closeAllSessions(this);
   }
 }
+Http2SecureServer.prototype[EventEmitter.captureRejectionSymbol] = Http2Server.prototype[EventEmitter.captureRejectionSymbol];
 function createServer(options, onRequestHandler) {
   return new Http2Server(options, onRequestHandler);
 }

--- a/test/js/node/http2/h2-secureserver-rejection.test.ts
+++ b/test/js/node/http2/h2-secureserver-rejection.test.ts
@@ -9,5 +9,6 @@ test("Http2SecureServer has captureRejectionSymbol handler matching Http2Server"
   const sym = (EventEmitter as any).captureRejectionSymbol;
   expect(typeof (secure as any)[sym]).toBe("function");
   expect((secure as any)[sym]).toBe((plain as any)[sym]);
+  plain.close();
   secure.close();
 });

--- a/test/js/node/http2/h2-secureserver-rejection.test.ts
+++ b/test/js/node/http2/h2-secureserver-rejection.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "bun:test";
+import http2 from "node:http2";
+import { EventEmitter } from "node:events";
+import { tls } from "harness";
+
+test("Http2SecureServer has captureRejectionSymbol handler matching Http2Server", () => {
+  const plain = http2.createServer();
+  const secure = http2.createSecureServer({ key: tls.key, cert: tls.cert });
+  const sym = (EventEmitter as any).captureRejectionSymbol;
+  expect(typeof (secure as any)[sym]).toBe("function");
+  expect((secure as any)[sym]).toBe((plain as any)[sym]);
+  secure.close();
+});

--- a/test/js/node/http2/h2-secureserver-rejection.test.ts
+++ b/test/js/node/http2/h2-secureserver-rejection.test.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "bun:test";
-import http2 from "node:http2";
-import { EventEmitter } from "node:events";
+import { expect, test } from "bun:test";
 import { tls } from "harness";
+import { EventEmitter } from "node:events";
+import http2 from "node:http2";
 
 test("Http2SecureServer has captureRejectionSymbol handler matching Http2Server", () => {
   const plain = http2.createServer();


### PR DESCRIPTION
`Http2Server.prototype[captureRejectionSymbol]` was set but `Http2SecureServer` inherits only from `tls.Server`, so async rejections in secure-server stream/request handlers were not routed through the http2 handler (which responds 500 + closes the stream). Node assigns the same handler to both server classes (lib/internal/http2/core.js:3450). Match that.