### PR TITLE
fix(usockets): hold a context ref for the lifetime of pending_resolve_callback

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -568,6 +568,10 @@ void *us_socket_context_connect(int ssl, struct us_socket_context_t *context, co
     c->timeout = 255;
     c->long_timeout = 255;
     c->pending_resolve_callback = 1;
+    /* hold a context ref for the lifetime of pending_resolve_callback so that
+     * us_internal_socket_after_resolve always sees a live context, even if c is
+     * unlinked/relinked between now and the drain */
+    us_socket_context_ref(ssl, context);
     c->port = port;
     us_internal_socket_context_link_connecting_socket(ssl, context, c);
 
@@ -629,22 +633,27 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
 }
 
 void us_internal_socket_after_resolve(struct us_connecting_socket_t *c) {
+    int ssl = c->ssl;
+    struct us_socket_context_t *context = c->context;
+
     // make sure to decrement the active_handles counter, no matter what
 #ifdef _WIN32
-    c->context->loop->uv_loop->active_handles--;
+    context->loop->uv_loop->active_handles--;
 #else
-    c->context->loop->num_polls--;
+    context->loop->num_polls--;
 #endif
 
     c->pending_resolve_callback = 0;
     // if the socket was closed while we were resolving the address, free it
     if (c->closed) {
-        us_connecting_socket_free(c->ssl, c);
+        us_connecting_socket_free(ssl, c);
+        us_socket_context_unref(ssl, context);
         return;
     }
     struct addrinfo_result *result = Bun__addrinfo_getRequestResult(c->addrinfo_req);
     if (result->error) {
-        us_connecting_socket_close(c->ssl, c);
+        us_connecting_socket_close(ssl, c);
+        us_socket_context_unref(ssl, context);
         return;
     }
 
@@ -652,9 +661,9 @@ void us_internal_socket_after_resolve(struct us_connecting_socket_t *c) {
 
     int opened = start_connections(c, CONCURRENT_CONNECTIONS);
     if (opened == 0) {
-        us_connecting_socket_close(c->ssl, c);
-        return;
+        us_connecting_socket_close(ssl, c);
     }
+    us_socket_context_unref(ssl, context);
 }
 
 void us_internal_socket_after_open(struct us_socket_t *s, int error) {

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -634,6 +634,8 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
 
 void us_internal_socket_after_resolve(struct us_connecting_socket_t *c) {
     int ssl = c->ssl;
+    /* us_socket_context_connect took a context ref alongside
+     * pending_resolve_callback = 1; every return below drops it */
     struct us_socket_context_t *context = c->context;
 
     // make sure to decrement the active_handles counter, no matter what


### PR DESCRIPTION
## What

Take an explicit \`us_socket_context_ref\` in \`us_socket_context_connect\` immediately after setting \`c->pending_resolve_callback = 1\` (before \`Bun__addrinfo_set\` exposes \`c\` to the DNS worker), and drop it at every exit of \`us_internal_socket_after_resolve\`. Snapshot \`context\`/\`ssl\` into locals at the top of \`after_resolve\` so the unref uses a stable pointer even after \`us_connecting_socket_free\`/\`close\` has unlinked \`c\`.

## Why

v1.3.11 crash signature, linux x86_64_baseline:

\`\`\`
Segmentation fault at address 0x00000000
- loop.c:238: us_loop_run_bun_tick
\`\`\`

\`loop\` is the first field of \`us_socket_context_t\`, so address 0x0 means \`c->context\` was NULL when the inlined \`after_resolve\` ran \`c->context->loop->num_polls--\`. The existing invariant relies on the link-ref taken by \`us_internal_socket_context_link_connecting_socket\`; this PR makes the ref independent of link/unlink so the context is guaranteed live for the entire pending-resolve window regardless of which list \`c\` is on.

Features in the report: spawn, fetch, http_client_proxy, WebSocket, abort_signal. \`Bun.spawnSync\` (whose tick changed in v1.3.11 from \`tickWithoutJS\` to \`tickTasksOnly\`) lets \`dns_ready_head\` accumulate while the JS thread is blocked, widening the window.

## Testing

No deterministic repro on macOS — the production crash is on linux with the work-pool getaddrinfo path; an ASAN stress test (concurrent multi-IP WebSocket + spawnSync + abort, 400 iters) runs clean on the debug build. Existing suites pass on the debug build: socket.test.ts (29/29), node-net.test.ts (31/31+1 skip), resolve-dns.test.ts (71/71).

## Related

- #29064 snapshots \`loop\` before unref in \`us_connecting_socket_free\` (independent ordering fix)
- #29065 takes the ref inside \`after_resolve\` instead — this PR supersedes it by acquiring the ref before the DNS thread can observe \`c\`