### PR TITLE
tty: native TTY handle, ReadStream extends net.Socket

### DIFF
--- a/src/bun.js/bindings/ProcessBindingTTYWrap.cpp
+++ b/src/bun.js/bindings/ProcessBindingTTYWrap.cpp
@@ -1,6 +1,5 @@
 #include "root.h"
 
-#include "JavaScriptCore/JSDestructibleObject.h"
 #include "JavaScriptCore/ExceptionScope.h"
 #include "JavaScriptCore/Identifier.h"
 
@@ -27,31 +26,8 @@
 #endif
 
 #if OS(WINDOWS)
-
 extern "C" int Source__setRawModeStdin(bool raw);
-
-namespace UV {
-
-class TTY {
-public:
-    uv_tty_t handle {};
-
-    uv_tty_t* tty() { return &handle; }
-
-    void close()
-    {
-        uv_close((uv_handle_t*)(tty()), [](uv_handle_t* handle) -> void {
-            uv_tty_t* ttyHandle = (uv_tty_t*)handle;
-            ptrdiff_t offset = offsetof(UV::TTY, handle);
-
-            UV::TTY* tty = (UV::TTY*)((char*)ttyHandle - offset);
-            delete tty;
-        });
-    }
-};
-
-}
-
+extern "C" void Bun__setCTRLHandler(BOOL add);
 #endif
 
 namespace Bun {
@@ -102,89 +78,6 @@ static bool getWindowSize(int fd, size_t* width, size_t* height)
 #endif
 }
 
-class TTYWrapObject final : public JSC::JSDestructibleObject {
-public:
-    using Base = JSC::JSDestructibleObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags;
-
-    static TTYWrapObject* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, int fd)
-    {
-
-        TTYWrapObject* object = new (NotNull, JSC::allocateCell<TTYWrapObject>(vm)) TTYWrapObject(vm, structure, fd);
-        object->finishCreation(vm);
-
-        return object;
-    }
-
-    DECLARE_INFO;
-
-    template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
-    {
-        if constexpr (mode == JSC::SubspaceAccess::Concurrently)
-            return nullptr;
-
-        return WebCore::subspaceForImpl<TTYWrapObject, UseCustomHeapCellType::No>(
-            vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForTTYWrapObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTTYWrapObject = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForTTYWrapObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForTTYWrapObject = std::forward<decltype(space)>(space); });
-    }
-
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSObject* prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
-    }
-
-    static void destroy(JSC::JSCell* cell)
-    {
-        static_cast<TTYWrapObject*>(cell)->TTYWrapObject::~TTYWrapObject();
-    }
-
-    ~TTYWrapObject()
-    {
-#if OS(WINDOWS)
-        if (handle) {
-            handle->close();
-        }
-#endif
-    }
-
-    int fd = -1;
-
-#if OS(WINDOWS)
-    UV::TTY* handle;
-#endif
-
-private:
-    TTYWrapObject(JSC::VM& vm, JSC::Structure* structure, const int fd)
-        : Base(vm, structure)
-        , fd(fd)
-
-    {
-#if OS(WINDOWS)
-        handle = nullptr;
-#endif
-    }
-
-    void finishCreation(JSC::VM& vm)
-    {
-        Base::finishCreation(vm);
-
-        ASSERT(inherits(info()));
-    }
-};
-
-#if OS(WINDOWS)
-extern "C" void Bun__setCTRLHandler(BOOL add);
-#endif
-
-const ClassInfo TTYWrapObject::s_info = {
-    "LibuvStreamWrap"_s,
-
-    &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TTYWrapObject)
-};
-
 JSC::EncodedJSValue Process_functionInternalGetWindowSize(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame);
 
 extern "C" int Bun__ttySetMode(int fd, int mode);
@@ -227,78 +120,6 @@ JSC_DEFINE_HOST_FUNCTION(jsTTYSetMode, (JSC::JSGlobalObject * globalObject, Call
 #endif
 }
 
-JSC_DEFINE_HOST_FUNCTION(TTYWrap_functionSetMode,
-    (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
-{
-    auto& vm = JSC::getVM(globalObject);
-    auto argCount = callFrame->argumentCount();
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-    if (argCount == 0) {
-        JSC::throwTypeError(globalObject, throwScope, "setRawMode requires 1 argument (a number)"_s);
-        return {};
-    }
-
-    TTYWrapObject* ttyWrap = jsDynamicCast<TTYWrapObject*>(callFrame->thisValue());
-    if (!ttyWrap) [[unlikely]] {
-        JSC::throwTypeError(globalObject, throwScope, "TTY.setRawMode expects a TTYWrapObject as this"_s);
-        return {};
-    }
-
-    int fd = ttyWrap->fd;
-    JSValue mode = callFrame->argument(0);
-    if (!mode.isNumber()) {
-        throwTypeError(globalObject, throwScope, "mode must be a number"_s);
-        return {};
-    }
-
-#if OS(WINDOWS)
-    if (mode.toInt32(globalObject) == 0) {
-        Bun__setCTRLHandler(1);
-    }
-
-    int err = uv_tty_set_mode(ttyWrap->handle->tty(), mode.toInt32(globalObject));
-#else
-    // Nodejs does not throw when ttySetMode fails. An Error event is emitted instead.
-    int err = Bun__ttySetMode(fd, mode.toInt32(globalObject));
-#endif
-    return JSValue::encode(jsNumber(err));
-}
-
-JSC_DEFINE_HOST_FUNCTION(TTYWrap_functionGetWindowSize,
-    (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
-{
-    auto& vm = JSC::getVM(globalObject);
-    auto argCount = callFrame->argumentCount();
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-    if (argCount == 0) {
-        JSC::throwTypeError(globalObject, throwScope, "getWindowSize requires 1 argument (an array)"_s);
-        return {};
-    }
-
-    TTYWrapObject* ttyWrap = jsDynamicCast<TTYWrapObject*>(callFrame->thisValue());
-    if (!ttyWrap) [[unlikely]] {
-        JSC::throwTypeError(globalObject, throwScope, "TTY.getWindowSize expects a TTYWrapObject as this"_s);
-        return {};
-    }
-
-    int fd = ttyWrap->fd;
-    JSC::JSArray* array = jsDynamicCast<JSC::JSArray*>(callFrame->uncheckedArgument(0));
-    if (!array || array->length() < 2) {
-        JSC::throwTypeError(globalObject, throwScope, "getWindowSize expects an array"_s);
-        return {};
-    }
-
-    size_t width, height;
-    if (!getWindowSize(fd, &width, &height)) {
-        return JSC::JSValue::encode(jsBoolean(false));
-    }
-
-    array->putDirectIndex(globalObject, 0, jsNumber(width));
-    array->putDirectIndex(globalObject, 1, jsNumber(height));
-
-    return JSC::JSValue::encode(jsBoolean(true));
-}
-
 JSC_DEFINE_HOST_FUNCTION(Process_functionInternalGetWindowSize,
     (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
@@ -331,167 +152,6 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionInternalGetWindowSize,
     return JSC::JSValue::encode(jsBoolean(true));
 }
 
-static const HashTableValue TTYWrapPrototypeValues[] = {
-    { "getWindowSize"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, TTYWrap_functionGetWindowSize, 1 } },
-    { "setRawMode"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, TTYWrap_functionSetMode, 0 } },
-};
-
-class TTYWrapPrototype final : public JSC::JSNonFinalObject {
-public:
-    DECLARE_INFO;
-    using Base = JSC::JSNonFinalObject;
-
-    static Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
-    {
-        return Structure::create(vm, globalObject, globalObject->objectPrototype(), TypeInfo(ObjectType, StructureFlags), info());
-    }
-
-    static TTYWrapPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure)
-    {
-        TTYWrapPrototype* prototype = new (NotNull, JSC::allocateCell<TTYWrapPrototype>(vm)) TTYWrapPrototype(vm, structure);
-        prototype->finishCreation(vm, globalObject);
-        return prototype;
-    }
-
-    template<typename CellType, JSC::SubspaceAccess>
-    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
-    {
-        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(TTYWrapPrototype, Base);
-        return &vm.plainObjectSpace();
-    }
-
-    void finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
-    {
-        Base::finishCreation(vm);
-
-        reifyStaticProperties(vm, TTYWrapObject::info(), TTYWrapPrototypeValues, *this);
-        JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
-    }
-
-    TTYWrapPrototype(JSC::VM& vm, JSC::Structure* structure)
-        : Base(vm, structure)
-    {
-    }
-};
-
-const ClassInfo TTYWrapPrototype::s_info = {
-    "LibuvStreamWrap"_s,
-    &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TTYWrapPrototype)
-};
-
-class TTYWrapConstructor final : public JSC::InternalFunction {
-public:
-    using Base = JSC::InternalFunction;
-    static TTYWrapConstructor* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSObject* prototype)
-    {
-        TTYWrapConstructor* constructor = new (NotNull, JSC::allocateCell<TTYWrapConstructor>(vm)) TTYWrapConstructor(vm, structure);
-        constructor->finishCreation(vm, globalObject, prototype);
-        return constructor;
-    }
-
-    static constexpr unsigned StructureFlags = Base::StructureFlags;
-    static constexpr JSC::DestructionMode needsDestruction = DoesNotNeedDestruction;
-
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::InternalFunctionType, StructureFlags), info());
-    }
-
-    template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
-    {
-        if constexpr (mode == JSC::SubspaceAccess::Concurrently)
-            return nullptr;
-        return &vm.internalFunctionSpace();
-    }
-
-    static JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES call(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callframe)
-    {
-        auto& vm = JSC::getVM(globalObject);
-        auto scope = DECLARE_THROW_SCOPE(vm);
-
-        throwTypeError(globalObject, scope, "TTYWrapConstructor cannot be called as a function"_s);
-        return {};
-    }
-
-    // new TTY()
-    static JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES construct(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callframe)
-    {
-        auto& vm = JSC::getVM(globalObject);
-        auto scope = DECLARE_THROW_SCOPE(vm);
-
-        auto* constructor = jsDynamicCast<TTYWrapConstructor*>(callframe->jsCallee());
-
-        if (!constructor) {
-            throwTypeError(globalObject, scope, "TTYWrapConstructor::construct called with wrong 'this' value"_s);
-            return {};
-        }
-
-        if (callframe->argumentCount() < 1) {
-            throwTypeError(globalObject, scope, "Expected at least 1 argument"_s);
-            return {};
-        }
-
-        JSValue fd_value = callframe->argument(0);
-        int32_t fd = fd_value.toInt32(globalObject);
-
-        RETURN_IF_EXCEPTION(scope, {});
-
-        if (fd < 0) {
-            throwTypeError(globalObject, scope, "fd must be a positive number"_s);
-            return {};
-        }
-
-        auto prototypeValue = constructor->get(globalObject, vm.propertyNames->prototype);
-        RETURN_IF_EXCEPTION(scope, {});
-        if (!prototypeValue.isObject()) {
-            throwTypeError(globalObject, scope, "TTYWrapConstructor prototype is not an object"_s);
-            return {};
-        }
-
-#if OS(WINDOWS)
-        auto* handle = new UV::TTY();
-        memset(handle, 0, sizeof(UV::TTY));
-        int rc = uv_tty_init(jsCast<Zig::GlobalObject*>(globalObject)->uvLoop(), handle->tty(), fd, 0);
-        if (rc < 0) {
-            delete handle;
-            throwTypeError(globalObject, scope, "Failed to initialize TTY handle"_s);
-            return {};
-        }
-        ASSERT(handle->tty()->loop);
-#else
-        if (!isatty(fd)) {
-            throwTypeError(globalObject, scope, makeString("fd"_s, fd, " is not a tty"_s));
-            return {};
-        }
-#endif
-
-        auto* structure = TTYWrapObject::createStructure(vm, globalObject, prototypeValue.getObject());
-        auto* object = TTYWrapObject::create(vm, globalObject, structure, fd);
-
-#if OS(WINDOWS)
-        object->handle = handle;
-#endif
-
-        return JSValue::encode(object);
-    }
-
-    DECLARE_EXPORT_INFO;
-
-private:
-    TTYWrapConstructor(JSC::VM& vm, JSC::Structure* structure)
-        : Base(vm, structure, call, construct)
-    {
-    }
-
-    void finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSObject* prototype)
-    {
-        Base::finishCreation(vm, 1, "TTYWrap"_s);
-        putDirectWithoutTransition(vm, vm.propertyNames->prototype, prototype, JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete);
-    }
-};
-
-const ClassInfo TTYWrapConstructor::s_info = { "TTY"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TTYWrapConstructor) };
-
 JSValue createBunTTYFunctions(Zig::GlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);
@@ -506,6 +166,8 @@ JSValue createBunTTYFunctions(Zig::GlobalObject* globalObject)
     return obj;
 }
 
+extern "C" SYSV_ABI JSC::EncodedJSValue TTY__getConstructor(Zig::GlobalObject*);
+
 JSValue createNodeTTYWrapObject(JSC::JSGlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);
@@ -513,11 +175,15 @@ JSValue createNodeTTYWrapObject(JSC::JSGlobalObject* globalObject)
 
     obj->putDirect(vm, PropertyName(Identifier::fromString(vm, "isTTY"_s)), JSFunction::create(vm, globalObject, 0, "isatty"_s, Zig::jsFunctionTty_isatty, ImplementationVisibility::Public), 0);
 
-    TTYWrapPrototype* prototype = TTYWrapPrototype::create(vm, globalObject, TTYWrapPrototype::createStructure(vm, globalObject));
-    TTYWrapConstructor* constructor = TTYWrapConstructor::create(vm, globalObject, TTYWrapConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), prototype);
-
-    obj->putDirect(vm, Identifier::fromString(vm, "TTY"_s), constructor, JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete);
+    auto* zigGlobal = jsCast<Zig::GlobalObject*>(globalObject);
+    obj->putDirect(vm, Identifier::fromString(vm, "TTY"_s), JSValue::decode(TTY__getConstructor(zigGlobal)), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete);
 
     return obj;
 }
+}
+
+// Exposed to TTY.zig for getWindowSize on the handle.
+extern "C" bool Bun__getTTYWindowSize(int fd, size_t* width, size_t* height)
+{
+    return Bun::getWindowSize(fd, width, height);
 }

--- a/src/bun.js/bindings/generated_classes_list.zig
+++ b/src/bun.js/bindings/generated_classes_list.zig
@@ -92,6 +92,7 @@ pub const Classes = struct {
     pub const BlockList = api.BlockList;
     pub const NativeZstd = api.NativeZstd;
     pub const SourceMap = bun.SourceMap.JSSourceMap;
+    pub const TTY = node.TTY;
 };
 
 const bun = @import("bun");

--- a/src/bun.js/bindings/webcore/DOMClientIsoSubspaces.h
+++ b/src/bun.js/bindings/webcore/DOMClientIsoSubspaces.h
@@ -56,7 +56,6 @@ public:
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSDiffieHellman;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSDiffieHellmanGroup;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSECDH;
-    std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForTTYWrapObject;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForNapiHandleScopeImpl;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForNapiTypeTag;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForNativePromiseContext;

--- a/src/bun.js/bindings/webcore/DOMIsoSubspaces.h
+++ b/src/bun.js/bindings/webcore/DOMIsoSubspaces.h
@@ -53,7 +53,6 @@ public:
     std::unique_ptr<IsoSubspace> m_subspaceForBunInspectorConnection;
     std::unique_ptr<IsoSubspace> m_subspaceForJSNextTickQueue;
     std::unique_ptr<IsoSubspace> m_subspaceForNAPIFunction;
-    std::unique_ptr<IsoSubspace> m_subspaceForTTYWrapObject;
     std::unique_ptr<IsoSubspace> m_subspaceForNapiHandleScopeImpl;
     std::unique_ptr<IsoSubspace> m_subspaceForNapiTypeTag;
     std::unique_ptr<IsoSubspace> m_subspaceForNativePromiseContext;

--- a/src/bun.js/node.zig
+++ b/src/bun.js/node.zig
@@ -15,6 +15,8 @@ pub const crypto = @import("./node/node_crypto_binding.zig");
 pub const os = @import("./node/node_os.zig");
 /// node:process
 pub const process = @import("./node/node_process.zig");
+/// process.binding('tty_wrap').TTY
+pub const TTY = @import("./node/TTY.zig");
 pub const validators = @import("./node/util/validators.zig");
 pub const ErrorCode = @import("./node/nodejs_error_code.zig").Code;
 

--- a/src/bun.js/node/TTY.zig
+++ b/src/bun.js/node/TTY.zig
@@ -69,9 +69,9 @@ extern "c" fn Bun__getTTYWindowSize(i32, *usize, *usize) bool;
 const UV_EOF: i32 = -4095;
 
 inline fn toUVErrno(err: bun.sys.Error) i32 {
-    if (comptime Environment.isWindows) {
-        return @intCast(err.errno);
-    }
+    // bun.sys.Error.errno is u16 magnitude on every platform (Windows stores
+    // via @abs in fromCodeInt); recover the negative libuv code here so
+    // net.Socket's onStreamRead sees nread < 0 as an error.
     return -@as(i32, @intCast(err.errno));
 }
 
@@ -92,9 +92,29 @@ pub fn constructor(
     }
     const fd: bun.FD = .fromUV(fd_int);
 
-    // Do NOT throw on !isatty — Node accepts pipe/socket fds in
-    // tty.ReadStream and reports failures via the ctx out-param. We only
-    // populate ctx.code on a hard syscall error below.
+    // libuv's uv_tty_init rejects FILE and UNKNOWN fds with UV_EINVAL (TTY,
+    // PIPE, TCP, UDP are accepted). Report via the ctx out-param so
+    // tty.ReadStream throws ERR_TTY_INIT_FAILED — Node returns a dead wrap
+    // here rather than throwing, so we do the same.
+    const handle_type = node_util_binding.guessHandleTypeFromFd(fd_int);
+    if (handle_type == 3 or handle_type == 5) { // FILE | UNKNOWN
+        if (args[1].isObject()) {
+            args[1].put(globalObject, jsc.ZigString.static("code"), try bun.String.static("EINVAL").toJS(globalObject));
+        }
+        const dead = bun.new(TTY, .{
+            .ref_count = .init(),
+            .fd = fd,
+            .fd_int = fd_int,
+            .owned_fd = fd,
+            .reader = IOReader.init(TTY),
+            .event_loop_handle = jsc.EventLoopHandle.init(globalObject.bunVM().eventLoop()),
+            .globalThis = globalObject,
+            .flags = .{ .closed = true },
+        });
+        dead.reader.setParent(dead);
+        dead.this_value = jsc.JSRef.initWeak(this_value);
+        return dead;
+    }
 
     var owned_fd = fd;
     var nonblocking = false;
@@ -135,10 +155,6 @@ pub fn constructor(
     tty.reader.flags.close_handle = false;
 
     tty.this_value = jsc.JSRef.initWeak(this_value);
-
-    // Node's ctx out-param: only populate code on hard failure. We have none
-    // here (reopen failure just falls back), so leave ctx untouched.
-    _ = args[1];
 
     return tty;
 }
@@ -227,12 +243,12 @@ pub fn getWindowSize(this: *TTY, globalObject: *jsc.JSGlobalObject, callframe: *
     var width: usize = 0;
     var height: usize = 0;
     if (!Bun__getTTYWindowSize(this.fd_int, &width, &height)) {
-        return JSValue.jsBoolean(false);
+        return .false;
     }
 
     try arr_value.putIndex(globalObject, 0, JSValue.jsNumber(width));
     try arr_value.putIndex(globalObject, 1, JSValue.jsNumber(height));
-    return JSValue.jsBoolean(true);
+    return .true;
 }
 
 pub fn close(this: *TTY, _: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {
@@ -292,9 +308,9 @@ pub fn onReadChunk(this: *TTY, chunk: []const u8, has_more: bun.io.ReadState) bo
     const callback = js.gc.get(.onread, this_jsvalue) orelse return this.flags.reading;
 
     const globalThis = this.globalThis;
-    // dupe — the reader buffer is reused across reads.
-    const duped = bun.default_allocator.dupe(u8, chunk) catch return this.flags.reading;
-    const buf = jsc.ArrayBuffer.createBuffer(globalThis, duped) catch return this.flags.reading;
+    // createBuffer memcpy's into JSC-owned memory, so the reader's reused
+    // backing buffer is safe to pass directly.
+    const buf = jsc.ArrayBuffer.createBuffer(globalThis, chunk) catch return this.flags.reading;
 
     this.bytes_read += chunk.len;
 
@@ -384,6 +400,7 @@ extern "c" fn Source__setRawModeStdin(bool) i32;
 
 const bun = @import("bun");
 const Environment = bun.Environment;
+const node_util_binding = @import("./node_util_binding.zig");
 
 const jsc = bun.jsc;
 const JSValue = jsc.JSValue;

--- a/src/bun.js/node/TTY.zig
+++ b/src/bun.js/node/TTY.zig
@@ -92,7 +92,7 @@ pub fn constructor(
     }
     const fd: bun.FD = .fromUV(fd_int);
 
-    // g5: do NOT throw on !isatty — Node accepts pipe/socket fds in
+    // Do NOT throw on !isatty — Node accepts pipe/socket fds in
     // tty.ReadStream and reports failures via the ctx out-param. We only
     // populate ctx.code on a hard syscall error below.
 
@@ -101,12 +101,10 @@ pub fn constructor(
     var owns_fd = false;
 
     if (comptime Environment.isPosix) {
-        // c1/c5: reopen with the original access mode (not hardcoded RDONLY) so
-        // writes don't EBADF. Fall back to the original fd on -1 (FileReader
-        // pattern).
-        const O_ACCMODE: u32 = 0o3;
+        // Reopen with the original access mode (not hardcoded RDONLY) so writes
+        // don't EBADF. Fall back to the original fd on -1 (FileReader pattern).
         const accmode: i32 = switch (fd.getFcntlFlags()) {
-            .result => |fl| @intCast(fl & O_ACCMODE),
+            .result => |fl| @intCast(fl & 0o3), // O_ACCMODE
             .err => bun.O.RDWR,
         };
         const rc = open_as_nonblocking_tty(fd_int, accmode);
@@ -115,8 +113,8 @@ pub fn constructor(
             nonblocking = true;
             owns_fd = true;
         }
-        // c1: intentionally NOT dup2(newfd, 0) — children with stdio:'inherit'
-        // get the original blocking fd, which is the desired UX. Documented
+        // Intentionally NOT dup2(newfd, 0) — children with stdio:'inherit' get
+        // the original blocking fd, which is the desired UX. Documented
         // divergence from libuv.
     }
 
@@ -146,7 +144,7 @@ pub fn constructor(
 }
 
 pub fn readStart(this: *TTY, _: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {
-    log("readStart (started={}, hasPendingRead={}, isDone={}, paused={})", .{ this.flags.reader_started, if (this.flags.reader_started) this.reader.hasPendingRead() else false, if (this.flags.reader_started) this.reader.isDone() else false, if (this.flags.reader_started) this.reader.flags.is_paused else false });
+    log("readStart (started={})", .{this.flags.reader_started});
     if (this.flags.closed) return JSValue.jsNumber(0);
 
     this.flags.reading = true;
@@ -169,7 +167,7 @@ pub fn readStart(this: *TTY, _: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSEr
             .err => |err| return JSValue.jsNumber(toUVErrno(err)),
         }
     } else {
-        // c2: unpause() only clears the flag. registerPoll (via watch()) re-arms
+        // unpause() only clears the flag. registerPoll (via watch()) re-arms
         // the kevent; updateRef re-activates the loop's keepalive that pause()'s
         // unregister→deactivate dropped (unless the user explicitly unref'd).
         this.reader.unpause();
@@ -204,9 +202,8 @@ pub fn doUnref(this: *TTY, _: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSErro
     return .js_undefined;
 }
 
-pub fn setRawMode(this: *TTY, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+pub fn setRawMode(this: *TTY, _: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
     const args = callframe.argumentsAsArray(1);
-    _ = globalObject;
     const flag: i32 = if (args[0].toBoolean()) 1 else 0;
 
     if (comptime Environment.isWindows) {
@@ -288,14 +285,14 @@ pub fn onReadChunk(this: *TTY, chunk: []const u8, has_more: bun.io.ReadState) bo
     _ = has_more;
     log("onReadChunk: {} bytes", .{chunk.len});
 
-    // c4: drop zero-length reads (Node's onStreamRead skips nread == 0).
+    // Drop zero-length reads (Node's onStreamRead skips nread == 0).
     if (chunk.len == 0) return this.flags.reading;
 
     const this_jsvalue = this.this_value.tryGet() orelse return this.flags.reading;
     const callback = js.gc.get(.onread, this_jsvalue) orelse return this.flags.reading;
 
     const globalThis = this.globalThis;
-    // g6: dupe — the reader buffer is reused across reads.
+    // dupe — the reader buffer is reused across reads.
     const duped = bun.default_allocator.dupe(u8, chunk) catch return this.flags.reading;
     const buf = jsc.ArrayBuffer.createBuffer(globalThis, duped) catch return this.flags.reading;
 
@@ -308,7 +305,7 @@ pub fn onReadChunk(this: *TTY, chunk: []const u8, has_more: bun.io.ReadState) bo
         &.{ JSValue.jsNumber(@as(i32, @intCast(chunk.len))), buf },
     );
 
-    // g6: honor readStop set during JS re-entry — don't hardcode true.
+    // Honor readStop set during JS re-entry — don't hardcode true.
     return this.flags.reading;
 }
 

--- a/src/bun.js/node/TTY.zig
+++ b/src/bun.js/node/TTY.zig
@@ -385,8 +385,6 @@ fn deinit(this: *TTY) void {
 
 extern "c" fn Source__setRawModeStdin(bool) i32;
 
-const std = @import("std");
-
 const bun = @import("bun");
 const Environment = bun.Environment;
 

--- a/src/bun.js/node/TTY.zig
+++ b/src/bun.js/node/TTY.zig
@@ -262,7 +262,14 @@ fn closeInternal(this: *TTY) void {
     this.flags.reading = false;
 
     if (this.flags.reader_started) {
-        this.reader.close();
+        // reader.close() is a no-op with close_handle=false, so the
+        // terminal onReaderDone/onReaderError → readerTerminated path
+        // can't release the ref readStart took. pause() unregisters the
+        // poll (no more callbacks), then release the ref directly. The
+        // FilePoll/buffers are freed via reader.deinit() when ref_count→0.
+        this.reader.pause();
+        this.reader.updateRef(false);
+        this.readerTerminated();
     }
     if (this.flags.owns_fd and this.owned_fd != bun.invalid_fd) {
         this.owned_fd.close();

--- a/src/bun.js/node/TTY.zig
+++ b/src/bun.js/node/TTY.zig
@@ -1,0 +1,394 @@
+//! Native TTY handle for `process.binding('tty_wrap').TTY`.
+//!
+//! Node's `tty.ReadStream` extends `net.Socket` with `_handle` set to a native
+//! `TTY` object exposing readStart/readStop/setRawMode/getWindowSize/ref/unref
+//! plus the StreamBase onread callback. This is Bun's equivalent, backed by
+//! `bun.io.BufferedReader` so the same backpressure mechanism Node uses
+//! (push() === false → readStop(), _read → readStart()) drives fd 0 release.
+//!
+//! Lifecycle: JSRef starts weak, upgrades to strong on readStart and back to
+//! weak on readStop so the JS wrapper survives GC while the poll is live. The
+//! Zig struct is separately ref-counted: the JS wrapper holds one ref
+//! (released in finalize), and the reader holds one ref while started — so
+//! reader callbacks never fire on freed memory even if GC finalizes mid-read.
+
+const TTY = @This();
+
+const log = bun.Output.scoped(.TTY, .hidden);
+
+pub const js = jsc.Codegen.JSTTY;
+pub const toJS = js.toJS;
+pub const fromJS = js.fromJS;
+pub const fromJSDirect = js.fromJSDirect;
+
+const RefCount = bun.ptr.RefCount(@This(), "ref_count", deinit, .{});
+pub const ref = RefCount.ref;
+pub const deref = RefCount.deref;
+
+pub const IOReader = bun.io.BufferedReader;
+
+ref_count: RefCount,
+
+/// Original fd as passed from JS (e.g. 0). Used for setRawMode/getWindowSize
+/// (which take a C int on both platforms) and as fallback when the nonblocking
+/// reopen fails.
+fd: bun.FD,
+fd_int: i32,
+
+/// On POSIX this is the reopened nonblocking fd from open_as_nonblocking_tty,
+/// or `fd` itself when reopen fails. On Windows it's always `fd`.
+owned_fd: bun.FD,
+
+reader: IOReader,
+
+this_value: jsc.JSRef = jsc.JSRef.empty(),
+event_loop_handle: jsc.EventLoopHandle,
+globalThis: *jsc.JSGlobalObject,
+
+bytes_read: u64 = 0,
+bytes_written: u64 = 0,
+
+flags: Flags = .{},
+
+pub const Flags = packed struct(u8) {
+    reading: bool = false,
+    closed: bool = false,
+    /// reader.start() succeeded (and the reader holds a ref on this struct)
+    reader_started: bool = false,
+    /// owned_fd != fd; we close owned_fd on close()
+    owns_fd: bool = false,
+    /// user called handle.unref(); readStart must not re-ref
+    unreffed: bool = false,
+    _: u3 = 0,
+};
+
+extern "c" fn open_as_nonblocking_tty(i32, i32) i32;
+extern "c" fn Bun__ttySetMode(i32, i32) i32;
+extern "c" fn Bun__getTTYWindowSize(i32, *usize, *usize) bool;
+
+const UV_EOF: i32 = -4095;
+
+inline fn toUVErrno(err: bun.sys.Error) i32 {
+    if (comptime Environment.isWindows) {
+        return @intCast(err.errno);
+    }
+    return -@as(i32, @intCast(err.errno));
+}
+
+pub fn constructor(
+    globalObject: *jsc.JSGlobalObject,
+    callframe: *jsc.CallFrame,
+    this_value: jsc.JSValue,
+) bun.JSError!*TTY {
+    const args = callframe.argumentsAsArray(2);
+    const fd_value = args[0];
+
+    if (!fd_value.isNumber()) {
+        return globalObject.throw("fd must be a number", .{});
+    }
+    const fd_int = fd_value.toInt32();
+    if (fd_int < 0) {
+        return globalObject.throw("fd must be a non-negative integer", .{});
+    }
+    const fd: bun.FD = .fromUV(fd_int);
+
+    // g5: do NOT throw on !isatty — Node accepts pipe/socket fds in
+    // tty.ReadStream and reports failures via the ctx out-param. We only
+    // populate ctx.code on a hard syscall error below.
+
+    var owned_fd = fd;
+    var nonblocking = false;
+    var owns_fd = false;
+
+    if (comptime Environment.isPosix) {
+        // c1/c5: reopen with the original access mode (not hardcoded RDONLY) so
+        // writes don't EBADF. Fall back to the original fd on -1 (FileReader
+        // pattern).
+        const O_ACCMODE: u32 = 0o3;
+        const accmode: i32 = switch (fd.getFcntlFlags()) {
+            .result => |fl| @intCast(fl & O_ACCMODE),
+            .err => bun.O.RDWR,
+        };
+        const rc = open_as_nonblocking_tty(fd_int, accmode);
+        if (rc > -1) {
+            owned_fd = .fromNative(rc);
+            nonblocking = true;
+            owns_fd = true;
+        }
+        // c1: intentionally NOT dup2(newfd, 0) — children with stdio:'inherit'
+        // get the original blocking fd, which is the desired UX. Documented
+        // divergence from libuv.
+    }
+
+    const tty = bun.new(TTY, .{
+        .ref_count = .init(),
+        .fd = fd,
+        .fd_int = fd_int,
+        .owned_fd = owned_fd,
+        .reader = IOReader.init(TTY),
+        .event_loop_handle = jsc.EventLoopHandle.init(globalObject.bunVM().eventLoop()),
+        .globalThis = globalObject,
+        .flags = .{ .owns_fd = owns_fd },
+    });
+
+    tty.reader.setParent(tty);
+    tty.reader.flags.nonblocking = nonblocking;
+    tty.reader.flags.pollable = true;
+    tty.reader.flags.close_handle = false;
+
+    tty.this_value = jsc.JSRef.initWeak(this_value);
+
+    // Node's ctx out-param: only populate code on hard failure. We have none
+    // here (reopen failure just falls back), so leave ctx untouched.
+    _ = args[1];
+
+    return tty;
+}
+
+pub fn readStart(this: *TTY, _: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {
+    log("readStart (started={}, hasPendingRead={}, isDone={}, paused={})", .{ this.flags.reader_started, if (this.flags.reader_started) this.reader.hasPendingRead() else false, if (this.flags.reader_started) this.reader.isDone() else false, if (this.flags.reader_started) this.reader.flags.is_paused else false });
+    if (this.flags.closed) return JSValue.jsNumber(0);
+
+    this.flags.reading = true;
+    this.this_value.upgrade(this.globalThis);
+
+    if (!this.flags.reader_started) {
+        switch (this.reader.start(this.owned_fd, true)) {
+            .result => {
+                this.flags.reader_started = true;
+                // Reader now holds a ref on this struct until its terminal
+                // callback (onReaderDone/onReaderError) fires.
+                this.ref();
+                if (comptime Environment.isPosix) {
+                    if (this.reader.handle == .poll) {
+                        this.reader.handle.poll.flags.insert(.nonblocking);
+                    }
+                }
+                if (this.flags.unreffed) this.reader.updateRef(false);
+            },
+            .err => |err| return JSValue.jsNumber(toUVErrno(err)),
+        }
+    } else {
+        // c2: unpause() only clears the flag. registerPoll (via watch()) re-arms
+        // the kevent; updateRef re-activates the loop's keepalive that pause()'s
+        // unregister→deactivate dropped (unless the user explicitly unref'd).
+        this.reader.unpause();
+        if (!this.reader.isDone() and !this.reader.hasPendingRead()) {
+            this.reader.watch();
+        }
+        if (!this.flags.unreffed) this.reader.updateRef(true);
+    }
+
+    return JSValue.jsNumber(0);
+}
+
+pub fn readStop(this: *TTY, _: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {
+    log("readStop", .{});
+    this.flags.reading = false;
+    if (this.flags.reader_started) {
+        this.reader.pause();
+    }
+    this.this_value.downgrade();
+    return JSValue.jsNumber(0);
+}
+
+pub fn doRef(this: *TTY, _: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {
+    this.flags.unreffed = false;
+    this.reader.updateRef(true);
+    return .js_undefined;
+}
+
+pub fn doUnref(this: *TTY, _: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {
+    this.flags.unreffed = true;
+    this.reader.updateRef(false);
+    return .js_undefined;
+}
+
+pub fn setRawMode(this: *TTY, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    const args = callframe.argumentsAsArray(1);
+    _ = globalObject;
+    const flag: i32 = if (args[0].toBoolean()) 1 else 0;
+
+    if (comptime Environment.isWindows) {
+        if (this.fd_int == 0) {
+            return JSValue.jsNumber(Source__setRawModeStdin(flag != 0));
+        }
+        // Non-stdin TTY on Windows: no per-handle raw-mode path yet.
+        return JSValue.jsNumber(0);
+    }
+
+    return JSValue.jsNumber(Bun__ttySetMode(this.fd_int, flag));
+}
+
+pub fn getWindowSize(this: *TTY, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    const args = callframe.argumentsAsArray(1);
+    const arr_value = args[0];
+    if (!arr_value.jsType().isArray()) {
+        return globalObject.throw("getWindowSize expects an array", .{});
+    }
+
+    var width: usize = 0;
+    var height: usize = 0;
+    if (!Bun__getTTYWindowSize(this.fd_int, &width, &height)) {
+        return JSValue.jsBoolean(false);
+    }
+
+    try arr_value.putIndex(globalObject, 0, JSValue.jsNumber(width));
+    try arr_value.putIndex(globalObject, 1, JSValue.jsNumber(height));
+    return JSValue.jsBoolean(true);
+}
+
+pub fn close(this: *TTY, _: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {
+    this.closeInternal();
+    return .js_undefined;
+}
+
+fn closeInternal(this: *TTY) void {
+    if (this.flags.closed) return;
+    this.flags.closed = true;
+    this.flags.reading = false;
+
+    if (this.flags.reader_started) {
+        this.reader.close();
+    }
+    if (this.flags.owns_fd and this.owned_fd != bun.invalid_fd) {
+        this.owned_fd.close();
+        this.owned_fd = bun.invalid_fd;
+    }
+    this.safeDowngrade();
+}
+
+pub fn getOnRead(_: *TTY, thisValue: jsc.JSValue, _: *jsc.JSGlobalObject) JSValue {
+    return js.gc.get(.onread, thisValue) orelse .js_undefined;
+}
+
+pub fn setOnRead(_: *TTY, thisValue: jsc.JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) void {
+    js.gc.set(.onread, thisValue, globalObject, value);
+}
+
+pub fn getBytesRead(this: *TTY, _: *jsc.JSGlobalObject) JSValue {
+    return JSValue.jsNumber(this.bytes_read);
+}
+
+pub fn getBytesWritten(this: *TTY, _: *jsc.JSGlobalObject) JSValue {
+    return JSValue.jsNumber(this.bytes_written);
+}
+
+pub fn getFd(this: *TTY, _: *jsc.JSGlobalObject) JSValue {
+    return JSValue.jsNumber(this.fd_int);
+}
+
+pub fn getExternalStream(_: *TTY, _: *jsc.JSGlobalObject) JSValue {
+    return .jsNull();
+}
+
+// Reader vtable callbacks ----------------------------------------------------
+
+pub fn onReadChunk(this: *TTY, chunk: []const u8, has_more: bun.io.ReadState) bool {
+    _ = has_more;
+    log("onReadChunk: {} bytes", .{chunk.len});
+
+    // c4: drop zero-length reads (Node's onStreamRead skips nread == 0).
+    if (chunk.len == 0) return this.flags.reading;
+
+    const this_jsvalue = this.this_value.tryGet() orelse return this.flags.reading;
+    const callback = js.gc.get(.onread, this_jsvalue) orelse return this.flags.reading;
+
+    const globalThis = this.globalThis;
+    // g6: dupe — the reader buffer is reused across reads.
+    const duped = bun.default_allocator.dupe(u8, chunk) catch return this.flags.reading;
+    const buf = jsc.ArrayBuffer.createBuffer(globalThis, duped) catch return this.flags.reading;
+
+    this.bytes_read += chunk.len;
+
+    globalThis.bunVM().eventLoop().runCallback(
+        callback,
+        globalThis,
+        this_jsvalue,
+        &.{ JSValue.jsNumber(@as(i32, @intCast(chunk.len))), buf },
+    );
+
+    // g6: honor readStop set during JS re-entry — don't hardcode true.
+    return this.flags.reading;
+}
+
+pub fn onReaderDone(this: *TTY) void {
+    log("onReaderDone", .{});
+    defer this.readerTerminated();
+    this.flags.reading = false;
+    this.reader.pause();
+    this.reader.updateRef(false);
+    this.callOnRead(JSValue.jsNumber(UV_EOF), .js_undefined);
+    this.safeDowngrade();
+}
+
+pub fn onReaderError(this: *TTY, err: bun.sys.Error) void {
+    log("onReaderError: {any}", .{err});
+    defer this.readerTerminated();
+    this.flags.reading = false;
+    this.reader.pause();
+    this.reader.updateRef(false);
+    this.callOnRead(JSValue.jsNumber(toUVErrno(err)), .js_undefined);
+    this.safeDowngrade();
+}
+
+/// Reader's terminal callback fired — release the ref it held.
+fn readerTerminated(this: *TTY) void {
+    if (this.flags.reader_started) {
+        this.flags.reader_started = false;
+        this.deref();
+    }
+}
+
+/// downgrade() asserts on .finalized; reader callbacks may run after finalize
+/// (struct stays alive via ref_count), so check first.
+inline fn safeDowngrade(this: *TTY) void {
+    if (this.this_value.isStrong()) this.this_value.downgrade();
+}
+
+fn callOnRead(this: *TTY, nread: JSValue, buf: JSValue) void {
+    const this_jsvalue = this.this_value.tryGet() orelse return;
+    const callback = js.gc.get(.onread, this_jsvalue) orelse return;
+    this.globalThis.bunVM().eventLoop().runCallback(
+        callback,
+        this.globalThis,
+        this_jsvalue,
+        &.{ nread, buf },
+    );
+}
+
+// EventLoop hooks for IOReader -----------------------------------------------
+
+pub fn eventLoop(this: *TTY) jsc.EventLoopHandle {
+    return this.event_loop_handle;
+}
+
+pub fn loop(this: *TTY) *bun.Async.Loop {
+    if (comptime Environment.isWindows) {
+        return this.event_loop_handle.loop().uv_loop;
+    }
+    return this.event_loop_handle.loop();
+}
+
+pub fn finalize(this: *TTY) callconv(.c) void {
+    log("finalize", .{});
+    jsc.markBinding(@src());
+    this.closeInternal();
+    this.this_value.finalize();
+    this.deref();
+}
+
+fn deinit(this: *TTY) void {
+    this.reader.deinit();
+    bun.destroy(this);
+}
+
+extern "c" fn Source__setRawModeStdin(bool) i32;
+
+const std = @import("std");
+
+const bun = @import("bun");
+const Environment = bun.Environment;
+
+const jsc = bun.jsc;
+const JSValue = jsc.JSValue;

--- a/src/bun.js/node/node_util_binding.zig
+++ b/src/bun.js/node/node_util_binding.zig
@@ -106,6 +106,75 @@ pub fn enobufsErrorCode(_: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!j
     return jsc.JSValue.jsNumberFromInt32(-bun.sys.UV_E.NOBUFS);
 }
 
+/// Node's `util.guessHandleType(fd)` — returns a uint32 index into
+/// `["TCP","TTY","UDP","FILE","PIPE","UNKNOWN"]`, matching the libuv
+/// `uv_guess_handle` mapping that Node's `createHandle`/`getStdin` rely on.
+pub fn guessHandleType(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+    const fd_value = callframe.argument(0);
+    if (!fd_value.isNumber()) {
+        return globalThis.throwInvalidArgumentTypeValue("fd", "number", fd_value);
+    }
+    const fd_int = fd_value.toInt32();
+    if (fd_int < 0) return jsc.JSValue.jsNumber(@as(u32, 5)); // UNKNOWN
+
+    return jsc.JSValue.jsNumber(@as(u32, guessHandleTypeFromFd(fd_int)));
+}
+
+fn guessHandleTypeFromFd(fd_int: i32) u32 {
+    const TCP = 0;
+    const TTY_TYPE = 1;
+    const UDP = 2;
+    const FILE_TYPE = 3;
+    const PIPE_TYPE = 4;
+    const UNKNOWN = 5;
+
+    if (comptime bun.Environment.isWindows) {
+        const uv = bun.windows.libuv;
+        return switch (uv.uv_guess_handle(fd_int)) {
+            uv.Handle.Type.tcp => TCP,
+            uv.Handle.Type.tty => TTY_TYPE,
+            uv.Handle.Type.udp => UDP,
+            uv.Handle.Type.file => FILE_TYPE,
+            uv.Handle.Type.named_pipe => PIPE_TYPE,
+            else => UNKNOWN,
+        };
+    }
+
+    const fd: bun.FD = .fromNative(fd_int);
+
+    if (std.posix.isatty(fd_int)) return TTY_TYPE;
+
+    const st = switch (bun.sys.fstat(fd)) {
+        .result => |s| s,
+        .err => return UNKNOWN,
+    };
+    const mode = st.mode;
+    if (std.posix.S.ISREG(mode) or std.posix.S.ISCHR(mode)) return FILE_TYPE;
+    if (std.posix.S.ISFIFO(mode)) return PIPE_TYPE;
+    if (!std.posix.S.ISSOCK(mode)) return UNKNOWN;
+
+    var ss: std.posix.sockaddr.storage = undefined;
+    var ss_len: std.posix.socklen_t = @sizeOf(std.posix.sockaddr.storage);
+    if (std.c.getsockname(fd_int, @ptrCast(&ss), &ss_len) != 0) return UNKNOWN;
+
+    var so_type: c_int = 0;
+    var so_type_len: std.posix.socklen_t = @sizeOf(c_int);
+    if (std.c.getsockopt(fd_int, std.posix.SOL.SOCKET, std.posix.SO.TYPE, @ptrCast(&so_type), &so_type_len) != 0) {
+        return UNKNOWN;
+    }
+
+    const family = ss.family;
+    if (so_type == std.posix.SOCK.DGRAM) {
+        if (family == std.posix.AF.INET or family == std.posix.AF.INET6) return UDP;
+        return UNKNOWN;
+    }
+    if (so_type == std.posix.SOCK.STREAM) {
+        if (family == std.posix.AF.INET or family == std.posix.AF.INET6) return TCP;
+        if (family == std.posix.AF.UNIX) return PIPE_TYPE;
+    }
+    return UNKNOWN;
+}
+
 /// `extractedSplitNewLines` for ASCII/Latin1 strings. Panics if passed a non-string.
 /// Returns `undefined` if param is utf8 or utf16 and not fully ascii.
 ///

--- a/src/bun.js/node/node_util_binding.zig
+++ b/src/bun.js/node/node_util_binding.zig
@@ -120,7 +120,7 @@ pub fn guessHandleType(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFram
     return jsc.JSValue.jsNumber(@as(u32, guessHandleTypeFromFd(fd_int)));
 }
 
-fn guessHandleTypeFromFd(fd_int: i32) u32 {
+pub fn guessHandleTypeFromFd(fd_int: i32) u32 {
     const TCP = 0;
     const TTY_TYPE = 1;
     const UDP = 2;

--- a/src/bun.js/node/node_util_binding.zig
+++ b/src/bun.js/node/node_util_binding.zig
@@ -149,9 +149,9 @@ fn guessHandleTypeFromFd(fd_int: i32) u32 {
         .err => return UNKNOWN,
     };
     const mode = st.mode;
-    if (std.posix.S.ISREG(mode) or std.posix.S.ISCHR(mode)) return FILE_TYPE;
-    if (std.posix.S.ISFIFO(mode)) return PIPE_TYPE;
-    if (!std.posix.S.ISSOCK(mode)) return UNKNOWN;
+    if (bun.S.ISREG(mode) or bun.S.ISCHR(mode)) return FILE_TYPE;
+    if (bun.S.ISFIFO(mode)) return PIPE_TYPE;
+    if (!bun.S.ISSOCK(mode)) return UNKNOWN;
 
     var ss: std.posix.sockaddr.storage = undefined;
     var ss_len: std.posix.socklen_t = @sizeOf(std.posix.sockaddr.storage);

--- a/src/bun.js/node/tty.classes.ts
+++ b/src/bun.js/node/tty.classes.ts
@@ -1,0 +1,28 @@
+import { define } from "../../codegen/class-definitions";
+
+export default [
+  define({
+    name: "TTY",
+    construct: true,
+    constructNeedsThis: true,
+    finalize: true,
+    configurable: false,
+    klass: {},
+    values: ["onread"],
+    proto: {
+      readStart: { fn: "readStart", length: 0 },
+      readStop: { fn: "readStop", length: 0 },
+      setRawMode: { fn: "setRawMode", length: 1 },
+      getWindowSize: { fn: "getWindowSize", length: 1 },
+      ref: { fn: "doRef", length: 0 },
+      unref: { fn: "doUnref", length: 0 },
+      close: { fn: "close", length: 1 },
+      onread: { getter: "getOnRead", setter: "setOnRead", this: true },
+
+      bytesRead: { getter: "getBytesRead", enumerable: false },
+      bytesWritten: { getter: "getBytesWritten", enumerable: false },
+      fd: { getter: "getFd", enumerable: false },
+      _externalStream: { getter: "getExternalStream", enumerable: false },
+    },
+  }),
+];

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -117,6 +117,34 @@ export function getStdinStream(
   fdType: BunProcessStdinFdType,
 ) {
   $assert(fd === 0);
+
+  if (isTTY) {
+    // Node lib/internal/bootstrap/switches/is_main_thread.js getStdin().
+    // tty.ReadStream extends net.Socket; readableHighWaterMark 0 makes
+    // push() return false on every chunk so onStreamRead readStop()s and
+    // _read() re-owns only when a consumer pulls.
+    const tty = require("node:tty");
+    const stdin = new tty.ReadStream(fd);
+    stdin.fd = fd;
+
+    if (stdin._handle && stdin._handle.readStop) {
+      stdin._handle.reading = false;
+      stdin._readableState.reading = false;
+      stdin._handle.readStop();
+    }
+
+    stdin.on("pause", () => {
+      process.nextTick(() => {
+        if (!stdin._handle) return;
+        stdin._handle.reading = false;
+        stdin._readableState.reading = false;
+        stdin._handle.readStop();
+      });
+    });
+
+    return stdin;
+  }
+
   const native = Bun.stdin.stream();
   const source = native.$bunNativePtr;
 
@@ -163,7 +191,7 @@ export function getStdinStream(
     }
   }
 
-  const ReadStream = isTTY ? require("node:tty").ReadStream : require("node:fs").ReadStream;
+  const ReadStream = require("node:fs").ReadStream;
   const stream = new ReadStream(null, { fd, autoClose: false });
 
   const originalOn = stream.on;
@@ -188,9 +216,7 @@ export function getStdinStream(
 
   stream.fd = fd;
 
-  // tty.ReadStream is supposed to extend from net.Socket.
-  // but we haven't made that work yet. Until then, we need to manually add some of net.Socket's methods
-  if (isTTY || fdType !== BunProcessStdinFdType.file) {
+  if (fdType !== BunProcessStdinFdType.file) {
     stream.ref = function () {
       forceUnref = false;
       own();

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -125,7 +125,6 @@ export function getStdinStream(
     // _read() re-owns only when a consumer pulls.
     const tty = require("node:tty");
     const stdin = new tty.ReadStream(fd);
-    stdin.fd = fd;
 
     if (stdin._handle && stdin._handle.readStop) {
       stdin._handle.reading = false;

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -135,9 +135,13 @@ export function getStdinStream(
     stdin.on("pause", () => {
       process.nextTick(() => {
         if (!stdin._handle) return;
-        stdin._handle.reading = false;
-        stdin._readableState.reading = false;
-        stdin._handle.readStop();
+        // Only stop if still paused and a read is actually in flight —
+        // resume() may have run in the same tick (Node's onpause guard).
+        if (stdin._handle.reading && !stdin.readableFlowing) {
+          stdin._readableState.reading = false;
+          stdin._handle.reading = false;
+          stdin._handle.readStop();
+        }
       });
     });
 

--- a/src/js/internal/shared.ts
+++ b/src/js/internal/shared.ts
@@ -165,6 +165,7 @@ export default {
   once,
   getLazy,
 
+  owner_symbol: Symbol("owner_symbol"),
   kHandle: Symbol("kHandle"),
   kAutoDestroyed: Symbol("kAutoDestroyed"),
   kResistStopPropagation: Symbol("kResistStopPropagation"),

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2648,18 +2648,20 @@ function onStreamRead(nread, arrayBuffer) {
     let ret;
     if (self[kBuffer]) {
       // onread: {buffer, callback}. Node's native layer writes directly into
-      // the user buffer; copy from the handle's buffer so the callback
-      // receives the caller's buffer as documented.
+      // the user buffer; we copy from the handle's buffer here, so the
+      // callback must receive the truncated count (bytes actually in
+      // userBuf), not the handle's nread.
       let userBuf = self[kBufferGen]();
+      let n = nread;
       if ($isTypedArrayView(userBuf)) {
         if (userBuf !== arrayBuffer) {
-          const n = nread < userBuf.byteLength ? nread : userBuf.byteLength;
+          n = nread < userBuf.byteLength ? nread : userBuf.byteLength;
           userBuf.set(arrayBuffer.subarray(0, n));
         }
       } else {
         userBuf = arrayBuffer;
       }
-      ret = self[kBufferCb](nread, userBuf);
+      ret = self[kBufferCb](n, userBuf);
     } else {
       ret = self.push(arrayBuffer);
     }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -62,6 +62,7 @@ const { owner_symbol } = require("internal/shared");
 const UV_EOF = -4095;
 const kBuffer = Symbol("kBuffer");
 const kBufferCb = Symbol("kBufferCb");
+const kBufferGen = Symbol("kBufferGen");
 
 const kServerSocket = Symbol("kServerSocket");
 const kBytesWritten = Symbol("kBytesWritten");
@@ -757,6 +758,7 @@ function Socket(options?) {
     }
     this[kBuffer] = true;
     this[kBufferCb] = onread.callback;
+    this[kBufferGen] = typeof onread.buffer === "function" ? onread.buffer : () => onread.buffer;
     // when the onread option is specified we use a different handlers object
     this[khandlers] = {
       ...SocketHandlers2,
@@ -2637,7 +2639,19 @@ function onStreamRead(nread, arrayBuffer) {
     self.bytesRead += nread;
     let ret;
     if (self[kBuffer]) {
-      ret = self[kBufferCb](nread, arrayBuffer);
+      // onread: {buffer, callback}. Node's native layer writes directly into
+      // the user buffer; copy from the handle's buffer so the callback
+      // receives the caller's buffer as documented.
+      let userBuf = self[kBufferGen]();
+      if ($isTypedArrayView(userBuf)) {
+        if (userBuf !== arrayBuffer) {
+          const n = nread < userBuf.byteLength ? nread : userBuf.byteLength;
+          userBuf.set(arrayBuffer.subarray(0, n));
+        }
+      } else {
+        userBuf = arrayBuffer;
+      }
+      ret = self[kBufferCb](nread, userBuf);
     } else {
       ret = self.push(arrayBuffer);
     }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1219,42 +1219,50 @@ Object.defineProperty(Socket.prototype, "pending", {
 });
 
 Socket.prototype.pause = function pause() {
-  if (this[kBuffer] && !this.connecting && this._handle && this._handle.reading !== false) {
-    this._handle.reading = false;
-    if (!this.destroyed) {
-      if ($isCallable(this._handle.readStop)) {
-        const err = this._handle.readStop();
-        if (err) this.destroy(new ErrnoException(err, "read"));
-      } else {
-        // usocket-backed handle in onread mode: keep the pre-existing native
-        // pause, since SocketHandlers.data's onread variant does not apply
-        // backpressure on its own.
-        this._handle.pause?.();
+  const handle = this._handle;
+  if (handle) {
+    if ($isCallable(handle.readStop)) {
+      // stream-wrap handle (TTY / Pipe) — Node lib/net.js behavior.
+      if (this[kBuffer] && !this.connecting && handle.reading) {
+        handle.reading = false;
+        if (!this.destroyed) {
+          const err = handle.readStop();
+          if (err) this.destroy(new ErrnoException(err, "read"));
+        }
       }
+    } else if (!this.destroyed) {
+      // Bun-native socket handle. Pause at the source so the data callback
+      // (which increments bytesRead) can't fire while the stream is paused
+      // — server pauseOnConnect depends on this.
+      handle.pause?.();
     }
   }
   return Duplex.prototype.pause.$call(this);
 };
 
 Socket.prototype.resume = function resume() {
-  if (this[kBuffer] && !this.connecting && this._handle && !this._handle.reading) {
-    if ($isCallable(this._handle.readStart)) {
-      tryReadStart(this);
-    } else {
-      this._handle.reading = true;
-      this._handle.resume?.();
+  const handle = this._handle;
+  if (handle) {
+    if ($isCallable(handle.readStart)) {
+      if (this[kBuffer] && !this.connecting && !handle.reading) {
+        tryReadStart(this);
+      }
+    } else if (!this.connecting) {
+      handle.resume?.();
     }
   }
   return Duplex.prototype.resume.$call(this);
 };
 
 Socket.prototype.read = function read(size) {
-  if (this[kBuffer] && !this.connecting && this._handle && !this._handle.reading) {
-    if ($isCallable(this._handle.readStart)) {
-      tryReadStart(this);
-    } else {
-      this._handle.reading = true;
-      this._handle.resume?.();
+  const handle = this._handle;
+  if (handle) {
+    if ($isCallable(handle.readStart)) {
+      if (this[kBuffer] && !this.connecting && !handle.reading) {
+        tryReadStart(this);
+      }
+    } else if (!this.connecting) {
+      handle.resume?.();
     }
   }
   return Duplex.prototype.read.$call(this, size);

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -57,7 +57,12 @@ const getBufferedAmount = $newZigFunction("socket.zig", "jsGetBufferedAmount", 1
 
 const bunTlsSymbol = Symbol.for("::buntls::");
 const bunSocketServerOptions = Symbol.for("::bunnetserveroptions::");
-const owner_symbol = Symbol("owner_symbol");
+const { owner_symbol } = require("internal/shared");
+
+const UV_EOF = -4095;
+const kBuffer = Symbol("kBuffer");
+const kBufferCb = Symbol("kBufferCb");
+const kBufferGen = Symbol("kBufferGen");
 
 const kServerSocket = Symbol("kServerSocket");
 const kBytesWritten = Symbol("kBytesWritten");
@@ -81,7 +86,7 @@ const kwriteCallback = Symbol("writeCallback");
 const kSocketClass = Symbol("kSocketClass");
 
 function endNT(socket, callback, err) {
-  socket.$end();
+  socket.$end?.();
   callback(err);
 }
 function emitCloseNT(self, hasError) {
@@ -682,8 +687,6 @@ function Socket(options?) {
   Duplex.$call(this, {
     ...opts,
     allowHalfOpen,
-    readable: true,
-    writable: true,
     //For node.js compat do not emit close on destroy.
     emitClose: false,
     autoDestroy: true,
@@ -725,9 +728,22 @@ function Socket(options?) {
   // Shut down the socket when we're finished with it.
   this.on("end", onSocketEnd);
 
-  if (options?.fd !== undefined) {
+  if (options?.handle != null) {
+    this._handle = options.handle;
+    initSocketHandle(this);
+  } else if (options?.fd !== undefined) {
     const { fd } = options;
     validateInt32(fd, "fd", 0);
+  }
+
+  if (this._handle && $isCallable(this._handle.readStart) && options.readable !== false) {
+    if (options.pauseOnCreate) {
+      this._handle.reading = false;
+      this._handle.readStop();
+      this._readableState.flowing = false;
+    } else if (!options.manualStart) {
+      this.read(0);
+    }
   }
 
   if (socket instanceof Socket) {
@@ -740,6 +756,9 @@ function Socket(options?) {
     if (typeof onread.callback !== "function") {
       throw new TypeError("onread.callback must be a function");
     }
+    this[kBuffer] = true;
+    this[kBufferCb] = onread.callback;
+    this[kBufferGen] = typeof onread.buffer === "function" ? onread.buffer : () => onread.buffer;
     // when the onread option is specified we use a different handlers object
     this[khandlers] = {
       ...SocketHandlers2,
@@ -787,7 +806,7 @@ Socket.prototype._onTimeout = function () {
   const handle = this._handle;
   // if there is a handle, and it has pending data,
   // we suppress the timeout because a write is in progress
-  if (handle && getBufferedAmount(handle) > 0) {
+  if (handle && !$isCallable(handle.readStart) && getBufferedAmount(handle) > 0) {
     return;
   }
   this.emit("timeout");
@@ -1199,23 +1218,39 @@ Object.defineProperty(Socket.prototype, "pending", {
   },
 });
 
-Socket.prototype.resume = function resume() {
-  if (!this.connecting) {
-    this._handle?.resume();
-  }
-  return Duplex.prototype.resume.$call(this);
-};
-
 Socket.prototype.pause = function pause() {
-  if (!this.destroyed) {
-    this._handle?.pause();
+  if (this[kBuffer] && !this.connecting && this._handle && $isCallable(this._handle.readStop) && this._handle.reading) {
+    this._handle.reading = false;
+    if (!this.destroyed) {
+      const err = this._handle.readStop();
+      if (err) this.destroy(new ErrnoException(err, "read"));
+    }
   }
   return Duplex.prototype.pause.$call(this);
 };
 
+Socket.prototype.resume = function resume() {
+  if (
+    this[kBuffer] &&
+    !this.connecting &&
+    this._handle &&
+    $isCallable(this._handle.readStart) &&
+    !this._handle.reading
+  ) {
+    tryReadStart(this);
+  }
+  return Duplex.prototype.resume.$call(this);
+};
+
 Socket.prototype.read = function read(size) {
-  if (!this.connecting) {
-    this._handle?.resume();
+  if (
+    this[kBuffer] &&
+    !this.connecting &&
+    this._handle &&
+    $isCallable(this._handle.readStart) &&
+    !this._handle.reading
+  ) {
+    tryReadStart(this);
   }
   return Duplex.prototype.read.$call(this, size);
 };
@@ -1224,8 +1259,10 @@ Socket.prototype._read = function _read(size) {
   const socket = this._handle;
   if (this.connecting || !socket) {
     this.once("connect", () => this._read(size));
+  } else if ($isCallable(socket.readStart)) {
+    if (!socket.reading) tryReadStart(this);
   } else {
-    socket?.resume();
+    socket?.resume?.();
   }
 };
 
@@ -1458,6 +1495,13 @@ Socket.prototype._write = function _write(chunk, encoding, callback) {
     return false;
   }
   this._unrefTimer();
+  if ($isCallable(socket.readStart)) {
+    // Stream-wrap handle (TTY/Pipe). Full writeBuffer/req plumbing is a
+    // follow-up; reachable only for duplex net.Socket({fd}), never for
+    // process.stdin which is constructed with writable:false.
+    callback($ERR_METHOD_NOT_IMPLEMENTED("_write on stream-wrap handle"));
+    return false;
+  }
   const success = socket.$write(chunk, encoding);
   this[kBytesWritten] = socket.bytesWritten;
   if (success) {
@@ -2577,7 +2621,42 @@ function initSocketHandle(self) {
   // Handle creation may be deferred to bind() or connect() time.
   if (self._handle) {
     self._handle[owner_symbol] = self;
+    if ($isCallable(self._handle.readStart)) {
+      self._handle.onread = onStreamRead;
+    }
   }
+}
+
+// Node lib/internal/stream_base_commons.js onStreamRead.
+function onStreamRead(nread, arrayBuffer) {
+  const self = this[owner_symbol];
+  if (nread > 0) {
+    self.bytesRead += nread;
+    let ret;
+    if (self[kBuffer]) {
+      ret = self[kBufferCb](nread, arrayBuffer);
+    } else {
+      ret = self.push(arrayBuffer);
+    }
+    if (ret === false && this.reading) {
+      this.reading = false;
+      this.readStop();
+    }
+    return;
+  }
+  if (nread === 0) return;
+  if (nread !== UV_EOF) {
+    self.destroy(new ErrnoException(nread, "read"));
+    return;
+  }
+  self.push(null);
+  self.read(0);
+}
+
+function tryReadStart(socket) {
+  socket._handle.reading = true;
+  const err = socket._handle.readStart();
+  if (err) socket.destroy(new ErrnoException(err, "read"));
 }
 
 function closeSocketHandle(self, isException, isCleanupPending = false) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -62,7 +62,6 @@ const { owner_symbol } = require("internal/shared");
 const UV_EOF = -4095;
 const kBuffer = Symbol("kBuffer");
 const kBufferCb = Symbol("kBufferCb");
-const kBufferGen = Symbol("kBufferGen");
 
 const kServerSocket = Symbol("kServerSocket");
 const kBytesWritten = Symbol("kBytesWritten");
@@ -758,7 +757,6 @@ function Socket(options?) {
     }
     this[kBuffer] = true;
     this[kBufferCb] = onread.callback;
-    this[kBufferGen] = typeof onread.buffer === "function" ? onread.buffer : () => onread.buffer;
     // when the onread option is specified we use a different handlers object
     this[khandlers] = {
       ...SocketHandlers2,
@@ -1219,38 +1217,43 @@ Object.defineProperty(Socket.prototype, "pending", {
 });
 
 Socket.prototype.pause = function pause() {
-  if (this[kBuffer] && !this.connecting && this._handle && $isCallable(this._handle.readStop) && this._handle.reading) {
+  if (this[kBuffer] && !this.connecting && this._handle && this._handle.reading !== false) {
     this._handle.reading = false;
     if (!this.destroyed) {
-      const err = this._handle.readStop();
-      if (err) this.destroy(new ErrnoException(err, "read"));
+      if ($isCallable(this._handle.readStop)) {
+        const err = this._handle.readStop();
+        if (err) this.destroy(new ErrnoException(err, "read"));
+      } else {
+        // usocket-backed handle in onread mode: keep the pre-existing native
+        // pause, since SocketHandlers.data's onread variant does not apply
+        // backpressure on its own.
+        this._handle.pause?.();
+      }
     }
   }
   return Duplex.prototype.pause.$call(this);
 };
 
 Socket.prototype.resume = function resume() {
-  if (
-    this[kBuffer] &&
-    !this.connecting &&
-    this._handle &&
-    $isCallable(this._handle.readStart) &&
-    !this._handle.reading
-  ) {
-    tryReadStart(this);
+  if (this[kBuffer] && !this.connecting && this._handle && !this._handle.reading) {
+    if ($isCallable(this._handle.readStart)) {
+      tryReadStart(this);
+    } else {
+      this._handle.reading = true;
+      this._handle.resume?.();
+    }
   }
   return Duplex.prototype.resume.$call(this);
 };
 
 Socket.prototype.read = function read(size) {
-  if (
-    this[kBuffer] &&
-    !this.connecting &&
-    this._handle &&
-    $isCallable(this._handle.readStart) &&
-    !this._handle.reading
-  ) {
-    tryReadStart(this);
+  if (this[kBuffer] && !this.connecting && this._handle && !this._handle.reading) {
+    if ($isCallable(this._handle.readStart)) {
+      tryReadStart(this);
+    } else {
+      this._handle.reading = true;
+      this._handle.resume?.();
+    }
   }
   return Duplex.prototype.read.$call(this, size);
 };

--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -12,91 +12,59 @@ const {
 const { validateInteger } = require("internal/validators");
 const fs = require("internal/fs/streams");
 
-function ReadStream(fd): void {
+const { TTY } = process.binding("tty_wrap");
+
+// Node lib/tty.js: tty.ReadStream extends net.Socket with a native TTY handle.
+// readableHighWaterMark: 0 makes push() return false on every chunk so
+// onStreamRead's backpressure path readStop()s between reads, and _read()
+// readStart()s again only when a consumer pulls.
+function ReadStream(fd, options): void {
   if (!(this instanceof ReadStream)) {
-    return new ReadStream(fd);
+    return new ReadStream(fd, options);
   }
-  fs.ReadStream.$apply(this, ["", { fd }]);
+  if (fd >> 0 !== fd || fd < 0) {
+    throw $ERR_OUT_OF_RANGE("fd", "a non-negative integer", fd);
+  }
+
+  const ctx: { code?: string } = {};
+  const tty = new TTY(fd, ctx);
+  if (ctx.code !== undefined) {
+    const err = new Error("TTY initialization failed: " + ctx.code);
+    (err as any).code = "ERR_TTY_INIT_FAILED";
+    throw err;
+  }
+
+  const { Socket } = require("node:net");
+  Socket.$call(this, {
+    readableHighWaterMark: 0,
+    handle: tty,
+    manualStart: true,
+    ...options,
+  });
+
+  this.fd = fd;
   this.isRaw = false;
-  // Only set isTTY to true if the fd is actually a TTY
-  this.isTTY = isatty(fd);
+  this.isTTY = true;
 }
-$toClass(ReadStream, "ReadStream", fs.ReadStream);
 
 Object.defineProperty(ReadStream, "prototype", {
   get() {
-    const Prototype = Object.create(fs.ReadStream.prototype);
-
-    // Add ref/unref methods to make tty.ReadStream behave like Node.js
-    // where TTY streams have socket-like behavior
-    Prototype.ref = function () {
-      // Get the underlying native stream source if available
-      const source = this.$bunNativePtr;
-      if (source?.updateRef) {
-        source.updateRef(true);
-      }
-      return this;
-    };
-
-    Prototype.unref = function () {
-      // Get the underlying native stream source if available
-      const source = this.$bunNativePtr;
-      if (source?.updateRef) {
-        source.updateRef(false);
-      }
-      return this;
-    };
+    const { Socket } = require("node:net");
+    const Prototype = Object.create(Socket.prototype);
 
     Prototype.setRawMode = function (flag) {
       flag = !!flag;
-
-      // On windows, this goes through the stream handle itself, as it must call
-      // uv_tty_set_mode on the uv_tty_t.
-      //
-      // On POSIX, I tried to use the same approach, but it didn't work reliably,
-      // so we just use the file descriptor and use termios APIs directly.
-      if (process.platform === "win32") {
-        // Special case for stdin, as it has a shared uv_tty handle
-        // and it's stream is constructed differently
-        if (this.fd === 0) {
-          const err = ttySetMode(flag);
-          if (err) {
-            this.emit("error", new Error("setRawMode failed with errno: " + err));
-          }
-          return this;
-        }
-
-        const handle = this.$bunNativePtr;
-        if (!handle) {
-          this.emit("error", new Error("setRawMode failed because it was called on something that is not a TTY"));
-          return this;
-        }
-
-        // If you call setRawMode before you call on('data'), the stream will
-        // not be constructed, leading to EBADF
-        // This corresponds to the `ensureConstructed` function in `native-readable.ts`
-        this.$start();
-
-        const err = handle.setRawMode(flag);
-        if (err) {
-          this.emit("error", err);
-          return this;
-        }
-      } else {
-        const err = ttySetMode(this.fd, flag);
-        if (err) {
-          this.emit("error", new Error("setRawMode failed with errno: " + err));
-          return this;
-        }
+      const err = this._handle?.setRawMode(flag);
+      if (err) {
+        this.emit("error", new Error("setRawMode failed with errno: " + err));
+        return this;
       }
-
       this.isRaw = flag;
-
       return this;
     };
 
     Object.defineProperty(ReadStream, "prototype", { value: Prototype });
-
+    Object.setPrototypeOf(ReadStream, Socket);
     return Prototype;
   },
   enumerable: true,

--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -55,6 +55,7 @@ Object.defineProperty(ReadStream, "prototype", {
   get() {
     const Socket = net.Socket;
     const Prototype = Object.create(Socket.prototype);
+    Prototype.constructor = ReadStream;
 
     Prototype.setRawMode = function (flag) {
       flag = !!flag;

--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -3,11 +3,7 @@
 // Note: please keep this module's loading constrants light, as some users
 // import it just to call `isatty`. In that case, `node:stream` is not needed.
 
-const {
-  setRawMode: ttySetMode,
-  isatty,
-  getWindowSize: _getWindowSize,
-} = $cpp("ProcessBindingTTYWrap.cpp", "createBunTTYFunctions");
+const { isatty, getWindowSize: _getWindowSize } = $cpp("ProcessBindingTTYWrap.cpp", "createBunTTYFunctions");
 
 const { validateInteger } = require("internal/validators");
 const fs = require("internal/fs/streams");

--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -7,6 +7,7 @@ const { isatty, getWindowSize: _getWindowSize } = $cpp("ProcessBindingTTYWrap.cp
 
 const { validateInteger } = require("internal/validators");
 const fs = require("internal/fs/streams");
+const { Socket } = require("node:net");
 
 const { TTY } = process.binding("tty_wrap");
 
@@ -30,7 +31,6 @@ function ReadStream(fd, options): void {
     throw err;
   }
 
-  const { Socket } = require("node:net");
   Socket.$call(this, {
     readableHighWaterMark: 0,
     handle: tty,
@@ -43,29 +43,23 @@ function ReadStream(fd, options): void {
   this.isTTY = true;
 }
 
-Object.defineProperty(ReadStream, "prototype", {
-  get() {
-    const { Socket } = require("node:net");
-    const Prototype = Object.create(Socket.prototype);
+// Wire the constructor chain eagerly (Node lib/tty.js does the same) so
+// Object.getPrototypeOf(tty.ReadStream) === net.Socket holds without first
+// touching ReadStream.prototype — test-net-access-byteswritten.js relies on
+// this.
+Object.setPrototypeOf(ReadStream.prototype, Socket.prototype);
+Object.setPrototypeOf(ReadStream, Socket);
 
-    Prototype.setRawMode = function (flag) {
-      flag = !!flag;
-      const err = this._handle?.setRawMode(flag);
-      if (err) {
-        this.emit("error", new Error("setRawMode failed with errno: " + err));
-        return this;
-      }
-      this.isRaw = flag;
-      return this;
-    };
-
-    Object.defineProperty(ReadStream, "prototype", { value: Prototype });
-    Object.setPrototypeOf(ReadStream, Socket);
-    return Prototype;
-  },
-  enumerable: true,
-  configurable: true,
-});
+ReadStream.prototype.setRawMode = function (flag) {
+  flag = !!flag;
+  const err = this._handle?.setRawMode(flag);
+  if (err) {
+    this.emit("error", new Error("setRawMode failed with errno: " + err));
+    return this;
+  }
+  this.isRaw = flag;
+  return this;
+};
 
 function WriteStream(fd): void {
   if (!(this instanceof WriteStream)) return new WriteStream(fd);

--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -7,7 +7,7 @@ const { isatty, getWindowSize: _getWindowSize } = $cpp("ProcessBindingTTYWrap.cp
 
 const { validateInteger } = require("internal/validators");
 const fs = require("internal/fs/streams");
-const { Socket } = require("node:net");
+const net = require("node:net");
 
 const { TTY } = process.binding("tty_wrap");
 
@@ -31,7 +31,7 @@ function ReadStream(fd, options): void {
     throw err;
   }
 
-  Socket.$call(this, {
+  net.Socket.$call(this, {
     readableHighWaterMark: 0,
     handle: tty,
     manualStart: true,
@@ -44,22 +44,36 @@ function ReadStream(fd, options): void {
 }
 
 // Wire the constructor chain eagerly (Node lib/tty.js does the same) so
-// Object.getPrototypeOf(tty.ReadStream) === net.Socket holds without first
-// touching ReadStream.prototype — test-net-access-byteswritten.js relies on
-// this.
-Object.setPrototypeOf(ReadStream.prototype, Socket.prototype);
-Object.setPrototypeOf(ReadStream, Socket);
+// Object.getPrototypeOf(tty.ReadStream) === net.Socket holds without
+// touching ReadStream.prototype first — test-net-access-byteswritten.js
+// relies on this. $toClass falls back to Function.prototype if the base
+// isn't an object yet (circular load); the lazy prototype getter below
+// re-installs the real chain on first access in that case.
+$toClass(ReadStream, "ReadStream", net.Socket);
 
-ReadStream.prototype.setRawMode = function (flag) {
-  flag = !!flag;
-  const err = this._handle?.setRawMode(flag);
-  if (err) {
-    this.emit("error", new Error("setRawMode failed with errno: " + err));
-    return this;
-  }
-  this.isRaw = flag;
-  return this;
-};
+Object.defineProperty(ReadStream, "prototype", {
+  get() {
+    const Socket = net.Socket;
+    const Prototype = Object.create(Socket.prototype);
+
+    Prototype.setRawMode = function (flag) {
+      flag = !!flag;
+      const err = this._handle?.setRawMode(flag);
+      if (err) {
+        this.emit("error", new Error("setRawMode failed with errno: " + err));
+        return this;
+      }
+      this.isRaw = flag;
+      return this;
+    };
+
+    Object.defineProperty(ReadStream, "prototype", { value: Prototype });
+    Object.setPrototypeOf(ReadStream, Socket);
+    return Prototype;
+  },
+  enumerable: true,
+  configurable: true,
+});
 
 function WriteStream(fd): void {
   if (!(this instanceof WriteStream)) return new WriteStream(fd);

--- a/test/js/node/net/socket-handle-option.test.ts
+++ b/test/js/node/net/socket-handle-option.test.ts
@@ -93,3 +93,52 @@ test("net.Socket({handle, onread}) passes user buffer to callback", async () => 
   expect(calls[0].buf).not.toBe(handleBuf);
   expect(userBuf.subarray(0, 5).toString()).toBe("hello");
 });
+
+// When the user buffer is smaller than the chunk, the copy truncates — the
+// callback must be told the truncated count, not the handle's full nread,
+// or buf.subarray(0, nread) overruns into stale data.
+test("net.Socket({handle, onread}) reports truncated nread for small buffer", async () => {
+  let onread;
+  const handle = {
+    readStart() {
+      return 0;
+    },
+    readStop() {
+      return 0;
+    },
+    close() {},
+    set onread(fn) {
+      onread = fn;
+    },
+    get onread() {
+      return onread;
+    },
+    reading: false,
+  };
+
+  const userBuf = Buffer.alloc(4);
+  const calls: { nread: number; buf: Buffer }[] = [];
+  const socket = new Socket({
+    handle,
+    manualStart: true,
+    writable: false,
+    onread: {
+      buffer: userBuf,
+      callback(nread, buf) {
+        calls.push({ nread, buf });
+      },
+    },
+  });
+  socket.read(0);
+
+  onread.call(handle, 10, Buffer.from("0123456789"));
+  onread.call(handle, -4095, undefined); // UV_EOF
+
+  await new Promise(resolve => socket.on("end", resolve));
+
+  expect(calls.length).toBe(1);
+  expect(calls[0].buf).toBe(userBuf);
+  expect(calls[0].nread).toBe(4); // truncated to userBuf.byteLength
+  expect(userBuf.toString()).toBe("0123");
+  expect(calls[0].buf.subarray(0, calls[0].nread).toString()).toBe("0123");
+});

--- a/test/js/node/net/socket-handle-option.test.ts
+++ b/test/js/node/net/socket-handle-option.test.ts
@@ -44,3 +44,52 @@ test("net.Socket({handle, manualStart}) drives onStreamRead", async () => {
   expect(socket.bytesRead).toBe(5);
   expect(socket.writable).toBe(false);
 });
+
+// onread: {buffer, callback} must deliver the caller's buffer to the
+// callback, not the handle's internal buffer.
+test("net.Socket({handle, onread}) passes user buffer to callback", async () => {
+  let onread;
+  const handle = {
+    readStart() {
+      return 0;
+    },
+    readStop() {
+      return 0;
+    },
+    close() {},
+    set onread(fn) {
+      onread = fn;
+    },
+    get onread() {
+      return onread;
+    },
+    reading: false,
+  };
+
+  const userBuf = Buffer.alloc(16);
+  const calls: { nread: number; buf: Buffer }[] = [];
+  const socket = new Socket({
+    handle,
+    manualStart: true,
+    writable: false,
+    onread: {
+      buffer: userBuf,
+      callback(nread, buf) {
+        calls.push({ nread, buf });
+      },
+    },
+  });
+  socket.read(0);
+
+  const handleBuf = Buffer.from("hello");
+  onread.call(handle, 5, handleBuf);
+  onread.call(handle, -4095, undefined); // UV_EOF
+
+  await new Promise(resolve => socket.on("end", resolve));
+
+  expect(calls.length).toBe(1);
+  expect(calls[0].nread).toBe(5);
+  expect(calls[0].buf).toBe(userBuf); // identity, not the handle's buffer
+  expect(calls[0].buf).not.toBe(handleBuf);
+  expect(userBuf.subarray(0, 5).toString()).toBe("hello");
+});

--- a/test/js/node/net/socket-handle-option.test.ts
+++ b/test/js/node/net/socket-handle-option.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import { Socket } from "node:net";
+
+// new Socket({handle, manualStart}) wires _handle.onread = onStreamRead and
+// drives reads via readStart/readStop (Node's stream-wrap contract). The
+// handle here is a JS mock — the native TTY/Pipe handles ship in follow-ups.
+test("net.Socket({handle, manualStart}) drives onStreamRead", async () => {
+  let onread;
+  let readStartCalls = 0;
+  const handle = {
+    readStart() {
+      readStartCalls++;
+      return 0;
+    },
+    readStop() {
+      return 0;
+    },
+    close() {},
+    set onread(fn) {
+      onread = fn;
+    },
+    get onread() {
+      return onread;
+    },
+    reading: false,
+  };
+
+  const socket = new Socket({ handle, manualStart: true, writable: false });
+  expect(socket._handle).toBe(handle);
+  expect(typeof onread).toBe("function");
+  expect(readStartCalls).toBe(0); // manualStart
+
+  const chunks: Buffer[] = [];
+  socket.on("data", c => chunks.push(c));
+  await Bun.sleep(0);
+  expect(readStartCalls).toBe(1); // _read → tryReadStart
+
+  onread.call(handle, 5, Buffer.from("hello"));
+  onread.call(handle, -4095, undefined); // UV_EOF
+
+  await new Promise(resolve => socket.on("end", resolve));
+
+  expect(Buffer.concat(chunks).toString()).toBe("hello");
+  expect(socket.bytesRead).toBe(5);
+  expect(socket.writable).toBe(false);
+});

--- a/test/js/node/nodettywrap.test.ts
+++ b/test/js/node/nodettywrap.test.ts
@@ -17,6 +17,12 @@ test("process.binding('tty_wrap')", () => {
 
   expect(tty_prototype).toHaveProperty("getWindowSize");
   expect(tty_prototype).toHaveProperty("setRawMode");
+  // Stream-handle surface (Node's LibuvStreamWrap interface). Exercising these
+  // proves the Zig handle compiles and is wired on every platform — the PTY
+  // tests can't run on Windows.
+  for (const m of ["readStart", "readStop", "ref", "unref", "close"]) {
+    expect(typeof tty_prototype[m]).toBe("function");
+  }
 
   const tty_isTTY = tty_wrap.isTTY;
 
@@ -28,13 +34,25 @@ test("process.binding('tty_wrap')", () => {
 
   expect(() => tty()).toThrow(TypeError);
 
-  if (isatty(0)) {
-    expect(() => new tty(0)).not.toThrow();
+  // Find a tty fd to construct a real handle; CI on each platform runs at
+  // least one job with a tty attached to one of these.
+  const ttyFd = [0, 1, 2].find(fd => isatty(fd));
+
+  if (ttyFd !== undefined) {
+    expect(() => new tty(ttyFd)).not.toThrow();
+
+    const handle = new tty(ttyFd);
+    // Exercise the readStart/readStop native paths — return 0 on success.
+    expect(handle.readStart()).toBe(0);
+    expect(handle.readStop()).toBe(0);
+    handle.unref();
+    handle.ref();
+    expect(() => handle.close()).not.toThrow();
 
     const array = [-1, -1];
 
     expect(() => tty_prototype.getWindowSize.call(array, 0)).toThrow(TypeError);
-    const ttywrapper = new tty(0);
+    const ttywrapper = new tty(ttyFd);
 
     expect(ttywrapper.getWindowSize(array)).toBeBoolean();
 
@@ -51,6 +69,6 @@ test("process.binding('tty_wrap')", () => {
     // Node's TTY binding accepts non-tty fds (uv_tty_init reports via ctx
     // out-param, not throw). The handle just won't deliver tty-specific data.
     expect(() => new tty(0)).not.toThrow();
-    console.warn("warn: Skipping tty tests because stdin is not a tty");
+    console.warn("warn: Skipping tty handle tests because no fd in [0,1,2] is a tty");
   }
 });

--- a/test/js/node/nodettywrap.test.ts
+++ b/test/js/node/nodettywrap.test.ts
@@ -48,7 +48,9 @@ test("process.binding('tty_wrap')", () => {
       expect(array[1]).toBe(-1);
     }
   } else {
-    expect(() => new tty(0)).toThrow();
+    // Node's TTY binding accepts non-tty fds (uv_tty_init reports via ctx
+    // out-param, not throw). The handle just won't deliver tty-specific data.
+    expect(() => new tty(0)).not.toThrow();
     console.warn("warn: Skipping tty tests because stdin is not a tty");
   }
 });

--- a/test/js/node/process/stdin/readable-removed-releases-tty.mjs
+++ b/test/js/node/process/stdin/readable-removed-releases-tty.mjs
@@ -1,0 +1,45 @@
+// Under a real TTY (highWaterMark 0), after removing the last 'readable'
+// listener Node releases fd 0 via backpressure (push() returns false →
+// readStop()) once the next chunk arrives, so a stdio:'inherit' child reads
+// subsequent bytes. Parent may buffer at most ONE chunk before release.
+import { spawn } from "node:child_process";
+
+const drain = () => {
+  let c;
+  while ((c = process.stdin.read()) !== null) {
+    process.stdout.write("PARENT:" + JSON.stringify(c.toString()) + "\n");
+  }
+};
+process.stdin.setRawMode(true);
+process.stdin.on("readable", drain);
+
+// give the read loop a tick to start
+process.stdout.write("%ready%\n");
+
+process.stdin.once("readable", () => {
+  // first byte arrives → drain it, then unsubscribe and hand off to child
+  process.stdin.removeListener("readable", drain);
+  process.stdin.setRawMode(false);
+
+  const child = spawn(
+    process.execPath,
+    [
+      "-e",
+      `process.stdin.setRawMode(true);
+       process.stdin.on("data", d => {
+         for (const ch of d.toString()) {
+           if (ch === "\\x03") process.exit(0);
+           process.stdout.write("CHILD:" + JSON.stringify(ch) + "\\n");
+         }
+         process.stdout.write("%ready%\\n");
+       });
+       process.stdout.write("%ready%\\n");`,
+    ],
+    { stdio: "inherit" },
+  );
+  child.on("close", code => {
+    process.stdout.write("PARENT: child closed " + code + "\n");
+    process.stdout.write("%ready%\n");
+    process.exit(code ?? 1);
+  });
+});

--- a/test/js/node/process/stdin/run-with-pty-readable.py
+++ b/test/js/node/process/stdin/run-with-pty-readable.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+import pty
+import os
+import sys
+import select
+import signal
+
+def waitForReady():
+    buffer = b""
+    while b"%ready%" not in buffer:
+        ready = select.select([master_fd], [], [], 0.1)[0]
+        if ready:
+            data = os.read(master_fd, 1024)
+            if data:
+                buffer += data
+                sys.stdout.buffer.write(data)
+                sys.stdout.buffer.flush()
+
+def waitAndWrite(b):
+    waitForReady()
+    os.write(master_fd, b)
+
+def timeout_handler(signum, frame):
+    try:
+        os.kill(pid, 9)
+    except:
+        pass
+    sys.exit(1)
+
+command = sys.argv[1:]
+master_fd, slave_fd = pty.openpty()
+pid = os.fork()
+
+if pid == 0:
+    os.close(master_fd)
+    os.setsid()
+    os.dup2(slave_fd, 0)
+    os.dup2(slave_fd, 1)
+    os.dup2(slave_fd, 2)
+    if slave_fd > 2:
+        os.close(slave_fd)
+    os.execvp(command[0], command)
+else:
+    os.close(slave_fd)
+    signal.signal(signal.SIGALRM, timeout_handler)
+    signal.alarm(5)
+
+    # Parent: trigger first 'readable' (parent drains '1', then removes listener)
+    waitAndWrite(b'1')
+    # Child spawned and wrote %ready%. The parent may buffer at most one chunk
+    # before backpressure releases fd 0, so the first byte sent here may be
+    # swallowed silently. Don't wait for an echo between bytes.
+    waitForReady()
+    for b in (b'A', b'B', b'C', b'D', b'E'):
+        os.write(master_fd, b)
+        # Drain any output but don't require %ready% (the first byte may be
+        # buffered in the parent with no echo).
+        deadline = 0.1
+        while deadline > 0:
+            ready = select.select([master_fd], [], [], 0.05)[0]
+            deadline -= 0.05
+            if ready:
+                data = os.read(master_fd, 1024)
+                sys.stdout.buffer.write(data)
+                sys.stdout.buffer.flush()
+    os.write(master_fd, b'\x03')
+    waitForReady()
+
+    _, status = os.waitpid(pid, 0)
+    os.close(master_fd)
+    sys.exit(os.WEXITSTATUS(status) if os.WIFEXITED(status) else 1)

--- a/test/js/node/tty-readstream-prototype.test.ts
+++ b/test/js/node/tty-readstream-prototype.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+test.skipIf(isWindows)("tty.ReadStream extends net.Socket with a native TTY _handle", async () => {
+  // Under a PTY so process.stdin is a tty.ReadStream.
+  await using proc = Bun.spawn({
+    cmd: [
+      "script",
+      "-q",
+      "/dev/null",
+      bunExe(),
+      "-e",
+      `
+        const net = require("net");
+        const tty = require("tty");
+        const { Duplex, Readable } = require("stream");
+        const s = process.stdin;
+        const out = {
+          isReadStream: s instanceof tty.ReadStream,
+          isSocket: s instanceof net.Socket,
+          isDuplex: s instanceof Duplex,
+          isReadable: s instanceof Readable,
+          protoChain: Object.getPrototypeOf(tty.ReadStream.prototype) === net.Socket.prototype,
+          handle: s._handle?.constructor.name,
+          hwm: s.readableHighWaterMark,
+          handleMethods: ["readStart", "readStop", "setRawMode", "getWindowSize", "ref", "unref", "close"].every(
+            m => typeof s._handle?.[m] === "function"
+          ),
+        };
+        process.stdout.write(JSON.stringify(out));
+        process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const json = stdout.slice(stdout.indexOf("{"));
+  expect(JSON.parse(json)).toEqual({
+    isReadStream: true,
+    isSocket: true,
+    isDuplex: true,
+    isReadable: true,
+    protoChain: true,
+    handle: "TTY",
+    hwm: 0,
+    handleMethods: true,
+  });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/tty-readstream-prototype.test.ts
+++ b/test/js/node/tty-readstream-prototype.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 // `script` gives us a real PTY so process.stdin takes the tty.ReadStream path.
 // Alpine musl images don't ship util-linux `script`, and there's no /dev/tty
@@ -7,40 +7,46 @@ import { bunEnv, bunExe, isWindows } from "harness";
 const scriptPath = Bun.which("script");
 
 test.skipIf(isWindows || !scriptPath)("tty.ReadStream extends net.Socket with a native TTY _handle", async () => {
-  const probe = `
-    const net = require("net");
-    const tty = require("tty");
-    const { Duplex, Readable } = require("stream");
-    const s = process.stdin;
-    const out = {
-      isReadStream: s instanceof tty.ReadStream,
-      isSocket: s instanceof net.Socket,
-      isDuplex: s instanceof Duplex,
-      isReadable: s instanceof Readable,
-      protoChain: Object.getPrototypeOf(tty.ReadStream.prototype) === net.Socket.prototype,
-      handle: s._handle?.constructor.name,
-      hwm: s.readableHighWaterMark,
-      handleMethods: ["readStart", "readStop", "setRawMode", "getWindowSize", "ref", "unref", "close"].every(
-        m => typeof s._handle?.[m] === "function"
-      ),
-    };
-    process.stdout.write("\\n<<<JSON" + JSON.stringify(out) + "JSON>>>\\n");
-    process.exit(0);
-  `;
-  const inner = `${bunExe()} -e ${JSON.stringify(probe)}`;
+  // Write the probe to a file — going through `sh -c "bun -e ..."` needs
+  // shell-escaping the source, and JSON.stringify's output is JS-string
+  // syntax, not POSIX-shell syntax (\\n stays literal under sh).
+  using dir = tempDir("tty-readstream-proto", {
+    "probe.js": `
+      const net = require("net");
+      const tty = require("tty");
+      const { Duplex, Readable } = require("stream");
+      const s = process.stdin;
+      const out = {
+        isReadStream: s instanceof tty.ReadStream,
+        isSocket: s instanceof net.Socket,
+        isDuplex: s instanceof Duplex,
+        isReadable: s instanceof Readable,
+        protoChain: Object.getPrototypeOf(tty.ReadStream.prototype) === net.Socket.prototype,
+        handle: s._handle?.constructor.name,
+        hwm: s.readableHighWaterMark,
+        handleMethods: ["readStart", "readStop", "setRawMode", "getWindowSize", "ref", "unref", "close"].every(
+          m => typeof s._handle?.[m] === "function"
+        ),
+      };
+      process.stdout.write("\\n<<<JSON" + JSON.stringify(out) + "JSON>>>\\n");
+      process.exit(0);
+    `,
+  });
+
+  const inner = `${bunExe()} ${dir}/probe.js`;
   // BSD script (macOS): script -q /dev/null <cmd> <args...>
   // util-linux script:  script -q -c "<command>" /dev/null
   const cmd =
     process.platform === "darwin"
-      ? [scriptPath!, "-q", "/dev/null", "sh", "-c", inner]
+      ? [scriptPath!, "-q", "/dev/null", bunExe(), `${dir}/probe.js`]
       : [scriptPath!, "-q", "-c", inner, "/dev/null"];
 
   await using proc = Bun.spawn({ cmd, env: bunEnv, stdout: "pipe", stderr: "pipe" });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
+  expect(stderr.trim()).toBe("");
   const m = stdout.match(/<<<JSON(.*?)JSON>>>/s);
-  expect(m?.[1], `no JSON in stdout; stdout=${JSON.stringify(stdout)}`).toBeString();
+  expect(m?.[1], `no JSON marker; stdout=${JSON.stringify(stdout)} exit=${exitCode}`).toBeString();
   expect(JSON.parse(m![1])).toEqual({
     isReadStream: true,
     isSocket: true,

--- a/test/js/node/tty-readstream-prototype.test.ts
+++ b/test/js/node/tty-readstream-prototype.test.ts
@@ -1,44 +1,47 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
 
-test.skipIf(isWindows)("tty.ReadStream extends net.Socket with a native TTY _handle", async () => {
-  // Under a PTY so process.stdin is a tty.ReadStream.
-  await using proc = Bun.spawn({
-    cmd: [
-      "script",
-      "-q",
-      "/dev/null",
-      bunExe(),
-      "-e",
-      `
-        const net = require("net");
-        const tty = require("tty");
-        const { Duplex, Readable } = require("stream");
-        const s = process.stdin;
-        const out = {
-          isReadStream: s instanceof tty.ReadStream,
-          isSocket: s instanceof net.Socket,
-          isDuplex: s instanceof Duplex,
-          isReadable: s instanceof Readable,
-          protoChain: Object.getPrototypeOf(tty.ReadStream.prototype) === net.Socket.prototype,
-          handle: s._handle?.constructor.name,
-          hwm: s.readableHighWaterMark,
-          handleMethods: ["readStart", "readStop", "setRawMode", "getWindowSize", "ref", "unref", "close"].every(
-            m => typeof s._handle?.[m] === "function"
-          ),
-        };
-        process.stdout.write(JSON.stringify(out));
-        process.exit(0);
-      `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+// `script` gives us a real PTY so process.stdin takes the tty.ReadStream path.
+// Alpine musl images don't ship util-linux `script`, and there's no /dev/tty
+// equivalent on Windows — skip on both.
+const scriptPath = Bun.which("script");
 
+test.skipIf(isWindows || !scriptPath)("tty.ReadStream extends net.Socket with a native TTY _handle", async () => {
+  const probe = `
+    const net = require("net");
+    const tty = require("tty");
+    const { Duplex, Readable } = require("stream");
+    const s = process.stdin;
+    const out = {
+      isReadStream: s instanceof tty.ReadStream,
+      isSocket: s instanceof net.Socket,
+      isDuplex: s instanceof Duplex,
+      isReadable: s instanceof Readable,
+      protoChain: Object.getPrototypeOf(tty.ReadStream.prototype) === net.Socket.prototype,
+      handle: s._handle?.constructor.name,
+      hwm: s.readableHighWaterMark,
+      handleMethods: ["readStart", "readStop", "setRawMode", "getWindowSize", "ref", "unref", "close"].every(
+        m => typeof s._handle?.[m] === "function"
+      ),
+    };
+    process.stdout.write("\\n<<<JSON" + JSON.stringify(out) + "JSON>>>\\n");
+    process.exit(0);
+  `;
+  const inner = `${bunExe()} -e ${JSON.stringify(probe)}`;
+  // BSD script (macOS): script -q /dev/null <cmd> <args...>
+  // util-linux script:  script -q -c "<command>" /dev/null
+  const cmd =
+    process.platform === "darwin"
+      ? [scriptPath!, "-q", "/dev/null", "sh", "-c", inner]
+      : [scriptPath!, "-q", "-c", inner, "/dev/null"];
+
+  await using proc = Bun.spawn({ cmd, env: bunEnv, stdout: "pipe", stderr: "pipe" });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const json = stdout.slice(stdout.indexOf("{"));
-  expect(JSON.parse(json)).toEqual({
+
+  expect(stderr).toBe("");
+  const m = stdout.match(/<<<JSON(.*?)JSON>>>/s);
+  expect(m?.[1], `no JSON in stdout; stdout=${JSON.stringify(stdout)}`).toBeString();
+  expect(JSON.parse(m![1])).toEqual({
     isReadStream: true,
     isSocket: true,
     isDuplex: true,

--- a/test/regression/issue/29126.test.ts
+++ b/test/regression/issue/29126.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+import { join } from "node:path";
+
+// Node's tty.ReadStream sets highWaterMark: 0 so push() returns false on
+// every chunk and onStreamRead readStop()s. After the 'readable' listener is
+// removed, the next chunk pushes → false → readStop, and a stdio:'inherit'
+// child reads subsequent bytes from fd 0. Bun's stdin is wrapped around an
+// async reader, so this exercises the equivalent disown-on-backpressure path.
+test.skipIf(isWindows)("removing the last 'readable' listener releases fd 0 under a TTY", async () => {
+  const fixtureDir = join(import.meta.dir, "..", "..", "js", "node", "process", "stdin");
+  const script = join(fixtureDir, "readable-removed-releases-tty.mjs");
+  const pty = join(fixtureDir, "run-with-pty-readable.py");
+
+  await using proc = Bun.spawn({
+    cmd: [Bun.which("python3") ?? Bun.which("python") ?? "python", pty, bunExe(), script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const childLines = stdout
+    .split("\n")
+    .map(l => l.trim())
+    .filter(l => l.startsWith("CHILD:"));
+
+  // The parent may buffer at most one chunk (Node's backpressure semantics
+  // with highWaterMark 0). The child must receive at least 4 of the 5 bytes
+  // A–E. On the unfixed build, the parent buffers ≥2 bytes and the child
+  // receives <4.
+  expect({ stderr, childLines, exitCode }).toEqual({
+    stderr: "",
+    childLines: expect.arrayContaining(['CHILD:"B"', 'CHILD:"C"', 'CHILD:"D"', 'CHILD:"E"']),
+    exitCode: 0,
+  });
+  expect(childLines.length).toBeGreaterThanOrEqual(4);
+});

--- a/test/regression/issue/tui-app-tty-pattern.test.ts
+++ b/test/regression/issue/tui-app-tty-pattern.test.ts
@@ -107,35 +107,34 @@ test("TUI app pattern: read piped stdin then reopen /dev/tty", async () => {
   expect(exitCode).toBe(0);
 });
 
-// Test that tty.ReadStream works correctly with various file descriptors
-test("tty.ReadStream handles non-TTY file descriptors correctly", () => {
+// Node's uv_tty_init rejects regular-file fds with UV_EINVAL, so
+// new tty.ReadStream(regular_file_fd) throws ERR_TTY_INIT_FAILED. Bun now
+// matches this since tty.ReadStream extends net.Socket with a native TTY
+// handle (previously it wrapped fs.ReadStream and accepted any fd).
+test("tty.ReadStream rejects non-TTY file descriptors", () => {
   const fs = require("fs");
   const tty = require("tty");
   const path = require("path");
   const os = require("os");
 
-  // Create a regular file in the system temp directory
   const tempFile = path.join(os.tmpdir(), "test-regular-file-" + Date.now() + ".txt");
   fs.writeFileSync(tempFile, "test content");
 
+  let fd;
   try {
-    const fd = fs.openSync(tempFile, "r");
-    const stream = new tty.ReadStream(fd);
-
-    // Regular file should not be identified as TTY
-    expect(stream.isTTY).toBe(false);
-
-    // ref/unref should still exist (for compatibility) but may be no-ops
-    expect(typeof stream.ref).toBe("function");
-    expect(typeof stream.unref).toBe("function");
-
-    // Clean up - only destroy the stream, don't double-close the fd
-    stream.destroy();
+    fd = fs.openSync(tempFile, "r");
+    let thrown;
+    try {
+      new tty.ReadStream(fd);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeDefined();
+    expect(thrown.code).toBe("ERR_TTY_INIT_FAILED");
   } finally {
     try {
+      if (fd !== undefined) fs.closeSync(fd);
       fs.unlinkSync(tempFile);
-    } catch (e) {
-      // Ignore cleanup errors
-    }
+    } catch {}
   }
 });


### PR DESCRIPTION
Part **3/5** of the `process.stdin` Node-parity stack. Stacked on #29139. **Fixes #29126.**

`tty.ReadStream` now extends `net.Socket` (like Node) with `_handle` = a native Zig `TTY` object exposing `readStart`/`readStop`/`setRawMode`/`getWindowSize`/`ref`/`unref` and the `onread(nread, buf)` callback.

- `TTY.zig` + `tty.classes.ts`: backed by `bun.io.BufferedReader`. fd reopened `O_NONBLOCK` with fallback. **Ref-counted** — JS wrapper holds one ref, reader holds one while polling, so reader callbacks never fire on freed memory.
- `ProcessBindingTTYWrap.cpp`: replaces C++ `TTYWrapObject` with the Zig-generated constructor on `process.binding('tty_wrap')`
- `tty.ts`: `ReadStream` rewritten to match Node `lib/tty.js`
- `getStdinStream`: TTY path = `new tty.ReadStream(fd)` + `readStop` + `'pause'` listener (Node `is_main_thread.js` parity); pipe/file unchanged

156 pass / 0 fail (stdin/stdio/tty/readline/stream/net). `zig:check-all` clean. Both new tests fail on system bun.

Stack:
- A: `guessHandleType` (#29137)
- B: `net.Socket({handle})` (#29139)
- **→ C: this PR**
- D: native `Pipe` handle + `createHandle`
- E: Pipe `writeBuffer`/`shutdown`