### PR TITLE
docs: bun-types changes don't require `bun bd`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,16 @@ When exec args are present, build output is suppressed unless the build fails â€
 bun run build:release --build-dir=build/baseline
 ```
 
+### Changes that don't require a build
+
+Edits to **TypeScript type declarations** (`packages/bun-types/**/*.d.ts`) do not touch any compiled code, so `bun bd` is unnecessary. The types test just packs the `.d.ts` files and runs `tsc` against fixtures â€” it never executes your build. Run it directly with the system Bun:
+
+```sh
+bun test test/integration/bun-types/bun-types.test.ts
+```
+
+This is an explicit exception to the "never use `bun test` directly" rule. There are no native changes for a debug build to pick up, so don't wait on one.
+
 ## Testing
 
 ### Running Tests


### PR DESCRIPTION
Adds a short section to CLAUDE.md clarifying that edits to `packages/bun-types/**/*.d.ts` are type-only and don't need a native build — `bun-types.test.ts` just packs the declarations and runs `tsc` against fixtures, so it can be run with system Bun directly.

Prevents agents from kicking off a 30-min cold build to validate a `.d.ts` tweak.