### PR TITLE
streams: remove extra microtask hops in TransformStream sink path

### DIFF
--- a/src/js/builtins/TransformStreamInternals.ts
+++ b/src/js/builtins/TransformStreamInternals.ts
@@ -236,19 +236,16 @@ export function transformStreamDefaultControllerError(controller, e) {
 }
 
 export function transformStreamDefaultControllerPerformTransform(controller, chunk) {
-  const promiseCapability = $newPromiseCapability(Promise);
-
   const transformPromise = $getByIdDirectPrivate(controller, "transformAlgorithm").$call(undefined, chunk);
-  transformPromise.$then(
-    () => {
-      promiseCapability.resolve();
-    },
-    r => {
-      $transformStreamError($getByIdDirectPrivate(controller, "stream"), r);
-      promiseCapability.reject.$call(undefined, r);
-    },
-  );
-  return promiseCapability.promise;
+  // Match the WHATWG spec: return the transform promise directly with an error handler
+  // chained on it. The previous implementation wrapped this in a fresh promise capability,
+  // adding an unnecessary microtask hop between transform completion and the write
+  // promise resolving. That extra hop could let a queued close sentinel race ahead of
+  // the transform's completion observers.
+  return transformPromise.$then(undefined, r => {
+    $transformStreamError($getByIdDirectPrivate(controller, "stream"), r);
+    throw r;
+  });
 }
 
 export function transformStreamDefaultControllerTerminate(controller) {
@@ -271,34 +268,23 @@ export function transformStreamDefaultSinkWriteAlgorithm(stream, chunk) {
   const controller = $getByIdDirectPrivate(stream, "controller");
 
   if ($getByIdDirectPrivate(stream, "backpressure")) {
-    const promiseCapability = $newPromiseCapability(Promise);
-
     const backpressureChangePromise = $getByIdDirectPrivate(stream, "backpressureChangePromise");
     $assert(backpressureChangePromise !== undefined);
-    backpressureChangePromise.promise.$then(
-      () => {
-        const state = $getByIdDirectPrivate(writable, "state");
-        if (state === "erroring") {
-          promiseCapability.reject.$call(undefined, $getByIdDirectPrivate(writable, "storedError"));
-          return;
-        }
 
-        $assert(state === "writable");
-        $transformStreamDefaultControllerPerformTransform(controller, chunk).$then(
-          () => {
-            promiseCapability.resolve();
-          },
-          e => {
-            promiseCapability.reject.$call(undefined, e);
-          },
-        );
-      },
-      e => {
-        promiseCapability.reject.$call(undefined, e);
-      },
-    );
+    // Match the WHATWG spec: react to backpressureChangePromise with the fulfillment
+    // steps returning the transform promise. Using a direct `.then()` chain lets the
+    // returned promise adopt the transform's state rather than hopping through an
+    // extra promise capability. This ensures the writable's write promise waits for
+    // the transform to fully resolve before the close sentinel can be processed.
+    return backpressureChangePromise.promise.$then(() => {
+      const state = $getByIdDirectPrivate(writable, "state");
+      if (state === "erroring") {
+        throw $getByIdDirectPrivate(writable, "storedError");
+      }
 
-    return promiseCapability.promise;
+      $assert(state === "writable");
+      return $transformStreamDefaultControllerPerformTransform(controller, chunk);
+    });
   }
   return $transformStreamDefaultControllerPerformTransform(controller, chunk);
 }

--- a/test/regression/issue/29123.test.ts
+++ b/test/regression/issue/29123.test.ts
@@ -12,7 +12,12 @@ test("TransformStream: flush runs after async transform resolves (minimal)", asy
 
   const ts = new TransformStream({
     async transform(chunk, controller) {
-      await new Promise(r => setTimeout(r, 1));
+      // Multiple microtask boundaries — no wall-clock timer so the test
+      // doesn't become flaky under load. Each await gives the close
+      // sentinel a chance to race ahead of the transform's completion.
+      await Promise.resolve();
+      await new Promise<void>(r => queueMicrotask(r));
+      await Promise.resolve();
       transformComplete = true;
       controller.enqueue(chunk);
     },
@@ -122,7 +127,9 @@ test("TransformStream: transform errors still propagate through write", async ()
   const writer = ts.writable.getWriter();
 
   // The write promise should reject with the thrown error.
-  await expect(writer.write("x")).rejects.toBe(err);
+  await expect(async () => {
+    await writer.write("x");
+  }).toThrow(err);
 });
 
 test("TransformStream: flush does not run if transform throws", async () => {
@@ -140,8 +147,12 @@ test("TransformStream: flush does not run if transform throws", async () => {
   });
 
   const writer = ts.writable.getWriter();
-  await expect(writer.write("x")).rejects.toBe(err);
+  await expect(async () => {
+    await writer.write("x");
+  }).toThrow(err);
   // Closing an errored stream should reject, and flush should not run.
-  await expect(writer.close()).rejects.toBeDefined();
+  await expect(async () => {
+    await writer.close();
+  }).toThrow();
   expect(flushRan).toBe(false);
 });

--- a/test/regression/issue/29123.test.ts
+++ b/test/regression/issue/29123.test.ts
@@ -1,0 +1,147 @@
+// https://github.com/oven-sh/bun/issues/29123
+// TransformStream: flush() must only fire after all pending async transform()
+// calls have resolved. Prior to the fix, extra promise-capability wrappers in
+// performTransform and sinkWriteAlgorithm added microtask hops that could let
+// a queued close sentinel race ahead of the transform's completion.
+
+import { test, expect } from "bun:test";
+
+test("TransformStream: flush runs after async transform resolves (minimal)", async () => {
+  let transformComplete = false;
+  let flushTransformCompleteState: boolean | null = null;
+
+  const ts = new TransformStream({
+    async transform(chunk, controller) {
+      await new Promise(r => setTimeout(r, 1));
+      transformComplete = true;
+      controller.enqueue(chunk);
+    },
+    flush() {
+      flushTransformCompleteState = transformComplete;
+    },
+  });
+
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+
+  writer.write("c1");
+  writer.close();
+
+  while (true) {
+    const { done } = await reader.read();
+    if (done) break;
+  }
+
+  expect(flushTransformCompleteState).toBe(true);
+});
+
+test("TransformStream: flush runs after async transform resolves (many chunks)", async () => {
+  const N = 10;
+  let transformsFinished = 0;
+  let flushState: number | null = null;
+
+  const ts = new TransformStream({
+    async transform(chunk, controller) {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      transformsFinished++;
+      controller.enqueue(chunk);
+    },
+    flush() {
+      flushState = transformsFinished;
+    },
+  });
+
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+
+  const writes: Promise<void>[] = [];
+  for (let i = 0; i < N; i++) writes.push(writer.write(i));
+  writes.push(writer.close());
+
+  const received: unknown[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    received.push(value);
+  }
+  await Promise.all(writes);
+
+  expect(received).toHaveLength(N);
+  expect(flushState).toBe(N);
+});
+
+test("TransformStream: flush runs after async transform resolves (pipeThrough)", async () => {
+  const N = 20;
+  let transformsFinished = 0;
+  let flushState: number | null = null;
+
+  const source = new ReadableStream<number>({
+    start(c) {
+      for (let i = 0; i < N; i++) c.enqueue(i);
+      c.close();
+    },
+  });
+
+  const ts = new TransformStream<number, number>({
+    async transform(chunk, controller) {
+      // Multiple await boundaries to stress the microtask scheduling.
+      await Promise.resolve();
+      await new Promise(r => queueMicrotask(r));
+      await Promise.resolve();
+      transformsFinished++;
+      controller.enqueue(chunk);
+    },
+    flush() {
+      flushState = transformsFinished;
+    },
+  });
+
+  const reader = source.pipeThrough(ts).getReader();
+  const received: number[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    received.push(value as number);
+  }
+
+  expect(received).toHaveLength(N);
+  expect(flushState).toBe(N);
+});
+
+test("TransformStream: transform errors still propagate through write", async () => {
+  const err = new Error("transform bang");
+  const ts = new TransformStream({
+    async transform() {
+      await Promise.resolve();
+      throw err;
+    },
+  });
+
+  const writer = ts.writable.getWriter();
+
+  // The write promise should reject with the thrown error.
+  await expect(writer.write("x")).rejects.toBe(err);
+});
+
+test("TransformStream: flush does not run if transform throws", async () => {
+  const err = new Error("transform bang");
+  let flushRan = false;
+
+  const ts = new TransformStream({
+    async transform() {
+      await Promise.resolve();
+      throw err;
+    },
+    flush() {
+      flushRan = true;
+    },
+  });
+
+  const writer = ts.writable.getWriter();
+  await expect(writer.write("x")).rejects.toBe(err);
+  // Closing an errored stream should reject, and flush should not run.
+  await expect(writer.close()).rejects.toBeDefined();
+  expect(flushRan).toBe(false);
+});

--- a/test/regression/issue/29123.test.ts
+++ b/test/regression/issue/29123.test.ts
@@ -125,11 +125,24 @@ test("TransformStream: transform errors still propagate through write", async ()
   });
 
   const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+
+  // TransformStream starts with backpressure=true, so writer.write() can't
+  // even reach the transform until a reader pulls. Drain concurrently.
+  const readDone = (async () => {
+    try {
+      while (!(await reader.read()).done) {}
+    } catch {
+      // Reader surfaces the errored readable side; that's expected.
+    }
+  })();
 
   // The write promise should reject with the thrown error.
   await expect(async () => {
     await writer.write("x");
   }).toThrow(err);
+
+  await readDone;
 });
 
 test("TransformStream: flush does not run if transform throws", async () => {
@@ -147,6 +160,16 @@ test("TransformStream: flush does not run if transform throws", async () => {
   });
 
   const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+
+  // See test above — concurrent reader drains so the write isn't blocked on
+  // backpressure.
+  const readDone = (async () => {
+    try {
+      while (!(await reader.read()).done) {}
+    } catch {}
+  })();
+
   await expect(async () => {
     await writer.write("x");
   }).toThrow(err);
@@ -154,5 +177,7 @@ test("TransformStream: flush does not run if transform throws", async () => {
   await expect(async () => {
     await writer.close();
   }).toThrow();
+
+  await readDone;
   expect(flushRan).toBe(false);
 });

--- a/test/regression/issue/29123.test.ts
+++ b/test/regression/issue/29123.test.ts
@@ -4,7 +4,7 @@
 // performTransform and sinkWriteAlgorithm added microtask hops that could let
 // a queued close sentinel race ahead of the transform's completion.
 
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("TransformStream: flush runs after async transform resolves (minimal)", async () => {
   let transformComplete = false;


### PR DESCRIPTION
Fixes #29123

## Problem

The reporter observes `TransformStream` `flush()` firing before an async `transform()` call has resolved, which violates the WHATWG Streams spec:

> The flush algorithm is called after all chunks written to the writable side have been transformed by successfully passing through transformer.transform().

The user reports it is timing-dependent and reproduces consistently in Vercel AI SDK's `runToolsTransformation` when sync I/O (SQLite) occurs in the transform's async path, affecting microtask scheduling. Node.js does not exhibit the behavior.

## Cause

`transformStreamDefaultControllerPerformTransform` and the backpressure branch of `transformStreamDefaultSinkWriteAlgorithm` both wrap the transform promise in a fresh `$newPromiseCapability(Promise)` and resolve/reject it manually from a chained `.then`. Each wrapper adds a microtask hop between the user's async `transform()` settling and the writable's write promise settling.

The WHATWG spec's `TransformStreamDefaultSinkWriteAlgorithm` reacts to `backpressureChangePromise` with fulfillment steps that simply *return* `PerformTransform(...)` — standard `.then()` adopts the transform promise's state without the intermediate capability. Bun's old code pre-dated this simplification.

The extra hops are harmless for most code because promise chains settle in FIFO order. But they widen the window in which a concurrently-scheduled microtask (e.g. the close-sentinel being processed by the writable's `advanceQueueIfNeeded`) can run between the transform resolving and the write promise resolving.

## Fix

Match the spec / reference polyfill pattern with direct `.then()` chaining:

- `performTransform` returns `transformPromise.$then(undefined, errHandler)` — the error handler still calls `transformStreamError` before re-throwing. No wrapper capability.
- `sinkWriteAlgorithm` backpressure branch returns `backpressureChangePromise.promise.$then(() => performTransform(...))`. A fulfillment handler that returns a promise causes the outer `.then`'s returned promise to adopt that promise's state — no wrapper, no manual resolve.

Semantically equivalent to the old code (rejection still errors the stream and propagates; fulfillment still waits for the inner transform) but with two fewer microtask boundaries per chunk in the backpressure path.

## Tests

New `test/regression/issue/29123.test.ts` covers:
1. The minimal repro from the issue (single chunk, async transform with timer).
2. Many-chunks case with multiple `await` boundaries in each `transform()`.
3. `pipeThrough` variant to exercise the pipe-loop path.
4. Transform rejection propagates through `writer.write()`.
5. Flush does not run if transform throws.

## Notes on reproduction

I could not reproduce the user's observed symptom with a minimal script despite stress-testing the patterns they described (pipeThrough, multiple awaits, synchronous SQLite I/O, the full AI SDK `streamText` + tool-call flow). My reading of the existing code suggested it was already spec-serialized via `inFlightWriteRequest`, but comparing against the WHATWG reference polyfill revealed the unnecessary wrapper promise capabilities that the spec avoids. This PR brings the sink write path back in line with the spec shape; whether it is sufficient for the user's timing-sensitive case will need their confirmation once a build is available.