### PR TITLE
types: add Map/WeakMap getOrInsert and getOrInsertComputed

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1115,6 +1115,50 @@ interface ArrayConstructor {
   ): Promise<Awaited<U>[]>;
 }
 
+interface Map<K, V> {
+  /**
+   * If an entry with the given `key` already exists, its value is returned.
+   * Otherwise, a new entry is added with the given `key` mapped to `defaultValue`,
+   * and `defaultValue` is returned.
+   *
+   * @param key The key of the element to return from the `Map` object.
+   * @param defaultValue The value to insert and return if no entry exists for `key`.
+   */
+  getOrInsert(key: K, defaultValue: V): V;
+
+  /**
+   * If an entry with the given `key` already exists, its value is returned.
+   * Otherwise, `callback` is called with `key`, a new entry is added mapping `key`
+   * to the callback's return value, and that value is returned.
+   *
+   * @param key The key of the element to return from the `Map` object.
+   * @param callback The function to compute a value for `key` if no entry exists.
+   */
+  getOrInsertComputed(key: K, callback: (key: K) => V): V;
+}
+
+interface WeakMap<K extends WeakKey, V> {
+  /**
+   * If an entry with the given `key` already exists, its value is returned.
+   * Otherwise, a new entry is added with the given `key` mapped to `defaultValue`,
+   * and `defaultValue` is returned.
+   *
+   * @param key The key of the element to return from the `WeakMap` object.
+   * @param defaultValue The value to insert and return if no entry exists for `key`.
+   */
+  getOrInsert(key: K, defaultValue: V): V;
+
+  /**
+   * If an entry with the given `key` already exists, its value is returned.
+   * Otherwise, `callback` is called with `key`, a new entry is added mapping `key`
+   * to the callback's return value, and that value is returned.
+   *
+   * @param key The key of the element to return from the `WeakMap` object.
+   * @param callback The function to compute a value for `key` if no entry exists.
+   */
+  getOrInsertComputed(key: K, callback: (key: K) => V): V;
+}
+
 interface ConsoleOptions {
   stdout: import("stream").Writable;
   stderr?: import("stream").Writable;

--- a/test/integration/bun-types/fixture/map.ts
+++ b/test/integration/bun-types/fixture/map.ts
@@ -36,6 +36,9 @@ import { expectType } from "./utilities";
 
   // @ts-expect-error - value type must match V
   weak.getOrInsert(key, 123);
+
+  // @ts-expect-error - callback return type must match V
+  weak.getOrInsertComputed(key, () => 123);
 }
 
 export {};

--- a/test/integration/bun-types/fixture/map.ts
+++ b/test/integration/bun-types/fixture/map.ts
@@ -1,0 +1,41 @@
+import { expectType } from "./utilities";
+
+// https://github.com/oven-sh/bun/issues/27380
+// Map.prototype.getOrInsert / Map.prototype.getOrInsertComputed
+// WeakMap.prototype.getOrInsert / WeakMap.prototype.getOrInsertComputed
+
+{
+  const options = new Map<string, number>();
+
+  expectType(options.getOrInsert("a", 1)).is<number>();
+  expectType(options.getOrInsertComputed("a", key => key.length)).is<number>();
+
+  options.getOrInsertComputed("a", key => {
+    expectType(key).is<string>();
+    return key.length;
+  });
+
+  // @ts-expect-error - value type must match V
+  options.getOrInsert("a", "not-a-number");
+
+  // @ts-expect-error - callback return type must match V
+  options.getOrInsertComputed("a", () => "not-a-number");
+}
+
+{
+  const weak = new WeakMap<object, string>();
+  const key = {};
+
+  expectType(weak.getOrInsert(key, "light")).is<string>();
+  expectType(weak.getOrInsertComputed(key, k => String(k))).is<string>();
+
+  weak.getOrInsertComputed(key, k => {
+    expectType(k).is<object>();
+    return "dark";
+  });
+
+  // @ts-expect-error - value type must match V
+  weak.getOrInsert(key, 123);
+}
+
+export {};

--- a/test/regression/issue/27380.test.ts
+++ b/test/regression/issue/27380.test.ts
@@ -33,8 +33,8 @@ test("bun-types declares getOrInsert / getOrInsertComputed on Map and WeakMap", 
     }
   });
 
-  expect([...found.Map].sort()).toEqual(["getOrInsert", "getOrInsertComputed"]);
-  expect([...found.WeakMap].sort()).toEqual(["getOrInsert", "getOrInsertComputed"]);
+  expect([...found.Map]).toEqual(expect.arrayContaining(["getOrInsert", "getOrInsertComputed"]));
+  expect([...found.WeakMap]).toEqual(expect.arrayContaining(["getOrInsert", "getOrInsertComputed"]));
 });
 
 test("Map.prototype.getOrInsert", () => {

--- a/test/regression/issue/27380.test.ts
+++ b/test/regression/issue/27380.test.ts
@@ -1,0 +1,97 @@
+// https://github.com/oven-sh/bun/issues/27380
+// Map.prototype.getOrInsert / getOrInsertComputed and
+// WeakMap.prototype.getOrInsert / getOrInsertComputed are implemented at
+// runtime (TC39 proposal-upsert, Stage 3) but were missing from bun-types,
+// so TypeScript reported ts(2339).
+//
+// The full conflict-free type integration (including merging with
+// lib.esnext.collection.d.ts / lib.dom.d.ts) is covered by
+// test/integration/bun-types/bun-types.test.ts via fixture/map.ts.
+
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import ts from "typescript";
+
+test("bun-types declares getOrInsert / getOrInsertComputed on Map and WeakMap", () => {
+  const path = join(import.meta.dir, "../../../packages/bun-types/globals.d.ts");
+  const source = ts.createSourceFile(path, readFileSync(path, "utf8"), ts.ScriptTarget.Latest, true);
+
+  const found = {
+    Map: new Set<string>(),
+    WeakMap: new Set<string>(),
+  };
+
+  source.forEachChild(node => {
+    if (!ts.isInterfaceDeclaration(node)) return;
+    const name = node.name.text;
+    if (name !== "Map" && name !== "WeakMap") return;
+    for (const member of node.members) {
+      if (ts.isMethodSignature(member) && member.name && ts.isIdentifier(member.name)) {
+        found[name].add(member.name.text);
+      }
+    }
+  });
+
+  expect([...found.Map].sort()).toEqual(["getOrInsert", "getOrInsertComputed"]);
+  expect([...found.WeakMap].sort()).toEqual(["getOrInsert", "getOrInsertComputed"]);
+});
+
+test("Map.prototype.getOrInsert", () => {
+  const map = new Map<string, number>();
+
+  expect(map.getOrInsert("a", 1)).toBe(1);
+  expect(map.get("a")).toBe(1);
+  // existing entry is returned, not overwritten
+  expect(map.getOrInsert("a", 2)).toBe(1);
+  expect(map.get("a")).toBe(1);
+});
+
+test("Map.prototype.getOrInsertComputed", () => {
+  const map = new Map<string, number>();
+  let calls = 0;
+
+  expect(
+    map.getOrInsertComputed("key", k => {
+      calls++;
+      return k.length;
+    }),
+  ).toBe(3);
+  expect(calls).toBe(1);
+  expect(map.get("key")).toBe(3);
+
+  // callback is not invoked when the key already exists
+  expect(
+    map.getOrInsertComputed("key", () => {
+      calls++;
+      return 999;
+    }),
+  ).toBe(3);
+  expect(calls).toBe(1);
+});
+
+test("WeakMap.prototype.getOrInsert / getOrInsertComputed", () => {
+  const weak = new WeakMap<object, string>();
+  const key = {};
+
+  expect(weak.getOrInsert(key, "light")).toBe("light");
+  expect(weak.getOrInsert(key, "dark")).toBe("light");
+
+  let calls = 0;
+  const key2 = {};
+  expect(
+    weak.getOrInsertComputed(key2, k => {
+      calls++;
+      expect(k).toBe(key2);
+      return "computed";
+    }),
+  ).toBe("computed");
+  expect(calls).toBe(1);
+  expect(
+    weak.getOrInsertComputed(key2, () => {
+      calls++;
+      return "never";
+    }),
+  ).toBe("computed");
+  expect(calls).toBe(1);
+});


### PR DESCRIPTION
### What does this PR do?

Adds TypeScript declarations for `Map.prototype.getOrInsert`, `Map.prototype.getOrInsertComputed`, `WeakMap.prototype.getOrInsert`, and `WeakMap.prototype.getOrInsertComputed` to `packages/bun-types/globals.d.ts`.

Fixes #27380

### Repro

Bun already implements these at runtime (TC39 [proposal-upsert](https://github.com/tc39/proposal-upsert), Stage 3):

```js
const options = new Map();
options.getOrInsert("theme", "light"); // "light"
```

…but TypeScript reports `ts(2339) Property 'getOrInsert' does not exist on type 'Map<any, any>'` because `bun-types` had no declarations for them.

### Fix

Add global `interface Map<K, V>` / `interface WeakMap<K extends WeakKey, V>` augmentations alongside the existing `ArrayBuffer` / `ArrayConstructor` augmentations in `globals.d.ts`. The signatures match TypeScript's own `lib.esnext.collection.d.ts` exactly, so:

- when `lib` includes `ESNext` (or TS ≥6.0 is used), the declarations merge cleanly with no conflict
- when `lib` does **not** include `ESNext` (or on older TypeScript), bun-types provides them

### Verification

`test/integration/bun-types/bun-types.test.ts` — all 11 cases pass, including the `lib: []`, `lib: ["ESNext"]`, and `lib: ["ESNext", "DOM", …]` configurations. New fixture `test/integration/bun-types/fixture/map.ts` exercises return types, callback-param inference, and value-type mismatches for both `Map` and `WeakMap`.

Without the `globals.d.ts` change, the `lib: []` case fails with:
```
Property 'getOrInsert' does not exist on type 'Map<string, number>'. Do you need to change your target library? Try changing the 'lib' compiler option to 'esnext' or later.
```