### PR TITLE
fix(usockets): hold context ref across us_internal_socket_after_resolve

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -629,22 +629,30 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
 }
 
 void us_internal_socket_after_resolve(struct us_connecting_socket_t *c) {
+    int ssl = c->ssl;
+    struct us_socket_context_t *context = c->context;
+    /* make sure the context is alive until the callback ends; on_connect_error
+     * (via close) or unlink (via free) can otherwise drop the last ref */
+    us_socket_context_ref(ssl, context);
+
     // make sure to decrement the active_handles counter, no matter what
 #ifdef _WIN32
-    c->context->loop->uv_loop->active_handles--;
+    context->loop->uv_loop->active_handles--;
 #else
-    c->context->loop->num_polls--;
+    context->loop->num_polls--;
 #endif
 
     c->pending_resolve_callback = 0;
     // if the socket was closed while we were resolving the address, free it
     if (c->closed) {
-        us_connecting_socket_free(c->ssl, c);
+        us_connecting_socket_free(ssl, c);
+        us_socket_context_unref(ssl, context);
         return;
     }
     struct addrinfo_result *result = Bun__addrinfo_getRequestResult(c->addrinfo_req);
     if (result->error) {
-        us_connecting_socket_close(c->ssl, c);
+        us_connecting_socket_close(ssl, c);
+        us_socket_context_unref(ssl, context);
         return;
     }
 
@@ -652,9 +660,9 @@ void us_internal_socket_after_resolve(struct us_connecting_socket_t *c) {
 
     int opened = start_connections(c, CONCURRENT_CONNECTIONS);
     if (opened == 0) {
-        us_connecting_socket_close(c->ssl, c);
-        return;
+        us_connecting_socket_close(ssl, c);
     }
+    us_socket_context_unref(ssl, context);
 }
 
 void us_internal_socket_after_open(struct us_socket_t *s, int error) {


### PR DESCRIPTION
The DNS drain loop (loop.c:235-241) calls us_internal_socket_after_resolve() for each queued us_connecting_socket_t. Inside, both us_connecting_socket_close() (via on_connect_error) and us_connecting_socket_free() (via unlink) can drop a context reference. Snapshot context/ssl into locals and hold an explicit ref for the duration, the same pattern us_socket_close() (socket.c:213) already uses.

## Crash signature

Bun v1.3.11, linux x86_64_baseline, segfault at address 0x00000000:
- loop.c:238 us_loop_run_bun_tick (inlined us_internal_socket_after_resolve in the DNS drain)

loop is the first field of us_socket_context_t, so address 0x0 means c->context was NULL when after_resolve ran c->context->loop->num_polls--. Features in the report: spawn, fetch, http_client_proxy, WebSocket.

Bun.spawnSync spins a separate uws.Loop (SpawnSyncEventLoop.zig) and does not drain the main loop dns_ready_head, so while spawnSync blocks the JS thread the DNS worker keeps queuing callbacks; the next tick then drains a multi-entry chain in one pass, widening the window.

## Testing

No deterministic repro yet — an ASAN stress test (concurrent WebSocket-to-unreachable-host + cancel + spawnSync, 50 iters) runs clean on the debug build; the production crash likely needs release-mode mimalloc reuse to surface. Existing tests pass: socket.test.ts (29/29), node-net.test.ts (31/31+1 skip), resolve-dns.test.ts (71/71), fetch abort, proxy.test.ts (36/39 — the 3 redirect timeouts are pre-existing on main).

Companion PR: snapshot loop before unref in us_connecting_socket_free.