### PR TITLE
fix(http2): support raw [k,v,...] header arrays in request()/respond()

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -4068,6 +4068,9 @@ pub const H2FrameParser = struct {
                     const name_slice = name_str.toUTF8(bun.default_allocator);
                     defer name_slice.deinit();
                     const name = name_slice.slice();
+                    if (name.len > name_buffer.len) {
+                        return globalObject.ERR(.HTTP2_INVALID_HEADER_VALUE, "Header name is too long", .{}).throw();
+                    }
 
                     const validated_name = toValidHeaderName(name, name_buffer[0..name.len]) catch {
                         const exception = globalObject.toTypeError(.INVALID_HTTP_TOKEN, "The arguments Header name is invalid. Received \"{s}\"", .{name});
@@ -4123,7 +4126,7 @@ pub const H2FrameParser = struct {
                         stream.state = .CLOSED;
                         stream.rstCode = @intFromEnum(ErrorCode.COMPRESSION_ERROR);
                         this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
-                        return .js_undefined;
+                        return jsc.JSValue.jsNumber(stream_id);
                     };
                 }
             }

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -4048,84 +4048,199 @@ pub const H2FrameParser = struct {
         }
 
         // we iterate twice, because pseudo headers must be sent first, but can appear anywhere in the headers object
-        var iter = try jsc.JSPropertyIterator(.{
-            .skip_empty_name = false,
-            .include_value = true,
-        }).init(globalObject, headers_obj);
-        defer iter.deinit();
         var single_value_headers: [SingleValueHeaders.keys().len]bool = undefined;
         @memset(&single_value_headers, false);
 
-        for (0..2) |ignore_pseudo_headers| {
-            iter.reset();
-
-            while (try iter.next()) |header_name| {
-                if (header_name.length() == 0) continue;
-
-                const name_slice = header_name.toUTF8(bun.default_allocator);
-                defer name_slice.deinit();
-                const name = name_slice.slice();
-
-                const validated_name = toValidHeaderName(name, name_buffer[0..name.len]) catch {
-                    const exception = globalObject.toTypeError(.INVALID_HTTP_TOKEN, "The arguments Header name is invalid. Received \"{s}\"", .{name});
-                    return globalObject.throwValue(exception);
-                };
-
-                if (header_name.charAt(0) == ':') {
-                    if (ignore_pseudo_headers == 1) continue;
-
-                    if (this.isServer) {
-                        if (!ValidResponsePseudoHeaders.has(validated_name)) {
-                            if (!globalObject.hasException()) {
-                                return globalObject.ERR(.HTTP2_INVALID_PSEUDOHEADER, "\"{s}\" is an invalid pseudoheader or is used incorrectly", .{name}).throw();
-                            }
-                            return .zero;
-                        }
-                    } else {
-                        if (!ValidRequestPseudoHeaders.has(validated_name)) {
-                            if (!globalObject.hasException()) {
-                                return globalObject.ERR(.HTTP2_INVALID_PSEUDOHEADER, "\"{s}\" is an invalid pseudoheader or is used incorrectly", .{name}).throw();
-                            }
-                            return .zero;
-                        }
+        if (headers_arg.jsType().isArray()) {
+            // Raw [k, v, k, v, ...] array form (Node.js raw headers). Preserves
+            // duplicate ordering on the wire so the receiver's rawHeaders matches.
+            const length = try headers_arg.getLength(globalObject);
+            for (0..2) |ignore_pseudo_headers| {
+                var i: usize = 0;
+                while (i + 1 < length) : (i += 2) {
+                    const name_js = try headers_arg.getIndex(globalObject, @intCast(i));
+                    if (!name_js.isString()) {
+                        return globalObject.throw("Expected header name to be a string", .{});
                     }
-                } else if (ignore_pseudo_headers == 0) {
-                    continue;
-                }
+                    const name_str = try name_js.toBunString(globalObject);
+                    defer name_str.deref();
+                    if (name_str.length() == 0) continue;
+                    const name_slice = name_str.toUTF8(bun.default_allocator);
+                    defer name_slice.deinit();
+                    const name = name_slice.slice();
 
-                const js_value = iter.value;
-                if (js_value.isUndefinedOrNull()) {
-                    const exception = globalObject.toTypeError(.HTTP2_INVALID_HEADER_VALUE, "Invalid value for header \"{s}\"", .{name});
-                    return globalObject.throwValue(exception);
-                }
+                    const validated_name = toValidHeaderName(name, name_buffer[0..name.len]) catch {
+                        const exception = globalObject.toTypeError(.INVALID_HTTP_TOKEN, "The arguments Header name is invalid. Received \"{s}\"", .{name});
+                        return globalObject.throwValue(exception);
+                    };
 
-                if (js_value.jsType().isArray()) {
-                    log("array header {s}", .{name});
-                    // https://github.com/oven-sh/bun/issues/8940
-                    var value_iter = try js_value.arrayIterator(globalObject);
+                    if (name[0] == ':') {
+                        if (ignore_pseudo_headers == 1) continue;
+                        if (this.isServer) {
+                            if (!ValidResponsePseudoHeaders.has(validated_name)) {
+                                return globalObject.ERR(.HTTP2_INVALID_PSEUDOHEADER, "\"{s}\" is an invalid pseudoheader or is used incorrectly", .{name}).throw();
+                            }
+                        } else if (!ValidRequestPseudoHeaders.has(validated_name)) {
+                            return globalObject.ERR(.HTTP2_INVALID_PSEUDOHEADER, "\"{s}\" is an invalid pseudoheader or is used incorrectly", .{name}).throw();
+                        }
+                    } else if (ignore_pseudo_headers == 0) {
+                        continue;
+                    }
 
                     if (SingleValueHeaders.indexOf(validated_name)) |idx| {
-                        if (value_iter.len > 1 or single_value_headers[idx]) {
-                            if (!globalObject.hasException()) {
-                                const exception = globalObject.toTypeError(.HTTP2_HEADER_SINGLE_VALUE, "Header field \"{s}\" must only have a single value", .{validated_name});
-                                return globalObject.throwValue(exception);
-                            }
-                            return .zero;
+                        if (single_value_headers[idx]) {
+                            const exception = globalObject.toTypeError(.HTTP2_HEADER_SINGLE_VALUE, "Header field \"{s}\" must only have a single value", .{validated_name});
+                            return globalObject.throwValue(exception);
                         }
                         single_value_headers[idx] = true;
                     }
 
-                    while (try value_iter.next()) |item| {
-                        if (item.isEmptyOrUndefinedOrNull()) {
-                            if (!globalObject.hasException()) {
-                                return globalObject.ERR(.HTTP2_INVALID_HEADER_VALUE, "Invalid value for header \"{s}\"", .{validated_name}).throw();
+                    const value_js = try headers_arg.getIndex(globalObject, @intCast(i + 1));
+                    if (value_js.isUndefinedOrNull()) {
+                        const exception = globalObject.toTypeError(.HTTP2_INVALID_HEADER_VALUE, "Invalid value for header \"{s}\"", .{name});
+                        return globalObject.throwValue(exception);
+                    }
+                    const value_str = value_js.toJSString(globalObject) catch {
+                        globalObject.clearException();
+                        return globalObject.ERR(.HTTP2_INVALID_HEADER_VALUE, "Invalid value for header \"{s}\"", .{name}).throw();
+                    };
+                    const value_slice = value_str.toSlice(globalObject, bun.default_allocator);
+                    defer value_slice.deinit();
+                    const value = value_slice.slice();
+
+                    const never_index = (try sensitive_arg.getTruthyPropertyValue(globalObject, validated_name) orelse try sensitive_arg.getTruthyPropertyValue(globalObject, name)) != null;
+
+                    _ = this.encodeHeaderIntoList(&encoded_headers, alloc, validated_name, value, never_index) catch |err| {
+                        if (err == error.OutOfMemory) {
+                            return globalObject.throw("Failed to allocate header buffer", .{});
+                        }
+                        const stream = this.handleReceivedStreamID(stream_id) orelse {
+                            return jsc.JSValue.jsNumber(-1);
+                        };
+                        if (!stream_ctx_arg.isEmptyOrUndefinedOrNull() and stream_ctx_arg.isObject()) {
+                            stream.setContext(stream_ctx_arg, globalObject);
+                        }
+                        stream.state = .CLOSED;
+                        stream.rstCode = @intFromEnum(ErrorCode.COMPRESSION_ERROR);
+                        this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
+                        return .js_undefined;
+                    };
+                }
+            }
+        } else {
+            var iter = try jsc.JSPropertyIterator(.{
+                .skip_empty_name = false,
+                .include_value = true,
+            }).init(globalObject, headers_obj);
+            defer iter.deinit();
+
+            for (0..2) |ignore_pseudo_headers| {
+                iter.reset();
+
+                while (try iter.next()) |header_name| {
+                    if (header_name.length() == 0) continue;
+
+                    const name_slice = header_name.toUTF8(bun.default_allocator);
+                    defer name_slice.deinit();
+                    const name = name_slice.slice();
+
+                    const validated_name = toValidHeaderName(name, name_buffer[0..name.len]) catch {
+                        const exception = globalObject.toTypeError(.INVALID_HTTP_TOKEN, "The arguments Header name is invalid. Received \"{s}\"", .{name});
+                        return globalObject.throwValue(exception);
+                    };
+
+                    if (header_name.charAt(0) == ':') {
+                        if (ignore_pseudo_headers == 1) continue;
+
+                        if (this.isServer) {
+                            if (!ValidResponsePseudoHeaders.has(validated_name)) {
+                                if (!globalObject.hasException()) {
+                                    return globalObject.ERR(.HTTP2_INVALID_PSEUDOHEADER, "\"{s}\" is an invalid pseudoheader or is used incorrectly", .{name}).throw();
+                                }
+                                return .zero;
                             }
-                            return .zero;
+                        } else {
+                            if (!ValidRequestPseudoHeaders.has(validated_name)) {
+                                if (!globalObject.hasException()) {
+                                    return globalObject.ERR(.HTTP2_INVALID_PSEUDOHEADER, "\"{s}\" is an invalid pseudoheader or is used incorrectly", .{name}).throw();
+                                }
+                                return .zero;
+                            }
+                        }
+                    } else if (ignore_pseudo_headers == 0) {
+                        continue;
+                    }
+
+                    const js_value = iter.value;
+                    if (js_value.isUndefinedOrNull()) {
+                        const exception = globalObject.toTypeError(.HTTP2_INVALID_HEADER_VALUE, "Invalid value for header \"{s}\"", .{name});
+                        return globalObject.throwValue(exception);
+                    }
+
+                    if (js_value.jsType().isArray()) {
+                        log("array header {s}", .{name});
+                        // https://github.com/oven-sh/bun/issues/8940
+                        var value_iter = try js_value.arrayIterator(globalObject);
+
+                        if (SingleValueHeaders.indexOf(validated_name)) |idx| {
+                            if (value_iter.len > 1 or single_value_headers[idx]) {
+                                if (!globalObject.hasException()) {
+                                    const exception = globalObject.toTypeError(.HTTP2_HEADER_SINGLE_VALUE, "Header field \"{s}\" must only have a single value", .{validated_name});
+                                    return globalObject.throwValue(exception);
+                                }
+                                return .zero;
+                            }
+                            single_value_headers[idx] = true;
                         }
 
-                        const value_str = item.toJSString(globalObject) catch {
+                        while (try value_iter.next()) |item| {
+                            if (item.isEmptyOrUndefinedOrNull()) {
+                                if (!globalObject.hasException()) {
+                                    return globalObject.ERR(.HTTP2_INVALID_HEADER_VALUE, "Invalid value for header \"{s}\"", .{validated_name}).throw();
+                                }
+                                return .zero;
+                            }
+
+                            const value_str = item.toJSString(globalObject) catch {
+                                globalObject.clearException();
+                                return globalObject.ERR(.HTTP2_INVALID_HEADER_VALUE, "Invalid value for header \"{s}\"", .{validated_name}).throw();
+                            };
+
+                            const never_index = (try sensitive_arg.getTruthyPropertyValue(globalObject, validated_name) orelse try sensitive_arg.getTruthyPropertyValue(globalObject, name)) != null;
+
+                            const value_slice = value_str.toSlice(globalObject, bun.default_allocator);
+                            defer value_slice.deinit();
+                            const value = value_slice.slice();
+                            log("encode header {s} {s}", .{ validated_name, value });
+
+                            _ = this.encodeHeaderIntoList(&encoded_headers, alloc, validated_name, value, never_index) catch |err| {
+                                if (err == error.OutOfMemory) {
+                                    return globalObject.throw("Failed to allocate header buffer", .{});
+                                }
+                                const stream = this.handleReceivedStreamID(stream_id) orelse {
+                                    return jsc.JSValue.jsNumber(-1);
+                                };
+                                if (!stream_ctx_arg.isEmptyOrUndefinedOrNull() and stream_ctx_arg.isObject()) {
+                                    stream.setContext(stream_ctx_arg, globalObject);
+                                }
+                                stream.state = .CLOSED;
+                                stream.rstCode = @intFromEnum(ErrorCode.COMPRESSION_ERROR);
+                                this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
+                                return .js_undefined;
+                            };
+                        }
+                    } else if (!js_value.isEmptyOrUndefinedOrNull()) {
+                        log("single header {s}", .{name});
+                        if (SingleValueHeaders.indexOf(validated_name)) |idx| {
+                            if (single_value_headers[idx]) {
+                                const exception = globalObject.toTypeError(.HTTP2_HEADER_SINGLE_VALUE, "Header field \"{s}\" must only have a single value", .{validated_name});
+                                return globalObject.throwValue(exception);
+                            }
+                            single_value_headers[idx] = true;
+                        }
+                        const value_str = js_value.toJSString(globalObject) catch {
                             globalObject.clearException();
-                            return globalObject.ERR(.HTTP2_INVALID_HEADER_VALUE, "Invalid value for header \"{s}\"", .{validated_name}).throw();
+                            return globalObject.ERR(.HTTP2_INVALID_HEADER_VALUE, "Invalid value for header \"{s}\"", .{name}).throw();
                         };
 
                         const never_index = (try sensitive_arg.getTruthyPropertyValue(globalObject, validated_name) orelse try sensitive_arg.getTruthyPropertyValue(globalObject, name)) != null;
@@ -4142,51 +4257,15 @@ pub const H2FrameParser = struct {
                             const stream = this.handleReceivedStreamID(stream_id) orelse {
                                 return jsc.JSValue.jsNumber(-1);
                             };
+                            stream.state = .CLOSED;
                             if (!stream_ctx_arg.isEmptyOrUndefinedOrNull() and stream_ctx_arg.isObject()) {
                                 stream.setContext(stream_ctx_arg, globalObject);
                             }
-                            stream.state = .CLOSED;
                             stream.rstCode = @intFromEnum(ErrorCode.COMPRESSION_ERROR);
                             this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
-                            return .js_undefined;
+                            return jsc.JSValue.jsNumber(stream_id);
                         };
                     }
-                } else if (!js_value.isEmptyOrUndefinedOrNull()) {
-                    log("single header {s}", .{name});
-                    if (SingleValueHeaders.indexOf(validated_name)) |idx| {
-                        if (single_value_headers[idx]) {
-                            const exception = globalObject.toTypeError(.HTTP2_HEADER_SINGLE_VALUE, "Header field \"{s}\" must only have a single value", .{validated_name});
-                            return globalObject.throwValue(exception);
-                        }
-                        single_value_headers[idx] = true;
-                    }
-                    const value_str = js_value.toJSString(globalObject) catch {
-                        globalObject.clearException();
-                        return globalObject.ERR(.HTTP2_INVALID_HEADER_VALUE, "Invalid value for header \"{s}\"", .{name}).throw();
-                    };
-
-                    const never_index = (try sensitive_arg.getTruthyPropertyValue(globalObject, validated_name) orelse try sensitive_arg.getTruthyPropertyValue(globalObject, name)) != null;
-
-                    const value_slice = value_str.toSlice(globalObject, bun.default_allocator);
-                    defer value_slice.deinit();
-                    const value = value_slice.slice();
-                    log("encode header {s} {s}", .{ validated_name, value });
-
-                    _ = this.encodeHeaderIntoList(&encoded_headers, alloc, validated_name, value, never_index) catch |err| {
-                        if (err == error.OutOfMemory) {
-                            return globalObject.throw("Failed to allocate header buffer", .{});
-                        }
-                        const stream = this.handleReceivedStreamID(stream_id) orelse {
-                            return jsc.JSValue.jsNumber(-1);
-                        };
-                        stream.state = .CLOSED;
-                        if (!stream_ctx_arg.isEmptyOrUndefinedOrNull() and stream_ctx_arg.isObject()) {
-                            stream.setContext(stream_ctx_arg, globalObject);
-                        }
-                        stream.rstCode = @intFromEnum(ErrorCode.COMPRESSION_ERROR);
-                        this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
-                        return jsc.JSValue.jsNumber(stream_id);
-                    };
                 }
             }
         }

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -4055,6 +4055,9 @@ pub const H2FrameParser = struct {
             // Raw [k, v, k, v, ...] array form (Node.js raw headers). Preserves
             // duplicate ordering on the wire so the receiver's rawHeaders matches.
             const length = try headers_arg.getLength(globalObject);
+            if (length % 2 != 0) {
+                return globalObject.ERR(.INVALID_ARG_VALUE, "The argument 'headers' must have an even number of elements", .{}).throw();
+            }
             for (0..2) |ignore_pseudo_headers| {
                 var i: usize = 0;
                 while (i + 1 < length) : (i += 2) {
@@ -4146,6 +4149,9 @@ pub const H2FrameParser = struct {
                     const name_slice = header_name.toUTF8(bun.default_allocator);
                     defer name_slice.deinit();
                     const name = name_slice.slice();
+                    if (name.len > name_buffer.len) {
+                        return globalObject.ERR(.HTTP2_INVALID_HEADER_VALUE, "Header name is too long", .{}).throw();
+                    }
 
                     const validated_name = toValidHeaderName(name, name_buffer[0..name.len]) catch {
                         const exception = globalObject.toTypeError(.INVALID_HTTP_TOKEN, "The arguments Header name is invalid. Received \"{s}\"", .{name});

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3883,8 +3883,11 @@ class ClientHttp2Session extends Http2Session {
       if (headers == undefined) {
         headers = {};
       } else if (ArrayIsArray(headers)) {
+        if (headers.length % 2 !== 0) {
+          throw $ERR_INVALID_ARG_VALUE("headers", headers, "must have an even number of elements");
+        }
         sensitives = headers[sensitiveHeaders];
-        rawHeaders = headers;
+        rawHeaders = ArrayPrototypeSlice.$call(headers);
         headers = undefined;
       } else if (!$isObject(headers)) {
         throw $ERR_INVALID_ARG_TYPE("headers", "object", headers);

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -63,6 +63,8 @@ const ObjectKeys = Object.keys;
 const FunctionPrototypeBind = Function.prototype.bind;
 const StringPrototypeTrim = String.prototype.trim;
 const ArrayPrototypePush = Array.prototype.push;
+const ArrayPrototypeSlice = Array.prototype.slice;
+const ArrayPrototypeUnshift = Array.prototype.unshift;
 const StringPrototypeToLowerCase = String.prototype.toLowerCase;
 const StringPrototypeIncludes = String.prototype.includes;
 const StringPrototypeStartsWith = String.prototype.startsWith;
@@ -2625,8 +2627,11 @@ class ServerHttp2Stream extends Http2Stream {
     if (headers == undefined) {
       headers = {};
     } else if (ArrayIsArray(headers)) {
+      if (headers.length % 2 !== 0) {
+        throw $ERR_INVALID_ARG_VALUE("headers", headers, "must have an even number of elements");
+      }
       sensitives = headers[sensitiveHeaders];
-      rawHeaders = headers;
+      rawHeaders = ArrayPrototypeSlice.$call(headers);
       headers = undefined;
     } else if (!$isObject(headers)) {
       throw $ERR_INVALID_ARG_TYPE("headers", "object", headers);
@@ -2654,10 +2659,9 @@ class ServerHttp2Stream extends Http2Stream {
         if (key === HTTP2_HEADER_STATUS) statusCode = rawHeaders[i + 1];
         else if (key === "date") hasDate = true;
       }
-      rawHeaders = rawHeaders.slice();
       if (statusCode === undefined) {
         statusCode = 200;
-        rawHeaders.unshift(HTTP2_HEADER_STATUS, statusCode);
+        ArrayPrototypeUnshift.$call(rawHeaders, HTTP2_HEADER_STATUS, statusCode);
       }
       const sendDate = options?.sendDate;
       if (!hasDate && (sendDate == null || sendDate)) {
@@ -3903,9 +3907,14 @@ class ClientHttp2Session extends Http2Session {
 
       let authority, method, scheme, path;
       if (rawHeaders !== undefined) {
+        let hasHost = false;
         for (let i = 0; i < rawHeaders.length; i += 2) {
-          if (rawHeaders[i][0] !== ":") continue;
-          const key = StringPrototypeToLowerCase.$call(rawHeaders[i]);
+          const rawKey = rawHeaders[i];
+          if (rawKey[0] !== ":") {
+            if (!hasHost && StringPrototypeToLowerCase.$call(rawKey) === "host") hasHost = true;
+            continue;
+          }
+          const key = StringPrototypeToLowerCase.$call(rawKey);
           const value = rawHeaders[i + 1];
           if (key === ":method") method = value;
           else if (key === ":scheme") scheme = value;
@@ -3917,7 +3926,7 @@ class ClientHttp2Session extends Http2Session {
           method = "GET";
           ArrayPrototypePush.$call(additional, ":method", method);
         }
-        if (authority === undefined) {
+        if (authority === undefined && !hasHost) {
           authority = this.#authority;
           ArrayPrototypePush.$call(additional, ":authority", authority);
         }
@@ -3929,7 +3938,10 @@ class ClientHttp2Session extends Http2Session {
         if (path === undefined) {
           ArrayPrototypePush.$call(additional, ":path", "/");
         }
-        rawHeaders = additional.length ? additional.concat(rawHeaders) : rawHeaders.slice();
+        if (additional.length) {
+          for (let i = 0; i < rawHeaders.length; i++) ArrayPrototypePush.$call(additional, rawHeaders[i]);
+          rawHeaders = additional;
+        }
         if (sensitives !== undefined) rawHeaders[sensitiveHeaders] = sensitives;
       } else {
         authority = headers[":authority"];

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -320,6 +320,7 @@ const bunHTTP2StreamStatus = Symbol.for("::bunhttp2StreamStatus::");
 
 const bunHTTP2Session = Symbol.for("::bunhttp2session::");
 const bunHTTP2Headers = Symbol.for("::bunhttp2headers::");
+const bunHTTP2RawHeaders = Symbol.for("::bunhttp2rawheaders::");
 
 const ReflectGetPrototypeOf = Reflect.getPrototypeOf;
 
@@ -1966,6 +1967,7 @@ class Http2Stream extends Duplex {
 
   rstCode: number | undefined = undefined;
   [bunHTTP2Headers]: any;
+  [bunHTTP2RawHeaders]: any;
   [kInfoHeaders]: any;
   #sentTrailers: any;
   [kAborted]: boolean = false;
@@ -2002,7 +2004,28 @@ class Http2Stream extends Duplex {
   }
 
   get sentHeaders() {
-    return this[bunHTTP2Headers];
+    if (this[bunHTTP2Headers] || !this[bunHTTP2RawHeaders]) {
+      return this[bunHTTP2Headers];
+    }
+    const rawHeaders = this[bunHTTP2RawHeaders];
+    const headersObject = { __proto__: null };
+    for (let i = 0; i < rawHeaders.length; i += 2) {
+      const key = rawHeaders[i];
+      const value = rawHeaders[i + 1];
+      const existing = headersObject[key];
+      if (existing === undefined) {
+        headersObject[key] = value;
+      } else if (ArrayIsArray(existing)) {
+        ArrayPrototypePush.$call(existing, value);
+      } else {
+        headersObject[key] = [existing, value];
+      }
+    }
+    if (rawHeaders[sensitiveHeaders] !== undefined) {
+      headersObject[sensitiveHeaders] = rawHeaders[sensitiveHeaders];
+    }
+    this[bunHTTP2Headers] = headersObject;
+    return headersObject;
   }
 
   get sentInfoHeaders() {
@@ -2597,29 +2620,64 @@ class ServerHttp2Stream extends Http2Stream {
       throw $ERR_HTTP2_TRAILERS_ALREADY_SENT();
     }
 
+    let rawHeaders: any[] | undefined;
+    let sensitives;
     if (headers == undefined) {
       headers = {};
+    } else if (ArrayIsArray(headers)) {
+      sensitives = headers[sensitiveHeaders];
+      rawHeaders = headers;
+      headers = undefined;
     } else if (!$isObject(headers)) {
       throw $ERR_INVALID_ARG_TYPE("headers", "object", headers);
     } else {
       headers = { ...headers };
+      sensitives = headers[sensitiveHeaders];
+      delete headers[sensitiveHeaders];
     }
 
-    const sensitives = headers[sensitiveHeaders];
-    delete headers[sensitiveHeaders];
     const sensitiveNames = {};
     if (sensitives) {
       if (!$isArray(sensitives)) {
         throw $ERR_INVALID_ARG_VALUE("headers[http2.neverIndex]", sensitives);
       }
       for (let i = 0; i < sensitives.length; i++) {
-        sensitiveNames[sensitives[i]] = true;
+        sensitiveNames[StringPrototypeToLowerCase.$call(sensitives[i])] = true;
       }
     }
-    if (headers[HTTP2_HEADER_STATUS] === undefined) {
-      headers[HTTP2_HEADER_STATUS] = 200;
+
+    let statusCode;
+    if (rawHeaders !== undefined) {
+      let hasDate = false;
+      for (let i = 0; i < rawHeaders.length; i += 2) {
+        const key = StringPrototypeToLowerCase.$call(rawHeaders[i]);
+        if (key === HTTP2_HEADER_STATUS) statusCode = rawHeaders[i + 1];
+        else if (key === "date") hasDate = true;
+      }
+      rawHeaders = rawHeaders.slice();
+      if (statusCode === undefined) {
+        statusCode = 200;
+        rawHeaders.unshift(HTTP2_HEADER_STATUS, statusCode);
+      }
+      const sendDate = options?.sendDate;
+      if (!hasDate && (sendDate == null || sendDate)) {
+        ArrayPrototypePush.$call(rawHeaders, "date", utcDate());
+      }
+      if (sensitives !== undefined) rawHeaders[sensitiveHeaders] = sensitives;
+    } else {
+      if (headers[HTTP2_HEADER_STATUS] === undefined) {
+        headers[HTTP2_HEADER_STATUS] = 200;
+      }
+      statusCode = headers[HTTP2_HEADER_STATUS];
+      const sendDate = options?.sendDate;
+      if (sendDate == null || sendDate) {
+        const current_date = headers["date"];
+        if (current_date == null) {
+          headers["date"] = utcDate();
+        }
+      }
     }
-    const statusCode = headers[HTTP2_HEADER_STATUS];
+
     let endStream = !!options?.endStream;
     if (
       endStream ||
@@ -2631,21 +2689,19 @@ class ServerHttp2Stream extends Http2Stream {
       options = { ...options, endStream: true };
       endStream = true;
     }
-    const sendDate = options?.sendDate;
-    if (sendDate == null || sendDate) {
-      const current_date = headers["date"];
-      if (current_date == null) {
-        headers["date"] = utcDate();
-      }
-    }
 
+    const headersToSend = rawHeaders !== undefined ? rawHeaders : headers;
     if (typeof options === "undefined") {
-      session[bunHTTP2Native]?.request(this.id, undefined, headers, sensitiveNames);
+      session[bunHTTP2Native]?.request(this.id, undefined, headersToSend, sensitiveNames);
     } else {
-      session[bunHTTP2Native]?.request(this.id, undefined, headers, sensitiveNames, options);
+      session[bunHTTP2Native]?.request(this.id, undefined, headersToSend, sensitiveNames, options);
     }
     this.headersSent = true;
-    this[bunHTTP2Headers] = headers;
+    if (rawHeaders !== undefined) {
+      this[bunHTTP2RawHeaders] = rawHeaders;
+    } else {
+      this[bunHTTP2Headers] = headers;
+    }
     if (endStream) {
       this.end();
     }
@@ -3818,59 +3874,94 @@ class ClientHttp2Session extends Http2Session {
         throw $ERR_HTTP2_TRAILERS_ALREADY_SENT();
       }
 
+      let rawHeaders: any[] | undefined;
+      let sensitives;
       if (headers == undefined) {
         headers = {};
+      } else if (ArrayIsArray(headers)) {
+        sensitives = headers[sensitiveHeaders];
+        rawHeaders = headers;
+        headers = undefined;
       } else if (!$isObject(headers)) {
         throw $ERR_INVALID_ARG_TYPE("headers", "object", headers);
       } else {
         headers = { ...headers };
+        sensitives = headers[sensitiveHeaders];
+        delete headers[sensitiveHeaders];
       }
 
-      const sensitives = headers[sensitiveHeaders];
-      delete headers[sensitiveHeaders];
       const sensitiveNames = {};
       if (sensitives) {
         if (!$isArray(sensitives)) {
           throw $ERR_INVALID_ARG_VALUE("headers[http2.neverIndex]", sensitives);
         }
         for (let i = 0; i < sensitives.length; i++) {
-          sensitiveNames[sensitives[i]] = true;
+          sensitiveNames[StringPrototypeToLowerCase.$call(sensitives[i])] = true;
         }
       }
       const url = this.#url;
 
-      let authority = headers[":authority"];
-      if (!authority) {
-        // Use precomputed authority (like Node.js's session[kAuthority])
-        authority = this.#authority;
-        if (!headers["host"]) {
-          headers[":authority"] = authority;
+      let authority, method, scheme, path;
+      if (rawHeaders !== undefined) {
+        for (let i = 0; i < rawHeaders.length; i += 2) {
+          if (rawHeaders[i][0] !== ":") continue;
+          const key = StringPrototypeToLowerCase.$call(rawHeaders[i]);
+          const value = rawHeaders[i + 1];
+          if (key === ":method") method = value;
+          else if (key === ":scheme") scheme = value;
+          else if (key === ":authority") authority = value;
+          else if (key === ":path") path = value;
         }
-      }
-      let method = headers[":method"];
-      if (!method) {
-        method = "GET";
-        headers[":method"] = method;
-      }
-
-      let scheme = headers[":scheme"];
-      if (!scheme) {
-        let protocol: string = url.protocol || options?.protocol || "https:";
-        switch (protocol) {
-          case "https:":
-            scheme = "https";
-            break;
-          case "http:":
-            scheme = "http";
-            break;
-          default:
-            scheme = protocol;
+        const additional: string[] = [];
+        if (method === undefined) {
+          method = "GET";
+          ArrayPrototypePush.$call(additional, ":method", method);
         }
-        headers[":scheme"] = scheme;
-      }
-
-      if (headers[":path"] == undefined) {
-        headers[":path"] = "/";
+        if (authority === undefined) {
+          authority = this.#authority;
+          ArrayPrototypePush.$call(additional, ":authority", authority);
+        }
+        if (scheme === undefined) {
+          const protocol: string = url.protocol || options?.protocol || "https:";
+          scheme = protocol === "http:" ? "http" : protocol === "https:" ? "https" : protocol;
+          ArrayPrototypePush.$call(additional, ":scheme", scheme);
+        }
+        if (path === undefined) {
+          ArrayPrototypePush.$call(additional, ":path", "/");
+        }
+        rawHeaders = additional.length ? additional.concat(rawHeaders) : rawHeaders.slice();
+        if (sensitives !== undefined) rawHeaders[sensitiveHeaders] = sensitives;
+      } else {
+        authority = headers[":authority"];
+        if (!authority) {
+          authority = this.#authority;
+          if (!headers["host"]) {
+            headers[":authority"] = authority;
+          }
+        }
+        method = headers[":method"];
+        if (!method) {
+          method = "GET";
+          headers[":method"] = method;
+        }
+        scheme = headers[":scheme"];
+        if (!scheme) {
+          const protocol: string = url.protocol || options?.protocol || "https:";
+          switch (protocol) {
+            case "https:":
+              scheme = "https";
+              break;
+            case "http:":
+              scheme = "http";
+              break;
+            default:
+              scheme = protocol;
+          }
+          headers[":scheme"] = scheme;
+        }
+        if (headers[":path"] == undefined) {
+          headers[":path"] = "/";
+        }
       }
 
       if (NoPayloadMethods.has(method.toUpperCase())) {
@@ -3883,16 +3974,19 @@ class ClientHttp2Session extends Http2Session {
       let stream_id: number = this.#parser.getNextStream();
       if (stream_id < 0) {
         const req = new ClientHttp2Stream(undefined, this, headers);
+        if (rawHeaders !== undefined) req[bunHTTP2RawHeaders] = rawHeaders;
         process.nextTick(emitOutofStreamErrorNT, req);
         return req;
       }
       const req = new ClientHttp2Stream(stream_id, this, headers);
+      if (rawHeaders !== undefined) req[bunHTTP2RawHeaders] = rawHeaders;
       req.authority = authority;
       req[kHeadRequest] = method === HTTP2_METHOD_HEAD;
+      const headersToSend = rawHeaders !== undefined ? rawHeaders : headers;
       if (typeof options === "undefined") {
-        this.#parser.request(stream_id, req, headers, sensitiveNames);
+        this.#parser.request(stream_id, req, headersToSend, sensitiveNames);
       } else {
-        this.#parser.request(stream_id, req, headers, sensitiveNames, options);
+        this.#parser.request(stream_id, req, headersToSend, sensitiveNames, options);
       }
       process.nextTick(emitEventNT, req, "ready");
       return req;

--- a/test/js/node/test/parallel/test-http2-raw-headers-defaults.js
+++ b/test/js/node/test/parallel/test-http2-raw-headers-defaults.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+{
+  const server = http2.createServer();
+  server.on('stream', common.mustCall((stream, _headers, _flags, rawHeaders) => {
+    assert.deepStrictEqual(rawHeaders, [
+      ':method', 'GET',
+      ':authority', `localhost:${server.address().port}`,
+      ':scheme', 'http',
+      ':path', '/',
+      'a', 'b',
+      'x-foo', 'bar', // Lowercased as required for HTTP/2
+      'a', 'c', // Duplicate header order preserved
+    ]);
+    stream.respond([
+      'x', '1',
+      'x-FOO', 'bar',
+      'x', '2',
+    ]);
+
+    assert.partialDeepStrictEqual(stream.sentHeaders, {
+      '__proto__': null,
+      ':status': 200,
+      'x': [ '1', '2' ],
+      'x-FOO': 'bar',
+    });
+
+    assert.strictEqual(typeof stream.sentHeaders.date, 'string');
+
+    stream.end();
+  }));
+
+
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+    const client = http2.connect(`http://localhost:${port}`);
+
+    const req = client.request([
+      'a', 'b',
+      'x-FOO', 'bar',
+      'a', 'c',
+    ]).end();
+
+    assert.deepStrictEqual(req.sentHeaders, {
+      '__proto__': null,
+      ':path': '/',
+      ':scheme': 'http',
+      ':authority': `localhost:${server.address().port}`,
+      ':method': 'GET',
+      'a': [ 'b', 'c' ],
+      'x-FOO': 'bar',
+    });
+
+    req.on('response', common.mustCall((_headers, _flags, rawHeaders) => {
+      assert.strictEqual(rawHeaders.length, 10);
+      assert.deepStrictEqual(rawHeaders.slice(0, 8), [
+        ':status', '200',
+        'x', '1',
+        'x-foo', 'bar', // Lowercased as required for HTTP/2
+        'x', '2', // Duplicate header order preserved
+      ]);
+
+      assert.strictEqual(rawHeaders[8], 'date');
+      assert.strictEqual(typeof rawHeaders[9], 'string');
+
+      client.close();
+      server.close();
+    }));
+  }));
+}

--- a/test/js/node/test/parallel/test-http2-raw-headers.js
+++ b/test/js/node/test/parallel/test-http2-raw-headers.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+{
+  const server = http2.createServer();
+  server.on('stream', common.mustCall((stream, _headers, _flags, rawHeaders) => {
+    assert.deepStrictEqual(rawHeaders, [
+      ':path', '/foobar',
+      ':scheme', 'http',
+      ':authority', `test.invalid:${server.address().port}`,
+      ':method', 'POST',
+      'a', 'b',
+      'x-foo', 'bar', // Lowercased as required for HTTP/2
+      'a', 'c', // Duplicate header order preserved
+    ]);
+
+    stream.respond([
+      ':status', '404',
+      'x', '1',
+      'x-FOO', 'bar',
+      'x', '2',
+      'DATE', '0000',
+    ]);
+
+    assert.deepStrictEqual(stream.sentHeaders, {
+      '__proto__': null,
+      ':status': '404',
+      'x': [ '1', '2' ],
+      'x-FOO': 'bar',
+      'DATE': '0000',
+    });
+
+    stream.end();
+  }));
+
+
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+    const client = http2.connect(`http://localhost:${port}`);
+
+    const req = client.request([
+      ':path', '/foobar',
+      ':scheme', 'http',
+      ':authority', `test.invalid:${server.address().port}`,
+      ':method', 'POST',
+      'a', 'b',
+      'x-FOO', 'bar',
+      'a', 'c',
+    ]).end();
+
+    assert.deepStrictEqual(req.sentHeaders, {
+      '__proto__': null,
+      ':path': '/foobar',
+      ':scheme': 'http',
+      ':authority': `test.invalid:${server.address().port}`,
+      ':method': 'POST',
+      'a': [ 'b', 'c' ],
+      'x-FOO': 'bar',
+    });
+
+    req.on('response', common.mustCall((_headers, _flags, rawHeaders) => {
+      assert.deepStrictEqual(rawHeaders, [
+        ':status', '404',
+        'x', '1',
+        'x-foo', 'bar', // Lowercased as required for HTTP/2
+        'x', '2', // Duplicate header order preserved
+        'date', '0000', // Server doesn't automatically set its own value
+      ]);
+      client.close();
+      server.close();
+    }));
+  }));
+}


### PR DESCRIPTION
Node.js allows passing headers to `client.request()` and `stream.respond()` as a flat `[name, value, name, value, ...]` array, preserving duplicate ordering on the wire and exposing it via the `rawHeaders` argument of `'stream'`/`'response'`. `stream.sentHeaders` lazily reflects this as a null-prototype object (case preserved, duplicates → array).

Bun previously only handled object headers; arrays were spread into `{0:k, 1:v, ...}` and rejected by the Zig encoder.

**JS** (`src/js/node/http2.ts`): `request()`/`respond()` now detect array headers, prepend default pseudo-headers (matching Node's `prepareRequestHeadersArray`), store the augmented array on the stream, and pass the array to native. New lazy `sentHeaders` getter mirrors Node's. Also lowercases `sensitiveHeaders` keys for case-insensitive matching.

**Zig** (`h2_frame_parser.zig`): `request()` adds an array branch that iterates `[k,v]` pairs in two passes (RFC 9113 §8.3 — pseudo-headers first), validating and HPACK-encoding in order so the receiver's `rawHeaders` matches sender order.

Ports Node tests `test-http2-raw-headers.js` and `test-http2-raw-headers-defaults.js`.