### PR TITLE
Fix stack overflow when inspecting JSX elements with circular references

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -1136,7 +1136,7 @@ pub const Formatter = struct {
 
         pub fn canHaveCircularReferences(tag: Tag) bool {
             return switch (tag) {
-                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event => true,
+                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event, .JSX => true,
                 else => false,
             };
         }
@@ -3130,13 +3130,12 @@ pub const Formatter = struct {
                     }
                 }
 
-                if (try value.get(this.globalThis, "props")) |props| {
+                if (try value.get(this.globalThis, "props")) |props| props_block: {
                     const prev_quote_strings = this.quote_strings;
                     defer this.quote_strings = prev_quote_strings;
                     this.quote_strings = true;
 
-                    // SAFETY: JSX props are always objects
-                    const props_obj = props.getObject().?;
+                    const props_obj = props.getObject() orelse break :props_block;
                     var props_iter = try jsc.JSPropertyIterator(.{
                         .skip_empty_name = true,
                         .include_value = true,

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -326,7 +326,7 @@ pub const JestPrettyFormat = struct {
             }
 
             pub inline fn canHaveCircularReferences(tag: Tag) bool {
-                return tag == .Array or tag == .Object or tag == .Map or tag == .Set;
+                return tag == .Array or tag == .Object or tag == .Map or tag == .Set or tag == .JSX;
             }
 
             const Result = struct {
@@ -1536,13 +1536,12 @@ pub const JestPrettyFormat = struct {
                         }
                     }
 
-                    if (try value.get(this.globalThis, "props")) |props| {
+                    if (try value.get(this.globalThis, "props")) |props| props_block: {
                         const prev_quote_strings = this.quote_strings;
                         defer this.quote_strings = prev_quote_strings;
                         this.quote_strings = true;
 
-                        // SAFETY: JSX props are always an object.
-                        const props_obj = props.getObject().?;
+                        const props_obj = props.getObject() orelse break :props_block;
                         var props_iter = try jsc.JSPropertyIterator(.{
                             .skip_empty_name = true,
                             .include_value = true,

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,6 +316,25 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
+it("jsx with circular references does not crash", () => {
+  const a = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null };
+  a.props = a;
+  expect(Bun.inspect(a)).toContain("[Circular]");
+
+  const b = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: {} };
+  b.props.children = b;
+  expect(Bun.inspect(b)).toContain("[Circular]");
+
+  const c = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: {} };
+  c.key = c;
+  expect(Bun.inspect(c)).toContain("[Circular]");
+});
+
+it("jsx with non-object props does not crash", () => {
+  const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: 42 };
+  expect(Bun.inspect(el)).toBe("<div />");
+});
+
 it("inspect", () => {
   expect(Bun.inspect(new TypeError("what")).includes("TypeError: what")).toBe(true);
   expect(Bun.inspect("hi")).toBe('"hi"');


### PR DESCRIPTION
Fuzzer found a segfault when calling `Bun.inspect()` on a React element whose `props` (or `key`, or `props.children`) contains a reference back to the element itself:

```js
const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null };
el.props = el;
Bun.inspect(el); // segfault (stack overflow)
```

The `.JSX` formatter tag was missing from `canHaveCircularReferences()`, so neither the visited-map cycle detection nor the stack guard was applied when formatting JSX elements. The formatter would recurse into `props` → format the same JSX element → recurse into `props` → … until the stack blew.

While in the area, also fixed a related panic: `props.getObject().?` assumed `props` is always an object, but a user-constructed element can have `props: 42` and would hit `attempt to use null value`. Now it just skips props iteration and renders `<div />`.

Same fixes applied to both `ConsoleObject.zig` (Bun.inspect/console.log) and `test/pretty_format.zig` (test matcher formatting).

Fuzzer fingerprint: `2b73926abbed374a`