### PR TITLE
Fix null deref in forEachProperty when Proxy traps throw

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5290,10 +5290,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasSlot = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasSlot)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5365,7 +5366,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue nextProto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!nextProto || !nextProto.isObject())
+                break;
+            iterating = nextProto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -451,6 +451,29 @@ const fixture = [
         },
       },
     ),
+  () => {
+    class Foo {
+      get x() {
+        throw new Error("boom");
+      }
+    }
+    const obj = new Foo();
+    Object.setPrototypeOf(obj, new Proxy(Object.getPrototypeOf(obj), {}));
+    return obj;
+  },
+  () => {
+    class Foo {}
+    const obj = new Foo();
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(Object.getPrototypeOf(obj), {
+        getPrototypeOf() {
+          throw new Error("boom");
+        },
+      }),
+    );
+    return obj;
+  },
 ];
 
 describe("crash testing", () => {


### PR DESCRIPTION
Fuzzilli fingerprint: `8bfeac75c4d58b34`

## What

`Bun.inspect()` / `console.log()` crashed with a null `JSCell` dereference when formatting an object whose prototype chain contains a Proxy with a throwing trap.

Minimal repro:
```js
class Foo {
  get x() { throw new Error('boom'); }
}
const obj = new Foo();
Object.setPrototypeOf(obj, new Proxy(Object.getPrototypeOf(obj), {}));
console.log(obj);
```

Also crashes with a throwing `getPrototypeOf` trap:
```js
class Foo {}
const obj = new Foo();
Object.setPrototypeOf(obj, new Proxy(Object.getPrototypeOf(obj), {
  getPrototypeOf() { throw new Error('boom'); },
}));
console.log(obj);
```

## Why

In `JSC__JSValue__forEachPropertyImpl`:

1. `object->getPropertySlot()` can throw via a Proxy `[[Get]]` trap and return `false`. The `CLEAR_IF_EXCEPTION` that was meant to swallow this sat *after* the early `continue`, so it was never reached and the pending exception leaked forward.
2. `iterating->getPrototype(globalObject)` can throw via a Proxy `[[GetPrototypeOf]]` trap (or observe the leaked exception from (1)) and return an empty `JSValue`. Calling `.getObject()` on an empty `JSValue` dereferences a null `JSCell`.

## Fix

- Clear the exception before the `continue`.
- Check the `getPrototype()` result (clear any exception, bail on empty / non-object) before dereferencing.

Added regression cases to the existing `inspect.test.js` crash-testing fixture list.