### PR TITLE
server: unlink unix socket file on SIGTERM/SIGINT and process.exit

### DIFF
--- a/src/Global.zig
+++ b/src/Global.zig
@@ -78,7 +78,12 @@ const ExitFn = *const fn () callconv(.c) void;
 var on_exit_callbacks = std.ArrayListUnmanaged(ExitFn){};
 export fn Bun__atexit(function: ExitFn) void {
     if (std.mem.indexOfScalar(ExitFn, on_exit_callbacks.items, function) == null) {
-        on_exit_callbacks.append(bun.default_allocator, function) catch {};
+        // The caller has no signal channel (return type is `void`), so
+        // swallowing OOM here silently drops the exit callback — e.g.
+        // the unix-socket cleanup registered from `bun_initialize_process`
+        // for #29166 — which would reintroduce that bug on
+        // `process.exit()`. Crash instead.
+        bun.handleOom(on_exit_callbacks.append(bun.default_allocator, function));
     }
 }
 

--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -1087,11 +1087,11 @@ const BoringSSL = bun.BoringSSL.c;
 const uv = bun.windows.libuv;
 
 const api = bun.api;
-const UnixSocketCleanup = bun.api.server.UnixSocketCleanup;
 const Handlers = bun.api.SocketHandlers;
 const TCPSocket = bun.api.TCPSocket;
 const TLSSocket = bun.api.TLSSocket;
 const SSLConfig = bun.api.ServerConfig.SSLConfig;
+const UnixSocketCleanup = bun.api.server.UnixSocketCleanup;
 
 const NewSocket = api.socket.NewSocket;
 const SocketConfig = api.socket.SocketConfig;

--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -14,6 +14,10 @@ protos: ?[]const u8 = null,
 strong_data: jsc.Strong.Optional = .empty,
 strong_self: jsc.Strong.Optional = .empty,
 
+/// Registration in the process-global unix socket cleanup list. Non-null
+/// only while a unix-socket listener is active — see UnixSocketCleanup.zig.
+unix_cleanup_handle: ?UnixSocketCleanup.Handle = null,
+
 pub const js = jsc.Codegen.JSListener;
 pub const toJS = js.toJS;
 pub const fromJS = js.fromJS;
@@ -317,6 +321,12 @@ pub fn listen(globalObject: *jsc.JSGlobalObject, opts: JSValue) bun.JSError!JSVa
     this.strong_self.set(globalObject, this_value);
     this.poll_ref.ref(handlers.vm);
 
+    // Register the unix socket path for cleanup if the process exits
+    // via a signal without reaching `doStop()`.
+    if (this.connection == .unix) {
+        this.unix_cleanup_handle = UnixSocketCleanup.register(this.connection.unix);
+    }
+
     return this_value;
 }
 
@@ -478,8 +488,13 @@ pub fn finalize(this: *Listener) callconv(.c) void {
 
 /// Match Node.js/libuv: unlink the unix socket file before closing the listening fd.
 /// Unlinking after close would race with another process creating a socket at the same path.
-fn unlinkUnixSocketPath(this: *const Listener) void {
+fn unlinkUnixSocketPath(this: *Listener) void {
     if (this.connection != .unix) return;
+    // Clear the cleanup registration first — this path is now handled by us,
+    // the signal/atexit hook should skip it.
+    UnixSocketCleanup.unregister(this.unix_cleanup_handle);
+    this.unix_cleanup_handle = null;
+
     const path = this.connection.unix;
     // Abstract sockets (Linux) start with a NUL byte and have no filesystem entry.
     if (path.len == 0 or path[0] == 0) return;
@@ -1072,6 +1087,7 @@ const BoringSSL = bun.BoringSSL.c;
 const uv = bun.windows.libuv;
 
 const api = bun.api;
+const UnixSocketCleanup = bun.api.server.UnixSocketCleanup;
 const Handlers = bun.api.SocketHandlers;
 const TCPSocket = bun.api.TCPSocket;
 const TLSSocket = bun.api.TLSSocket;

--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -16,7 +16,7 @@ strong_self: jsc.Strong.Optional = .empty,
 
 /// Registration in the process-global unix socket cleanup list. Non-null
 /// only while a unix-socket listener is active — see UnixSocketCleanup.zig.
-unix_cleanup_handle: ?UnixSocketCleanup.Handle = null,
+#unix_cleanup_handle: ?UnixSocketCleanup.Handle = null,
 
 pub const js = jsc.Codegen.JSListener;
 pub const toJS = js.toJS;
@@ -291,6 +291,15 @@ pub fn listen(globalObject: *jsc.JSGlobalObject, opts: JSValue) bun.JSError!JSVa
         return globalObject.throwValue(err);
     };
 
+    // Register the unix socket path for cleanup as soon as the bind
+    // succeeds and before we do any other work — a signal delivered
+    // between `listenUnix()` returning and the registration call would
+    // otherwise leave the socket path out of the cleanup registry.
+    const unix_cleanup_handle: ?UnixSocketCleanup.Handle = if (connection == .unix)
+        UnixSocketCleanup.register(connection.unix)
+    else
+        null;
+
     var socket: Listener = .{
         .handlers = handlers.*,
         .connection = connection,
@@ -298,6 +307,7 @@ pub fn listen(globalObject: *jsc.JSGlobalObject, opts: JSValue) bun.JSError!JSVa
         .socket_context = socket_context,
         .listener = .{ .uws = listen_socket },
         .protos = if (ssl) |s| s.takeProtos() else null,
+        .#unix_cleanup_handle = unix_cleanup_handle,
     };
 
     if (socket_config.default_data != .zero) {
@@ -320,12 +330,6 @@ pub fn listen(globalObject: *jsc.JSGlobalObject, opts: JSValue) bun.JSError!JSVa
     const this_value = this.toJS(globalObject);
     this.strong_self.set(globalObject, this_value);
     this.poll_ref.ref(handlers.vm);
-
-    // Register the unix socket path for cleanup if the process exits
-    // via a signal without reaching `doStop()`.
-    if (this.connection == .unix) {
-        this.unix_cleanup_handle = UnixSocketCleanup.register(this.connection.unix);
-    }
 
     return this_value;
 }
@@ -492,8 +496,8 @@ fn unlinkUnixSocketPath(this: *Listener) void {
     if (this.connection != .unix) return;
     // Clear the cleanup registration first — this path is now handled by us,
     // the signal/atexit hook should skip it.
-    UnixSocketCleanup.unregister(this.unix_cleanup_handle);
-    this.unix_cleanup_handle = null;
+    UnixSocketCleanup.unregister(this.#unix_cleanup_handle);
+    this.#unix_cleanup_handle = null;
 
     const path = this.connection.unix;
     // Abstract sockets (Linux) start with a NUL byte and have no filesystem entry.

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -535,7 +535,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
         listener: ?*App.ListenSocket = null,
         /// Registration in the process-global unix socket cleanup list. Non-null
         /// only while a unix-socket listener is active — see UnixSocketCleanup.zig.
-        unix_cleanup_handle: ?UnixSocketCleanup.Handle = null,
+        #unix_cleanup_handle: ?UnixSocketCleanup.Handle = null,
         js_value: jsc.JSRef = jsc.JSRef.empty(),
         /// Potentially null before listen() is called, and once .destroy() is called.
         vm: *jsc.VirtualMachine,
@@ -1555,12 +1555,17 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             this.notifyInspectorServerStopped();
 
             if (this.config.address == .unix) {
+                // Tombstone the cleanup registration BEFORE unlinking: a
+                // signal delivered between the two calls would otherwise
+                // see this node as still live and could re-unlink the path
+                // after another process races in and binds a new socket.
+                UnixSocketCleanup.unregister(this.#unix_cleanup_handle);
+                this.#unix_cleanup_handle = null;
+
                 const path = this.config.address.unix;
                 if (path.len > 0 and path[0] != 0) {
                     _ = bun.sys.unlink(path);
                 }
-                UnixSocketCleanup.unregister(this.unix_cleanup_handle);
-                this.unix_cleanup_handle = null;
             }
 
             if (!abrupt) {
@@ -1813,16 +1818,19 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 return this.onListenFailed();
             }
 
+            // Register the unix socket path for cleanup as the very first
+            // thing — a signal delivered between uSockets returning from
+            // bind(2) and this callback running would already be after the
+            // socket file exists on disk, so we want the registry entry
+            // installed before we do any other work.
+            if (this.config.address == .unix) {
+                this.#unix_cleanup_handle = UnixSocketCleanup.register(this.config.address.unix);
+            }
+
             this.listener = socket;
             this.vm.event_loop_handle = Async.Loop.get();
             if (!ssl_enabled)
                 this.vm.addListeningSocketForWatchMode(socket.?.socket().fd());
-
-            // Register the unix socket path for cleanup if the process exits
-            // via a signal without reaching `stopListening()`.
-            if (this.config.address == .unix) {
-                this.unix_cleanup_handle = UnixSocketCleanup.register(this.config.address.unix);
-            }
         }
 
         pub fn ref(this: *ThisServer) void {

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -274,6 +274,7 @@ pub const AnyRoute = union(enum) {
 pub const ServerConfig = @import("./server/ServerConfig.zig");
 pub const ServerWebSocket = @import("./server/ServerWebSocket.zig");
 pub const NodeHTTPResponse = @import("./server/NodeHTTPResponse.zig");
+pub const UnixSocketCleanup = @import("./server/UnixSocketCleanup.zig");
 
 /// State machine to handle loading plugins asynchronously. This structure is not thread-safe.
 const ServePlugins = struct {
@@ -532,6 +533,9 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
         pub const App = uws.NewApp(ssl_enabled);
         app: ?*App = null,
         listener: ?*App.ListenSocket = null,
+        /// Registration in the process-global unix socket cleanup list. Non-null
+        /// only while a unix-socket listener is active — see UnixSocketCleanup.zig.
+        unix_cleanup_handle: ?UnixSocketCleanup.Handle = null,
         js_value: jsc.JSRef = jsc.JSRef.empty(),
         /// Potentially null before listen() is called, and once .destroy() is called.
         vm: *jsc.VirtualMachine,
@@ -1555,6 +1559,8 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 if (path.len > 0 and path[0] != 0) {
                     _ = bun.sys.unlink(path);
                 }
+                UnixSocketCleanup.unregister(this.unix_cleanup_handle);
+                this.unix_cleanup_handle = null;
             }
 
             if (!abrupt) {
@@ -1811,6 +1817,12 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             this.vm.event_loop_handle = Async.Loop.get();
             if (!ssl_enabled)
                 this.vm.addListeningSocketForWatchMode(socket.?.socket().fd());
+
+            // Register the unix socket path for cleanup if the process exits
+            // via a signal without reaching `stopListening()`.
+            if (this.config.address == .unix) {
+                this.unix_cleanup_handle = UnixSocketCleanup.register(this.config.address.unix);
+            }
         }
 
         pub fn ref(this: *ThisServer) void {

--- a/src/bun.js/api/server/UnixSocketCleanup.zig
+++ b/src/bun.js/api/server/UnixSocketCleanup.zig
@@ -1,0 +1,101 @@
+//! Tracks unix domain socket paths that `Bun.serve` / `Bun.listen` currently
+//! own, so they can be unlinked from an `atexit()` hook or a signal handler
+//! if the process terminates without a clean `server.stop()` / `listener.stop()`.
+//!
+//! Design constraints:
+//! - Must be async-signal-safe when walked from a SIGINT/SIGTERM handler.
+//!   `unlink(2)` is on the POSIX async-signal-safe list; anything else we do
+//!   here must avoid malloc/free and lock acquisition.
+//! - Register/unregister is called from the JS main thread, under normal
+//!   circumstances infrequently (one or two unix listeners per process).
+//!
+//! Implementation: append-only singly linked list with CAS at the head.
+//! Unregister just flips an atomic tombstone flag and eagerly calls
+//! `unlink` so the cleanup walk can skip the node. Nodes are never freed
+//! (total leak is bounded by the number of unix listeners ever created in
+//! the process lifetime) — this keeps the signal-handler walk wait-free.
+
+const Node = struct {
+    /// Null-terminated owned slice in `bun.default_allocator`. Never mutated
+    /// or freed after publication so the signal handler can read it safely.
+    path: [:0]const u8,
+    tombstoned: std.atomic.Value(bool),
+    next: std.atomic.Value(?*Node),
+};
+
+var head: std.atomic.Value(?*Node) = .init(null);
+
+/// Opaque handle returned from `register`; pass to `unregister` on clean stop.
+pub const Handle = *Node;
+
+/// Register a unix socket path for cleanup on unexpected process termination.
+///
+/// - `path` is copied into a new null-terminated buffer owned by the registry
+///   (the caller retains its own copy).
+/// - Returns null for empty or abstract (`path[0] == 0`) sockets, since those
+///   have no filesystem entry to remove.
+/// - Safe to call on the main thread during `onListen`.
+pub fn register(path: []const u8) ?Handle {
+    if (path.len == 0 or path[0] == 0) return null;
+
+    const node = bun.default_allocator.create(Node) catch return null;
+    const path_dup = bun.default_allocator.dupeZ(u8, path) catch {
+        bun.default_allocator.destroy(node);
+        return null;
+    };
+
+    node.* = .{
+        .path = path_dup,
+        .tombstoned = .init(false),
+        .next = .init(null),
+    };
+
+    // CAS node into the head of the list.
+    var current = head.load(.acquire);
+    while (true) {
+        node.next.store(current, .release);
+        const res = head.cmpxchgWeak(current, node, .acq_rel, .acquire);
+        if (res == null) break;
+        current = res.?;
+    }
+
+    return node;
+}
+
+/// Mark a node tombstoned so the cleanup walk will skip it. Called from a
+/// clean `stopListening()` path after the path has already been unlinked —
+/// this is purely bookkeeping, it does NOT touch the filesystem.
+///
+/// Nodes are never actually removed from the list (see module docs) so this
+/// is a plain atomic flag set.
+pub fn unregister(handle: ?Handle) void {
+    const node = handle orelse return;
+    node.tombstoned.store(true, .release);
+}
+
+/// Walk the registered-but-not-tombstoned nodes and unlink each path.
+///
+/// Intended to be called from `atexit()` and, via an `extern "C"` shim,
+/// from a SIGINT/SIGTERM handler. Uses only `unlink(2)` on the syscall
+/// path, which is async-signal-safe.
+pub fn cleanupAll() void {
+    var cur = head.load(.acquire);
+    while (cur) |node| : (cur = node.next.load(.acquire)) {
+        if (node.tombstoned.load(.acquire)) continue;
+        // Best-effort: errors here (ENOENT if already removed, EACCES if
+        // chmod'd, etc.) are intentionally swallowed — we're on the
+        // termination path and have no way to report them.
+        _ = bun.sys.unlink(node.path);
+        // Flip the tombstone so a second invocation (e.g. atexit firing
+        // after the signal handler already ran) is a no-op.
+        node.tombstoned.store(true, .release);
+    }
+}
+
+/// C entry point for the atexit hook and signal handler shim.
+pub export fn Bun__cleanupUnixSocketPaths() void {
+    cleanupAll();
+}
+
+const bun = @import("bun");
+const std = @import("std");

--- a/src/bun.js/api/server/UnixSocketCleanup.zig
+++ b/src/bun.js/api/server/UnixSocketCleanup.zig
@@ -86,16 +86,22 @@ pub fn unregister(handle: ?Handle) void {
 /// Walk the registered-but-not-tombstoned nodes and unlink each path.
 ///
 /// Intended to be called from `atexit()` and, via an `extern "C"` shim,
-/// from a SIGINT/SIGTERM handler. Uses only `unlink(2)` on the syscall
-/// path, which is async-signal-safe.
+/// from a SIGINT/SIGTERM handler. We call `unlink(2)` directly via
+/// `std.posix.system.unlink` — `bun.sys.unlink` logs on debug builds
+/// via a scoped logger that takes a mutex and writes to stdio, which is
+/// NOT async-signal-safe and could deadlock/reenter if a signal arrives
+/// while the main thread holds that lock. Raw `unlink(2)` is on the
+/// POSIX async-signal-safe list.
 pub fn cleanupAll() void {
     var cur = head.load(.acquire);
     while (cur) |node| : (cur = node.next.load(.acquire)) {
         if (node.tombstoned.load(.acquire)) continue;
         // Best-effort: errors here (ENOENT if already removed, EACCES if
         // chmod'd, etc.) are intentionally swallowed — we're on the
-        // termination path and have no way to report them.
-        _ = bun.sys.unlink(node.path);
+        // termination path and have no way to report them. We don't
+        // retry on EINTR either: a second signal during exit is going
+        // to be handled by the kernel's default disposition anyway.
+        _ = std.posix.system.unlink(node.path.ptr);
         // Flip the tombstone so a second invocation (e.g. atexit firing
         // after the signal handler already ran) is a no-op.
         node.tombstoned.store(true, .release);

--- a/src/bun.js/api/server/UnixSocketCleanup.zig
+++ b/src/bun.js/api/server/UnixSocketCleanup.zig
@@ -10,8 +10,10 @@
 //!   circumstances infrequently (one or two unix listeners per process).
 //!
 //! Implementation: append-only singly linked list with CAS at the head.
-//! Unregister just flips an atomic tombstone flag and eagerly calls
-//! `unlink` so the cleanup walk can skip the node. Nodes are never freed
+//! `unregister` only flips an atomic tombstone flag (it does NOT touch the
+//! filesystem — the caller is responsible for calling `bun.sys.unlink`
+//! separately, and must do so AFTER `unregister` to close the
+//! tombstone-vs-unlink race; see `unregister` docs). Nodes are never freed
 //! (total leak is bounded by the number of unix listeners ever created in
 //! the process lifetime) — this keeps the signal-handler walk wait-free.
 
@@ -40,8 +42,8 @@ pub fn register(path: []const u8) ?Handle {
 
     // Allocator failures here are OOM-only — crash via `handleOom` rather
     // than silently starting a listener that is missing from the cleanup
-    // registry (which would indistinguishable from the "abstract socket"
-    // early return above).
+    // registry (which would be indistinguishable from the "abstract
+    // socket" early return above).
     const node = bun.handleOom(bun.default_allocator.create(Node));
     const path_dup = bun.handleOom(bun.default_allocator.dupeZ(u8, path));
 
@@ -63,12 +65,19 @@ pub fn register(path: []const u8) ?Handle {
     return node;
 }
 
-/// Mark a node tombstoned so the cleanup walk will skip it. Called from a
-/// clean `stopListening()` path after the path has already been unlinked —
-/// this is purely bookkeeping, it does NOT touch the filesystem.
+/// Mark a node tombstoned so the cleanup walk will skip it. Purely
+/// bookkeeping — this does NOT touch the filesystem. The caller must
+/// still `bun.sys.unlink` the path separately.
 ///
-/// Nodes are never actually removed from the list (see module docs) so this
-/// is a plain atomic flag set.
+/// **Call order matters**: the clean `stopListening()` path MUST call
+/// `unregister` BEFORE `unlink`, not after. If a signal arrives between
+/// `unlink` and `unregister`, the cleanup walk would see the node as
+/// live and re-unlink the path — which would be wrong if another
+/// process has already bound a new socket at the same path in that
+/// window. Tombstoning first closes that race.
+///
+/// Nodes are never actually removed from the list (see module docs) so
+/// this is a plain atomic flag set.
 pub fn unregister(handle: ?Handle) void {
     const node = handle orelse return;
     node.tombstoned.store(true, .release);

--- a/src/bun.js/api/server/UnixSocketCleanup.zig
+++ b/src/bun.js/api/server/UnixSocketCleanup.zig
@@ -92,19 +92,29 @@ pub fn unregister(handle: ?Handle) void {
 /// NOT async-signal-safe and could deadlock/reenter if a signal arrives
 /// while the main thread holds that lock. Raw `unlink(2)` is on the
 /// POSIX async-signal-safe list.
+///
+/// Concurrency: `cleanupAll` can be re-entered — the signal handler may
+/// preempt an in-progress `atexit` walk, since POSIX doesn't block
+/// signals during atexit callbacks. We claim each node with an atomic
+/// compare-and-swap so that only one caller issues `unlink(2)` for a
+/// given path. This matters in the pathological case where another
+/// process binds a new socket at the same path in the nanoseconds
+/// between one caller's `unlink` and a second redundant `unlink` from
+/// the re-entrant walk — the CAS prevents the second call entirely.
 pub fn cleanupAll() void {
     var cur = head.load(.acquire);
     while (cur) |node| : (cur = node.next.load(.acquire)) {
-        if (node.tombstoned.load(.acquire)) continue;
+        // Atomically claim the right to unlink this node. If another
+        // `cleanupAll` caller (or the signal handler preempting us) has
+        // already flipped the tombstone, this CAS returns the old `true`
+        // and we skip. Otherwise we are the sole unlinker for this path.
+        if (node.tombstoned.cmpxchgStrong(false, true, .acq_rel, .acquire) != null) continue;
         // Best-effort: errors here (ENOENT if already removed, EACCES if
         // chmod'd, etc.) are intentionally swallowed — we're on the
         // termination path and have no way to report them. We don't
         // retry on EINTR either: a second signal during exit is going
         // to be handled by the kernel's default disposition anyway.
         _ = std.posix.system.unlink(node.path.ptr);
-        // Flip the tombstone so a second invocation (e.g. atexit firing
-        // after the signal handler already ran) is a no-op.
-        node.tombstoned.store(true, .release);
     }
 }
 

--- a/src/bun.js/api/server/UnixSocketCleanup.zig
+++ b/src/bun.js/api/server/UnixSocketCleanup.zig
@@ -38,11 +38,12 @@ pub const Handle = *Node;
 pub fn register(path: []const u8) ?Handle {
     if (path.len == 0 or path[0] == 0) return null;
 
-    const node = bun.default_allocator.create(Node) catch return null;
-    const path_dup = bun.default_allocator.dupeZ(u8, path) catch {
-        bun.default_allocator.destroy(node);
-        return null;
-    };
+    // Allocator failures here are OOM-only — crash via `handleOom` rather
+    // than silently starting a listener that is missing from the cleanup
+    // registry (which would indistinguishable from the "abstract socket"
+    // early return above).
+    const node = bun.handleOom(bun.default_allocator.create(Node));
+    const path_dup = bun.handleOom(bun.default_allocator.dupeZ(u8, path));
 
     node.* = .{
         .path = path_dup,

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -397,6 +397,8 @@ extern "C" ssize_t pwritev2(int fd, const struct iovec* iov, int iovcnt,
 #endif
 
 extern "C" void Bun__onExit();
+extern "C" void Bun__cleanupUnixSocketPaths();
+extern "C" void Bun__atexit(void (*func)(void));
 extern "C" int32_t bun_stdio_tty[3];
 #if !OS(WINDOWS)
 static termios termios_to_restore_later[3];
@@ -432,6 +434,10 @@ extern "C" void bun_restore_stdio()
 #if !OS(WINDOWS)
 extern "C" void onExitSignal(int sig)
 {
+    // `unlink(2)` is on the POSIX async-signal-safe list, so it is safe to
+    // call from here. The cleanup walks a wait-free linked list and does not
+    // allocate or take locks.
+    Bun__cleanupUnixSocketPaths();
     bun_restore_stdio();
     signal(sig, SIG_DFL);
     raise(sig);
@@ -528,8 +534,13 @@ extern "C" void bun_initialize_process()
         close(devNullFd_);
     }
 
-    // Restore TTY state on exit
-    if (anyTTYs) {
+    // Install the exit signal handler for SIGTERM / SIGINT unconditionally.
+    // It restores TTY state (if any), unlinks any tracked unix-socket paths,
+    // and re-raises the signal with SIG_DFL so the process exits with the
+    // usual signal semantics. We want this even when stdin/stdout/stderr are
+    // not TTYs, so `Bun.serve({ unix: ... })` processes terminated by
+    // SIGTERM still clean up their socket file.
+    {
         struct sigaction sa;
         memset(&sa, 0, sizeof(sa));
         sigemptyset(&sa.sa_mask);
@@ -540,6 +551,7 @@ extern "C" void bun_initialize_process()
         sigaction(SIGTERM, &sa, nullptr);
         sigaction(SIGINT, &sa, nullptr);
     }
+    (void)anyTTYs;
 #elif OS(WINDOWS)
     for (int fd = 0; fd <= 2; ++fd) {
         auto handle = reinterpret_cast<HANDLE>(uv_get_osfhandle(fd));
@@ -583,6 +595,13 @@ extern "C" void bun_initialize_process()
     atexit(Bun__onExit);
 #elif !OS(WINDOWS)
     at_quick_exit(Bun__onExit);
+#endif
+
+#if !OS(WINDOWS)
+    // Ensure any unix-socket paths registered by `Bun.serve` / `Bun.listen`
+    // are removed on a normal `process.exit()` / `std.c.exit`, not just on
+    // a signal. `Bun__atexit` appends to the list walked by `Bun__onExit`.
+    Bun__atexit(Bun__cleanupUnixSocketPaths);
 #endif
 }
 

--- a/test/regression/issue/29166.test.ts
+++ b/test/regression/issue/29166.test.ts
@@ -1,0 +1,115 @@
+// https://github.com/oven-sh/bun/issues/29166
+//
+// `Bun.serve({ unix })` leaves the socket file on disk when the process is
+// killed by SIGTERM/SIGINT, so re-running the same script fails with
+// EADDRINUSE. The fix is a process-global cleanup walk installed on an
+// atexit hook and on the SIGTERM/SIGINT signal handlers.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+// Spawn a child that listens on `socketPath` with `api` ("serve" or "listen"),
+// wait for it to print "ready\n", send it `signal`, then wait for it to exit.
+async function spawnChildAndKill(socketPath: string, api: "serve" | "listen", signal: "SIGTERM" | "SIGINT") {
+  const source =
+    api === "serve"
+      ? `Bun.serve({
+           unix: ${JSON.stringify(socketPath)},
+           fetch() { return new Response("ok"); },
+         });
+         process.stdout.write("ready\\n");`
+      : `Bun.listen({
+           unix: ${JSON.stringify(socketPath)},
+           socket: { data() {}, open() {} },
+         });
+         process.stdout.write("ready\\n");`;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", source],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+
+  // Wait for "ready\n" on stdout — at that point the listener is bound and
+  // the socket file exists.
+  const reader = proc.stdout.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  while (!buf.includes("ready\n")) {
+    const { value, done } = await reader.read();
+    if (done) {
+      const stderr = await proc.stderr.text();
+      throw new Error(`child exited before ready: ${stderr}`);
+    }
+    buf += decoder.decode(value);
+  }
+  reader.releaseLock();
+
+  proc.kill(signal);
+  await proc.exited;
+}
+
+test.skipIf(isWindows)("#29166 Bun.serve(unix) unlinks socket file on SIGTERM", async () => {
+  using dir = tempDir("issue-29166-serve-sigterm", {});
+  const sock = join(String(dir), "EADDRINUSE.sock");
+
+  await spawnChildAndKill(sock, "serve", "SIGTERM");
+
+  // The cleanup walk should have removed the socket file. (Before the fix
+  // this was still present and the next run hit EADDRINUSE.)
+  expect(existsSync(sock)).toBe(false);
+
+  // Re-running the exact same script must succeed — this was the user's
+  // original reproducer.
+  await spawnChildAndKill(sock, "serve", "SIGTERM");
+  expect(existsSync(sock)).toBe(false);
+});
+
+test.skipIf(isWindows)("#29166 Bun.serve(unix) unlinks socket file on SIGINT", async () => {
+  using dir = tempDir("issue-29166-serve-sigint", {});
+  const sock = join(String(dir), "EADDRINUSE.sock");
+
+  await spawnChildAndKill(sock, "serve", "SIGINT");
+
+  expect(existsSync(sock)).toBe(false);
+});
+
+test.skipIf(isWindows)("#29166 Bun.listen(unix) unlinks socket file on SIGTERM", async () => {
+  using dir = tempDir("issue-29166-listen-sigterm", {});
+  const sock = join(String(dir), "EADDRINUSE.sock");
+
+  await spawnChildAndKill(sock, "listen", "SIGTERM");
+
+  expect(existsSync(sock)).toBe(false);
+});
+
+test.skipIf(isWindows)("#29166 Bun.serve(unix) unlinks socket file on process.exit(0)", async () => {
+  using dir = tempDir("issue-29166-serve-exit", {});
+  const sock = join(String(dir), "EADDRINUSE.sock");
+
+  // No explicit server.stop() — rely on the atexit hook.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `Bun.serve({
+         unix: ${JSON.stringify(sock)},
+         fetch() { return new Response("ok"); },
+       });
+       process.exit(0);`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  // The stderr may contain an ASAN warning in debug builds; we only care
+  // that nothing *threw* (i.e. the child exited cleanly with code 0 and
+  // no unrelated error text).
+  expect(stderr).not.toContain("Error");
+  expect(exitCode).toBe(0);
+  expect(existsSync(sock)).toBe(false);
+});

--- a/test/regression/issue/29166.test.ts
+++ b/test/regression/issue/29166.test.ts
@@ -105,11 +105,8 @@ test.skipIf(isWindows)("#29166 Bun.serve(unix) unlinks socket file on process.ex
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-  // The stderr may contain an ASAN warning in debug builds; we only care
-  // that nothing *threw* (i.e. the child exited cleanly with code 0 and
-  // no unrelated error text).
-  expect(stderr).not.toContain("Error");
-  expect(exitCode).toBe(0);
+  const exitCode = await proc.exited;
+  // Behavior assertion first, exit code last.
   expect(existsSync(sock)).toBe(false);
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Repro

```js
// bun /tmp/EADDRINUSE.js
Bun.serve({
  unix: '/tmp/EADDRINUSE.sock',
  fetch: _ => new Response('Hello'),
});
```

Run once, Ctrl+C / `kill %1`, run again → `EADDRINUSE: address already in use`.

## Cause

PR #28798 made clean `server.stop()` / `listener.stop()` unlink the socket file, matching Node.js/libuv semantics. But the unlink only runs on the clean-stop path. If the process is killed by SIGINT/SIGTERM, or exits without calling `.stop()` (the common case — `Bun.serve` keeps the loop alive indefinitely, so Ctrl+C is how you stop it), the socket file is left on disk and the next run EADDRINUSEs.

## Fix

New `src/bun.js/api/server/UnixSocketCleanup.zig` — a process-global wait-free linked list of live unix-listener paths. Registered in `onListen`, cleared on clean stop. Walked from:

- an `atexit` / `at_quick_exit` hook (covers `process.exit()` and implicit end-of-script termination).
- the SIGTERM / SIGINT handler in `c-bindings.cpp`, now installed unconditionally (previously only if stdio was a TTY). `unlink(2)` is on the POSIX async-signal-safe list, and the registry uses no allocation or locking on the walk path, so calling it from the signal handler is safe.

Abstract sockets (Linux, `path[0] == 0`) and Windows named pipes are skipped — they have no filesystem entry.

## Verification

New regression test `test/regression/issue/29166.test.ts` spawns a child running the user's exact script, kills it with SIGTERM / SIGINT, and asserts the socket file is gone. Also covers `Bun.listen` and the `process.exit(0)` path. Before this commit all four fail; after, all four pass. Existing `test/js/bun/net/unix-socket-unlink.test.ts` (9 tests) still pass.

Fixes #29166.