### PR TITLE
Fix null deref in Bun.inspect when Proxy getPrototypeOf throws

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5289,10 +5289,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5364,7 +5365,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = proto ? proto.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/util/inspect-proxy-prototype.test.js
+++ b/test/js/bun/util/inspect-proxy-prototype.test.js
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 // Regression: Bun.inspect crashed with a null deref when walking a prototype
 // chain through a Proxy whose getPrototypeOf trap throws, because

--- a/test/js/bun/util/inspect-proxy-prototype.test.js
+++ b/test/js/bun/util/inspect-proxy-prototype.test.js
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test";
+
+// Regression: Bun.inspect crashed with a null deref when walking a prototype
+// chain through a Proxy whose getPrototypeOf trap throws, because
+// JSObject::getPrototype returns an empty JSValue on exception and the
+// result was unconditionally dereferenced via .getObject().
+test("Bun.inspect doesn't crash when a Proxy getPrototypeOf trap throws", () => {
+  const obj = {};
+  Object.setPrototypeOf(
+    obj,
+    new Proxy(
+      { foo: 1 },
+      {
+        getPrototypeOf() {
+          throw new Error("trap threw");
+        },
+      },
+    ),
+  );
+  expect(() => Bun.inspect(obj)).not.toThrow();
+});
+
+test("Bun.inspect doesn't crash on a Proxy prototype wrapping a native prototype", () => {
+  const v = Bun.jest(import.meta.path).expect(1);
+  const originalPrototype = Object.getPrototypeOf(v);
+  Object.setPrototypeOf(v, new Proxy(originalPrototype, {}));
+  expect(() => Bun.inspect(v)).not.toThrow();
+});


### PR DESCRIPTION
Fuzzilli fingerprint: `03307a0eaa9cbbc8`

## What does this PR do?

Fixes a null pointer dereference in `JSC__JSValue__forEachPropertyImpl` (used by `Bun.inspect` / `console.log`) when walking the prototype chain through a `ProxyObject`.

### Root cause

When advancing to the next prototype in the chain:
```cpp
iterating = iterating->getPrototype(globalObject).getObject();
```
`getPrototype()` on a `ProxyObject` can return an empty `JSValue` when:
- the `getPrototypeOf` trap throws, or
- there is already a pending exception (e.g. from an earlier Proxy `get` trap in the property loop that was not cleared before `continue`)

An empty `JSValue` has `isCell() == true` but `asCell() == nullptr`, so `.getObject()` calls `nullptr->getObject()`.

### Fix

1. Store the result of `getPrototype()`, clear any exception (matching the other `getPrototype` call sites in this function), and only call `getObject()` on a non-empty value.
2. Clear exceptions from `getPropertySlot` **before** the early `continue`, so a throwing trap that also returns `false` doesn't leave a pending exception lingering into the next iteration / into `getPrototype()`.

## How did you verify your code works?

Minimal repros that crashed before and now exit cleanly:
```js
// throwing getPrototypeOf trap
const obj = {};
Object.setPrototypeOf(obj, new Proxy({ foo: 1 }, {
  getPrototypeOf() { throw new Error("trap threw"); },
}));
Bun.inspect(obj);
```
```js
// native prototype wrapped in a Proxy (original fuzzer case)
const v = Bun.jest(import.meta.path).expect(1);
Object.setPrototypeOf(v, new Proxy(Object.getPrototypeOf(v), {}));
Bun.inspect(v);
```

Added regression tests in `test/js/bun/util/inspect-proxy-prototype.test.js`. Existing `test/js/bun/util/inspect.test.js` still passes.