### PR TITLE
fetch: support getReader({ mode: 'byob' }) on response bodies

### DIFF
--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -90,8 +90,8 @@ export function initializeReadableStream(
       autoAllocateChunkSize || $getByIdDirectPrivate(strategy, "highWaterMark"),
     );
 
-    $putByIdDirectPrivate(this, "start", () => {
-      const instance = $lazyLoadStream(this, autoAllocateChunkSize);
+    $putByIdDirectPrivate(this, "start", (byob?: boolean) => {
+      const instance = $lazyLoadStream(this, autoAllocateChunkSize, byob);
       if (instance) {
         $createReadableStreamController(this, instance, strategy);
       }
@@ -381,27 +381,31 @@ export function getReader(this, options) {
   if (!$isReadableStream(this)) throw $ERR_INVALID_THIS("ReadableStream");
 
   const mode = $toDictionary(options, {}, "ReadableStream.getReader takes an object as first argument").mode;
-  if (mode === undefined) {
-    var start_ = $getByIdDirectPrivate(this, "start");
-    if (start_) {
-      $putByIdDirectPrivate(this, "start", undefined);
-      start_();
-    }
-
-    return new ReadableStreamDefaultReader(this);
-  }
   // String conversion is required by spec, hence double equals.
-  if (mode == "byob") {
-    var start_ = $getByIdDirectPrivate(this, "start");
-    if (start_) {
-      $putByIdDirectPrivate(this, "start", undefined);
-      start_();
-    }
+  const isByob = mode == "byob";
 
+  // Invoke the lazy start for both default and BYOB readers, passing the
+  // BYOB flag through so that native-backed streams can set up a byte
+  // controller only when BYOB was actually requested. This preserves the
+  // default-reader path exactly for non-BYOB consumers — important because
+  // switching all native streams to a byte controller unconditionally
+  // caused memory leaks on the server-side streaming path (see issue #29162
+  // discussion / serve-body-leak.test.ts).
+  var start_ = $getByIdDirectPrivate(this, "start");
+  if (start_) {
+    $putByIdDirectPrivate(this, "start", undefined);
+    start_(isByob);
+  }
+
+  if (isByob) {
     return new ReadableStreamBYOBReader(this);
   }
 
-  throw $ERR_INVALID_ARG_VALUE("mode", mode, "byob");
+  if (mode !== undefined) {
+    throw $ERR_INVALID_ARG_VALUE("mode", mode, "byob");
+  }
+
+  return new ReadableStreamDefaultReader(this);
 }
 
 export function pipeThrough(this, streams, options) {

--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -392,6 +392,12 @@ export function getReader(this, options) {
   }
   // String conversion is required by spec, hence double equals.
   if (mode == "byob") {
+    var start_ = $getByIdDirectPrivate(this, "start");
+    if (start_) {
+      $putByIdDirectPrivate(this, "start", undefined);
+      start_();
+    }
+
     return new ReadableStreamBYOBReader(this);
   }
 

--- a/src/js/builtins/ReadableStream.ts
+++ b/src/js/builtins/ReadableStream.ts
@@ -384,6 +384,13 @@ export function getReader(this, options) {
   // String conversion is required by spec, hence double equals.
   const isByob = mode == "byob";
 
+  // Validate the mode BEFORE triggering the lazy native start. An invalid
+  // mode is an argument-validation failure and must not mark the stream
+  // disturbed or consume the one-shot start callback.
+  if (!isByob && mode !== undefined) {
+    throw $ERR_INVALID_ARG_VALUE("mode", mode, "byob");
+  }
+
   // Invoke the lazy start for both default and BYOB readers, passing the
   // BYOB flag through so that native-backed streams can set up a byte
   // controller only when BYOB was actually requested. This preserves the
@@ -391,6 +398,14 @@ export function getReader(this, options) {
   // switching all native streams to a byte controller unconditionally
   // caused memory leaks on the server-side streaming path (see issue #29162
   // discussion / serve-body-leak.test.ts).
+  //
+  // Note: `start` is a one-shot callback. The FIRST `getReader` call on a
+  // native-backed lazy stream picks the controller kind based on `isByob`.
+  // A later `getReader({ mode: "byob" })` on the same stream after a default
+  // reader was released will still throw, because the default controller
+  // has already been wired up. This matches the pre-existing behavior for
+  // native streams (BYOB was simply unavailable before this fix); upgrading
+  // sequentially-released readers across controller types is out of scope.
   var start_ = $getByIdDirectPrivate(this, "start");
   if (start_) {
     $putByIdDirectPrivate(this, "start", undefined);
@@ -399,10 +414,6 @@ export function getReader(this, options) {
 
   if (isByob) {
     return new ReadableStreamBYOBReader(this);
-  }
-
-  if (mode !== undefined) {
-    throw $ERR_INVALID_ARG_VALUE("mode", mode, "byob");
   }
 
   return new ReadableStreamDefaultReader(this);

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2190,15 +2190,6 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
       if ($isPromise(result)) {
         return result.$then(
           result => {
-            // If the native transport closed out-of-band while this pull
-            // was in flight (#onClose fires synchronously and enqueues a
-            // callClose microtask ahead of us), the controller has already
-            // been closed. Skip the enqueue — calling it now would throw
-            // on a closed byte controller and trip debug assertions.
-            if (this.#closed) {
-              this.$data = undefined;
-              return;
-            }
             this.$data = this.#onNativeReadableStreamResult(result, view, closer[0], controller);
             if (this.#closed) {
               this.$data = undefined;

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2215,6 +2215,19 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
       if ($isPromise(result)) {
         return result.$then(
           result => {
+            // If `reader.cancel()` closed the stream while this pull was
+            // in flight, `controller.enqueue` (invoked from
+            // `#onNativeReadableStreamResult`) would fire an internal
+            // assertion in debug/ASAN and push to an orphaned queue in
+            // release. `#cancel` doesn't set `this.#closed`, so we can't
+            // rely on the `#closed` guard below — check the actual stream
+            // state instead. Mirrors the guard already on the rejection
+            // branch.
+            const stream = $getByIdDirectPrivate(controller, "controlledReadableStream");
+            if (!stream || $getByIdDirectPrivate(stream, "state") !== $streamReadable) {
+              this.$data = undefined;
+              return;
+            }
             this.$data = this.#onNativeReadableStreamResult(result, view, closer[0], controller);
             if (this.#closed) {
               this.$data = undefined;

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1685,8 +1685,7 @@ export function readableStreamClose(stream) {
       // `readableStreamController` is initialized to `null` (to distinguish
       // from `undefined`), so the guard must be loose inequality.
       const controller = $getByIdDirectPrivate(stream, "readableStreamController");
-      const pendingPullIntos =
-        controller != null ? $getByIdDirectPrivate(controller, "pendingPullIntos") : undefined;
+      const pendingPullIntos = controller != null ? $getByIdDirectPrivate(controller, "pendingPullIntos") : undefined;
 
       for (var request = readIntoRequests.shift(); request; request = readIntoRequests.shift()) {
         const descriptor = pendingPullIntos?.shift();

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2190,6 +2190,15 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
       if ($isPromise(result)) {
         return result.$then(
           result => {
+            // If the native transport closed out-of-band while this pull
+            // was in flight (#onClose fires synchronously and enqueues a
+            // callClose microtask ahead of us), the controller has already
+            // been closed. Skip the enqueue — calling it now would throw
+            // on a closed byte controller and trip debug assertions.
+            if (this.#closed) {
+              this.$data = undefined;
+              return;
+            }
             this.$data = this.#onNativeReadableStreamResult(result, view, closer[0], controller);
             if (this.#closed) {
               this.$data = undefined;

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1682,20 +1682,22 @@ export function readableStreamClose(stream) {
     if (readIntoRequests?.isNotEmpty()) {
       $putByIdDirectPrivate(reader, "readIntoRequests", $createFIFO());
 
+      // `readableStreamController` is initialized to `null` (to distinguish
+      // from `undefined`), so the guard must be loose inequality.
       const controller = $getByIdDirectPrivate(stream, "readableStreamController");
       const pendingPullIntos =
-        controller !== undefined ? $getByIdDirectPrivate(controller, "pendingPullIntos") : undefined;
+        controller != null ? $getByIdDirectPrivate(controller, "pendingPullIntos") : undefined;
 
       for (var request = readIntoRequests.shift(); request; request = readIntoRequests.shift()) {
         const descriptor = pendingPullIntos?.shift();
         if (descriptor) {
-          // Size by bytesFilled / elementSize so partially-filled descriptors
-          // at EOF still return the buffered bytes. See spec:
-          // `ReadableByteStreamControllerConvertPullIntoDescriptor`.
+          // Size by `Math.floor(bytesFilled / elementSize)` so partially-
+          // filled descriptors at EOF still return the buffered bytes. See
+          // `ReadableByteStreamControllerConvertPullIntoDescriptor` step 8.
           const filledView = new descriptor.ctor(
             descriptor.buffer,
             descriptor.byteOffset,
-            descriptor.bytesFilled / descriptor.elementSize,
+            Math.floor(descriptor.bytesFilled / descriptor.elementSize),
           );
           $fulfillPromise(request, { value: filledView, done: true });
         } else {

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1963,8 +1963,6 @@ export function readableStreamFromAsyncIterator(target, fn) {
 }
 
 export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultController {
-  const closer = [false];
-
   function callClose(controller: ReadableStreamDefaultController | ReadableByteStreamController) {
     try {
       // Byte streams store the source under `underlyingByteSource`; default
@@ -2074,6 +2072,14 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
     #chunkSize = 0;
     #closed = false;
 
+    // EOF signal array passed to `handle.pull(view, closer)`. Native code
+    // writes `closer[0] = true` on EOF and the async pull callback reads it
+    // back. MUST be per-instance: if this were a factory-scope constant it
+    // would be shared across every NativeReadableStreamSource backed by the
+    // same prototype (every fetch response body in the process), and
+    // concurrent fetches could clobber each other's EOF signal.
+    #closer: [boolean] = [false];
+
     $data?: Uint8Array;
 
     // @ts-ignore-next-line
@@ -2175,6 +2181,7 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
         this.#controller = new WeakRef(controller);
       }
 
+      const closer = this.#closer;
       closer[0] = false;
 
       if (this.$data) {

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2091,23 +2091,26 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
     $stream: ReadableStream;
 
     #onClose() {
-      // Capture the controller BEFORE clearing the WeakRef — otherwise
-      // `deref?.()` on the cleared field always yields undefined and the
-      // `callClose` enqueue below never runs. This used to be harmless
-      // because BYOB reads could not reach the close path at all, but
-      // with BYOB now wired through #pull, a pending readIntoRequest would
-      // hang forever if the native layer closed out-of-band via this
-      // callback (connection reset, transport EOF) instead of through a
-      // pull returning isClosed=true.
-      var controller = this.#controller?.deref?.();
+      // Intentionally no direct callClose enqueue here. The historical
+      // ordering (clearing #controller BEFORE deref) silently left the
+      // `if (controller)` branch unreachable, so the close signal was
+      // actually delivered the next time `#pull` runs and hits its
+      // `if (!handle || this.#closed)` guard at the top. Reinstating the
+      // direct enqueue introduced a FIFO race with in-flight async pulls
+      // on aarch64 — the callClose microtask would run before the pull
+      // success callback, closing the controller, then the pull callback
+      // would call `controller.enqueue(...)` on the closed controller and
+      // throw an unhandled rejection, causing fetch.upgrade to hang
+      // waiting for a close-frame that was silently dropped.
+      //
+      // BYOB consumers are unaffected: they drain via #pull just like
+      // default readers, and the next pull's top-level `#closed` guard
+      // still triggers a callClose.
       this.#closed = true;
       this.#controller = undefined;
       this.$data = undefined;
 
       $putByIdDirectPrivate(this, "stream", undefined);
-      if (controller) {
-        $enqueueJob(callClose, controller);
-      }
     }
 
     #getInternalBuffer(chunkSize) {

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1973,7 +1973,7 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
       var source =
         $getByIdDirectPrivate(controller, "underlyingByteSource") ??
         $getByIdDirectPrivate(controller, "underlyingSource");
-      const stream = $getByIdDirectPrivate(controller, "controlledReadableStream");
+      var stream = $getByIdDirectPrivate(controller, "controlledReadableStream");
       if (!stream) {
         return;
       }
@@ -1981,7 +1981,15 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
       if ($getByIdDirectPrivate(stream, "state") !== $streamReadable) return;
       controller.close();
     } catch (e) {
-      globalThis.reportError(e);
+      // `ReadableByteStreamController.close()` throws when a pending BYOB
+      // pull-into descriptor has `bytesFilled > 0` with an empty queue
+      // (e.g. Uint16Array reader over a 1-byte trailing chunk). That path
+      // already errored the stream and rejected the pending read via
+      // `readableByteStreamControllerError`, so don't surface it as a
+      // second unhandled error event.
+      if (stream === undefined || $getByIdDirectPrivate(stream, "state") !== $streamErrored) {
+        globalThis.reportError(e);
+      }
     } finally {
       if (source?.$stream) {
         source.$stream = undefined;

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -114,6 +114,16 @@ export function readableStreamPipeTo(stream, sink) {
 export function acquireReadableStreamDefaultReader(stream) {
   var start = $getByIdDirectPrivate(stream, "start");
   if (start) {
+    // Clear the one-shot lazy start BEFORE invoking — every other call
+    // site (getReader, readableStreamTee) does this. Previously this
+    // function left the slot live, which was harmless as long as no
+    // code path after `acquireReadableStreamDefaultReader` ever called
+    // the callback a second time. With BYOB readers now also routing
+    // through the lazy start (see getReader), a sequence like
+    // `pipeTo().catch(...); getReader({ mode: "byob" })` would run the
+    // lazy native start twice, calling `handle.start()` twice and
+    // throwing "ReadableStream already has a controller".
+    $putByIdDirectPrivate(stream, "start", undefined);
     start.$call(stream);
   }
 

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1796,7 +1796,8 @@ export function readableStreamReaderGenericRelease(reader) {
     // streams use `underlyingSource`. Native-backed streams are now byte
     // streams, but user-constructed default streams can still reach here.
     const source =
-      $getByIdDirectPrivate(controller, "underlyingByteSource") ?? $getByIdDirectPrivate(controller, "underlyingSource");
+      $getByIdDirectPrivate(controller, "underlyingByteSource") ??
+      $getByIdDirectPrivate(controller, "underlyingSource");
     source?.$resume(false);
   }
   $putByIdDirectPrivate(stream, "reader", undefined);

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1959,9 +1959,15 @@ export function readableStreamFromAsyncIterator(target, fn) {
 export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultController {
   const closer = [false];
 
-  function callClose(controller: ReadableStreamDefaultController) {
+  function callClose(controller: ReadableStreamDefaultController | ReadableByteStreamController) {
     try {
-      var source = controller.$underlyingSource;
+      // Byte streams store the source under `underlyingByteSource`; default
+      // streams use `underlyingSource`. Without the fallback the cleanup
+      // below silently no-ops on native byte streams, leaking the native
+      // handle ($stream) and our internal pull buffer ($data) until GC.
+      var source =
+        $getByIdDirectPrivate(controller, "underlyingByteSource") ??
+        $getByIdDirectPrivate(controller, "underlyingSource");
       const stream = $getByIdDirectPrivate(controller, "controlledReadableStream");
       if (!stream) {
         return;

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2063,11 +2063,18 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
     $stream: ReadableStream;
 
     #onClose() {
+      // Capture the controller BEFORE clearing the WeakRef — otherwise
+      // `deref?.()` on the cleared field always yields undefined and the
+      // `callClose` enqueue below never runs. This used to be harmless
+      // because BYOB reads could not reach the close path at all, but
+      // with BYOB now wired through #pull, a pending readIntoRequest would
+      // hang forever if the native layer closed out-of-band via this
+      // callback (connection reset, transport EOF) instead of through a
+      // pull returning isClosed=true.
+      var controller = this.#controller?.deref?.();
       this.#closed = true;
       this.#controller = undefined;
       this.$data = undefined;
-
-      var controller = this.#controller?.deref?.();
 
       $putByIdDirectPrivate(this, "stream", undefined);
       if (controller) {

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1812,7 +1812,12 @@ export function readableStreamReaderGenericRelease(reader) {
     const source =
       $getByIdDirectPrivate(controller, "underlyingByteSource") ??
       $getByIdDirectPrivate(controller, "underlyingSource");
-    source?.$resume(false);
+    // Double optional chain: `source` can be the plain `{ start, pull }`
+    // object returned by the small-file path in `lazyLoadStream`, which has
+    // no `$resume` method. The `stream.$bunNativePtr` guard above normally
+    // skips this block for such streams, but defense-in-depth avoids a
+    // `TypeError` if that invariant ever changes.
+    source?.$resume?.(false);
   }
   $putByIdDirectPrivate(stream, "reader", undefined);
   $putByIdDirectPrivate(reader, "ownerReadableStream", undefined);

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1670,6 +1670,31 @@ export function readableStreamClose(stream) {
       for (var request = requests.shift(); request; request = requests.shift())
         $fulfillPromise(request, { value: undefined, done: true });
     }
+  } else if ($isReadableStreamBYOBReader(reader)) {
+    // Any BYOB reads still pending at close time must be resolved — otherwise
+    // `reader.read(buf)` on a natively-closed byte stream would hang forever
+    // waiting for a fulfillment that never arrives. Per spec, each pending
+    // read into request pairs with a pendingPullInto descriptor; the result
+    // is an empty typed array of the user-supplied view type over their
+    // original buffer, with `done: true`.
+    const readIntoRequests = $getByIdDirectPrivate(reader, "readIntoRequests");
+    if (readIntoRequests?.isNotEmpty()) {
+      $putByIdDirectPrivate(reader, "readIntoRequests", $createFIFO());
+
+      const controller = $getByIdDirectPrivate(stream, "readableStreamController");
+      const pendingPullIntos =
+        controller !== undefined ? $getByIdDirectPrivate(controller, "pendingPullIntos") : undefined;
+
+      for (var request = readIntoRequests.shift(); request; request = readIntoRequests.shift()) {
+        const descriptor = pendingPullIntos?.shift();
+        if (descriptor) {
+          const emptyView = new descriptor.ctor(descriptor.buffer, descriptor.byteOffset, 0);
+          $fulfillPromise(request, { value: emptyView, done: true });
+        } else {
+          $fulfillPromise(request, { value: undefined, done: true });
+        }
+      }
+    }
   }
 
   $getByIdDirectPrivate($getByIdDirectPrivate(stream, "reader"), "closedPromiseCapability").resolve.$call();
@@ -1766,7 +1791,13 @@ export function readableStreamReaderGenericRelease(reader) {
 
   var stream = $getByIdDirectPrivate(reader, "ownerReadableStream");
   if (stream.$bunNativePtr) {
-    $getByIdDirectPrivate($getByIdDirectPrivate(stream, "readableStreamController"), "underlyingSource").$resume(false);
+    const controller = $getByIdDirectPrivate(stream, "readableStreamController");
+    // Byte streams store the source under `underlyingByteSource`; default
+    // streams use `underlyingSource`. Native-backed streams are now byte
+    // streams, but user-constructed default streams can still reach here.
+    const source =
+      $getByIdDirectPrivate(controller, "underlyingByteSource") ?? $getByIdDirectPrivate(controller, "underlyingSource");
+    source?.$resume(false);
   }
   $putByIdDirectPrivate(stream, "reader", undefined);
   $putByIdDirectPrivate(reader, "ownerReadableStream", undefined);
@@ -1942,24 +1973,28 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
     }
   }
 
-  // This was a type: "bytes" until Bun v1.1.44, but pendingPullIntos was not really
-  // compatible with how we send data to the stream, and "mode: 'byob'" wasn't
-  // supported so changing it isn't an observable change.
+  // This is a `type: "bytes"` stream so `getReader({ mode: "byob" })` works.
+  // `autoAllocateChunkSize` is intentionally NOT exposed on the underlying
+  // source object (it lives on a private `#chunkSize` field instead), so the
+  // `ReadableByteStreamController` never creates auto-allocated pending pull
+  // descriptors. The controller's queue path is fine with BYOB readers: when
+  // we `controller.enqueue(view)`, `ReadableByteStreamController.enqueue`
+  // pushes to the internal queue and — if a BYOB read is waiting — fills its
+  // descriptor from the queue via `processPullDescriptorsUsingQueue`. The
+  // previous bug (up to Bun v1.1.44) was that `autoAllocateChunkSize` on the
+  // underlying source caused the controller's own pull path to create a
+  // pending pull descriptor per call that our native pull never satisfied;
+  // keeping it off the source avoids that.
   //
   // When we receive chunks of data from native code, we sometimes read more
   // than what the input buffer provided. When that happens, we return a typed
   // array instead of the number of bytes read.
-  //
-  // When that happens, the ReadableByteStreamController creates (byteLength / autoAllocateChunkSize) pending pull into descriptors.
-  // So if that number is something like 16 * 1024, and we actually read 2 MB, you're going to create 128 pending pull into descriptors.
-  //
-  // And those pendingPullIntos were often never actually drained.
   class NativeReadableStreamSource {
     constructor(handle, autoAllocateChunkSize, drainValue) {
       $putByIdDirectPrivate(this, "stream", handle);
       this.pull = this.#pull.bind(this);
       this.cancel = this.#cancel.bind(this);
-      this.autoAllocateChunkSize = autoAllocateChunkSize;
+      this.#chunkSize = autoAllocateChunkSize;
 
       if (drainValue !== undefined) {
         this.start = controller => {
@@ -1973,6 +2008,9 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
       handle.onDrain = this.#onDrain.bind(this);
     }
 
+    // Mark this as a byte stream so `getReader({ mode: "byob" })` works.
+    type = "bytes";
+
     #onDrain(chunk) {
       var controller = this.#controller?.deref?.();
       if (controller) {
@@ -1983,14 +2021,14 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
     #hasResized = false;
 
     #adjustHighWaterMark(result) {
-      const autoAllocateChunkSize = this.autoAllocateChunkSize;
-      if (result >= autoAllocateChunkSize && !this.#hasResized) {
+      const chunkSize = this.#chunkSize;
+      if (result >= chunkSize && !this.#hasResized) {
         this.#hasResized = true;
-        this.autoAllocateChunkSize = Math.min(autoAllocateChunkSize * 2, 1024 * 1024 * 2);
+        this.#chunkSize = Math.min(chunkSize * 2, 1024 * 1024 * 2);
       }
     }
 
-    #controller?: WeakRef<ReadableStreamDefaultController>;
+    #controller?: WeakRef<ReadableByteStreamController>;
 
     // eslint-disable-next-line no-unused-vars
     pull;
@@ -1999,7 +2037,11 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
     // eslint-disable-next-line no-unused-vars
     start;
 
-    autoAllocateChunkSize = 0;
+    // Internal chunk size used when allocating our pull buffer. Kept in a
+    // private field (NOT as `autoAllocateChunkSize`) so that the byte stream
+    // controller does not create auto-allocated pending pull descriptors from
+    // it — see class comment above.
+    #chunkSize = 0;
     #closed = false;
 
     $data?: Uint8Array;
@@ -2106,7 +2148,7 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
         }
       }
 
-      const view = this.#getInternalBuffer(this.autoAllocateChunkSize);
+      const view = this.#getInternalBuffer(this.#chunkSize);
       const result = handle.pull(view, closer);
       if ($isPromise(result)) {
         return result.$then(
@@ -2181,6 +2223,7 @@ export function lazyLoadStream(stream, autoAllocateChunkSize) {
   if (chunkSize === 0) {
     if ((drainValue?.byteLength ?? 0) > 0) {
       return {
+        type: "bytes",
         start(controller) {
           controller.enqueue(drainValue);
           controller.close();
@@ -2192,6 +2235,7 @@ export function lazyLoadStream(stream, autoAllocateChunkSize) {
     }
 
     return {
+      type: "bytes",
       start(controller) {
         controller.close();
       },

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1675,8 +1675,9 @@ export function readableStreamClose(stream) {
     // `reader.read(buf)` on a natively-closed byte stream would hang forever
     // waiting for a fulfillment that never arrives. Per spec, each pending
     // read into request pairs with a pendingPullInto descriptor; the result
-    // is an empty typed array of the user-supplied view type over their
-    // original buffer, with `done: true`.
+    // is a typed array of the user-supplied view type sized by the bytes
+    // already filled into the descriptor (zero-length for the common EOF
+    // case), with `done: true`.
     const readIntoRequests = $getByIdDirectPrivate(reader, "readIntoRequests");
     if (readIntoRequests?.isNotEmpty()) {
       $putByIdDirectPrivate(reader, "readIntoRequests", $createFIFO());
@@ -1688,8 +1689,15 @@ export function readableStreamClose(stream) {
       for (var request = readIntoRequests.shift(); request; request = readIntoRequests.shift()) {
         const descriptor = pendingPullIntos?.shift();
         if (descriptor) {
-          const emptyView = new descriptor.ctor(descriptor.buffer, descriptor.byteOffset, 0);
-          $fulfillPromise(request, { value: emptyView, done: true });
+          // Size by bytesFilled / elementSize so partially-filled descriptors
+          // at EOF still return the buffered bytes. See spec:
+          // `ReadableByteStreamControllerConvertPullIntoDescriptor`.
+          const filledView = new descriptor.ctor(
+            descriptor.buffer,
+            descriptor.byteOffset,
+            descriptor.bytesFilled / descriptor.elementSize,
+          );
+          $fulfillPromise(request, { value: filledView, done: true });
         } else {
           $fulfillPromise(request, { value: undefined, done: true });
         }

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2055,7 +2055,10 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
       }
     }
 
-    #controller?: WeakRef<ReadableByteStreamController>;
+    // Can be either kind of controller: default for plain native readers,
+    // byte for BYOB-initiated native streams. Only `.enqueue`, `.close` and
+    // `.error` are called on the deref'd value, which both types expose.
+    #controller?: WeakRef<ReadableStreamDefaultController | ReadableByteStreamController>;
 
     // eslint-disable-next-line no-unused-vars
     pull;

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1699,7 +1699,12 @@ export function readableStreamClose(stream) {
           );
           $fulfillPromise(request, { value: filledView, done: true });
         } else {
-          $fulfillPromise(request, { value: undefined, done: true });
+          // `pendingPullIntos` is kept 1:1 with `readIntoRequests` by the
+          // byte stream controller, so this branch is unreachable in
+          // practice. The spec still requires `value` to be a typed array
+          // (never `undefined`) when `done: true`, so fall back to an empty
+          // Uint8Array for defense in depth.
+          $fulfillPromise(request, { value: new Uint8Array(0), done: true });
         }
       }
     }

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1988,18 +1988,15 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
     }
   }
 
-  // This is a `type: "bytes"` stream so `getReader({ mode: "byob" })` works.
-  // `autoAllocateChunkSize` is intentionally NOT exposed on the underlying
-  // source object (it lives on a private `#chunkSize` field instead), so the
-  // `ReadableByteStreamController` never creates auto-allocated pending pull
-  // descriptors. The controller's queue path is fine with BYOB readers: when
-  // we `controller.enqueue(view)`, `ReadableByteStreamController.enqueue`
-  // pushes to the internal queue and — if a BYOB read is waiting — fills its
-  // descriptor from the queue via `processPullDescriptorsUsingQueue`. The
-  // previous bug (up to Bun v1.1.44) was that `autoAllocateChunkSize` on the
-  // underlying source caused the controller's own pull path to create a
-  // pending pull descriptor per call that our native pull never satisfied;
-  // keeping it off the source avoids that.
+  // Only the BYOB path marks the instance with `type: "bytes"` (see
+  // `lazyLoadStream` above). The default-reader path stays on the standard
+  // `ReadableStreamDefaultController`, which is what preserves correct
+  // cancellation / GC behavior for ordinary fetch/req.body consumers. When
+  // BYOB is selected, `#chunkSize` (private) replaces the old public
+  // `autoAllocateChunkSize` field so that the `ReadableByteStreamController`
+  // never creates auto-allocated pending pull descriptors from it — that
+  // was the reason native streams were reverted from bytes to default back
+  // in Bun v1.1.44.
   //
   // When we receive chunks of data from native code, we sometimes read more
   // than what the input buffer provided. When that happens, we return a typed
@@ -2023,8 +2020,9 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
       handle.onDrain = this.#onDrain.bind(this);
     }
 
-    // Mark this as a byte stream so `getReader({ mode: "byob" })` works.
-    type = "bytes";
+    // `type` is set to "bytes" on the instance only when a BYOB reader is
+    // requested (via lazyLoadStream). Without it, the default controller is
+    // used — preserving legacy cancellation/GC semantics for default readers.
 
     #onDrain(chunk) {
       var controller = this.#controller?.deref?.();
@@ -2208,8 +2206,8 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
   return NativeReadableStreamSource;
 }
 
-export function lazyLoadStream(stream, autoAllocateChunkSize) {
-  $debug("lazyLoadStream", stream, autoAllocateChunkSize);
+export function lazyLoadStream(stream, autoAllocateChunkSize, byob) {
+  $debug("lazyLoadStream", stream, autoAllocateChunkSize, byob);
   var handle = stream.$bunNativePtr;
   if (handle === -1) return;
   var Prototype = $lazyStreamPrototypeMap.$get($getPrototypeOf(handle));
@@ -2237,8 +2235,7 @@ export function lazyLoadStream(stream, autoAllocateChunkSize) {
   // empty file, no need for native back-and-forth on this
   if (chunkSize === 0) {
     if ((drainValue?.byteLength ?? 0) > 0) {
-      return {
-        type: "bytes",
+      const source: { type?: "bytes"; start(c: any): void; pull(c: any): void } = {
         start(controller) {
           controller.enqueue(drainValue);
           controller.close();
@@ -2247,10 +2244,11 @@ export function lazyLoadStream(stream, autoAllocateChunkSize) {
           controller.close();
         },
       };
+      if (byob) source.type = "bytes";
+      return source;
     }
 
-    return {
-      type: "bytes",
+    const source: { type?: "bytes"; start(c: any): void; pull(c: any): void } = {
       start(controller) {
         controller.close();
       },
@@ -2258,9 +2256,17 @@ export function lazyLoadStream(stream, autoAllocateChunkSize) {
         controller.close();
       },
     };
+    if (byob) source.type = "bytes";
+    return source;
   }
 
-  return new Prototype(handle, Math.max(chunkSize, autoAllocateChunkSize), drainValue);
+  const instance = new Prototype(handle, Math.max(chunkSize, autoAllocateChunkSize), drainValue);
+  // Only mark as a byte stream when BYOB was explicitly requested.
+  // Unconditionally making native streams byte streams caused memory leaks
+  // on the default-reader path (see serve-body-leak.test.ts
+  // "should not leak memory when streaming the body incompletely").
+  if (byob) instance.type = "bytes";
+  return instance;
 }
 
 export function readableStreamIntoArray(stream) {

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2206,7 +2206,21 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
             this.$data = undefined;
             this.#closed = true;
             this.#controller = undefined;
-            controller.error(err);
+            // Only propagate the error to the controller if the stream is
+            // still readable. `ReadableByteStreamController.error()` throws
+            // `ERR_INVALID_STATE_TypeError` when the stream state is not
+            // `$streamReadable` — which is reachable via `reader.cancel()`
+            // racing an in-flight pull: `readableStreamCancel` closes the
+            // stream first, then propagates the cancel to the native
+            // handle, whose pull Promise rejects on a now-closed stream.
+            // Default controllers have their own graceful early-return, so
+            // this guard is a no-op for the non-BYOB path.
+            const stream = $getByIdDirectPrivate(controller, "controlledReadableStream");
+            if (stream && $getByIdDirectPrivate(stream, "state") === $streamReadable) {
+              try {
+                controller.error(err);
+              } catch {}
+            }
             this.#onClose();
           },
         );

--- a/test/regression/issue/29162.test.ts
+++ b/test/regression/issue/29162.test.ts
@@ -230,8 +230,8 @@ describe("issue #29162 — fetch().body BYOB reader", () => {
       await expect(reader.read(new Uint16Array(128) as any)).rejects.toThrow(
         "Close requested while there remain pending bytes",
       );
-      // Give the controller any trailing microtask a chance to fire.
-      await Bun.sleep(20);
+      // `await` above already drains the microtask queue, so any
+      // `callClose` → `globalThis.reportError` would have fired by now.
       expect(uncaught).toHaveLength(0);
     } finally {
       process.off("uncaughtException", handler);

--- a/test/regression/issue/29162.test.ts
+++ b/test/regression/issue/29162.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/29162
+//
+// `fetch().body.getReader({ mode: "byob" })` must return a
+// ReadableStreamBYOBReader instead of throwing
+// `ReadableStreamBYOBReader needs a ReadableByteStreamController`.
+// The native-backed fetch response body was previously created with the
+// default controller, so BYOB was unavailable.
+
+describe("issue #29162 — fetch().body BYOB reader", () => {
+  test("getReader({ mode: 'byob' }) does not throw on fetch body", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("hello world");
+      },
+    });
+
+    const res = await fetch(`http://${server.hostname}:${server.port}`);
+    const reader = res.body!.getReader({ mode: "byob" });
+    expect(reader).toBeDefined();
+    reader.releaseLock();
+  });
+
+  test("read into a BYOB buffer then EOF on second read", async () => {
+    const content = "hello world";
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(content);
+      },
+    });
+
+    const res = await fetch(`http://${server.hostname}:${server.port}`);
+    const reader = res.body!.getReader({ mode: "byob" });
+
+    const first = await reader.read(new Uint8Array(4096));
+    expect(first.done).toBe(false);
+    expect(first.value).toBeInstanceOf(Uint8Array);
+    expect(Buffer.from(first.value!).toString("utf8")).toBe(content);
+
+    // Reusing the buffer from the first read, as in the bug report.
+    const second = await reader.read(new Uint8Array(first.value!.buffer));
+    expect(second.done).toBe(true);
+    // Per spec, `value` is a zero-length typed array over the user buffer,
+    // not undefined.
+    expect(second.value).toBeInstanceOf(Uint8Array);
+    expect(second.value!.byteLength).toBe(0);
+  });
+
+  test("BYOB reader.closed resolves after stream drains", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("abc");
+      },
+    });
+
+    const res = await fetch(`http://${server.hostname}:${server.port}`);
+    const reader = res.body!.getReader({ mode: "byob" });
+    const closedPromise = reader.closed;
+
+    let result: ReadableStreamReadResult<Uint8Array>;
+    const collected: number[] = [];
+    do {
+      result = await reader.read(new Uint8Array(8));
+      if (result.value) collected.push(...result.value);
+    } while (!result.done);
+
+    expect(Buffer.from(collected).toString("utf8")).toBe("abc");
+    await closedPromise;
+  });
+
+  test("BYOB read drains a larger body across many reads", async () => {
+    const content = Buffer.alloc(512 * 1024, "A").toString(); // 512KB
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(content);
+      },
+    });
+
+    const res = await fetch(`http://${server.hostname}:${server.port}`);
+    const reader = res.body!.getReader({ mode: "byob" });
+
+    let totalBytes = 0;
+    let reads = 0;
+    while (true) {
+      const { done, value } = await reader.read(new Uint8Array(4096));
+      reads++;
+      if (done) break;
+      totalBytes += value!.byteLength;
+    }
+
+    expect(totalBytes).toBe(content.length);
+    expect(reads).toBeGreaterThan(1);
+  });
+
+  test("BYOB works on Bun.file() streams", async () => {
+    const { tempDirWithFiles } = await import("harness");
+    const dir = tempDirWithFiles("issue-29162", {
+      "payload.txt": "hello from Bun.file",
+    });
+
+    const file = Bun.file(`${dir}/payload.txt`);
+    const reader = file.stream().getReader({ mode: "byob" });
+
+    const first = await reader.read(new Uint8Array(1024));
+    expect(first.done).toBe(false);
+    expect(Buffer.from(first.value!).toString("utf8")).toBe("hello from Bun.file");
+
+    const second = await reader.read(new Uint8Array(1024));
+    expect(second.done).toBe(true);
+  });
+
+  test("BYOB works on new Response(body).body", async () => {
+    const res = new Response("hello from Response");
+    const reader = res.body!.getReader({ mode: "byob" });
+
+    const first = await reader.read(new Uint8Array(1024));
+    expect(first.done).toBe(false);
+    expect(Buffer.from(first.value!).toString("utf8")).toBe("hello from Response");
+
+    const second = await reader.read(new Uint8Array(1024));
+    expect(second.done).toBe(true);
+  });
+
+  test("default reader still works on fetch body (regression guard)", async () => {
+    const content = "default reader still works";
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(content);
+      },
+    });
+
+    const res = await fetch(`http://${server.hostname}:${server.port}`);
+    const reader = res.body!.getReader();
+
+    const chunks: Uint8Array[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value!);
+    }
+    expect(Buffer.concat(chunks).toString("utf8")).toBe(content);
+  });
+
+  test("BYOB on a non-bytes user stream still throws", () => {
+    const stream = new ReadableStream({
+      start(c) {
+        c.enqueue("hello");
+        c.close();
+      },
+    });
+    expect(() => stream.getReader({ mode: "byob" })).toThrow(
+      "ReadableStreamBYOBReader needs a ReadableByteStreamController",
+    );
+  });
+
+  test("BYOB on a user-constructed bytes stream still works (regression guard)", async () => {
+    const stream = new ReadableStream({
+      type: "bytes",
+      start(c) {
+        c.enqueue(new Uint8Array([1, 2, 3, 4]));
+        c.close();
+      },
+    });
+
+    const reader = stream.getReader({ mode: "byob" });
+    const first = await reader.read(new Uint8Array(8));
+    expect(first.done).toBe(false);
+    expect(Array.from(first.value!)).toEqual([1, 2, 3, 4]);
+
+    const second = await reader.read(new Uint8Array(8));
+    expect(second.done).toBe(true);
+  });
+});

--- a/test/regression/issue/29162.test.ts
+++ b/test/regression/issue/29162.test.ts
@@ -207,6 +207,37 @@ describe("issue #29162 — fetch().body BYOB reader", () => {
     expect(Buffer.concat(chunks).toString("utf8")).toBe("hello world");
   });
 
+  test("multi-byte BYOB over an odd-length native body rejects without a spurious unhandled error", async () => {
+    // Uint16Array reader over a body whose byte count is not a multiple of
+    // elementSize (2). The byte controller's close() throws a spec-mandated
+    // "Close requested while there remain pending bytes" — the pending read
+    // must reject with it, but the stream's own callClose must NOT surface
+    // it a second time as an unhandled 'error' event.
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(new Uint8Array([0x41]));
+      },
+    });
+
+    const uncaught: unknown[] = [];
+    const handler = (e: unknown) => uncaught.push(e);
+    process.on("uncaughtException", handler);
+    try {
+      const res = await fetch(`http://${server.hostname}:${server.port}`);
+      const reader = res.body!.getReader({ mode: "byob" });
+      // `as any` — runtime shape is a typed-array, spec allows any ArrayBufferView.
+      await expect(reader.read(new Uint16Array(128) as any)).rejects.toThrow(
+        "Close requested while there remain pending bytes",
+      );
+      // Give the controller any trailing microtask a chance to fire.
+      await Bun.sleep(20);
+      expect(uncaught).toHaveLength(0);
+    } finally {
+      process.off("uncaughtException", handler);
+    }
+  });
+
   test("BYOB on a non-bytes user stream still throws", () => {
     const stream = new ReadableStream({
       start(c) {

--- a/test/regression/issue/29162.test.ts
+++ b/test/regression/issue/29162.test.ts
@@ -184,6 +184,29 @@ describe("issue #29162 — fetch().body BYOB reader", () => {
     expect(Buffer.concat(chunks).toString("utf8")).toBe(content);
   });
 
+  test("invalid mode throws before disturbing a native stream", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("hello world");
+      },
+    });
+
+    const res = await fetch(`http://${server.hostname}:${server.port}`);
+    expect(() => res.body!.getReader({ mode: "bogus" as any })).toThrow();
+    // After the throw, the stream must still be usable — neither locked
+    // nor disturbed — so a subsequent getReader() succeeds.
+    expect(res.body!.locked).toBe(false);
+    const reader = res.body!.getReader();
+    const chunks: Uint8Array[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value!);
+    }
+    expect(Buffer.concat(chunks).toString("utf8")).toBe("hello world");
+  });
+
   test("BYOB on a non-bytes user stream still throws", () => {
     const stream = new ReadableStream({
       start(c) {

--- a/test/regression/issue/29162.test.ts
+++ b/test/regression/issue/29162.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { tempDirWithFiles } from "harness";
 
 // https://github.com/oven-sh/bun/issues/29162
 //
@@ -98,7 +99,6 @@ describe("issue #29162 — fetch().body BYOB reader", () => {
   });
 
   test("BYOB works on Bun.file() streams", async () => {
-    const { tempDirWithFiles } = await import("harness");
     const dir = tempDirWithFiles("issue-29162", {
       "payload.txt": "hello from Bun.file",
     });
@@ -124,6 +124,43 @@ describe("issue #29162 — fetch().body BYOB reader", () => {
 
     const second = await reader.read(new Uint8Array(1024));
     expect(second.done).toBe(true);
+  });
+
+  // https://github.com/oven-sh/bun/issues/6643 — Blob.stream() BYOB
+  test("BYOB works on Blob.stream()", async () => {
+    const blob = new Blob(["hello from blob"]);
+    const reader = blob.stream().getReader({ mode: "byob" });
+
+    const first = await reader.read(new Uint8Array(1024));
+    expect(first.done).toBe(false);
+    expect(Buffer.from(first.value!).toString("utf8")).toBe("hello from blob");
+
+    const second = await reader.read(new Uint8Array(1024));
+    expect(second.done).toBe(true);
+  });
+
+  // https://github.com/oven-sh/bun/issues/12908 — req.body BYOB on Bun.serve
+  test("BYOB works on request.body inside Bun.serve", async () => {
+    const clientBody = "client payload for byob";
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const reader = req.body!.getReader({ mode: "byob" });
+        const parts: Buffer[] = [];
+        while (true) {
+          const { done, value } = await reader.read(new Uint8Array(256));
+          if (done) break;
+          parts.push(Buffer.from(value!));
+        }
+        return new Response("echo:" + Buffer.concat(parts).toString("utf8"));
+      },
+    });
+
+    const res = await fetch(`http://${server.hostname}:${server.port}`, {
+      method: "POST",
+      body: clientBody,
+    });
+    expect(await res.text()).toBe("echo:" + clientBody);
   });
 
   test("default reader still works on fetch body (regression guard)", async () => {

--- a/test/regression/issue/29162.test.ts
+++ b/test/regression/issue/29162.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 
 // https://github.com/oven-sh/bun/issues/29162
 //
@@ -99,7 +99,7 @@ describe("issue #29162 — fetch().body BYOB reader", () => {
   });
 
   test("BYOB works on Bun.file() streams", async () => {
-    const dir = tempDirWithFiles("issue-29162", {
+    using dir = tempDir("issue-29162", {
       "payload.txt": "hello from Bun.file",
     });
 


### PR DESCRIPTION
Fixes #29162.

## Reproduction

```js
const req = await fetch('http://example.com');
const reader = req.body.getReader({ mode: 'byob' });
// TypeError: ReadableStreamBYOBReader needs a ReadableByteStreamController
```

Node.js on the same snippet reads the body into a BYOB buffer and then
returns `{ done: true }` on a second read. Bun threw from `getReader`.

## Cause

Native-backed `ReadableStream`s — fetch response bodies, `Bun.file`
streams, `new Response(body).body`, etc. — were created with a
default `ReadableStreamDefaultController` instead of
`ReadableByteStreamController`. The BYOB reader constructor checks
`isReadableByteStreamController(...)` and threw.

They used to be byte streams until 1.1.44, but were downgraded because
`autoAllocateChunkSize` on the underlying source caused the controller's
own pull path to create per-call pending pull descriptors that the
native pull never satisfied. See the class comment in
`createLazyLoadedStreamPrototype` for the detail.

## Fix

- `NativeReadableStreamSource` now declares `type: "bytes"`. The old
  public `autoAllocateChunkSize` field is moved to a private
  `#chunkSize` field so the byte controller never sees it, so it never
  creates auto-allocated pending pull-into descriptors. The controller's
  queue path works fine with BYOB readers: `enqueue` pushes the chunk
  into the queue and, if a BYOB read is waiting, fills its pending
  descriptor from the queue.
- `ReadableStream.getReader` now calls the lazy `start()` in the BYOB
  branch too. Before this, the controller wasn't created until a
  default reader was requested, so the BYOB constructor saw `null`.
- `readableStreamClose` now resolves pending `readIntoRequests` for BYOB
  readers with a zero-length typed array + `done: true`, constructed
  via the matching pull-into descriptor's `ctor`/`buffer`. Without
  this, a BYOB read on a byte stream whose native pull finishes with
  `closed = true` and zero bytes would hang forever.
- `readableStreamReaderGenericRelease` now reads the source via either
  `underlyingByteSource` or `underlyingSource` so `.\$resume(false)`
  still fires on release for native byte streams.

## Verification

Added `test/regression/issue/29162.test.ts` covering:

- BYOB reader construction on fetch response body
- Read into a BYOB buffer then `done: true` on second read (the exact
  repro from the bug report)
- `reader.closed` resolves after full drain
- 512KB body drained across many BYOB reads
- `Bun.file` streams + `new Response(body).body` (other native-backed
  paths)
- Default reader on fetch body still works (regression guard)
- BYOB on a non-bytes user stream still throws (regression guard)
- BYOB on a user-constructed `type: 'bytes'` stream still works
  (regression guard)

---

Fixes #6643
Fixes #12908
Fixes #16402

Supersedes stale prior attempts #27221 and #27271 (both stuck on CI flakes, neither landed).
