### PR TITLE
fix(windows): prevent panic in RtlNtStatusToDosError when Win32 code not in enum

### DIFF
--- a/src/windows.zig
+++ b/src/windows.zig
@@ -647,6 +647,10 @@ pub const Win32Error = enum(u16) {
     PROCESS_MODE_ALREADY_BACKGROUND = 402,
     /// The process is not in background processing mode.
     PROCESS_MODE_NOT_BACKGROUND = 403,
+    /// The path cannot be traversed because it contains an untrusted mount point.
+    /// Returned by NtCreateFile (STATUS_UNTRUSTED_MOUNT_POINT = 0xC00004BC) when
+    /// traversing a junction that Windows 11 security policy considers untrusted.
+    UNTRUSTED_MOUNT_POINT = 448,
     /// Attempt to access invalid address.
     INVALID_ADDRESS = 487,
     /// User profile cannot be loaded.

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -149,7 +149,7 @@ pub extern "kernel32" fn SetCurrentDirectoryW(
     lpPathName: win32.LPCWSTR,
 ) callconv(.winapi) win32.BOOL;
 pub const SetCurrentDirectory = SetCurrentDirectoryW;
-pub extern "ntdll" fn RtlNtStatusToDosError(win32.NTSTATUS) callconv(.winapi) Win32Error;
+pub extern "ntdll" fn RtlNtStatusToDosError(win32.NTSTATUS) callconv(.winapi) u32;
 pub extern "advapi32" fn SaferiIsExecutableFileType(szFullPathname: win32.LPCWSTR, bFromShellExecute: win32.BOOLEAN) callconv(.winapi) win32.BOOL;
 // This was originally copied from Zig's standard library
 /// Codes are from https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/18d8fbe8-a967-4f1c-ae50-99ca8e491d2d
@@ -2971,7 +2971,13 @@ pub const Win32Error = enum(u16) {
     }
 
     pub fn fromNTStatus(status: win32.NTSTATUS) Win32Error {
-        return RtlNtStatusToDosError(status);
+        const code: u32 = RtlNtStatusToDosError(status);
+        // Win32 error codes fit in u16; codes outside this range or not in the
+        // enum (e.g. from junction/reparse-point traversal) fall back to
+        // ERROR_MR_MID_NOT_FOUND, which is what RtlNtStatusToDosError itself
+        // returns for unrecognised NTSTATUS values.
+        if (code > std.math.maxInt(u16)) return .MR_MID_NOT_FOUND;
+        return std.meta.intToEnum(Win32Error, @as(u16, @intCast(code))) catch .MR_MID_NOT_FOUND;
     }
 };
 

--- a/test/regression/issue/29158.test.ts
+++ b/test/regression/issue/29158.test.ts
@@ -1,0 +1,56 @@
+// https://github.com/oven-sh/bun/issues/29158
+// Windows: panic 'invalid enum value' when resolving node_modules junctions
+// via RtlNtStatusToDosError returning a Win32 code not in Win32Error enum.
+//
+// This only affects Windows. The test creates a junction in node_modules
+// and verifies that Bun can resolve it without panicking.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import fs from "fs";
+import path from "path";
+
+test.if(process.platform === "win32")(
+  "resolving a junction in node_modules does not panic",
+  async () => {
+    using dir = tempDir("bun-29158", {
+      // A minimal package that bun will try to resolve through a junction
+      "package.json": JSON.stringify({
+        name: "test-29158",
+        version: "1.0.0",
+      }),
+      "index.ts": `export const ok = true;`,
+    });
+
+    const dirStr = String(dir);
+
+    // Create the actual package directory
+    const pkgTarget = path.join(dirStr, "node_modules", ".real", "my-pkg");
+    fs.mkdirSync(pkgTarget, { recursive: true });
+    fs.writeFileSync(
+      path.join(pkgTarget, "package.json"),
+      JSON.stringify({ name: "my-pkg", version: "1.0.0", main: "index.js" }),
+    );
+    fs.writeFileSync(path.join(pkgTarget, "index.js"), `module.exports = 42;`);
+
+    // Create a junction pointing to the real package (mirrors what bun install does)
+    const junctionPath = path.join(dirStr, "node_modules", "my-pkg");
+    fs.mkdirSync(path.join(dirStr, "node_modules"), { recursive: true });
+    fs.symlinkSync(pkgTarget, junctionPath, "junction");
+
+    // Bun must resolve my-pkg through the junction without panicking
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `const x = require('my-pkg'); process.exit(x === 42 ? 0 : 1);`],
+      env: bunEnv,
+      cwd: dirStr,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("panic");
+    expect(stderr).not.toContain("invalid enum value");
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
## Summary

- `RtlNtStatusToDosError` was declared as returning `Win32Error` (`enum(u16)`), but the actual Windows API returns `DWORD` (`u32`). When the NTSTATUS→Win32 code mapping yields a value absent from the enum, Zig's safety check fires `panic: invalid enum value`.
- Changed declaration to return `u32` (matching Zig stdlib + Windows docs) and added safe conversion in `fromNTStatus` with `MR_MID_NOT_FOUND` as fallback.
- Reproduces when resolving junctions in `node_modules` (created by `bun install`) on Windows 11, crashing the resolver before any user code runs.

Fixes #29158

## Changes

**`src/windows.zig`**
```zig
// Before
pub extern "ntdll" fn RtlNtStatusToDosError(win32.NTSTATUS) callconv(.winapi) Win32Error;

pub fn fromNTStatus(status: win32.NTSTATUS) Win32Error {
    return RtlNtStatusToDosError(status);
}

// After
pub extern "ntdll" fn RtlNtStatusToDosError(win32.NTSTATUS) callconv(.winapi) u32;

pub fn fromNTStatus(status: win32.NTSTATUS) Win32Error {
    const code: u32 = RtlNtStatusToDosError(status);
    if (code > std.math.maxInt(u16)) return .MR_MID_NOT_FOUND;
    return std.meta.intToEnum(Win32Error, @as(u16, @intCast(code))) catch .MR_MID_NOT_FOUND;
}
```

## Test plan

- [ ] `test/regression/issue/29158.test.ts` — creates a node_modules junction on Windows and verifies Bun resolves it without panicking
- [ ] Verify `bun bd test test/regression/issue/29158.test.ts` passes on Windows
- [ ] Verify no regression on other platforms (non-Windows path is unchanged)