### PR TITLE
build: use lld for linux relocatable merge; bump parallel zig commit

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -750,7 +750,7 @@ fn configureObj(b: *Build, opts: *BunBuildOptions, obj: *Compile) void {
 
     // Object options
     obj.use_llvm = !opts.no_llvm;
-    obj.use_lld = if (opts.os == .mac or opts.os == .linux) false else !opts.no_llvm;
+    obj.use_lld = if (opts.os == .mac) false else !opts.no_llvm;
 
     if (@hasField(std.meta.Child(@TypeOf(obj)), "llvm_codegen_threads"))
         obj.llvm_codegen_threads = opts.llvm_codegen_threads orelse 0;

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -39,7 +39,7 @@ import { streamPath } from "./stream.ts";
  * is trusted, collapse both back to one constant.
  */
 export const ZIG_COMMIT = "365343af4fc5a1a632e6b54aadd0b87be30edd81";
-export const ZIG_COMMIT_PARALLEL = "6093f9372660953a6b95532e45373037174fa76c";
+export const ZIG_COMMIT_PARALLEL = "7d3c0c9b3698d6ce57ef632833e71cab05b783b6";
 
 /**
  * The one place that picks which compiler to use. Everything coupled to


### PR DESCRIPTION
Two changes on top of Dylan's compiler-split in #28826:

**`build.zig:753`** — drop Linux from the `use_lld = false` exception. With `llvm_codegen_threads>1` the zig step emits N shard objects merged via `-r`; zig's self-hosted ELF linker is pathologically slow there (one pread per input section × per-function COMDAT = hundreds of thousands of syscalls). `ld.lld -r` is fast. macOS stays on the self-hosted MachO path.

**`zig.ts:42`** — bump `ZIG_COMMIT_PARALLEL` to `7d3c0c9b36` (oven-sh/zig `upgrade-0.15.2` tip). Adds:
- ELF `writeRelocatable` batched preads (so even without lld it's no longer a hang)
- `--llvm-no-merge-shards` flag + `std.Build` wiring

`defaultZigCommit` still gates parallel to macOS-local-only — left as-is until someone confirms a clean Linux build with the new commit.

> [!NOTE]
> Autobuild for `7d3c0c9b36` needs to finish on oven-sh/zig before this can merge (compiler download will 404 otherwise).