### PR TITLE
fix(usockets): release addrinfo request and cancel pending DNS when a connecting socket is closed

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -649,8 +649,9 @@ void us_internal_socket_after_resolve(struct us_connecting_socket_t *c) {
     c->pending_resolve_callback = 0;
     // if the socket was closed while we were resolving the address, free it
     if (c->closed) {
-        // close() ran before the DNS callback set addrinfo_req, so it could not
-        // have released the request ref taken by Bun__addrinfo_get; do it here
+        // us_connecting_socket_close could not cancel the pending callback (the
+        // result was already set), so the request ref taken by Bun__addrinfo_get
+        // is released here instead
         if (c->addrinfo_req) {
             Bun__addrinfo_freeRequest(c->addrinfo_req, 0);
             c->addrinfo_req = 0;

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -572,6 +572,7 @@ void *us_socket_context_connect(int ssl, struct us_socket_context_t *context, co
      * us_internal_socket_after_resolve always sees a live context, even if c is
      * unlinked/relinked between now and the drain */
     us_socket_context_ref(ssl, context);
+    c->addrinfo_req = ai_req;
     c->port = port;
     us_internal_socket_context_link_connecting_socket(ssl, context, c);
 

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -568,6 +568,10 @@ void *us_socket_context_connect(int ssl, struct us_socket_context_t *context, co
     c->timeout = 255;
     c->long_timeout = 255;
     c->pending_resolve_callback = 1;
+    /* hold a context ref for the lifetime of pending_resolve_callback so that
+     * us_internal_socket_after_resolve always sees a live context, even if c is
+     * unlinked/relinked between now and the drain */
+    us_socket_context_ref(ssl, context);
     c->port = port;
     us_internal_socket_context_link_connecting_socket(ssl, context, c);
 
@@ -629,22 +633,27 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
 }
 
 void us_internal_socket_after_resolve(struct us_connecting_socket_t *c) {
+    int ssl = c->ssl;
+    struct us_socket_context_t *context = c->context;
+
     // make sure to decrement the active_handles counter, no matter what
 #ifdef _WIN32
-    c->context->loop->uv_loop->active_handles--;
+    context->loop->uv_loop->active_handles--;
 #else
-    c->context->loop->num_polls--;
+    context->loop->num_polls--;
 #endif
 
     c->pending_resolve_callback = 0;
     // if the socket was closed while we were resolving the address, free it
     if (c->closed) {
-        us_connecting_socket_free(c->ssl, c);
+        us_connecting_socket_free(ssl, c);
+        us_socket_context_unref(ssl, context);
         return;
     }
     struct addrinfo_result *result = Bun__addrinfo_getRequestResult(c->addrinfo_req);
     if (result->error) {
-        us_connecting_socket_close(c->ssl, c);
+        us_connecting_socket_close(ssl, c);
+        us_socket_context_unref(ssl, context);
         return;
     }
 
@@ -652,9 +661,9 @@ void us_internal_socket_after_resolve(struct us_connecting_socket_t *c) {
 
     int opened = start_connections(c, CONCURRENT_CONNECTIONS);
     if (opened == 0) {
-        us_connecting_socket_close(c->ssl, c);
-        return;
+        us_connecting_socket_close(ssl, c);
     }
+    us_socket_context_unref(ssl, context);
 }
 
 void us_internal_socket_after_open(struct us_socket_t *s, int error) {

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -634,6 +634,8 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
 
 void us_internal_socket_after_resolve(struct us_connecting_socket_t *c) {
     int ssl = c->ssl;
+    /* us_socket_context_connect took a context ref alongside
+     * pending_resolve_callback = 1; every return below drops it */
     struct us_socket_context_t *context = c->context;
 
     // make sure to decrement the active_handles counter, no matter what

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -646,6 +646,12 @@ void us_internal_socket_after_resolve(struct us_connecting_socket_t *c) {
     c->pending_resolve_callback = 0;
     // if the socket was closed while we were resolving the address, free it
     if (c->closed) {
+        // close() ran before the DNS callback set addrinfo_req, so it could not
+        // have released the request ref taken by Bun__addrinfo_get; do it here
+        if (c->addrinfo_req) {
+            Bun__addrinfo_freeRequest(c->addrinfo_req, 0);
+            c->addrinfo_req = 0;
+        }
         us_connecting_socket_free(ssl, c);
         us_socket_context_unref(ssl, context);
         return;

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -109,6 +109,7 @@ struct addrinfo_result {
 
 extern int Bun__addrinfo_get(struct us_loop_t* loop, const char* host, uint16_t port,  struct addrinfo_request** ptr);
 extern int Bun__addrinfo_set(struct addrinfo_request* ptr, struct us_connecting_socket_t* socket);
+extern int Bun__addrinfo_cancel(struct addrinfo_request* ptr, struct us_connecting_socket_t* socket);
 extern void Bun__addrinfo_freeRequest(struct addrinfo_request* addrinfo_req, int error);
 extern struct addrinfo_result *Bun__addrinfo_getRequestResult(struct addrinfo_request* addrinfo_req);
 

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -215,9 +215,9 @@ void us_internal_handle_low_priority_sockets(struct us_loop_t *loop) {
 // Called when DNS resolution completes
 // Does not wake up the loop.
 void us_internal_dns_callback(struct us_connecting_socket_t *c, void* addrinfo_req) {
+    (void)addrinfo_req; /* already stored on c by us_socket_context_connect */
     struct us_loop_t *loop = c->context->loop;
     Bun__lock(&loop->data.mutex);
-    c->addrinfo_req = addrinfo_req;
     c->next = loop->data.dns_ready_head;
     loop->data.dns_ready_head = c;
     Bun__unlock(&loop->data.mutex);

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -204,6 +204,8 @@ void us_connecting_socket_close(int ssl, struct us_connecting_socket_t *c) {
             Bun__addrinfo_freeRequest(c->addrinfo_req, 0);
             c->addrinfo_req = 0;
             us_connecting_socket_free(ssl, c);
+            /* drop the ref us_socket_context_connect took alongside
+             * pending_resolve_callback = 1; after_resolve will not run for c */
             us_socket_context_unref(ssl, context);
             return;
         }

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -187,7 +187,6 @@ void us_connecting_socket_close(int ssl, struct us_connecting_socket_t *c) {
         c->error = ECONNABORTED;
     }
     struct us_socket_context_t *context = c->context;
-    context->on_connect_error(c, c->error);
 
     if (c->pending_resolve_callback) {
         // The DNS callback has not been drained. Try to remove c from the
@@ -203,11 +202,13 @@ void us_connecting_socket_close(int ssl, struct us_connecting_socket_t *c) {
             c->pending_resolve_callback = 0;
             Bun__addrinfo_freeRequest(c->addrinfo_req, 0);
             c->addrinfo_req = 0;
+            context->on_connect_error(c, c->error);
             us_connecting_socket_free(ssl, c);
             /* drop the ref us_socket_context_connect took alongside
              * pending_resolve_callback = 1; after_resolve will not run for c */
             us_socket_context_unref(ssl, context);
-            return;
+        } else {
+            context->on_connect_error(c, c->error);
         }
         return;
     }
@@ -216,6 +217,7 @@ void us_connecting_socket_close(int ssl, struct us_connecting_socket_t *c) {
         Bun__addrinfo_freeRequest(c->addrinfo_req, c->error == ECONNREFUSED);
         c->addrinfo_req = 0;
     }
+    context->on_connect_error(c, c->error);
     us_connecting_socket_free(ssl, c);
 }
 

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -186,16 +186,35 @@ void us_connecting_socket_close(int ssl, struct us_connecting_socket_t *c) {
         // if we have no error, we have to set that we were aborted aka we called close
         c->error = ECONNABORTED;
     }
-    c->context->on_connect_error(c, c->error);
+    struct us_socket_context_t *context = c->context;
+    context->on_connect_error(c, c->error);
+
+    if (c->pending_resolve_callback) {
+        // The DNS callback has not been drained. Try to remove c from the
+        // request's notify list so it never fires. Returns 0 if the result is
+        // already set (the callback has fired or is about to), in which case
+        // after_resolve will see c->closed and finish teardown.
+        if (c->addrinfo_req && Bun__addrinfo_cancel(c->addrinfo_req, c)) {
+#ifdef _WIN32
+            context->loop->uv_loop->active_handles--;
+#else
+            context->loop->num_polls--;
+#endif
+            c->pending_resolve_callback = 0;
+            Bun__addrinfo_freeRequest(c->addrinfo_req, 0);
+            c->addrinfo_req = 0;
+            us_connecting_socket_free(ssl, c);
+            us_socket_context_unref(ssl, context);
+            return;
+        }
+        return;
+    }
+
     if(c->addrinfo_req) {
         Bun__addrinfo_freeRequest(c->addrinfo_req, c->error == ECONNREFUSED);
         c->addrinfo_req = 0;
     }
-    // we can only schedule the socket to be freed if there is no pending callback
-    // otherwise, the callback will see that the socket is closed and will free it
-    if (!c->pending_resolve_callback) {
-        us_connecting_socket_free(ssl, c);
-    }
+    us_connecting_socket_free(ssl, c);
 }
 
 struct us_socket_t *us_socket_close(int ssl, struct us_socket_t *s, int code, void *reason) {

--- a/src/bun.js/api/bun/dns.zig
+++ b/src/bun.js/api/bun/dns.zig
@@ -1786,6 +1786,28 @@ pub const internal = struct {
         bun.handleOom(request.notify.append(bun.default_allocator, .{ .socket = socket }));
     }
 
+    fn us_getaddrinfo_cancel(
+        request: *Request,
+        socket: *bun.uws.ConnectingSocket,
+    ) callconv(.c) c_int {
+        global_cache.lock.lock();
+        defer global_cache.lock.unlock();
+        // afterResult sets result and moves the notify list out under this same
+        // lock, so once result is non-null the socket is no longer cancellable
+        // (the callback has fired or is about to fire on the worker thread).
+        if (request.result != null) return 0;
+        for (request.notify.items, 0..) |item, i| {
+            switch (item) {
+                .socket => |s| if (s == socket) {
+                    _ = request.notify.swapRemove(i);
+                    return 1;
+                },
+                .prefetch => {},
+            }
+        }
+        return 0;
+    }
+
     fn freeaddrinfo(req: *Request, err: c_int) callconv(.c) void {
         global_cache.lock.lock();
         defer global_cache.lock.unlock();
@@ -1814,6 +1836,9 @@ pub const InternalDNSRequest = internal.Request;
 comptime {
     @export(&internal.us_getaddrinfo_set, .{
         .name = "Bun__addrinfo_set",
+    });
+    @export(&internal.us_getaddrinfo_cancel, .{
+        .name = "Bun__addrinfo_cancel",
     });
     @export(&internal.us_getaddrinfo, .{
         .name = "Bun__addrinfo_get",


### PR DESCRIPTION
Stacked on #29067.

Two commits, both addressing the case where a \`us_connecting_socket_t\` is closed before \`us_internal_socket_after_resolve\` runs.

## 642c35c3 — release addrinfo_req in the closed branch of after_resolve

When the socket is closed before the DNS callback fires, \`us_connecting_socket_close()\` finds \`c->addrinfo_req == NULL\` (it is only assigned by \`us_internal_dns_callback\`) and skips \`Bun__addrinfo_freeRequest\`. The callback later assigns it and enqueues \`c\` on \`dns_ready_head\`; \`after_resolve\` then takes the \`c->closed\` branch and frees \`c\` without ever decrementing the request refcount taken by \`Bun__addrinfo_get\`. Release it here.

## c3119586 — cancel the pending DNS notify so close does not have to wait for getaddrinfo

Previously, closing while DNS resolution was still in flight only marked \`c->closed\`; the socket and its context remained pinned until the DNS worker eventually called back. If \`getaddrinfo\` never returned, both leaked.

\`c->addrinfo_req\` is now stored at connect time and a new \`Bun__addrinfo_cancel(req, socket)\` removes the socket from the request notify list under the global cache lock. \`afterResult\` sets \`result\` and moves the notify list out under that same lock, so a non-null \`result\` means the callback has fired or is about to fire and cancellation is refused.

In \`us_connecting_socket_close\`, when \`pending_resolve_callback\` is set, attempt cancellation. On success: undo what \`us_socket_context_connect\` set up (\`num_polls\`/\`active_handles\`, the pending-resolve context ref from #29067, the request refcount) and free the socket immediately. On failure: leave the socket alive so \`after_resolve\` finishes teardown via its closed branch (first commit).

## Testing

socket.test.ts (29/29), node-net.test.ts (31/31+1 skip), resolve-dns.test.ts (71/71), fetch-abort (2/2), and a 100-iter abort smoke test all pass on the debug build. The leak itself is a pinned \`internal.Request\` refcount and a pinned context, neither observable from JS without instrumentation, so no fail-before regression test.