### PR TITLE
inspect: handle throwing Proxy traps when walking prototype chain

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5289,10 +5289,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasSlot = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasSlot)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5364,7 +5365,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!proto)
+                break;
+            iterating = proto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -451,6 +451,36 @@ const fixture = [
         },
       },
     ),
+  () => {
+    const o = {};
+    Object.setPrototypeOf(
+      o,
+      new Proxy(
+        { a: 1 },
+        {
+          getPrototypeOf() {
+            throw new Error("oops");
+          },
+        },
+      ),
+    );
+    return o;
+  },
+  () => {
+    const o = {};
+    Object.setPrototypeOf(
+      o,
+      new Proxy(
+        {
+          get foo() {
+            throw new Error("oops");
+          },
+        },
+        {},
+      ),
+    );
+    return o;
+  },
 ];
 
 describe("crash testing", () => {
@@ -739,4 +769,38 @@ it("CustomEvent", () => {
       BUBBLING_PHASE: 3,
     }"
   `);
+});
+
+it("Proxy prototype with throwing getPrototypeOf trap", () => {
+  const o = {};
+  Object.setPrototypeOf(
+    o,
+    new Proxy(
+      { a: 1, b: 2 },
+      {
+        getPrototypeOf() {
+          throw new Error("oops");
+        },
+      },
+    ),
+  );
+  expect(Bun.inspect(o)).toBe("{\n  a: 1,\n  b: 2,\n}");
+});
+
+it("Proxy prototype with throwing getter on target", () => {
+  const o = {};
+  Object.setPrototypeOf(
+    o,
+    new Proxy(
+      {
+        get foo() {
+          throw new Error("oops");
+        },
+        bar: 2,
+      },
+      {},
+    ),
+  );
+  const result = Bun.inspect(o);
+  expect(result).toContain("bar: 2");
 });


### PR DESCRIPTION
Fuzzilli fingerprint: `3ece47c123fdcdb2`

## What

`Bun.inspect` / `console.log` crashed with a null pointer dereference when formatting an object whose prototype chain contains a Proxy that throws from its `getPrototypeOf` trap, or whose target has a throwing getter.

## Repro

```js
const o = {};
Object.setPrototypeOf(o, new Proxy({ a: 1 }, {
  getPrototypeOf() { throw new Error("oops"); }
}));
console.log(o); // segfault
```

## Why

`JSC__JSValue__forEachPropertyImpl` walks the prototype chain on the slow path via:

```cpp
iterating = iterating->getPrototype(globalObject).getObject();
```

When `iterating` is a Proxy, `getPrototype()` invokes the `getPrototypeOf` trap, which can throw and return an empty `JSValue`. Calling `.getObject()` on an empty `JSValue` dereferences a null cell.

Additionally, when `getPropertySlot()` goes through a Proxy `[[Get]]` and the underlying getter throws, it returns `false` — but the existing `CLEAR_IF_EXCEPTION` was placed after the `continue`, so the pending exception leaked into the next `getPrototype()` call and produced the same empty value.

## Fix

- Clear the exception from `getPropertySlot()` before checking its return value.
- Check the result of `getPrototype()` and break out of the loop if it's empty, clearing any exception from the trap.

This mirrors the handling already present in the fast path of the same function.