### PR TITLE
build: WebKit → preview-pr-181-ebf11e28

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "preview-pr-181-e38dd2fc";
+export const WEBKIT_VERSION = "preview-pr-181-68e2ebfa";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "preview-pr-181-68e2ebfa";
+export const WEBKIT_VERSION = "preview-pr-181-4596a6f6";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "42f80a684c5df57121a97e20825a3bcab7a0741b";
+export const WEBKIT_VERSION = "preview-pr-181-e38dd2fc";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "preview-pr-181-4596a6f6";
+export const WEBKIT_VERSION = "preview-pr-181-ebf11e28";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
Points the WebKit prebuilt at [oven-sh/WebKit#181](https://github.com/oven-sh/WebKit/pull/181)'s preview build (`autobuild-preview-pr-181-e38dd2fc`).

That PR fixes Windows resource exhaustion in libpas/WTF:
- Scavenger thread HANDLE leak (one per ~10s idle cycle)
- FLS index dropped → TLC destructor never fired
- `OSAllocator::decommit` never released commit charge (`MEM_RESET` → `MEM_DECOMMIT`)
- `pas_page_malloc` decommit leaked commit on the `do_mprotect=false` path

Baseline artifacts are present in this preview release, so no build-system workaround needed.