### PR TITLE
Preserve string-literal names in re-export clauses

### DIFF
--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -1960,14 +1960,18 @@ fn NewPrinter(
                     p.printClauseAlias(item.alias);
                 }
             } else if (comptime as == .export_from) {
-                // In `export { x } from 'mod'`, the "name" on the left of `as` refers
-                // to an export of the other module. ECMAScript allows this to be a
-                // string literal (`export { "a b c" } from 'mod'`), so we must use
-                // `printClauseAlias` rather than `printIdentifier` here. The symbol
-                // does not participate in local renaming.
-                p.printClauseAlias(name);
+                // In `export { x } from 'mod'`, the "name" on the left of `as`
+                // refers to an export of the other module, not a local binding.
+                // It's stored as the raw source text on `item.original_name`
+                // (ECMAScript allows this to be a string literal like `"a b c"`)
+                // and the item's ref points to a synthesized intermediate symbol
+                // whose display name may be mangled by a minifier. We must print
+                // `original_name` via `printClauseAlias` so string literals stay
+                // quoted and mangling can't corrupt the foreign-module name.
+                const from_name = if (item.original_name.len > 0) item.original_name else name;
+                p.printClauseAlias(from_name);
 
-                if (!strings.eql(name, item.alias)) {
+                if (!strings.eql(from_name, item.alias)) {
                     p.print(" as ");
                     p.addSourceMapping(item.alias_loc);
                     p.printClauseAlias(item.alias);

--- a/src/js_printer.zig
+++ b/src/js_printer.zig
@@ -1926,6 +1926,10 @@ fn NewPrinter(
             return printClauseItemAs(p, item, .@"export");
         }
 
+        fn printExportFromClauseItem(p: *Printer, item: js_ast.ClauseItem) void {
+            return printClauseItemAs(p, item, .export_from);
+        }
+
         fn printClauseItemAs(p: *Printer, item: js_ast.ClauseItem, comptime as: @Type(.enum_literal)) void {
             const name = p.renamer.nameForSymbol(item.name.ref.?);
 
@@ -1949,6 +1953,19 @@ fn NewPrinter(
                 }
             } else if (comptime as == .@"export") {
                 p.printIdentifier(name);
+
+                if (!strings.eql(name, item.alias)) {
+                    p.print(" as ");
+                    p.addSourceMapping(item.alias_loc);
+                    p.printClauseAlias(item.alias);
+                }
+            } else if (comptime as == .export_from) {
+                // In `export { x } from 'mod'`, the "name" on the left of `as` refers
+                // to an export of the other module. ECMAScript allows this to be a
+                // string literal (`export { "a b c" } from 'mod'`), so we must use
+                // `printClauseAlias` rather than `printIdentifier` here. The symbol
+                // does not participate in local renaming.
+                p.printClauseAlias(name);
 
                 if (!strings.eql(name, item.alias)) {
                     p.print(" as ");
@@ -4216,7 +4233,7 @@ fn NewPrinter(
                             p.printNewline();
                             p.printIndent();
                         }
-                        p.printExportClauseItem(item);
+                        p.printExportFromClauseItem(item);
                     }
 
                     if (!s.is_single_line) {

--- a/test/regression/issue/29242.test.ts
+++ b/test/regression/issue/29242.test.ts
@@ -106,10 +106,7 @@ test.concurrent("transpiler preserves string literal names under --minify-identi
   // is a synthesized intermediate that a minifier may rename. Printing
   // `original_name` (the raw source text) keeps re-exports correct.
   using dir = tempDir("issue-29242-minify", {
-    "input.ts": [
-      `export { "a b c" as aliased } from './mod';`,
-      `export { foo as bar } from './mod';`,
-    ].join("\n"),
+    "input.ts": [`export { "a b c" as aliased } from './mod';`, `export { foo as bar } from './mod';`].join("\n"),
   });
 
   await using proc = Bun.spawn({

--- a/test/regression/issue/29242.test.ts
+++ b/test/regression/issue/29242.test.ts
@@ -1,0 +1,121 @@
+// https://github.com/oven-sh/bun/issues/29242
+//
+// The parser handles string-literal names in `export { ... } from 'mod'`
+// clauses, but when transpiling without bundling the printer dropped the
+// quotes around the local name, producing invalid syntax that JSC then
+// rejected:
+//
+//   export { "a b c" } from './b.mjs';   // input
+//   export { a b c } from './b.mjs';     // old output — SyntaxError
+//   export { "a b c" } from './b.mjs';   // fixed output
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("re-export with string literal local name (export { 'x y z' } from 'mod')", async () => {
+  using dir = tempDir("issue-29242-bare", {
+    "a.mjs": `export { "a b c" } from './b.mjs';`,
+    "b.mjs": `const a = 1;\nexport { a as "a b c" };`,
+    "main.mjs": `import { "a b c" as a } from './a.mjs';\nconsole.log(a);`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  expect(stderr).not.toContain("SyntaxError");
+  expect(stdout).toBe("1\n");
+  expect(exitCode).toBe(0);
+});
+
+test("re-export aliasing from string literal to identifier", async () => {
+  using dir = tempDir("issue-29242-alias", {
+    "a.mjs": `export { "a b c" as a } from './b.mjs';`,
+    "b.mjs": `const a = 1;\nexport { a as "a b c" };`,
+    "main.mjs": `import { a } from './a.mjs';\nconsole.log(a);`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  expect(stderr).not.toContain("SyntaxError");
+  expect(stdout).toBe("1\n");
+  expect(exitCode).toBe(0);
+});
+
+test("re-export aliasing string literal to string literal", async () => {
+  using dir = tempDir("issue-29242-both", {
+    "a.mjs": `export { "a b c" as "x y z" } from './b.mjs';`,
+    "b.mjs": `const a = 1;\nexport { a as "a b c" };`,
+    "main.mjs": `import { "x y z" as a } from './a.mjs';\nconsole.log(a);`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  expect(stderr).not.toContain("SyntaxError");
+  expect(stdout).toBe("1\n");
+  expect(exitCode).toBe(0);
+});
+
+test.each([
+  [`export { "a b c" } from './mod';`, [`"a b c"`], []],
+  [`export { "a b c" as a } from './mod';`, [`"a b c"`], []],
+  [`export { "a b c" as "x y z" } from './mod';`, [`"a b c"`, `"x y z"`], []],
+  [`export { plain, "a b c" as aliased } from './mod';`, [`"a b c"`, `plain`], []],
+])(
+  "transpiler preserves string literal names in export-from clauses: %s",
+  async (source, mustContain, _) => {
+    // Direct test of the printer: transpile without bundling and confirm the
+    // quotes around the local names are preserved.
+    using dir = tempDir("issue-29242-printer", {
+      "input.ts": source,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "input.ts", "--target=bun", "--no-bundle"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).not.toContain("SyntaxError");
+    expect(exitCode).toBe(0);
+    for (const frag of mustContain) {
+      expect(stdout).toContain(frag);
+    }
+    // No unquoted `a b c` or `x y z` anywhere.
+    expect(stdout).not.toMatch(/(^|[^"])a b c(?!")/);
+    expect(stdout).not.toMatch(/(^|[^"])x y z(?!")/);
+  },
+);

--- a/test/regression/issue/29242.test.ts
+++ b/test/regression/issue/29242.test.ts
@@ -11,7 +11,7 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-test("re-export with string literal local name (export { 'x y z' } from 'mod')", async () => {
+test.concurrent("re-export with string literal local name (export { 'x y z' } from 'mod')", async () => {
   using dir = tempDir("issue-29242-bare", {
     "a.mjs": `export { "a b c" } from './b.mjs';`,
     "b.mjs": `const a = 1;\nexport { a as "a b c" };`,
@@ -31,7 +31,7 @@ test("re-export with string literal local name (export { 'x y z' } from 'mod')",
   expect(exitCode).toBe(0);
 });
 
-test("re-export aliasing from string literal to identifier", async () => {
+test.concurrent("re-export aliasing from string literal to identifier", async () => {
   using dir = tempDir("issue-29242-alias", {
     "a.mjs": `export { "a b c" as a } from './b.mjs';`,
     "b.mjs": `const a = 1;\nexport { a as "a b c" };`,
@@ -51,7 +51,7 @@ test("re-export aliasing from string literal to identifier", async () => {
   expect(exitCode).toBe(0);
 });
 
-test("re-export aliasing string literal to string literal", async () => {
+test.concurrent("re-export aliasing string literal to string literal", async () => {
   using dir = tempDir("issue-29242-both", {
     "a.mjs": `export { "a b c" as "x y z" } from './b.mjs';`,
     "b.mjs": `const a = 1;\nexport { a as "a b c" };`,
@@ -71,12 +71,12 @@ test("re-export aliasing string literal to string literal", async () => {
   expect(exitCode).toBe(0);
 });
 
-test.each([
-  [`export { "a b c" } from './mod';`, [`"a b c"`], []],
-  [`export { "a b c" as a } from './mod';`, [`"a b c"`], []],
-  [`export { "a b c" as "x y z" } from './mod';`, [`"a b c"`, `"x y z"`], []],
-  [`export { plain, "a b c" as aliased } from './mod';`, [`"a b c"`, `plain`], []],
-])("transpiler preserves string literal names in export-from clauses: %s", async (source, mustContain, _) => {
+test.concurrent.each([
+  [`export { "a b c" } from './mod';`, [`"a b c"`]],
+  [`export { "a b c" as a } from './mod';`, [`"a b c"`]],
+  [`export { "a b c" as "x y z" } from './mod';`, [`"a b c"`, `"x y z"`]],
+  [`export { plain, "a b c" as aliased } from './mod';`, [`"a b c"`, `plain`]],
+])("transpiler preserves string literal names in export-from clauses: %s", async (source, mustContain) => {
   // Direct test of the printer: transpile without bundling and confirm the
   // quotes around the local names are preserved.
   using dir = tempDir("issue-29242-printer", {
@@ -92,11 +92,37 @@ test.each([
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).not.toContain("SyntaxError");
-  expect(exitCode).toBe(0);
   for (const frag of mustContain) {
     expect(stdout).toContain(frag);
   }
   // No unquoted `a b c` or `x y z` anywhere.
   expect(stdout).not.toMatch(/(^|[^"])a b c(?!")/);
   expect(stdout).not.toMatch(/(^|[^"])x y z(?!")/);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("transpiler preserves string literal names under --minify-identifiers", async () => {
+  // Regression for a subtlety: the export-from clause's left-side symbol
+  // is a synthesized intermediate that a minifier may rename. Printing
+  // `original_name` (the raw source text) keeps re-exports correct.
+  using dir = tempDir("issue-29242-minify", {
+    "input.ts": [
+      `export { "a b c" as aliased } from './mod';`,
+      `export { foo as bar } from './mod';`,
+    ].join("\n"),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "input.ts", "--target=bun", "--no-bundle", "--minify-identifiers"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("SyntaxError");
+  expect(stdout).toContain(`"a b c" as aliased`);
+  expect(stdout).toContain(`foo as bar`);
+  expect(stdout).not.toMatch(/(^|[^"])a b c(?!")/);
+  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/29242.test.ts
+++ b/test/regression/issue/29242.test.ts
@@ -11,7 +11,7 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-test.concurrent("re-export with string literal local name (export { 'x y z' } from 'mod')", async () => {
+test.concurrent("re-export with string literal local name (export { 'a b c' } from 'mod')", async () => {
   using dir = tempDir("issue-29242-bare", {
     "a.mjs": `export { "a b c" } from './b.mjs';`,
     "b.mjs": `const a = 1;\nexport { a as "a b c" };`,
@@ -95,9 +95,9 @@ test.concurrent.each([
   for (const frag of mustContain) {
     expect(stdout).toContain(frag);
   }
-  // No unquoted `a b c` or `x y z` anywhere.
-  expect(stdout).not.toMatch(/(^|[^"])a b c(?!")/);
-  expect(stdout).not.toMatch(/(^|[^"])x y z(?!")/);
+  // No unquoted `a b c` or `x y z` anywhere (guard quote-style agnostic).
+  expect(stdout).not.toMatch(/(^|[^"'])a b c(?!["'])/);
+  expect(stdout).not.toMatch(/(^|[^"'])x y z(?!["'])/);
   expect(exitCode).toBe(0);
 });
 
@@ -120,6 +120,6 @@ test.concurrent("transpiler preserves string literal names under --minify-identi
   expect(stderr).not.toContain("SyntaxError");
   expect(stdout).toContain(`"a b c" as aliased`);
   expect(stdout).toContain(`foo as bar`);
-  expect(stdout).not.toMatch(/(^|[^"])a b c(?!")/);
+  expect(stdout).not.toMatch(/(^|[^"'])a b c(?!["'])/);
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/29242.test.ts
+++ b/test/regression/issue/29242.test.ts
@@ -25,11 +25,7 @@ test("re-export with string literal local name (export { 'x y z' } from 'mod')",
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).not.toContain("SyntaxError");
   expect(stdout).toBe("1\n");
   expect(exitCode).toBe(0);
@@ -49,11 +45,7 @@ test("re-export aliasing from string literal to identifier", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).not.toContain("SyntaxError");
   expect(stdout).toBe("1\n");
   expect(exitCode).toBe(0);
@@ -73,11 +65,7 @@ test("re-export aliasing string literal to string literal", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).not.toContain("SyntaxError");
   expect(stdout).toBe("1\n");
   expect(exitCode).toBe(0);
@@ -88,34 +76,27 @@ test.each([
   [`export { "a b c" as a } from './mod';`, [`"a b c"`], []],
   [`export { "a b c" as "x y z" } from './mod';`, [`"a b c"`, `"x y z"`], []],
   [`export { plain, "a b c" as aliased } from './mod';`, [`"a b c"`, `plain`], []],
-])(
-  "transpiler preserves string literal names in export-from clauses: %s",
-  async (source, mustContain, _) => {
-    // Direct test of the printer: transpile without bundling and confirm the
-    // quotes around the local names are preserved.
-    using dir = tempDir("issue-29242-printer", {
-      "input.ts": source,
-    });
+])("transpiler preserves string literal names in export-from clauses: %s", async (source, mustContain, _) => {
+  // Direct test of the printer: transpile without bundling and confirm the
+  // quotes around the local names are preserved.
+  using dir = tempDir("issue-29242-printer", {
+    "input.ts": source,
+  });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "input.ts", "--target=bun", "--no-bundle"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
-    expect(stderr).not.toContain("SyntaxError");
-    expect(exitCode).toBe(0);
-    for (const frag of mustContain) {
-      expect(stdout).toContain(frag);
-    }
-    // No unquoted `a b c` or `x y z` anywhere.
-    expect(stdout).not.toMatch(/(^|[^"])a b c(?!")/);
-    expect(stdout).not.toMatch(/(^|[^"])x y z(?!")/);
-  },
-);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "input.ts", "--target=bun", "--no-bundle"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("SyntaxError");
+  expect(exitCode).toBe(0);
+  for (const frag of mustContain) {
+    expect(stdout).toContain(frag);
+  }
+  // No unquoted `a b c` or `x y z` anywhere.
+  expect(stdout).not.toMatch(/(^|[^"])a b c(?!")/);
+  expect(stdout).not.toMatch(/(^|[^"])x y z(?!")/);
+});


### PR DESCRIPTION
Fixes #29242

## Repro

```js
// a.mjs
export { "a b c" } from './b.mjs';
// b.mjs
const a = 1;
export { a as "a b c" };
// main.mjs
import { "a b c" as a } from './a.mjs';
console.log(a);
```

`bun main.mjs` fails with:

```
1 | export { "a b c" } from './b.mjs';
    ^
SyntaxError: Unexpected identifier 'b'. Expected '}' to end an export list.
```

## Cause

Bun's parser already accepts string-literal module export names in `export { ... } from 'mod'` clauses, but the printer emitted the local name via `printIdentifier`. For `export { "a b c" } from './b.mjs'`, this stripped the quotes and produced `export { a b c } from './b.mjs'` which JSC then rejected. Bundled output was fine — only single-file transpile hit this path.

## Fix

Added an `.export_from` variant of `printClauseItemAs` that prints the local name via `printClauseAlias` (which quotes the string when it isn't a valid identifier). The regular `export { x }` path is unchanged — per spec the local name there must be an `IdentifierReference`, so `printIdentifier` is still correct.

## Verification

`test/regression/issue/29242.test.ts` covers four variants (`{ 'x y z' }`, `{ 'x y z' as a }`, `{ 'x y z' as 'a b c' }`, mixed) plus direct printer checks. All seven fail on main and pass with the fix.