### PR TITLE
Implement `bun test --changed`

### DIFF
--- a/src/bun.js/RuntimeTranspilerStore.zig
+++ b/src/bun.js/RuntimeTranspilerStore.zig
@@ -342,7 +342,12 @@ pub const RuntimeTranspilerStore = struct {
                 .hot, .watch => {
                     if (vm.bun_watcher.indexOf(hash)) |index| {
                         const watcher_fd = vm.bun_watcher.watchlist().items(.fd)[index];
-                        fd = if (watcher_fd.stdioTag() == null) watcher_fd else null;
+                        // On Linux, `addFileByPathSlow` inserts watchlist
+                        // entries with `fd = invalid_fd` (only kqueue needs
+                        // the descriptor). Treat invalid as "no cached fd"
+                        // so `readFileWithAllocator` opens the file instead
+                        // of calling `seekTo` on a bogus handle.
+                        fd = if (watcher_fd.isValid() and watcher_fd.stdioTag() == null) watcher_fd else null;
                         package_json = vm.bun_watcher.watchlist().items(.package_json)[index];
                     }
                 },

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -73,11 +73,16 @@ pub const WatchReloader = NewHotReloader(VirtualMachine, jsc.EventLoop, true);
 ///
 /// Set by `test_command.zig` on the main thread before the watcher thread
 /// starts; after that point only the watcher thread touches it. Its
-/// contents are serialized into `BUN_INTERNAL_TEST_CHANGED_TRIGGER` via
-/// `setenv` immediately before `reloadProcess` so they survive exec().
+/// contents are written to `watch_changed_trigger_file` immediately
+/// before `reloadProcess`; the new process reads and deletes that file.
 pub var watch_changed_paths: ?*bun.StringSet = null;
 
-const trigger_env_var = "BUN_INTERNAL_TEST_CHANGED_TRIGGER";
+/// Absolute path of the temp file `flushChangedPathsForReload` writes
+/// the changed-path list into. The same path is exported via the
+/// `BUN_INTERNAL_TEST_CHANGED_TRIGGER_FILE` env var so the restarted
+/// process can find it. Set alongside `watch_changed_paths` by
+/// `test_command.zig`; the string must outlive the process.
+pub var watch_changed_trigger_file: ?[:0]const u8 = null;
 
 fn recordChangedPath(path: []const u8) void {
     const set = watch_changed_paths orelse return;
@@ -85,25 +90,26 @@ fn recordChangedPath(path: []const u8) void {
     bun.handleOom(set.insert(path));
 }
 
-fn exportChangedPathsToEnv() void {
-    // Windows `--watch` restarts via TerminateProcess + parent respawn;
-    // setenv in the dying child cannot reach the new child, so we fall
-    // back to re-querying git there (the pre-existing behaviour).
-    if (Environment.isWindows) return;
-
+/// Write the recorded changed paths to the trigger file so the next
+/// process (after exec()) can consume them. Best-effort: if the write
+/// fails, the new process falls back to querying git.
+fn flushChangedPathsForReload() void {
     const set = watch_changed_paths orelse return;
+    const dest = watch_changed_trigger_file orelse return;
     if (set.count() == 0) return;
 
     var buf = std.array_list.Managed(u8).init(bun.default_allocator);
+    defer buf.deinit();
     for (set.keys()) |p| {
         buf.appendSlice(p) catch return;
         buf.append('\n') catch return;
     }
-    const joined = buf.toOwnedSliceSentinel(0) catch return;
-    _ = setenv(trigger_env_var, joined.ptr, 1);
+    std.fs.cwd().writeFile(.{
+        .sub_path = dest,
+        .data = buf.items,
+        .flags = .{ .truncate = true },
+    }) catch {};
 }
-
-extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
 
 extern fn BunDebugger__willHotReload() void;
 
@@ -252,7 +258,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                         if (this.reloader.ctx.rare_data) |rare|
                             rare.closeAllListenSocketsForWatchMode();
                     }
-                    exportChangedPathsToEnv();
+                    flushChangedPathsForReload();
                     bun.reloadProcess(bun.default_allocator, clear_screen, false);
                     unreachable;
                 }

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -94,6 +94,11 @@ fn recordChangedPath(path: []const u8) void {
 /// process (after exec()) can consume them. Best-effort: if the write
 /// fails, the new process falls back to querying git.
 fn flushChangedPathsForReload() void {
+    // `watch_changed_trigger_file` is never set on Windows (see
+    // `ChangedFilesFilter.initWatchTrigger`), so this body would be
+    // dead there anyway; guarding lets us use POSIX path types below.
+    if (Environment.isWindows) return;
+
     const set = watch_changed_paths orelse return;
     const dest = watch_changed_trigger_file orelse return;
     if (set.count() == 0) return;
@@ -104,11 +109,7 @@ fn flushChangedPathsForReload() void {
         buf.appendSlice(p) catch return;
         buf.append('\n') catch return;
     }
-    std.fs.cwd().writeFile(.{
-        .sub_path = dest,
-        .data = buf.items,
-        .flags = .{ .truncate = true },
-    }) catch {};
+    _ = bun.sys.File.writeFile(bun.FD.cwd(), dest, buf.items);
 }
 
 extern fn BunDebugger__willHotReload() void;

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -64,6 +64,47 @@ pub const ImportWatcher = union(enum) {
 pub const HotReloader = NewHotReloader(VirtualMachine, jsc.EventLoop, false);
 pub const WatchReloader = NewHotReloader(VirtualMachine, jsc.EventLoop, true);
 
+/// When non-null, `onFileUpdate` records the absolute path of every file
+/// it sees change before triggering a reload. Used by `bun test --changed
+/// --watch` so the restarted process can narrow its changed-file set to
+/// what the watcher actually observed (instead of re-querying git, which
+/// would re-run every test affected by any uncommitted change, not just
+/// the one that was just edited).
+///
+/// Set by `test_command.zig` on the main thread before the watcher thread
+/// starts; after that point only the watcher thread touches it. Its
+/// contents are serialized into `BUN_INTERNAL_TEST_CHANGED_TRIGGER` via
+/// `setenv` immediately before `reloadProcess` so they survive exec().
+pub var watch_changed_paths: ?*bun.StringSet = null;
+
+const trigger_env_var = "BUN_INTERNAL_TEST_CHANGED_TRIGGER";
+
+fn recordChangedPath(path: []const u8) void {
+    const set = watch_changed_paths orelse return;
+    if (path.len == 0) return;
+    bun.handleOom(set.insert(path));
+}
+
+fn exportChangedPathsToEnv() void {
+    // Windows `--watch` restarts via TerminateProcess + parent respawn;
+    // setenv in the dying child cannot reach the new child, so we fall
+    // back to re-querying git there (the pre-existing behaviour).
+    if (Environment.isWindows) return;
+
+    const set = watch_changed_paths orelse return;
+    if (set.count() == 0) return;
+
+    var buf = std.array_list.Managed(u8).init(bun.default_allocator);
+    for (set.keys()) |p| {
+        buf.appendSlice(p) catch return;
+        buf.append('\n') catch return;
+    }
+    const joined = buf.toOwnedSliceSentinel(0) catch return;
+    _ = setenv(trigger_env_var, joined.ptr, 1);
+}
+
+extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+
 extern fn BunDebugger__willHotReload() void;
 
 pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime reload_immediately: bool) type {
@@ -211,6 +252,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                         if (this.reloader.ctx.rare_data) |rare|
                             rare.closeAllListenSocketsForWatchMode();
                     }
+                    exportChangedPathsToEnv();
                     bun.reloadProcess(bun.default_allocator, clear_screen, false);
                     unreachable;
                 }
@@ -377,6 +419,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                             debug("File changed: {s}", .{fs.relativeTo(file_path)});
 
                         if (event.op.write or event.op.delete or event.op.rename) {
+                            recordChangedPath(file_path);
                             if (comptime Environment.isMac) {
                                 if (event.op.rename) {
                                     // Special case for entrypoint: defer reload until we get
@@ -426,6 +469,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                                     if (this.main.is_waiting_for_dir_change and this.main.dir_hash == current_hash) {
                                         if (bun.sys.faccessat(file_descriptors[event.index], std.fs.path.basename(this.main.file)) == .result) {
                                             this.main.is_waiting_for_dir_change = false;
+                                            recordChangedPath(this.main.file);
                                             current_task.append(this.main.hash);
                                         }
                                     }
@@ -494,6 +538,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
                                                 if (hash == file_hash) {
                                                     if (file_descriptors[entry_id].isValid()) {
                                                         if (prev_entry_id != entry_id) {
+                                                            recordChangedPath(path_string.slice());
                                                             current_task.append(hashes[entry_id]);
                                                             if (this.verbose)
                                                                 debug("Removing file: {s}", .{path_string.slice()});

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -1635,10 +1635,13 @@ pub const BundleV2 = struct {
     /// used by `bun test --changed` to walk import records and compute which
     /// test entry points transitively depend on a given set of source files.
     ///
-    /// The returned BundleV2 and its graph are allocated on a fresh
-    /// ThreadLocalArena; the caller should dupe anything it needs and then
-    /// release it with `deinitWithoutFreeingArena()` followed by
-    /// `graph.heap.deinit()`.
+    /// The returned BundleV2, its ThreadLocalArena, and its worker pool are
+    /// intentionally left alive for the remainder of the process. Tearing
+    /// the pool down via `deinitWithoutFreeingArena()` blocks on worker
+    /// shutdown and contends with the runtime VM's own parse threads; the
+    /// sole caller exec()s (watch mode) or exits shortly after, so the leak
+    /// is bounded. Dupe anything you need out of the graph before returning
+    /// to the caller.
     pub fn scanModuleGraphFromCLI(
         transpiler: *Transpiler,
         alloc: std.mem.Allocator,

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -1636,8 +1636,9 @@ pub const BundleV2 = struct {
     /// test entry points transitively depend on a given set of source files.
     ///
     /// The returned BundleV2 and its graph are allocated on a fresh
-    /// ThreadLocalArena; the caller is expected to let them leak for the
-    /// lifetime of the process (this runs once during test startup).
+    /// ThreadLocalArena; the caller should dupe anything it needs and then
+    /// release it with `deinitWithoutFreeingArena()` followed by
+    /// `graph.heap.deinit()`.
     pub fn scanModuleGraphFromCLI(
         transpiler: *Transpiler,
         alloc: std.mem.Allocator,
@@ -1659,10 +1660,17 @@ pub const BundleV2 = struct {
             return error.BuildFailed;
         }
 
-        try this.enqueueEntryPoints(.normal, entry_points);
+        // enqueueEntryPoints schedules the runtime task before any fallible
+        // allocation. If a later allocation fails we must still drain the
+        // pool so workers aren't left holding pointers into the caller's
+        // stack-allocated Transpiler.
+        this.enqueueEntryPoints(.normal, entry_points) catch |err| {
+            this.waitForParse();
+            return err;
+        };
 
-        // Even if entry point resolution produced errors we still wait for all
-        // enqueued parse tasks to finish so the graph is consistent.
+        // Even if entry point resolution produced errors we still wait for
+        // all enqueued parse tasks to finish so the graph is consistent.
         this.waitForParse();
 
         return this;

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -1630,6 +1630,44 @@ pub const BundleV2 = struct {
         };
     }
 
+    /// Build only the parse graph for the given entry points and return the
+    /// BundleV2 instance. No linking or code generation is performed; this is
+    /// used by `bun test --changed` to walk import records and compute which
+    /// test entry points transitively depend on a given set of source files.
+    ///
+    /// The returned BundleV2 and its graph are allocated on a fresh
+    /// ThreadLocalArena; the caller is expected to let them leak for the
+    /// lifetime of the process (this runs once during test startup).
+    pub fn scanModuleGraphFromCLI(
+        transpiler: *Transpiler,
+        alloc: std.mem.Allocator,
+        event_loop: EventLoop,
+        entry_points: []const []const u8,
+    ) !*BundleV2 {
+        var this = try BundleV2.init(
+            transpiler,
+            null,
+            alloc,
+            event_loop,
+            false,
+            null,
+            .init(),
+        );
+        this.unique_key = generateUniqueKey();
+
+        if (this.transpiler.log.hasErrors()) {
+            return error.BuildFailed;
+        }
+
+        try this.enqueueEntryPoints(.normal, entry_points);
+
+        // Even if entry point resolution produced errors we still wait for all
+        // enqueued parse tasks to finish so the graph is consistent.
+        this.waitForParse();
+
+        return this;
+    }
+
     pub fn generateFromBakeProductionCLI(
         entry_points: bake.production.EntryPointMap,
         server_transpiler: *Transpiler,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -357,6 +357,12 @@ pub const Command = struct {
         test_filter_pattern: ?[]const u8 = null,
         test_filter_regex: ?*RegularExpression = null,
         max_concurrency: u32 = 20,
+        /// `bun test --changed[=<since>]`. When set, only test files whose
+        /// module graph reaches a file changed according to git are run.
+        /// null = flag not passed. "" = compare against uncommitted changes.
+        /// Otherwise the value is a git ref (commit, branch, tag) to diff
+        /// against.
+        changed: ?[]const u8 = null,
 
         reporters: struct {
             dots: bool = false,

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -242,6 +242,7 @@ pub const test_only_params = [_]ParamType{
     clap.parseParam("--only-failures                  Only display test failures, hiding passing tests.") catch unreachable,
     clap.parseParam("--max-concurrency <NUMBER>        Maximum number of concurrent tests to execute at once. Default is 20.") catch unreachable,
     clap.parseParam("--path-ignore-patterns <STR>...   Glob patterns for test file paths to ignore.") catch unreachable,
+    clap.parseParam("--changed <STR>?                 Only run test files affected by changed files according to git. Optionally pass a commit or branch to compare against.") catch unreachable,
 };
 pub const test_params = test_only_params ++ runtime_params_ ++ transpiler_params_ ++ base_params_;
 
@@ -604,6 +605,9 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
                 Global.exit(1);
             };
             ctx.test_options.test_filter_regex = regex;
+        }
+        if (args.option("--changed")) |since| {
+            ctx.test_options.changed = since;
         }
         ctx.test_options.update_snapshots = args.flag("--update-snapshots");
         ctx.test_options.run_todo = args.flag("--todo");

--- a/src/cli/test/ChangedFilesFilter.zig
+++ b/src/cli/test/ChangedFilesFilter.zig
@@ -340,10 +340,11 @@ const GitError = error{ GitNotFound, GitFailed } || std.mem.Allocator.Error;
 
 /// Return the set of changed files (absolute paths) according to git.
 ///
-/// With `since == ""` this is the union of unstaged, staged, and untracked
-/// files. With a ref, it is `git diff --name-only <since>`. Paths that do not
-/// exist on disk (deletions) are skipped since they cannot appear in the
-/// module graph.
+/// With `since == ""` this is the union of unstaged, staged, and
+/// untracked files. With a ref, it is `git diff --name-only <since>`
+/// unioned with untracked files (a brand-new file is "changed since"
+/// any prior commit). Paths that do not exist on disk (deletions) are
+/// skipped since they cannot appear in the module graph.
 fn getChangedFiles(
     allocator: std.mem.Allocator,
     top_level_dir: []const u8,
@@ -405,16 +406,6 @@ fn getChangedFiles(
                 appendPaths(&set, git_root, staged.stdout.items);
             }
         }
-
-        // Untracked files. `--full-name` forces repo-root-relative output
-        // regardless of our cwd, matching `git diff --name-only` above.
-        var untracked = try runGit(allocator, git_path, top_level_dir, &.{ "ls-files", "--others", "--exclude-standard", "--full-name" });
-        defer untracked.stdout.deinit();
-        defer untracked.stderr.deinit();
-        if (untracked.spawn_failed) return error.GitFailed;
-        if (untracked.ok) {
-            appendPaths(&set, git_root, untracked.stdout.items);
-        }
     } else {
         var diff = try runGit(allocator, git_path, top_level_dir, &.{ "diff", "--name-only", since, "--" });
         defer diff.stdout.deinit();
@@ -430,6 +421,22 @@ fn getChangedFiles(
             return error.GitFailed;
         }
         appendPaths(&set, git_root, diff.stdout.items);
+    }
+
+    // Untracked files are always considered changed — a brand-new file
+    // did not exist at HEAD or at `since`, so it is "changed since"
+    // either. `git diff --name-only` never reports untracked files, so
+    // supplement with ls-files in both branches above. `--full-name`
+    // forces repo-root-relative output regardless of our cwd, matching
+    // `git diff --name-only`.
+    {
+        var untracked = try runGit(allocator, git_path, top_level_dir, &.{ "ls-files", "--others", "--exclude-standard", "--full-name" });
+        defer untracked.stdout.deinit();
+        defer untracked.stderr.deinit();
+        if (untracked.spawn_failed) return error.GitFailed;
+        if (untracked.ok) {
+            appendPaths(&set, git_root, untracked.stdout.items);
+        }
     }
 
     return set;

--- a/src/cli/test/ChangedFilesFilter.zig
+++ b/src/cli/test/ChangedFilesFilter.zig
@@ -10,8 +10,6 @@
 //!
 //! Only those test entry points are returned.
 
-const ChangedFilesFilter = @This();
-
 pub const Result = struct {
     /// The filtered list of test files. Slice of the original `test_files`
     /// allocation, owned by the caller.
@@ -404,11 +402,9 @@ const Environment = bun.Environment;
 const Global = bun.Global;
 const Output = bun.Output;
 const Transpiler = bun.Transpiler;
+const jsc = bun.jsc;
 const logger = bun.logger;
 const strings = bun.strings;
-
-const Command = bun.cli.Command;
-const jsc = bun.jsc;
-
 const BundleV2 = bun.bundle_v2.BundleV2;
+const Command = bun.cli.Command;
 const Index = bun.ast.Index;

--- a/src/cli/test/ChangedFilesFilter.zig
+++ b/src/cli/test/ChangedFilesFilter.zig
@@ -1,0 +1,414 @@
+//! Implements `bun test --changed` (vitest-compatible).
+//!
+//! 1. Ask git for the set of changed files relative to HEAD (uncommitted,
+//!    staged, and untracked) or relative to a user-supplied ref.
+//! 2. Run the bundler over every discovered test file with packages marked
+//!    external so node_modules are not entered. This produces the full parse
+//!    graph (transitive imports) without linking or emitting code.
+//! 3. Starting from each changed file that appears in the graph, walk the
+//!    reverse import edges to find every test entry point that can reach it.
+//!
+//! Only those test entry points are returned.
+
+const ChangedFilesFilter = @This();
+
+pub const Result = struct {
+    /// The filtered list of test files. Slice of the original `test_files`
+    /// allocation, owned by the caller.
+    test_files: []bun.PathString,
+    /// Number of files git reported as changed.
+    changed_count: usize,
+    /// Number of test files before filtering.
+    total_tests: usize,
+    /// Absolute paths of every local source file that participates in the
+    /// module graph (test entry points and everything they transitively
+    /// import, excluding node_modules). Used by `--changed --watch` to watch
+    /// files that would not otherwise be loaded when a subset of tests runs.
+    /// Owned by the caller; each element is individually allocated.
+    module_graph_files: []const []const u8 = &.{},
+};
+
+/// Filter `test_files` in place to only the entries whose module graph
+/// reaches a changed file. On success, `test_files` is compacted (preserving
+/// order) and the new length is returned via `Result.test_files`.
+pub fn filter(
+    ctx: Command.Context,
+    vm: *jsc.VirtualMachine,
+    test_files: []bun.PathString,
+    changed_since: []const u8,
+) !Result {
+    const allocator = ctx.allocator;
+    const top_level_dir = vm.transpiler.fs.top_level_dir;
+
+    var changed_files = getChangedFiles(allocator, top_level_dir, changed_since) catch |err| switch (err) {
+        error.GitNotFound => {
+            Output.errGeneric("<b>--changed<r> requires <b>git<r> to be installed and in PATH", .{});
+            Global.exit(1);
+        },
+        error.GitFailed => {
+            // getChangedFiles already printed the git error output.
+            Global.exit(1);
+        },
+        else => return err,
+    };
+    defer changed_files.deinit();
+
+    if (test_files.len == 0) {
+        return .{
+            .test_files = test_files[0..0],
+            .changed_count = changed_files.count(),
+            .total_tests = 0,
+        };
+    }
+
+    // Convert PathString list to []const []const u8 for the bundler.
+    const entry_points = try allocator.alloc([]const u8, test_files.len);
+    defer allocator.free(entry_points);
+    for (test_files, entry_points) |p, *out| out.* = p.slice();
+
+    // Build a dedicated transpiler for scanning. We do not reuse the VM's
+    // transpiler because BundleV2.init takes ownership of the allocator and
+    // log, and we want the runtime transpiler left untouched for actually
+    // executing tests afterward.
+    var log = logger.Log.init(allocator);
+    defer log.deinit();
+
+    var scan_transpiler = Transpiler.init(allocator, &log, ctx.args, vm.transpiler.env) catch |err| {
+        Output.errGeneric("Failed to initialize module graph scanner for --changed: {s}", .{@errorName(err)});
+        Global.exit(1);
+    };
+    scan_transpiler.options.target = .bun;
+    scan_transpiler.options.entry_points = entry_points;
+    // Do not follow bare specifiers into node_modules; changes there are not
+    // considered local edits.
+    scan_transpiler.options.packages = .external;
+    // The module graph scan is best-effort. A test file that imports
+    // something unresolved should still be considered, not abort --changed.
+    scan_transpiler.options.ignore_module_resolution_errors = true;
+    scan_transpiler.options.output_dir = "";
+    scan_transpiler.options.tree_shaking = false;
+    scan_transpiler.configureLinker();
+    scan_transpiler.configureDefines() catch {};
+    scan_transpiler.resolver.opts = scan_transpiler.options;
+    scan_transpiler.resolver.env_loader = scan_transpiler.env;
+
+    const bundle = BundleV2.scanModuleGraphFromCLI(
+        &scan_transpiler,
+        allocator,
+        jsc.AnyEventLoop.init(allocator),
+        entry_points,
+    ) catch |err| {
+        // Fall back to running every test rather than aborting the run.
+        Output.warn("--changed: failed to build module graph ({s}); running all tests", .{@errorName(err)});
+        Output.flush();
+        return .{
+            .test_files = test_files,
+            .changed_count = changed_files.count(),
+            .total_tests = test_files.len,
+        };
+    };
+
+    const sources = bundle.graph.input_files.items(.source);
+    const import_records = bundle.graph.ast.items(.import_records);
+
+    // Map absolute source path -> source index for paths that participate in
+    // the graph. This lets us look up changed-file paths quickly.
+    var path_to_index = bun.StringHashMap(u32).init(allocator);
+    defer path_to_index.deinit();
+    try path_to_index.ensureTotalCapacity(@intCast(sources.len));
+
+    // Reverse graph: for each source index, the list of source indexes that
+    // import it. Built once, then used for a backward BFS from every changed
+    // file.
+    const importers = try allocator.alloc(std.ArrayListUnmanaged(u32), sources.len);
+    defer {
+        for (importers) |*list| list.deinit(allocator);
+        allocator.free(importers);
+    }
+    for (importers) |*list| list.* = .{};
+
+    var graph_files: std.ArrayListUnmanaged([]const u8) = .{};
+    errdefer {
+        for (graph_files.items) |p| allocator.free(p);
+        graph_files.deinit(allocator);
+    }
+
+    for (sources, 0..) |*source, idx| {
+        const index = Index.init(@as(u32, @intCast(idx)));
+        if (index.isRuntime()) continue;
+        const path_text = source.path.text;
+        if (path_text.len == 0) continue;
+        // Only record real on-disk files (the bundler reserves a few
+        // virtual slots whose namespace is not "file").
+        if (!source.path.isFile()) continue;
+        // All scanned entry points are absolute, and the resolver emits
+        // absolute file paths as well.
+        path_to_index.putAssumeCapacity(path_text, @intCast(idx));
+        // Copy out of the bundler's arena so the caller can use these paths
+        // after the BundleV2 heap is gone.
+        try graph_files.append(allocator, try allocator.dupe(u8, path_text));
+    }
+
+    for (import_records, 0..) |records, idx| {
+        const importer: u32 = @intCast(idx);
+        for (records.slice()) |*record| {
+            const dep = record.source_index;
+            if (!dep.isValid() or dep.isRuntime()) continue;
+            if (dep.get() >= sources.len) continue;
+            try importers[dep.get()].append(allocator, importer);
+        }
+    }
+
+    // Identify which source indexes correspond to test entry points so we can
+    // check BFS results against them. `bundle.graph.entry_points` preserves
+    // the order of `entry_points`, but an entry point that failed to resolve
+    // is skipped, so we map by path rather than by position.
+    var entry_index_to_test_slot = std.AutoHashMap(u32, usize).init(allocator);
+    defer entry_index_to_test_slot.deinit();
+    for (bundle.graph.entry_points.items) |entry_index| {
+        const path_text = sources[entry_index.get()].path.text;
+        // `test_files` is typically small enough that a linear lookup is fine
+        // (matching the overall cost of building the graph). Match by
+        // identity against the PathString slices we passed in.
+        for (test_files, 0..) |tf, slot| {
+            if (strings.eql(tf.slice(), path_text)) {
+                try entry_index_to_test_slot.put(entry_index.get(), slot);
+                break;
+            }
+        }
+    }
+
+    // BFS backward from every changed file that participates in the graph.
+    var affected = try bun.bit_set.DynamicBitSetUnmanaged.initEmpty(allocator, sources.len);
+    defer affected.deinit(allocator);
+    var queue: std.ArrayListUnmanaged(u32) = .{};
+    defer queue.deinit(allocator);
+
+    {
+        var it = changed_files.map.iterator();
+        while (it.next()) |entry| {
+            const changed_path = entry.key_ptr.*;
+            if (path_to_index.get(changed_path)) |idx| {
+                if (!affected.isSet(idx)) {
+                    affected.set(idx);
+                    try queue.append(allocator, idx);
+                }
+            }
+        }
+    }
+
+    while (queue.pop()) |idx| {
+        for (importers[idx].items) |importer| {
+            if (affected.isSet(importer)) continue;
+            affected.set(importer);
+            try queue.append(allocator, importer);
+        }
+    }
+
+    // A test file is selected if (a) its entry point source index is marked
+    // affected, or (b) the test file itself is in the changed set (covers
+    // test files that failed to enter the graph for any reason).
+    var write: usize = 0;
+    for (test_files, 0..) |tf, slot| {
+        var keep = changed_files.contains(tf.slice());
+
+        if (!keep) {
+            // Find the entry index that corresponds to this slot.
+            var iter = entry_index_to_test_slot.iterator();
+            while (iter.next()) |e| {
+                if (e.value_ptr.* == slot) {
+                    if (affected.isSet(e.key_ptr.*)) keep = true;
+                    break;
+                }
+            }
+        }
+
+        if (keep) {
+            test_files[write] = tf;
+            write += 1;
+        }
+    }
+
+    return .{
+        .test_files = test_files[0..write],
+        .changed_count = changed_files.count(),
+        .total_tests = test_files.len,
+        .module_graph_files = try graph_files.toOwnedSlice(allocator),
+    };
+}
+
+const GitError = error{ GitNotFound, GitFailed } || std.mem.Allocator.Error;
+
+/// Return the set of changed files (absolute paths) according to git.
+///
+/// With `since == ""` this is the union of unstaged, staged, and untracked
+/// files. With a ref, it is `git diff --name-only <since>`. Paths that do not
+/// exist on disk (deletions) are skipped since they cannot appear in the
+/// module graph.
+fn getChangedFiles(
+    allocator: std.mem.Allocator,
+    top_level_dir: []const u8,
+    since: []const u8,
+) GitError!bun.StringSet {
+    var which_buf: bun.PathBuffer = undefined;
+    const git_path = bun.which(&which_buf, bun.env_var.PATH.get() orelse "", top_level_dir, "git") orelse {
+        return error.GitNotFound;
+    };
+
+    // Find the git repository root so we can make the paths git prints
+    // absolute (git prints paths relative to the repo toplevel with these
+    // commands).
+    const git_root = blk: {
+        var result = try runGit(allocator, git_path, top_level_dir, &.{ "rev-parse", "--show-toplevel" });
+        defer result.stdout.deinit();
+        defer result.stderr.deinit();
+        if (!result.ok) {
+            if (result.stderr.items.len > 0) {
+                Output.errGeneric("--changed: {s}", .{strings.trim(result.stderr.items, " \r\n\t")});
+            } else {
+                Output.errGeneric("--changed requires running inside a git repository", .{});
+            }
+            return error.GitFailed;
+        }
+        break :blk try allocator.dupe(u8, strings.trim(result.stdout.items, " \r\n\t"));
+    };
+    defer allocator.free(git_root);
+
+    var set = bun.StringSet.init(allocator);
+    errdefer set.deinit();
+
+    if (since.len == 0) {
+        // Uncommitted (unstaged + staged). `git diff HEAD` covers both.
+        // On a repo with no commits, `HEAD` is unresolved; fall back to just
+        // `git diff` (unstaged) + staged.
+        var diff = try runGit(allocator, git_path, top_level_dir, &.{ "diff", "--name-only", "HEAD", "--" });
+        defer diff.stdout.deinit();
+        defer diff.stderr.deinit();
+        if (diff.ok) {
+            try appendPaths(&set, git_root, diff.stdout.items);
+        } else {
+            var unstaged = try runGit(allocator, git_path, top_level_dir, &.{ "diff", "--name-only", "--" });
+            defer unstaged.stdout.deinit();
+            defer unstaged.stderr.deinit();
+            try appendPaths(&set, git_root, unstaged.stdout.items);
+
+            var staged = try runGit(allocator, git_path, top_level_dir, &.{ "diff", "--name-only", "--cached", "--" });
+            defer staged.stdout.deinit();
+            defer staged.stderr.deinit();
+            try appendPaths(&set, git_root, staged.stdout.items);
+        }
+
+        // Untracked files.
+        var untracked = try runGit(allocator, git_path, top_level_dir, &.{ "ls-files", "--others", "--exclude-standard" });
+        defer untracked.stdout.deinit();
+        defer untracked.stderr.deinit();
+        if (untracked.ok) {
+            try appendPaths(&set, git_root, untracked.stdout.items);
+        }
+    } else {
+        var diff = try runGit(allocator, git_path, top_level_dir, &.{ "diff", "--name-only", since, "--" });
+        defer diff.stdout.deinit();
+        defer diff.stderr.deinit();
+        if (!diff.ok) {
+            if (diff.stderr.items.len > 0) {
+                Output.errGeneric("--changed: {s}", .{strings.trim(diff.stderr.items, " \r\n\t")});
+            } else {
+                Output.errGeneric("--changed: git diff against {f} failed", .{bun.fmt.quote(since)});
+            }
+            return error.GitFailed;
+        }
+        try appendPaths(&set, git_root, diff.stdout.items);
+    }
+
+    return set;
+}
+
+const GitResult = struct {
+    ok: bool,
+    stdout: std.array_list.Managed(u8),
+    stderr: std.array_list.Managed(u8),
+};
+
+fn runGit(
+    allocator: std.mem.Allocator,
+    git_path: []const u8,
+    cwd: []const u8,
+    args: []const []const u8,
+) std.mem.Allocator.Error!GitResult {
+    var argv = try std.array_list.Managed([]const u8).initCapacity(allocator, args.len + 1);
+    defer argv.deinit();
+    argv.appendAssumeCapacity(git_path);
+    argv.appendSliceAssumeCapacity(args);
+
+    const proc = bun.spawnSync(&.{
+        .argv = argv.items,
+        .cwd = cwd,
+        .stdout = .buffer,
+        .stderr = .buffer,
+        .stdin = .ignore,
+        .envp = null,
+        // The test command has a JSC VM running; reuse its event loop on
+        // Windows rather than spinning up a MiniEventLoop.
+        .windows = if (Environment.isWindows) .{
+            .loop = jsc.EventLoopHandle.init(jsc.VirtualMachine.get()),
+        },
+    }) catch |err| {
+        Output.errGeneric("--changed: failed to spawn git: {s}", .{@errorName(err)});
+        return .{
+            .ok = false,
+            .stdout = .init(allocator),
+            .stderr = .init(allocator),
+        };
+    };
+
+    return switch (proc) {
+        .err => |err| {
+            Output.errGeneric("--changed: failed to spawn git: {f}", .{err});
+            return .{
+                .ok = false,
+                .stdout = .init(allocator),
+                .stderr = .init(allocator),
+            };
+        },
+        .result => |result| .{
+            .ok = result.isOK(),
+            .stdout = result.stdout,
+            .stderr = result.stderr,
+        },
+    };
+}
+
+/// Parse newline-delimited repo-relative paths from git output, join each
+/// with the repository root, and insert existing files into `set`.
+fn appendPaths(
+    set: *bun.StringSet,
+    git_root: []const u8,
+    stdout: []const u8,
+) std.mem.Allocator.Error!void {
+    var buf: bun.PathBuffer = undefined;
+    var it = std.mem.tokenizeAny(u8, stdout, "\r\n");
+    while (it.next()) |line| {
+        const rel = strings.trim(line, " \t");
+        if (rel.len == 0) continue;
+        const abs = bun.path.joinAbsStringBuf(git_root, &buf, &[_][]const u8{rel}, .auto);
+        // Skip deletions; the bundler can only parse files that exist.
+        if (!bun.sys.exists(abs)) continue;
+        try set.insert(abs);
+    }
+}
+
+const std = @import("std");
+
+const bun = @import("bun");
+const Environment = bun.Environment;
+const Global = bun.Global;
+const Output = bun.Output;
+const Transpiler = bun.Transpiler;
+const logger = bun.logger;
+const strings = bun.strings;
+
+const Command = bun.cli.Command;
+const jsc = bun.jsc;
+
+const BundleV2 = bun.bundle_v2.BundleV2;
+const Index = bun.ast.Index;

--- a/src/cli/test/ChangedFilesFilter.zig
+++ b/src/cli/test/ChangedFilesFilter.zig
@@ -105,6 +105,11 @@ pub fn filter(
             .total_tests = test_files.len,
         };
     };
+    // The bundler's ThreadLocalArena and worker pool are intentionally
+    // left in place for the remainder of the process. `bun test --watch`
+    // exec()s a fresh process on each reload, so nothing accumulates
+    // across restarts; tearing the pool down here blocks on worker
+    // shutdown and competes with the runtime VM's own parse threads.
 
     const sources = bundle.graph.input_files.items(.source);
     const import_records = bundle.graph.ast.items(.import_records);
@@ -157,23 +162,13 @@ pub fn filter(
         }
     }
 
-    // Identify which source indexes correspond to test entry points so we can
-    // check BFS results against them. `bundle.graph.entry_points` preserves
-    // the order of `entry_points`, but an entry point that failed to resolve
-    // is skipped, so we map by path rather than by position.
-    var entry_index_to_test_slot = std.AutoHashMap(u32, usize).init(allocator);
-    defer entry_index_to_test_slot.deinit();
-    for (bundle.graph.entry_points.items) |entry_index| {
-        const path_text = sources[entry_index.get()].path.text;
-        // `test_files` is typically small enough that a linear lookup is fine
-        // (matching the overall cost of building the graph). Match by
-        // identity against the PathString slices we passed in.
-        for (test_files, 0..) |tf, slot| {
-            if (strings.eql(tf.slice(), path_text)) {
-                try entry_index_to_test_slot.put(entry_index.get(), slot);
-                break;
-            }
-        }
+    // Map the original test_files slot -> bundler source index. An entry
+    // point that failed to resolve is skipped by enqueueEntryPoints, so
+    // match by absolute path via path_to_index rather than by position.
+    const slot_to_source = try allocator.alloc(?u32, test_files.len);
+    defer allocator.free(slot_to_source);
+    for (test_files, slot_to_source) |tf, *out| {
+        out.* = path_to_index.get(tf.slice());
     }
 
     // BFS backward from every changed file that participates in the graph.
@@ -207,19 +202,9 @@ pub fn filter(
     // affected, or (b) the test file itself is in the changed set (covers
     // test files that failed to enter the graph for any reason).
     var write: usize = 0;
-    for (test_files, 0..) |tf, slot| {
-        var keep = changed_files.contains(tf.slice());
-
-        if (!keep) {
-            // Find the entry index that corresponds to this slot.
-            var iter = entry_index_to_test_slot.iterator();
-            while (iter.next()) |e| {
-                if (e.value_ptr.* == slot) {
-                    if (affected.isSet(e.key_ptr.*)) keep = true;
-                    break;
-                }
-            }
-        }
+    for (test_files, slot_to_source) |tf, maybe_source| {
+        const keep = changed_files.contains(tf.slice()) or
+            (if (maybe_source) |src| affected.isSet(src) else false);
 
         if (keep) {
             test_files[write] = tf;
@@ -261,7 +246,9 @@ fn getChangedFiles(
         defer result.stdout.deinit();
         defer result.stderr.deinit();
         if (!result.ok) {
-            if (result.stderr.items.len > 0) {
+            if (result.spawn_failed) {
+                // runGit already printed the spawn error.
+            } else if (result.stderr.items.len > 0) {
                 Output.errGeneric("--changed: {s}", .{strings.trim(result.stderr.items, " \r\n\t")});
             } else {
                 Output.errGeneric("--changed requires running inside a git repository", .{});
@@ -323,6 +310,10 @@ fn getChangedFiles(
 
 const GitResult = struct {
     ok: bool,
+    /// Set when the git process could not be spawned at all. The failure
+    /// has already been reported; callers should not print a second
+    /// "not a git repo" style message.
+    spawn_failed: bool = false,
     stdout: std.array_list.Managed(u8),
     stderr: std.array_list.Managed(u8),
 };
@@ -354,6 +345,7 @@ fn runGit(
         Output.errGeneric("--changed: failed to spawn git: {s}", .{@errorName(err)});
         return .{
             .ok = false,
+            .spawn_failed = true,
             .stdout = .init(allocator),
             .stderr = .init(allocator),
         };
@@ -364,6 +356,7 @@ fn runGit(
             Output.errGeneric("--changed: failed to spawn git: {f}", .{err});
             return .{
                 .ok = false,
+                .spawn_failed = true,
                 .stdout = .init(allocator),
                 .stderr = .init(allocator),
             };

--- a/src/cli/test/ChangedFilesFilter.zig
+++ b/src/cli/test/ChangedFilesFilter.zig
@@ -282,12 +282,14 @@ fn getChangedFiles(
         var diff = try runGit(allocator, git_path, top_level_dir, &.{ "diff", "--name-only", "HEAD", "--" });
         defer diff.stdout.deinit();
         defer diff.stderr.deinit();
+        if (diff.spawn_failed) return error.GitFailed;
         if (diff.ok) {
             appendPaths(&set, git_root, diff.stdout.items);
         } else {
             var unstaged = try runGit(allocator, git_path, top_level_dir, &.{ "diff", "--name-only", "--" });
             defer unstaged.stdout.deinit();
             defer unstaged.stderr.deinit();
+            if (unstaged.spawn_failed) return error.GitFailed;
             if (unstaged.ok) {
                 appendPaths(&set, git_root, unstaged.stdout.items);
             }
@@ -295,6 +297,7 @@ fn getChangedFiles(
             var staged = try runGit(allocator, git_path, top_level_dir, &.{ "diff", "--name-only", "--cached", "--" });
             defer staged.stdout.deinit();
             defer staged.stderr.deinit();
+            if (staged.spawn_failed) return error.GitFailed;
             if (staged.ok) {
                 appendPaths(&set, git_root, staged.stdout.items);
             }
@@ -305,6 +308,7 @@ fn getChangedFiles(
         var untracked = try runGit(allocator, git_path, top_level_dir, &.{ "ls-files", "--others", "--exclude-standard", "--full-name" });
         defer untracked.stdout.deinit();
         defer untracked.stderr.deinit();
+        if (untracked.spawn_failed) return error.GitFailed;
         if (untracked.ok) {
             appendPaths(&set, git_root, untracked.stdout.items);
         }

--- a/src/cli/test/ChangedFilesFilter.zig
+++ b/src/cli/test/ChangedFilesFilter.zig
@@ -59,6 +59,16 @@ pub fn filter(
         };
     }
 
+    // With a clean working tree and no --watch, nothing can be affected and
+    // there is no watcher to seed, so skip the module-graph scan entirely.
+    if (changed_files.count() == 0 and ctx.debug.hot_reload != .watch) {
+        return .{
+            .test_files = test_files[0..0],
+            .changed_count = 0,
+            .total_tests = test_files.len,
+        };
+    }
+
     // Convert PathString list to []const []const u8 for the bundler.
     const entry_points = try allocator.alloc([]const u8, test_files.len);
     defer allocator.free(entry_points);
@@ -273,20 +283,20 @@ fn getChangedFiles(
         defer diff.stdout.deinit();
         defer diff.stderr.deinit();
         if (diff.ok) {
-            try appendPaths(&set, git_root, diff.stdout.items);
+            appendPaths(&set, git_root, diff.stdout.items);
         } else {
             var unstaged = try runGit(allocator, git_path, top_level_dir, &.{ "diff", "--name-only", "--" });
             defer unstaged.stdout.deinit();
             defer unstaged.stderr.deinit();
             if (unstaged.ok) {
-                try appendPaths(&set, git_root, unstaged.stdout.items);
+                appendPaths(&set, git_root, unstaged.stdout.items);
             }
 
             var staged = try runGit(allocator, git_path, top_level_dir, &.{ "diff", "--name-only", "--cached", "--" });
             defer staged.stdout.deinit();
             defer staged.stderr.deinit();
             if (staged.ok) {
-                try appendPaths(&set, git_root, staged.stdout.items);
+                appendPaths(&set, git_root, staged.stdout.items);
             }
         }
 
@@ -296,21 +306,23 @@ fn getChangedFiles(
         defer untracked.stdout.deinit();
         defer untracked.stderr.deinit();
         if (untracked.ok) {
-            try appendPaths(&set, git_root, untracked.stdout.items);
+            appendPaths(&set, git_root, untracked.stdout.items);
         }
     } else {
         var diff = try runGit(allocator, git_path, top_level_dir, &.{ "diff", "--name-only", since, "--" });
         defer diff.stdout.deinit();
         defer diff.stderr.deinit();
         if (!diff.ok) {
-            if (diff.stderr.items.len > 0) {
+            if (diff.spawn_failed) {
+                // runGit already printed the spawn error.
+            } else if (diff.stderr.items.len > 0) {
                 Output.errGeneric("--changed: {s}", .{strings.trim(diff.stderr.items, " \r\n\t")});
             } else {
                 Output.errGeneric("--changed: git diff against {f} failed", .{bun.fmt.quote(since)});
             }
             return error.GitFailed;
         }
-        try appendPaths(&set, git_root, diff.stdout.items);
+        appendPaths(&set, git_root, diff.stdout.items);
     }
 
     return set;
@@ -388,7 +400,7 @@ fn appendPaths(
     set: *bun.StringSet,
     git_root: []const u8,
     stdout: []const u8,
-) std.mem.Allocator.Error!void {
+) void {
     var buf: bun.PathBuffer = undefined;
     var it = std.mem.tokenizeAny(u8, stdout, "\r\n");
     while (it.next()) |line| {
@@ -397,7 +409,10 @@ fn appendPaths(
         const abs = bun.path.joinAbsStringBuf(git_root, &buf, &[_][]const u8{rel}, .auto);
         // Skip deletions; the bundler can only parse files that exist.
         if (!bun.sys.exists(abs)) continue;
-        try set.insert(abs);
+        // `StringSet.insert` dupes the key internally; abort on OOM rather
+        // than propagating so the set can never be left holding a pointer
+        // into our stack `buf` on the errdefer cleanup path.
+        bun.handleOom(set.insert(abs));
     }
 }
 

--- a/src/cli/test/ChangedFilesFilter.zig
+++ b/src/cli/test/ChangedFilesFilter.zig
@@ -38,17 +38,28 @@ pub fn filter(
     const allocator = ctx.allocator;
     const top_level_dir = vm.transpiler.fs.top_level_dir;
 
-    var changed_files = getChangedFiles(allocator, top_level_dir, changed_since) catch |err| switch (err) {
-        error.GitNotFound => {
-            Output.errGeneric("<b>--changed<r> requires <b>git<r> to be installed and in PATH", .{});
-            Global.exit(1);
-        },
-        error.GitFailed => {
-            // getChangedFiles already printed the git error output.
-            Global.exit(1);
-        },
-        else => return err,
-    };
+    // If this process was restarted by the --watch file watcher, it
+    // recorded exactly which files changed in this env var before
+    // exec()ing. Use that as the changed-file set instead of re-querying
+    // git, so editing one file re-runs only the tests that reach that
+    // file rather than every test affected by any uncommitted change.
+    // (On Windows the watcher restarts via TerminateProcess + parent
+    // respawn, which cannot carry state, so this is POSIX-only; Windows
+    // falls through to git below.)
+    var changed_files = if (consumeWatchTrigger(allocator)) |trigger_set|
+        trigger_set
+    else
+        getChangedFiles(allocator, top_level_dir, changed_since) catch |err| switch (err) {
+            error.GitNotFound => {
+                Output.errGeneric("<b>--changed<r> requires <b>git<r> to be installed and in PATH", .{});
+                Global.exit(1);
+            },
+            error.GitFailed => {
+                // getChangedFiles already printed the git error output.
+                Global.exit(1);
+            },
+            else => return err,
+        };
     defer changed_files.deinit();
 
     if (test_files.len == 0) {
@@ -86,7 +97,6 @@ pub fn filter(
         Global.exit(1);
     };
     scan_transpiler.options.target = .bun;
-    scan_transpiler.options.entry_points = entry_points;
     // Do not follow bare specifiers into node_modules; changes there are not
     // considered local edits.
     scan_transpiler.options.packages = .external;
@@ -231,6 +241,46 @@ pub fn filter(
         .total_tests = test_files.len,
         .module_graph_files = try graph_files.toOwnedSlice(allocator),
     };
+}
+
+/// Name of the env var the watcher writes changed paths into before
+/// exec()ing. Kept in sync with `hot_reloader.zig`.
+const trigger_env_var = "BUN_INTERNAL_TEST_CHANGED_TRIGGER";
+
+/// If the watcher recorded which files triggered this restart, parse the
+/// newline-separated absolute-path list out of the env var and return
+/// the set. Returns null if the env var is absent or empty.
+///
+/// The env var is intentionally left set: calling libc `unsetenv` here
+/// would desync `std.os.environ` (a fixed-length slice captured at
+/// startup) from libc's shifted `environ`, leaving a null entry that
+/// crashes the next `env_loader.loadProcess`. The next watcher restart
+/// overwrites it via `setenv` anyway, so staleness is not a concern.
+fn consumeWatchTrigger(allocator: std.mem.Allocator) ?bun.StringSet {
+    if (bun.Environment.isWindows) return null;
+
+    const raw = bun.getenvZ(trigger_env_var) orelse return null;
+    if (raw.len == 0) return null;
+
+    var set = bun.StringSet.init(allocator);
+    var it = std.mem.tokenizeAny(u8, raw, "\r\n");
+    while (it.next()) |path| {
+        if (path.len == 0) continue;
+        // The watcher may see a file disappear (delete/rename). A path
+        // that no longer exists cannot appear in the module graph this
+        // run, so drop it; its importers will still be picked up if the
+        // importer file itself was touched.
+        if (!bun.sys.exists(path)) continue;
+        bun.handleOom(set.insert(path));
+    }
+    // If every triggering path was a deletion, fall back to git so the
+    // user at least gets the same behaviour as the initial run rather
+    // than "0 changed files, nothing to run".
+    if (set.count() == 0) {
+        set.deinit();
+        return null;
+    }
+    return set;
 }
 
 const GitError = error{ GitNotFound, GitFailed } || std.mem.Allocator.Error;

--- a/src/cli/test/ChangedFilesFilter.zig
+++ b/src/cli/test/ChangedFilesFilter.zig
@@ -252,9 +252,10 @@ pub const trigger_file_env_var = "BUN_INTERNAL_TEST_CHANGED_TRIGGER_FILE";
 
 /// Make sure the trigger-file env var is set (generating a fresh temp
 /// path if this is the first process in the --watch chain) and wire up
-/// the hot-reloader collector to record changed paths into `set`. The
-/// returned path is what the watcher will write to before each restart.
-pub fn initWatchTrigger(allocator: std.mem.Allocator, set: *bun.StringSet) void {
+/// the hot-reloader collector to record changed paths. The collector
+/// and the path string intentionally live for the rest of the process;
+/// --watch exec()s on reload so nothing accumulates across restarts.
+pub fn initWatchTrigger(allocator: std.mem.Allocator) void {
     if (bun.Environment.isWindows) {
         // Windows --watch restarts via TerminateProcess + parent
         // respawn with the parent's (unchanged) env, so a setenv in
@@ -283,6 +284,8 @@ pub fn initWatchTrigger(allocator: std.mem.Allocator, set: *bun.StringSet) void 
         break :brk fresh;
     };
 
+    const set = bun.handleOom(allocator.create(bun.StringSet));
+    set.* = bun.StringSet.init(allocator);
     jsc.hot_reloader.watch_changed_paths = set;
     jsc.hot_reloader.watch_changed_trigger_file = path;
 }
@@ -297,19 +300,20 @@ extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int
 fn consumeWatchTrigger(allocator: std.mem.Allocator) ?bun.StringSet {
     if (bun.Environment.isWindows) return null;
 
-    const trigger_path = bun.getenvZ(trigger_file_env_var) orelse return null;
-    if (trigger_path.len == 0) return null;
+    const trigger_path_raw = bun.getenvZ(trigger_file_env_var) orelse return null;
+    if (trigger_path_raw.len == 0) return null;
+    const trigger_path = bun.handleOom(allocator.dupeZ(u8, trigger_path_raw));
+    defer allocator.free(trigger_path);
 
-    const contents = std.fs.cwd().readFileAlloc(
-        allocator,
-        trigger_path,
-        32 * 1024 * 1024,
-    ) catch return null;
+    const contents = switch (bun.sys.File.readFrom(bun.FD.cwd(), trigger_path, allocator)) {
+        .result => |bytes| bytes,
+        .err => return null,
+    };
     defer allocator.free(contents);
     // Consume-once: the next restart writes a fresh list. If the
     // process restarts for any other reason (crash + auto-reload) it
     // should fall back to git, not re-read a stale list.
-    std.fs.cwd().deleteFile(trigger_path) catch {};
+    _ = bun.sys.unlink(trigger_path);
 
     var set = bun.StringSet.init(allocator);
     var it = std.mem.tokenizeAny(u8, contents, "\r\n");

--- a/src/cli/test/ChangedFilesFilter.zig
+++ b/src/cli/test/ChangedFilesFilter.zig
@@ -243,27 +243,76 @@ pub fn filter(
     };
 }
 
-/// Name of the env var the watcher writes changed paths into before
-/// exec()ing. Kept in sync with `hot_reloader.zig`.
-const trigger_env_var = "BUN_INTERNAL_TEST_CHANGED_TRIGGER";
+/// Env var carrying the absolute path of the temp file that the
+/// previous process's watcher wrote its changed-path list into before
+/// exec()ing. Set once by `initWatchTrigger` in the first process and
+/// inherited through every restart. The value is a short path, never
+/// the list itself, so there is no env size concern.
+pub const trigger_file_env_var = "BUN_INTERNAL_TEST_CHANGED_TRIGGER_FILE";
 
-/// If the watcher recorded which files triggered this restart, parse the
-/// newline-separated absolute-path list out of the env var and return
-/// the set. Returns null if the env var is absent or empty.
-///
-/// The env var is intentionally left set: calling libc `unsetenv` here
-/// would desync `std.os.environ` (a fixed-length slice captured at
-/// startup) from libc's shifted `environ`, leaving a null entry that
-/// crashes the next `env_loader.loadProcess`. The next watcher restart
-/// overwrites it via `setenv` anyway, so staleness is not a concern.
+/// Make sure the trigger-file env var is set (generating a fresh temp
+/// path if this is the first process in the --watch chain) and wire up
+/// the hot-reloader collector to record changed paths into `set`. The
+/// returned path is what the watcher will write to before each restart.
+pub fn initWatchTrigger(allocator: std.mem.Allocator, set: *bun.StringSet) void {
+    if (bun.Environment.isWindows) {
+        // Windows --watch restarts via TerminateProcess + parent
+        // respawn with the parent's (unchanged) env, so a setenv in
+        // the first child would not reach subsequent children. Fall
+        // back to re-querying git on each restart there for now.
+        return;
+    }
+
+    const path: [:0]const u8 = if (bun.getenvZ(trigger_file_env_var)) |existing|
+        bun.handleOom(allocator.dupeZ(u8, existing))
+    else brk: {
+        var rng = std.Random.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())) ^
+            @as(u64, @intCast(std.c.getpid())));
+        const tmpdir = bun.fs.FileSystem.RealFS.tmpdirPath();
+        const fresh = bun.handleOom(std.fmt.allocPrintSentinel(
+            allocator,
+            "{s}{c}.bun-test-changed-{x}.trigger",
+            .{ strings.withoutTrailingSlash(tmpdir), std.fs.path.sep, rng.random().int(u64) },
+            0,
+        ));
+        // Export once so every exec()'d descendant inherits the same
+        // path. Adding (not removing) an env var is safe w.r.t.
+        // `std.os.environ`; it simply won't be visible to code that
+        // iterates the startup-captured slice in this process.
+        _ = setenv(trigger_file_env_var, fresh.ptr, 1);
+        break :brk fresh;
+    };
+
+    jsc.hot_reloader.watch_changed_paths = set;
+    jsc.hot_reloader.watch_changed_trigger_file = path;
+}
+
+extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+
+/// If the previous process's watcher recorded which files triggered
+/// this restart, read the newline-separated absolute-path list out of
+/// the trigger file, delete the file, and return the set. Returns null
+/// if the file is absent, empty, or every path no longer exists (in
+/// which case the caller falls back to querying git).
 fn consumeWatchTrigger(allocator: std.mem.Allocator) ?bun.StringSet {
     if (bun.Environment.isWindows) return null;
 
-    const raw = bun.getenvZ(trigger_env_var) orelse return null;
-    if (raw.len == 0) return null;
+    const trigger_path = bun.getenvZ(trigger_file_env_var) orelse return null;
+    if (trigger_path.len == 0) return null;
+
+    const contents = std.fs.cwd().readFileAlloc(
+        allocator,
+        trigger_path,
+        32 * 1024 * 1024,
+    ) catch return null;
+    defer allocator.free(contents);
+    // Consume-once: the next restart writes a fresh list. If the
+    // process restarts for any other reason (crash + auto-reload) it
+    // should fall back to git, not re-read a stale list.
+    std.fs.cwd().deleteFile(trigger_path) catch {};
 
     var set = bun.StringSet.init(allocator);
-    var it = std.mem.tokenizeAny(u8, raw, "\r\n");
+    var it = std.mem.tokenizeAny(u8, contents, "\r\n");
     while (it.next()) |path| {
         if (path.len == 0) continue;
         // The watcher may see a file disappear (delete/rename). A path

--- a/src/cli/test/ChangedFilesFilter.zig
+++ b/src/cli/test/ChangedFilesFilter.zig
@@ -135,6 +135,9 @@ pub fn filter(
         for (graph_files.items) |p| allocator.free(p);
         graph_files.deinit(allocator);
     }
+    // Reserve once so the dupe+append below cannot leak a duped path if the
+    // list ever needed to grow and failed.
+    try graph_files.ensureTotalCapacityPrecise(allocator, sources.len);
 
     for (sources, 0..) |*source, idx| {
         const index = Index.init(@as(u32, @intCast(idx)));
@@ -149,7 +152,7 @@ pub fn filter(
         path_to_index.putAssumeCapacity(path_text, @intCast(idx));
         // Copy out of the bundler's arena so the caller can use these paths
         // after the BundleV2 heap is gone.
-        try graph_files.append(allocator, try allocator.dupe(u8, path_text));
+        graph_files.appendAssumeCapacity(try allocator.dupe(u8, path_text));
     }
 
     for (import_records, 0..) |records, idx| {
@@ -275,16 +278,21 @@ fn getChangedFiles(
             var unstaged = try runGit(allocator, git_path, top_level_dir, &.{ "diff", "--name-only", "--" });
             defer unstaged.stdout.deinit();
             defer unstaged.stderr.deinit();
-            try appendPaths(&set, git_root, unstaged.stdout.items);
+            if (unstaged.ok) {
+                try appendPaths(&set, git_root, unstaged.stdout.items);
+            }
 
             var staged = try runGit(allocator, git_path, top_level_dir, &.{ "diff", "--name-only", "--cached", "--" });
             defer staged.stdout.deinit();
             defer staged.stderr.deinit();
-            try appendPaths(&set, git_root, staged.stdout.items);
+            if (staged.ok) {
+                try appendPaths(&set, git_root, staged.stdout.items);
+            }
         }
 
-        // Untracked files.
-        var untracked = try runGit(allocator, git_path, top_level_dir, &.{ "ls-files", "--others", "--exclude-standard" });
+        // Untracked files. `--full-name` forces repo-root-relative output
+        // regardless of our cwd, matching `git diff --name-only` above.
+        var untracked = try runGit(allocator, git_path, top_level_dir, &.{ "ls-files", "--others", "--exclude-standard", "--full-name" });
         defer untracked.stdout.deinit();
         defer untracked.stderr.deinit();
         if (untracked.ok) {
@@ -324,9 +332,14 @@ fn runGit(
     cwd: []const u8,
     args: []const []const u8,
 ) std.mem.Allocator.Error!GitResult {
-    var argv = try std.array_list.Managed([]const u8).initCapacity(allocator, args.len + 1);
+    var argv = try std.array_list.Managed([]const u8).initCapacity(allocator, args.len + 3);
     defer argv.deinit();
     argv.appendAssumeCapacity(git_path);
+    // `core.quotePath` (on by default) wraps non-ASCII filenames in quotes
+    // and emits octal escapes. We want raw UTF-8 paths so they match the
+    // bundler's resolved paths byte-for-byte.
+    argv.appendAssumeCapacity("-c");
+    argv.appendAssumeCapacity("core.quotePath=off");
     argv.appendSliceAssumeCapacity(args);
 
     const proc = bun.spawnSync(&.{

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1602,8 +1602,10 @@ pub const TestCommand = struct {
 
         // With --changed, only a subset of test files (possibly none) runs,
         // so the module loader won't naturally add every source file to the
-        // watcher. Seed it from the module graph so editing any local source
-        // file still triggers a restart under --watch.
+        // watcher. Seed it from the module graph before running tests so
+        // editing any local source file — including files only reachable
+        // from tests that were filtered out — still triggers a restart
+        // under --watch.
         if (ctx.test_options.changed != null and vm.isWatcherEnabled()) {
             for (changed_module_graph_files) |path| {
                 _ = vm.bun_watcher.addFileByPathSlow(path, vm.transpiler.options.loader(std.fs.path.extension(path)));

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1600,18 +1600,6 @@ pub const TestCommand = struct {
             }
         }
 
-        // With --changed, only a subset of test files (possibly none) runs,
-        // so the module loader won't naturally add every source file to the
-        // watcher. Seed it from the module graph before running tests so
-        // editing any local source file — including files only reachable
-        // from tests that were filtered out — still triggers a restart
-        // under --watch.
-        if (ctx.test_options.changed != null and vm.isWatcherEnabled()) {
-            for (changed_module_graph_files) |path| {
-                _ = vm.bun_watcher.addFileByPathSlow(path, vm.transpiler.options.loader(std.fs.path.extension(path)));
-            }
-        }
-
         if (test_files.len > 0) {
             // Randomize the order of test files if --randomize flag is set
             if (random) |rand| {
@@ -1619,6 +1607,28 @@ pub const TestCommand = struct {
             }
 
             runAllTests(reporter, vm, test_files, ctx.allocator);
+        }
+
+        // With --changed, only a subset of test files (possibly none) runs,
+        // so the module loader won't naturally add every source file to the
+        // watcher. Seed it from the module graph so editing any local source
+        // file — including files only reachable from tests that were
+        // filtered out — still triggers a restart under --watch.
+        //
+        // This must happen AFTER runAllTests: during the run the module
+        // loader registers loaded files with a readable fd, which
+        // RuntimeTranspilerStore reuses on the next load. On macOS
+        // addFileByPathSlow opens with O_EVTONLY (not readable); seeding
+        // first would hand that fd to the transpiler. Seeding after means
+        // loaded files are already present (indexOf early-returns) and only
+        // the never-loaded filtered-out subgraph gets an O_EVTONLY entry,
+        // which the transpiler never touches. The test harness syncs on the
+        // "Ran N tests" summary (printed after this), so seeding completes
+        // before the next file edit.
+        if (ctx.test_options.changed != null and vm.isWatcherEnabled()) {
+            for (changed_module_graph_files) |path| {
+                _ = vm.bun_watcher.addFileByPathSlow(path, vm.transpiler.options.loader(std.fs.path.extension(path)));
+            }
         }
 
         const write_snapshots_success = try jest.Jest.runner.?.snapshots.writeInlineSnapshots();

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1599,9 +1599,7 @@ pub const TestCommand = struct {
             // runAllTests (separate concern; see O_EVTONLY comment
             // below).
             if (ctx.test_options.changed != null and vm.hot_reload == .watch) {
-                const trigger_set = bun.handleOom(ctx.allocator.create(bun.StringSet));
-                trigger_set.* = bun.StringSet.init(ctx.allocator);
-                ChangedFilesFilter.initWatchTrigger(ctx.allocator, trigger_set);
+                ChangedFilesFilter.initWatchTrigger(ctx.allocator);
             }
 
             switch (vm.hot_reload) {

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1560,7 +1560,7 @@ pub const TestCommand = struct {
                 Global.exit(1);
             };
             changed_module_graph_files = result.module_graph_files;
-            if (result.changed_count == 0) {
+            if (result.test_files.len == 0 and result.changed_count == 0) {
                 Output.prettyError("<r><d>--changed:<r> no changed files, nothing to run\n", .{});
                 pass_with_no_tests_from_changed = true;
             } else if (result.test_files.len == 0) {

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1629,6 +1629,16 @@ pub const TestCommand = struct {
             for (changed_module_graph_files) |path| {
                 _ = vm.bun_watcher.addFileByPathSlow(path, vm.transpiler.options.loader(std.fs.path.extension(path)));
             }
+
+            // Have the watcher record which file(s) triggered each
+            // restart so the next process can narrow the changed-file
+            // set to just those (instead of re-querying git and
+            // re-running every test affected by any uncommitted change).
+            // This lives for the rest of the process; `--watch` exec()s
+            // on reload, so it never accumulates across restarts.
+            const trigger_set = bun.handleOom(ctx.allocator.create(bun.StringSet));
+            trigger_set.* = bun.StringSet.init(ctx.allocator);
+            jsc.hot_reloader.watch_changed_paths = trigger_set;
         }
 
         const write_snapshots_success = try jest.Jest.runner.?.snapshots.writeInlineSnapshots();

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1550,6 +1550,11 @@ pub const TestCommand = struct {
             ctx.allocator.free(changed_module_graph_files);
         }
         const test_files: []PathString = if (ctx.test_options.changed) |changed_since| brk: {
+            // If the Scanner found nothing, fall through to the existing
+            // "no tests found" error path rather than treating it as a
+            // --changed success.
+            if (all_test_files.len == 0) break :brk all_test_files;
+
             const result = ChangedFilesFilter.filter(ctx, vm, all_test_files, changed_since) catch |err| {
                 Output.err(err, "--changed: unable to determine affected tests", .{});
                 Global.exit(1);

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1593,6 +1593,17 @@ pub const TestCommand = struct {
         if (test_files.len > 0 or (ctx.test_options.changed != null and all_test_files.len > 0)) {
             vm.hot_reload = ctx.debug.hot_reload;
 
+            // Install the --changed trigger collector BEFORE the watcher
+            // thread starts so a file edit during runAllTests is still
+            // recorded. The addFileByPathSlow seeding stays after
+            // runAllTests (separate concern; see O_EVTONLY comment
+            // below).
+            if (ctx.test_options.changed != null and vm.hot_reload == .watch) {
+                const trigger_set = bun.handleOom(ctx.allocator.create(bun.StringSet));
+                trigger_set.* = bun.StringSet.init(ctx.allocator);
+                ChangedFilesFilter.initWatchTrigger(ctx.allocator, trigger_set);
+            }
+
             switch (vm.hot_reload) {
                 .hot => jsc.hot_reloader.HotReloader.enableHotModuleReloading(vm, null),
                 .watch => jsc.hot_reloader.WatchReloader.enableHotModuleReloading(vm, null),
@@ -1629,16 +1640,6 @@ pub const TestCommand = struct {
             for (changed_module_graph_files) |path| {
                 _ = vm.bun_watcher.addFileByPathSlow(path, vm.transpiler.options.loader(std.fs.path.extension(path)));
             }
-
-            // Have the watcher record which file(s) triggered each
-            // restart so the next process can narrow the changed-file
-            // set to just those (instead of re-querying git and
-            // re-running every test affected by any uncommitted change).
-            // This lives for the rest of the process; `--watch` exec()s
-            // on reload, so it never accumulates across restarts.
-            const trigger_set = bun.handleOom(ctx.allocator.create(bun.StringSet));
-            trigger_set.* = bun.StringSet.init(ctx.allocator);
-            jsc.hot_reloader.watch_changed_paths = trigger_set;
         }
 
         const write_snapshots_success = try jest.Jest.runner.?.snapshots.writeInlineSnapshots();

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1539,22 +1539,76 @@ pub const TestCommand = struct {
             };
         }
 
-        const test_files = bun.handleOom(scanner.takeFoundTestFiles());
-        defer ctx.allocator.free(test_files);
+        const all_test_files = bun.handleOom(scanner.takeFoundTestFiles());
+        defer ctx.allocator.free(all_test_files);
         const search_count = scanner.search_count;
 
-        if (test_files.len > 0) {
-            // Randomize the order of test files if --randomize flag is set
-            if (random) |rand| {
-                rand.shuffle(PathString, test_files);
+        var pass_with_no_tests_from_changed = false;
+        var changed_module_graph_files: []const []const u8 = &.{};
+        defer {
+            for (changed_module_graph_files) |p| ctx.allocator.free(p);
+            ctx.allocator.free(changed_module_graph_files);
+        }
+        const test_files: []PathString = if (ctx.test_options.changed) |changed_since| brk: {
+            const result = ChangedFilesFilter.filter(ctx, vm, all_test_files, changed_since) catch |err| {
+                Output.err(err, "--changed: unable to determine affected tests", .{});
+                Global.exit(1);
+            };
+            changed_module_graph_files = result.module_graph_files;
+            if (result.changed_count == 0) {
+                Output.prettyError("<r><d>--changed:<r> no changed files, nothing to run\n", .{});
+                pass_with_no_tests_from_changed = true;
+            } else if (result.test_files.len == 0) {
+                Output.prettyError(
+                    "<r><d>--changed:<r> {d} changed file{s}, but no test files are affected\n",
+                    .{ result.changed_count, if (result.changed_count == 1) "" else "s" },
+                );
+                pass_with_no_tests_from_changed = true;
+            } else {
+                Output.prettyError(
+                    "<r><d>--changed:<r> {d} changed file{s}, running {d}/{d} test file{s}\n",
+                    .{
+                        result.changed_count,
+                        if (result.changed_count == 1) "" else "s",
+                        result.test_files.len,
+                        result.total_tests,
+                        if (result.total_tests == 1) "" else "s",
+                    },
+                );
             }
+            Output.flush();
+            break :brk result.test_files;
+        } else all_test_files;
 
+        // Normally the watcher is only enabled when there are test files to
+        // run; `bun test --watch` with nothing matching should still exit.
+        // With --changed we always want to keep watching as long as any test
+        // files exist, since "nothing changed yet" is the common starting
+        // state and editing a source file should kick off a run.
+        if (test_files.len > 0 or (ctx.test_options.changed != null and all_test_files.len > 0)) {
             vm.hot_reload = ctx.debug.hot_reload;
 
             switch (vm.hot_reload) {
                 .hot => jsc.hot_reloader.HotReloader.enableHotModuleReloading(vm, null),
                 .watch => jsc.hot_reloader.WatchReloader.enableHotModuleReloading(vm, null),
                 else => {},
+            }
+        }
+
+        // With --changed, only a subset of test files (possibly none) runs,
+        // so the module loader won't naturally add every source file to the
+        // watcher. Seed it from the module graph so editing any local source
+        // file still triggers a restart under --watch.
+        if (ctx.test_options.changed != null and vm.isWatcherEnabled()) {
+            for (changed_module_graph_files) |path| {
+                _ = vm.bun_watcher.addFileByPathSlow(path, vm.transpiler.options.loader(std.fs.path.extension(path)));
+            }
+        }
+
+        if (test_files.len > 0) {
+            // Randomize the order of test files if --randomize flag is set
+            if (random) |rand| {
+                rand.shuffle(PathString, test_files);
             }
 
             runAllTests(reporter, vm, test_files, ctx.allocator);
@@ -1601,7 +1655,7 @@ pub const TestCommand = struct {
 
         var failed_to_find_any_tests = false;
 
-        if (test_files.len == 0) {
+        if (test_files.len == 0 and !pass_with_no_tests_from_changed) {
             failed_to_find_any_tests = true;
 
             // "bun test" - positionals[0] == "test"
@@ -2012,6 +2066,7 @@ pub fn @"export"() void {
 
 const string = []const u8;
 
+const ChangedFilesFilter = @import("./test/ChangedFilesFilter.zig");
 const DotEnv = @import("../env_loader.zig");
 const Scanner = @import("./test/Scanner.zig");
 const bun_test = @import("../bun.js/test/bun_test.zig");

--- a/test/cli/test/test-changed.test.ts
+++ b/test/cli/test/test-changed.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
 import { appendFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -13,10 +13,16 @@ setDefaultTimeout(30_000);
 // for every spawned `bun test --changed` process, since that process
 // itself shells out to git and would otherwise inherit the developer's
 // excludes/config.
+//
+// GIT_CONFIG_GLOBAL must point at a real (empty) file: pointing at the
+// null device works on most platforms, but git on some Windows builds
+// rejects "NUL" with "unable to access 'NUL': Invalid argument".
+const emptyGitConfig = join(tmpdirSync(), "empty.gitconfig");
+writeFileSync(emptyGitConfig, "");
 const gitEnv = {
   ...bunEnv,
   GIT_CONFIG_NOSYSTEM: "1",
-  GIT_CONFIG_GLOBAL: isWindows ? "NUL" : "/dev/null",
+  GIT_CONFIG_GLOBAL: emptyGitConfig,
   GIT_AUTHOR_NAME: "Test",
   GIT_AUTHOR_EMAIL: "test@example.com",
   GIT_COMMITTER_NAME: "Test",

--- a/test/cli/test/test-changed.test.ts
+++ b/test/cli/test/test-changed.test.ts
@@ -335,7 +335,12 @@ describe.concurrent("bun test --changed", () => {
   });
 });
 
-describe("bun test --changed --watch", () => {
+// On Windows, `bun test --watch` runs as a parent watcher-manager that
+// respawns a child process on change (rather than exec()-in-place), which
+// makes this test's stderr-stream sync points racy there. The 15 cases
+// above fully cover the --changed filtering logic on Windows; this case
+// only verifies composition with --watch.
+describe.skipIf(isWindows)("bun test --changed --watch", () => {
   test("restarts and reruns only affected tests when a dependency changes", async () => {
     using dir = tempDir("test-changed-watch", {
       "package.json": JSON.stringify({ name: "watch", type: "module" }),

--- a/test/cli/test/test-changed.test.ts
+++ b/test/cli/test/test-changed.test.ts
@@ -306,7 +306,7 @@ describe.concurrent("bun test --changed", () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "--changed"],
       cwd: String(dir),
-      env: { ...bunEnv, GIT_CEILING_DIRECTORIES: String(dir), GIT_DIR: join(String(dir), "no-such-git-dir") },
+      env: { ...gitEnv, GIT_CEILING_DIRECTORIES: String(dir), GIT_DIR: join(String(dir), "no-such-git-dir") },
       stdout: "pipe",
       stderr: "pipe",
       stdin: "ignore",
@@ -359,8 +359,8 @@ describe("bun test --changed --watch", () => {
     const decoder = new TextDecoder();
     let buf = "";
 
-    async function waitFor(needle: string): Promise<void> {
-      while (!buf.includes(needle)) {
+    async function waitFor(needle: string, from = 0): Promise<void> {
+      while (!buf.slice(from).includes(needle)) {
         const { value, done } = await reader.read();
         if (done) throw new Error(`stream closed before seeing ${JSON.stringify(needle)}\n${buf}`);
         buf += decoder.decode(value, { stream: true });
@@ -377,19 +377,20 @@ describe("bun test --changed --watch", () => {
     const before = buf.length;
     appendFileSync(join(String(dir), "dep-a.ts"), "// touched\n");
 
-    await waitFor("wa.test.ts:");
+    await waitFor("wa.test.ts:", before);
     const afterA = buf.slice(before);
     expect(afterA).toContain("wa.test.ts:");
     expect(afterA).not.toContain("wb.test.ts:");
 
-    // Touch dep-b.ts as well: next restart should also run wb.test.ts
-    // (both are now uncommitted).
+    // Touch dep-b.ts as well: next restart should run BOTH wa and wb
+    // (both deps are now uncommitted).
     const before2 = buf.length;
     appendFileSync(join(String(dir), "dep-b.ts"), "// touched\n");
 
-    await waitFor("wb.test.ts:");
+    await waitFor("wb.test.ts:", before2);
+    await waitFor("wa.test.ts:", before2);
     const afterB = buf.slice(before2);
-    expect(afterB).toContain("wb.test.ts:");
+    expect(ranFiles(afterB, ["wa.test.ts", "wb.test.ts"])).toEqual(["wa.test.ts", "wb.test.ts"]);
 
     proc.kill();
     reader.releaseLock();

--- a/test/cli/test/test-changed.test.ts
+++ b/test/cli/test/test-changed.test.ts
@@ -1,12 +1,12 @@
 import { spawnSync } from "bun";
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { appendFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 // Each case spawns a full `bun test` process; give the concurrent group
 // headroom on slow ASAN/CI machines.
 setDefaultTimeout(30_000);
-import { appendFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
 
 // Keep git from reading the developer's global config and make commits
 // deterministic across machines.

--- a/test/cli/test/test-changed.test.ts
+++ b/test/cli/test/test-changed.test.ts
@@ -367,28 +367,28 @@ describe("bun test --changed --watch", () => {
       }
     }
 
-    // Initial run: nothing changed.
+    // Initial run: nothing changed. Wait for the summary so the watcher is
+    // fully seeded before we touch anything.
     await waitFor("no changed files");
+    await waitFor("Ran 0 tests");
     expect(buf).not.toContain("wa.test.ts:");
     expect(buf).not.toContain("wb.test.ts:");
 
-    // Touch dep-a.ts: watcher restarts the process, --changed now sees an
-    // uncommitted change to dep-a.ts and should run only wa.test.ts.
+    // Touch dep-a.ts: watcher restarts, --changed now sees an uncommitted
+    // change to dep-a.ts and should run only wa.test.ts. Sync on the
+    // end-of-run summary rather than the file header so the child is
+    // quiescent (watcher seeded, tests done) before the next touch.
     const before = buf.length;
     appendFileSync(join(String(dir), "dep-a.ts"), "// touched\n");
-
-    await waitFor("wa.test.ts:", before);
+    await waitFor("Ran 1 test across 1 file", before);
     const afterA = buf.slice(before);
-    expect(afterA).toContain("wa.test.ts:");
-    expect(afterA).not.toContain("wb.test.ts:");
+    expect(ranFiles(afterA, ["wa.test.ts", "wb.test.ts"])).toEqual(["wa.test.ts"]);
 
-    // Touch dep-b.ts as well: next restart should run BOTH wa and wb
-    // (both deps are now uncommitted).
+    // Touch dep-b.ts as well: next restart should run BOTH wa and wb since
+    // both deps are now uncommitted.
     const before2 = buf.length;
     appendFileSync(join(String(dir), "dep-b.ts"), "// touched\n");
-
-    await waitFor("wb.test.ts:", before2);
-    await waitFor("wa.test.ts:", before2);
+    await waitFor("Ran 2 tests across 2 files", before2);
     const afterB = buf.slice(before2);
     expect(ranFiles(afterB, ["wa.test.ts", "wb.test.ts"])).toEqual(["wa.test.ts", "wb.test.ts"]);
 

--- a/test/cli/test/test-changed.test.ts
+++ b/test/cli/test/test-changed.test.ts
@@ -1,0 +1,366 @@
+import { spawnSync } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { appendFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Keep git from reading the developer's global config and make commits
+// deterministic across machines.
+const gitEnv = {
+  ...bunEnv,
+  GIT_CONFIG_NOSYSTEM: "1",
+  GIT_CONFIG_GLOBAL: isWindows ? "NUL" : "/dev/null",
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@example.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@example.com",
+};
+
+function git(cwd: string, ...args: string[]) {
+  const res = spawnSync({ cmd: ["git", ...args], cwd, env: gitEnv, stdout: "pipe", stderr: "pipe" });
+  if (!res.success) {
+    throw new Error(`git ${args.join(" ")} failed in ${cwd}:\n${res.stderr.toString()}`);
+  }
+  return res.stdout.toString();
+}
+
+function initRepo(cwd: string) {
+  git(cwd, "init", "-q");
+  git(cwd, "config", "user.name", "Test");
+  git(cwd, "config", "user.email", "test@example.com");
+  git(cwd, "config", "commit.gpgsign", "false");
+  git(cwd, "add", "-A");
+  git(cwd, "commit", "-q", "-m", "initial");
+}
+
+async function runTestChanged(
+  cwd: string,
+  extra: string[] = [],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--changed", ...extra],
+    cwd,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+/** Which of the given test-file basenames were executed (appear as a file
+ *  header in bun test's stderr). */
+function ranFiles(stderr: string, names: string[]): string[] {
+  return names.filter(n => stderr.includes(n + ":")).sort();
+}
+
+// The --watch test at the end is the slow one; everything else is independent
+// git repos so run them concurrently.
+describe.concurrent("bun test --changed", () => {
+  const fixture = {
+    "package.json": JSON.stringify({ name: "changed-test", type: "module" }),
+    // a.test.ts -> util.ts -> helper.ts (transitive, two levels)
+    "src/helper.ts": `export const helper = () => 1;\n`,
+    "src/util.ts": `import { helper } from "./helper";\nexport const util = () => helper() + 1;\n`,
+    "a.test.ts": `import { test, expect } from "bun:test";\nimport { util } from "./src/util";\ntest("a", () => expect(util()).toBe(2));\n`,
+    // b.test.ts -> other.ts (independent subgraph)
+    "src/other.ts": `export const other = () => 9;\n`,
+    "b.test.ts": `import { test, expect } from "bun:test";\nimport { other } from "./src/other";\ntest("b", () => expect(other()).toBe(9));\n`,
+    // c.test.ts has no local imports
+    "c.test.ts": `import { test, expect } from "bun:test";\ntest("c", () => expect(1).toBe(1));\n`,
+    // non-source file that nothing imports
+    "README.md": "hello\n",
+  };
+  const names = ["a.test.ts", "b.test.ts", "c.test.ts"];
+
+  test("no changes -> runs nothing and exits 0", async () => {
+    using dir = tempDir("test-changed-none", fixture);
+    initRepo(String(dir));
+
+    const { stderr, exitCode } = await runTestChanged(String(dir));
+    expect(ranFiles(stderr, names)).toEqual([]);
+    expect(stderr).toContain("no changed files");
+    expect(exitCode).toBe(0);
+  });
+
+  test("direct change to a test file runs only that test", async () => {
+    using dir = tempDir("test-changed-direct", fixture);
+    initRepo(String(dir));
+
+    appendFileSync(join(String(dir), "c.test.ts"), "// touched\n");
+
+    const { stderr, exitCode } = await runTestChanged(String(dir));
+    expect(ranFiles(stderr, names)).toEqual(["c.test.ts"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("change to a direct dependency selects the importing test", async () => {
+    using dir = tempDir("test-changed-dep", fixture);
+    initRepo(String(dir));
+
+    appendFileSync(join(String(dir), "src", "other.ts"), "// touched\n");
+
+    const { stderr, exitCode } = await runTestChanged(String(dir));
+    expect(ranFiles(stderr, names)).toEqual(["b.test.ts"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("change to a transitive dependency selects the importing test", async () => {
+    using dir = tempDir("test-changed-transitive", fixture);
+    initRepo(String(dir));
+
+    // a.test.ts -> util.ts -> helper.ts: touching helper should select a.
+    appendFileSync(join(String(dir), "src", "helper.ts"), "// touched\n");
+
+    const { stderr, exitCode } = await runTestChanged(String(dir));
+    expect(ranFiles(stderr, names)).toEqual(["a.test.ts"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("change to a file no test imports runs nothing", async () => {
+    using dir = tempDir("test-changed-unrelated", fixture);
+    initRepo(String(dir));
+
+    appendFileSync(join(String(dir), "README.md"), "more\n");
+
+    const { stderr, exitCode } = await runTestChanged(String(dir));
+    expect(ranFiles(stderr, names)).toEqual([]);
+    expect(stderr).toContain("no test files are affected");
+    expect(exitCode).toBe(0);
+  });
+
+  test("multiple changes select the union of affected tests", async () => {
+    using dir = tempDir("test-changed-multi", fixture);
+    initRepo(String(dir));
+
+    appendFileSync(join(String(dir), "src", "helper.ts"), "// touched\n");
+    appendFileSync(join(String(dir), "src", "other.ts"), "// touched\n");
+
+    const { stderr, exitCode } = await runTestChanged(String(dir));
+    expect(ranFiles(stderr, names)).toEqual(["a.test.ts", "b.test.ts"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("shared dependency selects all importers", async () => {
+    using dir = tempDir("test-changed-shared", {
+      "package.json": JSON.stringify({ name: "shared", type: "module" }),
+      "shared.ts": `export const v = 1;\n`,
+      "one.test.ts": `import { test, expect } from "bun:test";\nimport { v } from "./shared";\ntest("one", () => expect(v).toBe(1));\n`,
+      "two.test.ts": `import { test, expect } from "bun:test";\nimport { v } from "./shared";\ntest("two", () => expect(v).toBe(1));\n`,
+      "three.test.ts": `import { test, expect } from "bun:test";\ntest("three", () => expect(1).toBe(1));\n`,
+    });
+    initRepo(String(dir));
+    appendFileSync(join(String(dir), "shared.ts"), "// touched\n");
+
+    const { stderr, exitCode } = await runTestChanged(String(dir));
+    expect(ranFiles(stderr, ["one.test.ts", "two.test.ts", "three.test.ts"])).toEqual([
+      "one.test.ts",
+      "two.test.ts",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("staged changes are picked up", async () => {
+    using dir = tempDir("test-changed-staged", fixture);
+    initRepo(String(dir));
+
+    appendFileSync(join(String(dir), "src", "other.ts"), "// touched\n");
+    git(String(dir), "add", "-A");
+
+    const { stderr, exitCode } = await runTestChanged(String(dir));
+    expect(ranFiles(stderr, names)).toEqual(["b.test.ts"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("untracked test file is picked up", async () => {
+    using dir = tempDir("test-changed-untracked", fixture);
+    initRepo(String(dir));
+
+    writeFileSync(
+      join(String(dir), "new.test.ts"),
+      `import { test, expect } from "bun:test";\ntest("new", () => expect(1).toBe(1));\n`,
+    );
+
+    const { stderr, exitCode } = await runTestChanged(String(dir));
+    expect(ranFiles(stderr, [...names, "new.test.ts"])).toEqual(["new.test.ts"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("--changed=<ref> compares against a commit", async () => {
+    using dir = tempDir("test-changed-ref", fixture);
+    initRepo(String(dir));
+
+    // Make a second commit that touches helper.ts.
+    appendFileSync(join(String(dir), "src", "helper.ts"), "// v2\n");
+    git(String(dir), "add", "-A");
+    git(String(dir), "commit", "-q", "-m", "v2");
+
+    // Working tree is clean, so bare --changed should run nothing.
+    {
+      const { stderr, exitCode } = await runTestChanged(String(dir));
+      expect(ranFiles(stderr, names)).toEqual([]);
+      expect(exitCode).toBe(0);
+    }
+
+    // Against HEAD~1, helper.ts changed -> a.test.ts is selected.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--changed=HEAD~1"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("a.test.ts:");
+    expect(ranFiles(stderr, names)).toEqual(["a.test.ts"]);
+    expect(stdout).toBeDefined();
+    expect(exitCode).toBe(0);
+  });
+
+  test("change inside node_modules does not select any test", async () => {
+    using dir = tempDir("test-changed-nm", {
+      "package.json": JSON.stringify({ name: "nm", type: "module" }),
+      "node_modules/fake-pkg/package.json": JSON.stringify({
+        name: "fake-pkg",
+        version: "1.0.0",
+        main: "index.js",
+      }),
+      "node_modules/fake-pkg/index.js": `module.exports = { value: 1 };\n`,
+      "pkg.test.ts": `import { test, expect } from "bun:test";\nimport pkg from "fake-pkg";\ntest("pkg", () => expect(pkg.value).toBe(1));\n`,
+    });
+    initRepo(String(dir));
+
+    appendFileSync(join(String(dir), "node_modules", "fake-pkg", "index.js"), "// touched\n");
+
+    const { stderr, exitCode } = await runTestChanged(String(dir));
+    // node_modules are not entered by the module graph scan, so changing
+    // a file there should not select pkg.test.ts.
+    expect(ranFiles(stderr, ["pkg.test.ts"])).toEqual([]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("works from a subdirectory of the git repo", async () => {
+    using dir = tempDir("test-changed-subdir", {
+      "package.json": JSON.stringify({ name: "root" }),
+      "app/package.json": JSON.stringify({ name: "app", type: "module" }),
+      "app/dep.ts": `export const x = 1;\n`,
+      "app/sub.test.ts": `import { test, expect } from "bun:test";\nimport { x } from "./dep";\ntest("sub", () => expect(x).toBe(1));\n`,
+      "app/untouched.test.ts": `import { test, expect } from "bun:test";\ntest("untouched", () => expect(1).toBe(1));\n`,
+    });
+    initRepo(String(dir));
+    appendFileSync(join(String(dir), "app", "dep.ts"), "// touched\n");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--changed"],
+      cwd: join(String(dir), "app"),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(ranFiles(stderr, ["sub.test.ts", "untouched.test.ts"])).toEqual(["sub.test.ts"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("errors helpfully outside a git repo", async () => {
+    using dir = tempDir("test-changed-nogit", {
+      "package.json": JSON.stringify({ name: "nogit" }),
+      "only.test.ts": `import { test } from "bun:test";\ntest("only", () => {});\n`,
+    });
+
+    // Ensure git cannot discover a parent repository above the temp dir
+    // (CI checkouts sometimes place /tmp inside the repo's worktree).
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--changed"],
+      cwd: String(dir),
+      env: { ...bunEnv, GIT_CEILING_DIRECTORIES: String(dir), GIT_DIR: join(String(dir), "no-such-git-dir") },
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr.toLowerCase()).toContain("git");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("test with a syntax-error dependency still filters by changed path", async () => {
+    // The module graph scan is best-effort; a parse error in one file must
+    // not abort filtering for the rest.
+    using dir = tempDir("test-changed-parseerr", {
+      "package.json": JSON.stringify({ name: "pe", type: "module" }),
+      "good.ts": `export const g = 1;\n`,
+      "good.test.ts": `import { test, expect } from "bun:test";\nimport { g } from "./good";\ntest("good", () => expect(g).toBe(1));\n`,
+      "bad.test.ts": `import { test } from "bun:test";\nimport { nope } from "./does-not-exist";\ntest("bad", () => {});\n`,
+    });
+    initRepo(String(dir));
+    appendFileSync(join(String(dir), "good.ts"), "// touched\n");
+
+    const { stderr } = await runTestChanged(String(dir));
+    expect(stderr).toContain("good.test.ts:");
+    expect(stderr).not.toContain("bad.test.ts:");
+  });
+});
+
+describe("bun test --changed --watch", () => {
+  test("restarts and reruns only affected tests when a dependency changes", async () => {
+    using dir = tempDir("test-changed-watch", {
+      "package.json": JSON.stringify({ name: "watch", type: "module" }),
+      "dep-a.ts": `export const A = 1;\n`,
+      "dep-b.ts": `export const B = 2;\n`,
+      "wa.test.ts": `import { test, expect } from "bun:test";\nimport { A } from "./dep-a";\ntest("wa", () => expect(A).toBe(1));\n`,
+      "wb.test.ts": `import { test, expect } from "bun:test";\nimport { B } from "./dep-b";\ntest("wb", () => expect(B).toBe(2));\n`,
+    });
+    initRepo(String(dir));
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--changed", "--watch", "--no-clear-screen"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+
+    const reader = proc.stderr.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+
+    async function waitFor(needle: string): Promise<void> {
+      while (!buf.includes(needle)) {
+        const { value, done } = await reader.read();
+        if (done) throw new Error(`stream closed before seeing ${JSON.stringify(needle)}\n${buf}`);
+        buf += decoder.decode(value, { stream: true });
+      }
+    }
+
+    // Initial run: nothing changed.
+    await waitFor("no changed files");
+    expect(buf).not.toContain("wa.test.ts:");
+    expect(buf).not.toContain("wb.test.ts:");
+
+    // Touch dep-a.ts: watcher restarts the process, --changed now sees an
+    // uncommitted change to dep-a.ts and should run only wa.test.ts.
+    const before = buf.length;
+    appendFileSync(join(String(dir), "dep-a.ts"), "// touched\n");
+
+    await waitFor("wa.test.ts:");
+    const afterA = buf.slice(before);
+    expect(afterA).toContain("wa.test.ts:");
+    expect(afterA).not.toContain("wb.test.ts:");
+
+    // Touch dep-b.ts as well: next restart should also run wb.test.ts
+    // (both are now uncommitted).
+    const before2 = buf.length;
+    appendFileSync(join(String(dir), "dep-b.ts"), "// touched\n");
+
+    await waitFor("wb.test.ts:");
+    const afterB = buf.slice(before2);
+    expect(afterB).toContain("wb.test.ts:");
+
+    proc.kill();
+    reader.releaseLock();
+  }, 60_000);
+});

--- a/test/cli/test/test-changed.test.ts
+++ b/test/cli/test/test-changed.test.ts
@@ -228,6 +228,38 @@ describe.concurrent("bun test --changed", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("--changed=<ref> includes untracked files", async () => {
+    using dir = tempDir("test-changed-ref-untracked", fixture);
+    initRepo(String(dir));
+
+    // Two commits so HEAD~1 is valid; working tree is clean.
+    appendFileSync(join(String(dir), "src", "helper.ts"), "// v2\n");
+    git(String(dir), "add", "-A");
+    git(String(dir), "commit", "-q", "-m", "v2");
+
+    // Create a brand-new untracked test file. It did not exist at
+    // HEAD~1, so it is "changed since HEAD~1" even though
+    // `git diff --name-only HEAD~1` never lists untracked files.
+    writeFileSync(
+      join(String(dir), "new.test.ts"),
+      `import { test, expect } from "bun:test";\ntest("new", () => expect(1).toBe(1));\n`,
+    );
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--changed=HEAD~1"],
+      cwd: String(dir),
+      env: gitEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // a.test.ts (helper.ts changed between HEAD~1 and HEAD) and the
+    // brand-new untracked file should both run.
+    expect(ranFiles(stderr, [...names, "new.test.ts"])).toEqual(["a.test.ts", "new.test.ts"]);
+    expect(exitCode).toBe(0);
+  });
+
   test("change inside node_modules does not select any test", async () => {
     using dir = tempDir("test-changed-nm", {
       "package.json": JSON.stringify({ name: "nm", type: "module" }),

--- a/test/cli/test/test-changed.test.ts
+++ b/test/cli/test/test-changed.test.ts
@@ -9,7 +9,10 @@ import { join } from "node:path";
 setDefaultTimeout(30_000);
 
 // Keep git from reading the developer's global config and make commits
-// deterministic across machines.
+// deterministic across machines. Used both for the `git` helper below and
+// for every spawned `bun test --changed` process, since that process
+// itself shells out to git and would otherwise inherit the developer's
+// excludes/config.
 const gitEnv = {
   ...bunEnv,
   GIT_CONFIG_NOSYSTEM: "1",
@@ -44,7 +47,7 @@ async function runTestChanged(
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", "--changed", ...extra],
     cwd,
-    env: bunEnv,
+    env: gitEnv,
     stdout: "pipe",
     stderr: "pipe",
     stdin: "ignore",
@@ -208,7 +211,7 @@ describe.concurrent("bun test --changed", () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "--changed=HEAD~1"],
       cwd: String(dir),
-      env: bunEnv,
+      env: gitEnv,
       stdout: "pipe",
       stderr: "pipe",
       stdin: "ignore",
@@ -255,13 +258,40 @@ describe.concurrent("bun test --changed", () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "--changed"],
       cwd: join(String(dir), "app"),
-      env: bunEnv,
+      env: gitEnv,
       stdout: "pipe",
       stderr: "pipe",
       stdin: "ignore",
     });
     const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(ranFiles(stderr, ["sub.test.ts", "untouched.test.ts"])).toEqual(["sub.test.ts"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("untracked test file in a subdirectory is picked up", async () => {
+    // `git ls-files --others` prints cwd-relative paths unless --full-name
+    // is passed; this exercises that path join.
+    using dir = tempDir("test-changed-subdir-untracked", {
+      "package.json": JSON.stringify({ name: "root" }),
+      "app/package.json": JSON.stringify({ name: "app", type: "module" }),
+      "app/base.test.ts": `import { test, expect } from "bun:test";\ntest("base", () => expect(1).toBe(1));\n`,
+    });
+    initRepo(String(dir));
+    writeFileSync(
+      join(String(dir), "app", "brand-new.test.ts"),
+      `import { test, expect } from "bun:test";\ntest("brand-new", () => expect(1).toBe(1));\n`,
+    );
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--changed"],
+      cwd: join(String(dir), "app"),
+      env: gitEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(ranFiles(stderr, ["base.test.ts", "brand-new.test.ts"])).toEqual(["brand-new.test.ts"]);
     expect(exitCode).toBe(0);
   });
 
@@ -319,7 +349,7 @@ describe("bun test --changed --watch", () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "--changed", "--watch", "--no-clear-screen"],
       cwd: String(dir),
-      env: bunEnv,
+      env: gitEnv,
       stdout: "pipe",
       stderr: "pipe",
       stdin: "ignore",

--- a/test/cli/test/test-changed.test.ts
+++ b/test/cli/test/test-changed.test.ts
@@ -1,6 +1,10 @@
 import { spawnSync } from "bun";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// Each case spawns a full `bun test` process; give the concurrent group
+// headroom on slow ASAN/CI machines.
+setDefaultTimeout(30_000);
 import { appendFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -209,10 +213,9 @@ describe.concurrent("bun test --changed", () => {
       stderr: "pipe",
       stdin: "ignore",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain("a.test.ts:");
     expect(ranFiles(stderr, names)).toEqual(["a.test.ts"]);
-    expect(stdout).toBeDefined();
     expect(exitCode).toBe(0);
   });
 
@@ -295,9 +298,10 @@ describe.concurrent("bun test --changed", () => {
     initRepo(String(dir));
     appendFileSync(join(String(dir), "good.ts"), "// touched\n");
 
-    const { stderr } = await runTestChanged(String(dir));
+    const { stderr, exitCode } = await runTestChanged(String(dir));
     expect(stderr).toContain("good.test.ts:");
     expect(stderr).not.toContain("bad.test.ts:");
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/cli/test/test-changed.test.ts
+++ b/test/cli/test/test-changed.test.ts
@@ -361,7 +361,7 @@ describe.skipIf(isWindows)("bun test --changed --watch", () => {
       cmd: [bunExe(), "test", "--changed", "--watch", "--no-clear-screen"],
       cwd: String(dir),
       env: gitEnv,
-      stdout: "pipe",
+      stdout: "ignore",
       stderr: "pipe",
       stdin: "ignore",
     });
@@ -395,13 +395,64 @@ describe.skipIf(isWindows)("bun test --changed --watch", () => {
     const afterA = buf.slice(before);
     expect(ranFiles(afterA, ["wa.test.ts", "wb.test.ts"])).toEqual(["wa.test.ts"]);
 
-    // Touch dep-b.ts as well: next restart should run BOTH wa and wb since
-    // both deps are now uncommitted.
+    // Touch dep-b.ts: dep-a is still uncommitted in git, but the watcher
+    // only saw dep-b change this restart, so only wb.test.ts should run.
     const before2 = buf.length;
     appendFileSync(join(String(dir), "dep-b.ts"), "// touched\n");
-    await waitFor("Ran 2 tests across 2 files", before2);
+    await waitFor("Ran 1 test across 1 file", before2);
     const afterB = buf.slice(before2);
-    expect(ranFiles(afterB, ["wa.test.ts", "wb.test.ts"])).toEqual(["wa.test.ts", "wb.test.ts"]);
+    expect(ranFiles(afterB, ["wa.test.ts", "wb.test.ts"])).toEqual(["wb.test.ts"]);
+
+    proc.kill();
+    reader.releaseLock();
+  }, 60_000);
+
+  // Regression for: with two uncommitted test files, editing one of them
+  // during --changed --watch should only re-run that one, not both.
+  test("editing one of several dirty test files reruns only that one", async () => {
+    using dir = tempDir("test-changed-watch-narrow", {
+      "package.json": JSON.stringify({ name: "watch", type: "module" }),
+      "wa.test.ts": `import { test, expect } from "bun:test";\ntest("wa", () => expect(1).toBe(1));\n`,
+      "wb.test.ts": `import { test, expect } from "bun:test";\ntest("wb", () => expect(2).toBe(2));\n`,
+    });
+    initRepo(String(dir));
+    // Make both test files dirty (uncommitted) before starting the watcher.
+    appendFileSync(join(String(dir), "wa.test.ts"), "// dirty\n");
+    appendFileSync(join(String(dir), "wb.test.ts"), "// dirty\n");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--changed", "--watch", "--no-clear-screen"],
+      cwd: String(dir),
+      env: gitEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+
+    const reader = proc.stderr.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+
+    async function waitFor(needle: string, from = 0): Promise<void> {
+      while (!buf.slice(from).includes(needle)) {
+        const { value, done } = await reader.read();
+        if (done) throw new Error(`stream closed before seeing ${JSON.stringify(needle)}\n${buf}`);
+        buf += decoder.decode(value, { stream: true });
+      }
+    }
+
+    // Initial run: git reports both test files changed, so both run.
+    await waitFor("Ran 2 tests across 2 files");
+    expect(ranFiles(buf, ["wa.test.ts", "wb.test.ts"])).toEqual(["wa.test.ts", "wb.test.ts"]);
+
+    // Now edit only wa.test.ts. The watcher passes exactly that path to
+    // the restarted process; wb.test.ts (though still dirty in git) is
+    // not in its DAG, so it must not re-run.
+    const before = buf.length;
+    appendFileSync(join(String(dir), "wa.test.ts"), "// touched again\n");
+    await waitFor("Ran 1 test across 1 file", before);
+    const after = buf.slice(before);
+    expect(ranFiles(after, ["wa.test.ts", "wb.test.ts"])).toEqual(["wa.test.ts"]);
 
     proc.kill();
     reader.releaseLock();

--- a/test/cli/test/test-changed.test.ts
+++ b/test/cli/test/test-changed.test.ts
@@ -154,10 +154,7 @@ describe.concurrent("bun test --changed", () => {
     appendFileSync(join(String(dir), "shared.ts"), "// touched\n");
 
     const { stderr, exitCode } = await runTestChanged(String(dir));
-    expect(ranFiles(stderr, ["one.test.ts", "two.test.ts", "three.test.ts"])).toEqual([
-      "one.test.ts",
-      "two.test.ts",
-    ]);
+    expect(ranFiles(stderr, ["one.test.ts", "two.test.ts", "three.test.ts"])).toEqual(["one.test.ts", "two.test.ts"]);
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
Adds a vitest-compatible `--changed[=<since>]` flag to `bun test` that only runs test files whose module graph reaches a file git reports as changed.

```sh
bun test --changed           # uncommitted (unstaged + staged + untracked)
bun test --changed=HEAD~1    # diff against a commit / branch / tag
bun test --changed=main
bun test --changed --watch   # re-filters on every restart
```

### How it works

1. The existing `Scanner` walks the tree and finds every `*.test.*` / `*.spec.*` file as usual.
2. `git` is asked for the changed file set (`git diff --name-only HEAD` + `git ls-files --others --exclude-standard`, or `git diff --name-only <since>`), joined against `git rev-parse --show-toplevel`.
3. A new **scan-only** bundler entry point, `BundleV2.scanModuleGraphFromCLI`, enqueues every test file as an entry point with `packages = external` and `ignore_module_resolution_errors = true`, then runs `waitForParse()`. This yields the full transitive import graph without entering `node_modules` and **without linking or emitting code** — same idea as the `DependenciesScanner` used by `bun install --analyze` / `bun create ./Foo.jsx`, but stopping after parse.
4. A reverse-edge map (`source_index → importers`) is built from `graph.ast.items(.import_records)`. A single backward BFS seeded with every changed source index marks all reachable entry points; only those test files are run.

### `--changed --watch`

Because only a subset of tests runs, the module loader wouldn't naturally add every local source file to the watcher. When `--watch` is combined with `--changed`, the watcher is seeded with every on-disk file in the module graph (via `addFileByPathSlow`), so editing any local source — even one not imported by the currently-selected tests — triggers a restart. Each restart re-queries git, so the filtered set tracks the working tree.

"0 changed files" with `--watch` keeps the process alive watching; without `--watch` it exits 0.

### Tests

`test/cli/test/test-changed.test.ts` creates a real git repo per case and covers: no changes, direct test edit, direct dependency, **transitive** dependency, unrelated file, union of changes, shared dependency fan-out, staged changes, untracked new test, `--changed=HEAD~1`, `node_modules` edits ignored, running from a repo subdirectory, not-a-git-repo error, parse-error tolerance, and `--changed --watch` re-running only affected tests on file edit.

All 15 cases pass with this build and fail on the baked bun (flag not recognized / no filtering).


Fixes #5401
Fixes #4825