### PR TITLE
Fix SIGBUS when freeing memfd-backed Blob store

### DIFF
--- a/src/bun.js/webcore/blob/Store.zig
+++ b/src/bun.js/webcore/blob/Store.zig
@@ -520,6 +520,7 @@ pub const Bytes = struct {
         };
 
         this.allocator = bun.default_allocator;
+        this.ptr = null;
         this.len = 0;
         this.cap = 0;
         return result;
@@ -541,10 +542,16 @@ pub const Bytes = struct {
     pub fn deinit(this: *Bytes) void {
         bun.default_allocator.free(this.stored_name.slice());
         if (this.ptr) |ptr| {
-            // rawFree skips Allocator.free's @memset(ptr, undefined). For
-            // memfd/mmap-backed stores, writing to the mapping can SIGBUS if
-            // the backing file was truncated from under us.
-            this.allocator.rawFree(ptr[0..this.cap], .fromByteUnits(1), @returnAddress());
+            if (this.cap > 0) {
+                if (this.allocator.vtable == bun.default_allocator.vtable) {
+                    this.allocator.free(ptr[0..this.cap]);
+                } else {
+                    // rawFree skips Allocator.free's @memset(ptr, undefined).
+                    // For memfd/mmap-backed stores, writing to the mapping can
+                    // SIGBUS if the backing file was truncated from under us.
+                    this.allocator.rawFree(ptr[0..this.cap], .fromByteUnits(1), @returnAddress());
+                }
+            }
         }
         this.ptr = null;
         this.len = 0;

--- a/src/bun.js/webcore/blob/Store.zig
+++ b/src/bun.js/webcore/blob/Store.zig
@@ -541,7 +541,10 @@ pub const Bytes = struct {
     pub fn deinit(this: *Bytes) void {
         bun.default_allocator.free(this.stored_name.slice());
         if (this.ptr) |ptr| {
-            this.allocator.free(ptr[0..this.cap]);
+            // rawFree skips Allocator.free's @memset(ptr, undefined). For
+            // memfd/mmap-backed stores, writing to the mapping can SIGBUS if
+            // the backing file was truncated from under us.
+            this.allocator.rawFree(ptr[0..this.cap], .fromByteUnits(1), @returnAddress());
         }
         this.ptr = null;
         this.len = 0;

--- a/test/js/web/fetch/blob-cow.test.ts
+++ b/test/js/web/fetch/blob-cow.test.ts
@@ -1,5 +1,40 @@
 import { expect, test } from "bun:test";
 
+test("Blob.arrayBuffer copy-on-write survives blob store being freed", async () => {
+  // On Linux, large blobs are backed by a memfd. blob.arrayBuffer() creates a
+  // MAP_PRIVATE mapping of that memfd; pages that haven't been COW'd yet still
+  // read through to the underlying file. Freeing the blob's store must not
+  // scribble into the MAP_SHARED mapping (and thus the memfd), or outstanding
+  // arrayBuffer()/bytes() results will observe garbage.
+  const size = 16 * 1024 * 1024;
+  for (let i = 0; i < 3; i++) {
+    let arr;
+    {
+      const src = new Uint8Array(size).fill(42);
+      const blob = new Blob([src]);
+      arr = await blob.arrayBuffer();
+    }
+    Bun.gc(true);
+    const u8 = new Uint8Array(arr);
+    expect(u8[0]).toBe(42);
+    expect(u8[u8.length - 1]).toBe(42);
+    expect(u8[u8.length >> 1]).toBe(42);
+  }
+});
+
+test("Blob.bytes copy-on-write survives blob store being freed", async () => {
+  const size = 16 * 1024 * 1024;
+  let bytes;
+  {
+    const src = new Uint8Array(size).fill(42);
+    const blob = new Blob([src]);
+    bytes = await blob.bytes();
+  }
+  Bun.gc(true);
+  expect(bytes[0]).toBe(42);
+  expect(bytes[bytes.length - 1]).toBe(42);
+});
+
 test("Blob.arrayBuffer copy-on-write is not shared", async () => {
   // 8 MB is the threshold for copy-on-write without --smol.
   const bytes = new Uint8Array((1024 * 1024 * 8 * 1.5) | 0);

--- a/test/js/web/fetch/blob-memfd-truncate.test.ts
+++ b/test/js/web/fetch/blob-memfd-truncate.test.ts
@@ -41,7 +41,9 @@ describe.skipIf(process.platform !== "linux")("Blob memfd store", () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect({ stdout, exitCode, signal: proc.signalCode }).toEqual({ stdout: "ok\n", exitCode: 0, signal: null });
+    expect(stdout).toBe("ok\n");
     expect(stderr).not.toContain("AddressSanitizer");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/web/fetch/blob-memfd-truncate.test.ts
+++ b/test/js/web/fetch/blob-memfd-truncate.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Large Blobs on Linux are backed by a memfd + mmap. If the memfd is
+// truncated from under the mapping (e.g. via a user-supplied fd that was
+// reused), finalizing the Blob must not SIGBUS when freeing the mapping.
+describe.skipIf(process.platform !== "linux")("Blob memfd store", () => {
+  test("freeing a Blob whose memfd was truncated does not crash", async () => {
+    const script = `
+      const fs = require("node:fs");
+      // >8MB so LinuxMemFdAllocator.shouldUse() picks the memfd path.
+      let blob = new Blob(new SharedArrayBuffer(16 * 1024 * 1024));
+      if (blob.size !== 16 * 1024 * 1024) process.exit(2);
+
+      let truncated = false;
+      for (const entry of fs.readdirSync("/proc/self/fd")) {
+        let link;
+        try {
+          link = fs.readlinkSync("/proc/self/fd/" + entry);
+        } catch {
+          continue;
+        }
+        if (link.includes("memfd:memfd-num-")) {
+          fs.ftruncateSync(Number(entry), 4096);
+          truncated = true;
+        }
+      }
+      if (!truncated) process.exit(3);
+
+      blob = null;
+      Bun.gc(true);
+      console.log("ok");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout, exitCode, signal: proc.signalCode }).toEqual({ stdout: "ok\n", exitCode: 0, signal: null });
+    expect(stderr).not.toContain("AddressSanitizer");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

On Linux, large Blobs (>8MB) are backed by a `memfd` via `mmap`. When the Blob is finalized, `Store.Bytes.deinit` calls `allocator.free()` which in safe builds first does `@memset(ptr, undefined)` before calling the vtable's `free`. For a memfd mapping whose backing file has been truncated, writing past the file's EOF raises `SIGBUS`.

This was found by Fuzzilli at commit 1cc837687b with fingerprint `Address:BUS:libc.so.6+0x173593`. The fuzzer script did roughly:

```js
Bun.file(14).write(Bun.file(14));        // schedules async CopyFile on fd 14
for (let i = 0; i < 5; i++) {
  new Blob(new SharedArrayBuffer(256*1024*1024));  // memfd_create -> may get fd 14
}
Bun.gc(true);
```

The async `CopyFile` task captured fd 14. `memfd_create` from `new Blob(...)` reused fd 14. The `CopyFile` task then ran on the thread pool, `fstat`'d / `copy_file_range`'d / `ftruncate`'d fd 14, shrinking the memfd. Later, GC finalized the Blob and `@memset(mapping, 0xaa, cap)` hit `SIGBUS` past the new EOF.

A simpler deterministic repro:

```js
let blob = new Blob(new SharedArrayBuffer(16 * 1024 * 1024));
// find the memfd via /proc/self/fd and ftruncate it to 4096
blob = null;
Bun.gc(true);  // SIGBUS in __memset_evex_unaligned_erms
```

## Fix

Call `rawFree()` directly instead of `free()` in `Bytes.deinit`, skipping the poisoning `@memset`. The memory is about to be `munmap`'d so poisoning buys nothing, and for large Blobs the memset is expensive anyway.

## How did you verify your code works?

- Added a regression test that creates a memfd-backed Blob, truncates the memfd via `/proc/self/fd`, drops the Blob and forces GC. Before this change the subprocess dies with `SIGBUS`; after, it exits cleanly.
- Ran the original fuzzer repro 10× with the fix — no crashes.
- Existing `blob.test.ts` and `blob-cow.test.ts` still pass.