### PR TITLE
fix(workers): resolve worker.terminate() promise immediately after construction

### DIFF
--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -611,11 +611,14 @@ pub fn notifyNeedTermination(this: *WebWorker) callconv(.c) void {
 
     if (this.vm) |vm| {
         vm.eventLoop().wakeup();
-        // TODO(@190n) notifyNeedTermination
     }
 
-    // TODO(@190n) delete
-    this.setRefInternal(false);
+    // Note: we deliberately do NOT unref the parent poll here. The parent
+    // event loop must stay alive until the worker thread dispatches the
+    // "close" event back to it, otherwise `worker.terminate().then(...)`
+    // never resolves because the parent exits first. The parent poll is
+    // released later in `deinit()` (on the worker thread, after the close
+    // event has been posted) or by `onUnhandledRejection`.
 }
 
 /// This handles cleanup, emitting the "close" event, and deinit.

--- a/test/regression/issue/29077.test.ts
+++ b/test/regression/issue/29077.test.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/29077
+// `worker.terminate()` must resolve its promise even when called immediately
+// after construction. Prior to the fix, notifyNeedTermination unref'd the
+// parent poll right away, so the parent event loop exited before the worker
+// thread could dispatch its "close" event back to the parent, leaving the
+// promise pending forever.
+
+test("worker.terminate() .then() runs when called right after construction", async () => {
+  using dir = tempDir("issue-29077", {
+    "worker.mjs": `console.log("worker started");`,
+    "main.mjs": `
+      import { Worker } from "node:worker_threads";
+      import * as path from "node:path";
+      import { fileURLToPath } from "node:url";
+
+      const __dirname = path.dirname(fileURLToPath(import.meta.url));
+      const worker = new Worker(path.join(__dirname, "worker.mjs"));
+
+      worker.terminate().then(code => {
+        console.log("terminated:" + code);
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("terminated:0");
+  expect(exitCode).toBe(0);
+});
+
+test("worker.terminate() .then() runs when worker has a long-running task", async () => {
+  using dir = tempDir("issue-29077-busy", {
+    "worker.mjs": `setInterval(() => {}, 1000);`,
+    "main.mjs": `
+      import { Worker } from "node:worker_threads";
+      import * as path from "node:path";
+      import { fileURLToPath } from "node:url";
+
+      const __dirname = path.dirname(fileURLToPath(import.meta.url));
+      const worker = new Worker(path.join(__dirname, "worker.mjs"));
+
+      worker.terminate().then(code => {
+        console.log("terminated:" + code);
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("terminated:0");
+  expect(exitCode).toBe(0);
+});
+
+test("multiple worker.terminate() calls each resolve", async () => {
+  using dir = tempDir("issue-29077-multi", {
+    "worker.mjs": `console.log("worker started");`,
+    "main.mjs": `
+      import { Worker } from "node:worker_threads";
+      import * as path from "node:path";
+      import { fileURLToPath } from "node:url";
+
+      const __dirname = path.dirname(fileURLToPath(import.meta.url));
+      const worker = new Worker(path.join(__dirname, "worker.mjs"));
+
+      const p1 = worker.terminate();
+      const p2 = worker.terminate();
+
+      let resolved = 0;
+      p1.then(code => { resolved++; console.log("p1:" + code); });
+      p2.then(code => { resolved++; console.log("p2:" + code); });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toContain("p1:0");
+  expect(stdout).toContain("p2:0");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Repro

```js
import { Worker } from 'node:worker_threads';
const worker = new Worker(new URL('./worker.mjs', import.meta.url));
worker.terminate().then(() => console.log('terminated'));
// Bun: (no output)  ← bug
// Node: 'terminated'
```

## Cause

`notifyNeedTermination` in `src/bun.js/web_worker.zig` unref'd the parent poll immediately:

```zig
pub fn notifyNeedTermination(this: *WebWorker) callconv(.c) void {
    // ...
    if (this.vm) |vm| { vm.eventLoop().wakeup(); }
    this.setRefInternal(false);  // ← drops parent poll ref
}
```

When `terminate()` is called right after construction — before anything else keeps the parent event loop alive — the parent loop exits before the worker thread reaches `exitAndDeinit` → `WebWorker__dispatchExit`, which is what posts the `close` event back to the parent. No close event ⇒ the promise returned by `terminate()` stays pending forever, the `.then()` never fires, and the process exits silently.

As a secondary issue, `notifyNeedTermination` is called from any thread (including the worker thread itself via `process.exit()`), but `setRefInternal(false)` used the **non-concurrent** `Async.KeepAlive.unref` — only safe on the owning loop's thread.

## Fix

Stop unref'ing in `notifyNeedTermination`. The parent poll is released later in `deinit()` (on the worker thread, after the close event has been posted via `WebWorker__dispatchExit`) or by `onUnhandledRejection`'s explicit `unrefConcurrently`.

`Async.KeepAlive` tracks `status` internally, so the second `unref` paths via `deinit()` are already no-ops when the poll was already released — no double-unref risk.

## Verification

`test/regression/issue/29077.test.ts` covers three cases that all fail on `USE_SYSTEM_BUN=1` and pass with this fix:
- `.then()` right after construction (the exact repro)
- `.then()` on a worker with a long-running task
- two `terminate()` calls, each with its own `.then()`

Fixes #29077