### PR TITLE
Upgrade WebKit to b39129e720d37e949da0f7f2df2cd989aa980d68

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "42f80a684c5df57121a97e20825a3bcab7a0741b";
+export const WEBKIT_VERSION = "b39129e720d37e949da0f7f2df2cd989aa980d68";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "b39129e720d37e949da0f7f2df2cd989aa980d68";
+export const WEBKIT_VERSION = "8b7f6f706720ab7e5284906c29f2fbf77dfbd1e9";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
Bumps WebKit from `42f80a684c5d` → `b39129e720d3` (15 commits).

https://github.com/oven-sh/WebKit/compare/42f80a684c5df57121a97e20825a3bcab7a0741b...b39129e720d37e949da0f7f2df2cd989aa980d68

| Commit | Message |
|---|---|
| 24d76be9b327 | Windows: fix resource exhaustion in libpas/WTF |
| e38dd2fc34a0 | pas_page_malloc: optimistic single-call commit/decommit on Windows |
| 61c73c25601c | libpas: fix 8 memory-accounting bugs found via adversarial sweep |
| 617c2ba416b9 | libpas: add embedder thread-suspension callback and enable Linux TLC decommit |
| 98dc8d6eb9dc | WTF: install pas_thread_suspender on Linux, wrapping Thread::suspend/resume |
| 68e2ebfa862f | Restore do_mprotect gate in decommit_impl on Windows |
| d8d42dd398d9 | ThreadingPOSIX: avoid allocation in Thread::suspend's self-check assertion |
| 9c8ba3a07c81 | Revert FlsAlloc — TLC destructor crashes on Windows thread exit |
| 4596a6f61d01 | libpas: use is_exiting flag instead of (void*)1 sentinel for TLC teardown |
| ebf11e28e73e | pas_thread: fix pthread_once on Windows |
| 98ceda0246f4 | OSAllocatorPOSIX: madvise advice is an enum, not a bitmask |
| 7d4f81658658 | pas_scavenger: also decommit TLCs on the last-chance tick before deep sleep |
| b39129e720d3 | ThreadingPOSIX: retry sem_wait on EINTR |

Closes https://github.com/oven-sh/bun/pull/26352
Closes https://github.com/oven-sh/bun/pull/26661
Closes https://github.com/oven-sh/bun/pull/27972
Closes https://github.com/oven-sh/bun/pull/26842
Closes https://github.com/oven-sh/bun/pull/23635
Closes https://github.com/oven-sh/bun/pull/22363

Fixes https://github.com/oven-sh/bun/issues/20422
Fixes https://github.com/oven-sh/bun/issues/26982