### PR TITLE
Fix integer overflow reading sliced non-regular file blobs

### DIFF
--- a/src/bun.js/webcore/blob/read_file.zig
+++ b/src/bun.js/webcore/blob/read_file.zig
@@ -347,10 +347,7 @@ pub const ReadFile = struct {
             // read up to 4k at a time if
             // they didn't explicitly set a size and we're reading from something that's not a regular file
         } else if (stat.size == 0 and this.could_block) {
-            this.size = if (this.max_length == Blob.max_size)
-                4096
-            else
-                this.max_length;
+            this.size = @min(this.max_length, 4096);
         }
 
         if (this.offset > 0) {
@@ -384,7 +381,7 @@ pub const ReadFile = struct {
 
         // add an extra 16 bytes to the buffer to avoid having to resize it for trailing extra data
         if (!this.could_block or (this.size > 0 and this.size != Blob.max_size))
-            this.buffer = std.ArrayListUnmanaged(u8).initCapacity(bun.default_allocator, this.size + 16) catch |err| {
+            this.buffer = std.ArrayListUnmanaged(u8).initCapacity(bun.default_allocator, this.size +| 16) catch |err| {
                 this.errno = err;
                 this.onFinish();
                 return;
@@ -669,10 +666,7 @@ pub const ReadFileUV = struct {
         } else if (stat.size == 0 and !this.is_regular_file) {
             // read up to 4k at a time if they didn't explicitly set a size and
             // we're reading from something that's not a regular file.
-            this.size = if (this.max_length == Blob.max_size)
-                4096
-            else
-                this.max_length;
+            this.size = @min(this.max_length, 4096);
         }
 
         if (this.offset > 0) {
@@ -698,7 +692,7 @@ pub const ReadFileUV = struct {
             return;
         }
         // add an extra 16 bytes to the buffer to avoid having to resize it for trailing extra data
-        this.buffer.ensureTotalCapacityPrecise(this.byte_store.allocator, @min(this.size + 16, @as(usize, std.math.maxInt(bun.windows.ULONG)))) catch {
+        this.buffer.ensureTotalCapacityPrecise(this.byte_store.allocator, @min(this.size +| 16, @as(usize, std.math.maxInt(bun.windows.ULONG)))) catch {
             this.errno = error.OutOfMemory;
             this.system_error = bun.sys.Error.fromCode(bun.sys.E.NOMEM, .read).toSystemError();
             this.onFinish();

--- a/test/js/bun/util/bun-stdin-slice.test.ts
+++ b/test/js/bun/util/bun-stdin-slice.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Reading a sliced non-regular file blob (like stdin from a pipe) with a size
+// close to Blob.max_size used to overflow when computing the initial read
+// buffer capacity.
+test("Bun.stdin.slice(1).text() does not crash when stdin is a pipe", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `process.stdout.write(await Bun.stdin.slice(1).text());`],
+    env: bunEnv,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  proc.stdin.write("hello world");
+  await proc.stdin.end();
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toBe("hello world");
+  expect(exitCode).toBe(0);
+});
+
+test("Bun.stdin.slice(0, N).text() caps reads at N bytes", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `process.stdout.write(await Bun.stdin.slice(0, 3).text());`],
+    env: bunEnv,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  proc.stdin.write("0123456789");
+  await proc.stdin.end();
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toBe("012");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/util/bun-stdin-slice.test.ts
+++ b/test/js/bun/util/bun-stdin-slice.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 
 // Reading a sliced non-regular file blob (like stdin from a pipe) with a size
 // close to Blob.max_size used to overflow when computing the initial read
-// buffer capacity.
-test("Bun.stdin.slice(1).text() does not crash when stdin is a pipe", async () => {
+// buffer capacity. The overflow was only reachable on POSIX; on Windows the
+// ReadFileUV path already bailed on size > ULONG_MAX before the addition.
+test.skipIf(isWindows)("Bun.stdin.slice(1).text() does not crash when stdin is a pipe", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", `process.stdout.write(await Bun.stdin.slice(1).text());`],
     env: bunEnv,
@@ -22,7 +23,7 @@ test("Bun.stdin.slice(1).text() does not crash when stdin is a pipe", async () =
   expect(exitCode).toBe(0);
 });
 
-test("Bun.stdin.slice(0, N).text() caps reads at N bytes", async () => {
+test.skipIf(isWindows)("Bun.stdin.slice(0, N).text() caps reads at N bytes", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", `process.stdout.write(await Bun.stdin.slice(0, 3).text());`],
     env: bunEnv,


### PR DESCRIPTION
## What does this PR do?

Fixes an integer overflow panic in `ReadFile` when reading a sliced file blob backed by a non-regular file (pipe/fifo/socket).

Fuzzer fingerprint: `8a544632e2452b59`

## Repro

```js
await Bun.stdin.slice(1).text();
```

With stdin piped, this panics in debug builds at `read_file.zig:387` with `integer overflow`.

## Root cause

`Bun.stdin` has an unknown size, represented as `Blob.max_size` (`maxInt(u52)`). Slicing it with `.slice(1)` produces a blob with `size = Blob.max_size - 1`.

When reading such a blob, `doReadFile` passes `blob.size` as `max_length` to `ReadFile`. For non-regular files with `stat.size == 0`, the initial buffer size was set to `max_length` whenever `max_length != Blob.max_size` — so `max_size - 1` was used directly. Adding the 16-byte slack then overflowed `u52`.

Even without the overflow, using `max_length` as the *pre-allocation* size for pipes is wrong: `max_length` is a cap, not an expected size.

## Fix

- Cap the initial buffer for non-regular files at `@min(max_length, 4096)`. The read loop already grows the buffer via the 64KB stack buffer path as data arrives, and still respects `max_length` as a cap.
- Use saturating addition (`+|`) for the 16-byte slack as defense-in-depth.
- Applied the same change to the Windows `ReadFileUV` path.

## How did you verify your code works?

- `bun bd test test/js/bun/util/bun-stdin-slice.test.ts` passes.
- Same test run against the unfixed debug build fails (subprocess panics).
- `Bun.stdin.slice(0, N).text()` still correctly caps reads at N bytes.
- Existing `bun-file-read.test.ts` and `bun-file.test.ts` still pass.