### PR TITLE
fetch: fix race where upgraded request body stream never starts

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -2114,6 +2114,14 @@ pub fn toResult(this: *HTTPClient) HTTPClientResult {
     else
         .{ .unknown = {} };
 
+    // FetchTasklet.callback() coalesces results: a later toResult() can overwrite an earlier
+    // one before the JS thread sees it. The first progressUpdate after request headers are
+    // sent is what flips can_stream=true so the JS side starts pulling the request body
+    // stream. If the response headers race in before that task runs and we report
+    // can_stream=false here, the request body stream is never started and upgraded
+    // connections (which depend on the body stream for their write side) deadlock.
+    const can_stream = (this.state.request_stage == .body or this.state.request_stage == .proxy_body) and this.flags.is_streaming_request_body;
+
     var certificate_info: ?CertificateInfo = null;
     if (this.state.certificate_info) |info| {
         // transfer owner ship of the certificate info here
@@ -2131,6 +2139,7 @@ pub fn toResult(this: *HTTPClient) HTTPClientResult {
             .has_more = certificate_info != null or (this.state.fail == null and !this.state.isDone()),
             .body_size = body_size,
             .certificate_info = null,
+            .can_stream = can_stream,
         };
     }
     return HTTPClientResult{
@@ -2142,8 +2151,7 @@ pub fn toResult(this: *HTTPClient) HTTPClientResult {
         .has_more = certificate_info != null or (this.state.fail == null and !this.state.isDone()),
         .body_size = body_size,
         .certificate_info = certificate_info,
-        // we can stream the request_body at this stage
-        .can_stream = (this.state.request_stage == .body or this.state.request_stage == .proxy_body) and this.flags.is_streaming_request_body,
+        .can_stream = can_stream,
     };
 }
 

--- a/test/js/web/fetch/fetch.upgrade.test.ts
+++ b/test/js/web/fetch/fetch.upgrade.test.ts
@@ -37,26 +37,30 @@ describe("fetch upgrade", () => {
     expect(res.headers.get("sec-websocket-accept")).toBeString();
     expect(res.headers.get("connection")).toBe("Upgrade");
 
-    const clientMessages: string[] = [];
-    const { promise, resolve } = Promise.withResolvers<void>();
     const reader = res.body!.getReader();
+    // Accumulate across reads: a frame may straddle two reader.read() chunks and
+    // decodeFrames() silently skips partial frames at the tail of its input, so we
+    // re-decode the full buffer from scratch each iteration.
+    let buffered = Buffer.alloc(0);
+    let clientMessages: string[] = [];
+    let gotClose = false;
 
-    while (true) {
+    while (!gotClose) {
       const { value, done } = await reader.read();
       if (done) break;
-      for (const msg of decodeFrames(Buffer.from(value))) {
+      buffered = Buffer.concat([buffered, Buffer.from(value)]);
+      clientMessages = [];
+      for (const msg of decodeFrames(buffered)) {
         if (typeof msg === "string") {
           clientMessages.push(msg);
         } else {
           clientMessages.push(msg.type);
-        }
-
-        if (msg.type === "close") {
-          resolve();
+          if (msg.type === "close") gotClose = true;
         }
       }
     }
-    await promise;
+    await reader.cancel();
+    expect(gotClose).toBe(true);
     expect(serverMessages).toEqual(["hello", "world", "bye", "close"]);
     expect(clientMessages).toEqual(["Hello World", "close"]);
   });


### PR DESCRIPTION
## Summary

Fixes the intermittent `test/js/web/fetch/fetch.upgrade.test.ts` timeout seen on `:ubuntu: 25.04 aarch64` (and reproducible ~90% locally under `taskset -c 0`).

## Root cause

`FetchTasklet.callback()` coalesces `HTTPClientResult`s: if the HTTP thread fires two `progressUpdate`s before the JS thread drains the queued task, the second result overwrites the first in `task.result` (`FetchTasklet.zig:1385`).

The first update — fired right after request headers are sent — carries `can_stream=true`, which is the signal for the JS side to call `startRequestStream()` and begin pulling from the request `body` generator. The second update — the 101 response metadata — went through the `cloned_metadata` branch of `toResult()` (`http.zig:2125`) which **never set `.can_stream`**, so it defaulted to `false`.

When the server's 101 + `open()` frame race in before the JS thread processes the first task:
1. `task.result.can_stream` is overwritten `true` → `false`
2. `onProgressUpdate` runs once, sees `can_stream=false`, skips `startRequestStream()`
3. The body generator is never pulled → close frame never sent → server never closes → `reader.read()` blocks forever

## Fix

Compute `can_stream` once in `toResult()` and set it on both return branches, so the metadata-carrying result also reports the correct streaming state.

Also hardened the test's read loop to accumulate bytes across `reader.read()` chunks (the `decodeFrames` helper silently skips a frame that straddles two chunks).

## Verification

```sh
# Before (bun-29171, x64): 27/30 hung
# After (debug build): passes under same single-CPU stress
for i in $(seq 1 30); do
  timeout 15 taskset -c 0 ./build/debug/bun-debug test test/js/web/fetch/fetch.upgrade.test.ts
done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)