### PR TITLE
fix(expect): propagate exception from custom asymmetric matcher in asymmetricMatch

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -1689,51 +1689,49 @@ pub const ExpectCustomAsymmetricMatcher = struct {
         return instance_jsvalue;
     }
 
-    /// Function called by c++ function "matchAsymmetricMatcher" to execute the custom matcher against the provided leftValue
-    pub fn execute(this: *ExpectCustomAsymmetricMatcher, thisValue: JSValue, globalThis: *JSGlobalObject, received: JSValue) callconv(.c) bool {
+    fn executeImpl(this: *ExpectCustomAsymmetricMatcher, thisValue: JSValue, globalThis: *JSGlobalObject, received: JSValue) bun.JSError!bool {
         // retrieve the user-provided matcher implementation function (the function passed to expect.extend({ ... }))
         const matcher_fn: JSValue = js.matcherFnGetCached(thisValue) orelse {
-            globalThis.throw("Internal consistency error: the ExpectCustomAsymmetricMatcher(matcherFn) was garbage collected but it should not have been!", .{}) catch {};
-            return false;
+            return globalThis.throw("Internal consistency error: the ExpectCustomAsymmetricMatcher(matcherFn) was garbage collected but it should not have been!", .{});
         };
         matcher_fn.ensureStillAlive();
         if (!matcher_fn.jsType().isFunction()) {
-            globalThis.throw("Internal consistency error: the ExpectCustomMatcher(matcherFn) is not a function!", .{}) catch {};
-            return false;
+            return globalThis.throw("Internal consistency error: the ExpectCustomMatcher(matcherFn) is not a function!", .{});
         }
 
         // retrieve the matcher name
-        const matcher_name = matcher_fn.getName(globalThis) catch {
-            return false;
-        };
+        const matcher_name = try matcher_fn.getName(globalThis);
 
         // retrieve the asymmetric matcher args
         // if null, it means the function has not yet been called to capture the args, which is a misuse of the matcher
         const captured_args: JSValue = js.capturedArgsGetCached(thisValue) orelse {
-            globalThis.throw("expect.{f} misused, it needs to be instantiated by calling it with 0 or more arguments", .{matcher_name}) catch {};
-            return false;
+            return globalThis.throw("expect.{f} misused, it needs to be instantiated by calling it with 0 or more arguments", .{matcher_name});
         };
         captured_args.ensureStillAlive();
 
         // prepare the args array as `[received, ...captured_args]`
-        const args_count = captured_args.getLength(globalThis) catch return false;
+        const args_count = try captured_args.getLength(globalThis);
         var allocator = std.heap.stackFallback(8 * @sizeOf(JSValue), globalThis.allocator());
         var matcher_args = std.array_list.Managed(JSValue).initCapacity(allocator.get(), args_count + 1) catch {
-            globalThis.throwOutOfMemory() catch {};
-            return false;
+            return globalThis.throwOutOfMemory();
         };
         matcher_args.appendAssumeCapacity(received);
         for (0..args_count) |i| {
-            matcher_args.appendAssumeCapacity(captured_args.getIndex(globalThis, @truncate(i)) catch return false);
+            matcher_args.appendAssumeCapacity(try captured_args.getIndex(globalThis, @truncate(i)));
         }
 
-        return Expect.executeCustomMatcher(globalThis, matcher_name, matcher_fn, matcher_args.items, this.flags, true) catch false;
+        return Expect.executeCustomMatcher(globalThis, matcher_name, matcher_fn, matcher_args.items, this.flags, true);
+    }
+
+    /// Function called by c++ function "matchAsymmetricMatcher" to execute the custom matcher against the provided leftValue
+    pub fn execute(this: *ExpectCustomAsymmetricMatcher, thisValue: JSValue, globalThis: *JSGlobalObject, received: JSValue) callconv(.c) bool {
+        return executeImpl(this, thisValue, globalThis, received) catch false;
     }
 
     pub fn asymmetricMatch(this: *ExpectCustomAsymmetricMatcher, globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
         const arguments = callframe.arguments_old(1).slice();
         const received_value = if (arguments.len < 1) .js_undefined else arguments[0];
-        const matched = execute(this, callframe.this(), globalThis, received_value);
+        const matched = try executeImpl(this, callframe.this(), globalThis, received_value);
         return JSValue.jsBoolean(matched);
     }
 

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -1734,6 +1734,7 @@ pub const ExpectCustomAsymmetricMatcher = struct {
         const arguments = callframe.arguments_old(1).slice();
         const received_value = if (arguments.len < 1) .js_undefined else arguments[0];
         const matched = execute(this, callframe.this(), globalThis, received_value);
+        if (globalThis.hasException()) return error.JSError;
         return JSValue.jsBoolean(matched);
     }
 

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -1689,52 +1689,49 @@ pub const ExpectCustomAsymmetricMatcher = struct {
         return instance_jsvalue;
     }
 
-    /// Function called by c++ function "matchAsymmetricMatcher" to execute the custom matcher against the provided leftValue
-    pub fn execute(this: *ExpectCustomAsymmetricMatcher, thisValue: JSValue, globalThis: *JSGlobalObject, received: JSValue) callconv(.c) bool {
+    fn executeImpl(this: *ExpectCustomAsymmetricMatcher, thisValue: JSValue, globalThis: *JSGlobalObject, received: JSValue) bun.JSError!bool {
         // retrieve the user-provided matcher implementation function (the function passed to expect.extend({ ... }))
         const matcher_fn: JSValue = js.matcherFnGetCached(thisValue) orelse {
-            globalThis.throw("Internal consistency error: the ExpectCustomAsymmetricMatcher(matcherFn) was garbage collected but it should not have been!", .{}) catch {};
-            return false;
+            return globalThis.throw("Internal consistency error: the ExpectCustomAsymmetricMatcher(matcherFn) was garbage collected but it should not have been!", .{});
         };
         matcher_fn.ensureStillAlive();
         if (!matcher_fn.jsType().isFunction()) {
-            globalThis.throw("Internal consistency error: the ExpectCustomMatcher(matcherFn) is not a function!", .{}) catch {};
-            return false;
+            return globalThis.throw("Internal consistency error: the ExpectCustomMatcher(matcherFn) is not a function!", .{});
         }
 
         // retrieve the matcher name
-        const matcher_name = matcher_fn.getName(globalThis) catch {
-            return false;
-        };
+        const matcher_name = try matcher_fn.getName(globalThis);
 
         // retrieve the asymmetric matcher args
         // if null, it means the function has not yet been called to capture the args, which is a misuse of the matcher
         const captured_args: JSValue = js.capturedArgsGetCached(thisValue) orelse {
-            globalThis.throw("expect.{f} misused, it needs to be instantiated by calling it with 0 or more arguments", .{matcher_name}) catch {};
-            return false;
+            return globalThis.throw("expect.{f} misused, it needs to be instantiated by calling it with 0 or more arguments", .{matcher_name});
         };
         captured_args.ensureStillAlive();
 
         // prepare the args array as `[received, ...captured_args]`
-        const args_count = captured_args.getLength(globalThis) catch return false;
+        const args_count = try captured_args.getLength(globalThis);
         var allocator = std.heap.stackFallback(8 * @sizeOf(JSValue), globalThis.allocator());
         var matcher_args = std.array_list.Managed(JSValue).initCapacity(allocator.get(), args_count + 1) catch {
-            globalThis.throwOutOfMemory() catch {};
-            return false;
+            return globalThis.throwOutOfMemory();
         };
         matcher_args.appendAssumeCapacity(received);
         for (0..args_count) |i| {
-            matcher_args.appendAssumeCapacity(captured_args.getIndex(globalThis, @truncate(i)) catch return false);
+            matcher_args.appendAssumeCapacity(try captured_args.getIndex(globalThis, @truncate(i)));
         }
 
-        return Expect.executeCustomMatcher(globalThis, matcher_name, matcher_fn, matcher_args.items, this.flags, true) catch false;
+        return Expect.executeCustomMatcher(globalThis, matcher_name, matcher_fn, matcher_args.items, this.flags, true);
+    }
+
+    /// Function called by c++ function "matchAsymmetricMatcher" to execute the custom matcher against the provided leftValue
+    pub fn execute(this: *ExpectCustomAsymmetricMatcher, thisValue: JSValue, globalThis: *JSGlobalObject, received: JSValue) callconv(.c) bool {
+        return executeImpl(this, thisValue, globalThis, received) catch false;
     }
 
     pub fn asymmetricMatch(this: *ExpectCustomAsymmetricMatcher, globalThis: *JSGlobalObject, callframe: *CallFrame) bun.JSError!JSValue {
         const arguments = callframe.arguments_old(1).slice();
         const received_value = if (arguments.len < 1) .js_undefined else arguments[0];
-        const matched = execute(this, callframe.this(), globalThis, received_value);
-        if (globalThis.hasException()) return error.JSError;
+        const matched = try executeImpl(this, callframe.this(), globalThis, received_value);
         return JSValue.jsBoolean(matched);
     }
 

--- a/test/js/bun/test/expect-extend-asymmetric-match-throw.test.ts
+++ b/test/js/bun/test/expect-extend-asymmetric-match-throw.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test";
+
+test("asymmetricMatch propagates exceptions thrown by the matcher", () => {
+  expect.extend({
+    _toThrowOnMatch() {
+      throw new Error("boom from matcher");
+    },
+  });
+  // @ts-expect-error: _toThrowOnMatch is registered dynamically via expect.extend
+  const matcher = expect._toThrowOnMatch();
+  expect(() => matcher.asymmetricMatch({})).toThrow("boom from matcher");
+});

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -379,16 +379,6 @@ it("works on classes", () => {
   expect(123)._toBeBar();
 });
 
-it("asymmetricMatch propagates exceptions thrown by the matcher", () => {
-  expect.extend({
-    _toThrowOnMatch() {
-      throw new Error("boom from matcher");
-    },
-  });
-  const matcher = expect._toThrowOnMatch();
-  expect(() => matcher.asymmetricMatch({})).toThrow("boom from matcher");
-});
-
 test("expect.extend with numeric index keys does not crash", () => {
   // Numeric keys are valid array indices. putDirect asserts they are not indices,
   // so putMayBeIndex must be used instead. Without the fix, putDirect incorrectly

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -379,6 +379,16 @@ it("works on classes", () => {
   expect(123)._toBeBar();
 });
 
+it("asymmetricMatch propagates exceptions thrown by the matcher", () => {
+  expect.extend({
+    _toThrowOnMatch() {
+      throw new Error("boom from matcher");
+    },
+  });
+  const matcher = expect._toThrowOnMatch();
+  expect(() => matcher.asymmetricMatch({})).toThrow("boom from matcher");
+});
+
 test("expect.extend with numeric index keys does not crash", () => {
   // Numeric keys are valid array indices. putDirect asserts they are not indices,
   // so putMayBeIndex must be used instead. Without the fix, putDirect incorrectly


### PR DESCRIPTION
## What does this PR do?

Fuzzilli found a debug assertion crash (fingerprint `3c2ad38d8c96b67d`) where calling `.asymmetricMatch()` on a custom asymmetric matcher whose implementation throws triggers:

```
ASSERTION FAILED: Unexpected exception observed
!exception()
ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

### Root cause

`ExpectCustomAsymmetricMatcher.execute()` is a `callconv(.c)` function (shared with the C++ deep-equals path) that handles errors with `catch false` / `catch return false`. This swallows the Zig `error.JSError` but leaves the JSC exception pending on the VM.

`asymmetricMatch()` then returned `JSValue.jsBoolean(matched)` — a non-zero value — while a JSC exception was still pending. The host-function wrapper asserts that a non-zero return implies no pending exception, and tripped `releaseAssertNoException()`.

### Fix

After calling `execute()`, check `globalThis.hasException()` and return `error.JSError` so the exception is properly propagated to JavaScript instead of returning a stale boolean.

### Repro

```js
const { expect } = Bun.jest(import.meta.path);
expect.extend({
  myMatcher() { throw new Error("boom"); },
});
expect.myMatcher().asymmetricMatch({}); // previously: assertion crash in debug builds
```

## How did you verify your code works?

- Minimal repro above crashes on `build/debug-fuzz/bun-debug` (before), throws a catchable JS error (after).
- Added regression test in `test/js/bun/test/expect-extend.test.js` which crashes the unfixed debug build and passes with the fix.
- Full `expect-extend.test.js` suite passes (aside from pre-existing "intensive usage" timeout that also fails on the unfixed build due to debug-build slowness).