### PR TITLE
fix(console): print AggregateError wrapper instead of dropping it

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -3338,19 +3338,8 @@ fn printErrorInstance(
             continue;
         }
 
-        // BuildMessage / ResolveMessage paths inside printErrorFromMaybePrivateData
-        // already emit their own leading newline when `this.had_errors` is set,
-        // which it is by the time we get here (we set it at the top of
-        // printErrorInstance). Only add our own separator for entries that go
-        // through the generic Error path.
-        if (err.jsType() != .DOMWrapper) {
-            try writer.writeAll("\n");
-        }
-        // Go through printErrorFromMaybePrivateData so DOMWrapper children
-        // (BuildMessage / ResolveMessage from processFetchLog) are routed
-        // through their specialized formatters; everything else falls
-        // through to printErrorInstance.
-        _ = this.printErrorFromMaybePrivateData(err, exception_list, formatter, Writer, writer, allow_ansi_color, allow_side_effects);
+        try writer.writeAll("\n");
+        try this.printErrorInstance(.js, err, exception_list, formatter, Writer, writer, allow_ansi_color, allow_side_effects);
         _ = formatter.map.remove(err);
     }
 }

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -3271,24 +3271,22 @@ fn printErrorInstance(
 
         // `AggregateError.errors` is a non-enumerable own property, so the
         // property iterator above skips it. Walk it manually and queue each
-        // entry so the wrapper gets printed first (matching Node's
-        // `[errors]: [...]` format) instead of the errors replacing it.
+        // entry (of any type — Promise.any can reject with non-Error values)
+        // so the wrapper gets printed first, matching Node's `[errors]: [...]`
+        // format instead of the errors replacing it.
         if (error_instance.isAggregateError(this.global)) {
             const AggregateErrorsIterator = struct {
                 errors_to_append: *std.array_list.Managed(JSValue),
 
                 pub fn visit(_: *VM, _: *JSGlobalObject, ctx: ?*anyopaque, next_value: JSValue) callconv(.c) void {
                     const self: *@This() = @ptrCast(@alignCast(ctx.?));
-                    if (next_value.jsType() == .ErrorInstance) {
-                        next_value.protect();
-                        bun.handleOom(self.errors_to_append.append(next_value));
-                    }
+                    next_value.protect();
+                    bun.handleOom(self.errors_to_append.append(next_value));
                 }
             };
             var errors_iter = AggregateErrorsIterator{ .errors_to_append = &errors_to_append };
-            error_instance.getErrorsProperty(this.global).forEach(this.global, &errors_iter, AggregateErrorsIterator.visit) catch {
-                if (this.global.hasException()) this.global.clearException();
-            };
+            const errors_array = error_instance.getErrorsProperty(this.global);
+            try errors_array.forEach(this.global, &errors_iter, AggregateErrorsIterator.visit);
         }
     } else if (mode == .js and error_instance != .zero) {
         // If you do reportError([1,2,3]] we should still show something at least.

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -3259,21 +3259,12 @@ fn printErrorInstance(
             try writer.writeAll("\n");
         }
 
-        // "cause" is not enumerable, so the above loop won't see it.
-        if (!saw_cause) {
-            if (try error_instance.getOwn(this.global, "cause")) |cause| {
-                if (cause.jsType() == .ErrorInstance) {
-                    cause.protect();
-                    try errors_to_append.append(cause);
-                }
-            }
-        }
-
         // `AggregateError.errors` is a non-enumerable own property, so the
         // property iterator above skips it. Walk it manually and queue each
         // entry (of any type — Promise.any can reject with non-Error values)
-        // so the wrapper gets printed first, matching Node's `[errors]: [...]`
-        // format instead of the errors replacing it.
+        // so the wrapper gets printed first and the children follow, matching
+        // Node's `[errors]: [...]` format. Queue errors BEFORE cause so the
+        // drain loop emits them in Node's order (wrapper → errors → cause).
         if (error_instance.isAggregateError(this.global)) {
             const AggregateErrorsIterator = struct {
                 errors_to_append: *std.array_list.Managed(JSValue),
@@ -3287,6 +3278,16 @@ fn printErrorInstance(
             var errors_iter = AggregateErrorsIterator{ .errors_to_append = &errors_to_append };
             const errors_array = error_instance.getErrorsProperty(this.global);
             try errors_array.forEach(this.global, &errors_iter, AggregateErrorsIterator.visit);
+        }
+
+        // "cause" is not enumerable, so the above loop won't see it.
+        if (!saw_cause) {
+            if (try error_instance.getOwn(this.global, "cause")) |cause| {
+                if (cause.jsType() == .ErrorInstance) {
+                    cause.protect();
+                    try errors_to_append.append(cause);
+                }
+            }
         }
     } else if (mode == .js and error_instance != .zero) {
         // If you do reportError([1,2,3]] we should still show something at least.
@@ -3338,7 +3339,11 @@ fn printErrorInstance(
         }
 
         try writer.writeAll("\n");
-        try this.printErrorInstance(.js, err, exception_list, formatter, Writer, writer, allow_ansi_color, allow_side_effects);
+        // Go through printErrorFromMaybePrivateData so DOMWrapper children
+        // (BuildMessage / ResolveMessage from processFetchLog) are routed
+        // through their specialized formatters; everything else falls
+        // through to printErrorInstance.
+        _ = this.printErrorFromMaybePrivateData(err, exception_list, formatter, Writer, writer, allow_ansi_color, allow_side_effects);
         _ = formatter.map.remove(err);
     }
 }

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -2454,31 +2454,10 @@ pub fn printErrorlikeObject(
         }
     }
 
-    if (value.isAggregateError(this.global)) {
-        const AggregateErrorIterator = struct {
-            writer: Writer,
-            current_exception_list: ?*ExceptionList = null,
-            formatter: *ConsoleObject.Formatter,
-
-            pub fn iteratorWithColor(vm: *VM, globalObject: *JSGlobalObject, ctx: ?*anyopaque, nextValue: JSValue) callconv(.c) void {
-                iterator(vm, globalObject, nextValue, ctx.?, true);
-            }
-            pub fn iteratorWithOutColor(vm: *VM, globalObject: *JSGlobalObject, ctx: ?*anyopaque, nextValue: JSValue) callconv(.c) void {
-                iterator(vm, globalObject, nextValue, ctx.?, false);
-            }
-            fn iterator(_: *VM, _: *JSGlobalObject, nextValue: JSValue, ctx: ?*anyopaque, comptime color: bool) void {
-                const this_ = @as(*@This(), @ptrFromInt(@intFromPtr(ctx)));
-                VirtualMachine.get().printErrorlikeObject(nextValue, null, this_.current_exception_list, this_.formatter, Writer, this_.writer, color, allow_side_effects);
-            }
-        };
-        var iter = AggregateErrorIterator{ .writer = writer, .current_exception_list = exception_list, .formatter = formatter };
-        if (comptime allow_ansi_color) {
-            value.getErrorsProperty(this.global).forEach(this.global, &iter, AggregateErrorIterator.iteratorWithColor) catch return; // TODO: properly propagate exception upwards
-        } else {
-            value.getErrorsProperty(this.global).forEach(this.global, &iter, AggregateErrorIterator.iteratorWithOutColor) catch return; // TODO: properly propagate exception upwards
-        }
-        return;
-    }
+    // AggregateError is handled by printErrorInstance, which prints the
+    // wrapper (name / message / stack) and then fans out the non-enumerable
+    // `errors` array via the errors_to_append queue — see the cause block
+    // there for the same pattern.
 
     was_internal = this.printErrorFromMaybePrivateData(
         value,
@@ -3288,6 +3267,28 @@ fn printErrorInstance(
                     try errors_to_append.append(cause);
                 }
             }
+        }
+
+        // `AggregateError.errors` is a non-enumerable own property, so the
+        // property iterator above skips it. Walk it manually and queue each
+        // entry so the wrapper gets printed first (matching Node's
+        // `[errors]: [...]` format) instead of the errors replacing it.
+        if (error_instance.isAggregateError(this.global)) {
+            const AggregateErrorsIterator = struct {
+                errors_to_append: *std.array_list.Managed(JSValue),
+
+                pub fn visit(_: *VM, _: *JSGlobalObject, ctx: ?*anyopaque, next_value: JSValue) callconv(.c) void {
+                    const self: *@This() = @ptrCast(@alignCast(ctx.?));
+                    if (next_value.jsType() == .ErrorInstance) {
+                        next_value.protect();
+                        bun.handleOom(self.errors_to_append.append(next_value));
+                    }
+                }
+            };
+            var errors_iter = AggregateErrorsIterator{ .errors_to_append = &errors_to_append };
+            error_instance.getErrorsProperty(this.global).forEach(this.global, &errors_iter, AggregateErrorsIterator.visit) catch {
+                if (this.global.hasException()) this.global.clearException();
+            };
         }
     } else if (mode == .js and error_instance != .zero) {
         // If you do reportError([1,2,3]] we should still show something at least.

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -3338,7 +3338,14 @@ fn printErrorInstance(
             continue;
         }
 
-        try writer.writeAll("\n");
+        // BuildMessage / ResolveMessage paths inside printErrorFromMaybePrivateData
+        // already emit their own leading newline when `this.had_errors` is set,
+        // which it is by the time we get here (we set it at the top of
+        // printErrorInstance). Only add our own separator for entries that go
+        // through the generic Error path.
+        if (err.jsType() != .DOMWrapper) {
+            try writer.writeAll("\n");
+        }
         // Go through printErrorFromMaybePrivateData so DOMWrapper children
         // (BuildMessage / ResolveMessage from processFetchLog) are routed
         // through their specialized formatters; everything else falls

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -17,7 +17,6 @@
   "EXCEPTION_ASSERT(!scope.exception())": 0,
   "JSValue.false": 0,
   "JSValue.true": 0,
-  "TODO: properly propagate exception upwards": 112,
   "alloc.ptr !=": 0,
   "alloc.ptr ==": 0,
   "allocator.ptr !=": 1,

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -17,6 +17,7 @@
   "EXCEPTION_ASSERT(!scope.exception())": 0,
   "JSValue.false": 0,
   "JSValue.true": 0,
+  "TODO: properly propagate exception upwards": 112,
   "alloc.ptr !=": 0,
   "alloc.ptr ==": 0,
   "allocator.ptr !=": 1,

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -17,7 +17,7 @@
   "EXCEPTION_ASSERT(!scope.exception())": 0,
   "JSValue.false": 0,
   "JSValue.true": 0,
-  "TODO: properly propagate exception upwards": 114,
+  "TODO: properly propagate exception upwards": 112,
   "alloc.ptr !=": 0,
   "alloc.ptr ==": 0,
   "allocator.ptr !=": 1,

--- a/test/internal/ban-words.test.ts
+++ b/test/internal/ban-words.test.ts
@@ -54,7 +54,6 @@ const words: Record<string, { reason: string; regex?: boolean }> = {
   "globalThis.hasException": { reason: "Incompatible with strict exception checks. Use a CatchScope instead." },
   "EXCEPTION_ASSERT(!scope.exception())": { reason: "Use scope.assertNoException() instead" },
   " catch bun.outOfMemory()": { reason: "Use bun.handleOom to avoid catching unrelated errors" },
-  "TODO: properly propagate exception upwards": { reason: "This entry is here for tracking" },
 };
 const words_keys = [...Object.keys(words)];
 

--- a/test/internal/ban-words.test.ts
+++ b/test/internal/ban-words.test.ts
@@ -54,6 +54,7 @@ const words: Record<string, { reason: string; regex?: boolean }> = {
   "globalThis.hasException": { reason: "Incompatible with strict exception checks. Use a CatchScope instead." },
   "EXCEPTION_ASSERT(!scope.exception())": { reason: "Use scope.assertNoException() instead" },
   " catch bun.outOfMemory()": { reason: "Use bun.handleOom to avoid catching unrelated errors" },
+  "TODO: properly propagate exception upwards": { reason: "This entry is here for tracking" },
 };
 const words_keys = [...Object.keys(words)];
 

--- a/test/regression/issue/29157.test.ts
+++ b/test/regression/issue/29157.test.ts
@@ -20,7 +20,6 @@ test("console.dir on AggregateError prints the wrapper, not just the inner error
   expect(stdout).toContain("wrapper");
   expect(stdout).toContain("child1");
   expect(stdout).toContain("child2");
-  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });
 
@@ -34,7 +33,6 @@ test("Promise.any rejection surfaces as an AggregateError, not a stray inner err
 
   expect(stdout).toContain("AggregateError");
   expect(stdout).toContain("inner");
-  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });
 
@@ -70,6 +68,13 @@ test("AggregateError with a cause chain prints wrapper + errors + cause", async 
   expect(stdout).toContain("wrapper");
   expect(stdout).toContain("child");
   expect(stdout).toContain("root cause");
-  expect(stderr).toBe("");
+  // Node's util.inspect emits "[errors]: [ ... ]" with the children before
+  // the cause. Assert that ordering so we don't regress to wrapper → cause →
+  // children (the pre-fix queueing order in errors_to_append).
+  const childIdx = stdout.indexOf("child");
+  const causeIdx = stdout.indexOf("root cause");
+  expect(childIdx).toBeGreaterThan(-1);
+  expect(causeIdx).toBeGreaterThan(-1);
+  expect(childIdx).toBeLessThan(causeIdx);
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/29157.test.ts
+++ b/test/regression/issue/29157.test.ts
@@ -1,16 +1,4 @@
 // https://github.com/oven-sh/bun/issues/29157
-//
-// Bun's native `console.dir` / `console.log` formatter early-returned on any
-// AggregateError, walking `.errors` and printing each entry as a top-level
-// error — dropping the AggregateError wrapper's name, message, and stack.
-//
-// `Promise.any([Promise.reject(Error(""))]).catch(console.dir)` should print
-// `AggregateError: ... { [errors]: [ ... ] }` like Node. Bun instead printed
-// just the inner `Error` with no trace of the wrapper.
-//
-// Fix: removed the AggregateError early-return in `printErrorlikeObject` and
-// taught `printErrorInstance` to walk the non-enumerable `.errors` array the
-// same way it already walks `.cause`.
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
@@ -28,14 +16,12 @@ test("console.dir on AggregateError prints the wrapper, not just the inner error
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(exitCode).toBe(0);
-  // The wrapper's name + message must be in the output. Pre-fix, this was
-  // absent — the formatter printed only "error: child1 ... error: child2".
   expect(stdout).toContain("AggregateError");
   expect(stdout).toContain("wrapper");
-  // Children must still be printed below the wrapper.
   expect(stdout).toContain("child1");
   expect(stdout).toContain("child2");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });
 
 test("Promise.any rejection surfaces as an AggregateError, not a stray inner error", async () => {
@@ -46,11 +32,10 @@ test("Promise.any rejection surfaces as an AggregateError, not a stray inner err
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(exitCode).toBe(0);
-  // Pre-fix Bun printed `Error:` with no mention of AggregateError at all —
-  // exactly the bug from the issue report.
   expect(stdout).toContain("AggregateError");
   expect(stdout).toContain("inner");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });
 
 test("uncaught AggregateError rejection still shows the wrapper", async () => {
@@ -61,13 +46,10 @@ test("uncaught AggregateError rejection still shows the wrapper", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(exitCode).not.toBe(0);
-  // Uncaught rejection goes to stderr. The wrapper must appear there — the
-  // native error-reporter was fanning out `.errors` without printing the
-  // outer AggregateError at all.
   expect(stderr).toContain("AggregateError");
   expect(stderr).toContain("a");
   expect(stderr).toContain("b");
+  expect(exitCode).not.toBe(0);
 });
 
 test("AggregateError with a cause chain prints wrapper + errors + cause", async () => {
@@ -84,9 +66,10 @@ test("AggregateError with a cause chain prints wrapper + errors + cause", async 
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(exitCode).toBe(0);
   expect(stdout).toContain("AggregateError");
   expect(stdout).toContain("wrapper");
   expect(stdout).toContain("child");
   expect(stdout).toContain("root cause");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/29157.test.ts
+++ b/test/regression/issue/29157.test.ts
@@ -1,0 +1,116 @@
+// https://github.com/oven-sh/bun/issues/29157
+//
+// Bun's native `console.dir` / `console.log` formatter early-returned on any
+// AggregateError, walking `.errors` and printing each entry as a top-level
+// error — dropping the AggregateError wrapper's name, message, and stack.
+//
+// `Promise.any([Promise.reject(Error(""))]).catch(console.dir)` should print
+// `AggregateError: ... { [errors]: [ ... ] }` like Node. Bun instead printed
+// just the inner `Error` with no trace of the wrapper.
+//
+// Fix: removed the AggregateError early-return in `printErrorlikeObject` and
+// taught `printErrorInstance` to walk the non-enumerable `.errors` array the
+// same way it already walks `.cause`.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("console.dir on AggregateError prints the wrapper, not just the inner errors", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const err = new AggregateError([new Error("child1"), new Error("child2")], "wrapper");
+       console.dir(err);`,
+    ],
+    env: bunEnv,
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  // The wrapper's name + message must be in the output. Pre-fix, this was
+  // absent — the formatter printed only "error: child1 ... error: child2".
+  expect(stdout).toContain("AggregateError");
+  expect(stdout).toContain("wrapper");
+  // Children must still be printed below the wrapper.
+  expect(stdout).toContain("child1");
+  expect(stdout).toContain("child2");
+});
+
+test("Promise.any rejection surfaces as an AggregateError, not a stray inner error", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `await Promise.any([Promise.reject(new Error("inner"))]).catch(console.dir);`,
+    ],
+    env: bunEnv,
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  // Pre-fix Bun printed `Error:` with no mention of AggregateError at all —
+  // exactly the bug from the issue report.
+  expect(stdout).toContain("AggregateError");
+  expect(stdout).toContain("inner");
+});
+
+test("uncaught AggregateError rejection still shows the wrapper", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `await Promise.any([Promise.reject(new Error("a")), Promise.reject(new Error("b"))]);`,
+    ],
+    env: bunEnv,
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).not.toBe(0);
+  // Uncaught rejection goes to stderr. The wrapper must appear there — the
+  // native error-reporter was fanning out `.errors` without printing the
+  // outer AggregateError at all.
+  expect(stderr).toContain("AggregateError");
+  expect(stderr).toContain("a");
+  expect(stderr).toContain("b");
+});
+
+test("AggregateError with a cause chain prints wrapper + errors + cause", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const cause = new Error("root cause");
+       const err = new AggregateError([new Error("child")], "wrapper", { cause });
+       console.dir(err);`,
+    ],
+    env: bunEnv,
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain("AggregateError");
+  expect(stdout).toContain("wrapper");
+  expect(stdout).toContain("child");
+  expect(stdout).toContain("root cause");
+});

--- a/test/regression/issue/29157.test.ts
+++ b/test/regression/issue/29157.test.ts
@@ -26,11 +26,7 @@ test("console.dir on AggregateError prints the wrapper, not just the inner error
     env: bunEnv,
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   // The wrapper's name + message must be in the output. Pre-fix, this was
@@ -44,19 +40,11 @@ test("console.dir on AggregateError prints the wrapper, not just the inner error
 
 test("Promise.any rejection surfaces as an AggregateError, not a stray inner error", async () => {
   await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `await Promise.any([Promise.reject(new Error("inner"))]).catch(console.dir);`,
-    ],
+    cmd: [bunExe(), "-e", `await Promise.any([Promise.reject(new Error("inner"))]).catch(console.dir);`],
     env: bunEnv,
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   // Pre-fix Bun printed `Error:` with no mention of AggregateError at all —
@@ -67,19 +55,11 @@ test("Promise.any rejection surfaces as an AggregateError, not a stray inner err
 
 test("uncaught AggregateError rejection still shows the wrapper", async () => {
   await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `await Promise.any([Promise.reject(new Error("a")), Promise.reject(new Error("b"))]);`,
-    ],
+    cmd: [bunExe(), "-e", `await Promise.any([Promise.reject(new Error("a")), Promise.reject(new Error("b"))]);`],
     env: bunEnv,
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).not.toBe(0);
   // Uncaught rejection goes to stderr. The wrapper must appear there — the
@@ -102,11 +82,7 @@ test("AggregateError with a cause chain prints wrapper + errors + cause", async 
     env: bunEnv,
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stdout).toContain("AggregateError");

--- a/test/regression/issue/29157.test.ts
+++ b/test/regression/issue/29157.test.ts
@@ -38,15 +38,22 @@ test("Promise.any rejection surfaces as an AggregateError, not a stray inner err
 
 test("uncaught AggregateError rejection still shows the wrapper", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `await Promise.any([Promise.reject(new Error("a")), Promise.reject(new Error("b"))]);`],
+    cmd: [
+      bunExe(),
+      "-e",
+      `await Promise.any([Promise.reject(new Error("child_aaa")), Promise.reject(new Error("child_bbb"))]);`,
+    ],
     env: bunEnv,
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toContain("AggregateError");
-  expect(stderr).toContain("a");
-  expect(stderr).toContain("b");
+  // Distinctive messages so the assertion can only pass when the inner
+  // errors are actually printed — single-char strings would match the
+  // wrapper name or stack-frame content even if the children were dropped.
+  expect(stderr).toContain("child_aaa");
+  expect(stderr).toContain("child_bbb");
   expect(exitCode).not.toBe(0);
 });
 

--- a/test/regression/issue/29157.test.ts
+++ b/test/regression/issue/29157.test.ts
@@ -3,7 +3,7 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-test("console.dir on AggregateError prints the wrapper, not just the inner errors", async () => {
+test.concurrent("console.dir on AggregateError prints the wrapper, not just the inner errors", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -23,7 +23,7 @@ test("console.dir on AggregateError prints the wrapper, not just the inner error
   expect(exitCode).toBe(0);
 });
 
-test("Promise.any rejection surfaces as an AggregateError, not a stray inner error", async () => {
+test.concurrent("Promise.any rejection surfaces as an AggregateError, not a stray inner error", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", `await Promise.any([Promise.reject(new Error("inner"))]).catch(console.dir);`],
     env: bunEnv,
@@ -36,7 +36,7 @@ test("Promise.any rejection surfaces as an AggregateError, not a stray inner err
   expect(exitCode).toBe(0);
 });
 
-test("uncaught AggregateError rejection still shows the wrapper", async () => {
+test.concurrent("uncaught AggregateError rejection still shows the wrapper", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -57,7 +57,7 @@ test("uncaught AggregateError rejection still shows the wrapper", async () => {
   expect(exitCode).not.toBe(0);
 });
 
-test("AggregateError with a cause chain prints wrapper + errors + cause", async () => {
+test.concurrent("AggregateError with a cause chain prints wrapper + errors + cause", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),


### PR DESCRIPTION
Fixes #29157

### Repro

```js
await Promise.any([Promise.reject(Error(""))]).catch(console.dir);
```

Bun (before):
```
Error:
      at /tmp/poc.mjs:1:35
```

Node:
```
[AggregateError: All promises were rejected] {
  [errors]: [ Error ... ]
}
```

### Cause

`VirtualMachine.printErrorlikeObject` special-cased `AggregateError` at the top of the function:

```zig
if (value.isAggregateError(this.global)) {
    // …
    value.getErrorsProperty(this.global).forEach(this.global, &iter, iteratorWithColor) catch return;
    // …
    return;
}
```

It walked `.errors` with `forEach` and re-entered `printErrorlikeObject` on each child as a top-level error, then `return`-ed — the wrapper's name, message, stack, and any own properties were never printed. The same thing happened for `console.dir` and for uncaught rejections, because both paths land in `printErrorlikeObject`.

### Fix

Remove the unconditional unwrap. Let `printErrorInstance` handle the AggregateError like any other error (which already prints name / message / stack / enumerable own props / cause). Teach it that `.errors` is a non-enumerable own property on AggregateError — mirror the existing `.cause` branch that force-queues the non-enumerable cause into `errors_to_append`:

```zig
if (error_instance.isAggregateError(this.global)) {
    const AggregateErrorsIterator = struct { /* … */ };
    var errors_iter = AggregateErrorsIterator{ .errors_to_append = &errors_to_append };
    error_instance.getErrorsProperty(this.global).forEach(this.global, &errors_iter, visit) catch { /* … */ };
}
```

Now `console.dir(aggregateError)` and uncaught-rejection output both print the AggregateError wrapper first, followed by each inner error (reusing the same chained-print path that already formats `cause`).

### Test

`test/regression/issue/29157.test.ts` covers four shapes:

1. `console.dir(new AggregateError([...], 'wrapper'))` → must contain `AggregateError`, `wrapper`, and each inner error message.
2. `Promise.any([Promise.reject(Error('inner'))]).catch(console.dir)` — the exact issue reproducer.
3. Uncaught `await Promise.any([...rejected])` → stderr must contain `AggregateError` and each inner message.
4. `AggregateError` with both `.errors` and `.cause` → wrapper + each child + the cause must all print.

Pre-fix, the first assertion in each test fails — the output contains only the bare inner errors and no mention of `AggregateError`.