### PR TITLE
Upgrade WebKit to 456cd04b8d5be123bd451f2c007b97dbb3ffed57

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "456cd04b8d5be123bd451f2c007b97dbb3ffed57";
+export const WEBKIT_VERSION = "42f80a684c5df57121a97e20825a3bcab7a0741b";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "c2010c47d12c525d36adabe3a17b2eb6ec850960";
+export const WEBKIT_VERSION = "456cd04b8d5be123bd451f2c007b97dbb3ffed57";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/bun.js/bindings/BunHeapProfiler.cpp
+++ b/src/bun.js/bindings/BunHeapProfiler.cpp
@@ -285,7 +285,7 @@ WTF::String generateHeapProfile(JSC::VM& vm)
     // DFS using explicit stack
     WTF::Vector<uint32_t> stackNodes(nodeCount);
     WTF::Vector<size_t> stackEdgeIdx(nodeCount);
-    WTF::Vector<uint8_t> visited(nodeCount, 0);
+    WTF::Vector<uint8_t> visited(WTF::FillWith { }, nodeCount, static_cast<uint8_t>(0));
 
     uint32_t postOrderIndex = 0;
     int stackTop = 0;
@@ -364,9 +364,9 @@ WTF::String generateHeapProfile(JSC::VM& vm)
     uint32_t rootPostOrderIndex = nodeCount - 1;
     uint32_t noEntry = nodeCount;
 
-    WTF::Vector<uint8_t> affected(nodeCount, 0);
-    WTF::Vector<uint32_t> dominators(nodeCount, noEntry);
-    WTF::Vector<uint32_t> nodeOrdinalToDominator(nodeCount, 0);
+    WTF::Vector<uint8_t> affected(WTF::FillWith { }, nodeCount, static_cast<uint8_t>(0));
+    WTF::Vector<uint32_t> dominators(WTF::FillWith { }, nodeCount, noEntry);
+    WTF::Vector<uint32_t> nodeOrdinalToDominator(WTF::FillWith { }, nodeCount, 0u);
 
     // Root dominates itself
     dominators[rootPostOrderIndex] = rootPostOrderIndex;

--- a/src/bun.js/bindings/BunHeapProfiler.cpp
+++ b/src/bun.js/bindings/BunHeapProfiler.cpp
@@ -285,7 +285,7 @@ WTF::String generateHeapProfile(JSC::VM& vm)
     // DFS using explicit stack
     WTF::Vector<uint32_t> stackNodes(nodeCount);
     WTF::Vector<size_t> stackEdgeIdx(nodeCount);
-    WTF::Vector<uint8_t> visited(WTF::FillWith { }, nodeCount, static_cast<uint8_t>(0));
+    WTF::Vector<uint8_t> visited(WTF::FillWith {}, nodeCount, static_cast<uint8_t>(0));
 
     uint32_t postOrderIndex = 0;
     int stackTop = 0;
@@ -364,9 +364,9 @@ WTF::String generateHeapProfile(JSC::VM& vm)
     uint32_t rootPostOrderIndex = nodeCount - 1;
     uint32_t noEntry = nodeCount;
 
-    WTF::Vector<uint8_t> affected(WTF::FillWith { }, nodeCount, static_cast<uint8_t>(0));
-    WTF::Vector<uint32_t> dominators(WTF::FillWith { }, nodeCount, noEntry);
-    WTF::Vector<uint32_t> nodeOrdinalToDominator(WTF::FillWith { }, nodeCount, 0u);
+    WTF::Vector<uint8_t> affected(WTF::FillWith {}, nodeCount, static_cast<uint8_t>(0));
+    WTF::Vector<uint32_t> dominators(WTF::FillWith {}, nodeCount, noEntry);
+    WTF::Vector<uint32_t> nodeOrdinalToDominator(WTF::FillWith {}, nodeCount, 0u);
 
     // Root dominates itself
     dominators[rootPostOrderIndex] = rootPostOrderIndex;

--- a/src/bun.js/bindings/JSBundlerPlugin.cpp
+++ b/src/bun.js/bindings/JSBundlerPlugin.cpp
@@ -673,7 +673,7 @@ extern "C" void JSBundlerPlugin__drainDeferred(Bun::JSBundlerPlugin* pluginObjec
     auto& vm = pluginObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     for (auto promiseValue : arguments) {
-        JSPromise* promise = jsCast<JSPromise*>(JSValue::decode(promiseValue));
+        JSPromise* promise = jsCast<JSPromise*>(promiseValue);
         if (rejected) {
             promise->reject(vm, globalObject, JSC::jsUndefined());
         } else {

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -4359,7 +4359,7 @@ JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC::EncodedJSValu
         uint32_t j = 0;
 
         // if "." is the only character, it will search for an empty string twice.
-        if (pathString.characterAt(0) == '.') {
+        if (pathString.codeUnitAt(0) == '.') {
             auto* currPropObject = currProp.toObject(globalObject);
             RETURN_IF_EXCEPTION(scope, {});
             currProp = currPropObject->getIfPropertyExists(globalObject, vm.propertyNames->emptyIdentifier);
@@ -4370,7 +4370,7 @@ JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC::EncodedJSValu
         }
 
         while (i < length) {
-            char16_t ic = pathString.characterAt(i);
+            char16_t ic = pathString.codeUnitAt(i);
             while (ic == '[' || ic == ']' || ic == '.') {
                 i += 1;
                 if (i == length) {
@@ -4392,7 +4392,7 @@ JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC::EncodedJSValu
                 }
 
                 char16_t previous = ic;
-                ic = pathString.characterAt(i);
+                ic = pathString.codeUnitAt(i);
                 if (previous == '.' && ic == '.') {
                     auto* currPropObject = currProp.toObject(globalObject);
                     RETURN_IF_EXCEPTION(scope, {});
@@ -4406,14 +4406,14 @@ JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC::EncodedJSValu
             }
 
             j = i;
-            char16_t jc = pathString.characterAt(j);
+            char16_t jc = pathString.codeUnitAt(j);
             while (!(jc == '[' || jc == ']' || jc == '.')) {
                 j += 1;
                 if (j == length) {
                     // break and search for property
                     break;
                 }
-                jc = pathString.characterAt(j);
+                jc = pathString.codeUnitAt(j);
             }
 
             String propNameStr = pathString.substring(i, j - i);

--- a/src/bun.js/bindings/node/http/NodeHTTPParser.cpp
+++ b/src/bun.js/bindings/node/http/NodeHTTPParser.cpp
@@ -494,9 +494,9 @@ int HTTPParser::onHeadersComplete()
     } else {
         auto headers = createHeaders(globalObject);
         RETURN_IF_EXCEPTION(scope, -1);
-        args.set(A_HEADERS, headers);
+        args.at(A_HEADERS) = headers;
         if (m_parserData.type == HTTP_REQUEST) {
-            args.set(A_URL, m_url.toString(globalObject));
+            args.at(A_URL) = m_url.toString(globalObject);
         }
     }
 
@@ -504,21 +504,21 @@ int HTTPParser::onHeadersComplete()
     m_numValues = 0;
 
     if (m_parserData.type == HTTP_REQUEST) {
-        args.set(A_METHOD, jsNumber(m_parserData.method));
+        args.at(A_METHOD) = jsNumber(m_parserData.method);
     }
 
     if (m_parserData.type == HTTP_RESPONSE) {
-        args.set(A_STATUS_CODE, jsNumber(m_parserData.status_code));
-        args.set(A_STATUS_MESSAGE, m_statusMessage.toString(globalObject));
+        args.at(A_STATUS_CODE) = jsNumber(m_parserData.status_code);
+        args.at(A_STATUS_MESSAGE) = m_statusMessage.toString(globalObject);
     }
 
-    args.set(A_VERSION_MAJOR, jsNumber(m_parserData.http_major));
-    args.set(A_VERSION_MINOR, jsNumber(m_parserData.http_minor));
+    args.at(A_VERSION_MAJOR) = jsNumber(m_parserData.http_major);
+    args.at(A_VERSION_MINOR) = jsNumber(m_parserData.http_minor);
 
     bool shouldKeepAlive = llhttp_should_keep_alive(&m_parserData);
 
-    args.set(A_SHOULD_KEEP_ALIVE, jsBoolean(shouldKeepAlive));
-    args.set(A_UPGRADE, jsBoolean(m_parserData.upgrade));
+    args.at(A_SHOULD_KEEP_ALIVE) = jsBoolean(shouldKeepAlive);
+    args.at(A_UPGRADE) = jsBoolean(m_parserData.upgrade);
 
     CallData callData = getCallData(onHeadersCompleteCallback);
 

--- a/src/bun.js/bindings/v8/shim/InternalFieldObject.h
+++ b/src/bun.js/bindings/v8/shim/InternalFieldObject.h
@@ -38,7 +38,7 @@ public:
 protected:
     InternalFieldObject(JSC::VM& vm, JSC::Structure* structure, int internalFieldCount)
         : Base(vm, structure)
-        , m_fields(WTF::FillWith { }, internalFieldCount, JSC::WriteBarrier<JSC::Unknown>(vm, this, JSC::jsUndefined()))
+        , m_fields(WTF::FillWith {}, internalFieldCount, JSC::WriteBarrier<JSC::Unknown>(vm, this, JSC::jsUndefined()))
     {
     }
 

--- a/src/bun.js/bindings/v8/shim/InternalFieldObject.h
+++ b/src/bun.js/bindings/v8/shim/InternalFieldObject.h
@@ -38,7 +38,7 @@ public:
 protected:
     InternalFieldObject(JSC::VM& vm, JSC::Structure* structure, int internalFieldCount)
         : Base(vm, structure)
-        , m_fields(internalFieldCount, JSC::WriteBarrier<JSC::Unknown>(vm, this, JSC::jsUndefined()))
+        , m_fields(WTF::FillWith { }, internalFieldCount, JSC::WriteBarrier<JSC::Unknown>(vm, this, JSC::jsUndefined()))
     {
     }
 

--- a/src/bun.js/bindings/webcore/WebSocket.cpp
+++ b/src/bun.js/bindings/webcore/WebSocket.cpp
@@ -378,7 +378,7 @@ ExceptionOr<Ref<WebSocket>> WebSocket::create(ScriptExecutionContext& context, c
 
 ExceptionOr<Ref<WebSocket>> WebSocket::create(ScriptExecutionContext& context, const String& url, const String& protocol)
 {
-    return create(context, url, Vector<String> { 1, protocol });
+    return create(context, url, Vector<String> { protocol });
 }
 
 ExceptionOr<void> WebSocket::connect(const String& url)
@@ -388,7 +388,7 @@ ExceptionOr<void> WebSocket::connect(const String& url)
 
 ExceptionOr<void> WebSocket::connect(const String& url, const String& protocol)
 {
-    return connect(url, Vector<String> { 1, protocol }, std::nullopt);
+    return connect(url, Vector<String> { protocol }, std::nullopt);
 }
 
 static String resourceName(const URL& url)

--- a/src/bun.js/modules/NodeModuleModule.cpp
+++ b/src/bun.js/modules/NodeModuleModule.cpp
@@ -517,9 +517,9 @@ JSC::JSValue resolveLookupPaths(JSC::JSGlobalObject* globalObject, String reques
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // Check for node modules paths.
-    if (request.characterAt(0) != '.' || (request.length() > 1 && request.characterAt(1) != '.' && request.characterAt(1) != '/' &&
+    if (request.codeUnitAt(0) != '.' || (request.length() > 1 && request.codeUnitAt(1) != '.' && request.codeUnitAt(1) != '/' &&
 #if OS(WINDOWS)
-            request.characterAt(1) != '\\'
+            request.codeUnitAt(1) != '\\'
 #else
             true
 #endif


### PR DESCRIPTION
# WebKit Upgrade: c2010c47d12c → d924138e38f4

Merged 1316 upstream commits (306 touching JSC/WTF/bmalloc).

## API Changes Affecting Bun

| Change | Impact |
|---|---|
| `JSObject::globalObject()` → `realm()` (7d4583947a7b "Realm-less Objects") | All call sites that fetch a cell's global must use `realm()`. Bun's `JSPromise.cpp` InternalPromise check and `JSWebAssembly.cpp` updated. |
| `MarkedJSValueRefArray` → `MarkedVector<JSValueRef>` | testapi only; no Bun runtime impact. |
| `JSCell::type()/indexingType*()` now defined inline in `JSCell.h` (6eaeb2be1205) | Bun's `JS_EXPORT_PRIVATE` on `type()` dropped — symbol no longer needed since definition is header-inline. |
| `Heap::hasHeapAccess()/worldIsStopped()` moved from `HeapInlines.h` → `Heap.h` | Bun's commented-out `isMarked` block kept; duplicate inline defs removed. |
| `NODELETE` annotations adopted widely (61dfe117a295) | Merged with Bun's `JS_EXPORT_PRIVATE` additions where both apply. |
| `GCMemoryOperations.h` rewritten (7a412e324d10 "wider bulk copy") | Upstream now has `#if !OS(WINDOWS)` guard around `.p2align`, superseding Bun's separate Windows-ARM64 SEH workaround. Took upstream wholesale. |
| `WTF_MAKE_TZONE_ALLOCATED_IMPL(ScheduledTask)` added in `RunLoopGeneric.cpp` | Integrated above Bun's `USE(BUN_EVENT_LOOP)` constructor. |
| `OSAllocatorPOSIX.cpp`: Linux `PR_SET_VMA` memory tagging (b651d820ecaa) | Added alongside Bun's Darwin `BUN_VM_CHILD_PROCESS_INHERIT` defines; dropped Bun's file-wide `WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN` (upstream now uses targeted scopes). |
| `trunc/isnan` → `std::trunc/std::isnan` (aaf28d392ef7) | Propagated to Bun-relocated copies in `JSCJSValueInlines.h`. |
| `JSCell::toThis` removed upstream | Bun's stale `JS_EXPORT_PRIVATE` declaration dropped (no implementation existed). |
| `MarkedVector::set(i, v)` removed | Bun's `NodeHTTPParser.cpp` switched to `args.at(i) = v`. `MarkedArgumentBuffer` iterator now yields `JSValue` (not `EncodedJSValue`) — `JSBundlerPlugin.cpp` updated. |
| `Vector(size, val)` / `FixedVector(size, val)` now require `WTF::FillWith{}` tag (22a4dd063a31) | `BunHeapProfiler.cpp`, `InternalFieldObject.h`, `WebSocket.cpp` updated. |
| `String::characterAt()` → `codeUnitAt()` (e4f1bb7dd2dc) | `bindings.cpp`, `NodeModuleModule.cpp` updated. |
| `RootMarkReason::MarkedJSValueRefArray` enum value removed | `BunV8HeapSnapshotBuilder.cpp` switch case dropped. |
| `InlineCacheHandler.h` new transitive include of `InlineCacheCompiler.h` | Added to `PRIVATE_FRAMEWORK_HEADERS` in JSC `CMakeLists.txt`. |

### Compatibility Shim Added (oven-sh/WebKit only)
`JSObject::globalObject()` and `Structure::globalObject()` were re-introduced under `USE(BUN_JSC_ADDITIONS)` as inline aliases of `realmMayBeNull()` / `realm()`. This avoids a 300+-call-site rename across Bun's bindings and codegen templates in this PR; the alias preserves the pre-rename nullable semantics. Migration to `realm()` can be done incrementally.

## Notable JSC Commits

### Performance
- da43fc766f60 — `ArrayLengthStore` IC for `array.length = N`
- 3ba3be2ff84e — IC for property keys `undefined`/`true`/`false`/`null`
- 7aea7dd35f02 — Fold string length in DFG/FTL
- 47263c1fcdf7 — `toUpperCase` intrinsic
- 3a21b7550526 — `String#indexOf` one-char fast path in DFG/FTL
- 6276c6b5f2b9 — Remove redundant `mov` in await/yield bytecode
- 7d5f97e8a6c0 — Persist FunctionExecutable singleton invalidation
- 7ba657c06781 — Cache default date formatters
- f977b7aa6f76 — Refine clobberize for `CheckPrivateBrand`/`SetPrivateBrand`
- 7a412e324d10 — Wider bulk copy in GC-safe memcpy/memmove
- 65b433087d28 — Reserve/inline-capacity for JSC vectors
- 85a8086c469f — SIMD-accelerate `equalIgnoringASCIICase*`
- 72a6facdf6de — `makeLatin1Identifier` in parseString SIMD fast path

### Correctness / Bugfixes
- 24d4993f2796 — RegExp exec/test reload internal RegExp after `ToLength(lastIndex)`
- 291f0457787d — DFG constant folding: handle TOP in `CheckIsConstant`
- 83895848013f — `isWithinPowerOfTwo` unsound for `BitAnd` w/ negative mask
- c3f07df74de4 — Propagate `InstanceFieldEvalContext` through arrows/nested scopes
- 46479ddbd5e6 — `import { "*" as x }` not treated as namespace import
- 6117e70109ac — TypedArray iterator-next-with-detached test262 fix
- c16330f64843 — `Date.toLocaleString()` ICU crash from Worker
- 036d2c0c8216 / 8c10428db1b8 / c4f242d634ec / f30b516527da — YARR backtracking/capture fixes

### New Features
- 7fdc018c4dd7 — `Iterator.prototype.includes` (behind flag)
- 6de094278d71 — JSPI: `WebAssembly.Suspending`/`SuspendError` as data properties

### Wasm
- f9c6e4889485 — IPInt support for SIMD and atomics
- 12997e819ca5 — Multimemory in BBQ/OMG SIMD/atomics
- 599f35b67143 — Stack results match arguments
- 7900f4775411 — OMG bounds check uses `AboveEqual`
- Multiple Wasm-debugger improvements (LLDB integration, dynamic-module notify, exception interception)

### WTF / bmalloc
- e4f1bb7dd2dc — `characterAt()/characterStartingAt()` → `codeUnitAt()/codePointAt()`
- 0655a1df8268 — `WTF::Unexpected` → `std::unexpected`
- 41539422d60f — Removed ~9% of `#include`s from WTF
- 75529ed6e070 — libpas: fix CSE of atomic-load under concurrent modification
- 569d28c26a9b — libpas: MTE Previous-Tag-Exclusion
- 83b6ec32bc25 — `StringImpl::create` (UTF-8) defensive against concurrent mutation
- b7ac868d7113 / 2b9732f54c5e — `= default` constructor adoption
- 3242d3d821c5 — `roundUpToPowerOfTwo()` no longer truncates to uint32_t

## Merge Conflict Resolutions

28 conflicts. Patterns:

- **Include style `"X.h"` ↔ `<JavaScriptCore/X.h>`** — adopted upstream bracket style (BlockDirectory.h, MarkedBlock.h, StrongInlines.h, Integrity.h, InPlaceInterpreter.h, WasmDebugServerUtilities.h, WebAssemblyGCStructure.h).
- **`NODELETE` × Bun's `JS_EXPORT_PRIVATE`/additions** — combined both (MarkingConstraint.h, JSCell.h, VMManager.h, Nodes.h, SourceProvider.h, LiteralParser.h, CachedTypes.cpp, ExceptionHelpers.cpp, NodesCodegen.cpp, Options.cpp).
- **Heap.cpp** — Bun intentionally removes `growthMode`/`maxEdenSizeForRateLimiting` (rate-limiting) and de-`static`s heap-sizing helpers; kept Bun's behavior, dropped upstream's `NODELETE` on the removed functions.
- **GCMemoryOperations.h** — upstream rewrite supersedes Bun's Windows-ARM64 patches; took theirs.
- **JSCJSValue.h** — upstream re-touched inline funcs Bun had moved to `JSCJSValueInlines.h`; kept Bun's relocation, ported `std::` qualification fix.
- **JSPromise.cpp / JSWebAssembly.cpp** — adopted `realm()` rename; kept Bun's InternalPromise short-circuit.
- **RunLoopGeneric.cpp** — added `WTF_MAKE_TZONE_ALLOCATED_IMPL` before Bun's `USE(BUN_EVENT_LOOP)` ctor.
- **OSAllocatorPOSIX.cpp** — kept both Bun's Darwin defines and upstream's Linux `prctl` block; dropped redundant file-wide unsafe-buffer wrap.
- **PlatformMac.cmake** — `platform/mac/StringUtilities.h` removed upstream (moved to `platform/cocoa/`).

## Checks
- `JSType.h`: no upstream changes — `src/bun.js/bindings/JSType.zig` still in sync.
- WebCore bindings code generator: no relevant changes detected.
