### PR TITLE
feat(worker_threads): implement markAsUntransferable and validate transfer lists

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -114,6 +114,40 @@ const _MessagePort = globalThis.MessagePort;
 injectFakeEmitter(_MessagePort);
 
 const MessagePort = _MessagePort;
+const untransferableObjects = new WeakSet<object>();
+
+function isObjectLike(value: unknown): value is object {
+  return (typeof value === "object" && value !== null) || typeof value === "function";
+}
+
+function throwDataCloneError(message = "Cannot transfer object of unsupported type.") {
+  throw new DOMException(message, "DataCloneError");
+}
+
+function validateTransferList(transferList: unknown) {
+  if (!transferList || !isObjectLike(transferList)) {
+    return;
+  }
+
+  const iterator = transferList[Symbol.iterator];
+  if (typeof iterator !== "function") {
+    return;
+  }
+
+  for (const transferable of transferList as Iterable<unknown>) {
+    if (isObjectLike(transferable) && untransferableObjects.has(transferable)) {
+      throwDataCloneError();
+    }
+  }
+}
+
+const messagePortPostMessage = MessagePort.prototype.postMessage;
+Object.defineProperty(MessagePort.prototype, "postMessage", {
+  value(...args: [any, any]) {
+    validateTransferList(args[1]);
+    return messagePortPostMessage.$apply(this, args);
+  },
+});
 
 let resourceLimits = {};
 
@@ -151,6 +185,7 @@ function fakeParentPort() {
   const postMessage = $newCppFunction("ZigGlobalObject.cpp", "jsFunctionPostMessage", 1);
   Object.defineProperty(fake, "postMessage", {
     value(...args: [any, any]) {
+      validateTransferList(args[1]);
       return postMessage.$apply(null, args);
     },
   });
@@ -215,8 +250,10 @@ function setEnvironmentData(key: unknown, value: unknown): void {
   }
 }
 
-function markAsUntransferable() {
-  throwNotImplemented("worker_threads.markAsUntransferable");
+function markAsUntransferable(object?: unknown) {
+  if (isObjectLike(object)) {
+    untransferableObjects.add(object);
+  }
 }
 
 function moveMessagePortToContext() {
@@ -234,6 +271,8 @@ class Worker extends EventEmitter {
 
   constructor(filename: string, options: NodeWorkerOptions = {}) {
     super();
+
+    validateTransferList(options.transferList);
 
     const builtinsGeneratorHatesEval = "ev" + "a" + "l"[0];
     if (options && builtinsGeneratorHatesEval in options) {
@@ -341,6 +380,7 @@ class Worker extends EventEmitter {
   }
 
   postMessage(...args: [any, any]) {
+    validateTransferList(args[1]);
     return this.#worker.postMessage.$apply(this.#worker, args);
   }
 

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -142,11 +142,15 @@ function validateTransferList(transferList: unknown) {
 }
 
 const messagePortPostMessage = MessagePort.prototype.postMessage;
+const messagePortPostMessageDescriptor = Object.getOwnPropertyDescriptor(MessagePort.prototype, "postMessage");
+function postMessage(this: MessagePort, message: any, transfer: any) {
+  validateTransferList(transfer);
+  return messagePortPostMessage.$apply(this, arguments);
+}
+Object.defineProperty(postMessage, "length", { value: messagePortPostMessage.length });
 Object.defineProperty(MessagePort.prototype, "postMessage", {
-  value(...args: [any, any]) {
-    validateTransferList(args[1]);
-    return messagePortPostMessage.$apply(this, args);
-  },
+  ...messagePortPostMessageDescriptor,
+  value: postMessage,
 });
 
 let resourceLimits = {};
@@ -272,7 +276,7 @@ class Worker extends EventEmitter {
   constructor(filename: string, options: NodeWorkerOptions = {}) {
     super();
 
-    validateTransferList(options.transferList);
+    validateTransferList(options?.transferList);
 
     const builtinsGeneratorHatesEval = "ev" + "a" + "l"[0];
     if (options && builtinsGeneratorHatesEval in options) {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -124,27 +124,32 @@ function throwDataCloneError(message = "Cannot transfer object of unsupported ty
   throw new DOMException(message, "DataCloneError");
 }
 
-function validateTransferList(transferList: unknown) {
+function validateTransferList(transferList: unknown): unknown[] | undefined {
   if (!transferList || !isObjectLike(transferList)) {
-    return;
+    return undefined;
   }
 
   const iterator = transferList[Symbol.iterator];
   if (typeof iterator !== "function") {
-    return;
+    return undefined;
   }
 
-  for (const transferable of transferList as Iterable<unknown>) {
+  const items = Array.isArray(transferList) ? transferList : Array.from(transferList as Iterable<unknown>);
+  for (const transferable of items) {
     if (isObjectLike(transferable) && untransferableObjects.has(transferable)) {
       throwDataCloneError();
     }
   }
+  return items;
 }
 
 const messagePortPostMessage = MessagePort.prototype.postMessage;
 const messagePortPostMessageDescriptor = Object.getOwnPropertyDescriptor(MessagePort.prototype, "postMessage");
 function postMessage(this: MessagePort, message: any, transfer: any) {
-  validateTransferList(transfer);
+  const normalized = validateTransferList(transfer);
+  if (normalized && normalized !== transfer) {
+    return messagePortPostMessage.$apply(this, [message, normalized]);
+  }
   return messagePortPostMessage.$apply(this, arguments);
 }
 Object.defineProperty(postMessage, "length", { value: messagePortPostMessage.length });
@@ -189,7 +194,10 @@ function fakeParentPort() {
   const postMessage = $newCppFunction("ZigGlobalObject.cpp", "jsFunctionPostMessage", 1);
   Object.defineProperty(fake, "postMessage", {
     value(...args: [any, any]) {
-      validateTransferList(args[1]);
+      const normalized = validateTransferList(args[1]);
+      if (normalized && normalized !== args[1]) {
+        return postMessage.$apply(null, [args[0], normalized]);
+      }
       return postMessage.$apply(null, args);
     },
   });
@@ -276,7 +284,10 @@ class Worker extends EventEmitter {
   constructor(filename: string, options: NodeWorkerOptions = {}) {
     super();
 
-    validateTransferList(options?.transferList);
+    const normalizedTransferList = validateTransferList(options?.transferList);
+    if (normalizedTransferList && normalizedTransferList !== options.transferList) {
+      options = { ...options, transferList: normalizedTransferList as any };
+    }
 
     const builtinsGeneratorHatesEval = "ev" + "a" + "l"[0];
     if (options && builtinsGeneratorHatesEval in options) {
@@ -384,7 +395,10 @@ class Worker extends EventEmitter {
   }
 
   postMessage(...args: [any, any]) {
-    validateTransferList(args[1]);
+    const normalized = validateTransferList(args[1]);
+    if (normalized && normalized !== args[1]) {
+      return this.#worker.postMessage.$apply(this.#worker, [args[0], normalized]);
+    }
     return this.#worker.postMessage.$apply(this.#worker, args);
   }
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -67,13 +67,41 @@ test("all worker_threads module properties are present", () => {
 
   expect(() => {
     // @ts-expect-error no args
-    wt.markAsUntransferable();
-  }).toThrow("not yet implemented");
-
-  expect(() => {
-    // @ts-expect-error no args
     wt.moveMessagePortToContext();
   }).toThrow("not yet implemented");
+});
+
+test("markAsUntransferable rejects marked ArrayBuffers in MessagePort transfer lists", () => {
+  const { port1, port2 } = new MessageChannel();
+  port2.once("message", () => {
+    expect().fail("message handler must not be called");
+  });
+
+  const view = new Uint8Array([1, 2, 3, 4]);
+  markAsUntransferable(view.buffer);
+
+  expect(() => {
+    port1.postMessage(view, [view.buffer]);
+  }).toThrow(new DOMException("Cannot transfer object of unsupported type.", "DataCloneError"));
+
+  expect(Array.from(view)).toStrictEqual([1, 2, 3, 4]);
+  expect(view.byteLength).toBe(4);
+  port1.close();
+  port2.close();
+});
+
+test("markAsUntransferable rejects marked ArrayBuffers in Worker transfer lists", async () => {
+  const worker = new Worker(`onmessage = () => {};`, { eval: true });
+  const view = new Uint8Array([1, 2, 3, 4]);
+  markAsUntransferable(view.buffer);
+
+  expect(() => {
+    worker.postMessage(view, [view.buffer]);
+  }).toThrow(new DOMException("Cannot transfer object of unsupported type.", "DataCloneError"));
+
+  expect(Array.from(view)).toStrictEqual([1, 2, 3, 4]);
+  expect(view.byteLength).toBe(4);
+  await worker.terminate();
 });
 
 test("all worker_threads worker instance properties are present", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -320,7 +320,7 @@ test("eval does not leak source code", async () => {
   const errors = await proc.stderr.text();
   if (errors.length > 0) throw new Error(errors);
   expect(proc.exitCode).toBe(0);
-});
+}, 30000);
 
 describe("worker event", () => {
   test("is emitted on the next tick with the right value", () => {


### PR DESCRIPTION
## Summary
Implement `worker_threads.markAsUntransferable()` in Bun's Node compatibility layer and reject marked objects when they appear in `MessagePort` and `Worker` transfer lists.

## Why
Bun previously exposed `markAsUntransferable()` but did not implement it. This change adds the missing behavior and covers the Node-facing transfer paths that should throw `DataCloneError` for marked objects.

## Testing
- `BUN_DEBUG_QUIET_LOGS=1 bun bd --asan=off test test/js/node/worker_threads/worker_threads.test.ts`
- `BUN_DEBUG_QUIET_LOGS=1 bun bd --asan=off test test/js/node/worker_threads/worker_threads.test.ts -t "markAsUntransferable rejects"`
- `USE_SYSTEM_BUN=1 bun test test/js/node/worker_threads/worker_threads.test.ts -t "markAsUntransferable rejects"`

## Notes
- Increased the timeout for the existing `eval does not leak source code` test because the debug+harness subprocess path takes about 19 seconds locally even when the fixture succeeds.
- The default `bun bd test ...` path still hits an ASan smoke-check abort on this machine, so validation was done with `--asan=off`.
