### PR TITLE
build: pass --locked to cargo for vendored Rust deps

### DIFF
--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -795,7 +795,8 @@ export function formatConfig(cfg: Config, exe: string): string {
   // revert my WebKit test branch" before the build goes weird.
   if (cfg.webkitVersion !== versionDefaults.webkitVersion)
     features.push(`webkit-version:${cfg.webkitVersion.slice(0, 10)}`);
-  if (cfg.zigCommit !== defaultZigCommit(cfg.ci, cfg.host.os)) features.push(`zig-commit:${cfg.zigCommit.slice(0, 10)}`);
+  if (cfg.zigCommit !== defaultZigCommit(cfg.ci, cfg.host.os))
+    features.push(`zig-commit:${cfg.zigCommit.slice(0, 10)}`);
   if (cfg.nodejsVersion !== versionDefaults.nodejsVersion) features.push(`nodejs:${cfg.nodejsVersion}`);
   lines.push(`  ${label("features")} ${features.length > 0 ? c.cyan(features.join(", ")) : c.dim("(none)")}`);
   return lines.join("\n");

--- a/scripts/build/deps/lolhtml.ts
+++ b/scripts/build/deps/lolhtml.ts
@@ -8,11 +8,7 @@
 
 import type { CargoBuild, Dependency } from "../source.ts";
 
-// When bumping: emitCargo passes --locked, so the new commit's
-// c-api/Cargo.lock must be in sync with its Cargo.toml. Upstream has
-// shipped release tags with a stale lockfile before (e.g. 2.7.2 at
-// e3aa547, fixed in 77127cd) — verify with `cargo metadata --locked`
-// in c-api/ before pinning a release commit.
+// When bumping: verify `cargo metadata --locked` passes in c-api/.
 const LOLHTML_COMMIT = "77127cd2b8545998756e8d64e36ee2313c4bb312";
 
 export const lolhtml: Dependency = {

--- a/scripts/build/deps/lolhtml.ts
+++ b/scripts/build/deps/lolhtml.ts
@@ -8,7 +8,12 @@
 
 import type { CargoBuild, Dependency } from "../source.ts";
 
-const LOLHTML_COMMIT = "e3aa54798602dd27250fafde1b5a66f080046252";
+// When bumping: emitCargo passes --locked, so the new commit's
+// c-api/Cargo.lock must be in sync with its Cargo.toml. Upstream has
+// shipped release tags with a stale lockfile before (e.g. 2.7.2 at
+// e3aa547, fixed in 77127cd) — verify with `cargo metadata --locked`
+// in c-api/ before pinning a release commit.
+const LOLHTML_COMMIT = "77127cd2b8545998756e8d64e36ee2313c4bb312";
 
 export const lolhtml: Dependency = {
   name: "lolhtml",

--- a/scripts/build/deps/lolhtml.ts
+++ b/scripts/build/deps/lolhtml.ts
@@ -8,7 +8,6 @@
 
 import type { CargoBuild, Dependency } from "../source.ts";
 
-// When bumping: verify `cargo metadata --locked` passes in c-api/.
 const LOLHTML_COMMIT = "77127cd2b8545998756e8d64e36ee2313c4bb312";
 
 export const lolhtml: Dependency = {

--- a/scripts/build/source.ts
+++ b/scripts/build/source.ts
@@ -294,12 +294,6 @@ export interface PreBuildSpec {
   outputs: string[];
 }
 
-/**
- * Built with `cargo build --locked`, so the dep's tarball must ship a
- * Cargo.lock in `manifestDir`. If it doesn't, the build fails (intentionally
- * — unlocked cargo deps would re-resolve transitive crates against crates.io
- * on every build, breaking reproducibility).
- */
 export interface CargoBuild {
   kind: "cargo";
   /**
@@ -1229,10 +1223,6 @@ function emitCargo(n: Ninja, cfg: Config, name: string, spec: CargoBuild, input:
   const lib = resolve(targetDir, outSubdir, `${cfg.libPrefix}${spec.libName}${cfg.libSuffix}`);
 
   // ─── Build args ───
-  // --locked: the dep's tarball ships a Cargo.lock (e.g. lolhtml's
-  // c-api/Cargo.lock). Without --locked, a yanked crate or upstream
-  // lockfile/Cargo.toml drift would silently re-resolve against crates.io,
-  // breaking build reproducibility. With it, that case fails loud.
   const args: string[] = ["--locked", "--target-dir", targetDir];
   if (cfg.release) args.push("--release");
   if (spec.rustTarget) args.push("--target", spec.rustTarget);

--- a/scripts/build/source.ts
+++ b/scripts/build/source.ts
@@ -294,6 +294,12 @@ export interface PreBuildSpec {
   outputs: string[];
 }
 
+/**
+ * Built with `cargo build --locked`, so the dep's tarball must ship a
+ * Cargo.lock in `manifestDir`. If it doesn't, the build fails (intentionally
+ * — unlocked cargo deps would re-resolve transitive crates against crates.io
+ * on every build, breaking reproducibility).
+ */
 export interface CargoBuild {
   kind: "cargo";
   /**
@@ -1223,7 +1229,11 @@ function emitCargo(n: Ninja, cfg: Config, name: string, spec: CargoBuild, input:
   const lib = resolve(targetDir, outSubdir, `${cfg.libPrefix}${spec.libName}${cfg.libSuffix}`);
 
   // ─── Build args ───
-  const args: string[] = ["--target-dir", targetDir];
+  // --locked: the dep's tarball ships a Cargo.lock (e.g. lolhtml's
+  // c-api/Cargo.lock). Without --locked, a yanked crate or upstream
+  // lockfile/Cargo.toml drift would silently re-resolve against crates.io,
+  // breaking build reproducibility. With it, that case fails loud.
+  const args: string[] = ["--locked", "--target-dir", targetDir];
   if (cfg.release) args.push("--release");
   if (spec.rustTarget) args.push("--target", spec.rustTarget);
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -279,7 +279,7 @@ it("process.versions", () => {
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "886098f3f339617b4243b286f5ed364b9989e245",
     tinycc: "12882eee073cfe5c7621bcfadf679e1372d4537b",
-    lolhtml: "e3aa54798602dd27250fafde1b5a66f080046252",
+    lolhtml: "77127cd2b8545998756e8d64e36ee2313c4bb312",
     ares: "3ac47ee46edd8ea40370222f91613fc16c434853",
     libdeflate: "c8c56a20f8f621e6a966b716b31f1dedab6a41e3",
     zstd: "f8745da6ff1ad1e7bab384bd1f9d742439278e99",


### PR DESCRIPTION
Pass `--locked` to `cargo build` in `emitCargo()` so transitive Rust crate versions can't silently re-resolve against crates.io.

Bumps `LOLHTML_COMMIT` one commit forward (`e3aa547`→`77127cd`) because the old pin's `c-api/Cargo.lock` was stale (upstream forgot to regenerate it for 2.7.2). The new pin is the upstream lockfile fix; only `c-api/Cargo.lock` differs between the two — same lol-html 2.7.2 source.