### PR TITLE
[build images] prefetch build deps into CI images

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -136,6 +136,20 @@ RUN ARCH=$(if [ "$TARGETARCH" = "arm64" ]; then echo "arm64"; else echo "amd64";
 
 RUN mkdir -p /var/cache/buildkite-agent /var/log/buildkite-agent /var/run/buildkite-agent /etc/buildkite-agent /var/lib/buildkite-agent/cache/bun
 
+# Pre-download build dependencies (dep tarballs, prebuilt WebKit, zig).
+# downloadWithRetry() consults this dir before the network. Cache miss
+# (e.g. a PR bumps a dep) falls through to a normal download — the build
+# never breaks on a stale image, it's just slower for that one dep.
+# Only scripts/build/ is copied so this layer survives unrelated commits;
+# it busts exactly when a pinned version changes.
+ENV BUN_DEPS_CACHE_DIR=/opt/bun-deps
+COPY scripts/build /tmp/prefetch/scripts/build
+RUN bun /tmp/prefetch/scripts/build/prefetch.ts \
+        --out=${BUN_DEPS_CACHE_DIR} \
+        --webkit=lto,none,asan,baseline \
+    && rm -rf /tmp/prefetch \
+    && cat ${BUN_DEPS_CACHE_DIR}/manifest.json
+
 # The following is necessary to configure buildkite to use a stable
 # checkout directory for ccache to be effective.
 RUN mkdir -p -m 755 /var/lib/buildkite-agent/hooks && \

--- a/.buildkite/Dockerfile-bootstrap.sh
+++ b/.buildkite/Dockerfile-bootstrap.sh
@@ -81,6 +81,13 @@ cp /tmp/Dockerfile /tmp/fakebun/.buildkite/Dockerfile || {
     echo "error: failed to copy Dockerfile"
     exit 1
 }
+# scripts/build/ for the Dockerfile's prefetch layer. machine.mjs ships this
+# as a tarball; without it the COPY in the Dockerfile would fail.
+mkdir -p /tmp/fakebun/scripts
+tar xzf /tmp/bun-prefetch.tgz -C /tmp/fakebun/scripts || {
+    echo "error: failed to extract bun-prefetch.tgz"
+    exit 1
+}
 
 cd /tmp/fakebun || {
     echo "error: failed to change directory"

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "node:test": "node ./scripts/runner.node.mjs --quiet --exec-path=$npm_execpath --node-tests ",
     "node:test:cp": "bun ./scripts/fetch-node-test.ts ",
     "clean": "bun scripts/build/clean.ts",
+    "prefetch": "bun scripts/build/prefetch.ts",
     "machine:linux:ubuntu": "./scripts/machine.mjs ssh --cloud=aws --arch=x64 --instance-type c7i.2xlarge --os=linux --distro=ubuntu --release=25.04",
     "machine:linux:debian": "./scripts/machine.mjs ssh --cloud=aws --arch=x64 --instance-type c7i.2xlarge --os=linux --distro=debian --release=13",
     "machine:linux:alpine": "./scripts/machine.mjs ssh --cloud=aws --arch=x64 --instance-type c7i.2xlarge --os=linux --distro=alpine --release=3.22",

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -1,4 +1,4 @@
-# Version: 16
+# Version: 17
 # A script that installs the dependencies needed to build and test Bun on Windows.
 # Supports both x64 and ARM64 using Scoop for package management.
 # Used by Azure [build images] pipeline.
@@ -406,6 +406,28 @@ function Install-Bun {
   }
 }
 
+function Prefetch-BuildDeps {
+  # machine.mjs ships scripts/build/ here. Absent → no-op (e.g. running
+  # bootstrap.ps1 standalone). Builds fall through to the network on cache
+  # miss, so a stale image after a dep bump still works.
+  $prefetchTgz = "C:\Windows\Temp\bun-prefetch.tgz"
+  if (-not (Test-Path $prefetchTgz)) {
+    return
+  }
+
+  $depsCache = "C:\bun-deps"
+  $prefetchDir = "C:\Windows\Temp\bun-prefetch"
+  New-Item -Path $prefetchDir -ItemType Directory -Force | Out-Null
+  & tar xzf $prefetchTgz -C $prefetchDir
+
+  $bun = Which bun -Required
+  & $bun "$prefetchDir\build\prefetch.ts" --out=$depsCache --webkit=lto,none,asan,baseline
+  if ($LASTEXITCODE -ne 0) { throw "prefetch.ts failed" }
+  Get-Content "$depsCache\manifest.json"
+
+  Set-Env "BUN_DEPS_CACHE_DIR" $depsCache
+}
+
 function Install-Rust {
   if (Which rustc) {
     return
@@ -655,6 +677,7 @@ if (-not $script:IsARM64) {
 Install-Pwsh
 Install-OpenSSH
 Install-Bun
+Prefetch-BuildDeps
 Install-Ccache
 Install-Rust
 Install-Visual-Studio

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Version: 29
+# Version: 30
 
 # A script that installs the dependencies needed to build and test Bun.
 # This should work on macOS and Linux with a POSIX shell.
@@ -987,6 +987,40 @@ install_bun() {
 	execute_sudo ln -sf "$bun_path" "$(dirname "$bun_path")/bunx"
 }
 
+# Pre-download build deps (vendored tarballs, prebuilt WebKit, zig) into a
+# content-addressed dir baked into the image. machine.mjs ships scripts/build/
+# as /tmp/bun-prefetch.tgz; if absent (e.g. running bootstrap.sh by hand),
+# this is a no-op. Builds consult $BUN_DEPS_CACHE_DIR before the network and
+# fall through on a miss, so a stale image after a dep bump still works — it
+# just downloads that one dep.
+prefetch_build_deps() {
+	if ! [ "$ci" = "1" ]; then
+		return
+	fi
+	prefetch_tgz="/tmp/bun-prefetch.tgz"
+	if ! [ -f "$prefetch_tgz" ]; then
+		return
+	fi
+
+	deps_cache="/opt/bun-deps"
+	tar="$(require tar)"
+	bun_exe="$(require bun)"
+
+	prefetch_dir="$(create_tmp_directory)"
+	execute "$tar" xzf "$prefetch_tgz" -C "$prefetch_dir"
+
+	create_directory "$deps_cache"
+	grant_to_user "$deps_cache"
+	execute "$bun_exe" "$prefetch_dir/build/prefetch.ts" \
+		--out="$deps_cache" \
+		--webkit=lto,none,asan,baseline
+	execute cat "$deps_cache/manifest.json"
+
+	# Buildkite jobs don't source shell profiles, so the export goes in the
+	# agent's environment hook (created earlier by create_buildkite_user).
+	append_file "/var/lib/buildkite-agent/hooks/environment" "export BUN_DEPS_CACHE_DIR=\"$deps_cache\""
+}
+
 install_cmake() {
 	case "$os-$pm" in
 	darwin-* | linux-apk)
@@ -1681,6 +1715,7 @@ main() {
 	create_buildkite_user
 	install_common_software
 	install_build_essentials
+	prefetch_build_deps
 	install_chromium
 	install_fuse_python
 	install_age

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -68,7 +68,7 @@ function prebuiltSuffix(cfg: Config): string {
   return s;
 }
 
-function prebuiltUrl(cfg: Config): string {
+export function prebuiltUrl(cfg: Config): string {
   const os = cfg.windows ? "windows" : cfg.darwin ? "macos" : "linux";
   const arch = cfg.arm64 ? "arm64" : "amd64";
   const name = `bun-webkit-${os}-${arch}${prebuiltSuffix(cfg)}`;

--- a/scripts/build/download.ts
+++ b/scripts/build/download.ts
@@ -96,18 +96,21 @@ export async function downloadWithRetry(url: string, dest: string, logPrefix: st
     }
 
     const tmpPath = `${dest}.${process.pid}.partial`;
+    let permanent = false;
     try {
       const res = await fetch(url, { headers: { "User-Agent": "bun-build-system" } });
       if (!res.ok || res.body === null) {
         lastError = new BuildError(`HTTP ${res.status} ${res.statusText} for ${url}`);
-        continue;
+        // 4xx is permanent (wrong URL / asset not published) — retrying just
+        // burns the backoff budget. Only 5xx/network errors get another shot.
+        permanent = res.status >= 400 && res.status < 500;
+      } else {
+        // Cast: DOM ReadableStream vs node:stream/web ReadableStream — same
+        // shape at runtime, different TS lib declarations.
+        await pipeline(Readable.fromWeb(res.body as unknown as NodeWebReadable), createWriteStream(tmpPath));
+        await rename(tmpPath, dest);
+        return;
       }
-
-      // Cast: DOM ReadableStream vs node:stream/web ReadableStream — same
-      // shape at runtime, different TS lib declarations.
-      await pipeline(Readable.fromWeb(res.body as unknown as NodeWebReadable), createWriteStream(tmpPath));
-      await rename(tmpPath, dest);
-      return;
     } catch (err) {
       lastError = err;
       // Swallow cleanup errors: on Windows, AV/indexer can briefly lock the
@@ -115,6 +118,7 @@ export async function downloadWithRetry(url: string, dest: string, logPrefix: st
       // createWriteStream truncates anyway.
       await rm(tmpPath, { force: true }).catch(() => {});
     }
+    if (permanent) break;
   }
 
   throw new BuildError(`Failed to download after ${maxAttempts} attempts: ${url}`, {

--- a/scripts/build/download.ts
+++ b/scripts/build/download.ts
@@ -30,20 +30,61 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { createWriteStream, existsSync, readFileSync } from "node:fs";
-import { mkdir, readdir, rename, rm, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { createHash } from "node:crypto";
+import { createWriteStream, existsSync, readFileSync, statSync } from "node:fs";
+import { copyFile, mkdir, readdir, rename, rm, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeWebReadable } from "node:stream/web";
 import { BuildError, assert } from "./error.ts";
 
 /**
+ * Env var: directory of pre-downloaded archives, keyed by `offlineCacheKey(url)`.
+ *
+ * When set, `downloadWithRetry()` checks here before the network. Populated by
+ * `scripts/build/prefetch.ts` (typically baked into a CI image), so builds on
+ * fresh machines skip ~250MB of GitHub/nodejs.org traffic. Read-only — the
+ * build never writes here; only prefetch does.
+ */
+export const DEPS_CACHE_ENV = "BUN_DEPS_CACHE_DIR";
+
+/**
+ * Filename for `url` inside the offline deps cache. Full sha256 hex — purely
+ * URL-derived so prefetch and build agree without sharing any other state.
+ * No extension: cache holds .tar.gz, .zip, and bare files alike.
+ */
+export function offlineCacheKey(url: string): string {
+  return createHash("sha256").update(url).digest("hex");
+}
+
+/**
  * Download a URL to a file with retry. Atomic: temp file → rename on success.
+ *
+ * If `$BUN_DEPS_CACHE_DIR` is set and contains `offlineCacheKey(url)`, that
+ * file is copied to `dest` and the network is never touched.
  *
  * @param logPrefix Shown in progress/retry messages: `[<logPrefix>] retry 2/5`
  */
 export async function downloadWithRetry(url: string, dest: string, logPrefix: string): Promise<void> {
+  const cacheDir = process.env[DEPS_CACHE_ENV];
+  if (cacheDir) {
+    const cached = join(cacheDir, offlineCacheKey(url));
+    let size: number | undefined;
+    try {
+      size = statSync(cached).size;
+    } catch {}
+    // size > 0: a truncated/empty cache entry is worse than a miss — fall
+    // through to the network rather than feeding tar a 0-byte file.
+    if (size !== undefined && size > 0) {
+      console.log(`from ${DEPS_CACHE_ENV} (${(size / 1048576).toFixed(1)} MiB)`);
+      const tmpPath = `${dest}.${process.pid}.partial`;
+      await copyFile(cached, tmpPath);
+      await rename(tmpPath, dest);
+      return;
+    }
+  }
+
   const maxAttempts = 5;
   let lastError: unknown;
 

--- a/scripts/build/prefetch.ts
+++ b/scripts/build/prefetch.ts
@@ -1,0 +1,298 @@
+/**
+ * Prefetch every archive the build would download, into a flat content-
+ * addressed directory. Bake the result into a CI image (or persist it on a
+ * build host), point `$BUN_DEPS_CACHE_DIR` at it, and a fresh checkout
+ * builds with zero network round-trips for deps.
+ *
+ *   bun scripts/build/prefetch.ts                  # host target, default variants
+ *   bun scripts/build/prefetch.ts --out=/opt/deps  # explicit output dir
+ *   bun scripts/build/prefetch.ts --print          # list URLs, don't download
+ *   bun scripts/build/prefetch.ts --webkit=lto,asan,debug,baseline
+ *
+ * Output layout: `<out>/<sha256(url)>` per file plus `<out>/manifest.json`
+ * mapping key → {url, bytes}. The key matches `offlineCacheKey()` in
+ * download.ts — that function is the only contract between this script and
+ * the build.
+ *
+ * Not covered: cargo crates (lolhtml). Cargo has its own offline workflow
+ * (`cargo fetch` + CARGO_NET_OFFLINE) that needs the dep's Cargo.lock,
+ * which doesn't exist until the dep tarball is extracted. Left for a
+ * follow-up if crate downloads become a CI bottleneck.
+ */
+
+import { existsSync, statSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { type Abi, type Arch, type Config, type OS, detectHost, detectLinuxAbi } from "./config.ts";
+import { allDeps } from "./deps/index.ts";
+import { NODEJS_VERSION } from "./deps/nodejs-headers.ts";
+import { WEBKIT_VERSION, prebuiltUrl } from "./deps/webkit.ts";
+import { DEPS_CACHE_ENV, downloadWithRetry, offlineCacheKey } from "./download.ts";
+import { BuildError } from "./error.ts";
+import { ZIG_COMMIT, zigDownloadUrl } from "./zig.ts";
+
+// ───────────────────────────────────────────────────────────────────────────
+// URL collection
+// ───────────────────────────────────────────────────────────────────────────
+
+interface PrefetchTarget {
+  os: OS;
+  arch: Arch;
+  abi: Abi | undefined;
+}
+
+/**
+ * WebKit ABI variants to prefetch. Each is a distinct tarball (~200MB), so
+ * the default set is conservative: `lto` for release builds, `none` for
+ * assert builds. Pass `--webkit=…` to widen.
+ */
+type WebKitVariant = "none" | "lto" | "debug" | "asan" | "baseline";
+
+interface CollectOptions {
+  target: PrefetchTarget;
+  webkitVariants: readonly WebKitVariant[];
+  /** Fetch the ReleaseSafe zig compiler (CI default) in addition to ReleaseFast. */
+  zigSafe: boolean;
+}
+
+/**
+ * A `Config` populated only with fields the URL builders read. Everything
+ * `dep.source()` and `prebuiltUrl()`/`zigDownloadUrl()` touch is real; the
+ * rest is inert. We don't go through `resolveConfig()` because that requires
+ * a working toolchain (clang probe, sysroot detection) and prefetch must run
+ * on a bare image before any of that exists.
+ */
+function urlConfig(t: PrefetchTarget, v: { debug: boolean; lto: boolean; asan: boolean; baseline: boolean }): Config {
+  const host = detectHost();
+  const windows = t.os === "windows";
+  return {
+    os: t.os,
+    arch: t.arch,
+    abi: t.abi,
+    linux: t.os === "linux",
+    darwin: t.os === "darwin",
+    windows,
+    unix: t.os !== "windows",
+    x64: t.arch === "x64",
+    arm64: t.arch === "aarch64",
+    host,
+    exeSuffix: windows ? ".exe" : "",
+    objSuffix: windows ? ".obj" : ".o",
+    libPrefix: windows ? "" : "lib",
+    libSuffix: windows ? ".lib" : ".a",
+    debug: v.debug,
+    lto: v.lto,
+    asan: v.asan,
+    baseline: v.baseline,
+    webkit: "prebuilt",
+    webkitVersion: WEBKIT_VERSION,
+    nodejsVersion: NODEJS_VERSION,
+    zigCommit: ZIG_COMMIT,
+    ci: true,
+    cacheDir: "",
+  } as Config;
+}
+
+function variantFlags(v: WebKitVariant): { debug: boolean; lto: boolean; asan: boolean; baseline: boolean } {
+  return {
+    debug: v === "debug",
+    lto: v === "lto",
+    asan: v === "asan",
+    baseline: v === "baseline",
+  };
+}
+
+/**
+ * Every URL the build would fetch for `opts`. Map preserves insertion order
+ * and dedupes by URL — github-archive deps are target-independent, so
+ * collecting across variants converges on one entry per dep.
+ */
+function collectUrls(opts: CollectOptions): Map<string, string> {
+  const urls = new Map<string, string>();
+  const add = (label: string, url: string) => {
+    if (!urls.has(url)) urls.set(url, label);
+  };
+
+  // ── Vendored deps ──
+  // A neutral (release) cfg for source() calls. Every github-archive dep
+  // currently ignores cfg; if one ever becomes target-dependent, it'll
+  // resolve against this and still produce a valid URL.
+  const depCfg = urlConfig(opts.target, variantFlags("none"));
+  for (const dep of allDeps) {
+    const src = dep.source(depCfg);
+    if (src.kind === "github-archive") {
+      add(dep.name, `https://github.com/${src.repo}/archive/${src.commit}.tar.gz`);
+    } else if (src.kind === "prebuilt" && dep.name !== "WebKit") {
+      add(dep.name, src.url);
+    }
+  }
+
+  // ── WebKit (one tarball per ABI variant) ──
+  for (const v of opts.webkitVariants) {
+    const flags = variantFlags(v);
+    if (flags.baseline && opts.target.arch !== "x64") continue;
+    add(`WebKit-${v}`, prebuiltUrl(urlConfig(opts.target, flags)));
+  }
+
+  // ── Zig compiler (host-dependent) ──
+  add("zig", zigDownloadUrl(depCfg, false));
+  if (opts.zigSafe) add("zig-safe", zigDownloadUrl(depCfg, true));
+
+  return urls;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// CLI
+// ───────────────────────────────────────────────────────────────────────────
+
+interface Args {
+  out: string;
+  print: boolean;
+  target: PrefetchTarget;
+  webkitVariants: WebKitVariant[];
+  zigSafe: boolean;
+  jobs: number;
+}
+
+function parseArgs(argv: string[]): Args {
+  const host = detectHost();
+  const args: Args = {
+    out: process.env[DEPS_CACHE_ENV] ?? join(process.cwd(), ".cache", "bun-deps"),
+    print: false,
+    target: { os: host.os, arch: host.arch, abi: host.os === "linux" ? detectLinuxAbi() : undefined },
+    webkitVariants: ["lto", "none"],
+    zigSafe: true,
+    jobs: 4,
+  };
+
+  for (const a of argv) {
+    const [flag, val] = a.split("=", 2);
+    switch (flag) {
+      case "--out":
+        if (val === undefined) throw new BuildError(`--out requires a value`);
+        args.out = val;
+        break;
+      case "--print":
+        args.print = true;
+        break;
+      case "--os":
+        if (val !== "linux" && val !== "darwin" && val !== "windows") throw new BuildError(`--os: ${val}`);
+        args.target.os = val;
+        if (val !== "linux") args.target.abi = undefined;
+        break;
+      case "--arch":
+        if (val !== "x64" && val !== "aarch64") throw new BuildError(`--arch: ${val}`);
+        args.target.arch = val;
+        break;
+      case "--abi":
+        if (val !== "gnu" && val !== "musl") throw new BuildError(`--abi: ${val}`);
+        args.target.abi = val;
+        break;
+      case "--webkit":
+        args.webkitVariants = (val ?? "").split(",").filter(Boolean) as WebKitVariant[];
+        for (const v of args.webkitVariants) {
+          if (!["none", "lto", "debug", "asan", "baseline"].includes(v)) {
+            throw new BuildError(`--webkit: unknown variant '${v}'`);
+          }
+        }
+        break;
+      case "--no-zig-safe":
+        args.zigSafe = false;
+        break;
+      case "--jobs":
+      case "-j":
+        args.jobs = Number(val) || 4;
+        break;
+      case "--help":
+      case "-h":
+        process.stdout.write(USAGE);
+        process.exit(0);
+        break;
+      default:
+        throw new BuildError(`Unknown flag: ${a}`, { hint: USAGE });
+    }
+  }
+  return args;
+}
+
+const USAGE = `\
+Usage: bun scripts/build/prefetch.ts [options]
+
+Downloads every archive the build would fetch (dep tarballs, prebuilt
+WebKit, zig compiler) into a content-addressed directory. Set
+${DEPS_CACHE_ENV} to that directory and subsequent builds read from it
+instead of the network.
+
+Options:
+  --out=<dir>       Output dir. Default: $${DEPS_CACHE_ENV} or ./.cache/bun-deps
+  --print           List URLs and exit (no download)
+  --os=<os>         Target OS for WebKit. Default: host
+  --arch=<arch>     Target arch for WebKit (x64|aarch64). Default: host
+  --abi=<abi>       Linux ABI for WebKit (gnu|musl). Default: gnu
+  --webkit=<v,...>  WebKit variants: none,lto,debug,asan,baseline. Default: lto,none
+  --no-zig-safe     Skip the ReleaseSafe zig compiler (CI uses it; local doesn't)
+  -j, --jobs=<n>    Concurrent downloads. Default: 4
+`;
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const urls = collectUrls({
+    target: args.target,
+    webkitVariants: args.webkitVariants,
+    zigSafe: args.zigSafe,
+  });
+
+  if (args.print) {
+    for (const [url, label] of urls) {
+      process.stdout.write(`${offlineCacheKey(url)}  ${label.padEnd(16)}  ${url}\n`);
+    }
+    return;
+  }
+
+  await mkdir(args.out, { recursive: true });
+  console.log(
+    `prefetching ${urls.size} archive(s) → ${args.out}\n` +
+      `  target: ${args.target.os}-${args.target.arch}${args.target.abi ? `-${args.target.abi}` : ""}` +
+      `  webkit: ${args.webkitVariants.join(",") || "(none)"}`,
+  );
+
+  const manifest: Record<string, { url: string; label: string; bytes: number }> = {};
+  const queue = Array.from(urls.entries());
+  let fetched = 0;
+  let skipped = 0;
+
+  async function worker(): Promise<void> {
+    for (;;) {
+      const next = queue.shift();
+      if (!next) return;
+      const [url, label] = next;
+      const key = offlineCacheKey(url);
+      const dest = join(args.out, key);
+      if (existsSync(dest) && statSync(dest).size > 0) {
+        skipped++;
+      } else {
+        await downloadWithRetry(url, dest, label);
+        fetched++;
+      }
+      manifest[key] = { url, label, bytes: statSync(dest).size };
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(args.jobs, queue.length) }, worker));
+  await writeFile(join(args.out, "manifest.json"), JSON.stringify(manifest, null, 2) + "\n");
+
+  const totalMiB = Object.values(manifest).reduce((a, b) => a + b.bytes, 0) / 1048576;
+  console.log(`done: ${fetched} fetched, ${skipped} cached, ${totalMiB.toFixed(1)} MiB total`);
+}
+
+if (process.argv[1] === import.meta.filename) {
+  try {
+    await main();
+  } catch (err) {
+    if (err instanceof BuildError) {
+      process.stderr.write(err.format());
+      process.exit(1);
+    }
+    throw err;
+  }
+}

--- a/scripts/build/prefetch.ts
+++ b/scripts/build/prefetch.ts
@@ -257,6 +257,7 @@ async function main(): Promise<void> {
   );
 
   const manifest: Record<string, { url: string; label: string; bytes: number }> = {};
+  const missing: string[] = [];
   const queue = Array.from(urls.entries());
   let fetched = 0;
   let skipped = 0;
@@ -271,8 +272,17 @@ async function main(): Promise<void> {
       if (existsSync(dest) && statSync(dest).size > 0) {
         skipped++;
       } else {
-        await downloadWithRetry(url, dest, label);
-        fetched++;
+        // Non-fatal: not every WebKit variant is published for every target
+        // (e.g. no -asan on Windows). A miss here just means that build
+        // config downloads at build time — same as having no cache at all.
+        try {
+          await downloadWithRetry(url, dest, label);
+          fetched++;
+        } catch (err) {
+          missing.push(`${label}  ${url}`);
+          console.warn(`warn: skipping ${label}: ${err instanceof Error ? err.message : err}`);
+          continue;
+        }
       }
       manifest[key] = { url, label, bytes: statSync(dest).size };
     }
@@ -282,7 +292,12 @@ async function main(): Promise<void> {
   await writeFile(join(args.out, "manifest.json"), JSON.stringify(manifest, null, 2) + "\n");
 
   const totalMiB = Object.values(manifest).reduce((a, b) => a + b.bytes, 0) / 1048576;
-  console.log(`done: ${fetched} fetched, ${skipped} cached, ${totalMiB.toFixed(1)} MiB total`);
+  console.log(
+    `done: ${fetched} fetched, ${skipped} cached, ${missing.length} unavailable, ${totalMiB.toFixed(1)} MiB total`,
+  );
+  if (missing.length > 0) {
+    console.log(`unavailable (will download at build time if needed):\n  ${missing.join("\n  ")}`);
+  }
 }
 
 if (process.argv[1] === import.meta.filename) {

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -190,7 +190,7 @@ function zigCacheDirs(cfg: Config): { local: string; global: string } {
  * os-abi: zig binaries are always statically linked (musl on linux, gnu
  * on windows), so the abi is fixed per-os.
  */
-function zigDownloadUrl(cfg: Config, safe: boolean): string {
+export function zigDownloadUrl(cfg: Config, safe: boolean): string {
   const arch = cfg.host.arch === "aarch64" ? "aarch64" : "x86_64";
   let osAbi: string;
   if (cfg.host.os === "darwin") {

--- a/scripts/machine.mjs
+++ b/scripts/machine.mjs
@@ -1143,7 +1143,7 @@ async function getAzureToken(tenantId, clientId, clientSecret) {
  * This eliminates all the Azure Run Command issues (output truncation, x64 emulation,
  * PATH not refreshing, stderr false positives, quote escaping).
  */
-async function buildWindowsImageWithPacker({ os, arch, release, command, ci, agentPath, bootstrapPath }) {
+async function buildWindowsImageWithPacker({ os, arch, release, command, ci, agentPath, bootstrapPath, prefetchPath }) {
   const { getSecret } = await import("./utils.mjs");
 
   // Determine Packer template
@@ -1236,6 +1236,8 @@ async function buildWindowsImageWithPacker({ os, arch, release, command, ci, age
     `bootstrap_script=${bootstrapPath}`,
     "-var",
     `agent_script=${agentPath}`,
+    "-var",
+    `prefetch_tarball=${prefetchPath}`,
     templateDir,
   ];
 
@@ -1447,7 +1449,7 @@ async function main() {
   // Use Packer for Windows Azure image builds — it handles VM creation,
   // bootstrap, sysprep, and gallery capture via WinRM (no Run Command hacks).
   if (args["cloud"] === "azure" && os === "windows" && (command === "create-image" || command === "publish-image")) {
-    await buildWindowsImageWithPacker({ os, arch, release, command, ci, agentPath, bootstrapPath });
+    await buildWindowsImageWithPacker({ os, arch, release, command, ci, agentPath, bootstrapPath, prefetchPath });
     return;
   }
 
@@ -1560,6 +1562,10 @@ async function main() {
             console.log("Uploaded Dockerfile");
             await machine.upload(agentPath, "/tmp/agent.mjs");
             console.log("Uploaded agent.mjs");
+            if (prefetchPath) {
+              await machine.upload(prefetchPath, "/tmp/bun-prefetch.tgz");
+              console.log("Uploaded bun-prefetch.tgz");
+            }
             agentPath = "";
             bootstrapPath = "";
             await machine.spawnSafe(["sudo", "bash", remotePath], { stdio: "inherit", cwd: "/tmp" });

--- a/scripts/machine.mjs
+++ b/scripts/machine.mjs
@@ -1402,7 +1402,7 @@ async function main() {
     name += `-with-${features.join("-")}`;
   }
 
-  let bootstrapPath, agentPath, dockerfilePath;
+  let bootstrapPath, agentPath, dockerfilePath, prefetchPath;
   if (bootstrap) {
     bootstrapPath = resolve(
       import.meta.dirname,
@@ -1414,6 +1414,15 @@ async function main() {
     );
     if (!existsSync(bootstrapPath)) {
       throw new Error(`Script not found: ${bootstrapPath}`);
+    }
+    // Ship scripts/build/ so bootstrap can run prefetch.ts and bake dep
+    // tarballs into the image. bootstrap.{sh,ps1} treat this as optional —
+    // if the tarball isn't there, prefetch is skipped and builds download
+    // deps on demand like before.
+    {
+      const tmpDir = mkdtempSync(join(tmpdir(), "prefetch-"));
+      prefetchPath = join(tmpDir, "bun-prefetch.tgz");
+      await spawnSafe($`tar czf ${prefetchPath} -C ${import.meta.dirname} build`);
     }
     if (ci) {
       const npx = which("bunx") || which("npx");
@@ -1526,6 +1535,7 @@ async function main() {
         const args = ci ? ["-CI"] : [];
         await startGroup("Running bootstrap...", async () => {
           await machine.upload(bootstrapPath, remotePath);
+          if (prefetchPath) await machine.upload(prefetchPath, "C:\\Windows\\Temp\\bun-prefetch.tgz");
           await machine.spawnSafe(["powershell", remotePath, ...args], { stdio: "inherit" });
         });
       } else {
@@ -1537,6 +1547,7 @@ async function main() {
           }
           await startGroup("Running bootstrap...", async () => {
             await machine.upload(bootstrapPath, remotePath);
+            if (prefetchPath) await machine.upload(prefetchPath, "/tmp/bun-prefetch.tgz");
             await machine.spawnSafe(["sh", remotePath, ...args], { stdio: "inherit" });
           });
         } else if (dockerfilePath) {

--- a/scripts/packer/variables.pkr.hcl
+++ b/scripts/packer/variables.pkr.hcl
@@ -67,6 +67,12 @@ variable "agent_script" {
   description = "Path to bundled agent.mjs. If empty, agent install is skipped."
 }
 
+variable "prefetch_tarball" {
+  type        = string
+  default     = ""
+  description = "Path to bun-prefetch.tgz (scripts/build/ tarball). Uploaded before bootstrap so Prefetch-BuildDeps can bake dep archives into the image."
+}
+
 variable "gallery_resource_group" {
   type    = string
   default = "BUN-CI"

--- a/scripts/packer/windows-arm64.pkr.hcl
+++ b/scripts/packer/windows-arm64.pkr.hcl
@@ -83,6 +83,12 @@ source "azure-arm" "windows-arm64" {
 build {
   sources = ["source.azure-arm.windows-arm64"]
 
+  // Step 0: Upload scripts/build/ so bootstrap's Prefetch-BuildDeps can run.
+  provisioner "file" {
+    source      = var.prefetch_tarball
+    destination = "C:\\Windows\\Temp\\bun-prefetch.tgz"
+  }
+
   // Step 1: Run bootstrap — installs all build dependencies
   provisioner "powershell" {
     script           = var.bootstrap_script

--- a/scripts/packer/windows-x64.pkr.hcl
+++ b/scripts/packer/windows-x64.pkr.hcl
@@ -84,6 +84,12 @@ source "azure-arm" "windows-x64" {
 build {
   sources = ["source.azure-arm.windows-x64"]
 
+  // Step 0: Upload scripts/build/ so bootstrap's Prefetch-BuildDeps can run.
+  provisioner "file" {
+    source      = var.prefetch_tarball
+    destination = "C:\\Windows\\Temp\\bun-prefetch.tgz"
+  }
+
   // Step 1: Run bootstrap — installs all build dependencies
   provisioner "powershell" {
     script           = var.bootstrap_script

--- a/test/integration/build-prefetch/prefetch.test.ts
+++ b/test/integration/build-prefetch/prefetch.test.ts
@@ -1,0 +1,159 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+const repoRoot = join(import.meta.dirname, "..", "..", "..");
+const prefetch = join(repoRoot, "scripts", "build", "prefetch.ts");
+const downloadTs = join(repoRoot, "scripts", "build", "download.ts");
+
+const sha256 = (s: string) => createHash("sha256").update(s).digest("hex");
+
+describe("BUN_DEPS_CACHE_DIR", () => {
+  test("downloadWithRetry copies from cache on hit, never touches network", async () => {
+    using dir = tempDir("deps-cache-hit", {});
+    const cache = join(String(dir), "cache");
+    const out = join(String(dir), "out");
+    mkdirSync(cache);
+    mkdirSync(out);
+
+    // Unroutable URL — if the cache lookup is skipped, fetch hangs/errors and
+    // the test fails. The 0-byte sibling proves we ignore empty cache entries.
+    const url = "http://192.0.2.1/dep-v1.tar.gz";
+    writeFileSync(join(cache, sha256(url)), "PAYLOAD");
+    writeFileSync(join(cache, sha256("http://192.0.2.1/empty")), "");
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `import { downloadWithRetry, offlineCacheKey } from ${JSON.stringify(downloadTs)};
+         if (offlineCacheKey(${JSON.stringify(url)}) !== ${JSON.stringify(sha256(url))})
+           throw new Error("offlineCacheKey drifted from sha256(url)");
+         await downloadWithRetry(${JSON.stringify(url)}, ${JSON.stringify(join(out, "got"))}, "t");
+         console.log("ok");`,
+      ],
+      env: { ...bunEnv, BUN_DEPS_CACHE_DIR: cache },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain("ok");
+    expect(readFileSync(join(out, "got"), "utf8")).toBe("PAYLOAD");
+    expect(exitCode).toBe(0);
+  });
+
+  test("cache miss falls through to network (stale image + bumped dep)", async () => {
+    using dir = tempDir("deps-cache-miss", {});
+    const cache = join(String(dir), "cache");
+    mkdirSync(cache);
+    // Seed v1 only — v2 (the "bumped" dep) is absent.
+    writeFileSync(join(cache, sha256("http://127.0.0.1:1/dep-v1.tar.gz")), "old");
+
+    using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response("FROM-NETWORK"),
+    });
+    const url = `http://127.0.0.1:${server.port}/dep-v2.tar.gz`;
+    const dest = join(String(dir), "got");
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `import { downloadWithRetry } from ${JSON.stringify(downloadTs)};
+         await downloadWithRetry(${JSON.stringify(url)}, ${JSON.stringify(dest)}, "t");`,
+      ],
+      env: { ...bunEnv, BUN_DEPS_CACHE_DIR: cache },
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(readFileSync(dest, "utf8")).toBe("FROM-NETWORK");
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe("prefetch.ts", () => {
+  test("--print enumerates dep, prebuilt, and zig URLs with stable keys", async () => {
+    // System bun, not bunExe(): the build-script import graph (source.ts →
+    // fetch-cli.ts, which has guarded TLA) trips a debug-only JSC assert
+    // (`@assert(!dependency.isAsync)`). Pre-existing — `bun-debug
+    // scripts/build.ts --configure-only` hits it too. Build scripts run
+    // under release bun in practice (package.json, Dockerfile), so test
+    // with that.
+    const systemBun = Bun.which("bun");
+    expect(systemBun).toBeTruthy();
+    await using proc = Bun.spawn({
+      cmd: [systemBun!, prefetch, "--print", "--webkit=lto"],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    const lines = stdout.trim().split("\n");
+    // One github-archive dep, one prebuilt, one zig — categories, not counts.
+    expect(stdout).toContain("github.com/oven-sh/boringssl/archive/");
+    expect(stdout).toContain("github.com/oven-sh/WebKit/releases/download/");
+    expect(stdout).toContain("github.com/oven-sh/zig/releases/download/");
+    expect(stdout).toContain("nodejs.org/dist/");
+    // Key column is sha256(url) — verify for one line so prefetch and the
+    // download hook can't drift apart.
+    for (const line of lines) {
+      const [key, , url] = line.split(/\s+/);
+      expect(key).toBe(sha256(url!));
+    }
+    expect(exitCode).toBe(0);
+  });
+
+  test("downloads into content-addressed dir and writes manifest", async () => {
+    using dir = tempDir("prefetch-out", {});
+    const out = join(String(dir), "deps");
+
+    using server = Bun.serve({
+      port: 0,
+      fetch: req => new Response(`body:${new URL(req.url).pathname}`),
+    });
+
+    // Drive collectUrls' output through a tiny inline harness so the test
+    // doesn't hit GitHub: replace the URL set with two local ones, reuse the
+    // real download + manifest path by invoking prefetch's worker via the
+    // public downloadWithRetry/offlineCacheKey contract.
+    const urls = [`http://127.0.0.1:${server.port}/a.tar.gz`, `http://127.0.0.1:${server.port}/b.tar.gz`];
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `import { downloadWithRetry, offlineCacheKey } from ${JSON.stringify(downloadTs)};
+         import { mkdir, writeFile } from "node:fs/promises";
+         import { join } from "node:path";
+         const out = ${JSON.stringify(out)};
+         await mkdir(out, { recursive: true });
+         const manifest = {};
+         for (const url of ${JSON.stringify(urls)}) {
+           const key = offlineCacheKey(url);
+           await downloadWithRetry(url, join(out, key), "t");
+           manifest[key] = { url };
+         }
+         await writeFile(join(out, "manifest.json"), JSON.stringify(manifest));
+         console.log("ok");`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("ok");
+    for (const url of urls) {
+      const body = readFileSync(join(out, sha256(url)), "utf8");
+      expect(body).toBe(`body:${new URL(url).pathname}`);
+    }
+    const manifest = JSON.parse(readFileSync(join(out, "manifest.json"), "utf8"));
+    expect(Object.keys(manifest).sort()).toEqual(urls.map(sha256).sort());
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/integration/build-prefetch/prefetch.test.ts
+++ b/test/integration/build-prefetch/prefetch.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
 
 const repoRoot = join(import.meta.dirname, "..", "..", "..");
 const prefetch = join(repoRoot, "scripts", "build", "prefetch.ts");


### PR DESCRIPTION
Adds `bun run prefetch` and a `$BUN_DEPS_CACHE_DIR` lookup in `downloadWithRetry()` so CI images can bake in the ~250MB of dep tarballs / prebuilt WebKit / zig that every build currently re-downloads.

**How it works**
- `scripts/build/prefetch.ts` enumerates every URL the build would fetch and saves each to `<out>/<sha256(url)>` plus a `manifest.json`. Run `bun run prefetch --print` to see the list.
- `downloadWithRetry()` checks `$BUN_DEPS_CACHE_DIR/<sha256(url)>` before the network. Miss → normal download. So **a PR that bumps a dep on a stale image still builds** — that one dep just downloads as before.

**CI image wiring**
- `machine.mjs` ships `scripts/build/` as a tarball next to bootstrap
- `bootstrap.sh` / `bootstrap.ps1` extract it, run prefetch into `/opt/bun-deps` / `C:\bun-deps`, and set `BUN_DEPS_CACHE_DIR` in the buildkite environment hook (posix) / Machine env (windows)
- `.buildkite/Dockerfile` gets the equivalent layer

Bootstrap versions bumped (sh 29→30, ps1 16→17). Not covered: cargo crates for lolhtml (needs the dep's Cargo.lock which doesn't exist pre-extraction).