### PR TITLE
resolver: skip auto-install for invalid npm package names

### DIFF
--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -1904,7 +1904,7 @@ pub const Resolver = struct {
         dir_info = source_dir_info;
 
         // this is the magic!
-        if (global_cache.canUse(any_node_modules_folder) and r.usePackageManager() and esm_ != null) {
+        if (global_cache.canUse(any_node_modules_folder) and r.usePackageManager() and esm_ != null and strings.isNPMPackageName(esm_.?.name)) {
             const esm = esm_.?.withAutoVersion();
             load_module_from_cache: {
                 // If the source directory doesn't have a node_modules directory, we can

--- a/test/js/bun/resolve/resolve-autoinstall-invalid-name.test.ts
+++ b/test/js/bun/resolve/resolve-autoinstall-invalid-name.test.ts
@@ -48,7 +48,7 @@ test("resolver does not attempt auto-install for invalid npm package names", asy
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toContain("ok");
   expect(requests).toBe(0);
@@ -86,7 +86,7 @@ test("resolver still attempts auto-install for valid npm package names", async (
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toContain("ok");
   expect(requests).toBeGreaterThan(0);

--- a/test/js/bun/resolve/resolve-autoinstall-invalid-name.test.ts
+++ b/test/js/bun/resolve/resolve-autoinstall-invalid-name.test.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// When auto-install is enabled, the resolver must not attempt to install a
+// package whose name is not a valid npm package name. Attempting to do so
+// reentrantly ticks the JS event loop from inside the resolver, which has led
+// to crashes when reached via mock.module() / vi.mock() / Bun.resolveSync()
+// with arbitrary user-provided strings.
+test("resolver does not attempt auto-install for invalid npm package names", async () => {
+  let requests = 0;
+  await using server = Bun.serve({
+    port: 0,
+    fetch() {
+      requests++;
+      return new Response("{}", { status: 404, headers: { "content-type": "application/json" } });
+    },
+  });
+
+  using dir = tempDir("resolve-autoinstall-invalid-name", {
+    "index.js": `
+      const specifiers = [
+        "function f2() {\\n    const v6 = new ArrayBuffer();\\n}",
+        "has spaces",
+        "(parens)",
+        "{braces}",
+        "line1\\nline2",
+        "foo\\tbar",
+        "a\\u0000b",
+      ];
+      for (const s of specifiers) {
+        try {
+          Bun.resolveSync(s, import.meta.dir);
+        } catch {}
+      }
+      console.log("ok");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--install=force", "index.js"],
+    env: {
+      ...bunEnv,
+      BUN_CONFIG_REGISTRY: server.url.href,
+      NPM_CONFIG_REGISTRY: server.url.href,
+    },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("ok");
+  expect(requests).toBe(0);
+  expect(exitCode).toBe(0);
+});
+
+test("resolver still attempts auto-install for valid npm package names", async () => {
+  let requests = 0;
+  await using server = Bun.serve({
+    port: 0,
+    fetch() {
+      requests++;
+      return new Response("{}", { status: 404, headers: { "content-type": "application/json" } });
+    },
+  });
+
+  using dir = tempDir("resolve-autoinstall-valid-name", {
+    "index.js": `
+      try {
+        Bun.resolveSync("some-package-that-does-not-exist-abc123", import.meta.dir);
+      } catch {}
+      console.log("ok");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--install=force", "index.js"],
+    env: {
+      ...bunEnv,
+      BUN_CONFIG_REGISTRY: server.url.href,
+      NPM_CONFIG_REGISTRY: server.url.href,
+    },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("ok");
+  expect(requests).toBeGreaterThan(0);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/mock/mock-module-non-string.test.ts
+++ b/test/js/bun/test/mock/mock-module-non-string.test.ts
@@ -16,3 +16,23 @@ test("mock.module still works with valid string argument", async () => {
   const m = await import("mock-module-non-string-test-fixture");
   expect(m.default).toBe(42);
 });
+
+test("mock.module does not crash on specifiers that are not valid npm package names", () => {
+  const specifiers = [
+    "function f2() {\n    const v6 = new ArrayBuffer();\n    v6.transferToFixedLength();\n}",
+    "foo\nbar",
+    "foo\rbar",
+    "has spaces",
+    "(parens)",
+    "{braces}",
+    "[brackets]",
+  ];
+  for (const specifier of specifiers) {
+    expect(() => mock.module(specifier, () => ({ default: 1 }))).not.toThrow();
+  }
+  for (const specifier of specifiers) {
+    // @ts-expect-error missing callback on purpose
+    expect(() => mock.module(specifier)).toThrow("mock(module, fn) requires a function");
+  }
+  Bun.gc(true);
+});


### PR DESCRIPTION
## Problem

Fuzzilli hit a flaky SIGSEGV (fingerprint `2519cad1804eace1`) from:

```js
const v13 = Bun.jest().vi;
try { v13.mock("function f2() {\n    const v6 = new ArrayBuffer();\n    ...\n}"); } catch (e) {}
Bun.gc(true);
```

`JSMock__jsModuleMock` calls `Bun__resolveSyncWithSource` on the specifier before validating the callback, which sends the garbage string through the resolver. The resolver's auto-install gate at `loadNodeModules` only checks `esm_ != null`; `ESModule.Package.parse` accepts anything that doesn't start with `.` or contain `\` / `%`, so the whole function source is treated as a package name. `enqueueDependencyToRoot` then calls `PackageManager.sleepUntil`, which re-enters `EventLoop.tick()` from inside a call that is itself running inside an event-loop tick:

```
#0 ConcurrentTask.PackedNextPtr.atomicLoadPtr
#1 UnboundedQueue(ConcurrentTask).popBatch
#3 event_loop.tickConcurrentWithCount
#7 AnyEventLoop.tick
#8 PackageManager.sleepUntil
#9 PackageManager.enqueueDependencyToRoot
#10 Resolver.resolveAndAutoInstall
#16 Bun__resolveSyncWithSource
#17 JSMock__jsModuleMock
```

The same path is reachable from `Bun.resolveSync`, `import()`, and `require.resolve` with any user-provided string.

## Fix

Gate the auto-install branch on `strings.isNPMPackageName(esm_.?.name)`. That validator already exists and is used by `bun link`, `bun pm view`, and the bundler; it rejects newlines, spaces, braces, and anything else that could never be a registry package. Specifiers failing the check fall straight through to `.not_found` — the same result the registry fetch would eventually produce — without initializing the package manager or ticking the event loop.

This is a resolver-level fix, so it covers every entry point (not just `mock.module`). It also avoids spurious network requests for garbage specifiers; on this container a single resolve of a multi-line specifier dropped from ~275ms to ~16ms.

## Tests

- `test/js/bun/resolve/resolve-autoinstall-invalid-name.test.ts` stands up a local registry and verifies zero manifest requests for a set of invalid names with `--install=force`, plus a positive control that a valid name still hits the registry.
- `test/js/bun/test/mock/mock-module-non-string.test.ts` gains a case for `mock.module` with newline / whitespace / bracket specifiers (with and without a callback).
- Existing `test/cli/run/run-autoinstall.test.ts` (11 tests) and `test/js/bun/test/mock/mock-module.test.ts` all pass.

Related: #28945, #28956, #28500, #28511.
Fingerprint: `2519cad1804eace1`