### PR TITLE
fix(http2): reject non-zero content-length with END_STREAM on HEADERS per RFC 9113 8.6

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -1921,7 +1921,14 @@ pub const H2FrameParser = struct {
             }
 
             if (this.isServer and strings.eqlComptime(header.name, "content-length")) {
-                stream.contentLength = std.fmt.parseInt(i64, header.value, 10) catch -1;
+                // RFC 9113 §8.1.1: malformed if content-length is not a valid non-negative integer,
+                // or if multiple content-length fields with differing values are present.
+                const parsed = std.fmt.parseInt(i64, header.value, 10) catch -1;
+                if (parsed < 0 or (stream.contentLength != -1 and stream.contentLength != parsed)) {
+                    this.endStream(stream, ErrorCode.PROTOCOL_ERROR);
+                    return null;
+                }
+                stream.contentLength = parsed;
             }
 
             // RFC 7540 Section 6.5.2: Calculate header list size
@@ -1986,9 +1993,14 @@ pub const H2FrameParser = struct {
             }
         }
 
-        if (this.isServer and stream.contentLength > 0 and (flags & @intFromEnum(HeadersFrameFlags.END_STREAM)) != 0) {
+        // RFC 9113 §8.6: a request is malformed if the value of a content-length header field
+        // does not equal the sum of the DATA frame payload lengths. A non-zero content-length
+        // with END_STREAM on the header block (no DATA frames possible) is therefore malformed.
+        // Only check once the full header block is assembled (END_HEADERS set); use
+        // stream.endAfterHeaders so the END_STREAM flag from the original HEADERS frame is
+        // honored even when CONTINUATION frames carry part of the block.
+        if (this.isServer and stream.contentLength > 0 and stream.endAfterHeaders and (flags & @intFromEnum(HeadersFrameFlags.END_HEADERS)) != 0) {
             this.endStream(stream, ErrorCode.PROTOCOL_ERROR);
-            if (this.streams.getEntry(stream_id)) |entry| return entry.value_ptr;
             return null;
         }
 
@@ -2329,11 +2341,12 @@ pub const H2FrameParser = struct {
         if (handleIncommingPayload(this, data, frame.streamIdentifier)) |content| {
             const payload = content.data;
             this.readBuffer.reset();
-            stream.endAfterHeaders = frame.flags & @intFromEnum(HeadersFrameFlags.END_STREAM) != 0;
+            // CONTINUATION frames never carry END_STREAM; preserve stream.endAfterHeaders
+            // from the originating HEADERS frame so decodeHeaderBlock can validate against it.
             stream = (try this.decodeHeaderBlock(payload[0..payload.len], stream, frame.flags)) orelse {
                 return content.end;
             };
-            if (stream.endAfterHeaders) {
+            if (stream.endAfterHeaders and frame.flags & @intFromEnum(HeadersFrameFlags.END_HEADERS) != 0) {
                 stream.isWaitingMoreHeaders = false;
                 if (frame.flags & @intFromEnum(HeadersFrameFlags.END_STREAM) != 0) {
                     const identifier = stream.getIdentifier();
@@ -2395,6 +2408,9 @@ pub const H2FrameParser = struct {
                 return content.end;
             }
             stream.endAfterHeaders = frame.flags & @intFromEnum(HeadersFrameFlags.END_STREAM) != 0;
+            // Reset for each HEADERS frame so a content-length from the initial request
+            // headers does not leak into a later trailer HEADERS block.
+            stream.contentLength = -1;
             stream = (try this.decodeHeaderBlock(payload[offset..end], stream, frame.flags)) orelse {
                 return content.end;
             };

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -768,6 +768,7 @@ pub const H2FrameParser = struct {
         waitForTrailers: bool = false,
         closeAfterDrain: bool = false,
         endAfterHeaders: bool = false,
+        contentLength: i64 = -1,
         isWaitingMoreHeaders: bool = false,
         padding: ?u8 = null,
         paddingStrategy: PaddingStrategy = .none,
@@ -1919,6 +1920,10 @@ pub const H2FrameParser = struct {
                 return null;
             }
 
+            if (this.isServer and strings.eqlComptime(header.name, "content-length")) {
+                stream.contentLength = std.fmt.parseInt(i64, header.value, 10) catch -1;
+            }
+
             // RFC 7540 Section 6.5.2: Calculate header list size
             // Size = name length + value length + HPACK entry overhead per header
             headerListSize += header.name.len + header.value.len + HPACK_ENTRY_OVERHEAD;
@@ -1979,6 +1984,12 @@ pub const H2FrameParser = struct {
             if (offset >= payload.len) {
                 break;
             }
+        }
+
+        if (this.isServer and stream.contentLength > 0 and (flags & @intFromEnum(HeadersFrameFlags.END_STREAM)) != 0) {
+            this.endStream(stream, ErrorCode.PROTOCOL_ERROR);
+            if (this.streams.getEntry(stream_id)) |entry| return entry.value_ptr;
+            return null;
         }
 
         this.dispatchWith3Extra(.onStreamHeaders, stream.getIdentifier(), headers, sensitiveHeaders, jsc.JSValue.jsNumber(flags));

--- a/test/js/node/http2/h2-content-length-mismatch.test.ts
+++ b/test/js/node/http2/h2-content-length-mismatch.test.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "bun:test";
+import http2 from "node:http2";
+import { once } from "node:events";
+
+test("server rejects request with non-zero content-length and END_STREAM per RFC 9113 8.6", async () => {
+  const server = http2.createServer();
+  let streamCount = 0;
+  server.on("stream", stream => {
+    streamCount++;
+    stream.respond({ ":status": 200 });
+    stream.end();
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as any).port;
+
+  const client = http2.connect("http://127.0.0.1:" + port);
+  try {
+    const req = client.request({ ":method": "POST", "content-length": "10" }, { endStream: true });
+    req.on("error", () => {});
+    const closed = once(req, "close");
+    req.end();
+    await closed;
+
+    expect(streamCount).toBe(0);
+    expect(req.rstCode).toBe(http2.constants.NGHTTP2_PROTOCOL_ERROR);
+  } finally {
+    client.close();
+    server.close();
+    await once(server, "close");
+  }
+});

--- a/test/js/node/http2/h2-content-length-mismatch.test.ts
+++ b/test/js/node/http2/h2-content-length-mismatch.test.ts
@@ -31,3 +31,38 @@ test("server rejects request with non-zero content-length and END_STREAM per RFC
     await once(server, "close");
   }
 });
+
+test("server accepts request with content-length, body, and trailers", async () => {
+  const server = http2.createServer();
+  const { promise: gotTrailers, resolve: resolveTrailers } = Promise.withResolvers<Record<string, string>>();
+  server.on("stream", stream => {
+    stream.on("trailers", headers => resolveTrailers(headers as Record<string, string>));
+    stream.on("error", () => {});
+    stream.respond({ ":status": 200 });
+    stream.resume();
+    stream.end();
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const port = (server.address() as any).port;
+
+  const client = http2.connect("http://127.0.0.1:" + port);
+  try {
+    const req = client.request({ ":method": "POST", "content-length": "10" }, { endStream: false, waitForTrailers: true });
+    req.on("error", () => {});
+    req.on("wantTrailers", () => req.sendTrailers({ "x-trailer": "ok" }));
+    const { promise: closed, resolve } = Promise.withResolvers<void>();
+    req.on("close", () => resolve());
+    req.write("0123456789");
+    req.end();
+    const trailers = await gotTrailers;
+    await closed;
+
+    expect(trailers["x-trailer"]).toBe("ok");
+    expect(req.rstCode).toBe(http2.constants.NGHTTP2_NO_ERROR);
+  } finally {
+    client.close();
+    server.close();
+    await once(server, "close");
+  }
+});

--- a/test/js/node/http2/h2-content-length-mismatch.test.ts
+++ b/test/js/node/http2/h2-content-length-mismatch.test.ts
@@ -17,8 +17,9 @@ test("server rejects request with non-zero content-length and END_STREAM per RFC
   const client = http2.connect("http://127.0.0.1:" + port);
   try {
     const req = client.request({ ":method": "POST", "content-length": "10" }, { endStream: true });
+    const { promise: closed, resolve } = Promise.withResolvers<void>();
     req.on("error", () => {});
-    const closed = once(req, "close");
+    req.on("close", () => resolve());
     req.end();
     await closed;
 

--- a/test/js/node/http2/h2-content-length-mismatch.test.ts
+++ b/test/js/node/http2/h2-content-length-mismatch.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "bun:test";
-import http2 from "node:http2";
+import { expect, test } from "bun:test";
 import { once } from "node:events";
+import http2 from "node:http2";
 
 test("server rejects request with non-zero content-length and END_STREAM per RFC 9113 8.6", async () => {
   const server = http2.createServer();

--- a/test/js/node/http2/h2-content-length-mismatch.test.ts
+++ b/test/js/node/http2/h2-content-length-mismatch.test.ts
@@ -48,7 +48,10 @@ test("server accepts request with content-length, body, and trailers", async () 
 
   const client = http2.connect("http://127.0.0.1:" + port);
   try {
-    const req = client.request({ ":method": "POST", "content-length": "10" }, { endStream: false, waitForTrailers: true });
+    const req = client.request(
+      { ":method": "POST", "content-length": "10" },
+      { endStream: false, waitForTrailers: true },
+    );
     req.on("error", () => {});
     req.on("wantTrailers", () => req.sendTrailers({ "x-trailer": "ok" }));
     const { promise: closed, resolve } = Promise.withResolvers<void>();


### PR DESCRIPTION
RFC 9113 8.6: a request with a non-zero \`content-length\` and \`END_STREAM\` on the HEADERS frame is malformed (it declares a body it can never send). nghttp2 RSTs the stream with \`PROTOCOL_ERROR\`; Bun accepted these and dispatched them to the \`'stream'\` handler.

\`decodeHeaderBlock\` now records the parsed \`content-length\` on the stream and RSTs with \`PROTOCOL_ERROR\` when \`END_STREAM\` is set and \`content-length > 0\` (server side).

Adds a focused test. Node's \`test-http2-multi-content-length.js\` also asserts the client-side error event on the resulting RST, which surfaces a separate Bun behavior (client emits \`'end'\` before \`'error'\` on RST); tracked separately.