### PR TITLE
docs(CLAUDE.md): add code review self-check section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,12 @@ Built-in JavaScript modules use special syntax and are organized as:
 - `internal/` - Internal modules not exposed to users
 - `builtins/` - Core JavaScript builtins (streams, console, etc.)
 
+## Code Review Self-Check
+
+- Before writing code that makes a non-obvious choice, pre-emptively ask "why this and not the alternative?" If you can't answer, research until you can — don't write first and justify later.
+- Don't take a bug report's suggested fix at face value; verify it's the right layer.
+- If neighboring code does something differently than you're about to, find out _why_ before deviating — its choices are often load-bearing, not stylistic.
+
 ## Important Development Notes
 
 1. **Never use `bun test` or `bun <file>` directly** - always use `bun bd test` or `bun bd <command>`. `bun bd` compiles & runs the debug build.


### PR DESCRIPTION
Adds a short "Code Review Self-Check" section before "Important Development Notes":

- Justify each non-obvious choice before writing it (research first, don't write-then-justify)
- Don't take a bug report's suggested fix at face value — verify the layer
- Understand *why* neighbors do what they do before deviating