### PR TITLE
feat(vscode): add terminal debugging support via console configuration

### DIFF
--- a/packages/bun-debug-adapter-protocol/src/debugger/adapter.ts
+++ b/packages/bun-debug-adapter-protocol/src/debugger/adapter.ts
@@ -111,13 +111,13 @@ type InitializeRequest = DAP.InitializeRequest & {
   enableConsole?: boolean | true;
 } & (
     | {
-        enableLifecycleAgentReporter?: false;
-        sendImmediatePreventExit?: false;
-      }
+      enableLifecycleAgentReporter?: false;
+      sendImmediatePreventExit?: false;
+    }
     | {
-        enableLifecycleAgentReporter: true;
-        sendImmediatePreventExit?: boolean;
-      }
+      enableLifecycleAgentReporter: true;
+      sendImmediatePreventExit?: boolean;
+    }
   );
 
 type LaunchRequest = DAP.LaunchRequest & {
@@ -127,6 +127,7 @@ type LaunchRequest = DAP.LaunchRequest & {
   args?: string[];
   cwd?: string;
   env?: Record<string, string>;
+  console?: "internalConsole" | "integratedTerminal" | "externalTerminal";
   strictEnv?: boolean;
   stopOnEntry?: boolean;
   noDebug?: boolean;
@@ -148,15 +149,15 @@ type Source = DAP.Source & {
   sourceMap: SourceMap;
 } & (
     | {
-        sourceId: string;
-        path: string;
-        sourceReference?: undefined;
-      }
+      sourceId: string;
+      path: string;
+      sourceReference?: undefined;
+    }
     | {
-        sourceId: number;
-        path?: undefined;
-        sourceReference: number;
-      }
+      sourceId: number;
+      path?: undefined;
+      sourceReference: number;
+    }
   );
 
 type Breakpoint = DAP.Breakpoint & {
@@ -212,7 +213,7 @@ export type DebugAdapterEventMap = InspectorEventMap & {
   "Adapter.response": [DAP.Response];
   "Adapter.event": [DAP.Event];
   "Adapter.error": [Error];
-  "Adapter.reverseRequest": [DAP.Request];
+  "Adapter.reverseRequest": [DAP.Request & { cb: (response: DAP.Response) => void }];
 } & {
   "Process.requested": [unknown];
   "Process.spawned": [ChildProcess];
@@ -383,12 +384,15 @@ export abstract class BaseDebugAdapter<T extends Inspector = Inspector>
     });
   }
 
-  #reverseRequest<T extends keyof DAP.RequestMap>(command: T, args?: DAP.RequestMap[T]): void {
-    this.emit("Adapter.reverseRequest", {
-      type: "request",
-      seq: 0,
-      command,
-      arguments: args,
+  protected reverseRequest<T extends keyof DAP.RequestMap>(command: T, args?: DAP.RequestMap[T]): Promise<DAP.Response> {
+    return new Promise(resolve => {
+      this.emit("Adapter.reverseRequest", {
+        type: "request",
+        seq: 0,
+        command,
+        arguments: args,
+        cb: resolve,
+      });
     });
   }
 
@@ -2141,6 +2145,7 @@ export class WebSocketDebugAdapter extends BaseDebugAdapter<WebSocketInspector> 
       args = [],
       cwd,
       env = {},
+      console = "internalConsole",
       strictEnv = false,
       watchMode = false,
       stopOnEntry = false,
@@ -2172,81 +2177,64 @@ export class WebSocketDebugAdapter extends BaseDebugAdapter<WebSocketInspector> 
 
     const processEnv = strictEnv
       ? {
-          ...env,
-        }
+        ...env,
+      }
       : {
-          ...process.env,
-          ...env,
-        };
+        ...process.env,
+        ...env,
+      };
 
-    if (process.platform !== "win32") {
-      // we're on unix
-      const url = `ws+unix://${randomUnixPath()}`;
-      const signal = new UnixSignal();
-
-      signal.on("Signal.received", () => {
-        this.#attach({ url });
-      });
-
-      this.once("Adapter.terminated", () => {
-        signal.close();
-      });
-
-      const query = stopOnEntry ? "break=1" : "wait=1";
-      processEnv["BUN_INSPECT"] = `${url}?${query}`;
-      processEnv["BUN_INSPECT_NOTIFY"] = signal.url;
-
-      // This is probably not correct, but it's the best we can do for now.
-      processEnv["FORCE_COLOR"] = "1";
-      processEnv["BUN_QUIET_DEBUG_LOGS"] = "1";
-      processEnv["BUN_DEBUG_QUIET_LOGS"] = "1";
-
-      const started = await this.#spawn({
-        command: runtime,
-        args: processArgs,
-        env: processEnv,
-        cwd,
-        isDebugee: true,
-      });
-
-      if (!started) {
-        throw new Error("Program could not be started.");
+    const { url, signal } = process.platform !== "win32"
+      ? {
+        url: `ws+unix://${randomUnixPath()}`,
+        signal: new UnixSignal(),
       }
-    } else {
-      // we're on windows
-      // Create TCPSocketSignal
-      const url = `ws://127.0.0.1:${await getAvailablePort()}/${getRandomId()}`; // 127.0.0.1 so it resolves correctly on windows
-      const signal = new TCPSocketSignal(await getAvailablePort());
+      : {
+        url: `ws://127.0.0.1:${await getAvailablePort()}/${getRandomId()}`, // 127.0.0.1 so it resolves correctly on windows
+        signal: new TCPSocketSignal(await getAvailablePort()),
+      };
 
-      signal.on("Signal.received", async () => {
-        this.#attach({ url });
-      });
+    signal.on("Signal.received", () => {
+      this.#attach({ url });
+    });
 
-      this.once("Adapter.terminated", () => {
-        signal.close();
-      });
+    this.once("Adapter.terminated", () => {
+      signal.close();
+    });
 
-      const query = stopOnEntry ? "break=1" : "wait=1";
-      processEnv["BUN_INSPECT"] = `${url}?${query}`;
-      processEnv["BUN_INSPECT_NOTIFY"] = signal.url; // 127.0.0.1 so it resolves correctly on windows
+    const query = stopOnEntry ? "break=1" : "wait=1";
+    processEnv["BUN_INSPECT"] = `${url}?${query}`;
+    processEnv["BUN_INSPECT_NOTIFY"] = signal.url;
 
-      // This is probably not correct, but it's the best we can do for now.
-      processEnv["FORCE_COLOR"] = "1";
-      processEnv["BUN_QUIET_DEBUG_LOGS"] = "1";
-      processEnv["BUN_DEBUG_QUIET_LOGS"] = "1";
+    // This is probably not correct, but it's the best we can do for now.
+    processEnv["FORCE_COLOR"] = "1";
+    processEnv["BUN_QUIET_DEBUG_LOGS"] = "1";
+    processEnv["BUN_DEBUG_QUIET_LOGS"] = "1";
 
-      const started = await this.#spawn({
-        command: runtime,
-        args: processArgs,
-        env: processEnv,
-        cwd,
-        isDebugee: true,
-      });
+    const usingTerminal = console === "integratedTerminal" || console === "externalTerminal";
 
-      if (!started) {
-        throw new Error("Program could not be started.");
-      }
+    const started = usingTerminal ? await this.#runInTerminal({
+      kind: console === "integratedTerminal" ? "integrated" : "external",
+      title: "Bun Debug",
+      cwd: cwd ?? process.cwd(),
+      args: [runtime, ...processArgs],
+      env: processEnv,
+    }) : await this.#spawn({
+      command: runtime,
+      args: processArgs,
+      env: processEnv,
+      cwd,
+      isDebugee: true,
+    });
+
+    if (!started) {
+      throw new Error("Program could not be started.");
     }
+  }
+
+  async #runInTerminal(request: DAP.RunInTerminalRequest): Promise<boolean> {
+    const resp = await this.reverseRequest("runInTerminal", request);
+    return resp.success;
   }
 
   async #spawn(options: {

--- a/packages/bun-vscode/package.json
+++ b/packages/bun-vscode/package.json
@@ -224,6 +224,21 @@
                 "description": "The environment variables to pass to Bun.",
                 "default": {}
               },
+              "console": {
+                "type": "string",
+                "description": "The console to use.",
+                "enum": [
+                  "internalConsole",
+                  "integratedTerminal",
+                  "externalTerminal"
+                ],
+                "enumDescriptions": [
+                  "VS Code Debug Console (which doesn't support to read input from a program)",
+                  "VS Code's integrated terminal",
+                  "External terminal that can be configured via user settings"
+                ],
+                "default": "internalConsole"
+              },
               "strictEnv": {
                 "type": "boolean",
                 "description": "If environment variables should not be inherited from the parent process.",

--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -410,8 +410,8 @@ class FileDebugSession extends DebugSession {
       });
     }
 
-    this.adapter.on("Adapter.reverseRequest", ({ command, arguments: args }) =>
-      this.sendRequest(command, args, 5000, () => {}),
+    this.adapter.on("Adapter.reverseRequest", ({ command, arguments: args, cb }) =>
+      this.sendRequest(command, args, 5000, (resp) => cb(resp as DAP.Response))
     );
 
     adapters.set(url, this);
@@ -435,6 +435,10 @@ class FileDebugSession extends DebugSession {
       }
 
       this.adapter.emit("Adapter.request", message);
+    } else if (type === "response") {
+      // Handle response messages (e.g., from reverse requests like runInTerminal)
+      // Pass to parent class ProtocolServer to trigger the callback
+      super.handleMessage(message);
     } else {
       throw new Error(`Not supported: ${type}`);
     }


### PR DESCRIPTION
Add support for launching Bun debugger in integrated or external terminal via the 'console' setting in launch.json. This allows debugging programs that require terminal input or need to run in a real terminal environment.

Changes:
- Add runInTerminal reverse request support in debug adapter
- Handle 'integratedTerminal' and 'externalTerminal' console options
- Pass proper environment variables for terminal debugging

Fixes #15706

### What does this PR do?

This PR adds support for the `console` configuration option in `launch.json` to enable debugging Bun programs in an integrated or external terminal.

Currently, when debugging programs that require user input (e.g., `readline()`, `prompt()`), the debugger cannot properly handle stdin because it runs in the debug console. This PR allows users to configure `console: "integratedTerminal"` or `console: "externalTerminal"` in their launch configuration, enabling terminal-based debugging with full stdin/stdout support.

Changes:
- Added `runInTerminal` reverse request support in the debug adapter
- Handle `integratedTerminal` and `externalTerminal` console options
- Pass proper environment variables for terminal debugging sessions

### How did you verify your code works?

1. Created a test script that uses `readline()` to accept user input
2. Configured `launch.json` with `"console": "integratedTerminal"`
3. Started debugging session and confirmed the program launches in VS Code's integrated terminal
4. Verified user input works correctly during debugging
5. Tested with `"console": "externalTerminal"` to confirm external terminal support