### PR TITLE
Fix double-free of path in S3Client static methods on error

### DIFF
--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -84,6 +84,7 @@ pub fn presign(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.J
             }
             const options = args.nextEat();
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
             return try getPresignUrlFrom(&blob, globalThis, options);
         },
@@ -114,6 +115,7 @@ pub fn unlink(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
             }
             const options = args.nextEat();
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
             return try blob.store.?.data.s3.unlink(blob.store.?, globalThis, options);
         },
@@ -151,6 +153,7 @@ pub fn write(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSE
                 return globalThis.throwInvalidArguments("Expected a S3 or path to upload", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
 
             var blob_internal: PathOrBlob = .{ .blob = blob };
@@ -190,6 +193,7 @@ pub fn size(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
                 return globalThis.throwInvalidArguments("Expected a S3 or path to get size", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
 
             return S3BlobStatTask.size(globalThis, &blob);
@@ -223,6 +227,7 @@ pub fn exists(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
                 return globalThis.throwInvalidArguments("Expected a S3 or path to check if it exists", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
 
             return S3BlobStatTask.exists(globalThis, &blob);
@@ -574,6 +579,7 @@ pub fn stat(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
                 return globalThis.throwInvalidArguments("Expected a S3 or path to get size", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
 
             return S3BlobStatTask.stat(globalThis, &blob);

--- a/test/js/bun/s3/s3-static-path-error.test.ts
+++ b/test/js/bun/s3/s3-static-path-error.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // S3Client static methods that accept a path construct an internal Blob

--- a/test/js/bun/s3/s3-static-path-error.test.ts
+++ b/test/js/bun/s3/s3-static-path-error.test.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// S3Client static methods that accept a path construct an internal Blob
+// which takes ownership of the path. If the subsequent operation throws
+// (e.g. missing credentials), the errdefer must not double-free the path.
+test("S3Client.presign with a path throws cleanly on sign error without double-freeing the path", async () => {
+  const env = { ...bunEnv };
+  for (const key of Object.keys(env)) {
+    if (/^(AWS_|S3_)/.test(key)) delete env[key];
+  }
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        let err;
+        try {
+          Bun.S3Client.presign("some-path", 123);
+        } catch (e) {
+          err = e;
+        }
+        if (!err) throw new Error("expected presign to throw");
+        if (err.code !== "ERR_S3_MISSING_CREDENTIALS") throw err;
+        Bun.gc(true);
+        console.log("ok");
+      `,
+    ],
+    env,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a crash (debug assert / double-free) in `Bun.S3Client` static methods (`presign`, `unlink`, `write`, `size`, `exists`, `stat`) when called with a string path and the subsequent operation throws.

```js
// no credentials configured
Bun.S3Client.presign("some-path", 123);
```

```
panic(main thread): reached unreachable code
...
#5  bun.assert (ok=false)
#6  string.wtf.WTFStringImplStruct.deref
#7  string.String.deref
#8  string.SliceWithUnderlyingString.deinit
#9  bun.js.node.types.PathLike.deinit
#10 bun.js.node.types.PathOrFileDescriptor.deinit
#11 bun.js.webcore.S3File.presign (errdefer)
```

## How did you verify your code works?

- Minimal repro no longer crashes under the ASAN debug build; it now throws `ERR_S3_MISSING_CREDENTIALS` as expected.
- Original Fuzzilli crash script runs cleanly.
- Added `test/js/bun/s3/s3-static-path-error.test.ts`.

## Root cause

`constructS3FileInternalStore` stores the `PathLike` directly in the blob's S3 store without adding a ref (despite the "this actually protects/refs the pathlike" comment, `PathLike.toThreadSafe` does not add a ref in the common case). So once the blob is constructed, it owns the path.

If the subsequent call (e.g. `getPresignUrlFrom`) throws:
1. `defer blob.deinit()` runs → store deinit → `pathlike.deinit()` → deref (refcount → 0)
2. outer `errdefer path_or_blob.path.deinit()` runs → deref again → `bun.assert(self.hasAtLeastOneRef())` fails

Fix: after `constructS3FileInternalStore` succeeds, reset `path_or_blob` to an empty `PathString` so the errdefer becomes a no-op.

Fuzzilli fingerprint: `641d23ceb14c14b2`