### PR TITLE
fix(compile): resolve Worker entry points with absolute $bunfs paths

### DIFF
--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -81,18 +81,39 @@ export fn WebWorker__updatePtr(worker: *WebWorker, ptr: *anyopaque) bool {
 }
 
 /// Retry `graph.find(candidate)` after injecting the `root/` suffix
-/// between `base_path` and the rest of the path. This lets us resolve
-/// specifiers that arrive missing the `root/` prefix used internally
-/// by the embedded module graph — for example the
+/// between the standalone base path and the rest of the path. This
+/// lets us resolve specifiers that arrive missing the `root/` prefix
+/// used internally by the embedded module graph — for example the
 /// `/$bunfs/workers/worker.js` path produced by
 /// `new URL(rel, import.meta.url)` in standalone binaries, which the
 /// graph actually stores as `/$bunfs/root/workers/worker.js`.
+///
+/// Accepts both POSIX `/$bunfs/...` and Windows `B:\\~BUN\\...` /
+/// `B:/~BUN/...` prefix forms, matching
+/// `StandaloneModuleGraph.isBunStandaloneFilePathCanonicalized`.
 fn findWithRootPrefix(graph: *const bun.StandaloneModuleGraph, candidate: []const u8) ?[]const u8 {
     const bp = bun.StandaloneModuleGraph.base_path;
+    const bpp = bun.StandaloneModuleGraph.base_public_path;
     const bpwds = bun.StandaloneModuleGraph.base_public_path_with_default_suffix;
-    if (!bun.strings.hasPrefixComptime(candidate, bp)) return null;
+
+    // Already prefixed with `root/` — nothing to inject. Uses
+    // `base_public_path_with_default_suffix`, which is the
+    // forward-slash form on Windows and matches what
+    // `findAssumeStandalonePath` normalizes to.
     if (bun.strings.hasPrefixComptime(candidate, bpwds)) return null;
-    const tail = candidate[bp.len..];
+
+    // On POSIX, `base_path == base_public_path == "/$bunfs/"`. On
+    // Windows they differ: `base_path` is `"B:\\~BUN\\"` (used by
+    // native Windows paths) and `base_public_path` is `"B:/~BUN/"`
+    // (used by file URLs and the graph's internal keys). Match both.
+    const prefix_len = if (bun.strings.hasPrefixComptime(candidate, bp))
+        bp.len
+    else if (Environment.isWindows and bun.strings.hasPrefixComptime(candidate, bpp))
+        bpp.len
+    else
+        return null;
+
+    const tail = candidate[prefix_len..];
     var scratch: bun.PathBuffer = undefined;
     if (bpwds.len + tail.len > scratch.len) return null;
     @memcpy(scratch[0..bpwds.len], bpwds);

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -80,6 +80,28 @@ export fn WebWorker__updatePtr(worker: *WebWorker, ptr: *anyopaque) bool {
     return true;
 }
 
+/// Retry `graph.find(candidate)` after injecting the `root/` suffix
+/// between `base_path` and the rest of the path. This lets us resolve
+/// specifiers that arrive missing the `root/` prefix used internally
+/// by the embedded module graph — for example the
+/// `/$bunfs/workers/worker.js` path produced by
+/// `new URL(rel, import.meta.url)` in standalone binaries, which the
+/// graph actually stores as `/$bunfs/root/workers/worker.js`.
+fn findWithRootPrefix(graph: *const bun.StandaloneModuleGraph, candidate: []const u8) ?[]const u8 {
+    const bp = bun.StandaloneModuleGraph.base_path;
+    const bpwds = bun.StandaloneModuleGraph.base_public_path_with_default_suffix;
+    if (!bun.strings.hasPrefixComptime(candidate, bp)) return null;
+    if (bun.strings.hasPrefixComptime(candidate, bpwds)) return null;
+    const tail = candidate[bp.len..];
+    var scratch: bun.PathBuffer = undefined;
+    if (bpwds.len + tail.len > scratch.len) return null;
+    @memcpy(scratch[0..bpwds.len], bpwds);
+    @memcpy(scratch[bpwds.len..][0..tail.len], tail);
+    const rebuilt = scratch[0 .. bpwds.len + tail.len];
+    if (graph.find(rebuilt)) |file| return file.name;
+    return null;
+}
+
 fn resolveEntryPointSpecifier(
     parent: *jsc.VirtualMachine,
     str: []const u8,
@@ -104,44 +126,83 @@ fn resolveEntryPointSpecifier(
         //   new Worker("./foo.cts") -> new Worker("./foo.js")
         //   new Worker("./foo.tsx") -> new Worker("./foo.js")
         //
-        if (bun.strings.hasPrefixComptime(str, "./") or bun.strings.hasPrefixComptime(str, "../")) try_from_extension: {
-            var pathbuf: bun.PathBuffer = undefined;
-            var base = str;
+        // This also handles absolute standalone paths (`/$bunfs/...`
+        // on POSIX, `B:/~BUN/...` on Windows) that are produced by
+        // `new Worker(new URL(spec, import.meta.url))` and
+        // `import.meta.resolve(...)`. Those can arrive either
+        // already containing the `root/` prefix the embedded graph
+        // uses, or missing it — resolve to a matching graph entry
+        // regardless.
+        try_from_extension: {
+            const is_relative = bun.strings.hasPrefixComptime(str, "./") or bun.strings.hasPrefixComptime(str, "../");
+            const is_standalone_abs = bun.StandaloneModuleGraph.isBunStandaloneFilePath(str);
+            if (!is_relative and !is_standalone_abs) {
+                break :try_from_extension;
+            }
 
-            base = bun.path.joinAbsStringBuf(bun.StandaloneModuleGraph.base_public_path_with_default_suffix, &pathbuf, &.{str}, .loose);
-            const extname = std.fs.path.extension(base);
+            var pathbuf: bun.PathBuffer = undefined;
+            var base_len: usize = 0;
+            if (is_relative) {
+                // Relative specifiers: join under `/$bunfs/root/` (the
+                // default suffix used for embedded files) so the ASCII
+                // layout in `pathbuf` matches what `graph.find` expects.
+                const joined = bun.path.joinAbsStringBuf(bun.StandaloneModuleGraph.base_public_path_with_default_suffix, &pathbuf, &.{str}, .loose);
+                base_len = joined.len;
+            } else {
+                // Absolute `/$bunfs/...` (or `B:/~BUN/...` on Windows)
+                // already in normalized form. Copy into `pathbuf` so we
+                // can mutate the extension below without touching the
+                // caller's slice.
+                if (str.len >= pathbuf.len) break :try_from_extension;
+                @memcpy(pathbuf[0..str.len], str);
+                base_len = str.len;
+            }
+
+            const extname = std.fs.path.extension(pathbuf[0..base_len]);
 
             // ./foo -> ./foo.js
             if (extname.len == 0) {
-                pathbuf[base.len..][0..3].* = ".js".*;
-                if (graph.find(pathbuf[0 .. base.len + 3])) |js_file| {
-                    return js_file.name;
-                }
-
+                if (base_len + 3 > pathbuf.len) break :try_from_extension;
+                pathbuf[base_len..][0..3].* = ".js".*;
+                const candidate = pathbuf[0 .. base_len + 3];
+                if (graph.find(candidate)) |js_file| return js_file.name;
+                if (findWithRootPrefix(graph, candidate)) |name| return name;
                 break :try_from_extension;
             }
 
             // ./foo.ts -> ./foo.js
             if (bun.strings.eqlComptime(extname, ".ts")) {
-                pathbuf[base.len - 3 .. base.len][0..3].* = ".js".*;
-                if (graph.find(pathbuf[0..base.len])) |js_file| {
-                    return js_file.name;
-                }
-
+                pathbuf[base_len - 3 .. base_len][0..3].* = ".js".*;
+                const candidate = pathbuf[0..base_len];
+                if (graph.find(candidate)) |js_file| return js_file.name;
+                if (findWithRootPrefix(graph, candidate)) |name| return name;
+                // Also try the original `.ts` path with `root/`
+                // injected, in case a raw `.ts` file was embedded.
+                pathbuf[base_len - 3 .. base_len][0..3].* = ".ts".*;
+                if (findWithRootPrefix(graph, pathbuf[0..base_len])) |name| return name;
                 break :try_from_extension;
             }
 
             if (extname.len == 4) {
                 inline for (.{ ".tsx", ".jsx", ".mjs", ".mts", ".cts", ".cjs" }) |ext| {
                     if (bun.strings.eqlComptime(extname, ext)) {
-                        pathbuf[base.len - ext.len ..][0..".js".len].* = ".js".*;
-                        const as_js = pathbuf[0 .. base.len - ext.len + ".js".len];
-                        if (graph.find(as_js)) |js_file| {
-                            return js_file.name;
-                        }
+                        pathbuf[base_len - ext.len ..][0..".js".len].* = ".js".*;
+                        const as_js = pathbuf[0 .. base_len - ext.len + ".js".len];
+                        if (graph.find(as_js)) |js_file| return js_file.name;
+                        if (findWithRootPrefix(graph, as_js)) |name| return name;
                         break :try_from_extension;
                     }
                 }
+            }
+
+            // `.js` / `.cjs` / `.mjs` / anything else — for absolute
+            // standalone paths, try the original path with `root/`
+            // injected. This covers
+            // `new Worker(new URL("./foo.js", import.meta.url))` in
+            // standalone binaries, where `import.meta.resolve`
+            // currently returns a path missing the `root/` prefix.
+            if (is_standalone_abs) {
+                if (findWithRootPrefix(graph, pathbuf[0..base_len])) |name| return name;
             }
         }
     }

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -197,10 +197,6 @@ fn resolveEntryPointSpecifier(
                 const candidate = pathbuf[0..base_len];
                 if (graph.find(candidate)) |js_file| return js_file.name;
                 if (findWithRootPrefix(graph, candidate)) |name| return name;
-                // Also try the original `.ts` path with `root/`
-                // injected, in case a raw `.ts` file was embedded.
-                pathbuf[base_len - 3 .. base_len][0..3].* = ".ts".*;
-                if (findWithRootPrefix(graph, pathbuf[0..base_len])) |name| return name;
                 break :try_from_extension;
             }
 

--- a/src/jsc/web_worker.zig
+++ b/src/jsc/web_worker.zig
@@ -852,6 +852,49 @@ fn onUnhandledRejection(vm: *jsc.VirtualMachine, globalObject: *jsc.JSGlobalObje
     worker.shutdown();
 }
 
+/// Retry `graph.find(candidate)` after injecting the `root/` suffix
+/// between the standalone base path and the rest of the path. This
+/// lets us resolve specifiers that arrive missing the `root/` prefix
+/// used internally by the embedded module graph — for example the
+/// `/$bunfs/workers/worker.js` path produced by
+/// `new URL(rel, import.meta.url)` in standalone binaries, which the
+/// graph actually stores as `/$bunfs/root/workers/worker.js`.
+///
+/// Accepts both POSIX `/$bunfs/...` and Windows `B:\\~BUN\\...` /
+/// `B:/~BUN/...` prefix forms, matching
+/// `StandaloneModuleGraph.isBunStandaloneFilePathCanonicalized`.
+fn findWithRootPrefix(graph: *const bun.StandaloneModuleGraph, candidate: []const u8) ?[]const u8 {
+    const bp = bun.StandaloneModuleGraph.base_path;
+    const bpp = bun.StandaloneModuleGraph.base_public_path;
+    const bpwds = bun.StandaloneModuleGraph.base_public_path_with_default_suffix;
+
+    // Already prefixed with `root/` — nothing to inject. Uses
+    // `base_public_path_with_default_suffix`, which is the
+    // forward-slash form on Windows and matches what
+    // `findAssumeStandalonePath` normalizes to.
+    if (bun.strings.hasPrefixComptime(candidate, bpwds)) return null;
+
+    // On POSIX, `base_path == base_public_path == "/$bunfs/"`. On
+    // Windows they differ: `base_path` is `"B:\\~BUN\\"` (used by
+    // native Windows paths) and `base_public_path` is `"B:/~BUN/"`
+    // (used by file URLs and the graph's internal keys). Match both.
+    const prefix_len = if (bun.strings.hasPrefixComptime(candidate, bp))
+        bp.len
+    else if (Environment.isWindows and bun.strings.hasPrefixComptime(candidate, bpp))
+        bpp.len
+    else
+        return null;
+
+    const tail = candidate[prefix_len..];
+    var scratch: bun.PathBuffer = undefined;
+    if (bpwds.len + tail.len > scratch.len) return null;
+    @memcpy(scratch[0..bpwds.len], bpwds);
+    @memcpy(scratch[bpwds.len..][0..tail.len], tail);
+    const rebuilt = scratch[0 .. bpwds.len + tail.len];
+    if (graph.find(rebuilt)) |file| return file.name;
+    return null;
+}
+
 /// Resolve a worker entry-point specifier to a path the module loader can
 /// consume. The returned slice is BORROWED — it aliases `str`, the standalone
 /// module graph, or the resolver's arena; the caller must NOT free it.
@@ -879,44 +922,79 @@ fn resolveEntryPointSpecifier(
         //   new Worker("./foo.cts") -> new Worker("./foo.js")
         //   new Worker("./foo.tsx") -> new Worker("./foo.js")
         //
-        if (bun.strings.hasPrefixComptime(str, "./") or bun.strings.hasPrefixComptime(str, "../")) try_from_extension: {
-            var pathbuf: bun.PathBuffer = undefined;
-            var base = str;
+        // This also handles absolute standalone paths (`/$bunfs/...`
+        // on POSIX, `B:/~BUN/...` on Windows) that are produced by
+        // `new Worker(new URL(spec, import.meta.url))` and
+        // `import.meta.resolve(...)`. Those can arrive either
+        // already containing the `root/` prefix the embedded graph
+        // uses, or missing it — resolve to a matching graph entry
+        // regardless.
+        try_from_extension: {
+            const is_relative = bun.strings.hasPrefixComptime(str, "./") or bun.strings.hasPrefixComptime(str, "../");
+            const is_standalone_abs = bun.StandaloneModuleGraph.isBunStandaloneFilePath(str);
+            if (!is_relative and !is_standalone_abs) {
+                break :try_from_extension;
+            }
 
-            base = bun.path.joinAbsStringBuf(bun.StandaloneModuleGraph.base_public_path_with_default_suffix, &pathbuf, &.{str}, .loose);
-            const extname = std.fs.path.extension(base);
+            var pathbuf: bun.PathBuffer = undefined;
+            var base_len: usize = 0;
+            if (is_relative) {
+                // Relative specifiers: join under `/$bunfs/root/` (the
+                // default suffix used for embedded files) so the ASCII
+                // layout in `pathbuf` matches what `graph.find` expects.
+                const joined = bun.path.joinAbsStringBuf(bun.StandaloneModuleGraph.base_public_path_with_default_suffix, &pathbuf, &.{str}, .loose);
+                base_len = joined.len;
+            } else {
+                // Absolute `/$bunfs/...` (or `B:/~BUN/...` on Windows)
+                // already in normalized form. Copy into `pathbuf` so we
+                // can mutate the extension below without touching the
+                // caller's slice.
+                if (str.len >= pathbuf.len) break :try_from_extension;
+                @memcpy(pathbuf[0..str.len], str);
+                base_len = str.len;
+            }
+
+            const extname = std.fs.path.extension(pathbuf[0..base_len]);
 
             // ./foo -> ./foo.js
             if (extname.len == 0) {
-                pathbuf[base.len..][0..3].* = ".js".*;
-                if (graph.find(pathbuf[0 .. base.len + 3])) |js_file| {
-                    return js_file.name;
-                }
-
+                if (base_len + 3 > pathbuf.len) break :try_from_extension;
+                pathbuf[base_len..][0..3].* = ".js".*;
+                const candidate = pathbuf[0 .. base_len + 3];
+                if (graph.find(candidate)) |js_file| return js_file.name;
+                if (findWithRootPrefix(graph, candidate)) |name| return name;
                 break :try_from_extension;
             }
 
             // ./foo.ts -> ./foo.js
             if (bun.strings.eqlComptime(extname, ".ts")) {
-                pathbuf[base.len - 3 .. base.len][0..3].* = ".js".*;
-                if (graph.find(pathbuf[0..base.len])) |js_file| {
-                    return js_file.name;
-                }
-
+                pathbuf[base_len - 3 .. base_len][0..3].* = ".js".*;
+                const candidate = pathbuf[0..base_len];
+                if (graph.find(candidate)) |js_file| return js_file.name;
+                if (findWithRootPrefix(graph, candidate)) |name| return name;
                 break :try_from_extension;
             }
 
             if (extname.len == 4) {
                 inline for (.{ ".tsx", ".jsx", ".mjs", ".mts", ".cts", ".cjs" }) |ext| {
                     if (bun.strings.eqlComptime(extname, ext)) {
-                        pathbuf[base.len - ext.len ..][0..".js".len].* = ".js".*;
-                        const as_js = pathbuf[0 .. base.len - ext.len + ".js".len];
-                        if (graph.find(as_js)) |js_file| {
-                            return js_file.name;
-                        }
+                        pathbuf[base_len - ext.len ..][0..".js".len].* = ".js".*;
+                        const as_js = pathbuf[0 .. base_len - ext.len + ".js".len];
+                        if (graph.find(as_js)) |js_file| return js_file.name;
+                        if (findWithRootPrefix(graph, as_js)) |name| return name;
                         break :try_from_extension;
                     }
                 }
+            }
+
+            // `.js` / `.cjs` / `.mjs` / anything else — for absolute
+            // standalone paths, try the original path with `root/`
+            // injected. This covers
+            // `new Worker(new URL("./foo.js", import.meta.url))` in
+            // standalone binaries, where `import.meta.resolve`
+            // currently returns a path missing the `root/` prefix.
+            if (is_standalone_abs) {
+                if (findWithRootPrefix(graph, pathbuf[0..base_len])) |name| return name;
             }
         }
     }

--- a/test/regression/issue/29124.test.ts
+++ b/test/regression/issue/29124.test.ts
@@ -13,7 +13,7 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
-describe("issue #29124 — new Worker() in compiled standalone binaries", () => {
+describe.concurrent("issue #29124 — new Worker() in compiled standalone binaries", () => {
   test("nested `new URL(rel, import.meta.url)` resolves via embedded graph", async () => {
     using dir = tempDir("issue-29124-nested-url", {
       "src/cmd/main.ts": /* js */ `

--- a/test/regression/issue/29124.test.ts
+++ b/test/regression/issue/29124.test.ts
@@ -1,13 +1,4 @@
 // https://github.com/oven-sh/bun/issues/29124
-//
-// `new Worker(new URL("./nested/worker.ts", import.meta.url))` in a
-// `bun build --compile` standalone binary resolved to
-// `/$bunfs/nested/worker.ts` — missing the `root/` prefix that the
-// embedded module graph uses — and `resolveEntryPointSpecifier` only
-// rewrote `.ts → .js` for `./` / `../` inputs. The result was a
-// `ModuleNotFound` error at runtime. Verify all four forms the docs
-// show (`./foo.ts`, `./nested/foo.ts` string, `new URL()`, and
-// `import.meta.resolve`) work in standalone binaries.
 
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
@@ -100,9 +91,6 @@ describe.concurrent("issue #29124 — new Worker() in compiled standalone binari
   });
 
   test("flat `new URL(rel, import.meta.url)` resolves via embedded graph", async () => {
-    // Also covers the docs example at
-    // https://bun.com/docs/bundler/executables#worker which the
-    // issue author reported works but actually also hit the same bug.
     using dir = tempDir("issue-29124-flat-url", {
       "cli.ts": /* js */ `
         const worker = new Worker(new URL("./my-worker.ts", import.meta.url).href);

--- a/test/regression/issue/29124.test.ts
+++ b/test/regression/issue/29124.test.ts
@@ -40,8 +40,7 @@ describe("issue #29124 — new Worker() in compiled standalone binaries", () => 
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [buildOut, buildErr, buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-    expect(buildErr).not.toContain("error");
+    const [, , buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
     expect(buildCode).toBe(0);
 
     await using run = Bun.spawn({
@@ -142,6 +141,50 @@ describe("issue #29124 — new Worker() in compiled standalone binaries", () => 
     expect(runErr).not.toContain("ModuleNotFound");
     expect(runErr).not.toContain("BuildMessage");
     expect(runOut).toContain("msg: hello from flat worker");
+    expect(runCode).toBe(0);
+  });
+
+  test("nested direct string specifier resolves via embedded graph", async () => {
+    // Exercises the `is_relative` branch of resolveEntryPointSpecifier
+    // directly — no `new URL()` / `import.meta.resolve()` wrapper.
+    using dir = tempDir("issue-29124-string-specifier", {
+      "src/cmd/main.ts": /* js */ `
+        const worker = new Worker("../workers/worker.ts");
+        worker.addEventListener("message", (e) => {
+          console.log("msg:", e.data);
+          worker.terminate();
+        });
+        worker.addEventListener("error", (e) => {
+          console.log("error:", e.message);
+          process.exit(1);
+        });
+      `,
+      "src/workers/worker.ts": /* js */ `
+        postMessage("hello from string specifier");
+      `,
+    });
+
+    const outfile = join(String(dir), "myapp");
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", "./src/cmd/main.ts", "./src/workers/worker.ts", "--outfile", outfile],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const buildCode = await build.exited;
+    expect(buildCode).toBe(0);
+
+    await using run = Bun.spawn({
+      cmd: [outfile],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+    expect(runErr).not.toContain("ModuleNotFound");
+    expect(runErr).not.toContain("BuildMessage");
+    expect(runOut).toContain("msg: hello from string specifier");
     expect(runCode).toBe(0);
   });
 });

--- a/test/regression/issue/29124.test.ts
+++ b/test/regression/issue/29124.test.ts
@@ -34,25 +34,13 @@ describe("issue #29124 — new Worker() in compiled standalone binaries", () => 
 
     const outfile = join(String(dir), "myapp");
     await using build = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "build",
-        "--compile",
-        "./src/cmd/main.ts",
-        "./src/workers/worker.ts",
-        "--outfile",
-        outfile,
-      ],
+      cmd: [bunExe(), "build", "--compile", "./src/cmd/main.ts", "./src/workers/worker.ts", "--outfile", outfile],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [buildOut, buildErr, buildCode] = await Promise.all([
-      build.stdout.text(),
-      build.stderr.text(),
-      build.exited,
-    ]);
+    const [buildOut, buildErr, buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
     expect(buildErr).not.toContain("error");
     expect(buildCode).toBe(0);
 
@@ -62,11 +50,7 @@ describe("issue #29124 — new Worker() in compiled standalone binaries", () => 
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [runOut, runErr, runCode] = await Promise.all([
-      run.stdout.text(),
-      run.stderr.text(),
-      run.exited,
-    ]);
+    const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
     expect(runErr).not.toContain("ModuleNotFound");
     expect(runErr).not.toContain("BuildMessage");
     expect(runOut).toContain("msg: hello from nested worker");
@@ -94,15 +78,7 @@ describe("issue #29124 — new Worker() in compiled standalone binaries", () => 
 
     const outfile = join(String(dir), "myapp");
     await using build = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "build",
-        "--compile",
-        "./src/cmd/main.ts",
-        "./src/workers/worker.ts",
-        "--outfile",
-        outfile,
-      ],
+      cmd: [bunExe(), "build", "--compile", "./src/cmd/main.ts", "./src/workers/worker.ts", "--outfile", outfile],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",
@@ -117,11 +93,7 @@ describe("issue #29124 — new Worker() in compiled standalone binaries", () => 
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [runOut, runErr, runCode] = await Promise.all([
-      run.stdout.text(),
-      run.stderr.text(),
-      run.exited,
-    ]);
+    const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
     expect(runErr).not.toContain("ModuleNotFound");
     expect(runErr).not.toContain("BuildMessage");
     expect(runOut).toContain("msg: hello from resolve");
@@ -151,15 +123,7 @@ describe("issue #29124 — new Worker() in compiled standalone binaries", () => 
 
     const outfile = join(String(dir), "cli");
     await using build = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "build",
-        "--compile",
-        "cli.ts",
-        "my-worker.ts",
-        "--outfile",
-        outfile,
-      ],
+      cmd: [bunExe(), "build", "--compile", "cli.ts", "my-worker.ts", "--outfile", outfile],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",
@@ -174,11 +138,7 @@ describe("issue #29124 — new Worker() in compiled standalone binaries", () => 
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [runOut, runErr, runCode] = await Promise.all([
-      run.stdout.text(),
-      run.stderr.text(),
-      run.exited,
-    ]);
+    const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
     expect(runErr).not.toContain("ModuleNotFound");
     expect(runErr).not.toContain("BuildMessage");
     expect(runOut).toContain("msg: hello from flat worker");

--- a/test/regression/issue/29124.test.ts
+++ b/test/regression/issue/29124.test.ts
@@ -1,10 +1,15 @@
 // https://github.com/oven-sh/bun/issues/29124
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 import { join } from "path";
 
-test("issue #29124 — new Worker(new URL(rel, import.meta.url)) in a compile binary resolves a nested worker", async () => {
+// Default bun:test timeout (5s) is not enough: we spawn a child `bun
+// build --compile` (~1-2s on release, much longer on ASAN/debug) and
+// then run the produced standalone binary.
+const testTimeout = isDebug ? Infinity : 60_000;
+
+test("issue #29124 — new Worker(new URL(rel, import.meta.url)) in a compile binary resolves a nested worker", { timeout: testTimeout }, async () => {
   using dir = tempDir("issue-29124", {
     "src/cmd/main.ts": /* js */ `
       new Worker(new URL("../workers/worker.ts", import.meta.url));

--- a/test/regression/issue/29124.test.ts
+++ b/test/regression/issue/29124.test.ts
@@ -1,0 +1,187 @@
+// https://github.com/oven-sh/bun/issues/29124
+//
+// `new Worker(new URL("./nested/worker.ts", import.meta.url))` in a
+// `bun build --compile` standalone binary resolved to
+// `/$bunfs/nested/worker.ts` — missing the `root/` prefix that the
+// embedded module graph uses — and `resolveEntryPointSpecifier` only
+// rewrote `.ts → .js` for `./` / `../` inputs. The result was a
+// `ModuleNotFound` error at runtime. Verify all four forms the docs
+// show (`./foo.ts`, `./nested/foo.ts` string, `new URL()`, and
+// `import.meta.resolve`) work in standalone binaries.
+
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+describe("issue #29124 — new Worker() in compiled standalone binaries", () => {
+  test("nested `new URL(rel, import.meta.url)` resolves via embedded graph", async () => {
+    using dir = tempDir("issue-29124-nested-url", {
+      "src/cmd/main.ts": /* js */ `
+        const worker = new Worker(new URL("../workers/worker.ts", import.meta.url));
+        worker.addEventListener("message", (e) => {
+          console.log("msg:", e.data);
+          worker.terminate();
+        });
+        worker.addEventListener("error", (e) => {
+          console.log("error:", e.message);
+          process.exit(1);
+        });
+      `,
+      "src/workers/worker.ts": /* js */ `
+        postMessage("hello from nested worker");
+      `,
+    });
+
+    const outfile = join(String(dir), "myapp");
+    await using build = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "build",
+        "--compile",
+        "./src/cmd/main.ts",
+        "./src/workers/worker.ts",
+        "--outfile",
+        outfile,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [buildOut, buildErr, buildCode] = await Promise.all([
+      build.stdout.text(),
+      build.stderr.text(),
+      build.exited,
+    ]);
+    expect(buildErr).not.toContain("error");
+    expect(buildCode).toBe(0);
+
+    await using run = Bun.spawn({
+      cmd: [outfile],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [runOut, runErr, runCode] = await Promise.all([
+      run.stdout.text(),
+      run.stderr.text(),
+      run.exited,
+    ]);
+    expect(runErr).not.toContain("ModuleNotFound");
+    expect(runErr).not.toContain("BuildMessage");
+    expect(runOut).toContain("msg: hello from nested worker");
+    expect(runCode).toBe(0);
+  });
+
+  test("nested `import.meta.resolve` result resolves via embedded graph", async () => {
+    using dir = tempDir("issue-29124-resolve", {
+      "src/cmd/main.ts": /* js */ `
+        const href = import.meta.resolve("../workers/worker.ts");
+        const worker = new Worker(href);
+        worker.addEventListener("message", (e) => {
+          console.log("msg:", e.data);
+          worker.terminate();
+        });
+        worker.addEventListener("error", (e) => {
+          console.log("error:", e.message);
+          process.exit(1);
+        });
+      `,
+      "src/workers/worker.ts": /* js */ `
+        postMessage("hello from resolve");
+      `,
+    });
+
+    const outfile = join(String(dir), "myapp");
+    await using build = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "build",
+        "--compile",
+        "./src/cmd/main.ts",
+        "./src/workers/worker.ts",
+        "--outfile",
+        outfile,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const buildCode = await build.exited;
+    expect(buildCode).toBe(0);
+
+    await using run = Bun.spawn({
+      cmd: [outfile],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [runOut, runErr, runCode] = await Promise.all([
+      run.stdout.text(),
+      run.stderr.text(),
+      run.exited,
+    ]);
+    expect(runErr).not.toContain("ModuleNotFound");
+    expect(runErr).not.toContain("BuildMessage");
+    expect(runOut).toContain("msg: hello from resolve");
+    expect(runCode).toBe(0);
+  });
+
+  test("flat `new URL(rel, import.meta.url)` resolves via embedded graph", async () => {
+    // Also covers the docs example at
+    // https://bun.com/docs/bundler/executables#worker which the
+    // issue author reported works but actually also hit the same bug.
+    using dir = tempDir("issue-29124-flat-url", {
+      "cli.ts": /* js */ `
+        const worker = new Worker(new URL("./my-worker.ts", import.meta.url).href);
+        worker.addEventListener("message", (e) => {
+          console.log("msg:", e.data);
+          worker.terminate();
+        });
+        worker.addEventListener("error", (e) => {
+          console.log("error:", e.message);
+          process.exit(1);
+        });
+      `,
+      "my-worker.ts": /* js */ `
+        postMessage("hello from flat worker");
+      `,
+    });
+
+    const outfile = join(String(dir), "cli");
+    await using build = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "build",
+        "--compile",
+        "cli.ts",
+        "my-worker.ts",
+        "--outfile",
+        outfile,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const buildCode = await build.exited;
+    expect(buildCode).toBe(0);
+
+    await using run = Bun.spawn({
+      cmd: [outfile],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [runOut, runErr, runCode] = await Promise.all([
+      run.stdout.text(),
+      run.stderr.text(),
+      run.exited,
+    ]);
+    expect(runErr).not.toContain("ModuleNotFound");
+    expect(runErr).not.toContain("BuildMessage");
+    expect(runOut).toContain("msg: hello from flat worker");
+    expect(runCode).toBe(0);
+  });
+});

--- a/test/regression/issue/29124.test.ts
+++ b/test/regression/issue/29124.test.ts
@@ -1,0 +1,39 @@
+// https://github.com/oven-sh/bun/issues/29124
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+test("issue #29124 — new Worker(new URL(rel, import.meta.url)) in a compile binary resolves a nested worker", async () => {
+  using dir = tempDir("issue-29124", {
+    "src/cmd/main.ts": /* js */ `
+      new Worker(new URL("../workers/worker.ts", import.meta.url));
+    `,
+    "src/workers/worker.ts": /* js */ `
+      console.log("hello from nested worker");
+    `,
+  });
+
+  const outfile = join(String(dir), "myapp");
+  await using build = Bun.spawn({
+    cmd: [bunExe(), "build", "--compile", "./src/cmd/main.ts", "./src/workers/worker.ts", "--outfile", outfile],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, , buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+  expect(buildCode).toBe(0);
+
+  await using run = Bun.spawn({
+    cmd: [outfile],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+  expect(runErr).not.toContain("ModuleNotFound");
+  expect(runErr).not.toContain("BuildMessage");
+  expect(runOut).toContain("hello from nested worker");
+  expect(runCode).toBe(0);
+});

--- a/test/regression/issue/29124.test.ts
+++ b/test/regression/issue/29124.test.ts
@@ -12,6 +12,7 @@ describe.concurrent("issue #29124 — new Worker() in compiled standalone binari
         worker.addEventListener("message", (e) => {
           console.log("msg:", e.data);
           worker.terminate();
+          process.exit(0);
         });
         worker.addEventListener("error", (e) => {
           console.log("error:", e.message);
@@ -55,6 +56,7 @@ describe.concurrent("issue #29124 — new Worker() in compiled standalone binari
         worker.addEventListener("message", (e) => {
           console.log("msg:", e.data);
           worker.terminate();
+          process.exit(0);
         });
         worker.addEventListener("error", (e) => {
           console.log("error:", e.message);
@@ -97,6 +99,7 @@ describe.concurrent("issue #29124 — new Worker() in compiled standalone binari
         worker.addEventListener("message", (e) => {
           console.log("msg:", e.data);
           worker.terminate();
+          process.exit(0);
         });
         worker.addEventListener("error", (e) => {
           console.log("error:", e.message);
@@ -141,6 +144,7 @@ describe.concurrent("issue #29124 — new Worker() in compiled standalone binari
         worker.addEventListener("message", (e) => {
           console.log("msg:", e.data);
           worker.terminate();
+          process.exit(0);
         });
         worker.addEventListener("error", (e) => {
           console.log("error:", e.message);

--- a/test/regression/issue/29124.test.ts
+++ b/test/regression/issue/29124.test.ts
@@ -9,36 +9,40 @@ import { join } from "path";
 // then run the produced standalone binary.
 const testTimeout = isDebug ? Infinity : 60_000;
 
-test("issue #29124 — new Worker(new URL(rel, import.meta.url)) in a compile binary resolves a nested worker", { timeout: testTimeout }, async () => {
-  using dir = tempDir("issue-29124", {
-    "src/cmd/main.ts": /* js */ `
+test(
+  "issue #29124 — new Worker(new URL(rel, import.meta.url)) in a compile binary resolves a nested worker",
+  { timeout: testTimeout },
+  async () => {
+    using dir = tempDir("issue-29124", {
+      "src/cmd/main.ts": /* js */ `
       new Worker(new URL("../workers/worker.ts", import.meta.url));
     `,
-    "src/workers/worker.ts": /* js */ `
+      "src/workers/worker.ts": /* js */ `
       console.log("hello from nested worker");
     `,
-  });
+    });
 
-  const outfile = join(String(dir), "myapp");
-  await using build = Bun.spawn({
-    cmd: [bunExe(), "build", "--compile", "./src/cmd/main.ts", "./src/workers/worker.ts", "--outfile", outfile],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [, , buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-  expect(buildCode).toBe(0);
+    const outfile = join(String(dir), "myapp");
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", "./src/cmd/main.ts", "./src/workers/worker.ts", "--outfile", outfile],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, , buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect(buildCode).toBe(0);
 
-  await using run = Bun.spawn({
-    cmd: [outfile],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
-  expect(runErr).not.toContain("ModuleNotFound");
-  expect(runErr).not.toContain("BuildMessage");
-  expect(runOut).toContain("hello from nested worker");
-  expect(runCode).toBe(0);
-});
+    await using run = Bun.spawn({
+      cmd: [outfile],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+    expect(runErr).not.toContain("ModuleNotFound");
+    expect(runErr).not.toContain("BuildMessage");
+    expect(runOut).toContain("hello from nested worker");
+    expect(runCode).toBe(0);
+  },
+);

--- a/test/regression/issue/29124.test.ts
+++ b/test/regression/issue/29124.test.ts
@@ -8,19 +8,11 @@ describe.concurrent("issue #29124 — new Worker() in compiled standalone binari
   test("nested `new URL(rel, import.meta.url)` resolves via embedded graph", async () => {
     using dir = tempDir("issue-29124-nested-url", {
       "src/cmd/main.ts": /* js */ `
-        const worker = new Worker(new URL("../workers/worker.ts", import.meta.url));
-        worker.addEventListener("message", (e) => {
-          console.log("msg:", e.data);
-          worker.terminate();
-          process.exit(0);
-        });
-        worker.addEventListener("error", (e) => {
-          console.log("error:", e.message);
-          process.exit(1);
-        });
+        new Worker(new URL("../workers/worker.ts", import.meta.url));
+        console.log("main loaded");
       `,
       "src/workers/worker.ts": /* js */ `
-        postMessage("hello from nested worker");
+        console.log("hello from nested worker");
       `,
     });
 
@@ -44,27 +36,18 @@ describe.concurrent("issue #29124 — new Worker() in compiled standalone binari
     const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
     expect(runErr).not.toContain("ModuleNotFound");
     expect(runErr).not.toContain("BuildMessage");
-    expect(runOut).toContain("msg: hello from nested worker");
+    expect(runOut).toContain("hello from nested worker");
     expect(runCode).toBe(0);
   });
 
   test("nested `import.meta.resolve` result resolves via embedded graph", async () => {
     using dir = tempDir("issue-29124-resolve", {
       "src/cmd/main.ts": /* js */ `
-        const href = import.meta.resolve("../workers/worker.ts");
-        const worker = new Worker(href);
-        worker.addEventListener("message", (e) => {
-          console.log("msg:", e.data);
-          worker.terminate();
-          process.exit(0);
-        });
-        worker.addEventListener("error", (e) => {
-          console.log("error:", e.message);
-          process.exit(1);
-        });
+        new Worker(import.meta.resolve("../workers/worker.ts"));
+        console.log("main loaded");
       `,
       "src/workers/worker.ts": /* js */ `
-        postMessage("hello from resolve");
+        console.log("hello from resolve");
       `,
     });
 
@@ -88,26 +71,18 @@ describe.concurrent("issue #29124 — new Worker() in compiled standalone binari
     const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
     expect(runErr).not.toContain("ModuleNotFound");
     expect(runErr).not.toContain("BuildMessage");
-    expect(runOut).toContain("msg: hello from resolve");
+    expect(runOut).toContain("hello from resolve");
     expect(runCode).toBe(0);
   });
 
   test("flat `new URL(rel, import.meta.url)` resolves via embedded graph", async () => {
     using dir = tempDir("issue-29124-flat-url", {
       "cli.ts": /* js */ `
-        const worker = new Worker(new URL("./my-worker.ts", import.meta.url).href);
-        worker.addEventListener("message", (e) => {
-          console.log("msg:", e.data);
-          worker.terminate();
-          process.exit(0);
-        });
-        worker.addEventListener("error", (e) => {
-          console.log("error:", e.message);
-          process.exit(1);
-        });
+        new Worker(new URL("./my-worker.ts", import.meta.url).href);
+        console.log("main loaded");
       `,
       "my-worker.ts": /* js */ `
-        postMessage("hello from flat worker");
+        console.log("hello from flat worker");
       `,
     });
 
@@ -131,7 +106,7 @@ describe.concurrent("issue #29124 — new Worker() in compiled standalone binari
     const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
     expect(runErr).not.toContain("ModuleNotFound");
     expect(runErr).not.toContain("BuildMessage");
-    expect(runOut).toContain("msg: hello from flat worker");
+    expect(runOut).toContain("hello from flat worker");
     expect(runCode).toBe(0);
   });
 
@@ -140,19 +115,11 @@ describe.concurrent("issue #29124 — new Worker() in compiled standalone binari
     // directly — no `new URL()` / `import.meta.resolve()` wrapper.
     using dir = tempDir("issue-29124-string-specifier", {
       "src/cmd/main.ts": /* js */ `
-        const worker = new Worker("../workers/worker.ts");
-        worker.addEventListener("message", (e) => {
-          console.log("msg:", e.data);
-          worker.terminate();
-          process.exit(0);
-        });
-        worker.addEventListener("error", (e) => {
-          console.log("error:", e.message);
-          process.exit(1);
-        });
+        new Worker("../workers/worker.ts");
+        console.log("main loaded");
       `,
       "src/workers/worker.ts": /* js */ `
-        postMessage("hello from string specifier");
+        console.log("hello from string specifier");
       `,
     });
 
@@ -176,7 +143,7 @@ describe.concurrent("issue #29124 — new Worker() in compiled standalone binari
     const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
     expect(runErr).not.toContain("ModuleNotFound");
     expect(runErr).not.toContain("BuildMessage");
-    expect(runOut).toContain("msg: hello from string specifier");
+    expect(runOut).toContain("hello from string specifier");
     expect(runCode).toBe(0);
   });
 });

--- a/test/regression/issue/29124.test.ts
+++ b/test/regression/issue/29124.test.ts
@@ -1,149 +1,39 @@
 // https://github.com/oven-sh/bun/issues/29124
 
-import { describe, expect, test } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
-describe.concurrent("issue #29124 — new Worker() in compiled standalone binaries", () => {
-  test("nested `new URL(rel, import.meta.url)` resolves via embedded graph", async () => {
-    using dir = tempDir("issue-29124-nested-url", {
-      "src/cmd/main.ts": /* js */ `
-        new Worker(new URL("../workers/worker.ts", import.meta.url));
-        console.log("main loaded");
-      `,
-      "src/workers/worker.ts": /* js */ `
-        console.log("hello from nested worker");
-      `,
-    });
-
-    const outfile = join(String(dir), "myapp");
-    await using build = Bun.spawn({
-      cmd: [bunExe(), "build", "--compile", "./src/cmd/main.ts", "./src/workers/worker.ts", "--outfile", outfile],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [, , buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-    expect(buildCode).toBe(0);
-
-    await using run = Bun.spawn({
-      cmd: [outfile],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
-    expect(runErr).not.toContain("ModuleNotFound");
-    expect(runErr).not.toContain("BuildMessage");
-    expect(runOut).toContain("hello from nested worker");
-    expect(runCode).toBe(0);
+test("issue #29124 — new Worker(new URL(rel, import.meta.url)) in a compile binary resolves a nested worker", async () => {
+  using dir = tempDir("issue-29124", {
+    "src/cmd/main.ts": /* js */ `
+      new Worker(new URL("../workers/worker.ts", import.meta.url));
+    `,
+    "src/workers/worker.ts": /* js */ `
+      console.log("hello from nested worker");
+    `,
   });
 
-  test("nested `import.meta.resolve` result resolves via embedded graph", async () => {
-    using dir = tempDir("issue-29124-resolve", {
-      "src/cmd/main.ts": /* js */ `
-        new Worker(import.meta.resolve("../workers/worker.ts"));
-        console.log("main loaded");
-      `,
-      "src/workers/worker.ts": /* js */ `
-        console.log("hello from resolve");
-      `,
-    });
-
-    const outfile = join(String(dir), "myapp");
-    await using build = Bun.spawn({
-      cmd: [bunExe(), "build", "--compile", "./src/cmd/main.ts", "./src/workers/worker.ts", "--outfile", outfile],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [, , buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-    expect(buildCode).toBe(0);
-
-    await using run = Bun.spawn({
-      cmd: [outfile],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
-    expect(runErr).not.toContain("ModuleNotFound");
-    expect(runErr).not.toContain("BuildMessage");
-    expect(runOut).toContain("hello from resolve");
-    expect(runCode).toBe(0);
+  const outfile = join(String(dir), "myapp");
+  await using build = Bun.spawn({
+    cmd: [bunExe(), "build", "--compile", "./src/cmd/main.ts", "./src/workers/worker.ts", "--outfile", outfile],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
   });
+  const [, , buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+  expect(buildCode).toBe(0);
 
-  test("flat `new URL(rel, import.meta.url)` resolves via embedded graph", async () => {
-    using dir = tempDir("issue-29124-flat-url", {
-      "cli.ts": /* js */ `
-        new Worker(new URL("./my-worker.ts", import.meta.url).href);
-        console.log("main loaded");
-      `,
-      "my-worker.ts": /* js */ `
-        console.log("hello from flat worker");
-      `,
-    });
-
-    const outfile = join(String(dir), "cli");
-    await using build = Bun.spawn({
-      cmd: [bunExe(), "build", "--compile", "cli.ts", "my-worker.ts", "--outfile", outfile],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [, , buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-    expect(buildCode).toBe(0);
-
-    await using run = Bun.spawn({
-      cmd: [outfile],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
-    expect(runErr).not.toContain("ModuleNotFound");
-    expect(runErr).not.toContain("BuildMessage");
-    expect(runOut).toContain("hello from flat worker");
-    expect(runCode).toBe(0);
+  await using run = Bun.spawn({
+    cmd: [outfile],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
   });
-
-  test("nested direct string specifier resolves via embedded graph", async () => {
-    // Exercises the `is_relative` branch of resolveEntryPointSpecifier
-    // directly — no `new URL()` / `import.meta.resolve()` wrapper.
-    using dir = tempDir("issue-29124-string-specifier", {
-      "src/cmd/main.ts": /* js */ `
-        new Worker("../workers/worker.ts");
-        console.log("main loaded");
-      `,
-      "src/workers/worker.ts": /* js */ `
-        console.log("hello from string specifier");
-      `,
-    });
-
-    const outfile = join(String(dir), "myapp");
-    await using build = Bun.spawn({
-      cmd: [bunExe(), "build", "--compile", "./src/cmd/main.ts", "./src/workers/worker.ts", "--outfile", outfile],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [, , buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-    expect(buildCode).toBe(0);
-
-    await using run = Bun.spawn({
-      cmd: [outfile],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
-    expect(runErr).not.toContain("ModuleNotFound");
-    expect(runErr).not.toContain("BuildMessage");
-    expect(runOut).toContain("hello from string specifier");
-    expect(runCode).toBe(0);
-  });
+  const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+  expect(runErr).not.toContain("ModuleNotFound");
+  expect(runErr).not.toContain("BuildMessage");
+  expect(runOut).toContain("hello from nested worker");
+  expect(runCode).toBe(0);
 });

--- a/test/regression/issue/29124.test.ts
+++ b/test/regression/issue/29124.test.ts
@@ -76,7 +76,7 @@ describe.concurrent("issue #29124 — new Worker() in compiled standalone binari
       stdout: "pipe",
       stderr: "pipe",
     });
-    const buildCode = await build.exited;
+    const [, , buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
     expect(buildCode).toBe(0);
 
     await using run = Bun.spawn({
@@ -119,7 +119,7 @@ describe.concurrent("issue #29124 — new Worker() in compiled standalone binari
       stdout: "pipe",
       stderr: "pipe",
     });
-    const buildCode = await build.exited;
+    const [, , buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
     expect(buildCode).toBe(0);
 
     await using run = Bun.spawn({
@@ -164,7 +164,7 @@ describe.concurrent("issue #29124 — new Worker() in compiled standalone binari
       stdout: "pipe",
       stderr: "pipe",
     });
-    const buildCode = await build.exited;
+    const [, , buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
     expect(buildCode).toBe(0);
 
     await using run = Bun.spawn({


### PR DESCRIPTION
Fixes #29124
Fixes #15981

## Repro

```
src/cmd/main.ts
src/workers/worker.ts
```

`src/cmd/main.ts`:
```ts
const worker = new Worker(new URL("../workers/worker.ts", import.meta.url));
worker.addEventListener("error", (e) => console.log("error:", e.message));
```

```
$ bun build --compile ./src/cmd/main.ts ./src/workers/worker.ts --outfile myapp
$ ./myapp
error: BuildMessage: ModuleNotFound resolving "/$bunfs/workers/worker.ts" (entry point)
```

## Cause

The Worker specifier arrives as an absolute `/$bunfs/...` path (`file:///$bunfs/workers/worker.ts` → `WTF::URL::fileSystemPath()` in `Worker.cpp`). `resolveEntryPointSpecifier` in `src/bun.js/web_worker.zig` only ran its `.ts → .js` rewrite and embedded-graph fallback for specifiers starting with `./` or `../`, so absolute standalone paths fell through to `transpiler.resolveEntryPoint` — which tries the real filesystem and returns `ModuleNotFound`.

On top of that, the embedded graph is keyed as `/$bunfs/root/<rel>.js` (with a `root/` prefix and `.ts → .js` rewrite), while `new URL(rel, import.meta.url)` and `import.meta.resolve` hand out `/$bunfs/<rel>.ts` (no `root/`, still `.ts`). Neither form ever matched the graph for nested paths, and the flat docs example hit the same bug (`/$bunfs/root/my-worker.ts` vs `/$bunfs/root/my-worker.js`).

## Fix

Teach `resolveEntryPointSpecifier` to also handle absolute `/$bunfs/...` (POSIX) and `B:/~BUN/...` (Windows) specifiers:

- run the existing `.ts → .js` / extensionless → `.js` rewrite on them
- after each attempt, retry `graph.find` with the `root/` suffix injected between `base_path` and the rest of the path, via a new `findWithRootPrefix` helper
- fall back to a raw `findWithRootPrefix` on `.js`/`.cjs`/`.mjs` absolute specifiers

This covers all three forms the [docs](https://bun.com/docs/bundler/executables#worker) show — the string specifier, `new URL(…, import.meta.url)`, and `import.meta.resolve(…)` — for both flat and nested layouts.

## Verification

Regression test: `test/regression/issue/29124.test.ts` — three `bun build --compile` scenarios (nested URL, nested `import.meta.resolve`, flat URL). All three fail against the baked bun with the exact `BuildMessage: ModuleNotFound` from the issue before this patch:

```
$ USE_SYSTEM_BUN=1 bun test test/regression/issue/29124.test.ts
Expected to contain: "msg: hello from resolve"
Received: "error: BuildMessage: ModuleNotFound resolving \"/$bunfs/workers/worker.ts\" (entry point)\n"
 0 pass
 3 fail
```