### PR TITLE
fix(blob): don't scribble MAP_SHARED memfd region when freeing blob store

### DIFF
--- a/src/bun.js/webcore/blob/Store.zig
+++ b/src/bun.js/webcore/blob/Store.zig
@@ -541,7 +541,15 @@ pub const Bytes = struct {
     pub fn deinit(this: *Bytes) void {
         bun.default_allocator.free(this.stored_name.slice());
         if (this.ptr) |ptr| {
-            this.allocator.free(ptr[0..this.cap]);
+            if ((comptime bun.Environment.isLinux) and bun.linux.MemFdAllocator.isInstance(this.allocator)) {
+                // Bypass the @memset(undefined) in std.mem.Allocator.free for memfd-backed
+                // storage. The MAP_SHARED mapping propagates writes back to the memfd, which:
+                //   - corrupts any outstanding MAP_PRIVATE views (e.g. from blob.arrayBuffer())
+                //   - forces commitment of the entire region to tmpfs, spiking RSS for large blobs
+                this.allocator.rawFree(ptr[0..this.cap], .fromByteUnits(1), @returnAddress());
+            } else {
+                this.allocator.free(ptr[0..this.cap]);
+            }
         }
         this.ptr = null;
         this.len = 0;

--- a/test/js/web/fetch/blob-cow.test.ts
+++ b/test/js/web/fetch/blob-cow.test.ts
@@ -1,5 +1,40 @@
 import { expect, test } from "bun:test";
 
+test("Blob.arrayBuffer copy-on-write survives blob store being freed", async () => {
+  // On Linux, large blobs are backed by a memfd. blob.arrayBuffer() creates a
+  // MAP_PRIVATE mapping of that memfd; pages that haven't been COW'd yet still
+  // read through to the underlying file. Freeing the blob's store must not
+  // scribble into the MAP_SHARED mapping (and thus the memfd), or outstanding
+  // arrayBuffer()/bytes() results will observe garbage.
+  const size = 16 * 1024 * 1024;
+  for (let i = 0; i < 3; i++) {
+    let arr;
+    {
+      const src = new Uint8Array(size).fill(42);
+      const blob = new Blob([src]);
+      arr = await blob.arrayBuffer();
+    }
+    Bun.gc(true);
+    const u8 = new Uint8Array(arr);
+    expect(u8[0]).toBe(42);
+    expect(u8[u8.length - 1]).toBe(42);
+    expect(u8[u8.length >> 1]).toBe(42);
+  }
+});
+
+test("Blob.bytes copy-on-write survives blob store being freed", async () => {
+  const size = 16 * 1024 * 1024;
+  let bytes;
+  {
+    const src = new Uint8Array(size).fill(42);
+    const blob = new Blob([src]);
+    bytes = await blob.bytes();
+  }
+  Bun.gc(true);
+  expect(bytes[0]).toBe(42);
+  expect(bytes[bytes.length - 1]).toBe(42);
+});
+
 test("Blob.arrayBuffer copy-on-write is not shared", async () => {
   // 8 MB is the threshold for copy-on-write without --smol.
   const bytes = new Uint8Array((1024 * 1024 * 8 * 1.5) | 0);


### PR DESCRIPTION
## What does this PR do?

On Linux, large (≥8 MiB) `Blob` stores are backed by a memfd: the data is written to the memfd and then `mmap`'d `MAP_SHARED` as the store's byte buffer. `blob.arrayBuffer()` and `blob.bytes()` create separate `MAP_PRIVATE` mappings of the same memfd and return them to JS.

When the blob store is freed, `Store.Bytes.deinit` calls `this.allocator.free(ptr[0..cap])`. Zig's `std.mem.Allocator.free` does `@memset(buf, undefined)` **before** dispatching to the vtable's `free`. In safe/debug builds that writes `0xAA` across the entire buffer. Because the store's mapping is `MAP_SHARED`, those writes go straight into the memfd — and any outstanding `MAP_PRIVATE` view whose pages haven't been COW'd yet reads `0xAA` instead of the blob's data.

```js
const src = new Uint8Array(16 * 1024 * 1024).fill(42);
const blob = new Blob([src]);
const arr = await blob.arrayBuffer();
// blob collected here → store freed → memfd scribbled
new Uint8Array(arr)[0]; // 170 (0xAA) in debug, should be 42
```

The same `@memset` also forces every page of the region into tmpfs right before it's unmapped, so freeing a 256 MiB blob store commits 256 MiB of physical memory for no reason. In memory-constrained environments this showed up as a SIGKILL (fuzzer fingerprint `d0cddd0241b6b110`).

Fix: for memfd-backed stores, call `rawFree` directly instead of `free` to skip the scribble. The vtable's free is `munmap`, which doesn't need the memory pre-poisoned.

## How did you verify your code works?

Added regression tests in `test/js/web/fetch/blob-cow.test.ts` that force GC between `blob.arrayBuffer()` / `blob.bytes()` returning and the result being read. They fail before (`Received: 170`) and pass after.

Also verified peak RSS (`VmHWM`) for the fuzzer repro drops from ~610 MB to ~342 MB.