### PR TITLE
Use the virtual $bunfs path for __dirname/__filename in --compile executables

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2598,9 +2598,9 @@ pub mod parse_worker {
         // Only the Bun-runtime chunks of a `--compile` build should emit the
         // `var __dirname = import.meta.dir` lowering. HTML-imported client
         // sources are bundled for the browser via the lazily-created client
-        // transpiler, which inherits `options.compile` from the server build;
+        // transpiler, which inherits `compile_mode` from the server build;
         // `import.meta.dir`/`.path` are Bun-only and would be `undefined` there.
-        opts.compile = topts.compile && target.is_bun();
+        opts.compile = topts.compile_mode.is_executable() && target.is_bun();
 
         // For files that are not user-specified entrypoints, set `import.meta.main` to `false`.
         // Entrypoints will have `import.meta.main` set as "unknown", unless we use `--compile`,

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2595,6 +2595,13 @@ pub mod parse_worker {
         opts.ignore_dce_annotations =
             topts.ignore_dce_annotations && !task.source_index.is_runtime();
 
+        // Only the Bun-runtime chunks of a `--compile` build should emit the
+        // `var __dirname = import.meta.dir` lowering. HTML-imported client
+        // sources are bundled for the browser via the lazily-created client
+        // transpiler, which inherits `options.compile` from the server build;
+        // `import.meta.dir`/`.path` are Bun-only and would be `undefined` there.
+        opts.compile = topts.compile && target.is_bun();
+
         // For files that are not user-specified entrypoints, set `import.meta.main` to `false`.
         // Entrypoints will have `import.meta.main` set as "unknown", unless we use `--compile`,
         // in which we inline `true`.

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2595,11 +2595,8 @@ pub mod parse_worker {
         opts.ignore_dce_annotations =
             topts.ignore_dce_annotations && !task.source_index.is_runtime();
 
-        // Only the Bun-runtime chunks of a `--compile` build should emit the
-        // `var __dirname = import.meta.dir` lowering. HTML-imported client
-        // sources are bundled for the browser via the lazily-created client
-        // transpiler, which inherits `compile_mode` from the server build;
-        // `import.meta.dir`/`.path` are Bun-only and would be `undefined` there.
+        // The client transpiler for HTML imports inherits `compile_mode`, but its
+        // browser chunks have no `import.meta.dir` to defer `__dirname` to.
         opts.compile = topts.compile_mode.is_executable() && target.is_bun();
 
         // For files that are not user-specified entrypoints, set `import.meta.main` to `false`.

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2595,8 +2595,7 @@ pub mod parse_worker {
         opts.ignore_dce_annotations =
             topts.ignore_dce_annotations && !task.source_index.is_runtime();
 
-        // The client transpiler for HTML imports inherits `compile_mode`, but its
-        // browser chunks have no `import.meta.dir` to defer `__dirname` to.
+        // HTML-import browser chunks inherit `compile_mode` but have no `import.meta.dir`.
         opts.compile = topts.compile_mode.is_executable() && target.is_bun();
 
         // For files that are not user-specified entrypoints, set `import.meta.main` to `false`.

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1585,6 +1585,7 @@ impl<'a> Transpiler<'a> {
                     transform_only: self.options.transform_only,
                     import_meta_main_value: None,
                     lower_import_meta_main_for_node_js: false,
+                    compile: false,
                     framework: None,
                     repl_mode: self.options.repl_mode,
                     lower_toml_datetimes: false,

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -515,13 +515,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         || (p.options.bundle
                             && p.options.output_format == js_parser::options::Format::Cjs)
                     {
-                        // For `--compile`, avoid embedding the build machine's absolute
-                        // file path into the standalone executable. The CJS entry chunk
-                        // is wrapped in `(function(exports, require, module, __filename,
-                        // __dirname) {...})`, and those parameters are populated at
-                        // runtime with the virtual `/$bunfs/root/...` path, so rewrite
-                        // `import.meta.dir` / `.dirname` / `.path` / `.filename` to
-                        // reference them instead of inlining a string literal.
+                        // Compiled CJS chunks take the virtual path from the wrapper's
+                        // `__dirname` / `__filename` parameters, so point these there.
                         if p.options.compile {
                             if name == b"dir" || name == b"dirname" {
                                 p.record_usage(p.dirname_ref);

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -515,8 +515,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         || (p.options.bundle
                             && p.options.output_format == js_parser::options::Format::Cjs)
                     {
-                        // Compiled CJS chunks take the virtual path from the wrapper's
-                        // `__dirname` / `__filename` parameters, so point these there.
+                        // Compiled CJS chunks read these from the wrapper's parameters.
                         if p.options.compile {
                             if name == b"dir" || name == b"dirname" {
                                 p.record_usage(p.dirname_ref);

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -515,6 +515,34 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         || (p.options.bundle
                             && p.options.output_format == js_parser::options::Format::Cjs)
                     {
+                        // For `--compile`, avoid embedding the build machine's absolute
+                        // file path into the standalone executable. The CJS entry chunk
+                        // is wrapped in `(function(exports, require, module, __filename,
+                        // __dirname) {...})`, and those parameters are populated at
+                        // runtime with the virtual `/$bunfs/root/...` path, so rewrite
+                        // `import.meta.dir` / `.dirname` / `.path` to reference them
+                        // instead of inlining a string literal.
+                        if p.options.compile {
+                            if name == b"dir" || name == b"dirname" {
+                                p.record_usage(p.dirname_ref);
+                                return Some(p.new_expr(
+                                    E::Identifier {
+                                        ref_: p.dirname_ref,
+                                        ..Default::default()
+                                    },
+                                    name_loc,
+                                ));
+                            } else if name == b"path" {
+                                p.record_usage(p.filename_ref);
+                                return Some(p.new_expr(
+                                    E::Identifier {
+                                        ref_: p.filename_ref,
+                                        ..Default::default()
+                                    },
+                                    name_loc,
+                                ));
+                            }
+                        }
                         if name == b"dir" || name == b"dirname" {
                             // Inline import.meta.dir
                             return Some(

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -520,8 +520,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // is wrapped in `(function(exports, require, module, __filename,
                         // __dirname) {...})`, and those parameters are populated at
                         // runtime with the virtual `/$bunfs/root/...` path, so rewrite
-                        // `import.meta.dir` / `.dirname` / `.path` to reference them
-                        // instead of inlining a string literal.
+                        // `import.meta.dir` / `.dirname` / `.path` / `.filename` to
+                        // reference them instead of inlining a string literal.
                         if p.options.compile {
                             if name == b"dir" || name == b"dirname" {
                                 p.record_usage(p.dirname_ref);
@@ -532,7 +532,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     },
                                     name_loc,
                                 ));
-                            } else if name == b"path" {
+                            } else if name == b"path" || name == b"filename" {
                                 p.record_usage(p.filename_ref);
                                 return Some(p.new_expr(
                                     E::Identifier {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -94,9 +94,8 @@ pub struct Options<'a> {
     pub import_meta_main_value: Option<bool>,
     pub lower_import_meta_main_for_node_js: bool,
 
-    /// Set when bundling for `--compile`. Affects how `__dirname`, `__filename`,
-    /// and inlined `import.meta.*` paths are emitted so that the build machine's
-    /// absolute file paths are not embedded in the standalone executable.
+    /// Bundling into a standalone executable: `__dirname` / `__filename` resolve
+    /// to the virtual `/$bunfs/` path at runtime instead of being inlined.
     pub compile: bool,
 
     /// When using react fast refresh or server components, the framework is
@@ -1135,18 +1134,9 @@ impl<'a> Parser<'a> {
         //    var __dirname = "foo/bar"
         //    var __filename = "foo/bar/baz.js"
         //
-        // For `--compile`, we do not want to embed the build machine's absolute
-        // file path into the standalone executable. Instead we defer to
-        // `import.meta.dir` / `import.meta.path` which at runtime resolve to the
-        // virtual `/$bunfs/root/...` path of the containing chunk (matching the
-        // behavior of `import.meta.url`).
-        //
-        // For `--compile --format=cjs` we cannot use `import.meta` (the chunk is
-        // wrapped in a function expression and evaluated as a Script, where
-        // `import.meta` is a syntax error), so we skip emitting the declaration
-        // and let references fall through to the `__filename` / `__dirname`
-        // parameters of the outer wrapper, which Bun's runtime populates with the
-        // virtual path.
+        // except for `--compile`, where the values come from `import.meta` (ESM) or,
+        // since `import.meta` is a syntax error inside the CJS wrapper, from the
+        // wrapper's own `__filename` / `__dirname` parameters (no declaration at all).
         if p.options.compile && p.options.output_format == options::Format::Cjs {
             uses_dirname = false;
             uses_filename = false;

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -94,8 +94,7 @@ pub struct Options<'a> {
     pub import_meta_main_value: Option<bool>,
     pub lower_import_meta_main_for_node_js: bool,
 
-    /// Bundling into a standalone executable: `__dirname` / `__filename` resolve
-    /// to the virtual `/$bunfs/` path at runtime instead of being inlined.
+    /// Standalone executable: `__dirname` / `__filename` resolve to the virtual path at runtime.
     pub compile: bool,
 
     /// When using react fast refresh or server components, the framework is
@@ -1134,9 +1133,7 @@ impl<'a> Parser<'a> {
         //    var __dirname = "foo/bar"
         //    var __filename = "foo/bar/baz.js"
         //
-        // except for `--compile`, where the values come from `import.meta` (ESM) or,
-        // since `import.meta` is a syntax error inside the CJS wrapper, from the
-        // wrapper's own `__filename` / `__dirname` parameters (no declaration at all).
+        // except under `--compile`: ESM uses `import.meta`; CJS keeps the wrapper's own parameters.
         if p.options.compile && p.options.output_format == options::Format::Cjs {
             uses_dirname = false;
             uses_filename = false;

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -94,6 +94,11 @@ pub struct Options<'a> {
     pub import_meta_main_value: Option<bool>,
     pub lower_import_meta_main_for_node_js: bool,
 
+    /// Set when bundling for `--compile`. Affects how `__dirname`, `__filename`,
+    /// and inlined `import.meta.*` paths are emitted so that the build machine's
+    /// absolute file paths are not embedded in the standalone executable.
+    pub compile: bool,
+
     /// When using react fast refresh or server components, the framework is
     /// able to customize what import sources are used.
     pub framework: Option<&'a options::Framework>, // TYPE_ONLY: was bun_runtime::bake::Framework
@@ -136,6 +141,7 @@ impl<'a> Default for Options<'a> {
             transform_only: false,
             import_meta_main_value: None,
             lower_import_meta_main_for_node_js: false,
+            compile: false,
             framework: None,
             repl_mode: false,
             lower_toml_datetimes: false,
@@ -220,6 +226,7 @@ impl<'a> Options<'a> {
             transform_only: self.transform_only,
             import_meta_main_value: self.import_meta_main_value,
             lower_import_meta_main_for_node_js: self.lower_import_meta_main_for_node_js,
+            compile: self.compile,
             framework: self.framework,
             repl_mode: self.repl_mode,
             lower_toml_datetimes: self.lower_toml_datetimes,
@@ -292,6 +299,7 @@ impl<'a> Options<'a> {
             transform_only: false,
             import_meta_main_value: None,
             lower_import_meta_main_for_node_js: false,
+            compile: false,
             framework: None,
             repl_mode: false,
             lower_toml_datetimes: loader == options::Loader::Toml,
@@ -1127,6 +1135,22 @@ impl<'a> Parser<'a> {
         //    var __dirname = "foo/bar"
         //    var __filename = "foo/bar/baz.js"
         //
+        // For `--compile`, we do not want to embed the build machine's absolute
+        // file path into the standalone executable. Instead we defer to
+        // `import.meta.dir` / `import.meta.path` which at runtime resolve to the
+        // virtual `/$bunfs/root/...` path of the containing chunk (matching the
+        // behavior of `import.meta.url`).
+        //
+        // For `--compile --format=cjs` we cannot use `import.meta` (the chunk is
+        // wrapped in a function expression and evaluated as a Script, where
+        // `import.meta` is a syntax error), so we skip emitting the declaration
+        // and let references fall through to the `__filename` / `__dirname`
+        // parameters of the outer wrapper, which Bun's runtime populates with the
+        // virtual path.
+        if p.options.compile && p.options.output_format == options::Format::Cjs {
+            uses_dirname = false;
+            uses_filename = false;
+        }
         if p.options.bundle || !p.options.features.commonjs_at_runtime {
             if uses_dirname || uses_filename {
                 let count = (uses_dirname as usize) + (uses_filename as usize);
@@ -1136,6 +1160,29 @@ impl<'a> Parser<'a> {
                     .arena
                     .alloc_slice_fill_with::<G::Decl, _>(count, |_| G::Decl::default());
                 if uses_dirname {
+                    let value = if p.options.compile {
+                        // var __dirname = import.meta.dir
+                        p.has_import_meta = true;
+                        let import_meta = p.new_expr(E::ImportMeta {}, bun_ast::Loc::EMPTY);
+                        p.new_expr(
+                            E::Dot {
+                                name: b"dir".into(),
+                                name_loc: bun_ast::Loc::EMPTY,
+                                target: import_meta,
+                                can_be_removed_if_unused: true,
+                                ..Default::default()
+                            },
+                            bun_ast::Loc::EMPTY,
+                        )
+                    } else {
+                        p.new_expr(
+                            E::String {
+                                data: p.source.path.name().dir.into(),
+                                ..Default::default()
+                            },
+                            bun_ast::Loc::EMPTY,
+                        )
+                    };
                     decls[0] = G::Decl {
                         binding: p.b(
                             B::Identifier {
@@ -1143,13 +1190,7 @@ impl<'a> Parser<'a> {
                             },
                             bun_ast::Loc::EMPTY,
                         ),
-                        value: Some(p.new_expr(
-                            E::String {
-                                data: p.source.path.name().dir.into(),
-                                ..Default::default()
-                            },
-                            bun_ast::Loc::EMPTY,
-                        )),
+                        value: Some(value),
                     };
                     declared_symbols.append_assume_capacity(DeclaredSymbol {
                         ref_: p.dirname_ref,
@@ -1157,6 +1198,29 @@ impl<'a> Parser<'a> {
                     });
                 }
                 if uses_filename {
+                    let value = if p.options.compile {
+                        // var __filename = import.meta.path
+                        p.has_import_meta = true;
+                        let import_meta = p.new_expr(E::ImportMeta {}, bun_ast::Loc::EMPTY);
+                        p.new_expr(
+                            E::Dot {
+                                name: b"path".into(),
+                                name_loc: bun_ast::Loc::EMPTY,
+                                target: import_meta,
+                                can_be_removed_if_unused: true,
+                                ..Default::default()
+                            },
+                            bun_ast::Loc::EMPTY,
+                        )
+                    } else {
+                        p.new_expr(
+                            E::String {
+                                data: p.source.path.text.into(),
+                                ..Default::default()
+                            },
+                            bun_ast::Loc::EMPTY,
+                        )
+                    };
                     decls[uses_dirname as usize] = G::Decl {
                         binding: p.b(
                             B::Identifier {
@@ -1164,13 +1228,7 @@ impl<'a> Parser<'a> {
                             },
                             bun_ast::Loc::EMPTY,
                         ),
-                        value: Some(p.new_expr(
-                            E::String {
-                                data: p.source.path.text.into(),
-                                ..Default::default()
-                            },
-                            bun_ast::Loc::EMPTY,
-                        )),
+                        value: Some(value),
                     };
                     declared_symbols.append_assume_capacity(DeclaredSymbol {
                         ref_: p.filename_ref,

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1162,7 +1162,6 @@ impl<'a> Parser<'a> {
                 if uses_dirname {
                     let value = if p.options.compile {
                         // var __dirname = import.meta.dir
-                        p.has_import_meta = true;
                         let import_meta = p.new_expr(E::ImportMeta {}, bun_ast::Loc::EMPTY);
                         p.new_expr(
                             E::Dot {
@@ -1200,7 +1199,6 @@ impl<'a> Parser<'a> {
                 if uses_filename {
                     let value = if p.options.compile {
                         // var __filename = import.meta.path
-                        p.has_import_meta = true;
                         let import_meta = p.new_expr(E::ImportMeta {}, bun_ast::Loc::EMPTY);
                         p.new_expr(
                             E::Dot {

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -917,7 +917,7 @@ JSCommonJSModule* JSCommonJSModule::create(
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto key = requireMapKey->value(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    auto index = key->reverseFind(PLATFORM_SEP, key->length());
+    auto index = lastPathSeparatorIndex(key.data);
 
     JSString* dirname;
     if (index != WTF::notFound) {
@@ -1507,7 +1507,7 @@ std::optional<JSC::SourceCode> createCommonJSModule(
     }
 
     if (!moduleObject) {
-        size_t index = sourceURL.reverseFind(PLATFORM_SEP, sourceURL.length());
+        size_t index = lastPathSeparatorIndex(sourceURL);
         JSString* dirname;
         JSString* filename = requireMapKey;
         if (index != WTF::notFound) {
@@ -1625,7 +1625,7 @@ std::optional<JSC::SourceCode> createCommonJSModule(
     }
 
     if (!moduleObject) {
-        size_t index = sourceURL.reverseFind(PLATFORM_SEP, sourceURL.length());
+        size_t index = lastPathSeparatorIndex(sourceURL);
         JSString* dirname;
         JSString* filename = requireMapKey;
         if (index != WTF::notFound) {
@@ -1665,7 +1665,7 @@ JSObject* JSCommonJSModule::createBoundRequireFunction(VM& vm, JSGlobalObject* l
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSString* filename = JSC::jsStringWithCache(vm, pathString);
-    auto index = pathString.reverseFind(PLATFORM_SEP, pathString.length());
+    auto index = lastPathSeparatorIndex(pathString);
     JSString* dirname;
     if (index != WTF::notFound) {
         dirname = JSC::jsSubstring(globalObject, filename, 0, index);

--- a/src/jsc/bindings/PathInlines.h
+++ b/src/jsc/bindings/PathInlines.h
@@ -55,6 +55,21 @@ ALWAYS_INLINE bool isAbsolutePath(WTF::String input)
 #undef IS_LETTER
 #undef IS_SLASH
 
+ALWAYS_INLINE size_t lastPathSeparatorIndex(const WTF::String& path)
+{
+#if OS(WINDOWS)
+    size_t slash = path.reverseFind(POSIX_PATH_SEP, path.length());
+    size_t backslash = path.reverseFind(WINDOWS_PATH_SEP, path.length());
+    if (slash == WTF::notFound)
+        return backslash;
+    if (backslash == WTF::notFound)
+        return slash;
+    return std::max(slash, backslash);
+#else
+    return path.reverseFind(POSIX_PATH_SEP, path.length());
+#endif
+}
+
 extern "C" BunString ResolvePath__joinAbsStringBufCurrentPlatformBunString(JSC::JSGlobalObject*, const BunString*);
 
 /// CWD is determined by the global object's current cwd.

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -658,6 +658,179 @@ describe("bundler", () => {
       setCwd: true,
     },
   });
+  // `__dirname` / `__filename` must not be inlined as the build machine's
+  // absolute file path when producing a standalone executable. They should
+  // resolve to the same virtual `/$bunfs/root/...` path that `import.meta.dir`
+  // and `import.meta.path` return at runtime.
+  itBundled("compile/DirnameFilenameUsesVirtualPath", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        import "./nested.cjs";
+        console.log("entry __dirname:", __dirname);
+        console.log("entry __filename:", __filename);
+        if (__dirname !== import.meta.dir) throw new Error("__dirname !== import.meta.dir");
+        if (__filename !== import.meta.path) throw new Error("__filename !== import.meta.path");
+      `,
+      "/nested.cjs": /* js */ `
+        console.log("nested __dirname:", __dirname);
+        console.log("nested __filename:", __filename);
+        module.exports = 1;
+      `,
+    },
+    run: {
+      stdout:
+        process.platform !== "win32"
+          ? [
+              "nested __dirname: /$bunfs/root",
+              "nested __filename: /$bunfs/root/out",
+              "entry __dirname: /$bunfs/root",
+              "entry __filename: /$bunfs/root/out",
+            ].join("\n")
+          : [
+              "nested __dirname: B:\\~BUN\\root",
+              "nested __filename: B:\\~BUN\\root\\out",
+              "entry __dirname: B:\\~BUN\\root",
+              "entry __filename: B:\\~BUN\\root\\out",
+            ].join("\n"),
+    },
+  });
+  itBundled("compile/DirnameFilenameUsesVirtualPathCJS", {
+    compile: true,
+    format: "cjs",
+    files: {
+      "/entry.ts": /* js */ `
+        require("./nested.cjs");
+        console.log("entry __dirname:", __dirname);
+        console.log("entry __filename:", __filename);
+        console.log("entry import.meta.dir:", import.meta.dir);
+        console.log("entry import.meta.path:", import.meta.path);
+        if (__dirname !== import.meta.dir) throw new Error("__dirname !== import.meta.dir");
+        if (__filename !== import.meta.path) throw new Error("__filename !== import.meta.path");
+      `,
+      "/nested.cjs": /* js */ `
+        console.log("nested __dirname:", __dirname);
+        console.log("nested __filename:", __filename);
+        module.exports = 1;
+      `,
+    },
+    run: {
+      stdout:
+        process.platform !== "win32"
+          ? [
+              "nested __dirname: /$bunfs/root",
+              "nested __filename: /$bunfs/root/out",
+              "entry __dirname: /$bunfs/root",
+              "entry __filename: /$bunfs/root/out",
+              "entry import.meta.dir: /$bunfs/root",
+              "entry import.meta.path: /$bunfs/root/out",
+            ].join("\n")
+          : [
+              "nested __dirname: B:\\~BUN\\root",
+              "nested __filename: B:\\~BUN\\root\\out",
+              "entry __dirname: B:\\~BUN\\root",
+              "entry __filename: B:\\~BUN\\root\\out",
+              "entry import.meta.dir: B:\\~BUN\\root",
+              "entry import.meta.path: B:\\~BUN\\root\\out",
+            ].join("\n"),
+    },
+  });
+  // With `--bytecode`, a module whose only `import.meta` reference is the
+  // synthetic `var __dirname = import.meta.dir` we inject must still be
+  // recorded as containing `import.meta` so the bytecode module record is
+  // created with the ImportMeta feature enabled.
+  itBundled("compile/DirnameFilenameUsesVirtualPathBytecode", {
+    compile: true,
+    bytecode: true,
+    files: {
+      "/entry.ts": /* js */ `
+        const nested = require("./nested.cjs");
+        console.log("entry __dirname:", __dirname);
+        console.log("entry __filename:", __filename);
+        nested.report();
+      `,
+      "/nested.cjs": /* js */ `
+        module.exports.report = function () {
+          console.log("nested __dirname:", __dirname);
+          console.log("nested __filename:", __filename);
+        };
+      `,
+    },
+    run: {
+      stdout:
+        process.platform !== "win32"
+          ? [
+              "entry __dirname: /$bunfs/root",
+              "entry __filename: /$bunfs/root/out",
+              "nested __dirname: /$bunfs/root",
+              "nested __filename: /$bunfs/root/out",
+            ].join("\n")
+          : [
+              "entry __dirname: B:\\~BUN\\root",
+              "entry __filename: B:\\~BUN\\root\\out",
+              "nested __dirname: B:\\~BUN\\root",
+              "nested __filename: B:\\~BUN\\root\\out",
+            ].join("\n"),
+    },
+  });
+  // Browser-side chunks produced by the client transpiler for HTML imports
+  // must keep the string-literal lowering for `__dirname`/`__filename`;
+  // `import.meta.dir`/`.path` are Bun-only and undefined in a real browser.
+  test("compile/DirnameFilenameInBrowserChunk", async () => {
+    using dir = tempDir("compile-dirname-browser", {
+      "frontend.tsx": `
+        console.log("browser __dirname=" + __dirname);
+        console.log("browser __filename=" + __filename);
+      `,
+      "index.html": `<!doctype html>
+        <html><head><script type="module" src="./frontend.tsx" async></script></head>
+        <body><div id="root"></div></body></html>`,
+      "entry.tsx": `
+        import index from "./index.html";
+        const server = Bun.serve({ port: 0, routes: { "/*": index }, development: false });
+        const html = await (await fetch(server.url)).text();
+        const m = html.match(/src="([^"]+\\.js)"/);
+        if (!m) { console.error("no browser JS chunk in HTML"); process.exit(1); }
+        const js = await (await fetch(new URL(m[1], server.url))).text();
+        await server.stop();
+        if (js.includes("import.meta.dir") || js.includes("import.meta.path")) {
+          console.error("browser chunk contains import.meta.dir/path");
+          console.error(js);
+          process.exit(1);
+        }
+        console.log("server __dirname:", __dirname);
+        console.log("browser chunk inlines __dirname as string:", typeof js === "string" && /__dirname\\s*=\\s*"/.test(js));
+      `,
+    });
+    const ext = isWindows ? ".exe" : "";
+    const outfile = join(String(dir), "app" + ext);
+    {
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "--compile", join(String(dir), "entry.tsx"), "--outfile", outfile],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+      if (exitCode !== 0) console.error(stdout, stderr);
+      expect(exitCode).toBe(0);
+    }
+    await using proc = Bun.spawn({
+      cmd: [outfile],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const bunfsRoot = isWindows ? "B:\\~BUN\\root" : "/$bunfs/root";
+    expect({ stderr, stdout: stdout.trim() }).toEqual({
+      stderr: "",
+      stdout: ["server __dirname: " + bunfsRoot, "browser chunk inlines __dirname as string: true"].join("\n"),
+    });
+    expect(exitCode).toBe(0);
+  }, 60_000);
   itBundled("compile/VariousBunAPIs", {
     todo: isWindows, // TODO
     compile: true,

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -662,117 +662,81 @@ describe("bundler", () => {
   // absolute file path when producing a standalone executable. They should
   // resolve to the same virtual `/$bunfs/root/...` path that `import.meta.dir`
   // and `import.meta.path` return at runtime.
-  itBundled("compile/DirnameFilenameUsesVirtualPath", {
-    compile: true,
-    files: {
-      "/entry.ts": /* js */ `
-        import "./nested.cjs";
-        console.log("entry __dirname:", __dirname);
-        console.log("entry __filename:", __filename);
-        if (__dirname !== import.meta.dir) throw new Error("__dirname !== import.meta.dir");
-        if (__filename !== import.meta.path) throw new Error("__filename !== import.meta.path");
-      `,
-      "/nested.cjs": /* js */ `
-        console.log("nested __dirname:", __dirname);
-        console.log("nested __filename:", __filename);
-        module.exports = 1;
-      `,
-    },
-    run: {
-      stdout:
-        process.platform !== "win32"
-          ? [
-              "nested __dirname: /$bunfs/root",
-              "nested __filename: /$bunfs/root/out",
-              "entry __dirname: /$bunfs/root",
-              "entry __filename: /$bunfs/root/out",
-            ].join("\n")
-          : [
-              "nested __dirname: B:\\~BUN\\root",
-              "nested __filename: B:\\~BUN\\root\\out",
-              "entry __dirname: B:\\~BUN\\root",
-              "entry __filename: B:\\~BUN\\root\\out",
-            ].join("\n"),
-    },
-  });
-  itBundled("compile/DirnameFilenameUsesVirtualPathCJS", {
-    compile: true,
-    format: "cjs",
-    files: {
-      "/entry.ts": /* js */ `
-        require("./nested.cjs");
-        console.log("entry __dirname:", __dirname);
-        console.log("entry __filename:", __filename);
-        console.log("entry import.meta.dir:", import.meta.dir);
-        console.log("entry import.meta.path:", import.meta.path);
-        if (__dirname !== import.meta.dir) throw new Error("__dirname !== import.meta.dir");
-        if (__filename !== import.meta.path) throw new Error("__filename !== import.meta.path");
-      `,
-      "/nested.cjs": /* js */ `
-        console.log("nested __dirname:", __dirname);
-        console.log("nested __filename:", __filename);
-        module.exports = 1;
-      `,
-    },
-    run: {
-      stdout:
-        process.platform !== "win32"
-          ? [
-              "nested __dirname: /$bunfs/root",
-              "nested __filename: /$bunfs/root/out",
-              "entry __dirname: /$bunfs/root",
-              "entry __filename: /$bunfs/root/out",
-              "entry import.meta.dir: /$bunfs/root",
-              "entry import.meta.path: /$bunfs/root/out",
-            ].join("\n")
-          : [
-              "nested __dirname: B:\\~BUN\\root",
-              "nested __filename: B:\\~BUN\\root\\out",
-              "entry __dirname: B:\\~BUN\\root",
-              "entry __filename: B:\\~BUN\\root\\out",
-              "entry import.meta.dir: B:\\~BUN\\root",
-              "entry import.meta.path: B:\\~BUN\\root\\out",
-            ].join("\n"),
-    },
-  });
-  // With `--bytecode`, a module whose only `import.meta` reference is the
-  // synthetic `var __dirname = import.meta.dir` we inject must still be
-  // recorded as containing `import.meta` so the bytecode module record is
-  // created with the ImportMeta feature enabled.
-  itBundled("compile/DirnameFilenameUsesVirtualPathBytecode", {
-    compile: true,
-    bytecode: true,
-    files: {
-      "/entry.ts": /* js */ `
-        const nested = require("./nested.cjs");
-        console.log("entry __dirname:", __dirname);
-        console.log("entry __filename:", __filename);
-        nested.report();
-      `,
-      "/nested.cjs": /* js */ `
-        module.exports.report = function () {
+  //
+  // ESM output reads them from `import.meta`, which uses the platform
+  // separator. CJS output (`--format=cjs`, or `--bytecode`, which implies it)
+  // leaves them to the module wrapper's parameters, which are the standalone
+  // graph key: forward-slashed on every platform, including Windows.
+  const bunfsEsm = isWindows ? ["B:\\~BUN\\root", "B:\\~BUN\\root\\out"] : ["/$bunfs/root", "/$bunfs/root/out"];
+  const bunfsCjs = isWindows ? ["B:/~BUN/root", "B:/~BUN/root/out"] : ["/$bunfs/root", "/$bunfs/root/out"];
+
+  for (const bytecode of [false, true]) {
+    itBundled(`compile/DirnameFilenameUsesVirtualPath${bytecode ? "Bytecode" : ""}`, {
+      compile: true,
+      // With --bytecode, the synthetic `var __dirname = import.meta.dir` may be
+      // a module's only `import.meta` reference; it still has to be recorded so
+      // the bytecode module record is created with import.meta enabled.
+      bytecode,
+      format: "esm",
+      files: {
+        "/entry.ts": /* js */ `
+          import "./nested.cjs";
+          console.log("entry __dirname:", __dirname);
+          console.log("entry __filename:", __filename);
+          if (__dirname !== import.meta.dir) throw new Error("__dirname !== import.meta.dir");
+          if (__filename !== import.meta.path) throw new Error("__filename !== import.meta.path");
+        `,
+        "/nested.cjs": /* js */ `
           console.log("nested __dirname:", __dirname);
           console.log("nested __filename:", __filename);
-        };
-      `,
-    },
-    run: {
-      stdout:
-        process.platform !== "win32"
-          ? [
-              "entry __dirname: /$bunfs/root",
-              "entry __filename: /$bunfs/root/out",
-              "nested __dirname: /$bunfs/root",
-              "nested __filename: /$bunfs/root/out",
-            ].join("\n")
-          : [
-              "entry __dirname: B:\\~BUN\\root",
-              "entry __filename: B:\\~BUN\\root\\out",
-              "nested __dirname: B:\\~BUN\\root",
-              "nested __filename: B:\\~BUN\\root\\out",
-            ].join("\n"),
-    },
-  });
+          module.exports = 1;
+        `,
+      },
+      run: {
+        stdout: [
+          `nested __dirname: ${bunfsEsm[0]}`,
+          `nested __filename: ${bunfsEsm[1]}`,
+          `entry __dirname: ${bunfsEsm[0]}`,
+          `entry __filename: ${bunfsEsm[1]}`,
+        ].join("\n"),
+      },
+    });
+  }
+  for (const bytecode of [false, true]) {
+    itBundled(`compile/DirnameFilenameUsesVirtualPathCJS${bytecode ? "Bytecode" : ""}`, {
+      compile: true,
+      bytecode,
+      format: "cjs",
+      files: {
+        "/entry.ts": /* js */ `
+          const nested = require("./nested.cjs");
+          console.log("entry __dirname:", __dirname);
+          console.log("entry __filename:", __filename);
+          console.log("entry import.meta.dir:", import.meta.dir);
+          console.log("entry import.meta.path:", import.meta.path);
+          if (__dirname !== import.meta.dir) throw new Error("__dirname !== import.meta.dir");
+          if (__filename !== import.meta.path) throw new Error("__filename !== import.meta.path");
+          nested.report();
+        `,
+        "/nested.cjs": /* js */ `
+          module.exports.report = function () {
+            console.log("nested __dirname:", __dirname);
+            console.log("nested __filename:", __filename);
+          };
+        `,
+      },
+      run: {
+        stdout: [
+          `entry __dirname: ${bunfsCjs[0]}`,
+          `entry __filename: ${bunfsCjs[1]}`,
+          `entry import.meta.dir: ${bunfsCjs[0]}`,
+          `entry import.meta.path: ${bunfsCjs[1]}`,
+          `nested __dirname: ${bunfsCjs[0]}`,
+          `nested __filename: ${bunfsCjs[1]}`,
+        ].join("\n"),
+      },
+    });
+  }
   // Browser-side chunks produced by the client transpiler for HTML imports
   // must keep the string-literal lowering for `__dirname`/`__filename`;
   // `import.meta.dir`/`.path` are Bun-only and undefined in a real browser.

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -716,6 +716,8 @@ describe("bundler", () => {
           console.log("entry import.meta.path:", import.meta.path);
           if (__dirname !== import.meta.dir) throw new Error("__dirname !== import.meta.dir");
           if (__filename !== import.meta.path) throw new Error("__filename !== import.meta.path");
+          if (__dirname !== import.meta.dirname) throw new Error("__dirname !== import.meta.dirname");
+          if (__filename !== import.meta.filename) throw new Error("__filename !== import.meta.filename");
           nested.report();
         `,
         "/nested.cjs": /* js */ `

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -673,9 +673,9 @@ describe("bundler", () => {
   for (const bytecode of [false, true]) {
     itBundled(`compile/DirnameFilenameUsesVirtualPath${bytecode ? "Bytecode" : ""}`, {
       compile: true,
-      // With --bytecode, the synthetic `var __dirname = import.meta.dir` may be
-      // a module's only `import.meta` reference; it still has to be recorded so
-      // the bytecode module record is created with import.meta enabled.
+      // With --bytecode the chunk is never parsed by JSC at runtime: the module
+      // record only gets import.meta because the printer saw the synthesized
+      // `import.meta.dir` and flagged the chunk, so that path is covered too.
       bytecode,
       format: "esm",
       files: {
@@ -702,43 +702,42 @@ describe("bundler", () => {
       },
     });
   }
-  for (const bytecode of [false, true]) {
-    itBundled(`compile/DirnameFilenameUsesVirtualPathCJS${bytecode ? "Bytecode" : ""}`, {
-      compile: true,
-      bytecode,
-      format: "cjs",
-      files: {
-        "/entry.ts": /* js */ `
-          const nested = require("./nested.cjs");
-          console.log("entry __dirname:", __dirname);
-          console.log("entry __filename:", __filename);
-          console.log("entry import.meta.dir:", import.meta.dir);
-          console.log("entry import.meta.path:", import.meta.path);
-          if (__dirname !== import.meta.dir) throw new Error("__dirname !== import.meta.dir");
-          if (__filename !== import.meta.path) throw new Error("__filename !== import.meta.path");
-          if (__dirname !== import.meta.dirname) throw new Error("__dirname !== import.meta.dirname");
-          if (__filename !== import.meta.filename) throw new Error("__filename !== import.meta.filename");
-          nested.report();
-        `,
-        "/nested.cjs": /* js */ `
-          module.exports.report = function () {
-            console.log("nested __dirname:", __dirname);
-            console.log("nested __filename:", __filename);
-          };
-        `,
-      },
-      run: {
-        stdout: [
-          `entry __dirname: ${bunfsCjs[0]}`,
-          `entry __filename: ${bunfsCjs[1]}`,
-          `entry import.meta.dir: ${bunfsCjs[0]}`,
-          `entry import.meta.path: ${bunfsCjs[1]}`,
-          `nested __dirname: ${bunfsCjs[0]}`,
-          `nested __filename: ${bunfsCjs[1]}`,
-        ].join("\n"),
-      },
-    });
-  }
+  // The `--bytecode` (implied CJS) variant is in compile-asset-bunfs.test.ts so
+  // that it also runs on Windows, where the wrapper's separator handling matters.
+  itBundled("compile/DirnameFilenameUsesVirtualPathCJS", {
+    compile: true,
+    format: "cjs",
+    files: {
+      "/entry.ts": /* js */ `
+        const nested = require("./nested.cjs");
+        console.log("entry __dirname:", __dirname);
+        console.log("entry __filename:", __filename);
+        console.log("entry import.meta.dir:", import.meta.dir);
+        console.log("entry import.meta.path:", import.meta.path);
+        if (__dirname !== import.meta.dir) throw new Error("__dirname !== import.meta.dir");
+        if (__filename !== import.meta.path) throw new Error("__filename !== import.meta.path");
+        if (__dirname !== import.meta.dirname) throw new Error("__dirname !== import.meta.dirname");
+        if (__filename !== import.meta.filename) throw new Error("__filename !== import.meta.filename");
+        nested.report();
+      `,
+      "/nested.cjs": /* js */ `
+        module.exports.report = function () {
+          console.log("nested __dirname:", __dirname);
+          console.log("nested __filename:", __filename);
+        };
+      `,
+    },
+    run: {
+      stdout: [
+        `entry __dirname: ${bunfsCjs[0]}`,
+        `entry __filename: ${bunfsCjs[1]}`,
+        `entry import.meta.dir: ${bunfsCjs[0]}`,
+        `entry import.meta.path: ${bunfsCjs[1]}`,
+        `nested __dirname: ${bunfsCjs[0]}`,
+        `nested __filename: ${bunfsCjs[1]}`,
+      ].join("\n"),
+    },
+  });
   // Browser-side chunks produced by the client transpiler for HTML imports
   // must keep the string-literal lowering for `__dirname`/`__filename`;
   // `import.meta.dir`/`.path` are Bun-only and undefined in a real browser.

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -738,6 +738,23 @@ describe("bundler", () => {
       ].join("\n"),
     },
   });
+  // An entry that uses none of `require` / `module` / `exports` / `import` is
+  // classified as ESM by the parser. The CJS wrapper is applied per chunk by
+  // the linker, so `__dirname` / `__filename` still bind to its parameters.
+  itBundled("compile/DirnameFilenameCJSEntryWithoutRequire", {
+    compile: true,
+    format: "cjs",
+    files: {
+      "/entry.ts": /* js */ `
+        console.log(__dirname);
+        console.log(__filename);
+        console.log(import.meta.dir === __dirname && import.meta.path === __filename);
+      `,
+    },
+    run: {
+      stdout: [bunfsCjs[0], bunfsCjs[1], "true"].join("\n"),
+    },
+  });
   // Browser-side chunks produced by the client transpiler for HTML imports
   // must keep the string-literal lowering for `__dirname`/`__filename`;
   // `import.meta.dir`/`.path` are Bun-only and undefined in a real browser.
@@ -779,6 +796,7 @@ describe("bundler", () => {
       });
       const [stdout, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
       if (exitCode !== 0) console.error(stdout, stderr);
+      expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     }
     await using proc = Bun.spawn({

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -186,34 +186,66 @@ console.log(utils());`,
       });
       const baseDir = baseDirPath + "";
 
-      const { exited } = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "build",
-          path.join(baseDir, "我/我.ts"),
-          "--compile",
-          "--outfile",
-          path.join(baseDir, "exe.exe"),
-        ],
-        env: bunEnv,
-        cwd: baseDir,
-        stdout: "inherit",
-        stderr: "inherit",
-      });
-      expect(await exited).toBe(0);
+      {
+        // Without --compile, __dirname / __filename are inlined as string literals
+        // containing the source path. This covers UTF-8 path encoding (issue #10474).
+        const build = Bun.spawn({
+          cmd: [bunExe(), "build", path.join(baseDir, "我/我.ts"), "--outfile", path.join(baseDir, "out.js")],
+          env: bunEnv,
+          cwd: baseDir,
+          stdout: "inherit",
+          stderr: "inherit",
+        });
+        expect(await build.exited).toBe(0);
 
-      await using proc = Bun.spawn({
-        cmd: [path.join(baseDir, "exe.exe")],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const text = await proc.stdout.text();
-      await proc.exited;
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), path.join(baseDir, "out.js")],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const text = await proc.stdout.text();
+        await proc.exited;
 
-      expect(text).toContain(path.join(baseDir, "我") + "\n");
-      expect(text).toContain(path.join(baseDir, "我", "我.ts") + "\n");
-    });
+        expect(text).toContain(path.join(baseDir, "我") + "\n");
+        expect(text).toContain(path.join(baseDir, "我", "我.ts") + "\n");
+      }
+
+      {
+        // With --compile, __dirname / __filename must not leak the build machine's
+        // path; they resolve to the virtual /$bunfs/root/... path of the chunk,
+        // consistent with import.meta.dir / import.meta.path.
+        const build = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "build",
+            path.join(baseDir, "我/我.ts"),
+            "--compile",
+            "--outfile",
+            path.join(baseDir, "exe.exe"),
+          ],
+          env: bunEnv,
+          cwd: baseDir,
+          stdout: "inherit",
+          stderr: "inherit",
+        });
+        expect(await build.exited).toBe(0);
+
+        await using proc = Bun.spawn({
+          cmd: [path.join(baseDir, "exe.exe")],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const text = await proc.stdout.text();
+        await proc.exited;
+
+        const dir = process.platform === "win32" ? "B:\\~BUN\\root" : "/$bunfs/root";
+        expect(text).toContain(dir + "\n");
+        expect(text).toContain(path.join(dir, "exe.exe") + "\n");
+        expect(text).not.toContain(baseDir);
+      }
+    }, 60_000);
 
     test.skipIf(!isWindows)("should be able to handle pretty path when using pnpm +  #14685", async () => {
       // this test code follows the same structure as and

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -204,11 +204,12 @@ console.log(utils());`,
           stdout: "pipe",
           stderr: "pipe",
         });
-        const text = await proc.stdout.text();
-        await proc.exited;
+        const [text, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
         expect(text).toContain(path.join(baseDir, "我") + "\n");
         expect(text).toContain(path.join(baseDir, "我", "我.ts") + "\n");
+        expect(stderr).toBe("");
+        expect(exitCode).toBe(0);
       }
 
       {
@@ -237,13 +238,14 @@ console.log(utils());`,
           stdout: "pipe",
           stderr: "pipe",
         });
-        const text = await proc.stdout.text();
-        await proc.exited;
+        const [text, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
         const dir = process.platform === "win32" ? "B:\\~BUN\\root" : "/$bunfs/root";
         expect(text).toContain(dir + "\n");
         expect(text).toContain(path.join(dir, "exe.exe") + "\n");
         expect(text).not.toContain(baseDir);
+        expect(stderr).toBe("");
+        expect(exitCode).toBe(0);
       }
     }, 60_000);
 

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -1,6 +1,6 @@
 // https://github.com/oven-sh/bun/issues/15734
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { rmSync } from "node:fs";
 import { join, sep } from "path";
 
@@ -198,29 +198,39 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
   // next to the code has to see that directory as __dirname. The source tree
   // is deleted before the binary runs so a build-machine path cannot satisfy
   // the read.
-  test(
-    "--asset files are reachable through __dirname after the build tree is gone",
-    async () => {
+  //
+  // ESM output gets the value from import.meta (platform separators). With
+  // --bytecode the output is CJS and the value comes from the module wrapper,
+  // whose parameters are the standalone graph key: forward-slashed even on
+  // Windows, where the wrapper used to split on backslash only and produce "".
+  test.each([
+    ["esm", [], isWindows ? "B:\\~BUN\\root" : "/$bunfs/root"],
+    ["--bytecode (cjs wrapper)", ["--bytecode"], isWindows ? "B:/~BUN/root" : "/$bunfs/root"],
+  ])(
+    "--asset files are reachable through __dirname after the build tree is gone (%s)",
+    async (_, extraArgs, expectedDirname) => {
       using dir = tempDir("bunfs-asset-dirname", {
         "index.ts": /* ts */ `
           const fs = require("node:fs");
           const path = require("node:path");
           console.log(JSON.stringify({
+            dirname: __dirname,
+            filename: __filename,
             dirnameIsImportMetaDir: __dirname === import.meta.dir,
-            filenameIsImportMetaPath: __filename === import.meta.path,
             greeting: fs.readFileSync(path.join(__dirname, "data", "greeting.txt"), "utf8"),
           }));
         `,
         "data/greeting.txt": "hello from an embedded asset",
       });
-      await compile(String(dir), ["--asset", "./data"]);
+      await compile(String(dir), ["--asset", "./data", ...extraArgs]);
       rmSync(join(String(dir), "data"), { recursive: true });
 
       const { stdout, stderr, code } = await run(String(dir));
       expect(stderr.trim()).toBe("");
       expect(JSON.parse(stdout.trim())).toEqual({
+        dirname: expectedDirname,
+        filename: expect.stringMatching(/^.*[/\\]root[/\\]app(\.exe)?$/),
         dirnameIsImportMetaDir: true,
-        filenameIsImportMetaPath: true,
         greeting: "hello from an embedded asset",
       });
       expect(code).toBe(0);

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -1,6 +1,7 @@
 // https://github.com/oven-sh/bun/issues/15734
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { rmSync } from "node:fs";
 import { join, sep } from "path";
 
 // `bun build --compile` copies + rewrites the whole bun binary (~1GB under
@@ -187,6 +188,41 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
       expect(r.client.recursive.join("\n")).not.toContain(sep === "/" ? "\\" : "/");
       // data.txt + config.json + 5 under client/
       expect(r.client.embeddedFileCount).toBeGreaterThanOrEqual(7);
+      expect(code).toBe(0);
+    },
+    TIMEOUT,
+  );
+
+  // --asset embeds files under the same /$bunfs/root/ directory the entry
+  // chunk lives in, so the usual CommonJS idiom for locating files shipped
+  // next to the code has to see that directory as __dirname. The source tree
+  // is deleted before the binary runs so a build-machine path cannot satisfy
+  // the read.
+  test(
+    "--asset files are reachable through __dirname after the build tree is gone",
+    async () => {
+      using dir = tempDir("bunfs-asset-dirname", {
+        "index.ts": /* ts */ `
+          const fs = require("node:fs");
+          const path = require("node:path");
+          console.log(JSON.stringify({
+            dirnameIsImportMetaDir: __dirname === import.meta.dir,
+            filenameIsImportMetaPath: __filename === import.meta.path,
+            greeting: fs.readFileSync(path.join(__dirname, "data", "greeting.txt"), "utf8"),
+          }));
+        `,
+        "data/greeting.txt": "hello from an embedded asset",
+      });
+      await compile(String(dir), ["--asset", "./data"]);
+      rmSync(join(String(dir), "data"), { recursive: true });
+
+      const { stdout, stderr, code } = await run(String(dir));
+      expect(stderr.trim()).toBe("");
+      expect(JSON.parse(stdout.trim())).toEqual({
+        dirnameIsImportMetaDir: true,
+        filenameIsImportMetaPath: true,
+        greeting: "hello from an embedded asset",
+      });
       expect(code).toBe(0);
     },
     TIMEOUT,


### PR DESCRIPTION
### Problem

- In a `bun build --compile` executable, `__dirname` and `__filename` are string literals holding the build machine's source paths (`var __dirname = "/home/user/project/src"`), while `import.meta.dir` / `import.meta.path` in the same binary resolve to the executable's virtual `/$bunfs/root` directory at runtime.
- Cause: the bundler's post-visit step in `src/js_parser/parse/parse_entry.rs` (`PartTag::DirnameFilename`) always injects the source file's directory and path as literals, with nothing telling it that the output is a standalone executable.
- Effects: the build machine's paths end up inside every shipped binary, and the CommonJS idiom for locating files shipped next to the code (`path.join(__dirname, ...)`, `require(path.join(__dirname, "addon.node"))`) only works on the machine that ran the build. Files embedded with `--asset` (#36302) live under `/$bunfs/root/`, so they are unreachable through `__dirname` even though they are reachable through `import.meta.dir`.

### Fix

- `ParseTask` sets a new parser option `compile` when `compile_mode.is_executable()` and the chunk targets Bun. Browser chunks of HTML imports inherit `compile_mode` but not the target, so they keep the string literals (`import.meta.dir` does not exist in a browser).
- ESM output: the injected declarations become `var __dirname = import.meta.dir, __filename = import.meta.path`. Nothing else is needed for `--bytecode`: the printer flags a chunk as containing `import.meta` when it prints the synthesized node, and that flag is what the bytecode module record is created from (an earlier revision also set the parser's `has_import_meta`, which is only read by the runtime CommonJS wrapper and never in a bundle, so that was dropped).
- CJS output (`--format=cjs`, or `--bytecode`, which implies it): no declaration is injected, so references bind to the `__filename` / `__dirname` parameters of the CommonJS wrapper, which the runtime fills with the virtual path. `import.meta.dir` / `.dirname` / `.path` / `.filename` are rewritten to those same identifiers in this mode (`src/js_parser/fold.rs`) so the two spellings stay equal. (`.filename` is not inlined at all for plain CJS bundles today and survives as a syntax error inside the wrapper; that non-compile case is tracked separately, this PR only covers it for compiled output.)
- Not covered: `import.meta.url` (and `.file`) in `--format=cjs` compiled output still inline their build-time values. The wrapper only provides `__filename`, and turning that into a `file:` URL needs `pathToFileURL` (percent-encoding; on Windows the key is `B:/~BUN/...`), so the parser has no runtime expression to lower it to without emitting a call into a builtin. The default ESM output leaves `import.meta.url` untouched and it resolves to `file:///$bunfs/root/<name>` at runtime.
- Windows: the wrapper derived `__dirname` by splitting the module key on a backslash only, but standalone keys are forward-slashed (`B:/~BUN/root/app.exe`), so once the declaration stopped shadowing the parameter, CJS output got `__dirname === ""` there (reproduced on Windows x64 without this hunk). `JSCommonJSModule.cpp` now splits on either separator via `lastPathSeparatorIndex` in `PathInlines.h`. This hunk is taken from #35470.
- Why this is the right value: a compiled executable is relocated by definition, and `/$bunfs/root` is the directory its embedded files (entry, chunks, file-loader assets, `--asset` files) are addressed by, so it is the only value of `__dirname` that can locate anything at runtime. It is also what `import.meta.dir` already reports in the same binary.
- Native addons (question raised in review): the documented `require("./addon.node")` form is unaffected, since the bundler turns it into an embedded asset reference without involving `__dirname`. The `require(path.join(__dirname, "addon.node"))` form was never embedded and only resolved on the build machine; with this change plus `--asset addon.node` it loads on any machine (`process.dlopen` looks the `/$bunfs/root/addon.node` path up in the embedded graph and extracts it). Checked with a small N-API addon, transcript in the details block below.
- Non-compile bundles (`--target=bun` / `--target=node` without `--compile`) are intentionally unchanged: inlining the source paths there is the existing behavior that #17222 and #4216 discuss, and it is a separate decision. This PR does not resolve #17188 or #4216; it covers the `--compile` case only. #35470, which changed all Bun/Node-target bundles, is closed in favor of this PR.

Verification:

- `test/bundler/bundler_compile.test.ts`: `compile/DirnameFilenameUsesVirtualPath{,Bytecode,CJS}` and `compile/DirnameFilenameCJSEntryWithoutRequire` (an entry with no `require` / `module` / `exports` / `import`, which the parser classifies as ESM while the linker still wraps the chunk) (ESM output with and without `--bytecode`, `--format=cjs` output including the `import.meta.dir` / `.path` / `.dirname` / `.filename` rewrites, all also checking a nested module and `__dirname === import.meta.dir`) and `compile/DirnameFilenameInBrowserChunk`. All 5 fail on the unfixed build, pass with the fix.
- `test/bundler/compile-asset-bunfs.test.ts`: `--asset files are reachable through __dirname after the build tree is gone`, run for ESM output and for `--bytecode` (implied CJS, wrapper-provided `__dirname`): reads an `--asset` file through `path.join(__dirname, ...)` after deleting the source tree and pins the exact `__dirname` value per mode (`B:\~BUN\root` vs `B:/~BUN/root` on Windows). Both fail unfixed with `ENOENT` on the build path and pass with the fix. This is a plain `test()` file, so unlike the `itBundled` cases it runs on the Windows CI lane, and the `--bytecode` case is the one that exercises the separator fix there (it reads through the wrapper's `__dirname`, which is `""` without the `PathInlines.h` hunk).
- `test/bundler/cli.test.ts`: the existing `__dirname and __filename are printed correctly` test now expects the virtual path for the compiled half and keeps its UTF-8 path coverage through a plain `bun build`.
- Full `bundler_compile.test.ts`, `bundler_compile_splitting.test.ts`, `cli.test.ts`, `compile-asset-bunfs.test.ts`, `bun-build-api.test.ts` pass with a debug build on Linux (the only failure, `compile/HelloWorldWithProcessVersionsBun`, compares against the `-debug` version string and fails on every debug build).
- The same tests pass on Windows x64 with a debug build of this branch. `itBundled` tests currently do not execute on Windows at all (the harness's `test/bundler/` stack check fails on backslash paths, tracked separately), so the Windows expectations in the `compile/DirnameFilename*` cases were run by temporarily patching that check locally; the CJS cases print an empty `__dirname` there without the `PathInlines.h` hunk, which is why the `--bytecode` variant was put in `compile-asset-bunfs.test.ts` instead of adding a fourth `itBundled` binary. Total: six compiled binaries across the three files, each covering a distinct output mode or guard.

### Background

- `/$bunfs/root` (`B:\~BUN\root` on Windows) is the virtual directory a compiled executable's embedded files are mounted under: the entry chunk is `/$bunfs/root/<outfile name>`, and `--asset` files and file-loader assets sit next to it. `import.meta.dir` / `import.meta.path` report these paths, and `node:fs` resolves them against the embedded graph.
- For CJS-format output the runtime does not evaluate the chunk as a module; it wraps it in `(function(exports, require, module, __filename, __dirname) { ... })` and fills the last two parameters from the module's require-cache key (`JSCommonJSModule.cpp`). `import.meta` is a syntax error inside that wrapper, which is why CJS output defers to the parameters instead of emitting `import.meta.dir`. For standalone executables that key is forward-slashed on every platform, so on Windows the CJS spelling is `B:/~BUN/root` while the ESM spelling is `B:\~BUN\root`; the tests pin both.
- `compile_mode` (`CompileMode::Executable` vs `StandaloneHtml`) is how the bundler records what `--compile` resolved to; only executables have a `/$bunfs/` filesystem, so the option keys off `is_executable()`.

<details>
<summary>N-API addon through <code>__dirname</code> plus <code>--asset</code></summary>

`entry.js`:

```js
const path = require("path");
const addon = require(path.join(__dirname, "addon.node"));
console.log("__dirname:", __dirname);
console.log(addon.hello());
```

Built on Linux x64 with `bun build --compile --asset ./addon.node ./entry.js --outfile app`, then the binary copied to another directory and the source directory's `addon.node` moved away (simulating a different machine):

```
# unfixed
error: Cannot find module '/tmp/triage/addon/addon.node' from '/$bunfs/root/app-main'

# this branch
__dirname: /$bunfs/root
hello from embedded addon
```

The same pattern with a data file instead of an addon is what the new `compile-asset-bunfs.test.ts` case checks.

</details>

<details>
<summary>Previous description</summary>

Earlier revisions of this PR described the change as a `compile` flag threaded from `BundleOptions.compile`; `main` has since replaced that field with `compile_mode`, and this branch was updated to match. The Windows separator fix and the ESM-with-bytecode, CJS-without-bytecode and `--asset` test cases were added while consolidating #35470 into this PR. The `cli.test.ts` adjustment and the browser-chunk guard (`target.is_bun()`) are unchanged from the earlier revisions.

</details>

Refs #17188, #4216 (non-compile bundles; not changed here).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 15 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/compile-asset-bunfs.test.ts, test/bundler/cli.test.ts, test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->


