### PR TITLE
chore: Harden CI supply chain

### DIFF
--- a/.github/actions/bump/action.yml
+++ b/.github/actions/bump/action.yml
@@ -25,7 +25,7 @@ runs:
         echo "version=$LATEST" >> $GITHUB_OUTPUT
         echo "message=$MESSAGE" >> $GITHUB_OUTPUT
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
       with:
         add-paths: |
           LATEST

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -34,7 +34,7 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
       - name: Setup Dependencies
         run: |
-          bun install
+          bun ci
       - name: Format Code
         run: |
           # Start prettier in background with prefixed output

--- a/.github/workflows/packages-ci.yml
+++ b/.github/workflows/packages-ci.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          bun install
-          pushd ./packages/bun-plugin-svelte && bun install
+          bun ci
+          pushd ./packages/bun-plugin-svelte && bun ci
 
       - name: Lint
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           bun-version: "1.2.3"
       - name: Install Dependencies
-        run: bun install
+        run: bun ci
       - name: Sign Release
         run: |
           echo "$GPG_PASSPHRASE" | bun upload-assets -- "${{ env.BUN_VERSION }}"
@@ -100,7 +100,7 @@ jobs:
         with:
           bun-version: "1.2.3"
       - name: Install Dependencies
-        run: bun install
+        run: bun ci
       - name: Release
         run: bun upload-npm -- "${{ env.BUN_VERSION }}" publish
         env:
@@ -134,7 +134,7 @@ jobs:
         with:
           bun-version: "canary" # Must be 'canary' so tag is correct
       - name: Install Dependencies
-        run: bun install
+        run: bun ci
       - name: Setup Tag
         if: ${{ env.BUN_VERSION == 'canary' }}
         run: |
@@ -317,7 +317,7 @@ jobs:
         with:
           bun-version: "1.2.0"
       - name: Install Dependencies
-        run: bun install
+        run: bun ci
       - name: Release
         run: bun upload-s3 -- "${{ env.BUN_VERSION }}"
         env:

--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -21,10 +21,10 @@ jobs:
           bun-version: "1.2.18"
 
       - name: Install dependencies (root)
-        run: bun install
+        run: bun ci
 
       - name: Install dependencies
-        run: bun install
+        run: bun ci
         working-directory: packages/bun-vscode
 
       - name: Set Version
@@ -32,7 +32,7 @@ jobs:
         working-directory: packages/bun-vscode
 
       - name: Build (inspector protocol)
-        run: bun install && bun run build
+        run: bun ci && bun run build
         working-directory: packages/bun-inspector-protocol
 
       - name: Build (vscode extension)


### PR DESCRIPTION
## Summary

Pin third-party GitHub Action to SHA and enforce frozen lockfiles in CI workflows, complementing #28616.

## Changes Made (CI Fixes)

- **SHA pinning**: Pin `peter-evans/create-pull-request@v7` to commit SHA in `.github/actions/bump/action.yml` (missed by #28616)
- **Frozen lockfile**: Replace all `bun install` with [`bun ci`](https://bun.sh/docs/cli/install#bun-ci) across 4 workflow files (`release.yml`, `format.yml`, `packages-ci.yml`, `vscode-release.yml`) to prevent lockfile drift in CI. `bun ci` is equivalent to `bun install --frozen-lockfile` and is [recommended by Bun for CI/CD environments](https://bun.sh/docs/cli/install#cicd).

## Recommendations

> These items require manual follow-up and are NOT included as code changes in this PR.

- [ ] Configure Dependabot with [`cooldown`](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) setting, or Renovate with [`minimumReleaseAge`](https://docs.renovatebot.com/configuration-options/#minimumreleaseage) — no automated dependency update tooling is currently configured
- [ ] Pin `docker/*` actions to SHA in `release.yml`
- [ ] Pin `ruby/setup-ruby` to SHA in `release.yml`
- [ ] Pin `getsentry/action-release` to SHA in `release.yml`
- [ ] Pin `oven-sh/setup-bun` to SHA in `update-root-certs.yml` and `update-vendor.yml`

<details>
<summary>Why This Matters</summary>

### GitHub Actions tag references are mutable

When a workflow references an action by tag (e.g., `actions/checkout@v4`), the tag can be moved to point to a different commit at any time — by the maintainer, or by an attacker who compromises the repository. SHA pinning makes the reference immutable.

**Real-world incidents:**
- **Trivy** ([CVE-2026-33634](https://nvd.nist.gov/vuln/detail/CVE-2026-33634)) — compromised GitHub Action allowed arbitrary code execution in CI pipelines.
- **KICS** ([CVE-2026-33634](https://nvd.nist.gov/vuln/detail/CVE-2026-33634), [writeup](https://www.wiz.io/blog/teampcp-attack-kics-github-action)) — supply chain attack on the KICS GitHub Action used for infrastructure-as-code scanning.
- **LiteLLM** ([CVE-2026-33634](https://nvd.nist.gov/vuln/detail/CVE-2026-33634), [advisory](https://docs.litellm.ai/blog/security-update-march-2026)) — compromised action in the LiteLLM project's CI pipeline.
- **tj-actions/changed-files** ([CVE-2025-30066](https://nvd.nist.gov/vuln/detail/CVE-2025-30066)) — attacker compromised the action and rewrote version tags to inject credential-stealing code. Every repo using a tag reference silently ran the malicious version.
- **reviewdog** ([CVE-2025-30154](https://nvd.nist.gov/vuln/detail/CVE-2025-30154)) — similar tag-rewriting attack on a widely-used code review action.

### Unfrozen lockfiles in CI enable dependency confusion

Without `--frozen-lockfile` (or `bun ci`), a CI install can silently resolve newer package versions than what's in the lockfile. If an attacker publishes a compromised version of a dependency, CI would pick it up on the next run.

**Real-world incidents:**
- **Axios npm compromise impacting OpenAI** ([2026](https://openai.com/index/axios-developer-tool-compromise/)) — compromised axios package affected OpenAI and other major consumers.
- **PyTorch torchtriton** ([2022](https://pytorch.org/blog/compromised-nightly-dependency/)) — attacker published a malicious package to PyPI that shadowed an internal dependency, exfiltrating environment variables.
- **colors.js** ([CVE-2021-23567](https://nvd.nist.gov/vuln/detail/CVE-2021-23567), 2022) — maintainer deliberately corrupted the package, causing infinite loops in downstream projects.
- **ua-parser-js** ([GHSA-pjwm-rvh2-c87w](https://github.com/advisories/GHSA-pjwm-rvh2-c87w), 2021) — compromised npm package with cryptominer, affecting millions of weekly downloads.
- **event-stream** ([GHSA-mh6f-8j2x-4483](https://github.com/advisories/GHSA-mh6f-8j2x-4483), 2018) — attacker gained maintainer access and injected a targeted cryptocurrency-stealing payload.

</details>