### PR TITLE
build: enable parallel zig compiler on linux local builds

### DIFF
--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -795,7 +795,8 @@ export function formatConfig(cfg: Config, exe: string): string {
   // revert my WebKit test branch" before the build goes weird.
   if (cfg.webkitVersion !== versionDefaults.webkitVersion)
     features.push(`webkit-version:${cfg.webkitVersion.slice(0, 10)}`);
-  if (cfg.zigCommit !== defaultZigCommit(cfg.ci, cfg.host.os)) features.push(`zig-commit:${cfg.zigCommit.slice(0, 10)}`);
+  if (cfg.zigCommit !== defaultZigCommit(cfg.ci, cfg.host.os))
+    features.push(`zig-commit:${cfg.zigCommit.slice(0, 10)}`);
   if (cfg.nodejsVersion !== versionDefaults.nodejsVersion) features.push(`nodejs:${cfg.nodejsVersion}`);
   lines.push(`  ${label("features")} ${features.length > 0 ? c.cyan(features.join(", ")) : c.dim("(none)")}`);
   return lines.join("\n");

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -39,7 +39,7 @@ import { streamPath } from "./stream.ts";
  * is trusted, collapse both back to one constant.
  */
 export const ZIG_COMMIT = "365343af4fc5a1a632e6b54aadd0b87be30edd81";
-export const ZIG_COMMIT_PARALLEL = "6093f9372660953a6b95532e45373037174fa76c";
+export const ZIG_COMMIT_PARALLEL = "7d3c0c9b3698d6ce57ef632833e71cab05b783b6";
 
 /**
  * The one place that picks which compiler to use. Everything coupled to
@@ -47,11 +47,11 @@ export const ZIG_COMMIT_PARALLEL = "6093f9372660953a6b95532e45373037174fa76c";
  * on the resolved cfg.zigCommit via usingParallelCompiler(), so changing
  * this — or passing --zigCommit=<hash> — is sufficient.
  *
- * Parallel compiler is macOS-local only for now; CI and linux/windows
- * local builds stay on the stable compiler until it's proven there.
+ * Parallel compiler is enabled for local builds; CI stays on the stable
+ * compiler until release builds are proven correct under parallel sema.
  */
 export function defaultZigCommit(ci: boolean, hostOs: OS): string {
-  if (ci || hostOs !== "darwin") return ZIG_COMMIT;
+  if (ci || hostOs === "windows") return ZIG_COMMIT;
   return ZIG_COMMIT_PARALLEL;
 }
 


### PR DESCRIPTION
Bumps `ZIG_COMMIT_PARALLEL` to `7d3c0c9b36` (oven-sh/zig `upgrade-0.15.2` tip) and drops the darwin-only gate so Linux local builds use the parallel compiler too.

The previous parallel commit hung on Linux during ELF flush — sharded codegen emits per-function COMDAT sections and zig's self-hosted ELF `-r` merge did one `pread`+alloc per section (hundreds of thousands of tiny syscalls). `7d3c0c9b36` batches those into per-file contiguous reads.

CI and Windows stay on the stable compiler.

> [!NOTE]
> Don't merge until autobuild for `7d3c0c9b36` finishes on oven-sh/zig (compiler download will 404 otherwise).