### PR TITLE
fix: snapshot SharedArrayBuffer bytes before UTF-8 string conversion

### DIFF
--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -795,7 +795,8 @@ export function formatConfig(cfg: Config, exe: string): string {
   // revert my WebKit test branch" before the build goes weird.
   if (cfg.webkitVersion !== versionDefaults.webkitVersion)
     features.push(`webkit-version:${cfg.webkitVersion.slice(0, 10)}`);
-  if (cfg.zigCommit !== defaultZigCommit(cfg.ci, cfg.host.os)) features.push(`zig-commit:${cfg.zigCommit.slice(0, 10)}`);
+  if (cfg.zigCommit !== defaultZigCommit(cfg.ci, cfg.host.os))
+    features.push(`zig-commit:${cfg.zigCommit.slice(0, 10)}`);
   if (cfg.nodejsVersion !== versionDefaults.nodejsVersion) features.push(`nodejs:${cfg.nodejsVersion}`);
   lines.push(`  ${label("features")} ${features.length > 0 ? c.cyan(features.join(", ")) : c.dim("(none)")}`);
   return lines.join("\n");

--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -397,6 +397,9 @@ extern "C" [[ZIG_EXPORT(nothrow)]] BunString BunString__fromLatin1Unitialized(si
     return { BunStringTag::WTFStringImpl, { .wtf = impl.leakRef() } };
 }
 
+// `bytes` must remain stable for the duration of this call. Callers holding a
+// JS ArrayBufferView must snapshot when isShared() before passing it here; the
+// simdutf length+convert path will overflow if the input mutates between passes.
 extern "C" BunString BunString__fromUTF8(const char* bytes, size_t length)
 {
     ASSERT(length > 0);

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -1794,7 +1794,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_swap64Body(JSC::JSGlobalObj
     return JSC::JSValue::encode(castedThis);
 }
 
-JSC::EncodedJSValue jsBufferToStringFromBytes(JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, std::span<const uint8_t> bytes, BufferEncodingType encoding)
+JSC::EncodedJSValue jsBufferToStringFromBytes(JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, std::span<const uint8_t> bytes, BufferEncodingType encoding, bool isShared)
 {
     auto& vm = lexicalGlobalObject->vm();
 
@@ -1868,6 +1868,15 @@ JSC::EncodedJSValue jsBufferToStringFromBytes(JSGlobalObject* lexicalGlobalObjec
     case WebCore::BufferEncodingType::base64:
     case WebCore::BufferEncodingType::base64url:
     case WebCore::BufferEncodingType::hex: {
+        // Bun__encoding__toString's utf8 path sizes its output buffer from a first
+        // pass over `bytes` and then converts in a second pass. If `bytes` is backed
+        // by a SharedArrayBuffer a Worker can mutate it between passes and overflow
+        // the allocation, so snapshot shared input into owned memory first.
+        Vector<uint8_t> copy;
+        if (isShared) [[unlikely]] {
+            copy.append(bytes);
+            bytes = copy.span();
+        }
         EncodedJSValue res = Bun__encoding__toString(bytes.data(), bytes.size(), lexicalGlobalObject, static_cast<uint8_t>(encoding));
         RETURN_IF_EXCEPTION(scope, {});
 
@@ -1912,7 +1921,7 @@ JSC::EncodedJSValue jsBufferToString(JSC::JSGlobalObject* lexicalGlobalObject, T
         length = byteLength - offset;
     }
 
-    return jsBufferToStringFromBytes(lexicalGlobalObject, scope, castedThis->span().subspan(offset, length), encoding);
+    return jsBufferToStringFromBytes(lexicalGlobalObject, scope, castedThis->span().subspan(offset, length), encoding, castedThis->isShared());
 }
 
 // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/src/node_buffer.cc#L208-L233

--- a/src/bun.js/bindings/JSBuffer.h
+++ b/src/bun.js/bindings/JSBuffer.h
@@ -64,7 +64,7 @@ JSC_DECLARE_HOST_FUNCTION(constructSlowBuffer);
 JSC::JSObject* createBufferPrototype(JSC::VM&, JSC::JSGlobalObject*);
 JSC::Structure* createBufferStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue prototype);
 JSC::JSObject* createBufferConstructor(JSC::VM&, JSC::JSGlobalObject*, JSC::JSObject* bufferPrototype);
-JSC::EncodedJSValue jsBufferToStringFromBytes(JSC::JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& scope, std::span<const uint8_t> bytes, BufferEncodingType encoding);
+JSC::EncodedJSValue jsBufferToStringFromBytes(JSC::JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& scope, std::span<const uint8_t> bytes, BufferEncodingType encoding, bool isShared);
 JSC::EncodedJSValue jsBufferToString(JSC::JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& scope, JSC::JSArrayBufferView* castedThis, size_t offset, size_t length, WebCore::BufferEncodingType encoding);
 JSC::EncodedJSValue constructFromEncoding(JSC::JSGlobalObject* lexicalGlobalObject, std::span<const uint8_t> span, WebCore::BufferEncodingType encoding);
 JSC::EncodedJSValue constructFromEncoding(JSC::JSGlobalObject* lexicalGlobalObject, WTF::StringView string, WebCore::BufferEncodingType encoding);

--- a/src/bun.js/bindings/JSStringDecoder.cpp
+++ b/src/bun.js/bindings/JSStringDecoder.cpp
@@ -412,7 +412,14 @@ static inline JSC::EncodedJSValue jsStringDecoderPrototypeFunction_writeBody(JSC
 
         return Bun::ERR::INVALID_ARG_TYPE(throwScope, lexicalGlobalObject, "buf"_s, "Buffer, TypedArray, or DataView"_s, buffer);
     }
-    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->write(vm, lexicalGlobalObject, reinterpret_cast<uint8_t*>(view->vector()), view->byteLength())));
+    auto* bufPtr = reinterpret_cast<uint8_t*>(view->vector());
+    uint32_t bufLen = view->byteLength();
+    Vector<uint8_t> copy;
+    if (view->isShared()) [[unlikely]] {
+        copy.append(std::span { bufPtr, bufLen });
+        bufPtr = copy.begin();
+    }
+    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->write(vm, lexicalGlobalObject, bufPtr, bufLen)));
 }
 static inline JSC::EncodedJSValue jsStringDecoderPrototypeFunction_endBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, JSStringDecoder* castedThis)
 {
@@ -428,7 +435,14 @@ static inline JSC::EncodedJSValue jsStringDecoderPrototypeFunction_endBody(JSC::
         throwVMTypeError(lexicalGlobalObject, throwScope, "Expected Uint8Array"_s);
         return {};
     }
-    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->end(vm, lexicalGlobalObject, reinterpret_cast<uint8_t*>(view->vector()), view->byteLength())));
+    auto* bufPtr = reinterpret_cast<uint8_t*>(view->vector());
+    uint32_t bufLen = view->byteLength();
+    Vector<uint8_t> copy;
+    if (view->isShared()) [[unlikely]] {
+        copy.append(std::span { bufPtr, bufLen });
+        bufPtr = copy.begin();
+    }
+    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->end(vm, lexicalGlobalObject, bufPtr, bufLen)));
 }
 static inline JSC::EncodedJSValue jsStringDecoderPrototypeFunction_textBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, JSStringDecoder* castedThis)
 {
@@ -450,7 +464,14 @@ static inline JSC::EncodedJSValue jsStringDecoderPrototypeFunction_textBody(JSC:
     uint32_t byteLength = view->byteLength();
     if (offset > byteLength)
         RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(JSC::jsEmptyString(vm)));
-    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->write(vm, lexicalGlobalObject, reinterpret_cast<uint8_t*>(view->vector()) + offset, byteLength - offset)));
+    auto* bufPtr = reinterpret_cast<uint8_t*>(view->vector()) + offset;
+    uint32_t bufLen = byteLength - offset;
+    Vector<uint8_t> copy;
+    if (view->isShared()) [[unlikely]] {
+        copy.append(std::span { bufPtr, bufLen });
+        bufPtr = copy.begin();
+    }
+    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->write(vm, lexicalGlobalObject, bufPtr, bufLen)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsStringDecoderPrototypeFunction_write,

--- a/src/bun.js/bindings/JSUint8Array.zig
+++ b/src/bun.js/bindings/JSUint8Array.zig
@@ -11,6 +11,11 @@ pub const JSUint8Array = opaque {
         return this.ptr()[0..this.len()];
     }
 
+    extern fn JSUint8Array__isShared(this: *JSUint8Array) bool;
+    pub fn isShared(this: *JSUint8Array) bool {
+        return JSUint8Array__isShared(this);
+    }
+
     extern fn JSUint8Array__fromDefaultAllocator(*jsc.JSGlobalObject, ptr: [*]u8, len: usize) jsc.JSValue;
     /// *bytes* must come from bun.default_allocator
     pub fn fromBytes(globalThis: *JSGlobalObject, bytes: []u8) jsc.JSValue {

--- a/src/bun.js/bindings/Uint8Array.cpp
+++ b/src/bun.js/bindings/Uint8Array.cpp
@@ -23,6 +23,11 @@ extern "C" JSC::EncodedJSValue JSUint8Array__fromDefaultAllocator(JSC::JSGlobalO
     return JSC::JSValue::encode(uint8Array);
 }
 
+extern "C" bool JSUint8Array__isShared(JSC::JSUint8Array* array)
+{
+    return array->isShared();
+}
+
 extern "C" JSC::EncodedJSValue JSArrayBuffer__fromDefaultAllocator(JSC::JSGlobalObject* lexicalGlobalObject, uint8_t* ptr, size_t length)
 {
 

--- a/src/bun.js/bindings/node/crypto/CryptoUtil.cpp
+++ b/src/bun.js/bindings/node/crypto/CryptoUtil.cpp
@@ -85,7 +85,7 @@ EncodedJSValue encode(JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, st
         return JSValue::encode(JSC::JSUint8Array::create(lexicalGlobalObject, globalObject->JSBufferSubclassStructure(), WTF::move(buffer), 0, bytes.size()));
     }
     default: {
-        return jsBufferToStringFromBytes(lexicalGlobalObject, scope, bytes, encoding);
+        return jsBufferToStringFromBytes(lexicalGlobalObject, scope, bytes, encoding, false);
     }
     }
 }

--- a/src/bun.js/bindings/node/http/JSHTTPParserPrototype.cpp
+++ b/src/bun.js/bindings/node/http/JSHTTPParserPrototype.cpp
@@ -127,6 +127,12 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPParser_execute, (JSGlobalObject * globalObject, C
             throwTypeError(globalObject, scope, "Buffer is detached"_s);
             return {};
         }
+        if (buffer->isShared()) [[unlikely]] {
+            // StringPtr stores raw pointers into this buffer and later passes them to
+            // WTF::String::fromUTF8, which requires stable input.
+            throwTypeError(globalObject, scope, "Buffer must not be backed by a SharedArrayBuffer"_s);
+            return {};
+        }
 
         JSValue result = parser->impl()->execute(globalObject, reinterpret_cast<const char*>(buffer->vector()), buffer->byteLength());
         RETURN_IF_EXCEPTION(scope, {});

--- a/src/bun.js/webcore/TextDecoder.zig
+++ b/src/bun.js/webcore/TextDecoder.zig
@@ -158,13 +158,24 @@ pub fn decodeUTF16(
 pub fn decode(this: *TextDecoder, globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
     const arguments = callframe.arguments_old(2).slice();
 
-    const input_slice = input_slice: {
+    var owned_input: ?[]u8 = null;
+    defer if (owned_input) |owned| bun.default_allocator.free(owned);
+
+    const input_slice: []const u8 = input_slice: {
         if (arguments.len == 0 or arguments[0].isUndefined()) {
             break :input_slice "";
         }
 
         if (arguments[0].asArrayBuffer(globalThis)) |array_buffer| {
-            break :input_slice array_buffer.slice();
+            const raw = array_buffer.slice();
+            // decodeSlice's UTF-8 path sizes its output from a first pass over the
+            // input and then converts in a second pass. SharedArrayBuffer bytes can
+            // change between passes, so snapshot them into owned memory first.
+            if (array_buffer.shared) {
+                owned_input = bun.default_allocator.dupe(u8, raw) catch return globalThis.throwOutOfMemory();
+                break :input_slice owned_input.?;
+            }
+            break :input_slice raw;
         }
 
         return globalThis.throwInvalidArguments("TextDecoder.decode expects an ArrayBuffer or TypedArray", .{});
@@ -186,7 +197,13 @@ pub fn decode(this: *TextDecoder, globalThis: *jsc.JSGlobalObject, callframe: *j
 }
 
 pub fn decodeWithoutTypeChecks(this: *TextDecoder, globalThis: *jsc.JSGlobalObject, uint8array: *jsc.JSUint8Array) bun.JSError!JSValue {
-    return this.decodeSlice(globalThis, uint8array.slice(), false);
+    const raw = uint8array.slice();
+    if (uint8array.isShared()) {
+        const owned = bun.default_allocator.dupe(u8, raw) catch return globalThis.throwOutOfMemory();
+        defer bun.default_allocator.free(owned);
+        return this.decodeSlice(globalThis, owned, false);
+    }
+    return this.decodeSlice(globalThis, raw, false);
 }
 
 fn decodeSlice(this: *TextDecoder, globalThis: *jsc.JSGlobalObject, buffer_slice: []const u8, comptime flush: bool) bun.JSError!JSValue {

--- a/src/string/immutable/unicode.zig
+++ b/src/string/immutable/unicode.zig
@@ -1082,6 +1082,9 @@ pub fn nonASCIISequenceLength(first_byte: u8) u3_fast {
 /// Convert a UTF-8 string to a UTF-16 string IF there are any non-ascii characters
 /// If there are no non-ascii characters, this returns null
 /// This is intended to be used for strings that go to JavaScript
+/// `bytes` must remain stable for the duration of this call. Callers holding a
+/// JS ArrayBufferView must snapshot when `isShared()` before passing it here;
+/// the simdutf length+convert path will overflow if the input mutates between passes.
 pub fn toUTF16Alloc(allocator: std.mem.Allocator, bytes: []const u8, comptime fail_if_invalid: bool, comptime sentinel: bool) !if (sentinel) ?[:0]u16 else ?[]u16 {
     if (strings.firstNonASCII(bytes)) |i| {
         const output_: ?std.array_list.Managed(u16) = if (comptime bun.FeatureFlags.use_simdutf) simd: {
@@ -1203,6 +1206,9 @@ pub fn toUTF16AllocForReal(allocator: std.mem.Allocator, bytes: []const u8, comp
     };
 }
 
+/// `bytes` must remain stable for the duration of this call. Callers holding a
+/// JS ArrayBufferView must snapshot when `isShared()` before passing it here;
+/// the simdutf length+convert path will overflow if the input mutates between passes.
 pub fn toUTF16AllocMaybeBuffered(
     allocator: std.mem.Allocator,
     bytes: []const u8,

--- a/test/js/node/buffer/buffer-sharedarraybuffer-tostring.test.ts
+++ b/test/js/node/buffer/buffer-sharedarraybuffer-tostring.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { StringDecoder } from "node:string_decoder";
 
 // UTF-8 → UTF-16 conversion sizes its output buffer from a first pass over the

--- a/test/js/node/buffer/buffer-sharedarraybuffer-tostring.test.ts
+++ b/test/js/node/buffer/buffer-sharedarraybuffer-tostring.test.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "bun:test";
+import { StringDecoder } from "node:string_decoder";
+
+// UTF-8 → UTF-16 conversion sizes its output buffer from a first pass over the
+// input and then converts in a second pass. A Worker mutating a SharedArrayBuffer
+// between passes (e.g. 3-byte '€' sequences → ASCII) makes the second pass write
+// more code units than were allocated. The fix snapshots shared input before
+// conversion, so these calls must never crash regardless of what the Worker does.
+
+const SIZE = 3 * 64 * 1024;
+const ITERS = 1000;
+
+const workerSrc = `
+self.onmessage = (e) => {
+  const u8 = new Uint8Array(e.data);
+  self.postMessage("ready");
+  while (true) {
+    for (let i = 0; i < u8.length; i += 3) { u8[i] = 0xE2; u8[i+1] = 0x82; u8[i+2] = 0xAC; }
+    for (let i = 0; i < u8.length; i++) u8[i] = 0x41;
+  }
+};
+`;
+
+async function startRacingWorker(sab: SharedArrayBuffer): Promise<Worker> {
+  const worker = new Worker(URL.createObjectURL(new Blob([workerSrc])));
+  const ready = new Promise<void>(resolve => {
+    worker.onmessage = () => resolve();
+  });
+  worker.postMessage(sab);
+  await ready;
+  return worker;
+}
+
+function fillEuro(u8: Uint8Array) {
+  for (let i = 0; i < u8.length; i += 3) {
+    u8[i] = 0xe2;
+    u8[i + 1] = 0x82;
+    u8[i + 2] = 0xac;
+  }
+}
+
+test("Buffer.prototype.toString('utf8') on SharedArrayBuffer does not crash under concurrent mutation", async () => {
+  const sab = new SharedArrayBuffer(SIZE);
+  fillEuro(new Uint8Array(sab));
+  const worker = await startRacingWorker(sab);
+  try {
+    const buf = Buffer.from(sab);
+    for (let i = 0; i < ITERS; i++) {
+      const s = buf.toString("utf8");
+      expect(typeof s).toBe("string");
+    }
+  } finally {
+    worker.terminate();
+  }
+});
+
+test("TextDecoder.prototype.decode on SharedArrayBuffer does not crash under concurrent mutation", async () => {
+  const sab = new SharedArrayBuffer(SIZE);
+  fillEuro(new Uint8Array(sab));
+  const worker = await startRacingWorker(sab);
+  try {
+    const td = new TextDecoder("utf-8");
+    const u8 = new Uint8Array(sab);
+    for (let i = 0; i < ITERS; i++) {
+      const s = td.decode(u8);
+      expect(typeof s).toBe("string");
+    }
+  } finally {
+    worker.terminate();
+  }
+});
+
+test("StringDecoder.prototype.write on SharedArrayBuffer does not crash under concurrent mutation", async () => {
+  const sab = new SharedArrayBuffer(SIZE);
+  fillEuro(new Uint8Array(sab));
+  const worker = await startRacingWorker(sab);
+  try {
+    const sd = new StringDecoder("utf8");
+    const buf = Buffer.from(sab);
+    for (let i = 0; i < ITERS; i++) {
+      const s = sd.write(buf);
+      expect(typeof s).toBe("string");
+    }
+  } finally {
+    worker.terminate();
+  }
+});
+
+test("http_parser.execute rejects SharedArrayBuffer-backed input", () => {
+  const binding = process.binding("http_parser");
+  const HTTPParser = binding.HTTPParser;
+  const parser = new HTTPParser();
+  parser.initialize(HTTPParser.REQUEST, {});
+  const sab = new SharedArrayBuffer(64);
+  new Uint8Array(sab).set(Buffer.from("GET / HTTP/1.1\r\nHost: a\r\n\r\n"));
+  expect(() => parser.execute(Buffer.from(sab))).toThrow(/SharedArrayBuffer/);
+});


### PR DESCRIPTION
Bun's UTF-8 → UTF-16 conversion (`strings.toUTF16Alloc` / `toUTF16AllocMaybeBuffered` and `WTF::String::fromUTF8`) works in two passes: measure the output length, allocate exactly that, then convert. When the input is a view into a `SharedArrayBuffer`, a Worker can mutate the bytes between the two passes (e.g. 3-byte `€` sequences → ASCII), causing the second pass to write up to 3× more code units than were allocated — a heap buffer overflow.

This snapshots the input into owned memory at the JS boundary when `isShared()`, before handing it to the converter. Non-shared ArrayBuffers are stable for the duration of a synchronous native call, so they skip the copy.

Affected APIs:

- `Buffer.prototype.toString('utf8')` / `utf8Slice()` — snapshot in `jsBufferToStringFromBytes` when the view is shared
- `TextDecoder.prototype.decode` (both the generic and DOMJIT paths) — snapshot when `ArrayBuffer.shared`
- `StringDecoder.prototype.write/end/text` — snapshot when `view->isShared()`
- `process.binding('http_parser').HTTPParser.prototype.execute` — reject SharedArrayBuffer-backed input (internal binding, never legitimately receives one)

Also adds a `JSUint8Array.isShared()` Zig helper and documents the stability contract on `toUTF16Alloc`, `toUTF16AllocMaybeBuffered`, and `BunString__fromUTF8`.

The included test reliably segfaults on an unfixed build (fault address `0x41004100410041` — the racing 'A' bytes overwriting a pointer) and passes with this change.