### PR TITLE
Fix integer overflow in ReadFile buffer preallocation

### DIFF
--- a/src/bun.js/webcore/blob/read_file.zig
+++ b/src/bun.js/webcore/blob/read_file.zig
@@ -384,7 +384,7 @@ pub const ReadFile = struct {
 
         // add an extra 16 bytes to the buffer to avoid having to resize it for trailing extra data
         if (!this.could_block or (this.size > 0 and this.size != Blob.max_size))
-            this.buffer = std.ArrayListUnmanaged(u8).initCapacity(bun.default_allocator, this.size + 16) catch |err| {
+            this.buffer = std.ArrayListUnmanaged(u8).initCapacity(bun.default_allocator, this.size +| 16) catch |err| {
                 this.errno = err;
                 this.onFinish();
                 return;

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from "bun:test";
-import { tmpdir } from "node:os";
 import { bunEnv, bunExe, isWindows } from "harness";
+import { tmpdir } from "node:os";
 
 it("offset should work in Bun.file() #4963", async () => {
   const filename = tmpdir() + "/bun.test.offset.txt";

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "bun:test";
 import { tmpdir } from "node:os";
+import { bunEnv, bunExe, isWindows } from "harness";
 
 it("offset should work in Bun.file() #4963", async () => {
   const filename = tmpdir() + "/bun.test.offset.txt";
@@ -8,4 +9,15 @@ it("offset should work in Bun.file() #4963", async () => {
   const slice = file.slice(2, file.size);
   const contents = await slice.text();
   expect(contents).toBe("ntents");
+});
+
+it.skipIf(isWindows)("reading a non-regular file sliced to near-max size should not overflow", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `await Bun.file("/dev/null").slice(0, 2**52 - 2).arrayBuffer(); console.log("ok");`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
 });


### PR DESCRIPTION
Fuzzilli found a debug panic (`integer overflow`) in `ReadFile.runAsyncWithFD`. Fingerprint: `9cb0cbabf00a5721`.

### What
When reading a file Blob backed by a non-regular file (pipe, character device) that has been sliced with an end value close to `maxInt(u52)`, `this.size` is set to `max_length` and then `this.size + 16` overflows the `u52` `SizeType` when computing the initial buffer capacity.

```js
await Bun.file("/dev/null").slice(0, 2**52 - 2).arrayBuffer();
```

```
panic: integer overflow
bun.js.webcore.blob.read_file.ReadFile.runAsyncWithFD
src/bun.js/webcore/blob/read_file.zig:387:100
```

### How
Use saturating addition (`+|`) so the allocation request is passed through to the allocator, which will fail cleanly with `OutOfMemory` (handled by the existing `catch`) instead of panicking on overflow.