### PR TITLE
bun create: strip leading `--` and wrapper-consumed `--bun` from forwarded argv

### DIFF
--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -795,7 +795,8 @@ export function formatConfig(cfg: Config, exe: string): string {
   // revert my WebKit test branch" before the build goes weird.
   if (cfg.webkitVersion !== versionDefaults.webkitVersion)
     features.push(`webkit-version:${cfg.webkitVersion.slice(0, 10)}`);
-  if (cfg.zigCommit !== defaultZigCommit(cfg.ci, cfg.host.os)) features.push(`zig-commit:${cfg.zigCommit.slice(0, 10)}`);
+  if (cfg.zigCommit !== defaultZigCommit(cfg.ci, cfg.host.os))
+    features.push(`zig-commit:${cfg.zigCommit.slice(0, 10)}`);
   if (cfg.nodejsVersion !== versionDefaults.nodejsVersion) features.push(`nodejs:${cfg.nodejsVersion}`);
   lines.push(`  ${label("features")} ${features.length > 0 ? c.cyan(features.join(", ")) : c.dim("(none)")}`);
   return lines.join("\n");

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1726,14 +1726,49 @@ pub const Command = struct {
             example_tag != CreateCommandExample.Tag.local_folder;
 
         if (use_bunx) {
-            const bunx_args = try allocator.alloc([:0]const u8, 2 + args.len - template_name_start + @intFromBool(dash_dash_bun));
+            // Forward everything after the template name to the create
+            // script, but:
+            //   1. drop `--bun` — the wrapper already consumed it into
+            //      `dash_dash_bun` and re-inserts it below, so leaving it
+            //      in the forwarded args would leak it to the create
+            //      script (see #29087).
+            //   2. drop a single leading `--` — the npm/yarn convention
+            //      is that the first bare `--` is an argument separator
+            //      (so `bun create foo -- -t v3` is equivalent to
+            //      `bun create foo -t v3`). Any subsequent `--` is a
+            //      literal argument and must be preserved.
+            const forwarded = args[template_name_start..];
+
+            var forwarded_count: usize = 0;
+            var seen_separator = false;
+            for (forwarded) |arg| {
+                const slice = bun.asByteSlice(arg);
+                if (strings.eqlComptime(slice, "--bun")) continue;
+                if (!seen_separator and strings.eqlComptime(slice, "--")) {
+                    seen_separator = true;
+                    continue;
+                }
+                forwarded_count += 1;
+            }
+
+            const bunx_args = try allocator.alloc([:0]const u8, 2 + forwarded_count + @intFromBool(dash_dash_bun));
             bunx_args[0] = "bunx";
             if (dash_dash_bun) {
                 bunx_args[1] = "--bun";
             }
             bunx_args[1 + @as(usize, @intFromBool(dash_dash_bun))] = try BunxCommand.addCreatePrefix(allocator, template_name);
-            for (bunx_args[2 + @as(usize, @intFromBool(dash_dash_bun)) ..], args[template_name_start..]) |*dest, src| {
-                dest.* = src;
+
+            var dest_i: usize = 2 + @as(usize, @intFromBool(dash_dash_bun));
+            seen_separator = false;
+            for (forwarded) |arg| {
+                const slice = bun.asByteSlice(arg);
+                if (strings.eqlComptime(slice, "--bun")) continue;
+                if (!seen_separator and strings.eqlComptime(slice, "--")) {
+                    seen_separator = true;
+                    continue;
+                }
+                bunx_args[dest_i] = arg;
+                dest_i += 1;
             }
 
             try BunxCommand.exec(ctx, bunx_args);

--- a/test/regression/issue/29087.test.ts
+++ b/test/regression/issue/29087.test.ts
@@ -141,9 +141,7 @@ describe("issue #29087", () => {
 
     const match = stdout.match(/ARGV:(.+)/);
     if (!match) {
-      throw new Error(
-        `Could not find ARGV line in stdout (exit ${exitCode}).\nstdout:\n${stdout}\nstderr:\n${stderr}`,
-      );
+      throw new Error(`Could not find ARGV line in stdout (exit ${exitCode}).\nstdout:\n${stdout}\nstderr:\n${stderr}`);
     }
     return { argv: JSON.parse(match[1]!), stdout, stderr };
   }

--- a/test/regression/issue/29087.test.ts
+++ b/test/regression/issue/29087.test.ts
@@ -1,0 +1,173 @@
+// https://github.com/oven-sh/bun/issues/29087
+//
+// `bun create <template> -- <args>` should strip a single leading `--` before
+// forwarding to the create script (npm/yarn convention), and must not leak
+// flags the `bun create` wrapper itself consumed (`--bun`, `--help`, `-h`).
+//
+// Before the fix:
+//   $ bun create foo -- -t v3
+//   process.argv.slice(2) === ["--", "-t", "v3"]
+// After:
+//   process.argv.slice(2) === ["-t", "v3"]
+
+import type { Server } from "bun";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+/** Minimal gzipped tar of a single-binary npm package. */
+function createTarball(name: string, version: string, binName: string, script: string): Uint8Array {
+  const packageJson = JSON.stringify({
+    name,
+    version,
+    bin: { [binName]: "index.js" },
+  });
+
+  const files: Record<string, string> = {
+    "package/package.json": packageJson,
+    "package/index.js": script,
+  };
+
+  const entries: Buffer[] = [];
+  let tarSize = 0;
+
+  for (const [path, content] of Object.entries(files)) {
+    const contentBuf = Buffer.from(content, "utf8");
+    const blockSize = Math.ceil((contentBuf.length + 512) / 512) * 512;
+    const entry = Buffer.alloc(blockSize);
+
+    entry.write(path, 0, Math.min(path.length, 99));
+    entry.write("0000755", 100, 7); // mode (executable — bin needs +x)
+    entry.write("0000000", 108, 7); // uid
+    entry.write("0000000", 116, 7); // gid
+    entry.write(contentBuf.length.toString(8).padStart(11, "0"), 124, 11); // size
+    entry.write("00000000000", 136, 11); // mtime
+    entry.write("        ", 148, 8); // checksum placeholder (8 spaces)
+    entry.write("0", 156, 1); // type flag: regular file
+
+    // tar checksum = sum of header bytes, with checksum field treated as spaces.
+    let checksum = 0;
+    for (let i = 0; i < 512; i++) {
+      checksum += i >= 148 && i < 156 ? 32 : entry[i];
+    }
+    entry.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148, 8);
+
+    contentBuf.copy(entry, 512);
+    entries.push(entry);
+    tarSize += blockSize;
+  }
+
+  // Two 512-byte zero blocks = end-of-archive.
+  entries.push(Buffer.alloc(1024));
+  tarSize += 1024;
+
+  return Bun.gzipSync(Buffer.concat(entries, tarSize));
+}
+
+describe("issue #29087", () => {
+  const pkgName = "create-bun-issue29087-argv-printer";
+  const binName = "create-bun-issue29087-argv-printer";
+  // Intentionally uses process.argv.slice(2): the script should only see args
+  // the user passed after `bun create <name>`, not the separator.
+  const script = `#!/usr/bin/env node\nconsole.log("ARGV:" + JSON.stringify(process.argv.slice(2)));\n`;
+
+  let server: Server;
+  let registryUrl: string;
+
+  beforeAll(() => {
+    const tarball = createTarball(pkgName, "1.0.0", binName, script);
+
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+
+        // Tarball request
+        if (url.pathname.endsWith(".tgz")) {
+          return new Response(tarball, {
+            status: 200,
+            headers: { "Content-Type": "application/octet-stream" },
+          });
+        }
+
+        // Package metadata
+        if (url.pathname === `/${pkgName}`) {
+          return Response.json({
+            name: pkgName,
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name: pkgName,
+                version: "1.0.0",
+                bin: { [binName]: "index.js" },
+                dist: {
+                  tarball: `${registryUrl}/${pkgName}/-/${pkgName}-1.0.0.tgz`,
+                },
+              },
+            },
+          });
+        }
+
+        return new Response("not found", { status: 404 });
+      },
+    });
+    registryUrl = `http://localhost:${server.port}`;
+  });
+
+  afterAll(() => {
+    server.stop(true);
+  });
+
+  /** Run `bun create <args>` against the local registry and return the argv the create script received. */
+  async function runCreate(...createArgs: string[]): Promise<{ argv: string[]; stdout: string; stderr: string }> {
+    using dir = tempDir(`bun-create-29087`, {
+      "bunfig.toml": `[install]\ncache = false\nregistry = "${registryUrl}/"\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "create", ...createArgs],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        // Make sure bunx hits our registry, not the real one.
+        BUN_INSTALL_CACHE_DIR: String(dir) + "/.cache",
+        npm_config_registry: `${registryUrl}/`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const match = stdout.match(/ARGV:(.+)/);
+    if (!match) {
+      throw new Error(
+        `Could not find ARGV line in stdout (exit ${exitCode}).\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+      );
+    }
+    return { argv: JSON.parse(match[1]!), stdout, stderr };
+  }
+
+  test("strips a single leading `--` separator before forwarding to the create script", async () => {
+    // "bun-issue29087-argv-printer" resolves to "create-bun-issue29087-argv-printer"
+    const { argv } = await runCreate("bun-issue29087-argv-printer", "--", "-t", "v3");
+    expect(argv).toEqual(["-t", "v3"]);
+  });
+
+  test("forwards long-form flags with no `--` separator unchanged", async () => {
+    const { argv } = await runCreate("bun-issue29087-argv-printer", "--template", "v3");
+    expect(argv).toEqual(["--template", "v3"]);
+  });
+
+  test("preserves a second `--` as a literal (only the first is the separator)", async () => {
+    const { argv } = await runCreate("bun-issue29087-argv-printer", "--", "--", "-t", "v3");
+    expect(argv).toEqual(["--", "-t", "v3"]);
+  });
+
+  test("does not leak `--bun` (consumed by wrapper) into forwarded argv", async () => {
+    // Wrapper-consumed flags should not reach the create script regardless of
+    // where they appear relative to the template name or separator.
+    const { argv } = await runCreate("bun-issue29087-argv-printer", "--bun", "--", "-t", "v3");
+    expect(argv).toEqual(["-t", "v3"]);
+  });
+});


### PR DESCRIPTION
Fixes #29087.

## Repro

```console
$ bun create bun-args-test-antlis -- -t v3
args received: [ '--', '-t', 'v3' ]      # ← wrong

$ bun create bun-args-test-antlis --bun -- -t v3
args received: [ '--bun', '--', '-t', 'v3' ]  # ← also leaks `--bun`
```

`create-nuxt` (and other npm-init scripts) see `--` first, can't parse it, and silently ignore the rest — so `bun create nuxt@latest -- -t v3` never picks the v3 template. Reported against Nuxt in nuxt/nuxt#32854 (docs patched in nuxt/nuxt#34792 to work around this Bun-side bug).

## Cause

`src/cli.zig` `"bun create"` scans `args[1..]` for positionals/flags and records `template_name_start` = index of the first arg after the template name. Then it blindly copies everything from there into `bunx_args`:

```zig
for (bunx_args[2 + ..], args[template_name_start..]) |*dest, src| {
    dest.* = src;
}
```

Nothing ever strips a leading `--`, and `--bun` is never removed from the forwarded tail even though the wrapper has already consumed it into `dash_dash_bun` (which is then re-inserted as a real arg to `bunx`).

## Fix

Follow the npm/yarn convention: the first bare `--` in the forwarded args is an argument separator and is dropped; any subsequent `--` is literal and preserved. Also drop every `--bun` token from the forwarded args — it's already consumed by the wrapper.

```
bun create foo -- -t v3          →  bunx create-foo -t v3
bun create foo --bun -- -t v3    →  bunx --bun create-foo -t v3
bun create foo -- -- -t v3       →  bunx create-foo -- -t v3     (2nd `--` is literal)
bun create foo --template v3     →  bunx create-foo --template v3 (no separator, unchanged)
```

## Verification

`test/regression/issue/29087.test.ts` spins up a local registry serving a tiny `create-bun-issue29087-argv-printer` package whose binary prints `process.argv.slice(2)` as JSON. The four cases above are asserted against that output.

```
bun bd test test/regression/issue/29087.test.ts
  (pass) strips a single leading `--` separator before forwarding to the create script
  (pass) forwards long-form flags with no `--` separator unchanged
  (pass) preserves a second `--` as a literal (only the first is the separator)
  (pass) does not leak `--bun` (consumed by wrapper) into forwarded argv
```

On the baked release bun (pre-fix) the three `--`/`--bun` cases all fail with the expected leaked tokens:

```
USE_SYSTEM_BUN=1 bun test test/regression/issue/29087.test.ts
  (fail) ["--", "-t", "v3"] vs expected ["-t", "v3"]
  (fail) ["--", "--", "-t", "v3"] vs ["--", "-t", "v3"]
  (fail) ["--bun", "--", "-t", "v3"] vs ["-t", "v3"]
```

The existing `test/cli/install/bun-create.test.ts` "should not crash" subset (including the `["create", "--"]` edge case) still passes.