### PR TITLE
Fix integer overflow in ReadFile buffer pre-allocation

### DIFF
--- a/src/bun.js/webcore/blob/read_file.zig
+++ b/src/bun.js/webcore/blob/read_file.zig
@@ -384,7 +384,7 @@ pub const ReadFile = struct {
 
         // add an extra 16 bytes to the buffer to avoid having to resize it for trailing extra data
         if (!this.could_block or (this.size > 0 and this.size != Blob.max_size))
-            this.buffer = std.ArrayListUnmanaged(u8).initCapacity(bun.default_allocator, this.size + 16) catch |err| {
+            this.buffer = std.ArrayListUnmanaged(u8).initCapacity(bun.default_allocator, this.size +| 16) catch |err| {
                 this.errno = err;
                 this.onFinish();
                 return;

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "bun:test";
 import { tmpdir } from "node:os";
+import { bunEnv, bunExe, isWindows } from "harness";
 
 it("offset should work in Bun.file() #4963", async () => {
   const filename = tmpdir() + "/bun.test.offset.txt";
@@ -8,4 +9,20 @@ it("offset should work in Bun.file() #4963", async () => {
   const slice = file.slice(2, file.size);
   const contents = await slice.text();
   expect(contents).toBe("ntents");
+});
+
+it.skipIf(isWindows)("slicing a non-regular file blob by offset should not overflow", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `await Bun.file("/dev/null").slice(1).text().then(() => console.log("ok"), e => console.log("ok", e?.name));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toContain("ok");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from "bun:test";
-import { tmpdir } from "node:os";
 import { bunEnv, bunExe, isWindows } from "harness";
+import { tmpdir } from "node:os";
 
 it("offset should work in Bun.file() #4963", async () => {
   const filename = tmpdir() + "/bun.test.offset.txt";


### PR DESCRIPTION
Fuzzilli fingerprint: `8fabc0535d925586`

## What

`Bun.file("/dev/null").slice(1).text()` panicked with an integer overflow in debug builds.

## Why

When a file-backed `Blob` has an unknown size, its `size` is the sentinel `Blob.max_size` (`maxInt(u52)`). Slicing it by an offset `N` produces a blob with `size = max_size - N`.

When reading such a blob backed by a non-regular file (char device, pipe, FIFO) whose `fstat` reports `st_size == 0`, `ReadFile.resolveSizeAndLastModified` sets `this.size = this.max_length` because `max_length != Blob.max_size`. Then `runAsyncWithFD` computes the initial buffer capacity as `this.size + 16`, which overflows `u52` and traps.

## Fix

Use saturating addition for the pre-allocation size. The initial capacity is only a hint; the read loop grows the buffer via a stack buffer fallback as needed, and the existing `catch` already handles allocation failure.

## Repro

```js
await Bun.file("/dev/null").slice(1).text();
```

Before:
```
panic: integer overflow
bun.js.webcore.blob.read_file.ReadFile.runAsyncWithFD
/workspace/bun/src/bun.js/webcore/blob/read_file.zig:387:100
```

After: resolves with `""`.