### PR TITLE
redis: accept null for onclose/onconnect setters

### DIFF
--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -84,7 +84,8 @@ declare module "bun" {
      * Assign `null` or `undefined` to detach the handler. Reading the
      * property after detaching returns `undefined`.
      */
-    onconnect: ((this: RedisClient) => void) | null | undefined;
+    get onconnect(): ((this: RedisClient) => void) | undefined;
+    set onconnect(value: ((this: RedisClient) => void) | null | undefined);
 
     /**
      * Callback fired when the client disconnects from the Redis server.
@@ -94,7 +95,8 @@ declare module "bun" {
      *
      * @param error The error that caused the disconnection
      */
-    onclose: ((this: RedisClient, error: Error) => void) | null | undefined;
+    get onclose(): ((this: RedisClient, error: Error) => void) | undefined;
+    set onclose(value: ((this: RedisClient, error: Error) => void) | null | undefined);
 
     /**
      * Connect to the Redis server

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -79,16 +79,22 @@ declare module "bun" {
     readonly bufferedAmount: number;
 
     /**
-     * Callback fired when the client connects to the Redis server
+     * Callback fired when the client connects to the Redis server.
+     *
+     * Assign `null` or `undefined` to detach the handler. Reading the
+     * property after detaching returns `undefined`.
      */
-    onconnect: ((this: RedisClient) => void) | null;
+    onconnect: ((this: RedisClient) => void) | null | undefined;
 
     /**
-     * Callback fired when the client disconnects from the Redis server
+     * Callback fired when the client disconnects from the Redis server.
+     *
+     * Assign `null` or `undefined` to detach the handler. Reading the
+     * property after detaching returns `undefined`.
      *
      * @param error The error that caused the disconnection
      */
-    onclose: ((this: RedisClient, error: Error) => void) | null;
+    onclose: ((this: RedisClient, error: Error) => void) | null | undefined;
 
     /**
      * Connect to the Redis server

--- a/src/runtime/valkey_jsc/js_valkey.zig
+++ b/src/runtime/valkey_jsc/js_valkey.zig
@@ -705,23 +705,37 @@ pub const JSValkeyClient = struct {
 
     pub fn getOnConnect(_: *JSValkeyClient, thisValue: JSValue, _: *jsc.JSGlobalObject) JSValue {
         if (js.onconnectGetCached(thisValue)) |value| {
-            return value;
+            if (value.isCallable()) return value;
         }
         return .js_undefined;
     }
 
-    pub fn setOnConnect(_: *JSValkeyClient, thisValue: JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) void {
+    pub fn setOnConnect(_: *JSValkeyClient, thisValue: JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) bun.JSError!void {
+        if (value.isUndefinedOrNull()) {
+            js.onconnectSetCached(thisValue, globalObject, .zero);
+            return;
+        }
+        if (!value.isCallable()) {
+            return globalObject.throwInvalidArgumentType("RedisClient", "onconnect", "function");
+        }
         js.onconnectSetCached(thisValue, globalObject, value);
     }
 
     pub fn getOnClose(_: *JSValkeyClient, thisValue: JSValue, _: *jsc.JSGlobalObject) JSValue {
         if (js.oncloseGetCached(thisValue)) |value| {
-            return value;
+            if (value.isCallable()) return value;
         }
         return .js_undefined;
     }
 
-    pub fn setOnClose(_: *JSValkeyClient, thisValue: JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) void {
+    pub fn setOnClose(_: *JSValkeyClient, thisValue: JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) bun.JSError!void {
+        if (value.isUndefinedOrNull()) {
+            js.oncloseSetCached(thisValue, globalObject, .zero);
+            return;
+        }
+        if (!value.isCallable()) {
+            return globalObject.throwInvalidArgumentType("RedisClient", "onclose", "function");
+        }
         js.oncloseSetCached(thisValue, globalObject, value);
     }
 
@@ -889,9 +903,11 @@ pub const JSValkeyClient = struct {
             js.helloSetCached(this_value, globalObject, hello_value);
             // Call onConnect callback if defined by the user
             if (js.onconnectGetCached(this_value)) |on_connect| {
-                const js_value = this_value;
-                js_value.ensureStillAlive();
-                globalObject.queueMicrotask(on_connect, &[_]JSValue{ js_value, hello_value });
+                if (on_connect.isCallable()) {
+                    const js_value = this_value;
+                    js_value.ensureStillAlive();
+                    globalObject.queueMicrotask(on_connect, &[_]JSValue{ js_value, hello_value });
+                }
             }
 
             if (js.connectionPromiseGetCached(this_value)) |promise| {
@@ -1023,11 +1039,13 @@ pub const JSValkeyClient = struct {
 
         // Call onClose callback if it exists
         if (js.oncloseGetCached(this_jsvalue)) |on_close| {
-            _ = on_close.call(
-                globalObject,
-                this_jsvalue,
-                &[_]JSValue{error_value},
-            ) catch |e| globalObject.reportActiveExceptionAsUnhandled(e);
+            if (on_close.isCallable()) {
+                _ = on_close.call(
+                    globalObject,
+                    this_jsvalue,
+                    &[_]JSValue{error_value},
+                ) catch |e| globalObject.reportActiveExceptionAsUnhandled(e);
+            }
         }
     }
 
@@ -1044,6 +1062,7 @@ pub const JSValkeyClient = struct {
         const this_value = this.this_value.tryGet() orelse return;
         const globalObject = this.globalObject;
         if (js.oncloseGetCached(this_value)) |on_close| {
+            if (!on_close.isCallable()) return;
             const loop = this.client.vm.eventLoop();
             loop.enter();
             defer loop.exit();

--- a/src/runtime/valkey_jsc/js_valkey.zig
+++ b/src/runtime/valkey_jsc/js_valkey.zig
@@ -705,37 +705,23 @@ pub const JSValkeyClient = struct {
 
     pub fn getOnConnect(_: *JSValkeyClient, thisValue: JSValue, _: *jsc.JSGlobalObject) JSValue {
         if (js.onconnectGetCached(thisValue)) |value| {
-            if (value.isCallable()) return value;
+            return value;
         }
         return .js_undefined;
     }
 
-    pub fn setOnConnect(_: *JSValkeyClient, thisValue: JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) bun.JSError!void {
-        if (value.isUndefinedOrNull()) {
-            js.onconnectSetCached(thisValue, globalObject, .zero);
-            return;
-        }
-        if (!value.isCallable()) {
-            return globalObject.throwInvalidArgumentType("RedisClient", "onconnect", "function");
-        }
+    pub fn setOnConnect(_: *JSValkeyClient, thisValue: JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) void {
         js.onconnectSetCached(thisValue, globalObject, value);
     }
 
     pub fn getOnClose(_: *JSValkeyClient, thisValue: JSValue, _: *jsc.JSGlobalObject) JSValue {
         if (js.oncloseGetCached(thisValue)) |value| {
-            if (value.isCallable()) return value;
+            return value;
         }
         return .js_undefined;
     }
 
-    pub fn setOnClose(_: *JSValkeyClient, thisValue: JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) bun.JSError!void {
-        if (value.isUndefinedOrNull()) {
-            js.oncloseSetCached(thisValue, globalObject, .zero);
-            return;
-        }
-        if (!value.isCallable()) {
-            return globalObject.throwInvalidArgumentType("RedisClient", "onclose", "function");
-        }
+    pub fn setOnClose(_: *JSValkeyClient, thisValue: JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) void {
         js.oncloseSetCached(thisValue, globalObject, value);
     }
 
@@ -903,11 +889,9 @@ pub const JSValkeyClient = struct {
             js.helloSetCached(this_value, globalObject, hello_value);
             // Call onConnect callback if defined by the user
             if (js.onconnectGetCached(this_value)) |on_connect| {
-                if (on_connect.isCallable()) {
-                    const js_value = this_value;
-                    js_value.ensureStillAlive();
-                    globalObject.queueMicrotask(on_connect, &[_]JSValue{ js_value, hello_value });
-                }
+                const js_value = this_value;
+                js_value.ensureStillAlive();
+                globalObject.queueMicrotask(on_connect, &[_]JSValue{ js_value, hello_value });
             }
 
             if (js.connectionPromiseGetCached(this_value)) |promise| {
@@ -1039,13 +1023,11 @@ pub const JSValkeyClient = struct {
 
         // Call onClose callback if it exists
         if (js.oncloseGetCached(this_jsvalue)) |on_close| {
-            if (on_close.isCallable()) {
-                _ = on_close.call(
-                    globalObject,
-                    this_jsvalue,
-                    &[_]JSValue{error_value},
-                ) catch |e| globalObject.reportActiveExceptionAsUnhandled(e);
-            }
+            _ = on_close.call(
+                globalObject,
+                this_jsvalue,
+                &[_]JSValue{error_value},
+            ) catch |e| globalObject.reportActiveExceptionAsUnhandled(e);
         }
     }
 
@@ -1062,7 +1044,6 @@ pub const JSValkeyClient = struct {
         const this_value = this.this_value.tryGet() orelse return;
         const globalObject = this.globalObject;
         if (js.oncloseGetCached(this_value)) |on_close| {
-            if (!on_close.isCallable()) return;
             const loop = this.client.vm.eventLoop();
             loop.enter();
             defer loop.exit();

--- a/src/valkey/js_valkey.zig
+++ b/src/valkey/js_valkey.zig
@@ -698,23 +698,37 @@ pub const JSValkeyClient = struct {
 
     pub fn getOnConnect(_: *JSValkeyClient, thisValue: JSValue, _: *jsc.JSGlobalObject) JSValue {
         if (js.onconnectGetCached(thisValue)) |value| {
-            return value;
+            if (value.isCallable()) return value;
         }
         return .js_undefined;
     }
 
-    pub fn setOnConnect(_: *JSValkeyClient, thisValue: JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) void {
+    pub fn setOnConnect(_: *JSValkeyClient, thisValue: JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) bun.JSError!void {
+        if (value.isUndefinedOrNull()) {
+            js.onconnectSetCached(thisValue, globalObject, .zero);
+            return;
+        }
+        if (!value.isCallable()) {
+            return globalObject.throwInvalidArgumentType("RedisClient", "onconnect", "function");
+        }
         js.onconnectSetCached(thisValue, globalObject, value);
     }
 
     pub fn getOnClose(_: *JSValkeyClient, thisValue: JSValue, _: *jsc.JSGlobalObject) JSValue {
         if (js.oncloseGetCached(thisValue)) |value| {
-            return value;
+            if (value.isCallable()) return value;
         }
         return .js_undefined;
     }
 
-    pub fn setOnClose(_: *JSValkeyClient, thisValue: JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) void {
+    pub fn setOnClose(_: *JSValkeyClient, thisValue: JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) bun.JSError!void {
+        if (value.isUndefinedOrNull()) {
+            js.oncloseSetCached(thisValue, globalObject, .zero);
+            return;
+        }
+        if (!value.isCallable()) {
+            return globalObject.throwInvalidArgumentType("RedisClient", "onclose", "function");
+        }
         js.oncloseSetCached(thisValue, globalObject, value);
     }
 
@@ -882,9 +896,11 @@ pub const JSValkeyClient = struct {
             js.helloSetCached(this_value, globalObject, hello_value);
             // Call onConnect callback if defined by the user
             if (js.onconnectGetCached(this_value)) |on_connect| {
-                const js_value = this_value;
-                js_value.ensureStillAlive();
-                globalObject.queueMicrotask(on_connect, &[_]JSValue{ js_value, hello_value });
+                if (on_connect.isCallable()) {
+                    const js_value = this_value;
+                    js_value.ensureStillAlive();
+                    globalObject.queueMicrotask(on_connect, &[_]JSValue{ js_value, hello_value });
+                }
             }
 
             if (js.connectionPromiseGetCached(this_value)) |promise| {
@@ -1016,11 +1032,13 @@ pub const JSValkeyClient = struct {
 
         // Call onClose callback if it exists
         if (js.oncloseGetCached(this_jsvalue)) |on_close| {
-            _ = on_close.call(
-                globalObject,
-                this_jsvalue,
-                &[_]JSValue{error_value},
-            ) catch |e| globalObject.reportActiveExceptionAsUnhandled(e);
+            if (on_close.isCallable()) {
+                _ = on_close.call(
+                    globalObject,
+                    this_jsvalue,
+                    &[_]JSValue{error_value},
+                ) catch |e| globalObject.reportActiveExceptionAsUnhandled(e);
+            }
         }
     }
 
@@ -1037,6 +1055,7 @@ pub const JSValkeyClient = struct {
         const this_value = this.this_value.tryGet() orelse return;
         const globalObject = this.globalObject;
         if (js.oncloseGetCached(this_value)) |on_close| {
+            if (!on_close.isCallable()) return;
             const loop = this.client.vm.eventLoop();
             loop.enter();
             defer loop.exit();

--- a/src/valkey/js_valkey.zig
+++ b/src/valkey/js_valkey.zig
@@ -698,37 +698,23 @@ pub const JSValkeyClient = struct {
 
     pub fn getOnConnect(_: *JSValkeyClient, thisValue: JSValue, _: *jsc.JSGlobalObject) JSValue {
         if (js.onconnectGetCached(thisValue)) |value| {
-            if (value.isCallable()) return value;
+            return value;
         }
         return .js_undefined;
     }
 
-    pub fn setOnConnect(_: *JSValkeyClient, thisValue: JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) bun.JSError!void {
-        if (value.isUndefinedOrNull()) {
-            js.onconnectSetCached(thisValue, globalObject, .zero);
-            return;
-        }
-        if (!value.isCallable()) {
-            return globalObject.throwInvalidArgumentType("RedisClient", "onconnect", "function");
-        }
+    pub fn setOnConnect(_: *JSValkeyClient, thisValue: JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) void {
         js.onconnectSetCached(thisValue, globalObject, value);
     }
 
     pub fn getOnClose(_: *JSValkeyClient, thisValue: JSValue, _: *jsc.JSGlobalObject) JSValue {
         if (js.oncloseGetCached(thisValue)) |value| {
-            if (value.isCallable()) return value;
+            return value;
         }
         return .js_undefined;
     }
 
-    pub fn setOnClose(_: *JSValkeyClient, thisValue: JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) bun.JSError!void {
-        if (value.isUndefinedOrNull()) {
-            js.oncloseSetCached(thisValue, globalObject, .zero);
-            return;
-        }
-        if (!value.isCallable()) {
-            return globalObject.throwInvalidArgumentType("RedisClient", "onclose", "function");
-        }
+    pub fn setOnClose(_: *JSValkeyClient, thisValue: JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) void {
         js.oncloseSetCached(thisValue, globalObject, value);
     }
 
@@ -896,11 +882,9 @@ pub const JSValkeyClient = struct {
             js.helloSetCached(this_value, globalObject, hello_value);
             // Call onConnect callback if defined by the user
             if (js.onconnectGetCached(this_value)) |on_connect| {
-                if (on_connect.isCallable()) {
-                    const js_value = this_value;
-                    js_value.ensureStillAlive();
-                    globalObject.queueMicrotask(on_connect, &[_]JSValue{ js_value, hello_value });
-                }
+                const js_value = this_value;
+                js_value.ensureStillAlive();
+                globalObject.queueMicrotask(on_connect, &[_]JSValue{ js_value, hello_value });
             }
 
             if (js.connectionPromiseGetCached(this_value)) |promise| {
@@ -1032,13 +1016,11 @@ pub const JSValkeyClient = struct {
 
         // Call onClose callback if it exists
         if (js.oncloseGetCached(this_jsvalue)) |on_close| {
-            if (on_close.isCallable()) {
-                _ = on_close.call(
-                    globalObject,
-                    this_jsvalue,
-                    &[_]JSValue{error_value},
-                ) catch |e| globalObject.reportActiveExceptionAsUnhandled(e);
-            }
+            _ = on_close.call(
+                globalObject,
+                this_jsvalue,
+                &[_]JSValue{error_value},
+            ) catch |e| globalObject.reportActiveExceptionAsUnhandled(e);
         }
     }
 
@@ -1055,7 +1037,6 @@ pub const JSValkeyClient = struct {
         const this_value = this.this_value.tryGet() orelse return;
         const globalObject = this.globalObject;
         if (js.oncloseGetCached(this_value)) |on_close| {
-            if (!on_close.isCallable()) return;
             const loop = this.client.vm.eventLoop();
             loop.enter();
             defer loop.exit();

--- a/test/regression/issue/29145.test.ts
+++ b/test/regression/issue/29145.test.ts
@@ -1,0 +1,119 @@
+import { RedisClient } from "bun";
+import { describe, expect, test } from "bun:test";
+
+/**
+ * Regression test for issue #29145: `c.onclose = null` panics during `close()`
+ *
+ * The RedisClient `onclose`/`onconnect` setters cached whatever JS value was
+ * assigned (including `null`), and the teardown path invoked `.call(...)` on
+ * the cached value unconditionally, throwing a TypeError that was then
+ * cleared during teardown and surfaced as:
+ *
+ *   panic(main thread): A JavaScript exception was thrown, but it was
+ *   cleared before it could be read.
+ *
+ * The type definitions document `((...)=>void) | null` as the type for both
+ * properties, so assigning `null` must be a supported way to detach the
+ * handler.
+ */
+describe("RedisClient: assigning null to onclose/onconnect (#29145)", () => {
+  test("onclose = null does not panic on close()", () => {
+    const c = new RedisClient("redis://localhost:6379");
+    c.onclose = null;
+    expect(() => c.close()).not.toThrow();
+  });
+
+  test("onconnect = null does not panic on close()", () => {
+    const c = new RedisClient("redis://localhost:6379");
+    c.onconnect = null;
+    expect(() => c.close()).not.toThrow();
+  });
+
+  test("onclose = undefined is also accepted", () => {
+    const c = new RedisClient("redis://localhost:6379");
+    c.onclose = undefined as any;
+    expect(() => c.close()).not.toThrow();
+  });
+
+  test("onconnect = undefined is also accepted", () => {
+    const c = new RedisClient("redis://localhost:6379");
+    c.onconnect = undefined as any;
+    expect(() => c.close()).not.toThrow();
+  });
+
+  test("reading onclose after assigning null returns undefined", () => {
+    const c = new RedisClient("redis://localhost:6379");
+    c.onclose = null;
+    expect(c.onclose).toBeUndefined();
+    c.close();
+  });
+
+  test("reading onconnect after assigning null returns undefined", () => {
+    const c = new RedisClient("redis://localhost:6379");
+    c.onconnect = null;
+    expect(c.onconnect).toBeUndefined();
+    c.close();
+  });
+
+  test("assigning a function to onclose still works", () => {
+    const c = new RedisClient("redis://localhost:6379");
+    const handler = () => {};
+    c.onclose = handler;
+    expect(c.onclose).toBe(handler);
+    c.close();
+  });
+
+  test("assigning a function to onconnect still works", () => {
+    const c = new RedisClient("redis://localhost:6379");
+    const handler = () => {};
+    c.onconnect = handler;
+    expect(c.onconnect).toBe(handler);
+    c.close();
+  });
+
+  test("assigning a non-callable non-null value to onclose throws TypeError", () => {
+    const c = new RedisClient("redis://localhost:6379");
+    expect(() => {
+      (c as any).onclose = "not a function";
+    }).toThrow(TypeError);
+    expect(() => {
+      (c as any).onclose = 42;
+    }).toThrow(TypeError);
+    expect(() => {
+      (c as any).onclose = {};
+    }).toThrow(TypeError);
+    c.close();
+  });
+
+  test("assigning a non-callable non-null value to onconnect throws TypeError", () => {
+    const c = new RedisClient("redis://localhost:6379");
+    expect(() => {
+      (c as any).onconnect = "not a function";
+    }).toThrow(TypeError);
+    expect(() => {
+      (c as any).onconnect = 42;
+    }).toThrow(TypeError);
+    expect(() => {
+      (c as any).onconnect = {};
+    }).toThrow(TypeError);
+    c.close();
+  });
+
+  test("null onclose while an in-flight connection is being torn down does not panic", async () => {
+    // This reproduces the original bug's exact shape: obtain an in-flight
+    // connection, detach via `null`, and close. Before the fix, the close path
+    // invoked `.call(...)` on the cached `null`, triggering a TypeError that
+    // was cleared during teardown.
+    const c = new RedisClient("redis://localhost:6379");
+    try {
+      // Touch the connection so the client transitions through states that
+      // exercise the onclose callback path. If the server isn't reachable we
+      // just swallow the rejection — the bug fires regardless of whether the
+      // command succeeds.
+      await c.set("test:issue-29145", "v", "EX", "10").catch(() => {});
+    } finally {
+      c.onclose = null;
+      expect(() => c.close()).not.toThrow();
+    }
+  });
+});

--- a/test/regression/issue/29145.test.ts
+++ b/test/regression/issue/29145.test.ts
@@ -17,53 +17,18 @@ import { isDebug } from "harness";
  * properties, so assigning `null` must be a supported way to detach the
  * handler.
  *
- * The panic is a cleared-exception assertion which only surfaces on
- * debug/ASAN builds, so this file is gated on `isDebug` — release CI lanes
- * skip it and the gate (which runs `bun bd` with ASAN) still exercises it.
+ * The tests are split into two blocks:
+ *
+ * - Behavior tests (setter validation, getter readback, function storage)
+ *   run on every lane. A release regression in the setter/getter contract
+ *   still fails visibly.
+ * - Panic tests run only on debug/ASAN builds. The cleared-exception
+ *   assertion that made this bug observable only fires under ASAN; on
+ *   release builds the TypeError is silently swallowed during teardown
+ *   and the no-throw assertion would pass even on the buggy code, so
+ *   gating them prevents false greens.
  */
-describe.skipIf(!isDebug)("RedisClient: assigning null to onclose/onconnect (#29145)", () => {
-  test("onclose = null does not panic on close()", () => {
-    const c = new RedisClient("redis://localhost:6379");
-    try {
-      c.onclose = null;
-      expect(() => c.close()).not.toThrow();
-    } finally {
-      c.close();
-    }
-  });
-
-  test("onconnect = null does not panic on close()", () => {
-    const c = new RedisClient("redis://localhost:6379");
-    try {
-      c.onconnect = null;
-      expect(() => c.close()).not.toThrow();
-    } finally {
-      c.close();
-    }
-  });
-
-  test("onclose = undefined is also accepted", () => {
-    const c = new RedisClient("redis://localhost:6379");
-    try {
-      c.onclose = undefined;
-      expect(c.onclose).toBeUndefined();
-      expect(() => c.close()).not.toThrow();
-    } finally {
-      c.close();
-    }
-  });
-
-  test("onconnect = undefined is also accepted", () => {
-    const c = new RedisClient("redis://localhost:6379");
-    try {
-      c.onconnect = undefined;
-      expect(c.onconnect).toBeUndefined();
-      expect(() => c.close()).not.toThrow();
-    } finally {
-      c.close();
-    }
-  });
-
+describe("RedisClient: onclose/onconnect setter/getter contract (#29145)", () => {
   test("reading onclose after assigning null returns undefined", () => {
     const c = new RedisClient("redis://localhost:6379");
     try {
@@ -78,6 +43,26 @@ describe.skipIf(!isDebug)("RedisClient: assigning null to onclose/onconnect (#29
     const c = new RedisClient("redis://localhost:6379");
     try {
       c.onconnect = null;
+      expect(c.onconnect).toBeUndefined();
+    } finally {
+      c.close();
+    }
+  });
+
+  test("reading onclose after assigning undefined returns undefined", () => {
+    const c = new RedisClient("redis://localhost:6379");
+    try {
+      c.onclose = undefined;
+      expect(c.onclose).toBeUndefined();
+    } finally {
+      c.close();
+    }
+  });
+
+  test("reading onconnect after assigning undefined returns undefined", () => {
+    const c = new RedisClient("redis://localhost:6379");
+    try {
+      c.onconnect = undefined;
       expect(c.onconnect).toBeUndefined();
     } finally {
       c.close();
@@ -135,6 +120,28 @@ describe.skipIf(!isDebug)("RedisClient: assigning null to onclose/onconnect (#29
       expect(() => {
         (c as any).onconnect = {};
       }).toThrow(TypeError);
+    } finally {
+      c.close();
+    }
+  });
+});
+
+describe.skipIf(!isDebug)("RedisClient: no panic on null detach during teardown (#29145)", () => {
+  test("onclose = null does not panic on close()", () => {
+    const c = new RedisClient("redis://localhost:6379");
+    try {
+      c.onclose = null;
+      expect(() => c.close()).not.toThrow();
+    } finally {
+      c.close();
+    }
+  });
+
+  test("onconnect = null does not panic on close()", () => {
+    const c = new RedisClient("redis://localhost:6379");
+    try {
+      c.onconnect = null;
+      expect(() => c.close()).not.toThrow();
     } finally {
       c.close();
     }

--- a/test/regression/issue/29145.test.ts
+++ b/test/regression/issue/29145.test.ts
@@ -127,26 +127,6 @@ describe("RedisClient: onclose/onconnect setter/getter contract (#29145)", () =>
 });
 
 describe.skipIf(!isDebug)("RedisClient: no panic on null detach during teardown (#29145)", () => {
-  test("onclose = null does not panic on close()", () => {
-    const c = new RedisClient("redis://localhost:6379");
-    try {
-      c.onclose = null;
-      expect(() => c.close()).not.toThrow();
-    } finally {
-      c.close();
-    }
-  });
-
-  test("onconnect = null does not panic on close()", () => {
-    const c = new RedisClient("redis://localhost:6379");
-    try {
-      c.onconnect = null;
-      expect(() => c.close()).not.toThrow();
-    } finally {
-      c.close();
-    }
-  });
-
   test("null onclose while a connection is being torn down does not panic", async () => {
     // Reproduces the original bug by forcing the teardown path:
     //

--- a/test/regression/issue/29145.test.ts
+++ b/test/regression/issue/29145.test.ts
@@ -1,5 +1,6 @@
 import { RedisClient } from "bun";
 import { describe, expect, test } from "bun:test";
+import { isDebug } from "harness";
 
 /**
  * Regression test for issue #29145: `c.onclose = null` panics during `close()`
@@ -15,8 +16,12 @@ import { describe, expect, test } from "bun:test";
  * The type definitions document `((...)=>void) | null` as the type for both
  * properties, so assigning `null` must be a supported way to detach the
  * handler.
+ *
+ * The panic is a cleared-exception assertion which only surfaces on
+ * debug/ASAN builds, so this file is gated on `isDebug` — release CI lanes
+ * skip it and the gate (which runs `bun bd` with ASAN) still exercises it.
  */
-describe("RedisClient: assigning null to onclose/onconnect (#29145)", () => {
+describe.skipIf(!isDebug)("RedisClient: assigning null to onclose/onconnect (#29145)", () => {
   test("onclose = null does not panic on close()", () => {
     const c = new RedisClient("redis://localhost:6379");
     try {

--- a/test/regression/issue/29145.test.ts
+++ b/test/regression/issue/29145.test.ts
@@ -133,19 +133,28 @@ describe("RedisClient: assigning null to onclose/onconnect (#29145)", () => {
     }
   });
 
-  test("null onclose while an in-flight connection is being torn down does not panic", async () => {
-    // This reproduces the original bug's exact shape: obtain an in-flight
-    // connection, detach via `null`, and close. Before the fix, the close path
-    // invoked `.call(...)` on the cached `null`, triggering a TypeError that
-    // was cleared during teardown.
-    const c = new RedisClient("redis://localhost:6379");
+  test("null onclose while a connection is being torn down does not panic", async () => {
+    // Reproduces the original bug by forcing the teardown path:
+    //
+    //   1. Point the client at a guaranteed-refused local port (127.0.0.1:1)
+    //      so no external Redis is required and the test is self-contained.
+    //   2. Issue a command to make the client connect; the connect fails with
+    //      "Connection closed", which drives the socket close handler and
+    //      fires the `onclose` callback path.
+    //   3. Detach the handler via `null` before the final `close()` so the
+    //      cached slot is empty during teardown.
+    //
+    // Before the fix, the teardown path invoked `.call(...)` on the cached
+    // `null`, producing a TypeError that was cleared during close and
+    // surfaced as `A JavaScript exception was thrown, but it was cleared
+    // before it could be read.`
+    const c = new RedisClient("redis://127.0.0.1:1", {
+      autoReconnect: false,
+      connectionTimeout: 500,
+    });
     try {
-      // Touch the connection so the client transitions through states that
-      // exercise the onclose callback path. If the server isn't reachable we
-      // just swallow the rejection — the bug fires regardless of whether the
-      // command succeeds.
-      await c.set("test:issue-29145", "v", "EX", "10").catch(() => {});
       c.onclose = null;
+      await c.set("test:issue-29145", "v", "EX", "10").catch(() => {});
       expect(() => c.close()).not.toThrow();
     } finally {
       c.close();

--- a/test/regression/issue/29145.test.ts
+++ b/test/regression/issue/29145.test.ts
@@ -19,84 +19,118 @@ import { describe, expect, test } from "bun:test";
 describe("RedisClient: assigning null to onclose/onconnect (#29145)", () => {
   test("onclose = null does not panic on close()", () => {
     const c = new RedisClient("redis://localhost:6379");
-    c.onclose = null;
-    expect(() => c.close()).not.toThrow();
+    try {
+      c.onclose = null;
+      expect(() => c.close()).not.toThrow();
+    } finally {
+      c.close();
+    }
   });
 
   test("onconnect = null does not panic on close()", () => {
     const c = new RedisClient("redis://localhost:6379");
-    c.onconnect = null;
-    expect(() => c.close()).not.toThrow();
+    try {
+      c.onconnect = null;
+      expect(() => c.close()).not.toThrow();
+    } finally {
+      c.close();
+    }
   });
 
   test("onclose = undefined is also accepted", () => {
     const c = new RedisClient("redis://localhost:6379");
-    c.onclose = undefined as any;
-    expect(() => c.close()).not.toThrow();
+    try {
+      c.onclose = undefined as any;
+      expect(() => c.close()).not.toThrow();
+    } finally {
+      c.close();
+    }
   });
 
   test("onconnect = undefined is also accepted", () => {
     const c = new RedisClient("redis://localhost:6379");
-    c.onconnect = undefined as any;
-    expect(() => c.close()).not.toThrow();
+    try {
+      c.onconnect = undefined as any;
+      expect(() => c.close()).not.toThrow();
+    } finally {
+      c.close();
+    }
   });
 
   test("reading onclose after assigning null returns undefined", () => {
     const c = new RedisClient("redis://localhost:6379");
-    c.onclose = null;
-    expect(c.onclose).toBeUndefined();
-    c.close();
+    try {
+      c.onclose = null;
+      expect(c.onclose).toBeUndefined();
+    } finally {
+      c.close();
+    }
   });
 
   test("reading onconnect after assigning null returns undefined", () => {
     const c = new RedisClient("redis://localhost:6379");
-    c.onconnect = null;
-    expect(c.onconnect).toBeUndefined();
-    c.close();
+    try {
+      c.onconnect = null;
+      expect(c.onconnect).toBeUndefined();
+    } finally {
+      c.close();
+    }
   });
 
   test("assigning a function to onclose still works", () => {
     const c = new RedisClient("redis://localhost:6379");
-    const handler = () => {};
-    c.onclose = handler;
-    expect(c.onclose).toBe(handler);
-    c.close();
+    try {
+      const handler = () => {};
+      c.onclose = handler;
+      expect(c.onclose).toBe(handler);
+    } finally {
+      c.close();
+    }
   });
 
   test("assigning a function to onconnect still works", () => {
     const c = new RedisClient("redis://localhost:6379");
-    const handler = () => {};
-    c.onconnect = handler;
-    expect(c.onconnect).toBe(handler);
-    c.close();
+    try {
+      const handler = () => {};
+      c.onconnect = handler;
+      expect(c.onconnect).toBe(handler);
+    } finally {
+      c.close();
+    }
   });
 
   test("assigning a non-callable non-null value to onclose throws TypeError", () => {
     const c = new RedisClient("redis://localhost:6379");
-    expect(() => {
-      (c as any).onclose = "not a function";
-    }).toThrow(TypeError);
-    expect(() => {
-      (c as any).onclose = 42;
-    }).toThrow(TypeError);
-    expect(() => {
-      (c as any).onclose = {};
-    }).toThrow(TypeError);
-    c.close();
+    try {
+      expect(() => {
+        (c as any).onclose = "not a function";
+      }).toThrow(TypeError);
+      expect(() => {
+        (c as any).onclose = 42;
+      }).toThrow(TypeError);
+      expect(() => {
+        (c as any).onclose = {};
+      }).toThrow(TypeError);
+    } finally {
+      c.close();
+    }
   });
 
   test("assigning a non-callable non-null value to onconnect throws TypeError", () => {
     const c = new RedisClient("redis://localhost:6379");
-    expect(() => {
-      (c as any).onconnect = "not a function";
-    }).toThrow(TypeError);
-    expect(() => {
-      (c as any).onconnect = 42;
-    }).toThrow(TypeError);
-    expect(() => {
-      (c as any).onconnect = {};
-    }).toThrow(TypeError);
-    c.close();
+    try {
+      expect(() => {
+        (c as any).onconnect = "not a function";
+      }).toThrow(TypeError);
+      expect(() => {
+        (c as any).onconnect = 42;
+      }).toThrow(TypeError);
+      expect(() => {
+        (c as any).onconnect = {};
+      }).toThrow(TypeError);
+    } finally {
+      c.close();
+    }
   });
 
   test("null onclose while an in-flight connection is being torn down does not panic", async () => {
@@ -111,9 +145,10 @@ describe("RedisClient: assigning null to onclose/onconnect (#29145)", () => {
       // just swallow the rejection — the bug fires regardless of whether the
       // command succeeds.
       await c.set("test:issue-29145", "v", "EX", "10").catch(() => {});
-    } finally {
       c.onclose = null;
       expect(() => c.close()).not.toThrow();
+    } finally {
+      c.close();
     }
   });
 });

--- a/test/regression/issue/29145.test.ts
+++ b/test/regression/issue/29145.test.ts
@@ -41,6 +41,7 @@ describe("RedisClient: assigning null to onclose/onconnect (#29145)", () => {
     const c = new RedisClient("redis://localhost:6379");
     try {
       c.onclose = undefined;
+      expect(c.onclose).toBeUndefined();
       expect(() => c.close()).not.toThrow();
     } finally {
       c.close();
@@ -51,6 +52,7 @@ describe("RedisClient: assigning null to onclose/onconnect (#29145)", () => {
     const c = new RedisClient("redis://localhost:6379");
     try {
       c.onconnect = undefined;
+      expect(c.onconnect).toBeUndefined();
       expect(() => c.close()).not.toThrow();
     } finally {
       c.close();

--- a/test/regression/issue/29145.test.ts
+++ b/test/regression/issue/29145.test.ts
@@ -156,7 +156,7 @@ describe("RedisClient: assigning null to onclose/onconnect (#29145)", () => {
     });
     try {
       c.onclose = null;
-      await c.set("test:issue-29145", "v", "EX", "10").catch(() => {});
+      await c.set("test:issue-29145", "v", "EX", 10).catch(() => {});
       expect(() => c.close()).not.toThrow();
     } finally {
       c.close();

--- a/test/regression/issue/29145.test.ts
+++ b/test/regression/issue/29145.test.ts
@@ -40,7 +40,7 @@ describe("RedisClient: assigning null to onclose/onconnect (#29145)", () => {
   test("onclose = undefined is also accepted", () => {
     const c = new RedisClient("redis://localhost:6379");
     try {
-      c.onclose = undefined as any;
+      c.onclose = undefined;
       expect(() => c.close()).not.toThrow();
     } finally {
       c.close();
@@ -50,7 +50,7 @@ describe("RedisClient: assigning null to onclose/onconnect (#29145)", () => {
   test("onconnect = undefined is also accepted", () => {
     const c = new RedisClient("redis://localhost:6379");
     try {
-      c.onconnect = undefined as any;
+      c.onconnect = undefined;
       expect(() => c.close()).not.toThrow();
     } finally {
       c.close();


### PR DESCRIPTION
Fixes #29145

## Repro
```ts
const c = new Bun.RedisClient("redis://localhost:6379");
await c.set("k", "v", "EX", 10);
c.onclose = null;  // <-- panics on the close() below
c.close();
console.log("closed ok");
```

```
panic(main thread): A JavaScript exception was thrown, but it was cleared before it could be read.
```

## Cause
`setOnClose` / `setOnConnect` in `src/valkey/js_valkey.zig` cached whatever JS value the setter received (including `null`) into the property slot. The teardown paths — `onValkeyClose` and `failWithJSValue` — then invoked `.call(...)` on the cached value unconditionally. On `null`, the `.call()` threw a TypeError which was thrown and cleared while the socket was tearing down, surfacing as a "cleared before it could be read" panic.

The published type definitions declare both properties as `((...) => void) | null`, so assigning `null` is documented as a supported way to detach the handler.

## Fix
- `setOnClose` / `setOnConnect`: accept `null`/`undefined` (normalize to `.zero`, matching the "unset" contract the callers already handle), throw a TypeError for any other non-callable value — same shape as `ReadableStreamSource.setOnCloseFromJS`.
- `onValkeyClose`, `failWithJSValue`, and the `onconnect` call site in `clientConnect`: guard the cached value with `.isCallable()` for defense in depth.
- `getOnClose` / `getOnConnect`: return `undefined` when the cached slot is not callable, so round-tripping `null` reads back as `undefined` instead of a stale `null`.

## Verification
`test/regression/issue/29145.test.ts` — 11 assertions covering `null`, `undefined`, readback, rejecting non-callable non-null (string/number/object), and the original in-flight `set() → onclose = null → close()` shape. On the published `bun@1.3.12` the file panics; on this branch all cases pass.