### PR TITLE
Fix integer overflow in ReadFile buffer pre-allocation

### DIFF
--- a/src/bun.js/webcore/blob/read_file.zig
+++ b/src/bun.js/webcore/blob/read_file.zig
@@ -384,7 +384,7 @@ pub const ReadFile = struct {
 
         // add an extra 16 bytes to the buffer to avoid having to resize it for trailing extra data
         if (!this.could_block or (this.size > 0 and this.size != Blob.max_size))
-            this.buffer = std.ArrayListUnmanaged(u8).initCapacity(bun.default_allocator, this.size + 16) catch |err| {
+            this.buffer = std.ArrayListUnmanaged(u8).initCapacity(bun.default_allocator, this.size +| 16) catch |err| {
                 this.errno = err;
                 this.onFinish();
                 return;
@@ -698,7 +698,7 @@ pub const ReadFileUV = struct {
             return;
         }
         // add an extra 16 bytes to the buffer to avoid having to resize it for trailing extra data
-        this.buffer.ensureTotalCapacityPrecise(this.byte_store.allocator, @min(this.size + 16, @as(usize, std.math.maxInt(bun.windows.ULONG)))) catch {
+        this.buffer.ensureTotalCapacityPrecise(this.byte_store.allocator, @min(this.size +| 16, @as(usize, std.math.maxInt(bun.windows.ULONG)))) catch {
             this.errno = error.OutOfMemory;
             this.system_error = bun.sys.Error.fromCode(bun.sys.E.NOMEM, .read).toSystemError();
             this.onFinish();

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "bun:test";
 import { tmpdir } from "node:os";
+import { bunEnv, bunExe, isPosix } from "harness";
 
 it("offset should work in Bun.file() #4963", async () => {
   const filename = tmpdir() + "/bun.test.offset.txt";
@@ -8,4 +9,20 @@ it("offset should work in Bun.file() #4963", async () => {
   const slice = file.slice(2, file.size);
   const contents = await slice.text();
   expect(contents).toBe("ntents");
+});
+
+it.skipIf(!isPosix)("reading a file blob sliced to near Blob.max_size should not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `await Bun.file("/dev/zero").slice(0, 4503599627370490).text().then(() => {}, () => {});`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from "bun:test";
-import { tmpdir } from "node:os";
 import { bunEnv, bunExe, isPosix } from "harness";
+import { tmpdir } from "node:os";
 
 it("offset should work in Bun.file() #4963", async () => {
   const filename = tmpdir() + "/bun.test.offset.txt";
@@ -13,11 +13,7 @@ it("offset should work in Bun.file() #4963", async () => {
 
 it.skipIf(!isPosix)("reading a file blob sliced to near Blob.max_size should not crash", async () => {
   await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `await Bun.file("/dev/zero").slice(0, 4503599627370490).text().then(() => {}, () => {});`,
-    ],
+    cmd: [bunExe(), "-e", `await Bun.file("/dev/zero").slice(0, 4503599627370490).text().then(() => {}, () => {});`],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",


### PR DESCRIPTION
## What does this PR do?

Fixes an integer overflow panic in `ReadFile.runAsyncWithFD` (and the equivalent spot in `ReadFileUV`) when computing the initial buffer capacity.

`ReadFile.size` is a `u52`. When a file `Blob` backed by a non-regular file (e.g. `/dev/zero`) is sliced to a length near `Blob.max_size` (`maxInt(u52)`) and then read, `resolveSizeAndLastModified` sets `this.size = this.max_length`, and then `this.size + 16` overflows and panics in debug builds.

Minimal repro (before this change, panics with `integer overflow`):
```js
await Bun.file("/dev/zero").slice(0, 4503599627370490).text();
```

The fix uses a saturating add (`+|`) so the value caps at `maxInt(u52)`; the subsequent allocation then fails with `OutOfMemory`, which is already handled by the existing `catch` block.

## How did you verify your code works?

- Reproduced the panic with the minimal repro above against the unfixed binary; the fixed binary exits cleanly.
- Added a regression test in `test/js/bun/util/bun-file-read.test.ts` that spawns a subprocess and asserts it exits with code 0 / no signal. Test fails (timeout, subprocess panics and hangs) on the unfixed binary and passes on the fixed binary.
- Ran the original Fuzzilli crash script repeatedly against the fixed binary with no panics.

Fuzzilli fingerprint: `4540f8005402e562`