### PR TITLE
fix(http2): propagate session.destroy(error) to in-flight stream 'error' listeners

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -312,6 +312,7 @@ function getUnpackedSettings(buf?: any, options?: any): any {
 const sensitiveHeaders = Symbol.for("nodejs.http2.sensitiveHeaders");
 const bunHTTP2Native = Symbol.for("::bunhttp2native::");
 
+const bunHTTP2SessionDestroyError = Symbol("bunHTTP2SessionDestroyError");
 const bunHTTP2Socket = Symbol.for("::bunhttp2socket::");
 const bunHTTP2OriginSet = Symbol("::bunhttp2originset::");
 const bunHTTP2StreamFinal = Symbol.for("::bunHTTP2StreamFinal::");
@@ -2669,7 +2670,11 @@ function emitStreamErrorNT(self, stream, error, destroy, destroy_self) {
   if (stream) {
     let error_instance: Error | number | undefined = undefined;
     if (stream.listenerCount("error") > 0) {
-      if (typeof error === "number") {
+      const sessionErr = self?.[bunHTTP2SessionDestroyError];
+      if (sessionErr !== undefined) {
+        error_instance = sessionErr;
+        if (typeof error === "number") stream.rstCode = error;
+      } else if (typeof error === "number") {
         stream.rstCode = error;
         if (error != 0) {
           error_instance = streamErrorFromCode(error);
@@ -3250,6 +3255,7 @@ class ServerHttp2Session extends Http2Session {
     }
     const parser = this.#parser;
     if (parser) {
+      if (error !== undefined) this[bunHTTP2SessionDestroyError] = error;
       parser.emitErrorToAllStreams(code || constants.NGHTTP2_NO_ERROR);
       parser.detach();
       this.#parser = null;
@@ -3796,6 +3802,7 @@ class ClientHttp2Session extends Http2Session {
     }
     const parser = this.#parser;
     if (parser) {
+      if (error !== undefined) this[bunHTTP2SessionDestroyError] = error;
       parser.emitErrorToAllStreams(code || constants.NGHTTP2_NO_ERROR);
       parser.detach();
     }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3240,9 +3240,15 @@ class ServerHttp2Session extends Http2Session {
     if (server) {
       server[kSessions].delete(this);
     }
+    let streamDestroyError: Error | undefined;
     if (typeof error === "number") {
       code = error;
       error = code !== NGHTTP2_NO_ERROR ? $ERR_HTTP2_SESSION_ERROR(code) : undefined;
+    } else {
+      // Only forward caller-supplied Error objects to streams. When destroy() is invoked with
+      // a numeric code (protocol error), streams should keep receiving ERR_HTTP2_STREAM_ERROR
+      // derived from that code via emitErrorToAllStreams -> emitStreamErrorNT.
+      streamDestroyError = error;
     }
 
     const socket = this[bunHTTP2Socket];
@@ -3255,7 +3261,7 @@ class ServerHttp2Session extends Http2Session {
     }
     const parser = this.#parser;
     if (parser) {
-      if (error !== undefined) this[bunHTTP2SessionDestroyError] = error;
+      if (streamDestroyError !== undefined) this[bunHTTP2SessionDestroyError] = streamDestroyError;
       parser.emitErrorToAllStreams(code || constants.NGHTTP2_NO_ERROR);
       parser.detach();
       this.#parser = null;

--- a/test/js/node/http2/h2-session-destroy-stream-error.test.ts
+++ b/test/js/node/http2/h2-session-destroy-stream-error.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "bun:test";
+import http2 from "node:http2";
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+
+test("session.destroy(error) propagates the error to in-flight streams", async () => {
+  const server = http2.createServer();
+  server.on("stream", () => {});
+  server.listen(0);
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const client = http2.connect(`http://127.0.0.1:${port}`);
+  try {
+    await once(client, "connect");
+    const req = client.request({ ":path": "/" });
+    req.on("response", () => {});
+    req.end();
+
+    const { promise, resolve, reject } = Promise.withResolvers<unknown>();
+    req.on("error", resolve);
+    req.on("close", () => reject(new Error("stream closed without error")));
+
+    const myErr = Object.assign(new Error("boom"), { code: "ERR_HTTP2_SESSION_ERROR" });
+    client.on("error", () => {});
+    client.destroy(myErr);
+
+    const err = await promise;
+    expect(err).toBe(myErr);
+  } finally {
+    client.destroy();
+    server.close();
+    await once(server, "close");
+  }
+});

--- a/test/js/node/http2/h2-session-destroy-stream-error.test.ts
+++ b/test/js/node/http2/h2-session-destroy-stream-error.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "bun:test";
-import http2 from "node:http2";
+import { expect, test } from "bun:test";
 import { once } from "node:events";
+import http2 from "node:http2";
 import type { AddressInfo } from "node:net";
 
 test("session.destroy(error) propagates the error to in-flight streams", async () => {


### PR DESCRIPTION
Node's `closeSession` destroys open streams with the original session error ([lib/internal/http2/core.js:1222](https://github.com/nodejs/node/blob/main/lib/internal/http2/core.js)). Bun's `destroy()` called `parser.emitErrorToAllStreams(code)`, which surfaced to streams as a numeric code that `emitStreamErrorNT` mapped to `ERR_HTTP2_STREAM_ERROR` (or nothing for code 0), losing the original `Error`.

Now `destroy()` stores the Error on the session via a private symbol before tearing down streams; `emitStreamErrorNT` reads it and uses that as the stream's error when an `'error'` listener exists, matching Node semantics.

This is a partial step toward Node tests `test-http2-propagate-session-destroy-code.js` and `test-http2-server-shutdown-before-respond.js` (those also need `session.closed` timing changes shipped separately).