### PR TITLE
Fix segfault in StringDecoder.write() when result exceeds String::MaxLength

### DIFF
--- a/src/bun.js/bindings/JSStringDecoder.cpp
+++ b/src/bun.js/bindings/JSStringDecoder.cpp
@@ -68,6 +68,17 @@ ALWAYS_INLINE bool isContinuation(uint8_t byte)
     return (byte & 0xC0) == 0x80;
 }
 
+// Wraps Bun__encoding__toString so callers get a JSString* directly.
+// Returns nullptr with an exception pending when encoding fails (e.g.
+// ERR_STRING_TOO_LONG).
+static ALWAYS_INLINE JSString* encodingToString(const uint8_t* input, size_t len, JSGlobalObject* globalObject, BufferEncodingType encoding)
+{
+    EncodedJSValue encoded = Bun__encoding__toString(input, len, globalObject, static_cast<uint8_t>(encoding));
+    if (!encoded) [[unlikely]]
+        return nullptr;
+    return asString(JSValue::decode(encoded));
+}
+
 static inline JSStringDecoder* jsStringDecoderCast(JSGlobalObject* globalObject, JSValue stringDecoderValue, WTF::ASCIILiteral functionName)
 {
     ASSERT(stringDecoderValue);
@@ -135,7 +146,7 @@ uint8_t JSStringDecoder::utf8CheckIncomplete(uint8_t* bufPtr, uint32_t length, u
     return 0;
 }
 
-JSC::JSValue JSStringDecoder::fillLast(JSC::VM& vm, JSC::JSGlobalObject* globalObject, uint8_t* bufPtr, uint32_t length)
+JSC::JSString* JSStringDecoder::fillLast(JSC::VM& vm, JSC::JSGlobalObject* globalObject, uint8_t* bufPtr, uint32_t length)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
@@ -164,13 +175,13 @@ JSC::JSValue JSStringDecoder::fillLast(JSC::VM& vm, JSC::JSGlobalObject* globalO
                 uint32_t chars = m_lastTotal - m_lastNeed + i;
                 memmove(m_lastChar + m_lastTotal - m_lastNeed, bufPtr, i);
                 m_lastNeed = i;
-                RELEASE_AND_RETURN(throwScope, JSC::JSValue::decode(Bun__encoding__toString(m_lastChar, chars, globalObject, static_cast<uint8_t>(m_encoding))));
+                RELEASE_AND_RETURN(throwScope, encodingToString(m_lastChar, chars, globalObject, m_encoding));
             }
         }
     }
     if (m_lastNeed <= length) {
         memmove(m_lastChar + m_lastTotal - m_lastNeed, bufPtr, m_lastNeed);
-        RELEASE_AND_RETURN(throwScope, JSC::JSValue::decode(Bun__encoding__toString(m_lastChar, m_lastTotal, globalObject, static_cast<uint8_t>(m_encoding))));
+        RELEASE_AND_RETURN(throwScope, encodingToString(m_lastChar, m_lastTotal, globalObject, m_encoding));
     }
 
     memmove(m_lastChar + m_lastTotal - m_lastNeed, bufPtr, length);
@@ -180,7 +191,7 @@ JSC::JSValue JSStringDecoder::fillLast(JSC::VM& vm, JSC::JSGlobalObject* globalO
         if (total == 0) {
             uint32_t len = m_lastTotal - m_lastNeed + length;
             m_lastNeed = length;
-            RELEASE_AND_RETURN(throwScope, JSC::JSValue::decode(Bun__encoding__toString(m_lastChar, len, globalObject, static_cast<uint8_t>(m_encoding))));
+            RELEASE_AND_RETURN(throwScope, encodingToString(m_lastChar, len, globalObject, m_encoding));
         }
         m_lastNeed = lastLastNeed;
     }
@@ -190,7 +201,7 @@ JSC::JSValue JSStringDecoder::fillLast(JSC::VM& vm, JSC::JSGlobalObject* globalO
 }
 
 // This is not the exposed text
-JSC::JSValue JSStringDecoder::text(JSC::VM& vm, JSC::JSGlobalObject* globalObject, uint8_t* bufPtr, uint32_t length, uint32_t offset)
+JSC::JSString* JSStringDecoder::text(JSC::VM& vm, JSC::JSGlobalObject* globalObject, uint8_t* bufPtr, uint32_t length, uint32_t offset)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
@@ -206,30 +217,30 @@ JSC::JSValue JSStringDecoder::text(JSC::VM& vm, JSC::JSGlobalObject* globalObjec
                 m_lastTotal = 4;
                 m_lastChar[0] = bufPtr[length - 2];
                 m_lastChar[1] = bufPtr[length - 1];
-                RELEASE_AND_RETURN(throwScope, JSC::JSValue::decode(Bun__encoding__toString(bufPtr + offset, length - offset - 2, globalObject, static_cast<uint8_t>(m_encoding))));
+                RELEASE_AND_RETURN(throwScope, encodingToString(bufPtr + offset, length - offset - 2, globalObject, m_encoding));
             }
-            RELEASE_AND_RETURN(throwScope, JSC::JSValue::decode(Bun__encoding__toString(bufPtr + offset, length - offset, globalObject, static_cast<uint8_t>(m_encoding))));
+            RELEASE_AND_RETURN(throwScope, encodingToString(bufPtr + offset, length - offset, globalObject, m_encoding));
         }
         m_lastNeed = 1;
         m_lastTotal = 2;
         m_lastChar[0] = bufPtr[length - 1];
-        RELEASE_AND_RETURN(throwScope, JSC::JSValue::decode(Bun__encoding__toString(bufPtr + offset, length - offset - 1, globalObject, static_cast<uint8_t>(m_encoding))));
+        RELEASE_AND_RETURN(throwScope, encodingToString(bufPtr + offset, length - offset - 1, globalObject, m_encoding));
     }
     case BufferEncodingType::utf8: {
         uint32_t total = utf8CheckIncomplete(bufPtr, length, offset);
         if (!m_lastNeed)
-            RELEASE_AND_RETURN(throwScope, JSC::JSValue::decode(Bun__encoding__toString(bufPtr + offset, length - offset, globalObject, static_cast<uint8_t>(m_encoding))));
+            RELEASE_AND_RETURN(throwScope, encodingToString(bufPtr + offset, length - offset, globalObject, m_encoding));
         m_lastTotal = total;
         uint32_t end = length - (total - m_lastNeed);
         if (end < length)
             memmove(m_lastChar, bufPtr + end, std::min(4U, length - end));
-        RELEASE_AND_RETURN(throwScope, JSC::JSValue::decode(Bun__encoding__toString(bufPtr + offset, end - offset, globalObject, static_cast<uint8_t>(m_encoding))));
+        RELEASE_AND_RETURN(throwScope, encodingToString(bufPtr + offset, end - offset, globalObject, m_encoding));
     }
     case BufferEncodingType::base64:
     case BufferEncodingType::base64url: {
         uint32_t n = (length - offset) % 3;
         if (n == 0)
-            RELEASE_AND_RETURN(throwScope, JSC::JSValue::decode(Bun__encoding__toString(bufPtr + offset, length - offset, globalObject, static_cast<uint8_t>(m_encoding))));
+            RELEASE_AND_RETURN(throwScope, encodingToString(bufPtr + offset, length - offset, globalObject, m_encoding));
         m_lastNeed = 3 - n;
         m_lastTotal = 3;
         if (n == 1) {
@@ -238,11 +249,11 @@ JSC::JSValue JSStringDecoder::text(JSC::VM& vm, JSC::JSGlobalObject* globalObjec
             m_lastChar[0] = bufPtr[length - 2];
             m_lastChar[1] = bufPtr[length - 1];
         }
-        RELEASE_AND_RETURN(throwScope, JSC::JSValue::decode(Bun__encoding__toString(bufPtr + offset, length - offset - n, globalObject, static_cast<uint8_t>(m_encoding))));
+        RELEASE_AND_RETURN(throwScope, encodingToString(bufPtr + offset, length - offset - n, globalObject, m_encoding));
     }
     default: {
         // should never reach here.
-        RELEASE_AND_RETURN(throwScope, JSC::jsUndefined());
+        RELEASE_AND_RETURN(throwScope, nullptr);
         break;
     }
     }
@@ -250,7 +261,7 @@ JSC::JSValue JSStringDecoder::text(JSC::VM& vm, JSC::JSGlobalObject* globalObjec
     __builtin_unreachable();
 }
 
-JSC::JSValue JSStringDecoder::write(JSC::VM& vm, JSC::JSGlobalObject* globalObject, uint8_t* bufPtr, uint32_t length)
+JSC::JSString* JSStringDecoder::write(JSC::VM& vm, JSC::JSGlobalObject* globalObject, uint8_t* bufPtr, uint32_t length)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     if (length == 0)
@@ -264,10 +275,8 @@ JSC::JSValue JSStringDecoder::write(JSC::VM& vm, JSC::JSGlobalObject* globalObje
     case BufferEncodingType::base64url: {
         uint32_t offset = 0;
         if (m_lastNeed) {
-            JSValue firstHalfValue = fillLast(vm, globalObject, bufPtr, length);
-            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
-            JSString* firstHalf = firstHalfValue.toString(globalObject);
-            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+            JSString* firstHalf = fillLast(vm, globalObject, bufPtr, length);
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
             if (firstHalf->length() == 0)
                 RELEASE_AND_RETURN(throwScope, firstHalf);
             offset = m_lastNeed;
@@ -275,22 +284,18 @@ JSC::JSValue JSStringDecoder::write(JSC::VM& vm, JSC::JSGlobalObject* globalObje
             if (offset == length)
                 RELEASE_AND_RETURN(throwScope, firstHalf);
 
-            JSValue secondHalfValue = text(vm, globalObject, bufPtr, length, offset);
-            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
-            JSString* secondHalf = secondHalfValue.toString(globalObject);
-            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+            JSString* secondHalf = text(vm, globalObject, bufPtr, length, offset);
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
             if (secondHalf->length() == 0)
                 RELEASE_AND_RETURN(throwScope, firstHalf);
             RELEASE_AND_RETURN(throwScope, JSC::jsString(globalObject, firstHalf, secondHalf));
         }
-        JSValue strValue = text(vm, globalObject, bufPtr, length, offset);
-        RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
-        JSString* str = strValue.toString(globalObject);
-        RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+        JSString* str = text(vm, globalObject, bufPtr, length, offset);
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
         RELEASE_AND_RETURN(throwScope, str);
     }
     default: {
-        RELEASE_AND_RETURN(throwScope, JSC::JSValue::decode(Bun__encoding__toString(bufPtr, length, globalObject, static_cast<uint8_t>(m_encoding))));
+        RELEASE_AND_RETURN(throwScope, encodingToString(bufPtr, length, globalObject, m_encoding));
     }
     }
 
@@ -316,7 +321,7 @@ ResetScope::~ResetScope()
     memset(m_decoder->m_lastChar, 0, 4);
 }
 
-JSC::JSValue
+JSC::JSString*
 JSStringDecoder::end(JSC::VM& vm, JSC::JSGlobalObject* globalObject, uint8_t* bufPtr, uint32_t length)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
@@ -326,38 +331,31 @@ JSStringDecoder::end(JSC::VM& vm, JSC::JSGlobalObject* globalObject, uint8_t* bu
     case BufferEncodingType::utf16le: {
         if (length == 0) {
             if (m_lastNeed) {
-                RELEASE_AND_RETURN(throwScope, JSC::JSValue::decode(Bun__encoding__toString(m_lastChar, m_lastTotal - m_lastNeed, globalObject, static_cast<uint8_t>(m_encoding))));
-            } else {
-                RELEASE_AND_RETURN(throwScope, JSC::jsEmptyString(vm));
+                RELEASE_AND_RETURN(throwScope, encodingToString(m_lastChar, m_lastTotal - m_lastNeed, globalObject, m_encoding));
             }
+            RELEASE_AND_RETURN(throwScope, JSC::jsEmptyString(vm));
         }
-        JSValue firstHalfValue = write(vm, globalObject, bufPtr, length);
-        RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
-        JSString* firstHalf = firstHalfValue.toString(globalObject);
-        RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+        JSString* firstHalf = write(vm, globalObject, bufPtr, length);
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
         if (m_lastNeed) {
-            JSValue secondHalfValue = JSC::JSValue::decode(Bun__encoding__toString(m_lastChar, m_lastTotal - m_lastNeed, globalObject, static_cast<uint8_t>(m_encoding)));
-            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
-            JSString* secondHalf = secondHalfValue.toString(globalObject);
-            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+            JSString* secondHalf = encodingToString(m_lastChar, m_lastTotal - m_lastNeed, globalObject, m_encoding);
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
             RELEASE_AND_RETURN(throwScope, JSC::jsString(globalObject, firstHalf, secondHalf));
-        } else {
-            RELEASE_AND_RETURN(throwScope, firstHalf);
         }
+        RELEASE_AND_RETURN(throwScope, firstHalf);
     }
     case BufferEncodingType::utf8: {
         if (length == 0) {
-            RELEASE_AND_RETURN(throwScope, m_lastNeed ? JSC::JSValue::decode(Bun__encoding__toString(m_lastChar, m_lastTotal - m_lastNeed, globalObject, static_cast<uint8_t>(m_encoding))) : JSC::jsEmptyString(vm));
+            if (m_lastNeed) {
+                RELEASE_AND_RETURN(throwScope, encodingToString(m_lastChar, m_lastTotal - m_lastNeed, globalObject, m_encoding));
+            }
+            RELEASE_AND_RETURN(throwScope, JSC::jsEmptyString(vm));
         }
-        JSValue firstHalfValue = write(vm, globalObject, bufPtr, length);
-        RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
-        JSString* firstHalf = firstHalfValue.toString(globalObject);
-        RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+        JSString* firstHalf = write(vm, globalObject, bufPtr, length);
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
         if (m_lastNeed) {
-            JSValue secondHalfValue = JSC::JSValue::decode(Bun__encoding__toString(m_lastChar, m_lastTotal - m_lastNeed, globalObject, static_cast<uint8_t>(m_encoding)));
-            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
-            JSString* secondHalf = secondHalfValue.toString(globalObject);
-            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+            JSString* secondHalf = encodingToString(m_lastChar, m_lastTotal - m_lastNeed, globalObject, m_encoding);
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
             RELEASE_AND_RETURN(throwScope, JSC::jsString(globalObject, firstHalf, secondHalf));
         }
         RELEASE_AND_RETURN(throwScope, firstHalf);
@@ -366,24 +364,18 @@ JSStringDecoder::end(JSC::VM& vm, JSC::JSGlobalObject* globalObject, uint8_t* bu
     case BufferEncodingType::base64url: {
         if (length == 0) {
             if (m_lastNeed) {
-                RELEASE_AND_RETURN(throwScope, JSC::JSValue::decode(Bun__encoding__toString(m_lastChar, 3 - m_lastNeed, globalObject, static_cast<uint8_t>(m_encoding))));
-            } else {
-                RELEASE_AND_RETURN(throwScope, JSC::jsEmptyString(vm));
+                RELEASE_AND_RETURN(throwScope, encodingToString(m_lastChar, 3 - m_lastNeed, globalObject, m_encoding));
             }
+            RELEASE_AND_RETURN(throwScope, JSC::jsEmptyString(vm));
         }
-        JSValue firstHalfValue = write(vm, globalObject, bufPtr, length);
-        RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
-        JSString* firstHalf = firstHalfValue.toString(globalObject);
-        RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+        JSString* firstHalf = write(vm, globalObject, bufPtr, length);
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
         if (m_lastNeed) {
-            JSValue secondHalfValue = JSC::JSValue::decode(Bun__encoding__toString(m_lastChar, 3 - m_lastNeed, globalObject, static_cast<uint8_t>(m_encoding)));
-            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
-            JSString* secondHalf = secondHalfValue.toString(globalObject);
-            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+            JSString* secondHalf = encodingToString(m_lastChar, 3 - m_lastNeed, globalObject, m_encoding);
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
             RELEASE_AND_RETURN(throwScope, JSC::jsString(globalObject, firstHalf, secondHalf));
-        } else {
-            RELEASE_AND_RETURN(throwScope, firstHalf);
         }
+        RELEASE_AND_RETURN(throwScope, firstHalf);
     }
     default: {
         if (length == 0) {

--- a/src/bun.js/bindings/JSStringDecoder.cpp
+++ b/src/bun.js/bindings/JSStringDecoder.cpp
@@ -264,7 +264,9 @@ JSC::JSValue JSStringDecoder::write(JSC::VM& vm, JSC::JSGlobalObject* globalObje
     case BufferEncodingType::base64url: {
         uint32_t offset = 0;
         if (m_lastNeed) {
-            JSString* firstHalf = fillLast(vm, globalObject, bufPtr, length).toString(globalObject);
+            JSValue firstHalfValue = fillLast(vm, globalObject, bufPtr, length);
+            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+            JSString* firstHalf = firstHalfValue.toString(globalObject);
             RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
             if (firstHalf->length() == 0)
                 RELEASE_AND_RETURN(throwScope, firstHalf);
@@ -273,13 +275,17 @@ JSC::JSValue JSStringDecoder::write(JSC::VM& vm, JSC::JSGlobalObject* globalObje
             if (offset == length)
                 RELEASE_AND_RETURN(throwScope, firstHalf);
 
-            JSString* secondHalf = text(vm, globalObject, bufPtr, length, offset).toString(globalObject);
+            JSValue secondHalfValue = text(vm, globalObject, bufPtr, length, offset);
+            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+            JSString* secondHalf = secondHalfValue.toString(globalObject);
             RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
             if (secondHalf->length() == 0)
                 RELEASE_AND_RETURN(throwScope, firstHalf);
             RELEASE_AND_RETURN(throwScope, JSC::jsString(globalObject, firstHalf, secondHalf));
         }
-        JSString* str = text(vm, globalObject, bufPtr, length, offset).toString(globalObject);
+        JSValue strValue = text(vm, globalObject, bufPtr, length, offset);
+        RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+        JSString* str = strValue.toString(globalObject);
         RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
         RELEASE_AND_RETURN(throwScope, str);
     }
@@ -325,10 +331,15 @@ JSStringDecoder::end(JSC::VM& vm, JSC::JSGlobalObject* globalObject, uint8_t* bu
                 RELEASE_AND_RETURN(throwScope, JSC::jsEmptyString(vm));
             }
         }
-        JSString* firstHalf = write(vm, globalObject, bufPtr, length).toString(globalObject);
+        JSValue firstHalfValue = write(vm, globalObject, bufPtr, length);
+        RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+        JSString* firstHalf = firstHalfValue.toString(globalObject);
         RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
         if (m_lastNeed) {
-            JSString* secondHalf = JSC::JSValue::decode(Bun__encoding__toString(m_lastChar, m_lastTotal - m_lastNeed, globalObject, static_cast<uint8_t>(m_encoding))).toString(globalObject);
+            JSValue secondHalfValue = JSC::JSValue::decode(Bun__encoding__toString(m_lastChar, m_lastTotal - m_lastNeed, globalObject, static_cast<uint8_t>(m_encoding)));
+            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+            JSString* secondHalf = secondHalfValue.toString(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
             RELEASE_AND_RETURN(throwScope, JSC::jsString(globalObject, firstHalf, secondHalf));
         } else {
             RELEASE_AND_RETURN(throwScope, firstHalf);
@@ -338,15 +349,18 @@ JSStringDecoder::end(JSC::VM& vm, JSC::JSGlobalObject* globalObject, uint8_t* bu
         if (length == 0) {
             RELEASE_AND_RETURN(throwScope, m_lastNeed ? JSC::JSValue::decode(Bun__encoding__toString(m_lastChar, m_lastTotal - m_lastNeed, globalObject, static_cast<uint8_t>(m_encoding))) : JSC::jsEmptyString(vm));
         }
-        JSString* firstHalf = write(vm, globalObject, bufPtr, length).toString(globalObject);
+        JSValue firstHalfValue = write(vm, globalObject, bufPtr, length);
         RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
-        RELEASE_AND_RETURN(throwScope,
-            m_lastNeed
-                ? JSC::jsString(
-                      globalObject,
-                      firstHalf,
-                      jsCast<JSString*>(JSC::JSValue::decode(Bun__encoding__toString(m_lastChar, m_lastTotal - m_lastNeed, globalObject, static_cast<uint8_t>(m_encoding)))))
-                : firstHalf);
+        JSString* firstHalf = firstHalfValue.toString(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+        if (m_lastNeed) {
+            JSValue secondHalfValue = JSC::JSValue::decode(Bun__encoding__toString(m_lastChar, m_lastTotal - m_lastNeed, globalObject, static_cast<uint8_t>(m_encoding)));
+            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+            JSString* secondHalf = secondHalfValue.toString(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+            RELEASE_AND_RETURN(throwScope, JSC::jsString(globalObject, firstHalf, secondHalf));
+        }
+        RELEASE_AND_RETURN(throwScope, firstHalf);
     }
     case BufferEncodingType::base64:
     case BufferEncodingType::base64url: {
@@ -357,10 +371,14 @@ JSStringDecoder::end(JSC::VM& vm, JSC::JSGlobalObject* globalObject, uint8_t* bu
                 RELEASE_AND_RETURN(throwScope, JSC::jsEmptyString(vm));
             }
         }
-        JSString* firstHalf = write(vm, globalObject, bufPtr, length).toString(globalObject);
+        JSValue firstHalfValue = write(vm, globalObject, bufPtr, length);
+        RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+        JSString* firstHalf = firstHalfValue.toString(globalObject);
         RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
         if (m_lastNeed) {
-            JSString* secondHalf = JSC::JSValue::decode(Bun__encoding__toString(m_lastChar, 3 - m_lastNeed, globalObject, static_cast<uint8_t>(m_encoding))).toString(globalObject);
+            JSValue secondHalfValue = JSC::JSValue::decode(Bun__encoding__toString(m_lastChar, 3 - m_lastNeed, globalObject, static_cast<uint8_t>(m_encoding)));
+            RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
+            JSString* secondHalf = secondHalfValue.toString(globalObject);
             RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
             RELEASE_AND_RETURN(throwScope, JSC::jsString(globalObject, firstHalf, secondHalf));
         } else {

--- a/src/bun.js/bindings/JSStringDecoder.h
+++ b/src/bun.js/bindings/JSStringDecoder.h
@@ -51,8 +51,9 @@ public:
         static_cast<JSStringDecoder*>(thisObject)->~JSStringDecoder();
     }
 
-    JSC::JSValue write(JSC::VM&, JSC::JSGlobalObject*, uint8_t*, uint32_t);
-    JSC::JSValue end(JSC::VM&, JSC::JSGlobalObject*, uint8_t*, uint32_t);
+    // These return nullptr with an exception pending on failure.
+    JSC::JSString* write(JSC::VM&, JSC::JSGlobalObject*, uint8_t*, uint32_t);
+    JSC::JSString* end(JSC::VM&, JSC::JSGlobalObject*, uint8_t*, uint32_t);
 
     uint8_t m_lastNeed = 0;
     uint8_t m_lastTotal = 0;
@@ -60,8 +61,8 @@ public:
     BufferEncodingType m_encoding = BufferEncodingType::utf8;
 
 private:
-    JSC::JSValue fillLast(JSC::VM&, JSC::JSGlobalObject*, uint8_t*, uint32_t);
-    JSC::JSValue text(JSC::VM&, JSC::JSGlobalObject*, uint8_t*, uint32_t, uint32_t);
+    JSC::JSString* fillLast(JSC::VM&, JSC::JSGlobalObject*, uint8_t*, uint32_t);
+    JSC::JSString* text(JSC::VM&, JSC::JSGlobalObject*, uint8_t*, uint32_t, uint32_t);
     uint8_t utf8CheckIncomplete(uint8_t*, uint32_t, uint32_t);
 };
 

--- a/test/js/node/string_decoder/string-decoder.test.js
+++ b/test/js/node/string_decoder/string-decoder.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, withoutAggressiveGC } from "harness";
 
 const RealStringDecoder = require("string_decoder").StringDecoder;
 
@@ -270,11 +270,36 @@ it("invalid utf-8 at end of stream can sometimes produce more than one replaceme
   expect(decoder.end(Buffer.from("9c", "hex"))).toEqual("\uFFFD\uFFFD");
 });
 
-it("invalid utf-8 at end of stream can sometimes produce more than one replacement character", () => {
-  let decoder = new RealStringDecoder("utf-8");
-  expect(decoder.write(Buffer.from("36f59c", "hex"))).toEqual("6");
-  expect(decoder.end()).toEqual("\uFFFD\uFFFD");
-  decoder = new RealStringDecoder("utf-8");
-  expect(decoder.write(Buffer.from("36f5", "hex"))).toEqual("6");
-  expect(decoder.end(Buffer.from("9c", "hex"))).toEqual("\uFFFD\uFFFD");
-});
+// When the input buffer is too large to be represented as a JS string,
+// write()/end() should throw ERR_STRING_TOO_LONG instead of segfaulting.
+// Previously, Bun__encoding__toString would throw and return an empty JSValue,
+// and JSStringDecoder::write would call .toString() on it before checking for
+// an exception, dereferencing nullptr->m_type (segfault at address 0x5).
+it("write() with a buffer larger than String::MaxLength throws instead of crashing", async () => {
+  const src = `
+    const { StringDecoder } = require("string_decoder");
+    // Larger than JSC's String::MaxLength (2^31 - 1). allocUnsafe is lazily
+    // committed so this stays cheap until the ASCII scan touches pages.
+    const buf = Buffer.allocUnsafe(2 ** 31);
+    for (const method of ["write", "end"]) {
+      const decoder = new StringDecoder("utf8");
+      try {
+        decoder[method](buf);
+        console.log(method, "no throw");
+      } catch (e) {
+        console.log(method, e.code);
+      }
+    }
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, exitCode }).toEqual({
+    stdout: "write ERR_STRING_TOO_LONG\nend ERR_STRING_TOO_LONG\n",
+    exitCode: 0,
+  });
+}, 60000);

--- a/test/js/node/string_decoder/string-decoder.test.js
+++ b/test/js/node/string_decoder/string-decoder.test.js
@@ -275,8 +275,10 @@ it("invalid utf-8 at end of stream can sometimes produce more than one replaceme
 // Previously, Bun__encoding__toString would throw and return an empty JSValue,
 // and JSStringDecoder::write would call .toString() on it before checking for
 // an exception, dereferencing nullptr->m_type (segfault at address 0x5).
-it("write() with a buffer larger than String::MaxLength throws instead of crashing", async () => {
-  const src = `
+it(
+  "write() with a buffer larger than String::MaxLength throws instead of crashing",
+  async () => {
+    const src = `
     const { StringDecoder } = require("string_decoder");
     // Larger than JSC's String::MaxLength (2^31 - 1). allocUnsafe is lazily
     // committed so this stays cheap until the ASCII scan touches pages.
@@ -291,21 +293,23 @@ it("write() with a buffer larger than String::MaxLength throws instead of crashi
       }
     }
   `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", src],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  // ASAN builds unconditionally print "WARNING: ASAN interferes with JSC
-  // signal handlers..." to stderr from WebKit's Options.cpp; filter it out.
-  const stderrFiltered = stderr
-    .split(/\r?\n/)
-    .filter(s => !s.startsWith("WARNING: ASAN interferes"))
-    .join("\n");
-  expect(stderrFiltered).toBe("");
-  expect(stdout).toBe("write ERR_STRING_TOO_LONG\nend ERR_STRING_TOO_LONG\n");
-  expect(exitCode).toBe(0);
-  // The 2 GiB ASCII scan takes ~15s under debug/ASAN vs ~1s in release.
-}, isDebug || isASAN ? 60_000 : undefined);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // ASAN builds unconditionally print "WARNING: ASAN interferes with JSC
+    // signal handlers..." to stderr from WebKit's Options.cpp; filter it out.
+    const stderrFiltered = stderr
+      .split(/\r?\n/)
+      .filter(s => !s.startsWith("WARNING: ASAN interferes"))
+      .join("\n");
+    expect(stderrFiltered).toBe("");
+    expect(stdout).toBe("write ERR_STRING_TOO_LONG\nend ERR_STRING_TOO_LONG\n");
+    expect(exitCode).toBe(0);
+    // The 2 GiB ASCII scan takes ~15s under debug/ASAN vs ~1s in release.
+  },
+  isDebug || isASAN ? 60_000 : undefined,
+);

--- a/test/js/node/string_decoder/string-decoder.test.js
+++ b/test/js/node/string_decoder/string-decoder.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, withoutAggressiveGC } from "harness";
 
 const RealStringDecoder = require("string_decoder").StringDecoder;
 
@@ -307,4 +307,5 @@ it("write() with a buffer larger than String::MaxLength throws instead of crashi
   expect(stderrFiltered).toBe("");
   expect(stdout).toBe("write ERR_STRING_TOO_LONG\nend ERR_STRING_TOO_LONG\n");
   expect(exitCode).toBe(0);
-}, 60000);
+  // The 2 GiB ASCII scan takes ~15s under debug/ASAN vs ~1s in release.
+}, isDebug || isASAN ? 60_000 : undefined);

--- a/test/js/node/string_decoder/string-decoder.test.js
+++ b/test/js/node/string_decoder/string-decoder.test.js
@@ -298,8 +298,13 @@ it("write() with a buffer larger than String::MaxLength throws instead of crashi
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, exitCode }).toEqual({
-    stdout: "write ERR_STRING_TOO_LONG\nend ERR_STRING_TOO_LONG\n",
-    exitCode: 0,
-  });
+  // ASAN builds unconditionally print "WARNING: ASAN interferes with JSC
+  // signal handlers..." to stderr from WebKit's Options.cpp; filter it out.
+  const stderrFiltered = stderr
+    .split(/\r?\n/)
+    .filter(s => !s.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  expect(stderrFiltered).toBe("");
+  expect(stdout).toBe("write ERR_STRING_TOO_LONG\nend ERR_STRING_TOO_LONG\n");
+  expect(exitCode).toBe(0);
 }, 60000);


### PR DESCRIPTION
## Reproduction

```js
const { StringDecoder } = require("string_decoder");
new StringDecoder("utf8").write(Buffer.allocUnsafe(2 ** 31));
```
```
panic(main thread): Segmentation fault at address 0x5
```

## Cause

`Bun__encoding__toString` can throw (e.g. `ERR_STRING_TOO_LONG` when the decoded length exceeds JSC's `String::MaxLength` of 2³¹-1) and return encoded-0. `JSStringDecoder::text()` / `fillLast()` / `write()` propagate that as an empty `JSValue` via `RELEASE_AND_RETURN`, and the caller then did:

```cpp
JSString* str = text(vm, globalObject, bufPtr, length, offset).toString(globalObject);
RETURN_IF_EXCEPTION(throwScope, JSC::jsUndefined());
```

`.toString()` runs *before* the exception check. On an empty `JSValue`, `isCell()` is `true`, `asCell()` is `nullptr`, and `asCell()->type()` reads `JSCell::m_type` at offset 5 → segfault at address `0x5`.

## Fix

Store the `JSValue`, `RETURN_IF_EXCEPTION`, *then* `.toString()`. Same pattern applied to all affected sites in `write()` and `end()`.

Now throws `ERR_STRING_TOO_LONG` like Node.js instead of crashing.

## Verification

- `bun bd test test/js/node/string_decoder/string-decoder.test.js` → 84 pass / 0 fail
- `USE_SYSTEM_BUN=1 bun test ... -t "larger than String::MaxLength"` → fails (subprocess segfaults)
- `BUN_JSC_validateExceptionChecks=1` clean on all encoding paths
- Node parallel tests `test-string-decoder{,-end,-fuzz}.js` all pass