### PR TITLE
deflake: fetch-proxy-tls-intern-race timeout on Linux release builds

### DIFF
--- a/test/js/web/fetch/fetch-proxy-tls-intern-race-fixture.ts
+++ b/test/js/web/fetch/fetch-proxy-tls-intern-race-fixture.ts
@@ -31,6 +31,16 @@ let stop = false;
 let driverOk = 0;
 let probes = 0;
 
+// Hard cap is started immediately as a timer (not awaited sequentially) so it
+// is authoritative regardless of what the loops below are blocked on. It both
+// flips `stop` and aborts any in-flight driver fetch so `await driverDone`
+// cannot hang on a stalled proxy connection.
+const driverAbort = new AbortController();
+const hardCap = setTimeout(() => {
+  stop = true;
+  driverAbort.abort();
+}, HARD_CAP_MS);
+
 // Probe: setImmediate loop firing fetch+abort. Each call to fetch() runs
 // intern() on the JS thread. abort() causes the request to complete quickly,
 // triggering deref() on the HTTP thread. The JS thread immediately queues
@@ -51,21 +61,23 @@ function probe() {
 async function driver() {
   while (!stop) {
     try {
-      const r = await fetch(url, { proxy, keepalive: false, tls });
+      const r = await fetch(url, { proxy, keepalive: false, tls, signal: driverAbort.signal });
       if ((await r.text()) === "ok") driverOk++;
     } catch {}
     await Bun.sleep(1);
   }
 }
 
-// Run both concurrently in the same event loop.
-probe();
+// Let the driver complete one request against an idle proxy before starting
+// the probe flood, so the driverOk>0 sanity check holds even on loaded CI.
+// Bounded by hardCap above — if the warmup itself stalls, stop flips and we
+// fall through to report driverOk=0 (a real failure) instead of hanging.
 const driverDone = driver();
+while (driverOk === 0 && !stop) await Bun.sleep(1);
+probe();
 
-// Hard cap so the fixture always terminates.
-await Bun.sleep(HARD_CAP_MS);
-stop = true;
 await driverDone;
+clearTimeout(hardCap);
 
 process.stdout.write(JSON.stringify({ driverOk, probes }) + "\n");
 process.exit(0);

--- a/test/js/web/fetch/fetch-proxy-tls-intern-race-fixture.ts
+++ b/test/js/web/fetch/fetch-proxy-tls-intern-race-fixture.ts
@@ -36,10 +36,10 @@ let probes = 0;
 // flips `stop` and aborts any in-flight driver fetch so `await driverDone`
 // cannot hang on a stalled proxy connection.
 const driverAbort = new AbortController();
-const hardCap = setTimeout(() => {
+setTimeout(() => {
   stop = true;
   driverAbort.abort();
-}, HARD_CAP_MS);
+}, HARD_CAP_MS).unref();
 
 // Probe: setImmediate loop firing fetch+abort. Each call to fetch() runs
 // intern() on the JS thread. abort() causes the request to complete quickly,
@@ -77,7 +77,6 @@ while (driverOk === 0 && !stop) await Bun.sleep(1);
 probe();
 
 await driverDone;
-clearTimeout(hardCap);
 
 process.stdout.write(JSON.stringify({ driverOk, probes }) + "\n");
 process.exit(0);

--- a/test/js/web/fetch/fetch-proxy-tls-intern-race.test.ts
+++ b/test/js/web/fetch/fetch-proxy-tls-intern-race.test.ts
@@ -22,6 +22,14 @@ import { join } from "node:path";
 async function createConnectProxy() {
   const server = net.createServer(client => {
     let head = Buffer.alloc(0);
+    let upstream: net.Socket | undefined;
+    // The probe loop aborts immediately after fetch(), so the client socket
+    // often closes with FIN (not RST) before or during the upstream connect.
+    // Without a "close" handler the proxy→backend socket leaks, and after a
+    // few thousand probes the backend's accept queue / FD table saturates and
+    // the driver's fetch stalls forever. Tear down upstream on any client exit.
+    client.on("error", () => upstream?.destroy());
+    client.on("close", () => upstream?.destroy());
     const onData = (chunk: Buffer) => {
       head = Buffer.concat([head, chunk]);
       const headerEnd = head.indexOf("\r\n\r\n");
@@ -32,15 +40,15 @@ async function createConnectProxy() {
       const colon = hostPort!.lastIndexOf(":");
       const host = hostPort!.slice(0, colon);
       const port = Number(hostPort!.slice(colon + 1));
-      const upstream = net.connect(port, host, () => {
+      upstream = net.connect(port, host, () => {
         client.write("HTTP/1.1 200 Connection Established\r\n\r\n");
         const extra = head.subarray(headerEnd + 4);
-        if (extra.length > 0) upstream.write(extra);
-        client.pipe(upstream);
-        upstream.pipe(client);
+        if (extra.length > 0) upstream!.write(extra);
+        client.pipe(upstream!);
+        upstream!.pipe(client);
       });
       upstream.on("error", () => client.destroy());
-      client.on("error", () => upstream.destroy());
+      upstream.on("close", () => client.destroy());
     };
     client.on("data", onData);
   });


### PR DESCRIPTION
## Summary

Fixes the 41/200 timeout flake of `test/js/web/fetch/fetch-proxy-tls-intern-race.test.ts` on Linux release targets (🐧 25.04 x64-baseline, 🐧 3.23 aarch64, 🐧 13 x64-baseline).

**Root cause:** the test's CONNECT proxy only handled `client.on("error")`, not `"close"`. The probe loop aborts each fetch immediately, so the client→proxy socket usually closes with FIN (not RST). The proxy→backend `upstream` socket was never destroyed in that path. On release builds the `setImmediate` probe loop fires thousands of times per second, so orphaned TLS connections accumulate on the backend `Bun.serve` until its accept queue / FD table saturates and the driver's fetch stalls. The driver fetch had no abort signal, so `await driverDone` hung past the 30s test timeout.

**Fix:**
- Proxy: destroy `upstream` on client `"close"` (and vice versa) so aborted probes don't leak backend connections.
- Fixture: start the hard cap as a `setTimeout` up front so it's authoritative regardless of what the loops are blocked on; it flips `stop` and aborts the in-flight driver fetch.
- Fixture: let the driver complete one request against an idle proxy before the probe flood so the `driverOk > 0` sanity check holds on loaded CI. The warmup wait is bounded by the same hard-cap timer (addresses the unbounded-loop review feedback on #28873).

Supersedes the `fetch-proxy-tls-intern-race-fixture.ts` portion of #28873.

## Test plan
- [x] 20× sequential runs with release build (bun-pr 29163): all pass at ~5.4s
- [x] 18× parallel runs (6 concurrent × 3 rounds) under load: all pass
- [x] 4× `bun bd test` (debug+ASAN): all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)