### PR TITLE
inspect: show real class name for DOM constructors, not `[class Function]`

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -2326,16 +2326,28 @@ pub const Formatter = struct {
                 );
             },
             .Class => {
-                var printable = ZigString.init(&name_buf);
-                try value.getClassName(this.globalThis, &printable);
-                this.addForNewLine(printable.len);
+                // Prefer the constructor's own `.name` property over
+                // `getClassName` / `calculatedClassName`. For DOM / WebCore
+                // InternalFunction constructors like `ReadableStreamBYOBReader`,
+                // `calculatedClassName` walks the prototype chain and hits
+                // `Function.prototype.constructor === Function`, returning
+                // "Function". The `.name` property is set to the real class
+                // name on the constructor itself. See #29225.
+                var printable = try value.getName(this.globalThis);
+                defer printable.deref();
+                this.addForNewLine(printable.length());
 
+                // Only report `extends` when the parent is itself a class
+                // (i.e. `class Foo extends Bar`). Built-in and DOM constructors
+                // have `Function.prototype` as their prototype, which would
+                // render as `[class X extends Function]` and is noise.
                 const proto = value.getPrototype(this.globalThis);
-                var printable_proto = ZigString.init(&name_buf);
-                try proto.getClassName(this.globalThis, &printable_proto);
-                this.addForNewLine(printable_proto.len);
+                const proto_is_class = !proto.isEmptyOrUndefinedOrNull() and proto.isCell() and proto.isClass(this.globalThis);
+                var printable_proto: bun.String = if (proto_is_class) try proto.getName(this.globalThis) else bun.String.empty;
+                defer printable_proto.deref();
+                this.addForNewLine(printable_proto.length());
 
-                if (printable.len == 0) {
+                if (printable.isEmpty()) {
                     if (printable_proto.isEmpty()) {
                         writer.print(comptime Output.prettyFmt("<cyan>[class (anonymous)]<r>", enable_ansi_colors), .{});
                     } else {

--- a/test/regression/issue/29225.test.ts
+++ b/test/regression/issue/29225.test.ts
@@ -58,11 +58,7 @@ test("node:stream/web classes inspect as [class X], not [class Function]", async
     stderr: "pipe",
   });
 
-  const [stdout, _stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
 
@@ -97,11 +93,7 @@ test("other DOM / WebCore constructors inspect as [class X]", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, _stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   expect(stdout).toBe(
@@ -131,11 +123,7 @@ test("user-defined classes and extends still render correctly", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, _stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(exitCode).toBe(0);
   // `Anon` picks up the "Anon" name from the variable binding, matching

--- a/test/regression/issue/29225.test.ts
+++ b/test/regression/issue/29225.test.ts
@@ -1,21 +1,9 @@
 // https://github.com/oven-sh/bun/issues/29225
-//
-// Before the fix, `console.log(ReadableStreamBYOBReader)` printed
-// `[class Function]` in Bun. The underlying bug was in the inspector's
-// `.Class` formatter: it used `calculatedClassName`, which walks the
-// prototype chain looking for `.constructor`. For DOM / WebCore
-// InternalFunction constructors, that walk resolves to
-// `Function.prototype.constructor === Function` and returns `"Function"`.
-//
-// The fix is to use the constructor's own `.name` property instead,
-// which is set at constructor initialization to the real class name.
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { ReadableStreamBYOBReader } from "node:stream/web";
 
-// All of these are WebCore-generated `InternalFunction` constructors in
-// Bun. Every one of them reported as `[class Function]` before the fix.
 const streamWebClasses = [
   "ByteLengthQueuingStrategy",
   "CompressionStream",
@@ -36,7 +24,7 @@ const streamWebClasses = [
   "WritableStreamDefaultWriter",
 ];
 
-test("node:stream/web classes inspect as [class X], not [class Function]", async () => {
+test.concurrent("node:stream/web classes inspect as [class X], not [class Function]", async () => {
   const source = `
     const sw = require("node:stream/web");
     const names = ${JSON.stringify(streamWebClasses)};
@@ -60,8 +48,6 @@ test("node:stream/web classes inspect as [class X], not [class Function]", async
 
   const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(exitCode).toBe(0);
-
   const lines = stdout.trim().split("\n");
   expect(lines.length).toBe(streamWebClasses.length);
 
@@ -72,9 +58,10 @@ test("node:stream/web classes inspect as [class X], not [class Function]", async
     expect(lines[i]).not.toContain("MISSING");
     expect(lines[i]).toBe(`${name}: [class ${name}]`);
   }
+  expect(exitCode).toBe(0);
 });
 
-test("other DOM / WebCore constructors inspect as [class X]", async () => {
+test.concurrent("other DOM / WebCore constructors inspect as [class X]", async () => {
   // Sanity: the inspect formatter should work for any `isConstructor`
   // InternalFunction exposed as a global. Keep this list small — it's
   // a regression guard, not an audit.
@@ -95,7 +82,6 @@ test("other DOM / WebCore constructors inspect as [class X]", async () => {
 
   const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(exitCode).toBe(0);
   expect(stdout).toBe(
     "URL: [class URL]\n" +
       "Request: [class Request]\n" +
@@ -103,9 +89,10 @@ test("other DOM / WebCore constructors inspect as [class X]", async () => {
       "Blob: [class Blob]\n" +
       "Event: [class Event]\n",
   );
+  expect(exitCode).toBe(0);
 });
 
-test("user-defined classes and extends still render correctly", async () => {
+test.concurrent("user-defined classes and extends still render correctly", async () => {
   const code = `
     class Foo {}
     class Bar extends Foo {}
@@ -125,13 +112,13 @@ test("user-defined classes and extends still render correctly", async () => {
 
   const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(exitCode).toBe(0);
   // `Anon` picks up the "Anon" name from the variable binding, matching
   // JSC's naming inference for `const Anon = class {};`.
   expect(stdout).toBe("Foo: [class Foo]\n" + "Bar: [class Bar extends Foo]\n" + "Anon: [class Anon]\n");
+  expect(exitCode).toBe(0);
 });
 
-test("instanceof and prototype identity still work", async () => {
+test.concurrent("instanceof and prototype identity still work", async () => {
   // Functional behavior must not regress — the fix is cosmetic only.
   const stream = new ReadableStream({
     type: "bytes",

--- a/test/regression/issue/29225.test.ts
+++ b/test/regression/issue/29225.test.ts
@@ -1,0 +1,162 @@
+// https://github.com/oven-sh/bun/issues/29225
+//
+// Before the fix, `console.log(ReadableStreamBYOBReader)` printed
+// `[class Function]` in Bun. The underlying bug was in the inspector's
+// `.Class` formatter: it used `calculatedClassName`, which walks the
+// prototype chain looking for `.constructor`. For DOM / WebCore
+// InternalFunction constructors, that walk resolves to
+// `Function.prototype.constructor === Function` and returns `"Function"`.
+//
+// The fix is to use the constructor's own `.name` property instead,
+// which is set at constructor initialization to the real class name.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { ReadableStreamBYOBReader } from "node:stream/web";
+
+// All of these are WebCore-generated `InternalFunction` constructors in
+// Bun. Every one of them reported as `[class Function]` before the fix.
+const streamWebClasses = [
+  "ByteLengthQueuingStrategy",
+  "CompressionStream",
+  "CountQueuingStrategy",
+  "DecompressionStream",
+  "ReadableByteStreamController",
+  "ReadableStream",
+  "ReadableStreamBYOBReader",
+  "ReadableStreamBYOBRequest",
+  "ReadableStreamDefaultController",
+  "ReadableStreamDefaultReader",
+  "TextDecoderStream",
+  "TextEncoderStream",
+  "TransformStream",
+  "TransformStreamDefaultController",
+  "WritableStream",
+  "WritableStreamDefaultController",
+  "WritableStreamDefaultWriter",
+];
+
+test("node:stream/web classes inspect as [class X], not [class Function]", async () => {
+  const source = `
+    const sw = require("node:stream/web");
+    const names = ${JSON.stringify(streamWebClasses)};
+    for (const name of names) {
+      const klass = sw[name];
+      if (typeof klass !== "function") {
+        console.log(name + ": MISSING");
+        continue;
+      }
+      // Bun.inspect() uses the same formatter as console.log.
+      console.log(name + ": " + Bun.inspect(klass));
+    }
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", source],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, _stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+
+  const lines = stdout.trim().split("\n");
+  expect(lines.length).toBe(streamWebClasses.length);
+
+  for (let i = 0; i < streamWebClasses.length; i++) {
+    const name = streamWebClasses[i];
+    // Must not be "MISSING" (sanity check for the test itself) and
+    // must report the real class name, not "Function".
+    expect(lines[i]).not.toContain("MISSING");
+    expect(lines[i]).toBe(`${name}: [class ${name}]`);
+  }
+});
+
+test("other DOM / WebCore constructors inspect as [class X]", async () => {
+  // Sanity: the inspect formatter should work for any `isConstructor`
+  // InternalFunction exposed as a global. Keep this list small — it's
+  // a regression guard, not an audit.
+  const code = `
+    console.log("URL: " + Bun.inspect(URL));
+    console.log("Request: " + Bun.inspect(Request));
+    console.log("Response: " + Bun.inspect(Response));
+    console.log("Blob: " + Bun.inspect(Blob));
+    console.log("Event: " + Bun.inspect(Event));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, _stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toBe(
+    "URL: [class URL]\n" +
+      "Request: [class Request]\n" +
+      "Response: [class Response]\n" +
+      "Blob: [class Blob]\n" +
+      "Event: [class Event]\n",
+  );
+});
+
+test("user-defined classes and extends still render correctly", async () => {
+  const code = `
+    class Foo {}
+    class Bar extends Foo {}
+    const Anon = class {};
+
+    console.log("Foo: " + Bun.inspect(Foo));
+    console.log("Bar: " + Bun.inspect(Bar));
+    console.log("Anon: " + Bun.inspect(Anon));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, _stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  // `Anon` picks up the "Anon" name from the variable binding, matching
+  // JSC's naming inference for `const Anon = class {};`.
+  expect(stdout).toBe("Foo: [class Foo]\n" + "Bar: [class Bar extends Foo]\n" + "Anon: [class Anon]\n");
+});
+
+test("instanceof and prototype identity still work", async () => {
+  // Functional behavior must not regress — the fix is cosmetic only.
+  const stream = new ReadableStream({
+    type: "bytes",
+    start(c) {
+      c.enqueue(new Uint8Array([1, 2, 3]));
+      c.close();
+    },
+  });
+  const reader = stream.getReader({ mode: "byob" });
+  expect(reader).toBeInstanceOf(ReadableStreamBYOBReader);
+  expect(Object.getPrototypeOf(reader)).toBe(ReadableStreamBYOBReader.prototype);
+  reader.releaseLock();
+
+  class Sub extends ReadableStreamBYOBReader {}
+  expect(Object.getPrototypeOf(Sub.prototype)).toBe(ReadableStreamBYOBReader.prototype);
+});


### PR DESCRIPTION
Fixes #29225

## Repro

```js
import { ReadableStreamBYOBReader } from "node:stream/web";
console.log(ReadableStreamBYOBReader);
```

### Before

```
[class Function]
```

### After

```
[class ReadableStreamBYOBReader]
```

## Cause

The `.Class` formatter in `ConsoleObject.zig` called `value.getClassName()`, which under the hood falls through to `JSObject::calculatedClassName`. That helper walks the prototype chain looking for `.constructor`. For any WebCore `InternalFunction` constructor (`ReadableStream`, `WritableStream`, `TextDecoderStream`, …), its own `.constructor` lookup traverses the proto chain and resolves to `Function.prototype.constructor === Function`, so the class name came out as `"Function"`.

Every DOM / `node:stream/web` class was affected:

```
ByteLengthQueuingStrategy, CompressionStream, CountQueuingStrategy, DecompressionStream,
ReadableByteStreamController, ReadableStream, ReadableStreamBYOBReader,
ReadableStreamBYOBRequest, ReadableStreamDefaultController, ReadableStreamDefaultReader,
TextDecoderStream, TextEncoderStream, TransformStream, TransformStreamDefaultController,
WritableStream, WritableStreamDefaultController, WritableStreamDefaultWriter
```

Functional behavior (`instanceof`, prototype identity, subclassing) was fine — the bug was cosmetic.

## Fix

Use the constructor's own `.name` property (which `JSDOMBuiltinConstructor::initializeProperties` sets to the real class name) instead of `calculatedClassName`. This is the same approach the `.Function` formatter already uses.

Also only report `extends` when the prototype is itself a class — otherwise built-ins with a `Function.prototype` parent would render as `[class X extends Function]`.

## Verification

`test/regression/issue/29225.test.ts` covers:
- all 17 `node:stream/web` class constructors inspect as `[class X]`
- 5 other WebCore constructors (`URL`, `Request`, `Response`, `Blob`, `Event`) inspect as `[class X]`
- user-defined `class Foo`, `class Bar extends Foo`, and variable-bound anonymous class expressions still render correctly
- `instanceof` and prototype identity still work for `ReadableStreamBYOBReader`

`test/js/bun/util/inspect.test.js` (71 pre-existing cases incl. `[class A]`, `[class B extends A]`, `[class (anonymous) extends A]`, `[class (anonymous)]`) still passes.