### PR TITLE
build: bump ZIG_COMMIT_PARALLEL to 445fc0cbba

### DIFF
--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -39,7 +39,7 @@ import { streamPath } from "./stream.ts";
  * is trusted, collapse both back to one constant.
  */
 export const ZIG_COMMIT = "365343af4fc5a1a632e6b54aadd0b87be30edd81";
-export const ZIG_COMMIT_PARALLEL = "7d3c0c9b3698d6ce57ef632833e71cab05b783b6";
+export const ZIG_COMMIT_PARALLEL = "445fc0cbba4eea579e5c846f2b8be7c9bdc4e1cc";
 
 /**
  * The one place that picks which compiler to use. Everything coupled to


### PR DESCRIPTION
Bumps the parallel-sema compiler from `7d3c0c9b36` → `445fc0cbba` (oven-sh/zig `upgrade-0.15.2` tip).

**Full behaviour matrix is now 0-failed** under `-Dllvm-codegen-threads=8` (was 17 failed at `7d3c0c9b`).

Picks up 6 commits:
- `c2983b5f2c` — 14 parallel-sema race fixes (ARM64 seqlock missing acquire fence, `.removed` cluster, retry leaks, UAF)
- `a59bd0a09e` — `-Dllvm-codegen-threads` threaded through behaviour tests
- `6c33e106df` — COFF COMDAT, module-asm routing, cross-shard `@export` alias collapse, IES yield
- `d05d437103` — self-ref global false cycle, union wip race, `-fno-sanitize=address`, `clock_getres`
- `c38724a979` — error-set `@typeInfo` order tests made order-agnostic
- `445fc0cbba` — f16 Darwin ABI fix in `lib/zig.h` + `compiler_rt`; CBE strlen gate

Also fixes the Linux empty-`bun-zig.o` issue from the docker daily build (the ELF merge now produces valid output).

> [!NOTE]
> Don't merge until autobuild for `445fc0cbba` finishes on oven-sh/zig.