### PR TITLE
fix(cron): cap macOS launchd calendar-interval product at 256

### DIFF
--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -1385,6 +1385,15 @@ fn cronToCalendarInterval(schedule: []const u8) ![]const u8 {
         }
         try result.appendSlice("    </dict>");
     } else {
+        // Bound total StartCalendarInterval dicts before emitting. The OR split emits two
+        // passes (day-of-month and day-of-week) whose sum is what launchd actually parses,
+        // so cap the sum — not each pass — at 256.
+        const total: u64 = if (needs_or_split)
+            countCalendarDicts(field_values, .exclude_weekday) + countCalendarDicts(field_values, .exclude_day)
+        else
+            countCalendarDicts(field_values, .include_all);
+        if (total > 256) return error.TooManyTriggers;
+
         try result.appendSlice("    <array>\n");
 
         if (needs_or_split) {
@@ -1411,28 +1420,37 @@ fn appendCalendarKey(result: *std.array_list.Managed(u8), key: []const u8, val: 
 
 const EmitMode = enum { include_all, exclude_weekday, exclude_day };
 
-/// Emit Cartesian-product <dict> entries for the given field values.
-/// In exclude_weekday mode, day-of-week (index 4) is treated as wildcard.
-/// In exclude_day mode, day-of-month (index 2) is treated as wildcard.
-fn emitCalendarDicts(result: *std.array_list.Managed(u8), field_values: [5]?[]const i32, mode: EmitMode) !void {
-    const plist_keys = [_][]const u8{ "Minute", "Hour", "Day", "Month", "Weekday" };
-
-    // Build effective field values based on mode
+fn effectiveFieldValues(field_values: [5]?[]const i32, mode: EmitMode) [5]?[]const i32 {
     var effective: [5]?[]const i32 = field_values;
     switch (mode) {
         .exclude_weekday => effective[4] = null,
         .exclude_day => effective[2] = null,
         .include_all => {},
     }
+    return effective;
+}
+
+/// Count how many <dict> entries emitCalendarDicts() would produce for a given mode.
+fn countCalendarDicts(field_values: [5]?[]const i32, mode: EmitMode) u64 {
+    const effective = effectiveFieldValues(field_values, mode);
+    var product: u64 = 1;
+    inline for (effective) |fv| product *= if (fv) |v| v.len else 1;
+    return product;
+}
+
+/// Emit Cartesian-product <dict> entries for the given field values.
+/// In exclude_weekday mode, day-of-week (index 4) is treated as wildcard.
+/// In exclude_day mode, day-of-month (index 2) is treated as wildcard.
+fn emitCalendarDicts(result: *std.array_list.Managed(u8), field_values: [5]?[]const i32, mode: EmitMode) !void {
+    const plist_keys = [_][]const u8{ "Minute", "Hour", "Day", "Month", "Weekday" };
+
+    const effective = effectiveFieldValues(field_values, mode);
 
     const iter_mins: []const i32 = if (effective[0]) |v| v else &.{0};
     const iter_hrs: []const i32 = if (effective[1]) |v| v else &.{0};
     const iter_days: []const i32 = if (effective[2]) |v| v else &.{0};
     const iter_mons: []const i32 = if (effective[3]) |v| v else &.{0};
     const iter_wdays: []const i32 = if (effective[4]) |v| v else &.{0};
-
-    const product: u64 = @as(u64, iter_mins.len) * iter_hrs.len * iter_days.len * iter_mons.len * iter_wdays.len;
-    if (product > 256) return error.TooManyTriggers;
 
     for (iter_mins) |m| {
         for (iter_hrs) |h| {

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -275,8 +275,12 @@ pub const CronRegisterJob = struct {
     fn startMac(this: *CronRegisterJob) void {
         this.state = .writing_plist;
 
-        const calendar_xml = cronToCalendarInterval(this.schedule) catch {
-            this.setErr("Invalid cron expression", .{});
+        const calendar_xml = cronToCalendarInterval(this.schedule) catch |err| {
+            if (err == error.TooManyTriggers) {
+                this.setErr("This cron expression expands to too many launchd calendar intervals (max 256). Use wildcards (*) for fields that don't need restricting, or simplify the expression.", .{});
+            } else {
+                this.setErr("Invalid cron expression", .{});
+            }
             this.finish();
             return;
         };
@@ -1426,6 +1430,9 @@ fn emitCalendarDicts(result: *std.array_list.Managed(u8), field_values: [5]?[]co
     const iter_days: []const i32 = if (effective[2]) |v| v else &.{0};
     const iter_mons: []const i32 = if (effective[3]) |v| v else &.{0};
     const iter_wdays: []const i32 = if (effective[4]) |v| v else &.{0};
+
+    const product: u64 = @as(u64, iter_mins.len) * iter_hrs.len * iter_days.len * iter_mons.len * iter_wdays.len;
+    if (product > 256) return error.TooManyTriggers;
 
     for (iter_mins) |m| {
         for (iter_hrs) |h| {

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -58,6 +58,15 @@ export const escapeRegExpForPackageNameMatching = $newZigFunction(
   1,
 );
 
+// macOS launchd StartCalendarInterval generator. Exposed so the 256-interval
+// cap can be tested on any platform (the production path only runs on macOS).
+// Returns the plist XML, or throws for invalid / over-cap expressions.
+export const cronToCalendarIntervalForTesting: (schedule: string) => string = $newZigFunction(
+  "runtime/api/cron.zig",
+  "jsCronToCalendarIntervalForTesting",
+  1,
+);
+
 export const shellInternals = {
   lex: (a, ...b) => shellLex(a.raw, b),
   parse: (a, ...b) => shellParse(a.raw, b),

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -2777,10 +2777,7 @@ pub fn js_cron_to_calendar_interval_for_testing(
     }
     let schedule = arg.to_slice(global)?;
     match cron_to_calendar_interval(schedule.slice()) {
-        Ok(xml) => {
-            let s = bun_core::String::clone_utf8(&xml);
-            bun_jsc::bun_string_jsc::to_js(&s, global)
-        }
+        Ok(xml) => bun_jsc::bun_string_jsc::create_utf8_for_js(global, &xml),
         Err(CalendarError::TooManyTriggers) => Err(global.throw(format_args!(
             "This cron expression expands to too many launchd calendar intervals (max 256). Use wildcards (*) for fields that don't need restricting, or simplify the expression."
         ))),

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -496,6 +496,13 @@ impl CronRegisterJob {
 
         let calendar_xml = match cron_to_calendar_interval(s.schedule.as_bytes()) {
             Ok(x) => x,
+            Err(CalendarError::TooManyTriggers) => {
+                s.set_err(format_args!(
+                    "This cron expression expands to too many launchd calendar intervals (max 256). Use wildcards (*) for fields that don't need restricting, or simplify the expression."
+                ));
+                // SAFETY: local reborrow `s` has ended; `this` is the live heap job.
+                return unsafe { Self::finish(this) };
+            }
             Err(_) => {
                 s.set_err(format_args!("Invalid cron expression"));
                 // SAFETY: local reborrow `s` has ended; `this` is the live heap job.
@@ -2550,6 +2557,8 @@ pub enum CalendarError {
     InvalidCron,
     #[error("OutOfMemory")]
     OutOfMemory,
+    #[error("TooManyTriggers")]
+    TooManyTriggers,
 }
 // TODO(port): narrow error set
 
@@ -2631,6 +2640,19 @@ pub fn cron_to_calendar_interval(schedule: &[u8]) -> Result<Vec<u8>, CalendarErr
         }
         result.extend_from_slice(b"    </dict>");
     } else {
+        // Bound total StartCalendarInterval dicts before emitting. The OR split emits two
+        // passes (day-of-month and day-of-week) whose sum is what launchd actually parses,
+        // so cap the sum — not each pass — at 256.
+        let total: u64 = if needs_or_split {
+            count_calendar_dicts(&fv_slices, EmitMode::ExcludeWeekday)
+                + count_calendar_dicts(&fv_slices, EmitMode::ExcludeDay)
+        } else {
+            count_calendar_dicts(&fv_slices, EmitMode::IncludeAll)
+        };
+        if total > 256 {
+            return Err(CalendarError::TooManyTriggers);
+        }
+
         result.extend_from_slice(b"    <array>\n");
 
         if needs_or_split {
@@ -2666,6 +2688,29 @@ enum EmitMode {
     ExcludeDay,
 }
 
+/// Apply an `EmitMode` mask: the excluded field is treated as a wildcard (None).
+fn effective_field_values<'a>(
+    field_values: &[Option<&'a [i32]>; 5],
+    mode: EmitMode,
+) -> [Option<&'a [i32]>; 5] {
+    let mut effective: [Option<&'a [i32]>; 5] = *field_values;
+    match mode {
+        EmitMode::ExcludeWeekday => effective[4] = None,
+        EmitMode::ExcludeDay => effective[2] = None,
+        EmitMode::IncludeAll => {}
+    }
+    effective
+}
+
+/// Count how many <dict> entries emit_calendar_dicts() would produce for a given mode.
+fn count_calendar_dicts(field_values: &[Option<&[i32]>; 5], mode: EmitMode) -> u64 {
+    let effective = effective_field_values(field_values, mode);
+    effective
+        .iter()
+        .map(|fv| fv.map_or(1, |v| v.len() as u64))
+        .product()
+}
+
 /// Emit Cartesian-product <dict> entries for the given field values.
 /// In exclude_weekday mode, day-of-week (index 4) is treated as wildcard.
 /// In exclude_day mode, day-of-month (index 2) is treated as wildcard.
@@ -2676,13 +2721,7 @@ fn emit_calendar_dicts(
 ) -> Result<(), CalendarError> {
     const PLIST_KEYS: [&[u8]; 5] = [b"Minute", b"Hour", b"Day", b"Month", b"Weekday"];
 
-    // Build effective field values based on mode
-    let mut effective: [Option<&[i32]>; 5] = *field_values;
-    match mode {
-        EmitMode::ExcludeWeekday => effective[4] = None,
-        EmitMode::ExcludeDay => effective[2] = None,
-        EmitMode::IncludeAll => {}
-    }
+    let effective = effective_field_values(field_values, mode);
 
     static ZERO: [i32; 1] = [0];
     let iter_mins: &[i32] = effective[0].unwrap_or(&ZERO);

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -2760,6 +2760,34 @@ fn emit_calendar_dicts(
     Ok(())
 }
 
+/// Testing-only (`bun:internal-for-testing`): drive `cron_to_calendar_interval`
+/// directly so the macOS launchd `StartCalendarInterval` 256-cap can be
+/// exercised on any platform (the production path only runs on macOS via
+/// `start_mac`). Returns the plist XML on success; throws on
+/// `InvalidCron`/`TooManyTriggers` with the same message `start_mac` surfaces.
+pub fn js_cron_to_calendar_interval_for_testing(
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+) -> JsResult<JSValue> {
+    let arg = frame.argument(0);
+    if !arg.is_string() {
+        return Err(global.throw_invalid_arguments(format_args!(
+            "cronToCalendarInterval expects a string schedule"
+        )));
+    }
+    let schedule = arg.to_slice(global)?;
+    match cron_to_calendar_interval(schedule.slice()) {
+        Ok(xml) => {
+            let s = bun_core::String::clone_utf8(&xml);
+            bun_jsc::bun_string_jsc::to_js(&s, global)
+        }
+        Err(CalendarError::TooManyTriggers) => Err(global.throw(format_args!(
+            "This cron expression expands to too many launchd calendar intervals (max 256). Use wildcards (*) for fields that don't need restricting, or simplify the expression."
+        ))),
+        Err(_) => Err(global.throw(format_args!("Invalid cron expression"))),
+    }
+}
+
 #[derive(thiserror::Error, strum::IntoStaticStr, Debug, PartialEq, Eq)]
 pub enum TaskXmlError {
     #[error("InvalidCron")]

--- a/src/runtime/api/cron.zig
+++ b/src/runtime/api/cron.zig
@@ -1409,6 +1409,15 @@ fn cronToCalendarInterval(schedule: []const u8) ![]const u8 {
         }
         try result.appendSlice("    </dict>");
     } else {
+        // Bound total StartCalendarInterval dicts before emitting. The OR split emits two
+        // passes (day-of-month and day-of-week) whose sum is what launchd actually parses,
+        // so cap the sum — not each pass — at 256.
+        const total: u64 = if (needs_or_split)
+            countCalendarDicts(field_values, .exclude_weekday) + countCalendarDicts(field_values, .exclude_day)
+        else
+            countCalendarDicts(field_values, .include_all);
+        if (total > 256) return error.TooManyTriggers;
+
         try result.appendSlice("    <array>\n");
 
         if (needs_or_split) {
@@ -1435,28 +1444,37 @@ fn appendCalendarKey(result: *std.array_list.Managed(u8), key: []const u8, val: 
 
 const EmitMode = enum { include_all, exclude_weekday, exclude_day };
 
-/// Emit Cartesian-product <dict> entries for the given field values.
-/// In exclude_weekday mode, day-of-week (index 4) is treated as wildcard.
-/// In exclude_day mode, day-of-month (index 2) is treated as wildcard.
-fn emitCalendarDicts(result: *std.array_list.Managed(u8), field_values: [5]?[]const i32, mode: EmitMode) !void {
-    const plist_keys = [_][]const u8{ "Minute", "Hour", "Day", "Month", "Weekday" };
-
-    // Build effective field values based on mode
+fn effectiveFieldValues(field_values: [5]?[]const i32, mode: EmitMode) [5]?[]const i32 {
     var effective: [5]?[]const i32 = field_values;
     switch (mode) {
         .exclude_weekday => effective[4] = null,
         .exclude_day => effective[2] = null,
         .include_all => {},
     }
+    return effective;
+}
+
+/// Count how many <dict> entries emitCalendarDicts() would produce for a given mode.
+fn countCalendarDicts(field_values: [5]?[]const i32, mode: EmitMode) u64 {
+    const effective = effectiveFieldValues(field_values, mode);
+    var product: u64 = 1;
+    inline for (effective) |fv| product *= if (fv) |v| v.len else 1;
+    return product;
+}
+
+/// Emit Cartesian-product <dict> entries for the given field values.
+/// In exclude_weekday mode, day-of-week (index 4) is treated as wildcard.
+/// In exclude_day mode, day-of-month (index 2) is treated as wildcard.
+fn emitCalendarDicts(result: *std.array_list.Managed(u8), field_values: [5]?[]const i32, mode: EmitMode) !void {
+    const plist_keys = [_][]const u8{ "Minute", "Hour", "Day", "Month", "Weekday" };
+
+    const effective = effectiveFieldValues(field_values, mode);
 
     const iter_mins: []const i32 = if (effective[0]) |v| v else &.{0};
     const iter_hrs: []const i32 = if (effective[1]) |v| v else &.{0};
     const iter_days: []const i32 = if (effective[2]) |v| v else &.{0};
     const iter_mons: []const i32 = if (effective[3]) |v| v else &.{0};
     const iter_wdays: []const i32 = if (effective[4]) |v| v else &.{0};
-
-    const product: u64 = @as(u64, iter_mins.len) * iter_hrs.len * iter_days.len * iter_mons.len * iter_wdays.len;
-    if (product > 256) return error.TooManyTriggers;
 
     for (iter_mins) |m| {
         for (iter_hrs) |h| {

--- a/src/runtime/api/cron.zig
+++ b/src/runtime/api/cron.zig
@@ -275,8 +275,12 @@ pub const CronRegisterJob = struct {
     fn startMac(this: *CronRegisterJob) void {
         this.state = .writing_plist;
 
-        const calendar_xml = cronToCalendarInterval(this.schedule) catch {
-            this.setErr("Invalid cron expression", .{});
+        const calendar_xml = cronToCalendarInterval(this.schedule) catch |err| {
+            if (err == error.TooManyTriggers) {
+                this.setErr("This cron expression expands to too many launchd calendar intervals (max 256). Use wildcards (*) for fields that don't need restricting, or simplify the expression.", .{});
+            } else {
+                this.setErr("Invalid cron expression", .{});
+            }
             this.finish();
             return;
         };
@@ -1450,6 +1454,9 @@ fn emitCalendarDicts(result: *std.array_list.Managed(u8), field_values: [5]?[]co
     const iter_days: []const i32 = if (effective[2]) |v| v else &.{0};
     const iter_mons: []const i32 = if (effective[3]) |v| v else &.{0};
     const iter_wdays: []const i32 = if (effective[4]) |v| v else &.{0};
+
+    const product: u64 = @as(u64, iter_mins.len) * iter_hrs.len * iter_days.len * iter_mons.len * iter_wdays.len;
+    if (product > 256) return error.TooManyTriggers;
 
     for (iter_mins) |m| {
         for (iter_hrs) |h| {

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -944,13 +944,20 @@ describe.skipIf(!hasLaunchctl)("cron registration (macOS)", () => {
       await expect(Bun.cron(`${dir}/job.ts`, "0-9 0-9 1-3 * *", "test-mac-toomany")).rejects.toThrow(
         /too many launchd calendar intervals/i,
       );
+      // OR-split: both day-of-month and day-of-week restricted emits two passes.
+      // (10×10×2) + (10×10×2) = 400 dicts — each pass is under 256 but the sum is not.
+      await expect(Bun.cron(`${dir}/job.ts`, "0-9 0-9 1,15 * 1,3", "test-mac-toomany-or")).rejects.toThrow(
+        /too many launchd calendar intervals/i,
+      );
       // Nothing should have been written.
       expect(existsSync(plistPath("test-mac-toomany"))).toBe(false);
+      expect(existsSync(plistPath("test-mac-toomany-or"))).toBe(false);
       // Just under the cap still works.
       await Bun.cron(`${dir}/job.ts`, "0-9 0-9 1,15 * *", "test-mac-undercap"); // 10×10×2 = 200
       expect(existsSync(plistPath("test-mac-undercap"))).toBe(true);
     } finally {
       removeLaunchdJob("test-mac-toomany");
+      removeLaunchdJob("test-mac-toomany-or");
       removeLaunchdJob("test-mac-undercap");
     }
   });

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -935,6 +935,26 @@ describe.skipIf(!hasLaunchctl)("cron registration (macOS)", () => {
     }
   });
 
+  test("rejects expressions that expand to too many calendar intervals", async () => {
+    using dir = tempDir("bun-cron-test", {
+      "job.ts": `export default { scheduled() {} };`,
+    });
+    try {
+      // 10 × 10 × 3 = 300 dicts, over the 256 cap. Harmless ~60KB if a regression slips through.
+      await expect(Bun.cron(`${dir}/job.ts`, "0-9 0-9 1-3 * *", "test-mac-toomany")).rejects.toThrow(
+        /too many launchd calendar intervals/i,
+      );
+      // Nothing should have been written.
+      expect(existsSync(plistPath("test-mac-toomany"))).toBe(false);
+      // Just under the cap still works.
+      await Bun.cron(`${dir}/job.ts`, "0-9 0-9 1,15 * *", "test-mac-undercap"); // 10×10×2 = 200
+      expect(existsSync(plistPath("test-mac-undercap"))).toBe(true);
+    } finally {
+      removeLaunchdJob("test-mac-toomany");
+      removeLaunchdJob("test-mac-undercap");
+    }
+  });
+
   test("plist contains correct CalendarInterval XML", async () => {
     using dir = tempDir("bun-cron-test", {
       "job.ts": `export default { scheduled() {} };`,

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -1813,9 +1813,9 @@ describe("calendar interval generation (launchd)", () => {
     // Both day-of-month and day-of-week restricted → two passes:
     // (10 × 10 × 2) + (10 × 10 × 2) = 400 entries. Each pass is under 256 but
     // the sum is not — the cap must sum the passes, not check each one.
-    expect(() =>
-      cronToCalendarIntervalForTesting("0,1,2,3,4,5,6,7,8,9 0,1,2,3,4,5,6,7,8,9 1,15 * 1,3"),
-    ).toThrow(/too many launchd calendar intervals/i);
+    expect(() => cronToCalendarIntervalForTesting("0,1,2,3,4,5,6,7,8,9 0,1,2,3,4,5,6,7,8,9 1,15 * 1,3")).toThrow(
+      /too many launchd calendar intervals/i,
+    );
   });
 
   test("accepts expressions just under the cap", () => {

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -1794,3 +1794,40 @@ describe("Bun.cron.parse", () => {
     expect(fromNumber.getTime()).toBe(fromDate.getTime());
   });
 });
+
+// macOS launchd plist generation (cron_to_calendar_interval). Driven directly
+// via the internal binding so the 256-interval cap is exercised on every
+// platform — the Bun.cron(...) path only reaches it on macOS (launchd), so the
+// `describe.skipIf(!hasLaunchctl)` suites above skip it on Linux/Windows CI.
+describe("calendar interval generation (launchd)", () => {
+  const { cronToCalendarIntervalForTesting } = require("bun:internal-for-testing");
+
+  test("caps the total dict count at 256", () => {
+    // Single-pass Cartesian product: 10 × 10 × 3 = 300 entries, over the cap.
+    expect(() => cronToCalendarIntervalForTesting("0,1,2,3,4,5,6,7,8,9 0,1,2,3,4,5,6,7,8,9 1,2,3 * *")).toThrow(
+      /too many launchd calendar intervals/i,
+    );
+  });
+
+  test("caps the SUM across both OR-split passes", () => {
+    // Both day-of-month and day-of-week restricted → two passes:
+    // (10 × 10 × 2) + (10 × 10 × 2) = 400 entries. Each pass is under 256 but
+    // the sum is not — the cap must sum the passes, not check each one.
+    expect(() =>
+      cronToCalendarIntervalForTesting("0,1,2,3,4,5,6,7,8,9 0,1,2,3,4,5,6,7,8,9 1,15 * 1,3"),
+    ).toThrow(/too many launchd calendar intervals/i);
+  });
+
+  test("accepts expressions just under the cap", () => {
+    // 10 × 10 × 2 = 200 entries.
+    const xml = cronToCalendarIntervalForTesting("0,1,2,3,4,5,6,7,8,9 0,1,2,3,4,5,6,7,8,9 1,15 * *");
+    expect(xml).toContain("<array>");
+    expect(xml).toContain("<key>Minute</key>");
+    // 200 dicts emitted.
+    expect(xml.split("<dict>").length - 1).toBe(200);
+  });
+
+  test("rejects malformed expressions with a generic error", () => {
+    expect(() => cronToCalendarIntervalForTesting("not a cron")).toThrow(/Invalid cron expression/i);
+  });
+});

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { cronToCalendarIntervalForTesting } from "bun:internal-for-testing";
 import { bunEnv, bunExe, isLinux, isMacOS, isWindows, tempDir } from "harness";
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 
@@ -1800,8 +1801,6 @@ describe("Bun.cron.parse", () => {
 // platform — the Bun.cron(...) path only reaches it on macOS (launchd), so the
 // `describe.skipIf(!hasLaunchctl)` suites above skip it on Linux/Windows CI.
 describe("calendar interval generation (launchd)", () => {
-  const { cronToCalendarIntervalForTesting } = require("bun:internal-for-testing");
-
   test("caps the total dict count at 256", () => {
     // Single-pass Cartesian product: 10 × 10 × 3 = 300 entries, over the cap.
     expect(() => cronToCalendarIntervalForTesting("0,1,2,3,4,5,6,7,8,9 0,1,2,3,4,5,6,7,8,9 1,2,3 * *")).toThrow(

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "bun:test";
 import { cronToCalendarIntervalForTesting } from "bun:internal-for-testing";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isMacOS, isWindows, tempDir } from "harness";
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 


### PR DESCRIPTION
## What

`emitCalendarDicts` (the macOS plist generator) ran an uncapped 5-deep Cartesian loop. A 24-byte input like `"1-59 1-23 2-31 2-12 1-6"` produced ~537,372 `<dict>` blocks ≈ **130 MB** plist (≈260 MB peak after the format-string copy), then handed it to `launchctl bootstrap`.

The Windows path already returns `error.TooManyTriggers` at 48. macOS had no equivalent.

## Fix

Compute the total `StartCalendarInterval` count in `cronToCalendarInterval` before emitting anything and return `error.TooManyTriggers` if it exceeds 256. When both day-of-month and day-of-week are restricted (POSIX OR semantics), two passes are emitted; the cap applies to their **sum**, not each pass independently. A `countCalendarDicts(field_values, mode)` helper shares the mode-masking logic with the emitter. The macOS caller now surfaces a launchd-specific message instead of the generic "Invalid cron expression".

256 is generous enough for any real schedule (~50 KB plist worst case) while bounding memory and disk.

## Test

- `"0-9 0-9 1-3 * *"` (300 entries) rejects
- `"0-9 0-9 1,15 * 1,3"` (OR-split: 200+200 = 400 entries) rejects — each pass is under 256 but the sum is not
- `"0-9 0-9 1,15 * *"` (200 entries) still registers

Harmless ~60–80 KB if a regression slips through during `USE_SYSTEM_BUN=1` runs.

```
USE_SYSTEM_BUN=1 bun test cron.test.ts -t "too many calendar"   # fails (promise resolved)
bun bd test cron.test.ts -t "too many calendar"                 # 1 pass
bun bd test cron.test.ts -t "macOS"                             # 26 pass, 0 fail
```
