### PR TITLE
Fix double-deref of path when S3Client.presign throws

### DIFF
--- a/src/bun.js/webcore/S3Client.zig
+++ b/src/bun.js/webcore/S3Client.zig
@@ -145,7 +145,7 @@ pub const S3Client = struct {
         const arguments = callframe.arguments_old(2).slice();
         var args = jsc.CallFrame.ArgumentsSlice.init(globalThis.bunVM(), arguments);
         defer args.deinit();
-        const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
+        var path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             if (args.len() == 0) {
                 return globalThis.ERR(.MISSING_ARGS, "Expected a path to presign", .{}).throw();
             }
@@ -155,6 +155,7 @@ pub const S3Client = struct {
 
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path = .{ .string = bun.PathString.empty };
         defer blob.detach();
         return S3File.getPresignUrlFrom(&blob, globalThis, options);
     }
@@ -163,7 +164,7 @@ pub const S3Client = struct {
         const arguments = callframe.arguments_old(2).slice();
         var args = jsc.CallFrame.ArgumentsSlice.init(globalThis.bunVM(), arguments);
         defer args.deinit();
-        const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
+        var path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             if (args.len() == 0) {
                 return globalThis.ERR(.MISSING_ARGS, "Expected a path to check if it exists", .{}).throw();
             }
@@ -172,6 +173,7 @@ pub const S3Client = struct {
         errdefer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path = .{ .string = bun.PathString.empty };
         defer blob.detach();
         return S3File.S3BlobStatTask.exists(globalThis, &blob);
     }
@@ -180,7 +182,7 @@ pub const S3Client = struct {
         const arguments = callframe.arguments_old(2).slice();
         var args = jsc.CallFrame.ArgumentsSlice.init(globalThis.bunVM(), arguments);
         defer args.deinit();
-        const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
+        var path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             if (args.len() == 0) {
                 return globalThis.ERR(.MISSING_ARGS, "Expected a path to check the size of", .{}).throw();
             }
@@ -189,6 +191,7 @@ pub const S3Client = struct {
         errdefer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path = .{ .string = bun.PathString.empty };
         defer blob.detach();
         return S3File.S3BlobStatTask.size(globalThis, &blob);
     }
@@ -197,7 +200,7 @@ pub const S3Client = struct {
         const arguments = callframe.arguments_old(2).slice();
         var args = jsc.CallFrame.ArgumentsSlice.init(globalThis.bunVM(), arguments);
         defer args.deinit();
-        const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
+        var path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             if (args.len() == 0) {
                 return globalThis.ERR(.MISSING_ARGS, "Expected a path to check the stat of", .{}).throw();
             }
@@ -206,6 +209,7 @@ pub const S3Client = struct {
         errdefer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path = .{ .string = bun.PathString.empty };
         defer blob.detach();
         return S3File.S3BlobStatTask.stat(globalThis, &blob);
     }
@@ -214,7 +218,7 @@ pub const S3Client = struct {
         const arguments = callframe.arguments_old(3).slice();
         var args = jsc.CallFrame.ArgumentsSlice.init(globalThis.bunVM(), arguments);
         defer args.deinit();
-        const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
+        var path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             return globalThis.ERR(.MISSING_ARGS, "Expected a path to write to", .{}).throw();
         };
         errdefer path.deinit();
@@ -224,6 +228,7 @@ pub const S3Client = struct {
 
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path = .{ .string = bun.PathString.empty };
         defer blob.detach();
         var blob_internal: PathOrBlob = .{ .blob = blob };
         return Blob.writeFileInternal(globalThis, &blob_internal, data, .{
@@ -248,12 +253,13 @@ pub const S3Client = struct {
         const arguments = callframe.arguments_old(2).slice();
         var args = jsc.CallFrame.ArgumentsSlice.init(globalThis.bunVM(), arguments);
         defer args.deinit();
-        const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
+        var path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             return globalThis.ERR(.MISSING_ARGS, "Expected a path to unlink", .{}).throw();
         };
         errdefer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path = .{ .string = bun.PathString.empty };
         defer blob.detach();
         return blob.store.?.data.s3.unlink(blob.store.?, globalThis, options);
     }

--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -84,6 +84,7 @@ pub fn presign(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.J
             }
             const options = args.nextEat();
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
             return try getPresignUrlFrom(&blob, globalThis, options);
         },
@@ -114,6 +115,7 @@ pub fn unlink(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
             }
             const options = args.nextEat();
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
             return try blob.store.?.data.s3.unlink(blob.store.?, globalThis, options);
         },
@@ -151,6 +153,7 @@ pub fn write(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSE
                 return globalThis.throwInvalidArguments("Expected a S3 or path to upload", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
 
             var blob_internal: PathOrBlob = .{ .blob = blob };
@@ -190,6 +193,7 @@ pub fn size(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
                 return globalThis.throwInvalidArguments("Expected a S3 or path to get size", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
 
             return S3BlobStatTask.size(globalThis, &blob);
@@ -223,6 +227,7 @@ pub fn exists(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
                 return globalThis.throwInvalidArguments("Expected a S3 or path to check if it exists", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
 
             return S3BlobStatTask.exists(globalThis, &blob);
@@ -574,6 +579,7 @@ pub fn stat(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
                 return globalThis.throwInvalidArguments("Expected a S3 or path to get size", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
 
             return S3BlobStatTask.stat(globalThis, &blob);

--- a/test/js/bun/s3/s3-presign-missing-credentials.test.ts
+++ b/test/js/bun/s3/s3-presign-missing-credentials.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // When S3Client.presign() (and friends) throws after the temporary S3

--- a/test/js/bun/s3/s3-presign-missing-credentials.test.ts
+++ b/test/js/bun/s3/s3-presign-missing-credentials.test.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// When S3Client.presign() (and friends) throws after the temporary S3
+// blob has been constructed, the errdefer that cleans up the path used
+// to double-deref the underlying WTFStringImpl (ownership had already
+// transferred to the blob's store). That tripped a debug assertion /
+// SIGFPE in release builds.
+test("S3Client.presign with missing credentials throws instead of crashing", async () => {
+  const script = `
+    let caught = 0;
+    try { Bun.S3Client.presign("foo"); } catch { caught++; }
+    try { Bun.S3Client.presign("foo", {}); } catch { caught++; }
+    try { Bun.s3.presign("foo"); } catch { caught++; }
+    try { new Bun.S3Client({}).presign("foo"); } catch { caught++; }
+    if (caught !== 4) throw new Error("expected all presign calls to throw, got " + caught);
+    console.log("ok");
+  `;
+
+  // Make sure no ambient S3 credentials make the presign succeed.
+  const env: Record<string, string> = { ...bunEnv };
+  for (const k of Object.keys(env)) {
+    if (k.startsWith("S3_") || k.startsWith("AWS_")) delete env[k];
+  }
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`Bun.S3Client.presign("foo")` (and the other static/instance helpers that construct a temporary S3 blob from a path) crashed with `reached unreachable code` in debug builds and SIGFPE in release when the underlying `signRequest` failed (e.g. missing credentials).

Repro:
```js
Bun.S3Client.presign("foo"); // no S3 credentials configured
```

## Why

`Blob.Store.initS3` consumes the caller's `PathLike` reference: it copies the struct by value and calls `toThreadSafe()` on the copy, which derefs the original `WTFStringImpl` when a new thread-safe impl is created. After construction, the caller's `PathLike` is stale.

The static/instance helpers in `S3File.zig` and `S3Client.zig` kept an `errdefer path.deinit()` in scope across both construction *and* the follow-up call (`getPresignUrlFrom`, `writeFileInternal`, etc.). When that follow-up call threw, `defer blob.deinit()` released the store's ref and then the errdefer derefed the same (already-consumed) string a second time, tripping `hasAtLeastOneRef()`.

## Fix

After the blob is successfully constructed, clear the local path so the errdefer becomes a no-op — the same pattern already used in `Blob.findOrCreateFileFromPath`. The errdefer still runs for errors thrown *before* ownership transfers.

Fuzzer fingerprint: `1f40a92dc166c1e8`