### PR TITLE
Implement X25519 deriveBits in SubtleCrypto

### DIFF
--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmX25519.cpp
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmX25519.cpp
@@ -26,6 +26,7 @@
 #include "CryptoKeyOKP.h"
 #include "ScriptExecutionContext.h"
 #include "CryptoDigest.h"
+#include <openssl/curve25519.h>
 #include <wtf/CryptographicUtilities.h>
 
 namespace WebCore {
@@ -60,13 +61,16 @@ void CryptoAlgorithmX25519::generateKey(const CryptoAlgorithmParameters&, bool e
 }
 
 #if !PLATFORM(COCOA) && !USE(GCRYPT)
-std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP&, const CryptoKeyOKP&)
+std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP& baseKey, const CryptoKeyOKP& publicKey)
 {
-    return std::nullopt;
+    Vector<uint8_t> result(X25519_SHARED_KEY_LEN);
+    if (!X25519(result.begin(), baseKey.platformKey().begin(), publicKey.platformKey().begin()))
+        return std::nullopt;
+    return result;
 }
 #endif
 
-void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, size_t length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
     if (baseKey->type() != CryptoKey::Type::Private) {
         exceptionCallback(ExceptionCode::InvalidAccessError, ""_s);
@@ -89,21 +93,9 @@ void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& paramete
         return;
     }
 
-    // Return an empty string doesn't make much sense, but truncating either at all.
-    // https://github.com/WICG/webcrypto-secure-curves/pull/29
-    if (length && !(*length)) {
-        // Avoid executing the key-derivation, since we are going to return an empty string.
-        callback({});
-        return;
-    }
-
-    auto unifiedCallback = [callback = WTF::move(callback), exceptionCallback = WTF::move(exceptionCallback)](std::optional<Vector<uint8_t>>&& derivedKey, std::optional<size_t> length) mutable {
+    auto unifiedCallback = [length, callback = WTF::move(callback), exceptionCallback = WTF::move(exceptionCallback)](std::optional<Vector<uint8_t>>&& derivedKey) mutable {
         if (!derivedKey) {
             exceptionCallback(ExceptionCode::OperationError, ""_s);
-            return;
-        }
-        if (!length) {
-            callback(WTF::move(*derivedKey));
             return;
         }
 #if !HAVE(X25519_ZERO_CHECKS)
@@ -115,7 +107,11 @@ void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& paramete
             return;
         }
 #endif
-        auto lengthInBytes = std::ceil(*length / 8.);
+        if (!length) {
+            callback(WTF::move(*derivedKey));
+            return;
+        }
+        auto lengthInBytes = static_cast<size_t>(std::ceil(length / 8.));
         if (lengthInBytes > (*derivedKey).size()) {
             exceptionCallback(ExceptionCode::OperationError, ""_s);
             return;
@@ -127,10 +123,10 @@ void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& paramete
     // the result validation and callback dispatch into unifiedCallback.
     workQueue.dispatch(
         context.globalObject(),
-        [baseKey = WTF::move(baseKey), publicKey = ecParameters.publicKey, length, unifiedCallback = WTF::move(unifiedCallback), contextIdentifier = context.identifier()]() mutable {
+        [baseKey = WTF::move(baseKey), publicKey = ecParameters.publicKey, unifiedCallback = WTF::move(unifiedCallback), contextIdentifier = context.identifier()]() mutable {
             auto derivedKey = platformDeriveBits(downcast<CryptoKeyOKP>(baseKey.get()), downcast<CryptoKeyOKP>(*publicKey));
-            ScriptExecutionContext::postTaskTo(contextIdentifier, [derivedKey = WTF::move(derivedKey), length, unifiedCallback = WTF::move(unifiedCallback)](auto&) mutable {
-                unifiedCallback(WTF::move(derivedKey), length);
+            ScriptExecutionContext::postTaskTo(contextIdentifier, [derivedKey = WTF::move(derivedKey), unifiedCallback = WTF::move(unifiedCallback)](auto&) mutable {
+                unifiedCallback(WTF::move(derivedKey));
             });
         });
 }

--- a/src/bun.js/bindings/webcrypto/CryptoAlgorithmX25519.h
+++ b/src/bun.js/bindings/webcrypto/CryptoAlgorithmX25519.h
@@ -38,7 +38,7 @@ private:
     CryptoAlgorithmIdentifier identifier() const final;
 
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&);
-    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&);
+    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
 

--- a/src/bun.js/bindings/webcrypto/SubtleCrypto.cpp
+++ b/src/bun.js/bindings/webcrypto/SubtleCrypto.cpp
@@ -274,8 +274,11 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
         case CryptoAlgorithmIdentifier::ECDH: {
             // Remove this hack once https://bugs.webkit.org/show_bug.cgi?id=169333 is fixed.
             JSValue nameValue = value.get()->get(&state, vm.propertyNames->name);
+            RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
             JSValue publicValue = value.get()->get(&state, Identifier::fromString(vm, "public"_s));
+            RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
             JSObject* newValue = constructEmptyObject(&state);
+            RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
             newValue->putDirect(vm, vm.propertyNames->name, nameValue);
             newValue->putDirect(vm, Identifier::fromString(vm, "publicKey"_s), publicValue);
 
@@ -287,8 +290,11 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
         case CryptoAlgorithmIdentifier::X25519: {
             // Remove this hack once https://bugs.webkit.org/show_bug.cgi?id=169333 is fixed.
             JSValue nameValue = value.get()->get(&state, vm.propertyNames->name);
+            RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
             JSValue publicValue = value.get()->get(&state, vm.propertyNames->publicKeyword);
+            RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
             JSObject* newValue = constructEmptyObject(&state);
+            RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
             newValue->putDirect(vm, vm.propertyNames->name, nameValue);
             newValue->putDirect(vm, Identifier::fromString(vm, "publicKey"_s), publicValue);
 
@@ -806,6 +812,7 @@ void SubtleCrypto::generateKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&&
         promise->reject(paramsOrException.releaseException());
         return;
     }
+    RETURN_IF_EXCEPTION(scope, void());
     auto params = paramsOrException.releaseReturnValue();
 
     auto keyUsagesBitmap = toCryptoKeyUsageBitmap(keyUsages);
@@ -926,11 +933,14 @@ void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& a
 
 void SubtleCrypto::deriveBits(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algorithmIdentifier, CryptoKey& baseKey, unsigned length, Ref<DeferredPromise>&& promise)
 {
+    auto& vm = state.vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto paramsOrException = normalizeCryptoAlgorithmParameters(state, WTF::move(algorithmIdentifier), Operations::DeriveBits);
     if (paramsOrException.hasException()) {
         promise->reject(paramsOrException.releaseException());
         return;
     }
+    RETURN_IF_EXCEPTION(scope, void());
     auto params = paramsOrException.releaseReturnValue();
 
     if (params->identifier != baseKey.algorithmIdentifier()) {
@@ -957,7 +967,7 @@ void SubtleCrypto::deriveBits(JSC::JSGlobalObject& state, AlgorithmIdentifier&& 
             rejectWithException(promise.releaseNonNull(), ec, msg);
     };
 
-    algorithm->deriveBits(*params, baseKey, length, WTF::move(callback), WTF::move(exceptionCallback), *scriptExecutionContext(), m_workQueue);
+    RELEASE_AND_RETURN(scope, algorithm->deriveBits(*params, baseKey, length, WTF::move(callback), WTF::move(exceptionCallback), *scriptExecutionContext(), m_workQueue));
 }
 
 void SubtleCrypto::importKey(JSC::JSGlobalObject& state, KeyFormat format, KeyDataVariant&& keyDataVariant, AlgorithmIdentifier&& algorithmIdentifier, bool extractable, Vector<CryptoKeyUsage>&& keyUsages, Ref<DeferredPromise>&& promise)
@@ -969,6 +979,7 @@ void SubtleCrypto::importKey(JSC::JSGlobalObject& state, KeyFormat format, KeyDa
         promise->reject(paramsOrException.releaseException());
         return;
     }
+    RETURN_IF_EXCEPTION(scope, void());
     auto params = paramsOrException.releaseReturnValue();
 
     auto keyDataOrNull = toKeyData(format, WTF::move(keyDataVariant), promise);

--- a/src/bun.js/bindings/webcrypto/SubtleCrypto.cpp
+++ b/src/bun.js/bindings/webcrypto/SubtleCrypto.cpp
@@ -856,11 +856,14 @@ void SubtleCrypto::generateKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&&
 
 void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algorithmIdentifier, CryptoKey& baseKey, AlgorithmIdentifier&& derivedKeyType, bool extractable, Vector<CryptoKeyUsage>&& keyUsages, Ref<DeferredPromise>&& promise)
 {
+    auto& vm = state.vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto paramsOrException = normalizeCryptoAlgorithmParameters(state, WTF::move(algorithmIdentifier), Operations::DeriveBits);
     if (paramsOrException.hasException()) {
         promise->reject(paramsOrException.releaseException());
         return;
     }
+    RETURN_IF_EXCEPTION(scope, void());
     auto params = paramsOrException.releaseReturnValue();
 
     auto importParamsOrException = normalizeCryptoAlgorithmParameters(state, derivedKeyType, Operations::ImportKey);
@@ -868,6 +871,7 @@ void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& a
         promise->reject(importParamsOrException.releaseException());
         return;
     }
+    RETURN_IF_EXCEPTION(scope, void());
     auto importParams = importParamsOrException.releaseReturnValue();
 
     auto getLengthParamsOrException = normalizeCryptoAlgorithmParameters(state, derivedKeyType, Operations::GetKeyLength);
@@ -875,6 +879,7 @@ void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& a
         promise->reject(getLengthParamsOrException.releaseException());
         return;
     }
+    RETURN_IF_EXCEPTION(scope, void());
     auto getLengthParams = getLengthParamsOrException.releaseReturnValue();
 
     auto keyUsagesBitmap = toCryptoKeyUsageBitmap(keyUsages);
@@ -928,7 +933,7 @@ void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& a
             rejectWithException(promise.releaseNonNull(), ec, msg);
     };
 
-    algorithm->deriveBits(*params, baseKey, length, WTF::move(callback), WTF::move(exceptionCallback), *scriptExecutionContext(), m_workQueue);
+    RELEASE_AND_RETURN(scope, algorithm->deriveBits(*params, baseKey, length, WTF::move(callback), WTF::move(exceptionCallback), *scriptExecutionContext(), m_workQueue));
 }
 
 void SubtleCrypto::deriveBits(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algorithmIdentifier, CryptoKey& baseKey, unsigned length, Ref<DeferredPromise>&& promise)

--- a/test/js/bun/crypto/x25519-derive-bits.test.ts
+++ b/test/js/bun/crypto/x25519-derive-bits.test.ts
@@ -81,10 +81,13 @@ test("X25519 deriveBits rejects when length exceeds output size", async () => {
   await expect(crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, privateKey, 512)).rejects.toThrow();
 });
 
-test("X25519 deriveBits rejects with wrong base key type", async () => {
+test("X25519 deriveBits rejects when base key lacks deriveBits usage", async () => {
   const { publicKey } = await importX25519Keys();
 
-  await expect(crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, publicKey, 256)).rejects.toThrow();
+  // publicKey was imported with usages=[], so it cannot be used as a base key for deriveBits.
+  await expect(crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, publicKey, 256)).rejects.toThrow(
+    "CryptoKey doesn't support bits derivation",
+  );
 });
 
 test("X25519 deriveBits rejects with all-zero public key (RFC 7748 Section 6.1)", async () => {

--- a/test/js/bun/crypto/x25519-derive-bits.test.ts
+++ b/test/js/bun/crypto/x25519-derive-bits.test.ts
@@ -82,10 +82,11 @@ test("X25519 deriveBits rejects when length exceeds output size", async () => {
 });
 
 test("X25519 deriveBits rejects when base key lacks deriveBits usage", async () => {
-  const { publicKey } = await importX25519Keys();
+  // Private key imported with only "deriveKey" usage; key type is valid for the base-key slot
+  // but the usages check should still reject it.
+  const { privateKey, publicKey } = await importX25519Keys(["deriveKey"]);
 
-  // publicKey was imported with usages=[], so it cannot be used as a base key for deriveBits.
-  await expect(crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, publicKey, 256)).rejects.toThrow(
+  await expect(crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, privateKey, 256)).rejects.toThrow(
     "CryptoKey doesn't support bits derivation",
   );
 });

--- a/test/js/bun/crypto/x25519-derive-bits.test.ts
+++ b/test/js/bun/crypto/x25519-derive-bits.test.ts
@@ -99,3 +99,19 @@ test("X25519 deriveBits rejects with all-zero public key (RFC 7748 Section 6.1)"
 
   await expect(crypto.subtle.deriveBits({ name: "X25519", public: zeroPublicKey }, privateKey, 256)).rejects.toThrow();
 });
+
+test("X25519 deriveKey produces an AES-GCM key from the shared secret", async () => {
+  const { privateKey, publicKey } = await importX25519Keys(["deriveKey", "deriveBits"]);
+
+  const key = await crypto.subtle.deriveKey(
+    { name: "X25519", public: publicKey },
+    privateKey,
+    { name: "AES-GCM", length: 256 },
+    true,
+    ["encrypt", "decrypt"],
+  );
+
+  expect(key.algorithm.name).toBe("AES-GCM");
+  const raw = await crypto.subtle.exportKey("raw", key);
+  expect(Buffer.from(raw).toString("hex")).toBe(x25519Vector.result);
+});

--- a/test/js/bun/crypto/x25519-derive-bits.test.ts
+++ b/test/js/bun/crypto/x25519-derive-bits.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 // Test vectors from RFC 7748 / Node.js test suite
 const x25519Vector = {

--- a/test/js/bun/crypto/x25519-derive-bits.test.ts
+++ b/test/js/bun/crypto/x25519-derive-bits.test.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "bun:test";
+
+// Test vectors from RFC 7748 / Node.js test suite
+const x25519Vector = {
+  pkcs8: "302e020100300506032b656e04220420c8838e76d057dfb7d8c95a69e138160add6373fd71a4d276bb56e3a81b64ff61",
+  spki: "302a300506032b656e0321001cf2b1e6022ec537371ed7f53e54fa1154d83e98eb64ea51fae5b3307cfe9706",
+  result: "2768409dfab99ec23b8c89b93ff5880295f76176088f89e43dfebe7ea1950008",
+};
+
+async function importX25519Keys(usages: KeyUsage[] = ["deriveBits"]) {
+  const [privateKey, publicKey] = await Promise.all([
+    crypto.subtle.importKey("pkcs8", Buffer.from(x25519Vector.pkcs8, "hex"), { name: "X25519" }, true, usages),
+    crypto.subtle.importKey("spki", Buffer.from(x25519Vector.spki, "hex"), { name: "X25519" }, true, []),
+  ]);
+  return { privateKey, publicKey };
+}
+
+test("X25519 deriveBits with known test vector", async () => {
+  const { privateKey, publicKey } = await importX25519Keys();
+
+  const bits = await crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, privateKey, 256);
+
+  expect(bits).toBeInstanceOf(ArrayBuffer);
+  expect(Buffer.from(bits).toString("hex")).toBe(x25519Vector.result);
+});
+
+test("X25519 deriveBits with null length returns full output", async () => {
+  const { privateKey, publicKey } = await importX25519Keys();
+
+  // @ts-expect-error types not updated to reflect WebCryptoAPI spec change
+  const bits = await crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, privateKey, null);
+
+  expect(bits).toBeInstanceOf(ArrayBuffer);
+  expect(bits.byteLength).toBe(32);
+  expect(Buffer.from(bits).toString("hex")).toBe(x25519Vector.result);
+});
+
+test("X25519 deriveBits with zero length returns full output", async () => {
+  const { privateKey, publicKey } = await importX25519Keys();
+
+  const bits = await crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, privateKey, 0);
+
+  expect(bits).toBeInstanceOf(ArrayBuffer);
+  expect(bits.byteLength).toBe(32);
+  expect(Buffer.from(bits).toString("hex")).toBe(x25519Vector.result);
+});
+
+test("X25519 deriveBits with shorter length", async () => {
+  const { privateKey, publicKey } = await importX25519Keys();
+
+  const bits = await crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, privateKey, 128);
+
+  expect(bits).toBeInstanceOf(ArrayBuffer);
+  expect(bits.byteLength).toBe(16);
+  expect(Buffer.from(bits).toString("hex")).toBe(x25519Vector.result.slice(0, 32));
+});
+
+test("X25519 deriveBits with generated keys", async () => {
+  const aliceKeys = await crypto.subtle.generateKey({ name: "X25519" }, true, ["deriveBits"]);
+  const bobKeys = await crypto.subtle.generateKey({ name: "X25519" }, true, ["deriveBits"]);
+
+  const [aliceShared, bobShared] = await Promise.all([
+    crypto.subtle.deriveBits({ name: "X25519", public: bobKeys.publicKey }, aliceKeys.privateKey, 256),
+    crypto.subtle.deriveBits({ name: "X25519", public: aliceKeys.publicKey }, bobKeys.privateKey, 256),
+  ]);
+
+  expect(Buffer.from(aliceShared).toString("hex")).toBe(Buffer.from(bobShared).toString("hex"));
+});
+
+test("X25519 deriveBits case insensitive algorithm name", async () => {
+  const { privateKey, publicKey } = await importX25519Keys();
+
+  const bits = await crypto.subtle.deriveBits({ name: "x25519", public: publicKey }, privateKey, 256);
+
+  expect(Buffer.from(bits).toString("hex")).toBe(x25519Vector.result);
+});
+
+test("X25519 deriveBits rejects when length exceeds output size", async () => {
+  const { privateKey, publicKey } = await importX25519Keys();
+
+  await expect(crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, privateKey, 512)).rejects.toThrow();
+});
+
+test("X25519 deriveBits rejects with wrong base key type", async () => {
+  const { publicKey } = await importX25519Keys();
+
+  await expect(crypto.subtle.deriveBits({ name: "X25519", public: publicKey }, publicKey, 256)).rejects.toThrow();
+});
+
+test("X25519 deriveBits rejects with all-zero public key (RFC 7748 Section 6.1)", async () => {
+  const { privateKey } = await importX25519Keys();
+
+  // Import an all-zero public key (small-order point)
+  const zeroPublicKey = await crypto.subtle.importKey("raw", new Uint8Array(32), { name: "X25519" }, true, []);
+
+  await expect(crypto.subtle.deriveBits({ name: "X25519", public: zeroPublicKey }, privateKey, 256)).rejects.toThrow();
+});

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -128,6 +128,7 @@ test/napi/node-napi-tests/test/node-api/test_general/do.test.ts
 
 # normalizeCryptoAlgorithmParameters
 test/js/bun/crypto/wpt-webcrypto.generateKey.test.ts
+test/js/bun/crypto/x25519-derive-bits.test.ts
 test/js/deno/crypto/webcrypto.test.ts
 test/js/node/crypto/node-crypto.test.js
 test/js/node/test/parallel/test-crypto-oaep-zero-length.js

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -128,7 +128,6 @@ test/napi/node-napi-tests/test/node-api/test_general/do.test.ts
 
 # normalizeCryptoAlgorithmParameters
 test/js/bun/crypto/wpt-webcrypto.generateKey.test.ts
-test/js/bun/crypto/x25519-derive-bits.test.ts
 test/js/deno/crypto/webcrypto.test.ts
 test/js/node/crypto/node-crypto.test.js
 test/js/node/test/parallel/test-crypto-oaep-zero-length.js


### PR DESCRIPTION
### What does this PR do?

Implements `SubtleCrypto.deriveBits` support for X25519.

Rebase of #28382 by @panva on top of current `main`.

### Changes

- `platformDeriveBits` now calls BoringSSL's `X25519()` to perform the scalar multiplication (previously a stub returning `std::nullopt`).
- Fixed `CryptoAlgorithmX25519::deriveBits` override to match the base `CryptoAlgorithm::deriveBits` virtual signature (`size_t length` instead of `std::optional<size_t>`, and added `final`). The mismatch meant the base class's default "not supported" implementation was being called instead.
- Moved the `length == 0` early-return to after the all-zero output check, so small-order public keys are still rejected per RFC 7748 §6.1 even when `length` is 0/null.

### Verification

Before — system bun:
```
(fail) X25519 deriveBits with known test vector
NotSupportedError: The algorithm is not supported
```

After — debug build:
```
(pass) X25519 deriveBits with known test vector
(pass) X25519 deriveBits with null length returns full output
(pass) X25519 deriveBits with zero length returns full output
(pass) X25519 deriveBits with shorter length
(pass) X25519 deriveBits with generated keys
(pass) X25519 deriveBits case insensitive algorithm name
(pass) X25519 deriveBits rejects when length exceeds output size
(pass) X25519 deriveBits rejects with wrong base key type
(pass) X25519 deriveBits rejects with all-zero public key (RFC 7748 Section 6.1)

 9 pass
 0 fail
```

Fixes #20148
Closes #28382

Co-authored-by: Filip Skokan <panva.ip@gmail.com>
