### PR TITLE
fix(cron): accept named weekday ranges ending in SUN

### DIFF
--- a/src/bun.js/api/cron_parser.zig
+++ b/src/bun.js/api/cron_parser.zig
@@ -221,7 +221,10 @@ fn parseField(comptime T: type, field: []const u8, min: u7, max: u7, kind: NameK
         } else {
             if (splitRange(base)) |range_parts| {
                 const lo = parseValue(range_parts[0], min, max, kind) catch return error.InvalidNumber;
-                const hi = parseValue(range_parts[1], min, max, kind) catch return error.InvalidNumber;
+                var hi = parseValue(range_parts[1], min, max, kind) catch return error.InvalidNumber;
+                // Named SUN/Sunday maps to 0; promote to 7 at the end of a range so
+                // FRI-SUN behaves like 5-7 (folded to {0,5,6} below).
+                if (kind == .weekday and hi == 0 and lo > 0) hi = 7;
                 if (lo > hi) return error.InvalidRange;
                 range_min = lo;
                 range_max = hi;

--- a/src/bun.js/api/cron_parser.zig
+++ b/src/bun.js/api/cron_parser.zig
@@ -223,8 +223,10 @@ fn parseField(comptime T: type, field: []const u8, min: u7, max: u7, kind: NameK
                 const lo = parseValue(range_parts[0], min, max, kind) catch return error.InvalidNumber;
                 var hi = parseValue(range_parts[1], min, max, kind) catch return error.InvalidNumber;
                 // Named SUN/Sunday maps to 0; promote to 7 at the end of a range so
-                // FRI-SUN behaves like 5-7 (folded to {0,5,6} below).
-                if (kind == .weekday and hi == 0 and lo > 0) hi = 7;
+                // FRI-SUN behaves like 5-7 (folded to {0,5,6} below). Gate on an
+                // alphabetic token so numeric `5-0` still rejects per Vixie semantics.
+                if (kind == .weekday and hi == 0 and lo > 0 and
+                    range_parts[1].len > 0 and std.ascii.isAlphabetic(range_parts[1][0])) hi = 7;
                 if (lo > hi) return error.InvalidRange;
                 range_min = lo;
                 range_max = hi;

--- a/src/runtime/api/cron_parser.rs
+++ b/src/runtime/api/cron_parser.rs
@@ -316,8 +316,18 @@ fn parse_field<T: BitInt>(field: &[u8], min: u8, max: u8, kind: NameKind) -> Res
         } else if let Some(range_parts) = split_range(base) {
             let lo = parse_value(range_parts[0], min, max, kind)
                 .map_err(|_| CronError::InvalidNumber)?;
-            let hi = parse_value(range_parts[1], min, max, kind)
+            let mut hi = parse_value(range_parts[1], min, max, kind)
                 .map_err(|_| CronError::InvalidNumber)?;
+            // Named SUN/Sunday maps to 0; promote to 7 at the end of a range so
+            // FRI-SUN behaves like 5-7 (folded to {0,5,6} below). Gate on an
+            // alphabetic token so numeric `5-0` still rejects per Vixie semantics.
+            if kind == NameKind::Weekday
+                && hi == 0
+                && lo > 0
+                && range_parts[1].first().is_some_and(u8::is_ascii_alphabetic)
+            {
+                hi = 7;
+            }
             if lo > hi {
                 return Err(CronError::InvalidRange);
             }

--- a/src/runtime/api/cron_parser.zig
+++ b/src/runtime/api/cron_parser.zig
@@ -221,7 +221,10 @@ fn parseField(comptime T: type, field: []const u8, min: u7, max: u7, kind: NameK
         } else {
             if (splitRange(base)) |range_parts| {
                 const lo = parseValue(range_parts[0], min, max, kind) catch return error.InvalidNumber;
-                const hi = parseValue(range_parts[1], min, max, kind) catch return error.InvalidNumber;
+                var hi = parseValue(range_parts[1], min, max, kind) catch return error.InvalidNumber;
+                // Named SUN/Sunday maps to 0; promote to 7 at the end of a range so
+                // FRI-SUN behaves like 5-7 (folded to {0,5,6} below).
+                if (kind == .weekday and hi == 0 and lo > 0) hi = 7;
                 if (lo > hi) return error.InvalidRange;
                 range_min = lo;
                 range_max = hi;

--- a/src/runtime/api/cron_parser.zig
+++ b/src/runtime/api/cron_parser.zig
@@ -223,8 +223,10 @@ fn parseField(comptime T: type, field: []const u8, min: u7, max: u7, kind: NameK
                 const lo = parseValue(range_parts[0], min, max, kind) catch return error.InvalidNumber;
                 var hi = parseValue(range_parts[1], min, max, kind) catch return error.InvalidNumber;
                 // Named SUN/Sunday maps to 0; promote to 7 at the end of a range so
-                // FRI-SUN behaves like 5-7 (folded to {0,5,6} below).
-                if (kind == .weekday and hi == 0 and lo > 0) hi = 7;
+                // FRI-SUN behaves like 5-7 (folded to {0,5,6} below). Gate on an
+                // alphabetic token so numeric `5-0` still rejects per Vixie semantics.
+                if (kind == .weekday and hi == 0 and lo > 0 and
+                    range_parts[1].len > 0 and std.ascii.isAlphabetic(range_parts[1][0])) hi = 7;
                 if (lo > hi) return error.InvalidRange;
                 range_min = lo;
                 range_max = hi;

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -1615,15 +1615,15 @@ describe("Bun.cron.parse", () => {
       ["fri-sun", "5-7"],
       ["Friday-Sunday", "5-7"],
     ] as const) {
-      const namedResults = nextN(`0 0 * * ${named}`, from, 7);
-      const numericResults = nextN(`0 0 * * ${numeric}`, from, 7);
-      expect({ expr: named, days: namedResults.map(t => new Date(t).getUTCDay()) }).toEqual({
+      expect({ expr: named, results: nextN(`0 0 * * ${named}`, from, 7) }).toEqual({
         expr: named,
-        days: numericResults.map(t => new Date(t).getUTCDay()),
+        results: nextN(`0 0 * * ${numeric}`, from, 7),
       });
     }
     // Spot-check FRI-SUN hits exactly Fri(5), Sat(6), Sun(0)
     expect(nextN("0 0 * * FRI-SUN", from, 6).map(t => new Date(t).getUTCDay())).toEqual([5, 6, 0, 5, 6, 0]);
+    // Numeric `5-0` is still rejected — promotion is gated on named tokens.
+    expect(() => Bun.cron.parse("0 0 * * 5-0", from)).toThrow(/range must be ascending/i);
   });
 
   test("day 7 and SUN both schedule on Sundays", () => {

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -1605,6 +1605,27 @@ describe("Bun.cron.parse", () => {
     expect(results.map(t => new Date(t).getUTCDay())).toEqual([1, 3, 5, 1, 3, 5]);
   });
 
+  test("named weekday ranges ending in SUN behave like 5-7 / 6-7 (Vixie semantics)", () => {
+    const from = Date.UTC(2025, 0, 1, 12, 0, 0); // Wednesday
+    for (const [named, numeric] of [
+      ["FRI-SUN", "5-7"],
+      ["SAT-SUN", "6-7"],
+      ["THU-SUN", "4-7"],
+      ["MON-SUN", "1-7"],
+      ["fri-sun", "5-7"],
+      ["Friday-Sunday", "5-7"],
+    ] as const) {
+      const namedResults = nextN(`0 0 * * ${named}`, from, 7);
+      const numericResults = nextN(`0 0 * * ${numeric}`, from, 7);
+      expect({ expr: named, days: namedResults.map(t => new Date(t).getUTCDay()) }).toEqual({
+        expr: named,
+        days: numericResults.map(t => new Date(t).getUTCDay()),
+      });
+    }
+    // Spot-check FRI-SUN hits exactly Fri(5), Sat(6), Sun(0)
+    expect(nextN("0 0 * * FRI-SUN", from, 6).map(t => new Date(t).getUTCDay())).toEqual([5, 6, 0, 5, 6, 0]);
+  });
+
   test("day 7 and SUN both schedule on Sundays", () => {
     const from = Date.UTC(2025, 0, 13, 0, 0, 0); // Monday
     expect(nextN("0 0 * * 7", from, 3)).toEqual(nextN("0 0 * * SUN", from, 3));


### PR DESCRIPTION
## What

`Bun.cron.parse("0 0 * * FRI-SUN")` threw `InvalidRange` while the equivalent numeric form `5-7` worked.

## Why

`weekday_map` maps `SUN`/`Sunday` → `0`. A range like `FRI-SUN` therefore parsed as `5-0`, which fails the `lo > hi` ascending check. Numeric `5-7` works because the parser already folds bit 7 into bit 0 after range expansion (Vixie/croner semantics).

## Fix

When parsing a weekday range, promote `hi` from `0` → `7` if `lo > 0`. The existing bit-7-fold then yields the correct set `{Fri, Sat, Sun}`.

## Test

Added a test verifying `FRI-SUN`, `SAT-SUN`, `THU-SUN`, `MON-SUN`, and case variants each match their numeric `N-7` equivalents over 7 occurrences, plus a spot-check that `FRI-SUN` produces exactly `[5,6,0,5,6,0]`.

```
USE_SYSTEM_BUN=1 bun test cron.test.ts -t "ending in SUN"   # fails (TypeError)
bun bd test cron.test.ts -t "ending in SUN"                 # passes
bun bd test cron.test.ts -t "Bun.cron.parse"                # 37 pass, 0 fail
```