### PR TITLE
fix(inspect): null deref when Proxy getPrototypeOf trap throws

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5364,7 +5364,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!proto || !proto.isObject())
+                break;
+            iterating = proto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { normalizeBunSnapshot, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tmpdirSync } from "harness";
 import { join } from "path";
 import util from "util";
 it("prototype", () => {
@@ -451,6 +451,36 @@ const fixture = [
         },
       },
     ),
+  () => {
+    const obj = { a: 1 };
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(
+        { b: 2 },
+        {
+          getPrototypeOf() {
+            throw new Error("trap");
+          },
+        },
+      ),
+    );
+    return obj;
+  },
+  () => {
+    const obj = {};
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(
+        { b: 2 },
+        {
+          getPrototypeOf() {
+            throw new Error("trap");
+          },
+        },
+      ),
+    );
+    return obj;
+  },
 ];
 
 describe("crash testing", () => {
@@ -465,6 +495,28 @@ describe("crash testing", () => {
       }
     });
   }
+});
+
+it("Proxy prototype with throwing getPrototypeOf trap", async () => {
+  const code = `
+    const obj = { a: 1 };
+    Object.setPrototypeOf(obj, new Proxy({ b: 2 }, {
+      getPrototypeOf() { throw new Error("trap"); }
+    }));
+    const str = Bun.inspect(obj);
+    if (!str.includes("a: 1") || !str.includes("b: 2")) {
+      throw new Error("unexpected output: " + str);
+    }
+    console.log("ok");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
 });
 
 it("possibly formatted emojis log", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a null pointer dereference in `JSC__JSValue__forEachPropertyImpl` when walking the prototype chain during property enumeration (used by `Bun.inspect`, `console.log`, `expect()` diff formatting, etc.).

When an object's prototype chain contains a Proxy whose `getPrototypeOf` trap throws, `JSObject::getPrototype()` returns an empty `JSValue`. An empty `JSValue` (encoded as 0) passes the `isCell()` check since it has no tag bits set, so `.getObject()` / `.isObject()` end up calling a member function on a null `JSCell*`.

The same path is also hit when a pending exception from an earlier property access in the loop reaches the `getPrototype()` call.

## Repro

```js
const obj = { a: 1 };
Object.setPrototypeOf(obj, new Proxy({ b: 2 }, {
  getPrototypeOf() { throw new Error("trap"); }
}));
Bun.inspect(obj); // SIGABRT (UBSAN) / SIGSEGV
```

## Fix

Check for an empty/non-object prototype before dereferencing and break out of the loop, clearing any exception from the trap. This matches the exception handling already used for `getPrototype()` in the fast path of the same function.

Found by Fuzzilli (fingerprint `82f6d2539edfab4d`).

## How did you verify your code works?

- Added a subprocess regression test that fails on `main` (exit 132 / segfault) and passes with the fix
- Added in-process fixtures to the existing `crash testing` describe block
- `bun bd test test/js/bun/util/inspect.test.js` — 74 pass, 0 fail