### PR TITLE
Fix stack overflow when inspecting circular JSX elements

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -1136,7 +1136,7 @@ pub const Formatter = struct {
 
         pub fn canHaveCircularReferences(tag: Tag) bool {
             return switch (tag) {
-                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event => true,
+                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event, .JSX => true,
                 else => false,
             };
         }
@@ -3130,13 +3130,11 @@ pub const Formatter = struct {
                     }
                 }
 
-                if (try value.get(this.globalThis, "props")) |props| {
+                if (try value.get(this.globalThis, "props")) |props| if (props.getObject()) |props_obj| {
                     const prev_quote_strings = this.quote_strings;
                     defer this.quote_strings = prev_quote_strings;
                     this.quote_strings = true;
 
-                    // SAFETY: JSX props are always objects
-                    const props_obj = props.getObject().?;
                     var props_iter = try jsc.JSPropertyIterator(.{
                         .skip_empty_name = true,
                         .include_value = true,
@@ -3293,7 +3291,7 @@ pub const Formatter = struct {
                             }
                         }
                     }
-                }
+                };
 
                 writer.writeAll(" />");
             },

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -326,7 +326,7 @@ pub const JestPrettyFormat = struct {
             }
 
             pub inline fn canHaveCircularReferences(tag: Tag) bool {
-                return tag == .Array or tag == .Object or tag == .Map or tag == .Set;
+                return tag == .Array or tag == .Object or tag == .Map or tag == .Set or tag == .JSX;
             }
 
             const Result = struct {
@@ -1536,13 +1536,11 @@ pub const JestPrettyFormat = struct {
                         }
                     }
 
-                    if (try value.get(this.globalThis, "props")) |props| {
+                    if (try value.get(this.globalThis, "props")) |props| if (props.getObject()) |props_obj| {
                         const prev_quote_strings = this.quote_strings;
                         defer this.quote_strings = prev_quote_strings;
                         this.quote_strings = true;
 
-                        // SAFETY: JSX props are always an object.
-                        const props_obj = props.getObject().?;
                         var props_iter = try jsc.JSPropertyIterator(.{
                             .skip_empty_name = true,
                             .include_value = true,
@@ -1693,7 +1691,7 @@ pub const JestPrettyFormat = struct {
                                 }
                             }
                         }
-                    }
+                    };
 
                     writer.writeAll(" />");
                 },

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { normalizeBunSnapshot, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tmpdirSync } from "harness";
 import { join } from "path";
 import util from "util";
 it("prototype", () => {
@@ -739,4 +739,44 @@ it("CustomEvent", () => {
       BUBBLING_PHASE: 3,
     }"
   `);
+});
+
+describe("JSX element edge cases", () => {
+  it("does not crash on circular JSX element or non-object props", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const a = { $$typeof: Symbol.for("react.element"), type: "div" };
+          a.props = a;
+          console.log(Bun.inspect(a));
+
+          const b = { $$typeof: Symbol.for("react.element"), type: "span" };
+          b.props = { children: b };
+          console.log(Bun.inspect(b));
+
+          const c = { $$typeof: Symbol.for("react.element"), type: "p" };
+          c.props = { children: [c] };
+          console.log(Bun.inspect(c));
+
+          const d = { $$typeof: Symbol.for("react.element"), type: "i", props: 42 };
+          console.log(Bun.inspect(d));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toContain("[Circular]");
+    expect(stdout).toContain("<i />");
+    expect(exitCode).toBe(0);
+  });
+
+  it("circular JSX prints [Circular]", () => {
+    const el = { $$typeof: Symbol.for("react.element"), type: "div" };
+    el.props = { children: el };
+    expect(Bun.inspect(el)).toContain("[Circular]");
+  });
 });


### PR DESCRIPTION
## What

`Bun.inspect()` / `console.log()` would crash with a stack overflow (SIGSEGV) when a React element contained a circular reference through its `props` or `children`.

```js
const el = { $$typeof: Symbol.for("react.element"), type: "div" };
el.props = el;
Bun.inspect(el); // segfault
```

## Why

The `.JSX` tag was not included in `canHaveCircularReferences()`, so the formatter skipped both the visited-set check and the `isSafeToRecurse()` stack guard when recursing into JSX props/children. A cycle would recurse until the native stack was exhausted.

While here, also guard against non-object `props` instead of unwrapping with `.?`, which would panic with "attempt to use null value" in debug builds.

Both fixes applied to `ConsoleObject.zig` and `pretty_format.zig`.

Fuzzer fingerprint: `d8d53c93d7954f20`