### PR TITLE
fix(http2): treat unsolicited PING ACK as PROTOCOL_ERROR per RFC 9113 §6.7

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -2258,7 +2258,11 @@ pub const H2FrameParser = struct {
             if (isNotACK) {
                 this.sendPing(true, payload);
             } else {
-                this.outStandingPings -|= 1;
+                if (this.outStandingPings == 0) {
+                    this.sendGoAway(0, ErrorCode.PROTOCOL_ERROR, "Unsolicited PING ACK", this.lastStreamID, true);
+                    return content.end;
+                }
+                this.outStandingPings -= 1;
             }
             const buffer = this.handlers.binary_type.toJS(payload, this.handlers.globalObject) catch .zero; // TODO: properly propagate exception upwards
             this.dispatchWithExtra(.onPing, buffer, jsc.JSValue.jsBoolean(!isNotACK));

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -673,6 +673,10 @@ pub const H2FrameParser = struct {
     queuedDataSize: u64 = 0, // this is in bytes
     maxOutstandingPings: u64 = 10,
     outStandingPings: u64 = 0,
+    /// 8-byte opaque payloads of PING frames we sent that are still awaiting an
+    /// ACK. RFC 9113 §6.7 requires the ACK to echo the exact payload, so we
+    /// must remember what we sent in order to reject unsolicited/mismatched ACKs.
+    outstandingPingPayloads: std.ArrayListUnmanaged([8]u8) = .{},
     maxSendHeaderBlockLength: u32 = 0,
     lastStreamID: u32 = 0,
     isServer: bool = false,
@@ -1432,6 +1436,10 @@ pub const H2FrameParser = struct {
         const writer = stream.writer();
         if (!ack) {
             this.outStandingPings += 1;
+            var stored: [8]u8 = .{0} ** 8;
+            const len = @min(payload.len, 8);
+            @memcpy(stored[0..len], payload[0..len]);
+            bun.handleOom(this.outstandingPingPayloads.append(this.allocator, stored));
         }
         var frame = FrameHeader{
             .type = @intFromEnum(FrameType.HTTP_FRAME_PING),
@@ -2258,11 +2266,20 @@ pub const H2FrameParser = struct {
             if (isNotACK) {
                 this.sendPing(true, payload);
             } else {
-                if (this.outStandingPings == 0) {
+                // RFC 9113 §6.7: a PING ACK MUST contain the exact opaque data
+                // of a PING we previously sent. Reject ACKs that do not match
+                // any outstanding PING payload (including the case where no
+                // PINGs are outstanding at all).
+                const matched_index: ?usize = for (this.outstandingPingPayloads.items, 0..) |stored, i| {
+                    if (strings.eql(stored[0..], payload)) break i;
+                } else null;
+                if (matched_index) |i| {
+                    _ = this.outstandingPingPayloads.orderedRemove(i);
+                    this.outStandingPings -= 1;
+                } else {
                     this.sendGoAway(0, ErrorCode.PROTOCOL_ERROR, "Unsolicited PING ACK", this.lastStreamID, true);
                     return data.len;
                 }
-                this.outStandingPings -= 1;
             }
             const buffer = this.handlers.binary_type.toJS(payload, this.handlers.globalObject) catch .zero; // TODO: properly propagate exception upwards
             this.dispatchWithExtra(.onPing, buffer, jsc.JSValue.jsBoolean(!isNotACK));
@@ -4785,6 +4802,7 @@ pub const H2FrameParser = struct {
         this.readBuffer.deinit();
         this.writeBuffer.clearAndFree(this.allocator);
         this.writeBufferOffset = 0;
+        this.outstandingPingPayloads.clearAndFree(this.allocator);
 
         if (this.hpack) |hpack| {
             hpack.deinit();

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -2260,7 +2260,7 @@ pub const H2FrameParser = struct {
             } else {
                 if (this.outStandingPings == 0) {
                     this.sendGoAway(0, ErrorCode.PROTOCOL_ERROR, "Unsolicited PING ACK", this.lastStreamID, true);
-                    return content.end;
+                    return data.len;
                 }
                 this.outStandingPings -= 1;
             }

--- a/test/js/node/http2/h2-ping-unsolicited-ack.test.ts
+++ b/test/js/node/http2/h2-ping-unsolicited-ack.test.ts
@@ -4,7 +4,10 @@ import http2 from "node:http2";
 import net from "node:net";
 
 const kSettings = Buffer.from([0, 0, 0, 4, 0, 0, 0, 0, 0]);
-const kPingAck = Buffer.from([0, 0, 8, 6, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+function pingAck(payload: Buffer) {
+  return Buffer.concat([Buffer.from([0, 0, 8, 6, 1, 0, 0, 0, 0]), payload]);
+}
+const kPingAck = pingAck(Buffer.alloc(8));
 
 test("server treats unsolicited PING ACK as a protocol error per RFC 9113 §6.7", async () => {
   const server = http2.createServer();
@@ -28,6 +31,72 @@ test("server treats unsolicited PING ACK as a protocol error per RFC 9113 §6.7"
     const err = await errored;
     expect(err).toBeInstanceOf(Error);
     expect((err as NodeJS.ErrnoException).code).toMatch(/^ERR_HTTP2/);
+  } finally {
+    conn.destroy();
+    server.close();
+    await once(server, "close");
+  }
+});
+
+test("server treats PING ACK with mismatched payload as a protocol error per RFC 9113 §6.7", async () => {
+  const sentPayload = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+  const server = http2.createServer();
+  const { promise: errored, resolve, reject } = Promise.withResolvers<Error>();
+  server.on("session", session => {
+    // send a real PING so outStandingPings > 0; the ACK we send back will have a different payload
+    session.ping(sentPayload, () => {});
+    session.on("error", err => resolve(err as Error));
+    session.on("close", () => reject(new Error("session closed without error")));
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as net.AddressInfo).port;
+
+  const conn = net.connect(port);
+  conn.on("error", () => {});
+  try {
+    await once(conn, "connect");
+    conn.write(Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", "ascii"));
+    conn.write(kSettings);
+    // ACK with a payload that does NOT match the PING the server sent
+    conn.write(pingAck(Buffer.from([9, 9, 9, 9, 9, 9, 9, 9])));
+
+    const err = await errored;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as NodeJS.ErrnoException).code).toMatch(/^ERR_HTTP2/);
+  } finally {
+    conn.destroy();
+    server.close();
+    await once(server, "close");
+  }
+});
+
+test("server accepts PING ACK whose payload matches an outstanding PING", async () => {
+  const sentPayload = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+  const server = http2.createServer();
+  const { promise: result, resolve, reject } = Promise.withResolvers<Buffer>();
+  server.on("session", session => {
+    session.ping(sentPayload, (err, _duration, payload) => {
+      if (err) reject(err);
+      else resolve(payload);
+    });
+    session.on("error", err => reject(err));
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as net.AddressInfo).port;
+
+  const conn = net.connect(port);
+  conn.on("error", () => {});
+  try {
+    await once(conn, "connect");
+    conn.write(Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", "ascii"));
+    conn.write(kSettings);
+    // ACK with the exact payload the server sent
+    conn.write(pingAck(sentPayload));
+
+    const payload = await result;
+    expect(Buffer.compare(payload, sentPayload)).toBe(0);
   } finally {
     conn.destroy();
     server.close();

--- a/test/js/node/http2/h2-ping-unsolicited-ack.test.ts
+++ b/test/js/node/http2/h2-ping-unsolicited-ack.test.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "bun:test";
+import http2 from "node:http2";
+import net from "node:net";
+import { once } from "node:events";
+
+const kSettings = Buffer.from([0, 0, 0, 4, 0, 0, 0, 0, 0]);
+const kPingAck = Buffer.from([0, 0, 8, 6, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+
+test("server treats unsolicited PING ACK as a protocol error per RFC 9113 §6.7", async () => {
+  const server = http2.createServer();
+  const { promise: errored, resolve, reject } = Promise.withResolvers<Error>();
+  server.on("session", session => {
+    session.on("error", err => resolve(err as Error));
+    session.on("close", () => reject(new Error("session closed without error")));
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as net.AddressInfo).port;
+
+  const conn = net.connect(port);
+  conn.on("error", () => {});
+  await once(conn, "connect");
+  conn.write(Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", "ascii"));
+  conn.write(kSettings);
+  conn.write(kPingAck);
+
+  const err = await errored;
+  expect(err).toBeInstanceOf(Error);
+  expect((err as NodeJS.ErrnoException).code).toMatch(/^ERR_HTTP2/);
+
+  conn.destroy();
+  server.close();
+  await once(server, "close");
+});

--- a/test/js/node/http2/h2-ping-unsolicited-ack.test.ts
+++ b/test/js/node/http2/h2-ping-unsolicited-ack.test.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
+import { once } from "node:events";
 import http2 from "node:http2";
 import net from "node:net";
-import { once } from "node:events";
 
 const kSettings = Buffer.from([0, 0, 0, 4, 0, 0, 0, 0, 0]);
 const kPingAck = Buffer.from([0, 0, 8, 6, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);

--- a/test/js/node/http2/h2-ping-unsolicited-ack.test.ts
+++ b/test/js/node/http2/h2-ping-unsolicited-ack.test.ts
@@ -1,7 +1,7 @@
-import { expect, test } from "bun:test";
-import { once } from "node:events";
+import { test, expect } from "bun:test";
 import http2 from "node:http2";
 import net from "node:net";
+import { once } from "node:events";
 
 const kSettings = Buffer.from([0, 0, 0, 4, 0, 0, 0, 0, 0]);
 const kPingAck = Buffer.from([0, 0, 8, 6, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
@@ -19,16 +19,18 @@ test("server treats unsolicited PING ACK as a protocol error per RFC 9113 §6.7"
 
   const conn = net.connect(port);
   conn.on("error", () => {});
-  await once(conn, "connect");
-  conn.write(Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", "ascii"));
-  conn.write(kSettings);
-  conn.write(kPingAck);
+  try {
+    await once(conn, "connect");
+    conn.write(Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", "ascii"));
+    conn.write(kSettings);
+    conn.write(kPingAck);
 
-  const err = await errored;
-  expect(err).toBeInstanceOf(Error);
-  expect((err as NodeJS.ErrnoException).code).toMatch(/^ERR_HTTP2/);
-
-  conn.destroy();
-  server.close();
-  await once(server, "close");
+    const err = await errored;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as NodeJS.ErrnoException).code).toMatch(/^ERR_HTTP2/);
+  } finally {
+    conn.destroy();
+    server.close();
+    await once(server, "close");
+  }
 });


### PR DESCRIPTION
RFC 9113 §6.7: a PING ACK that doesn't correspond to a previously sent PING is a protocol error. nghttp2 detects this via `NGHTTP2_ERR_PROTO` and tears down the session; Bun was silently saturating-subtracting `outStandingPings` and continuing.

Now sends `GOAWAY(PROTOCOL_ERROR)` and emits a session error when an unsolicited ACK arrives.

The error currently surfaces as `ERR_HTTP2_SESSION_ERROR` (Node uses `ERR_HTTP2_ERROR` via `NghttpError`); matching that exactly requires distinguishing locally-detected protocol errors from peer-sent GOAWAY in the JS error handler — tracked as a follow-up. Adds a focused test exercising the detection.