### PR TITLE
Fix os.freemem() on Linux to use MemAvailable

### DIFF
--- a/src/bun.js/bindings/OsBinding.cpp
+++ b/src/bun.js/bindings/OsBinding.cpp
@@ -23,12 +23,78 @@ extern "C" uint64_t Bun__Os__getFreeMemory(void)
 
 #if OS(LINUX)
 #include <sys/sysinfo.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
 
+// Read a numeric field (in kB) from /proc/meminfo, matching libuv's
+// uv__read_proc_meminfo. Returns the value in bytes, or 0 on failure.
+static uint64_t bunReadProcMeminfo(const char* what)
+{
+    char buf[4096]; // Large enough to hold all of /proc/meminfo.
+    int fd;
+    ssize_t n = 0;
+    size_t off = 0;
+    bool readError = false;
+
+    do {
+        fd = open("/proc/meminfo", O_RDONLY | O_CLOEXEC);
+    } while (fd == -1 && errno == EINTR);
+    if (fd == -1) {
+        return 0;
+    }
+
+    while (off < sizeof(buf) - 1) {
+        do {
+            n = read(fd, buf + off, sizeof(buf) - 1 - off);
+        } while (n == -1 && errno == EINTR);
+        if (n == 0) {
+            break; // EOF
+        }
+        if (n < 0) {
+            readError = true;
+            break;
+        }
+        off += static_cast<size_t>(n);
+    }
+    close(fd);
+
+    if (readError) {
+        return 0;
+    }
+    buf[off] = '\0';
+
+    const char* p = strstr(buf, what);
+    if (p == nullptr) {
+        return 0;
+    }
+    p += strlen(what);
+
+    uint64_t rc = 0;
+    if (sscanf(p, "%" SCNu64 " kB", &rc) != 1) {
+        return 0;
+    }
+    return rc * 1024;
+}
+
+// Matches libuv's uv_get_free_memory (vendor/libuv/src/unix/linux.c): prefer
+// MemAvailable from /proc/meminfo (kernel's estimate of memory available for
+// new allocations, including reclaimable page cache) and only fall back to
+// sysinfo.freeram (which excludes page cache) when /proc/meminfo cannot be
+// read. This matches Node.js's os.freemem() behaviour.
 extern "C" uint64_t Bun__Os__getFreeMemory(void)
 {
+    uint64_t rc = bunReadProcMeminfo("MemAvailable:");
+    if (rc != 0) {
+        return rc;
+    }
+
     struct sysinfo info;
     if (sysinfo(&info) == 0) {
-        return info.freeram * info.mem_unit;
+        return static_cast<uint64_t>(info.freeram) * info.mem_unit;
     }
     return 0;
 }

--- a/test/regression/issue/29072.test.ts
+++ b/test/regression/issue/29072.test.ts
@@ -1,0 +1,74 @@
+// https://github.com/oven-sh/bun/issues/29072
+//
+// On Linux, os.freemem() used sysinfo.freeram which excludes reclaimable
+// page cache. On any system with a non-trivial page cache (which is
+// essentially every Linux host after doing real work) this returned a
+// number much smaller than what Node.js returns — Node uses /proc/meminfo's
+// MemAvailable, which includes reclaimable page cache/slab and is the
+// kernel's own estimate of memory available for new allocations.
+//
+// Fixed: Bun__Os__getFreeMemory on Linux now reads MemAvailable first and
+// only falls back to sysinfo.freeram when /proc/meminfo is unreadable,
+// matching libuv (and therefore Node.js).
+
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { freemem, totalmem } from "node:os";
+import { isLinux } from "harness";
+
+function parseMeminfo(): Record<string, number> {
+  const text = readFileSync("/proc/meminfo", "utf8");
+  const out: Record<string, number> = {};
+  for (const line of text.split("\n")) {
+    const match = line.match(/^(\w+):\s+(\d+)\s*kB/);
+    if (match) {
+      out[match[1]] = Number(match[2]) * 1024;
+    }
+  }
+  return out;
+}
+
+test.skipIf(!isLinux)("os.freemem() uses MemAvailable, not MemFree", () => {
+  // Populate the page cache so MemAvailable is meaningfully larger than
+  // MemFree. Reading a handful of large, well-known files pushes their
+  // pages into the cache; those pages count towards MemAvailable (they
+  // are reclaimable) but NOT towards MemFree.
+  try {
+    readFileSync("/proc/kallsyms");
+  } catch {}
+  try {
+    // /proc/meminfo itself is tiny; prefer something bulkier that every
+    // Linux system has.
+    readFileSync("/proc/self/maps");
+  } catch {}
+
+  const info = parseMeminfo();
+  expect(info.MemAvailable).toBeGreaterThan(0);
+  expect(info.MemFree).toBeGreaterThan(0);
+
+  const free = freemem();
+  const total = totalmem();
+
+  // Sanity: free is positive and bounded by total.
+  expect(free).toBeGreaterThan(0);
+  expect(free).toBeLessThanOrEqual(total);
+
+  // The core of the regression: freemem() must be close to MemAvailable,
+  // NOT MemFree. Memory fluctuates between reads, so allow a generous
+  // tolerance. Before the fix freemem() returned sysinfo.freeram (≈ MemFree),
+  // which on any system with a populated page cache differs from
+  // MemAvailable by far more than this tolerance.
+  const tolerance = Math.max(info.MemAvailable * 0.15, 256 * 1024 * 1024);
+  expect(Math.abs(free - info.MemAvailable)).toBeLessThan(tolerance);
+
+  // When MemAvailable is significantly larger than MemFree (the common
+  // case — any machine that's been running long enough to cache files),
+  // freemem() must report much more than MemFree. This is the direct
+  // assertion that Bun is not returning the sysinfo.freeram value.
+  if (info.MemAvailable > info.MemFree + 512 * 1024 * 1024) {
+    // free should be closer to MemAvailable than to MemFree
+    const distToAvailable = Math.abs(free - info.MemAvailable);
+    const distToFree = Math.abs(free - info.MemFree);
+    expect(distToAvailable).toBeLessThan(distToFree);
+  }
+});

--- a/test/regression/issue/29072.test.ts
+++ b/test/regression/issue/29072.test.ts
@@ -11,9 +11,9 @@
 // matching libuv (and therefore Node.js).
 
 import { expect, test } from "bun:test";
+import { isLinux } from "harness";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { freemem, totalmem } from "node:os";
-import { isLinux } from "harness";
 
 function parseMeminfo(): Record<string, number> {
   const text = readFileSync("/proc/meminfo", "utf8");

--- a/test/regression/issue/29072.test.ts
+++ b/test/regression/issue/29072.test.ts
@@ -1,20 +1,19 @@
 // https://github.com/oven-sh/bun/issues/29072
 //
 // On Linux, os.freemem() used sysinfo.freeram which excludes reclaimable
-// page cache. On any system with a non-trivial page cache (which is
-// essentially every Linux host after doing real work) this returned a
-// number much smaller than what Node.js returns — Node uses /proc/meminfo's
-// MemAvailable, which includes reclaimable page cache/slab and is the
-// kernel's own estimate of memory available for new allocations.
+// page cache. On any system that's done real work it returned a number
+// much smaller than Node.js — Node uses /proc/meminfo's MemAvailable,
+// the kernel's own estimate of memory available for new allocations,
+// which counts reclaimable cache/slab.
 //
-// Fixed: Bun__Os__getFreeMemory on Linux now reads MemAvailable first and
+// Fix: Bun__Os__getFreeMemory on Linux now reads MemAvailable first and
 // only falls back to sysinfo.freeram when /proc/meminfo is unreadable,
 // matching libuv (and therefore Node.js).
 
 import { expect, test } from "bun:test";
-import { isLinux } from "harness";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { freemem, totalmem } from "node:os";
+import { isLinux } from "harness";
 
 function parseMeminfo(): Record<string, number> {
   const text = readFileSync("/proc/meminfo", "utf8");
@@ -28,19 +27,29 @@ function parseMeminfo(): Record<string, number> {
   return out;
 }
 
-test.skipIf(!isLinux)("os.freemem() uses MemAvailable, not MemFree", () => {
-  // Populate the page cache so MemAvailable is meaningfully larger than
-  // MemFree. Reading a handful of large, well-known files pushes their
-  // pages into the cache; those pages count towards MemAvailable (they
-  // are reclaimable) but NOT towards MemFree.
-  try {
-    readFileSync("/proc/kallsyms");
-  } catch {}
-  try {
-    // /proc/meminfo itself is tiny; prefer something bulkier that every
-    // Linux system has.
-    readFileSync("/proc/self/maps");
-  } catch {}
+// Read a large real on-disk file so its pages land in the Linux page
+// cache. Unlike /proc/* pseudo-files, disk-backed pages are reclaimable
+// and contribute to the MemAvailable–MemFree gap. This makes the bug
+// observable even on otherwise-cold CI hosts.
+function warmPageCache(): void {
+  const candidates = [
+    "/usr/lib/locale/locale-archive",
+    "/usr/lib/x86_64-linux-gnu/libc.so.6",
+    "/usr/lib/aarch64-linux-gnu/libc.so.6",
+    "/usr/bin/bash",
+    "/bin/bash",
+  ];
+  for (const path of candidates) {
+    try {
+      if (existsSync(path) && statSync(path).size > 64 * 1024) {
+        readFileSync(path);
+      }
+    } catch {}
+  }
+}
+
+test.skipIf(!isLinux)("os.freemem() uses MemAvailable, not MemFree (#29072)", () => {
+  warmPageCache();
 
   const info = parseMeminfo();
   expect(info.MemAvailable).toBeGreaterThan(0);
@@ -53,20 +62,24 @@ test.skipIf(!isLinux)("os.freemem() uses MemAvailable, not MemFree", () => {
   expect(free).toBeGreaterThan(0);
   expect(free).toBeLessThanOrEqual(total);
 
-  // The core of the regression: freemem() must be close to MemAvailable,
-  // NOT MemFree. Memory fluctuates between reads, so allow a generous
-  // tolerance. Before the fix freemem() returned sysinfo.freeram (≈ MemFree),
-  // which on any system with a populated page cache differs from
-  // MemAvailable by far more than this tolerance.
-  const tolerance = Math.max(info.MemAvailable * 0.15, 256 * 1024 * 1024);
-  expect(Math.abs(free - info.MemAvailable)).toBeLessThan(tolerance);
+  // The core assertion: os.freemem() must return MemAvailable (what Node
+  // returns via libuv), not MemFree / sysinfo.freeram.
+  //
+  // Memory values fluctuate slightly between the two kernel reads, so
+  // allow a small absolute tolerance. 64 MiB is comfortably larger than
+  // typical inter-read drift on a busy system and comfortably smaller
+  // than the MemAvailable–MemFree gap on any host with a populated
+  // page cache (which every CI runner has by the time a test runs).
+  const tolerance = 64 * 1024 * 1024;
+  expect(Math.abs(free - info.MemAvailable)).toBeLessThanOrEqual(tolerance);
 
-  // When MemAvailable is significantly larger than MemFree (the common
-  // case — any machine that's been running long enough to cache files),
-  // freemem() must report much more than MemFree. This is the direct
-  // assertion that Bun is not returning the sysinfo.freeram value.
-  if (info.MemAvailable > info.MemFree + 512 * 1024 * 1024) {
-    // free should be closer to MemAvailable than to MemFree
+  // Additionally, when the gap between MemAvailable and MemFree is
+  // clearly larger than the fluctuation tolerance (the overwhelming
+  // common case on Linux), assert that `free` is closer to MemAvailable
+  // than to MemFree. This is the direct proof the fix is in effect:
+  // the pre-fix implementation returned ~MemFree, which would fail here.
+  const gap = info.MemAvailable - info.MemFree;
+  if (gap > tolerance * 2) {
     const distToAvailable = Math.abs(free - info.MemAvailable);
     const distToFree = Math.abs(free - info.MemFree);
     expect(distToAvailable).toBeLessThan(distToFree);

--- a/test/regression/issue/29072.test.ts
+++ b/test/regression/issue/29072.test.ts
@@ -12,9 +12,9 @@
 // matching libuv (and therefore Node.js).
 
 import { expect, test } from "bun:test";
+import { isLinux } from "harness";
 import { readFileSync } from "node:fs";
 import { freemem, totalmem } from "node:os";
-import { isLinux } from "harness";
 
 function parseMeminfo(): Record<string, number> {
   const text = readFileSync("/proc/meminfo", "utf8");


### PR DESCRIPTION
Fixes #29072

## Repro

```js
import os from 'node:os';
console.log('total:', os.totalmem());
console.log('free :', os.freemem());
console.log('ratio:', (os.freemem() / os.totalmem()).toFixed(4));
```

On a Linux host with `MemTotal: 130G`, `MemFree: 36G`, `MemAvailable: 117G`:

```
$ bun repro.mjs        $ node repro.mjs
total: 133613760512    total: 133613760512
free : 36713017344     free : 121134342144
ratio: 0.2748          ratio: 0.9066
```

## Cause

`src/bun.js/bindings/OsBinding.cpp` on Linux used `sysinfo(2)`:

```cpp
struct sysinfo info;
if (sysinfo(&info) == 0) {
    return info.freeram * info.mem_unit;
}
```

`sysinfo.freeram` counts only pages that are completely unused — it matches `MemFree` in `/proc/meminfo` and **excludes** the reclaimable page cache. On a healthy Linux system the page cache is typically huge, so this is always much smaller than what applications expect.

Node.js (via libuv, `vendor/libuv/src/unix/linux.c:2074`) reads `MemAvailable:` from `/proc/meminfo` and only falls back to `sysinfo.freeram` on failure. `MemAvailable` is the kernel's own estimate of memory available for starting new applications without swapping — it includes reclaimable cache/slab, which is what `os.freemem()` is documented to return.

## Fix

Port libuv's `uv__read_proc_meminfo` + `uv_get_free_memory` logic to `Bun__Os__getFreeMemory`:

1. Read `MemAvailable:` from `/proc/meminfo`
2. Fall back to `sysinfo.freeram * mem_unit` only if that fails

Parsing matches libuv's implementation (sscanf `"%PRIu64 kB"`, 4096-byte buffer). Darwin and Windows paths are unchanged.

## Test

`test/regression/issue/29072.test.ts` — reads `/proc/meminfo` directly and asserts that `os.freemem()` is close to `MemAvailable` (not `MemFree`). On any system with a populated page cache the two differ enough that the pre-fix behaviour fails the tolerance check, and when `MemAvailable` is meaningfully larger than `MemFree` the test also asserts that `freemem()` is closer to `MemAvailable` than to `MemFree`.

Skipped on non-Linux (Darwin/Windows don't use this code path).