### PR TITLE
build: gate parallel zig compiler back to darwin-only

### DIFF
--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -47,11 +47,15 @@ export const ZIG_COMMIT_PARALLEL = "445fc0cbba4eea579e5c846f2b8be7c9bdc4e1cc";
  * on the resolved cfg.zigCommit via usingParallelCompiler(), so changing
  * this — or passing --zigCommit=<hash> — is sufficient.
  *
- * Parallel compiler is enabled for local builds; CI stays on the stable
- * compiler until release builds are proven correct under parallel sema.
+ * Parallel compiler is darwin-local only for now. Linux is gated off
+ * because oven-sh/zig's self-hosted ELF `-r` merge (used to combine
+ * sharded codegen output when no_link_obj=true) currently emits an
+ * incomplete bun-zig.o — link fails with every Zig symbol undefined on
+ * a fresh build. macOS's Mach-O merge path works. See #29132. CI and
+ * Windows stay on the stable compiler regardless.
  */
 export function defaultZigCommit(ci: boolean, hostOs: OS): string {
-  if (ci || hostOs === "windows") return ZIG_COMMIT;
+  if (ci || hostOs !== "darwin") return ZIG_COMMIT;
   return ZIG_COMMIT_PARALLEL;
 }
 


### PR DESCRIPTION
Partially reverts #29092 (`68e80dbdb1`).

## Problem

Fresh `bun run build` on Linux fails at link with **every** Zig-exported symbol undefined:

```
[664/666] link bun-debug
ld.lld: error: undefined symbol: Bun__reportUnhandledError
ld.lld: error: undefined symbol: Bun__panic
... (every Zig export)
```

The zig step itself reports success. Reproduced by oven-sh/bun-development-docker-image's Daily Docker Build on every run since Apr 9 ([example](https://github.com/oven-sh/bun-development-docker-image/actions/runs/24260266660)).

## Cause

#29092 enabled the parallel-sema compiler with sharded LLVM codegen on Linux local builds. Sharded codegen on Linux goes through oven-sh/zig's self-hosted ELF `-r` merge to combine the per-shard `.o` files into `bun-zig.o`. #29092's compiler bump fixed a hang in that merge, but the merge output is still incomplete — `getEmittedBin()` installs a `bun-zig.o` missing the symbols. The subsequent bumps to `7d3c0c9b` / `445fc0cb` haven't fixed it either.

macOS uses the Mach-O merge path, which works (verified locally — single 315MB `.o` with `llvm_codegen_threads=16`).

## Fix

Gate the parallel compiler back to darwin-only until the ELF merge in oven-sh/zig is fixed. Linux local builds revert to the stable compiler (same as CI). No change for darwin or CI.

## Verification

- `bunx tsc --noEmit -p scripts/build/tsconfig.json` clean
- `bun scripts/build.ts --configure-only` on darwin → still selects `ZIG_COMMIT_PARALLEL` (build.ninja unchanged)
- Linux path: `hostOs !== "darwin"` → `ZIG_COMMIT` → `usingParallelCompiler=false` → `llvm_codegen_threads=0`

Closes #29132 on the bun side. Once this lands, oven-sh/bun-development-docker-image can revert its workaround and go back to plain `bun run build`.