### PR TITLE
Fix neon CPU feature detection on macOS arm64

### DIFF
--- a/src/bun.js/bindings/CPUFeatures.cpp
+++ b/src/bun.js/bindings/CPUFeatures.cpp
@@ -97,7 +97,7 @@ static uint8_t aarch64_cpu_features()
 #elif OS(MACOS)
     int value = 0;
     size_t size = sizeof(value);
-    if (sysctlbyname("hw.optional.AdvSIMD", &value, &size, NULL, 0) == 0 && value == 1)
+    if (sysctlbyname("hw.optional.arm.AdvSIMD", &value, &size, NULL, 0) == 0 && value == 1)
         features |= 1 << static_cast<uint8_t>(AArch64CPUFeature::neon);
     if (sysctlbyname("hw.optional.floatingpoint", &value, &size, NULL, 0) == 0 && value == 1)
         features |= 1 << static_cast<uint8_t>(AArch64CPUFeature::fp);


### PR DESCRIPTION
## Summary
- `aarch64_cpu_features()` queried `hw.optional.AdvSIMD`, which does not exist on macOS. The documented key is `hw.optional.arm.AdvSIMD` (legacy alias `hw.optional.neon`).
- Effect: the `neon` bit in `bun_cpu_features()` was never set on Apple Silicon. The other macOS aarch64 keys (`hw.optional.floatingpoint`, `hw.optional.arm.FEAT_AES`, `hw.optional.armv8_crc32`, `hw.optional.arm.FEAT_LSE`) are correct.

```console
$ sysctl hw.optional.AdvSIMD
sysctl: unknown oid 'hw.optional.AdvSIMD'
$ sysctl hw.optional.arm.AdvSIMD
hw.optional.arm.AdvSIMD: 1
```

Ref: https://developer.apple.com/documentation/kernel/1387446-sysctlbyname/determining_instruction_set_characteristics

## Test plan
- [x] `sysctl hw.optional.arm.AdvSIMD` returns `1` on Apple Silicon
- [ ] `bun --print 'require("bun:internal-for-testing").crash_handler.getCPUFeatures?.()'` (or crash-report metadata) shows `neon` on macOS arm64