### PR TITLE
fix(valkey): guard updatePollRef against finalized this_value

### DIFF
--- a/src/valkey/js_valkey.zig
+++ b/src/valkey/js_valkey.zig
@@ -1263,7 +1263,14 @@ pub const JSValkeyClient = struct {
         // isDeletable may throw an exception, and if it does, we have to assume
         // that the object still has references. Best we can do is hope nothing
         // catastrophic happens.
-        const subs_deletable: bool = !(this._subscription_ctx.hasSubscriptions(this.globalObject) catch false);
+        //
+        // Once the JS wrapper has been finalized, the subscription callback map
+        // (stored on the JS object) is gone. Reading it would hit `unreachable`
+        // in `subscriptionCallbackMap()` because `this_value.tryGet()` returns
+        // null for a finalized ref. Short-circuit here: a finalized client has
+        // no subscriptions by definition.
+        const subs_deletable: bool = this.client.flags.finalized or
+            !(this._subscription_ctx.hasSubscriptions(this.globalObject) catch false);
 
         const has_activity = has_pending_commands or !subs_deletable or this.client.flags.is_reconnecting;
 

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -10,14 +10,18 @@ import { bunEnv, bunExe } from "harness";
 
 test.concurrent("RedisClient survives GC after a command throws during argument validation", async () => {
   const src = `
+    let threw = 0;
     for (let i = 0; i < 200; i++) {
       const c = new Bun.RedisClient();
       try {
         // BigUint64Array (a constructor function) is not a valid argument,
         // so this throws before send() / connect() is ever called.
         c.zrangebylex(65535, 65535, BigUint64Array);
-      } catch {}
+      } catch {
+        threw++;
+      }
     }
+    if (threw !== 200) throw new Error("expected zrangebylex to throw on every call, got " + threw);
     Bun.gc(true);
     await 1;
     Bun.gc(true);

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -8,7 +8,7 @@ import { bunEnv, bunExe } from "harness";
 // `orelse unreachable` because `this_value.tryGet()` returns null for a
 // finalized JSRef.
 
-test("RedisClient survives GC after a command throws during argument validation", async () => {
+test.concurrent("RedisClient survives GC after a command throws during argument validation", async () => {
   const src = `
     for (let i = 0; i < 200; i++) {
       const c = new Bun.RedisClient();
@@ -38,7 +38,7 @@ test("RedisClient survives GC after a command throws during argument validation"
   expect(exitCode).toBe(0);
 });
 
-test("RedisClient survives GC across many short-lived instances", async () => {
+test.concurrent("RedisClient survives GC across many short-lived instances", async () => {
   const src = `
     for (let i = 0; i < 1000; i++) {
       new Bun.RedisClient();

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -28,7 +28,7 @@ test("RedisClient survives GC after a command throws during argument validation"
     cmd: [bunExe(), "-e", src],
     env: bunEnv,
     stdout: "pipe",
-    stderr: "pipe",
+    stderr: "inherit",
   });
 
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
@@ -40,7 +40,7 @@ test("RedisClient survives GC after a command throws during argument validation"
 
 test("RedisClient survives GC across many short-lived instances", async () => {
   const src = `
-    for (let i = 0; i < 5000; i++) {
+    for (let i = 0; i < 1000; i++) {
       new Bun.RedisClient();
     }
     Bun.gc(true);
@@ -53,7 +53,7 @@ test("RedisClient survives GC across many short-lived instances", async () => {
     cmd: [bunExe(), "-e", src],
     env: bunEnv,
     stdout: "pipe",
-    stderr: "pipe",
+    stderr: "inherit",
   });
 
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Fuzzer found a flaky SIGILL when a RedisClient is constructed, a command
+// throws during argument validation (before any connection attempt), and the
+// client is then garbage collected. `updatePollRef` could be reached after
+// the JS wrapper was finalized, and `subscriptionCallbackMap()` would hit
+// `orelse unreachable` because `this_value.tryGet()` returns null for a
+// finalized JSRef.
+
+test("RedisClient survives GC after a command throws during argument validation", async () => {
+  const src = `
+    for (let i = 0; i < 200; i++) {
+      const c = new Bun.RedisClient();
+      try {
+        // BigUint64Array (a constructor function) is not a valid argument,
+        // so this throws before send() / connect() is ever called.
+        c.zrangebylex(65535, 65535, BigUint64Array);
+      } catch {}
+    }
+    Bun.gc(true);
+    await 1;
+    Bun.gc(true);
+    console.log("OK");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("OK");
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});
+
+test("RedisClient survives GC across many short-lived instances", async () => {
+  const src = `
+    for (let i = 0; i < 5000; i++) {
+      new Bun.RedisClient();
+    }
+    Bun.gc(true);
+    await 1;
+    Bun.gc(true);
+    console.log("OK");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("OK");
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fuzzilli found a flaky SIGILL (fingerprint `3a1165d6b5ef80c4`) with:

```js
const v4 = new Bun.RedisClient();
try { v4.zrangebylex(65535, 65535, BigUint64Array); } catch (e) {}
Bun.gc(true);
```

## What

`updatePollRef()` computes `hasSubscriptions()` → `subscriptionCallbackMap()`, which does:

```zig
const parent_this = this.parent().this_value.tryGet() orelse unreachable;
```

After `finalize()` runs, `this_value` is in the `.finalized` state and `tryGet()` returns `null`, tripping the `unreachable` → SIGILL.

`updatePollRef()` is reachable after finalize: `finalize()` → `closeSocketNextTick()` enqueues a task → task runs `client.close()` → uSockets synchronously fires `SocketHandler.onClose` → its `defer` calls `updatePollRef()`. Both `SocketHandler.onClose` and `onValkeyClose` have deferred `updatePollRef()` calls that can race with a finalized wrapper.

## How

Short-circuit on `flags.finalized` before calling `hasSubscriptions()`, mirroring the existing guard in `SubscriptionCtx.isDeletable()`. Once the JS wrapper is gone there is no subscription callback map to read and no subscriptions to keep alive.

The crash was too flaky to reproduce deterministically outside the REPRL loop (conservative stack scanning keeps the wrapper alive most of the time), but the code path is real and the `unreachable` is demonstrably reachable. Added a test that exercises many short-lived RedisClient instances under GC pressure.