### PR TITLE
net: support Socket({handle, manualStart}) with stream-wrap onread

### DIFF
--- a/src/bun.js/node/node_util_binding.zig
+++ b/src/bun.js/node/node_util_binding.zig
@@ -106,6 +106,75 @@ pub fn enobufsErrorCode(_: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!j
     return jsc.JSValue.jsNumberFromInt32(-bun.sys.UV_E.NOBUFS);
 }
 
+/// Node's `util.guessHandleType(fd)` — returns a uint32 index into
+/// `["TCP","TTY","UDP","FILE","PIPE","UNKNOWN"]`, matching the libuv
+/// `uv_guess_handle` mapping that Node's `createHandle`/`getStdin` rely on.
+pub fn guessHandleType(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+    const fd_value = callframe.argument(0);
+    if (!fd_value.isNumber()) {
+        return globalThis.throwInvalidArgumentTypeValue("fd", "number", fd_value);
+    }
+    const fd_int = fd_value.toInt32();
+    if (fd_int < 0) return jsc.JSValue.jsNumber(@as(u32, 5)); // UNKNOWN
+
+    return jsc.JSValue.jsNumber(@as(u32, guessHandleTypeFromFd(fd_int)));
+}
+
+fn guessHandleTypeFromFd(fd_int: i32) u32 {
+    const TCP = 0;
+    const TTY_TYPE = 1;
+    const UDP = 2;
+    const FILE_TYPE = 3;
+    const PIPE_TYPE = 4;
+    const UNKNOWN = 5;
+
+    if (comptime bun.Environment.isWindows) {
+        const uv = bun.windows.libuv;
+        return switch (uv.uv_guess_handle(fd_int)) {
+            uv.Handle.Type.tcp => TCP,
+            uv.Handle.Type.tty => TTY_TYPE,
+            uv.Handle.Type.udp => UDP,
+            uv.Handle.Type.file => FILE_TYPE,
+            uv.Handle.Type.named_pipe => PIPE_TYPE,
+            else => UNKNOWN,
+        };
+    }
+
+    const fd: bun.FD = .fromNative(fd_int);
+
+    if (std.posix.isatty(fd_int)) return TTY_TYPE;
+
+    const st = switch (bun.sys.fstat(fd)) {
+        .result => |s| s,
+        .err => return UNKNOWN,
+    };
+    const mode = st.mode;
+    if (std.posix.S.ISREG(mode) or std.posix.S.ISCHR(mode)) return FILE_TYPE;
+    if (std.posix.S.ISFIFO(mode)) return PIPE_TYPE;
+    if (!std.posix.S.ISSOCK(mode)) return UNKNOWN;
+
+    var ss: std.posix.sockaddr.storage = undefined;
+    var ss_len: std.posix.socklen_t = @sizeOf(std.posix.sockaddr.storage);
+    if (std.c.getsockname(fd_int, @ptrCast(&ss), &ss_len) != 0) return UNKNOWN;
+
+    var so_type: c_int = 0;
+    var so_type_len: std.posix.socklen_t = @sizeOf(c_int);
+    if (std.c.getsockopt(fd_int, std.posix.SOL.SOCKET, std.posix.SO.TYPE, @ptrCast(&so_type), &so_type_len) != 0) {
+        return UNKNOWN;
+    }
+
+    const family = ss.family;
+    if (so_type == std.posix.SOCK.DGRAM) {
+        if (family == std.posix.AF.INET or family == std.posix.AF.INET6) return UDP;
+        return UNKNOWN;
+    }
+    if (so_type == std.posix.SOCK.STREAM) {
+        if (family == std.posix.AF.INET or family == std.posix.AF.INET6) return TCP;
+        if (family == std.posix.AF.UNIX) return PIPE_TYPE;
+    }
+    return UNKNOWN;
+}
+
 /// `extractedSplitNewLines` for ASCII/Latin1 strings. Panics if passed a non-string.
 /// Returns `undefined` if param is utf8 or utf16 and not fully ascii.
 ///

--- a/src/bun.js/node/node_util_binding.zig
+++ b/src/bun.js/node/node_util_binding.zig
@@ -164,13 +164,15 @@ fn guessHandleTypeFromFd(fd_int: i32) u32 {
     }
 
     const family = ss.family;
+    // libuv checks AF_UNIX before SO_TYPE and returns UV_NAMED_PIPE for any
+    // AF_UNIX socket (STREAM/DGRAM/SEQPACKET).
+    if (family == std.posix.AF.UNIX) return PIPE_TYPE;
     if (so_type == std.posix.SOCK.DGRAM) {
         if (family == std.posix.AF.INET or family == std.posix.AF.INET6) return UDP;
         return UNKNOWN;
     }
     if (so_type == std.posix.SOCK.STREAM) {
         if (family == std.posix.AF.INET or family == std.posix.AF.INET6) return TCP;
-        if (family == std.posix.AF.UNIX) return PIPE_TYPE;
     }
     return UNKNOWN;
 }

--- a/src/bun.js/node/node_util_binding.zig
+++ b/src/bun.js/node/node_util_binding.zig
@@ -149,9 +149,9 @@ fn guessHandleTypeFromFd(fd_int: i32) u32 {
         .err => return UNKNOWN,
     };
     const mode = st.mode;
-    if (std.posix.S.ISREG(mode) or std.posix.S.ISCHR(mode)) return FILE_TYPE;
-    if (std.posix.S.ISFIFO(mode)) return PIPE_TYPE;
-    if (!std.posix.S.ISSOCK(mode)) return UNKNOWN;
+    if (bun.S.ISREG(mode) or bun.S.ISCHR(mode)) return FILE_TYPE;
+    if (bun.S.ISFIFO(mode)) return PIPE_TYPE;
+    if (!bun.S.ISSOCK(mode)) return UNKNOWN;
 
     var ss: std.posix.sockaddr.storage = undefined;
     var ss_len: std.posix.socklen_t = @sizeOf(std.posix.sockaddr.storage);

--- a/src/js/internal/shared.ts
+++ b/src/js/internal/shared.ts
@@ -165,6 +165,7 @@ export default {
   once,
   getLazy,
 
+  owner_symbol: Symbol("owner_symbol"),
   kHandle: Symbol("kHandle"),
   kAutoDestroyed: Symbol("kAutoDestroyed"),
   kResistStopPropagation: Symbol("kResistStopPropagation"),

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -62,7 +62,6 @@ const { owner_symbol } = require("internal/shared");
 const UV_EOF = -4095;
 const kBuffer = Symbol("kBuffer");
 const kBufferCb = Symbol("kBufferCb");
-const kBufferGen = Symbol("kBufferGen");
 
 const kServerSocket = Symbol("kServerSocket");
 const kBytesWritten = Symbol("kBytesWritten");
@@ -760,7 +759,6 @@ function Socket(options?) {
     }
     this[kBuffer] = true;
     this[kBufferCb] = onread.callback;
-    this[kBufferGen] = typeof onread.buffer === "function" ? onread.buffer : () => onread.buffer;
     // when the onread option is specified we use a different handlers object
     this[khandlers] = {
       ...SocketHandlers2,
@@ -1221,38 +1219,43 @@ Object.defineProperty(Socket.prototype, "pending", {
 });
 
 Socket.prototype.pause = function pause() {
-  if (this[kBuffer] && !this.connecting && this._handle && $isCallable(this._handle.readStop) && this._handle.reading) {
+  if (this[kBuffer] && !this.connecting && this._handle && this._handle.reading !== false) {
     this._handle.reading = false;
     if (!this.destroyed) {
-      const err = this._handle.readStop();
-      if (err) this.destroy(new ErrnoException(err, "read"));
+      if ($isCallable(this._handle.readStop)) {
+        const err = this._handle.readStop();
+        if (err) this.destroy(new ErrnoException(err, "read"));
+      } else {
+        // usocket-backed handle in onread mode: keep the pre-existing native
+        // pause, since SocketHandlers.data's onread variant does not apply
+        // backpressure on its own.
+        this._handle.pause?.();
+      }
     }
   }
   return Duplex.prototype.pause.$call(this);
 };
 
 Socket.prototype.resume = function resume() {
-  if (
-    this[kBuffer] &&
-    !this.connecting &&
-    this._handle &&
-    $isCallable(this._handle.readStart) &&
-    !this._handle.reading
-  ) {
-    tryReadStart(this);
+  if (this[kBuffer] && !this.connecting && this._handle && !this._handle.reading) {
+    if ($isCallable(this._handle.readStart)) {
+      tryReadStart(this);
+    } else {
+      this._handle.reading = true;
+      this._handle.resume?.();
+    }
   }
   return Duplex.prototype.resume.$call(this);
 };
 
 Socket.prototype.read = function read(size) {
-  if (
-    this[kBuffer] &&
-    !this.connecting &&
-    this._handle &&
-    $isCallable(this._handle.readStart) &&
-    !this._handle.reading
-  ) {
-    tryReadStart(this);
+  if (this[kBuffer] && !this.connecting && this._handle && !this._handle.reading) {
+    if ($isCallable(this._handle.readStart)) {
+      tryReadStart(this);
+    } else {
+      this._handle.reading = true;
+      this._handle.resume?.();
+    }
   }
   return Duplex.prototype.read.$call(this, size);
 };

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -738,19 +738,11 @@ function Socket(options?) {
     validateInt32(fd, "fd", 0);
   }
 
-  if (this._handle && $isCallable(this._handle.readStart) && options.readable !== false) {
-    if (options.pauseOnCreate) {
-      this._handle.reading = false;
-      this._handle.readStop();
-      this._readableState.flowing = false;
-    } else if (!options.manualStart) {
-      this.read(0);
-    }
-  }
-
   if (socket instanceof Socket) {
     this[ksocket] = socket;
   }
+  // onread must be set up before the read(0) below — a handle's readStart
+  // can fire onread synchronously, and onStreamRead routes on kBuffer.
   if (onread) {
     if (typeof onread !== "object") {
       throw new TypeError("onread must be an object");
@@ -773,6 +765,17 @@ function Socket(options?) {
         }
       },
     };
+  }
+
+  if (this._handle && $isCallable(this._handle.readStart) && options.readable !== false) {
+    if (options.pauseOnCreate) {
+      this._handle.reading = false;
+      const err = this._handle.readStop();
+      if (err) this.destroy(new ErrnoException(err, "read"));
+      this._readableState.flowing = false;
+    } else if (!options.manualStart) {
+      this.read(0);
+    }
   }
   if (signal) {
     if (signal.aborted) {
@@ -1221,42 +1224,51 @@ Object.defineProperty(Socket.prototype, "pending", {
 });
 
 Socket.prototype.pause = function pause() {
-  if (this[kBuffer] && !this.connecting && this._handle && this._handle.reading !== false) {
-    this._handle.reading = false;
-    if (!this.destroyed) {
-      if ($isCallable(this._handle.readStop)) {
-        const err = this._handle.readStop();
-        if (err) this.destroy(new ErrnoException(err, "read"));
-      } else {
-        // usocket-backed handle in onread mode: keep the pre-existing native
-        // pause, since SocketHandlers.data's onread variant does not apply
-        // backpressure on its own.
-        this._handle.pause?.();
+  const handle = this._handle;
+  if (handle) {
+    if ($isCallable(handle.readStop)) {
+      // stream-wrap handle: only drive readStop directly in onread mode —
+      // otherwise Duplex.pause stops _read which stops readStart (Node's
+      // lib/net.js kBuffer gating).
+      if (this[kBuffer] && !this.connecting && handle.reading !== false) {
+        handle.reading = false;
+        if (!this.destroyed) {
+          const err = handle.readStop();
+          if (err) this.destroy(new ErrnoException(err, "read"));
+        }
       }
+    } else if (!this.destroyed) {
+      // usocket handle: SocketHandlers.data pushes unconditionally, so the
+      // native side must be paused explicitly (pre-existing behavior).
+      handle.pause?.();
     }
   }
   return Duplex.prototype.pause.$call(this);
 };
 
 Socket.prototype.resume = function resume() {
-  if (this[kBuffer] && !this.connecting && this._handle && !this._handle.reading) {
-    if ($isCallable(this._handle.readStart)) {
-      tryReadStart(this);
-    } else {
-      this._handle.reading = true;
-      this._handle.resume?.();
+  const handle = this._handle;
+  if (handle) {
+    if ($isCallable(handle.readStart)) {
+      if (this[kBuffer] && !this.connecting && !handle.reading) {
+        tryReadStart(this);
+      }
+    } else if (!this.connecting) {
+      handle.resume?.();
     }
   }
   return Duplex.prototype.resume.$call(this);
 };
 
 Socket.prototype.read = function read(size) {
-  if (this[kBuffer] && !this.connecting && this._handle && !this._handle.reading) {
-    if ($isCallable(this._handle.readStart)) {
-      tryReadStart(this);
-    } else {
-      this._handle.reading = true;
-      this._handle.resume?.();
+  const handle = this._handle;
+  if (handle) {
+    if ($isCallable(handle.readStart)) {
+      if (this[kBuffer] && !this.connecting && !handle.reading) {
+        tryReadStart(this);
+      }
+    } else if (!this.connecting) {
+      handle.resume?.();
     }
   }
   return Duplex.prototype.read.$call(this, size);
@@ -2639,23 +2651,26 @@ function initSocketHandle(self) {
 function onStreamRead(nread, arrayBuffer) {
   const self = this[owner_symbol];
   if (nread > 0) {
-    self.bytesRead += nread;
     let ret;
     if (self[kBuffer]) {
       // onread: {buffer, callback}. Node's native layer writes directly into
-      // the user buffer; copy from the handle's buffer so the callback
-      // receives the caller's buffer as documented.
+      // the user buffer so nread <= buffer.byteLength by construction; until
+      // native useUserBuffer lands we copy here, clamping nread to what fits
+      // so the callback's (nread, buf) contract holds.
       let userBuf = self[kBufferGen]();
+      let n = nread;
       if ($isTypedArrayView(userBuf)) {
         if (userBuf !== arrayBuffer) {
-          const n = nread < userBuf.byteLength ? nread : userBuf.byteLength;
+          if (n > userBuf.byteLength) n = userBuf.byteLength;
           userBuf.set(arrayBuffer.subarray(0, n));
         }
       } else {
         userBuf = arrayBuffer;
       }
-      ret = self[kBufferCb](nread, userBuf);
+      self.bytesRead += n;
+      ret = self[kBufferCb](n, userBuf);
     } else {
+      self.bytesRead += nread;
       ret = self.push(arrayBuffer);
     }
     if (ret === false && this.reading) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -62,6 +62,7 @@ const { owner_symbol } = require("internal/shared");
 const UV_EOF = -4095;
 const kBuffer = Symbol("kBuffer");
 const kBufferCb = Symbol("kBufferCb");
+const kBufferGen = Symbol("kBufferGen");
 
 const kServerSocket = Symbol("kServerSocket");
 const kBytesWritten = Symbol("kBytesWritten");
@@ -759,6 +760,7 @@ function Socket(options?) {
     }
     this[kBuffer] = true;
     this[kBufferCb] = onread.callback;
+    this[kBufferGen] = typeof onread.buffer === "function" ? onread.buffer : () => onread.buffer;
     // when the onread option is specified we use a different handlers object
     this[khandlers] = {
       ...SocketHandlers2,
@@ -2640,7 +2642,19 @@ function onStreamRead(nread, arrayBuffer) {
     self.bytesRead += nread;
     let ret;
     if (self[kBuffer]) {
-      ret = self[kBufferCb](nread, arrayBuffer);
+      // onread: {buffer, callback}. Node's native layer writes directly into
+      // the user buffer; copy from the handle's buffer so the callback
+      // receives the caller's buffer as documented.
+      let userBuf = self[kBufferGen]();
+      if ($isTypedArrayView(userBuf)) {
+        if (userBuf !== arrayBuffer) {
+          const n = nread < userBuf.byteLength ? nread : userBuf.byteLength;
+          userBuf.set(arrayBuffer.subarray(0, n));
+        }
+      } else {
+        userBuf = arrayBuffer;
+      }
+      ret = self[kBufferCb](nread, userBuf);
     } else {
       ret = self.push(arrayBuffer);
     }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2675,7 +2675,10 @@ function onStreamRead(nread, arrayBuffer) {
     }
     if (ret === false && this.reading) {
       this.reading = false;
-      this.readStop();
+      if (!self.destroyed) {
+        const err = this.readStop();
+        if (err) self.destroy(new ErrnoException(err, "read"));
+      }
     }
     return;
   }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -57,7 +57,12 @@ const getBufferedAmount = $newZigFunction("socket.zig", "jsGetBufferedAmount", 1
 
 const bunTlsSymbol = Symbol.for("::buntls::");
 const bunSocketServerOptions = Symbol.for("::bunnetserveroptions::");
-const owner_symbol = Symbol("owner_symbol");
+const { owner_symbol } = require("internal/shared");
+
+const UV_EOF = -4095;
+const kBuffer = Symbol("kBuffer");
+const kBufferCb = Symbol("kBufferCb");
+const kBufferGen = Symbol("kBufferGen");
 
 const kServerSocket = Symbol("kServerSocket");
 const kBytesWritten = Symbol("kBytesWritten");
@@ -81,7 +86,7 @@ const kwriteCallback = Symbol("writeCallback");
 const kSocketClass = Symbol("kSocketClass");
 
 function endNT(socket, callback, err) {
-  socket.$end();
+  socket.$end?.();
   callback(err);
 }
 function emitCloseNT(self, hasError) {
@@ -684,8 +689,6 @@ function Socket(options?) {
   Duplex.$call(this, {
     ...opts,
     allowHalfOpen,
-    readable: true,
-    writable: true,
     //For node.js compat do not emit close on destroy.
     emitClose: false,
     autoDestroy: true,
@@ -727,9 +730,22 @@ function Socket(options?) {
   // Shut down the socket when we're finished with it.
   this.on("end", onSocketEnd);
 
-  if (options?.fd !== undefined) {
+  if (options?.handle != null) {
+    this._handle = options.handle;
+    initSocketHandle(this);
+  } else if (options?.fd !== undefined) {
     const { fd } = options;
     validateInt32(fd, "fd", 0);
+  }
+
+  if (this._handle && $isCallable(this._handle.readStart) && options.readable !== false) {
+    if (options.pauseOnCreate) {
+      this._handle.reading = false;
+      this._handle.readStop();
+      this._readableState.flowing = false;
+    } else if (!options.manualStart) {
+      this.read(0);
+    }
   }
 
   if (socket instanceof Socket) {
@@ -742,6 +758,9 @@ function Socket(options?) {
     if (typeof onread.callback !== "function") {
       throw new TypeError("onread.callback must be a function");
     }
+    this[kBuffer] = true;
+    this[kBufferCb] = onread.callback;
+    this[kBufferGen] = typeof onread.buffer === "function" ? onread.buffer : () => onread.buffer;
     // when the onread option is specified we use a different handlers object
     this[khandlers] = {
       ...SocketHandlers2,
@@ -789,7 +808,7 @@ Socket.prototype._onTimeout = function () {
   const handle = this._handle;
   // if there is a handle, and it has pending data,
   // we suppress the timeout because a write is in progress
-  if (handle && getBufferedAmount(handle) > 0) {
+  if (handle && !$isCallable(handle.readStart) && getBufferedAmount(handle) > 0) {
     return;
   }
   this.emit("timeout");
@@ -1201,23 +1220,39 @@ Object.defineProperty(Socket.prototype, "pending", {
   },
 });
 
-Socket.prototype.resume = function resume() {
-  if (!this.connecting) {
-    this._handle?.resume();
-  }
-  return Duplex.prototype.resume.$call(this);
-};
-
 Socket.prototype.pause = function pause() {
-  if (!this.destroyed) {
-    this._handle?.pause();
+  if (this[kBuffer] && !this.connecting && this._handle && $isCallable(this._handle.readStop) && this._handle.reading) {
+    this._handle.reading = false;
+    if (!this.destroyed) {
+      const err = this._handle.readStop();
+      if (err) this.destroy(new ErrnoException(err, "read"));
+    }
   }
   return Duplex.prototype.pause.$call(this);
 };
 
+Socket.prototype.resume = function resume() {
+  if (
+    this[kBuffer] &&
+    !this.connecting &&
+    this._handle &&
+    $isCallable(this._handle.readStart) &&
+    !this._handle.reading
+  ) {
+    tryReadStart(this);
+  }
+  return Duplex.prototype.resume.$call(this);
+};
+
 Socket.prototype.read = function read(size) {
-  if (!this.connecting) {
-    this._handle?.resume();
+  if (
+    this[kBuffer] &&
+    !this.connecting &&
+    this._handle &&
+    $isCallable(this._handle.readStart) &&
+    !this._handle.reading
+  ) {
+    tryReadStart(this);
   }
   return Duplex.prototype.read.$call(this, size);
 };
@@ -1226,8 +1261,10 @@ Socket.prototype._read = function _read(size) {
   const socket = this._handle;
   if (this.connecting || !socket) {
     this.once("connect", () => this._read(size));
+  } else if ($isCallable(socket.readStart)) {
+    if (!socket.reading) tryReadStart(this);
   } else {
-    socket?.resume();
+    socket?.resume?.();
   }
 };
 
@@ -1460,6 +1497,13 @@ Socket.prototype._write = function _write(chunk, encoding, callback) {
     return false;
   }
   this._unrefTimer();
+  if ($isCallable(socket.readStart)) {
+    // Stream-wrap handle (TTY/Pipe). Full writeBuffer/req plumbing is a
+    // follow-up; reachable only for duplex net.Socket({fd}), never for
+    // process.stdin which is constructed with writable:false.
+    callback($ERR_METHOD_NOT_IMPLEMENTED("_write on stream-wrap handle"));
+    return false;
+  }
   const success = socket.$write(chunk, encoding);
   this[kBytesWritten] = socket.bytesWritten;
   if (success) {
@@ -2580,7 +2624,42 @@ function initSocketHandle(self) {
   // Handle creation may be deferred to bind() or connect() time.
   if (self._handle) {
     self._handle[owner_symbol] = self;
+    if ($isCallable(self._handle.readStart)) {
+      self._handle.onread = onStreamRead;
+    }
   }
+}
+
+// Node lib/internal/stream_base_commons.js onStreamRead.
+function onStreamRead(nread, arrayBuffer) {
+  const self = this[owner_symbol];
+  if (nread > 0) {
+    self.bytesRead += nread;
+    let ret;
+    if (self[kBuffer]) {
+      ret = self[kBufferCb](nread, arrayBuffer);
+    } else {
+      ret = self.push(arrayBuffer);
+    }
+    if (ret === false && this.reading) {
+      this.reading = false;
+      this.readStop();
+    }
+    return;
+  }
+  if (nread === 0) return;
+  if (nread !== UV_EOF) {
+    self.destroy(new ErrnoException(nread, "read"));
+    return;
+  }
+  self.push(null);
+  self.read(0);
+}
+
+function tryReadStart(socket) {
+  socket._handle.reading = true;
+  const err = socket._handle.readStart();
+  if (err) socket.destroy(new ErrnoException(err, "read"));
 }
 
 function closeSocketHandle(self, isException, isCleanupPending = false) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -62,7 +62,6 @@ const { owner_symbol } = require("internal/shared");
 const UV_EOF = -4095;
 const kBuffer = Symbol("kBuffer");
 const kBufferCb = Symbol("kBufferCb");
-const kBufferGen = Symbol("kBufferGen");
 
 const kServerSocket = Symbol("kServerSocket");
 const kBytesWritten = Symbol("kBytesWritten");
@@ -761,7 +760,6 @@ function Socket(options?) {
     }
     this[kBuffer] = true;
     this[kBufferCb] = onread.callback;
-    this[kBufferGen] = typeof onread.buffer === "function" ? onread.buffer : () => onread.buffer;
     // when the onread option is specified we use a different handlers object
     this[khandlers] = {
       ...SocketHandlers2,
@@ -1227,38 +1225,43 @@ Object.defineProperty(Socket.prototype, "pending", {
 });
 
 Socket.prototype.pause = function pause() {
-  if (this[kBuffer] && !this.connecting && this._handle && $isCallable(this._handle.readStop) && this._handle.reading) {
+  if (this[kBuffer] && !this.connecting && this._handle && this._handle.reading !== false) {
     this._handle.reading = false;
     if (!this.destroyed) {
-      const err = this._handle.readStop();
-      if (err) this.destroy(new ErrnoException(err, "read"));
+      if ($isCallable(this._handle.readStop)) {
+        const err = this._handle.readStop();
+        if (err) this.destroy(new ErrnoException(err, "read"));
+      } else {
+        // usocket-backed handle in onread mode: keep the pre-existing native
+        // pause, since SocketHandlers.data's onread variant does not apply
+        // backpressure on its own.
+        this._handle.pause?.();
+      }
     }
   }
   return Duplex.prototype.pause.$call(this);
 };
 
 Socket.prototype.resume = function resume() {
-  if (
-    this[kBuffer] &&
-    !this.connecting &&
-    this._handle &&
-    $isCallable(this._handle.readStart) &&
-    !this._handle.reading
-  ) {
-    tryReadStart(this);
+  if (this[kBuffer] && !this.connecting && this._handle && !this._handle.reading) {
+    if ($isCallable(this._handle.readStart)) {
+      tryReadStart(this);
+    } else {
+      this._handle.reading = true;
+      this._handle.resume?.();
+    }
   }
   return Duplex.prototype.resume.$call(this);
 };
 
 Socket.prototype.read = function read(size) {
-  if (
-    this[kBuffer] &&
-    !this.connecting &&
-    this._handle &&
-    $isCallable(this._handle.readStart) &&
-    !this._handle.reading
-  ) {
-    tryReadStart(this);
+  if (this[kBuffer] && !this.connecting && this._handle && !this._handle.reading) {
+    if ($isCallable(this._handle.readStart)) {
+      tryReadStart(this);
+    } else {
+      this._handle.reading = true;
+      this._handle.resume?.();
+    }
   }
   return Duplex.prototype.read.$call(this, size);
 };

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -62,6 +62,7 @@ const { owner_symbol } = require("internal/shared");
 const UV_EOF = -4095;
 const kBuffer = Symbol("kBuffer");
 const kBufferCb = Symbol("kBufferCb");
+const kBufferGen = Symbol("kBufferGen");
 
 const kServerSocket = Symbol("kServerSocket");
 const kBytesWritten = Symbol("kBytesWritten");
@@ -760,6 +761,7 @@ function Socket(options?) {
     }
     this[kBuffer] = true;
     this[kBufferCb] = onread.callback;
+    this[kBufferGen] = typeof onread.buffer === "function" ? onread.buffer : () => onread.buffer;
     // when the onread option is specified we use a different handlers object
     this[khandlers] = {
       ...SocketHandlers2,
@@ -2648,7 +2650,19 @@ function onStreamRead(nread, arrayBuffer) {
     self.bytesRead += nread;
     let ret;
     if (self[kBuffer]) {
-      ret = self[kBufferCb](nread, arrayBuffer);
+      // onread: {buffer, callback}. Node's native layer writes directly into
+      // the user buffer; copy from the handle's buffer so the callback
+      // receives the caller's buffer as documented.
+      let userBuf = self[kBufferGen]();
+      if ($isTypedArrayView(userBuf)) {
+        if (userBuf !== arrayBuffer) {
+          const n = nread < userBuf.byteLength ? nread : userBuf.byteLength;
+          userBuf.set(arrayBuffer.subarray(0, n));
+        }
+      } else {
+        userBuf = arrayBuffer;
+      }
+      ret = self[kBufferCb](nread, userBuf);
     } else {
       ret = self.push(arrayBuffer);
     }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1236,7 +1236,7 @@ Socket.prototype.pause = function pause() {
       // stream-wrap handle: only drive readStop directly in onread mode —
       // otherwise Duplex.pause stops _read which stops readStart (Node's
       // lib/net.js kBuffer gating).
-      if (this[kBuffer] && !this.connecting && handle.reading !== false) {
+      if (this[kBuffer] && !this.connecting && handle.reading) {
         handle.reading = false;
         if (!this.destroyed) {
           const err = handle.readStop();

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2683,7 +2683,10 @@ function onStreamRead(nread, arrayBuffer) {
     }
     if (ret === false && this.reading) {
       this.reading = false;
-      this.readStop();
+      if (!self.destroyed) {
+        const err = this.readStop();
+        if (err) self.destroy(new ErrnoException(err, "read"));
+      }
     }
     return;
   }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -57,7 +57,12 @@ const getBufferedAmount = $newZigFunction("runtime/socket/socket.zig", "jsGetBuf
 
 const bunTlsSymbol = Symbol.for("::buntls::");
 const bunSocketServerOptions = Symbol.for("::bunnetserveroptions::");
-const owner_symbol = Symbol("owner_symbol");
+const { owner_symbol } = require("internal/shared");
+
+const UV_EOF = -4095;
+const kBuffer = Symbol("kBuffer");
+const kBufferCb = Symbol("kBufferCb");
+const kBufferGen = Symbol("kBufferGen");
 
 const kServerSocket = Symbol("kServerSocket");
 const kBytesWritten = Symbol("kBytesWritten");
@@ -81,7 +86,7 @@ const kwriteCallback = Symbol("writeCallback");
 const kSocketClass = Symbol("kSocketClass");
 
 function endNT(socket, callback, err) {
-  socket.$end();
+  socket.$end?.();
   callback(err);
 }
 function emitCloseNT(self, hasError) {
@@ -685,8 +690,6 @@ function Socket(options?) {
   Duplex.$call(this, {
     ...opts,
     allowHalfOpen,
-    readable: true,
-    writable: true,
     //For node.js compat do not emit close on destroy.
     emitClose: false,
     autoDestroy: true,
@@ -728,9 +731,22 @@ function Socket(options?) {
   // Shut down the socket when we're finished with it.
   this.on("end", onSocketEnd);
 
-  if (options?.fd !== undefined) {
+  if (options?.handle != null) {
+    this._handle = options.handle;
+    initSocketHandle(this);
+  } else if (options?.fd !== undefined) {
     const { fd } = options;
     validateInt32(fd, "fd", 0);
+  }
+
+  if (this._handle && $isCallable(this._handle.readStart) && options.readable !== false) {
+    if (options.pauseOnCreate) {
+      this._handle.reading = false;
+      this._handle.readStop();
+      this._readableState.flowing = false;
+    } else if (!options.manualStart) {
+      this.read(0);
+    }
   }
 
   if (socket instanceof Socket) {
@@ -743,6 +759,9 @@ function Socket(options?) {
     if (typeof onread.callback !== "function") {
       throw new TypeError("onread.callback must be a function");
     }
+    this[kBuffer] = true;
+    this[kBufferCb] = onread.callback;
+    this[kBufferGen] = typeof onread.buffer === "function" ? onread.buffer : () => onread.buffer;
     // when the onread option is specified we use a different handlers object
     this[khandlers] = {
       ...SocketHandlers2,
@@ -792,7 +811,7 @@ Socket.prototype._onTimeout = function () {
   const handle = this._handle;
   // if there is a handle, and it has pending data,
   // we suppress the timeout because a write is in progress
-  if (handle && getBufferedAmount(handle) > 0) {
+  if (handle && !$isCallable(handle.readStart) && getBufferedAmount(handle) > 0) {
     return;
   }
   this.emit("timeout");
@@ -1207,23 +1226,39 @@ Object.defineProperty(Socket.prototype, "pending", {
   },
 });
 
-Socket.prototype.resume = function resume() {
-  if (!this.connecting) {
-    this._handle?.resume();
-  }
-  return Duplex.prototype.resume.$call(this);
-};
-
 Socket.prototype.pause = function pause() {
-  if (!this.destroyed) {
-    this._handle?.pause();
+  if (this[kBuffer] && !this.connecting && this._handle && $isCallable(this._handle.readStop) && this._handle.reading) {
+    this._handle.reading = false;
+    if (!this.destroyed) {
+      const err = this._handle.readStop();
+      if (err) this.destroy(new ErrnoException(err, "read"));
+    }
   }
   return Duplex.prototype.pause.$call(this);
 };
 
+Socket.prototype.resume = function resume() {
+  if (
+    this[kBuffer] &&
+    !this.connecting &&
+    this._handle &&
+    $isCallable(this._handle.readStart) &&
+    !this._handle.reading
+  ) {
+    tryReadStart(this);
+  }
+  return Duplex.prototype.resume.$call(this);
+};
+
 Socket.prototype.read = function read(size) {
-  if (!this.connecting) {
-    this._handle?.resume();
+  if (
+    this[kBuffer] &&
+    !this.connecting &&
+    this._handle &&
+    $isCallable(this._handle.readStart) &&
+    !this._handle.reading
+  ) {
+    tryReadStart(this);
   }
   return Duplex.prototype.read.$call(this, size);
 };
@@ -1232,8 +1267,10 @@ Socket.prototype._read = function _read(size) {
   const socket = this._handle;
   if (this.connecting || !socket) {
     this.once("connect", () => this._read(size));
+  } else if ($isCallable(socket.readStart)) {
+    if (!socket.reading) tryReadStart(this);
   } else {
-    socket?.resume();
+    socket?.resume?.();
   }
 };
 
@@ -1466,6 +1503,13 @@ Socket.prototype._write = function _write(chunk, encoding, callback) {
     return false;
   }
   this._unrefTimer();
+  if ($isCallable(socket.readStart)) {
+    // Stream-wrap handle (TTY/Pipe). Full writeBuffer/req plumbing is a
+    // follow-up; reachable only for duplex net.Socket({fd}), never for
+    // process.stdin which is constructed with writable:false.
+    callback($ERR_METHOD_NOT_IMPLEMENTED("_write on stream-wrap handle"));
+    return false;
+  }
   const success = socket.$write(chunk, encoding);
   this[kBytesWritten] = socket.bytesWritten;
   if (success) {
@@ -2588,7 +2632,42 @@ function initSocketHandle(self) {
   // Handle creation may be deferred to bind() or connect() time.
   if (self._handle) {
     self._handle[owner_symbol] = self;
+    if ($isCallable(self._handle.readStart)) {
+      self._handle.onread = onStreamRead;
+    }
   }
+}
+
+// Node lib/internal/stream_base_commons.js onStreamRead.
+function onStreamRead(nread, arrayBuffer) {
+  const self = this[owner_symbol];
+  if (nread > 0) {
+    self.bytesRead += nread;
+    let ret;
+    if (self[kBuffer]) {
+      ret = self[kBufferCb](nread, arrayBuffer);
+    } else {
+      ret = self.push(arrayBuffer);
+    }
+    if (ret === false && this.reading) {
+      this.reading = false;
+      this.readStop();
+    }
+    return;
+  }
+  if (nread === 0) return;
+  if (nread !== UV_EOF) {
+    self.destroy(new ErrnoException(nread, "read"));
+    return;
+  }
+  self.push(null);
+  self.read(0);
+}
+
+function tryReadStart(socket) {
+  socket._handle.reading = true;
+  const err = socket._handle.readStart();
+  if (err) socket.destroy(new ErrnoException(err, "read"));
 }
 
 function closeSocketHandle(self, isException, isCleanupPending = false) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -739,19 +739,11 @@ function Socket(options?) {
     validateInt32(fd, "fd", 0);
   }
 
-  if (this._handle && $isCallable(this._handle.readStart) && options.readable !== false) {
-    if (options.pauseOnCreate) {
-      this._handle.reading = false;
-      this._handle.readStop();
-      this._readableState.flowing = false;
-    } else if (!options.manualStart) {
-      this.read(0);
-    }
-  }
-
   if (socket instanceof Socket) {
     this[ksocket] = socket;
   }
+  // onread must be set up before the read(0) below — a handle's readStart
+  // can fire onread synchronously, and onStreamRead routes on kBuffer.
   if (onread) {
     if (typeof onread !== "object") {
       throw new TypeError("onread must be an object");
@@ -776,6 +768,17 @@ function Socket(options?) {
         }
       },
     };
+  }
+
+  if (this._handle && $isCallable(this._handle.readStart) && options.readable !== false) {
+    if (options.pauseOnCreate) {
+      this._handle.reading = false;
+      const err = this._handle.readStop();
+      if (err) this.destroy(new ErrnoException(err, "read"));
+      this._readableState.flowing = false;
+    } else if (!options.manualStart) {
+      this.read(0);
+    }
   }
   if (signal) {
     if (signal.aborted) {
@@ -1227,42 +1230,51 @@ Object.defineProperty(Socket.prototype, "pending", {
 });
 
 Socket.prototype.pause = function pause() {
-  if (this[kBuffer] && !this.connecting && this._handle && this._handle.reading !== false) {
-    this._handle.reading = false;
-    if (!this.destroyed) {
-      if ($isCallable(this._handle.readStop)) {
-        const err = this._handle.readStop();
-        if (err) this.destroy(new ErrnoException(err, "read"));
-      } else {
-        // usocket-backed handle in onread mode: keep the pre-existing native
-        // pause, since SocketHandlers.data's onread variant does not apply
-        // backpressure on its own.
-        this._handle.pause?.();
+  const handle = this._handle;
+  if (handle) {
+    if ($isCallable(handle.readStop)) {
+      // stream-wrap handle: only drive readStop directly in onread mode —
+      // otherwise Duplex.pause stops _read which stops readStart (Node's
+      // lib/net.js kBuffer gating).
+      if (this[kBuffer] && !this.connecting && handle.reading !== false) {
+        handle.reading = false;
+        if (!this.destroyed) {
+          const err = handle.readStop();
+          if (err) this.destroy(new ErrnoException(err, "read"));
+        }
       }
+    } else if (!this.destroyed) {
+      // usocket handle: SocketHandlers.data pushes unconditionally, so the
+      // native side must be paused explicitly (pre-existing behavior).
+      handle.pause?.();
     }
   }
   return Duplex.prototype.pause.$call(this);
 };
 
 Socket.prototype.resume = function resume() {
-  if (this[kBuffer] && !this.connecting && this._handle && !this._handle.reading) {
-    if ($isCallable(this._handle.readStart)) {
-      tryReadStart(this);
-    } else {
-      this._handle.reading = true;
-      this._handle.resume?.();
+  const handle = this._handle;
+  if (handle) {
+    if ($isCallable(handle.readStart)) {
+      if (this[kBuffer] && !this.connecting && !handle.reading) {
+        tryReadStart(this);
+      }
+    } else if (!this.connecting) {
+      handle.resume?.();
     }
   }
   return Duplex.prototype.resume.$call(this);
 };
 
 Socket.prototype.read = function read(size) {
-  if (this[kBuffer] && !this.connecting && this._handle && !this._handle.reading) {
-    if ($isCallable(this._handle.readStart)) {
-      tryReadStart(this);
-    } else {
-      this._handle.reading = true;
-      this._handle.resume?.();
+  const handle = this._handle;
+  if (handle) {
+    if ($isCallable(handle.readStart)) {
+      if (this[kBuffer] && !this.connecting && !handle.reading) {
+        tryReadStart(this);
+      }
+    } else if (!this.connecting) {
+      handle.resume?.();
     }
   }
   return Duplex.prototype.read.$call(this, size);
@@ -2647,23 +2659,26 @@ function initSocketHandle(self) {
 function onStreamRead(nread, arrayBuffer) {
   const self = this[owner_symbol];
   if (nread > 0) {
-    self.bytesRead += nread;
     let ret;
     if (self[kBuffer]) {
       // onread: {buffer, callback}. Node's native layer writes directly into
-      // the user buffer; copy from the handle's buffer so the callback
-      // receives the caller's buffer as documented.
+      // the user buffer so nread <= buffer.byteLength by construction; until
+      // native useUserBuffer lands we copy here, clamping nread to what fits
+      // so the callback's (nread, buf) contract holds.
       let userBuf = self[kBufferGen]();
+      let n = nread;
       if ($isTypedArrayView(userBuf)) {
         if (userBuf !== arrayBuffer) {
-          const n = nread < userBuf.byteLength ? nread : userBuf.byteLength;
+          if (n > userBuf.byteLength) n = userBuf.byteLength;
           userBuf.set(arrayBuffer.subarray(0, n));
         }
       } else {
         userBuf = arrayBuffer;
       }
-      ret = self[kBufferCb](nread, userBuf);
+      self.bytesRead += n;
+      ret = self[kBufferCb](n, userBuf);
     } else {
+      self.bytesRead += nread;
       ret = self.push(arrayBuffer);
     }
     if (ret === false && this.reading) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2658,6 +2658,7 @@ function initSocketHandle(self) {
 // Node lib/internal/stream_base_commons.js onStreamRead.
 function onStreamRead(nread, arrayBuffer) {
   const self = this[owner_symbol];
+  self._unrefTimer();
   if (nread > 0) {
     let ret;
     if (self[kBuffer]) {
@@ -2679,7 +2680,10 @@ function onStreamRead(nread, arrayBuffer) {
       ret = self[kBufferCb](n, userBuf);
     } else {
       self.bytesRead += nread;
-      ret = self.push(arrayBuffer);
+      // The handle reports how many bytes it actually wrote into arrayBuffer,
+      // which may be smaller than the buffer it allocated (libuv's read-callback
+      // contract). Push exactly nread bytes, mirroring Node's stream_base_commons.
+      ret = self.push(nread < arrayBuffer.length ? arrayBuffer.subarray(0, nread) : arrayBuffer);
     }
     if (ret === false && this.reading) {
       this.reading = false;

--- a/src/runtime/node/node_util_binding.rs
+++ b/src/runtime/node/node_util_binding.rs
@@ -284,6 +284,11 @@ fn guess_handle_type_from_fd(fd_int: i32) -> u32 {
     }
 
     let family = ss.ss_family as libc::c_int;
+    // libuv checks AF_UNIX before SO_TYPE and returns UV_NAMED_PIPE for any
+    // AF_UNIX socket (STREAM/DGRAM/SEQPACKET).
+    if family == libc::AF_UNIX {
+        return GHT_PIPE;
+    }
     if so_type == libc::SOCK_DGRAM {
         if family == libc::AF_INET || family == libc::AF_INET6 {
             return GHT_UDP;
@@ -293,9 +298,6 @@ fn guess_handle_type_from_fd(fd_int: i32) -> u32 {
     if so_type == libc::SOCK_STREAM {
         if family == libc::AF_INET || family == libc::AF_INET6 {
             return GHT_TCP;
-        }
-        if family == libc::AF_UNIX {
-            return GHT_PIPE;
         }
     }
     GHT_UNKNOWN

--- a/src/runtime/node/node_util_binding.rs
+++ b/src/runtime/node/node_util_binding.rs
@@ -258,28 +258,38 @@ fn guess_handle_type_from_fd(fd_int: i32) -> u32 {
         return GHT_UNKNOWN;
     }
 
-    // SAFETY: `fd` refers to a socket (checked via S_ISSOCK above). `getsockname`
-    // and `getsockopt` fill `ss`/`so_type` and never read uninitialised memory we
-    // pass; we check the return code before reading the output.
     let mut ss: libc::sockaddr_storage = bun_core::ffi::zeroed();
     let mut ss_len: libc::socklen_t =
         core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
-    if unsafe { libc::getsockname(fd_int, core::ptr::from_mut(&mut ss).cast(), &mut ss_len) } != 0 {
+    // SAFETY: `fd` refers to a socket (checked via S_ISSOCK above). `getsockname`
+    // fills `ss`/`ss_len` and never reads uninitialised memory we pass; we check
+    // the return code before reading the output.
+    let rc = unsafe {
+        libc::getsockname(
+            fd_int,
+            core::ptr::from_mut(&mut ss).cast(),
+            core::ptr::from_mut(&mut ss_len),
+        )
+    };
+    if rc != 0 {
         return GHT_UNKNOWN;
     }
 
     let mut so_type: libc::c_int = 0;
     let mut so_type_len: libc::socklen_t = core::mem::size_of::<libc::c_int>() as libc::socklen_t;
-    if unsafe {
+    // SAFETY: `fd` refers to a socket. `getsockopt` fills `so_type`/`so_type_len`
+    // and never reads uninitialised memory we pass; we check the return code
+    // before reading the output.
+    let rc = unsafe {
         libc::getsockopt(
             fd_int,
             libc::SOL_SOCKET,
             libc::SO_TYPE,
             core::ptr::from_mut(&mut so_type).cast(),
-            &mut so_type_len,
+            core::ptr::from_mut(&mut so_type_len),
         )
-    } != 0
-    {
+    };
+    if rc != 0 {
         return GHT_UNKNOWN;
     }
 

--- a/test/js/node/net/socket-handle-option.test.ts
+++ b/test/js/node/net/socket-handle-option.test.ts
@@ -44,3 +44,52 @@ test("net.Socket({handle, manualStart}) drives onStreamRead", async () => {
   expect(socket.bytesRead).toBe(5);
   expect(socket.writable).toBe(false);
 });
+
+// onread: {buffer, callback} must deliver the caller's buffer to the
+// callback, not the handle's internal buffer.
+test("net.Socket({handle, onread}) passes user buffer to callback", async () => {
+  let onread;
+  const handle = {
+    readStart() {
+      return 0;
+    },
+    readStop() {
+      return 0;
+    },
+    close() {},
+    set onread(fn) {
+      onread = fn;
+    },
+    get onread() {
+      return onread;
+    },
+    reading: false,
+  };
+
+  const userBuf = Buffer.alloc(16);
+  const calls: { nread: number; buf: Buffer }[] = [];
+  const socket = new Socket({
+    handle,
+    manualStart: true,
+    writable: false,
+    onread: {
+      buffer: userBuf,
+      callback(nread, buf) {
+        calls.push({ nread, buf });
+      },
+    },
+  });
+  socket.read(0);
+
+  const handleBuf = Buffer.from("hello");
+  onread.call(handle, 5, handleBuf);
+  onread.call(handle, -4095, undefined); // UV_EOF
+
+  await new Promise(resolve => socket.on("end", resolve));
+
+  expect(calls.length).toBe(1);
+  expect(calls[0].nread).toBe(5);
+  expect(calls[0].buf).toBe(userBuf); // identity, not the handle's buffer
+  expect(calls[0].buf).not.toBe(handleBuf);
+  expect(userBuf.subarray(0, 5).toString()).toBe("hello");
+});

--- a/test/js/node/net/socket-handle-option.test.ts
+++ b/test/js/node/net/socket-handle-option.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import { Socket } from "node:net";
+
+// new Socket({handle, manualStart}) wires _handle.onread = onStreamRead and
+// drives reads via readStart/readStop (Node's stream-wrap contract). The
+// handle here is a JS mock — the native TTY/Pipe handles ship in follow-ups.
+test("net.Socket({handle, manualStart}) drives onStreamRead", async () => {
+  let onread;
+  let readStartCalls = 0;
+  const handle = {
+    readStart() {
+      readStartCalls++;
+      return 0;
+    },
+    readStop() {
+      return 0;
+    },
+    close() {},
+    set onread(fn) {
+      onread = fn;
+    },
+    get onread() {
+      return onread;
+    },
+    reading: false,
+  };
+
+  const socket = new Socket({ handle, manualStart: true, writable: false });
+  expect(socket._handle).toBe(handle);
+  expect(typeof onread).toBe("function");
+  expect(readStartCalls).toBe(0); // manualStart
+
+  const chunks: Buffer[] = [];
+  socket.on("data", c => chunks.push(c));
+  await Bun.sleep(0);
+  expect(readStartCalls).toBe(1); // _read → tryReadStart
+
+  onread.call(handle, 5, Buffer.from("hello"));
+  onread.call(handle, -4095, undefined); // UV_EOF
+
+  await new Promise(resolve => socket.on("end", resolve));
+
+  expect(Buffer.concat(chunks).toString()).toBe("hello");
+  expect(socket.bytesRead).toBe(5);
+  expect(socket.writable).toBe(false);
+});

--- a/test/js/node/net/socket-handle-option.test.ts
+++ b/test/js/node/net/socket-handle-option.test.ts
@@ -93,3 +93,41 @@ test("net.Socket({handle, onread}) passes user buffer to callback", async () => 
   expect(calls[0].buf).not.toBe(handleBuf);
   expect(userBuf.subarray(0, 5).toString()).toBe("hello");
 });
+
+// nread reported to the onread callback must not exceed the user buffer's
+// capacity — callers do buf.subarray(0, nread).
+test("net.Socket({handle, onread}) clamps nread to user buffer", async () => {
+  let onread;
+  const handle = {
+    readStart: () => 0,
+    readStop: () => 0,
+    close() {},
+    set onread(fn) {
+      onread = fn;
+    },
+    get onread() {
+      return onread;
+    },
+    reading: false,
+  };
+
+  const userBuf = Buffer.alloc(4);
+  const calls: { nread: number; buf: Buffer }[] = [];
+  const socket = new Socket({
+    handle,
+    manualStart: true,
+    writable: false,
+    onread: { buffer: userBuf, callback: (nread, buf) => calls.push({ nread, buf }) },
+  });
+  socket.read(0);
+
+  onread.call(handle, 10, Buffer.from("0123456789"));
+  onread.call(handle, -4095, undefined); // UV_EOF
+  await new Promise(resolve => socket.on("end", resolve));
+
+  expect(calls.length).toBe(1);
+  expect(calls[0].buf).toBe(userBuf);
+  expect(calls[0].nread).toBe(4);
+  expect(userBuf.toString()).toBe("0123");
+  expect(socket.bytesRead).toBe(4);
+});

--- a/test/js/node/net/socket-handle-option.test.ts
+++ b/test/js/node/net/socket-handle-option.test.ts
@@ -131,3 +131,77 @@ test("net.Socket({handle, onread}) clamps nread to user buffer", async () => {
   expect(userBuf.toString()).toBe("0123");
   expect(socket.bytesRead).toBe(4);
 });
+
+// Without the onread option the data path pushes straight to the stream. The
+// handle may report fewer bytes than the buffer it allocated (libuv's
+// read-callback contract), so the pushed chunk must be sliced to nread —
+// otherwise trailing garbage leaks into 'data' and bytesRead disagrees.
+test("net.Socket({handle}) pushes only nread bytes of an oversized buffer", async () => {
+  let onread;
+  const handle = {
+    readStart: () => 0,
+    readStop: () => 0,
+    close() {},
+    set onread(fn) {
+      onread = fn;
+    },
+    get onread() {
+      return onread;
+    },
+    reading: false,
+  };
+
+  const socket = new Socket({ handle, manualStart: true, writable: false });
+  const chunks: Buffer[] = [];
+  socket.on("data", c => chunks.push(c));
+  socket.read(0);
+
+  // 100-byte buffer, only 5 bytes actually read.
+  const buf = Buffer.alloc(100);
+  buf.write("hello");
+  onread.call(handle, 5, buf);
+  onread.call(handle, -4095, undefined); // UV_EOF
+
+  await new Promise(resolve => socket.on("end", resolve));
+
+  const received = Buffer.concat(chunks);
+  expect(received.length).toBe(5);
+  expect(received.toString()).toBe("hello");
+  expect(socket.bytesRead).toBe(5);
+});
+
+// Node's onStreamRead refreshes the idle timer on every invocation
+// (stream[kUpdateTimer]()), so a socket actively receiving data does not fire
+// 'timeout'. The port must do the same via _unrefTimer().
+test("net.Socket({handle}) refreshes the idle timer on incoming data", async () => {
+  let onread;
+  const handle = {
+    readStart: () => 0,
+    readStop: () => 0,
+    close() {},
+    set onread(fn) {
+      onread = fn;
+    },
+    get onread() {
+      return onread;
+    },
+    reading: false,
+  };
+
+  const socket = new Socket({ handle, manualStart: true, writable: false });
+  let unrefTimerCalls = 0;
+  const original = socket._unrefTimer.bind(socket);
+  socket._unrefTimer = function () {
+    unrefTimerCalls++;
+    return original();
+  };
+
+  socket.on("data", () => {});
+  socket.read(0);
+
+  onread.call(handle, 5, Buffer.from("hello"));
+  expect(unrefTimerCalls).toBeGreaterThanOrEqual(1);
+
+  onread.call(handle, -4095, undefined); // UV_EOF
+  await new Promise(resolve => socket.on("end", resolve));
+});

--- a/test/js/node/net/socket-handle-option.test.ts
+++ b/test/js/node/net/socket-handle-option.test.ts
@@ -205,3 +205,40 @@ test("net.Socket({handle}) refreshes the idle timer on incoming data", async () 
   onread.call(handle, -4095, undefined); // UV_EOF
   await new Promise(resolve => socket.on("end", resolve));
 });
+
+// pause() gates readStop on a truthy handle.reading, matching Node's lib/net.js
+// and staying symmetric with resume()/read() (which gate on !handle.reading).
+// A handle that has never started reading (no `reading` property) must not be
+// readStop()'d by an early pause().
+test("net.Socket({handle}) pause() does not readStop a never-started handle", async () => {
+  let onread;
+  let readStopCalls = 0;
+  // Note: no `reading` property — so handle.reading is undefined.
+  const handle = {
+    readStart: () => 0,
+    readStop() {
+      readStopCalls++;
+      return 0;
+    },
+    close() {},
+    set onread(fn) {
+      onread = fn;
+    },
+    get onread() {
+      return onread;
+    },
+  };
+
+  const socket = new Socket({
+    handle,
+    manualStart: true,
+    writable: false,
+    onread: { buffer: Buffer.alloc(16), callback() {} },
+  });
+  expect(handle.reading).toBeUndefined();
+
+  socket.pause();
+  expect(readStopCalls).toBe(0); // reading was never started
+
+  socket.destroy();
+});


### PR DESCRIPTION
Part **2/5** of the `process.stdin` Node-parity stack (#29126). Stacked on #29137.

Adds `net.Socket({handle, manualStart})` support per Node's stream-wrap contract:

- Constructor accepts `{handle, manualStart, pauseOnCreate}`; `initSocketHandle` wires `_handle.onread = onStreamRead` when `readStart` is callable
- `onStreamRead(nread, buf)`: `nread>0` → push, `UV_EOF` → push(null), `<0` → destroy
- `pause`/`resume`/`read` are `kBuffer`-gated (Node's `lib/net.js` pattern) — usocket backpressure is independently handled by `SocketHandlers.data` + `_read`
- `_read` branches on `readStart` → `tryReadStart`
- Drops hardcoded `readable:true, writable:true` so `{writable:false}` is honored
- `owner_symbol` moves to `internal/shared`

Tested with a JS mock handle (the native `TTY`/`Pipe` handles arrive in parts 3/4). net/stdin/readline/stream suites: 143 pass / 0 fail (3 net failures pre-existing on system bun).

Stack:
- A: `guessHandleType` (#29137)
- **→ B: this PR**
- C: native `TTY` handle + `tty.ReadStream extends net.Socket`
- D: native `Pipe` handle + `createHandle`
- E: Pipe `writeBuffer`/`shutdown`