### PR TITLE
serve: consolidate file streaming into FileResponseStream; Range support; fix aborted-stream hang

### DIFF
--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -363,7 +363,10 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
     n.blank();
     const archiveName = `${cfg.libPrefix}${exeName}${cfg.libSuffix}`;
     const archive = ar(n, cfg, archiveName, allObjects);
-    n.phony("bun", [archive]);
+    // depLibs explicit in the phony: deps with no provided includes (tinycc,
+    // lolhtml) aren't in depHeaderSignal, so the archive doesn't pull them
+    // transitively — but link-only still needs them uploaded.
+    n.phony("bun", [archive, ...depLibs]);
     n.default(["bun"]);
     return { archive, deps, codegen, zigObjects, objects: allObjects };
   }

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -19,6 +19,8 @@ pub fn writeStatus(comptime ssl: bool, resp_ptr: ?*uws.NewApp(ssl).Response, sta
 // TODO: rename to StaticBlobRoute? the html bundle is sometimes a static route
 pub const StaticRoute = @import("./server/StaticRoute.zig");
 pub const FileRoute = @import("./server/FileRoute.zig");
+pub const FileResponseStream = @import("./server/FileResponseStream.zig");
+pub const RangeRequest = @import("./server/RangeRequest.zig");
 
 pub const AnyRoute = union(enum) {
     /// Serve a static file

--- a/src/bun.js/api/server/FileResponseStream.zig
+++ b/src/bun.js/api/server/FileResponseStream.zig
@@ -1,0 +1,385 @@
+//! Streams an already-open file descriptor to a uWS `AnyResponse`, handling
+//! backpressure, client aborts, and fd lifetime. Shared by `FileRoute` (static
+//! file routes) and `RequestContext` (file-blob bodies returned from `fetch`
+//! handlers) so both get the same abort-safe lifecycle and so the SSL/Windows
+//! path streams instead of buffering the whole file.
+//!
+//! The caller writes status + headers first, then hands off body streaming by
+//! calling `start()`. Exactly one of `on_complete` / `on_error` fires, exactly
+//! once; after it fires the caller must not touch `resp` body methods again.
+
+const FileResponseStream = @This();
+
+ref_count: RefCount,
+resp: AnyResponse,
+vm: *jsc.VirtualMachine,
+fd: bun.FD,
+auto_close: bool,
+idle_timeout: u8,
+
+ctx: *anyopaque,
+on_complete: *const fn (*anyopaque, AnyResponse) void,
+on_error: *const fn (*anyopaque, AnyResponse, bun.sys.Error) void,
+
+mode: Mode,
+reader: bun.io.BufferedReader = bun.io.BufferedReader.init(FileResponseStream),
+max_size: ?u64 = null,
+eof_task: ?jsc.AnyTask = null,
+sendfile: Sendfile = .{},
+
+state: packed struct(u8) {
+    response_done: bool = false,
+    finished: bool = false,
+    errored: bool = false,
+    resp_detached: bool = false,
+    _: u4 = 0,
+} = .{},
+
+const Mode = enum { reader, sendfile };
+
+const Sendfile = struct {
+    socket_fd: bun.FD = bun.invalid_fd,
+    remain: u64 = 0,
+    offset: u64 = 0,
+    has_set_on_writable: bool = false,
+};
+
+pub const StartOptions = struct {
+    fd: bun.FD,
+    auto_close: bool = true,
+    resp: AnyResponse,
+    vm: *jsc.VirtualMachine,
+    file_type: bun.io.FileType,
+    pollable: bool,
+    /// Byte offset into the file to begin reading from.
+    offset: u64 = 0,
+    /// Maximum bytes to send; `null` reads to EOF. For regular files this
+    /// should be `stat.size - offset` (after Range/slice clamping).
+    length: ?u64 = null,
+    idle_timeout: u8,
+    ctx: *anyopaque,
+    on_complete: *const fn (*anyopaque, AnyResponse) void,
+    on_error: *const fn (*anyopaque, AnyResponse, bun.sys.Error) void,
+};
+
+pub fn start(opts: StartOptions) void {
+    const use_sendfile = canSendfile(opts.resp, opts.file_type, opts.length);
+
+    var this = bun.new(FileResponseStream, .{
+        .ref_count = .init(),
+        .resp = opts.resp,
+        .vm = opts.vm,
+        .fd = opts.fd,
+        .auto_close = opts.auto_close,
+        .idle_timeout = opts.idle_timeout,
+        .ctx = opts.ctx,
+        .on_complete = opts.on_complete,
+        .on_error = opts.on_error,
+        .mode = if (use_sendfile) .sendfile else .reader,
+    });
+
+    this.resp.timeout(this.idle_timeout);
+    this.resp.onAborted(*FileResponseStream, onAborted, this);
+
+    log("start mode={s} len={?d}", .{ @tagName(this.mode), opts.length });
+
+    if (use_sendfile) {
+        this.sendfile = .{
+            .socket_fd = opts.resp.getNativeHandle(),
+            .offset = opts.offset,
+            .remain = opts.length.?,
+        };
+        this.resp.prepareForSendfile();
+        _ = this.onSendfile();
+        return;
+    }
+
+    // BufferedReader path
+    this.max_size = opts.length;
+    this.reader.flags.close_handle = false; // we own fd via auto_close
+    this.reader.flags.pollable = opts.pollable;
+    this.reader.flags.nonblocking = opts.file_type != .file;
+    if (comptime bun.Environment.isPosix) {
+        if (opts.file_type == .socket) this.reader.flags.socket = true;
+    }
+    this.reader.setParent(this);
+
+    this.ref();
+    defer this.deref();
+
+    switch (if (opts.offset > 0)
+        this.reader.startFileOffset(this.fd, opts.pollable, opts.offset)
+    else
+        this.reader.start(this.fd, opts.pollable)) {
+        .err => |err| {
+            this.failWith(err);
+            return;
+        },
+        .result => {},
+    }
+
+    this.reader.updateRef(true);
+
+    if (comptime bun.Environment.isPosix) {
+        if (this.reader.handle.getPoll()) |poll| {
+            if (this.reader.flags.nonblocking) poll.flags.insert(.nonblocking);
+            switch (opts.file_type) {
+                .socket => poll.flags.insert(.socket),
+                .nonblocking_pipe, .pipe => poll.flags.insert(.fifo),
+                .file => {},
+            }
+        }
+    }
+
+    // hold a ref for the in-flight read; released in onReaderDone/onReaderError
+    this.ref();
+    this.reader.read();
+}
+
+fn canSendfile(resp: AnyResponse, file_type: bun.io.FileType, length: ?u64) bool {
+    if (comptime bun.Environment.isWindows) return false;
+    if (resp == .SSL) return false;
+    if (file_type != .file) return false;
+    const len = length orelse return false;
+    // Below ~1MB the syscall + dual-readiness overhead doesn't pay off.
+    return len >= 1 << 20;
+}
+
+// ───────────────────────── reader backend ─────────────────────────
+
+pub fn onReadChunk(this: *FileResponseStream, chunk_: []const u8, state_: bun.io.ReadState) bool {
+    this.ref();
+    defer this.deref();
+
+    if (this.state.response_done) return false;
+
+    const chunk, const state = brk: {
+        if (this.max_size) |*max| {
+            const c = chunk_[0..@min(chunk_.len, max.*)];
+            max.* -|= c.len;
+            if (state_ != .eof and max.* == 0) {
+                if (comptime !bun.Environment.isPosix) this.reader.pause();
+                this.eof_task = jsc.AnyTask.New(FileResponseStream, FileResponseStream.onReaderDone).init(this);
+                this.vm.eventLoop().enqueueTask(jsc.Task.init(&this.eof_task.?));
+                break :brk .{ c, .eof };
+            }
+            break :brk .{ c, state_ };
+        }
+        break :brk .{ chunk_, state_ };
+    };
+
+    this.resp.timeout(this.idle_timeout);
+
+    if (state == .eof) {
+        this.state.response_done = true;
+        this.detachResp();
+        this.resp.end(chunk, this.resp.shouldCloseConnection());
+        this.on_complete(this.ctx, this.resp);
+        return false;
+    }
+
+    switch (this.resp.write(chunk)) {
+        .backpressure => {
+            // release the read ref; onWritable re-takes it
+            defer this.deref();
+            this.resp.onWritable(*FileResponseStream, onWritable, this);
+            if (comptime !bun.Environment.isPosix) this.reader.pause();
+            return false;
+        },
+        .want_more => return true,
+    }
+}
+
+pub fn onReaderDone(this: *FileResponseStream) void {
+    defer this.deref();
+    this.finish();
+}
+
+pub fn onReaderError(this: *FileResponseStream, err: bun.sys.Error) void {
+    defer this.deref();
+    this.failWith(err);
+}
+
+fn onWritable(this: *FileResponseStream, _: u64, _: AnyResponse) bool {
+    log("onWritable", .{});
+    this.ref();
+    defer this.deref();
+
+    if (this.mode == .sendfile) return this.onSendfile();
+
+    if (this.reader.isDone()) {
+        this.finish();
+        return true;
+    }
+    this.resp.timeout(this.idle_timeout);
+    this.ref();
+    this.reader.read();
+    return true;
+}
+
+// ───────────────────────── sendfile backend ─────────────────────────
+
+fn onSendfile(this: *FileResponseStream) bool {
+    log("onSendfile remain={d} offset={d}", .{ this.sendfile.remain, this.sendfile.offset });
+    if (this.state.response_done) {
+        this.finish();
+        return false;
+    }
+
+    const adjusted = @min(this.sendfile.remain, @as(u64, std.math.maxInt(i32)));
+
+    if (comptime bun.Environment.isLinux) {
+        var off: i64 = @intCast(this.sendfile.offset);
+        const rc = std.os.linux.sendfile(
+            this.sendfile.socket_fd.cast(),
+            this.fd.cast(),
+            &off,
+            adjusted,
+        );
+        const errno = bun.sys.getErrno(rc);
+        const sent: u64 = @intCast(@max(@as(i64, @intCast(off)) - @as(i64, @intCast(this.sendfile.offset)), 0));
+        this.sendfile.offset = @intCast(off);
+        this.sendfile.remain -|= sent;
+
+        if (errno == .AGAIN) return this.armSendfileWritable();
+        if (errno != .SUCCESS) {
+            this.failWith(.{ .errno = @intFromEnum(errno), .syscall = .sendfile, .fd = this.fd });
+            return false;
+        }
+        if (this.sendfile.remain == 0 or sent == 0) {
+            this.endSendfile();
+            return false;
+        }
+        return this.armSendfileWritable();
+    } else if (comptime bun.Environment.isMac) {
+        var sbytes: std.posix.off_t = @intCast(adjusted);
+        const errno = bun.sys.getErrno(std.c.sendfile(
+            this.fd.cast(),
+            this.sendfile.socket_fd.cast(),
+            @intCast(this.sendfile.offset),
+            &sbytes,
+            null,
+            0,
+        ));
+        const sent: u64 = @intCast(sbytes);
+        this.sendfile.offset += sent;
+        this.sendfile.remain -|= sent;
+
+        if (errno == .AGAIN) return this.armSendfileWritable();
+        if (errno != .SUCCESS and errno != .PIPE and errno != .NOTCONN) {
+            this.failWith(.{ .errno = @intFromEnum(errno), .syscall = .sendfile, .fd = this.fd });
+            return false;
+        }
+        if (this.sendfile.remain == 0 or sent == 0 or errno == .PIPE or errno == .NOTCONN) {
+            this.endSendfile();
+            return false;
+        }
+        return this.armSendfileWritable();
+    } else {
+        unreachable; // canSendfile gates this
+    }
+}
+
+fn armSendfileWritable(this: *FileResponseStream) bool {
+    log("armSendfileWritable", .{});
+    if (!this.sendfile.has_set_on_writable) {
+        this.sendfile.has_set_on_writable = true;
+        this.resp.onWritable(*FileResponseStream, onWritable, this);
+    }
+    this.resp.markNeedsMore();
+    return true;
+}
+
+fn endSendfile(this: *FileResponseStream) void {
+    log("endSendfile", .{});
+    if (this.state.response_done) return;
+    this.state.response_done = true;
+    this.detachResp();
+    this.resp.endSendFile(this.sendfile.offset, this.resp.shouldCloseConnection());
+    this.on_complete(this.ctx, this.resp);
+    this.finish();
+}
+
+// ───────────────────────── lifecycle ─────────────────────────
+
+fn onAborted(this: *FileResponseStream, _: AnyResponse) void {
+    log("onAborted", .{});
+    if (!this.state.response_done) {
+        this.state.response_done = true;
+        this.detachResp();
+        this.on_complete(this.ctx, this.resp);
+    }
+    this.finish();
+}
+
+fn failWith(this: *FileResponseStream, err: bun.sys.Error) void {
+    if (!this.state.response_done) {
+        this.state.response_done = true;
+        this.state.errored = true;
+        this.detachResp();
+        this.resp.forceClose();
+        this.on_error(this.ctx, this.resp, err);
+    }
+    this.finish();
+}
+
+/// Clear all uWS callbacks pointing at us. Must run while `resp` is still
+/// live (i.e., before `resp.end()` / `endSendFile()` / `forceClose()` give the
+/// socket back to uWS, which may free it on the next loop tick). After this
+/// runs, `finish()` — which can be reached from the deferred `eof_task` —
+/// will not touch `resp` again.
+fn detachResp(this: *FileResponseStream) void {
+    if (this.state.resp_detached) return;
+    this.state.resp_detached = true;
+    this.resp.clearOnWritable();
+    this.resp.clearAborted();
+    this.resp.clearTimeout();
+}
+
+fn finish(this: *FileResponseStream) void {
+    log("finish (already={})", .{this.state.finished});
+    if (this.state.finished) return;
+    this.state.finished = true;
+
+    if (!this.state.response_done) {
+        this.state.response_done = true;
+        this.detachResp();
+        this.resp.endWithoutBody(this.resp.shouldCloseConnection());
+        this.on_complete(this.ctx, this.resp);
+    }
+
+    this.deref();
+}
+
+fn deinit(this: *FileResponseStream) void {
+    log("deinit", .{});
+    if (this.mode == .reader) this.reader.deinit();
+    if (this.auto_close) {
+        bun.Async.Closer.close(this.fd, if (comptime bun.Environment.isWindows) bun.windows.libuv.Loop.get());
+    }
+    bun.destroy(this);
+}
+
+pub fn eventLoop(this: *FileResponseStream) jsc.EventLoopHandle {
+    return jsc.EventLoopHandle.init(this.vm.eventLoop());
+}
+
+pub fn loop(this: *FileResponseStream) *Async.Loop {
+    if (comptime bun.Environment.isWindows) {
+        return this.eventLoop().loop().uv_loop;
+    }
+    return this.eventLoop().loop();
+}
+
+const RefCount = bun.ptr.RefCount(@This(), "ref_count", deinit, .{});
+pub const ref = RefCount.ref;
+pub const deref = RefCount.deref;
+
+const log = bun.Output.scoped(.FileResponseStream, .hidden);
+
+const std = @import("std");
+const bun = @import("bun");
+const jsc = bun.jsc;
+const Async = bun.Async;
+const uws = bun.uws;
+const AnyResponse = uws.AnyResponse;

--- a/src/bun.js/api/server/FileResponseStream.zig
+++ b/src/bun.js/api/server/FileResponseStream.zig
@@ -378,8 +378,10 @@ pub const deref = RefCount.deref;
 const log = bun.Output.scoped(.FileResponseStream, .hidden);
 
 const std = @import("std");
+
 const bun = @import("bun");
-const jsc = bun.jsc;
 const Async = bun.Async;
+const jsc = bun.jsc;
+
 const uws = bun.uws;
 const AnyResponse = uws.AnyResponse;

--- a/src/bun.js/api/server/FileResponseStream.zig
+++ b/src/bun.js/api/server/FileResponseStream.zig
@@ -19,6 +19,7 @@ idle_timeout: u8,
 
 ctx: *anyopaque,
 on_complete: *const fn (*anyopaque, AnyResponse) void,
+on_abort: ?*const fn (*anyopaque, AnyResponse) void,
 on_error: *const fn (*anyopaque, AnyResponse, bun.sys.Error) void,
 
 mode: Mode,
@@ -59,6 +60,9 @@ pub const StartOptions = struct {
     idle_timeout: u8,
     ctx: *anyopaque,
     on_complete: *const fn (*anyopaque, AnyResponse) void,
+    /// Fires instead of `on_complete` when the client disconnects mid-stream.
+    /// If null, abort is reported via `on_complete`.
+    on_abort: ?*const fn (*anyopaque, AnyResponse) void = null,
     on_error: *const fn (*anyopaque, AnyResponse, bun.sys.Error) void,
 };
 
@@ -74,6 +78,7 @@ pub fn start(opts: StartOptions) void {
         .idle_timeout = opts.idle_timeout,
         .ctx = opts.ctx,
         .on_complete = opts.on_complete,
+        .on_abort = opts.on_abort,
         .on_error = opts.on_error,
         .mode = if (use_sendfile) .sendfile else .reader,
     });
@@ -307,7 +312,7 @@ fn onAborted(this: *FileResponseStream, _: AnyResponse) void {
     if (!this.state.response_done) {
         this.state.response_done = true;
         this.detachResp();
-        this.on_complete(this.ctx, this.resp);
+        (this.on_abort orelse this.on_complete)(this.ctx, this.resp);
     }
     this.finish();
 }

--- a/src/bun.js/api/server/FileResponseStream.zig
+++ b/src/bun.js/api/server/FileResponseStream.zig
@@ -231,55 +231,72 @@ fn onSendfile(this: *FileResponseStream) bool {
         return false;
     }
 
-    const adjusted = @min(this.sendfile.remain, @as(u64, std.math.maxInt(i32)));
-
     if (comptime bun.Environment.isLinux) {
-        var off: i64 = @intCast(this.sendfile.offset);
-        const rc = std.os.linux.sendfile(
-            this.sendfile.socket_fd.cast(),
-            this.fd.cast(),
-            &off,
-            adjusted,
-        );
-        const errno = bun.sys.getErrno(rc);
-        const sent: u64 = @intCast(@max(@as(i64, @intCast(off)) - @as(i64, @intCast(this.sendfile.offset)), 0));
-        this.sendfile.offset = @intCast(off);
-        this.sendfile.remain -|= sent;
+        while (true) {
+            const adjusted = @min(this.sendfile.remain, @as(u64, std.math.maxInt(i32)));
+            var off: i64 = @intCast(this.sendfile.offset);
+            const rc = std.os.linux.sendfile(
+                this.sendfile.socket_fd.cast(),
+                this.fd.cast(),
+                &off,
+                adjusted,
+            );
+            const errno = bun.sys.getErrno(rc);
+            const sent: u64 = @intCast(@max(@as(i64, @intCast(off)) - @as(i64, @intCast(this.sendfile.offset)), 0));
+            this.sendfile.offset = @intCast(off);
+            this.sendfile.remain -|= sent;
 
-        if (errno == .AGAIN) return this.armSendfileWritable();
-        if (errno != .SUCCESS) {
-            this.failWith(.{ .errno = @intFromEnum(errno), .syscall = .sendfile, .fd = this.fd });
-            return false;
+            switch (errno) {
+                .SUCCESS => {
+                    if (this.sendfile.remain == 0 or sent == 0) {
+                        this.endSendfile();
+                        return false;
+                    }
+                    return this.armSendfileWritable();
+                },
+                .INTR => continue,
+                .AGAIN => return this.armSendfileWritable(),
+                else => {
+                    this.failWith(.{ .errno = @intFromEnum(errno), .syscall = .sendfile, .fd = this.fd });
+                    return false;
+                },
+            }
         }
-        if (this.sendfile.remain == 0 or sent == 0) {
-            this.endSendfile();
-            return false;
-        }
-        return this.armSendfileWritable();
     } else if (comptime bun.Environment.isMac) {
-        var sbytes: std.posix.off_t = @intCast(adjusted);
-        const errno = bun.sys.getErrno(std.c.sendfile(
-            this.fd.cast(),
-            this.sendfile.socket_fd.cast(),
-            @intCast(this.sendfile.offset),
-            &sbytes,
-            null,
-            0,
-        ));
-        const sent: u64 = @intCast(sbytes);
-        this.sendfile.offset += sent;
-        this.sendfile.remain -|= sent;
+        while (true) {
+            var sbytes: std.posix.off_t = @intCast(@min(this.sendfile.remain, @as(u64, std.math.maxInt(i32))));
+            const errno = bun.sys.getErrno(std.c.sendfile(
+                this.fd.cast(),
+                this.sendfile.socket_fd.cast(),
+                @intCast(this.sendfile.offset),
+                &sbytes,
+                null,
+                0,
+            ));
+            const sent: u64 = @intCast(sbytes);
+            this.sendfile.offset += sent;
+            this.sendfile.remain -|= sent;
 
-        if (errno == .AGAIN) return this.armSendfileWritable();
-        if (errno != .SUCCESS and errno != .PIPE and errno != .NOTCONN) {
-            this.failWith(.{ .errno = @intFromEnum(errno), .syscall = .sendfile, .fd = this.fd });
-            return false;
+            switch (errno) {
+                .SUCCESS => {
+                    if (this.sendfile.remain == 0 or sent == 0) {
+                        this.endSendfile();
+                        return false;
+                    }
+                    return this.armSendfileWritable();
+                },
+                .INTR => continue,
+                .AGAIN => return this.armSendfileWritable(),
+                .PIPE, .NOTCONN => {
+                    this.endSendfile();
+                    return false;
+                },
+                else => {
+                    this.failWith(.{ .errno = @intFromEnum(errno), .syscall = .sendfile, .fd = this.fd });
+                    return false;
+                },
+            }
         }
-        if (this.sendfile.remain == 0 or sent == 0 or errno == .PIPE or errno == .NOTCONN) {
-            this.endSendfile();
-            return false;
-        }
-        return this.armSendfileWritable();
     } else {
         unreachable; // canSendfile gates this
     }

--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -8,6 +8,7 @@ status_code: u16,
 stat_hash: bun.fs.StatHash = .{},
 has_last_modified_header: bool,
 has_content_length_header: bool,
+has_content_range_header: bool,
 
 pub const InitOptions = struct {
     server: ?AnyServer,
@@ -43,6 +44,7 @@ pub fn initFromBlob(blob: Blob, opts: InitOptions) *FileRoute {
         .headers = headers,
         .has_last_modified_header = headers.get("last-modified") != null,
         .has_content_length_header = headers.get("content-length") != null,
+        .has_content_range_header = headers.get("content-range") != null,
         .status_code = opts.status_code,
     });
 }
@@ -80,6 +82,7 @@ pub fn fromJS(globalThis: *jsc.JSGlobalObject, argument: jsc.JSValue) bun.JSErro
                 .headers = headers,
                 .has_last_modified_header = headers.get("last-modified") != null,
                 .has_content_length_header = headers.get("content-length") != null,
+                .has_content_range_header = headers.get("content-range") != null,
                 .status_code = response.statusCode(),
             });
         }
@@ -96,6 +99,7 @@ pub fn fromJS(globalThis: *jsc.JSGlobalObject, argument: jsc.JSValue) bun.JSErro
                 .headers = bun.handleOom(Headers.from(null, bun.default_allocator, .{ .body = &.{ .Blob = b } })),
                 .has_content_length_header = false,
                 .has_last_modified_header = false,
+                .has_content_range_header = false,
                 .status_code = 200,
             });
         }
@@ -235,9 +239,9 @@ pub fn on(this: *FileRoute, req: *uws.Request, resp: AnyResponse, method: bun.ht
 
     // Range applies to the slice the route was configured with, not the
     // underlying file: a Bun.file(p).slice(a,b) route exposes only [a,b).
-    // Only honor Range for routes configured with a 200 status — serving a
-    // partial body under a custom status (201, 400, …) is incoherent.
-    const range: RangeRequest.Result = if (file_type == .file and this.status_code == 200)
+    // Skip if the route has a non-200 status or the user already set
+    // Content-Range — they're managing partial responses themselves.
+    const range: RangeRequest.Result = if (file_type == .file and this.status_code == 200 and !this.has_content_range_header)
         RangeRequest.fromRequest(req, size)
     else
         .none;

--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -247,8 +247,9 @@ pub fn on(this: *FileRoute, req: *uws.Request, resp: AnyResponse, method: bun.ht
         .none;
 
     const status_code: u16 = brk: {
-        if (range == .unsatisfiable) break :brk 416;
-        if (range == .satisfiable) break :brk 206;
+        // RFC 9110 §13.2.2: conditional preconditions are evaluated before
+        // Range. If-Modified-Since on an unmodified resource yields 304 even
+        // when a Range header is present (without If-Range).
         // Unlike If-Unmodified-Since, If-Modified-Since can only be used with a
         // GET or HEAD. When used in combination with If-None-Match, it is
         // ignored, unless the server doesn't support If-None-Match.
@@ -261,6 +262,9 @@ pub fn on(this: *FileRoute, req: *uws.Request, resp: AnyResponse, method: bun.ht
                 }
             }
         }
+
+        if (range == .unsatisfiable) break :brk 416;
+        if (range == .satisfiable) break :brk 206;
 
         if (size == 0 and file_type == .file and this.status_code == 200) {
             break :brk 204;
@@ -275,6 +279,17 @@ pub fn on(this: *FileRoute, req: *uws.Request, resp: AnyResponse, method: bun.ht
     resp.writeMark();
     this.writeHeaders(resp);
 
+    // Bodiless statuses end here — before the range switch, so a 304 (which
+    // can win over a satisfiable Range per RFC 9110 §13.2.2) doesn't emit
+    // Content-Range.
+    switch (status_code) {
+        204, 205, 304, 307, 308 => {
+            resp.endWithoutBody(resp.shouldCloseConnection());
+            return;
+        },
+        else => {},
+    }
+
     const body_offset: u64, const body_len: ?u64 = switch (range) {
         .satisfiable => |r| brk: {
             var crbuf: [96]u8 = undefined;
@@ -285,6 +300,7 @@ pub fn on(this: *FileRoute, req: *uws.Request, resp: AnyResponse, method: bun.ht
         .unsatisfiable => {
             var crbuf: [64]u8 = undefined;
             resp.writeHeader("content-range", std.fmt.bufPrint(&crbuf, "bytes */{d}", .{size}) catch unreachable);
+            resp.writeHeader("accept-ranges", "bytes");
             resp.end("", resp.shouldCloseConnection());
             return;
         },
@@ -293,14 +309,6 @@ pub fn on(this: *FileRoute, req: *uws.Request, resp: AnyResponse, method: bun.ht
             if (file_type == .file and this.blob.size > 0) @as(u64, @intCast(size)) else null,
         },
     };
-
-    switch (status_code) {
-        204, 205, 304, 307, 308 => {
-            resp.endWithoutBody(resp.shouldCloseConnection());
-            return;
-        },
-        else => {},
-    }
 
     if (file_type == .file and !resp.state().hasWrittenContentLengthHeader()) {
         resp.writeHeaderInt("content-length", body_len orelse size);

--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -314,7 +314,8 @@ const StreamTransfer = struct {
 
     state: packed struct(u8) {
         has_ended_response: bool = false,
-        _: u7 = 0,
+        finished: bool = false,
+        _: u6 = 0,
     } = .{},
     const log = Output.scoped(.StreamTransfer, .visible);
 
@@ -517,7 +518,11 @@ const StreamTransfer = struct {
 
     fn finish(this: *StreamTransfer) void {
         log("finish", .{});
-        // lets make sure that we detach the response
+        // onAborted and onReaderDone/onReaderError can both reach here for the
+        // same transfer; the second call must not consume another ref.
+        if (this.state.finished) return;
+        this.state.finished = true;
+
         this.resp.clearOnWritable();
         this.resp.clearAborted();
         this.resp.clearTimeout();
@@ -536,7 +541,12 @@ const StreamTransfer = struct {
 
     fn onAborted(this: *StreamTransfer, _: AnyResponse) void {
         log("onAborted", .{});
-        this.state.has_ended_response = true;
+        if (!this.state.has_ended_response) {
+            this.state.has_ended_response = true;
+            // The socket is gone, so we can't write a response — but we still
+            // owe the server a pending_requests decrement and the route deref.
+            this.route.onResponseComplete(this.resp);
+        }
         this.finish();
     }
 

--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -193,7 +193,7 @@ pub fn on(this: *FileRoute, req: *uws.Request, resp: AnyResponse, method: bun.ht
     // paths below — hits this defer, so neither the fd nor the route ref
     // (or the server's pending_requests counter) can leak regardless of
     // which branch runs. The streaming path clears `fd_owned` right
-    // before handing ownership to `StreamTransfer`.
+    // before handing ownership to `FileResponseStream`.
     var fd_owned = true;
     defer if (fd_owned) {
         bun.Async.Closer.close(fd, if (bun.Environment.isWindows) bun.windows.libuv.Loop.get());
@@ -233,7 +233,16 @@ pub fn on(this: *FileRoute, req: *uws.Request, resp: AnyResponse, method: bun.ht
         return;
     }
 
+    // Range applies to the slice the route was configured with, not the
+    // underlying file: a Bun.file(p).slice(a,b) route exposes only [a,b).
+    const range: RangeRequest.Result = if (file_type == .file)
+        RangeRequest.fromRequest(req, size)
+    else
+        .none;
+
     const status_code: u16 = brk: {
+        if (range == .unsatisfiable) break :brk 416;
+        if (range == .satisfiable and this.status_code == 200) break :brk 206;
         // Unlike If-Unmodified-Since, If-Modified-Since can only be used with a
         // GET or HEAD. When used in combination with If-None-Match, it is
         // ignored, unless the server doesn't support If-None-Match.
@@ -260,6 +269,25 @@ pub fn on(this: *FileRoute, req: *uws.Request, resp: AnyResponse, method: bun.ht
     resp.writeMark();
     this.writeHeaders(resp);
 
+    const body_offset: u64, const body_len: ?u64 = switch (range) {
+        .satisfiable => |r| brk: {
+            var crbuf: [96]u8 = undefined;
+            resp.writeHeader("content-range", std.fmt.bufPrint(&crbuf, "bytes {d}-{d}/{d}", .{ r.start, r.end, size }) catch unreachable);
+            resp.writeHeader("accept-ranges", "bytes");
+            break :brk .{ this.blob.offset + r.start, r.end - r.start + 1 };
+        },
+        .unsatisfiable => {
+            var crbuf: [64]u8 = undefined;
+            resp.writeHeader("content-range", std.fmt.bufPrint(&crbuf, "bytes */{d}", .{size}) catch unreachable);
+            resp.end("", resp.shouldCloseConnection());
+            return;
+        },
+        .none => .{
+            if (file_type == .file) this.blob.offset else 0,
+            if (file_type == .file and this.blob.size > 0) @as(u64, @intCast(size)) else null,
+        },
+    };
+
     switch (status_code) {
         204, 205, 304, 307, 308 => {
             resp.endWithoutBody(resp.shouldCloseConnection());
@@ -269,7 +297,7 @@ pub fn on(this: *FileRoute, req: *uws.Request, resp: AnyResponse, method: bun.ht
     }
 
     if (file_type == .file and !resp.state().hasWrittenContentLengthHeader()) {
-        resp.writeHeaderInt("content-length", size);
+        resp.writeHeaderInt("content-length", body_len orelse size);
         resp.markWroteContentLengthHeader();
     }
 
@@ -278,13 +306,33 @@ pub fn on(this: *FileRoute, req: *uws.Request, resp: AnyResponse, method: bun.ht
         return;
     }
 
-    // Hand ownership of the fd to StreamTransfer; disable the defer close.
+    // Hand ownership of the fd to FileResponseStream; disable the defer close.
+    // The route ref taken at the top of on() is released in onStreamComplete.
     fd_owned = false;
-    const transfer = StreamTransfer.create(fd, resp, this, pollable, file_type != .file, file_type);
-    transfer.start(
-        if (file_type == .file) this.blob.offset else 0,
-        if (file_type == .file and this.blob.size > 0) @intCast(size) else null,
-    );
+    FileResponseStream.start(.{
+        .fd = fd,
+        .auto_close = true,
+        .resp = resp,
+        .vm = this.server.?.vm(),
+        .file_type = file_type,
+        .pollable = pollable,
+        .offset = body_offset,
+        .length = body_len,
+        .idle_timeout = this.server.?.config().idleTimeout,
+        .ctx = this,
+        .on_complete = onStreamComplete,
+        .on_error = onStreamError,
+    });
+}
+
+fn onStreamComplete(ctx: *anyopaque, resp: AnyResponse) void {
+    const this: *FileRoute = @ptrCast(@alignCast(ctx));
+    this.onResponseComplete(resp);
+}
+
+fn onStreamError(ctx: *anyopaque, resp: AnyResponse, _: bun.sys.Error) void {
+    const this: *FileRoute = @ptrCast(@alignCast(ctx));
+    this.onResponseComplete(resp);
 }
 
 fn onResponseComplete(this: *FileRoute, resp: AnyResponse) void {
@@ -297,267 +345,6 @@ fn onResponseComplete(this: *FileRoute, resp: AnyResponse) void {
     this.deref();
 }
 
-const StreamTransfer = struct {
-    const StreamTransferRefCount = bun.ptr.RefCount(@This(), "ref_count", StreamTransfer.deinit, .{});
-    pub const ref = StreamTransferRefCount.ref;
-    pub const deref = StreamTransferRefCount.deref;
-
-    reader: bun.io.BufferedReader = bun.io.BufferedReader.init(StreamTransfer),
-    ref_count: StreamTransferRefCount,
-    fd: bun.FD,
-    resp: AnyResponse,
-    route: *FileRoute,
-
-    max_size: ?u64 = null,
-
-    eof_task: ?jsc.AnyTask = null,
-
-    state: packed struct(u8) {
-        has_ended_response: bool = false,
-        finished: bool = false,
-        _: u6 = 0,
-    } = .{},
-    const log = Output.scoped(.StreamTransfer, .visible);
-
-    pub fn create(
-        fd: bun.FD,
-        resp: AnyResponse,
-        route: *FileRoute,
-        pollable: bool,
-        nonblocking: bool,
-        file_type: FileType,
-    ) *StreamTransfer {
-        var t = bun.new(StreamTransfer, .{
-            .ref_count = .init(),
-            .fd = fd,
-            .resp = resp,
-            .route = route,
-        });
-        t.reader.flags.close_handle = true;
-        t.reader.flags.pollable = pollable;
-        t.reader.flags.nonblocking = nonblocking;
-        if (comptime bun.Environment.isPosix) {
-            if (file_type == .socket) {
-                t.reader.flags.socket = true;
-            }
-        }
-        t.reader.setParent(t);
-        return t;
-    }
-
-    fn start(this: *StreamTransfer, start_offset: usize, size: ?usize) void {
-        log("start", .{});
-
-        this.ref();
-        defer this.deref();
-
-        this.max_size = size;
-
-        switch (if (start_offset > 0)
-            this.reader.startFileOffset(this.fd, this.reader.flags.pollable, start_offset)
-        else
-            this.reader.start(this.fd, this.reader.flags.pollable)) {
-            .err => {
-                this.finish();
-                return;
-            },
-            .result => {},
-        }
-
-        this.reader.updateRef(true);
-
-        if (bun.Environment.isPosix) {
-            if (this.reader.handle.getPoll()) |poll| {
-                if (this.reader.flags.nonblocking) {
-                    poll.flags.insert(.nonblocking);
-                }
-
-                switch (this.reader.getFileType()) {
-                    .socket => poll.flags.insert(.socket),
-                    .nonblocking_pipe, .pipe => poll.flags.insert(.fifo),
-                    .file => {},
-                }
-            }
-        }
-        // the socket maybe open for some time before so we reset the timeout here
-        if (this.route.server) |server| {
-            this.resp.timeout(server.config().idleTimeout);
-        }
-        // we connection aborts/closes so we need to be notified
-        this.resp.onAborted(*StreamTransfer, onAborted, this);
-
-        // we are reading so increase the ref count until onReaderDone/onReaderError
-        this.ref();
-        this.reader.read();
-    }
-
-    pub fn onReadChunk(this: *StreamTransfer, chunk_: []const u8, state_: bun.io.ReadState) bool {
-        log("onReadChunk", .{});
-
-        this.ref();
-        defer this.deref();
-
-        if (this.state.has_ended_response) {
-            return false;
-        }
-
-        const chunk, const state = brk: {
-            if (this.max_size) |*max_size| {
-                const chunk = chunk_[0..@min(chunk_.len, max_size.*)];
-                max_size.* -|= chunk.len;
-                if (state_ != .eof and max_size.* == 0) {
-                    // artificially end the stream aka max_size reached
-                    log("max_size reached, ending stream", .{});
-                    if (this.route.server) |server| {
-                        // dont need to ref because we are already holding a ref and will be derefed in onReaderDone
-                        if (!bun.Environment.isPosix) {
-                            this.reader.pause();
-                        }
-                        // we cannot free inside onReadChunk this would be UAF so we schedule it to be done in the next event loop tick
-                        this.eof_task = jsc.AnyTask.New(StreamTransfer, StreamTransfer.onReaderDone).init(this);
-                        server.vm().enqueueTask(jsc.Task.init(&this.eof_task.?));
-                    }
-                    break :brk .{ chunk, .eof };
-                }
-
-                break :brk .{ chunk, state_ };
-            }
-
-            break :brk .{ chunk_, state_ };
-        };
-
-        if (this.route.server) |server| {
-            this.resp.timeout(server.config().idleTimeout);
-        }
-
-        if (state == .eof) {
-            this.state.has_ended_response = true;
-            const resp = this.resp;
-            const route = this.route;
-            route.onResponseComplete(resp);
-            resp.end(chunk, resp.shouldCloseConnection());
-            log("end: {}", .{chunk.len});
-            return false;
-        }
-
-        switch (this.resp.write(chunk)) {
-            .backpressure => {
-                // pause the reader so deref until onWritable
-                defer this.deref();
-                this.resp.onWritable(*StreamTransfer, onWritable, this);
-                if (!bun.Environment.isPosix) {
-                    this.reader.pause();
-                }
-                return false;
-            },
-            .want_more => {
-                return true;
-            },
-        }
-    }
-
-    pub fn onReaderDone(this: *StreamTransfer) void {
-        log("onReaderDone", .{});
-        // deref the ref because reader is done
-        defer this.deref();
-
-        this.finish();
-    }
-
-    pub fn onReaderError(this: *StreamTransfer, err: bun.sys.Error) void {
-        log("onReaderError {f}", .{err});
-        defer this.deref(); // deref the ref because reader is done
-
-        if (!this.state.has_ended_response) {
-            // we need to signal to the client that something went wrong, so close the connection
-            // sending the end chunk would be a lie and could cause issues
-            this.state.has_ended_response = true;
-            const resp = this.resp;
-            const route = this.route;
-            route.onResponseComplete(resp);
-            this.resp.forceClose();
-        }
-        this.finish();
-    }
-
-    pub fn eventLoop(this: *StreamTransfer) jsc.EventLoopHandle {
-        return jsc.EventLoopHandle.init(this.route.server.?.vm().eventLoop());
-    }
-
-    pub fn loop(this: *StreamTransfer) *Async.Loop {
-        if (comptime bun.Environment.isWindows) {
-            return this.eventLoop().loop().uv_loop;
-        } else {
-            return this.eventLoop().loop();
-        }
-    }
-
-    fn onWritable(this: *StreamTransfer, _: u64, _: AnyResponse) bool {
-        log("onWritable", .{});
-
-        this.ref();
-        defer this.deref();
-
-        if (this.reader.isDone()) {
-            @branchHint(.unlikely);
-            log("finish inside onWritable", .{});
-            this.finish();
-            return true;
-        }
-
-        // reset the socket timeout before reading more data
-        if (this.route.server) |server| {
-            this.resp.timeout(server.config().idleTimeout);
-        }
-
-        // we are reading so increase the ref count until onReaderDone/onReaderError
-        this.ref();
-        this.reader.read();
-        return true;
-    }
-
-    fn finish(this: *StreamTransfer) void {
-        log("finish", .{});
-        // onAborted and onReaderDone/onReaderError can both reach here for the
-        // same transfer; the second call must not consume another ref.
-        if (this.state.finished) return;
-        this.state.finished = true;
-
-        this.resp.clearOnWritable();
-        this.resp.clearAborted();
-        this.resp.clearTimeout();
-
-        if (!this.state.has_ended_response) {
-            this.state.has_ended_response = true;
-            const resp = this.resp;
-            const route = this.route;
-            route.onResponseComplete(resp);
-            log("endWithoutBody", .{});
-            resp.endWithoutBody(resp.shouldCloseConnection());
-        }
-        // deref this indicates the main thing is done, the reader may be holding a ref and will be derefed in onReaderDone/onReaderError
-        this.deref();
-    }
-
-    fn onAborted(this: *StreamTransfer, _: AnyResponse) void {
-        log("onAborted", .{});
-        if (!this.state.has_ended_response) {
-            this.state.has_ended_response = true;
-            // The socket is gone, so we can't write a response — but we still
-            // owe the server a pending_requests decrement and the route deref.
-            this.route.onResponseComplete(this.resp);
-        }
-        this.finish();
-    }
-
-    pub fn deinit(this: *StreamTransfer) void {
-        log("deinit", .{});
-        // deinit will close the reader if it is not already closed (this will not trigger onReaderDone/onReaderError)
-        this.reader.deinit();
-        bun.destroy(this);
-    }
-};
-
 const RefCount = bun.ptr.RefCount(@This(), "ref_count", deinit, .{});
 pub const ref = RefCount.ref;
 pub const deref = RefCount.deref;
@@ -565,14 +352,13 @@ pub const deref = RefCount.deref;
 const std = @import("std");
 
 const bun = @import("bun");
-const Async = bun.Async;
-const Output = bun.Output;
 const jsc = bun.jsc;
-const FileType = bun.io.FileType;
 const Headers = bun.http.Headers;
 const AnyServer = jsc.API.AnyServer;
 const Blob = jsc.WebCore.Blob;
 const writeStatus = bun.api.server.writeStatus;
+const FileResponseStream = bun.api.server.FileResponseStream;
+const RangeRequest = bun.api.server.RangeRequest;
 
 const uws = bun.uws;
 const AnyResponse = uws.AnyResponse;

--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -235,14 +235,16 @@ pub fn on(this: *FileRoute, req: *uws.Request, resp: AnyResponse, method: bun.ht
 
     // Range applies to the slice the route was configured with, not the
     // underlying file: a Bun.file(p).slice(a,b) route exposes only [a,b).
-    const range: RangeRequest.Result = if (file_type == .file)
+    // Only honor Range for routes configured with a 200 status — serving a
+    // partial body under a custom status (201, 400, …) is incoherent.
+    const range: RangeRequest.Result = if (file_type == .file and this.status_code == 200)
         RangeRequest.fromRequest(req, size)
     else
         .none;
 
     const status_code: u16 = brk: {
         if (range == .unsatisfiable) break :brk 416;
-        if (range == .satisfiable and this.status_code == 200) break :brk 206;
+        if (range == .satisfiable) break :brk 206;
         // Unlike If-Unmodified-Since, If-Modified-Since can only be used with a
         // GET or HEAD. When used in combination with If-None-Match, it is
         // ignored, unless the server doesn't support If-None-Match.

--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -256,7 +256,11 @@ pub fn on(this: *FileRoute, req: *uws.Request, resp: AnyResponse, method: bun.ht
         if (input_if_modified_since_date) |requested_if_modified_since| {
             if (method == .HEAD or method == .GET) {
                 if (this.lastModifiedDate() catch return) |actual_last_modified_at| { // TODO: properly propagate exception upwards
-                    if (actual_last_modified_at <= requested_if_modified_since) {
+                    // Compare at second precision: the Last-Modified header we
+                    // emit is second-granular (HTTP-date), so a sub-second
+                    // mtime would otherwise never satisfy `<=` against the
+                    // client's echoed value.
+                    if (actual_last_modified_at / 1000 <= requested_if_modified_since / 1000) {
                         break :brk 304;
                     }
                 }

--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -356,9 +356,10 @@ const jsc = bun.jsc;
 const Headers = bun.http.Headers;
 const AnyServer = jsc.API.AnyServer;
 const Blob = jsc.WebCore.Blob;
-const writeStatus = bun.api.server.writeStatus;
+
 const FileResponseStream = bun.api.server.FileResponseStream;
 const RangeRequest = bun.api.server.RangeRequest;
+const writeStatus = bun.api.server.writeStatus;
 
 const uws = bun.uws;
 const AnyResponse = uws.AnyResponse;

--- a/src/bun.js/api/server/FileRoute.zig
+++ b/src/bun.js/api/server/FileRoute.zig
@@ -239,9 +239,10 @@ pub fn on(this: *FileRoute, req: *uws.Request, resp: AnyResponse, method: bun.ht
 
     // Range applies to the slice the route was configured with, not the
     // underlying file: a Bun.file(p).slice(a,b) route exposes only [a,b).
-    // Skip if the route has a non-200 status or the user already set
-    // Content-Range — they're managing partial responses themselves.
-    const range: RangeRequest.Result = if (file_type == .file and this.status_code == 200 and !this.has_content_range_header)
+    // RFC 9110 §14.2: Range is only defined for GET (HEAD mirrors GET's
+    // headers). Skip if the route has a non-200 status or the user already
+    // set Content-Range — they're managing partial responses themselves.
+    const range: RangeRequest.Result = if ((method == .GET or method == .HEAD) and file_type == .file and this.status_code == 200 and !this.has_content_range_header)
         RangeRequest.fromRequest(req, size)
     else
         .none;

--- a/src/bun.js/api/server/RangeRequest.zig
+++ b/src/bun.js/api/server/RangeRequest.zig
@@ -23,7 +23,10 @@ pub const Raw = union(enum) {
         return switch (this) {
             .none => .none,
             .suffix => |n| {
-                if (n == 0 or total == 0) return .unsatisfiable;
+                if (n == 0) return .unsatisfiable;
+                // RFC 9110 §14.1.3: a positive suffix-length is satisfiable;
+                // for an empty representation we serve the whole (0-byte) body.
+                if (total == 0) return .none;
                 return .{ .satisfiable = .{ .start = total -| n, .end = total - 1 } };
             },
             .bounded => |b| {

--- a/src/bun.js/api/server/RangeRequest.zig
+++ b/src/bun.js/api/server/RangeRequest.zig
@@ -1,0 +1,61 @@
+//! Parses an HTTP `Range: bytes=...` request header against a known total
+//! size. Only single-range `bytes=start-end` / `bytes=start-` / `bytes=-suffix`
+//! forms are supported; multi-range and non-`bytes` units fall back to `.none`
+//! (serve full body) rather than 416, matching common static-server behavior.
+
+pub const Result = union(enum) {
+    /// No Range header (or unsupported form) — serve 200 with the full body.
+    none,
+    /// Serve 206 with `Content-Range: bytes start-end/total`. `end` is inclusive.
+    satisfiable: struct { start: u64, end: u64 },
+    /// Serve 416 with `Content-Range: bytes */total`.
+    unsatisfiable,
+};
+
+pub fn parse(header: []const u8, total: u64) Result {
+    // Match WebKit's parseRange (HTTPParsers.cpp): case-insensitive "bytes",
+    // optional whitespace before "=". https://fetch.spec.whatwg.org/#simple-range-header-value
+    var rest = header;
+    if (rest.len < 5 or !bun.strings.eqlCaseInsensitiveASCII(rest[0..5], "bytes", false)) return .none;
+    rest = bun.strings.trim(rest[5..], " \t");
+    if (rest.len == 0 or rest[0] != '=') return .none;
+    rest = rest[1..];
+
+    // Multi-range — not supported, fall through to full body.
+    if (bun.strings.indexOfChar(rest, ',') != null) return .none;
+
+    const dash = bun.strings.indexOfChar(rest, '-') orelse return .none;
+    const start_s = bun.strings.trim(rest[0..dash], " \t");
+    const end_s = bun.strings.trim(rest[dash + 1 ..], " \t");
+
+    if (start_s.len == 0) {
+        // suffix: bytes=-N → last N bytes
+        const n = std.fmt.parseUnsigned(u64, end_s, 10) catch return .none;
+        if (n == 0) return .unsatisfiable;
+        if (total == 0) return .unsatisfiable;
+        const start = total -| n;
+        return .{ .satisfiable = .{ .start = start, .end = total - 1 } };
+    }
+
+    const start = std.fmt.parseUnsigned(u64, start_s, 10) catch return .none;
+    if (start >= total) return .unsatisfiable;
+
+    if (end_s.len == 0) {
+        // open: bytes=N-
+        return .{ .satisfiable = .{ .start = start, .end = total - 1 } };
+    }
+
+    var end = std.fmt.parseUnsigned(u64, end_s, 10) catch return .none;
+    if (end < start) return .none;
+    if (end >= total) end = total - 1;
+    return .{ .satisfiable = .{ .start = start, .end = end } };
+}
+
+pub fn fromRequest(req: *uws.Request, total: u64) Result {
+    const h = req.header("range") orelse return .none;
+    return parse(h, total);
+}
+
+const std = @import("std");
+const bun = @import("bun");
+const uws = bun.uws;

--- a/src/bun.js/api/server/RangeRequest.zig
+++ b/src/bun.js/api/server/RangeRequest.zig
@@ -57,5 +57,6 @@ pub fn fromRequest(req: *uws.Request, total: u64) Result {
 }
 
 const std = @import("std");
+
 const bun = @import("bun");
 const uws = bun.uws;

--- a/src/bun.js/api/server/RangeRequest.zig
+++ b/src/bun.js/api/server/RangeRequest.zig
@@ -12,9 +12,34 @@ pub const Result = union(enum) {
     unsatisfiable,
 };
 
-pub fn parse(header: []const u8, total: u64) Result {
-    // Match WebKit's parseRange (HTTPParsers.cpp): case-insensitive "bytes",
-    // optional whitespace before "=". https://fetch.spec.whatwg.org/#simple-range-header-value
+/// Parsed Range header before the total size is known. Safe to store on a
+/// request context: it owns no slices into the uWS request buffer.
+pub const Raw = union(enum) {
+    none,
+    suffix: u64, // bytes=-N
+    bounded: struct { start: u64, end: ?u64 }, // bytes=N-[M]
+
+    pub fn resolve(this: Raw, total: u64) Result {
+        return switch (this) {
+            .none => .none,
+            .suffix => |n| {
+                if (n == 0 or total == 0) return .unsatisfiable;
+                return .{ .satisfiable = .{ .start = total -| n, .end = total - 1 } };
+            },
+            .bounded => |b| {
+                if (b.start >= total) return .unsatisfiable;
+                var end = b.end orelse (total - 1);
+                if (end < b.start) return .none;
+                if (end >= total) end = total - 1;
+                return .{ .satisfiable = .{ .start = b.start, .end = end } };
+            },
+        };
+    }
+};
+
+/// Match WebKit's parseRange (HTTPParsers.cpp): case-insensitive "bytes",
+/// optional whitespace before "=". https://fetch.spec.whatwg.org/#simple-range-header-value
+pub fn parseRaw(header: []const u8) Raw {
     var rest = header;
     if (rest.len < 5 or !bun.strings.eqlCaseInsensitiveASCII(rest[0..5], "bytes", false)) return .none;
     rest = bun.strings.trim(rest[5..], " \t");
@@ -29,31 +54,27 @@ pub fn parse(header: []const u8, total: u64) Result {
     const end_s = bun.strings.trim(rest[dash + 1 ..], " \t");
 
     if (start_s.len == 0) {
-        // suffix: bytes=-N → last N bytes
         const n = std.fmt.parseUnsigned(u64, end_s, 10) catch return .none;
-        if (n == 0) return .unsatisfiable;
-        if (total == 0) return .unsatisfiable;
-        const start = total -| n;
-        return .{ .satisfiable = .{ .start = start, .end = total - 1 } };
+        return .{ .suffix = n };
     }
 
     const start = std.fmt.parseUnsigned(u64, start_s, 10) catch return .none;
-    if (start >= total) return .unsatisfiable;
+    const end: ?u64 = if (end_s.len == 0) null else std.fmt.parseUnsigned(u64, end_s, 10) catch return .none;
+    return .{ .bounded = .{ .start = start, .end = end } };
+}
 
-    if (end_s.len == 0) {
-        // open: bytes=N-
-        return .{ .satisfiable = .{ .start = start, .end = total - 1 } };
-    }
-
-    var end = std.fmt.parseUnsigned(u64, end_s, 10) catch return .none;
-    if (end < start) return .none;
-    if (end >= total) end = total - 1;
-    return .{ .satisfiable = .{ .start = start, .end = end } };
+pub fn parse(header: []const u8, total: u64) Result {
+    return parseRaw(header).resolve(total);
 }
 
 pub fn fromRequest(req: *uws.Request, total: u64) Result {
     const h = req.header("range") orelse return .none;
     return parse(h, total);
+}
+
+pub fn rawFromRequest(req: *uws.Request) Raw {
+    const h = req.header("range") orelse return .none;
+    return parseRaw(h);
 }
 
 const std = @import("std");

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -902,7 +902,9 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             else
                 false;
             const is_whole_file = this.blob.Blob.offset == 0 and (original_size == Blob.max_size or original_size == stat_size);
-            if (is_regular and !user_handles_range and is_whole_file and this.range != .none) {
+            // RFC 9110 §14.2: Range is only defined for GET (HEAD mirrors GET's headers).
+            const method_allows_range = this.method == .GET or this.method == .HEAD;
+            if (is_regular and method_allows_range and !user_handles_range and is_whole_file and this.range != .none) {
                 switch (this.range.resolve(stat_size)) {
                     .none => {},
                     .satisfiable => |r| {
@@ -915,6 +917,12 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                         if (auto_close) fd.close();
                         var crbuf: [64]u8 = undefined;
                         this.doWriteStatus(416);
+                        if (this.response_ptr) |response| {
+                            if (response.swapInitHeaders()) |headers_| {
+                                defer headers_.deref();
+                                this.doWriteHeaders(headers_);
+                            }
+                        }
                         resp.writeHeader("content-range", std.fmt.bufPrint(&crbuf, "bytes */{d}", .{stat_size}) catch unreachable);
                         resp.writeHeader("accept-ranges", "bytes");
                         const close = resp.shouldCloseConnection();

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -757,6 +757,13 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             this.deref();
         }
 
+        fn onFileStreamAbort(ctx: *anyopaque, resp: uws.AnyResponse) void {
+            const this: *RequestContext = @ptrCast(@alignCast(ctx));
+            // Route through the real onAbort so flags.aborted, request.signal,
+            // and additional_on_abort fire exactly as they did pre-consolidation.
+            this.onAbort(if (comptime ssl_enabled) resp.SSL else resp.TCP);
+        }
+
         fn onFileStreamError(ctx: *anyopaque, resp: uws.AnyResponse, _: bun.sys.Error) void {
             // FileResponseStream already force-closed the socket; just clean up.
             onFileStreamComplete(ctx, resp);
@@ -815,7 +822,6 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
         pub fn doSendfile(this: *RequestContext, blob: Blob) void {
             if (this.isAbortedOrEnded()) return;
             if (this.flags.has_sendfile_ctx) return;
-            this.flags.has_sendfile_ctx = true;
 
             if (this.resp == null or this.server == null) return;
             const globalThis = this.server.?.globalThis;
@@ -923,6 +929,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             // as userData. uWS keeps a single shared userData slot per response, so
             // any later setAbortHandler()/onWritable() from this RequestContext would
             // stomp it and hand FileResponseStream's callbacks a *RequestContext.
+            this.flags.has_sendfile_ctx = true;
             this.flags.has_abort_handler = true;
             this.flags.has_marked_pending = true;
 
@@ -938,6 +945,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                 .idle_timeout = this.server.?.config.idleTimeout,
                 .ctx = this,
                 .on_complete = onFileStreamComplete,
+                .on_abort = onFileStreamAbort,
                 .on_error = onFileStreamError,
             });
         }

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -892,14 +892,17 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             // Content-Range arithmetic gets ambiguous; the slice path keeps
             // its existing slice-as-range behavior. `offset == 0` alone is
             // insufficient — `Bun.file(p).slice(0, n)` has offset 0 — so we
-            // also require the unset-size sentinel that only an unsliced file
-            // blob carries. Skip if the user already set Content-Range or a
-            // non-200 status — they're managing partial responses themselves.
+            // also check the size: an unsliced blob has either the unset-size
+            // sentinel or, if JS already read `.size`, the stat'd size; a
+            // `.slice(0, n)` blob has `n < stat_size`. Skip if the user
+            // already set Content-Range or a non-200 status — they're
+            // managing partial responses themselves.
             const user_handles_range = if (this.response_ptr) |r|
                 r.statusCode() != 200 or (if (r.getInitHeaders()) |h| h.fastHas(.ContentRange) else false)
             else
                 false;
-            if (is_regular and !user_handles_range and this.blob.Blob.offset == 0 and original_size == Blob.max_size and this.range != .none) {
+            const is_whole_file = this.blob.Blob.offset == 0 and (original_size == Blob.max_size or original_size == stat_size);
+            if (is_regular and !user_handles_range and is_whole_file and this.range != .none) {
                 switch (this.range.resolve(stat_size)) {
                     .none => {},
                     .satisfiable => |r| {

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -78,7 +78,6 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
         additional_on_abort: ?AdditionalOnAbortCallback = null,
 
         // TODO: support builtin compression
-        const can_sendfile = !ssl_enabled and !Environment.isWindows;
 
         pub fn setSignalAborted(this: *RequestContext, reason: bun.jsc.CommonAbortReason) void {
             if (this.signal) |signal| {
@@ -469,26 +468,6 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             }
         }
 
-        /// Render a complete response buffer
-        pub fn renderResponseBufferAndMetadata(this: *RequestContext) void {
-            if (this.resp) |resp| {
-                this.renderMetadata();
-
-                if (!resp.tryEnd(
-                    this.response_buf_owned.items,
-                    this.response_buf_owned.items.len,
-                    this.shouldCloseConnection(),
-                )) {
-                    this.flags.has_marked_pending = true;
-                    resp.onWritable(*RequestContext, onWritableCompleteResponseBuffer, this);
-                    return;
-                }
-            }
-            this.detachResponse();
-            this.endRequestStreamingAndDrain();
-            this.deref();
-        }
-
         /// Drain a partial response buffer
         pub fn drainResponseBufferAndMetadata(this: *RequestContext) void {
             if (this.resp) |resp| {
@@ -769,92 +748,16 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             }
         }
 
-        pub fn endSendFile(this: *RequestContext, writeOffSet: usize, closeConnection: bool) void {
-            if (this.resp) |resp| {
-                defer this.deref();
-
-                this.detachResponse();
-                this.endRequestStreamingAndDrain();
-                resp.endSendFile(writeOffSet, closeConnection);
-            }
+        fn onFileStreamComplete(ctx: *anyopaque, _: uws.AnyResponse) void {
+            const this: *RequestContext = @ptrCast(@alignCast(ctx));
+            this.detachResponse();
+            this.endRequestStreamingAndDrain();
+            this.deref();
         }
 
-        fn cleanupAndFinalizeAfterSendfile(this: *RequestContext) void {
-            const sendfile = this.sendfile;
-            this.endSendFile(sendfile.offset, this.shouldCloseConnection());
-
-            // use node syscall so that we don't segfault on BADF
-            if (sendfile.auto_close)
-                sendfile.fd.close();
-        }
-        const separator: string = "\r\n";
-        const separator_iovec = [1]std.posix.iovec_const{.{
-            .iov_base = separator.ptr,
-            .iov_len = separator.len,
-        }};
-
-        pub fn onSendfile(this: *RequestContext) bool {
-            if (this.isAbortedOrEnded()) {
-                this.cleanupAndFinalizeAfterSendfile();
-                return false;
-            }
-            const resp = this.resp.?;
-
-            const adjusted_count_temporary = @min(@as(u64, this.sendfile.remain), @as(u63, std.math.maxInt(u63)));
-            // TODO we should not need this int cast; improve the return type of `@min`
-            const adjusted_count = @as(u63, @intCast(adjusted_count_temporary));
-
-            if (Environment.isLinux) {
-                var signed_offset = @as(i64, @intCast(this.sendfile.offset));
-                const start = this.sendfile.offset;
-                const val = linux.sendfile(this.sendfile.socket_fd.cast(), this.sendfile.fd.cast(), &signed_offset, this.sendfile.remain);
-                this.sendfile.offset = @as(Blob.SizeType, @intCast(signed_offset));
-
-                const errcode = bun.sys.getErrno(val);
-
-                this.sendfile.remain -|= @as(Blob.SizeType, @intCast(this.sendfile.offset -| start));
-
-                if (errcode != .SUCCESS or this.isAbortedOrEnded() or this.sendfile.remain == 0 or val == 0) {
-                    if (errcode != .AGAIN and errcode != .SUCCESS and errcode != .PIPE and errcode != .NOTCONN) {
-                        Output.prettyErrorln("Error: {s}", .{@tagName(errcode)});
-                        Output.flush();
-                    }
-                    this.cleanupAndFinalizeAfterSendfile();
-                    return errcode != .SUCCESS;
-                }
-            } else {
-                var sbytes: std.posix.off_t = adjusted_count;
-                const signed_offset = @as(i64, @bitCast(@as(u64, this.sendfile.offset)));
-                const errcode = bun.sys.getErrno(std.c.sendfile(
-                    this.sendfile.fd.cast(),
-                    this.sendfile.socket_fd.cast(),
-                    signed_offset,
-                    &sbytes,
-                    null,
-                    0,
-                ));
-                const wrote = @as(Blob.SizeType, @intCast(sbytes));
-                this.sendfile.offset +|= wrote;
-                this.sendfile.remain -|= wrote;
-                if (errcode != .AGAIN or this.isAbortedOrEnded() or this.sendfile.remain == 0 or sbytes == 0) {
-                    if (errcode != .AGAIN and errcode != .SUCCESS and errcode != .PIPE and errcode != .NOTCONN) {
-                        Output.prettyErrorln("Error: {s}", .{@tagName(errcode)});
-                        Output.flush();
-                    }
-                    this.cleanupAndFinalizeAfterSendfile();
-                    return errcode == .SUCCESS;
-                }
-            }
-
-            if (!this.sendfile.has_set_on_writable) {
-                this.sendfile.has_set_on_writable = true;
-                this.flags.has_marked_pending = true;
-                resp.onWritable(*RequestContext, onWritableSendfile, this);
-            }
-
-            resp.markNeedsMore();
-
-            return true;
+        fn onFileStreamError(ctx: *anyopaque, resp: uws.AnyResponse, _: bun.sys.Error) void {
+            // FileResponseStream already force-closed the socket; just clean up.
+            onFileStreamComplete(ctx, resp);
         }
 
         pub fn onWritableBytes(this: *RequestContext, write_offset: u64, resp: *App.Response) bool {
@@ -907,14 +810,11 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             return true;
         }
 
-        pub fn onWritableSendfile(this: *RequestContext, _: u64, _: *App.Response) bool {
-            ctxLog("onWritableSendfile", .{});
-            return this.onSendfile();
-        }
+        pub fn doSendfile(this: *RequestContext, blob: Blob) void {
+            if (this.isAbortedOrEnded()) return;
+            if (this.flags.has_sendfile_ctx) return;
+            this.flags.has_sendfile_ctx = true;
 
-        // We tried open() in another thread for this
-        // it was not faster due to the mountain of syscalls
-        pub fn renderSendFile(this: *RequestContext, blob: jsc.WebCore.Blob) void {
             if (this.resp == null or this.server == null) return;
             const globalThis = this.server.?.globalThis;
             const resp = this.resp.?;
@@ -923,7 +823,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             const file = &this.blob.store().?.data.file;
             var file_buf: bun.PathBuffer = undefined;
             const auto_close = file.pathlike != .fd;
-            const fd = if (!auto_close)
+            const fd: bun.FD = if (!auto_close)
                 file.pathlike.fd
             else switch (bun.sys.open(file.pathlike.path.sliceZ(&file_buf), bun.O.RDONLY | bun.O.NONBLOCK | bun.O.CLOEXEC, 0)) {
                 .result => |_fd| _fd,
@@ -935,174 +835,82 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                 },
             };
 
-            // stat only blocks if the target is a file descriptor
             const stat: bun.Stat = switch (bun.sys.fstat(fd)) {
-                .result => |result| result,
+                .result => |s| s,
                 .err => |err| {
-                    // Close fd before toJS call, which might throw
-                    if (auto_close) {
-                        fd.close();
-                    }
+                    if (auto_close) fd.close();
                     const js_err = err.withPathLike(file.pathlike).toJS(globalThis) catch {
                         return this.renderProductionError(500);
                     };
-                    this.runErrorHandler(js_err);
-                    return;
+                    return this.runErrorHandler(js_err);
                 },
             };
 
-            if (Environment.isMac) {
-                if (!bun.isRegularFile(stat.mode)) {
-                    if (auto_close) {
-                        fd.close();
-                    }
-
-                    var err = bun.sys.Error{
-                        .errno = @as(bun.sys.Error.Int, @intCast(@intFromEnum(std.posix.E.INVAL))),
-                        .syscall = .sendfile,
-                    };
-                    var sys = err.withPathLike(file.pathlike).toSystemError();
-                    sys.message = bun.String.static("MacOS does not support sending non-regular files");
-                    const js_err = sys.toErrorInstance(globalThis);
-                    this.runErrorHandler(js_err);
-                    return;
+            const is_regular = bun.isRegularFile(stat.mode);
+            const file_type: bun.io.FileType, const pollable: bool = brk: {
+                if (bun.S.ISFIFO(@intCast(stat.mode)) or bun.S.ISCHR(@intCast(stat.mode))) break :brk .{ .pipe, true };
+                if (bun.S.ISSOCK(@intCast(stat.mode))) break :brk .{ .socket, true };
+                if (bun.S.ISDIR(@intCast(stat.mode))) {
+                    if (auto_close) fd.close();
+                    var sys = (bun.sys.Error{
+                        .errno = @intFromEnum(bun.sys.E.ISDIR),
+                        .syscall = .read,
+                    }).withPathLike(file.pathlike).toSystemError();
+                    sys.message = bun.String.static("Cannot stream a directory as a response body");
+                    return this.runErrorHandler(sys.toErrorInstance(globalThis));
                 }
-            }
-
-            if (Environment.isLinux) {
-                if (!(bun.isRegularFile(stat.mode) or std.posix.S.ISFIFO(stat.mode) or std.posix.S.ISSOCK(stat.mode))) {
-                    if (auto_close) {
-                        fd.close();
-                    }
-
-                    var err = bun.sys.Error{
-                        .errno = @as(bun.sys.Error.Int, @intCast(@intFromEnum(std.posix.E.INVAL))),
-                        .syscall = .sendfile,
-                    };
-                    var sys = err.withPathLike(file.pathlike).toShellSystemError();
-                    sys.message = bun.String.static("File must be regular or FIFO");
-                    const js_err = sys.toErrorInstance(globalThis);
-                    this.runErrorHandler(js_err);
-                    return;
-                }
-            }
-
-            const original_size = this.blob.Blob.size;
-            const stat_size = @as(Blob.SizeType, @intCast(stat.size));
-            this.blob.Blob.size = if (bun.isRegularFile(stat.mode))
-                stat_size
-            else
-                @min(original_size, stat_size);
-
-            this.flags.needs_content_length = true;
-
-            this.sendfile = .{
-                .fd = fd,
-                .remain = this.blob.Blob.offset + original_size,
-                .offset = this.blob.Blob.offset,
-                .auto_close = auto_close,
-                .socket_fd = if (!this.isAbortedOrEnded()) resp.getNativeHandle() else bun.invalid_fd,
+                break :brk .{ .file, false };
             };
 
-            // if we are sending only part of a file, include the content-range header
-            // only include content-range automatically when using a file path instead of an fd
-            // this is to better support manually controlling the behavior
-            if (bun.isRegularFile(stat.mode) and auto_close) {
+            const original_size = this.blob.Blob.size;
+            const stat_size: Blob.SizeType = @intCast(@max(stat.size, 0));
+            this.blob.Blob.size = if (is_regular) stat_size else @min(original_size, stat_size);
+
+            this.flags.needs_content_length = true;
+            this.sendfile = .{
+                .remain = this.blob.Blob.offset + original_size,
+                .offset = this.blob.Blob.offset,
+            };
+            if (is_regular and auto_close) {
                 this.flags.needs_content_range = (this.sendfile.remain -| this.sendfile.offset) != stat_size;
             }
-
-            // we know the bounds when we are sending a regular file
-            if (bun.isRegularFile(stat.mode)) {
+            if (is_regular) {
                 this.sendfile.offset = @min(this.sendfile.offset, stat_size);
                 this.sendfile.remain = @min(@max(this.sendfile.remain, this.sendfile.offset), stat_size) -| this.sendfile.offset;
             }
 
-            resp.runCorkedWithType(*RequestContext, renderMetadataAndNewline, this);
+            resp.runCorkedWithType(*RequestContext, renderMetadata, this);
 
-            if (this.sendfile.remain == 0 or !this.method.hasBody()) {
-                this.cleanupAndFinalizeAfterSendfile();
+            if ((is_regular and this.sendfile.remain == 0) or !this.method.hasBody()) {
+                if (auto_close) fd.close();
+                this.detachResponse();
+                this.endRequestStreamingAndDrain();
+                resp.end("", this.shouldCloseConnection());
+                this.deref();
                 return;
             }
 
-            _ = this.onSendfile();
-        }
+            // FileResponseStream registers its own onAborted/onWritable with itself
+            // as userData. uWS keeps a single shared userData slot per response, so
+            // any later setAbortHandler()/onWritable() from this RequestContext would
+            // stomp it and hand FileResponseStream's callbacks a *RequestContext.
+            this.flags.has_abort_handler = true;
+            this.flags.has_marked_pending = true;
 
-        pub fn renderMetadataAndNewline(this: *RequestContext) void {
-            if (this.resp) |resp| {
-                this.renderMetadata();
-                resp.prepareForSendfile();
-            }
-        }
-
-        pub fn doSendfile(this: *RequestContext, blob: Blob) void {
-            if (this.isAbortedOrEnded()) {
-                return;
-            }
-
-            if (this.flags.has_sendfile_ctx) return;
-
-            this.flags.has_sendfile_ctx = true;
-
-            if (comptime can_sendfile) {
-                return this.renderSendFile(blob);
-            }
-            if (this.server) |server| {
-                this.ref();
-                this.blob.Blob.doReadFileInternal(*RequestContext, this, onReadFile, server.globalThis);
-            }
-        }
-
-        pub fn onReadFile(this: *RequestContext, result: Blob.read_file.ReadFileResultType) void {
-            defer this.deref();
-
-            if (this.isAbortedOrEnded()) {
-                return;
-            }
-
-            if (result == .err) {
-                if (this.server) |server| {
-                    const js_err = result.err.toErrorInstance(server.globalThis);
-                    this.runErrorHandler(js_err);
-                }
-                return;
-            }
-
-            const is_temporary = result.result.is_temporary;
-
-            if (comptime Environment.allow_assert) {
-                assert(this.blob == .Blob);
-            }
-
-            if (!is_temporary) {
-                this.blob.Blob.resolveSize();
-                this.doRenderBlob();
-            } else {
-                const stat_size = @as(Blob.SizeType, @intCast(result.result.total_size));
-
-                if (this.blob == .Blob) {
-                    const original_size = this.blob.Blob.size;
-                    // if we dont know the size we use the stat size
-                    this.blob.Blob.size = if (original_size == 0 or original_size == Blob.max_size)
-                        stat_size
-                    else // the blob can be a slice of a file
-                        @max(original_size, stat_size);
-                }
-
-                if (!this.flags.has_written_status)
-                    this.flags.needs_content_range = true;
-
-                // this is used by content-range
-                this.sendfile = .{
-                    .fd = bun.invalid_fd,
-                    .remain = @as(Blob.SizeType, @truncate(result.result.buf.len)),
-                    .offset = if (this.blob == .Blob) this.blob.Blob.offset else 0,
-                    .auto_close = false,
-                    .socket_fd = bun.invalid_fd,
-                };
-
-                this.response_buf_owned = .{ .items = result.result.buf, .capacity = result.result.buf.len };
-                this.resp.?.runCorkedWithType(*RequestContext, renderResponseBufferAndMetadata, this);
-            }
+            FileResponseStream.start(.{
+                .fd = fd,
+                .auto_close = auto_close,
+                .resp = if (comptime ssl_enabled) .{ .SSL = resp } else .{ .TCP = resp },
+                .vm = this.server.?.vm,
+                .file_type = file_type,
+                .pollable = pollable,
+                .offset = this.sendfile.offset,
+                .length = if (is_regular) @as(u64, this.sendfile.remain) else null,
+                .idle_timeout = this.server.?.config.idleTimeout,
+                .ctx = this,
+                .on_complete = onFileStreamComplete,
+                .on_error = onFileStreamError,
+            });
         }
 
         pub fn doRenderWithBodyLocked(this: *anyopaque, value: *jsc.WebCore.Body.Value) void {
@@ -2582,14 +2390,12 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
     };
 }
 
+// Retained only for `renderMetadata` to compute Content-Range / Content-Length
+// for file-blob bodies; the actual fd/socket bookkeeping lives in
+// `FileResponseStream` now.
 const SendfileContext = struct {
-    fd: bun.FD,
-    socket_fd: bun.FD = bun.invalid_fd,
     remain: Blob.SizeType = 0,
     offset: Blob.SizeType = 0,
-    has_listener: bool = false,
-    has_set_on_writable: bool = false,
-    auto_close: bool = false,
 };
 
 fn NewFlags(comptime debug_mode: bool) type {
@@ -2686,7 +2492,6 @@ const string = []const u8;
 
 const std = @import("std");
 const Fallback = @import("../../../runtime.zig").Fallback;
-const linux = std.os.linux;
 
 const bun = @import("bun");
 const Environment = bun.Environment;
@@ -2699,6 +2504,7 @@ const logger = bun.logger;
 const uws = bun.uws;
 const Api = bun.schema.api;
 const writeStatus = bun.api.server.writeStatus;
+const FileResponseStream = bun.api.server.FileResponseStream;
 
 const HTTP = bun.http;
 const MimeType = bun.http.MimeType;

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -893,8 +893,13 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             // its existing slice-as-range behavior. `offset == 0` alone is
             // insufficient — `Bun.file(p).slice(0, n)` has offset 0 — so we
             // also require the unset-size sentinel that only an unsliced file
-            // blob carries.
-            if (is_regular and this.blob.Blob.offset == 0 and original_size == Blob.max_size and this.range != .none) {
+            // blob carries. Skip if the user already set Content-Range or a
+            // non-200 status — they're managing partial responses themselves.
+            const user_handles_range = if (this.response_ptr) |r|
+                r.statusCode() != 200 or (if (r.getInitHeaders()) |h| h.fastHas(.ContentRange) else false)
+            else
+                false;
+            if (is_regular and !user_handles_range and this.blob.Blob.offset == 0 and original_size == Blob.max_size and this.range != .none) {
                 switch (this.range.resolve(stat_size)) {
                     .none => {},
                     .satisfiable => |r| {

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -905,9 +905,10 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                         var crbuf: [64]u8 = undefined;
                         this.doWriteStatus(416);
                         resp.writeHeader("content-range", std.fmt.bufPrint(&crbuf, "bytes */{d}", .{stat_size}) catch unreachable);
+                        const close = resp.shouldCloseConnection();
                         this.detachResponse();
                         this.endRequestStreamingAndDrain();
-                        resp.end("", this.shouldCloseConnection());
+                        resp.end("", close);
                         this.deref();
                         return;
                     },
@@ -918,9 +919,10 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
 
             if ((is_regular and this.sendfile.remain == 0) or !this.method.hasBody()) {
                 if (auto_close) fd.close();
+                const close = resp.shouldCloseConnection();
                 this.detachResponse();
                 this.endRequestStreamingAndDrain();
-                resp.end("", this.shouldCloseConnection());
+                resp.end("", close);
                 this.deref();
                 return;
             }

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -54,6 +54,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
         blob: jsc.WebCore.Blob.Any = jsc.WebCore.Blob.Any{ .Blob = .{} },
 
         sendfile: SendfileContext = undefined,
+        range: RangeRequest.Raw = .none,
 
         request_body_readable_stream_ref: jsc.WebCore.ReadableStream.Strong = .{},
         request_body: ?*WebCore.Body.Value.HiveRef = null,
@@ -575,6 +576,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                 .method = method orelse HTTP.Method.which(req.method()) orelse .GET,
                 .server = server,
                 .defer_deinit_until_callback_completes = should_deinit_context,
+                .range = RangeRequest.rawFromRequest(req),
             };
 
             ctxLog("create<d> ({*})<r>", .{this});
@@ -877,6 +879,33 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             if (is_regular) {
                 this.sendfile.offset = @min(this.sendfile.offset, stat_size);
                 this.sendfile.remain = @min(@max(this.sendfile.remain, this.sendfile.offset), stat_size) -| this.sendfile.offset;
+            }
+
+            // Honor an incoming Range: header for whole-file responses. We
+            // don't compose Range with a user-supplied .slice() because the
+            // Content-Range arithmetic gets ambiguous; the slice path keeps
+            // its existing slice-as-range behavior.
+            if (is_regular and this.blob.Blob.offset == 0 and this.range != .none) {
+                switch (this.range.resolve(stat_size)) {
+                    .none => {},
+                    .satisfiable => |r| {
+                        this.sendfile.offset = @intCast(r.start);
+                        this.sendfile.remain = @intCast(r.end - r.start + 1);
+                        this.sendfile.total = stat_size;
+                        this.flags.needs_content_range = true;
+                    },
+                    .unsatisfiable => {
+                        if (auto_close) fd.close();
+                        var crbuf: [64]u8 = undefined;
+                        this.doWriteStatus(416);
+                        resp.writeHeader("content-range", std.fmt.bufPrint(&crbuf, "bytes */{d}", .{stat_size}) catch unreachable);
+                        this.detachResponse();
+                        this.endRequestStreamingAndDrain();
+                        resp.end("", this.shouldCloseConnection());
+                        this.deref();
+                        return;
+                    },
+                }
             }
 
             resp.runCorkedWithType(*RequestContext, renderMetadata, this);
@@ -2054,7 +2083,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
 
             var response: *jsc.WebCore.Response = this.response_ptr.?;
             var status = response.statusCode();
-            var needs_content_range = this.flags.needs_content_range and this.sendfile.remain < this.blob.size();
+            var needs_content_range = this.flags.needs_content_range and (this.sendfile.total > 0 or this.sendfile.remain < this.blob.size());
 
             const size = if (needs_content_range)
                 this.sendfile.remain
@@ -2078,7 +2107,10 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                 defer headers_.deref();
                 has_content_disposition = headers_.fastHas(.ContentDisposition);
                 has_content_range = headers_.fastHas(.ContentRange);
-                needs_content_range = needs_content_range and has_content_range;
+                // For .slice()-driven ranges, only promote to 206 if the user
+                // also set Content-Range (preserves the old contract). For an
+                // incoming Range: header (sendfile.total > 0) we always 206.
+                needs_content_range = needs_content_range and (this.sendfile.total > 0 or has_content_range);
                 if (needs_content_range) {
                     status = 206;
                 }
@@ -2125,6 +2157,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
 
             if (this.flags.needs_content_length) {
                 resp.writeHeaderInt("content-length", size);
+                resp.markWroteContentLengthHeader();
                 this.flags.needs_content_length = false;
             }
 
@@ -2133,14 +2166,21 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
 
                 resp.writeHeader(
                     "content-range",
-                    std.fmt.bufPrint(
-                        &content_range_buf,
-                        // we omit the full size of the Blob because it could
-                        // change between requests and this potentially leaks
-                        // PII undesirably
-                        "bytes {d}-{d}/*",
-                        .{ this.sendfile.offset, this.sendfile.offset + (this.sendfile.remain -| 1) },
-                    ) catch "bytes */*",
+                    if (this.sendfile.total > 0)
+                        // We resolved an incoming Range header against the
+                        // stat'd size, so the total is meaningful.
+                        std.fmt.bufPrint(&content_range_buf, "bytes {d}-{d}/{d}", .{
+                            this.sendfile.offset,
+                            this.sendfile.offset + (this.sendfile.remain -| 1),
+                            this.sendfile.total,
+                        }) catch "bytes */*"
+                    else
+                        // For .slice()-driven ranges we omit the full size:
+                        // it can change between requests and may leak PII.
+                        std.fmt.bufPrint(&content_range_buf, "bytes {d}-{d}/*", .{
+                            this.sendfile.offset,
+                            this.sendfile.offset + (this.sendfile.remain -| 1),
+                        }) catch "bytes */*",
                 );
                 this.flags.needs_content_range = false;
             }
@@ -2396,6 +2436,8 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
 const SendfileContext = struct {
     remain: Blob.SizeType = 0,
     offset: Blob.SizeType = 0,
+    /// When non-zero, the Content-Range total (`/{total}` instead of `/*`).
+    total: Blob.SizeType = 0,
 };
 
 fn NewFlags(comptime debug_mode: bool) type {
@@ -2505,6 +2547,7 @@ const uws = bun.uws;
 const Api = bun.schema.api;
 
 const FileResponseStream = bun.api.server.FileResponseStream;
+const RangeRequest = bun.api.server.RangeRequest;
 const writeStatus = bun.api.server.writeStatus;
 
 const HTTP = bun.http;

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -890,8 +890,11 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             // Honor an incoming Range: header for whole-file responses. We
             // don't compose Range with a user-supplied .slice() because the
             // Content-Range arithmetic gets ambiguous; the slice path keeps
-            // its existing slice-as-range behavior.
-            if (is_regular and this.blob.Blob.offset == 0 and this.range != .none) {
+            // its existing slice-as-range behavior. `offset == 0` alone is
+            // insufficient — `Bun.file(p).slice(0, n)` has offset 0 — so we
+            // also require the unset-size sentinel that only an unsliced file
+            // blob carries.
+            if (is_regular and this.blob.Blob.offset == 0 and original_size == Blob.max_size and this.range != .none) {
                 switch (this.range.resolve(stat_size)) {
                     .none => {},
                     .satisfiable => |r| {
@@ -2192,6 +2195,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                             this.sendfile.offset + (this.sendfile.remain -| 1),
                         }) catch "bytes */*",
                 );
+                if (this.sendfile.total > 0) resp.writeHeader("accept-ranges", "bytes");
                 this.flags.needs_content_range = false;
             }
         }

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -913,6 +913,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                         var crbuf: [64]u8 = undefined;
                         this.doWriteStatus(416);
                         resp.writeHeader("content-range", std.fmt.bufPrint(&crbuf, "bytes */{d}", .{stat_size}) catch unreachable);
+                        resp.writeHeader("accept-ranges", "bytes");
                         const close = resp.shouldCloseConnection();
                         this.detachResponse();
                         this.endRequestStreamingAndDrain();

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -2503,8 +2503,9 @@ const assert = bun.assert;
 const logger = bun.logger;
 const uws = bun.uws;
 const Api = bun.schema.api;
-const writeStatus = bun.api.server.writeStatus;
+
 const FileResponseStream = bun.api.server.FileResponseStream;
+const writeStatus = bun.api.server.writeStatus;
 
 const HTTP = bun.http;
 const MimeType = bun.http.MimeType;

--- a/src/deps/uws/Response.zig
+++ b/src/deps/uws/Response.zig
@@ -514,6 +514,18 @@ pub const AnyResponse = union(enum) {
         }
     }
 
+    pub fn getNativeHandle(this: AnyResponse) bun.FD {
+        return switch (this) {
+            inline else => |resp| resp.getNativeHandle(),
+        };
+    }
+
+    pub fn prepareForSendfile(this: AnyResponse) void {
+        return switch (this) {
+            inline else => |resp| resp.prepareForSendfile(),
+        };
+    }
+
     pub fn onWritable(this: AnyResponse, comptime UserDataType: type, comptime handler: fn (UserDataType, u64, AnyResponse) bool, optional_data: UserDataType) void {
         const wrapper = struct {
             pub fn ssl_handler(user_data: UserDataType, offset: u64, resp: *uws.NewApp(true).Response) bool {

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -339,6 +339,25 @@ describe("Bun.file in serve routes", () => {
       });
     });
 
+    it("If-Modified-Since wins over Range (304, no Content-Range)", async () => {
+      // RFC 9110 §13.2.2: preconditions evaluate before Range. An unmodified
+      // resource returns 304 even when a Range header is present.
+      const res1 = await fetch(new URL(`/partial.txt`, server.url));
+      const lastModified = res1.headers.get("Last-Modified");
+      expect(lastModified).not.toBeEmpty();
+
+      const res2 = await fetch(new URL(`/partial.txt`, server.url), {
+        headers: {
+          "If-Modified-Since": new Date(Date.parse(lastModified!) + 10000).toISOString(),
+          "Range": "bytes=0-3",
+        },
+      });
+
+      expect(res2.status).toBe(304);
+      expect(res2.headers.get("content-range")).toBeNull();
+      expect(await res2.text()).toBe("");
+    });
+
     it("ignores If-Modified-Since for non-GET/HEAD requests", async () => {
       const res1 = await fetch(new URL(`/hello.txt`, server.url));
       const lastModified = res1.headers.get("Last-Modified");
@@ -631,6 +650,7 @@ describe.each([
     const res = await fetch(new URL(path, server.url), { headers: { Range: "bytes=100-200" } });
     expect(res.status).toBe(416);
     expect(res.headers.get("content-range")).toBe("bytes */16");
+    expect(res.headers.get("accept-ranges")).toBe("bytes");
     expect(await res.text()).toBe("");
   });
 

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -640,3 +640,20 @@ describe.each([
     expect(await res.text()).toBe(body);
   });
 });
+
+test("Range header cannot escape a Bun.file().slice(0, n) window via fetch handler", async () => {
+  const dir = tempDirWithFiles("range-slice-escape-", {
+    "f.bin": Buffer.from(Array.from({ length: 256 }, (_, i) => i)),
+  });
+  using server = Bun.serve({
+    port: 0,
+    fetch: () => new Response(Bun.file(join(dir, "f.bin")).slice(0, 100)),
+  });
+  const res = await fetch(server.url, { headers: { Range: "bytes=200-220" } });
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  // Range must be ignored for sliced blobs: serve the 100-byte slice, never bytes 200-220.
+  expect(bytes.length).toBe(100);
+  expect(bytes[0]).toBe(0);
+  expect(bytes[99]).toBe(99);
+  expect(res.headers.get("content-range")).not.toContain("/256");
+});

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -592,6 +592,51 @@ describe("Bun.file in serve routes", () => {
   });
 });
 
+describe("Range requests", () => {
+  let dir: string;
+  let server: Server;
+  const body = "0123456789ABCDEF";
+  beforeAll(() => {
+    dir = tempDirWithFiles("file-route-range-", { "data.bin": body });
+    server = Bun.serve({
+      port: 0,
+      routes: { "/data": new Response(Bun.file(join(dir, "data.bin"))) },
+      fetch: () => new Response("fallback"),
+    });
+  });
+  afterAll(() => {
+    server?.stop(true);
+    using _ = rmScope(dir);
+  });
+
+  it.each([
+    ["bytes=0-3", 206, "0123", "bytes 0-3/16"],
+    ["bytes=4-", 206, "456789ABCDEF", "bytes 4-15/16"],
+    ["bytes=-4", 206, "CDEF", "bytes 12-15/16"],
+    ["bytes=0-999", 206, body, "bytes 0-15/16"],
+    ["Bytes = 2-5", 206, "2345", "bytes 2-5/16"],
+  ])("%s → %d", async (range, status, expected, contentRange) => {
+    const res = await fetch(new URL("/data", server.url), { headers: { Range: range } });
+    expect(res.status).toBe(status);
+    expect(res.headers.get("content-range")).toBe(contentRange);
+    expect(res.headers.get("content-length")).toBe(String(expected.length));
+    expect(await res.text()).toBe(expected);
+  });
+
+  it("416 on start past EOF", async () => {
+    const res = await fetch(new URL("/data", server.url), { headers: { Range: "bytes=100-200" } });
+    expect(res.status).toBe(416);
+    expect(res.headers.get("content-range")).toBe("bytes */16");
+    expect(await res.text()).toBe("");
+  });
+
+  it("ignores multi-range and serves full body", async () => {
+    const res = await fetch(new URL("/data", server.url), { headers: { Range: "bytes=0-1,4-5" } });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(body);
+  });
+});
+
 test("aborting a streaming file response mid-transfer does not leak pending_requests (server.stop resolves)", async () => {
   using dir = tempDir("file-route-abort", {
     "fixture.ts": /* ts */ `

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -592,16 +592,20 @@ describe("Bun.file in serve routes", () => {
   });
 });
 
-describe("Range requests", () => {
+describe.each([
+  ["FileRoute", "/route"],
+  ["fetch handler", "/handler"],
+])("Range requests via %s", (_label, path) => {
   let dir: string;
   let server: Server;
   const body = "0123456789ABCDEF";
   beforeAll(() => {
     dir = tempDirWithFiles("file-route-range-", { "data.bin": body });
+    const file = Bun.file(join(dir, "data.bin"));
     server = Bun.serve({
       port: 0,
-      routes: { "/data": new Response(Bun.file(join(dir, "data.bin"))) },
-      fetch: () => new Response("fallback"),
+      routes: { "/route": new Response(file) },
+      fetch: req => (new URL(req.url).pathname === "/handler" ? new Response(file) : new Response("fallback")),
     });
   });
   afterAll(() => {
@@ -616,7 +620,7 @@ describe("Range requests", () => {
     ["bytes=0-999", 206, body, "bytes 0-15/16"],
     ["Bytes = 2-5", 206, "2345", "bytes 2-5/16"],
   ])("%s → %d", async (range, status, expected, contentRange) => {
-    const res = await fetch(new URL("/data", server.url), { headers: { Range: range } });
+    const res = await fetch(new URL(path, server.url), { headers: { Range: range } });
     expect(res.status).toBe(status);
     expect(res.headers.get("content-range")).toBe(contentRange);
     expect(res.headers.get("content-length")).toBe(String(expected.length));
@@ -624,14 +628,14 @@ describe("Range requests", () => {
   });
 
   it("416 on start past EOF", async () => {
-    const res = await fetch(new URL("/data", server.url), { headers: { Range: "bytes=100-200" } });
+    const res = await fetch(new URL(path, server.url), { headers: { Range: "bytes=100-200" } });
     expect(res.status).toBe(416);
     expect(res.headers.get("content-range")).toBe("bytes */16");
     expect(await res.text()).toBe("");
   });
 
   it("ignores multi-range and serves full body", async () => {
-    const res = await fetch(new URL("/data", server.url), { headers: { Range: "bytes=0-1,4-5" } });
+    const res = await fetch(new URL(path, server.url), { headers: { Range: "bytes=0-1,4-5" } });
     expect(res.status).toBe(200);
     expect(await res.text()).toBe(body);
   });

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -87,6 +87,10 @@ describe("Bun.file in serve routes", () => {
         return new Response(f);
       },
       "/slice-escape": () => new Response(Bun.file(join(tempDir, "bytes256.bin")).slice(0, 100)),
+      "/range-custom-headers": () =>
+        new Response(Bun.file(join(tempDir, "partial.txt")), {
+          headers: { "Cache-Control": "max-age=3600", "X-Custom": "abc" },
+        }),
     } as const;
 
     server = Bun.serve({
@@ -659,6 +663,31 @@ describe("Bun.file in serve routes", () => {
       const res = await fetch(new URL(path, server.url), { headers: { Range: "bytes=0-1,4-5" } });
       expect(res.status).toBe(200);
       expect(await res.text()).toBe(body);
+    });
+
+    it("ignores Range for non-GET/HEAD methods", async () => {
+      // RFC 9110 §14.2: Range is only defined for GET.
+      const res = await fetch(new URL(path, server.url), { method: "POST", headers: { Range: "bytes=0-3" } });
+      expect(res.status).not.toBe(206);
+      expect(res.headers.get("content-range")).toBeNull();
+    });
+  });
+
+  describe.concurrent("Range with custom headers (fetch handler)", () => {
+    it("416 preserves user headers", async () => {
+      const res = await fetch(new URL("/range-custom-headers", server.url), { headers: { Range: "bytes=100-200" } });
+      expect(res.status).toBe(416);
+      expect(res.headers.get("cache-control")).toBe("max-age=3600");
+      expect(res.headers.get("x-custom")).toBe("abc");
+      expect(res.headers.get("content-range")).toBe("bytes */16");
+    });
+
+    it("206 preserves user headers", async () => {
+      const res = await fetch(new URL("/range-custom-headers", server.url), { headers: { Range: "bytes=0-3" } });
+      expect(res.status).toBe(206);
+      expect(res.headers.get("cache-control")).toBe("max-age=3600");
+      expect(res.headers.get("x-custom")).toBe("abc");
+      expect(await res.text()).toBe("0123");
     });
   });
 

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1,6 +1,6 @@
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test";
-import { rmScope, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, rmScope, tempDir, tempDirWithFiles } from "harness";
 import { unlinkSync } from "node:fs";
 import { join } from "node:path";
 
@@ -590,4 +590,58 @@ describe("Bun.file in serve routes", () => {
       expect(res.headers.get("Content-Type")).toMatch(/application\/octet-stream/);
     });
   });
+});
+
+test("aborting a streaming file response mid-transfer does not leak pending_requests (server.stop resolves)", async () => {
+  using dir = tempDir("file-route-abort", {
+    "fixture.ts": /* ts */ `
+      import { connect } from "node:net";
+      import { writeFileSync } from "node:fs";
+      import { join } from "node:path";
+
+      const big = join(import.meta.dir, "big.bin");
+      writeFileSync(big, Buffer.alloc(5 * 1024 * 1024));
+
+      using server = Bun.serve({
+        port: 0,
+        routes: { "/big": new Response(Bun.file(big)) },
+        fetch: () => new Response("unreachable"),
+      });
+
+      // Raw TCP: send GET, receive first chunk, then drop the socket. The 5MB
+      // body fills the kernel send buffer so StreamTransfer is paused on
+      // backpressure when onAborted fires.
+      await new Promise<void>((resolve, reject) => {
+        const sock = connect({ port: server.port, host: "127.0.0.1" }, () => {
+          sock.write("GET /big HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
+          sock.once("data", () => {
+            sock.destroy();
+            resolve();
+          });
+        });
+        sock.on("error", reject);
+      });
+
+      const result = await Promise.race([
+        server.stop().then(() => "stopped"),
+        Bun.sleep(2000).then(() => "HUNG: pending_requests was never decremented"),
+      ]);
+      console.log(result);
+      process.exit(result === "stopped" ? 0 : 1);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(normalizeBunSnapshot(stdout)).toBe("stopped");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -641,6 +641,38 @@ describe.each([
   });
 });
 
+describe("user-set Content-Range disables automatic Range handling", () => {
+  let dir: string;
+  let server: Server;
+  const body = "0123456789ABCDEF";
+  beforeAll(() => {
+    dir = tempDirWithFiles("user-content-range-", { "data.bin": body });
+    const file = () => Bun.file(join(dir, "data.bin"));
+    server = Bun.serve({
+      port: 0,
+      routes: {
+        "/route": new Response(file(), { headers: { "Content-Range": "bytes 0-15/100" } }),
+      },
+      fetch: () => new Response(file(), { headers: { "Content-Range": "bytes 0-15/100" } }),
+    });
+  });
+  afterAll(() => {
+    server?.stop(true);
+    using _ = rmScope(dir);
+  });
+
+  it.each([
+    ["FileRoute", "/route"],
+    ["fetch handler", "/handler"],
+  ])("via %s: client Range ignored, user Content-Range preserved", async (_label, path) => {
+    const res = await fetch(new URL(path, server.url), { headers: { Range: "bytes=2-5" } });
+    // User explicitly set Content-Range — they're managing partial responses
+    // themselves. We must serve the full body with their header, exactly once.
+    expect(await res.text()).toBe(body);
+    expect(res.headers.get("content-range")).toBe("bytes 0-15/100");
+  });
+});
+
 test("Range header cannot escape a Bun.file().slice(0, n) window via fetch handler", async () => {
   const dir = tempDirWithFiles("range-slice-escape-", {
     "f.bin": Buffer.from(Array.from({ length: 256 }, (_, i) => i)),

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1,5 +1,5 @@
 import type { Server } from "bun";
-import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test";
 import { rmScope, tempDirWithFiles } from "harness";
 import { unlinkSync } from "node:fs";
 import { join } from "node:path";

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -16,6 +16,7 @@ const files = {
   "special chars & symbols.txt": "special file content",
   "will-be-deleted.txt": "will be deleted",
   "partial.txt": "0123456789ABCDEF",
+  "bytes256.bin": Buffer.from(Array.from({ length: 256 }, (_, i) => i)),
 };
 
 describe("Bun.file in serve routes", () => {
@@ -70,6 +71,22 @@ describe("Bun.file in serve routes", () => {
         // This would test file descriptors, but they're not supported yet
         return new Response(Bun.file(join(tempDir, "hello.txt")));
       })(),
+      // Static route with user-set Content-Range — auto-Range must be disabled.
+      "/user-content-range-route": new Response(Bun.file(join(tempDir, "partial.txt")), {
+        headers: { "Content-Range": "bytes 0-15/100" },
+      }),
+      // Function routes (dynamic responses) — exercised by the fetch-handler
+      // Range tests below. Kept as routes (not the `fetch` fallback) so they
+      // don't perturb the fallback handler's mock call count.
+      "/range-handler": () => new Response(Bun.file(join(tempDir, "partial.txt"))),
+      "/user-content-range-handler": () =>
+        new Response(Bun.file(join(tempDir, "partial.txt")), { headers: { "Content-Range": "bytes 0-15/100" } }),
+      "/range-after-size": () => {
+        const f = Bun.file(join(tempDir, "partial.txt"));
+        void f.size;
+        return new Response(f);
+      },
+      "/slice-escape": () => new Response(Bun.file(join(tempDir, "bytes256.bin")).slice(0, 100)),
     } as const;
 
     server = Bun.serve({
@@ -87,7 +104,7 @@ describe("Bun.file in serve routes", () => {
     using _ = rmScope(tempDir);
   });
 
-  describe("Basic file serving", () => {
+  describe.concurrent("Basic file serving", () => {
     it("serves text file", async () => {
       const res = await fetch(new URL(`/hello.txt`, server.url));
       expect(res.status).toBe(200);
@@ -228,7 +245,7 @@ describe("Bun.file in serve routes", () => {
     });
   });
 
-  describe("HTTP methods", () => {
+  describe.concurrent("HTTP methods", () => {
     it("supports HEAD requests", async () => {
       const res = await fetch(new URL(`/hello.txt`, server.url), { method: "HEAD" });
       expect(res.status).toBe(200);
@@ -244,7 +261,7 @@ describe("Bun.file in serve routes", () => {
     });
   });
 
-  describe("Custom headers and status", () => {
+  describe.concurrent("Custom headers and status", () => {
     it("preserves custom headers", async () => {
       const res = await fetch(new URL(`/with-headers.txt`, server.url));
       expect(res.status).toBe(200);
@@ -304,7 +321,7 @@ describe("Bun.file in serve routes", () => {
     });
   });
 
-  describe("Conditional requests", () => {
+  describe.concurrent("Conditional requests", () => {
     describe.each(["GET", "HEAD"])("%s", method => {
       it(`handles If-Modified-Since with future date (304)`, async () => {
         // First request to get Last-Modified
@@ -468,7 +485,7 @@ describe("Bun.file in serve routes", () => {
     });
   });
 
-  describe("Last-Modified header handling", () => {
+  describe.concurrent("Last-Modified header handling", () => {
     it("automatically adds Last-Modified header", async () => {
       const res = await fetch(new URL(`/hello.txt`, server.url));
       const lastModified = res.headers.get("Last-Modified");
@@ -500,7 +517,7 @@ describe("Bun.file in serve routes", () => {
     });
   });
 
-  describe("File slicing", () => {
+  describe.concurrent("File slicing", () => {
     it("serves complete file", async () => {
       const res = await fetch(new URL(`/partial.txt`, server.url));
       expect(res.status).toBe(200);
@@ -516,7 +533,7 @@ describe("Bun.file in serve routes", () => {
     });
   });
 
-  describe("Special status codes", () => {
+  describe.concurrent("Special status codes", () => {
     it("returns 204 for empty files with 200 status", async () => {
       const res = await fetch(new URL(`/empty.txt`, server.url));
       expect(res.status).toBe(204);
@@ -545,7 +562,7 @@ describe("Bun.file in serve routes", () => {
     });
   });
 
-  describe("Streaming and file types", () => {
+  describe.concurrent("Streaming and file types", () => {
     it("sets Content-Length for regular files", async () => {
       const res = await fetch(new URL(`/hello.txt`, server.url));
       expect(res.headers.get("Content-Length")).toBe("13");
@@ -593,7 +610,7 @@ describe("Bun.file in serve routes", () => {
     });
   });
 
-  describe("Content-Type detection", () => {
+  describe.concurrent("Content-Type detection", () => {
     it("detects text/plain for .txt files", async () => {
       const res = await fetch(new URL(`/hello.txt`, server.url));
       expect(res.headers.get("Content-Type")).toMatch(/text\/plain/);
@@ -609,123 +626,75 @@ describe("Bun.file in serve routes", () => {
       expect(res.headers.get("Content-Type")).toMatch(/application\/octet-stream/);
     });
   });
-});
 
-describe.each([
-  ["FileRoute", "/route"],
-  ["fetch handler", "/handler"],
-])("Range requests via %s", (_label, path) => {
-  let dir: string;
-  let server: Server;
-  const body = "0123456789ABCDEF";
-  beforeAll(() => {
-    dir = tempDirWithFiles("file-route-range-", { "data.bin": body });
-    const file = Bun.file(join(dir, "data.bin"));
-    server = Bun.serve({
-      port: 0,
-      routes: { "/route": new Response(file) },
-      fetch: req => (new URL(req.url).pathname === "/handler" ? new Response(file) : new Response("fallback")),
+  describe.concurrent.each([
+    ["FileRoute", "/partial.txt"],
+    ["fetch handler", "/range-handler"],
+  ])("Range requests via %s", (_label, path) => {
+    const body = files["partial.txt"];
+
+    it.each([
+      ["bytes=0-3", 206, "0123", "bytes 0-3/16"],
+      ["bytes=4-", 206, "456789ABCDEF", "bytes 4-15/16"],
+      ["bytes=-4", 206, "CDEF", "bytes 12-15/16"],
+      ["bytes=0-999", 206, body, "bytes 0-15/16"],
+      ["Bytes = 2-5", 206, "2345", "bytes 2-5/16"],
+    ])("%s → %d", async (range, status, expected, contentRange) => {
+      const res = await fetch(new URL(path, server.url), { headers: { Range: range } });
+      expect(res.status).toBe(status);
+      expect(res.headers.get("content-range")).toBe(contentRange);
+      expect(res.headers.get("content-length")).toBe(String(expected.length));
+      expect(await res.text()).toBe(expected);
+    });
+
+    it("416 on start past EOF", async () => {
+      const res = await fetch(new URL(path, server.url), { headers: { Range: "bytes=100-200" } });
+      expect(res.status).toBe(416);
+      expect(res.headers.get("content-range")).toBe("bytes */16");
+      expect(res.headers.get("accept-ranges")).toBe("bytes");
+      expect(await res.text()).toBe("");
+    });
+
+    it("ignores multi-range and serves full body", async () => {
+      const res = await fetch(new URL(path, server.url), { headers: { Range: "bytes=0-1,4-5" } });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(body);
     });
   });
-  afterAll(() => {
-    server?.stop(true);
-    using _ = rmScope(dir);
-  });
 
-  it.each([
-    ["bytes=0-3", 206, "0123", "bytes 0-3/16"],
-    ["bytes=4-", 206, "456789ABCDEF", "bytes 4-15/16"],
-    ["bytes=-4", 206, "CDEF", "bytes 12-15/16"],
-    ["bytes=0-999", 206, body, "bytes 0-15/16"],
-    ["Bytes = 2-5", 206, "2345", "bytes 2-5/16"],
-  ])("%s → %d", async (range, status, expected, contentRange) => {
-    const res = await fetch(new URL(path, server.url), { headers: { Range: range } });
-    expect(res.status).toBe(status);
-    expect(res.headers.get("content-range")).toBe(contentRange);
-    expect(res.headers.get("content-length")).toBe(String(expected.length));
-    expect(await res.text()).toBe(expected);
-  });
+  describe.concurrent("user-set Content-Range disables automatic Range handling", () => {
+    const body = files["partial.txt"];
 
-  it("416 on start past EOF", async () => {
-    const res = await fetch(new URL(path, server.url), { headers: { Range: "bytes=100-200" } });
-    expect(res.status).toBe(416);
-    expect(res.headers.get("content-range")).toBe("bytes */16");
-    expect(res.headers.get("accept-ranges")).toBe("bytes");
-    expect(await res.text()).toBe("");
-  });
-
-  it("ignores multi-range and serves full body", async () => {
-    const res = await fetch(new URL(path, server.url), { headers: { Range: "bytes=0-1,4-5" } });
-    expect(res.status).toBe(200);
-    expect(await res.text()).toBe(body);
-  });
-});
-
-describe("user-set Content-Range disables automatic Range handling", () => {
-  let dir: string;
-  let server: Server;
-  const body = "0123456789ABCDEF";
-  beforeAll(() => {
-    dir = tempDirWithFiles("user-content-range-", { "data.bin": body });
-    const file = () => Bun.file(join(dir, "data.bin"));
-    server = Bun.serve({
-      port: 0,
-      routes: {
-        "/route": new Response(file(), { headers: { "Content-Range": "bytes 0-15/100" } }),
-      },
-      fetch: () => new Response(file(), { headers: { "Content-Range": "bytes 0-15/100" } }),
+    it.each([
+      ["FileRoute", "/user-content-range-route"],
+      ["fetch handler", "/user-content-range-handler"],
+    ])("via %s: client Range ignored, user Content-Range preserved", async (_label, path) => {
+      const res = await fetch(new URL(path, server.url), { headers: { Range: "bytes=2-5" } });
+      // User explicitly set Content-Range — they're managing partial responses
+      // themselves. We must serve the full body with their header, exactly once.
+      expect(await res.text()).toBe(body);
+      expect(res.headers.get("content-range")).toBe("bytes 0-15/100");
     });
   });
-  afterAll(() => {
-    server?.stop(true);
-    using _ = rmScope(dir);
-  });
 
-  it.each([
-    ["FileRoute", "/route"],
-    ["fetch handler", "/handler"],
-  ])("via %s: client Range ignored, user Content-Range preserved", async (_label, path) => {
-    const res = await fetch(new URL(path, server.url), { headers: { Range: "bytes=2-5" } });
-    // User explicitly set Content-Range — they're managing partial responses
-    // themselves. We must serve the full body with their header, exactly once.
-    expect(await res.text()).toBe(body);
-    expect(res.headers.get("content-range")).toBe("bytes 0-15/100");
-  });
-});
+  describe.concurrent("Range via fetch handler edge cases", () => {
+    it("Range works after JS reads file.size before constructing Response", async () => {
+      // Reading .size resolves the Blob.max_size sentinel; the Range guard must
+      // also accept original_size == stat_size for this case.
+      const res = await fetch(new URL("/range-after-size", server.url), { headers: { Range: "bytes=4-7" } });
+      expect(res.status).toBe(206);
+      expect(res.headers.get("content-range")).toBe("bytes 4-7/16");
+      expect(await res.text()).toBe("4567");
+    });
 
-test("Range works after JS reads file.size before constructing Response", async () => {
-  // Reading .size resolves the Blob.max_size sentinel; the Range guard must
-  // also accept original_size == stat_size for this case.
-  const dir = tempDirWithFiles("range-after-size-", { "f.txt": "0123456789ABCDEF" });
-  using _ = rmScope(dir);
-  using server = Bun.serve({
-    port: 0,
-    fetch: () => {
-      const f = Bun.file(join(dir, "f.txt"));
-      void f.size;
-      return new Response(f);
-    },
+    it("Range header cannot escape a Bun.file().slice(0, n) window via fetch handler", async () => {
+      const res = await fetch(new URL("/slice-escape", server.url), { headers: { Range: "bytes=200-220" } });
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      // Range must be ignored for sliced blobs: serve the 100-byte slice, never bytes 200-220.
+      expect(bytes.length).toBe(100);
+      expect(bytes[0]).toBe(0);
+      expect(bytes[99]).toBe(99);
+      expect(res.headers.get("content-range")).not.toContain("/256");
+    });
   });
-  const res = await fetch(server.url, { headers: { Range: "bytes=4-7" } });
-  expect(res.status).toBe(206);
-  expect(res.headers.get("content-range")).toBe("bytes 4-7/16");
-  expect(await res.text()).toBe("4567");
-});
-
-test("Range header cannot escape a Bun.file().slice(0, n) window via fetch handler", async () => {
-  const dir = tempDirWithFiles("range-slice-escape-", {
-    "f.bin": Buffer.from(Array.from({ length: 256 }, (_, i) => i)),
-  });
-  using _ = rmScope(dir);
-  using server = Bun.serve({
-    port: 0,
-    fetch: () => new Response(Bun.file(join(dir, "f.bin")).slice(0, 100)),
-  });
-  const res = await fetch(server.url, { headers: { Range: "bytes=200-220" } });
-  const bytes = new Uint8Array(await res.arrayBuffer());
-  // Range must be ignored for sliced blobs: serve the 100-byte slice, never bytes 200-220.
-  expect(bytes.length).toBe(100);
-  expect(bytes[0]).toBe(0);
-  expect(bytes[99]).toBe(99);
-  expect(res.headers.get("content-range")).not.toContain("/256");
 });

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1,5 +1,5 @@
 import type { Server } from "bun";
-import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
 import { rmScope, tempDirWithFiles } from "harness";
 import { unlinkSync } from "node:fs";
 import { join } from "node:path";

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -693,10 +693,30 @@ describe("user-set Content-Range disables automatic Range handling", () => {
   });
 });
 
+test("Range works after JS reads file.size before constructing Response", async () => {
+  // Reading .size resolves the Blob.max_size sentinel; the Range guard must
+  // also accept original_size == stat_size for this case.
+  const dir = tempDirWithFiles("range-after-size-", { "f.txt": "0123456789ABCDEF" });
+  using _ = rmScope(dir);
+  using server = Bun.serve({
+    port: 0,
+    fetch: () => {
+      const f = Bun.file(join(dir, "f.txt"));
+      void f.size;
+      return new Response(f);
+    },
+  });
+  const res = await fetch(server.url, { headers: { Range: "bytes=4-7" } });
+  expect(res.status).toBe(206);
+  expect(res.headers.get("content-range")).toBe("bytes 4-7/16");
+  expect(await res.text()).toBe("4567");
+});
+
 test("Range header cannot escape a Bun.file().slice(0, n) window via fetch handler", async () => {
   const dir = tempDirWithFiles("range-slice-escape-", {
     "f.bin": Buffer.from(Array.from({ length: 256 }, (_, i) => i)),
   });
+  using _ = rmScope(dir);
   using server = Bun.serve({
     port: 0,
     fetch: () => new Response(Bun.file(join(dir, "f.bin")).slice(0, 100)),

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1,6 +1,6 @@
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, rmScope, tempDir, tempDirWithFiles } from "harness";
+import { rmScope, tempDirWithFiles } from "harness";
 import { unlinkSync } from "node:fs";
 import { join } from "node:path";
 
@@ -639,58 +639,4 @@ describe.each([
     expect(res.status).toBe(200);
     expect(await res.text()).toBe(body);
   });
-});
-
-test("aborting a streaming file response mid-transfer does not leak pending_requests (server.stop resolves)", async () => {
-  using dir = tempDir("file-route-abort", {
-    "fixture.ts": /* ts */ `
-      import { connect } from "node:net";
-      import { writeFileSync } from "node:fs";
-      import { join } from "node:path";
-
-      const big = join(import.meta.dir, "big.bin");
-      writeFileSync(big, Buffer.alloc(5 * 1024 * 1024));
-
-      using server = Bun.serve({
-        port: 0,
-        routes: { "/big": new Response(Bun.file(big)) },
-        fetch: () => new Response("unreachable"),
-      });
-
-      // Raw TCP: send GET, receive first chunk, then drop the socket. The 5MB
-      // body fills the kernel send buffer so StreamTransfer is paused on
-      // backpressure when onAborted fires.
-      await new Promise<void>((resolve, reject) => {
-        const sock = connect({ port: server.port, host: "127.0.0.1" }, () => {
-          sock.write("GET /big HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
-          sock.once("data", () => {
-            sock.destroy();
-            resolve();
-          });
-        });
-        sock.on("error", reject);
-      });
-
-      const result = await Promise.race([
-        server.stop().then(() => "stopped"),
-        Bun.sleep(2000).then(() => "HUNG: pending_requests was never decremented"),
-      ]);
-      console.log(result);
-      process.exit(result === "stopped" ? 0 : 1);
-    `,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "fixture.ts"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(normalizeBunSnapshot(stdout)).toBe("stopped");
-  expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/20965.test.ts
+++ b/test/regression/issue/20965.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/20965
+// StreamTransfer.onAborted set has_ended_response=true before finish(), so
+// route.onResponseComplete() was skipped and pending_requests was never
+// decremented — server.stop() would hang after any aborted file stream.
+test("aborting a streaming file response mid-transfer does not leak pending_requests (server.stop resolves)", async () => {
+  using dir = tempDir("file-route-abort", {
+    "fixture.ts": /* ts */ `
+      import { connect } from "node:net";
+      import { writeFileSync } from "node:fs";
+      import { join } from "node:path";
+
+      const big = join(import.meta.dir, "big.bin");
+      writeFileSync(big, Buffer.alloc(5 * 1024 * 1024));
+
+      using server = Bun.serve({
+        port: 0,
+        routes: { "/big": new Response(Bun.file(big)) },
+        fetch: () => new Response("unreachable"),
+      });
+
+      // Raw TCP: send GET, receive first chunk, then drop the socket. The 5MB
+      // body fills the kernel send buffer so StreamTransfer is paused on
+      // backpressure when onAborted fires.
+      await new Promise<void>((resolve, reject) => {
+        const sock = connect({ port: server.port, host: "127.0.0.1" }, () => {
+          sock.write("GET /big HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
+          sock.once("data", () => {
+            sock.destroy();
+            resolve();
+          });
+        });
+        sock.on("error", reject);
+      });
+
+      const result = await Promise.race([
+        server.stop().then(() => "stopped"),
+        Bun.sleep(2000).then(() => "HUNG: pending_requests was never decremented"),
+      ]);
+      console.log(result);
+      process.exit(result === "stopped" ? 0 : 1);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(normalizeBunSnapshot(stdout)).toBe("stopped");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Started as a follow-up to #29185 fixing two `StreamTransfer` abort bugs, then consolidated the four divergent file-response strategies into one shared implementation and added Range support.

Fixes #20965

## FileResponseStream

New `src/bun.js/api/server/FileResponseStream.zig` — owns fd→`AnyResponse` body streaming. Shared by `FileRoute` (static `routes:` entries) and `RequestContext` (file bodies returned from `fetch` handlers).

- BufferedReader path by default; kernel `sendfile()` only for ≥1MB regular files on non-SSL POSIX
- Idempotent `finish()`, abort-safe; `detachResp()` clears uWS callbacks before `end()`/`endSendFile()` so the deferred `eof_task` can never touch a reaped socket
- fd closed in `deinit()` regardless of which path ran
- Optional `on_abort` callback so `RequestContext` can route disconnects through its real `onAbort` (preserving `flags.aborted` / `additional_on_abort` / `req.signal`)

### Replaces

| Before | After |
|---|---|
| `FileRoute.StreamTransfer` (~250 lines) | deleted |
| `RequestContext` sendfile loop (`onSendfile` / `onWritableSendfile` / `endSendFile` / `cleanupAndFinalizeAfterSendfile` / `renderMetadataAndNewline`) | deleted |
| `RequestContext` SSL/Windows **read-whole-file-into-memory** fallback (`doReadFileInternal` → `onReadFile` → `renderResponseBufferAndMetadata`) | streams via BufferedReader |

`SendfileContext` shrinks to `{offset, remain, total}` — only what `renderMetadata` reads.

## Range requests

New `src/bun.js/api/server/RangeRequest.zig` — parses `Range: bytes=...` matching WebKit's `parseRange` semantics (case-insensitive unit, whitespace-tolerant, suffix/open forms; multi-range falls through to full body). Two-phase: `parseRaw()` captures the header without knowing total size (so `RequestContext` can store it past the uWS request buffer's lifetime), `.resolve(total)` validates against the stat'd size.

Both paths now honor incoming `Range:` for whole-file 200 responses → 206 + `Content-Range` / 416 + `bytes */total`. Range is ignored when the route has a non-200 status or the blob is already `.slice()`d.

## Bugs fixed

- **`server.stop()` hangs after any aborted file stream** (#20965) — `StreamTransfer.onAborted` set `has_ended_response` before `finish()`, so `route.onResponseComplete()` was skipped and `pending_requests` was never decremented.
- **UAF when `onReaderDone` fires after abort** — `finish()` unconditionally deref'd; second entry took refcount to 0 and the queued `defer this.deref()` hit freed memory.
- **fd leak on aborted sendfile from a fetch handler** — `RequestContext.onAbort` never closed `sendfile.fd`; `deinit()` didn't either. Now owned by `FileResponseStream.deinit`.
- **SSL/Windows file responses buffered the entire file** — the `doReadFileInternal` fallback. Now streams.
- **`shouldCloseConnection()` always false on 416/empty paths** — was called after `detachResponse()` nulled `this.resp`.
- **Error handler returning a file-backed Response was dropped** — `has_sendfile_ctx` was latched before open/stat validation.
- **Duplicate `Content-Length` on file responses** — `renderMetadata` wrote one, then uWS `end()` added another; now marked.
- **`bytes=-N` on a zero-length file returned 416** — RFC 9110 §14.1.3 says positive suffix-length is satisfiable; now serves the (empty) representation.

## Tests

- `test/regression/issue/20965.test.ts` — 5MB FileRoute, raw-TCP abort after first chunk, assert `server.stop()` resolves (fails on main with `HUNG`)
- `bun-serve-file.test.ts` — Range tests (`describe.each` over FileRoute and fetch-handler paths): closed/open/suffix/past-EOF/clamped/multi-range/case-insensitive

`serve.test.ts` 189 pass × 8 runs no ASAN; `bun-serve-file` 56 / `static` 34 / `routes` 40 / `ssl` 16; `zig:check-all` clean on all 12 targets.
