### PR TITLE
Force JS loader for `data:` URL imports

### DIFF
--- a/src/options.zig
+++ b/src/options.zig
@@ -2750,9 +2750,9 @@ const string = []const u8;
 const DotEnv = @import("./env_loader.zig");
 const Fs = @import("./fs.zig");
 const resolver = @import("./resolver/resolver.zig");
+const DataURL = @import("./resolver/data_url.zig").DataURL;
 const Runtime = @import("./runtime.zig").Runtime;
 const URL = @import("./url.zig").URL;
-const DataURL = @import("./resolver/data_url.zig").DataURL;
 
 const MacroRemap = @import("./resolver/package_json.zig").MacroMap;
 const PackageJSON = @import("./resolver/package_json.zig").PackageJSON;

--- a/src/options.zig
+++ b/src/options.zig
@@ -1061,6 +1061,28 @@ pub fn getLoaderAndVirtualSource(
     var loader: ?Loader = path.loader(&jsc_vm.transpiler.options.loaders);
     var virtual_source: ?*logger.Source = null;
 
+    // `data:` URLs are parsed as plain JavaScript (or JSON, etc.) based on
+    // the MIME type — never as TypeScript or JSX, regardless of the default
+    // loader Bun uses for on-disk files. This matches Node.js semantics:
+    // `import("data:application/javascript,export enum A{}")` must throw
+    // `SyntaxError`, since `export enum` is TypeScript.
+    //
+    // Parse from `specifier_str` (not `specifier`) because `normalizeSpecifier`
+    // splits on the first `?`, which would truncate a data URL whose payload
+    // contains a literal `?` before we can see the MIME type's semicolons.
+    if (strings.hasPrefixComptime(specifier_str, "data:")) {
+        if (DataURL.parseWithoutCheck(specifier_str)) |data_url| {
+            switch (data_url.decodeMimeType().category) {
+                .javascript => loader = .js,
+                .json => loader = .json,
+                .css => loader = .css,
+                .text => loader = .text,
+                .wasm => loader = .wasm,
+                else => {},
+            }
+        } else |_| {}
+    }
+
     if (jsc_vm.module_loader.eval_source) |eval_source| {
         if (strings.endsWithComptime(specifier, bun.pathLiteral("/[eval]"))) {
             virtual_source = eval_source;
@@ -2730,6 +2752,7 @@ const Fs = @import("./fs.zig");
 const resolver = @import("./resolver/resolver.zig");
 const Runtime = @import("./runtime.zig").Runtime;
 const URL = @import("./url.zig").URL;
+const DataURL = @import("./resolver/data_url.zig").DataURL;
 
 const MacroRemap = @import("./resolver/package_json.zig").MacroMap;
 const PackageJSON = @import("./resolver/package_json.zig").PackageJSON;

--- a/test/regression/issue/29159.test.ts
+++ b/test/regression/issue/29159.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/29159
+// `data:application/javascript` data URLs must be parsed as plain JavaScript.
+// TypeScript-only syntax like `export enum` must be rejected with SyntaxError,
+// matching Node.js semantics. Previously Bun ran data URLs through its default
+// tsx loader, which silently accepted TS syntax.
+
+test("data:application/javascript rejects TypeScript enum syntax", async () => {
+  // base64 of:
+  //   export const a = "a";
+  //
+  //   export enum A {
+  //     A,
+  //     B,
+  //     C,
+  //   }
+  const dataUrl =
+    "data:application/javascript;base64,ZXhwb3J0IGNvbnN0IGEgPSAiYSI7CgpleHBvcnQgZW51bSBBIHsKICBBLAogIEIsCiAgQywKfQo=";
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `await import(${JSON.stringify(dataUrl)});`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toMatch(/SyntaxError|Unexpected|enum/);
+  expect(exitCode).not.toBe(0);
+});
+
+test("data:text/javascript rejects TypeScript enum syntax", async () => {
+  const dataUrl = "data:text/javascript,export%20enum%20A%7BA%7D";
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `await import(${JSON.stringify(dataUrl)});`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toMatch(/SyntaxError|Unexpected|enum/);
+  expect(exitCode).not.toBe(0);
+});
+
+test("data:application/javascript still runs valid JavaScript", async () => {
+  // base64 of: export const value = 42;
+  const dataUrl = "data:application/javascript;base64,ZXhwb3J0IGNvbnN0IHZhbHVlID0gNDI7";
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const m = await import(${JSON.stringify(dataUrl)}); console.log(m.value);`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("42");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/29159.test.ts
+++ b/test/regression/issue/29159.test.ts
@@ -53,21 +53,13 @@ test("data:application/javascript still runs valid JavaScript", async () => {
   const dataUrl = "data:application/javascript;base64,ZXhwb3J0IGNvbnN0IHZhbHVlID0gNDI7";
 
   await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `const m = await import(${JSON.stringify(dataUrl)}); console.log(m.value);`,
-    ],
+    cmd: [bunExe(), "-e", `const m = await import(${JSON.stringify(dataUrl)}); console.log(m.value);`],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe("42");


### PR DESCRIPTION
## What

Bun was running `import("data:application/javascript,...")` through its default `tsx` loader, silently accepting TypeScript syntax like `export enum`. Node.js (and the HTML spec) treat `data:` URL modules as plain JavaScript when the MIME type is `text/javascript` / `application/javascript` and should reject TS-only syntax with a `SyntaxError`.

## Repro

```js
// main.mjs
const a = await import(
  "data:application/javascript;base64,ZXhwb3J0IGNvbnN0IGEgPSAiYSI7CgpleHBvcnQgZW51bSBBIHsKICBBLAogIEIsCiAgQywKfQo="
);
console.log(a.a);
```

Decoded payload:
```ts
export const a = "a";

export enum A { A, B, C }
```

**Before:** Bun prints `a`.
**After (this PR, matching Node):** `SyntaxError: Unexpected token 'export'` on the `export enum` line.

## Cause

`getLoaderAndVirtualSource` (src/options.zig) builds a `Fs.Path` from the data URL via `Fs.Path.init`, which puts it in the `file` namespace. `path.loader()` then falls through extension lookup (no matching extension in `data:application/javascript;base64,...`) and returns `null`. Downstream, the null loader defaults to `.tsx`, so TypeScript-only syntax silently parses.

## Fix

Detect `data:` specifiers in `getLoaderAndVirtualSource` and pick the loader from the MIME category — `.javascript → js`, `.json → json`, `.css → css`, `.text → text`, `.wasm → wasm`. Parsed from the un-normalized `specifier_str` so a literal `?` inside the payload doesn't truncate the MIME type prematurely.

## Test

`test/regression/issue/29159.test.ts` covers:
- `data:application/javascript;base64,...` with `export enum` must throw `SyntaxError`.
- `data:text/javascript,...` with `export enum` must throw `SyntaxError`.
- `data:application/javascript` with valid JS still imports successfully.

Confirmed the first two tests fail against the baked bun (bug present) and the third passes — `USE_SYSTEM_BUN=1 bun test test/regression/issue/29159.test.ts`.

Fixes #29159