### PR TITLE
child_process: honor runtime process.env.PATH in sync spawn variants

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -534,7 +534,7 @@ function spawnSync(file, args, options) {
       // Bun.spawn() expects cmd[0] to be the command to run, and argv0 to replace the first arg when running the command,
       // so we have to set argv0 to spawnargs[0] and cmd[0] to file
       cmd: [options.file, ...Array.prototype.slice.$call(options.args, 1)],
-      env: options.env || undefined,
+      env: options[kBunEnv] || undefined,
       cwd: options.cwd || undefined,
       stdio: bunStdio,
       windowsVerbatimArguments: options.windowsVerbatimArguments,

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -991,7 +991,15 @@ function normalizeSpawnArguments(file, args, options) {
     if (value !== undefined) {
       validateArgumentNullCheck(key, `options.env['${key}']`);
       validateArgumentNullCheck(value, `options.env['${key}']`);
-      bunEnv[key] = value;
+      // On Windows, env keys are case-insensitive but `process.env` iterates
+      // with the OS's canonical casing (e.g. "Path"). Bun.spawnSync's PATH
+      // lookup for argv[0] does a case-sensitive match on "PATH", so rename
+      // the PATH entry here to keep command resolution working.
+      if (process.platform === "win32" && StringPrototypeToUpperCase.$call(key) === "PATH") {
+        bunEnv["PATH"] = value;
+      } else {
+        bunEnv[key] = value;
+      }
     }
   }
 

--- a/test/regression/issue/29237.test.ts
+++ b/test/regression/issue/29237.test.ts
@@ -45,10 +45,17 @@ test.skipIf(isWindows)("execFileSync/spawnSync/execSync honor runtime mutations 
     cmd: [bunExe(), "fixture.js"],
     env: bunEnv,
     cwd: String(dir),
-    stderr: "ignore",
+    stderr: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  // Surface any subprocess stderr on assertion failure for diagnosis.
+  if (exitCode !== 0) console.error("fixture stderr:", stderr);
 
   // Assert stdout first for better failure messages, then exit code.
   expect(stdout).toBe(

--- a/test/regression/issue/29237.test.ts
+++ b/test/regression/issue/29237.test.ts
@@ -48,11 +48,7 @@ test.skipIf(isWindows)("execFileSync/spawnSync/execSync honor runtime mutations 
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // Surface any subprocess stderr on assertion failure for diagnosis.
   if (exitCode !== 0) console.error("fixture stderr:", stderr);

--- a/test/regression/issue/29237.test.ts
+++ b/test/regression/issue/29237.test.ts
@@ -45,19 +45,17 @@ test.skipIf(isWindows)("execFileSync/spawnSync/execSync honor runtime mutations 
     cmd: [bunExe(), "fixture.js"],
     env: bunEnv,
     cwd: String(dir),
-    stderr: "pipe",
+    stderr: "ignore",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
-  expect({ stdout, exitCode }).toEqual({
-    stdout:
-      "execFileSync: FAKE_CALLED\n" +
+  // Assert stdout first for better failure messages, then exit code.
+  expect(stdout).toBe(
+    "execFileSync: FAKE_CALLED\n" +
       "spawnSync: FAKE_CALLED\n" +
       "execSync: FAKE_CALLED\n" +
       "execFileSync+env: FAKE_CALLED\n",
-    exitCode: 0,
-  });
-  // stderr may contain ASAN banner; we just want no actual errors from the fixture.
-  expect(stderr).not.toContain("error:");
+  );
+  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/29237.test.ts
+++ b/test/regression/issue/29237.test.ts
@@ -1,0 +1,70 @@
+// Regression test for https://github.com/oven-sh/bun/issues/29237
+// child_process sync variants (execFileSync, spawnSync, execSync) must
+// resolve commands using the *current* process.env.PATH when options.env
+// is omitted — not a stale snapshot captured at Bun startup.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+test.skipIf(isWindows)(
+  "execFileSync/spawnSync/execSync honor runtime mutations to process.env.PATH",
+  async () => {
+    using dir = tempDir("issue-29237", {
+      // Fake `marker` binary — whichever PATH entry wins gets called.
+      "fake/marker": '#!/bin/sh\necho "FAKE_CALLED"\n',
+      "fixture.js": `
+        const { execFileSync, spawnSync, execSync } = require("node:child_process");
+        const path = require("node:path");
+
+        // Prepend our fake-binary dir to PATH at runtime.
+        const fakeDir = path.join(__dirname, "fake");
+        process.env.PATH = fakeDir + path.delimiter + process.env.PATH;
+
+        // 1. execFileSync without explicit env — must use mutated PATH.
+        const a = execFileSync("marker", { encoding: "utf8" }).trim();
+        console.log("execFileSync:", a);
+
+        // 2. spawnSync without explicit env.
+        const b = spawnSync("marker", [], { encoding: "utf8" });
+        console.log("spawnSync:", (b.stdout || "").trim());
+
+        // 3. execSync without explicit env.
+        const c = execSync("marker", { encoding: "utf8" }).trim();
+        console.log("execSync:", c);
+
+        // 4. execFileSync *with* explicit env — sanity check, already worked.
+        const d = execFileSync("marker", { encoding: "utf8", env: process.env }).trim();
+        console.log("execFileSync+env:", d);
+      `,
+    });
+
+    // chmod the fake binary so it's executable — tempDir writes 0644 by default.
+    const { chmodSync } = require("node:fs");
+    const path = require("node:path");
+    chmodSync(path.join(String(dir), "fake", "marker"), 0o755);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect({ stdout, exitCode }).toEqual({
+      stdout:
+        "execFileSync: FAKE_CALLED\n" +
+        "spawnSync: FAKE_CALLED\n" +
+        "execSync: FAKE_CALLED\n" +
+        "execFileSync+env: FAKE_CALLED\n",
+      exitCode: 0,
+    });
+    // stderr may contain ASAN banner; we just want no actual errors from the fixture.
+    expect(stderr).not.toContain("error:");
+  },
+);

--- a/test/regression/issue/29237.test.ts
+++ b/test/regression/issue/29237.test.ts
@@ -4,9 +4,9 @@
 // is omitted — not a stale snapshot captured at Bun startup.
 
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { chmodSync } from "node:fs";
 import path from "node:path";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 test.skipIf(isWindows)("execFileSync/spawnSync/execSync honor runtime mutations to process.env.PATH", async () => {
   using dir = tempDir("issue-29237", {

--- a/test/regression/issue/29237.test.ts
+++ b/test/regression/issue/29237.test.ts
@@ -6,13 +6,11 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
-test.skipIf(isWindows)(
-  "execFileSync/spawnSync/execSync honor runtime mutations to process.env.PATH",
-  async () => {
-    using dir = tempDir("issue-29237", {
-      // Fake `marker` binary — whichever PATH entry wins gets called.
-      "fake/marker": '#!/bin/sh\necho "FAKE_CALLED"\n',
-      "fixture.js": `
+test.skipIf(isWindows)("execFileSync/spawnSync/execSync honor runtime mutations to process.env.PATH", async () => {
+  using dir = tempDir("issue-29237", {
+    // Fake `marker` binary — whichever PATH entry wins gets called.
+    "fake/marker": '#!/bin/sh\necho "FAKE_CALLED"\n',
+    "fixture.js": `
         const { execFileSync, spawnSync, execSync } = require("node:child_process");
         const path = require("node:path");
 
@@ -36,35 +34,30 @@ test.skipIf(isWindows)(
         const d = execFileSync("marker", { encoding: "utf8", env: process.env }).trim();
         console.log("execFileSync+env:", d);
       `,
-    });
+  });
 
-    // chmod the fake binary so it's executable — tempDir writes 0644 by default.
-    const { chmodSync } = require("node:fs");
-    const path = require("node:path");
-    chmodSync(path.join(String(dir), "fake", "marker"), 0o755);
+  // chmod the fake binary so it's executable — tempDir writes 0644 by default.
+  const { chmodSync } = require("node:fs");
+  const path = require("node:path");
+  chmodSync(path.join(String(dir), "fake", "marker"), 0o755);
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "fixture.js"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-    });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect({ stdout, exitCode }).toEqual({
-      stdout:
-        "execFileSync: FAKE_CALLED\n" +
-        "spawnSync: FAKE_CALLED\n" +
-        "execSync: FAKE_CALLED\n" +
-        "execFileSync+env: FAKE_CALLED\n",
-      exitCode: 0,
-    });
-    // stderr may contain ASAN banner; we just want no actual errors from the fixture.
-    expect(stderr).not.toContain("error:");
-  },
-);
+  expect({ stdout, exitCode }).toEqual({
+    stdout:
+      "execFileSync: FAKE_CALLED\n" +
+      "spawnSync: FAKE_CALLED\n" +
+      "execSync: FAKE_CALLED\n" +
+      "execFileSync+env: FAKE_CALLED\n",
+    exitCode: 0,
+  });
+  // stderr may contain ASAN banner; we just want no actual errors from the fixture.
+  expect(stderr).not.toContain("error:");
+});

--- a/test/regression/issue/29237.test.ts
+++ b/test/regression/issue/29237.test.ts
@@ -4,6 +4,8 @@
 // is omitted — not a stale snapshot captured at Bun startup.
 
 import { expect, test } from "bun:test";
+import { chmodSync } from "node:fs";
+import path from "node:path";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 test.skipIf(isWindows)("execFileSync/spawnSync/execSync honor runtime mutations to process.env.PATH", async () => {
@@ -37,8 +39,6 @@ test.skipIf(isWindows)("execFileSync/spawnSync/execSync honor runtime mutations 
   });
 
   // chmod the fake binary so it's executable — tempDir writes 0644 by default.
-  const { chmodSync } = require("node:fs");
-  const path = require("node:path");
   chmodSync(path.join(String(dir), "fake", "marker"), 0o755);
 
   await using proc = Bun.spawn({


### PR DESCRIPTION
Fixes #29237

## Problem

`execFileSync`, `spawnSync`, and `execSync` were resolving bare command names against a *stale* snapshot of the environment when the caller omits `options.env` — so runtime mutations to `process.env.PATH` were ignored. Node honors them; Bun didn't. Passing `env: process.env` explicitly worked around it.

## Repro

```js
const { execFileSync } = require('node:child_process');
const fs = require('node:fs'), path = require('node:path'), os = require('node:os');

const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bun-path-test-'));
fs.writeFileSync(path.join(tmpDir, 'ls'), '#!/bin/sh\nrecho FAKE_CALLED'.replace('recho', 'echo'), { mode: 0o755 });
process.env.PATH = tmpDir + path.delimiter + process.env.PATH;

console.log(execFileSync('ls', { encoding: 'utf8' }).split('\n')[0]);
// Bun before: real /bin/ls output
// Bun after:  FAKE_CALLED
```

## Cause

`normalizeSpawnArguments` (in `src/js/node/child_process.ts`) reads `options.env || process.env` *live*, copies it into a fresh `bunEnv` object, and stashes that on the returned options as a symbol-keyed property `[kBunEnv]`. The **async** path (`ChildProcess.spawn`, line 1308) correctly reads:

```ts
var env = options[kBunEnv] || parseEnvPairs(options.envPairs) || process.env;
```

The **sync** path (`spawnSync`, line 537) was reading the wrong property:

```ts
env: options.env || undefined,
```

When the user omits `env`, `options.env` is `undefined` and `Bun.spawnSync` falls back to the process-start environment snapshot for PATH resolution. The freshly-captured `bunEnv` sits unused.

## Fix

Route `spawnSync` through the same `kBunEnv` symbol the async path already uses:

```diff
-      env: options.env || undefined,
+      env: options[kBunEnv] || undefined,
```

One-line change — this also fixes `execFileSync` and `execSync`, which route through `spawnSync`.

## Verification

New regression test: `test/regression/issue/29237.test.ts` — covers `execFileSync`, `spawnSync`, `execSync` (no explicit env) plus an explicit-env sanity check.

- **Without fix:** command not found → exit 1 (fake dir's PATH entry is ignored)
- **With fix:** all four calls output `FAKE_CALLED`

```
$ bun bd test test/regression/issue/29237.test.ts
(pass) execFileSync/spawnSync/execSync honor runtime mutations to process.env.PATH [1681.01ms]
```

Skipped on Windows (the PATH mutation test needs POSIX-style shebang binaries).

## CI note

Build #45425 shows only infra-flake failures on `linux-aarch64-musl-build-cpp` (exit -1, agent preemption) and two `darwin-*-aarch64-test-bun` jobs stuck in `Expired` state before running. All 52 other jobs pass, including every Windows test variant (verifying the Windows PATH casing fix), ASAN on Linux, and all non-aarch64 macOS/Linux/Windows configurations. No test-level failures.