### PR TITLE
http: emit ServerResponse 'close' on client disconnect

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -908,6 +908,12 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
         req.destroy();
       }
     }
+
+    // Fire the close callback set by assignSocketInternal
+    // (onServerResponseClose). This forwards the socket close to the
+    // attached ServerResponse so `res.on("close", ...)` runs on client
+    // disconnect, matching Node.js. See issues #29219, #14697.
+    callCloseCallback(this);
   }
   #onCloseForDestroy(closeCallback) {
     this.#onClose();

--- a/test/regression/issue/29219.test.ts
+++ b/test/regression/issue/29219.test.ts
@@ -1,0 +1,86 @@
+// https://github.com/oven-sh/bun/issues/29219
+import { expect, test } from "bun:test";
+import http from "node:http";
+import net from "node:net";
+
+test("ServerResponse emits 'close' when the client aborts mid-response", async () => {
+  const { promise, resolve } = Promise.withResolvers<{
+    resClosed: boolean;
+    reqErrored: boolean;
+  }>();
+
+  let resClosed = false;
+  let reqErrored = false;
+
+  const server = http.createServer((req, res) => {
+    res.on("close", () => {
+      resClosed = true;
+    });
+
+    // Write some data so the response is mid-stream when the client aborts.
+    res.write("hello\n");
+
+    req.on("error", () => {
+      reqErrored = true;
+      server.close(() => {
+        resolve({ resClosed, reqErrored });
+      });
+    });
+  });
+
+  await new Promise<void>(done => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as net.AddressInfo;
+      const client = net.createConnection({ port, host: "127.0.0.1" }, () => {
+        client.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+        client.on("data", () => {
+          client.end(); // force abort mid-response
+        });
+      });
+      done();
+    });
+  });
+
+  const result = await promise;
+  expect(result).toEqual({ resClosed: true, reqErrored: true });
+});
+
+// Also covers https://github.com/oven-sh/bun/issues/14697 — same root
+// cause, but the handler never writes a response before the client
+// disconnects. Pre-fix, only `req.on("close")` fired.
+test("ServerResponse emits 'close' when the client aborts before any write", async () => {
+  const { promise, resolve } = Promise.withResolvers<{
+    resClosed: boolean;
+    reqClosed: boolean;
+  }>();
+
+  let resClosed = false;
+  let reqClosed = false;
+
+  const server = http.createServer((req, res) => {
+    res.once("close", () => {
+      resClosed = true;
+      if (reqClosed) server.close(() => resolve({ resClosed, reqClosed }));
+    });
+    req.once("close", () => {
+      reqClosed = true;
+      if (resClosed) server.close(() => resolve({ resClosed, reqClosed }));
+    });
+    // Deliberately don't write or end — wait for the client to go away.
+  });
+
+  await new Promise<void>(done => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as net.AddressInfo;
+      const client = net.createConnection({ port, host: "127.0.0.1" }, () => {
+        client.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+        // Wait a tick so the server receives the request, then yank the socket.
+        setTimeout(() => client.destroy(), 100);
+      });
+      done();
+    });
+  });
+
+  const result = await promise;
+  expect(result).toEqual({ resClosed: true, reqClosed: true });
+});

--- a/test/regression/issue/29219.test.ts
+++ b/test/regression/issue/29219.test.ts
@@ -4,83 +4,79 @@ import http from "node:http";
 import net from "node:net";
 
 test("ServerResponse emits 'close' when the client aborts mid-response", async () => {
-  const { promise, resolve } = Promise.withResolvers<{
-    resClosed: boolean;
-    reqErrored: boolean;
+  const { promise: closed, resolve: resolveClosed } = Promise.withResolvers<{
+    writableEnded: boolean;
   }>();
-
-  let resClosed = false;
-  let reqErrored = false;
 
   const server = http.createServer((req, res) => {
     res.on("close", () => {
-      resClosed = true;
+      resolveClosed({ writableEnded: res.writableEnded });
     });
 
     // Write some data so the response is mid-stream when the client aborts.
     res.write("hello\n");
-
-    req.on("error", () => {
-      reqErrored = true;
-      server.close(() => {
-        resolve({ resClosed, reqErrored });
-      });
-    });
   });
 
-  await new Promise<void>(done => {
-    server.listen(0, "127.0.0.1", () => {
-      const { port } = server.address() as net.AddressInfo;
-      const client = net.createConnection({ port, host: "127.0.0.1" }, () => {
-        client.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
-        client.on("data", () => {
-          client.end(); // force abort mid-response
+  try {
+    await new Promise<void>(done => {
+      server.listen(0, "127.0.0.1", () => {
+        const { port } = server.address() as net.AddressInfo;
+        const client = net.createConnection({ port, host: "127.0.0.1" }, () => {
+          client.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
         });
+        client.on("data", () => {
+          // Abrupt close once the server has written its first chunk.
+          client.destroy();
+        });
+        client.on("error", () => {});
+        done();
       });
-      done();
     });
-  });
 
-  const result = await promise;
-  expect(result).toEqual({ resClosed: true, reqErrored: true });
+    const result = await closed;
+    // Pre-fix, this promise never resolved. Post-fix, it resolves and
+    // writableEnded is false because the client yanked the socket before
+    // res.end() could run.
+    expect(result).toEqual({ writableEnded: false });
+  } finally {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
 });
 
 // Also covers https://github.com/oven-sh/bun/issues/14697 — same root
 // cause, but the handler never writes a response before the client
 // disconnects. Pre-fix, only `req.on("close")` fired.
 test("ServerResponse emits 'close' when the client aborts before any write", async () => {
-  const { promise, resolve } = Promise.withResolvers<{
-    resClosed: boolean;
-    reqClosed: boolean;
-  }>();
-
-  let resClosed = false;
-  let reqClosed = false;
+  const { promise: resClose, resolve: resolveResClose } = Promise.withResolvers<void>();
+  const { promise: reqClose, resolve: resolveReqClose } = Promise.withResolvers<void>();
+  const { promise: requestSeen, resolve: markRequestSeen } = Promise.withResolvers<void>();
 
   const server = http.createServer((req, res) => {
-    res.once("close", () => {
-      resClosed = true;
-      if (reqClosed) server.close(() => resolve({ resClosed, reqClosed }));
-    });
-    req.once("close", () => {
-      reqClosed = true;
-      if (resClosed) server.close(() => resolve({ resClosed, reqClosed }));
-    });
+    res.once("close", resolveResClose);
+    req.once("close", resolveReqClose);
+    markRequestSeen();
     // Deliberately don't write or end — wait for the client to go away.
   });
 
-  await new Promise<void>(done => {
-    server.listen(0, "127.0.0.1", () => {
-      const { port } = server.address() as net.AddressInfo;
-      const client = net.createConnection({ port, host: "127.0.0.1" }, () => {
-        client.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
-        // Wait a tick so the server receives the request, then yank the socket.
-        setTimeout(() => client.destroy(), 100);
+  try {
+    await new Promise<void>(done => {
+      server.listen(0, "127.0.0.1", () => {
+        const { port } = server.address() as net.AddressInfo;
+        const client = net.createConnection({ port, host: "127.0.0.1" }, () => {
+          client.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+          // Destroy the client only after the server has entered the handler.
+          requestSeen.then(() => client.destroy());
+        });
+        client.on("error", () => {});
+        done();
       });
-      done();
     });
-  });
 
-  const result = await promise;
-  expect(result).toEqual({ resClosed: true, reqClosed: true });
+    // Both events must fire. Pre-fix, res close never did — this would
+    // hang and timeout the test instead of reaching the assertion.
+    await Promise.all([resClose, reqClose]);
+    expect(true).toBe(true);
+  } finally {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
 });

--- a/test/regression/issue/29219.test.ts
+++ b/test/regression/issue/29219.test.ts
@@ -47,13 +47,15 @@ test("ServerResponse emits 'close' when the client aborts mid-response", async (
 // cause, but the handler never writes a response before the client
 // disconnects. Pre-fix, only `req.on("close")` fired.
 test("ServerResponse emits 'close' when the client aborts before any write", async () => {
-  const { promise: resClose, resolve: resolveResClose } = Promise.withResolvers<void>();
+  const { promise: resClose, resolve: resolveResClose } = Promise.withResolvers<{
+    writableEnded: boolean;
+  }>();
   const { promise: reqClose, resolve: resolveReqClose } = Promise.withResolvers<void>();
   const { promise: requestSeen, resolve: markRequestSeen } = Promise.withResolvers<void>();
 
   const server = http.createServer((req, res) => {
-    res.once("close", resolveResClose);
-    req.once("close", resolveReqClose);
+    res.once("close", () => resolveResClose({ writableEnded: res.writableEnded }));
+    req.once("close", () => resolveReqClose());
     markRequestSeen();
     // Deliberately don't write or end — wait for the client to go away.
   });
@@ -72,10 +74,11 @@ test("ServerResponse emits 'close' when the client aborts before any write", asy
       });
     });
 
-    // Both events must fire. Pre-fix, res close never did — this would
-    // hang and timeout the test instead of reaching the assertion.
-    await Promise.all([resClose, reqClose]);
-    expect(true).toBe(true);
+    // Pre-fix, `res.on("close")` never fired, so awaiting resClose would
+    // hang and the test would timeout. Post-fix, both events fire and
+    // writableEnded is false because the handler never called res.end().
+    const [resResult] = await Promise.all([resClose, reqClose]);
+    expect(resResult).toEqual({ writableEnded: false });
   } finally {
     await new Promise<void>(resolve => server.close(() => resolve()));
   }


### PR DESCRIPTION
## Summary

`http.ServerResponse` never fired its `'close'` event when the client aborted mid-response. Reported in #29219; same root cause as #14697.

## Repro

```js
import http from 'node:http';
import net from 'node:net';

const server = http.createServer((req, res) => {
  let closed = false;
  res.on('close', () => { closed = true; console.log('res close fired'); });
  res.write('hello\n');
  req.on('error', () => {
    server.close(() => console.log('server closed, res closed =', closed));
  });
});

server.listen(3000, () => {
  const client = net.createConnection({ port: 3000 }, () => {
    client.write('GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n');
    client.on('data', () => client.end());
  });
});
```

Node / Deno:
```
res close fired
server closed, res closed = true
```

Bun, pre-fix:
```
server closed, res closed = false
```

## Cause

`assignSocketInternal` takes the `canUseInternalAssignSocket` fast path and stores `onServerResponseClose` on the socket via `setCloseCallback` (i.e. `socket[kCloseCallback] = onServerResponseClose`) instead of registering a real `.once('close', ...)` listener — this is a ~10% perf win in JSC.

When the underlying native handle was closed (via `handle.onclose`), `NodeHTTPServerSocket#onClose` destroyed the `IncomingMessage` but never invoked the stored `kCloseCallback`. The `onServerResponseClose` → `emitCloseNT(httpMessage)` chain that forwards the event to the attached `ServerResponse` therefore never ran.

## Fix

Call `callCloseCallback(this)` at the end of `NodeHTTPServerSocket#onClose`, after the request-destroy step. This runs whether the handle was closed by the native side (abort) or via `#onCloseForDestroy`, so both the mid-response case (#29219) and the no-write case (#14697) are covered.

## Tests

`test/regression/issue/29219.test.ts` covers two scenarios:

1. Client aborts after receiving the first chunk of a response that's already in-flight (#29219 repro).
2. Client destroys the socket before the handler writes anything (#14697 repro).

Verified with the gate:
- without fix → both tests fail (`resClosed: false`, second test times out)
- with fix → both tests pass

Fixes #29219
Fixes #14697