### PR TITLE
bundler: fix segfault when plugin onResolve races with failed sibling import

### DIFF
--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -3392,6 +3392,18 @@ pub const BundleV2 = struct {
         if (resolve_result.last_error) |err| {
             debug("failed with error: {s}", .{@errorName(err)});
             resolve_result.resolve_queue.clearAndFree();
+
+            // Preserve the parsed import_records on the graph so any plugin
+            // onResolve tasks already dispatched for *other* records in this
+            // same file can still dereference
+            // `graph.ast.items(.import_records)[importer_source_index]` when
+            // they complete. Without this, the graph entry stays at
+            // JSAst.empty and the deferred plugin callback index-out-of-
+            // bounds crashes in BundleV2.onResolve / runResolver. The linker
+            // never runs because `transpiler.log.errors > 0` aborts the
+            // build before link time, so saving the AST is safe.
+            this.graph.ast.items(.import_records)[source_index.get()] = result.ast.import_records;
+
             parse_result.value = .{
                 .err = .{
                     .err = err,

--- a/test/regression/issue/29264.test.ts
+++ b/test/regression/issue/29264.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { tempDirWithFiles } from "harness";
+import { join } from "node:path";
 
 // https://github.com/oven-sh/bun/issues/29264
 //
@@ -10,52 +11,39 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // import_records from `graph.ast`, which was still at `JSAst.empty`, and
 // crashed with "index out of bounds: index 0, len 0" (segfault in release).
 test("#29264 bundler survives external + missing imports in same file", async () => {
-  using dir = tempDir("29264", {
-    "build-fixture.js": /* js */ `
-      try {
-        const res = await Bun.build({
-          entrypoints: ["index.js"],
-          plugins: [
-            {
-              name: "mark-bare-external",
-              setup(build) {
-                build.onResolve({ filter: /^[^.]/ }, () => ({ external: true }));
-              },
-            },
-          ],
-        });
-        console.log("DONE:success=" + res.success);
-      } catch (e) {
-        console.log("DONE:caught");
-        if (e && e.errors) {
-          for (const err of e.errors) console.log("ERR:" + err.message);
-        }
-      }
-    `,
-    "index.js": /* js */ `
+  const dir = tempDirWithFiles("issue-29264", {
+    "index.js": `
       import "src";
       import "./src";
     `,
   });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "build-fixture.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stderr: "pipe",
-    stdout: "pipe",
-  });
+  let caught: any = null;
+  try {
+    await Bun.build({
+      entrypoints: [join(dir, "index.js")],
+      plugins: [
+        {
+          name: "mark-bare-external",
+          setup(build) {
+            build.onResolve({ filter: /^[^.]/ }, () => ({ external: true }));
+          },
+        },
+      ],
+    });
+  } catch (e) {
+    caught = e;
+  }
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  // The fixture script must reach the `catch` and print DONE. Before
-  // the fix, the process crashed inside `Bun.build` with a segfault
-  // (release) or index-out-of-bounds panic (debug/ASAN), so neither
-  // `DONE:` nor the per-error lines ever made it out. We deliberately
-  // do NOT assert on the bare "src" import — whether the plugin's
-  // `{ external: true }` (with no `path`) falls through to a resolver
-  // error is plugin semantics, not what this test guards against.
-  expect(stdout).toContain("DONE:caught");
-  expect(stdout).toContain('ERR:Could not resolve: "./src"');
-  expect(exitCode).toBe(0);
+  // Before the fix, the bundler segfaulted (release) or panicked with an
+  // index-out-of-bounds (debug/ASAN) during the plugin onResolve callback
+  // for "src" — never reaching the catch. Now it rejects with an
+  // AggregateError whose `.errors` include the resolve failure for
+  // "./src". We deliberately do NOT assert on the bare "src" import
+  // because whether the plugin's `{ external: true }` (with no `path`)
+  // falls through to a resolver error is plugin semantics, not what
+  // this test guards against.
+  expect(caught).not.toBeNull();
+  const messages = (caught?.errors ?? []).map((e: any) => String(e?.message ?? e));
+  expect(messages.some((m: string) => m.includes('Could not resolve: "./src"'))).toBe(true);
 });

--- a/test/regression/issue/29264.test.ts
+++ b/test/regression/issue/29264.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/29264
+//
+// When a bundle plugin had an onResolve filter that matched one import but
+// the same file also contained a non-external import that could not be
+// resolved, the parse task finalized as an error without saving the parsed
+// AST. A deferred onResolve plugin task later tried to read the importer's
+// import_records from `graph.ast`, which was still at `JSAst.empty`, and
+// crashed with "index out of bounds: index 0, len 0" (segfault in release).
+test("#29264 bundler survives external + missing imports in same file", async () => {
+  using dir = tempDir("29264", {
+    "build-fixture.js": /* js */ `
+      try {
+        const res = await Bun.build({
+          entrypoints: ["index.js"],
+          plugins: [
+            {
+              name: "mark-bare-external",
+              setup(build) {
+                build.onResolve({ filter: /^[^.]/ }, () => ({ external: true }));
+              },
+            },
+          ],
+        });
+        console.log("DONE:success=" + res.success);
+      } catch (e) {
+        console.log("DONE:caught");
+        if (e && e.errors) {
+          for (const err of e.errors) console.log("ERR:" + err.message);
+        }
+      }
+    `,
+    "index.js": /* js */ `
+      import "src";
+      import "./src";
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build-fixture.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  // The fixture script must reach the `catch` and print DONE. Before
+  // the fix, the process crashed inside `Bun.build` with a segfault
+  // (release) or index-out-of-bounds panic (debug/ASAN), so neither
+  // `DONE:` nor the per-error lines ever made it out.
+  expect(stdout).toContain("DONE:caught");
+  expect(stdout).toContain('ERR:Could not resolve: "./src"');
+  expect(stdout).toContain('ERR:Could not resolve: "src"');
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/29264.test.ts
+++ b/test/regression/issue/29264.test.ts
@@ -46,11 +46,7 @@ test("#29264 bundler survives external + missing imports in same file", async ()
     stdout: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // The fixture script must reach the `catch` and print DONE. Before
   // the fix, the process crashed inside `Bun.build` with a segfault

--- a/test/regression/issue/29264.test.ts
+++ b/test/regression/issue/29264.test.ts
@@ -51,9 +51,11 @@ test("#29264 bundler survives external + missing imports in same file", async ()
   // The fixture script must reach the `catch` and print DONE. Before
   // the fix, the process crashed inside `Bun.build` with a segfault
   // (release) or index-out-of-bounds panic (debug/ASAN), so neither
-  // `DONE:` nor the per-error lines ever made it out.
+  // `DONE:` nor the per-error lines ever made it out. We deliberately
+  // do NOT assert on the bare "src" import — whether the plugin's
+  // `{ external: true }` (with no `path`) falls through to a resolver
+  // error is plugin semantics, not what this test guards against.
   expect(stdout).toContain("DONE:caught");
   expect(stdout).toContain('ERR:Could not resolve: "./src"');
-  expect(stdout).toContain('ERR:Could not resolve: "src"');
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/29264.test.ts
+++ b/test/regression/issue/29264.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir } from "harness";
 import { join } from "node:path";
 
 // https://github.com/oven-sh/bun/issues/29264
@@ -11,7 +11,7 @@ import { join } from "node:path";
 // import_records from `graph.ast`, which was still at `JSAst.empty`, and
 // crashed with "index out of bounds: index 0, len 0" (segfault in release).
 test("#29264 bundler survives external + missing imports in same file", async () => {
-  const dir = tempDirWithFiles("issue-29264", {
+  using dir = tempDir("issue-29264", {
     "index.js": `
       import "src";
       import "./src";
@@ -21,7 +21,7 @@ test("#29264 bundler survives external + missing imports in same file", async ()
   let caught: any = null;
   try {
     await Bun.build({
-      entrypoints: [join(dir, "index.js")],
+      entrypoints: [join(String(dir), "index.js")],
       plugins: [
         {
           name: "mark-bare-external",

--- a/test/regression/issue/29264.test.ts
+++ b/test/regression/issue/29264.test.ts
@@ -1,49 +1,53 @@
 import { expect, test } from "bun:test";
-import { tempDir } from "harness";
-import { join } from "node:path";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 // https://github.com/oven-sh/bun/issues/29264
-//
-// When a bundle plugin had an onResolve filter that matched one import but
-// the same file also contained a non-external import that could not be
-// resolved, the parse task finalized as an error without saving the parsed
-// AST. A deferred onResolve plugin task later tried to read the importer's
-// import_records from `graph.ast`, which was still at `JSAst.empty`, and
-// crashed with "index out of bounds: index 0, len 0" (segfault in release).
-test("#29264 bundler survives external + missing imports in same file", async () => {
+test("#29264 bundler survives external + missing imports in same file", { timeout: 30_000 }, async () => {
   using dir = tempDir("issue-29264", {
-    "index.js": `
+    "build-fixture.js": /* js */ `
+      try {
+        await Bun.build({
+          entrypoints: ["index.js"],
+          plugins: [
+            {
+              name: "mark-bare-external",
+              setup(build) {
+                build.onResolve({ filter: /^[^.]/ }, () => ({ external: true }));
+              },
+            },
+          ],
+        });
+        console.log("DONE:ok");
+      } catch (e) {
+        console.log("DONE:caught");
+        if (e && e.errors) {
+          for (const err of e.errors) console.log("ERR:" + err.message);
+        }
+      }
+    `,
+    "index.js": /* js */ `
       import "src";
       import "./src";
     `,
   });
 
-  let caught: any = null;
-  try {
-    await Bun.build({
-      entrypoints: [join(String(dir), "index.js")],
-      plugins: [
-        {
-          name: "mark-bare-external",
-          setup(build) {
-            build.onResolve({ filter: /^[^.]/ }, () => ({ external: true }));
-          },
-        },
-      ],
-    });
-  } catch (e) {
-    caught = e;
-  }
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build-fixture.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
 
-  // Before the fix, the bundler segfaulted (release) or panicked with an
-  // index-out-of-bounds (debug/ASAN) during the plugin onResolve callback
-  // for "src" — never reaching the catch. Now it rejects with an
-  // AggregateError whose `.errors` include the resolve failure for
-  // "./src". We deliberately do NOT assert on the bare "src" import
-  // because whether the plugin's `{ external: true }` (with no `path`)
-  // falls through to a resolver error is plugin semantics, not what
-  // this test guards against.
-  expect(caught).not.toBeNull();
-  const messages = (caught?.errors ?? []).map((e: any) => String(e?.message ?? e));
-  expect(messages.some((m: string) => m.includes('Could not resolve: "./src"'))).toBe(true);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Before the fix, the child crashed in Bun.build — segfault (release) or
+  // index-out-of-bounds panic (debug/ASAN) — so "DONE:caught" never printed.
+  // We deliberately don't assert on the bare "src" import; whether the
+  // plugin's `{ external: true }` (with no `path`) falls through to a
+  // resolver error is plugin semantics, not what this test guards against.
+  const combined = stdout + stderr;
+  expect(combined).toContain("DONE:caught");
+  expect(combined).toContain('Could not resolve: "./src"');
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Repro

```js
// build.js
await Bun.build({
  entrypoints: ['index.js'],
  plugins: [{
    name: 'mark-bare-external',
    setup(build) {
      build.onResolve({ filter: /^[^.]/ }, () => ({ external: true }));
    },
  }],
});
```

```js
// index.js
import 'src';
import './src';
```

```
panic: Segmentation fault at address 0xAAAAAAAAAAAAAB3E
```

Debug/ASAN surfaces it more clearly:

```
panic: index out of bounds: index 0, len 0
resolver.resolver.Resolver.resolve
```

## Cause

`resolveImportRecords` walks every import record in a file. For `src` the plugin filter matches so `enqueueOnResolvePluginIfNeeded` ships off an async onResolve task to the JS loop. Immediately after, `./src` goes through standard resolution and fails with `ModuleNotFound`, which sets `last_error`. `runResolutionForParseTask` then overwrites `parse_result.value` with `.err` and returns; `onParseTaskComplete` takes the `.err` branch, which never calls `graph.ast.set`, so the graph entry for `index.js` stays at `JSAst.empty`.

When the in-flight plugin callback for `src` finally runs, the user returns `{ external: true }` with no `path`, which `runOnResolvePlugins` maps to `no_match`. `BundleV2.onResolve` falls into the file-namespace path and calls `runResolver`, which tries to look the record up via `this.graph.ast.items(.import_records)[importer_source_index].slice()[import_record_index]`. That slice has length 0 → debug panic / release segfault.

## Fix

Save the parsed `import_records` onto `graph.ast` before flipping `parse_result.value` to `.err`. Deferred plugin onResolve callbacks can then dereference the importer slot as usual; they find the record, see it marked `is_disabled`, and unwind cleanly. The linker never runs in this path — `transpiler.log.errors > 0` aborts the build at the first post-parse gate — so there is no risk of the "saved" AST leaking into later stages.

## Verification

Added `test/regression/issue/29264.test.ts`:
- On a pre-fix binary the repro child crashes inside `Bun.build`, the test's `await proc.exited` never sees a clean exit, and the harness kills it at 5s.
- On the fixed binary `Bun.build` throws, the fixture reaches the `catch` and prints both resolve errors, exit 0.

Existing `test/bundler/bundler_plugin.test.ts` (55 tests) still green.

Fixes #29264