### PR TITLE
bundler: fix stale HTML-import manifest etag across rebuilds

### DIFF
--- a/src/bundler/HTMLImportManifest.zig
+++ b/src/bundler/HTMLImportManifest.zig
@@ -201,7 +201,11 @@ pub fn write(index: u32, graph: *const Graph, linker_graph: *const LinkerGraph, 
                     }
                     break :brk ch.final_rel_path;
                 },
-                ch.isolated_hash,
+                // The HTML chunk's body embeds the hashed paths of its JS/CSS
+                // chunks, so its etag must change when those do. `isolated_hash`
+                // by design excludes those substitutions; the placeholder hash
+                // folds them in via `appendIsolatedHashesForImportedChunks`.
+                ch.template.placeholder.hash orelse ch.isolated_hash,
                 ch.content.loader(),
                 if (ch.entry_point.is_entry_point)
                     .@"entry-point"

--- a/src/bundler/LinkerContext.zig
+++ b/src/bundler/LinkerContext.zig
@@ -1505,10 +1505,13 @@ pub const LinkerContext = struct {
             );
         }
 
-        // Mix in hashes for referenced asset paths (i.e. the "file" loader)
+        // Mix in hashes for content referenced via output pieces. JS chunks
+        // express cross-chunk dependencies via `cross_chunk_imports` above, but
+        // HTML (and CSS) chunks only reference other chunks through pieces, so
+        // recurse on those too.
         switch (chunk.intermediate_output) {
-            .pieces => |pieces| for (pieces.slice()) |piece| {
-                if (piece.query.kind == .asset) {
+            .pieces => |pieces| for (pieces.slice()) |piece| switch (piece.query.kind) {
+                .asset => {
                     var from_chunk_dir = std.fs.path.dirnamePosix(chunk.final_rel_path) orelse "";
                     if (strings.eqlComptime(from_chunk_dir, "."))
                         from_chunk_dir = "";
@@ -1523,7 +1526,15 @@ pub const LinkerContext = struct {
                         },
                         .source_index => {},
                     }
-                }
+                },
+                .chunk => c.appendIsolatedHashesForImportedChunks(hash, chunks, piece.query.index, chunk_visit_map),
+                .scb => c.appendIsolatedHashesForImportedChunks(
+                    hash,
+                    chunks,
+                    c.graph.files.items(.entry_point_chunk_index)[piece.query.index],
+                    chunk_visit_map,
+                ),
+                .none, .html_import => {},
             },
             else => {},
         }

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { itBundled } from "./expectBundled";
 import { tempDirWithFiles } from "harness";
+import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { writeFileSync, readFileSync } from "node:fs";
+import { itBundled } from "./expectBundled";
 
 describe.concurrent("bundler", () => {
   // Test HTML import manifest with enhanced metadata

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { itBundled } from "./expectBundled";
+import { tempDirWithFiles } from "harness";
+import { join } from "node:path";
+import { writeFileSync, readFileSync } from "node:fs";
 
 describe.concurrent("bundler", () => {
   // Test HTML import manifest with enhanced metadata
@@ -107,7 +110,7 @@ console.log(favicon);
                 "loader": "js",
                 "isEntry": true,
                 "headers": {
-                  "etag": "14Q4Q7Mm8TM",
+                  "etag": "efKwB-6QGwk",
                   "content-type": "text/javascript;charset=utf-8"
                 }
               },
@@ -117,7 +120,7 @@ console.log(favicon);
                 "loader": "html",
                 "isEntry": true,
                 "headers": {
-                  "etag": "hZ3u5t2Rmuo",
+                  "etag": "sJJm55rxM4I",
                   "content-type": "text/html;charset=utf-8"
                 }
               },
@@ -127,7 +130,7 @@ console.log(favicon);
                 "loader": "css",
                 "isEntry": true,
                 "headers": {
-                  "etag": "0k_h5oYVQlA",
+                  "etag": "4B9l6JnTRAU",
                   "content-type": "text/css;charset=utf-8"
                 }
               },
@@ -287,7 +290,7 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/javascript;charset=utf-8",
-                  "etag": "18fAEMlKmOw",
+                  "etag": "xAZoSOIIQJ8",
                 },
                 "input": "home.html",
                 "isEntry": true,
@@ -297,7 +300,7 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/html;charset=utf-8",
-                  "etag": "_Qy4EtlcGvs",
+                  "etag": "uIE6dXgvM-4",
                 },
                 "input": "home.html",
                 "isEntry": true,
@@ -307,7 +310,7 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/css;charset=utf-8",
-                  "etag": "6qg2qb7a2qo",
+                  "etag": "ZTZtbLd3364",
                 },
                 "input": "home.html",
                 "isEntry": true,
@@ -322,7 +325,7 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/javascript;charset=utf-8",
-                  "etag": "-3e3gOCTAZg",
+                  "etag": "INLwcb4oxw8",
                 },
                 "input": "about.html",
                 "isEntry": true,
@@ -332,7 +335,7 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/html;charset=utf-8",
-                  "etag": "igL7YEH9e0I",
+                  "etag": "ZpqlG2wo2xo",
                 },
                 "input": "about.html",
                 "isEntry": true,
@@ -342,7 +345,7 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/css;charset=utf-8",
-                  "etag": "DE8kdBXWhVg",
+                  "etag": "x6pW8hAzxGI",
                 },
                 "input": "about.html",
                 "isEntry": true,
@@ -355,6 +358,41 @@ console.log("About manifest:", aboutHtml);
         ]
       `);
     },
+  });
+
+  // The HTML chunk's etag must change when only a referenced JS/CSS chunk
+  // changes; otherwise the browser 304s to a body that points at chunks the
+  // server no longer has.
+  test("html-import/etag-changes-with-referenced-chunks", async () => {
+    const dir = tempDirWithFiles("html-etag", {
+      "server.ts": `import m from "./index.html"; console.log(JSON.stringify(m));`,
+      "index.html": `<!doctype html><script type="module" src="./app.ts"></script>`,
+      "app.ts": `console.log(1);`,
+    });
+
+    async function buildAndReadManifest() {
+      const out = join(dir, "out");
+      const r = await Bun.build({ entrypoints: [join(dir, "server.ts")], outdir: out, target: "bun" });
+      expect(r.success).toBe(true);
+      const js = readFileSync(join(out, "server.js"), "utf8");
+      const m = js.match(/__jsonParse\("(.+?)"\)/s)!;
+      return JSON.parse(JSON.parse('"' + m[1] + '"')) as {
+        files: Array<{ loader: string; path: string; headers: { etag: string } }>;
+      };
+    }
+
+    const a = await buildAndReadManifest();
+    writeFileSync(join(dir, "app.ts"), `console.log(2);`);
+    const b = await buildAndReadManifest();
+
+    const htmlA = a.files.find(f => f.loader === "html")!;
+    const htmlB = b.files.find(f => f.loader === "html")!;
+    const jsA = a.files.find(f => f.loader === "js")!;
+    const jsB = b.files.find(f => f.loader === "js")!;
+
+    expect(jsA.path).not.toBe(jsB.path);
+    expect(htmlA.path).toBe(htmlB.path);
+    expect(htmlA.headers.etag).not.toBe(htmlB.headers.etag);
   });
 
   // Test that import with {type: 'file'} still works as a file import


### PR DESCRIPTION
## What does this PR do?

The HTML chunk's manifest `etag` was its `isolated_hash`, which by design hashes the output pieces *between* unique-key placeholders — i.e. it excludes the slots where child-chunk paths are substituted. So when only a referenced JS/CSS chunk changed, the served HTML body changed (it embeds `/chunk-<hash>.js`) but its etag did not. `Bun.serve` would then 304 to a cached body that referenced chunks the new build no longer served, leaving the page blank until a hard refresh.

Fix:
- `appendIsolatedHashesForImportedChunks` now also recurses on `.chunk`/`.scb` output pieces. HTML chunks reference their JS/CSS via pieces only (their `cross_chunk_imports` is empty), so without this their transitive hash never folded in children. For JS chunks the visit map makes the new recursion a no-op since those pieces are already reached via `cross_chunk_imports`.
- `HTMLImportManifest` emits each chunk's `template.placeholder.hash` (the transitive hash) instead of `isolated_hash`.

JS/CSS chunk filenames are unchanged (verified by the existing snapshots — only `etag` values moved).

Fixes #23009


## How did you verify your code works?

New test `html-import/etag-changes-with-referenced-chunks` builds the same HTML import twice with different JS content and asserts the HTML `etag` differs while the HTML `path` stays the same. Fails on `main`, passes here.