### PR TITLE
fix(url): reject malformed percent-encoding in fileURLToPath

### DIFF
--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -932,12 +932,24 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
 
         // Node.js implements fileURLToPath via decodeURIComponent on the
         // pathname, which throws URIError: URI malformed for any '%' not
-        // followed by two hex digits. WTF::URL::fileSystemPath uses a lenient
-        // decoder, so validate strictly here to match Node.
+        // followed by two hex digits AND for percent sequences that decode
+        // to invalid UTF-8 (e.g. lone continuation bytes, truncated
+        // multibyte sequences, overlong encodings). WTF::URL::fileSystemPath
+        // is lenient on both counts, so validate strictly here.
         const unsigned pathLen = p.length();
+
+        // Walk the pathname, decoding %XX into a byte buffer so we can
+        // hand it to simdutf::validate_utf8. Non-percent characters are
+        // always ASCII at this point because WHATWG URL percent-encodes
+        // every non-ASCII byte when building the pathname.
+        Vector<uint8_t, 256> decoded;
+        decoded.reserveInitialCapacity(pathLen);
         for (unsigned i = 0; i < pathLen; ++i) {
-            if (p[i] != '%')
+            char16_t c = p[i];
+            if (c != '%') {
+                decoded.append(static_cast<uint8_t>(c));
                 continue;
+            }
             if (i + 2 >= pathLen) {
                 scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_URI, "URI malformed"_s));
                 return {};
@@ -948,6 +960,13 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
                 scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_URI, "URI malformed"_s));
                 return {};
             }
+            decoded.append(toASCIIHexValue(hi, lo));
+            i += 2;
+        }
+        auto decodedSpan = decoded.span();
+        if (!simdutf::validate_utf8(reinterpret_cast<const char*>(decodedSpan.data()), decodedSpan.size())) {
+            scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_URI, "URI malformed"_s));
+            return {};
         }
     }
 

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -934,11 +934,17 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
         // pathname, which throws URIError: URI malformed for any '%' not
         // followed by two hex digits. WTF::URL::fileSystemPath uses a lenient
         // decoder, so validate strictly here to match Node.
-        const size_t length = p.length();
-        for (size_t i = 0; i < length; ++i) {
+        const unsigned pathLen = p.length();
+        for (unsigned i = 0; i < pathLen; ++i) {
             if (p[i] != '%')
                 continue;
-            if (i + 2 >= length || !WTF::isASCIIHexDigit(p[i + 1]) || !WTF::isASCIIHexDigit(p[i + 2])) {
+            if (i + 2 >= pathLen) {
+                scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_URI, "URI malformed"_s));
+                return {};
+            }
+            char16_t hi = p[i + 1];
+            char16_t lo = p[i + 2];
+            if (!isASCIIHexDigit(hi) || !isASCIIHexDigit(lo)) {
                 scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_URI, "URI malformed"_s));
                 return {};
             }

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -21,6 +21,7 @@
 #include <JavaScriptCore/DateInstance.h>
 #include <JavaScriptCore/JSONObject.h>
 #include "wtf/SIMDUTF.h"
+#include <wtf/ASCIICType.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include "headers.h"
 #include "BunObject.h"
@@ -928,6 +929,20 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
             return {};
         }
 #endif
+
+        // Node.js implements fileURLToPath via decodeURIComponent on the
+        // pathname, which throws URIError: URI malformed for any '%' not
+        // followed by two hex digits. WTF::URL::fileSystemPath uses a lenient
+        // decoder, so validate strictly here to match Node.
+        const size_t length = p.length();
+        for (size_t i = 0; i < length; ++i) {
+            if (p[i] != '%')
+                continue;
+            if (i + 2 >= length || !WTF::isASCIIHexDigit(p[i + 1]) || !WTF::isASCIIHexDigit(p[i + 2])) {
+                scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_URI, "URI malformed"_s));
+                return {};
+            }
+        }
     }
 
     auto fileSystemPath = url.fileSystemPath();

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -932,12 +932,24 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
 
         // Node.js implements fileURLToPath via decodeURIComponent on the
         // pathname, which throws URIError: URI malformed for any '%' not
-        // followed by two hex digits. WTF::URL::fileSystemPath uses a lenient
-        // decoder, so validate strictly here to match Node.
+        // followed by two hex digits AND for percent sequences that decode
+        // to invalid UTF-8 (e.g. lone continuation bytes, truncated
+        // multibyte sequences, overlong encodings). WTF::URL::fileSystemPath
+        // is lenient on both counts, so validate strictly here.
         const unsigned pathLen = p.length();
+
+        // Walk the pathname, decoding %XX into a byte buffer so we can
+        // hand it to simdutf::validate_utf8. Non-percent characters are
+        // always ASCII at this point because WHATWG URL percent-encodes
+        // every non-ASCII byte when building the pathname.
+        Vector<uint8_t, 256> decoded;
+        decoded.reserveInitialCapacity(pathLen);
         for (unsigned i = 0; i < pathLen; ++i) {
-            if (p[i] != '%')
+            char16_t c = p[i];
+            if (c != '%') {
+                decoded.append(static_cast<uint8_t>(c));
                 continue;
+            }
             if (i + 2 >= pathLen) {
                 scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_URI, "URI malformed"_s));
                 return {};
@@ -948,6 +960,13 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
                 scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_URI, "URI malformed"_s));
                 return {};
             }
+            decoded.append(toASCIIHexValue(hi, lo));
+            i += 2;
+        }
+        auto decodedSpan = decoded.span();
+        if (!simdutf::validate_utf8(reinterpret_cast<const char*>(decodedSpan.data()), decodedSpan.size())) {
+            scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_URI, "URI malformed"_s));
+            return {};
         }
     }
 

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -934,11 +934,17 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
         // pathname, which throws URIError: URI malformed for any '%' not
         // followed by two hex digits. WTF::URL::fileSystemPath uses a lenient
         // decoder, so validate strictly here to match Node.
-        const size_t length = p.length();
-        for (size_t i = 0; i < length; ++i) {
+        const unsigned pathLen = p.length();
+        for (unsigned i = 0; i < pathLen; ++i) {
             if (p[i] != '%')
                 continue;
-            if (i + 2 >= length || !WTF::isASCIIHexDigit(p[i + 1]) || !WTF::isASCIIHexDigit(p[i + 2])) {
+            if (i + 2 >= pathLen) {
+                scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_URI, "URI malformed"_s));
+                return {};
+            }
+            char16_t hi = p[i + 1];
+            char16_t lo = p[i + 2];
+            if (!isASCIIHexDigit(hi) || !isASCIIHexDigit(lo)) {
                 scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_URI, "URI malformed"_s));
                 return {};
             }

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -21,6 +21,7 @@
 #include <JavaScriptCore/DateInstance.h>
 #include <JavaScriptCore/JSONObject.h>
 #include "wtf/SIMDUTF.h"
+#include <wtf/ASCIICType.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/JSObjectInlines.h>
 #include "headers.h"
@@ -928,6 +929,20 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
             return {};
         }
 #endif
+
+        // Node.js implements fileURLToPath via decodeURIComponent on the
+        // pathname, which throws URIError: URI malformed for any '%' not
+        // followed by two hex digits. WTF::URL::fileSystemPath uses a lenient
+        // decoder, so validate strictly here to match Node.
+        const size_t length = p.length();
+        for (size_t i = 0; i < length; ++i) {
+            if (p[i] != '%')
+                continue;
+            if (i + 2 >= length || !WTF::isASCIIHexDigit(p[i + 1]) || !WTF::isASCIIHexDigit(p[i + 2])) {
+                scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_URI, "URI malformed"_s));
+                return {};
+            }
+        }
     }
 
     auto fileSystemPath = url.fileSystemPath();

--- a/test/regression/issue/29174.test.ts
+++ b/test/regression/issue/29174.test.ts
@@ -16,6 +16,13 @@ describe("fileURLToPath rejects malformed percent encoding (#29174)", () => {
     "file:///tmp/%.txt", // % followed by non-hex
     "file:///tmp/%", // lone trailing %
     "file:///%", // lone % at root
+    // Percent-encodings that are syntactically valid but decode to
+    // invalid UTF-8. Node's decodeURIComponent throws URIError on these,
+    // and we match that behavior.
+    "file:///tmp/%E0%A4", // truncated multi-byte sequence
+    "file:///tmp/%C0%80", // overlong encoding of NUL
+    "file:///tmp/%80", // lone continuation byte
+    "file:///tmp/%FE", // invalid start byte
   ];
 
   for (const input of malformed) {
@@ -57,6 +64,9 @@ describe("fileURLToPath rejects malformed percent encoding (#29174)", () => {
     expect(fileURLToPath("file:///tmp/%20space.txt")).toBe("/tmp/ space.txt");
     expect(fileURLToPath("file:///tmp/a%7Eb.txt")).toBe("/tmp/a~b.txt");
     expect(fileURLToPath("file:///tmp/%7e.txt")).toBe("/tmp/~.txt");
+    // Valid multi-byte UTF-8 sequences should decode fine.
+    expect(fileURLToPath("file:///tmp/%E0%A4%AD")).toBe("/tmp/भ");
+    expect(fileURLToPath("file:///tmp/%C3%A9")).toBe("/tmp/é");
   });
 
   test.skipIf(isWindows)("paths with no percent encoding are untouched (posix)", () => {

--- a/test/regression/issue/29174.test.ts
+++ b/test/regression/issue/29174.test.ts
@@ -5,6 +5,7 @@
 // followed by a space. Node.js throws `URIError: URI malformed` for any `%`
 // that is not followed by two hex digits, via `decodeURIComponent`.
 import { describe, expect, test } from "bun:test";
+import { isWindows } from "harness";
 import { fileURLToPath } from "node:url";
 
 describe("fileURLToPath rejects malformed percent encoding (#29174)", () => {
@@ -49,14 +50,27 @@ describe("fileURLToPath rejects malformed percent encoding (#29174)", () => {
     );
   });
 
-  test("valid percent encoding still works", () => {
+  // These use POSIX-shaped paths (`/tmp/...`). On Windows `fileURLToPath`
+  // rejects those as non-absolute (`ERR_INVALID_FILE_URL_PATH`), so the
+  // decoding assertions only make sense on posix platforms.
+  test.skipIf(isWindows)("valid percent encoding still works (posix)", () => {
     expect(fileURLToPath("file:///tmp/%20space.txt")).toBe("/tmp/ space.txt");
     expect(fileURLToPath("file:///tmp/a%7Eb.txt")).toBe("/tmp/a~b.txt");
     expect(fileURLToPath("file:///tmp/%7e.txt")).toBe("/tmp/~.txt");
   });
 
-  test("paths with no percent encoding are untouched", () => {
+  test.skipIf(isWindows)("paths with no percent encoding are untouched (posix)", () => {
     expect(fileURLToPath("file:///tmp/plain.txt")).toBe("/tmp/plain.txt");
+  });
+
+  test.if(isWindows)("valid percent encoding still works (windows)", () => {
+    expect(fileURLToPath("file:///C:/%20space.txt")).toBe("C:\\ space.txt");
+    expect(fileURLToPath("file:///C:/a%7Eb.txt")).toBe("C:\\a~b.txt");
+    expect(fileURLToPath("file:///C:/%7e.txt")).toBe("C:\\~.txt");
+  });
+
+  test.if(isWindows)("paths with no percent encoding are untouched (windows)", () => {
+    expect(fileURLToPath("file:///C:/plain.txt")).toBe("C:\\plain.txt");
   });
 
   test("encoded slash still throws ERR_INVALID_FILE_URL_PATH (unchanged)", () => {

--- a/test/regression/issue/29174.test.ts
+++ b/test/regression/issue/29174.test.ts
@@ -1,0 +1,70 @@
+// https://github.com/oven-sh/bun/issues/29174
+//
+// Bun's `fileURLToPath` was delegating to WebKit's lenient percent-decoder,
+// which silently interpreted malformed sequences like `%%20` as a literal `%`
+// followed by a space. Node.js throws `URIError: URI malformed` for any `%`
+// that is not followed by two hex digits, via `decodeURIComponent`.
+import { describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+describe("fileURLToPath rejects malformed percent encoding (#29174)", () => {
+  const malformed = [
+    "file:///tmp/%%20users.txt", // % followed by another %
+    "file:///tmp/%GG.txt", // non-hex digits
+    "file:///tmp/%2.txt", // single hex digit then non-hex
+    "file:///tmp/%.txt", // % followed by non-hex
+    "file:///tmp/%", // lone trailing %
+    "file:///%", // lone % at root
+  ];
+
+  for (const input of malformed) {
+    test(`string input: ${input}`, () => {
+      expect(() => fileURLToPath(input)).toThrow(
+        expect.objectContaining({
+          name: "URIError",
+          code: "ERR_INVALID_URI",
+          message: "URI malformed",
+        }),
+      );
+    });
+
+    test(`URL input: ${input}`, () => {
+      expect(() => fileURLToPath(new URL(input))).toThrow(
+        expect.objectContaining({
+          name: "URIError",
+          code: "ERR_INVALID_URI",
+          message: "URI malformed",
+        }),
+      );
+    });
+  }
+
+  test("round-trip through `% users.txt` throws like Node", () => {
+    const url = new URL("file:///tmp/%%20users.txt");
+    expect(() => fileURLToPath(url)).toThrow(
+      expect.objectContaining({
+        name: "URIError",
+        code: "ERR_INVALID_URI",
+      }),
+    );
+  });
+
+  test("valid percent encoding still works", () => {
+    expect(fileURLToPath("file:///tmp/%20space.txt")).toBe("/tmp/ space.txt");
+    expect(fileURLToPath("file:///tmp/a%7Eb.txt")).toBe("/tmp/a~b.txt");
+    expect(fileURLToPath("file:///tmp/%7e.txt")).toBe("/tmp/~.txt");
+  });
+
+  test("paths with no percent encoding are untouched", () => {
+    expect(fileURLToPath("file:///tmp/plain.txt")).toBe("/tmp/plain.txt");
+  });
+
+  test("encoded slash still throws ERR_INVALID_FILE_URL_PATH (unchanged)", () => {
+    expect(() => fileURLToPath("file:///tmp/%2Fhack")).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_FILE_URL_PATH" }),
+    );
+    expect(() => fileURLToPath("file:///tmp/%2fhack")).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_FILE_URL_PATH" }),
+    );
+  });
+});

--- a/test/regression/issue/29174.test.ts
+++ b/test/regression/issue/29174.test.ts
@@ -1,9 +1,4 @@
 // https://github.com/oven-sh/bun/issues/29174
-//
-// Bun's `fileURLToPath` was delegating to WebKit's lenient percent-decoder,
-// which silently interpreted malformed sequences like `%%20` as a literal `%`
-// followed by a space. Node.js throws `URIError: URI malformed` for any `%`
-// that is not followed by two hex digits, via `decodeURIComponent`.
 import { describe, expect, test } from "bun:test";
 import { isWindows } from "harness";
 import { fileURLToPath } from "node:url";


### PR DESCRIPTION
Fixes #29174.

## Reproduction

```js
import { fileURLToPath } from 'node:url';
fileURLToPath('file:///tmp/%%20users.txt');
```

**Node.js:** throws `URIError: URI malformed`.
**Bun (before):** silently returned `/tmp/% users.txt`.

## Cause

`functionFileURLToPath` in `src/bun.js/bindings/BunObject.cpp` was handing the URL pathname to WebKit's `WTF::URL::fileSystemPath()`, which uses a lenient percent-decoder that treats invalid sequences as literal characters. Node, in contrast, implements `fileURLToPath` via `decodeURIComponent(pathname)` which throws `URIError: URI malformed` for any `%` not followed by exactly two hex digits.

## Fix

Before the call to `url.fileSystemPath()`, iterate the pathname and throw `ERR_INVALID_URI` (a `URIError` with message `URI malformed`, matching Node) if any `%` is not followed by two hex digits. The existing encoded-slash check (`%2F`, `%5C`) still runs first, preserving Node's error precedence.

## Verification

`test/regression/issue/29174.test.ts` — 16 cases covering:

- malformed sequences: `%%20`, `%GG`, `%2.`, `%.`, lone trailing `%`, lone `/%`
- valid encoding still decodes: `%20`, `%7E`
- unencoded paths untouched
- encoded slash still throws `ERR_INVALID_FILE_URL_PATH` (unchanged)

Each case was cross-checked against Node.js — same error name (`URIError`), `code`, and `message`.
