### PR TITLE
fix(install): skip lockfile-level diff checks in recursive workspace comparisons

### DIFF
--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -571,27 +571,31 @@ pub fn Package(comptime SemverIntType: type) type {
                 const from_resolutions = from.resolutions.get(from_lockfile.buffers.resolutions.items);
                 var to_i: usize = 0;
 
-                if (from_lockfile.overrides.map.count() != to_lockfile.overrides.map.count()) {
-                    summary.overrides_changed = true;
+                // Overrides are a lockfile-level concept; skip for recursive
+                // workspace-package comparisons (same rationale as trusted_dependencies).
+                if (is_root) {
+                    if (from_lockfile.overrides.map.count() != to_lockfile.overrides.map.count()) {
+                        summary.overrides_changed = true;
 
-                    if (PackageManager.verbose_install) {
-                        Output.prettyErrorln("Overrides changed since last install", .{});
-                    }
-                } else {
-                    from_lockfile.overrides.sort(from_lockfile);
-                    to_lockfile.overrides.sort(to_lockfile);
-                    for (
-                        from_lockfile.overrides.map.keys(),
-                        from_lockfile.overrides.map.values(),
-                        to_lockfile.overrides.map.keys(),
-                        to_lockfile.overrides.map.values(),
-                    ) |from_k, *from_override, to_k, *to_override| {
-                        if ((from_k != to_k) or (!from_override.eql(to_override, from_lockfile.buffers.string_bytes.items, to_lockfile.buffers.string_bytes.items))) {
-                            summary.overrides_changed = true;
-                            if (PackageManager.verbose_install) {
-                                Output.prettyErrorln("Overrides changed since last install", .{});
+                        if (PackageManager.verbose_install) {
+                            Output.prettyErrorln("Overrides changed since last install", .{});
+                        }
+                    } else {
+                        from_lockfile.overrides.sort(from_lockfile);
+                        to_lockfile.overrides.sort(to_lockfile);
+                        for (
+                            from_lockfile.overrides.map.keys(),
+                            from_lockfile.overrides.map.values(),
+                            to_lockfile.overrides.map.keys(),
+                            to_lockfile.overrides.map.values(),
+                        ) |from_k, *from_override, to_k, *to_override| {
+                            if ((from_k != to_k) or (!from_override.eql(to_override, from_lockfile.buffers.string_bytes.items, to_lockfile.buffers.string_bytes.items))) {
+                                summary.overrides_changed = true;
+                                if (PackageManager.verbose_install) {
+                                    Output.prettyErrorln("Overrides changed since last install", .{});
+                                }
+                                break;
                             }
-                            break;
                         }
                     }
                 }
@@ -680,6 +684,15 @@ pub fn Package(comptime SemverIntType: type) type {
                     //     are dependencies are all from the new lockfile. Removed is empty because the default
                     //     list isn't appended to the lockfile.
 
+                    // Trusted dependencies are a lockfile-level concept. When this
+                    // function is called recursively to compare individual workspace
+                    // packages, from_lockfile/to_lockfile are the *global* lockfiles
+                    // — not per-workspace — so comparing their trusted_dependencies
+                    // here produces a spurious diff (the temp lockfile used for the
+                    // fresh package.json parse has no trusted_dependencies). Skip
+                    // this check for non-root (recursive) calls.
+                    if (!is_root) break :trusted_dependencies;
+
                     // 1
                     if (from_lockfile.trusted_dependencies == null and to_lockfile.trusted_dependencies == null) break :trusted_dependencies;
 
@@ -765,7 +778,10 @@ pub fn Package(comptime SemverIntType: type) type {
                     }
                 }
 
+                // Patched dependencies are a lockfile-level concept; skip for
+                // recursive workspace-package comparisons.
                 summary.patched_dependencies_changed = patched_dependencies_changed: {
+                    if (!is_root) break :patched_dependencies_changed false;
                     if (from_lockfile.patched_dependencies.entries.len != to_lockfile.patched_dependencies.entries.len) break :patched_dependencies_changed true;
                     var iter = to_lockfile.patched_dependencies.iterator();
                     while (iter.next()) |entry| {

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1949,3 +1949,73 @@ test("matching workspace devDependency and npm peerDependency", async () => {
   expect(err).not.toContain("updated");
   expect(out).toContain("no changes");
 });
+
+// Regression test for https://github.com/oven-sh/bun/issues/19088
+// --frozen-lockfile was failing in workspace monorepos because lockfile-level
+// properties (trusted dependencies, overrides, patched dependencies) were
+// spuriously compared during recursive per-workspace diff calls.
+test("frozen lockfile succeeds in workspace monorepo with workspace: deps", async () => {
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "my-monorepo",
+        workspaces: ["packages/*"],
+      }),
+    ),
+    write(
+      join(packageDir, "packages", "shared", "package.json"),
+      JSON.stringify({
+        name: "@test/shared",
+        version: "1.0.0",
+        dependencies: {
+          "no-deps": "1.0.0",
+        },
+      }),
+    ),
+    write(
+      join(packageDir, "packages", "app", "package.json"),
+      JSON.stringify({
+        name: "@test/app",
+        version: "1.0.0",
+        dependencies: {
+          "@test/shared": "workspace:*",
+          "no-deps": "1.0.0",
+        },
+      }),
+    ),
+  ]);
+
+  // First install generates the lockfile
+  var { exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+
+  expect(await exited).toBe(0);
+
+  // --frozen-lockfile must succeed immediately after
+  ({ exited } = spawn({
+    cmd: [bunExe(), "install", "--frozen-lockfile"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  }));
+
+  expect(await exited).toBe(0);
+
+  // --production (which implies --frozen-lockfile) must also succeed
+  ({ exited } = spawn({
+    cmd: [bunExe(), "install", "--production"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  }));
+
+  expect(await exited).toBe(0);
+});

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1987,7 +1987,7 @@ test("frozen lockfile succeeds in workspace monorepo with workspace: deps", asyn
   ]);
 
   // First install generates the lockfile
-  var { exited } = spawn({
+  var proc = spawn({
     cmd: [bunExe(), "install"],
     cwd: packageDir,
     stdout: "ignore",
@@ -1995,27 +1995,33 @@ test("frozen lockfile succeeds in workspace monorepo with workspace: deps", asyn
     env,
   });
 
-  expect(await exited).toBe(0);
+  var stderr = await proc.stderr.text();
+  expect(stderr).not.toContain("error");
+  expect(await proc.exited).toBe(0);
 
   // --frozen-lockfile must succeed immediately after
-  ({ exited } = spawn({
+  proc = spawn({
     cmd: [bunExe(), "install", "--frozen-lockfile"],
     cwd: packageDir,
     stdout: "ignore",
     stderr: "pipe",
     env,
-  }));
+  });
 
-  expect(await exited).toBe(0);
+  stderr = await proc.stderr.text();
+  expect(stderr).not.toContain("lockfile had changes");
+  expect(await proc.exited).toBe(0);
 
   // --production (which implies --frozen-lockfile) must also succeed
-  ({ exited } = spawn({
+  proc = spawn({
     cmd: [bunExe(), "install", "--production"],
     cwd: packageDir,
     stdout: "ignore",
     stderr: "pipe",
     env,
-  }));
+  });
 
-  expect(await exited).toBe(0);
+  stderr = await proc.stderr.text();
+  expect(stderr).not.toContain("lockfile had changes");
+  expect(await proc.exited).toBe(0);
 });

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1954,7 +1954,7 @@ test("matching workspace devDependency and npm peerDependency", async () => {
 // --frozen-lockfile was failing in workspace monorepos because lockfile-level
 // properties (trusted dependencies, overrides, patched dependencies) were
 // spuriously compared during recursive per-workspace diff calls.
-test("frozen lockfile succeeds in workspace monorepo with workspace: deps", async () => {
+test("frozen lockfile succeeds in workspace monorepo with trustedDependencies", async () => {
   await Promise.all([
     write(
       packageJson,
@@ -1971,6 +1971,7 @@ test("frozen lockfile succeeds in workspace monorepo with workspace: deps", asyn
         dependencies: {
           "no-deps": "1.0.0",
         },
+        trustedDependencies: ["no-deps"],
       }),
     ),
     write(
@@ -1987,41 +1988,47 @@ test("frozen lockfile succeeds in workspace monorepo with workspace: deps", asyn
   ]);
 
   // First install generates the lockfile
-  var proc = spawn({
-    cmd: [bunExe(), "install"],
-    cwd: packageDir,
-    stdout: "ignore",
-    stderr: "pipe",
-    env,
-  });
+  {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
 
-  var stderr = await proc.stderr.text();
-  expect(stderr).not.toContain("error");
-  expect(await proc.exited).toBe(0);
+    const stderr = await proc.stderr.text();
+    expect(stderr).not.toContain("lockfile had changes");
+    expect(await proc.exited).toBe(0);
+  }
 
   // --frozen-lockfile must succeed immediately after
-  proc = spawn({
-    cmd: [bunExe(), "install", "--frozen-lockfile"],
-    cwd: packageDir,
-    stdout: "ignore",
-    stderr: "pipe",
-    env,
-  });
+  {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
 
-  stderr = await proc.stderr.text();
-  expect(stderr).not.toContain("lockfile had changes");
-  expect(await proc.exited).toBe(0);
+    const stderr = await proc.stderr.text();
+    expect(stderr).not.toContain("lockfile had changes");
+    expect(await proc.exited).toBe(0);
+  }
 
   // --production (which implies --frozen-lockfile) must also succeed
-  proc = spawn({
-    cmd: [bunExe(), "install", "--production"],
-    cwd: packageDir,
-    stdout: "ignore",
-    stderr: "pipe",
-    env,
-  });
+  {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--production"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
 
-  stderr = await proc.stderr.text();
-  expect(stderr).not.toContain("lockfile had changes");
-  expect(await proc.exited).toBe(0);
+    const stderr = await proc.stderr.text();
+    expect(stderr).not.toContain("lockfile had changes");
+    expect(await proc.exited).toBe(0);
+  }
 });


### PR DESCRIPTION
### What does this PR do?

Fixes `bun install --frozen-lockfile` (and `--production`, which implies frozen lockfile) always failing in workspace monorepos, even when the lockfile was just generated by `bun install` on the same machine.

**Root cause:** `Package.Diff.generate` is called recursively — once at the root level to compare the root package, and then for each workspace package. The recursive calls receive the *global* `from_lockfile` and `to_lockfile`, not per-workspace lockfiles. When any workspace `package.json` has `trustedDependencies`, the temp lockfile accumulates state across workspace comparisons, producing spurious diffs that mark every subsequent workspace as "updated". This triggers unnecessary dependency re-resolution, which in large monorepos produces a different hoisted dependency tree, causing the frozen-lockfile `eql` check to fail. The same class of bug affects `overrides` and `patched_dependencies`.

**Fix:** Guard the `overrides`, `trusted_dependencies`, and `patched_dependencies` comparisons with `is_root` checks, matching the existing guard on `catalogs` (which was already correctly wrapped in `if (is_root)`). These lockfile-level concepts are already correctly compared in the root-level call — the recursive workspace calls were redundant and harmful.

Fixes #19088

Reproduction: [hassellof/bun-frozen-lockfile-repro](https://github.com/hassellof/bun-frozen-lockfile-repro) (minimal). Also consistently reproduced against a private [Phystack](https://github.com/phystack) monorepo with 4 apps, 6 shared workspace packages, and ~4600 total dependencies.

### How did you verify your code works?

Tested against the real-world workspace monorepo described above:

```bash
# Before fix:
bun install                    # succeeds
bun install --frozen-lockfile  # FAILS: "lockfile had changes, but lockfile is frozen"
bun install --production       # FAILS: same error

# After fix:
bun install                    # succeeds
bun install --frozen-lockfile  # succeeds
bun install --production       # succeeds
```

All 63 existing workspace tests pass (0 failures), including the new regression test.

Also verified that the binary lockfile format (`bun.lockb`) was unaffected — it uses a different comparison path (`hasMetaHashChanged`) that doesn't have this issue.

## Test plan

- [x] Verified fix against real workspace monorepo reproduction case
- [x] Verified `--frozen-lockfile` passes after clean install
- [x] Verified `--production` (which implies `--frozen-lockfile`) passes
- [x] Verified binary lockfile still works
- [x] Regression test added (`test/cli/install/bun-workspaces.test.ts`)
- [x] All 63 workspace tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)