### PR TITLE
Fix integer overflow in ReadFile buffer capacity calculation

### DIFF
--- a/src/bun.js/webcore/blob/read_file.zig
+++ b/src/bun.js/webcore/blob/read_file.zig
@@ -384,7 +384,7 @@ pub const ReadFile = struct {
 
         // add an extra 16 bytes to the buffer to avoid having to resize it for trailing extra data
         if (!this.could_block or (this.size > 0 and this.size != Blob.max_size))
-            this.buffer = std.ArrayListUnmanaged(u8).initCapacity(bun.default_allocator, this.size + 16) catch |err| {
+            this.buffer = std.ArrayListUnmanaged(u8).initCapacity(bun.default_allocator, this.size +| 16) catch |err| {
                 this.errno = err;
                 this.onFinish();
                 return;

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from "bun:test";
-import { devNull, tmpdir } from "node:os";
 import { isWindows } from "harness";
+import { devNull, tmpdir } from "node:os";
 
 it("offset should work in Bun.file() #4963", async () => {
   const filename = tmpdir() + "/bun.test.offset.txt";

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "bun:test";
-import { tmpdir } from "node:os";
+import { devNull, tmpdir } from "node:os";
+import { isWindows } from "harness";
 
 it("offset should work in Bun.file() #4963", async () => {
   const filename = tmpdir() + "/bun.test.offset.txt";
@@ -8,4 +9,18 @@ it("offset should work in Bun.file() #4963", async () => {
   const slice = file.slice(2, file.size);
   const contents = await slice.text();
   expect(contents).toBe("ntents");
+});
+
+it.skipIf(isWindows)("reading a non-regular file blob sliced near max_size does not crash", async () => {
+  // Blob.max_size is maxInt(u52). Slicing just below that caused an integer
+  // overflow when computing the initial read buffer capacity (size + 16).
+  const file = Bun.file(devNull);
+  const sliced = file.slice(0, 4503599627370490);
+  const result = await sliced.arrayBuffer().catch(e => e);
+  // /dev/null has no data; we just care that this does not panic.
+  if (result instanceof ArrayBuffer) {
+    expect(result.byteLength).toBe(0);
+  } else {
+    expect(result).toBeInstanceOf(Error);
+  }
 });


### PR DESCRIPTION
Fuzzer fingerprint: `a83967f18cb850d8`

## What

Reading a non-regular file blob (e.g. `/dev/null`) that has been sliced to a length near `maxInt(u52)` panicked with an integer overflow on a thread pool worker.

## Why

In `ReadFile.runAsyncWithFD`, when the underlying file is not a regular file and `stat.size == 0`, `this.size` is set to `this.max_length` (the slice length supplied by the user). The initial read buffer is then pre-allocated with capacity `this.size + 16`. Since `size` is a `u52` and `max_length` can be any value up to `Blob.max_size - 1`, adding 16 overflows.

```js
const sliced = Bun.file("/dev/null").slice(0, 4503599627370490);
await sliced.arrayBuffer(); // panic: integer overflow
```

## Fix

Use saturating addition (`+|`) for the capacity hint. If the resulting allocation is too large it is handled by the existing `catch` path instead of crashing the process.