### PR TITLE
process: release stdin fd 0 via backpressure (Node parity)

### DIFF
--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -165,6 +165,14 @@ export function getStdinStream(
 
   const ReadStream = isTTY ? require("node:tty").ReadStream : require("node:fs").ReadStream;
   const stream = new ReadStream(null, { fd, autoClose: false });
+  // fs.ReadStream has an async _construct (to open() the file), which leaves
+  // kConstructed unset for two ticks and makes the nReadingNextTick → read(0)
+  // path skip _read(). Node's net.Socket has no _construct. fd 0 is already
+  // open, so there is nothing to construct — mark it done so _read() is
+  // reachable on the first tick. The in-flight constructNT will set it again
+  // (idempotent) and the kOnConstructed → maybeReadMore that follows is a
+  // no-op once reading has started.
+  stream._readableState.constructed = true;
 
   const originalOn = stream.on;
 
@@ -222,9 +230,13 @@ export function getStdinStream(
       const { value } = await reader.read();
 
       if (value) {
-        stream.push(value);
-
-        if (shouldDisown) disown();
+        // Node's onStreamRead: `if (!stream.push(buf)) handle.readStop()`.
+        // With highWaterMark 0 (TTY), push() returns false on every chunk so
+        // we release fd 0 after each one; _read() (triggerRead) re-owns when a
+        // consumer pulls. If nothing is consuming, fd 0 stays released and a
+        // stdio:'inherit' child reads it exclusively.
+        const more = stream.push(value);
+        if (shouldDisown || !more) disown();
       } else {
         if (!stream_endEmitted) {
           stream_endEmitted = true;
@@ -238,10 +250,11 @@ export function getStdinStream(
       }
     } catch (err) {
       if (err?.code === "ERR_STREAM_RELEASE_LOCK") {
-        // The stream was unref()ed. It may be ref()ed again in the future,
-        // or maybe it has already been ref()ed again and we just need to
-        // restart the internalRead() function. triggerRead() will figure that out.
-        triggerRead.$call(stream, undefined);
+        // disown() released the reader while a read was pending. Don't
+        // re-enter triggerRead (which would own() again); the next legitimate
+        // _read() from Readable.prototype.read() will own() when a consumer
+        // actually wants data.
+        needsInternalReadRefresh = true;
         return;
       }
       stream.destroy(err);
@@ -254,9 +267,14 @@ export function getStdinStream(
     if (reader && !shouldDisown) {
       internalRead(this);
     } else {
-      // The stream has not been ref()ed yet. If it is ever ref()ed,
-      // run internalRead()
+      // Node's Socket.prototype._read → tryReadStart() → handle.readStart().
+      // own() will start internalRead via needsInternalReadRefresh. Skip when
+      // explicitly paused (kPaused) so a stray _read() from maybeReadMore_
+      // (scheduled before the 'pause' handler ran) doesn't re-acquire fd 0.
       needsInternalReadRefresh = true;
+      if (!stream._readableState.paused) {
+        own();
+      }
     }
   }
   stream._read = triggerRead;

--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -16,7 +16,10 @@ function ReadStream(fd): void {
   if (!(this instanceof ReadStream)) {
     return new ReadStream(fd);
   }
-  fs.ReadStream.$apply(this, ["", { fd }]);
+  // Node's tty.ReadStream sets readableHighWaterMark: 0 so push() returns
+  // false on every chunk and onStreamRead's backpressure path can readStop()
+  // between reads.
+  fs.ReadStream.$apply(this, ["", { fd, highWaterMark: 0 }]);
   this.isRaw = false;
   // Only set isTTY to true if the fd is actually a TTY
   this.isTTY = isatty(fd);

--- a/test/js/node/process/stdin/readable-removed-pty.test.ts
+++ b/test/js/node/process/stdin/readable-removed-pty.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+import { join } from "node:path";
+
+// Node's tty.ReadStream sets highWaterMark: 0 so push() returns false on
+// every chunk and onStreamRead readStop()s. After the 'readable' listener is
+// removed, the next chunk pushes → false → readStop, and a stdio:'inherit'
+// child reads subsequent bytes from fd 0. Bun's stdin is wrapped around an
+// async reader, so this exercises the equivalent disown-on-backpressure path.
+test.skipIf(isWindows)("removing the last 'readable' listener releases fd 0 under a TTY", async () => {
+  const script = join(import.meta.dir, "readable-removed-releases-tty.mjs");
+  const pty = join(import.meta.dir, "run-with-pty-readable.py");
+
+  await using proc = Bun.spawn({
+    cmd: [Bun.which("python3") ?? Bun.which("python") ?? "python", pty, bunExe(), script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const childLines = stdout
+    .split("\n")
+    .map(l => l.trim())
+    .filter(l => l.startsWith("CHILD:"));
+
+  // The parent may buffer at most one chunk (Node's backpressure semantics
+  // with highWaterMark 0). The child must receive at least 4 of the 5 bytes
+  // A–E. On the unfixed build, the parent buffers ≥2 bytes and the child
+  // receives <4.
+  expect({ stderr, childLines, exitCode }).toEqual({
+    stderr: "",
+    childLines: expect.arrayContaining(['CHILD:"B"', 'CHILD:"C"', 'CHILD:"D"', 'CHILD:"E"']),
+    exitCode: 0,
+  });
+  expect(childLines.length).toBeGreaterThanOrEqual(4);
+});

--- a/test/js/node/process/stdin/readable-removed-releases-tty.mjs
+++ b/test/js/node/process/stdin/readable-removed-releases-tty.mjs
@@ -1,0 +1,45 @@
+// Under a real TTY (highWaterMark 0), after removing the last 'readable'
+// listener Node releases fd 0 via backpressure (push() returns false →
+// readStop()) once the next chunk arrives, so a stdio:'inherit' child reads
+// subsequent bytes. Parent may buffer at most ONE chunk before release.
+import { spawn } from "node:child_process";
+
+const drain = () => {
+  let c;
+  while ((c = process.stdin.read()) !== null) {
+    process.stdout.write("PARENT:" + JSON.stringify(c.toString()) + "\n");
+  }
+};
+process.stdin.setRawMode(true);
+process.stdin.on("readable", drain);
+
+// give the read loop a tick to start
+process.stdout.write("%ready%\n");
+
+process.stdin.once("readable", () => {
+  // first byte arrives → drain it, then unsubscribe and hand off to child
+  process.stdin.removeListener("readable", drain);
+  process.stdin.setRawMode(false);
+
+  const child = spawn(
+    process.execPath,
+    [
+      "-e",
+      `process.stdin.setRawMode(true);
+       process.stdin.on("data", d => {
+         for (const ch of d.toString()) {
+           if (ch === "\\x03") process.exit(0);
+           process.stdout.write("CHILD:" + JSON.stringify(ch) + "\\n");
+         }
+         process.stdout.write("%ready%\\n");
+       });
+       process.stdout.write("%ready%\\n");`,
+    ],
+    { stdio: "inherit" },
+  );
+  child.on("close", code => {
+    process.stdout.write("PARENT: child closed " + code + "\n");
+    process.stdout.write("%ready%\n");
+    process.exit(code ?? 1);
+  });
+});

--- a/test/js/node/process/stdin/run-with-pty-readable.py
+++ b/test/js/node/process/stdin/run-with-pty-readable.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+import pty
+import os
+import sys
+import select
+import signal
+
+def waitForReady():
+    buffer = b""
+    while b"%ready%" not in buffer:
+        ready = select.select([master_fd], [], [], 0.1)[0]
+        if ready:
+            data = os.read(master_fd, 1024)
+            if data:
+                buffer += data
+                sys.stdout.buffer.write(data)
+                sys.stdout.buffer.flush()
+
+def waitAndWrite(b):
+    waitForReady()
+    os.write(master_fd, b)
+
+def timeout_handler(signum, frame):
+    try:
+        os.kill(pid, 9)
+    except:
+        pass
+    sys.exit(1)
+
+command = sys.argv[1:]
+master_fd, slave_fd = pty.openpty()
+pid = os.fork()
+
+if pid == 0:
+    os.close(master_fd)
+    os.setsid()
+    os.dup2(slave_fd, 0)
+    os.dup2(slave_fd, 1)
+    os.dup2(slave_fd, 2)
+    if slave_fd > 2:
+        os.close(slave_fd)
+    os.execvp(command[0], command)
+else:
+    os.close(slave_fd)
+    signal.signal(signal.SIGALRM, timeout_handler)
+    signal.alarm(5)
+
+    # Parent: trigger first 'readable' (parent drains '1', then removes listener)
+    waitAndWrite(b'1')
+    # Child spawned and wrote %ready%. The parent may buffer at most one chunk
+    # before backpressure releases fd 0, so the first byte sent here may be
+    # swallowed silently. Don't wait for an echo between bytes.
+    waitForReady()
+    for b in (b'A', b'B', b'C', b'D', b'E'):
+        os.write(master_fd, b)
+        # Drain any output but don't require %ready% (the first byte may be
+        # buffered in the parent with no echo).
+        deadline = 0.1
+        while deadline > 0:
+            ready = select.select([master_fd], [], [], 0.05)[0]
+            deadline -= 0.05
+            if ready:
+                data = os.read(master_fd, 1024)
+                sys.stdout.buffer.write(data)
+                sys.stdout.buffer.flush()
+    os.write(master_fd, b'\x03')
+    waitForReady()
+
+    _, status = os.waitpid(pid, 0)
+    os.close(master_fd)
+    sys.exit(os.WEXITSTATUS(status) if os.WIFEXITED(status) else 1)


### PR DESCRIPTION
## What

After `process.stdin.on('readable', fn)` → `removeListener('readable', fn)`, Bun kept polling fd 0. A child spawned with `stdio: 'inherit'` then raced the parent for input — the parent silently buffered keystrokes meant for the child. This breaks the common TUI pattern (Ink, etc.) of unmounting before handing the terminal to vim/less/tmux.

## How

Match Node's mechanism exactly — no listener tracking, no `readable.ts` changes:

| | Node | This PR |
|---|---|---|
| TTY `highWaterMark` | `0` (lib/tty.js:64) | `tty.ReadStream` now sets `highWaterMark: 0` |
| Release fd | `onStreamRead`: `if (!push(buf)) handle.readStop()` | `internalRead`: `if (!push(value)) disown()` |
| Re-acquire fd | `Socket.prototype._read` → `tryReadStart()` | `triggerRead`: `own()` unless paused |

With hwm=0, `push()` returns false on every TTY chunk → `disown()` after each → `_read()` re-owns only when a consumer pulls. Once the last `'readable'` listener is gone, Readable stops calling `_read()` → fd 0 stays released → child reads exclusively. Pipe stdin keeps hwm=65536 and only releases at backpressure (same as Node).

Also fixes two prerequisites this surfaced:
- `tty.ReadStream(fd)` was dropping the `highWaterMark` option (hardcoded `{fd}`)
- stdin's `constructed` flag was unset for two ticks (`fs.ReadStream` has async `_construct`, Node's `net.Socket` doesn't), making `read(0)` skip `_read()` when hwm=0

## Test plan

- [x] `bun bd test test/js/node/process/stdin/ test/js/node/process/process-stdin.test.ts test/js/node/process/process-stdio.test.ts test/js/node/readline/ test/js/node/stream/ test/js/node/tty/` — 163 pass
- [x] New PTY test fails on system bun, passes on debug; output byte-identical to Node
- [x] `process.stdin.readableHighWaterMark`: 0 under TTY, 65536 under pipe — matches Node
- [x] Adversarial: `removeAllListeners()` → re-subscribe → remove under PTY — matches Node
- [x] Adversarial: pause/resume cycle under TTY — matches Node
- [x] Adversarial: 200KB pipe input through backpressure — no data loss

Supersedes #29061.