### PR TITLE
dns.lookup: default to libc getaddrinfo on Linux

### DIFF
--- a/src/cares_sys/c_ares.zig
+++ b/src/cares_sys/c_ares.zig
@@ -1319,6 +1319,7 @@ pub const Error = enum(i32) {
         return switch (eai) {
             @as(std.posix.system.EAI, @enumFromInt(0)) => return null,
             .ADDRFAMILY => Error.EBADFAMILY,
+            .AGAIN => Error.ETIMEOUT, // Temporary failure in name resolution; matches Node and the Windows/libuv path above.
             .BADFLAGS => Error.EBADFLAGS, // Invalid hints
             .FAIL => Error.EBADRESP,
             .FAMILY => Error.EBADFAMILY,

--- a/src/dns.zig
+++ b/src/dns.zig
@@ -286,9 +286,18 @@ pub const GetAddrInfo = struct {
             .{ "getaddrinfo", .libc },
         });
 
+        // `dns.lookup` is specified to behave like getaddrinfo(3), which
+        // consults nsswitch.conf / /etc/hosts. On Linux the default
+        // backend used to be `c_ares`, which produced results that did
+        // not match Node for names defined only in /etc/hosts — see
+        // https://github.com/oven-sh/bun/issues/29227.
+        //
+        // Only `dns.lookup` routes through this default. `dns.resolve*`
+        // (and all record-type queries) use c-ares directly, matching
+        // Node's behavior.
         pub const default: GetAddrInfo.Backend = switch (bun.Environment.os) {
             .mac, .windows => .system,
-            else => .c_ares,
+            else => .libc,
         };
 
         pub const FromJSError = JSError || error{

--- a/src/dns/dns.zig
+++ b/src/dns/dns.zig
@@ -175,12 +175,21 @@ pub const GetAddrInfo = struct {
             .{ "getaddrinfo", .libc },
         });
 
+        // `dns.lookup` is specified to behave like getaddrinfo(3), which
+        // consults nsswitch.conf / /etc/hosts. On Linux the default
+        // backend used to be `c_ares`, which produced results that did
+        // not match Node for names defined only in /etc/hosts — see
+        // https://github.com/oven-sh/bun/issues/29227.
+        //
+        // Only `dns.lookup` routes through this default. `dns.resolve*`
+        // (and all record-type queries) use c-ares directly, matching
+        // Node's behavior.
         pub const default: GetAddrInfo.Backend = switch (bun.Environment.os) {
             .mac, .windows => .system,
             // Android: c-ares can't discover nameservers (no /etc/resolv.conf,
             // no JNI for ares_library_init_android). bionic getaddrinfo proxies
             // through netd which knows the real resolvers.
-            else => if (bun.Environment.isAndroid) .system else .c_ares,
+            else => if (bun.Environment.isAndroid) .system else .libc,
         };
 
         pub const FromJSError = JSError || error{

--- a/test/regression/issue/29227.test.ts
+++ b/test/regression/issue/29227.test.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "bun:test";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { bunEnv, bunExe, isLinux } from "harness";
+
+// https://github.com/oven-sh/bun/issues/29227
+//
+// On Linux, `dns.lookup()` for a name that only has an IPv4 entry in
+// /etc/hosts must return only IPv4, matching Node. Previously Bun's
+// default backend returned an extra `::1` entry (and, because the
+// default result order is `verbatim`, that `::1` became the single
+// result returned by the callback form).
+//
+// This test requires Linux because it mutates /etc/hosts. The bug is
+// Linux-specific — macOS uses LibInfo and Windows uses libuv, both
+// already matching Node.
+test.skipIf(!isLinux)("dns.lookup respects /etc/hosts and matches Node", async () => {
+  // Use a random tag so re-runs don't conflict. The tag is long enough
+  // that it's extremely unlikely to collide with anything on the host.
+  const tag = "bun-issue-29227-" + Math.random().toString(36).slice(2, 10);
+  const hostsEntry = `\n127.0.0.1 ${tag}\n`;
+
+  // /etc/hosts is a system file; snapshot-then-restore so a crashed
+  // test can't leave the system in a bad state.
+  let original: string;
+  try {
+    original = readFileSync("/etc/hosts", "utf8");
+  } catch {
+    // Not writable / not root — skip. CI Linux is root in the container.
+    return;
+  }
+
+  try {
+    appendFileSync("/etc/hosts", hostsEntry);
+  } catch {
+    return;
+  }
+
+  try {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+const dns = require("node:dns");
+const name = ${JSON.stringify(tag)};
+dns.lookup(name, { all: true }, (err, results) => {
+  if (err) { console.error("ERR:" + err.code); process.exit(1); }
+  console.log(JSON.stringify(results));
+});
+dns.lookup(name, (err, address, family) => {
+  if (err) { console.error("ERR:" + err.code); process.exit(1); }
+  console.log("single:" + address + ":" + family);
+});
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    // Filter out the ASAN warning that debug builds print to stderr.
+    const realStderr = stderr
+      .split("\n")
+      .filter(l => l && !l.includes("ASAN"))
+      .join("\n");
+    expect(realStderr).toBe("");
+
+    // Stdout assertions come before exitCode so a failure surfaces the
+    // actual output rather than an opaque exit-code mismatch.
+    const lines = stdout.trim().split("\n");
+    const allLine = lines.find(l => l.startsWith("["))!;
+    const singleLine = lines.find(l => l.startsWith("single:"))!;
+
+    expect(JSON.parse(allLine)).toEqual([{ address: "127.0.0.1", family: 4 }]);
+    expect(singleLine).toBe("single:127.0.0.1:4");
+    expect(exitCode).toBe(0);
+  } finally {
+    // Always restore /etc/hosts, even if assertions fail.
+    writeFileSync("/etc/hosts", original);
+  }
+});

--- a/test/regression/issue/29227.test.ts
+++ b/test/regression/issue/29227.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "bun:test";
-import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux } from "harness";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 
 // https://github.com/oven-sh/bun/issues/29227
 //
@@ -58,11 +58,7 @@ dns.lookup(name, (err, address, family) => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // Filter out the ASAN warning that debug builds print to stderr.
     const realStderr = stderr

--- a/test/regression/issue/29227.test.ts
+++ b/test/regression/issue/29227.test.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "bun:test";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { bunEnv, bunExe, isLinux } from "harness";
+
+// https://github.com/oven-sh/bun/issues/29227
+//
+// On Linux, `dns.lookup()` for a name that only has an IPv4 entry in
+// /etc/hosts must return only IPv4, matching Node. Previously Bun's
+// default backend returned an extra `::1` entry (and, because the
+// default result order is `verbatim`, that `::1` became the single
+// result returned by the callback form).
+//
+// This test requires Linux because it mutates /etc/hosts. The bug is
+// Linux-specific — macOS uses LibInfo and Windows uses libuv, both
+// already matching Node.
+test.skipIf(!isLinux)("dns.lookup respects /etc/hosts and matches Node", async () => {
+  // Use a random tag so re-runs don't conflict. The tag is long enough
+  // that it's extremely unlikely to collide with anything on the host.
+  const tag = "bun-issue-29227-" + Math.random().toString(36).slice(2, 10);
+  const hostsEntry = `\n127.0.0.1 ${tag}\n`;
+
+  // /etc/hosts is a system file; snapshot-then-restore so a crashed
+  // test can't leave the system in a bad state.
+  let original: string;
+  try {
+    original = readFileSync("/etc/hosts", "utf8");
+  } catch {
+    // Not writable / not root — skip. CI Linux is root in the container.
+    return;
+  }
+
+  try {
+    appendFileSync("/etc/hosts", hostsEntry);
+  } catch {
+    return;
+  }
+
+  try {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+const dns = require("node:dns");
+const name = ${JSON.stringify(tag)};
+dns.lookup(name, { all: true }, (err, results) => {
+  if (err) { console.error("ERR:" + err.code); process.exit(1); }
+  console.log(JSON.stringify(results));
+});
+dns.lookup(name, (err, address, family) => {
+  if (err) { console.error("ERR:" + err.code); process.exit(1); }
+  console.log("single:" + address + ":" + family);
+});
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    // Filter out the ASAN warning that debug builds print to stderr.
+    const realStderr = stderr
+      .split("\n")
+      .filter(l => l && !l.includes("ASAN"))
+      .join("\n");
+    expect(realStderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    // Find the `all` array and the single-form line in the output.
+    const lines = stdout.trim().split("\n");
+    const allLine = lines.find(l => l.startsWith("["))!;
+    const singleLine = lines.find(l => l.startsWith("single:"))!;
+
+    expect(JSON.parse(allLine)).toEqual([{ address: "127.0.0.1", family: 4 }]);
+    expect(singleLine).toBe("single:127.0.0.1:4");
+  } finally {
+    // Always restore /etc/hosts, even if assertions fail.
+    writeFileSync("/etc/hosts", original);
+  }
+});


### PR DESCRIPTION
Fixes #29227

## Repro

```
# /etc/hosts
127.0.0.1  mongo-1
```

```js
import dns from "node:dns";
dns.lookup("mongo-1", { all: true }, (err, r) => console.log(r));
```

| | Result |
|---|---|
| Node | `[{ address: '127.0.0.1', family: 4 }]` |
| Bun (before) | `[{ address: '::1', family: 6 }, { address: '127.0.0.1', family: 4 }]` |
| Bun (after) | `[{ address: '127.0.0.1', family: 4 }]` |

Because the default result order is `verbatim`, the callback form `dns.lookup(name, cb)` would surface `::1` as the single address in Bun while Node returned `127.0.0.1`.

## Cause

`dns.lookup` is specified to behave like `getaddrinfo(3)`, which consults `nsswitch.conf` / `/etc/hosts`. On Linux Bun's `dns.lookup` was defaulting to the c-ares backend, which produces results that don't match libc for names defined only in `/etc/hosts`. macOS (LibInfo) and Windows (libuv) already matched Node.

## Fix

Switch the Linux default in `GetAddrInfo.Backend.default` from `.c_ares` to `.libc`, so `dns.lookup` routes through `LibC.lookup` → `std.c.getaddrinfo`. Only `dns.lookup` takes this default; `dns.resolve*` (and all record-type queries) go through separate entry points and continue to use c-ares, matching Node. Android keeps `.system` because bionic `getaddrinfo` proxies through `netd`.

Users who want the previous behavior can still opt in with `dns.lookup(name, { backend: 'c_ares' })` on the native API.

Also maps `EAI_AGAIN` to `ETIMEOUT` in the POSIX branch of `initEAI`, matching the existing Windows/libuv path. Without that, the new libc-default would surface transient DNS failures as `ENOTIMP` instead of the retryable `ETIMEOUT` that Node and the Windows path use.

## Test

`test/regression/issue/29227.test.ts` snapshots `/etc/hosts`, appends a random `127.0.0.1 <tag>` entry, runs `dns.lookup(tag, { all: true })` and `dns.lookup(tag, cb)`, and asserts both return only IPv4. The original `/etc/hosts` is always restored. Skipped on non-Linux.