### PR TITLE
build: WebKit → preview-pr-182-d8d42dd3

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "preview-pr-182-98dc8d6e";
+export const WEBKIT_VERSION = "preview-pr-182-d8d42dd3";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "42f80a684c5df57121a97e20825a3bcab7a0741b";
+export const WEBKIT_VERSION = "preview-pr-182-98dc8d6e";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
Points the WebKit prebuilt at [oven-sh/WebKit#182](https://github.com/oven-sh/WebKit/pull/182)'s preview build (`autobuild-preview-pr-182-98dc8d6e`).

That PR fixes Linux RSS not recovering after load drops:
- libpas cartesian-tree max-heap invariant inverted → allocator pulled fresh pages while free blocks sat hidden
- `pas_bitfit_directory` race stranded pages so the scavenger never returned them
- TLC allocator-page decommit was Darwin-only — adds `pas_thread_suspender` callback so Linux can route through `WTF::Thread::suspend`
- Six smaller correctness fixes (PGM UAF, missed flag copy, missing mutex unlock, etc.)

Baseline artifacts are present in this preview release.