### PR TITLE
fix(runtime-transpiler): don't read `this` after publishing TranspilerJob to main thread

### DIFF
--- a/src/bun.js/RuntimeTranspilerStore.zig
+++ b/src/bun.js/RuntimeTranspilerStore.zig
@@ -238,8 +238,10 @@ pub const RuntimeTranspilerStore = struct {
 
         pub fn dispatchToMainThread(this: *TranspilerJob) void {
             const vm = this.vm;
-            vm.transpiler_store.queue.push(this);
-            vm.eventLoop().enqueueTaskConcurrent(jsc.ConcurrentTask.createFrom(&vm.transpiler_store));
+            const transpiler_store = &vm.transpiler_store;
+            transpiler_store.queue.push(this);
+            // Another thread may free `this` at any time after .push, so we cannot use it any more.
+            vm.eventLoop().enqueueTaskConcurrent(jsc.ConcurrentTask.createFrom(transpiler_store));
         }
 
         pub fn runFromJSThread(this: *TranspilerJob) bun.JSError!void {

--- a/src/bun.js/RuntimeTranspilerStore.zig
+++ b/src/bun.js/RuntimeTranspilerStore.zig
@@ -237,8 +237,9 @@ pub const RuntimeTranspilerStore = struct {
         threadlocal var source_code_printer: ?*js_printer.BufferPrinter = null;
 
         pub fn dispatchToMainThread(this: *TranspilerJob) void {
-            this.vm.transpiler_store.queue.push(this);
-            this.vm.eventLoop().enqueueTaskConcurrent(jsc.ConcurrentTask.createFrom(&this.vm.transpiler_store));
+            const vm = this.vm;
+            vm.transpiler_store.queue.push(this);
+            vm.eventLoop().enqueueTaskConcurrent(jsc.ConcurrentTask.createFrom(&vm.transpiler_store));
         }
 
         pub fn runFromJSThread(this: *TranspilerJob) bun.JSError!void {


### PR DESCRIPTION
### What does this PR do?

`dispatchToMainThread()` runs on a WorkPool thread and does:

```zig
this.vm.transpiler_store.queue.push(this);
this.vm.eventLoop().enqueueTaskConcurrent(...);
```

After `queue.push(this)` publishes the job, the main thread can be woken by a `ConcurrentTask` enqueued by a different worker, call `RuntimeTranspilerStore.runFromJSThread()` → `queue.popBatch()` (which drains all pushed jobs, including this one) → `runFromJSThread()` → `store.put(this)`. `HiveArray.put()` writes `value.* = undefined` across the slot, so by the time this worker executes the second line and reloads `this.vm`, it reads `0xAA` poison and `vm.eventLoop()` dereferences a non-canonical pointer.

In practice this only crashes on Windows x64 release builds: those are ReleaseSafe, so `= undefined` actually writes `0xAA` (ReleaseFast is a no-op), and the generated code reloads `this.vm` after the `xchg` in `queue.push` rather than CSE'ing it. The window between the two instructions is a handful of cycles, so it only fires when the worker is preempted right after the push on an oversubscribed machine.

Crash reports show up as `Segmentation fault at address 0xFFFFFFFFFFFFFFFF` with frames `VirtualMachine.zig:eventLoop` / `arena_allocator.zig:deinit` / `atomic.zig:fetchSub` (the innermost inline at each PC; the outermost frames are `dispatchToMainThread` / `TranspilerJob.run` / `ThreadPool.Thread.run`).

Fix: snapshot `vm` into a local before `queue.push(this)` and never touch `this` after publishing.

Fixes #15805
Fixes #14681