### PR TITLE
fix(http2): apply remote SETTINGS_HEADER_TABLE_SIZE to HPACK encoder

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -2438,6 +2438,13 @@ pub const H2FrameParser = struct {
                 if (this.outstandingSettings > 0) {
                     this.outstandingSettings -= 1;
 
+                    // RFC 7541 §4.2: now that the peer has ACKed our SETTINGS_HEADER_TABLE_SIZE,
+                    // raise/lower the decoder's max capacity so we accept Dynamic Table Size
+                    // Update instructions up to the value we advertised.
+                    if (this.hpack) |hpack| {
+                        hpack.setDecoderMaxCapacity(this.localSettings.headerTableSize);
+                    }
+
                     // Per RFC 7540 Section 6.9.2: When INITIAL_WINDOW_SIZE changes, adjust
                     // all existing stream windows by the difference. Now that our SETTINGS
                     // is ACKed, the peer knows about our window size, so we can enforce it.
@@ -2501,8 +2508,8 @@ pub const H2FrameParser = struct {
             this.readBuffer.reset();
             this.remoteSettings = remoteSettings;
             // RFC 9113 §6.5.2 / RFC 7541 §4.2: the peer's SETTINGS_HEADER_TABLE_SIZE bounds
-            // OUR encoder's dynamic table. ls-hpack will emit the required Dynamic Table
-            // Size Update on the next header block once we propagate the new limit.
+            // OUR encoder's dynamic table. NOTE: lshpack_enc_set_max_capacity does NOT
+            // auto-emit the RFC 7541 §6.3 Dynamic Table Size Update; that is tracked separately.
             if (this.hpack) |hpack| {
                 hpack.setEncoderMaxCapacity(remoteSettings.headerTableSize);
             }

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -2500,6 +2500,12 @@ pub const H2FrameParser = struct {
             }
             this.readBuffer.reset();
             this.remoteSettings = remoteSettings;
+            // RFC 9113 §6.5.2 / RFC 7541 §4.2: the peer's SETTINGS_HEADER_TABLE_SIZE bounds
+            // OUR encoder's dynamic table. ls-hpack will emit the required Dynamic Table
+            // Size Update on the next header block once we propagate the new limit.
+            if (this.hpack) |hpack| {
+                hpack.setEncoderMaxCapacity(remoteSettings.headerTableSize);
+            }
             log("remoteSettings.initialWindowSize: {} {} {}", .{ remoteSettings.initialWindowSize, this.remoteUsedWindowSize, this.remoteWindowSize });
             if (remoteSettings.initialWindowSize >= this.remoteWindowSize) {
                 var it = this.streams.valueIterator();

--- a/src/bun.js/api/bun/lshpack.zig
+++ b/src/bun.js/api/bun/lshpack.zig
@@ -53,6 +53,19 @@ pub const HPACK = extern struct {
     pub fn deinit(self: *HPACK) void {
         lshpack_wrapper_deinit(self);
     }
+
+    /// Called when the remote peer's SETTINGS_HEADER_TABLE_SIZE changes (RFC 9113 §6.5.2).
+    /// The encoder MUST NOT use a dynamic table larger than the peer permits, and must
+    /// emit an HPACK Dynamic Table Size Update (RFC 7541 §6.3) on the next header block.
+    pub fn setEncoderMaxCapacity(self: *HPACK, max_capacity: u32) void {
+        lshpack_wrapper_set_enc_max_capacity(self, max_capacity);
+    }
+
+    /// Called when our own SETTINGS_HEADER_TABLE_SIZE is acknowledged so the decoder
+    /// will accept Dynamic Table Size Update instructions up to the value we advertised.
+    pub fn setDecoderMaxCapacity(self: *HPACK, max_capacity: u32) void {
+        lshpack_wrapper_set_dec_max_capacity(self, max_capacity);
+    }
 };
 
 const lshpack_wrapper_alloc = ?*const fn (size: usize) callconv(.c) ?*anyopaque;
@@ -61,6 +74,8 @@ extern fn lshpack_wrapper_init(alloc: lshpack_wrapper_alloc, free: lshpack_wrapp
 extern fn lshpack_wrapper_deinit(self: *HPACK) void;
 extern fn lshpack_wrapper_decode(self: *HPACK, src: [*]const u8, src_len: usize, output: *lshpack_header) usize;
 extern fn lshpack_wrapper_encode(self: *HPACK, name: [*]const u8, name_len: usize, value: [*]const u8, value_len: usize, never_index: c_int, buffer: [*]u8, buffer_len: usize, buffer_offset: usize) usize;
+extern fn lshpack_wrapper_set_enc_max_capacity(self: *HPACK, max_capacity: c_uint) void;
+extern fn lshpack_wrapper_set_dec_max_capacity(self: *HPACK, max_capacity: c_uint) void;
 
 const bun = @import("bun");
 const mimalloc = bun.mimalloc;

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -350,6 +350,16 @@ void lshpack_wrapper_deinit(lshpack_wrapper* self)
     lshpack_enc_cleanup(&self->enc);
     self->free(self);
 }
+
+void lshpack_wrapper_set_enc_max_capacity(lshpack_wrapper* self, unsigned max_capacity)
+{
+    lshpack_enc_set_max_capacity(&self->enc, max_capacity);
+}
+
+void lshpack_wrapper_set_dec_max_capacity(lshpack_wrapper* self, unsigned max_capacity)
+{
+    lshpack_dec_set_max_capacity(&self->dec, max_capacity);
+}
 }
 
 #if OS(LINUX)

--- a/test/regression/issue/19152.test.ts
+++ b/test/regression/issue/19152.test.ts
@@ -1,0 +1,215 @@
+// Issue #19152: Bun's HTTP/2 server ignores peer's SETTINGS_HEADER_TABLE_SIZE.
+// Per RFC 9113 §6.5.2 the peer's SETTINGS_HEADER_TABLE_SIZE bounds OUR HPACK
+// encoder's dynamic table. When a client (e.g. nginx as reverse proxy) sends
+// SETTINGS_HEADER_TABLE_SIZE=0, the server must stop emitting dynamic-table
+// references (indices ≥ 62) and emit a Dynamic Table Size Update of 0
+// (RFC 7541 §6.3). Bun previously never propagated the remote setting to the
+// ls-hpack encoder, so the second response on a connection would reference a
+// dynamic-table entry the client never accepted, yielding "invalid http2 table
+// index" upstream.
+//
+// This test speaks raw HTTP/2 over a net.Socket so we can inspect the encoded
+// HEADERS bytes directly rather than relying on a lenient decoder.
+import { test, expect } from "bun:test";
+import http2 from "node:http2";
+import net from "node:net";
+import { once } from "node:events";
+
+const PREFACE = Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
+
+function frame(type: number, flags: number, streamId: number, payload: Buffer = Buffer.alloc(0)) {
+  const header = Buffer.alloc(9);
+  header.writeUIntBE(payload.length, 0, 3);
+  header.writeUInt8(type, 3);
+  header.writeUInt8(flags, 4);
+  header.writeUInt32BE(streamId & 0x7fffffff, 5);
+  return Buffer.concat([header, payload]);
+}
+
+function settingsFrame(pairs: Array<[number, number]>) {
+  const payload = Buffer.alloc(pairs.length * 6);
+  pairs.forEach(([id, value], i) => {
+    payload.writeUInt16BE(id, i * 6);
+    payload.writeUInt32BE(value, i * 6 + 2);
+  });
+  return frame(0x4, 0, 0, payload);
+}
+
+// Minimal HPACK encoding using only literal-without-indexing representations so
+// the request itself never depends on dynamic-table state.
+function hpackLiteral(name: string, value: string) {
+  const n = Buffer.from(name);
+  const v = Buffer.from(value);
+  return Buffer.concat([Buffer.from([0x00, n.length]), n, Buffer.from([v.length]), v]);
+}
+
+function requestHeaders() {
+  return Buffer.concat([
+    hpackLiteral(":method", "GET"),
+    hpackLiteral(":scheme", "http"),
+    hpackLiteral(":path", "/"),
+    hpackLiteral(":authority", "localhost"),
+  ]);
+}
+
+type ParsedFrame = { type: number; flags: number; streamId: number; payload: Buffer };
+
+function parseFrames(buf: Buffer): { frames: ParsedFrame[]; rest: Buffer } {
+  const frames: ParsedFrame[] = [];
+  let off = 0;
+  while (buf.length - off >= 9) {
+    const len = buf.readUIntBE(off, 3);
+    if (buf.length - off < 9 + len) break;
+    frames.push({
+      type: buf.readUInt8(off + 3),
+      flags: buf.readUInt8(off + 4),
+      streamId: buf.readUInt32BE(off + 5) & 0x7fffffff,
+      payload: buf.subarray(off + 9, off + 9 + len),
+    });
+    off += 9 + len;
+  }
+  return { frames, rest: buf.subarray(off) };
+}
+
+// Decode an HPACK integer with N-bit prefix starting at buf[pos]; returns [value, bytesConsumed].
+function hpackInt(buf: Buffer, pos: number, prefixBits: number): [number, number] {
+  const mask = (1 << prefixBits) - 1;
+  let value = buf[pos] & mask;
+  if (value < mask) return [value, 1];
+  let m = 0;
+  let i = 1;
+  while (true) {
+    const b = buf[pos + i];
+    value += (b & 0x7f) << m;
+    m += 7;
+    i++;
+    if ((b & 0x80) === 0) break;
+  }
+  return [value, i];
+}
+
+// Walk an HPACK header block and return a summary of representations seen.
+function scanHpack(block: Buffer) {
+  let pos = 0;
+  let sawSizeUpdateZero = false;
+  let maxIndexedRef = 0;
+  let incrementalIndexing = 0;
+  while (pos < block.length) {
+    const b = block[pos];
+    if (b & 0x80) {
+      // Indexed Header Field (RFC 7541 §6.1)
+      const [idx, n] = hpackInt(block, pos, 7);
+      maxIndexedRef = Math.max(maxIndexedRef, idx);
+      pos += n;
+    } else if ((b & 0xc0) === 0x40) {
+      // Literal with Incremental Indexing (RFC 7541 §6.2.1) — adds to dynamic table
+      incrementalIndexing++;
+      const [idx, n] = hpackInt(block, pos, 6);
+      pos += n;
+      if (idx === 0) {
+        const [nlen, nn] = hpackInt(block, pos, 7);
+        pos += nn + nlen;
+      }
+      const [vlen, vn] = hpackInt(block, pos, 7);
+      pos += vn + vlen;
+    } else if ((b & 0xe0) === 0x20) {
+      // Dynamic Table Size Update (RFC 7541 §6.3)
+      const [size, n] = hpackInt(block, pos, 5);
+      if (size === 0) sawSizeUpdateZero = true;
+      pos += n;
+    } else {
+      // Literal without Indexing / Never Indexed (§6.2.2, §6.2.3)
+      const [idx, n] = hpackInt(block, pos, 4);
+      pos += n;
+      if (idx === 0) {
+        const [nlen, nn] = hpackInt(block, pos, 7);
+        pos += nn + nlen;
+      }
+      const [vlen, vn] = hpackInt(block, pos, 7);
+      pos += vn + vlen;
+    }
+  }
+  return { sawSizeUpdateZero, maxIndexedRef, incrementalIndexing };
+}
+
+test("http2 server respects remote SETTINGS_HEADER_TABLE_SIZE=0 (issue #19152)", async () => {
+  const server = http2.createServer();
+  server.on("stream", stream => {
+    stream.respond({
+      ":status": 200,
+      "content-type": "text/plain",
+      "x-hpack-probe": "issue-19152",
+    });
+    stream.end();
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as net.AddressInfo).port;
+
+  try {
+    const sock = net.connect(port, "127.0.0.1");
+    await once(sock, "connect");
+
+    // Client preface + SETTINGS_HEADER_TABLE_SIZE=0. Per RFC 9113 §6.5.2 this
+    // limits the SERVER's HPACK encoder dynamic table to zero entries.
+    sock.write(PREFACE);
+    sock.write(settingsFrame([[0x1, 0]]));
+
+    let buffer = Buffer.alloc(0);
+    const allFrames: ParsedFrame[] = [];
+    sock.on("data", chunk => {
+      buffer = Buffer.concat([buffer, chunk]);
+      const { frames, rest } = parseFrames(buffer);
+      buffer = rest;
+      allFrames.push(...frames);
+    });
+
+    const waitFor = (pred: () => boolean) =>
+      new Promise<void>((resolve, reject) => {
+        const check = () => (pred() ? resolve() : undefined);
+        sock.on("data", check);
+        sock.on("error", reject);
+        sock.on("close", () => (pred() ? resolve() : reject(new Error("closed before condition met"))));
+        check();
+      });
+
+    // Wait for the server's initial SETTINGS, then ACK it.
+    await waitFor(() => allFrames.some(f => f.type === 0x4 && (f.flags & 0x1) === 0));
+    sock.write(frame(0x4, 0x1, 0));
+
+    // Wait for the server to ACK our SETTINGS so we know it has applied
+    // headerTableSize=0 before we send any request.
+    await waitFor(() => allFrames.some(f => f.type === 0x4 && (f.flags & 0x1) === 0x1));
+
+    // Two requests: a buggy server adds x-hpack-probe to its dynamic table on
+    // stream 1, then references it by index ≥ 62 on stream 3.
+    const req = requestHeaders();
+    sock.write(frame(0x1, 0x05, 1, req)); // HEADERS, END_STREAM|END_HEADERS
+    sock.write(frame(0x1, 0x05, 3, req));
+
+    await waitFor(() => allFrames.filter(f => f.type === 0x1 && f.streamId !== 0).length >= 2);
+    sock.destroy();
+
+    const responses = allFrames
+      .filter(f => f.type === 0x1)
+      .sort((a, b) => a.streamId - b.streamId)
+      .map(f => scanHpack(f.payload));
+
+    expect(responses.length).toBeGreaterThanOrEqual(2);
+
+    // NOTE: RFC 7541 §6.3 also requires emitting a Dynamic Table Size Update
+    // of 0 in the first subsequent header block. ls-hpack does not auto-emit
+    // this when capacity is reduced; tracked separately. The user-visible bug
+    // (#19152) is the dynamic-table references below, which this asserts.
+
+    for (const r of responses) {
+      // No dynamic-table references: static table ends at index 61.
+      expect(r.maxIndexedRef).toBeLessThanOrEqual(61);
+      // No literals-with-incremental-indexing: with a zero-size table the
+      // encoder must not attempt to add entries.
+      expect(r.incrementalIndexing).toBe(0);
+    }
+  } finally {
+    server.close();
+  }
+});

--- a/test/regression/issue/19152.test.ts
+++ b/test/regression/issue/19152.test.ts
@@ -10,10 +10,10 @@
 //
 // This test speaks raw HTTP/2 over a net.Socket so we can inspect the encoded
 // HEADERS bytes directly rather than relying on a lenient decoder.
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
+import { once } from "node:events";
 import http2 from "node:http2";
 import net from "node:net";
-import { once } from "node:events";
 
 const PREFACE = Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
 


### PR DESCRIPTION
RFC 9113 §6.5.2: a peer's `SETTINGS_HEADER_TABLE_SIZE` bounds **our** encoder's dynamic table. Bun never propagated the remote setting to ls-hpack, so the encoder would add entries to its dynamic table and reference them by index (≥62) even when the peer advertised size 0, causing decoders like nginx to fail with `upstream sent invalid http2 table index`.

Adds `lshpack_wrapper_set_{enc,dec}_max_capacity` bindings and calls `setEncoderMaxCapacity(remoteSettings.headerTableSize)` when applying remote SETTINGS, so the encoder stops emitting dynamic-table references and literal-with-incremental-indexing representations.

**Note**: RFC 7541 §6.3 additionally requires emitting a Dynamic Table Size Update at the start of the next header block when capacity decreases. ls-hpack's `lshpack_enc_set_max_capacity` does not auto-emit this; that strict-compliance gap is tracked separately. The functional bug — emitting indices the peer cannot decode — is fixed here.

Fixes #19152