### PR TITLE
fetch: accept a URL object for proxy.url

### DIFF
--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -668,51 +668,54 @@ fn fetchImpl(
                         allocator.free(url_proxy_buffer);
                         break :extract_proxy buffer;
                     }
-                    // Handle object format: proxy: { url: "http://proxy.example.com:8080", headers?: Headers }
-                    // If the proxy object doesn't have a 'url' property, ignore it.
-                    // This handles cases like passing a URL object directly as proxy (which has 'href' not 'url').
+                    // Handle object format: proxy: { url: string | URL, headers?: Headers }
+                    // `url` may be a string or any value accepted by `new URL()` (e.g. a WHATWG
+                    // `URL` object, as produced by `@npmcli/agent`'s proxy getter).
                     if (proxy_arg.isObject()) {
                         // Get the URL from the proxy object
                         if (try proxy_arg.get(globalThis, "url")) |proxy_url_arg| {
                             if (!proxy_url_arg.isUndefinedOrNull()) {
-                                if (proxy_url_arg.isString() and try proxy_url_arg.getLength(ctx) > 0) {
-                                    var href = try jsc.URL.hrefFromJS(proxy_url_arg, globalThis);
-                                    if (href.tag == .Dead) {
-                                        const err = ctx.toTypeError(.INVALID_ARG_VALUE, "fetch() proxy URL is invalid", .{});
-                                        is_error = true;
-                                        return JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, err);
-                                    }
-                                    defer href.deref();
-                                    const buffer = try std.fmt.allocPrint(allocator, "{s}{f}", .{ url_proxy_buffer, href });
-                                    url = ZigURL.parse(buffer[0..url.href.len]);
-                                    if (url.isFile()) {
-                                        url_type = URLType.file;
-                                    } else if (url.isBlob()) {
-                                        url_type = URLType.blob;
-                                    }
-
-                                    proxy = ZigURL.parse(buffer[url.href.len..]);
-                                    allocator.free(url_proxy_buffer);
-                                    url_proxy_buffer = buffer;
-
-                                    // Get the headers from the proxy object (optional)
-                                    if (try proxy_arg.get(globalThis, "headers")) |headers_value| {
-                                        if (!headers_value.isUndefinedOrNull()) {
-                                            if (headers_value.as(FetchHeaders)) |fetch_hdrs| {
-                                                proxy_headers = Headers.from(fetch_hdrs, allocator, .{}) catch |err| bun.handleOom(err);
-                                            } else if (try FetchHeaders.createFromJS(ctx, headers_value)) |fetch_hdrs| {
-                                                defer fetch_hdrs.deref();
-                                                proxy_headers = Headers.from(fetch_hdrs, allocator, .{}) catch |err| bun.handleOom(err);
-                                            }
-                                        }
-                                    }
-
-                                    break :extract_proxy url_proxy_buffer;
-                                } else {
+                                // Reject an explicit empty string with the legacy message.
+                                // Any other value (including `URL` objects) goes through
+                                // `hrefFromJS`, matching the top-level `proxy: string | URL` path.
+                                if (proxy_url_arg.isString() and (try proxy_url_arg.getLength(ctx)) == 0) {
                                     const err = ctx.toTypeError(.INVALID_ARG_VALUE, "fetch() proxy.url must be a non-empty string", .{});
                                     is_error = true;
                                     return JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, err);
                                 }
+
+                                var href = try jsc.URL.hrefFromJS(proxy_url_arg, globalThis);
+                                if (href.tag == .Dead) {
+                                    const err = ctx.toTypeError(.INVALID_ARG_VALUE, "fetch() proxy URL is invalid", .{});
+                                    is_error = true;
+                                    return JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, err);
+                                }
+                                defer href.deref();
+                                const buffer = try std.fmt.allocPrint(allocator, "{s}{f}", .{ url_proxy_buffer, href });
+                                url = ZigURL.parse(buffer[0..url.href.len]);
+                                if (url.isFile()) {
+                                    url_type = URLType.file;
+                                } else if (url.isBlob()) {
+                                    url_type = URLType.blob;
+                                }
+
+                                proxy = ZigURL.parse(buffer[url.href.len..]);
+                                allocator.free(url_proxy_buffer);
+                                url_proxy_buffer = buffer;
+
+                                // Get the headers from the proxy object (optional)
+                                if (try proxy_arg.get(globalThis, "headers")) |headers_value| {
+                                    if (!headers_value.isUndefinedOrNull()) {
+                                        if (headers_value.as(FetchHeaders)) |fetch_hdrs| {
+                                            proxy_headers = Headers.from(fetch_hdrs, allocator, .{}) catch |err| bun.handleOom(err);
+                                        } else if (try FetchHeaders.createFromJS(ctx, headers_value)) |fetch_hdrs| {
+                                            defer fetch_hdrs.deref();
+                                            proxy_headers = Headers.from(fetch_hdrs, allocator, .{}) catch |err| bun.handleOom(err);
+                                        }
+                                    }
+                                }
+
+                                break :extract_proxy url_proxy_buffer;
                             }
                         }
                     }

--- a/test/regression/issue/29103.test.ts
+++ b/test/regression/issue/29103.test.ts
@@ -36,10 +36,7 @@ async function createHttpProxy() {
         [host, port] = rawPath.split(":");
       }
 
-      const destinationPort = Number.parseInt(
-        (port || (method === "CONNECT" ? "443" : "80")).toString(),
-        10,
-      );
+      const destinationPort = Number.parseInt((port || (method === "CONNECT" ? "443" : "80")).toString(), 10);
       log.push(`${method} ${host}:${port}${requestPath}`);
 
       const upstream = net.connect(destinationPort, host, () => {

--- a/test/regression/issue/29103.test.ts
+++ b/test/regression/issue/29103.test.ts
@@ -1,0 +1,132 @@
+// https://github.com/oven-sh/bun/issues/29103
+//
+// `fetch()` must accept a WHATWG `URL` object for `proxy.url`, not just a
+// string. `@npmcli/agent` (used by the entire npm registry ecosystem)
+// constructs its proxy option as `{ url: new URL(process.env.HTTPS_PROXY) }`,
+// so any npm operation run through an `HTTP(S)_PROXY` environment variable
+// previously blew up with:
+//
+//     fetch() proxy.url must be a non-empty string
+//
+// The top-level `proxy: string | URL` path already went through
+// `URL.hrefFromJS`, which happily normalizes a `URL` instance via its
+// `toString()`. The object form was gratuitously stricter.
+import type { Server } from "bun";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { once } from "node:events";
+import net from "node:net";
+
+async function createHttpProxy() {
+  const log: string[] = [];
+  const server = net.createServer(clientSocket => {
+    clientSocket.once("data", data => {
+      const request = data.toString();
+      const firstLine = request.split("\r\n", 1)[0] ?? "";
+      const [method, rawPath] = firstLine.split(" ");
+
+      let host = "";
+      let port: string | number = 0;
+      let requestPath = "";
+      if (rawPath && rawPath.indexOf("http") !== -1) {
+        const parsed = new URL(rawPath);
+        host = parsed.hostname;
+        port = parsed.port;
+        requestPath = parsed.pathname + (parsed.search || "");
+      } else if (rawPath) {
+        [host, port] = rawPath.split(":");
+      }
+
+      const destinationPort = Number.parseInt(
+        (port || (method === "CONNECT" ? "443" : "80")).toString(),
+        10,
+      );
+      log.push(`${method} ${host}:${port}${requestPath}`);
+
+      const upstream = net.connect(destinationPort, host, () => {
+        if (method === "CONNECT") {
+          clientSocket.write("HTTP/1.1 200 OK\r\n\r\n");
+          clientSocket.pipe(upstream);
+          upstream.pipe(clientSocket);
+        } else {
+          upstream.write(`${method} ${requestPath} HTTP/1.1\r\n`);
+          upstream.write(data.slice(request.indexOf("\r\n") + 2));
+          upstream.pipe(clientSocket);
+        }
+      });
+
+      clientSocket.on("error", () => {});
+      upstream.on("error", () => {
+        clientSocket.end();
+      });
+    });
+  });
+
+  server.listen(0);
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
+  return { server, url: `http://localhost:${port}`, log };
+}
+
+let originServer: Server;
+let proxyServer: { server: net.Server; url: string; log: string[] };
+
+beforeAll(async () => {
+  originServer = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response("ok");
+    },
+  });
+  proxyServer = await createHttpProxy();
+});
+
+afterAll(async () => {
+  originServer?.stop(true);
+  proxyServer?.server.close();
+  if (proxyServer?.server) await once(proxyServer.server, "close");
+});
+
+describe.concurrent("fetch() proxy.url accepts a URL object (#29103)", () => {
+  test("proxy: { url: new URL(...) } routes through the proxy", async () => {
+    // This is exactly the shape `@npmcli/agent` produces for its proxy getter.
+    const response = await fetch(originServer.url, {
+      proxy: { url: new URL(proxyServer.url) },
+      keepalive: false,
+    });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("ok");
+    // Confirm the request actually went through the proxy, not direct.
+    expect(proxyServer.log.length).toBeGreaterThan(0);
+  });
+
+  test("proxy: { url: '' } still rejects with the legacy message", async () => {
+    // Empty strings remain an error so users with broken env vars still
+    // get a clear signal instead of silently bypassing the proxy.
+    let err: unknown;
+    try {
+      await fetch(originServer.url, {
+        proxy: { url: "" },
+        keepalive: false,
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect((err as Error).message).toBe("fetch() proxy.url must be a non-empty string");
+  });
+
+  test("proxy: { url: 'not a valid url' } rejects with 'proxy URL is invalid'", async () => {
+    // Matches the top-level `proxy: string` branch's error for garbage input.
+    let err: unknown;
+    try {
+      await fetch(originServer.url, {
+        proxy: { url: "not a valid url" },
+        keepalive: false,
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect((err as Error).message).toBe("fetch() proxy URL is invalid");
+  });
+});


### PR DESCRIPTION
## What

`fetch("...", { proxy: { url: new URL("http://127.0.0.1:10808") } })` threw

```
fetch() proxy.url must be a non-empty string
```

before any network work happened. The object branch in `fetchImpl` demanded `proxy.url` be `isString()` before calling `URL.hrefFromJS`, so anything else — including a WHATWG `URL` instance — fell through to the empty-string error.

This is exactly the shape [`@npmcli/agent`](https://github.com/npm/agent) constructs for its proxy getter, so every npm registry operation run behind an `HTTP(S)_PROXY` environment variable failed on Bun with that message.

## Repro

```js
const proxyUrl = new URL("http://127.0.0.1:10808");
await fetch("https://example.com", { proxy: { url: proxyUrl } });
// TypeError: fetch() proxy.url must be a non-empty string
```

## Fix

`src/bun.js/webcore/fetch.zig`: the sibling top-level `proxy: string | URL` branch already goes through `URL.hrefFromJS`, which `toWTFString()` s the value first and then feeds it to `WTF::URL` — happily accepting a `URL` instance (whose `toString()` is `href`). The object branch was gratuitously stricter for no reason.

The object branch now matches the sibling:

- explicit empty string (`{ url: "" }`) still rejects with the legacy `"proxy.url must be a non-empty string"` message
- anything else goes through `hrefFromJS`; `.Dead` → `"proxy URL is invalid"` (same message as the sibling branch for garbage input); otherwise proceed

## Test

`test/regression/issue/29103.test.ts` spins up a local HTTP proxy with `net.createServer` and an origin server with `Bun.serve`, then asserts:

1. `proxy: { url: new URL(proxyServer.url) }` routes through the proxy (positive case — the one that was previously broken)
2. `proxy: { url: "" }` still throws `"proxy.url must be a non-empty string"` (legacy behavior preserved)
3. `proxy: { url: "not a valid url" }` throws `"proxy URL is invalid"` (matches sibling branch)

Fixes #29103