### PR TITLE
Fix dynamic import() resolving before TLA module finishes evaluating

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2711,6 +2711,19 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
 
     putDirectBuiltinFunction(vm, this, builtinNames.overridableRequirePrivateName(), commonJSOverridableRequireCodeGenerator(vm), 0);
 
+    // Override the stock WebKit `requestImportModule` builtin on the
+    // JSModuleLoader with a version that correctly waits for an in-flight
+    // top-level-await evaluation before resolving. The stock builtin sets
+    // `entry.evaluated = true` synchronously at the start of async
+    // evaluation, which causes a concurrent dynamic `import()` of the same
+    // module to take a fast path and return the namespace before the TLA
+    // completes. See https://github.com/oven-sh/bun/issues/29221.
+    //
+    // The JSC C++ `JSModuleLoader::requestImportModule` looks this function
+    // up dynamically by its private-name property, so installing our version
+    // here replaces both C++-initiated and JS-initiated dynamic imports.
+    this->moduleLoader()->putDirectBuiltinFunction(vm, this, vm.propertyNames->builtinNames().requestImportModulePublicName(), moduleLoaderOverridesRequestImportModuleCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontEnum);
+
     putDirectNativeFunction(vm, this, builtinNames.createUninitializedArrayBufferPrivateName(), 1, functionCreateUninitializedArrayBuffer, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectNativeFunction(vm, this, builtinNames.resolveSyncPrivateName(), 1, functionImportMeta__resolveSyncPrivate, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectNativeFunction(vm, this, builtinNames.createInternalModuleByIdPrivateName(), 1, InternalModuleRegistry::jsCreateInternalModuleById, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2720,8 +2720,9 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     // completes. See https://github.com/oven-sh/bun/issues/29221.
     //
     // The JSC C++ `JSModuleLoader::requestImportModule` looks this function
-    // up dynamically by its private-name property, so installing our version
-    // here replaces both C++-initiated and JS-initiated dynamic imports.
+    // up dynamically by its public-name property (the plain string key, not
+    // an @-prefixed private symbol), so installing our version here replaces
+    // both C++-initiated and JS-initiated dynamic imports.
     this->moduleLoader()->putDirectBuiltinFunction(vm, this, vm.propertyNames->builtinNames().requestImportModulePublicName(), moduleLoaderOverridesRequestImportModuleCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontEnum);
 
     putDirectNativeFunction(vm, this, builtinNames.createUninitializedArrayBufferPrivateName(), 1, functionCreateUninitializedArrayBuffer, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2723,7 +2723,7 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     // up dynamically by its public-name property (the plain string key, not
     // an @-prefixed private symbol), so installing our version here replaces
     // both C++-initiated and JS-initiated dynamic imports.
-    this->moduleLoader()->putDirectBuiltinFunction(vm, this, vm.propertyNames->builtinNames().requestImportModulePublicName(), moduleLoaderOverridesRequestImportModuleCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontEnum);
+    this->moduleLoader()->putDirectBuiltinFunction(vm, this, vm.propertyNames->builtinNames().requestImportModulePublicName(), moduleLoaderOverridesRequestImportModuleCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
 
     putDirectNativeFunction(vm, this, builtinNames.createUninitializedArrayBufferPrivateName(), 1, functionCreateUninitializedArrayBuffer, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectNativeFunction(vm, this, builtinNames.resolveSyncPrivateName(), 1, functionImportMeta__resolveSyncPrivate, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);

--- a/src/js/builtins/ModuleLoaderOverrides.ts
+++ b/src/js/builtins/ModuleLoaderOverrides.ts
@@ -51,6 +51,11 @@ export async function requestImportModule(
 
   // Fast path 2: another caller raced us through requestSatisfy and already
   // finished (or is in the middle of) evaluating.
+  //
+  // `entry.evaluated` and `entry.module` are both set synchronously at the
+  // start of `linkAndEvaluateModule` below, so whenever `evaluatingPromise`
+  // is truthy `evaluated`/`module` are already set — this path is the only
+  // place concurrent TLA callers rendezvous.
   if (entry.evaluated && (mod = entry.module)) {
     if (entry.evaluatingPromise) {
       await entry.evaluatingPromise;
@@ -58,19 +63,15 @@ export async function requestImportModule(
     return this.getModuleNamespaceObject(mod);
   }
 
-  // Another concurrent import may have reached the eval step first.
-  if (entry.evaluatingPromise) {
-    await entry.evaluatingPromise;
-    return this.getModuleNamespaceObject(entry.module);
-  }
-
   // First call to reach evaluation for this entry. `linkAndEvaluateModule`
   // returns `moduleEvaluation(entry, fetcher)` directly, which for a TLA
   // module is the promise returned by `asyncModuleEvaluation`. Cache it on
   // the entry so any concurrent caller that slips through the fast paths
-  // can observe and await the same in-flight evaluation.
+  // can observe and await the same in-flight evaluation. Use the tamper-
+  // proof `$isPromise` intrinsic rather than a duck-typed `.then` check so
+  // `delete Promise.prototype.then` in user code can't defeat the fix.
   const evalResult = this.linkAndEvaluateModule(entry.key, fetcher);
-  if (evalResult && typeof (evalResult as any).then === "function") {
+  if (evalResult && $isPromise(evalResult)) {
     entry.evaluatingPromise = evalResult;
     try {
       await evalResult;

--- a/src/js/builtins/ModuleLoaderOverrides.ts
+++ b/src/js/builtins/ModuleLoaderOverrides.ts
@@ -48,7 +48,7 @@ export async function requestImportModule(
     return this.getModuleNamespaceObject(mod);
   }
 
-  entry = await this.requestSatisfy(entry, parameters, fetcher, new Set());
+  entry = await this.requestSatisfy(entry, parameters, fetcher, new $Set());
 
   // Fast path 2: another caller raced us through requestSatisfy and already
   // finished (or is in the middle of) evaluating.

--- a/src/js/builtins/ModuleLoaderOverrides.ts
+++ b/src/js/builtins/ModuleLoaderOverrides.ts
@@ -1,6 +1,6 @@
 // Override(s) installed on the JSC `JSModuleLoader` object at Zig::GlobalObject
 // construction. Each builtin in this file is installed by
-// ZigGlobalObject::finishCreation via `moduleLoader->putDirectBuiltinFunction`.
+// `GlobalObject::addBuiltinGlobals` via `moduleLoader->putDirectBuiltinFunction`.
 //
 // Why this file exists: the stock WebKit builtin `ModuleLoader.js`'s
 // `requestImportModule` has a fast path that returns the module namespace

--- a/src/js/builtins/ModuleLoaderOverrides.ts
+++ b/src/js/builtins/ModuleLoaderOverrides.ts
@@ -1,0 +1,82 @@
+// Override(s) installed on the JSC `JSModuleLoader` object at Zig::GlobalObject
+// construction. Each builtin in this file is installed by
+// ZigGlobalObject::finishCreation via `moduleLoader->putDirectBuiltinFunction`.
+//
+// Why this file exists: the stock WebKit builtin `ModuleLoader.js`'s
+// `requestImportModule` has a fast path that returns the module namespace
+// synchronously when `entry.evaluated` is set, even though for a top-level
+// await (TLA) module `entry.evaluated` is set *before* evaluation has
+// actually completed. As a result, a second dynamic `import()` of the same
+// module while the first is still mid-TLA resolves its promise before the
+// module finishes evaluating — breaking ECMA262 ContinueDynamicImport and
+// diverging from Node/Deno. See https://github.com/oven-sh/bun/issues/29221.
+//
+// Bun ships prebuilt WebKit, so patching the vendored `ModuleLoader.js`
+// isn't enough — we install this override on top of the existing builtin.
+// JSC's C++ `JSModuleLoader::requestImportModule` looks the function up
+// dynamically by its private-name property every time, so overriding the
+// property is sufficient for both C++-initiated and JS-initiated imports.
+//
+// The fix: cache the evaluation promise on the registry entry so concurrent
+// dynamic imports can `await` it instead of taking the early-return path.
+
+// `this` is the JSModuleLoader; `requestImportModule` is a builtin method.
+$visibility = "Private";
+export async function requestImportModule(
+  this: any,
+  moduleName: string,
+  referrer: unknown,
+  parameters: unknown,
+  fetcher: unknown,
+) {
+  "use strict";
+
+  const key = moduleName;
+  let entry = this.ensureRegistered(key);
+  let mod: unknown;
+
+  // Fast path 1: entry already present with a module record.
+  //
+  // If evaluation is still in flight (TLA), `entry.evaluatingPromise` holds
+  // the async evaluation promise — wait on it before handing the namespace
+  // back. This is the key fix for issue #29221.
+  if (entry.evaluated && (mod = entry.module)) {
+    if (entry.evaluatingPromise) {
+      await entry.evaluatingPromise;
+    }
+    return this.getModuleNamespaceObject(mod);
+  }
+
+  entry = await this.requestSatisfy(entry, parameters, fetcher, new Set());
+
+  // Fast path 2: another caller raced us through requestSatisfy and already
+  // finished (or is in the middle of) evaluating.
+  if (entry.evaluated && (mod = entry.module)) {
+    if (entry.evaluatingPromise) {
+      await entry.evaluatingPromise;
+    }
+    return this.getModuleNamespaceObject(mod);
+  }
+
+  // Another concurrent import may have reached the eval step first.
+  if (entry.evaluatingPromise) {
+    await entry.evaluatingPromise;
+    return this.getModuleNamespaceObject(entry.module);
+  }
+
+  // First call to reach evaluation for this entry. `linkAndEvaluateModule`
+  // returns `moduleEvaluation(entry, fetcher)` directly, which for a TLA
+  // module is the promise returned by `asyncModuleEvaluation`. Cache it on
+  // the entry so any concurrent caller that slips through the fast paths
+  // can observe and await the same in-flight evaluation.
+  const evalResult = this.linkAndEvaluateModule(entry.key, fetcher);
+  if (evalResult && typeof (evalResult as any).then === "function") {
+    entry.evaluatingPromise = evalResult;
+    try {
+      await evalResult;
+    } finally {
+      entry.evaluatingPromise = undefined;
+    }
+  }
+  return this.getModuleNamespaceObject(entry.module);
+}

--- a/src/js/builtins/ModuleLoaderOverrides.ts
+++ b/src/js/builtins/ModuleLoaderOverrides.ts
@@ -14,8 +14,9 @@
 // Bun ships prebuilt WebKit, so patching the vendored `ModuleLoader.js`
 // isn't enough — we install this override on top of the existing builtin.
 // JSC's C++ `JSModuleLoader::requestImportModule` looks the function up
-// dynamically by its private-name property every time, so overriding the
-// property is sufficient for both C++-initiated and JS-initiated imports.
+// dynamically by its public-name property (the plain string key, not an
+// @-prefixed private symbol) every time, so overriding the property is
+// sufficient for both C++-initiated and JS-initiated imports.
 //
 // The fix: cache the evaluation promise on the registry entry so concurrent
 // dynamic imports can `await` it instead of taking the early-return path.

--- a/test/regression/issue/29221.test.ts
+++ b/test/regression/issue/29221.test.ts
@@ -1,14 +1,19 @@
 // https://github.com/oven-sh/bun/issues/29221
+// Also covers https://github.com/oven-sh/bun/issues/20489
+// and         https://github.com/oven-sh/bun/issues/22367
 //
 // Dynamic `import()` of a module with top-level await must not resolve its
 // promise before the module finishes evaluating. Repeated `import()` calls
-// for the same module share one evaluation — both `.then()` handlers fire
+// for the same module share one evaluation — every `.then()` handler fires
 // AFTER the module's TLA settles, matching Node.js / Deno.
 //
 // Bug was in JSC's ModuleLoader.js builtin (`requestImportModule` /
 // `moduleEvaluation`): `entry.evaluated` was set synchronously at the start
 // of async evaluation, so a second `import()` in the same tick took a fast
-// path that returned the namespace without awaiting the pending TLA.
+// path that returned the namespace without awaiting the pending TLA. The
+// visible symptoms were (a) `.then()` handlers firing in reversed order
+// (#29221) and (b) concurrent importers observing uninitialized bindings
+// ("Cannot access 'x' before initialization" — #20489, #22367).
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
@@ -30,7 +35,8 @@ globalThis.order.push("tla-end");
   });
 
   await using proc = Bun.spawn({
-    cmd: [bunExe(), String(dir) + "/entry.mjs"],
+    cmd: [bunExe(), "entry.mjs"],
+    cwd: String(dir),
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
@@ -44,11 +50,55 @@ globalThis.order.push("tla-end");
   // second import's `.then()` fired before the TLA even resumed, because
   // the JSC builtin's fast path returned the namespace without awaiting
   // the pending evaluation promise.
-  expect({
-    stdout: stdout.trim(),
-    exitCode,
-  }).toEqual({
-    stdout: `["tla-start","tla-end","then-a","then-b"]`,
-    exitCode: 0,
+  expect(stdout.trim()).toBe(`["tla-start","tla-end","then-a","then-b"]`);
+  expect(exitCode).toBe(0);
+});
+
+test("concurrent dynamic imports of a TLA module all see initialized bindings (#20489, #22367)", async () => {
+  // Mirrors the reproduction from #20489: five concurrent `import()` calls
+  // for the same TLA module. Pre-fix, imports 2..5 took the fast path,
+  // resolved early, and saw the module's named exports still in the TDZ
+  // ("Cannot access 'x' before initialization"). After the fix, every
+  // import waits for the same in-flight evaluation and observes fully
+  // initialized bindings.
+  using dir = tempDir("issue-29221-concurrent", {
+    "entry.mjs": `
+const results = [];
+async function load(i) {
+  const mod = await import("./tla-exports.mjs");
+  // Touching both exports would throw TDZ pre-fix. Read them eagerly.
+  results.push([i, mod.arr.length, typeof mod.fn]);
+}
+await Promise.all([load(1), load(2), load(3), load(4), load(5)]);
+// Sort by import index so the assertion doesn't depend on resolution order.
+results.sort((a, b) => a[0] - b[0]);
+console.log(JSON.stringify(results));
+`,
+    "tla-exports.mjs": `
+// Yield across a microtask boundary so all five imports start before
+// this module's bindings are initialized.
+await new Promise((r) => setTimeout(r, 20));
+export const arr = [1, 2, 3];
+export function fn() { return "ok"; }
+`,
   });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout.trim()).toBe(
+    `[[1,3,"function"],[2,3,"function"],[3,3,"function"],[4,3,"function"],[5,3,"function"]]`,
+  );
+  expect(stderr).not.toContain("before initialization");
+  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/29221.test.ts
+++ b/test/regression/issue/29221.test.ts
@@ -18,18 +18,7 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-// ASAN builds unconditionally print "WARNING: ASAN interferes with JSC
-// signal handlers..." to stderr from WebKit's Options.cpp; filter it out
-// so debug runs don't fail the stderr-empty assertions below.
-function cleanStderr(stderr: string): string {
-  return stderr
-    .split("\n")
-    .filter(line => !line.startsWith("WARNING: ASAN interferes"))
-    .join("\n")
-    .trim();
-}
-
-test("dynamic import waits for top-level await to settle (#29221)", async () => {
+test.concurrent("dynamic import waits for top-level await to settle (#29221)", async () => {
   using dir = tempDir("issue-29221", {
     "entry.mjs": `
 globalThis.order = [];
@@ -52,7 +41,7 @@ globalThis.order.push("tla-end");
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // Expected ordering: the TLA module runs to completion first (tla-start
   // then tla-end), then BOTH .then() handlers fire in import order.
@@ -62,19 +51,20 @@ globalThis.order.push("tla-end");
   // the JSC builtin's fast path returned the namespace without awaiting
   // the pending evaluation promise.
   expect(stdout.trim()).toBe(`["tla-start","tla-end","then-a","then-b"]`);
-  expect(cleanStderr(stderr)).toBe("");
   expect(exitCode).toBe(0);
 });
 
-test("concurrent dynamic imports of a TLA module all see initialized bindings (#20489, #22367)", async () => {
-  // Mirrors the reproduction from #20489: five concurrent `import()` calls
-  // for the same TLA module. Pre-fix, imports 2..5 took the fast path,
-  // resolved early, and saw the module's named exports still in the TDZ
-  // ("Cannot access 'x' before initialization"). After the fix, every
-  // import waits for the same in-flight evaluation and observes fully
-  // initialized bindings.
-  using dir = tempDir("issue-29221-concurrent", {
-    "entry.mjs": `
+test.concurrent(
+  "concurrent dynamic imports of a TLA module all see initialized bindings (#20489, #22367)",
+  async () => {
+    // Mirrors the reproduction from #20489: five concurrent `import()` calls
+    // for the same TLA module. Pre-fix, imports 2..5 took the fast path,
+    // resolved early, and saw the module's named exports still in the TDZ
+    // ("Cannot access 'x' before initialization"). After the fix, every
+    // import waits for the same in-flight evaluation and observes fully
+    // initialized bindings.
+    using dir = tempDir("issue-29221-concurrent", {
+      "entry.mjs": `
 const results = [];
 async function load(i) {
   const mod = await import("./tla-exports.mjs");
@@ -86,25 +76,33 @@ await Promise.all([load(1), load(2), load(3), load(4), load(5)]);
 results.sort((a, b) => a[0] - b[0]);
 console.log(JSON.stringify(results));
 `,
-    "tla-exports.mjs": `
+      "tla-exports.mjs": `
 // Yield across a microtask boundary so all five imports start before
 // this module's bindings are initialized.
 await new Promise((r) => setTimeout(r, 20));
 export const arr = [1, 2, 3];
 export function fn() { return "ok"; }
 `,
-  });
+    });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "entry.mjs"],
-    cwd: String(dir),
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
 
-  expect(stdout.trim()).toBe(`[[1,3,"function"],[2,3,"function"],[3,3,"function"],[4,3,"function"],[5,3,"function"]]`);
-  expect(cleanStderr(stderr)).toBe("");
-  expect(exitCode).toBe(0);
-});
+    expect(stdout.trim()).toBe(`[[1,3,"function"],[2,3,"function"],[3,3,"function"],[4,3,"function"],[5,3,"function"]]`);
+    // Failure mode for #20489/#22367 is a TDZ error on the child; assert
+    // explicitly that no uninitialized-binding error reached stderr in
+    // addition to the exitCode check below.
+    expect(stderr).not.toContain("before initialization");
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/regression/issue/29221.test.ts
+++ b/test/regression/issue/29221.test.ts
@@ -1,0 +1,58 @@
+// https://github.com/oven-sh/bun/issues/29221
+//
+// Dynamic `import()` of a module with top-level await must not resolve its
+// promise before the module finishes evaluating. Repeated `import()` calls
+// for the same module share one evaluation — both `.then()` handlers fire
+// AFTER the module's TLA settles, matching Node.js / Deno.
+//
+// Bug was in JSC's ModuleLoader.js builtin (`requestImportModule` /
+// `moduleEvaluation`): `entry.evaluated` was set synchronously at the start
+// of async evaluation, so a second `import()` in the same tick took a fast
+// path that returned the namespace without awaiting the pending TLA.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("dynamic import waits for top-level await to settle (#29221)", async () => {
+  using dir = tempDir("issue-29221", {
+    "entry.mjs": `
+globalThis.order = [];
+const a = import("./tla.mjs").then(() => globalThis.order.push("then-a"));
+const b = import("./tla.mjs").then(() => globalThis.order.push("then-b"));
+await Promise.all([a, b]);
+console.log(JSON.stringify(globalThis.order));
+`,
+    "tla.mjs": `
+globalThis.order.push("tla-start");
+await new Promise((r) => setTimeout(r, 50));
+globalThis.order.push("tla-end");
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), String(dir) + "/entry.mjs"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  // Expected ordering: the TLA module runs to completion first (tla-start
+  // then tla-end), then BOTH .then() handlers fire in import order.
+  //
+  // Pre-fix, Bun produced ["tla-start","then-b","then-a","tla-end"] — the
+  // second import's `.then()` fired before the TLA even resumed, because
+  // the JSC builtin's fast path returned the namespace without awaiting
+  // the pending evaluation promise.
+  expect({
+    stdout: stdout.trim(),
+    exitCode,
+  }).toEqual({
+    stdout: `["tla-start","tla-end","then-a","then-b"]`,
+    exitCode: 0,
+  });
+});

--- a/test/regression/issue/29221.test.ts
+++ b/test/regression/issue/29221.test.ts
@@ -90,15 +90,9 @@ export function fn() { return "ok"; }
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout.trim()).toBe(
-    `[[1,3,"function"],[2,3,"function"],[3,3,"function"],[4,3,"function"],[5,3,"function"]]`,
-  );
+  expect(stdout.trim()).toBe(`[[1,3,"function"],[2,3,"function"],[3,3,"function"],[4,3,"function"],[5,3,"function"]]`);
   expect(stderr).not.toContain("before initialization");
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/29221.test.ts
+++ b/test/regression/issue/29221.test.ts
@@ -92,13 +92,11 @@ export function fn() { return "ok"; }
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout.trim()).toBe(`[[1,3,"function"],[2,3,"function"],[3,3,"function"],[4,3,"function"],[5,3,"function"]]`);
+    expect(stdout.trim()).toBe(
+      `[[1,3,"function"],[2,3,"function"],[3,3,"function"],[4,3,"function"],[5,3,"function"]]`,
+    );
     // Failure mode for #20489/#22367 is a TDZ error on the child; assert
     // explicitly that no uninitialized-binding error reached stderr in
     // addition to the exitCode check below.

--- a/test/regression/issue/29221.test.ts
+++ b/test/regression/issue/29221.test.ts
@@ -35,11 +35,7 @@ globalThis.order.push("tla-end");
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // Expected ordering: the TLA module runs to completion first (tla-start
   // then tla-end), then BOTH .then() handlers fire in import order.

--- a/test/regression/issue/29221.test.ts
+++ b/test/regression/issue/29221.test.ts
@@ -18,6 +18,17 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
+// ASAN builds unconditionally print "WARNING: ASAN interferes with JSC
+// signal handlers..." to stderr from WebKit's Options.cpp; filter it out
+// so debug runs don't fail the stderr-empty assertions below.
+function cleanStderr(stderr: string): string {
+  return stderr
+    .split("\n")
+    .filter(line => !line.startsWith("WARNING: ASAN interferes"))
+    .join("\n")
+    .trim();
+}
+
 test("dynamic import waits for top-level await to settle (#29221)", async () => {
   using dir = tempDir("issue-29221", {
     "entry.mjs": `
@@ -41,7 +52,11 @@ globalThis.order.push("tla-end");
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
 
   // Expected ordering: the TLA module runs to completion first (tla-start
   // then tla-end), then BOTH .then() handlers fire in import order.
@@ -51,6 +66,7 @@ globalThis.order.push("tla-end");
   // the JSC builtin's fast path returned the namespace without awaiting
   // the pending evaluation promise.
   expect(stdout.trim()).toBe(`["tla-start","tla-end","then-a","then-b"]`);
+  expect(cleanStderr(stderr)).toBe("");
   expect(exitCode).toBe(0);
 });
 
@@ -90,9 +106,13 @@ export function fn() { return "ok"; }
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
 
   expect(stdout.trim()).toBe(`[[1,3,"function"],[2,3,"function"],[3,3,"function"],[4,3,"function"],[5,3,"function"]]`);
-  expect(stderr).not.toContain("before initialization");
+  expect(cleanStderr(stderr)).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/29221.test.ts
+++ b/test/regression/issue/29221.test.ts
@@ -52,11 +52,7 @@ globalThis.order.push("tla-end");
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // Expected ordering: the TLA module runs to completion first (tla-start
   // then tla-end), then BOTH .then() handlers fire in import order.
@@ -106,11 +102,7 @@ export function fn() { return "ok"; }
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout.trim()).toBe(`[[1,3,"function"],[2,3,"function"],[3,3,"function"],[4,3,"function"],[5,3,"function"]]`);
   expect(cleanStderr(stderr)).toBe("");


### PR DESCRIPTION
## Repro

```js
// temp.mjs
import("./temp2.mjs").then(() => console.log(3));
import("./temp2.mjs").then(() => console.log(4));

// temp2.mjs
console.log(1);
await new Promise((r) => setTimeout(r, 200));
console.log(2);
```

Node/Deno print `1 2 3 4`. Bun printed `1 4 2 3` — both `.then()` handlers fired *before* `temp2.mjs`'s top-level await settled, and the second handler ran before the first. Users of #20489 and #22367 see the same root cause surface as `Cannot access 'x' before initialization` when a concurrent `import()` reads a named export before the TLA completes.

## Cause

The stock WebKit `ModuleLoader.js` builtin's `requestImportModule`:

```js
if (entry.evaluated && (mod = entry.module)) {
    return this.getModuleNamespaceObject(mod);   // fast path — fires early
}
...
await this.linkAndEvaluateModule(entry.key, fetcher);
```

For an async (TLA) module, `moduleEvaluation` sets `entry.evaluated = true` **synchronously** at the start of `asyncModuleEvaluation` and then awaits the TLA. A second dynamic `import()` of the same module in the same tick hits that fast path, sees `evaluated === true`, and returns the namespace without awaiting the in-flight evaluation promise.

The stock builtin never caches the evaluation promise anywhere on the entry, so there's nothing for a concurrent caller to await — this diverges from the spec's `[[TopLevelCapability]]` behaviour.

## Fix

Since Bun ships prebuilt WebKit, patching the vendored `ModuleLoader.js` isn't enough — any release using the cached tarball would miss the fix. Instead, install an override `requestImportModule` builtin on the `JSModuleLoader` at `Zig::GlobalObject` init time.

JSC's C++ `JSModuleLoader::requestImportModule` looks the function up dynamically by its private name on the loader object every call, so `moduleLoader->putDirectBuiltinFunction(..., requestImportModulePublicName(), ...)` cleanly replaces both C++-initiated and JS-initiated dynamic imports.

The override caches the evaluation promise on `entry.evaluatingPromise` when it first kicks off `linkAndEvaluateModule`, and on every fast path checks for and awaits that promise before handing back the namespace. Once evaluation settles the field is cleared. Uses `$isPromise` (the tamper-proof intrinsic) rather than a duck-typed `.then` check.

## Verification

`test/regression/issue/29221.test.ts` has two cases:

1. **`.then()` ordering** — two concurrent `import()` calls for a TLA module. Pre-fix: `["tla-start","then-b","then-a","tla-end"]`. Post-fix: `["tla-start","tla-end","then-a","then-b"]`, matching Node and Deno.
2. **Named export TDZ** — five concurrent `import()` calls that read `mod.arr.length` and `typeof mod.fn`. Pre-fix: imports 2..5 fail with `Cannot access 'arr' before initialization` (reproducing #20489 / #22367). Post-fix: all five see fully initialized bindings.

```
USE_SYSTEM_BUN=1 bun test test/regression/issue/29221.test.ts   → 2 fail
bun bd test       test/regression/issue/29221.test.ts           → 2 pass
```

Fixes #29221
Fixes #20489
Fixes #22367
