### PR TITLE
net: reset Socket.setTimeout() idle timer on incoming data

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -156,6 +156,7 @@ const SocketHandlers: SocketHandler = {
     const { data: self } = socket;
     if (!self) return;
 
+    self._unrefTimer();
     self.bytesRead += buffer.length;
     if (!self.push(buffer)) {
       socket.pause();
@@ -303,6 +304,7 @@ const ServerHandlers: SocketHandler<NetSocket> = {
     const { data: self } = socket;
     if (!self) return;
 
+    self._unrefTimer();
     self.bytesRead += buffer.length;
     if (!self.push(buffer)) {
       socket.pause();
@@ -508,6 +510,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
   data(socket, buffer) {
     $debug("Bun.Socket data");
     const { self } = socket.data;
+    self._unrefTimer();
     self.bytesRead += buffer.length;
     if (!self.push(buffer)) socket.pause();
   },
@@ -745,8 +748,10 @@ function Socket(options?) {
     // when the onread option is specified we use a different handlers object
     this[khandlers] = {
       ...SocketHandlers2,
-      data({ data: self }, buffer) {
+      data(socket, buffer) {
+        const { self } = socket.data;
         if (!self) return;
+        self._unrefTimer();
         try {
           onread.callback(buffer.length, buffer);
         } catch (e) {

--- a/test/regression/issue/29283.test.ts
+++ b/test/regression/issue/29283.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test";
+import { connect, createServer } from "node:net";
+import { once } from "node:events";
+
+// https://github.com/oven-sh/bun/issues/29283
+// https://github.com/oven-sh/bun/issues/12306
+//
+// `socket.setTimeout()` is an inactivity timer in Node.js: it must be
+// reset by any socket activity, including incoming data. Before this
+// fix, Bun only refreshed the timer in `_write()`, so a socket that
+// was actively receiving data but not writing would incorrectly emit
+// `timeout` after the configured interval.
+test("Socket.setTimeout resets on incoming data", async () => {
+  // Server writes a chunk every 50ms — well under the 300ms timeout.
+  await using server = createServer(socket => {
+    const id = setInterval(() => socket.write("ping"), 50);
+    socket.on("close", () => clearInterval(id));
+    socket.on("error", () => clearInterval(id));
+  }).listen(0);
+  await once(server, "listening");
+  const { port } = server.address() as { port: number };
+
+  let timedOut = false;
+  let chunks = 0;
+  const { promise: enoughReads, resolve: readsDone } = Promise.withResolvers<void>();
+
+  const client = connect({ host: "127.0.0.1", port, timeout: 300 });
+  client.on("data", () => {
+    // Receive enough chunks to clearly cross the timeout window:
+    // 20 * 50ms = 1000ms >> 300ms timeout. If setTimeout() is not
+    // an idle timer, the 300ms timer will fire before we hit 20.
+    if (++chunks >= 20) readsDone();
+  });
+  client.on("timeout", () => {
+    timedOut = true;
+    client.destroy();
+    readsDone();
+  });
+
+  await once(client, "connect");
+  await enoughReads;
+  client.destroy();
+
+  expect(timedOut).toBe(false);
+  expect(chunks).toBeGreaterThanOrEqual(20);
+});
+
+// The corollary: when the socket actually goes idle, the timeout
+// still fires. This guards against a fix that silently disables the
+// timer.
+test("Socket.setTimeout still fires on genuine idle", async () => {
+  await using server = createServer(() => {
+    // Accept the connection but never write.
+  }).listen(0);
+  await once(server, "listening");
+  const { port } = server.address() as { port: number };
+
+  const client = connect({ host: "127.0.0.1", port, timeout: 100 });
+  await once(client, "connect");
+  await once(client, "timeout");
+  client.destroy();
+});

--- a/test/regression/issue/29283.test.ts
+++ b/test/regression/issue/29283.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import { connect, createServer } from "node:net";
 import { once } from "node:events";
+import { connect, createServer } from "node:net";
 
 // https://github.com/oven-sh/bun/issues/29283
 // https://github.com/oven-sh/bun/issues/12306


### PR DESCRIPTION
## Problem

`socket.setTimeout()` in `node:net` is [documented](https://nodejs.org/api/net.html#socketsettimeouttimeout-callback) as an inactivity timer that resets on **any** socket activity. In Bun, the timer was only refreshed inside `Socket.prototype._write`, so a socket that was actively receiving data but not writing (HTTP response bodies, database query results, long-lived pipes) would incorrectly emit `timeout` after the configured interval even while data was flowing.

Closes #29283
Closes #12306

## Repro

```js
import net from 'node:net';

const server = net.createServer(socket => {
  const id = setInterval(() => socket.write('ping'), 100);
  socket.on('close', () => clearInterval(id));
});

server.listen(0, () => {
  const { port } = server.address();
  const client = net.connect({ host: '127.0.0.1', port, timeout: 2000 });
  client.on('data', () => {});
  client.on('timeout', () => {
    console.log('timeout fired — this should NOT happen while data is flowing');
    client.destroy();
    server.close();
  });
});
```

Before: Bun fires `timeout` after 2s while pings are arriving every 100ms. Node doesn't.

## Fix

`self._unrefTimer()` is now called from every data-delivery path:

- `SocketHandlers.data` — TLS client/server
- `ServerHandlers.data` — `net` server-side accepted connection
- `SocketHandlers2.data` — `net` client
- the `Socket({ onread })` override

The `onread` override additionally had a destructuring bug — it read `socket.data` into a variable named `self` directly, but `socket.data` is actually the `{ self, req }` record created in `kConnectTcp`/`kConnectPipe`. Fixed to match `SocketHandlers2.data`.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/regression/issue/29283.test.ts
  → 1 pass, 1 fail (idle-reset test fails — bug reproduced)

bun bd test test/regression/issue/29283.test.ts
  → 2 pass (both idle-reset and genuine-idle cases verified)
```

The test file covers both directions: timeout must not fire while reads are flowing, and timeout must still fire on genuine idle (guards against accidentally disabling the timer).